### PR TITLE
docs(providers): add claude-byok, deepseek, and ollama to the capability matrix

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -390,24 +390,24 @@ Older configs use `legacyCli: true` to force the `claude-cli` provider. This sti
 
 Rows marked **(capability)** come directly from each session class's `static get capabilities()` object — those are the keys the provider registry inspects at runtime. The remaining rows are **(behavioural)** — derived from reading the session class's implementation (attachment handling, agent-tracking events, cost parsing, continuity across `sendMessage` calls). Behavioural rows are not currently part of the `capabilities` contract and may change if the class is refactored.
 
-| Capability | `claude-sdk` | `claude-cli` | `claude-tui` | `claude-channel` | `codex` | `gemini` | `ollama` |
-|------------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| **(capability)** Permissions (`canUseTool` / hook) | Yes | Yes | Yes (HTTP hook) | Yes (channel relay) | — | — | Yes (in-process) |
-| **(capability)** In-process permissions | Yes | — | — | — | — | — | Yes |
-| **(capability)** Live model switch | Yes | Yes | — | — | Yes | Yes | Yes |
-| **(capability)** Live permission-mode switch | Yes | Yes | — | — | — | — | Yes |
-| **(capability)** Plan mode | — | **Yes** | — | — | — | — | — |
-| **(capability)** Resume (`resumeSessionId`) | Yes | — | — | — | — | — | — |
-| **(capability)** Terminal (raw PTY) | — | — | — | — | — | — | — |
-| **(capability)** Thinking level control | Yes | — | — | — | — | — | — |
-| **(capability)** Live streaming (`stream_delta`) | Yes | Yes | **No** (deliver-on-complete) | **Yes** | Yes | Yes | Yes |
-| **(behavioural)** Attachments (images, files) | Yes | Yes | — | — | — | — | — |
-| **(behavioural)** Agent tracking (spawned/completed) | Yes | Yes | — | — | — | — | Yes |
-| **(behavioural)** Cost reporting (`result.cost`) | Yes | Yes | — | — | — | — | Yes (always $0) |
-| **(behavioural)** Multi-session (SessionManager) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| **(behavioural)** Conversation continuity across messages | Yes (SDK state) | Yes (persistent process) | Yes (persistent PTY) | Yes (persistent session) | **No** | **No** | Yes (in-memory history) |
+| Capability | `claude-sdk` | `claude-cli` | `claude-tui` | `claude-channel` | `codex` | `gemini` | `claude-byok` | `deepseek` | `ollama` |
+|------------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| **(capability)** Permissions (`canUseTool` / hook) | Yes | Yes | Yes (HTTP hook) | Yes (channel relay) | — | — | Yes (in-process) | Yes (in-process) | Yes (in-process) |
+| **(capability)** In-process permissions | Yes | — | — | — | — | — | Yes | Yes | Yes |
+| **(capability)** Live model switch | Yes | Yes | — | — | Yes | Yes | Yes | Yes | Yes |
+| **(capability)** Live permission-mode switch | Yes | Yes | — | — | — | — | Yes | Yes | Yes |
+| **(capability)** Plan mode | — | **Yes** | — | — | — | — | — | — | — |
+| **(capability)** Resume (`resumeSessionId`) | Yes | — | — | — | — | — | — | — | — |
+| **(capability)** Terminal (raw PTY) | — | — | — | — | — | — | — | — | — |
+| **(capability)** Thinking level control | Yes | — | — | — | — | — | — | — | — |
+| **(capability)** Live streaming (`stream_delta`) | Yes | Yes | **No** (deliver-on-complete) | **Yes** | Yes | Yes | Yes | Yes | Yes |
+| **(behavioural)** Attachments (images, files) | Yes | Yes | — | — | — | — | — | — | — |
+| **(behavioural)** Agent tracking (spawned/completed) | Yes | Yes | — | — | — | — | Yes | Yes | Yes |
+| **(behavioural)** Cost reporting (`result.cost`) | Yes | Yes | — | — | — | — | Yes (per-token API) | Yes (per-token API) | Yes (always $0) |
+| **(behavioural)** Multi-session (SessionManager) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| **(behavioural)** Conversation continuity across messages | Yes (SDK state) | Yes (persistent process) | Yes (persistent PTY) | Yes (persistent session) | **No** | **No** | Yes (in-memory history) | Yes (in-memory history) | Yes (in-memory history) |
 
-> The `ollama` column inherits `claude-byok`'s session class (same `capabilities` object and agent loop) — the BYOK and DeepSeek providers, which share it, behave identically and are omitted here only because their columns predate this table's last sweep.
+> The `claude-byok`, `deepseek`, and `ollama` columns share one session class — `deepseek-session.js` and `ollama-session.js` subclass `ClaudeByokSession` (`byok-session.js`), overriding only credentials, endpoint, model registry, and pricing — so their **(capability)** rows are identical by construction. Behaviourally they differ in cost reporting: `claude-byok` and `deepseek` compute real per-token API cost from their pricing tables, while `ollama` reports an honest $0 (local inference). Attachments are dropped with a session-level error ("does not yet materialise attachments") on all three; in-memory history means continuity within the server process but no cross-restart resume (`resume: false`, tracked in #4047).
 
 For capability rows, "—" means the provider's `capabilities` object reports `false`. For behavioural rows, "—" means the feature is unimplemented (the session class throws or emits a `not supported` error, or silently no-ops). Most provider-agnostic UI (session tabs, chat/terminal dual view, push notifications, conversation search, web dashboard) works across all providers.
 


### PR DESCRIPTION
Closes #5423.

## What

Adds `claude-byok` and `deepseek` columns to the capability matrix in `docs/providers.md` (the `ollama` column already existed from #5418 — verified, no row drift) and removes the stale footnote that said the missing columns were "tracked separately".

## How each cell was verified

All three providers share one session class: `deepseek-session.js` and `ollama-session.js` subclass `ClaudeByokSession` (`byok-session.js`), overriding only credentials, endpoint, model registry, and the pricing seam — they do not override `capabilities`, `customEvents`, `sendMessage`, or the agent loop.

**(capability) rows** — read directly off `ClaudeByokSession.capabilities` (`byok-session.js:78-101`): `permissions: true` + `inProcessPermissions: true` (PermissionManager, same machinery as claude-sdk), `modelSwitch: true`, `permissionModeSwitch: true`, `planMode: false`, `resume: false` (in-memory `_history`, persistence tracked in #4047), `terminal: false`, `thinkingLevel: false`, `streaming: true`. Identical for both new columns by construction (neither subclass overrides the getter; confirmed by grep — the only `capabilities` definition in the three files is in `byok-session.js`).

**(behavioural) rows** — verified against the implementation:

- **Attachments: —** `sendMessage(prompt, attachments)` emits a session-level `error` ("BYOK provider does not yet materialise attachments (N dropped)") and drops them (`byok-session.js:488-493`). Footnote wording matches the emit (it is an `error` event, despite the adjacent comment calling it a warn).
- **Agent tracking: Yes** — `agent_spawned` / `agent_completed` are emitted around Task-tool subagent dispatch (`byok-session.js:1303-1340`) and pinned in `customEvents` (#4049). Shared loop, so applies to all three.
- **Cost reporting:** `result.cost` is accumulated per turn via `computePromptCostUsd(usage, pricing)` (`byok-session.js:710,856,880`). The pricing seam differs: `claude-byok` uses `getModelPricing` (Anthropic per-token rates), `deepseek` uses `getDeepSeekPricing` — both real per-token API billing, so **Yes (per-token API)**; `ollama` returns a frozen zero-rate entry, so its existing **Yes (always $0)** cell is accurate and unchanged.
- **Continuity: Yes (in-memory history)** — `_history` array capped at `MAX_HISTORY_TURNS = 50`, lives in the session instance; survives across messages, not across server restarts (hence `resume: false`).
- **Multi-session: Yes** — plain registry providers under SessionManager, nothing provider-specific.

## Acceptance criteria

- [x] `docs/providers.md` capability matrix has `claude-byok` and `deepseek` columns
- [x] Capability rows match `ClaudeByokSession.capabilities` (shared by all three)
- [x] Behavioural rows verified against the session classes (attachments dropped, agent tracking, cost reporting, continuity)
- [x] Footnote about omitted columns removed (replaced with a note on the shared class and the cells where the three columns genuinely differ)

## Out of scope (pre-existing drift, noting for a possible follow-up)

The intro ("Six first-party providers ship built-in") and the Provider table earlier in the same doc do not list `claude-byok` or `deepseek` either, even though both are registered in `providers.js`. The issue's acceptance criteria cover only the capability matrix, so this PR doesn't touch those sections.
