### PR TITLE
feat: typeable short pairing code — host display + dashboard entry

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -606,6 +606,10 @@ export function App() {
   const [qrSvg, setQrSvg] = useState<string | null>(null)
   const [qrLoading, setQrLoading] = useState(false)
   const [qrError, setQrError] = useState<string | null>(null)
+  // #5512 — the typeable short pairing code shown beside the linking-mode QR so
+  // camera-less devices can type it instead of scanning. The QR encodes the same
+  // id. Null for per-session "Share" QRs (those carry a session-bound token).
+  const [qrPairingCode, setQrPairingCode] = useState<string | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(() => {
     const params = new URLSearchParams(window.location.search)
     return params.get('settings') === '1'
@@ -1534,24 +1538,36 @@ export function App() {
     setQrLoading(true)
     setQrError(null)
     setQrSvg(null)
+    setQrPairingCode(null)
     const token = getAuthToken()
     if (!token) {
       setQrLoading(false)
       setQrError('No auth token available')
       return
     }
+    // The typeable code (#5512) only applies to the linking-mode QR — per-session
+    // "Share" QRs (/qr/session/…) issue a session-bound token with no displayed
+    // code. Fetch the code in parallel with the QR for the linking-mode path.
+    const isLinkingQr = path === '/qr'
     try {
-      const res = await fetch(path, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({ error: 'Request failed' }))
-        setQrError(body.error || `HTTP ${res.status}`)
+      const [qrRes, codeRes] = await Promise.all([
+        fetch(path, { headers: { Authorization: `Bearer ${token}` } }),
+        isLinkingQr
+          ? fetch('/pairing-code', { headers: { Authorization: `Bearer ${token}` } }).catch(() => null)
+          : Promise.resolve(null),
+      ])
+      if (!qrRes.ok) {
+        const body = await qrRes.json().catch(() => ({ error: 'Request failed' }))
+        setQrError(body.error || `HTTP ${qrRes.status}`)
         setQrSvg(null)
       } else {
-        const svg = await res.text()
+        const svg = await qrRes.text()
         setQrSvg(svg)
         setQrError(null)
+      }
+      if (codeRes && codeRes.ok) {
+        const body = await codeRes.json().catch(() => null)
+        if (body?.code) setQrPairingCode(String(body.code))
       }
     } catch (err) {
       setQrError(err instanceof Error ? err.message : 'Failed to fetch QR code')
@@ -2816,6 +2832,7 @@ export function App() {
             ? 'Scan to chat into this session only — the scanner cannot list, switch, or destroy other sessions.'
             : 'Scan with Chroxy app to pair your phone'
         }
+        pairingCode={qrShareMode === 'share' ? null : qrPairingCode}
       />
 
       {/* #3209: SkillsPanel — popover for manual-skill toggles + #3205 metadata */}

--- a/packages/dashboard/src/components/QrModal.test.tsx
+++ b/packages/dashboard/src/components/QrModal.test.tsx
@@ -55,6 +55,19 @@ describe('QrModal', () => {
     expect(screen.getByText(/Scan with Chroxy app/)).toBeInTheDocument()
   })
 
+  it('shows the typeable pairing code beside the QR (#5512)', () => {
+    const svg = '<svg><rect/></svg>'
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} pairingCode="ABCD2345" />)
+    expect(screen.getByTestId('qr-pairing-code')).toBeInTheDocument()
+    expect(screen.getByTestId('qr-pairing-code-value')).toHaveTextContent('ABCD2345')
+  })
+
+  it('omits the pairing code when none is provided (#5512)', () => {
+    const svg = '<svg><rect/></svg>'
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} />)
+    expect(screen.queryByTestId('qr-pairing-code')).not.toBeInTheDocument()
+  })
+
   it('closes on Escape key (#1549)', () => {
     const onClose = vi.fn()
     render(<QrModal open={true} onClose={onClose} qrSvg={null} loading={false} />)

--- a/packages/dashboard/src/components/QrModal.tsx
+++ b/packages/dashboard/src/components/QrModal.tsx
@@ -18,6 +18,12 @@ export interface QrModalProps {
   title?: string
   /** Body line shown under the QR — defaults to the link-mode text. */
   instructions?: string
+  /**
+   * Typeable short pairing code shown beside the QR (#5512). The QR encodes the
+   * SAME id, so a camera-less device can type this code instead of scanning.
+   * Omitted for per-session "Share" QRs (those issue a session-bound token).
+   */
+  pairingCode?: string | null
 }
 
 export function QrModal({
@@ -28,6 +34,7 @@ export function QrModal({
   error,
   title = 'Pair Mobile App',
   instructions = 'Scan with Chroxy app to pair your phone',
+  pairingCode = null,
 }: QrModalProps) {
   return (
     <Modal open={open} onClose={onClose} title={title} maxWidth="400px">
@@ -58,6 +65,14 @@ export function QrModal({
           <p className="qr-modal-instructions">
             {instructions}
           </p>
+          {pairingCode && (
+            <div className="qr-modal-code" data-testid="qr-pairing-code">
+              <span className="qr-modal-code-label">Or type this code:</span>
+              <code className="qr-modal-code-value" data-testid="qr-pairing-code-value">
+                {pairingCode}
+              </code>
+            </div>
+          )}
         </div>
       )}
     </Modal>

--- a/packages/dashboard/src/components/ServerPicker.test.tsx
+++ b/packages/dashboard/src/components/ServerPicker.test.tsx
@@ -588,4 +588,63 @@ describe('ServerPicker', () => {
       expect(mockSwitchServer).toHaveBeenCalledWith('srv_new')
     })
   })
+
+  describe('Have a code? entry (#5512)', () => {
+    it('opens the code-entry panel from the header button', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-have-code-btn'))
+      expect(screen.getByTestId('have-code-form')).toBeTruthy()
+      expect(screen.getByTestId('have-code-host-input')).toBeTruthy()
+      expect(screen.getByTestId('have-code-code-input')).toBeTruthy()
+    })
+
+    it('pairs via the same path as a chroxy://?pair= URL (LAN host:port)', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-have-code-btn'))
+      fireEvent.change(screen.getByTestId('have-code-host-input'), { target: { value: '192.168.1.5:8765' } })
+      fireEvent.change(screen.getByTestId('have-code-code-input'), { target: { value: 'abcd-2345' } })
+      fireEvent.click(screen.getByTestId('have-code-submit'))
+      // Code normalized (uppercased, dashes stripped); LAN ws inferred from the port.
+      expect(mockPairServer).toHaveBeenCalledWith('192.168.1.5:8765', 'ws://192.168.1.5:8765/ws', 'ABCD2345')
+      expect(mockAddServer).not.toHaveBeenCalled()
+    })
+
+    it('infers wss for a bare tunnel host', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-have-code-btn'))
+      fireEvent.change(screen.getByTestId('have-code-host-input'), { target: { value: 'my.tunnel.tld' } })
+      fireEvent.change(screen.getByTestId('have-code-code-input'), { target: { value: 'WXYZ2345' } })
+      fireEvent.click(screen.getByTestId('have-code-submit'))
+      expect(mockPairServer).toHaveBeenCalledWith('my.tunnel.tld', 'wss://my.tunnel.tld/ws', 'WXYZ2345')
+    })
+
+    it('disables Pair until both host and code are entered', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-have-code-btn'))
+      expect((screen.getByTestId('have-code-submit') as HTMLButtonElement).disabled).toBe(true)
+      fireEvent.change(screen.getByTestId('have-code-host-input'), { target: { value: 'my.tunnel.tld' } })
+      expect((screen.getByTestId('have-code-submit') as HTMLButtonElement).disabled).toBe(true)
+      fireEvent.change(screen.getByTestId('have-code-code-input'), { target: { value: 'ABCD2345' } })
+      expect((screen.getByTestId('have-code-submit') as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    it('shows a legible error for an unparsable host', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-have-code-btn'))
+      // A code that normalizes to empty (only separators) fails parse though the
+      // raw input is non-blank, so the disabled-guard passes but parse returns null.
+      fireEvent.change(screen.getByTestId('have-code-host-input'), { target: { value: 'my.tunnel.tld' } })
+      fireEvent.change(screen.getByTestId('have-code-code-input'), { target: { value: '- - -' } })
+      fireEvent.click(screen.getByTestId('have-code-submit'))
+      expect(screen.getByTestId('have-code-error')).toBeTruthy()
+      expect(mockPairServer).not.toHaveBeenCalled()
+    })
+
+    it('cancels the code panel', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-have-code-btn'))
+      fireEvent.click(screen.getByTestId('have-code-cancel'))
+      expect(screen.queryByTestId('have-code-form')).toBeNull()
+    })
+  })
 })

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -9,7 +9,7 @@ import { useConnectionStore } from '../store/connection'
 import type { ServerEntry, ConnectionPhase } from '../store/types'
 import { isTauri } from '../utils/tauri'
 import { discoverLanServers, type DiscoveredServer } from '../utils/discovery'
-import { parsePairingUrl } from '../utils/pairing'
+import { parsePairingUrl, parsePairingCodeEntry } from '../utils/pairing'
 import { requestPairing, type PairRequestState, type PairRequestHandle } from '../utils/request-pairing'
 
 function statusDot(phase: ConnectionPhase, isActive: boolean): string {
@@ -266,6 +266,86 @@ function RequestPairPanel({ wsUrl, name, onApproved, onCancel }: RequestPairPane
   )
 }
 
+interface HaveCodePanelProps {
+  /** Pair via host + typed code — same path as the chroxy://?pair= flow (#5512). */
+  onPair: (name: string, wsUrl: string, pairingId: string) => void
+  onCancel: () => void
+}
+
+/**
+ * HaveCodePanel — the camera-less "Have a code?" entry (#5512, epic #5509). The
+ * host displays a short typeable code (read off its OWN screen → physical presence,
+ * so no extra approval, matching QR trust). The user types the host + code here;
+ * `parsePairingCodeEntry` synthesizes the same `chroxy://host?pair=<code>` request
+ * the QR/paste path builds, so this drives the identical pairing handshake. A
+ * bad/expired code is rejected SERVER-SIDE and surfaces as a `pair_fail` alert.
+ */
+function HaveCodePanel({ onPair, onCancel }: HaveCodePanelProps) {
+  const [host, setHost] = useState('')
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = useCallback((e?: React.FormEvent) => {
+    e?.preventDefault()
+    const parsed = parsePairingCodeEntry(host, code)
+    if (!parsed?.pairingId) {
+      setError('Enter the host (e.g. my.tunnel.tld or 192.168.1.5:8765) and the code shown on it.')
+      return
+    }
+    setError(null)
+    let name = parsed.wsUrl
+    try { name = new URL(parsed.wsUrl).host } catch { /* keep wsUrl */ }
+    onPair(name, parsed.wsUrl, parsed.pairingId)
+  }, [host, code, onPair])
+
+  return (
+    <form className="server-add-form" data-testid="have-code-form" onSubmit={handleSubmit}>
+      <input
+        type="text"
+        placeholder="Host (e.g. my.tunnel.tld or 192.168.1.5:8765)"
+        value={host}
+        onChange={e => setHost(e.target.value)}
+        className="server-input"
+        data-testid="have-code-host-input"
+      />
+      <input
+        type="text"
+        placeholder="Pairing code"
+        value={code}
+        onChange={e => setCode(e.target.value)}
+        className={`server-input${error ? ' server-input-error' : ''}`}
+        data-testid="have-code-code-input"
+        autoCapitalize="characters"
+        autoCorrect="off"
+        spellCheck={false}
+      />
+      {error && (
+        <span className="server-form-error" data-testid="have-code-error" role="alert">
+          {error}
+        </span>
+      )}
+      <div className="server-add-actions">
+        <button
+          type="submit"
+          className="server-btn server-btn-primary"
+          disabled={!host.trim() || !code.trim()}
+          data-testid="have-code-submit"
+        >
+          Pair
+        </button>
+        <button
+          type="button"
+          className="server-btn"
+          onClick={onCancel}
+          data-testid="have-code-cancel"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
 interface ServerItemProps {
   server: ServerEntry
   isActive: boolean
@@ -343,6 +423,8 @@ export function ServerPicker() {
   const pairServer = useConnectionStore(s => s.pairServer)
 
   const [showAddForm, setShowAddForm] = useState(false)
+  // #5512 — camera-less "Have a code?" entry (host + typeable code).
+  const [showCodeForm, setShowCodeForm] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
   // #5510 — active "Request to pair" round-trip (requester surface).
   const [pairRequest, setPairRequest] = useState<{ name: string; wsUrl: string } | null>(null)
@@ -372,6 +454,7 @@ export function ServerPicker() {
       pairServer(name, wsUrl, pairingId)
       setAddError(null)
       setShowAddForm(false)
+      setShowCodeForm(false)
       setPrefill(null)
       // A bad/expired pairing id surfaces later as a pair_fail alert; the
       // optimistic entry is cleaned up there.
@@ -427,16 +510,34 @@ export function ServerPicker() {
     <div className="server-picker" data-testid="server-picker">
       <div className="server-picker-header">
         <span className="server-picker-title">Servers</span>
-        <button
-          type="button"
-          className="server-btn server-btn-add"
-          onClick={() => setShowAddForm(true)}
-          data-testid="server-add-btn"
-          aria-label="Add server"
-        >
-          <span aria-hidden="true">+</span>
-        </button>
+        <div className="server-picker-header-actions">
+          {/* #5512 — camera-less entry: type the host + the short code shown on it. */}
+          <button
+            type="button"
+            className="server-btn server-have-code-btn"
+            onClick={() => { setShowCodeForm(true); setShowAddForm(false); setAddError(null) }}
+            data-testid="server-have-code-btn"
+          >
+            Have a code?
+          </button>
+          <button
+            type="button"
+            className="server-btn server-btn-add"
+            onClick={() => { setShowAddForm(true); setShowCodeForm(false) }}
+            data-testid="server-add-btn"
+            aria-label="Add server"
+          >
+            <span aria-hidden="true">+</span>
+          </button>
+        </div>
       </div>
+
+      {showCodeForm && (
+        <HaveCodePanel
+          onPair={handlePair}
+          onCancel={() => setShowCodeForm(false)}
+        />
+      )}
 
       {showAddForm && (
         <AddServerForm

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6120,6 +6120,29 @@ button.sidebar-token-view-session-row:hover {
   font-size: 13px;
 }
 
+/* #5512 — typeable short pairing code shown beside the linking-mode QR. */
+.qr-modal-code {
+  margin: 14px 0 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.qr-modal-code-label {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.qr-modal-code-value {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  letter-spacing: 4px;
+  color: var(--accent-blue);
+  user-select: all;
+}
+
 .footer-qr-btn {
   background: none;
   border: none;
@@ -7482,6 +7505,18 @@ button.sidebar-token-view-session-row:hover {
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-dim);
+}
+
+/* #5512 — header action cluster ("Have a code?" + add). */
+.server-picker-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.server-have-code-btn {
+  font-size: 11px;
+  padding: 3px 8px;
 }
 
 .server-btn {

--- a/packages/dashboard/src/utils/pairing.test.ts
+++ b/packages/dashboard/src/utils/pairing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parsePairingUrl, isPairingUrl } from './pairing'
+import { parsePairingUrl, isPairingUrl, normalizePairingCode, parsePairingCodeEntry } from './pairing'
 
 describe('parsePairingUrl', () => {
   it('infers ws:// for a LAN chroxy URL (explicit port)', () => {
@@ -59,5 +59,41 @@ describe('isPairingUrl', () => {
     expect(isPairingUrl('chroxy://192.168.1.5:8765?token=tok')).toBe(false)
     expect(isPairingUrl('wss://host/ws')).toBe(false)
     expect(isPairingUrl('garbage')).toBe(false)
+  })
+})
+
+describe('normalizePairingCode (#5512)', () => {
+  it('uppercases and strips spaces and dashes', () => {
+    expect(normalizePairingCode('abcd-2345')).toBe('ABCD2345')
+    expect(normalizePairingCode('ab cd 23 45')).toBe('ABCD2345')
+    expect(normalizePairingCode('  AB-CD 2345  ')).toBe('ABCD2345')
+  })
+})
+
+describe('parsePairingCodeEntry (#5512)', () => {
+  it('builds a LAN ws pairing from host:port + code', () => {
+    const r = parsePairingCodeEntry('192.168.1.5:8765', 'abcd-2345')
+    expect(r).toEqual({ wsUrl: 'ws://192.168.1.5:8765/ws', pairingId: 'ABCD2345' })
+  })
+
+  it('builds a tunnel wss pairing from a bare host + code', () => {
+    const r = parsePairingCodeEntry('my.tunnel.tld', 'wxyz2345')
+    expect(r).toEqual({ wsUrl: 'wss://my.tunnel.tld/ws', pairingId: 'WXYZ2345' })
+  })
+
+  it('honors an explicit ws://host URL scheme', () => {
+    const r = parsePairingCodeEntry('ws://my.tunnel.tld:443', 'ABCD2345')
+    expect(r).toEqual({ wsUrl: 'ws://my.tunnel.tld:443/ws', pairingId: 'ABCD2345' })
+  })
+
+  it('accepts a full chroxy:// URL as the host (typed code wins)', () => {
+    const r = parsePairingCodeEntry('chroxy://192.168.1.5:8765?pair=OLDONE', 'new-code-23')
+    expect(r).toEqual({ wsUrl: 'ws://192.168.1.5:8765/ws', pairingId: 'NEWCODE23' })
+  })
+
+  it('returns null when host or code is empty', () => {
+    expect(parsePairingCodeEntry('', 'ABCD2345')).toBeNull()
+    expect(parsePairingCodeEntry('192.168.1.5:8765', '')).toBeNull()
+    expect(parsePairingCodeEntry('192.168.1.5:8765', '   ')).toBeNull()
   })
 })

--- a/packages/dashboard/src/utils/pairing.ts
+++ b/packages/dashboard/src/utils/pairing.ts
@@ -59,3 +59,53 @@ export function parsePairingUrl(raw: string): ParsedPairing | null {
 export function isPairingUrl(raw: string): boolean {
   return parsePairingUrl(raw)?.pairingId != null
 }
+
+/**
+ * Normalize a typed pairing code (#5512): uppercase, strip whitespace and dashes.
+ * Mirrors the server's `normalizePairingCode` so a code read off the host screen
+ * validates regardless of case or the spaces/dashes people add when reading aloud.
+ */
+export function normalizePairingCode(raw: string): string {
+  return raw.replace(/[\s-]+/g, '').toUpperCase()
+}
+
+/**
+ * Build a ParsedPairing from a separately-typed host (or full ws/chroxy URL) and a
+ * pairing code (#5512, the TV-app pattern). This is the camera-less equivalent of
+ * pasting a `chroxy://host?pair=<code>` URL — it synthesizes that URL and reuses
+ * `parsePairingUrl`, so the resulting wsUrl + pairingId drive the exact same pair
+ * request as the QR/paste path. Returns null when host or code is empty/unparsable.
+ *
+ * `host` may be a bare `host[:port]`, or a full `ws://`/`wss://`/`chroxy://` URL
+ * (a `?pair=` already present is ignored — the typed code wins).
+ */
+export function parsePairingCodeEntry(host: string, code: string): ParsedPairing | null {
+  const normalizedCode = normalizePairingCode(code.trim())
+  if (!normalizedCode) return null
+  const trimmedHost = host.trim()
+  if (!trimmedHost) return null
+
+  // Reduce whatever the user typed to a scheme + host[:port], then synthesize the
+  // canonical chroxy://host?pair=<code> string parsePairingUrl already understands.
+  let scheme: 'chroxy' | 'ws' | 'wss' = 'chroxy'
+  let hostPart = trimmedHost
+  try {
+    if (/^wss?:\/\//i.test(trimmedHost)) {
+      const u = new URL(trimmedHost)
+      scheme = trimmedHost.toLowerCase().startsWith('wss://') ? 'wss' : 'ws'
+      hostPart = u.host
+    } else if (/^chroxy:\/\//i.test(trimmedHost)) {
+      const u = new URL(trimmedHost.replace(/^chroxy:\/\//i, 'https://'))
+      hostPart = u.host
+    } else {
+      // Bare host[:port] — strip any path/query the user may have pasted.
+      hostPart = trimmedHost.replace(/^\/+/, '').split('/')[0]?.split('?')[0] ?? ''
+    }
+  } catch {
+    return null
+  }
+  if (!hostPart) return null
+
+  const synthesized = `${scheme}://${hostPart}?pair=${encodeURIComponent(normalizedCode)}`
+  return parsePairingUrl(synthesized)
+}

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -19,6 +19,7 @@ import { registerSessionCommands } from './cli/session-cmd.js'
 import { registerServiceCommand } from './cli/service-cmd.js'
 import { registerUpdateCommand } from './cli/update-cmd.js'
 import { registerStatusCommand } from './cli/status-cmd.js'
+import { registerPairCodeCommand } from './cli/pair-code-cmd.js'
 import { registerWorktreeCommand } from './cli/worktree-gc-cmd.js'
 import { registerCredentialsCommand } from './cli/credentials-cmd.js'
 
@@ -42,6 +43,7 @@ registerSessionCommands(program)
 registerServiceCommand(program)
 registerUpdateCommand(program)
 registerStatusCommand(program)
+registerPairCodeCommand(program)
 registerWorktreeCommand(program)
 registerCredentialsCommand(program)
 

--- a/packages/server/src/cli/pair-code-cmd.js
+++ b/packages/server/src/cli/pair-code-cmd.js
@@ -8,7 +8,10 @@
  * delivered via any other channel must use the #5510 approval primitive instead.
  *
  * Prints once with the remaining TTL and exits (scriptable). It does NOT loop —
- * the code rotates every ~60s, so re-run to get a fresh one.
+ * re-run to get a fresh code. Note the fetch hits GET /pairing-code, which (like
+ * /qr) extends the current code's grace period, so the displayed code can stay
+ * valid past the ~60s base TTL; the printed "expires in NNs" reflects the live
+ * (possibly extended) remaining window.
  */
 
 function portFromUrl(url) {

--- a/packages/server/src/cli/pair-code-cmd.js
+++ b/packages/server/src/cli/pair-code-cmd.js
@@ -1,0 +1,105 @@
+/**
+ * chroxy pair-code — print the host's current typeable pairing code.
+ *
+ * For camera-less devices (the TV-app pattern, #5512, epic #5509): the host shows
+ * a short, human-typable code; the new device types it on the dashboard's "Have a
+ * code?" form. Because the code is read off the host's OWN screen (physical
+ * presence), pairing needs no extra approval — same trust as a scanned QR. Codes
+ * delivered via any other channel must use the #5510 approval primitive instead.
+ *
+ * Prints once with the remaining TTL and exits (scriptable). It does NOT loop —
+ * the code rotates every ~60s, so re-run to get a fresh one.
+ */
+
+function portFromUrl(url) {
+  if (typeof url !== 'string') return null
+  const m = url.match(/:(\d+)(?:\/|$)/)
+  return m ? parseInt(m[1], 10) : null
+}
+
+/**
+ * Fetch the current pairing code from the local daemon. Exposed for testing.
+ * @param {object} [deps]
+ * @param {function} [deps.readConnectionInfo]
+ * @param {function} [deps.fetchFn]
+ * @param {number}   [deps.defaultPort]
+ * @returns {Promise<{ ok: true, code: string, url: string|null, expiresInSeconds: number, wsUrl: string|null }
+ *                  | { ok: false, reason: 'not_running'|'no_token'|'unavailable', message?: string }>}
+ */
+export async function fetchPairingCode(deps = {}) {
+  const readConnectionInfo =
+    deps.readConnectionInfo ||
+    (await import('../connection-info.js')).readConnectionInfo
+  const fetchFn = deps.fetchFn || globalThis.fetch
+  const defaultPort = deps.defaultPort || 8765
+
+  const info = readConnectionInfo()
+  if (!info) return { ok: false, reason: 'not_running' }
+  if (!info.apiToken) return { ok: false, reason: 'no_token' }
+
+  const port = portFromUrl(info.httpUrl) || portFromUrl(info.wsUrl) || defaultPort
+  try {
+    const res = await fetchFn(`http://127.0.0.1:${port}/pairing-code`, {
+      signal: AbortSignal.timeout(3000),
+      headers: { Authorization: `Bearer ${info.apiToken}`, Accept: 'application/json' },
+    })
+    if (!res || !res.ok) {
+      let message = res ? `HTTP ${res.status}` : 'no response'
+      try {
+        const body = await res.json()
+        if (body?.error) message = body.error
+      } catch { /* keep default */ }
+      return { ok: false, reason: 'unavailable', message }
+    }
+    const body = await res.json()
+    return {
+      ok: true,
+      code: body.code,
+      url: body.url ?? null,
+      expiresInSeconds: body.expiresInSeconds,
+      wsUrl: info.wsUrl || info.httpUrl || null,
+    }
+  } catch (err) {
+    return { ok: false, reason: 'unavailable', message: err?.message || 'request failed' }
+  }
+}
+
+/** Render a single human line: `<code>  (expires in NNs)  host: <ws url>`. */
+export function formatPairingCode(result) {
+  const ttl = Number.isFinite(result.expiresInSeconds) ? result.expiresInSeconds : '?'
+  const host = result.wsUrl || '(unknown)'
+  return `${result.code}  (expires in ${ttl}s)  host: ${host}`
+}
+
+export async function runPairCodeCmd(options = {}, deps = {}) {
+  const result = await fetchPairingCode(deps)
+  const write = deps.write || console.log
+  const writeErr = deps.writeErr || console.error
+  if (options.json) {
+    write(JSON.stringify(result, null, 2))
+    return result
+  }
+  if (!result.ok) {
+    if (result.reason === 'not_running') {
+      writeErr('Chroxy server is not running. Start it with `chroxy start`.')
+    } else if (result.reason === 'no_token') {
+      writeErr('Server is running without an auth token — pairing codes are unavailable.')
+    } else {
+      writeErr(`Could not fetch pairing code: ${result.message || result.reason}`)
+    }
+    return result
+  }
+  write(formatPairingCode(result))
+  return result
+}
+
+export function registerPairCodeCommand(program) {
+  program
+    .command('pair-code')
+    .description('Print the current typeable pairing code for a camera-less device to enter')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (options) => {
+      const result = await runPairCodeCmd(options)
+      if (!result.ok) process.exitCode = 1
+    })
+}

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -489,7 +489,7 @@ export function createHttpHandler(server) {
         code: snap.code,
         url: snap.url,
         expiresAtMs: snap.expiresAtMs,
-        expiresInSeconds: Math.round(expiresInMs / 1000),
+        expiresInSeconds: Math.ceil(expiresInMs / 1000),
       }))
       return
     }

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -174,7 +174,7 @@ export function createHttpHandler(server) {
   const dispatch = async (req, res) => {
     // CORS preflight
     if (req.method === 'OPTIONS') {
-      const isRestricted = req.url?.startsWith('/qr') || req.url?.startsWith('/connect')
+      const isRestricted = req.url?.startsWith('/qr') || req.url?.startsWith('/connect') || req.url?.startsWith('/pairing-code')
       const corsOrigin = isRestricted
         ? matchAllowedOrigin(req.headers['origin'])
         : '*'
@@ -454,6 +454,43 @@ export function createHttpHandler(server) {
       }
       res.writeHead(200, connectHeaders)
       res.end(JSON.stringify(connInfo))
+      return
+    }
+
+    // Typeable pairing-code endpoint (#5512): GET /pairing-code returns the
+    // current linking-mode pairing code as JSON so the dashboard/CLI can DISPLAY
+    // it beside the QR (the QR encodes the same id — one mechanism). Same bearer
+    // auth + grace-extension as /qr; camera-less devices enter this code by hand.
+    if (req.method === 'GET' && req.url?.split('?')[0] === '/pairing-code') {
+      if (!server._validateBearerAuth(req, res)) return
+      const codeCors = matchAllowedOrigin(req.headers['origin'])
+      const codeHeaders = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+      if (codeCors) {
+        codeHeaders['Access-Control-Allow-Origin'] = codeCors
+        codeHeaders['Vary'] = 'Origin'
+      }
+      if (!server._pairingManager) {
+        res.writeHead(503, codeHeaders)
+        res.end(JSON.stringify({ error: 'Pairing not available' }))
+        return
+      }
+      // Someone is actively viewing the code — extend the grace period so it
+      // survives long enough to be typed on the other device (mirrors /qr).
+      server._pairingManager.extendCurrentId()
+      const snap = server._pairingManager.currentPairingCode
+      if (!snap) {
+        res.writeHead(503, codeHeaders)
+        res.end(JSON.stringify({ error: 'Pairing code not available yet' }))
+        return
+      }
+      const expiresInMs = Math.max(0, snap.expiresAtMs - Date.now())
+      res.writeHead(200, codeHeaders)
+      res.end(JSON.stringify({
+        code: snap.code,
+        url: snap.url,
+        expiresAtMs: snap.expiresAtMs,
+        expiresInSeconds: Math.round(expiresInMs / 1000),
+      }))
       return
     }
 

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -10,6 +10,53 @@
 import { EventEmitter } from 'events'
 import { randomBytes, timingSafeEqual } from 'crypto'
 
+// -- Typeable short pairing code (#5512, epic #5509) --
+//
+// Pairing ids double as a human-typable code read off the host's own screen (the
+// TV-app pattern: display-on-host = physical presence, so no extra approval — same
+// trust as a scanned QR). The QR carries the SAME id, so this is one mechanism, not
+// two. Codes delivered via any OTHER channel must use the #5510 approval primitive
+// instead — possession of a code is only sufficient when it was read off the host.
+//
+// Alphabet: uppercase, ambiguity-free (no 0/O, 1/I/L). 8 chars over a 31-symbol
+// alphabet ≈ 31^8 ≈ 8.5e11 combinations — paired with a 60s single-use TTL this is
+// not brute-forceable. Entry is case-insensitive and tolerant of spaces/dashes;
+// inputs are normalized (uppercased, separators stripped) before lookup.
+export const TYPEABLE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
+const TYPEABLE_CODE_LENGTH = 8
+
+/**
+ * Generate a crypto-random typeable pairing code. Rejection-samples bytes so the
+ * alphabet is unbiased (no modulo skew toward the first 256 % N symbols).
+ * @returns {string}
+ */
+function generateTypeableCode() {
+  const n = TYPEABLE_ALPHABET.length
+  const max = Math.floor(256 / n) * n // largest multiple of n ≤ 256 (rejection bound)
+  let out = ''
+  while (out.length < TYPEABLE_CODE_LENGTH) {
+    const buf = randomBytes(TYPEABLE_CODE_LENGTH)
+    for (let i = 0; i < buf.length && out.length < TYPEABLE_CODE_LENGTH; i++) {
+      const b = buf[i]
+      if (b >= max) continue // reject to keep the distribution uniform
+      out += TYPEABLE_ALPHABET[b % n]
+    }
+  }
+  return out
+}
+
+/**
+ * Normalize a user-typed pairing code: uppercase, strip whitespace and dashes.
+ * Makes entry case-insensitive and tolerant of the spaces/dashes people add when
+ * reading a code aloud. Returns '' for non-string / nullish input.
+ * @param {string} raw
+ * @returns {string}
+ */
+export function normalizePairingCode(raw) {
+  if (typeof raw !== 'string') return ''
+  return raw.replace(/[\s-]+/g, '').toUpperCase()
+}
+
 const DEFAULT_TTL_MS = 60_000
 const DEFAULT_GRACE_PERIOD_MS = 3 * 60_000 // 3 minutes after first QR display
 const DEFAULT_SESSION_TOKEN_TTL_MS = 24 * 60 * 60_000 // 24 hours
@@ -66,6 +113,23 @@ export class PairingManager extends EventEmitter {
   }
 
   /**
+   * Snapshot of the current linking-mode pairing code for host display surfaces
+   * (#5512): the typeable code, its chroxy:// URL (QR carries the same id), and the
+   * absolute expiry so a CLI/dashboard can render "expires in NNs". Null when
+   * destroyed or no pairing exists.
+   * @returns {{ code: string, url: string|null, expiresAtMs: number, ttlMs: number }|null}
+   */
+  get currentPairingCode() {
+    if (this._destroyed || !this._current) return null
+    return {
+      code: this._current.id,
+      url: this.currentPairingUrl,
+      expiresAtMs: this._current.expiresAt,
+      ttlMs: this._ttlMs,
+    }
+  }
+
+  /**
    * Generate a NEW pairing ID bound at creation time to a specific session
    * (#3070). Unlike `_generatePairing()`, this does NOT replace `_current`
    * (the linking-mode QR keeps auto-refreshing for general device pairing);
@@ -107,7 +171,7 @@ export class PairingManager extends EventEmitter {
       this._activePairings.delete(victim ?? this._activePairings.keys().next().value)
     }
 
-    const id = randomBytes(12).toString('base64url')
+    const id = generateTypeableCode()
     const expiresAt = Date.now() + this._ttlMs
     this._activePairings.set(id, { expiresAt, used: false, boundSessionId: sessionId })
 
@@ -131,6 +195,11 @@ export class PairingManager extends EventEmitter {
    * @returns {{ valid: boolean, sessionToken?: string, reason?: string }}
    */
   validatePairing(pairingId, sessionId = null) {
+    // Normalize typed/scanned input so a code read off the host screen validates
+    // regardless of case or the spaces/dashes a user adds (#5512). Stored keys are
+    // already canonical (uppercase, separator-free) so this is a no-op for QR ids.
+    pairingId = normalizePairingCode(pairingId)
+
     // Look up in active pairings (includes current + grace period entries)
     const entry = this._activePairings.get(pairingId)
     if (!entry) {
@@ -521,7 +590,7 @@ export class PairingManager extends EventEmitter {
       this._activePairings.delete(oldest)
     }
 
-    const id = randomBytes(12).toString('base64url')
+    const id = generateTypeableCode()
     const expiresAt = now + this._ttlMs
     this._current = { id, createdAt: now, expiresAt }
     this._activePairings.set(id, { expiresAt, used: false })

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -231,6 +231,69 @@ describe('http-routes', () => {
     })
   })
 
+  // #5512: typeable pairing-code endpoint
+  describe('pairing-code endpoint', () => {
+    function makeCodeMock(snap, overrides = {}) {
+      let extended = 0
+      return createMockServer({
+        _pairingManager: {
+          extendCurrentId() { extended++ },
+          get currentPairingCode() { return snap },
+          _extendedCount: () => extended,
+        },
+        ...overrides,
+      })
+    }
+
+    it('GET /pairing-code returns the typeable code as JSON', async () => {
+      const snap = {
+        code: 'ABCD2345',
+        url: 'chroxy://example.com?pair=ABCD2345',
+        expiresAtMs: Date.now() + 45_000,
+        ttlMs: 60_000,
+      }
+      const mock = makeCodeMock(snap)
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pairing-code`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      assert.equal(res.headers.get('content-type'), 'application/json')
+      const body = await res.json()
+      assert.equal(body.code, 'ABCD2345')
+      assert.equal(body.url, 'chroxy://example.com?pair=ABCD2345')
+      assert.equal(body.expiresAtMs, snap.expiresAtMs)
+      assert.ok(body.expiresInSeconds >= 44 && body.expiresInSeconds <= 45)
+      // Viewing the code extends the grace period (mirrors /qr).
+      assert.equal(mock._pairingManager._extendedCount(), 1)
+    })
+
+    it('returns 403 without auth', async () => {
+      const mock = makeCodeMock({ code: 'ABCD2345', url: null, expiresAtMs: Date.now() + 1000, ttlMs: 60_000 })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pairing-code`)
+      assert.equal(res.status, 403)
+    })
+
+    it('returns 503 when no pairing manager is wired', async () => {
+      const mock = createMockServer({ _pairingManager: null })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pairing-code`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 503)
+    })
+
+    it('returns 503 when no code is available yet', async () => {
+      const mock = makeCodeMock(null)
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pairing-code`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 503)
+    })
+  })
+
   // #3070: per-session "Share this session" QR endpoint
   describe('per-session share QR endpoint', () => {
     function makeSharedMock(overrides = {}) {

--- a/packages/server/tests/pair-code-cmd.test.js
+++ b/packages/server/tests/pair-code-cmd.test.js
@@ -1,0 +1,64 @@
+/**
+ * `chroxy pair-code` CLI (#5512, epic #5509).
+ *
+ * Prints the host's current typeable pairing code once, with its remaining TTL and
+ * ws URL, then exits — scriptable, no refresh loop. The code is read off the host's
+ * own screen (physical presence), so the new device pairs with no extra approval.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { fetchPairingCode, formatPairingCode } from '../src/cli/pair-code-cmd.js'
+
+function mockResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return body },
+  }
+}
+
+describe('pair-code CLI (#5512)', () => {
+  it('fetches the code from the daemon using the connection-info token', async () => {
+    let calledUrl = null
+    let calledAuth = null
+    const result = await fetchPairingCode({
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', wsUrl: 'wss://x.tld', apiToken: 'tok' }),
+      fetchFn: async (url, opts) => {
+        calledUrl = url
+        calledAuth = opts.headers.Authorization
+        return mockResponse(200, { code: 'ABCD2345', url: 'chroxy://x.tld?pair=ABCD2345', expiresAtMs: Date.now() + 50_000, expiresInSeconds: 50 })
+      },
+    })
+    assert.ok(calledUrl.endsWith('/pairing-code'))
+    assert.equal(calledAuth, 'Bearer tok')
+    assert.equal(result.ok, true)
+    assert.equal(result.code, 'ABCD2345')
+    assert.equal(result.expiresInSeconds, 50)
+    assert.equal(result.wsUrl, 'wss://x.tld')
+  })
+
+  it('reports not-running when no connection info exists', async () => {
+    const result = await fetchPairingCode({
+      readConnectionInfo: () => null,
+      fetchFn: async () => { throw new Error('should not be called') },
+    })
+    assert.equal(result.ok, false)
+    assert.equal(result.reason, 'not_running')
+  })
+
+  it('reports an error when the daemon returns non-200', async () => {
+    const result = await fetchPairingCode({
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', apiToken: 'tok' }),
+      fetchFn: async () => mockResponse(503, { error: 'Pairing code not available yet' }),
+    })
+    assert.equal(result.ok, false)
+    assert.equal(result.reason, 'unavailable')
+  })
+
+  it('formatPairingCode renders code, ttl, and host on one line', () => {
+    const line = formatPairingCode({ ok: true, code: 'ABCD2345', expiresInSeconds: 42, wsUrl: 'wss://x.tld' })
+    assert.match(line, /ABCD2345/)
+    assert.match(line, /expires in 42s/)
+    assert.match(line, /wss:\/\/x\.tld/)
+  })
+})

--- a/packages/server/tests/pairing-typeable-code.test.js
+++ b/packages/server/tests/pairing-typeable-code.test.js
@@ -1,0 +1,128 @@
+/**
+ * Typeable short pairing code (#5512, epic #5509).
+ *
+ * The TV-app pattern: a camera-less device pairs by reading a short, human-typable
+ * code off the host's own screen. Pairing ids therefore become uppercase,
+ * ambiguity-free, 8-char codes; entry is case-insensitive and tolerant of spaces
+ * and dashes (normalized before lookup). One mechanism — the QR carries the same
+ * code in its chroxy://…?pair= URL.
+ */
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+
+describe('typeable pairing codes (#5512)', () => {
+  let PairingManager
+  let normalizePairingCode
+  let TYPEABLE_ALPHABET
+
+  before(async () => {
+    const mod = await import('../src/pairing.js')
+    PairingManager = mod.PairingManager
+    normalizePairingCode = mod.normalizePairingCode
+    TYPEABLE_ALPHABET = mod.TYPEABLE_ALPHABET
+  })
+
+  describe('alphabet & shape', () => {
+    it('exports an ambiguity-free uppercase alphabet (no 0/O/1/I/L)', () => {
+      assert.equal(typeof TYPEABLE_ALPHABET, 'string')
+      assert.ok(TYPEABLE_ALPHABET.length > 0)
+      for (const bad of ['0', 'O', '1', 'I', 'L']) {
+        assert.ok(!TYPEABLE_ALPHABET.includes(bad), `alphabet must not include ${bad}`)
+      }
+      // Uppercase + digits only.
+      assert.match(TYPEABLE_ALPHABET, /^[A-Z2-9]+$/)
+    })
+
+    it('generates an 8-char code drawn only from the typeable alphabet', () => {
+      const pm = new PairingManager({})
+      const id = pm.currentPairingId
+      assert.equal(id.length, 8, 'pairing code should be 8 chars')
+      for (const ch of id) {
+        assert.ok(TYPEABLE_ALPHABET.includes(ch), `char ${ch} not in alphabet`)
+      }
+      pm.destroy()
+    })
+
+    it('bound pairing ids also use the typeable alphabet', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+      const { pairingId } = pm.generateBoundPairing('sess-A')
+      assert.equal(pairingId.length, 8)
+      for (const ch of pairingId) {
+        assert.ok(TYPEABLE_ALPHABET.includes(ch), `char ${ch} not in alphabet`)
+      }
+      pm.destroy()
+    })
+
+    it('codes vary across refreshes (crypto-random)', () => {
+      const pm = new PairingManager({ ttlMs: 60_000 })
+      const seen = new Set()
+      for (let i = 0; i < 20; i++) {
+        seen.add(pm.currentPairingId)
+        pm.refresh()
+      }
+      assert.ok(seen.size >= 18, 'codes should be effectively unique across refreshes')
+      pm.destroy()
+    })
+  })
+
+  describe('normalizePairingCode', () => {
+    it('uppercases and strips spaces and dashes', () => {
+      assert.equal(normalizePairingCode('abcd-2345'), 'ABCD2345')
+      assert.equal(normalizePairingCode('ab cd 23 45'), 'ABCD2345')
+      assert.equal(normalizePairingCode('  AB-CD 2345  '), 'ABCD2345')
+    })
+
+    it('returns empty string for null/undefined/non-string', () => {
+      assert.equal(normalizePairingCode(null), '')
+      assert.equal(normalizePairingCode(undefined), '')
+      assert.equal(normalizePairingCode(42), '')
+    })
+  })
+
+  describe('case-insensitive / formatting-tolerant validation', () => {
+    it('accepts a lowercased copy of the current code', () => {
+      const pm = new PairingManager({})
+      const id = pm.currentPairingId
+      const result = pm.validatePairing(id.toLowerCase())
+      assert.equal(result.valid, true, 'lowercase entry should validate')
+      assert.ok(result.sessionToken)
+      pm.destroy()
+    })
+
+    it('accepts a code typed with dashes and spaces', () => {
+      const pm = new PairingManager({})
+      const id = pm.currentPairingId
+      const messy = `${id.slice(0, 4)}-${id.slice(4)}`.toLowerCase()
+      const result = pm.validatePairing(messy)
+      assert.equal(result.valid, true, 'dashed/lowercased entry should validate')
+      pm.destroy()
+    })
+
+    it('still rejects an unknown code after normalization', () => {
+      const pm = new PairingManager({})
+      const result = pm.validatePairing('zz-zz-zz-zz')
+      assert.equal(result.valid, false)
+      assert.equal(result.reason, 'invalid_pairing_id')
+      pm.destroy()
+    })
+  })
+
+  describe('current code snapshot helper', () => {
+    it('currentPairingCode returns code + expiry for host display', () => {
+      const pm = new PairingManager({ wsUrl: 'wss://example.com', ttlMs: 60_000 })
+      const snap = pm.currentPairingCode
+      assert.ok(snap, 'should return a snapshot')
+      assert.equal(snap.code, pm.currentPairingId)
+      assert.ok(typeof snap.expiresAtMs === 'number')
+      assert.ok(snap.expiresAtMs > Date.now())
+      assert.ok(snap.url.startsWith('chroxy://example.com?pair='))
+      pm.destroy()
+    })
+
+    it('currentPairingCode is null after destroy', () => {
+      const pm = new PairingManager({})
+      pm.destroy()
+      assert.equal(pm.currentPairingCode, null)
+    })
+  })
+})


### PR DESCRIPTION
## Typeable short pairing code for camera-less devices

The TV-app pattern (epic #5509): the host displays a short, human-typable code; a device that can't scan a QR types it. The code is read off the host's **own screen** — physical presence — so pairing needs **no extra approval**, matching today's QR trust semantics. Codes delivered via any other channel must use the #5510 approval primitive instead (noted in the `pairing.js` header).

### One mechanism, not two
All pairing ids now use a typeable alphabet, so the QR carries the same id a user can type. No parallel code path.

- **Alphabet**: uppercase, ambiguity-free (`ABCDEFGHJKMNPQRSTUVWXYZ23456789` — no `0/O/1/I/L`), 8 chars, crypto-random with rejection sampling (unbiased).
- **Entry tolerance**: case-insensitive, spaces/dashes stripped. Inputs are normalized before lookup on both ends (`normalizePairingCode` server + dashboard), so existing QR/paste flows are byte-for-byte unaffected.

### Host display surfaces
- **CLI** — `chroxy pair-code` prints `<code>  (expires in NNs)  host: <ws url>` once and exits (scriptable; `--json` supported). Does not loop.
- **Dashboard** — the QR modal fetches `GET /pairing-code` alongside the QR and shows the code under it ("Or type this code:"). Per-session "Share" QRs keep no code (they issue a session-bound token).
- **New endpoint** — `GET /pairing-code` returns `{ code, url, expiresAtMs, expiresInSeconds }`, bearer-authed + grace-extending + CORS-restricted exactly like `/qr`.

### Client entry
ServerPicker gains a **"Have a code?"** panel: host + code fields. `parsePairingCodeEntry` normalizes the code and synthesizes the same `chroxy://host?pair=<code>` request the QR/paste path builds, then reuses `pairServer()` — identical handshake. A bad/expired code is rejected server-side and surfaces as the existing `pair_fail` alert.

### Out of scope / follow-up
- **Tray (Rust)** display is deliberately left as a follow-up per the issue.

### Protocol
No protocol/schema changes — the `pair` message already carries the id.

### Tests
- Server (`node --test --test-force-exit`): pairing + http-routes + pair-code + ws-auth suites — **279 passed, 0 failed** (pairing/http/cli: 124; ws-auth: 155). Custom lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) pass.
- Dashboard (`vitest run`): pairing util + QrModal + ServerPicker + connection-pairing/request-pairing — **96 passed, 0 failed**. `tsc --noEmit` clean.

Closes #5512.

Related to #5509.
