### PR TITLE
perf: smooth streaming — memoized bubbles, adaptive delta flush, tighter single-client coalescing

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -15,6 +15,7 @@ import {
   resetReplayFlags,
   registerPendingPermissionModeRequest,
   _testClearPendingPermissionModeRequests,
+  setDeltaFlushIntervalOverride,
 } from '../../store/message-handler';
 import { createEmptySessionState } from '../../store/utils';
 import { clearPersistedSession } from '../../store/persistence';
@@ -1880,6 +1881,39 @@ describe('stream_delta handler', () => {
     const ss = store.getState().sessionStates.s1;
     const msg = ss.messages.find((m) => m.id === 'msg-1');
     expect(msg?.content).toBe('Hello world');
+  });
+
+  // #5516 (epic #5514): the delta flush is scheduled on an ADAPTIVE timer
+  // (was a fixed 100ms). With the constant override pinned, the first delta
+  // must schedule a setTimeout at exactly that interval — proving the override
+  // is honored and the call site reads it. Default (no override) is covered by
+  // resolveDeltaFlushMs's own unit tests in store-core.
+  it('schedules the delta flush at the overridden interval (#5516)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    try {
+      setDeltaFlushIntervalOverride(16);
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
+      _testMessageHandler.handle({ type: 'stream_delta', messageId: 'msg-1', sessionId: 's1', delta: 'Hi' });
+
+      // The flush timer must have been scheduled at the pinned 16ms.
+      const flushCall = setTimeoutSpy.mock.calls.find((c) => c[1] === 16);
+      expect(flushCall).toBeDefined();
+
+      jest.runAllTimers();
+      const ss = store.getState().sessionStates.s1;
+      expect(ss.messages.find((m) => m.id === 'msg-1')?.content).toBe('Hi');
+    } finally {
+      setDeltaFlushIntervalOverride(null);
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   // #5515 (epic #5514): the latency instrumentation reads the optional

--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -573,7 +573,7 @@ HighlightedCode.displayName = 'HighlightedCode';
  *
  *  `messageTextStyle` is threaded through to FormattedTextBlock so the
  *  parent can control the base text appearance. */
-export function FormattedResponse({ content, messageTextStyle }: { content: string; messageTextStyle: StyleProp<TextStyle> }) {
+function FormattedResponseImpl({ content, messageTextStyle }: { content: string; messageTextStyle: StyleProp<TextStyle> }) {
   const blocks = useMemo(() => splitContentBlocks(content.trim()), [content]);
 
   if (blocks.length === 0) return null;
@@ -594,6 +594,19 @@ export function FormattedResponse({ content, messageTextStyle }: { content: stri
     </View>
   );
 }
+
+/**
+ * #5516 (epic #5514): memoize the whole markdown render so a parent re-render
+ * that DOESN'T change `content` skips the block split + per-line markdown parse
+ * (`FormattedTextBlock`, which is otherwise un-memoized). `messageTextStyle` is
+ * a stable StyleSheet ref at every call site, so a shallow prop compare is
+ * exact. The primary defence against re-parse is MessageBubble's own memo
+ * (non-tail bubbles never re-render); this is belt-and-suspenders for the cases
+ * where the bubble itself must re-render (selection toggle, expiry tick) but
+ * the markdown body is unchanged.
+ */
+export const FormattedResponse = React.memo(FormattedResponseImpl);
+FormattedResponse.displayName = 'FormattedResponse';
 
 export const md = StyleSheet.create({
   container: {

--- a/packages/app/src/components/__tests__/MessageBubble.memoization.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.memoization.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * MessageBubble memoization — #5516 (epic #5514, "smooth streaming")
+ *
+ * Proves the React.memo wrapper added in #5516 stops non-tail chat bubbles
+ * from re-rendering (and re-parsing markdown) on a streaming delta flush.
+ *
+ * The store's `flushPendingDeltas` replaces ONLY the streamed message's object
+ * (`{ ...m, content: m.content + d }`) — every other message keeps its
+ * identity across the flush. This test reproduces that exact shape: a stable
+ * non-tail message + a tail message whose object is swapped for one with more
+ * content, then a parent re-render with FRESH callback identities (mirroring
+ * ChatView, which recreates callbacks every render). Only the tail bubble may
+ * re-render.
+ *
+ * Render counts are read from the shared dev-only counter in @chroxy/store-core
+ * (keyed `MessageBubble:<id>`), the same instrument added for the latency work.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { getRenderCount, resetRenderCounts } from '@chroxy/store-core';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+
+function responseMessage(id: string, content: string): ChatMessage {
+  return {
+    id,
+    type: 'response',
+    content,
+    timestamp: 1000,
+  } as ChatMessage;
+}
+
+/** Render a list of bubbles the way ChatView does — fresh callbacks each pass. */
+function Harness({ messages }: { messages: ChatMessage[] }) {
+  return (
+    <>
+      {messages.map((m) => (
+        <MessageBubble
+          key={m.id}
+          message={m}
+          // Fresh closures every render — must NOT defeat the memo.
+          isSelected={false}
+          isSelecting={false}
+          onLongPress={() => {}}
+          onPress={() => {}}
+          onOpenDetail={() => {}}
+          onImagePress={() => {}}
+          onSelectOption={() => {}}
+        />
+      ))}
+    </>
+  );
+}
+
+describe('MessageBubble memoization (#5516)', () => {
+  beforeEach(() => resetRenderCounts());
+
+  it('only the tail/streaming bubble re-renders on a delta flush', () => {
+    const nonTail = responseMessage('m-1', 'Earlier finished message');
+    const tailV1 = responseMessage('m-2', 'Streaming so far');
+
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<Harness messages={[nonTail, tailV1]} />);
+    });
+
+    expect(getRenderCount('MessageBubble:m-1')).toBe(1);
+    expect(getRenderCount('MessageBubble:m-2')).toBe(1);
+
+    // Simulate flushPendingDeltas: the non-tail object is UNCHANGED (same
+    // reference), the tail object is replaced with appended content.
+    const tailV2 = { ...tailV1, content: tailV1.content + ' …and more tokens' };
+    act(() => {
+      tree.update(<Harness messages={[nonTail, tailV2]} />);
+    });
+
+    // The non-tail bubble must NOT have re-rendered (no markdown re-parse).
+    expect(getRenderCount('MessageBubble:m-1')).toBe(1);
+    // The tail bubble re-rendered exactly once to show the new tokens.
+    expect(getRenderCount('MessageBubble:m-2')).toBe(2);
+  });
+
+  it('re-renders a bubble when a render-affecting scalar prop changes', () => {
+    // Guard against an over-aggressive comparator: isSelected toggling must
+    // still re-render that bubble.
+    const msg = responseMessage('s-1', 'Pick me');
+
+    function SelectableHarness({ selected }: { selected: boolean }) {
+      return (
+        <MessageBubble
+          message={msg}
+          isSelected={selected}
+          isSelecting
+          onLongPress={() => {}}
+          onPress={() => {}}
+          onOpenDetail={() => {}}
+        />
+      );
+    }
+
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SelectableHarness selected={false} />);
+    });
+    expect(getRenderCount('MessageBubble:s-1')).toBe(1);
+
+    act(() => {
+      tree.update(<SelectableHarness selected />);
+    });
+    expect(getRenderCount('MessageBubble:s-1')).toBe(2);
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -8,7 +8,7 @@ import {
   Image,
   LayoutAnimation,
 } from 'react-native';
-import { OTHER_OPTION_VALUE } from '@chroxy/store-core';
+import { OTHER_OPTION_VALUE, bumpRenderCount } from '@chroxy/store-core';
 // #4875: `OtherFreeformAnswer` moved to @chroxy/store-core/freeform-answer
 // so the mobile store, the mobile screen, and (eventually) the dashboard
 // can converge on a single declaration paired with the shared
@@ -52,7 +52,7 @@ export type { OtherFreeformAnswer };
 
 export type SelectOptionValue = string | OtherFreeformAnswer;
 
-export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall }: {
+function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall }: {
   message: ChatMessage;
   onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
   /**
@@ -85,6 +85,13 @@ export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, 
    */
   onRetryStreamStall?: () => void;
 }) {
+  // #5516 (epic #5514): dev-only render tally. Proves (in the memoization
+  // test and ad-hoc dev profiling) that only the tail/streaming bubble
+  // re-renders on a delta flush — non-tail bubbles must skip this entirely
+  // thanks to the React.memo comparator below. Cheap Map write; never read on
+  // the hot path. Stripped from release builds by the `__DEV__` guard.
+  if (__DEV__) bumpRenderCount(`MessageBubble:${message.id}`);
+
   const longPressedRef = useRef(false);
   const [isExpired, setIsExpired] = useState(() =>
     message.expiresAt != null && message.expiresAt <= Date.now()
@@ -516,6 +523,36 @@ export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, 
     </TouchableOpacity>
   );
 }
+
+/**
+ * #5516 (epic #5514): memoize the bubble so a streaming delta flush only
+ * re-renders the ONE message whose content changed — the rest of the
+ * transcript skips React reconciliation (and, crucially, the markdown
+ * re-parse inside FormattedResponse) entirely.
+ *
+ * The store's flush replaces ONLY the streamed message's object (`{ ...m,
+ * content: m.content + d }` in `flushPendingDeltas`) — every non-tail message
+ * keeps its identity across the flush. So a reference check on `message` is
+ * both correct and the cheapest possible comparator for the data half.
+ *
+ * The callback props (`onPress`, `onLongPress`, `onSelectOption`,
+ * `onSubmitMultiQuestion`, `onOpenDetail`, `onImagePress`) are recreated by
+ * ChatView on every render, so comparing them by identity would defeat the
+ * memo — we intentionally ignore them. `onRetryStreamStall` is the one
+ * callback whose PRESENCE (not identity) changes render output (the stall
+ * chip's Retry affordance is wired only on the tail), so we compare it as a
+ * boolean. The remaining render-affecting props are scalar booleans.
+ */
+export const MessageBubble = React.memo(MessageBubbleImpl, (prev, next) => {
+  return (
+    prev.message === next.message &&
+    prev.isSelected === next.isSelected &&
+    prev.isSelecting === next.isSelecting &&
+    prev.allowMultiQuestion === next.allowMultiQuestion &&
+    (prev.onRetryStreamStall == null) === (next.onRetryStreamStall == null)
+  );
+});
+MessageBubble.displayName = 'MessageBubble';
 
 const styles = StyleSheet.create({
   messageBubble: {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -138,6 +138,8 @@ import {
   // #5515 (epic #5514): latency instrumentation primitives.
   RollingPercentiles,
   splitRtt,
+  // #5516 (epic #5514): adaptive client delta-flush interval.
+  resolveDeltaFlushMs,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
@@ -597,6 +599,21 @@ const EWMA_ALPHA = 0.3; // Weight for new samples (higher = more responsive)
 // can't spam the console — one line every few seconds is enough to watch the
 // numbers move when flush intervals are tuned.
 const LATENCY_LOG_INTERVAL_MS = 3_000;
+
+// #5516 (epic #5514): adaptive delta-flush interval. Production reads the
+// current EWMA RTT and adapts (16-33ms cheap → 100ms poor) via
+// `resolveDeltaFlushMs`. Tests pin it to a constant by calling
+// `setDeltaFlushIntervalOverride(N)`; `null` (the default) restores adaptive
+// behavior. Kept testable per the issue's "constant override testable" ask.
+let _deltaFlushOverrideMs: number | null = null;
+export function setDeltaFlushIntervalOverride(ms: number | null): void {
+  _deltaFlushOverrideMs = ms;
+}
+function currentDeltaFlushMs(): number {
+  return _deltaFlushOverrideMs != null
+    ? _deltaFlushOverrideMs
+    : resolveDeltaFlushMs(_ctx.ewmaRtt);
+}
 
 export function stopHeartbeat(): void {
   if (_ctx.heartbeatInterval) { clearInterval(_ctx.heartbeatInterval); _ctx.heartbeatInterval = null; }
@@ -1720,7 +1737,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
         scheduleFlush: () => {
           if (!_ctx.deltaFlushTimer) {
-            _ctx.deltaFlushTimer = setTimeout(flushPendingDeltas, 100);
+            // #5516 — adaptive interval (was a fixed 100ms). Memoized bubbles
+            // (step 1) make the tighter flush cheap: only the tail re-renders.
+            _ctx.deltaFlushTimer = setTimeout(flushPendingDeltas, currentDeltaFlushMs());
           }
         },
       });

--- a/packages/dashboard/src/components/ChatView.memoization.test.tsx
+++ b/packages/dashboard/src/components/ChatView.memoization.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * ChatView memoization — #5516 (epic #5514, "smooth streaming")
+ *
+ * Proves the `DefaultMessageRow` memo extracted in #5516 stops non-tail chat
+ * rows from re-rendering — and re-running `renderMarkdown` — on a streaming
+ * delta flush.
+ *
+ * Before #5516 the inline `dedupedMessages.map` re-parsed markdown for EVERY
+ * response row on every store update (~10×/sec while streaming). Now only the
+ * row whose content changed re-renders. Render counts come from the shared
+ * dev-only counter in @chroxy/store-core (keyed `ChatMessageRow:<id>`).
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, act } from '@testing-library/react'
+import { getRenderCount, resetRenderCounts } from '@chroxy/store-core'
+import { ChatView, type ChatViewMessage } from './ChatView'
+
+afterEach(cleanup)
+beforeEach(() => resetRenderCounts())
+
+function response(id: string, content: string): ChatViewMessage {
+  return { id, type: 'response', content, timestamp: 1000 }
+}
+
+describe('ChatView memoization (#5516)', () => {
+  it('only the streamed row re-renders (re-parses markdown) on a delta flush', () => {
+    const nonTail = response('m-1', 'Earlier finished message')
+    const tailV1 = response('m-2', 'Streaming so far')
+
+    const { rerender } = render(
+      <ChatView messages={[nonTail, tailV1]} isStreaming />,
+    )
+
+    expect(getRenderCount('ChatMessageRow:m-1')).toBe(1)
+    expect(getRenderCount('ChatMessageRow:m-2')).toBe(1)
+
+    // Simulate the store's delta flush: it hands ChatView a brand-new array
+    // with fresh objects, but only the tail's CONTENT changed. The non-tail
+    // row's scalar props are identical → memo skips it.
+    const tailV2 = response('m-2', 'Streaming so far …and more tokens')
+    act(() => {
+      rerender(<ChatView messages={[response('m-1', 'Earlier finished message'), tailV2]} isStreaming />)
+    })
+
+    // Non-tail row must NOT re-render (no markdown re-parse).
+    expect(getRenderCount('ChatMessageRow:m-1')).toBe(1)
+    // Tail row re-rendered once to show the appended tokens.
+    expect(getRenderCount('ChatMessageRow:m-2')).toBe(2)
+  })
+
+  it('re-renders a row when its content actually changes', () => {
+    const msg = response('only', 'v1')
+    const { rerender } = render(<ChatView messages={[msg]} isStreaming={false} />)
+    expect(getRenderCount('ChatMessageRow:only')).toBe(1)
+
+    act(() => {
+      rerender(<ChatView messages={[response('only', 'v2')]} isStreaming={false} />)
+    })
+    expect(getRenderCount('ChatMessageRow:only')).toBe(2)
+  })
+})

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -7,6 +7,7 @@
  * - Deduplicates messages by id for reconnect replay
  */
 import { memo, useRef, useState, useCallback, useEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
+import { bumpRenderCount } from '@chroxy/store-core'
 import { ThinkingDots } from './ThinkingDots'
 import { renderMarkdown } from '../lib/markdown'
 
@@ -142,6 +143,70 @@ function formatTime(ts: number): string {
   return `${h}:${m} ${ampm}`
 }
 
+const IS_DEV = typeof import.meta !== 'undefined' && Boolean(import.meta.env?.DEV)
+
+/**
+ * #5516 (epic #5514): the default (non-renderMessage) message row, extracted
+ * into a memoized component so a streaming delta flush only re-runs the
+ * markdown parse (`renderMarkdown`) for the ONE message whose content changed.
+ *
+ * Before #5516 every store update re-ran the whole `dedupedMessages.map`,
+ * calling `renderMarkdown(msg.content)` inline for EVERY response/tool_use row
+ * — an O(conversation) markdown re-parse ~10×/sec while streaming. By keying
+ * the memo on the render-affecting scalars (id/type/content/timestamp), only
+ * the tail bubble (whose content is appended each flush) re-parses; the rest of
+ * the transcript is skipped entirely. The store hands each row a fresh object
+ * per render, so a shallow scalar compare — not reference equality — is what
+ * makes the skip fire.
+ */
+/** Row container class for a message type (was computed inline in the map). */
+function rowClassFor(type: string, hasIcon: boolean): string {
+  if (type === 'user_input') return 'msg-row msg-row-user'
+  if (type === 'system') return 'msg-row msg-row-system'
+  return hasIcon ? 'msg-row' : ''
+}
+
+const DefaultMessageRow = memo(function DefaultMessageRow({
+  id,
+  type,
+  content,
+  timestamp,
+  isStreaming,
+}: {
+  id: string
+  type: ChatViewMessage['type']
+  content: string
+  timestamp: number
+  isStreaming?: boolean
+}) {
+  // Dev-only render tally — proves (in the memoization test + ad-hoc
+  // profiling) non-tail rows don't re-render on a delta flush. Never read on
+  // the hot path.
+  if (IS_DEV) bumpRenderCount(`ChatMessageRow:${id}`)
+
+  // Derive icon + row class from `type` INSIDE the memo. Computing them in the
+  // parent map would hand the memo a fresh `icon` JSX element identity every
+  // render and defeat the skip — every prop must be a stable scalar.
+  const icon = senderIconFor(type)
+  const rowClass = rowClassFor(type, icon !== null)
+
+  const body =
+    type === 'response' || type === 'tool_use'
+      ? <div dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
+      : content
+
+  return (
+    <div data-testid={`msg-${id}`} className={rowClass}>
+      {type !== 'user_input' && icon}
+      <div className={`msg ${TYPE_CLASS[type] || 'assistant'}${isStreaming ? ' streaming' : ''}`}>
+        {body}
+        {timestamp > 0 && <span className="msg-timestamp">{formatTime(timestamp)}</span>}
+      </div>
+      {type === 'user_input' && icon}
+    </div>
+  )
+})
+
 function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
@@ -265,26 +330,14 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
             )
           }
           return (
-            <div
+            <DefaultMessageRow
               key={msg.id}
-              data-testid={`msg-${msg.id}`}
-              className={rowClass}
-            >
-              {msg.type !== 'user_input' && icon}
-              <div
-                className={`msg ${TYPE_CLASS[msg.type] || 'assistant'}${msg.isStreaming ? ' streaming' : ''}`}
-              >
-                {(msg.type === 'response' || msg.type === 'tool_use') ? (
-                  <div dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }} />
-                ) : (
-                  msg.content
-                )}
-                {msg.timestamp > 0 && (
-                  <span className="msg-timestamp">{formatTime(msg.timestamp)}</span>
-                )}
-              </div>
-              {msg.type === 'user_input' && icon}
-            </div>
+              id={msg.id}
+              type={msg.type}
+              content={msg.content}
+              timestamp={msg.timestamp}
+              isStreaming={msg.isStreaming}
+            />
           )
         })}
         {(isStreaming || isBusy) && <ThinkingDots />}

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -35,6 +35,7 @@ import {
   registerTrustGrantRequest,
   clearPendingTrustGrants,
   _testTrustGrantPendingSize,
+  setDeltaFlushIntervalOverride,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
 import type { ConnectionState } from './types'
@@ -932,6 +933,35 @@ describe('dashboard message-handler dispatch', () => {
       )
       const state = store.getState() as any
       expect(state._terminalWrites).toContain('hello ')
+    })
+
+    // #5516 (epic #5514): the flush is scheduled on an ADAPTIVE timer (was a
+    // fixed 100ms). With the constant override pinned, the first delta must
+    // schedule a setTimeout at exactly that interval. Default (no override)
+    // behavior is covered by resolveDeltaFlushMs's store-core unit tests.
+    it('schedules the delta flush at the overridden interval (#5516)', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      }))
+      setStore(store)
+
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+      try {
+        setDeltaFlushIntervalOverride(16)
+        handleMessage({ type: 'stream_start', messageId: 'msg-x', sessionId: 's1' }, ctx() as any)
+        handleMessage({ type: 'stream_delta', messageId: 'msg-x', sessionId: 's1', delta: 'Hi' }, ctx() as any)
+
+        const flushCall = setTimeoutSpy.mock.calls.find((c) => c[1] === 16)
+        expect(flushCall).toBeDefined()
+
+        vi.runAllTimers()
+        const ss = (store.getState() as any).sessionStates.s1
+        expect(ss.messages.find((m: any) => m.id === 'msg-x')?.content).toBe('Hi')
+      } finally {
+        setDeltaFlushIntervalOverride(null)
+        setTimeoutSpy.mockRestore()
+      }
     })
 
     // #3071 — when stream_start is dropped (e.g., session not yet in store at

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -130,6 +130,8 @@ import {
   // #5515 (epic #5514): latency instrumentation primitives.
   RollingPercentiles,
   splitRtt,
+  // #5516 (epic #5514): adaptive client delta-flush interval.
+  resolveDeltaFlushMs,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -565,6 +567,18 @@ function _onPong(serverTs?: number): void {
 // ---------------------------------------------------------------------------
 const pendingDeltas = new Map<string, { sessionId: string | null; delta: string }>();
 let deltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+// #5516 (epic #5514): adaptive delta-flush interval (was a fixed 100ms).
+// Production adapts to the current EWMA RTT via `resolveDeltaFlushMs`
+// (16-33ms cheap → 100ms poor). Tests pin it with
+// `setDeltaFlushIntervalOverride(N)`; `null` restores adaptive behavior.
+let _deltaFlushOverrideMs: number | null = null;
+export function setDeltaFlushIntervalOverride(ms: number | null): void {
+  _deltaFlushOverrideMs = ms;
+}
+function currentDeltaFlushMs(): number {
+  return _deltaFlushOverrideMs != null ? _deltaFlushOverrideMs : resolveDeltaFlushMs(_ewmaRtt);
+}
 
 function flushPendingDeltas(): void {
   deltaFlushTimer = null;
@@ -1542,7 +1556,9 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 
     scheduleFlush: () => {
       if (!deltaFlushTimer) {
-        deltaFlushTimer = setTimeout(flushPendingDeltas, 100);
+        // #5516 — adaptive interval (was a fixed 100ms). Memoized rows
+        // (step 1) make the tighter flush cheap: only the tail re-renders.
+        deltaFlushTimer = setTimeout(flushPendingDeltas, currentDeltaFlushMs());
       }
     },
   });

--- a/packages/server/src/connection-locality.js
+++ b/packages/server/src/connection-locality.js
@@ -1,0 +1,52 @@
+/**
+ * Connection-locality classification (#5516, epic #5514).
+ *
+ * Decides whether an inbound WebSocket upgrade came from a LOCAL / LAN peer
+ * (this machine over loopback, or another device on the local network) versus
+ * through the Cloudflare tunnel / a remote proxy.
+ *
+ * Used to skip permessage-deflate for local/LAN peers: on a fast local link the
+ * CPU cost of gzip-per-message buys nothing — the link isn't the bottleneck, so
+ * compressing just adds latency and burns cycles on the (already busy) dev
+ * machine. Tunnel connections KEEP deflate, where the WAN bandwidth saving is
+ * real.
+ *
+ * SECURITY: this mirrors the trust model in rate-limiter.js. Proxy headers
+ * (cf-connecting-ip / x-forwarded-for) are attacker-controllable over the
+ * network, so they can only make us treat a connection as REMOTE (keep deflate
+ * — the safe, unchanged default). They can never make a connection look local.
+ * The only inputs that can flip a connection to "local" are the kernel-supplied
+ * socket peer address (loopback or RFC1918) AND the ABSENCE of proxy headers.
+ * Worst case for a spoofer: deflate stays on. No security property depends on
+ * this classification — it's a pure transport-efficiency hint.
+ */
+
+import { isLoopbackHost } from './bind-host.js'
+import { isPrivateOrSpecialIp } from './ssrf-guard.js'
+
+function hasProxyHeaders(headers) {
+  if (!headers) return false
+  // A tunnel / reverse proxy stamps the original client IP here. Presence means
+  // the TCP peer is a proxy, not the real client — treat as remote.
+  return Boolean(headers['cf-connecting-ip'] || headers['x-forwarded-for'])
+}
+
+/**
+ * True when the upgrade request comes directly from this machine (loopback) or
+ * a LAN peer — i.e. NOT through the tunnel / a reverse proxy.
+ *
+ * @param {object} req - Node IncomingMessage. Reads `req.socket.remoteAddress`
+ *   (kernel-supplied, unspoofable) and the proxy headers.
+ * @returns {boolean}
+ */
+export function isLocalOrLanPeer(req) {
+  const socketIp = req?.socket?.remoteAddress
+  if (typeof socketIp !== 'string' || socketIp.length === 0) return false
+  // Any proxy header => the TCP peer is a proxy (tunnel/CDN). Keep deflate.
+  if (hasProxyHeaders(req.headers)) return false
+  // Direct loopback (same machine) — definitely local.
+  if (isLoopbackHost(socketIp)) return true
+  // Direct RFC1918 / link-local peer with no proxy in front — a LAN device.
+  if (isPrivateOrSpecialIp(socketIp)) return true
+  return false
+}

--- a/packages/server/src/connection-locality.js
+++ b/packages/server/src/connection-locality.js
@@ -27,8 +27,11 @@ import { isPrivateOrSpecialIp } from './ssrf-guard.js'
 function hasProxyHeaders(headers) {
   if (!headers) return false
   // A tunnel / reverse proxy stamps the original client IP here. Presence means
-  // the TCP peer is a proxy, not the real client — treat as remote.
-  return Boolean(headers['cf-connecting-ip'] || headers['x-forwarded-for'])
+  // the TCP peer is a proxy, not the real client — treat as remote. Test for
+  // PRESENCE (!= null), not truthiness: a proxy that forwards an empty-string
+  // header value still means "a proxy is in front", so it must keep deflate —
+  // never be misclassified as a direct local peer.
+  return headers['cf-connecting-ip'] != null || headers['x-forwarded-for'] != null
 }
 
 /**

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks'
 import { toShortModelId } from './models.js'
 import { createLogger } from './logger.js'
 

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -658,8 +658,25 @@ Object.assign(EVENT_MAP, {
  * Owns delta buffering with configurable flush interval.
  */
 export class EventNormalizer {
-  constructor({ flushIntervalMs = 50 } = {}) {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.flushIntervalMs=50] - default delta coalescing window.
+   * @param {number} [opts.singleClientFlushIntervalMs=25] - #5516 (epic #5514):
+   *   tighter window used when EXACTLY ONE client is subscribed to the session
+   *   being buffered. With a single viewer there's no fan-out to amortize, so a
+   *   tighter coalescing window cuts perceived streaming latency in half (the
+   *   common phone-on-LAN / single-dashboard case). Multi-client sessions keep
+   *   the default window unchanged — coalescing amortizes the fan-out cost and
+   *   keeps every client's bandwidth bounded.
+   * @param {(sessionId: string|null) => (number|null)} [opts.getSubscriberCount]
+   *   - returns how many clients are subscribed to `sessionId`, or null when
+   *   unknown (e.g. legacy single-session mode). When the count is exactly 1 the
+   *   single-client window is used; otherwise (0, ≥2, or null) the default.
+   */
+  constructor({ flushIntervalMs = 50, singleClientFlushIntervalMs = 25, getSubscriberCount = null } = {}) {
     this._flushIntervalMs = flushIntervalMs
+    this._singleClientFlushIntervalMs = singleClientFlushIntervalMs
+    this._getSubscriberCount = typeof getSubscriberCount === 'function' ? getSubscriberCount : null
     // Delta buffer: key -> accumulated text
     // In multi-session mode key = `${sessionId}:${messageId}`, otherwise just messageId
     this._deltaBuffer = new Map()
@@ -669,7 +686,25 @@ export class EventNormalizer {
     // — a true monotonic duration, same process both ends.
     this._deltaEmitMono = new Map()
     this._deltaFlushTimer = null
+    // #5516: monotonic deadline (performance.now ms) the pending flush timer is
+    // scheduled to fire at. Lets a later single-client buffer SHORTEN an
+    // already-scheduled default-window timer instead of waiting it out.
+    this._deltaFlushDeadline = 0
     this._onFlush = null // callback: (entries) => void, where entries = [{ key, sessionId, messageId, delta, emitMonoMs }]
+  }
+
+  /**
+   * #5516: resolve the coalescing window for the session currently being
+   * buffered. Single-subscriber sessions get the tighter window; everything
+   * else (0, 2+, or unknown count) keeps the default. No subscriber-count
+   * resolver wired (legacy mode) → always the default.
+   * @param {string|null} sessionId
+   * @returns {number} flush interval in ms
+   */
+  _resolveFlushIntervalMs(sessionId) {
+    if (!this._getSubscriberCount) return this._flushIntervalMs
+    const count = this._getSubscriberCount(sessionId)
+    return count === 1 ? this._singleClientFlushIntervalMs : this._flushIntervalMs
   }
 
   /**
@@ -731,8 +766,22 @@ export class EventNormalizer {
     if (typeof emitMonoMs === 'number' && !this._deltaEmitMono.has(key)) {
       this._deltaEmitMono.set(key, emitMonoMs)
     }
+    // #5516 (epic #5514): adaptive coalescing window — tighter (25ms) when this
+    // session has a single subscriber, default (50ms) otherwise. The flush
+    // timer is shared across all buffered sessions, so a single-client session
+    // buffered AFTER a default-window timer was already armed must be able to
+    // pull the deadline IN (reschedule to the sooner target) rather than wait
+    // out the 50ms. We never push a deadline out.
+    const intervalMs = this._resolveFlushIntervalMs(sessionId)
+    const now = performance.now()
+    const wantDeadline = now + intervalMs
     if (!this._deltaFlushTimer) {
-      this._deltaFlushTimer = setTimeout(() => this._flushDeltas(), this._flushIntervalMs)
+      this._deltaFlushDeadline = wantDeadline
+      this._deltaFlushTimer = setTimeout(() => this._flushDeltas(), intervalMs)
+    } else if (wantDeadline < this._deltaFlushDeadline) {
+      clearTimeout(this._deltaFlushTimer)
+      this._deltaFlushDeadline = wantDeadline
+      this._deltaFlushTimer = setTimeout(() => this._flushDeltas(), Math.max(0, wantDeadline - now))
     }
   }
 
@@ -766,6 +815,7 @@ export class EventNormalizer {
     if (this._deltaBuffer.size === 0 && this._deltaFlushTimer) {
       clearTimeout(this._deltaFlushTimer)
       this._deltaFlushTimer = null
+      this._deltaFlushDeadline = 0
     }
     return entries
   }
@@ -775,6 +825,7 @@ export class EventNormalizer {
    */
   _flushDeltas() {
     this._deltaFlushTimer = null
+    this._deltaFlushDeadline = 0
     if (this._deltaBuffer.size === 0) return
     if (this._onFlush) {
       const entries = []
@@ -816,6 +867,7 @@ export class EventNormalizer {
       clearTimeout(this._deltaFlushTimer)
       this._deltaFlushTimer = null
     }
+    this._deltaFlushDeadline = 0
     this._deltaBuffer.clear()
     this._deltaEmitMono.clear()
   }

--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -139,6 +139,28 @@ export class WsBroadcaster {
     }
   }
 
+  /**
+   * #5516 (epic #5514): count authenticated clients subscribed to a session.
+   * Mirrors `_broadcastToSession`'s default recipient filter (activeSessionId
+   * match OR explicit subscribedSessionIds membership) so the count reflects
+   * exactly who would receive a session-scoped broadcast. Used by the
+   * EventNormalizer to pick a tighter delta-coalescing window when exactly one
+   * client is watching.
+   * @param {string} sessionId
+   * @returns {number}
+   */
+  _countSessionSubscribers(sessionId) {
+    let count = 0
+    for (const [ws, client] of this._clients) {
+      if (!client.authenticated || ws.readyState !== 1) continue
+      if (client.activeSessionId === sessionId ||
+          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))) {
+        count++
+      }
+    }
+    return count
+  }
+
   /** Broadcast client_joined to all OTHER authenticated clients */
   _broadcastClientJoined(newClient, excludeWs) {
     const info = newClient.deviceInfo || {}

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -887,7 +887,15 @@ export class WsServer {
     }
 
     this.serverMode = 'cli'
-    this._normalizer = new EventNormalizer()
+    // #5516 (epic #5514): hand the normalizer a subscriber-count resolver so it
+    // can tighten the delta-coalescing window (50→25ms) when a session has a
+    // single subscriber — the common phone-on-LAN / single-dashboard case.
+    // Multi-client sessions keep the 50ms window (fan-out amortization). Legacy
+    // single-session mode (sessionId === null) reports 0 → default window.
+    this._normalizer = new EventNormalizer({
+      getSubscriberCount: (sessionId) =>
+        sessionId == null ? null : this._broadcaster._countSessionSubscribers(sessionId),
+    })
     this._gitInfo = getGitInfo()
     this._startedAt = Date.now()
     this._draining = false

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -28,6 +28,7 @@ import { WsBroadcaster } from './ws-broadcaster.js'
 import { WsClientManager } from './ws-client-manager.js'
 import { getProviderDataDirs } from './providers.js'
 import { isLoopbackHost } from './bind-host.js'
+import { isLocalOrLanPeer } from './connection-locality.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -1150,6 +1151,13 @@ export class WsServer {
     this.wss = new WebSocketServer({
       noServer: true,
       maxPayload: this._maxPayload,
+      // #5516 (epic #5514): permessage-deflate is enabled here for ALL
+      // connections (tunnel bandwidth saving). It is then SKIPPED per-connection
+      // for local/LAN peers in the 'upgrade' handler below (strip the client's
+      // Sec-WebSocket-Extensions header before handleUpgrade) — local links
+      // aren't bandwidth-bound, so compressing every frame just adds CPU
+      // latency. Choosing skip-on-local over a blanket higher threshold keeps
+      // tunnel behavior byte-for-byte unchanged.
       perMessageDeflate: {
         zlibDeflateOptions: { level: 6 },
         zlibInflateOptions: { chunkSize: 16 * 1024 },
@@ -1165,6 +1173,20 @@ export class WsServer {
         log.warn(`Pre-auth connection limit reached (${pendingCount}/${this._maxPendingConnections}), rejecting upgrade`)
         socket.end('HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
         return
+      }
+      // #5516 (epic #5514): skip permessage-deflate for local/LAN peers. On a
+      // fast local link compressing every message buys nothing (the link isn't
+      // the bottleneck) and just adds CPU latency on the dev machine. Tunnel
+      // connections KEEP deflate — that's where the WAN bandwidth saving is
+      // real. `ws` negotiates permessage-deflate from the client's
+      // Sec-WebSocket-Extensions request header, so deleting it for a local
+      // peer makes `handleUpgrade` complete WITHOUT compression for THIS socket
+      // only — the server-level config still applies to tunnel connections.
+      // Security: isLocalOrLanPeer keys off the unspoofable socket peer; a
+      // forged proxy header can only KEEP deflate (the safe default), never
+      // remove it. See connection-locality.js.
+      if (isLocalOrLanPeer(req)) {
+        delete req.headers['sec-websocket-extensions']
       }
       this.wss.handleUpgrade(req, socket, head, (ws) => {
         this.wss.emit('connection', ws, req)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -892,7 +892,8 @@ export class WsServer {
     // can tighten the delta-coalescing window (50→25ms) when a session has a
     // single subscriber — the common phone-on-LAN / single-dashboard case.
     // Multi-client sessions keep the 50ms window (fan-out amortization). Legacy
-    // single-session mode (sessionId === null) reports 0 → default window.
+    // single-session mode (sessionId === null) reports null (unknown), which the
+    // normalizer treats as "keep the default window".
     this._normalizer = new EventNormalizer({
       getSubscriberCount: (sessionId) =>
         sessionId == null ? null : this._broadcaster._countSessionSubscribers(sessionId),

--- a/packages/server/tests/connection-locality.test.js
+++ b/packages/server/tests/connection-locality.test.js
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isLocalOrLanPeer } from '../src/connection-locality.js'
+
+function req({ remoteAddress, headers = {} } = {}) {
+  return { socket: { remoteAddress }, headers }
+}
+
+describe('isLocalOrLanPeer (#5516)', () => {
+  it('treats a direct loopback peer as local', () => {
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '127.0.0.1' })), true)
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '::1' })), true)
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '::ffff:127.0.0.1' })), true)
+  })
+
+  it('treats a direct RFC1918 LAN peer as local', () => {
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '192.168.1.50' })), true)
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '10.0.0.4' })), true)
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '172.16.5.9' })), true)
+  })
+
+  it('treats a tunnel connection (loopback peer + proxy header) as REMOTE', () => {
+    // cloudflared connects from loopback but stamps the real client IP.
+    assert.equal(
+      isLocalOrLanPeer(req({ remoteAddress: '127.0.0.1', headers: { 'cf-connecting-ip': '203.0.113.7' } })),
+      false,
+    )
+    assert.equal(
+      isLocalOrLanPeer(req({ remoteAddress: '127.0.0.1', headers: { 'x-forwarded-for': '203.0.113.7' } })),
+      false,
+    )
+  })
+
+  it('a spoofed proxy header can only make a connection look REMOTE (deflate stays on)', () => {
+    // An attacker can add headers but cannot change the kernel socket peer.
+    // Worst case: a LAN peer is treated as remote and keeps deflate. Safe.
+    assert.equal(
+      isLocalOrLanPeer(req({ remoteAddress: '192.168.1.50', headers: { 'x-forwarded-for': '8.8.8.8' } })),
+      false,
+    )
+  })
+
+  it('treats a genuinely public socket peer as remote', () => {
+    // Note: a direct connection from a public IP only happens when the daemon
+    // is bound to a public interface (rare). Reserved doc ranges like
+    // 203.0.113.0/24 are flagged private by the SSRF guard, which is fine for
+    // this transport hint — they're never real remote clients anyway.
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '8.8.8.8' })), false)
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: '1.1.1.1' })), false)
+  })
+
+  it('is safe (remote) when the socket address is missing', () => {
+    assert.equal(isLocalOrLanPeer(req({ remoteAddress: undefined })), false)
+    assert.equal(isLocalOrLanPeer({}), false)
+    assert.equal(isLocalOrLanPeer(undefined), false)
+  })
+})

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventNormalizer, EVENT_MAP } from '../src/event-normalizer.js'
 import { ServerSkillChangedSchema } from '@chroxy/protocol'
@@ -916,6 +916,112 @@ describe('EventNormalizer', () => {
       assert.equal(normalizer._deltaBuffer.size, 0)
       assert.equal(normalizer._deltaFlushTimer, null)
     })
+  })
+})
+
+// ---- #5516 (epic #5514): adaptive single-client coalescing window ----
+
+describe('EventNormalizer adaptive flush window (#5516)', () => {
+  // Capture the delay each bufferDelta schedules its flush timer with, without
+  // depending on real wall-clock timing. We spy on global.setTimeout, record
+  // the requested delay, and return a dummy handle so the timer never actually
+  // fires during the assertion.
+  function withSetTimeoutSpy(fn) {
+    const delays = []
+    const orig = global.setTimeout
+    mock.method(global, 'setTimeout', (cb, ms, ...rest) => {
+      delays.push(ms)
+      // Real handle so clearTimeout works in the reschedule path; we never let
+      // it fire (orig with a huge delay would, so use a no-op handle instead).
+      return orig(() => {}, 1_000_000, ...rest)
+    })
+    try { fn(delays) } finally { mock.restoreAll() }
+  }
+
+  it('uses the 25ms window when a session has exactly one subscriber', () => {
+    const n = new EventNormalizer({ getSubscriberCount: () => 1 })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 25)
+    })
+    n.destroy()
+  })
+
+  it('uses the default 50ms window when 2+ clients are subscribed', () => {
+    const n = new EventNormalizer({ getSubscriberCount: () => 2 })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 50)
+    })
+    n.destroy()
+  })
+
+  it('uses the default window when 0 clients (or unknown count) are subscribed', () => {
+    const nZero = new EventNormalizer({ getSubscriberCount: () => 0 })
+    withSetTimeoutSpy((delays) => {
+      nZero.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 50)
+    })
+    nZero.destroy()
+
+    const nNull = new EventNormalizer({ getSubscriberCount: () => null })
+    withSetTimeoutSpy((delays) => {
+      nNull.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 50)
+    })
+    nNull.destroy()
+  })
+
+  it('keeps the default window when no subscriber-count resolver is wired (legacy)', () => {
+    const n = new EventNormalizer()
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 50)
+    })
+    n.destroy()
+  })
+
+  it('honors custom interval overrides', () => {
+    const n = new EventNormalizer({
+      flushIntervalMs: 80,
+      singleClientFlushIntervalMs: 12,
+      getSubscriberCount: () => 1,
+    })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 12)
+    })
+    n.destroy()
+  })
+
+  it('a single-client buffer pulls in an already-armed default-window deadline', () => {
+    // Per-session subscriber counts: sess-multi has 3 clients, sess-solo has 1.
+    const counts = { 'sess-multi': 3, 'sess-solo': 1 }
+    const n = new EventNormalizer({ getSubscriberCount: (s) => counts[s] ?? 0 })
+    withSetTimeoutSpy((delays) => {
+      // Multi-client session arms the 50ms timer first.
+      n.bufferDelta('sess-multi', 'm', 'a')
+      assert.equal(delays[0], 50)
+      // A solo session buffered immediately after must SHORTEN the deadline:
+      // the reschedule clears the old timer and arms a sooner one (~25ms).
+      n.bufferDelta('sess-solo', 's', 'b')
+      assert.equal(delays.length, 2, 'a reschedule must have occurred')
+      assert.ok(delays[1] <= 25, `expected reschedule <=25ms, got ${delays[1]}`)
+    })
+    n.destroy()
+  })
+
+  it('does NOT push the deadline out when a multi-client session buffers after a solo one', () => {
+    const counts = { 'sess-multi': 3, 'sess-solo': 1 }
+    const n = new EventNormalizer({ getSubscriberCount: (s) => counts[s] ?? 0 })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-solo', 's', 'a')      // arms ~25ms
+      assert.equal(delays[0], 25)
+      n.bufferDelta('sess-multi', 'm', 'b')     // wants 50ms — but 25ms deadline is sooner
+      // No reschedule: the existing sooner deadline stands.
+      assert.equal(delays.length, 1, 'must not reschedule to a later deadline')
+    })
+    n.destroy()
   })
 })
 

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -233,6 +233,42 @@ describe('WsBroadcaster', () => {
     })
   })
 
+  // #5516 (epic #5514): subscriber count drives the normalizer's adaptive
+  // delta-coalescing window (25ms when a session has exactly one viewer).
+  describe('_countSessionSubscribers()', () => {
+    it('counts activeSessionId matches and explicit subscribers', () => {
+      clients.set(createFakeWs(), createFakeClient({ id: 'c1', activeSessionId: 'sess-1' }))
+      clients.set(createFakeWs(), createFakeClient({ id: 'c2', activeSessionId: 'other', subscribedSessionIds: new Set(['sess-1']) }))
+      clients.set(createFakeWs(), createFakeClient({ id: 'c3', activeSessionId: 'other' }))
+      assert.equal(broadcaster._countSessionSubscribers('sess-1'), 2)
+      assert.equal(broadcaster._countSessionSubscribers('other'), 2) // c2 active + c3 active
+    })
+
+    it('returns 1 for a single-viewer session', () => {
+      clients.set(createFakeWs(), createFakeClient({ id: 'c1', activeSessionId: 'solo' }))
+      assert.equal(broadcaster._countSessionSubscribers('solo'), 1)
+    })
+
+    it('returns 0 when nobody is watching', () => {
+      clients.set(createFakeWs(), createFakeClient({ id: 'c1', activeSessionId: 'other' }))
+      assert.equal(broadcaster._countSessionSubscribers('ghost'), 0)
+    })
+
+    it('excludes unauthenticated and non-OPEN clients', () => {
+      clients.set(createFakeWs({ readyState: 1 }), createFakeClient({ id: 'c1', activeSessionId: 'sess-1', authenticated: false }))
+      clients.set(createFakeWs({ readyState: 3 }), createFakeClient({ id: 'c2', activeSessionId: 'sess-1' }))
+      clients.set(createFakeWs({ readyState: 1 }), createFakeClient({ id: 'c3', activeSessionId: 'sess-1' }))
+      assert.equal(broadcaster._countSessionSubscribers('sess-1'), 1)
+    })
+
+    it('does not throw when a client lacks subscribedSessionIds (#4799 parity)', () => {
+      const c = createFakeClient({ id: 'c1', activeSessionId: 'other' })
+      c.subscribedSessionIds = undefined
+      clients.set(createFakeWs(), c)
+      assert.equal(broadcaster._countSessionSubscribers('sess-1'), 0)
+    })
+  })
+
   describe('_broadcastClientJoined()', () => {
     it('sends client_joined to all except the joining client ws', () => {
       const wsNew = createFakeWs()

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4601,3 +4601,67 @@ describe('WsServer _historyCtx.resultTimeoutMs late-binds to config (#3766)', ()
     assert.equal(authOk.hardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
   })
 })
+
+// #5516 (epic #5514): permessage-deflate is skipped for local/LAN peers so a
+// fast local link doesn't pay per-frame gzip CPU, but kept for tunnel
+// connections (real WAN bandwidth saving). The decision keys off the
+// unspoofable socket peer; a forged proxy header can only KEEP deflate.
+describe('WsServer permessage-deflate locality (#5516)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  /** Open a ws client (offering permessage-deflate) and return its negotiated extensions string. */
+  async function negotiatedExtensions(port, headers) {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers })
+    await withTimeout(
+      new Promise((resolve, reject) => {
+        ws.once('open', resolve)
+        ws.once('error', reject)
+      }),
+      2000,
+      'connection timeout',
+    )
+    // ws exposes the negotiated extensions; permessage-deflate present => compression on.
+    const ext = ws.extensions || ''
+    ws.close()
+    return ext
+  }
+
+  it('does NOT negotiate permessage-deflate for a direct loopback peer', async () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-deflate',
+      cliSession: createMockSession(),
+      authRequired: false,
+    })
+    const port = await startServerAndGetPort(server)
+    const ext = await negotiatedExtensions(port)
+    assert.ok(
+      !/permessage-deflate/.test(ext),
+      `loopback peer should skip deflate, got extensions: "${ext}"`,
+    )
+  })
+
+  it('DOES negotiate permessage-deflate when a proxy header marks the connection as remote (tunnel)', async () => {
+    server = new WsServer({
+      port: 0,
+      apiToken: 'tok-deflate',
+      cliSession: createMockSession(),
+      authRequired: false,
+    })
+    const port = await startServerAndGetPort(server)
+    // A real tunnel arrives from loopback but stamps cf-connecting-ip; simulate
+    // that so isLocalOrLanPeer treats the connection as remote and keeps deflate.
+    const ext = await negotiatedExtensions(port, { 'cf-connecting-ip': '203.0.113.9' })
+    assert.ok(
+      /permessage-deflate/.test(ext),
+      `tunnel peer should keep deflate, got extensions: "${ext}"`,
+    )
+  })
+})

--- a/packages/store-core/src/delta-flush.test.ts
+++ b/packages/store-core/src/delta-flush.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveDeltaFlushMs,
+  DELTA_FLUSH_MIN_MS,
+  DELTA_FLUSH_FLOOR_MS,
+  DELTA_FLUSH_MAX_MS,
+  DELTA_FLUSH_CHEAP_RTT_MS,
+  DELTA_FLUSH_POOR_RTT_MS,
+} from './delta-flush'
+
+describe('resolveDeltaFlushMs', () => {
+  it('returns the floor when RTT is unknown', () => {
+    expect(resolveDeltaFlushMs(null)).toBe(DELTA_FLUSH_FLOOR_MS)
+    expect(resolveDeltaFlushMs(undefined)).toBe(DELTA_FLUSH_FLOOR_MS)
+    expect(resolveDeltaFlushMs(NaN)).toBe(DELTA_FLUSH_FLOOR_MS)
+    expect(resolveDeltaFlushMs(Infinity)).toBe(DELTA_FLUSH_FLOOR_MS)
+  })
+
+  it('flushes at the min interval on a cheap (low-RTT) link', () => {
+    expect(resolveDeltaFlushMs(0)).toBe(DELTA_FLUSH_MIN_MS)
+    expect(resolveDeltaFlushMs(5)).toBe(DELTA_FLUSH_MIN_MS)
+    expect(resolveDeltaFlushMs(DELTA_FLUSH_CHEAP_RTT_MS)).toBe(DELTA_FLUSH_MIN_MS)
+  })
+
+  it('flushes at the max interval on a poor (high-RTT) link', () => {
+    expect(resolveDeltaFlushMs(DELTA_FLUSH_POOR_RTT_MS)).toBe(DELTA_FLUSH_MAX_MS)
+    expect(resolveDeltaFlushMs(1000)).toBe(DELTA_FLUSH_MAX_MS)
+  })
+
+  it('ramps monotonically from floor toward max across the mid band', () => {
+    const mid = (DELTA_FLUSH_CHEAP_RTT_MS + DELTA_FLUSH_POOR_RTT_MS) / 2
+    const v = resolveDeltaFlushMs(mid)
+    expect(v).toBeGreaterThan(DELTA_FLUSH_FLOOR_MS)
+    expect(v).toBeLessThan(DELTA_FLUSH_MAX_MS)
+    // Strictly increasing as RTT degrades.
+    expect(resolveDeltaFlushMs(100)).toBeLessThanOrEqual(resolveDeltaFlushMs(200))
+    expect(resolveDeltaFlushMs(200)).toBeLessThanOrEqual(resolveDeltaFlushMs(300))
+  })
+
+  it('never returns outside [MIN, MAX]', () => {
+    for (const rtt of [-50, 0, 30, 60, 150, 300, 400, 5000]) {
+      const v = resolveDeltaFlushMs(rtt)
+      expect(v).toBeGreaterThanOrEqual(DELTA_FLUSH_MIN_MS)
+      expect(v).toBeLessThanOrEqual(DELTA_FLUSH_MAX_MS)
+    }
+  })
+})

--- a/packages/store-core/src/delta-flush.ts
+++ b/packages/store-core/src/delta-flush.ts
@@ -1,0 +1,60 @@
+/**
+ * Adaptive client-side delta-flush interval (#5516, epic #5514).
+ *
+ * The client batches incoming `stream_delta` tokens and flushes them to the
+ * store (the render trigger) on a timer. Before #5516 that timer was a fixed
+ * 100ms — which, stacked on the server's 50ms coalescing window, added up to
+ * ~150ms of token-batching latency even on a LAN where RTT is single-digit ms.
+ *
+ * Now the interval ADAPTS to the smoothed (EWMA) round-trip time:
+ *
+ *   - Good link (low RTT): flush fast — there's no transport latency to hide
+ *     behind, so a tight interval makes streaming feel live. We floor at 16ms
+ *     ("one frame") on a clearly-cheap link and 33ms ("two frames") otherwise.
+ *   - Poor link (high RTT): the transport already dominates perceived latency,
+ *     so flushing faster just burns CPU re-rendering for no felt benefit. We
+ *     scale back toward the old 100ms so big batches amortize the render cost.
+ *
+ * The memoization landed first (step 1 of #5516) so a faster flush only
+ * re-renders the tail bubble — without it, a 16ms flush would re-parse the
+ * whole transcript 60×/sec.
+ *
+ * Pure + dependency-free so the app and dashboard share identical behavior and
+ * it's trivially unit-testable. Both call sites keep a constant override (the
+ * raw setTimeout(..., N) is replaced by setTimeout(..., resolveDeltaFlushMs())
+ * with the override threaded through) so tests can pin the interval.
+ */
+
+/** Tightest flush on a clearly-cheap (low-RTT) link — one 60fps frame. */
+export const DELTA_FLUSH_MIN_MS = 16
+/** Default floor when RTT is unknown or merely "good" — two frames. */
+export const DELTA_FLUSH_FLOOR_MS = 33
+/** Ceiling — the legacy fixed interval, used when the link is poor. */
+export const DELTA_FLUSH_MAX_MS = 100
+
+/** At/below this EWMA RTT the link is "cheap": flush at DELTA_FLUSH_MIN_MS. */
+export const DELTA_FLUSH_CHEAP_RTT_MS = 60
+/** At/above this EWMA RTT the link is "poor": flush at DELTA_FLUSH_MAX_MS. */
+export const DELTA_FLUSH_POOR_RTT_MS = 400
+
+/**
+ * Resolve the delta-flush interval (ms) for the current smoothed RTT.
+ *
+ * @param ewmaRtt - EWMA-smoothed round-trip time in ms, or null when no
+ *   ping/pong has completed yet (treated as "good but unknown" → floor).
+ * @returns flush interval in ms, in [DELTA_FLUSH_MIN_MS, DELTA_FLUSH_MAX_MS].
+ *
+ * Shape:
+ *   - rtt <= CHEAP            → MIN (16ms)
+ *   - CHEAP < rtt < POOR      → linear ramp FLOOR (33ms) → MAX (100ms)
+ *   - rtt >= POOR             → MAX (100ms)
+ *   - rtt null / non-finite   → FLOOR (33ms)
+ */
+export function resolveDeltaFlushMs(ewmaRtt: number | null | undefined): number {
+  if (ewmaRtt == null || !Number.isFinite(ewmaRtt)) return DELTA_FLUSH_FLOOR_MS
+  if (ewmaRtt <= DELTA_FLUSH_CHEAP_RTT_MS) return DELTA_FLUSH_MIN_MS
+  if (ewmaRtt >= DELTA_FLUSH_POOR_RTT_MS) return DELTA_FLUSH_MAX_MS
+  // Linear ramp from FLOOR (at CHEAP) to MAX (at POOR).
+  const t = (ewmaRtt - DELTA_FLUSH_CHEAP_RTT_MS) / (DELTA_FLUSH_POOR_RTT_MS - DELTA_FLUSH_CHEAP_RTT_MS)
+  return Math.round(DELTA_FLUSH_FLOOR_MS + t * (DELTA_FLUSH_MAX_MS - DELTA_FLUSH_FLOOR_MS))
+}

--- a/packages/store-core/src/delta-flush.ts
+++ b/packages/store-core/src/delta-flush.ts
@@ -54,7 +54,10 @@ export function resolveDeltaFlushMs(ewmaRtt: number | null | undefined): number 
   if (ewmaRtt == null || !Number.isFinite(ewmaRtt)) return DELTA_FLUSH_FLOOR_MS
   if (ewmaRtt <= DELTA_FLUSH_CHEAP_RTT_MS) return DELTA_FLUSH_MIN_MS
   if (ewmaRtt >= DELTA_FLUSH_POOR_RTT_MS) return DELTA_FLUSH_MAX_MS
-  // Linear ramp from FLOOR (at CHEAP) to MAX (at POOR).
+  // Linear ramp toward MAX across the open band (CHEAP, POOR): rising just
+  // above CHEAP starts at FLOOR and climbs to MAX as RTT approaches POOR. (At
+  // exactly CHEAP the earlier branch already returned MIN, so the ramp's lower
+  // endpoint is approached from above, not hit.)
   const t = (ewmaRtt - DELTA_FLUSH_CHEAP_RTT_MS) / (DELTA_FLUSH_POOR_RTT_MS - DELTA_FLUSH_CHEAP_RTT_MS)
   return Math.round(DELTA_FLUSH_FLOOR_MS + t * (DELTA_FLUSH_MAX_MS - DELTA_FLUSH_FLOOR_MS))
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -541,3 +541,16 @@ export {
   resetRenderCounts,
   renderCountSnapshot,
 } from './render-counter'
+
+// #5516 (epic #5514): adaptive client delta-flush interval. Replaces the fixed
+// 100ms client flush with an RTT-aware floor (16-33ms on a cheap link, scaling
+// toward 100ms when EWMA RTT is poor). Shared so the app and dashboard adapt
+// identically; pure + testable with a constant override at each call site.
+export {
+  resolveDeltaFlushMs,
+  DELTA_FLUSH_MIN_MS,
+  DELTA_FLUSH_FLOOR_MS,
+  DELTA_FLUSH_MAX_MS,
+  DELTA_FLUSH_CHEAP_RTT_MS,
+  DELTA_FLUSH_POOR_RTT_MS,
+} from './delta-flush'

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -531,3 +531,13 @@ export {
 // measure token-to-render and uplink/downlink identically.
 export { RollingPercentiles, splitRtt } from './latency-stats'
 export type { RttSplit, RttSplitInput } from './latency-stats'
+
+// #5516 (epic #5514): dev-only render counter — a process-global tally used by
+// the bubble-memoization tests to prove non-tail bubbles don't re-render (and
+// re-parse markdown) on a streaming delta flush. Never read on the hot path.
+export {
+  bumpRenderCount,
+  getRenderCount,
+  resetRenderCounts,
+  renderCountSnapshot,
+} from './render-counter'

--- a/packages/store-core/src/render-counter.test.ts
+++ b/packages/store-core/src/render-counter.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  bumpRenderCount,
+  getRenderCount,
+  resetRenderCounts,
+  renderCountSnapshot,
+} from './render-counter'
+
+describe('render-counter', () => {
+  beforeEach(() => resetRenderCounts())
+
+  it('starts at 0 for an unknown label', () => {
+    expect(getRenderCount('nope')).toBe(0)
+  })
+
+  it('increments and returns the running tally', () => {
+    expect(bumpRenderCount('a')).toBe(1)
+    expect(bumpRenderCount('a')).toBe(2)
+    expect(getRenderCount('a')).toBe(2)
+  })
+
+  it('tracks labels independently', () => {
+    bumpRenderCount('a')
+    bumpRenderCount('b')
+    bumpRenderCount('b')
+    expect(getRenderCount('a')).toBe(1)
+    expect(getRenderCount('b')).toBe(2)
+  })
+
+  it('reset clears one label or all', () => {
+    bumpRenderCount('a')
+    bumpRenderCount('b')
+    resetRenderCounts('a')
+    expect(getRenderCount('a')).toBe(0)
+    expect(getRenderCount('b')).toBe(1)
+    resetRenderCounts()
+    expect(getRenderCount('b')).toBe(0)
+  })
+
+  it('snapshot reflects all tracked labels', () => {
+    bumpRenderCount('a')
+    bumpRenderCount('a')
+    bumpRenderCount('b')
+    expect(renderCountSnapshot()).toEqual({ a: 2, b: 1 })
+  })
+})

--- a/packages/store-core/src/render-counter.ts
+++ b/packages/store-core/src/render-counter.ts
@@ -1,0 +1,42 @@
+/**
+ * Dev-only render counter (#5516, epic #5514).
+ *
+ * A process-global tally of how many times a labelled component instance has
+ * rendered. Used by the memoization tests (and ad-hoc dev debugging) to PROVE
+ * that non-tail chat bubbles do not re-render — and re-parse markdown — on a
+ * streaming delta flush.
+ *
+ * Deliberately tiny and dependency-free: a single `Map<label, count>`. It is
+ * NEVER consulted on the production hot path — only the tests and an opt-in
+ * dev log read it. Components call {@link bumpRenderCount} from their render
+ * body (cheap Map write); the buffers/percentiles live in `latency-stats`.
+ *
+ * The counter is keyed by an arbitrary string label. Callers that want a
+ * per-instance tally pass a stable id (e.g. `MessageBubble:${message.id}`);
+ * callers that want an aggregate pass a constant (e.g. `MessageBubble`).
+ */
+
+const _counts = new Map<string, number>()
+
+/** Increment (and return) the render tally for `label`. */
+export function bumpRenderCount(label: string): number {
+  const next = (_counts.get(label) ?? 0) + 1
+  _counts.set(label, next)
+  return next
+}
+
+/** Current render tally for `label` (0 if never rendered). */
+export function getRenderCount(label: string): number {
+  return _counts.get(label) ?? 0
+}
+
+/** Reset one label's tally, or all of them when `label` is omitted. */
+export function resetRenderCounts(label?: string): void {
+  if (label === undefined) _counts.clear()
+  else _counts.delete(label)
+}
+
+/** Snapshot of every tracked label → count. Test/debug only. */
+export function renderCountSnapshot(): Record<string, number> {
+  return Object.fromEntries(_counts)
+}


### PR DESCRIPTION
## Smooth streaming (#5516, epic #5514)

Cuts the token-batching latency that makes remote chroxy feel "remoted-in" rather than live. Implemented in the ordered sequence the issue specifies — **memoization first**, which is the prerequisite that makes the faster client flush safe (without it, a 16ms flush would re-parse the whole transcript ~60×/sec).

### 1. Memoize bubbles (prerequisite)
- **store-core**: dev-only render counter (`bumpRenderCount`/`getRenderCount`/`resetRenderCounts`/`renderCountSnapshot`) — a process-global tally, never read on the hot path, used to prove non-tail bubbles don't re-render.
- **app `MessageBubble`**: `React.memo` with a comparator keyed on message identity (the store replaces only the streamed message's object per flush, so non-tail messages keep their reference) plus the render-affecting scalar props; callback identity is intentionally ignored. `FormattedResponse` memoized too so a forced bubble re-render (selection/expiry) with unchanged content still skips the markdown re-parse.
- **dashboard `ChatView`**: extracted the default message row into a memoized `DefaultMessageRow` keyed on id/type/content/timestamp/isStreaming, so only the streamed row re-runs `renderMarkdown` (was an O(conversation) inline re-parse on every store update). Icon/rowClass derived inside the memo so a fresh JSX icon can't defeat the skip.

### 2. Adaptive client flush (100ms → ~16–33ms)
- **store-core `resolveDeltaFlushMs(ewmaRtt)`**: pure, shared, testable. 16ms on a clearly-cheap link (≤60ms RTT), 33ms floor when RTT is unknown/good, linear ramp toward the legacy 100ms as RTT degrades to ≥400ms (poor links: transport already dominates, so big batches amortize render cost).
- app + dashboard `message-handler` `scheduleFlush` now read the current EWMA RTT through it. Each exposes `setDeltaFlushIntervalOverride(ms)` so the constant stays testable.

### 3. Server coalescing (50ms → 25ms for single-subscriber sessions)
- **event-normalizer**: adaptive coalescing window. When exactly one client is subscribed to the session being buffered, use 25ms; otherwise (0/2+/unknown) keep the unchanged 50ms — multi-client behavior is **not** changed (fan-out amortization). The shared flush timer pulls its deadline IN for a solo session buffered after a default-window timer was already armed (never pushes out). Config-gated via constructor opts + a `getSubscriberCount` resolver.
- **ws-broadcaster** `_countSessionSubscribers` mirrors `_broadcastToSession`'s recipient filter. **ws-server** wires the resolver; legacy single-session mode reports null → default window.

### 4. permessage-deflate threshold
- **connection-locality** `isLocalOrLanPeer(req)` — true for a direct loopback/RFC1918 socket peer with no proxy headers; false (remote) when `cf-connecting-ip`/`x-forwarded-for` is present (tunnel/CDN). Keys off the unspoofable kernel socket peer; a forged proxy header can only KEEP deflate (the safe default), never strip it.
- **ws-server** strips the client's `Sec-WebSocket-Extensions` header for local/LAN peers at upgrade time so `ws` negotiates that socket WITHOUT compression — per-connection, leaving the server-level config and **tunnel behavior byte-for-byte unchanged**. Chose skip-on-local over a blanket higher threshold so tunnel framing is untouched.

## No protocol changes
No schema changes (the #5520 instrumentation already added `serverTs`/`splitRtt`; this PR only consumes it).

## Tests
- **store-core** (vitest): full suite 1226 passed (incl. new `delta-flush` + `render-counter`).
- **dashboard** (vitest): full suite 3405 passed (incl. new `ChatView.memoization` + flush-override).
- **app** (jest): touched components + store 427 passed (incl. new `MessageBubble.memoization` proving only the tail bubble re-renders on a delta flush + flush-override).
- **server** (node:test, `--test-force-exit`): ws-server/ws-forwarding/ws-broadcaster/event-normalizer/connection-locality 369 passed, incl. new adaptive-window selection + reschedule semantics, subscriber-count counting, locality classification table, and an **e2e** test proving deflate is absent for a loopback client and present when a proxy header marks the connection remote.
- Server lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) + eslint on changed server files: clean. TS strict typecheck (app/dashboard/store-core): clean.

The render-counter test is the concrete "memo proves non-tail bubbles don't re-render" measuring stick the issue/epic asked for; live p50/p95 token-to-render numbers require a running daemon + device and weren't captured in this pass.

Closes #5516.
Related to #5514.
