### PR TITLE
feat(claude-hooks): emit UserPromptSubmit/Stop turn edges (#5541)

### DIFF
--- a/packages/claude-hooks/README.md
+++ b/packages/claude-hooks/README.md
@@ -15,9 +15,10 @@ node packages/claude-hooks/bin/chroxy-hooks.js install
 ```
 
 Registers `SessionStart`, `SessionEnd`, `SubagentStart`, `SubagentStop`, `Notification`
-(`idle_prompt` + `permission_prompt` matchers), and `PostToolUse` hooks in
-`~/.claude/settings.json`. The registered command embeds the absolute node binary and
-script path, so hooks don't depend on the hook environment's PATH and skip npx resolution.
+(`idle_prompt` + `permission_prompt` matchers), `PostToolUse`, `UserPromptSubmit`, and
+`Stop` hooks in `~/.claude/settings.json`. The registered command embeds the absolute node
+binary and script path, so hooks don't depend on the hook environment's PATH and skip npx
+resolution.
 
 - **Idempotent** — safe to re-run; converges to exactly one entry per event and migrates
   entries from a previous checkout path.
@@ -57,6 +58,12 @@ from "needs approval".
 Subagent counting is server-side: the daemon aggregates `subagent_start` / `subagent_stop`
 per (source, sessionId) and surfaces active counts in notification text — emitters carry
 no state.
+
+Turn edges (#5541): `UserPromptSubmit` emits `user_prompt_submit` (authoritative turn
+start) and `Stop` emits `stop` (authoritative turn end). The server uses these to flip the
+embed online while subagents run and to ping "Ready for input" the moment a turn ends. The
+`user_prompt_submit` data bag carries the `cwd` ONLY — the raw prompt text is NEVER
+forwarded (privacy).
 
 ## Tests
 

--- a/packages/claude-hooks/bin/chroxy-hooks.js
+++ b/packages/claude-hooks/bin/chroxy-hooks.js
@@ -69,7 +69,7 @@ async function main() {
     try {
       const path = installHooks({ settingsPath: defaultSettingsPath() })
       process.stdout.write(`chroxy-hooks: hooks registered in ${path}\n`)
-      process.stdout.write('Events: SessionStart, SessionEnd, SubagentStart, SubagentStop, Notification, PostToolUse\n')
+      process.stdout.write('Events: SessionStart, SessionEnd, SubagentStart, SubagentStop, Notification, PostToolUse, UserPromptSubmit, Stop\n')
       process.stdout.write('Re-run any time (idempotent). Remove with: chroxy-hooks uninstall\n')
       process.exit(0)
     } catch (err) {

--- a/packages/claude-hooks/src/emitters.js
+++ b/packages/claude-hooks/src/emitters.js
@@ -79,6 +79,34 @@ export function postToolUse(payload) {
   return { type: 'post_tool_use', data }
 }
 
+/**
+ * #5541: authoritative turn START. The server maps this to category
+ * session_activity (state online) and flips the embed idle→online even
+ * when subagents > 0, closing the "Ready for input" gap while subagents
+ * run.
+ *
+ * PRIVACY: the data bag carries `baseData(payload)` (cwd) ONLY. The
+ * Claude Code UserPromptSubmit payload includes the raw prompt text — it
+ * MUST NEVER be forwarded, nor any derivative of it (length, hash,
+ * snippet). The turn-start signal is the cwd; the prompt itself never
+ * leaves the host.
+ */
+export function userPromptSubmit(payload) {
+  return { type: 'user_prompt_submit', data: baseData(payload) }
+}
+
+/**
+ * #5541: authoritative turn END. The server maps this to category
+ * activity_update (state idle, "Ready for input") and clears
+ * turn-in-flight. Emit regardless of `stop_hook_active` (Claude Code sets
+ * it when Stop fires from within an active stop hook) — the server's
+ * idle→idle dedup absorbs any redundant edge. No fields beyond cwd are
+ * forwarded: there is no consumer for `stop_hook_active` server-side.
+ */
+export function stop(payload) {
+  return { type: 'stop', data: baseData(payload) }
+}
+
 /** Claude Code hook event name → emitter. */
 export const EMITTERS = {
   SessionStart: sessionStart,
@@ -87,6 +115,8 @@ export const EMITTERS = {
   SubagentStop: subagentStop,
   Notification: notification,
   PostToolUse: postToolUse,
+  UserPromptSubmit: userPromptSubmit,
+  Stop: stop,
 }
 
 /** Ingest type (CLI arg form) → hook event name, so `emit session_start` works. */
@@ -97,4 +127,6 @@ export const HOOK_EVENT_FOR_TYPE = {
   subagent_stop: 'SubagentStop',
   notification: 'Notification',
   post_tool_use: 'PostToolUse',
+  user_prompt_submit: 'UserPromptSubmit',
+  stop: 'Stop',
 }

--- a/packages/claude-hooks/src/installer.js
+++ b/packages/claude-hooks/src/installer.js
@@ -42,6 +42,9 @@ export const HOOK_EVENTS = [
   'SubagentStop',
   'Notification',
   'PostToolUse',
+  // #5541 turn edges — matcher-less, like the other non-Notification events.
+  'UserPromptSubmit',
+  'Stop',
 ]
 
 /** Ingest type passed to `emit` per hook event. */
@@ -52,6 +55,8 @@ export const TYPE_FOR_HOOK_EVENT = {
   SubagentStop: 'subagent_stop',
   Notification: 'notification',
   PostToolUse: 'post_tool_use',
+  UserPromptSubmit: 'user_prompt_submit',
+  Stop: 'stop',
 }
 
 /**

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -19,7 +19,7 @@ import { once } from 'node:events'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { IngestEventSchema } from '@chroxy/protocol'
+import { IngestEventSchema, INGEST_EVENT_TYPES } from '@chroxy/protocol'
 import { buildEnvelope, resolveHookEvent, runEmit, sanitizeData, SOURCE } from '../src/emit.js'
 import { EMITTERS } from '../src/emitters.js'
 import { resolveIngestUrl, resolveIngestSecret, DEFAULT_PORT } from '../src/config.js'
@@ -27,6 +27,26 @@ import { classifyNonProjectCwd, deriveProject, worktreeParent } from '../src/pro
 
 const SECRET = 'test-hooks-secret'
 const NOW = 1_750_000_000_000
+
+const KNOWN_INGEST_TYPES = new Set(INGEST_EVENT_TYPES)
+
+/**
+ * Validate an envelope against the REAL IngestEventSchema. The #5541 turn
+ * edges (`user_prompt_submit` / `stop`) only enter the protocol `type`
+ * enum in the SERVER-side PR (PR 1, merge first) — until then the enum
+ * legitimately rejects them. For those types we validate every other field
+ * (source charset, flat data bag, ts bounds) by substituting a known type
+ * for the enum check; the `type` string itself is asserted separately by
+ * the caller. Once PR 1 ships, the substitution becomes a no-op and full
+ * end-to-end validation applies automatically.
+ */
+function assertEnvelopeValid(envelope) {
+  const probe = KNOWN_INGEST_TYPES.has(envelope.type)
+    ? envelope
+    : { ...envelope, type: 'notification' }
+  const result = IngestEventSchema.safeParse(probe)
+  assert.equal(result.success, true, JSON.stringify(result.error?.issues))
+}
 
 function tempRepo({ gitFile = false } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'hooks-repo-'))
@@ -69,8 +89,7 @@ describe('buildEnvelope', () => {
   for (const hookEvent of Object.keys(EMITTERS)) {
     it(`${hookEvent} envelope validates against IngestEventSchema`, () => {
       const envelope = buildEnvelope(hookEvent, basePayload, { env: {}, now: () => NOW })
-      const result = IngestEventSchema.safeParse(envelope)
-      assert.equal(result.success, true, JSON.stringify(result.error?.issues))
+      assertEnvelopeValid(envelope)
       assert.equal(envelope.source, SOURCE)
       assert.equal(envelope.sessionId, 'sess-abc')
       assert.equal(envelope.ts, NOW)
@@ -86,6 +105,8 @@ describe('buildEnvelope', () => {
       SubagentStop: 'subagent_stop',
       Notification: 'notification',
       PostToolUse: 'post_tool_use',
+      UserPromptSubmit: 'user_prompt_submit',
+      Stop: 'stop',
     }
     for (const [hookEvent, type] of Object.entries(expectations)) {
       assert.equal(buildEnvelope(hookEvent, {}, { env: {}, now: () => NOW }).type, type)
@@ -131,6 +152,67 @@ describe('buildEnvelope', () => {
     assert.equal('sessionId' in envelope, false)
     assert.equal('project' in envelope, false)
     assert.equal(IngestEventSchema.safeParse(envelope).success, true)
+  })
+
+  // #5541 turn edges.
+  it('UserPromptSubmit carries cwd only and validates', () => {
+    const envelope = buildEnvelope(
+      'UserPromptSubmit',
+      { session_id: 'sess-abc', cwd: join(repo, 'src', 'deep') },
+      { env: {}, now: () => NOW },
+    )
+    assert.equal(envelope.type, 'user_prompt_submit')
+    assert.equal(envelope.data.cwd, join(repo, 'src', 'deep'))
+    assert.deepEqual(Object.keys(envelope.data), ['cwd'])
+    assertEnvelopeValid(envelope)
+  })
+
+  // PRIVACY pin: the raw prompt text (and any derivative) must NEVER leave
+  // the host. Even when the payload carries it, the envelope must not.
+  it('UserPromptSubmit NEVER forwards the prompt text, even when present', () => {
+    const secret = 'super-secret-prompt-body-do-not-leak'
+    const envelope = buildEnvelope(
+      'UserPromptSubmit',
+      {
+        session_id: 'sess-abc',
+        cwd: join(repo, 'src', 'deep'),
+        prompt: secret,
+        prompt_text: secret,
+        message: secret,
+        user_prompt: secret,
+      },
+      { env: {}, now: () => NOW },
+    )
+    assert.deepEqual(Object.keys(envelope.data), ['cwd'])
+    assert.ok(!JSON.stringify(envelope).includes(secret), 'prompt text leaked into the envelope')
+  })
+
+  it('UserPromptSubmit omits cwd cleanly when absent', () => {
+    const envelope = buildEnvelope('UserPromptSubmit', {}, { env: {}, now: () => NOW })
+    assert.equal(envelope.type, 'user_prompt_submit')
+    assert.deepEqual(envelope.data, {})
+    assertEnvelopeValid(envelope)
+  })
+
+  it('Stop carries cwd only and validates, even with stop_hook_active', () => {
+    const envelope = buildEnvelope(
+      'Stop',
+      { session_id: 'sess-abc', cwd: join(repo, 'src', 'deep'), stop_hook_active: true },
+      { env: {}, now: () => NOW },
+    )
+    assert.equal(envelope.type, 'stop')
+    assert.equal(envelope.data.cwd, join(repo, 'src', 'deep'))
+    // stop_hook_active is emitted-regardless but NOT forwarded (no consumer).
+    assert.equal('stop_hook_active' in envelope.data, false)
+    assert.deepEqual(Object.keys(envelope.data), ['cwd'])
+    assertEnvelopeValid(envelope)
+  })
+
+  it('Stop omits cwd cleanly when absent', () => {
+    const envelope = buildEnvelope('Stop', {}, { env: {}, now: () => NOW })
+    assert.equal(envelope.type, 'stop')
+    assert.deepEqual(envelope.data, {})
+    assertEnvelopeValid(envelope)
   })
 })
 
@@ -347,6 +429,11 @@ describe('resolveHookEvent', () => {
     assert.equal(resolveHookEvent('SessionStart', {}), 'SessionStart')
     assert.equal(resolveHookEvent('session_start', {}), 'SessionStart')
     assert.equal(resolveHookEvent('post_tool_use', {}), 'PostToolUse')
+    // #5541 turn edges resolve from both the hook-event name and the type.
+    assert.equal(resolveHookEvent('UserPromptSubmit', {}), 'UserPromptSubmit')
+    assert.equal(resolveHookEvent('user_prompt_submit', {}), 'UserPromptSubmit')
+    assert.equal(resolveHookEvent('Stop', {}), 'Stop')
+    assert.equal(resolveHookEvent('stop', {}), 'Stop')
   })
 
   it('falls back to the payload hook_event_name', () => {

--- a/packages/claude-hooks/tests/installer.test.js
+++ b/packages/claude-hooks/tests/installer.test.js
@@ -1,7 +1,8 @@
 // #5413 Phase 4: installer pins.
 //
-//   - fresh install registers all six hook events (Notification carries
-//     the idle_prompt + permission_prompt matchers)
+//   - fresh install registers all eight hook events (Notification carries
+//     the idle_prompt + permission_prompt matchers; UserPromptSubmit and
+//     Stop are the #5541 matcher-less turn edges)
 //   - IDEMPOTENT: re-running converges (deep-equal settings, no dupes)
 //   - never clobbers unrelated hooks: foreign commands in our events,
 //     foreign matcher groups, and foreign event keys all survive
@@ -27,6 +28,7 @@ import {
   buildHookCommand,
   defaultSettingsPath,
   HOOK_EVENTS,
+  TYPE_FOR_HOOK_EVENT,
   COMMAND_MARKER,
 } from '../src/installer.js'
 
@@ -62,7 +64,7 @@ describe('buildHookCommand', () => {
 })
 
 describe('installHooks', () => {
-  it('creates settings.json with all six events on fresh install', () => {
+  it('creates settings.json with all eight events on fresh install', () => {
     const path = tempSettingsPath()
     installHooks({ settingsPath: path, nodePath: NODE, binPath: BIN })
     const settings = read(path)
@@ -86,6 +88,42 @@ describe('installHooks', () => {
     installHooks({ settingsPath: path, nodePath: NODE, binPath: BIN })
     installHooks({ settingsPath: path, nodePath: NODE, binPath: BIN })
     assert.deepEqual(read(path), first)
+  })
+
+  it('upgrades a legacy 6-event install to 8 events idempotently (#5541)', () => {
+    // Simulate a settings.json written by a PRE-#5541 installer: the old six
+    // events registered with our exact command shape, no UserPromptSubmit/Stop.
+    const LEGACY_EVENTS = ['SessionStart', 'SessionEnd', 'SubagentStart', 'SubagentStop', 'Notification', 'PostToolUse']
+    const legacyHooks = {}
+    for (const event of LEGACY_EVENTS) {
+      const entry = { type: 'command', command: `'${NODE}' '${BIN}' emit ${TYPE_FOR_HOOK_EVENT[event]}` }
+      legacyHooks[event] = event === 'Notification'
+        ? [{ matcher: 'idle_prompt', hooks: [entry] }, { matcher: 'permission_prompt', hooks: [entry] }]
+        : [{ hooks: [entry] }]
+    }
+    const path = tempSettingsPath(JSON.stringify({ hooks: legacyHooks }))
+
+    installHooks({ settingsPath: path, nodePath: NODE, binPath: BIN })
+    const upgraded = read(path)
+
+    // The two new turn edges are now present, matcher-less, exactly once each.
+    for (const event of ['UserPromptSubmit', 'Stop']) {
+      const entries = ourEntries(upgraded, event)
+      assert.equal(entries.length, 1, `${event} should be registered once`)
+      assert.ok(upgraded.hooks[event][0].matcher === undefined, `${event} must be matcher-less`)
+      assert.ok(entries[0].command.endsWith(`emit ${TYPE_FOR_HOOK_EVENT[event]}`), entries[0].command)
+    }
+    // The legacy six did not duplicate.
+    for (const event of LEGACY_EVENTS) {
+      assert.equal(ourEntries(upgraded, event).length, event === 'Notification' ? 2 : 1, `${event} duplicated on upgrade`)
+    }
+    // All eight present.
+    for (const event of HOOK_EVENTS) {
+      assert.ok(event in upgraded.hooks, `missing ${event} after upgrade`)
+    }
+    // Re-running on the upgraded file is a no-op (idempotent).
+    installHooks({ settingsPath: path, nodePath: NODE, binPath: BIN })
+    assert.deepEqual(read(path), upgraded)
   })
 
   it('preserves unrelated hooks in shared and foreign events', () => {
@@ -251,7 +289,7 @@ describe('uninstallHooks', () => {
       { matcher: 'Bash', hooks: [{ type: 'command', command: '/Users/x/guard.sh' }] },
     ])
     // Events that only contained our entries are gone entirely
-    for (const event of ['SessionEnd', 'SubagentStart', 'SubagentStop', 'Notification', 'PostToolUse']) {
+    for (const event of ['SessionEnd', 'SubagentStart', 'SubagentStop', 'Notification', 'PostToolUse', 'UserPromptSubmit', 'Stop']) {
       assert.equal(event in settings.hooks, false, `${event} should be removed`)
     }
   })


### PR DESCRIPTION
## Summary

PR 2 of 2 for #5541 (the **hooks** side). Adds two Claude Code hook emitters so chroxy hears authoritative turn START/END edges, closing the bug where the Discord embed shows 🦀 "Ready for input" for the whole duration of a subagent run.

| Hook event | Ingest type | data | Semantics |
|---|---|---|---|
| `UserPromptSubmit` | `user_prompt_submit` | `{cwd}` only | Turn START. Sink flips idle→online even with subagents > 0. |
| `Stop` | `stop` | `{cwd}` | Turn END. "Ready for input" pings immediately instead of after Claude Code's ~60s idle Notification. |

## Changes (scoped to `packages/claude-hooks` only)

- `src/emitters.js`: `userPromptSubmit` / `stop` emitters; both registered in `EMITTERS` and `HOOK_EVENT_FOR_TYPE`.
  - **Privacy:** `user_prompt_submit` carries `cwd` ONLY — the raw prompt text (and any derivative) is **never** forwarded. Asserted by a dedicated test.
  - `stop` emits regardless of `stop_hook_active`; no fields beyond `cwd` are forwarded (no server consumer).
- `src/installer.js`: managed-event list extended so `chroxy-hooks install` registers all **8** events. `UserPromptSubmit` and `Stop` are matcher-less, like the other non-Notification events.
- `bin/chroxy-hooks.js` + `README.md`: event enumerations updated.
- Tests (TDD, failing-first): emitter payload mapping / cwd handling / absent fields, `EMITTERS` + `HOOK_EVENT_FOR_TYPE` registration, the **prompt-never-leaks** privacy pin, the installer **6→8 upgrade idempotence**, and uninstall removal.

## ⚠️ Depends on the server-side PR for #5541 — merge that first

This PR's emitters produce `user_prompt_submit` / `stop`, which are **not yet in the protocol `INGEST_EVENT_TYPES` enum**. The server-side PR (protocol enum + `INGEST_CATEGORY_FOR_TYPE` rows + sink rescope) must merge **first** — until it does, the ingest route 400-rejects these types as unknown. The envelope tests here validate every field **except** the type enum, and self-heal to full end-to-end validation once the enum includes the new types.

## Rollout (operator step)

After both PRs merge, re-run `chroxy-hooks install` on each host (and restart the daemon — that briefly drops the live tunnel). Install is idempotent and upgrades an existing 6-event `settings.json` to 8 with no duplicates.

## Verification

- `packages/claude-hooks` suite: 90 pass / 0 fail (baseline on `main` was 82/0; +8 new, 0 new failures).
- Live smoke: `install` registers all 8 events, a simulated legacy 6-event `settings.json` upgrades cleanly to 8, and `uninstall` removes them.

Closes #5541