### PR TITLE
feat(server): warn on non-loopback bind and public quick tunnel

### DIFF
--- a/docs/security/bearer-token-authority.md
+++ b/docs/security/bearer-token-authority.md
@@ -142,7 +142,29 @@ Before merging any PR that adds a new HTTP route or WebSocket message handler th
 4. **Never log raw tokens.** `maskToken()` exists for a reason.
 5. **Use `safeTokenCompare()`** for any byte-equality check against a token.
 
-## 10. Known Risks
+## 10. LAN-Bind Unauthenticated Surface (#5356)
+
+By default the server binds **all interfaces** (`resolveBindHost()` in [`packages/server/src/bind-host.js`](../../packages/server/src/bind-host.js) returns `undefined` unless `--no-auth` or an explicit `host` is set, so `httpServer.listen(port)` binds `0.0.0.0`). Every device on the local network can therefore reach the HTTP/WS socket. Possession of a bearer token remains the authorization boundary — but the following is reachable **without any token**:
+
+| Surface | What it leaks / allows |
+|---|---|
+| `GET /`, `GET /health` | `{ status, mode, version }` — fingerprints a running chroxy daemon and its exact version. This is the same probe the mobile app's LAN scanner uses, so it is also what a hostile subnet scan finds. |
+| `GET /dashboard/*`, `GET /assets/xterm/*` | Static dashboard shell + JS only; no session data without a token. |
+| WS pre-auth | `auth` (256-bit token, constant-time compare, exponential-backoff lockout) and `pair` (live 60-second, single-use, ~96-bit pairing ID) attempts; 10s pre-auth timeout, pre-auth connection cap. |
+| `POST /api/events`, `GET /diagnostics` | Pre-auth per-IP rate limit, then secret-/bearer-gated (see §6). |
+
+So the unauthenticated blast radius on a LAN bind is **service fingerprinting (existence + version) plus an online brute-force surface** — not session access. Note also that direct LAN connections use `ws://` (no TLS), so when LAN mode is actually used the token travels plaintext on the local network — see [`encryption-threat-model.md` §8](encryption-threat-model.md).
+
+Mitigations / visibility:
+
+- **Opt-in loopback bind**: `--host 127.0.0.1`, `CHROXY_HOST=127.0.0.1`, or `"host": "127.0.0.1"` in `~/.chroxy/config.json` restricts the socket to the local machine. The Cloudflare tunnel is unaffected (cloudflared dials `http://localhost:<port>`); only mobile LAN mode and LAN-client flows need a non-loopback bind.
+- **Startup warning** (`maybeWarnNonLoopbackBind()` in `bind-host.js`): one `log.warn` whenever the server binds non-loopback, naming the bind address and the restriction knob.
+- **Quick-tunnel warning**: when a public trycloudflare quick tunnel comes up, the tunnel adapter warns that the URL is internet-reachable (bearer-gated, but fingerprintable).
+- **Dashboard banner**: the auth_ok `exposure` snapshot (`{ lanBind, bindHost, quickTunnel }`) drives a dismissible dashboard warning banner reflecting the same two conditions.
+
+Whether the *defaults* should change (loopback-by-default for the desktop app, explicit tunnel choice in the wizard) is tracked in issue #5356 and deliberately not decided here.
+
+## 11. Known Risks
 
 - **Static primary token is the default.** The QR shown at startup encodes an ephemeral pairing URL (not the primary token), so the leak surface is the OS keychain entry, a fallback `~/.chroxy/config.json` on systems without keychain support, or any environment / launcher that surfaces the token in process listings. If any of those are exfiltrated, the attacker has full authority until the user rotates. Rotation is opt-in.
 - **No certificate pinning or out-of-band key verification.** See [`encryption-threat-model.md` §8 — Trust On First Use](encryption-threat-model.md#trust-on-first-use-tofu).

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -52,6 +52,7 @@ import { ResumeUnknownChip } from './components/ResumeUnknownChip'
 import { SessionNotFoundChip } from './components/SessionNotFoundChip'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
+import { ExposureWarningBanner } from './components/ExposureWarningBanner'
 import { ConnectionAnnouncer } from './components/ConnectionAnnouncer'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
@@ -298,6 +299,10 @@ export function App() {
   const connectionError = useConnectionStore(s => s.connectionError)
   const serverPhase = useConnectionStore(s => s.serverPhase)
   const tunnelProgress = useConnectionStore(s => s.tunnelProgress)
+  // #5356: exposure snapshot from auth_ok + per-connection dismissal flag.
+  const serverExposure = useConnectionStore(s => s.serverExposure)
+  const exposureBannerDismissed = useConnectionStore(s => s.exposureBannerDismissed)
+  const dismissExposureBanner = useConnectionStore(s => s.dismissExposureBanner)
   const serverStartupLogs = useConnectionStore(s => s.serverStartupLogs)
   const connectionRetryCount = useConnectionStore(s => s.connectionRetryCount)
   const filePickerFiles = useConnectionStore(s => s.filePickerFiles)
@@ -2121,6 +2126,17 @@ export function App() {
           </>
         ) : null}
       </div>
+
+      {/* Exposure warning banner (#5356) — server reported a non-loopback
+          bind and/or a public quick tunnel in auth_ok. Dismissible per
+          connection; no defaults are changed by this banner. */}
+      {serverExposure && !exposureBannerDismissed && (
+        <ExposureWarningBanner
+          lanBind={serverExposure.lanBind}
+          quickTunnel={serverExposure.quickTunnel}
+          onDismiss={dismissExposureBanner}
+        />
+      )}
 
       {/* Header */}
       <header id="header">

--- a/packages/dashboard/src/components/ExposureWarningBanner.test.tsx
+++ b/packages/dashboard/src/components/ExposureWarningBanner.test.tsx
@@ -30,7 +30,8 @@ describe('ExposureWarningBanner', () => {
   it('renders the quick-tunnel warning', () => {
     render(<ExposureWarningBanner lanBind={false} quickTunnel onDismiss={vi.fn()} />)
     const message = screen.getByTestId('exposure-warning-message')
-    expect(message.textContent).toMatch(/quick tunnel is publicly reachable/i)
+    expect(message.textContent).toMatch(/public quick tunnel is configured/i)
+    expect(message.textContent).toMatch(/once established/i)
     expect(message.textContent).toMatch(/bearer-token gated/i)
     expect(message.textContent).not.toMatch(/all network interfaces/i)
   })
@@ -39,7 +40,7 @@ describe('ExposureWarningBanner', () => {
     render(<ExposureWarningBanner lanBind quickTunnel onDismiss={vi.fn()} />)
     const message = screen.getByTestId('exposure-warning-message')
     expect(message.textContent).toMatch(/all network interfaces/i)
-    expect(message.textContent).toMatch(/quick tunnel is publicly reachable/i)
+    expect(message.textContent).toMatch(/public quick tunnel is configured/i)
   })
 
   it('calls onDismiss when the dismiss button is clicked', () => {

--- a/packages/dashboard/src/components/ExposureWarningBanner.test.tsx
+++ b/packages/dashboard/src/components/ExposureWarningBanner.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ExposureWarningBanner tests (#5356, visibility layer)
+ *
+ * The banner renders when the server's auth_ok exposure snapshot reports a
+ * non-loopback bind (`lanBind`) and/or a public quick tunnel (`quickTunnel`),
+ * and is dismissible via the parent's onDismiss handler (which sets the
+ * store's `exposureBannerDismissed` flag).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ExposureWarningBanner } from './ExposureWarningBanner'
+
+afterEach(cleanup)
+
+describe('ExposureWarningBanner', () => {
+  it('renders nothing when neither condition is reported', () => {
+    render(<ExposureWarningBanner lanBind={false} quickTunnel={false} onDismiss={vi.fn()} />)
+    expect(screen.queryByTestId('exposure-warning-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders the LAN-bind warning with the restriction hint', () => {
+    render(<ExposureWarningBanner lanBind quickTunnel={false} onDismiss={vi.fn()} />)
+    expect(screen.getByTestId('exposure-warning-banner')).toBeInTheDocument()
+    const message = screen.getByTestId('exposure-warning-message')
+    expect(message.textContent).toMatch(/all network interfaces/i)
+    expect(message.textContent).toMatch(/--host 127\.0\.0\.1/)
+    expect(message.textContent).not.toMatch(/quick tunnel/i)
+  })
+
+  it('renders the quick-tunnel warning', () => {
+    render(<ExposureWarningBanner lanBind={false} quickTunnel onDismiss={vi.fn()} />)
+    const message = screen.getByTestId('exposure-warning-message')
+    expect(message.textContent).toMatch(/quick tunnel is publicly reachable/i)
+    expect(message.textContent).toMatch(/bearer-token gated/i)
+    expect(message.textContent).not.toMatch(/all network interfaces/i)
+  })
+
+  it('renders both warnings when both conditions are reported', () => {
+    render(<ExposureWarningBanner lanBind quickTunnel onDismiss={vi.fn()} />)
+    const message = screen.getByTestId('exposure-warning-message')
+    expect(message.textContent).toMatch(/all network interfaces/i)
+    expect(message.textContent).toMatch(/quick tunnel is publicly reachable/i)
+  })
+
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(<ExposureWarningBanner lanBind quickTunnel={false} onDismiss={onDismiss} />)
+    fireEvent.click(screen.getByTestId('exposure-dismiss-button'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses role="status" + aria-live="polite" (informative, not interruptive)', () => {
+    render(<ExposureWarningBanner lanBind quickTunnel={false} onDismiss={vi.fn()} />)
+    const banner = screen.getByTestId('exposure-warning-banner')
+    expect(banner).toHaveAttribute('role', 'status')
+    expect(banner).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/packages/dashboard/src/components/ExposureWarningBanner.tsx
+++ b/packages/dashboard/src/components/ExposureWarningBanner.tsx
@@ -1,0 +1,65 @@
+/**
+ * ExposureWarningBanner (#5356, visibility layer) — dismissible warning shown
+ * when the server reports an exposed network posture in its auth_ok
+ * `exposure` snapshot:
+ *
+ * - `lanBind`: the server is bound to a non-loopback interface (the
+ *   historical 0.0.0.0 default included), so devices on the local network
+ *   can reach its auth/pairing endpoints (bearer-gated, but the server is
+ *   fingerprintable via /health).
+ * - `quickTunnel`: a public trycloudflare quick tunnel is up, so the server
+ *   is internet-reachable at a random public URL (bearer-gated).
+ *
+ * This banner changes no defaults — it only surfaces the current posture and
+ * how to restrict it. Dismissal is per-connection (store flag, reset on a
+ * fresh non-reconnect auth); see `exposureBannerDismissed` in the store.
+ */
+
+export interface ExposureWarningBannerProps {
+  lanBind: boolean
+  quickTunnel: boolean
+  onDismiss: () => void
+}
+
+export function ExposureWarningBanner({ lanBind, quickTunnel, onDismiss }: ExposureWarningBannerProps) {
+  if (!lanBind && !quickTunnel) return null
+
+  const parts: string[] = []
+  if (lanBind) {
+    parts.push(
+      'Server is listening on all network interfaces — devices on your network can reach its auth and pairing endpoints. Restrict with --host 127.0.0.1.',
+    )
+  }
+  if (quickTunnel) {
+    parts.push(
+      'Quick tunnel is publicly reachable — anyone with the URL can probe this server (bearer-token gated). Use --tunnel none or --tunnel named to change this.',
+    )
+  }
+
+  return (
+    // role="status" + aria-live="polite" per the dashboard convention
+    // (see StdinDisabledBanner / Toast): a posture warning is informative,
+    // not an emergency interruption.
+    <div
+      className="exposure-warning-banner"
+      data-testid="exposure-warning-banner"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="exposure-warning-icon" aria-hidden="true">
+        !
+      </span>
+      <span className="exposure-warning-message" data-testid="exposure-warning-message">
+        {parts.join(' ')}
+      </span>
+      <button
+        className="btn-retry"
+        data-testid="exposure-dismiss-button"
+        onClick={onDismiss}
+        type="button"
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ExposureWarningBanner.tsx
+++ b/packages/dashboard/src/components/ExposureWarningBanner.tsx
@@ -7,8 +7,10 @@
  *   historical 0.0.0.0 default included), so devices on the local network
  *   can reach its auth/pairing endpoints (bearer-gated, but the server is
  *   fingerprintable via /health).
- * - `quickTunnel`: a public trycloudflare quick tunnel is up, so the server
- *   is internet-reachable at a random public URL (bearer-gated).
+ * - `quickTunnel`: a public trycloudflare quick tunnel is configured —
+ *   recorded by the server before tunnel startup, so this is a posture
+ *   signal, not proof the tunnel is established. Once it comes up, the
+ *   server is internet-reachable at a random public URL (bearer-gated).
  *
  * This banner changes no defaults — it only surfaces the current posture and
  * how to restrict it. Dismissal is per-connection (store flag, reset on a
@@ -32,7 +34,7 @@ export function ExposureWarningBanner({ lanBind, quickTunnel, onDismiss }: Expos
   }
   if (quickTunnel) {
     parts.push(
-      'Quick tunnel is publicly reachable — anyone with the URL can probe this server (bearer-token gated). Use --tunnel none or --tunnel named to change this.',
+      'A public quick tunnel is configured — once established, anyone with its URL can probe this server (bearer-token gated). Use --tunnel none or --tunnel named to change this.',
     )
   }
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -462,6 +462,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   resolvedPermissions: {},
   serverPhase: null,
   tunnelProgress: null,
+  // #5356: exposure snapshot from auth_ok + banner dismissal flag.
+  serverExposure: null,
+  exposureBannerDismissed: false,
   shutdownReason: null,
   restartEtaMs: null,
   restartingSince: null,
@@ -1445,6 +1448,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       resolvedPermissions: {},
       serverPhase: null,
       tunnelProgress: null,
+      // #5356: clear exposure on disconnect so a reconnect against a
+      // different server can't show a stale banner.
+      serverExposure: null,
+      exposureBannerDismissed: false,
       shutdownReason: null,
       restartEtaMs: null,
       restartingSince: null,
@@ -2629,6 +2636,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set((state) => ({
       serverErrors: state.serverErrors.filter((e) => e.id !== id),
     }));
+  },
+
+  // #5356: dismiss the exposure warning banner for this connection.
+  dismissExposureBanner: () => {
+    set({ exposureBannerDismissed: true });
   },
 
   addInfoNotification: (message: string) => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2124,6 +2124,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         get().updateServer(pairedServerId, { token: auth.sessionToken });
       }
 
+      // #5356: exposure snapshot (non-loopback bind / public quick tunnel).
+      // Read off the raw message — the auth_ok schema is passthrough and the
+      // shared parser predates the field. Absent/malformed → null (no banner).
+      const rawExposure = (msg as { exposure?: { lanBind?: unknown; quickTunnel?: unknown } }).exposure;
+      const serverExposure =
+        rawExposure && typeof rawExposure === 'object'
+          ? { lanBind: rawExposure.lanBind === true, quickTunnel: rawExposure.quickTunnel === true }
+          : null;
+
       // On reconnect, preserve messages and terminal buffer
       const connectedState = {
         connectionPhase: 'connected' as const,
@@ -2149,6 +2158,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // Clear shutdown / startup state on successful connect
         serverPhase: null,
         tunnelProgress: null,
+        serverExposure,
         shutdownReason: null,
         restartEtaMs: null,
         restartingSince: null,
@@ -2160,6 +2170,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       } else {
         set({
           ...connectedState,
+          // #5356: a fresh (non-reconnect) connection re-surfaces the
+          // exposure banner; silent reconnects keep the user's dismissal.
+          exposureBannerDismissed: false,
           messages: [],
           terminalBuffer: '',
           terminalRawBuffer: '',
@@ -3073,10 +3086,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         break;
       }
       if (phase === 'ready') {
-        set({
+        const readyPatch: Partial<ConnectionState> = {
           serverPhase: 'ready',
           tunnelProgress: null,
-        } as Partial<ConnectionState>);
+        };
+        // #5356: a quick tunnel coming up mid-connection makes the server
+        // publicly reachable — merge into the exposure snapshot so the
+        // warning banner appears even when auth_ok predated the tunnel.
+        if ((msg as { tunnelMode?: unknown }).tunnelMode === 'quick') {
+          const prevExposure = get().serverExposure;
+          readyPatch.serverExposure = {
+            lanBind: prevExposure?.lanBind ?? false,
+            quickTunnel: true,
+          };
+        }
+        set(readyPatch);
         break;
       }
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -677,10 +677,13 @@ export interface ConnectionState {
 
   // #5356: exposure snapshot from auth_ok (`lanBind` = server bound to a
   // non-loopback interface so LAN peers can reach its auth/pairing
-  // endpoints; `quickTunnel` = a public trycloudflare quick tunnel is up).
+  // endpoints; `quickTunnel` = a public trycloudflare quick tunnel is
+  // CONFIGURED — the server records it before tunnel startup, so treat it
+  // as a posture signal, not proof the tunnel is established).
   // null = server didn't report (pre-#5356 server) — no banner. quickTunnel
   // is also flipped true by a `server_status { phase: 'ready',
-  // tunnelMode: 'quick' }` broadcast for clients that connected mid-warming.
+  // tunnelMode: 'quick' }` broadcast (which DOES mean the tunnel is live)
+  // for clients that connected mid-warming.
   serverExposure: { lanBind: boolean; quickTunnel: boolean } | null;
   // #5356: user dismissed the exposure warning banner. Reset on a fresh
   // (non-reconnect) auth so a new connection re-surfaces the warning, but

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -675,6 +675,19 @@ export interface ConnectionState {
   serverPhase: 'tunnel_warming' | 'tunnel_verifying' | 'ready' | null;
   tunnelProgress: { attempt: number; maxAttempts: number } | null;
 
+  // #5356: exposure snapshot from auth_ok (`lanBind` = server bound to a
+  // non-loopback interface so LAN peers can reach its auth/pairing
+  // endpoints; `quickTunnel` = a public trycloudflare quick tunnel is up).
+  // null = server didn't report (pre-#5356 server) — no banner. quickTunnel
+  // is also flipped true by a `server_status { phase: 'ready',
+  // tunnelMode: 'quick' }` broadcast for clients that connected mid-warming.
+  serverExposure: { lanBind: boolean; quickTunnel: boolean } | null;
+  // #5356: user dismissed the exposure warning banner. Reset on a fresh
+  // (non-reconnect) auth so a new connection re-surfaces the warning, but
+  // preserved across silent reconnects to the same server.
+  exposureBannerDismissed: boolean;
+  dismissExposureBanner: () => void;
+
   // Shutdown state (reason + ETA for restarting banner countdown)
   shutdownReason: 'restart' | 'shutdown' | 'crash' | null;
   restartEtaMs: number | null;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -28,8 +28,9 @@
 #app.with-sidebar {
   display: grid;
   grid-template-columns: auto 1fr;
-  /* Rows: reconnect-banner, tunnel-warming-banner, header, content (sidebar+main), footer-bar. */
-  grid-template-rows: auto auto auto 1fr auto;
+  /* Rows: reconnect-banner, tunnel-warming-banner, exposure-warning-banner,
+     header, content (sidebar+main), footer-bar. */
+  grid-template-rows: auto auto auto auto 1fr auto;
 }
 
 #app.with-sidebar > .reconnect-banner {
@@ -38,26 +39,33 @@
 }
 
 /* Tunnel-warming banner must span full width above the header. Without explicit
-   grid placement it auto-places into row 4 col 1 (under the sidebar only),
-   producing an asymmetric strip that pushes the sidebar/chat columns out of
-   alignment when the banner expands from max-height: 0 to 2rem. */
+   grid placement it auto-places into the content row col 1 (under the sidebar
+   only), producing an asymmetric strip that pushes the sidebar/chat columns out
+   of alignment when the banner expands from max-height: 0 to 2rem. */
 #app.with-sidebar > .tunnel-warming-banner {
   grid-row: 2;
   grid-column: 1 / -1;
 }
 
-#app.with-sidebar > header {
+/* Exposure warning banner (#5356) — same full-width treatment; the row
+   collapses to 0 when the banner isn't rendered. */
+#app.with-sidebar > .exposure-warning-banner {
   grid-row: 3;
   grid-column: 1 / -1;
 }
 
-#app.with-sidebar > .sidebar {
+#app.with-sidebar > header {
   grid-row: 4;
+  grid-column: 1 / -1;
+}
+
+#app.with-sidebar > .sidebar {
+  grid-row: 5;
   grid-column: 1;
 }
 
 #app.with-sidebar > .main-wrapper {
-  grid-row: 4;
+  grid-row: 5;
   grid-column: 2;
   display: flex;
   flex-direction: column;
@@ -65,10 +73,10 @@
   min-width: 0;
 }
 
-/* Explicit row 5 placement so future in-flow children don't accidentally
+/* Explicit last-row placement so future in-flow children don't accidentally
    shift the footer's auto-placement target (Copilot review #3177). */
 #app.with-sidebar > .footer-bar {
-  grid-row: 5;
+  grid-row: 6;
   grid-column: 1 / -1;
 }
 
@@ -3245,6 +3253,41 @@ button.sidebar-token-view-session-row:hover {
 }
 
 .stdin-disabled-banner-message {
+  flex: 1;
+}
+
+/* ---- Exposure Warning Banner (#5356) ----
+   Dismissible warning when the server reports a non-loopback bind and/or a
+   public quick tunnel in its auth_ok exposure snapshot. Visual language
+   mirrors the stdin-disabled banner (orange caution band). */
+.exposure-warning-banner {
+  background: #3b2010;
+  color: var(--accent-orange);
+  padding: 8px 12px;
+  font-size: var(--text-base);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent-orange) 30%, transparent);
+}
+
+.exposure-warning-icon {
+  flex-shrink: 0;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent-orange);
+  color: var(--bg-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.exposure-warning-message {
   flex: 1;
 }
 

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -59,6 +59,11 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
     resultTimeoutMs: z.ZodOptional<z.ZodNumber>;
     hardTimeoutMs: z.ZodOptional<z.ZodNumber>;
     streamStallTimeoutMs: z.ZodOptional<z.ZodNumber>;
+    exposure: z.ZodOptional<z.ZodObject<{
+        lanBind: z.ZodBoolean;
+        bindHost: z.ZodNullable<z.ZodString>;
+        quickTunnel: z.ZodBoolean;
+    }, z.core.$strip>>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -91,6 +91,20 @@ export const ServerAuthOkSchema = z.object({
     // constant is `DEFAULT_STREAM_STALL_TIMEOUT_MS` exported from
     // `base-session.js` but is not re-exported from this package.
     streamStallTimeoutMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
+    // #5356 (visibility layer): exposure snapshot so clients can warn about the
+    // server's network posture. `lanBind` = the HTTP/WS socket is bound to a
+    // non-loopback interface (the historical 0.0.0.0 default included), so LAN
+    // peers can reach the unauthenticated surface (/health fingerprint,
+    // dashboard assets, rate-limited auth/pairing attempts). `quickTunnel` =
+    // a public trycloudflare quick tunnel is configured, so the server is
+    // internet-reachable at a random public URL (bearer-gated). `bindHost` is
+    // the literal address passed to listen(). Optional — servers from before
+    // #5356 don't emit it, and clients treat absence as "unknown" (no banner).
+    exposure: z.object({
+        lanBind: z.boolean(),
+        bindHost: z.string().nullable(),
+        quickTunnel: z.boolean(),
+    }).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -94,6 +94,20 @@ export const ServerAuthOkSchema = z.object({
   // constant is `DEFAULT_STREAM_STALL_TIMEOUT_MS` exported from
   // `base-session.js` but is not re-exported from this package.
   streamStallTimeoutMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
+  // #5356 (visibility layer): exposure snapshot so clients can warn about the
+  // server's network posture. `lanBind` = the HTTP/WS socket is bound to a
+  // non-loopback interface (the historical 0.0.0.0 default included), so LAN
+  // peers can reach the unauthenticated surface (/health fingerprint,
+  // dashboard assets, rate-limited auth/pairing attempts). `quickTunnel` =
+  // a public trycloudflare quick tunnel is configured, so the server is
+  // internet-reachable at a random public URL (bearer-gated). `bindHost` is
+  // the literal address passed to listen(). Optional — servers from before
+  // #5356 don't emit it, and clients treat absence as "unknown" (no banner).
+  exposure: z.object({
+    lanBind: z.boolean(),
+    bindHost: z.string().nullable(),
+    quickTunnel: z.boolean(),
+  }).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({

--- a/packages/server/src/bind-host.js
+++ b/packages/server/src/bind-host.js
@@ -76,7 +76,7 @@ export function maybeWarnNonLoopbackBind({ bindHost, log }) {
   log.warn(
     `Listening on ${shown} — devices on your local network can reach this server's ` +
     'auth and pairing endpoints (bearer-token gated, but the server is fingerprintable via /health). ' +
-    'To restrict to this machine only, start with --host 127.0.0.1 or set "host": "127.0.0.1" in ~/.chroxy/config.json'
+    'To restrict to this machine only, start with --host 127.0.0.1, set CHROXY_HOST=127.0.0.1, or set "host": "127.0.0.1" in ~/.chroxy/config.json'
   )
   return true
 }

--- a/packages/server/src/bind-host.js
+++ b/packages/server/src/bind-host.js
@@ -56,3 +56,27 @@ export function resolveBindHost({ noAuth, host } = {}) {
   if (typeof host === 'string' && host.length > 0) return host
   return undefined
 }
+
+/**
+ * #5356 (visibility layer): emit a single startup warning when the server is
+ * about to bind a non-loopback interface — the default `undefined` →
+ * 0.0.0.0 bind included. LAN peers can then reach the unauthenticated
+ * surface (`/health` fingerprint, dashboard assets, rate-limited auth and
+ * pairing attempts). This does NOT change any default — it only makes the
+ * existing posture visible and points at the existing restriction knob.
+ *
+ * @param {object} opts
+ * @param {string} [opts.bindHost] - resolved bind host (`undefined` = 0.0.0.0).
+ * @param {{ warn: (msg: string) => void }} opts.log - logger to warn through.
+ * @returns {boolean} true when the warning was emitted.
+ */
+export function maybeWarnNonLoopbackBind({ bindHost, log }) {
+  if (isLoopbackHost(bindHost)) return false
+  const shown = bindHost || '0.0.0.0 (all interfaces)'
+  log.warn(
+    `Listening on ${shown} — devices on your local network can reach this server's ` +
+    'auth and pairing endpoints (bearer-token gated, but the server is fingerprintable via /health). ' +
+    'To restrict to this machine only, start with --host 127.0.0.1 or set "host": "127.0.0.1" in ~/.chroxy/config.json'
+  )
+  return true
+}

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -28,7 +28,7 @@ import { removeConnectionInfo } from './connection-info.js'
 import { TokenManager } from './token-manager.js'
 import { PairingManager } from './pairing.js'
 import { getLanIp } from './lan-ip.js'
-import { resolveBindHost, isLoopbackHost, formatHostForUrl } from './bind-host.js'
+import { resolveBindHost, isLoopbackHost, formatHostForUrl, maybeWarnNonLoopbackBind } from './bind-host.js'
 import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { maybeEncryptCredentialsAtRest } from './credential-store.js'
@@ -87,14 +87,19 @@ export function buildTunnelWarmingStatus({ tunnelMode, tunnelUrl, attempt, maxAt
  * signals the dashboard banner to disappear and the tunnel URL to be
  * considered routable.
  *
- * @param {{ tunnelUrl: string }} args
+ * `tunnelMode` (#5356) lets clients that connected before the tunnel came up
+ * (whose auth_ok exposure snapshot predates it) learn that a public quick
+ * tunnel is now live. Optional so older callers/tests stay valid.
+ *
+ * @param {{ tunnelUrl: string, tunnelMode?: string }} args
  * @returns {object} WS message envelope
  */
-export function buildTunnelReadyStatus({ tunnelUrl }) {
+export function buildTunnelReadyStatus({ tunnelUrl, tunnelMode }) {
   return {
     type: 'server_status',
     phase: 'ready',
     tunnelUrl,
+    ...(tunnelMode ? { tunnelMode } : {}),
     message: 'Tunnel is ready',
   }
 }
@@ -806,6 +811,11 @@ export async function startCliServer(config) {
   // config.host (e.g. --host 127.0.0.1) binds that interface with auth still
   // on, and the default (undefined) binds 0.0.0.0 as before.
   const bindHost = resolveBindHost({ noAuth: NO_AUTH, host: config.host })
+  // #5356 (visibility layer): one warning when binding non-loopback (the
+  // default 0.0.0.0 included) — LAN peers can reach the unauthenticated
+  // surface (/health fingerprint, dashboard assets, rate-limited auth and
+  // pairing attempts). No default change; points at --host 127.0.0.1.
+  maybeWarnNonLoopbackBind({ bindHost, log })
   wsServer.start(bindHost)
 
   // #5053: wire the pool stats aggregator to the shared pool so the
@@ -867,6 +877,9 @@ export async function startCliServer(config) {
   const SKIP_TUNNEL = NO_AUTH || !tunnelArg || !!externalUrl
 
   if (!SKIP_TUNNEL) {
+    // #5356 (visibility layer): record quick-tunnel exposure before startup so
+    // the auth_ok exposure snapshot covers clients that connect mid-warming.
+    wsServer.setQuickTunnelActive(tunnelArg.mode === 'quick')
     // #5368 slice (c): the tunnel lifecycle (create + start + emergency-cleanup
     // on a start throw, wireTunnelEvents, tunnel_recovered re-verify + QR
     // re-render, waitForTunnel with warming/ready broadcasts + emergency-cleanup

--- a/packages/server/src/server-cli/tunnel-lifecycle-handler.js
+++ b/packages/server/src/server-cli/tunnel-lifecycle-handler.js
@@ -177,7 +177,7 @@ export class TunnelLifecycleHandler {
       await this._emergencyCleanup(this._cleanupBag(tunnel))
       return { ok: false, tunnel }
     }
-    wsServer.broadcastMinProtocolVersion(TUNNEL_STATUS_MIN_PROTOCOL_VERSION, this._buildTunnelReadyStatus({ tunnelUrl: httpUrl }))
+    wsServer.broadcastMinProtocolVersion(TUNNEL_STATUS_MIN_PROTOCOL_VERSION, this._buildTunnelReadyStatus({ tunnelUrl: httpUrl, tunnelMode: tunnelArg.mode }))
 
     // 7. Generate connection info (modeLabel computed up-front; see above)
     startupDisplay.currentTunnelMode = modeLabel

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -188,6 +188,15 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           const wsUrl = this.url.replace('https://', 'wss://')
 
           log.info(`Cloudflare tunnel established: HTTP=${this.url} WebSocket=${wsUrl}`)
+          // #5356 (visibility layer): a quick tunnel publishes the server on a
+          // public trycloudflare.com URL. Every endpoint stays bearer-token
+          // gated, but anyone who learns the URL can fingerprint the server
+          // via /health and attempt auth/pairing — make that visible once.
+          log.warn(
+            `Quick tunnel is publicly reachable at ${this.url} — endpoints are bearer-token gated, ` +
+            'but anyone with this URL can fingerprint the server via /health and attempt auth. ' +
+            'Use --tunnel none to disable remote access, or --tunnel named for a stable domain you control.'
+          )
 
           resolve({ httpUrl: this.url, wsUrl })
         }

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -105,6 +105,10 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // Optional — older callers (and most tests) leave this undefined and
     // get the legacy default/first behavior.
     devicePreferences,
+    // #5356: exposure snapshot ({ lanBind, bindHost, quickTunnel }) — null /
+    // undefined when the server hasn't bound a socket (test harnesses) or the
+    // ctx predates the field; the auth_ok field is omitted in that case.
+    exposure,
   } = ctx
   const client = clients.get(ws)
 
@@ -231,6 +235,9 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     resultTimeoutMs: effectiveResultTimeoutMs,
     hardTimeoutMs: effectiveHardTimeoutMs,
     streamStallTimeoutMs: effectiveStreamStallTimeoutMs,
+    // #5356: exposure snapshot for the dashboard warning banner. Optional on
+    // the wire — older servers omit it and clients treat that as "unknown".
+    ...(exposure ? { exposure } : {}),
     ...extra,
   })
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -27,6 +27,7 @@ import { PermissionAuditLog } from './permission-audit.js'
 import { WsBroadcaster } from './ws-broadcaster.js'
 import { WsClientManager } from './ws-client-manager.js'
 import { getProviderDataDirs } from './providers.js'
+import { isLoopbackHost } from './bind-host.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -484,6 +485,12 @@ export class WsServer {
     this._keyExchangeTimeoutMs = keyExchangeTimeoutMs ?? 10_000
     this._localhostBypass = localhostBypass ?? true
     this._maxPendingConnections = maxPendingConnections ?? 20
+    // #5356 (visibility layer): exposure snapshot surfaced in auth_ok so the
+    // dashboard can warn about non-loopback binds / public quick tunnels.
+    // _boundHost is set in start(); _quickTunnelActive by server-cli when a
+    // quick (trycloudflare) tunnel is configured.
+    this._boundHost = undefined
+    this._quickTunnelActive = false
     this._backpressureThreshold = backpressureThreshold ?? 1024 * 1024 // 1MB default
     this._backpressureMaxDrops = 10 // close connection after this many consecutive drops
     // #3996: name each limiter so eviction logs and /diagnostics
@@ -698,6 +705,10 @@ export class WsServer {
       // always supplies the default disk-backed store from the WsServer
       // constructor.
       get devicePreferences() { return self._devicePreferences },
+      // #5356: exposure snapshot (non-loopback bind / public quick tunnel)
+      // surfaced in auth_ok so the dashboard can render a warning banner.
+      // null until start() has bound a socket.
+      get exposure() { return self.exposure },
     }
     this._authCtx = {
       get clients() { return self.clients },
@@ -1066,7 +1077,35 @@ export class WsServer {
     if (secret) this._hookSecrets.delete(secret)
   }
 
+  /**
+   * #5356: record whether the configured tunnel is a public quick
+   * (trycloudflare) tunnel. Called by server-cli before tunnel startup so the
+   * exposure snapshot in auth_ok reflects the public URL.
+   * @param {boolean} active
+   */
+  setQuickTunnelActive(active) {
+    this._quickTunnelActive = !!active
+  }
+
+  /**
+   * #5356: exposure snapshot included in auth_ok (see sendPostAuthInfo).
+   * `null` until start() has bound a socket — test harnesses that never call
+   * start() simply omit the field from auth_ok.
+   * @returns {{ lanBind: boolean, bindHost: string, quickTunnel: boolean }|null}
+   */
+  get exposure() {
+    if (this._boundHost === undefined) return null
+    return {
+      lanBind: !isLoopbackHost(this._boundHost),
+      bindHost: this._boundHost,
+      quickTunnel: this._quickTunnelActive,
+    }
+  }
+
   start(host) {
+    // #5356: remember what we bound. `undefined` means the default
+    // all-interfaces bind — record it as 0.0.0.0 so exposure reads true.
+    this._boundHost = host ?? '0.0.0.0'
     // Create HTTP server — route handling extracted to http-routes.js
     this.httpServer = createServer(createHttpHandler(this))
 

--- a/packages/server/tests/bind-host.test.js
+++ b/packages/server/tests/bind-host.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { resolveBindHost, isLoopbackHost, formatHostForUrl } from '../src/bind-host.js'
+import { resolveBindHost, isLoopbackHost, formatHostForUrl, maybeWarnNonLoopbackBind } from '../src/bind-host.js'
 
 describe('isLoopbackHost', () => {
   it('treats 127.0.0.1 and the 127.0.0.0/8 range as loopback', () => {
@@ -69,5 +69,45 @@ describe('resolveBindHost', () => {
     assert.equal(resolveBindHost({ noAuth: false, host: '127.0.0.1' }), '127.0.0.1')
     assert.equal(resolveBindHost({ noAuth: false, host: '0.0.0.0' }), '0.0.0.0')
     assert.equal(resolveBindHost({ noAuth: false, host: '192.168.1.10' }), '192.168.1.10')
+  })
+})
+
+// #5356 (visibility layer): one startup warning when binding non-loopback.
+describe('maybeWarnNonLoopbackBind', () => {
+  function captureLogger() {
+    const warns = []
+    return { warns, log: { warn: (msg) => warns.push(msg) } }
+  }
+
+  it('warns once for the default undefined bind (0.0.0.0)', () => {
+    const { warns, log } = captureLogger()
+    assert.equal(maybeWarnNonLoopbackBind({ bindHost: undefined, log }), true)
+    assert.equal(warns.length, 1)
+    assert.match(warns[0], /0\.0\.0\.0 \(all interfaces\)/)
+  })
+
+  it('warns for an explicit 0.0.0.0 or LAN bind, naming the bind address', () => {
+    for (const bindHost of ['0.0.0.0', '192.168.1.10', '::']) {
+      const { warns, log } = captureLogger()
+      assert.equal(maybeWarnNonLoopbackBind({ bindHost, log }), true)
+      assert.equal(warns.length, 1)
+      assert.ok(warns[0].includes(bindHost), `warning names ${bindHost}: ${warns[0]}`)
+    }
+  })
+
+  it('says LAN peers can reach auth/pairing endpoints and how to restrict', () => {
+    const { warns, log } = captureLogger()
+    maybeWarnNonLoopbackBind({ bindHost: undefined, log })
+    assert.match(warns[0], /auth and pairing endpoints/)
+    assert.match(warns[0], /--host 127\.0\.0\.1/)
+    assert.match(warns[0], /config\.json/)
+  })
+
+  it('stays silent for loopback binds', () => {
+    for (const bindHost of ['127.0.0.1', '127.0.0.53', 'localhost', '::1']) {
+      const { warns, log } = captureLogger()
+      assert.equal(maybeWarnNonLoopbackBind({ bindHost, log }), false)
+      assert.equal(warns.length, 0, `no warning for ${bindHost}`)
+    }
   })
 })

--- a/packages/server/tests/bind-host.test.js
+++ b/packages/server/tests/bind-host.test.js
@@ -100,6 +100,7 @@ describe('maybeWarnNonLoopbackBind', () => {
     maybeWarnNonLoopbackBind({ bindHost: undefined, log })
     assert.match(warns[0], /auth and pairing endpoints/)
     assert.match(warns[0], /--host 127\.0\.0\.1/)
+    assert.match(warns[0], /CHROXY_HOST=127\.0\.0\.1/)
     assert.match(warns[0], /config\.json/)
   })
 

--- a/packages/server/tests/tunnel-warming-broadcast.test.js
+++ b/packages/server/tests/tunnel-warming-broadcast.test.js
@@ -89,6 +89,13 @@ describe('buildTunnelReadyStatus (production helper)', () => {
     assert.equal(msg.tunnelUrl, 'https://example.trycloudflare.com')
     assert.match(msg.message, /ready/i)
   })
+
+  it('passes tunnelMode through when provided, omits it otherwise (#5356)', () => {
+    const withMode = buildTunnelReadyStatus({ tunnelUrl: 'https://example.trycloudflare.com', tunnelMode: 'quick' })
+    assert.equal(withMode.tunnelMode, 'quick')
+    const withoutMode = buildTunnelReadyStatus({ tunnelUrl: 'https://example.trycloudflare.com' })
+    assert.ok(!('tunnelMode' in withoutMode))
+  })
 })
 
 describe('tunnel_warming broadcast sequencing via waitForTunnel.onAttempt', () => {

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test'
+import { describe, it, mock, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'events'
 import { CloudflareTunnelAdapter } from '../../src/tunnel/cloudflare.js'
@@ -404,5 +404,62 @@ describe('CloudflareTunnelAdapter', () => {
     it('has correct static name', () => {
       assert.equal(CloudflareTunnelAdapter.name, 'cloudflare')
     })
+  })
+})
+
+// #5356 (visibility layer): quick-tunnel startup emits one public-exposure
+// warning. The tunnel logger writes warn-level lines via console.warn, so the
+// warning is captured there (same pattern as tunnel-check-logging.test.js).
+describe('quick-tunnel public exposure warning (#5356)', () => {
+  afterEach(() => {
+    mock.restoreAll()
+  })
+
+  it('warns that the quick tunnel URL is publicly reachable', async () => {
+    const warns = []
+    mock.method(console, 'warn', (msg) => warns.push(String(msg)))
+
+    const mockSpawn = () => createMockProcess({ url: 'https://exposed-test.trycloudflare.com' })
+    const tunnel = new TestCloudflareAdapter({ port: 3000, mockSpawn })
+    await tunnel.start()
+
+    const exposureWarns = warns.filter((l) => l.includes('publicly reachable'))
+    assert.equal(exposureWarns.length, 1, `expected exactly one exposure warning, got: ${JSON.stringify(warns)}`)
+    assert.ok(exposureWarns[0].includes('https://exposed-test.trycloudflare.com'), 'warning names the public URL')
+    assert.match(exposureWarns[0], /bearer-token gated/)
+    assert.match(exposureWarns[0], /--tunnel none/)
+
+    await tunnel.stop()
+  })
+
+  it('does not emit the exposure warning for a named tunnel', async () => {
+    const warns = []
+    mock.method(console, 'warn', (msg) => warns.push(String(msg)))
+
+    const mockSpawn = () => {
+      const proc = new EventEmitter()
+      proc.stdout = new EventEmitter()
+      proc.stderr = new EventEmitter()
+      proc.killed = false
+      proc.kill = function () {
+        this.killed = true
+        setImmediate(() => this.emit('close', 0, null))
+      }
+      setImmediate(() => {
+        proc.stderr.emit('data', Buffer.from('Registered tunnel connection connIndex=0'))
+      })
+      return proc
+    }
+    const tunnel = new TestCloudflareAdapter({
+      port: 3000,
+      mockSpawn,
+      mode: 'named',
+      config: { tunnelName: 'chroxy', tunnelHostname: 'chroxy.example.com' },
+    })
+    await tunnel.start()
+
+    assert.equal(warns.filter((l) => l.includes('publicly reachable')).length, 0)
+
+    await tunnel.stop()
   })
 })


### PR DESCRIPTION
## Summary

Implements the **warning/visibility layer** of the control-socket exposure report — the safe subset that changes **no defaults**. The default-flip decisions (loopback-by-default for the desktop app, explicit wizard tunnel choice) are deliberately left open for the maintainer per the assessment. Related to #5356.

### Server startup warnings

- **Non-loopback bind** — `maybeWarnNonLoopbackBind()` in `packages/server/src/bind-host.js`, called from `startCliServer` right before `wsServer.start(bindHost)`. One `log.warn` whenever the resolved bind is non-loopback (the default `undefined` → `0.0.0.0` included): names the bind address, states that LAN peers can reach the auth/pairing endpoints (bearer-gated, fingerprintable via `/health`), and points at `--host 127.0.0.1` / `"host"` in `~/.chroxy/config.json`.
- **Public quick tunnel** — in `packages/server/src/tunnel/cloudflare.js` `_startQuickTunnel()`, one `log.warn` when the trycloudflare URL is established: the URL is publicly reachable (bearer-token gated, but the server is fingerprintable), with `--tunnel none` / `--tunnel named` as the alternatives. Named tunnels do not emit it.

### Dashboard banner

- `auth_ok` gains an optional `exposure: { lanBind, bindHost, quickTunnel }` snapshot — recorded by `WsServer.start()` (bound host) and `setQuickTunnelActive()` (set by server-cli before tunnel startup), surfaced via `sendPostAuthInfo`. Optional on the wire; older servers omit it and clients treat absence as "unknown" (no banner).
- `buildTunnelReadyStatus` now passes `tunnelMode` so a client that connected mid-warming learns the quick tunnel went live via the existing `server_status { phase: 'ready' }` broadcast.
- New `ExposureWarningBanner` (pattern: `ReconnectBanner` / `StdinDisabledBanner`) renders when the store's `serverExposure` reports either condition; dismissible per connection (`exposureBannerDismissed` resets on a fresh non-reconnect auth, survives silent reconnects, clears on disconnect).
- Protocol: optional `exposure` field on `ServerAuthOkSchema`; `dist/schemas/server.{js,d.ts}` rebuilt and committed.

### Docs

- `docs/security/bearer-token-authority.md` — new §10 documenting the LAN-bind unauthenticated surface (`/health` fingerprint, dashboard static assets, rate-limited auth/pairing attempts), the plaintext-`ws://` LAN caveat, and the mitigation/visibility knobs.

## Tests

- `packages/server/tests/bind-host.test.js` — warn fires for `undefined`/`0.0.0.0`/LAN/`::` binds with address + endpoints + restriction hint; silent for loopback. 
- `packages/server/tests/tunnel/cloudflare.test.js` — quick tunnel emits exactly one exposure warning naming the URL; named tunnel emits none.
- `packages/server/tests/tunnel-warming-broadcast.test.js` — `tunnelMode` passthrough/omission on the ready broadcast.
- `packages/dashboard/src/components/ExposureWarningBanner.test.tsx` — render conditions (LAN-only / quick-only / both / neither), dismiss handler, ARIA convention.

Results: targeted server suites green; full server suite 8516/8524 pass — the 2 failures (`tests/service.test.js` health-probe timeout tests) are environmental: a live local chroxy daemon on `:8765` answered the probe these tests expect to time out; unrelated to this change. Dashboard: `vitest run` 166 files / 3283 tests pass; `tsc --noEmit` clean. `lint-*.sh` all pass.