### PR TITLE
fix(server): treat cloudflared 502/530 as tunnel-routable (#5489)

### DIFF
--- a/packages/server/src/tunnel-check.js
+++ b/packages/server/src/tunnel-check.js
@@ -5,6 +5,18 @@ const log = createLogger('tunnel')
 export const QUICK_TUNNEL_DNS_SETTLE_MS = 20_000
 
 /**
+ * #5489 — cloudflared returns these statuses when the edge reached the tunnel
+ * but the origin (localhost server) is unreachable. The supervisor verifies the
+ * tunnel BEFORE forking the server child (#5314 no-orphan ordering), so the
+ * origin is intentionally down at verification time. Since this check only
+ * confirms routability (the edge resolved and proxied — i.e. DNS has settled),
+ * a 502/530 is proof of success, not a failure.
+ *   502 Bad Gateway        — origin connection refused / reset
+ *   530 (Cloudflare)       — origin unreachable / DNS error at the edge
+ */
+const ROUTABLE_ORIGIN_DOWN_STATUSES = new Set([502, 530])
+
+/**
  * Verify a Cloudflare tunnel is fully routable before exposing it to users.
  * New tunnel URLs need time for DNS propagation — Quick Tunnels can take
  * 30+ seconds. Uses an optional initial delay, then linear backoff:
@@ -28,8 +40,11 @@ export async function waitForTunnel(httpUrl, { maxAttempts = 20, initialInterval
     const timeout = setTimeout(() => controller.abort(), 5000)
     try {
       const res = await fetch(httpUrl, { signal: controller.signal })
-      if (res.ok) {
-        log.info(`Tunnel verified on attempt ${attempt}/${maxAttempts} (took ${((Date.now() - startTime) / 1000).toFixed(1)}s)`)
+      // A successful response OR an "edge reached, origin down" response (#5489)
+      // both prove the tunnel is routable — that's all this check verifies.
+      if (res.ok || ROUTABLE_ORIGIN_DOWN_STATUSES.has(res.status)) {
+        const detail = res.ok ? '' : ` (HTTP ${res.status} — edge routable, origin not yet up)`
+        log.info(`Tunnel verified on attempt ${attempt}/${maxAttempts} (took ${((Date.now() - startTime) / 1000).toFixed(1)}s)${detail}`)
         return
       }
       log.info(`Attempt ${attempt}/${maxAttempts} failed: HTTP ${res.status}`)

--- a/packages/server/tests/tunnel-check-logging.test.js
+++ b/packages/server/tests/tunnel-check-logging.test.js
@@ -36,7 +36,9 @@ describe('waitForTunnel logging', () => {
   it('logs HTTP status code for non-ok responses', async () => {
     const logs = []
     mock.method(console, 'log', (msg) => logs.push(msg))
-    mock.method(globalThis, 'fetch', async () => ({ ok: false, status: 502 }))
+    // #5489 — 502/530 now count as routable, so use a genuinely-failing status
+    // (404) to exercise the HTTP-status logging path.
+    mock.method(globalThis, 'fetch', async () => ({ ok: false, status: 404 }))
 
     await assert.rejects(
       () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, initialInterval: 0 }),
@@ -45,7 +47,7 @@ describe('waitForTunnel logging', () => {
 
     const attemptLogs = logs.filter((l) => l.includes('Attempt'))
     assert.equal(attemptLogs.length, 2)
-    assert.ok(attemptLogs[0].includes('HTTP 502'))
+    assert.ok(attemptLogs[0].includes('HTTP 404'))
   })
 
   it('logs success with attempt number on verification pass', async () => {

--- a/packages/server/tests/tunnel-check.test.js
+++ b/packages/server/tests/tunnel-check.test.js
@@ -60,12 +60,54 @@ describe('waitForTunnel', () => {
   })
 
   it('throws TUNNEL_NOT_ROUTABLE when all responses are non-ok', async () => {
-    mock.method(globalThis, 'fetch', async () => ({ ok: false }))
+    mock.method(globalThis, 'fetch', async () => ({ ok: false, status: 404 }))
     await assert.rejects(
       () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, initialInterval: 0 }),
       (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
     )
     assert.equal(globalThis.fetch.mock.calls.length, 2)
+  })
+
+  // #5489 — cloudflared returns 502/530 ("edge reached, origin down") when the
+  // tunnel is routable but the server child has not forked yet. The check's
+  // purpose is to confirm the edge resolves and proxies (DNS settling), so a
+  // 502/530 is proof of routability, not a failure.
+  it('resolves when probe returns HTTP 502 (edge reached, origin down)', async () => {
+    mock.method(globalThis, 'fetch', async () => ({ ok: false, status: 502 }))
+    await assert.doesNotReject(() =>
+      waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, initialInterval: 0 })
+    )
+    // Should accept on the first probe, not retry to exhaustion.
+    assert.equal(globalThis.fetch.mock.calls.length, 1)
+  })
+
+  it('resolves when probe returns HTTP 530 (edge reached, origin down)', async () => {
+    mock.method(globalThis, 'fetch', async () => ({ ok: false, status: 530 }))
+    await assert.doesNotReject(() =>
+      waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 3, initialInterval: 0 })
+    )
+    assert.equal(globalThis.fetch.mock.calls.length, 1)
+  })
+
+  it('still fails when probe always errors (no edge reached)', async () => {
+    mock.method(globalThis, 'fetch', async () => { throw new Error('ECONNREFUSED') })
+    await assert.rejects(
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, initialInterval: 0 }),
+      (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
+    )
+    assert.equal(globalThis.fetch.mock.calls.length, 2)
+  })
+
+  it('still fails when probe times out (AbortError)', async () => {
+    mock.method(globalThis, 'fetch', async () => {
+      const err = new Error('The operation was aborted')
+      err.name = 'AbortError'
+      throw err
+    })
+    await assert.rejects(
+      () => waitForTunnel('https://example.trycloudflare.com', { maxAttempts: 2, initialInterval: 0 }),
+      (err) => err.code === 'TUNNEL_NOT_ROUTABLE'
+    )
   })
 
   it('uses the provided URL in every fetch call', async () => {


### PR DESCRIPTION
## Summary

Fixes the quick-tunnel boot deadlock from #5489. The supervisor crash-looped at boot because it verifies the tunnel **before** forking the server child (the #5314 WP-1.4 no-orphan ordering: `supervisor.js:252 → :305 → :345`). cloudflared therefore proxies the public URL to a `localhost:8765` origin that is intentionally not listening yet, and answers `HTTP 502` for every verification attempt. `waitForTunnel` treated 502 as failure, exhausted all 20 attempts, threw `TUNNEL_NOT_ROUTABLE`, and `_failBoot()` tore the service down — which launchd `KeepAlive` then respawned, repeating forever.

## Approach — issue option 2 (smallest change, preserves #5314 ordering)

`waitForTunnel` (`packages/server/src/tunnel-check.js`) only verifies **routability** — that the Cloudflare edge resolved the new DNS name and proxied the request. A `502`/`530` ("edge reached, origin down") proves exactly that: the edge is up and forwarding. So those statuses are now accepted as success alongside `2xx`. Genuine connection errors (ECONNREFUSED, ENOTFOUND) and timeouts (AbortError) still fail as before.

This keeps the fork-after-verify ordering intact (no orphan-cleanup changes needed) and is the minimal diff.

### Both call sites verified

- **`_waitForTunnel` at supervisor.js:114** (boot path, `:305`): the origin is down at verification time by design — this is the deadlock. Now resolves on 502/530. ✅
- **`tunnel_recovered` handler at supervisor.js:265**: the child **is** running here, so a healthy origin returns `200` and the normal success path fires. Accepting 502/530 only **widens** what counts as routable; it never rejects a previously-passing case. Routability — not origin health — is what this check verifies in both places, so the broadened acceptance is correct here too. ✅

## Tests (TDD, Node 22)

RED first, then GREEN. Added to `tunnel-check.test.js`:
- resolves on HTTP 502 (accepts on first probe, no retry-to-exhaustion)
- resolves on HTTP 530
- still fails on persistent connection error (ECONNREFUSED)
- still fails on timeout (AbortError)

Also updated the pre-existing `tunnel-check-logging.test.js` "logs HTTP status" test (it asserted 502 → reject, now incorrect) to use `404`, which still genuinely fails and exercises the same status-logging path. The "all responses non-ok" test in `tunnel-check.test.js` was given an explicit `status: 404` for the same reason.

```
tunnel-check.test.js + tunnel-check-logging.test.js
# tests 16  # pass 16  # fail 0
```

Run via the repo's test invocation under Node 22 (local default node is 26 + broken c8):
`node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit tests/tunnel-check*.test.js`

The supervisor-suite files fail in a fresh /tmp worktree because dependencies (`ws`, etc.) aren't installed there — environmental, pre-existing on unmodified main, unrelated to this change. The changed code (`tunnel-check.js`) has zero external deps and its tests pass cleanly.

## Logging

Updated the success log so a 502/530-as-routable pass is not misleading: it now reads `Tunnel verified ... (HTTP 502 — edge routable, origin not yet up)`.

## Follow-up

The live workaround — running the service with `--no-supervisor` under launchd (#5491) — can be revisited once this lands, since supervisor-mode boot will no longer deadlock on quick tunnels.

Closes #5489