### PR TITLE
fix(claude-hooks): make GAP B cwd-filter tests hermetic to the OS temp dir

### DIFF
--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -28,11 +28,19 @@ const TMP_PREFIXES = ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp']
  * would classify as 'tmp' and legit-repo tests fail on CI but pass on macOS
  * (/var/folders/...). Tests point this at a path that doesn't exist so their
  * fixtures classify by the real rules. Never set in production.
+ *
+ * Entries are trimmed and stripped of trailing slashes; if the override
+ * yields no usable absolute prefixes (e.g. only relative/empty segments),
+ * fall back to the built-in list rather than silently disabling suppression.
  */
 function tmpPrefixes(env) {
   const raw = env?.CHROXY_HOOKS_TMP_PREFIXES
   if (typeof raw !== 'string' || raw.length === 0) return TMP_PREFIXES
-  return raw.split(':').filter((p) => p.startsWith('/'))
+  const prefixes = raw
+    .split(':')
+    .map((p) => p.trim().replace(/\/+$/, ''))
+    .filter((p) => p.startsWith('/'))
+  return prefixes.length > 0 ? prefixes : TMP_PREFIXES
 }
 
 /** resolve() then realpath (macOS: /tmp → /private/tmp); best-effort, never throws. */

--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -22,6 +22,19 @@ const WORKTREE_MARKER = '/.claude/worktrees/'
 /** Temp roots (plus their macOS /private realpaths) — never project sessions. */
 const TMP_PREFIXES = ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp']
 
+/**
+ * Test-surface override (colon-separated), sibling of CHROXY_HOOKS_SKIP_CWD_FILTER:
+ * on Linux os.tmpdir() IS /tmp, so test fixtures built under the OS temp dir
+ * would classify as 'tmp' and legit-repo tests fail on CI but pass on macOS
+ * (/var/folders/...). Tests point this at a path that doesn't exist so their
+ * fixtures classify by the real rules. Never set in production.
+ */
+function tmpPrefixes(env) {
+  const raw = env?.CHROXY_HOOKS_TMP_PREFIXES
+  if (typeof raw !== 'string' || raw.length === 0) return TMP_PREFIXES
+  return raw.split(':').filter((p) => p.startsWith('/'))
+}
+
 /** resolve() then realpath (macOS: /tmp → /private/tmp); best-effort, never throws. */
 function realResolve(p) {
   let dir
@@ -69,7 +82,7 @@ export function classifyNonProjectCwd(cwd, env = process.env) {
   if (typeof cwd !== 'string' || cwd.length === 0) return null
   const dir = realResolve(cwd)
   if (!dir) return null
-  for (const prefix of TMP_PREFIXES) {
+  for (const prefix of tmpPrefixes(env)) {
     if (dir === prefix || dir.startsWith(prefix + '/')) return 'tmp'
   }
   if (dir.includes(WORKTREE_MARKER)) return 'worktree'

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -234,7 +234,15 @@ describe('runEmit', () => {
 
   after(() => server.close())
 
-  const envFor = () => ({ CHROXY_INGEST_URL: baseUrl, CHROXY_INGEST_SECRET: SECRET })
+  // CHROXY_HOOKS_TMP_PREFIXES points at a nonexistent root so fixtures built
+  // under os.tmpdir() — which IS /tmp on Linux CI — don't classify as 'tmp'
+  // and get suppressed before the behavior under test runs (#5439 GAP B).
+  // The tests that exercise tmp suppression itself override this explicitly.
+  const envFor = () => ({
+    CHROXY_INGEST_URL: baseUrl,
+    CHROXY_INGEST_SECRET: SECRET,
+    CHROXY_HOOKS_TMP_PREFIXES: '/chroxy-nonexistent-tmp',
+  })
 
   it('POSTs a schema-valid envelope with the bearer secret', async () => {
     const repo = tempRepo()
@@ -337,7 +345,8 @@ describe('runEmit', () => {
       const result = await runEmit({
         hookEventArg: 'session_start',
         stdinText: JSON.stringify({ cwd: tmpCwd, session_id: 's-tmp' }),
-        env: envFor(),
+        // real prefixes, stated explicitly (incl. the macOS /tmp realpath)
+        env: { ...envFor(), CHROXY_HOOKS_TMP_PREFIXES: '/tmp:/private/tmp' },
         now: () => NOW,
       })
       assert.deepEqual(result, { sent: false, reason: 'non_project_cwd' })
@@ -403,7 +412,11 @@ describe('runEmit', () => {
       const result = await runEmit({
         hookEventArg: 'session_start',
         stdinText: JSON.stringify({ cwd: tmpCwd, session_id: 's-bypass' }),
-        env: { ...envFor(), CHROXY_HOOKS_SKIP_CWD_FILTER: '1' },
+        env: {
+          ...envFor(),
+          CHROXY_HOOKS_TMP_PREFIXES: '/tmp:/private/tmp',
+          CHROXY_HOOKS_SKIP_CWD_FILTER: '1',
+        },
         now: () => NOW,
       })
       assert.deepEqual(result, { sent: true })


### PR DESCRIPTION
Main has been red on `Claude Hooks Tests` since #5465 landed: the #5439 GAP B cwd filter suppresses `/tmp` sessions, and on Linux `os.tmpdir()` IS `/tmp`, so the suite's legitimate-repo fixtures (built via `mkdtempSync(tmpdir())`) classified as `'tmp'` and were suppressed before the behavior under test ran. macOS dev machines never see it (`/var/folders/...`), which is why it passed locally and in the PR-era runs. Deterministic repro: `TMPDIR=/tmp npm test` → 3 failures, byte-identical to the main CI log.

## Fix

- `classifyNonProjectCwd` reads `CHROXY_HOOKS_TMP_PREFIXES` (colon-separated, documented as a test surface, sibling of the existing `CHROXY_HOOKS_SKIP_CWD_FILTER` escape hatch) before falling back to the built-in prefixes. Production behavior unchanged — the variable is never set outside tests.
- `envFor()` points it at a nonexistent root so legit fixtures classify by the real rules on any OS; the two tests that exercise tmp suppression itself pin `/tmp:/private/tmp` explicitly (including the macOS realpath).

## Test plan

- `npm test` (claude-hooks): 60/60 under default `TMPDIR` AND under `TMPDIR=/tmp` (the CI condition).
- The previously-failing trio (envelope POST, home-project non-suppression, worktree remap) all green under both.

Unbreaks main CI (the `Server Platform Tests (Windows)` red is separate — #5455).
