### PR TITLE
fix(desktop): surface server-spawn failures on the loading screen instead of spinning forever

### DIFF
--- a/packages/desktop/dist/loading.js
+++ b/packages/desktop/dist/loading.js
@@ -4,31 +4,110 @@
   var spinner = document.getElementById('spinner');
   var wizard = document.getElementById('wizard');
 
+  var invoke = (window.__TAURI__ && window.__TAURI__.core)
+    ? window.__TAURI__.core.invoke
+    : null;
+
+  // -- Splash failure surfacing (issue #5492) --
+  // The splash used to spin on "Starting server..." forever when the spawned
+  // server child died before health succeeded (e.g. EADDRINUSE because
+  // another chroxy owns the port). Two safety nets:
+  //   1. `server_error` (now also emitted on child exit, Rust side) switches
+  //      to an error state with the buffered server log and a Retry button.
+  //   2. A 30s splash-side timeout: if neither ready nor error has fired,
+  //      reframe as "still starting" and show the log view — without
+  //      touching the (still alive) child.
+  var STARTUP_TIMEOUT_MS = 30000;
+  var LOG_REFRESH_MS = 5000;
+  var startupTimer = null;
+  var logRefreshTimer = null;
+
+  function stopLogRefresh() {
+    if (logRefreshTimer) { clearInterval(logRefreshTimer); logRefreshTimer = null; }
+  }
+
+  function clearStartupTimers() {
+    if (startupTimer) { clearTimeout(startupTimer); startupTimer = null; }
+    stopLogRefresh();
+  }
+
+  function armStartupTimeout() {
+    clearStartupTimers();
+    startupTimer = setTimeout(function() {
+      startupTimer = null;
+      // The child is still alive as far as we know — don't kill anything,
+      // just stop spinning silently: reframe the text and show the buffered
+      // server log so the user can see what's slow. Keep refreshing it.
+      status.textContent = 'Still starting... (taking longer than usual)';
+      status.className = 'status';
+      renderStartupLogs(true);
+      logRefreshTimer = setInterval(renderStartupLogs, LOG_REFRESH_MS);
+    }, STARTUP_TIMEOUT_MS);
+  }
+
+  function removeStartupLogs() {
+    var panel = document.getElementById('startup-logs');
+    if (panel) panel.parentNode.removeChild(panel);
+  }
+
+  function hideRetryButton() {
+    var btn = document.getElementById('retry-btn');
+    if (btn) btn.parentNode.removeChild(btn);
+  }
+
+  function showRetryButton() {
+    if (!invoke || document.getElementById('retry-btn')) return;
+    var btn = document.createElement('button');
+    btn.id = 'retry-btn';
+    btn.textContent = 'Retry';
+    btn.className = 'btn btn-primary';
+    btn.style.cssText = 'margin-top:1rem;';
+    btn.addEventListener('click', function() {
+      hideRetryButton();
+      removeStartupLogs();
+      spinner.style.display = '';
+      status.textContent = 'Starting server...';
+      status.className = 'status';
+      armStartupTimeout();
+      invoke('start_server');
+    });
+    // Directly under the status line, above any logs panel.
+    status.parentNode.insertBefore(btn, status.nextSibling);
+  }
+
   // -- Event listeners for loading view --
   function listenForEvents() {
     if (!window.__TAURI__ || !window.__TAURI__.event) return;
 
     window.__TAURI__.event.listen('server_ready', function(event) {
+      clearStartupTimers();
+      hideRetryButton();
+      removeStartupLogs();
       status.textContent = 'Connected!';
       status.className = 'status';
       window.location.href = event.payload.url;
     });
 
     window.__TAURI__.event.listen('server_error', function(event) {
+      clearStartupTimers();
       spinner.style.display = 'none';
       status.textContent = event.payload.message || 'Server error';
       status.className = 'status error';
-      renderStartupLogs();
+      showRetryButton();
+      renderStartupLogs(true);
     });
 
     window.__TAURI__.event.listen('server_restarting', function(event) {
       var p = event.payload;
+      hideRetryButton();
       status.textContent = 'Restarting... (attempt ' + p.attempt + '/' + p.max_attempts + ')';
       status.className = 'status';
       spinner.style.display = '';
+      armStartupTimeout();
     });
 
     window.__TAURI__.event.listen('server_stopped', function() {
+      clearStartupTimers();
       spinner.style.display = 'none';
       status.textContent = 'Server stopped';
       status.className = 'status';
@@ -38,8 +117,7 @@
   listenForEvents();
 
   // -- Check if first run --
-  if (!window.__TAURI__ || !window.__TAURI__.core) return;
-  var invoke = window.__TAURI__.core.invoke;
+  if (!invoke) return;
 
   // -- Startup log inspection (issue #2835 sub-fix C) --
   // When a startup error fires, fetch the last ~30 server log lines and
@@ -52,7 +130,12 @@
   // to see the latest picture. We preserve the `open` state of the
   // <details> element across refreshes so the user's interaction isn't
   // clobbered when they've already expanded the panel.
-  function renderStartupLogs() {
+  //
+  // `forceOpen` (#5492): error and still-starting states pass true so the
+  // log lines are visible immediately instead of collapsed behind the
+  // summary; periodic refreshes omit it and inherit the user's state.
+  function renderStartupLogs(forceOpen) {
+    if (!invoke) return;
     invoke('get_startup_logs', { limit: 30 }).then(function(lines) {
       if (!lines || lines.length === 0) return;
 
@@ -73,7 +156,7 @@
       var details = document.createElement('details');
       details.id = 'startup-logs';
       details.style.cssText = 'margin-top:1.25rem;text-align:left;font-size:0.75rem;';
-      if (wasOpen) details.setAttribute('open', '');
+      if (wasOpen || forceOpen === true) details.setAttribute('open', '');
 
       var summary = document.createElement('summary');
       summary.textContent = 'Show server logs (' + lines.length + ' lines)';
@@ -113,8 +196,12 @@
       loading.style.display = 'none';
       wizard.classList.add('active');
       runDependencyCheck();
+    } else {
+      // Not first run: a start is normally in flight when this page shows.
+      // Arm the splash timeout so we never spin silently forever (#5492) —
+      // server_ready / server_error / server_stopped all cancel it.
+      armStartupTimeout();
     }
-    // If not first run and server is already running, the event listeners handle navigation
   });
 
   // -- Wizard state --
@@ -230,6 +317,7 @@
       status.textContent = 'Starting server...';
       status.className = 'status';
 
+      armStartupTimeout();
       invoke('start_server');
     });
   });

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1639,6 +1639,19 @@ fn monitor_startup(app: &tauri::AppHandle, context: StartupContext) -> bool {
     for _ in 0..60 {
         std::thread::sleep(std::time::Duration::from_secs(1));
         let state = app.state::<Mutex<ServerManager>>();
+
+        // Child-exit fast path (issue #5492): if the spawned server process
+        // died before health ever succeeded (e.g. EADDRINUSE because another
+        // chroxy owns the port), fail immediately with a classified cause
+        // instead of spinning — a foreign healthy server on the same port
+        // can answer the health poll and mask the death entirely.
+        if let Some(msg) = lock_or_recover(&state).check_startup_child_exit() {
+            update_menu_state(app, MenuState::Stopped);
+            window::emit_server_error(app, &msg);
+            send_notification(app, error_title, &msg);
+            return false;
+        }
+
         let status = lock_or_recover(&state).status();
         match status {
             ServerStatus::Running => {

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -267,6 +267,34 @@ pub(crate) fn build_enriched_path(
     format!("{}{}{}", dirs.join(path_sep), path_sep, base_path)
 }
 
+/// Build the one-line cause shown on the loading page when the spawned
+/// server child exits before the health check ever succeeds (issue #5492).
+///
+/// Pure so it can be unit-tested: scans the buffered log lines for the
+/// Node `EADDRINUSE` marker and renders a port-conflict hint (the canonical
+/// failure is another chroxy already owning the port); otherwise falls back
+/// to a generic exit message carrying the exit code.
+pub(crate) fn classify_startup_exit(
+    log_lines: &[String],
+    port: u16,
+    exit_code: Option<i32>,
+) -> String {
+    if log_lines.iter().any(|l| l.contains("EADDRINUSE")) {
+        return format!(
+            "Port {} is in use — another chroxy server may already be running on port {}. \
+             Quit it or change the app's port, then retry.",
+            port, port
+        );
+    }
+    match exit_code {
+        Some(code) => format!(
+            "Server exited during startup (exit code {}). See logs below.",
+            code
+        ),
+        None => "Server exited during startup (terminated by signal). See logs below.".to_string(),
+    }
+}
+
 /// Current state of the server process.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ServerStatus {
@@ -445,6 +473,51 @@ impl ServerManager {
             1 => 6,
             _ => 12,
         })
+    }
+
+    /// Detect a child that died while we were still `Starting` (issue #5492).
+    ///
+    /// Called by the startup monitor loop in `lib.rs`. When the spawned
+    /// server process exits before the health check ever succeeds (the
+    /// canonical case is `EADDRINUSE` because another chroxy already owns
+    /// the port), the health poll alone can't tell "slow start" from
+    /// "already dead" — worse, a foreign healthy server on the same port
+    /// can answer the poll with 200 and mask the failure entirely, leaving
+    /// the splash on "Starting server..." forever. So we check the child
+    /// handle directly.
+    ///
+    /// Returns `None` when there is no child, the child is still running,
+    /// or status is no longer `Starting` (someone else already resolved
+    /// it). Otherwise: stops the health poll (generation bump) so a foreign
+    /// 200 can't flip us to Running post-mortem, classifies the failure
+    /// from the buffered logs, flips status to `Error`, and returns the
+    /// one-line cause for the UI.
+    pub fn check_startup_child_exit(&mut self) -> Option<String> {
+        if self.status() != ServerStatus::Starting {
+            return None;
+        }
+        let child = self.child.as_mut()?;
+        let exit_status = match child.try_wait() {
+            Ok(Some(st)) => st,
+            Ok(None) | Err(_) => return None,
+        };
+
+        // Stop the health poll: the child is dead, so any 200 from this
+        // port now belongs to a different server.
+        self.health_generation.fetch_add(1, Ordering::SeqCst);
+        self.child = None;
+
+        Self::push_log_line(
+            &self.log_buffer,
+            format!(
+                "[tray] server process exited during startup: {}",
+                exit_status
+            ),
+        );
+        let logs = self.get_logs();
+        let msg = classify_startup_exit(&logs, self.config.port, exit_status.code());
+        *lock_or_recover(&self.status) = ServerStatus::Error(msg.clone());
+        Some(msg)
     }
 
     /// Kill any process listening on the given port (cleanup from previous crash).
@@ -1651,6 +1724,118 @@ mod tests {
         assert!(tail.iter().any(|l| l.starts_with("[stderr]")));
         assert!(tail.iter().any(|l| l.contains("connection refused")));
         assert!(tail.iter().any(|l| l.contains("TIMEOUT after 60s")));
+    }
+
+    // -- classify_startup_exit + check_startup_child_exit (#5492) --
+
+    #[test]
+    fn classify_startup_exit_detects_eaddrinuse() {
+        let logs = vec![
+            "[chroxy] starting server".to_string(),
+            "[stderr] Error: listen EADDRINUSE: address already in use 0.0.0.0:8765".to_string(),
+        ];
+        let msg = classify_startup_exit(&logs, 8765, Some(1));
+        assert!(msg.contains("Port 8765 is in use"), "got: {}", msg);
+        assert!(
+            msg.contains("another chroxy server may already be running on port 8765"),
+            "got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn classify_startup_exit_generic_fallback_includes_exit_code() {
+        let logs = vec!["[stderr] something unrelated blew up".to_string()];
+        let msg = classify_startup_exit(&logs, 8765, Some(7));
+        assert!(msg.contains("exit code 7"), "got: {}", msg);
+        assert!(!msg.contains("EADDRINUSE"), "got: {}", msg);
+    }
+
+    #[test]
+    fn classify_startup_exit_signal_fallback_when_no_exit_code() {
+        let msg = classify_startup_exit(&[], 8765, None);
+        assert!(msg.contains("terminated by signal"), "got: {}", msg);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn check_startup_child_exit_flags_dead_child_and_stops_health_poll() {
+        let mut mgr = ServerManager::new();
+        mgr.config.port = 9911;
+        *lock_or_recover(&mgr.status) = ServerStatus::Starting;
+        ServerManager::push_log_line(
+            &mgr.log_buffer,
+            "[stderr] Error: listen EADDRINUSE: address already in use 0.0.0.0:9911".to_string(),
+        );
+
+        // Spawn a child that exits immediately and reap it so try_wait()
+        // deterministically reports the cached exit status.
+        let mut child = Command::new("sh").args(["-c", "exit 1"]).spawn().unwrap();
+        child.wait().unwrap();
+        mgr.child = Some(child);
+
+        let gen_before = mgr.health_generation.load(Ordering::SeqCst);
+        let msg = mgr
+            .check_startup_child_exit()
+            .expect("dead child during Starting must surface an error");
+
+        assert!(msg.contains("Port 9911 is in use"), "got: {}", msg);
+        assert!(matches!(mgr.status(), ServerStatus::Error(_)));
+        assert!(mgr.child.is_none(), "child handle must be cleared");
+        assert!(
+            mgr.health_generation.load(Ordering::SeqCst) > gen_before,
+            "health poll generation must advance so a foreign 200 can't flip status"
+        );
+        // The exit itself is logged so it shows up in the startup-log panel.
+        assert!(
+            mgr.get_logs()
+                .iter()
+                .any(|l| l.contains("exited during startup")),
+            "logs: {:?}",
+            mgr.get_logs()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn check_startup_child_exit_ignores_live_child() {
+        let mut mgr = ServerManager::new();
+        *lock_or_recover(&mgr.status) = ServerStatus::Starting;
+
+        let child = Command::new("sleep").arg("30").spawn().unwrap();
+        mgr.child = Some(child);
+
+        assert!(mgr.check_startup_child_exit().is_none());
+        assert_eq!(mgr.status(), ServerStatus::Starting);
+        assert!(mgr.child.is_some(), "live child must not be cleared");
+
+        // Cleanup.
+        if let Some(ref mut c) = mgr.child {
+            let _ = c.kill();
+            let _ = c.wait();
+        }
+        mgr.child = None;
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn check_startup_child_exit_noop_when_not_starting() {
+        let mut mgr = ServerManager::new();
+        // Status is Stopped (default) — even a dead child must not flip it.
+        let mut child = Command::new("sh").args(["-c", "exit 1"]).spawn().unwrap();
+        child.wait().unwrap();
+        mgr.child = Some(child);
+
+        assert!(mgr.check_startup_child_exit().is_none());
+        assert_eq!(mgr.status(), ServerStatus::Stopped);
+    }
+
+    #[test]
+    fn check_startup_child_exit_noop_without_child() {
+        let mut mgr = ServerManager::new();
+        *lock_or_recover(&mgr.status) = ServerStatus::Starting;
+        assert!(mgr.check_startup_child_exit().is_none());
+        assert_eq!(mgr.status(), ServerStatus::Starting);
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -475,7 +475,7 @@ impl ServerManager {
         })
     }
 
-    /// Detect a child that died while we were still `Starting` (issue #5492).
+    /// Detect a child that died during the startup window (issue #5492).
     ///
     /// Called by the startup monitor loop in `lib.rs`. When the spawned
     /// server process exits before the health check ever succeeds (the
@@ -486,14 +486,25 @@ impl ServerManager {
     /// the splash on "Starting server..." forever. So we check the child
     /// handle directly.
     ///
+    /// The gate accepts both `Starting` and `Running`: a foreign 200 can
+    /// land before the child even finishes crashing (a healthy server
+    /// answers in milliseconds, Node needs ~0.5s to die on `EADDRINUSE`),
+    /// flipping status to `Running` pre-mortem — the dead child must still
+    /// be surfaced before `monitor_startup` reports success. A child found
+    /// dead while `Running` inside the startup window is a startup failure,
+    /// not a crash for the phase-2 auto-restart loop.
+    ///
     /// Returns `None` when there is no child, the child is still running,
-    /// or status is no longer `Starting` (someone else already resolved
-    /// it). Otherwise: stops the health poll (generation bump) so a foreign
-    /// 200 can't flip us to Running post-mortem, classifies the failure
-    /// from the buffered logs, flips status to `Error`, and returns the
-    /// one-line cause for the UI.
+    /// or status was already resolved to a terminal state (`Error`,
+    /// `Stopped`). Otherwise: stops the health poll (generation bump) so a
+    /// foreign 200 can't flip us to Running post-mortem, classifies the
+    /// failure from the buffered logs, flips status to `Error`, and returns
+    /// the one-line cause for the UI.
     pub fn check_startup_child_exit(&mut self) -> Option<String> {
-        if self.status() != ServerStatus::Starting {
+        if !matches!(
+            self.status(),
+            ServerStatus::Starting | ServerStatus::Running
+        ) {
             return None;
         }
         let child = self.child.as_mut()?;
@@ -1167,7 +1178,16 @@ impl ServerManager {
                         eprintln!("{}", msg);
                         Self::push_log_line(&log_buf, msg);
                         if code == 200 {
-                            *lock_or_recover(&status) = ServerStatus::Running;
+                            // Re-check the generation under the status lock
+                            // (#5495): this request may have been in flight
+                            // when the child-exit path (or kill_child) bumped
+                            // the generation and resolved status — a late 200
+                            // must not overwrite Error/Stopped post-mortem.
+                            let mut s = lock_or_recover(&status);
+                            if generation.load(Ordering::SeqCst) != my_gen {
+                                return;
+                            }
+                            *s = ServerStatus::Running;
                             break;
                         } else {
                             non200 += 1;
@@ -1205,7 +1225,14 @@ impl ServerManager {
                 match ureq::get(&url).timeout(Duration::from_secs(2)).call() {
                     Ok(resp) => {
                         if resp.status() == 200 {
-                            *lock_or_recover(&status) = ServerStatus::Running;
+                            // Same in-flight guard as the startup loop: a
+                            // 200 that raced a generation bump must not
+                            // resurrect a resolved status (#5495).
+                            let mut s = lock_or_recover(&status);
+                            if generation.load(Ordering::SeqCst) != my_gen {
+                                return;
+                            }
+                            *s = ServerStatus::Running;
                         }
                     }
                     Err(err) => {
@@ -1828,6 +1855,28 @@ mod tests {
 
         assert!(mgr.check_startup_child_exit().is_none());
         assert_eq!(mgr.status(), ServerStatus::Stopped);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn check_startup_child_exit_flags_dead_child_when_running() {
+        // A foreign 200 can flip status to Running before the child finishes
+        // dying (pre-mortem masking) — the dead child must still be surfaced
+        // while the startup monitor is watching.
+        let mut mgr = ServerManager::new();
+        mgr.config.port = 9912;
+        *lock_or_recover(&mgr.status) = ServerStatus::Running;
+
+        let mut child = Command::new("sh").args(["-c", "exit 1"]).spawn().unwrap();
+        child.wait().unwrap();
+        mgr.child = Some(child);
+
+        let msg = mgr
+            .check_startup_child_exit()
+            .expect("dead child during Running must surface an error");
+        assert!(msg.contains("exit code 1"), "got: {}", msg);
+        assert!(matches!(mgr.status(), ServerStatus::Error(_)));
+        assert!(mgr.child.is_none(), "child handle must be cleared");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Chroxy.app spun on "Starting server…" forever when its spawned server child died before the health check succeeded — canonically `EADDRINUSE` because another chroxy (e.g. the launchd daemon) already owns the port. The health poll can't distinguish a slow start from a dead child, and a foreign healthy server answering on the same port masks the death entirely. This implements expectation 2 from the issue (error surfacing); the adopt-existing-server flow is intentionally not touched.

Closes #5492.
Related to #5281 (adopt-existing-server is that epic's territory and stays out of scope here).

## Changes

**Rust (`server.rs`, `lib.rs`)**
- `ServerManager::check_startup_child_exit()` — `try_wait()`s the child while status is `Starting`; on exit it bumps the health-poll generation (so a foreign 200 can't flip status to `Running` post-mortem), logs the exit, classifies the failure from the buffered log ring, and flips status to `Error`.
- `classify_startup_exit()` — pure, unit-tested: `EADDRINUSE` anywhere in the buffer renders "Port N is in use — another chroxy server may already be running on port N. Quit it or change the app's port, then retry."; otherwise a generic exit-code/signal message.
- `monitor_startup()` checks the child every tick (1s) and emits the existing `server_error` event with the classified cause — no new events or commands needed; the splash already had `get_startup_logs`.

**Loading page (`dist/loading.js`, dependency-free, existing style)**
- `server_error` now also renders a **Retry** button (re-invokes the existing `start_server` command) and opens the buffered-log panel (last ~30 lines) by default instead of leaving it collapsed.
- **30s splash timeout**: if neither `server_ready` nor `server_error` has fired, the splash reframes to "Still starting… (taking longer than usual)" and shows the same log view with a 5s refresh — the child is left alone. `server_ready`/`server_error`/`server_stopped` cancel the timers; `server_restarting` re-arms them; the wizard's Start button and Retry arm them too.

## Testing

- `cargo test --locked` in `packages/desktop/src-tauri`: 203 tests pass, including 7 new ones (3 × `classify_startup_exit_*`, 4 × `check_startup_child_exit_*` covering dead child + health-poll cutoff, live child no-op, non-Starting no-op, no-child no-op).
- `node --check` on `loading.js` (no JS test infra exists for the splash; logic kept small and DOM-driven).
- Touched Rust files are `cargo fmt`-clean; clippy reports no new warnings (remaining ones are pre-existing).
- No .app build/signing performed.

## Review follow-up (2438d98f7)

- `check_startup_child_exit()` gate widened to `Starting | Running` so a foreign 200 that lands pre-mortem can't mask the dead child.
- Health-poll thread re-checks the generation under the status lock before writing `Running` (startup and monitoring loops), closing the in-flight-200 race.
- `cargo test`: 204 tests pass (one new: `check_startup_child_exit_flags_dead_child_when_running`).

Closes #5495
