### PR TITLE
feat: latency instrumentation — serverTs on stream messages, stamped pong, token-to-render summary

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1882,6 +1882,30 @@ describe('stream_delta handler', () => {
     expect(msg?.content).toBe('Hello world');
   });
 
+  // #5515 (epic #5514): the latency instrumentation reads the optional
+  // serverTs off the delta and a serverTs off the pong; neither may perturb the
+  // existing hot path. Content must still accumulate and render exactly, and a
+  // stamped pong must be consumed without throwing.
+  it('renders delta content unchanged when serverTs is present (#5515)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1', serverTs: 1_700_000_000_000 });
+    _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Hello', serverTs: 1_700_000_000_010 });
+    _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: ' world', serverTs: 1_700_000_000_020 });
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.messages.find((m) => m.id === 'msg-1')?.content).toBe('Hello world');
+    // A stamped pong must not throw (RTT split is best-effort, dev-log only).
+    expect(() => _testMessageHandler.handle({ type: 'pong', serverTs: 1_700_000_000_030 })).not.toThrow();
+  });
+
   it('ID collision: routes deltas to suffixed response ID', () => {
     const toolMsg = { id: 'msg-1', type: 'tool_use' as const, content: 'ls', timestamp: 1 };
     const store = createMockStore({

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -135,6 +135,9 @@ import {
   // toast uses, so the mobile Alert and the dashboard sub-line can't
   // drift apart on copy/format.
   formatPartialCostLine,
+  // #5515 (epic #5514): latency instrumentation primitives.
+  RollingPercentiles,
+  splitRtt,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
@@ -262,6 +265,16 @@ interface MessageHandlerContext extends EncryptionContext {
   pendingDeltas: Map<string, { sessionId: string | null; delta: string }>;
   deltaFlushTimer: ReturnType<typeof setTimeout> | null;
 
+  // #5515 (epic #5514): latency instrumentation. `deltaServerTs` records the
+  // server-stamped serverTs (and local recv time) of the OLDEST un-rendered
+  // delta per messageId; on flush we measure serverTs→render (token-to-render)
+  // and recv→render (client-side render cost) into the rolling buffers. See
+  // store-core/latency-stats for the clock discipline.
+  deltaServerTs: Map<string, { serverTs: number; recvAt: number }>;
+  tokenToRender: RollingPercentiles;
+  clientRender: RollingPercentiles;
+  lastLatencyLogAt: number;
+
   // Message queue
   messageQueue: QueuedMessage[];
 }
@@ -282,6 +295,10 @@ function createDefaultContext(): MessageHandlerContext {
     ewmaRtt: null,
     pendingDeltas: new Map<string, { sessionId: string | null; delta: string }>(),
     deltaFlushTimer: null,
+    deltaServerTs: new Map<string, { serverTs: number; recvAt: number }>(),
+    tokenToRender: new RollingPercentiles(200),
+    clientRender: new RollingPercentiles(200),
+    lastLatencyLogAt: 0,
     messageQueue: [],
   };
 }
@@ -576,6 +593,10 @@ export const SUBSCRIBE_SESSIONS_CHUNK_SIZE = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 const EWMA_ALPHA = 0.3; // Weight for new samples (higher = more responsive)
+// #5515 (epic #5514): throttle the dev latency readout so a streaming turn
+// can't spam the console — one line every few seconds is enough to watch the
+// numbers move when flush intervals are tuned.
+const LATENCY_LOG_INTERVAL_MS = 3_000;
 
 export function stopHeartbeat(): void {
   if (_ctx.heartbeatInterval) { clearInterval(_ctx.heartbeatInterval); _ctx.heartbeatInterval = null; }
@@ -600,17 +621,29 @@ export function startHeartbeat(socket: WebSocket): void {
   }, HEARTBEAT_INTERVAL_MS);
 }
 
-function _onPong(): void {
+function _onPong(serverTs?: number): void {
   if (_ctx.pongTimeout) { clearTimeout(_ctx.pongTimeout); _ctx.pongTimeout = null; }
   // Measure RTT and update connection quality using EWMA for stability
   if (_ctx.lastPingSentAt > 0) {
-    const rttMs = Date.now() - _ctx.lastPingSentAt;
-    _ctx.lastPingSentAt = 0;
+    const pongRecvAt = Date.now();
+    const rttMs = pongRecvAt - _ctx.lastPingSentAt;
     // EWMA: smoothed = alpha * new + (1 - alpha) * prev (first sample bootstraps)
     _ctx.ewmaRtt = _ctx.ewmaRtt === null ? rttMs : EWMA_ALPHA * rttMs + (1 - EWMA_ALPHA) * _ctx.ewmaRtt;
     const smoothed = Math.round(_ctx.ewmaRtt);
     const quality: 'good' | 'fair' | 'poor' = smoothed < 200 ? 'good' : smoothed < 500 ? 'fair' : 'poor';
     useConnectionLifecycleStore.getState().setConnectionQuality(smoothed, quality);
+
+    // #5515 (epic #5514): split this RTT into approximate uplink/downlink
+    // halves using the server-stamped serverTs. The split is positioned within
+    // the locally-measured [ping,pong] interval (skew-clamped), so it stays
+    // sane even with clock skew — see store-core/latency-stats. Dev-only log,
+    // throttled by the same window as token-to-render.
+    const split = splitRtt({ pingSentAt: _ctx.lastPingSentAt, pongRecvAt, serverTs });
+    if (split.uplinkMs !== null && pongRecvAt - _ctx.lastLatencyLogAt >= LATENCY_LOG_INTERVAL_MS) {
+      _ctx.lastLatencyLogAt = pongRecvAt;
+      console.log(`[latency] rtt=${split.rttMs}ms split≈ up ${split.uplinkMs}ms / down ${split.downlinkMs}ms (approx, clock-skew)`);
+    }
+    _ctx.lastPingSentAt = 0;
   }
 }
 
@@ -692,6 +725,45 @@ function flushPendingDeltas(): void {
   if (!flatUpdated) {
     getStore().setState({ sessionStates: newSessionStates });
   }
+
+  // #5515 (epic #5514): the store write above is the render trigger; sample
+  // latency for the message ids we just flushed. serverTs→render is the
+  // headline token-to-render number (wall-clock both ends but measured as one
+  // delta against the local recv, see below); recv→render is the pure client
+  // cost. Each id's stamp is consumed once so the next flush window restamps.
+  recordLatencySamples(updates.keys());
+}
+
+// #5515: measure token-to-render for the flushed message ids and feed the
+// rolling p50/p95 buffers, emitting a throttled dev log. Pulled out of
+// flushPendingDeltas so the hot path stays readable and it can be unit-tested.
+//
+// Clock note: `serverTs` is the server's wall-clock stamp and `now`/`recvAt`
+// are the client's. A raw serverTs→now subtraction is skew-prone, so we report
+// it as APPROXIMATE token-to-render and pair it with recv→render (same client
+// clock, skew-free) as the trustworthy client-render cost. We do NOT derive
+// one-way transport numbers from this subtraction — those come from the
+// RTT-split path in _onPong.
+function recordLatencySamples(messageIds: Iterable<string>): void {
+  const now = Date.now();
+  let sampled = false;
+  for (const id of messageIds) {
+    const stamp = _ctx.deltaServerTs.get(id);
+    if (!stamp) continue;
+    _ctx.deltaServerTs.delete(id);
+    _ctx.tokenToRender.add(now - stamp.serverTs);
+    _ctx.clientRender.add(now - stamp.recvAt);
+    sampled = true;
+  }
+  if (!sampled) return;
+  if (now - _ctx.lastLatencyLogAt < LATENCY_LOG_INTERVAL_MS) return;
+  _ctx.lastLatencyLogAt = now;
+  const ttr = _ctx.tokenToRender.summary();
+  const cr = _ctx.clientRender.summary();
+  console.log(
+    `[latency] token→render(~approx, wall-clock) n=${ttr.count} p50=${ttr.p50}ms p95=${ttr.p95}ms | ` +
+    `client-render n=${cr.count} p50=${cr.p50}ms p95=${cr.p95}ms`
+  );
 }
 
 export function clearDeltaBuffers(): void {
@@ -700,6 +772,9 @@ export function clearDeltaBuffers(): void {
     _ctx.deltaFlushTimer = null;
   }
   _ctx.pendingDeltas.clear();
+  // #5515: drop any un-flushed latency stamps so they can't survive a reset
+  // and pollute the next session's token-to-render window.
+  _ctx.deltaServerTs.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -991,7 +1066,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
   switch (msg.type) {
     case 'pong':
-      _onPong();
+      _onPong(typeof msg.serverTs === 'number' ? msg.serverTs : undefined);
       return;
 
     case 'auth_ok': {
@@ -1570,6 +1645,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'stream_delta': {
+      // #5515 (epic #5514): record the server-stamped serverTs and the local
+      // recv time of the OLDEST un-rendered delta for this messageId, so
+      // flushPendingDeltas can measure token-to-render. First-write-wins until
+      // the next flush clears it (mirrors the server's per-flush emit stamp).
+      if (typeof msg.messageId === 'string') {
+        const sTs = typeof msg.serverTs === 'number' ? msg.serverTs : null;
+        if (sTs !== null && !_ctx.deltaServerTs.has(msg.messageId)) {
+          _ctx.deltaServerTs.set(msg.messageId, { serverTs: sTs, recvAt: Date.now() });
+        }
+      }
       // #4981 — thin wrapper over `sharedStreamDelta`. The platform-neutral
       // hot path (post-permission split, single-hop defensive remap, post-tool
       // continuation split with the #4999/#5014 sentence gate and #4975

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -127,6 +127,9 @@ import {
   // #5039: pre-formatted partial-cost sub-line used by the `case 'error'`
   // branch so the toast and the mobile Alert share copy.
   formatPartialCostLine,
+  // #5515 (epic #5514): latency instrumentation primitives.
+  RollingPercentiles,
+  splitRtt,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -497,6 +500,18 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 const EWMA_ALPHA = 0.3; // Weight for new samples (higher = more responsive)
 
+// #5515 (epic #5514): latency instrumentation. `_deltaServerTs` records the
+// server-stamped serverTs (and local recv time) of the OLDEST un-rendered
+// delta per messageId; on flush we measure serverTs→render (token-to-render)
+// and recv→render (client render cost) into the rolling p50/p95 buffers. See
+// store-core/latency-stats for the clock discipline. Dev-only console readout,
+// throttled so a streaming turn can't spam the log.
+const LATENCY_LOG_INTERVAL_MS = 3_000;
+const _deltaServerTs = new Map<string, { serverTs: number; recvAt: number }>();
+const _tokenToRender = new RollingPercentiles(200);
+const _clientRender = new RollingPercentiles(200);
+let _lastLatencyLogAt = 0;
+
 export function stopHeartbeat(): void {
   if (_heartbeatInterval) { clearInterval(_heartbeatInterval); _heartbeatInterval = null; }
   if (_pongTimeout) { clearTimeout(_pongTimeout); _pongTimeout = null; }
@@ -520,17 +535,28 @@ export function startHeartbeat(socket: WebSocket): void {
   }, HEARTBEAT_INTERVAL_MS);
 }
 
-function _onPong(): void {
+function _onPong(serverTs?: number): void {
   if (_pongTimeout) { clearTimeout(_pongTimeout); _pongTimeout = null; }
   // Measure RTT and update connection quality using EWMA for stability
   if (_lastPingSentAt > 0) {
-    const rttMs = Date.now() - _lastPingSentAt;
-    _lastPingSentAt = 0;
+    const pongRecvAt = Date.now();
+    const rttMs = pongRecvAt - _lastPingSentAt;
     // EWMA: smoothed = alpha * new + (1 - alpha) * prev (first sample bootstraps)
     _ewmaRtt = _ewmaRtt === null ? rttMs : EWMA_ALPHA * rttMs + (1 - EWMA_ALPHA) * _ewmaRtt;
     const smoothed = Math.round(_ewmaRtt);
     const quality: 'good' | 'fair' | 'poor' = smoothed < 200 ? 'good' : smoothed < 500 ? 'fair' : 'poor';
     getStore().setState({ latencyMs: smoothed, connectionQuality: quality });
+
+    // #5515 (epic #5514): split this RTT into approximate uplink/downlink
+    // halves using the server-stamped serverTs, positioned within the locally-
+    // measured [ping,pong] interval (skew-clamped) — see store-core/latency-
+    // stats. Dev-only, throttled by the same window as token-to-render.
+    const split = splitRtt({ pingSentAt: _lastPingSentAt, pongRecvAt, serverTs });
+    if (split.uplinkMs !== null && pongRecvAt - _lastLatencyLogAt >= LATENCY_LOG_INTERVAL_MS) {
+      _lastLatencyLogAt = pongRecvAt;
+      console.log(`[latency] rtt=${split.rttMs}ms split≈ up ${split.uplinkMs}ms / down ${split.downlinkMs}ms (approx, clock-skew)`);
+    }
+    _lastPingSentAt = 0;
   }
 }
 
@@ -607,6 +633,37 @@ function flushPendingDeltas(): void {
   if (!flatUpdated) {
     getStore().setState({ sessionStates: newSessionStates });
   }
+
+  // #5515 (epic #5514): the store writes above are the render trigger; sample
+  // latency for the ids we just flushed. See store-core/latency-stats for the
+  // clock discipline (serverTs→render is approximate/wall-clock; recv→render is
+  // the skew-free client render cost).
+  recordLatencySamples(updates.keys());
+}
+
+// #5515: measure token-to-render for the flushed message ids into the rolling
+// p50/p95 buffers and emit a throttled dev log. Each id's stamp is consumed
+// once so the next flush window restamps.
+function recordLatencySamples(messageIds: Iterable<string>): void {
+  const now = Date.now();
+  let sampled = false;
+  for (const id of messageIds) {
+    const stamp = _deltaServerTs.get(id);
+    if (!stamp) continue;
+    _deltaServerTs.delete(id);
+    _tokenToRender.add(now - stamp.serverTs);
+    _clientRender.add(now - stamp.recvAt);
+    sampled = true;
+  }
+  if (!sampled) return;
+  if (now - _lastLatencyLogAt < LATENCY_LOG_INTERVAL_MS) return;
+  _lastLatencyLogAt = now;
+  const ttr = _tokenToRender.summary();
+  const cr = _clientRender.summary();
+  console.log(
+    `[latency] token→render(~approx, wall-clock) n=${ttr.count} p50=${ttr.p50}ms p95=${ttr.p95}ms | ` +
+    `client-render n=${cr.count} p50=${cr.p50}ms p95=${cr.p95}ms`
+  );
 }
 
 export function clearDeltaBuffers(): void {
@@ -615,6 +672,8 @@ export function clearDeltaBuffers(): void {
     deltaFlushTimer = null;
   }
   pendingDeltas.clear();
+  // #5515: drop un-flushed latency stamps so they can't survive a reset.
+  _deltaServerTs.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -792,8 +851,8 @@ type Handler = (msg: Record<string, unknown>, get: MsgGet, set: MsgSet, ctx: Con
 
 // --- Extracted handler functions ---
 
-function handlePong(_msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  _onPong();
+function handlePong(msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  _onPong(typeof msg.serverTs === 'number' ? msg.serverTs : undefined);
 }
 
 function handleRaw(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
@@ -1356,6 +1415,16 @@ function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 }
 
 function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  // #5515 (epic #5514): record the server-stamped serverTs and local recv time
+  // of the OLDEST un-rendered delta for this messageId so flushPendingDeltas
+  // can measure token-to-render. First-write-wins until the next flush clears
+  // it (mirrors the server's per-flush emit stamp).
+  if (typeof msg.messageId === 'string') {
+    const sTs = typeof msg.serverTs === 'number' ? msg.serverTs : null;
+    if (sTs !== null && !_deltaServerTs.has(msg.messageId)) {
+      _deltaServerTs.set(msg.messageId, { serverTs: sTs, recvAt: Date.now() });
+    }
+  }
   // #4981 — thin wrapper over `sharedStreamDelta`. The platform-neutral hot
   // path (post-permission split, single-hop defensive remap, post-tool
   // continuation split with the #4999/#5014 sentence gate and #4975 mid-word

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -113,15 +113,18 @@ export declare const ServerClaudeReadySchema: z.ZodObject<{
 export declare const ServerStreamStartSchema: z.ZodObject<{
     type: z.ZodLiteral<"stream_start">;
     messageId: z.ZodString;
+    serverTs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerStreamDeltaSchema: z.ZodObject<{
     type: z.ZodLiteral<"stream_delta">;
     messageId: z.ZodString;
     delta: z.ZodString;
+    serverTs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerStreamEndSchema: z.ZodObject<{
     type: z.ZodLiteral<"stream_end">;
     messageId: z.ZodString;
+    serverTs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerMessageSchema: z.ZodObject<{
     type: z.ZodLiteral<"message">;
@@ -1752,6 +1755,7 @@ export declare const ServerShutdownSchema: z.ZodObject<{
 }, z.core.$strip>;
 export declare const ServerPongSchema: z.ZodObject<{
     type: z.ZodLiteral<"pong">;
+    serverTs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerCostUpdateSchema: z.ZodObject<{
     type: z.ZodLiteral<"cost_update">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -148,18 +148,29 @@ export const ServerClaudeReadySchema = z.object({
         reason: z.string(),
     }).optional(),
 });
+// #5515 (epic #5514): optional, additive wall-clock (ms epoch) timestamp
+// stamped on stream messages and the pong reply at broadcast time. Clients use
+// it to measure server→render latency (token-to-render) and to split RTT into
+// uplink/downlink. Wall-clock (not monotonic) because it crosses machines;
+// consumers MUST treat raw cross-machine subtraction as skew-prone and derive
+// one-way numbers from the RTT-split method instead (see app/dashboard
+// latency-stats). Always optional so older servers/clients interop unchanged.
+const ServerTsSchema = z.number().int().nonnegative().finite().optional();
 export const ServerStreamStartSchema = z.object({
     type: z.literal('stream_start'),
     messageId: z.string(),
+    serverTs: ServerTsSchema,
 });
 export const ServerStreamDeltaSchema = z.object({
     type: z.literal('stream_delta'),
     messageId: z.string(),
     delta: z.string(),
+    serverTs: ServerTsSchema,
 });
 export const ServerStreamEndSchema = z.object({
     type: z.literal('stream_end'),
     messageId: z.string(),
+    serverTs: ServerTsSchema,
 });
 export const ServerMessageSchema = z.object({
     type: z.literal('message'),
@@ -1760,6 +1771,10 @@ export const ServerShutdownSchema = z.object({
 });
 export const ServerPongSchema = z.object({
     type: z.literal('pong'),
+    // #5515: optional wall-clock stamp so clients can split the ping/pong RTT
+    // into uplink (ping send → serverTs) and downlink (serverTs → pong recv)
+    // halves. See ServerStreamDeltaSchema for the wall-clock/skew caveat.
+    serverTs: z.number().int().nonnegative().finite().optional(),
 });
 export const ServerCostUpdateSchema = z.object({
     type: z.literal('cost_update'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -156,20 +156,32 @@ export const ServerClaudeReadySchema = z.object({
   }).optional(),
 })
 
+// #5515 (epic #5514): optional, additive wall-clock (ms epoch) timestamp
+// stamped on stream messages and the pong reply at broadcast time. Clients use
+// it to measure server→render latency (token-to-render) and to split RTT into
+// uplink/downlink. Wall-clock (not monotonic) because it crosses machines;
+// consumers MUST treat raw cross-machine subtraction as skew-prone and derive
+// one-way numbers from the RTT-split method instead (see app/dashboard
+// latency-stats). Always optional so older servers/clients interop unchanged.
+const ServerTsSchema = z.number().int().nonnegative().finite().optional()
+
 export const ServerStreamStartSchema = z.object({
   type: z.literal('stream_start'),
   messageId: z.string(),
+  serverTs: ServerTsSchema,
 })
 
 export const ServerStreamDeltaSchema = z.object({
   type: z.literal('stream_delta'),
   messageId: z.string(),
   delta: z.string(),
+  serverTs: ServerTsSchema,
 })
 
 export const ServerStreamEndSchema = z.object({
   type: z.literal('stream_end'),
   messageId: z.string(),
+  serverTs: ServerTsSchema,
 })
 
 export const ServerMessageSchema = z.object({
@@ -1868,6 +1880,10 @@ export const ServerShutdownSchema = z.object({
 
 export const ServerPongSchema = z.object({
   type: z.literal('pong'),
+  // #5515: optional wall-clock stamp so clients can split the ping/pong RTT
+  // into uplink (ping send → serverTs) and downlink (serverTs → pong recv)
+  // halves. See ServerStreamDeltaSchema for the wall-clock/skew caveat.
+  serverTs: z.number().int().nonnegative().finite().optional(),
 })
 
 export const ServerCostUpdateSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -2756,5 +2756,65 @@ describe('@chroxy/protocol schemas', () => {
         }).success)
       })
     })
+
+    // #5515 (epic #5514): latency instrumentation — optional, additive
+    // `serverTs` (wall-clock ms epoch, stamped at broadcast) on the stream
+    // messages and the pong reply so clients can measure token-to-render and
+    // split RTT into uplink/downlink.
+    describe('serverTs latency instrumentation (#5515)', () => {
+      it('ServerStreamDeltaSchema accepts an optional serverTs', async () => {
+        const { ServerStreamDeltaSchema } = await import('../src/schemas/server.ts')
+        const result = ServerStreamDeltaSchema.safeParse({
+          type: 'stream_delta',
+          messageId: 'm1',
+          delta: 'hi',
+          serverTs: 1_700_000_000_000,
+        })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.serverTs, 1_700_000_000_000)
+      })
+
+      it('ServerStreamDeltaSchema still validates without serverTs (additive)', async () => {
+        const { ServerStreamDeltaSchema } = await import('../src/schemas/server.ts')
+        assert.ok(ServerStreamDeltaSchema.safeParse({
+          type: 'stream_delta',
+          messageId: 'm1',
+          delta: 'hi',
+        }).success)
+      })
+
+      it('ServerStreamStartSchema / ServerStreamEndSchema accept serverTs', async () => {
+        const { ServerStreamStartSchema, ServerStreamEndSchema } = await import('../src/schemas/server.ts')
+        assert.ok(ServerStreamStartSchema.safeParse({
+          type: 'stream_start',
+          messageId: 'm1',
+          serverTs: 1_700_000_000_000,
+        }).success)
+        assert.ok(ServerStreamEndSchema.safeParse({
+          type: 'stream_end',
+          messageId: 'm1',
+          serverTs: 1_700_000_000_000,
+        }).success)
+        // Additive: both still validate without it.
+        assert.ok(ServerStreamStartSchema.safeParse({ type: 'stream_start', messageId: 'm1' }).success)
+        assert.ok(ServerStreamEndSchema.safeParse({ type: 'stream_end', messageId: 'm1' }).success)
+      })
+
+      it('ServerPongSchema accepts an optional serverTs and still validates without it', async () => {
+        const { ServerPongSchema } = await import('../src/schemas/server.ts')
+        assert.ok(ServerPongSchema.safeParse({ type: 'pong', serverTs: 1_700_000_000_000 }).success)
+        assert.ok(ServerPongSchema.safeParse({ type: 'pong' }).success)
+      })
+
+      it('rejects a non-numeric serverTs on stream_delta', async () => {
+        const { ServerStreamDeltaSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!ServerStreamDeltaSchema.safeParse({
+          type: 'stream_delta',
+          messageId: 'm1',
+          delta: 'hi',
+          serverTs: 'nope',
+        }).success)
+      })
+    })
   })
 })

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -663,8 +663,13 @@ export class EventNormalizer {
     // Delta buffer: key -> accumulated text
     // In multi-session mode key = `${sessionId}:${messageId}`, otherwise just messageId
     this._deltaBuffer = new Map()
+    // #5515 (epic #5514): key -> monotonic ms of the FIRST delta buffered into
+    // the current (un-flushed) window. Lets ws-forwarding measure the time the
+    // oldest token in a flush spent inside the server (coalescing + forwarding)
+    // — a true monotonic duration, same process both ends.
+    this._deltaEmitMono = new Map()
     this._deltaFlushTimer = null
-    this._onFlush = null // callback: (entries) => void, where entries = [{ key, sessionId, messageId, delta }]
+    this._onFlush = null // callback: (entries) => void, where entries = [{ key, sessionId, messageId, delta, emitMonoMs }]
   }
 
   /**
@@ -715,11 +720,17 @@ export class EventNormalizer {
    * @param {string} sessionId - Session ID (may be null for legacy mode)
    * @param {string} messageId - Stream message ID
    * @param {string} delta - Text delta to buffer
+   * @param {number} [emitMonoMs] - #5515: monotonic ms the provider emitted this
+   *   delta. First-write-wins per flush window so the flushed entry reports how
+   *   long the OLDEST coalesced token waited inside the server.
    */
-  bufferDelta(sessionId, messageId, delta) {
+  bufferDelta(sessionId, messageId, delta, emitMonoMs) {
     const key = sessionId ? `${sessionId}:${messageId}` : messageId
     const existing = this._deltaBuffer.get(key) || ''
     this._deltaBuffer.set(key, existing + delta)
+    if (typeof emitMonoMs === 'number' && !this._deltaEmitMono.has(key)) {
+      this._deltaEmitMono.set(key, emitMonoMs)
+    }
     if (!this._deltaFlushTimer) {
       this._deltaFlushTimer = setTimeout(() => this._flushDeltas(), this._flushIntervalMs)
     }
@@ -729,7 +740,7 @@ export class EventNormalizer {
    * Flush all buffered deltas for a specific session (called before stream_end).
    * Returns the flushed entries so the caller can broadcast them.
    * @param {string|null} sessionId - Session to flush (null = flush all)
-   * @returns {Array<{ key, sessionId, messageId, delta }>}
+   * @returns {Array<{ key, sessionId, messageId, delta, emitMonoMs }>}
    */
   flushSession(sessionId) {
     const entries = []
@@ -738,16 +749,18 @@ export class EventNormalizer {
       for (const [key, delta] of this._deltaBuffer) {
         if (key.startsWith(prefix)) {
           const messageId = key.slice(prefix.length)
-          entries.push({ key, sessionId, messageId, delta })
+          entries.push({ key, sessionId, messageId, delta, emitMonoMs: this._deltaEmitMono.get(key) })
           this._deltaBuffer.delete(key)
+          this._deltaEmitMono.delete(key)
         }
       }
     } else {
       // Legacy mode: flush everything
       for (const [key, delta] of this._deltaBuffer) {
-        entries.push({ key, sessionId: null, messageId: key, delta })
+        entries.push({ key, sessionId: null, messageId: key, delta, emitMonoMs: this._deltaEmitMono.get(key) })
       }
       this._deltaBuffer.clear()
+      this._deltaEmitMono.clear()
     }
     // If buffer is now empty, cancel the pending timer
     if (this._deltaBuffer.size === 0 && this._deltaFlushTimer) {
@@ -766,11 +779,12 @@ export class EventNormalizer {
     if (this._onFlush) {
       const entries = []
       for (const [key, delta] of this._deltaBuffer) {
+        const emitMonoMs = this._deltaEmitMono.get(key)
         const sepIdx = key.indexOf(':')
         if (sepIdx !== -1) {
-          entries.push({ key, sessionId: key.slice(0, sepIdx), messageId: key.slice(sepIdx + 1), delta })
+          entries.push({ key, sessionId: key.slice(0, sepIdx), messageId: key.slice(sepIdx + 1), delta, emitMonoMs })
         } else {
-          entries.push({ key, sessionId: null, messageId: key, delta })
+          entries.push({ key, sessionId: null, messageId: key, delta, emitMonoMs })
         }
       }
       // #5313 (WP-1.3): _onFlush is a broadcast callback invoked from a
@@ -786,10 +800,12 @@ export class EventNormalizer {
         log.error(`Delta flush onFlush callback threw: ${message}${err?.stack ? '\n' + err.stack : ''}`)
       } finally {
         this._deltaBuffer.clear()
+        this._deltaEmitMono.clear()
       }
       return
     }
     this._deltaBuffer.clear()
+    this._deltaEmitMono.clear()
   }
 
   /**
@@ -801,6 +817,7 @@ export class EventNormalizer {
       this._deltaFlushTimer = null
     }
     this._deltaBuffer.clear()
+    this._deltaEmitMono.clear()
   }
 }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -817,7 +817,12 @@ export class SdkSession extends BaseSession {
                     this.emit('stream_start', { messageId })
                   }
                   didStreamText = true
-                  this.emit('stream_delta', { messageId, delta: delta.text })
+                  // #5515 (epic #5514): stamp the monotonic emit time so
+                  // ws-forwarding can measure emit→broadcast (the server-side
+                  // coalescing cost). Monotonic (hrtime) — not wall-clock —
+                  // because both ends are this same process; it's a true
+                  // elapsed duration, unlike the cross-machine serverTs field.
+                  this.emit('stream_delta', { messageId, delta: delta.text, _emitMonoMs: Number(process.hrtime.bigint() / 1_000_000n) })
                 }
                 break
               }

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -40,7 +40,9 @@ function recordEmitToBroadcast(emitMonoMs) {
   if (now - _lastEmitBroadcastLogMs < EMIT_BROADCAST_LOG_INTERVAL_MS) return
   _lastEmitBroadcastLogMs = now
   const sorted = [..._emitToBroadcastSamples].sort((a, b) => a - b)
-  const p = (q) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]
+  // Standard nearest-rank: ceil(q*n) - 1, clamped to [0, n-1]. floor(q*n)
+  // biases one position high and makes p95 the max for small n (#5520 review).
+  const p = (q) => sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1))]
   log.debug(`[latency] emit→broadcast n=${sorted.length} p50=${Math.round(p(0.5))}ms p95=${Math.round(p(0.95))}ms`)
 }
 

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -3,6 +3,47 @@ import { getDefaultModelId, getRegistryForProvider } from './models.js'
 
 const log = createLogger('ws-forwarding')
 
+// #5515 (epic #5514): the stream message types we stamp with a broadcast-time
+// wall-clock serverTs so clients can measure token-to-render latency.
+const STREAM_TS_TYPES = new Set(['stream_start', 'stream_delta', 'stream_end'])
+
+// #5515: stamp a wall-clock (ms epoch) serverTs on a stream message at the
+// moment it is handed to broadcast. Wall-clock — not the #5414 monotonic
+// watchdog clock — because the field crosses machines; clients treat it as
+// skew-prone and derive one-way numbers from the RTT split, not raw
+// subtraction. Returns a new object so we never mutate a caller's message
+// (the normalizer/flush callers build fresh literals, but this keeps the
+// helper safe regardless). No-op for non-stream messages.
+function withServerTs(msg) {
+  if (!msg || !STREAM_TS_TYPES.has(msg.type)) return msg
+  return { ...msg, serverTs: Date.now() }
+}
+
+// #5515 — emit→broadcast instrumentation. The provider (sdk-session) stamps the
+// monotonic time it emitted a delta onto the event (`_emitMonoMs`); we compute
+// the time spent inside the server (coalescing buffer + forwarding) here and
+// log a throttled p50/p95 summary so the coalescing buffer can be confirmed as
+// the only meaningful server-side cost. Monotonic both ends (same process), so
+// this is a true elapsed duration — unlike the cross-machine serverTs field.
+const _emitToBroadcastSamples = []
+const EMIT_BROADCAST_RING = 200
+let _lastEmitBroadcastLogMs = 0
+const EMIT_BROADCAST_LOG_INTERVAL_MS = 5000
+
+function recordEmitToBroadcast(emitMonoMs) {
+  if (typeof emitMonoMs !== 'number') return
+  const elapsed = Number(process.hrtime.bigint() / 1_000_000n) - emitMonoMs
+  if (!Number.isFinite(elapsed) || elapsed < 0) return
+  _emitToBroadcastSamples.push(elapsed)
+  if (_emitToBroadcastSamples.length > EMIT_BROADCAST_RING) _emitToBroadcastSamples.shift()
+  const now = Date.now()
+  if (now - _lastEmitBroadcastLogMs < EMIT_BROADCAST_LOG_INTERVAL_MS) return
+  _lastEmitBroadcastLogMs = now
+  const sorted = [..._emitToBroadcastSamples].sort((a, b) => a - b)
+  const p = (q) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]
+  log.debug(`[latency] emit→broadcast n=${sorted.length} p50=${Math.round(p(0.5))}ms p95=${Math.round(p(0.95))}ms`)
+}
+
 // #5313 (WP-1.3) — wrap a forwarding listener so a throw in its body (almost
 // always a broadcast to a torn-down client, or a downstream devPreview call)
 // can't unwind the EventEmitter's emit() in the emitting code (session-manager /
@@ -44,11 +85,12 @@ export function setupForwarding(ctx) {
 
   // Wire the normalizer's timer-based delta flush to broadcast
   normalizer.onFlush = (entries) => {
-    for (const { sessionId, messageId, delta } of entries) {
+    for (const { sessionId, messageId, delta, emitMonoMs } of entries) {
+      recordEmitToBroadcast(emitMonoMs)
       if (sessionId) {
-        broadcastToSession(sessionId, { type: 'stream_delta', messageId, delta })
+        broadcastToSession(sessionId, withServerTs({ type: 'stream_delta', messageId, delta }))
       } else {
-        broadcast({ type: 'stream_delta', messageId, delta })
+        broadcast(withServerTs({ type: 'stream_delta', messageId, delta }))
       }
     }
   }
@@ -114,7 +156,7 @@ function setupSessionForwarding(normalizer, ctx) {
 
     // Handle delta buffering
     if (result.buffer) {
-      normalizer.bufferDelta(sessionId, data.messageId, data.delta)
+      normalizer.bufferDelta(sessionId, data.messageId, data.delta, data._emitMonoMs)
       return
     }
 
@@ -124,10 +166,11 @@ function setupSessionForwarding(normalizer, ctx) {
 
     // Broadcast messages
     for (const { msg, filter } of result.messages) {
+      const stamped = withServerTs(msg)
       if (filter) {
-        broadcastToSession(sessionId, msg, filter)
+        broadcastToSession(sessionId, stamped, filter)
       } else {
-        broadcastToSession(sessionId, msg)
+        broadcastToSession(sessionId, stamped)
       }
     }
     } catch (err) {
@@ -205,7 +248,7 @@ function setupCliForwarding(normalizer, ctx) {
         if (!result) return
 
         if (result.buffer) {
-          normalizer.bufferDelta(null, data.messageId, data.delta)
+          normalizer.bufferDelta(null, data.messageId, data.delta, data._emitMonoMs)
           return
         }
 
@@ -213,10 +256,11 @@ function setupCliForwarding(normalizer, ctx) {
         executeRegistrations(result.registrations, null, ctx)
 
         for (const { msg, filter } of result.messages) {
+          const stamped = withServerTs(msg)
           if (filter) {
-            broadcast(msg, filter)
+            broadcast(stamped, filter)
           } else {
-            broadcast(msg)
+            broadcast(stamped)
           }
         }
       } catch (err) {
@@ -286,11 +330,12 @@ function executeSideEffects(sideEffects, sessionId, ctx) {
       case 'flush_deltas': {
         const sid = effect.sessionId ?? sessionId
         const entries = normalizer.flushSession(sid)
-        for (const { sessionId: eSid, messageId, delta } of entries) {
+        for (const { sessionId: eSid, messageId, delta, emitMonoMs } of entries) {
+          recordEmitToBroadcast(emitMonoMs)
           if (eSid) {
-            broadcastToSession(eSid, { type: 'stream_delta', messageId, delta })
+            broadcastToSession(eSid, withServerTs({ type: 'stream_delta', messageId, delta }))
           } else {
-            broadcast({ type: 'stream_delta', messageId, delta })
+            broadcast(withServerTs({ type: 'stream_delta', messageId, delta }))
           }
         }
         break

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1463,7 +1463,13 @@ export class WsServer {
 
     // Respond to client-side heartbeat pings immediately (even during drain)
     if (msg.type === 'ping') {
-      this._send(ws, { type: 'pong' })
+      // #5515 (epic #5514): stamp a wall-clock (ms epoch) serverTs so clients
+      // can split the ping/pong RTT into uplink (ping send → serverTs) and
+      // downlink (serverTs → pong recv) halves. Wall-clock — not the monotonic
+      // clock used by the #5414 watchdogs — because it crosses machines; the
+      // client treats it as skew-prone and derives one-way numbers from the
+      // RTT split, never from raw clock subtraction.
+      this._send(ws, { type: 'pong', serverTs: Date.now() })
       return
     }
 

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -821,6 +821,32 @@ describe('EventNormalizer', () => {
       assert.equal(entries.length, 2)
     })
 
+    // #5515 (epic #5514): the buffer carries the FIRST emit monotonic time per
+    // key so ws-forwarding can measure emit→broadcast (server-side coalescing).
+    it('carries the first emitMonoMs per key through flushSession (#5515)', () => {
+      normalizer.bufferDelta('sess-1', 'msg-1', 'Hello', 1000)
+      normalizer.bufferDelta('sess-1', 'msg-1', ' World', 1005)
+      const entries = normalizer.flushSession('sess-1')
+      assert.equal(entries.length, 1)
+      // First-write-wins: the oldest token's emit time, not the latest.
+      assert.equal(entries[0].emitMonoMs, 1000)
+    })
+
+    it('emitMonoMs is undefined when not supplied (additive, #5515)', () => {
+      normalizer.bufferDelta('sess-1', 'msg-1', 'Hello')
+      const entries = normalizer.flushSession('sess-1')
+      assert.equal(entries[0].emitMonoMs, undefined)
+    })
+
+    it('does not leak emitMonoMs across flush windows for the same key (#5515)', () => {
+      normalizer.bufferDelta('sess-1', 'msg-1', 'A', 1000)
+      normalizer.flushSession('sess-1')
+      // New window for the same key: a fresh emit time should win.
+      normalizer.bufferDelta('sess-1', 'msg-1', 'B', 2000)
+      const entries = normalizer.flushSession('sess-1')
+      assert.equal(entries[0].emitMonoMs, 2000)
+    })
+
     it('fires onFlush callback on timer', async () => {
       let flushed = null
       normalizer.onFlush = (entries) => { flushed = entries }

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -79,6 +79,69 @@ describe('setupForwarding', () => {
     })
   })
 
+  // #5515 (epic #5514): latency instrumentation — broadcast-time serverTs.
+  describe('serverTs stamping (#5515)', () => {
+    it('stamps a wall-clock serverTs on flushed stream_delta (session path)', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+      const before = Date.now()
+      ctx.normalizer._onFlush([
+        { sessionId: 'sess-1', messageId: 'msg-1', delta: 'hello' },
+      ])
+      const after = Date.now()
+      const msg = ctx.broadcastToSession.mock.calls[0].arguments[1]
+      assert.equal(typeof msg.serverTs, 'number')
+      assert.ok(msg.serverTs >= before && msg.serverTs <= after, `serverTs ${msg.serverTs} not in [${before}, ${after}]`)
+    })
+
+    it('stamps serverTs on flushed stream_delta (broadcast/legacy path)', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+      ctx.normalizer._onFlush([
+        { sessionId: null, messageId: 'msg-2', delta: 'world' },
+      ])
+      const msg = ctx.broadcast.mock.calls[0].arguments[0]
+      assert.equal(typeof msg.serverTs, 'number')
+    })
+
+    it('stamps serverTs on stream_start / stream_end broadcast through the normalizer', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-1',
+        event: 'stream_start',
+        data: { messageId: 'm1' },
+      })
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-1',
+        event: 'stream_end',
+        data: { messageId: 'm1' },
+      })
+      const stamped = ctx.broadcastToSession.mock.calls
+        .map((c) => c.arguments[1])
+        .filter((m) => m && (m.type === 'stream_start' || m.type === 'stream_end'))
+      assert.ok(stamped.length >= 2, `expected stream_start+stream_end, got ${stamped.map((m) => m.type)}`)
+      for (const m of stamped) {
+        assert.equal(typeof m.serverTs, 'number', `${m.type} missing serverTs`)
+      }
+    })
+
+    it('does not stamp serverTs on non-stream messages (e.g. session_activity)', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-1',
+        event: 'stream_start',
+        data: { messageId: 'm1' },
+      })
+      const activity = ctx.broadcast.mock.calls
+        .map((c) => c.arguments[0])
+        .find((m) => m && m.type === 'session_activity')
+      assert.ok(activity, 'expected a session_activity broadcast')
+      assert.equal(activity.serverTs, undefined)
+    })
+  })
+
   describe('models_updated event', () => {
     it('broadcasts available_models to all clients', () => {
       const ctx = makeCtx()

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1064,6 +1064,11 @@ describe('outbound message sequence numbers', () => {
     assert.equal(pong.seq, initialCount + 1,
       'pong seq should continue from where initial messages left off')
 
+    // #5515 (epic #5514): the pong reply carries a wall-clock serverTs so
+    // clients can split the ping/pong RTT into uplink/downlink halves.
+    assert.equal(typeof pong.serverTs, 'number', 'pong should carry a serverTs')
+    assert.ok(pong.serverTs > 0, 'serverTs should be a positive ms epoch')
+
     ws.close()
   })
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -525,3 +525,9 @@ export {
   getWsCloseMessage,
   getHealthCheckErrorMessage,
 } from './ws-errors'
+
+// #5515 (epic #5514): latency instrumentation primitives — a bounded p50/p95
+// ring buffer and the skew-safe RTT splitter, shared so the app and dashboard
+// measure token-to-render and uplink/downlink identically.
+export { RollingPercentiles, splitRtt } from './latency-stats'
+export type { RttSplit, RttSplitInput } from './latency-stats'

--- a/packages/store-core/src/latency-stats.test.ts
+++ b/packages/store-core/src/latency-stats.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the latency instrumentation primitives (#5515, epic #5514).
+ *
+ * `RollingPercentiles` is a bounded ring buffer (no deps) that yields p50/p95
+ * over the last N samples. `splitRtt` derives skew-resistant one-way estimates
+ * from a stamped pong (the wall-clock `serverTs` only positions the split
+ * WITHIN the locally-measured RTT — it is never subtracted across machines).
+ */
+import { describe, it, expect } from 'vitest'
+import { RollingPercentiles, splitRtt } from './latency-stats'
+
+describe('RollingPercentiles (#5515)', () => {
+  it('reports null percentiles when empty', () => {
+    const r = new RollingPercentiles(200)
+    expect(r.count).toBe(0)
+    expect(r.summary()).toEqual({ count: 0, p50: null, p95: null })
+  })
+
+  it('computes p50/p95 over a known distribution', () => {
+    const r = new RollingPercentiles(200)
+    for (let i = 1; i <= 100; i++) r.add(i)
+    const s = r.summary()
+    expect(s.count).toBe(100)
+    // nearest-rank: p50 → ~50, p95 → ~95 (exact index depends on rounding,
+    // but must land in the expected neighbourhood).
+    expect(s.p50).toBeGreaterThanOrEqual(49)
+    expect(s.p50).toBeLessThanOrEqual(51)
+    expect(s.p95).toBeGreaterThanOrEqual(94)
+    expect(s.p95).toBeLessThanOrEqual(96)
+  })
+
+  it('bounds the buffer to its capacity (oldest evicted)', () => {
+    const r = new RollingPercentiles(3)
+    r.add(1)
+    r.add(2)
+    r.add(3)
+    r.add(4) // evicts 1
+    expect(r.count).toBe(3)
+    // window is now {2,3,4}; p50 should be 3, not influenced by the evicted 1.
+    expect(r.summary().p50).toBe(3)
+  })
+
+  it('ignores non-finite / negative samples', () => {
+    const r = new RollingPercentiles(200)
+    r.add(NaN)
+    r.add(Infinity)
+    r.add(-5)
+    r.add(10)
+    expect(r.count).toBe(1)
+    expect(r.summary().p50).toBe(10)
+  })
+})
+
+describe('splitRtt (#5515)', () => {
+  it('returns null halves when serverTs is missing (skew-safe degrade)', () => {
+    const out = splitRtt({ pingSentAt: 1000, pongRecvAt: 1100, serverTs: undefined })
+    expect(out.rttMs).toBe(100)
+    expect(out.uplinkMs).toBeNull()
+    expect(out.downlinkMs).toBeNull()
+  })
+
+  it('splits RTT using serverTs positioned within the local interval', () => {
+    // serverTs falls 30ms into the 100ms locally-measured interval → uplink 30,
+    // downlink 70. (The absolute value of serverTs is irrelevant — only its
+    // position relative to pingSentAt within [pingSentAt, pongRecvAt] matters,
+    // and we clamp it into that window to stay robust to clock skew.)
+    const out = splitRtt({ pingSentAt: 1000, pongRecvAt: 1100, serverTs: 1030 })
+    expect(out.rttMs).toBe(100)
+    expect(out.uplinkMs).toBe(30)
+    expect(out.downlinkMs).toBe(70)
+  })
+
+  it('clamps a skewed serverTs into the local window', () => {
+    // serverTs before pingSentAt (clock skew) → clamp to 0 uplink.
+    const lo = splitRtt({ pingSentAt: 1000, pongRecvAt: 1100, serverTs: 500 })
+    expect(lo.uplinkMs).toBe(0)
+    expect(lo.downlinkMs).toBe(100)
+    // serverTs after pongRecvAt → clamp to full uplink.
+    const hi = splitRtt({ pingSentAt: 1000, pongRecvAt: 1100, serverTs: 5000 })
+    expect(hi.uplinkMs).toBe(100)
+    expect(hi.downlinkMs).toBe(0)
+  })
+
+  it('returns null halves for a non-positive RTT', () => {
+    const out = splitRtt({ pingSentAt: 1100, pongRecvAt: 1100, serverTs: 1100 })
+    expect(out.rttMs).toBe(0)
+    expect(out.uplinkMs).toBeNull()
+    expect(out.downlinkMs).toBeNull()
+  })
+})

--- a/packages/store-core/src/latency-stats.ts
+++ b/packages/store-core/src/latency-stats.ts
@@ -1,0 +1,100 @@
+/**
+ * Latency instrumentation primitives (#5515, epic #5514).
+ *
+ * Shared by the app and dashboard message handlers so both measure
+ * token-to-render and RTT-split identically. No dependencies — a bounded ring
+ * buffer plus a pure RTT-split function.
+ *
+ * Clock discipline (read before touching the math):
+ *
+ *   - Token-to-render is measured ENTIRELY on the client clock: we record the
+ *     local recv time when a `stream_delta` arrives and the local render time
+ *     after `flushPendingDeltas`. Both are the same (monotonic-ish) client
+ *     clock, so the difference is a true elapsed duration. The server's
+ *     wall-clock `serverTs` is NOT subtracted here — cross-machine subtraction
+ *     is poisoned by clock skew.
+ *
+ *   - RTT split DOES use `serverTs`, but only to POSITION the split inside an
+ *     interval the client measured locally ([pingSentAt, pongRecvAt]). We clamp
+ *     serverTs into that window, so even an arbitrarily skewed server clock can
+ *     only move the uplink/downlink boundary between 0 and the full RTT — it can
+ *     never produce a negative half or one larger than the (locally measured,
+ *     skew-free) RTT. The halves are therefore best-effort estimates, documented
+ *     as approximate, derived from the RTT-split method rather than raw clock
+ *     subtraction (which the #5414 monotonic-clock work made us careful about).
+ */
+
+/** A bounded ring buffer that yields p50/p95 over the last `capacity` samples. */
+export class RollingPercentiles {
+  private readonly buf: number[]
+  private readonly capacity: number
+  private head = 0
+  private size = 0
+
+  constructor(capacity = 200) {
+    this.capacity = Math.max(1, Math.floor(capacity))
+    this.buf = new Array(this.capacity)
+  }
+
+  /** Number of samples currently retained (≤ capacity). */
+  get count(): number {
+    return this.size
+  }
+
+  /** Record a sample. Non-finite or negative values are ignored. */
+  add(sample: number): void {
+    if (!Number.isFinite(sample) || sample < 0) return
+    this.buf[this.head] = sample
+    this.head = (this.head + 1) % this.capacity
+    if (this.size < this.capacity) this.size++
+  }
+
+  /**
+   * p50/p95 over the retained window via nearest-rank on a sorted copy.
+   * Returns `null` percentiles when empty. O(n log n) per call — only invoked
+   * from a throttled readout, never the hot path.
+   */
+  summary(): { count: number; p50: number | null; p95: number | null } {
+    if (this.size === 0) return { count: 0, p50: null, p95: null }
+    const sorted = this.buf.slice(0, this.size).sort((a, b) => a - b)
+    const pick = (q: number): number => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]!
+    return { count: this.size, p50: pick(0.5), p95: pick(0.95) }
+  }
+}
+
+export interface RttSplitInput {
+  /** Local clock ms when the client sent the ping. */
+  pingSentAt: number
+  /** Local clock ms when the client received the pong. */
+  pongRecvAt: number
+  /** Server wall-clock ms stamped on the pong (`serverTs`), if present. */
+  serverTs: number | undefined
+}
+
+export interface RttSplit {
+  /** Round-trip time, measured purely on the local clock (skew-free). */
+  rttMs: number
+  /** Estimated uplink (ping→server). `null` when serverTs is absent/RTT≤0. */
+  uplinkMs: number | null
+  /** Estimated downlink (server→pong). `null` when serverTs is absent/RTT≤0. */
+  downlinkMs: number | null
+}
+
+/**
+ * Split a ping/pong RTT into approximate uplink/downlink halves using the
+ * server-stamped `serverTs` to position the split. See the clock-discipline
+ * note at the top of the file: the RTT itself is locally measured (skew-free);
+ * serverTs only positions the boundary and is clamped into the local window so
+ * skew can never produce a nonsensical half.
+ */
+export function splitRtt(input: RttSplitInput): RttSplit {
+  const rttMs = input.pongRecvAt - input.pingSentAt
+  if (!(rttMs > 0) || typeof input.serverTs !== 'number' || !Number.isFinite(input.serverTs)) {
+    return { rttMs: Math.max(0, rttMs), uplinkMs: null, downlinkMs: null }
+  }
+  // Position serverTs within [pingSentAt, pongRecvAt], clamped for skew safety.
+  const clamped = Math.min(input.pongRecvAt, Math.max(input.pingSentAt, input.serverTs))
+  const uplinkMs = clamped - input.pingSentAt
+  const downlinkMs = rttMs - uplinkMs
+  return { rttMs, uplinkMs, downlinkMs }
+}

--- a/packages/store-core/src/latency-stats.ts
+++ b/packages/store-core/src/latency-stats.ts
@@ -57,7 +57,11 @@ export class RollingPercentiles {
   summary(): { count: number; p50: number | null; p95: number | null } {
     if (this.size === 0) return { count: 0, p50: null, p95: null }
     const sorted = this.buf.slice(0, this.size).sort((a, b) => a - b)
-    const pick = (q: number): number => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]!
+    // Standard nearest-rank: rank = ceil(q*n), 0-based index = rank - 1,
+    // clamped to [0, n-1]. (Using floor(q*n) biases one position high and
+    // makes p95 the max for small n — #5520 review.)
+    const pick = (q: number): number =>
+      sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1))]!
     return { count: this.size, p50: pick(0.5), p95: pick(0.95) }
   }
 }


### PR DESCRIPTION
Latency instrumentation for the streaming-latency epic — measure before tuning the flush intervals. Every later change in the epic is judged by these numbers.

## What this adds

**Server (additive, optional protocol fields):**
- `serverTs` (wall-clock ms epoch) stamped at broadcast time on `stream_start` / `stream_delta` / `stream_end`, and on the `pong` reply. All optional (`z.number().int().nonnegative().finite().optional()`) so old/new servers and clients interop unchanged. Committed protocol dist rebuilt.
- Stamping happens at the broadcast chokepoints in `ws-forwarding.js` (timer flush, normalizer `result.messages`, `flush_deltas` side effect, legacy-cli path) — a true broadcast-time stamp, not normalize-time.
- `pong` carries `serverTs: Date.now()` so clients can split the existing EWMA ping/pong RTT into uplink/downlink halves.
- Provider emit→broadcast: `sdk-session` stamps a monotonic emit time on each text delta; the normalizer carries the first emit time per coalescing key; `ws-forwarding` logs a throttled p50/p95 emit→broadcast summary (`log.debug`, monotonic both ends → a true elapsed duration) to confirm the coalescing buffer is the only meaningful server-side cost.

**Client (app + dashboard, dev/debug only — no new prominent UI):**
- New dependency-free `store-core/latency-stats`: `RollingPercentiles` (bounded ~200-sample ring, nearest-rank p50/p95) and `splitRtt`.
- Both message handlers record the oldest un-rendered delta's `serverTs` + local recv time per messageId on arrival, then on `flushPendingDeltas` sample serverTs→render (approximate token-to-render) and recv→render (skew-free client render cost) into the rolling buffers, with a throttled dev console line. `_onPong` feeds `splitRtt` and logs the uplink/downlink estimate.

## Clock discipline

Wall-clock `Date.now()` is correct for `serverTs` because the field crosses machines — but it is never subtracted across machines for a one-way number. Token-to-render is measured entirely on the client clock (recv→render is the trustworthy, skew-free piece; serverTs→render is reported as approximate). The RTT split uses `serverTs` only to position the boundary *within* a locally-measured ping/pong interval, clamped so clock skew can never produce a negative or oversized half. This is documented in `latency-stats.ts` and in the protocol schema comment. Distinct from the #5414 monotonic-watchdog work, which this keeps straight.

## Tests
- protocol: schema round-trip + rejection for the optional `serverTs` (228 pass)
- server: normalizer emitMonoMs threading, broadcast serverTs stamping, stamped pong (256 pass across the 3 touched files)
- store-core: latency-stats ring-buffer eviction / percentiles / skew-clamp split / degrade-to-null (1216 pass full suite)
- app: delta content + stamped pong unchanged (191 pass message-handler)
- dashboard: full store vitest green (632 pass)

Closes #5515.

Related to #5514.