### PR TITLE
chore: update smoke-form skill to template 3cd93cc (dictation mic buttons)

### DIFF
--- a/.claude/commands/smoke-form.md
+++ b/.claude/commands/smoke-form.md
@@ -104,6 +104,16 @@ fail=red, blocked=amber, skipped=gray. Respect `prefers-reduced-motion`.
 
 - Every input persists to `localStorage` keyed by the file's slug+date
   (restore on load; checkbox auto-checks when a result is chosen).
+- **Dictation (progressive enhancement):** if `window.SpeechRecognition ||
+  window.webkitSpeechRecognition` exists, render a small round 🎤 button beside
+  every note field and tester-metadata input. Click → start recognition
+  (`continuous: true`, final results only, `lang` from `navigator.language`),
+  appending each final transcript to the field (space-joined) and persisting;
+  button pulses red while recording, click again (⏹) to stop; only one active
+  recorder at a time. Errors (mic permission, offline) surface via the button
+  tooltip — never an alert. Where the API is absent the button simply doesn't
+  render. Title-hint the privacy caveat: Chromium relays audio to Google's
+  speech service; macOS users can always use built-in Dictation instead.
 - Progress counts update live in header and section summaries.
 - **Copy Results markdown format** (exact):
 
@@ -140,4 +150,4 @@ Result: X pass / Y fail / Z blocked / W skipped / U untested
   item UNLESS it has a visual/device component automation can't see.
   Server node:test + dashboard/store-core vitest + app jest suites run in CI on every PR; the 20 Maestro flows (`packages/app/.maestro/run-all.yaml`) cover mobile UI on a simulator; `/smoke-test` drives the dashboard headless via Playwright. Manual items should target what those cannot see: real-device feel (latency, scroll, keyboard), multi-machine flows (LAN pairing, tunnel fallback), Discord-side rendering, and anything flagged "needs simulator/device pass" in PR bodies.
 
-<!-- skill-templates: smoke-form 8cd4426 2026-06-11 -->
+<!-- skill-templates: smoke-form 3cd93cc 2026-06-11 -->

--- a/.claude/skills.lock
+++ b/.claude/skills.lock
@@ -74,7 +74,7 @@
       "installed": "2026-06-04"
     },
     "smoke-form": {
-      "hash": "8cd4426",
+      "hash": "3cd93cc",
       "installed": "2026-06-11",
       "profileHash": "57b5312"
     },


### PR DESCRIPTION
Routine /skill update: upstream template smoke-form@3cd93cc added a dictation spec — a progressive-enhancement Web Speech API mic button beside every note/metadata field, with recording state, single-active-recorder discipline, tooltip-surfaced errors, and the Chromium privacy caveat. Same customization fills as #5539; preserves that review's markdown fix. Lock bumped 8cd4426 → 3cd93cc.