### PR TITLE
fix(server): classify claude-tui --resume failures from the PTY tail for retry-FRESH eligibility

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1389,8 +1389,8 @@ export class ClaudeTuiSession extends BaseSession {
               'as unknown on this machine — it may have been wiped from ~/.claude/projects/). Retrying once with ' +
               'a fresh conversation; the model will not see the earlier transcript.'
             : 'Previous Claude conversation could not be resumed (claude reports the conversation id as unknown — ' +
-              'it was likely never persisted before the PTY died). Retrying once with a fresh conversation; the ' +
-              'model will not see any earlier transcript.',
+              'it may never have been persisted before the PTY died, or it was removed from this machine). ' +
+              'Retrying once with a fresh conversation; the model will not see any earlier transcript.',
           attemptedResumeId: abandonedId,
         })
         // Fall through to the scheduling below — this IS the extra attempt.

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1923,17 +1923,38 @@ export class ClaudeTuiSession extends BaseSession {
    * land in `_outputTail` when claude rejects a `--resume <id>` and exits
    * during warmup. `_outputTail` is reset at the top of every _spawnPty, so a
    * match always describes the MOST RECENT death, never a stale prior
-   * attempt. Whitespace is collapsed first (mirrors _scanOutputForAuthFailure
-   * — the TUI wraps/box-pads, so a pattern can straddle a rendered line
-   * break). Consulted by _scheduleRespawn at the respawn cap to decide
-   * retry-FRESH eligibility. The tail is only SCANNED here, never logged —
-   * every diagnostic surface keeps routing through the redaction helpers
-   * (_outputTailDiagnostic / _outputTailHexDump, #5322/#5358).
+   * attempt.
+   *
+   * Matching is PER LINE plus adjacent-line pairs — NOT one collapsed blob.
+   * CliSession's classifier tests each stderr line separately, which bounds
+   * the `.*` in the #4950 co-occurrence patterns (e.g.
+   * `/(fail|error|…).*resum(e|ing).*(session|conversation|\bid\b)/i`) to a
+   * single line. Collapsing the whole 4KB tail into one string would let
+   * those patterns match "error" + "resume" + "session" scattered across
+   * UNRELATED lines — and a `--resume` warmup re-renders the restored
+   * transcript into the tail, so ordinary conversation content (the exact
+   * large-but-present-conversation crash this gate exists to protect) could
+   * false-positive and abandon a real conversation id. Joining each adjacent
+   * line pair (whitespace-collapsed, mirroring _scanOutputForAuthFailure's
+   * normalization) still catches a rejection the TUI wrapped/box-padded
+   * across one rendered line break, while keeping the match window ≤ two
+   * lines instead of the whole tail. Consulted by _scheduleRespawn at the
+   * respawn cap to decide retry-FRESH eligibility. The tail is only SCANNED
+   * here, never logged — every diagnostic surface keeps routing through the
+   * redaction helpers (_outputTailDiagnostic / _outputTailHexDump,
+   * #5322/#5358).
    */
   _scanOutputForUnknownResume() {
     const tail = this._outputTail || ''
     if (!tail) return false
-    return stderrIndicatesUnknownResume([tail.replace(/\s+/g, ' ')])
+    const lines = tail
+      .split(/[\r\n]+/)
+      .map((line) => line.replace(/\s+/g, ' ').trim())
+      .filter(Boolean)
+    if (lines.length === 0) return false
+    const candidates = lines.slice()
+    for (let i = 0; i + 1 < lines.length; i++) candidates.push(`${lines[i]} ${lines[i + 1]}`)
+    return stderrIndicatesUnknownResume(candidates)
   }
 
   async sendMessage(prompt, attachments, _options = {}) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -5,6 +5,10 @@ import { performance } from 'node:perf_hooks'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+// #5417 — the TUI shares CliSession's pinned "unknown resume id" patterns
+// (RESUME_UNKNOWN_STDERR_PATTERNS, #4929/#4950) via this matcher: the PTY
+// merges stdout+stderr, so claude's resume rejection lands in _outputTail.
+import { stderrIndicatesUnknownResume } from './cli-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
@@ -509,10 +513,12 @@ export class ClaudeTuiSession extends BaseSession {
     // #5348 — remember whether this session was SEEDED from a persisted resume
     // id. `_resumedFromPersisted` flips to true on every respawn (the respawn
     // must `--resume` the live conversation), so later code can't use it to
-    // tell a restored session from an originally-fresh one. Only an
-    // originally-fresh session is eligible for the drop-and-retry-FRESH
-    // fallback in _scheduleRespawn — falling back on a restored session would
-    // silently discard a real prior conversation.
+    // tell a restored session from an originally-fresh one. #5417: no longer
+    // the retry-FRESH eligibility gate (the PTY-tail classification in
+    // _scheduleRespawn is — claude itself must report the conversation id as
+    // unknown); kept to word the resume_unknown message honestly (restored =
+    // "the persisted conversation is gone from this machine" vs fresh = "it
+    // was likely never persisted before the PTY died").
     this._seededFromPersisted = this._resumedFromPersisted
     // #5348 — one-shot latch for the retry-FRESH fallback (mirrors
     // cli-session.js's `_didFallbackFromUnknownResume`). Re-armed by a respawn
@@ -1303,8 +1309,9 @@ export class ClaudeTuiSession extends BaseSession {
   /**
    * #5315 (WP-2.1) — schedule a bounded PTY respawn with exponential backoff,
    * mirroring CliSession._scheduleRespawn (cli-session.js:556). Backoff is
-   * [1s,2s,4s,8s,15s] and caps at 5 attempts (an originally-fresh session gets
-   * ONE extra drop-and-retry-FRESH attempt at the cap, #5348); on exhaustion it
+   * [1s,2s,4s,8s,15s] and caps at 5 attempts (a session whose dying PTY tail
+   * confirms the resume id is unknown gets ONE extra drop-and-retry-FRESH
+   * attempt at the cap, #5348/#5417); on exhaustion it
    * emits a categorized `error` AND a `respawn_exhausted` event so
    * SessionManager drops the session from its list (no input-rejecting zombie
    * tab — the audit AC).
@@ -1335,15 +1342,28 @@ export class ClaudeTuiSession extends BaseSession {
       // `--session-id`) that died before claude persisted its conversation
       // makes every `--resume` respawn doomed: claude can't find the
       // conversation and exits during warmup. Reaching this cap means 5
-      // consecutive respawns never survived warmup — for an originally-fresh
-      // session, spend ONE extra attempt on a brand-new conversation id before
-      // giving up. Restored sessions are excluded: their conversation existed
-      // before this process, so dropping the id here would silently discard
-      // real context (the TUI-AUDIT-001 amnesia class) — for them, exhaustion
-      // is the honest outcome. Mirrors cli-session.js's resume_unknown
-      // fallback, just triggered by exhaustion instead of stderr classification
-      // (the TUI renders no machine-readable resume-failure diagnostic).
-      if (!this._seededFromPersisted && !this._didFallbackFromUnknownResume) {
+      // consecutive respawns never survived warmup — spend ONE extra attempt
+      // on a brand-new conversation id before giving up.
+      //
+      // #5417 — eligibility is the PTY-tail CLASSIFICATION, not the seeding
+      // origin. The cap alone proves 5 respawns died during warmup, NOT that
+      // the conversation is missing: a crash loop with an unrelated cause
+      // (OOM, broken install, claude crashing while loading a large-but-
+      // present conversation file) used to trigger the #5348 blunt fallback
+      // on originally-fresh sessions and abandon real context a fresh spawn
+      // may not even fix. Requiring claude's own resume rejection in the
+      // dying output ("No conversation found with session ID …" — the same
+      // pinned patterns CliSession's #4929 stderr classifier uses; the PTY
+      // merges stdout+stderr so it lands in _outputTail, which _spawnPty
+      // resets per attempt so the match describes the LAST death) confines
+      // the fallback to the failure it was designed for AND safely extends
+      // it to RESTORED sessions (CliSession parity): when claude confirms
+      // the persisted conversation is gone (wiped ~/.claude/projects/, state
+      // file from another machine), a loud fresh retry beats burning to a
+      // destroyed session. No match → exhaustion is the honest outcome for
+      // both seeding origins (the TUI-AUDIT-001 amnesia class stays closed:
+      // an UNCONFIRMED cause never abandons a conversation id).
+      if (this._scanOutputForUnknownResume() && !this._didFallbackFromUnknownResume) {
         this._didFallbackFromUnknownResume = true
         this._freshRetryPending = true
         const abandonedId = this._sessionId
@@ -1357,17 +1377,20 @@ export class ClaudeTuiSession extends BaseSession {
         // re-emitted `ready` (mirrors cli-session.js rebinding on system.init).
         this._log = loggerForSession('claude-tui-session', this._sessionId)
         ;(this._log || log).warn(
-          `all --resume respawns died during warmup (attemptedResumeId=${abandonedId}) — ` +
-          'retrying once with a fresh --session-id (the original fresh conversation was likely never persisted)',
+          `all --resume respawns died during warmup and the PTY tail confirms claude does not know the ` +
+          `conversation id (attemptedResumeId=${abandonedId}) — retrying once with a fresh --session-id`,
         )
         // Loud one-shot signal (same code as cli-session.js) so the dashboard
         // can render "starting fresh" instead of a generic crash toast.
         this.emit('error', {
           code: 'resume_unknown',
-          message:
-            'Previous Claude conversation could not be resumed after repeated respawn failures (it was likely ' +
-            'never persisted before the PTY died). Retrying once with a fresh conversation; the model will not ' +
-            'see any earlier transcript.',
+          message: this._seededFromPersisted
+            ? 'Previous Claude conversation could not be resumed (claude reports the persisted conversation id ' +
+              'as unknown on this machine — it may have been wiped from ~/.claude/projects/). Retrying once with ' +
+              'a fresh conversation; the model will not see the earlier transcript.'
+            : 'Previous Claude conversation could not be resumed (claude reports the conversation id as unknown — ' +
+              'it was likely never persisted before the PTY died). Retrying once with a fresh conversation; the ' +
+              'model will not see any earlier transcript.',
           attemptedResumeId: abandonedId,
         })
         // Fall through to the scheduling below — this IS the extra attempt.
@@ -1570,10 +1593,11 @@ export class ClaudeTuiSession extends BaseSession {
     // is rejected by claude. Falls back to the fresh path whenever the session
     // wasn't seeded from a persisted id. Resume-failure handling (claude can't
     // find the conversation, e.g. cleared ~/.claude history) surfaces via the
-    // warmup `_ptyExited` error path → bounded respawn (#5315) → and, for an
-    // originally-fresh session whose 5 resume-respawns all died during warmup,
-    // ONE drop-and-retry-FRESH attempt with a new uuid (#5348, see
-    // _scheduleRespawn) before exhaustion destroys the session.
+    // warmup `_ptyExited` error path → bounded respawn (#5315) → and, when 5
+    // resume-respawns all died during warmup AND the dying PTY tail confirms
+    // claude does not know the conversation id, ONE drop-and-retry-FRESH
+    // attempt with a new uuid (#5348/#5417, see _scheduleRespawn) before
+    // exhaustion destroys the session.
     const idArgs = this._resumedFromPersisted
       ? ['--resume', this._sessionId]
       : ['--session-id', this._sessionId]
@@ -1889,6 +1913,27 @@ export class ClaudeTuiSession extends BaseSession {
     // spaces) so a line-wrapped "Please run\n  /login" still matches.
     const normalized = tail.replace(/\s+/g, ' ')
     return AUTH_FAILURE_PATTERNS.some((re) => re.test(normalized))
+  }
+
+  /**
+   * #5417 — classify the ANSI-stripped PTY tail as a "--resume id unknown"
+   * failure. The PTY merges stdout+stderr, so the same diagnostics
+   * CliSession's stderr classifier pins ("No conversation found with session
+   * ID …" — RESUME_UNKNOWN_STDERR_PATTERNS in cli-session.js, #4929/#4950)
+   * land in `_outputTail` when claude rejects a `--resume <id>` and exits
+   * during warmup. `_outputTail` is reset at the top of every _spawnPty, so a
+   * match always describes the MOST RECENT death, never a stale prior
+   * attempt. Whitespace is collapsed first (mirrors _scanOutputForAuthFailure
+   * — the TUI wraps/box-pads, so a pattern can straddle a rendered line
+   * break). Consulted by _scheduleRespawn at the respawn cap to decide
+   * retry-FRESH eligibility. The tail is only SCANNED here, never logged —
+   * every diagnostic surface keeps routing through the redaction helpers
+   * (_outputTailDiagnostic / _outputTailHexDump, #5322/#5358).
+   */
+  _scanOutputForUnknownResume() {
+    const tail = this._outputTail || ''
+    if (!tail) return false
+    return stderrIndicatesUnknownResume([tail.replace(/\s+/g, ' ')])
   }
 
   async sendMessage(prompt, attachments, _options = {}) {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -706,6 +706,19 @@ describe('ClaudeTuiSession', () => {
       return s
     }
 
+    // #5417 — mimic the real _spawnPty tail lifecycle for a dying spawn: the
+    // real method resets both output tails at the top of every spawn, then the
+    // child's dying output (the PTY merges stdout+stderr, so claude's
+    // "No conversation found with session ID …" resume rejection lands here)
+    // accumulates via onData before _onPtyGone fires. Tests stub _spawnPty, so
+    // the stub has to reproduce that reset+append ordering itself.
+    function dieWithTail(self, text) {
+      self._outputTail = ''
+      self._outputTailRaw = Buffer.alloc(0)
+      if (text) self._appendToOutputTail(text)
+      self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+    }
+
     it('an unexpected PTY death schedules a respawn that re-invokes _spawnPty', async () => {
       let spawnCalls = 0
       session = makeSession(() => { spawnCalls++ })
@@ -772,16 +785,18 @@ describe('ClaudeTuiSession', () => {
       assert.equal(spawnCalls, 2, 'second death triggers a second respawn')
     })
 
-    it('after 5 attempts a RESTORED session emits a fatal error + respawn_exhausted and stops (no infinite loop)', async () => {
+    it('after 5 attempts a RESTORED session whose deaths carry NO resume-failure tail exhausts and stops (no infinite loop)', async () => {
       let spawnCalls = 0
       // Every respawn dies again during warmup → drives toward the cap. In
       // production the wired onExit/close handlers call _onPtyGone when the PTY
       // dies; the stub mimics that so the same scheduling path runs.
-      // #5348 — a session seeded from a persisted resume id must NOT fall back
-      // to a fresh conversation (that would silently discard real prior
-      // context): exhaustion after exactly 5 attempts is the honest outcome.
-      // Seed through the REAL ctor path (resumeSessionId opt) so the
-      // `_seededFromPersisted` wiring is what's under test, not a poked flag.
+      // #5348/#5417 — the deaths here leave NO resume-failure diagnostic in the
+      // PTY tail, so claude never confirmed the conversation id is unknown. A
+      // restored session must NOT fall back to a fresh conversation on an
+      // unconfirmed cause (the conversation may still exist — e.g. claude
+      // crashing while loading it): exhaustion after exactly 5 attempts is the
+      // honest outcome. Seed through the REAL ctor path (resumeSessionId opt)
+      // so the restore wiring is what's under test, not a poked flag.
       session = makeSession((self) => {
         spawnCalls++
         self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
@@ -818,11 +833,17 @@ describe('ClaudeTuiSession', () => {
     // (claude can't find it → exits during warmup). At the 5-attempt cap the
     // session gets ONE extra attempt with a brand-new --session-id before
     // giving up, instead of burning to exhaustion on a futile resume.
-    it('an originally-fresh session gets ONE retry-FRESH attempt at the cap (#5348)', async () => {
+    // #5417 — the fallback now additionally requires the dying PTY tail to
+    // CONFIRM the resume id is unknown (claude's own "No conversation found"
+    // rejection), so the doomed resumes here die with that diagnostic in the
+    // tail, exactly as the real claude TUI renders it before exiting.
+    it('an originally-fresh session gets ONE retry-FRESH attempt at the cap when the tail confirms resume_unknown (#5348/#5417)', async () => {
       const spawns = []
       session = makeSession((self) => {
         spawns.push({ resumed: self._resumedFromPersisted, id: self._sessionId })
-        self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+        dieWithTail(self, self._resumedFromPersisted
+          ? `No conversation found with session ID: ${self._sessionId}`
+          : null)
       })
       const errors = []
       const exhausted = []
@@ -857,11 +878,12 @@ describe('ClaudeTuiSession', () => {
 
     it('a retry-FRESH attempt that survives warmup re-emits ready with the new uuid and re-arms the latch (#5348)', async () => {
       let spawnCalls = 0
-      // First 5 spawns die during warmup (doomed resumes); the 6th — the fresh
-      // fallback — survives.
+      // First 5 spawns die during warmup (doomed resumes, each leaving claude's
+      // resume rejection in the tail, #5417); the 6th — the fresh fallback —
+      // survives.
       session = makeSession((self) => {
         spawnCalls++
-        if (spawnCalls <= 5) self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+        if (spawnCalls <= 5) dieWithTail(self, `No conversation found with session ID: ${self._sessionId}`)
       })
       const readies = []
       session.on('ready', (d) => readies.push(d))
@@ -879,6 +901,103 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._respawnCount, 0, 'retry budget restored after the surviving warmup')
       assert.equal(session._didFallbackFromUnknownResume, false, 'one-shot latch re-armed on success (a FUTURE doomed-resume window may fall back again)')
       assert.equal(session._processReady, true)
+    })
+
+    // #5417 — the blunt "5 warmup deaths" trigger alone is NOT enough: a fresh
+    // session crash-looping for an unrelated cause (OOM, broken install,
+    // corrupted-but-present conversation file) never had its conversation
+    // confirmed missing, so abandoning the id would discard real context a
+    // fresh spawn may not even fix. No tail match → honest exhaustion.
+    it('an originally-fresh session whose deaths carry NO resume-failure tail exhausts WITHOUT the retry-FRESH fallback (#5417)', async () => {
+      let spawnCalls = 0
+      session = makeSession((self) => {
+        spawnCalls++
+        // Unrelated crash diagnostic — must not match the resume patterns.
+        dieWithTail(self, 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory')
+      })
+      const errors = []
+      const exhausted = []
+      session.on('error', (e) => errors.push(e))
+      session.on('respawn_exhausted', (d) => exhausted.push(d))
+
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      for (const d of [1000, 2000, 4000, 8000, 15000]) {
+        mock.timers.tick(d)
+        await new Promise((r) => setImmediate(r))
+      }
+      mock.timers.tick(15000)
+      await new Promise((r) => setImmediate(r))
+
+      assert.equal(spawnCalls, 5, 'exactly 5 respawn attempts — no extra fresh attempt without a confirming tail')
+      assert.equal(errors.some((e) => e.code === 'resume_unknown'), false, 'no resume_unknown fallback on an unconfirmed cause')
+      assert.ok(errors.some((e) => e.code === 'pty_respawn_exhausted'), 'plain exhaustion code (not resume_unknown_exhausted)')
+      assert.equal(exhausted.length, 1)
+      assert.equal(exhausted[0].reason, 'pty_respawn_exhausted')
+      assert.equal(session._sessionId, 'conv-uuid-1234', 'the conversation id is never abandoned without confirmation')
+      assert.equal(session._respawnScheduled, false, 'no further respawn after exhaustion')
+    })
+
+    // #5417 — CliSession parity for RESTORED sessions: when claude itself
+    // reports the persisted conversation id as unknown (wiped
+    // ~/.claude/projects/, state file copied from another machine), burning 5
+    // doomed resumes and destroying the session helps nobody. With the tail
+    // CONFIRMING the conversation is gone, the restored session now gets the
+    // same loud one-shot retry-FRESH fallback an originally-fresh session gets.
+    it('a RESTORED session falls back loudly when the tail confirms the conversation id is unknown (#5417)', async () => {
+      const spawns = []
+      session = makeSession((self) => {
+        spawns.push({ resumed: self._resumedFromPersisted, id: self._sessionId })
+        dieWithTail(self, self._resumedFromPersisted
+          ? `No conversation found with session ID: ${self._sessionId}`
+          : null)
+      }, { resumeSessionId: 'restored-uuid-9999' })
+      assert.equal(session._seededFromPersisted, true, 'ctor seeds _seededFromPersisted from resumeSessionId')
+      const errors = []
+      const exhausted = []
+      session.on('error', (e) => errors.push(e))
+      session.on('respawn_exhausted', (d) => exhausted.push(d))
+
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      // 5 doomed --resume attempts, then the fresh fallback (also 15s backoff).
+      for (const d of [1000, 2000, 4000, 8000, 15000, 15000]) {
+        mock.timers.tick(d)
+        await new Promise((r) => setImmediate(r))
+      }
+      mock.timers.tick(15000)
+      await new Promise((r) => setImmediate(r))
+
+      assert.equal(spawns.length, 6, '5 resume attempts + exactly one fresh fallback attempt')
+      assert.ok(spawns.slice(0, 5).every((s) => s.resumed && s.id === 'restored-uuid-9999'), 'first 5 attempts --resume the restored conversation')
+      assert.equal(spawns[5].resumed, false, 'the fallback attempt spawns FRESH (--session-id, not --resume)')
+      assert.notEqual(spawns[5].id, 'restored-uuid-9999', 'the fallback attempt mints a brand-new conversation uuid')
+      const resumeUnknown = errors.filter((e) => e.code === 'resume_unknown')
+      assert.equal(resumeUnknown.length, 1, 'one loud resume_unknown error so the dashboard can render "starting fresh"')
+      assert.equal(resumeUnknown[0].attemptedResumeId, 'restored-uuid-9999', 'the error carries the abandoned conversation id')
+      assert.equal(exhausted.length, 1, 'when the fresh attempt also dies, the session exhausts (one-shot latch, no loop)')
+      assert.equal(exhausted[0].reason, 'resume_unknown_exhausted')
+      const terminal = errors.find((e) => e.code === 'resume_unknown_exhausted')
+      assert.ok(terminal, 'terminal error carries the resume_unknown_exhausted code')
+      assert.equal(terminal.attemptedResumeId, 'restored-uuid-9999')
+      assert.equal(session._respawnScheduled, false, 'no further respawn after exhaustion')
+    })
+
+    // #5417 — the classifier itself: shares CliSession's pinned
+    // RESUME_UNKNOWN_STDERR_PATTERNS, matched against the ANSI-stripped tail
+    // with whitespace collapsed (the TUI line-wraps and box-pads its output,
+    // so a pattern can straddle a rendered line break).
+    describe('_scanOutputForUnknownResume (#5417)', () => {
+      it('matches claude\'s resume rejection through ANSI codes and line wrapping', () => {
+        session = makeSession()
+        session._appendToOutputTail('\x1b[1m\x1b[31mNo conversation\r\n    found with session ID: abc-123\x1b[0m\r\n')
+        assert.equal(session._scanOutputForUnknownResume(), true)
+      })
+
+      it('does not match unrelated crash output or an empty tail', () => {
+        session = makeSession()
+        assert.equal(session._scanOutputForUnknownResume(), false, 'empty tail never matches')
+        session._appendToOutputTail('Segmentation fault (core dumped)\r\nnode exited with code 139\r\n')
+        assert.equal(session._scanOutputForUnknownResume(), false, 'unrelated crash output never matches')
+      })
     })
 
     it('a flapping session (warmup keeps resetting _respawnCount) gives up via the rolling rate cap (#5349)', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -982,9 +982,10 @@ describe('ClaudeTuiSession', () => {
     })
 
     // #5417 — the classifier itself: shares CliSession's pinned
-    // RESUME_UNKNOWN_STDERR_PATTERNS, matched against the ANSI-stripped tail
-    // with whitespace collapsed (the TUI line-wraps and box-pads its output,
-    // so a pattern can straddle a rendered line break).
+    // RESUME_UNKNOWN_STDERR_PATTERNS, matched per ANSI-stripped tail line
+    // plus adjacent-line pairs (the TUI line-wraps and box-pads its output,
+    // so a pattern can straddle ONE rendered line break — but the `.*` in the
+    // #4950 co-occurrence patterns must never span unrelated lines).
     describe('_scanOutputForUnknownResume (#5417)', () => {
       it('matches claude\'s resume rejection through ANSI codes and line wrapping', () => {
         session = makeSession()
@@ -997,6 +998,24 @@ describe('ClaudeTuiSession', () => {
         assert.equal(session._scanOutputForUnknownResume(), false, 'empty tail never matches')
         session._appendToOutputTail('Segmentation fault (core dumped)\r\nnode exited with code 139\r\n')
         assert.equal(session._scanOutputForUnknownResume(), false, 'unrelated crash output never matches')
+      })
+
+      // The #4950 co-occurrence patterns carry `.*`, which CliSession bounds
+      // by testing each stderr LINE separately. The TUI tail must keep that
+      // boundedness: a `--resume` warmup re-renders the restored transcript
+      // into the tail, so "error" / "resume" / "session" scattered across
+      // UNRELATED conversation lines must never co-occur into a match (a
+      // false positive here would abandon a real conversation id — the exact
+      // amnesia this gate exists to prevent).
+      it('does not match pattern words scattered across distant transcript lines', () => {
+        session = makeSession()
+        session._appendToOutputTail(
+          '> the respawn loop hit an error during warmup yesterday\r\n' +
+          'I dug through the logs for details\r\n' +
+          'claude will resume automatically after the backoff\r\n' +
+          'check the session state file under ~/.chroxy\r\n',
+        )
+        assert.equal(session._scanOutputForUnknownResume(), false, 'cross-line co-occurrence never matches')
       })
     })
 


### PR DESCRIPTION
## Summary

The #5348 drop-and-retry-FRESH fallback fired on a blunt trigger — "5 consecutive respawns died during warmup" — gated on construction-time seeding (`_seededFromPersisted`). The trigger never confirmed the conversation was actually missing, so:

- an **originally-fresh** session crash-looping for an unrelated cause (OOM, broken install, claude crashing while loading a large-but-present conversation file) abandoned real context on an unconfirmed hunch, and
- a **restored** session whose persisted conversation genuinely vanished (wiped `~/.claude/projects/`, state file from another machine, the #5415 die-before-persist corner) burned 5 doomed resumes and was destroyed, even though CliSession falls back loudly in exactly this case.

This PR gates the fallback on classification of the PTY output tail instead of seeding origin.

## Design

- **Shared patterns:** new `_scanOutputForUnknownResume()` reuses `stderrIndicatesUnknownResume` / the pinned `RESUME_UNKNOWN_STDERR_PATTERNS` exported from `cli-session.js` (#4929/#4950) — no second copy of the marker strings. The PTY merges stdout+stderr, so claude's "No conversation found with session ID …" rejection lands in `_outputTail` (already ANSI-stripped). Whitespace is collapsed before matching (mirrors `_scanOutputForAuthFailure`) so TUI line wrapping can't split a pattern.
- **Freshness of the evidence:** `_spawnPty` resets the tail at the top of every attempt, so a match at the respawn cap always describes the MOST RECENT death, never a stale prior attempt.
- **New gate in `_scheduleRespawn`:** at the 5-attempt cap, retry-FRESH requires the tail match (plus the existing one-shot latch). No match → honest exhaustion (`pty_respawn_exhausted`) for BOTH seeding origins — an unconfirmed cause never abandons a conversation id (keeps the TUI-AUDIT-001 amnesia class closed).
- **Restored-session parity:** with the tail confirming the id is unknown, restored sessions now get the same loud one-shot `resume_unknown` fallback (new uuid, `attemptedResumeId` surfaced, JSONL stays on disk); a failed fallback still escalates to `resume_unknown_exhausted`.
- **`_seededFromPersisted`** is no longer the eligibility gate; it only words the `resume_unknown` message ("wiped from this machine" vs "likely never persisted").
- **Redaction (#5322/#5358):** the tail is only *scanned* — never logged by the classifier. All diagnostic surfaces keep routing through `_outputTailDiagnostic()` / `_outputTailHexDump()`.

## Tests

`tests/claude-tui-session.test.js` (written RED first):
- fresh + tail match → ONE retry-FRESH at the cap (updated #5348 test, deaths now carry the real rejection text)
- fresh + NO match → exhaustion, no `resume_unknown`, conversation id never abandoned (new)
- restored + tail match → loud one-shot fallback with `attemptedResumeId`, fresh uuid, `resume_unknown_exhausted` when the fresh attempt also dies (new)
- restored + NO match → exhaustion after exactly 5 attempts (updated)
- classifier unit: matches through ANSI codes + line wrapping; no match on unrelated crash output / empty tail (new)

406/406 across `claude-tui-session`, `cli-session`, `cli-session-resume-unknown`, `event-normalizer-resume-unknown`; all three server shell lints green.

Closes #5417.
Related to #5338.