### PR TITLE
fix(server): pin the Windows ACL test fixture against runner-image default drift

### DIFF
--- a/packages/server/tests/platform-windows.test.js
+++ b/packages/server/tests/platform-windows.test.js
@@ -183,17 +183,26 @@ try {
       // icacls steps (all principal identification via well-known SIDs so
       // the test stays locale-portable — display-language changes on a
       // future windows-latest image must not break ACE matching, #5003):
-      //   1. /inheritance:d  — break inheritance so we can replace ACEs.
-      //   2. /remove *S-1-5-32-545 (BUILTIN\Users), *S-1-1-0 (Everyone),
-      //      *S-1-5-11 (Authenticated Users) — strip group/world access
-      //      (these are the SIDs that a profile-rooted directory would
-      //      also lack). icacls accepts the `*<SID>` prefix in place of a
-      //      principal name.
+      //   1. /inheritance:r — REMOVE all inherited ACEs (not `:d`, which
+      //      copies them as explicit ACEs). Pre-#5455 this fixture used
+      //      `:d` + selective `/remove`, which left the directory's ACL
+      //      derived from whatever the runner image's temp-dir defaults
+      //      happened to be — i.e. the assertion partly tested the
+      //      image's inherited defaults, not our write behaviour, and a
+      //      windows-latest image update broke the job on every main
+      //      push. `:r` pins the fixture: the directory ACL below is
+      //      fully spelled out by this test, regardless of image drift.
+      //   2. /grant *S-1-5-18:(OI)(CI)F — NT AUTHORITY\SYSTEM, matching
+      //      the real per-user profile ACL shape (profile dirs grant
+      //      SYSTEM alongside the user).
       //   3. /grant *<current-user-SID>:(OI)(CI)F — grant the current user
       //      full control with object + container inherit so child files
       //      inherit user-only access. The current user's SID is parsed
       //      from `whoami /user` so we don't rely on %USERNAME% resolving
-      //      to a locale-stable display name.
+      //      to a locale-stable display name. icacls accepts the `*<SID>`
+      //      prefix in place of a principal name.
+      // All three run as a single icacls invocation so there is no
+      // intermediate state between stripping inheritance and granting.
       const restrictedDir = join(tmpDir, 'restricted')
       mkdirSync(restrictedDir)
 
@@ -214,92 +223,100 @@ try {
       const userSid = (whoami.stdout.match(/\bS-1-[\d-]+/) || [])[0]
       assert.ok(userSid, `failed to extract current user SID from whoami /user output:\n${whoami.stdout}`)
 
-      const breakInherit = spawnSync('icacls', [restrictedDir, '/inheritance:d'], { encoding: 'utf-8' })
-      assert.strictEqual(breakInherit.status, 0, `icacls /inheritance:d failed: ${breakInherit.stderr}`)
-
-      // Remove group/world ACEs by well-known SID rather than by their
-      // localised principal names. We tolerate "no such ACE" exits (the
-      // SIDs may not be present in the inherited ACL after :d), so we
-      // don't assert success on the remove steps.
-      //   *S-1-5-32-545  BUILTIN\Users
-      //   *S-1-1-0       Everyone
-      //   *S-1-5-11      NT AUTHORITY\Authenticated Users
-      spawnSync('icacls', [restrictedDir, '/remove', '*S-1-5-32-545'], { encoding: 'utf-8' })
-      spawnSync('icacls', [restrictedDir, '/remove', '*S-1-1-0'], { encoding: 'utf-8' })
-      spawnSync('icacls', [restrictedDir, '/remove', '*S-1-5-11'], { encoding: 'utf-8' })
-
-      // Grant the current user full control with OI/CI so files inherit
-      // user-only access. `*<SID>` keeps the call locale-independent.
-      const grant = spawnSync('icacls', [restrictedDir, '/grant', `*${userSid}:(OI)(CI)F`], { encoding: 'utf-8' })
-      assert.strictEqual(grant.status, 0, `icacls /grant failed: ${grant.stderr}`)
+      const pin = spawnSync(
+        'icacls',
+        [
+          restrictedDir,
+          '/inheritance:r',
+          '/grant', '*S-1-5-18:(OI)(CI)F',
+          '/grant', `*${userSid}:(OI)(CI)F`,
+        ],
+        { encoding: 'utf-8' }
+      )
+      assert.strictEqual(pin.status, 0, `icacls fixture pin failed: ${pin.stderr || pin.stdout}`)
 
       // Write the file via the helper and read back its ACL via
-      // PowerShell's `(Get-Acl <path>).Sddl`, which returns a single line
-      // of canonical SDDL with principals serialised as raw `S-1-...`
-      // strings (no two-letter abbreviations like `WD`/`AU`/`BU`, no
-      // locale-dependent display names). This is the documented
-      // contract for the .NET FileSecurity / DirectorySecurity SDDL
-      // property the cmdlet wraps.
+      // PowerShell: `(Get-Acl <path>).Sddl` for the raw SDDL string, then
+      // parse that SDDL with `RawSecurityDescriptor` and emit each DACL
+      // ACE's `SecurityIdentifier.Value` — one raw `S-1-...` SID per line.
+      //
+      // The per-ACE SID normalisation is load-bearing (#5455): contrary to
+      // what this test originally assumed, SDDL serialisation DOES
+      // abbreviate well-known principals to two-letter aliases (`SY`,
+      // `BA`, `BU`, `WD`, `AU`, and notably `LA` for the machine's RID-500
+      // Administrator). The windows-2025 image update of 2026-06 switched
+      // the job to run as the built-in Administrator, whose grant then
+      // rendered as `LA` instead of its raw SID — the #5032 tripwire below
+      // fired (correctly: the raw-SID substring checks were blind to alias
+      // forms). Comparing parsed full SIDs is alias-proof in both
+      // directions and makes prefix collisions (`S-1-5-11` vs
+      // `S-1-5-113`, the #5031 concern) structurally impossible — exact
+      // string equality on whole SIDs, no substring anchoring needed.
       //
       // Why not `icacls /save`: its output file is not specified to be
       // SDDL (the docs only call it "an ACL file for later use with
       // /restore"), is UTF-16 LE with BOM (so a utf-8 readFileSync
-      // returns nul-interleaved garbage), and even when it does emit
-      // SDDL fragments, well-known principals get two-letter
-      // abbreviations rather than raw SID strings — all three failure
-      // modes make the absence assertions vacuously true.
-      // Why not `icacls <file>`: it resolves SIDs back to display names,
-      // which would be locale-dependent and undo the entire point of
-      // pinning to SIDs above.
+      // returns nul-interleaved garbage), and its well-known-principal
+      // abbreviations are exactly the failure mode above.
+      // Why not `(Get-Acl).Access`: IdentityReference holds localised
+      // display names (locale-dependent, #5003); going through the SDDL
+      // string + RawSecurityDescriptor keeps the read-back on the same
+      // canonical path we report in failure messages.
       const filePath = join(restrictedDir, 'secret.json')
       writeFileRestricted(filePath, JSON.stringify({ token: 'sensitive' }))
       assert.ok(existsSync(filePath), 'file must exist after writeFileRestricted')
 
       // PowerShell on `windows-latest` is `powershell.exe` (Windows
       // PowerShell 5.1). `-NoProfile` skips any user profile that could
-      // perturb the output; the `;` after the assignment keeps the
-      // emitted line to just the SDDL string.
+      // perturb the output. Output contract: line 1 is the raw SDDL,
+      // every subsequent line is one DACL ACE's raw SID. A null DACL
+      // (everyone-allowed) yields no SID lines and trips the #5032
+      // tripwire below, as it should.
+      const psScript = [
+        `$ErrorActionPreference = 'Stop'`,
+        `$sddl = (Get-Acl -LiteralPath '${filePath.replace(/'/g, "''")}').Sddl`,
+        `$sd = New-Object System.Security.AccessControl.RawSecurityDescriptor($sddl)`,
+        `Write-Output $sddl`,
+        `if ($sd.DiscretionaryAcl) { $sd.DiscretionaryAcl | ForEach-Object { Write-Output $_.SecurityIdentifier.Value } }`,
+      ].join('; ')
       const getAcl = spawnSync(
         'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          `(Get-Acl -LiteralPath '${filePath.replace(/'/g, "''")}').Sddl`,
-        ],
+        ['-NoProfile', '-NonInteractive', '-Command', psScript],
         { encoding: 'utf-8' }
       )
-      assert.strictEqual(getAcl.status, 0, `Get-Acl failed: ${getAcl.stderr}`)
-      const sddl = getAcl.stdout.trim()
+      assert.strictEqual(getAcl.status, 0, `Get-Acl read-back failed: ${getAcl.stderr}`)
+      const [sddl = '', ...aceSids] = getAcl.stdout.trim().split(/\r?\n/).map((line) => line.trim())
       assert.ok(sddl.length > 0, `Get-Acl returned empty SDDL`)
 
       // Tripwire: confirm the read-back path can actually detect a SID
       // before we run absence assertions. We assert the current user's
       // SID IS present (the explicit grant added above must round-trip
       // into the file's inherited ACL), which means a future regression
-      // that breaks the read-back (encoding, format, parsing) would
-      // fire this assertion before silently green-lighting a real ACL
-      // regression downstream. See #5032.
+      // that breaks the read-back (encoding, format, SDDL parsing,
+      // alias handling) would fire this assertion before silently
+      // green-lighting a real ACL regression downstream. See #5032.
       assert.ok(
-        sddl.includes(userSid),
-        `tripwire: SDDL must contain the current user's SID (${userSid}) — read-back path is broken if absent:\n${sddl}`
+        aceSids.includes(userSid),
+        `tripwire: DACL must contain an ACE for the current user's SID (${userSid}) — read-back path is broken if absent.\nSDDL: ${sddl}\nACE SIDs: ${aceSids.join(', ')}`
       )
 
-      // Assert the SDDL does not contain the group/world SIDs. ACEs in
-      // SDDL are written as `(A;...;<sid>)` — we anchor on the closing
-      // `)` so a prefix collision (e.g. `S-1-5-11` vs `S-1-5-113`,
-      // `S-1-5-114`) cannot cause a false positive. See #5031.
+      // Assert the DACL has no ACE for the group/world principals.
+      // Exact equality on the parsed full SIDs — alias-proof (see #5455)
+      // and immune to the #5031 prefix-collision concern by construction.
+      //   S-1-5-32-545  BUILTIN\Users
+      //   S-1-1-0       Everyone
+      //   S-1-5-11      NT AUTHORITY\Authenticated Users
       assert.ok(
-        !/;S-1-5-32-545\)/.test(sddl),
-        `SDDL must not contain BUILTIN\\Users (*S-1-5-32-545):\n${sddl}`
+        !aceSids.includes('S-1-5-32-545'),
+        `DACL must not contain BUILTIN\\Users (S-1-5-32-545).\nSDDL: ${sddl}\nACE SIDs: ${aceSids.join(', ')}`
       )
       assert.ok(
-        !/;S-1-1-0\)/.test(sddl),
-        `SDDL must not contain Everyone (*S-1-1-0):\n${sddl}`
+        !aceSids.includes('S-1-1-0'),
+        `DACL must not contain Everyone (S-1-1-0).\nSDDL: ${sddl}\nACE SIDs: ${aceSids.join(', ')}`
       )
       assert.ok(
-        !/;S-1-5-11\)/.test(sddl),
-        `SDDL must not contain Authenticated Users (*S-1-5-11):\n${sddl}`
+        !aceSids.includes('S-1-5-11'),
+        `DACL must not contain Authenticated Users (S-1-5-11).\nSDDL: ${sddl}\nACE SIDs: ${aceSids.join(', ')}`
       )
     })
   })


### PR DESCRIPTION
## Problem

`Server Platform Tests (Windows)` is red on every main push: the #4927 ACL-inheritance assertion (`a freshly written file under a user-only directory does NOT grant Users / Everyone access`) fails at the #5032 tripwire. PR runs don't see it because of the #5002 path gate.

## Root cause: runner-image drift, not a `writeFileRestricted` regression

The failing run's SDDL dump (run 27298087888, image `windows-2025 20260607.161.1`):

```
tripwire: SDDL must contain the current user's SID (S-1-5-21-508430013-671840188-3235177247-500) — read-back path is broken if absent:
O:LAG:S-1-5-21-508430013-671840188-3235177247-513D:AI(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;FA;;;LA)
```

Reading the ACEs: the freshly written file's DACL is **exactly correct** — SYSTEM (`SY`), Administrators (`BA`), and the current user (`LA`), all inherited from the fixture directory; **no Users / Everyone / Authenticated Users ACE**. `writeFileRestricted` did not regress.

What changed is the image: the job now runs as the **built-in Administrator (RID 500)** instead of `runneradmin` (a normal RID-1000+ local account). SDDL serialisation abbreviates well-known SIDs, so the current user's ACE renders as the alias `LA` rather than the raw `S-1-5-21-…-500` string — and the tripwire's `sddl.includes(userSid)` substring check fails.

The tripwire fired correctly, in the #5032 sense: it exposed that the SDDL raw-SID substring checks were blind to alias forms. The test's premise that `Get-Acl` SDDL contains "no two-letter abbreviations" is empirically false (`SY`/`BA`/`LA` in the dump above) — so the absence checks for `S-1-5-32-545` / `S-1-1-0` / `S-1-5-11` were **latently vacuous**: had those principals been present they'd have rendered as `BU` / `WD` / `AU`, which the raw-SID regexes never match.

## Fix (test only — no production code change)

1. **Pin the fixture** against image-default drift: a single `icacls` invocation with `/inheritance:r` (remove ALL inherited ACEs — the old `:d` + selective `/remove` kept whatever the image's temp-dir defaults were) plus explicit `(OI)(CI)F` grants for SYSTEM (`*S-1-5-18`) and the current user's SID. The directory ACL is now fully spelled out by the test, so the assertion tests **our write behaviour**, not the runner's inherited defaults.
2. **Alias-proof read-back**: the PowerShell step still fetches `(Get-Acl).Sddl`, but now also parses it with `RawSecurityDescriptor` and emits each DACL ACE's raw SID (one per line). The #5032 tripwire and the #5031 absence checks compare **exact full SID strings** — immune to well-known-SID aliasing in both directions, and the #5031 prefix-collision concern (`S-1-5-11` vs `S-1-5-113`) is structurally impossible with whole-string equality. A null DACL (everyone-allowed) yields no SID lines and trips the tripwire, preserving the anti-vacuous-truth guarantee. Failure messages still dump the raw SDDL plus the parsed SID list.

Both hardening rounds are strengthened, not weakened: the absence checks now actually cover the alias forms they previously missed.

## Verification

- macOS/Linux: `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit ./tests/platform.test.js ./tests/platform-windows.test.js` — 18/18 pass (Windows suite skips on POSIX as designed).
- Windows: this PR touches `packages/server/tests/platform*.test.js`, so the #5002 path gate runs `Server Platform Tests (Windows)` on this PR — that job is the verification loop.

Closes #5455.