### PR TITLE
fix(server): swarm-audit phase-1 quick wins — delta-buffer cap, connect de-dupe, provider validation, token eviction

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -788,16 +788,24 @@ export class EventNormalizer {
    */
   bufferDelta(sessionId, messageId, delta, emitMonoMs) {
     const key = sessionId ? `${sessionId}:${messageId}` : messageId
+    // #5555: coerce a non-string delta to its string form ONCE and use that for
+    // both the buffer concat AND the byte count. A bare `existing + delta` would
+    // string-coerce a non-string into the buffer (real residency) while a
+    // `typeof delta === 'string'` byte guard scored it as 0 — the caps would
+    // under-count actual residency and could miss the OOM ceiling this fix
+    // exists to enforce. Coercing once keeps the accounting equal to what's
+    // stored. (Providers always emit strings; this is purely defensive.)
+    const text = typeof delta === 'string' ? delta : String(delta ?? '')
     const existing = this._deltaBuffer.get(key) || ''
-    this._deltaBuffer.set(key, existing + delta)
+    this._deltaBuffer.set(key, existing + text)
     if (typeof emitMonoMs === 'number' && !this._deltaEmitMono.has(key)) {
       this._deltaEmitMono.set(key, emitMonoMs)
     }
     // #5555: maintain byte-size counters incrementally (UTF-8) — no
-    // re-serialization on the hot path. `delta` is the only new text, so its
+    // re-serialization on the hot path. `text` is the only new content, so its
     // byte length is the per-call growth for both the key total and the global
-    // total. typeof guard tolerates a non-string delta defensively.
-    const addedBytes = typeof delta === 'string' ? Buffer.byteLength(delta) : 0
+    // total, and it matches exactly what was concatenated above.
+    const addedBytes = Buffer.byteLength(text)
     const keyBytes = (this._deltaKeyBytes.get(key) || 0) + addedBytes
     this._deltaKeyBytes.set(key, keyBytes)
     this._deltaTotalBytes += addedBytes

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -4,6 +4,19 @@ import { createLogger } from './logger.js'
 
 const log = createLogger('event-normalizer')
 
+// #5555: caps on the delta coalescing buffer's un-flushed residency.
+//   - MAX_DELTA_KEY_BYTES: per-stream ceiling. One message buffering more than
+//     this between flushes forces an immediate flush of THAT key, preserving
+//     order (it is flushed and re-buffered fresh on the next delta).
+//   - MAX_DELTA_TOTAL_BYTES: aggregate ceiling across all streams. Crossing it
+//     forces a full flush. Guards the many-small-streams case that no per-key
+//     cap catches.
+// Chosen so a normal stream (sub-second flush windows of a few KB) never trips
+// them, while a runaway provider is bounded to ~2MB of residency instead of
+// growing the heap until V8 OOMs. Forced flush, never truncation — no data loss.
+const MAX_DELTA_KEY_BYTES = 256 * 1024 // 256 KB per stream
+const MAX_DELTA_TOTAL_BYTES = 2 * 1024 * 1024 // 2 MB across all streams
+
 /**
  * Declarative event-to-WS-message mapping.
  *
@@ -674,10 +687,23 @@ export class EventNormalizer {
    *   unknown (e.g. legacy single-session mode). When the count is exactly 1 the
    *   single-client window is used; otherwise (0, ≥2, or null) the default.
    */
-  constructor({ flushIntervalMs = 50, singleClientFlushIntervalMs = 25, getSubscriberCount = null } = {}) {
+  constructor({ flushIntervalMs = 50, singleClientFlushIntervalMs = 25, getSubscriberCount = null, maxKeyBytes = MAX_DELTA_KEY_BYTES, maxTotalBytes = MAX_DELTA_TOTAL_BYTES } = {}) {
     this._flushIntervalMs = flushIntervalMs
     this._singleClientFlushIntervalMs = singleClientFlushIntervalMs
     this._getSubscriberCount = typeof getSubscriberCount === 'function' ? getSubscriberCount : null
+    // #5555: residency caps for the coalescing buffer. A runaway provider (huge
+    // tool output, model repetition loop) can grow this Map between flushes
+    // faster than ws-broadcaster's socket backpressure can react — the data
+    // hasn't reached a socket yet, so backpressure never trips and V8 OOMs the
+    // daemon. We bound RESIDENCY (not content): exceeding a cap forces an
+    // immediate ordered flush of the affected key / whole buffer. No truncation,
+    // no data loss — the cap just shortens how long bytes live un-flushed.
+    this._maxKeyBytes = maxKeyBytes
+    this._maxTotalBytes = maxTotalBytes
+    // Byte sizes tracked incrementally (UTF-8) so the hot path never
+    // re-serializes the buffer to measure it.
+    this._deltaKeyBytes = new Map() // key -> byte length of its accumulated text
+    this._deltaTotalBytes = 0 // sum of _deltaKeyBytes values
     // Delta buffer: key -> accumulated text
     // In multi-session mode key = `${sessionId}:${messageId}`, otherwise just messageId
     this._deltaBuffer = new Map()
@@ -767,6 +793,36 @@ export class EventNormalizer {
     if (typeof emitMonoMs === 'number' && !this._deltaEmitMono.has(key)) {
       this._deltaEmitMono.set(key, emitMonoMs)
     }
+    // #5555: maintain byte-size counters incrementally (UTF-8) — no
+    // re-serialization on the hot path. `delta` is the only new text, so its
+    // byte length is the per-call growth for both the key total and the global
+    // total. typeof guard tolerates a non-string delta defensively.
+    const addedBytes = typeof delta === 'string' ? Buffer.byteLength(delta) : 0
+    const keyBytes = (this._deltaKeyBytes.get(key) || 0) + addedBytes
+    this._deltaKeyBytes.set(key, keyBytes)
+    this._deltaTotalBytes += addedBytes
+
+    // #5555: residency caps. Order matters — flush the over-cap KEY first
+    // (bounded, targeted), then re-check the global total. A forced flush
+    // emits via the same onFlush path the timer uses, so coalescing order is
+    // preserved: the over-cap key goes out now, fresh deltas re-buffer behind
+    // it. We flush BEFORE arming/keeping the timer below so a tripped cap
+    // doesn't also leave a redundant timer pointing at an empty key.
+    if (keyBytes >= this._maxKeyBytes) {
+      this._forceFlushKey(key)
+    }
+    if (this._deltaTotalBytes >= this._maxTotalBytes) {
+      this._flushDeltas()
+    }
+    if (this._deltaBuffer.size === 0) {
+      // Everything just got force-flushed — no timer needed.
+      if (this._deltaFlushTimer) {
+        clearTimeout(this._deltaFlushTimer)
+        this._deltaFlushTimer = null
+        this._deltaFlushDeadline = 0
+      }
+      return
+    }
     // #5516 (epic #5514): adaptive coalescing window — tighter (25ms) when this
     // session has a single subscriber, default (50ms) otherwise. The flush
     // timer is shared across all buffered sessions, so a single-client session
@@ -787,6 +843,38 @@ export class EventNormalizer {
   }
 
   /**
+   * #5555: force an immediate flush of a SINGLE over-cap key via the onFlush
+   * path, preserving coalescing order. The key is removed from all buffer maps;
+   * subsequent deltas for it re-buffer fresh behind whatever just went out.
+   * No-op (but still drops the key's accounting) when no onFlush is wired.
+   * @param {string} key
+   */
+  _forceFlushKey(key) {
+    if (!this._deltaBuffer.has(key)) return
+    const delta = this._deltaBuffer.get(key)
+    const emitMonoMs = this._deltaEmitMono.get(key)
+    this._deltaBuffer.delete(key)
+    this._deltaEmitMono.delete(key)
+    this._deltaTotalBytes -= this._deltaKeyBytes.get(key) || 0
+    this._deltaKeyBytes.delete(key)
+    if (this._deltaTotalBytes < 0) this._deltaTotalBytes = 0
+    if (this._onFlush) {
+      const sepIdx = key.indexOf(':')
+      const entry = sepIdx !== -1
+        ? { key, sessionId: key.slice(0, sepIdx), messageId: key.slice(sepIdx + 1), delta, emitMonoMs }
+        : { key, sessionId: null, messageId: key, delta, emitMonoMs }
+      // Mirror _flushDeltas' containment: a throwing broadcast must not escape
+      // the buffer hot path (which runs under the provider's event emit).
+      try {
+        this._onFlush([entry])
+      } catch (err) {
+        const message = err?.message || String(err)
+        log.error(`Delta force-flush onFlush callback threw: ${message}${err?.stack ? '\n' + err.stack : ''}`)
+      }
+    }
+  }
+
+  /**
    * Flush all buffered deltas for a specific session (called before stream_end).
    * Returns the flushed entries so the caller can broadcast them.
    * @param {string|null} sessionId - Session to flush (null = flush all)
@@ -802,8 +890,12 @@ export class EventNormalizer {
           entries.push({ key, sessionId, messageId, delta, emitMonoMs: this._deltaEmitMono.get(key) })
           this._deltaBuffer.delete(key)
           this._deltaEmitMono.delete(key)
+          // #5555: keep residency counters in sync as keys leave the buffer.
+          this._deltaTotalBytes -= this._deltaKeyBytes.get(key) || 0
+          this._deltaKeyBytes.delete(key)
         }
       }
+      if (this._deltaTotalBytes < 0) this._deltaTotalBytes = 0
     } else {
       // Legacy mode: flush everything
       for (const [key, delta] of this._deltaBuffer) {
@@ -811,6 +903,8 @@ export class EventNormalizer {
       }
       this._deltaBuffer.clear()
       this._deltaEmitMono.clear()
+      this._deltaKeyBytes.clear()
+      this._deltaTotalBytes = 0
     }
     // If buffer is now empty, cancel the pending timer
     if (this._deltaBuffer.size === 0 && this._deltaFlushTimer) {
@@ -853,11 +947,15 @@ export class EventNormalizer {
       } finally {
         this._deltaBuffer.clear()
         this._deltaEmitMono.clear()
+        this._deltaKeyBytes.clear()
+        this._deltaTotalBytes = 0
       }
       return
     }
     this._deltaBuffer.clear()
     this._deltaEmitMono.clear()
+    this._deltaKeyBytes.clear()
+    this._deltaTotalBytes = 0
   }
 
   /**
@@ -871,6 +969,8 @@ export class EventNormalizer {
     this._deltaFlushDeadline = 0
     this._deltaBuffer.clear()
     this._deltaEmitMono.clear()
+    this._deltaKeyBytes.clear()
+    this._deltaTotalBytes = 0
   }
 }
 

--- a/packages/server/src/pairing.js
+++ b/packages/server/src/pairing.js
@@ -62,6 +62,13 @@ const DEFAULT_GRACE_PERIOD_MS = 3 * 60_000 // 3 minutes after first QR display
 const DEFAULT_SESSION_TOKEN_TTL_MS = 24 * 60 * 60_000 // 24 hours
 const SESSION_TOKEN_BYTES = 32
 const MAX_SESSION_TOKENS = 100
+// #5555: cadence for the background session-token TTL sweep. Mirrors the
+// _pendingRequests sweep so expired tokens are reaped even when no lookup or
+// new issuance touches them — without this they linger to the cap and trigger
+// eviction of a still-valid (longest-paired) token, silently logging out a
+// device. Hourly is ample against a 24h TTL; unref'd so it never holds the
+// process open.
+const SESSION_TOKEN_SWEEP_INTERVAL_MS = 60 * 60_000 // 1 hour
 const MAX_ACTIVE_PAIRINGS = 10
 
 // -- Pairing-approval primitive (#5510, epic #5509) --
@@ -89,6 +96,9 @@ export class PairingManager extends EventEmitter {
     this._activePairings = new Map() // id → { expiresAt, used }
     this._sessionTokens = new Map() // sessionToken → { createdAt }
     this._refreshTimer = null
+    // #5555: background TTL sweep for _sessionTokens (started lazily on first
+    // token issuance, cleared on destroy — no leaked timer).
+    this._sessionTokenSweepTimer = null
     this._destroyed = false
 
     // -- Pairing-approval primitive (#5510) --
@@ -282,11 +292,7 @@ export class PairingManager extends EventEmitter {
     // pairings that didn't fix a binding at creation time.
     const effectiveSessionId = entry.boundSessionId || sessionId || null
     const sessionToken = randomBytes(SESSION_TOKEN_BYTES).toString('base64url')
-    if (this._sessionTokens.size >= MAX_SESSION_TOKENS) {
-      const oldest = this._sessionTokens.keys().next().value
-      this._sessionTokens.delete(oldest)
-    }
-    this._sessionTokens.set(sessionToken, { createdAt: Date.now(), sessionId: effectiveSessionId })
+    this._storeSessionToken(sessionToken, { createdAt: Date.now(), sessionId: effectiveSessionId })
 
     // Auto-regenerate so the dashboard always shows a fresh QR (#2916), but
     // only when the just-consumed ID was the linking-mode `_current`. Bound
@@ -352,6 +358,58 @@ export class PairingManager extends EventEmitter {
       }
     }
     return null
+  }
+
+  /**
+   * #5555: drop every expired session token. Used both before cap-eviction
+   * (so we never evict a still-valid token while expired ones occupy slots)
+   * and by the background sweep timer. Constant-key iteration, no allocation.
+   * @returns {number} count of tokens removed
+   */
+  _sweepSessionTokens() {
+    if (this._destroyed) return 0
+    const now = Date.now()
+    let removed = 0
+    for (const [stored, meta] of this._sessionTokens) {
+      if (now - meta.createdAt > this._sessionTokenTtlMs) {
+        this._sessionTokens.delete(stored)
+        removed++
+      }
+    }
+    // Stop the timer once the map is empty — re-armed on the next issuance.
+    if (this._sessionTokens.size === 0 && this._sessionTokenSweepTimer) {
+      clearInterval(this._sessionTokenSweepTimer)
+      this._sessionTokenSweepTimer = null
+    }
+    return removed
+  }
+
+  _ensureSessionTokenSweepTimer() {
+    if (this._destroyed || this._sessionTokenSweepTimer) return
+    this._sessionTokenSweepTimer = setInterval(() => this._sweepSessionTokens(), SESSION_TOKEN_SWEEP_INTERVAL_MS)
+    this._sessionTokenSweepTimer.unref?.()
+  }
+
+  /**
+   * #5555: issue a new session token under the cap, sweeping expired tokens
+   * BEFORE evicting any still-valid one. The pre-fix path evicted the oldest
+   * Map entry by insertion order — the longest-paired (and likely still-valid)
+   * device — even when expired tokens were sitting in the map ready to be
+   * reaped. Only after the sweep, if still at cap, do we evict the oldest
+   * remaining (now guaranteed all-valid) token.
+   * @param {string} token
+   * @param {object} meta - token metadata ({ createdAt, sessionId })
+   */
+  _storeSessionToken(token, meta) {
+    if (this._sessionTokens.size >= MAX_SESSION_TOKENS) {
+      this._sweepSessionTokens()
+      if (this._sessionTokens.size >= MAX_SESSION_TOKENS) {
+        const oldest = this._sessionTokens.keys().next().value
+        this._sessionTokens.delete(oldest)
+      }
+    }
+    this._sessionTokens.set(token, meta)
+    this._ensureSessionTokenSweepTimer()
   }
 
   /**
@@ -530,12 +588,8 @@ export class PairingManager extends EventEmitter {
     entry.resolved = true
 
     const token = randomBytes(SESSION_TOKEN_BYTES).toString('base64url')
-    if (this._sessionTokens.size >= MAX_SESSION_TOKENS) {
-      const oldest = this._sessionTokens.keys().next().value
-      this._sessionTokens.delete(oldest)
-    }
     // Unbound (host-authority) token — sessionId: null, like linking-mode QR.
-    this._sessionTokens.set(token, { createdAt: Date.now(), sessionId: null })
+    this._storeSessionToken(token, { createdAt: Date.now(), sessionId: null })
     return { ok: true, token }
   }
 
@@ -631,6 +685,10 @@ export class PairingManager extends EventEmitter {
     if (this._sweepTimer) {
       clearInterval(this._sweepTimer)
       this._sweepTimer = null
+    }
+    if (this._sessionTokenSweepTimer) {
+      clearInterval(this._sessionTokenSweepTimer)
+      this._sessionTokenSweepTimer = null
     }
     this.removeAllListeners()
   }

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -54,12 +54,6 @@ const PROVIDERS = {
 // Names hidden from listProviders() (backward-compat aliases, etc.)
 const HIDDEN = new Set()
 
-// Seed per-provider registries for built-in providers so models.js can
-// resolve provider-scoped model metadata without waiting for registerProvider.
-for (const [name, ProviderClass] of Object.entries(PROVIDERS)) {
-  registerProviderRegistry(name, ProviderClass)
-}
-
 /** Required methods every provider class prototype must expose. */
 const REQUIRED_METHODS = ['sendMessage', 'interrupt', 'setModel', 'setPermissionMode', 'start', 'destroy']
 
@@ -91,6 +85,19 @@ export function validateProviderClass(ProviderClass, name) {
       }
     }
   }
+}
+
+// #5555: validate every built-in against the ProviderSession contract at
+// registry construction, then seed its per-provider model registry. Before
+// this, validateProviderClass only ran on the registerProvider() path
+// (Docker / external / config-driven endpoints) — the 9 first-class providers
+// in the PROVIDERS literal got NO interface check, so the documented contract
+// didn't actually cover its main case. A built-in that drops a required method
+// (or flips inProcessPermissions without the permission methods) now fails
+// loudly at module load instead of throwing deep inside a live session.
+for (const [name, ProviderClass] of Object.entries(PROVIDERS)) {
+  validateProviderClass(ProviderClass, name)
+  registerProviderRegistry(name, ProviderClass)
 }
 
 /**

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -348,7 +348,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
 
     if (entry) {
       send(ws, { type: 'session_switched', sessionId: activeId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
-      sendSessionInfo(ctx, ws, activeId)
+      // #5555: `sendSessionInfo` normally pushes `available_models` (the
+      // tab-switch path, #4302). On the connect handshake the post-auth block
+      // below already pushes one provider-scoped `available_models` snapshot
+      // (and, for the no-active-session case, the ONLY snapshot), so skip the
+      // duplicate here to avoid sending `available_models` twice per connect.
+      // The post-auth block owns the refresh schedule in this path (below).
+      sendSessionInfo(ctx, ws, activeId, { skipModels: true })
       replayHistory(ctx, ws, activeId)
     }
 
@@ -368,11 +374,12 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     const activeProvider = entry?.provider || null
     const activeRegistry = getRegistryForProvider(activeProvider)
     send(ws, { type: 'available_models', models: activeRegistry.getModels(), defaultModel: activeRegistry.getDefaultModelId(), provider: activeProvider })
-    // #5421: dynamic-discovery refresh (ollama /api/tags) is scheduled by
-    // sendSessionInfo above whenever a session is active — scheduling here
-    // too would join the same in-flight probe twice and double-push a
-    // changed list to this client. With no active session activeProvider
-    // is null and there is nothing to refresh.
+    // #5421/#5555: dynamic-discovery refresh (ollama /api/tags). `sendSessionInfo`
+    // above was told to skip its own `available_models` push (de-dupe on connect),
+    // so it also skipped scheduling the refresh — this path now owns the single
+    // schedule. With no active session activeProvider is null and there is nothing
+    // to refresh (scheduleProviderModelsRefresh no-ops on a null provider).
+    scheduleProviderModelsRefresh(ctx, ws, activeProvider)
     send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
     permissions.resendPendingPermissions(ws, client)
     return
@@ -452,8 +459,16 @@ export function scheduleProviderModelsRefresh(ctx, ws, providerName) {
 
 /**
  * Send session-specific info (model, permission, ready status) to a client.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.skipModels] - #5555: skip the `available_models` push
+ *   (and its paired refresh schedule). Set by `sendPostAuthInfo` on connect,
+ *   where the post-auth block sends a single `available_models` snapshot itself
+ *   — without this the same client would receive `available_models` twice per
+ *   connect. The tab-switch path (#4302) leaves it false so a switch still
+ *   re-tags the dashboard's provider.
  */
-export function sendSessionInfo(ctx, ws, sessionId) {
+export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
   const { sessionManager, send } = ctx
   const entry = sessionManager?.getSession(sessionId)
   if (!entry) return
@@ -469,17 +484,19 @@ export function sendSessionInfo(ctx, ws, sessionId) {
   // the model picker for any session whose provider differs from the
   // initial one — most visibly, a claude-cli session created after a
   // TUI/SDK session loses its picker entirely.
-  const activeProvider = entry.provider || null
-  const activeRegistry = getRegistryForProvider(activeProvider)
-  send(ws, {
-    type: 'available_models',
-    models: activeRegistry.getModels(),
-    defaultModel: activeRegistry.getDefaultModelId(),
-    provider: activeProvider,
-  })
-  // #5421: background dynamic-discovery refresh (ollama /api/tags); a
-  // changed list is re-pushed to this client when the probe lands.
-  scheduleProviderModelsRefresh(ctx, ws, activeProvider)
+  if (!opts.skipModels) {
+    const activeProvider = entry.provider || null
+    const activeRegistry = getRegistryForProvider(activeProvider)
+    send(ws, {
+      type: 'available_models',
+      models: activeRegistry.getModels(),
+      defaultModel: activeRegistry.getDefaultModelId(),
+      provider: activeProvider,
+    })
+    // #5421: background dynamic-discovery refresh (ollama /api/tags); a
+    // changed list is re-pushed to this client when the probe lands.
+    scheduleProviderModelsRefresh(ctx, ws, activeProvider)
+  }
   send(ws, {
     type: 'model_changed',
     // #3687: prefer the user's explicit override (`model`) so a later

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -903,6 +903,105 @@ describe('EventNormalizer', () => {
       assert.equal(lastFlushed[0].delta, 'second')
     })
 
+    // ---- #5555: residency caps (per-key + total) ----
+    //
+    // A runaway provider can grow the un-flushed buffer faster than socket
+    // backpressure can react (data hasn't reached a socket yet). The caps force
+    // an immediate ORDERED flush — never truncation — bounding heap residency.
+    describe('residency caps (#5555)', () => {
+      it('forces an immediate flush of a key that exceeds the per-key byte cap', () => {
+        const flushed = []
+        // Tiny caps so the test stays cheap; the production defaults are 256KB/2MB.
+        const n = new EventNormalizer({ flushIntervalMs: 10, maxKeyBytes: 100, maxTotalBytes: 10_000 })
+        n.onFlush = (entries) => { flushed.push(...entries) }
+        try {
+          n.bufferDelta('sess-1', 'msg-1', 'a'.repeat(60)) // under cap, buffered
+          assert.equal(flushed.length, 0, 'no flush before the cap is crossed')
+          n.bufferDelta('sess-1', 'msg-1', 'b'.repeat(50)) // 110 >= 100 → force flush
+          assert.equal(flushed.length, 1, 'crossing the per-key cap forces one flush')
+          // Content preserved in order, nothing truncated.
+          assert.equal(flushed[0].delta, 'a'.repeat(60) + 'b'.repeat(50))
+          assert.equal(flushed[0].sessionId, 'sess-1')
+          assert.equal(flushed[0].messageId, 'msg-1')
+          // Key was flushed out of the buffer; counters reset for it.
+          assert.equal(n._deltaBuffer.has('sess-1:msg-1'), false)
+          assert.equal(n._deltaTotalBytes, 0)
+        } finally {
+          n.destroy()
+        }
+      })
+
+      it('preserves order: post-flush deltas re-buffer behind the flushed chunk', () => {
+        const flushed = []
+        const n = new EventNormalizer({ flushIntervalMs: 10, maxKeyBytes: 100, maxTotalBytes: 10_000 })
+        n.onFlush = (entries) => { flushed.push(...entries) }
+        try {
+          n.bufferDelta('sess-1', 'msg-1', 'x'.repeat(120)) // force-flush chunk 1
+          n.bufferDelta('sess-1', 'msg-1', 'tail') // re-buffers fresh behind it
+          const rest = n.flushSession('sess-1')
+          assert.equal(flushed.length, 1)
+          assert.equal(flushed[0].delta, 'x'.repeat(120))
+          assert.equal(rest.length, 1)
+          assert.equal(rest[0].delta, 'tail', 'later delta lands after the force-flushed chunk, in order')
+        } finally {
+          n.destroy()
+        }
+      })
+
+      it('only one key under the per-key cap does not flush others', () => {
+        const flushed = []
+        const n = new EventNormalizer({ flushIntervalMs: 10, maxKeyBytes: 100, maxTotalBytes: 10_000 })
+        n.onFlush = (entries) => { flushed.push(...entries) }
+        try {
+          n.bufferDelta('sess-1', 'big', 'z'.repeat(120)) // force-flush this key
+          n.bufferDelta('sess-1', 'small', 'tiny') // stays buffered
+          assert.equal(flushed.length, 1)
+          assert.equal(flushed[0].messageId, 'big')
+          assert.equal(n._deltaBuffer.has('sess-1:small'), true, 'under-cap key is untouched')
+        } finally {
+          n.destroy()
+        }
+      })
+
+      it('forces a full flush when the aggregate total cap is exceeded', () => {
+        const flushed = []
+        // Per-key cap high enough that no single key trips it; total cap small
+        // so the many-small-streams case is what forces the flush.
+        const n = new EventNormalizer({ flushIntervalMs: 10, maxKeyBytes: 10_000, maxTotalBytes: 250 })
+        n.onFlush = (entries) => { flushed.push(...entries) }
+        try {
+          n.bufferDelta('sess-1', 'm1', 'p'.repeat(100))
+          n.bufferDelta('sess-1', 'm2', 'q'.repeat(100))
+          assert.equal(flushed.length, 0, 'still under the total cap')
+          n.bufferDelta('sess-1', 'm3', 'r'.repeat(100)) // 300 >= 250 → full flush
+          // All three keys flushed in one pass; content intact.
+          assert.equal(flushed.length, 3)
+          const byKey = Object.fromEntries(flushed.map(e => [e.messageId, e.delta]))
+          assert.equal(byKey.m1, 'p'.repeat(100))
+          assert.equal(byKey.m2, 'q'.repeat(100))
+          assert.equal(byKey.m3, 'r'.repeat(100))
+          assert.equal(n._deltaBuffer.size, 0)
+          assert.equal(n._deltaTotalBytes, 0)
+        } finally {
+          n.destroy()
+        }
+      })
+
+      it('measures bytes (UTF-8), not chars — multibyte content trips the cap sooner', () => {
+        const flushed = []
+        const n = new EventNormalizer({ flushIntervalMs: 10, maxKeyBytes: 100, maxTotalBytes: 10_000 })
+        n.onFlush = (entries) => { flushed.push(...entries) }
+        try {
+          // '😀' is 4 UTF-8 bytes. 30 of them = 120 bytes (only 60 UTF-16 units).
+          n.bufferDelta('sess-1', 'emoji', '😀'.repeat(30))
+          assert.equal(flushed.length, 1, 'byte-counted cap trips on multibyte payload')
+          assert.equal(flushed[0].delta, '😀'.repeat(30), 'no truncation of multibyte content')
+        } finally {
+          n.destroy()
+        }
+      })
+    })
+
     it('cancels timer when buffer emptied by flushSession', () => {
       normalizer.bufferDelta('sess-1', 'msg-1', 'x')
       normalizer.flushSession('sess-1')

--- a/packages/server/tests/pairing.test.js
+++ b/packages/server/tests/pairing.test.js
@@ -335,6 +335,90 @@ describe('PairingManager (#1836)', () => {
     })
   })
 
+  // #5555: at the session-token cap the pre-fix code evicted the OLDEST
+  // still-valid token (Map insertion order) — silently logging out the
+  // longest-paired device — even when expired tokens sat in the map ready to
+  // be reaped. Now we sweep expired tokens before evicting any valid one, plus
+  // run a periodic TTL sweep so tokens don't linger to the cap untouched.
+  describe('session token eviction — sweep before evict (#5555)', () => {
+    it('sweeps expired tokens instead of evicting a valid one at the cap', async () => {
+      const pm = new PairingManager({ sessionTokenTtlMs: 30 })
+      // The oldest 5 tokens we insert NOW; they will expire after the TTL.
+      const now = Date.now()
+      for (let i = 0; i < 5; i++) {
+        pm._sessionTokens.set(`old-${i}`, { createdAt: now, sessionId: `old-sess-${i}` })
+      }
+      // Let those 5 expire.
+      await delay(50)
+      // Top up to exactly the cap with FRESH (valid) tokens (indices 5..99).
+      const fresh = Date.now()
+      for (let i = pm._sessionTokens.size; i < 100; i++) {
+        pm._sessionTokens.set(`fresh-${i}`, { createdAt: fresh, sessionId: `fresh-sess-${i}` })
+      }
+      assert.equal(pm._sessionTokens.size, 100, 'at cap before next issuance')
+      // Issue one more — must sweep the 5 expired, NOT evict a valid token.
+      pm._storeSessionToken('brand-new', { createdAt: Date.now(), sessionId: 'new-sess' })
+      // The 5 expired are gone; every fresh token survived; new one stored.
+      for (let i = 0; i < 5; i++) {
+        assert.equal(pm._sessionTokens.has(`old-${i}`), false, `expired old-${i} swept`)
+      }
+      assert.equal(pm._sessionTokens.has('brand-new'), true, 'new token stored')
+      // The longest-paired VALID token must still be present (not evicted).
+      assert.equal(pm._sessionTokens.has('fresh-5'), true, 'longest-paired valid token survives')
+      pm.destroy()
+    })
+
+    it('evicts the oldest valid token only when still at cap after sweeping', () => {
+      // No expired tokens to reclaim → must fall back to evicting the oldest.
+      const pm = new PairingManager({ sessionTokenTtlMs: 60_000 })
+      pm._sessionTokens.clear()
+      const now = Date.now()
+      for (let i = 0; i < 100; i++) {
+        pm._sessionTokens.set(`v-${i}`, { createdAt: now, sessionId: `s-${i}` })
+      }
+      assert.equal(pm._sessionTokens.size, 100)
+      pm._storeSessionToken('overflow', { createdAt: Date.now(), sessionId: 's-new' })
+      assert.equal(pm._sessionTokens.size, 100, 'stays at cap')
+      assert.equal(pm._sessionTokens.has('v-0'), false, 'oldest valid evicted as last resort')
+      assert.equal(pm._sessionTokens.has('overflow'), true)
+      pm.destroy()
+    })
+
+    it('_sweepSessionTokens removes only expired tokens', async () => {
+      const pm = new PairingManager({ sessionTokenTtlMs: 30 })
+      pm._sessionTokens.clear()
+      pm._sessionTokens.set('expired', { createdAt: Date.now(), sessionId: null })
+      await delay(50)
+      pm._sessionTokens.set('alive', { createdAt: Date.now(), sessionId: null })
+      const removed = pm._sweepSessionTokens()
+      assert.equal(removed, 1)
+      assert.equal(pm._sessionTokens.has('expired'), false)
+      assert.equal(pm._sessionTokens.has('alive'), true)
+      pm.destroy()
+    })
+
+    it('arms a periodic sweep timer on issuance and clears it on destroy (no leak)', () => {
+      const pm = new PairingManager({})
+      assert.equal(pm._sessionTokenSweepTimer, null, 'no timer before any token issued')
+      pm._storeSessionToken('t', { createdAt: Date.now(), sessionId: null })
+      assert.notEqual(pm._sessionTokenSweepTimer, null, 'sweep timer armed on first issuance')
+      pm.destroy()
+      assert.equal(pm._sessionTokenSweepTimer, null, 'sweep timer cleared on destroy')
+    })
+
+    it('periodic sweep stops itself once the token map drains', async () => {
+      const pm = new PairingManager({ sessionTokenTtlMs: 30 })
+      pm._storeSessionToken('solo', { createdAt: Date.now(), sessionId: null })
+      assert.notEqual(pm._sessionTokenSweepTimer, null)
+      // Manually drain via the sweep after expiry; the helper should null the timer.
+      await delay(50)
+      pm._sweepSessionTokens()
+      assert.equal(pm._sessionTokens.size, 0)
+      assert.equal(pm._sessionTokenSweepTimer, null, 'timer stops when map empties')
+      pm.destroy()
+    })
+  })
+
   describe('auto-regen on consumption (#2916)', () => {
     it('emits pairing_refreshed after a pairing ID is consumed', () => {
       const pm = new PairingManager({})

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync, utimesSync, unlinkSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { registerProvider, getProvider, listProviders, registerDockerProvider, _resetCredsCacheForTest } from '../src/providers.js'
+import { registerProvider, getProvider, listProviders, registerDockerProvider, _resetCredsCacheForTest, validateProviderClass, getRegisteredProviderNames } from '../src/providers.js'
 import { CliSession } from '../src/cli-session.js'
 import { SdkSession } from '../src/sdk-session.js'
 import { CodexSession } from '../src/codex-session.js'
@@ -54,6 +54,61 @@ describe('Provider Registry', () => {
     }
     registerProvider('test-roundtrip', TestProvider)
     assert.equal(getProvider('test-roundtrip'), TestProvider)
+  })
+
+  // #5555: validateProviderClass was only invoked on the registerProvider()
+  // path (Docker / external). The built-ins in the PROVIDERS literal, seeded via
+  // the registry construction loop, got NO interface check — the contract
+  // didn't cover its main case. The loop now validates every built-in at module
+  // load, so a regressed built-in fails loudly instead of deep in a live session.
+  describe('built-in provider contract validation (#5555)', () => {
+    it('every registered built-in passes validateProviderClass', () => {
+      // The module already loaded (and the seeding loop already validated), so
+      // reaching this test at all proves no built-in throws. Re-assert per
+      // built-in for a precise failure message if one ever regresses.
+      const builtins = getRegisteredProviderNames().filter(n => !n.startsWith('test-') && !n.startsWith('docker-'))
+      assert.ok(builtins.length >= 9, 'expected the 9 first-class built-ins to be registered')
+      for (const name of builtins) {
+        const ProviderClass = getProvider(name)
+        assert.doesNotThrow(() => validateProviderClass(ProviderClass, name),
+          `built-in '${name}' must satisfy the ProviderSession contract`)
+      }
+    })
+
+    it('a bogus built-in (missing a required method) fails loudly — mirrors the seeding loop', () => {
+      // Simulate what the registry construction loop does to each entry of the
+      // PROVIDERS literal: a class dropping a required method must throw, naming
+      // the method, rather than register silently and explode at call time.
+      class BogusProvider {
+        sendMessage() {}
+        interrupt() {}
+        setModel() {}
+        setPermissionMode() {}
+        start() {}
+        // destroy() intentionally omitted
+      }
+      assert.throws(
+        () => validateProviderClass(BogusProvider, 'bogus-builtin'),
+        /missing required method: destroy/,
+      )
+    })
+
+    it('a built-in claiming inProcessPermissions without the methods fails loudly', () => {
+      class HalfBakedInProcess {
+        sendMessage() {}
+        interrupt() {}
+        setModel() {}
+        setPermissionMode() {}
+        start() {}
+        destroy() {}
+        static get capabilities() { return { inProcessPermissions: true } }
+        // respondToPermission / respondToQuestion intentionally omitted
+      }
+      assert.throws(
+        () => validateProviderClass(HalfBakedInProcess, 'half-baked'),
+        /inProcessPermissions=true but is missing required method/,
+      )
+    })
   })
 
   it('listProviders returns registered providers with capabilities', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -704,6 +704,53 @@ describe('sendSessionInfo', () => {
     assert.equal(modelMsg.model, 'sonnet')
   })
 
+  // #5555: the connect handshake used to push available_models twice (once in
+  // sendSessionInfo, once in the post-auth block). sendSessionInfo now takes a
+  // skipModels opt the post-auth path sets so a single connect sends it once.
+  describe('skipModels opt (#5555)', () => {
+    it('skipModels=true suppresses available_models but still sends the rest', () => {
+      const { manager } = createMockSessionManager([
+        { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+      ])
+      const ws = makeFakeWs()
+      const ctx = makeCtx({ sessionManager: manager })
+      registerClient(ctx, ws)
+
+      sendSessionInfo(ctx, ws, 'sess-1', { skipModels: true })
+      assert.equal(ctx._sends.filter(m => m.type === 'available_models').length, 0,
+        'available_models suppressed when skipModels is set')
+      // The rest of the session info still flows.
+      assert.ok(ctx._sends.find(m => m.type === 'model_changed'), 'model_changed still sent')
+      assert.ok(ctx._sends.find(m => m.type === 'permission_mode_changed'), 'permission_mode_changed still sent')
+    })
+
+    it('default (tab switch) still sends exactly one available_models', () => {
+      const { manager } = createMockSessionManager([
+        { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+      ])
+      const ws = makeFakeWs()
+      const ctx = makeCtx({ sessionManager: manager })
+      registerClient(ctx, ws)
+
+      sendSessionInfo(ctx, ws, 'sess-1')
+      assert.equal(ctx._sends.filter(m => m.type === 'available_models').length, 1,
+        'tab-switch path is unaffected — still pushes available_models')
+    })
+  })
+
+  it('connect handshake sends available_models exactly once (#5555 de-dupe)', () => {
+    const { manager } = createMockSessionManager(
+      [{ id: 'sess-1', name: 'Alpha', cwd: '/alpha' }],
+    )
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-1' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(ctx._sends.filter(m => m.type === 'available_models').length, 1,
+      'a single connect must push available_models exactly once')
+  })
+
   // #4302 — sendSessionInfo runs on every switch_session. Pre-fix it did
   // not push available_models, so the dashboard's availableModelsProvider
   // stayed tagged with whichever provider sendPostAuthInfo set at auth.
@@ -2255,7 +2302,7 @@ describe('scheduleProviderModelsRefresh (#5421 / #5450)', () => {
     }
   })
 
-  it('is scheduled exactly once per handshake — sendPostAuthInfo does not double-push', async () => {
+  it('is scheduled exactly once per handshake — sendPostAuthInfo does not double-push (#5555)', async () => {
     const name = 'fake-refresh-once'
     const refreshSpy = createSpy(async () => {
       getRegistryForProvider(name).updateModels([
@@ -2279,17 +2326,19 @@ describe('scheduleProviderModelsRefresh (#5421 / #5450)', () => {
     registerClient(ctx, ws)
 
     sendPostAuthInfo(ctx, ws)
-    // The synchronous handshake pushes available_models twice (sendSessionInfo
-    // + the post-auth snapshot) — only sendSessionInfo may schedule a refresh.
+    // #5555: de-duped — the handshake pushes available_models exactly ONCE.
+    // sendSessionInfo is told to skip its own push (skipModels) so the
+    // post-auth block owns the single synchronous snapshot AND the single
+    // refresh schedule. Pre-fix this was two synchronous pushes.
     const syncPushes = ctx._sends.filter(m => m.type === 'available_models').length
-    assert.equal(syncPushes, 2, 'handshake baseline: two synchronous available_models snapshots')
+    assert.equal(syncPushes, 1, 'handshake baseline: one synchronous available_models snapshot')
 
     await flushAsync()
 
     assert.equal(refreshSpy.callCount, 1,
-      'refreshModels must be scheduled exactly once per handshake (sendSessionInfo owns it)')
+      'refreshModels must be scheduled exactly once per handshake')
     const totalPushes = ctx._sends.filter(m => m.type === 'available_models').length
     assert.equal(totalPushes, syncPushes + 1,
-      'exactly one async re-push on top of the synchronous snapshots')
+      'exactly one async re-push on top of the single synchronous snapshot')
   })
 })


### PR DESCRIPTION
## Summary

Four small, independent, well-evidenced server fixes from the swarm audit — one PR, one commit per fix.

### 1. Cap the stream-delta coalescing buffer (HIGH — daemon-wide OOM vector)
**Finding:** `event-normalizer.js` `bufferDelta` did `existing + delta` per `${sessionId}:${messageId}` key, flushed only on the 25–50ms timer, with **no size cap**. A runaway provider (huge tool output, model repetition loop) grows the daemon heap until V8 OOMs — `ws-broadcaster.js` socket backpressure can't trip because the data never reached a socket.

**Fix:** two residency caps, both enforced as a **forced ordered flush** (never truncation, no data loss — the cap only bounds un-flushed residency):
- **per-key** ceiling (256KB) → force-flushes just that key; later deltas re-buffer fresh behind the flushed chunk.
- **total** ceiling (2MB) → forces a full flush, catching the many-small-streams case no per-key cap sees.

Byte sizes are tracked **incrementally** (UTF-8, `Buffer.byteLength` on the new `delta` only) so the hot path never re-serializes the buffer. Every flush path (timer, `flushSession`, force-flush, `destroy`) keeps the counters in sync.

### 2. De-dupe the double `available_models` on connect
**Finding:** `ws-history.js` `sendPostAuthInfo` sent `available_models` once via `sendSessionInfo` and **again** in its own post-auth block — every client got the snapshot twice per connect. The `sendSessionInfo` copy exists for the tab-switch case (#4302).

**Fix:** a `skipModels` opt on `sendSessionInfo`. The connect handshake sets it so `sendSessionInfo` suppresses its `available_models` push **and** the paired dynamic-discovery refresh schedule; the post-auth block then owns the single synchronous snapshot + single refresh schedule. Tab-switch callers leave `skipModels` false, so a switch still re-tags the dashboard's provider.

### 3. Validate built-in providers
**Finding:** `providers.js` `validateProviderClass` was only invoked from `registerProvider` (Docker / external / config-driven path). The 9 built-ins in the `PROVIDERS` literal — seeded via the registry construction loop — got **no** interface check, so the documented `ProviderSession` contract didn't cover its main case.

**Fix:** validate every built-in in the seeding loop (moved below `validateProviderClass`). A built-in that drops a required method, or flips `inProcessPermissions` without the permission methods, now fails loudly at module load instead of deep in a live session. All current built-ins satisfy the contract (no class or contract was weakened).

### 4. `_sessionTokens`: sweep expired before evicting valid
**Finding:** `pairing.js` at `MAX_SESSION_TOKENS` evicted the oldest entry by Map insertion order — the longest-paired, likely **still-valid** device — even when expired tokens sat in the map ready to be reaped. Silent logout of an active device.

**Fix:** both token-issuance sites funnel through a new `_storeSessionToken`, which sweeps expired tokens first and only evicts the oldest remaining (now all-valid) token if still at cap. Adds a periodic TTL sweep mirroring the `_pendingRequests` sweep: armed on first issuance, self-stopping when the map drains, `unref`'d, cleared on `destroy` (no leaked timer).

## Test plan

New tests (all green; `node --test --test-force-exit`):
- **Buffer cap** (`event-normalizer.test.js`): per-key force-flush preserves content + order, post-flush deltas re-buffer behind the chunk, under-cap keys untouched, total-cap full flush, UTF-8 byte counting (multibyte payload).
- **Connect de-dupe** (`ws-history.test.js`): single `available_models` per connect; `skipModels=true` suppresses models but still sends the rest; tab-switch path still sends exactly one; refresh scheduled exactly once.
- **Built-in validation** (`providers.test.js`): every registered built-in passes `validateProviderClass`; a bogus class missing a method fails loudly (mirrors the seeding loop); a half-baked `inProcessPermissions` class fails loudly.
- **Token sweep** (`pairing.test.js`): sweep-before-evict keeps the longest-paired valid token; oldest-valid evicted only as last resort; `_sweepSessionTokens` removes only expired; periodic timer armed on issuance, cleared on destroy, self-stops on drain.

Full affected suites: `event-normalizer` + `pairing` + `providers` + `ws-history` = **349 tests, 0 fail**. Cross-file regression check (`ws-server`, `ws-server-broadcast`, `ws-exposure`, `models-per-provider`, `ws-message-handlers`, handler suites) all green. All `packages/server/scripts/lint-*.sh` pass; eslint clean on all changed source files.

## Design decisions
- **Cap values (256KB per key / 2MB total):** a normal stream flushes a few KB per sub-second window, so neither cap trips in practice; the bound caps a runaway at ~2MB residency instead of unbounded heap growth. Forced flush, not truncation, so user-visible content is never lost.
- **Connect de-dupe direction:** kept the post-auth block as the single owner of the snapshot + refresh (it also handles the no-active-session case), and made `sendSessionInfo` opt out — rather than removing the post-auth send — so all connect sub-cases stay correct.
- **Token sweep cadence (1h):** ample against the 24h TTL; `unref`'d and self-stopping so it never holds the process open or leaks.

Related to #5555
