### PR TITLE
feat(control-room): repo-relay observability — workflow presence, version drift, run status

### DIFF
--- a/packages/dashboard/src/components/IntegrationsSection.test.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.test.tsx
@@ -16,7 +16,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
-import type { IntegrationRepo, RepoMemoryStatus, ServerIntegrationStatusSnapshotMessage } from '@chroxy/protocol'
+import type { IntegrationRepo, RepoMemoryStatus, RepoRelayStatus, ServerIntegrationStatusSnapshotMessage } from '@chroxy/protocol'
 
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: unknown) => unknown) =>
@@ -322,5 +322,155 @@ describe('formatBytes', () => {
     expect(formatBytes(421888)).toBe('412 KB')
     expect(formatBytes(2314240)).toBe('2.2 MB')
     expect(formatBytes(-1)).toBe('—')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5501 — repo-relay columns.
+// ---------------------------------------------------------------------------
+
+function repoRelay(over: Partial<RepoRelayStatus> = {}): RepoRelayStatus {
+  return {
+    installed: true,
+    pinnedVersion: 'v1.1.0',
+    pinnedSha: null,
+    latestVersion: 'v1.1.0',
+    runs: [
+      { databaseId: 9001, status: 'completed', conclusion: 'success', event: 'pull_request', createdAt: '2026-06-10T11:00:00.000Z' },
+      { databaseId: 9000, status: 'completed', conclusion: 'success', event: 'issues', createdAt: '2026-06-10T10:00:00.000Z' },
+    ],
+    failureStreak: 0,
+    verdict: 'ok',
+    driftUnknown: false,
+    workflowUrl: 'https://github.com/blamechris/chroxy/actions/workflows/repo-relay.yml',
+    reason: null,
+    ...over,
+  }
+}
+
+const RELAY_NOT_INSTALLED: RepoRelayStatus = {
+  installed: false,
+  pinnedVersion: null,
+  pinnedSha: null,
+  latestVersion: null,
+  runs: [],
+  failureStreak: 0,
+  verdict: 'not_installed',
+  driftUnknown: false,
+  workflowUrl: null,
+  reason: null,
+}
+
+function relayRepo(name: string, relay: RepoRelayStatus | undefined): IntegrationRepo {
+  return { name, path: `/p/${name}`, repoMemory: NOT_CONFIGURED, ...(relay !== undefined ? { repoRelay: relay } : {}) }
+}
+
+describe('IntegrationsSection — repo-relay (#5501)', () => {
+  it('renders the grouped repo-memory / repo-relay column headers', () => {
+    renderSection(snapshot())
+    expect(screen.getByTestId('integration-group-memory').textContent).toBe('repo-memory')
+    expect(screen.getByTestId('integration-group-relay').textContent).toBe('repo-relay')
+  })
+
+  it('renders the verdict chips with their accents', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('green', repoRelay()),
+      relayRepo('red', repoRelay({ verdict: 'failing', failureStreak: 2 })),
+      relayRepo('stale', repoRelay({ verdict: 'drifted', pinnedVersion: 'v1.0.0' })),
+      relayRepo('bare', RELAY_NOT_INSTALLED),
+    ]))
+    expect(screen.getByTestId('integration-relay-status-green').textContent).toBe('OK')
+    expect(screen.getByTestId('integration-relay-status-green').getAttribute('data-accent')).toBe('ok')
+    expect(screen.getByTestId('integration-relay-status-red').getAttribute('data-accent')).toBe('bad')
+    expect(screen.getByTestId('integration-relay-status-stale').getAttribute('data-accent')).toBe('warn')
+    expect(screen.getByTestId('integration-relay-status-bare').textContent).toBe('Not installed')
+    expect(screen.getByTestId('integration-relay-status-bare').getAttribute('data-accent')).toBe('neutral')
+  })
+
+  it('an unknown verdict carries its degradation reason as tooltip', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('island', repoRelay({ verdict: 'unknown', runs: [], reason: 'no GitHub remote' })),
+    ]))
+    expect(screen.getByTestId('integration-relay-status-island').getAttribute('title')).toContain('no GitHub remote')
+  })
+
+  it('version cell shows pinned → latest with a drift highlight when behind', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('stale', repoRelay({ verdict: 'drifted', pinnedVersion: 'v1.0.0', latestVersion: 'v1.1.0' })),
+    ]))
+    const cell = screen.getByTestId('integration-relay-version-stale')
+    expect(cell.textContent).toContain('v1.0.0 → v1.1.0')
+    expect(cell.querySelector('.cr-warn')).toBeTruthy()
+  })
+
+  it('an up-to-date pin renders without the drift highlight', () => {
+    renderSection(oneRepoSnapshot([relayRepo('green', repoRelay())]))
+    const cell = screen.getByTestId('integration-relay-version-green')
+    expect(cell.textContent).toContain('v1.1.0')
+    expect(cell.querySelector('.cr-warn')).toBeNull()
+  })
+
+  it('a bare sha pin renders the short sha with a drift-unknown tooltip', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('sha', repoRelay({
+        pinnedVersion: null,
+        pinnedSha: 'f08840b9c336b50f6aef8d6e157d8f7e705fa875',
+        driftUnknown: true,
+        verdict: 'ok',
+      })),
+    ]))
+    const cell = screen.getByTestId('integration-relay-version-sha')
+    expect(cell.textContent).toContain('f08840b')
+    expect(cell.getAttribute('title')?.toLowerCase()).toContain('drift')
+  })
+
+  it('last-run cell shows the conclusion, age, and the Actions deep link', () => {
+    renderSection(oneRepoSnapshot([relayRepo('green', repoRelay())]))
+    const cell = screen.getByTestId('integration-relay-lastrun-green')
+    expect(cell.textContent).toContain('success')
+    expect(cell.textContent).toContain('1h ago')
+    const link = screen.getByTestId('integration-relay-link-green') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://github.com/blamechris/chroxy/actions/workflows/repo-relay.yml')
+  })
+
+  it('streak cell shows the failure streak with the bad accent, "—" when clean', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('red', repoRelay({ verdict: 'failing', failureStreak: 3 })),
+      relayRepo('green', repoRelay()),
+    ]))
+    const streak = screen.getByTestId('integration-relay-streak-red')
+    expect(streak.textContent).toContain('3')
+    expect(streak.querySelector('.cr-bad')).toBeTruthy()
+    expect(screen.getByTestId('integration-relay-streak-green').textContent).toBe('—')
+  })
+
+  it('a snapshot without repoRelay blocks (pre-#5501 producer) renders quiet relay cells', () => {
+    renderSection(oneRepoSnapshot([relayRepo('legacy', undefined)]))
+    expect(screen.getByTestId('integration-relay-status-legacy').textContent).toBe('Not installed')
+    expect(screen.getByTestId('integration-relay-version-legacy').textContent).toBe('—')
+    expect(screen.getByTestId('integration-relay-lastrun-legacy').textContent).toBe('—')
+    expect(screen.getByTestId('integration-relay-streak-legacy').textContent).toBe('—')
+  })
+
+  it('renders the relay summary chips (defaulting to 0 for pre-#5501 summaries)', () => {
+    renderSection(snapshot({
+      summary: { total: 3, configured: 1, notConfigured: 2, degraded: 0, relayInstalled: 2, relayFailing: 1, relayDrifted: 1 },
+    }))
+    expect(screen.getByTestId('integration-chip-count-relayInstalled').textContent).toBe('2')
+    expect(screen.getByTestId('integration-chip-count-relayFailing').textContent).toBe('1')
+    expect(screen.getByTestId('integration-chip-count-relayDrifted').textContent).toBe('1')
+    cleanup()
+    renderSection(snapshot()) // summary without the relay keys
+    expect(screen.getByTestId('integration-chip-count-relayFailing').textContent).toBe('0')
+  })
+
+  it('renders the gh-missing callout when the snapshot says gh was not found', () => {
+    renderSection(snapshot({ ghCli: { found: false, path: null, note: 'gh CLI not found on PATH' } }))
+    expect(screen.getByTestId('integration-gh-note').textContent).toContain('gh CLI not found on PATH')
+  })
+
+  it('renders no gh callout when gh was found', () => {
+    renderSection(snapshot({ ghCli: { found: true, path: '/usr/local/bin/gh', note: null } }))
+    expect(screen.queryByTestId('integration-gh-note')).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/IntegrationsSection.test.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.test.tsx
@@ -410,7 +410,7 @@ describe('IntegrationsSection — repo-relay (#5501)', () => {
     expect(cell.querySelector('.cr-warn')).toBeNull()
   })
 
-  it('a bare sha pin renders the short sha with a drift-unknown tooltip', () => {
+  it('a bare sha pin renders the short sha with a drift-unknown tooltip and the latest for context', () => {
     renderSection(oneRepoSnapshot([
       relayRepo('sha', repoRelay({
         pinnedVersion: null,
@@ -421,7 +421,33 @@ describe('IntegrationsSection — repo-relay (#5501)', () => {
     ]))
     const cell = screen.getByTestId('integration-relay-version-sha')
     expect(cell.textContent).toContain('f08840b')
+    expect(cell.textContent).toContain('→ v1.1.0')
     expect(cell.getAttribute('title')?.toLowerCase()).toContain('drift')
+  })
+
+  it('a drift-unknown row prefers the per-repo reason as the tooltip (branch pin, unparseable uses line)', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('branchy', repoRelay({
+        pinnedVersion: null,
+        pinnedSha: null,
+        driftUnknown: true,
+        verdict: 'ok',
+        reason: 'could not parse the repo-relay uses pin from the workflow',
+      })),
+    ]))
+    const cell = screen.getByTestId('integration-relay-version-branchy')
+    expect(cell.getAttribute('title')).toContain('could not parse the repo-relay uses pin')
+  })
+
+  it('an equal-but-differently-formatted pin (no drift) renders without the → latest arrow', () => {
+    // Server-side compareVersions treats v1.1 == v1.1.0 → verdict ok, no
+    // driftUnknown. The cell must not suggest an upgrade is available.
+    renderSection(oneRepoSnapshot([
+      relayRepo('formatted', repoRelay({ pinnedVersion: 'v1.1', latestVersion: 'v1.1.0', verdict: 'ok' })),
+    ]))
+    const cell = screen.getByTestId('integration-relay-version-formatted')
+    expect(cell.textContent).toBe('v1.1')
+    expect(cell.textContent).not.toContain('→')
   })
 
   it('last-run cell shows the conclusion, age, and the Actions deep link', () => {

--- a/packages/dashboard/src/components/IntegrationsSection.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.tsx
@@ -3,13 +3,20 @@
  *
  * Renders the per-repo integration survey the server returns in an
  * `integration_status_snapshot`: an eyebrow + title + subtitle, a row of
- * summary chips (repos / configured / not configured / degraded), an optional
- * missing-CLI callout, and a table with one row per surveyed repo showing its
- * repo-memory status — configured (summarizer + tool groups), cache presence
- * + size, hit ratio, tokens saved, stale entries, and last activity. A repo
- * without `.repo-memory.json` renders a quiet "not configured" row — absence
- * is signal, not an error. A sibling repo-relay column block lands in the
- * follow-up issue (#5498 sub-issues).
+ * summary chips (repos / configured / not configured / degraded / relay
+ * tallies), optional missing-CLI callouts, and a table with one row per
+ * surveyed repo. The columns are grouped under two headers:
+ *
+ *   - repo-memory (#5499): configured (summarizer + tool groups), cache
+ *     presence + size, hit ratio, tokens saved, stale entries, last activity,
+ *     and the #5500 Reindex action. A repo without `.repo-memory.json`
+ *     renders a quiet "not configured" row — absence is signal, not an error.
+ *   - repo-relay (#5501): verdict chip (ok / failing / drifted / not
+ *     installed / unknown), version pin vs latest release (drift
+ *     highlighted; a bare sha pin renders the short sha with a drift-unknown
+ *     tooltip), last run conclusion + age with the Actions deep link, and the
+ *     failure streak. Degraded cells carry the per-repo `reason` as tooltip;
+ *     a repo without the workflow file is a quiet "Not installed" row.
  *
  * #5500 adds the control half: a per-row Reindex button for configured repos
  * that dispatches `integration_action` (repo_memory_reindex) via the store's
@@ -33,7 +40,7 @@
  *   - not configured               → neutral (dim)    — quiet, not an error.
  */
 import { useConnectionStore } from '../store/connection'
-import type { IntegrationRepo, RepoMemoryStatus, ServerIntegrationStatusSnapshotMessage } from '@chroxy/protocol'
+import type { IntegrationRepo, RepoMemoryStatus, RepoRelayStatus, RepoRelayVerdict, ServerIntegrationStatusSnapshotMessage } from '@chroxy/protocol'
 import type { ReindexResult } from '../store/types'
 import { formatGeneratedAgo } from './ControlRoomSection'
 
@@ -46,12 +53,16 @@ interface SummaryChip {
 }
 
 // Chip order mirrors the summary row: total first (neutral), then the healthy
-// bucket, then the ones the operator scans for.
+// bucket, then the ones the operator scans for. The #5501 relay tallies are
+// optional on pre-relay summaries — counts default to 0.
 const SUMMARY_CHIPS: readonly SummaryChip[] = [
   { key: 'total', label: 'Repos', accent: 'neutral' },
   { key: 'configured', label: 'Configured', accent: 'ok' },
   { key: 'notConfigured', label: 'Not configured', accent: 'neutral' },
   { key: 'degraded', label: 'Degraded', accent: 'warn' },
+  { key: 'relayInstalled', label: 'Relay installed', accent: 'neutral' },
+  { key: 'relayFailing', label: 'Relay failing', accent: 'bad' },
+  { key: 'relayDrifted', label: 'Relay drifted', accent: 'warn' },
 ]
 
 /** ISO date (no time) for the eyebrow, e.g. "2026-06-10". */
@@ -133,6 +144,131 @@ function HitRatioCell({ repo }: { repo: IntegrationRepo }) {
     <td data-testid={`integration-ratio-${repo.name}`}>
       <span className="cr-ok">{(report.cacheHitRatio * 100).toFixed(1)}%</span>
       <span className="cr-dim cr-mono"> ({report.cacheHits}/{lookups})</span>
+    </td>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// #5501 — repo-relay cells.
+// ---------------------------------------------------------------------------
+
+/** Verdict → tag label + accent (mirrors the runner tab's chip style). */
+const RELAY_VERDICT_META: Record<RepoRelayVerdict, { label: string; accent: Accent | 'neutral' }> = {
+  ok: { label: 'OK', accent: 'ok' },
+  failing: { label: 'Failing', accent: 'bad' },
+  drifted: { label: 'Drifted', accent: 'warn' },
+  not_installed: { label: 'Not installed', accent: 'neutral' },
+  unknown: { label: 'Unknown', accent: 'neutral' },
+}
+
+/**
+ * A missing `repoRelay` block (pre-#5501 producer) renders the same quiet
+ * cells as a not-installed one — the table never breaks on an old snapshot.
+ */
+function relayOf(repo: IntegrationRepo): RepoRelayStatus | null {
+  return repo.repoRelay ?? null
+}
+
+function RelayStatusTag({ repo }: { repo: IntegrationRepo }) {
+  const relay = relayOf(repo)
+  const { label, accent } = RELAY_VERDICT_META[relay?.verdict ?? 'not_installed']
+  return (
+    <span
+      className={`cr-tag${accent === 'neutral' ? '' : ` cr-tag-${accent}`}`}
+      data-testid={`integration-relay-status-${repo.name}`}
+      data-accent={accent}
+      title={relay?.reason ?? undefined}
+    >
+      {label}
+    </span>
+  )
+}
+
+/**
+ * Version cell: `pinned → latest` with a drift highlight when the verdict is
+ * drifted; a bare sha pin renders the short sha with a drift-unknown tooltip;
+ * a single side renders alone; nothing known renders "—".
+ */
+function RelayVersionCell({ repo }: { repo: IntegrationRepo }) {
+  const relay = relayOf(repo)
+  if (!relay || !relay.installed) {
+    return <td className="cr-dim" data-testid={`integration-relay-version-${repo.name}`}>—</td>
+  }
+  const pinnedLabel = relay.pinnedVersion
+    ?? (relay.pinnedSha ? relay.pinnedSha.slice(0, 7) : null)
+  const drifted = relay.verdict === 'drifted'
+  const title = relay.driftUnknown
+    ? 'pin does not resolve to a version (no # vX.Y.Z comment) — drift unknown'
+    : undefined
+  if (!pinnedLabel && !relay.latestVersion) {
+    return <td className="cr-dim" data-testid={`integration-relay-version-${repo.name}`} title={title}>—</td>
+  }
+  return (
+    <td className="cr-mono" data-testid={`integration-relay-version-${repo.name}`} title={title}>
+      <span className={drifted ? 'cr-warn' : undefined}>{pinnedLabel ?? '—'}</span>
+      {relay.latestVersion && pinnedLabel !== relay.latestVersion && (
+        <span className="cr-dim"> → {relay.latestVersion}</span>
+      )}
+    </td>
+  )
+}
+
+/** Last-run cell: latest run's conclusion/status + age, with the Actions deep link. */
+function RelayLastRunCell({ repo, now }: { repo: IntegrationRepo; now: number }) {
+  const relay = relayOf(repo)
+  const latest = relay?.runs[0] ?? null
+  if (!relay || !relay.installed || !latest) {
+    return (
+      <td className="cr-dim" data-testid={`integration-relay-lastrun-${repo.name}`} title={relay?.reason ?? undefined}>
+        {relay?.workflowUrl ? (
+          <a
+            href={relay.workflowUrl}
+            target="_blank"
+            rel="noreferrer"
+            data-testid={`integration-relay-link-${repo.name}`}
+            title="Open the workflow in the GitHub Actions UI"
+          >
+            —
+          </a>
+        ) : (
+          '—'
+        )}
+      </td>
+    )
+  }
+  const state = latest.conclusion ?? latest.status ?? 'unknown'
+  const stateClass = latest.conclusion === 'success' ? 'cr-ok' : latest.conclusion === 'failure' ? 'cr-bad' : 'cr-dim'
+  return (
+    <td data-testid={`integration-relay-lastrun-${repo.name}`} title={relay.reason ?? undefined}>
+      <span className={stateClass}>{state}</span>
+      <span className="cr-dim"> · {formatAgo(latest.createdAt, now)}</span>
+      {relay.workflowUrl && (
+        <>
+          {' '}
+          <a
+            href={relay.workflowUrl}
+            target="_blank"
+            rel="noreferrer"
+            data-testid={`integration-relay-link-${repo.name}`}
+            title="Open the workflow in the GitHub Actions UI"
+          >
+            ↗
+          </a>
+        </>
+      )}
+    </td>
+  )
+}
+
+/** Failure-streak cell: consecutive failed runs, "—" when clean/unknown. */
+function RelayStreakCell({ repo }: { repo: IntegrationRepo }) {
+  const relay = relayOf(repo)
+  if (!relay || !relay.installed || relay.failureStreak === 0) {
+    return <td className="cr-dim" data-testid={`integration-relay-streak-${repo.name}`}>—</td>
+  }
+  return (
+    <td data-testid={`integration-relay-streak-${repo.name}`}>
+      <span className="cr-bad">{relay.failureStreak}×</span>
     </td>
   )
 }
@@ -248,6 +384,10 @@ function IntegrationRow({
         connected={connected}
         onReindex={onReindex}
       />
+      <td><RelayStatusTag repo={repo} /></td>
+      <RelayVersionCell repo={repo} />
+      <RelayLastRunCell repo={repo} now={now} />
+      <RelayStreakCell repo={repo} />
     </tr>
   )
 }
@@ -328,8 +468,9 @@ export function IntegrationsSection({
         </div>
         {snapshot && (
           <p className="cr-sub" data-testid="integration-sub">
-            repo-memory status across {snapshot.repos.length} repo{snapshot.repos.length === 1 ? '' : 's'} under{' '}
-            <span className="cr-mono">{snapshot.root}</span> — config, cache, and telemetry from the read-only CLI report.
+            repo-memory and repo-relay status across {snapshot.repos.length} repo{snapshot.repos.length === 1 ? '' : 's'} under{' '}
+            <span className="cr-mono">{snapshot.root}</span> — config, cache, and telemetry from the read-only CLI
+            report; workflow presence, version drift, and run health from the filesystem + gh.
           </p>
         )}
         {snapshot && !Number.isNaN(generatedAtMs) && (
@@ -370,7 +511,7 @@ export function IntegrationsSection({
             {SUMMARY_CHIPS.map((chip) => (
               <span className="cr-chip" key={chip.key} data-testid={`integration-chip-${chip.key}`}>
                 {chip.accent !== 'neutral' && <span className={`cr-dot cr-dot-${chip.accent}`} aria-hidden="true" />}
-                {chip.label}: <b data-testid={`integration-chip-count-${chip.key}`}>{snapshot.summary[chip.key]}</b>
+                {chip.label}: <b data-testid={`integration-chip-count-${chip.key}`}>{snapshot.summary[chip.key] ?? 0}</b>
               </span>
             ))}
           </div>
@@ -388,12 +529,26 @@ export function IntegrationsSection({
             </div>
           )}
 
+          {snapshot.ghCli && !snapshot.ghCli.found && (
+            <div className="cr-callout" data-testid="integration-gh-note">
+              <b>gh CLI unavailable:</b> {snapshot.ghCli.note ?? 'binary not found'} — relay install and version-pin
+              columns still populate from the filesystem; the run and release columns are degraded for every repo.
+            </div>
+          )}
+
           <section className="cr-table-wrap">
             <table className="cr-table" data-testid="integration-table">
               <thead>
+                {/* #5501: two-row header — the repo-memory and repo-relay
+                    column families are grouped so the wide table stays
+                    legible. */}
                 <tr>
-                  <th>Repo</th>
-                  <th>repo-memory</th>
+                  <th rowSpan={2}>Repo</th>
+                  <th colSpan={8} className="cr-th-group" data-testid="integration-group-memory">repo-memory</th>
+                  <th colSpan={4} className="cr-th-group" data-testid="integration-group-relay">repo-relay</th>
+                </tr>
+                <tr>
+                  <th>Status</th>
                   <th>Summarizer / tools</th>
                   <th>Cache</th>
                   <th>Hit ratio</th>
@@ -401,12 +556,16 @@ export function IntegrationsSection({
                   <th>Entries</th>
                   <th>Last activity</th>
                   <th>Actions</th>
+                  <th>Status</th>
+                  <th>Version</th>
+                  <th>Last run</th>
+                  <th>Streak</th>
                 </tr>
               </thead>
               <tbody>
                 {snapshot.repos.length === 0 ? (
                   <tr data-testid="integration-no-repos">
-                    <td colSpan={9} className="cr-dim">
+                    <td colSpan={13} className="cr-dim">
                       No repos found under {snapshot.root}.
                     </td>
                   </tr>

--- a/packages/dashboard/src/components/IntegrationsSection.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.tsx
@@ -197,16 +197,29 @@ function RelayVersionCell({ repo }: { repo: IntegrationRepo }) {
   const pinnedLabel = relay.pinnedVersion
     ?? (relay.pinnedSha ? relay.pinnedSha.slice(0, 7) : null)
   const drifted = relay.verdict === 'drifted'
+  // Drift-unknown covers more than the bare-sha case (branch pins, an
+  // unparseable uses line) — prefer the per-repo reason when the survey
+  // recorded one, fall back to the sha-specific hint, then the general one.
   const title = relay.driftUnknown
-    ? 'pin does not resolve to a version (no # vX.Y.Z comment) — drift unknown'
+    ? (relay.reason
+      ?? (relay.pinnedSha
+        ? 'sha pin has no # vX.Y.Z comment — drift unknown'
+        : 'pin does not resolve to a version — drift unknown'))
     : undefined
   if (!pinnedLabel && !relay.latestVersion) {
     return <td className="cr-dim" data-testid={`integration-relay-version-${repo.name}`} title={title}>—</td>
   }
+  // The `→ latest` arrow only renders when it carries signal: a confirmed
+  // drift, or an unresolvable pin (show what latest is for context). An
+  // up-to-date pin that merely FORMATS differently (e.g. `v1.1` vs `v1.1.0`,
+  // equal under the server's numeric compare) must not suggest an upgrade.
+  const showLatest = Boolean(
+    relay.latestVersion && pinnedLabel !== relay.latestVersion && (drifted || relay.driftUnknown),
+  )
   return (
     <td className="cr-mono" data-testid={`integration-relay-version-${repo.name}`} title={title}>
       <span className={drifted ? 'cr-warn' : undefined}>{pinnedLabel ?? '—'}</span>
-      {relay.latestVersion && pinnedLabel !== relay.latestVersion && (
+      {showLatest && (
         <span className="cr-dim"> → {relay.latestVersion}</span>
       )}
     </td>
@@ -224,7 +237,7 @@ function RelayLastRunCell({ repo, now }: { repo: IntegrationRepo; now: number })
           <a
             href={relay.workflowUrl}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             data-testid={`integration-relay-link-${repo.name}`}
             title="Open the workflow in the GitHub Actions UI"
           >
@@ -248,7 +261,7 @@ function RelayLastRunCell({ repo, now }: { repo: IntegrationRepo; now: number })
           <a
             href={relay.workflowUrl}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             data-testid={`integration-relay-link-${repo.name}`}
             title="Open the workflow in the GitHub Actions UI"
           >
@@ -532,7 +545,8 @@ export function IntegrationsSection({
           {snapshot.ghCli && !snapshot.ghCli.found && (
             <div className="cr-callout" data-testid="integration-gh-note">
               <b>gh CLI unavailable:</b> {snapshot.ghCli.note ?? 'binary not found'} — relay install and version-pin
-              columns still populate from the filesystem; the run and release columns are degraded for every repo.
+              columns still populate from the filesystem; the run and release columns are degraded for every repo
+              with repo-relay installed.
             </div>
           )}
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8840,6 +8840,20 @@ button.sidebar-token-view-session-row:hover {
   font-weight: 700;
 }
 
+/* #5501 — Integrations table: amber drift highlight (version pin behind the
+   latest release). */
+.cr-warn {
+  color: var(--accent-orange);
+}
+
+/* #5501 — Integrations table: grouped column-family header cells (the
+   "repo-memory" / "repo-relay" spanning row above the per-column row). */
+.cr-th-group {
+  text-align: center;
+  color: var(--text-muted);
+  border-bottom: none;
+}
+
 .cr-empty {
   background: var(--bg-secondary);
   border: 1px solid var(--border-primary);

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -34,7 +34,7 @@ export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
 export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, ServerCancelActivityAckMessage, } from './schemas/server.ts';
 export type { RepoVerdict, RepoTree, RepoStatus, HostStatusSummary, ServerHostStatusSnapshotMessage, } from './schemas/server.ts';
 export type { RunnerVerdict, RunnerServiceState, RunnerInfo, RepoRunners, RunnerStatusSummary, ServerRunnerStatusSnapshotMessage, } from './schemas/server.ts';
-export type { RepoMemoryCache, RepoMemoryReport, RepoMemoryStatus, IntegrationRepo, IntegrationStatusSummary, IntegrationCliStatus, ServerIntegrationStatusSnapshotMessage, } from './schemas/server.ts';
+export type { RepoMemoryCache, RepoMemoryReport, RepoMemoryStatus, RepoRelayRun, RepoRelayVerdict, RepoRelayStatus, IntegrationRepo, IntegrationStatusSummary, IntegrationCliStatus, ServerIntegrationStatusSnapshotMessage, } from './schemas/server.ts';
 export type { IntegrationActionCounts, ServerIntegrationActionAckMessage, } from './schemas/server.ts';
 export type { HostStatusRequestMessage } from './schemas/client.ts';
 export type { RunnerStatusRequestMessage } from './schemas/client.ts';

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -1049,11 +1049,91 @@ export declare const RepoMemoryStatusSchema: z.ZodObject<{
     reason: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
 /**
+ * #5501 — one recent repo-relay workflow run, distilled from
+ * `gh run list --workflow=repo-relay.yml --json status,conclusion,event,createdAt,databaseId`.
+ * `databaseId` is GitHub's run id — #5502's rerun action consumes it, so it is
+ * carried verbatim. `conclusion` is null while the run is still in progress.
+ */
+export declare const RepoRelayRunSchema: z.ZodObject<{
+    databaseId: z.ZodNumber;
+    status: z.ZodNullable<z.ZodString>;
+    conclusion: z.ZodNullable<z.ZodString>;
+    event: z.ZodNullable<z.ZodString>;
+    createdAt: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+/**
+ * #5501 — per-repo repo-relay verdict, mirroring the runner tab's bucket
+ * style:
+ *
+ *   - 'failing'       — the latest CONCLUDED run failed (wins over drift:
+ *     a broken relay is more urgent than a stale pin).
+ *   - 'drifted'       — pinned version < latest release (sha pins resolve via
+ *     their `# vX.Y.Z` comment first).
+ *   - 'ok'            — latest concluded run succeeded and no drift.
+ *   - 'not_installed' — no `.github/workflows/repo-relay.yml` in the checkout.
+ *   - 'unknown'       — installed but unassessable (gh missing / rate-limited /
+ *     no GitHub remote / no concluded runs and no drift signal); the row's
+ *     `reason` explains why.
+ */
+export declare const RepoRelayVerdictSchema: z.ZodEnum<{
+    unknown: "unknown";
+    failing: "failing";
+    ok: "ok";
+    drifted: "drifted";
+    not_installed: "not_installed";
+}>;
+/**
+ * #5501 — one repo's repo-relay status.
+ *
+ *   - `installed` — answered from the filesystem alone (the workflow file),
+ *     so it survives every gh/network degradation.
+ *   - `pinnedVersion` / `pinnedSha` — parsed from the workflow's
+ *     `uses: blamechris/repo-relay@<ref>` line. A tag pin fills
+ *     `pinnedVersion` only; a sha pin fills `pinnedSha` plus `pinnedVersion`
+ *     when a `# vX.Y.Z` comment resolves it.
+ *   - `driftUnknown` — installed but the pin couldn't be resolved to a
+ *     version (bare sha with no comment, branch pin, unparseable uses line)
+ *     so drift can't be assessed.
+ *   - `latestVersion` — `releases/latest` tag of blamechris/repo-relay,
+ *     fetched ONCE per snapshot (and cached briefly across snapshots).
+ *   - `runs` — most-recent-first; empty when unavailable (see `reason`).
+ *   - `failureStreak` — consecutive failed conclusions from the most recent
+ *     run backwards (in-progress runs are skipped, not streak-breaking).
+ *   - `workflowUrl` — Actions UI deep link, null without a GitHub remote.
+ *   - `reason` — per-repo degradation note (gh missing, rate limit, no
+ *     GitHub remote, …). Null when nothing degraded.
+ */
+export declare const RepoRelayStatusSchema: z.ZodObject<{
+    installed: z.ZodBoolean;
+    pinnedVersion: z.ZodNullable<z.ZodString>;
+    pinnedSha: z.ZodNullable<z.ZodString>;
+    latestVersion: z.ZodNullable<z.ZodString>;
+    runs: z.ZodArray<z.ZodObject<{
+        databaseId: z.ZodNumber;
+        status: z.ZodNullable<z.ZodString>;
+        conclusion: z.ZodNullable<z.ZodString>;
+        event: z.ZodNullable<z.ZodString>;
+        createdAt: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    failureStreak: z.ZodNumber;
+    verdict: z.ZodEnum<{
+        unknown: "unknown";
+        failing: "failing";
+        ok: "ok";
+        drifted: "drifted";
+        not_installed: "not_installed";
+    }>;
+    driftUnknown: z.ZodBoolean;
+    workflowUrl: z.ZodNullable<z.ZodString>;
+    reason: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+/**
  * One surveyed repo in the Integrations snapshot. `repoMemory` is nullable so
- * a future integration can appear without forcing a repo-memory block; a
- * sibling `repoRelay` block lands in the follow-up issue (#5501) as an
- * additive key — consumers must tolerate unknown extra keys per the usual Zod
- * non-strict object semantics.
+ * a future integration can appear without forcing a repo-memory block.
+ * `repoRelay` (#5501) is additive — optional so #5503-era producers/fixtures
+ * stay valid; the current survey always emits it (a repo without the workflow
+ * file gets a quiet `installed: false` block, same posture as unconfigured
+ * repo-memory).
  */
 export declare const IntegrationRepoSchema: z.ZodObject<{
     name: z.ZodString;
@@ -1079,6 +1159,30 @@ export declare const IntegrationRepoSchema: z.ZodObject<{
         }, z.core.$strip>>;
         reason: z.ZodNullable<z.ZodString>;
     }, z.core.$strip>>;
+    repoRelay: z.ZodOptional<z.ZodNullable<z.ZodObject<{
+        installed: z.ZodBoolean;
+        pinnedVersion: z.ZodNullable<z.ZodString>;
+        pinnedSha: z.ZodNullable<z.ZodString>;
+        latestVersion: z.ZodNullable<z.ZodString>;
+        runs: z.ZodArray<z.ZodObject<{
+            databaseId: z.ZodNumber;
+            status: z.ZodNullable<z.ZodString>;
+            conclusion: z.ZodNullable<z.ZodString>;
+            event: z.ZodNullable<z.ZodString>;
+            createdAt: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>;
+        failureStreak: z.ZodNumber;
+        verdict: z.ZodEnum<{
+            unknown: "unknown";
+            failing: "failing";
+            ok: "ok";
+            drifted: "drifted";
+            not_installed: "not_installed";
+        }>;
+        driftUnknown: z.ZodBoolean;
+        workflowUrl: z.ZodNullable<z.ZodString>;
+        reason: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>>;
 }, z.core.$strip>;
 /**
  * Aggregate repo-memory counts across the surveyed repos, carried alongside
@@ -1090,6 +1194,9 @@ export declare const IntegrationStatusSummarySchema: z.ZodObject<{
     configured: z.ZodNumber;
     notConfigured: z.ZodNumber;
     degraded: z.ZodNumber;
+    relayInstalled: z.ZodOptional<z.ZodNumber>;
+    relayFailing: z.ZodOptional<z.ZodNumber>;
+    relayDrifted: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 /**
  * Snapshot-level note about the `repo-memory` CLI binary, probed ONCE per
@@ -1120,6 +1227,9 @@ export declare const ServerIntegrationStatusSnapshotSchema: z.ZodObject<{
         configured: z.ZodNumber;
         notConfigured: z.ZodNumber;
         degraded: z.ZodNumber;
+        relayInstalled: z.ZodOptional<z.ZodNumber>;
+        relayFailing: z.ZodOptional<z.ZodNumber>;
+        relayDrifted: z.ZodOptional<z.ZodNumber>;
     }, z.core.$strip>;
     repos: z.ZodArray<z.ZodObject<{
         name: z.ZodString;
@@ -1145,8 +1255,37 @@ export declare const ServerIntegrationStatusSnapshotSchema: z.ZodObject<{
             }, z.core.$strip>>;
             reason: z.ZodNullable<z.ZodString>;
         }, z.core.$strip>>;
+        repoRelay: z.ZodOptional<z.ZodNullable<z.ZodObject<{
+            installed: z.ZodBoolean;
+            pinnedVersion: z.ZodNullable<z.ZodString>;
+            pinnedSha: z.ZodNullable<z.ZodString>;
+            latestVersion: z.ZodNullable<z.ZodString>;
+            runs: z.ZodArray<z.ZodObject<{
+                databaseId: z.ZodNumber;
+                status: z.ZodNullable<z.ZodString>;
+                conclusion: z.ZodNullable<z.ZodString>;
+                event: z.ZodNullable<z.ZodString>;
+                createdAt: z.ZodNullable<z.ZodString>;
+            }, z.core.$strip>>;
+            failureStreak: z.ZodNumber;
+            verdict: z.ZodEnum<{
+                unknown: "unknown";
+                failing: "failing";
+                ok: "ok";
+                drifted: "drifted";
+                not_installed: "not_installed";
+            }>;
+            driftUnknown: z.ZodBoolean;
+            workflowUrl: z.ZodNullable<z.ZodString>;
+            reason: z.ZodNullable<z.ZodString>;
+        }, z.core.$strip>>>;
     }, z.core.$strip>>;
     repoMemoryCli: z.ZodOptional<z.ZodObject<{
+        found: z.ZodBoolean;
+        path: z.ZodNullable<z.ZodString>;
+        note: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    ghCli: z.ZodOptional<z.ZodObject<{
         found: z.ZodBoolean;
         path: z.ZodNullable<z.ZodString>;
         note: z.ZodNullable<z.ZodString>;
@@ -1824,6 +1963,9 @@ export type ServerRunnerStatusSnapshotMessage = z.infer<typeof ServerRunnerStatu
 export type RepoMemoryCache = z.infer<typeof RepoMemoryCacheSchema>;
 export type RepoMemoryReport = z.infer<typeof RepoMemoryReportSchema>;
 export type RepoMemoryStatus = z.infer<typeof RepoMemoryStatusSchema>;
+export type RepoRelayRun = z.infer<typeof RepoRelayRunSchema>;
+export type RepoRelayVerdict = z.infer<typeof RepoRelayVerdictSchema>;
+export type RepoRelayStatus = z.infer<typeof RepoRelayStatusSchema>;
 export type IntegrationRepo = z.infer<typeof IntegrationRepoSchema>;
 export type IntegrationStatusSummary = z.infer<typeof IntegrationStatusSummarySchema>;
 export type IntegrationCliStatus = z.infer<typeof IntegrationCliStatusSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -1040,16 +1040,79 @@ export const RepoMemoryStatusSchema = z.object({
     reason: z.string().nullable(),
 });
 /**
+ * #5501 — one recent repo-relay workflow run, distilled from
+ * `gh run list --workflow=repo-relay.yml --json status,conclusion,event,createdAt,databaseId`.
+ * `databaseId` is GitHub's run id — #5502's rerun action consumes it, so it is
+ * carried verbatim. `conclusion` is null while the run is still in progress.
+ */
+export const RepoRelayRunSchema = z.object({
+    databaseId: z.number().int().nonnegative().finite(),
+    status: z.string().nullable(),
+    conclusion: z.string().nullable(),
+    event: z.string().nullable(),
+    createdAt: z.string().datetime().nullable(),
+});
+/**
+ * #5501 — per-repo repo-relay verdict, mirroring the runner tab's bucket
+ * style:
+ *
+ *   - 'failing'       — the latest CONCLUDED run failed (wins over drift:
+ *     a broken relay is more urgent than a stale pin).
+ *   - 'drifted'       — pinned version < latest release (sha pins resolve via
+ *     their `# vX.Y.Z` comment first).
+ *   - 'ok'            — latest concluded run succeeded and no drift.
+ *   - 'not_installed' — no `.github/workflows/repo-relay.yml` in the checkout.
+ *   - 'unknown'       — installed but unassessable (gh missing / rate-limited /
+ *     no GitHub remote / no concluded runs and no drift signal); the row's
+ *     `reason` explains why.
+ */
+export const RepoRelayVerdictSchema = z.enum(['ok', 'failing', 'drifted', 'not_installed', 'unknown']);
+/**
+ * #5501 — one repo's repo-relay status.
+ *
+ *   - `installed` — answered from the filesystem alone (the workflow file),
+ *     so it survives every gh/network degradation.
+ *   - `pinnedVersion` / `pinnedSha` — parsed from the workflow's
+ *     `uses: blamechris/repo-relay@<ref>` line. A tag pin fills
+ *     `pinnedVersion` only; a sha pin fills `pinnedSha` plus `pinnedVersion`
+ *     when a `# vX.Y.Z` comment resolves it.
+ *   - `driftUnknown` — installed but the pin couldn't be resolved to a
+ *     version (bare sha with no comment, branch pin, unparseable uses line)
+ *     so drift can't be assessed.
+ *   - `latestVersion` — `releases/latest` tag of blamechris/repo-relay,
+ *     fetched ONCE per snapshot (and cached briefly across snapshots).
+ *   - `runs` — most-recent-first; empty when unavailable (see `reason`).
+ *   - `failureStreak` — consecutive failed conclusions from the most recent
+ *     run backwards (in-progress runs are skipped, not streak-breaking).
+ *   - `workflowUrl` — Actions UI deep link, null without a GitHub remote.
+ *   - `reason` — per-repo degradation note (gh missing, rate limit, no
+ *     GitHub remote, …). Null when nothing degraded.
+ */
+export const RepoRelayStatusSchema = z.object({
+    installed: z.boolean(),
+    pinnedVersion: z.string().nullable(),
+    pinnedSha: z.string().nullable(),
+    latestVersion: z.string().nullable(),
+    runs: z.array(RepoRelayRunSchema),
+    failureStreak: z.number().int().nonnegative().finite(),
+    verdict: RepoRelayVerdictSchema,
+    driftUnknown: z.boolean(),
+    workflowUrl: z.string().nullable(),
+    reason: z.string().nullable(),
+});
+/**
  * One surveyed repo in the Integrations snapshot. `repoMemory` is nullable so
- * a future integration can appear without forcing a repo-memory block; a
- * sibling `repoRelay` block lands in the follow-up issue (#5501) as an
- * additive key — consumers must tolerate unknown extra keys per the usual Zod
- * non-strict object semantics.
+ * a future integration can appear without forcing a repo-memory block.
+ * `repoRelay` (#5501) is additive — optional so #5503-era producers/fixtures
+ * stay valid; the current survey always emits it (a repo without the workflow
+ * file gets a quiet `installed: false` block, same posture as unconfigured
+ * repo-memory).
  */
 export const IntegrationRepoSchema = z.object({
     name: z.string(),
     path: z.string(),
     repoMemory: RepoMemoryStatusSchema.nullable(),
+    repoRelay: RepoRelayStatusSchema.nullable().optional(),
 });
 /**
  * Aggregate repo-memory counts across the surveyed repos, carried alongside
@@ -1061,6 +1124,12 @@ export const IntegrationStatusSummarySchema = z.object({
     configured: z.number().int().nonnegative().finite(),
     notConfigured: z.number().int().nonnegative().finite(),
     degraded: z.number().int().nonnegative().finite(),
+    // #5501 (additive — optional so pre-relay snapshots stay valid): repo-relay
+    // tallies for the summary chips. `relayFailing` / `relayDrifted` count the
+    // verdict buckets; `relayInstalled` counts repos with the workflow file.
+    relayInstalled: z.number().int().nonnegative().finite().optional(),
+    relayFailing: z.number().int().nonnegative().finite().optional(),
+    relayDrifted: z.number().int().nonnegative().finite().optional(),
 });
 /**
  * Snapshot-level note about the `repo-memory` CLI binary, probed ONCE per
@@ -1091,6 +1160,10 @@ export const ServerIntegrationStatusSnapshotSchema = z.object({
     summary: IntegrationStatusSummarySchema,
     repos: z.array(IntegrationRepoSchema),
     repoMemoryCli: IntegrationCliStatusSchema.optional(),
+    // #5501: snapshot-level note about the `gh` CLI, probed ONCE per survey —
+    // when `found` is false every repo-relay run/release cell degrades and
+    // `note` explains why (each installed repo's `reason` repeats it).
+    ghCli: IntegrationCliStatusSchema.optional(),
     // Additive degraded-snapshot annotation — same posture as the host/runner
     // snapshots: on a forbidden/in-progress/failed survey the handler returns an
     // otherwise-valid empty snapshot plus this `error`.

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -91,6 +91,10 @@ export type {
   RepoMemoryCache,
   RepoMemoryReport,
   RepoMemoryStatus,
+  // #5501: repo-relay observability block.
+  RepoRelayRun,
+  RepoRelayVerdict,
+  RepoRelayStatus,
   IntegrationRepo,
   IntegrationStatusSummary,
   IntegrationCliStatus,

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -1103,16 +1103,82 @@ export const RepoMemoryStatusSchema = z.object({
 })
 
 /**
+ * #5501 — one recent repo-relay workflow run, distilled from
+ * `gh run list --workflow=repo-relay.yml --json status,conclusion,event,createdAt,databaseId`.
+ * `databaseId` is GitHub's run id — #5502's rerun action consumes it, so it is
+ * carried verbatim. `conclusion` is null while the run is still in progress.
+ */
+export const RepoRelayRunSchema = z.object({
+  databaseId: z.number().int().nonnegative().finite(),
+  status: z.string().nullable(),
+  conclusion: z.string().nullable(),
+  event: z.string().nullable(),
+  createdAt: z.string().datetime().nullable(),
+})
+
+/**
+ * #5501 — per-repo repo-relay verdict, mirroring the runner tab's bucket
+ * style:
+ *
+ *   - 'failing'       — the latest CONCLUDED run failed (wins over drift:
+ *     a broken relay is more urgent than a stale pin).
+ *   - 'drifted'       — pinned version < latest release (sha pins resolve via
+ *     their `# vX.Y.Z` comment first).
+ *   - 'ok'            — latest concluded run succeeded and no drift.
+ *   - 'not_installed' — no `.github/workflows/repo-relay.yml` in the checkout.
+ *   - 'unknown'       — installed but unassessable (gh missing / rate-limited /
+ *     no GitHub remote / no concluded runs and no drift signal); the row's
+ *     `reason` explains why.
+ */
+export const RepoRelayVerdictSchema = z.enum(['ok', 'failing', 'drifted', 'not_installed', 'unknown'])
+
+/**
+ * #5501 — one repo's repo-relay status.
+ *
+ *   - `installed` — answered from the filesystem alone (the workflow file),
+ *     so it survives every gh/network degradation.
+ *   - `pinnedVersion` / `pinnedSha` — parsed from the workflow's
+ *     `uses: blamechris/repo-relay@<ref>` line. A tag pin fills
+ *     `pinnedVersion` only; a sha pin fills `pinnedSha` plus `pinnedVersion`
+ *     when a `# vX.Y.Z` comment resolves it.
+ *   - `driftUnknown` — installed but the pin couldn't be resolved to a
+ *     version (bare sha with no comment, branch pin, unparseable uses line)
+ *     so drift can't be assessed.
+ *   - `latestVersion` — `releases/latest` tag of blamechris/repo-relay,
+ *     fetched ONCE per snapshot (and cached briefly across snapshots).
+ *   - `runs` — most-recent-first; empty when unavailable (see `reason`).
+ *   - `failureStreak` — consecutive failed conclusions from the most recent
+ *     run backwards (in-progress runs are skipped, not streak-breaking).
+ *   - `workflowUrl` — Actions UI deep link, null without a GitHub remote.
+ *   - `reason` — per-repo degradation note (gh missing, rate limit, no
+ *     GitHub remote, …). Null when nothing degraded.
+ */
+export const RepoRelayStatusSchema = z.object({
+  installed: z.boolean(),
+  pinnedVersion: z.string().nullable(),
+  pinnedSha: z.string().nullable(),
+  latestVersion: z.string().nullable(),
+  runs: z.array(RepoRelayRunSchema),
+  failureStreak: z.number().int().nonnegative().finite(),
+  verdict: RepoRelayVerdictSchema,
+  driftUnknown: z.boolean(),
+  workflowUrl: z.string().nullable(),
+  reason: z.string().nullable(),
+})
+
+/**
  * One surveyed repo in the Integrations snapshot. `repoMemory` is nullable so
- * a future integration can appear without forcing a repo-memory block; a
- * sibling `repoRelay` block lands in the follow-up issue (#5501) as an
- * additive key — consumers must tolerate unknown extra keys per the usual Zod
- * non-strict object semantics.
+ * a future integration can appear without forcing a repo-memory block.
+ * `repoRelay` (#5501) is additive — optional so #5503-era producers/fixtures
+ * stay valid; the current survey always emits it (a repo without the workflow
+ * file gets a quiet `installed: false` block, same posture as unconfigured
+ * repo-memory).
  */
 export const IntegrationRepoSchema = z.object({
   name: z.string(),
   path: z.string(),
   repoMemory: RepoMemoryStatusSchema.nullable(),
+  repoRelay: RepoRelayStatusSchema.nullable().optional(),
 })
 
 /**
@@ -1125,6 +1191,12 @@ export const IntegrationStatusSummarySchema = z.object({
   configured: z.number().int().nonnegative().finite(),
   notConfigured: z.number().int().nonnegative().finite(),
   degraded: z.number().int().nonnegative().finite(),
+  // #5501 (additive — optional so pre-relay snapshots stay valid): repo-relay
+  // tallies for the summary chips. `relayFailing` / `relayDrifted` count the
+  // verdict buckets; `relayInstalled` counts repos with the workflow file.
+  relayInstalled: z.number().int().nonnegative().finite().optional(),
+  relayFailing: z.number().int().nonnegative().finite().optional(),
+  relayDrifted: z.number().int().nonnegative().finite().optional(),
 })
 
 /**
@@ -1157,6 +1229,10 @@ export const ServerIntegrationStatusSnapshotSchema = z.object({
   summary: IntegrationStatusSummarySchema,
   repos: z.array(IntegrationRepoSchema),
   repoMemoryCli: IntegrationCliStatusSchema.optional(),
+  // #5501: snapshot-level note about the `gh` CLI, probed ONCE per survey —
+  // when `found` is false every repo-relay run/release cell degrades and
+  // `note` explains why (each installed repo's `reason` repeats it).
+  ghCli: IntegrationCliStatusSchema.optional(),
   // Additive degraded-snapshot annotation — same posture as the host/runner
   // snapshots: on a forbidden/in-progress/failed survey the handler returns an
   // otherwise-valid empty snapshot plus this `error`.
@@ -2076,6 +2152,10 @@ export type ServerRunnerStatusSnapshotMessage = z.infer<typeof ServerRunnerStatu
 export type RepoMemoryCache = z.infer<typeof RepoMemoryCacheSchema>
 export type RepoMemoryReport = z.infer<typeof RepoMemoryReportSchema>
 export type RepoMemoryStatus = z.infer<typeof RepoMemoryStatusSchema>
+// #5501: repo-relay observability block (sibling to RepoMemoryStatus).
+export type RepoRelayRun = z.infer<typeof RepoRelayRunSchema>
+export type RepoRelayVerdict = z.infer<typeof RepoRelayVerdictSchema>
+export type RepoRelayStatus = z.infer<typeof RepoRelayStatusSchema>
 export type IntegrationRepo = z.infer<typeof IntegrationRepoSchema>
 export type IntegrationStatusSummary = z.infer<typeof IntegrationStatusSummarySchema>
 export type IntegrationCliStatus = z.infer<typeof IntegrationCliStatusSchema>

--- a/packages/server/src/control-room/integrations.js
+++ b/packages/server/src/control-room/integrations.js
@@ -3,8 +3,8 @@
  *
  * Sibling to the host survey (survey.js) and the runner survey (runners.js).
  * Where those classify git repos and self-hosted runners, this one surveys
- * **integration status** per repo — repo-memory for this slice (a sibling
- * repo-relay block is the follow-up sub-issue of #5498):
+ * **integration status** per repo — repo-memory (#5499) and repo-relay
+ * (#5501):
  *
  *   - config:  does `.repo-memory.json` exist in the repo root? Parse its
  *     `summarizer` and enabled tool groups when it does.
@@ -13,15 +13,29 @@
  *     telemetry report carries no timestamp of its own).
  *   - report:  `repo-memory report <repoRoot> --json --diagnostics` — total
  *     events, hit ratio, tokens saved, cache entry/stale counts. Read-only CLI.
+ *   - relay (#5501): `.github/workflows/repo-relay.yml` presence, the
+ *     `uses: blamechris/repo-relay@<ref>` version pin (tag or sha+comment),
+ *     the latest upstream release (`gh api .../releases/latest`, ONE call per
+ *     snapshot + a short module cache), and the five most recent workflow runs
+ *     (`gh run list -R <owner>/<repo>` — owner/repo derived from the git
+ *     remote via survey.js's parseGithubOwnerRepo).
  *
  * Degradation semantics (the survey NEVER fails because one cell did):
  *   - The `repo-memory` binary is resolved ONCE per snapshot (`which`), not per
  *     repo. When absent, every configured repo's report cell degrades with a
  *     per-repo `reason` and the snapshot carries a `repoMemoryCli` note.
+ *   - Same for `gh` (#5501): one probe per snapshot; when absent every
+ *     installed repo's relay run/release cells degrade with a per-repo
+ *     `reason` and the snapshot carries a `ghCli` note.
  *   - A per-repo CLI failure (exit 1, timeout, unparseable output) degrades
  *     that repo's report cell with a `reason` string.
  *   - A repo without `.repo-memory.json` is a quiet `configured: false` row —
- *     absence is signal, not an error.
+ *     absence is signal, not an error. Same for a repo without the relay
+ *     workflow file (`installed: false`).
+ *   - A repo with no GitHub remote still answers `installed` (and the pin)
+ *     from the filesystem; the run cells degrade with reason
+ *     'no GitHub remote'. Drift is still assessed — the pin comes from the
+ *     workflow file and the latest release is repo-independent.
  *
  * The result conforms to `ServerIntegrationStatusSnapshotSchema` from
  * `@chroxy/protocol` (minus the `type` field, which the WS handler adds).
@@ -38,6 +52,7 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { readFile, stat } from 'fs/promises'
 import { join } from 'path'
+import { parseGithubOwnerRepo } from './survey.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -58,6 +73,18 @@ const EXEC_OPTS = { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }
 
 /** Snapshot-level note used when the binary probe finds nothing. */
 export const CLI_MISSING_NOTE = 'repo-memory CLI not found on PATH — install @blamechris/repo-memory globally or set controlRoomRepoMemoryBin'
+
+/** #5501: snapshot-level note (and per-repo reason) when `gh` is missing. */
+export const GH_MISSING_NOTE = 'gh CLI not found on PATH — install GitHub CLI (gh) to populate repo-relay run and release data'
+
+/** #5501: per-repo reason when a repo has no recognisable GitHub remote. */
+export const NO_GITHUB_REMOTE_REASON = 'no GitHub remote'
+
+/** #5501: the upstream action repo whose releases define "latest". */
+export const RELAY_UPSTREAM_REPO = 'blamechris/repo-relay'
+
+/** #5501: the workflow file (and `gh run list --workflow` target) per repo. */
+export const RELAY_WORKFLOW_FILE = 'repo-relay.yml'
 
 /**
  * #5500: timeout for `repo-memory index` — deliberately much more generous
@@ -178,8 +205,19 @@ export function parseRepoMemoryReport(json) {
  */
 export async function resolveRepoMemoryBin(execFn, binOverride) {
   if (typeof binOverride === 'string' && binOverride.length > 0) return binOverride
+  return probeBinOnPath(execFn, 'repo-memory')
+}
+
+/**
+ * Probe the PATH for a binary with `which`. Any failure resolves null.
+ *
+ * @param {Function} execFn - promisified execFile seam.
+ * @param {string} name - binary name (e.g. 'repo-memory', 'gh').
+ * @returns {Promise<string|null>} resolved binary path, or null.
+ */
+async function probeBinOnPath(execFn, name) {
   try {
-    const { stdout } = await execFn('which', ['repo-memory'], EXEC_OPTS)
+    const { stdout } = await execFn('which', [name], EXEC_OPTS)
     const path = String(stdout == null ? '' : stdout).split('\n')[0].trim()
     return path.length > 0 ? path : null
   } catch {
@@ -299,6 +337,312 @@ export async function runRepoMemoryIndex(repoPath, opts = {}) {
   return { counts: parseRepoMemoryIndexCounts(typeof stdout === 'string' ? stdout : '') }
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// #5501 — repo-relay observability helpers.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse the `uses: blamechris/repo-relay@<ref>` line out of a workflow file.
+ *
+ * Handles both pin forms:
+ *   - tag-pinned:          `uses: blamechris/repo-relay@v1.1.0`
+ *   - sha-pinned+comment:  `uses: blamechris/repo-relay@f08840b9… # v1.1.0`
+ *     (chroxy's own `.github/workflows/repo-relay.yml` is the live example)
+ *
+ * `version` resolves from the tag (when it looks like a version) or from the
+ * sha pin's trailing `# vX.Y.Z` comment; it stays null for a bare sha or a
+ * branch pin — drift then can't be assessed (`driftUnknown` upstream).
+ *
+ * @param {string|null|undefined} text - raw workflow YAML.
+ * @returns {{ ref: string, sha: string|null, version: string|null }|null}
+ *   the parsed pin, or null when no repo-relay uses line is present.
+ */
+export function parseRelayPin(text) {
+  if (typeof text !== 'string' || text.length === 0) return null
+  const m = /^\s*(?:-\s+)?uses:\s*['"]?blamechris\/repo-relay@([^\s'"#]+)['"]?[ \t]*(?:#[ \t]*(\S+))?[ \t]*$/m.exec(text)
+  if (!m) return null
+  const ref = m[1]
+  const comment = m[2] || null
+  const versionLike = v => typeof v === 'string' && /^v?\d+(\.\d+){0,2}$/.test(v)
+  if (/^[0-9a-f]{7,40}$/i.test(ref)) {
+    return { ref, sha: ref, version: versionLike(comment) ? comment : null }
+  }
+  return { ref, sha: null, version: versionLike(ref) ? ref : null }
+}
+
+/**
+ * Compare two version tags (`v1.1.0` / `1.1` — the leading `v` and a missing
+ * minor/patch are tolerated). Returns -1/0/1, or null when either side is
+ * unparseable (branch names, bare shas) — callers treat null as "can't
+ * assess", never as equality.
+ *
+ * @param {unknown} a
+ * @param {unknown} b
+ * @returns {-1|0|1|null}
+ */
+export function compareVersions(a, b) {
+  const parse = v => {
+    const m = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(String(v ?? '').trim())
+    return m ? [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0)] : null
+  }
+  const pa = parse(a)
+  const pb = parse(b)
+  if (!pa || !pb) return null
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1
+  }
+  return 0
+}
+
+/**
+ * Parse `gh run list --json status,conclusion,event,createdAt,databaseId`
+ * output into the `RepoRelayRunSchema` shape, most-recent-first as gh emits
+ * it. Entries without a usable `databaseId` are dropped (#5502's rerun action
+ * needs the id); `createdAt` is normalised to a strict ISO-8601 string.
+ *
+ * @param {string|null|undefined} json - raw stdout, or null when unavailable.
+ * @returns {object[]|null} parsed runs, or null when the payload is
+ *   absent/unparseable/not an array (the caller degrades with a reason).
+ */
+export function parseRelayRuns(json) {
+  if (json === null || json === undefined) return null
+  let parsed
+  try {
+    parsed = JSON.parse(String(json))
+  } catch {
+    return null
+  }
+  if (!Array.isArray(parsed)) return null
+  const runs = []
+  for (const r of parsed) {
+    if (!r || typeof r !== 'object') continue
+    if (!Number.isInteger(r.databaseId) || r.databaseId < 0) continue
+    const str = v => (typeof v === 'string' && v.length > 0 ? v : null)
+    const createdMs = typeof r.createdAt === 'string' ? Date.parse(r.createdAt) : NaN
+    runs.push({
+      databaseId: r.databaseId,
+      status: str(r.status),
+      conclusion: str(r.conclusion),
+      event: str(r.event),
+      createdAt: Number.isNaN(createdMs) ? null : new Date(createdMs).toISOString(),
+    })
+  }
+  return runs
+}
+
+/**
+ * Count consecutive failed conclusions from the most recent run backwards.
+ * In-progress runs (no conclusion yet) are skipped — they neither extend nor
+ * break the streak; any other conclusion (success, cancelled, …) breaks it.
+ *
+ * @param {Array<{ conclusion: string|null }>|null|undefined} runs
+ * @returns {number}
+ */
+export function computeRelayFailureStreak(runs) {
+  let streak = 0
+  for (const r of Array.isArray(runs) ? runs : []) {
+    const conclusion = r && typeof r.conclusion === 'string' && r.conclusion.length > 0 ? r.conclusion : null
+    if (conclusion === null) continue // still running — no signal yet
+    if (conclusion === 'failure') {
+      streak++
+      continue
+    }
+    break
+  }
+  return streak
+}
+
+/**
+ * Classify a repo's relay status into a `RepoRelayVerdictSchema` bucket.
+ * Precedence (most urgent first): a broken relay beats a stale pin beats
+ * green:
+ *
+ *   - not installed                              → 'not_installed'
+ *   - latest CONCLUDED run failed                → 'failing'
+ *   - pinned version < latest release            → 'drifted'
+ *   - latest concluded run succeeded             → 'ok'
+ *   - anything else (no concluded runs, runs
+ *     unavailable, drift unassessable)           → 'unknown'
+ *
+ * @param {{ installed: boolean, pinnedVersion: string|null,
+ *   latestVersion: string|null, runs: Array<{ conclusion: string|null }> }} relay
+ * @returns {'ok'|'failing'|'drifted'|'not_installed'|'unknown'}
+ */
+export function classifyRelay({ installed, pinnedVersion, latestVersion, runs }) {
+  if (!installed) return 'not_installed'
+  const latestConcluded = (Array.isArray(runs) ? runs : [])
+    .find(r => r && typeof r.conclusion === 'string' && r.conclusion.length > 0)
+  if (latestConcluded && latestConcluded.conclusion === 'failure') return 'failing'
+  const cmp = compareVersions(pinnedVersion, latestVersion)
+  if (cmp !== null && cmp < 0) return 'drifted'
+  if (latestConcluded && latestConcluded.conclusion === 'success') return 'ok'
+  return 'unknown'
+}
+
+/**
+ * #5501: how long a fetched `releases/latest` result stays good across
+ * snapshots. Refresh-spamming the Integrations tab must not hammer the GitHub
+ * API — within this window the module-level cache answers without a call.
+ * Only SUCCESSFUL fetches are cached: a rate-limited/offline attempt degrades
+ * that snapshot with a reason and the next refresh retries.
+ */
+export const RELAY_RELEASE_CACHE_TTL_MS = 5 * 60 * 1000
+
+/** Module-level latest-release cache: `{ version, fetchedAtMs }` or null. */
+let relayReleaseCache = null
+
+/** Test seam: drop the module-level latest-release cache. */
+export function _clearRelayReleaseCache() {
+  relayReleaseCache = null
+}
+
+/**
+ * Fetch the latest blamechris/repo-relay release tag via
+ * `gh api repos/blamechris/repo-relay/releases/latest`, honouring the module
+ * cache. Never throws — failures resolve `{ version: null, reason }`.
+ *
+ * @param {Function} execFn - promisified execFile seam.
+ * @param {string} ghPath - resolved gh binary path.
+ * @param {number} nowMs - snapshot clock (the injected `_now`).
+ * @returns {Promise<{ version: string|null, reason: string|null }>}
+ */
+async function fetchLatestRelayRelease(execFn, ghPath, nowMs) {
+  if (relayReleaseCache && nowMs >= relayReleaseCache.fetchedAtMs
+    && nowMs - relayReleaseCache.fetchedAtMs < RELAY_RELEASE_CACHE_TTL_MS) {
+    return { version: relayReleaseCache.version, reason: null }
+  }
+  let stdout
+  try {
+    ;({ stdout } = await execFn(ghPath, ['api', `repos/${RELAY_UPSTREAM_REPO}/releases/latest`], EXEC_OPTS))
+  } catch (err) {
+    return { version: null, reason: execFailureReason(err, 'gh releases/latest') }
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(typeof stdout === 'string' ? stdout : '')
+  } catch {
+    parsed = null
+  }
+  const version = parsed && typeof parsed === 'object' && typeof parsed.tag_name === 'string' && parsed.tag_name.length > 0
+    ? parsed.tag_name
+    : null
+  if (version === null) {
+    return { version: null, reason: 'gh releases/latest returned no tag_name' }
+  }
+  relayReleaseCache = { version, fetchedAtMs: nowMs }
+  return { version, reason: null }
+}
+
+/** The quiet `installed: false` relay block (no workflow file → no probing). */
+function relayNotInstalled() {
+  return {
+    installed: false,
+    pinnedVersion: null,
+    pinnedSha: null,
+    latestVersion: null,
+    runs: [],
+    failureStreak: 0,
+    verdict: 'not_installed',
+    driftUnknown: false,
+    workflowUrl: null,
+    reason: null,
+  }
+}
+
+/**
+ * Survey one repo's repo-relay status (#5501).
+ *
+ * `installed` + the version pin come from the filesystem alone; the run list
+ * and latest release ride on `gh`. Every degradation is per-repo (a `reason`
+ * string) — the block always returns. The first applicable reason wins, most
+ * actionable first: gh missing → no GitHub remote → run-list failure →
+ * latest-release failure → unparseable pin.
+ *
+ * @param {object} ctx - { readFn, execFn, ghPath, getLatestRelease }
+ * @param {{ name: string, path: string }} repo
+ * @returns {Promise<object>} a `RepoRelayStatusSchema`-shaped object.
+ */
+async function surveyRepoRelay(ctx, repo) {
+  const { readFn, execFn, ghPath, getLatestRelease } = ctx
+
+  let workflowText = null
+  try {
+    workflowText = await readFn(join(repo.path, '.github', 'workflows', RELAY_WORKFLOW_FILE), 'utf8')
+  } catch {
+    workflowText = null
+  }
+  if (workflowText === null) return relayNotInstalled()
+
+  const pin = parseRelayPin(workflowText)
+
+  // GitHub target from the repo's origin remote — same derivation the host
+  // survey uses for its PR rollup (survey.js parseGithubOwnerRepo).
+  let target = null
+  try {
+    const { stdout } = await execFn('git', ['remote', 'get-url', 'origin'], { ...EXEC_OPTS, cwd: repo.path })
+    target = parseGithubOwnerRepo(typeof stdout === 'string' ? stdout : '')
+  } catch {
+    target = null
+  }
+
+  let latestVersion = null
+  let runs = []
+  let reason = null
+
+  if (!ghPath) {
+    reason = GH_MISSING_NOTE
+  } else {
+    // One shared call per snapshot — `getLatestRelease` memoises the promise.
+    const latest = await getLatestRelease()
+    latestVersion = latest.version
+
+    if (!target) {
+      reason = NO_GITHUB_REMOTE_REASON
+    } else {
+      try {
+        const { stdout } = await execFn(ghPath, [
+          'run', 'list', `--workflow=${RELAY_WORKFLOW_FILE}`, '-R', `${target.owner}/${target.repo}`,
+          '--limit', '5', '--json', 'status,conclusion,event,createdAt,databaseId',
+        ], EXEC_OPTS)
+        const parsed = parseRelayRuns(typeof stdout === 'string' ? stdout : '')
+        if (parsed === null) {
+          reason = 'gh run list produced unparseable output'
+        } else {
+          runs = parsed
+        }
+      } catch (err) {
+        reason = execFailureReason(err, 'gh run list')
+      }
+    }
+
+    if (reason === null && latest.reason !== null) reason = latest.reason
+  }
+
+  if (reason === null && pin === null) {
+    reason = 'could not parse the repo-relay uses pin from the workflow'
+  }
+
+  const pinnedVersion = pin ? pin.version : null
+  const relay = {
+    installed: true,
+    pinnedVersion,
+    pinnedSha: pin ? pin.sha : null,
+    latestVersion,
+    runs,
+    failureStreak: computeRelayFailureStreak(runs),
+    verdict: 'unknown',
+    // Installed but the pin doesn't resolve to a version (bare sha, branch,
+    // unparseable uses line) → drift can't be assessed.
+    driftUnknown: pinnedVersion === null,
+    workflowUrl: target
+      ? `https://github.com/${target.owner}/${target.repo}/actions/workflows/${RELAY_WORKFLOW_FILE}`
+      : null,
+    reason,
+  }
+  relay.verdict = classifyRelay(relay)
+  return relay
+}
+
 /**
  * Run `tasks` with a concurrency cap, preserving order. (Same helper shape as
  * survey.js / runners.js — kept local so the modules stay independent.)
@@ -321,9 +665,22 @@ async function mapWithCap(tasks, cap) {
 
 /** Tally the summary buckets across the surveyed repos. */
 function summarize(repos) {
-  const summary = { total: 0, configured: 0, notConfigured: 0, degraded: 0 }
+  const summary = {
+    total: 0,
+    configured: 0,
+    notConfigured: 0,
+    degraded: 0,
+    // #5501: repo-relay tallies (verdict buckets the operator scans for).
+    relayInstalled: 0,
+    relayFailing: 0,
+    relayDrifted: 0,
+  }
   for (const repo of repos) {
     summary.total++
+    const relay = repo.repoRelay
+    if (relay && relay.installed) summary.relayInstalled++
+    if (relay && relay.verdict === 'failing') summary.relayFailing++
+    if (relay && relay.verdict === 'drifted') summary.relayDrifted++
     const rm = repo.repoMemory
     if (!rm || !rm.configured) {
       summary.notConfigured++
@@ -336,13 +693,13 @@ function summarize(repos) {
 }
 
 /**
- * Survey one repo's repo-memory status.
+ * Survey one repo's repo-memory status (#5499).
  *
  * @param {object} ctx - { readFn, statFn, execFn, binPath }
  * @param {{ name: string, path: string }} repo
- * @returns {Promise<{ name: string, path: string, repoMemory: object }>}
+ * @returns {Promise<object>} a `RepoMemoryStatusSchema`-shaped object.
  */
-async function surveyRepo(ctx, repo) {
+async function surveyRepoMemory(ctx, repo) {
   const { readFn, statFn, execFn, binPath } = ctx
 
   let configText = null
@@ -354,11 +711,7 @@ async function surveyRepo(ctx, repo) {
 
   if (configText === null) {
     // Quiet "not configured" row — absence is signal, not an error.
-    return {
-      name: repo.name,
-      path: repo.path,
-      repoMemory: { configured: false, summarizer: null, toolGroups: [], cache: null, report: null, reason: null },
-    }
+    return { configured: false, summarizer: null, toolGroups: [], cache: null, report: null, reason: null }
   }
 
   const config = parseRepoMemoryConfig(configText)
@@ -379,17 +732,29 @@ async function surveyRepo(ctx, repo) {
   }
 
   return {
-    name: repo.name,
-    path: repo.path,
-    repoMemory: {
-      configured: true,
-      summarizer: config ? config.summarizer : null,
-      toolGroups: config ? config.toolGroups : [],
-      cache,
-      report,
-      reason,
-    },
+    configured: true,
+    summarizer: config ? config.summarizer : null,
+    toolGroups: config ? config.toolGroups : [],
+    cache,
+    report,
+    reason,
   }
+}
+
+/**
+ * Survey one repo's integration status: the repo-memory block (#5499) and the
+ * repo-relay block (#5501), probed concurrently — they share no state.
+ *
+ * @param {object} ctx - { readFn, statFn, execFn, binPath, ghPath, getLatestRelease }
+ * @param {{ name: string, path: string }} repo
+ * @returns {Promise<{ name: string, path: string, repoMemory: object, repoRelay: object }>}
+ */
+async function surveyRepo(ctx, repo) {
+  const [repoMemory, repoRelay] = await Promise.all([
+    surveyRepoMemory(ctx, repo),
+    surveyRepoRelay(ctx, repo),
+  ])
+  return { name: repo.name, path: repo.path, repoMemory, repoRelay }
 }
 
 /**
@@ -422,10 +787,26 @@ export async function surveyIntegrations(repoSet, opts = {}) {
   const now = _now()
   const repos = Array.isArray(repoSet) ? repoSet.filter(r => r && typeof r.path === 'string') : []
 
-  // One binary probe per snapshot — never one per repo.
-  const binPath = await resolveRepoMemoryBin(_execFile, bin)
+  // One binary probe per snapshot — never one per repo. The gh probe (#5501)
+  // follows the same rule.
+  const [binPath, ghPath] = await Promise.all([
+    resolveRepoMemoryBin(_execFile, bin),
+    probeBinOnPath(_execFile, 'gh'),
+  ])
 
-  const ctx = { readFn: _readFile, statFn: _stat, execFn: _execFile, binPath }
+  // #5501: the upstream releases/latest lookup is repo-independent — memoise
+  // the promise so the first installed repo triggers it and every other repo
+  // shares the result (exactly ONE call per snapshot; the module cache then
+  // spans snapshots). Never created when no repo has the workflow installed.
+  let latestReleasePromise = null
+  const getLatestRelease = () => {
+    if (!latestReleasePromise) {
+      latestReleasePromise = fetchLatestRelayRelease(_execFile, ghPath, now.getTime())
+    }
+    return latestReleasePromise
+  }
+
+  const ctx = { readFn: _readFile, statFn: _stat, execFn: _execFile, binPath, ghPath, getLatestRelease }
   const tasks = repos.map(repo => () => surveyRepo(ctx, repo))
   const surveyed = await mapWithCap(tasks, concurrency)
 
@@ -438,6 +819,11 @@ export async function surveyIntegrations(repoSet, opts = {}) {
       found: binPath !== null,
       path: binPath,
       note: binPath !== null ? null : CLI_MISSING_NOTE,
+    },
+    ghCli: {
+      found: ghPath !== null,
+      path: ghPath,
+      note: ghPath !== null ? null : GH_MISSING_NOTE,
     },
   }
 }

--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -165,23 +165,26 @@ export function parseOpenPRs(json) {
 }
 
 /**
- * Derive a repo's GitHub pull-requests URL from its `origin` remote URL.
+ * Derive a repo's GitHub `{ owner, repo }` from its `origin` remote URL.
  *
  * Handles the three forms `git remote get-url origin` can return for a GitHub
  * remote — SCP-style SSH (`git@github.com:owner/repo.git`), `ssh://` URLs, and
- * `https://` URLs — with or without a trailing `.git`. Returns
- * `https://github.com/<owner>/<repo>/pulls`, or `null` for a non-GitHub remote,
- * an empty/failed lookup, or anything that doesn't match.
+ * `https://` URLs — with or without a trailing `.git`. Returns null for a
+ * non-GitHub remote, an empty/failed lookup, or anything that doesn't match.
+ *
+ * Shared derivation: this survey builds the PR rollup link from it (see
+ * {@link parseGithubPrsUrl}); the Integrations survey (#5501) reuses it to
+ * target `gh run list -R <owner>/<repo>` and the Actions deep link.
  *
  * @param {string|null} remote - raw `git remote get-url origin` stdout.
- * @returns {string|null}
+ * @returns {{ owner: string, repo: string }|null}
  */
-export function parseGithubPrsUrl(remote) {
+export function parseGithubOwnerRepo(remote) {
   if (!remote || typeof remote !== 'string') return null
   const trimmed = remote.trim()
   // owner + repo are each a single path segment ([^/]+) so an extra segment
   // (e.g. `owner/repo/extra`) does NOT match (returns null rather than minting
-  // a bogus `.../pulls`). The ssh URL form allows an optional port (e.g. the
+  // a bogus target). The ssh URL form allows an optional port (e.g. the
   // common ssh-over-:443 remote).
   const patterns = [
     /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/, // scp-style ssh
@@ -190,9 +193,22 @@ export function parseGithubPrsUrl(remote) {
   ]
   for (const re of patterns) {
     const m = re.exec(trimmed)
-    if (m) return `https://github.com/${m[1]}/${m[2]}/pulls`
+    if (m) return { owner: m[1], repo: m[2] }
   }
   return null
+}
+
+/**
+ * Derive a repo's GitHub pull-requests URL from its `origin` remote URL —
+ * `https://github.com/<owner>/<repo>/pulls`, or null when the remote isn't a
+ * recognisable GitHub repo (see {@link parseGithubOwnerRepo}).
+ *
+ * @param {string|null} remote - raw `git remote get-url origin` stdout.
+ * @returns {string|null}
+ */
+export function parseGithubPrsUrl(remote) {
+  const target = parseGithubOwnerRepo(remote)
+  return target ? `https://github.com/${target.owner}/${target.repo}/pulls` : null
 }
 
 /**

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -254,8 +254,8 @@ function integrationErrorSnapshot(root, requestId, error) {
 }
 
 /**
- * #5499 (epic #5498) — Integrations survey handler (repo-memory observability
- * for this slice). Same authority + in-flight + degraded-reply contract as
+ * #5499/#5501 (epic #5498) — Integrations survey handler (repo-memory and
+ * repo-relay observability). Same authority + in-flight + degraded-reply contract as
  * `handleHostStatusRequest`: the survey exposes host-wide per-repo metadata,
  * so it is served only to host-level (unbound) clients, one survey per client
  * at a time. The repo set is the same one the host survey resolves
@@ -310,6 +310,8 @@ async function handleIntegrationStatusRequest(ws, client, msg, ctx) {
       summary: snapshot.summary,
       repos: snapshot.repos,
       repoMemoryCli: snapshot.repoMemoryCli,
+      // #5501: snapshot-level gh CLI note for the repo-relay columns.
+      ghCli: snapshot.ghCli,
     })
   } catch (err) {
     log.warn(`integration_status_request failed: ${err && err.message ? err.message : 'unknown error'}`)

--- a/packages/server/tests/control-room-handlers.test.js
+++ b/packages/server/tests/control-room-handlers.test.js
@@ -429,6 +429,8 @@ const SAMPLE_INTEGRATION_SNAPSHOT = {
     },
   ],
   repoMemoryCli: { found: true, path: '/usr/local/bin/repo-memory', note: null },
+  // #5501: snapshot-level gh CLI note for the repo-relay columns.
+  ghCli: { found: true, path: '/usr/local/bin/gh', note: null },
 }
 
 function makeIntegrationCtx(overrides = {}) {
@@ -468,6 +470,8 @@ describe('integration_status_request handler (#5499)', () => {
     assert.equal(payload.repos.length, 2)
     assert.equal(payload.summary.configured, 1)
     assert.equal(payload.repoMemoryCli.found, true)
+    // #5501: the gh CLI note passes through to the snapshot.
+    assert.equal(payload.ghCli.found, true)
   })
 
   it('resolves the repo set from config.repos + controlRoomRoot and passes the root to the survey', async () => {

--- a/packages/server/tests/control-room-integrations.test.js
+++ b/packages/server/tests/control-room-integrations.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test'
+import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   parseRepoMemoryConfig,
@@ -6,6 +6,16 @@ import {
   resolveRepoMemoryBin,
   surveyIntegrations,
   CLI_MISSING_NOTE,
+  // #5501: repo-relay observability.
+  parseRelayPin,
+  parseRelayRuns,
+  compareVersions,
+  computeRelayFailureStreak,
+  classifyRelay,
+  GH_MISSING_NOTE,
+  NO_GITHUB_REMOTE_REASON,
+  RELAY_RELEASE_CACHE_TTL_MS,
+  _clearRelayReleaseCache,
 } from '../src/control-room/integrations.js'
 import { validateConfig } from '../src/config.js'
 import { ServerIntegrationStatusSnapshotSchema } from '@chroxy/protocol'
@@ -153,7 +163,17 @@ function makeWorld({ files = {}, stats = {}, exec } = {}) {
       _execFile: async (file, args, o) => {
         execCalls.push([file, args])
         if (exec) return exec(file, args, o)
-        if (file === 'which') return { stdout: '/usr/local/bin/repo-memory\n' }
+        if (file === 'which') {
+          if (args[0] === 'repo-memory') return { stdout: '/usr/local/bin/repo-memory\n' }
+          if (args[0] === 'gh') return { stdout: '/usr/local/bin/gh\n' }
+          throw new Error(`which: no ${args[0]}`)
+        }
+        if (file === 'git') return { stdout: 'git@github.com:blamechris/chroxy.git\n' }
+        if (file === '/usr/local/bin/gh') {
+          if (args[0] === 'api') return { stdout: JSON.stringify({ tag_name: 'v1.1.0' }) }
+          if (args[0] === 'run') return { stdout: '[]' }
+          throw new Error(`unexpected gh invocation: ${args.join(' ')}`)
+        }
         return { stdout: SAMPLE_REPORT_JSON }
       },
       _now: () => new Date('2026-06-10T12:00:00.000Z'),
@@ -187,7 +207,10 @@ describe('surveyIntegrations (#5499)', () => {
 
     assert.equal(snapshot.generatedAt, '2026-06-10T12:00:00.000Z')
     assert.equal(snapshot.root, '/home/user/Projects')
-    assert.deepEqual(snapshot.summary, { total: 2, configured: 1, notConfigured: 1, degraded: 0 })
+    assert.deepEqual(snapshot.summary, {
+      total: 2, configured: 1, notConfigured: 1, degraded: 0,
+      relayInstalled: 0, relayFailing: 0, relayDrifted: 0,
+    })
 
     const [a, b] = snapshot.repos
     assert.equal(a.name, 'chroxy')
@@ -221,8 +244,11 @@ describe('surveyIntegrations (#5499)', () => {
       { name: 'b', path: '/home/user/Projects/b' },
       { name: 'c', path: '/home/user/Projects/c' },
     ], manyConfigured.opts)
-    const whichCalls = manyConfigured.execCalls.filter(([file]) => file === 'which')
+    const whichCalls = manyConfigured.execCalls.filter(([file, args]) => file === 'which' && args[0] === 'repo-memory')
     assert.equal(whichCalls.length, 1, 'exactly one binary probe per snapshot')
+    // #5501: the gh probe is also once-per-snapshot.
+    const ghProbes = manyConfigured.execCalls.filter(([file, args]) => file === 'which' && args[0] === 'gh')
+    assert.equal(ghProbes.length, 1, 'exactly one gh probe per snapshot')
     void world
   })
 
@@ -256,7 +282,10 @@ describe('surveyIntegrations (#5499)', () => {
     // The unconfigured repo stays a quiet row (no reason).
     assert.equal(b.repoMemory.reason, null)
 
-    assert.deepEqual(snapshot.summary, { total: 2, configured: 1, notConfigured: 1, degraded: 1 })
+    assert.deepEqual(snapshot.summary, {
+      total: 2, configured: 1, notConfigured: 1, degraded: 1,
+      relayInstalled: 0, relayFailing: 0, relayDrifted: 0,
+    })
 
     const parsed = ServerIntegrationStatusSnapshotSchema.safeParse({ type: 'integration_status_snapshot', ...snapshot })
     assert.ok(parsed.success, JSON.stringify(parsed.error?.issues))
@@ -330,18 +359,497 @@ describe('surveyIntegrations (#5499)', () => {
   it('uses the explicit bin override without probing the PATH', async () => {
     const world = configuredWorld()
     const snapshot = await surveyIntegrations([REPO_A], { ...world.opts, bin: '/opt/custom/repo-memory' })
-    assert.equal(world.execCalls.filter(([file]) => file === 'which').length, 0)
+    assert.equal(world.execCalls.filter(([file, args]) => file === 'which' && args[0] === 'repo-memory').length, 0)
     assert.equal(snapshot.repoMemoryCli.path, '/opt/custom/repo-memory')
-    assert.equal(world.execCalls[0][0], '/opt/custom/repo-memory')
+    assert.ok(world.execCalls.some(([file]) => file === '/opt/custom/repo-memory'))
   })
 
   it('an empty repo set is a valid empty snapshot', async () => {
     const world = makeWorld()
     const snapshot = await surveyIntegrations([], world.opts)
     assert.deepEqual(snapshot.repos, [])
-    assert.deepEqual(snapshot.summary, { total: 0, configured: 0, notConfigured: 0, degraded: 0 })
+    assert.deepEqual(snapshot.summary, {
+      total: 0, configured: 0, notConfigured: 0, degraded: 0,
+      relayInstalled: 0, relayFailing: 0, relayDrifted: 0,
+    })
     const parsed = ServerIntegrationStatusSnapshotSchema.safeParse({ type: 'integration_status_snapshot', ...snapshot })
     assert.ok(parsed.success, JSON.stringify(parsed.error?.issues))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5501 — repo-relay observability: pure helpers.
+// ---------------------------------------------------------------------------
+
+// Chroxy's own live workflow form: sha-pinned with a version comment.
+const USES_SHA_COMMENT = '      - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875 # v1.1.0'
+
+function workflowWith(usesLine) {
+  return [
+    'name: Repo Relay',
+    'on:',
+    '  pull_request:',
+    'jobs:',
+    '  notify:',
+    '    runs-on: ubuntu-latest',
+    '    steps:',
+    '      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4',
+    usesLine,
+    '        with:',
+    '          discord_bot_token: x',
+    '',
+  ].join('\n')
+}
+
+describe('parseRelayPin (#5501)', () => {
+  it('parses a tag pin', () => {
+    assert.deepEqual(
+      parseRelayPin(workflowWith('      - uses: blamechris/repo-relay@v1.1.0')),
+      { ref: 'v1.1.0', sha: null, version: 'v1.1.0' },
+    )
+  })
+
+  it('parses a sha pin with a version comment (chroxy live form)', () => {
+    assert.deepEqual(parseRelayPin(workflowWith(USES_SHA_COMMENT)), {
+      ref: 'f08840b9c336b50f6aef8d6e157d8f7e705fa875',
+      sha: 'f08840b9c336b50f6aef8d6e157d8f7e705fa875',
+      version: 'v1.1.0',
+    })
+  })
+
+  it('parses a bare sha pin (no comment) with version null', () => {
+    assert.deepEqual(
+      parseRelayPin(workflowWith('      - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875')),
+      { ref: 'f08840b9c336b50f6aef8d6e157d8f7e705fa875', sha: 'f08840b9c336b50f6aef8d6e157d8f7e705fa875', version: null },
+    )
+  })
+
+  it('a branch pin yields neither sha nor version', () => {
+    assert.deepEqual(
+      parseRelayPin(workflowWith('      - uses: blamechris/repo-relay@main')),
+      { ref: 'main', sha: null, version: null },
+    )
+  })
+
+  it('tolerates quotes around the uses value', () => {
+    const pin = parseRelayPin(workflowWith("      - uses: 'blamechris/repo-relay@v1.0.2'"))
+    assert.deepEqual(pin, { ref: 'v1.0.2', sha: null, version: 'v1.0.2' })
+  })
+
+  it('does not match the cache action pin (other uses lines)', () => {
+    const pin = parseRelayPin(workflowWith('      - uses: blamechris/repo-relay@v1.1.0'))
+    assert.equal(pin.ref, 'v1.1.0')
+  })
+
+  it('returns null when there is no repo-relay uses line / empty input', () => {
+    assert.equal(parseRelayPin(workflowWith('      - uses: actions/checkout@v4')), null)
+    assert.equal(parseRelayPin(''), null)
+    assert.equal(parseRelayPin(null), null)
+  })
+})
+
+describe('compareVersions (#5501)', () => {
+  it('orders semver tags, with or without the v prefix', () => {
+    assert.equal(compareVersions('v1.0.0', 'v1.1.0'), -1)
+    assert.equal(compareVersions('v1.1.0', 'v1.0.9'), 1)
+    assert.equal(compareVersions('1.1.0', 'v1.1.0'), 0)
+    assert.equal(compareVersions('v1.1', 'v1.1.0'), 0)
+    assert.equal(compareVersions('v2.0.0', 'v10.0.0'), -1)
+  })
+
+  it('returns null for unparseable versions', () => {
+    assert.equal(compareVersions('main', 'v1.1.0'), null)
+    assert.equal(compareVersions('v1.1.0', null), null)
+  })
+})
+
+describe('parseRelayRuns (#5501)', () => {
+  it('parses gh run list JSON into the protocol run shape (createdAt normalised to ISO)', () => {
+    const runs = parseRelayRuns(JSON.stringify([
+      { status: 'completed', conclusion: 'success', event: 'pull_request', createdAt: '2026-06-09T22:00:00Z', databaseId: 123 },
+      { status: 'in_progress', conclusion: null, event: 'issues', createdAt: '2026-06-09T21:00:00Z', databaseId: 122 },
+    ]))
+    assert.deepEqual(runs, [
+      { databaseId: 123, status: 'completed', conclusion: 'success', event: 'pull_request', createdAt: '2026-06-09T22:00:00.000Z' },
+      { databaseId: 122, status: 'in_progress', conclusion: null, event: 'issues', createdAt: '2026-06-09T21:00:00.000Z' },
+    ])
+  })
+
+  it('drops entries without a numeric databaseId', () => {
+    const runs = parseRelayRuns(JSON.stringify([{ status: 'completed' }, { databaseId: 5 }]))
+    assert.deepEqual(runs, [{ databaseId: 5, status: null, conclusion: null, event: null, createdAt: null }])
+  })
+
+  it('returns null for absent / unparseable / non-array output', () => {
+    assert.equal(parseRelayRuns(null), null)
+    assert.equal(parseRelayRuns('boom'), null)
+    assert.equal(parseRelayRuns('{}'), null)
+  })
+})
+
+describe('computeRelayFailureStreak (#5501)', () => {
+  const run = (conclusion) => ({ databaseId: 1, status: 'completed', conclusion, event: null, createdAt: null })
+
+  it('counts consecutive failures from the most recent run backwards', () => {
+    assert.equal(computeRelayFailureStreak([run('failure'), run('failure'), run('success')]), 2)
+  })
+
+  it('a leading success means streak 0', () => {
+    assert.equal(computeRelayFailureStreak([run('success'), run('failure')]), 0)
+  })
+
+  it('skips in-progress (unconcluded) runs without breaking the streak', () => {
+    assert.equal(computeRelayFailureStreak([run(null), run('failure'), run('failure')]), 2)
+  })
+
+  it('a non-failure conclusion (cancelled) breaks the streak', () => {
+    assert.equal(computeRelayFailureStreak([run('failure'), run('cancelled'), run('failure')]), 1)
+  })
+
+  it('empty / missing runs → 0', () => {
+    assert.equal(computeRelayFailureStreak([]), 0)
+    assert.equal(computeRelayFailureStreak(null), 0)
+  })
+})
+
+describe('classifyRelay (#5501)', () => {
+  const run = (conclusion) => ({ databaseId: 1, status: 'completed', conclusion, event: null, createdAt: null })
+
+  it('not installed wins everything', () => {
+    assert.equal(classifyRelay({ installed: false, pinnedVersion: 'v1.0.0', latestVersion: 'v1.1.0', runs: [run('failure')] }), 'not_installed')
+  })
+
+  it('latest concluded run failed → failing (wins over drift)', () => {
+    assert.equal(classifyRelay({ installed: true, pinnedVersion: 'v1.0.0', latestVersion: 'v1.1.0', runs: [run('failure')] }), 'failing')
+  })
+
+  it('skips an in-progress run when finding the latest concluded one', () => {
+    assert.equal(classifyRelay({ installed: true, pinnedVersion: 'v1.1.0', latestVersion: 'v1.1.0', runs: [run(null), run('failure')] }), 'failing')
+  })
+
+  it('pinned < latest → drifted (wins over ok)', () => {
+    assert.equal(classifyRelay({ installed: true, pinnedVersion: 'v1.0.0', latestVersion: 'v1.1.0', runs: [run('success')] }), 'drifted')
+  })
+
+  it('latest concluded run success, no drift → ok', () => {
+    assert.equal(classifyRelay({ installed: true, pinnedVersion: 'v1.1.0', latestVersion: 'v1.1.0', runs: [run('success')] }), 'ok')
+  })
+
+  it('unresolvable pin cannot drift — falls through to the runs verdict', () => {
+    assert.equal(classifyRelay({ installed: true, pinnedVersion: null, latestVersion: 'v1.1.0', runs: [run('success')] }), 'ok')
+  })
+
+  it('no concluded runs and no drift signal → unknown', () => {
+    assert.equal(classifyRelay({ installed: true, pinnedVersion: 'v1.1.0', latestVersion: 'v1.1.0', runs: [] }), 'unknown')
+    assert.equal(classifyRelay({ installed: true, pinnedVersion: null, latestVersion: null, runs: [run(null)] }), 'unknown')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5501 — surveyIntegrations: repoRelay block with injected gh fakes.
+// ---------------------------------------------------------------------------
+
+const RUNS_OK = [
+  { status: 'completed', conclusion: 'success', event: 'pull_request', createdAt: '2026-06-10T11:00:00Z', databaseId: 9001 },
+  { status: 'completed', conclusion: 'success', event: 'issues', createdAt: '2026-06-10T10:00:00Z', databaseId: 9000 },
+]
+const RUNS_FAILING = [
+  { status: 'completed', conclusion: 'failure', event: 'pull_request', createdAt: '2026-06-10T11:00:00Z', databaseId: 9003 },
+  { status: 'completed', conclusion: 'failure', event: 'issues', createdAt: '2026-06-10T10:00:00Z', databaseId: 9002 },
+  { status: 'completed', conclusion: 'success', event: 'release', createdAt: '2026-06-10T09:00:00Z', databaseId: 9001 },
+]
+
+const WORKFLOW_PATH = '/home/user/Projects/chroxy/.github/workflows/repo-relay.yml'
+
+/**
+ * Injected-exec world for relay tests: configurable workflow file, git remote,
+ * `gh run list` runs, and `gh api releases/latest` payload.
+ */
+function relayWorld({
+  usesLine = '      - uses: blamechris/repo-relay@v1.1.0',
+  files = {},
+  remote = 'git@github.com:blamechris/chroxy.git\n',
+  runsJson = JSON.stringify(RUNS_OK),
+  latestJson = JSON.stringify({ tag_name: 'v1.1.0' }),
+  ghFound = true,
+  onExec,
+} = {}) {
+  const worldFiles = usesLine === null ? { ...files } : { [WORKFLOW_PATH]: workflowWith(usesLine), ...files }
+  return makeWorld({
+    files: worldFiles,
+    exec: async (file, args) => {
+      if (onExec) {
+        const handled = onExec(file, args)
+        if (handled !== undefined) return handled
+      }
+      if (file === 'which') {
+        if (args[0] === 'gh') {
+          if (!ghFound) throw new Error('which: no gh')
+          return { stdout: '/usr/local/bin/gh\n' }
+        }
+        if (args[0] === 'repo-memory') throw new Error('which: no repo-memory')
+        throw new Error(`which: no ${args[0]}`)
+      }
+      if (file === 'git' && args[0] === 'remote') {
+        if (remote === null) throw new Error('fatal: no such remote')
+        return { stdout: remote }
+      }
+      if (file === '/usr/local/bin/gh') {
+        if (args[0] === 'api') return { stdout: latestJson }
+        if (args[0] === 'run') return { stdout: runsJson }
+      }
+      throw new Error(`unexpected exec: ${file} ${args.join(' ')}`)
+    },
+  })
+}
+
+describe('surveyIntegrations repoRelay (#5501)', () => {
+  beforeEach(() => _clearRelayReleaseCache())
+
+  it('installed + latest run success + up-to-date pin → ok, schema-conformant', async () => {
+    const world = relayWorld()
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+
+    const parsed = ServerIntegrationStatusSnapshotSchema.safeParse({ type: 'integration_status_snapshot', ...snapshot })
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues))
+
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.installed, true)
+    assert.equal(relay.verdict, 'ok')
+    assert.equal(relay.pinnedVersion, 'v1.1.0')
+    assert.equal(relay.pinnedSha, null)
+    assert.equal(relay.latestVersion, 'v1.1.0')
+    assert.equal(relay.failureStreak, 0)
+    assert.equal(relay.driftUnknown, false)
+    assert.equal(relay.reason, null)
+    assert.equal(relay.workflowUrl, 'https://github.com/blamechris/chroxy/actions/workflows/repo-relay.yml')
+    // Run ids + conclusions ride along for #5502's rerun action.
+    assert.deepEqual(relay.runs.map(r => [r.databaseId, r.conclusion]), [[9001, 'success'], [9000, 'success']])
+    assert.equal(relay.runs[0].createdAt, '2026-06-10T11:00:00.000Z')
+
+    assert.deepEqual(snapshot.ghCli, { found: true, path: '/usr/local/bin/gh', note: null })
+    assert.equal(snapshot.summary.relayInstalled, 1)
+    assert.equal(snapshot.summary.relayFailing, 0)
+    assert.equal(snapshot.summary.relayDrifted, 0)
+  })
+
+  it('asks gh for the right run list (workflow, -R owner/repo from the git remote, limit 5)', async () => {
+    const world = relayWorld()
+    await surveyIntegrations([REPO_A], world.opts)
+    const runCall = world.execCalls.find(([file, args]) => file === '/usr/local/bin/gh' && args[0] === 'run')
+    assert.deepEqual(runCall[1], [
+      'run', 'list', '--workflow=repo-relay.yml', '-R', 'blamechris/chroxy',
+      '--limit', '5', '--json', 'status,conclusion,event,createdAt,databaseId',
+    ])
+  })
+
+  it('latest concluded run failed → failing, with the failure streak counted', async () => {
+    const world = relayWorld({ runsJson: JSON.stringify(RUNS_FAILING), latestJson: JSON.stringify({ tag_name: 'v1.2.0' }) })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    // failing wins over the simultaneous drift (v1.1.0 < v1.2.0).
+    assert.equal(relay.verdict, 'failing')
+    assert.equal(relay.failureStreak, 2)
+    assert.equal(snapshot.summary.relayFailing, 1)
+  })
+
+  it('tag pin behind the latest release → drifted', async () => {
+    const world = relayWorld({
+      usesLine: '      - uses: blamechris/repo-relay@v1.0.0',
+      latestJson: JSON.stringify({ tag_name: 'v1.1.0' }),
+    })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.verdict, 'drifted')
+    assert.equal(relay.pinnedVersion, 'v1.0.0')
+    assert.equal(relay.latestVersion, 'v1.1.0')
+    assert.equal(snapshot.summary.relayDrifted, 1)
+  })
+
+  it('sha pin resolves drift via its version comment (chroxy live form)', async () => {
+    const world = relayWorld({ usesLine: USES_SHA_COMMENT, latestJson: JSON.stringify({ tag_name: 'v1.2.0' }) })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.pinnedSha, 'f08840b9c336b50f6aef8d6e157d8f7e705fa875')
+    assert.equal(relay.pinnedVersion, 'v1.1.0')
+    assert.equal(relay.verdict, 'drifted')
+    assert.equal(relay.driftUnknown, false)
+  })
+
+  it('bare sha pin (no comment) → driftUnknown, never drifted', async () => {
+    const world = relayWorld({
+      usesLine: '      - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875',
+      latestJson: JSON.stringify({ tag_name: 'v9.9.9' }),
+    })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.pinnedVersion, null)
+    assert.equal(relay.driftUnknown, true)
+    assert.equal(relay.verdict, 'ok', 'runs are green — drift simply cannot be assessed')
+  })
+
+  it('no workflow file → quiet installed:false row, no gh calls for that repo', async () => {
+    const world = relayWorld({ usesLine: null })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.deepEqual(relay, {
+      installed: false,
+      pinnedVersion: null,
+      pinnedSha: null,
+      latestVersion: null,
+      runs: [],
+      failureStreak: 0,
+      verdict: 'not_installed',
+      driftUnknown: false,
+      workflowUrl: null,
+      reason: null,
+    })
+    assert.equal(world.execCalls.filter(([file]) => file === '/usr/local/bin/gh').length, 0)
+    assert.equal(snapshot.summary.relayInstalled, 0)
+  })
+
+  it('makes exactly ONE releases/latest call regardless of installed repo count', async () => {
+    const world = makeWorld({
+      files: {
+        '/home/user/Projects/a/.github/workflows/repo-relay.yml': workflowWith('      - uses: blamechris/repo-relay@v1.1.0'),
+        '/home/user/Projects/b/.github/workflows/repo-relay.yml': workflowWith('      - uses: blamechris/repo-relay@v1.0.0'),
+        '/home/user/Projects/c/.github/workflows/repo-relay.yml': workflowWith(USES_SHA_COMMENT),
+      },
+      exec: async (file, args) => {
+        if (file === 'which' && args[0] === 'gh') return { stdout: '/usr/local/bin/gh\n' }
+        if (file === 'which') throw new Error('not found')
+        if (file === 'git') return { stdout: 'git@github.com:blamechris/x.git\n' }
+        if (file === '/usr/local/bin/gh' && args[0] === 'api') return { stdout: JSON.stringify({ tag_name: 'v1.1.0' }) }
+        if (file === '/usr/local/bin/gh' && args[0] === 'run') return { stdout: JSON.stringify(RUNS_OK) }
+        throw new Error(`unexpected exec: ${file}`)
+      },
+    })
+    await surveyIntegrations([
+      { name: 'a', path: '/home/user/Projects/a' },
+      { name: 'b', path: '/home/user/Projects/b' },
+      { name: 'c', path: '/home/user/Projects/c' },
+    ], world.opts)
+    const apiCalls = world.execCalls.filter(([file, args]) => file === '/usr/local/bin/gh' && args[0] === 'api')
+    assert.equal(apiCalls.length, 1, 'exactly one releases/latest call per snapshot')
+    assert.deepEqual(apiCalls[0][1], ['api', 'repos/blamechris/repo-relay/releases/latest'])
+  })
+
+  it('caches the latest release across snapshots within the TTL, refetches after it', async () => {
+    const t0 = Date.parse('2026-06-10T12:00:00.000Z')
+    const makeAt = (ms) => {
+      const world = relayWorld()
+      world.opts._now = () => new Date(ms)
+      return world
+    }
+
+    const first = makeAt(t0)
+    await surveyIntegrations([REPO_A], first.opts)
+    assert.equal(first.execCalls.filter(([f, a]) => f === '/usr/local/bin/gh' && a[0] === 'api').length, 1)
+
+    // Second snapshot inside the TTL: served from the module cache, no call.
+    const second = makeAt(t0 + RELAY_RELEASE_CACHE_TTL_MS - 1)
+    const snapshot = await surveyIntegrations([REPO_A], second.opts)
+    assert.equal(second.execCalls.filter(([f, a]) => f === '/usr/local/bin/gh' && a[0] === 'api').length, 0)
+    assert.equal(snapshot.repos[0].repoRelay.latestVersion, 'v1.1.0')
+
+    // Past the TTL: a fresh call.
+    const third = makeAt(t0 + RELAY_RELEASE_CACHE_TTL_MS + 1)
+    await surveyIntegrations([REPO_A], third.opts)
+    assert.equal(third.execCalls.filter(([f, a]) => f === '/usr/local/bin/gh' && a[0] === 'api').length, 1)
+  })
+
+  it('gh missing → relay cells degrade with a reason, snapshot still returns', async () => {
+    const world = relayWorld({ ghFound: false })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.installed, true, 'installed is answered from the filesystem')
+    assert.equal(relay.pinnedVersion, 'v1.1.0', 'the pin is answered from the filesystem')
+    assert.equal(relay.latestVersion, null)
+    assert.deepEqual(relay.runs, [])
+    assert.equal(relay.reason, GH_MISSING_NOTE)
+    assert.equal(relay.verdict, 'unknown')
+    assert.deepEqual(snapshot.ghCli, { found: false, path: null, note: GH_MISSING_NOTE })
+
+    const parsed = ServerIntegrationStatusSnapshotSchema.safeParse({ type: 'integration_status_snapshot', ...snapshot })
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues))
+  })
+
+  it('rate-limited releases/latest degrades with the stderr reason; runs still populate', async () => {
+    const world = relayWorld({
+      onExec: (file, args) => {
+        if (file === '/usr/local/bin/gh' && args[0] === 'api') {
+          throw Object.assign(new Error('gh: HTTP 403'), { stderr: 'API rate limit exceeded for user\n' })
+        }
+        return undefined
+      },
+    })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.latestVersion, null)
+    assert.match(relay.reason, /rate limit/)
+    // Runs were fetched fine — the verdict still reflects them.
+    assert.equal(relay.verdict, 'ok')
+    assert.equal(relay.runs.length, 2)
+  })
+
+  it('a rate-limited (failed) latest fetch is NOT cached — the next snapshot retries', async () => {
+    let fail = true
+    const world = relayWorld({
+      onExec: (file, args) => {
+        if (file === '/usr/local/bin/gh' && args[0] === 'api' && fail) {
+          throw Object.assign(new Error('gh: HTTP 403'), { stderr: 'API rate limit exceeded\n' })
+        }
+        return undefined
+      },
+    })
+    await surveyIntegrations([REPO_A], world.opts)
+    fail = false
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    assert.equal(snapshot.repos[0].repoRelay.latestVersion, 'v1.1.0')
+  })
+
+  it('a failed run list degrades that repo with a reason; the snapshot survives', async () => {
+    const world = relayWorld({
+      onExec: (file, args) => {
+        if (file === '/usr/local/bin/gh' && args[0] === 'run') {
+          throw Object.assign(new Error('gh: network'), { stderr: 'error connecting to api.github.com\n' })
+        }
+        return undefined
+      },
+    })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.deepEqual(relay.runs, [])
+    assert.match(relay.reason, /api\.github\.com/)
+    assert.equal(relay.verdict, 'unknown')
+  })
+
+  it('no GitHub remote → installed from the filesystem, run cells degrade, drift still assessable', async () => {
+    const world = relayWorld({
+      usesLine: '      - uses: blamechris/repo-relay@v1.0.0',
+      remote: null,
+      latestJson: JSON.stringify({ tag_name: 'v1.1.0' }),
+    })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.installed, true)
+    assert.deepEqual(relay.runs, [])
+    assert.equal(relay.workflowUrl, null)
+    assert.equal(relay.reason, NO_GITHUB_REMOTE_REASON)
+    // Pin (filesystem) + latest (repo-independent) are both known → drift holds.
+    assert.equal(relay.verdict, 'drifted')
+    assert.equal(world.execCalls.filter(([f, a]) => f === '/usr/local/bin/gh' && a[0] === 'run').length, 0)
+  })
+
+  it('an unparseable uses pin degrades with a reason and driftUnknown', async () => {
+    const world = relayWorld({ usesLine: '      - uses: actions/checkout@v4' })
+    const snapshot = await surveyIntegrations([REPO_A], world.opts)
+    const relay = snapshot.repos[0].repoRelay
+    assert.equal(relay.installed, true)
+    assert.equal(relay.pinnedVersion, null)
+    assert.equal(relay.pinnedSha, null)
+    assert.equal(relay.driftUnknown, true)
+    assert.match(relay.reason, /uses pin/)
   })
 })
 

--- a/packages/server/tests/control-room-survey.test.js
+++ b/packages/server/tests/control-room-survey.test.js
@@ -24,6 +24,7 @@ import {
   countWorktrees,
   parseOpenPRs,
   parsePrChecks,
+  parseGithubOwnerRepo,
   parseGithubPrsUrl,
   parseAheadBehind,
   detectAttribution,
@@ -177,6 +178,19 @@ describe('parsePrChecks', () => {
   it('a PR with no checks counts as neither failing nor pending', () => {
     const json = JSON.stringify([pr({ statusCheckRollup: [] })])
     assert.deepEqual(parsePrChecks(json), { failing: 0, pending: 0, approved: 0, changesRequested: 0 })
+  })
+})
+
+describe('parseGithubOwnerRepo (#5501 shared derivation)', () => {
+  it('derives { owner, repo } from the three GitHub remote forms', () => {
+    assert.deepEqual(parseGithubOwnerRepo('git@github.com:owner/repo.git'), { owner: 'owner', repo: 'repo' })
+    assert.deepEqual(parseGithubOwnerRepo('https://github.com/owner/repo'), { owner: 'owner', repo: 'repo' })
+    assert.deepEqual(parseGithubOwnerRepo('ssh://git@github.com:443/owner/repo.git'), { owner: 'owner', repo: 'repo' })
+  })
+  it('returns null for non-GitHub / malformed remotes', () => {
+    assert.equal(parseGithubOwnerRepo('git@gitlab.com:owner/repo.git'), null)
+    assert.equal(parseGithubOwnerRepo('git@github.com:owner/repo/extra.git'), null)
+    assert.equal(parseGithubOwnerRepo(null), null)
   })
 })
 


### PR DESCRIPTION
## What

Third slice of the Integrations tab (epic #5498): per surveyed repo, a `repoRelay` block in the `integration_status_snapshot`, rendered as a grouped column family next to repo-memory in the dashboard.

## Verdict semantics

Precedence, most urgent first — a broken relay beats a stale pin beats green:

| Verdict | Condition |
|---|---|
| `not_installed` | no `.github/workflows/repo-relay.yml` in the checkout (quiet row, like unconfigured repo-memory) |
| `failing` | latest **concluded** run failed (in-progress runs are skipped when finding it) — wins over drift |
| `drifted` | pinned version < `releases/latest` of `blamechris/repo-relay` |
| `ok` | latest concluded run succeeded, no drift |
| `unknown` | installed but unassessable (gh missing / rate-limited / no GitHub remote / no concluded runs and no drift signal) — the row's `reason` explains why |

Pin parsing handles both forms: tag-pinned (`@v1.1.0`) and sha-pinned-with-comment (`@f08840b9… # v1.1.0`, chroxy's own workflow being the live example). A bare sha or branch pin can't resolve to a version → `driftUnknown: true` and drift is never claimed. Failure streak counts consecutive failed conclusions from the most recent run backwards (in-progress skipped, any other conclusion breaks it). Run `databaseId`s + conclusions ride along in the snapshot for #5502's rerun action.

## The one-call drift check

`gh api repos/blamechris/repo-relay/releases/latest` runs **exactly once per snapshot** regardless of repo count: the survey memoises the fetch promise, created lazily by the first repo that has the workflow installed, and every other repo awaits the same promise. On top of that a **5-minute module-level cache** spans snapshots, so refresh-spamming the tab never hammers the API. Only successful fetches are cached — a rate-limited/offline attempt degrades that snapshot with a reason and the next refresh retries.

## Degradation (snapshot always returns)

- `gh` is probed once per snapshot (same rule as the repo-memory binary); missing → every installed repo's run/release cells degrade with a reason and the snapshot carries a `ghCli` note (dashboard callout).
- Rate limit / network failure → per-repo `reason` from the first stderr line.
- No GitHub remote → `installed` + the pin still answer from the filesystem, run cells degrade with reason `no GitHub remote`; drift is still assessed since the pin is local and the latest release is repo-independent.
- Owner/repo for `gh run list -R` comes from the repo's git remote via `parseGithubOwnerRepo`, extracted from survey.js's existing `parseGithubPrsUrl` derivation (shared, not reinvented).

## Protocol

Additive only: optional `repoRelay` per repo, optional `relayInstalled`/`relayFailing`/`relayDrifted` summary tallies, optional snapshot-level `ghCli` — pre-#5501 producers/fixtures stay valid. Committed `dist/` rebuilt.

## Dashboard

Two-row grouped header (repo-memory / repo-relay) keeps the 13-column table legible. Relay cells: verdict chip with reason tooltip, `pinned → latest` with amber drift highlight (short sha + drift-unknown tooltip for bare sha pins), last run + age + Actions deep link, failure streak. Summary chips gain the three relay tallies.

## Tests

- server: `control-room-integrations.test.js` 64 pass (injected gh fakes: ok / failing+streak / drifted / sha-pin parse with+without comment / not_installed / single releases/latest call across many repos / cache TTL + failed-fetch-not-cached / gh missing / rate-limited / no remote / unparseable pin), control-room suites 221 pass total
- protocol: 270 pass
- dashboard: `IntegrationsSection.test.tsx` 38 pass, full suite 3358 pass, `tsc --noEmit` clean
- server lint scripts (state-file-path, opt-forwarding, logger-scoping) + eslint clean

Closes #5501.
Related to #5498.