### PR TITLE
chore: review follow-ups — pruneAfterMs floor + tmp-prefix fallback coverage

### DIFF
--- a/docs/guides/discord-notifications.md
+++ b/docs/guides/discord-notifications.md
@@ -118,7 +118,11 @@ The non-secret knobs live in `~/.chroxy/config.json` under
   refreshed — an offline embed is final and is never re-PATCHed.
 - **`pruneAfterMs`** — how long a project entry may sit untouched in the
   state file before chroxy stops tracking it (default `86400000` / 24h;
-  `0` disables pruning). Only real pipeline events count as touches —
+  `0` disables pruning; minimum `60000` / 60s — smaller values fall back
+  to the default, since a retention shorter than the gap between events
+  would prune the tracked message id in between and turn the single
+  status embed into one message per event). Only real pipeline events
+  count as touches —
   heartbeat footer refreshes deliberately don't reset the clock, so an
   entry whose session stopped emitting events (e.g. ended without a
   session-end event) is dropped instead of being refreshed forever.

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -23,7 +23,7 @@ import { IngestEventSchema } from '@chroxy/protocol'
 import { buildEnvelope, resolveHookEvent, runEmit, sanitizeData, SOURCE } from '../src/emit.js'
 import { EMITTERS } from '../src/emitters.js'
 import { resolveIngestUrl, resolveIngestSecret, DEFAULT_PORT } from '../src/config.js'
-import { deriveProject } from '../src/project.js'
+import { classifyNonProjectCwd, deriveProject } from '../src/project.js'
 
 const SECRET = 'test-hooks-secret'
 const NOW = 1_750_000_000_000
@@ -142,6 +142,41 @@ describe('deriveProject', () => {
     writeFileSync(join(wt, '.git'), 'gitdir: /elsewhere/worktrees/agent-abc123\n')
     assert.equal(deriveProject(wt, {}), 'myproj')
     assert.equal(deriveProject(join(wt, 'packages', 'server'), {}), 'myproj', 'nested worktree cwd remaps too')
+  })
+})
+
+// #5471: every runEmit suppression test sets CHROXY_HOOKS_TMP_PREFIXES, so
+// the default `return TMP_PREFIXES` branch of tmpPrefixes() is never hit by
+// the emit tests — a regression in the production list would ship silently
+// while the pinned tests stayed green. Pin the built-in list (and the
+// override normalization) directly. Hermetic: the paths don't need to exist
+// (realResolve falls back to the resolved path when realpathSync throws), so
+// this passes under any TMPDIR on both Linux and macOS; on macOS an existing
+// /tmp/... realpaths to /private/tmp/..., which the default list also covers.
+describe('classifyNonProjectCwd — default TMP_PREFIXES fallback (#5471)', () => {
+  it('classifies /tmp and /var/tmp as tmp with the env var unset (production list)', () => {
+    assert.equal(classifyNonProjectCwd('/tmp/some-session', {}), 'tmp')
+    assert.equal(classifyNonProjectCwd('/var/tmp/x', {}), 'tmp')
+    // macOS realpaths of the same roots are first-class entries too
+    assert.equal(classifyNonProjectCwd('/private/tmp/some-session', {}), 'tmp')
+    assert.equal(classifyNonProjectCwd('/private/var/tmp/x', {}), 'tmp')
+  })
+
+  it('falls back to the built-ins on an empty override', () => {
+    assert.equal(classifyNonProjectCwd('/tmp/x', { CHROXY_HOOKS_TMP_PREFIXES: '' }), 'tmp')
+  })
+
+  it('falls back to the built-ins when the override yields no usable absolute prefixes', () => {
+    const env = { CHROXY_HOOKS_TMP_PREFIXES: 'relative/path: ::  ' }
+    assert.equal(classifyNonProjectCwd('/tmp/x', env), 'tmp')
+  })
+
+  it('trims override entries and strips trailing slashes (cea68b30b normalization)', () => {
+    const env = { CHROXY_HOOKS_TMP_PREFIXES: ' /chroxy-test-tmp/ ' }
+    assert.equal(classifyNonProjectCwd('/chroxy-test-tmp/session', env), 'tmp', 'trailing slash stripped — prefix + "/" still matches')
+    assert.equal(classifyNonProjectCwd('/chroxy-test-tmp', env), 'tmp', 'the root itself matches after trimming')
+    assert.equal(classifyNonProjectCwd('/chroxy-test-tmpfoo', env), null, 'no false prefix match on a sibling name')
+    assert.equal(classifyNonProjectCwd('/tmp/x', env), null, 'a usable override REPLACES the built-ins')
   })
 })
 

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -533,7 +533,7 @@ The non-secret knobs live under `notifications.discord` in `config.json`:
 | `errorColor` | number | Sidebar color for the session-error state (default `15158332`, red) |
 | `updateThrottleMs` | number | Minimum interval between same-state routine embed updates per project (default `15000`; state changes always go out) |
 | `heartbeatIntervalMs` | number | Elapsed-time footer refresh interval for live embeds — offline embeds are final and never re-PATCHed (default `300000`; `0` disables; minimum `10000`) |
-| `pruneAfterMs` | number | Retention for state-store entries: entries untouched longer than this are dropped on load (default `86400000` / 24h; `0` disables; the last Discord message is kept). Heartbeat refreshes don't reset the clock — only real pipeline events do |
+| `pruneAfterMs` | number | Retention for state-store entries: entries untouched longer than this are dropped on load (default `86400000` / 24h; `0` disables; minimum `60000` / 60s — smaller values fall back to the default, since a retention shorter than the gap between events prunes the tracked message id in between and turns the embed into message-per-event spam; the last Discord message is kept). Heartbeat refreshes don't reset the clock — only real pipeline events do |
 
 Status-message state (message ids, current state per project) persists in
 `~/.chroxy/discord-webhook-state.json`. Full setup walkthrough:

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -485,11 +485,16 @@ function validateDiscordNotificationsBlock(discord, warnings) {
   }
 
   // #5429/#5434: state-store entry retention. 0 disables pruning; the sink
-  // falls back to its 24h default on invalid values.
+  // falls back to its 24h default on invalid values. #5457: values below 60s
+  // get the same treatment — a retention shorter than the gap between events
+  // prunes the messageId in between and turns the single status embed into
+  // message-per-event spam (parity with the heartbeatIntervalMs floor).
   if (Object.prototype.hasOwnProperty.call(discord, 'pruneAfterMs')) {
     const v = discord.pruneAfterMs
     if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
       warnings.push(`Invalid value for 'notifications.discord.pruneAfterMs': expected a number >= 0 (0 disables pruning), got ${JSON.stringify(v)}`)
+    } else if (v !== 0 && v < 60_000) {
+      warnings.push(`Invalid value for 'notifications.discord.pruneAfterMs': ${v} (minimum 60000 / 60s; set 0 to disable pruning — the sink falls back to its default)`)
     }
   }
 }

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -74,6 +74,13 @@ const MAX_RETRY_AFTER_MS = 30_000
 // this are dropped at load time; the Discord message itself is KEPT (an
 // offline embed is a final record — only the tracking stops).
 const DEFAULT_PRUNE_AFTER_MS = 86_400_000 // 24h
+// #5457: sanity floor. A retention shorter than the gap between consecutive
+// events prunes the entry (and its messageId) in between, so every event
+// takes the no-`prev` path and POSTs a brand-new message — message-per-event
+// spam instead of one embed PATCHed in place. Anything below updateThrottleMs
+// is definitely pathological; 60s is the conservative line. 0 stays the
+// documented disable (parity with the heartbeatIntervalMs 10s floor).
+const MIN_PRUNE_AFTER_MS = 60_000 // 60s
 
 // Embed sidebar color defaults — ported from claude-code-notify
 // (colors.conf.example + the CLAUDE_NOTIFY_*_COLOR defaults).
@@ -168,7 +175,9 @@ export class DiscordWebhookSink extends NotificationSink {
    * @param {number} [opts.pruneAfterMs] - Retention for state-store entries
    *   (#5429/#5434): entries whose lastUpdateTs is older than this are
    *   dropped at load time (the first load after init is the startup sweep).
-   *   0 disables pruning; invalid values fall back to the 24h default.
+   *   0 disables pruning; invalid values and values below 60s fall back to
+   *   the 24h default (#5457 — a tiny retention prunes the messageId between
+   *   events and turns the status embed into message-per-event spam).
    * @param {Function} [opts.resolveWebhookUrl] - Injection seam for tests;
    *   defaults to the env > 0600-credentials.json resolver.
    * @param {Function} [opts.sleepImpl] - Injection seam for tests (429/backoff
@@ -203,7 +212,9 @@ export class DiscordWebhookSink extends NotificationSink {
     if (!Number.isFinite(heartbeatIntervalMs) || heartbeatIntervalMs < 0) heartbeatIntervalMs = 300_000
     if (heartbeatIntervalMs > 0 && heartbeatIntervalMs < 10_000) heartbeatIntervalMs = 300_000
     this._heartbeatIntervalMs = heartbeatIntervalMs
-    this._pruneAfterMs = Number.isFinite(pruneAfterMs) && pruneAfterMs >= 0 ? pruneAfterMs : DEFAULT_PRUNE_AFTER_MS
+    if (!Number.isFinite(pruneAfterMs) || pruneAfterMs < 0) pruneAfterMs = DEFAULT_PRUNE_AFTER_MS
+    if (pruneAfterMs > 0 && pruneAfterMs < MIN_PRUNE_AFTER_MS) pruneAfterMs = DEFAULT_PRUNE_AFTER_MS
+    this._pruneAfterMs = pruneAfterMs
     this._resolveWebhookUrl = resolveWebhookUrl
     this._sleep = sleepImpl
     this._now = now

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -687,6 +687,22 @@ describe('config — notifications.discord block (#5413)', () => {
     const result = validateConfig({ notifications: { discord: { heartbeatIntervalMs: 500 } } })
     assert.ok(result.warnings.some((w) => w.includes('heartbeatIntervalMs')))
   })
+
+  // #5457: a tiny retention prunes the entry (and its messageId) between
+  // consecutive events — every event then POSTs a brand-new message instead
+  // of PATCHing in place. Same non-fatal warning as the heartbeat floor.
+  it('warns on a too-small pruneAfterMs (value warning, never fatal) (#5457)', () => {
+    const result = validateConfig({ notifications: { discord: { pruneAfterMs: 5_000 } } })
+    assert.ok(result.warnings.some((w) => w.includes('pruneAfterMs') && w.includes('60000')))
+    assert.ok(!result.warnings.some((w) => w.startsWith('Invalid type')))
+  })
+
+  it('does not warn on pruneAfterMs at the floor or at 0 (disable)', () => {
+    for (const v of [0, 60_000, 86_400_000]) {
+      const result = validateConfig({ notifications: { discord: { pruneAfterMs: v } } })
+      assert.ok(!result.warnings.some((w) => w.includes('pruneAfterMs')), `unexpected warning for ${v}: ${JSON.stringify(result.warnings)}`)
+    }
+  })
 })
 
 describe('formatDuration (ported from claude-code-notify)', () => {
@@ -1163,6 +1179,21 @@ describe('DiscordWebhookSink — stale-entry pruning (#5429 / #5434)', () => {
     assert.equal(sink._pruneAfterMs, DAY_MS)
     const { sink: sink2 } = makeSink({ pruneAfterMs: 'soon' })
     assert.equal(sink2._pruneAfterMs, DAY_MS)
+  })
+
+  // #5457: a retention below the 60s floor prunes the entry between
+  // consecutive events, breaking PATCH-in-place into message-per-event spam.
+  // Clamp to the default (parity with the heartbeatIntervalMs clamp); 0
+  // stays 0 — it is the documented disable.
+  it('a too-small pruneAfterMs (0 < v < 60s) falls back to the default retention (#5457)', () => {
+    const { sink } = makeSink({ pruneAfterMs: 5_000 })
+    assert.equal(sink._pruneAfterMs, DAY_MS)
+    const { sink: sink2 } = makeSink({ pruneAfterMs: 59_999 })
+    assert.equal(sink2._pruneAfterMs, DAY_MS)
+    const { sink: sink3 } = makeSink({ pruneAfterMs: 60_000 })
+    assert.equal(sink3._pruneAfterMs, 60_000, 'the floor itself is accepted')
+    const { sink: sink4 } = makeSink({ pruneAfterMs: 0 })
+    assert.equal(sink4._pruneAfterMs, 0, '0 stays the documented disable')
   })
 
   it('a state file whose projects slot is an array is treated as corrupt (fresh map, tracking persists)', async () => {


### PR DESCRIPTION
Two small review follow-ups, one commit each.

## 1. `fix(server)`: floor `notifications.discord.pruneAfterMs` at 60s (#5457)

A retention shorter than the gap between consecutive events prunes a project's state-store entry (and its tracked messageId) in between, so every event takes the no-`prev` path and POSTs a brand-new message — the single PATCH-in-place status embed degrades into one frozen embed per event.

- `validateDiscordNotificationsBlock` warns on `0 < pruneAfterMs < 60000` with the same non-fatal "Invalid value" wording as the `heartbeatIntervalMs` floor
- `DiscordWebhookSink` clamps such values to the 24h default (parity with the `heartbeatIntervalMs` clamp); `0` stays the documented disable
- Tests pin the warning, the clamp, the 60s floor boundary (accepted), and `0`
- `CONFIG.md` + `docs/guides/discord-notifications.md` document the floor

## 2. `test(claude-hooks)`: cover the tmp-prefix fallback in `classifyNonProjectCwd` (#5471)

After #5470, every `runEmit` suppression test sets `CHROXY_HOOKS_TMP_PREFIXES`, so the default `return TMP_PREFIXES` branch of `tmpPrefixes()` was never executed by any test. New hermetic unit tests pin:

- env var unset → `/tmp`, `/var/tmp` (and `/private` macOS realpaths) classify as `tmp` via the built-in list
- empty and malformed-only overrides fall back to the built-ins instead of silently disabling suppression
- the trim / trailing-slash normalization from cea68b30b, and that a usable override replaces the built-ins

Hermetic under any `TMPDIR` on both Linux and macOS — the probed paths need not exist (`realResolve` falls back to the resolved path when `realpathSync` throws).

## Testing

- `packages/server`: `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test tests/discord-webhook-sink.test.js` — 85/85 pass (TDD: both new tests red before the fix)
- `packages/claude-hooks`: `npm test` — 64/64 pass
- `lint-logger-session-scoping.sh` / `lint-session-opt-forwarding.sh` / `lint-tests-state-file-path.sh` all green; eslint clean

Closes #5457.
Closes #5471.