### PR TITLE
feat(dashboard): Control Room Settings tab — converge preference surfaces (#5544)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -92,7 +92,7 @@ import { EnvironmentPanel } from './components/EnvironmentPanel'
 import { SnapshotsPanel } from './components/SnapshotsPanel'
 import { PoolStatsPanel } from './components/PoolStatsPanel'
 import { type RepoInvestigateRequest, type RepoOpenSessionRequest } from './components/ControlRoomSection'
-import { ControlRoomView } from './components/ControlRoomView'
+import { ControlRoomView, type ControlRoomTab } from './components/ControlRoomView'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
@@ -648,6 +648,42 @@ export function App() {
     setSplitMode(null)
     persistSplitMode(null)
   }, [])
+  // #5544 — the Control Room Settings tab is now the single home for the
+  // preference surfaces that used to live in the slide-out SettingsPanel
+  // modal. Two redirect paths converge on the Settings tab:
+  //   - Control Room already open: bump `settingsRedirectNonce`, which
+  //     ControlRoomView watches to switch tabs (even from another tab).
+  //   - Control Room closed: mount ControlRoomView with `initialTab='settings'`
+  //     so it opens straight onto Settings without a flash of another tab.
+  // `controlRoomInitialTab` is a one-shot: cleared back to undefined right
+  // after the open so a later sidebar "Control Room" click lands on the
+  // operator's persisted tab, not Settings.
+  const [settingsRedirectNonce, setSettingsRedirectNonce] = useState(0)
+  const [controlRoomInitialTab, setControlRoomInitialTab] = useState<ControlRoomTab | undefined>(undefined)
+  const openSettings = useCallback(() => {
+    setControlRoomActive((wasActive) => {
+      if (!wasActive) {
+        // CR is opening fresh — seed the initial tab so the mount lands on
+        // Settings. (openControlRoom below also flips this true; doing it
+        // here lets us read the prior value for the nonce-vs-initial choice.)
+        setControlRoomInitialTab('settings')
+      } else {
+        // CR already visible — drive the redirect via the nonce instead.
+        setSettingsRedirectNonce((n) => n + 1)
+      }
+      return wasActive
+    })
+    openControlRoom()
+  }, [openControlRoom])
+  // #5544 — clear the one-shot initial-tab seed after the Control Room has
+  // mounted with it. ControlRoomView only reads `initialTab` in its mount
+  // initializer, so clearing it now is invisible to the live view but ensures
+  // a later reopen (e.g. sidebar "Control Room") starts on the persisted tab.
+  useEffect(() => {
+    if (controlRoomActive && controlRoomInitialTab !== undefined) {
+      setControlRoomInitialTab(undefined)
+    }
+  }, [controlRoomActive, controlRoomInitialTab])
   const closeControlRoom = useCallback(() => {
     // Closing is non-destructive: the tab disappears and we fall back to the
     // prior session (activeSessionId is untouched). The store-held snapshot
@@ -896,6 +932,8 @@ export function App() {
     setPaletteOpen,
     setSidebarOpen,
     setSettingsOpen,
+    // #5544 — Cmd+, redirects to the Control Room Settings tab.
+    openSettings,
     setShowCreateSession,
     setShortcutHelpOpen,
     handleSwitchSession,
@@ -1641,8 +1679,9 @@ export function App() {
     // The dashboard's existing "connect to a different server" surface
     // is the Settings panel's Server Registry section. The menu item
     // opens Settings; the user picks a registry entry there.
-    setSettingsOpen(true)
-  }, [])
+    // #5544 — Settings now lives in the Control Room Settings tab.
+    openSettings()
+  }, [openSettings])
   const menuDisconnect = useCallback(() => {
     useConnectionStore.getState().disconnect()
   }, [])
@@ -1661,8 +1700,9 @@ export function App() {
     window.location.reload()
   }, [])
   const menuOpenSettings = useCallback(() => {
-    setSettingsOpen(true)
-  }, [])
+    // #5544 — redirect to the Control Room Settings tab (the single home).
+    openSettings()
+  }, [openSettings])
   useTauriMenuEvents({
     onNewSession: handleNewSession,
     onConnectToServer: menuConnectToServer,
@@ -2344,7 +2384,9 @@ export function App() {
                 label: 'Settings',
                 icon: '⚙',
                 title: `Settings (${formatShortcutKeys('Cmd+,')})`,
-                onClick: () => setSettingsOpen(true),
+                // #5544 — redirect to the Control Room Settings tab (the
+                // single home) instead of opening the legacy slide-out modal.
+                onClick: openSettings,
               },
             ]
             return <HeaderOverflowMenu items={overflowItems} />
@@ -2502,7 +2544,28 @@ export function App() {
             double-rendering with the disconnected/startup screens. */}
         {controlRoomActive && (
           <div className="main-content" data-testid="control-room-main">
-            <ControlRoomView onInvestigate={handleInvestigate} onOpenSession={handleOpenSession} />
+            <ControlRoomView
+              onInvestigate={handleInvestigate}
+              onOpenSession={handleOpenSession}
+              // #5544 — the Settings tab embeds the converged preference body.
+              // Closed→open via a Settings entry point mounts straight onto the
+              // Settings tab (`initialTab`); an entry-point click while the CR
+              // is already open bumps `settingsRedirectNonce` so the view jumps
+              // to Settings even from another tab.
+              initialTab={controlRoomInitialTab}
+              forceTab="settings"
+              forceTabNonce={settingsRedirectNonce}
+              showConsoleTab={showConsoleTab}
+              onToggleConsoleTab={(show) => {
+                setShowConsoleTab(show)
+                persistShowConsoleTab(show)
+              }}
+              interventionPingEnabled={interventionPingEnabled}
+              onToggleInterventionPing={(enabled) => {
+                setInterventionPingEnabled(enabled)
+                persistInterventionPing(enabled)
+              }}
+            />
           </div>
         )}
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -661,20 +661,20 @@ export function App() {
   const [settingsRedirectNonce, setSettingsRedirectNonce] = useState(0)
   const [controlRoomInitialTab, setControlRoomInitialTab] = useState<ControlRoomTab | undefined>(undefined)
   const openSettings = useCallback(() => {
-    setControlRoomActive((wasActive) => {
-      if (!wasActive) {
-        // CR is opening fresh — seed the initial tab so the mount lands on
-        // Settings. (openControlRoom below also flips this true; doing it
-        // here lets us read the prior value for the nonce-vs-initial choice.)
-        setControlRoomInitialTab('settings')
-      } else {
-        // CR already visible — drive the redirect via the nonce instead.
-        setSettingsRedirectNonce((n) => n + 1)
-      }
-      return wasActive
-    })
+    // The redirect must also dismiss the legacy modal (the `?settings=1`
+    // deep-link can leave it open) — otherwise the tab switch happens behind
+    // the overlay and the shortcut appears dead.
+    setSettingsOpen(false)
+    if (controlRoomActive) {
+      // CR already visible — drive the redirect via the nonce instead.
+      setSettingsRedirectNonce((n) => n + 1)
+    } else {
+      // CR is opening fresh — seed the initial tab so the mount lands on
+      // Settings without a flash of another tab.
+      setControlRoomInitialTab('settings')
+    }
     openControlRoom()
-  }, [openControlRoom])
+  }, [controlRoomActive, openControlRoom])
   // #5544 — clear the one-shot initial-tab seed after the Control Room has
   // mounted with it. ControlRoomView only reads `initialTab` in its mount
   // initializer, so clearing it now is invisible to the live view but ensures

--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -63,6 +63,16 @@ vi.mock('./RunnerStatusSection', () => ({
 vi.mock('./IntegrationsSection', () => ({
   IntegrationsSection: () => <div data-testid="stub-integrations">integrations</div>,
 }))
+// #5544: the Settings tab embeds the (heavy, store-backed) SettingsContent.
+// Stub it so the tab-shell tests stay focused on routing/auto-fetch behaviour
+// and surface the `active` prop the embed threads through.
+vi.mock('./SettingsPanel', () => ({
+  SettingsContent: ({ active }: { active?: boolean }) => (
+    <div data-testid="stub-settings" data-active={active ? 'yes' : 'no'}>
+      settings
+    </div>
+  ),
+}))
 
 import { ControlRoomView, CONTROL_ROOM_STALENESS_MS } from './ControlRoomView'
 
@@ -85,9 +95,12 @@ describe('ControlRoomView', () => {
     expect(screen.getByTestId('cr-tab-repos')).toBeTruthy()
     expect(screen.getByTestId('cr-tab-runners')).toBeTruthy()
     expect(screen.getByTestId('cr-tab-integrations')).toBeTruthy()
+    // #5544: the converged Settings tab.
+    expect(screen.getByTestId('cr-tab-settings')).toBeTruthy()
     expect(screen.getByTestId('stub-repos')).toBeTruthy()
     expect(screen.queryByTestId('stub-runners')).toBeNull()
     expect(screen.queryByTestId('stub-integrations')).toBeNull()
+    expect(screen.queryByTestId('stub-settings')).toBeNull()
     expect(screen.getByTestId('cr-tab-repos').getAttribute('aria-selected')).toBe('true')
   })
 
@@ -141,6 +154,65 @@ describe('ControlRoomView', () => {
   it('honours an explicit initialTab override', () => {
     render(<ControlRoomView initialTab="runners" />)
     expect(screen.getByTestId('stub-runners')).toBeTruthy()
+  })
+})
+
+describe('ControlRoomView Settings tab (#5544)', () => {
+  it('renders the embedded SettingsContent when the Settings tab is clicked, as active', () => {
+    render(<ControlRoomView />)
+    fireEvent.click(screen.getByTestId('cr-tab-settings'))
+    const settings = screen.getByTestId('stub-settings')
+    expect(settings).toBeTruthy()
+    expect(settings.getAttribute('data-active')).toBe('yes')
+    expect(screen.queryByTestId('stub-repos')).toBeNull()
+    expect(screen.getByTestId('cr-tab-settings').getAttribute('aria-selected')).toBe('true')
+    expect(localStorage.getItem(KEY)).toBe('settings')
+  })
+
+  it('restores a persisted settings tab on the next mount', () => {
+    localStorage.setItem(KEY, 'settings')
+    render(<ControlRoomView />)
+    expect(screen.getByTestId('stub-settings')).toBeTruthy()
+  })
+
+  it('does NOT trigger any survey fetch when the Settings tab is the active one', () => {
+    localStorage.setItem(KEY, 'settings')
+    render(<ControlRoomView />)
+    expect(requestHostStatusMock).not.toHaveBeenCalled()
+    expect(requestRunnerStatusMock).not.toHaveBeenCalled()
+    expect(requestIntegrationStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT trigger a survey fetch when switching from repos to the Settings tab', () => {
+    // Seed a fresh repos snapshot so the initial repos activation does not
+    // itself fetch — isolating the assertion to the Settings switch.
+    resetStore({ hostStatus: snapshotAt(CONTROL_ROOM_STALENESS_MS / 2) })
+    render(<ControlRoomView initialTab="repos" />)
+    requestHostStatusMock.mockClear()
+    fireEvent.click(screen.getByTestId('cr-tab-settings'))
+    expect(requestHostStatusMock).not.toHaveBeenCalled()
+    expect(requestRunnerStatusMock).not.toHaveBeenCalled()
+    expect(requestIntegrationStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects to the Settings tab when forceTabNonce bumps while mounted', () => {
+    const { rerender } = render(
+      <ControlRoomView forceTab="settings" forceTabNonce={0} initialTab="repos" />,
+    )
+    // Mount does not redirect — seeded from the incoming nonce.
+    expect(screen.getByTestId('stub-repos')).toBeTruthy()
+    rerender(<ControlRoomView forceTab="settings" forceTabNonce={1} initialTab="repos" />)
+    expect(screen.getByTestId('stub-settings')).toBeTruthy()
+    expect(screen.queryByTestId('stub-repos')).toBeNull()
+  })
+
+  it('does not redirect on mount even when an initial non-zero nonce is supplied', () => {
+    // Models App reopening the CR via the sidebar after a prior gear click left
+    // the nonce non-zero: the closed→open path uses initialTab, not the nonce,
+    // so a stale nonce must not hijack a plain reopen.
+    render(<ControlRoomView forceTab="settings" forceTabNonce={3} initialTab="runners" />)
+    expect(screen.getByTestId('stub-runners')).toBeTruthy()
+    expect(screen.queryByTestId('stub-settings')).toBeNull()
   })
 })
 

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -14,13 +14,26 @@
  * App.tsx renders this in place of the old `ControlRoomSection` and forwards the
  * `onInvestigate` action through to the repo table unchanged.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
 import { RunnerStatusSection } from './RunnerStatusSection'
 import { IntegrationsSection } from './IntegrationsSection'
+import { SettingsContent } from './SettingsPanel'
 import { useConnectionStore } from '../store/connection'
 
-export type ControlRoomTab = 'repos' | 'runners' | 'integrations'
+// #5544: the Settings tab converges the scattered preference surfaces
+// (notification categories, appearance, session defaults, BYOK, Tauri
+// desktop options) into the Control Room. It embeds `SettingsContent` — the
+// same body the legacy slide-out modal renders — so there's a single home and
+// no duplicated controls.
+export type ControlRoomTab = 'repos' | 'runners' | 'integrations' | 'settings'
+
+/**
+ * #5544: the survey-backed tabs whose auto-fetch effect (#5543/#5546) shells
+ * out to git/gh. The Settings tab is purely client/server-config driven and
+ * must NOT trip the snapshot fetch, so the effect early-returns for it.
+ */
+const SURVEY_TABS: ReadonlySet<ControlRoomTab> = new Set<ControlRoomTab>(['repos', 'runners', 'integrations'])
 
 /**
  * #5543: how old a tab's snapshot may be before opening/switching to that tab
@@ -33,7 +46,7 @@ export type ControlRoomTab = 'repos' | 'runners' | 'integrations'
 export const CONTROL_ROOM_STALENESS_MS = 60_000
 
 const CR_TAB_STORAGE_KEY = 'chroxy_cr_tab'
-const VALID_TABS: ReadonlySet<string> = new Set<ControlRoomTab>(['repos', 'runners', 'integrations'])
+const VALID_TABS: ReadonlySet<string> = new Set<ControlRoomTab>(['repos', 'runners', 'integrations', 'settings'])
 
 function loadPersistedTab(): ControlRoomTab {
   try {
@@ -69,6 +82,7 @@ const TABS: ReadonlyArray<{ key: ControlRoomTab; label: string }> = [
   { key: 'repos', label: 'Project status' },
   { key: 'runners', label: 'Self-hosted runners' },
   { key: 'integrations', label: 'Integrations' },
+  { key: 'settings', label: 'Settings' },
 ]
 
 export interface ControlRoomViewProps {
@@ -78,15 +92,56 @@ export interface ControlRoomViewProps {
   onOpenSession?: (req: RepoOpenSessionRequest) => void
   /** Optional initial tab override (defaults to the persisted tab). For tests. */
   initialTab?: ControlRoomTab
+  /**
+   * #5544: imperative tab redirect. When this value changes to a non-null
+   * tab, the view switches to it (and persists the choice). App.tsx bumps
+   * the paired nonce when the gear / Cmd+, entry points fire so they land on
+   * the Settings tab even if the Control Room is already open on another tab.
+   */
+  forceTab?: ControlRoomTab | null
+  /** Monotonic nonce that re-triggers `forceTab` even when the tab is unchanged. */
+  forceTabNonce?: number
+  // #5544: the Settings tab's dashboard-scoped toggles (Console tab + audible
+  // intervention ping) are App-owned localStorage prefs, threaded through here
+  // exactly as they were to the legacy SettingsPanel modal. Optional so the
+  // tab still renders (without those two rows) when a caller doesn't wire them.
+  showConsoleTab?: boolean
+  onToggleConsoleTab?: (show: boolean) => void
+  interventionPingEnabled?: boolean
+  onToggleInterventionPing?: (enabled: boolean) => void
 }
 
-export function ControlRoomView({ onInvestigate, onOpenSession, initialTab }: ControlRoomViewProps = {}) {
+export function ControlRoomView({
+  onInvestigate,
+  onOpenSession,
+  initialTab,
+  forceTab,
+  forceTabNonce,
+  showConsoleTab,
+  onToggleConsoleTab,
+  interventionPingEnabled,
+  onToggleInterventionPing,
+}: ControlRoomViewProps = {}) {
   const [tab, setTab] = useState<ControlRoomTab>(() => initialTab ?? loadPersistedTab())
 
   const selectTab = useCallback((next: ControlRoomTab) => {
     setTab(next)
     persistTab(next)
   }, [])
+
+  // #5544: honour an imperative redirect while the Control Room is already
+  // mounted. The nonce is seeded from the incoming prop so the *mount* never
+  // redirects (the closed→open path is handled by App seeding `initialTab`
+  // instead) — only a subsequent bump, i.e. an explicit gear / Cmd+, / menu
+  // click while the CR is open, switches to `forceTab` (Settings), even if the
+  // user had navigated to another tab in between.
+  const lastForceNonce = useRef(forceTabNonce)
+  useEffect(() => {
+    if (forceTabNonce === lastForceNonce.current) return
+    lastForceNonce.current = forceTabNonce
+    if (!forceTab) return
+    selectTab(forceTab)
+  }, [forceTab, forceTabNonce, selectTab])
 
   // #5543: auto-fetch the active tab's survey when the Control Room opens with a
   // tab already active and on each tab switch, with a staleness guard. We only
@@ -109,6 +164,8 @@ export function ControlRoomView({ onInvestigate, onOpenSession, initialTab }: Co
 
   useEffect(() => {
     if (!connected) return
+    // #5544: the Settings tab is static (no survey) — never fetch for it.
+    if (!SURVEY_TABS.has(tab)) return
 
     const snapshot = tab === 'repos' ? hostStatus : tab === 'runners' ? runnerStatus : integrationStatus
     const loading =
@@ -176,8 +233,23 @@ export function ControlRoomView({ onInvestigate, onOpenSession, initialTab }: Co
         <ControlRoomSection onInvestigate={onInvestigate} onOpenSession={onOpenSession} />
       ) : tab === 'runners' ? (
         <RunnerStatusSection />
-      ) : (
+      ) : tab === 'integrations' ? (
         <IntegrationsSection />
+      ) : (
+        // #5544: scrollable wrapper so the (often long) settings body scrolls
+        // inside the tab panel rather than the whole Control Room view. The
+        // `cr-settings-tab` class reuses the modal's `.settings-section`
+        // typography (h3 section headers) which #5530's read-only repo-config
+        // surface will sit beside, visually distinct, later.
+        <div className="cr-settings-tab" data-testid="cr-settings-tab">
+          <SettingsContent
+            active={tab === 'settings'}
+            showConsoleTab={showConsoleTab}
+            onToggleConsoleTab={onToggleConsoleTab}
+            interventionPingEnabled={interventionPingEnabled}
+            onToggleInterventionPing={onToggleInterventionPing}
+          />
+        </div>
       )}
     </div>
   )

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -151,14 +151,36 @@ function getQuietHoursTimezoneOptions(): { value: string; label: string }[] {
   }))
 }
 
-export interface SettingsPanelProps {
-  isOpen: boolean
-  onClose: () => void
+/**
+ * #5544: the preference body shared between the legacy slide-out modal
+ * (`SettingsPanel`) and the Control Room Settings tab (`SettingsContent`
+ * embedded). `SettingsPanel` wraps this in the modal chrome; the Control
+ * Room renders it directly inside its tab. Persistence per setting is
+ * unchanged — this is UI convergence, not a storage migration.
+ */
+export interface SettingsContentProps {
+  /**
+   * Whether the content is currently visible. Gates the on-open effects
+   * (refresh notification prefs, BYOK status, Tauri tunnel/hotkey load) so
+   * they fire once the surface becomes active and re-fire on re-activation.
+   * In the modal this tracks `isOpen`; in the Control Room tab it's true
+   * while the Settings tab is the active sub-tab.
+   */
+  active: boolean
   showConsoleTab?: boolean
   onToggleConsoleTab?: (show: boolean) => void
   // #4891 — audible intervention ping enable/mute. Optional so existing
   // call sites / tests that don't wire it stay valid; the row only renders
   // when the handler is provided.
+  interventionPingEnabled?: boolean
+  onToggleInterventionPing?: (enabled: boolean) => void
+}
+
+export interface SettingsPanelProps {
+  isOpen: boolean
+  onClose: () => void
+  showConsoleTab?: boolean
+  onToggleConsoleTab?: (show: boolean) => void
   interventionPingEnabled?: boolean
   onToggleInterventionPing?: (enabled: boolean) => void
 }
@@ -622,8 +644,11 @@ function ThemeSwatches({ theme }: { theme: ThemeDefinition }) {
   )
 }
 
-export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing }: SettingsPanelProps) {
-  const backdropRef = useRef<HTMLDivElement>(null)
+export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing }: SettingsContentProps) {
+  // #5544: alias retained so the body's many `isOpen` reads (effect gates,
+  // refresh-on-open) keep their original meaning — true while this surface
+  // is the visible one (modal open, or Control Room Settings tab active).
+  const isOpen = active
   const activeTheme = useConnectionStore(s => s.activeTheme)
   const setTheme = useConnectionStore(s => s.setTheme)
   const defaultProvider = useConnectionStore(s => s.defaultProvider)
@@ -1073,35 +1098,14 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     }
   }, [updateInputSettings])
 
-  useEffect(() => {
-    if (!isOpen) return
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        const overlays = document.querySelectorAll('[data-modal-overlay]')
-        if (overlays.length > 0 && overlays[overlays.length - 1] === backdropRef.current) {
-          e.preventDefault()
-          onClose()
-        }
-      }
-    }
-    document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
-  }, [isOpen, onClose])
-
+  // #5544: the embedded Control Room tab keeps the content mounted but
+  // inactive while another sub-tab is focused; render nothing then so the
+  // on-open effects don't churn against a hidden surface. The modal wrapper
+  // already unmounts on close, so this is also its `!isOpen` guard.
   if (!isOpen) return null
 
   return (
-    <>
-      <div ref={backdropRef} className="settings-backdrop" data-modal-overlay onClick={onClose} />
-      <div className="settings-panel" role="dialog" aria-modal="true" aria-labelledby="settings-title">
-        <div className="settings-header">
-          <h2 id="settings-title">Settings</h2>
-          <button className="settings-close" onClick={onClose} aria-label="Close settings" type="button">
-            &times;
-          </button>
-        </div>
-
-        <div className="settings-body">
+    <div className="settings-body" data-testid="settings-content">
           <section className="settings-section">
             <h3>Appearance</h3>
             <div className="theme-grid">
@@ -1930,7 +1934,53 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               </div>
             </section>
           )}
+    </div>
+  )
+}
+
+/**
+ * #5544: legacy slide-out modal. Kept as a thin wrapper around
+ * `SettingsContent` so the `settings=1` URL param and any external callers
+ * still open a dismissable panel. The primary entry points (gear / Cmd+,)
+ * now redirect to the Control Room Settings tab instead — see App.tsx.
+ */
+export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing }: SettingsPanelProps) {
+  const backdropRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        const overlays = document.querySelectorAll('[data-modal-overlay]')
+        if (overlays.length > 0 && overlays[overlays.length - 1] === backdropRef.current) {
+          e.preventDefault()
+          onClose()
+        }
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <>
+      <div ref={backdropRef} className="settings-backdrop" data-modal-overlay onClick={onClose} />
+      <div className="settings-panel" role="dialog" aria-modal="true" aria-labelledby="settings-title">
+        <div className="settings-header">
+          <h2 id="settings-title">Settings</h2>
+          <button className="settings-close" onClick={onClose} aria-label="Close settings" type="button">
+            &times;
+          </button>
         </div>
+        <SettingsContent
+          active={isOpen}
+          showConsoleTab={showConsoleTab}
+          onToggleConsoleTab={onToggleConsoleTab}
+          interventionPingEnabled={interventionPingEnabled}
+          onToggleInterventionPing={onToggleInterventionPing}
+        />
       </div>
     </>
   )

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -1098,10 +1098,12 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
     }
   }, [updateInputSettings])
 
-  // #5544: the embedded Control Room tab keeps the content mounted but
-  // inactive while another sub-tab is focused; render nothing then so the
-  // on-open effects don't churn against a hidden surface. The modal wrapper
-  // already unmounts on close, so this is also its `!isOpen` guard.
+  // #5544: both hosts unmount this content when it's hidden — the modal
+  // wrapper on close, and the Control Room Settings tab whenever another
+  // sub-tab is focused (ControlRoomView renders tab bodies conditionally) —
+  // so `isOpen` is effectively always true today. The guard stays as a cheap
+  // safety net for any future host that keeps the content mounted while
+  // hidden.
   if (!isOpen) return null
 
   return (

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -46,6 +46,13 @@ export interface ShortcutDispatchProps {
   setPaletteOpen: (fn: (prev: boolean) => boolean) => void
   setSidebarOpen: (fn: (prev: boolean) => boolean) => void
   setSettingsOpen: (fn: (prev: boolean) => boolean) => void
+  /**
+   * #5544 — Cmd+, now redirects to the Control Room Settings tab (the single
+   * home for preferences). When provided this takes precedence over the
+   * legacy `setSettingsOpen` modal toggle; left optional so older call sites
+   * / tests that only wire the modal toggle keep working.
+   */
+  openSettings?: () => void
   setShowCreateSession: (open: boolean) => void
   setShortcutHelpOpen: (fn: (prev: boolean) => boolean) => void
   handleSwitchSession: (sessionId: string) => void
@@ -67,6 +74,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     setPaletteOpen,
     setSidebarOpen,
     setSettingsOpen,
+    openSettings,
     setShowCreateSession,
     setShortcutHelpOpen,
     handleSwitchSession,
@@ -188,7 +196,10 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
             setSidebarOpen(prev => !prev)
             break
           case 'settings.open':
-            setSettingsOpen(prev => !prev)
+            // #5544 — prefer the Control Room Settings tab redirect; fall back
+            // to the legacy modal toggle when the redirect isn't wired.
+            if (openSettings) openSettings()
+            else setSettingsOpen(prev => !prev)
             break
           case 'session.new':
             setShowCreateSession(true)
@@ -262,6 +273,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     setPaletteOpen,
     setSidebarOpen,
     setSettingsOpen,
+    openSettings,
     setShowCreateSession,
     setShortcutHelpOpen,
   ])

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8957,6 +8957,25 @@ button.sidebar-token-view-session-row:hover {
   border-bottom: 1px solid var(--bg-card);
 }
 
+/* #5544 — Control Room Settings tab. Embeds the same `SettingsContent` body
+   the slide-out modal renders, so the modal's `.settings-section` /
+   `.settings-field` typography carries over unchanged. The wrapper just owns
+   the scroll + a centred, comfortable reading width (the survey tables run
+   full-bleed; a long preferences form reads better constrained). #5530's
+   read-only repo-config surface will sit in its own section here later,
+   visually distinct from these user options. */
+.cr-settings-tab {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.cr-settings-tab .settings-body {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 20px 28px 40px;
+}
+
 /* #5253 — runner table: per-project group header row + the GitHub deep link. */
 .runner-repo-row td {
   padding-top: 16px;


### PR DESCRIPTION
## Summary

Adds a fourth Control Room tab, **Settings**, as the single home for the user-scoped preference surfaces that were previously discovered separately behind the slide-out `SettingsPanel` modal. The modal body is extracted into a reusable `SettingsContent` component embedded by the tab, so there is exactly one set of controls — no duplication — and the old entry points (gear, Cmd+,, Tauri menus) redirect to the tab instead of opening the modal.

Per the issue, persistence stays exactly where it is per setting (server config / localStorage / Tauri desktop settings) — this is **UI convergence, not a storage migration**.

## Inventory findings (surface → decision)

Inventory pass over `packages/dashboard/src/` (every settings/preference surface the dashboard reads/writes):

| Surface | Where it lived | Decision |
|---|---|---|
| Appearance (theme picker) | SettingsPanel modal | **Moved** into `SettingsContent` (tab + modal share it) |
| Session Defaults (provider, model, header badge mode, confirm-before-close, send shortcut, voice input) | SettingsPanel modal | **Moved** |
| Keyboard shortcuts (`ShortcutsSection`) | SettingsPanel modal | **Moved** (rendered inside `SettingsContent`) |
| Active session toggles (prompt evaluator, Chroxy context hint, session preamble) | SettingsPanel modal | **Moved** |
| Provider auth status / BYOK credentials / `ProviderCredentialsPane` | SettingsPanel modal | **Moved** |
| Notifications (per-category, per-device mutes, quiet hours, known-devices) | SettingsPanel modal | **Moved** |
| Dashboard toggles (Show Console tab, audible intervention ping) | SettingsPanel modal, App-owned localStorage | **Moved** — handlers threaded through `ControlRoomView` exactly as before |
| Tauri desktop settings (Security/auto-permission, Network/tunnel mode, Desktop/summon hotkey, macOS speech reset) | SettingsPanel modal, Tauri IPC | **Moved** — the same `isTauri()`-gated rows render in the tab when running in the desktop shell |
| Gear button (header overflow) | App.tsx → opened modal | **Redirected** to Control Room Settings tab |
| Cmd+, shortcut (`settings.open`) | `useShortcutDispatch` → toggled modal | **Redirected** (optional `openSettings` prop; falls back to modal toggle when unwired) |
| Tauri menu "Settings" + "Connect to server" | App.tsx → opened modal | **Redirected** |
| `?settings=1` URL deep-link | App.tsx init state | **Left as-is** — still opens the modal (now a thin wrapper around `SettingsContent`) as a dismissable fallback; low-traffic deep-link, not worth breaking |

**What was left and why:** the `SettingsPanel` modal component is retained as a thin wrapper (modal chrome + Escape handling) around the shared `SettingsContent`, so the `?settings=1` deep-link and any external callers keep a working dismissable panel. All primary entry points now land on the tab — one home, muscle memory preserved.

## Implementation notes

- `SettingsContent` takes an `active` prop that gates the on-open effects (refresh notification prefs, BYOK status, Tauri tunnel/hotkey load). In the modal it tracks `isOpen`; in the tab it's true while Settings is the active sub-tab.
- The Control Room auto-fetch effect (#5543/#5546) early-returns for the Settings tab via a `SURVEY_TABS` guard — the static tab never triggers a host/runner/integration survey.
- Redirect plumbing: closed→open uses `initialTab='settings'` (mounts straight onto Settings, no flash); an entry-point click while the Control Room is already open bumps `settingsRedirectNonce` so the view jumps to Settings even from another tab. A stale nonce can't hijack a plain sidebar reopen.
- Section headers (`.settings-section` h3) are preserved, leaving room for #5530's read-only repo-config surface to sit beside the user options later, visually distinct.

## Test plan

- `npx tsc --noEmit` — clean.
- `npm run build` — succeeds (only pre-existing chunk-size / dynamic-import advisories).
- `npm test` — **3454 passed (176 files)**, including 7 new `ControlRoomView` Settings-tab cases: tab renders + embeds `SettingsContent` as active, persists/restores `settings`, never triggers a survey fetch (on open or on switch), `forceTabNonce` redirect while mounted, and no mount-time hijack from a stale nonce.

Closes #5544