### PR TITLE
chore: bump version to 0.9.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.46] - 2026-06-11
+
+The control-surface release. The Control Room becomes the dashboard's single operational home: an **Integrations tab** (repo-memory/repo-relay observability and actions), a **Settings tab** converging every scattered preference surface, and per-repo **Open-session** buttons. Connecting gets dramatically easier for camera-less devices (**pairing epic #5509**: approval-gated pairing, one-click LAN pair, typeable short codes, Discord delivery) and faster once connected (**latency epic #5514**: adaptive delta flushing, memoized/virtualized chat, LAN auto-prefer with tunnel fallback). Plus: right-click **session summarize & carry-over**, first-class **OpenRouter** support, and accurate Discord turn-edge status for external sessions.
+
+### Added
+
+- **Control Room Integrations tab (#5498):** per-repo repo-memory status with a Reindex action (#5503, #5504), repo-relay observability — workflow presence, version drift, run status (#5505) — and re-running failed repo-relay runs (#5506).
+- **Control Room Settings tab (#5544):** single home for appearance, session defaults, shortcuts, provider credentials/BYOK, notification preferences, and desktop options; gear, Cmd+,, and Tauri menus redirect to it (#5549).
+- **Per-repo Open-session button (#5507):** quick-start a session in any surveyed repo from the Project status tab, with model + permission pickers (#5508).
+- **Summarize & carry a session (#5547):** right-click a session (or project group) in the sidebar → server-side one-shot continuation brief from the persisted history → create-session modal opens with the summary seeded editable in the composer; Copy transcript joins the same menu (#5551).
+- **Pairing epic #5509 — camera-less connection:**
+  - Pairing-approval primitive — approve new devices from the dashboard (#5527).
+  - One-click Request-to-pair on discovered LAN daemons (#5528).
+  - Typeable 8-char short pairing code — host display + dashboard entry (#5531).
+  - Discord pairing-link delivery — host-triggered, approval-gated (#5538).
+- **OpenRouter ergonomics (#5548):** `chroxy providers add openrouter` preset, generic `modelDiscovery: { url, format }` catalog discovery for anthropic-compatible entries (openrouter + openai formats), and per-model pricing autofill so OpenRouter sessions report real cost (#5550).
+- **Latency instrumentation (#5520):** `serverTs` on stream messages, stamped pong, token-to-render summaries.
+- **Turn-edge ingest (#5541):** `UserPromptSubmit`/`Stop` hook emitters (#5542) + ingest types (#5545) so external-session Discord status flips working/ready on real turn boundaries.
+
+### Changed
+
+- **Streaming feels live (epic #5514):** memoized bubbles, adaptive delta flush keyed on EWMA RTT, tighter single-client coalescing (#5532); chat list virtualization (#5534); terminal WebView writes via postMessage (#5529); mobile auto-prefers a verified direct LAN connection with tunnel fallback (#5535).
+- Control Room tabs auto-fetch on open with a staleness guard — no more manual Refresh on entry (#5546).
+
+### Fixed
+
+- Discord embed: markdown escaped in free-text fields (#5525), subagent counts aggregated per project (#5496), scheduled-wakeup push body rendered as relative time (#5522), webhook URL resolved from encrypted credentials.json (#5523).
+- launchd/systemd service starts out of the box (#5526); cloudflared 502/530 treated as tunnel-routable (#5521).
+- claude-hooks installer hardened against malformed settings.json (#5524).
+
 ## [0.9.45] - 2026-06-10
 
 The notifications release. Epic #5413 lands in full: chroxy now maintains a live per-project **Discord status embed** for any Claude Code session on the machine — not just chroxy-managed ones — via the new `@chroxy/claude-hooks` package (stateless hook emitters + idempotent installer), a `POST /api/events` ingest endpoint with its own daemon-level token class, and server-side subagent counting. Alongside it: a deep **claude-tui reliability wave** (~30 fixes off the failure-readiness audit, from crash containment to PTY redaction to restart-resume), **provider expansion** (local Ollama models with auto-discovery, plus any Anthropic-compatible endpoint via config), and the desktop app finally **surfaces server-startup failures** on the loading screen instead of spinning forever.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16876,7 +16876,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16929,7 +16929,7 @@
     },
     "packages/claude-hooks": {
       "name": "@chroxy/claude-hooks",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "license": "MIT",
       "bin": {
         "chroxy-hooks": "bin/chroxy-hooks.js"
@@ -16943,7 +16943,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17053,11 +17053,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.45"
+      "version": "0.9.46"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17068,7 +17068,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17130,7 +17130,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.45",
+    "version": "0.9.46",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.45</string>
+    <string>0.9.46</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/claude-hooks",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "Stateless Claude Code hook emitters for chroxy's POST /api/events ingest",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.45"
+version = "0.9.46"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.45"
+version = "0.9.46"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.45",
+      "version": "0.9.46",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary
Version bump `0.9.45` → `0.9.46` via `scripts/bump-version.sh` (all 11 version-bearing files in lockstep, verified) + full CHANGELOG section for the release.

## Release highlights
- Control Room Integrations tab (#5498) + Settings tab (#5544) + per-repo Open-session (#5507)
- Summarize & carry a session (#5547)
- Pairing epic #5509 (approval primitive, LAN one-click, typeable codes, Discord delivery)
- Latency epic #5514 (adaptive flush, memoized/virtualized chat, LAN auto-prefer)
- OpenRouter ergonomics (#5548), turn-edge Discord status (#5541)

## Test plan
- `grep -h '"version"' package.json packages/*/package.json` → 8× 0.9.46
- CI green across packages