### PR TITLE
chore(release): cut v0.9.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.45] - 2026-06-10
+
+The notifications release. Epic #5413 lands in full: chroxy now maintains a live per-project **Discord status embed** for any Claude Code session on the machine — not just chroxy-managed ones — via the new `@chroxy/claude-hooks` package (stateless hook emitters + idempotent installer), a `POST /api/events` ingest endpoint with its own daemon-level token class, and server-side subagent counting. Alongside it: a deep **claude-tui reliability wave** (~30 fixes off the failure-readiness audit, from crash containment to PTY redaction to restart-resume), **provider expansion** (local Ollama models with auto-discovery, plus any Anthropic-compatible endpoint via config), and the desktop app finally **surfaces server-startup failures** on the loading screen instead of spinning forever.
+
+### Added
+
+- **Notifications epic #5413 — Discord status embed + external-session ingest (complete):**
+  - **`NotificationSink` registry (#5425):** notification delivery extracted behind a sink interface; Expo push becomes `ExpoPushSink`.
+  - **`DiscordWebhookSink` (#5427):** per-project status embed ported from `claude-code-notify` — ready/approval states delete + re-post (so Discord pings), routine updates edit in place; shared pipeline preferences, quiet hours, and rate limits apply. See `docs/guides/discord-notifications.md`.
+  - **`POST /api/events` ingest (#5432):** external session events enter the notification pipeline, authenticated by a generated daemon-level **ingest secret** (`~/.chroxy/ingest-secret`, 0600) — a fourth token class alongside primary/pairing/hook-secret.
+  - **`@chroxy/claude-hooks` (#5447):** six stateless hook emitters (<100ms, silent-fail) plus a `chroxy-hooks install|uninstall|emit` CLI that idempotently registers them in Claude Code settings; server-side per-`(source, sessionId)` subagent counting (2h TTL, LRU-bounded).
+  - **Parity gaps closed before cutover (#5465):** idle prompts map to activity updates, worktree/tmp/home cwds don't mint their own project embeds, an idle-armed embed re-pings when the last subagent finishes, and a hand-deleted embed message is re-posted instead of 404-looping offline.
+  - **`~/.chroxy/worktrees` remap (#5481):** sessions in chroxy's own session worktrees attribute to the parent project (recovered from the worktree `.git` gitdir), like `.claude/worktrees` agents already did.
+  - **Ready-for-input notifications carry the background-task snapshot (#5436, #5452):** "ready" pushes enumerate still-running agents/shells so you know whether ready means *done*.
+  - **Embed-state hygiene (#5456):** stale per-project webhook-state entries are pruned (24h default) and the footer-refresh heartbeat is bounded to live projects.
+  - **Client preference surfaces:** `session_online` / `session_offline` / `session_activity` categories in mobile notification prefs (#5443) and labeled in the dashboard prefs panel (#5477).
+- **Providers:**
+  - **Ollama (#5418):** local models via Ollama's Anthropic-compatible API, with installed-model discovery through `GET /api/tags` (#5445).
+  - **Config-driven Anthropic-compatible endpoints (#5458):** point a provider at any Anthropic-compatible server (LM Studio ≥0.4.1, llama.cpp, vLLM, OpenRouter, …) via `providers.anthropicCompatible` config — BYOK seams, per-endpoint model validation, inline secrets rejected.
+- **Security & operations:**
+  - **Exposure warnings (#5459):** startup log + dashboard banner when the daemon binds non-loopback or a public quick tunnel comes up.
+  - **Subscription auth-failure detection (#5355):** a dead subscription surfaces immediately instead of a 90-second silent hang.
+  - **Configurable background-shell hard-quiesce window (#5303)** and a **periodic worktree auto-reaper (#5363)** (no longer boot-only).
+- **Desktop:**
+  - **Startup failures are visible (#5494):** a dead server child (e.g. `EADDRINUSE` port conflict) turns the loading screen into a classified error + last server log lines + Retry button, with a 30s "still starting" fallback; startup health-poll races closed so a foreign server answering on the port can't mask the dead child (#5495).
+  - **Editable summon hotkey (#5301)** with live re-registration.
+  - **Windows MSI is Authenticode-signed** via Azure Trusted Signing (#5299).
+
+### Fixed
+
+- **claude-tui reliability wave** (from the failure-readiness audit, `docs/audit/`, #5306):
+  - **Restart durability:** conversations persist and `--resume` across daemon restart (#5339); session state flushes on every supervised shutdown/crash path (#5340) with per-pid temp files (#5341); worktree bindings rebind after restart (#5342); retry-FRESH fallback when every `--resume` respawn dies in warmup (#5415), with PTY-tail failure classification gating eligibility (#5449).
+  - **Crash containment:** daemon survives PTY socket faults (#5343), route handler throws (#5344), fire-and-forget rejections and listener/broadcast throws (#5345); supervisor crash safety + cloudflared boot-leak (#5346); bounded per-session PTY auto-respawn (#5347) under a rolling-window rate cap shared by both providers (#5411).
+  - **Lifecycle:** `start()` rejects on PTY spawn failure and restore preserves history (#5350); `destroy()` escalates to SIGKILL so no orphan `claude`/tool children outlive the session (#5351); SIGHUP routes through graceful shutdown (#5406); watchdog timing moved to a monotonic clock (#5414).
+  - **AskUserQuestion:** silence backstops suspend while a human is answering (#5352); per-`toolUseId` stall watchdogs (#5353); recovery arms on every respond path (#5354).
+  - **Redaction:** credentials scrubbed from PTY hex/tail diagnostics (#5357); ANSI-split tokens + JWTs caught in PTY dumps (#5412); ANSI stripped from the concatenated tail, not per-chunk (#5362).
+  - **Hooks/permissions:** hook sink recovers if it vanishes mid-turn (#5410); hook-sink files bounded + stale dirs boot-swept (#5359); permission hook fails closed when it can't reach the user (#5409); atomic permission-mode sidecar writes (#5407); checkpoint-restore failures preserve pending changes and orphan refs are pruned (#5408).
+  - **Streams/observability:** error listeners on subprocess stdout/stderr (#5360, #5397); swallowed observability errors surfaced (#5366); WebTaskManager poll completes healthy tasks and unrefs its timer (#5364).
+- **Server:** oversize request bodies get their 413 before teardown (#5442); unknown `contextWindow` no longer assumed to be 200k (#5444); dashboard auth path caches the credentials.json read (#5484); supervisor-sent notifications honor `notifications.discord` config (#5451).
+- **App:** `chroxy://` QR pairing infers ws/wss by port so LAN pairing connects (#5302).
+- **CI/tests:** Windows ACL tests pinned against runner-image default drift (#5478); GAP B cwd-filter tests hermetic to the OS temp dir (#5470); all Maestro flows migrated to the dev client (#5395, #5466); coverage for provider-models refresh scheduling (#5482), respawn exhaustion, Rancher config validation, and permission-guard branches (#5384–#5387, #5391).
+
+### Changed
+
+- **`startCliServer` decomposed** into `PushNotificationHandler`, `StartupDisplay`, `TunnelLifecycleHandler`, and `ServerOrchestrator` (#5400–#5403), with shared emergency-cleanup helpers (#5393) and a shared sleep-with-abort/backoff helper (#5405).
+- **`BaseSession` opt forwarding** now goes through the `buildBaseSessionOpts` picker, single-sourced from `BASE_SESSION_OPT_KEYS`, with the CI lint inverted to catch drift (#5398); `SkillsManager` + `BackgroundShellTracker` extracted (#5399); `_intentionalStop` hoisted (#5392); setter guards centralized (#5394); session-scoped logger selection centralized (#5390).
+- **Permission resolution single-sourced** across WS and hook transports (#5404); JSON responses centralized in `ws-permissions` handlers (#5389).
+- **Dashboard adopts shared store-core handlers** for the remaining duplicated message types (#5487).
+- **Docs:** Unattended Merge Authority codified for autonomous sessions (#5485); provider docs cover the BYOK family, DeepSeek, and Ollama in the capability matrix (#5440, #5476); claude-tui failure-readiness audit published (#5306).
+
 ## [0.9.44] - 2026-06-07
 
 Big-feature consolidation plus a fleet-management push: the docker-byok / Task-subagent arc lands its final round of follow-ups, two cloud backends arrive (config-driven K8s/Rancher with per-tenant namespace isolation + resource quotas), the dashboard becomes a multi-host LAN client (epic #5281) able to join shared sessions on remote daemons, Control Room graduates to v2 with a navigable host/repo status section + self-hosted-runner page, a `cancel_activity` request/response chain lets the operator stop in-flight agents/subagents from the Control Room tree, and credentials.json is now encrypted at rest behind an OS-keychain data key (with a rotation path) on keychain-capable hosts — falling back to the prior 0600 plaintext store where no keychain is available. Rounded out by worktree-gc safety hardening, background-shell reap fixes, and the dashboard Provider Credentials pane.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,19 +13,22 @@ Essential development notes for working with Claude on Chroxy.
 ```
 chroxy/
 ├── packages/
-│   ├── server/      # Node.js daemon + CLI + web dashboard (ES modules, no TypeScript)
-│   ├── app/         # React Native mobile app (TypeScript, Expo 54)
-│   ├── desktop/     # Tauri tray app (Rust + web dashboard)
-│   ├── protocol/    # Shared protocol types and Zod schemas (@chroxy/protocol)
-│   └── store-core/  # Shared store logic and crypto (@chroxy/store-core)
+│   ├── server/       # Node.js daemon + CLI (ES modules, no TypeScript)
+│   ├── app/          # React Native mobile app (TypeScript, Expo 54)
+│   ├── desktop/      # Tauri tray app (Rust, wraps the dashboard)
+│   ├── dashboard/    # Web dashboard (React + Vite, served by the server)
+│   ├── protocol/     # Shared protocol types and Zod schemas (@chroxy/protocol)
+│   ├── store-core/   # Shared store logic and crypto (@chroxy/store-core)
+│   └── claude-hooks/ # Hook emitters for external Claude Code sessions (@chroxy/claude-hooks)
 ├── docs/            # Setup guides, architecture
 └── scripts/         # Install helpers
 ```
 
-**Current Status (v0.6.0):**
-- Server works: CLI headless mode, WebSocket protocol, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications, session management, model switching, plan mode detection, background agent tracking, web dashboard, container environments (Docker Compose, DevContainer, snapshots), container/worktree isolation, permission rule engine, extensible provider/handler system
-- Desktop works: Tauri tray app, web dashboard with syntax highlighting, xterm.js terminal, notifications, session tabs, voice-to-text (macOS), console page, environment management panel
+**Current Status (v0.9.45):**
+- Server works: CLI headless mode, multi-provider registry (Claude SDK/CLI/TUI, BYOK, Gemini, Codex, DeepSeek, Ollama, config-driven Anthropic-compatible endpoints), WebSocket protocol, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications + Discord status-embed sink, external-session event ingest (`POST /api/events` + ingest secret), session management, model switching, plan mode detection, background agent tracking, container environments (Docker Compose, DevContainer, snapshots), container/worktree isolation, K8s/Rancher backends, permission rule engine, encrypted credentials at rest (OS keychain), extensible provider/handler system
+- Desktop works: Tauri tray app, multi-host LAN client (server picker, mDNS discovery, shared-session join), web dashboard with syntax highlighting, xterm.js terminal, Control Room, notifications, session tabs, voice-to-text (macOS), console page, environment management panel, startup-failure surfacing with retry
 - App works: QR code scanning, connection flow with health checks and retries, ConnectionPhase state machine for resilient reconnection, markdown rendering, dual-view chat/terminal, xterm.js terminal emulation (WebView), plan approval UI, agent monitoring, settings screen, voice-to-text input, session rules UI, worktree toggle
+- Claude-hooks works: `chroxy-hooks install` registers six stateless emitters in Claude Code settings so plain (non-chroxy) sessions feed the daemon's notification pipeline — see `docs/guides/discord-notifications.md`
 - **Dev build required** — `expo-speech-recognition` native module means Expo Go no longer works. Use `npx expo run:ios` or `npx expo run:android`.
 
 ## Critical Dev Notes
@@ -360,5 +363,5 @@ For detailed component tables, WebSocket protocol messages, file listings, and s
 
 ---
 
-*Last Updated: 2026-03-18*
-*Version: 0.6.0*
+*Last Updated: 2026-06-10*
+*Version: 0.9.45*

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Run a lightweight daemon on your dev machine, connect from your phone or desktop
 - **Phone + Desktop** — React Native mobile app and a Tauri desktop tray app with a web dashboard.
 - **Encrypted** — End-to-end encryption over Cloudflare tunnel. Your machine, your tunnel, no cloud middleman.
 - **Resilient** — Auto-reconnect on network drops, supervisor auto-restart on crash, push notifications for permission prompts.
+- **Discord notifications** — A live status embed per project that pings when a session is ready for input or needs approval — even for plain Claude Code sessions outside chroxy, via the `chroxy-hooks` installer. See [docs/guides/discord-notifications.md](docs/guides/discord-notifications.md).
 - **Voice input** — Dictate messages with speech-to-text on mobile and macOS desktop.
 - **Docker isolation** — Run sessions in Docker containers with resource limits and security guards.
 - **Open source** — MIT licensed. Audit it, fork it, improve it.
@@ -63,7 +64,7 @@ Chroxy includes cost controls to help you stay within budget — see `CHROXY_COS
 ## Features
 
 **Server:**
-CLI headless mode, multi-provider support (Claude Agent SDK, legacy `claude -p`, Gemini, Codex — see [docs/providers.md](docs/providers.md)), WebSocket protocol with auth, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications, multi-session management, model switching, plan mode detection, background agent tracking, web dashboard, persistent container environments (Docker Compose, DevContainer, snapshot/restore), Docker session providers, git worktree isolation, permission rule engine, extensible provider/handler system, shared skills system (drop Markdown files in `~/.chroxy/skills/` — see [docs/skills.md](docs/skills.md))
+CLI headless mode, multi-provider support (Claude Agent SDK, legacy `claude -p`, Gemini, Codex, Ollama, any Anthropic-compatible endpoint — see [docs/providers.md](docs/providers.md)), WebSocket protocol with auth, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications, Discord status-embed notifications (see [docs/guides/discord-notifications.md](docs/guides/discord-notifications.md)), external-session event ingest via `@chroxy/claude-hooks`, multi-session management, model switching, plan mode detection, background agent tracking, web dashboard, persistent container environments (Docker Compose, DevContainer, snapshot/restore), Docker session providers, git worktree isolation, permission rule engine, encrypted credentials at rest, extensible provider/handler system, shared skills system (drop Markdown files in `~/.chroxy/skills/` — see [docs/skills.md](docs/skills.md))
 
 **Desktop (Tauri):**
 System tray app, web dashboard with syntax highlighting (15+ languages), xterm.js terminal, session tabs, desktop notifications, voice-to-text (macOS SFSpeechRecognizer), command palette with keyboard shortcuts

--- a/docs/guides/discord-notifications.md
+++ b/docs/guides/discord-notifications.md
@@ -70,6 +70,16 @@ layer of defence.
 That's it. The sink is off by default and switches on the moment a webhook
 URL resolves — restart the daemon after adding it.
 
+> **Known limitation (#5493):** on keychain-capable hosts where BYOK keys have
+> been stored, `~/.chroxy/credentials.json` is an **encrypted envelope** — the
+> plain `discordWebhookUrl` field shown above can't coexist with it, so the
+> env var is the only working source on such hosts. That covers shell-started
+> daemons and wrapper-based launchd services, but a server spawned by the
+> desktop app gets no shell env and silently runs without the sink. Until the
+> keychain fallback lands (#5493), bridge it for GUI launches with
+> `launchctl setenv CHROXY_DISCORD_WEBHOOK_URL <url>` (macOS; resets at
+> logout) before opening the app.
+
 ### 3. (Optional) Colors and tuning
 
 The non-secret knobs live in `~/.chroxy/config.json` under

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16876,7 +16876,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16929,7 +16929,7 @@
     },
     "packages/claude-hooks": {
       "name": "@chroxy/claude-hooks",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "license": "MIT",
       "bin": {
         "chroxy-hooks": "bin/chroxy-hooks.js"
@@ -16943,7 +16943,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17053,11 +17053,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.44"
+      "version": "0.9.45"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17068,7 +17068,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17130,7 +17130,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.44",
+    "version": "0.9.45",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.44</string>
+    <string>0.9.45</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/claude-hooks",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "description": "Stateless Claude Code hook emitters for chroxy's POST /api/events ingest",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.44"
+version = "0.9.45"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.44"
+version = "0.9.45"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## v0.9.45 — the notifications release

92 commits since v0.9.44. Headlines:

- **Epic #5413 complete:** live per-project Discord status embed (`DiscordWebhookSink`), `POST /api/events` ingest with a dedicated ingest-secret token class, the new `@chroxy/claude-hooks` package (six stateless emitters + idempotent `chroxy-hooks` installer) so plain Claude Code sessions feed the pipeline, server-side subagent counting, and the full claude-code-notify parity-gap closure (#5465, #5481).
- **claude-tui reliability wave:** ~30 fixes off the failure-readiness audit (#5306) — restart persistence/resume, crash containment, bounded respawn, AskUserQuestion watchdogs, PTY redaction hardening.
- **Provider expansion:** Ollama with model auto-discovery (#5418, #5445); any Anthropic-compatible endpoint via `providers.anthropicCompatible` config (#5458).
- **Desktop:** server-startup failures surfaced on the loading screen with cause + logs + Retry (#5494/#5495); editable summon hotkey (#5301); Authenticode-signed Windows MSI (#5299).

## In this PR

- `scripts/bump-version.sh 0.9.45` across all package files
- CHANGELOG.md section for 0.9.45
- CLAUDE.md status block refreshed (was stale at v0.6.0 / 2026-03-18): package tree gains `dashboard/` + `claude-hooks/`, status lines catch up to the last three months
- README: Discord-notifications bullet + server feature list (Ollama, Anthropic-compatible endpoints, event ingest, encrypted credentials)
- discord-notifications guide: known-limitation note for #5493 (encrypted credentials envelope vs plain `discordWebhookUrl`; GUI-spawned servers need the env bridge until the keychain fallback lands)

On squash-merge, `auto-tag-on-release.yml` pushes `v0.9.45` and dispatches `release.yml`.