### PR TITLE
perf(app): terminal WebView writes via postMessage instead of injectJavaScript

### DIFF
--- a/packages/app/jest.setup.js
+++ b/packages/app/jest.setup.js
@@ -65,14 +65,37 @@ jest.mock('@expo/vector-icons', () => {
   };
 });
 
-// Mock react-native-webview (native module not available in Jest)
+// Mock react-native-webview (native module not available in Jest).
+// The imperative handle exposes stable jest.fn()s (postMessage/injectJavaScript)
+// and the latest instance is published on global.__lastWebViewInstance so render
+// tests can inspect the messages RN sent into the WebView and simulate the
+// WebView -> RN bridge by invoking the onMessage prop.
 jest.mock('react-native-webview', () => {
   const React = require('react');
   const { View } = require('react-native');
   const WebView = React.forwardRef((props, ref) => {
-    React.useImperativeHandle(ref, () => ({
-      injectJavaScript: jest.fn(),
-    }));
+    const instanceRef = React.useRef(null);
+    if (!instanceRef.current) {
+      instanceRef.current = {
+        postMessage: jest.fn(),
+        injectJavaScript: jest.fn(),
+        reload: jest.fn(),
+        // Captured onMessage prop so tests can drive the WebView -> RN bridge.
+        emitMessage: (data) => {
+          if (props.onMessage) {
+            props.onMessage({ nativeEvent: { data } });
+          }
+        },
+      };
+    }
+    // Keep emitMessage bound to the current onMessage prop.
+    instanceRef.current.emitMessage = (data) => {
+      if (props.onMessage) {
+        props.onMessage({ nativeEvent: { data } });
+      }
+    };
+    React.useImperativeHandle(ref, () => instanceRef.current);
+    global.__lastWebViewInstance = instanceRef.current;
     return React.createElement(View, { testID: 'webview', ...props });
   });
   WebView.displayName = 'WebView';

--- a/packages/app/src/__tests__/components/TerminalView.test.tsx
+++ b/packages/app/src/__tests__/components/TerminalView.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * TerminalView postMessage bridge tests (#5519)
+ *
+ * The mobile TerminalView delivers batched terminal writes to the embedded
+ * xterm WebView via `webViewRef.postMessage(...)` rather than serializing into
+ * a JS string and `injectJavaScript`-evaluating it. This test proves:
+ *
+ *  1. writes are delivered through postMessage (not injectJavaScript),
+ *  2. clear() is delivered through postMessage,
+ *  3. escaping-sensitive content (quotes, backticks, backslashes, ANSI escape
+ *     sequences, emoji / UTF-16 surrogate pairs) round-trips byte-identical
+ *     across the RN -> WebView bridge — the class of bug that string-eval
+ *     injection invites,
+ *  4. writes arriving before the WebView signals `ready` are queued and
+ *     flushed (in order) once ready, with no data loss.
+ *
+ * The WebView is mocked in jest.setup.js. The mock captures every postMessage
+ * payload and lets the test drive the WebView -> RN bridge (the `ready`
+ * handshake) by invoking the onMessage prop. The page-side parse is exactly
+ * `JSON.parse(e.data)` (see xterm-html.ts handleMsg), so we decode captured
+ * payloads the same way to assert the terminal would have received identical
+ * bytes.
+ */
+import React from 'react';
+import { create, act, ReactTestRenderer } from 'react-test-renderer';
+import { TerminalView, TerminalHandle } from '../../components/TerminalView';
+
+interface MockWebViewInstance {
+  postMessage: jest.Mock;
+  injectJavaScript: jest.Mock;
+  emitMessage: (data: string) => void;
+}
+
+function getWebView(): MockWebViewInstance {
+  return (global as unknown as { __lastWebViewInstance: MockWebViewInstance })
+    .__lastWebViewInstance;
+}
+
+// Decode a captured RN->WebView postMessage payload the way the embedded
+// xterm page does (handleMsg: JSON.parse(e.data)).
+function decode(payload: string): { type: string; data?: string } {
+  return JSON.parse(payload);
+}
+
+function renderTerminal(): {
+  renderer: ReactTestRenderer;
+  handleRef: React.RefObject<TerminalHandle | null>;
+} {
+  const handleRef = React.createRef<TerminalHandle>();
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(<TerminalView ref={handleRef} />);
+  });
+  return { renderer, handleRef };
+}
+
+function markReady(): void {
+  act(() => {
+    getWebView().emitMessage(
+      JSON.stringify({ type: 'ready', cols: 80, rows: 24 }),
+    );
+  });
+}
+
+describe('TerminalView postMessage bridge (#5519)', () => {
+  it('delivers writes via postMessage, not injectJavaScript', () => {
+    const { handleRef } = renderTerminal();
+    markReady();
+    const wv = getWebView();
+    wv.postMessage.mockClear();
+
+    act(() => {
+      handleRef.current!.write('hello world');
+    });
+
+    expect(wv.injectJavaScript).not.toHaveBeenCalled();
+    expect(wv.postMessage).toHaveBeenCalledTimes(1);
+    const msg = decode(wv.postMessage.mock.calls[0][0]);
+    expect(msg).toEqual({ type: 'write', data: 'hello world' });
+  });
+
+  it('delivers clear via postMessage', () => {
+    const { handleRef } = renderTerminal();
+    markReady();
+    const wv = getWebView();
+    wv.postMessage.mockClear();
+
+    act(() => {
+      handleRef.current!.clear();
+    });
+
+    expect(wv.injectJavaScript).not.toHaveBeenCalled();
+    expect(wv.postMessage).toHaveBeenCalledTimes(1);
+    expect(decode(wv.postMessage.mock.calls[0][0])).toEqual({ type: 'clear' });
+  });
+
+  describe('escaping-sensitive content round-trips byte-identical', () => {
+    const cases: Array<[string, string]> = [
+      ['double quotes', 'echo "hello"'],
+      ['single quotes', "echo 'world'"],
+      ['backticks', 'echo `whoami` and ```fence```'],
+      ['backslashes', 'C:\\path\\to\\file and \\n literal'],
+      ['dollar template', 'price is ${value} and $HOME'],
+      ['newlines and tabs', 'line1\nline2\tcol\r\n'],
+      ['ANSI color sequence', '\x1b[31mred\x1b[0m \x1b[1;32mgreen\x1b[0m'],
+      ['ANSI cursor + clear', '\x1b[2J\x1b[H\x1b[?25l'],
+      ['emoji surrogate pairs', 'done 🎉 fire 🔥 family 👨‍👩‍👧‍👦'],
+      ['lone-ish high codepoints', '𝕳𝖊𝖑𝖑𝖔 \u{1F600}'],
+      ['null and control bytes', 'a\x00b\x07c\x08d'],
+      ['mixed shell + ansi + emoji', '\x1b[33m$ git commit -m "fix: \\`bug\\`"\x1b[0m 🚀'],
+      ['html-ish injection attempt', '</script><script>alert(1)</script>'],
+      ['unicode whitespace', 'a b c d'],
+    ];
+
+    it.each(cases)('round-trips: %s', (_label, input) => {
+      const { handleRef } = renderTerminal();
+      markReady();
+      const wv = getWebView();
+      wv.postMessage.mockClear();
+
+      act(() => {
+        handleRef.current!.write(input);
+      });
+
+      expect(wv.postMessage).toHaveBeenCalledTimes(1);
+      const decoded = decode(wv.postMessage.mock.calls[0][0]);
+      expect(decoded.type).toBe('write');
+      // Byte-identical: the terminal receives exactly what we wrote.
+      expect(decoded.data).toBe(input);
+      // Code-unit-level equality guard against any silent normalization.
+      expect([...(decoded.data ?? '')].map((c) => c.codePointAt(0))).toEqual(
+        [...input].map((c) => c.codePointAt(0)),
+      );
+    });
+  });
+
+  it('queues writes before ready and flushes them in order once ready', () => {
+    const { handleRef } = renderTerminal();
+    const wv = getWebView();
+
+    // No ready yet — these must be buffered, not sent.
+    act(() => {
+      handleRef.current!.write('first ');
+      handleRef.current!.write('"second" ');
+      handleRef.current!.write('🔥 third');
+    });
+    expect(wv.postMessage).not.toHaveBeenCalled();
+    expect(wv.injectJavaScript).not.toHaveBeenCalled();
+
+    // Ready handshake flushes the queue.
+    markReady();
+
+    expect(wv.postMessage).toHaveBeenCalledTimes(1);
+    const decoded = decode(wv.postMessage.mock.calls[0][0]);
+    expect(decoded).toEqual({ type: 'write', data: 'first "second" 🔥 third' });
+  });
+
+  it('drops queued writes on clear before ready', () => {
+    const { handleRef } = renderTerminal();
+    const wv = getWebView();
+
+    act(() => {
+      handleRef.current!.write('buffered');
+      handleRef.current!.clear();
+    });
+
+    markReady();
+
+    // clear() emptied the pending buffer; nothing to flush, and clear() before
+    // ready does not post (matches existing semantics).
+    expect(wv.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -34,37 +34,35 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
     };
   }, []);
 
-  const injectWrite = useCallback((data: string) => {
-    if (!webViewRef.current) return;
-    // Escape for safe injection into JS string literal
-    const escaped = JSON.stringify(data);
-    webViewRef.current.injectJavaScript(
-      `try{handleMsg({data:JSON.stringify({type:'write',data:${escaped}})})}catch(e){};true;`
-    );
+  // Deliver a write to the embedded xterm page via postMessage. The page's
+  // `message` listener (see xterm-html.ts handleMsg) parses the payload with
+  // JSON.parse(e.data), so JSON.stringify here makes the data round-trip
+  // byte-identical — quotes, backticks, backslashes, ANSI escapes and
+  // emoji/UTF-16 surrogate pairs survive without the string-eval escaping
+  // hazards of injectJavaScript (#5519).
+  const postWrite = useCallback((data: string) => {
+    webViewRef.current?.postMessage(JSON.stringify({ type: 'write', data }));
   }, []);
 
-  const injectClear = useCallback(() => {
-    if (!webViewRef.current) return;
-    webViewRef.current.injectJavaScript(
-      `try{handleMsg({data:JSON.stringify({type:'clear'})})}catch(e){};true;`
-    );
+  const postClear = useCallback(() => {
+    webViewRef.current?.postMessage(JSON.stringify({ type: 'clear' }));
   }, []);
 
   useImperativeHandle(ref, () => ({
     write(data: string) {
       if (readyRef.current) {
-        injectWrite(data);
+        postWrite(data);
       } else {
         pendingWritesRef.current.push(data);
       }
     },
     clear() {
       if (readyRef.current) {
-        injectClear();
+        postClear();
       }
       pendingWritesRef.current = [];
     },
-  }), [injectWrite, injectClear]);
+  }), [postWrite, postClear]);
 
   const handleMessage = useCallback((event: WebViewMessageEvent) => {
     try {
@@ -80,7 +78,7 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
         const pending = pendingWritesRef.current;
         pendingWritesRef.current = [];
         if (pending.length > 0) {
-          injectWrite(pending.join(''));
+          postWrite(pending.join(''));
         }
         onReady?.();
         // Forward initial dimensions so the PTY is sized correctly on mount/reload
@@ -93,7 +91,7 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
     } catch {
       // Ignore malformed messages
     }
-  }, [injectWrite, onReady, onResize]);
+  }, [postWrite, onReady, onResize]);
 
   // Crash recovery: reload WebView when the OS kills the content process
   const handleWebViewCrash = useCallback(() => {

--- a/packages/app/src/components/xterm-html.ts
+++ b/packages/app/src/components/xterm-html.ts
@@ -103,6 +103,11 @@ export function buildXtermHtml(): string {
     handleMsg(e);
   });
 
+  // Handles RN -> WebView messages delivered via webViewRef.postMessage(...).
+  // e.data is the raw string RN sent; we JSON.parse it back to the bridge
+  // message. This makes terminal writes round-trip byte-identical (quotes,
+  // backticks, backslashes, ANSI escapes, emoji/UTF-16 surrogates) without the
+  // string-eval escaping hazards injectJavaScript invited (#5519).
   function handleMsg(e) {
     try {
       var msg = JSON.parse(e.data);
@@ -121,9 +126,6 @@ export function buildXtermHtml(): string {
       // Ignore malformed messages
     }
   }
-
-  // Expose handleMsg globally so injectJavaScript can call it from RN
-  window.handleMsg = handleMsg;
 })();
 <\/script>
 </body>


### PR DESCRIPTION
## Summary

The mobile `TerminalView` delivered each batched terminal write by serializing it into a JS string and evaluating it with `injectJavaScript` (`packages/app/src/components/TerminalView.tsx:41-45`), which called `window.handleMsg` in the embedded xterm page. This switches to `webViewRef.postMessage(...)`.

The embedded xterm page (`xterm-html.ts`) **already** listens for `message` / `document message` events and parses `e.data` with `JSON.parse` in `handleMsg` — so the page side needed no new listener, just removal of the now-unused `window.handleMsg` global exposure that only existed for `injectJavaScript` to reach.

This removes the per-write string-eval overhead and the escaping hazard that string-eval injection invites. The terminal write data now round-trips as a plain JSON-serialized payload.

## What changed

- **`TerminalView.tsx`** — `postWrite`/`postClear` send `JSON.stringify({type, data})` via `webViewRef.postMessage`. The early-write **queue + flush-on-ready** and **clear-empties-buffer** semantics are unchanged (writes before `ready` are buffered and flushed in order; `clear()` before ready drops the buffer and does not post).
- **`xterm-html.ts`** — dropped the unused `window.handleMsg` global; updated the bridge comment.
- **`jest.setup.js`** — the `react-native-webview` mock now exposes stable `postMessage`/`injectJavaScript` `jest.fn()`s and publishes the latest instance on `global.__lastWebViewInstance`, so render tests can inspect outbound messages and drive the WebView→RN `ready` handshake via the captured `onMessage` prop.
- **`TerminalView.test.tsx`** (new) — render-based TDD test (failing-first → passing).

## Out of scope (unchanged, per issue)

- The **50ms client-side terminal write batching** in `packages/app/src/store/message-handler.ts` (`appendPendingTerminalWrite`/`flushTerminalWrites`) is untouched.
- **Dashboard `TerminalView`** is untouched.

## Tests

- New `TerminalView.test.tsx`: 18 tests. Proves writes/clear go via `postMessage` (not `injectJavaScript`), and that **escaping-sensitive content round-trips byte-identical** — quotes, backticks, backslashes, `${}` templates, ANSI color/cursor/clear sequences, emoji + ZWJ surrogate pairs, high codepoints, NUL/control bytes, and an HTML/script-injection attempt — decoded the same way the page does (`JSON.parse(e.data)`), with a code-point-level equality guard against silent normalization. Plus the pre-ready queue/flush/drop behaviour.
- App **jest**: 117 suites / **1653 tests pass** (the `expo-notifications` Expo-Go warning + worker force-exit are pre-existing, unrelated).
- App **tsc** (`--noEmit`): **0 errors**.

### Note on the pre-existing `xterm-bundle.generated` tsc error

The flagged pre-existing tsc error in `xterm-bundle.generated` did **not** surface here — that file is gitignored and regenerated fresh by the `bundle-xterm` postinstall, so tsc was clean (exit 0). No change was made to chase it.

### Maestro

The terminal Maestro flow (`packages/app/.maestro/`) was **not** run — it needs a booted simulator + dev client + Metro, which isn't available in this environment. **The terminal Maestro flow should be run before release** to confirm output renders identically end-to-end.

Closes #5519.

Related to #5514.