### PR TITLE
feat(server): OpenRouter ergonomics — preset, model catalog discovery, pricing autofill (#5548)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -380,7 +380,8 @@ Many services and local inference servers now expose **Anthropic-compatible `/v1
         "defaultModel": "glm-4.7",
         "models": ["glm-4.7", "glm-4.7-air"],
         "pricing": { "input": 0.6, "output": 2.2 },
-        "contextWindow": 200000
+        "contextWindow": 200000,
+        "modelDiscovery": { "url": "https://openrouter.ai/api/v1/models", "format": "openrouter" }
       }
     ]
   }
@@ -398,6 +399,7 @@ Many services and local inference servers now expose **Anthropic-compatible `/v1
 | `models` | no | Model **allowlist** for live model switching. Omit entirely for an unrestricted endpoint (any model id is passed through verbatim — the `ollama` rule; an unknown id surfaces as the endpoint's own error). |
 | `pricing` | no | USD per million tokens: `{ "input", "output", "cacheRead", "cacheWrite" }` (missing rates default to 0). Omit for free/local endpoints — cost reports an honest $0. |
 | `contextWindow` | no | Context window in tokens (dashboard chip). Omit when unknown — Chroxy never fabricates a window; the chip is simply hidden. |
+| `modelDiscovery` | no | Live model-catalog discovery: `{ "url", "format" }`. `format` is `openrouter` (`GET /api/v1/models`, OpenAI-ish list with per-token pricing) or `openai` (bare `/v1/models`, ids only). A discovered catalog feeds the dashboard picker, **replaces** the static `models` allowlist for validation, and (openrouter) autofills per-model cost. See [OpenRouter](#openrouter) below. |
 
 **Secrets never go in `config.json`.** `apiKeyEnv` / `credentialsKey` name *where* the key lives; an entry carrying a literal key (an `apiKey`/`token` field, a value that looks like `sk-...`, or `user:pass@` in the URL) is rejected at startup with a pointed warning. Invalid entries are skipped; valid siblings still register.
 
@@ -422,7 +424,7 @@ LM Studio 0.4.1+ serves an Anthropic-compatible `/v1/messages` locally. llama.cp
 
 No `apiKeyEnv` / `credentialsKey` → no credential gate (a placeholder key is sent on the wire, which local servers ignore); no `pricing` → cost is always $0; no `models` → any loaded model id is accepted; no `contextWindow` → decided by the local model, so no chip is shown.
 
-For **OpenRouter**, use `"baseUrl": "https://openrouter.ai/api"`, `"apiKeyEnv": "OPENROUTER_API_KEY"`, and any platform model id (e.g. `"defaultModel": "qwen/qwen3-coder"`) — OpenRouter's `/v1/messages` accepts the Anthropic format for all models, not just Claude.
+For **OpenRouter** — which accepts the Anthropic format for *every* model on the platform and adds live catalog discovery + per-model pricing — there's a one-command preset: see [OpenRouter](#openrouter) below.
 
 ### Use
 
@@ -436,6 +438,40 @@ npx chroxy start --provider lm-studio
 - These compatibility layers are young — llama.cpp explicitly makes "no strong claims of compatibility". Probe streamed tool input (`input_json_delta`), parallel tool calls, and usage accounting against your specific server before relying on them.
 - Tool-use quality depends entirely on the model behind the endpoint (same caveat as Ollama).
 - Capabilities are identical to `claude-byok` by construction — see the [capability matrix](#capability-matrix) note.
+
+## OpenRouter
+
+[OpenRouter](https://openrouter.ai) aggregates hundreds of models behind one key and accepts the **Anthropic Messages format for every model on the platform** — so it drives the same agent loop as `claude-byok` (streaming, tools, permission prompts, MCP, history, cost). It's an [Anthropic-compatible endpoint](#anthropic-compatible-endpoints-config-driven) with first-class ergonomics: a preset, live model-catalog discovery, and per-model pricing autofill.
+
+### Preset
+
+```bash
+npx chroxy providers add openrouter
+```
+
+This writes the `providers.anthropicCompatible` entry for you — `baseUrl https://openrouter.ai/api`, the `OPENROUTER_API_KEY` env seam (or the `openrouterApiKey` field in `~/.chroxy/credentials.json`, mode `0600`), a sensible default model, and the `modelDiscovery` block. It's **idempotent**: re-running leaves an existing entry untouched (`--force` rewrites it to the current preset).
+
+Then provide your key and start:
+
+```bash
+export OPENROUTER_API_KEY=sk-or-...           # or save it as "openrouterApiKey" in ~/.chroxy/credentials.json (0600)
+npx chroxy start --provider openrouter
+```
+
+### Model discovery
+
+On session start (and on every `available_models` push) Chroxy probes `GET https://openrouter.ai/api/v1/models` and feeds the live catalog into the model picker — exactly like Ollama's `/api/tags` discovery. Results (success *and* failure) are cached for 5 minutes and concurrent callers share one in-flight request, so a reconnecting dashboard never hammers the endpoint. The catalog is large (hundreds of models); the dashboard picker supports filter/search to navigate it.
+
+Discovery is **authoritative for validation**: once a catalog is in hand the discovered ids become the model allowlist for that provider (replacing the unrestricted pass-through), so an unknown id is rejected before it reaches OpenRouter. Until the first probe resolves (cold boot), the `defaultModel` works immediately and the endpoint stays unrestricted.
+
+### Pricing autofill
+
+OpenRouter's models endpoint reports per-token pricing. Chroxy converts it to its internal USD-per-MTok convention and applies it **per model**, so a session reports the real cost of the specific model in use instead of `$0` — no hand-authored `pricing` block needed. A model not present in the catalog (or a probe that hasn't run yet) falls back to the entry's flat `pricing` block, or an honest `$0` if none is configured.
+
+### Caveats
+
+- The same young-compatibility-layer caveats as any [Anthropic-compatible endpoint](#caveats) apply; tool-use quality depends on the model you route to.
+- `modelDiscovery` generalizes beyond OpenRouter: any aggregator or local server exposing an OpenAI-format `/v1/models` (LM Studio, vLLM) can opt in with `"format": "openai"` (ids only, no pricing).
 
 ## Selecting a provider
 

--- a/packages/server/src/anthropic-compatible-config.js
+++ b/packages/server/src/anthropic-compatible-config.js
@@ -23,7 +23,13 @@
  *     "models": ["glm-4.7", "glm-4.7-air"], // optional — allowlist; absent = unrestricted (#5418 tri-state)
  *     "pricing": { "input": 0.6, "output": 2.2, "cacheRead": 0.11, "cacheWrite": 0 },
  *                                           // optional — USD per MTok; absent = zero pricing (local endpoints)
- *     "contextWindow": 200000               // optional — tokens; absent = null (never fabricate, #5444)
+ *     "contextWindow": 200000,              // optional — tokens; absent = null (never fabricate, #5444)
+ *     "modelDiscovery": { "url": "https://openrouter.ai/api/v1/models", "format": "openrouter" }
+ *                                           // optional — live model catalog + per-model pricing autofill (#5548).
+ *                                           //   format 'openrouter' (GET /api/v1/models, OpenAI-ish list with pricing)
+ *                                           //   or 'openai' (bare /v1/models, ids only). A discovered catalog feeds
+ *                                           //   the picker AND replaces the static `models` allowlist for tri-state
+ *                                           //   validation (#5418); per-model pricing overrides the flat `pricing`.
  *   }
  *
  * Security boundary: config.json is NOT permission-restricted and gets
@@ -92,10 +98,19 @@ const FORBIDDEN_SECRET_KEYS = Object.freeze(['apiKey', 'api_key', 'key', 'token'
 // surface at startup instead of silently doing nothing.
 const KNOWN_ENTRY_KEYS = new Set([
   'id', 'label', 'baseUrl', 'apiKeyEnv', 'credentialsKey',
-  'defaultModel', 'models', 'pricing', 'contextWindow',
+  'defaultModel', 'models', 'pricing', 'contextWindow', 'modelDiscovery',
 ])
 
 const PRICING_RATE_KEYS = Object.freeze(['input', 'output', 'cacheRead', 'cacheWrite'])
+
+// Model-catalog discovery formats supported today (#5548). 'openrouter' is the
+// validation target (GET /api/v1/models, OpenAI-ish list carrying per-token
+// pricing); 'openai' covers a bare /v1/models id list (LM Studio, vLLM) — no
+// pricing, just a picker feed. Keep this list the single source of truth so the
+// fetch adapters in model-discovery.js and the validator can never disagree.
+export const MODEL_DISCOVERY_FORMATS = Object.freeze(['openrouter', 'openai'])
+
+const MODEL_DISCOVERY_KEYS = new Set(['url', 'format'])
 
 /**
  * Heuristic: does this string look like a pasted secret VALUE rather
@@ -328,6 +343,63 @@ function validateEntry(raw, path, seenIds, reservedIds, warnings) {
     }
   }
 
+  // --- modelDiscovery (live catalog + per-model pricing autofill, #5548) ---
+  // Absent → no discovery (the picker keeps the static `models`/defaultModel
+  // seed, the steady state since #5419). A malformed value drops the whole
+  // entry: a half-configured discovery seam (bad url, unknown format) is a
+  // misconfig the operator must see, not silently degrade to "no discovery".
+  let modelDiscovery = null
+  if (Object.prototype.hasOwnProperty.call(raw, 'modelDiscovery')) {
+    const md = raw.modelDiscovery
+    if (typeof md !== 'object' || md === null || Array.isArray(md)) {
+      warnings.push(`Invalid value for '${path}.modelDiscovery': expected an object with 'url' and 'format', got ${typeName(md)}`)
+      valid = false
+    } else {
+      let mdValid = true
+      for (const key of Object.keys(md)) {
+        if (!MODEL_DISCOVERY_KEYS.has(key)) {
+          warnings.push(`Unknown key '${path}.modelDiscovery.${key}' (will be ignored)`)
+        }
+      }
+      // url — http(s), no embedded credentials (same posture as baseUrl).
+      let url = null
+      if (typeof md.url !== 'string' || md.url.length === 0) {
+        warnings.push(`Invalid value for '${path}.modelDiscovery.url': required — the http(s) URL of the model-catalog endpoint`)
+        mdValid = false
+      } else {
+        let parsed = null
+        try {
+          parsed = new URL(md.url)
+        } catch {
+          warnings.push(`Invalid URL format for '${path}.modelDiscovery.url': expected an http(s) URL (value not shown — fix it in config.json)`)
+          mdValid = false
+        }
+        if (parsed && parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          warnings.push(`Invalid value for '${path}.modelDiscovery.url': must use http:// or https://, got '${parsed.protocol}'`)
+          mdValid = false
+        }
+        if (parsed && (parsed.username || parsed.password)) {
+          warnings.push(`Invalid value for '${path}.modelDiscovery.url': embedded credentials (user:pass@) are not supported — secrets don't belong in config.json`)
+          mdValid = false
+        }
+        if (mdValid) url = md.url
+      }
+      // format — one of the known adapters.
+      let format = null
+      if (typeof md.format !== 'string' || !MODEL_DISCOVERY_FORMATS.includes(md.format)) {
+        warnings.push(`Invalid value for '${path}.modelDiscovery.format': expected one of ${MODEL_DISCOVERY_FORMATS.map((f) => `'${f}'`).join(', ')}, got ${JSON.stringify(md.format)}`)
+        mdValid = false
+      } else {
+        format = md.format
+      }
+      if (mdValid) {
+        modelDiscovery = Object.freeze({ url, format })
+      } else {
+        valid = false
+      }
+    }
+  }
+
   if (!valid) return null
 
   seenIds.add(id)
@@ -341,6 +413,7 @@ function validateEntry(raw, path, seenIds, reservedIds, warnings) {
     models: models ? Object.freeze(models) : null,
     pricing,
     contextWindow,
+    modelDiscovery,
   })
 }
 

--- a/packages/server/src/anthropic-compatible-session.js
+++ b/packages/server/src/anthropic-compatible-session.js
@@ -43,6 +43,8 @@ import Anthropic from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from './byok-session.js'
 import { validateAnthropicCompatibleProviders } from './anthropic-compatible-config.js'
 import { registerProvider, getRegisteredProviderNames } from './providers.js'
+import { getRegistryForProvider } from './models.js'
+import { refreshDiscoveredModels } from './model-discovery.js'
 import { cachedResolveCredentialFile } from './auth-probes.js'
 import { createLogger } from './logger.js'
 
@@ -228,13 +230,59 @@ export function createAnthropicCompatibleSessionClass(rawEntry) {
     models: Array.isArray(rawEntry.models) && rawEntry.models.length > 0 ? Object.freeze([...rawEntry.models]) : null,
     pricing: rawEntry.pricing ? Object.freeze({ ...ZERO_PRICING, ...rawEntry.pricing }) : null,
     contextWindow: Number.isInteger(rawEntry.contextWindow) && rawEntry.contextWindow > 0 ? rawEntry.contextWindow : null,
+    modelDiscovery: (rawEntry.modelDiscovery
+      && typeof rawEntry.modelDiscovery === 'object'
+      && typeof rawEntry.modelDiscovery.url === 'string'
+      && typeof rawEntry.modelDiscovery.format === 'string')
+      ? Object.freeze({ url: rawEntry.modelDiscovery.url, format: rawEntry.modelDiscovery.format })
+      : null,
   })
 
   const keyless = !entry.apiKeyEnv && !entry.credentialsKey
-  const pricing = entry.pricing || ZERO_PRICING
+  const flatPricing = entry.pricing || ZERO_PRICING
+
+  // Per-class mutable catalog state (#5548). Populated by model discovery
+  // (refreshModels → applyCatalog) when `modelDiscovery` is configured;
+  // otherwise stays null and every model-shaped static falls back to the
+  // static `models`/defaultModel seed. Held in a closure shared by the class
+  // statics — one catalog per registered provider id, exactly like the
+  // module-scoped registry the registry hooks below resolve.
+  //   - catalogIds: Set of discovered model ids (authoritative allowlist)
+  //   - catalogMeta: Map id → { label, contextWindow }
+  //   - catalogPricing: Map id → { input, output, cacheRead, cacheWrite }
+  let catalogIds = null
+  let catalogMeta = null
+  let catalogPricing = null
+
+  function applyCatalog(catalog) {
+    const models = Array.isArray(catalog?.models) ? catalog.models : []
+    if (models.length === 0) return
+    const ids = new Set()
+    const meta = new Map()
+    for (const m of models) {
+      if (typeof m?.id !== 'string' || m.id.length === 0) continue
+      ids.add(m.id)
+      meta.set(m.id, {
+        label: typeof m.label === 'string' && m.label.length > 0 ? m.label : m.id,
+        contextWindow: Number.isInteger(m.contextWindow) && m.contextWindow > 0 ? m.contextWindow : null,
+      })
+    }
+    const pricingTable = catalog?.pricing && typeof catalog.pricing === 'object' ? catalog.pricing : {}
+    const pricingMap = new Map()
+    for (const id of Object.keys(pricingTable)) {
+      const p = pricingTable[id]
+      if (p && typeof p === 'object') {
+        pricingMap.set(id, Object.freeze({ ...ZERO_PRICING, ...p }))
+      }
+    }
+    catalogIds = ids
+    catalogMeta = meta
+    catalogPricing = pricingMap
+  }
 
   // Picker seed: the allowlist when one is declared, otherwise just the
-  // default model (the operator can type any id — unrestricted).
+  // default model (the operator can type any id — unrestricted). Discovery,
+  // once it runs, supersedes this in getFallbackModels via catalogMeta.
   const fallbackModels = Object.freeze(
     (entry.models || [entry.defaultModel]).map((id) =>
       Object.freeze({ id, label: id, fullId: id, contextWindow: entry.contextWindow })),
@@ -321,22 +369,51 @@ export function createAnthropicCompatibleSessionClass(rawEntry) {
     }
 
     static getFallbackModels() {
+      // Once a catalog has been discovered, seed the picker from it (hundreds
+      // of models with labels + windows) instead of the static default-only
+      // seed. Pre-discovery (cold boot) the static seed keeps the picker
+      // useful until the first refresh resolves.
+      if (catalogMeta && catalogMeta.size > 0) {
+        return Object.freeze(
+          [...catalogMeta.entries()].map(([id, m]) =>
+            Object.freeze({ id, label: m.label, fullId: id, contextWindow: m.contextWindow })),
+        )
+      }
       return fallbackModels
+    }
+
+    /** The validated modelDiscovery seam for this class (null when absent). */
+    static get modelDiscovery() {
+      return entry.modelDiscovery
     }
 
     /**
      * Tri-state model validation source (settings-handlers, #2946/#5418):
-     *   - `models` declared → the array is the authoritative allowlist.
-     *   - `models` absent   → null = unrestricted; any non-empty model id
-     *     passes through verbatim and an unknown id surfaces as the
-     *     endpoint's own error (the ollama rule).
+     *   - discovered catalog present → the discovered ids are the
+     *     authoritative allowlist (replaces PROVIDER_MODELS_UNRESTRICTED for
+     *     this entry — the issue's tri-state interplay).
+     *   - `models` declared (no/empty catalog) → the static array is the
+     *     authoritative allowlist.
+     *   - neither → null = unrestricted; any non-empty model id passes
+     *     through verbatim and an unknown id surfaces as the endpoint's own
+     *     error (the ollama rule).
      */
     static getAllowedModels() {
+      if (catalogIds && catalogIds.size > 0) return [...catalogIds]
       return entry.models ? [...entry.models] : null
     }
 
     static getModelMetadata(modelId) {
       if (typeof modelId !== 'string' || modelId.length === 0) return null
+      // Discovered catalog wins: it carries real labels + context windows.
+      if (catalogMeta && catalogMeta.size > 0) {
+        const hit = catalogMeta.get(modelId)
+        if (hit) return { id: modelId, label: hit.label, fullId: modelId, contextWindow: hit.contextWindow }
+        // Catalog present but this id isn't in it — unknown model. The picker
+        // is now restricted to the catalog (getAllowedModels), so return null
+        // the same way a declared-allowlist miss does.
+        return null
+      }
       if (entry.models) {
         if (!entry.models.includes(modelId)) return null
         return { id: modelId, label: modelId, fullId: modelId, contextWindow: entry.contextWindow }
@@ -349,11 +426,59 @@ export function createAnthropicCompatibleSessionClass(rawEntry) {
       return { id: modelId, label: modelId, fullId: modelId, contextWindow: entry.contextWindow }
     }
 
+    /**
+     * Dynamic model-catalog discovery hook (#5548) — ws-history's generic
+     * `scheduleProviderModelsRefresh` calls this (fire-and-forget) whenever it
+     * sends `available_models` for this provider, and pushes a refreshed list
+     * if discovery changed the registry. No-op (resolves null) when the entry
+     * declares no `modelDiscovery`. Never throws, never blocks validation.
+     *
+     * `deps` is a test seam (fetchFn / now / ttlMs / registry / apiKey).
+     */
+    static refreshModels(deps = {}) {
+      if (!entry.modelDiscovery) return Promise.resolve(null)
+      const apiKey = deps.apiKey !== undefined ? deps.apiKey : resolveDiscoveryApiKey(entry)
+      return refreshDiscoveredModels({
+        id: entry.id,
+        url: entry.modelDiscovery.url,
+        format: entry.modelDiscovery.format,
+        apiKey,
+        registry: deps.registry || getRegistryForProvider(entry.id),
+        applyCatalog,
+        ...deps,
+      })
+    }
+
+    /** Test/introspection hook: the discovered per-model pricing snapshot. */
+    static get discoveredPricing() {
+      return catalogPricing
+    }
+
     constructor(opts = {}) {
       // Force the registry name so the provider id on this session is
       // always the config entry's id — independent of whatever the
       // embedder passed (mirrors DeepSeekSession / OllamaSession).
       super({ ...opts, provider: entry.id })
+    }
+
+    /**
+     * #5548: kick off catalog discovery on session start when the entry opts
+     * in via `modelDiscovery` — the moment we know the user cares about this
+     * endpoint, exactly like OllamaSession.start() probes /api/tags. Fire-and-
+     * forget: discovery must never delay or fail session start (byok's start()
+     * already emitted 'ready' by the time the probe resolves). On a changed
+     * list, emit `models_updated` so the picker refreshes without a restart.
+     */
+    async start() {
+      await super.start()
+      if (!entry.modelDiscovery) return
+      AnthropicCompatibleSession.refreshModels()
+        .then((models) => {
+          if (Array.isArray(models) && models.length > 0) {
+            this.emit('models_updated', { models })
+          }
+        })
+        .catch(() => {})
     }
 
     // --- Seam overrides (see byok-session.js for the contract) ---
@@ -373,12 +498,40 @@ export function createAnthropicCompatibleSessionClass(rawEntry) {
       })
     }
 
-    _getPricing() {
-      return pricing
+    /**
+     * Per-model pricing (#5548). When discovery has populated a per-model
+     * table, the model's discovered rates win so OpenRouter sessions report
+     * real cost; otherwise fall back to the flat `pricing` block (or honest
+     * all-zero for local endpoints). byok-session calls this with the active
+     * model id, so cost reflects the specific model in use, not a single flat
+     * rate across a catalog of hundreds.
+     */
+    _getPricing(model) {
+      if (catalogPricing && typeof model === 'string') {
+        const hit = catalogPricing.get(model)
+        if (hit) return hit
+      }
+      return flatPricing
     }
   }
 
   return AnthropicCompatibleSession
+}
+
+/**
+ * Resolve the API key to pass on the discovery probe (#5548). OpenRouter's
+ * /api/v1/models needs no key, but passing the entry's key is harmless and
+ * future-proofs gated aggregators. Returns null (no Authorization header) when
+ * unresolved or for the keyless placeholder. Never logged.
+ *
+ * @param {object} entry - normalized config entry
+ * @returns {string|null}
+ */
+function resolveDiscoveryApiKey(entry) {
+  if (!entry.apiKeyEnv && !entry.credentialsKey) return null
+  const resolved = resolveAnthropicCompatibleApiKey(entry)
+  if (resolved.key && resolved.key !== COMPAT_PLACEHOLDER_API_KEY) return resolved.key
+  return null
 }
 
 /**

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -23,6 +23,7 @@ import { registerPairCodeCommand } from './cli/pair-code-cmd.js'
 import { registerPairDiscordCommand } from './cli/pair-discord-cmd.js'
 import { registerWorktreeCommand } from './cli/worktree-gc-cmd.js'
 import { registerCredentialsCommand } from './cli/credentials-cmd.js'
+import { registerProvidersCommand } from './cli/providers-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -48,5 +49,6 @@ registerPairCodeCommand(program)
 registerPairDiscordCommand(program)
 registerWorktreeCommand(program)
 registerCredentialsCommand(program)
+registerProvidersCommand(program)
 
 program.parse()

--- a/packages/server/src/cli/providers-cmd.js
+++ b/packages/server/src/cli/providers-cmd.js
@@ -1,0 +1,168 @@
+/**
+ * `chroxy providers` CLI subcommands (#5548).
+ *
+ * `add openrouter` is a one-liner preset that writes the
+ * `providers.anthropicCompatible` entry the docs describe by hand — right
+ * baseUrl, key seam (OPENROUTER_API_KEY env or a `credentialsKey` in the
+ * encrypted store), a sensible default model, and the `modelDiscovery` seam so
+ * the picker fills from OpenRouter's live catalog and sessions report real
+ * cost instead of $0. No new session class — it generates config the existing
+ * anthropicCompatible machinery (#5419/#5458) already registers at startup.
+ *
+ * Idempotent: if an `openrouter` entry already exists it is left untouched
+ * (re-running is a no-op) unless `--force` rewrites it to the current preset.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { writeFileRestricted } from '../platform.js'
+import { CONFIG_FILE } from './shared.js'
+
+// The OpenRouter preset, in one place so the CLI and any future dashboard
+// affordance write an identical entry. baseUrl is the Anthropic-compat root
+// (the SDK appends /v1/messages); modelDiscovery points at the OpenAI-ish
+// catalog (a sibling /v1/models, NOT under the messages base).
+export const OPENROUTER_PRESET = Object.freeze({
+  id: 'openrouter',
+  label: 'OpenRouter',
+  baseUrl: 'https://openrouter.ai/api',
+  apiKeyEnv: 'OPENROUTER_API_KEY',
+  credentialsKey: 'openrouterApiKey',
+  defaultModel: 'anthropic/claude-sonnet-4',
+  modelDiscovery: Object.freeze({
+    url: 'https://openrouter.ai/api/v1/models',
+    format: 'openrouter',
+  }),
+})
+
+/**
+ * Build the merged config object after adding the openrouter preset. Pure (no
+ * I/O) so tests assert the written shape directly. Returns
+ * `{ config, status }` where status is one of 'added' | 'exists' | 'updated'.
+ *
+ * @param {object} fileConfig - parsed config.json (may be {})
+ * @param {object} [opts]
+ * @param {boolean} [opts.force] - rewrite an existing entry to the preset
+ * @param {object} [opts.preset] - override the preset (tests)
+ */
+export function applyOpenRouterPreset(fileConfig, opts = {}) {
+  const preset = opts.preset || OPENROUTER_PRESET
+  const config = { ...fileConfig }
+
+  // Normalize providers into the object form {anthropicCompatible: [...]}.
+  // The legacy `providers: [..ids..]` array form (written by `chroxy init`) is
+  // a DIFFERENT, purely-informational shape (provider selection is driven by
+  // `--provider` / the top-level `provider` key, not this list). The
+  // anthropicCompatible block only exists under the object form, so when the
+  // file carries the legacy array we promote to the object form and report it
+  // via `convertedLegacyArray` so the CLI can warn the user.
+  let providers = config.providers
+  let convertedLegacyArray = false
+  if (Array.isArray(providers)) {
+    convertedLegacyArray = providers.length > 0
+    providers = {}
+  } else if (typeof providers !== 'object' || providers === null) {
+    providers = {}
+  } else {
+    providers = { ...providers }
+  }
+
+  let list = Array.isArray(providers.anthropicCompatible) ? [...providers.anthropicCompatible] : []
+  const idx = list.findIndex((e) => e && typeof e === 'object' && e.id === preset.id)
+
+  let status
+  const entry = { ...preset, modelDiscovery: { ...preset.modelDiscovery } }
+  if (idx === -1) {
+    list = [...list, entry]
+    status = 'added'
+  } else if (opts.force) {
+    list = list.map((e, i) => (i === idx ? entry : e))
+    status = 'updated'
+  } else {
+    // Idempotent: leave the existing entry untouched.
+    status = 'exists'
+  }
+
+  providers.anthropicCompatible = list
+  config.providers = providers
+
+  return { config, status, convertedLegacyArray }
+}
+
+/**
+ * Run `chroxy providers add openrouter`. `deps` is a test seam
+ * (readFileFn / writeFileFn / existsFn / configFilePath / logFn).
+ *
+ * @returns {{ status: string, written: boolean, configFilePath: string }}
+ */
+export function runProvidersAddOpenRouter(options = {}, deps = {}) {
+  const logFn = deps.logFn || console.log
+  const writeFileFn = deps.writeFileFn || writeFileRestricted
+  const existsFn = deps.existsFn || existsSync
+  const readFileFn = deps.readFileFn || ((p) => readFileSync(p, 'utf-8'))
+  const configFilePath = deps.configFilePath || options.config || CONFIG_FILE
+
+  let fileConfig = {}
+  if (existsFn(configFilePath)) {
+    try {
+      fileConfig = JSON.parse(readFileFn(configFilePath))
+    } catch (err) {
+      logFn(`❌ Config file contains invalid JSON: ${configFilePath}`)
+      logFn(`   ${err.message}`)
+      logFn(`   Fix the file or run 'npx chroxy init' to recreate it.`)
+      return { status: 'invalid-json', written: false, configFilePath }
+    }
+  } else {
+    logFn(`❌ No config found at ${configFilePath}. Run 'npx chroxy init' first.`)
+    return { status: 'no-config', written: false, configFilePath }
+  }
+
+  const { config, status, convertedLegacyArray } = applyOpenRouterPreset(fileConfig, { force: options.force })
+
+  if (status === 'exists') {
+    logFn(`• OpenRouter is already configured in ${configFilePath} — nothing to do.`)
+    logFn(`  Re-run with --force to overwrite it with the current preset.`)
+    return { status, written: false, configFilePath }
+  }
+
+  writeFileFn(configFilePath, JSON.stringify(config, null, 2))
+
+  if (convertedLegacyArray) {
+    logFn(`ℹ Converted the legacy 'providers' id-list to the object form to hold the entry.`)
+    logFn(`  Provider selection still uses --provider / the 'provider' key — nothing changes there.`)
+  }
+
+  logFn(`${status === 'updated' ? '✓ Updated' : '✓ Added'} the OpenRouter provider in ${configFilePath}.`)
+  logFn('')
+  logFn('Next steps:')
+  logFn('  1. Provide your API key (either is fine):')
+  logFn(`       export ${OPENROUTER_PRESET.apiKeyEnv}=sk-or-...`)
+  logFn(`     or save it as "${OPENROUTER_PRESET.credentialsKey}" in ~/.chroxy/credentials.json (mode 0600)`)
+  logFn('  2. Start with OpenRouter as the active provider:')
+  logFn(`       npx chroxy start --provider ${OPENROUTER_PRESET.id}`)
+  logFn('')
+  logFn('  The model picker fills from OpenRouter\'s live catalog and per-model')
+  logFn('  pricing is applied automatically — sessions report real cost.')
+
+  return { status, written: true, configFilePath }
+}
+
+export function registerProvidersCommand(program) {
+  const providers = program
+    .command('providers')
+    .description('Manage configured session providers')
+
+  const add = providers
+    .command('add')
+    .description('Add a preset provider to config.json')
+
+  add
+    .command('openrouter')
+    .description('Add the OpenRouter Anthropic-compatible provider (baseUrl + key seam + model discovery + pricing autofill)')
+    .option('-c, --config <path>', 'Path to config file', CONFIG_FILE)
+    .option('--force', 'Overwrite an existing openrouter entry with the current preset')
+    .action((options) => {
+      const result = runProvidersAddOpenRouter(options)
+      if (result.status === 'no-config' || result.status === 'invalid-json') {
+        process.exitCode = 1
+      }
+    })
+}

--- a/packages/server/src/model-discovery.js
+++ b/packages/server/src/model-discovery.js
@@ -258,7 +258,18 @@ export async function refreshDiscoveredModels(opts = {}) {
           log.debug(`discovery: applyCatalog for ${id} threw: ${err?.message || err}`)
         }
       }
-      const key = JSON.stringify(catalog.models.map((m) => m.id))
+      // Change-detection key: order-insensitive (a reorder of the same set
+      // isn't a change) and metadata-aware (a label / context-window update on
+      // an existing id IS a change the registry must pick up — updateModels()
+      // feeds those into the picker). Sort so upstream ordering can't trigger a
+      // spurious rebroadcast; include label + window so a metadata-only update
+      // still re-pushes. (Pricing already refreshes unconditionally via the
+      // applyCatalog call above, so it stays out of the key.)
+      const key = JSON.stringify(
+        catalog.models
+          .map((m) => [m.id, m.label ?? '', m.contextWindow ?? null])
+          .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)),
+      )
       if (key === slot.lastAppliedKey) return null
       const registry = opts.registry
       if (!registry || typeof registry.updateModels !== 'function') return null

--- a/packages/server/src/model-discovery.js
+++ b/packages/server/src/model-discovery.js
@@ -1,0 +1,277 @@
+/**
+ * Generic model-catalog discovery for `providers.anthropicCompatible` entries
+ * (#5548) — a capability declared via `modelDiscovery: { url, format }`, NOT
+ * OpenRouter-specific code.
+ *
+ * Many aggregators and local servers expose an OpenAI-ish `/v1/models` listing
+ * (OpenRouter carries per-token pricing alongside; LM Studio / vLLM list ids
+ * only). This module probes that endpoint, normalizes the response per-format
+ * into `{ models, pricing }`, and feeds the result into the provider's models
+ * registry + per-model cost table — exactly the role Ollama's /api/tags probe
+ * (ollama-tags.js, #5421) plays for the local daemon. The cache/refresh shape
+ * is deliberately the same:
+ *
+ *   - ADVISORY for the picker, AUTHORITATIVE for validation. A discovered
+ *     catalog replaces the static `models` allowlist for that entry (the
+ *     issue's tri-state interplay with #5418): the session class reports the
+ *     discovered ids from getAllowedModels() once a catalog is in hand.
+ *   - GRACEFUL FAILURE. Endpoint down / slow / garbage must never delay or
+ *     break session start: bounded timeout, debug-level logging, and the
+ *     picker keeps whatever it already had (the static seed on cold boot).
+ *   - NO RETRY STORM. Results — success AND failure — are cached per entry for
+ *     a TTL, and concurrent callers share one in-flight request. A reconnect
+ *     loop can't hammer the aggregator.
+ *
+ * Unlike Ollama's single global daemon, anthropicCompatible entries are
+ * many-and-configurable, so the cache here is keyed per entry id (a Map of
+ * per-entry slots) rather than module-level scalars.
+ *
+ * Pricing: OpenRouter reports USD-per-TOKEN rates as strings (e.g.
+ * `"0.0000004"` = $0.40/MTok). We convert to chroxy's internal USD-per-MTok
+ * convention so the discovered table drops straight into byok-session's cost
+ * math (the same units `pricing` blocks already use).
+ */
+
+import { createLogger } from './logger.js'
+
+const log = createLogger('model-discovery')
+
+// Bounded probe. A catalog endpoint is a remote HTTP service (OpenRouter) or a
+// local one (LM Studio) — 4s is generous for the former and instant for the
+// latter, while still capping a wedged endpoint's drag on a session that opted
+// in. Discovery is fire-and-forget, so this never blocks the user.
+export const MODEL_DISCOVERY_TIMEOUT_MS = 4000
+
+// Cache window for discovery results (success AND failure). A catalog of
+// hundreds of models changes slowly; 5 min keeps a reconnecting dashboard /
+// multi-client handshake burst down to at most one HTTP probe per window while
+// still picking up new models within the session.
+export const MODEL_DISCOVERY_CACHE_TTL_MS = 5 * 60_000
+
+// USD per token → USD per MTok. OpenRouter prices are per-token strings.
+const TOKENS_PER_MTOK = 1_000_000
+
+/**
+ * Coerce an OpenRouter per-token price (string or number) to USD-per-MTok.
+ * Missing / unparseable / negative → 0 (an honest $0 rather than a fabricated
+ * rate — the ollama/local convention).
+ *
+ * @param {*} perToken
+ * @returns {number}
+ */
+function perTokenToMTok(perToken) {
+  const n = typeof perToken === 'string' ? Number(perToken) : perToken
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return 0
+  return n * TOKENS_PER_MTOK
+}
+
+/**
+ * Normalize an OpenRouter /api/v1/models response into chroxy's shape.
+ *
+ * OpenRouter entry (relevant fields):
+ *   { id, name, context_length,
+ *     pricing: { prompt, completion, input_cache_read, input_cache_write } }
+ *
+ * @param {*} body - parsed JSON
+ * @returns {{ models: Array<{id,label,contextWindow}>, pricing: Object }|null}
+ */
+function parseOpenRouter(body) {
+  const list = Array.isArray(body?.data) ? body.data : null
+  if (!list) return null
+  const models = []
+  const pricing = {}
+  const seen = new Set()
+  for (const m of list) {
+    const id = typeof m?.id === 'string' ? m.id.trim() : ''
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    const label = typeof m?.name === 'string' && m.name.trim().length > 0 ? m.name.trim() : id
+    const ctx = Number.isInteger(m?.context_length) && m.context_length > 0 ? m.context_length : null
+    models.push({ id, label, contextWindow: ctx })
+    const p = m?.pricing
+    if (p && typeof p === 'object') {
+      pricing[id] = Object.freeze({
+        input: perTokenToMTok(p.prompt),
+        output: perTokenToMTok(p.completion),
+        cacheRead: perTokenToMTok(p.input_cache_read),
+        cacheWrite: perTokenToMTok(p.input_cache_write),
+      })
+    }
+  }
+  if (models.length === 0) return null
+  return { models, pricing }
+}
+
+/**
+ * Normalize a bare OpenAI /v1/models response (ids only, no pricing). Covers
+ * LM Studio, vLLM, and any OpenAI-format server. Designed to slot in alongside
+ * the openrouter adapter — same return shape, empty pricing table.
+ *
+ * OpenAI entry: { id, object: 'model', ... } under a top-level `data` array.
+ *
+ * @param {*} body
+ * @returns {{ models: Array<{id,label,contextWindow}>, pricing: Object }|null}
+ */
+function parseOpenAi(body) {
+  const list = Array.isArray(body?.data) ? body.data : null
+  if (!list) return null
+  const models = []
+  const seen = new Set()
+  for (const m of list) {
+    const id = typeof m?.id === 'string' ? m.id.trim() : ''
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    // No name/context in the bare OpenAI list — id doubles as label, window
+    // unknown (null, never fabricated — the #5444 rule).
+    models.push({ id, label: id, contextWindow: null })
+  }
+  if (models.length === 0) return null
+  return { models, pricing: {} }
+}
+
+const FORMAT_PARSERS = Object.freeze({
+  openrouter: parseOpenRouter,
+  openai: parseOpenAi,
+})
+
+/**
+ * Fetch + normalize a model catalog. Returns `{ models, pricing }` on success
+ * or null on ANY failure (endpoint down, non-2xx, malformed JSON, unexpected
+ * shape, timeout, unknown format). Failures log at debug level only.
+ *
+ * Authorization: discovery endpoints often gate the list behind the same key
+ * as the chat endpoint (OpenRouter requires no key for /api/v1/models, but
+ * passing one is harmless and future-proofs gated aggregators). When `apiKey`
+ * is supplied and non-empty it rides as `Authorization: Bearer`. Never logged.
+ *
+ * @param {Object} opts
+ * @param {string} opts.url
+ * @param {string} opts.format - one of MODEL_DISCOVERY_FORMATS
+ * @param {string|null} [opts.apiKey]
+ * @param {typeof fetch} [opts.fetchFn] - injectable fetch for tests
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<{models:Array,pricing:Object}|null>}
+ */
+export async function fetchModelCatalog({ url, format, apiKey = null, fetchFn = fetch, timeoutMs = MODEL_DISCOVERY_TIMEOUT_MS } = {}) {
+  const parse = FORMAT_PARSERS[format]
+  if (typeof parse !== 'function') {
+    log.debug(`discovery: unknown format '${format}' for ${url}`)
+    return null
+  }
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const headers = { accept: 'application/json' }
+    if (typeof apiKey === 'string' && apiKey.length > 0) {
+      headers.authorization = `Bearer ${apiKey}`
+    }
+    const res = await fetchFn(url, { signal: controller.signal, headers })
+    if (!res?.ok) {
+      log.debug(`discovery: ${url} answered ${res?.status ?? 'no response'}`)
+      return null
+    }
+    const body = await res.json()
+    const parsed = parse(body)
+    if (!parsed) {
+      log.debug(`discovery: ${url} returned an unexpected shape for format '${format}'`)
+      return null
+    }
+    return parsed
+  } catch (err) {
+    log.debug(`discovery: ${url} failed (${err?.name === 'AbortError' ? `timeout after ${timeoutMs}ms` : err?.message || err})`)
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// --- Per-entry TTL cache for refreshDiscoveredModels ---
+// Keyed by entry id (anthropicCompatible entries are many; Ollama is one
+// global daemon and uses module scalars). Each slot tracks last-probe time,
+// the in-flight promise, and the last-applied key for change detection.
+const _slots = new Map()
+
+function slotFor(id) {
+  let slot = _slots.get(id)
+  if (!slot) {
+    slot = { lastProbeAt: -Infinity, inflight: null, lastAppliedKey: null }
+    _slots.set(id, slot)
+  }
+  return slot
+}
+
+/** Test hook: drop all per-entry cache + change-detection state. */
+export function _resetModelDiscoveryStateForTests() {
+  _slots.clear()
+}
+
+/**
+ * Discover the catalog for one anthropicCompatible entry and feed it into the
+ * provider's models registry. Resolves to the refreshed registry model list
+ * when the picker CHANGED, or null when there is nothing new to broadcast
+ * (probe failed, no models, same set as last time, or served from the TTL
+ * cache) — the exact contract of refreshOllamaModels so the generic
+ * `scheduleProviderModelsRefresh` hook in ws-history treats both alike.
+ *
+ * Side effect: when discovery succeeds, the full catalog (`{ models, pricing }`)
+ * is published via `applyCatalog(catalog)` BEFORE the registry feed, so the
+ * session class's getModelMetadata/getAllowedModels/_getPricing read from the
+ * discovered ids + context windows + per-model pricing (real cost, not $0) by
+ * the time the registry's updateModels() consults them.
+ *
+ * @param {Object} opts
+ * @param {string} opts.id - provider/entry id (cache key + log label)
+ * @param {string} opts.url
+ * @param {string} opts.format
+ * @param {string|null} [opts.apiKey]
+ * @param {Object} opts.registry - provider models registry (updateModels/getModels)
+ * @param {(catalog: {models:Array,pricing:Object}) => void} [opts.applyCatalog] - catalog sink
+ * @param {typeof fetch} [opts.fetchFn]
+ * @param {number} [opts.timeoutMs]
+ * @param {number} [opts.ttlMs]
+ * @param {() => number} [opts.now] - injectable clock for tests
+ * @returns {Promise<Array<Object>|null>}
+ */
+export async function refreshDiscoveredModels(opts = {}) {
+  const { id } = opts
+  if (typeof id !== 'string' || id.length === 0) return null
+  const now = typeof opts.now === 'function' ? opts.now : Date.now
+  const ttlMs = typeof opts.ttlMs === 'number' ? opts.ttlMs : MODEL_DISCOVERY_CACHE_TTL_MS
+  const slot = slotFor(id)
+  if (slot.inflight) return slot.inflight
+  if (now() - slot.lastProbeAt < ttlMs) return null
+  slot.inflight = (async () => {
+    try {
+      const catalog = await fetchModelCatalog(opts)
+      slot.lastProbeAt = now()
+      if (!catalog || !Array.isArray(catalog.models) || catalog.models.length === 0) return null
+      // Publish the catalog to the session class FIRST (cheap, idempotent) so
+      // its getModelMetadata/getAllowedModels/_getPricing reflect the discovered
+      // ids + context windows + per-model pricing before updateModels() (which
+      // consults getModelMetadata for labels/windows) runs below. Done on every
+      // successful probe so a re-probe with the same model SET but updated rates
+      // still refreshes cost reporting.
+      if (typeof opts.applyCatalog === 'function') {
+        try {
+          opts.applyCatalog(catalog)
+        } catch (err) {
+          log.debug(`discovery: applyCatalog for ${id} threw: ${err?.message || err}`)
+        }
+      }
+      const key = JSON.stringify(catalog.models.map((m) => m.id))
+      if (key === slot.lastAppliedKey) return null
+      const registry = opts.registry
+      if (!registry || typeof registry.updateModels !== 'function') return null
+      const converted = registry.updateModels(
+        catalog.models.map((m) => ({ value: m.id, displayName: m.label, contextWindow: m.contextWindow })),
+      )
+      if (!Array.isArray(converted) || converted.length === 0) return null
+      slot.lastAppliedKey = key
+      log.info(`discovered ${catalog.models.length} models for '${id}' via ${opts.format} catalog`)
+      return typeof registry.getModels === 'function' ? registry.getModels() : converted
+    } finally {
+      slot.inflight = null
+    }
+  })()
+  return slot.inflight
+}

--- a/packages/server/tests/openrouter-ergonomics.test.js
+++ b/packages/server/tests/openrouter-ergonomics.test.js
@@ -1,0 +1,419 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  validateAnthropicCompatibleProviders,
+  MODEL_DISCOVERY_FORMATS,
+} from '../src/anthropic-compatible-config.js'
+import {
+  fetchModelCatalog,
+  refreshDiscoveredModels,
+  _resetModelDiscoveryStateForTests,
+  MODEL_DISCOVERY_CACHE_TTL_MS,
+} from '../src/model-discovery.js'
+import { createAnthropicCompatibleSessionClass } from '../src/anthropic-compatible-session.js'
+import {
+  applyOpenRouterPreset,
+  runProvidersAddOpenRouter,
+  OPENROUTER_PRESET,
+} from '../src/cli/providers-cmd.js'
+
+/**
+ * Tests for first-class OpenRouter ergonomics (#5548): the generalized
+ * `modelDiscovery` capability on anthropicCompatible entries, model-catalog
+ * fetch/parse/cache, per-model pricing autofill, tri-state validation
+ * interplay, and the `chroxy providers add openrouter` preset.
+ *
+ * NEVER hits the network — every fetch is injected. NEVER writes the real
+ * ~/.chroxy — the CLI tests pass an in-memory writeFileFn and a temp path.
+ */
+
+// A trimmed OpenRouter /api/v1/models payload (two models, one with full
+// pricing, one with partial) mirroring the real OpenAI-ish `{ data: [...] }`
+// shape with per-token string prices.
+function openRouterBody() {
+  return {
+    data: [
+      {
+        id: 'anthropic/claude-sonnet-4',
+        name: 'Anthropic: Claude Sonnet 4',
+        context_length: 200000,
+        pricing: { prompt: '0.000003', completion: '0.000015', input_cache_read: '0.0000003', input_cache_write: '0.00000375' },
+      },
+      {
+        id: 'qwen/qwen3-coder',
+        name: 'Qwen3 Coder',
+        context_length: 262144,
+        pricing: { prompt: '0.0000004', completion: '0.0000016' },
+      },
+    ],
+  }
+}
+
+function makeFetch(body, { ok = true, status = 200 } = {}) {
+  const calls = []
+  const fetchFn = async (url, opts) => {
+    calls.push({ url, opts })
+    return {
+      ok,
+      status,
+      json: async () => body,
+    }
+  }
+  fetchFn.calls = calls
+  return fetchFn
+}
+
+describe('modelDiscovery config validation (#5548)', () => {
+  function makeEntry(overrides = {}) {
+    return { id: 'openrouter', baseUrl: 'https://openrouter.ai/api', defaultModel: 'anthropic/claude-sonnet-4', ...overrides }
+  }
+
+  it('accepts a valid modelDiscovery block and normalizes it', () => {
+    const { entries, warnings } = validateAnthropicCompatibleProviders([
+      makeEntry({ modelDiscovery: { url: 'https://openrouter.ai/api/v1/models', format: 'openrouter' } }),
+    ])
+    assert.deepEqual(warnings, [])
+    assert.equal(entries.length, 1)
+    assert.deepEqual(entries[0].modelDiscovery, { url: 'https://openrouter.ai/api/v1/models', format: 'openrouter' })
+  })
+
+  it('absent modelDiscovery normalizes to null', () => {
+    const { entries } = validateAnthropicCompatibleProviders([makeEntry()])
+    assert.equal(entries[0].modelDiscovery, null)
+  })
+
+  it('rejects an unknown format and drops the entry', () => {
+    const { entries, warnings } = validateAnthropicCompatibleProviders([
+      makeEntry({ modelDiscovery: { url: 'https://x.test/v1/models', format: 'bogus' } }),
+    ])
+    assert.equal(entries.length, 0)
+    assert.ok(warnings.some((w) => /modelDiscovery\.format/.test(w)))
+  })
+
+  it('rejects a non-http(s) discovery url', () => {
+    const { entries, warnings } = validateAnthropicCompatibleProviders([
+      makeEntry({ modelDiscovery: { url: 'ftp://x.test/models', format: 'openrouter' } }),
+    ])
+    assert.equal(entries.length, 0)
+    assert.ok(warnings.some((w) => /modelDiscovery\.url/.test(w)))
+  })
+
+  it('rejects embedded credentials in the discovery url', () => {
+    const { entries, warnings } = validateAnthropicCompatibleProviders([
+      makeEntry({ modelDiscovery: { url: 'https://user:pass@x.test/models', format: 'openrouter' } }),
+    ])
+    assert.equal(entries.length, 0)
+    assert.ok(warnings.some((w) => /embedded credentials/.test(w)))
+  })
+
+  it('warns on an unknown modelDiscovery sub-key but still accepts', () => {
+    const { entries, warnings } = validateAnthropicCompatibleProviders([
+      makeEntry({ modelDiscovery: { url: 'https://x.test/v1/models', format: 'openai', extra: 1 } }),
+    ])
+    assert.equal(entries.length, 1)
+    assert.ok(warnings.some((w) => /modelDiscovery\.extra/.test(w)))
+  })
+
+  it('rejects a non-object modelDiscovery', () => {
+    const { entries, warnings } = validateAnthropicCompatibleProviders([
+      makeEntry({ modelDiscovery: 'https://x.test/models' }),
+    ])
+    assert.equal(entries.length, 0)
+    assert.ok(warnings.some((w) => /modelDiscovery/.test(w)))
+  })
+
+  it('exports the supported formats list', () => {
+    assert.deepEqual([...MODEL_DISCOVERY_FORMATS], ['openrouter', 'openai'])
+  })
+})
+
+describe('fetchModelCatalog (#5548)', () => {
+  it('parses the OpenRouter format into models + per-MTok pricing', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    const out = await fetchModelCatalog({ url: 'https://openrouter.ai/api/v1/models', format: 'openrouter', fetchFn })
+    assert.equal(out.models.length, 2)
+    const sonnet = out.models.find((m) => m.id === 'anthropic/claude-sonnet-4')
+    assert.equal(sonnet.label, 'Anthropic: Claude Sonnet 4')
+    assert.equal(sonnet.contextWindow, 200000)
+    // 0.000003 USD/token * 1e6 = 3.0 USD/MTok
+    assert.equal(out.pricing['anthropic/claude-sonnet-4'].input, 3)
+    assert.equal(out.pricing['anthropic/claude-sonnet-4'].output, 15)
+    assert.equal(out.pricing['anthropic/claude-sonnet-4'].cacheRead, 0.3)
+    assert.equal(out.pricing['anthropic/claude-sonnet-4'].cacheWrite, 3.75)
+    // Partial pricing → missing rates default to 0.
+    assert.equal(out.pricing['qwen/qwen3-coder'].cacheRead, 0)
+    assert.ok(Math.abs(out.pricing['qwen/qwen3-coder'].input - 0.4) < 1e-9)
+  })
+
+  it('parses the bare OpenAI format (ids only, no pricing)', async () => {
+    const fetchFn = makeFetch({ data: [{ id: 'local-model-a', object: 'model' }, { id: 'local-model-b', object: 'model' }] })
+    const out = await fetchModelCatalog({ url: 'http://localhost:1234/v1/models', format: 'openai', fetchFn })
+    assert.equal(out.models.length, 2)
+    assert.equal(out.models[0].label, 'local-model-a')
+    assert.equal(out.models[0].contextWindow, null)
+    assert.deepEqual(out.pricing, {})
+  })
+
+  it('passes the api key as a Bearer header when supplied', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    await fetchModelCatalog({ url: 'https://x.test/v1/models', format: 'openrouter', apiKey: 'sk-or-secret', fetchFn })
+    assert.equal(fetchFn.calls[0].opts.headers.authorization, 'Bearer sk-or-secret')
+  })
+
+  it('omits the Authorization header when no key is supplied', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    await fetchModelCatalog({ url: 'https://x.test/v1/models', format: 'openrouter', fetchFn })
+    assert.equal(fetchFn.calls[0].opts.headers.authorization, undefined)
+  })
+
+  it('returns null on a non-2xx response', async () => {
+    const fetchFn = makeFetch(openRouterBody(), { ok: false, status: 503 })
+    const out = await fetchModelCatalog({ url: 'https://x.test/v1/models', format: 'openrouter', fetchFn })
+    assert.equal(out, null)
+  })
+
+  it('returns null on an unexpected shape (no data array)', async () => {
+    const fetchFn = makeFetch({ models: [] })
+    const out = await fetchModelCatalog({ url: 'https://x.test/v1/models', format: 'openrouter', fetchFn })
+    assert.equal(out, null)
+  })
+
+  it('returns null on an unknown format', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    const out = await fetchModelCatalog({ url: 'https://x.test/v1/models', format: 'nope', fetchFn })
+    assert.equal(out, null)
+  })
+
+  it('returns null when fetch throws (endpoint down)', async () => {
+    const fetchFn = async () => { throw new Error('ECONNREFUSED') }
+    const out = await fetchModelCatalog({ url: 'https://x.test/v1/models', format: 'openrouter', fetchFn })
+    assert.equal(out, null)
+  })
+})
+
+describe('refreshDiscoveredModels cache + change detection (#5548)', () => {
+  beforeEach(() => _resetModelDiscoveryStateForTests())
+  afterEach(() => _resetModelDiscoveryStateForTests())
+
+  function makeRegistry() {
+    let models = []
+    return {
+      updateModels: (input) => { models = input.map((m) => ({ id: m.value, label: m.displayName, contextWindow: m.contextWindow, fullId: m.value })); return models },
+      getModels: () => models,
+    }
+  }
+
+  it('feeds the registry, applies the catalog, and reports the changed list', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = makeRegistry()
+    let applied = null
+    const out = await refreshDiscoveredModels({
+      id: 'openrouter', url: 'https://x.test/v1/models', format: 'openrouter',
+      registry, applyCatalog: (c) => { applied = c }, fetchFn,
+    })
+    assert.equal(out.length, 2)
+    assert.equal(applied.models.length, 2)
+    assert.equal(applied.pricing['anthropic/claude-sonnet-4'].input, 3)
+  })
+
+  it('returns null (no re-broadcast) within the TTL window', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = makeRegistry()
+    let now = 1000
+    const opts = { id: 'or', url: 'https://x.test/v1/models', format: 'openrouter', registry, fetchFn, now: () => now }
+    const first = await refreshDiscoveredModels(opts)
+    assert.ok(Array.isArray(first))
+    now += 1000 // still inside TTL
+    const second = await refreshDiscoveredModels(opts)
+    assert.equal(second, null, 'second call inside TTL is served from cache')
+    assert.equal(fetchFn.calls.length, 1, 'only one HTTP probe inside the TTL window')
+  })
+
+  it('re-probes after the TTL expires', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = makeRegistry()
+    let now = 1000
+    const opts = { id: 'or2', url: 'https://x.test/v1/models', format: 'openrouter', registry, fetchFn, now: () => now }
+    await refreshDiscoveredModels(opts)
+    now += MODEL_DISCOVERY_CACHE_TTL_MS + 1
+    await refreshDiscoveredModels(opts)
+    assert.equal(fetchFn.calls.length, 2)
+  })
+
+  it('returns null when the model set is unchanged across probes', async () => {
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = makeRegistry()
+    let now = 1000
+    const opts = { id: 'or3', url: 'https://x.test/v1/models', format: 'openrouter', registry, fetchFn, now: () => now }
+    const first = await refreshDiscoveredModels(opts)
+    assert.ok(Array.isArray(first))
+    now += MODEL_DISCOVERY_CACHE_TTL_MS + 1
+    const second = await refreshDiscoveredModels(opts)
+    assert.equal(second, null, 'same model ids → no re-broadcast')
+  })
+})
+
+describe('session class catalog integration (#5548)', () => {
+  beforeEach(() => _resetModelDiscoveryStateForTests())
+  afterEach(() => _resetModelDiscoveryStateForTests())
+
+  function makeClass(extra = {}) {
+    return createAnthropicCompatibleSessionClass({
+      id: 'openrouter', baseUrl: 'https://openrouter.ai/api', defaultModel: 'anthropic/claude-sonnet-4',
+      modelDiscovery: { url: 'https://openrouter.ai/api/v1/models', format: 'openrouter' },
+      ...extra,
+    })
+  }
+
+  it('starts unrestricted (no catalog) — getAllowedModels null pre-discovery', () => {
+    const Cls = makeClass()
+    assert.equal(Cls.getAllowedModels(), null, 'unrestricted until discovery runs')
+    assert.equal(Cls.modelDiscovery.format, 'openrouter')
+  })
+
+  it('after discovery, getAllowedModels returns the catalog ids (tri-state: catalog replaces UNRESTRICTED)', async () => {
+    const Cls = makeClass()
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = { updateModels: (i) => i.map((m) => ({ id: m.value, label: m.displayName, contextWindow: m.contextWindow, fullId: m.value })), getModels() { return [] } }
+    await Cls.refreshModels({ registry, fetchFn })
+    const allowed = Cls.getAllowedModels()
+    assert.deepEqual(allowed.sort(), ['anthropic/claude-sonnet-4', 'qwen/qwen3-coder'])
+  })
+
+  it('after discovery, getModelMetadata returns discovered label + window', async () => {
+    const Cls = makeClass()
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = { updateModels: (i) => i, getModels() { return [] } }
+    await Cls.refreshModels({ registry, fetchFn })
+    const meta = Cls.getModelMetadata('anthropic/claude-sonnet-4')
+    assert.equal(meta.label, 'Anthropic: Claude Sonnet 4')
+    assert.equal(meta.contextWindow, 200000)
+    assert.equal(Cls.getModelMetadata('not-in-catalog'), null, 'catalog miss → null')
+  })
+
+  it('_getPricing returns per-model discovered rates after discovery', async () => {
+    const Cls = makeClass()
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = { updateModels: (i) => i, getModels() { return [] } }
+    await Cls.refreshModels({ registry, fetchFn })
+    const session = new Cls()
+    const sonnetPricing = session._getPricing('anthropic/claude-sonnet-4')
+    assert.equal(sonnetPricing.input, 3)
+    assert.equal(sonnetPricing.output, 15)
+    const qwenPricing = session._getPricing('qwen/qwen3-coder')
+    assert.ok(Math.abs(qwenPricing.input - 0.4) < 1e-9)
+  })
+
+  it('_getPricing falls back to the flat pricing block for an unknown model', async () => {
+    const Cls = makeClass({ pricing: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } })
+    const fetchFn = makeFetch(openRouterBody())
+    const registry = { updateModels: (i) => i, getModels() { return [] } }
+    await Cls.refreshModels({ registry, fetchFn })
+    const session = new Cls()
+    const unknown = session._getPricing('some/unlisted-model')
+    assert.equal(unknown.input, 1)
+    assert.equal(unknown.output, 2)
+  })
+
+  it('refreshModels is a no-op (null) when the entry declares no modelDiscovery', async () => {
+    const Cls = createAnthropicCompatibleSessionClass({ id: 'plain', baseUrl: 'https://x.test/api', defaultModel: 'm1' })
+    const out = await Cls.refreshModels({ fetchFn: makeFetch(openRouterBody()) })
+    assert.equal(out, null)
+    assert.equal(Cls.modelDiscovery, null)
+  })
+})
+
+describe('chroxy providers add openrouter preset (#5548)', () => {
+  it('the preset entry validates cleanly through the config validator', () => {
+    const { entries, warnings } = validateAnthropicCompatibleProviders([
+      { ...OPENROUTER_PRESET, modelDiscovery: { ...OPENROUTER_PRESET.modelDiscovery } },
+    ])
+    assert.deepEqual(warnings, [])
+    assert.equal(entries.length, 1)
+    assert.equal(entries[0].id, 'openrouter')
+    assert.equal(entries[0].baseUrl, 'https://openrouter.ai/api')
+    assert.equal(entries[0].apiKeyEnv, 'OPENROUTER_API_KEY')
+    assert.equal(entries[0].modelDiscovery.format, 'openrouter')
+  })
+
+  it('adds the entry to an empty config', () => {
+    const { config, status } = applyOpenRouterPreset({ port: 8765 })
+    assert.equal(status, 'added')
+    assert.equal(config.port, 8765)
+    assert.equal(config.providers.anthropicCompatible.length, 1)
+    assert.equal(config.providers.anthropicCompatible[0].id, 'openrouter')
+  })
+
+  it('is idempotent — re-adding leaves the existing entry untouched', () => {
+    const { config } = applyOpenRouterPreset({})
+    const { status, config: again } = applyOpenRouterPreset(config)
+    assert.equal(status, 'exists')
+    assert.equal(again.providers.anthropicCompatible.length, 1)
+  })
+
+  it('--force rewrites an existing entry', () => {
+    const base = applyOpenRouterPreset({}).config
+    // Mutate the existing entry, then force back to the preset.
+    base.providers.anthropicCompatible[0].defaultModel = 'something/else'
+    const { status, config } = applyOpenRouterPreset(base, { force: true })
+    assert.equal(status, 'updated')
+    assert.equal(config.providers.anthropicCompatible[0].defaultModel, OPENROUTER_PRESET.defaultModel)
+  })
+
+  it('promotes a legacy providers id-array to the object form without dropping siblings', () => {
+    const { config, status, convertedLegacyArray } = applyOpenRouterPreset({ port: 8765, providers: ['claude-sdk'] })
+    assert.equal(status, 'added')
+    assert.equal(convertedLegacyArray, true)
+    assert.equal(Array.isArray(config.providers), false)
+    assert.equal(config.providers.anthropicCompatible[0].id, 'openrouter')
+  })
+
+  it('preserves a sibling anthropicCompatible entry', () => {
+    const existing = { providers: { anthropicCompatible: [{ id: 'zai-glm', baseUrl: 'https://api.z.ai/api/anthropic', defaultModel: 'glm-4.7' }] } }
+    const { config } = applyOpenRouterPreset(existing)
+    const ids = config.providers.anthropicCompatible.map((e) => e.id)
+    assert.deepEqual(ids.sort(), ['openrouter', 'zai-glm'])
+  })
+
+  it('runProvidersAddOpenRouter writes via the injected writeFile (temp path, never real home)', () => {
+    let written = null
+    const result = runProvidersAddOpenRouter({}, {
+      configFilePath: '/tmp/does-not-matter.json',
+      existsFn: () => true,
+      readFileFn: () => JSON.stringify({ port: 8765 }),
+      writeFileFn: (path, contents) => { written = { path, contents } },
+      logFn: () => {},
+    })
+    assert.equal(result.status, 'added')
+    assert.equal(result.written, true)
+    assert.equal(written.path, '/tmp/does-not-matter.json')
+    const parsed = JSON.parse(written.contents)
+    assert.equal(parsed.providers.anthropicCompatible[0].id, 'openrouter')
+  })
+
+  it('runProvidersAddOpenRouter does not write when the entry already exists', () => {
+    let wrote = false
+    const existing = JSON.stringify({ providers: { anthropicCompatible: [{ ...OPENROUTER_PRESET }] } })
+    const result = runProvidersAddOpenRouter({}, {
+      configFilePath: '/tmp/x.json',
+      existsFn: () => true,
+      readFileFn: () => existing,
+      writeFileFn: () => { wrote = true },
+      logFn: () => {},
+    })
+    assert.equal(result.status, 'exists')
+    assert.equal(result.written, false)
+    assert.equal(wrote, false)
+  })
+
+  it('runProvidersAddOpenRouter errors when no config exists', () => {
+    const result = runProvidersAddOpenRouter({}, {
+      configFilePath: '/tmp/missing.json',
+      existsFn: () => false,
+      writeFileFn: () => { throw new Error('should not write') },
+      logFn: () => {},
+    })
+    assert.equal(result.status, 'no-config')
+    assert.equal(result.written, false)
+  })
+})


### PR DESCRIPTION
## Summary

OpenRouter already works via `providers.anthropicCompatible` (#5458) — its `/v1/messages` accepts the Anthropic format for every platform model. What was missing was ergonomics: the user hand-edited config.json, typed model ids blind from a catalog of hundreds, and got $0 cost reporting. This PR adds the ergonomics on top, **without a new session class**:

1. **Preset** — `chroxy providers add openrouter` writes the `anthropicCompatible` entry (baseUrl `https://openrouter.ai/api`, `OPENROUTER_API_KEY` env / `openrouterApiKey` credential seam, sensible default model, `modelDiscovery` block). Idempotent: re-running is a no-op; `--force` rewrites to the current preset. `-c/--config` targets a non-default config path.
2. **Model catalog discovery** — generalized as a `modelDiscovery: { url, format }` capability on `anthropicCompatible` entries (not OpenRouter-specific). `GET /api/v1/models` feeds the existing model picker.
3. **Pricing autofill** — per-model rates from the discovered catalog so sessions report real cost instead of $0.
4. **Docs** — OpenRouter promoted from the recipe paragraph to its own section alongside Ollama.

## Design

**`modelDiscovery` generalization.** A capability of any `anthropicCompatible` entry, declared in config:

```json
"modelDiscovery": { "url": "https://openrouter.ai/api/v1/models", "format": "openrouter" }
```

`format` is `openrouter` (OpenAI-ish `{ data: [...] }` list carrying per-token pricing) or `openai` (bare `/v1/models`, ids only — LM Studio / vLLM can opt in). Format adapters live in `model-discovery.js`; the supported list is a single exported source of truth (`MODEL_DISCOVERY_FORMATS`) shared by the validator and the fetch adapters. Validation (URL must be http(s), no embedded credentials, known format) lives in `anthropic-compatible-config.js` and drops a half-configured entry rather than silently degrading.

**Cache pattern (mirrors Ollama #5445).** `refreshDiscoveredModels` reuses the `refreshOllamaModels` contract — resolves the refreshed list on *change*, null on no-change / failure / TTL-cache — so it slots straight into the existing generic `scheduleProviderModelsRefresh` hook in `ws-history.js` (any provider class with a static `refreshModels()` already gets its picker re-pushed). Differences from Ollama: anthropicCompatible entries are many-and-configurable, so the TTL cache is keyed **per entry id** (a Map of slots) rather than module scalars; the TTL is 5 min (a remote catalog of hundreds of models changes slowly) vs Ollama's 30s. Same in-flight dedup and graceful-failure-cached-too posture (no retry storm).

**Validation interplay (#5458 tri-state).** A discovered catalog is **authoritative** for that entry: once `applyCatalog` runs, `getAllowedModels()` returns the discovered ids (replacing the `PROVIDER_MODELS_UNRESTRICTED` pass-through), and `getModelMetadata()` returns the discovered label + context window. Until the first probe resolves (cold boot), `defaultModel` works immediately and the endpoint stays unrestricted. The session class holds the catalog in per-class closure state populated by discovery; `_getPricing(model)` consults the per-model table (falling back to the flat `pricing` block, then honest $0).

**Dashboard affordance — deliberately out of scope.** The issue allowed a low-cost "Add OpenRouter" button in the Provider Credentials pane *if* it didn't balloon scope. It would require a new authenticated server HTTP route that writes config.json, a new WS protocol message, and cross-package dashboard UI + tests — a meaningful scope increase. Left out; the CLI preset covers point 1. Flagged here per the issue's guidance.

## Test plan

New `tests/openrouter-ergonomics.test.js` (35 tests, all green) — never hits the network (injected fetch) and never writes real `~/.chroxy` (injected writeFile + temp paths):

- `modelDiscovery` config validation: valid block normalizes; absent → null; unknown format / non-http url / embedded credentials / non-object → entry dropped with warning; unknown sub-key warns-but-accepts.
- `fetchModelCatalog`: openrouter parse (models + per-MTok pricing conversion), openai parse (ids only), Bearer header on/off, null on non-2xx / bad shape / unknown format / thrown fetch.
- `refreshDiscoveredModels`: registry feed + catalog apply, TTL cache (one probe inside window, re-probe after), no-rebroadcast on unchanged set.
- Session class: unrestricted pre-discovery → catalog ids post-discovery (tri-state), discovered metadata, per-model `_getPricing` + flat fallback, no-op when `modelDiscovery` absent.
- CLI preset: entry validates through `validateAnthropicCompatibleProviders`; add to empty config; idempotent re-add; `--force` rewrite; legacy id-array promotion; sibling-entry preservation; injected-write path; no-write-when-exists; no-config error.

Plus: existing `anthropic-compatible.test.js` / `config.test.js` / `providers.test.js` / `models-per-provider.test.js` / `ollama-session.test.js` / `byok-session.test.js` / `cli-init-cmd.test.js` all still green (382 tests). All custom shell lints pass (`lint-logger-session-scoping`, `lint-session-opt-forwarding`, `lint-tests-state-file-path`). `npm run lint` (eslint) clean on touched files (0 errors). End-to-end smoke test: the CLI writes a config that validates through `config.js` with zero warnings, and re-running is idempotent.

Closes #5548