### PR TITLE
fix(server): close claude-code-notify parity gaps before cutover (idle prompts, project mapping, subagent interplay, offline 404)

### DIFF
--- a/packages/claude-hooks/README.md
+++ b/packages/claude-hooks/README.md
@@ -39,9 +39,17 @@ Everything resolves automatically from the chroxy daemon's config; env vars over
 | `CHROXY_CONFIG_DIR` | `~/.chroxy` |
 | `CHROXY_HOOKS_SETTINGS_PATH` | `~/.claude/settings.json` (install/uninstall target) |
 | `CHROXY_HOOKS_DEBUG=1` | stderr diagnostics from `emit` (silent otherwise) |
+| `CHROXY_HOOKS_SKIP_CWD_FILTER=1` | bypass the non-project cwd filter (tests/debugging) |
 
-`project` is derived hook-side (cwd → nearest `.git`, then `$CLAUDE_PROJECT_DIR`) and sent
-explicitly; the server's cwd derivation is fallback only.
+`project` is derived hook-side (worktree-parent remap for `.claude/worktrees/*` checkouts,
+then cwd → nearest `.git`, then `$CLAUDE_PROJECT_DIR`) and sent explicitly; the server's
+cwd derivation is fallback only.
+
+Non-project sessions are filtered hook-side (#5439): temp-dir (`/tmp`, `/var/tmp`) and
+home-root cwds emit nothing; worktree-agent cwds emit only subagent events, attributed to
+the parent project. The `Notification` emitter forwards `notification_type`
+(`idle_prompt` / `permission_prompt`) so the server can distinguish "ready for input"
+from "needs approval".
 
 Subagent counting is server-side: the daemon aggregates `subagent_start` / `subagent_stop`
 per (source, sessionId) and surfaces active counts in notification text — emitters carry

--- a/packages/claude-hooks/src/emit.js
+++ b/packages/claude-hooks/src/emit.js
@@ -12,7 +12,7 @@
  */
 
 import { resolveIngestSecret, resolveIngestUrl } from './config.js'
-import { deriveProject } from './project.js'
+import { classifyNonProjectCwd, deriveProject } from './project.js'
 import { EMITTERS, HOOK_EVENT_FOR_TYPE } from './emitters.js'
 
 export const SOURCE = 'claude-hooks'
@@ -125,6 +125,24 @@ export async function runEmit({
     if (!hookEvent) {
       debugLog(env, `unknown hook event "${hookEventArg}"`)
       return { sent: false, reason: 'unknown_event' }
+    }
+
+    // #5439 GAP B — non-project session filter (port of claude-notify.sh's
+    // tmp / home / worktree cwd filter): temp-dir and home-root sessions are
+    // suppressed outright; worktree-agent cwds pass ONLY subagent events
+    // through (their counts belong to the parent project — deriveProject
+    // remaps the name), so parallel agents don't thrash the parent embed's
+    // lifecycle. CHROXY_HOOKS_SKIP_CWD_FILTER=1 bypasses (tests/debugging),
+    // mirroring the bash CLAUDE_NOTIFY_SKIP_TMP_FILTER.
+    if (env.CHROXY_HOOKS_SKIP_CWD_FILTER !== '1') {
+      const cwdKind = classifyNonProjectCwd(typeof payload.cwd === 'string' ? payload.cwd : null, env)
+      if (
+        cwdKind === 'tmp' || cwdKind === 'home' ||
+        (cwdKind === 'worktree' && hookEvent !== 'SubagentStart' && hookEvent !== 'SubagentStop')
+      ) {
+        debugLog(env, `suppressed ${hookEvent} from non-project cwd (${cwdKind})`)
+        return { sent: false, reason: 'non_project_cwd' }
+      }
     }
 
     const secret = resolveIngestSecret(env)

--- a/packages/claude-hooks/src/emitters.js
+++ b/packages/claude-hooks/src/emitters.js
@@ -63,6 +63,12 @@ export function notification(payload) {
   if (message) data.message = message
   const title = str(payload.title)
   if (title) data.title = title
+  // #5439 GAP A: forward the matcher discriminator. The server maps
+  // `idle_prompt` to the idle embed state (🦀 Ready for input) and
+  // `permission_prompt` (or absent) to needs-approval (🔐) — dropping it
+  // made every idle prompt render as a permission ping.
+  const notificationType = str(payload.notification_type)
+  if (notificationType) data.notificationType = notificationType
   return { type: 'notification', data }
 }
 

--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -38,6 +38,15 @@ function realResolve(p) {
 }
 
 /**
+ * Normalize separators for the shape checks below: resolve()/realpathSync()
+ * emit backslash-separated paths on Windows, where the POSIX marker/prefix
+ * substrings would never match (Copilot review on #5462). No-op on POSIX.
+ */
+function normSlashes(p) {
+  return p.replace(/\\/g, '/')
+}
+
+/**
  * #5439 GAP B: a cwd inside a worktree checkout belongs to the PARENT
  * project — the segment before /.claude/worktrees/ — not the agent-*
  * checkout (port of extract_project_name's worktree remap; without this
@@ -47,9 +56,11 @@ export function worktreeParent(cwd) {
   if (typeof cwd !== 'string' || cwd.length === 0) return null
   const dir = realResolve(cwd)
   if (!dir) return null
-  const idx = dir.indexOf(WORKTREE_MARKER)
+  const norm = normSlashes(dir)
+  const idx = norm.indexOf(WORKTREE_MARKER)
   if (idx <= 0) return null
-  const name = basename(dir.slice(0, idx))
+  // basename() handles '/' on every platform (win32 accepts both separators).
+  const name = basename(norm.slice(0, idx))
   return name.length > 0 ? name : null
 }
 
@@ -69,10 +80,13 @@ export function classifyNonProjectCwd(cwd, env = process.env) {
   if (typeof cwd !== 'string' || cwd.length === 0) return null
   const dir = realResolve(cwd)
   if (!dir) return null
+  // Shape checks run on the slash-normalized path so Windows backslash
+  // paths classify identically (Copilot review on #5462).
+  const norm = normSlashes(dir)
   for (const prefix of TMP_PREFIXES) {
-    if (dir === prefix || dir.startsWith(prefix + '/')) return 'tmp'
+    if (norm === prefix || norm.startsWith(prefix + '/')) return 'tmp'
   }
-  if (dir.includes(WORKTREE_MARKER)) return 'worktree'
+  if (norm.includes(WORKTREE_MARKER)) return 'worktree'
   const homeRaw = typeof env.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
   if (homeRaw) {
     let homeResolved
@@ -81,7 +95,13 @@ export function classifyNonProjectCwd(cwd, env = process.env) {
     } catch {
       homeResolved = null
     }
-    if (dir === homeResolved || dir === realResolve(homeRaw)) return 'home'
+    // Home-root equality is also separator-normalized — both sides come
+    // from resolve()/realpath, so on POSIX this is byte-identical to the
+    // raw comparison.
+    if (
+      (homeResolved && norm === normSlashes(homeResolved)) ||
+      norm === normSlashes(realResolve(homeRaw) ?? '')
+    ) return 'home'
   }
   return null
 }

--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -12,8 +12,79 @@
  * shells out (this runs on every hook fire inside the <100ms budget).
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
+
+/** Agent worktree checkouts live under <parent>/.claude/worktrees/<name>. */
+const WORKTREE_MARKER = '/.claude/worktrees/'
+
+/** Temp roots (plus their macOS /private realpaths) — never project sessions. */
+const TMP_PREFIXES = ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp']
+
+/** resolve() then realpath (macOS: /tmp → /private/tmp); best-effort, never throws. */
+function realResolve(p) {
+  let dir
+  try {
+    dir = resolve(p)
+  } catch {
+    return null
+  }
+  try {
+    return realpathSync(dir)
+  } catch {
+    return dir
+  }
+}
+
+/**
+ * #5439 GAP B: a cwd inside a worktree checkout belongs to the PARENT
+ * project — the segment before /.claude/worktrees/ — not the agent-*
+ * checkout (port of extract_project_name's worktree remap; without this
+ * every parallel agent mints its own `agent-<hash>` status embed).
+ */
+export function worktreeParent(cwd) {
+  if (typeof cwd !== 'string' || cwd.length === 0) return null
+  const dir = realResolve(cwd)
+  if (!dir) return null
+  const idx = dir.indexOf(WORKTREE_MARKER)
+  if (idx <= 0) return null
+  const name = basename(dir.slice(0, idx))
+  return name.length > 0 ? name : null
+}
+
+/**
+ * Classify cwds that should not mint their own status embeds (#5439 GAP B,
+ * port of claude-notify.sh's non-project session filter):
+ *
+ *   'tmp'      — /tmp, /var/tmp (and their /private macOS realpaths)
+ *   'home'     — the home directory ROOT itself (basename = username, not a
+ *                project); projects under home are fine
+ *   'worktree' — .claude/worktrees agent checkouts (runEmit suppresses all
+ *                but subagent events, whose counts belong to the parent)
+ *
+ * Returns null for normal project cwds or when no cwd is available.
+ */
+export function classifyNonProjectCwd(cwd, env = process.env) {
+  if (typeof cwd !== 'string' || cwd.length === 0) return null
+  const dir = realResolve(cwd)
+  if (!dir) return null
+  for (const prefix of TMP_PREFIXES) {
+    if (dir === prefix || dir.startsWith(prefix + '/')) return 'tmp'
+  }
+  if (dir.includes(WORKTREE_MARKER)) return 'worktree'
+  const homeRaw = typeof env.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
+  if (homeRaw) {
+    let homeResolved
+    try {
+      homeResolved = resolve(homeRaw)
+    } catch {
+      homeResolved = null
+    }
+    if (dir === homeResolved || dir === realResolve(homeRaw)) return 'home'
+  }
+  return null
+}
 
 function gitRootName(cwd) {
   if (typeof cwd !== 'string' || cwd.length === 0) return null
@@ -43,12 +114,16 @@ function gitRootName(cwd) {
 }
 
 /**
- * Resolve the project name for the envelope: git root of the payload's cwd
- * first, then $CLAUDE_PROJECT_DIR (Claude Code exports the project root
- * there for hook processes), then null (server-side derivation remains the
- * last-resort fallback).
+ * Resolve the project name for the envelope: worktree-parent remap first
+ * (#5439 GAP B — a worktree's own `.git` FILE would otherwise win the walk
+ * and name the checkout, not the project), then the git root of the
+ * payload's cwd, then $CLAUDE_PROJECT_DIR (Claude Code exports the project
+ * root there for hook processes), then null (server-side derivation remains
+ * the last-resort fallback).
  */
 export function deriveProject(cwd, env = process.env) {
+  const fromWorktree = worktreeParent(cwd)
+  if (fromWorktree) return fromWorktree
   const fromCwd = gitRootName(cwd)
   if (fromCwd) return fromCwd
   const projectDir = env.CLAUDE_PROJECT_DIR

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -23,7 +23,7 @@ import { IngestEventSchema } from '@chroxy/protocol'
 import { buildEnvelope, resolveHookEvent, runEmit, sanitizeData, SOURCE } from '../src/emit.js'
 import { EMITTERS } from '../src/emitters.js'
 import { resolveIngestUrl, resolveIngestSecret, DEFAULT_PORT } from '../src/config.js'
-import { deriveProject } from '../src/project.js'
+import { classifyNonProjectCwd, deriveProject, worktreeParent } from '../src/project.js'
 
 const SECRET = 'test-hooks-secret'
 const NOW = 1_750_000_000_000
@@ -142,6 +142,18 @@ describe('deriveProject', () => {
     writeFileSync(join(wt, '.git'), 'gitdir: /elsewhere/worktrees/agent-abc123\n')
     assert.equal(deriveProject(wt, {}), 'myproj')
     assert.equal(deriveProject(join(wt, 'packages', 'server'), {}), 'myproj', 'nested worktree cwd remaps too')
+  })
+
+  // Copilot review on #5462: resolve()/realpathSync() emit backslash paths
+  // on Windows, where the POSIX marker/prefix substrings would never match —
+  // the shape checks must be separator-normalized. The fixture is a POSIX
+  // absolute path with backslash-separated components: resolve() keeps it
+  // as-is on every platform (no cwd-prefix artifact), so the assertion is
+  // deterministic and fails exactly when the normalization is missing.
+  it('normalizes backslash separators in the worktree shape checks (Windows paths)', () => {
+    const winish = '/nonexistent-hooks-tests/C:\\checkouts\\parentproj\\.claude\\worktrees\\agent-1'
+    assert.equal(worktreeParent(winish), 'parentproj')
+    assert.equal(classifyNonProjectCwd(winish, {}), 'worktree')
   })
 })
 

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -242,7 +242,11 @@ describe('runEmit', () => {
     const result = await runEmit({
       hookEventArg: 'session_start',
       stdinText: JSON.stringify(payload),
-      env: envFor(),
+      // This test pins the wire shape, not the cwd filter — and tempRepo()
+      // lives under tmpdir(), which on Linux IS /tmp and would be
+      // tmp-suppressed (#5439 GAP B). Bypass, like the bash test suite's
+      // CLAUDE_NOTIFY_SKIP_TMP_FILTER.
+      env: { ...envFor(), CHROXY_HOOKS_SKIP_CWD_FILTER: '1' },
       now: () => NOW,
     })
     assert.deepEqual(result, { sent: true })
@@ -330,7 +334,18 @@ describe('runEmit', () => {
   // tmp / home / worktree cwd filter). Suppressed events never touch the
   // network; worktree cwds still pass SUBAGENT events through (their counts
   // belong to the parent project).
+  //
+  // Home/worktree fixtures are deliberately NONEXISTENT absolute paths:
+  // the classifier falls back from realpath to resolve() for them, so the
+  // tests exercise pure path shape. Real fixtures under tmpdir() are a
+  // platform trap — Linux's tmpdir IS /tmp (tmp-classified), and a checkout
+  // inside an agent worktree puts cwd-relative scratch dirs under
+  // `/.claude/worktrees/` (worktree-classified). macOS /var/folders hid
+  // both on local runs.
   describe('non-project cwd suppression (#5439 GAP B)', () => {
+    const FAKE_HOME = '/nonexistent-hooks-tests/home/someuser'
+    const FAKE_WT = '/nonexistent-hooks-tests/checkouts/parentproj/.claude/worktrees/agent-xyz'
+
     it('suppresses events from /tmp cwds', async () => {
       const tmpCwd = mkdtempSync('/tmp/hooks-tmpfilter-')
       const countBefore = received.length
@@ -345,12 +360,11 @@ describe('runEmit', () => {
     })
 
     it('suppresses events from the home directory root (basename = username, not a project)', async () => {
-      const home = mkdtempSync(join(tmpdir(), 'hooks-home-'))
       const countBefore = received.length
       const result = await runEmit({
         hookEventArg: 'notification',
-        stdinText: JSON.stringify({ cwd: home }),
-        env: { ...envFor(), HOME: home },
+        stdinText: JSON.stringify({ cwd: FAKE_HOME }),
+        env: { ...envFor(), HOME: FAKE_HOME },
         now: () => NOW,
       })
       assert.deepEqual(result, { sent: false, reason: 'non_project_cwd' })
@@ -358,13 +372,13 @@ describe('runEmit', () => {
     })
 
     it('does NOT suppress a project under the home directory', async () => {
-      const home = mkdtempSync(join(tmpdir(), 'hooks-home-'))
-      const proj = join(home, 'realproject')
-      mkdirSync(join(proj, '.git'), { recursive: true })
+      const proj = join(FAKE_HOME, 'realproject')
       const result = await runEmit({
         hookEventArg: 'session_start',
         stdinText: JSON.stringify({ cwd: proj, session_id: 's-proj' }),
-        env: { ...envFor(), HOME: home },
+        // No real .git to walk to — CLAUDE_PROJECT_DIR supplies the name
+        // (the git-root derivation has its own deriveProject coverage).
+        env: { ...envFor(), HOME: FAKE_HOME, CLAUDE_PROJECT_DIR: proj },
         now: () => NOW,
       })
       assert.deepEqual(result, { sent: true })
@@ -372,9 +386,7 @@ describe('runEmit', () => {
     })
 
     it('suppresses non-subagent events from worktree cwds, but lets subagent events through remapped to the parent', async () => {
-      const root = mkdtempSync(join(tmpdir(), 'hooks-wtfilter-'))
-      const wt = join(root, 'parentproj', '.claude', 'worktrees', 'agent-xyz')
-      mkdirSync(wt, { recursive: true })
+      const wt = FAKE_WT
 
       const countBefore = received.length
       const start = await runEmit({

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -88,6 +88,21 @@ describe('buildEnvelope', () => {
     assert.equal(buildEnvelope('PreCompact', {}, { env: {}, now: () => NOW }), null)
   })
 
+  // #5439 GAP A: the Notification emitter must forward the matcher
+  // discriminator — without it the server cannot tell idle prompts from
+  // permission prompts and every "ready for input" renders as 🔐.
+  it('Notification forwards notification_type as data.notificationType (#5439 GAP A)', () => {
+    const idle = buildEnvelope('Notification', { notification_type: 'idle_prompt', message: 'Ready' }, { env: {}, now: () => NOW })
+    assert.equal(idle.data.notificationType, 'idle_prompt')
+    assert.equal(IngestEventSchema.safeParse(idle).success, true)
+
+    const perm = buildEnvelope('Notification', { notification_type: 'permission_prompt' }, { env: {}, now: () => NOW })
+    assert.equal(perm.data.notificationType, 'permission_prompt')
+
+    const none = buildEnvelope('Notification', { message: 'hi' }, { env: {}, now: () => NOW })
+    assert.equal('notificationType' in none.data, false, 'absent on payloads without notification_type')
+  })
+
   it('omits sessionId/project when underivable and still validates', () => {
     const envelope = buildEnvelope('Notification', {}, { env: {}, now: () => NOW })
     assert.equal('sessionId' in envelope, false)
@@ -113,6 +128,20 @@ describe('deriveProject', () => {
 
   it('returns null with no cwd and no CLAUDE_PROJECT_DIR', () => {
     assert.equal(deriveProject(null, {}), null)
+  })
+
+  // #5439 GAP B: worktree-agent cwds belong to the PARENT project — the
+  // segment before /.claude/worktrees/ — not the agent-* checkout (port of
+  // extract_project_name's worktree remap).
+  it('maps .claude/worktrees/agent-* cwds to the parent project (#5439 GAP B)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'hooks-wt-'))
+    const proj = join(root, 'myproj')
+    const wt = join(proj, '.claude', 'worktrees', 'agent-abc123')
+    mkdirSync(join(wt, 'packages', 'server'), { recursive: true })
+    // Worktree checkouts carry a .git FILE — the remap must win over the walk.
+    writeFileSync(join(wt, '.git'), 'gitdir: /elsewhere/worktrees/agent-abc123\n')
+    assert.equal(deriveProject(wt, {}), 'myproj')
+    assert.equal(deriveProject(join(wt, 'packages', 'server'), {}), 'myproj', 'nested worktree cwd remaps too')
   })
 })
 
@@ -295,5 +324,89 @@ describe('runEmit', () => {
     const result = await runEmit({ hookEventArg: 'PreCompact', stdinText: '{}', env: envFor(), now: () => NOW })
     assert.deepEqual(result, { sent: false, reason: 'unknown_event' })
     assert.equal(received.length, countBefore)
+  })
+
+  // #5439 GAP B — non-project session filtering (port of claude-notify.sh's
+  // tmp / home / worktree cwd filter). Suppressed events never touch the
+  // network; worktree cwds still pass SUBAGENT events through (their counts
+  // belong to the parent project).
+  describe('non-project cwd suppression (#5439 GAP B)', () => {
+    it('suppresses events from /tmp cwds', async () => {
+      const tmpCwd = mkdtempSync('/tmp/hooks-tmpfilter-')
+      const countBefore = received.length
+      const result = await runEmit({
+        hookEventArg: 'session_start',
+        stdinText: JSON.stringify({ cwd: tmpCwd, session_id: 's-tmp' }),
+        env: envFor(),
+        now: () => NOW,
+      })
+      assert.deepEqual(result, { sent: false, reason: 'non_project_cwd' })
+      assert.equal(received.length, countBefore, 'no network call for a /tmp session')
+    })
+
+    it('suppresses events from the home directory root (basename = username, not a project)', async () => {
+      const home = mkdtempSync(join(tmpdir(), 'hooks-home-'))
+      const countBefore = received.length
+      const result = await runEmit({
+        hookEventArg: 'notification',
+        stdinText: JSON.stringify({ cwd: home }),
+        env: { ...envFor(), HOME: home },
+        now: () => NOW,
+      })
+      assert.deepEqual(result, { sent: false, reason: 'non_project_cwd' })
+      assert.equal(received.length, countBefore)
+    })
+
+    it('does NOT suppress a project under the home directory', async () => {
+      const home = mkdtempSync(join(tmpdir(), 'hooks-home-'))
+      const proj = join(home, 'realproject')
+      mkdirSync(join(proj, '.git'), { recursive: true })
+      const result = await runEmit({
+        hookEventArg: 'session_start',
+        stdinText: JSON.stringify({ cwd: proj, session_id: 's-proj' }),
+        env: { ...envFor(), HOME: home },
+        now: () => NOW,
+      })
+      assert.deepEqual(result, { sent: true })
+      assert.equal(JSON.parse(received.at(-1).body).project, 'realproject')
+    })
+
+    it('suppresses non-subagent events from worktree cwds, but lets subagent events through remapped to the parent', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'hooks-wtfilter-'))
+      const wt = join(root, 'parentproj', '.claude', 'worktrees', 'agent-xyz')
+      mkdirSync(wt, { recursive: true })
+
+      const countBefore = received.length
+      const start = await runEmit({
+        hookEventArg: 'session_start',
+        stdinText: JSON.stringify({ cwd: wt, session_id: 's-wt' }),
+        env: envFor(),
+        now: () => NOW,
+      })
+      assert.deepEqual(start, { sent: false, reason: 'non_project_cwd' })
+      assert.equal(received.length, countBefore, 'worktree SessionStart suppressed')
+
+      const stop = await runEmit({
+        hookEventArg: 'subagent_stop',
+        stdinText: JSON.stringify({ cwd: wt, session_id: 's-wt' }),
+        env: envFor(),
+        now: () => NOW,
+      })
+      assert.deepEqual(stop, { sent: true }, 'worktree SubagentStop reaches the counting code')
+      const sent = JSON.parse(received.at(-1).body)
+      assert.equal(sent.type, 'subagent_stop')
+      assert.equal(sent.project, 'parentproj', 'subagent counts belong to the parent project')
+    })
+
+    it('CHROXY_HOOKS_SKIP_CWD_FILTER=1 bypasses the filter (test/debug escape hatch)', async () => {
+      const tmpCwd = mkdtempSync('/tmp/hooks-tmpfilter-')
+      const result = await runEmit({
+        hookEventArg: 'session_start',
+        stdinText: JSON.stringify({ cwd: tmpCwd, session_id: 's-bypass' }),
+        env: { ...envFor(), CHROXY_HOOKS_SKIP_CWD_FILTER: '1' },
+        now: () => NOW,
+      })
+      assert.deepEqual(result, { sent: true })
+    })
   })
 })

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -383,6 +383,18 @@ export function handleEventIngest(server, req, res) {
         }
       }
 
+      // #5439 GAP C: the count→0 subagent_stop is LOAD-BEARING — the Discord
+      // sink's idle_busy re-ping triggers on it. session_activity rides a
+      // global 30s category window (RATE_LIMITS in push.js) that is almost
+      // always warm during subagent work, so without an exemption the
+      // transition is dropped semi-randomly: the re-ping then never fires
+      // (the main loop is idle — nothing follows), or fires LATE off stale
+      // state as a false ping. Port of the bash exemption (notify-helpers.sh
+      // should_patch_subagent_update: "Count reaching 0 = all agents done;
+      // always let it through").
+      const bypassRateLimit =
+        event.type === 'subagent_stop' && !!event.sessionId && activeSubagents === 0
+
       // Fire-and-forget: the pipeline owns delivery (category rate limits,
       // prefs, sink retries). A hard sink failure is logged, not surfaced —
       // emitters can't act on it anyway.
@@ -397,7 +409,7 @@ export function handleEventIngest(server, req, res) {
           // (discord-webhook-sink.js `data.subagents` → embed field).
           ...(event.sessionId ? { subagents: activeSubagents } : {}),
           ts: event.ts,
-        })
+        }, undefined, { bypassRateLimit })
       ).then((ok) => {
         if (ok === false) log.warn(`Ingest event ${event.type} from "${event.source}" failed sink delivery`)
       }).catch((err) => {

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -75,6 +75,9 @@ const INGEST_IP_BURST = 30
  *   post_tool_use  → session_activity
  *   notification   → activity_waiting (existing category: input/approval needed —
  *                                      ping-worthy, like the bash Notification arm)
+ *                    EXCEPT data.notificationType === 'idle_prompt' (#5439
+ *                    GAP A) → activity_update (embed: idle — 🦀 ready ping
+ *                    with idle→idle dedup, the bash idle_prompt arm)
  */
 export const INGEST_CATEGORY_FOR_TYPE = {
   session_start: { category: 'session_online', title: 'Session online', body: 'External session started' },
@@ -83,6 +86,21 @@ export const INGEST_CATEGORY_FOR_TYPE = {
   subagent_stop: { category: 'session_activity', title: 'Subagent finished', body: 'A subagent completed' },
   notification: { category: 'activity_waiting', title: 'Input needed', body: 'Claude is waiting' },
   post_tool_use: { category: 'session_activity', title: 'Tool activity', body: 'Tool use completed' },
+}
+
+/**
+ * #5439 GAP A: the hooks' Notification emitter forwards the matcher
+ * discriminator as data.notificationType. `idle_prompt` is the bash
+ * original's highest-volume ping ("ready for input") and must ride the
+ * activity_update category — the Discord sink maps it to the `idle` embed
+ * state (project color, idle→idle dedup). `permission_prompt` (and any
+ * payload without the discriminator) keeps the activity_waiting default
+ * above (permission embed, always re-pings).
+ */
+export const INGEST_IDLE_PROMPT_MAPPING = {
+  category: 'activity_update',
+  title: 'Ready for input',
+  body: 'Claude is waiting for input',
 }
 
 /** Default on-disk location for the ingest secret (0600, same-user reads). */
@@ -321,7 +339,7 @@ export function handleEventIngest(server, req, res) {
         return
       }
 
-      const mapping = INGEST_CATEGORY_FOR_TYPE[event.type]
+      let mapping = INGEST_CATEGORY_FOR_TYPE[event.type]
       // Schema enum and this map are kept in lockstep; belt-and-braces only.
       if (!mapping) {
         sendJson(res, 400, { error: 'invalid event', details: [`type: unsupported type ${event.type}`] })
@@ -332,6 +350,12 @@ export function handleEventIngest(server, req, res) {
       // walk). The Discord sink's _projectKey prefers data.project, so this
       // is what keys the per-project status embed.
       const data = event.data || {}
+
+      // #5439 GAP A: split the Notification hook by its discriminator —
+      // idle prompts are "ready for input" (idle embed), not approvals.
+      if (event.type === 'notification' && data.notificationType === 'idle_prompt') {
+        mapping = INGEST_IDLE_PROMPT_MAPPING
+      }
       const project = event.project
         || (typeof data.cwd === 'string' ? deriveProjectFromCwd(data.cwd) : null)
 

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -393,8 +393,36 @@ export class DiscordWebhookSink extends NotificationSink {
       if (state === 'offline') {
         // SessionEnd PATCHes in place — and only when there is something to
         // mark offline (bash: skip when state is empty or already offline).
+        // #5439 GAP D: if the tracked message was deleted externally, do NOT
+        // POST a fresh offline embed (bash no_post_on_404) — just drop the id.
         if (!prev?.messageId || prev.state === 'offline') return true
-        return await this._patchOrPost(webhookUrl, project, entry, store)
+        return await this._patchOrPost(webhookUrl, project, entry, store, { noPostOn404: true })
+      }
+
+      // #5439 GAP C — subagent/idle interplay (port of claude-notify.sh
+      // :528-539 and :383-384). While the user is being waited on (idle /
+      // permission embed) with subagents still running, routine activity
+      // must NOT flip the embed back to 🟢 online: keep the waiting state
+      // and text, refreshing only the live fields (Subagents count, footer).
+      // And when the LAST subagent finishes while the embed sits idle,
+      // re-ping 🦀 "Ready for input" (the bash idle_busy → idle repost on
+      // count→0). Permission embeds with count→0 fall through to online —
+      // the row-20 intentional diff (approval cleared by the next activity).
+      if (state === 'online' && prev?.messageId && (prev.state === 'idle' || prev.state === 'permission')) {
+        const allDone = entry.subagents === 0 && Number.isFinite(prev.subagents) && prev.subagents > 0
+        if (entry.subagents > 0 || (allDone && prev.state === 'idle')) {
+          entry.state = prev.state
+          if (typeof prev.body === 'string' && prev.body.length > 0) entry.body = prev.body
+          entry.detail = prev.detail ?? entry.detail
+          entry.lastStateChangeTs = prev.lastStateChangeTs ?? now
+          if (allDone) {
+            return await this._repost(webhookUrl, project, entry, store, prev.messageId)
+          }
+          if (Number.isFinite(prev.lastUpdateTs) && now - prev.lastUpdateTs < this._updateThrottleMs) {
+            return true
+          }
+          return await this._patchOrPost(webhookUrl, project, entry, store)
+        }
       }
 
       if (PING_STATES.has(state)) {
@@ -483,10 +511,16 @@ export class DiscordWebhookSink extends NotificationSink {
     return true
   }
 
-  /** PATCH the existing message; self-heal on 404 / missing id by POSTing. */
-  async _patchOrPost(webhookUrl, project, entry, store) {
+  /**
+   * PATCH the existing message; self-heal on 404 / missing id by POSTing.
+   * `noPostOn404` (#5439 GAP D, port of bash no_post_on_404) suppresses the
+   * healing POST — used by the offline path, where re-creating a message
+   * that was deleted externally would just leave an orphan offline embed.
+   */
+  async _patchOrPost(webhookUrl, project, entry, store, { noPostOn404 = false } = {}) {
     const base = this._apiBase(webhookUrl)
     if (!entry.messageId) {
+      if (noPostOn404) return true
       return await this._post(base, project, entry, store)
     }
     const payload = this._buildPayload(project, entry)
@@ -496,8 +530,14 @@ export class DiscordWebhookSink extends NotificationSink {
       body: JSON.stringify(payload),
     })
     if (res.status === 404) {
-      // Message deleted externally — re-POST (parity with the bash self-heal).
+      // Message deleted externally — re-POST (parity with the bash self-heal)
+      // unless suppressed: then just drop the id so the next session POSTs.
       entry.messageId = null
+      if (noPostOn404) {
+        store.projects[project] = entry
+        this._persistState(store)
+        return true
+      }
       return await this._post(base, project, entry, store)
     }
     if (!res.ok) {

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -373,6 +373,13 @@ export class DiscordWebhookSink extends NotificationSink {
       // Phase 4 fills this from the hook event stream; until then callers
       // may pass a count and we surface it.
       subagents: Number.isFinite(data.subagents) ? data.subagents : (prev?.subagents ?? 0),
+      // #5439 GAP C: true iff the embed went idle WHILE subagents were
+      // running — the bash `idle_busy` state, entered exclusively via an
+      // idle ping that carries a live count (set in the PING_STATES branch
+      // below). Carried through demoted count refreshes; the count→0
+      // re-ping requires it, so counts that rise AFTER a plain idle ping
+      // (main loop took input and is busy again) never arm a false ping.
+      idleBusy: prev?.idleBusy === true,
       firstSeenTs: prev?.firstSeenTs ?? now,
       lastUpdateTs: now,
       lastStateChangeTs: prev?.state === state ? (prev?.lastStateChangeTs ?? now) : now,
@@ -388,6 +395,7 @@ export class DiscordWebhookSink extends NotificationSink {
         entry.firstSeenTs = now
         entry.lastStateChangeTs = now
         entry.subagents = Number.isFinite(data.subagents) ? data.subagents : 0
+        entry.idleBusy = false
         return await this._repost(webhookUrl, project, entry, store, prev?.messageId)
       }
       if (state === 'offline') {
@@ -404,18 +412,23 @@ export class DiscordWebhookSink extends NotificationSink {
       // permission embed) with subagents still running, routine activity
       // must NOT flip the embed back to 🟢 online: keep the waiting state
       // and text, refreshing only the live fields (Subagents count, footer).
-      // And when the LAST subagent finishes while the embed sits idle,
-      // re-ping 🦀 "Ready for input" (the bash idle_busy → idle repost on
-      // count→0). Permission embeds with count→0 fall through to online —
-      // the row-20 intentional diff (approval cleared by the next activity).
+      // And when the LAST subagent finishes while the embed sits idle AND
+      // armed (`idleBusy` — it went idle with a live count, the bash
+      // idle_busy state), re-ping 🦀 "Ready for input" (the bash :383-384
+      // repost on count→0). A PLAIN idle embed whose count rose later (the
+      // demote branch below) means the main loop took input and is busy —
+      // bash never reposted from plain `idle`, and neither do we.
+      // Permission embeds with count→0 fall through to online — the row-20
+      // intentional diff (approval cleared by the next activity).
       if (state === 'online' && prev?.messageId && (prev.state === 'idle' || prev.state === 'permission')) {
-        const allDone = entry.subagents === 0 && Number.isFinite(prev.subagents) && prev.subagents > 0
-        if (entry.subagents > 0 || (allDone && prev.state === 'idle')) {
+        const allDone = entry.subagents === 0 && prev.state === 'idle' && prev.idleBusy === true
+        if (entry.subagents > 0 || allDone) {
           entry.state = prev.state
           if (typeof prev.body === 'string' && prev.body.length > 0) entry.body = prev.body
           entry.detail = prev.detail ?? entry.detail
           entry.lastStateChangeTs = prev.lastStateChangeTs ?? now
           if (allDone) {
+            entry.idleBusy = false
             return await this._repost(webhookUrl, project, entry, store, prev.messageId)
           }
           if (Number.isFinite(prev.lastUpdateTs) && now - prev.lastUpdateTs < this._updateThrottleMs) {
@@ -426,11 +439,32 @@ export class DiscordWebhookSink extends NotificationSink {
       }
 
       if (PING_STATES.has(state)) {
+        // #5439 GAP C: an idle ping that arrives with a live count IS the
+        // bash idle_busy state — arm the count→0 re-ping. Recomputed on
+        // every idle ping so a later plain-idle ping disarms.
+        if (state === 'idle') entry.idleBusy = entry.subagents > 0
         // Parity: an embed already sitting in `idle` is NOT re-posted for
         // another idle event (`[ "$CURRENT_STATE" = "idle" ] && exit 0`) —
         // re-pinging "still ready" is noise. `permission` always re-posts:
         // each new approval request deserves a fresh ping.
-        if (state === 'idle' && prev?.state === 'idle' && prev?.messageId) return true
+        if (state === 'idle' && prev?.state === 'idle' && prev?.messageId) {
+          // bash :600-603: idle_busy + an idle prompt with all agents done
+          // is NOT a dedup no-op — it reposts plain idle (fresh ping).
+          // Falling through also disarms (entry.idleBusy is false here), so
+          // no stale armed count lingers to mis-fire later.
+          const busyAllDone = prev.idleBusy === true && entry.subagents === 0
+          if (!busyAllDone) {
+            if (entry.idleBusy && prev.idleBusy !== true) {
+              // Deduped re-idle that carries a live count: record the
+              // arming (no Discord call) so a later count→0 can re-ping —
+              // covers the embed that was already idle when the main loop
+              // went idle again with subagents running.
+              store.projects[project] = { ...prev, idleBusy: true, subagents: entry.subagents, lastUpdateTs: now }
+              this._persistState(store)
+            }
+            return true
+          }
+        }
         return await this._repost(webhookUrl, project, entry, store, prev?.messageId)
       }
 

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -448,6 +448,14 @@ export class PushManager {
    * @param {string} body - Notification body text
    * @param {object} [data] - Extra data payload
    * @param {string} [categoryId] - iOS notification category for action buttons
+   * @param {object} [opts]
+   * @param {boolean} [opts.bypassRateLimit] - Exempt this send from the
+   *   per-category window (#5439 GAP C: the count→0 subagent_stop is a
+   *   LOAD-BEARING transition — the Discord sink's idle re-ping triggers on
+   *   it, and the always-warm session_activity window would otherwise drop
+   *   it semi-randomly. The bash original equally exempted count-0 updates
+   *   from its throttle in should_patch_subagent_update). The window stamp
+   *   still advances so routine sends stay throttled.
    * @returns {Promise<boolean>} `true` when no hard delivery failure occurred
    *   (the sinks accepted it, or there was nothing to send / we were
    *   rate-limited — both of which are "no error" from the caller's view).
@@ -456,7 +464,7 @@ export class PushManager {
    *   (#3870) use this to decide whether to release a latch so a transient
    *   failure doesn't permanently suppress future notifications.
    */
-  async send(category, title, body, data = {}, categoryId = undefined) {
+  async send(category, title, body, data = {}, categoryId = undefined, { bypassRateLimit = false } = {}) {
     // No sink has anywhere to deliver to — silent no-op, and intentionally
     // BEFORE the rate-limit stamp (matching the pre-extraction
     // `tokens.size === 0` early return) so a tokenless send doesn't burn
@@ -469,7 +477,7 @@ export class PushManager {
     // per-device prefs. See RATE_LIMITS history comments above.
     const limit = RATE_LIMITS[category] ?? 30_000
     const lastSent = this._lastSent.get(category) || 0
-    if (Date.now() - lastSent < limit) {
+    if (!bypassRateLimit && Date.now() - lastSent < limit) {
       return true
     }
     this._lastSent.set(category, Date.now())

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -832,6 +832,202 @@ describe('DiscordWebhookSink — online/offline lifecycle (#5413 Phase 3)', () =
   })
 })
 
+// #5439 GAP C — subagent/idle interplay (port of claude-notify.sh:528-539
+// and :383-384). While the user is being waited on (idle / permission embed)
+// with subagents still running, routine session_activity must NOT flip the
+// embed back to 🟢 "Session Online"; and when the LAST subagent finishes
+// while the embed sits idle, the sink re-pings 🦀 "Ready for input" (the
+// bash idle_busy → idle repost on count→0).
+describe('DiscordWebhookSink — subagent/idle interplay (#5439 GAP C)', () => {
+  const online = (data = {}) => ({
+    category: 'session_online',
+    title: 'Session online',
+    body: 'External session started',
+    data: { project: 'proj1', ...data },
+  })
+  const activity = (data = {}) => ({
+    category: 'session_activity',
+    title: 'Subagent finished',
+    body: 'A subagent completed',
+    data: { project: 'proj1', ...data },
+  })
+  const ready = (data = {}) => ({
+    category: 'activity_update',
+    title: 'Ready for input',
+    body: 'Claude is waiting for input',
+    data: { project: 'proj1', ...data },
+  })
+  const approval = (data = {}) => ({
+    category: 'activity_waiting',
+    title: 'Input needed',
+    body: 'Claude is waiting',
+    data: { project: 'proj1', ...data },
+  })
+
+  /** online (m1) → idle ping with running subagents (DELETE m1 + POST m2). */
+  async function seedWaitingWithSubagents(sink, advance, state = 'idle') {
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    advance(16_000)
+    scriptFetch([{ status: 204 }, { status: 200, body: { id: 'm2' } }])
+    await sink.send(state === 'idle' ? ready({ subagents: 2 }) : approval({ subagents: 2 }))
+    advance(16_000)
+  }
+
+  it('session_activity does NOT flip an idle embed back online while subagents are running', async () => {
+    const { sink, statePath, advance } = makeSink()
+    await seedWaitingWithSubagents(sink, advance, 'idle')
+    const calls = scriptFetch([{ status: 200 }])
+    assert.equal(await sink.send(activity({ subagents: 2 })), true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].method, 'PATCH', 'count refresh PATCHes in place — no ping')
+    assert.ok(calls[0].url.endsWith('/messages/m2'))
+    const embed = JSON.parse(calls[0].body).embeds[0]
+    assert.match(embed.title, /Ready for input/, 'embed keeps the waiting title')
+    assert.ok(embed.fields.some((f) => f.name === 'Subagents' && f.value === '2'))
+    const st = readState(statePath).projects.proj1
+    assert.equal(st.state, 'idle', 'stored state stays idle')
+  })
+
+  it('session_activity does NOT flip a permission embed back online while subagents are running', async () => {
+    const { sink, statePath, advance } = makeSink()
+    await seedWaitingWithSubagents(sink, advance, 'permission')
+    const calls = scriptFetch([{ status: 200 }])
+    assert.equal(await sink.send(activity({ subagents: 1 })), true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].method, 'PATCH')
+    assert.match(JSON.parse(calls[0].body).embeds[0].title, /Needs Approval/)
+    assert.equal(readState(statePath).projects.proj1.state, 'permission')
+  })
+
+  it('the demoted count refresh keeps the waiting body, not the activity text', async () => {
+    const { sink, advance } = makeSink()
+    await seedWaitingWithSubagents(sink, advance, 'idle')
+    const calls = scriptFetch([{ status: 200 }])
+    await sink.send(activity({ subagents: 1 }))
+    const embed = JSON.parse(calls[0].body).embeds[0]
+    assert.ok(
+      embed.fields.some((f) => f.name === 'Status' && f.value === 'Claude is waiting for input'),
+      'Status field keeps the waiting text'
+    )
+  })
+
+  it('count→0 while idle re-pings Ready for input (DELETE + POST — bash :383-384)', async () => {
+    const { sink, statePath, advance } = makeSink()
+    await seedWaitingWithSubagents(sink, advance, 'idle')
+    const calls = scriptFetch([
+      { status: 204 },                       // DELETE m2
+      { status: 200, body: { id: 'm3' } },   // fresh POST pings
+    ])
+    assert.equal(await sink.send(activity({ subagents: 0 })), true)
+    assert.deepEqual(calls.map((c) => c.method), ['DELETE', 'POST'])
+    assert.ok(calls[0].url.endsWith('/messages/m2'))
+    const embed = JSON.parse(calls[1].body).embeds[0]
+    assert.match(embed.title, /Ready for input/)
+    const st = readState(statePath).projects.proj1
+    assert.equal(st.state, 'idle')
+    assert.equal(st.messageId, 'm3')
+    assert.equal(st.subagents, 0)
+  })
+
+  it('count→0 while permission falls through to online (row-20 intentional diff, no false ready ping)', async () => {
+    const { sink, statePath, advance } = makeSink()
+    await seedWaitingWithSubagents(sink, advance, 'permission')
+    const calls = scriptFetch([{ status: 200 }])
+    assert.equal(await sink.send(activity({ subagents: 0 })), true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].method, 'PATCH', 'no ping — permission clears to online on next activity')
+    assert.match(JSON.parse(calls[0].body).embeds[0].title, /Session Online/)
+    assert.equal(readState(statePath).projects.proj1.state, 'online')
+  })
+
+  it('an idle embed with NO subagents still wakes to online on session_activity (guard scoped to live counts)', async () => {
+    const { sink, statePath, advance } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    advance(16_000)
+    scriptFetch([{ status: 204 }, { status: 200, body: { id: 'm2' } }])
+    await sink.send(ready()) // plain idle, no subagents
+    advance(16_000)
+    const calls = scriptFetch([{ status: 200 }])
+    assert.equal(await sink.send(activity({ subagents: 0 })), true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].method, 'PATCH')
+    assert.match(JSON.parse(calls[0].body).embeds[0].title, /Session Online/)
+    assert.equal(readState(statePath).projects.proj1.state, 'online')
+  })
+
+  it('demoted count refreshes are still throttled inside the window', async () => {
+    const { sink, advance } = makeSink({ updateThrottleMs: 15_000 })
+    await seedWaitingWithSubagents(sink, advance, 'idle')
+    scriptFetch([{ status: 200 }])
+    await sink.send(activity({ subagents: 2 }))
+    advance(1_000) // inside the window
+    const calls = scriptFetch()
+    assert.equal(await sink.send(activity({ subagents: 2 })), true)
+    assert.equal(calls.length, 0, 'same-state count refresh throttled')
+  })
+})
+
+// #5439 GAP D — SessionEnd 404 orphan (port of bash no_post_on_404). When
+// the tracked message was deleted externally, marking the session offline
+// must NOT POST a fresh offline embed — drop the messageId and move on.
+describe('DiscordWebhookSink — offline 404 leaves no orphan (#5439 GAP D)', () => {
+  const online = (data = {}) => ({
+    category: 'session_online',
+    title: 'Session online',
+    body: 'External session started',
+    data: { project: 'proj1', ...data },
+  })
+  const offline = (data = {}) => ({
+    category: 'session_offline',
+    title: 'Session offline',
+    body: 'External session ended',
+    data: { project: 'proj1', ...data },
+  })
+
+  it('a 404 on the offline PATCH drops the messageId without POSTing an orphan', async () => {
+    const { sink, statePath, advance } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    advance(60_000)
+    const calls = scriptFetch([{ status: 404 }])
+    assert.equal(await sink.send(offline()), true)
+    assert.equal(calls.length, 1, 'no healing POST after the 404')
+    assert.equal(calls[0].method, 'PATCH')
+    const st = readState(statePath).projects.proj1
+    assert.equal(st.messageId, null, 'tracking dropped')
+    assert.equal(st.state, 'offline')
+  })
+
+  it('after the 404-drop, the next session_online POSTs fresh with no DELETE', async () => {
+    const { sink, statePath, advance } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    advance(60_000)
+    scriptFetch([{ status: 404 }])
+    await sink.send(offline())
+    advance(60_000)
+    const calls = scriptFetch([{ status: 200, body: { id: 'm2' } }])
+    assert.equal(await sink.send(online()), true)
+    assert.deepEqual(calls.map((c) => c.method), ['POST'], 'nothing tracked → no DELETE')
+    assert.equal(readState(statePath).projects.proj1.messageId, 'm2')
+  })
+
+  it('a NON-offline PATCH 404 still self-heals by POSTing (regression guard)', async () => {
+    const { sink, statePath } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(idle())
+    const calls = scriptFetch([
+      { status: 404 },                     // PATCH 404 (message gone)
+      { status: 200, body: { id: 'm2' } }, // healing POST
+    ])
+    assert.equal(await sink.send(errored()), true)
+    assert.deepEqual(calls.map((c) => c.method), ['PATCH', 'POST'])
+    assert.equal(readState(statePath).projects.alpha.messageId, 'm2')
+  })
+})
+
 // #5429 / #5434 — stale-entry pruning. Entries in discord-webhook-state.json
 // accumulated forever (one per project key / session id), and the heartbeat
 // PATCHed every tracked entry — including final `offline` embeds —

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -967,6 +967,63 @@ describe('DiscordWebhookSink — subagent/idle interplay (#5439 GAP C)', () => {
     assert.equal(await sink.send(activity({ subagents: 2 })), true)
     assert.equal(calls.length, 0, 'same-state count refresh throttled')
   })
+
+  // idle_busy arming: the count→0 re-ping must only fire for embeds that
+  // went idle WHILE subagents were running (bash idle_busy, entered
+  // exclusively via the idle_prompt arm with a live count). A count that
+  // rises AFTER a plain idle ping means the main loop took input and is
+  // busy again — bash's plain `idle` never reposted on count→0
+  // (should_patch_subagent_update returns 1 for `idle`), and re-pinging
+  // "Ready for input" mid-task would be a false ping.
+  it('a PLAIN idle embed whose count rose via the demote path does NOT re-ping on count→0', async () => {
+    const { sink, statePath, advance } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    advance(16_000)
+    scriptFetch([{ status: 204 }, { status: 200, body: { id: 'm2' } }])
+    await sink.send(ready()) // plain idle ping, no subagents → NOT armed
+    advance(16_000)
+    scriptFetch([{ status: 200 }])
+    await sink.send(activity({ subagents: 1 })) // user responded; main loop launched a subagent
+    advance(16_000)
+    const calls = scriptFetch([{ status: 200 }])
+    assert.equal(await sink.send(activity({ subagents: 0 })), true)
+    assert.deepEqual(calls.map((c) => c.method), ['PATCH'], 'no DELETE+POST — falls through to online')
+    assert.match(JSON.parse(calls[0].body).embeds[0].title, /Session Online/)
+    const st = readState(statePath).projects.proj1
+    assert.equal(st.state, 'online')
+    assert.equal(st.idleBusy, false)
+  })
+
+  it('a deduped idle event carrying a live count arms the count→0 re-ping', async () => {
+    const { sink, statePath, advance } = makeSink()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    advance(16_000)
+    scriptFetch([{ status: 204 }, { status: 200, body: { id: 'm2' } }])
+    await sink.send(ready()) // plain idle, not armed
+    advance(16_000)
+    let calls = scriptFetch()
+    await sink.send(ready({ subagents: 2 })) // re-idle WITH live count: dedup, but arm
+    assert.equal(calls.length, 0, 'deduped — no Discord call')
+    assert.equal(readState(statePath).projects.proj1.idleBusy, true)
+    advance(16_000)
+    calls = scriptFetch([{ status: 204 }, { status: 200, body: { id: 'm3' } }])
+    assert.equal(await sink.send(activity({ subagents: 0 })), true)
+    assert.deepEqual(calls.map((c) => c.method), ['DELETE', 'POST'], 'armed count→0 re-pings')
+    assert.match(JSON.parse(calls[1].body).embeds[0].title, /Ready for input/)
+  })
+
+  it('an armed idle embed re-pings on an idle prompt with all agents done (bash :600-603, not a dedup no-op)', async () => {
+    const { sink, statePath, advance } = makeSink()
+    await seedWaitingWithSubagents(sink, advance, 'idle') // armed: idle ping with count 2
+    const calls = scriptFetch([{ status: 204 }, { status: 200, body: { id: 'm3' } }])
+    assert.equal(await sink.send(ready({ subagents: 0 })), true)
+    assert.deepEqual(calls.map((c) => c.method), ['DELETE', 'POST'])
+    const st = readState(statePath).projects.proj1
+    assert.equal(st.idleBusy, false, 'disarmed after the repost')
+    assert.equal(st.messageId, 'm3')
+  })
 })
 
 // #5439 GAP D — SessionEnd 404 orphan (port of bash no_post_on_404). When

--- a/packages/server/tests/event-ingest-subagents.test.js
+++ b/packages/server/tests/event-ingest-subagents.test.js
@@ -28,8 +28,8 @@ function makePushManager() {
   return {
     calls,
     hasConfiguredSinks: () => true,
-    send: (category, title, body, data) => {
-      calls.push({ category, title, body, data })
+    send: (category, title, body, data, categoryId, opts) => {
+      calls.push({ category, title, body, data, opts })
       return Promise.resolve(true)
     },
   }
@@ -110,6 +110,30 @@ describe('event ingest subagent counting', () => {
     assert.equal(lastCall().data.subagents, 0)
     await post({ ...base, type: 'notification' })
     assert.equal(lastCall().body, 'Claude is waiting')
+  })
+
+  // #5439 GAP C: the count→0 subagent_stop is load-bearing (the Discord
+  // sink's idle_busy re-ping triggers on it) and session_activity's global
+  // 30s window is almost always warm during subagent work — so exactly that
+  // transition must request a rate-limit bypass (the bash original equally
+  // exempted count-0 updates in should_patch_subagent_update).
+  it('subagent_stop reaching count 0 requests a rate-limit bypass', async () => {
+    await post({ ...base, type: 'subagent_start' })
+    assert.equal(lastCall().opts?.bypassRateLimit, false, 'start never bypasses')
+    await post({ ...base, type: 'subagent_start' })
+    await post({ ...base, type: 'subagent_stop' })
+    assert.equal(lastCall().data.subagents, 1)
+    assert.equal(lastCall().opts?.bypassRateLimit, false, 'stop above 0 stays throttled')
+    await post({ ...base, type: 'subagent_stop' })
+    assert.equal(lastCall().data.subagents, 0)
+    assert.equal(lastCall().opts?.bypassRateLimit, true, 'count→0 bypasses the category window')
+  })
+
+  it('a sessionId-less subagent_stop never requests a bypass', async () => {
+    const { sessionId, ...noSession } = base
+    await post({ ...noSession, type: 'subagent_stop' })
+    assert.equal('subagents' in lastCall().data, false)
+    assert.equal(lastCall().opts?.bypassRateLimit, false)
   })
 
   it('counts are isolated per session', async () => {

--- a/packages/server/tests/event-ingest.test.js
+++ b/packages/server/tests/event-ingest.test.js
@@ -322,6 +322,42 @@ describe('event-ingest', () => {
       }
     })
 
+    // #5439 GAP A — both directions pinned: idle_prompt must ride the
+    // activity_update category (Discord sink: `idle` embed, 🦀 "Ready for
+    // input", idle→idle dedup), while permission_prompt (and a missing
+    // discriminator) stays activity_waiting (🔐 "Needs Approval" ping).
+    it('notification + notificationType=idle_prompt maps to activity_update (idle embed)', async () => {
+      await startWith(createMockServer())
+      const res = await post(validEvent({
+        type: 'notification',
+        data: { notificationType: 'idle_prompt' },
+      }))
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.category, 'activity_update')
+      const call = mockServer.pushManager.calls[0]
+      assert.equal(call.category, 'activity_update')
+      assert.equal(call.title, 'Ready for input')
+    })
+
+    it('notification + notificationType=permission_prompt stays activity_waiting', async () => {
+      await startWith(createMockServer())
+      const res = await post(validEvent({
+        type: 'notification',
+        data: { notificationType: 'permission_prompt' },
+      }))
+      assert.equal(res.status, 200)
+      assert.equal((await res.json()).category, 'activity_waiting')
+      assert.equal(mockServer.pushManager.calls[0].category, 'activity_waiting')
+    })
+
+    it('notification without a notificationType stays activity_waiting (back-compat)', async () => {
+      await startWith(createMockServer())
+      const res = await post(validEvent({ type: 'notification' }))
+      assert.equal(res.status, 200)
+      assert.equal((await res.json()).category, 'activity_waiting')
+    })
+
     it('derives project from data.cwd (git-root walk) when project is absent', async () => {
       const repo = mkdtempSync(join(tmpdir(), 'ingest-repo-'))
       mkdirSync(join(repo, '.git'))

--- a/packages/server/tests/push.test.js
+++ b/packages/server/tests/push.test.js
@@ -340,6 +340,18 @@ describe('PushManager', () => {
       assert.equal(fetchMock.mock.calls.length, 1)
     })
 
+    it('bypassRateLimit exempts a send from the window but still advances the stamp (#5439 GAP C)', async () => {
+      manager.registerToken(VALID_TOKEN)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await manager.send('session_activity', 'T', 'B')
+      await manager.send('session_activity', 'T', 'B', {}, undefined, { bypassRateLimit: true })
+      assert.equal(fetchMock.mock.calls.length, 2, 'bypassed send goes out inside the window')
+      await manager.send('session_activity', 'T', 'B')
+      assert.equal(fetchMock.mock.calls.length, 2, 'routine send right after is still throttled')
+    })
+
     it('applies the 30s default rate limit to unknown/unregistered categories', async () => {
       manager.registerToken(VALID_TOKEN)
       const fetchMock = mockFetchOk()


### PR DESCRIPTION
Closes the four parity gaps from the #5439 cutover verification (parity-matrix rows 19/29/30/31; Epic #5413 Phase 5). Each gap is a behavior port from `claude-notify.sh`, landed TDD (RED tests first per gap).

Related to #5439, #5413.

## GAP A — idle prompts rendered as 🔐 "Needs Approval" (cutover blocker)

- `packages/claude-hooks/src/emitters.js`: the `Notification` emitter now forwards the hook payload's `notification_type` as `data.notificationType` (the dropped discriminator was the root cause).
- `packages/server/src/event-ingest.js`: `notification` + `notificationType === 'idle_prompt'` maps to the `activity_update` category (`INGEST_IDLE_PROMPT_MAPPING`, default title "Ready for input") → Discord `idle` state with 🦀 project-color embed and idle→idle dedup. `permission_prompt` and an absent discriminator keep `activity_waiting` (🔐 ping).
- `push.js` `RATE_LIMITS` already covers `activity_update` (0 — immediate); no change needed.
- Tests pin **both directions**: `idle_prompt → activity_update` and `permission_prompt`/absent `→ activity_waiting`.

## GAP B — non-project session filtering

- `packages/claude-hooks/src/project.js`: cwds under `*/.claude/worktrees/*` remap to the **parent** project (segment before `/.claude/worktrees/`) — checked before the git-root walk, since a worktree's own `.git` file would otherwise name the `agent-*` checkout.
- `runEmit` (emit.js) ports the bash non-project filter: `/tmp` / `/var/tmp` (and `/private` realpaths) and `$HOME`-root cwds emit nothing; worktree cwds suppress everything **except** `SubagentStart`/`SubagentStop` (their counts belong to the parent project, exactly like the bash `extract_project_name` + filter combo at claude-notify.sh:117-145). `CHROXY_HOOKS_SKIP_CWD_FILTER=1` is the test/debug bypass (mirror of `CLAUDE_NOTIFY_SKIP_TMP_FILTER`).

## GAP C — subagent/idle interplay

- **First half (as briefed):** `discord-webhook-sink.js` no longer PATCHes a waiting embed (`idle`/`permission`) back to 🟢 online on `session_activity` while the live subagent count is > 0 (port of claude-notify.sh:528-539). The embed keeps its waiting title/body; only the Subagents field + footer refresh (throttled as routine updates).
- **Second half — implemented, but in the sink rather than event-ingest (please review this decision):** the brief framed the count→0 ready re-ping as an unconditional `activity_update` emit from `event-ingest.js`. I implemented the bash `:383-384` port **inside the sink** instead, because the bash repost is conditioned on the embed being in `idle_busy` (i.e. *waiting* with subagents) — state only the sink knows. An unconditional ingest-side emit would (a) fire a false 🦀 "Ready for input" ping whenever the last subagent finishes while the main loop is still mid-task (embed online), and (b) be swallowed by the idle→idle dedup in the actual target scenario anyway. Sink-side: when a `session_activity` event brings the count to 0 while the embed sits `idle` with a previously positive count, the sink DELETE+POSTs the idle embed (fresh ping) — faithful to `repost_status_message "idle"` on `idle_busy && count==0`. A `permission` embed with count→0 falls through to online (the row-20 intentional diff). If the ingest-side framing is preferred, happy to rework.

## GAP D — SessionEnd 404 orphan (cosmetic)

- `_patchOrPost` takes a `noPostOn404` flag (port of bash `no_post_on_404`); the `session_offline` branch passes it, so a 404 on the offline PATCH drops the tracked `messageId` (persisted) instead of POSTing a fresh orphan offline embed. The non-offline 404 self-heal is regression-pinned unchanged.

## Tests

- `packages/claude-hooks`: 60/60 pass (12 new — emitter discriminator, worktree remap, tmp/home/worktree suppression incl. subagent pass-through and bypass env).
- `packages/server` targeted suites (`discord-webhook-sink`, `event-ingest`, `event-ingest-subagents`, `push`, plus `notification-sinks`, `push-activity-update`, `push-notification-handler`, `http-routes`, `http-oversize-413-delivery`, `supervisor-push-config`): 257/257 pass.
- `npm run lint` (0 errors) + all three `scripts/lint-*.sh` green.