### PR TITLE
fix(server): aggregate subagent counts per project for the Discord embed

### DIFF
--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -365,13 +365,27 @@ export function handleEventIngest(server, req, res) {
       // Discord embed's `data.subagents` field and the notification text can
       // use it. Lazily constructed like the rate limiters; tests can pre-seed
       // `_subagentCounter` for clock injection.
+      //
+      // #5463: the surfaced count is the PER-PROJECT total, not the event's
+      // own session count. The embed is keyed per project, and several
+      // sessions emit into one project (main session + worktree agents
+      // remapped to the parent by the hooks' GAP B filter) — stamping each
+      // event with its own session's count made the embed flip between
+      // unrelated numbers, and a zero from session B falsely fired session
+      // A's armed count→0 ready re-ping. `project` here is the post-remap
+      // name (explicit envelope project wins over cwd derivation), i.e. the
+      // same key _projectKey uses for the embed. Events without a project
+      // fall back to the per-session count — the embed key falls back to
+      // the sessionId in that case too, so the scopes still match.
       if (!server._subagentCounter) {
         server._subagentCounter = new SubagentCounter()
       }
-      const counted = server._subagentCounter.record(event.type, event.source, event.sessionId)
-      const activeSubagents = counted !== null
-        ? counted
-        : server._subagentCounter.getCount(event.source, event.sessionId)
+      const counted = server._subagentCounter.record(event.type, event.source, event.sessionId, project)
+      const activeSubagents = project
+        ? server._subagentCounter.getProjectTotal(project)
+        : (counted !== null
+          ? counted
+          : server._subagentCounter.getCount(event.source, event.sessionId))
 
       const title = typeof data.title === 'string' && data.title.length > 0 ? data.title : mapping.title
       let notifyBody = typeof data.message === 'string' && data.message.length > 0 ? data.message : mapping.body

--- a/packages/server/src/subagent-counter.js
+++ b/packages/server/src/subagent-counter.js
@@ -19,6 +19,17 @@
  *     even though the route is bearer-gated and rate-limited)
  *
  * Events without a sessionId are not counted — there is nothing to key on.
+ *
+ * Project dimension (#5463): the Discord status embed is keyed per PROJECT,
+ * and several sessions can emit into one project (main session + worktree
+ * agents remapped to the parent by the hooks' GAP B filter). Each entry
+ * therefore remembers the project its events carried, and
+ * `getProjectTotal(project)` sums the live entries of that project — the
+ * per-session entries stay the single source of truth (they carry the
+ * TTL/LRU lifecycle), so session_end and TTL/LRU eviction subtract a
+ * session's contribution automatically; there is no maintained per-project
+ * counter to drift. The total deliberately spans sources: the embed's
+ * project key has no source dimension either.
  */
 
 /** Default time-to-live for an untouched entry. */
@@ -35,7 +46,7 @@ export class SubagentCounter {
     this._ttlMs = ttlMs
     this._maxEntries = maxEntries
     this._now = now
-    /** @type {Map<string, { count: number, touchedAt: number }>} */
+    /** @type {Map<string, { count: number, touchedAt: number, project: string|null }>} */
     this._entries = new Map()
     this._lastSweepAt = 0
   }
@@ -68,8 +79,13 @@ export class SubagentCounter {
    * Fold one ingested event into the counter. Returns the active count for
    * the event's (source, sessionId) after the update, or null when the
    * event doesn't participate (no sessionId, or an uncounted type).
+   *
+   * `project` (#5463) is the post-remap project the event was attributed to
+   * (the same key the Discord embed uses) — stored on the entry so
+   * getProjectTotal can aggregate across the sessions of one project.
+   * Latest event wins if a session's project ever changes.
    */
-  record(type, source, sessionId) {
+  record(type, source, sessionId, project = null) {
     if (typeof sessionId !== 'string' || sessionId.length === 0) return null
     this._sweep()
     const key = this._key(source, sessionId)
@@ -84,7 +100,9 @@ export class SubagentCounter {
     this._entries.delete(key)
     if (count > 0 || type === 'subagent_stop') {
       this._evictIfFull()
-      this._entries.set(key, { count, touchedAt: this._now() })
+      const normalizedProject =
+        typeof project === 'string' && project.length > 0 ? project : (prev?.project ?? null)
+      this._entries.set(key, { count, touchedAt: this._now(), project: normalizedProject })
     }
     return count
   }
@@ -100,6 +118,28 @@ export class SubagentCounter {
       return 0
     }
     return entry.count
+  }
+
+  /**
+   * Per-project active-subagent total (#5463): the sum over all LIVE
+   * session entries attributed to `project`, across sources (the embed's
+   * project key has no source dimension). Computed lazily at read time —
+   * expired entries are dropped as they're encountered, so TTL expiry (and
+   * session_end / LRU eviction, which delete entries outright) subtracts a
+   * session's contribution with no maintained counter to drift.
+   */
+  getProjectTotal(project) {
+    if (typeof project !== 'string' || project.length === 0) return 0
+    const now = this._now()
+    let total = 0
+    for (const [key, entry] of this._entries) {
+      if (now - entry.touchedAt > this._ttlMs) {
+        this._entries.delete(key)
+        continue
+      }
+      if (entry.project === project) total += entry.count
+    }
+    return total
   }
 
   /** Number of tracked entries (tests + observability). */

--- a/packages/server/tests/event-ingest-subagents.test.js
+++ b/packages/server/tests/event-ingest-subagents.test.js
@@ -10,6 +10,14 @@
 //   - sessions are isolated; events without a sessionId are not counted
 //     and carry no `subagents` key
 //
+// #5463 — per-project aggregation: events that carry a project are stamped
+// with the PROJECT total (sum over that project's live sessions), so a
+// second session emitting into the same project (worktree agents remapped
+// by GAP B) can't overwrite the embed's count with its own unrelated number
+// — and, concretely, a zero from session B can't fire session A's armed
+// idle count→0 ready re-ping. Pinned both at the ingest level (stamped
+// data.subagents) and end-to-end through a real DiscordWebhookSink.
+//
 // Uses handleEventIngest directly with a mock server object (same pattern
 // as event-ingest.test.js). No SessionManager, no real state paths.
 
@@ -17,8 +25,12 @@ import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { handleEventIngest } from '../src/event-ingest.js'
 import { SubagentCounter } from '../src/subagent-counter.js'
+import { DiscordWebhookSink } from '../src/notifications/discord-webhook-sink.js'
 
 const SECRET = 'subagent-test-secret'
 const VALID_TS = 1_750_000_000_000
@@ -132,5 +144,186 @@ describe('event ingest subagent counting', () => {
     await post({ ...base, type: 'subagent_start' })
     assert.ok(mockServer._subagentCounter instanceof SubagentCounter)
     assert.equal(mockServer._subagentCounter.getCount('claude-hooks', 'sess-1'), 1)
+  })
+
+  // -- #5463: per-project aggregation --------------------------------------
+
+  const inProj = (sessionId, event) => ({ source: 'claude-hooks', project: 'proj1', sessionId, ts: VALID_TS, ...event })
+
+  it('stamps the project total, not the emitting session\'s own count', async () => {
+    await post(inProj('sess-A', { type: 'subagent_start' }))
+    await post(inProj('sess-A', { type: 'subagent_start' }))
+    // Session B (e.g. a worktree agent remapped to the parent project)
+    // reports activity with ZERO subagents of its own — pre-#5463 this
+    // stamped subagents: 0 and fired A's armed count→0 ready re-ping.
+    await post(inProj('sess-B', { type: 'post_tool_use' }))
+    assert.equal(lastCall().data.subagents, 2, 'B\'s event carries the project total')
+    assert.equal(lastCall().body, 'Tool use completed — 2 subagents active')
+  })
+
+  it('subagent events from a second session add to the project total', async () => {
+    await post(inProj('sess-A', { type: 'subagent_start' }))
+    await post(inProj('sess-B', { type: 'subagent_start' }))
+    assert.equal(lastCall().data.subagents, 2)
+    assert.equal(lastCall().body, 'A subagent is running (2 active)')
+  })
+
+  it('session_end subtracts only the ending session\'s contribution', async () => {
+    await post(inProj('sess-A', { type: 'subagent_start' }))
+    await post(inProj('sess-A', { type: 'subagent_start' }))
+    await post(inProj('sess-B', { type: 'subagent_start' }))
+    await post(inProj('sess-B', { type: 'session_end' }))
+    assert.equal(lastCall().data.subagents, 2, 'A\'s contribution survives B\'s end')
+    await post(inProj('sess-A', { type: 'session_end' }))
+    assert.equal(lastCall().data.subagents, 0)
+  })
+
+  it('projects are isolated from each other', async () => {
+    await post(inProj('sess-A', { type: 'subagent_start' }))
+    await post({ source: 'claude-hooks', project: 'proj2', sessionId: 'sess-C', type: 'post_tool_use', ts: VALID_TS })
+    assert.equal(lastCall().data.subagents, 0)
+  })
+
+  it('events without a project fall back to the per-session count', async () => {
+    await post(inProj('sess-A', { type: 'subagent_start' }))
+    await post(inProj('sess-B', { type: 'subagent_start' }))
+    await post({ source: 'claude-hooks', sessionId: 'sess-A', type: 'notification', ts: VALID_TS })
+    assert.equal(lastCall().data.subagents, 1, 'no project → the session\'s own count')
+  })
+})
+
+// #5463 end-to-end: two sessions in one project, driven through POST
+// /api/events into a REAL DiscordWebhookSink (mocked fetch). Session A is
+// idle-armed with 2 running subagents; session B's activity must NOT fire
+// the count→0 ready re-ping — only A's own last subagent_stop may.
+describe('event ingest → Discord sink: cross-session re-ping (#5463)', () => {
+  const SECRET2 = 'subagent-e2e-secret'
+  const WEBHOOK = 'https://discord.com/api/webhooks/123456789012345678/aBcDeFgHiJkLmNoPqRsTuVwXyZ-0123456789_abcdefghijklmnopqrstuvwx'
+  let httpServer
+  let url
+  let mockServer
+  let sink
+  let statePath
+  let deliveries
+  let fetchCalls
+  let originalFetch
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch
+    fetchCalls = []
+    let autoId = 0
+    globalThis.fetch = async (fetchUrl, options = {}) => {
+      fetchCalls.push({ url: String(fetchUrl), method: options.method || 'GET', body: options.body })
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ id: `m${++autoId}` }),
+      }
+    }
+    statePath = join(mkdtempSync(join(tmpdir(), 'ingest-discord-e2e-')), 'state.json')
+    sink = new DiscordWebhookSink({
+      statePath,
+      resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+      sleepImpl: async () => {},
+      heartbeatIntervalMs: 0,
+      updateThrottleMs: 0,
+    })
+    deliveries = []
+    mockServer = {
+      _ingestSecret: SECRET2,
+      _subagentCounter: new SubagentCounter(),
+      pushManager: {
+        hasConfiguredSinks: () => true,
+        send: (category, title, body, data) => {
+          const p = sink.send({ category, title, body, data })
+          deliveries.push(p)
+          return p
+        },
+      },
+    }
+    httpServer = createServer((req, res) => handleEventIngest(mockServer, req, res))
+    httpServer.listen(0, '127.0.0.1')
+    await once(httpServer, 'listening')
+    url = `http://127.0.0.1:${httpServer.address().port}/api/events`
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    sink.destroy?.()
+    httpServer.close()
+  })
+
+  // post() must hit the local HTTP server with the REAL fetch — the mocked
+  // global is reserved for the sink's Discord calls.
+  async function post(event) {
+    const res = await originalFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${SECRET2}` },
+      body: JSON.stringify(event),
+    })
+    assert.equal(res.status, 200)
+    // The ingest dispatch is fire-and-forget; settle sink delivery before
+    // asserting on the Discord calls.
+    await Promise.all(deliveries)
+  }
+
+  const ev = (sessionId, type, data = {}) => ({
+    source: 'claude-hooks', project: 'proj1', sessionId, ts: VALID_TS, type,
+    ...(Object.keys(data).length > 0 ? { data } : {}),
+  })
+
+  function readState() {
+    return JSON.parse(readFileSync(statePath, 'utf-8')).projects.proj1
+  }
+
+  it('B\'s zero-count activity does not fire A\'s armed ready re-ping; A\'s last stop does', async () => {
+    // Session A online, spins up 2 subagents, then goes idle (armed embed).
+    await post(ev('sess-A', 'session_start'))
+    await post(ev('sess-A', 'subagent_start'))
+    await post(ev('sess-A', 'subagent_start'))
+    await post(ev('sess-A', 'notification', { notificationType: 'idle_prompt' }))
+    assert.equal(readState().state, 'idle')
+    assert.equal(readState().subagents, 2)
+    const armedMessageId = readState().messageId
+
+    // Session B (worktree agent remapped into proj1 by GAP B) reports tool
+    // activity. Its own count is 0 — pre-#5463 the stamped 0 looked like
+    // "all subagents done" and re-pinged Ready for input.
+    fetchCalls.length = 0
+    await post(ev('sess-B', 'post_tool_use'))
+    assert.ok(!fetchCalls.some((c) => c.method === 'DELETE'), 'no re-ping repost (DELETE+POST)')
+    assert.deepEqual(fetchCalls.map((c) => c.method), ['PATCH'], 'count refresh PATCHes in place')
+    assert.equal(readState().state, 'idle', 'embed stays armed')
+    assert.equal(readState().subagents, 2, 'A\'s running subagents still shown')
+    assert.equal(readState().messageId, armedMessageId, 'same message — nobody was pinged')
+
+    // A's first subagent finishes → still one running → no re-ping.
+    fetchCalls.length = 0
+    await post(ev('sess-A', 'subagent_stop'))
+    assert.deepEqual(fetchCalls.map((c) => c.method), ['PATCH'])
+    assert.equal(readState().subagents, 1)
+
+    // A's LAST subagent finishes → project total hits 0 → ready re-ping.
+    fetchCalls.length = 0
+    await post(ev('sess-A', 'subagent_stop'))
+    assert.deepEqual(fetchCalls.map((c) => c.method), ['DELETE', 'POST'], 'count→0 re-pings')
+    assert.equal(readState().state, 'idle')
+    assert.equal(readState().subagents, 0)
+  })
+
+  it('B ending its session does not zero A\'s armed count', async () => {
+    await post(ev('sess-A', 'session_start'))
+    await post(ev('sess-A', 'subagent_start'))
+    await post(ev('sess-B', 'subagent_start'))
+    await post(ev('sess-A', 'notification', { notificationType: 'idle_prompt' }))
+    assert.equal(readState().subagents, 2)
+
+    // B's subagent finishes and B's session ends — A's subagent still runs.
+    fetchCalls.length = 0
+    await post(ev('sess-B', 'subagent_stop'))
+    assert.ok(!fetchCalls.some((c) => c.method === 'DELETE'), 'total is 1, not 0 — no re-ping')
+    assert.equal(readState().state, 'idle')
+    assert.equal(readState().subagents, 1)
   })
 })

--- a/packages/server/tests/subagent-counter.test.js
+++ b/packages/server/tests/subagent-counter.test.js
@@ -8,6 +8,12 @@
 //   - stale entries expire after the TTL (lazy sweep, injected clock)
 //   - hard cap: oldest-touched entries evicted first, size stays bounded
 //   - events without a sessionId are not counted
+//
+// #5463 — per-project aggregation (the Discord embed is keyed per project,
+// not per session):
+//   - getProjectTotal sums the live sessions of one project, across sources
+//   - session_end and TTL expiry subtract that session's contribution
+//   - entries without a project never leak into any project total
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
@@ -114,5 +120,81 @@ describe('SubagentCounter', () => {
   it('defaults are sane', () => {
     assert.ok(SUBAGENT_ENTRY_TTL_MS >= 60 * 60 * 1000)
     assert.ok(SUBAGENT_MAX_ENTRIES >= 100)
+  })
+})
+
+describe('SubagentCounter — per-project totals (#5463)', () => {
+  it('sums live sessions of one project and isolates other projects', () => {
+    const counter = new SubagentCounter()
+    counter.record('subagent_start', 'claude-hooks', 'a', 'proj1')
+    counter.record('subagent_start', 'claude-hooks', 'a', 'proj1')
+    counter.record('subagent_start', 'claude-hooks', 'b', 'proj1')
+    counter.record('subagent_start', 'claude-hooks', 'c', 'proj2')
+    assert.equal(counter.getProjectTotal('proj1'), 3)
+    assert.equal(counter.getProjectTotal('proj2'), 1)
+    assert.equal(counter.getProjectTotal('proj3'), 0)
+  })
+
+  it('spans sources — the embed project key has no source dimension', () => {
+    const counter = new SubagentCounter()
+    counter.record('subagent_start', 'claude-hooks', 's1', 'proj1')
+    counter.record('subagent_start', 'other-tool', 's1', 'proj1')
+    assert.equal(counter.getProjectTotal('proj1'), 2)
+  })
+
+  it('session_end subtracts only that session\'s contribution', () => {
+    const counter = new SubagentCounter()
+    counter.record('subagent_start', 'claude-hooks', 'a', 'proj1')
+    counter.record('subagent_start', 'claude-hooks', 'a', 'proj1')
+    counter.record('subagent_start', 'claude-hooks', 'b', 'proj1')
+    counter.record('session_end', 'claude-hooks', 'a', 'proj1')
+    assert.equal(counter.getProjectTotal('proj1'), 1)
+    counter.record('session_end', 'claude-hooks', 'b', 'proj1')
+    assert.equal(counter.getProjectTotal('proj1'), 0)
+  })
+
+  it('TTL expiry subtracts an abandoned session\'s contribution', () => {
+    const clock = makeClock()
+    const counter = new SubagentCounter({ now: clock.now })
+    counter.record('subagent_start', 'claude-hooks', 'abandoned', 'proj1')
+    clock.advance(SUBAGENT_ENTRY_TTL_MS - 1000)
+    counter.record('subagent_start', 'claude-hooks', 'live', 'proj1')
+    assert.equal(counter.getProjectTotal('proj1'), 2)
+    clock.advance(2000) // 'abandoned' is past the TTL, 'live' is not
+    assert.equal(counter.getProjectTotal('proj1'), 1)
+    assert.equal(counter.size, 1, 'expired entry dropped during the scan')
+  })
+
+  it('LRU eviction subtracts the evicted session\'s contribution', () => {
+    const counter = new SubagentCounter({ maxEntries: 2 })
+    counter.record('subagent_start', 'src', 'a', 'proj1')
+    counter.record('subagent_start', 'src', 'b', 'proj1')
+    counter.record('subagent_start', 'src', 'c', 'proj1') // evicts a
+    assert.equal(counter.getProjectTotal('proj1'), 2)
+  })
+
+  it('entries without a project never leak into a project total', () => {
+    const counter = new SubagentCounter()
+    counter.record('subagent_start', 'claude-hooks', 'no-project')
+    counter.record('subagent_start', 'claude-hooks', 'with-project', 'proj1')
+    assert.equal(counter.getProjectTotal('proj1'), 1)
+    assert.equal(counter.getProjectTotal(''), 0)
+    assert.equal(counter.getProjectTotal(null), 0)
+    assert.equal(counter.getProjectTotal(undefined), 0)
+  })
+
+  it('a later event without a project keeps the entry\'s known project', () => {
+    const counter = new SubagentCounter()
+    counter.record('subagent_start', 'claude-hooks', 's1', 'proj1')
+    counter.record('subagent_start', 'claude-hooks', 's1') // e.g. missing cwd
+    assert.equal(counter.getProjectTotal('proj1'), 2)
+  })
+
+  it('per-session reads are unchanged by the project dimension', () => {
+    const counter = new SubagentCounter()
+    counter.record('subagent_start', 'claude-hooks', 'a', 'proj1')
+    counter.record('subagent_start', 'claude-hooks', 'b', 'proj1')
+    assert.equal(counter.getCount('claude-hooks', 'a'), 1)
+    assert.equal(counter.getCount('claude-hooks', 'b'), 1)
   })
 })


### PR DESCRIPTION
## Problem

`SubagentCounter` aggregates per `(source, sessionId)`, but the Discord status embed is keyed per **project**. With multiple sessions emitting into one project (the main session plus worktree agents remapped to the parent project by the hooks' GAP B filter), every ingested event stamped `data.subagents` with its **own** session's count, so the per-project embed flipped between unrelated numbers.

Concrete failure: session A sits idle-armed with 2 running subagents (idle embed, count 2). Session B — a worktree agent attributed to the same project — emits a `session_activity` event. B's own count is 0, so the event carried `subagents: 0`, which the sink's GAP C logic read as "all subagents done" and fired the count-to-0 🦀 ready re-ping while A's subagents were still running. The bash original (claude-code-notify) aggregated per project and didn't have this failure mode.

## Fix

- **`subagent-counter.js`** — entries now remember the (post-remap) project their events carried; new `getProjectTotal(project)` sums the live entries of that project at read time, across sources (the embed's project key has no source dimension either). The per-session entries remain the single source of truth — they carry the TTL/LRU lifecycle — so `session_end`, TTL expiry, and LRU eviction subtract a session's contribution automatically, with no maintained per-project counter to drift.
- **`event-ingest.js`** — threads the derived project (explicit envelope `project` wins over cwd derivation, i.e. the same key the sink's `_projectKey` uses) into `record()`, and stamps `data.subagents` with the **project total** when a project is known. Events without a project keep the per-session fallback — the embed key falls back to the sessionId there too, so the scopes still match.

No sink changes needed: given a correct `data.subagents`, the existing GAP C arming/re-ping logic behaves correctly.

## Acceptance criteria

1. ✅ `data.subagents` on ingested events now carries the per-project active-subagent aggregate (sum over that project's live sessions).
2. ✅ `session_end` and TTL expiry (and LRU eviction) subtract that session's contribution — totals are computed lazily over live entries, so eviction handles itself.
3. ✅ Test: two sessions in one project — B's zero-count activity does NOT fire A's armed re-ping, pinned both at the ingest level and end-to-end through a real `DiscordWebhookSink` (B's activity PATCHes the armed idle embed in place; A's own last `subagent_stop` still re-pings).

## Tests

- `subagent-counter.test.js` — per-project totals: multi-session sums, project/source isolation, `session_end`/TTL/LRU subtraction, no-project entries never leak, per-session reads unchanged.
- `event-ingest-subagents.test.js` — project-total stamping through `POST /api/events`, plus the end-to-end ingest → Discord sink cross-session re-ping pins.
- Full run of `subagent-counter`, `event-ingest-subagents`, `event-ingest`, `discord-webhook-sink` test files: **142 pass, 0 fail**. Custom shell lints + eslint green.

Closes #5463.