### PR TITLE
feat(server): enrich ready-for-input notifications with the background-task snapshot

### DIFF
--- a/packages/server/src/notifications/ready-body.js
+++ b/packages/server/src/notifications/ready-body.js
@@ -31,6 +31,22 @@ export const DEFAULT_READY_BODY = 'Ready for next message'
 // shared clamp is the binding one.
 export const READY_BODY_MAX_LENGTH = 140
 
+// Task descriptions and wakeup reasons come from the session transcript's
+// tool_use input — model-authored text, NOT raw PTY bytes. Newlines are
+// routine (the scanner's Agent fallback is `prompt.slice(0, 80)`, and
+// prompts are usually multi-line); embedded escape/control bytes are
+// implausible but cheap to defend against. Push trays and the Discord
+// Status field render the body as flowed text, so: drop ANSI CSI/ESC
+// sequences outright, turn remaining C0/C1 controls into spaces, then
+// collapse all whitespace to single spaces.
+function sanitizeDetail(text) {
+  return String(text)
+    .replace(/\u001b\[[0-9;?]*[ -\/]*[@-~]/g, '') // ANSI CSI sequences
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ') // remaining C0/C1 controls
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 /**
  * Clamp `detail` so `prefix + detail + suffix` fits READY_BODY_MAX_LENGTH.
  * The suffix (`+N more`) always survives — it carries the "there is more
@@ -39,7 +55,11 @@ export const READY_BODY_MAX_LENGTH = 140
 function clampDetail(prefix, detail, suffix = '') {
   const budget = READY_BODY_MAX_LENGTH - prefix.length - suffix.length
   if (detail.length > budget) {
-    detail = `${detail.slice(0, Math.max(0, budget - 1))}…`
+    let cut = detail.slice(0, Math.max(0, budget - 1))
+    // Never cut through a surrogate pair — a half emoji is an ill-formed
+    // string in the push/Discord JSON payload (renders as U+FFFD at best).
+    if (/[\uD800-\uDBFF]$/.test(cut)) cut = cut.slice(0, -1)
+    detail = `${cut}…`
   }
   return `${prefix}${detail}${suffix}`
 }
@@ -65,7 +85,12 @@ export function composeReadyNotificationBody(snapshot) {
     for (let i = 1; i < tasks.length; i++) {
       if ((tasks[i]?.startedAt ?? 0) > (newest?.startedAt ?? 0)) newest = tasks[i]
     }
-    const detail = String(newest?.description || newest?.toolUseId || 'background task')
+    // Sanitize each candidate BEFORE the fallback chain so a whitespace-only
+    // description still falls through to the toolUseId.
+    const detail =
+      sanitizeDetail(newest?.description ?? '') ||
+      sanitizeDetail(newest?.toolUseId ?? '') ||
+      'background task'
     const suffix = tasks.length > 1 ? ` +${tasks.length - 1} more` : ''
     return clampDetail('Ready for input — still watching: ', detail, suffix)
   }
@@ -76,7 +101,7 @@ export function composeReadyNotificationBody(snapshot) {
     if (!Number.isFinite(at.getTime())) return DEFAULT_READY_BODY
     // Server-local HH:MM — same formatting as the dashboard's wakeup chip.
     const hhmm = `${String(at.getHours()).padStart(2, '0')}:${String(at.getMinutes()).padStart(2, '0')}`
-    const reason = typeof wakeup.reason === 'string' ? wakeup.reason : ''
+    const reason = sanitizeDetail(typeof wakeup.reason === 'string' ? wakeup.reason : '')
     if (!reason) return `Ready for input — resumes at ${hhmm}`
     return clampDetail(`Ready for input — resumes at ${hhmm}: `, reason)
   }

--- a/packages/server/src/notifications/ready-body.js
+++ b/packages/server/src/notifications/ready-body.js
@@ -1,0 +1,102 @@
+/**
+ * #5438 — ready-for-input notification body, enriched with the #5436
+ * background-task snapshot.
+ *
+ * The idle push ("session finished a turn, waiting on you") is composed once
+ * in PushNotificationHandler and fans out through PushManager to every sink:
+ * the Expo sink delivers `body` as the OS notification text, and the
+ * DiscordWebhookSink renders `notification.body` as its status embed's
+ * Status field. Enriching the body HERE is therefore the single point that
+ * covers both sinks — no per-sink special-casing.
+ *
+ * Snapshot contract (mirrors the `claude_ready` wire fields from #5436):
+ *   - absent (null/undefined) = no information → today's plain body
+ *   - present, even `{ backgroundTasks: [] }`, = authoritative → an empty
+ *     snapshot also yields the plain body (nothing outstanding to surface)
+ *
+ * Wording is kept consistent with the dashboard ActivityIndicator chips
+ * (#5436): most-recent task by `startedAt`, `description || toolUseId`
+ * detail, `+N more` overflow, HH:MM local wakeup time — and the same
+ * priority order: outstanding tasks win over an armed wakeup, because a
+ * still-running watcher is the thing the user is most likely waiting on
+ * (the wakeup will re-busy the session on its own anyway).
+ */
+
+/** Today's plain idle-push body — unchanged when the snapshot has nothing. */
+export const DEFAULT_READY_BODY = 'Ready for next message'
+
+// Practical ceiling for push-notification bodies: iOS/Android tray text and
+// the Expo payload both render ~1-2 lines; past ~140 chars the tail is never
+// visible. The Discord embed field has its own 1000-char truncate, so this
+// shared clamp is the binding one.
+export const READY_BODY_MAX_LENGTH = 140
+
+/**
+ * Clamp `detail` so `prefix + detail + suffix` fits READY_BODY_MAX_LENGTH.
+ * The suffix (`+N more`) always survives — it carries the "there is more
+ * going on than this one line" signal that a blind tail-truncate would eat.
+ */
+function clampDetail(prefix, detail, suffix = '') {
+  const budget = READY_BODY_MAX_LENGTH - prefix.length - suffix.length
+  if (detail.length > budget) {
+    detail = `${detail.slice(0, Math.max(0, budget - 1))}…`
+  }
+  return `${prefix}${detail}${suffix}`
+}
+
+/**
+ * Compose the idle-push body from a background-task snapshot.
+ *
+ * @param {{ backgroundTasks?: Array<{toolUseId:string, description?:string, startedAt?:number}>,
+ *           scheduledWakeup?: { at:number, reason?:string } | null } | null | undefined} snapshot
+ *   Output of `getBackgroundTaskSnapshot()` (#5436), or null when the session
+ *   type doesn't expose one / the transcript scan degraded.
+ * @returns {string} the notification body — DEFAULT_READY_BODY when there is
+ *   nothing outstanding, otherwise the enriched still-watching / resumes-at
+ *   line, clamped to READY_BODY_MAX_LENGTH.
+ */
+export function composeReadyNotificationBody(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return DEFAULT_READY_BODY
+
+  const tasks = Array.isArray(snapshot.backgroundTasks) ? snapshot.backgroundTasks : []
+  if (tasks.length > 0) {
+    // Most recent task by startedAt — same pick as the dashboard chip.
+    let newest = tasks[0]
+    for (let i = 1; i < tasks.length; i++) {
+      if ((tasks[i]?.startedAt ?? 0) > (newest?.startedAt ?? 0)) newest = tasks[i]
+    }
+    const detail = String(newest?.description || newest?.toolUseId || 'background task')
+    const suffix = tasks.length > 1 ? ` +${tasks.length - 1} more` : ''
+    return clampDetail('Ready for input — still watching: ', detail, suffix)
+  }
+
+  const wakeup = snapshot.scheduledWakeup
+  if (wakeup && typeof wakeup === 'object') {
+    const at = new Date(wakeup.at)
+    if (!Number.isFinite(at.getTime())) return DEFAULT_READY_BODY
+    // Server-local HH:MM — same formatting as the dashboard's wakeup chip.
+    const hhmm = `${String(at.getHours()).padStart(2, '0')}:${String(at.getMinutes()).padStart(2, '0')}`
+    const reason = typeof wakeup.reason === 'string' ? wakeup.reason : ''
+    if (!reason) return `Ready for input — resumes at ${hhmm}`
+    return clampDetail(`Ready for input — resumes at ${hhmm}: `, reason)
+  }
+
+  return DEFAULT_READY_BODY
+}
+
+/**
+ * Read a session's background-task snapshot for notification enrichment.
+ * Returns null (= "no information", body unchanged) when the session type
+ * doesn't implement `getBackgroundTaskSnapshot()` or the read throws —
+ * the same degrade-to-plain-ready posture as event-normalizer's
+ * backgroundTaskFields().
+ */
+export function readBackgroundTaskSnapshot(session) {
+  try {
+    return typeof session?.getBackgroundTaskSnapshot === 'function'
+      ? session.getBackgroundTaskSnapshot()
+      : null
+  } catch {
+    return null
+  }
+}

--- a/packages/server/src/server-cli/push-notification-handler.js
+++ b/packages/server/src/server-cli/push-notification-handler.js
@@ -19,6 +19,11 @@
 // logger) make this unit-testable with fakes — the biggest coverage win of the
 // split, since the inline version was impossible to exercise in isolation.
 
+import {
+  composeReadyNotificationBody,
+  readBackgroundTaskSnapshot,
+} from '../notifications/ready-body.js'
+
 export class PushNotificationHandler {
   /**
    * @param {{
@@ -146,7 +151,15 @@ export class PushNotificationHandler {
           const allowed = noClients || noActiveViewers
           const alreadyNotified = this._idleNotifiedSessions.has(sessionId)
           if (allowed && !alreadyNotified) {
-            const sessionName = sessionManager.getSession(sessionId)?.name
+            const session = sessionManager.getSession(sessionId)
+            const sessionName = session?.name
+            // #5438 — enrich the idle body with the #5436 background-task
+            // snapshot ("still watching: <task>" / "resumes at HH:MM").
+            // Absent snapshot (session type doesn't expose one, or the
+            // transcript scan degraded) = no information → body unchanged.
+            // The body rides the pipeline to every sink, so the Expo push
+            // and the Discord status embed both pick this up.
+            const body = composeReadyNotificationBody(readBackgroundTaskSnapshot(session))
             // #3870: latch SYNCHRONOUSLY before send() returns its promise
             // so a second `result` arriving in the same tick can't double-
             // fire (passes the !alreadyNotified gate twice). `send()` now
@@ -159,7 +172,7 @@ export class PushNotificationHandler {
             // *and* permanently latched until the session went busy again.
             this._idleNotifiedSessions.add(sessionId)
             Promise.resolve(
-              pushManager.send('activity_update', 'Session idle', 'Ready for next message', {
+              pushManager.send('activity_update', 'Session idle', body, {
                 sessionId,
                 sessionName,
                 state: 'idle',

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -406,6 +406,19 @@ describe('DiscordWebhookSink — status-message state machine', () => {
     assert.ok(embed.timestamp)
   })
 
+  it('the #5438-enriched idle body rides notification.body into the Status field', async () => {
+    // The ready-for-input enrichment is composed upstream (PushNotificationHandler
+    // via composeReadyNotificationBody) and rides notification.body — this pins
+    // that the status embed surfaces it without any sink special-casing.
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    const enriched = 'Ready for input — still watching: deploy monitor +1 more'
+    await sink.send({ ...idle(), body: enriched })
+    const embed = JSON.parse(calls[0].body).embeds[0]
+    assert.ok(embed.title.includes('Ready for input'))
+    assert.ok(embed.fields.some((f) => f.name === 'Status' && f.value === enriched))
+  })
+
   it('uses the permission color for needs-approval regardless of project overrides', async () => {
     const calls = scriptFetch()
     const { sink } = makeSink({ colors: { alpha: 1752220 } })

--- a/packages/server/tests/push-notification-handler.test.js
+++ b/packages/server/tests/push-notification-handler.test.js
@@ -225,6 +225,80 @@ describe('PushNotificationHandler — per-event push fan-out', () => {
   })
 })
 
+describe('PushNotificationHandler — #5438 ready-body enrichment', () => {
+  const wireSession = (fakes, session) => { fakes.sessionManager.getSession = () => session }
+  const emitResult = (fakes) =>
+    fakes.sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+
+  it('keeps the plain body when the session has no getBackgroundTaskSnapshot (absent = no info)', () => {
+    const fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) })
+    wireSession(fakes, { name: 'n' })
+    emitResult(fakes)
+    assert.equal(fakes.sends[0].body, 'Ready for next message')
+  })
+
+  it('keeps the plain body when the snapshot is null (degraded transcript scan)', () => {
+    const fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) })
+    wireSession(fakes, { name: 'n', getBackgroundTaskSnapshot: () => null })
+    emitResult(fakes)
+    assert.equal(fakes.sends[0].body, 'Ready for next message')
+  })
+
+  it('keeps the plain body for an explicit empty snapshot (authoritative nothing-outstanding)', () => {
+    const fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) })
+    wireSession(fakes, {
+      name: 'n',
+      getBackgroundTaskSnapshot: () => ({ backgroundTasks: [], scheduledWakeup: null }),
+    })
+    emitResult(fakes)
+    assert.equal(fakes.sends[0].body, 'Ready for next message')
+  })
+
+  it('enriches the body with the most recent outstanding task (+N more)', () => {
+    const fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) })
+    wireSession(fakes, {
+      name: 'n',
+      getBackgroundTaskSnapshot: () => ({
+        backgroundTasks: [
+          { toolUseId: 'a', kind: 'bash', description: 'older watcher', startedAt: 1_000 },
+          { toolUseId: 'b', kind: 'agent', description: 'deploy monitor', startedAt: 2_000 },
+        ],
+        scheduledWakeup: null,
+      }),
+    })
+    emitResult(fakes)
+    assert.equal(fakes.sends.length, 1)
+    assert.equal(fakes.sends[0].body, 'Ready for input — still watching: deploy monitor +1 more')
+    assert.equal(fakes.sends[0].category, 'activity_update')
+    assert.equal(fakes.sends[0].data.state, 'idle')
+  })
+
+  it('enriches the body with an armed wakeup (local HH:MM + reason)', () => {
+    const at = new Date(2026, 5, 10, 7, 30).getTime()
+    const fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) })
+    wireSession(fakes, {
+      name: 'n',
+      getBackgroundTaskSnapshot: () => ({
+        backgroundTasks: [],
+        scheduledWakeup: { at, reason: 'poll the release build' },
+      }),
+    })
+    emitResult(fakes)
+    assert.equal(fakes.sends[0].body, 'Ready for input — resumes at 07:30: poll the release build')
+  })
+
+  it('a throwing snapshot read degrades to the plain body (push still fires)', () => {
+    const fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) })
+    wireSession(fakes, {
+      name: 'n',
+      getBackgroundTaskSnapshot: () => { throw new Error('transcript gone') },
+    })
+    assert.doesNotThrow(() => emitResult(fakes))
+    assert.equal(fakes.sends.length, 1)
+    assert.equal(fakes.sends[0].body, 'Ready for next message')
+  })
+})
+
 describe('PushNotificationHandler — session_destroyed clears dedupe', () => {
   let fakes
   beforeEach(() => { fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) }) })

--- a/packages/server/tests/ready-notification-body.test.js
+++ b/packages/server/tests/ready-notification-body.test.js
@@ -74,6 +74,33 @@ describe('composeReadyNotificationBody — outstanding tasks', () => {
     })
     assert.equal(body, 'Ready for input — still watching: toolu_01')
   })
+
+  it('falls back to the toolUseId when the description is whitespace-only', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task({ description: ' \n\t ' })],
+      scheduledWakeup: null,
+    })
+    assert.equal(body, 'Ready for input — still watching: toolu_01')
+  })
+
+  it('collapses newlines and tabs in a multi-line description (Agent prompt fallback)', () => {
+    // TranscriptTaskScanner falls back to `prompt.slice(0, 80)` for Agent
+    // launches with no description — multi-line prompts are routine, and a
+    // raw newline would wrap the one-line push body / Discord Status field.
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task({ description: 'watch the deploy\n\nand report back\twhen done' })],
+      scheduledWakeup: null,
+    })
+    assert.equal(body, 'Ready for input — still watching: watch the deploy and report back when done')
+  })
+
+  it('strips ANSI escapes and control bytes from the description', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task({ description: '\u001b[31mred\u001b[0m alert\u0007 bell' })],
+      scheduledWakeup: null,
+    })
+    assert.equal(body, 'Ready for input — still watching: red alert bell')
+  })
 })
 
 describe('composeReadyNotificationBody — armed wakeup', () => {
@@ -91,6 +118,15 @@ describe('composeReadyNotificationBody — armed wakeup', () => {
     const body = composeReadyNotificationBody({
       backgroundTasks: [],
       scheduledWakeup: { at, reason: '' },
+    })
+    assert.equal(body, 'Ready for input — resumes at 23:59')
+  })
+
+  it('omits the reason segment when the reason is whitespace-only', () => {
+    const at = new Date(2026, 5, 10, 23, 59).getTime()
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [],
+      scheduledWakeup: { at, reason: ' \n ' },
     })
     assert.equal(body, 'Ready for input — resumes at 23:59')
   })
@@ -135,6 +171,19 @@ describe('composeReadyNotificationBody — length clamp', () => {
     })
     assert.ok(body.length <= READY_BODY_MAX_LENGTH)
     assert.ok(body.endsWith('… +1 more'), `suffix survives the clamp (got: ${body.slice(-20)})`)
+  })
+
+  it('never splits a surrogate pair at the truncation point', () => {
+    // Build a description whose clamp budget lands exactly mid-emoji: if the
+    // cut split the pair, the body would carry a lone high surrogate into
+    // the push/Discord JSON payload.
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task({ description: '🚀'.repeat(200) })],
+      scheduledWakeup: null,
+    })
+    assert.ok(body.length <= READY_BODY_MAX_LENGTH)
+    assert.ok(!/[\uD800-\uDBFF]…/.test(body), 'no lone high surrogate before the ellipsis')
+    assert.ok(body.isWellFormed(), 'body is a well-formed unicode string')
   })
 
   it('truncates an oversized wakeup reason too', () => {

--- a/packages/server/tests/ready-notification-body.test.js
+++ b/packages/server/tests/ready-notification-body.test.js
@@ -1,0 +1,150 @@
+// #5438 — unit tests for the ready-for-input notification body composer.
+// The composer turns a #5436 background-task snapshot into the idle-push
+// body shared by the Expo sink and the Discord status embed (which renders
+// `notification.body` as its Status field). Contract under test:
+//   - absent snapshot (null/undefined) → today's plain body, unchanged
+//   - explicit empty snapshot ([], no wakeup) → plain body too
+//   - outstanding tasks → 'Ready for input — still watching: <desc>' (+N more)
+//   - armed wakeup → 'Ready for input — resumes at HH:MM: <reason>'
+//   - tasks win over a wakeup when both exist (dashboard chip priority)
+//   - the composed body is clamped to ~140 chars (push payload hygiene)
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  composeReadyNotificationBody,
+  DEFAULT_READY_BODY,
+  READY_BODY_MAX_LENGTH,
+} from '../src/notifications/ready-body.js'
+
+const task = (over = {}) => ({
+  toolUseId: 'toolu_01',
+  kind: 'bash',
+  description: 'npm test in worktree',
+  startedAt: 1_000,
+  ...over,
+})
+
+describe('composeReadyNotificationBody — absent / empty snapshot', () => {
+  it('returns the plain body for an absent snapshot (null)', () => {
+    assert.equal(composeReadyNotificationBody(null), DEFAULT_READY_BODY)
+  })
+
+  it('returns the plain body for undefined', () => {
+    assert.equal(composeReadyNotificationBody(undefined), DEFAULT_READY_BODY)
+  })
+
+  it('returns the plain body for an explicit empty snapshot ([] + null wakeup)', () => {
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: null }),
+      DEFAULT_READY_BODY
+    )
+  })
+
+  it('returns the plain body for a malformed snapshot (non-object)', () => {
+    assert.equal(composeReadyNotificationBody('garbage'), DEFAULT_READY_BODY)
+  })
+})
+
+describe('composeReadyNotificationBody — outstanding tasks', () => {
+  it('single task: still-watching with the task description', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task()],
+      scheduledWakeup: null,
+    })
+    assert.equal(body, 'Ready for input — still watching: npm test in worktree')
+  })
+
+  it('several tasks: picks the most recent (max startedAt) and appends +N more', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [
+        task({ toolUseId: 'a', description: 'old watcher', startedAt: 1_000 }),
+        task({ toolUseId: 'b', description: 'newest deploy', startedAt: 3_000 }),
+        task({ toolUseId: 'c', description: 'middle build', startedAt: 2_000 }),
+      ],
+      scheduledWakeup: null,
+    })
+    assert.equal(body, 'Ready for input — still watching: newest deploy +2 more')
+  })
+
+  it('falls back to the toolUseId when the description is empty', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task({ description: '' })],
+      scheduledWakeup: null,
+    })
+    assert.equal(body, 'Ready for input — still watching: toolu_01')
+  })
+})
+
+describe('composeReadyNotificationBody — armed wakeup', () => {
+  it('formats the wakeup in server-local HH:MM with the reason', () => {
+    const at = new Date(2026, 5, 10, 9, 5).getTime() // 09:05 local
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [],
+      scheduledWakeup: { at, reason: 'poll CI for the release build' },
+    })
+    assert.equal(body, 'Ready for input — resumes at 09:05: poll CI for the release build')
+  })
+
+  it('omits the reason segment when the reason is empty', () => {
+    const at = new Date(2026, 5, 10, 23, 59).getTime()
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [],
+      scheduledWakeup: { at, reason: '' },
+    })
+    assert.equal(body, 'Ready for input — resumes at 23:59')
+  })
+
+  it('degrades to the plain body when the wakeup time is unparsable', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [],
+      scheduledWakeup: { at: NaN, reason: 'whatever' },
+    })
+    assert.equal(body, DEFAULT_READY_BODY)
+  })
+})
+
+describe('composeReadyNotificationBody — both tasks and a wakeup', () => {
+  it('tasks win (same priority order as the dashboard ActivityIndicator chips)', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task({ description: 'tail deploy logs' })],
+      scheduledWakeup: { at: Date.now() + 60_000, reason: 'check again later' },
+    })
+    assert.equal(body, 'Ready for input — still watching: tail deploy logs')
+  })
+})
+
+describe('composeReadyNotificationBody — length clamp', () => {
+  it('truncates an oversized task description so the body stays within the limit', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [task({ description: 'x'.repeat(500) })],
+      scheduledWakeup: null,
+    })
+    assert.ok(body.length <= READY_BODY_MAX_LENGTH, `body length ${body.length} exceeds limit`)
+    assert.ok(body.startsWith('Ready for input — still watching: x'))
+    assert.ok(body.endsWith('…'), 'truncation marked with an ellipsis')
+  })
+
+  it('truncation preserves the +N more suffix', () => {
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [
+        task({ toolUseId: 'a', description: 'y'.repeat(500), startedAt: 9_000 }),
+        task({ toolUseId: 'b', description: 'older', startedAt: 1_000 }),
+      ],
+      scheduledWakeup: null,
+    })
+    assert.ok(body.length <= READY_BODY_MAX_LENGTH)
+    assert.ok(body.endsWith('… +1 more'), `suffix survives the clamp (got: ${body.slice(-20)})`)
+  })
+
+  it('truncates an oversized wakeup reason too', () => {
+    const at = new Date(2026, 5, 10, 12, 0).getTime()
+    const body = composeReadyNotificationBody({
+      backgroundTasks: [],
+      scheduledWakeup: { at, reason: 'z'.repeat(500) },
+    })
+    assert.ok(body.length <= READY_BODY_MAX_LENGTH)
+    assert.ok(body.startsWith('Ready for input — resumes at 12:00: z'))
+    assert.ok(body.endsWith('…'))
+  })
+})


### PR DESCRIPTION
Closes #5438.

Enriches the idle push ("Session idle") with the #5436 transcript-derived background-task snapshot, so an unattended "ready for input" notification tells you what the session is still waiting on.

## What changed

- **New `packages/server/src/notifications/ready-body.js`** — `composeReadyNotificationBody(snapshot)`:
  - Outstanding tasks → `Ready for input — still watching: <description>` (most recent task by `startedAt`, `description || toolUseId` fallback, ` +N more` when several).
  - Armed wakeup → `Ready for input — resumes at <HH:MM>: <reason>` (server-local HH:MM, same formatting as the dashboard chip; the `: <reason>` segment is omitted when the reason is empty; an unparsable `at` degrades to the plain body).
  - Empty (`backgroundTasks: []`, no wakeup) or absent (`null`) snapshot → `Ready for next message`, byte-identical to today. Absent = no information, present-even-empty = authoritative — the #5436 contract.
  - Bodies are clamped to 140 chars (push-tray practical limit); truncation ellipsizes the description/reason but always preserves the ` +N more` suffix.
- **`push-notification-handler.js`** — the idle-push arm reads the snapshot off the session (`readBackgroundTaskSnapshot`, which returns `null` for session types without `getBackgroundTaskSnapshot()` or a throwing read — same degrade-to-plain-ready posture as event-normalizer's `backgroundTaskFields`) and composes the body once.

## Both sinks, one composition point

The enrichment rides `notification.body` through PushManager's fan-out: the Expo sink delivers it as the OS notification text, and the DiscordWebhookSink renders `notification.body` as the status embed's **Status** field. No per-sink special-casing — a sink test pins that the enriched body surfaces in the embed.

## Priority order when both tasks and a wakeup exist

**Tasks win.** This matches the dashboard ActivityIndicator chip order from #5436 (the transcript-tasks chip renders before the wakeup chip): a still-running watcher is the thing the user is most likely waiting on, and the wakeup will re-busy the session on its own regardless.

## Tests

- `tests/ready-notification-body.test.js` (new, 14 cases): 1 task, many tasks (+N more, most-recent pick), `toolUseId` fallback, wakeup with/without reason, invalid wakeup time, both-present priority, empty array (no enrichment), absent/null (no enrichment), malformed snapshot, 140-char truncation for descriptions and reasons, suffix survival through truncation.
- `tests/push-notification-handler.test.js` (+6): enrichment through the real send site — session without the method (absent = plain body), null snapshot, explicit-empty snapshot, task enrichment, wakeup enrichment, throwing snapshot read (push still fires with the plain body).
- `tests/discord-webhook-sink.test.js` (+1): enriched body → embed Status field.

`push-notification-handler`, `ready-notification-body`, `discord-webhook-sink`, `notification-sinks`, `push`, `push-activity-update`: **168/168 pass** (exit 0). `lint-logger-session-scoping.sh`, `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh` and eslint all green.

Related to #5413, #5436.