### PR TITLE
fix: swarm-audit phase-1 UX parity — dashboard restart countdown, mobile input decoupling

### DIFF
--- a/packages/app/__tests__/ComponentRendering.test.ts
+++ b/packages/app/__tests__/ComponentRendering.test.ts
@@ -38,10 +38,22 @@ describe('InputBar component', () => {
 
   test('defines InputBarProps interface with required props', () => {
     expect(inputBarSrc).toMatch(/export\s+interface\s+InputBarProps/)
-    expect(inputBarSrc).toMatch(/inputText:\s*string/)
+    // #5556 — InputBar owns its draft internally; `inputText` is now an
+    // optional seed prop and the draft is driven via the imperative ref.
+    expect(inputBarSrc).toMatch(/inputText\?:\s*string/)
     expect(inputBarSrc).toMatch(/onSend:\s*\(\)/)
     expect(inputBarSrc).toMatch(/onInterrupt:\s*\(\)/)
     expect(inputBarSrc).toMatch(/isStreaming:\s*boolean/)
+  })
+
+  test('exposes an imperative InputBarHandle (focus/getValue/setValue/clear) and is memoized (#5556)', () => {
+    expect(inputBarSrc).toMatch(/export\s+interface\s+InputBarHandle/)
+    expect(inputBarSrc).toMatch(/focus:\s*\(\)/)
+    expect(inputBarSrc).toMatch(/getValue:\s*\(\)/)
+    expect(inputBarSrc).toMatch(/setValue:\s*\(text:\s*string\)/)
+    expect(inputBarSrc).toMatch(/clear:\s*\(\)/)
+    expect(inputBarSrc).toMatch(/useImperativeHandle/)
+    expect(inputBarSrc).toMatch(/React\.memo\(/)
   })
 
   test('has send button with accessibilityRole and accessibilityLabel', () => {

--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useRef, useEffect } from 'react';
+import React, { forwardRef, useMemo, useRef, useEffect, useState, useImperativeHandle, useCallback } from 'react';
 import { View, Text, TextInput, TouchableOpacity, ScrollView, Image, StyleSheet, Platform, Animated, Alert } from 'react-native';
 import { ICON_RETURN, ICON_PARAGRAPH } from '../constants/icons';
 import { Icon } from './Icon';
@@ -15,9 +15,43 @@ export interface PastedTextBlockChip {
   content: string;
 }
 
+/**
+ * Imperative handle exposed via the InputBar ref (#5556 — input/stream
+ * decoupling). InputBar owns the composer draft internally so that streaming
+ * message re-renders in SessionScreen no longer re-render the TextInput on
+ * every delta. SessionScreen reads/writes the draft through this handle for
+ * the send path, voice-transcript merge, seed prompts (`@agent `), and
+ * pasted-text marker stripping.
+ *
+ * `setValue` updates the internal draft WITHOUT firing `onChangeText`, so
+ * programmatic writes (paste collapse, voice merge, marker strip) don't
+ * recursively re-trigger the diff/paste-detection path. User keystrokes fire
+ * `onChangeText(next, prev)` as before.
+ */
+export interface InputBarHandle {
+  /** Focus the underlying TextInput. */
+  focus: () => void;
+  /** Read the current draft value. */
+  getValue: () => string;
+  /** Replace the draft programmatically (does NOT fire onChangeText). */
+  setValue: (text: string) => void;
+  /** Clear the draft (equivalent to setValue('')). */
+  clear: () => void;
+}
+
 export interface InputBarProps {
-  inputText: string;
-  onChangeText: (text: string) => void;
+  /**
+   * Optional seed value. InputBar owns its draft internally; this prop only
+   * supplies an initial value on mount. To change the draft after mount, use
+   * the imperative ref (`setValue`/`clear`). Kept for back-compat and tests.
+   */
+  inputText?: string;
+  /**
+   * Fired on every user keystroke with the new value and the previous value.
+   * The `prevText` arg lets the parent run paste-diff detection (#3797)
+   * without holding the draft in its own render-scope state.
+   */
+  onChangeText: (text: string, prevText: string) => void;
   onSend: () => void;
   onInterrupt: () => void;
   onKeyPress: (key: string) => void;
@@ -49,7 +83,7 @@ export interface InputBarProps {
 
 // -- Component --
 
-export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
+export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(function InputBar({
   inputText,
   onChangeText,
   onSend,
@@ -79,6 +113,44 @@ export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
 }, ref) {
   const a11yDisabled = disabled ? { disabled: true as const } : undefined;
 
+  // #5556 — InputBar owns the composer draft internally so that streaming
+  // re-renders in SessionScreen don't re-render the TextInput on every delta.
+  // `inputText` is consumed once as an initial seed; subsequent changes flow
+  // through user keystrokes (onChangeText) or the imperative ref.
+  const [value, setValue] = useState(inputText ?? '');
+  const textInputRef = useRef<TextInput>(null);
+
+  // Keep a live ref to the current value so the imperative handle's getValue()
+  // and the programmatic setValue() always read the freshest draft without
+  // depending on a stale closure.
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  useImperativeHandle(ref, () => ({
+    focus: () => textInputRef.current?.focus(),
+    getValue: () => valueRef.current,
+    setValue: (text: string) => {
+      // Programmatic write — does NOT fire onChangeText, so paste detection /
+      // voice merge / marker strip don't recurse back into the parent diff.
+      valueRef.current = text;
+      setValue(text);
+    },
+    clear: () => {
+      valueRef.current = '';
+      setValue('');
+    },
+  }), []);
+
+  // User keystrokes: update the internal draft and notify the parent with both
+  // the new and previous values so it can run paste-diff detection (#3797)
+  // without holding the draft itself.
+  const handleChangeText = useCallback((next: string) => {
+    const prev = valueRef.current;
+    valueRef.current = next;
+    setValue(next);
+    onChangeText(next, prev);
+  }, [onChangeText]);
+
   // Pulsing animation for recording state
   const pulseAnim = useRef(new Animated.Value(1)).current;
   useEffect(() => {
@@ -101,12 +173,12 @@ export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
 
   // Filter slash commands based on current input (only when typing `/` at the start)
   const filteredCommands = useMemo(() => {
-    if (viewMode !== 'chat' || !inputText.startsWith('/') || slashCommands.length === 0) return [];
-    const query = inputText.slice(1).toLowerCase();
+    if (viewMode !== 'chat' || !value.startsWith('/') || slashCommands.length === 0) return [];
+    const query = value.slice(1).toLowerCase();
     // Show all commands if user just typed `/`
     if (!query) return slashCommands;
     return slashCommands.filter((cmd) => cmd.name.toLowerCase().includes(query));
-  }, [inputText, slashCommands, viewMode]);
+  }, [value, slashCommands, viewMode]);
 
   const showDropdown = filteredCommands.length > 0;
 
@@ -122,7 +194,7 @@ export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
             <TouchableOpacity
               key={cmd.name}
               style={styles.dropdownItem}
-              onPress={() => onChangeText(`/${cmd.name} `)}
+              onPress={() => handleChangeText(`/${cmd.name} `)}
               accessibilityRole="button"
               accessibilityLabel={`Slash command ${cmd.name}`}
             >
@@ -250,12 +322,12 @@ export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
           <Text style={styles.enterModeText}>{enterToSend ? ICON_RETURN : ICON_PARAGRAPH}</Text>
         </TouchableOpacity>
         <TextInput
-          ref={ref}
+          ref={textInputRef}
           style={[styles.input, !enterToSend && styles.inputMultiline, disabled && styles.inputDisabled]}
           placeholder={disabled ? (disabledPlaceholder || 'Reconnecting...') : !claudeReady ? 'Connecting to Claude...' : 'Message Claude...'}
           placeholderTextColor={COLORS.textDim}
-          value={inputText}
-          onChangeText={onChangeText}
+          value={value}
+          onChangeText={handleChangeText}
           // When enterToSend is true, multiline is false and onSubmitEditing fires on Enter.
           // When enterToSend is false, multiline is true so onSubmitEditing never fires.
           onSubmitEditing={enterToSend && !isStreaming && !disabled ? onSend : undefined}
@@ -342,7 +414,7 @@ export const InputBar = forwardRef<TextInput, InputBarProps>(function InputBar({
       </View>
     </View>
   );
-});
+}));
 
 // -- Styles --
 

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Render tests for the mobile InputBar input-state ownership (#5556).
+ *
+ * InputBar now owns its composer draft internally and exposes an imperative
+ * handle (focus/getValue/setValue/clear). This decouples typing from parent
+ * streaming re-renders: the parent no longer holds the draft in render-scope
+ * state, so message-delta re-renders don't churn the TextInput.
+ *
+ * Covers:
+ *  - getValue/setValue/clear round-trips through the ref
+ *  - user typing fires onChangeText(next, prev) and updates the draft
+ *  - setValue is silent (does NOT fire onChangeText) — the property the
+ *    voice-merge / paste-collapse / marker-strip paths rely on to avoid
+ *    recursing back into the parent diff
+ *  - React.memo: a parent re-render that leaves InputBar's props unchanged
+ *    does NOT re-render InputBar (the typing/streaming decoupling)
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { TextInput } from 'react-native';
+import { InputBar, type InputBarHandle } from '../InputBar';
+
+const noop = () => {};
+
+const baseProps = {
+  onSend: noop,
+  onInterrupt: noop,
+  onKeyPress: noop,
+  onClearTerminal: noop,
+  enterToSend: true,
+  onToggleEnterMode: noop,
+  isStreaming: false,
+  claudeReady: true,
+  viewMode: 'chat' as const,
+  hasTerminal: false,
+  bottomPadding: 0,
+};
+
+function getTextInput(tree: renderer.ReactTestRenderer): ReactTestInstance {
+  return tree.root.findByProps({ testID: 'chat-message-input' });
+}
+
+describe('InputBar imperative draft ownership (#5556)', () => {
+  it('round-trips draft via getValue/setValue/clear on the ref', () => {
+    const ref = React.createRef<InputBarHandle>();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar ref={ref} {...baseProps} onChangeText={noop} />);
+    });
+
+    expect(ref.current?.getValue()).toBe('');
+
+    act(() => { ref.current?.setValue('hello'); });
+    expect(ref.current?.getValue()).toBe('hello');
+    expect(getTextInput(tree).props.value).toBe('hello');
+
+    act(() => { ref.current?.clear(); });
+    expect(ref.current?.getValue()).toBe('');
+    expect(getTextInput(tree).props.value).toBe('');
+  });
+
+  it('seeds the initial draft from the inputText prop', () => {
+    const ref = React.createRef<InputBarHandle>();
+    act(() => {
+      renderer.create(<InputBar ref={ref} {...baseProps} inputText="seed" onChangeText={noop} />);
+    });
+    expect(ref.current?.getValue()).toBe('seed');
+  });
+
+  it('user typing fires onChangeText(next, prev) and updates the draft', () => {
+    const ref = React.createRef<InputBarHandle>();
+    const onChangeText = jest.fn();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar ref={ref} {...baseProps} onChangeText={onChangeText} />);
+    });
+
+    act(() => { getTextInput(tree).props.onChangeText('a'); });
+    expect(onChangeText).toHaveBeenCalledWith('a', '');
+    expect(ref.current?.getValue()).toBe('a');
+
+    act(() => { getTextInput(tree).props.onChangeText('ab'); });
+    expect(onChangeText).toHaveBeenLastCalledWith('ab', 'a');
+    expect(ref.current?.getValue()).toBe('ab');
+  });
+
+  it('setValue does NOT fire onChangeText (silent programmatic write)', () => {
+    const ref = React.createRef<InputBarHandle>();
+    const onChangeText = jest.fn();
+    act(() => {
+      renderer.create(<InputBar ref={ref} {...baseProps} onChangeText={onChangeText} />);
+    });
+
+    act(() => { ref.current?.setValue('voice transcript'); });
+    expect(onChangeText).not.toHaveBeenCalled();
+    expect(ref.current?.getValue()).toBe('voice transcript');
+
+    act(() => { ref.current?.clear(); });
+    expect(onChangeText).not.toHaveBeenCalled();
+  });
+
+  it('focus() drives the underlying TextInput', () => {
+    const ref = React.createRef<InputBarHandle>();
+    const focusSpy = jest.spyOn(TextInput.prototype, 'focus').mockImplementation(noop);
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar ref={ref} {...baseProps} onChangeText={noop} />);
+    });
+    // Sanity: the input is rendered.
+    expect(getTextInput(tree)).toBeTruthy();
+    act(() => { ref.current?.focus(); });
+    expect(focusSpy).toHaveBeenCalled();
+    focusSpy.mockRestore();
+  });
+
+  it('is memoized — a parent re-render with unchanged InputBar props does not re-render InputBar', () => {
+    // Count actual InputBar renders. InputBar reads `attachments.length` in its
+    // JSX body on every render (the attachment-strip gate, not memoized), so a
+    // Proxy whose `length` getter increments a counter fires exactly once per
+    // committed InputBar render.
+    let renderCount = 0;
+    const attachmentsArr: never[] = [];
+    const attachments = new Proxy(attachmentsArr, {
+      get(target, prop, recv) {
+        if (prop === 'length') renderCount++;
+        return Reflect.get(target, prop, recv);
+      },
+    });
+
+    // Stable handler / prop identities (what SessionScreen now guarantees via
+    // useCallback + the latest-ref send wrapper) keep InputBar's props shallow-
+    // equal across parent re-renders, so React.memo can short-circuit.
+    const stableProps = { ...baseProps, onChangeText: noop, attachments };
+
+    function Parent({ bump }: { bump: number }) {
+      // `bump` simulates streaming churn; intentionally not in InputBar's props.
+      void bump;
+      return <InputBar {...stableProps} />;
+    }
+
+    let tree!: renderer.ReactTestRenderer;
+    act(() => { tree = renderer.create(<Parent bump={0} />); });
+    const afterFirst = renderCount;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    // Parent re-renders with a new `bump` but every InputBar prop value is
+    // referentially equal → React.memo short-circuits → no InputBar re-render.
+    act(() => { tree.update(<Parent bump={1} />); });
+    expect(renderCount).toBe(afterFirst);
+
+    act(() => { tree.update(<Parent bump={2} />); });
+    expect(renderCount).toBe(afterFirst);
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -34,7 +34,7 @@ import type { SelectOptionValue } from '../components/chat/MessageBubble';
 import { TerminalView, TerminalHandle } from '../components/TerminalView';
 import { SettingsBar } from '../components/SettingsBar';
 import { WebTasksPanel } from '../components/WebTasksPanel';
-import { InputBar } from '../components/InputBar';
+import { InputBar, type InputBarHandle } from '../components/InputBar';
 import { ActivityIndicator } from '../components/ActivityIndicator';
 import { CheckInChip } from '../components/CheckInChip';
 import { FileBrowser } from '../components/FileBrowser';
@@ -121,7 +121,9 @@ export function formatTranscript(selected: ChatMessage[]): string {
 
 export function SessionScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const [inputText, setInputText] = useState('');
+  // #5556 — the composer draft now lives inside InputBar (see `inputRef`
+  // below). SessionScreen no longer holds it in render-scope state, which is
+  // what decouples typing from streaming-message re-renders.
   const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
   const [showAttachSheet, setShowAttachSheet] = useState(false);
   // #5517: ChatView's transcript is a virtualized FlatList. SessionScreen
@@ -367,7 +369,10 @@ export function SessionScreen() {
   const { isRecognizing, transcript, isAvailable: speechAvailable, startListening, stopListening, error: speechError } = useSpeechRecognition({
     mode: inputSettings.voiceInputMode,
   });
-  const dictationStartRef = useRef(inputText.length);
+  // Anchor index where the current dictation session began inserting. Seeded
+  // to 0 and reset in handleMicPress (and on manual edits during dictation)
+  // from the live draft length read off the InputBar ref (#5556).
+  const dictationStartRef = useRef(0);
   const usedVoiceRef = useRef(false);
 
   // Surface speech recognition errors to the user
@@ -531,8 +536,12 @@ export function SessionScreen() {
   const isSelectingRef = useRef(false);
   isSelectingRef.current = isSelecting;
 
-  // Ref for focusing the input bar when user taps "Give Feedback" on plan approval
-  const inputRef = useRef<TextInput>(null);
+  // #5556 — InputBar now owns its draft internally and exposes an imperative
+  // handle (focus/getValue/setValue/clear). SessionScreen reads/writes the
+  // composer draft through this ref for the send path, voice-transcript merge,
+  // seed prompts, and pasted-text marker stripping — so streaming re-renders no
+  // longer churn the TextInput on every delta.
+  const inputRef = useRef<InputBarHandle>(null);
 
   const toggleSelection = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -579,16 +588,23 @@ export function SessionScreen() {
     }
   }, [messages, selectedIds, clearSelection]);
 
-  const handleSend = () => {
+  // #5556 — `handleSend` closes over fast-changing state (pendingAttachments,
+  // streamingMessageId, pastedTextBlocks, viewMode, …), so a useCallback dep
+  // array would re-create it on every streaming delta and defeat InputBar's
+  // React.memo. Instead we keep the live implementation in a ref (refreshed
+  // each render) behind a single stable wrapper passed to InputBar.
+  const handleSendImpl = () => {
     const hasAttachments = pendingAttachments.length > 0;
-    if ((!inputText.trim() && !hasAttachments) || streamingMessageId) return;
+    // #5556 — read the draft from the InputBar ref (it owns the value now).
+    const draft = inputRef.current?.getValue() ?? '';
+    if ((!draft.trim() && !hasAttachments) || streamingMessageId) return;
     // Expand any collapsed-paste markers back to their original content
     // before send (#3797). Trim happens AFTER expansion so an expanded
     // payload with surrounding whitespace still sends cleanly.
     const blockMap = new Map(pastedTextBlocks.map(b => [b.id, b.content]));
-    const expanded = blockMap.size > 0 ? expandPasteMarkers(inputText, blockMap) : inputText;
+    const expanded = blockMap.size > 0 ? expandPasteMarkers(draft, blockMap) : draft;
     const text = expanded.trim();
-    setInputText('');
+    inputRef.current?.clear();
     // Clear paste state alongside the input — neither persists across sends.
     setPastedTextBlocks([]);
     pastedTextNextIdRef.current = 0;
@@ -659,6 +675,10 @@ export function SessionScreen() {
       });
     }
   };
+  // Refresh the live implementation each render, then expose a stable wrapper.
+  const handleSendRef = useRef(handleSendImpl);
+  handleSendRef.current = handleSendImpl;
+  const handleSend = useCallback(() => handleSendRef.current(), []);
 
   const addAttachment = useCallback(async (picker: () => Promise<Attachment | null>) => {
     if (pendingAttachments.length >= MAX_ATTACHMENTS) {
@@ -692,7 +712,7 @@ export function SessionScreen() {
     setPendingAttachments((prev) => prev.filter((a) => a.id !== id));
   }, []);
 
-  const handleKeyPress = (key: string) => {
+  const handleKeyPress = useCallback((key: string) => {
     const keyMap: Record<string, string> = {
       'Enter': '\r',
       'Tab': '\t',
@@ -709,7 +729,18 @@ export function SessionScreen() {
     if (keyMap[key]) {
       sendInput(keyMap[key]);
     }
-  };
+  }, [sendInput]);
+
+  // #5556 — stable handlers for InputBar so React.memo isn't defeated by
+  // fresh inline arrows on each streaming re-render.
+  const handleClearTerminal = useCallback(() => {
+    clearTerminalBuffer();
+    terminalRef.current?.clear();
+  }, [clearTerminalBuffer]);
+  const handleToggleEnterMode = useCallback(() => {
+    const key = viewMode === 'terminal' ? 'terminalEnterToSend' : 'chatEnterToSend';
+    updateInputSettings({ [key]: !inputSettings[key] });
+  }, [viewMode, inputSettings, updateInputSettings]);
 
   // Handle tapping a prompt option
   // #4755 — `value` widened to `SelectOptionValue` to carry the
@@ -790,11 +821,11 @@ export function SessionScreen() {
   }, []);
 
   const handleInvokeAgent = useCallback((agentName: string) => {
-    setInputText(`@${agentName} `);
+    inputRef.current?.setValue(`@${agentName} `);
     inputRef.current?.focus();
   }, []);
 
-  // Track whether the latest inputText change came from dictation (vs manual edit)
+  // Track whether the latest draft change came from dictation (vs manual edit)
   const isDictationUpdateRef = useRef(false);
 
   // Pasted-text-block storage for the composer (#3797). React Native
@@ -807,9 +838,12 @@ export function SessionScreen() {
   const pastedTextNextIdRef = useRef(0);
   const [inspectedPastedTextId, setInspectedPastedTextId] = useState<number | null>(null);
 
-  // Wrap setInputText to detect manual edits during dictation AND to
-  // collapse oversized pastes (#3797).
-  const handleChangeText = useCallback((text: string) => {
+  // #5556 — InputBar owns the draft and has already applied the user's
+  // keystroke before calling this; we only react to it. `prev` is supplied by
+  // InputBar (the value before this change) so paste-diff no longer needs the
+  // draft in SessionScreen's render-scope state. On a collapse we push the
+  // marker-substituted value BACK into InputBar via the imperative setValue.
+  const handleChangeText = useCallback((text: string, prev: string) => {
     if (!isDictationUpdateRef.current && isRecognizing) {
       // User manually edited text during dictation — update anchor point
       dictationStartRef.current = text.length;
@@ -825,28 +859,26 @@ export function SessionScreen() {
     // the 20-line threshold (#3798 review, #3799). Running
     // `detectPasteFromDiff` on every grow keeps both clients honouring
     // the same criteria.
-    const prev = inputText;
     if (text.length > prev.length) {
       const diff = detectPasteFromDiff(prev, text);
       if (diff && shouldCollapsePaste(diff.inserted)) {
         const nextId = pastedTextNextIdRef.current + 1;
         pastedTextNextIdRef.current = nextId;
         const marker = formatPasteMarker(nextId, diff.inserted);
-        setPastedTextBlocks(prev => [...prev, { id: nextId, content: diff.inserted }]);
-        setInputText(diff.prefix + marker + diff.suffix);
-        return;
+        setPastedTextBlocks(prevBlocks => [...prevBlocks, { id: nextId, content: diff.inserted }]);
+        inputRef.current?.setValue(diff.prefix + marker + diff.suffix);
       }
     }
-
-    setInputText(text);
-  }, [isRecognizing, inputText]);
+  }, [isRecognizing]);
 
   const handleRemovePastedText = useCallback((id: number) => {
     setPastedTextBlocks(prev => prev.filter(b => b.id !== id));
     // Strip this block's marker from the input. Per-id regex so we only
-    // touch the matching marker, not unrelated ones.
+    // touch the matching marker, not unrelated ones. #5556 — read/write the
+    // draft through the InputBar ref instead of a functional setState.
     const markerRe = new RegExp(`\\[Pasted text #${id} \\+\\d+ (?:lines|chars)\\]`, 'g');
-    setInputText(prev => prev.replace(markerRe, ''));
+    const current = inputRef.current?.getValue() ?? '';
+    inputRef.current?.setValue(current.replace(markerRe, ''));
     setInspectedPastedTextId(curr => (curr === id ? null : curr));
   }, []);
 
@@ -854,23 +886,26 @@ export function SessionScreen() {
     setInspectedPastedTextId(id);
   }, []);
 
-  // Voice input: toggle start/stop and merge transcript into input text
+  // Voice input: toggle start/stop and merge transcript into input text.
+  // #5556 — anchor the dictation start at the live draft length read off the
+  // InputBar ref, and merge the transcript back through the ref.
   const handleMicPress = useCallback(() => {
     if (isRecognizing) {
       stopListening();
     } else {
-      dictationStartRef.current = inputText.length;
+      dictationStartRef.current = (inputRef.current?.getValue() ?? '').length;
       startListening();
     }
-  }, [isRecognizing, inputText.length, startListening, stopListening]);
+  }, [isRecognizing, startListening, stopListening]);
 
   useEffect(() => {
     if (isRecognizing && transcript) {
-      const prefix = inputText.slice(0, dictationStartRef.current);
+      const current = inputRef.current?.getValue() ?? '';
+      const prefix = current.slice(0, dictationStartRef.current);
       const separator = prefix.length > 0 && !prefix.endsWith(' ') ? ' ' : '';
       isDictationUpdateRef.current = true;
       usedVoiceRef.current = true;
-      setInputText(prefix + separator + transcript);
+      inputRef.current?.setValue(prefix + separator + transcript);
     }
   }, [transcript]); // eslint-disable-line react-hooks/exhaustive-deps -- only react to transcript changes
 
@@ -1463,17 +1498,13 @@ export function SessionScreen() {
       {/* Input area */}
       <InputBar
         ref={inputRef}
-        inputText={inputText}
         onChangeText={handleChangeText}
         onSend={handleSend}
         onInterrupt={sendInterrupt}
-        onClearTerminal={() => { clearTerminalBuffer(); terminalRef.current?.clear(); }}
+        onClearTerminal={handleClearTerminal}
         onKeyPress={handleKeyPress}
         enterToSend={enterToSend}
-        onToggleEnterMode={() => {
-          const key = viewMode === 'terminal' ? 'terminalEnterToSend' : 'chatEnterToSend';
-          updateInputSettings({ [key]: !inputSettings[key] });
-        }}
+        onToggleEnterMode={handleToggleEnterMode}
         isStreaming={!!streamingMessageId}
         claudeReady={claudeReady}
         viewMode={viewMode}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -306,6 +306,11 @@ export function App() {
   const dismissExposureBanner = useConnectionStore(s => s.dismissExposureBanner)
   const serverStartupLogs = useConnectionStore(s => s.serverStartupLogs)
   const connectionRetryCount = useConnectionStore(s => s.connectionRetryCount)
+  // #5556 — restart-countdown parity with mobile: feed the ETA/anchor/reason
+  // through to ReconnectBanner so it can render a live ~M:SS countdown.
+  const shutdownReason = useConnectionStore(s => s.shutdownReason)
+  const restartEtaMs = useConnectionStore(s => s.restartEtaMs)
+  const restartingSince = useConnectionStore(s => s.restartingSince)
   const filePickerFiles = useConnectionStore(s => s.filePickerFiles)
   const sessionNotifications = useConnectionStore(s => s.sessionNotifications)
   // #5510 (epic #5509): pairing-approval primitive — host-surface pending queue.
@@ -2259,6 +2264,9 @@ export function App() {
         attempt={connectionRetryCount}
         maxAttempts={5}
         message={connectionPhase === 'server_restarting' ? 'Server restarting...' : undefined}
+        restartEtaMs={connectionPhase === 'server_restarting' ? restartEtaMs : null}
+        restartingSince={connectionPhase === 'server_restarting' ? restartingSince : null}
+        shutdownReason={connectionPhase === 'server_restarting' ? shutdownReason : null}
         onRetry={handleRetry}
         onStartServer={isTauri() ? handleStartServer : undefined}
       />

--- a/packages/dashboard/src/components/ReconnectBanner.test.tsx
+++ b/packages/dashboard/src/components/ReconnectBanner.test.tsx
@@ -90,6 +90,30 @@ describe('ReconnectBanner', () => {
       expect(screen.getByTestId('reconnect-banner').textContent).toContain('~1:05')
     })
 
+    it('does not throw when the ETA is already expired on mount', () => {
+      // Regression: the first synchronous `update()` runs before `interval` is
+      // assigned, so an already-zero countdown must not hit a TDZ on
+      // `clearInterval(interval)`. `restartingSince` is in the past beyond the
+      // ETA, so `computeRemaining` returns 0 on the very first call.
+      const now = 2_500_000
+      vi.setSystemTime(now)
+      expect(() => {
+        render(
+          <ReconnectBanner
+            {...baseProps}
+            message="Server restarting..."
+            restartEtaMs={5_000}
+            restartingSince={now - 10_000}
+            shutdownReason="restart"
+          />,
+        )
+      }).not.toThrow()
+      const text = screen.getByTestId('reconnect-banner').textContent || ''
+      // Expired → no countdown, falls back to the plain restart line.
+      expect(text).toContain('Server restarting...')
+      expect(text).not.toMatch(/~\d+:\d{2}/)
+    })
+
     it('ticks the countdown down each second', () => {
       const now = 3_000_000
       vi.setSystemTime(now)

--- a/packages/dashboard/src/components/ReconnectBanner.test.tsx
+++ b/packages/dashboard/src/components/ReconnectBanner.test.tsx
@@ -2,7 +2,7 @@
  * ReconnectBanner accessibility and rendering tests (#1720)
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { ReconnectBanner } from './ReconnectBanner'
 
 afterEach(cleanup)
@@ -53,5 +53,167 @@ describe('ReconnectBanner', () => {
     render(<ReconnectBanner {...baseProps} onRetry={onRetry} />)
     fireEvent.click(screen.getByTestId('retry-button'))
     expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  // #5556 — restart-countdown parity with mobile.
+  describe('restart-countdown mode (#5556)', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('renders a ~M:SS countdown from restartEtaMs/restartingSince', () => {
+      const now = 1_000_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={90_000}
+          restartingSince={now}
+          shutdownReason="restart"
+        />,
+      )
+      // 90s remaining → ~1:30
+      expect(screen.getByTestId('reconnect-banner').textContent).toContain('Server restarting... ~1:30')
+    })
+
+    it('zero-pads the seconds component', () => {
+      const now = 2_000_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={65_000}
+          restartingSince={now}
+          shutdownReason="restart"
+        />,
+      )
+      // 65s → ~1:05 (not ~1:5)
+      expect(screen.getByTestId('reconnect-banner').textContent).toContain('~1:05')
+    })
+
+    it('ticks the countdown down each second', () => {
+      const now = 3_000_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={10_000}
+          restartingSince={now}
+          shutdownReason="restart"
+        />,
+      )
+      expect(screen.getByTestId('reconnect-banner').textContent).toContain('~0:10')
+      act(() => {
+        vi.advanceTimersByTime(3_000)
+      })
+      expect(screen.getByTestId('reconnect-banner').textContent).toContain('~0:07')
+    })
+
+    it('expires gracefully — drops the countdown and falls back to the plain restart line', () => {
+      const now = 4_000_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          message="Server restarting..."
+          restartEtaMs={5_000}
+          restartingSince={now}
+          shutdownReason="restart"
+        />,
+      )
+      act(() => {
+        vi.advanceTimersByTime(6_000)
+      })
+      const text = screen.getByTestId('reconnect-banner').textContent || ''
+      expect(text).toContain('Server restarting...')
+      expect(text).not.toMatch(/~\d+:\d{2}/)
+    })
+
+    it('shows "Graceful restart" detail for shutdownReason=restart', () => {
+      const now = 5_000_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={30_000}
+          restartingSince={now}
+          shutdownReason="restart"
+        />,
+      )
+      expect(screen.getByTestId('reconnect-detail').textContent).toBe('Graceful restart')
+    })
+
+    it('shows "Recovering from crash" detail for a null shutdownReason', () => {
+      const now = 6_000_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={30_000}
+          restartingSince={now}
+          shutdownReason={null}
+        />,
+      )
+      expect(screen.getByTestId('reconnect-detail').textContent).toBe('Recovering from crash')
+    })
+
+    it('shows "Recovering from crash" detail for shutdownReason=crash', () => {
+      const now = 6_500_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={30_000}
+          restartingSince={now}
+          shutdownReason="crash"
+        />,
+      )
+      expect(screen.getByTestId('reconnect-detail').textContent).toBe('Recovering from crash')
+    })
+
+    it('shows a terminal "Server shut down" line with no countdown for shutdownReason=shutdown', () => {
+      const now = 7_000_000
+      vi.setSystemTime(now)
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={30_000}
+          restartingSince={now}
+          shutdownReason="shutdown"
+        />,
+      )
+      const text = screen.getByTestId('reconnect-banner').textContent || ''
+      expect(text).toContain('Server shut down')
+      expect(text).not.toMatch(/~\d+:\d{2}/)
+      expect(screen.queryByTestId('reconnect-detail')).not.toBeInTheDocument()
+    })
+
+    it('plain-message mode is unchanged when restart fields are absent', () => {
+      render(<ReconnectBanner {...baseProps} message="Server unreachable" />)
+      const text = screen.getByTestId('reconnect-banner').textContent || ''
+      expect(text).toContain('Server unreachable')
+      expect(text).not.toMatch(/~\d+:\d{2}/)
+      expect(screen.queryByTestId('reconnect-detail')).not.toBeInTheDocument()
+    })
+
+    it('does not leave a timer running after unmount', () => {
+      const now = 8_000_000
+      vi.setSystemTime(now)
+      const { unmount } = render(
+        <ReconnectBanner
+          {...baseProps}
+          restartEtaMs={30_000}
+          restartingSince={now}
+          shutdownReason="restart"
+        />,
+      )
+      unmount()
+      // Advancing time after unmount must not throw (no setState on an
+      // unmounted component → no dangling interval).
+      expect(() => {
+        act(() => {
+          vi.advanceTimersByTime(5_000)
+        })
+      }).not.toThrow()
+    })
   })
 })

--- a/packages/dashboard/src/components/ReconnectBanner.tsx
+++ b/packages/dashboard/src/components/ReconnectBanner.tsx
@@ -83,13 +83,18 @@ export function ReconnectBanner({
       setCountdown(null)
       return
     }
+    // `interval` is declared up front (not `const` in-block) so the first
+    // synchronous `update()` — which runs before `setInterval` returns — can
+    // safely call `clearInterval(interval)` if the ETA is already expired on
+    // mount, instead of hitting a TDZ ReferenceError on the `const`.
+    let interval: ReturnType<typeof setInterval> | undefined
     const update = () => {
       const remaining = computeRemaining(restartEtaMs, restartingSince)
       setCountdown(remaining)
-      if (remaining != null && remaining <= 0) clearInterval(interval)
+      if (remaining != null && remaining <= 0 && interval !== undefined) clearInterval(interval)
     }
     update()
-    const interval = setInterval(update, 1000)
+    interval = setInterval(update, 1000)
     return () => clearInterval(interval)
   }, [visible, inRestartMode, restartEtaMs, restartingSince])
 

--- a/packages/dashboard/src/components/ReconnectBanner.tsx
+++ b/packages/dashboard/src/components/ReconnectBanner.tsx
@@ -1,6 +1,22 @@
 /**
  * ReconnectBanner — connection lost notification with retry.
+ *
+ * Two modes:
+ *  - **Plain message mode** (default): renders `message` (or a generic
+ *    "Connection lost" fallback) plus the attempt counter. Used for ordinary
+ *    reconnect attempts.
+ *  - **Restart-countdown mode**: when `restartEtaMs`/`restartingSince` are
+ *    supplied, renders a live `~M:SS` countdown plus a context line
+ *    ("Graceful restart" / "Recovering from crash"), mirroring the mobile
+ *    SessionScreen banner. `shutdownReason === 'shutdown'` shows a terminal
+ *    "Server shut down" message with no countdown.
+ *
+ * The countdown ticks client-side on a 1s interval while the banner is
+ * visible and is cleaned up on unmount / when restart state clears.
  */
+import { useState, useEffect } from 'react'
+
+export type ShutdownReason = 'restart' | 'shutdown' | 'crash' | null
 
 export interface ReconnectBannerProps {
   visible: boolean
@@ -9,16 +25,106 @@ export interface ReconnectBannerProps {
   message?: string
   onRetry: () => void
   onStartServer?: () => void
+  /**
+   * Total restart ETA in milliseconds (from the server's health-check
+   * `restartEtaMs`). When present together with `restartingSince`, the banner
+   * renders restart-countdown mode instead of the plain-message mode.
+   */
+  restartEtaMs?: number | null
+  /** Epoch ms when the restart began — the countdown anchor. */
+  restartingSince?: number | null
+  /**
+   * Why the server is unavailable. `'restart'` → graceful, `'crash'`/null →
+   * recovering, `'shutdown'` → terminal (no countdown).
+   */
+  shutdownReason?: ShutdownReason
 }
 
-export function ReconnectBanner({ visible, attempt, maxAttempts, message, onRetry, onStartServer }: ReconnectBannerProps) {
+/**
+ * Compute the remaining whole seconds until the restart ETA, clamped at 0.
+ * Returns null when restart state isn't populated.
+ */
+function computeRemaining(restartEtaMs: number | null | undefined, restartingSince: number | null | undefined): number | null {
+  if (!restartEtaMs || restartEtaMs <= 0 || !restartingSince) return null
+  const elapsed = Date.now() - restartingSince
+  return Math.max(0, Math.ceil((restartEtaMs - elapsed) / 1000))
+}
+
+function formatCountdown(seconds: number): string {
+  return `~${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`
+}
+
+export function ReconnectBanner({
+  visible,
+  attempt,
+  maxAttempts,
+  message,
+  onRetry,
+  onStartServer,
+  restartEtaMs,
+  restartingSince,
+  shutdownReason,
+}: ReconnectBannerProps) {
+  // Restart-countdown mode is active only when both the ETA and the anchor
+  // timestamp are populated. `shutdownReason === 'shutdown'` is terminal and
+  // shows no countdown even if an ETA is somehow present.
+  const inRestartMode =
+    !!restartEtaMs && restartEtaMs > 0 && !!restartingSince && shutdownReason !== 'shutdown'
+
+  // Client-side ticking countdown. Mirrors the mobile SessionScreen effect:
+  // recompute every second, clear the interval once it hits zero, and reset to
+  // null whenever the banner leaves restart mode. Only runs while visible so a
+  // hidden banner doesn't keep a timer alive.
+  const [countdown, setCountdown] = useState<number | null>(() =>
+    inRestartMode ? computeRemaining(restartEtaMs, restartingSince) : null,
+  )
+  useEffect(() => {
+    if (!visible || !inRestartMode) {
+      setCountdown(null)
+      return
+    }
+    const update = () => {
+      const remaining = computeRemaining(restartEtaMs, restartingSince)
+      setCountdown(remaining)
+      if (remaining != null && remaining <= 0) clearInterval(interval)
+    }
+    update()
+    const interval = setInterval(update, 1000)
+    return () => clearInterval(interval)
+  }, [visible, inRestartMode, restartEtaMs, restartingSince])
+
   if (!visible) return null
+
+  // Build the primary status line. Restart mode overrides the plain message.
+  let statusText: string
+  if (shutdownReason === 'shutdown') {
+    statusText = 'Server shut down'
+  } else if (inRestartMode && countdown != null && countdown > 0) {
+    statusText = `Server restarting... ${formatCountdown(countdown)}`
+  } else if (inRestartMode || message) {
+    statusText = message || 'Server restarting...'
+  } else {
+    statusText = 'Connection lost. Reconnecting...'
+  }
+
+  // Context detail line, restart mode only. `'restart'` → graceful; a null /
+  // `'crash'` reason → recovering. `'shutdown'` shows no detail.
+  let detail: string | null = null
+  if (inRestartMode) {
+    if (shutdownReason === 'restart') detail = 'Graceful restart'
+    else if (!shutdownReason || shutdownReason === 'crash') detail = 'Recovering from crash'
+  }
 
   return (
     <div className="reconnect-banner" data-testid="reconnect-banner" role="status" aria-live="polite">
       <span className="reconnect-message">
-        {message || 'Connection lost. Reconnecting...'} (attempt {attempt}/{maxAttempts})
+        {statusText} (attempt {attempt}/{maxAttempts})
       </span>
+      {detail && (
+        <span className="reconnect-detail" data-testid="reconnect-detail">
+          {detail}
+        </span>
+      )}
       {onStartServer && (
         <button
           className="btn-retry"

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3207,6 +3207,15 @@ button.sidebar-token-view-session-row:hover {
   flex: 1;
 }
 
+/* #5556 — restart-mode context line ("Graceful restart" / "Recovering from
+   crash"). Muted secondary label that rides alongside the message without
+   competing for the flex stretch. */
+.reconnect-detail {
+  flex-shrink: 0;
+  opacity: 0.75;
+  font-size: var(--text-sm);
+}
+
 .btn-retry {
   background: var(--accent-orange);
   color: var(--bg-secondary);


### PR DESCRIPTION
Phase-1 client UX-parity quick wins from the swarm audit. Two fixes, one PR — each ports polish that existed on one client to the other.

## FIX 1 — Dashboard ReconnectBanner: restart countdown parity with mobile

**Summary:** The dashboard store already populated `restartEtaMs` / `restartingSince` / `shutdownReason`, but `ReconnectBanner` only accepted a static `message` and App.tsx fed it the flat string `'Server restarting...'`. The mobile SessionScreen banner shows a live `~M:SS` countdown plus "Graceful restart" vs "Recovering from crash" context. This ports those exact semantics to the dashboard:

- `ReconnectBanner` now accepts `restartEtaMs` / `restartingSince` / `shutdownReason`. When both the ETA and the anchor timestamp are populated it renders **restart-countdown mode**: `Server restarting... ~M:SS` plus a context detail line (`Graceful restart` for `shutdownReason='restart'`, `Recovering from crash` for `null`/`'crash'`). `shutdownReason='shutdown'` shows a terminal `Server shut down` line with no countdown.
- The countdown ticks client-side on a 1s interval **while the banner is visible** and is cleaned up on unmount / when restart state clears (mirrors the mobile effect, including the `Math.ceil((eta - elapsed)/1000)` formula and zero-padded seconds).
- **Plain-message mode is unchanged** for all non-restart uses.
- App.tsx feeds the three fields through, gated on the `server_restarting` phase.
- Added `.reconnect-detail` styling for the context line.

**Test plan:** `ReconnectBanner.test.tsx` extended with restart-mode tests (countdown renders from `restartEtaMs`, ticks down each second, zero-pads, expires gracefully back to the plain line, `Graceful restart` / `Recovering from crash` / `Server shut down` copy, plain-message mode unchanged, no timer leak after unmount). Dashboard: `npx tsc --noEmit` clean, `npm test` 177 files / 3476 tests pass, `npm run build` succeeds.

## FIX 2 — Mobile InputBar: decouple typing from streaming re-renders

**Summary:** `SessionScreen` owned the composer draft (`inputText`) via `useState` while also subscribing to messages, so every streaming delta re-rendered `SessionScreen` and the un-memoized `InputBar` with fresh inline-arrow props. The dashboard already solved this with internal input state; this ports the pattern to mobile.

- **InputBar owns its draft internally** and exposes an imperative handle `InputBarHandle` (`focus` / `getValue` / `setValue` / `clear`) through the existing ref. `setValue` is a **silent** programmatic write (does not fire `onChangeText`), so the voice-merge, paste-collapse, and marker-strip paths don't recurse back into the parent diff.
- `onChangeText` now reports `(next, prev)` so paste-diff detection (#3797) works without the parent holding the draft in render-scope state.
- `InputBar` is wrapped in `React.memo`.
- **Every prior `inputText` consumer was traced and rerouted through the ref:** the send path (`getValue` + `clear`), seed prompts (`@agent ` via `setValue`), voice-transcript merge (read prefix via `getValue`, write via `setValue`, anchor via `getValue().length`), and pasted-text marker stripping. Handlers passed to InputBar are stabilised (useCallback for `handleKeyPress` / `handleClearTerminal` / `handleToggleEnterMode` / the existing change/mic/paste callbacks, plus a latest-ref wrapper for `handleSend`) so `React.memo` isn't defeated by fresh inline props on each streaming re-render.

**Test plan:** New `InputBar.imperative.test.tsx` (react-test-renderer) covers the imperative API round-trip, the initial-seed prop, `onChangeText(next, prev)` on user typing, **silent setValue** (no `onChangeText`), `focus()`, and a **render-count test** proving InputBar does not re-render when an unrelated parent prop changes. `ComponentRendering.test.ts` updated for the optional `inputText` prop + the new handle/memo. App: `npx tsc --noEmit` clean, full jest suite 123 suites / 1704 tests pass.

### InputBar ref API decision

InputBar exposes a slightly larger imperative surface (`getValue`/`setValue`/`clear` on top of `focus`) rather than changing behavior, per the brief's "prefer a slightly larger ref API over changed behavior" guidance. `setValue` is intentionally silent (no `onChangeText`) — the three programmatic-write paths (voice merge, paste collapse, marker strip) rely on this to avoid recursing into the parent's paste-diff. The `handleSend` stability uses a latest-ref wrapper because `handleSend` closes over fast-changing state (`streamingMessageId`, `pendingAttachments`, `pastedTextBlocks`, …) — a useCallback dep array would re-create it on every streaming delta and defeat the memo.

Related to #5556
