### PR TITLE
feat(control-room): per-repo Open-session button on the Project status tab

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -90,7 +90,7 @@ import { ConsolePage } from './components/ConsolePage'
 import { EnvironmentPanel } from './components/EnvironmentPanel'
 import { SnapshotsPanel } from './components/SnapshotsPanel'
 import { PoolStatsPanel } from './components/PoolStatsPanel'
-import { type RepoInvestigateRequest } from './components/ControlRoomSection'
+import { type RepoInvestigateRequest, type RepoOpenSessionRequest } from './components/ControlRoomSection'
 import { ControlRoomView } from './components/ControlRoomView'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
@@ -1462,6 +1462,15 @@ export function App() {
     openCreateSession({ cwd: req.cwd, seed: req.reason })
   }, [openCreateSession])
 
+  // #5507 — open the create-session picker pre-filled for an "Open session"
+  // row action: cwd = the repo path. Same plumbing as Investigate minus the
+  // composer seeding (no reason note) — the modal suggests + dedupes the
+  // session name from the repo's basename, and the user picks
+  // model/provider/permission/worktree before creating.
+  const handleOpenSession = useCallback((req: RepoOpenSessionRequest) => {
+    openCreateSession({ cwd: req.cwd })
+  }, [openCreateSession])
+
   // #4695 / #4942 — bridge the macOS menu bar items to App-state
   // handlers. See the `useTauriMenuEvents` call below `handleShowQr`
   // (further down in this file) for the actual wiring — we can't
@@ -2448,7 +2457,7 @@ export function App() {
             double-rendering with the disconnected/startup screens. */}
         {controlRoomActive && (
           <div className="main-content" data-testid="control-room-main">
-            <ControlRoomView onInvestigate={handleInvestigate} />
+            <ControlRoomView onInvestigate={handleInvestigate} onOpenSession={handleOpenSession} />
           </div>
         )}
 

--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -870,3 +870,79 @@ describe('ControlRoomSection investigate action (#5202)', () => {
     expect(screen.getByTestId('cr-verdict-onboarded').tagName).toBe('SPAN')
   })
 })
+
+describe('ControlRoomSection open-session action (#5507)', () => {
+  it('does not render an Open session action when no handler is wired', () => {
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    expect(screen.queryByTestId('cr-action-open-chroxy')).toBeNull()
+    expect(screen.queryByTestId('cr-action-open-medlens')).toBeNull()
+    expect(screen.queryByTestId('cr-action-open-no-it-all')).toBeNull()
+  })
+
+  it('renders an Open session action on every repo row, regardless of verdict', () => {
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onOpenSession={() => {}}
+      />,
+    )
+    // live, investigate, and onboarded rows all get the action.
+    expect(screen.getByTestId('cr-action-open-chroxy').tagName).toBe('BUTTON')
+    expect(screen.getByTestId('cr-action-open-medlens').tagName).toBe('BUTTON')
+    expect(screen.getByTestId('cr-action-open-no-it-all').tagName).toBe('BUTTON')
+  })
+
+  it('gives the Open session button a per-row accessible name including the repo', () => {
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onOpenSession={() => {}}
+      />,
+    )
+    const btn = screen.getByTestId('cr-action-open-medlens')
+    expect(btn).toHaveAttribute('aria-label', expect.stringContaining('medlens'))
+  })
+
+  it('calls onOpenSession with the repo cwd and name on click', () => {
+    const onOpenSession = vi.fn()
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onOpenSession={onOpenSession}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('cr-action-open-medlens'))
+    expect(onOpenSession).toHaveBeenCalledWith({
+      cwd: '/Users/me/Projects/medlens',
+      name: 'medlens',
+    })
+  })
+
+  it('opens a session even for a repo with a live session (multi-session allowed)', () => {
+    const onOpenSession = vi.fn()
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onOpenSession={onOpenSession}
+      />,
+    )
+    // chroxy is the live row — still actionable.
+    fireEvent.click(screen.getByTestId('cr-action-open-chroxy'))
+    expect(onOpenSession).toHaveBeenCalledWith({
+      cwd: '/Users/me/Projects/chroxy',
+      name: 'chroxy',
+    })
+  })
+})

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -253,6 +253,22 @@ export interface RepoInvestigateRequest {
 }
 
 /**
+ * #5507 — payload emitted when an operator clicks a repo's "Open session" row
+ * action. The host wires this to the create-session flow exactly like
+ * `onInvestigate` (see `:243`), minus the investigate-specific composer seeding:
+ * it opens the picker pre-filled with `cwd`, and the modal's existing logic
+ * suggests + dedupes a session name from the repo's basename (`name` is the
+ * suggested label / contract hint). Available on every repo row, regardless of
+ * verdict — unlike Investigate, this is not gated on an actionable verdict.
+ */
+export interface RepoOpenSessionRequest {
+  /** Absolute path of the repo — becomes the new session's cwd. */
+  cwd: string
+  /** Repo display name, the suggested session name (modal dedupes collisions). */
+  name: string
+}
+
+/**
  * #5202 — which verdicts are clickable "control actions". Start with
  * `investigate` only; extend this map per-verdict as more actions land (e.g.
  * `abandoned` → review-and-clean) so the click wiring grows in one place.
@@ -576,8 +592,11 @@ function AttributionCell({ attribution }: { attribution: boolean | null }) {
  * the absolute repo path to the clipboard). Both are side-effect-free from the
  * server's perspective — no local command execution — so they behave identically
  * in the web dashboard and the desktop app.
+ *
+ * #5507 — adds an "Open session" action (shown on every row when `onOpenSession`
+ * is wired) that opens the create-session modal pre-filled with this repo's cwd.
  */
-function RowActions({ repo }: { repo: RepoStatus }) {
+function RowActions({ repo, onOpenSession }: { repo: RepoStatus; onOpenSession?: (req: RepoOpenSessionRequest) => void }) {
   const [copied, setCopied] = useState(false)
   const copyPath = useCallback(() => {
     // Route through the shared clipboard helper, which uses the Tauri plugin
@@ -614,6 +633,26 @@ function RowActions({ repo }: { repo: RepoStatus }) {
       >
         {copied ? 'Copied' : 'Copy path'}
       </button>
+      {onOpenSession && (
+        <button
+          type="button"
+          className="cr-action"
+          data-testid={`cr-action-open-${repo.name}`}
+          // #5507 — the visible label is just "Open session", identical on every
+          // row; give screen readers a per-row accessible name (the title tooltip
+          // is not a reliable accessible-name source). The hint flags that opening
+          // a session in a live repo runs alongside the existing one.
+          aria-label={`Open a session in ${repo.name} (${repo.path})`}
+          title={
+            repo.live
+              ? `Open another session in ${repo.path} (a live session is already running here)`
+              : `Open a session in ${repo.path}`
+          }
+          onClick={() => onOpenSession({ cwd: repo.path, name: repo.name })}
+        >
+          Open session
+        </button>
+      )}
     </td>
   )
 }
@@ -632,6 +671,8 @@ interface RepoRowsProps {
   now?: () => number
   /** #5202 — investigate action, forwarded to the verdict tag. */
   onInvestigate?: (req: RepoInvestigateRequest) => void
+  /** #5507 — open-session action, forwarded to the row actions cell. */
+  onOpenSession?: (req: RepoOpenSessionRequest) => void
   /** #5272 — cancel a subagent in this repo's session (bound to its sessionId). */
   onCancelActivity?: (activityId: string, sessionId: string) => void
   /** #5272 — interrupt this repo's session (heading "Interrupt turn"). */
@@ -640,7 +681,7 @@ interface RepoRowsProps {
   cancellingActivityIds?: ReadonlySet<string>
 }
 
-function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onInvestigate, onCancelActivity, onInterruptSession, cancellingActivityIds }: RepoRowsProps) {
+function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onInvestigate, onOpenSession, onCancelActivity, onInterruptSession, cancellingActivityIds }: RepoRowsProps) {
   // Map repo → its active chroxy session (by cwd). When a session is found the
   // name cell becomes a disclosure toggle that reveals that session's live
   // activity tree (subagents / shells / tools — the retired v1 panel's view).
@@ -703,7 +744,7 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onI
         <PrCell repo={repo} />
         <AttributionCell attribution={repo.attribution} />
         <td className="cr-dim cr-last">{relativeLast(repo.lastTouched)}</td>
-        <RowActions repo={repo} />
+        <RowActions repo={repo} onOpenSession={onOpenSession} />
       </tr>
       {repo.note && (
         <tr className="cr-act" data-testid={`cr-note-row-${repo.name}`}>
@@ -812,6 +853,13 @@ export interface ControlRoomSectionProps {
    */
   onInvestigate?: (req: RepoInvestigateRequest) => void
   /**
+   * #5507 — invoked when an operator clicks a repo's "Open session" row action.
+   * The host opens the create-session picker pre-filled with the repo cwd (same
+   * plumbing as `onInvestigate`, minus the composer seeding). Available on every
+   * repo row regardless of verdict.
+   */
+  onOpenSession?: (req: RepoOpenSessionRequest) => void
+  /**
    * #5272 — cancel a subagent node in a drill-down's session. Defaults to the
    * store's `sendCancelActivity`. Injectable for tests.
    */
@@ -837,6 +885,7 @@ export function ControlRoomSection({
   sessions: sessionsProp,
   now = Date.now,
   onInvestigate,
+  onOpenSession,
   onCancelActivity: onCancelActivityProp,
   onInterruptSession: onInterruptSessionProp,
 }: ControlRoomSectionProps = {}) {
@@ -1081,6 +1130,7 @@ export function ControlRoomSection({
                       onToggleExpand={handleToggleRepo}
                       now={now}
                       onInvestigate={onInvestigate}
+                      onOpenSession={onOpenSession}
                       onCancelActivity={onCancelActivity}
                       onInterruptSession={onInterruptSession}
                       cancellingActivityIds={cancellingActivityIds}

--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -4,7 +4,7 @@
  * Covers: all tabs render, the repos tab is the default, clicking a tab swaps
  * the active section, the choice is persisted to localStorage and restored on
  * the next mount, a stale/garbage persisted value degrades to the default, and
- * onInvestigate is forwarded to the repo section.
+ * onInvestigate / onOpenSession are forwarded to the repo section.
  *
  * The child sections each read the zustand store; stub them so this test
  * only exercises the tab shell.
@@ -13,8 +13,14 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 
 vi.mock('./ControlRoomSection', () => ({
-  ControlRoomSection: ({ onInvestigate }: { onInvestigate?: unknown }) => (
-    <div data-testid="stub-repos" data-has-investigate={onInvestigate ? 'yes' : 'no'}>repos</div>
+  ControlRoomSection: ({ onInvestigate, onOpenSession }: { onInvestigate?: unknown; onOpenSession?: unknown }) => (
+    <div
+      data-testid="stub-repos"
+      data-has-investigate={onInvestigate ? 'yes' : 'no'}
+      data-has-open-session={onOpenSession ? 'yes' : 'no'}
+    >
+      repos
+    </div>
   ),
 }))
 vi.mock('./RunnerStatusSection', () => ({
@@ -85,6 +91,11 @@ describe('ControlRoomView', () => {
   it('forwards onInvestigate to the repo section', () => {
     render(<ControlRoomView onInvestigate={() => {}} />)
     expect(screen.getByTestId('stub-repos').getAttribute('data-has-investigate')).toBe('yes')
+  })
+
+  it('forwards onOpenSession to the repo section', () => {
+    render(<ControlRoomView onOpenSession={() => {}} />)
+    expect(screen.getByTestId('stub-repos').getAttribute('data-has-open-session')).toBe('yes')
   })
 
   it('honours an explicit initialTab override', () => {

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -15,7 +15,7 @@
  * `onInvestigate` action through to the repo table unchanged.
  */
 import { useCallback, useState } from 'react'
-import { ControlRoomSection, type RepoInvestigateRequest } from './ControlRoomSection'
+import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
 import { RunnerStatusSection } from './RunnerStatusSection'
 import { IntegrationsSection } from './IntegrationsSection'
 
@@ -51,11 +51,13 @@ const TABS: ReadonlyArray<{ key: ControlRoomTab; label: string }> = [
 export interface ControlRoomViewProps {
   /** Forwarded to the repo table's actionable verdict tags (#5202). */
   onInvestigate?: (req: RepoInvestigateRequest) => void
+  /** Forwarded to the repo table's per-row "Open session" action (#5507). */
+  onOpenSession?: (req: RepoOpenSessionRequest) => void
   /** Optional initial tab override (defaults to the persisted tab). For tests. */
   initialTab?: ControlRoomTab
 }
 
-export function ControlRoomView({ onInvestigate, initialTab }: ControlRoomViewProps = {}) {
+export function ControlRoomView({ onInvestigate, onOpenSession, initialTab }: ControlRoomViewProps = {}) {
   const [tab, setTab] = useState<ControlRoomTab>(() => initialTab ?? loadPersistedTab())
 
   const selectTab = useCallback((next: ControlRoomTab) => {
@@ -102,7 +104,7 @@ export function ControlRoomView({ onInvestigate, initialTab }: ControlRoomViewPr
         })}
       </div>
       {tab === 'repos' ? (
-        <ControlRoomSection onInvestigate={onInvestigate} />
+        <ControlRoomSection onInvestigate={onInvestigate} onOpenSession={onOpenSession} />
       ) : tab === 'runners' ? (
         <RunnerStatusSection />
       ) : (


### PR DESCRIPTION
## What

Adds a per-repo **Open session** row action to every repo row in the Control Room's **Project status** tab (`ControlRoomSection`). Previously the only session entry point from the table was the Investigate verdict tag, which only appears for actionable verdicts and carries investigate-specific semantics. Now any repo can be opened directly.

Clicking **Open session** opens the existing `CreateSessionModal` pre-filled with that repo's path (`initialCwd`). The modal's existing logic suggests a session name from the repo basename and dedupes it against existing names; the user picks provider / model / permission mode / worktree as usual and hits Create. No new prompt UI — the modal *is* the basic prompt.

## Wiring

- **`ControlRoomSection.tsx`** — new `onOpenSession?: (req: { cwd: string; name: string }) => void` prop, threaded through `RepoRowsProps` → `RepoRows` → `RowActions` exactly like the existing `onInvestigate`. The button renders in the row-actions cell (next to View PRs / Copy path) on **every** row when the handler is wired — not gated on a verdict. A per-row `aria-label` gives screen readers the repo name; live repos get a title hint that the new session runs alongside the existing one (multi-session per repo is supported).
- **`ControlRoomView.tsx`** — forwards `onOpenSession` to the repo section alongside `onInvestigate`.
- **`App.tsx`** — `handleOpenSession` routes through the shared `openCreateSession({ cwd })` opener, **minus** the investigate composer seeding (no `seed`/reason note). The single-owner opener clears any stale seed, so no investigate reason can leak into an Open-session launch.

## Behaviour preserved

- Investigate is byte-identical — its `VerdictTag` button, `RepoInvestigateRequest`, and `handleInvestigate` paths are untouched.
- No protocol or server changes; dashboard-only wiring into the existing create-session flow.

## Tests

- `ControlRoomSection.test.tsx` — new `open-session action (#5507)` block: no action without a handler, action on every row regardless of verdict, per-row accessible name, callback payload `{ cwd, name }`, and the live-repo case still actionable.
- `ControlRoomView.test.tsx` — `onOpenSession` forwarding to the repo section (mirrors the `onInvestigate` forwarding test).
- Full dashboard suite green (3381 tests) and `tsc --noEmit` clean.

Closes #5507.

Related to #5159.