### PR TITLE
test: cover provider-models refresh scheduling and auth_ok exposure lifecycle

### DIFF
--- a/packages/dashboard/src/store/exposure-banner-store.test.ts
+++ b/packages/dashboard/src/store/exposure-banner-store.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Exposure-banner store lifecycle tests (#5356 / #5459 / #5460).
+ *
+ * The ExposureWarningBanner component has its own render tests; these pin the
+ * subtle part of the feature — the store-level dismissal lifecycle:
+ *
+ *   - fresh (non-reconnect) auth_ok resets exposureBannerDismissed to false
+ *   - silent reconnect preserves the dismissal while refreshing serverExposure
+ *   - explicit disconnect clears both (serverExposure: null, dismissed: false)
+ *   - server_status { phase: 'ready', tunnelMode: 'quick' } merges
+ *     quickTunnel: true into the snapshot, preserving lanBind
+ *   - auth_ok without exposure (older server) yields serverExposure: null
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  stopHeartbeat,
+} from './message-handler'
+import type { ConnectionState } from './types'
+
+// ---------------------------------------------------------------------------
+// Test helpers (same shape as auth-ok-handler.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Create a mock store compatible with setStore(). */
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  const store = {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+  return store
+}
+
+/** Create a mock WebSocket with a send spy. */
+function createMockSocket(): WebSocket {
+  return {
+    send: () => {},
+    close: () => {},
+    readyState: WebSocket.OPEN,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  } as unknown as WebSocket
+}
+
+/** Build a minimal auth_ok message. */
+function createAuthOkMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'auth_ok',
+    serverMode: 'cli',
+    cwd: '/home/user/project',
+    defaultCwd: '/home/user',
+    serverVersion: '0.9.0',
+    serverCommit: 'abc1234',
+    protocolVersion: 3,
+    clientId: 'client-1',
+    connectedClients: [],
+    ...overrides,
+  }
+}
+
+function createInitialState(overrides: Partial<ConnectionState> = {}) {
+  return {
+    connectionPhase: 'connecting',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    messages: [],
+    terminalBuffer: '',
+    terminalRawBuffer: '',
+    customAgents: [],
+    slashCommands: [],
+    connectionError: null,
+    connectionRetryCount: 0,
+    serverExposure: null,
+    exposureBannerDismissed: false,
+    ...overrides,
+  } as unknown as ConnectionState
+}
+
+function makeCtx(socket: WebSocket, isReconnect: boolean) {
+  return {
+    url: 'wss://test.example.com',
+    token: 'tok',
+    socket,
+    isReconnect,
+    silent: isReconnect,
+  }
+}
+
+describe('exposure banner store lifecycle (#5356)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  beforeEach(() => {
+    localStorage.clear()
+    clearDeltaBuffers()
+    mockSocket = createMockSocket()
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+  })
+
+  describe('auth_ok exposure decoding', () => {
+    it('stores the exposure snapshot from auth_ok (strict-boolean coercion)', () => {
+      store = createMockStore(createInitialState())
+      setStore(store)
+
+      handleMessage(
+        createAuthOkMessage({ exposure: { lanBind: true, bindHost: '0.0.0.0', quickTunnel: false } }) as never,
+        makeCtx(mockSocket, false) as never,
+      )
+
+      expect(store.getState().serverExposure).toEqual({ lanBind: true, quickTunnel: false })
+    })
+
+    it('yields serverExposure: null when auth_ok omits exposure (older server)', () => {
+      store = createMockStore(createInitialState({
+        // Stale snapshot from a previous server must not survive the new auth.
+        serverExposure: { lanBind: true, quickTunnel: true },
+      }))
+      setStore(store)
+
+      handleMessage(createAuthOkMessage() as never, makeCtx(mockSocket, false) as never)
+
+      expect(store.getState().serverExposure).toBeNull()
+    })
+
+    it('treats a malformed exposure field as null (no banner)', () => {
+      store = createMockStore(createInitialState())
+      setStore(store)
+
+      handleMessage(
+        createAuthOkMessage({ exposure: 'wide open' }) as never,
+        makeCtx(mockSocket, false) as never,
+      )
+
+      expect(store.getState().serverExposure).toBeNull()
+    })
+  })
+
+  describe('dismissal lifecycle', () => {
+    it('fresh (non-reconnect) auth_ok resets exposureBannerDismissed to false', () => {
+      store = createMockStore(createInitialState({ exposureBannerDismissed: true }))
+      setStore(store)
+
+      handleMessage(
+        createAuthOkMessage({ exposure: { lanBind: true, quickTunnel: false } }) as never,
+        makeCtx(mockSocket, false) as never,
+      )
+
+      const state = store.getState()
+      expect(state.exposureBannerDismissed).toBe(false)
+      expect(state.serverExposure).toEqual({ lanBind: true, quickTunnel: false })
+    })
+
+    it('silent reconnect preserves the dismissal while refreshing serverExposure', () => {
+      store = createMockStore(createInitialState({
+        exposureBannerDismissed: true,
+        serverExposure: { lanBind: true, quickTunnel: false },
+      }))
+      setStore(store)
+
+      // Same server, tunnel now active — the snapshot refreshes but the
+      // user's dismissal must survive the silent reconnect.
+      handleMessage(
+        createAuthOkMessage({ exposure: { lanBind: true, quickTunnel: true } }) as never,
+        makeCtx(mockSocket, true) as never,
+      )
+
+      const state = store.getState()
+      expect(state.exposureBannerDismissed).toBe(true)
+      expect(state.serverExposure).toEqual({ lanBind: true, quickTunnel: true })
+    })
+
+    it('explicit disconnect clears the snapshot and the dismissal (real store)', async () => {
+      const { useConnectionStore } = await import('./connection')
+      useConnectionStore.setState({
+        socket: null,
+        serverExposure: { lanBind: true, quickTunnel: true },
+        exposureBannerDismissed: true,
+      })
+
+      useConnectionStore.getState().disconnect()
+
+      const state = useConnectionStore.getState()
+      expect(state.connectionPhase).toBe('disconnected')
+      expect(state.serverExposure).toBeNull()
+      expect(state.exposureBannerDismissed).toBe(false)
+    })
+
+    it('dismissExposureBanner sets the flag without touching the snapshot (real store)', async () => {
+      const { useConnectionStore } = await import('./connection')
+      useConnectionStore.setState({
+        serverExposure: { lanBind: true, quickTunnel: false },
+        exposureBannerDismissed: false,
+      })
+
+      useConnectionStore.getState().dismissExposureBanner()
+
+      const state = useConnectionStore.getState()
+      expect(state.exposureBannerDismissed).toBe(true)
+      expect(state.serverExposure).toEqual({ lanBind: true, quickTunnel: false })
+    })
+  })
+
+  describe('server_status ready merge (mid-warming quick tunnel)', () => {
+    it('merges quickTunnel: true into the snapshot, preserving lanBind', () => {
+      store = createMockStore(createInitialState({
+        serverExposure: { lanBind: true, quickTunnel: false },
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'server_status', phase: 'ready', tunnelMode: 'quick' } as never,
+        makeCtx(mockSocket, false) as never,
+      )
+
+      expect(store.getState().serverExposure).toEqual({ lanBind: true, quickTunnel: true })
+    })
+
+    it('builds a snapshot from scratch when auth_ok predated the tunnel (lanBind defaults false)', () => {
+      store = createMockStore(createInitialState({ serverExposure: null }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'server_status', phase: 'ready', tunnelMode: 'quick' } as never,
+        makeCtx(mockSocket, false) as never,
+      )
+
+      expect(store.getState().serverExposure).toEqual({ lanBind: false, quickTunnel: true })
+    })
+
+    it('does not touch the snapshot for a non-quick tunnel ready', () => {
+      store = createMockStore(createInitialState({
+        serverExposure: { lanBind: false, quickTunnel: false },
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'server_status', phase: 'ready', tunnelMode: 'named' } as never,
+        makeCtx(mockSocket, false) as never,
+      )
+
+      expect(store.getState().serverExposure).toEqual({ lanBind: false, quickTunnel: false })
+    })
+  })
+})

--- a/packages/server/tests/ws-exposure.test.js
+++ b/packages/server/tests/ws-exposure.test.js
@@ -1,0 +1,239 @@
+/**
+ * #5460 — auth_ok exposure emission (#5356 visibility layer, shipped in #5459).
+ *
+ * Three seams, covered bottom-up:
+ *   1. The WsServer `exposure` getter: null until start() records a bound
+ *      host, then `{ lanBind, bindHost, quickTunnel }` with lanBind derived
+ *      from isLoopbackHost and quickTunnel from setQuickTunnelActive().
+ *   2. The sendPostAuthInfo glue: the auth_ok payload carries `exposure`
+ *      only when ctx.exposure is non-null (older ctx shapes and never-started
+ *      harnesses omit the field entirely — clients treat that as "unknown").
+ *   3. End to end: a real client connecting to a started server sees the
+ *      exposure snapshot on the auth_ok wire, and setQuickTunnelActive(true)
+ *      flips quickTunnel for the next handshake.
+ */
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import WebSocket from 'ws'
+import { WsServer as _WsServer } from '../src/ws-server.js'
+import { sendPostAuthInfo } from '../src/ws-history.js'
+import { createMockSession, waitFor } from './test-helpers.js'
+import { setLogListener } from '../src/logger.js'
+
+// Default noEncrypt: true (avoids key-exchange timeouts) and silence the
+// log listener WsServer.start() registers so log_entry broadcasts don't
+// interfere with message assertions — same wrapper as ws-server-auth.test.js.
+class WsServer extends _WsServer {
+  constructor(opts = {}) {
+    super({ noEncrypt: true, ...opts })
+  }
+  start(...args) {
+    super.start(...args)
+    setLogListener(null)
+  }
+}
+
+async function startServerAndGetPort(server, host = '127.0.0.1') {
+  server.start(host)
+  const httpServer = server.httpServer
+  await new Promise((resolve, reject) => {
+    function onListening() {
+      httpServer.removeListener('error', onError)
+      resolve()
+    }
+    function onError(err) {
+      httpServer.removeListener('listening', onListening)
+      reject(err)
+    }
+    httpServer.once('listening', onListening)
+    httpServer.once('error', onError)
+  })
+  return server.httpServer.address().port
+}
+
+/** Connect a client and wait for its auth_ok (authRequired: false servers). */
+async function connectAndGetAuthOk(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`)
+  const messages = []
+  ws.on('message', (data) => {
+    try { messages.push(JSON.parse(data.toString())) } catch { /* non-JSON frame */ }
+  })
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('connect timeout')), 2000)
+    ws.once('open', () => { clearTimeout(timer); resolve() })
+    ws.once('error', (err) => { clearTimeout(timer); reject(err) })
+  })
+  const authOk = await waitFor(
+    () => messages.find(m => m.type === 'auth_ok'),
+    { timeoutMs: 2000, label: 'auth_ok' },
+  )
+  ws.close()
+  return authOk
+}
+
+// ── exposure getter ────────────────────────────────────────────────────────
+
+describe('WsServer exposure getter (#5356)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('is null before start() has bound a socket', () => {
+    server = new WsServer({ port: 0, apiToken: 'tok', cliSession: createMockSession() })
+    assert.equal(server.exposure, null)
+  })
+
+  it('reports lanBind: false for a loopback bind after start()', async () => {
+    server = new WsServer({ port: 0, apiToken: 'tok', cliSession: createMockSession(), authRequired: false })
+    await startServerAndGetPort(server, '127.0.0.1')
+
+    assert.deepEqual(server.exposure, {
+      lanBind: false,
+      bindHost: '127.0.0.1',
+      quickTunnel: false,
+    })
+  })
+
+  it('reports lanBind: true for non-loopback bind hosts', () => {
+    // Simulate the host record start() makes (`this._boundHost = host ?? '0.0.0.0'`)
+    // without actually binding all interfaces in a test (macOS firewall prompts).
+    server = new WsServer({ port: 0, apiToken: 'tok', cliSession: createMockSession() })
+
+    server._boundHost = '0.0.0.0'
+    assert.deepEqual(server.exposure, { lanBind: true, bindHost: '0.0.0.0', quickTunnel: false })
+
+    server._boundHost = '192.168.1.10'
+    assert.deepEqual(server.exposure, { lanBind: true, bindHost: '192.168.1.10', quickTunnel: false })
+  })
+
+  it('setQuickTunnelActive flips quickTunnel in the snapshot (coerced to boolean)', async () => {
+    server = new WsServer({ port: 0, apiToken: 'tok', cliSession: createMockSession(), authRequired: false })
+    await startServerAndGetPort(server, '127.0.0.1')
+
+    server.setQuickTunnelActive(true)
+    assert.equal(server.exposure.quickTunnel, true)
+
+    server.setQuickTunnelActive(false)
+    assert.equal(server.exposure.quickTunnel, false)
+
+    server.setQuickTunnelActive('truthy string')
+    assert.equal(server.exposure.quickTunnel, true, 'truthy input must coerce to boolean true')
+  })
+})
+
+// ── sendPostAuthInfo emission / omission ───────────────────────────────────
+
+describe('sendPostAuthInfo — auth_ok exposure field (#5356)', () => {
+  function makeCtx(overrides = {}) {
+    const sends = []
+    const ctx = {
+      clients: new Map(),
+      sessionManager: null,
+      cliSession: null,
+      defaultSessionId: null,
+      serverMode: 'multi',
+      serverVersion: '0.9.0',
+      latestVersion: '0.9.0',
+      gitInfo: { commit: 'abc1234' },
+      encryptionEnabled: false,
+      localhostBypass: false,
+      keyExchangeTimeoutMs: 5000,
+      protocolVersion: 3,
+      minProtocolVersion: 1,
+      webTaskManager: { getFeatureStatus: () => ({ available: false, remote: false, teleport: false }) },
+      send: (ws, msg) => sends.push(msg),
+      broadcast: () => {},
+      getConnectedClientList: () => [],
+      permissions: { resendPendingPermissions: () => {} },
+      ...overrides,
+    }
+    ctx._sends = sends
+    return ctx
+  }
+
+  function makeWs(ctx) {
+    const ws = { readyState: 1, send: () => {}, close: () => {} }
+    ctx.clients.set(ws, { id: 'client-1', socketIp: '10.0.0.1', activeSessionId: null })
+    return ws
+  }
+
+  it('includes the exposure snapshot in auth_ok when ctx.exposure is set', () => {
+    const exposure = { lanBind: true, bindHost: '0.0.0.0', quickTunnel: true }
+    const ctx = makeCtx({ exposure })
+    const ws = makeWs(ctx)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    assert.ok(authOk, 'auth_ok not sent')
+    assert.deepEqual(authOk.exposure, exposure)
+  })
+
+  it('omits the field entirely when ctx.exposure is null (server never bound a socket)', () => {
+    const ctx = makeCtx({ exposure: null })
+    const ws = makeWs(ctx)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    assert.ok(authOk, 'auth_ok not sent')
+    assert.equal('exposure' in authOk, false, 'auth_ok must not carry an exposure key')
+  })
+
+  it('omits the field when ctx predates exposure entirely (no key on ctx)', () => {
+    const ctx = makeCtx() // no exposure key at all — older ctx shape
+    const ws = makeWs(ctx)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    assert.ok(authOk, 'auth_ok not sent')
+    assert.equal('exposure' in authOk, false)
+  })
+})
+
+// ── end-to-end: exposure on the auth_ok wire ───────────────────────────────
+
+describe('auth_ok exposure over a real connection (#5459 / #5460)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('carries the loopback exposure snapshot, then quickTunnel: true after setQuickTunnelActive', async () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok',
+      cliSession: createMockSession(),
+      authRequired: false,
+    })
+    const port = await startServerAndGetPort(server, '127.0.0.1')
+
+    const first = await connectAndGetAuthOk(port)
+    assert.deepEqual(first.exposure, {
+      lanBind: false,
+      bindHost: '127.0.0.1',
+      quickTunnel: false,
+    })
+
+    // server-cli flags the public quick tunnel before tunnel startup; the
+    // next handshake must reflect it.
+    server.setQuickTunnelActive(true)
+
+    const second = await connectAndGetAuthOk(port)
+    assert.deepEqual(second.exposure, {
+      lanBind: false,
+      bindHost: '127.0.0.1',
+      quickTunnel: true,
+    })
+  })
+})

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1,5 +1,8 @@
-import { describe, it, beforeEach, mock } from 'node:test'
+import { describe, it, before, after, beforeEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { createSpy, createMockSession, createMockSessionManager } from './test-helpers.js'
 import {
   sendPostAuthInfo,
@@ -7,13 +10,17 @@ import {
   replayHistory,
   flushPostAuthQueue,
   scheduleAfterDrain,
+  scheduleProviderModelsRefresh,
 } from '../src/ws-history.js'
 import { PERMISSION_MODES } from '../src/handler-utils.js'
 import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
+import { getRegistryForProvider, _resetProviderRegistryCacheForTests } from '../src/models.js'
 // Importing providers.js triggers built-in provider registration, which in turn
 // calls registerProviderRegistry() so getRegistryForProvider('codex'/'gemini')
 // resolves to the correct provider class in per-provider tests below.
-import '../src/providers.js'
+// registerProvider is used by the scheduleProviderModelsRefresh suite to
+// inject fake provider classes (#5450).
+import { registerProvider } from '../src/providers.js'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -2037,5 +2044,252 @@ describe('scheduleAfterDrain — max-wait cap (#5328)', () => {
     } finally {
       mock.timers.reset()
     }
+  })
+})
+
+// #5450 — direct unit coverage for the ws-layer dynamic-discovery glue
+// added in #5421/#5445. The discovery core (TTL cache, change detection,
+// in-flight dedupe) is covered by ollama-tags.test.js; these tests pin the
+// scheduleProviderModelsRefresh contract itself with injected fake provider
+// classes: provider gating, re-push-on-change only, readyState guard,
+// rejection swallowing, and single-schedule-per-handshake.
+describe('scheduleProviderModelsRefresh (#5421 / #5450)', () => {
+  // Provider registries hydrate from `${CHROXY_CONFIG_DIR}/models-cache.<name>.json`
+  // on first access — point that at a temp dir so the suite never reads (or,
+  // via loadCache's heal path, writes) the real ~/.chroxy tree.
+  let savedConfigDir
+  before(() => {
+    savedConfigDir = process.env.CHROXY_CONFIG_DIR
+    process.env.CHROXY_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'chroxy-ws-history-refresh-'))
+    _resetProviderRegistryCacheForTests()
+  })
+  after(() => {
+    if (savedConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+    else process.env.CHROXY_CONFIG_DIR = savedConfigDir
+    _resetProviderRegistryCacheForTests()
+  })
+
+  /**
+   * Build and register a fake non-Claude provider class. Each test uses a
+   * unique name so PROVIDERS / providerRegistryCache entries never leak
+   * across tests. `refreshModels` (when given) is attached as the static
+   * dynamic-discovery hook scheduleProviderModelsRefresh looks for.
+   */
+  function registerFakeProvider(name, { refreshModels } = {}) {
+    class FakeProviderSession {
+      sendMessage() {}
+      interrupt() {}
+      setModel() {}
+      setPermissionMode() {}
+      start() {}
+      destroy() {}
+      static get capabilities() { return {} }
+      static getFallbackModels() {
+        return [{ id: 'fake-seed', label: 'Fake Seed', fullId: 'fake-seed', contextWindow: 8192 }]
+      }
+    }
+    if (refreshModels) FakeProviderSession.refreshModels = refreshModels
+    registerProvider(name, FakeProviderSession)
+    return FakeProviderSession
+  }
+
+  /** Settle the fire-and-forget then/catch chain inside the scheduler. */
+  function flushAsync() {
+    return new Promise((resolve) => setImmediate(resolve))
+  }
+
+  it('is a no-op for a null provider name', async () => {
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    scheduleProviderModelsRefresh(ctx, ws, null)
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 0)
+  })
+
+  it('swallows an unknown provider name (getProvider throw) without sending', async () => {
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    // Must not throw synchronously despite getProvider throwing for
+    // unregistered names.
+    scheduleProviderModelsRefresh(ctx, ws, 'no-such-provider-5450')
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 0)
+  })
+
+  it('is a no-op for providers without a static refreshModels', async () => {
+    registerFakeProvider('fake-refresh-static-only')
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    scheduleProviderModelsRefresh(ctx, ws, 'fake-refresh-static-only')
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 0)
+  })
+
+  it('re-pushes available_models to the triggering client when the probe resolves a changed list', async () => {
+    const name = 'fake-refresh-changed'
+    // Mirror the provider refresh contract (see refreshOllamaModels): the
+    // registry is updated BEFORE the promise resolves with the changed list;
+    // the ws glue then re-reads the registry for the re-push payload.
+    registerFakeProvider(name, {
+      refreshModels: async () => {
+        getRegistryForProvider(name).updateModels([
+          { value: 'fake-discovered', displayName: 'Fake Discovered' },
+        ])
+        return ['fake-discovered']
+      },
+    })
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    scheduleProviderModelsRefresh(ctx, ws, name)
+    assert.equal(ctx.send.callCount, 0, 'the refresh must be async — no synchronous send')
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 1, 'exactly one re-push for one resolved probe')
+    const msg = ctx._sends[0]
+    assert.equal(msg.type, 'available_models')
+    assert.equal(msg.provider, name, 're-push must stay tagged with the probed provider')
+    // updateModels merges the static seed back in (stale-entry resilience),
+    // so assert the discovered model is present AND the payload mirrors the
+    // registry exactly — the glue must re-read the registry, not echo the
+    // probe's resolved array.
+    assert.ok(msg.models.some(m => m.id === 'fake-discovered'),
+      're-push must carry the freshly discovered model')
+    assert.deepEqual(msg.models, getRegistryForProvider(name).getModels(),
+      're-push payload must mirror the updated registry list')
+    assert.equal(msg.defaultModel, getRegistryForProvider(name).getDefaultModelId())
+  })
+
+  it('does not re-push on a null resolution and leaves the registry untouched (failed probe)', async () => {
+    const name = 'fake-refresh-null'
+    // null = probe failed / no change / TTL-cached: the snapshot already
+    // sent is still accurate, so nothing further may be emitted.
+    registerFakeProvider(name, { refreshModels: async () => null })
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    scheduleProviderModelsRefresh(ctx, ws, name)
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 0)
+    assert.deepEqual(getRegistryForProvider(name).getModels().map(m => m.id), ['fake-seed'],
+      'a failed probe must leave the registry on the static seed list')
+  })
+
+  it('does not re-push on an empty-array resolution', async () => {
+    const name = 'fake-refresh-empty'
+    registerFakeProvider(name, { refreshModels: async () => [] })
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    scheduleProviderModelsRefresh(ctx, ws, name)
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 0)
+  })
+
+  it('drops the re-push when the client leaves OPEN mid-probe', async () => {
+    const name = 'fake-refresh-gone'
+    let resolveProbe
+    registerFakeProvider(name, {
+      refreshModels: () => new Promise((resolve) => { resolveProbe = resolve }),
+    })
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    scheduleProviderModelsRefresh(ctx, ws, name)
+    // refreshModels is invoked on a later microtask (Promise.resolve().then),
+    // so flush once for the probe to actually start before disconnecting.
+    await flushAsync()
+    // Client disconnects while the probe is in flight, THEN the probe lands.
+    ws.readyState = 3
+    resolveProbe(['fake-discovered'])
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 0, 'no send to a socket that left OPEN')
+  })
+
+  it('still re-pushes when the test socket has no readyState at all', async () => {
+    // Plain-object sockets (some test harnesses) have readyState undefined;
+    // the guard only blocks sockets that EXPOSE a non-OPEN readyState.
+    const name = 'fake-refresh-bare-ws'
+    registerFakeProvider(name, { refreshModels: async () => ['fake-seed'] })
+    const ctx = makeCtx()
+    const ws = {} // no readyState, ctx.send records the payload
+
+    scheduleProviderModelsRefresh(ctx, ws, name)
+    await flushAsync()
+
+    assert.equal(ctx.send.callCount, 1)
+    assert.equal(ctx._sends[0].type, 'available_models')
+  })
+
+  it('swallows a rejecting refreshModels — no send, no unhandled rejection', async () => {
+    const name = 'fake-refresh-reject'
+    registerFakeProvider(name, {
+      refreshModels: async () => { throw new Error('probe exploded') },
+    })
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+
+    const rejections = []
+    const onRejection = (err) => rejections.push(err)
+    process.on('unhandledRejection', onRejection)
+    try {
+      scheduleProviderModelsRefresh(ctx, ws, name)
+      await flushAsync()
+      // Give a hypothetical unhandled rejection a second turn to surface.
+      await flushAsync()
+
+      assert.equal(ctx.send.callCount, 0)
+      assert.equal(rejections.length, 0,
+        `refreshModels rejection leaked as unhandled: ${rejections[0]}`)
+    } finally {
+      process.off('unhandledRejection', onRejection)
+    }
+  })
+
+  it('is scheduled exactly once per handshake — sendPostAuthInfo does not double-push', async () => {
+    const name = 'fake-refresh-once'
+    const refreshSpy = createSpy(async () => {
+      getRegistryForProvider(name).updateModels([
+        { value: 'fake-discovered', displayName: 'Fake Discovered' },
+      ])
+      return ['fake-discovered']
+    })
+    registerFakeProvider(name, { refreshModels: refreshSpy })
+
+    const { manager } = createMockSessionManager(
+      [{ id: 'sess-fake', name: 'Fake', cwd: '/tmp' }],
+      {
+        getSession: (id) => {
+          if (id !== 'sess-fake') return undefined
+          return { session: createMockSession(), name: 'Fake', cwd: '/tmp', provider: name }
+        },
+      },
+    )
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-fake' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    // The synchronous handshake pushes available_models twice (sendSessionInfo
+    // + the post-auth snapshot) — only sendSessionInfo may schedule a refresh.
+    const syncPushes = ctx._sends.filter(m => m.type === 'available_models').length
+    assert.equal(syncPushes, 2, 'handshake baseline: two synchronous available_models snapshots')
+
+    await flushAsync()
+
+    assert.equal(refreshSpy.callCount, 1,
+      'refreshModels must be scheduled exactly once per handshake (sendSessionInfo owns it)')
+    const totalPushes = ctx._sends.filter(m => m.type === 'available_models').length
+    assert.equal(totalPushes, syncPushes + 1,
+      'exactly one async re-push on top of the synchronous snapshots')
   })
 })


### PR DESCRIPTION
## Summary

Two test-coverage follow-ups from review of #5445 and #5459, in separate commits.

### Commit 1 — `scheduleProviderModelsRefresh` unit coverage (#5450)

New `scheduleProviderModelsRefresh` describe block in `packages/server/tests/ws-history.test.js` (10 tests) using injected fake provider classes registered through the real `registerProvider`/`getRegistryForProvider` machinery:

- **No-op gating:** null provider name, unknown provider (`getProvider` throw swallowed), provider without a static `refreshModels()`
- **Re-push on change:** a non-null, non-empty resolution re-pushes `available_models` to the triggering client, tagged with the provider and mirroring the updated registry (not echoing the probe's resolved array)
- **No re-push:** null resolution (failed probe / no change / TTL-cached) and empty-array resolution emit nothing; a failed probe leaves the registry on its static seed list
- **readyState guard:** the re-push is dropped when the client leaves OPEN mid-probe; bare test sockets without a `readyState` still receive it
- **Rejection swallowing:** a rejecting `refreshModels()` produces no send and no unhandled rejection in the post-auth path
- **Single-schedule-per-handshake:** `sendPostAuthInfo` triggers exactly one `refreshModels()` call and exactly one async re-push on top of the two synchronous `available_models` snapshots (sendSessionInfo owns the scheduling; the post-auth snapshot must not double-schedule)

Provider registries are pointed at a temp `CHROXY_CONFIG_DIR` for the suite so cache hydration never touches the real `~/.chroxy` tree.

### Commit 2 — auth_ok exposure emission + dashboard banner lifecycle (#5460)

**Server — new `packages/server/tests/ws-exposure.test.js` (8 tests):**

- `exposure` getter: `null` before `start()`; loopback bind after `start('127.0.0.1')` yields `{ lanBind: false, bindHost: '127.0.0.1', quickTunnel: false }`; non-loopback hosts (`0.0.0.0`, LAN IPs) map to `lanBind: true`; `setQuickTunnelActive()` flips `quickTunnel` with strict-boolean coercion
- `sendPostAuthInfo`: auth_ok carries the `exposure` field when `ctx.exposure` is set, and omits the key entirely when it is null or absent (never-started harnesses / older ctx shapes)
- End to end: a real WebSocket client sees the loopback snapshot on the auth_ok wire, and the next handshake after `setQuickTunnelActive(true)` carries `quickTunnel: true`

**Dashboard — new `packages/dashboard/src/store/exposure-banner-store.test.ts` (10 tests):**

- auth_ok exposure decoding: strict-boolean coercion, missing field (older server) yields `serverExposure: null`, malformed field ignored
- fresh (non-reconnect) auth_ok resets `exposureBannerDismissed` to false
- silent reconnect preserves the dismissal while refreshing `serverExposure`
- explicit disconnect clears both (`serverExposure: null`, `exposureBannerDismissed: false`); `dismissExposureBanner()` sets the flag without touching the snapshot
- `server_status { phase: 'ready', tunnelMode: 'quick' }` merges `quickTunnel: true` preserving `lanBind`, builds a snapshot from scratch when auth_ok predated the tunnel, and leaves the snapshot untouched for non-quick tunnels

## Test results

- `tests/ws-history.test.js`: 104/104 (94 baseline + 10 new)
- `tests/ws-exposure.test.js`: 8/8 new
- Combined run with `ws-server-auth` + `ollama-tags`: 188/188
- Dashboard vitest full suite: 3293/3293 across 167 files (10 new); `tsc --noEmit` clean
- Server custom shell lints (`lint-logger-session-scoping`, `lint-session-opt-forwarding`, `lint-tests-state-file-path`): all pass

Closes #5450.
Closes #5460.