### PR TITLE
feat(control-room): re-run failed repo-relay runs from the Integrations tab

### DIFF
--- a/packages/dashboard/src/components/IntegrationsSection.test.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.test.tsx
@@ -29,6 +29,10 @@ vi.mock('../store/connection', () => ({
       reindexingRepoPaths: new Set<string>(),
       reindexResults: {},
       sendRepoMemoryReindex: () => false,
+      // #5502: relay Re-run action state.
+      relayRerunningRepoPaths: new Set<string>(),
+      relayRerunResults: {},
+      sendRepoRelayRerun: () => false,
     }),
 }))
 import { IntegrationsSection, formatBytes } from './IntegrationsSection'
@@ -498,5 +502,94 @@ describe('IntegrationsSection — repo-relay (#5501)', () => {
   it('renders no gh callout when gh was found', () => {
     renderSection(snapshot({ ghCli: { found: true, path: '/usr/local/bin/gh', note: null } }))
     expect(screen.queryByTestId('integration-gh-note')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5502 — repo-relay Re-run action (+ the upstream-blocked Sync now stub).
+// ---------------------------------------------------------------------------
+
+describe('IntegrationsSection — relay Re-run action (#5502)', () => {
+  const FAILED_LATEST = repoRelay({
+    verdict: 'failing',
+    failureStreak: 1,
+    runs: [
+      { databaseId: 9001, status: 'completed', conclusion: 'failure', event: 'pull_request', createdAt: '2026-06-10T11:00:00.000Z' },
+      { databaseId: 9000, status: 'completed', conclusion: 'success', event: 'issues', createdAt: '2026-06-10T10:00:00.000Z' },
+    ],
+  })
+
+  it('renders a Re-run button only when the latest run concluded failure', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('red', FAILED_LATEST),
+      relayRepo('green', repoRelay()),
+      relayRepo('bare', RELAY_NOT_INSTALLED),
+      // Latest run in progress (no conclusion) — older failure must not arm the button.
+      relayRepo('running', repoRelay({
+        runs: [
+          { databaseId: 9002, status: 'in_progress', conclusion: null, event: 'pull_request', createdAt: '2026-06-10T11:30:00.000Z' },
+          { databaseId: 9001, status: 'completed', conclusion: 'failure', event: 'pull_request', createdAt: '2026-06-10T11:00:00.000Z' },
+        ],
+      })),
+    ]))
+    expect(screen.getByTestId('integration-relay-rerun-red')).toBeTruthy()
+    expect(screen.queryByTestId('integration-relay-rerun-green')).toBeNull()
+    expect(screen.queryByTestId('integration-relay-rerun-bare')).toBeNull()
+    expect(screen.queryByTestId('integration-relay-rerun-running')).toBeNull()
+  })
+
+  it('dispatches onRelayRerun with the repo path and the latest run id', () => {
+    const onRelayRerun = vi.fn()
+    renderSection(oneRepoSnapshot([relayRepo('red', FAILED_LATEST)]), { onRelayRerun })
+    fireEvent.click(screen.getByTestId('integration-relay-rerun-red'))
+    expect(onRelayRerun).toHaveBeenCalledWith('/p/red', 9001)
+  })
+
+  it('shows the pending "Re-running…" state, disabled, and does not re-dispatch', () => {
+    const onRelayRerun = vi.fn()
+    renderSection(oneRepoSnapshot([relayRepo('red', FAILED_LATEST)]), {
+      onRelayRerun,
+      relayRerunningRepoPaths: new Set(['/p/red']),
+    })
+    const btn = screen.getByTestId('integration-relay-rerun-red') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(btn.textContent).toContain('Re-running…')
+    fireEvent.click(btn)
+    expect(onRelayRerun).not.toHaveBeenCalled()
+  })
+
+  it('disables Re-run when disconnected', () => {
+    renderSection(oneRepoSnapshot([relayRepo('red', FAILED_LATEST)]), { connected: false })
+    expect((screen.getByTestId('integration-relay-rerun-red') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('shows the "re-run requested" note (inviting a refresh) after the ack', () => {
+    renderSection(oneRepoSnapshot([relayRepo('red', FAILED_LATEST)]), {
+      relayRerunResults: { '/p/red': { error: null, at: NOW } },
+    })
+    const note = screen.getByTestId('integration-relay-rerun-result-red')
+    expect(note.textContent?.toLowerCase()).toContain('re-run requested')
+    expect(note.textContent?.toLowerCase()).toContain('refresh')
+  })
+
+  it('renders the inline error from an INTEGRATION_ACTION_FAILED reply', () => {
+    renderSection(oneRepoSnapshot([relayRepo('red', FAILED_LATEST)]), {
+      relayRerunResults: { '/p/red': { error: 'run 9001 did not fail (success)', at: NOW } },
+    })
+    expect(screen.getByTestId('integration-relay-rerun-error-red').textContent).toContain('did not fail')
+  })
+
+  it('renders a disabled Sync now stub naming the upstream blocker for installed repos', () => {
+    renderSection(oneRepoSnapshot([
+      relayRepo('red', FAILED_LATEST),
+      relayRepo('green', repoRelay()),
+      relayRepo('bare', RELAY_NOT_INSTALLED),
+    ]))
+    for (const name of ['red', 'green']) {
+      const sync = screen.getByTestId(`integration-relay-syncnow-${name}`) as HTMLButtonElement
+      expect(sync.disabled).toBe(true)
+      expect(sync.getAttribute('title')).toContain('repo-relay#168')
+    }
+    expect(screen.queryByTestId('integration-relay-syncnow-bare')).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/IntegrationsSection.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.tsx
@@ -14,9 +14,11 @@
  *   - repo-relay (#5501): verdict chip (ok / failing / drifted / not
  *     installed / unknown), version pin vs latest release (drift
  *     highlighted; a bare sha pin renders the short sha with a drift-unknown
- *     tooltip), last run conclusion + age with the Actions deep link, and the
- *     failure streak. Degraded cells carry the per-repo `reason` as tooltip;
- *     a repo without the workflow file is a quiet "Not installed" row.
+ *     tooltip), last run conclusion + age with the Actions deep link, the
+ *     failure streak, and the #5502 actions cell (Re-run for a failed latest
+ *     run; the upstream-blocked "Sync now" stub). Degraded cells carry the
+ *     per-repo `reason` as tooltip; a repo without the workflow file is a
+ *     quiet "Not installed" row.
  *
  * #5500 adds the control half: a per-row Reindex button for configured repos
  * that dispatches `integration_action` (repo_memory_reindex) via the store's
@@ -41,7 +43,7 @@
  */
 import { useConnectionStore } from '../store/connection'
 import type { IntegrationRepo, RepoMemoryStatus, RepoRelayStatus, RepoRelayVerdict, ServerIntegrationStatusSnapshotMessage } from '@chroxy/protocol'
-import type { ReindexResult } from '../store/types'
+import type { ReindexResult, RelayRerunResult } from '../store/types'
 import { formatGeneratedAgo } from './ControlRoomSection'
 
 type Accent = 'ok' | 'warn' | 'bad'
@@ -341,20 +343,104 @@ function ReindexCell({
   )
 }
 
+/**
+ * #5502 — per-row relay actions cell.
+ *
+ * Re-run: only armed when the LATEST run concluded `failure` (an older
+ * failure behind an in-progress or green run is not re-runnable from here —
+ * the row's truth is the latest attempt). Dispatches `integration_action`
+ * (repo_relay_rerun) with the run's databaseId; the server re-validates the
+ * id against a fresh `gh run list` before exec. While pending (keyed by
+ * repoPath in `relayRerunningRepoPaths`) the button shows "Re-running…";
+ * the outcome renders inline — on ack a "re-run requested" note inviting a
+ * refresh (the new attempt appears as in_progress on the next survey), on
+ * INTEGRATION_ACTION_FAILED the echoed reason.
+ *
+ * Sync now: Part 2 of #5502, BLOCKED on upstream blamechris/repo-relay#168
+ * (repo-relay has no workflow_dispatch trigger, so a manual relay pass
+ * cannot be fired). Rendered as a permanently-disabled stub naming the
+ * blocker so the operator knows the capability is coming, not missing.
+ */
+function RelayActionsCell({
+  repo,
+  rerunning,
+  result,
+  connected,
+  onRerun,
+}: {
+  repo: IntegrationRepo
+  rerunning: boolean
+  result: RelayRerunResult | undefined
+  connected: boolean
+  onRerun: (repoPath: string, runId: number) => void
+}) {
+  const relay = relayOf(repo)
+  if (!relay || !relay.installed) {
+    return <td className="cr-dim" data-testid={`integration-relay-actions-${repo.name}`}>—</td>
+  }
+  const latest = relay.runs[0] ?? null
+  const canRerun = latest !== null && latest.conclusion === 'failure'
+  const disabled = rerunning || !connected
+  return (
+    <td data-testid={`integration-relay-actions-${repo.name}`}>
+      {canRerun && (
+        <button
+          type="button"
+          className="cr-refresh"
+          data-testid={`integration-relay-rerun-${repo.name}`}
+          onClick={() => { if (!disabled) onRerun(repo.path, latest.databaseId) }}
+          disabled={disabled}
+          aria-busy={rerunning}
+          title={connected
+            ? 'Re-run the failed repo-relay run via gh run rerun'
+            : 'Not connected — reconnect to re-run'}
+        >
+          {rerunning ? 'Re-running…' : 'Re-run'}
+        </button>
+      )}
+      <button
+        type="button"
+        className="cr-refresh"
+        data-testid={`integration-relay-syncnow-${repo.name}`}
+        disabled
+        title="Blocked on blamechris/repo-relay#168 — repo-relay has no workflow_dispatch trigger yet, so a manual relay pass cannot be fired"
+      >
+        Sync now
+      </button>
+      {!rerunning && result && result.error !== null && (
+        <div className="cr-bad" data-testid={`integration-relay-rerun-error-${repo.name}`}>
+          {result.error}
+        </div>
+      )}
+      {!rerunning && result && result.error === null && (
+        <div className="cr-dim" data-testid={`integration-relay-rerun-result-${repo.name}`}>
+          ✓ re-run requested — refresh to see the new run
+        </div>
+      )}
+    </td>
+  )
+}
+
 function IntegrationRow({
   repo,
   now,
   reindexing,
   reindexResult,
+  rerunning,
+  rerunResult,
   connected,
   onReindex,
+  onRelayRerun,
 }: {
   repo: IntegrationRepo
   now: number
   reindexing: boolean
   reindexResult: ReindexResult | undefined
+  rerunning: boolean
+  rerunResult: RelayRerunResult | undefined
   connected: boolean
   onReindex: (repoPath: string) => void
+  onRelayRerun: (repoPath: string, runId: number) => void
 }) {
   const rm = repo.repoMemory
   const report = rm?.report ?? null
@@ -401,6 +487,13 @@ function IntegrationRow({
       <RelayVersionCell repo={repo} />
       <RelayLastRunCell repo={repo} now={now} />
       <RelayStreakCell repo={repo} />
+      <RelayActionsCell
+        repo={repo}
+        rerunning={rerunning}
+        result={rerunResult}
+        connected={connected}
+        onRerun={onRelayRerun}
+      />
     </tr>
   )
 }
@@ -420,6 +513,12 @@ export interface IntegrationsSectionProps {
   reindexResults?: Record<string, ReindexResult>
   /** #5500: Reindex action. Defaults to the store's sendRepoMemoryReindex. */
   onReindex?: (repoPath: string) => void
+  /** #5502: repo paths with an in-flight relay re-run. Defaults to the store. */
+  relayRerunningRepoPaths?: Set<string>
+  /** #5502: last relay re-run outcome per repo path. Defaults to the store. */
+  relayRerunResults?: Record<string, RelayRerunResult>
+  /** #5502: Re-run action. Defaults to the store's sendRepoRelayRerun. */
+  onRelayRerun?: (repoPath: string, runId: number) => void
   /** Injectable clock (epoch ms) for the "generated Nm ago" / activity cells. */
   now?: () => number
 }
@@ -432,6 +531,9 @@ export function IntegrationsSection({
   reindexingRepoPaths: reindexingProp,
   reindexResults: reindexResultsProp,
   onReindex: onReindexProp,
+  relayRerunningRepoPaths: rerunningProp,
+  relayRerunResults: rerunResultsProp,
+  onRelayRerun: onRelayRerunProp,
   now = Date.now,
 }: IntegrationsSectionProps = {}) {
   const storeSnapshot = useConnectionStore((s) => s.integrationStatus)
@@ -441,6 +543,9 @@ export function IntegrationsSection({
   const storeReindexing = useConnectionStore((s) => s.reindexingRepoPaths)
   const storeReindexResults = useConnectionStore((s) => s.reindexResults)
   const sendRepoMemoryReindex = useConnectionStore((s) => s.sendRepoMemoryReindex)
+  const storeRerunning = useConnectionStore((s) => s.relayRerunningRepoPaths)
+  const storeRerunResults = useConnectionStore((s) => s.relayRerunResults)
+  const sendRepoRelayRerun = useConnectionStore((s) => s.sendRepoRelayRerun)
 
   const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
   const loading = loadingProp !== undefined ? loadingProp : storeLoading
@@ -449,6 +554,9 @@ export function IntegrationsSection({
   const reindexingRepoPaths = reindexingProp ?? storeReindexing
   const reindexResults = reindexResultsProp ?? storeReindexResults
   const onReindex = onReindexProp ?? sendRepoMemoryReindex
+  const relayRerunningRepoPaths = rerunningProp ?? storeRerunning
+  const relayRerunResults = rerunResultsProp ?? storeRerunResults
+  const onRelayRerun = onRelayRerunProp ?? sendRepoRelayRerun
 
   const refreshDisabled = loading || !connected
   const handleRefresh = () => {
@@ -559,7 +667,7 @@ export function IntegrationsSection({
                 <tr>
                   <th rowSpan={2}>Repo</th>
                   <th colSpan={8} className="cr-th-group" data-testid="integration-group-memory">repo-memory</th>
-                  <th colSpan={4} className="cr-th-group" data-testid="integration-group-relay">repo-relay</th>
+                  <th colSpan={5} className="cr-th-group" data-testid="integration-group-relay">repo-relay</th>
                 </tr>
                 <tr>
                   <th>Status</th>
@@ -574,12 +682,13 @@ export function IntegrationsSection({
                   <th>Version</th>
                   <th>Last run</th>
                   <th>Streak</th>
+                  <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {snapshot.repos.length === 0 ? (
                   <tr data-testid="integration-no-repos">
-                    <td colSpan={13} className="cr-dim">
+                    <td colSpan={14} className="cr-dim">
                       No repos found under {snapshot.root}.
                     </td>
                   </tr>
@@ -591,8 +700,11 @@ export function IntegrationsSection({
                       now={nowMs}
                       reindexing={reindexingRepoPaths.has(repo.path)}
                       reindexResult={reindexResults[repo.path]}
+                      rerunning={relayRerunningRepoPaths.has(repo.path)}
+                      rerunResult={relayRerunResults[repo.path]}
                       connected={connected}
                       onReindex={onReindex}
+                      onRelayRerun={onRelayRerun}
                     />
                   ))
                 )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -405,6 +405,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // per repo for inline display (same lifecycle as cancellingActivityIds).
   reindexingRepoPaths: new Set<string>(),
   reindexResults: {},
+  // #5502: relay Re-run pending/result buckets (separate from reindex).
+  relayRerunningRepoPaths: new Set<string>(),
+  relayRerunResults: {},
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -731,6 +734,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     delete results[repoPath];
     set({ reindexingRepoPaths: pending, reindexResults: results });
     wsSend(socket, { type: 'integration_action', action: 'repo_memory_reindex', repoPath, requestId });
+    return true;
+  },
+
+  // #5502 (epic #5498): re-run a FAILED repo-relay run for one surveyed repo.
+  // Same contract as sendRepoMemoryReindex: pending state flips ONLY when the
+  // message is genuinely on the wire (never queued offline — a re-run that
+  // drains seconds later would strand the row "Re-running…" with no ack ever
+  // arriving), and the repo's previous inline result is dropped so a stale
+  // outcome can't sit next to the pending state. The runId is the databaseId
+  // the snapshot surfaced; the server re-validates it before any exec.
+  sendRepoRelayRerun: (repoPath: string, runId: number): boolean => {
+    const { socket } = get();
+    if (!repoPath || !Number.isInteger(runId) || runId < 0) return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const requestId = `relay-rerun-${nextMessageId()}`;
+    const pending = new Set(get().relayRerunningRepoPaths);
+    pending.add(repoPath);
+    const results = { ...get().relayRerunResults };
+    delete results[repoPath];
+    set({ relayRerunningRepoPaths: pending, relayRerunResults: results });
+    wsSend(socket, { type: 'integration_action', action: 'repo_relay_rerun', repoPath, runId, requestId });
     return true;
   },
 
@@ -1333,6 +1357,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().reindexingRepoPaths.size > 0) {
         set({ reindexingRepoPaths: new Set<string>() });
       }
+      // #5502: ditto for in-flight relay re-runs.
+      if (get().relayRerunningRepoPaths.size > 0) {
+        set({ relayRerunningRepoPaths: new Set<string>() });
+      }
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
@@ -1551,6 +1579,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // connection-scoped Control Room state.
       reindexingRepoPaths: new Set<string>(),
       reindexResults: {},
+      // #5502: relay re-run pending/result state goes with it.
+      relayRerunningRepoPaths: new Set<string>(),
+      relayRerunResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -1585,6 +1616,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // connection-scoped Control Room state.
       reindexingRepoPaths: new Set<string>(),
       reindexResults: {},
+      // #5502: relay re-run pending/result state goes with it.
+      relayRerunningRepoPaths: new Set<string>(),
+      relayRerunResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-integration-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-integration-action.test.ts
@@ -73,6 +73,9 @@ function baseState(): Partial<ConnectionState> {
     sessionStates: {},
     reindexingRepoPaths: new Set([REPO, OTHER_REPO]),
     reindexResults: {},
+    // #5502: the relay re-run pendings live in their own bucket.
+    relayRerunningRepoPaths: new Set([REPO, OTHER_REPO]),
+    relayRerunResults: {},
     messages: [],
   }
 }
@@ -184,5 +187,100 @@ describe('integration action dispatch (#5500)', () => {
     handleMessage(ack(), ctx() as never)
     expect(store.getState().reindexResults[REPO]!.error).toBeNull()
     expect(store.getState().reindexResults[REPO]!.counts).toEqual(COUNTS)
+  })
+})
+
+describe('repo-relay rerun action dispatch (#5502)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  function rerunAck(over: Record<string, unknown> = {}) {
+    return {
+      type: 'integration_action_ack',
+      action: 'repo_relay_rerun',
+      repoPath: REPO,
+      requestId: 'rr-1',
+      runId: 9001,
+      counts: null,
+      ...over,
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('a rerun ack clears the RERUN pending state and never touches the reindex bucket', () => {
+    handleMessage(rerunAck(), ctx() as never)
+    const s = store.getState()
+    expect(s.relayRerunningRepoPaths.has(REPO)).toBe(false)
+    expect(s.relayRerunningRepoPaths.has(OTHER_REPO)).toBe(true) // other repo untouched
+    expect(s.relayRerunResults[REPO]).toBeDefined()
+    expect(s.relayRerunResults[REPO]!.error).toBeNull()
+    // The reindex bucket for the same repoPath must stay untouched.
+    expect(s.reindexingRepoPaths.has(REPO)).toBe(true)
+    expect(s.reindexResults[REPO]).toBeUndefined()
+  })
+
+  it('a reindex ack never touches the rerun bucket', () => {
+    handleMessage(
+      { type: 'integration_action_ack', action: 'repo_memory_reindex', repoPath: REPO, counts: COUNTS },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.relayRerunningRepoPaths.has(REPO)).toBe(true)
+    expect(s.reindexingRepoPaths.has(REPO)).toBe(false)
+  })
+
+  it('an INTEGRATION_ACTION_FAILED with action repo_relay_rerun clears pending and records the inline error', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage(
+      {
+        type: 'session_error',
+        code: 'INTEGRATION_ACTION_FAILED',
+        message: 'run 9001 did not fail (success) — only failed runs can be re-run',
+        reason: 'run-not-failed',
+        action: 'repo_relay_rerun',
+        repoPath: REPO,
+        runId: 9001,
+        requestId: 'rr-1',
+      },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.relayRerunningRepoPaths.has(REPO)).toBe(false)
+    expect(s.relayRerunResults[REPO]!.error).toMatch(/only failed runs/)
+    // Reindex bucket untouched by a rerun failure.
+    expect(s.reindexingRepoPaths.has(REPO)).toBe(true)
+    expect(s.reindexResults[REPO]).toBeUndefined()
+  })
+
+  it('a fresh rerun ack replaces a previous inline error for the same repo', () => {
+    store.setState({
+      relayRerunResults: { [REPO]: { error: 'old failure', at: 1 } },
+    } as never)
+    handleMessage(rerunAck(), ctx() as never)
+    expect(store.getState().relayRerunResults[REPO]!.error).toBeNull()
   })
 })

--- a/packages/dashboard/src/store/dispatch-integration-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-integration-action.test.ts
@@ -154,8 +154,8 @@ describe('integration action dispatch (#5500)', () => {
       {
         type: 'session_error',
         code: 'INTEGRATION_ACTION_FAILED',
-        message: 'A reindex is already in progress for /Users/me/Projects/chroxy',
-        reason: 'reindex-in-progress',
+        message: 'An integration action (repo_memory_reindex) is already in progress for /Users/me/Projects/chroxy',
+        reason: 'action-in-progress',
         action: 'repo_memory_reindex',
         repoPath: REPO,
         requestId: 'rx-1',
@@ -282,5 +282,35 @@ describe('repo-relay rerun action dispatch (#5502)', () => {
     } as never)
     handleMessage(rerunAck(), ctx() as never)
     expect(store.getState().relayRerunResults[REPO]!.error).toBeNull()
+  })
+
+  it('an ack for an unknown future action touches neither bucket (forward-compat opacity)', () => {
+    handleMessage(rerunAck({ action: 'repo_relay_dispatch', runId: null }), ctx() as never)
+    const s = store.getState()
+    expect(s.relayRerunningRepoPaths.has(REPO)).toBe(true)
+    expect(s.relayRerunResults[REPO]).toBeUndefined()
+    expect(s.reindexingRepoPaths.has(REPO)).toBe(true)
+    expect(s.reindexResults[REPO]).toBeUndefined()
+  })
+
+  it('an INTEGRATION_ACTION_FAILED for an unknown future action touches neither bucket', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage(
+      {
+        type: 'session_error',
+        code: 'INTEGRATION_ACTION_FAILED',
+        message: 'something upstream broke',
+        reason: 'dispatch-failed',
+        action: 'repo_relay_dispatch',
+        repoPath: REPO,
+        requestId: 'rd-1',
+      },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.relayRerunningRepoPaths.has(REPO)).toBe(true)
+    expect(s.relayRerunResults[REPO]).toBeUndefined()
+    expect(s.reindexingRepoPaths.has(REPO)).toBe(true)
+    expect(s.reindexResults[REPO]).toBeUndefined()
   })
 })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2038,6 +2038,25 @@ function resolveReindex(
 }
 
 /**
+ * #5502 — same contract for the relay Re-run action, against its own bucket
+ * (`relayRerunningRepoPaths` / `relayRerunResults`): a rerun outcome must
+ * never clear, or be cleared by, a reindex on the same repoPath.
+ */
+function resolveRelayRerun(
+  get: MsgGet,
+  set: MsgSet,
+  repoPath: string,
+  result: { error: string | null },
+): void {
+  const pending = new Set(get().relayRerunningRepoPaths);
+  pending.delete(repoPath);
+  set({
+    relayRerunningRepoPaths: pending,
+    relayRerunResults: { ...get().relayRerunResults, [repoPath]: { ...result, at: Date.now() } },
+  });
+}
+
+/**
  * #5500 — Reindex success ack: positive confirmation that the
  * `integration_action` repo_memory_reindex run completed, echoing the
  * request's repoPath (+ requestId) with the parsed index counts (`null` when
@@ -2049,6 +2068,13 @@ function resolveReindex(
 function handleIntegrationActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const parsed = ServerIntegrationActionAckSchema.safeParse(msg);
   if (!parsed.success) return;
+  // #5502: route by the echoed action — a relay re-run ack resolves the
+  // rerun bucket; everything else (repo_memory_reindex today, unknown future
+  // actions) keeps the original reindex routing.
+  if (parsed.data.action === 'repo_relay_rerun') {
+    resolveRelayRerun(get, set, parsed.data.repoPath, { error: null });
+    return;
+  }
   resolveReindex(get, set, parsed.data.repoPath, { counts: parsed.data.counts, error: null });
 }
 
@@ -2618,14 +2644,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       } else if (parsed.code === 'SESSION_NOT_FOUND') {
         clearCancellingForSession(get, set, parsed.attemptedSessionId ?? undefined);
       } else if (parsed.code === 'INTEGRATION_ACTION_FAILED' && typeof msg.repoPath === 'string') {
-        // #5500: a failed Reindex echoes the exact repoPath — clear that
-        // row's "Reindexing…" pending state and surface the reason inline
-        // (the generic branch below still raises the toast, matching the
-        // CANCEL_ACTIVITY_FAILED precedent).
-        resolveReindex(get, set, msg.repoPath, {
-          counts: null,
-          error: parsed.message || 'Reindex failed.',
-        });
+        // #5500/#5502: a failed integration action echoes the exact repoPath
+        // (and action) — clear that row's pending state and surface the
+        // reason inline (the generic branch below still raises the toast,
+        // matching the CANCEL_ACTIVITY_FAILED precedent). Routed by the
+        // echoed action so a rerun failure can't clear a reindex pending.
+        if (msg.action === 'repo_relay_rerun') {
+          resolveRelayRerun(get, set, msg.repoPath, {
+            error: parsed.message || 'Re-run failed.',
+          });
+        } else {
+          resolveReindex(get, set, msg.repoPath, {
+            counts: null,
+            error: parsed.message || 'Reindex failed.',
+          });
+        }
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {
         const crashedId = parsed.sessionPatch.sessionId;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2069,12 +2069,15 @@ function handleIntegrationActionAck(msg: Record<string, unknown>, get: MsgGet, s
   const parsed = ServerIntegrationActionAckSchema.safeParse(msg);
   if (!parsed.success) return;
   // #5502: route by the echoed action — a relay re-run ack resolves the
-  // rerun bucket; everything else (repo_memory_reindex today, unknown future
-  // actions) keeps the original reindex routing.
+  // rerun bucket, a reindex ack the reindex bucket. An unknown future
+  // action's ack stays opaque (the protocol's forward-compat contract):
+  // this client can't have pending state for an action it can't send, so
+  // clearing either bucket would clobber the wrong row.
   if (parsed.data.action === 'repo_relay_rerun') {
     resolveRelayRerun(get, set, parsed.data.repoPath, { error: null });
     return;
   }
+  if (parsed.data.action !== 'repo_memory_reindex') return;
   resolveReindex(get, set, parsed.data.repoPath, { counts: parsed.data.counts, error: null });
 }
 
@@ -2648,12 +2651,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // (and action) — clear that row's pending state and surface the
         // reason inline (the generic branch below still raises the toast,
         // matching the CANCEL_ACTIVITY_FAILED precedent). Routed by the
-        // echoed action so a rerun failure can't clear a reindex pending.
+        // echoed action so a rerun failure can't clear a reindex pending;
+        // an unknown future action's failure touches neither bucket (the
+        // generic toast below still fires).
         if (msg.action === 'repo_relay_rerun') {
           resolveRelayRerun(get, set, msg.repoPath, {
             error: parsed.message || 'Re-run failed.',
           });
-        } else {
+        } else if (msg.action === 'repo_memory_reindex') {
           resolveReindex(get, set, msg.repoPath, {
             counts: null,
             error: parsed.message || 'Reindex failed.',

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -419,6 +419,44 @@ describe('useConnectionStore', () => {
     expect(useConnectionStore.getState().reindexingRepoPaths.has('/p/chroxy')).toBe(false);
   });
 
+  it('#5502: sendRepoRelayRerun marks the repo pending, clears its stale result, and sends the runId', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const send = vi.fn();
+    const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+    useConnectionStore.setState({
+      socket: openSocket,
+      relayRerunningRepoPaths: new Set(),
+      relayRerunResults: { '/p/chroxy': { error: 'old failure', at: 1 } },
+    });
+
+    const result = useConnectionStore.getState().sendRepoRelayRerun('/p/chroxy', 9001);
+
+    expect(result).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse((send.mock.calls[0]![0]) as string);
+    expect(payload.type).toBe('integration_action');
+    expect(payload.action).toBe('repo_relay_rerun');
+    expect(payload.repoPath).toBe('/p/chroxy');
+    expect(payload.runId).toBe(9001);
+    expect(typeof payload.requestId).toBe('string');
+    expect(useConnectionStore.getState().relayRerunningRepoPaths.has('/p/chroxy')).toBe(true);
+    // A fresh request invalidates the previous inline result for the repo.
+    expect(useConnectionStore.getState().relayRerunResults['/p/chroxy']).toBeUndefined();
+  });
+
+  it('#5502: sendRepoRelayRerun is a no-op offline and rejects a non-integer runId', async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({ socket: null, relayRerunningRepoPaths: new Set(), relayRerunResults: {} });
+    expect(useConnectionStore.getState().sendRepoRelayRerun('/p/chroxy', 9001)).toBe(false);
+    expect(useConnectionStore.getState().relayRerunningRepoPaths.has('/p/chroxy')).toBe(false);
+
+    const send = vi.fn();
+    const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: openSocket });
+    expect(useConnectionStore.getState().sendRepoRelayRerun('/p/chroxy', 1.5)).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it('exposes all required actions', async () => {
     const { useConnectionStore } = await import('./connection');
     const state = useConnectionStore.getState();

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -492,6 +492,19 @@ export interface ReindexResult {
   at: number;
 }
 
+/**
+ * #5502 — outcome of the last repo-relay Re-run action for one repo, kept
+ * for inline display in its Integrations row. A successful ack records
+ * `error: null` (the row shows "re-run requested" and invites a refresh —
+ * the new run appears as in_progress on the next survey); an
+ * INTEGRATION_ACTION_FAILED session_error records the message. `at` is the
+ * local receipt time (epoch ms).
+ */
+export interface RelayRerunResult {
+  error: string | null;
+  at: number;
+}
+
 export interface ConnectionState {
   // Connection
   connectionPhase: ConnectionPhase;
@@ -623,6 +636,19 @@ export interface ConnectionState {
    * reindexed again.
    */
   reindexResults: Record<string, ReindexResult>;
+  /**
+   * #5502 — repo paths with an in-flight `integration_action` relay re-run:
+   * set when sendRepoRelayRerun is called, cleared on the
+   * `integration_action_ack` / INTEGRATION_ACTION_FAILED session_error. A
+   * separate bucket from `reindexingRepoPaths` so a rerun outcome can never
+   * clear (or be cleared by) a reindex on the same repo.
+   */
+  relayRerunningRepoPaths: Set<string>;
+  /**
+   * #5502 — last relay re-run outcome per repo path, for inline display in
+   * the Integrations row. Replaced when the repo is re-run again.
+   */
+  relayRerunResults: Record<string, RelayRerunResult>;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;
@@ -1115,6 +1141,16 @@ export interface ConnectionState {
   // when the message actually went on the wire — an offline send returns
   // false without queuing, so the row can't strand "Reindexing…".
   sendRepoMemoryReindex: (repoPath: string) => boolean;
+
+  // #5502 (epic #5498): re-run a FAILED repo-relay workflow run for one
+  // surveyed repo. Dispatches an `integration_action` (action:
+  // repo_relay_rerun) carrying the runId the observability snapshot surfaced
+  // — the server re-validates it against a fresh `gh run list` before any
+  // exec. Same wire-or-nothing contract as sendRepoMemoryReindex: marks the
+  // repo in `relayRerunningRepoPaths` (and drops its stale
+  // `relayRerunResults` entry) ONLY when the message actually went on the
+  // wire; an offline send (or a non-integer runId) returns false.
+  sendRepoRelayRerun: (repoPath: string, runId: number) => boolean;
 
   // #4542: per-category notification preferences. Mirrors the server
   // snapshot received over WS (`notification_prefs`). `null` until the

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -583,8 +583,10 @@ export declare const IntegrationActionSchema: z.ZodObject<{
     type: z.ZodLiteral<"integration_action">;
     action: z.ZodEnum<{
         repo_memory_reindex: "repo_memory_reindex";
+        repo_relay_rerun: "repo_relay_rerun";
     }>;
     repoPath: z.ZodString;
+    runId: z.ZodOptional<z.ZodNumber>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
 export declare const EncryptedEnvelopeSchema: z.ZodObject<{
@@ -949,8 +951,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"integration_action">;
     action: z.ZodEnum<{
         repo_memory_reindex: "repo_memory_reindex";
+        repo_relay_rerun: "repo_relay_rerun";
     }>;
     repoPath: z.ZodString;
+    runId: z.ZodOptional<z.ZodNumber>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>], "type">;
 export type AuthMessage = z.infer<typeof AuthSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -713,27 +713,35 @@ export const IntegrationStatusRequestSchema = z.object({
 });
 // #5500 (epic #5498): a MUTATING Control Room integration action — the
 // observe half of the tab is `integration_status_request`; this is the
-// control half. Currently one action: `repo_memory_reindex`, which runs
-// `repo-memory index <repoRoot>` host-side to prewarm/refresh the summary
-// cache (no watcher exists — the cache only refreshes on agent reads or an
-// explicit index run).
+// control half. Actions:
+//   - `repo_memory_reindex` (#5500): runs `repo-memory index <repoRoot>`
+//     host-side to prewarm/refresh the summary cache (no watcher exists —
+//     the cache only refreshes on agent reads or an explicit index run).
+//   - `repo_relay_rerun` (#5502): re-runs a FAILED repo-relay workflow run
+//     via `gh run rerun <databaseId>`. Requires `runId` (server-enforced).
 //
 // Designed as an extensible envelope: `action` is a CLOSED enum so an
 // unknown/mistyped action is rejected at the schema layer before it reaches
-// the handler, and #5502's `repo_relay_rerun` lands by extending the enum —
-// no new message type per action. `repoPath` identifies the target repo; the
-// server MUST validate it against the surveyed repo set before any exec
-// (bearer-token-authority checklist) — the schema bound here is only a
-// sanity cap, not the security boundary.
+// the handler — no new message type per action. `repoPath` identifies the
+// target repo; the server MUST validate it against the surveyed repo set
+// before any exec (bearer-token-authority checklist) — the schema bound here
+// is only a sanity cap, not the security boundary.
 //
 // Correlation contract clones `cancel_activity` (#5277): the optional
 // client-generated `requestId` is echoed on the `integration_action_ack`
 // (success) and the `INTEGRATION_ACTION_FAILED` session_error (failure), so
-// the dashboard can tie a specific Reindex click to its outcome.
+// the dashboard can tie a specific Reindex / Re-run click to its outcome.
 export const IntegrationActionSchema = z.object({
     type: z.literal('integration_action'),
-    action: z.enum(['repo_memory_reindex']),
+    action: z.enum(['repo_memory_reindex', 'repo_relay_rerun']),
     repoPath: z.string().min(1).max(4096),
+    // #5502: the GitHub Actions run to re-run (the `databaseId` the
+    // observability snapshot surfaced). Optional at the schema layer because
+    // the envelope is shared across actions — the server validates it as
+    // required-for-rerun, then RE-FETCHES the run list and only execs when the
+    // id names a run it itself surfaced with conclusion 'failure' (the client
+    // id is a lookup key, never a trusted exec target).
+    runId: z.number().int().nonnegative().finite().optional(),
     requestId: z.string().max(128).optional(),
 }).passthrough();
 // -- Encrypted envelope --

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -1322,12 +1322,18 @@ export declare const IntegrationActionCountsSchema: z.ZodObject<{
  * `repoPath` and treat unknown actions as opaque. `counts` is the parsed
  * index result for `repo_memory_reindex`, or null when the CLI output
  * couldn't be parsed (the UI then just refreshes the survey for the truth).
+ *
+ * #5502: `runId` echoes the re-run request's GitHub Actions run id on a
+ * `repo_relay_rerun` ack (null/absent on reindex acks). A rerun ack carries
+ * `counts: null` — there is nothing to count; the new attempt shows up as
+ * in_progress on the next survey refresh.
  */
 export declare const ServerIntegrationActionAckSchema: z.ZodObject<{
     type: z.ZodLiteral<"integration_action_ack">;
     action: z.ZodString;
     repoPath: z.ZodString;
     requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    runId: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
     counts: z.ZodNullable<z.ZodObject<{
         scanned: z.ZodNumber;
         summarized: z.ZodNumber;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -1201,12 +1201,18 @@ export const IntegrationActionCountsSchema = z.object({
  * `repoPath` and treat unknown actions as opaque. `counts` is the parsed
  * index result for `repo_memory_reindex`, or null when the CLI output
  * couldn't be parsed (the UI then just refreshes the survey for the truth).
+ *
+ * #5502: `runId` echoes the re-run request's GitHub Actions run id on a
+ * `repo_relay_rerun` ack (null/absent on reindex acks). A rerun ack carries
+ * `counts: null` — there is nothing to count; the new attempt shows up as
+ * in_progress on the next survey refresh.
  */
 export const ServerIntegrationActionAckSchema = z.object({
     type: z.literal('integration_action_ack'),
     action: z.string(),
     repoPath: z.string(),
     requestId: z.string().max(128).nullable().optional(),
+    runId: z.number().int().nonnegative().finite().nullable().optional(),
     counts: IntegrationActionCountsSchema.nullable(),
 }).passthrough();
 export const ServerClientFocusChangedSchema = z.object({

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -825,27 +825,35 @@ export const IntegrationStatusRequestSchema = z.object({
 
 // #5500 (epic #5498): a MUTATING Control Room integration action — the
 // observe half of the tab is `integration_status_request`; this is the
-// control half. Currently one action: `repo_memory_reindex`, which runs
-// `repo-memory index <repoRoot>` host-side to prewarm/refresh the summary
-// cache (no watcher exists — the cache only refreshes on agent reads or an
-// explicit index run).
+// control half. Actions:
+//   - `repo_memory_reindex` (#5500): runs `repo-memory index <repoRoot>`
+//     host-side to prewarm/refresh the summary cache (no watcher exists —
+//     the cache only refreshes on agent reads or an explicit index run).
+//   - `repo_relay_rerun` (#5502): re-runs a FAILED repo-relay workflow run
+//     via `gh run rerun <databaseId>`. Requires `runId` (server-enforced).
 //
 // Designed as an extensible envelope: `action` is a CLOSED enum so an
 // unknown/mistyped action is rejected at the schema layer before it reaches
-// the handler, and #5502's `repo_relay_rerun` lands by extending the enum —
-// no new message type per action. `repoPath` identifies the target repo; the
-// server MUST validate it against the surveyed repo set before any exec
-// (bearer-token-authority checklist) — the schema bound here is only a
-// sanity cap, not the security boundary.
+// the handler — no new message type per action. `repoPath` identifies the
+// target repo; the server MUST validate it against the surveyed repo set
+// before any exec (bearer-token-authority checklist) — the schema bound here
+// is only a sanity cap, not the security boundary.
 //
 // Correlation contract clones `cancel_activity` (#5277): the optional
 // client-generated `requestId` is echoed on the `integration_action_ack`
 // (success) and the `INTEGRATION_ACTION_FAILED` session_error (failure), so
-// the dashboard can tie a specific Reindex click to its outcome.
+// the dashboard can tie a specific Reindex / Re-run click to its outcome.
 export const IntegrationActionSchema = z.object({
   type: z.literal('integration_action'),
-  action: z.enum(['repo_memory_reindex']),
+  action: z.enum(['repo_memory_reindex', 'repo_relay_rerun']),
   repoPath: z.string().min(1).max(4096),
+  // #5502: the GitHub Actions run to re-run (the `databaseId` the
+  // observability snapshot surfaced). Optional at the schema layer because
+  // the envelope is shared across actions — the server validates it as
+  // required-for-rerun, then RE-FETCHES the run list and only execs when the
+  // id names a run it itself surfaced with conclusion 'failure' (the client
+  // id is a lookup key, never a trusted exec target).
+  runId: z.number().int().nonnegative().finite().optional(),
   requestId: z.string().max(128).optional(),
 }).passthrough()
 

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -1272,12 +1272,18 @@ export const IntegrationActionCountsSchema = z.object({
  * `repoPath` and treat unknown actions as opaque. `counts` is the parsed
  * index result for `repo_memory_reindex`, or null when the CLI output
  * couldn't be parsed (the UI then just refreshes the survey for the truth).
+ *
+ * #5502: `runId` echoes the re-run request's GitHub Actions run id on a
+ * `repo_relay_rerun` ack (null/absent on reindex acks). A rerun ack carries
+ * `counts: null` — there is nothing to count; the new attempt shows up as
+ * in_progress on the next survey refresh.
  */
 export const ServerIntegrationActionAckSchema = z.object({
   type: z.literal('integration_action_ack'),
   action: z.string(),
   repoPath: z.string(),
   requestId: z.string().max(128).nullable().optional(),
+  runId: z.number().int().nonnegative().finite().nullable().optional(),
   counts: IntegrationActionCountsSchema.nullable(),
 }).passthrough()
 

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -2687,5 +2687,74 @@ describe('@chroxy/protocol schemas', () => {
         assert.ok(schemas.IntegrationActionCountsSchema)
       })
     })
+
+    describe('repo-relay rerun action (#5502)', () => {
+      it('IntegrationActionSchema accepts repo_relay_rerun with a runId + the client union takes it', async () => {
+        const { IntegrationActionSchema, ClientMessageSchema } = await import('../src/schemas/client.ts')
+        assert.ok(IntegrationActionSchema.safeParse({
+          type: 'integration_action',
+          action: 'repo_relay_rerun',
+          repoPath: '/p/chroxy',
+          runId: 16523339621,
+          requestId: 'rr-1',
+        }).success)
+        const u = ClientMessageSchema.safeParse({
+          type: 'integration_action',
+          action: 'repo_relay_rerun',
+          repoPath: '/p/chroxy',
+          runId: 16523339621,
+        })
+        assert.ok(u.success, JSON.stringify(u.error?.issues))
+        assert.equal(u.data.type, 'integration_action')
+      })
+
+      it('runId stays optional at the schema layer (shared envelope — required-for-rerun is server-side)', async () => {
+        const { IntegrationActionSchema } = await import('../src/schemas/client.ts')
+        assert.ok(IntegrationActionSchema.safeParse({
+          type: 'integration_action',
+          action: 'repo_relay_rerun',
+          repoPath: '/p/chroxy',
+        }).success, 'absence is a server-side rejection, not a wire-schema one')
+        assert.ok(IntegrationActionSchema.safeParse({
+          type: 'integration_action',
+          action: 'repo_memory_reindex',
+          repoPath: '/p/chroxy',
+        }).success, 'reindex keeps working without a runId')
+      })
+
+      it('rejects a negative / non-integer / non-numeric runId', async () => {
+        const { IntegrationActionSchema } = await import('../src/schemas/client.ts')
+        const base = { type: 'integration_action', action: 'repo_relay_rerun', repoPath: '/p/chroxy' }
+        assert.ok(!IntegrationActionSchema.safeParse({ ...base, runId: -1 }).success)
+        assert.ok(!IntegrationActionSchema.safeParse({ ...base, runId: 1.5 }).success)
+        assert.ok(!IntegrationActionSchema.safeParse({ ...base, runId: '9001' }).success)
+        assert.ok(!IntegrationActionSchema.safeParse({ ...base, runId: Infinity }).success)
+      })
+
+      it('ServerIntegrationActionAckSchema round-trips a rerun ack (runId echoed, counts null)', async () => {
+        const { ServerIntegrationActionAckSchema } = await import('../src/schemas/server.ts')
+        const result = ServerIntegrationActionAckSchema.safeParse({
+          type: 'integration_action_ack',
+          action: 'repo_relay_rerun',
+          repoPath: '/p/chroxy',
+          requestId: 'rr-1',
+          runId: 16523339621,
+          counts: null,
+        })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.runId, 16523339621)
+        assert.equal(result.data.counts, null)
+      })
+
+      it('a reindex ack without runId still validates (runId is additive)', async () => {
+        const { ServerIntegrationActionAckSchema } = await import('../src/schemas/server.ts')
+        assert.ok(ServerIntegrationActionAckSchema.safeParse({
+          type: 'integration_action_ack',
+          action: 'repo_memory_reindex',
+          repoPath: '/p/chroxy',
+          counts: null,
+        }).success)
+      })
+    })
   })
 })

--- a/packages/server/src/control-room/integrations.js
+++ b/packages/server/src/control-room/integrations.js
@@ -338,6 +338,107 @@ export async function runRepoMemoryIndex(repoPath, opts = {}) {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// #5502 — repo-relay Re-run action.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * #5502: timeout for `gh run rerun` — a single API mutation, so it gets a
+ * 30s bound (longer than the 20s survey probes to ride out a slow API,
+ * nowhere near the 120s index budget).
+ */
+export const RERUN_TIMEOUT_MS = 30000
+/** Shared exec options for the rerun mutation. */
+const RERUN_EXEC_OPTS = { timeout: RERUN_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }
+
+/**
+ * #5502: build an Error carrying a stable machine `reason` alongside the
+ * human message. The WS handler echoes `reason` on the
+ * INTEGRATION_ACTION_FAILED session_error so the dashboard can branch
+ * without parsing message text.
+ */
+function rerunFailure(reason, message) {
+  const err = new Error(message)
+  err.reason = reason
+  return err
+}
+
+/**
+ * #5502: re-run a FAILED repo-relay workflow run via
+ * `gh run rerun <databaseId> -R <owner>/<repo>`.
+ *
+ * SECURITY — the client-supplied `runId` is a LOOKUP KEY, never a trusted
+ * exec target: before any mutation this re-fetches the same five-run window
+ * the observability snapshot (#5501) surfaced and requires the id to (a) be
+ * present in that fresh list and (b) have concluded `failure`. A stale,
+ * fabricated, or non-failed id is rejected with a legible reason — `gh run
+ * rerun` never sees an id the server didn't just observe. The owner/repo
+ * target likewise derives server-side from the repo's git remote (the same
+ * parseGithubOwnerRepo derivation the survey uses), never from the client.
+ *
+ * Throws with a machine `reason` (`gh-missing` / `no-github-remote` /
+ * `run-list-failed` / `unknown-run` / `run-not-failed` / `rerun-failed`) —
+ * the WS handler turns that into an INTEGRATION_ACTION_FAILED session_error.
+ *
+ * @param {string} repoPath - canonical repo root (the handler validates
+ *   membership in the surveyed repo set BEFORE calling this).
+ * @param {number} runId - the GitHub Actions run databaseId to re-run.
+ * @param {object} [opts]
+ * @param {Function} [opts._execFile] - promisified execFile seam.
+ * @returns {Promise<{ runId: number }>}
+ */
+export async function runRepoRelayRerun(repoPath, runId, opts = {}) {
+  const { _execFile = execFileAsync } = opts
+
+  const ghPath = await probeBinOnPath(_execFile, 'gh')
+  if (!ghPath) throw rerunFailure('gh-missing', GH_MISSING_NOTE)
+
+  // Server-side owner/repo derivation — same source as the survey (#5501).
+  let target = null
+  try {
+    const { stdout } = await _execFile('git', ['remote', 'get-url', 'origin'], { ...EXEC_OPTS, cwd: repoPath })
+    target = parseGithubOwnerRepo(typeof stdout === 'string' ? stdout : '')
+  } catch {
+    target = null
+  }
+  if (!target) {
+    throw rerunFailure('no-github-remote', `cannot re-run: ${NO_GITHUB_REMOTE_REASON} for ${repoPath}`)
+  }
+  const slug = `${target.owner}/${target.repo}`
+
+  // runId re-validation: fresh fetch of the window the snapshot showed.
+  let listStdout
+  try {
+    ;({ stdout: listStdout } = await _execFile(ghPath, [
+      'run', 'list', `--workflow=${RELAY_WORKFLOW_FILE}`, '-R', slug,
+      '--limit', '5', '--json', 'databaseId,conclusion,status',
+    ], EXEC_OPTS))
+  } catch (err) {
+    throw rerunFailure('run-list-failed', execFailureReason(err, 'gh run list'))
+  }
+  const runs = parseRelayRuns(typeof listStdout === 'string' ? listStdout : '')
+  if (runs === null) {
+    throw rerunFailure('run-list-failed', 'gh run list produced unparseable output')
+  }
+  const match = runs.find(r => r.databaseId === runId)
+  if (!match) {
+    throw rerunFailure('unknown-run',
+      `runId ${runId} is not among the last 5 repo-relay runs for ${slug} — refresh the survey and retry`)
+  }
+  if (match.conclusion !== 'failure') {
+    const state = match.conclusion ?? match.status ?? 'not concluded'
+    throw rerunFailure('run-not-failed',
+      `run ${runId} did not fail (${state}) — only failed runs can be re-run`)
+  }
+
+  try {
+    await _execFile(ghPath, ['run', 'rerun', String(runId), '-R', slug], RERUN_EXEC_OPTS)
+  } catch (err) {
+    throw rerunFailure('rerun-failed', execFailureReason(err, 'gh run rerun'))
+  }
+  return { runId }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // #5501 — repo-relay observability helpers.
 // ───────────────────────────────────────────────────────────────────────────
 

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -2,7 +2,7 @@
  * Control Room v2 (#5174) — Host/Repo Status WS handler.
  *
  * Handles: host_status_request, runner_status_request (#5253),
- * integration_status_request (#5499), integration_action (#5500)
+ * integration_status_request (#5499), integration_action (#5500/#5502)
  *
  * Wires the host survey (control-room/repo-set.js + control-room/survey.js) to
  * the WS protocol. On a `host_status_request` the handler:
@@ -34,7 +34,7 @@ import { createLogger } from '../logger.js'
 import { resolveRepoSet, DEFAULT_CONTROL_ROOM_ROOT } from '../control-room/repo-set.js'
 import { surveyRepos } from '../control-room/survey.js'
 import { surveyRunners, DEFAULT_RUNNER_ROOT } from '../control-room/runners.js'
-import { surveyIntegrations, runRepoMemoryIndex } from '../control-room/integrations.js'
+import { surveyIntegrations, runRepoMemoryIndex, runRepoRelayRerun } from '../control-room/integrations.js'
 
 const log = createLogger('ws')
 
@@ -325,31 +325,40 @@ async function handleIntegrationStatusRequest(ws, client, msg, ctx) {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// #5500 (epic #5498) — integration_action: repo-memory Reindex
+// #5500/#5502 (epic #5498) — integration_action: repo-memory Reindex and
+// repo-relay Re-run
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * #5500: per-repo in-flight reindex guard, keyed by the repo's CANONICAL
- * realpath (so a symlinked alias can't sidestep the overlap check). A plain
- * Map (not a WeakSet like the survey guards) because the key is a string and
- * entries are explicitly deleted in the handler's `finally` — nothing leaks
- * across client disconnects since completion always settles the promise.
- * Map.size doubles as the global concurrency gauge.
+ * #5500: per-repo in-flight guard for ALL integration actions, keyed by the
+ * repo's CANONICAL realpath (so a symlinked alias can't sidestep the overlap
+ * check). A plain Map (not a WeakSet like the survey guards) because the key
+ * is a string and entries are explicitly deleted in the handler's `finally`
+ * — nothing leaks across client disconnects since completion always settles
+ * the promise. Map.size doubles as the global concurrency gauge.
+ *
+ * #5502: deliberately ONE bucket across action kinds (reindex + relay
+ * re-run share it): a repo gets at most one mutating integration action at a
+ * time, and the global cap bounds total subprocess fan-out regardless of
+ * which buttons the operator mashes. Actions are rare operator clicks — a
+ * shared bucket is the simplest cap that still can't be sidestepped by
+ * mixing action kinds.
  */
-const reindexInFlight = new Map()
+const actionInFlight = new Map()
 /**
- * #5500: global concurrency cap — the Reindex button must not be able to
+ * #5500: global concurrency cap — the action buttons must not be able to
  * fork-bomb the host. No queue by design: a request above the cap is
  * rejected with a legible "busy" error and the operator retries.
  */
-export const MAX_CONCURRENT_REINDEX = 2
+export const MAX_CONCURRENT_INTEGRATION_ACTIONS = 2
 
 /**
  * #5500: shared INTEGRATION_ACTION_FAILED reply. Mirrors how the
  * CANCEL_ACTIVITY_FAILED session_error is built in input-handlers.js: the
  * `session_error` envelope with a stable `code`, a `reason` discriminator,
- * and the request's correlation fields (`requestId` / `action` / `repoPath`)
- * echoed so the dashboard can clear the exact row's pending state.
+ * and the request's correlation fields (`requestId` / `action` / `repoPath`,
+ * plus `runId` for #5502 re-runs) echoed so the dashboard can clear the
+ * exact row's pending state.
  */
 function integrationActionError(ws, ctx, msg, reason, message) {
   ctx.send(ws, {
@@ -359,22 +368,88 @@ function integrationActionError(ws, ctx, msg, reason, message) {
     reason,
     action: typeof msg?.action === 'string' ? msg.action : null,
     repoPath: typeof msg?.repoPath === 'string' ? msg.repoPath : null,
+    runId: Number.isInteger(msg?.runId) ? msg.runId : null,
     requestId: typeof msg?.requestId === 'string' ? msg.requestId : null,
   })
 }
 
 /**
- * #5500 (epic #5498) — `integration_action` handler. Currently one action:
- * `repo_memory_reindex`, which runs `repo-memory index <repoRoot>` host-side
- * to prewarm/refresh the summary cache (there is no watcher — the cache only
- * refreshes on agent reads or an explicit index run). Success replies with an
- * `integration_action_ack` carrying the parsed scanned/summarized/fresh/
- * skipped counts (or `counts: null` when the CLI output is unparseable);
- * every failure replies with an INTEGRATION_ACTION_FAILED session_error.
+ * #5500/#5502 — integration action registry. The shared handler below runs
+ * the authority / repoPath / repo-set-membership / in-flight gates ONCE for
+ * every action; each entry only contributes:
+ *   - `validate(msg)` — action-specific request-shape checks, run before any
+ *     path resolution. Returns `[reason, message]` to reject, or null.
+ *   - `run({ msg, ctx, config, targetKey })` — the exec, against the
+ *     CANONICAL realpath. Resolves the action-specific ack fields (spread
+ *     into the `integration_action_ack`); throws (optionally with a machine
+ *     `.reason`) to fail.
+ *   - `failureReason` — the fallback `reason` when a thrown error has none.
  *
- * SECURITY (docs/security/bearer-token-authority.md checklist): this handler
+ * The schema's closed enum already rejects unknown actions at the wire; the
+ * registry lookup is defence in depth for in-process callers/future drift.
+ */
+const integrationActions = {
+  /**
+   * #5500: `repo-memory index <repoRoot>` — prewarm/refresh the summary
+   * cache (there is no watcher — the cache only refreshes on agent reads or
+   * an explicit index run). Acks with the parsed scanned/summarized/fresh/
+   * skipped counts (or `counts: null` when the CLI output is unparseable).
+   * Safe alongside live sessions: repo-memory's cache is SQLite in WAL mode,
+   * so a concurrent index is safe next to an agent session reading summaries.
+   */
+  repo_memory_reindex: {
+    failureReason: 'index-failed',
+    validate: () => null,
+    async run({ ctx, config, targetKey }) {
+      const runFn = typeof ctx?.runRepoMemoryIndex === 'function' ? ctx.runRepoMemoryIndex : runRepoMemoryIndex
+      const bin = typeof config.controlRoomRepoMemoryBin === 'string' && config.controlRoomRepoMemoryBin.length > 0
+        ? config.controlRoomRepoMemoryBin
+        : undefined
+      const result = await runFn(targetKey, { bin })
+      return { counts: result && result.counts ? result.counts : null }
+    },
+  },
+  /**
+   * #5502: `gh run rerun <databaseId> -R <owner>/<repo>` for a FAILED
+   * repo-relay run. The client's `runId` is only a lookup key —
+   * runRepoRelayRerun re-fetches the run list server-side and requires the
+   * id to name a surfaced run with conclusion 'failure' before any exec.
+   * The rerun ack echoes the runId and carries `counts: null` (nothing to
+   * count — the new attempt shows as in_progress on the next refresh).
+   */
+  repo_relay_rerun: {
+    failureReason: 'rerun-failed',
+    validate(msg) {
+      if (!Number.isInteger(msg?.runId) || msg.runId < 0) {
+        return ['invalid-run-id',
+          'repo_relay_rerun requires an integer runId (the databaseId of a surveyed failed run)']
+      }
+      return null
+    },
+    async run({ msg, ctx, targetKey }) {
+      const runFn = typeof ctx?.runRepoRelayRerun === 'function' ? ctx.runRepoRelayRerun : runRepoRelayRerun
+      const result = await runFn(targetKey, msg.runId)
+      return { runId: result && Number.isInteger(result.runId) ? result.runId : msg.runId, counts: null }
+    },
+  },
+  // #5502 Part 2 (BLOCKED upstream) — `repo_relay_dispatch` ("Sync now")
+  // slots in HERE once blamechris/repo-relay#168 ships a workflow_dispatch
+  // trigger: same shared gates, `gh workflow run repo-relay.yml -R
+  // <owner>/<repo> -f ...`, additionally gated on the repo's pinned
+  // repo-relay version supporting dispatch (the #5501 drift data already
+  // carries the pin). Lands as its own PR when upstream releases.
+}
+
+/**
+ * #5500/#5502 (epic #5498) — `integration_action` handler. Dispatches to the
+ * `integrationActions` registry above; success replies with an
+ * `integration_action_ack` (the registry entry's fields + the correlation
+ * echo), every failure replies with exactly one INTEGRATION_ACTION_FAILED
+ * session_error.
+ *
+ * SECURITY (docs/security/bearer-token-authority.md checklist): every action
  * execs a binary against a host filesystem path, so two gates run BEFORE any
- * exec:
+ * exec — shared here, never per-action:
  *   1. Host-level authority — same bound-vs-unbound check as the surveys: a
  *      pairing-bound (share-a-session) client is scoped to one session and
  *      must not run host-wide actions.
@@ -386,13 +461,10 @@ function integrationActionError(ws, ctx, msg, reason, message) {
  *      realpath, never the raw client string — so traversal tricks
  *      (`repo/../../etc`) and symlink aliases collapse before comparison.
  *
- * Concurrency: one in-flight index per repo (overlapping requests on the
+ * Concurrency: one in-flight action per repo (overlapping requests on the
  * same repo are rejected with a clear error) plus a global cap of
- * MAX_CONCURRENT_REINDEX across all repos — rejected, not queued.
- *
- * Safe alongside live sessions: repo-memory's cache is SQLite in WAL mode,
- * so a concurrent index is safe next to an agent session reading summaries —
- * no session coordination is needed here.
+ * MAX_CONCURRENT_INTEGRATION_ACTIONS across all repos and action kinds —
+ * rejected, not queued (see the `actionInFlight` note on the shared bucket).
  */
 async function handleIntegrationAction(ws, client, msg, ctx) {
   const config = ctx?.config || {}
@@ -404,11 +476,14 @@ async function handleIntegrationAction(ws, client, msg, ctx) {
     return
   }
 
-  // The schema's closed enum already rejects unknown actions at the wire;
-  // this is defence in depth for in-process callers and future drift.
-  if (msg?.action !== 'repo_memory_reindex') {
+  // Registry lookup (Object.hasOwn so '__proto__'/'constructor' can't match
+  // inherited keys). The schema's closed enum already rejects unknown
+  // actions at the wire; this is defence in depth.
+  const action = typeof msg?.action === 'string' ? msg.action : ''
+  const actionEntry = Object.hasOwn(integrationActions, action) ? integrationActions[action] : null
+  if (!actionEntry) {
     integrationActionError(ws, ctx, msg, 'unsupported-action',
-      `Unsupported integration action: ${typeof msg?.action === 'string' ? msg.action : '(none)'}`)
+      `Unsupported integration action: ${action.length > 0 ? action : '(none)'}`)
     return
   }
 
@@ -422,16 +497,25 @@ async function handleIntegrationAction(ws, client, msg, ctx) {
       'integration_action requires a non-empty repoPath')
     return
   }
+
+  // Action-specific request-shape validation (e.g. #5502's required runId),
+  // still before any path resolution or exec.
+  const invalid = actionEntry.validate(msg)
+  if (invalid) {
+    integrationActionError(ws, ctx, msg, invalid[0], invalid[1])
+    return
+  }
+
   const root = typeof config.controlRoomRoot === 'string' && config.controlRoomRoot.length > 0
     ? config.controlRoomRoot
     : DEFAULT_CONTROL_ROOM_ROOT
   const repos = Array.isArray(config.repos) ? config.repos : []
 
-  // Tests inject ctx.resolveRepoSet / ctx.realpath / ctx.runRepoMemoryIndex
-  // to stub fs/exec; production falls through to the real implementations.
+  // Tests inject ctx.resolveRepoSet / ctx.realpath (and the per-action run
+  // seams, ctx.runRepoMemoryIndex / ctx.runRepoRelayRerun) to stub fs/exec;
+  // production falls through to the real implementations.
   const resolveFn = typeof ctx?.resolveRepoSet === 'function' ? ctx.resolveRepoSet : resolveRepoSet
   const realpathFn = typeof ctx?.realpath === 'function' ? ctx.realpath : realpathSync
-  const runFn = typeof ctx?.runRepoMemoryIndex === 'function' ? ctx.runRepoMemoryIndex : runRepoMemoryIndex
 
   // Repo-set membership gate (#2 above): canonicalize, then compare.
   let targetKey
@@ -468,42 +552,42 @@ async function handleIntegrationAction(ws, client, msg, ctx) {
     return
   }
 
-  // Per-repo overlap guard, then the global cap (reject, never queue).
-  if (reindexInFlight.has(targetKey)) {
-    integrationActionError(ws, ctx, msg, 'reindex-in-progress',
-      `A reindex is already in progress for ${targetKey}`)
+  // Per-repo overlap guard, then the global cap (reject, never queue). One
+  // shared bucket across action kinds — see the `actionInFlight` note.
+  if (actionInFlight.has(targetKey)) {
+    integrationActionError(ws, ctx, msg, 'action-in-progress',
+      `An integration action (${actionInFlight.get(targetKey)}) is already in progress for ${targetKey}`)
     return
   }
-  if (reindexInFlight.size >= MAX_CONCURRENT_REINDEX) {
+  if (actionInFlight.size >= MAX_CONCURRENT_INTEGRATION_ACTIONS) {
     integrationActionError(ws, ctx, msg, 'busy',
-      `The host is busy: ${reindexInFlight.size} reindex runs are already in flight (max ${MAX_CONCURRENT_REINDEX}) — retry when one finishes`)
+      `The host is busy: ${actionInFlight.size} integration actions are already in flight (max ${MAX_CONCURRENT_INTEGRATION_ACTIONS}) — retry when one finishes`)
     return
   }
 
-  const bin = typeof config.controlRoomRepoMemoryBin === 'string' && config.controlRoomRepoMemoryBin.length > 0
-    ? config.controlRoomRepoMemoryBin
-    : undefined
-
-  reindexInFlight.set(targetKey, true)
+  actionInFlight.set(targetKey, action)
   try {
     // Exec against the canonical realpath — never the raw client string.
-    const result = await runFn(targetKey, { bin })
-    log.info(`integration_action repo_memory_reindex completed for ${targetKey} (client=${client?.id})`)
+    const ackFields = await actionEntry.run({ msg, ctx, config, targetKey })
+    log.info(`integration_action ${action} completed for ${targetKey} (client=${client?.id})`)
     ctx.send(ws, {
       type: 'integration_action_ack',
-      action: 'repo_memory_reindex',
+      action,
       // Echo the CLIENT-supplied path so the dashboard's pending state
       // (keyed by what it sent) correlates even through a symlink alias.
       repoPath,
       requestId: typeof msg?.requestId === 'string' ? msg.requestId : null,
-      counts: result && result.counts ? result.counts : null,
+      ...ackFields,
     })
   } catch (err) {
-    const message = err && err.message ? err.message : 'repo-memory index failed'
-    log.warn(`integration_action repo_memory_reindex failed for ${targetKey}: ${message}`)
-    integrationActionError(ws, ctx, msg, 'index-failed', message)
+    const message = err && err.message ? err.message : `${action} failed`
+    log.warn(`integration_action ${action} failed for ${targetKey}: ${message}`)
+    const reason = err && typeof err.reason === 'string' && err.reason.length > 0
+      ? err.reason
+      : actionEntry.failureReason
+    integrationActionError(ws, ctx, msg, reason, message)
   } finally {
-    reindexInFlight.delete(targetKey)
+    actionInFlight.delete(targetKey)
   }
 }
 

--- a/packages/server/tests/control-room-rerun.test.js
+++ b/packages/server/tests/control-room-rerun.test.js
@@ -1,0 +1,339 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { controlRoomHandlers } from '../src/handlers/control-room-handlers.js'
+import { handleSessionMessage } from '../src/ws-message-handlers.js'
+import { createSpy } from './test-helpers.js'
+import {
+  runRepoRelayRerun,
+  RERUN_TIMEOUT_MS,
+  GH_MISSING_NOTE,
+} from '../src/control-room/integrations.js'
+import { ServerIntegrationActionAckSchema } from '@chroxy/protocol'
+
+/**
+ * Tests for the repo-relay Re-run action (#5502, epic #5498):
+ *   - runRepoRelayRerun (injected exec, no real subprocess) — gh/remote
+ *     derivation, the server-side runId RE-VALIDATION (re-fetch `gh run list`
+ *     and require the id to be present AND concluded 'failure' before any
+ *     `gh run rerun` exec), and legible failure reasons.
+ *   - the `integration_action` WS handler with action `repo_relay_rerun` —
+ *     same authority + repo-set gates as reindex (shared code path), the
+ *     required-for-rerun runId validation, the SHARED per-repo in-flight /
+ *     global-cap bucket, and ack/error correlation echoing the runId.
+ */
+
+const SLUG_REMOTE = 'git@github.com:blamechris/chroxy.git\n'
+const RUN_LIST = JSON.stringify([
+  { databaseId: 9002, conclusion: null, status: 'in_progress' },
+  { databaseId: 9001, conclusion: 'failure', status: 'completed' },
+  { databaseId: 9000, conclusion: 'success', status: 'completed' },
+])
+
+/** Injected exec fake covering the happy path; override per test. */
+function makeExec(overrides = {}) {
+  return createSpy(async (file, args) => {
+    if (file === 'which') return { stdout: '/opt/homebrew/bin/gh\n', stderr: '' }
+    if (file === 'git') {
+      if (overrides.git) return overrides.git(args)
+      return { stdout: SLUG_REMOTE, stderr: '' }
+    }
+    if (args[0] === 'run' && args[1] === 'list') {
+      if (overrides.runList) return overrides.runList(args)
+      return { stdout: RUN_LIST, stderr: '' }
+    }
+    if (args[0] === 'run' && args[1] === 'rerun') {
+      if (overrides.rerun) return overrides.rerun(args)
+      return { stdout: '', stderr: '' }
+    }
+    throw new Error(`unexpected exec: ${file} ${args.join(' ')}`)
+  })
+}
+
+describe('runRepoRelayRerun (#5502)', () => {
+  it('re-validates the runId against a fresh gh run list, then execs gh run rerun', async () => {
+    const execSpy = makeExec()
+    const result = await runRepoRelayRerun('/p/chroxy', 9001, { _execFile: execSpy })
+    assert.deepEqual(result, { runId: 9001 })
+
+    const listCall = execSpy.calls.find(c => c[1][0] === 'run' && c[1][1] === 'list')
+    assert.deepEqual(listCall[1], [
+      'run', 'list', '--workflow=repo-relay.yml', '-R', 'blamechris/chroxy',
+      '--limit', '5', '--json', 'databaseId,conclusion,status',
+    ], 'must re-fetch the exact window the survey surfaced')
+
+    const rerunCall = execSpy.calls.find(c => c[1][0] === 'run' && c[1][1] === 'rerun')
+    assert.equal(rerunCall[0], '/opt/homebrew/bin/gh')
+    assert.deepEqual(rerunCall[1], ['run', 'rerun', '9001', '-R', 'blamechris/chroxy'])
+    assert.equal(rerunCall[2].timeout, RERUN_TIMEOUT_MS, 'rerun gets the ~30s timeout')
+
+    // The list re-fetch MUST happen before the rerun exec.
+    const listIdx = execSpy.calls.indexOf(listCall)
+    const rerunIdx = execSpy.calls.indexOf(rerunCall)
+    assert.ok(listIdx < rerunIdx, 're-validation runs before the exec')
+  })
+
+  it('derives owner/repo from the git remote server-side (https form too)', async () => {
+    const execSpy = makeExec({ git: () => ({ stdout: 'https://github.com/someorg/somerepo.git\n', stderr: '' }) })
+    await runRepoRelayRerun('/p/somerepo', 9001, { _execFile: execSpy })
+    const rerunCall = execSpy.calls.find(c => c[1][0] === 'run' && c[1][1] === 'rerun')
+    assert.deepEqual(rerunCall[1], ['run', 'rerun', '9001', '-R', 'someorg/somerepo'])
+    const gitCall = execSpy.calls.find(c => c[0] === 'git')
+    assert.equal(gitCall[2].cwd, '/p/somerepo', 'remote read runs in the repo')
+  })
+
+  it('throws the gh-missing note when gh cannot be resolved (no exec attempted)', async () => {
+    const execSpy = createSpy(async (file) => {
+      if (file === 'which') throw new Error('not found')
+      throw new Error('must not exec anything else')
+    })
+    await assert.rejects(
+      () => runRepoRelayRerun('/p/chroxy', 9001, { _execFile: execSpy }),
+      err => err.message === GH_MISSING_NOTE && err.reason === 'gh-missing',
+    )
+  })
+
+  it('throws no-github-remote when the origin remote is missing or not GitHub', async () => {
+    for (const git of [
+      () => { throw new Error('fatal: no such remote') },
+      () => ({ stdout: 'https://gitlab.com/x/y.git\n', stderr: '' }),
+    ]) {
+      const execSpy = makeExec({ git })
+      await assert.rejects(
+        () => runRepoRelayRerun('/p/chroxy', 9001, { _execFile: execSpy }),
+        err => err.reason === 'no-github-remote' && /no GitHub remote/.test(err.message),
+      )
+      assert.equal(execSpy.calls.some(c => c[1][0] === 'run'), false, 'no gh run calls without a target')
+    }
+  })
+
+  it('rejects a runId the fresh run list does not contain — never trusts the client id', async () => {
+    const execSpy = makeExec()
+    await assert.rejects(
+      () => runRepoRelayRerun('/p/chroxy', 1234567, { _execFile: execSpy }),
+      err => err.reason === 'unknown-run' && /1234567/.test(err.message) && /refresh/i.test(err.message),
+    )
+    assert.equal(execSpy.calls.some(c => c[1][0] === 'run' && c[1][1] === 'rerun'), false, 'must not exec rerun')
+  })
+
+  it('rejects a run that did not conclude failure (success and in-progress)', async () => {
+    for (const [runId, statePattern] of [[9000, /success/], [9002, /in_progress/]]) {
+      const execSpy = makeExec()
+      await assert.rejects(
+        () => runRepoRelayRerun('/p/chroxy', runId, { _execFile: execSpy }),
+        err => err.reason === 'run-not-failed' && statePattern.test(err.message) && /only failed runs/i.test(err.message),
+      )
+      assert.equal(execSpy.calls.some(c => c[1][0] === 'run' && c[1][1] === 'rerun'), false)
+    }
+  })
+
+  it('throws run-list-failed when the re-fetch fails or is unparseable', async () => {
+    const failing = makeExec({ runList: () => { const e = new Error('boom'); e.stderr = 'HTTP 502\nmore'; throw e } })
+    await assert.rejects(
+      () => runRepoRelayRerun('/p/chroxy', 9001, { _execFile: failing }),
+      err => err.reason === 'run-list-failed' && /gh run list failed: HTTP 502/.test(err.message),
+    )
+    const garbage = makeExec({ runList: () => ({ stdout: 'not json', stderr: '' }) })
+    await assert.rejects(
+      () => runRepoRelayRerun('/p/chroxy', 9001, { _execFile: garbage }),
+      err => err.reason === 'run-list-failed' && /unparseable/.test(err.message),
+    )
+  })
+
+  it('throws rerun-failed with the first stderr line when gh run rerun fails', async () => {
+    const execSpy = makeExec({
+      rerun: () => { const e = new Error('exit 1'); e.stderr = 'failed to rerun: run 9001 cannot be rerun\nstack'; throw e },
+    })
+    await assert.rejects(
+      () => runRepoRelayRerun('/p/chroxy', 9001, { _execFile: execSpy }),
+      err => err.reason === 'rerun-failed' && /gh run rerun failed: failed to rerun/.test(err.message),
+    )
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// integration_action handler — repo_relay_rerun
+// ───────────────────────────────────────────────────────────────────────────
+
+const REPO_SET = [
+  { name: 'chroxy', path: '/home/user/Projects/chroxy' },
+  { name: 'other', path: '/home/user/Projects/other' },
+  { name: 'third', path: '/home/user/Projects/third' },
+]
+
+function makeActionCtx(overrides = {}) {
+  const sendSpy = createSpy()
+  return {
+    send: sendSpy,
+    config: { repos: [], controlRoomRoot: '/home/user/Projects' },
+    resolveRepoSet: createSpy(() => REPO_SET.map(r => ({ ...r }))),
+    runRepoRelayRerun: createSpy(async (repoPath, runId) => ({ runId })),
+    runRepoMemoryIndex: createSpy(async () => ({ counts: null })),
+    realpath: createSpy(p => p),
+    ...overrides,
+    _send: sendSpy,
+  }
+}
+
+function rerunMsg(over = {}) {
+  return {
+    type: 'integration_action',
+    action: 'repo_relay_rerun',
+    repoPath: '/home/user/Projects/chroxy',
+    runId: 9001,
+    requestId: 'rr-1',
+    ...over,
+  }
+}
+
+describe('integration_action handler — repo_relay_rerun (#5502)', () => {
+  let ctx, client, ws
+
+  beforeEach(() => {
+    ctx = makeActionCtx()
+    client = { id: 'client-RR' }
+    ws = {}
+  })
+
+  it('replies with a schema-conformant ack echoing requestId/action/repoPath/runId (no counts)', async () => {
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg(), ctx)
+    assert.equal(ctx._send.callCount, 1, 'exactly one reply')
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.type, 'integration_action_ack')
+    assert.equal(payload.action, 'repo_relay_rerun')
+    assert.equal(payload.repoPath, '/home/user/Projects/chroxy')
+    assert.equal(payload.requestId, 'rr-1')
+    assert.equal(payload.runId, 9001)
+    assert.equal(payload.counts, null)
+    const parsed = ServerIntegrationActionAckSchema.safeParse(payload)
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues))
+    // The runner received the canonical path + the client runId as lookup key.
+    assert.deepEqual(ctx.runRepoRelayRerun.lastCall.slice(0, 2), ['/home/user/Projects/chroxy', 9001])
+  })
+
+  it('rejects a session-bound client before any exec (same gate as reindex)', async () => {
+    client.boundSessionId = 'sess-1'
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg(), ctx)
+    assert.equal(ctx.runRepoRelayRerun.callCount, 0)
+    assert.equal(ctx.resolveRepoSet.callCount, 0)
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.code, 'INTEGRATION_ACTION_FAILED')
+    assert.equal(payload.action, 'repo_relay_rerun')
+    assert.match(payload.message, /host-level authority/)
+  })
+
+  it('rejects a repoPath outside the surveyed repo set before any exec', async () => {
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg({ repoPath: '/etc' }), ctx)
+    assert.equal(ctx.runRepoRelayRerun.callCount, 0)
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.code, 'INTEGRATION_ACTION_FAILED')
+    assert.equal(payload.repoPath, '/etc')
+  })
+
+  it('rejects a missing or non-integer runId before any path resolution', async () => {
+    for (const over of [{ runId: undefined }, { runId: null }, { runId: 1.5 }, { runId: -1 }, { runId: '9001' }]) {
+      ctx = makeActionCtx()
+      await controlRoomHandlers.integration_action(ws, client, rerunMsg(over), ctx)
+      assert.equal(ctx.realpath.callCount, 0, `must reject before realpath for runId=${String(over.runId)}`)
+      assert.equal(ctx.runRepoRelayRerun.callCount, 0)
+      const [, payload] = ctx._send.lastCall
+      assert.equal(payload.code, 'INTEGRATION_ACTION_FAILED')
+      assert.equal(payload.requestId, 'rr-1')
+      assert.match(payload.message, /runId/)
+    }
+  })
+
+  it('runs against the canonical realpath for a symlinked alias, echoing the client path', async () => {
+    ctx = makeActionCtx({
+      realpath: createSpy(p => (p === '/home/user/link-to-chroxy' ? '/home/user/Projects/chroxy' : p)),
+    })
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg({ repoPath: '/home/user/link-to-chroxy' }), ctx)
+    assert.equal(ctx.runRepoRelayRerun.lastCall[0], '/home/user/Projects/chroxy')
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.type, 'integration_action_ack')
+    assert.equal(payload.repoPath, '/home/user/link-to-chroxy')
+  })
+
+  it('maps a thrown rerun failure to INTEGRATION_ACTION_FAILED echoing requestId + runId', async () => {
+    ctx = makeActionCtx({
+      runRepoRelayRerun: createSpy(async () => {
+        const err = new Error('run 9001 did not fail (success) — only failed runs can be re-run')
+        err.reason = 'run-not-failed'
+        throw err
+      }),
+    })
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg(), ctx)
+    assert.equal(ctx._send.callCount, 1, 'exactly one reply on failure too')
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.type, 'session_error')
+    assert.equal(payload.code, 'INTEGRATION_ACTION_FAILED')
+    assert.equal(payload.reason, 'run-not-failed')
+    assert.equal(payload.requestId, 'rr-1')
+    assert.equal(payload.runId, 9001)
+    assert.match(payload.message, /only failed runs/)
+  })
+
+  it('shares the per-repo in-flight bucket with reindex (a reindex blocks a rerun on the same repo)', async () => {
+    let release
+    const gate = new Promise(r => { release = r })
+    ctx = makeActionCtx({
+      runRepoMemoryIndex: createSpy(async () => { await gate; return { counts: null } }),
+    })
+    const reindex = controlRoomHandlers.integration_action(ws, client, {
+      type: 'integration_action', action: 'repo_memory_reindex',
+      repoPath: '/home/user/Projects/chroxy', requestId: 'ix-1',
+    }, ctx)
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg({ requestId: 'rr-2' }), ctx)
+    assert.equal(ctx.runRepoRelayRerun.callCount, 0, 'rerun must not exec while a reindex holds the repo slot')
+    const rejected = ctx._send.calls.find(c => c[1].requestId === 'rr-2')
+    assert.equal(rejected[1].code, 'INTEGRATION_ACTION_FAILED')
+    assert.match(rejected[1].message, /already in progress/i)
+    release()
+    await reindex
+    // Slot freed — the rerun goes through now.
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg({ requestId: 'rr-3' }), ctx)
+    assert.equal(ctx.runRepoRelayRerun.callCount, 1)
+  })
+
+  it('counts toward the shared global cap of 2 across action kinds', async () => {
+    let release
+    const gate = new Promise(r => { release = r })
+    ctx = makeActionCtx({
+      runRepoMemoryIndex: createSpy(async () => { await gate; return { counts: null } }),
+      runRepoRelayRerun: createSpy(async (repoPath, runId) => { await gate; return { runId } }),
+    })
+    const p1 = controlRoomHandlers.integration_action(ws, client, {
+      type: 'integration_action', action: 'repo_memory_reindex',
+      repoPath: '/home/user/Projects/chroxy', requestId: 'a',
+    }, ctx)
+    const p2 = controlRoomHandlers.integration_action(
+      ws, client, rerunMsg({ repoPath: '/home/user/Projects/other', requestId: 'b' }), ctx,
+    )
+    await controlRoomHandlers.integration_action(
+      ws, client, rerunMsg({ repoPath: '/home/user/Projects/third', requestId: 'c' }), ctx,
+    )
+    const rejected = ctx._send.calls.find(c => c[1].requestId === 'c')
+    assert.equal(rejected[1].code, 'INTEGRATION_ACTION_FAILED')
+    assert.match(rejected[1].message, /busy/i)
+    release()
+    await Promise.all([p1, p2])
+    const ackB = ctx._send.calls.find(c => c[1].requestId === 'b')
+    assert.equal(ackB[1].type, 'integration_action_ack')
+  })
+
+  it('frees the in-flight slot even when the rerun throws', async () => {
+    ctx = makeActionCtx({
+      runRepoRelayRerun: createSpy(async () => { throw new Error('exploded') }),
+    })
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg({ requestId: 'a' }), ctx)
+    await controlRoomHandlers.integration_action(ws, client, rerunMsg({ requestId: 'b' }), ctx)
+    assert.equal(ctx.runRepoRelayRerun.callCount, 2, 'a failed rerun must not wedge the per-repo slot')
+  })
+
+  it('dispatches through the registry via handleSessionMessage', async () => {
+    await handleSessionMessage(ws, client, rerunMsg({ requestId: 'reg' }), ctx)
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.type, 'integration_action_ack')
+    assert.equal(payload.action, 'repo_relay_rerun')
+    assert.equal(payload.requestId, 'reg')
+  })
+})


### PR DESCRIPTION
## Summary

Part 1 of the repo-relay control half (epic #5498): a **Re-run** action on the Control Room Integrations tab for repos whose latest relay run failed. Reuses the `integration_action` / `integration_action_ack` envelope from the reindex action (#5503/#5504) and the run data the observability snapshot (#5505) already surfaces.

## runId re-validation design

The client-supplied `runId` is never trusted as an exec target — it is only a **lookup key**:

1. The dashboard sends the `databaseId` of the latest failed run from the snapshot.
2. At action time the server re-derives `owner/repo` from the repo's git remote (the #5505 `parseGithubOwnerRepo` derivation — never from the client) and **re-fetches** `gh run list --workflow=repo-relay.yml -R <owner>/<repo> --limit 5 --json databaseId,conclusion,status`.
3. The runId must be present in that fresh list AND have `conclusion == 'failure'`. Unknown ids reject with `unknown-run` ("refresh the survey and retry"); non-failed runs (success, cancelled, still in progress) reject with `run-not-failed`. Only then does `gh run rerun <databaseId> -R <owner>/<repo>` exec (execFile args array, 30s timeout).

Shared, not copy-pasted, with reindex: the handler now dispatches through an action registry, so the host-level authority gate (bound tokens rejected), the realpath repo-set membership validation, and the per-repo in-flight + global cap (one bucket across action kinds, cap 2 — a repo gets at most one mutating integration action at a time and total subprocess fan-out stays bounded regardless of which buttons are mashed) run once for every action. Failures reply exactly once with an `INTEGRATION_ACTION_FAILED` session_error echoing `requestId`/`action`/`repoPath`/`runId`; the rerun ack echoes the same with `counts: null`.

Dashboard: the Re-run button only renders when the latest run's conclusion is `failure`, shows a per-repo busy state until the ack/error, then an inline "re-run requested" note inviting a refresh (the new attempt appears as in_progress on the next survey). Rerun state lives in its own store bucket so a rerun outcome can never clear (or be cleared by) a reindex on the same repo.

## Part 2 — manual dispatch ("Sync now") is upstream-blocked

repo-relay has no `workflow_dispatch` trigger, so a manual relay pass cannot be fired yet — blocked on blamechris/repo-relay#168. This PR deliberately does NOT implement `repo_relay_dispatch`; it ships:

- a permanently-disabled **Sync now** stub on installed rows whose tooltip names the blocker, and
- a documented slot in the server's action registry where the dispatch action lands (its own PR, gated on the pinned version supporting dispatch) once upstream releases.

## Tests

- Protocol: 275 pass (new enum/runId/ack coverage)
- Server: 305 pass across `control-room-*` + `ws-message-handlers` suites (`--test-force-exit`), incl. new `control-room-rerun.test.js` with injected `gh` fakes for accept/reject/error paths and shared-bucket concurrency
- Dashboard: full vitest suite 3373 pass; `tsc --noEmit` clean
- Server shell lints (state-file-path, opt-forwarding, logger-scoping) + eslint clean

Closes #5502.
Related to #5498.
Related to blamechris/repo-relay#168.