### PR TITLE
perf(server): shrink the delta-coalescing window — client EWMA is the adaptive throttle (#5562)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -674,20 +674,31 @@ Object.assign(EVENT_MAP, {
 export class EventNormalizer {
   /**
    * @param {object} [opts]
-   * @param {number} [opts.flushIntervalMs=50] - default delta coalescing window.
-   * @param {number} [opts.singleClientFlushIntervalMs=25] - #5516 (epic #5514):
-   *   tighter window used when EXACTLY ONE client is subscribed to the session
-   *   being buffered. With a single viewer there's no fan-out to amortize, so a
-   *   tighter coalescing window cuts perceived streaming latency in half (the
-   *   common phone-on-LAN / single-dashboard case). Multi-client sessions keep
-   *   the default window unchanged — coalescing amortizes the fan-out cost and
-   *   keeps every client's bandwidth bounded.
+   * @param {number} [opts.flushIntervalMs=16] - #5562: default delta micro-batch
+   *   window. This is NOT an adaptive throttle — it's a small fixed window that
+   *   coalesces the burst of per-token deltas a provider emits into a single
+   *   emit + broadcast, bounding per-token CPU/socket overhead. The ADAPTIVE
+   *   throttle lives client-side (store-core resolveDeltaFlushMs, a 16-100ms
+   *   EWMA keyed on render cost). Before #5562 the server window was 25/50ms,
+   *   which STACKED on top of the client EWMA — up to ~150ms of pure buffering
+   *   on a poor link, and a LAN client never got under the 25ms floor. Shrinking
+   *   it to ~8-16ms leaves the client EWMA as the sole adaptive system while the
+   *   server still amortizes the per-token broadcast cost.
+   * @param {number} [opts.singleClientFlushIntervalMs=8] - #5562: tighter
+   *   micro-batch window used when EXACTLY ONE client is subscribed to the
+   *   session being buffered. With a single viewer there's no fan-out to
+   *   amortize, so the window only needs to absorb the immediate per-token burst
+   *   (the common phone-on-LAN / single-dashboard case). The subscriber-count
+   *   distinction is kept because it bounds broadcast amplification — a wider
+   *   window on multi-client sessions still batches the fan-out — but both
+   *   values are now far below the client EWMA floor so they no longer dominate
+   *   end-to-end latency.
    * @param {(sessionId: string|null) => (number|null)} [opts.getSubscriberCount]
    *   - returns how many clients are subscribed to `sessionId`, or null when
    *   unknown (e.g. legacy single-session mode). When the count is exactly 1 the
    *   single-client window is used; otherwise (0, ≥2, or null) the default.
    */
-  constructor({ flushIntervalMs = 50, singleClientFlushIntervalMs = 25, getSubscriberCount = null, maxKeyBytes = MAX_DELTA_KEY_BYTES, maxTotalBytes = MAX_DELTA_TOTAL_BYTES } = {}) {
+  constructor({ flushIntervalMs = 16, singleClientFlushIntervalMs = 8, getSubscriberCount = null, maxKeyBytes = MAX_DELTA_KEY_BYTES, maxTotalBytes = MAX_DELTA_TOTAL_BYTES } = {}) {
     this._flushIntervalMs = flushIntervalMs
     this._singleClientFlushIntervalMs = singleClientFlushIntervalMs
     this._getSubscriberCount = typeof getSubscriberCount === 'function' ? getSubscriberCount : null
@@ -721,10 +732,12 @@ export class EventNormalizer {
   }
 
   /**
-   * #5516: resolve the coalescing window for the session currently being
-   * buffered. Single-subscriber sessions get the tighter window; everything
-   * else (0, 2+, or unknown count) keeps the default. No subscriber-count
-   * resolver wired (legacy mode) → always the default.
+   * #5516/#5562: resolve the fixed micro-batch window for the session currently
+   * being buffered. Single-subscriber sessions get the tighter window;
+   * everything else (0, 2+, or unknown count) keeps the default. No
+   * subscriber-count resolver wired (legacy mode) → always the default. This is
+   * a fixed window, not an adaptive throttle — the adaptive part lives in the
+   * client's resolveDeltaFlushMs EWMA (store-core).
    * @param {string|null} sessionId
    * @returns {number} flush interval in ms
    */
@@ -831,12 +844,15 @@ export class EventNormalizer {
       }
       return
     }
-    // #5516 (epic #5514): adaptive coalescing window — tighter (25ms) when this
-    // session has a single subscriber, default (50ms) otherwise. The flush
+    // #5516/#5562: fixed micro-batch window (NOT an adaptive coalescing window)
+    // — tighter (8ms) when this session has a single subscriber, default (16ms)
+    // otherwise. Its only job is to absorb the per-token burst into one
+    // emit/broadcast and bound that overhead; the ADAPTIVE throttle lives
+    // client-side in store-core resolveDeltaFlushMs (16-100ms EWMA). The flush
     // timer is shared across all buffered sessions, so a single-client session
     // buffered AFTER a default-window timer was already armed must be able to
     // pull the deadline IN (reschedule to the sooner target) rather than wait
-    // out the 50ms. We never push a deadline out.
+    // out the wider window. We never push a deadline out.
     const intervalMs = this._resolveFlushIntervalMs(sessionId)
     const now = performance.now()
     const wantDeadline = now + intervalMs

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -890,12 +890,15 @@ export class WsServer {
     }
 
     this.serverMode = 'cli'
-    // #5516 (epic #5514): hand the normalizer a subscriber-count resolver so it
-    // can tighten the delta-coalescing window (50→25ms) when a session has a
+    // #5516/#5562: hand the normalizer a subscriber-count resolver so it can
+    // tighten the fixed delta micro-batch window (16→8ms) when a session has a
     // single subscriber — the common phone-on-LAN / single-dashboard case.
-    // Multi-client sessions keep the 50ms window (fan-out amortization). Legacy
-    // single-session mode (sessionId === null) reports null (unknown), which the
-    // normalizer treats as "keep the default window".
+    // Multi-client sessions keep the 16ms window (fan-out amortization). These
+    // are fixed micro-batch windows, not an adaptive throttle — the adaptive
+    // part is the client-side store-core EWMA (resolveDeltaFlushMs); #5562
+    // shrank the server window from 25/50ms so it no longer stacks on top of
+    // that EWMA. Legacy single-session mode (sessionId === null) reports null
+    // (unknown), which the normalizer treats as "keep the default window".
     this._normalizer = new EventNormalizer({
       getSubscriberCount: (sessionId) =>
         sessionId == null ? null : this._broadcaster._countSessionSubscribers(sessionId),

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1127,33 +1127,52 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
   })
 
   // #5562 + #5520: real-timer sanity check that the shrunk window actually
-  // flushes a buffered delta inside ~2× the resolved window. Uses the #5515/#5520
-  // emitMonoMs instrumentation that bufferDelta carries through to the flushed
-  // entry — proving that hook still round-trips after the window change. Wall-clock
-  // tolerant (2× the 8ms solo window) rather than fake-timer exact, so it stays
-  // robust under CI scheduling jitter; runs with --test-force-exit.
-  it('flushes a single-subscriber delta within ~2x the 8ms window (real timer)', async () => {
+  // flushes a buffered delta through the real setTimeout path, and that the
+  // #5515/#5520 emitMonoMs instrumentation bufferDelta carries through still
+  // round-trips to the flushed entry after the window change. The EXACT 8/16ms
+  // contract is locked by the setTimeout-spy tests above; this test deliberately
+  // does NOT re-assert it. The upper bound here is a loose ceiling only — proof
+  // the flush is no longer near the old 25/50ms-stacked floor — set well above
+  // worst-case timer slip so it can't go flaky under CI scheduling jitter. A
+  // bounded timeout makes a never-fired callback fail fast instead of hanging,
+  // and destroy() runs in finally so an assertion failure can't leak the timer.
+  it('flushes a single-subscriber delta via the real timer and round-trips emitMonoMs', async () => {
     const n = new EventNormalizer({ getSubscriberCount: () => 1 })
-    const flushed = []
-    let resolveFlush
-    const done = new Promise((res) => { resolveFlush = res })
-    n.onFlush = (entries) => {
-      flushed.push({ at: performance.now(), entries })
-      resolveFlush()
+    try {
+      const flushed = []
+      let resolveFlush
+      const done = new Promise((res) => { resolveFlush = res })
+      n.onFlush = (entries) => {
+        flushed.push({ at: performance.now(), entries })
+        resolveFlush()
+      }
+      const emitMono = Number(process.hrtime.bigint() / 1_000_000n)
+      const buffered = performance.now()
+      n.bufferDelta('sess-1', 'msg-1', 'hello', emitMono)
+      // Bounded race: if the flush callback never fires, fail fast rather than
+      // hang until the test-runner timeout.
+      let bail
+      const timeout = new Promise((_, rej) => {
+        bail = setTimeout(() => rej(new Error('flush callback did not fire within 1000ms')), 1000)
+      })
+      try {
+        await Promise.race([done, timeout])
+      } finally {
+        clearTimeout(bail)
+      }
+      const elapsed = flushed[0].at - buffered
+      // Loose ceiling — NOT the 8ms contract (that's the spy tests' job). 100ms is
+      // far above any realistic single-timer slip yet still well below the old
+      // 25/50ms server window stacked on the client EWMA, so it confirms the
+      // server half no longer dominates without being jitter-sensitive.
+      assert.ok(elapsed < 100, `expected a prompt real-timer flush, got ${elapsed.toFixed(1)}ms`)
+      assert.equal(flushed[0].entries.length, 1)
+      assert.equal(flushed[0].entries[0].delta, 'hello')
+      // The #5520 emitMonoMs instrumentation survives the coalescing path.
+      assert.equal(flushed[0].entries[0].emitMonoMs, emitMono)
+    } finally {
+      n.destroy()
     }
-    const emitMono = Number(process.hrtime.bigint() / 1_000_000n)
-    const buffered = performance.now()
-    n.bufferDelta('sess-1', 'msg-1', 'hello', emitMono)
-    await done
-    const elapsed = flushed[0].at - buffered
-    // 2x the 8ms solo window = 16ms budget; allow generous headroom for CI jitter
-    // while still asserting we're nowhere near the old 25/50ms floor.
-    assert.ok(elapsed < 24, `expected flush within ~2x the 8ms window, got ${elapsed.toFixed(1)}ms`)
-    assert.equal(flushed[0].entries.length, 1)
-    assert.equal(flushed[0].entries[0].delta, 'hello')
-    // The #5520 emitMonoMs instrumentation survives the coalescing path.
-    assert.equal(flushed[0].entries[0].emitMonoMs, emitMono)
-    n.destroy()
   })
 })
 

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1037,20 +1037,23 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
     try { fn(delays) } finally { mock.restoreAll() }
   }
 
-  it('uses the 25ms window when a session has exactly one subscriber', () => {
+  // #5562: the server micro-batch window was shrunk from 25/50ms to 8/16ms so
+  // it no longer stacks on the client's 16-100ms EWMA. These assert the NEW
+  // contract (8ms single-subscriber / 16ms otherwise).
+  it('uses the 8ms window when a session has exactly one subscriber', () => {
     const n = new EventNormalizer({ getSubscriberCount: () => 1 })
     withSetTimeoutSpy((delays) => {
       n.bufferDelta('sess-1', 'msg-1', 'hi')
-      assert.equal(delays[0], 25)
+      assert.equal(delays[0], 8)
     })
     n.destroy()
   })
 
-  it('uses the default 50ms window when 2+ clients are subscribed', () => {
+  it('uses the default 16ms window when 2+ clients are subscribed', () => {
     const n = new EventNormalizer({ getSubscriberCount: () => 2 })
     withSetTimeoutSpy((delays) => {
       n.bufferDelta('sess-1', 'msg-1', 'hi')
-      assert.equal(delays[0], 50)
+      assert.equal(delays[0], 16)
     })
     n.destroy()
   })
@@ -1059,14 +1062,14 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
     const nZero = new EventNormalizer({ getSubscriberCount: () => 0 })
     withSetTimeoutSpy((delays) => {
       nZero.bufferDelta('sess-1', 'msg-1', 'hi')
-      assert.equal(delays[0], 50)
+      assert.equal(delays[0], 16)
     })
     nZero.destroy()
 
     const nNull = new EventNormalizer({ getSubscriberCount: () => null })
     withSetTimeoutSpy((delays) => {
       nNull.bufferDelta('sess-1', 'msg-1', 'hi')
-      assert.equal(delays[0], 50)
+      assert.equal(delays[0], 16)
     })
     nNull.destroy()
   })
@@ -1075,7 +1078,7 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
     const n = new EventNormalizer()
     withSetTimeoutSpy((delays) => {
       n.bufferDelta('sess-1', 'msg-1', 'hi')
-      assert.equal(delays[0], 50)
+      assert.equal(delays[0], 16)
     })
     n.destroy()
   })
@@ -1098,14 +1101,14 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
     const counts = { 'sess-multi': 3, 'sess-solo': 1 }
     const n = new EventNormalizer({ getSubscriberCount: (s) => counts[s] ?? 0 })
     withSetTimeoutSpy((delays) => {
-      // Multi-client session arms the 50ms timer first.
+      // Multi-client session arms the 16ms timer first.
       n.bufferDelta('sess-multi', 'm', 'a')
-      assert.equal(delays[0], 50)
+      assert.equal(delays[0], 16)
       // A solo session buffered immediately after must SHORTEN the deadline:
-      // the reschedule clears the old timer and arms a sooner one (~25ms).
+      // the reschedule clears the old timer and arms a sooner one (~8ms).
       n.bufferDelta('sess-solo', 's', 'b')
       assert.equal(delays.length, 2, 'a reschedule must have occurred')
-      assert.ok(delays[1] <= 25, `expected reschedule <=25ms, got ${delays[1]}`)
+      assert.ok(delays[1] <= 8, `expected reschedule <=8ms, got ${delays[1]}`)
     })
     n.destroy()
   })
@@ -1114,12 +1117,42 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
     const counts = { 'sess-multi': 3, 'sess-solo': 1 }
     const n = new EventNormalizer({ getSubscriberCount: (s) => counts[s] ?? 0 })
     withSetTimeoutSpy((delays) => {
-      n.bufferDelta('sess-solo', 's', 'a')      // arms ~25ms
-      assert.equal(delays[0], 25)
-      n.bufferDelta('sess-multi', 'm', 'b')     // wants 50ms — but 25ms deadline is sooner
+      n.bufferDelta('sess-solo', 's', 'a')      // arms ~8ms
+      assert.equal(delays[0], 8)
+      n.bufferDelta('sess-multi', 'm', 'b')     // wants 16ms — but 8ms deadline is sooner
       // No reschedule: the existing sooner deadline stands.
       assert.equal(delays.length, 1, 'must not reschedule to a later deadline')
     })
+    n.destroy()
+  })
+
+  // #5562 + #5520: real-timer sanity check that the shrunk window actually
+  // flushes a buffered delta inside ~2× the resolved window. Uses the #5515/#5520
+  // emitMonoMs instrumentation that bufferDelta carries through to the flushed
+  // entry — proving that hook still round-trips after the window change. Wall-clock
+  // tolerant (2× the 8ms solo window) rather than fake-timer exact, so it stays
+  // robust under CI scheduling jitter; runs with --test-force-exit.
+  it('flushes a single-subscriber delta within ~2x the 8ms window (real timer)', async () => {
+    const n = new EventNormalizer({ getSubscriberCount: () => 1 })
+    const flushed = []
+    let resolveFlush
+    const done = new Promise((res) => { resolveFlush = res })
+    n.onFlush = (entries) => {
+      flushed.push({ at: performance.now(), entries })
+      resolveFlush()
+    }
+    const emitMono = Number(process.hrtime.bigint() / 1_000_000n)
+    const buffered = performance.now()
+    n.bufferDelta('sess-1', 'msg-1', 'hello', emitMono)
+    await done
+    const elapsed = flushed[0].at - buffered
+    // 2x the 8ms solo window = 16ms budget; allow generous headroom for CI jitter
+    // while still asserting we're nowhere near the old 25/50ms floor.
+    assert.ok(elapsed < 24, `expected flush within ~2x the 8ms window, got ${elapsed.toFixed(1)}ms`)
+    assert.equal(flushed[0].entries.length, 1)
+    assert.equal(flushed[0].entries[0].delta, 'hello')
+    // The #5520 emitMonoMs instrumentation survives the coalescing path.
+    assert.equal(flushed[0].entries[0].emitMonoMs, emitMono)
     n.destroy()
   })
 })

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -233,8 +233,9 @@ describe('WsBroadcaster', () => {
     })
   })
 
-  // #5516 (epic #5514): subscriber count drives the normalizer's adaptive
-  // delta-coalescing window (25ms when a session has exactly one viewer).
+  // #5516/#5562: subscriber count drives the normalizer's fixed delta
+  // micro-batch window (8ms when a session has exactly one viewer, 16ms
+  // otherwise). The adaptive throttle is client-side (store-core EWMA).
   describe('_countSessionSubscribers()', () => {
     it('counts activeSessionId matches and explicit subscribers', () => {
       clients.set(createFakeWs(), createFakeClient({ id: 'c1', activeSessionId: 'sess-1' }))


### PR DESCRIPTION
## Summary

The server delta coalescer (`_resolveFlushIntervalMs`, `event-normalizer.js`) was a **fixed** 25ms (single-subscriber) / 50ms (multi-subscriber) window — its comment at `:770` mislabelled it an *"adaptive coalescing window"*, which it never was. It **stacked** on top of the client's adaptive 16-100ms EWMA flush (`store-core` `resolveDeltaFlushMs`, keyed on RTT/render cost): up to **~150ms of pure buffering** on a poor link, and a LAN client never got under the **25ms** floor.

### Decision: option (a) — minimalist

The swarm-audit panel weighed two options:

- **(a) Minimalist** — shrink the server window to ~8-16ms and let the client EWMA be the *sole* adaptive system. One adaptive throttle, no server-side RTT plumbing, no per-link divergence to reason about.
- **(b) Skeptic** — feed the server the client's EWMA via the existing `serverTs`/pong plumbing and reuse `resolveDeltaFlushMs` server-side. More machinery, and a single server-side window can't serve divergent per-client links anyway without per-link windows.

**Panel lean: (a) for v1**, revisit (b) only if multi-client divergence later demands per-link windows. This PR implements (a). The server keeps a *fixed* micro-batch whose only job is to coalesce the per-token burst a provider emits into a single emit + broadcast (bounding per-token CPU/socket overhead). The **adaptive** part stays entirely client-side.

## Changes

- **`_resolveFlushIntervalMs` / constructor defaults**: `25ms → 8ms` (single-subscriber), `50ms → 16ms` (multi). The subscriber-count distinction is kept (it bounds broadcast amplification on fan-out) but both values are now far below the client EWMA floor, so the server half no longer dominates end-to-end latency.
- **Comments fixed**: the `:770`-area comment and the constructor/`ws-server.js` construction-site comments now describe what this actually is — a fixed micro-batch to bound per-token emit/broadcast overhead — and point to `store-core` `resolveDeltaFlushMs` as the real adaptive throttle.
- **#5565 buffer caps untouched**: the per-key 256KB / total 2MB forced-flush logic and the incremental UTF-8 byte counters are independent of the window value. Shrinking the window only *reduces* buffer residency further; the cap path, accounting, and force-flush ordering are unchanged (the `:915-992` cap tests still pass).

## Measured / tested flush bound

- Updated the four tests that pinned `25`/`50` to assert the **new** `8`/`16` contract (single-subscriber window, multi-client default, 0/unknown/legacy default, and both reschedule-deadline tests) — asserting the tightened contract, not weakening it.
- Added a **real-timer** sanity check using the #5520 `emitMonoMs` instrumentation: a single-subscriber delta flushes within **~2× the 8ms window** (asserts `< 24ms`, nowhere near the old 25/50ms floor), and the `emitMonoMs` stamp round-trips through the coalescing path unchanged — confirming the #5515/#5520 latency hook survives the window change.

## Test results

- `event-normalizer.test.js` — 106 pass (incl. new real-timer test)
- `ws-broadcaster.test.js` — 41 pass
- `ws-forwarding.test.js` — 48 pass
- All `packages/server/scripts/lint-*.sh` — OK; eslint — 0 errors

Closes #5562

Related: #5514, #5555, #5520, #5565