### PR TITLE
fix(server): cache the credentials.json read on the dashboard resolveAuth path

### DIFF
--- a/packages/server/src/anthropic-compatible-session.js
+++ b/packages/server/src/anthropic-compatible-session.js
@@ -43,6 +43,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from './byok-session.js'
 import { validateAnthropicCompatibleProviders } from './anthropic-compatible-config.js'
 import { registerProvider, getRegisteredProviderNames } from './providers.js'
+import { cachedResolveCredentialFile } from './auth-probes.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('anthropic-compatible')
@@ -119,10 +120,42 @@ function readCredentialsField(field) {
  *
  * Never logged.
  *
+ * `resolveAuth` calls this once per configured entry on every dashboard
+ * `list_providers` round-trip, so entries with a `credentialsKey` route the
+ * credentials.json stat+read+parse through the shared
+ * `cachedResolveCredentialFile` cache (#5461) — the same mtime+size+mode /
+ * env-value invalidation contract the built-in byok/deepseek/discord slots
+ * use, with one dynamic slot per (apiKeyEnv, credentialsKey) pair. Keying by
+ * the resolver's actual inputs (rather than entry.id) means two entries that
+ * share a credential spec share the cached result, and an id-less raw entry
+ * can never poison a sibling's slot.
+ *
  * @param {{ apiKeyEnv: string|null, credentialsKey: string|null }} entry
  * @returns {{ key: string, source: 'env' | 'file' } | { key: null, source: 'none', reason: string }}
  */
 export function resolveAnthropicCompatibleApiKey(entry) {
+  const { apiKeyEnv, credentialsKey } = entry
+  if (!credentialsKey) {
+    // Keyless placeholder or env-only entry — no credentials.json I/O to
+    // cache; the uncached resolver never touches the file on these paths.
+    return resolveAnthropicCompatibleApiKeyUncached(entry)
+  }
+  return cachedResolveCredentialFile(
+    `compat:${apiKeyEnv || ''}:${credentialsKey}`,
+    apiKeyEnv ? process.env[apiKeyEnv] : undefined,
+    () => resolveAnthropicCompatibleApiKeyUncached(entry),
+    apiKeyEnv || null,
+  )
+}
+
+/**
+ * The uncached resolver body — does the actual env lookup and (0600-enforced)
+ * credentials.json read. Exercised through the cache wrapper above.
+ *
+ * @param {{ apiKeyEnv: string|null, credentialsKey: string|null }} entry
+ * @returns {{ key: string, source: 'env' | 'file' } | { key: null, source: 'none', reason: string }}
+ */
+function resolveAnthropicCompatibleApiKeyUncached(entry) {
   const { apiKeyEnv, credentialsKey } = entry
 
   if (!apiKeyEnv && !credentialsKey) {

--- a/packages/server/src/auth-probes.js
+++ b/packages/server/src/auth-probes.js
@@ -10,11 +10,14 @@
  *   - `hasClaudeOAuthCreds()` / `hasCodexOAuthCreds()` / `hasGeminiOAuthCreds()`:
  *     5s-TTL cached existence checks for the OAuth files written by the
  *     respective `claude login` / `codex login` / `gemini login` flows.
- *   - `cachedResolveCredentialFile(slot, envValue, resolve)`:
+ *   - `cachedResolveCredentialFile(slot, envValue, resolve, envVarName)`:
  *     mtime+size+mode keyed cache around the BYOK / DeepSeek
  *     `~/.chroxy/credentials.json` resolvers — repeats reuse the parsed
  *     resolver result so the dashboard's list_providers poll doesn't re-read
- *     and re-JSON.parse the file on every call.
+ *     and re-JSON.parse the file on every call. Slots beyond the fixed
+ *     byok/deepseek/discord trio are created lazily (#5461) so config-driven
+ *     Anthropic-compatible entries can route their resolveAuth file reads
+ *     through the same cache (one `compat:` slot per entry credential spec).
  *   - `resetCachesForTest()`: drops both caches so tests can isolate runs
  *     under temporary `CHROXY_*_HOME` overrides without flakiness.
  *
@@ -176,7 +179,16 @@ let _credFileCache = {
   // sink's isConfigured() is probed on every notification, so the resolver
   // must not re-stat/re-parse the file per probe.
   discord: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
+  // #5461: config-driven Anthropic-compatible entries add dynamic
+  // `compat:<apiKeyEnv>:<credentialsKey>` slots lazily on first use —
+  // bounded by the configured entries, dropped by resetCachesForTest().
 }
+
+// Empty template for a slot that has never resolved (also the lazy seed for
+// dynamic slots). Frozen — every cache write replaces the whole slot object.
+const _EMPTY_CRED_FILE_SLOT = Object.freeze({
+  envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null,
+})
 
 const _SLOT_ENV_VAR = {
   byok: 'ANTHROPIC_API_KEY',
@@ -190,13 +202,21 @@ const _SLOT_ENV_VAR = {
  * the env var is unchanged AND either (env-var path was taken last time) or
  * (the file's stat-mtime+size+mode still matches what we cached).
  *
- * @param {'byok' | 'deepseek' | 'discord'} slot
+ * Fixed slots (byok/deepseek/discord) pre-exist; any other slot name is
+ * created lazily on first use (#5461 — dynamic `compat:` slots for the
+ * config-driven Anthropic-compatible entries). For dynamic slots the env var
+ * named in the synthesized ENOENT reason comes from `envVarName` (pass null
+ * for a file-only credential spec — the env clause is omitted); fixed slots
+ * keep their `_SLOT_ENV_VAR` mapping and don't pass it.
+ *
+ * @param {string} slot - 'byok' | 'deepseek' | 'discord' | dynamic (e.g. 'compat:ZAI_API_KEY:zaiApiKey')
  * @param {string | undefined} envValue - current value of the relevant env var
  * @param {() => object} resolve - the underlying *-credentials resolver
+ * @param {string | null} [envVarName] - env var to name in the ENOENT reason (dynamic slots only)
  * @returns {object} resolver result
  */
-export function cachedResolveCredentialFile(slot, envValue, resolve) {
-  const entry = _credFileCache[slot]
+export function cachedResolveCredentialFile(slot, envValue, resolve, envVarName) {
+  const entry = _credFileCache[slot] || _EMPTY_CRED_FILE_SLOT
   const credPath = join(homedir(), '.chroxy', 'credentials.json')
 
   if (typeof envValue === 'string' && envValue.length > 0) {
@@ -214,10 +234,16 @@ export function cachedResolveCredentialFile(slot, envValue, resolve) {
   } catch (err) {
     _credFileCache[slot] = { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null }
     if (err.code === 'ENOENT') {
+      // The reason must match what the slot's own resolver would produce —
+      // dynamic slots name their entry's env var (or none, for file-only
+      // specs); fixed slots fall back to the static mapping.
+      const label = envVarName ?? _SLOT_ENV_VAR[slot]
       return {
         key: null,
         source: 'none',
-        reason: `${_SLOT_ENV_VAR[slot]} not set and ${credPath} does not exist`,
+        reason: label
+          ? `${label} not set and ${credPath} does not exist`
+          : `${credPath} does not exist`,
       }
     }
     return resolve()
@@ -250,9 +276,10 @@ export function cachedResolveCredentialFile(slot, envValue, resolve) {
 /**
  * Test-only hook: drop both cached probe results and the cached credential-
  * file resolver entries so suites that mutate the `CHROXY_*_HOME` overrides or
- * write/delete files under them start from a clean slate. Production code
- * should never call this — the env-var-keyed invalidation + 5s TTL + mtime
- * stat are what users see.
+ * write/delete files under them start from a clean slate. Replacing the whole
+ * `_credFileCache` object also discards any dynamic `compat:` slots (#5461).
+ * Production code should never call this — the env-var-keyed invalidation +
+ * 5s TTL + mtime stat are what users see.
  */
 export function resetCachesForTest() {
   _credsCache = {

--- a/packages/server/tests/anthropic-compatible.test.js
+++ b/packages/server/tests/anthropic-compatible.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, statSync, utimesSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -18,6 +18,7 @@ import { ClaudeByokSession } from '../src/byok-session.js'
 import { getProvider } from '../src/providers.js'
 import { OllamaSession } from '../src/ollama-session.js'
 import { validateConfig } from '../src/config.js'
+import { resetCachesForTest } from '../src/auth-probes.js'
 
 /**
  * Tests for config-driven Anthropic-compatible provider endpoints
@@ -517,6 +518,7 @@ describe('credential resolution', () => {
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
     delete process.env[ENV_VAR]
+    resetCachesForTest()
   })
 
   afterEach(() => {
@@ -524,6 +526,7 @@ describe('credential resolution', () => {
     else delete process.env.HOME
     delete process.env[ENV_VAR]
     rmSync(tmpHome, { recursive: true, force: true })
+    resetCachesForTest()
   })
 
   function writeCredentialsFile(contents, mode = 0o600) {
@@ -583,6 +586,173 @@ describe('credential resolution', () => {
     const resolved = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
     assert.equal(resolved.key, null)
     assert.match(resolved.reason, /"compatApiKey"/)
+  })
+})
+
+describe('credential file read caching (#5461)', () => {
+  // resolveAuth runs once per configured entry on every dashboard
+  // list_providers round-trip; the credentials.json read must go through
+  // the same mtime+size+mode keyed cache the built-in byok/deepseek/discord
+  // slots use (auth-probes.js#cachedResolveCredentialFile), via dynamic
+  // `compat:` slots. Same proof technique as the providers.test.js cache
+  // suite: mutate the file contents while restoring (mtime,size,mode) so a
+  // cache hit returns the stale result and an uncached path would re-read.
+
+  let tmpHome
+  let originalHome
+
+  const ENV_VAR = 'CHROXY_TEST_COMPAT_CACHE_KEY'
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-compat-cache-test-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tmpHome
+    delete process.env[ENV_VAR]
+    resetCachesForTest()
+  })
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    delete process.env[ENV_VAR]
+    rmSync(tmpHome, { recursive: true, force: true })
+    resetCachesForTest()
+  })
+
+  function writeRawCredentialsFile(raw) {
+    const dir = join(tmpHome, '.chroxy')
+    mkdirSync(dir, { recursive: true })
+    const file = join(dir, 'credentials.json')
+    writeFileSync(file, raw)
+    chmodSync(file, 0o600)
+    return file
+  }
+
+  // Pin mtime to a round second so utimesSync's second-granularity Dates
+  // round-trip exactly against statSync's sub-millisecond mtimeMs (same
+  // caveat as the providers.test.js cache suite).
+  function pinnedDate() {
+    return new Date(Math.floor(Date.now() / 1000) * 1000)
+  }
+
+  it('reuses the cached credentials.json read while the file stat is unchanged', () => {
+    // Two same-length payloads: the field rename keeps (size) constant while
+    // making a fresh re-read miss the field. Cache hit → stale key returned.
+    const original = JSON.stringify({ compatApiKey: 'sk-compat-cached' })
+    const renamed = JSON.stringify({ compatXpiKey: 'sk-compat-cached' })
+    assert.equal(original.length, renamed.length,
+      'rename fixture must be byte-equal to original for the cache key to hit')
+
+    const file = writeRawCredentialsFile(original)
+    const pinned = pinnedDate()
+    utimesSync(file, pinned, pinned)
+
+    const first = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(first.key, 'sk-compat-cached', 'baseline: file key resolves')
+    assert.equal(first.source, 'file')
+
+    const beforeStat = statSync(file)
+    writeFileSync(file, renamed)
+    chmodSync(file, 0o600)
+    utimesSync(file, pinned, pinned)
+    const afterStat = statSync(file)
+    assert.equal(afterStat.mtimeMs, beforeStat.mtimeMs,
+      'mtime restore must succeed for this test to actually exercise the cache')
+    assert.equal(afterStat.size, beforeStat.size,
+      'size must match for the cache key to hit')
+
+    const second = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(second.key, 'sk-compat-cached',
+      'cache hit: stale-but-cached key returned because (mtime,size,mode) is unchanged')
+  })
+
+  it('re-reads when credentials.json mtime changes', () => {
+    const file = writeRawCredentialsFile(JSON.stringify({ compatApiKey: 'sk-compat-original' }))
+    const first = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(first.key, 'sk-compat-original')
+
+    writeFileSync(file, JSON.stringify({ compatApiKey: 'sk-compat-rotated' }))
+    chmodSync(file, 0o600)
+    // Defensive explicit mtime bump in case the rewrite landed in the same
+    // sub-millisecond tick as the original write.
+    const future = new Date(Date.now() + 2000)
+    utimesSync(file, future, future)
+
+    const second = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(second.key, 'sk-compat-rotated', 'mtime change must invalidate the cached read')
+  })
+
+  it('re-reads when the file mode changes (cached 0600 read does not mask a loosened file)', () => {
+    const file = writeRawCredentialsFile(JSON.stringify({ compatApiKey: 'sk-compat-cached' }))
+    const pinned = pinnedDate()
+    utimesSync(file, pinned, pinned)
+    const first = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(first.key, 'sk-compat-cached')
+
+    // chmod alone leaves mtime+size untouched — only the mode key differs.
+    chmodSync(file, 0o644)
+    utimesSync(file, pinned, pinned)
+
+    const second = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(second.key, null, 'mode change must invalidate the cached read')
+    assert.match(second.reason, /mode 644/)
+  })
+
+  it('invalidates the cached env-path result when the env var changes', () => {
+    writeRawCredentialsFile(JSON.stringify({ compatApiKey: 'sk-compat-from-file' }))
+    const entry = { apiKeyEnv: ENV_VAR, credentialsKey: 'compatApiKey' }
+
+    process.env[ENV_VAR] = 'sk-compat-env-a'
+    const a = resolveAnthropicCompatibleApiKey(entry)
+    assert.equal(a.key, 'sk-compat-env-a')
+    assert.equal(a.source, 'env')
+
+    process.env[ENV_VAR] = 'sk-compat-env-b'
+    const b = resolveAnthropicCompatibleApiKey(entry)
+    assert.equal(b.key, 'sk-compat-env-b', 'env value change must invalidate the cached result')
+
+    delete process.env[ENV_VAR]
+    const c = resolveAnthropicCompatibleApiKey(entry)
+    assert.equal(c.key, 'sk-compat-from-file', 'unsetting the env var must fall back to a fresh file read')
+    assert.equal(c.source, 'file')
+  })
+
+  it('resetCachesForTest drops the dynamic compat slots', () => {
+    const original = JSON.stringify({ compatApiKey: 'sk-compat-cached' })
+    const renamed = JSON.stringify({ compatXpiKey: 'sk-compat-cached' })
+    const file = writeRawCredentialsFile(original)
+    const pinned = pinnedDate()
+    utimesSync(file, pinned, pinned)
+
+    const first = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(first.key, 'sk-compat-cached')
+
+    writeFileSync(file, renamed)
+    chmodSync(file, 0o600)
+    utimesSync(file, pinned, pinned)
+
+    const stale = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(stale.key, 'sk-compat-cached', 'precondition: the slot is serving the cached result')
+
+    resetCachesForTest()
+    const fresh = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(fresh.key, null, 'after reset the fresh read sees the renamed field')
+    assert.match(fresh.reason, /"compatApiKey"/)
+  })
+
+  it('keeps the not-found reason shape when credentials.json is absent', () => {
+    // The cache layer synthesises the ENOENT result without invoking the
+    // resolver — the reason must still match the uncached resolver's shape.
+    const both = resolveAnthropicCompatibleApiKey({ apiKeyEnv: ENV_VAR, credentialsKey: 'compatApiKey' })
+    assert.equal(both.key, null)
+    assert.equal(both.source, 'none')
+    assert.match(both.reason, new RegExp(`${ENV_VAR} not set and .*credentials\\.json does not exist`))
+
+    const fileOnly = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(fileOnly.key, null)
+    assert.equal(fileOnly.source, 'none')
+    assert.doesNotMatch(fileOnly.reason, /not set/, 'no env clause when no apiKeyEnv is configured')
+    assert.match(fileOnly.reason, /credentials\.json does not exist/)
   })
 })
 

--- a/packages/server/tests/auth-probes.test.js
+++ b/packages/server/tests/auth-probes.test.js
@@ -303,6 +303,78 @@ describe('auth-probes module (#4769)', () => {
       })
     })
 
+    it('lazily creates dynamic slots and caches by env value (#5461)', () => {
+      withSavedEnv(() => {
+        resetCachesForTest()
+        let called = 0
+        const r1 = cachedResolveCredentialFile('compat:ZAI_API_KEY:zaiApiKey', 'sk-dyn', () => {
+          called++
+          return { key: 'sk-dyn', source: 'env' }
+        })
+        assert.equal(called, 1)
+        assert.equal(r1.key, 'sk-dyn')
+
+        const r2 = cachedResolveCredentialFile('compat:ZAI_API_KEY:zaiApiKey', 'sk-dyn', () => {
+          called++
+          return { key: 'should-not-be-returned' }
+        })
+        assert.equal(called, 1, 'cached dynamic-slot entry must not re-invoke resolver')
+        assert.equal(r2.key, 'sk-dyn')
+
+        // A different dynamic slot is independent.
+        const r3 = cachedResolveCredentialFile('compat:OTHER_KEY:otherApiKey', 'sk-other', () => {
+          called++
+          return { key: 'sk-other', source: 'env' }
+        })
+        assert.equal(called, 2, 'distinct dynamic slots must not share cache entries')
+        assert.equal(r3.key, 'sk-other')
+      })
+    })
+
+    it('dynamic-slot ENOENT reason uses the provided env var name (#5461)', () => {
+      withSavedEnv(() => {
+        resetCachesForTest()
+        const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-dyn-noent-'))
+        const savedHome = process.env.HOME
+        process.env.HOME = tmp
+        try {
+          let called = 0
+          const r = cachedResolveCredentialFile('compat:ZAI_API_KEY:zaiApiKey', undefined, () => {
+            called++
+            return { key: 'should-not-be-called' }
+          }, 'ZAI_API_KEY')
+          assert.equal(called, 0, 'ENOENT short-circuit must skip resolver')
+          assert.equal(r.key, null)
+          assert.equal(r.source, 'none')
+          assert.match(r.reason, /ZAI_API_KEY not set and .*does not exist/)
+        } finally {
+          if (savedHome === undefined) delete process.env.HOME
+          else process.env.HOME = savedHome
+          rmSync(tmp, { recursive: true, force: true })
+        }
+      })
+    })
+
+    it('dynamic-slot ENOENT reason omits the env clause when no env var is configured (#5461)', () => {
+      withSavedEnv(() => {
+        resetCachesForTest()
+        const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-dyn-noent-'))
+        const savedHome = process.env.HOME
+        process.env.HOME = tmp
+        try {
+          const r = cachedResolveCredentialFile('compat::zaiApiKey', undefined, () => ({ key: null }), null)
+          assert.equal(r.key, null)
+          assert.equal(r.source, 'none')
+          assert.doesNotMatch(r.reason, /not set/)
+          assert.match(r.reason, /does not exist/)
+        } finally {
+          if (savedHome === undefined) delete process.env.HOME
+          else process.env.HOME = savedHome
+          rmSync(tmp, { recursive: true, force: true })
+        }
+      })
+    })
+
     it('synthesises DEEPSEEK_API_KEY reason for the deepseek slot', () => {
       withSavedEnv(() => {
         resetCachesForTest()
@@ -341,6 +413,20 @@ describe('auth-probes module (#4769)', () => {
         } finally {
           rmSync(tmp, { recursive: true, force: true })
         }
+      })
+    })
+
+    it('drops dynamic credential-file slots (#5461)', () => {
+      withSavedEnv(() => {
+        resetCachesForTest()
+        let called = 0
+        cachedResolveCredentialFile('compat:X:y', 'v', () => { called++; return { key: 'v1' } })
+        cachedResolveCredentialFile('compat:X:y', 'v', () => { called++; return { key: 'v2' } })
+        assert.equal(called, 1, 'precondition: the dynamic slot is cached')
+        resetCachesForTest()
+        const r = cachedResolveCredentialFile('compat:X:y', 'v', () => { called++; return { key: 'v3' } })
+        assert.equal(called, 2, 'reset must drop dynamic slots')
+        assert.equal(r.key, 'v3')
       })
     })
   })


### PR DESCRIPTION
## Summary

`resolveAnthropicCompatibleApiKey()` (the `resolveAuth` / `_resolveCredentials` path for config-driven Anthropic-compatible entries, #5419/#5458) did a fresh `statSync` + `readFileSync` + `JSON.parse` of `~/.chroxy/credentials.json` on every invocation — once per configured entry on every dashboard `list_providers` round-trip. The built-in byok/deepseek/discord resolvers already route the identical read through `cachedResolveCredentialFile()` in `auth-probes.js`; that cache was just keyed to the fixed slot trio.

## Changes

- **`auth-probes.js`**: `cachedResolveCredentialFile()` now creates slots lazily — any slot name beyond the fixed `byok`/`deepseek`/`discord` trio is seeded from a frozen empty template on first use. A new optional `envVarName` parameter keeps the synthesized ENOENT reason byte-identical to what the entry's own resolver would produce (`<VAR> not set and <path> does not exist`, env clause omitted for file-only specs); fixed slots keep their `_SLOT_ENV_VAR` mapping unchanged.
- **`anthropic-compatible-session.js`**: `resolveAnthropicCompatibleApiKey()` wraps its (renamed, private) uncached body in the cache under a dynamic `compat:<apiKeyEnv>:<credentialsKey>` slot. Slots are keyed by the resolver's actual inputs rather than `entry.id`, so entries sharing a credential spec share the cached result and an id-less raw entry can't poison a sibling's slot. Keyless and env-only entries bypass the cache entirely — those paths never touch the file.
- **Invalidation** is the existing contract, not a new scheme: cached result is reused only while the env-var value is unchanged and the file's `mtime+size+mode` stat matches; `resetCachesForTest()` / `_resetCredsCacheForTest()` drop dynamic slots via the existing whole-object replacement.

## Tests

- `anthropic-compatible.test.js` — new `credential file read caching (#5461)` suite (RED before the change): stat-unchanged content mutation (same-length field rename + `utimesSync` mtime restore, the providers.test.js technique) proves the cached read; plus mtime-change, mode-change (0600→0644 refusal not masked), env-value-change, ENOENT-reason-shape, and reset-drops-dynamic-slots coverage.
- `auth-probes.test.js` — dynamic-slot boundary tests: lazy creation + per-slot independence, ENOENT reason with/without a configured env var, reset dropping dynamic slots.
- Full server suite: 8561 pass / 2 fail — both failures are pre-existing environmental (`service.test.js` health-probe tests answered by the live local chroxy daemon; identical failures on a clean `origin/main` checkout).
- `npm run lint` clean (8 pre-existing warnings in unrelated files); all `scripts/lint-*.sh` pass.

## Acceptance criteria (#5461)

- [x] `cachedResolveCredentialFile` supports dynamic slots for config-driven entries
- [x] `resolveAnthropicCompatibleApiKey` uses it on the resolveAuth path
- [x] Cache invalidates on env-var change and on credentials.json mtime/size/mode change (same contract as the existing slots)
- [x] `_resetCredsCacheForTest` / `resetCachesForTest` covers the new slots

Closes #5461.