### PR TITLE
feat: Discord pairing-link delivery — host-triggered, approval-gated

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1596,7 +1596,8 @@ export function App() {
       if (res.ok && body?.posted) {
         return { posted: true as const, expiresInSeconds: body.expiresInSeconds }
       }
-      return { posted: false as const, reason: body?.reason || `http_${res.status}` }
+      // Auth/availability failures arrive as { error: ... }, not { reason: ... }.
+      return { posted: false as const, reason: body?.reason || body?.error || `http_${res.status}` }
     } catch {
       return { posted: false as const, reason: 'post_failed' }
     }

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1590,7 +1590,7 @@ export function App() {
     try {
       const res = await fetch('/pair-discord', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
       })
       const body = await res.json().catch(() => null)
       if (res.ok && body?.posted) {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1579,6 +1579,29 @@ export function App() {
 
   const handleShowQr = useCallback(() => fetchQrInto('/qr'), [fetchQrInto])
 
+  // #5513 — host-triggered Discord pairing-link delivery. POSTs to the daemon's
+  // primary-class-gated /pair-discord, which mints a FRESH approval-gated id and
+  // posts only the chroxy:// link. Redeeming it from the channel still needs host
+  // approval, so the channel grants nothing on its own. Returns a result the
+  // QrModal renders inline. Never surfaces token material.
+  const handlePostPairLinkToDiscord = useCallback(async () => {
+    const token = getAuthToken()
+    if (!token) return { posted: false as const, reason: 'no_token' }
+    try {
+      const res = await fetch('/pair-discord', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const body = await res.json().catch(() => null)
+      if (res.ok && body?.posted) {
+        return { posted: true as const, expiresInSeconds: body.expiresInSeconds }
+      }
+      return { posted: false as const, reason: body?.reason || `http_${res.status}` }
+    } catch {
+      return { posted: false as const, reason: 'post_failed' }
+    }
+  }, [])
+
   // #4695 / #4942 — bridge the macOS menu bar items to App-state
   // handlers. The sidebar's per-project "+" row and the command
   // palette entries currently open their respective dialogs through
@@ -2833,6 +2856,7 @@ export function App() {
             : 'Scan with Chroxy app to pair your phone'
         }
         pairingCode={qrShareMode === 'share' ? null : qrPairingCode}
+        onPostToDiscord={qrShareMode === 'share' ? undefined : handlePostPairLinkToDiscord}
       />
 
       {/* #3209: SkillsPanel — popover for manual-skill toggles + #3205 metadata */}

--- a/packages/dashboard/src/components/QrModal.test.tsx
+++ b/packages/dashboard/src/components/QrModal.test.tsx
@@ -98,6 +98,24 @@ describe('QrModal', () => {
     expect(await screen.findByTestId('qr-post-discord-status')).toHaveTextContent(/webhook|configur/i)
   })
 
+  it('shows legible copy for a primary_token_required rejection', async () => {
+    // The endpoint is primary-token gated: a dashboard authenticated with a
+    // pairing-issued session token gets 403 { error: 'primary_token_required' }.
+    const svg = '<svg><rect/></svg>'
+    const onPost = vi.fn().mockResolvedValue({ posted: false, reason: 'primary_token_required' })
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} pairingCode="ABCD2345" onPostToDiscord={onPost} />)
+    fireEvent.click(screen.getByTestId('qr-post-discord-btn'))
+    expect(await screen.findByTestId('qr-post-discord-status')).toHaveTextContent(/primary device/i)
+  })
+
+  it('shows legible copy for an unauthorized rejection', async () => {
+    const svg = '<svg><rect/></svg>'
+    const onPost = vi.fn().mockResolvedValue({ posted: false, reason: 'unauthorized' })
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} pairingCode="ABCD2345" onPostToDiscord={onPost} />)
+    fireEvent.click(screen.getByTestId('qr-post-discord-btn'))
+    expect(await screen.findByTestId('qr-post-discord-status')).toHaveTextContent(/not authorized/i)
+  })
+
   it('closes on Escape key (#1549)', () => {
     const onClose = vi.fn()
     render(<QrModal open={true} onClose={onClose} qrSvg={null} loading={false} />)

--- a/packages/dashboard/src/components/QrModal.test.tsx
+++ b/packages/dashboard/src/components/QrModal.test.tsx
@@ -68,6 +68,36 @@ describe('QrModal', () => {
     expect(screen.queryByTestId('qr-pairing-code')).not.toBeInTheDocument()
   })
 
+  // #5513 — host-triggered Discord pairing-link delivery
+  it('renders the Post-to-Discord button when onPostToDiscord is provided', () => {
+    const svg = '<svg><rect/></svg>'
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} pairingCode="ABCD2345" onPostToDiscord={vi.fn()} />)
+    expect(screen.getByTestId('qr-post-discord-btn')).toBeInTheDocument()
+  })
+
+  it('omits the Post-to-Discord button when onPostToDiscord is absent', () => {
+    const svg = '<svg><rect/></svg>'
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} pairingCode="ABCD2345" />)
+    expect(screen.queryByTestId('qr-post-discord-btn')).not.toBeInTheDocument()
+  })
+
+  it('calls onPostToDiscord and shows a success message on resolve', async () => {
+    const svg = '<svg><rect/></svg>'
+    const onPost = vi.fn().mockResolvedValue({ posted: true, expiresInSeconds: 60 })
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} pairingCode="ABCD2345" onPostToDiscord={onPost} />)
+    fireEvent.click(screen.getByTestId('qr-post-discord-btn'))
+    expect(onPost).toHaveBeenCalledOnce()
+    expect(await screen.findByTestId('qr-post-discord-status')).toHaveTextContent(/posted/i)
+  })
+
+  it('shows an error message when the post fails', async () => {
+    const svg = '<svg><rect/></svg>'
+    const onPost = vi.fn().mockResolvedValue({ posted: false, reason: 'not_configured' })
+    render(<QrModal open={true} onClose={vi.fn()} qrSvg={svg} loading={false} pairingCode="ABCD2345" onPostToDiscord={onPost} />)
+    fireEvent.click(screen.getByTestId('qr-post-discord-btn'))
+    expect(await screen.findByTestId('qr-post-discord-status')).toHaveTextContent(/webhook|configur/i)
+  })
+
   it('closes on Escape key (#1549)', () => {
     const onClose = vi.fn()
     render(<QrModal open={true} onClose={onClose} qrSvg={null} loading={false} />)

--- a/packages/dashboard/src/components/QrModal.tsx
+++ b/packages/dashboard/src/components/QrModal.tsx
@@ -48,6 +48,12 @@ function discordFailureMessage(reason?: string): string {
   if (reason === 'post_failed') {
     return 'Discord rejected the post — check the webhook.'
   }
+  if (reason === 'no_token' || reason === 'unauthorized') {
+    return 'Not authorized — reconnect to the daemon and try again.'
+  }
+  if (reason === 'primary_token_required') {
+    return 'Only the primary device can post pairing links.'
+  }
   return `Could not post to Discord${reason ? `: ${reason}` : ''}.`
 }
 

--- a/packages/dashboard/src/components/QrModal.tsx
+++ b/packages/dashboard/src/components/QrModal.tsx
@@ -5,8 +5,14 @@
  * aria-modal, and backdrop behavior.
  */
 
+import { useState } from 'react'
 import DOMPurify from 'dompurify'
 import { Modal } from './Modal'
+
+/** Result of a host-triggered Discord pairing-link post (#5513). */
+export type PostToDiscordResult =
+  | { posted: true; expiresInSeconds?: number }
+  | { posted: false; reason?: string }
 
 export interface QrModalProps {
   open: boolean
@@ -24,6 +30,25 @@ export interface QrModalProps {
    * Omitted for per-session "Share" QRs (those issue a session-bound token).
    */
   pairingCode?: string | null
+  /**
+   * Host-triggered Discord pairing-link delivery (#5513). When provided, a
+   * "Post link to Discord" button appears beside the code. It posts a FRESH
+   * approval-gated pairing id — redeeming it from the channel still needs host
+   * approval, so the channel grants nothing on its own. Omitted for the
+   * per-session "Share" QR (no Discord delivery there).
+   */
+  onPostToDiscord?: () => Promise<PostToDiscordResult>
+}
+
+/** Human-readable failure copy for a post_failed/not_configured reason. */
+function discordFailureMessage(reason?: string): string {
+  if (reason === 'not_configured') {
+    return 'No Discord webhook is configured on the host.'
+  }
+  if (reason === 'post_failed') {
+    return 'Discord rejected the post — check the webhook.'
+  }
+  return `Could not post to Discord${reason ? `: ${reason}` : ''}.`
 }
 
 export function QrModal({
@@ -35,7 +60,30 @@ export function QrModal({
   title = 'Pair Mobile App',
   instructions = 'Scan with Chroxy app to pair your phone',
   pairingCode = null,
+  onPostToDiscord,
 }: QrModalProps) {
+  const [posting, setPosting] = useState(false)
+  const [postStatus, setPostStatus] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const handlePostToDiscord = async () => {
+    if (!onPostToDiscord || posting) return
+    setPosting(true)
+    setPostStatus(null)
+    try {
+      const result = await onPostToDiscord()
+      if (result.posted) {
+        const ttl = typeof result.expiresInSeconds === 'number' ? result.expiresInSeconds : 60
+        setPostStatus({ ok: true, text: `Posted to Discord — expires in ${ttl}s, approval required on the host.` })
+      } else {
+        setPostStatus({ ok: false, text: discordFailureMessage(result.reason) })
+      }
+    } catch {
+      setPostStatus({ ok: false, text: discordFailureMessage() })
+    } finally {
+      setPosting(false)
+    }
+  }
+
   return (
     <Modal open={open} onClose={onClose} title={title} maxWidth="400px">
       <button className="qr-modal-close" onClick={onClose} aria-label="Close" type="button">
@@ -71,6 +119,28 @@ export function QrModal({
               <code className="qr-modal-code-value" data-testid="qr-pairing-code-value">
                 {pairingCode}
               </code>
+            </div>
+          )}
+          {onPostToDiscord && (
+            <div className="qr-modal-discord" data-testid="qr-post-discord">
+              <button
+                type="button"
+                className="qr-modal-discord-btn"
+                data-testid="qr-post-discord-btn"
+                onClick={handlePostToDiscord}
+                disabled={posting}
+              >
+                {posting ? 'Posting…' : 'Post link to Discord'}
+              </button>
+              {postStatus && (
+                <span
+                  className={postStatus.ok ? 'qr-modal-discord-ok' : 'qr-modal-discord-err'}
+                  data-testid="qr-post-discord-status"
+                  role={postStatus.ok ? undefined : 'alert'}
+                >
+                  {postStatus.text}
+                </span>
+              )}
             </div>
           )}
         </div>

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -421,6 +421,10 @@ export function ServerPicker() {
   const switchServer = useConnectionStore(s => s.switchServer)
   const connectLocal = useConnectionStore(s => s.connectLocal)
   const pairServer = useConnectionStore(s => s.pairServer)
+  // #5513 — a redeemed ?pair= link that turned out approval-gated lands here so
+  // we transparently open the request-pair flow for that host.
+  const pendingApprovalPairHost = useConnectionStore(s => s.pendingApprovalPairHost)
+  const clearPendingApprovalPairHost = useConnectionStore(s => s.clearPendingApprovalPairHost)
 
   const [showAddForm, setShowAddForm] = useState(false)
   // #5512 — camera-less "Have a code?" entry (host + typeable code).
@@ -480,6 +484,20 @@ export function ServerPicker() {
       setAddError(err instanceof Error ? err.message : 'Failed to add paired server')
     }
   }, [addServer, switchServer])
+
+  // #5513 — when the store flags an approval-gated redemption, open the
+  // request-pair panel for that host (the existing #5510 requester flow issues a
+  // fresh pair_request on a new connection). Clear the signal once consumed so
+  // it fires exactly once per redemption.
+  useEffect(() => {
+    if (!pendingApprovalPairHost) return
+    setAddError(null)
+    setShowAddForm(false)
+    setShowCodeForm(false)
+    setPrefill(null)
+    setPairRequest({ name: pendingApprovalPairHost.name, wsUrl: pendingApprovalPairHost.wsUrl })
+    clearPendingApprovalPairHost()
+  }, [pendingApprovalPairHost, clearPendingApprovalPairHost])
 
   const runDiscovery = useCallback(async () => {
     setDiscovering(true)

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -392,6 +392,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #5510 (epic #5509): pairing-approval primitive — outstanding pending pair
   // requests fanned out to this host surface. Empty until a pair_pending lands.
   pendingPairRequests: [],
+  // #5513 (epic #5509): set when a redeemed ?pair= link is approval-gated so the
+  // UI can transparently open the request-pair flow. Null otherwise.
+  pendingApprovalPairHost: null,
   // #5175 (epic #5170): Host/Repo Status Control Room snapshot, fed by the
   // host_status_snapshot handler. Null until the first survey lands.
   hostStatus: null,
@@ -712,6 +715,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     wsSend(socket, { type: 'pair_deny', requestId });
     set((s) => ({ pendingPairRequests: s.pendingPairRequests.filter((p) => p.requestId !== requestId) }));
     return true;
+  },
+
+  // #5513: clear the approval-gated redemption signal once the UI has consumed
+  // it (opened the request-pair panel) so it doesn't re-trigger.
+  clearPendingApprovalPairHost: (): void => {
+    set({ pendingApprovalPairHost: null });
   },
 
   // #5253: request a self-hosted runner survey. Mirrors requestHostStatus —

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -245,6 +245,32 @@ describe('dashboard message-handler dispatch', () => {
       handleMessage({ type: 'pair_fail', reason: 'rate_limited' }, ctx() as any)
       expect((store.getState() as any)._removeServerCalls).toEqual([])
     })
+
+    // #5513 — approval-gated redemption: a Discord-delivered link mints no
+    // token; the server replies requires_approval. The dashboard falls into the
+    // request-pair flow for the same host instead of dead-ending on an alert.
+    it('records the host in pendingApprovalPairHost on requires_approval (#5513)', () => {
+      store = createMockStore(baseState({
+        activeServerId: 'srv_gated',
+        serverRegistry: [{ id: 'srv_gated', name: 'GatedHost', wsUrl: 'wss://gated/ws', token: '', lastConnectedAt: null }],
+      }))
+      setStore(store)
+      handleMessage({ type: 'pair_fail', reason: 'requires_approval' }, ctx() as any)
+      const state = store.getState() as any
+      expect(state.pendingApprovalPairHost).toEqual({ name: 'GatedHost', wsUrl: 'wss://gated/ws' })
+      // The optimistic tokenless entry is still cleaned up.
+      expect(state._removeServerCalls).toEqual(['srv_gated'])
+    })
+
+    it('does NOT set pendingApprovalPairHost for other pair_fail reasons (#5513)', () => {
+      store = createMockStore(baseState({
+        activeServerId: 'srv_gated',
+        serverRegistry: [{ id: 'srv_gated', name: 'GatedHost', wsUrl: 'wss://gated/ws', token: '', lastConnectedAt: null }],
+      }))
+      setStore(store)
+      handleMessage({ type: 'pair_fail', reason: 'expired' }, ctx() as any)
+      expect((store.getState() as any).pendingApprovalPairHost).toBeUndefined()
+    })
   })
 
   describe('error dispatch', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2495,17 +2495,31 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // pairing failed before a session token was issued, so drop the dead entry.
       ctx.socket.close();
       set({ connectionPhase: 'disconnected', socket: null });
+      const { reason } = sharedPairFail(msg, 'unknown');
       const failedServerId = get().activeServerId;
-      if (failedServerId) {
-        const entry = get().serverRegistry.find((s) => s.id === failedServerId);
-        if (entry && !entry.token) get().removeServer(failedServerId);
+      // Capture the failed host BEFORE removing the optimistic entry, so the
+      // approval-gated path below can re-open the request-pair flow for it.
+      const failedEntry = failedServerId
+        ? get().serverRegistry.find((s) => s.id === failedServerId)
+        : undefined;
+      if (failedEntry && !failedEntry.token) get().removeServer(failedServerId!);
+
+      // #5513 (epic #5509) — the redeemed ?pair= link was approval-gated (a
+      // Discord-delivered link). Possession of the link is never sufficient: the
+      // device must REQUEST pairing and the host must approve it. Transparently
+      // fall into the request-pair UX (RequestPairPanel) for the same host
+      // instead of dead-ending on an alert. Old/other surfaces that don't read
+      // pendingApprovalPairHost still see the legible reason via the alert below.
+      if (reason === 'requires_approval' && failedEntry?.wsUrl) {
+        set({ pendingApprovalPairHost: { name: failedEntry.name, wsUrl: failedEntry.wsUrl } });
+        break;
       }
+
       if (!ctx.silent) {
         // Reason parse shared via store-core (#5454). The dashboard keeps its
         // plain `Pairing failed: <reason>` copy — the friendly
         // PAIR_FAIL_MESSAGES strings are QR-flow wording ("Scan the latest QR
         // code…") that doesn't fit this paste-a-pairing-URL surface.
-        const { reason } = sharedPairFail(msg, 'unknown');
         _adapters.alert.alert('Pairing Failed', `Pairing failed: ${reason}`);
       }
       break;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -595,6 +595,18 @@ export interface ConnectionState {
    */
   pendingPairRequests: ServerPairPendingMessage[];
 
+  /**
+   * #5513 (epic #5509) — a `?pair=` link the dashboard tried to redeem turned
+   * out to be approval-gated (a Discord-delivered link): the server replied
+   * `pair_fail { reason: 'requires_approval' }`. Possession of the link is never
+   * sufficient — the device must REQUEST pairing and the host must approve it.
+   * The pair_fail handler records the failed host here so the UI can
+   * transparently open the request-pair flow (RequestPairPanel) for that host
+   * instead of just surfacing a dead-end alert. Cleared once the panel opens
+   * (clearPendingApprovalPairHost) or the request resolves.
+   */
+  pendingApprovalPairHost: { name: string; wsUrl: string } | null;
+
   hostStatus: ServerHostStatusSnapshotMessage | null;
   /**
    * #5175 — true between dispatching a `host_status_request` and the matching
@@ -1138,6 +1150,10 @@ export interface ConnectionState {
   // #5510: deny a pending pair request, sending `pair_deny`. Same optimistic
   // drop + wire-result contract as approvePairRequest.
   denyPairRequest: (requestId: string) => boolean;
+
+  // #5513: clear the approval-gated redemption signal (`pendingApprovalPairHost`)
+  // after the UI has opened the request-pair flow for it.
+  clearPendingApprovalPairHost: () => void;
 
   // #5253: request a self-hosted runner survey. Dispatches a
   // `runner_status_request`; the server replies with a single

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6143,6 +6143,46 @@ button.sidebar-token-view-session-row:hover {
   user-select: all;
 }
 
+/* #5513 — host-triggered Discord pairing-link delivery */
+.qr-modal-discord {
+  margin: 14px 0 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.qr-modal-discord-btn {
+  background: var(--surface-raised, #2b2d31);
+  color: var(--text-primary);
+  border: 1px solid var(--border, #3a3c41);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.qr-modal-discord-btn:hover:not(:disabled) {
+  border-color: var(--accent-blue);
+}
+
+.qr-modal-discord-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.qr-modal-discord-ok {
+  color: var(--text-dim);
+  font-size: 12px;
+  text-align: center;
+}
+
+.qr-modal-discord-err {
+  color: var(--accent-red, #e74c3c);
+  font-size: 12px;
+  text-align: center;
+}
+
 .footer-qr-btn {
   background: none;
   border: none;

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -20,6 +20,7 @@ import { registerServiceCommand } from './cli/service-cmd.js'
 import { registerUpdateCommand } from './cli/update-cmd.js'
 import { registerStatusCommand } from './cli/status-cmd.js'
 import { registerPairCodeCommand } from './cli/pair-code-cmd.js'
+import { registerPairDiscordCommand } from './cli/pair-discord-cmd.js'
 import { registerWorktreeCommand } from './cli/worktree-gc-cmd.js'
 import { registerCredentialsCommand } from './cli/credentials-cmd.js'
 
@@ -44,6 +45,7 @@ registerServiceCommand(program)
 registerUpdateCommand(program)
 registerStatusCommand(program)
 registerPairCodeCommand(program)
+registerPairDiscordCommand(program)
 registerWorktreeCommand(program)
 registerCredentialsCommand(program)
 

--- a/packages/server/src/cli/pair-discord-cmd.js
+++ b/packages/server/src/cli/pair-discord-cmd.js
@@ -1,0 +1,98 @@
+/**
+ * chroxy pair-discord — post an approval-gated pairing link to Discord (#5513,
+ * epic #5509).
+ *
+ * Host-triggered convenience delivery for a camera-less device: the daemon
+ * generates a FRESH approval-gated pairing id and posts its `chroxy://…?pair=`
+ * link to the configured private Discord webhook channel. Tapping the link on
+ * the new device starts a pair REQUEST — the host must still approve it (#5510),
+ * so possession of the channel grants nothing on its own.
+ *
+ * Hits POST /pair-discord on the local daemon, which is gated on the PRIMARY
+ * token class (#5533). Exits non-zero on any failure (not running, no token,
+ * webhook not configured, post failed) with a legible reason.
+ */
+
+function portFromUrl(url) {
+  if (typeof url !== 'string') return null
+  const m = url.match(/:(\d+)(?:\/|$)/)
+  return m ? parseInt(m[1], 10) : null
+}
+
+/**
+ * Trigger a Discord pairing-link post on the local daemon. Exposed for testing.
+ * @param {object} [deps]
+ * @param {function} [deps.readConnectionInfo]
+ * @param {function} [deps.fetchFn]
+ * @param {number}   [deps.defaultPort]
+ * @returns {Promise<{ ok: true, expiresInSeconds: number }
+ *                  | { ok: false, reason: 'not_running'|'no_token'|'not_configured'|'post_failed'|'unavailable', message?: string }>}
+ */
+export async function postPairDiscord(deps = {}) {
+  const readConnectionInfo =
+    deps.readConnectionInfo ||
+    (await import('../connection-info.js')).readConnectionInfo
+  const fetchFn = deps.fetchFn || globalThis.fetch
+  const defaultPort = deps.defaultPort || 8765
+
+  const info = readConnectionInfo()
+  if (!info) return { ok: false, reason: 'not_running' }
+  if (!info.apiToken) return { ok: false, reason: 'no_token' }
+
+  const port = portFromUrl(info.httpUrl) || portFromUrl(info.wsUrl) || defaultPort
+  try {
+    const res = await fetchFn(`http://127.0.0.1:${port}/pair-discord`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(15000),
+      headers: { Authorization: `Bearer ${info.apiToken}`, Accept: 'application/json' },
+    })
+    let body = null
+    try { body = await res.json() } catch { /* keep null */ }
+    if (res && res.ok && body?.posted) {
+      return { ok: true, expiresInSeconds: body.expiresInSeconds }
+    }
+    // Map the daemon's structured reason through; fall back to a status string.
+    const reason = body?.reason || (res ? `http_${res.status}` : 'unavailable')
+    return { ok: false, reason }
+  } catch (err) {
+    return { ok: false, reason: 'unavailable', message: err?.message || 'request failed' }
+  }
+}
+
+/** Render a one-line success message. */
+export function formatPairDiscordResult(result) {
+  const ttl = Number.isFinite(result.expiresInSeconds) ? result.expiresInSeconds : 60
+  return `Posted pairing link to Discord — expires in ${ttl}s. Approval required on the host before the device connects.`
+}
+
+export async function runPairDiscordCmd(_options = {}, deps = {}) {
+  const result = await postPairDiscord(deps)
+  const write = deps.write || console.log
+  const writeErr = deps.writeErr || console.error
+  if (result.ok) {
+    write(formatPairDiscordResult(result))
+    return result
+  }
+  if (result.reason === 'not_running') {
+    writeErr('Chroxy server is not running. Start it with `chroxy start`.')
+  } else if (result.reason === 'no_token') {
+    writeErr('Server is running without an auth token — pairing is unavailable.')
+  } else if (result.reason === 'not_configured') {
+    writeErr('No Discord webhook is configured. Set CHROXY_DISCORD_WEBHOOK_URL or add discordWebhookUrl to ~/.chroxy/credentials.json.')
+  } else if (result.reason === 'post_failed') {
+    writeErr('Discord rejected the post — check the webhook is still valid.')
+  } else {
+    writeErr(`Could not post pairing link to Discord: ${result.message || result.reason}`)
+  }
+  return result
+}
+
+export function registerPairDiscordCommand(program) {
+  program
+    .command('pair-discord')
+    .description('Post an approval-gated pairing link to the configured Discord channel')
+    .action(async (options) => {
+      const result = await runPairDiscordCmd(options)
+      if (!result.ok) process.exitCode = 1
+    })
+}

--- a/packages/server/src/cli/pair-discord-cmd.js
+++ b/packages/server/src/cli/pair-discord-cmd.js
@@ -51,8 +51,10 @@ export async function postPairDiscord(deps = {}) {
     if (res && res.ok && body?.posted) {
       return { ok: true, expiresInSeconds: body.expiresInSeconds }
     }
-    // Map the daemon's structured reason through; fall back to a status string.
-    const reason = body?.reason || (res ? `http_${res.status}` : 'unavailable')
+    // Map the daemon's structured reason through; auth/availability failures
+    // arrive as { error: ... } rather than { reason: ... } — read both before
+    // degrading to a bare status string.
+    const reason = body?.reason || body?.error || (res ? `http_${res.status}` : 'unavailable')
     return { ok: false, reason }
   } catch (err) {
     return { ok: false, reason: 'unavailable', message: err?.message || 'request failed' }

--- a/packages/server/src/discord-pair-delivery.js
+++ b/packages/server/src/discord-pair-delivery.js
@@ -1,0 +1,113 @@
+/**
+ * Discord pairing-link delivery (#5513, epic #5509).
+ *
+ * A ONE-OFF webhook POST of an approval-gated chroxy:// pairing link to the
+ * configured private channel. Deliberately NOT the per-project status embed
+ * (discord-webhook-sink.js): no message-id tracking, no PATCH/DELETE lifecycle,
+ * no state machine — a single `webhook execute` POST and done. The two share
+ * only credential resolution (env > 0600 credentials.json) and the id/token
+ * extraction, which is the seam the issue calls for.
+ *
+ * Security:
+ *   - The link carries an APPROVAL-GATED id (PairingManager
+ *     .createApprovalGatedPairingId). Redeeming it never mints a token on its
+ *     own — the host must approve. So possession of the channel grants nothing.
+ *   - No token material beyond the ephemeral gated id is posted.
+ *   - The webhook URL is a SECRET. It is resolved here but NEVER logged and
+ *     NEVER returned in a result / reason string (a thrown fetch error may
+ *     embed the URL; we discard the error text and return a fixed reason).
+ *
+ * Host-triggered only (CLI `chroxy pair-discord`, dashboard button) — never
+ * automatic. Each trigger generates a fresh gated id upstream and calls this.
+ */
+
+import {
+  cachedResolveDiscordWebhookUrl,
+  isValidDiscordWebhookUrl,
+  extractWebhookIdToken,
+} from './discord-credentials.js'
+
+const FETCH_TIMEOUT_MS = 10_000
+
+/**
+ * Build the minimal Discord message for a pairing link. Plain `content` (no
+ * embeds, no state-machine fields). The only ephemeral material is the gated
+ * id already embedded in `url`.
+ *
+ * @param {{ url: string, expiresInSeconds?: number }} args
+ * @returns {{ content: string }}
+ */
+export function buildPairLinkMessage({ url, expiresInSeconds } = {}) {
+  const ttl = Number.isFinite(expiresInSeconds) ? Math.max(0, Math.round(expiresInSeconds)) : 60
+  // Minimal, masked-friendly: the link + the two facts a recipient needs.
+  // Approval is required on the host, so a leaked channel grants nothing.
+  const content = [
+    'Chroxy pairing link:',
+    url,
+    `Expires in ${ttl}s · approval required on the host.`,
+  ].join('\n')
+  return { content }
+}
+
+/**
+ * POST a pairing link to the configured Discord webhook. Resolves a plain
+ * result object; never throws, never logs or returns the webhook URL/token.
+ *
+ * @param {{ url: string, expiresInSeconds?: number }} link
+ * @param {object} [deps]
+ * @param {Function} [deps.resolveWebhookUrl] - injection seam; defaults to the
+ *   cached env > 0600-credentials resolver.
+ * @param {Function} [deps.fetchFn] - injection seam; defaults to global fetch.
+ * @returns {Promise<{ posted: true, expiresInSeconds: number }
+ *                  | { posted: false, reason: 'not_configured'|'invalid'|'post_failed' }>}
+ */
+export async function postPairLinkToDiscord(link, deps = {}) {
+  const resolveWebhookUrl = deps.resolveWebhookUrl || cachedResolveDiscordWebhookUrl
+  const fetchFn = deps.fetchFn || globalThis.fetch
+
+  const url = link?.url
+  if (typeof url !== 'string' || url.length === 0) {
+    return { posted: false, reason: 'invalid' }
+  }
+
+  let resolved
+  try {
+    resolved = resolveWebhookUrl()
+  } catch {
+    return { posted: false, reason: 'not_configured' }
+  }
+  const webhookUrl = resolved?.url
+  if (typeof webhookUrl !== 'string' || !isValidDiscordWebhookUrl(webhookUrl)) {
+    return { posted: false, reason: 'not_configured' }
+  }
+
+  const parts = extractWebhookIdToken(webhookUrl)
+  if (!parts) return { posted: false, reason: 'not_configured' }
+  const endpoint = `https://discord.com/api/webhooks/${parts.id}/${parts.token}`
+
+  const message = buildPairLinkMessage(link)
+  const expiresInSeconds = Number.isFinite(link?.expiresInSeconds)
+    ? Math.max(0, Math.round(link.expiresInSeconds))
+    : 60
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const res = await fetchFn(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(message),
+      signal: controller.signal,
+    })
+    if (!res || !res.ok) {
+      return { posted: false, reason: 'post_failed' }
+    }
+    return { posted: true, expiresInSeconds }
+  } catch {
+    // The thrown error text may embed the secret webhook URL — discard it and
+    // return a fixed reason. NEVER surface err.message.
+    return { posted: false, reason: 'post_failed' }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -174,7 +174,7 @@ export function createHttpHandler(server) {
   const dispatch = async (req, res) => {
     // CORS preflight
     if (req.method === 'OPTIONS') {
-      const isRestricted = req.url?.startsWith('/qr') || req.url?.startsWith('/connect') || req.url?.startsWith('/pairing-code')
+      const isRestricted = req.url?.startsWith('/qr') || req.url?.startsWith('/connect') || req.url?.startsWith('/pairing-code') || req.url?.startsWith('/pair-discord')
       const corsOrigin = isRestricted
         ? matchAllowedOrigin(req.headers['origin'])
         : '*'
@@ -491,6 +491,55 @@ export function createHttpHandler(server) {
         expiresAtMs: snap.expiresAtMs,
         expiresInSeconds: Math.ceil(expiresInMs / 1000),
       }))
+      return
+    }
+
+    // Discord pairing-link delivery (#5513, epic #5509): POST /pair-discord
+    // generates a FRESH approval-gated pairing id and posts its chroxy:// link
+    // to the configured Discord webhook. Host-triggered only (CLI / dashboard
+    // button). The gated id mints no token on redemption — the host must still
+    // approve (#5510) — so possession of the channel grants nothing.
+    //
+    // Gated on the PRIMARY token class from day one (#5533): posting a fresh
+    // pairing link is a host-authority action, so a pairing-bound session token
+    // (which is scoped, not host-level) is rejected. Mirrors /pairing-code's
+    // CORS, but uses _validatePrimaryBearerAuth instead of _validateBearerAuth.
+    if (req.method === 'POST' && req.url?.split('?')[0] === '/pair-discord') {
+      if (!server._validatePrimaryBearerAuth(req, res)) return
+      const pdCors = matchAllowedOrigin(req.headers['origin'])
+      const pdHeaders = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+      if (pdCors) {
+        pdHeaders['Access-Control-Allow-Origin'] = pdCors
+        pdHeaders['Vary'] = 'Origin'
+      }
+      if (!server._pairingManager) {
+        res.writeHead(503, pdHeaders)
+        res.end(JSON.stringify({ error: 'Pairing not available' }))
+        return
+      }
+      // Fresh gated id per trigger (60s TTL, single-use). The chroxy:// link is
+      // the only material posted — no token.
+      const gated = server._pairingManager.createApprovalGatedPairingId()
+      if (!gated?.pairingUrl) {
+        res.writeHead(503, pdHeaders)
+        res.end(JSON.stringify({ error: 'Pairing link not available — server has no public URL yet' }))
+        return
+      }
+      const expiresInSeconds = Number.isFinite(gated.expiresAt)
+        ? Math.max(0, Math.ceil((gated.expiresAt - Date.now()) / 1000))
+        : 60
+      const result = await server._postPairLinkToDiscord({ url: gated.pairingUrl, expiresInSeconds })
+      if (result?.posted) {
+        res.writeHead(200, pdHeaders)
+        res.end(JSON.stringify({ posted: true, expiresInSeconds: result.expiresInSeconds ?? expiresInSeconds }))
+        return
+      }
+      // not_configured → 409 (no webhook set); anything else → 502 (post failed).
+      // The webhook URL / token never appears in the response — postPairLinkToDiscord
+      // returns only a fixed reason code.
+      const status = result?.reason === 'not_configured' ? 409 : 502
+      res.writeHead(status, pdHeaders)
+      res.end(JSON.stringify({ posted: false, reason: result?.reason || 'post_failed' }))
       return
     }
 

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -182,12 +182,64 @@ export class PairingManager extends EventEmitter {
   }
 
   /**
+   * Generate a NEW pairing id flagged `requiresApproval: true` (#5513, epic
+   * #5509) — the Discord-delivery path. Unlike `generateBoundPairing`, a gated
+   * id NEVER mints a token on redemption: `validatePairing` returns
+   * `requires_approval` so the WsServer routes the redemption into the #5510
+   * pending-request approval flow (verify-code + host approve). Possession of
+   * the Discord channel therefore grants nothing on its own — a leaked link
+   * still needs an out-of-band host approval to connect.
+   *
+   * Like `generateBoundPairing`, this does NOT replace `_current` (the
+   * linking-mode QR keeps auto-refreshing); it adds an additional one-shot,
+   * single-use, TTL'd entry. Each trigger surface (CLI / dashboard button)
+   * calls this fresh so every Discord post carries its own ephemeral id.
+   *
+   * @returns {{ pairingId: string, pairingUrl: string|null, expiresAt: number }}
+   * @throws {Error} If the manager is destroyed.
+   */
+  createApprovalGatedPairingId() {
+    if (this._destroyed) {
+      throw new Error('PairingManager is destroyed')
+    }
+
+    // Cap active pairings to prevent unbounded growth. Skip _current.id when
+    // picking the eviction victim — dropping the linking-mode QR's entry would
+    // silently invalidate the main /qr (same rationale as generateBoundPairing).
+    if (this._activePairings.size >= MAX_ACTIVE_PAIRINGS) {
+      const linkingId = this._current?.id || null
+      let victim = null
+      for (const id of this._activePairings.keys()) {
+        if (id !== linkingId) {
+          victim = id
+          break
+        }
+      }
+      this._activePairings.delete(victim ?? this._activePairings.keys().next().value)
+    }
+
+    const id = generateTypeableCode()
+    const expiresAt = Date.now() + this._ttlMs
+    this._activePairings.set(id, { expiresAt, used: false, requiresApproval: true })
+
+    const pairingUrl = this._wsUrl
+      ? `chroxy://${this._wsUrl.replace(/^wss?:\/\//, '')}?pair=${id}`
+      : null
+    return { pairingId: id, pairingUrl, expiresAt }
+  }
+
+  /**
    * Validate a pairing ID and issue a session token if valid.
    * Accepts any active pairing ID (current or recently-refreshed within TTL).
    *
    * If the pairing entry was created via `generateBoundPairing(sessionId)`,
    * the binding is taken from the entry — `sessionId` param is ignored.
    * Otherwise (linking-mode pairings), the param controls the binding.
+   *
+   * Approval-gated entries (#5513, `createApprovalGatedPairingId`) are consumed
+   * (marked used) but NEVER mint a token: the call returns
+   * `{ valid: false, reason: 'requires_approval' }` so the caller routes the
+   * redemption into the host-approval flow instead.
    *
    * @param {string} pairingId
    * @param {string|null} [sessionId] - Session ID to bind to the issued token
@@ -216,6 +268,14 @@ export class PairingManager extends EventEmitter {
 
     // Mark as used (one-time)
     entry.used = true
+
+    // Approval-gated id (#5513): consume it but mint NO token. The caller
+    // (WsServer / handlePairMessage) maps `requires_approval` into the #5510
+    // pending-request flow — host approval is still required, so possession of
+    // the Discord-delivered link grants nothing on its own.
+    if (entry.requiresApproval) {
+      return { valid: false, reason: 'requires_approval' }
+    }
 
     // Issue a session token (with FIFO eviction at cap). Entry-bound pairings
     // (#3070) take precedence — the param is only honored for linking-mode

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -303,6 +303,25 @@ export function handlePairMessage(ctx, ws, msg) {
     return true
   }
 
+  // Approval-gated id (#5513, epic #5509): a Discord-delivered pairing link
+  // carries a flagged id that mints NO token. validatePairing consumed it
+  // (single-use) and reported `requires_approval`. This is NOT a failure — it
+  // is the intended routing: possession of the link is never sufficient; the
+  // device must request pairing and the host must approve it (#5510). We reply
+  // with a legible `pair_fail { reason: 'requires_approval' }` and close:
+  //   - old clients surface the reason and clean up (no hang);
+  //   - new dashboards detect the reason and transparently open the
+  //     request-pair UX (RequestPairPanel), which issues a fresh `pair_request`
+  //     on its own connection through the existing #5510 flow.
+  // It does NOT count toward either rate-limit bucket — this is a normal,
+  // expected redemption, not a brute-force or benign-hammer signal.
+  if (result.reason === 'requires_approval') {
+    log.info(`Gated pairing id redeemed from ${rateLimitKey} — routing to host approval (requires_approval)`)
+    send(ws, { type: 'pair_fail', reason: 'requires_approval' })
+    ws.close()
+    return true
+  }
+
   // Pairing failure — only increment the shared rate-limiter bucket for
   // genuine brute-force signals (invalid_pairing_id).
   //

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -15,6 +15,7 @@ import { createPermissionHandler } from './ws-permissions.js'
 import { setupForwarding } from './ws-forwarding.js'
 import { handleSessionMessage, handleCliMessage } from './ws-message-handlers.js'
 import { handleAuthMessage, handlePairMessage, handlePairRequestMessage, handleKeyExchange, BENIGN_PAIR_WINDOW_MS } from './ws-auth.js'
+import { postPairLinkToDiscord } from './discord-pair-delivery.js'
 import { sendPostAuthInfo, replayHistory, flushPostAuthQueue, sendSessionInfo } from './ws-history.js'
 import { createDevicePreferences } from './device-preferences.js'
 import { createHttpHandler } from './http-routes.js'
@@ -1016,6 +1017,48 @@ export class WsServer {
       return false
     }
     return true
+  }
+
+  /**
+   * Validate that an HTTP request carries the PRIMARY token class — i.e. the
+   * static apiToken (or an active rotation/grace token), NOT a pairing-bound
+   * session token. Used by host-authority endpoints that a scoped, paired
+   * device must not be able to invoke (#5533): e.g. POST /pair-discord, which
+   * posts a fresh pairing link to a shared channel. Per
+   * docs/security/bearer-token-authority.md, pairing-bound tokens are scoped to
+   * one session and must never carry host-level authority.
+   *
+   * A token is primary iff it validates but is NOT a PairingManager-issued
+   * session token. Returns true on pass; writes a 403 and returns false
+   * otherwise.
+   */
+  _validatePrimaryBearerAuth(req, res) {
+    if (!this.authRequired) return true
+    const authHeader = req.headers['authorization'] || ''
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+    if (!token || !this._isTokenValid(token)) {
+      res.writeHead(403, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'unauthorized' }))
+      return false
+    }
+    // Reject pairing-bound (and any other PairingManager-issued) session tokens:
+    // they are valid, but scoped — not the host-authority primary token.
+    if (this._pairingManager && this._pairingManager.isSessionTokenValid(token)) {
+      res.writeHead(403, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'primary_token_required' }))
+      return false
+    }
+    return true
+  }
+
+  /**
+   * Post an approval-gated pairing link to the configured Discord webhook
+   * (#5513). Thin seam around discord-pair-delivery.postPairLinkToDiscord so
+   * http-routes can call it and tests can stub it. Never logs / returns the
+   * webhook URL.
+   */
+  async _postPairLinkToDiscord(link) {
+    return postPairLinkToDiscord(link)
   }
 
   /**

--- a/packages/server/tests/discord-pair-delivery.test.js
+++ b/packages/server/tests/discord-pair-delivery.test.js
@@ -1,0 +1,97 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+// -- Discord pairing-link delivery (#5513, epic #5509) --
+//
+// A one-off webhook POST of the approval-gated chroxy:// pairing link. NOT the
+// per-project status embed (no state machine, no message id tracking). The
+// webhook URL is a secret — never logged, never returned in any error/result.
+describe('discord-pair-delivery (#5513)', () => {
+  let mod
+  let savedEnv
+
+  beforeEach(async () => {
+    mod = await import('../src/discord-pair-delivery.js')
+    savedEnv = process.env.CHROXY_DISCORD_WEBHOOK_URL
+  })
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CHROXY_DISCORD_WEBHOOK_URL
+    else process.env.CHROXY_DISCORD_WEBHOOK_URL = savedEnv
+  })
+
+  const validWebhook = 'https://discord.com/api/webhooks/123456789/abcDEF_token-xyz'
+
+  it('buildPairLinkMessage produces minimal text — link + expiry + approval note, no token material', () => {
+    const msg = mod.buildPairLinkMessage({
+      url: 'chroxy://host.example?pair=ABCD2345',
+      expiresInSeconds: 60,
+    })
+    assert.ok(typeof msg.content === 'string')
+    assert.ok(msg.content.includes('chroxy://host.example?pair=ABCD2345'), 'carries the chroxy:// link')
+    assert.match(msg.content, /60s|60 s|expires/i)
+    assert.match(msg.content, /approv/i, 'states host approval is required')
+    // No embed state-machine fields — a plain content post.
+    assert.equal(msg.embeds, undefined)
+  })
+
+  it('returns posted:false with reason not_configured when no webhook is set', async () => {
+    delete process.env.CHROXY_DISCORD_WEBHOOK_URL
+    const out = await mod.postPairLinkToDiscord(
+      { url: 'chroxy://h?pair=X', expiresInSeconds: 60 },
+      { resolveWebhookUrl: () => ({ url: null, source: 'none' }) },
+    )
+    assert.equal(out.posted, false)
+    assert.equal(out.reason, 'not_configured')
+  })
+
+  it('POSTs to the webhook execute endpoint and resolves posted:true on 2xx', async () => {
+    let captured = null
+    const fakeFetch = async (url, opts) => {
+      captured = { url, opts }
+      return { ok: true, status: 204 }
+    }
+    const out = await mod.postPairLinkToDiscord(
+      { url: 'chroxy://host?pair=CODE2345', expiresInSeconds: 45 },
+      { resolveWebhookUrl: () => ({ url: validWebhook, source: 'env' }), fetchFn: fakeFetch },
+    )
+    assert.equal(out.posted, true)
+    assert.equal(out.expiresInSeconds, 45)
+    // Hits the discord webhook execute endpoint built from id/token.
+    assert.ok(captured.url.startsWith('https://discord.com/api/webhooks/123456789/abcDEF_token-xyz'))
+    assert.equal(captured.opts.method, 'POST')
+    const body = JSON.parse(captured.opts.body)
+    assert.ok(body.content.includes('chroxy://host?pair=CODE2345'))
+  })
+
+  it('resolves posted:false reason post_failed on a non-2xx response', async () => {
+    const fakeFetch = async () => ({ ok: false, status: 400 })
+    const out = await mod.postPairLinkToDiscord(
+      { url: 'chroxy://h?pair=X', expiresInSeconds: 60 },
+      { resolveWebhookUrl: () => ({ url: validWebhook, source: 'env' }), fetchFn: fakeFetch },
+    )
+    assert.equal(out.posted, false)
+    assert.equal(out.reason, 'post_failed')
+  })
+
+  it('never includes the webhook URL or token in the result on failure', async () => {
+    const fakeFetch = async () => { throw new Error(`connect ${validWebhook} refused`) }
+    const out = await mod.postPairLinkToDiscord(
+      { url: 'chroxy://h?pair=X', expiresInSeconds: 60 },
+      { resolveWebhookUrl: () => ({ url: validWebhook, source: 'env' }), fetchFn: fakeFetch },
+    )
+    assert.equal(out.posted, false)
+    const serialized = JSON.stringify(out)
+    assert.ok(!serialized.includes('abcDEF_token-xyz'), 'token must never leak into the result')
+    assert.ok(!serialized.includes(validWebhook), 'full webhook URL must never leak into the result')
+  })
+
+  it('rejects a missing/invalid pairing url with reason invalid', async () => {
+    const out = await mod.postPairLinkToDiscord(
+      { url: null, expiresInSeconds: 60 },
+      { resolveWebhookUrl: () => ({ url: validWebhook, source: 'env' }) },
+    )
+    assert.equal(out.posted, false)
+    assert.equal(out.reason, 'invalid')
+  })
+})

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -294,6 +294,122 @@ describe('http-routes', () => {
     })
   })
 
+  // #5513: host-triggered Discord pairing-link delivery
+  describe('pair-discord endpoint', () => {
+    function makeDiscordMock(overrides = {}) {
+      const gatedIds = []
+      const posted = []
+      return createMockServer({
+        // Primary-class gate (#5533): only the static primary token may trigger.
+        _validatePrimaryBearerAuth(req, res) {
+          if (!this.authRequired) return true
+          const authHeader = req.headers['authorization'] || ''
+          const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+          // Treat 'pairing-bound' as a non-primary token in the mock.
+          if (token === 'pairing-bound') {
+            res.writeHead(403, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: 'primary_token_required' }))
+            return false
+          }
+          if (token !== this.apiToken) {
+            res.writeHead(403, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: 'unauthorized' }))
+            return false
+          }
+          return true
+        },
+        _pairingManager: {
+          createApprovalGatedPairingId() {
+            const id = `gated-${gatedIds.length}`
+            gatedIds.push(id)
+            return { pairingId: id, pairingUrl: `chroxy://example.com?pair=${id}`, expiresAt: Date.now() + 60_000 }
+          },
+        },
+        async _postPairLinkToDiscord(link) {
+          posted.push(link)
+          return { posted: true, expiresInSeconds: 60 }
+        },
+        _gatedIds: gatedIds,
+        _postedLinks: posted,
+        ...overrides,
+      })
+    }
+
+    it('POST /pair-discord generates a gated id, posts it, returns posted:true', async () => {
+      const mock = makeDiscordMock()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pair-discord`, {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.posted, true)
+      assert.equal(body.expiresInSeconds, 60)
+      assert.equal(mock._gatedIds.length, 1, 'one fresh gated id generated')
+      assert.equal(mock._postedLinks.length, 1)
+      assert.ok(mock._postedLinks[0].url.includes('gated-0'))
+    })
+
+    it('returns 403 without auth', async () => {
+      const mock = makeDiscordMock()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pair-discord`, { method: 'POST' })
+      assert.equal(res.status, 403)
+      assert.equal(mock._gatedIds.length, 0, 'no gated id minted for an unauthed request')
+    })
+
+    it('returns 403 for a pairing-bound (non-primary) token (#5533)', async () => {
+      const mock = makeDiscordMock()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pair-discord`, {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer pairing-bound' },
+      })
+      assert.equal(res.status, 403)
+      assert.equal(mock._gatedIds.length, 0, 'a non-primary token must not trigger a Discord post')
+    })
+
+    it('returns 503 when no pairing manager is wired', async () => {
+      const mock = makeDiscordMock({ _pairingManager: null })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pair-discord`, {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 503)
+    })
+
+    it('returns 409 + reason when the webhook is not configured', async () => {
+      const mock = makeDiscordMock({
+        async _postPairLinkToDiscord() { return { posted: false, reason: 'not_configured' } },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pair-discord`, {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 409)
+      const body = await res.json()
+      assert.equal(body.posted, false)
+      assert.equal(body.reason, 'not_configured')
+    })
+
+    it('returns 502 when the Discord POST fails', async () => {
+      const mock = makeDiscordMock({
+        async _postPairLinkToDiscord() { return { posted: false, reason: 'post_failed' } },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pair-discord`, {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 502)
+      const body = await res.json()
+      assert.equal(body.reason, 'post_failed')
+    })
+  })
+
   // #3070: per-session "Share this session" QR endpoint
   describe('per-session share QR endpoint', () => {
     function makeSharedMock(overrides = {}) {

--- a/packages/server/tests/pair-discord-cmd.test.js
+++ b/packages/server/tests/pair-discord-cmd.test.js
@@ -57,6 +57,18 @@ describe('pair-discord CLI (#5513)', () => {
     assert.equal(result.reason, 'not_configured')
   })
 
+  it('maps a 403 { error: primary_token_required } body through as the reason', async () => {
+    // Auth failures from the daemon use the { error: ... } shape, not
+    // { reason: ... } — postPairDiscord must read both so a scoped-token
+    // rejection stays legible instead of degrading to http_403.
+    const result = await postPairDiscord({
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', apiToken: 'tok' }),
+      fetchFn: async () => mockResponse(403, { error: 'primary_token_required' }),
+    })
+    assert.equal(result.ok, false)
+    assert.equal(result.reason, 'primary_token_required')
+  })
+
   it('maps a 502 post_failed into a legible reason', async () => {
     const result = await postPairDiscord({
       readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', apiToken: 'tok' }),

--- a/packages/server/tests/pair-discord-cmd.test.js
+++ b/packages/server/tests/pair-discord-cmd.test.js
@@ -1,0 +1,98 @@
+/**
+ * `chroxy pair-discord` CLI (#5513, epic #5509).
+ *
+ * Host-triggered post of an approval-gated pairing link to the configured
+ * Discord webhook channel. Hits the daemon's POST /pair-discord, which mints a
+ * fresh gated id (redeeming it needs host approval — the channel grants
+ * nothing) and posts only the chroxy:// link. Exits non-zero on any failure.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { postPairDiscord, formatPairDiscordResult, runPairDiscordCmd } from '../src/cli/pair-discord-cmd.js'
+
+function mockResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return body },
+  }
+}
+
+describe('pair-discord CLI (#5513)', () => {
+  it('POSTs to /pair-discord with the connection-info token', async () => {
+    let calledUrl = null
+    let calledMethod = null
+    let calledAuth = null
+    const result = await postPairDiscord({
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', wsUrl: 'wss://x.tld', apiToken: 'tok' }),
+      fetchFn: async (url, opts) => {
+        calledUrl = url
+        calledMethod = opts.method
+        calledAuth = opts.headers.Authorization
+        return mockResponse(200, { posted: true, expiresInSeconds: 60 })
+      },
+    })
+    assert.ok(calledUrl.endsWith('/pair-discord'))
+    assert.equal(calledMethod, 'POST')
+    assert.equal(calledAuth, 'Bearer tok')
+    assert.equal(result.ok, true)
+    assert.equal(result.expiresInSeconds, 60)
+  })
+
+  it('reports not-running when no connection info exists', async () => {
+    const result = await postPairDiscord({
+      readConnectionInfo: () => null,
+      fetchFn: async () => { throw new Error('should not be called') },
+    })
+    assert.equal(result.ok, false)
+    assert.equal(result.reason, 'not_running')
+  })
+
+  it('maps a 409 not_configured into a legible reason', async () => {
+    const result = await postPairDiscord({
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', apiToken: 'tok' }),
+      fetchFn: async () => mockResponse(409, { posted: false, reason: 'not_configured' }),
+    })
+    assert.equal(result.ok, false)
+    assert.equal(result.reason, 'not_configured')
+  })
+
+  it('maps a 502 post_failed into a legible reason', async () => {
+    const result = await postPairDiscord({
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', apiToken: 'tok' }),
+      fetchFn: async () => mockResponse(502, { posted: false, reason: 'post_failed' }),
+    })
+    assert.equal(result.ok, false)
+    assert.equal(result.reason, 'post_failed')
+  })
+
+  it('formatPairDiscordResult renders a success line with the TTL', () => {
+    const line = formatPairDiscordResult({ ok: true, expiresInSeconds: 60 })
+    assert.match(line, /60s/)
+    assert.match(line, /approv/i)
+  })
+
+  it('runPairDiscordCmd writes the success line and returns the result', async () => {
+    const writes = []
+    const result = await runPairDiscordCmd({}, {
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', apiToken: 'tok' }),
+      fetchFn: async () => mockResponse(200, { posted: true, expiresInSeconds: 60 }),
+      write: (s) => writes.push(s),
+      writeErr: () => {},
+    })
+    assert.equal(result.ok, true)
+    assert.ok(writes.some((w) => /60s/.test(w)))
+  })
+
+  it('runPairDiscordCmd writes a clear error when the webhook is not configured', async () => {
+    const errs = []
+    const result = await runPairDiscordCmd({}, {
+      readConnectionInfo: () => ({ pid: 1, httpUrl: 'http://127.0.0.1:8765', apiToken: 'tok' }),
+      fetchFn: async () => mockResponse(409, { posted: false, reason: 'not_configured' }),
+      write: () => {},
+      writeErr: (s) => errs.push(s),
+    })
+    assert.equal(result.ok, false)
+    assert.ok(errs.some((e) => /webhook|configur/i.test(e)))
+  })
+})

--- a/packages/server/tests/pairing-approval-gated.test.js
+++ b/packages/server/tests/pairing-approval-gated.test.js
@@ -1,0 +1,96 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { setTimeout as delay } from 'node:timers/promises'
+
+// -- Approval-gated pairing ids (#5513, epic #5509) --
+//
+// A Discord-delivered pairing link carries a FLAGGED id: redeeming it via the
+// normal `pair` path must NOT mint a token (that is QR trust). Instead the id is
+// distinguishable so the redemption routes into the #5510 approval primitive —
+// host approval is still required. Possession of the channel grants nothing.
+describe('PairingManager — approval-gated ids (#5513)', () => {
+  let PairingManager
+
+  before(async () => {
+    const mod = await import('../src/pairing.js')
+    PairingManager = mod.PairingManager
+  })
+
+  it('createApprovalGatedPairingId returns a fresh id + chroxy:// url', () => {
+    const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+    const out = pm.createApprovalGatedPairingId()
+    assert.ok(out.pairingId, 'returns a pairing id')
+    assert.ok(typeof out.pairingId === 'string')
+    assert.ok(out.pairingId.length >= 8)
+    assert.ok(out.pairingUrl.startsWith('chroxy://example.com?pair='))
+    assert.ok(out.pairingUrl.includes(out.pairingId))
+    assert.ok(Number.isFinite(out.expiresAt))
+    assert.ok(!out.pairingUrl.includes('token='), 'url carries no token material')
+    pm.destroy()
+  })
+
+  it('a gated id is distinct from the linking-mode current id', () => {
+    const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+    const linking = pm.currentPairingId
+    const { pairingId } = pm.createApprovalGatedPairingId()
+    assert.notEqual(pairingId, linking, 'gated id is its own one-shot entry')
+    // The linking-mode QR must keep working — generating a gated id must not
+    // replace _current.
+    assert.equal(pm.currentPairingId, linking)
+    pm.destroy()
+  })
+
+  it('validatePairing on a gated id does NOT mint a token — returns requires_approval', () => {
+    const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+    const { pairingId } = pm.createApprovalGatedPairingId()
+    const result = pm.validatePairing(pairingId)
+    assert.equal(result.valid, false, 'gated id never validates to a token')
+    assert.equal(result.reason, 'requires_approval')
+    assert.equal(result.sessionToken, undefined, 'no token material leaks')
+    pm.destroy()
+  })
+
+  it('a gated id is single-use — a second redemption is already_used', () => {
+    const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+    const { pairingId } = pm.createApprovalGatedPairingId()
+    const first = pm.validatePairing(pairingId)
+    assert.equal(first.reason, 'requires_approval')
+    const second = pm.validatePairing(pairingId)
+    assert.equal(second.valid, false)
+    assert.equal(second.reason, 'already_used')
+    pm.destroy()
+  })
+
+  it('a gated id expires on its TTL', async () => {
+    const pm = new PairingManager({ wsUrl: 'wss://example.com', ttlMs: 1 })
+    const { pairingId } = pm.createApprovalGatedPairingId()
+    await delay(10)
+    const result = pm.validatePairing(pairingId)
+    assert.equal(result.valid, false)
+    assert.equal(result.reason, 'expired')
+    pm.destroy()
+  })
+
+  it('a normal (non-gated) id still mints a token', () => {
+    const pm = new PairingManager({ wsUrl: 'wss://example.com' })
+    const id = pm.currentPairingId
+    const result = pm.validatePairing(id)
+    assert.equal(result.valid, true)
+    assert.ok(result.sessionToken)
+    pm.destroy()
+  })
+
+  it('returns null url when no wsUrl is configured', () => {
+    const pm = new PairingManager({})
+    const out = pm.createApprovalGatedPairingId()
+    assert.ok(out.pairingId)
+    assert.equal(out.pairingUrl, null)
+    pm.destroy()
+  })
+
+  it('throws when the manager is destroyed', () => {
+    const pm = new PairingManager({})
+    pm.destroy()
+    assert.throws(() => pm.createApprovalGatedPairingId(), /destroyed/)
+  })
+})

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -777,6 +777,33 @@ describe('handlePairMessage', () => {
     })
   })
 
+  describe('approval-gated redemption (#5513)', () => {
+    it('does NOT authenticate or mint a token when validation returns requires_approval', () => {
+      const pairingManager = { validatePairing: createSpy(() => ({ valid: false, reason: 'requires_approval' })) }
+      const { ctx, ws, client, onAuthSuccess } = makePairCtx({ pairingManager })
+      const result = handlePairMessage(ctx, ws, { type: 'pair', pairingId: 'gated-id' })
+      assert.equal(result, true)
+      assert.equal(client.authenticated, false, 'a gated id must never authenticate the client')
+      assert.equal(client._sessionToken, undefined, 'no token material is issued')
+      assert.equal(onAuthSuccess.callCount, 0)
+      const last = ws.lastSent()
+      assert.equal(last.type, 'pair_fail')
+      assert.equal(last.reason, 'requires_approval', 'legible reason so old clients fail cleanly and new clients fall into request-pair')
+      assert.equal(ws.closed, true)
+    })
+
+    it('does NOT count requires_approval toward the brute-force rate limiter', () => {
+      const authFailures = new Map()
+      const benignPairAttempts = new Map()
+      const pairingManager = { validatePairing: createSpy(() => ({ valid: false, reason: 'requires_approval' })) }
+      const client = makeMockClient({ ip: '127.0.0.1', rateLimitKey: '203.0.113.9' })
+      const { ctx, ws } = makePairCtx({ pairingManager, authFailures, benignPairAttempts, client })
+      handlePairMessage(ctx, ws, { type: 'pair', pairingId: 'gated-id' })
+      assert.equal(authFailures.has('203.0.113.9'), false, 'requires_approval is not a brute-force signal')
+      assert.equal(benignPairAttempts.has('203.0.113.9'), false, 'requires_approval is a normal redemption, not benign hammering')
+    })
+  })
+
   describe('successful pairing', () => {
     it('authenticates client when pairingManager validates successfully', () => {
       const pairingManager = { validatePairing: createSpy(() => ({ valid: true, sessionToken: 'sess-tok' })) }

--- a/packages/server/tests/ws-server-auth.test.js
+++ b/packages/server/tests/ws-server-auth.test.js
@@ -299,6 +299,66 @@ describe('WsServer GET /version auth', () => {
   })
 })
 
+describe('WsServer POST /pair-discord primary-class auth (#5513)', () => {
+  let server
+  let pm
+
+  afterEach(() => {
+    if (server) { server.close(); server = null }
+    if (pm) { pm.destroy(); pm = null }
+  })
+
+  async function startWithPairing() {
+    const { PairingManager } = await import('../src/pairing.js')
+    pm = new PairingManager({ wsUrl: 'wss://example.com' })
+    server = new WsServer({
+      port: 0,
+      apiToken: 'primary-tok',
+      cliSession: createMockSession(),
+      authRequired: true,
+      pairingManager: pm,
+    })
+    // Stub the actual Discord post so the test never touches the network.
+    server._postPairLinkToDiscord = async (link) => ({ posted: true, expiresInSeconds: 60, _link: link })
+    const port = await startServerAndGetPort(server)
+    return port
+  }
+
+  it('accepts the primary token and posts a fresh gated link', async () => {
+    const port = await startWithPairing()
+    const res = await fetch(`http://127.0.0.1:${port}/pair-discord`, {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer primary-tok' },
+    })
+    assert.equal(res.status, 200)
+    const body = await res.json()
+    assert.equal(body.posted, true)
+    assert.ok(Number.isFinite(body.expiresInSeconds))
+  })
+
+  it('rejects a pairing-bound session token (#5533)', async () => {
+    const port = await startWithPairing()
+    // Mint a real pairing-bound session token via the linking-mode pairing.
+    const { sessionToken } = pm.validatePairing(pm.currentPairingId)
+    assert.ok(sessionToken, 'sanity: pairing issued a session token')
+    assert.equal(pm.isSessionTokenValid(sessionToken), true)
+
+    const res = await fetch(`http://127.0.0.1:${port}/pair-discord`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${sessionToken}` },
+    })
+    assert.equal(res.status, 403, 'a scoped session token must not trigger a Discord post')
+    const body = await res.json()
+    assert.equal(body.error, 'primary_token_required')
+  })
+
+  it('rejects an unauthenticated request', async () => {
+    const port = await startWithPairing()
+    const res = await fetch(`http://127.0.0.1:${port}/pair-discord`, { method: 'POST' })
+    assert.equal(res.status, 403)
+  })
+})
+
 describe('WsServer with authRequired: true (default behavior)', () => {
   let server
 


### PR DESCRIPTION
## Summary

Convenience delivery of a pairing link through the existing Discord webhook (#5413 infra): a host action posts the `chroxy://host?pair=<id>` link to the configured private channel so a camera-less device can deep-link into pairing. Delivery only — webhooks are post-only, so no buttons/interactions.

## Why possession of the channel grants nothing — the gated-id mechanism

The normal `?pair=` path mints a session token **immediately** on redemption (QR trust: a scanned code means physical presence). A Discord-delivered link must NOT have that property, or anyone with channel access could connect.

The mechanism makes the posted id **distinguishable server-side**:

- `PairingManager.createApprovalGatedPairingId()` mints a fresh one-shot, 60s-TTL id flagged `requiresApproval`. It does **not** replace the linking-mode QR (`_current`) — it's an additional entry, like `generateBoundPairing`.
- `validatePairing` consumes a gated id (single-use) but returns `{ valid: false, reason: 'requires_approval' }` — it **never mints a token**. No token material leaks.
- The link itself is an opaque `?pair=<id>`; the client can't tell gated from normal. Only the server knows, so a leaked channel can't be "downgraded" to a trust pairing.

When a client redeems a gated link:

- `handlePairMessage` maps `requires_approval` to a legible `pair_fail { reason: 'requires_approval' }` and closes the socket.
  - **Old clients** surface a clear "Pairing failed: requires_approval" (parsed via the existing `sharedPairFail`) — no hang.
  - **New dashboards** detect the reason in the `pair_fail` handler, record the failed host (`pendingApprovalPairHost`), and `ServerPicker` transparently opens the request-pair UX (`RequestPairPanel`), which issues a fresh `pair_request` through the existing #5510 host-approval flow (verify-code compare + host approve).
- `requires_approval` counts toward **neither** rate-limit bucket — it's a normal redemption, not a brute-force or benign-hammer signal.

So a pairing started from a Discord-delivered link always needs out-of-band host approval. The channel never grants access alone.

## Trigger surfaces (host-triggered only, never automatic)

- **CLI** `chroxy pair-discord` — hits `POST /pair-discord`; exits non-zero with a legible reason if the daemon is down / no token / no webhook / post fails.
- **Dashboard** — a "Post link to Discord" button beside the pairing code in `QrModal` (linking mode only; omitted for per-session Share QRs), with inline success/error status.

Each trigger generates a **fresh** gated id and posts only its `chroxy://` link.

## Server

- `POST /pair-discord` mints a fresh gated id and posts only its link via `discord-pair-delivery.js` — a **one-off webhook execute POST** that reuses the credentials resolution (env > 0600 `credentials.json`) + id/token extraction, **not** the per-project status-embed state machine (no message-id tracking, no PATCH/DELETE lifecycle).
- The webhook URL is a secret: never logged, never returned in any result/reason. A thrown fetch error that could embed the URL is discarded for a fixed reason code.
- Gated on the **primary token class from day one (#5533)** via a new `_validatePrimaryBearerAuth`: a pairing-bound (scoped) session token is valid but rejected — posting a fresh pairing link to a shared channel is host-authority. Mirrors `/pairing-code`'s CORS + auth seam.
- Statuses: `200 { posted, expiresInSeconds }`, `409 not_configured`, `502 post_failed`, `503` (no pairing manager / no public URL).

## Protocol

No `@chroxy/protocol` change: `ServerPairFailSchema.reason` is already a free `z.string()`, so `requires_approval` rides the existing `pair_fail` shape and old clients parse it legibly. No dist rebuild needed.

## Tests

TDD, failing-first. Targeted suites (server `--test-force-exit`, trust exit codes; SessionManager tests use temp `stateFilePath`):

- Server: `pairing-approval-gated` (8), `discord-pair-delivery` (6), `pair-discord-cmd` (7), `ws-auth` (88), `http-routes` + `ws-server-auth` pair-discord/primary-class cases. Combined touched server run: **243 pass, 0 fail**. Adjacent pairing + discord-webhook-sink regression run: **125 pass, 0 fail**.
- Dashboard: `QrModal` (17), `message-handler` pair_fail/requires_approval, `ServerPicker` (56). Touched dashboard run: **285 pass, 0 fail**. `tsc --noEmit` clean; `vite build` green.
- Lints: `lint-tests-state-file-path.sh` OK, `lint-session-opt-forwarding.sh` OK, eslint on changed server source files clean.

Closes #5513.
Related to #5509.