### PR TITLE
fix(server): decrypt credentials.json when resolving Discord webhook URL (#5490)

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -428,6 +428,36 @@ export function getStoredCredential(key) {
 }
 
 /**
+ * #5490 — read a single string field out of the credentials store, going
+ * through the SAME cipher-aware reader (`readStore`) the API-key resolvers use:
+ * 0600 mode enforcement, encrypted-envelope decryption, and the
+ * keychain-unavailable / corrupt-envelope distinctions all apply identically.
+ *
+ * Exposed for credential consumers whose field is NOT a `KNOWN_CREDENTIALS`
+ * env-var key — e.g. the Discord webhook URL (`discordWebhookUrl`), which lives
+ * in the same file but routes to the notification sink rather than a spawned
+ * provider. Returns the read metadata verbatim so the caller can build its own
+ * `reason` strings WITHOUT this module ever logging or echoing the value.
+ *
+ * The raw `value` is returned ONLY to the caller (never logged here). On any
+ * read error `value` is null and `error` carries a value-free reason. The
+ * `keychainUnavailable` flag marks the RECOVERABLE encrypted-but-locked case so
+ * callers can phrase a distinct (still value-free) reason.
+ *
+ * @param {string} field - the JSON field name to read (e.g. 'discordWebhookUrl')
+ * @returns {{ value: string | null, fileExists: boolean, error: string | null, keychainUnavailable: boolean }}
+ */
+export function readStoredField(field) {
+  const { data, fileExists, error, keychainUnavailable } = readStore()
+  if (error) {
+    return { value: null, fileExists, error, keychainUnavailable: Boolean(keychainUnavailable) }
+  }
+  const raw = data[field]
+  const value = typeof raw === 'string' && raw.length > 0 ? raw : null
+  return { value, fileExists, error: null, keychainUnavailable: false }
+}
+
+/**
  * Resolution order: process.env > store > unset.
  *
  * Used by spawn-env.js to inject stored credentials into a spawned child's

--- a/packages/server/src/discord-credentials.js
+++ b/packages/server/src/discord-credentials.js
@@ -101,19 +101,24 @@ export function resolveDiscordWebhookUrl() {
     }
   }
 
+  // A read error covers bad mode, malformed JSON, an encrypted envelope whose
+  // keychain data key is unavailable, a corrupt/undecryptable envelope, AND a
+  // non-ENOENT stat failure (EACCES/EPERM). readStore() reports those stat
+  // failures with `fileExists:false` but a populated `error`, so this MUST be
+  // checked before the `!fileExists` "does not exist" branch below — otherwise a
+  // permission error would be misreported as a missing file, hiding the real
+  // cause from an operator debugging a 0600/ownership problem. The reason is
+  // value-free (built by credential-store from the path/cause).
+  if (read.error) {
+    return { url: null, source: 'none', reason: read.error }
+  }
+
   if (!read.fileExists) {
     return {
       url: null,
       source: 'none',
       reason: `CHROXY_DISCORD_WEBHOOK_URL not set and ${CREDENTIALS_FILE} does not exist`,
     }
-  }
-
-  // A read error covers bad mode, malformed JSON, an encrypted envelope whose
-  // keychain data key is unavailable, and a corrupt/undecryptable envelope.
-  // The reason is value-free (built by credential-store from the path/cause).
-  if (read.error) {
-    return { url: null, source: 'none', reason: read.error }
   }
 
   if (read.value === null) {

--- a/packages/server/src/discord-credentials.js
+++ b/packages/server/src/discord-credentials.js
@@ -25,10 +25,10 @@
  * URLs (token part is the secret); masking at the use site via
  * maskWebhookUrl is the second layer.
  */
-import { readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { cachedResolveCredentialFile } from './auth-probes.js'
+import { readStoredField } from './credential-store.js'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home (same rationale as byok-credentials.js).
@@ -77,48 +77,46 @@ export function resolveDiscordWebhookUrl() {
   }
 
   const CREDENTIALS_FILE = credentialsFilePath()
-  let stat
+
+  // #5490: route the file read through credential-store's cipher-aware reader.
+  // The webhook URL lives in the SAME credentials.json the BYOK/API-key
+  // resolvers read, and the #5154 at-rest migration rewrites that file into an
+  // encrypted envelope on first daemon start. A plain JSON.parse here finds no
+  // `discordWebhookUrl` key in the envelope, so the sink silently goes
+  // unconfigured. `readStoredField` applies the same 0600 mode enforcement,
+  // envelope decryption, and keychain-unavailable handling as the other
+  // resolvers — plaintext (not-yet-encrypted) files still pass through. Never
+  // throws (readStore catches fs/JSON/decrypt errors); never logs or returns
+  // the URL in a reason string.
+  let read
   try {
-    stat = statSync(CREDENTIALS_FILE)
+    read = readStoredField('discordWebhookUrl')
   } catch (err) {
-    if (err.code === 'ENOENT') {
-      return {
-        url: null,
-        source: 'none',
-        reason: `CHROXY_DISCORD_WEBHOOK_URL not set and ${CREDENTIALS_FILE} does not exist`,
-      }
-    }
+    // Defensive: readStoredField is non-throwing by contract, but if it ever
+    // does, degrade to source:'none' rather than crash the sink's probe.
     return {
       url: null,
       source: 'none',
-      reason: `unable to stat ${CREDENTIALS_FILE}: ${err.message}`,
+      reason: `unable to read ${CREDENTIALS_FILE}: ${err.message}`,
     }
   }
 
-  // Refuse anything more permissive than 0600 — same security boundary as
-  // the BYOK/DeepSeek resolvers. A pasted-in credentials.json defaulting to
-  // 0644 on macOS would otherwise leak the webhook to every local user.
-  const perms = stat.mode & 0o777
-  if (perms !== 0o600) {
+  if (!read.fileExists) {
     return {
       url: null,
       source: 'none',
-      reason: `${CREDENTIALS_FILE} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${CREDENTIALS_FILE})`,
+      reason: `CHROXY_DISCORD_WEBHOOK_URL not set and ${CREDENTIALS_FILE} does not exist`,
     }
   }
 
-  let parsed
-  try {
-    parsed = JSON.parse(readFileSync(CREDENTIALS_FILE, 'utf8'))
-  } catch (err) {
-    return {
-      url: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} unreadable or not valid JSON: ${err.message}`,
-    }
+  // A read error covers bad mode, malformed JSON, an encrypted envelope whose
+  // keychain data key is unavailable, and a corrupt/undecryptable envelope.
+  // The reason is value-free (built by credential-store from the path/cause).
+  if (read.error) {
+    return { url: null, source: 'none', reason: read.error }
   }
 
-  if (typeof parsed?.discordWebhookUrl !== 'string' || parsed.discordWebhookUrl.length === 0) {
+  if (read.value === null) {
     return {
       url: null,
       source: 'none',
@@ -126,7 +124,7 @@ export function resolveDiscordWebhookUrl() {
     }
   }
 
-  return { url: parsed.discordWebhookUrl, source: 'file' }
+  return { url: read.value, source: 'file' }
 }
 
 /**

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -20,11 +20,15 @@ import { join } from 'node:path'
 import { DiscordWebhookSink, formatDuration } from '../src/notifications/discord-webhook-sink.js'
 import {
   resolveDiscordWebhookUrl,
+  cachedResolveDiscordWebhookUrl,
   isValidDiscordWebhookUrl,
   extractWebhookIdToken,
   maskWebhookUrl,
 } from '../src/discord-credentials.js'
 import { redactSensitive } from '../src/logger.js'
+import { _setCredentialKeychainForTests } from '../src/credential-store.js'
+import { encryptJson, getOrCreateMasterKey } from '../src/credential-cipher.js'
+import { resetCachesForTest } from '../src/auth-probes.js'
 import { SinkRegistry } from '../src/notifications/sink-registry.js'
 import { PushManager } from '../src/push.js'
 import { validateConfig } from '../src/config.js'
@@ -33,6 +37,18 @@ const WEBHOOK_ID = '123456789012345678'
 const WEBHOOK_TOKEN = 'aBcDeFgHiJkLmNoPqRsTuVwXyZ-0123456789_abcdefghijklmnopqrstuvwx'
 const WEBHOOK = `https://discord.com/api/webhooks/${WEBHOOK_ID}/${WEBHOOK_TOKEN}`
 const API_BASE = `https://discord.com/api/webhooks/${WEBHOOK_ID}/${WEBHOOK_TOKEN}`
+
+// In-memory keychain fake — drives the #5154 encrypted path deterministically
+// without touching the host's real OS keychain (suite default is no-keychain).
+function inMemoryKeychain() {
+  const store = new Map()
+  return {
+    isKeychainAvailable: () => true,
+    getToken: (service) => store.get(service) ?? null,
+    setToken: (token, service) => { store.set(service, token) },
+    _store: store,
+  }
+}
 
 let originalFetch
 let originalHome
@@ -161,6 +177,118 @@ describe('discord-credentials — webhook URL sourcing', () => {
     const r = resolveDiscordWebhookUrl()
     assert.equal(r.url, null)
     assert.equal(r.source, 'none')
+  })
+
+  it('missing-field reason is value-free and stable on a plaintext file', () => {
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    const dir = join(home, '.chroxy')
+    mkdirSync(dir, { recursive: true })
+    const file = join(dir, 'credentials.json')
+    // A credentials.json carrying only an API key — no webhook URL.
+    writeFileSync(file, JSON.stringify({ anthropicApiKey: 'sk-ant-xyz' }), { mode: 0o600 })
+    chmodSync(file, 0o600)
+    const r = resolveDiscordWebhookUrl()
+    assert.equal(r.url, null)
+    assert.equal(r.source, 'none')
+    assert.match(r.reason, /missing or empty "discordWebhookUrl"/)
+  })
+
+  // #5490: the #5154 at-rest encryption rewrites credentials.json into the
+  // cipher envelope on first daemon start. A plain JSON.parse finds no
+  // `discordWebhookUrl` key in the envelope, so the sink silently goes
+  // unconfigured. The resolver must decrypt via the keychain-backed key.
+  it('reads discordWebhookUrl from an ENCRYPTED credentials.json (#5490)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    const dir = join(home, '.chroxy')
+    mkdirSync(dir, { recursive: true })
+    const file = join(dir, 'credentials.json')
+
+    // Drive the encrypted branch with an in-memory keychain (the suite default
+    // is no-keychain → plaintext). Mint/fetch the data key the same way the
+    // store does, encrypt the plaintext blob, and write the envelope at 0600 —
+    // exactly what maybeEncryptCredentialsAtRest() produces at startup.
+    const keychain = inMemoryKeychain()
+    _setCredentialKeychainForTests(keychain)
+    resetCachesForTest()
+    try {
+      const key = getOrCreateMasterKey(keychain)
+      const envelope = encryptJson({ discordWebhookUrl: WEBHOOK }, key)
+      // Sanity: the secret must not be present in the on-disk envelope.
+      const serialized = JSON.stringify(envelope)
+      assert.ok(!serialized.includes(WEBHOOK_TOKEN), 'token must not appear in the envelope')
+      writeFileSync(file, serialized, { mode: 0o600 })
+      chmodSync(file, 0o600)
+
+      const r = resolveDiscordWebhookUrl()
+      assert.equal(r.source, 'file')
+      assert.equal(r.url, WEBHOOK)
+    } finally {
+      _setCredentialKeychainForTests(null)
+      resetCachesForTest()
+    }
+  })
+
+  it('encrypted file + unavailable keychain → none with a value-free reason (#5490)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    const dir = join(home, '.chroxy')
+    mkdirSync(dir, { recursive: true })
+    const file = join(dir, 'credentials.json')
+
+    // Encrypt under a real key, then drop the keychain so the read can't fetch
+    // the data key (locked keychain / headless host). Must fail closed to
+    // source:'none' with a reason that never echoes the URL.
+    const keychain = inMemoryKeychain()
+    _setCredentialKeychainForTests(keychain)
+    resetCachesForTest()
+    try {
+      const key = getOrCreateMasterKey(keychain)
+      const envelope = encryptJson({ discordWebhookUrl: WEBHOOK }, key)
+      writeFileSync(file, JSON.stringify(envelope), { mode: 0o600 })
+      chmodSync(file, 0o600)
+
+      // Swap to a keychain that reports unavailable → getMasterKey returns null.
+      _setCredentialKeychainForTests({ isKeychainAvailable: () => false })
+      const r = resolveDiscordWebhookUrl()
+      assert.equal(r.source, 'none')
+      assert.equal(r.url, null)
+      assert.ok(typeof r.reason === 'string' && r.reason.length > 0)
+      assert.ok(!r.reason.includes(WEBHOOK_TOKEN), 'reason must not echo the webhook token')
+    } finally {
+      _setCredentialKeychainForTests(null)
+      resetCachesForTest()
+    }
+  })
+
+  it('cachedResolveDiscordWebhookUrl composes with decryption (#5490)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    const dir = join(home, '.chroxy')
+    mkdirSync(dir, { recursive: true })
+    const file = join(dir, 'credentials.json')
+
+    const keychain = inMemoryKeychain()
+    _setCredentialKeychainForTests(keychain)
+    resetCachesForTest()
+    try {
+      const key = getOrCreateMasterKey(keychain)
+      const envelope = encryptJson({ discordWebhookUrl: WEBHOOK }, key)
+      writeFileSync(file, JSON.stringify(envelope), { mode: 0o600 })
+      chmodSync(file, 0o600)
+
+      // First (cold) call decrypts; second (cached) call must return the same.
+      const first = cachedResolveDiscordWebhookUrl()
+      assert.equal(first.source, 'file')
+      assert.equal(first.url, WEBHOOK)
+      const second = cachedResolveDiscordWebhookUrl()
+      assert.equal(second.source, 'file')
+      assert.equal(second.url, WEBHOOK)
+    } finally {
+      _setCredentialKeychainForTests(null)
+      resetCachesForTest()
+    }
   })
 
   it('validates webhook URL shapes', () => {

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -179,6 +179,38 @@ describe('discord-credentials — webhook URL sourcing', () => {
     assert.equal(r.source, 'none')
   })
 
+  // #5523 review: a non-ENOENT stat failure (EACCES/EPERM) must surface the
+  // real error, NOT be misreported as "does not exist". readStore() returns such
+  // failures as { fileExists:false, error:'unable to stat …' }, so the resolver
+  // must consult `error` before the missing-file branch. We force EACCES by
+  // making the parent `.chroxy` dir non-traversable. chmod is a no-op for root,
+  // so skip there.
+  it('non-ENOENT stat failure (EACCES) surfaces the real error, not "does not exist" (#5523)', () => {
+    if (process.getuid && process.getuid() === 0) return // root bypasses dir perms
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    const dir = join(home, '.chroxy')
+    const file = join(dir, 'credentials.json')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(file, JSON.stringify({ discordWebhookUrl: WEBHOOK }), { mode: 0o600 })
+    chmodSync(file, 0o600)
+    // Drop traverse on the parent dir → statSync(file) fails with EACCES.
+    chmodSync(dir, 0o000)
+    try {
+      const r = resolveDiscordWebhookUrl()
+      assert.equal(r.url, null)
+      assert.equal(r.source, 'none')
+      // The real reason must surface (stat error), never the misleading
+      // "does not exist", and never the URL/token.
+      assert.match(r.reason, /unable to stat/)
+      assert.doesNotMatch(r.reason, /does not exist/)
+      assert.ok(!r.reason.includes(WEBHOOK_TOKEN), 'reason must not echo the webhook token')
+    } finally {
+      // Restore so the temp dir is removable / harness cleanup succeeds.
+      chmodSync(dir, 0o700)
+    }
+  })
+
   it('missing-field reason is value-free and stable on a plaintext file', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
     process.env.HOME = home


### PR DESCRIPTION
## Summary

`resolveDiscordWebhookUrl()` (`packages/server/src/discord-credentials.js`) plain-`JSON.parse`d `~/.chroxy/credentials.json` and read `.discordWebhookUrl` directly. The #5154 at-rest encryption rewrites that file into the cipher envelope `{ v, alg: "nacl-secretbox", nonce, data }` on first daemon start — which parses fine but has no `discordWebhookUrl` key. So from that moment the resolver returned `source: 'none'` and the Discord webhook sink went **silently unconfigured** (ingest events 200, but `isConfigured()` false, no embed posted, nothing logged). The documented credentials-file config worked for exactly one daemon lifetime.

## Fix

Route the file read through credential-store's cipher-aware reader instead of inventing a new decrypt path:

- New `readStoredField(field)` export in `credential-store.js` reads a single string field through the existing `readStore()` — the same reader the BYOK/API-key resolvers use. It applies 0600 mode enforcement, encrypted-envelope decryption, the keychain-unavailable (recoverable) vs corrupt-envelope distinctions, and returns a value-free `error`/metadata so the caller builds its own reason without this module ever logging or echoing the secret.
- `resolveDiscordWebhookUrl()` now delegates the file read to `readStoredField('discordWebhookUrl')`.

Preserved behaviors:
- `CHROXY_DISCORD_WEBHOOK_URL` env var still takes precedence over the file.
- 0600 mode boundary stays (now via the shared reader — POSIX-enforced, win32 skipped to match how the encrypted file is actually written, consistent with the other resolvers).
- Plaintext (not-yet-encrypted) `credentials.json` still resolves.
- Keychain-unavailable / corrupt-envelope fail closed to `source: 'none'` with a useful, value-free reason. Never throws.

## Tests (TDD)

Added to `tests/discord-webhook-sink.test.js` (in-memory keychain fake drives the #5154 encrypted branch deterministically; suite default is no-keychain):

- **RED → GREEN**: encrypt `{ discordWebhookUrl }` via `credential-cipher` under a keychain-backed key, write the envelope at 0600, assert `resolveDiscordWebhookUrl()` returns the URL with `source: 'file'`. Fails on `main` (envelope has no `discordWebhookUrl` key); passes here.
- encrypted file + unavailable keychain → `source: 'none'` with a reason that never echoes the token.
- `cachedResolveDiscordWebhookUrl` composes with decryption (cold + cached call both return the decrypted URL).
- missing-field reason stays stable/value-free on a plaintext file.

Existing plaintext-path and bad-mode tests retained.

Targeted run (Node 22):
- `tests/discord-webhook-sink.test.js` — 82 pass / 0 fail
- `tests/credential-store.test.js`, `tests/credential-store-encryption.test.js`, `tests/credential-cipher.test.js`, `tests/byok-credentials.test.js` — 74 pass / 0 fail

ESLint clean on the changed source files.

## Note on the live workaround

The live deployment currently works around this via `CHROXY_DISCORD_WEBHOOK_URL` exported into the daemon environment (see #5491's launchd wrapper). Once this lands, the deployment can move back to the documented `credentials.json` `discordWebhookUrl` configuration.

Closes #5490