### PR TITLE
fix: stop assuming a 200k context window when contextWindow is unknown

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable, ScrollView } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
-import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
+import { resolveContextWindow } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm, SessionIntervention } from '@chroxy/store-core';
 import { formatCostBadge } from '@chroxy/store-core';
 import type { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer, PermissionMode } from '../store/connection';
@@ -80,6 +80,12 @@ export interface SettingsBarProps {
   sessionContext?: SessionContext | null;
   latencyMs?: number | null;
   connectionQuality?: 'good' | 'fair' | 'poor' | null;
+  // #5424: active session's provider name (e.g. 'claude-sdk', 'ollama').
+  // Drives context-window resolution — the 200k default only applies to
+  // claude-backed providers; for providers that legitimately report no
+  // window (ollama) the usage meter renders the raw token count without
+  // a percentage/progress bar instead of a misleading "% of 200k".
+  provider?: string | null;
 }
 
 // -- Helpers --
@@ -191,6 +197,7 @@ export function SettingsBar({
   sessionContext,
   latencyMs,
   connectionQuality,
+  provider,
 }: SettingsBarProps) {
   // Elapsed time ticker — only runs when expanded with active agents
   const [now, setNow] = useState(Date.now());
@@ -313,8 +320,14 @@ export function SettingsBar({
     const total = contextUsage.inputTokens + contextUsage.outputTokens;
     if (total > 0) {
       const mInfo = availableModels.find((m) => m.id === activeModel || m.fullId === activeModel);
-      const cw = mInfo?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
-      summaryParts.push(`${Math.min(Math.round((total / cw) * 100), 100)}%`);
+      const cw = resolveContextWindow(mInfo, provider);
+      // #5424: when the window is genuinely unknown (e.g. ollama reports
+      // none), show the raw token count instead of a fabricated "% of 200k".
+      summaryParts.push(
+        cw != null
+          ? `${Math.min(Math.round((total / cw) * 100), 100)}%`
+          : formatTokenCount(total),
+      );
     }
   }
 
@@ -513,7 +526,19 @@ export function SettingsBar({
                     const total = contextUsage.inputTokens + contextUsage.outputTokens;
                     if (total === 0) return null;
                     const modelInfo = availableModels.find((m) => m.id === activeModel || m.fullId === activeModel);
-                    const contextWindow = modelInfo?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+                    const contextWindow = resolveContextWindow(modelInfo, provider);
+                    if (contextWindow == null) {
+                      // #5424: window genuinely unknown (e.g. ollama reports
+                      // none — the real limit is the local model file's
+                      // num_ctx). Show the raw token count, no percentage or
+                      // progress bar, instead of metering against a
+                      // fabricated 200k.
+                      return (
+                        <Text style={styles.contextText} testID="context-usage-unknown-window">
+                          {formatTokenCount(total)}
+                        </Text>
+                      );
+                    }
                     const pct = (total / contextWindow) * 100;
                     const barColor = pct >= 80 ? COLORS.accentRed : pct >= 50 ? COLORS.accentOrange : COLORS.accentGreen;
                     return (

--- a/packages/app/src/components/__tests__/SettingsBarContextWindow.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarContextWindow.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Render tests for the SettingsBar context-usage meter when the model's
+ * context window is unknown (#5424).
+ *
+ * Ollama deliberately reports `contextWindow: null` (the effective window is
+ * the local model file's num_ctx), so the meter must show the raw token
+ * count — no percentage, no progress bar — instead of metering against a
+ * fabricated 200k. Claude-backed providers keep the 200k default because
+ * it's a genuine default there.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { SettingsBar } from '../SettingsBar';
+import type { SettingsBarProps } from '../SettingsBar';
+import type { ContextUsage, ModelInfo } from '../../store/connection';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+const contextUsage: ContextUsage = {
+  inputTokens: 12_000,
+  outputTokens: 500,
+  cacheCreation: 0,
+  cacheRead: 0,
+};
+
+function makeProps(overrides: Partial<SettingsBarProps> = {}): SettingsBarProps {
+  return {
+    expanded: false,
+    onToggle: () => {},
+    activeModel: 'llama3:8b',
+    availableModels: [
+      // Ollama models ship contextWindow: null on the wire; store-core drops
+      // non-positive values, so the entry simply has no contextWindow here.
+      { id: 'llama3:8b', label: 'llama3:8b', fullId: 'llama3:8b' } as ModelInfo,
+    ],
+    permissionMode: null,
+    availablePermissionModes: [],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextUsage,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    provider: 'ollama',
+    ...overrides,
+  };
+}
+
+function render(props: SettingsBarProps): renderer.ReactTestRenderer {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(<SettingsBar {...props} />);
+  });
+  return tree;
+}
+
+describe('SettingsBar context meter with unknown context window (#5424)', () => {
+  it('collapsed summary shows the raw token count (no percent) for an ollama model with no contextWindow', () => {
+    const tree = render(makeProps());
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('12.5k tokens');
+    expect(text).not.toMatch(/\d+%/);
+  });
+
+  it('collapsed summary still shows a percent against 200k for a claude provider missing contextWindow', () => {
+    const tree = render(makeProps({
+      provider: 'claude-sdk',
+      activeModel: 'sonnet',
+      availableModels: [
+        { id: 'sonnet', label: 'Sonnet 4.6', fullId: 'claude-sonnet-4-6' } as ModelInfo,
+      ],
+    }));
+    const text = collectVisibleText(tree.root);
+    // 12_500 / 200_000 = 6.25% → rounds to 6%
+    expect(text).toContain('6%');
+  });
+
+  it('expanded view renders the unknown-window row (raw count, no percent, no bar) for ollama', () => {
+    const tree = render(makeProps({ expanded: true }));
+    const unknownRow = tree.root.findByProps({ testID: 'context-usage-unknown-window' });
+    expect(collectVisibleText(unknownRow)).toContain('12.5k tokens');
+    const text = collectVisibleText(tree.root);
+    expect(text).not.toMatch(/\(\d+%\)/);
+  });
+
+  it('expanded view keeps the percentage + meter when the ollama model reports a real window', () => {
+    const tree = render(makeProps({
+      expanded: true,
+      availableModels: [
+        { id: 'llama3:8b', label: 'llama3:8b', fullId: 'llama3:8b', contextWindow: 32_000 } as ModelInfo,
+      ],
+    }));
+    expect(tree.root.findAllByProps({ testID: 'context-usage-unknown-window' })).toHaveLength(0);
+    // 12_500 / 32_000 ≈ 39%
+    expect(collectVisibleText(tree.root)).toContain('(39%)');
+  });
+
+  it('expanded view keeps the 200k-default percentage for a claude provider missing contextWindow', () => {
+    const tree = render(makeProps({
+      expanded: true,
+      provider: 'claude-sdk',
+      activeModel: 'sonnet',
+      availableModels: [
+        { id: 'sonnet', label: 'Sonnet 4.6', fullId: 'claude-sonnet-4-6' } as ModelInfo,
+      ],
+    }));
+    expect(tree.root.findAllByProps({ testID: 'context-usage-unknown-window' })).toHaveLength(0);
+    expect(collectVisibleText(tree.root)).toContain('(6%)');
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -1103,6 +1103,10 @@ export function SessionScreen() {
           sessionContext={sessionContext}
           latencyMs={latencyMs}
           connectionQuality={connectionQuality}
+          // #5424: provider drives context-window resolution — for providers
+          // that legitimately report no window (ollama) the usage meter shows
+          // the raw token count instead of a percentage against 200k.
+          provider={activeSessionProvider}
         />
       )}
 

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -2473,3 +2473,97 @@ describe('App', () => {
     })
   })
 })
+
+// #5424 — clients must not assume a 200k context window when a model's
+// contextWindow is unknown. Ollama deliberately reports none (the effective
+// window is the local model file's num_ctx), so the header meter must fall
+// back to the raw token-count chip instead of rendering a fabricated
+// "% of 200k". Claude-backed providers keep the 200k default — it's real.
+describe('context meter with unknown context window (#5424)', () => {
+  const contextUsage = { inputTokens: 12_000, outputTokens: 500 }
+
+  function sessionState(activeModel: string) {
+    return {
+      messages: [],
+      streamingMessageId: null,
+      activeModel,
+      permissionMode: null,
+      contextUsage,
+      sessionCost: null,
+      isIdle: true,
+      activeAgents: [],
+      isPlanPending: false,
+    }
+  }
+
+  function session(provider: string) {
+    return {
+      sessionId: 's1',
+      name: 'Test',
+      cwd: '/tmp',
+      type: 'cli' as const,
+      hasTerminal: true,
+      model: null,
+      permissionMode: null,
+      isBusy: false,
+      createdAt: Date.now(),
+      conversationId: null,
+      provider,
+    }
+  }
+
+  it('hides the percent meter and shows the raw token count for an ollama model with no contextWindow', () => {
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('ollama')],
+      activeSessionId: 's1',
+      availableModels: [
+        // Ollama models ship contextWindow: null on the wire; store-core
+        // drops it, so the entry simply has no contextWindow here.
+        { id: 'llama3:8b', label: 'llama3:8b', fullId: 'llama3:8b' },
+      ],
+      getActiveSessionState: () => sessionState('llama3:8b'),
+    }
+    const { container } = render(<App />)
+    // No used/total meter — there is no known total to meter against.
+    expect(screen.queryByTestId('status-context-meter')).not.toBeInTheDocument()
+    // The chip falls back to the raw token count (12.5k tokens), no percent.
+    const chip = container.querySelector('#header .status-context')
+    expect(chip).toBeTruthy()
+    expect(chip!.textContent).toContain('12.5k tokens')
+  })
+
+  it('still meters against the 200k default for a claude provider whose model entry lacks contextWindow', () => {
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('claude-sdk')],
+      activeSessionId: 's1',
+      availableModels: [
+        // Legacy servers can omit contextWindow on claude models — the
+        // 200k default is genuine there.
+        { id: 'sonnet', label: 'Sonnet 4.6', fullId: 'claude-sonnet-4-6' },
+      ],
+      getActiveSessionState: () => sessionState('sonnet'),
+    }
+    render(<App />)
+    const label = screen.getByTestId('status-context-label')
+    expect(label.textContent).toContain('12.5k')
+    expect(label.textContent).toContain('200.0k')
+  })
+
+  it('meters against the reported window when an ollama model does report one', () => {
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('ollama')],
+      activeSessionId: 's1',
+      availableModels: [
+        { id: 'llama3:8b', label: 'llama3:8b', fullId: 'llama3:8b', contextWindow: 32_000 },
+      ],
+      getActiveSessionState: () => sessionState('llama3:8b'),
+    }
+    render(<App />)
+    const label = screen.getByTestId('status-context-label')
+    expect(label.textContent).toContain('12.5k')
+    expect(label.textContent).toContain('32.0k')
+  })
+})

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -7,11 +7,11 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import {
-  DEFAULT_CONTEXT_WINDOW,
   deriveSessionVisualStatus,
   formatPasteMarker,
   formatTokensCompact,
   expandPasteMarkers,
+  resolveContextWindow,
   type SessionInfo,
 } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
@@ -1999,15 +1999,26 @@ export function App() {
     return [...registryRows, ...extraEntries].map(entry => ({ ...entry, keys: formatShortcutKeys(entry.keys) }))
   })()
 
-  // Compute context window usage percentage from active model metadata
+  // #5424: resolve the active model's context window once for the header
+  // meter, the footer meter, and the percent computation. `null` when the
+  // window is genuinely unknown (e.g. ollama deliberately reports none) —
+  // the 200k fallback only applies to claude-backed providers, where it's
+  // a real default rather than a fabricated number.
+  const activeContextWindow = useMemo(() => {
+    const modelInfo = availableModels.find(m => m.id === activeModel || m.fullId === activeModel)
+    return resolveContextWindow(modelInfo, activeSessionProvider)
+  }, [availableModels, activeModel, activeSessionProvider])
+
+  // Compute context window usage percentage from active model metadata.
+  // Null when the window is unknown (#5424) — the chips then fall back to
+  // the raw token-count text instead of a percentage/progress bar.
   const contextPercent = useMemo(() => {
     if (!contextUsage) return null
+    if (activeContextWindow == null) return null
     const total = contextUsage.inputTokens + contextUsage.outputTokens
     if (total === 0) return null
-    const modelInfo = availableModels.find(m => m.id === activeModel || m.fullId === activeModel)
-    const contextWindow = modelInfo?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
-    return (total / contextWindow) * 100
-  }, [contextUsage, activeModel, availableModels])
+    return (total / activeContextWindow) * 100
+  }, [contextUsage, activeContextWindow])
 
   // #5184: human-readable model label for the `provider-model` cost-badge
   // mode. Prefer the server-supplied `label`; fall back to the raw model id
@@ -2281,9 +2292,10 @@ export function App() {
             // the header. We only pass the window when there's an active
             // model — that's the "no session selected" gate the meter
             // hides on (`showMeter` requires a positive window).
-            contextWindow={activeModel
-              ? (availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow) ?? DEFAULT_CONTEXT_WINDOW
-              : undefined}
+            // #5424: `activeContextWindow` is null when the window is
+            // genuinely unknown (e.g. ollama) — the meter then hides and
+            // the chip falls back to the raw token-count text.
+            contextWindow={activeModel ? activeContextWindow ?? undefined : undefined}
             isBusy={!isIdle}
             agentCount={activeAgents.length}
             provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
@@ -2701,7 +2713,10 @@ export function App() {
         onShowQr={isConnected ? handleShowQr : undefined}
         onShareSession={isConnected && activeSessionId ? handleShareSession : undefined}
         provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
-        contextWindow={(availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow) ?? DEFAULT_CONTEXT_WINDOW}
+        // #5424: null when the window is genuinely unknown (e.g. ollama) —
+        // the model tooltip then omits the context-window sentence instead
+        // of claiming a fabricated 200k.
+        contextWindow={activeContextWindow ?? undefined}
         // #3857: surface a clickable "/compact" suggestion past 80% so the
         // user gets a remedy hint rather than just a red bar. Only enabled
         // when there's an active session to route the input through — without

--- a/packages/store-core/src/context-window.test.ts
+++ b/packages/store-core/src/context-window.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for shared context-window resolution (#5424).
+ *
+ * Pins the rule that the 200k DEFAULT_CONTEXT_WINDOW is a *Claude* default:
+ * providers that legitimately report no window (ollama deliberately sends
+ * `contextWindow: null`) must resolve to `null` so clients render an
+ * "unknown window" state instead of a misleading "% of 200k" meter.
+ */
+import { describe, it, expect } from 'vitest'
+import { isClaudeBackedProvider, resolveContextWindow } from './context-window'
+import { DEFAULT_CONTEXT_WINDOW } from './types'
+
+describe('isClaudeBackedProvider (#5424)', () => {
+  it('treats the claude-* family as claude-backed', () => {
+    for (const p of ['claude-cli', 'claude-sdk', 'claude-tui', 'claude-channel', 'claude-byok']) {
+      expect(isClaudeBackedProvider(p)).toBe(true)
+    }
+  })
+
+  it('treats the docker-* wrappers (claude in a container) as claude-backed', () => {
+    for (const p of ['docker', 'docker-cli', 'docker-sdk', 'docker-byok']) {
+      expect(isClaudeBackedProvider(p)).toBe(true)
+    }
+  })
+
+  it('treats null/undefined as claude-backed (legacy servers predate provider reporting)', () => {
+    expect(isClaudeBackedProvider(null)).toBe(true)
+    expect(isClaudeBackedProvider(undefined)).toBe(true)
+  })
+
+  it('treats non-claude providers as NOT claude-backed', () => {
+    for (const p of ['ollama', 'deepseek', 'gemini', 'codex', 'some-future-provider']) {
+      expect(isClaudeBackedProvider(p)).toBe(false)
+    }
+  })
+
+  it('does not prefix-match without the dash separator', () => {
+    // 'claudette' / 'dockerish' must not ride the claude/docker defaults.
+    expect(isClaudeBackedProvider('claudette')).toBe(false)
+    expect(isClaudeBackedProvider('dockerish')).toBe(false)
+  })
+})
+
+describe('resolveContextWindow (#5424)', () => {
+  it('returns the reported window when positive, regardless of provider', () => {
+    expect(resolveContextWindow({ contextWindow: 32_000 }, 'ollama')).toBe(32_000)
+    expect(resolveContextWindow({ contextWindow: 1_000_000 }, 'claude-sdk')).toBe(1_000_000)
+    expect(resolveContextWindow({ contextWindow: 128_000 }, undefined)).toBe(128_000)
+  })
+
+  it('falls back to the 200k default for claude-backed providers when missing', () => {
+    expect(resolveContextWindow({}, 'claude-cli')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(resolveContextWindow(undefined, 'claude-tui')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(resolveContextWindow(null, 'docker-sdk')).toBe(DEFAULT_CONTEXT_WINDOW)
+  })
+
+  it('falls back to 200k when the provider is unknown (legacy servers only ran claude)', () => {
+    expect(resolveContextWindow({}, null)).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(resolveContextWindow(undefined, undefined)).toBe(DEFAULT_CONTEXT_WINDOW)
+  })
+
+  it('returns null for non-claude providers when the window is missing (the ollama path)', () => {
+    expect(resolveContextWindow({}, 'ollama')).toBe(null)
+    expect(resolveContextWindow(undefined, 'ollama')).toBe(null)
+    expect(resolveContextWindow(null, 'gemini')).toBe(null)
+    expect(resolveContextWindow({}, 'codex')).toBe(null)
+  })
+
+  it('ignores non-positive / non-finite windows', () => {
+    expect(resolveContextWindow({ contextWindow: 0 }, 'ollama')).toBe(null)
+    expect(resolveContextWindow({ contextWindow: -1 }, 'ollama')).toBe(null)
+    expect(resolveContextWindow({ contextWindow: NaN }, 'ollama')).toBe(null)
+    expect(resolveContextWindow({ contextWindow: Infinity }, 'ollama')).toBe(null)
+    // ...but a claude-backed provider still gets the default in that case.
+    expect(resolveContextWindow({ contextWindow: 0 }, 'claude-sdk')).toBe(DEFAULT_CONTEXT_WINDOW)
+  })
+})

--- a/packages/store-core/src/context-window.ts
+++ b/packages/store-core/src/context-window.ts
@@ -1,0 +1,60 @@
+/**
+ * #5424 — context-window resolution shared by the mobile SettingsBar and the
+ * dashboard header/footer meters.
+ *
+ * `DEFAULT_CONTEXT_WINDOW` (200k) is a *Claude* default. The server's claude
+ * registry always ships a real `contextWindow` per model, so the fallback
+ * only fires for legacy servers that predate the field — which only ran
+ * claude. Other providers can legitimately report no window at all: ollama
+ * deliberately sends `contextWindow: null` (the effective window is the
+ * local model file's `num_ctx` — the server never fabricates a number).
+ * Rendering "% of 200k" for a local model whose real window may be 8k–32k
+ * is misleading in the dangerous direction (looks fine while the model is
+ * already truncating), so unknown stays unknown: callers get `null` and
+ * must render an "unknown window" presentation (raw token count, no
+ * percentage / progress bar) instead of a fabricated fraction.
+ */
+import { DEFAULT_CONTEXT_WINDOW } from './types'
+import type { ModelInfo } from './types'
+
+/**
+ * Providers whose sessions are backed by Claude models and therefore
+ * genuinely have the 200k default: the claude-* family plus the docker-*
+ * wrappers (docker-cli / docker-sdk / docker-byok / docker all run a Claude
+ * session inside the container — see provider-labels.ts).
+ */
+const CLAUDE_BACKED_PREFIXES = ['claude', 'docker'] as const
+
+/**
+ * Whether `provider` runs Claude models (and so may assume the Claude
+ * 200k default when a model's `contextWindow` is missing).
+ *
+ * `null`/`undefined` counts as Claude-backed: servers that predate
+ * per-session provider reporting only ran claude, so the legacy fallback
+ * behaviour is preserved for them.
+ */
+export function isClaudeBackedProvider(provider: string | null | undefined): boolean {
+  if (provider == null) return true
+  return CLAUDE_BACKED_PREFIXES.some(
+    (prefix) => provider === prefix || provider.startsWith(`${prefix}-`),
+  )
+}
+
+/**
+ * Resolve the context window (in tokens) to meter against for a model.
+ *
+ * - When the model reports a positive numeric `contextWindow`, that value
+ *   wins — provider is irrelevant.
+ * - When it's missing, the Claude 200k default applies ONLY to
+ *   Claude-backed providers (see `isClaudeBackedProvider`).
+ * - Otherwise returns `null`: the window is genuinely unknown and callers
+ *   must not render a percentage against a made-up total.
+ */
+export function resolveContextWindow(
+  modelInfo: Pick<ModelInfo, 'contextWindow'> | null | undefined,
+  provider?: string | null,
+): number | null {
+  const cw = modelInfo?.contextWindow
+  if (typeof cw === 'number' && Number.isFinite(cw) && cw > 0) return cw
+  return isClaudeBackedProvider(provider) ? DEFAULT_CONTEXT_WINDOW : null
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -11,6 +11,15 @@
 
 export { DEFAULT_CONTEXT_WINDOW } from './types'
 
+// #5424: shared context-window resolution. The 200k default is a Claude
+// default — for providers that legitimately report no window (ollama sends
+// `contextWindow: null` on purpose) `resolveContextWindow` returns null and
+// clients render an "unknown window" state instead of a % against 200k.
+export {
+  isClaudeBackedProvider,
+  resolveContextWindow,
+} from './context-window'
+
 // #4853: runtime type-guard for `VoiceInputMode` — keyed off an
 // exhaustive `Record<VoiceInputMode, true>` so widening the union is a
 // TS error in the guard, not a silent drop at the call site.


### PR DESCRIPTION
Closes #5424.

## Problem

PR #5418 deliberately ships `contextWindow: null` for Ollama models (the effective window is the local model file's `num_ctx` — no fabricated numbers). store-core drops non-positive values, so `modelInfo.contextWindow` ends up `undefined` — and both clients then metered token usage against `DEFAULT_CONTEXT_WINDOW` (200k). For a local model whose real window may be 8k–32k, a "% of 200k" meter is misleading in the dangerous direction: it looks fine while the model is already truncating.

## Fix

**store-core (single point):** new `resolveContextWindow(modelInfo, provider)` returns the model's reported window when positive; otherwise the 200k default **only** for claude-backed providers (`claude-*`, the `docker-*` claude wrappers, and `null`/`undefined` provider — legacy servers predate provider reporting and only ran claude). Everything else (ollama, deepseek, gemini, codex, unknown) resolves to `null`: the window is genuinely unknown.

**Mobile app (`SettingsBar`):** new optional `provider` prop threaded from `SessionScreen`'s existing `activeSessionProvider` selector. When the resolved window is `null`:
- collapsed summary shows the raw token count (`12.5k tokens`) instead of a percent
- expanded view shows the raw token count with no `(N%)` and no progress bar

**Dashboard (`App.tsx`):** the active window is resolved once (provider-aware) and feeds `contextPercent`, the header `StatusBar` meter, and the `FooterBar` meter/tooltip. With a `null` window, `contextPercent` is `null` and no `contextWindow` prop is passed — both components already degrade to their raw token-count chips (`StatusBar` hides the used/total meter; `FooterBar` renders the count text instead of the bar; the model tooltip omits the context-window sentence).

When `contextWindow` is a number, behavior is unchanged on every surface.

## Tests

- `packages/store-core/src/context-window.test.ts` — resolver matrix (claude family, docker wrappers, legacy null provider, ollama/gemini/codex null path, non-positive/non-finite windows, no false prefix matches)
- `packages/dashboard/src/App.test.tsx` — ollama model with no window hides the meter and shows the raw token chip; claude model without a window still meters against 200k; ollama model **with** a reported window meters against it
- `packages/app/src/components/__tests__/SettingsBarContextWindow.test.tsx` — collapsed + expanded unknown-window rendering, plus claude-default and real-window regressions

Results: store-core vitest 1189 passed, dashboard vitest 3277 passed (165 files), app jest SettingsBar/SessionScreen suites 73 passed, `tsc --noEmit` clean in app, dashboard, and store-core.