### PR TITLE
refactor(store-core): adopt shared handlers in the dashboard for the remaining duplicated message types

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -77,6 +77,14 @@ import {
   handlePermissionExpired as sharedPermissionExpired,
   handlePermissionTimeout as sharedPermissionTimeout,
   handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  // #5454 — remaining both-sides duplicates extracted into store-core
+  handleRawOutput as sharedRawOutput,
+  handleTokenRotated as sharedTokenRotated,
+  handlePairFail as sharedPairFail,
+  handleSessionCostThresholdCrossed as sharedSessionCostThresholdCrossed,
+  handleNotificationPrefs as sharedNotificationPrefs,
+  // #5454 — pure core of the #554 stream-split block (permission_request)
+  resolvePermissionStreamSplit,
   handleDirectoryListing as sharedDirectoryListing,
   handleFileListing as sharedFileListing,
   handleFileContent as sharedFileContent,
@@ -1138,14 +1146,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       set({ socket: null });
       useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
       if (!ctx.silent) {
-        const reason = (msg.reason as string) || 'pairing_failed';
-        const pairMessages: Record<string, string> = {
-          expired: 'This QR code has expired. Scan the latest QR code from your server.',
-          already_used: 'This QR code has already been used. Scan the latest QR code from your server.',
-          invalid_pairing_id: 'Invalid pairing code. Scan the latest QR code from your server.',
-          rate_limited: 'Too many attempts. Please wait a moment and try again.',
-        };
-        Alert.alert('Pairing Failed', pairMessages[reason] || `Pairing failed: ${reason}`);
+        // Reason parse + friendly QR-flow copy shared via store-core (#5454).
+        const { alertMessage } = sharedPairFail(msg, 'pairing_failed');
+        Alert.alert('Pairing Failed', alertMessage);
       }
       break;
     }
@@ -1841,10 +1844,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'raw':
-      get().appendTerminalData(msg.data as string);
-      useTerminalStore.getState().appendTerminalData(msg.data as string);
+    case 'raw': {
+      const { data: rawData } = sharedRawOutput(msg);
+      get().appendTerminalData(rawData);
+      useTerminalStore.getState().appendTerminalData(rawData);
       break;
+    }
 
     case 'claude_ready': {
       const patch = sharedClaudeReady();
@@ -2016,10 +2021,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'raw_background':
-      get().appendTerminalData(msg.data as string);
-      useTerminalStore.getState().appendTerminalData(msg.data as string);
+    case 'raw_background': {
+      const { data: rawBgData } = sharedRawOutput(msg);
+      get().appendTerminalData(rawBgData);
+      useTerminalStore.getState().appendTerminalData(rawBgData);
       break;
+    }
 
     case 'permission_request': {
       const permPayload = sharedPermissionRequest(msg);
@@ -2027,24 +2034,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // this, we'd insert a prompt with `requestId === null` (the handler
       // contract) and the cast on the next line would mask the issue.
       if (!permPayload.requestId) break;
-      // Split streaming response at permission boundary (#554)
+      // Split streaming response at permission boundary (#554). The pure
+      // split/remap-resolution core is shared via store-core (#5454); the
+      // side effects below keep their original order.
       {
         const permTargetId = permPayload.sessionId || get().activeSessionId;
         const permSs = permTargetId ? get().sessionStates[permTargetId] : null;
         const currentStreamId = permSs ? permSs.streamingMessageId : null;
-        if (currentStreamId && currentStreamId !== 'pending') {
+        const split = resolvePermissionStreamSplit(currentStreamId, _ctx.deltaIdRemaps);
+        if (split) {
           if (_ctx.deltaFlushTimer) {
             clearTimeout(_ctx.deltaFlushTimer);
           }
           flushPendingDeltas();
-          let serverStreamId = currentStreamId;
-          for (const [origId, remappedId] of _ctx.deltaIdRemaps) {
-            if (remappedId === currentStreamId) {
-              serverStreamId = origId;
-              break;
-            }
-          }
-          _ctx.postPermissionSplits.add(serverStreamId);
+          _ctx.postPermissionSplits.add(split.serverStreamId);
           const clearTarget = permTargetId || get().activeSessionId;
           if (clearTarget && get().sessionStates[clearTarget]) {
             updateSession(clearTarget, () => ({ streamingMessageId: null }));
@@ -2611,14 +2614,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'session_cost_threshold_crossed': {
       // #4075: soft "you've spent $X" warning. Fires ONCE per session.
       // Mobile mirrors dashboard semantics: the server doesn't replay so
-      // a missed banner stays missed (no store-and-replay).
-      const sid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      const costUsd = typeof msg.costUsd === 'number' && Number.isFinite(msg.costUsd) ? msg.costUsd : 0;
-      const thresholdUsd = typeof msg.thresholdUsd === 'number' && Number.isFinite(msg.thresholdUsd) ? msg.thresholdUsd : 0;
-      if (sid && get().sessionStates[sid]) {
-        updateSession(sid, () => ({
-          costThresholdWarning: { costUsd, thresholdUsd, dismissedAt: null },
-        }));
+      // a missed banner stays missed (no store-and-replay). Parse shared
+      // via store-core (#5454) — explicit sessionId only, no fallback.
+      const { sessionId: thresholdSid, patch: thresholdPatch } =
+        sharedSessionCostThresholdCrossed(msg);
+      if (thresholdSid && get().sessionStates[thresholdSid]) {
+        updateSession(thresholdSid, () => thresholdPatch);
       }
       break;
     }
@@ -2791,6 +2792,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // `notification_prefs_get` and broadcast after every
       // `notification_prefs_set` so multiple connected clients stay in
       // lockstep. Validated against the protocol Zod schema before storing.
+      // #5454: kept inline (store-core's handleNotificationPrefs has the
+      // same logic; the #4542/#4544 source-shape tests pin this impl).
       const parsed = ServerNotificationPrefsSchema.safeParse(msg);
       if (!parsed.success) {
         // eslint-disable-next-line no-console
@@ -2858,7 +2861,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'token_rotated': {
-      const newToken = typeof msg.token === 'string' ? msg.token : null;
+      // Token parse shared via store-core (#5454); persistence/re-auth side
+      // effects stay platform-specific.
+      const { token: newToken } = sharedTokenRotated(msg);
       if (newToken) {
         // Server sent the new token — update stored credentials seamlessly
         console.log('[ws] Server token rotated — updating stored token');

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -82,7 +82,8 @@ import {
   handleTokenRotated as sharedTokenRotated,
   handlePairFail as sharedPairFail,
   handleSessionCostThresholdCrossed as sharedSessionCostThresholdCrossed,
-  handleNotificationPrefs as sharedNotificationPrefs,
+  // (no handleNotificationPrefs import — the app keeps notification_prefs
+  // inline; the #4542/#4544 source-shape tests pin that implementation)
   // #5454 — pure core of the #554 stream-split block (permission_request)
   resolvePermissionStreamSplit,
   handleDirectoryListing as sharedDirectoryListing,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -62,6 +62,21 @@ import {
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
   handlePermissionExpired as sharedPermissionExpired,
   handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  // #5454 — dashboard adopts the shared permission family + the remaining
+  // both-sides duplicates
+  handlePermissionRequest as sharedPermissionRequest,
+  handlePermissionResolved as sharedPermissionResolved,
+  handlePermissionTimeout as sharedPermissionTimeout,
+  handleSessionStopped as sharedSessionStopped,
+  handleCheckpointRestored as sharedCheckpointRestored,
+  handleConversationsList as sharedConversationsList,
+  handleRawOutput as sharedRawOutput,
+  handleTokenRotated as sharedTokenRotated,
+  handlePairFail as sharedPairFail,
+  handleSessionCostThresholdCrossed as sharedSessionCostThresholdCrossed,
+  handleNotificationPrefs as sharedNotificationPrefs,
+  // #5454 — pure core of the #554 stream-split block (permission_request)
+  resolvePermissionStreamSplit,
   handleDirectoryListing as sharedDirectoryListing,
   handleFileListing as sharedFileListing,
   handleFileContent as sharedFileContent,
@@ -115,7 +130,7 @@ import {
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerNotificationPrefsSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema } from '@chroxy/protocol/schemas'
 import {
   createKeyPair,
   deriveSharedKey,
@@ -146,7 +161,6 @@ import type {
   SessionState,
   SlashCommand,
   FilePickerItem,
-  ConversationSummary,
   ProviderInfo,
   WebTask,
 } from './types';
@@ -783,15 +797,17 @@ function handlePong(_msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _
 }
 
 function handleRaw(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  get().appendTerminalData(msg.data as string);
+  get().appendTerminalData(sharedRawOutput(msg).data);
 }
 
 function handleRawBackground(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  get().appendTerminalData(msg.data as string);
+  get().appendTerminalData(sharedRawOutput(msg).data);
 }
 
 function handleTokenRotated(msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  const newToken = typeof msg.token === 'string' ? msg.token : null;
+  // Token parse shared via store-core (#5454); the URL-rewrite side effect
+  // stays dashboard-specific.
+  const { token: newToken } = sharedTokenRotated(msg);
   if (newToken) {
     // Server sent the new token — update URL query param for reconnection
     console.log('[ws] Server token rotated — updating stored token');
@@ -805,9 +821,18 @@ function handleTokenRotated(msg: Record<string, unknown>, _get: MsgGet, _set: Ms
   }
 }
 
-function handleCheckpointRestored(_msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  // Server has created a new session from the checkpoint.
-  // The session_list update will follow from the server — nothing to do here.
+function handleCheckpointRestored(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  // Server has created a new session from the checkpoint and already moved
+  // this client's server-side activeSessionId onto it (the message is sent
+  // only to the requesting client — see checkpoint-handlers.js). #5454:
+  // adopt the shared parser and auto-switch to the restored session, matching
+  // the app. Previously the dashboard left the operator on the old tab until
+  // they clicked the new "Rewind: …" entry; the session_list broadcast that
+  // follows still populates the tab strip.
+  const restored = sharedCheckpointRestored(msg);
+  if (restored) {
+    get().switchSession(restored.newSessionId);
+  }
 }
 
 /**
@@ -830,7 +855,9 @@ function handleWebTaskList(msg: Record<string, unknown>, _get: MsgGet, set: MsgS
 }
 
 function handleConversationsList(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const conversations = Array.isArray(msg.conversations) ? (msg.conversations as ConversationSummary[]) : [];
+  // Parser shared via store-core (#5454); the dashboard intentionally has no
+  // `conversationHistoryError` / conversation-store mirror (those are app-only).
+  const { conversations } = sharedConversationsList(msg);
   set({ conversationHistory: conversations, conversationHistoryLoading: false });
 }
 
@@ -1589,25 +1616,33 @@ function handleToolResult(msg: Record<string, unknown>, get: MsgGet, set: MsgSet
 }
 
 function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  // Split streaming response at permission boundary (#554)
+  // #5454: payload parse is shared via store-core (`handlePermissionRequest`)
+  // — same handler the app uses. Dashboard-specific glue kept below:
+  //   - flat-state fallbacks (`get().messages` / top-level `streamingMessageId`)
+  //     for sessions not yet in `sessionStates`;
+  //   - #2853 options trimming (allow/deny only — see comment below);
+  //   - the simpler 4-arg `pushSessionNotification` (no input preview).
+  const permPayload = sharedPermissionRequest(msg);
+  // Skip malformed messages with missing/non-string requestId — matches the
+  // app and the shared-handler contract. (Previously the dashboard would
+  // insert a prompt with an `undefined` requestId and still run the stream
+  // split; such a message is unanswerable, so drop it outright.)
+  if (!permPayload.requestId) return;
+  // Split streaming response at permission boundary (#554). The pure
+  // split/remap-resolution core is shared via store-core (#5454); the side
+  // effects below keep their original order.
   {
-    const permTargetId = (msg.sessionId as string) || get().activeSessionId;
+    const permTargetId = permPayload.sessionId || get().activeSessionId;
     const currentStreamId = permTargetId && get().sessionStates[permTargetId]
       ? get().sessionStates[permTargetId]!.streamingMessageId
       : get().streamingMessageId;
-    if (currentStreamId && currentStreamId !== 'pending') {
+    const split = resolvePermissionStreamSplit(currentStreamId, _deltaIdRemaps);
+    if (split) {
       if (deltaFlushTimer) {
         clearTimeout(deltaFlushTimer);
       }
       flushPendingDeltas();
-      let serverStreamId = currentStreamId;
-      for (const [origId, remappedId] of _deltaIdRemaps) {
-        if (remappedId === currentStreamId) {
-          serverStreamId = origId;
-          break;
-        }
-      }
-      _postPermissionSplits.add(serverStreamId);
+      _postPermissionSplits.add(split.serverStreamId);
       if (permTargetId && get().sessionStates[permTargetId]) {
         updateSession(permTargetId, () => ({ streamingMessageId: null }));
       } else {
@@ -1615,19 +1650,21 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
       }
     }
   }
-  const permRequestId = msg.requestId as string;
+  const permRequestId = permPayload.requestId;
   // #2853: PermissionPrompt hardcodes its own buttons (Allow / Allow for Session
   // / Deny) and never reads this array; `sendPermissionResponse` only accepts
   // 'allow' | 'deny' | 'allowSession'. Keep only the wire-level allow/deny
   // options in the stored payload for history/debug inspection, without
   // advertising dashboard-only decisions ('allowSession') or unreachable ones
-  // ('allowAlways') here.
+  // ('allowAlways') here. (Intentional divergence from the app, which builds
+  // its options list dynamically — including the #3072 provider-capability
+  // gate for 'Allow for Session' — because its prompt UI renders from it.)
   const newOptions = [
     { label: 'Allow', value: 'allow' },
     { label: 'Deny', value: 'deny' },
   ];
-  const newExpiresAt = typeof msg.remainingMs === 'number' ? Date.now() + msg.remainingMs : undefined;
-  const permTargetId = (msg.sessionId as string) || get().activeSessionId;
+  const newExpiresAt = permPayload.remainingMs !== null ? Date.now() + permPayload.remainingMs : undefined;
+  const permTargetId = permPayload.sessionId || get().activeSessionId;
 
   const targetMessages = permTargetId && get().sessionStates[permTargetId]
     ? get().sessionStates[permTargetId]!.messages
@@ -1650,25 +1687,21 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
       set({ messages: updater({ messages: get().messages }).messages });
     }
   } else {
-    // Validate string fields up front so the prompt content and tool slot
-    // are guaranteed strings — non-string `msg.tool`/`msg.description` could
-    // otherwise leak through `as string` casts and violate ChatMessage.content.
-    const tool = typeof msg.tool === 'string' ? msg.tool : null;
-    const description = typeof msg.description === 'string' ? msg.description : null;
     const permMsg: ChatMessage = {
       id: nextMessageId('perm'),
       type: 'prompt',
       // Render only the tool name when description is missing; otherwise
       // combine `"<tool>: <description>"`. Fallback to a generic label when
       // neither is available. Fixes the "Tool: undefined" string that the
-      // prior `${tool}: ${description}` template produced (#3122).
-      content: tool
-        ? (description ? `${tool}: ${description}` : tool)
-        : (description || 'Permission required'),
-      tool: tool ?? undefined,
+      // prior `${tool}: ${description}` template produced (#3122). The
+      // string guards (#3122) and the array-rejecting input guard (#3123)
+      // live in the shared parser.
+      content: permPayload.tool
+        ? (permPayload.description ? `${permPayload.tool}: ${permPayload.description}` : permPayload.tool)
+        : (permPayload.description || 'Permission required'),
+      tool: permPayload.tool ?? undefined,
       requestId: permRequestId,
-      // Reject arrays — match the tightened guard in handlePermissionRequest (#3123)
-      toolInput: msg.input && typeof msg.input === 'object' && !Array.isArray(msg.input) ? msg.input as Record<string, unknown> : undefined,
+      toolInput: permPayload.input ?? undefined,
       options: newOptions,
       expiresAt: newExpiresAt,
       timestamp: Date.now(),
@@ -1682,7 +1715,7 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
     }
   }
   if (permTargetId) {
-    const toolDesc = msg.tool ? `${msg.tool}` : 'Permission needed';
+    const toolDesc = permPayload.tool ?? 'Permission needed';
     pushSessionNotification(permTargetId, 'permission', toolDesc, permRequestId);
   }
 }
@@ -1691,13 +1724,16 @@ function handlePermissionResolved(msg: Record<string, unknown>, get: MsgGet, set
   // Another client resolved this permission — dismiss the prompt on this client.
   // The permission_request may have been stored in ANY session state (whichever tab
   // was active when it arrived), so search all session states for the matching requestId.
-  const resolvedRequestId = msg.requestId as string;
-  const resolvedDecision = msg.decision as string;
+  // #5454: payload parse shared via store-core (same handler the app uses);
+  // the flat-messages fallback and #5008 mark-read banner draining below are
+  // dashboard-specific.
+  const { requestId: resolvedRequestId, decision: resolvedDecision } =
+    sharedPermissionResolved(msg);
   if (resolvedRequestId) {
     const updater = (ss: { messages: ChatMessage[] }) => ({
       messages: ss.messages.map((m) =>
         m.requestId === resolvedRequestId && m.type === 'prompt'
-          ? { ...m, answered: resolvedDecision, answeredAt: Date.now(), options: undefined }
+          ? { ...m, answered: resolvedDecision ?? undefined, answeredAt: Date.now(), options: undefined }
           : m
       ),
     });
@@ -2266,7 +2302,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         if (entry && !entry.token) get().removeServer(failedServerId);
       }
       if (!ctx.silent) {
-        const reason = typeof msg.reason === 'string' ? msg.reason : 'unknown';
+        // Reason parse shared via store-core (#5454). The dashboard keeps its
+        // plain `Pairing failed: <reason>` copy — the friendly
+        // PAIR_FAIL_MESSAGES strings are QR-flow wording ("Scan the latest QR
+        // code…") that doesn't fit this paste-a-pairing-URL surface.
+        const { reason } = sharedPairFail(msg, 'unknown');
         _adapters.alert.alert('Pairing Failed', `Pairing failed: ${reason}`);
       }
       break;
@@ -2619,7 +2659,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // "Session stopped." carries the full signal there. Missing code
       // (future in-process providers per the #4756 follow-up) is also
       // bare; surfacing "(exit undefined)" would be noisier than useful.
-      const stoppedCode = typeof msg.code === 'number' ? msg.code : null;
+      //
+      // #5454: parse + session patch shared via store-core (same handler the
+      // app uses; it also tightens the code guard with Number.isInteger so a
+      // fractional/NaN code renders bare instead of "(exit 1.5)"). The patch
+      // sets `stoppedAt`/`stoppedCode` on the target session — already part
+      // of the dashboard's BaseSessionState shape (#4879 parity) and cleared
+      // by `handleClaudeReady` exactly as on the app. The info toast stays
+      // dashboard-specific (#4878).
+      const stoppedPatch = sharedSessionStopped(msg, get().activeSessionId);
+      const stoppedTarget = stoppedPatch.sessionId;
+      if (stoppedTarget && get().sessionStates[stoppedTarget]) {
+        updateSession(stoppedTarget, () => stoppedPatch.patch);
+      }
+      const stoppedCode = stoppedPatch.patch.stoppedCode as number | null;
       const stoppedMessage = stoppedCode != null && stoppedCode !== 0
         ? `Session stopped. (exit ${stoppedCode})`
         : 'Session stopped.';
@@ -3042,6 +3095,57 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'permission_timeout': {
+      // #5454: the dashboard previously dropped this event on the floor while
+      // the app handled it (the #2661 close-out flagged the gap). Not yet
+      // emitted by the server (see the handler-coverage SYNTHETIC_TYPES
+      // note) — wired up now for parity via the shared store-core handler so
+      // both clients react identically when the server grows the emit side.
+      const { requestId: timeoutRequestId, systemMessage: timeoutSystemMsg } =
+        sharedPermissionTimeout(msg);
+      if (timeoutRequestId) {
+        // Mark the matching prompt as auto-denied. Scan all session states
+        // first (the prompt may have been stored in any session — mirrors the
+        // handlePermissionResolved all-sessions search), then fall back to
+        // the flat messages array for sessions not in sessionStates.
+        const timeoutUpdater = (ss: { messages: ChatMessage[] }) => ({
+          messages: ss.messages.map((m) =>
+            m.requestId === timeoutRequestId && m.type === 'prompt'
+              ? { ...m, content: `${m.content}\n(Auto-denied — permission timed out)`, options: undefined }
+              : m
+          ),
+        });
+        const timeoutStates = get().sessionStates;
+        let timeoutFound = false;
+        for (const sid of Object.keys(timeoutStates)) {
+          if (timeoutStates[sid]?.messages.some((m) => m.requestId === timeoutRequestId)) {
+            updateSession(sid, timeoutUpdater);
+            timeoutFound = true;
+            break;
+          }
+        }
+        if (!timeoutFound) {
+          set({ messages: timeoutUpdater({ messages: get().messages }).messages });
+        }
+        // #5008 — drain the banner stack without dropping the row from the
+        // NotificationsWidget's durable history: stamp `readAt` instead of
+        // removing (see handlePermissionResolved for the pattern source).
+        const readStamp = Date.now();
+        set((s) => ({
+          sessionNotifications: s.sessionNotifications.map((n) =>
+            n.requestId === timeoutRequestId && n.readAt === undefined
+              ? { ...n, readAt: readStamp }
+              : n
+          ),
+        }));
+      }
+      // Surface a dismissible error toast so the operator knows the
+      // permission was auto-denied (wording comes from the shared handler so
+      // the two clients stay in sync).
+      get().addServerError(timeoutSystemMsg.content);
+      break;
+    }
+
     case 'permission_rules_updated': {
       // Server broadcasts the full rule set for a session after a successful
       // set_permission_rules call. Store it on the session so "Allow for
@@ -3382,30 +3486,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // `notification_prefs_get` and broadcast after every
       // `notification_prefs_set`. The wire schema is permissive
       // (z.record(string, boolean) for categories) — adding a category
-      // server-side does not require a client rebuild.
-      const parsed = ServerNotificationPrefsSchema.safeParse(msg);
-      if (!parsed.success) {
+      // server-side does not require a client rebuild. Zod validation +
+      // #4544 bypassCategories handling are shared via store-core (#5454);
+      // a failed parse logs and leaves existing state alone, as before.
+      const { notificationPrefs, issues } = sharedNotificationPrefs(msg);
+      if (!notificationPrefs) {
         // eslint-disable-next-line no-console
-        console.warn('notification_prefs: invalid payload from server', parsed.error.issues);
+        console.warn('notification_prefs: invalid payload from server', issues);
         break;
       }
-      const prefs = parsed.data.prefs;
-      // #4544: the wire snapshot now carries an optional `bypassCategories`
-      // array (categories that fire even during quiet hours). Older servers
-      // omit it — clients fall back to the documented defaults
-      // (permission + activity_error). The quiet-hours window's
-      // `timezone` field is also new in #4544; the schema requires it
-      // when present, so per-device timezone-less windows from an
-      // intermediate state simply won't validate.
-      const bypassCategories = (prefs as { bypassCategories?: string[] }).bypassCategories;
-      set({
-        notificationPrefs: {
-          categories: prefs.categories,
-          devices: prefs.devices,
-          quietHours: prefs.quietHours,
-          ...(Array.isArray(bypassCategories) ? { bypassCategories } : {}),
-        },
-      });
+      set({ notificationPrefs });
       break;
     }
 
@@ -3474,14 +3564,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // #4075: soft "you've spent $X" warning. Fires ONCE per session.
       // The dashboard owns the dismissible banner state per-session; the
       // server doesn't re-fire even if costs continue rising, so a
-      // missed banner stays missed (don't store-and-replay).
-      const sid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      const costUsd = typeof msg.costUsd === 'number' && Number.isFinite(msg.costUsd) ? msg.costUsd : 0;
-      const thresholdUsd = typeof msg.thresholdUsd === 'number' && Number.isFinite(msg.thresholdUsd) ? msg.thresholdUsd : 0;
-      if (sid && get().sessionStates[sid]) {
-        updateSession(sid, () => ({
-          costThresholdWarning: { costUsd, thresholdUsd, dismissedAt: null },
-        }));
+      // missed banner stays missed (don't store-and-replay). Parse shared
+      // via store-core (#5454) — explicit sessionId only, no fallback.
+      const { sessionId: thresholdSid, patch: thresholdPatch } =
+        sharedSessionCostThresholdCrossed(msg);
+      if (thresholdSid && get().sessionStates[thresholdSid]) {
+        updateSession(thresholdSid, () => thresholdPatch);
       }
       break;
     }

--- a/packages/dashboard/src/store/permission-timeout.test.ts
+++ b/packages/dashboard/src/store/permission-timeout.test.ts
@@ -1,0 +1,171 @@
+/**
+ * permission_timeout handling (#5454).
+ *
+ * The dashboard previously dropped this event on the floor while the app
+ * handled it (gap flagged in the #2661 close-out audit). The handler now:
+ *   - marks the matching prompt as auto-denied (all-sessions scan with a
+ *     flat-messages fallback, mirroring handlePermissionResolved),
+ *   - drains the banner stack via the #5008 mark-read contract (stamp
+ *     `readAt`, keep the row as durable widget history),
+ *   - surfaces a dismissible error toast via addServerError, with wording
+ *     from the shared store-core handler so both clients stay in sync.
+ *
+ * Harness mirrors permission-resolved-drain.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setStore, handleMessage, setConnectionContext } from './message-handler'
+import type { ChatMessage, ConnectionState, SessionNotification } from './types'
+
+function createMockStore(initialState: Partial<ConnectionState>) {
+  let state = initialState as ConnectionState
+  return {
+    getState: () => state,
+    setState: (
+      updater:
+        | Partial<ConnectionState>
+        | ((s: ConnectionState) => Partial<ConnectionState>),
+    ) => {
+      if (typeof updater === 'function') {
+        state = { ...state, ...updater(state) }
+      } else {
+        state = { ...state, ...updater }
+      }
+    },
+  }
+}
+
+const mockCtx = {
+  url: 'wss://test',
+  token: 'test-token',
+  isReconnect: false,
+  silent: false,
+  socket: {} as WebSocket,
+}
+
+function makeNotification(
+  overrides: Partial<SessionNotification> = {},
+): SessionNotification {
+  return {
+    id: 'n-1',
+    sessionId: 'sess-1',
+    sessionName: 'Test Session',
+    eventType: 'permission',
+    message: 'Write to /tmp/test.txt',
+    timestamp: Date.now(),
+    requestId: 'req-abc',
+    ...overrides,
+  }
+}
+
+function makePrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'perm-1',
+    type: 'prompt',
+    content: 'Bash: run ls',
+    requestId: 'req-abc',
+    options: [
+      { label: 'Allow', value: 'allow' },
+      { label: 'Deny', value: 'deny' },
+    ],
+    timestamp: Date.now(),
+    ...overrides,
+  } as ChatMessage
+}
+
+describe('permission_timeout marks prompts auto-denied + drains banners (#5454)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let addServerError: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    addServerError = vi.fn()
+    store = createMockStore({
+      activeSessionId: 'sess-1',
+      messages: [],
+      addServerError: addServerError as unknown as ConnectionState['addServerError'],
+      sessionNotifications: [
+        makeNotification({ id: 'n-1', requestId: 'req-abc' }),
+        makeNotification({ id: 'n-2', requestId: 'req-def', message: 'Read /etc/hosts' }),
+      ],
+      sessionStates: {
+        'sess-1': { messages: [makePrompt()] },
+        // The prompt may live in a NON-active session's state (whichever tab
+        // was active when the request arrived) — covered below.
+        'sess-2': { messages: [makePrompt({ id: 'perm-2', requestId: 'req-other' })] },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+  })
+
+  it('appends the auto-denied line and strips options from the matching prompt', () => {
+    handleMessage({ type: 'permission_timeout', requestId: 'req-abc', tool: 'Bash' }, mockCtx)
+
+    const prompt = (store.getState().sessionStates['sess-1']!.messages as ChatMessage[])
+      .find((m) => m.requestId === 'req-abc')!
+    expect(prompt.content).toContain('(Auto-denied — permission timed out)')
+    expect(prompt.options).toBeUndefined()
+  })
+
+  it('finds the prompt in a non-active session state (all-sessions scan)', () => {
+    handleMessage({ type: 'permission_timeout', requestId: 'req-other', tool: 'Edit' }, mockCtx)
+
+    const prompt = (store.getState().sessionStates['sess-2']!.messages as ChatMessage[])
+      .find((m) => m.requestId === 'req-other')!
+    expect(prompt.content).toContain('(Auto-denied — permission timed out)')
+    expect(prompt.options).toBeUndefined()
+    // sess-1's prompt is untouched
+    const other = (store.getState().sessionStates['sess-1']!.messages as ChatMessage[])[0]!
+    expect(other.options).toBeDefined()
+  })
+
+  it('falls back to the flat messages array when no session state owns the prompt', () => {
+    store = createMockStore({
+      activeSessionId: 'sess-1',
+      messages: [makePrompt({ requestId: 'req-flat' })],
+      addServerError: addServerError as unknown as ConnectionState['addServerError'],
+      sessionNotifications: [],
+      sessionStates: {
+        'sess-1': { messages: [] },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+
+    handleMessage({ type: 'permission_timeout', requestId: 'req-flat', tool: 'Bash' }, mockCtx)
+
+    const prompt = (store.getState().messages as ChatMessage[])[0]!
+    expect(prompt.content).toContain('(Auto-denied — permission timed out)')
+    expect(prompt.options).toBeUndefined()
+  })
+
+  it('stamps readAt on the matching notification but keeps it in the list (#5008)', () => {
+    const before = Date.now()
+    handleMessage({ type: 'permission_timeout', requestId: 'req-abc', tool: 'Bash' }, mockCtx)
+    const after = Date.now()
+
+    const list = store.getState().sessionNotifications
+    expect(list).toHaveLength(2)
+    const matched = list.find((n) => n.requestId === 'req-abc')!
+    expect(matched.readAt).toBeTypeOf('number')
+    expect(matched.readAt!).toBeGreaterThanOrEqual(before)
+    expect(matched.readAt!).toBeLessThanOrEqual(after)
+    const other = list.find((n) => n.requestId === 'req-def')!
+    expect(other.readAt).toBeUndefined()
+  })
+
+  it('surfaces the shared-handler wording via addServerError', () => {
+    handleMessage({ type: 'permission_timeout', requestId: 'req-abc', tool: 'Bash' }, mockCtx)
+
+    expect(addServerError).toHaveBeenCalledTimes(1)
+    expect(addServerError).toHaveBeenCalledWith('Permission for "Bash" was auto-denied (timed out)')
+  })
+
+  it('still toasts (with the default tool label) when requestId is missing', () => {
+    handleMessage({ type: 'permission_timeout' }, mockCtx)
+
+    // No prompt/notification mutation possible without a requestId…
+    const list = store.getState().sessionNotifications
+    expect(list.every((n) => n.readAt === undefined)).toBe(true)
+    // …but the operator still learns about the auto-deny (matches the app).
+    expect(addServerError).toHaveBeenCalledWith('Permission for "permission" was auto-denied (timed out)')
+  })
+})

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -29,7 +29,7 @@ const SYNTHETIC_TYPES = new Set([
   'budget_resumed',        // budget resume ack (server-internal)
   'cancel_activity_ack',   // #5277 cancel correlation ack — emitted from input-handlers.js (not the ws-server.js broadcast surface the extractor scans), handled by the dashboard
   'thinking_level_changed', // thinking level change ack (server-internal)
-  'permission_timeout',     // app-side handler for future permission timeout event (not yet in protocol)
+  'permission_timeout',     // handled by both clients for the future permission timeout event (not yet in protocol; dashboard gained parity in #5454)
 ])
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -100,6 +100,14 @@ import {
   handleStreamStart,
   sharedStreamDelta,
   handleStreamEnd,
+  // #5454 — remaining both-sides duplicates
+  handleRawOutput,
+  handleTokenRotated,
+  handlePairFail,
+  PAIR_FAIL_MESSAGES,
+  handleSessionCostThresholdCrossed,
+  handleNotificationPrefs,
+  resolvePermissionStreamSplit,
 } from './index'
 import type { StreamDeltaContext, PendingDelta } from './index'
 import { nextMessageId } from '../utils'
@@ -8295,5 +8303,203 @@ describe('sharedStreamDelta (#4981)', () => {
     expect(buffered).toBeDefined()
     expect(buffered!.sessionId).toBe('s1')
     expect(buffered!.delta).toBe('world')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleRawOutput (#5454)
+// ---------------------------------------------------------------------------
+describe('handleRawOutput', () => {
+  it('extracts the data field verbatim', () => {
+    expect(handleRawOutput({ data: 'hello\x1b[0m' }).data).toBe('hello\x1b[0m')
+  })
+
+  it('preserves the prior inline cast behaviour for missing data (no coercion)', () => {
+    // Both clients previously did `appendTerminalData(msg.data as string)` —
+    // the verbatim cast is the documented contract.
+    expect(handleRawOutput({}).data).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleTokenRotated (#5454)
+// ---------------------------------------------------------------------------
+describe('handleTokenRotated', () => {
+  it('returns the token when it is a string', () => {
+    expect(handleTokenRotated({ token: 'tok-1' }).token).toBe('tok-1')
+  })
+
+  it('passes the empty string through verbatim (call sites gate on truthiness)', () => {
+    expect(handleTokenRotated({ token: '' }).token).toBe('')
+  })
+
+  it('returns null for missing or non-string tokens', () => {
+    expect(handleTokenRotated({}).token).toBeNull()
+    expect(handleTokenRotated({ token: 42 }).token).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handlePairFail (#5454)
+// ---------------------------------------------------------------------------
+describe('handlePairFail', () => {
+  it('maps known reasons to the friendly QR-flow copy', () => {
+    for (const reason of Object.keys(PAIR_FAIL_MESSAGES)) {
+      const result = handlePairFail({ reason }, 'pairing_failed')
+      expect(result.reason).toBe(reason)
+      expect(result.alertMessage).toBe(PAIR_FAIL_MESSAGES[reason])
+    }
+  })
+
+  it('falls back to the generic template for unknown reasons', () => {
+    const result = handlePairFail({ reason: 'weird_reason' }, 'pairing_failed')
+    expect(result.reason).toBe('weird_reason')
+    expect(result.alertMessage).toBe('Pairing failed: weird_reason')
+  })
+
+  it('uses the injected fallback for missing, empty, and non-string reasons', () => {
+    expect(handlePairFail({}, 'pairing_failed').reason).toBe('pairing_failed')
+    expect(handlePairFail({ reason: '' }, 'unknown').reason).toBe('unknown')
+    expect(handlePairFail({ reason: 42 }, 'unknown').reason).toBe('unknown')
+    expect(handlePairFail({}, 'unknown').alertMessage).toBe('Pairing failed: unknown')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionCostThresholdCrossed (#5454)
+// ---------------------------------------------------------------------------
+describe('handleSessionCostThresholdCrossed', () => {
+  it('builds the costThresholdWarning patch for the explicit session', () => {
+    const result = handleSessionCostThresholdCrossed({
+      sessionId: 'sess-1',
+      costUsd: 5.25,
+      thresholdUsd: 5,
+    })
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.patch).toEqual({
+      costThresholdWarning: { costUsd: 5.25, thresholdUsd: 5, dismissedAt: null },
+    })
+  })
+
+  it('does NOT fall back to any active session — explicit sessionId only', () => {
+    expect(handleSessionCostThresholdCrossed({ costUsd: 1, thresholdUsd: 1 }).sessionId).toBeNull()
+    expect(handleSessionCostThresholdCrossed({ sessionId: 42 }).sessionId).toBeNull()
+  })
+
+  it('defaults non-finite / missing / non-number amounts to 0', () => {
+    const result = handleSessionCostThresholdCrossed({
+      sessionId: 's',
+      costUsd: Number.NaN,
+      thresholdUsd: '5',
+    })
+    expect(result.patch.costThresholdWarning.costUsd).toBe(0)
+    expect(result.patch.costThresholdWarning.thresholdUsd).toBe(0)
+    expect(
+      handleSessionCostThresholdCrossed({ sessionId: 's', costUsd: Infinity })
+        .patch.costThresholdWarning.costUsd,
+    ).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleNotificationPrefs (#5454)
+// ---------------------------------------------------------------------------
+describe('handleNotificationPrefs', () => {
+  const validMsg = {
+    type: 'notification_prefs',
+    prefs: {
+      categories: { permission: true, activity_error: false },
+      devices: {},
+      quietHours: null,
+    },
+  }
+
+  it('parses a valid snapshot into the stored shape', () => {
+    const { notificationPrefs, issues } = handleNotificationPrefs(validMsg)
+    expect(issues).toBeNull()
+    expect(notificationPrefs).toEqual({
+      categories: { permission: true, activity_error: false },
+      devices: {},
+      quietHours: null,
+    })
+    // bypassCategories must be OMITTED (not undefined-valued) when absent
+    expect(Object.prototype.hasOwnProperty.call(notificationPrefs, 'bypassCategories')).toBe(false)
+  })
+
+  it('forwards bypassCategories and quietHours when present (#4544)', () => {
+    const { notificationPrefs } = handleNotificationPrefs({
+      type: 'notification_prefs',
+      prefs: {
+        categories: { permission: true },
+        devices: {
+          'device-1': { quietHours: { start: '22:00', end: '07:00', timezone: 'Australia/Melbourne' } },
+        },
+        quietHours: { start: '23:00', end: '06:00', timezone: 'Australia/Melbourne' },
+        bypassCategories: ['permission'],
+      },
+    })
+    expect(notificationPrefs).not.toBeNull()
+    expect(notificationPrefs!.bypassCategories).toEqual(['permission'])
+    expect(notificationPrefs!.quietHours).toEqual({
+      start: '23:00',
+      end: '06:00',
+      timezone: 'Australia/Melbourne',
+    })
+    expect(notificationPrefs!.devices['device-1']!.quietHours).toEqual({
+      start: '22:00',
+      end: '07:00',
+      timezone: 'Australia/Melbourne',
+    })
+  })
+
+  it('returns issues (and null prefs) when validation fails', () => {
+    const { notificationPrefs, issues } = handleNotificationPrefs({
+      type: 'notification_prefs',
+      prefs: { categories: { permission: 'yes' }, devices: {}, quietHours: null },
+    })
+    expect(notificationPrefs).toBeNull()
+    expect(Array.isArray(issues)).toBe(true)
+    expect((issues as unknown[]).length).toBeGreaterThan(0)
+  })
+
+  it('rejects a quiet-hours window missing its timezone (#4544)', () => {
+    const { notificationPrefs } = handleNotificationPrefs({
+      type: 'notification_prefs',
+      prefs: {
+        categories: {},
+        devices: {},
+        quietHours: { start: '22:00', end: '07:00' },
+      },
+    })
+    expect(notificationPrefs).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolvePermissionStreamSplit (#554 / #5454)
+// ---------------------------------------------------------------------------
+describe('resolvePermissionStreamSplit', () => {
+  it('returns null when there is no current stream', () => {
+    expect(resolvePermissionStreamSplit(null, new Map())).toBeNull()
+  })
+
+  it('returns null for the "pending" placeholder id', () => {
+    expect(resolvePermissionStreamSplit('pending', new Map())).toBeNull()
+  })
+
+  it('returns the current stream id verbatim when no remap matches', () => {
+    expect(resolvePermissionStreamSplit('msg-1', new Map([['orig-9', 'other']]))).toEqual({
+      serverStreamId: 'msg-1',
+    })
+  })
+
+  it('reverse-maps a remapped client id back to the server-origin id', () => {
+    const remaps = new Map([
+      ['orig-1', 'client-1'],
+      ['orig-2', 'client-2'],
+    ])
+    expect(resolvePermissionStreamSplit('client-2', remaps)).toEqual({
+      serverStreamId: 'orig-2',
+    })
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -8314,10 +8314,14 @@ describe('handleRawOutput', () => {
     expect(handleRawOutput({ data: 'hello\x1b[0m' }).data).toBe('hello\x1b[0m')
   })
 
-  it('preserves the prior inline cast behaviour for missing data (no coercion)', () => {
-    // Both clients previously did `appendTerminalData(msg.data as string)` —
-    // the verbatim cast is the documented contract.
-    expect(handleRawOutput({}).data).toBeUndefined()
+  it('falls back to the empty string for missing or non-string data', () => {
+    // The declared `{ data: string }` type is honest: a malformed payload
+    // appends nothing rather than letting `undefined` flow into the
+    // dashboard's `stripAnsi(data)` (which throws on non-strings). The
+    // server's raw payload is always a PTY string, so this is unreachable
+    // from a well-behaved producer.
+    expect(handleRawOutput({}).data).toBe('')
+    expect(handleRawOutput({ data: 42 }).data).toBe('')
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -5197,14 +5197,17 @@ export function handleResultUsage(
 /**
  * Extract the terminal data chunk from a `raw` / `raw_background` message.
  *
- * Behaviour-preserving: both clients previously did
- * `appendTerminalData(msg.data as string)` inline — the verbatim cast is kept
- * here (no string validation) so a malformed payload behaves exactly as it
- * did pre-extraction. Tightening would be a behaviour change beyond the scope
- * of #5454.
+ * Non-string / missing `data` falls back to `''` so the declared return type
+ * is honest. Both clients previously did `appendTerminalData(msg.data as
+ * string)` inline — a typed lie that let `undefined` flow into the
+ * dashboard's `stripAnsi(data)` (which throws on non-strings). The server's
+ * `raw` / `raw_background` payload is always a PTY string, so the fallback is
+ * unreachable from a well-behaved producer; for a malformed one, appending
+ * nothing beats crashing the message handler. Same tightening class as the
+ * other non-string fallbacks in this migration (#5454).
  */
 export function handleRawOutput(msg: Record<string, unknown>): { data: string } {
-  return { data: msg.data as string }
+  return { data: typeof msg.data === 'string' ? msg.data : '' }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -45,7 +45,7 @@ import type { ErrorPartialCost } from '../cost-format'
 // Centralised client-side error-category detection (#3151).
 import { isRateLimitMessage } from '@chroxy/protocol'
 // Established Zod-handler pattern (#3138).
-import { ServerAvailableModelsEntrySchema } from '@chroxy/protocol'
+import { ServerAvailableModelsEntrySchema, ServerNotificationPrefsSchema } from '@chroxy/protocol'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -5184,4 +5184,255 @@ export function handleResultUsage(
     lastResultCost,
     lastResultDuration,
   }
+}
+
+// ---------------------------------------------------------------------------
+// raw / raw_background (#5454)
+//
+// Note on `pong`: it carries no payload and its only effect is module-level
+// heartbeat bookkeeping (`_onPong()` timer reset) on each client, so there is
+// nothing to extract — it intentionally has no shared handler.
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the terminal data chunk from a `raw` / `raw_background` message.
+ *
+ * Behaviour-preserving: both clients previously did
+ * `appendTerminalData(msg.data as string)` inline — the verbatim cast is kept
+ * here (no string validation) so a malformed payload behaves exactly as it
+ * did pre-extraction. Tightening would be a behaviour change beyond the scope
+ * of #5454.
+ */
+export function handleRawOutput(msg: Record<string, unknown>): { data: string } {
+  return { data: msg.data as string }
+}
+
+// ---------------------------------------------------------------------------
+// token_rotated
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the new bearer token from a `token_rotated` message.
+ *
+ * Returns the token verbatim when it is a string (including the empty
+ * string), else null. Both call sites gate the "seamless update" path on a
+ * truthy check — so `''` takes the legacy "re-authentication required" path
+ * exactly as it did with the prior inline
+ * `typeof msg.token === 'string' ? msg.token : null` guard.
+ *
+ * Side effects are platform-specific and stay at the call site: the app
+ * persists the token via `saveConnection` (or disconnects + alerts on the
+ * legacy path); the dashboard rewrites the `token` query param in the
+ * browser URL.
+ */
+export function handleTokenRotated(msg: Record<string, unknown>): { token: string | null } {
+  return { token: typeof msg.token === 'string' ? msg.token : null }
+}
+
+// ---------------------------------------------------------------------------
+// pair_fail
+// ---------------------------------------------------------------------------
+
+/**
+ * User-facing copy for the known `pair_fail` reasons. Worded for the QR-code
+ * pairing flow — the mobile app uses these verbatim. The dashboard's
+ * paste-a-pairing-URL flow (#5297) keeps its plain `Pairing failed: <reason>`
+ * template at the call site, since "Scan the latest QR code" does not match
+ * that surface's UX.
+ */
+export const PAIR_FAIL_MESSAGES: Record<string, string> = {
+  expired: 'This QR code has expired. Scan the latest QR code from your server.',
+  already_used: 'This QR code has already been used. Scan the latest QR code from your server.',
+  invalid_pairing_id: 'Invalid pairing code. Scan the latest QR code from your server.',
+  rate_limited: 'Too many attempts. Please wait a moment and try again.',
+}
+
+/** Parsed payload from a `pair_fail` message. */
+export interface PairFailPayload {
+  /** The server-sent reason, or `fallbackReason` when missing/empty/non-string. */
+  reason: string
+  /**
+   * QR-flow alert copy: the friendly message for known reasons, else
+   * `Pairing failed: <reason>`.
+   */
+  alertMessage: string
+}
+
+/**
+ * Parse a `pair_fail` message.
+ *
+ * `fallbackReason` is injected because the two clients historically used
+ * different fallbacks (app: `'pairing_failed'`, dashboard: `'unknown'`) and
+ * the alert copy renders the reason verbatim — changing either fallback would
+ * change user-visible text.
+ *
+ * Non-string and empty-string reasons both resolve to the fallback. (The
+ * app's prior inline guard was `(msg.reason as string) || fallback` — a
+ * truthy check — so this is byte-identical for it; the dashboard's prior
+ * guard passed `''` through, which only affected the cosmetic
+ * `Pairing failed: ` string.)
+ *
+ * Socket teardown, lifecycle-phase flips, and registry cleanup (#5281) are
+ * platform glue and stay at the call sites.
+ */
+export function handlePairFail(
+  msg: Record<string, unknown>,
+  fallbackReason: string,
+): PairFailPayload {
+  const reason =
+    typeof msg.reason === 'string' && msg.reason.length > 0 ? msg.reason : fallbackReason
+  return {
+    reason,
+    alertMessage: PAIR_FAIL_MESSAGES[reason] ?? `Pairing failed: ${reason}`,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_cost_threshold_crossed (#4075)
+// ---------------------------------------------------------------------------
+
+/** Parsed payload from a `session_cost_threshold_crossed` message. */
+export interface SessionCostThresholdCrossedPayload {
+  /**
+   * Explicit sessionId from the message, or null. There is deliberately NO
+   * active-session fallback (matches both prior inline impls): the soft
+   * "you've spent $X" warning fires once per session and must never be
+   * misattributed to whichever session happens to be active.
+   */
+  sessionId: string | null
+  /** Session-state patch that arms the dismissible warning banner. */
+  patch: { costThresholdWarning: { costUsd: number; thresholdUsd: number; dismissedAt: null } }
+}
+
+/**
+ * Parse a `session_cost_threshold_crossed` message into a session patch.
+ *
+ * `costUsd` / `thresholdUsd` fall back to `0` for missing / non-number /
+ * non-finite values — identical to the prior inline guards on both clients.
+ * The caller applies the patch only when the target session exists in its
+ * store (the server doesn't replay this event, so a missed banner stays
+ * missed by design).
+ */
+export function handleSessionCostThresholdCrossed(
+  msg: Record<string, unknown>,
+): SessionCostThresholdCrossedPayload {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const costUsd =
+    typeof msg.costUsd === 'number' && Number.isFinite(msg.costUsd) ? msg.costUsd : 0
+  const thresholdUsd =
+    typeof msg.thresholdUsd === 'number' && Number.isFinite(msg.thresholdUsd)
+      ? msg.thresholdUsd
+      : 0
+  return {
+    sessionId,
+    patch: { costThresholdWarning: { costUsd, thresholdUsd, dismissedAt: null } },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// notification_prefs (#4542 / #4544)
+// ---------------------------------------------------------------------------
+
+/**
+ * Notification-prefs snapshot shape both clients store (mirrors the
+ * `notificationPrefs` state slice that existed verbatim on each side before
+ * this extraction).
+ */
+export interface NotificationPrefsState {
+  categories: Record<string, boolean>
+  devices: Record<
+    string,
+    {
+      categories?: Record<string, boolean>
+      quietHours?: { start: string; end: string; timezone: string } | null
+      bypassCategories?: string[]
+    }
+  >
+  quietHours: { start: string; end: string; timezone: string } | null
+  /**
+   * #4544: optional globally-applied bypass list (categories that fire even
+   * during quiet hours). Omitted entirely when the wire payload lacks it —
+   * clients fall back to the documented defaults (permission +
+   * activity_error).
+   */
+  bypassCategories?: string[]
+}
+
+/** Result of parsing a `notification_prefs` message. */
+export interface NotificationPrefsPayload {
+  /** Validated snapshot ready to store, or null when validation failed. */
+  notificationPrefs: NotificationPrefsState | null
+  /** Zod issues when validation failed, else null (for the call-site warn). */
+  issues: unknown[] | null
+}
+
+/**
+ * Validate and extract a `notification_prefs` snapshot.
+ *
+ * Emitted in response to `notification_prefs_get` and broadcast after every
+ * `notification_prefs_set` so multiple connected clients stay in lockstep.
+ * Validated against `ServerNotificationPrefsSchema` (the wire schema is
+ * permissive — `z.record(string, boolean)` for categories — so adding a
+ * category server-side does not require a client rebuild). On failure the
+ * caller logs `issues` and leaves existing state alone, exactly as both
+ * inline implementations did.
+ */
+export function handleNotificationPrefs(
+  msg: Record<string, unknown>,
+): NotificationPrefsPayload {
+  const parsed = ServerNotificationPrefsSchema.safeParse(msg)
+  if (!parsed.success) {
+    return { notificationPrefs: null, issues: parsed.error.issues }
+  }
+  const prefs = parsed.data.prefs
+  // #4544: wire snapshot carries an optional `bypassCategories`. Older
+  // servers omit it — spread-include only when it's a real array so the
+  // stored object matches the prior inline shape key-for-key.
+  const bypassCategories = (prefs as { bypassCategories?: string[] }).bypassCategories
+  return {
+    notificationPrefs: {
+      categories: prefs.categories,
+      devices: prefs.devices,
+      quietHours: prefs.quietHours,
+      ...(Array.isArray(bypassCategories) ? { bypassCategories } : {}),
+    },
+    issues: null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// permission_request — #554 stream-split resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the #554 "split streaming response at permission boundary" decision
+ * for a `permission_request` message.
+ *
+ * Both clients carried a near line-for-line copy of this block: when a
+ * permission prompt arrives mid-stream, the in-flight assistant message must
+ * be split so the prompt doesn't get visually fused onto it. The pure part —
+ * deciding whether a split applies and reverse-mapping the client-side stream
+ * id back to the server-origin id through the delta-remap table — lives here.
+ *
+ * Returns null when there is nothing to split: no current stream, or the
+ * `'pending'` placeholder id (stream_start not yet processed).
+ *
+ * Side effects stay at the call site, in this order (matching both prior
+ * inline copies): clear the pending delta-flush timer, flush pending deltas,
+ * add `serverStreamId` to the post-permission-splits set, and clear the
+ * target session's `streamingMessageId`.
+ */
+export function resolvePermissionStreamSplit(
+  currentStreamId: string | null,
+  deltaIdRemaps: ReadonlyMap<string, string>,
+): { serverStreamId: string } | null {
+  if (!currentStreamId || currentStreamId === 'pending') return null
+  let serverStreamId = currentStreamId
+  for (const [origId, remappedId] of deltaIdRemaps) {
+    if (remappedId === currentStreamId) {
+      serverStreamId = origId
+      break
+    }
+  }
+  return { serverStreamId }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -383,6 +383,11 @@ export type {
   StreamDeltaContext,
   PendingDelta,
   ResultUsagePayload,
+  // #5454 — remaining both-sides duplicates extracted into store-core
+  PairFailPayload,
+  SessionCostThresholdCrossedPayload,
+  NotificationPrefsState,
+  NotificationPrefsPayload,
 } from './handlers'
 
 export {
@@ -490,6 +495,15 @@ export {
   sharedStreamDelta,
   handleStreamEnd,
   handleResultUsage,
+  // #5454 — remaining both-sides duplicates extracted into store-core
+  handleRawOutput,
+  handleTokenRotated,
+  handlePairFail,
+  PAIR_FAIL_MESSAGES,
+  handleSessionCostThresholdCrossed,
+  handleNotificationPrefs,
+  // #5454 — pure core of the #554 stream-split block (permission_request)
+  resolvePermissionStreamSplit,
 } from './handlers'
 
 // #4591: shared device-list formatters. Eliminates duplicated copies of


### PR DESCRIPTION
Closes #5454. Related to #2661.

Implements both phases of the #2661 close-out residue: the dashboard now routes the remaining duplicated wire types through `@chroxy/store-core`, and the last both-sides duplicates are extracted into shared handlers.

## Per-message adoption

| Type | Before | After |
|---|---|---|
| `permission_resolved` | dashboard inline (~54 lines) | shared `handlePermissionResolved` parse; #5008 mark-read banner draining + flat-messages fallback stay local |
| `session_stopped` | dashboard inline exit-code formatting | shared `handleSessionStopped` parse + session patch; #4878 info toast stays local |
| `checkpoint_restored` | dashboard no-op | shared `handleCheckpointRestored` + auto-switch to the restored session (matches app; see behavior notes) |
| `conversations_list` | dashboard inline | shared `handleConversationsList` |
| `notification_prefs` | duplicated on both sides | **new** `handleNotificationPrefs` in store-core; dashboard adopts (app keeps inline — see notes) |
| `pair_fail` | duplicated on both sides | **new** `handlePairFail` + `PAIR_FAIL_MESSAGES`; both adopt the reason parse, copy stays per-platform |
| `session_cost_threshold_crossed` | duplicated on both sides | **new** `handleSessionCostThresholdCrossed`; both adopt |
| `token_rotated` | duplicated on both sides | **new** `handleTokenRotated`; both adopt the parse, side effects stay local |
| `raw` / `raw_background` | duplicated on both sides | **new** `handleRawOutput`; both adopt |
| `pong` | inline on both sides | intentionally NOT extracted — no payload; only effect is module-level heartbeat bookkeeping |
| `permission_request` | dashboard inline ~99 lines incl. a copy of the #554 stream-split block | shared `handlePermissionRequest` parse + **new** `resolvePermissionStreamSplit` (pure core of the #554 block, now used by both clients) |
| `permission_timeout` | **dashboard had no handler** (gap flagged in the close-out audit) | added via shared `handlePermissionTimeout`: all-sessions prompt scan with flat fallback, #5008 mark-read banner draining, `addServerError` toast with shared wording. New vitest suite `permission-timeout.test.ts` |

## Intentional dashboard divergences preserved (`permission_request` family)

- **#2853 options trimming** — stored options stay `allow`/`deny` only; the dashboard's `PermissionPrompt` hardcodes its own buttons and never reads the array. The app's dynamic options list (incl. the #3072 provider-capability gate for "Allow for Session") is app-only.
- **Flat-state fallbacks** — `get().messages` / top-level `streamingMessageId` fallbacks for sessions not yet in `sessionStates` are kept (the app has no flat fallback).
- **Notification shape** — the dashboard keeps the simpler 4-arg `pushSessionNotification` (no `tool`/`description`/`inputPreview` opts, no `truncateInput`).
- **pair_fail copy** — the dashboard keeps its plain `Pairing failed: <reason>` template; the friendly `PAIR_FAIL_MESSAGES` strings are QR-flow wording ("Scan the latest QR code…") that doesn't fit the paste-a-pairing-URL surface (#5297).

## Behavior deltas (deliberate, called out for review)

- **Dashboard `checkpoint_restored` now auto-switches** to the restored session. The message is sent only to the requesting client (`checkpoint-handlers.js`), so only the operator who clicked Restore switches — previously they were left on the old tab until they clicked the new "Rewind: …" entry manually.
- **Dashboard `permission_request` drops malformed messages** without a string `requestId` (previously inserted an unanswerable prompt and still ran the stream split). Matches the app.
- **Dashboard `session_stopped` now records `stoppedAt`/`stoppedCode`** on the target session (fields already exist in the shared `BaseSessionState`, were initialized but never written on the dashboard) and the exit-code guard tightens to `Number.isInteger` (fractional/NaN codes render the bare message instead of e.g. `(exit 1.5)`).
- Minor parse tightenings via the shared handlers: non-string `sessionId`/`tool`/`decision`/`reason` values now fall back instead of leaking through `as string` casts.

## App side

Byte-identical behavior; full jest suite passes unchanged. The app repoints `pair_fail`, `session_cost_threshold_crossed`, `token_rotated`, `raw`/`raw_background`, and the #554 split block onto the shared handlers. One exception: `notification_prefs` stays inline in the app because the #4542/#4544 source-shape regression tests pin that exact implementation — noted in a comment; relaxing those assertions is a separate change.

## Tests

- store-core vitest: 1208 passed (incl. new suites for all six extracted handlers)
- dashboard vitest: 3289 passed, 167 files (incl. new `permission-timeout.test.ts`)
- app jest: 1634 passed, 116 suites — unchanged
- protocol tests (handler-coverage contract): 257 passed
- `tsc --noEmit` clean in store-core, dashboard, and app