### PR TITLE
fix(server): render scheduled-wakeup push body as relative time (#5474)

### DIFF
--- a/packages/server/src/notifications/ready-body.js
+++ b/packages/server/src/notifications/ready-body.js
@@ -16,10 +16,19 @@
  *
  * Wording is kept consistent with the dashboard ActivityIndicator chips
  * (#5436): most-recent task by `startedAt`, `description || toolUseId`
- * detail, `+N more` overflow, HH:MM local wakeup time — and the same
- * priority order: outstanding tasks win over an armed wakeup, because a
- * still-running watcher is the thing the user is most likely waiting on
- * (the wakeup will re-busy the session on its own anyway).
+ * detail, `+N more` overflow — and the same priority order: outstanding
+ * tasks win over an armed wakeup, because a still-running watcher is the
+ * thing the user is most likely waiting on (the wakeup will re-busy the
+ * session on its own anyway).
+ *
+ * Wakeup time is rendered RELATIVE ("resumes in 12m"), not as a clock time
+ * (#5474). The push body is delivered to an OS tray / Discord embed with no
+ * timezone context, and chroxy may run in a different zone than the viewer
+ * (e.g. a UTC container vs. an AEST user) — an absolute HH:MM in the server's
+ * zone misleads. A relative offset is timezone- and DST-proof, and reads
+ * naturally in a notification tray. (The dashboard chip keeps "Resumes at
+ * HH:MM" — its `getHours()` runs in the *browser*, i.e. viewer-local, so it
+ * is correct as-is; only the push body needed fixing.)
  */
 
 /** Today's plain idle-push body — unchanged when the snapshot has nothing. */
@@ -65,17 +74,49 @@ function clampDetail(prefix, detail, suffix = '') {
 }
 
 /**
+ * Format the gap from `now` to a future wakeup `at` (both epoch ms) as a short
+ * relative offset for the push body — timezone- and DST-proof (#5474).
+ *
+ * Units climb sensibly so the string stays compact under the 140-char clamp:
+ *   - < 60s        → "<1m"          (sub-minute precision isn't useful in a tray)
+ *   - 1–89 minutes → "Nm"          (e.g. "12m")
+ *   - ≥ 90 minutes → "Hh" / "HhMm" (e.g. "2h", "2h05m")
+ *
+ * Returns null when `at` is non-finite or already in the past (the caller then
+ * degrades to the plain body — an offset of "in 0m" / a negative value would
+ * be noise, and a stale wakeup carries no useful "resumes in" signal).
+ */
+function formatRelativeWakeup(at, now) {
+  if (!Number.isFinite(at) || !Number.isFinite(now)) return null
+  const deltaMs = at - now
+  if (deltaMs <= 0) return null
+
+  const totalSeconds = Math.round(deltaMs / 1000)
+  if (totalSeconds < 60) return '<1m'
+
+  const totalMinutes = Math.round(totalSeconds / 60)
+  if (totalMinutes < 90) return `${totalMinutes}m`
+
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes === 0 ? `${hours}h` : `${hours}h${String(minutes).padStart(2, '0')}m`
+}
+
+/**
  * Compose the idle-push body from a background-task snapshot.
  *
  * @param {{ backgroundTasks?: Array<{toolUseId:string, description?:string, startedAt?:number}>,
  *           scheduledWakeup?: { at:number, reason?:string } | null } | null | undefined} snapshot
  *   Output of `getBackgroundTaskSnapshot()` (#5436), or null when the session
  *   type doesn't expose one / the transcript scan degraded.
+ * @param {number} [now] Reference epoch ms for the relative wakeup offset —
+ *   defaults to `Date.now()`. Parameterized so tests can pin the offset against
+ *   a fixed `at` without freezing the global clock.
  * @returns {string} the notification body — DEFAULT_READY_BODY when there is
- *   nothing outstanding, otherwise the enriched still-watching / resumes-at
+ *   nothing outstanding, otherwise the enriched still-watching / resumes-in
  *   line, clamped to READY_BODY_MAX_LENGTH.
  */
-export function composeReadyNotificationBody(snapshot) {
+export function composeReadyNotificationBody(snapshot, now = Date.now()) {
   if (!snapshot || typeof snapshot !== 'object') return DEFAULT_READY_BODY
 
   const tasks = Array.isArray(snapshot.backgroundTasks) ? snapshot.backgroundTasks : []
@@ -97,13 +138,15 @@ export function composeReadyNotificationBody(snapshot) {
 
   const wakeup = snapshot.scheduledWakeup
   if (wakeup && typeof wakeup === 'object') {
-    const at = new Date(wakeup.at)
-    if (!Number.isFinite(at.getTime())) return DEFAULT_READY_BODY
-    // Server-local HH:MM — same formatting as the dashboard's wakeup chip.
-    const hhmm = `${String(at.getHours()).padStart(2, '0')}:${String(at.getMinutes()).padStart(2, '0')}`
+    // Relative offset, not an absolute clock time (#5474): the body has no
+    // timezone context and the server may run in a different zone than the
+    // viewer. A past/unparsable `at` degrades to the plain body, exactly as a
+    // NaN time did before.
+    const rel = formatRelativeWakeup(Number(wakeup.at), now)
+    if (rel === null) return DEFAULT_READY_BODY
     const reason = sanitizeDetail(typeof wakeup.reason === 'string' ? wakeup.reason : '')
-    if (!reason) return `Ready for input — resumes at ${hhmm}`
-    return clampDetail(`Ready for input — resumes at ${hhmm}: `, reason)
+    if (!reason) return `Ready for input — resumes in ${rel}`
+    return clampDetail(`Ready for input — resumes in ${rel}: `, reason)
   }
 
   return DEFAULT_READY_BODY

--- a/packages/server/src/notifications/ready-body.js
+++ b/packages/server/src/notifications/ready-body.js
@@ -91,10 +91,17 @@ function formatRelativeWakeup(at, now) {
   const deltaMs = at - now
   if (deltaMs <= 0) return null
 
-  const totalSeconds = Math.round(deltaMs / 1000)
-  if (totalSeconds < 60) return '<1m'
+  // Compare the raw deltaMs against each boundary and FLOOR the minute
+  // conversion — never round. Rounding `deltaMs/1000` (or seconds/60) can push
+  // a value across a branch boundary it hasn't actually reached: 59.6s would
+  // round to 60s and render "1m" instead of the documented "<1m", and 89.5m
+  // would round to 90m and switch to the hours format before the real 90m
+  // mark. Flooring honours "<60s" and "<90m" precisely, and — because
+  // totalMinutes never reaches the next-hour value early — keeps the h+m branch
+  // self-consistent (e.g. 1h59m30s → "1h59m", never "1h60m"/"2h0m").
+  if (deltaMs < 60_000) return '<1m'
 
-  const totalMinutes = Math.round(totalSeconds / 60)
+  const totalMinutes = Math.floor(deltaMs / 60_000)
   if (totalMinutes < 90) return `${totalMinutes}m`
 
   const hours = Math.floor(totalMinutes / 60)

--- a/packages/server/tests/push-notification-handler.test.js
+++ b/packages/server/tests/push-notification-handler.test.js
@@ -273,8 +273,12 @@ describe('PushNotificationHandler — #5438 ready-body enrichment', () => {
     assert.equal(fakes.sends[0].data.state, 'idle')
   })
 
-  it('enriches the body with an armed wakeup (local HH:MM + reason)', () => {
-    const at = new Date(2026, 5, 10, 7, 30).getTime()
+  it('enriches the body with an armed wakeup (relative offset + reason)', () => {
+    // The handler composes without an explicit `now`, so the body is rendered
+    // against Date.now() at test runtime (#5474). Pin `at` 12 minutes out and
+    // assert with a tolerant regex so a few ms of runtime drift across the
+    // round-to-minute boundary can't flake the assertion.
+    const at = Date.now() + 12 * 60_000
     const fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) })
     wireSession(fakes, {
       name: 'n',
@@ -284,7 +288,7 @@ describe('PushNotificationHandler — #5438 ready-body enrichment', () => {
       }),
     })
     emitResult(fakes)
-    assert.equal(fakes.sends[0].body, 'Ready for input — resumes at 07:30: poll the release build')
+    assert.match(fakes.sends[0].body, /^Ready for input — resumes in 1[12]m: poll the release build$/)
   })
 
   it('a throwing snapshot read degrades to the plain body (push still fires)', () => {

--- a/packages/server/tests/ready-notification-body.test.js
+++ b/packages/server/tests/ready-notification-body.test.js
@@ -128,6 +128,64 @@ describe('composeReadyNotificationBody — armed wakeup (relative, #5474)', () =
     assert.equal(body, 'Ready for input — resumes in <1m: check again')
   })
 
+  // Boundary regression (#5522): thresholds compare raw deltaMs and the minute
+  // conversion floors — a near-boundary delta must NOT round across a branch.
+  it('keeps a 59.4s offset as "<1m"', () => {
+    const at = NOW + 59_400 // 59.4s — must not round up to a minute
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at, reason: '' } }, NOW),
+      'Ready for input — resumes in <1m'
+    )
+  })
+
+  it('keeps a 59.6s offset as "<1m" (no round-up to "1m")', () => {
+    const at = NOW + 59_600 // 59.6s — Math.round would have produced "1m"
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at, reason: '' } }, NOW),
+      'Ready for input — resumes in <1m'
+    )
+  })
+
+  it('renders a just-shy-of-1m offset as "<1m" right up to the 60s mark', () => {
+    const at = NOW + 59_999 // 59.999s
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at, reason: '' } }, NOW),
+      'Ready for input — resumes in <1m'
+    )
+  })
+
+  it('keeps an 89.5m offset in the minutes branch (no early switch to hours)', () => {
+    const at = NOW + 89.5 * 60_000 // 89.5m — Math.round would have switched to "1h30m"
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at, reason: '' } }, NOW),
+      'Ready for input — resumes in 89m'
+    )
+  })
+
+  it('switches to the hours branch only at the true 90m mark (89.999m → "89m")', () => {
+    const at = NOW + 89.999 * 60_000
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at, reason: '' } }, NOW),
+      'Ready for input — resumes in 89m'
+    )
+  })
+
+  it('keeps the h+m branch self-consistent for a near-hour-boundary delta (1h59m30s → "1h59m")', () => {
+    const at = NOW + 119.5 * 60_000 // 1h59m30s — floor must not roll over to "1h60m"/"2h0m"
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at, reason: '' } }, NOW),
+      'Ready for input — resumes in 1h59m'
+    )
+  })
+
+  it('renders 119.7m as "1h59m" without rounding minutes up to 60', () => {
+    const at = NOW + 119.7 * 60_000
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at, reason: '' } }, NOW),
+      'Ready for input — resumes in 1h59m'
+    )
+  })
+
   it('renders bare minutes up to 89m, then switches to hours', () => {
     const at89 = NOW + 89 * 60_000
     assert.equal(

--- a/packages/server/tests/ready-notification-body.test.js
+++ b/packages/server/tests/ready-notification-body.test.js
@@ -5,7 +5,9 @@
 //   - absent snapshot (null/undefined) → today's plain body, unchanged
 //   - explicit empty snapshot ([], no wakeup) → plain body too
 //   - outstanding tasks → 'Ready for input — still watching: <desc>' (+N more)
-//   - armed wakeup → 'Ready for input — resumes at HH:MM: <reason>'
+//   - armed wakeup → 'Ready for input — resumes in <rel>: <reason>' (#5474:
+//     relative offset, timezone-proof — `now` is injected so the offset is
+//     pinned against a fixed `at` without freezing the global clock)
 //   - tasks win over a wakeup when both exist (dashboard chip priority)
 //   - the composed body is clamped to ~140 chars (push payload hygiene)
 
@@ -103,39 +105,92 @@ describe('composeReadyNotificationBody — outstanding tasks', () => {
   })
 })
 
-describe('composeReadyNotificationBody — armed wakeup', () => {
-  it('formats the wakeup in server-local HH:MM with the reason', () => {
-    const at = new Date(2026, 5, 10, 9, 5).getTime() // 09:05 local
-    const body = composeReadyNotificationBody({
-      backgroundTasks: [],
-      scheduledWakeup: { at, reason: 'poll CI for the release build' },
-    })
-    assert.equal(body, 'Ready for input — resumes at 09:05: poll CI for the release build')
+describe('composeReadyNotificationBody — armed wakeup (relative, #5474)', () => {
+  // Fixed reference instant so the relative offset is deterministic without
+  // freezing the global clock — `now` is the second composer argument.
+  const NOW = new Date(2026, 5, 10, 9, 0).getTime()
+
+  it('formats the wakeup as a relative minute offset with the reason', () => {
+    const at = NOW + 12 * 60_000 // resumes in 12 minutes
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: 'poll CI for the release build' } },
+      NOW
+    )
+    assert.equal(body, 'Ready for input — resumes in 12m: poll CI for the release build')
+  })
+
+  it('renders "<1m" for a sub-minute offset', () => {
+    const at = NOW + 30_000 // 30 seconds out
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: 'check again' } },
+      NOW
+    )
+    assert.equal(body, 'Ready for input — resumes in <1m: check again')
+  })
+
+  it('renders bare minutes up to 89m, then switches to hours', () => {
+    const at89 = NOW + 89 * 60_000
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at: at89, reason: '' } }, NOW),
+      'Ready for input — resumes in 89m'
+    )
+    const at90 = NOW + 90 * 60_000
+    assert.equal(
+      composeReadyNotificationBody({ backgroundTasks: [], scheduledWakeup: { at: at90, reason: '' } }, NOW),
+      'Ready for input — resumes in 1h30m'
+    )
+  })
+
+  it('renders a whole-hour offset without a minutes component', () => {
+    const at = NOW + 2 * 60 * 60_000 // exactly 2 hours
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: '' } },
+      NOW
+    )
+    assert.equal(body, 'Ready for input — resumes in 2h')
+  })
+
+  it('zero-pads the trailing minutes in an hours+minutes offset', () => {
+    const at = NOW + (2 * 60 + 5) * 60_000 // 2h05m
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: '' } },
+      NOW
+    )
+    assert.equal(body, 'Ready for input — resumes in 2h05m')
   })
 
   it('omits the reason segment when the reason is empty', () => {
-    const at = new Date(2026, 5, 10, 23, 59).getTime()
-    const body = composeReadyNotificationBody({
-      backgroundTasks: [],
-      scheduledWakeup: { at, reason: '' },
-    })
-    assert.equal(body, 'Ready for input — resumes at 23:59')
+    const at = NOW + 12 * 60_000
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: '' } },
+      NOW
+    )
+    assert.equal(body, 'Ready for input — resumes in 12m')
   })
 
   it('omits the reason segment when the reason is whitespace-only', () => {
-    const at = new Date(2026, 5, 10, 23, 59).getTime()
-    const body = composeReadyNotificationBody({
-      backgroundTasks: [],
-      scheduledWakeup: { at, reason: ' \n ' },
-    })
-    assert.equal(body, 'Ready for input — resumes at 23:59')
+    const at = NOW + 12 * 60_000
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: ' \n ' } },
+      NOW
+    )
+    assert.equal(body, 'Ready for input — resumes in 12m')
   })
 
   it('degrades to the plain body when the wakeup time is unparsable', () => {
-    const body = composeReadyNotificationBody({
-      backgroundTasks: [],
-      scheduledWakeup: { at: NaN, reason: 'whatever' },
-    })
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at: NaN, reason: 'whatever' } },
+      NOW
+    )
+    assert.equal(body, DEFAULT_READY_BODY)
+  })
+
+  it('degrades to the plain body when the wakeup time is already in the past', () => {
+    const at = NOW - 60_000 // a minute ago
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: 'stale wakeup' } },
+      NOW
+    )
     assert.equal(body, DEFAULT_READY_BODY)
   })
 })
@@ -187,13 +242,14 @@ describe('composeReadyNotificationBody — length clamp', () => {
   })
 
   it('truncates an oversized wakeup reason too', () => {
-    const at = new Date(2026, 5, 10, 12, 0).getTime()
-    const body = composeReadyNotificationBody({
-      backgroundTasks: [],
-      scheduledWakeup: { at, reason: 'z'.repeat(500) },
-    })
+    const now = new Date(2026, 5, 10, 12, 0).getTime()
+    const at = now + 12 * 60_000
+    const body = composeReadyNotificationBody(
+      { backgroundTasks: [], scheduledWakeup: { at, reason: 'z'.repeat(500) } },
+      now
+    )
     assert.ok(body.length <= READY_BODY_MAX_LENGTH)
-    assert.ok(body.startsWith('Ready for input — resumes at 12:00: z'))
+    assert.ok(body.startsWith('Ready for input — resumes in 12m: z'))
     assert.ok(body.endsWith('…'))
   })
 })


### PR DESCRIPTION
## Summary

The idle ready-for-input push body (`packages/server/src/notifications/ready-body.js`) formatted a `ScheduleWakeup`'s time as **server-local HH:MM**. The push tray and Discord status embed carry no timezone context, so when chroxy runs in a different zone than the viewer (e.g. a UTC container, an AEST user) the body says "resumes at 04:12" while the user's clock and the dashboard chip say 14:12.

Per the issue's lean, this switches the wakeup line to a **relative offset** — timezone- and DST-proof, and reads naturally in a notification tray.

## What changed

- New `formatRelativeWakeup(at, now)` helper. Units climb sensibly under the 140-char clamp:
  - `< 60s` → `<1m`
  - `1–89 min` → `Nm` (e.g. `12m`)
  - `≥ 90 min` → `Hh` / `HhMm` (e.g. `2h`, `2h05m`)
- Wakeup branch now emits `Ready for input — resumes in <rel>` / `… <rel>: <reason>`.
- A **past or non-finite `at` degrades to the plain body**, preserving the exact contract the old `NaN` check had (a stale wakeup carries no useful "resumes in" signal).
- `composeReadyNotificationBody(snapshot, now = Date.now())` — `now` is injectable so tests pin the offset against a fixed `at` without freezing the global clock. The sole production caller (`push-notification-handler.js`) passes only the snapshot and takes the default.
- All existing contracts kept green: 140-char clamp, `+N more` suffix survival, surrogate-pair safety, ANSI/control sanitization, reason omit-when-empty.

## Truncation interaction

The reason still flows through `clampDetail` unchanged — relative formatting only affects the fixed prefix, so the suffix-preservation and surrogate-safety logic is untouched.

## Dashboard chip — intentionally left as-is

`packages/dashboard/src/components/ActivityIndicator.tsx` keeps `Resumes at {hhmm}`. Its `getHours()` runs in the **browser**, i.e. viewer-local time, so it is already correct — the issue notes this explicitly. This does introduce a now-intentional wording difference: the **dashboard chip** shows an absolute clock time ("Resumes at 14:12") while the **push body** shows a relative offset ("resumes in 12m"). Both are correct for their surface; the push surface is the only one without timezone context, which is why only it needed the change.

## Test evidence

Updated `packages/server/tests/ready-notification-body.test.js`: replaced the HH:MM assertions with relative ones (sub-minute, bare-minutes boundary at 89m→1h30m, whole-hour, zero-padded h+m, reason omit, oversized-reason clamp), kept the degrade cases (unparsable), and added a new degrade case for a past `at`.

```
node@22 --test tests/ready-notification-body.test.js
# tests 24
# pass 24
# fail 0
```

Closes #5474

Refs #5452, #5438, #5436