### PR TITLE
perf(app): swarm-audit phase-1 — single health probe, deviceId prewarm, reconnect dedup

### DIFF
--- a/packages/app/src/__tests__/store/connection-audit-phase1.test.ts
+++ b/packages/app/src/__tests__/store/connection-audit-phase1.test.ts
@@ -1,0 +1,368 @@
+/**
+ * #5555 — swarm-audit phase-1 connect-path quick wins.
+ *
+ * Covers the three fixes landed together:
+ *   1. Single `/health` probe on the auto-connect path (connectAuto threads the
+ *      endpoint selector's fresh probe into connect() so we don't probe twice).
+ *   2. getDeviceId() prewarm — the auth frame in onopen is not gated on a cold
+ *      SecureStore read.
+ *   3. Per-socket reconnect-dedup guard — a paired onclose + onerror for one
+ *      transport drop arms exactly one reconnect.
+ *
+ * Mocks global.fetch + global.WebSocket and expo-secure-store, mirroring the
+ * fake-WebSocket / fake-timer patterns in connection-connect.test.ts.
+ */
+import type { SavedConnection } from '@chroxy/store-core';
+
+// Mock expo-secure-store with real jest.fn()s so getDeviceId()'s keychain read
+// is controllable per-test (slow read for the prewarm ordering assertion).
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { clearAllCallbacks } from '../../store/imperative-callbacks';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flush all pending microtasks (promise chains). */
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) =>
+    jest.requireActual<typeof globalThis>('timers').setImmediate(resolve),
+  );
+}
+
+function mockResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  } as unknown as Response;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: ((event?: unknown) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onmessage: ((event: unknown) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+/** Installs a MockWebSocket that records every instance it constructs. */
+function installMockWebSocket(): { instances: FakeSocket[]; restore: () => void } {
+  const instances: FakeSocket[] = [];
+  const Original = global.WebSocket;
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 0;
+    onopen: (() => void) | null = null;
+    onclose: ((event?: unknown) => void) | null = null;
+    onerror: ((event?: unknown) => void) | null = null;
+    onmessage: ((event: unknown) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn();
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this as unknown as FakeSocket);
+    }
+  };
+  return { instances, restore: () => { global.WebSocket = Original; } };
+}
+
+/**
+ * Counts probe fetches. Both the endpoint selector (`probeHealth` → GET
+ * `…/health`) and connect()'s own pre-WS check (GET of the bare origin) are
+ * liveness probes against the same host, so we count every fetch — the whole
+ * point of FIX 1 is that exactly one of them runs per connect.
+ */
+function countHealthCalls(fetchMock: jest.Mock): number {
+  return fetchMock.mock.calls.length;
+}
+
+// ---------------------------------------------------------------------------
+// Store reset
+// ---------------------------------------------------------------------------
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  clearAllCallbacks();
+  __resetDeviceIdCacheForTests();
+  (SecureStore.getItemAsync as jest.Mock).mockReset();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('dev-id-123');
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+  useConnectionStore.setState({
+    serverErrors: [],
+    connectedClients: [],
+    myClientId: null,
+    primaryClientId: null,
+    sessionStates: {},
+    activeSessionId: null,
+    socket: null,
+    shutdownReason: null,
+    restartEtaMs: null,
+    restartingSince: null,
+  });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+  });
+});
+
+afterEach(() => {
+  useConnectionStore.getState().disconnect();
+  global.fetch = originalFetch;
+  jest.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// FIX 1 — single /health probe on the auto-connect path
+// ---------------------------------------------------------------------------
+
+describe('connectAuto() single health probe (#5555)', () => {
+  // A verified LAN record makes the selector probe `ws://…/health` once. The
+  // probe result is threaded into connect(), which must NOT probe again.
+  const lanSaved: SavedConnection = {
+    url: 'wss://tunnel.example.com',
+    token: 'tok',
+    tunnelUrl: 'wss://tunnel.example.com',
+    lanUrl: 'ws://192.168.1.50:8765',
+    lanVerified: true,
+  };
+
+  it('probes /health exactly once across selector + connect()', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    await useConnectionStore.getState().connectAuto(lanSaved, { silent: true });
+    await flushPromises();
+
+    // One probe total: the selector's LAN probe. connect() reused it.
+    expect(countHealthCalls(fetchMock)).toBe(1);
+    // …and the WS was opened against the LAN url (proves we didn't bail out).
+    expect(ws.instances.length).toBe(1);
+    expect(ws.instances[0].url).toBe('ws://192.168.1.50:8765');
+
+    ws.restore();
+  });
+
+  it('still probes once on the tunnel path (no precheck → connect() probes)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    // preferTunnel → selector returns the tunnel with NO healthPrecheck, so
+    // connect() runs its own (single) health check.
+    await useConnectionStore.getState().connectAuto(lanSaved, {
+      silent: true,
+      preferTunnel: true,
+    });
+    await flushPromises();
+
+    expect(countHealthCalls(fetchMock)).toBe(1);
+    expect(ws.instances[0].url).toBe('wss://tunnel.example.com');
+
+    ws.restore();
+  });
+
+  it('restarting detection still works on the normal (non-precheck) path', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(mockResponse(200, { status: 'restarting', restartEtaMs: 4000 }));
+    global.fetch = fetchMock;
+
+    // Direct connect() (no precheck) — the health body says restarting, so the
+    // restart branch must fire.
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    await flushPromises();
+
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_restarting');
+    expect(useConnectionStore.getState().restartEtaMs).toBe(4000);
+  });
+
+  it('does not honor a stale precheck (older than the freshness window)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    // A precheck timestamped well in the past must be ignored — connect() runs
+    // its own probe so we don't open a WS against a host whose liveness is stale.
+    useConnectionStore.getState().connect('ws://192.168.1.50:8765', 'tok', {
+      silent: true,
+      healthPrecheck: { ts: Date.now() - 60_000, status: 'ok' },
+    });
+    await flushPromises();
+
+    expect(countHealthCalls(fetchMock)).toBe(1);
+    ws.restore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FIX 2 — getDeviceId() prewarm
+// ---------------------------------------------------------------------------
+
+describe('getDeviceId() prewarm (#5555)', () => {
+  // getDeviceId() memoizes its result at module scope, so a "cold read"
+  // ordering assertion needs a freshly-imported module. jest.isolateModulesAsync
+  // gives each test its own registry → a null device-id memo.
+
+  it('kicks off the SecureStore read at connect() start, before WS open', async () => {
+    // beforeEach already cleared the device-id memo, so this is a cold read.
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    // Slow SecureStore read so we can observe the auth frame waiting on it.
+    const slowRead = deferred<string>();
+    (SecureStore.getItemAsync as jest.Mock).mockReturnValue(slowRead.promise);
+
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    await flushPromises();
+
+    // The prewarm fires inside connect() (before the WS handshake), so the
+    // SecureStore read is already in flight by the time the socket exists.
+    expect(SecureStore.getItemAsync).toHaveBeenCalled();
+    expect(ws.instances.length).toBe(1);
+
+    // onopen can't send the auth frame until the (prewarmed) read resolves.
+    ws.instances[0].readyState = 1;
+    ws.instances[0].onopen?.();
+    await flushPromises();
+    expect(ws.instances[0].send).not.toHaveBeenCalled(); // still awaiting SecureStore
+
+    slowRead.resolve('prewarmed-id');
+    await flushPromises();
+
+    expect(ws.instances[0].send).toHaveBeenCalledTimes(1);
+    const frame = JSON.parse(ws.instances[0].send.mock.calls[0][0] as string);
+    expect(frame.type).toBe('auth');
+    expect(frame.deviceInfo.deviceId).toBe('prewarmed-id');
+
+    ws.restore();
+  });
+
+  it('auth frame resolves instantly when the id is already memoized', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    // The mock resolves immediately; this connect warms the memo.
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('cached-id');
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    await flushPromises();
+
+    const first = ws.instances[ws.instances.length - 1];
+    first.readyState = 1;
+    first.onopen?.();
+    await flushPromises();
+    expect(first.send).toHaveBeenCalled();
+
+    ws.restore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FIX 3 — per-socket reconnect dedup (ported from dashboard #3624)
+// ---------------------------------------------------------------------------
+
+describe('reconnect dedup guard (#5555 / #3624)', () => {
+  async function openConnectedSocket() {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    await flushPromises();
+
+    // Simulate a fully-established connection so onclose/onerror take the
+    // auto-reconnect branch (wasConnected === true).
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+    return { ws, fetchMock };
+  }
+
+  it('onclose + onerror for one drop arm exactly one reconnect', async () => {
+    const { ws } = await openConnectedSocket();
+    const socket = ws.instances[0];
+    const beforeCount = ws.instances.length;
+
+    // Fire BOTH handlers back-to-back for the same transport drop (error → close
+    // is the common browser/RN ordering, but order shouldn't matter).
+    socket.onerror?.({ message: 'boom' });
+    socket.onclose?.({ code: 1006 });
+
+    // Advance past both delays (ERROR=2000, AUTO=1500) plus margin.
+    jest.advanceTimersByTime(5000);
+    await flushPromises();
+
+    // Exactly one new socket created by the single reconnect.
+    const newSockets = ws.instances.length - beforeCount;
+    expect(newSockets).toBe(1);
+
+    ws.restore();
+  });
+
+  it('reverse ordering (close → error) also arms exactly one reconnect', async () => {
+    const { ws } = await openConnectedSocket();
+    const socket = ws.instances[0];
+    const beforeCount = ws.instances.length;
+
+    socket.onclose?.({ code: 1006 });
+    socket.onerror?.({ message: 'boom' });
+
+    jest.advanceTimersByTime(5000);
+    await flushPromises();
+
+    expect(ws.instances.length - beforeCount).toBe(1);
+    ws.restore();
+  });
+
+  it('a fresh socket after reconnect can still arm its own retry', async () => {
+    const { ws } = await openConnectedSocket();
+    const first = ws.instances[0];
+
+    // First drop → one reconnect.
+    first.onerror?.({ message: 'boom' });
+    first.onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(5000);
+    await flushPromises();
+
+    expect(ws.instances.length).toBe(2);
+    const second = ws.instances[1];
+    // Mark the new socket connected, then drop it — its own per-socket flag is
+    // fresh, so it must arm a retry despite the global phase already being
+    // 'reconnecting'-ish.
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+    second.onerror?.({ message: 'boom again' });
+    second.onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(5000);
+    await flushPromises();
+
+    expect(ws.instances.length).toBe(3);
+    ws.restore();
+  });
+});

--- a/packages/app/src/__tests__/utils/endpoint-selector.test.ts
+++ b/packages/app/src/__tests__/utils/endpoint-selector.test.ts
@@ -83,7 +83,9 @@ describe('selectConnectEndpoint', () => {
       lanUrl: 'ws://192.168.1.5:8765', lanVerified: true,
     };
     const res = await selectConnectEndpoint(saved);
-    expect(res).toEqual({ url: 'ws://192.168.1.5:8765', path: 'lan' });
+    expect(res).toMatchObject({ url: 'ws://192.168.1.5:8765', path: 'lan' });
+    // #5555 — a successful LAN probe surfaces a healthPrecheck for connect() to reuse.
+    expect(res.healthPrecheck).toEqual({ ts: expect.any(Number), status: 'ok' });
     expect(probeHealth).toHaveBeenCalledWith('ws://192.168.1.5:8765', expect.any(Number));
   });
 
@@ -122,7 +124,8 @@ describe('selectConnectEndpoint', () => {
       lanUrl: 'ws://192.168.1.5:8765', lanVerified: true,
     };
     const res = await selectConnectEndpoint(saved);
-    expect(res).toEqual({ url: 'ws://192.168.1.5:8765', path: 'lan' });
+    expect(res).toMatchObject({ url: 'ws://192.168.1.5:8765', path: 'lan' });
+    expect(res.healthPrecheck).toEqual({ ts: expect.any(Number), status: 'ok' });
   });
 
   it('falls back to url when LAN-only record loses its LAN endpoint', async () => {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -242,6 +242,15 @@ async function getDeviceId(): Promise<string> {
   return id;
 }
 
+/**
+ * Test-only: clear the memoized device id so a test can exercise a *cold*
+ * SecureStore read (e.g. the #5555 prewarm-ordering assertion). No-op /
+ * harmless in production — nothing calls it outside tests.
+ */
+export function __resetDeviceIdCacheForTests(): void {
+  _cachedDeviceId = null;
+}
+
 function getDeviceInfo(): { deviceName: string | null; deviceType: 'phone' | 'tablet' | 'desktop' | 'unknown'; platform: string } {
   const deviceType: 'phone' | 'tablet' | 'desktop' | 'unknown' =
     Device.deviceType === Device.DeviceType.PHONE ? 'phone' :
@@ -693,7 +702,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     ) {
       return;
     }
-    get().connect(selection.url, saved.token, { silent: options?.silent });
+    get().connect(selection.url, saved.token, {
+      silent: options?.silent,
+      // #5555 — the selector already probed `/health` against this exact URL
+      // (LAN path only). Thread the fresh result through so connect() doesn't
+      // probe the same host a second time before opening the WS.
+      healthPrecheck: selection.healthPrecheck,
+    });
   },
 
   // Initial connection uses bounded retries (MAX_RETRIES) with exponential backoff.
@@ -701,11 +716,31 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // Auto-reconnect (socket.onclose) calls connect() with _retryCount=0, resetting
   // the retry budget — intentional, since established connections should recover
   // aggressively after transient drops (tunnel blips, server restarts, etc.).
-  connect: (url: string, token: string, options?: { silent?: boolean; _retryCount?: number }) => {
+  connect: (
+    url: string,
+    token: string,
+    options?: {
+      silent?: boolean;
+      _retryCount?: number;
+      // #5555 — a fresh `/health` result from connectAuto's endpoint selector.
+      // When recent (≤ HEALTH_PRECHECK_MAX_AGE_MS) and `status: 'ok'`, connect()
+      // skips its own redundant probe and opens the WS directly. Only ever
+      // carries 'ok' (the selector falls back to the tunnel for a restarting /
+      // unreachable box), so the restarting-detection path is never bypassed.
+      healthPrecheck?: { ts: number; status: 'ok' };
+    },
+  ) => {
     const _retryCount = options?._retryCount ?? 0;
     const silent = options?.silent ?? false;
     const MAX_RETRIES = 5;
     const RETRY_DELAYS = [1000, 2000, 3000, 5000, 8000];
+    // Honor a precheck only on the first attempt (retries must re-probe), and
+    // only when it's recent enough that the host's liveness hasn't gone stale.
+    const HEALTH_PRECHECK_MAX_AGE_MS = 2000;
+    const freshPrecheck =
+      _retryCount === 0 &&
+      options?.healthPrecheck?.status === 'ok' &&
+      Date.now() - options.healthPrecheck.ts <= HEALTH_PRECHECK_MAX_AGE_MS;
 
     // Detect if connecting to a different server — clear old session data + queue
     const currentUrl = useConnectionLifecycleStore.getState().wsUrl;
@@ -743,6 +778,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
     if (_retryCount > 0) {
       console.log(`[ws] Connection attempt ${_retryCount + 1}/${MAX_RETRIES + 1}...`);
+    }
+
+    // #5555 — prewarm the device ID off the critical path. The `auth` frame in
+    // `socket.onopen` awaits getDeviceId() (an async SecureStore read, memoized
+    // only after its first call). Kick it off here so the keychain read overlaps
+    // the health fetch + WS handshake; by the time onopen fires the cached value
+    // resolves instantly. `.catch` swallows — getDeviceId never rejects (it
+    // falls back to a generated id) but we keep this defensive so a stray
+    // rejection can't surface as an unhandled-promise warning.
+    void getDeviceId().catch(() => {});
+
+    // #5555 — fast path: connectAuto already probed `/health` against this exact
+    // URL and the result is fresh + ok. Skip the redundant GET and open the WS
+    // directly so one connect == one probe. (Retries and the manual paths carry
+    // no precheck, so they still run the full health check below — including the
+    // `restarting` detection.)
+    if (freshPrecheck) {
+      if (myAttemptId !== connectionAttemptId) return;
+      console.log('[ws] Reusing endpoint-selector health probe, connecting WebSocket...');
+      _connectWebSocket();
+      return;
     }
 
     // HTTP health check before WebSocket — verify tunnel is up
@@ -833,9 +889,37 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     setPendingKeyPair(null);
     const socket = new WebSocket(url);
 
+    // #3624 (ported from dashboard) — shared reconnect scheduler for both
+    // onclose and onerror. A single transport drop fires `error` → `close` on
+    // most WebSocket implementations, so without dedupe we'd queue two
+    // setTimeouts for one underlying failure. Previously mobile only avoided the
+    // double-reconnect by accident: the staggered AUTO_RECONNECT_DELAY (1500ms)
+    // vs ERROR_RECONNECT_DELAY (2000ms) delays plus the connectionAttemptId
+    // bump on the first-firing timer cancelled the second — timing-dependent,
+    // not a design guarantee.
+    //
+    // A per-socket flag (not phase-only dedupe) is correct here: each new socket
+    // gets a fresh scheduler with `reconnectScheduled = false`, so a *new*
+    // socket's failure mid-reconnect (when the global phase is already
+    // 'reconnecting') can still arm its own retry timer. The flag is bounded to
+    // this socket's lifetime. Delay semantics are preserved by passing each
+    // handler's original delay; first-write-wins on the reconnecting phase.
+    let reconnectScheduled = false;
+    const scheduleReconnect = (delayMs: number): void => {
+      if (reconnectScheduled) return;
+      reconnectScheduled = true;
+      setTimeout(() => {
+        if (myAttemptId !== connectionAttemptId) return;
+        get().connect(url, token);
+      }, delayMs);
+    };
+
     socket.onopen = () => {
       // Include device info in auth for multi-client awareness
       const info = getDeviceInfo();
+      // #5555 — getDeviceId() is prewarmed at the top of connect(), so this
+      // await point resolves instantly (cached) and the auth frame is not gated
+      // on a cold SecureStore read. This `.then` stays as the await point.
       void getDeviceId().then((deviceId) => {
         if (socket.readyState === WebSocket.OPEN) {
           // Use pairing flow when pendingPairingId is set (from QR scan)
@@ -927,10 +1011,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         if (closeMsg !== null) {
           useConnectionLifecycleStore.getState().setConnectionError(closeMsg, 0);
         }
-        setTimeout(() => {
-          if (myAttemptId !== connectionAttemptId) return;
-          get().connect(url, token);
-        }, AUTO_RECONNECT_DELAY);
+        // #3624 — dedup via the per-socket guard so a paired error → close
+        // sequence arms exactly one retry. Preserves the AUTO_RECONNECT_DELAY.
+        scheduleReconnect(AUTO_RECONNECT_DELAY);
       } else {
         // Connection dropped before it ever reached "connected" state. Previously
         // we silently marked as disconnected, swallowing the real close reason
@@ -962,13 +1045,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // Auto-reconnect on unexpected WS error
       if (disconnectedAttemptId !== myAttemptId) {
-        console.log(`[ws] WebSocket error (${detail || 'no detail'}), reconnecting...`);
-        useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
-        useConnectionLifecycleStore.getState().setConnectionError(errorMsg, 0);
-        setTimeout(() => {
-          if (myAttemptId !== connectionAttemptId) return;
-          get().connect(url, token);
-        }, ERROR_RECONNECT_DELAY);
+        // #3624 — if onclose already armed the retry for this same transport
+        // drop (error → close, or close → error), `scheduleReconnect` no-ops and
+        // we skip the phase/error writes too. That preserves first-write-wins on
+        // connectionError so a close-code-specific banner isn't clobbered by the
+        // generic error copy.
+        if (!reconnectScheduled) {
+          console.log(`[ws] WebSocket error (${detail || 'no detail'}), reconnecting...`);
+          useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
+          useConnectionLifecycleStore.getState().setConnectionError(errorMsg, 0);
+        }
+        scheduleReconnect(ERROR_RECONNECT_DELAY);
       }
     };
     } // end _connectWebSocket

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -219,9 +219,16 @@ let searchTimeoutId: ReturnType<typeof setTimeout> | undefined;
 // Stable device ID persisted across sessions
 const STORAGE_KEY_DEVICE_ID = 'chroxy_device_id';
 let _cachedDeviceId: string | null = null;
+// #5555 — memoize the *in-flight* read, not just the resolved string. The #5555
+// prewarm kicks getDeviceId() off at connect() start and `socket.onopen` calls
+// it again; on a cold first launch (empty/unavailable storage) caching only the
+// resolved value would let the two overlapping calls each pass the empty-cache
+// check and generate *different* random IDs (a race onto inconsistent deviceIds
+// within one connection). Sharing the promise collapses concurrent callers onto
+// a single SecureStore read + single generated id.
+let _deviceIdPromise: Promise<string> | null = null;
 
-async function getDeviceId(): Promise<string> {
-  if (_cachedDeviceId) return _cachedDeviceId;
+async function readOrCreateDeviceId(): Promise<string> {
   try {
     const stored = await SecureStore.getItemAsync(STORAGE_KEY_DEVICE_ID);
     if (stored) {
@@ -242,13 +249,30 @@ async function getDeviceId(): Promise<string> {
   return id;
 }
 
+function getDeviceId(): Promise<string> {
+  if (_cachedDeviceId) return Promise.resolve(_cachedDeviceId);
+  // Reuse an in-flight read so the prewarm and the onopen await share one result.
+  if (_deviceIdPromise) return _deviceIdPromise;
+  _deviceIdPromise = readOrCreateDeviceId();
+  // Drop the in-flight handle once settled; the resolved id is now in
+  // `_cachedDeviceId`, so the next caller short-circuits at the top. On
+  // rejection (it shouldn't — readOrCreateDeviceId never throws) clear it too so
+  // a later call can retry rather than replaying a poisoned promise.
+  void _deviceIdPromise.finally(() => {
+    _deviceIdPromise = null;
+  });
+  return _deviceIdPromise;
+}
+
 /**
- * Test-only: clear the memoized device id so a test can exercise a *cold*
- * SecureStore read (e.g. the #5555 prewarm-ordering assertion). No-op /
- * harmless in production — nothing calls it outside tests.
+ * Test-only: clear the memoized device id (resolved value AND any in-flight
+ * read) so a test can exercise a *cold* SecureStore read (e.g. the #5555
+ * prewarm-ordering assertion). No-op / harmless in production — nothing calls it
+ * outside tests.
  */
 export function __resetDeviceIdCacheForTests(): void {
   _cachedDeviceId = null;
+  _deviceIdPromise = null;
 }
 
 function getDeviceInfo(): { deviceName: string | null; deviceType: 'phone' | 'tablet' | 'desktop' | 'unknown'; platform: string } {
@@ -704,9 +728,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     get().connect(selection.url, saved.token, {
       silent: options?.silent,
-      // #5555 — the selector already probed `/health` against this exact URL
-      // (LAN path only). Thread the fresh result through so connect() doesn't
-      // probe the same host a second time before opening the WS.
+      // #5555 — the selector already ran a liveness probe (`/health`) against
+      // this exact URL (LAN path only). Thread the fresh result through so
+      // connect() doesn't re-check the same host before opening the WS.
       healthPrecheck: selection.healthPrecheck,
     });
   },
@@ -789,10 +813,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // rejection can't surface as an unhandled-promise warning.
     void getDeviceId().catch(() => {});
 
-    // #5555 — fast path: connectAuto already probed `/health` against this exact
-    // URL and the result is fresh + ok. Skip the redundant GET and open the WS
-    // directly so one connect == one probe. (Retries and the manual paths carry
-    // no precheck, so they still run the full health check below — including the
+    // #5555 — fast path: connectAuto's selector already probed `/health` against
+    // this exact URL and the result is fresh + ok. Skip connect()'s own pre-WS
+    // liveness check below (the `fetch(httpUrl)` GET of the bare origin — the
+    // server answers both `/` and `/health`) and open the WS directly so one
+    // connect == one round-trip. (Retries and the manual paths carry no
+    // precheck, so they still run the full check below — including the
     // `restarting` detection.)
     if (freshPrecheck) {
       if (myAttemptId !== connectionAttemptId) return;

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -366,7 +366,13 @@ export interface UIViewData {
  * start.
  */
 export interface ConnectionActions {
-  connect: (url: string, token: string, options?: { silent?: boolean; _retryCount?: number }) => void;
+  connect: (
+    url: string,
+    token: string,
+    // #5555 — `healthPrecheck` carries connectAuto's fresh `/health` result so
+    // connect() can skip its own redundant probe (one connect == one probe).
+    options?: { silent?: boolean; _retryCount?: number; healthPrecheck?: { ts: number; status: 'ok' } },
+  ) => void;
   /**
    * #5518 — auto-select the best endpoint for a saved connection (races a
    * `/health` probe against the verified LAN candidate, else tunnel) then

--- a/packages/app/src/utils/endpoint-selector.ts
+++ b/packages/app/src/utils/endpoint-selector.ts
@@ -50,6 +50,17 @@ export interface EndpointSelection {
   url: string;
   /** Whether the chosen URL is the direct LAN path or the tunnel fallback. */
   path: ConnectionPath;
+  /**
+   * #5555 — when this selection came from a *fresh, successful* `/health` probe
+   * against the chosen `url` (only the LAN path probes today), this carries the
+   * probe outcome + the timestamp it completed. `connect()` threads this in as
+   * a `healthPrecheck` so it can skip its own redundant `/health` GET when the
+   * probe is recent (one connect = one probe). It is only ever set for a
+   * `status: 'ok'` result — the selector returns the tunnel fallback for a
+   * `restarting`/unreachable box — so `connect()`'s restarting detection is
+   * never short-circuited by it.
+   */
+  healthPrecheck?: { ts: number; status: 'ok' };
 }
 
 export interface SelectOptions {
@@ -160,7 +171,8 @@ export async function selectConnectEndpoint(
   const timeout = opts.probeTimeoutMs ?? LAN_PROBE_TIMEOUT_MS;
   const health = await probeHealth(lanUrl, timeout);
   if (health) {
-    return { url: lanUrl, path: 'lan' };
+    // #5555 — surface the fresh probe so connect() can skip its own /health GET.
+    return { url: lanUrl, path: 'lan', healthPrecheck: { ts: Date.now(), status: 'ok' } };
   }
   return fallback;
 }


### PR DESCRIPTION
Swarm-audit phase-1 quick wins for the mobile (`packages/app`) connect path. Three independent fixes, one PR. No new dependencies.

## FIX 1 — single `/health` probe on the auto-connect path

**Before:** `connectAuto` → `selectConnectEndpoint` probes `/health` against the chosen host, throws the result away, then `connect()` probed `/health` against the *same* host again before opening the WebSocket. Two round-trips for one connect.

**After:** `selectConnectEndpoint` surfaces a `healthPrecheck` (`{ ts, status: 'ok' }`) when a fresh LAN probe succeeds. `connectAuto` threads it into `connect()`, which skips its own GET when the precheck is recent (≤ 2s) and only on the first attempt. The selector only ever emits `status: 'ok'` (it falls back to the tunnel for a restarting/unreachable box), so `connect()`'s `restarting` detection on the normal path is never bypassed. Retries and the manual paths (QR / ServerPicker / manual entry) carry no precheck and run the full health check unchanged.

### Test plan
- `probes /health exactly once across selector + connect()` — verified LAN record, count fetches.
- `still probes once on the tunnel path` — `preferTunnel` returns no precheck → connect() probes once.
- `restarting detection still works on the normal (non-precheck) path`.
- `does not honor a stale precheck` — a precheck older than the freshness window is ignored; connect() re-probes.

## FIX 2 — prewarm `getDeviceId()` off the critical path

**Before:** the `auth` frame inside `socket.onopen` awaited `getDeviceId()` — an async SecureStore (keychain) read memoized only after its first call — so a cold read sat on the handshake critical path.

**After:** `connect()` kicks `getDeviceId()` off at the top (alongside the health fetch) so the keychain read overlaps network time. The `.then` in `onopen` stays as the await point and resolves instantly once warmed.

### Test plan
- `kicks off the SecureStore read at connect() start, before WS open` — slow SecureStore mock; the auth frame is *not* sent until the read resolves, and the read was already kicked off before the socket existed.
- `auth frame resolves instantly when the id is already memoized`.

## FIX 3 — port the dashboard's reconnect-dedup guard (#3624 drift)

**Before:** mobile's `onclose` and `onerror` each independently armed a `setTimeout(() => connect())`. A single transport drop fires `error` → `close`, so both ran — deduped today only by the staggered 1500/2000 ms delays + the `connectionAttemptId` bump (a timing accident, not a design guarantee).

**After:** ported the dashboard's per-socket `reconnectScheduled` guard (`packages/dashboard/src/store/connection.ts`). Each new socket gets a fresh scheduler, so a paired `error` → `close` for one drop arms exactly one reconnect, while a *new* socket failing mid-reconnect can still arm its own retry (the per-socket flag is bounded to that socket's lifetime — not phase-only dedupe). Mobile's `AUTO_RECONNECT_DELAY` / `ERROR_RECONNECT_DELAY` and the `connectionAttemptId` staleness guard are preserved; first-write-wins on `connectionError` so a close-code-specific banner isn't clobbered by the generic error copy.

### Test plan
- `onclose + onerror for one drop arm exactly one reconnect` (and the reverse `close → error` ordering) — exactly one new socket created.
- `a fresh socket after reconnect can still arm its own retry`.

## Verification

- `packages/app` full Jest suite: **1706 passed** (123 suites), including the new `connection-audit-phase1.test.ts` (9 tests) and the updated `endpoint-selector.test.ts`.
- `npx tsc --noEmit`: clean.
- Lockfile unchanged (no new deps).

Related to #5555
