### PR TITLE
fix(server): prune stale discord-webhook-state entries and bound the heartbeat to live projects

### DIFF
--- a/docs/guides/discord-notifications.md
+++ b/docs/guides/discord-notifications.md
@@ -88,7 +88,8 @@ The non-secret knobs live in `~/.chroxy/config.json` under
       "permissionColor": 16753920,
       "errorColor": 15158332,
       "updateThrottleMs": 15000,
-      "heartbeatIntervalMs": 300000
+      "heartbeatIntervalMs": 300000,
+      "pruneAfterMs": 86400000
     }
   }
 }
@@ -113,7 +114,13 @@ The non-secret knobs live in `~/.chroxy/config.json` under
 - **`updateThrottleMs`** — minimum gap between same-state routine edits per
   project (state *changes* always go out immediately).
 - **`heartbeatIntervalMs`** — how often the elapsed-time footer refreshes.
-  `0` disables the refresh; minimum `10000`.
+  `0` disables the refresh; minimum `10000`. Only *live* embeds are
+  refreshed — an offline embed is final and is never re-PATCHed.
+- **`pruneAfterMs`** — how long a project entry may sit untouched in the
+  state file before chroxy stops tracking it (default `86400000` / 24h;
+  `0` disables pruning). Pruning only drops the bookkeeping entry — the
+  last Discord message (typically the final offline embed) stays in the
+  channel as a record.
 
 See [packages/server/CONFIG.md](../../packages/server/CONFIG.md#discord-notifications-notificationsdiscord)
 for the full key reference.
@@ -123,7 +130,9 @@ for the full key reference.
 Status-message bookkeeping (message id, current state, timestamps per
 project) persists in `~/.chroxy/discord-webhook-state.json`, written
 atomically. Deleting the file is safe — the next event posts a fresh status
-message.
+message. Entries untouched for longer than `pruneAfterMs` (24h by default)
+are swept automatically — on startup and on every subsequent load — so the
+file stays bounded even under heavy project/session rotation.
 
 ## External sessions via `POST /api/events`
 

--- a/docs/guides/discord-notifications.md
+++ b/docs/guides/discord-notifications.md
@@ -118,9 +118,12 @@ The non-secret knobs live in `~/.chroxy/config.json` under
   refreshed — an offline embed is final and is never re-PATCHed.
 - **`pruneAfterMs`** — how long a project entry may sit untouched in the
   state file before chroxy stops tracking it (default `86400000` / 24h;
-  `0` disables pruning). Pruning only drops the bookkeeping entry — the
-  last Discord message (typically the final offline embed) stays in the
-  channel as a record.
+  `0` disables pruning). Only real pipeline events count as touches —
+  heartbeat footer refreshes deliberately don't reset the clock, so an
+  entry whose session stopped emitting events (e.g. ended without a
+  session-end event) is dropped instead of being refreshed forever.
+  Pruning only drops the bookkeeping entry — the last Discord message
+  (typically the final offline embed) stays in the channel as a record.
 
 See [packages/server/CONFIG.md](../../packages/server/CONFIG.md#discord-notifications-notificationsdiscord)
 for the full key reference.

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -532,7 +532,7 @@ The non-secret knobs live under `notifications.discord` in `config.json`:
 | `errorColor` | number | Sidebar color for the session-error state (default `15158332`, red) |
 | `updateThrottleMs` | number | Minimum interval between same-state routine embed updates per project (default `15000`; state changes always go out) |
 | `heartbeatIntervalMs` | number | Elapsed-time footer refresh interval for live embeds — offline embeds are final and never re-PATCHed (default `300000`; `0` disables; minimum `10000`) |
-| `pruneAfterMs` | number | Retention for state-store entries: entries untouched longer than this are dropped on load (default `86400000` / 24h; `0` disables; the last Discord message is kept) |
+| `pruneAfterMs` | number | Retention for state-store entries: entries untouched longer than this are dropped on load (default `86400000` / 24h; `0` disables; the last Discord message is kept). Heartbeat refreshes don't reset the clock — only real pipeline events do |
 
 Status-message state (message ids, current state per project) persists in
 `~/.chroxy/discord-webhook-state.json`. Full setup walkthrough:

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -516,7 +516,8 @@ The non-secret knobs live under `notifications.discord` in `config.json`:
       "permissionColor": 16753920,
       "errorColor": 15158332,
       "updateThrottleMs": 15000,
-      "heartbeatIntervalMs": 300000
+      "heartbeatIntervalMs": 300000,
+      "pruneAfterMs": 86400000
     }
   }
 }
@@ -530,7 +531,8 @@ The non-secret knobs live under `notifications.discord` in `config.json`:
 | `permissionColor` | number | Sidebar color for the needs-approval state (default `16753920`, orange) |
 | `errorColor` | number | Sidebar color for the session-error state (default `15158332`, red) |
 | `updateThrottleMs` | number | Minimum interval between same-state routine embed updates per project (default `15000`; state changes always go out) |
-| `heartbeatIntervalMs` | number | Elapsed-time footer refresh interval (default `300000`; `0` disables; minimum `10000`) |
+| `heartbeatIntervalMs` | number | Elapsed-time footer refresh interval for live embeds — offline embeds are final and never re-PATCHed (default `300000`; `0` disables; minimum `10000`) |
+| `pruneAfterMs` | number | Retention for state-store entries: entries untouched longer than this are dropped on load (default `86400000` / 24h; `0` disables; the last Discord message is kept) |
 
 Status-message state (message ids, current state per project) persists in
 `~/.chroxy/discord-webhook-state.json`. Full setup walkthrough:

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -99,8 +99,10 @@ const CONFIG_SCHEMA = {
   // non-secret knobs: `botName` (string), `colors` (project → decimal
   // 24-bit RGB map for the embed sidebar), `defaultColor` /
   // `permissionColor` / `errorColor` (decimal RGB), `updateThrottleMs`
-  // (min interval between same-state routine embed updates) and
-  // `heartbeatIntervalMs` (elapsed-time refresh; 0 disables). The webhook
+  // (min interval between same-state routine embed updates),
+  // `heartbeatIntervalMs` (elapsed-time refresh; 0 disables) and
+  // `pruneAfterMs` (state-store entry retention, #5429/#5434; 0 disables
+  // pruning). The webhook
   // URL itself is a SECRET and deliberately NOT a config key — it lives in
   // CHROXY_DISCORD_WEBHOOK_URL or ~/.chroxy/credentials.json (0600); see
   // discord-credentials.js. Documented in CONFIG.md +
@@ -470,6 +472,15 @@ function validateDiscordNotificationsBlock(discord, warnings) {
       warnings.push(`Invalid value for 'notifications.discord.heartbeatIntervalMs': expected a number >= 0 (0 disables), got ${JSON.stringify(v)}`)
     } else if (v !== 0 && v < 10_000) {
       warnings.push(`Invalid value for 'notifications.discord.heartbeatIntervalMs': ${v} (minimum 10000 / 10s; set 0 to disable — the sink falls back to its default)`)
+    }
+  }
+
+  // #5429/#5434: state-store entry retention. 0 disables pruning; the sink
+  // falls back to its 24h default on invalid values.
+  if (Object.prototype.hasOwnProperty.call(discord, 'pruneAfterMs')) {
+    const v = discord.pruneAfterMs
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+      warnings.push(`Invalid value for 'notifications.discord.pruneAfterMs': expected a number >= 0 (0 disables pruning), got ${JSON.stringify(v)}`)
     }
   }
 }

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -259,7 +259,11 @@ export class DiscordWebhookSink extends NotificationSink {
     let store = { version: 1, projects: {} }
     try {
       const data = JSON.parse(readFileSync(this._resolvedStatePath(), 'utf-8'))
-      if (data && typeof data === 'object' && data.projects && typeof data.projects === 'object') {
+      // Arrays are rejected too: `typeof [] === 'object'`, but string-keyed
+      // entries assigned onto an array are silently dropped by
+      // JSON.stringify, so a corrupt `projects: []` would wedge tracking
+      // (every persist loses the messageId) — fall back to a fresh map.
+      if (data && typeof data === 'object' && data.projects && typeof data.projects === 'object' && !Array.isArray(data.projects)) {
         store = { version: 1, projects: data.projects }
       }
     } catch {

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -20,8 +20,11 @@
  *     The /tmp state machine was the root cause of the reliability pain the
  *     epic exists to fix.
  *   - The heartbeat is a single unref'd in-process setInterval that PATCHes
- *     each tracked embed so the elapsed-time footer stays current — not a
- *     forked bash daemon with a PID file.
+ *     each LIVE embed so the elapsed-time footer stays current — not a
+ *     forked bash daemon with a PID file. Offline embeds are final and are
+ *     skipped; entries untouched longer than `pruneAfterMs` are pruned from
+ *     the state store at load time (#5429/#5434), keeping both the file and
+ *     the heartbeat's per-tick work bounded to live projects.
  *   - Driven by chroxy's own notification pipeline categories (Phase 2).
  *     External Claude Code hook ingest is Phase 3; subagent counting from
  *     hooks is Phase 4 — until then the embed reflects what chroxy-launched
@@ -63,6 +66,14 @@ const BACKOFF_BASE_MS = 1_000
 // globally limited and should give up (send() resolves false; the pipeline
 // retries on the next event) rather than hold the fan-out hostage.
 const MAX_RETRY_AFTER_MS = 30_000
+
+// #5429/#5434: retention for state-store entries. Project keys fall back to
+// session ids (and Phase 3 ingest accepts arbitrary project names), so
+// without pruning the store grows one entry per key forever — and the
+// heartbeat's per-tick work grows with it. Entries untouched for longer than
+// this are dropped at load time; the Discord message itself is KEPT (an
+// offline embed is a final record — only the tracking stops).
+const DEFAULT_PRUNE_AFTER_MS = 86_400_000 // 24h
 
 // Embed sidebar color defaults — ported from claude-code-notify
 // (colors.conf.example + the CLAUDE_NOTIFY_*_COLOR defaults).
@@ -154,6 +165,10 @@ export class DiscordWebhookSink extends NotificationSink {
    * @param {number} [opts.heartbeatIntervalMs] - Elapsed-time refresh PATCH
    *   interval. 0 disables; values below 10s fall back to the default
    *   (parity with the bash heartbeat's interval clamp).
+   * @param {number} [opts.pruneAfterMs] - Retention for state-store entries
+   *   (#5429/#5434): entries whose lastUpdateTs is older than this are
+   *   dropped at load time (the first load after init is the startup sweep).
+   *   0 disables pruning; invalid values fall back to the 24h default.
    * @param {Function} [opts.resolveWebhookUrl] - Injection seam for tests;
    *   defaults to the env > 0600-credentials.json resolver.
    * @param {Function} [opts.sleepImpl] - Injection seam for tests (429/backoff
@@ -169,6 +184,7 @@ export class DiscordWebhookSink extends NotificationSink {
     errorColor = DEFAULT_ERROR_COLOR,
     updateThrottleMs = 15_000,
     heartbeatIntervalMs = 300_000,
+    pruneAfterMs = DEFAULT_PRUNE_AFTER_MS,
     // Cached by default (#5427 review): isConfigured() is probed per
     // notification; the cache only re-reads credentials.json when its
     // mtime/size/mode or the env var changes.
@@ -187,6 +203,7 @@ export class DiscordWebhookSink extends NotificationSink {
     if (!Number.isFinite(heartbeatIntervalMs) || heartbeatIntervalMs < 0) heartbeatIntervalMs = 300_000
     if (heartbeatIntervalMs > 0 && heartbeatIntervalMs < 10_000) heartbeatIntervalMs = 300_000
     this._heartbeatIntervalMs = heartbeatIntervalMs
+    this._pruneAfterMs = Number.isFinite(pruneAfterMs) && pruneAfterMs >= 0 ? pruneAfterMs : DEFAULT_PRUNE_AFTER_MS
     this._resolveWebhookUrl = resolveWebhookUrl
     this._sleep = sleepImpl
     this._now = now
@@ -239,15 +256,45 @@ export class DiscordWebhookSink extends NotificationSink {
    * over cached copies.
    */
   _loadState() {
+    let store = { version: 1, projects: {} }
     try {
       const data = JSON.parse(readFileSync(this._resolvedStatePath(), 'utf-8'))
       if (data && typeof data === 'object' && data.projects && typeof data.projects === 'object') {
-        return { version: 1, projects: data.projects }
+        store = { version: 1, projects: data.projects }
       }
     } catch {
       // Missing or corrupt — start fresh; the next successful send rewrites it.
     }
-    return { version: 1, projects: {} }
+    // #5429/#5434: retention sweep on every load — the first load after init
+    // doubles as the startup sweep, and every send/heartbeat afterwards keeps
+    // the store (and the heartbeat's per-tick work) bounded to live projects.
+    // Persisting here reuses the atomic 0600 path, so the pruned file is
+    // durable even when the caller's own persist never fires (throttled
+    // sends, no-op heartbeat ticks).
+    if (this._pruneStale(store)) this._persistState(store)
+    return store
+  }
+
+  /**
+   * Drop entries untouched for longer than the retention (and entries with
+   * no usable lastUpdateTs — corrupt slots must not accumulate forever).
+   * The Discord message is deliberately NOT deleted: a pruned entry's last
+   * embed (typically a final offline one) stays in the channel as a record;
+   * chroxy just stops tracking and refreshing it. Returns true when the
+   * store was mutated. Disabled when pruneAfterMs is 0.
+   */
+  _pruneStale(store) {
+    if (this._pruneAfterMs === 0) return false
+    const now = this._now()
+    let pruned = false
+    for (const [project, entry] of Object.entries(store.projects)) {
+      const last = entry?.lastUpdateTs
+      if (!Number.isFinite(last) || now - last > this._pruneAfterMs) {
+        delete store.projects[project]
+        pruned = true
+      }
+    }
+    return pruned
   }
 
   /** Atomic persist (temp+rename, 0600) — mirrors how push.js persists tokens. */
@@ -580,7 +627,14 @@ export class DiscordWebhookSink extends NotificationSink {
     this._heartbeatTimer.unref?.()
   }
 
-  /** One heartbeat pass: refresh each tracked project's embed in place. */
+  /**
+   * One heartbeat pass: refresh each LIVE project's embed in place.
+   * Offline entries are skipped (#5434) — the offline embed is final, and
+   * re-PATCHing it would both keep its elapsed-time footer counting up
+   * forever and spend a Discord call per dead project per tick. Stale
+   * entries never even reach the loop: _loadState prunes them, so the
+   * tick's work is bounded to live projects.
+   */
   async _heartbeatTick() {
     const webhookUrl = this._configuredUrl()
     if (!webhookUrl) return
@@ -588,7 +642,7 @@ export class DiscordWebhookSink extends NotificationSink {
     const store = this._loadState()
     let mutated = false
     for (const [project, entry] of Object.entries(store.projects)) {
-      if (!entry?.messageId) continue
+      if (!entry?.messageId || entry.state === 'offline') continue
       try {
         const res = await this._discordFetch(`${base}/messages/${entry.messageId}`, {
           method: 'PATCH',

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -654,10 +654,17 @@ describe('config — notifications.discord block (#5413)', () => {
           errorColor: 15158332,
           updateThrottleMs: 15000,
           heartbeatIntervalMs: 300000,
+          pruneAfterMs: 86400000,
         },
       },
     })
     assert.equal(result.valid, true, JSON.stringify(result.warnings))
+  })
+
+  it('warns on an invalid pruneAfterMs (value warning, never fatal)', () => {
+    const result = validateConfig({ notifications: { discord: { pruneAfterMs: -1 } } })
+    assert.ok(result.warnings.some((w) => w.includes('pruneAfterMs')))
+    assert.ok(!result.warnings.some((w) => w.startsWith('Invalid type')))
   })
 
   it('does not flag notifications as an unknown key', () => {
@@ -822,5 +829,143 @@ describe('DiscordWebhookSink — online/offline lifecycle (#5413 Phase 3)', () =
     const calls = scriptFetch()
     assert.equal(await sink.send({ category: 'mystery', title: 't', body: 'b', data: {} }), true)
     assert.equal(calls.length, 0)
+  })
+})
+
+// #5429 / #5434 — stale-entry pruning. Entries in discord-webhook-state.json
+// accumulated forever (one per project key / session id), and the heartbeat
+// PATCHed every tracked entry — including final `offline` embeds —
+// indefinitely. Pins:
+//   - the heartbeat skips offline entries (the offline embed is final)
+//   - entries untouched longer than `pruneAfterMs` are dropped at load time
+//     (the startup sweep is the first load after init) and the pruned store
+//     persists via the same atomic 0600 path
+//   - the Discord message is KEPT (no DELETE) — only the tracking stops
+//   - retention is configurable; 0 disables; fresh entries are untouched
+describe('DiscordWebhookSink — stale-entry pruning (#5429 / #5434)', () => {
+  const DAY_MS = 86_400_000
+  const online = (data = {}) => ({
+    category: 'session_online',
+    title: 'Session online',
+    body: 'External session started',
+    data: { project: 'proj1', ...data },
+  })
+  const offline = (data = {}) => ({
+    category: 'session_offline',
+    title: 'Session offline',
+    body: 'External session ended',
+    data: { project: 'proj1', ...data },
+  })
+
+  it('the heartbeat skips offline entries (the final embed is never re-PATCHed)', async () => {
+    const { sink, advance } = makeSink()
+    scriptFetch([
+      { status: 200, body: { id: 'm-proj1' } }, // POST proj1 online
+      { status: 200, body: { id: 'm-live' } },  // POST live online
+      { status: 200 },                          // PATCH proj1 offline
+    ])
+    await sink.send(online())
+    await sink.send(online({ project: 'live' }))
+    advance(60_000)
+    await sink.send(offline())
+    const calls = scriptFetch()
+    await sink._heartbeatTick()
+    const patches = calls.filter((c) => c.method === 'PATCH')
+    assert.equal(patches.length, 1, 'only the live project is refreshed')
+    assert.ok(patches[0].url.endsWith('/messages/m-live'))
+    assert.ok(!calls.some((c) => c.url.endsWith('/messages/m-proj1')), 'offline embed left alone')
+  })
+
+  it('an entry offline longer than the retention is pruned; the Discord message is kept (no DELETE)', async () => {
+    const { sink, statePath, advance } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }, { status: 200 }])
+    await sink.send(online())
+    advance(60_000)
+    await sink.send(offline())
+    assert.equal(readState(statePath).projects.proj1.state, 'offline')
+    advance(DAY_MS + 1)
+    const calls = scriptFetch([{ status: 200, body: { id: 'm-beta' } }])
+    await sink.send(idle({ sessionName: 'beta' }))
+    const { projects } = readState(statePath)
+    assert.equal(projects.proj1, undefined, 'offline entry pruned after the retention')
+    assert.equal(projects.beta.messageId, 'm-beta', 'fresh entry tracked normally')
+    assert.ok(!calls.some((c) => c.method === 'DELETE'), 'the final offline message is never deleted')
+  })
+
+  it('startup sweep: a new sink drops ancient and corrupt entries from a pre-existing state file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'discord-sink-'))
+    const statePath = join(dir, 'state.json')
+    const NOW = 200_000_000
+    writeFileSync(statePath, JSON.stringify({
+      version: 1,
+      projects: {
+        ancient: { messageId: 'm-ancient', state: 'idle', lastUpdateTs: NOW - DAY_MS - 1, firstSeenTs: 1 },
+        corrupt: { messageId: 'm-corrupt', state: 'idle' }, // no lastUpdateTs at all
+        fresh: { messageId: 'm-fresh', state: 'online', lastUpdateTs: NOW - 10_000, firstSeenTs: NOW - 10_000 },
+      },
+    }))
+    const sink = new DiscordWebhookSink({
+      statePath,
+      resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+      sleepImpl: async () => {},
+      heartbeatIntervalMs: 0,
+      now: () => NOW,
+    })
+    const calls = scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    const { projects } = readState(statePath)
+    assert.equal(projects.ancient, undefined, 'ancient entry swept')
+    assert.equal(projects.corrupt, undefined, 'entry without a usable lastUpdateTs swept')
+    assert.ok(projects.fresh, 'fresh entry survives the sweep')
+    const patches = calls.filter((c) => c.method === 'PATCH')
+    assert.equal(patches.length, 1, 'heartbeat work bounded to live entries')
+    assert.ok(patches[0].url.endsWith('/messages/m-fresh'))
+  })
+
+  it('the retention is configurable via pruneAfterMs', async () => {
+    const { sink, statePath, advance } = makeSink({ pruneAfterMs: 60_000 })
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(errored())
+    advance(30_000)
+    assert.ok(sink._loadState().projects.alpha, 'entry younger than the retention is untouched')
+    advance(30_001)
+    assert.equal(sink._loadState().projects.alpha, undefined, 'entry older than the custom retention pruned')
+    assert.equal(readState(statePath).projects.alpha, undefined, 'pruned store persisted')
+  })
+
+  it('entries younger than the default 24h retention are untouched', async () => {
+    const { sink, advance } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }, { status: 200 }])
+    await sink.send(online())
+    advance(60_000)
+    await sink.send(offline())
+    advance(DAY_MS - 120_000) // ~23h58m after the offline PATCH — inside retention
+    assert.equal(sink._loadState().projects.proj1.state, 'offline', 'recent offline entry retained')
+  })
+
+  it('pruneAfterMs: 0 disables pruning entirely', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'discord-sink-'))
+    const statePath = join(dir, 'state.json')
+    const NOW = 200_000_000
+    writeFileSync(statePath, JSON.stringify({
+      version: 1,
+      projects: { ancient: { messageId: 'm1', state: 'idle', lastUpdateTs: NOW - 10 * DAY_MS } },
+    }))
+    const sink = new DiscordWebhookSink({
+      statePath,
+      resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+      sleepImpl: async () => {},
+      heartbeatIntervalMs: 0,
+      pruneAfterMs: 0,
+      now: () => NOW,
+    })
+    assert.ok(sink._loadState().projects.ancient, 'nothing pruned when disabled')
+  })
+
+  it('an invalid pruneAfterMs falls back to the default retention', () => {
+    const { sink } = makeSink({ pruneAfterMs: -5 })
+    assert.equal(sink._pruneAfterMs, DAY_MS)
+    const { sink: sink2 } = makeSink({ pruneAfterMs: 'soon' })
+    assert.equal(sink2._pruneAfterMs, DAY_MS)
   })
 })

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -968,4 +968,17 @@ describe('DiscordWebhookSink — stale-entry pruning (#5429 / #5434)', () => {
     const { sink: sink2 } = makeSink({ pruneAfterMs: 'soon' })
     assert.equal(sink2._pruneAfterMs, DAY_MS)
   })
+
+  it('a state file whose projects slot is an array is treated as corrupt (fresh map, tracking persists)', async () => {
+    // typeof [] === 'object', but JSON.stringify drops string-keyed entries
+    // assigned onto an array — accepting the array would wedge tracking
+    // (every persist silently loses the messageId).
+    const { sink, statePath } = makeSink()
+    writeFileSync(statePath, JSON.stringify({ version: 1, projects: [] }))
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(errored())
+    const { projects } = readState(statePath)
+    assert.ok(!Array.isArray(projects), 'projects persists as a map, not an array')
+    assert.equal(projects.alpha.messageId, 'm1', 'entry tracked despite the corrupt array slot')
+  })
 })


### PR DESCRIPTION
## Summary

`DiscordWebhookSink` never removed entries from `discord-webhook-state.json`, so the file grew one slot per project key forever (session-id fallback keys + #5432's arbitrary ingest project names), and the unref'd heartbeat PATCHed every tracked entry — including final `offline` embeds — indefinitely, refreshing a dead embed's elapsed-time footer and spending a Discord call per historical project per tick.

## Changes

- **Retention sweep at load time** — `_loadState()` now runs `_pruneStale()`: entries whose `lastUpdateTs` is older than the retention (or missing/non-finite — corrupt slots) are dropped. The first load after init doubles as the startup sweep; every subsequent send/heartbeat load keeps the store bounded. When the sweep removes anything, the pruned store persists immediately through the existing atomic temp+rename `writeFileRestricted` path (0600).
- **Message kept, tracking stopped** — pruning never DELETEs the Discord message: the final embed (typically the offline one) stays in the channel as a record; chroxy just stops refreshing it.
- **Heartbeat bounded to live projects** — `_heartbeatTick()` skips entries in `offline` state (the embed is final, per #5434), and stale entries never reach the loop because the load already pruned them.
- **Config knob** — `notifications.discord.pruneAfterMs` (default `86400000` / 24h; `0` disables; invalid values fall back to the default), validated next to `updateThrottleMs`/`heartbeatIntervalMs` with the same non-fatal "Invalid value" wording, and documented in `packages/server/CONFIG.md` + `docs/guides/discord-notifications.md`.

## Tests

TDD — the new pruning suite was written first and confirmed RED on unmodified main (heartbeat PATCHed the offline entry; entries persisted past the retention; 63/63 pre-existing tests stayed green, so failures were behavioral, not environmental). After the fix:

- `tests/discord-webhook-sink.test.js` + `tests/notification-sinks.test.js` + `tests/push.test.js`: **122/122 pass, exit 0** (Node 22, `--import ./tests/_setup.mjs --experimental-test-module-mocks --test-force-exit`).
- New coverage: heartbeat skips offline entries while still refreshing live ones; offline entry pruned after retention with no DELETE issued; startup sweep drops ancient + corrupt (no `lastUpdateTs`) entries from a pre-existing state file and bounds the tick to live entries; retention configurable; fresh entries untouched at default retention; `pruneAfterMs: 0` disables; invalid values fall back to 24h; config validation accepts/warns appropriately.
- `lint-logger-session-scoping.sh`, `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`, eslint: all clean.

Closes #5434.
Closes #5429.
