### PR TITLE
feat(app): surface session_online / session_offline / session_activity in notification prefs

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -75,6 +75,18 @@ describe('SettingsScreen — Notification categories section (#4542)', () => {
     expect(settingsSource).toMatch(/activity_error:.*Session errors/);
     expect(settingsSource).toMatch(/inactivity_warning:.*Inactivity warnings/);
     expect(settingsSource).toMatch(/live_activity:.*Live Activity/);
+    // #5435: external-session categories fed by POST /api/events (#5413).
+    expect(settingsSource).toMatch(/session_online:.*External session online/);
+    expect(settingsSource).toMatch(/session_offline:.*External session offline/);
+    expect(settingsSource).toMatch(/session_activity:.*External session activity/);
+  });
+
+  it('includes the external-session categories in the render order (#5435)', () => {
+    // The order array drives rendering; a label without an order slot would
+    // fall through to the unknown-key tail and jitter on every snapshot.
+    expect(settingsSource).toMatch(
+      /NOTIFICATION_CATEGORY_ORDER\s*=\s*\[[\s\S]{0,600}'session_online',\s*\n\s*'session_offline',\s*\n\s*'session_activity',/,
+    );
   });
 
   it('passes the toggled value through Switch.onValueChange to setNotificationPrefsCategory', () => {

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -57,6 +57,10 @@ const NOTIFICATION_CATEGORY_LABELS: Record<string, { label: string; hint?: strin
   activity_error: { label: 'Session errors', hint: 'Crashes, tunnel drops, fatal session failures.' },
   inactivity_warning: { label: 'Inactivity warnings', hint: 'Heads-up before a long-idle session is paused.' },
   live_activity: { label: 'Live Activity (iOS)', hint: 'iOS Dynamic Island / lock-screen updates.' },
+  // #5413 Phase 3: external-session categories fed by POST /api/events.
+  session_online: { label: 'External session online', hint: 'An external session reported in via /api/events.' },
+  session_offline: { label: 'External session offline', hint: 'An external session ended or went away.' },
+  session_activity: { label: 'External session activity', hint: 'Subagent and tool activity from external sessions.' },
 };
 
 /** Render order for known categories. Unknown keys append in snapshot order. */
@@ -67,6 +71,11 @@ const NOTIFICATION_CATEGORY_ORDER = [
   'activity_update',
   'inactivity_warning',
   'result',
+  // External-session categories (#5413) grouped together, ahead of the
+  // platform-specific Live Activity entry which stays last.
+  'session_online',
+  'session_offline',
+  'session_activity',
   'live_activity',
 ];
 


### PR DESCRIPTION
## Summary

Gives the three external-session notification categories added server-side in #5432 friendly labels and a deterministic slot in the mobile Settings screen, instead of falling through to the raw-key unknown-category tail.

- `NOTIFICATION_CATEGORY_LABELS` in `packages/app/src/screens/SettingsScreen.tsx` gains:
  - `session_online` — **External session online** ("An external session reported in via /api/events.")
  - `session_offline` — **External session offline** ("An external session ended or went away.")
  - `session_activity` — **External session activity** ("Subagent and tool activity from external sessions.")
- `NOTIFICATION_CATEGORY_ORDER` slots the three as a group after `result`, keeping the platform-specific `live_activity` entry last.
- Static-source tests extended: the label-sync test now asserts the three new labels, and a new test pins their presence/grouping in the render order.

This PR is scoped app-only per #5435. Note: the desktop/web dashboard does have a notification-prefs surface (`packages/dashboard/src/components/SettingsPanel.tsx`) with its own label/order constants — dashboard parity for the three categories is tracked in #5446.

## Testing

- `npx jest src/__tests__/components/SettingsScreenNotificationPrefs.test.ts` — 74 passed
- `npx tsc --noEmit` in `packages/app` — clean

Closes #5435.
Related to #5413.
