### PR TITLE
feat: surface outstanding background work on ready-for-input sessions (#5431)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.transcriptTasks.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.transcriptTasks.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * ActivityIndicator transcript-derived background work + scheduled wakeup
+ * (#5431).
+ *
+ * The PTY-side shell tracker (#4418) only covers Bash shells and reaps via
+ * an mtime-quiescence sweep, which falsely drops silent watcher loops that
+ * write no output until they finish. #5431 adds transcript-derived tasks
+ * (exact task-notification pairing) carried on enriched `claude_ready`
+ * messages into `sessionStates[id].transcriptBackgroundTasks`, plus a
+ * pending `scheduledWakeup`. These tests lock in the renderer half: the
+ * idle chip falls back to transcript tasks when no PTY shell is pending,
+ * shows the wakeup chip when only a wakeup is armed, and stays empty when
+ * nothing is outstanding.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ActivityIndicator } from './ActivityIndicator'
+
+let storeState: Record<string, unknown> = {}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) => {
+    const sessionStates: Record<string, unknown> = (storeState.sessionStates as Record<string, unknown>) ?? {}
+    const store = {
+      activeSessionId: storeState.activeSessionId ?? 'sess-1',
+      sessionStates,
+      serverResultTimeoutMs: storeState.serverResultTimeoutMs ?? 30 * 60 * 1000,
+    }
+    return selector(store)
+  },
+}))
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (fn: unknown) => fn,
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function idleSessionState(overrides: Record<string, unknown>): void {
+  storeState = {
+    activeSessionId: 'sess-1',
+    serverResultTimeoutMs: 30 * 60 * 1000,
+    sessionStates: {
+      'sess-1': {
+        isIdle: true,
+        lastClientActivityAt: Date.now() - 2_000,
+        messages: [],
+        activeTools: [],
+        activeAgents: [],
+        pendingBackgroundShells: [],
+        transcriptBackgroundTasks: [],
+        scheduledWakeup: null,
+        inactivityWarning: null,
+        ...overrides,
+      },
+    },
+  }
+}
+
+describe('ActivityIndicator — transcript background tasks (#5431)', () => {
+  it('renders the transcript-task chip when idle with no PTY shells pending', () => {
+    const now = Date.now()
+    idleSessionState({
+      transcriptBackgroundTasks: [
+        { toolUseId: 'toolu_01', kind: 'bash', description: 'Wait for CI checks on PR #164', startedAt: now - 30_000 },
+      ],
+    })
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Waiting on background work/)
+    expect(label.textContent).toMatch(/Wait for CI checks on PR #164/)
+    expect(screen.getByTestId('activity-indicator-transcript-tasks')).toBeTruthy()
+  })
+
+  it('headline is the most-recently-started task, with a +N more suffix', () => {
+    const now = Date.now()
+    idleSessionState({
+      transcriptBackgroundTasks: [
+        { toolUseId: 'toolu_01', kind: 'bash', description: 'old watcher', startedAt: now - 60_000 },
+        { toolUseId: 'toolu_02', kind: 'agent', description: 'newest agent task', startedAt: now - 5_000 },
+        { toolUseId: 'toolu_03', kind: 'monitor', description: 'mid monitor', startedAt: now - 30_000 },
+      ],
+    })
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/newest agent task/)
+    expect(label.textContent).toMatch(/\+2 more/)
+  })
+
+  it('prefers the PTY pending-shell headline when both sources are present', () => {
+    const now = Date.now()
+    idleSessionState({
+      pendingBackgroundShells: [
+        { shellId: 'brk57kt6pm', command: 'npm run build', startedAt: now - 10_000 },
+      ],
+      transcriptBackgroundTasks: [
+        { toolUseId: 'toolu_01', kind: 'bash', description: 'transcript watcher', startedAt: now - 5_000 },
+      ],
+    })
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    // The richer PTY command text wins the chip; transcript chip is the fallback.
+    expect(label.textContent).toMatch(/npm run build/)
+    expect(screen.queryByTestId('activity-indicator-transcript-tasks')).toBeNull()
+  })
+
+  it('renders the scheduled-wakeup chip when only a wakeup is armed', () => {
+    const at = Date.now() + 20 * 60 * 1000
+    idleSessionState({
+      scheduledWakeup: { at, reason: 'watching CI run' },
+    })
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    const d = new Date(at)
+    const hhmm = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+    expect(label.textContent).toMatch(new RegExp(`Resumes at ${hhmm}`))
+    expect(label.textContent).toMatch(/watching CI run/)
+    expect(screen.getByTestId('activity-indicator-scheduled-wakeup')).toBeTruthy()
+  })
+
+  it('renders nothing when idle with no outstanding work (no regression)', () => {
+    idleSessionState({})
+    const { container } = render(<ActivityIndicator />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -154,6 +154,8 @@ export function ActivityIndicator() {
     agentDescription,
     agentStartedAt,
     pendingShells,
+    transcriptTasks,
+    scheduledWakeup,
   } = useConnectionStore(
     useShallow((s) => {
       const id = s.activeSessionId
@@ -191,6 +193,11 @@ export function ActivityIndicator() {
         agentDescription: mostRecentAgent?.description ?? null,
         agentStartedAt: mostRecentAgent?.startedAt ?? null,
         pendingShells: ss?.pendingBackgroundShells ?? null,
+        // #5431 — transcript-derived outstanding work + pending wakeup, the
+        // idle-state fallbacks when the PTY shell tracker has nothing (or
+        // falsely reaped a silent watcher via the mtime-quiescence sweep).
+        transcriptTasks: ss?.transcriptBackgroundTasks ?? null,
+        scheduledWakeup: ss?.scheduledWakeup ?? null,
       }
     }),
   )
@@ -381,6 +388,62 @@ export function ActivityIndicator() {
               </ul>
             </div>
           )}
+        </div>
+      )
+    }
+    // #5431 — no PTY-tracked shell, but the transcript reports outstanding
+    // background work (run_in_background Bash/Agent or Monitor without a
+    // matching task-notification yet). Transcript pairing is exact, so this
+    // chip survives the mtime-quiescence sweep falsely reaping silent
+    // watcher loops that write no output until they finish. Same neutral
+    // green chip as the pending-shell state.
+    if (transcriptTasks && transcriptTasks.length > 0) {
+      let newest = transcriptTasks[0]!
+      for (let i = 1; i < transcriptTasks.length; i++) {
+        if (transcriptTasks[i]!.startedAt > newest.startedAt) newest = transcriptTasks[i]!
+      }
+      const rawDetail = newest.description || newest.toolUseId
+      const detail = truncatePendingShellCommand(rawDetail)
+      const extra = transcriptTasks.length - 1
+      return (
+        <div
+          className="activity-indicator activity-indicator--green"
+          aria-label="Waiting on background work"
+          title={rawDetail}
+          data-testid="activity-indicator-transcript-tasks"
+        >
+          <span className="activity-indicator__dot" aria-hidden="true" />
+          <span
+            className="activity-indicator__label"
+            data-testid="activity-indicator-label"
+          >
+            Waiting on background work · {detail}{extra > 0 ? ` (+${extra} more)` : ''}
+          </span>
+        </div>
+      )
+    }
+    // #5431 — turn ended with a ScheduleWakeup armed: the agent will resume
+    // on its own. Say so instead of presenting the session as done.
+    if (scheduledWakeup) {
+      const at = new Date(scheduledWakeup.at)
+      const hhmm = `${String(at.getHours()).padStart(2, '0')}:${String(at.getMinutes()).padStart(2, '0')}`
+      const reasonSuffix = scheduledWakeup.reason
+        ? ` · ${truncatePendingShellCommand(scheduledWakeup.reason)}`
+        : ''
+      return (
+        <div
+          className="activity-indicator activity-indicator--green"
+          aria-label="Agent resumes automatically"
+          title={scheduledWakeup.reason || undefined}
+          data-testid="activity-indicator-scheduled-wakeup"
+        >
+          <span className="activity-indicator__dot" aria-hidden="true" />
+          <span
+            className="activity-indicator__label"
+            data-testid="activity-indicator-label"
+          >
+            Resumes at {hhmm}{reasonSuffix}
+          </span>
         </div>
       )
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -244,6 +244,9 @@ const EMPTY_ACTIVE_TOOLS: never[] = [];
 // #4307: stable empty reference for `pendingBackgroundShells` —
 // same `useShallow` stability rationale as the others above.
 const EMPTY_PENDING_BACKGROUND_SHELLS: never[] = [];
+// #5431: stable empty reference for `transcriptBackgroundTasks` — same
+// `useShallow` stability rationale as the others above.
+const EMPTY_TRANSCRIPT_BACKGROUND_TASKS: never[] = [];
 // #4653: stable empty reference for `interventions` — same `useShallow`
 // stability rationale as the others above. SessionIntervention[] in the
 // type system; never[] here because the array is provably empty and
@@ -920,6 +923,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #4307: parity with the BaseSessionState shape; no live
       // background-shell tracking in the flat-state fallback.
       pendingBackgroundShells: EMPTY_PENDING_BACKGROUND_SHELLS,
+      // #5431: parity — transcript-derived tasks only populate real
+      // SessionStates (enriched claude_ready resolves a sessionId).
+      transcriptBackgroundTasks: EMPTY_TRANSCRIPT_BACKGROUND_TASKS,
+      scheduledWakeup: null,
       isPlanPending: false,
       planAllowedPrompts: EMPTY_PROMPTS,
       primaryClientId: null,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1258,7 +1258,9 @@ function handleSessionSwitched(msg: Record<string, unknown>, get: MsgGet, set: M
 }
 
 function handleClaudeReady(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const patch = sharedClaudeReady();
+  // #5431: pass the wire message through — enriched ready carries
+  // transcript-derived backgroundTasks / scheduledWakeup fields.
+  const patch = sharedClaudeReady(msg);
   const targetId = resolveSessionId(msg, get().activeSessionId);
   if (targetId && get().sessionStates[targetId]) {
     updateSession(targetId, () => patch);

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -68,8 +68,42 @@ export declare const ServerPairFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"pair_fail">;
     reason: z.ZodString;
 }, z.core.$strip>;
+/**
+ * #5431 — one outstanding background task surfaced on `claude_ready`.
+ *
+ * `kind` maps the launching tool: a `run_in_background` Bash call, a
+ * `run_in_background` Agent (subagent) call, or a Monitor stream. The
+ * task is "outstanding" when its launch has no matching task-notification
+ * in the session transcript yet. `startedAt` is epoch ms (the transcript
+ * entry's timestamp), matching the `startedAt` convention used by
+ * `pendingBackgroundShells` / `activeTools`.
+ */
+export declare const BackgroundTaskSchema: z.ZodObject<{
+    toolUseId: z.ZodString;
+    kind: z.ZodEnum<{
+        bash: "bash";
+        agent: "agent";
+        monitor: "monitor";
+    }>;
+    description: z.ZodString;
+    startedAt: z.ZodNumber;
+}, z.core.$strip>;
 export declare const ServerClaudeReadySchema: z.ZodObject<{
     type: z.ZodLiteral<"claude_ready">;
+    backgroundTasks: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        toolUseId: z.ZodString;
+        kind: z.ZodEnum<{
+            bash: "bash";
+            agent: "agent";
+            monitor: "monitor";
+        }>;
+        description: z.ZodString;
+        startedAt: z.ZodNumber;
+    }, z.core.$strip>>>;
+    scheduledWakeup: z.ZodOptional<z.ZodObject<{
+        at: z.ZodNumber;
+        reason: z.ZodString;
+    }, z.core.$strip>>;
 }, z.core.$strip>;
 export declare const ServerStreamStartSchema: z.ZodObject<{
     type: z.ZodLiteral<"stream_start">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -100,8 +100,39 @@ export const ServerPairFailSchema = z.object({
     type: z.literal('pair_fail'),
     reason: z.string(),
 });
+/**
+ * #5431 — one outstanding background task surfaced on `claude_ready`.
+ *
+ * `kind` maps the launching tool: a `run_in_background` Bash call, a
+ * `run_in_background` Agent (subagent) call, or a Monitor stream. The
+ * task is "outstanding" when its launch has no matching task-notification
+ * in the session transcript yet. `startedAt` is epoch ms (the transcript
+ * entry's timestamp), matching the `startedAt` convention used by
+ * `pendingBackgroundShells` / `activeTools`.
+ */
+export const BackgroundTaskSchema = z.object({
+    toolUseId: z.string(),
+    kind: z.enum(['bash', 'agent', 'monitor']),
+    description: z.string(),
+    startedAt: z.number().int().nonnegative().finite(),
+});
 export const ServerClaudeReadySchema = z.object({
     type: z.literal('claude_ready'),
+    // #5431: outstanding background work detected from the session
+    // transcript when the readiness probe flips to "ready for input".
+    // Both fields are OPTIONAL — servers from before #5431 (and session
+    // providers without transcript access) never emit them, and clients
+    // treat absence exactly like today's plain ready. An explicit empty
+    // `backgroundTasks: []` means "previously-reported tasks have all
+    // completed" so clients can clear a stale indicator.
+    backgroundTasks: z.array(BackgroundTaskSchema).optional(),
+    // #5431: a pending ScheduleWakeup — the agent ended its turn but
+    // arranged to resume at `at` (epoch ms). Absent when no wakeup is
+    // scheduled or it has already fired/been superseded.
+    scheduledWakeup: z.object({
+        at: z.number().int().nonnegative().finite(),
+        reason: z.string(),
+    }).optional(),
 });
 export const ServerStreamStartSchema = z.object({
     type: z.literal('stream_start'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -106,8 +106,40 @@ export const ServerPairFailSchema = z.object({
   reason: z.string(),
 })
 
+/**
+ * #5431 — one outstanding background task surfaced on `claude_ready`.
+ *
+ * `kind` maps the launching tool: a `run_in_background` Bash call, a
+ * `run_in_background` Agent (subagent) call, or a Monitor stream. The
+ * task is "outstanding" when its launch has no matching task-notification
+ * in the session transcript yet. `startedAt` is epoch ms (the transcript
+ * entry's timestamp), matching the `startedAt` convention used by
+ * `pendingBackgroundShells` / `activeTools`.
+ */
+export const BackgroundTaskSchema = z.object({
+  toolUseId: z.string(),
+  kind: z.enum(['bash', 'agent', 'monitor']),
+  description: z.string(),
+  startedAt: z.number().int().nonnegative().finite(),
+})
+
 export const ServerClaudeReadySchema = z.object({
   type: z.literal('claude_ready'),
+  // #5431: outstanding background work detected from the session
+  // transcript when the readiness probe flips to "ready for input".
+  // Both fields are OPTIONAL — servers from before #5431 (and session
+  // providers without transcript access) never emit them, and clients
+  // treat absence exactly like today's plain ready. An explicit empty
+  // `backgroundTasks: []` means "previously-reported tasks have all
+  // completed" so clients can clear a stale indicator.
+  backgroundTasks: z.array(BackgroundTaskSchema).optional(),
+  // #5431: a pending ScheduleWakeup — the agent ended its turn but
+  // arranged to resume at `at` (epoch ms). Absent when no wakeup is
+  // scheduled or it has already fired/been superseded.
+  scheduledWakeup: z.object({
+    at: z.number().int().nonnegative().finite(),
+    reason: z.string(),
+  }).optional(),
 })
 
 export const ServerStreamStartSchema = z.object({

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -12,6 +12,7 @@ import { createLogger, loggerForSession, redactSensitive, redactSensitivePreserv
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { materializeAttachments, buildAttachmentsPromptSuffix } from './claude-tui-attachments.js'
+import { TranscriptTaskScanner, transcriptPathForSessionFile } from './transcript-tasks.js'
 import { hasClaudeOAuthCreds } from './auth-probes.js'
 import {
   parseBackgroundShellId,
@@ -643,6 +644,18 @@ export class ClaudeTuiSession extends BaseSession {
     // don't re-arm the first-output timer. Reset to false on each new
     // turn via `_resetFirstOutputWatchdogForTurn` (sendMessage entry path).
     this._firstOutputDisarmed = false
+    // #5431: incremental transcript scanner for outstanding background work
+    // (run_in_background Bash/Agent, Monitor, ScheduleWakeup). Created
+    // lazily by getBackgroundTaskSnapshot() once the per-PID session file
+    // resolves to a transcript path; replaced if the transcript path
+    // changes (new conversation id after /clear or resume).
+    this._transcriptTaskScanner = null
+    // #5431: change-detection poll armed while the last snapshot reported
+    // outstanding work. Re-scans the transcript so a task-notification that
+    // lands while the session is IDLE still clears the dashboard indicator
+    // (the TUI re-invokes itself on notifications — chroxy sees no turn).
+    this._backgroundTaskPollTimer = null
+    this._lastBackgroundTaskKey = null
   }
 
   /**
@@ -915,6 +928,99 @@ export class ClaudeTuiSession extends BaseSession {
       return typeof data.status === 'string' ? data.status : null
     } catch {
       return null
+    }
+  }
+
+  // #5431: cadence for the idle background-task re-scan. 15s mirrors the
+  // BackgroundShellTracker sweep — fast enough that a task-notification
+  // landing while the session is idle clears the dashboard indicator
+  // promptly, slow enough to be negligible I/O (each tick reads only the
+  // transcript bytes appended since the last scan).
+  static get BACKGROUND_TASK_POLL_MS() { return 15_000 }
+
+  /**
+   * #5431 — outstanding background work derived from the session transcript:
+   * `{ backgroundTasks: [{ toolUseId, kind, description, startedAt }],
+   *    scheduledWakeup: { at, reason } | null }`, or null when no transcript
+   * is resolvable (no PTY pid, no per-PID session file, parse failure — the
+   * "degrade to plain ready" contract).
+   *
+   * The per-PID session file that drives the readiness probe carries
+   * `sessionId` + `cwd`, which derive the transcript path
+   * (`~/.claude/projects/<slug>/<sessionId>.jsonl`). The scanner is
+   * incremental (byte offset per instance) so calling this on every
+   * readiness edge costs only the new transcript tail.
+   *
+   * Side effect: arms/disarms the idle re-scan poll (`_backgroundTaskPollTimer`)
+   * based on whether the snapshot reports outstanding work, so callers
+   * (event-normalizer's `ready` / `result` handlers, ws-history replay)
+   * keep the watch fresh without extra wiring. Never throws.
+   */
+  getBackgroundTaskSnapshot() {
+    try {
+      const pid = this._term && this._term.pid
+      if (!Number.isInteger(pid) || pid <= 0) return null
+      const transcriptPath = transcriptPathForSessionFile(ClaudeTuiSession.sessionFilePath(pid))
+      if (!transcriptPath) return null
+      if (!this._transcriptTaskScanner || this._transcriptTaskScanner.path !== transcriptPath) {
+        this._transcriptTaskScanner = new TranscriptTaskScanner(transcriptPath, this._log || log)
+      }
+      const snapshot = this._transcriptTaskScanner.scan()
+      this._lastBackgroundTaskKey = JSON.stringify(snapshot)
+      this._refreshBackgroundTaskPoll(snapshot)
+      return snapshot
+    } catch (err) {
+      ;(this._log || log).debug?.(`getBackgroundTaskSnapshot failed: ${err.message} — degrading to plain ready`)
+      return null
+    }
+  }
+
+  /**
+   * #5431 — arm the idle re-scan while work is outstanding, stop it when
+   * the snapshot drains. The tick skips busy turns (the turn-end `result`
+   * path recomputes anyway) and emits `background_tasks_changed` only when
+   * the snapshot actually changed, which the event-normalizer maps to an
+   * enriched `claude_ready` wire message (empty `backgroundTasks: []` on
+   * the final tick clears the client indicator).
+   */
+  _refreshBackgroundTaskPoll(snapshot) {
+    const outstanding = snapshot && (snapshot.backgroundTasks.length > 0 || snapshot.scheduledWakeup)
+    if (!outstanding) {
+      this._stopBackgroundTaskPoll()
+      return
+    }
+    if (this._backgroundTaskPollTimer || this._destroying) return
+    this._backgroundTaskPollTimer = setInterval(() => {
+      try {
+        if (this._destroying || this._ptyExited) {
+          this._stopBackgroundTaskPoll()
+          return
+        }
+        if (this._isBusy || !this._transcriptTaskScanner) return
+        const next = this._transcriptTaskScanner.scan()
+        const key = JSON.stringify(next)
+        if (key === this._lastBackgroundTaskKey) return
+        this._lastBackgroundTaskKey = key
+        this.emit('background_tasks_changed', next)
+        if (next.backgroundTasks.length === 0 && !next.scheduledWakeup) {
+          this._stopBackgroundTaskPoll()
+        }
+      } catch (err) {
+        // Never let the poll throw out of a timer tick — stop watching and
+        // degrade to "no live updates until the next readiness edge".
+        ;(this._log || log).debug?.(`background-task poll failed: ${err.message} — stopping poll`)
+        this._stopBackgroundTaskPoll()
+      }
+    }, ClaudeTuiSession.BACKGROUND_TASK_POLL_MS)
+    // Don't keep the event loop alive solely for the background-task watch.
+    if (typeof this._backgroundTaskPollTimer.unref === 'function') this._backgroundTaskPollTimer.unref()
+  }
+
+  /** #5431 — idempotent stop for the background-task re-scan poll. */
+  _stopBackgroundTaskPoll() {
+    if (this._backgroundTaskPollTimer) {
+      clearInterval(this._backgroundTaskPollTimer)
+      this._backgroundTaskPollTimer = null
     }
   }
 
@@ -4178,6 +4284,9 @@ export class ClaudeTuiSession extends BaseSession {
     // none can fire a stale ASK_USER_QUESTION_STALL event into a torn-down
     // listener.
     this._clearAllAskUserQuestionWatchdogs()
+    // #5431: stop the background-task transcript re-scan so a late tick
+    // can't emit background_tasks_changed into a torn-down listener set.
+    this._stopBackgroundTaskPoll()
     if (this._term) {
       // #5317 (WP-2.3) — capture the handle + pid BEFORE nulling so the
       // escalation timer (and _onPtyGone's cancel) still have something to act

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -33,11 +33,15 @@ function backgroundTaskFields(ctx) {
   try {
     const snap = ctx?.getSessionEntry?.()?.session?.getBackgroundTaskSnapshot?.()
     if (!snap) return null
+    // A computed snapshot is ALWAYS emitted, even when empty: clients treat a
+    // present `backgroundTasks` (including `[]`) as authoritative and an
+    // absent field as "no information — keep state". A task-notification that
+    // lands mid-turn would otherwise strand a stale indicator: the turn-end
+    // ready computes an empty snapshot, and the idle re-scan poll never arms
+    // because nothing is outstanding.
     const tasks = Array.isArray(snap.backgroundTasks) ? snap.backgroundTasks : []
-    const wakeup = snap.scheduledWakeup || null
-    if (tasks.length === 0 && !wakeup) return null
     const fields = { backgroundTasks: tasks }
-    if (wakeup) fields.scheduledWakeup = wakeup
+    if (snap.scheduledWakeup) fields.scheduledWakeup = snap.scheduledWakeup
     return fields
   } catch (err) {
     log.debug?.(`backgroundTaskFields failed: ${err?.message} — emitting plain ready`)

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -20,10 +20,38 @@ const log = createLogger('event-normalizer')
  *   mode: 'multi' | 'legacy-cli'
  */
 
+/**
+ * #5431 — project a session's outstanding-background-work snapshot into the
+ * optional `claude_ready` wire fields. Returns null when the session type
+ * doesn't expose a snapshot (only claude-tui implements
+ * `getBackgroundTaskSnapshot()` today), the snapshot is unavailable
+ * (degraded transcript parse), or there is simply nothing outstanding —
+ * in all of those cases the wire message stays byte-identical to the
+ * pre-#5431 plain ready, which is the no-regression contract.
+ */
+function backgroundTaskFields(ctx) {
+  try {
+    const snap = ctx?.getSessionEntry?.()?.session?.getBackgroundTaskSnapshot?.()
+    if (!snap) return null
+    const tasks = Array.isArray(snap.backgroundTasks) ? snap.backgroundTasks : []
+    const wakeup = snap.scheduledWakeup || null
+    if (tasks.length === 0 && !wakeup) return null
+    const fields = { backgroundTasks: tasks }
+    if (wakeup) fields.scheduledWakeup = wakeup
+    return fields
+  } catch (err) {
+    log.debug?.(`backgroundTaskFields failed: ${err?.message} — emitting plain ready`)
+    return null
+  }
+}
+
 const EVENT_MAP = Object.create(null)
 Object.assign(EVENT_MAP, {
   ready: (data, ctx) => {
-    const messages = [{ msg: { type: 'claude_ready' } }]
+    // #5431: attach outstanding background work (if any) so a respawn /
+    // reconnect mid-orchestration doesn't present the session as fully idle.
+    const bgFields = backgroundTaskFields(ctx)
+    const messages = [{ msg: { type: 'claude_ready', ...(bgFields || {}) } }]
     const entry = ctx.getSessionEntry?.()
     if (entry) {
       // #3687: prefer the actual model the underlying CLI/SDK reports at
@@ -50,6 +78,19 @@ Object.assign(EVENT_MAP, {
       })
     }
     return { messages }
+  },
+
+  // #5431: claude-tui's idle transcript re-scan saw the outstanding-work set
+  // change (a task-notification landed / a wakeup fired while no turn was
+  // running). Re-emit `claude_ready` with the fresh snapshot — the session is
+  // idle by definition when this fires, so the ready state is accurate, and
+  // an explicit empty `backgroundTasks: []` is the client's signal to clear a
+  // stale indicator (absence means "no information", per the schema contract).
+  background_tasks_changed: (data) => {
+    const tasks = Array.isArray(data?.backgroundTasks) ? data.backgroundTasks : []
+    const msg = { type: 'claude_ready', backgroundTasks: tasks }
+    if (data?.scheduledWakeup) msg.scheduledWakeup = data.scheduledWakeup
+    return { messages: [{ msg }] }
   },
 
   conversation_id: (data, ctx) => {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1828,7 +1828,12 @@ export class SessionManager extends EventEmitter {
    * Handles both CliSession and PtySession events.
    */
   _wireSessionEvents(sessionId, session) {
-    const PROXIED_EVENTS = ['ready', 'stream_start', 'stream_delta', 'stream_end', 'message', 'tool_start', 'tool_result', 'result', 'error', 'user_question']
+    // #5431: background_tasks_changed — claude-tui's idle transcript re-scan
+    // reporting that outstanding background work changed (a task-notification
+    // landed or a wakeup fired while no turn was running). Deliberately NOT
+    // an ACTIVITY_EVENT: the session is idle by definition when it fires, so
+    // it must not reset the idle timeout.
+    const PROXIED_EVENTS = ['ready', 'stream_start', 'stream_delta', 'stream_end', 'message', 'tool_start', 'tool_result', 'result', 'error', 'user_question', 'background_tasks_changed']
     // Events that indicate meaningful activity (reset idle timeout)
     const ACTIVITY_EVENTS = new Set(['message', 'stream_start', 'tool_start', 'result', 'user_question'])
     // Session-scoped logger — entries are tagged with sessionId for per-session routing

--- a/packages/server/src/transcript-tasks.js
+++ b/packages/server/src/transcript-tasks.js
@@ -1,0 +1,334 @@
+// TranscriptTaskScanner (#5431) — incremental session-transcript scanner that
+// derives OUTSTANDING background work (run_in_background Bash/Agent calls,
+// Monitor streams) and a pending ScheduleWakeup from a Claude Code session
+// transcript (`~/.claude/projects/<slug>/<sessionId>.jsonl`).
+//
+// Why a transcript scan: the per-PID session file (`~/.claude/sessions/
+// <pid>.json`) that drives the readiness probe carries only `status` — no
+// task info — but it DOES carry `sessionId` + `cwd`, which is enough to
+// derive the transcript path. The transcript contains both halves of the
+// signal, pairable by tool-use ID:
+//
+//   Launch (assistant entry, verified shape):
+//     { "type": "assistant", "timestamp": "2026-06-10T02:39:05.423Z",
+//       "message": { "role": "assistant", "content": [
+//         { "type": "tool_use", "id": "toolu_015ydMyyDW7NE7Jbrqu6Eoxe",
+//           "name": "Bash",
+//           "input": { "description": "Install dependencies in merge worktree",
+//                      "run_in_background": true, ... } } ] } }
+//
+//   Completion (queue-operation entry; the same XML is also re-delivered as
+//   a `user` entry with string content when the notification is dequeued):
+//     { "type": "queue-operation", "operation": "enqueue",
+//       "timestamp": "2026-06-10T02:39:40.819Z",
+//       "content": "<task-notification>\n<task-id>bnclpiaj0</task-id>\n
+//         <tool-use-id>toolu_015ydMyyDW7NE7Jbrqu6Eoxe</tool-use-id>\n…
+//         <status>completed</status>…</task-notification>" }
+//
+//   ScheduleWakeup (assistant tool_use, verified shape):
+//     { "type": "tool_use", "id": "toolu_016KpP2dT7mFhk4HDgUU2ype",
+//       "name": "ScheduleWakeup",
+//       "input": { "delaySeconds": 90, "reason": "Waiting for …",
+//                  "prompt": "Check PR #149 required checks; …" } }
+//
+// Outstanding work = launches without a matching completion. A wakeup is
+// pending until a later user/assistant entry lands AFTER its scheduled time
+// (the harness re-invoked the agent), a later user entry carries its prompt,
+// or a newer ScheduleWakeup supersedes it.
+//
+// Robustness contract (#5431 success criterion — degrade silently):
+//   - The transcript format is the harness's INTERNAL representation, not a
+//     stable API. Every parse is defensive; an unparseable line is skipped.
+//   - Any I/O or structural failure makes `scan()` return the EMPTY result
+//     (plus a debug log) — it never throws into the readiness path.
+//   - Transcripts grow large (5MB+); a byte offset is tracked per scanner so
+//     each scan reads only the new tail. A shrunken file (rotation /
+//     truncation) resets the scanner and re-reads from byte 0.
+
+import { closeSync, fstatSync, openSync, readFileSync, readSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { createLogger } from './logger.js'
+
+const log = createLogger('transcript-tasks')
+
+/** Empty scan result — the "no outstanding work / degraded" shape. */
+export const EMPTY_TASK_SNAPSHOT = Object.freeze({
+  backgroundTasks: Object.freeze([]),
+  scheduledWakeup: null,
+})
+
+// Cap a single incremental read so a pathological transcript (or a first
+// scan against an existing multi-MB file) can't balloon memory. 16 MiB is
+// >3x the largest transcript observed in the wild (~5 MB); when the unread
+// tail exceeds the cap we skip ahead and only parse the final window —
+// stale-launch detail may be lost but the scanner stays bounded and the
+// readiness path stays fast.
+export const MAX_SCAN_BYTES = 16 * 1024 * 1024
+
+// Truncate `description` fallbacks derived from an Agent `prompt` — prompts
+// are unbounded; 80 chars matches the issue's payload sketch.
+const PROMPT_DESCRIPTION_MAX = 80
+
+/**
+ * Slugify a cwd into the directory name Claude Code uses under
+ * `~/.claude/projects/`. Verified against real project dirs on disk:
+ * every non-alphanumeric character (slashes, dots, spaces, …) becomes `-`,
+ * e.g. `/Users/blamechris/Projects/repo-relay` →
+ * `-Users-blamechris-Projects-repo-relay` and
+ * `/Users/x/Downloads/Mom Hospitalization Files` →
+ * `-Users-x-Downloads-Mom-Hospitalization-Files`.
+ * @param {string} cwd
+ * @returns {string}
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-')
+}
+
+/**
+ * Derive the transcript path for a per-PID session file
+ * (`~/.claude/sessions/<pid>.json`, which carries `sessionId` + `cwd`).
+ * Returns null on any failure (missing file, bad JSON, missing fields) —
+ * callers treat null as "no transcript available, degrade to plain ready".
+ * @param {string} sessionFilePath
+ * @returns {string|null}
+ */
+export function transcriptPathForSessionFile(sessionFilePath) {
+  try {
+    const data = JSON.parse(readFileSync(sessionFilePath, 'utf8'))
+    const sessionId = typeof data?.sessionId === 'string' ? data.sessionId : null
+    const cwd = typeof data?.cwd === 'string' ? data.cwd : null
+    if (!sessionId || !cwd) return null
+    // Defence-in-depth: the sessionId becomes a path segment. Real ids are
+    // UUIDs; reject anything that could traverse out of the projects dir.
+    if (!/^[A-Za-z0-9-]+$/.test(sessionId)) return null
+    return join(homedir(), '.claude', 'projects', slugifyCwd(cwd), `${sessionId}.jsonl`)
+  } catch (err) {
+    log.debug?.(`transcriptPathForSessionFile failed for ${sessionFilePath}: ${err.message}`)
+    return null
+  }
+}
+
+/** Extract every `<tool-use-id>…</tool-use-id>` from a task-notification blob. */
+const TOOL_USE_ID_TAG = /<tool-use-id>\s*([^<\s]+)\s*<\/tool-use-id>/g
+
+/**
+ * Incremental scanner for one transcript file.
+ *
+ * Usage: construct once per (session, transcript path); call `scan()` on
+ * each readiness edge. Each call reads only bytes appended since the last
+ * call and returns the current outstanding-work snapshot:
+ *
+ *   { backgroundTasks: [{ toolUseId, kind, description, startedAt }],
+ *     scheduledWakeup: { at, reason } | null }
+ *
+ * `scan()` NEVER throws. A missing transcript yields the empty snapshot
+ * (the file may simply not exist yet); any other failure logs at debug and
+ * yields the empty snapshot too.
+ */
+export class TranscriptTaskScanner {
+  /**
+   * @param {string} transcriptPath - absolute path to the session .jsonl
+   * @param {object} [logger] - logger with debug/warn (defaults to module log)
+   */
+  constructor(transcriptPath, logger = log) {
+    this.path = transcriptPath
+    this._log = logger
+    this._reset()
+  }
+
+  _reset() {
+    this._offset = 0
+    this._remainder = ''
+    // Set when a capped read skipped ahead — the first "line" of the new
+    // window is almost certainly a tail fragment and must not be parsed.
+    this._discardFirstPartialLine = false
+    /** @type {Map<string, {toolUseId:string,kind:string,description:string,startedAt:number}>} */
+    this._tasks = new Map()
+    /** @type {{at:number,reason:string,prompt:string}|null} */
+    this._wakeup = null
+    // Latest user/assistant entry timestamp seen (epoch ms) — used to decide
+    // whether a scheduled wakeup has already fired (activity after its time).
+    this._lastActivityTs = 0
+  }
+
+  /**
+   * Read any new transcript bytes, fold them into the tracked state, and
+   * return the outstanding-work snapshot. Never throws.
+   * @returns {{backgroundTasks: Array<{toolUseId:string,kind:string,description:string,startedAt:number}>, scheduledWakeup: {at:number,reason:string}|null}}
+   */
+  scan() {
+    try {
+      this._readNewBytes()
+      return this._snapshot()
+    } catch (err) {
+      // ENOENT is the common benign case (transcript not written yet) —
+      // still debug-logged, but state is preserved so a later scan picks
+      // up where it left off if the file appears.
+      this._log.debug?.(`transcript scan failed for ${this.path}: ${err.message} — degrading to empty snapshot`)
+      return { backgroundTasks: [], scheduledWakeup: null }
+    }
+  }
+
+  _readNewBytes() {
+    const fd = openSync(this.path, 'r')
+    try {
+      const size = fstatSync(fd).size
+      if (size < this._offset) {
+        // Truncated / rotated — drop everything and re-read from the start.
+        this._log.debug?.(`transcript ${this.path} shrank (${size} < ${this._offset}) — resetting scanner`)
+        this._reset()
+      }
+      if (size === this._offset) return
+      let start = this._offset
+      if (size - start > MAX_SCAN_BYTES) {
+        // Bounded read: skip ahead and parse only the final window. The
+        // skipped prefix may contain launches we'll never pair — acceptable
+        // degradation for a pathological file; note it at debug level.
+        this._log.debug?.(`transcript ${this.path} unread tail ${size - start}B exceeds cap — scanning final ${MAX_SCAN_BYTES}B only`)
+        this._reset()
+        start = size - MAX_SCAN_BYTES
+        // Discard the (almost certainly partial) first line of the window.
+        this._discardFirstPartialLine = true
+      }
+      const buf = Buffer.alloc(size - start)
+      const bytesRead = readSync(fd, buf, 0, buf.length, start)
+      this._offset = start + bytesRead
+      let text = this._remainder + buf.toString('utf8', 0, bytesRead)
+      this._remainder = ''
+      const lines = text.split('\n')
+      // The final element is either '' (text ended with \n) or a partial
+      // line still being written — keep it for the next scan either way.
+      this._remainder = lines.pop() ?? ''
+      for (let line of lines) {
+        if (this._discardFirstPartialLine) {
+          this._discardFirstPartialLine = false
+          continue
+        }
+        line = line.trim()
+        if (line) this._ingestLine(line)
+      }
+    } finally {
+      closeSync(fd)
+    }
+  }
+
+  /**
+   * Fold one JSONL line into the tracked state. Skips (never throws on)
+   * unparseable or unexpected shapes.
+   * @param {string} line
+   */
+  _ingestLine(line) {
+    // Completion check works on the RAW line: the task-notification XML
+    // appears in several entry shapes (queue-operation `content` string,
+    // dequeued `user` message string content, attachment entries) and a
+    // raw-text match covers all of them without depending on any one shape.
+    if (line.includes('<task-notification>')) {
+      for (const m of line.matchAll(TOOL_USE_ID_TAG)) {
+        // JSONL string escaping never alters the id (alphanumeric), so the
+        // raw match is exact. Any status (completed/failed/…) means the
+        // task is no longer running.
+        this._tasks.delete(m[1])
+      }
+    }
+
+    let entry
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      return // mid-write torn line or non-JSON — skip silently
+    }
+    if (!entry || typeof entry !== 'object') return
+
+    const ts = typeof entry.timestamp === 'string' ? Date.parse(entry.timestamp) : NaN
+    const entryTs = Number.isFinite(ts) ? ts : null
+
+    if (entry.type === 'user' || entry.type === 'assistant') {
+      if (entryTs !== null && entryTs > this._lastActivityTs) this._lastActivityTs = entryTs
+    }
+
+    if (entry.type === 'assistant') {
+      const blocks = entry?.message?.content
+      if (Array.isArray(blocks)) {
+        for (const block of blocks) {
+          if (!block || block.type !== 'tool_use' || typeof block.id !== 'string') continue
+          this._ingestToolUse(block, entryTs ?? Date.now())
+        }
+      }
+      return
+    }
+
+    if (entry.type === 'user' && this._wakeup) {
+      // Wakeup consumption path 1: the fired wakeup is delivered back to the
+      // agent as a user message carrying the scheduled prompt.
+      const content = entry?.message?.content
+      const text = typeof content === 'string'
+        ? content
+        : Array.isArray(content)
+          ? content.map((b) => (typeof b?.text === 'string' ? b.text : typeof b?.content === 'string' ? b.content : '')).join('\n')
+          : ''
+      // Match on a bounded prefix — prompts are long and an exact full-string
+      // match is brittle against harness-side trimming/wrapping.
+      const probe = this._wakeup.prompt.slice(0, 200)
+      if (probe && text.includes(probe)) this._wakeup = null
+    }
+  }
+
+  /**
+   * @param {{id:string,name?:string,input?:object}} block
+   * @param {number} startedAt epoch ms
+   */
+  _ingestToolUse(block, startedAt) {
+    const name = typeof block.name === 'string' ? block.name : ''
+    const input = (block.input && typeof block.input === 'object') ? block.input : {}
+
+    if (name === 'ScheduleWakeup') {
+      const delaySeconds = Number(input.delaySeconds)
+      if (Number.isFinite(delaySeconds) && delaySeconds >= 0) {
+        // A newer ScheduleWakeup supersedes any earlier pending one — the
+        // harness keeps at most one timer armed.
+        this._wakeup = {
+          at: startedAt + delaySeconds * 1000,
+          reason: typeof input.reason === 'string' ? input.reason : '',
+          prompt: typeof input.prompt === 'string' ? input.prompt : '',
+        }
+      }
+      return
+    }
+
+    let kind = null
+    if (name === 'Monitor') {
+      kind = 'monitor'
+    } else if (input.run_in_background === true) {
+      if (name === 'Bash') kind = 'bash'
+      else if (name === 'Agent') kind = 'agent'
+    }
+    if (!kind) return
+
+    const description = typeof input.description === 'string' && input.description
+      ? input.description
+      : typeof input.prompt === 'string'
+        ? input.prompt.slice(0, PROMPT_DESCRIPTION_MAX)
+        : ''
+    this._tasks.set(block.id, { toolUseId: block.id, kind, description, startedAt })
+  }
+
+  _snapshot() {
+    let scheduledWakeup = null
+    if (this._wakeup) {
+      // Wakeup consumption path 2: ANY user/assistant activity after the
+      // scheduled time means the harness already re-invoked the agent (or
+      // the user did) — the wakeup is spent even if its prompt text never
+      // re-appears verbatim.
+      if (this._lastActivityTs > this._wakeup.at) {
+        this._wakeup = null
+      } else {
+        scheduledWakeup = { at: this._wakeup.at, reason: this._wakeup.reason }
+      }
+    }
+    return {
+      backgroundTasks: [...this._tasks.values()].map((t) => ({ ...t })),
+      scheduledWakeup,
+    }
+  }
+}

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -83,6 +83,65 @@ describe('EventNormalizer', () => {
       assert.equal(result.messages[0].msg.type, 'claude_ready')
     })
 
+    // #5431 — enriched ready: a session exposing getBackgroundTaskSnapshot()
+    // gets its outstanding work attached; a computed-but-empty snapshot still
+    // emits backgroundTasks: [] (the authoritative clear — a task-notification
+    // that landed mid-turn must not strand a stale client indicator); sessions
+    // without the method (or a throwing one) stay byte-identical plain ready.
+    it('attaches backgroundTasks + scheduledWakeup from the session snapshot (#5431)', () => {
+      const task = { toolUseId: 'toolu_01', kind: 'bash', description: 'Wait for CI', startedAt: 1781068000000 }
+      const wakeup = { at: 1781068600000, reason: 'watching CI' }
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: {
+            model: 'claude-sonnet-4-6',
+            permissionMode: 'approve',
+            getBackgroundTaskSnapshot: () => ({ backgroundTasks: [task], scheduledWakeup: wakeup }),
+          },
+        }),
+      })
+      const result = normalizer.normalize('ready', {}, ctx)
+      assert.equal(result.messages[0].msg.type, 'claude_ready')
+      assert.deepEqual(result.messages[0].msg.backgroundTasks, [task])
+      assert.deepEqual(result.messages[0].msg.scheduledWakeup, wakeup)
+    })
+
+    it('emits an explicit empty backgroundTasks for a computed empty snapshot (#5431)', () => {
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: {
+            model: 'claude-sonnet-4-6',
+            permissionMode: 'approve',
+            getBackgroundTaskSnapshot: () => ({ backgroundTasks: [], scheduledWakeup: null }),
+          },
+        }),
+      })
+      const result = normalizer.normalize('ready', {}, ctx)
+      assert.deepEqual(result.messages[0].msg.backgroundTasks, [])
+      assert.equal('scheduledWakeup' in result.messages[0].msg, false)
+    })
+
+    it('omits the fields entirely when the session has no snapshot method (#5431)', () => {
+      const result = normalizer.normalize('ready', {}, makeCtx())
+      assert.equal('backgroundTasks' in result.messages[0].msg, false)
+      assert.equal('scheduledWakeup' in result.messages[0].msg, false)
+    })
+
+    it('omits the fields and stays plain when the snapshot getter throws (#5431)', () => {
+      const ctx = makeCtx({
+        getSessionEntry: () => ({
+          session: {
+            model: 'claude-sonnet-4-6',
+            permissionMode: 'approve',
+            getBackgroundTaskSnapshot: () => { throw new Error('boom') },
+          },
+        }),
+      })
+      const result = normalizer.normalize('ready', {}, ctx)
+      assert.equal(result.messages[0].msg.type, 'claude_ready')
+      assert.equal('backgroundTasks' in result.messages[0].msg, false)
+    })
+
     // #3687: when the user didn't specify a model, session.model is null
     // but the underlying CLI booted with SOMETHING. The init event carries
     // that real model in data.model — normalizer must surface it instead
@@ -156,6 +215,29 @@ describe('EventNormalizer', () => {
   })
 
   // ---- EVENT_MAP: conversation_id ----
+
+  // ---- EVENT_MAP: background_tasks_changed (#5431) ----
+
+  describe('background_tasks_changed event', () => {
+    it('re-emits claude_ready with the fresh snapshot', () => {
+      const task = { toolUseId: 'toolu_02', kind: 'monitor', description: 'tail log', startedAt: 5 }
+      const result = normalizer.normalize(
+        'background_tasks_changed',
+        { backgroundTasks: [task], scheduledWakeup: { at: 9, reason: 'r' } },
+        makeCtx()
+      )
+      assert.equal(result.messages.length, 1)
+      assert.equal(result.messages[0].msg.type, 'claude_ready')
+      assert.deepEqual(result.messages[0].msg.backgroundTasks, [task])
+      assert.deepEqual(result.messages[0].msg.scheduledWakeup, { at: 9, reason: 'r' })
+    })
+
+    it('emits the explicit empty-array clear when work drains', () => {
+      const result = normalizer.normalize('background_tasks_changed', { backgroundTasks: [], scheduledWakeup: null }, makeCtx())
+      assert.deepEqual(result.messages[0].msg.backgroundTasks, [])
+      assert.equal('scheduledWakeup' in result.messages[0].msg, false)
+    })
+  })
 
   describe('conversation_id event', () => {
     it('emits conversation_id message and session_list side effect', () => {

--- a/packages/server/tests/transcript-tasks.test.js
+++ b/packages/server/tests/transcript-tasks.test.js
@@ -1,0 +1,323 @@
+// #5431: unit tests for the TranscriptTaskScanner — the incremental session-
+// transcript scanner that derives outstanding background work (run_in_background
+// Bash/Agent, Monitor) and pending ScheduleWakeups for the enriched
+// `claude_ready` payload.
+//
+// Fixture lines mirror the REAL transcript shapes verified against a live
+// 5MB transcript (~/.claude/projects/…/<sessionId>.jsonl): assistant
+// tool_use launches, queue-operation task-notification completions, and
+// ScheduleWakeup tool_use entries. The scanner's contract is "never throw,
+// degrade to empty" — several tests pin that explicitly.
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  TranscriptTaskScanner,
+  transcriptPathForSessionFile,
+  slugifyCwd,
+  MAX_SCAN_BYTES,
+} from '../src/transcript-tasks.js'
+
+let dir
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'transcript-tasks-test-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Fixture builders — shapes verified against a real transcript (#5431).
+// ---------------------------------------------------------------------------
+
+function launchLine({ id, name = 'Bash', runInBackground = true, description, prompt, ts = '2026-06-10T02:39:05.423Z' }) {
+  const input = {}
+  if (runInBackground !== null) input.run_in_background = runInBackground
+  if (description !== undefined) input.description = description
+  if (prompt !== undefined) input.prompt = prompt
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: ts,
+    message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] },
+  })
+}
+
+function completionLine({ id, status = 'completed', ts = '2026-06-10T02:39:40.819Z' }) {
+  const content = `<task-notification>\n<task-id>bnclpiaj0</task-id>\n<tool-use-id>${id}</tool-use-id>\n<output-file>/tmp/x.output</output-file>\n<status>${status}</status>\n<summary>Background command completed</summary>\n</task-notification>`
+  return JSON.stringify({ type: 'queue-operation', operation: 'enqueue', timestamp: ts, sessionId: 's-1', content })
+}
+
+function wakeupLine({ id = 'toolu_wake1', delaySeconds = 90, reason = 'Waiting for CI', prompt = 'Check PR #149 required checks; if all pass, squash-merge it', ts = '2026-06-10T02:41:22.369Z' }) {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: ts,
+    message: { role: 'assistant', content: [{ type: 'tool_use', id, name: 'ScheduleWakeup', input: { delaySeconds, reason, prompt } }] },
+  })
+}
+
+function userLine({ text, ts }) {
+  return JSON.stringify({ type: 'user', timestamp: ts, message: { role: 'user', content: text } })
+}
+
+function writeTranscript(lines, name = 'session.jsonl') {
+  const p = join(dir, name)
+  writeFileSync(p, lines.map((l) => l + '\n').join(''))
+  return p
+}
+
+// ---------------------------------------------------------------------------
+// slugifyCwd / transcriptPathForSessionFile
+// ---------------------------------------------------------------------------
+
+describe('slugifyCwd', () => {
+  it('replaces every non-alphanumeric character with a dash (verified rule)', () => {
+    assert.equal(slugifyCwd('/Users/blamechris/Projects/repo-relay'), '-Users-blamechris-Projects-repo-relay')
+    assert.equal(slugifyCwd('/Users/x/Downloads/Mom Hospitalization Files'), '-Users-x-Downloads-Mom-Hospitalization-Files')
+    assert.equal(slugifyCwd('/private/tmp/my.dotted_dir'), '-private-tmp-my-dotted-dir')
+  })
+})
+
+describe('transcriptPathForSessionFile', () => {
+  it('derives the projects-dir transcript path from sessionId + cwd', () => {
+    const sessFile = join(dir, '123.json')
+    writeFileSync(sessFile, JSON.stringify({
+      pid: 123,
+      sessionId: '34b3489f-d698-43af-a02e-b4be0c679e42',
+      cwd: '/Users/blamechris/Projects/repo-relay',
+      status: 'busy',
+    }))
+    const p = transcriptPathForSessionFile(sessFile)
+    assert.ok(p.endsWith(join('.claude', 'projects', '-Users-blamechris-Projects-repo-relay', '34b3489f-d698-43af-a02e-b4be0c679e42.jsonl')))
+  })
+
+  it('returns null for a missing file, bad JSON, missing fields, or unsafe sessionId', () => {
+    assert.equal(transcriptPathForSessionFile(join(dir, 'nope.json')), null)
+
+    const bad = join(dir, 'bad.json')
+    writeFileSync(bad, '{not json')
+    assert.equal(transcriptPathForSessionFile(bad), null)
+
+    const noCwd = join(dir, 'nocwd.json')
+    writeFileSync(noCwd, JSON.stringify({ sessionId: 'abc' }))
+    assert.equal(transcriptPathForSessionFile(noCwd), null)
+
+    const traversal = join(dir, 'traversal.json')
+    writeFileSync(traversal, JSON.stringify({ sessionId: '../../etc/passwd', cwd: '/tmp' }))
+    assert.equal(transcriptPathForSessionFile(traversal), null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TranscriptTaskScanner — launches and completions
+// ---------------------------------------------------------------------------
+
+describe('TranscriptTaskScanner — launch/completion pairing', () => {
+  it('reports an unmatched background Bash launch as outstanding', () => {
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_aaa', description: 'Wait for CI checks on PR #164' }),
+    ])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.equal(snap.backgroundTasks.length, 1)
+    assert.deepEqual(snap.backgroundTasks[0], {
+      toolUseId: 'toolu_aaa',
+      kind: 'bash',
+      description: 'Wait for CI checks on PR #164',
+      startedAt: Date.parse('2026-06-10T02:39:05.423Z'),
+    })
+    assert.equal(snap.scheduledWakeup, null)
+  })
+
+  it('clears a launch when its task-notification completion lands', () => {
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_aaa', description: 'watcher' }),
+      completionLine({ id: 'toolu_aaa' }),
+    ])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.deepEqual(snap.backgroundTasks, [])
+  })
+
+  it('treats a failed task-notification as completed too (task no longer running)', () => {
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_aaa', description: 'watcher' }),
+      completionLine({ id: 'toolu_aaa', status: 'failed' }),
+    ])
+    assert.deepEqual(new TranscriptTaskScanner(p).scan().backgroundTasks, [])
+  })
+
+  it('pairs by tool-use id — only the matching launch clears', () => {
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_aaa', description: 'first' }),
+      launchLine({ id: 'toolu_bbb', description: 'second' }),
+      completionLine({ id: 'toolu_aaa' }),
+    ])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.equal(snap.backgroundTasks.length, 1)
+    assert.equal(snap.backgroundTasks[0].toolUseId, 'toolu_bbb')
+  })
+
+  it('detects background Agent launches (kind=agent) with prompt-derived description', () => {
+    const longPrompt = 'Explore the project at /Users/blamechris/Projects/chroxy '.repeat(5)
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_agent', name: 'Agent', prompt: longPrompt }),
+    ])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.equal(snap.backgroundTasks[0].kind, 'agent')
+    assert.equal(snap.backgroundTasks[0].description, longPrompt.slice(0, 80))
+  })
+
+  it('detects Monitor calls as background work even without run_in_background', () => {
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_mon', name: 'Monitor', runInBackground: null, description: 'Watch deploy logs' }),
+    ])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.equal(snap.backgroundTasks[0].kind, 'monitor')
+  })
+
+  it('ignores foreground Bash/Agent tool_use entries', () => {
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_fg1', runInBackground: false, description: 'npm test' }),
+      launchLine({ id: 'toolu_fg2', runInBackground: null, description: 'git status' }),
+    ])
+    assert.deepEqual(new TranscriptTaskScanner(p).scan().backgroundTasks, [])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ScheduleWakeup
+// ---------------------------------------------------------------------------
+
+describe('TranscriptTaskScanner — ScheduleWakeup', () => {
+  it('reports a pending wakeup with at = entry timestamp + delaySeconds', () => {
+    const ts = '2026-06-10T02:41:22.369Z'
+    const p = writeTranscript([wakeupLine({ delaySeconds: 90, ts })])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.deepEqual(snap.scheduledWakeup, {
+      at: Date.parse(ts) + 90_000,
+      reason: 'Waiting for CI',
+    })
+  })
+
+  it('a newer ScheduleWakeup supersedes the previous one', () => {
+    const p = writeTranscript([
+      wakeupLine({ delaySeconds: 90, reason: 'first', ts: '2026-06-10T02:41:22.369Z' }),
+      wakeupLine({ delaySeconds: 240, reason: 'second', ts: '2026-06-10T02:42:21.322Z' }),
+    ])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.equal(snap.scheduledWakeup.reason, 'second')
+    assert.equal(snap.scheduledWakeup.at, Date.parse('2026-06-10T02:42:21.322Z') + 240_000)
+  })
+
+  it('consumes the wakeup when a later user message carries its prompt', () => {
+    const prompt = 'Check PR #149 required checks; if all pass, squash-merge it'
+    const p = writeTranscript([
+      wakeupLine({ prompt, ts: '2026-06-10T02:41:22.369Z' }),
+      userLine({ text: prompt, ts: '2026-06-10T02:42:55.000Z' }),
+    ])
+    assert.equal(new TranscriptTaskScanner(p).scan().scheduledWakeup, null)
+  })
+
+  it('consumes the wakeup when any user/assistant activity lands after the scheduled time', () => {
+    const ts = '2026-06-10T02:41:22.369Z' // wakeup at +90s = 02:42:52.369Z
+    const p = writeTranscript([
+      wakeupLine({ delaySeconds: 90, ts }),
+      userLine({ text: 'unrelated follow-up from the user', ts: '2026-06-10T02:45:00.000Z' }),
+    ])
+    assert.equal(new TranscriptTaskScanner(p).scan().scheduledWakeup, null)
+  })
+
+  it('keeps the wakeup pending when activity predates the scheduled time', () => {
+    const ts = '2026-06-10T02:41:22.369Z'
+    const p = writeTranscript([
+      wakeupLine({ delaySeconds: 600, ts }),
+      // tool_result chatter right after scheduling — well before the wakeup time
+      userLine({ text: 'Next wakeup scheduled for 19:43:00 (in 98s).', ts: '2026-06-10T02:41:22.515Z' }),
+    ])
+    assert.ok(new TranscriptTaskScanner(p).scan().scheduledWakeup)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Robustness — malformed input, empty/missing files, incremental reads
+// ---------------------------------------------------------------------------
+
+describe('TranscriptTaskScanner — robustness', () => {
+  it('returns the empty snapshot for a missing file (never throws)', () => {
+    const scanner = new TranscriptTaskScanner(join(dir, 'does-not-exist.jsonl'))
+    assert.deepEqual(scanner.scan(), { backgroundTasks: [], scheduledWakeup: null })
+  })
+
+  it('returns the empty snapshot for an empty file', () => {
+    const p = writeTranscript([])
+    assert.deepEqual(new TranscriptTaskScanner(p).scan(), { backgroundTasks: [], scheduledWakeup: null })
+  })
+
+  it('skips malformed lines without losing surrounding entries', () => {
+    const p = writeTranscript([
+      '{truncated json garbage',
+      launchLine({ id: 'toolu_ok', description: 'survives' }),
+      'not even json',
+      '{"type":"assistant","message":{"content":"not-an-array"}}',
+      '{"type":null}',
+    ])
+    const snap = new TranscriptTaskScanner(p).scan()
+    assert.equal(snap.backgroundTasks.length, 1)
+    assert.equal(snap.backgroundTasks[0].toolUseId, 'toolu_ok')
+  })
+
+  it('handles entries with no timestamp (last-prompt / mode metadata lines)', () => {
+    const p = writeTranscript([
+      JSON.stringify({ type: 'last-prompt' }),
+      JSON.stringify({ type: 'mode', timestamp: null }),
+      launchLine({ id: 'toolu_x', description: 'd' }),
+    ])
+    assert.equal(new TranscriptTaskScanner(p).scan().backgroundTasks.length, 1)
+  })
+
+  it('scans incrementally — a completion appended later clears the task on the next scan', () => {
+    const p = writeTranscript([launchLine({ id: 'toolu_inc', description: 'watching' })])
+    const scanner = new TranscriptTaskScanner(p)
+    assert.equal(scanner.scan().backgroundTasks.length, 1)
+
+    appendFileSync(p, completionLine({ id: 'toolu_inc' }) + '\n')
+    assert.deepEqual(scanner.scan().backgroundTasks, [])
+  })
+
+  it('buffers a partial trailing line until the rest is written', () => {
+    const full = completionLine({ id: 'toolu_part' })
+    const p = writeTranscript([launchLine({ id: 'toolu_part', description: 'd' })])
+    const scanner = new TranscriptTaskScanner(p)
+    assert.equal(scanner.scan().backgroundTasks.length, 1)
+
+    // Write only half the completion line (no newline) — must not match yet.
+    appendFileSync(p, full.slice(0, 40))
+    assert.equal(scanner.scan().backgroundTasks.length, 1)
+
+    // Complete the line — now it pairs.
+    appendFileSync(p, full.slice(40) + '\n')
+    assert.deepEqual(scanner.scan().backgroundTasks, [])
+  })
+
+  it('resets and rescans when the file shrinks (rotation/truncation)', () => {
+    const p = writeTranscript([
+      launchLine({ id: 'toolu_old', description: 'old session' }),
+      launchLine({ id: 'toolu_old2', description: 'old session 2' }),
+    ])
+    const scanner = new TranscriptTaskScanner(p)
+    assert.equal(scanner.scan().backgroundTasks.length, 2)
+
+    // Replace with a SHORTER file containing different tasks.
+    writeFileSync(p, launchLine({ id: 'toolu_new', description: 'fresh' }) + '\n')
+    const snap = scanner.scan()
+    assert.equal(snap.backgroundTasks.length, 1)
+    assert.equal(snap.backgroundTasks[0].toolUseId, 'toolu_new')
+  })
+
+  it('exposes a sane bounded-read cap', () => {
+    assert.ok(MAX_SCAN_BYTES >= 8 * 1024 * 1024)
+  })
+})

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -372,6 +372,56 @@ describe('handleClaudeReady', () => {
       stoppedCode: null,
     })
   })
+
+  // #5431 — enriched ready: a present `backgroundTasks` array (even empty)
+  // is an authoritative transcript snapshot for BOTH new fields; absence
+  // leaves stored state untouched (pre-#5431 servers / no transcript).
+  it('projects transcript backgroundTasks + scheduledWakeup when present (#5431)', () => {
+    const task = { toolUseId: 'toolu_01', kind: 'bash', description: 'Wait for CI checks', startedAt: 1781068000000 }
+    expect(handleClaudeReady({
+      type: 'claude_ready',
+      backgroundTasks: [task],
+      scheduledWakeup: { at: 1781068600000, reason: 'watching CI' },
+    })).toEqual({
+      claudeReady: true,
+      stoppedAt: null,
+      stoppedCode: null,
+      transcriptBackgroundTasks: [task],
+      scheduledWakeup: { at: 1781068600000, reason: 'watching CI' },
+    })
+  })
+
+  it('clears both fields on an explicit empty snapshot (#5431)', () => {
+    expect(handleClaudeReady({ type: 'claude_ready', backgroundTasks: [] })).toEqual({
+      claudeReady: true,
+      stoppedAt: null,
+      stoppedCode: null,
+      transcriptBackgroundTasks: [],
+      scheduledWakeup: null,
+    })
+  })
+
+  it('leaves the fields absent on a plain ready (#5431 wire-compat)', () => {
+    expect(handleClaudeReady({ type: 'claude_ready' })).toEqual({
+      claudeReady: true,
+      stoppedAt: null,
+      stoppedCode: null,
+    })
+  })
+
+  it('drops malformed task entries instead of throwing (#5431)', () => {
+    expect(handleClaudeReady({
+      type: 'claude_ready',
+      backgroundTasks: [null, 'junk', { toolUseId: 42 }, { toolUseId: 'toolu_02', kind: 'monitor', description: 'tail log', startedAt: 5 }],
+      scheduledWakeup: { at: 'soon' },
+    })).toEqual({
+      claudeReady: true,
+      stoppedAt: null,
+      stoppedCode: null,
+      transcriptBackgroundTasks: [{ toolUseId: 'toolu_02', kind: 'monitor', description: 'tail log', startedAt: 5 }],
+      scheduledWakeup: null,
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -27,6 +27,7 @@ import type {
   ModelInfo,
   PendingBackgroundShell,
   SearchResult,
+  TranscriptBackgroundTask,
   ServerError,
   SessionInfo,
   SessionIntervention,
@@ -239,12 +240,38 @@ export function handleConfirmPermissionMode(
  * sent another message after tapping Stop). This is purely additive for
  * sessions that were never stopped — both fields stay null end-to-end.
  */
-export function handleClaudeReady(): {
+export function handleClaudeReady(msg?: Record<string, unknown>): {
   claudeReady: true
   stoppedAt: null
   stoppedCode: null
+  transcriptBackgroundTasks?: TranscriptBackgroundTask[]
+  scheduledWakeup?: { at: number; reason: string } | null
 } {
-  return { claudeReady: true, stoppedAt: null, stoppedCode: null }
+  const patch: ReturnType<typeof handleClaudeReady> = {
+    claudeReady: true,
+    stoppedAt: null,
+    stoppedCode: null,
+  }
+  // #5431: enriched ready — `backgroundTasks` present (even as []) means the
+  // server computed a fresh transcript snapshot, so it is authoritative for
+  // BOTH fields: a snapshot with tasks but no wakeup means any previously
+  // stored wakeup has fired/been superseded. Absent means a pre-#5431 server
+  // or no transcript access — leave the stored fields untouched.
+  if (Array.isArray(msg?.backgroundTasks)) {
+    patch.transcriptBackgroundTasks = msg.backgroundTasks.filter(
+      (t): t is TranscriptBackgroundTask =>
+        !!t && typeof t === 'object' &&
+        typeof (t as TranscriptBackgroundTask).toolUseId === 'string' &&
+        typeof (t as TranscriptBackgroundTask).description === 'string' &&
+        typeof (t as TranscriptBackgroundTask).startedAt === 'number',
+    )
+    const wakeup = msg.scheduledWakeup as { at?: unknown; reason?: unknown } | undefined
+    patch.scheduledWakeup =
+      wakeup && typeof wakeup.at === 'number' && typeof wakeup.reason === 'string'
+        ? { at: wakeup.at, reason: wakeup.reason }
+        : null
+  }
+  return patch
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -262,8 +262,9 @@ export function handleClaudeReady(msg?: Record<string, unknown>): {
       (t): t is TranscriptBackgroundTask =>
         !!t && typeof t === 'object' &&
         typeof (t as TranscriptBackgroundTask).toolUseId === 'string' &&
+        ['bash', 'agent', 'monitor'].includes((t as TranscriptBackgroundTask).kind) &&
         typeof (t as TranscriptBackgroundTask).description === 'string' &&
-        typeof (t as TranscriptBackgroundTask).startedAt === 'number',
+        Number.isFinite((t as TranscriptBackgroundTask).startedAt),
     )
     const wakeup = msg.scheduledWakeup as { at?: unknown; reason?: unknown } | undefined
     patch.scheduledWakeup =

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -434,6 +434,22 @@ export interface PendingBackgroundShell {
   startedAt: number;
 }
 
+/**
+ * #5431 — one outstanding background task derived from the session
+ * transcript: a `run_in_background` Bash or Agent call, or a Monitor
+ * stream, whose completion task-notification hasn't landed yet.
+ * `toolUseId` is the launching tool_use id (the pairing key);
+ * `description` is the tool call's human-readable description (or a
+ * truncated Agent prompt); `startedAt` is epoch ms from the transcript
+ * entry's timestamp.
+ */
+export interface TranscriptBackgroundTask {
+  toolUseId: string;
+  kind: 'bash' | 'agent' | 'monitor';
+  description: string;
+  startedAt: number;
+}
+
 export interface ConnectedClient {
   clientId: string;
   deviceName: string | null;
@@ -792,6 +808,23 @@ export interface BaseSessionState {
    * state the activity indicator surfaces.
    */
   pendingBackgroundShells: PendingBackgroundShell[];
+  /**
+   * #5431 — outstanding background work derived from the session
+   * TRANSCRIPT (run_in_background Bash/Agent calls and Monitor streams
+   * without a matching task-notification yet). Arrives on enriched
+   * `claude_ready` messages. Complements `pendingBackgroundShells`
+   * (PTY-side tracker, Bash only, mtime-quiescence reaping): transcript
+   * pairing is exact, so silent watcher loops the quiescence sweep
+   * falsely reaps still surface here. An absent field on `claude_ready`
+   * leaves this unchanged; an explicit `[]` clears it.
+   */
+  transcriptBackgroundTasks: TranscriptBackgroundTask[];
+  /**
+   * #5431 — a pending ScheduleWakeup: the agent ended its turn but
+   * arranged to be re-invoked at `at` (epoch ms). Null when none is
+   * scheduled or it already fired.
+   */
+  scheduledWakeup: { at: number; reason: string } | null;
   isPlanPending: boolean;
   planAllowedPrompts: { tool: string; prompt: string }[];
   primaryClientId: string | null;

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -32,6 +32,10 @@ describe('createEmptyBaseSessionState', () => {
       // #4307: empty array on init — populated by background_work_changed
       // events and/or session_list snapshot seed.
       pendingBackgroundShells: [],
+      // #5431: transcript-derived outstanding work — empty/null until an
+      // enriched claude_ready arrives.
+      transcriptBackgroundTasks: [],
+      scheduledWakeup: null,
       isPlanPending: false,
       planAllowedPrompts: [],
       primaryClientId: null,

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -89,6 +89,10 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     // session_list snapshot arrives; null would force every renderer to
     // .length-check against null, so an empty array is the safer default.
     pendingBackgroundShells: [],
+    // #5431: transcript-derived outstanding work — empty/null until an
+    // enriched claude_ready arrives.
+    transcriptBackgroundTasks: [],
+    scheduledWakeup: null,
     isPlanPending: false,
     planAllowedPrompts: [],
     primaryClientId: null,


### PR DESCRIPTION
## Summary
When a turn ends, the readiness probe flips the session to "ready for input" — even when the agent is still mid-orchestration: background shell watchers, background subagents, Monitor streams, or an armed ScheduleWakeup. The dashboard presented those sessions as fully idle. Closes #5431.

The existing PTY shell tracker (#4307/#4418) doesn't cover this: it's Bash-only, and its mtime-quiescence sweep reaps any shell whose output file goes 60s without writes — which falsely drops the common `until <check>; do sleep 20; done` watcher that writes nothing until it finishes. That's exactly the reported symptom.

## How it works
- **`TranscriptTaskScanner`** (new, server): the per-PID session file that drives the readiness probe carries `sessionId` + `cwd`, which derive the transcript path (`~/.claude/projects/<slug>/<sessionId>.jsonl`). The scanner incrementally pairs `run_in_background` Bash/Agent and Monitor `tool_use` launches with their `task-notification` completions by tool-use id — exact, no heuristics — and tracks a pending ScheduleWakeup. Byte-offset incremental reads (16MiB cap), never throws: any parse/IO failure degrades to today's plain ready.
- **Protocol**: `claude_ready` gains optional `backgroundTasks` / `scheduledWakeup` fields. Absent = pre-#5431 server (wire-compatible); explicit `[]` = authoritative clear.
- **Server**: `ready` attaches the snapshot; while work is outstanding, a 15s unref'd idle re-scan emits `background_tasks_changed` (proxied, NOT an activity event) → re-emitted as enriched `claude_ready`, so the indicator clears when a task-notification lands with no turn running.
- **Dashboard**: the idle ActivityIndicator falls back to transcript tasks when no PTY shell is pending ("Waiting on background work · *Wait for CI checks on PR #164*"), and shows "Resumes at HH:MM · *reason*" for an armed wakeup. PTY pending-shell headline wins when both sources are present.

## Tests
- 23 scanner unit tests (launch/completion pairing, unmatched launches, wakeup consumption both ways, torn lines, truncation reset, capped reads, missing file)
- 4 store-core handler tests (enriched / clear / absent / malformed)
- 5 ActivityIndicator tests (transcript chip, most-recent headline + overflow, PTY-wins precedence, wakeup chip, no-regression empty)
- Full suites: server 8366 pass (5 pre-existing env-only failures, byte-identical set on unmodified main), dashboard 3274, store-core 1179, protocol green + build, app + dashboard typecheck clean

## Notes
- Transcript shapes were verified against a live 5MB session transcript (30 background launches, all pairable); the format is the harness's internal representation, so the scanner is defensive end-to-end and feature-degrades silently.
- `ws-history` replay stays plain (no snapshot attach) — replay has no live session context; the first real `ready`/`background_tasks_changed` enriches.