### PR TITLE
fix(server): honor notifications.discord config in supervisor-sent notifications

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -165,8 +165,16 @@ export class Supervisor extends EventEmitter {
     // down") looks different from every other update. The statePath default
     // matches the child server's so both processes converge on the same
     // status message; the sink persists that state atomically (temp+rename).
+    //
+    // prefsPath mirrors server-cli.js too: without it the per-send manager
+    // falls back to default prefs, so supervisor-sent notifications would
+    // ignore the operator's category mutes / quiet hours (both sinks gate on
+    // prefs) while the child server honors them. Read-only here — the
+    // supervisor never calls setPrefs/registerToken — and fresh-per-send
+    // picks up prefs the child persisted after startup, same as the tokens.
     const push = new PushManager({
       storagePath: this._pushStoragePath,
+      prefsPath: join(homedir(), '.chroxy', 'notification-prefs.json'),
       discord: {
         statePath: join(homedir(), '.chroxy', 'discord-webhook-state.json'),
         ...(this.config.notifications?.discord || {}),

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -158,7 +158,20 @@ export class Supervisor extends EventEmitter {
     // Create a fresh PushManager each time to reload tokens from disk.
     // The child process writes tokens after clients connect, so the supervisor
     // must re-read the file to pick up any tokens registered since startup.
-    const push = new PushManager({ storagePath: this._pushStoragePath })
+    //
+    // #5430: plumb the `notifications.discord` config block through, mirroring
+    // server-cli.js — otherwise the Discord sink runs with default botName/
+    // colors/throttle and a supervisor-emitted embed update ("Chroxy server is
+    // down") looks different from every other update. The statePath default
+    // matches the child server's so both processes converge on the same
+    // status message; the sink persists that state atomically (temp+rename).
+    const push = new PushManager({
+      storagePath: this._pushStoragePath,
+      discord: {
+        statePath: join(homedir(), '.chroxy', 'discord-webhook-state.json'),
+        ...(this.config.notifications?.discord || {}),
+      },
+    })
     try {
       await push.send(category, title, body)
     } finally {

--- a/packages/server/tests/supervisor-push-config.test.js
+++ b/packages/server/tests/supervisor-push-config.test.js
@@ -100,6 +100,11 @@ if (typeof mock.module !== 'function') {
       // convergence keeps working (both processes edit the same embed).
       assert.equal(opts.discord?.statePath, join(homedir(), '.chroxy', 'discord-webhook-state.json'))
 
+      // prefsPath must mirror server-cli.js too — otherwise the per-send
+      // manager runs with default prefs and supervisor notifications ignore
+      // the operator's category mutes / quiet hours (both sinks gate on prefs).
+      assert.equal(opts.prefsPath, join(homedir(), '.chroxy', 'notification-prefs.json'))
+
       assert.deepEqual(sendCalls, [
         { category: 'activity_error', title: 'Chroxy server is down', body: 'body' },
       ])

--- a/packages/server/tests/supervisor-push-config.test.js
+++ b/packages/server/tests/supervisor-push-config.test.js
@@ -1,0 +1,153 @@
+/**
+ * Supervisor per-send PushManager config plumbing (#5430).
+ *
+ * `Supervisor._sendPushNotification` constructs a fresh PushManager per send
+ * (by design — the supervisor must re-read tokens the child wrote to disk).
+ * After #5413 Phase 2 that manager fans out to sinks, and DiscordWebhookSink
+ * reads its cosmetic knobs (botName, colors, throttle/heartbeat intervals)
+ * from its constructor opts. The supervisor used to pass only `{ storagePath }`,
+ * so a supervisor-emitted notification ("Chroxy server is down") rendered the
+ * Discord status embed with default identity/colors while the child server's
+ * sink honoured the operator's `notifications.discord` block.
+ *
+ * These tests assert the supervisor mirrors server-cli.js:
+ *   { storagePath, discord: { statePath, ...config.notifications?.discord } }
+ *
+ * Mock strategy: mock.module('../src/push.js') BEFORE importing supervisor.js
+ * so the per-send `new PushManager(...)` call lands on a fake that captures
+ * constructor opts — this exercises the REAL _sendPushNotification (the main
+ * supervisor.test.js suite overrides that method entirely).
+ */
+import { describe, it, beforeEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// ── Guard: skip silently if mock.module is not available ──────────────────
+// mock.module requires --experimental-test-module-mocks. The test runner
+// command passes this flag; if for any reason the tests are run without it,
+// we emit a single skip rather than hard-failing the suite.
+if (typeof mock.module !== 'function') {
+  describe('Supervisor per-send PushManager config (#5430)', () => {
+    it('skipped — mock.module requires --experimental-test-module-mocks', (t) => {
+      t.skip('re-run with --experimental-test-module-mocks to exercise these tests')
+    })
+  })
+} else {
+  // Captured per-construction records: { opts, sendCalls, destroyed }
+  const constructions = []
+  let sendShouldThrow = false
+
+  class FakePushManager {
+    constructor(opts = {}) {
+      this._record = { opts, sendCalls: [], destroyed: false }
+      constructions.push(this._record)
+    }
+
+    async send(category, title, body) {
+      this._record.sendCalls.push({ category, title, body })
+      if (sendShouldThrow) throw new Error('simulated send failure')
+    }
+
+    destroy() {
+      this._record.destroyed = true
+    }
+  }
+
+  // supervisor.js imports `{ PushManager } from './push.js'` — resolve the
+  // same module URL from here so the mock intercepts that import.
+  mock.module(new URL('../src/push.js', import.meta.url).href, {
+    namedExports: { PushManager: FakePushManager },
+  })
+
+  const { Supervisor } = await import('../src/supervisor.js')
+
+  describe('Supervisor per-send PushManager config (#5430)', () => {
+    beforeEach(() => {
+      constructions.length = 0
+      sendShouldThrow = false
+    })
+
+    it('passes notifications.discord config knobs through to the per-send PushManager', async () => {
+      const supervisor = new Supervisor({
+        apiToken: 'test-token-123',
+        pushStoragePath: '/tmp/chroxy-test-push-tokens.json',
+        notifications: {
+          discord: {
+            botName: 'Custom Bot',
+            updateThrottleMs: 1234,
+            heartbeatIntervalMs: 60000,
+            colors: { chroxy: 3447003 },
+          },
+        },
+      })
+
+      await supervisor._sendPushNotification('activity_error', 'Chroxy server is down', 'body')
+
+      assert.equal(constructions.length, 1, 'expected exactly one per-send PushManager')
+      const { opts, sendCalls, destroyed } = constructions[0]
+
+      assert.equal(opts.storagePath, '/tmp/chroxy-test-push-tokens.json')
+
+      // The operator's notifications.discord block must reach the sink opts —
+      // this is the #5430 bug: previously only { storagePath } was passed.
+      assert.equal(opts.discord?.botName, 'Custom Bot')
+      assert.equal(opts.discord?.updateThrottleMs, 1234)
+      assert.equal(opts.discord?.heartbeatIntervalMs, 60000)
+      assert.deepEqual(opts.discord?.colors, { chroxy: 3447003 })
+
+      // statePath must match the child server's default so message-id
+      // convergence keeps working (both processes edit the same embed).
+      assert.equal(opts.discord?.statePath, join(homedir(), '.chroxy', 'discord-webhook-state.json'))
+
+      assert.deepEqual(sendCalls, [
+        { category: 'activity_error', title: 'Chroxy server is down', body: 'body' },
+      ])
+      assert.equal(destroyed, true, 'per-send manager must be destroyed (#5413 interval leak)')
+    })
+
+    it('config statePath override wins over the default (spread order mirrors server-cli.js)', async () => {
+      const supervisor = new Supervisor({
+        apiToken: 'test-token-123',
+        pushStoragePath: '/tmp/chroxy-test-push-tokens.json',
+        notifications: {
+          discord: { statePath: '/tmp/custom-discord-state.json' },
+        },
+      })
+
+      await supervisor._sendPushNotification('activity_error', 'title', 'body')
+
+      assert.equal(constructions.length, 1)
+      assert.equal(constructions[0].opts.discord?.statePath, '/tmp/custom-discord-state.json')
+    })
+
+    it('without a notifications block the discord sink still gets the default statePath', async () => {
+      const supervisor = new Supervisor({
+        apiToken: 'test-token-123',
+        pushStoragePath: '/tmp/chroxy-test-push-tokens.json',
+      })
+
+      await supervisor._sendPushNotification('activity_restarted', 'Chroxy restarted', 'body')
+
+      assert.equal(constructions.length, 1)
+      const { opts } = constructions[0]
+      assert.equal(opts.discord?.statePath, join(homedir(), '.chroxy', 'discord-webhook-state.json'))
+    })
+
+    it('destroys the per-send PushManager even when send() rejects', async () => {
+      sendShouldThrow = true
+      const supervisor = new Supervisor({
+        apiToken: 'test-token-123',
+        pushStoragePath: '/tmp/chroxy-test-push-tokens.json',
+        notifications: { discord: { botName: 'Custom Bot' } },
+      })
+
+      await assert.rejects(
+        () => supervisor._sendPushNotification('activity_error', 'title', 'body'),
+        /simulated send failure/,
+      )
+      assert.equal(constructions.length, 1)
+      assert.equal(constructions[0].destroyed, true)
+    })
+  })
+}


### PR DESCRIPTION
Closes #5430.

## Problem

`Supervisor._sendPushNotification` constructs its per-send `PushManager` with only `{ storagePath }`. After #5413 Phase 2 (PRs #5425/#5427/#5432) PushManager fans out to sinks, and the DiscordWebhookSink it registers therefore ran with defaults — default `botName`, default colors, default `updateThrottleMs`/`heartbeatIntervalMs` — ignoring the operator's `notifications.discord` config block that the child server's sink honors. A supervisor-emitted `activity_error` ("Chroxy server is down", max-restarts-exceeded path) rendered the status embed with the default identity/colors, inconsistent with every other embed update.

## Fix

Plumb the supervisor's already-loaded config into the per-send `PushManager`, mirroring `server-cli.js`:

```js
const push = new PushManager({
  storagePath: this._pushStoragePath,
  discord: {
    statePath: join(homedir(), '.chroxy', 'discord-webhook-state.json'),
    ...(this.config.notifications?.discord || {}),
  },
})
```

- The fresh-per-send construction is **kept by design** (the supervisor must re-read tokens the child wrote to disk after clients connect); only the opts change.
- The `statePath` default matches the child server's, so message-id convergence keeps working (both processes update the same embed). Concurrent state-file access is safe: the sink persists atomically via temp+rename (`writeFileRestricted`), as it already did when both processes defaulted to the same path.
- No secrets involved — the webhook URL still resolves only from `CHROXY_DISCORD_WEBHOOK_URL` / `~/.chroxy/credentials.json`; `config.notifications.discord` carries cosmetic knobs only (config validation rejects URL keys there).

## Tests

New `tests/supervisor-push-config.test.js` — mocks `push.js` via `mock.module` to capture per-send constructor opts and exercises the **real** `_sendPushNotification` (the existing supervisor suite overrides it entirely). RED before the fix (discord opts `undefined`), GREEN after:

- `notifications.discord` knobs (botName, throttle, heartbeat, colors) reach the per-send manager
- config `statePath` override wins over the default (spread order mirrors server-cli.js)
- default `statePath` still applied with no `notifications` block
- per-send manager is destroyed even when `send()` rejects (#5413 interval-leak regression cover)

180/180 tests pass across the supervisor + push + discord-sink suites; all `lint-*.sh` scripts green.