### PR TITLE
fix(claude-hooks): map ~/.chroxy/worktrees sessions to their parent project

### DIFF
--- a/packages/claude-hooks/README.md
+++ b/packages/claude-hooks/README.md
@@ -40,14 +40,17 @@ Everything resolves automatically from the chroxy daemon's config; env vars over
 | `CHROXY_HOOKS_SETTINGS_PATH` | `~/.claude/settings.json` (install/uninstall target) |
 | `CHROXY_HOOKS_DEBUG=1` | stderr diagnostics from `emit` (silent otherwise) |
 | `CHROXY_HOOKS_SKIP_CWD_FILTER=1` | bypass the non-project cwd filter (tests/debugging) |
+| `CHROXY_HOOKS_CHROXY_WORKTREES_ROOT` | `~/.chroxy/worktrees` (chroxy session-worktree root; test-surface override) |
 
-`project` is derived hook-side (worktree-parent remap for `.claude/worktrees/*` checkouts,
+`project` is derived hook-side (worktree-parent remap for `.claude/worktrees/*` checkouts
+and for chroxy session worktrees under `~/.chroxy/worktrees/<id>` — parsed back to the
+parent repo via the worktree `.git` file's `gitdir:` since the id basename is opaque —
 then cwd → nearest `.git`, then `$CLAUDE_PROJECT_DIR`) and sent explicitly; the server's
 cwd derivation is fallback only.
 
-Non-project sessions are filtered hook-side (#5439): temp-dir (`/tmp`, `/var/tmp`) and
-home-root cwds emit nothing; worktree-agent cwds emit only subagent events, attributed to
-the parent project. The `Notification` emitter forwards `notification_type`
+Non-project sessions are filtered hook-side (#5439, #5464): temp-dir (`/tmp`, `/var/tmp`)
+and home-root cwds emit nothing; worktree cwds (both sources) emit only subagent events,
+attributed to the parent project. The `Notification` emitter forwards `notification_type`
 (`idle_prompt` / `permission_prompt`) so the server can distinguish "ready for input"
 from "needs approval".
 

--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -12,7 +12,7 @@
  * shells out (this runs on every hook fire inside the <100ms budget).
  */
 
-import { existsSync, realpathSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 
@@ -59,15 +59,91 @@ function realResolve(p) {
 }
 
 /**
+ * #5464: chroxy's SECOND worktree source — session worktrees the daemon
+ * creates at ~/.chroxy/worktrees/<sessionId> (DEFAULT_WORKTREE_BASE in
+ * packages/server/src/session-manager.js, `git worktree add --detach`).
+ * The basename is an opaque hex session id, so unlike .claude/worktrees
+ * the parent project is NOT in the path — it has to be recovered from the
+ * worktree's .git file (see chroxyWorktreeParentProject).
+ *
+ * Test-surface override, sibling of CHROXY_HOOKS_TMP_PREFIXES: fixtures
+ * must be buildable under a temp dir on any OS, so the root is
+ * env-injectable. An unusable override (relative/empty) falls back to the
+ * real default rather than silently disabling the classification.
+ */
+function chroxyWorktreesRoot(env) {
+  const override = env?.CHROXY_HOOKS_CHROXY_WORKTREES_ROOT
+  if (typeof override === 'string' && override.length > 0) {
+    const trimmed = override.trim().replace(/\/+$/, '')
+    if (trimmed.startsWith('/')) return realResolve(trimmed)
+  }
+  const home = typeof env?.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
+  if (!home) return null
+  return realResolve(join(home, '.chroxy', 'worktrees'))
+}
+
+/**
+ * If `dir` (already real-resolved) is inside a chroxy session worktree,
+ * return that worktree's top dir (<root>/<sessionId>); else null. The root
+ * itself is not a worktree.
+ */
+function chroxyWorktreeTopDir(dir, env) {
+  const root = chroxyWorktreesRoot(env)
+  if (!root || !dir.startsWith(root + '/')) return null
+  const id = dir.slice(root.length + 1).split('/')[0]
+  return id.length > 0 ? join(root, id) : null
+}
+
+/**
+ * Recover the parent project for a chroxy session worktree from its .git
+ * FILE: `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so
+ * the repo root (the parent project) is three segments up. Returns null on
+ * any read/shape surprise — callers fall back, and classification (which
+ * must not depend on this parse) is handled separately.
+ */
+function chroxyWorktreeParentProject(worktreeDir) {
+  let raw
+  try {
+    raw = readFileSync(join(worktreeDir, '.git'), 'utf8')
+  } catch {
+    return null
+  }
+  const match = /^gitdir:\s*(.+?)\s*$/m.exec(raw)
+  if (!match) return null
+  let linkedGitDir
+  try {
+    // gitdir is absolute in practice; resolve() also covers relative ones.
+    linkedGitDir = resolve(worktreeDir, match[1])
+  } catch {
+    return null
+  }
+  const worktreesDir = dirname(linkedGitDir) // <repo>/.git/worktrees
+  if (basename(worktreesDir) !== 'worktrees') return null
+  const gitDir = dirname(worktreesDir) // <repo>/.git
+  const repoRoot = basename(gitDir) === '.git' ? dirname(gitDir) : gitDir
+  const name = basename(repoRoot)
+  return name.length > 0 ? name : null
+}
+
+/**
  * #5439 GAP B: a cwd inside a worktree checkout belongs to the PARENT
  * project — the segment before /.claude/worktrees/ — not the agent-*
  * checkout (port of extract_project_name's worktree remap; without this
  * every parallel agent mints its own `agent-<hash>` status embed).
+ *
+ * #5464 extends this to chroxy session worktrees (~/.chroxy/worktrees/<id>):
+ * their basename is an opaque session id, so the parent is parsed from the
+ * worktree .git file's gitdir instead. The chroxy check runs FIRST — an
+ * agent worktree nested INSIDE a chroxy worktree should still resolve to
+ * the real repo (the chroxy worktree's .git points there), not to the
+ * opaque id the /.claude/worktrees/ marker split would yield.
  */
-export function worktreeParent(cwd) {
+export function worktreeParent(cwd, env = process.env) {
   if (typeof cwd !== 'string' || cwd.length === 0) return null
   const dir = realResolve(cwd)
   if (!dir) return null
+  const chroxyTop = chroxyWorktreeTopDir(dir, env)
+  if (chroxyTop) return chroxyWorktreeParentProject(chroxyTop)
   const idx = dir.indexOf(WORKTREE_MARKER)
   if (idx <= 0) return null
   const name = basename(dir.slice(0, idx))
@@ -81,8 +157,10 @@ export function worktreeParent(cwd) {
  *   'tmp'      — /tmp, /var/tmp (and their /private macOS realpaths)
  *   'home'     — the home directory ROOT itself (basename = username, not a
  *                project); projects under home are fine
- *   'worktree' — .claude/worktrees agent checkouts (runEmit suppresses all
- *                but subagent events, whose counts belong to the parent)
+ *   'worktree' — .claude/worktrees agent checkouts AND chroxy session
+ *                worktrees under ~/.chroxy/worktrees/<id> (#5464); runEmit
+ *                suppresses all but subagent events, whose counts belong
+ *                to the parent project
  *
  * Returns null for normal project cwds or when no cwd is available.
  */
@@ -93,7 +171,10 @@ export function classifyNonProjectCwd(cwd, env = process.env) {
   for (const prefix of tmpPrefixes(env)) {
     if (dir === prefix || dir.startsWith(prefix + '/')) return 'tmp'
   }
-  if (dir.includes(WORKTREE_MARKER)) return 'worktree'
+  // Path-shape only — never gated on the .git gitdir parse succeeding: a
+  // session in a chroxy worktree must stay suppressed even when the parent
+  // can't be recovered (it would otherwise mint an opaque-id embed).
+  if (dir.includes(WORKTREE_MARKER) || chroxyWorktreeTopDir(dir, env)) return 'worktree'
   const homeRaw = typeof env.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
   if (homeRaw) {
     let homeResolved
@@ -143,7 +224,7 @@ function gitRootName(cwd) {
  * the last-resort fallback).
  */
 export function deriveProject(cwd, env = process.env) {
-  const fromWorktree = worktreeParent(cwd)
+  const fromWorktree = worktreeParent(cwd, env)
   if (fromWorktree) return fromWorktree
   const fromCwd = gitRootName(cwd)
   if (fromCwd) return fromCwd

--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -120,7 +120,13 @@ function chroxyWorktreeParentProject(worktreeDir) {
   const worktreesDir = dirname(linkedGitDir) // <repo>/.git/worktrees
   if (basename(worktreesDir) !== 'worktrees') return null
   const gitDir = dirname(worktreesDir) // <repo>/.git
-  const repoRoot = basename(gitDir) === '.git' ? dirname(gitDir) : gitDir
+  // Strict shape: the linked gitdir must be <repo>/.git/worktrees/<id> — the
+  // only shape `git worktree add` writes for the daemon's checkouts (the base
+  // cwd is always a normal working tree, never bare). Anything else (e.g.
+  // `/somewhere/worktrees/x`) is a shape surprise → null, so a tampered .git
+  // file can't misattribute the project; classification still suppresses.
+  if (basename(gitDir) !== '.git') return null
+  const repoRoot = dirname(gitDir)
   const name = basename(repoRoot)
   return name.length > 0 ? name : null
 }

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -223,6 +223,42 @@ describe('worktreeParent (#5464 chroxy worktrees)', () => {
     assert.equal(worktreeParent(root, env), null, 'the base dir is not a worktree')
     assert.equal(worktreeParent(join(base, 'projects', 'coolproj'), env), null, 'sibling paths are untouched')
   })
+
+  // Ordering pin: the chroxy-root check must run BEFORE the /.claude/worktrees/
+  // marker split. An agent worktree nested INSIDE a chroxy worktree must
+  // resolve via the chroxy worktree's .git file to the real repo — the marker
+  // split alone would yield the opaque session id (basename of the segment
+  // before the marker). Reordering the checks regresses this silently.
+  it('resolves an agent worktree nested inside a chroxy worktree to the real repo, not the opaque id', () => {
+    const { root, id, wt } = chroxyWorktreeFixture()
+    const nested = join(wt, '.claude', 'worktrees', 'agent-deadbeef', 'src')
+    mkdirSync(nested, { recursive: true })
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }
+    assert.equal(worktreeParent(nested, env), 'coolproj')
+    assert.notEqual(worktreeParent(nested, env), id, 'the marker split must not win over the chroxy gitdir parse')
+    assert.equal(deriveProject(nested, env), 'coolproj')
+  })
+
+  // #5470 lesson, pinned: an unusable override must FALL BACK to the $HOME
+  // default, not silently disable the chroxy-worktree handling.
+  it('falls back to the $HOME default when CHROXY_HOOKS_CHROXY_WORKTREES_ROOT is unusable', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hooks-chroxyhome-'))
+    const id = 'cafebabecafebabecafebabecafebabe'
+    const wt = join(home, '.chroxy', 'worktrees', id)
+    mkdirSync(wt, { recursive: true })
+    const repoRoot = join(home, 'projects', 'fallbackproj')
+    mkdirSync(join(repoRoot, '.git', 'worktrees', id), { recursive: true })
+    writeFileSync(join(wt, '.git'), `gitdir: ${join(repoRoot, '.git', 'worktrees', id)}\n`)
+    for (const bad of ['relative/junk', '   ', '/']) {
+      const env = { HOME: home, CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: bad }
+      assert.equal(worktreeParent(wt, env), 'fallbackproj', `override ${JSON.stringify(bad)} falls back to $HOME default`)
+      assert.equal(
+        classifyNonProjectCwd(wt, { ...env, CHROXY_HOOKS_TMP_PREFIXES: '/chroxy-nonexistent-tmp' }),
+        'worktree',
+        `classification survives unusable override ${JSON.stringify(bad)}`
+      )
+    }
+  })
 })
 
 describe('classifyNonProjectCwd (#5464 chroxy worktrees)', () => {

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -215,6 +215,12 @@ describe('worktreeParent (#5464 chroxy worktrees)', () => {
 
     const wrongShape = chroxyWorktreeFixture({ gitdir: '/somewhere/unrelated' })
     assert.equal(worktreeParent(wrongShape.wt, { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: wrongShape.root }), null, 'gitdir not under */worktrees/<id>')
+
+    // A worktrees-shaped gitdir that is NOT under a .git dir must also be
+    // rejected — without the strict <repo>/.git/worktrees/<id> check this
+    // would misattribute the project to 'somewhere' instead of returning null.
+    const noGitSegment = chroxyWorktreeFixture({ gitdir: '/somewhere/worktrees/x' })
+    assert.equal(worktreeParent(noGitSegment.wt, { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: noGitSegment.root }), null, 'gitdir */worktrees/<id> without a .git segment')
   })
 
   it('does not match the worktrees root itself or paths outside it', () => {

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -23,7 +23,7 @@ import { IngestEventSchema } from '@chroxy/protocol'
 import { buildEnvelope, resolveHookEvent, runEmit, sanitizeData, SOURCE } from '../src/emit.js'
 import { EMITTERS } from '../src/emitters.js'
 import { resolveIngestUrl, resolveIngestSecret, DEFAULT_PORT } from '../src/config.js'
-import { deriveProject } from '../src/project.js'
+import { classifyNonProjectCwd, deriveProject, worktreeParent } from '../src/project.js'
 
 const SECRET = 'test-hooks-secret'
 const NOW = 1_750_000_000_000
@@ -37,6 +37,29 @@ function tempRepo({ gitFile = false } = {}) {
   }
   mkdirSync(join(root, 'src', 'deep'), { recursive: true })
   return root
+}
+
+/**
+ * #5464: chroxy's SECOND worktree source — session worktrees under
+ * ~/.chroxy/worktrees/<sessionId> (DEFAULT_WORKTREE_BASE in
+ * session-manager.js). The basename is an opaque hex session id, so the
+ * parent project is only recoverable from the worktree's .git FILE
+ * (`gitdir: <repo>/.git/worktrees/<id>` — written by `git worktree add`).
+ * The root is env-injected (CHROXY_HOOKS_CHROXY_WORKTREES_ROOT) so fixtures
+ * are hermetic on any OS, same pattern as CHROXY_HOOKS_TMP_PREFIXES.
+ */
+function chroxyWorktreeFixture({ gitdir, noGitFile = false } = {}) {
+  const base = mkdtempSync(join(tmpdir(), 'hooks-chroxywt-'))
+  const root = join(base, 'worktrees')
+  const id = 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+  const wt = join(root, id)
+  mkdirSync(join(wt, 'packages', 'server'), { recursive: true })
+  const repoRoot = join(base, 'projects', 'coolproj')
+  mkdirSync(join(repoRoot, '.git', 'worktrees', id), { recursive: true })
+  if (!noGitFile) {
+    writeFileSync(join(wt, '.git'), `gitdir: ${gitdir ?? join(repoRoot, '.git', 'worktrees', id)}\n`)
+  }
+  return { base, root, id, wt, repoRoot }
 }
 
 describe('buildEnvelope', () => {
@@ -142,6 +165,85 @@ describe('deriveProject', () => {
     writeFileSync(join(wt, '.git'), 'gitdir: /elsewhere/worktrees/agent-abc123\n')
     assert.equal(deriveProject(wt, {}), 'myproj')
     assert.equal(deriveProject(join(wt, 'packages', 'server'), {}), 'myproj', 'nested worktree cwd remaps too')
+  })
+
+  // #5464: the SECOND worktree source — chroxy session worktrees under
+  // ~/.chroxy/worktrees/<id>. The opaque id basename must never name the
+  // project; the parent is recovered from the worktree .git file's gitdir.
+  it('maps ~/.chroxy/worktrees/<id> cwds to the parent project via the .git gitdir (#5464)', () => {
+    const { root, wt } = chroxyWorktreeFixture()
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }
+    assert.equal(deriveProject(wt, env), 'coolproj')
+    assert.equal(deriveProject(join(wt, 'packages', 'server'), env), 'coolproj', 'nested chroxy worktree cwd remaps too')
+  })
+
+  it('resolves the chroxy worktrees root from $HOME when no override is set (#5464)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hooks-chroxyhome-'))
+    const id = 'feedfacefeedfacefeedfacefeedface'
+    const wt = join(home, '.chroxy', 'worktrees', id)
+    mkdirSync(wt, { recursive: true })
+    const repoRoot = join(home, 'projects', 'homeproj')
+    mkdirSync(join(repoRoot, '.git', 'worktrees', id), { recursive: true })
+    writeFileSync(join(wt, '.git'), `gitdir: ${join(repoRoot, '.git', 'worktrees', id)}\n`)
+    assert.equal(deriveProject(wt, { HOME: home }), 'homeproj')
+  })
+})
+
+describe('worktreeParent (#5464 chroxy worktrees)', () => {
+  it('parses an absolute gitdir back to the parent repo basename', () => {
+    const { root, wt } = chroxyWorktreeFixture()
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }
+    assert.equal(worktreeParent(wt, env), 'coolproj')
+    assert.equal(worktreeParent(join(wt, 'packages', 'server'), env), 'coolproj')
+  })
+
+  it('resolves a relative gitdir against the worktree dir', () => {
+    const { root, wt } = chroxyWorktreeFixture({
+      gitdir: join('..', '..', 'projects', 'coolproj', '.git', 'worktrees', 'x'),
+    })
+    assert.equal(worktreeParent(wt, { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }), 'coolproj')
+  })
+
+  it('returns null when the .git file is missing or malformed (classification still suppresses)', () => {
+    const missing = chroxyWorktreeFixture({ noGitFile: true })
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: missing.root }
+    assert.equal(worktreeParent(missing.wt, env), null, 'no .git file')
+
+    const garbled = chroxyWorktreeFixture({ gitdir: null })
+    writeFileSync(join(garbled.wt, '.git'), 'not a gitdir line\n')
+    assert.equal(worktreeParent(garbled.wt, { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: garbled.root }), null, 'malformed .git file')
+
+    const wrongShape = chroxyWorktreeFixture({ gitdir: '/somewhere/unrelated' })
+    assert.equal(worktreeParent(wrongShape.wt, { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: wrongShape.root }), null, 'gitdir not under */worktrees/<id>')
+  })
+
+  it('does not match the worktrees root itself or paths outside it', () => {
+    const { base, root } = chroxyWorktreeFixture()
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }
+    assert.equal(worktreeParent(root, env), null, 'the base dir is not a worktree')
+    assert.equal(worktreeParent(join(base, 'projects', 'coolproj'), env), null, 'sibling paths are untouched')
+  })
+})
+
+describe('classifyNonProjectCwd (#5464 chroxy worktrees)', () => {
+  it("classifies ~/.chroxy/worktrees/<id> cwds as 'worktree'", () => {
+    const { root, wt } = chroxyWorktreeFixture()
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root, CHROXY_HOOKS_TMP_PREFIXES: '/chroxy-nonexistent-tmp' }
+    assert.equal(classifyNonProjectCwd(wt, env), 'worktree')
+    assert.equal(classifyNonProjectCwd(join(wt, 'packages', 'server'), env), 'worktree', 'nested cwds too')
+  })
+
+  it("still classifies as 'worktree' when the .git file is unreadable (suppression must not depend on the parse)", () => {
+    const { root, wt } = chroxyWorktreeFixture({ noGitFile: true })
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root, CHROXY_HOOKS_TMP_PREFIXES: '/chroxy-nonexistent-tmp' }
+    assert.equal(classifyNonProjectCwd(wt, env), 'worktree')
+  })
+
+  it('does not classify the worktrees base dir itself or sibling paths', () => {
+    const { base, root } = chroxyWorktreeFixture()
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root, CHROXY_HOOKS_TMP_PREFIXES: '/chroxy-nonexistent-tmp' }
+    assert.equal(classifyNonProjectCwd(root, env), null)
+    assert.equal(classifyNonProjectCwd(join(base, 'projects', 'coolproj'), env), null)
   })
 })
 
@@ -405,6 +507,35 @@ describe('runEmit', () => {
       const sent = JSON.parse(received.at(-1).body)
       assert.equal(sent.type, 'subagent_stop')
       assert.equal(sent.project, 'parentproj', 'subagent counts belong to the parent project')
+    })
+
+    // #5464: chroxy session worktrees (~/.chroxy/worktrees/<id>) get the
+    // SAME semantics as agent worktrees — without this, every chroxy
+    // worktree session mints a noise embed keyed on the opaque hex id.
+    it('suppresses non-subagent events from ~/.chroxy/worktrees cwds, but lets subagent events through remapped to the parent (#5464)', async () => {
+      const { root, wt } = chroxyWorktreeFixture()
+      const env = { ...envFor(), CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }
+
+      const countBefore = received.length
+      const start = await runEmit({
+        hookEventArg: 'session_start',
+        stdinText: JSON.stringify({ cwd: wt, session_id: 's-cwt' }),
+        env,
+        now: () => NOW,
+      })
+      assert.deepEqual(start, { sent: false, reason: 'non_project_cwd' })
+      assert.equal(received.length, countBefore, 'chroxy worktree SessionStart suppressed')
+
+      const stop = await runEmit({
+        hookEventArg: 'subagent_stop',
+        stdinText: JSON.stringify({ cwd: wt, session_id: 's-cwt' }),
+        env,
+        now: () => NOW,
+      })
+      assert.deepEqual(stop, { sent: true }, 'chroxy worktree SubagentStop reaches the counting code')
+      const sent = JSON.parse(received.at(-1).body)
+      assert.equal(sent.type, 'subagent_stop')
+      assert.equal(sent.project, 'coolproj', 'subagent counts belong to the parent repo, not the opaque worktree id')
     })
 
     it('CHROXY_HOOKS_SKIP_CWD_FILTER=1 bypasses the filter (test/debug escape hatch)', async () => {


### PR DESCRIPTION
Closes #5464.

## Problem

GAP B (#5465) remaps and filters `*/.claude/worktrees/*` cwds (agent-harness worktrees), but chroxy manages a **second** worktree source: session worktrees the daemon creates at `~/.chroxy/worktrees/<sessionId>` (`DEFAULT_WORKTREE_BASE` in `session-manager.js`, `git worktree add --detach <base>/<sessionId> HEAD`). The basename is an opaque 32-char hex session id (`randomBytes(16).toString('hex')`), so a Claude session running there hit neither the remap nor the filter: the git-root walk found the worktree's own `.git` file and minted one noise embed per chroxy worktree session, keyed on the opaque id — the exact failure mode GAP B fixed for `.claude/worktrees/agent-*`.

## Design

Same semantics as agent worktrees, applied to the second source:

- **Filtering** — `classifyNonProjectCwd` returns `'worktree'` for any cwd under the chroxy worktrees root, by **path shape alone** (never gated on the parent parse succeeding — a chroxy worktree session must stay suppressed even when the parent can't be recovered). `runEmit` then suppresses everything except subagent events, unchanged.
- **Remap** — `worktreeParent` recovers the parent project from the worktree's `.git` FILE: `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the repo root is three segments up (relative gitdirs are resolved against the worktree dir; non-matching shapes return null). The chroxy check runs **before** the `/.claude/worktrees/` marker split, so an agent worktree nested inside a chroxy worktree still resolves to the real repo instead of the opaque id.
- **Hermeticity (#5470 lesson)** — the root is env-injectable via `CHROXY_HOOKS_CHROXY_WORKTREES_ROOT` (sibling of `CHROXY_HOOKS_TMP_PREFIXES`); the default resolves from `$HOME`/`homedir()` and is realpath'd for the macOS `/private` aliasing. An unusable override falls back to the default rather than silently disabling suppression.
- **Server's `deriveProjectFromCwd` (event-ingest.js) intentionally unchanged** — hooks send `project` explicitly and the server walk is fallback-only; #5465 kept it remap-free for agent worktrees too, so adding chroxy-only handling there would break parity without fixing anything reachable.

## Acceptance criteria

- [x] Remap target decided: parse the worktree `.git` file's `gitdir:` back to the main repo (suppress-like-tmp rejected — subagent counts from worktree sessions still belong to the parent embed, matching GAP B)
- [x] Fold/dedup considered: chroxy worktree sessions get the same suppress-all-but-subagent treatment as agent worktrees, so chroxy's first-party notifications stay the only voice for those sessions
- [x] Tests for the new classification

## Tests

TDD in `packages/claude-hooks/tests/emit.test.js` (7 new tests, red before the change):

- `deriveProject` remaps `<root>/<id>` and nested cwds to the parent repo basename; HOME-based default root resolution
- `worktreeParent`: absolute + relative `gitdir`, missing/malformed `.git` file → null, root dir itself and sibling paths → null
- `classifyNonProjectCwd`: `'worktree'` for chroxy worktree cwds (including with an unreadable `.git`), null for the base dir and siblings
- `runEmit` integration: `session_start` suppressed (`non_project_cwd`, no network call); `subagent_stop` passes through with `project` = parent repo

Suite green under **both** the default `TMPDIR` and `TMPDIR=/tmp` (70/70 each). Server lint scripts (`lint-logger-session-scoping.sh`, `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`) green.