### PR TITLE
fix(dashboard): auto-fetch Control Room tabs on open with a staleness guard

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -223,6 +223,19 @@ vi.mock('./store/connection', () => {
     switchServer: vi.fn(),
     connectToServer: vi.fn(),
     updateServer: vi.fn(),
+    // #5543 — Control Room auto-fetch: ControlRoomView's mount effect reads the
+    // three snapshot/loading slices and calls the matching request action when
+    // the active tab is stale and the WS is connected. Mirror the real store so
+    // the effect doesn't crash on a missing action when CR tests run connected.
+    hostStatus: null,
+    runnerStatus: null,
+    integrationStatus: null,
+    hostStatusLoading: false,
+    runnerStatusLoading: false,
+    integrationStatusLoading: false,
+    requestHostStatus: vi.fn(),
+    requestRunnerStatus: vi.fn(),
+    requestIntegrationStatus: vi.fn(),
   }
   const useConnectionStore = (
     selector?: (s: typeof baseState) => unknown,

--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -12,6 +12,40 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 
+// #5543: the auto-fetch effect reads the connection store. Mock it (matching
+// the codebase convention in App.test/ControlRoomSection.test) so these tests
+// drive a plain state object + spy actions rather than the real store — which
+// also avoids the dual-React-instance hazard of rendering real store hooks
+// under testing-library.
+const requestHostStatusMock = vi.fn(() => true)
+const requestRunnerStatusMock = vi.fn(() => true)
+const requestIntegrationStatusMock = vi.fn(() => true)
+let storeState: Record<string, unknown> = {}
+
+function resetStore(over: Record<string, unknown> = {}) {
+  requestHostStatusMock.mockClear()
+  requestRunnerStatusMock.mockClear()
+  requestIntegrationStatusMock.mockClear()
+  storeState = {
+    connectionPhase: 'connected',
+    hostStatus: null,
+    runnerStatus: null,
+    integrationStatus: null,
+    hostStatusLoading: false,
+    runnerStatusLoading: false,
+    integrationStatusLoading: false,
+    requestHostStatus: requestHostStatusMock,
+    requestRunnerStatus: requestRunnerStatusMock,
+    requestIntegrationStatus: requestIntegrationStatusMock,
+    ...over,
+  }
+}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector?: (s: Record<string, unknown>) => unknown) =>
+    typeof selector === 'function' ? selector(storeState) : storeState,
+}))
+
 vi.mock('./ControlRoomSection', () => ({
   ControlRoomSection: ({ onInvestigate, onOpenSession }: { onInvestigate?: unknown; onOpenSession?: unknown }) => (
     <div
@@ -30,14 +64,20 @@ vi.mock('./IntegrationsSection', () => ({
   IntegrationsSection: () => <div data-testid="stub-integrations">integrations</div>,
 }))
 
-import { ControlRoomView } from './ControlRoomView'
+import { ControlRoomView, CONTROL_ROOM_STALENESS_MS } from './ControlRoomView'
 
 const KEY = 'chroxy_cr_tab'
 
 beforeEach(() => {
   localStorage.clear()
+  resetStore()
 })
 afterEach(cleanup)
+
+/** A snapshot whose `generatedAt` is `ageMs` in the past. */
+function snapshotAt(ageMs: number) {
+  return { type: 'host_status_snapshot', generatedAt: new Date(Date.now() - ageMs).toISOString(), root: '/p', repos: [] }
+}
 
 describe('ControlRoomView', () => {
   it('renders all tabs and defaults to the repos section', () => {
@@ -101,5 +141,66 @@ describe('ControlRoomView', () => {
   it('honours an explicit initialTab override', () => {
     render(<ControlRoomView initialTab="runners" />)
     expect(screen.getByTestId('stub-runners')).toBeTruthy()
+  })
+})
+
+describe('ControlRoomView auto-fetch on activation (#5543)', () => {
+  it('fires exactly one request for the active tab on open when its snapshot is null', () => {
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestHostStatusMock).toHaveBeenCalledTimes(1)
+    expect(requestRunnerStatusMock).not.toHaveBeenCalled()
+    expect(requestIntegrationStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('opens the persisted tab and fetches it (not the default repos tab)', () => {
+    localStorage.setItem(KEY, 'integrations')
+    render(<ControlRoomView />)
+    expect(requestIntegrationStatusMock).toHaveBeenCalledTimes(1)
+    expect(requestHostStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('does not re-fetch a snapshot fresher than the staleness window', () => {
+    resetStore({ hostStatus: snapshotAt(CONTROL_ROOM_STALENESS_MS / 2) })
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestHostStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('re-fetches a snapshot older than the staleness window', () => {
+    resetStore({ hostStatus: snapshotAt(CONTROL_ROOM_STALENESS_MS + 5_000) })
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestHostStatusMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats an unparseable generatedAt as stale and fetches', () => {
+    resetStore({ hostStatus: { type: 'host_status_snapshot', generatedAt: 'not-a-date', root: '/p', repos: [] } })
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestHostStatusMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire while a request is already in flight (in-flight guard)', () => {
+    resetStore({ hostStatusLoading: true })
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestHostStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when the WS is disconnected', () => {
+    resetStore({ connectionPhase: 'disconnected' })
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestHostStatusMock).not.toHaveBeenCalled()
+    expect(requestRunnerStatusMock).not.toHaveBeenCalled()
+    expect(requestIntegrationStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches the newly-activated tab on a tab switch', () => {
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestHostStatusMock).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByTestId('cr-tab-runners'))
+    expect(requestRunnerStatusMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fetch the inactive tab on open', () => {
+    render(<ControlRoomView initialTab="repos" />)
+    expect(requestRunnerStatusMock).not.toHaveBeenCalled()
+    expect(requestIntegrationStatusMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -14,12 +14,23 @@
  * App.tsx renders this in place of the old `ControlRoomSection` and forwards the
  * `onInvestigate` action through to the repo table unchanged.
  */
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
 import { RunnerStatusSection } from './RunnerStatusSection'
 import { IntegrationsSection } from './IntegrationsSection'
+import { useConnectionStore } from '../store/connection'
 
 export type ControlRoomTab = 'repos' | 'runners' | 'integrations'
+
+/**
+ * #5543: how old a tab's snapshot may be before opening/switching to that tab
+ * re-fetches it. Judged against the snapshot's `generatedAt`. The surveys shell
+ * out to git/gh per repo (the runner/integration ones are expensive), so this
+ * deliberately favours showing a slightly-stale snapshot over re-running a
+ * survey on every flick between tabs — and there is no interval polling, only
+ * fetch-on-activation plus the manual Refresh force.
+ */
+export const CONTROL_ROOM_STALENESS_MS = 60_000
 
 const CR_TAB_STORAGE_KEY = 'chroxy_cr_tab'
 const VALID_TABS: ReadonlySet<string> = new Set<ControlRoomTab>(['repos', 'runners', 'integrations'])
@@ -40,6 +51,18 @@ function persistTab(tab: ControlRoomTab): void {
   } catch {
     /* noop — storage unavailable */
   }
+}
+
+/**
+ * #5543: true when a tab's snapshot warrants a re-fetch — null/absent snapshot,
+ * an unparseable `generatedAt`, or one older than the staleness window. A fresh
+ * snapshot (within the window) returns false so we skip the survey.
+ */
+function isStale(generatedAt: string | undefined): boolean {
+  if (!generatedAt) return true
+  const ms = Date.parse(generatedAt)
+  if (Number.isNaN(ms)) return true
+  return Date.now() - ms >= CONTROL_ROOM_STALENESS_MS
 }
 
 const TABS: ReadonlyArray<{ key: ControlRoomTab; label: string }> = [
@@ -64,6 +87,52 @@ export function ControlRoomView({ onInvestigate, onOpenSession, initialTab }: Co
     setTab(next)
     persistTab(next)
   }, [])
+
+  // #5543: auto-fetch the active tab's survey when the Control Room opens with a
+  // tab already active and on each tab switch, with a staleness guard. We only
+  // fire when the WS is up (the request actions no-op when the socket is closed,
+  // but gating here avoids churning the effect against a snapshot that will
+  // never arrive) and the tab isn't already loading (the server enforces a
+  // per-client in-flight guard — don't trip it). A snapshot newer than the
+  // staleness window is left alone; the manual Refresh button still forces a
+  // re-fetch regardless. No interval polling — fetch-on-activation only.
+  const connected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const hostStatus = useConnectionStore((s) => s.hostStatus)
+  const runnerStatus = useConnectionStore((s) => s.runnerStatus)
+  const integrationStatus = useConnectionStore((s) => s.integrationStatus)
+  const hostStatusLoading = useConnectionStore((s) => s.hostStatusLoading)
+  const runnerStatusLoading = useConnectionStore((s) => s.runnerStatusLoading)
+  const integrationStatusLoading = useConnectionStore((s) => s.integrationStatusLoading)
+  const requestHostStatus = useConnectionStore((s) => s.requestHostStatus)
+  const requestRunnerStatus = useConnectionStore((s) => s.requestRunnerStatus)
+  const requestIntegrationStatus = useConnectionStore((s) => s.requestIntegrationStatus)
+
+  useEffect(() => {
+    if (!connected) return
+
+    const snapshot = tab === 'repos' ? hostStatus : tab === 'runners' ? runnerStatus : integrationStatus
+    const loading =
+      tab === 'repos' ? hostStatusLoading : tab === 'runners' ? runnerStatusLoading : integrationStatusLoading
+    if (loading) return
+
+    if (!isStale(snapshot?.generatedAt)) return
+
+    const request =
+      tab === 'repos' ? requestHostStatus : tab === 'runners' ? requestRunnerStatus : requestIntegrationStatus
+    request()
+  }, [
+    tab,
+    connected,
+    hostStatus,
+    runnerStatus,
+    integrationStatus,
+    hostStatusLoading,
+    runnerStatusLoading,
+    integrationStatusLoading,
+    requestHostStatus,
+    requestRunnerStatus,
+    requestIntegrationStatus,
+  ])
 
   return (
     <div className="cr-view" data-testid="control-room-view">


### PR DESCRIPTION
## Problem

Opening the Control Room (or switching tabs within it) showed empty/stale sections until the user clicked Refresh. All three tabs (Project status, Self-hosted runners, Integrations) are pull-model request/snapshot — nothing fired the request on mount.

## Fix

`ControlRoomView` now auto-requests on tab activation with a staleness guard:

- **Triggers** when the Control Room opens with a tab already active (including a localStorage-persisted tab) and on each tab switch — a `useEffect` keyed on the active tab + connection-ready state + the snapshot/loading slices.
- **Staleness window** (`CONTROL_ROOM_STALENESS_MS = 60_000`, a named constant): snapshot `null` → fetch; `generatedAt` unparseable → fetch; older than 60s → fetch; within the window → skip.
- **In-flight guard:** skips while the tab's loading flag is set, so it never double-fires or trips the server's per-client in-flight guard.
- **Disconnected-safe:** gated on `connectionPhase === 'connected'`; the request actions already no-op when the socket is closed, so opening while disconnected queues nothing and throws nothing.
- **Manual Refresh** still forces a re-fetch regardless of staleness.
- **No interval polling** — the runner/integration surveys shell out to git/gh per repo, so fetch-on-activation + manual refresh is the right cost model.

## Tests

New `ControlRoomView` auto-fetch suite (10 tests): null snapshot fires exactly one request for the active tab; persisted tab fetches its own survey (not repos); fresh snapshot (< window) does not re-fetch; stale snapshot (> window) and unparseable `generatedAt` re-fetch; in-flight loading flag prevents fetch; disconnected fires nothing; tab switch fetches the newly-activated tab; inactive tab is never fetched on open. Tests mock `../store/connection` per the codebase convention (App.test/ControlRoomSection.test). The App.test store mock gains the three snapshot/loading slices + request actions the new effect reads.

Dashboard vitest: 3448 passed. tsc --noEmit: clean.

Closes #5543.

Related to #5159.