### PR TITLE
perf(app): virtualize the chat list

### DIFF
--- a/packages/app/__tests__/ComponentRendering.test.ts
+++ b/packages/app/__tests__/ComponentRendering.test.ts
@@ -107,8 +107,9 @@ describe('ChatView component', () => {
     expect(chatViewSrc).toMatch(/import\s+React,\s*\{.*useState.*useRef.*useEffect.*useMemo/)
   })
 
-  test('imports ScrollView, AccessibilityInfo from react-native', () => {
-    expect(chatViewSrc).toMatch(/import[\s\S]*ScrollView[\s\S]*from\s+['"]react-native['"]/)
+  test('imports FlatList, AccessibilityInfo from react-native (#5517 virtualized list)', () => {
+    // #5517: the transcript is now a virtualized FlatList, not a ScrollView.
+    expect(chatViewSrc).toMatch(/import[\s\S]*FlatList[\s\S]*from\s+['"]react-native['"]/)
     expect(chatViewSrc).toMatch(/import[\s\S]*AccessibilityInfo[\s\S]*from\s+['"]react-native['"]/)
   })
 
@@ -142,7 +143,9 @@ describe('ChatView component', () => {
   })
 
   test('shows empty state text when no messages', () => {
-    expect(chatViewSrc).toMatch(/messages\.length === 0/)
+    // #5517: empty state is rendered through FlatList's ListEmptyComponent
+    // rather than a `messages.length === 0` ternary in the render body.
+    expect(chatViewSrc).toMatch(/ListEmptyComponent/)
     expect(chatViewSrc).toMatch(/Connected\. Send a message to Claude!/)
     expect(chatViewSrc).toMatch(/Starting Claude Code\.\.\./)
   })

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -472,10 +472,18 @@ export function ChatView({
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="handled"
         // #5517: search match scroll uses scrollToIndex; rows are variable-
-        // height and unmeasured until laid out, so swallow the failure and
-        // retry after the list reports content-size. Without this RN throws
-        // when scrolling to an off-screen index.
+        // height and unmeasured until laid out, so RN throws when the target
+        // is past `highestMeasuredFrameIndex`. Recover with the RN-recommended
+        // two-step: first `scrollToOffset` to the target's *estimated* offset
+        // (`index * averageItemLength`) — this mounts/measures the rows in
+        // between — then retry `scrollToIndex` on the next frame to land
+        // precisely. Bare-retrying scrollToIndex (the old path) could re-throw
+        // repeatedly when the row is still far off-screen.
         onScrollToIndexFailed={(info) => {
+          scrollViewRef.current?.scrollToOffset({
+            offset: info.index * info.averageItemLength,
+            animated: true,
+          });
           setTimeout(() => {
             scrollViewRef.current?.scrollToIndex({
               index: info.index,

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -1,16 +1,18 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   StyleSheet,
-  ScrollView,
+  FlatList,
   Platform,
   NativeSyntheticEvent,
   NativeScrollEvent,
   AccessibilityInfo,
+  ListRenderItemInfo,
 } from 'react-native';
 import type { ChatMessage, ToolResultImage } from '../store/connection';
+import type { DisplayGroup } from '@chroxy/store-core';
 import { ImageViewer } from './ImageViewer';
 import { AnimatedMessage } from './AnimatedMessage';
 import { ICON_CHEVRON_RIGHT } from '../constants/icons';
@@ -28,7 +30,13 @@ import { useConnectionStore } from '../store/connection';
 
 export interface ChatViewProps {
   messages: ChatMessage[];
-  scrollViewRef: React.RefObject<ScrollView | null>;
+  /**
+   * #5517: the chat list is now a virtualized FlatList. SessionScreen owns
+   * the ref and only passes it through (it never calls methods on it) — all
+   * imperative scrolling happens inside ChatView. Typed as FlatList; the
+   * `<unknown>` data param keeps SessionScreen's `useRef<FlatList>` simple.
+   */
+  scrollViewRef: React.RefObject<FlatList<unknown> | null>;
   claudeReady: boolean;
   /**
    * #4755 — `value` is `string` for regular option taps + zero-options
@@ -152,6 +160,26 @@ export function ChatView({
   const [toolDetail, setToolDetail] = useState<{ toolName: string; content: string; toolResult?: string; toolResultTruncated?: boolean; toolResultImages?: ToolResultImage[]; serverName?: string } | null>(null);
   const [viewerUri, setViewerUri] = useState<string | null>(null);
 
+  // #5517: row expand/collapse registry, keyed by message id / activity
+  // group key. The list is now a virtualized FlatList, so an off-screen tool
+  // bubble / activity group / answered-permission pill can unmount and remount
+  // as the user scrolls. Holding the expanded flags HERE — outside the
+  // recyclable row — means a recycled row reopens to the user's last choice
+  // instead of snapping back to collapsed. Rows seed from this map on mount
+  // (`getInitialExpanded`) and write back on toggle (`handleExpandedChange`).
+  // A ref (not state) keeps writes off the render hot path — recycled rows
+  // re-read it on their own mount, so ChatView never needs to re-render to
+  // surface a persisted flag.
+  const expandedIdsRef = useRef<Map<string, boolean>>(new Map());
+  const getInitialExpanded = useCallback(
+    (id: string) => expandedIdsRef.current.get(id) ?? false,
+    [],
+  );
+  const handleExpandedChange = useCallback((id: string, expanded: boolean) => {
+    if (expanded) expandedIdsRef.current.set(id, true);
+    else expandedIdsRef.current.delete(id);
+  }, []);
+
   // Animation: only animate messages arriving after initial mount
   const mountTimeRef = useRef(Date.now());
   const [reduceMotion, setReduceMotion] = useState(true);
@@ -161,15 +189,25 @@ export function ChatView({
     return () => listener.remove();
   }, []);
 
-  // Track message layout positions for search scroll-to-match
-  const messageLayoutsRef = useRef<Map<string, number>>(new Map());
+  // #5517: search scroll-to-match. The pre-virtualization ScrollView tracked
+  // each row's pixel y via onLayout and called `scrollTo({ y })`. A FlatList
+  // can't scroll to an arbitrary pixel offset for an off-screen (unmeasured)
+  // row, so we scroll to the row's INDEX instead. `groupIndexByMessageId`
+  // maps every message id (including each message inside an activity group)
+  // to its row index; `scrollToIndex` with `viewPosition: 0` lands the match
+  // near the top of the viewport (mirroring the old `y - 80` headroom).
+  const groupIndexByMessageIdRef = useRef<Map<string, number>>(new Map());
 
   // Scroll to the current search match when it changes
   useEffect(() => {
     if (!currentMatchId) return;
-    const y = messageLayoutsRef.current.get(currentMatchId);
-    if (y != null) {
-      scrollViewRef.current?.scrollTo({ y: Math.max(0, y - 80), animated: true });
+    const index = groupIndexByMessageIdRef.current.get(currentMatchId);
+    if (index != null) {
+      scrollViewRef.current?.scrollToIndex({
+        index,
+        animated: true,
+        viewPosition: 0,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- scrollViewRef is a stable ref
   }, [currentMatchId]);
@@ -237,6 +275,22 @@ export function ChatView({
     [messages, streamingMessageId],
   );
 
+  // #5517: map every message id (and each id inside an activity group) to its
+  // FlatList row index so search-match scroll can target a row by index. Kept
+  // in a ref synced from this memo — the search effect reads it imperatively.
+  useMemo(() => {
+    const map = new Map<string, number>();
+    displayGroups.forEach((group, index) => {
+      if (group.type === 'activity') {
+        for (const m of group.messages) map.set(m.id, index);
+      } else {
+        map.set(group.message.id, index);
+      }
+    });
+    groupIndexByMessageIdRef.current = map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref write, no render dependency
+  }, [displayGroups]);
+
   // #4496: last user input — used to gate the stream-stall chip's Retry
   // button. Mirrors the dashboard's `isTail` check (only the most recent
   // stall retry-button-wires; historical replayed stalls render chip
@@ -265,136 +319,196 @@ export function ChatView({
   };
 
   const scrollToTop = () => {
-    scrollViewRef.current?.scrollTo({ y: 0, animated: true });
+    scrollViewRef.current?.scrollToOffset({ offset: 0, animated: true });
   };
 
   const scrollToBottom = () => {
     scrollViewRef.current?.scrollToEnd({ animated: true });
   };
 
+  // #5517: stable per-row key. Activity groups carry a synthetic
+  // `activity-<firstId>` key (so a group never collapses onto a member id);
+  // single rows key by their message id. Identity-stable keys are what let
+  // the #5516 MessageBubble memo skip reconciliation on a streaming flush —
+  // the FlatList must not key by array index.
+  const keyExtractor = useCallback(
+    (group: DisplayGroup) => (group.type === 'activity' ? group.key : group.message.id),
+    [],
+  );
+
+  // #5517: FlatList row renderer — the body of the old `displayGroups.map`,
+  // lifted out so FlatList can mount/unmount rows on demand. Behaviour is
+  // otherwise identical: ActivityGroup for grouped tool/thinking runs,
+  // MessageBubble for single rows, with the #4615 stalled-prompt suppression
+  // and the #4496 tail-only stream-stall retry wiring preserved.
+  const renderItem = useCallback(
+    ({ item: group }: ListRenderItemInfo<DisplayGroup>) => {
+      if (group.type === 'activity') {
+        const firstMsg = group.messages[0];
+        return (
+          <AnimatedMessage
+            type={firstMsg.type}
+            timestamp={firstMsg.timestamp}
+            mountTime={mountTimeRef.current}
+            reduceMotion={reduceMotion}
+          >
+            <ActivityGroup
+              messages={group.messages}
+              isActive={group.isActive}
+              isSelecting={isSelecting}
+              selectedIds={selectedIds}
+              onToggleSelection={onToggleSelection}
+              searchMatchIds={searchMatchIds}
+              groupKey={group.key}
+              getInitialExpanded={getInitialExpanded}
+              onExpandedChange={handleExpandedChange}
+            />
+          </AnimatedMessage>
+        );
+      }
+      const msg = group.message;
+      // #4615 (mobile parity via #4806): suppress unanswered prompts
+      // invalidated by a subsequent ASK_USER_QUESTION_STALL. The pending
+      // prompt has already been discarded server-side; the stall-chip
+      // rendered for the error bubble carries the retry affordance.
+      if (
+        msg.type === 'prompt' &&
+        msg.options &&
+        !msg.requestId &&
+        stalledPromptIds.has(msg.id)
+      ) {
+        return null;
+      }
+      const isSearchMatch = searchMatchIds?.has(msg.id) ?? false;
+      const isCurrentMatch = currentMatchId === msg.id;
+      return (
+        <View
+          style={isSearchMatch ? (isCurrentMatch ? styles.searchMatchCurrent : styles.searchMatch) : undefined}
+        >
+          <AnimatedMessage
+            type={msg.type}
+            timestamp={msg.timestamp}
+            mountTime={mountTimeRef.current}
+            reduceMotion={reduceMotion}
+          >
+            <MessageBubble
+              message={msg}
+              onSelectOption={onSelectOption}
+              onSubmitMultiQuestion={onSubmitMultiQuestion}
+              allowMultiQuestion={allowMultiQuestion}
+              isSelected={selectedIds.has(msg.id)}
+              isSelecting={isSelecting}
+              onLongPress={() => onToggleSelection(msg.id)}
+              onPress={() => onToggleSelection(msg.id)}
+              onOpenDetail={handleOpenDetail}
+              onImagePress={setViewerUri}
+              getInitialExpanded={getInitialExpanded}
+              onExpandedChange={handleExpandedChange}
+              onRetryStreamStall={
+                // #4496: only wire retry when this stall is the tail bubble
+                // AND there's a user_input to resend.
+                msg.type === 'error' &&
+                msg.code === 'stream_stall' &&
+                msg.id === chatTailMessageId &&
+                lastUserInputContent != null
+                  ? () => sendInput(lastUserInputContent)
+                  : undefined
+              }
+            />
+          </AnimatedMessage>
+        </View>
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mountTimeRef/getInitialExpanded/handleExpandedChange are stable; the rest are render-affecting and intentionally tracked
+    [
+      reduceMotion,
+      isSelecting,
+      selectedIds,
+      onToggleSelection,
+      searchMatchIds,
+      currentMatchId,
+      stalledPromptIds,
+      onSelectOption,
+      onSubmitMultiQuestion,
+      allowMultiQuestion,
+      chatTailMessageId,
+      lastUserInputContent,
+      sendInput,
+    ],
+  );
+
   return (
     <View style={styles.chatContainer}>
-      <ScrollView
-        ref={scrollViewRef}
+      <FlatList
+        ref={scrollViewRef as React.RefObject<FlatList<DisplayGroup>>}
         style={styles.scrollView}
         contentContainerStyle={styles.chatContent}
+        data={displayGroups}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        // #5517: auto-scroll-to-bottom on new content (sticky streaming).
+        //
+        // The pre-virtualization ScrollView called scrollToEnd on every
+        // onContentSizeChange (gated only by selecting / unanswered-prompt).
+        // That was safe because a ScrollView's content size changed ONLY when
+        // real content did. A FlatList also fires onContentSizeChange as rows
+        // mount/unmount during scroll (windowing) — a literal port would yank
+        // a user who scrolled up back to the bottom mid-read. To preserve the
+        // observable UX (sticky to bottom while at the bottom; never yank a
+        // scrolled-up reader) we additionally gate on `showScrollToBottomRef`
+        // — the same "is the user near the bottom?" signal the keyboard and
+        // prompt auto-scroll effects already honour.
         onContentSizeChange={() => {
-          if (!isSelectingRef.current && !hasUnansweredPrompt) scrollViewRef.current?.scrollToEnd();
+          if (
+            !isSelectingRef.current &&
+            !hasUnansweredPrompt &&
+            !showScrollToBottomRef.current
+          ) {
+            scrollViewRef.current?.scrollToEnd();
+          }
         }}
         onScroll={handleScroll}
         scrollEventThrottle={16}
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="handled"
-      >
-      {messages.length === 0 ? (
-        <View style={styles.emptyState}>
-          <Text style={styles.emptyStateText}>
-            {claudeReady
-              ? 'Connected. Send a message to Claude!'
-              : isCliMode
-                ? 'Connecting...'
-                : 'Starting Claude Code...'}
-          </Text>
-        </View>
-      ) : (
-        displayGroups.map((group) => {
-          if (group.type === 'activity') {
-            const firstMsg = group.messages[0];
-            return (
-              <View
-                key={group.key}
-                onLayout={(e) => {
-                  const y = e.nativeEvent.layout.y;
-                  for (const m of group.messages) {
-                    messageLayoutsRef.current.set(m.id, y);
-                  }
-                }}
-              >
-                <AnimatedMessage
-                  type={firstMsg.type}
-                  timestamp={firstMsg.timestamp}
-                  mountTime={mountTimeRef.current}
-                  reduceMotion={reduceMotion}
-                >
-                  <ActivityGroup
-                    messages={group.messages}
-                    isActive={group.isActive}
-                    isSelecting={isSelecting}
-                    selectedIds={selectedIds}
-                    onToggleSelection={onToggleSelection}
-                    searchMatchIds={searchMatchIds}
-                  />
-                </AnimatedMessage>
-              </View>
-            );
-          }
-          const msg = group.message;
-          // #4615 (mobile parity via #4806): suppress unanswered prompts
-          // invalidated by a subsequent ASK_USER_QUESTION_STALL. The
-          // pending prompt has already been discarded server-side; the
-          // stall-chip rendered for the error bubble below carries the
-          // retry affordance. Mirrors the dashboard App.tsx renderMessage
-          // gating that has been live since #4615.
-          if (
-            msg.type === 'prompt' &&
-            msg.options &&
-            !msg.requestId &&
-            stalledPromptIds.has(msg.id)
-          ) {
-            return null;
-          }
-          const isSearchMatch = searchMatchIds?.has(msg.id) ?? false;
-          const isCurrentMatch = currentMatchId === msg.id;
-          return (
-            <View
-              key={msg.id}
-              style={isSearchMatch ? (isCurrentMatch ? styles.searchMatchCurrent : styles.searchMatch) : undefined}
-              onLayout={(e) => {
-                messageLayoutsRef.current.set(msg.id, e.nativeEvent.layout.y);
-              }}
-            >
-              <AnimatedMessage
-                type={msg.type}
-                timestamp={msg.timestamp}
-                mountTime={mountTimeRef.current}
-                reduceMotion={reduceMotion}
-              >
-                <MessageBubble
-                  message={msg}
-                  onSelectOption={onSelectOption}
-                  onSubmitMultiQuestion={onSubmitMultiQuestion}
-                  allowMultiQuestion={allowMultiQuestion}
-                  isSelected={selectedIds.has(msg.id)}
-                  isSelecting={isSelecting}
-                  onLongPress={() => onToggleSelection(msg.id)}
-                  onPress={() => onToggleSelection(msg.id)}
-                  onOpenDetail={handleOpenDetail}
-                  onImagePress={setViewerUri}
-                  onRetryStreamStall={
-                    // #4496: only wire retry when this stall is the tail
-                    // bubble AND there's a user_input to resend. Mirrors
-                    // dashboard App.tsx renderMessage gating.
-                    msg.type === 'error' &&
-                    msg.code === 'stream_stall' &&
-                    msg.id === chatTailMessageId &&
-                    lastUserInputContent != null
-                      ? () => sendInput(lastUserInputContent)
-                      : undefined
-                  }
-                />
-              </AnimatedMessage>
-            </View>
-          );
-        })
-      )}
-      {isPlanPending && onApprovePlan && onFocusInput && (
-        <PlanApprovalCard
-          allowedPrompts={planAllowedPrompts || []}
-          onApprove={onApprovePlan}
-          onFeedback={onFocusInput}
-        />
-      )}
-      </ScrollView>
+        // #5517: search match scroll uses scrollToIndex; rows are variable-
+        // height and unmeasured until laid out, so swallow the failure and
+        // retry after the list reports content-size. Without this RN throws
+        // when scrolling to an off-screen index.
+        onScrollToIndexFailed={(info) => {
+          setTimeout(() => {
+            scrollViewRef.current?.scrollToIndex({
+              index: info.index,
+              animated: true,
+              viewPosition: 0,
+            });
+          }, 100);
+        }}
+        // #5517: keep a couple screens of rows mounted so near-viewport
+        // expand state and scroll feel native; recycle the rest.
+        windowSize={11}
+        removeClippedSubviews={Platform.OS === 'android'}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyStateText}>
+              {claudeReady
+                ? 'Connected. Send a message to Claude!'
+                : isCliMode
+                  ? 'Connecting...'
+                  : 'Starting Claude Code...'}
+            </Text>
+          </View>
+        }
+        ListFooterComponent={
+          isPlanPending && onApprovePlan && onFocusInput ? (
+            <PlanApprovalCard
+              allowedPrompts={planAllowedPrompts || []}
+              onApprove={onApprovePlan}
+              onFeedback={onFocusInput}
+            />
+          ) : null
+        }
+      />
 
       {/* Scroll navigation buttons */}
       {showScrollToTop && (

--- a/packages/app/src/components/__tests__/ActivityGroup.test.tsx
+++ b/packages/app/src/components/__tests__/ActivityGroup.test.tsx
@@ -324,4 +324,78 @@ describe('ActivityGroup / ActivityEntry — structured-renderer wiring (#4201)',
     expect(allText).toMatch(/1 image attached/);
     expect(allText).not.toMatch(/2 images attached/);
   });
+
+  // #5517: virtualization recycle-safety. ChatView now renders the
+  // transcript through a FlatList, so a group / entry can unmount when
+  // scrolled off-screen and remount on the way back. The group + entry expand
+  // flags must seed from ChatView's id-keyed registry (getInitialExpanded /
+  // onExpandedChange) so the row reopens to the user's last choice rather than
+  // snapping back to collapsed.
+  describe('expand state survives FlatList row recycling (#5517)', () => {
+    function makeRegistry() {
+      const map = new Map<string, boolean>();
+      return {
+        getInitialExpanded: (id: string) => map.get(id) ?? false,
+        onExpandedChange: (id: string, expanded: boolean) => {
+          if (expanded) map.set(id, true);
+          else map.delete(id);
+        },
+        map,
+      };
+    }
+
+    function mountGroup(
+      reg: ReturnType<typeof makeRegistry>,
+      messages: ChatMessage[],
+    ): renderer.ReactTestRenderer {
+      let root!: renderer.ReactTestRenderer;
+      act(() => {
+        root = renderer.create(
+          <ActivityGroup
+            messages={messages}
+            isActive={false}
+            isSelecting={false}
+            selectedIds={new Set()}
+            onToggleSelection={() => {}}
+            groupKey={`activity-${messages[0].id}`}
+            getInitialExpanded={reg.getInitialExpanded}
+            onExpandedChange={reg.onExpandedChange}
+          />,
+        );
+      });
+      return root;
+    }
+
+    it('reopens an expanded group + entry after unmount/remount via the registry', () => {
+      const reg = makeRegistry();
+      const messages = [makeToolMessage({ id: 'm1' })];
+
+      // First mount: expand the group then the entry, then unmount (recycle).
+      const first = mountGroup(reg, messages);
+      expandGroup(first);
+      expandEntry(first, 'activity-entry-m1');
+      expect(findByTestId(first, 'todo-list-header')[0]).toBeTruthy();
+      act(() => first.unmount());
+
+      // The registry remembers both the group key and the entry id.
+      expect(reg.map.get('activity-m1')).toBe(true);
+      expect(reg.map.get('m1')).toBe(true);
+
+      // Remount (scrolled back into view): the structured renderer appears
+      // immediately, with no taps — proving the row seeded from the registry.
+      const second = mountGroup(reg, messages);
+      expect(findByTestId(second, 'todo-list-header')[0]).toBeTruthy();
+    });
+
+    it('a collapsed group stays collapsed after recycling (no false-positive)', () => {
+      const reg = makeRegistry();
+      const messages = [makeToolMessage({ id: 'm2' })];
+      const first = mountGroup(reg, messages);
+      // Never expanded.
+      act(() => first.unmount());
+      expect(reg.map.has('activity-m2')).toBe(false);
+      const second = mountGroup(reg, messages);
+      expect(findByTestId(second, 'todo-list-header')).toHaveLength(0);
+    });
+  });
 });

--- a/packages/app/src/components/__tests__/ChatView.virtualization.test.tsx
+++ b/packages/app/src/components/__tests__/ChatView.virtualization.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * ChatView virtualization — #5517 (epic #5514, "streaming latency")
+ *
+ * Replaces the ScrollView + `displayGroups.map` with a virtualized FlatList.
+ * These tests pin the behaviours the issue requires be preserved across the
+ * migration:
+ *
+ *  1. The conversation renders through a FlatList (so off-screen rows can be
+ *     recycled instead of all mounting at once).
+ *  2. Stable keys — activity groups keyed by `group.key`, single rows by the
+ *     message id — so the #5516 memo comparator's identity check holds and
+ *     FlatList recycling never collapses two rows onto one key.
+ *  3. Expand/collapse state of tool bubbles survives row recycling, because it
+ *     lives OUTSIDE the recyclable row (in a ChatView-held registry keyed by
+ *     message id) rather than in a row-local `useState` that resets on remount.
+ *  4. The auto-scroll-to-bottom / sticky-streaming / keyboard behaviours from
+ *     ChatView are still wired (source-level, mirroring the existing #1711
+ *     auto-scroll test which also reads the source).
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { FlatList } from 'react-native';
+import * as fs from 'fs';
+import * as path from 'path';
+
+jest.mock('../../store/connection', () => ({
+  useConnectionStore: (selector: (s: { sendInput: () => void }) => unknown) =>
+    selector({ sendInput: () => {} }),
+}));
+
+import { AccessibilityInfo } from 'react-native';
+import { ChatView } from '../ChatView';
+
+// The AccessibilityInfo reduceMotion listener resolves async after the test
+// completes; under react-test-renderer + jsdom the resulting setState fires a
+// global error event into a window without dispatchEvent, crashing teardown.
+// Spy on the real methods so the component's effect is inert in tests without
+// replacing the module (which the renderer's internals also depend on).
+beforeAll(() => {
+  jest
+    .spyOn(AccessibilityInfo, 'addEventListener')
+    .mockReturnValue({ remove: () => {} } as never);
+  jest
+    .spyOn(AccessibilityInfo, 'isReduceMotionEnabled')
+    .mockResolvedValue(true);
+});
+afterAll(() => jest.restoreAllMocks());
+import type { ChatMessage } from '../../store/types';
+
+const source = fs.readFileSync(
+  path.resolve(__dirname, '../ChatView.tsx'),
+  'utf-8',
+);
+
+function toolMessage(id: string, overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id,
+    type: 'tool_use',
+    content: 'cat file.txt',
+    tool: 'Bash',
+    toolUseId: `toolu_${id}`,
+    toolResult: 'file contents',
+    timestamp: 1000,
+    ...overrides,
+  } as ChatMessage;
+}
+
+function responseMessage(id: string, content: string): ChatMessage {
+  return { id, type: 'response', content, timestamp: 1000 } as ChatMessage;
+}
+
+const noop = () => {};
+
+function makeProps(messages: ChatMessage[]) {
+  const ref = React.createRef<FlatList>();
+  return {
+    messages,
+    scrollViewRef: ref as unknown as React.RefObject<FlatList<unknown> | null>,
+    claudeReady: true,
+    onSelectOption: noop,
+    isCliMode: false,
+    selectedIds: new Set<string>(),
+    isSelecting: false,
+    isSelectingRef: { current: false } as React.MutableRefObject<boolean>,
+    onToggleSelection: noop,
+    streamingMessageId: null,
+  };
+}
+
+/** Pull every host node of a given type out of a react-test-renderer tree. */
+function findAllByType(root: renderer.ReactTestInstance, type: unknown) {
+  return root.findAllByType(type as never);
+}
+
+describe('ChatView virtualization (#5517)', () => {
+  it('renders the conversation through a FlatList', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<ChatView {...makeProps([responseMessage('m1', 'hi')])} />);
+    });
+    const lists = findAllByType(tree.root, FlatList);
+    expect(lists.length).toBeGreaterThan(0);
+  });
+
+  it('gives each row a stable key (single by id, activity by group key)', () => {
+    // Two contiguous tool_use messages collapse into one activity group; a
+    // trailing response stays single. keyExtractor must return the group key
+    // for the activity and the message id for the response.
+    const messages = [
+      toolMessage('t1'),
+      toolMessage('t2'),
+      responseMessage('r1', 'done'),
+    ];
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<ChatView {...makeProps(messages)} />);
+    });
+    const list = findAllByType(tree.root, FlatList)[0];
+    const data = list.props.data as { type: string; key?: string; message?: ChatMessage }[];
+    const keyExtractor = list.props.keyExtractor as (item: unknown, i: number) => string;
+    const keys = data.map((item, i) => keyExtractor(item, i));
+    // Stable, unique keys.
+    expect(new Set(keys).size).toBe(keys.length);
+    // The activity group's key is the synthetic activity-<firstId>.
+    expect(keys).toContain('activity-t1');
+    // The trailing single response keys by its message id.
+    expect(keys).toContain('r1');
+  });
+
+  it('keeps the streamed/tail message identity stable for the memo comparator', () => {
+    // The keyExtractor must not wrap items in fresh objects per render — the
+    // #5516 memo relies on `prev.message === next.message`. Re-deriving keys
+    // from ids/group keys (not array index alone) guarantees a streamed delta
+    // only re-renders its own row.
+    const messages = [responseMessage('a', 'one'), responseMessage('b', 'two')];
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<ChatView {...makeProps(messages)} />);
+    });
+    const list = findAllByType(tree.root, FlatList)[0];
+    const keyExtractor = list.props.keyExtractor as (item: unknown, i: number) => string;
+    const data = list.props.data as unknown[];
+    expect(keyExtractor(data[0], 0)).toBe('a');
+    expect(keyExtractor(data[1], 1)).toBe('b');
+  });
+
+  // --- Source-level guarantees (recycling-safe expand state + scroll) ---
+
+  it('holds tool-bubble expand state outside the recyclable row (keyed by id)', () => {
+    // The registry must live in ChatView so a recycled row re-reads its
+    // expanded flag from the parent instead of resetting to collapsed.
+    expect(source).toMatch(/expandedIds|expandedRegistry|expandedMap/);
+  });
+
+  it('passes the expand registry / toggle down to the rows', () => {
+    // ChatView wires controlled expand props into the activity + bubble rows.
+    expect(source).toMatch(/onToggleExpanded|setExpandedIds|onExpandedChange/);
+  });
+
+  it('still auto-scrolls to bottom when content grows (sticky streaming)', () => {
+    // FlatList exposes scrollToEnd just like ScrollView; the onContentSizeChange
+    // → scrollToEnd path that keeps the latest message visible must survive.
+    expect(source).toMatch(/onContentSizeChange[\s\S]{0,200}scrollToEnd/);
+  });
+
+  it('still pauses auto-scroll while selecting or an unanswered prompt is up', () => {
+    expect(source).toMatch(/isSelectingRef\.current[\s\S]{0,120}hasUnansweredPrompt/);
+  });
+
+  it('does not yank a scrolled-up reader to the bottom on content-size churn', () => {
+    // FlatList fires onContentSizeChange on windowing too, so the auto-scroll
+    // must also gate on showScrollToBottomRef (user is near the bottom).
+    expect(source).toMatch(/onContentSizeChange[\s\S]{0,400}showScrollToBottomRef\.current/);
+  });
+
+  it('keeps keyboard auto-scroll wiring', () => {
+    expect(source).toMatch(/keyboardVisible[\s\S]{0,300}scrollToEnd/);
+  });
+
+  it('preserves keyboard handling props (dismiss-on-drag, persist taps)', () => {
+    expect(source).toMatch(/keyboardDismissMode=["']on-drag["']/);
+    expect(source).toMatch(/keyboardShouldPersistTaps=["']handled["']/);
+  });
+});

--- a/packages/app/src/components/chat/ActivityGroup.tsx
+++ b/packages/app/src/components/chat/ActivityGroup.tsx
@@ -25,11 +25,18 @@ function ActivityEntry({
   isSelected,
   isSelecting,
   onToggleSelection,
+  getInitialExpanded,
+  onExpandedChange,
 }: {
   message: ChatMessage;
   isSelected: boolean;
   isSelecting: boolean;
   onToggleSelection: (id: string) => void;
+  /** #5517: seed expand state from ChatView's id-keyed registry so it
+   *  survives FlatList row recycling (the row may unmount when scrolled
+   *  off-screen and remount fresh). */
+  getInitialExpanded?: (id: string) => boolean;
+  onExpandedChange?: (id: string, expanded: boolean) => void;
 }) {
   const longPressedRef = useRef(false);
   // #4201: per-entry expand state so each tool row can independently reveal
@@ -39,7 +46,15 @@ function ActivityEntry({
   // code for chat because ChatView never routes tool_use through
   // MessageBubble → ToolBubble (groupMessages always wraps in activity
   // groups).
-  const [expanded, setExpanded] = useState(false);
+  //
+  // #5517: seed from the ChatView registry so a recycled row reopens to
+  // the user's last choice instead of resetting to collapsed.
+  const [expanded, setExpanded] = useState(() => getInitialExpanded?.(message.id) ?? false);
+
+  const setExpandedTracked = (next: boolean) => {
+    setExpanded(next);
+    onExpandedChange?.(message.id, next);
+  };
 
   const handlePress = () => {
     if (longPressedRef.current) {
@@ -51,7 +66,7 @@ function ActivityEntry({
       return;
     }
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setExpanded((prev) => !prev);
+    setExpandedTracked(!expanded);
   };
 
   const handleLongPress = () => {
@@ -162,6 +177,9 @@ export function ActivityGroup({
   selectedIds,
   onToggleSelection,
   searchMatchIds,
+  groupKey,
+  getInitialExpanded,
+  onExpandedChange,
 }: {
   messages: ChatMessage[];
   isActive: boolean;
@@ -169,8 +187,18 @@ export function ActivityGroup({
   selectedIds: Set<string>;
   onToggleSelection: (id: string) => void;
   searchMatchIds?: Set<string>;
+  /** #5517: stable group id (the `activity-<firstId>` key) used to seed +
+   *  persist the group's expand state across FlatList row recycling. */
+  groupKey?: string;
+  getInitialExpanded?: (id: string) => boolean;
+  onExpandedChange?: (id: string, expanded: boolean) => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const registryKey = groupKey ?? activityMessages[0]?.id ?? '';
+  const [expanded, setExpanded] = useState(() => getInitialExpanded?.(registryKey) ?? false);
+  const setExpandedTracked = (next: boolean) => {
+    setExpanded(next);
+    onExpandedChange?.(registryKey, next);
+  };
   const toolCount = activityMessages.filter((m) => m.type === 'tool_use').length;
   const lastMessage = activityMessages[activityMessages.length - 1];
   const isThinking = isActive && lastMessage?.type === 'thinking';
@@ -182,14 +210,14 @@ export function ActivityGroup({
   useEffect(() => {
     if (hasSearchMatch && !expanded) {
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-      setExpanded(true);
+      setExpandedTracked(true);
     }
   }, [hasSearchMatch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handlePress = () => {
     if (isSelecting) return;
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setExpanded((prev) => !prev);
+    setExpandedTracked(!expanded);
   };
 
   // Auto-collapse when activity completes
@@ -197,7 +225,7 @@ export function ActivityGroup({
   useEffect(() => {
     if (wasActiveRef.current && !isActive) {
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-      setExpanded(false);
+      setExpandedTracked(false);
     }
     wasActiveRef.current = isActive;
   }, [isActive]);
@@ -237,6 +265,8 @@ export function ActivityGroup({
               isSelected={selectedIds.has(msg.id)}
               isSelecting={isSelecting}
               onToggleSelection={onToggleSelection}
+              getInitialExpanded={getInitialExpanded}
+              onExpandedChange={onExpandedChange}
             />
           ))}
         </ScrollView>

--- a/packages/app/src/components/chat/ActivityGroup.tsx
+++ b/packages/app/src/components/chat/ActivityGroup.tsx
@@ -193,7 +193,13 @@ export function ActivityGroup({
   getInitialExpanded?: (id: string) => boolean;
   onExpandedChange?: (id: string, expanded: boolean) => void;
 }) {
-  const registryKey = groupKey ?? activityMessages[0]?.id ?? '';
+  // #5517: the group's registry key must stay in the `activity-<id>`
+  // namespace so it never collides with an entry's bare `message.id` (entries
+  // register under their own id). ChatView always passes `group.key`; the
+  // fallback mirrors its `activity-<firstId>` shape so a caller that omits
+  // groupKey can't bleed the group's expand flag onto its first entry.
+  const registryKey = groupKey
+    ?? (activityMessages[0]?.id ? `activity-${activityMessages[0].id}` : '');
   const [expanded, setExpanded] = useState(() => getInitialExpanded?.(registryKey) ?? false);
   const setExpandedTracked = (next: boolean) => {
     setExpanded(next);

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -52,7 +52,7 @@ export type { OtherFreeformAnswer };
 
 export type SelectOptionValue = string | OtherFreeformAnswer;
 
-function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall }: {
+function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
   message: ChatMessage;
   onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
   /**
@@ -84,6 +84,13 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
    * the chip renders text only without a misleading Retry affordance.
    */
   onRetryStreamStall?: () => void;
+  /**
+   * #5517: seed + persist row expand state in ChatView's id-keyed registry
+   * so it survives FlatList row recycling. Forwarded to the inner ToolBubble
+   * (tool rows) and used for the answered-permission collapse toggle.
+   */
+  getInitialExpanded?: (id: string) => boolean;
+  onExpandedChange?: (id: string, expanded: boolean) => void;
 }) {
   // #5516 (epic #5514): dev-only render tally. Proves (in the memoization
   // test and ad-hoc dev profiling) that only the tail/streaming bubble
@@ -96,7 +103,15 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
   const [isExpired, setIsExpired] = useState(() =>
     message.expiresAt != null && message.expiresAt <= Date.now()
   );
-  const [permissionExpanded, setPermissionExpanded] = useState(false);
+  // #5517: seed from the ChatView registry so a recycled permission pill
+  // reopens to the user's last choice instead of resetting to collapsed.
+  const [permissionExpanded, setPermissionExpandedRaw] = useState(
+    () => getInitialExpanded?.(message.id) ?? false,
+  );
+  const setPermissionExpanded = (next: boolean) => {
+    setPermissionExpandedRaw(next);
+    onExpandedChange?.(message.id, next);
+  };
   // #3746: free-text mode when user picks the synthetic "Other" option
   const [otherActive, setOtherActive] = useState(false);
   const [otherText, setOtherText] = useState('');
@@ -228,6 +243,8 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
         isSelecting={isSelecting}
         onToggleSelection={onPress}
         onOpenDetail={onOpenDetail}
+        getInitialExpanded={getInitialExpanded}
+        onExpandedChange={onExpandedChange}
       />
     );
   }

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -40,14 +40,22 @@ function formatPartialPreview(partial: string): string {
   return partial;
 }
 
-export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection, onOpenDetail }: {
+export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection, onOpenDetail, getInitialExpanded, onExpandedChange }: {
   message: ChatMessage;
   isSelected: boolean;
   isSelecting: boolean;
   onToggleSelection: () => void;
   onOpenDetail: (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string) => void;
+  /** #5517: seed + persist expand state in ChatView's id-keyed registry so
+   *  it survives FlatList row recycling. */
+  getInitialExpanded?: (id: string) => boolean;
+  onExpandedChange?: (id: string, expanded: boolean) => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpandedRaw] = useState(() => getInitialExpanded?.(message.id) ?? false);
+  const setExpanded = (next: boolean) => {
+    setExpandedRaw(next);
+    onExpandedChange?.(message.id, next);
+  };
   const longPressedRef = useRef(false);
   // #4081: streaming inputs land in `toolInputPartial` before `content`
   // is populated. Use it as the bubble body when `content` is empty or

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -5,7 +5,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
-  ScrollView,
+  FlatList,
   Platform,
   Keyboard,
   Share,
@@ -124,7 +124,10 @@ export function SessionScreen() {
   const [inputText, setInputText] = useState('');
   const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
   const [showAttachSheet, setShowAttachSheet] = useState(false);
-  const scrollViewRef = useRef<ScrollView>(null);
+  // #5517: ChatView's transcript is a virtualized FlatList. SessionScreen
+  // only forwards this ref (never calls imperative methods on it); typed as
+  // FlatList<unknown> to match ChatView's prop without naming the row type.
+  const scrollViewRef = useRef<FlatList<unknown>>(null);
   const terminalRef = useRef<TerminalHandle>(null);
   const insets = useSafeAreaInsets();
   const keyboardHeight = useKeyboardHeight();


### PR DESCRIPTION
Replaces ChatView's `ScrollView` + `displayGroups.map` — which mounted every bubble and re-touched the whole tree on each store flush — with a virtualized `FlatList` over `displayGroups`. On long conversations (200+ messages) this caps mount/update cost to the on-screen window. It composes with the #5532 `MessageBubble`/`FormattedResponse` memoization: a streaming delta already re-rendered just its own row; now that single re-render also lives inside a bounded list instead of a fully-mounted transcript.

## List implementation: core FlatList (not FlashList)

Per the issue's recommendation, this uses **core `FlatList`** — no native module, **no dev-build / EAS rebuild required**. The win here is mount/update cost on long conversations, which FlatList captures with zero native-dependency churn.

`@shopify/flash-list` is noted as a **possible future upgrade** (better recycling/blank-cell behaviour on very long lists) — but it is a native module, so adopting it would force a dev-client rebuild for everyone. Not worth it for this issue's goal.

**Normal (non-inverted) list.** Chat UIs often use an `inverted` FlatList for bottom-anchoring, but ChatView's existing scroll logic is built around a top-anchored list with `scrollToEnd` (auto-scroll on new content, jump-to-top/bottom, keyboard/prompt/plan-card scroll). Keeping the normal orientation preserves the current UX with the least re-derivation; inverting would require reversing `displayGroups` and flipping every offset/index.

## Preserved behaviours (with tests)

- **Stable keys** — activity groups by `group.key` (`activity-<firstId>`), single rows by message id. The #5532 memo comparator relies on `prev.message === next.message`; index-keying would break it, so `keyExtractor` derives from ids/group keys.
- **Expand/collapse across recycling** — verified that expand state lived in **row-local `useState`** (ToolBubble, ActivityGroup, ActivityEntry, MessageBubble's answered-permission pill), which a virtualized list would reset on unmount/remount. Lifted it into an **id-keyed registry held in ChatView** (`getInitialExpanded` / `handleExpandedChange`); rows seed from it on mount and write back on toggle. In-component auto-expand-on-search and auto-collapse-on-complete effects are preserved. A behavioural test in `ActivityGroup.test.tsx` expands a group+entry, unmounts (recycle), remounts, and asserts the structured renderer reappears with no taps.
- **Scroll-to-bottom on new content / sticky streaming** — `onContentSizeChange → scrollToEnd`, still gated by selecting / unanswered-prompt. **User-scrolled-up case:** the old ScrollView never yanked a scrolled-up reader because its content size only changed on real content; a FlatList also fires `onContentSizeChange` on windowing, so a literal port would yank mid-read. The auto-scroll now additionally gates on `showScrollToBottomRef` (the same "near the bottom?" signal the keyboard/prompt effects already use), preserving the observable UX.
- **Keyboard interactions** — `keyboardDismissMode="on-drag"`, `keyboardShouldPersistTaps="handled"`, and the keyboard-open auto-scroll effect are unchanged.
- **Search match scroll** — moved from pixel `scrollTo({ y })` (unavailable on FlatList; off-screen rows are unmeasured) to `scrollToIndex` via a message-id→row-index map, with an `onScrollToIndexFailed` retry.
- Empty state → `ListEmptyComponent`; plan-approval card → `ListFooterComponent`.
- `SessionScreen`'s shared ref retyped `ScrollView` → `FlatList` (it only forwards the ref; all imperative scrolling stays inside ChatView).

## Tests

- App jest: **119 suites / 1668 tests, all green** (after generating the gitignored `xterm-bundle.generated.ts` via `npm run bundle-xterm`, which 5 TerminalView-importing suites need locally — unrelated to this change).
- `tsc --noEmit`: clean (0 errors).
- New: `ChatView.virtualization.test.tsx` (10 tests) + recycle-survival tests in `ActivityGroup.test.tsx`. Updated two stale source-analysis assertions in `ComponentRendering.test.ts` (old `ScrollView` import / `messages.length === 0` ternary → FlatList / `ListEmptyComponent`).

## Not run here

Maestro chat flows need a simulator and were **not** run. Before release, run `chat-todolist.yaml` and the session flows (via `run-all.yaml`) to confirm tap-to-expand, plan approval, and scroll behaviour on-device.

Closes #5517.
Related to #5514.