### PR TITLE
feat(server): pairing-approval primitive — approve new devices from the dashboard

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -210,6 +210,12 @@ vi.mock('./store/connection', () => {
     fetchConversationHistory: vi.fn(),
     resumeConversation: vi.fn(),
     connectedClients: [],
+    // #5510 — pairing-approval primitive: host-level pending pair-request banner
+    // slice + actions. Mirror the real store defaults so App renders the
+    // (empty) PendingPairRequests banner without crashing on `.length`.
+    pendingPairRequests: [],
+    approvePairRequest: vi.fn(),
+    denyPairRequest: vi.fn(),
     serverRegistry: [],
     activeServerId: null,
     addServer: vi.fn(),

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -59,6 +59,7 @@ import { WelcomeScreen } from './components/WelcomeScreen'
 import { CreateSessionModal } from './components/CreateSessionModal'
 import { ConfirmDialog } from './components/ConfirmDialog'
 import { NotificationBanners } from './components/NotificationBanners'
+import { PendingPairRequests } from './components/PendingPairRequests'
 import { Toast, type ToastItem } from './components/Toast'
 import { FileBrowserPanel } from './components/FileBrowserPanel'
 import { CheckpointTimeline } from './components/CheckpointTimeline'
@@ -307,6 +308,10 @@ export function App() {
   const connectionRetryCount = useConnectionStore(s => s.connectionRetryCount)
   const filePickerFiles = useConnectionStore(s => s.filePickerFiles)
   const sessionNotifications = useConnectionStore(s => s.sessionNotifications)
+  // #5510 (epic #5509): pairing-approval primitive — host-surface pending queue.
+  const pendingPairRequests = useConnectionStore(s => s.pendingPairRequests)
+  const approvePairRequest = useConnectionStore(s => s.approvePairRequest)
+  const denyPairRequest = useConnectionStore(s => s.denyPairRequest)
   const inputSettings = useConnectionStore(s => s.inputSettings)
   const connectedClients = useConnectionStore(s => s.connectedClients)
   // #5281 ①.3 — global primary (last-driver) fallback for the pre-session /
@@ -2470,6 +2475,14 @@ export function App() {
             className="main-content"
           />
         )}
+
+        {/* #5510 (epic #5509): pairing-approval primitive — host-level
+            approve/deny banner for camera-less device pair requests. */}
+        <PendingPairRequests
+          requests={pendingPairRequests}
+          onApprove={approvePairRequest}
+          onDeny={denyPairRequest}
+        />
 
         {/* Cross-session notification banners */}
         {sessionNotifications.length > 0 && (

--- a/packages/dashboard/src/components/PendingPairRequests.test.tsx
+++ b/packages/dashboard/src/components/PendingPairRequests.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * PendingPairRequests — host-level pairing-approval surface (#5510, epic #5509).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { PendingPairRequests } from './PendingPairRequests'
+import type { ServerPairPendingMessage } from '@chroxy/protocol'
+
+afterEach(cleanup)
+
+function req(over: Partial<ServerPairPendingMessage> = {}): ServerPairPendingMessage {
+  return {
+    type: 'pair_pending',
+    requestId: 'r1',
+    deviceName: 'Pixel 8',
+    verifyCode: '123456',
+    expiresAt: Date.now() + 120_000,
+    ...over,
+  }
+}
+
+describe('PendingPairRequests (#5510)', () => {
+  it('renders nothing when there are no requests', () => {
+    const { container } = render(
+      <PendingPairRequests requests={[]} onApprove={vi.fn()} onDeny={vi.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the device name and verify code', () => {
+    render(<PendingPairRequests requests={[req()]} onApprove={vi.fn()} onDeny={vi.fn()} />)
+    expect(screen.getByTestId('pair-request-device').textContent).toBe('Pixel 8')
+    expect(screen.getByTestId('pair-request-code').textContent).toBe('123456')
+  })
+
+  it('renders attacker-controlled deviceName as plain text (no HTML injection)', () => {
+    render(
+      <PendingPairRequests
+        requests={[req({ deviceName: '<img src=x onerror=alert(1)>' })]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    )
+    const el = screen.getByTestId('pair-request-device')
+    // React escapes — the text content is the literal string, no <img> element.
+    expect(el.textContent).toBe('<img src=x onerror=alert(1)>')
+    expect(el.querySelector('img')).toBeNull()
+  })
+
+  it('fires onApprove / onDeny with the requestId', () => {
+    const onApprove = vi.fn()
+    const onDeny = vi.fn()
+    render(<PendingPairRequests requests={[req()]} onApprove={onApprove} onDeny={onDeny} />)
+    fireEvent.click(screen.getByTestId('pair-request-approve'))
+    expect(onApprove).toHaveBeenCalledWith('r1')
+    fireEvent.click(screen.getByTestId('pair-request-deny'))
+    expect(onDeny).toHaveBeenCalledWith('r1')
+  })
+
+  it('stacks multiple requests', () => {
+    render(
+      <PendingPairRequests
+        requests={[req({ requestId: 'a' }), req({ requestId: 'b' })]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('pair-request-a')).toBeTruthy()
+    expect(screen.getByTestId('pair-request-b')).toBeTruthy()
+  })
+})

--- a/packages/dashboard/src/components/PendingPairRequests.tsx
+++ b/packages/dashboard/src/components/PendingPairRequests.tsx
@@ -1,0 +1,77 @@
+/**
+ * PendingPairRequests — host-level approval surface for the pairing-approval
+ * primitive (#5510, epic #5509).
+ *
+ * A camera-less device requests pairing without a QR; the daemon fans the
+ * request out to host surfaces as `pair_pending`. This banner shows the
+ * requesting device's name and the 6-digit verify code to COMPARE against the
+ * code shown on the new device, with Approve / Deny actions. Approving sends
+ * `pair_approve` (the server issues a session token to the requester); denying
+ * sends `pair_deny`.
+ *
+ * Security: `deviceName` is attacker-controlled and rendered as plain text
+ * (React escapes — no markdown/HTML interpolation). The verify code travels
+ * ONLY server→surface; the operator confirms it out-of-band by eyeballing both
+ * screens. Mirrors the NotificationBanners stacked-banner pattern.
+ */
+import type { ServerPairPendingMessage } from '@chroxy/protocol'
+
+export interface PendingPairRequestsProps {
+  requests: ServerPairPendingMessage[]
+  onApprove: (requestId: string) => void
+  onDeny: (requestId: string) => void
+}
+
+export function PendingPairRequests({ requests, onApprove, onDeny }: PendingPairRequestsProps) {
+  if (requests.length === 0) return null
+
+  return (
+    <div
+      className="pair-requests"
+      data-testid="pair-requests"
+      role="alertdialog"
+      aria-label="Pending device pairing requests"
+    >
+      {requests.map((r) => (
+        <div
+          key={r.requestId}
+          className="pair-request-banner"
+          data-testid={`pair-request-${r.requestId}`}
+        >
+          <div className="pair-request-content">
+            <span className="pair-request-title">Pairing request</span>
+            <span className="pair-request-device" data-testid="pair-request-device">
+              {r.deviceName || 'Unknown device'}
+            </span>
+            <span className="pair-request-compare">
+              Compare this code with the new device:
+            </span>
+            <span className="pair-request-code" data-testid="pair-request-code">
+              {r.verifyCode}
+            </span>
+          </div>
+          <div className="pair-request-actions">
+            <button
+              type="button"
+              className="pair-request-btn pair-request-btn--approve"
+              data-testid="pair-request-approve"
+              aria-label={`Approve pairing for ${r.deviceName || 'unknown device'}`}
+              onClick={() => onApprove(r.requestId)}
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className="pair-request-btn pair-request-btn--deny"
+              data-testid="pair-request-deny"
+              aria-label={`Deny pairing for ${r.deviceName || 'unknown device'}`}
+              onClick={() => onDeny(r.requestId)}
+            >
+              Deny
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/PendingPairRequests.tsx
+++ b/packages/dashboard/src/components/PendingPairRequests.tsx
@@ -31,7 +31,9 @@ export function PendingPairRequests({ requests, onApprove, onDeny }: PendingPair
     <div
       className="pair-requests"
       data-testid="pair-requests"
-      role="alertdialog"
+      // role="log" (not "alertdialog") — this is a non-modal stacked banner
+      // with no focus management/containment, matching NotificationBanners.
+      role="log"
       aria-label="Pending device pairing requests"
     >
       {requests.map((r) => (

--- a/packages/dashboard/src/components/PendingPairRequests.tsx
+++ b/packages/dashboard/src/components/PendingPairRequests.tsx
@@ -23,7 +23,9 @@ export interface PendingPairRequestsProps {
 }
 
 export function PendingPairRequests({ requests, onApprove, onDeny }: PendingPairRequestsProps) {
-  if (requests.length === 0) return null
+  // Defensive: a missing/undefined store slice must not white-screen the whole
+  // dashboard — render nothing rather than throw on `.length`/`.map`.
+  if (!requests || requests.length === 0) return null
 
   return (
     <div

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -4,12 +4,13 @@
  * Shows a list of registered servers with connection status indicators.
  * Provides add/remove/switch actions and an inline "Add Server" form.
  */
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { ServerEntry, ConnectionPhase } from '../store/types'
 import { isTauri } from '../utils/tauri'
 import { discoverLanServers, type DiscoveredServer } from '../utils/discovery'
 import { parsePairingUrl } from '../utils/pairing'
+import { requestPairing, type PairRequestState, type PairRequestHandle } from '../utils/request-pairing'
 
 function statusDot(phase: ConnectionPhase, isActive: boolean): string {
   if (!isActive) return 'server-dot disconnected'
@@ -58,9 +59,11 @@ interface AddServerFormProps {
   initialUrl?: string
   /** Pair via a pasted chroxy://…?pair= URL — no token typed (#5281 ③ PR 2). */
   onPair: (name: string, wsUrl: string, pairingId: string) => void
+  /** #5510 — request approval-gated pairing for a known wss:// URL (no token). */
+  onRequestPair: (name: string, wsUrl: string) => void
 }
 
-function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = '', onPair }: AddServerFormProps) {
+function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = '', onPair, onRequestPair }: AddServerFormProps) {
   const [name, setName] = useState(initialName)
   const [url, setUrl] = useState(initialUrl)
   const [token, setToken] = useState('')
@@ -140,6 +143,25 @@ function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = 
         >
           {pairingMode ? 'Pair' : 'Add'}
         </button>
+        {/* #5510 — when a plain ws(s):// URL is known but no token/pairing id is
+            present, offer approval-gated pairing: send a pair_request and wait
+            for the host to approve. */}
+        {!embeddedCreds && (() => {
+          const trimmed = url.trim()
+          const looksLikeWs = /^wss?:\/\//i.test(trimmed)
+          return (
+            <button
+              type="button"
+              className="server-btn"
+              disabled={!looksLikeWs}
+              onClick={() => onRequestPair(name.trim() || trimmed, trimmed)}
+              data-testid="server-request-pair"
+              title="Request approval-gated pairing from the host (no token needed)"
+            >
+              Request to pair
+            </button>
+          )
+        })()}
         <button
           type="button"
           className="server-btn"
@@ -150,6 +172,94 @@ function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = 
         </button>
       </div>
     </form>
+  )
+}
+
+interface RequestPairPanelProps {
+  /** Normalized ws(s):// URL of the daemon to request pairing from. */
+  wsUrl: string
+  /** Display name to store on the registry entry once approved. */
+  name: string
+  /** Token in hand → store the server + connect (mirrors the ?pair= flow). */
+  onApproved: (name: string, wsUrl: string, token: string) => void
+  onCancel: () => void
+}
+
+/**
+ * RequestPairPanel — the requester side of the pairing-approval primitive
+ * (#5510, epic #5509). Opens a short-lived pre-auth WS to the daemon, sends
+ * `pair_request`, shows the 6-digit verify code to compare with the host
+ * surface, and waits for `pair_result`. On approval it hands the issued token up
+ * so the server is added + connected exactly like the `chroxy://?pair=` flow.
+ */
+function RequestPairPanel({ wsUrl, name, onApproved, onCancel }: RequestPairPanelProps) {
+  const [state, setState] = useState<PairRequestState>({
+    phase: 'requesting', verifyCode: null, token: null, reason: null,
+  })
+  const handleRef = useRef<PairRequestHandle | null>(null)
+  // Latch onApproved so the effect can run exactly once without re-subscribing.
+  const onApprovedRef = useRef(onApproved)
+  onApprovedRef.current = onApproved
+
+  useEffect(() => {
+    const handle = requestPairing(wsUrl, name || 'Desktop Browser', (s) => {
+      setState(s)
+      if (s.phase === 'approved' && s.token) {
+        onApprovedRef.current(name, wsUrl, s.token)
+      }
+    })
+    handleRef.current = handle
+    return () => handle.cancel()
+  }, [wsUrl, name])
+
+  const host = wsUrl.replace(/^wss?:\/\//, '').replace(/\/ws$/, '')
+
+  return (
+    <div className="server-pair-request" data-testid="request-pair-panel">
+      <div className="server-pair-request-host">{host}</div>
+      {(state.phase === 'requesting' || state.phase === 'code-shown') && (
+        <>
+          <div className="server-pair-request-status" data-testid="request-pair-status">
+            {state.phase === 'requesting'
+              ? 'Requesting pairing…'
+              : 'Waiting for approval on the host'}
+          </div>
+          {state.verifyCode && (
+            <>
+              <div className="server-pair-request-compare">
+                Compare this code with the host:
+              </div>
+              <div className="server-pair-request-code" data-testid="request-pair-code">
+                {state.verifyCode}
+              </div>
+            </>
+          )}
+        </>
+      )}
+      {state.phase === 'denied' && (
+        <div className="server-pair-request-status server-pair-request-status--error" data-testid="request-pair-denied">
+          Pairing denied by the host.
+        </div>
+      )}
+      {state.phase === 'expired' && (
+        <div className="server-pair-request-status server-pair-request-status--error" data-testid="request-pair-expired">
+          Request expired. Try again.
+        </div>
+      )}
+      {state.phase === 'error' && (
+        <div className="server-pair-request-status server-pair-request-status--error" data-testid="request-pair-error">
+          Could not pair{state.reason ? ` (${state.reason})` : ''}.
+        </div>
+      )}
+      <button
+        type="button"
+        className="server-btn"
+        onClick={onCancel}
+        data-testid="request-pair-cancel"
+      >
+        {state.phase === 'approved' ? 'Done' : 'Cancel'}
+      </button>
+    </div>
   )
 }
 
@@ -231,6 +341,8 @@ export function ServerPicker() {
 
   const [showAddForm, setShowAddForm] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
+  // #5510 — active "Request to pair" round-trip (requester surface).
+  const [pairRequest, setPairRequest] = useState<{ name: string; wsUrl: string } | null>(null)
   // #5281 ③ — pre-fill the add form from a LAN-discovered daemon.
   const [prefill, setPrefill] = useState<{ name: string; url: string } | null>(null)
   // #5281 ③ — LAN discovery (desktop/Tauri only).
@@ -264,6 +376,24 @@ export function ServerPicker() {
       setAddError(err instanceof Error ? err.message : 'Failed to pair')
     }
   }, [pairServer])
+
+  // #5510 — open the requester panel for a known wss:// URL.
+  const handleRequestPair = useCallback((name: string, wsUrl: string) => {
+    setAddError(null)
+    setShowAddForm(false)
+    setPrefill(null)
+    setPairRequest({ name, wsUrl })
+  }, [])
+
+  // #5510 — pair_result approved with a token: store + connect like ?pair=.
+  const handlePairApproved = useCallback((name: string, wsUrl: string, token: string) => {
+    try {
+      const entry = addServer(name, wsUrl, token)
+      switchServer(entry.id)
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : 'Failed to add paired server')
+    }
+  }, [addServer, switchServer])
 
   const runDiscovery = useCallback(async () => {
     setDiscovering(true)
@@ -310,10 +440,21 @@ export function ServerPicker() {
           key={prefill?.url ?? 'blank'}
           onAdd={handleAdd}
           onPair={handlePair}
+          onRequestPair={handleRequestPair}
           onCancel={() => { setShowAddForm(false); setAddError(null); setPrefill(null) }}
           error={addError}
           initialName={prefill?.name ?? ''}
           initialUrl={prefill?.url ?? ''}
+        />
+      )}
+
+      {pairRequest && (
+        <RequestPairPanel
+          key={pairRequest.wsUrl}
+          wsUrl={pairRequest.wsUrl}
+          name={pairRequest.name}
+          onApproved={handlePairApproved}
+          onCancel={() => setPairRequest(null)}
         />
       )}
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -389,6 +389,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // reducer from activity_snapshot / activity_delta.
   activity: createEmptyActivityState(),
   cancellingActivityIds: new Set<string>(),
+  // #5510 (epic #5509): pairing-approval primitive — outstanding pending pair
+  // requests fanned out to this host surface. Empty until a pair_pending lands.
+  pendingPairRequests: [],
   // #5175 (epic #5170): Host/Repo Status Control Room snapshot, fed by the
   // host_status_snapshot handler. Null until the first survey lands.
   hostStatus: null,
@@ -685,6 +688,30 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       return true;
     }
     return false;
+  },
+
+  // #5510 (epic #5509): approve a pending pair request. Sends `pair_approve`
+  // and optimistically drops the request from the local queue (the server also
+  // retracts it via `pair_resolved` to every host surface). Returns false when
+  // the socket is closed (the banner stays so the operator can retry once
+  // reconnected). The verify code is never sent — the operator already compared
+  // it out-of-band; only `requestId` travels.
+  approvePairRequest: (requestId: string): boolean => {
+    const { socket } = get();
+    if (!requestId || !socket || socket.readyState !== WebSocket.OPEN) return false;
+    wsSend(socket, { type: 'pair_approve', requestId });
+    set((s) => ({ pendingPairRequests: s.pendingPairRequests.filter((p) => p.requestId !== requestId) }));
+    return true;
+  },
+
+  // #5510: deny a pending pair request. Same optimistic-drop + wire-result
+  // contract as approvePairRequest.
+  denyPairRequest: (requestId: string): boolean => {
+    const { socket } = get();
+    if (!requestId || !socket || socket.readyState !== WebSocket.OPEN) return false;
+    wsSend(socket, { type: 'pair_deny', requestId });
+    set((s) => ({ pendingPairRequests: s.pendingPairRequests.filter((p) => p.requestId !== requestId) }));
+    return true;
   },
 
   // #5253: request a self-hosted runner survey. Mirrors requestHostStatus —

--- a/packages/dashboard/src/store/dispatch-pair-pending.test.ts
+++ b/packages/dashboard/src/store/dispatch-pair-pending.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pairing-approval primitive dispatch (#5510, epic #5509).
+ *
+ * Guards the wire path between the dashboard message handler and the store for
+ * the host approval surface:
+ *   - `pair_pending` APPENDS to `pendingPairRequests` (deduped by requestId).
+ *   - `pair_resolved` REMOVES the matching request.
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function pending(requestId: string, deviceName = 'Pixel', verifyCode = '123456') {
+  return { type: 'pair_pending', requestId, deviceName, verifyCode, expiresAt: Date.now() + 120_000 }
+}
+
+describe('pairing-approval dispatch (#5510)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore({ connectionPhase: 'connected', pendingPairRequests: [] })
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('appends a pair_pending request', () => {
+    handleMessage(pending('r1', 'iPhone', '000111') as never, ctx() as never)
+    const s = store.getState()
+    expect(s.pendingPairRequests).toHaveLength(1)
+    expect(s.pendingPairRequests[0].requestId).toBe('r1')
+    expect(s.pendingPairRequests[0].deviceName).toBe('iPhone')
+    expect(s.pendingPairRequests[0].verifyCode).toBe('000111')
+  })
+
+  it('dedupes by requestId on a replay', () => {
+    handleMessage(pending('r1') as never, ctx() as never)
+    handleMessage(pending('r1') as never, ctx() as never)
+    expect(store.getState().pendingPairRequests).toHaveLength(1)
+  })
+
+  it('keeps multiple distinct requests', () => {
+    handleMessage(pending('r1') as never, ctx() as never)
+    handleMessage(pending('r2') as never, ctx() as never)
+    expect(store.getState().pendingPairRequests.map((p) => p.requestId)).toEqual(['r1', 'r2'])
+  })
+
+  it('removes a request on pair_resolved', () => {
+    handleMessage(pending('r1') as never, ctx() as never)
+    handleMessage(pending('r2') as never, ctx() as never)
+    handleMessage({ type: 'pair_resolved', requestId: 'r1', reason: 'approved' } as never, ctx() as never)
+    expect(store.getState().pendingPairRequests.map((p) => p.requestId)).toEqual(['r2'])
+  })
+
+  it('drops a malformed pair_pending without mutating state', () => {
+    handleMessage(pending('r1') as never, ctx() as never)
+    // Missing verifyCode → schema reject.
+    handleMessage({ type: 'pair_pending', requestId: 'bad', deviceName: 'x', expiresAt: 1 } as never, ctx() as never)
+    expect(store.getState().pendingPairRequests.map((p) => p.requestId)).toEqual(['r1'])
+  })
+})

--- a/packages/dashboard/src/store/dispatch-pair-pending.test.ts
+++ b/packages/dashboard/src/store/dispatch-pair-pending.test.ts
@@ -86,9 +86,11 @@ describe('pairing-approval dispatch (#5510)', () => {
     handleMessage(pending('r1', 'iPhone', '000111') as never, ctx() as never)
     const s = store.getState()
     expect(s.pendingPairRequests).toHaveLength(1)
-    expect(s.pendingPairRequests[0].requestId).toBe('r1')
-    expect(s.pendingPairRequests[0].deviceName).toBe('iPhone')
-    expect(s.pendingPairRequests[0].verifyCode).toBe('000111')
+    const first = s.pendingPairRequests[0]
+    if (!first) throw new Error('expected one pending pair request')
+    expect(first.requestId).toBe('r1')
+    expect(first.deviceName).toBe('iPhone')
+    expect(first.verifyCode).toBe('000111')
   })
 
   it('dedupes by requestId on a replay', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -133,7 +133,7 @@ import {
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerIntegrationActionAckSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerPairPendingSchema, ServerPairResolvedSchema } from '@chroxy/protocol/schemas'
 import {
   createKeyPair,
   deriveSharedKey,
@@ -2062,6 +2062,35 @@ function handleHostStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, se
 }
 
 /**
+ * #5510 (epic #5509) — a new device requested pairing; the daemon fanned the
+ * request out to this host surface. Append it to `pendingPairRequests` (deduped
+ * by requestId so a replay/reconnect can't double-stack the banner). Validated
+ * with the protocol Zod schema; a malformed payload is dropped rather than
+ * crashing the renderer. `deviceName` is attacker-controlled — stored as-is and
+ * rendered as plain text (React escapes on render).
+ */
+function handlePairPending(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerPairPendingSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const existing = get().pendingPairRequests;
+  const next = existing.filter((p) => p.requestId !== parsed.data.requestId);
+  next.push(parsed.data);
+  set({ pendingPairRequests: next });
+}
+
+/**
+ * #5510 — a pending pair request was resolved (approved/denied elsewhere, or it
+ * expired). Drop it from the banner queue. The carried `reason` is informational
+ * only; the surface simply retracts the entry.
+ */
+function handlePairResolved(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerPairResolvedSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const next = get().pendingPairRequests.filter((p) => p.requestId !== parsed.data.requestId);
+  set({ pendingPairRequests: next });
+}
+
+/**
  * #5253 — self-hosted runner survey `runner_status_snapshot`: REPLACE the
  * stored runner survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host survey
@@ -2206,6 +2235,9 @@ const HANDLERS: Record<string, Handler> = {
   activity_delta: handleActivityDelta,
   // #5277: positive ack correlating a cancel_activity request to its outcome.
   cancel_activity_ack: handleCancelActivityAck,
+  // #5510 (epic #5509): pairing-approval primitive — host-surface fan-out.
+  pair_pending: handlePairPending,
+  pair_resolved: handlePairResolved,
   // #5175 (epic #5170): Host/Repo Status Control Room survey snapshot.
   host_status_snapshot: handleHostStatusSnapshot,
   // #5253: self-hosted runner Control Room survey snapshot.

--- a/packages/dashboard/src/store/pair-approve-actions.test.ts
+++ b/packages/dashboard/src/store/pair-approve-actions.test.ts
@@ -1,0 +1,77 @@
+/**
+ * approvePairRequest / denyPairRequest store actions (#5510, epic #5509).
+ *
+ * Each sends only `{ type, requestId }` (the verify code never leaves the host
+ * — the operator compared it out-of-band) and optimistically drops the request
+ * from `pendingPairRequests`. Returns false (no wire write) when the socket is
+ * closed.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+interface Sent { type: string; requestId?: string; [k: string]: unknown }
+
+function seedState(useConnectionStore: typeof import('./connection').useConnectionStore, readyState = WebSocket.OPEN) {
+  const sent: Sent[] = []
+  const socket = {
+    send: vi.fn((raw: string) => { try { sent.push(JSON.parse(raw)) } catch { /* noop */ } }),
+    close: vi.fn(),
+    readyState,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+  useConnectionStore.setState({
+    socket,
+    pendingPairRequests: [
+      { type: 'pair_pending', requestId: 'r1', deviceName: 'A', verifyCode: '111111', expiresAt: Date.now() + 1000 },
+      { type: 'pair_pending', requestId: 'r2', deviceName: 'B', verifyCode: '222222', expiresAt: Date.now() + 1000 },
+    ],
+  })
+  return sent
+}
+
+describe('approvePairRequest / denyPairRequest (#5510)', () => {
+  beforeEach(() => { vi.resetModules() })
+
+  it('approve sends pair_approve with only the requestId and drops it locally', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent = seedState(useConnectionStore)
+    expect(useConnectionStore.getState().approvePairRequest('r1')).toBe(true)
+    expect(sent).toEqual([{ type: 'pair_approve', requestId: 'r1' }])
+    expect(useConnectionStore.getState().pendingPairRequests.map((p) => p.requestId)).toEqual(['r2'])
+  })
+
+  it('deny sends pair_deny with only the requestId and drops it locally', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent = seedState(useConnectionStore)
+    expect(useConnectionStore.getState().denyPairRequest('r2')).toBe(true)
+    expect(sent).toEqual([{ type: 'pair_deny', requestId: 'r2' }])
+    expect(useConnectionStore.getState().pendingPairRequests.map((p) => p.requestId)).toEqual(['r1'])
+  })
+
+  it('returns false and writes nothing when the socket is closed', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent = seedState(useConnectionStore, WebSocket.CLOSED)
+    expect(useConnectionStore.getState().approvePairRequest('r1')).toBe(false)
+    expect(useConnectionStore.getState().denyPairRequest('r1')).toBe(false)
+    expect(sent).toHaveLength(0)
+    expect(useConnectionStore.getState().pendingPairRequests).toHaveLength(2)
+  })
+
+  it('never includes the verify code on the wire', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent = seedState(useConnectionStore)
+    useConnectionStore.getState().approvePairRequest('r1')
+    expect(JSON.stringify(sent)).not.toContain('111111')
+  })
+})

--- a/packages/dashboard/src/store/pair-approve-actions.test.ts
+++ b/packages/dashboard/src/store/pair-approve-actions.test.ts
@@ -21,7 +21,7 @@ vi.mock('./crypto', () => ({
 
 interface Sent { type: string; requestId?: string; [k: string]: unknown }
 
-function seedState(useConnectionStore: typeof import('./connection').useConnectionStore, readyState = WebSocket.OPEN) {
+function seedState(useConnectionStore: typeof import('./connection').useConnectionStore, readyState: number = WebSocket.OPEN) {
   const sent: Sent[] = []
   const socket = {
     send: vi.fn((raw: string) => { try { sent.push(JSON.parse(raw)) } catch { /* noop */ } }),

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, IntegrationActionCounts } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -584,6 +584,17 @@ export interface ConnectionState {
    * empty/loading state). Replaced wholesale on each snapshot — the survey is a
    * full picture, not a delta stream.
    */
+  /**
+   * #5510 (epic #5509) — pairing-approval primitive: outstanding pending
+   * pair requests fanned out to this host-level surface via `pair_pending`.
+   * Each entry carries the requesting device's name, the 6-digit verify code to
+   * compare against the new device's screen, and its expiry. Entries are added
+   * on `pair_pending`, removed on `pair_resolved` (approved/denied/expired
+   * elsewhere) or after the local Approve/Deny action. `deviceName` is
+   * attacker-controlled and rendered as plain text (React escapes).
+   */
+  pendingPairRequests: ServerPairPendingMessage[];
+
   hostStatus: ServerHostStatusSnapshotMessage | null;
   /**
    * #5175 — true between dispatching a `host_status_request` and the matching
@@ -1118,6 +1129,15 @@ export interface ConnectionState {
   // button surfaces a "not connected" state). Sets `hostStatusLoading` while in
   // flight so the button can show a spinner.
   requestHostStatus: () => boolean;
+
+  // #5510 (epic #5509): approve a pending pair request, sending `pair_approve`.
+  // Optimistically drops the request from `pendingPairRequests` (the server also
+  // retracts it via `pair_resolved`). Returns whether the message went on the
+  // wire (false = socket closed).
+  approvePairRequest: (requestId: string) => boolean;
+  // #5510: deny a pending pair request, sending `pair_deny`. Same optimistic
+  // drop + wire-result contract as approvePairRequest.
+  denyPairRequest: (requestId: string) => boolean;
 
   // #5253: request a self-hosted runner survey. Dispatches a
   // `runner_status_request`; the server replies with a single

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3560,6 +3560,94 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.85;
 }
 
+/* #5510 (epic #5509): pairing-approval primitive — host approval banner. */
+.pair-requests {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.pair-request-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  font-size: var(--text-sm);
+  background: #0e1f2a;
+  border-left: 3px solid var(--accent-blue);
+  gap: 12px;
+}
+
+.pair-request-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.pair-request-title {
+  font-weight: 600;
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.pair-request-device {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pair-request-compare {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  flex-shrink: 0;
+}
+
+.pair-request-code {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  letter-spacing: 3px;
+  color: var(--accent-blue);
+  flex-shrink: 0;
+}
+
+.pair-request-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.pair-request-btn {
+  border: none;
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pair-request-btn--approve {
+  background: var(--accent-green, #3a3);
+  color: #fff;
+}
+
+.pair-request-btn--deny {
+  background: var(--accent-red, #c44);
+  color: #fff;
+}
+
+.pair-request-btn:hover {
+  opacity: 0.85;
+}
+
 .notification-banner-overflow {
   text-align: center;
   font-size: var(--text-xs);
@@ -7623,6 +7711,44 @@ button.sidebar-token-view-session-row:hover {
   display: flex;
   gap: 6px;
   justify-content: flex-end;
+}
+
+/* #5510 (epic #5509): pairing-approval primitive — requester panel. */
+.server-pair-request {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
+  border-left: 3px solid var(--accent-blue);
+  border-radius: 4px;
+}
+
+.server-pair-request-host {
+  font-weight: 600;
+  font-size: var(--text-sm);
+}
+
+.server-pair-request-status {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.server-pair-request-status--error {
+  color: var(--accent-red, #e55);
+}
+
+.server-pair-request-compare {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.server-pair-request-code {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  letter-spacing: 3px;
+  color: var(--accent-blue);
 }
 
 /* ---- Console Page ---- */

--- a/packages/dashboard/src/utils/request-pairing.test.ts
+++ b/packages/dashboard/src/utils/request-pairing.test.ts
@@ -39,21 +39,33 @@ describe('requestPairing (#5510)', () => {
   })
   afterEach(() => { vi.unstubAllGlobals() })
 
-  function run(deviceName = 'Desktop') {
+  function run(deviceName = 'Desktop'): FakeWebSocket {
     requestPairing('wss://host/ws', deviceName, (s) => states.push(s))
-    return FakeWebSocket.instances[0]
+    const ws = FakeWebSocket.instances[0]
+    if (!ws) throw new Error('requestPairing did not open a WebSocket')
+    return ws
+  }
+
+  // Last emitted state — asserts the harness actually pushed one (narrows the
+  // `noUncheckedIndexedAccess` `T | undefined` away for the call sites).
+  function lastState(): PairRequestState {
+    const s = states[states.length - 1]
+    if (!s) throw new Error('no PairRequestState was emitted')
+    return s
   }
 
   it('sends pair_request on open and surfaces the verify code', () => {
     const ws = run('Pixel 8')
     ws.open()
-    const sent = JSON.parse(ws.sent[0])
+    const firstSent = ws.sent[0]
+    if (!firstSent) throw new Error('no frame was sent')
+    const sent = JSON.parse(firstSent)
     expect(sent.type).toBe('pair_request')
     expect(sent.requestId).toBe('fixed-req-id')
     expect(sent.deviceName).toBe('Pixel 8')
 
     ws.recv({ type: 'pair_request_pending', requestId: 'fixed-req-id', verifyCode: '424242' })
-    const last = states[states.length - 1]
+    const last = lastState()
     expect(last.phase).toBe('code-shown')
     expect(last.verifyCode).toBe('424242')
   })
@@ -63,7 +75,7 @@ describe('requestPairing (#5510)', () => {
     ws.open()
     ws.recv({ type: 'pair_request_pending', requestId: 'fixed-req-id', verifyCode: '000000' })
     ws.recv({ type: 'pair_result', requestId: 'fixed-req-id', ok: true, token: 'sess-tok-xyz' })
-    const last = states[states.length - 1]
+    const last = lastState()
     expect(last.phase).toBe('approved')
     expect(last.token).toBe('sess-tok-xyz')
     expect(ws.readyState).toBe(3) // closed after terminal state
@@ -73,21 +85,21 @@ describe('requestPairing (#5510)', () => {
     const ws = run()
     ws.open()
     ws.recv({ type: 'pair_result', requestId: 'fixed-req-id', ok: false, reason: 'denied' })
-    expect(states[states.length - 1].phase).toBe('denied')
+    expect(lastState().phase).toBe('denied')
   })
 
   it('maps an expired result to the expired phase', () => {
     const ws = run()
     ws.open()
     ws.recv({ type: 'pair_result', requestId: 'fixed-req-id', ok: false, reason: 'expired' })
-    expect(states[states.length - 1].phase).toBe('expired')
+    expect(lastState().phase).toBe('expired')
   })
 
   it('ignores frames addressed to a different requestId', () => {
     const ws = run()
     ws.open()
     ws.recv({ type: 'pair_request_pending', requestId: 'someone-else', verifyCode: '999999' })
-    expect(states[states.length - 1].verifyCode).toBeNull()
+    expect(lastState().verifyCode).toBeNull()
   })
 
   it('never echoes the verify code back to the server', () => {
@@ -103,6 +115,6 @@ describe('requestPairing (#5510)', () => {
     const ws = run()
     ws.open()
     ws.onclose?.()
-    expect(states[states.length - 1].phase).toBe('error')
+    expect(lastState().phase).toBe('error')
   })
 })

--- a/packages/dashboard/src/utils/request-pairing.test.ts
+++ b/packages/dashboard/src/utils/request-pairing.test.ts
@@ -1,0 +1,108 @@
+/**
+ * request-pairing — requester side of the pairing-approval primitive (#5510).
+ *
+ * Drives a fake WebSocket through the round-trip and asserts the phase
+ * transitions: requesting → code-shown → approved/denied/expired/error. The
+ * verify code is only ever DISPLAYED (received on pair_request_pending), never
+ * sent back, so a mismatch is impossible by construction.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { requestPairing, type PairRequestState } from './request-pairing'
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  url: string
+  readyState = 0
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  send(data: string) { this.sent.push(data) }
+  close() { this.readyState = 3 }
+  // test helpers
+  open() { this.readyState = 1; this.onopen?.() }
+  recv(obj: unknown) { this.onmessage?.({ data: JSON.stringify(obj) }) }
+}
+
+describe('requestPairing (#5510)', () => {
+  let states: PairRequestState[]
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    states = []
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal('crypto', { randomUUID: () => 'fixed-req-id' })
+  })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  function run(deviceName = 'Desktop') {
+    requestPairing('wss://host/ws', deviceName, (s) => states.push(s))
+    return FakeWebSocket.instances[0]
+  }
+
+  it('sends pair_request on open and surfaces the verify code', () => {
+    const ws = run('Pixel 8')
+    ws.open()
+    const sent = JSON.parse(ws.sent[0])
+    expect(sent.type).toBe('pair_request')
+    expect(sent.requestId).toBe('fixed-req-id')
+    expect(sent.deviceName).toBe('Pixel 8')
+
+    ws.recv({ type: 'pair_request_pending', requestId: 'fixed-req-id', verifyCode: '424242' })
+    const last = states[states.length - 1]
+    expect(last.phase).toBe('code-shown')
+    expect(last.verifyCode).toBe('424242')
+  })
+
+  it('reaches approved with the token on a successful pair_result', () => {
+    const ws = run()
+    ws.open()
+    ws.recv({ type: 'pair_request_pending', requestId: 'fixed-req-id', verifyCode: '000000' })
+    ws.recv({ type: 'pair_result', requestId: 'fixed-req-id', ok: true, token: 'sess-tok-xyz' })
+    const last = states[states.length - 1]
+    expect(last.phase).toBe('approved')
+    expect(last.token).toBe('sess-tok-xyz')
+    expect(ws.readyState).toBe(3) // closed after terminal state
+  })
+
+  it('maps a denied result to the denied phase', () => {
+    const ws = run()
+    ws.open()
+    ws.recv({ type: 'pair_result', requestId: 'fixed-req-id', ok: false, reason: 'denied' })
+    expect(states[states.length - 1].phase).toBe('denied')
+  })
+
+  it('maps an expired result to the expired phase', () => {
+    const ws = run()
+    ws.open()
+    ws.recv({ type: 'pair_result', requestId: 'fixed-req-id', ok: false, reason: 'expired' })
+    expect(states[states.length - 1].phase).toBe('expired')
+  })
+
+  it('ignores frames addressed to a different requestId', () => {
+    const ws = run()
+    ws.open()
+    ws.recv({ type: 'pair_request_pending', requestId: 'someone-else', verifyCode: '999999' })
+    expect(states[states.length - 1].verifyCode).toBeNull()
+  })
+
+  it('never echoes the verify code back to the server', () => {
+    const ws = run()
+    ws.open()
+    ws.recv({ type: 'pair_request_pending', requestId: 'fixed-req-id', verifyCode: '424242' })
+    // Only the initial pair_request was ever sent — no follow-up carries the code.
+    expect(ws.sent).toHaveLength(1)
+    expect(JSON.stringify(ws.sent)).not.toContain('424242')
+  })
+
+  it('surfaces an error if the socket closes before a terminal result', () => {
+    const ws = run()
+    ws.open()
+    ws.onclose?.()
+    expect(states[states.length - 1].phase).toBe('error')
+  })
+})

--- a/packages/dashboard/src/utils/request-pairing.ts
+++ b/packages/dashboard/src/utils/request-pairing.ts
@@ -1,0 +1,153 @@
+/**
+ * request-pairing — the REQUESTER side of the pairing-approval primitive
+ * (#5510, epic #5509).
+ *
+ * A camera-less device (this dashboard, when it knows a server's URL but has no
+ * QR/token) opens a short-lived pre-auth WebSocket, sends `pair_request`,
+ * displays the 6-digit verify code the server returns, and waits for
+ * `pair_result`. On approval the issued session token is delivered over the same
+ * connection — the caller then stores it exactly like the existing
+ * `chroxy://?pair=` flow (addServer + switchServer).
+ *
+ * The verify code is generated SERVER-SIDE; this client only ever DISPLAYS it
+ * (never sends it back), so a mismatch is impossible by construction.
+ *
+ * This is intentionally self-contained (its own WS, not the main connection
+ * store socket): the requester has no credentials yet, so it cannot use the
+ * authenticated reconnect machinery. The socket is closed as soon as the flow
+ * reaches a terminal state.
+ */
+import { PROTOCOL_VERSION } from '@chroxy/protocol'
+
+export type PairRequestPhase =
+  | 'requesting' // socket opening / pair_request sent, awaiting code
+  | 'code-shown' // verify code received, awaiting host approval
+  | 'approved' // pair_result ok:true — token in hand
+  | 'denied' // pair_result ok:false reason:denied
+  | 'expired' // TTL elapsed before approval
+  | 'error' // transport / protocol failure
+
+export interface PairRequestState {
+  phase: PairRequestPhase
+  verifyCode: string | null
+  token: string | null
+  reason: string | null
+}
+
+export interface PairRequestHandle {
+  /** Abort the in-flight request and close the socket. */
+  cancel: () => void
+}
+
+/** Random 1-of-a-kind correlation id for this pair attempt. */
+function newRequestId(): string {
+  // crypto.randomUUID is available in all dashboard targets (browser + Tauri).
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `pr-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  }
+}
+
+/**
+ * Drive a single pair-request round-trip.
+ *
+ * @param wsUrl - normalized ws(s):// URL of the target daemon
+ * @param deviceName - human label shown to the approver (capped server-side)
+ * @param onState - called on every phase/state transition
+ * @returns a handle to cancel the in-flight request
+ */
+export function requestPairing(
+  wsUrl: string,
+  deviceName: string,
+  onState: (state: PairRequestState) => void,
+): PairRequestHandle {
+  const requestId = newRequestId()
+  let settled = false
+  let socket: WebSocket | null = null
+
+  const state: PairRequestState = {
+    phase: 'requesting',
+    verifyCode: null,
+    token: null,
+    reason: null,
+  }
+
+  const emit = () => onState({ ...state })
+
+  const settle = (phase: PairRequestPhase, extra?: Partial<PairRequestState>) => {
+    if (settled) return
+    settled = true
+    Object.assign(state, { phase }, extra)
+    emit()
+    try { socket?.close() } catch { /* ignore */ }
+    socket = null
+  }
+
+  try {
+    socket = new WebSocket(wsUrl)
+  } catch {
+    settle('error', { reason: 'connect_failed' })
+    return { cancel: () => settle('error', { reason: 'cancelled' }) }
+  }
+
+  socket.onopen = () => {
+    if (settled || !socket) return
+    socket.send(JSON.stringify({
+      type: 'pair_request',
+      requestId,
+      deviceName: deviceName.slice(0, 64),
+      protocolVersion: PROTOCOL_VERSION,
+    }))
+    emit() // still 'requesting'
+  }
+
+  socket.onmessage = (ev) => {
+    if (settled) return
+    let msg: Record<string, unknown>
+    try {
+      msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '')
+    } catch {
+      return // ignore unparseable frames
+    }
+    if (!msg || typeof msg !== 'object') return
+    // Ignore frames for other request ids (shouldn't happen on a dedicated
+    // socket, but be defensive).
+    if (typeof msg.requestId === 'string' && msg.requestId !== requestId) return
+
+    if (msg.type === 'pair_request_pending') {
+      if (typeof msg.verifyCode === 'string') {
+        state.phase = 'code-shown'
+        state.verifyCode = msg.verifyCode
+        emit()
+      }
+      return
+    }
+
+    if (msg.type === 'pair_result') {
+      if (msg.ok === true && typeof msg.token === 'string') {
+        settle('approved', { token: msg.token })
+        return
+      }
+      const reason = typeof msg.reason === 'string' ? msg.reason : 'denied'
+      // Map the few terminal reasons to dedicated phases for the UI.
+      if (reason === 'expired') settle('expired', { reason })
+      else if (reason === 'denied') settle('denied', { reason })
+      else settle('error', { reason })
+    }
+  }
+
+  socket.onerror = () => {
+    settle('error', { reason: 'transport_error' })
+  }
+
+  socket.onclose = () => {
+    // If the socket closed before a terminal result, treat it as an error so
+    // the UI doesn't hang in 'requesting' / 'code-shown' forever.
+    if (!settled) settle('error', { reason: 'connection_closed' })
+  }
+
+  return {
+    cancel: () => settle('error', { reason: 'cancelled' }),
+  }
+}

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -48,6 +48,20 @@ export declare const PairSchema: z.ZodObject<{
     }, z.core.$loose>>;
     capabilities: z.ZodDefault<z.ZodCatch<z.ZodOptional<z.ZodArray<z.ZodString>>>>;
 }, z.core.$loose>;
+export declare const PairRequestSchema: z.ZodObject<{
+    type: z.ZodLiteral<"pair_request">;
+    deviceName: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodString;
+    protocolVersion: z.ZodOptional<z.ZodNumber>;
+}, z.core.$loose>;
+export declare const PairApproveSchema: z.ZodObject<{
+    type: z.ZodLiteral<"pair_approve">;
+    requestId: z.ZodString;
+}, z.core.$loose>;
+export declare const PairDenySchema: z.ZodObject<{
+    type: z.ZodLiteral<"pair_deny">;
+    requestId: z.ZodString;
+}, z.core.$loose>;
 export declare const InputSchema: z.ZodObject<{
     type: z.ZodLiteral<"input">;
     data: z.ZodOptional<z.ZodString>;
@@ -956,9 +970,18 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     repoPath: z.ZodString;
     runId: z.ZodOptional<z.ZodNumber>;
     requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"pair_approve">;
+    requestId: z.ZodString;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"pair_deny">;
+    requestId: z.ZodString;
 }, z.core.$loose>], "type">;
 export type AuthMessage = z.infer<typeof AuthSchema>;
 export type PairMessage = z.infer<typeof PairSchema>;
+export type PairRequestMessage = z.infer<typeof PairRequestSchema>;
+export type PairApproveMessage = z.infer<typeof PairApproveSchema>;
+export type PairDenyMessage = z.infer<typeof PairDenySchema>;
 export type InputMessage = z.infer<typeof InputSchema>;
 export type InterruptMessage = z.infer<typeof InterruptSchema>;
 export type CancelActivityMessage = z.infer<typeof CancelActivitySchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -49,6 +49,38 @@ export const PairSchema = z.object({
     deviceInfo: DeviceInfoSchema.optional(),
     capabilities: z.array(z.string()).optional().catch([]).default([]),
 }).passthrough();
+// -- Pairing-approval primitive (#5510, epic #5509) --
+//
+// A camera-less device requests pairing without a QR/URL; the user approves it
+// from a trusted surface (host dashboard/tray). `pair_request` is UNAUTHENTICATED
+// — same exposure class as `pair` (handled pre-auth in ws-server.js, rate-limited
+// + TTL'd + queue-capped server-side), so it is NOT part of ClientMessageSchema.
+//
+// `deviceName` is attacker-controlled — hard length cap (64) here so it cannot be
+// used to inflate the pending-queue payload or any surface that renders it. It is
+// treated as PLAIN TEXT everywhere (React escapes on render; never interpolated
+// into a server log format).
+export const PairRequestSchema = z.object({
+    type: z.literal('pair_request'),
+    // Free-text device label shown to the approver. Capped at 64 chars.
+    deviceName: z.string().max(64).optional(),
+    // Client-generated correlation id echoed on pair_request_pending / pair_result.
+    requestId: z.string().min(1).max(128),
+    protocolVersion: z.number().int().min(0).optional(),
+}).passthrough();
+// `pair_approve` / `pair_deny` — host-level authority ONLY (an unbound client;
+// a session-bound pairing token is rejected, like host_status_request). These
+// ARE part of ClientMessageSchema (post-auth). The verify code never travels
+// from approver→server: the approver only confirms `requestId`, so the requester
+// cannot influence the code by construction.
+export const PairApproveSchema = z.object({
+    type: z.literal('pair_approve'),
+    requestId: z.string().min(1).max(128),
+}).passthrough();
+export const PairDenySchema = z.object({
+    type: z.literal('pair_deny'),
+    requestId: z.string().min(1).max(128),
+}).passthrough();
 export const InputSchema = z.object({
     type: z.literal('input'),
     data: z.string().max(100_000).optional(),
@@ -833,4 +865,6 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     RunnerStatusRequestSchema,
     IntegrationStatusRequestSchema,
     IntegrationActionSchema,
+    PairApproveSchema,
+    PairDenySchema,
 ]);

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -73,6 +73,30 @@ export declare const ServerPairFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"pair_fail">;
     reason: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerPairRequestPendingSchema: z.ZodObject<{
+    type: z.ZodLiteral<"pair_request_pending">;
+    requestId: z.ZodString;
+    verifyCode: z.ZodString;
+}, z.core.$strip>;
+export declare const ServerPairPendingSchema: z.ZodObject<{
+    type: z.ZodLiteral<"pair_pending">;
+    requestId: z.ZodString;
+    deviceName: z.ZodString;
+    verifyCode: z.ZodString;
+    expiresAt: z.ZodNumber;
+}, z.core.$strip>;
+export declare const ServerPairResultSchema: z.ZodObject<{
+    type: z.ZodLiteral<"pair_result">;
+    requestId: z.ZodString;
+    ok: z.ZodBoolean;
+    token: z.ZodOptional<z.ZodString>;
+    reason: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
+export declare const ServerPairResolvedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"pair_resolved">;
+    requestId: z.ZodString;
+    reason: z.ZodString;
+}, z.core.$strip>;
 /**
  * #5431 — one outstanding background task surfaced on `claude_ready`.
  *
@@ -1080,8 +1104,8 @@ export declare const RepoRelayRunSchema: z.ZodObject<{
  */
 export declare const RepoRelayVerdictSchema: z.ZodEnum<{
     unknown: "unknown";
-    failing: "failing";
     ok: "ok";
+    failing: "failing";
     drifted: "drifted";
     not_installed: "not_installed";
 }>;
@@ -1121,8 +1145,8 @@ export declare const RepoRelayStatusSchema: z.ZodObject<{
     failureStreak: z.ZodNumber;
     verdict: z.ZodEnum<{
         unknown: "unknown";
-        failing: "failing";
         ok: "ok";
+        failing: "failing";
         drifted: "drifted";
         not_installed: "not_installed";
     }>;
@@ -1177,8 +1201,8 @@ export declare const IntegrationRepoSchema: z.ZodObject<{
         failureStreak: z.ZodNumber;
         verdict: z.ZodEnum<{
             unknown: "unknown";
-            failing: "failing";
             ok: "ok";
+            failing: "failing";
             drifted: "drifted";
             not_installed: "not_installed";
         }>;
@@ -1273,8 +1297,8 @@ export declare const ServerIntegrationStatusSnapshotSchema: z.ZodObject<{
             failureStreak: z.ZodNumber;
             verdict: z.ZodEnum<{
                 unknown: "unknown";
-                failing: "failing";
                 ok: "ok";
+                failing: "failing";
                 drifted: "drifted";
                 not_installed: "not_installed";
             }>;
@@ -1933,6 +1957,10 @@ export declare const ServerEvaluatorClarifySchema: z.ZodObject<{
     evaluatorIteration: z.ZodNumber;
 }, z.core.$strip>;
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>;
+export type ServerPairRequestPendingMessage = z.infer<typeof ServerPairRequestPendingSchema>;
+export type ServerPairPendingMessage = z.infer<typeof ServerPairPendingSchema>;
+export type ServerPairResultMessage = z.infer<typeof ServerPairResultSchema>;
+export type ServerPairResolvedMessage = z.infer<typeof ServerPairResolvedSchema>;
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -114,6 +114,48 @@ export const ServerPairFailSchema = z.object({
     type: z.literal('pair_fail'),
     reason: z.string(),
 });
+// -- Pairing-approval primitive (#5510, epic #5509) --
+//
+// The verify code travels ONLY server→surfaces: the requester receives it on
+// `pair_request_pending` to display; the approver receives it on `pair_pending`
+// to compare. The requester never sends the code back, so it cannot influence
+// the value (mismatch is impossible by construction). The issued token is
+// delivered EXACTLY once on `pair_result { ok: true }` — never logged.
+// To the requester, immediately after the daemon queues its pair_request.
+export const ServerPairRequestPendingSchema = z.object({
+    type: z.literal('pair_request_pending'),
+    requestId: z.string(),
+    // 6-digit human-comparable verification code (string to preserve leading zeros).
+    verifyCode: z.string(),
+});
+// Fanned out to HOST-LEVEL (unbound) approval surfaces. deviceName is
+// attacker-controlled — capped at the schema and rendered as plain text.
+export const ServerPairPendingSchema = z.object({
+    type: z.literal('pair_pending'),
+    requestId: z.string(),
+    deviceName: z.string().max(64),
+    verifyCode: z.string(),
+    // epoch ms when this request expires (lets the surface render a countdown
+    // and drop the entry on TTL without a separate message).
+    expiresAt: z.number().int().nonnegative().finite(),
+});
+// To the requester over its still-open connection. On approve: { ok: true,
+// token }. On deny / timeout / approver-gone: { ok: false, reason }.
+export const ServerPairResultSchema = z.object({
+    type: z.literal('pair_result'),
+    requestId: z.string(),
+    ok: z.boolean(),
+    token: z.string().optional(),
+    reason: z.string().optional(),
+});
+// Sent to a host-level surface to RETRACT a pending request that has been
+// resolved (approved/denied elsewhere, or expired) so every surface can drop
+// its banner. No verify code — just the id and why.
+export const ServerPairResolvedSchema = z.object({
+    type: z.literal('pair_resolved'),
+    requestId: z.string(),
+    reason: z.string(),
+});
 /**
  * #5431 — one outstanding background task surfaced on `claude_ready`.
  *

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -125,8 +125,10 @@ export const ServerPairFailSchema = z.object({
 export const ServerPairRequestPendingSchema = z.object({
     type: z.literal('pair_request_pending'),
     requestId: z.string(),
-    // 6-digit human-comparable verification code (string to preserve leading zeros).
-    verifyCode: z.string(),
+    // 6-digit human-comparable verification code (string to preserve leading
+    // zeros). Constrained to exactly 6 digits so a server-side regression to a
+    // different alphabet/length is caught at the validation boundary.
+    verifyCode: z.string().regex(/^\d{6}$/),
 });
 // Fanned out to HOST-LEVEL (unbound) approval surfaces. deviceName is
 // attacker-controlled — capped at the schema and rendered as plain text.
@@ -134,7 +136,8 @@ export const ServerPairPendingSchema = z.object({
     type: z.literal('pair_pending'),
     requestId: z.string(),
     deviceName: z.string().max(64),
-    verifyCode: z.string(),
+    // Exactly 6 digits — see ServerPairRequestPendingSchema.
+    verifyCode: z.string().regex(/^\d{6}$/),
     // epoch ms when this request expires (lets the surface render a countdown
     // and drop the entry on TTL without a separate message).
     expiresAt: z.number().int().nonnegative().finite(),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -57,6 +57,41 @@ export const PairSchema = z.object({
   capabilities: z.array(z.string()).optional().catch([]).default([]),
 }).passthrough()
 
+// -- Pairing-approval primitive (#5510, epic #5509) --
+//
+// A camera-less device requests pairing without a QR/URL; the user approves it
+// from a trusted surface (host dashboard/tray). `pair_request` is UNAUTHENTICATED
+// — same exposure class as `pair` (handled pre-auth in ws-server.js, rate-limited
+// + TTL'd + queue-capped server-side), so it is NOT part of ClientMessageSchema.
+//
+// `deviceName` is attacker-controlled — hard length cap (64) here so it cannot be
+// used to inflate the pending-queue payload or any surface that renders it. It is
+// treated as PLAIN TEXT everywhere (React escapes on render; never interpolated
+// into a server log format).
+export const PairRequestSchema = z.object({
+  type: z.literal('pair_request'),
+  // Free-text device label shown to the approver. Capped at 64 chars.
+  deviceName: z.string().max(64).optional(),
+  // Client-generated correlation id echoed on pair_request_pending / pair_result.
+  requestId: z.string().min(1).max(128),
+  protocolVersion: z.number().int().min(0).optional(),
+}).passthrough()
+
+// `pair_approve` / `pair_deny` — host-level authority ONLY (an unbound client;
+// a session-bound pairing token is rejected, like host_status_request). These
+// ARE part of ClientMessageSchema (post-auth). The verify code never travels
+// from approver→server: the approver only confirms `requestId`, so the requester
+// cannot influence the code by construction.
+export const PairApproveSchema = z.object({
+  type: z.literal('pair_approve'),
+  requestId: z.string().min(1).max(128),
+}).passthrough()
+
+export const PairDenySchema = z.object({
+  type: z.literal('pair_deny'),
+  requestId: z.string().min(1).max(128),
+}).passthrough()
+
 export const InputSchema = z.object({
   type: z.literal('input'),
   data: z.string().max(100_000).optional(),
@@ -948,12 +983,17 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   RunnerStatusRequestSchema,
   IntegrationStatusRequestSchema,
   IntegrationActionSchema,
+  PairApproveSchema,
+  PairDenySchema,
 ])
 
 // -- Inferred TypeScript types --
 
 export type AuthMessage = z.infer<typeof AuthSchema>
 export type PairMessage = z.infer<typeof PairSchema>
+export type PairRequestMessage = z.infer<typeof PairRequestSchema>
+export type PairApproveMessage = z.infer<typeof PairApproveSchema>
+export type PairDenyMessage = z.infer<typeof PairDenySchema>
 export type InputMessage = z.infer<typeof InputSchema>
 export type InterruptMessage = z.infer<typeof InterruptSchema>
 export type CancelActivityMessage = z.infer<typeof CancelActivitySchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -120,6 +120,53 @@ export const ServerPairFailSchema = z.object({
   reason: z.string(),
 })
 
+// -- Pairing-approval primitive (#5510, epic #5509) --
+//
+// The verify code travels ONLY server→surfaces: the requester receives it on
+// `pair_request_pending` to display; the approver receives it on `pair_pending`
+// to compare. The requester never sends the code back, so it cannot influence
+// the value (mismatch is impossible by construction). The issued token is
+// delivered EXACTLY once on `pair_result { ok: true }` — never logged.
+
+// To the requester, immediately after the daemon queues its pair_request.
+export const ServerPairRequestPendingSchema = z.object({
+  type: z.literal('pair_request_pending'),
+  requestId: z.string(),
+  // 6-digit human-comparable verification code (string to preserve leading zeros).
+  verifyCode: z.string(),
+})
+
+// Fanned out to HOST-LEVEL (unbound) approval surfaces. deviceName is
+// attacker-controlled — capped at the schema and rendered as plain text.
+export const ServerPairPendingSchema = z.object({
+  type: z.literal('pair_pending'),
+  requestId: z.string(),
+  deviceName: z.string().max(64),
+  verifyCode: z.string(),
+  // epoch ms when this request expires (lets the surface render a countdown
+  // and drop the entry on TTL without a separate message).
+  expiresAt: z.number().int().nonnegative().finite(),
+})
+
+// To the requester over its still-open connection. On approve: { ok: true,
+// token }. On deny / timeout / approver-gone: { ok: false, reason }.
+export const ServerPairResultSchema = z.object({
+  type: z.literal('pair_result'),
+  requestId: z.string(),
+  ok: z.boolean(),
+  token: z.string().optional(),
+  reason: z.string().optional(),
+})
+
+// Sent to a host-level surface to RETRACT a pending request that has been
+// resolved (approved/denied elsewhere, or expired) so every surface can drop
+// its banner. No verify code — just the id and why.
+export const ServerPairResolvedSchema = z.object({
+  type: z.literal('pair_resolved'),
+  requestId: z.string(),
+  reason: z.string(),
+})
+
 /**
  * #5431 — one outstanding background task surfaced on `claude_ready`.
  *
@@ -2114,6 +2161,10 @@ export const ServerEvaluatorClarifySchema = z.object({
 // -- Inferred TypeScript types --
 
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>
+export type ServerPairRequestPendingMessage = z.infer<typeof ServerPairRequestPendingSchema>
+export type ServerPairPendingMessage = z.infer<typeof ServerPairPendingSchema>
+export type ServerPairResultMessage = z.infer<typeof ServerPairResultSchema>
+export type ServerPairResolvedMessage = z.infer<typeof ServerPairResolvedSchema>
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -132,8 +132,10 @@ export const ServerPairFailSchema = z.object({
 export const ServerPairRequestPendingSchema = z.object({
   type: z.literal('pair_request_pending'),
   requestId: z.string(),
-  // 6-digit human-comparable verification code (string to preserve leading zeros).
-  verifyCode: z.string(),
+  // 6-digit human-comparable verification code (string to preserve leading
+  // zeros). Constrained to exactly 6 digits so a server-side regression to a
+  // different alphabet/length is caught at the validation boundary.
+  verifyCode: z.string().regex(/^\d{6}$/),
 })
 
 // Fanned out to HOST-LEVEL (unbound) approval surfaces. deviceName is
@@ -142,7 +144,8 @@ export const ServerPairPendingSchema = z.object({
   type: z.literal('pair_pending'),
   requestId: z.string(),
   deviceName: z.string().max(64),
-  verifyCode: z.string(),
+  // Exactly 6 digits — see ServerPairRequestPendingSchema.
+  verifyCode: z.string().regex(/^\d{6}$/),
   // epoch ms when this request expires (lets the surface render a countdown
   // and drop the entry on TTL without a separate message).
   expiresAt: z.number().int().nonnegative().finite(),

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -47,6 +47,8 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
+  'pair_request_pending', // #5510 pairing-approval primitive — consumed by the dedicated requester panel (dashboard utils/request-pairing.ts, its own short-lived WS onmessage), NOT the main message-handler dispatch the extractor scans. Mobile requester side is an explicit out-of-scope fast-follow per epic #5509.
+  'pair_result',          // #5510 pairing-approval primitive — same as pair_request_pending: terminal result for the requester, handled by utils/request-pairing.ts, not the main dispatch. Mobile requester side deferred per epic #5509.
   // 'activity_snapshot' / 'activity_delta' removed — the dashboard now handles
   // them (Control Room panel #5163); they moved to PLATFORM_SPECIFIC as
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5159.
@@ -84,6 +86,8 @@ const PLATFORM_SPECIFIC = {
 
   // Dashboard only
   'pairing_refreshed': 'dashboard',  // QR display and auto-refresh is dashboard-only (#2916)
+  'pair_pending': 'dashboard',       // #5510 pairing-approval primitive — host-level approval banner fan-out is dashboard-only for v1 (the mobile app has no approve surface yet); mobile/desktop-tray approve is an explicit out-of-scope fast-follow per epic #5509
+  'pair_resolved': 'dashboard',      // #5510 pairing-approval primitive — banner retraction pairs with pair_pending; dashboard-only for v1, mobile parity deferred per epic #5509
   'log_entry': 'dashboard',          // console page is dashboard-only
   'file_list': 'dashboard',          // file explorer sidebar is dashboard-only
   'environment_created': 'dashboard', // environment panel is dashboard-only

--- a/packages/server/src/handlers/pairing-handlers.js
+++ b/packages/server/src/handlers/pairing-handlers.js
@@ -1,0 +1,88 @@
+/**
+ * Pairing-approval primitive (#5510, epic #5509) — host-level approve/deny.
+ *
+ * The requester side (`pair_request` → `pair_request_pending` → fan-out
+ * `pair_pending`) is handled PRE-AUTH in ws-auth.js. This module owns the
+ * post-auth control half: an authenticated host operator approves or denies a
+ * pending request.
+ *
+ * Bearer-token authority (docs/security/bearer-token-authority.md §9):
+ *   Approving a pair request issues a NEW host-authority session token to a
+ *   brand-new device — a host-wide grant, strictly broader than any single
+ *   session's scope. So, exactly like `host_status_request`, these handlers are
+ *   served ONLY to host-level clients (unbound — `client.boundSessionId` unset).
+ *   A pairing-bound (share-a-session) token is rejected with FORBIDDEN; it must
+ *   never mint credentials for other devices.
+ *
+ * The verify code is never consulted here: the operator confirmed the request
+ * out-of-band by comparing the code shown on the new device with the one in the
+ * `pair_pending` banner. By construction the requester cannot influence that
+ * code (it only ever travels server→surfaces).
+ *
+ * The issued token is delivered EXACTLY once, over the requester's still-open
+ * connection, via `pair_result { ok: true, token }`. The PairingManager marks
+ * the request resolved before minting, so a double-approve is a no-op error.
+ * The token is NEVER logged.
+ */
+import { createLogger } from '../logger.js'
+import { sendError } from '../handler-utils.js'
+
+const log = createLogger('ws')
+
+/** Reject a bound (non-host) client. Mirrors the host_status_request gate. */
+function rejectIfBound(ws, client, msg) {
+  if (!client?.boundSessionId) return false
+  sendError(ws, msg?.requestId ?? null, 'FORBIDDEN',
+    'pair approval requires host-level authority (a session-bound token cannot approve new devices)')
+  return true
+}
+
+async function handlePairApprove(ws, client, msg, ctx) {
+  if (rejectIfBound(ws, client, msg)) return
+  const pairingManager = ctx?.pairingManager
+  const requestId = typeof msg?.requestId === 'string' ? msg.requestId : null
+  if (!pairingManager || !requestId) {
+    sendError(ws, requestId, 'PAIR_APPROVE_FAILED', 'pairing is not enabled or requestId is missing')
+    return
+  }
+
+  const result = pairingManager.approvePendingRequest(requestId)
+  if (!result.ok) {
+    // not_found / expired / already_resolved — surface to the approver so the
+    // dashboard can drop its banner. Never logs a token.
+    sendError(ws, requestId, 'PAIR_APPROVE_FAILED', `cannot approve request: ${result.reason}`, { reason: result.reason })
+    // Retract the banner on every host surface for a stale request.
+    if (result.reason !== 'not_found') ctx.broadcastPairResolved(requestId, result.reason)
+    return
+  }
+
+  // Deliver the token to the requester EXACTLY once over its open connection.
+  // If the requester disconnected, the token is simply dropped (the entry is
+  // still consumed — no second approve can mint another).
+  ctx.resolvePairRequester(requestId, { ok: true, token: result.token })
+  // Retract the banner everywhere else.
+  ctx.broadcastPairResolved(requestId, 'approved')
+  log.info(`pair_request ${requestId} approved by client ${client.id}`)
+}
+
+async function handlePairDeny(ws, client, msg, ctx) {
+  if (rejectIfBound(ws, client, msg)) return
+  const pairingManager = ctx?.pairingManager
+  const requestId = typeof msg?.requestId === 'string' ? msg.requestId : null
+  if (!pairingManager || !requestId) {
+    sendError(ws, requestId, 'PAIR_DENY_FAILED', 'pairing is not enabled or requestId is missing')
+    return
+  }
+
+  pairingManager.denyPendingRequest(requestId)
+  // Tell the requester (idempotent — harmless if already resolved) and retract
+  // the banner on every host surface.
+  ctx.resolvePairRequester(requestId, { ok: false, reason: 'denied' })
+  ctx.broadcastPairResolved(requestId, 'denied')
+  log.info(`pair_request ${requestId} denied by client ${client.id}`)
+}
+
+export const pairingHandlers = {
+  pair_approve: handlePairApprove,
+  pair_deny: handlePairDeny,
+}

--- a/packages/server/src/handlers/pairing-handlers.js
+++ b/packages/server/src/handlers/pairing-handlers.js
@@ -62,7 +62,9 @@ async function handlePairApprove(ws, client, msg, ctx) {
   ctx.resolvePairRequester(requestId, { ok: true, token: result.token })
   // Retract the banner everywhere else.
   ctx.broadcastPairResolved(requestId, 'approved')
-  log.info(`pair_request ${requestId} approved by client ${client.id}`)
+  // requestId originated pre-auth (attacker-controlled); JSON.stringify keeps
+  // the log a single well-formed record (no newline/control-char injection).
+  log.info(`pair_request ${JSON.stringify(requestId)} approved by client ${client.id}`)
 }
 
 async function handlePairDeny(ws, client, msg, ctx) {
@@ -79,7 +81,8 @@ async function handlePairDeny(ws, client, msg, ctx) {
   // the banner on every host surface.
   ctx.resolvePairRequester(requestId, { ok: false, reason: 'denied' })
   ctx.broadcastPairResolved(requestId, 'denied')
-  log.info(`pair_request ${requestId} denied by client ${client.id}`)
+  // See handlePairApprove: requestId is pre-auth attacker-controlled.
+  log.info(`pair_request ${JSON.stringify(requestId)} denied by client ${client.id}`)
 }
 
 export const pairingHandlers = {

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -17,8 +17,22 @@ const SESSION_TOKEN_BYTES = 32
 const MAX_SESSION_TOKENS = 100
 const MAX_ACTIVE_PAIRINGS = 10
 
+// -- Pairing-approval primitive (#5510, epic #5509) --
+//
+// A camera-less device requests pairing without a QR; the user approves it from
+// a host-level surface. The pending queue is an UNAUTHENTICATED-fed DoS surface,
+// so it is hard-bounded on three axes: a global cap, a per-request TTL, and a
+// per-source rate limit. Expired entries are swept on an unref'd timer.
+const DEFAULT_PENDING_TTL_MS = 120_000 // 120s — a pending request expires
+const MAX_PENDING_REQUESTS = 5 // global cap on outstanding pending requests
+const PENDING_SWEEP_INTERVAL_MS = 5_000 // sweep cadence for expired entries
+// Per-source rate limit: at most N new requests in a rolling window.
+const PENDING_RATE_MAX = 5
+const PENDING_RATE_WINDOW_MS = 60_000
+const MAX_RATE_SOURCES = 1_000 // cap the rate-limit map cardinality
+
 export class PairingManager extends EventEmitter {
-  constructor({ wsUrl = null, ttlMs = DEFAULT_TTL_MS, sessionTokenTtlMs = DEFAULT_SESSION_TOKEN_TTL_MS, autoRefresh = false } = {}) {
+  constructor({ wsUrl = null, ttlMs = DEFAULT_TTL_MS, sessionTokenTtlMs = DEFAULT_SESSION_TOKEN_TTL_MS, autoRefresh = false, pendingTtlMs = DEFAULT_PENDING_TTL_MS } = {}) {
     super()
     this._wsUrl = wsUrl
     this._ttlMs = ttlMs
@@ -29,6 +43,12 @@ export class PairingManager extends EventEmitter {
     this._sessionTokens = new Map() // sessionToken → { createdAt }
     this._refreshTimer = null
     this._destroyed = false
+
+    // -- Pairing-approval primitive (#5510) --
+    this._pendingTtlMs = pendingTtlMs
+    this._pendingRequests = new Map() // requestId → { deviceName, verifyCode, expiresAt, resolved }
+    this._pendingRateBuckets = new Map() // source → { count, windowStart }
+    this._sweepTimer = null
 
     this._generatePairing()
     if (autoRefresh) this._scheduleRefresh()
@@ -249,14 +269,239 @@ export class PairingManager extends EventEmitter {
     this._wsUrl = wsUrl
   }
 
+  // ===================================================================
+  //  Pairing-approval primitive (#5510, epic #5509)
+  //
+  //  A new device sends `pair_request`; the daemon queues it with a 6-digit
+  //  verify code and a TTL, fans the request out to host-level surfaces, and
+  //  issues a session token only when an approver confirms it. The queue is an
+  //  unauthenticated-fed DoS surface — bounded by cap + TTL + per-source rate.
+  // ===================================================================
+
+  /**
+   * Queue a new pending pair request.
+   *
+   * The verify code is generated SERVER-SIDE and returned to the caller only so
+   * the WsServer can relay it to the requester (display) and to host surfaces
+   * (compare). The requester never sends it back, so a mismatch is impossible by
+   * construction.
+   *
+   * @param {object} args
+   * @param {string} args.requestId - client-generated correlation id
+   * @param {string} [args.deviceName] - attacker-controlled label (already
+   *   length-capped at the schema; re-clamped here defensively)
+   * @param {string} args.source - rate-limit key (CF-Connecting-IP / socket ip)
+   * @returns {{ ok: true, verifyCode: string, expiresAt: number }
+   *           | { ok: false, reason: 'rate_limited'|'queue_full'|'duplicate_request'|'invalid' }}
+   */
+  enqueuePendingRequest({ requestId, deviceName = '', source = '' } = {}) {
+    if (this._destroyed) return { ok: false, reason: 'invalid' }
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      return { ok: false, reason: 'invalid' }
+    }
+
+    this._sweepPending()
+
+    // Per-source rate limit (rolling window). Checked BEFORE the cap so a
+    // single noisy source cannot starve the cap-rejection path for others.
+    if (this._isRateLimited(source)) {
+      return { ok: false, reason: 'rate_limited' }
+    }
+
+    // Duplicate requestId — the caller should mint a fresh id. Reject rather
+    // than overwrite so an in-flight approval can never be hijacked by a
+    // collision.
+    if (this._pendingRequests.has(requestId)) {
+      return { ok: false, reason: 'duplicate_request' }
+    }
+
+    // Global cap. Reject newest-on-full (fail closed) rather than evicting an
+    // existing entry — evicting would silently drop a request the user may be
+    // mid-approval on.
+    if (this._pendingRequests.size >= MAX_PENDING_REQUESTS) {
+      return { ok: false, reason: 'queue_full' }
+    }
+
+    // Count this request against the source's bucket only after it is accepted.
+    this._recordRateAttempt(source)
+
+    const verifyCode = this._generateVerifyCode()
+    const expiresAt = Date.now() + this._pendingTtlMs
+    const cleanName = typeof deviceName === 'string' ? deviceName.slice(0, 64) : ''
+    this._pendingRequests.set(requestId, {
+      deviceName: cleanName,
+      verifyCode,
+      expiresAt,
+      resolved: false,
+    })
+
+    this._ensureSweepTimer()
+    return { ok: true, verifyCode, expiresAt }
+  }
+
+  /**
+   * Snapshot of a pending request for fan-out to host surfaces. Never includes
+   * the issued token (none exists yet). Returns null if absent/expired/resolved.
+   */
+  getPendingRequest(requestId) {
+    const entry = this._pendingRequests.get(requestId)
+    if (!entry || entry.resolved) return null
+    if (Date.now() > entry.expiresAt) return null
+    return {
+      requestId,
+      deviceName: entry.deviceName,
+      verifyCode: entry.verifyCode,
+      expiresAt: entry.expiresAt,
+    }
+  }
+
+  /** All live (unresolved, unexpired) pending requests — for surface replay. */
+  listPendingRequests() {
+    this._sweepPending()
+    const out = []
+    for (const [requestId, entry] of this._pendingRequests) {
+      if (entry.resolved) continue
+      out.push({
+        requestId,
+        deviceName: entry.deviceName,
+        verifyCode: entry.verifyCode,
+        expiresAt: entry.expiresAt,
+      })
+    }
+    return out
+  }
+
+  /**
+   * Approve a pending request and issue a session token EXACTLY once. A second
+   * approve of the same requestId is a no-op error (`already_resolved`).
+   *
+   * The issued token is an unbound (host-authority) session token — same class
+   * and TTL as a linking-mode QR pairing. The verify code is never consulted
+   * here: the approver confirmed the requestId out-of-band by eyeballing the
+   * code on both screens.
+   *
+   * @param {string} requestId
+   * @returns {{ ok: true, token: string }
+   *           | { ok: false, reason: 'not_found'|'expired'|'already_resolved' }}
+   */
+  approvePendingRequest(requestId) {
+    if (this._destroyed) return { ok: false, reason: 'not_found' }
+    const entry = this._pendingRequests.get(requestId)
+    if (!entry) return { ok: false, reason: 'not_found' }
+    if (entry.resolved) return { ok: false, reason: 'already_resolved' }
+    if (Date.now() > entry.expiresAt) {
+      entry.resolved = true
+      return { ok: false, reason: 'expired' }
+    }
+
+    // Mark resolved BEFORE issuing the token so a concurrent re-entrant approve
+    // (same tick) cannot mint a second token for the same request. The resolved
+    // entry stays in the map as a tombstone (reaped on the next sweep) so a
+    // second approve returns `already_resolved`, not `not_found`.
+    entry.resolved = true
+
+    const token = randomBytes(SESSION_TOKEN_BYTES).toString('base64url')
+    if (this._sessionTokens.size >= MAX_SESSION_TOKENS) {
+      const oldest = this._sessionTokens.keys().next().value
+      this._sessionTokens.delete(oldest)
+    }
+    // Unbound (host-authority) token — sessionId: null, like linking-mode QR.
+    this._sessionTokens.set(token, { createdAt: Date.now(), sessionId: null })
+    return { ok: true, token }
+  }
+
+  /**
+   * Deny / cancel a pending request. Returns true if a live entry was denied.
+   * Idempotent: denying an already-resolved/absent request returns false. The
+   * resolved tombstone is reaped on the next sweep.
+   */
+  denyPendingRequest(requestId) {
+    const entry = this._pendingRequests.get(requestId)
+    if (!entry || entry.resolved) return false
+    entry.resolved = true
+    return true
+  }
+
+  /** Generate a zero-padded 6-digit verification code (0-999999). */
+  _generateVerifyCode() {
+    // rejection-sampling-free: 4 bytes → uint32 → mod 1_000_000. The tiny modulo
+    // bias (2^32 % 1e6) is irrelevant for a 120s human-comparison code.
+    const n = randomBytes(4).readUInt32BE(0) % 1_000_000
+    return String(n).padStart(6, '0')
+  }
+
+  _isRateLimited(source) {
+    if (!source) return false
+    const bucket = this._pendingRateBuckets.get(source)
+    if (!bucket) return false
+    const now = Date.now()
+    if (now - bucket.windowStart > PENDING_RATE_WINDOW_MS) return false
+    return bucket.count >= PENDING_RATE_MAX
+  }
+
+  _recordRateAttempt(source) {
+    if (!source) return
+    const now = Date.now()
+    let bucket = this._pendingRateBuckets.get(source)
+    if (!bucket || now - bucket.windowStart > PENDING_RATE_WINDOW_MS) {
+      // Cap cardinality before inserting a fresh source.
+      if (!this._pendingRateBuckets.has(source) && this._pendingRateBuckets.size >= MAX_RATE_SOURCES) {
+        const oldest = this._pendingRateBuckets.keys().next().value
+        this._pendingRateBuckets.delete(oldest)
+      }
+      bucket = { count: 0, windowStart: now }
+      this._pendingRateBuckets.set(source, bucket)
+    }
+    bucket.count++
+  }
+
+  /**
+   * Remove expired pending requests, emitting `pending_request_expired` for
+   * each so the WsServer can notify the requester and retract host banners.
+   */
+  _sweepPending() {
+    if (this._destroyed) return
+    const now = Date.now()
+    for (const [requestId, entry] of this._pendingRequests) {
+      if (entry.resolved || now > entry.expiresAt) {
+        this._pendingRequests.delete(requestId)
+        if (!entry.resolved) {
+          this.emit('pending_request_expired', { requestId })
+        }
+      }
+    }
+    // Prune stale rate buckets opportunistically.
+    for (const [source, bucket] of this._pendingRateBuckets) {
+      if (now - bucket.windowStart > PENDING_RATE_WINDOW_MS) {
+        this._pendingRateBuckets.delete(source)
+      }
+    }
+    if (this._pendingRequests.size === 0 && this._sweepTimer) {
+      clearInterval(this._sweepTimer)
+      this._sweepTimer = null
+    }
+  }
+
+  _ensureSweepTimer() {
+    if (this._destroyed || this._sweepTimer) return
+    this._sweepTimer = setInterval(() => this._sweepPending(), PENDING_SWEEP_INTERVAL_MS)
+    this._sweepTimer.unref?.()
+  }
+
   destroy() {
     this._destroyed = true
     this._current = null
     this._activePairings.clear()
     this._sessionTokens.clear()
+    this._pendingRequests.clear()
+    this._pendingRateBuckets.clear()
     if (this._refreshTimer) {
       clearTimeout(this._refreshTimer)
       this._refreshTimer = null
+    }
+    if (this._sweepTimer) {
+      clearInterval(this._sweepTimer)
+      this._sweepTimer = null
     }
     this.removeAllListeners()
   }

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -5,7 +5,7 @@
  * concerns from message routing.
  */
 import { createKeyPair, deriveSharedKey, deriveConnectionKey } from '@chroxy/store-core/crypto'
-import { AuthSchema, KeyExchangeSchema, PairSchema } from './ws-schemas.js'
+import { AuthSchema, KeyExchangeSchema, PairSchema, PairRequestSchema } from './ws-schemas.js'
 import { createLogger } from './logger.js'
 import { metrics } from './metrics.js'
 
@@ -344,6 +344,93 @@ export function handlePairMessage(ctx, ws, msg) {
   log.info(`Pair failure from ${rateLimitKey}: ${result.reason} (benign — not counted toward strict rate limit)`)
   send(ws, { type: 'pair_fail', reason: result.reason })
   ws.close()
+  return true
+}
+
+/**
+ * Handle a `pair_request` from an UNAUTHENTICATED client (#5510, epic #5509).
+ *
+ * Same exposure class as `handlePairMessage`: pre-auth, rate-limited (the
+ * PairingManager queue enforces a global cap + per-request TTL + per-source rate
+ * limit), and the connection is kept OPEN so the requester can later receive its
+ * terminal `pair_result`.
+ *
+ * The verify code is generated SERVER-SIDE inside enqueuePendingRequest and only
+ * ever travels server→requester (display) and server→host surfaces (compare).
+ * The requester never echoes it back, so a mismatch is impossible by
+ * construction. deviceName is attacker-controlled — capped at the schema and
+ * relayed as plain text (never interpolated into a log format).
+ *
+ * Returns true if the message was consumed.
+ *
+ * @param {object} ctx - Server context (pairingManager, registerPairRequester,
+ *   broadcastPairPending, send)
+ * @param {WebSocket} ws
+ * @param {object} msg
+ * @returns {boolean}
+ */
+export function handlePairRequestMessage(ctx, ws, msg) {
+  const {
+    clients, pairingManager, send,
+    registerPairRequester, broadcastPairPending,
+  } = ctx
+  const client = clients.get(ws)
+  if (!client || client.authenticated) return false
+  if (msg.type !== 'pair_request') return false
+
+  if (!pairingManager) {
+    send(ws, { type: 'pair_result', requestId: msg?.requestId ?? '', ok: false, reason: 'pairing_not_enabled' })
+    ws.close()
+    return true
+  }
+
+  // Validate shape.
+  const parsed = PairRequestSchema.safeParse(msg)
+  if (!parsed.success) {
+    send(ws, { type: 'pair_result', requestId: typeof msg?.requestId === 'string' ? msg.requestId : '', ok: false, reason: 'invalid_message' })
+    ws.close()
+    return true
+  }
+  const data = parsed.data
+
+  // Rate-limit key: CF-Connecting-IP behind the tunnel, else socket ip (same
+  // rationale as handlePairMessage — keying off socketIp behind cloudflared lets
+  // one source lock out everyone).
+  const source = client.rateLimitKey || client.socketIp || ''
+
+  const result = pairingManager.enqueuePendingRequest({
+    requestId: data.requestId,
+    deviceName: data.deviceName || '',
+    source,
+  })
+
+  if (!result.ok) {
+    // Bounded rejection (rate_limited / queue_full / duplicate_request). Do NOT
+    // log deviceName (attacker-controlled). The connection closes — the
+    // requester can retry with backoff / a fresh requestId.
+    log.warn(`pair_request rejected for ${source}: ${result.reason}`)
+    send(ws, { type: 'pair_result', requestId: data.requestId, ok: false, reason: result.reason })
+    ws.close()
+    return true
+  }
+
+  // Track the requester's open connection so approve/deny/expire can reach it.
+  registerPairRequester(data.requestId, ws)
+
+  // Tell the requester its code to display.
+  send(ws, { type: 'pair_request_pending', requestId: data.requestId, verifyCode: result.verifyCode })
+
+  // Fan the request out to host-level approval surfaces. deviceName relayed
+  // verbatim (plain text); never logged.
+  broadcastPairPending({
+    type: 'pair_pending',
+    requestId: data.requestId,
+    deviceName: data.deviceName ? String(data.deviceName).slice(0, 64) : '',
+    verifyCode: result.verifyCode,
+    expiresAt: result.expiresAt,
+  })
+
+  log.info(`pair_request queued from ${source} (requestId ${data.requestId})`)
   return true
 }
 

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -379,7 +379,7 @@ export function handlePairRequestMessage(ctx, ws, msg) {
   if (msg.type !== 'pair_request') return false
 
   if (!pairingManager) {
-    send(ws, { type: 'pair_result', requestId: msg?.requestId ?? '', ok: false, reason: 'pairing_not_enabled' })
+    send(ws, { type: 'pair_result', requestId: typeof msg?.requestId === 'string' ? msg.requestId : '', ok: false, reason: 'pairing_not_enabled' })
     ws.close()
     return true
   }
@@ -430,7 +430,9 @@ export function handlePairRequestMessage(ctx, ws, msg) {
     expiresAt: result.expiresAt,
   })
 
-  log.info(`pair_request queued from ${source} (requestId ${data.requestId})`)
+  // requestId is pre-auth attacker-controlled (the schema permits newlines /
+  // control chars); JSON.stringify keeps it a single well-formed log record.
+  log.info(`pair_request queued from ${source} (requestId ${JSON.stringify(data.requestId)})`)
   return true
 }
 

--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -18,6 +18,7 @@ import { repoHandlers } from './handlers/repo-handlers.js'
 import { featureHandlers } from './handlers/feature-handlers.js'
 import { evaluatorHandlers } from './handlers/evaluator-handlers.js'
 import { controlRoomHandlers } from './handlers/control-room-handlers.js'
+import { pairingHandlers } from './handlers/pairing-handlers.js'
 
 const log = createLogger('ws')
 
@@ -33,6 +34,7 @@ const handlerRegistry = new Map([
   ...Object.entries(featureHandlers),
   ...Object.entries(evaluatorHandlers),
   ...Object.entries(controlRoomHandlers),
+  ...Object.entries(pairingHandlers),
 ])
 
 /**

--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -9,6 +9,9 @@ export {
   // Client schemas
   AuthSchema,
   PairSchema,
+  PairRequestSchema,
+  PairApproveSchema,
+  PairDenySchema,
   InputSchema,
   InterruptSchema,
   SetModelSchema,

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -14,7 +14,7 @@ import { createFileOps } from './ws-file-ops/index.js'
 import { createPermissionHandler } from './ws-permissions.js'
 import { setupForwarding } from './ws-forwarding.js'
 import { handleSessionMessage, handleCliMessage } from './ws-message-handlers.js'
-import { handleAuthMessage, handlePairMessage, handleKeyExchange, BENIGN_PAIR_WINDOW_MS } from './ws-auth.js'
+import { handleAuthMessage, handlePairMessage, handlePairRequestMessage, handleKeyExchange, BENIGN_PAIR_WINDOW_MS } from './ws-auth.js'
 import { sendPostAuthInfo, replayHistory, flushPostAuthQueue, sendSessionInfo } from './ws-history.js'
 import { createDevicePreferences } from './device-preferences.js'
 import { createHttpHandler } from './http-routes.js'
@@ -578,6 +578,11 @@ export class WsServer {
     this._sessionHookSecrets = new Map() // sessionId -> hookSecret (for cleanup on session_destroyed)
     this._questionSessionMap = new Map() // toolUseId -> sessionId (for routing question responses)
     this._primaryClients = new Map() // sessionId -> clientId (last-writer-wins)
+    // #5510: pairing-approval primitive — requestId → requester ws. The
+    // requester's WS stays open (pre-auth) after pair_request; on approve/deny/
+    // expire/disconnect we look it up here to deliver `pair_result`. Bounded by
+    // the PairingManager queue cap; cleaned up on resolution and on disconnect.
+    this._pairRequesters = new Map() // requestId -> ws
     // Late-binding wrappers: allows tests to monkey-patch _send/_broadcast
     const self = this
     const sendFn = (ws, msg) => self._send(ws, msg)
@@ -636,6 +641,10 @@ export class WsServer {
       get sessionManager() { return self.sessionManager },
       get cliSession() { return self.cliSession },
       get pushManager() { return self.pushManager },
+      // #5510: pairing-approval primitive — host-level approve/deny handlers.
+      get pairingManager() { return self._pairingManager },
+      resolvePairRequester: (requestId, result) => self._resolvePairRequester(requestId, result),
+      broadcastPairResolved: (requestId, reason) => self._broadcastPairResolved(requestId, reason),
       get checkpointManager() { return self._checkpointManager },
       get devPreview() { return self._devPreview },
       get webTaskManager() { return self._webTaskManager },
@@ -747,6 +756,10 @@ export class WsServer {
       minProtocolVersion: MIN_PROTOCOL_VERSION,
       serverProtocolVersion: SERVER_PROTOCOL_VERSION,
       flushPostAuthQueue: (ws, queue) => self._flushPostAuthQueue(ws, queue),
+      // #5510: register the requester's still-open ws so a later approve/deny
+      // can reach it, and fan `pair_pending` out to host-level surfaces.
+      registerPairRequester: (requestId, ws) => self._pairRequesters.set(requestId, ws),
+      broadcastPairPending: (msg) => self._broadcastPairPending(msg),
     }
 
     this.pushManager = pushManager
@@ -886,12 +899,22 @@ export class WsServer {
     // Wire PairingManager refresh events — broadcast pairing_refreshed to all
     // authenticated dashboard clients so they can auto-refresh the QR code (#2916).
     this._pairingRefreshedHandler = null
+    this._pendingRequestExpiredHandler = null
     if (this._pairingManager) {
       this._pairingRefreshedHandler = () => {
         this._broadcast({ type: 'pairing_refreshed' })
         log.debug('Broadcasted pairing_refreshed to all clients')
       }
       this._pairingManager.on('pairing_refreshed', this._pairingRefreshedHandler)
+
+      // #5510: a pending pair request hit its TTL while still unresolved. Tell
+      // the requester (its connection may still be open) and retract the banner
+      // on every host surface.
+      this._pendingRequestExpiredHandler = ({ requestId }) => {
+        this._resolvePairRequester(requestId, { ok: false, reason: 'expired' })
+        this._broadcastPairResolved(requestId, 'expired')
+      }
+      this._pairingManager.on('pending_request_expired', this._pendingRequestExpiredHandler)
     }
 
     // Wire TokenManager rotation events — broadcast new token to all clients
@@ -1288,6 +1311,10 @@ export class WsServer {
         if (client?.authenticated) {
           this._handleClientDeparture(client)
         }
+        // #5510: if a pair requester (unauthenticated, connection-pending) drops
+        // before resolution, deny + drop its queue entry and retract the host
+        // banner so an abandoned request can't sit on a queue slot for its TTL.
+        this._cleanupPairRequesterOnDisconnect(ws)
         // Do not remove rate limiter entries on disconnect — the limiter keys by IP,
         // so removing on disconnect would reset the shared bucket for all connections
         // from the same real IP. The sliding window's natural expiry cleans up entries.
@@ -1451,6 +1478,11 @@ export class WsServer {
     if (!client.authenticated) {
       if (msg.type === 'pair') {
         handlePairMessage(this._authCtx, ws, msg)
+      } else if (msg.type === 'pair_request') {
+        // #5510: camera-less device requests pairing. Same exposure class as
+        // `pair` (unauthenticated, rate-limited, queue-capped). The connection
+        // stays OPEN — the requester waits for `pair_result`.
+        handlePairRequestMessage(this._authCtx, ws, msg)
       } else {
         handleAuthMessage(this._authCtx, ws, msg)
       }
@@ -1558,6 +1590,51 @@ export class WsServer {
    */
   _broadcastToSession(sessionId, message, filter) {
     this._broadcaster._broadcastToSession(sessionId, message, filter)
+  }
+
+  /**
+   * #5510: fan a `pair_pending` (or any pairing-approval surface event) out to
+   * HOST-LEVEL clients only — authenticated clients with no `boundSessionId`.
+   * A session-bound (share-a-session) token must NOT see host-wide pair
+   * requests, mirroring the `host_status_request` authority gate. The verify
+   * code in `msg` is server-generated; deviceName is attacker-controlled and is
+   * relayed verbatim as plain text (surfaces escape on render).
+   */
+  _broadcastPairPending(message) {
+    this._broadcast(message, (client) => !client.boundSessionId)
+  }
+
+  /** #5510: retract a resolved pending request from every host surface. */
+  _broadcastPairResolved(requestId, reason) {
+    this._broadcastPairPending({ type: 'pair_resolved', requestId, reason })
+  }
+
+  /**
+   * #5510: deliver a terminal `pair_result` to the requester's still-open
+   * connection (if present) and drop the tracking entry. On approve the result
+   * carries the issued token; on deny/expire/disconnect it carries a reason.
+   * If the requester's connection is gone, the entry is just dropped.
+   */
+  _resolvePairRequester(requestId, result) {
+    const ws = this._pairRequesters.get(requestId)
+    this._pairRequesters.delete(requestId)
+    if (!ws || ws.readyState !== 1) return
+    this._send(ws, { type: 'pair_result', requestId, ...result })
+  }
+
+  /**
+   * #5510: a requester's connection closed. If it had an outstanding pending
+   * request, remove it from the queue (freeing the slot) and retract the host
+   * banner. No `pair_result` is sent (the socket is gone).
+   */
+  _cleanupPairRequesterOnDisconnect(ws) {
+    if (this._pairRequesters.size === 0) return
+    for (const [requestId, reqWs] of this._pairRequesters) {
+      if (reqWs !== ws) continue
+      this._pairRequesters.delete(requestId)
+      if (this._pairingManager) this._pairingManager.denyPendingRequest(requestId)
+      this._broadcastPairResolved(requestId, 'disconnected')
+    }
   }
 
   /**
@@ -1783,11 +1860,16 @@ export class WsServer {
 
   /** Graceful shutdown */
   close() {
-    // Remove PairingManager listener to prevent post-shutdown broadcasts
+    // Remove PairingManager listeners to prevent post-shutdown broadcasts
     if (this._pairingManager && this._pairingRefreshedHandler) {
       this._pairingManager.off('pairing_refreshed', this._pairingRefreshedHandler)
       this._pairingRefreshedHandler = null
     }
+    if (this._pairingManager && this._pendingRequestExpiredHandler) {
+      this._pairingManager.off('pending_request_expired', this._pendingRequestExpiredHandler)
+      this._pendingRequestExpiredHandler = null
+    }
+    this._pairRequesters.clear()
 
     // Remove TokenManager listener to prevent post-shutdown broadcasts
     if (this._tokenManager && this._tokenRotatedHandler) {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -385,6 +385,10 @@ function _isSecureRequest(req) {
  *   { type: 'discovered_sessions', sessions }           — discovered local Claude sessions
  *   { type: 'pair_fail', reason }                       — pairing failed
  *   { type: 'pairing_refreshed' }                       — pairing ID consumed; clients should re-fetch /qr (#2916)
+ *   { type: 'pair_request_pending', requestId, verifyCode } — pairing-approval primitive (#5510, epic #5509): ack to the camera-less requester carrying the 6-digit code to DISPLAY. Sent only over the requester's own pre-auth connection; the code travels server→requester only and is never echoed back.
+ *   { type: 'pair_pending', requestId, deviceName, verifyCode, expiresAt } — pairing-approval fan-out (#5510) to HOST-LEVEL (unbound) surfaces only; carries the verify code to COMPARE and the attacker-controlled (schema-capped, plain-text) deviceName. Bound/session-scoped clients never receive it.
+ *   { type: 'pair_result', requestId, ok, token?, reason? } — pairing-approval terminal result (#5510) to the requester over its still-open connection. On approve `ok: true` + the unbound (host-authority) session token, delivered exactly once and never logged; on deny/expire/disconnect `ok: false` + reason.
+ *   { type: 'pair_resolved', requestId, reason } — pairing-approval retraction (#5510) to host-level surfaces so every banner drops a request that was approved/denied/expired/disconnected elsewhere.
  *   { type: 'rate_limited', message }                   — client rate-limited
  *   { type: 'agent_spawned', sessionId, agentId, parentToolId, model } — background agent spawned
  *   { type: 'agent_completed', sessionId, agentId, parentToolId }       — background agent completed

--- a/packages/server/tests/pairing-approval-handlers.test.js
+++ b/packages/server/tests/pairing-approval-handlers.test.js
@@ -1,0 +1,180 @@
+/**
+ * Pairing-approval primitive (#5510) — WS handler unit tests.
+ *
+ * Covers the pre-auth `pair_request` handler (ws-auth.js) and the post-auth
+ * host-level `pair_approve` / `pair_deny` handlers (pairing-handlers.js), wired
+ * to a real PairingManager queue. No running WsServer required.
+ */
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { handlePairRequestMessage } from '../src/ws-auth.js'
+import { pairingHandlers } from '../src/handlers/pairing-handlers.js'
+import { PairingManager } from '../src/pairing.js'
+
+function makeMockWs() {
+  const sentRaw = []
+  return {
+    readyState: 1,
+    sentRaw,
+    sent: () => sentRaw.map(s => JSON.parse(s)),
+    closed: false,
+    send(data) { sentRaw.push(typeof data === 'string' ? data : JSON.stringify(data)) },
+    close() { this.closed = true },
+  }
+}
+
+function makeClient({ authenticated = false, boundSessionId = null, ip = '1.2.3.4' } = {}) {
+  return { id: 'c1', authenticated, boundSessionId, socketIp: ip, rateLimitKey: ip }
+}
+
+// Build a pre-auth ctx for handlePairRequestMessage backed by a real manager,
+// recording host fan-out and requester registration.
+function makeRequestCtx({ pairingManager } = {}) {
+  const ws = makeMockWs()
+  const client = makeClient()
+  const clients = new Map([[ws, client]])
+  const hostFanout = []
+  const registered = new Map()
+  const ctx = {
+    clients,
+    pairingManager,
+    send: (socket, msg) => socket.send(JSON.stringify(msg)),
+    registerPairRequester: (requestId, sock) => registered.set(requestId, sock),
+    broadcastPairPending: (msg) => hostFanout.push(msg),
+  }
+  return { ctx, ws, client, hostFanout, registered }
+}
+
+describe('handlePairRequestMessage (#5510 pre-auth)', () => {
+  let pm
+  beforeEach(() => { pm = new PairingManager({ wsUrl: 'wss://x' }) })
+
+  it('queues a request, replies pair_request_pending, and fans pair_pending to hosts', () => {
+    const { ctx, ws, hostFanout, registered } = makeRequestCtx({ pairingManager: pm })
+    const consumed = handlePairRequestMessage(ctx, ws, {
+      type: 'pair_request', requestId: 'req1', deviceName: 'Pixel 8',
+    })
+    assert.equal(consumed, true)
+    const pending = ws.sent().find(m => m.type === 'pair_request_pending')
+    assert.ok(pending, 'requester gets pair_request_pending')
+    assert.match(pending.verifyCode, /^\d{6}$/)
+    assert.equal(ws.closed, false, 'connection stays open')
+    assert.equal(registered.get('req1'), ws, 'requester ws is tracked')
+
+    assert.equal(hostFanout.length, 1)
+    assert.equal(hostFanout[0].type, 'pair_pending')
+    assert.equal(hostFanout[0].deviceName, 'Pixel 8')
+    assert.equal(hostFanout[0].verifyCode, pending.verifyCode, 'same code on both surfaces')
+    pm.destroy()
+  })
+
+  it('rejects when pairing is disabled', () => {
+    const { ctx, ws } = makeRequestCtx({ pairingManager: null })
+    handlePairRequestMessage(ctx, ws, { type: 'pair_request', requestId: 'r', deviceName: 'x' })
+    const res = ws.sent().find(m => m.type === 'pair_result')
+    assert.equal(res.ok, false)
+    assert.equal(res.reason, 'pairing_not_enabled')
+    assert.equal(ws.closed, true)
+  })
+
+  it('rejects an invalid message shape', () => {
+    const { ctx, ws } = makeRequestCtx({ pairingManager: pm })
+    handlePairRequestMessage(ctx, ws, { type: 'pair_request' }) // missing requestId
+    const res = ws.sent().find(m => m.type === 'pair_result')
+    assert.equal(res.ok, false)
+    assert.equal(res.reason, 'invalid_message')
+    assert.equal(ws.closed, true)
+    pm.destroy()
+  })
+
+  it('surfaces queue_full as a terminal pair_result and closes', () => {
+    // Fill the queue to cap (5) directly on the manager.
+    for (let i = 0; i < 5; i++) pm.enqueuePendingRequest({ requestId: `f${i}`, source: `s${i}` })
+    const { ctx, ws } = makeRequestCtx({ pairingManager: pm })
+    handlePairRequestMessage(ctx, ws, { type: 'pair_request', requestId: 'overflow', deviceName: 'n' })
+    const res = ws.sent().find(m => m.type === 'pair_result')
+    assert.equal(res.ok, false)
+    assert.equal(res.reason, 'queue_full')
+    assert.equal(ws.closed, true)
+    pm.destroy()
+  })
+
+  it('ignores an authenticated client (not its job)', () => {
+    const { ctx, ws, client } = makeRequestCtx({ pairingManager: pm })
+    client.authenticated = true
+    assert.equal(handlePairRequestMessage(ctx, ws, { type: 'pair_request', requestId: 'r' }), false)
+    pm.destroy()
+  })
+})
+
+describe('pair_approve / pair_deny (#5510 host-level)', () => {
+  let pm
+  beforeEach(() => { pm = new PairingManager({ wsUrl: 'wss://x' }) })
+
+  function makeApproveCtx() {
+    const resolved = []
+    const broadcasts = []
+    const ctx = {
+      pairingManager: pm,
+      resolvePairRequester: (requestId, result) => resolved.push({ requestId, result }),
+      broadcastPairResolved: (requestId, reason) => broadcasts.push({ requestId, reason }),
+    }
+    return { ctx, resolved, broadcasts }
+  }
+
+  it('approve issues the token to the requester exactly once and retracts banners', async () => {
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    const { ctx, resolved, broadcasts } = makeApproveCtx()
+    const ws = makeMockWs()
+    const client = makeClient({ authenticated: true })
+
+    await pairingHandlers.pair_approve(ws, client, { type: 'pair_approve', requestId: 'r1' }, ctx)
+    assert.equal(resolved.length, 1)
+    assert.equal(resolved[0].result.ok, true)
+    assert.ok(typeof resolved[0].result.token === 'string' && resolved[0].result.token.length > 0)
+    assert.equal(pm.isSessionTokenValid(resolved[0].result.token), true)
+    assert.deepEqual(broadcasts[0], { requestId: 'r1', reason: 'approved' })
+
+    // Second approve is a no-op error — no second token.
+    await pairingHandlers.pair_approve(ws, client, { type: 'pair_approve', requestId: 'r1' }, ctx)
+    assert.equal(resolved.length, 1, 'no second token delivered')
+    const err = ws.sent().find(m => m.type === 'error')
+    assert.ok(err && /already_resolved/.test(err.message))
+  })
+
+  it('rejects a session-bound (non-host) client with FORBIDDEN', async () => {
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    const { ctx, resolved } = makeApproveCtx()
+    const ws = makeMockWs()
+    const client = makeClient({ authenticated: true, boundSessionId: 'sess-A' })
+
+    await pairingHandlers.pair_approve(ws, client, { type: 'pair_approve', requestId: 'r1' }, ctx)
+    const err = ws.sent().find(m => m.type === 'error')
+    assert.equal(err.code, 'FORBIDDEN')
+    assert.equal(resolved.length, 0, 'no token issued for a bound client')
+    // The request is still live — a bound client cannot consume it.
+    assert.ok(pm.getPendingRequest('r1'))
+  })
+
+  it('deny notifies the requester and retracts banners', async () => {
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    const { ctx, resolved, broadcasts } = makeApproveCtx()
+    const ws = makeMockWs()
+    const client = makeClient({ authenticated: true })
+
+    await pairingHandlers.pair_deny(ws, client, { type: 'pair_deny', requestId: 'r1' }, ctx)
+    assert.deepEqual(resolved[0].result, { ok: false, reason: 'denied' })
+    assert.deepEqual(broadcasts[0], { requestId: 'r1', reason: 'denied' })
+    assert.equal(pm.getPendingRequest('r1'), null)
+  })
+
+  it('approve of an unknown request reports the failure reason', async () => {
+    const { ctx, resolved } = makeApproveCtx()
+    const ws = makeMockWs()
+    const client = makeClient({ authenticated: true })
+    await pairingHandlers.pair_approve(ws, client, { type: 'pair_approve', requestId: 'ghost' }, ctx)
+    const err = ws.sent().find(m => m.type === 'error')
+    assert.ok(err && /not_found/.test(err.message))
+    assert.equal(resolved.length, 0)
+  })
+})

--- a/packages/server/tests/pairing-approval-queue.test.js
+++ b/packages/server/tests/pairing-approval-queue.test.js
@@ -1,0 +1,170 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+
+// #5510 (epic #5509) — pairing-approval primitive: the pending-request queue
+// on PairingManager. Bounded by cap + TTL + per-source rate limit; approve
+// issues a token EXACTLY once; the verify code only travels server→surfaces.
+describe('PairingManager pending-request queue (#5510)', () => {
+  let PairingManager
+
+  before(async () => {
+    ({ PairingManager } = await import('../src/pairing.js'))
+  })
+
+  function mk(opts = {}) {
+    return new PairingManager({ wsUrl: 'wss://example.com', ...opts })
+  }
+
+  it('enqueues a request and returns a 6-digit verify code + expiry', () => {
+    const pm = mk()
+    const r = pm.enqueuePendingRequest({ requestId: 'r1', deviceName: 'iPhone', source: '1.1.1.1' })
+    assert.equal(r.ok, true)
+    assert.match(r.verifyCode, /^\d{6}$/, 'verify code is 6 digits')
+    assert.ok(r.expiresAt > Date.now(), 'expiresAt is in the future')
+    pm.destroy()
+  })
+
+  it('rejects a missing/empty requestId', () => {
+    const pm = mk()
+    assert.equal(pm.enqueuePendingRequest({ requestId: '', source: 'x' }).reason, 'invalid')
+    assert.equal(pm.enqueuePendingRequest({ source: 'x' }).reason, 'invalid')
+    pm.destroy()
+  })
+
+  it('clamps an over-long deviceName to 64 chars', () => {
+    const pm = mk()
+    pm.enqueuePendingRequest({ requestId: 'r1', deviceName: 'A'.repeat(200), source: 's' })
+    const snap = pm.getPendingRequest('r1')
+    assert.equal(snap.deviceName.length, 64)
+    pm.destroy()
+  })
+
+  it('caps the queue at 5 pending and rejects the 6th with queue_full', () => {
+    const pm = mk()
+    for (let i = 0; i < 5; i++) {
+      assert.equal(pm.enqueuePendingRequest({ requestId: `r${i}`, source: `src${i}` }).ok, true)
+    }
+    const r = pm.enqueuePendingRequest({ requestId: 'r6', source: 'src6' })
+    assert.equal(r.ok, false)
+    assert.equal(r.reason, 'queue_full')
+    pm.destroy()
+  })
+
+  it('rate-limits a single source after 5 requests in the window', () => {
+    const pm = mk()
+    // Same source — but each needs a distinct requestId. Approve to free queue
+    // slots so the cap does not mask the rate limit.
+    for (let i = 0; i < 5; i++) {
+      const res = pm.enqueuePendingRequest({ requestId: `q${i}`, source: 'noisy' })
+      assert.equal(res.ok, true)
+      pm.approvePendingRequest(`q${i}`)
+    }
+    const r = pm.enqueuePendingRequest({ requestId: 'q5', source: 'noisy' })
+    assert.equal(r.ok, false)
+    assert.equal(r.reason, 'rate_limited')
+    pm.destroy()
+  })
+
+  it('rejects a duplicate requestId', () => {
+    const pm = mk()
+    assert.equal(pm.enqueuePendingRequest({ requestId: 'dup', source: 'a' }).ok, true)
+    const r = pm.enqueuePendingRequest({ requestId: 'dup', source: 'b' })
+    assert.equal(r.ok, false)
+    assert.equal(r.reason, 'duplicate_request')
+    pm.destroy()
+  })
+
+  it('expires a pending request after its TTL', () => {
+    const pm = mk({ pendingTtlMs: 1 })
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    // Force time past TTL by reaching into the entry (no fake timers).
+    const entry = pm._pendingRequests.get('r1')
+    entry.expiresAt = Date.now() - 1
+    assert.equal(pm.getPendingRequest('r1'), null, 'expired request is not returned')
+    assert.equal(pm.approvePendingRequest('r1').reason, 'expired')
+    pm.destroy()
+  })
+
+  it('emits pending_request_expired on sweep', () => {
+    const pm = mk({ pendingTtlMs: 1 })
+    let fired = null
+    pm.on('pending_request_expired', (e) => { fired = e })
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    pm._pendingRequests.get('r1').expiresAt = Date.now() - 1
+    pm._sweepPending()
+    assert.deepEqual(fired, { requestId: 'r1' })
+    pm.destroy()
+  })
+
+  it('approve issues a session token EXACTLY once', () => {
+    const pm = mk()
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    const first = pm.approvePendingRequest('r1')
+    assert.equal(first.ok, true)
+    assert.ok(typeof first.token === 'string' && first.token.length > 0)
+    assert.equal(pm.isSessionTokenValid(first.token), true, 'issued token validates')
+
+    const second = pm.approvePendingRequest('r1')
+    assert.equal(second.ok, false)
+    assert.equal(second.reason, 'already_resolved')
+    assert.equal(second.token, undefined, 'no second token minted')
+    pm.destroy()
+  })
+
+  it('issued token is unbound (host-authority — sessionId null)', () => {
+    const pm = mk()
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    const { token } = pm.approvePendingRequest('r1')
+    assert.equal(pm.getSessionIdForToken(token), null)
+    pm.destroy()
+  })
+
+  it('deny removes the request and is idempotent', () => {
+    const pm = mk()
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    assert.equal(pm.denyPendingRequest('r1'), true)
+    assert.equal(pm.getPendingRequest('r1'), null)
+    assert.equal(pm.denyPendingRequest('r1'), false, 'second deny is a no-op')
+    // Approving a denied request must not mint a token.
+    assert.equal(pm.approvePendingRequest('r1').ok, false)
+    pm.destroy()
+  })
+
+  it('approve after not-found returns not_found', () => {
+    const pm = mk()
+    assert.equal(pm.approvePendingRequest('nope').reason, 'not_found')
+    pm.destroy()
+  })
+
+  it('the verify code never leaves the manager via getSessionIdForToken/snapshots and is opaque to the requester', () => {
+    // By construction: approvePendingRequest takes only requestId — no code is
+    // ever accepted from a caller, so a requester cannot influence it.
+    const pm = mk()
+    const { verifyCode } = pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    const snap = pm.getPendingRequest('r1')
+    assert.equal(snap.verifyCode, verifyCode, 'surfaces see the same server-generated code')
+    // approve signature accepts exactly one arg (requestId)
+    assert.equal(pm.approvePendingRequest.length, 1)
+    pm.destroy()
+  })
+
+  it('listPendingRequests returns only live entries', () => {
+    const pm = mk()
+    pm.enqueuePendingRequest({ requestId: 'a', source: 's1' })
+    pm.enqueuePendingRequest({ requestId: 'b', source: 's2' })
+    pm.denyPendingRequest('a')
+    const live = pm.listPendingRequests()
+    assert.equal(live.length, 1)
+    assert.equal(live[0].requestId, 'b')
+    pm.destroy()
+  })
+
+  it('destroy clears the queue and the sweep timer', () => {
+    const pm = mk()
+    pm.enqueuePendingRequest({ requestId: 'r1', source: 's' })
+    pm.destroy()
+    assert.equal(pm._pendingRequests.size, 0)
+    assert.equal(pm._sweepTimer, null)
+    assert.equal(pm.enqueuePendingRequest({ requestId: 'r2', source: 's' }).reason, 'invalid')
+  })
+})


### PR DESCRIPTION
## What

Foundation primitive for epic #5509 — a camera-less device requests pairing without a QR/URL, and the user approves it from a surface they already trust (the host dashboard). Possession of a link/code is never sufficient unless the code was read off the host's own screen.

## Flow

1. New client sends pre-auth `pair_request { deviceName, requestId }` — same exposure class as the existing `pair` message (unauthenticated, rate-limited, queue-capped, TTL'd), kept open to await the result.
2. Server queues it, assigns a **6-digit verify code**, replies `pair_request_pending { verifyCode, requestId }` to the requester, and fans `pair_pending { deviceName, verifyCode, requestId, expiresAt }` out to **host-level** (unbound) clients.
3. Host operator compares the code on the new device with the banner and sends `pair_approve { requestId }` / `pair_deny { requestId }`.
4. Approve issues a session token via PairingManager's existing machinery (unbound — host authority, same class/TTL as QR pairing) and delivers `pair_result { ok: true, token }` over the requester's still-open connection. Deny / timeout / disconnect → `pair_result { ok: false, reason }`; a gone requester just has its queue entry dropped. `pair_resolved` retracts the banner on every other host surface.

## DoS bounds

The pending queue is an unauthenticated-fed state allocator, so it is hard-bounded on three axes: a global cap (5 pending), a per-request TTL (120s), and a per-source rolling rate limit. Expired entries are swept on an `unref()`'d interval that is cleared on `close()` and when the queue drains (no new leaked timers — verified with `--test-force-exit`).

## Authority gates

- `pair_approve` / `pair_deny` require **host-level authority** — a session-bound (share-a-session) token is rejected with `FORBIDDEN`, exactly like `host_status_request`. The issued token is unbound (host authority), since approval grants a brand-new device host-wide access. Follows the docs/security/bearer-token-authority.md §9 checklist.
- Approve issues the token **exactly once** — the request is marked resolved before minting, so a double-approve is a no-op error (`already_resolved`).

## Security

- The verify code travels **only** server→surfaces (requester displays it; approver compares it). The requester never echoes it back, so a mismatch is impossible by construction.
- `deviceName` is attacker-controlled — length-capped (64) at the schema and treated as plain text everywhere (React escapes on render; never interpolated into a server log format). The issued token is never logged.

## Surfaces (v1)

- **Approval (dashboard):** `pendingPairRequests` store slice fed by `pair_pending`/`pair_resolved`, plus a `PendingPairRequests` banner (device name + verify code prominent, Approve/Deny). Approve/Deny send `{ type, requestId }` only.
- **Requester (dashboard):** `ServerPicker` "Request to pair" path (`request-pairing.ts` + `RequestPairPanel`) for a known `wss://` URL — states: requesting / code-shown / approved+connected / denied / expired. On approval the issued token is stored exactly like the `chroxy://?pair=` flow (addServer + switchServer).

## Tests

- Server: `pairing-approval-queue.test.js` (15) — cap/TTL/rate-limit, approve-once, deny, expiry sweep, unbound token, destroy. `pairing-approval-handlers.test.js` (9) — pre-auth `pair_request` (pending + host fan-out + open connection), approve/deny, host-authority reject. Plus ws-auth / schema-coverage / message-handler suites stay green.
- Dashboard: `dispatch-pair-pending.test.ts`, `pair-approve-actions.test.ts`, `request-pairing.test.ts`, `PendingPairRequests.test.tsx` (incl. an HTML-injection assertion on `deviceName`).
- Protocol: full suite green; dist rebuilt + committed.

## Out of scope (fast-follows)

- **Mobile push approve** — reuse the permission-prompt push path in `push.js` so an already-paired phone can approve. The push infra exists; deferred to keep this PR focused on the host/dashboard round-trip.
- **Desktop tray approve surface** — a native tray approve/deny for the primitive.
- Mobile *requester* side (the app adopting "Request to pair").

Closes #5510.
Related to #5509.