### PR TITLE
fix(server): make launchd/systemd service start out of the box (#5491)

### DIFF
--- a/packages/server/src/cli/service-cmd.js
+++ b/packages/server/src/cli/service-cmd.js
@@ -20,6 +20,7 @@ export function registerServiceCommand(program) {
         getServicePaths,
         resolveNode22Path,
         resolveChroxyBin,
+        resolveClaudeBin,
         loadServiceState,
         installService,
       } = await import('../service.js')
@@ -54,6 +55,17 @@ export function registerServiceCommand(program) {
         process.exit(1)
       }
 
+      // Resolve the claude CLI from the installer's PATH and bake it into the
+      // service PATH (#5491). Install MUST fail here rather than register a job
+      // that crash-loops on preflight when claude isn't on launchd's PATH.
+      let claudeBin
+      try {
+        claudeBin = resolveClaudeBin()
+      } catch (err) {
+        console.error(`Error: ${err.message}`)
+        process.exit(1)
+      }
+
       const cwd = options.cwd || homedir()
 
       if (options.cwd && !existsSync(options.cwd)) {
@@ -67,6 +79,7 @@ export function registerServiceCommand(program) {
         installService({
           nodePath,
           chroxyBin,
+          claudeBin,
           cwd,
           startAtLogin,
         })
@@ -77,6 +90,7 @@ export function registerServiceCommand(program) {
         console.log('\n\u2705 Chroxy service installed successfully!\n')
         console.log(`  Node:         ${nodePath}`)
         console.log(`  Chroxy CLI:   ${chroxyBin}`)
+        console.log(`  Claude CLI:   ${claudeBin}`)
         console.log(`  Service file: ${servicePath}`)
         console.log(`  Log dir:      ${paths.logDir}`)
         console.log(`  Working dir:  ${cwd}`)

--- a/packages/server/src/service.js
+++ b/packages/server/src/service.js
@@ -1,12 +1,24 @@
 import { homedir, platform } from 'os'
 import { join, dirname } from 'path'
-import { existsSync, readFileSync, mkdirSync, unlinkSync, readdirSync } from 'fs'
+import { existsSync, readFileSync, mkdirSync, unlinkSync, readdirSync, writeFileSync, chmodSync } from 'fs'
 import { writeFileRestricted } from './platform.js'
 import { execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
 
 const SERVICE_LABEL = 'com.chroxy.server'
 const DEFAULT_CONFIG_DIR = join(homedir(), '.chroxy')
+const WRAPPER_NAME = 'service-wrapper.sh'
+
+// Keychain coordinates for secrets resolved by the service wrapper at spawn
+// time. The api-token pair mirrors keychain.js (service 'chroxy', account
+// 'api-token'); the webhook pair mirrors the deployed workaround for #5490
+// (service 'chroxy-discord-webhook', account 'webhook-url').
+const KEYCHAIN_API_TOKEN = { service: 'chroxy', account: 'api-token', env: 'API_TOKEN' }
+const KEYCHAIN_DISCORD_WEBHOOK = {
+  service: 'chroxy-discord-webhook',
+  account: 'webhook-url',
+  env: 'CHROXY_DISCORD_WEBHOOK_URL',
+}
 
 /**
  * Escape XML special characters in a string.
@@ -60,13 +72,24 @@ export function generateLaunchdPlist(config) {
   const {
     nodePath,
     chroxyBin,
+    claudeBin,
+    wrapperPath,
     cwd = homedir(),
     startAtLogin = false,
     logDir = join(homedir(), '.chroxy', 'logs'),
   } = config
 
-  const nodeBinDir = dirname(nodePath)
-  const pathValue = `${nodeBinDir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`
+  // Bake a PATH that includes the node and claude bin dirs so the daemon's
+  // preflight finds both under launchd's bare default PATH (#5491).
+  const pathValue = buildServicePath({ nodePath, claudeBin })
+
+  // When a wrapper is provided, exec it so keychain secrets reach the daemon
+  // (#5491). Otherwise exec node+chroxy directly (legacy / no-wrapper path).
+  const programArgs = wrapperPath
+    ? `    <string>${escapeXml(wrapperPath)}</string>`
+    : `    <string>${escapeXml(nodePath)}</string>
+    <string>${escapeXml(chroxyBin)}</string>
+    <string>start</string>`
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -76,9 +99,7 @@ export function generateLaunchdPlist(config) {
   <string>${SERVICE_LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${escapeXml(nodePath)}</string>
-    <string>${escapeXml(chroxyBin)}</string>
-    <string>start</string>
+${programArgs}
   </array>
   <key>RunAtLoad</key>
   ${startAtLogin ? '<true/>' : '<false/>'}
@@ -109,12 +130,20 @@ export function generateSystemdUnit(config) {
   const {
     nodePath,
     chroxyBin,
+    claudeBin,
+    wrapperPath,
     cwd = homedir(),
     logDir = join(homedir(), '.chroxy', 'logs'),
   } = config
 
-  const nodeBinDir = dirname(nodePath)
-  const pathValue = `${nodeBinDir}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`
+  // Bake a PATH that includes the node and claude bin dirs for parity with the
+  // launchd plist (#5491).
+  const pathValue = buildServicePath({ nodePath, claudeBin })
+
+  // Prefer the wrapper (resolves keychain secrets) when provided.
+  const execStart = wrapperPath
+    ? `ExecStart=${wrapperPath}`
+    : `ExecStart="${nodePath}" "${chroxyBin}" start`
 
   return `[Unit]
 Description=Chroxy remote terminal daemon
@@ -122,7 +151,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart="${nodePath}" "${chroxyBin}" start
+${execStart}
 WorkingDirectory=${cwd}
 Restart=on-failure
 RestartSec=5
@@ -253,6 +282,116 @@ export function resolveChroxyBin() {
 }
 
 /**
+ * Resolve the `claude` CLI binary from the installer's environment.
+ *
+ * The Agent SDK requires the Claude Code CLI on PATH. launchd/systemd run the
+ * daemon with a bare PATH (`/usr/bin:/bin:...`), so `claude` (commonly under
+ * `~/.local/bin`) is invisible and preflight fails (#5491). We capture the
+ * resolved location at install time via `which` so it can be baked into the
+ * service's PATH.
+ *
+ * Throws with an actionable message if `claude` cannot be resolved — install
+ * MUST fail loudly rather than register a job that crash-loops on preflight.
+ *
+ * @param {object} [options]
+ * @param {(cmd: string, args: string[], opts: object) => string} [options._which]
+ *   Injectable exec for testing (defaults to execFileSync).
+ * @returns {string} Absolute path to the `claude` binary.
+ */
+export function resolveClaudeBin(options = {}) {
+  const which = options._which || execFileSync
+  try {
+    const resolved = which('which', ['claude'], { encoding: 'utf-8' }).trim()
+    if (resolved && existsSync(resolved)) {
+      return resolved
+    }
+  } catch {
+    // fall through to the actionable error below
+  }
+
+  throw new Error(
+    "Could not find the 'claude' CLI (required by the Agent SDK).\n" +
+    'Install Claude Code (https://claude.ai/code) and ensure `claude` is on your PATH,\n' +
+    'then re-run `chroxy service install`. The resolved location is baked into the\n' +
+    'service so the daemon can find it under launchd/systemd.'
+  )
+}
+
+/**
+ * Build the PATH value baked into the service definition.
+ *
+ * Includes the directories holding the resolved `node` and `claude` binaries
+ * (deduplicated, in that priority order) ahead of the standard system dirs,
+ * so the daemon's preflight finds both even under a bare launchd/systemd PATH.
+ *
+ * @param {object} args
+ * @param {string} args.nodePath - Resolved node binary path.
+ * @param {string} [args.claudeBin] - Resolved claude binary path.
+ * @returns {string} Colon-separated PATH.
+ */
+export function buildServicePath({ nodePath, claudeBin }) {
+  const dirs = []
+  const push = (p) => {
+    if (!p) return
+    const d = dirname(p)
+    if (!dirs.includes(d)) dirs.push(d)
+  }
+  push(nodePath)
+  push(claudeBin)
+  for (const sys of ['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']) {
+    if (!dirs.includes(sys)) dirs.push(sys)
+  }
+  return dirs.join(':')
+}
+
+/**
+ * Generate the service wrapper script the service definition execs.
+ *
+ * launchd resolves keychain items in a context where the daemon's own
+ * `getToken()` fails even though `security find-generic-password` succeeds in a
+ * shell spawned by the same job (#5491). This wrapper resolves the secrets via
+ * `/usr/bin/security` at spawn time, exports them, and execs the server.
+ *
+ * Secret resolution is graceful: a failed/empty keychain read leaves the env
+ * var unset so config-file / `--no-auth` setups still work. The token itself is
+ * NEVER written into the plist — only this 0700 wrapper reads it.
+ *
+ * @param {object} config
+ * @param {string} config.nodePath - Resolved node binary path.
+ * @param {string} config.chroxyBin - Resolved chroxy CLI entry point.
+ * @param {string} config.pathValue - PATH to export (from buildServicePath).
+ * @param {string} [config.cwd] - Working directory (informational; the service
+ *   definition sets the actual cwd).
+ * @returns {string} POSIX sh script.
+ */
+export function generateServiceWrapper(config) {
+  const { nodePath, chroxyBin, pathValue } = config
+
+  const sh = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
+  const keychainBlock = ({ service, account, env }) => `
+# ${env} — resolve from the keychain at spawn time (graceful: skip on failure)
+if _val="$(/usr/bin/security find-generic-password -s ${sh(service)} -a ${sh(account)} -w 2>/dev/null)"; then
+  if [ -n "$_val" ]; then
+    export ${env}="$_val"
+  fi
+fi`
+
+  return `#!/bin/sh
+# Chroxy service wrapper — generated by \`chroxy service install\` (#5491).
+# Resolves keychain secrets unavailable to the launchd/systemd daemon context
+# and execs the server. Regenerated on every \`service install\`; edits are lost.
+set -e
+
+export PATH=${sh(pathValue)}
+export CHROXY_DAEMON=1
+${keychainBlock(KEYCHAIN_API_TOKEN)}
+${keychainBlock(KEYCHAIN_DISCORD_WEBHOOK)}
+
+exec ${sh(nodePath)} ${sh(chroxyBin)} start
+`
+}
+
+/**
  * Load service state from the config directory.
  * @param {string} [configDir] - Override config directory (for testing)
  * @returns {object|null}
@@ -283,17 +422,42 @@ export function saveServiceState(state, configDir = DEFAULT_CONFIG_DIR) {
 }
 
 /**
+ * Write the service wrapper script to disk with 0700 perms (owner rwx only).
+ *
+ * The wrapper resolves keychain secrets at spawn time (#5491); it is owner-only
+ * executable because it is what the service execs and it reads secrets.
+ *
+ * @param {string} wrapperPath - Absolute path to write the wrapper to.
+ * @param {string} content - Wrapper script body (from generateServiceWrapper).
+ * @returns {string} The wrapper path written.
+ */
+export function writeServiceWrapper(wrapperPath, content) {
+  const dir = dirname(wrapperPath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  // 0600 first (no world/group bits during the write window), then 0700 so the
+  // service can exec it. The script holds no secret itself — only the security
+  // invocations that read them — but owner-only is defense in depth.
+  writeFileSync(wrapperPath, content, { mode: 0o600 })
+  chmodSync(wrapperPath, 0o700)
+  return wrapperPath
+}
+
+/**
  * Install Chroxy as a system daemon.
  * Generates the appropriate service file, writes it, and optionally registers it.
  *
  * @param {object} config
  * @param {string} config.nodePath - Path to Node 22 binary
  * @param {string} config.chroxyBin - Path to chroxy CLI entry point
+ * @param {string} [config.claudeBin] - Path to the claude CLI (baked into PATH)
  * @param {string} [config.cwd] - Working directory for sessions
  * @param {boolean} [config.startAtLogin] - Start on login
  * @param {string} [config._servicePath] - Override service file path (testing)
  * @param {string} [config._logDir] - Override log directory (testing)
  * @param {string} [config._stateDir] - Override state directory (testing)
+ * @param {string} [config._wrapperPath] - Override wrapper script path (testing)
  * @param {boolean} [config._skipRegister] - Skip launchctl/systemctl registration (testing)
  * @param {string} [config._platform] - Override platform (testing)
  */
@@ -313,11 +477,30 @@ export function installService(config) {
   const servicePath = config._servicePath || (plat === 'darwin' ? paths.plistPath : paths.unitPath)
   const logDir = config._logDir || paths.logDir
   const stateDir = config._stateDir || DEFAULT_CONFIG_DIR
+  const wrapperPath = config._wrapperPath || join(stateDir, WRAPPER_NAME)
+
+  // Bake the resolved binary locations into the service PATH so the daemon's
+  // preflight finds node + claude under the bare launchd/systemd PATH (#5491).
+  const pathValue = buildServicePath({
+    nodePath: config.nodePath,
+    claudeBin: config.claudeBin,
+  })
+
+  // Write the wrapper that resolves keychain secrets at spawn time (#5491).
+  const wrapperContent = generateServiceWrapper({
+    nodePath: config.nodePath,
+    chroxyBin: config.chroxyBin,
+    pathValue,
+    cwd: config.cwd || homedir(),
+  })
+  writeServiceWrapper(wrapperPath, wrapperContent)
 
   // Generate service file content
   const genConfig = {
     nodePath: config.nodePath,
     chroxyBin: config.chroxyBin,
+    claudeBin: config.claudeBin,
+    wrapperPath,
     cwd: config.cwd || homedir(),
     startAtLogin: config.startAtLogin || false,
     logDir,
@@ -360,6 +543,8 @@ export function installService(config) {
     servicePath,
     nodePath: config.nodePath,
     chroxyBin: config.chroxyBin,
+    claudeBin: config.claudeBin,
+    wrapperPath,
     cwd: genConfig.cwd,
     startAtLogin: genConfig.startAtLogin,
   }, stateDir)
@@ -399,6 +584,12 @@ export function uninstallService(options = {}) {
     unlinkSync(state.servicePath)
   }
 
+  // Remove the generated wrapper script (#5491)
+  const wrapperPath = state.wrapperPath || join(stateDir, WRAPPER_NAME)
+  if (existsSync(wrapperPath)) {
+    unlinkSync(wrapperPath)
+  }
+
   // Remove state file
   const statePath = join(stateDir, 'service.json')
   if (existsSync(statePath)) {
@@ -412,12 +603,15 @@ export function uninstallService(options = {}) {
  * @param {string} [options._platform] - Override platform for testing
  * @param {string} [options._stateDir] - Override state directory (for testing)
  * @param {boolean} [options._skipExec] - Skip actual launchctl/systemctl calls (for testing)
+ * @param {(cmd: string, args: string[], opts: object) => void} [options._exec]
+ *   Injectable exec for testing (defaults to execFileSync).
  * @returns {{ started: boolean, message: string }}
  */
 export function startService(options = {}) {
   const plat = options._platform || platform()
   const paths = getServicePaths(plat)
   const stateDir = options._stateDir || DEFAULT_CONFIG_DIR
+  const exec = options._exec || execFileSync
 
   if (plat === 'win32') {
     return {
@@ -430,6 +624,7 @@ export function startService(options = {}) {
   if (!options._skipExec) {
     if (paths.type === 'launchd') {
       const state = loadServiceState(stateDir)
+      let plistPath
       if (state?.servicePath) {
         if (!existsSync(state.servicePath)) {
           throw new Error(
@@ -437,24 +632,64 @@ export function startService(options = {}) {
             "The service state is stale. Run 'chroxy service install' to reinstall."
           )
         }
-        execFileSync('launchctl', ['bootstrap', `gui/${process.getuid()}`, state.servicePath], { stdio: 'pipe' })
+        plistPath = state.servicePath
+      } else if (existsSync(paths.plistPath)) {
+        // Service file exists but state is missing/stale — use the default path
+        plistPath = paths.plistPath
       } else {
-        // No servicePath in state — check if the plist exists at the default location
-        if (existsSync(paths.plistPath)) {
-          // Service file exists but state is missing/stale — use the default path
-          execFileSync('launchctl', ['bootstrap', `gui/${process.getuid()}`, paths.plistPath], { stdio: 'pipe' })
-        } else {
-          throw new Error(
-            "Service not installed. Run 'chroxy service install' first."
-          )
-        }
+        throw new Error(
+          "Service not installed. Run 'chroxy service install' first."
+        )
       }
+      bootstrapLaunchd(plistPath, exec)
     } else {
-      execFileSync('systemctl', ['--user', 'start', 'chroxy.service'], { stdio: 'pipe' })
+      exec('systemctl', ['--user', 'start', 'chroxy.service'], { stdio: 'pipe' })
     }
   }
 
   return { started: true, message: 'Service started' }
+}
+
+/**
+ * Idempotently (re)start a launchd job: bootout any existing instance of the
+ * label first, then bootstrap (#5491).
+ *
+ * launchd refuses to bootstrap a label that is already registered. A stale
+ * label left from a prior run makes the first `service start` fail with the
+ * opaque `Bootstrap failed: 5: Input/output error`. Booting out first makes
+ * start idempotent; if bootstrap still fails with EIO we translate it into an
+ * actionable hint instead of surfacing the raw launchd error.
+ *
+ * @param {string} plistPath - Path to the plist to bootstrap.
+ * @param {(cmd: string, args: string[], opts: object) => void} exec - exec impl.
+ */
+function bootstrapLaunchd(plistPath, exec) {
+  const domain = `gui/${process.getuid()}`
+
+  // Bootout a stale label first — failure is fine (label may not be loaded).
+  try {
+    exec('launchctl', ['bootout', `${domain}/${SERVICE_LABEL}`], { stdio: 'pipe' })
+  } catch {
+    // Not currently loaded — nothing to bootout.
+  }
+
+  try {
+    exec('launchctl', ['bootstrap', domain, plistPath], { stdio: 'pipe' })
+  } catch (err) {
+    const detail = String(err?.stderr || err?.message || '')
+    // `Bootstrap failed: 5: Input/output error` — usually a stale/duplicate
+    // label or a job still shutting down. Surface an actionable hint (#5491).
+    if (/Input\/output error|: 5:/.test(detail)) {
+      throw new Error(
+        'launchd could not bootstrap the Chroxy service (Bootstrap failed: 5: Input/output error).\n' +
+        'This usually means a previous instance is still registered or shutting down. Try:\n' +
+        `  launchctl bootout ${domain}/${SERVICE_LABEL}\n` +
+        '  chroxy service start\n' +
+        "If it persists, reinstall with 'chroxy service uninstall && chroxy service install'."
+      )
+    }
+    throw err
+  }
 }
 
 /**

--- a/packages/server/tests/service.test.js
+++ b/packages/server/tests/service.test.js
@@ -4,13 +4,18 @@ import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, writeFileSync
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
+import { fileURLToPath } from 'url'
 import {
   getServicePaths,
   generateLaunchdPlist,
   generateSystemdUnit,
+  generateServiceWrapper,
   getWindowsAlternatives,
   resolveNode22Path,
   resolveChroxyBin,
+  resolveClaudeBin,
+  buildServicePath,
+  writeServiceWrapper,
   loadServiceState,
   saveServiceState,
   installService,
@@ -20,6 +25,7 @@ import {
   getServiceStatus,
   getFullServiceStatus,
 } from '../src/service.js'
+import { statSync } from 'fs'
 
 describe('service', () => {
   let tmpDir
@@ -789,6 +795,331 @@ describe('service', () => {
       // _skipExec bypasses the actual exec calls — should succeed regardless
       const result = startService({ _skipExec: true, _platform: 'darwin' })
       assert.equal(result.started, true)
+    })
+  })
+
+  // ---- #5491: launchd robustness (PATH baking, keychain wrapper, start UX) ----
+
+  describe('resolveClaudeBin() (#5491 gap 1)', () => {
+    it('returns the path resolved by `which claude`', () => {
+      // Inject a fake `which` that points at a real file (this test file).
+      const fakePath = fileURLToPath(import.meta.url)
+      const which = (cmd, args) => {
+        assert.equal(cmd, 'which')
+        assert.deepEqual(args, ['claude'])
+        return fakePath + '\n'
+      }
+      const resolved = resolveClaudeBin({ _which: which })
+      assert.equal(resolved, fakePath)
+    })
+
+    it('throws an actionable error when claude cannot be resolved', () => {
+      const which = () => {
+        const err = new Error('which: no claude')
+        throw err
+      }
+      assert.throws(() => resolveClaudeBin({ _which: which }), {
+        message: /claude.*CLI|install claude code/i,
+      })
+    })
+
+    it('throws when `which` returns a path that does not exist', () => {
+      const which = () => '/nonexistent/path/to/claude\n'
+      assert.throws(() => resolveClaudeBin({ _which: which }), {
+        message: /claude/i,
+      })
+    })
+  })
+
+  describe('buildServicePath() (#5491 gap 1)', () => {
+    it('includes the node and claude bin dirs', () => {
+      const p = buildServicePath({
+        nodePath: '/opt/homebrew/opt/node@22/bin/node',
+        claudeBin: '/Users/me/.local/bin/claude',
+      })
+      const parts = p.split(':')
+      assert.ok(parts.includes('/opt/homebrew/opt/node@22/bin'))
+      assert.ok(parts.includes('/Users/me/.local/bin'))
+      // node and claude dirs come before system dirs
+      assert.ok(parts.indexOf('/opt/homebrew/opt/node@22/bin') < parts.indexOf('/usr/bin'))
+      assert.ok(parts.indexOf('/Users/me/.local/bin') < parts.indexOf('/usr/bin'))
+    })
+
+    it('still includes system dirs', () => {
+      const p = buildServicePath({ nodePath: '/usr/local/bin/node' })
+      assert.ok(p.includes('/usr/bin'))
+      assert.ok(p.includes('/bin'))
+    })
+
+    it('does not duplicate a dir that holds both binaries', () => {
+      const p = buildServicePath({
+        nodePath: '/usr/local/bin/node',
+        claudeBin: '/usr/local/bin/claude',
+      })
+      const occurrences = p.split(':').filter(d => d === '/usr/local/bin').length
+      assert.equal(occurrences, 1)
+    })
+  })
+
+  describe('generateLaunchdPlist() with baked claude PATH (#5491 gap 1)', () => {
+    it('bakes the claude bin dir into the plist PATH', () => {
+      const plist = generateLaunchdPlist({
+        nodePath: '/opt/homebrew/opt/node@22/bin/node',
+        chroxyBin: '/some/cli.js',
+        claudeBin: '/Users/me/.local/bin/claude',
+        cwd: '/Users/me',
+      })
+      assert.ok(plist.includes('<key>PATH</key>'))
+      assert.ok(plist.includes('/Users/me/.local/bin'))
+      assert.ok(plist.includes('/opt/homebrew/opt/node@22/bin'))
+    })
+
+    it('execs the wrapper when wrapperPath is provided', () => {
+      const plist = generateLaunchdPlist({
+        nodePath: '/n/node',
+        chroxyBin: '/c/cli.js',
+        wrapperPath: '/Users/me/.chroxy/service-wrapper.sh',
+        cwd: '/Users/me',
+      })
+      assert.ok(plist.includes('<string>/Users/me/.chroxy/service-wrapper.sh</string>'))
+      // Direct node+start args are replaced by the wrapper
+      assert.ok(!plist.includes('<string>start</string>'))
+    })
+  })
+
+  describe('generateSystemdUnit() with baked claude PATH (#5491 gap 1)', () => {
+    it('bakes the claude bin dir into Environment=PATH', () => {
+      const unit = generateSystemdUnit({
+        nodePath: '/usr/local/bin/node',
+        chroxyBin: '/some/cli.js',
+        claudeBin: '/home/me/.local/bin/claude',
+        cwd: '/home/me',
+      })
+      assert.ok(unit.includes('Environment=PATH='))
+      assert.ok(unit.includes('/home/me/.local/bin'))
+    })
+
+    it('uses the wrapper in ExecStart when wrapperPath is provided', () => {
+      const unit = generateSystemdUnit({
+        nodePath: '/usr/local/bin/node',
+        chroxyBin: '/some/cli.js',
+        wrapperPath: '/home/me/.chroxy/service-wrapper.sh',
+        cwd: '/home/me',
+      })
+      assert.ok(unit.includes('ExecStart=/home/me/.chroxy/service-wrapper.sh'))
+    })
+  })
+
+  describe('generateServiceWrapper() (#5491 gap 2)', () => {
+    const config = {
+      nodePath: '/opt/homebrew/opt/node@22/bin/node',
+      chroxyBin: '/some/cli.js',
+      pathValue: '/opt/homebrew/opt/node@22/bin:/usr/bin:/bin',
+      cwd: '/Users/me',
+    }
+
+    it('is a POSIX sh script', () => {
+      const w = generateServiceWrapper(config)
+      assert.ok(w.startsWith('#!/bin/sh'))
+    })
+
+    it('resolves the api token from the keychain via /usr/bin/security', () => {
+      const w = generateServiceWrapper(config)
+      assert.ok(w.includes('/usr/bin/security find-generic-password'))
+      assert.ok(w.includes("-s 'chroxy'"))
+      assert.ok(w.includes("-a 'api-token'"))
+      assert.ok(w.includes('export API_TOKEN='))
+    })
+
+    it('resolves the discord webhook from the keychain (relates to #5490)', () => {
+      const w = generateServiceWrapper(config)
+      assert.ok(w.includes("-s 'chroxy-discord-webhook'"))
+      assert.ok(w.includes("-a 'webhook-url'"))
+      assert.ok(w.includes('export CHROXY_DISCORD_WEBHOOK_URL='))
+    })
+
+    it('reads the keychain gracefully (suppresses errors, guards empty)', () => {
+      const w = generateServiceWrapper(config)
+      // security errors are swallowed (2>/dev/null) and empty values skipped
+      assert.ok(w.includes('2>/dev/null'))
+      assert.ok(/if \[ -n "\$_val" \]/.test(w))
+    })
+
+    it('exports the baked PATH and execs the server', () => {
+      const w = generateServiceWrapper(config)
+      assert.ok(w.includes('export PATH='))
+      assert.ok(w.includes(config.pathValue))
+      assert.ok(w.includes(`exec '${config.nodePath}' '${config.chroxyBin}' start`))
+    })
+
+    it('does NOT embed any token value in the script', () => {
+      const w = generateServiceWrapper(config)
+      // The token is resolved at runtime; only the security invocation appears.
+      assert.ok(!w.includes('API_TOKEN=sk-'))
+    })
+  })
+
+  describe('writeServiceWrapper() (#5491 gap 2)', () => {
+    it('writes the wrapper 0700 (owner rwx only)', () => {
+      const wrapperPath = join(tmpDir, '.chroxy', 'service-wrapper.sh')
+      writeServiceWrapper(wrapperPath, '#!/bin/sh\necho hi\n')
+      assert.ok(existsSync(wrapperPath))
+      const mode = statSync(wrapperPath).mode & 0o777
+      assert.equal(mode, 0o700, `expected 0700, got ${mode.toString(8)}`)
+    })
+
+    it('creates the parent directory if missing', () => {
+      const wrapperPath = join(tmpDir, 'nested', 'dir', 'service-wrapper.sh')
+      writeServiceWrapper(wrapperPath, '#!/bin/sh\n')
+      assert.ok(existsSync(wrapperPath))
+    })
+  })
+
+  describe('installService() writes wrapper and bakes PATH (#5491)', () => {
+    it('writes a 0700 wrapper with the security invocation on darwin', () => {
+      const serviceDir = join(tmpDir, 'LaunchAgents')
+      mkdirSync(serviceDir, { recursive: true })
+      const logDir = join(tmpDir, 'logs')
+      const stateDir = join(tmpDir, 'state')
+
+      installService({
+        nodePath: '/opt/homebrew/opt/node@22/bin/node',
+        chroxyBin: '/some/cli.js',
+        claudeBin: '/Users/me/.local/bin/claude',
+        cwd: '/Users/me',
+        _servicePath: join(serviceDir, 'com.chroxy.server.plist'),
+        _logDir: logDir,
+        _stateDir: stateDir,
+        _skipRegister: true,
+        _platform: 'darwin',
+      })
+
+      const wrapperPath = join(stateDir, 'service-wrapper.sh')
+      assert.ok(existsSync(wrapperPath), 'wrapper should be written')
+      const mode = statSync(wrapperPath).mode & 0o777
+      assert.equal(mode, 0o700)
+      const wrapper = readFileSync(wrapperPath, 'utf-8')
+      assert.ok(wrapper.includes('/usr/bin/security find-generic-password'))
+
+      // Plist execs the wrapper and bakes claude into PATH
+      const plist = readFileSync(join(serviceDir, 'com.chroxy.server.plist'), 'utf-8')
+      assert.ok(plist.includes(wrapperPath))
+      assert.ok(plist.includes('/Users/me/.local/bin'))
+
+      // State records claudeBin + wrapperPath
+      const state = loadServiceState(stateDir)
+      assert.equal(state.claudeBin, '/Users/me/.local/bin/claude')
+      assert.equal(state.wrapperPath, wrapperPath)
+    })
+  })
+
+  describe('uninstallService() removes the wrapper (#5491)', () => {
+    it('deletes the wrapper script', () => {
+      const serviceDir = join(tmpDir, 'LaunchAgents')
+      mkdirSync(serviceDir, { recursive: true })
+      const servicePath = join(serviceDir, 'com.chroxy.server.plist')
+      writeFileSync(servicePath, '<plist>test</plist>')
+      const stateDir = join(tmpDir, 'state')
+      const wrapperPath = join(stateDir, 'service-wrapper.sh')
+      writeServiceWrapper(wrapperPath, '#!/bin/sh\n')
+      saveServiceState({
+        installedAt: new Date().toISOString(),
+        platform: 'darwin',
+        servicePath,
+        wrapperPath,
+        nodePath: '/n/node',
+        chroxyBin: '/c/cli.js',
+      }, stateDir)
+
+      assert.ok(existsSync(wrapperPath))
+      uninstallService({ _stateDir: stateDir, _skipUnregister: true })
+      assert.ok(!existsSync(wrapperPath), 'wrapper should be removed')
+    })
+  })
+
+  describe('startService() bootout-then-bootstrap + EIO hint (#5491 gap 3)', () => {
+    it('boots out the stale label before bootstrapping', () => {
+      const serviceDir = join(tmpDir, 'LaunchAgents')
+      mkdirSync(serviceDir, { recursive: true })
+      const servicePath = join(serviceDir, 'com.chroxy.server.plist')
+      writeFileSync(servicePath, '<plist/>')
+      const stateDir = join(tmpDir, 'state')
+      saveServiceState({
+        installedAt: new Date().toISOString(),
+        platform: 'darwin',
+        servicePath,
+        nodePath: '/n/node',
+        chroxyBin: '/c/cli.js',
+      }, stateDir)
+
+      const calls = []
+      const exec = (cmd, args) => { calls.push([cmd, ...args]) }
+      const result = startService({ _platform: 'darwin', _stateDir: stateDir, _exec: exec })
+
+      assert.equal(result.started, true)
+      // bootout must precede bootstrap
+      const bootoutIdx = calls.findIndex(c => c.includes('bootout'))
+      const bootstrapIdx = calls.findIndex(c => c.includes('bootstrap'))
+      assert.ok(bootoutIdx >= 0, 'should call bootout')
+      assert.ok(bootstrapIdx >= 0, 'should call bootstrap')
+      assert.ok(bootoutIdx < bootstrapIdx, 'bootout must run before bootstrap')
+    })
+
+    it('ignores bootout failure (label not loaded) and still bootstraps', () => {
+      const serviceDir = join(tmpDir, 'LaunchAgents')
+      mkdirSync(serviceDir, { recursive: true })
+      const servicePath = join(serviceDir, 'com.chroxy.server.plist')
+      writeFileSync(servicePath, '<plist/>')
+      const stateDir = join(tmpDir, 'state')
+      saveServiceState({
+        installedAt: new Date().toISOString(),
+        platform: 'darwin',
+        servicePath,
+        nodePath: '/n/node',
+        chroxyBin: '/c/cli.js',
+      }, stateDir)
+
+      let bootstrapped = false
+      const exec = (cmd, args) => {
+        if (args.includes('bootout')) throw new Error('No such process')
+        if (args.includes('bootstrap')) bootstrapped = true
+      }
+      const result = startService({ _platform: 'darwin', _stateDir: stateDir, _exec: exec })
+      assert.equal(result.started, true)
+      assert.ok(bootstrapped, 'bootstrap should still run after a failed bootout')
+    })
+
+    it('translates Bootstrap failed: 5: Input/output error into an actionable hint', () => {
+      const serviceDir = join(tmpDir, 'LaunchAgents')
+      mkdirSync(serviceDir, { recursive: true })
+      const servicePath = join(serviceDir, 'com.chroxy.server.plist')
+      writeFileSync(servicePath, '<plist/>')
+      const stateDir = join(tmpDir, 'state')
+      saveServiceState({
+        installedAt: new Date().toISOString(),
+        platform: 'darwin',
+        servicePath,
+        nodePath: '/n/node',
+        chroxyBin: '/c/cli.js',
+      }, stateDir)
+
+      const exec = (cmd, args) => {
+        if (args.includes('bootout')) return
+        if (args.includes('bootstrap')) {
+          const err = new Error('Command failed')
+          err.stderr = 'Bootstrap failed: 5: Input/output error\n'
+          throw err
+        }
+      }
+      assert.throws(
+        () => startService({ _platform: 'darwin', _stateDir: stateDir, _exec: exec }),
+        (err) => {
+          assert.ok(/Input\/output error/.test(err.message), 'mentions the original error')
+          assert.ok(/bootout/.test(err.message), 'suggests bootout')
+          assert.ok(/chroxy service/i.test(err.message), 'suggests a chroxy command')
+          return true
+        }
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

`chroxy service install && chroxy service start` on macOS produced a crash-looping launchd job that never bound the port (hit live during the #5439 cutover). This fixes all three gaps documented in #5491.

### Gap 1 — bare launchd PATH fails preflight
The generated plist had no usable PATH, so the job ran with launchd's default (`/usr/bin:/bin:...`) and preflight failed with `claude: Not found`. Now:
- `resolveClaudeBin()` resolves `claude` from the **installer's** environment via `which` at install time, and **fails install with an actionable message** if it can't be resolved (rather than registering a job that crash-loops).
- `buildServicePath()` bakes the node + claude bin dirs ahead of the system dirs into the plist `EnvironmentVariables` PATH and the systemd `Environment=PATH` (Linux parity).

### Gap 2 — keychain token doesn't reach the daemon
`getToken()` fails in the launchd context even though `security find-generic-password` succeeds in a shell spawned by the same job. Mirroring the proven manual fix:
- `generateServiceWrapper()` + `writeServiceWrapper()` write a **0700 `~/.chroxy/service-wrapper.sh`** that the service execs. It resolves `API_TOKEN` via `/usr/bin/security find-generic-password -s chroxy -a api-token -w` at spawn time, exports it, and execs the server.
- Resolution is **graceful**: a failed/empty keychain read leaves the env var unset, so config-file / `--no-auth` setups still work. The token is **never written into the plist**.
- The wrapper also exports `CHROXY_DISCORD_WEBHOOK_URL` from keychain service `chroxy-discord-webhook` / account `webhook-url` — this matches the deployed workaround and relates to #5490. It's the same graceful pattern; kept since it keeps the wrapper a single secret-resolution seam.

### Gap 3 — opaque bootstrap error
First `service start` printed only `Bootstrap failed: 5: Input/output error` (stale label needed a `bootout` first). Now `startService` boots out the stale label **before** bootstrap (idempotent start), and translates the EIO failure into an actionable hint (suggesting `launchctl bootout` / reinstall).

The wrapper path + resolved `claudeBin` are recorded in service state and the wrapper is removed on `uninstall`.

## Testing

TDD — RED tests added first, then implementation. New coverage in `packages/server/tests/service.test.js`:
- `resolveClaudeBin`: returns `which` result; throws actionable error when absent / path missing.
- `buildServicePath`: includes node+claude dirs before system dirs; dedupes shared dir.
- plist/unit: baked claude PATH present; wrapper used in ProgramArguments / ExecStart.
- `generateServiceWrapper`: security invocation with correct service/account for both secrets; graceful guards (`2>/dev/null`, non-empty check); exports baked PATH and execs server; no token value embedded.
- `writeServiceWrapper`: file written **0700**, parent dir created.
- `installService`: writes 0700 wrapper with security invocation, plist execs it + bakes PATH, state records `claudeBin`/`wrapperPath`.
- `uninstallService`: removes the wrapper.
- `startService`: bootout precedes bootstrap; bootout failure ignored; EIO translated to actionable hint.

Targeted run (Node 22): **92 tests, 90 pass, 2 fail**. The 2 failures are pre-existing and environmental — they assert `health: null`, but a live chroxy daemon answering on `127.0.0.1:8765` on the dev host makes the status health-check fetch succeed. Verified identical 2 failures on clean `main` (67/69 pass there; this PR adds 23 passing tests).

## Note on this machine

This host currently runs a hand-rolled equivalent wrapper (the issue's "Workaround in place" section): `~/Library/LaunchAgents/com.chroxy.server.plist` execs `~/.chroxy/service-wrapper.sh`. A future `chroxy service install` re-run will now **correctly regenerate** that wrapper and plist hookup from first-class code, so the manual hookup is no longer lost on reinstall.

Closes #5491