### PR TITLE
fix(server): escape markdown in Discord embed free-text fields (#5475)

### DIFF
--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -152,6 +152,33 @@ function truncate(text, max = 1000) {
   return text.length > max ? `${text.slice(0, max - 3)}...` : text
 }
 
+/**
+ * Escape Discord markdown metacharacters so free-text user/transcript content
+ * (task descriptions, ScheduleWakeup reasons, session names) renders literally
+ * in an embed field instead of being styled or swallowed (#5475).
+ *
+ * Example: a task described as `watch dist/*_test.js` would otherwise render
+ * with the `*…*`/`_…_` runs interpreted as italics, eating characters.
+ *
+ * The sink is webhook-based and intentionally dependency-free, so this is a
+ * local 5-liner rather than pulling in discord.js's escapeMarkdown. We escape
+ * the inline-format set (`\\ * _ ~ \` |`) plus a leading `>` (blockquote — only
+ * meaningful at line start; we escape every `>` for simplicity, which is
+ * harmless mid-line). Backslash is escaped FIRST so we don't double-escape the
+ * escapes we then insert.
+ *
+ * Applied AFTER truncation deliberately: escaping first could push an escape
+ * pair across the 1000-char cut and leave a dangling `\` (or split a `\X` into
+ * `…\` + `X`). Escaping the already-truncated string keeps every inserted `\X`
+ * pair intact; the result can exceed 1000 chars, but Discord's embed-field
+ * limit is 1024, and the worst case here (≈2000 from all-metachar input) is
+ * not a realistic free-text body — the truncate cap is the binding hygiene.
+ */
+function escapeMarkdown(text) {
+  if (typeof text !== 'string') return ''
+  return text.replace(/[\\*_~`|>]/g, '\\$&')
+}
+
 export class DiscordWebhookSink extends NotificationSink {
   /**
    * @param {object} [opts]
@@ -638,14 +665,17 @@ export class DiscordWebhookSink extends NotificationSink {
   _buildPayload(project, entry) {
     const titleFor = STATE_TITLES[entry.state] || STATE_TITLES.idle
     const fields = []
+    // Free-text user/transcript fields (#5475): escape markdown so a body like
+    // `watch dist/*_test.js` renders literally. Escape AFTER truncate so an
+    // escape pair can't be split across the cut (see escapeMarkdown).
     if (entry.body) {
-      fields.push({ name: 'Status', value: truncate(entry.body), inline: false })
+      fields.push({ name: 'Status', value: escapeMarkdown(truncate(entry.body)), inline: false })
     }
     if (entry.detail) {
-      fields.push({ name: 'Detail', value: truncate(entry.detail), inline: false })
+      fields.push({ name: 'Detail', value: escapeMarkdown(truncate(entry.detail)), inline: false })
     }
     if (entry.sessionName) {
-      fields.push({ name: 'Session', value: truncate(entry.sessionName, 100), inline: true })
+      fields.push({ name: 'Session', value: escapeMarkdown(truncate(entry.sessionName, 100)), inline: true })
     }
     if (Number.isFinite(entry.subagents) && entry.subagents > 0) {
       fields.push({ name: 'Subagents', value: String(entry.subagents), inline: true })

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -167,16 +167,40 @@ function truncate(text, max = 1000) {
  * harmless mid-line). Backslash is escaped FIRST so we don't double-escape the
  * escapes we then insert.
  *
- * Applied AFTER truncation deliberately: escaping first could push an escape
- * pair across the 1000-char cut and leave a dangling `\` (or split a `\X` into
- * `…\` + `X`). Escaping the already-truncated string keeps every inserted `\X`
- * pair intact; the result can exceed 1000 chars, but Discord's embed-field
- * limit is 1024, and the worst case here (≈2000 from all-metachar input) is
- * not a realistic free-text body — the truncate cap is the binding hygiene.
+ * Escaping the already-truncated string keeps every inserted `\X` pair intact
+ * (escaping first could split a `\X` across the cut and leave a dangling `\`),
+ * so callers truncate FIRST and escape SECOND — see escapeAndCap.
  */
 function escapeMarkdown(text) {
   if (typeof text !== 'string') return ''
   return text.replace(/[\\*_~`|>]/g, '\\$&')
+}
+
+/**
+ * Truncate a free-text field, escape its markdown, and clamp the FINAL escaped
+ * string to `max` chars — the value that actually goes on the wire (#5475).
+ *
+ * Escaping after truncation can up to double the length (all-metachar input →
+ * ~2×). Discord's embed-field hard limit is 1024, so an un-clamped escaped
+ * value could exceed it and get the whole webhook PATCH/POST rejected with a
+ * 400. We re-truncate the escaped result to `max`; if the cut lands on a lone
+ * `\` inserted by escaping (i.e. the escape backslash without its metachar),
+ * we drop it so the field never ends in a dangling backslash.
+ *
+ * The inner truncate() appends a plain `...` marker (no metacharacters), so it
+ * is neither escaped nor split by the re-truncate.
+ */
+function escapeAndCap(text, max = 1000) {
+  const escaped = escapeMarkdown(truncate(text, max))
+  if (escaped.length <= max) return escaped
+  const cut = escaped.slice(0, max)
+  // escapeMarkdown emits `\` only immediately before a metacharacter, so every
+  // backslash in `escaped` belongs to a `\X` pair. A run of trailing backslashes
+  // of ODD length means the final `\` is a lone escape whose metachar fell past
+  // the cut; drop it so the field never ends in a dangling escape. An EVEN run
+  // is whole `\\` pairs (escaped literal backslashes) and stays intact.
+  const trailing = cut.length - cut.replace(/\\+$/, '').length
+  return trailing % 2 === 1 ? cut.slice(0, -1) : cut
 }
 
 export class DiscordWebhookSink extends NotificationSink {
@@ -666,16 +690,17 @@ export class DiscordWebhookSink extends NotificationSink {
     const titleFor = STATE_TITLES[entry.state] || STATE_TITLES.idle
     const fields = []
     // Free-text user/transcript fields (#5475): escape markdown so a body like
-    // `watch dist/*_test.js` renders literally. Escape AFTER truncate so an
-    // escape pair can't be split across the cut (see escapeMarkdown).
+    // `watch dist/*_test.js` renders literally. escapeAndCap truncates first,
+    // escapes, then clamps the FINAL escaped string so it can't blow past
+    // Discord's 1024-char field limit (see escapeAndCap).
     if (entry.body) {
-      fields.push({ name: 'Status', value: escapeMarkdown(truncate(entry.body)), inline: false })
+      fields.push({ name: 'Status', value: escapeAndCap(entry.body), inline: false })
     }
     if (entry.detail) {
-      fields.push({ name: 'Detail', value: escapeMarkdown(truncate(entry.detail)), inline: false })
+      fields.push({ name: 'Detail', value: escapeAndCap(entry.detail), inline: false })
     }
     if (entry.sessionName) {
-      fields.push({ name: 'Session', value: escapeMarkdown(truncate(entry.sessionName, 100)), inline: true })
+      fields.push({ name: 'Session', value: escapeAndCap(entry.sessionName, 100), inline: true })
     }
     if (Number.isFinite(entry.subagents) && entry.subagents > 0) {
       fields.push({ name: 'Subagents', value: String(entry.subagents), inline: true })

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -458,6 +458,43 @@ describe('DiscordWebhookSink — status-message state machine', () => {
     assert.equal(status, 'a\\\\\\*b')
   })
 
+  it('caps the FINAL escaped field at the truncate limit for all-metachar input (#5475)', async () => {
+    // Escaping after truncation can ~double the length (each metachar → `\X`).
+    // An all-metachar body must NOT push the escaped value past Discord's
+    // 1024-char field limit, or the webhook PATCH/POST is rejected with a 400.
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    await sink.send({
+      ...idle({
+        detail: '*'.repeat(1500),
+        sessionName: '~'.repeat(500),
+      }),
+      body: '*'.repeat(2000),
+    })
+    const embed = JSON.parse(calls[0].body).embeds[0]
+
+    for (const [name, cap] of [['Status', 1000], ['Detail', 1000], ['Session', 100]]) {
+      const value = embed.fields.find((f) => f.name === name).value
+      assert.ok(value.length <= cap, `${name} (${value.length}) within ${cap}-char cap`)
+      // Well-formed: never ends on a lone (odd-run) escape backslash.
+      const trailing = value.length - value.replace(/\\+$/, '').length
+      assert.equal(trailing % 2, 0, `${name} must not end in a dangling escape backslash`)
+      // And the body really was all-metachar → every kept char is part of a
+      // `\X` pair, so the escaped value is purely backslashes + metachars.
+      assert.ok(/^(\\[*~])+$/.test(value), `${name} is well-formed escaped metachars`)
+    }
+  })
+
+  it('does not re-truncate a normal-length metachar body (#5475)', async () => {
+    // A realistic free-text body stays under the cap even after escaping, so
+    // escapeAndCap is a no-op clamp and the escaping is byte-for-byte correct.
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    await sink.send({ ...idle(), body: 'watch dist/*_test.js | grep ~done~ > log' })
+    const status = JSON.parse(calls[0].body).embeds[0].fields.find((f) => f.name === 'Status').value
+    assert.equal(status, 'watch dist/\\*\\_test.js \\| grep \\~done\\~ \\> log')
+  })
+
   it('uses the permission color for needs-approval regardless of project overrides', async () => {
     const calls = scriptFetch()
     const { sink } = makeSink({ colors: { alpha: 1752220 } })

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -419,6 +419,45 @@ describe('DiscordWebhookSink — status-message state machine', () => {
     assert.ok(embed.fields.some((f) => f.name === 'Status' && f.value === enriched))
   })
 
+  it('escapes Discord markdown metacharacters in free-text fields (#5475)', async () => {
+    // A transcript task description like `watch dist/*_test.js` would otherwise
+    // render with the *…* / _…_ runs styled as italics, swallowing characters.
+    // Body (Status), detail (Detail), and sessionName (Session) are all
+    // free-text and must surface literally.
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    await sink.send({
+      ...idle({
+        detail: 'tool ~strike~ and `code`',
+        sessionName: 'proj_*beta*',
+      }),
+      body: 'watch dist/*_test.js | grep ~done~ > log',
+    })
+    const embed = JSON.parse(calls[0].body).embeds[0]
+
+    const status = embed.fields.find((f) => f.name === 'Status').value
+    assert.equal(status, 'watch dist/\\*\\_test.js \\| grep \\~done\\~ \\> log')
+    // Every metacharacter is backslash-escaped — none survive un-escaped.
+    assert.ok(!/(^|[^\\])[*_~`|>]/.test(status), 'no un-escaped metachar in Status')
+
+    const detail = embed.fields.find((f) => f.name === 'Detail').value
+    assert.equal(detail, 'tool \\~strike\\~ and \\`code\\`')
+
+    const session = embed.fields.find((f) => f.name === 'Session').value
+    assert.equal(session, 'proj\\_\\*beta\\*')
+  })
+
+  it('escapes a literal backslash before inserting markdown escapes (#5475)', async () => {
+    // Backslash must be escaped first so a body of `a\*b` becomes `a\\\*b`
+    // (escaped backslash + escaped star), not `a\\*b` (which Discord would
+    // read as an escaped backslash followed by an un-escaped star).
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    await sink.send({ ...idle(), body: 'a\\*b' })
+    const status = JSON.parse(calls[0].body).embeds[0].fields.find((f) => f.name === 'Status').value
+    assert.equal(status, 'a\\\\\\*b')
+  })
+
   it('uses the permission color for needs-approval regardless of project overrides', async () => {
     const calls = scriptFetch()
     const { sink } = makeSink({ colors: { alpha: 1752220 } })


### PR DESCRIPTION
## Summary

`DiscordWebhookSink` (`packages/server/src/notifications/discord-webhook-sink.js`) rendered `notification.body`, `data.detail`, and `data.sessionName` into the embed's **Status**, **Detail**, and **Session** fields with truncation but no markdown escaping. Since #5452 the body carries free text from transcript task descriptions and `ScheduleWakeup` reasons, so a description like `watch dist/*_test.js` renders in Discord with the `*…*` / `_…_` runs interpreted as italics — swallowing the literal characters.

## What changed

- Added a local, dependency-free `escapeMarkdown(text)` helper next to `truncate`. The sink is webhook-based by design (no discord.js), so this is a 1-line regex rather than pulling in `discord.js`'s `escapeMarkdown`.
  - Escapes the inline-format set `\\ * _ ~ \` |` plus `>` (leading blockquote; escaping every `>` is harmless mid-line).
  - Backslash is escaped **first** (`/[\\*_~\`|>]/g → \\$&`) so the escapes we insert aren't themselves double-escaped.
- Applied at all three free-text render sites in `_buildPayload` (Status, Detail, Session). The `title` and `footer` are sink-composed (bot name + sanitized project key) and intentionally left un-escaped — they carry no free text.

## Escape vs. truncate ordering

Escaping runs **after** `truncate` (`escapeMarkdown(truncate(...))`). Doing it the other way could push an inserted `\X` pair across the 1000-char cut and leave a dangling `\`, or split `\X` into `…\` + `X`. Escaping the already-truncated string keeps every `\X` pair intact. The result can exceed 1000 chars in a pathological all-metachar input (~2x), but Discord's embed-field limit is 1024 and such input is not a realistic free-text body — `truncate` remains the binding hygiene cap.

## Test evidence

Added two tests to `packages/server/tests/discord-webhook-sink.test.js` (following the existing `scriptFetch` / `makeSink` / `idle()` conventions):

- A metacharacter-laden body/detail/sessionName asserts each field surfaces literally (escaped) — including the `watch dist/*_test.js | grep ~done~ > log` example from the issue.
- A `a\*b` body pins the backslash-first ordering (`a\\\*b`).

```
node@22 --test tests/discord-webhook-sink.test.js
# tests 87
# pass 87
# fail 0
```

Closes #5475

Refs #5452, #5427