### PR TITLE
fix(desktop): label the external-session notification categories in the dashboard prefs

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -6,6 +6,8 @@
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import fs from 'node:fs'
+import path from 'node:path'
 import { SettingsPanel } from './SettingsPanel'
 
 // Mock theme-engine
@@ -1191,6 +1193,160 @@ describe('SettingsPanel', () => {
       })
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       expect(screen.getByTestId('notification-prefs-toggle-future_category')).toBeInTheDocument()
+    })
+  })
+
+  describe('Notification preferences — external-session categories (#5446)', () => {
+    // #5413 Phase 3 added session_online / session_offline / session_activity
+    // server-side; #5435 labeled them on mobile. These tests pin the dashboard
+    // labels + order to the same wording so the two clients never drift.
+    const categories = {
+      permission: true,
+      result: true,
+      activity_update: true,
+      activity_waiting: true,
+      activity_error: true,
+      inactivity_warning: true,
+      live_activity: true,
+      session_online: true,
+      session_offline: true,
+      session_activity: true,
+    }
+    const defaultPrefs = { categories, devices: {}, quietHours: null }
+
+    // Wording copied verbatim from packages/app/src/screens/SettingsScreen.tsx
+    // (#5435) — change both together or not at all.
+    const expectedLabels: Record<string, { label: string; hint: string }> = {
+      session_online: {
+        label: 'External session online',
+        hint: 'An external session reported in via /api/events.',
+      },
+      session_offline: {
+        label: 'External session offline',
+        hint: 'An external session ended or went away.',
+      },
+      session_activity: {
+        label: 'External session activity',
+        hint: 'Subagent and tool activity from external sessions.',
+      },
+    }
+
+    it('labels the three categories instead of falling back to the raw-key tail', () => {
+      setMockState({ notificationPrefs: defaultPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      for (const [cat, { label, hint }] of Object.entries(expectedLabels)) {
+        const toggle = screen.getByTestId(`notification-prefs-toggle-${cat}`)
+        // The row label is `meta?.label ?? cat` — raw key means no label entry.
+        expect(toggle.closest('label')?.textContent).toBe(label)
+        expect(screen.getByText(hint)).toBeInTheDocument()
+      }
+    })
+
+    it('orders them after result and before live_activity, matching mobile', () => {
+      setMockState({ notificationPrefs: defaultPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const rendered = screen
+        .getAllByTestId(/^notification-prefs-toggle-/)
+        .map((el) => el.getAttribute('data-testid')!.replace('notification-prefs-toggle-', ''))
+      expect(rendered).toEqual([
+        'permission',
+        'activity_waiting',
+        'activity_error',
+        'activity_update',
+        'inactivity_warning',
+        'result',
+        'session_online',
+        'session_offline',
+        'session_activity',
+        'live_activity',
+      ])
+    })
+  })
+
+  describe('Notification preferences — label sync with server ALL_CATEGORIES (#5446)', () => {
+    // Hardening: parse the canonical category enum straight out of
+    // packages/server/src/notification-prefs.js so a future server-side
+    // addition fails HERE (and in the mirror check below) instead of
+    // silently shipping a raw-key row in the unknown tail — the exact gap
+    // #5435 (mobile) and #5446 (dashboard) had to close after #5413.
+    function parseServerCategories(): string[] {
+      const src = fs.readFileSync(
+        path.resolve(__dirname, '../../../server/src/notification-prefs.js'),
+        'utf-8',
+      )
+      const m = src.match(/export const ALL_CATEGORIES = Object\.freeze\(\[([\s\S]*?)\]\)/)
+      if (!m) {
+        throw new Error(
+          'ALL_CATEGORIES not found in packages/server/src/notification-prefs.js — update this sync test',
+        )
+      }
+      return [...m[1]!.matchAll(/'([^']+)'/g)].map((hit) => hit[1]!)
+    }
+    const allCategories = parseServerCategories()
+
+    it('parses a sane category list from the server source', () => {
+      expect(allCategories.length).toBeGreaterThanOrEqual(10)
+      expect(allCategories).toContain('permission')
+      expect(allCategories).toContain('session_activity')
+    })
+
+    it('renders a friendly label for every server category (no raw-key fallback)', () => {
+      setMockState({
+        notificationPrefs: {
+          categories: Object.fromEntries(allCategories.map((c) => [c, true])),
+          devices: {},
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      for (const cat of allCategories) {
+        const toggle = screen.getByTestId(`notification-prefs-toggle-${cat}`)
+        // The unknown-key tail renders the raw key as the label text.
+        expect(toggle.closest('label')?.textContent).not.toBe(cat)
+      }
+    })
+
+    it('gives every server category an order slot (renders ahead of unknown keys)', () => {
+      // Known keys render in NOTIFICATION_CATEGORY_ORDER first; unknowns
+      // append after. Seed a sentinel unknown key — any server category
+      // missing an order slot would land at or after it.
+      setMockState({
+        notificationPrefs: {
+          categories: {
+            ...Object.fromEntries(allCategories.map((c) => [c, true])),
+            zz_unknown_sentinel: true,
+          },
+          devices: {},
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const rendered = screen
+        .getAllByTestId(/^notification-prefs-toggle-/)
+        .map((el) => el.getAttribute('data-testid')!.replace('notification-prefs-toggle-', ''))
+      const sentinelIdx = rendered.indexOf('zz_unknown_sentinel')
+      expect(sentinelIdx).toBeGreaterThan(-1)
+      for (const cat of allCategories) {
+        expect(rendered.indexOf(cat), `order slot for ${cat}`).toBeLessThan(sentinelIdx)
+      }
+    })
+
+    it('mobile SettingsScreen also labels every server category (cross-client guard)', () => {
+      // Same guard for the other client, asserted from one place so a new
+      // server category cannot fall into the raw-key tail on either UI.
+      const mobileSource = fs.readFileSync(
+        path.resolve(__dirname, '../../../app/src/screens/SettingsScreen.tsx'),
+        'utf-8',
+      )
+      const m = mobileSource.match(/const NOTIFICATION_CATEGORY_LABELS[^=]*=\s*\{([\s\S]*?)\n\};/)
+      if (!m) {
+        throw new Error(
+          'NOTIFICATION_CATEGORY_LABELS not found in packages/app/src/screens/SettingsScreen.tsx — update this sync test',
+        )
+      }
+      for (const cat of allCategories) {
+        expect(m[1], `mobile label for ${cat}`).toMatch(new RegExp(`\\b${cat}:`))
+      }
     })
   })
 

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -1307,14 +1307,19 @@ describe('SettingsPanel', () => {
     })
 
     it('gives every server category an order slot (renders ahead of unknown keys)', () => {
-      // Known keys render in NOTIFICATION_CATEGORY_ORDER first; unknowns
-      // append after. Seed a sentinel unknown key — any server category
-      // missing an order slot would land at or after it.
+      // Known keys render in NOTIFICATION_CATEGORY_ORDER first; unknown keys
+      // append after in *insertion order* (Object.keys is insertion-ordered
+      // for string keys — the zz_ prefix is cosmetic, nothing sorts). The
+      // sentinel therefore MUST be seeded FIRST: a server category missing
+      // its order slot falls into the unknown tail, and only a leading
+      // sentinel forces it to render after the sentinel. Seeded last, the
+      // missing category would render before the sentinel and this guard
+      // would pass vacuously (the #5032 lesson, again).
       setMockState({
         notificationPrefs: {
           categories: {
-            ...Object.fromEntries(allCategories.map((c) => [c, true])),
             zz_unknown_sentinel: true,
+            ...Object.fromEntries(allCategories.map((c) => [c, true])),
           },
           devices: {},
           quietHours: null,

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -92,6 +92,19 @@ const NOTIFICATION_CATEGORY_LABELS: Record<string, { label: string; hint?: strin
     label: 'Live Activity (iOS)',
     hint: 'iOS Dynamic Island / lock-screen Live Activity updates.',
   },
+  // #5413 Phase 3: external-session categories fed by POST /api/events.
+  session_online: {
+    label: 'External session online',
+    hint: 'An external session reported in via /api/events.',
+  },
+  session_offline: {
+    label: 'External session offline',
+    hint: 'An external session ended or went away.',
+  },
+  session_activity: {
+    label: 'External session activity',
+    hint: 'Subagent and tool activity from external sessions.',
+  },
 }
 
 /** Render order for known categories. Unknown keys append at the end in snapshot order. */
@@ -102,6 +115,11 @@ const NOTIFICATION_CATEGORY_ORDER = [
   'activity_update',
   'inactivity_warning',
   'result',
+  // External-session categories (#5413) grouped together, ahead of the
+  // platform-specific Live Activity entry which stays last.
+  'session_online',
+  'session_offline',
+  'session_activity',
   'live_activity',
 ]
 


### PR DESCRIPTION
Closes #5446.

## Summary

The dashboard's SettingsPanel carried its own `NOTIFICATION_CATEGORY_LABELS` / `NOTIFICATION_CATEGORY_ORDER` without the three external-session categories added server-side in #5413 (`session_online`, `session_offline`, `session_activity`), so they rendered through the raw-key unknown tail. This mirrors the mobile fix from #5443 (#5435) in the dashboard.

## Changes

- **`SettingsPanel.tsx`** — added the three entries to `NOTIFICATION_CATEGORY_LABELS` with the exact wording the mobile SettingsScreen uses ("External session online / offline / activity" + `/api/events` hints), and slotted them into `NOTIFICATION_CATEGORY_ORDER` after `result`, ahead of `live_activity` — same grouping as mobile.
- **`SettingsPanel.test.tsx`** —
  - New describe block pinning the three labels + hints and the full render order.
  - Label-sync hardening (the issue's optional item): tests parse `ALL_CATEGORIES` from `packages/server/src/notification-prefs.js` and assert every server category renders with a friendly label (not the raw-key fallback) and has an order slot (renders ahead of a seeded unknown-key sentinel). A cross-client guard also asserts the mobile `SettingsScreen.tsx` labels map covers every server category, so a future addition can't silently fall into the raw-key tail on either client.

## Testing

- `npx vitest run` (packages/dashboard): 166 files, 3289 tests passed
- `npx tsc --noEmit` (packages/dashboard): clean