### PR TITLE
feat(server): discover installed Ollama models via GET /api/tags

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -981,7 +981,13 @@ export function getRegistryForProvider(providerName) {
       const meta = typeof ProviderClass.getModelMetadata === 'function'
         ? ProviderClass.getModelMetadata(fullId)
         : null
-      return meta?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
+      // #5421: preserve an EXPLICIT null — providers like ollama return
+      // `contextWindow: null` to say "window unknown, never fabricate"
+      // (#5418), and substituting DEFAULT_CONTEXT_WINDOW here would pin a
+      // made-up 200k chip on every discovered local model. Only fall back
+      // to the default when the provider has no metadata entry at all.
+      if (meta && 'contextWindow' in meta) return meta.contextWindow
+      return DEFAULT_CONTEXT_WINDOW
     },
     // #4413: provider-scoped cache path. Lazy resolver so tests that mutate
     // `CHROXY_CONFIG_DIR` after registry creation still hit the temp dir.

--- a/packages/server/src/ollama-session.js
+++ b/packages/server/src/ollama-session.js
@@ -17,12 +17,16 @@
  *     `getAllowedModels()` returns null (session-manager treats a
  *     non-array as "no restriction"). `getFallbackModels()` seeds the
  *     dashboard picker with Ollama's recommended coder models; dynamic
- *     discovery via GET /api/tags is a tracked follow-up.
+ *     discovery via GET /api/tags (#5421, ollama-tags.js) replaces the
+ *     seed with the actually-installed list when the daemon is reachable.
+ *     Discovery is ADVISORY only — it feeds the picker, never validation.
  *   - Zero pricing. Local inference is free; `_getPricing` returns a
  *     zero-rate entry (not null) so byok-session's "no pricing entry"
  *     warn never fires and result.cost is an honest 0.
  *
- * Base URL resolution (first match wins):
+ * Base URL resolution (first match wins; lives in ollama-tags.js since
+ * #5421 so the tags probe and the SDK client can't disagree — re-exported
+ * here for compatibility):
  *   1. CHROXY_OLLAMA_BASE_URL — full URL, chroxy-specific override
  *   2. OLLAMA_HOST — Ollama's own convention; may be `host:port` without
  *      a scheme, normalized to http:// here
@@ -36,8 +40,10 @@
 
 import Anthropic from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from './byok-session.js'
+import { resolveOllamaBaseUrl, ollamaEnvOverride, refreshOllamaModels } from './ollama-tags.js'
 
-const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434'
+// Compatibility re-export — resolution moved to ollama-tags.js (#5421).
+export { resolveOllamaBaseUrl }
 
 // Ollama's documented "required but ignored" placeholder key. The
 // Anthropic SDK refuses an empty apiKey, so something must be sent.
@@ -62,50 +68,6 @@ const OLLAMA_FALLBACK_MODELS = Object.freeze([
 // tells operators to update CLAUDE_PRICING_USD_PER_MTOK) never fires for
 // a provider where missing pricing is not a bug.
 const OLLAMA_ZERO_PRICING = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 })
-
-/**
- * Resolve the Ollama endpoint. Exported for tests and for the auth
- * panel's detail string — keep resolution in exactly one place.
- *
- * @param {NodeJS.ProcessEnv} [env]
- * @returns {string}
- */
-export function resolveOllamaBaseUrl(env = process.env) {
-  // Trimmed-non-empty is the single "is set" predicate — resolveAuth
-  // derives its override-var label from the same helper so the detail
-  // string and the actual routing can never disagree. An exported-but-
-  // empty (or whitespace) var counts as unset. Deliberately NO URL
-  // validation here: silently redirecting a typo'd override to localhost
-  // would mask the misconfig — a malformed value flows through and fails
-  // loudly in the SDK's request path, and resolveAuth's `detail` shows
-  // the exact string in the dashboard.
-  const explicit = ollamaEnvOverride(env)
-  if (explicit === 'CHROXY_OLLAMA_BASE_URL') return env.CHROXY_OLLAMA_BASE_URL.trim()
-  if (explicit === 'OLLAMA_HOST') {
-    const host = env.OLLAMA_HOST.trim()
-    // OLLAMA_HOST accepts bare `host`, `host:port`, or a full URL.
-    return /^[a-z][a-z0-9+.-]*:\/\//i.test(host) ? host : `http://${host}`
-  }
-  return DEFAULT_OLLAMA_BASE_URL
-}
-
-/**
- * Which env var (if any) is overriding the endpoint. Shared by
- * resolveOllamaBaseUrl (routing) and resolveAuth (labelling) so the two
- * can't drift.
- *
- * @param {NodeJS.ProcessEnv} env
- * @returns {'CHROXY_OLLAMA_BASE_URL'|'OLLAMA_HOST'|null}
- */
-function ollamaEnvOverride(env) {
-  if (typeof env.CHROXY_OLLAMA_BASE_URL === 'string' && env.CHROXY_OLLAMA_BASE_URL.trim().length > 0) {
-    return 'CHROXY_OLLAMA_BASE_URL'
-  }
-  if (typeof env.OLLAMA_HOST === 'string' && env.OLLAMA_HOST.trim().length > 0) {
-    return 'OLLAMA_HOST'
-  }
-  return null
-}
 
 export class OllamaSession extends ClaudeByokSession {
   static get displayLabel() {
@@ -172,14 +134,57 @@ export class OllamaSession extends ClaudeByokSession {
   static getModelMetadata(modelId) {
     if (typeof modelId !== 'string' || modelId.length === 0) return null
     const hit = OLLAMA_FALLBACK_MODELS.find((m) => m.id === modelId || m.fullId === modelId)
-    if (!hit) return null
-    return { id: hit.id, label: hit.label, fullId: hit.fullId, contextWindow: hit.contextWindow }
+    if (hit) {
+      return { id: hit.id, label: hit.label, fullId: hit.fullId, contextWindow: hit.contextWindow }
+    }
+    // #5421: any other non-empty id is a locally-pulled tag discovered via
+    // /api/tags (or a user-typed alias) — valid metadata with an UNKNOWN
+    // context window. `contextWindow: null` is deliberate and load-bearing:
+    // the registry hook in models.js preserves an explicit null instead of
+    // substituting DEFAULT_CONTEXT_WINDOW, so the dashboard omits the
+    // context chip rather than showing a fabricated 200k (#5418's
+    // never-fabricate rule). The raw tag doubles as the label — Ollama tags
+    // (`llama3.2:7b`) don't survive Claude-style humanization.
+    return { id: modelId, label: modelId, fullId: modelId, contextWindow: null }
+  }
+
+  /**
+   * Dynamic model discovery hook (#5421) — ws-history calls this (fire-and-
+   * forget) whenever it sends `available_models` for an ollama session, and
+   * pushes a refreshed list if discovery changed the registry. Resolves to
+   * the updated model list on change, null otherwise (failure / no change /
+   * TTL-cached). Never throws, never blocks validation: getAllowedModels()
+   * above stays null regardless of what discovery finds.
+   */
+  static refreshModels(opts) {
+    return refreshOllamaModels(opts)
   }
 
   constructor(opts = {}) {
     // Force the registry name so the provider id on this session is
     // always 'ollama' — independent of whatever the embedder passed.
     super({ ...opts, provider: 'ollama' })
+  }
+
+  /**
+   * #5421: kick off model discovery when a session starts — the moment we
+   * know the user actually cares about this Ollama instance. Fire-and-
+   * forget: discovery must never delay or fail session start (byok's
+   * start() already emitted 'ready' by the time the probe resolves). On a
+   * changed list, emit `models_updated` — session-manager forwards it and
+   * ws-forwarding broadcasts a provider-tagged `available_models` to every
+   * connected client (same path the Claude SDK's supportedModels() push
+   * uses), so newly pulled models appear without a daemon restart.
+   */
+  async start() {
+    await super.start()
+    refreshOllamaModels()
+      .then((models) => {
+        if (Array.isArray(models) && models.length > 0) {
+          this.emit('models_updated', { models })
+        }
+      })
+      .catch(() => {})
   }
 
   // --- Seam overrides (see byok-session.js for the contract) ---

--- a/packages/server/src/ollama-tags.js
+++ b/packages/server/src/ollama-tags.js
@@ -1,0 +1,238 @@
+/**
+ * Dynamic Ollama model discovery — GET /api/tags (#5421).
+ *
+ * Asks the local Ollama daemon which models are actually pulled and feeds
+ * the result into the per-provider models registry so the dashboard picker
+ * reflects `ollama list` instead of the static 3-model seed from #5418.
+ *
+ * Design constraints (issue #5421):
+ *   - ADVISORY, NOT RESTRICTIVE. Discovery only populates the picker;
+ *     `OllamaSession.getAllowedModels()` stays null (unrestricted) because
+ *     a model can be `ollama pull`ed mid-session or addressed by an alias
+ *     the tag list doesn't spell out. Validation never consults this module.
+ *   - GRACEFUL FAILURE. Ollama down / slow / returning garbage must never
+ *     delay session start or spam the logs: short timeout (800ms), debug-
+ *     level logging only, and the picker keeps whatever it already had
+ *     (the static fallback list on cold boot).
+ *   - NO RETRY STORM. Results — including failures — are cached for a
+ *     30s TTL, and concurrent callers share one in-flight request. A
+ *     dashboard reconnect loop can't hammer the daemon.
+ *
+ * This module also owns base-URL resolution (moved here from
+ * ollama-session.js, which re-exports it for compatibility) so the session
+ * seam, the auth-panel label, and the tags probe can never disagree about
+ * where Ollama lives. /api/tags is served at the Ollama ROOT — when an
+ * operator's override includes the Anthropic-compat `/v1` path suffix, it
+ * is stripped before appending /api/tags.
+ */
+
+import { getRegistryForProvider } from './models.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('ollama')
+
+const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434'
+
+// Bounded probe: Ollama is a local daemon — if it hasn't answered in 800ms
+// it is down (or wedged), and the picker should just keep its current list.
+export const OLLAMA_TAGS_TIMEOUT_MS = 800
+
+// Cache window for discovery results (success AND failure). Keeps a
+// reconnecting dashboard / multi-client handshake burst down to at most
+// one HTTP probe per 30s while still picking up `ollama pull` quickly.
+export const OLLAMA_TAGS_CACHE_TTL_MS = 30_000
+
+/**
+ * Resolve the Ollama endpoint. Exported (and re-exported by
+ * ollama-session.js) for tests and for the auth panel's detail string —
+ * keep resolution in exactly one place.
+ *
+ * Resolution order (first match wins):
+ *   1. CHROXY_OLLAMA_BASE_URL — full URL, chroxy-specific override
+ *   2. OLLAMA_HOST — Ollama's own convention; may be `host:port` without
+ *      a scheme, normalized to http:// here
+ *   3. http://localhost:11434 — Ollama's default bind
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {string}
+ */
+export function resolveOllamaBaseUrl(env = process.env) {
+  // Trimmed-non-empty is the single "is set" predicate — resolveAuth
+  // derives its override-var label from the same helper so the detail
+  // string and the actual routing can never disagree. An exported-but-
+  // empty (or whitespace) var counts as unset. Deliberately NO URL
+  // validation here: silently redirecting a typo'd override to localhost
+  // would mask the misconfig — a malformed value flows through and fails
+  // loudly in the SDK's request path, and resolveAuth's `detail` shows
+  // the exact string in the dashboard.
+  const explicit = ollamaEnvOverride(env)
+  if (explicit === 'CHROXY_OLLAMA_BASE_URL') return env.CHROXY_OLLAMA_BASE_URL.trim()
+  if (explicit === 'OLLAMA_HOST') {
+    const host = env.OLLAMA_HOST.trim()
+    // OLLAMA_HOST accepts bare `host`, `host:port`, or a full URL.
+    return /^[a-z][a-z0-9+.-]*:\/\//i.test(host) ? host : `http://${host}`
+  }
+  return DEFAULT_OLLAMA_BASE_URL
+}
+
+/**
+ * Which env var (if any) is overriding the endpoint. Shared by
+ * resolveOllamaBaseUrl (routing) and OllamaSession.resolveAuth (labelling)
+ * so the two can't drift.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {'CHROXY_OLLAMA_BASE_URL'|'OLLAMA_HOST'|null}
+ */
+export function ollamaEnvOverride(env) {
+  if (typeof env.CHROXY_OLLAMA_BASE_URL === 'string' && env.CHROXY_OLLAMA_BASE_URL.trim().length > 0) {
+    return 'CHROXY_OLLAMA_BASE_URL'
+  }
+  if (typeof env.OLLAMA_HOST === 'string' && env.OLLAMA_HOST.trim().length > 0) {
+    return 'OLLAMA_HOST'
+  }
+  return null
+}
+
+/**
+ * Build the /api/tags URL from a resolved base URL. /api/tags lives at the
+ * Ollama root: trailing slashes and an Anthropic-compat `/v1` path suffix
+ * (some operators point CHROXY_OLLAMA_BASE_URL at the versioned path even
+ * though the SDK appends it itself) are stripped first.
+ *
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+export function buildOllamaTagsUrl(baseUrl) {
+  let root = typeof baseUrl === 'string' ? baseUrl.trim() : ''
+  root = root.replace(/\/+$/, '')
+  root = root.replace(/\/v1$/i, '')
+  return `${root}/api/tags`
+}
+
+/**
+ * GET <root>/api/tags and return the installed model tags as a normalized,
+ * deduplicated string array — or null on ANY failure (daemon down, non-2xx,
+ * malformed JSON, unexpected shape, timeout). Failures log at debug level
+ * only: an absent Ollama is a normal steady state, not an error.
+ *
+ * Normalization: a bare `:latest` suffix is stripped (Ollama treats
+ * `qwen3-coder` and `qwen3-coder:latest` as the same model, and the short
+ * form matches the curated fallback ids so the picker doesn't show
+ * duplicates). Other tags (`:7b`, `:q4_K_M`, …) identify distinct local
+ * variants and are kept verbatim.
+ *
+ * @param {Object} [opts]
+ * @param {NodeJS.ProcessEnv} [opts.env] - env for base-URL resolution
+ * @param {typeof fetch} [opts.fetchFn] - injectable fetch for tests
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<string[]|null>}
+ */
+export async function fetchOllamaTags({ env = process.env, fetchFn = fetch, timeoutMs = OLLAMA_TAGS_TIMEOUT_MS } = {}) {
+  const url = buildOllamaTagsUrl(resolveOllamaBaseUrl(env))
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetchFn(url, { signal: controller.signal })
+    if (!res?.ok) {
+      log.debug(`tags probe: ${url} answered ${res?.status ?? 'no response'}`)
+      return null
+    }
+    const body = await res.json()
+    if (!Array.isArray(body?.models)) {
+      log.debug(`tags probe: ${url} returned unexpected shape (no models array)`)
+      return null
+    }
+    const seen = new Set()
+    const tags = []
+    for (const m of body.models) {
+      // /api/tags entries carry both `name` and `model` (identical in
+      // practice); prefer `name`, fall back to `model` for forward-compat.
+      const raw = typeof m?.name === 'string' && m.name.trim().length > 0
+        ? m.name.trim()
+        : (typeof m?.model === 'string' ? m.model.trim() : '')
+      if (!raw) continue
+      const tag = raw.replace(/:latest$/, '')
+      if (!tag || seen.has(tag)) continue
+      seen.add(tag)
+      tags.push(tag)
+    }
+    return tags
+  } catch (err) {
+    // AbortError (timeout), ECONNREFUSED (daemon down), invalid JSON —
+    // all the same outcome: no discovery this round.
+    log.debug(`tags probe: ${url} failed (${err?.name === 'AbortError' ? `timeout after ${timeoutMs}ms` : err?.message || err})`)
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// --- TTL cache for refreshOllamaModels ---
+// -Infinity (not 0) so the first call always probes even under an injected
+// test clock that starts near zero.
+let _lastProbeAt = -Infinity
+let _inflight = null
+// Stringified tag set last fed into the registry — lets a successful
+// re-probe that found the SAME models skip the registry rebuild and the
+// resulting available_models re-broadcast.
+let _lastAppliedKey = null
+
+/** Test hook: drop the TTL cache + change-detection state. */
+export function _resetOllamaTagsStateForTests() {
+  _lastProbeAt = -Infinity
+  _inflight = null
+  _lastAppliedKey = null
+}
+
+/**
+ * Discover installed models and feed them into the ollama provider's
+ * models registry. Resolves to the registry's refreshed model list when
+ * the picker contents CHANGED, or null when there is nothing new to
+ * broadcast (probe failed, no models installed, same set as last time,
+ * or served from the TTL cache).
+ *
+ * Callers treat a non-null result as "push a fresh available_models to
+ * clients"; null means whatever was already sent is still accurate.
+ *
+ * Concurrency: one probe in flight at a time (joiners share its promise);
+ * results — including failures — are cached for OLLAMA_TAGS_CACHE_TTL_MS
+ * so handshake bursts and reconnect loops cost at most one HTTP GET per
+ * window.
+ *
+ * @param {Object} [opts] - forwarded to fetchOllamaTags; plus:
+ * @param {Object} [opts.registry] - injectable registry for tests.
+ *   Defaults to getRegistryForProvider('ollama'). In production the
+ *   provider is registered by providers.js at module load, well before
+ *   any caller of this function exists.
+ * @param {number} [opts.ttlMs]
+ * @param {() => number} [opts.now] - injectable clock for tests
+ * @returns {Promise<Array<Object>|null>}
+ */
+export async function refreshOllamaModels(opts = {}) {
+  const now = typeof opts.now === 'function' ? opts.now : Date.now
+  const ttlMs = typeof opts.ttlMs === 'number' ? opts.ttlMs : OLLAMA_TAGS_CACHE_TTL_MS
+  if (_inflight) return _inflight
+  if (now() - _lastProbeAt < ttlMs) return null
+  _inflight = (async () => {
+    try {
+      const tags = await fetchOllamaTags(opts)
+      _lastProbeAt = now()
+      // Failure or an empty install: keep the current picker contents
+      // (static fallback on cold boot, last successful discovery after).
+      if (!Array.isArray(tags) || tags.length === 0) return null
+      const key = JSON.stringify(tags)
+      if (key === _lastAppliedKey) return null
+      const registry = opts.registry ?? getRegistryForProvider('ollama')
+      // No displayName: labels come from OllamaSession.getModelMetadata
+      // (curated labels for the recommended models, the raw tag otherwise).
+      const converted = registry.updateModels(tags.map((tag) => ({ value: tag })))
+      if (!Array.isArray(converted) || converted.length === 0) return null
+      _lastAppliedKey = key
+      log.info(`discovered ${tags.length} installed Ollama model${tags.length === 1 ? '' : 's'} via /api/tags`)
+      return registry.getModels()
+    } finally {
+      _inflight = null
+    }
+  })()
+  return _inflight
+}

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -361,9 +361,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     const activeProvider = entry?.provider || null
     const activeRegistry = getRegistryForProvider(activeProvider)
     send(ws, { type: 'available_models', models: activeRegistry.getModels(), defaultModel: activeRegistry.getDefaultModelId(), provider: activeProvider })
-    // #5421: providers with dynamic discovery (ollama /api/tags) refresh in
-    // the background; a changed list is re-pushed to this client below.
-    scheduleProviderModelsRefresh(ctx, ws, activeProvider)
+    // #5421: dynamic-discovery refresh (ollama /api/tags) is scheduled by
+    // sendSessionInfo above whenever a session is active — scheduling here
+    // too would join the same in-flight probe twice and double-push a
+    // changed list to this client. With no active session activeProvider
+    // is null and there is nothing to refresh.
     send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
     permissions.resendPendingPermissions(ws, client)
     return

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -6,7 +6,7 @@
  */
 import { toShortModelId, getModels, getDefaultModelId, getRegistryForProvider } from './models.js'
 import { PERMISSION_MODES } from './handler-utils.js'
-import { listProviders } from './providers.js'
+import { listProviders, getProvider } from './providers.js'
 import { createLogger } from './logger.js'
 import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STALL_TIMEOUT_MS } from './base-session.js'
 import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
@@ -361,6 +361,9 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     const activeProvider = entry?.provider || null
     const activeRegistry = getRegistryForProvider(activeProvider)
     send(ws, { type: 'available_models', models: activeRegistry.getModels(), defaultModel: activeRegistry.getDefaultModelId(), provider: activeProvider })
+    // #5421: providers with dynamic discovery (ollama /api/tags) refresh in
+    // the background; a changed list is re-pushed to this client below.
+    scheduleProviderModelsRefresh(ctx, ws, activeProvider)
     send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
     permissions.resendPendingPermissions(ws, client)
     return
@@ -394,6 +397,51 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
 }
 
 /**
+ * #5421: fire-and-forget dynamic model discovery for providers that opt in
+ * via a static `refreshModels()` (currently ollama, which probes GET
+ * /api/tags for the locally installed tag list). Called right after an
+ * `available_models` snapshot goes out: when the refresh resolves with a
+ * CHANGED list (non-null), the registry has already been updated, so we
+ * re-push `available_models` to the same client. A null resolution means
+ * the snapshot already sent is still accurate (probe failed / no change /
+ * TTL-cached) and nothing further is emitted — Ollama being down costs one
+ * debug log line, never an error or a retry storm (the provider caches
+ * failures for its TTL window).
+ *
+ * Advisory only — this path feeds the picker; model VALIDATION for ollama
+ * stays unrestricted via getAllowedModels() returning null (a user can
+ * `ollama pull` mid-session or use an alias the tag list doesn't spell out).
+ */
+export function scheduleProviderModelsRefresh(ctx, ws, providerName) {
+  if (!providerName) return
+  let ProviderClass = null
+  try {
+    ProviderClass = getProvider(providerName)
+  } catch {
+    return // unknown provider — nothing to refresh
+  }
+  if (typeof ProviderClass?.refreshModels !== 'function') return
+  Promise.resolve()
+    .then(() => ProviderClass.refreshModels())
+    .then((models) => {
+      if (!Array.isArray(models) || models.length === 0) return
+      if (ws.readyState !== undefined && ws.readyState !== 1) return // client gone
+      const registry = getRegistryForProvider(providerName)
+      ctx.send(ws, {
+        type: 'available_models',
+        models: registry.getModels(),
+        defaultModel: registry.getDefaultModelId(),
+        provider: providerName,
+      })
+    })
+    .catch((err) => {
+      // refreshModels contracts never to throw, but a provider bug must not
+      // become an unhandled rejection in the post-auth path.
+      log.debug(`model refresh for provider ${providerName} failed: ${err?.message || err}`)
+    })
+}
+
+/**
  * Send session-specific info (model, permission, ready status) to a client.
  */
 export function sendSessionInfo(ctx, ws, sessionId) {
@@ -420,6 +468,9 @@ export function sendSessionInfo(ctx, ws, sessionId) {
     defaultModel: activeRegistry.getDefaultModelId(),
     provider: activeProvider,
   })
+  // #5421: background dynamic-discovery refresh (ollama /api/tags); a
+  // changed list is re-pushed to this client when the probe lands.
+  scheduleProviderModelsRefresh(ctx, ws, activeProvider)
   send(ws, {
     type: 'model_changed',
     // #3687: prefer the user's explicit override (`model`) so a later

--- a/packages/server/tests/ollama-session.test.js
+++ b/packages/server/tests/ollama-session.test.js
@@ -104,13 +104,33 @@ describe('OllamaSession', () => {
       }
     })
 
-    it('getModelMetadata answers for seeded models, null otherwise', () => {
+    it('getModelMetadata answers for seeded models with curated labels', () => {
       const qwen = OllamaSession.getModelMetadata('qwen3-coder')
       assert.equal(qwen.id, 'qwen3-coder')
+      assert.equal(qwen.label, 'Qwen3 Coder')
       assert.equal(qwen.contextWindow, null)
-      assert.equal(OllamaSession.getModelMetadata('some-custom-pull'), null)
+    })
+
+    it('getModelMetadata treats any other non-empty id as a valid local tag (#5421)', () => {
+      // Discovered /api/tags entries (and user-typed aliases) get identity
+      // metadata with an explicitly-null contextWindow so the registry
+      // never substitutes a fabricated default window.
+      const custom = OllamaSession.getModelMetadata('llama3.2:7b')
+      assert.deepEqual(custom, { id: 'llama3.2:7b', label: 'llama3.2:7b', fullId: 'llama3.2:7b', contextWindow: null })
+      assert.ok('contextWindow' in custom, 'explicit null key is load-bearing for models.js null-preservation')
       assert.equal(OllamaSession.getModelMetadata(''), null)
       assert.equal(OllamaSession.getModelMetadata(null), null)
+    })
+
+    it('refreshModels delegates to the /api/tags discovery path (#5421)', async () => {
+      assert.equal(typeof OllamaSession.refreshModels, 'function')
+      // Unreachable port + tiny timeout: must resolve null (graceful
+      // failure), never reject — ws-history fires this fire-and-forget.
+      const result = await OllamaSession.refreshModels({
+        env: { CHROXY_OLLAMA_BASE_URL: 'http://127.0.0.1:1' },
+        timeoutMs: 200,
+      })
+      assert.equal(result, null)
     })
   })
 

--- a/packages/server/tests/ollama-tags.test.js
+++ b/packages/server/tests/ollama-tags.test.js
@@ -1,0 +1,378 @@
+import { describe, it, beforeEach, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  buildOllamaTagsUrl,
+  fetchOllamaTags,
+  refreshOllamaModels,
+  resolveOllamaBaseUrl,
+  _resetOllamaTagsStateForTests,
+  OLLAMA_TAGS_CACHE_TTL_MS,
+} from '../src/ollama-tags.js'
+import {
+  registerProviderRegistry,
+  getRegistryForProvider,
+  _resetProviderRegistryCacheForTests,
+} from '../src/models.js'
+import { OllamaSession } from '../src/ollama-session.js'
+
+/**
+ * Tests for dynamic Ollama model discovery via GET /api/tags (#5421).
+ *
+ * Everything is injectable: fetchFn (no network), env (no process.env
+ * mutation for URL resolution), registry / now / ttlMs for the refresh
+ * cache. The registry-integration block uses the REAL per-provider
+ * registry machinery (registerProviderRegistry + getRegistryForProvider)
+ * to pin the end-to-end picker contents, including the explicit-null
+ * contextWindow preservation in models.js.
+ */
+
+// Minimal fetch Response stand-in.
+function okJson(body) {
+  return { ok: true, status: 200, json: async () => body }
+}
+
+function tagsBody(names) {
+  return { models: names.map((name) => ({ name, model: name })) }
+}
+
+describe('buildOllamaTagsUrl', () => {
+  it('appends /api/tags to the Ollama root', () => {
+    assert.equal(buildOllamaTagsUrl('http://localhost:11434'), 'http://localhost:11434/api/tags')
+  })
+
+  it('strips trailing slashes', () => {
+    assert.equal(buildOllamaTagsUrl('http://gpu-box:11434/'), 'http://gpu-box:11434/api/tags')
+    assert.equal(buildOllamaTagsUrl('http://gpu-box:11434///'), 'http://gpu-box:11434/api/tags')
+  })
+
+  it('strips an Anthropic-compat /v1 path suffix — /api/tags lives at the root', () => {
+    assert.equal(buildOllamaTagsUrl('http://localhost:11434/v1'), 'http://localhost:11434/api/tags')
+    assert.equal(buildOllamaTagsUrl('http://localhost:11434/v1/'), 'http://localhost:11434/api/tags')
+  })
+
+  it('does not mangle a path that merely ends in v1-ish text', () => {
+    assert.equal(buildOllamaTagsUrl('https://tunnel.example/ollamav1'), 'https://tunnel.example/ollamav1/api/tags')
+  })
+})
+
+describe('fetchOllamaTags', () => {
+  it('returns installed tag names, normalized and deduplicated', async () => {
+    const tags = await fetchOllamaTags({
+      env: {},
+      fetchFn: async () => okJson(tagsBody(['qwen3-coder:latest', 'llama3.2:7b', 'glm-4.7'])),
+    })
+    assert.deepEqual(tags, ['qwen3-coder', 'llama3.2:7b', 'glm-4.7'])
+  })
+
+  it('dedupes tags that collapse to the same name after :latest stripping', async () => {
+    const tags = await fetchOllamaTags({
+      env: {},
+      fetchFn: async () => okJson(tagsBody(['foo:latest', 'foo'])),
+    })
+    assert.deepEqual(tags, ['foo'])
+  })
+
+  it('falls back to the `model` field and drops malformed entries', async () => {
+    const tags = await fetchOllamaTags({
+      env: {},
+      fetchFn: async () => okJson({
+        models: [
+          { model: 'from-model-field' },
+          { name: '   ' }, // whitespace name, no model fallback
+          null,
+          42,
+          { name: 'good-one' },
+        ],
+      }),
+    })
+    assert.deepEqual(tags, ['from-model-field', 'good-one'])
+  })
+
+  it('returns null when the daemon is down (fetch rejects)', async () => {
+    const tags = await fetchOllamaTags({
+      env: {},
+      fetchFn: async () => { throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }) },
+    })
+    assert.equal(tags, null)
+  })
+
+  it('returns null on a non-2xx response', async () => {
+    const tags = await fetchOllamaTags({
+      env: {},
+      fetchFn: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+    })
+    assert.equal(tags, null)
+  })
+
+  it('returns null on malformed JSON', async () => {
+    const tags = await fetchOllamaTags({
+      env: {},
+      fetchFn: async () => ({ ok: true, status: 200, json: async () => { throw new SyntaxError('Unexpected token < in JSON') } }),
+    })
+    assert.equal(tags, null)
+  })
+
+  it('returns null when the body has no models array', async () => {
+    assert.equal(await fetchOllamaTags({ env: {}, fetchFn: async () => okJson({ models: 'nope' }) }), null)
+    assert.equal(await fetchOllamaTags({ env: {}, fetchFn: async () => okJson({}) }), null)
+    assert.equal(await fetchOllamaTags({ env: {}, fetchFn: async () => okJson(null) }), null)
+  })
+
+  it('returns [] when Ollama is up but nothing is pulled', async () => {
+    assert.deepEqual(await fetchOllamaTags({ env: {}, fetchFn: async () => okJson({ models: [] }) }), [])
+  })
+
+  it('aborts via the timeout signal and resolves null instead of hanging', async () => {
+    const tags = await fetchOllamaTags({
+      env: {},
+      timeoutMs: 25,
+      fetchFn: (url, { signal }) => new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })))
+      }),
+    })
+    assert.equal(tags, null)
+  })
+
+  describe('base-url resolution → probed URL', () => {
+    async function probedUrl(env) {
+      let seen = null
+      await fetchOllamaTags({
+        env,
+        fetchFn: async (url) => { seen = url; return okJson({ models: [] }) },
+      })
+      return seen
+    }
+
+    it('defaults to the standard local bind', async () => {
+      assert.equal(await probedUrl({}), 'http://localhost:11434/api/tags')
+    })
+
+    it('honours CHROXY_OLLAMA_BASE_URL (and tolerates a trailing slash)', async () => {
+      assert.equal(
+        await probedUrl({ CHROXY_OLLAMA_BASE_URL: 'https://tunnel.example/ollama/' }),
+        'https://tunnel.example/ollama/api/tags',
+      )
+    })
+
+    it('CHROXY_OLLAMA_BASE_URL wins over OLLAMA_HOST', async () => {
+      assert.equal(
+        await probedUrl({ CHROXY_OLLAMA_BASE_URL: 'http://a:1', OLLAMA_HOST: 'http://b:2' }),
+        'http://a:1/api/tags',
+      )
+    })
+
+    it('honours scheme-less OLLAMA_HOST (normalized to http://)', async () => {
+      assert.equal(await probedUrl({ OLLAMA_HOST: '192.168.1.20:11434' }), 'http://192.168.1.20:11434/api/tags')
+    })
+
+    it('strips a /v1 suffix off an override so /api/tags hits the root', async () => {
+      assert.equal(
+        await probedUrl({ CHROXY_OLLAMA_BASE_URL: 'http://gpu-box:11434/v1' }),
+        'http://gpu-box:11434/api/tags',
+      )
+    })
+
+    it('matches resolveOllamaBaseUrl — one source of truth for routing', async () => {
+      const env = { OLLAMA_HOST: 'gpu-box:11434' }
+      assert.equal(await probedUrl(env), `${resolveOllamaBaseUrl(env)}/api/tags`)
+    })
+  })
+})
+
+describe('refreshOllamaModels (TTL cache + change detection)', () => {
+  // Injected fake registry: records updateModels payloads, returns them.
+  function fakeRegistry() {
+    const calls = []
+    let models = [{ id: 'seed', label: 'Seed', fullId: 'seed', contextWindow: null }]
+    return {
+      calls,
+      updateModels(sdkModels) {
+        calls.push(sdkModels)
+        models = sdkModels.map((m) => ({ id: m.value, label: m.value, fullId: m.value, contextWindow: null }))
+        return models
+      },
+      getModels() {
+        return models
+      },
+    }
+  }
+
+  let clock
+  const now = () => clock
+
+  beforeEach(() => {
+    _resetOllamaTagsStateForTests()
+    clock = 1_000_000
+  })
+
+  it('feeds discovered tags into the registry and resolves the refreshed list', async () => {
+    const registry = fakeRegistry()
+    const models = await refreshOllamaModels({
+      env: {},
+      registry,
+      now,
+      fetchFn: async () => okJson(tagsBody(['qwen3-coder:latest', 'my-custom:7b'])),
+    })
+    assert.deepEqual(registry.calls, [[{ value: 'qwen3-coder' }, { value: 'my-custom:7b' }]])
+    assert.deepEqual(models.map((m) => m.id), ['qwen3-coder', 'my-custom:7b'])
+  })
+
+  it('serves from the TTL cache — at most one probe per window, success or failure', async () => {
+    const registry = fakeRegistry()
+    let fetchCount = 0
+    const opts = {
+      env: {},
+      registry,
+      now,
+      fetchFn: async () => { fetchCount++; return okJson(tagsBody(['a'])) },
+    }
+    assert.notEqual(await refreshOllamaModels(opts), null)
+    clock += 1_000
+    assert.equal(await refreshOllamaModels(opts), null, 'within TTL → cached, nothing new to broadcast')
+    assert.equal(fetchCount, 1)
+    clock += OLLAMA_TAGS_CACHE_TTL_MS
+    await refreshOllamaModels(opts)
+    assert.equal(fetchCount, 2, 'TTL elapsed → probe again')
+  })
+
+  it('caches failures too — Ollama down does not retry-storm', async () => {
+    let fetchCount = 0
+    const opts = {
+      env: {},
+      registry: fakeRegistry(),
+      now,
+      fetchFn: async () => { fetchCount++; throw new Error('ECONNREFUSED') },
+    }
+    assert.equal(await refreshOllamaModels(opts), null)
+    clock += 1_000
+    assert.equal(await refreshOllamaModels(opts), null)
+    assert.equal(fetchCount, 1, 'failure is cached for the TTL window')
+  })
+
+  it('resolves null when a re-probe finds the SAME tag set (no rebroadcast)', async () => {
+    const registry = fakeRegistry()
+    const opts = { env: {}, registry, now, fetchFn: async () => okJson(tagsBody(['a', 'b'])) }
+    assert.notEqual(await refreshOllamaModels(opts), null)
+    clock += OLLAMA_TAGS_CACHE_TTL_MS + 1
+    assert.equal(await refreshOllamaModels(opts), null, 'same set → picker already accurate')
+    assert.equal(registry.calls.length, 1, 'registry not rebuilt for an identical set')
+  })
+
+  it('resolves the new list when the tag set CHANGES across windows', async () => {
+    const registry = fakeRegistry()
+    let names = ['a']
+    const opts = { env: {}, registry, now, fetchFn: async () => okJson(tagsBody(names)) }
+    assert.notEqual(await refreshOllamaModels(opts), null)
+    names = ['a', 'freshly-pulled']
+    clock += OLLAMA_TAGS_CACHE_TTL_MS + 1
+    const models = await refreshOllamaModels(opts)
+    assert.deepEqual(models.map((m) => m.id), ['a', 'freshly-pulled'])
+  })
+
+  it('keeps the current picker on an empty install (no models pulled)', async () => {
+    const registry = fakeRegistry()
+    const models = await refreshOllamaModels({
+      env: {},
+      registry,
+      now,
+      fetchFn: async () => okJson({ models: [] }),
+    })
+    assert.equal(models, null)
+    assert.equal(registry.calls.length, 0, 'registry untouched — fallback list stays')
+  })
+
+  it('concurrent callers share one in-flight probe', async () => {
+    let fetchCount = 0
+    let release
+    const gate = new Promise((resolve) => { release = resolve })
+    const opts = {
+      env: {},
+      registry: fakeRegistry(),
+      now,
+      fetchFn: async () => { fetchCount++; await gate; return okJson(tagsBody(['a'])) },
+    }
+    const p1 = refreshOllamaModels(opts)
+    const p2 = refreshOllamaModels(opts)
+    release()
+    const [r1, r2] = await Promise.all([p1, p2])
+    assert.equal(fetchCount, 1)
+    assert.deepEqual(r1, r2)
+  })
+})
+
+describe('registry integration — discovery feeds the real ollama registry', () => {
+  // Use the production wiring: registerProviderRegistry('ollama', OllamaSession)
+  // exactly as providers.js does, then drive refreshOllamaModels at the
+  // default registry resolution (no injected registry).
+  let savedConfigDir
+
+  before(() => {
+    // Point the per-provider cache path at a temp dir so loadCache() never
+    // reads (and the registry never considers writing) the real ~/.chroxy.
+    savedConfigDir = process.env.CHROXY_CONFIG_DIR
+    process.env.CHROXY_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'chroxy-ollama-tags-'))
+    registerProviderRegistry('ollama', OllamaSession)
+  })
+
+  after(() => {
+    if (savedConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+    else process.env.CHROXY_CONFIG_DIR = savedConfigDir
+    _resetProviderRegistryCacheForTests('ollama')
+  })
+
+  beforeEach(() => {
+    _resetOllamaTagsStateForTests()
+    _resetProviderRegistryCacheForTests('ollama')
+  })
+
+  it('cold registry serves the static fallback seed (Ollama down at boot)', async () => {
+    await refreshOllamaModels({
+      env: {},
+      fetchFn: async () => { throw new Error('ECONNREFUSED') },
+    })
+    const models = getRegistryForProvider('ollama').getModels()
+    assert.deepEqual(models.map((m) => m.id), ['qwen3-coder', 'glm-4.7', 'minimax-m2.1'])
+  })
+
+  it('discovered tags land in the picker with curated labels, merged fallbacks, and NO fabricated contextWindow', async () => {
+    const models = await refreshOllamaModels({
+      env: {},
+      fetchFn: async () => okJson(tagsBody(['qwen3-coder:latest', 'llama3.2:7b'])),
+    })
+    assert.ok(Array.isArray(models))
+    const byId = new Map(models.map((m) => [m.id, m]))
+
+    // Discovered + recognized by the curated seed → curated label kept.
+    assert.equal(byId.get('qwen3-coder').label, 'Qwen3 Coder')
+    assert.equal(byId.get('qwen3-coder').contextWindow, null)
+
+    // Discovered, unknown to the seed → identity metadata, window stays
+    // null (pins the models.js explicit-null preservation — a regression
+    // here would show a fabricated 200k chip on every local model).
+    assert.equal(byId.get('llama3.2:7b').label, 'llama3.2:7b')
+    assert.equal(byId.get('llama3.2:7b').fullId, 'llama3.2:7b')
+    assert.equal(byId.get('llama3.2:7b').contextWindow, null)
+
+    // Static recommendations the SDK list didn't cover are merged in so the
+    // picker keeps suggesting pullable models.
+    assert.ok(byId.has('glm-4.7'))
+    assert.ok(byId.has('minimax-m2.1'))
+
+    // And the registry the WS layer reads agrees with what was returned.
+    assert.deepEqual(getRegistryForProvider('ollama').getModels(), models)
+  })
+
+  it('validation stays unrestricted regardless of discovery (advisory, not restrictive)', async () => {
+    await refreshOllamaModels({
+      env: {},
+      fetchFn: async () => okJson(tagsBody(['only-this-one'])),
+    })
+    // The allowlist tri-state in settings-handlers keys off getAllowedModels()
+    // returning a non-array — discovery must never change that, or a model
+    // pulled mid-session would be rejected by set_model.
+    assert.equal(OllamaSession.getAllowedModels(), null)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #5421.

PR #5418's `ollama` provider seeded the dashboard picker with a static 3-model fallback list. This PR makes the picker reflect what `ollama list` actually shows by probing `GET <root>/api/tags` and feeding the result into the per-provider models registry — while keeping model **validation** fully unrestricted (`getAllowedModels()` stays null: a model pulled mid-session, or an alias the tag list doesn't spell out, is still accepted by `set_model`). Discovery is advisory, never restrictive.

## How discovery reaches clients

- **New `src/ollama-tags.js`** — owns the probe: bounded 800ms timeout, tag normalization (`:latest` stripped, deduped; other tags like `:7b` kept), 30s TTL cache that covers **failures too** (Ollama down costs one debug log line per window — no error spam, no retry storm), and a single shared in-flight request for concurrent callers. `refreshOllamaModels()` resolves with the registry's refreshed list only when the picker contents actually changed, else `null`.
- **Base-URL resolution moved** into `ollama-tags.js` (re-exported from `ollama-session.js` for compatibility) so the tags probe and the Anthropic-SDK client can never disagree about where Ollama lives. `/api/tags` is served at the Ollama **root**: trailing slashes and an Anthropic-compat `/v1` path suffix on `CHROXY_OLLAMA_BASE_URL` / `OLLAMA_HOST` overrides are stripped before appending.
- **`ws-history.js`** — new generic `scheduleProviderModelsRefresh()` fires (fire-and-forget) right after each `available_models` send (post-auth handshake + session switch) for providers exposing a static `refreshModels()`. On a changed list it re-pushes `available_models` to that client.
- **`OllamaSession.start()`** — kicks off discovery when a session starts and emits `models_updated` on change, which rides the existing session-manager → ws-forwarding pipeline into a provider-tagged `available_models` broadcast to all clients (same path as the Claude SDK's `supportedModels()` push). Newly pulled models appear without a daemon restart.

## Never-fabricate contextWindow

`OllamaSession.getModelMetadata()` now answers for **any** non-empty id with identity metadata and an explicit `contextWindow: null`, and the per-provider registry hook in `models.js` preserves an explicit null instead of substituting the 200k `DEFAULT_CONTEXT_WINDOW` — so discovered local models never get a fabricated context chip (#5418's rule). Codex/Gemini metadata (numeric windows) is unaffected. `/api/show` enrichment stays a possible follow-up, per the issue ("populate when cheap, stay null otherwise").

No protocol changes: `available_models` already carries `models: z.array(z.unknown())` and the provider field.

## Acceptance criteria

- [x] Picker lists locally pulled models when Ollama is up (discovered tags + the curated recommendations merged in)
- [x] Boot with Ollama down → fallback list, no crash, no startup delay (probe is fire-and-forget with a bounded 800ms timeout; failures cached for 30s)
- [x] Refresh path picks up newly pulled models without daemon restart (session start broadcast + per-client refresh on handshake/session switch)

## Tests

- New `tests/ollama-tags.test.js` (37 tests): URL building (trailing slash, `/v1` suffix), tag fetch (success, normalization/dedupe, `model`-field fallback, daemon down, non-2xx, malformed JSON, bad shape, empty install, abort-on-timeout), env-override → probed-URL matrix (`CHROXY_OLLAMA_BASE_URL` / `OLLAMA_HOST`, scheme-less host), TTL cache (success + failure caching, change detection, in-flight dedupe), and a real-registry integration block pinning curated labels, fallback merge, the explicit-null contextWindow, and the unrestricted-validation invariant.
- `tests/ollama-session.test.js` updated for the catch-all metadata + `refreshModels` graceful-failure contract.
- Suites run: ollama-tags, ollama-session, models, models-factory, ws-forwarding, byok-session — 350/350 pass. (`models-per-provider`, `providers`, `settings-handlers-permission-rules`, `ws-history` fail identically on unmodified main in this environment — missing `@anthropic-ai/claude-agent-sdk` install — pre-existing, unrelated.)
- eslint clean; `lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`, `lint-tests-state-file-path.sh` all green.