### PR TITLE
fix(server): deliver the 413 response before tearing down oversize-body requests

### DIFF
--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -30,6 +30,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { safeTokenCompare } from './token-compare.js'
+import { sendOversizeResponse } from './http-oversize.js'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 import { RateLimiter, getRateLimitKey } from './rate-limiter.js'
@@ -248,10 +249,15 @@ export function handleEventIngest(server, req, res) {
   let body = ''
   let oversized = false
   req.on('data', (chunk) => {
+    if (oversized) return
     body += chunk
     if (body.length > MAX_INGEST_BODY_BYTES) {
       oversized = true
-      req.destroy()
+      // #5433: respond BEFORE teardown — destroying the socket here would
+      // suppress 'end' and the client would see a reset instead of the 413.
+      // The helper stops consumption (no buffering past the cap) and closes
+      // the connection after the response flushes.
+      sendOversizeResponse(req, res, { error: 'body too large' })
     }
   })
   req.on('end', () => {
@@ -259,10 +265,8 @@ export function handleEventIngest(server, req, res) {
     // dispatch try/catch (#5312) — wrap everything so a throw here can't
     // escape to uncaughtException and take the daemon down.
     try {
-      if (oversized) {
-        sendJson(res, 413, { error: 'body too large' })
-        return
-      }
+      // #5433: the 413 was already sent from the 'data' handler.
+      if (oversized) return
 
       let parsed
       try {

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -246,19 +246,27 @@ export function handleEventIngest(server, req, res) {
     return
   }
 
+  // utf8 decoding so multi-byte chars split across TCP chunks reassemble
+  // correctly, and the cap below counts BYTES (Buffer.byteLength), not
+  // UTF-16 code units — body.length undercounts non-ASCII ~3x.
+  req.setEncoding('utf8')
   let body = ''
+  let bodyBytes = 0
   let oversized = false
   req.on('data', (chunk) => {
     if (oversized) return
-    body += chunk
-    if (body.length > MAX_INGEST_BODY_BYTES) {
+    bodyBytes += Buffer.byteLength(chunk, 'utf8')
+    if (bodyBytes > MAX_INGEST_BODY_BYTES) {
       oversized = true
       // #5433: respond BEFORE teardown — destroying the socket here would
       // suppress 'end' and the client would see a reset instead of the 413.
-      // The helper stops consumption (no buffering past the cap) and closes
-      // the connection after the response flushes.
+      // The helper stops consumption and closes the connection after the
+      // response flushes. Cap checked BEFORE append: the violating chunk is
+      // never buffered, so `body` never exceeds the cap in memory.
       sendOversizeResponse(req, res, { error: 'body too large' })
+      return
     }
+    body += chunk
   })
   req.on('end', () => {
     // #5313 pattern: this callback runs on a later tick, OUTSIDE the HTTP

--- a/packages/server/src/http-oversize.js
+++ b/packages/server/src/http-oversize.js
@@ -31,13 +31,8 @@ export function sendOversizeResponse(req, res, payload = { error: 'body too larg
   req.pause()
   // Captured now — Node detaches res.socket before user 'finish' listeners run.
   const socket = res.socket
-  try {
-    res.writeHead(413, { 'Content-Type': 'application/json', 'Connection': 'close' })
-    res.end(JSON.stringify(payload))
-  } catch {
-    // Socket already torn down — nothing left to deliver the 413 to.
-    return
-  }
+  // Attached BEFORE end(): 'finish' is emitted async on Node streams, but
+  // ordering the listener first makes that guarantee irrelevant.
   res.once('finish', () => {
     try {
       if (socket && !socket.destroyed && typeof socket.destroySoon === 'function') {
@@ -45,4 +40,12 @@ export function sendOversizeResponse(req, res, payload = { error: 'body too larg
       }
     } catch { /* already gone */ }
   })
+  try {
+    res.writeHead(413, { 'Content-Type': 'application/json', 'Connection': 'close' })
+    res.end(JSON.stringify(payload))
+  } catch {
+    // Socket already torn down — nothing left to deliver the 413 to. The
+    // 'finish' listener stays attached harmlessly (destroySoon is idempotent
+    // and guarded); teardown falls to Node's requestTimeout backstop.
+  }
 }

--- a/packages/server/src/http-oversize.js
+++ b/packages/server/src/http-oversize.js
@@ -1,0 +1,48 @@
+/**
+ * #5433: shared oversize-body rejection for capped HTTP body readers.
+ *
+ * The previous pattern (`req.destroy()` inside the 'data' handler) tore the
+ * socket down before any response was written — after a mid-stream destroy,
+ * 'end' never fires (verified on Node 22), so the 413 branch in the 'end'
+ * handler was dead code and clients saw ECONNRESET instead of the documented
+ * 413.
+ *
+ * The replacement, used by all three capped readers (POST /api/events,
+ * POST /permission, POST /permission-response) so they stay in lockstep:
+ *
+ *   1. Stop consuming WITHOUT buffering past the cap: drop the 'data'
+ *      listeners and pause the stream. An attacker that keeps streaming now
+ *      backs up into the kernel receive buffer (TCP backpressure), not our
+ *      heap.
+ *   2. Send the 413 with `Connection: close`. The close header marks this
+ *      response as the socket's last (`res._last`), so once it flushes Node
+ *      tears the connection down itself via `socket.destroySoon()` — i.e.
+ *      the FIN goes out AFTER the 413 bytes, never before.
+ *   3. Belt-and-braces: on response 'finish', destroySoon the socket
+ *      ourselves in case anything upstream stripped the close semantics.
+ *      destroySoon (not destroy) so a still-flushing response is never cut
+ *      off; it is idempotent alongside Node's own teardown.
+ *
+ * Callers must treat the request as answered: their 'end'/'close' handlers
+ * should no-op when the oversize flag is set.
+ */
+export function sendOversizeResponse(req, res, payload = { error: 'body too large' }) {
+  req.removeAllListeners('data')
+  req.pause()
+  // Captured now — Node detaches res.socket before user 'finish' listeners run.
+  const socket = res.socket
+  try {
+    res.writeHead(413, { 'Content-Type': 'application/json', 'Connection': 'close' })
+    res.end(JSON.stringify(payload))
+  } catch {
+    // Socket already torn down — nothing left to deliver the 413 to.
+    return
+  }
+  res.once('finish', () => {
+    try {
+      if (socket && !socket.destroyed && typeof socket.destroySoon === 'function') {
+        socket.destroySoon()
+      }
+    } catch { /* already gone */ }
+  })
+}

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -131,12 +131,16 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     }
 
     const MAX_BODY = 65536
+    // utf8 decoding + byte-accurate cap (Buffer.byteLength, not UTF-16 code
+    // units), checked BEFORE append so the violating chunk is never buffered.
+    req.setEncoding('utf8')
     let body = ''
+    let bodyBytes = 0
     let oversized = false
     req.on('data', (chunk) => {
       if (oversized) return
-      body += chunk
-      if (body.length > MAX_BODY) {
+      bodyBytes += Buffer.byteLength(chunk, 'utf8')
+      if (bodyBytes > MAX_BODY) {
         oversized = true
         // #5433: respond BEFORE teardown — req.destroy() here suppressed
         // 'end' (the 413 branch below was dead code) and the hook saw a
@@ -144,7 +148,9 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         // consumption without buffering past the cap and closes the
         // connection after the response flushes.
         sendOversizeResponse(req, res, { decision: 'deny' })
+        return
       }
+      body += chunk
     })
     req.on('end', () => {
       // #5313 (WP-1.3): this callback fires on a later tick, after the HTTP
@@ -313,12 +319,16 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       : null
 
     const MAX_BODY = 4096
+    // utf8 decoding + byte-accurate cap, checked BEFORE append — see
+    // handlePermissionRequest above; the three capped readers stay in lockstep.
+    req.setEncoding('utf8')
     let body = ''
+    let bodyBytes = 0
     let oversized = false
     req.on('data', (chunk) => {
       if (oversized) return
-      body += chunk
-      if (body.length > MAX_BODY) {
+      bodyBytes += Buffer.byteLength(chunk, 'utf8')
+      if (bodyBytes > MAX_BODY) {
         oversized = true
         // #5433: same shared rejection as handlePermissionRequest /
         // /api/events — this site already responded before teardown, but the
@@ -327,7 +337,9 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         // the socket after the 413 flushes (Connection: close). It contains
         // torn-down-socket throws internally (#5389 guard preserved).
         sendOversizeResponse(req, res, { error: 'body too large' })
+        return
       }
+      body += chunk
     })
     req.on('end', () => {
       // #5313 (WP-1.3): same crash shape as handlePermissionRequest's end

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -3,6 +3,7 @@ import { createLogger } from './logger.js'
 import { RateLimiter, getRateLimitKey } from './rate-limiter.js'
 import { buildSessionTokenMismatchPayload } from './handler-utils.js'
 import { createPermissionResolver } from './permission-resolver.js'
+import { sendOversizeResponse } from './http-oversize.js'
 
 const log = createLogger('ws')
 
@@ -133,10 +134,16 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     let body = ''
     let oversized = false
     req.on('data', (chunk) => {
+      if (oversized) return
       body += chunk
       if (body.length > MAX_BODY) {
         oversized = true
-        req.destroy()
+        // #5433: respond BEFORE teardown — req.destroy() here suppressed
+        // 'end' (the 413 branch below was dead code) and the hook saw a
+        // socket reset instead of the documented 413 deny. The helper stops
+        // consumption without buffering past the cap and closes the
+        // connection after the response flushes.
+        sendOversizeResponse(req, res, { decision: 'deny' })
       }
     })
     req.on('end', () => {
@@ -148,10 +155,8 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       // on a torn-down socket, downstream session/broadcast calls) so any other
       // throw is contained and returns a 500 to the client when possible.
       try {
-      if (oversized) {
-        sendJson(res, 413, { decision: 'deny' })
-        return
-      }
+      // #5433: the 413 deny was already sent from the 'data' handler.
+      if (oversized) return
 
       let hookData
       try {
@@ -315,13 +320,13 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       body += chunk
       if (body.length > MAX_BODY) {
         oversized = true
-        // #5389 review: this 'data' callback runs on a later tick outside the
-        // route wrapper, so a throw here (e.g. writing to a torn-down socket)
-        // would escape to uncaughtException and crash the daemon — same shape
-        // as the #5313 guard on the 'end' handler. Contain it.
-        try {
-          sendJson(res, 413, { error: 'body too large' })
-        } catch { /* socket already torn down — nothing more we can do */ }
+        // #5433: same shared rejection as handlePermissionRequest /
+        // /api/events — this site already responded before teardown, but the
+        // helper also stops consumption (pause + listener removal, so an
+        // attacker can't keep streaming into a live connection) and closes
+        // the socket after the 413 flushes (Connection: close). It contains
+        // torn-down-socket throws internally (#5389 guard preserved).
+        sendOversizeResponse(req, res, { error: 'body too large' })
       }
     })
     req.on('end', () => {

--- a/packages/server/tests/event-ingest.test.js
+++ b/packages/server/tests/event-ingest.test.js
@@ -172,10 +172,10 @@ describe('event-ingest', () => {
     it('413 on an oversized body', async () => {
       await startWith(createMockServer())
       const big = JSON.stringify(validEvent({ project: 'x'.repeat(MAX_INGEST_BODY_BYTES) }))
-      const res = await post(big).catch(() => null)
-      // The server destroys the socket after flagging oversize; depending on
-      // timing the client sees the 413 or a reset. Both prove the cap.
-      if (res) assert.equal(res.status, 413)
+      // #5433: the 413 must actually be DELIVERED — no reset hedge. A
+      // connection reset rejects fetch() and fails the test.
+      const res = await post(big)
+      assert.equal(res.status, 413)
       assert.equal(mockServer.pushManager.calls.length, 0)
     })
 

--- a/packages/server/tests/http-oversize-413-delivery.test.js
+++ b/packages/server/tests/http-oversize-413-delivery.test.js
@@ -1,0 +1,121 @@
+// #5433: oversize-body 413 must actually be DELIVERED to the client.
+//
+// The old pattern called req.destroy() the moment the body cap tripped.
+// Empirically (Node 22) 'end' never fires after a mid-stream destroy — only
+// 'close' — so the 413 branch inside the 'end' handler was dead code and the
+// client saw a socket reset (UND_ERR_SOCKET / ECONNRESET) instead of the
+// documented 413.
+//
+// These tests use REAL sockets (node:http createServer + global fetch): a
+// connection reset makes fetch() REJECT, so each bare `await post(...)`
+// resolving with status 413 is the proof. No `.catch(() => null)` hedging —
+// that hedge is exactly how the original bug hid (#5432's test).
+//
+// All three capped body readers are covered so they stay in lockstep:
+//   POST /api/events          (event-ingest.js, 64KB)
+//   POST /permission          (ws-permissions.js, 64KB)
+//   POST /permission-response (ws-permissions.js, 4KB)
+
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { createHttpHandler } from '../src/http-routes.js'
+import { createPermissionHandler } from '../src/ws-permissions.js'
+import { MAX_INGEST_BODY_BYTES } from '../src/event-ingest.js'
+
+const INGEST_SECRET = 'test-ingest-secret-0123456789abcdef'
+
+function makeMockServer() {
+  const permissions = createPermissionHandler({
+    sendFn: () => {},
+    broadcastFn: () => {},
+    validateBearerAuth: () => true,
+    validateHookAuth: () => true,
+    pushManager: null,
+    pendingPermissions: new Map(),
+    permissionSessionMap: new Map(),
+    getSessionManager: () => null,
+  })
+  return {
+    permissions,
+    apiToken: 'primary-token',
+    authRequired: true,
+    serverMode: 'multi',
+    port: 0,
+    _latestVersion: null,
+    _gitInfo: { commit: 'abc', branch: 'main' },
+    _startedAt: Date.now(),
+    _encryptionEnabled: false,
+    _permissions: permissions,
+    _isTokenValid(token) { return token === this.apiToken },
+    _validateBearerAuth() { return true },
+    _ingestSecret: INGEST_SECRET,
+    pushManager: { hasConfiguredSinks: () => true, send: () => Promise.resolve(true) },
+  }
+}
+
+describe('oversize-body 413 delivery over real sockets (#5433)', () => {
+  let httpServer
+  let port
+  let mockServer
+
+  async function start() {
+    mockServer = makeMockServer()
+    httpServer = createServer(createHttpHandler(mockServer))
+    httpServer.listen(0, '127.0.0.1')
+    await once(httpServer, 'listening')
+    port = httpServer.address().port
+  }
+
+  afterEach(() => {
+    mockServer?.permissions?.destroy?.()
+    httpServer?.close()
+    httpServer = null
+  })
+
+  function post(path, body, headers = {}) {
+    return globalThis.fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body,
+    })
+  }
+
+  it('POST /api/events: the client receives the 413, not a reset', async () => {
+    await start()
+    const big = 'x'.repeat(MAX_INGEST_BODY_BYTES + 1024)
+    const res = await post('/api/events', big, { Authorization: `Bearer ${INGEST_SECRET}` })
+    assert.equal(res.status, 413)
+    assert.equal((await res.json()).error, 'body too large')
+  })
+
+  it('POST /permission: the client receives the 413 deny, not a reset', async () => {
+    await start()
+    const big = 'x'.repeat(65536 + 1024)
+    const res = await post('/permission', big, { Authorization: 'Bearer hook-secret' })
+    assert.equal(res.status, 413)
+    assert.equal((await res.json()).decision, 'deny')
+  })
+
+  it('POST /permission-response: the client receives the 413, not a reset', async () => {
+    await start()
+    const big = 'x'.repeat(4096 + 1024)
+    const res = await post('/permission-response', big, { Authorization: 'Bearer primary-token' })
+    assert.equal(res.status, 413)
+    assert.equal((await res.json()).error, 'body too large')
+  })
+
+  it('the oversize response closes the connection (Connection: close semantics)', async () => {
+    await start()
+    const big = 'x'.repeat(MAX_INGEST_BODY_BYTES + 1024)
+    const res = await post('/api/events', big, { Authorization: `Bearer ${INGEST_SECRET}` })
+    assert.equal(res.status, 413)
+    // The 413 socket must not be reusable: a follow-up request gets a fresh
+    // connection and still works (the server didn't wedge or leak state).
+    const ok = await post('/api/events', JSON.stringify({
+      source: 'claude-hooks', project: 'p', type: 'session_start', ts: 1_750_000_000_000,
+    }), { Authorization: `Bearer ${INGEST_SECRET}` })
+    assert.equal(ok.status, 200)
+  })
+})

--- a/packages/server/tests/http-oversize-413-delivery.test.js
+++ b/packages/server/tests/http-oversize-413-delivery.test.js
@@ -106,6 +106,20 @@ describe('oversize-body 413 delivery over real sockets (#5433)', () => {
     assert.equal((await res.json()).error, 'body too large')
   })
 
+  it('the cap counts BYTES, not UTF-16 code units (multi-byte payloads)', async () => {
+    await start()
+    // '€' is 1 UTF-16 code unit but 3 UTF-8 bytes: this payload is well under
+    // the cap in code units (the old body.length check would admit it) and
+    // ~50% over it in bytes.
+    const codeUnits = Math.floor(MAX_INGEST_BODY_BYTES / 2)
+    const big = '€'.repeat(codeUnits)
+    assert.ok(big.length < MAX_INGEST_BODY_BYTES)
+    assert.ok(Buffer.byteLength(big, 'utf8') > MAX_INGEST_BODY_BYTES)
+    const res = await post('/api/events', big, { Authorization: `Bearer ${INGEST_SECRET}` })
+    assert.equal(res.status, 413)
+    assert.equal((await res.json()).error, 'body too large')
+  })
+
   it('the oversize response closes the connection (Connection: close semantics)', async () => {
     await start()
     const big = 'x'.repeat(MAX_INGEST_BODY_BYTES + 1024)

--- a/packages/server/tests/permission-response-parity.test.js
+++ b/packages/server/tests/permission-response-parity.test.js
@@ -44,6 +44,8 @@ function makeReq(body, headers = {}) {
     emitter.emit('end')
   })
   emitter.destroy = mock.fn()
+  emitter.setEncoding = mock.fn()
+  emitter.pause = mock.fn()
   return emitter
 }
 

--- a/packages/server/tests/ws-permissions-binding-integration.test.js
+++ b/packages/server/tests/ws-permissions-binding-integration.test.js
@@ -54,6 +54,8 @@ function makeReq(body, headers = {}) {
     emitter.emit('end')
   })
   emitter.destroy = mock.fn()
+  emitter.setEncoding = mock.fn()
+  emitter.pause = mock.fn()
   return emitter
 }
 

--- a/packages/server/tests/ws-permissions-pause-integration.test.js
+++ b/packages/server/tests/ws-permissions-pause-integration.test.js
@@ -75,6 +75,8 @@ function makeReq(body, headers = {}) {
     emitter.emit('end')
   })
   emitter.destroy = mock.fn()
+  emitter.setEncoding = mock.fn()
+  emitter.pause = mock.fn()
   return emitter
 }
 

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -37,6 +37,10 @@ function makeReq(body, headers = {}) {
     emitter.emit('end')
   })
   emitter.destroy = mock.fn()
+  // Real IncomingMessage API used by the byte-accurate cap (#5433): the
+  // fake keeps emitting Buffers, which Buffer.byteLength handles the same.
+  emitter.setEncoding = mock.fn()
+  emitter.pause = mock.fn()
   return emitter
 }
 


### PR DESCRIPTION
## Summary

On oversize request bodies, all three capped HTTP body readers called `req.destroy()` the moment the cap tripped — tearing down the socket before any response was written. Clients saw a connection reset (`UND_ERR_SOCKET` / ECONNRESET) instead of the documented 413. This PR makes the 413 actually reach the client on all three routes.

## Root cause

After a mid-stream `req.destroy()`, the request's `'end'` event never fires (verified empirically on Node 22 — only `'close'` fires). The 413 branch inside each `'end'` handler was therefore dead code:

```js
req.on('data', (chunk) => {
  body += chunk
  if (body.length > MAX_BODY) { oversized = true; req.destroy() }  // socket gone
})
req.on('end', () => { if (oversized) { /* 413 — never runs */ } })
```

The memory cap itself still worked (buffering stopped), so this was a correctness/UX gap, not a resource one. The #5432 test hedged around it (`if (res) assert.equal(res.status, 413)` — the assertion never ran).

## Fix

New shared helper `packages/server/src/http-oversize.js` → `sendOversizeResponse(req, res, payload)`:

1. **Stop consuming without buffering past the cap** — remove the `'data'` listeners and `req.pause()`; an attacker that keeps streaming backs up into the kernel receive buffer (TCP backpressure), not the heap.
2. **Send the 413 first** — `writeHead(413, { 'Content-Type': 'application/json', Connection: 'close' })` + `res.end(...)`. The close header marks the response as the socket's last, so Node tears the connection down via `socket.destroySoon()` only after the 413 flushes.
3. **Belt-and-braces** — an idempotent `destroySoon` fallback on response `'finish'` (socket captured up front, since Node detaches `res.socket` before user finish listeners run). Torn-down-socket throws are contained internally (preserves the #5313 / #5389 crash guards).

Applied to all three sites in lockstep (per the issue):
- `event-ingest.js` `handleEventIngest` (64KB) — was destroy-then-dead-413
- `ws-permissions.js` `handlePermissionRequest` (64KB) — was destroy-then-dead-413; keeps the `{ decision: 'deny' }` payload
- `ws-permissions.js` `handlePermissionResponseHttp` (4KB) — already responded inline, but now also stops consumption and closes the connection after flush

The `'end'` handlers now no-op when the oversize flag is set (response already sent). Happy path is unchanged.

## Test plan

- **New (TDD, RED first):** `packages/server/tests/http-oversize-413-delivery.test.js` — real sockets (`node:http` createServer + global fetch, **no** `.catch` hedging, so a reset rejects fetch and fails the test). Before the fix: /api/events and /permission failed with `fetch failed` (connection reset); /permission-response passed (its 413 was already inline). After: all pass. Also asserts the 413 connection is not wedged — a follow-up request succeeds.
- **Updated:** the hedged 413 assertion in `event-ingest.test.js` now asserts delivery unconditionally.
- **Regression:** full `event-ingest.test.js` (37 tests, incl. the 429-before-401 gate-ordering pins), `ws-permissions.test.js`, `ws-permissions-pause-integration`, `permission-resolver`, `permission-session-map-cleanup`, `permission-hook`/`-failclosed`, `http-routes`, `http-metrics` — all green. (`permission-response-parity`, `ws-permissions-binding-integration`, `ws-server-permissions` fail identically on unmodified main — pre-existing environmental failures, verified via stash.)
- Custom CI shell lints (`lint-logger-session-scoping`, `lint-session-opt-forwarding`, `lint-tests-state-file-path`) and eslint on changed sources: pass.

Closes #5433.