### PR TITLE
refactor: extract shared RttSmoother — one EWMA implementation, tested (#5556)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -140,6 +140,8 @@ import {
   splitRtt,
   // #5516 (epic #5514): adaptive client delta-flush interval.
   resolveDeltaFlushMs,
+  // #5556 (epic #5514): shared stateful EWMA RTT smoother.
+  RttSmoother,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
@@ -262,7 +264,8 @@ interface MessageHandlerContext extends EncryptionContext {
   heartbeatInterval: ReturnType<typeof setInterval> | null;
   pongTimeout: ReturnType<typeof setTimeout> | null;
   lastPingSentAt: number;
-  ewmaRtt: number | null;
+  // #5556: EWMA-smoothed RTT (replaces the inlined `ewmaRtt` accumulator).
+  rttSmoother: RttSmoother;
 
   // Delta batching
   pendingDeltas: Map<string, { sessionId: string | null; delta: string }>;
@@ -295,7 +298,7 @@ function createDefaultContext(): MessageHandlerContext {
     heartbeatInterval: null,
     pongTimeout: null,
     lastPingSentAt: 0,
-    ewmaRtt: null,
+    rttSmoother: new RttSmoother(),
     pendingDeltas: new Map<string, { sessionId: string | null; delta: string }>(),
     deltaFlushTimer: null,
     deltaServerTs: new Map<string, { serverTs: number; recvAt: number }>(),
@@ -595,7 +598,6 @@ export function clearTerminalWriteBatching(): void {
 export const SUBSCRIBE_SESSIONS_CHUNK_SIZE = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
-const EWMA_ALPHA = 0.3; // Weight for new samples (higher = more responsive)
 // #5515 (epic #5514): throttle the dev latency readout so a streaming turn
 // can't spam the console — one line every few seconds is enough to watch the
 // numbers move when flush intervals are tuned.
@@ -613,14 +615,14 @@ export function setDeltaFlushIntervalOverride(ms: number | null): void {
 function currentDeltaFlushMs(): number {
   return _deltaFlushOverrideMs != null
     ? _deltaFlushOverrideMs
-    : resolveDeltaFlushMs(_ctx.ewmaRtt);
+    : resolveDeltaFlushMs(_ctx.rttSmoother.value);
 }
 
 export function stopHeartbeat(): void {
   if (_ctx.heartbeatInterval) { clearInterval(_ctx.heartbeatInterval); _ctx.heartbeatInterval = null; }
   if (_ctx.pongTimeout) { clearTimeout(_ctx.pongTimeout); _ctx.pongTimeout = null; }
   _ctx.lastPingSentAt = 0;
-  _ctx.ewmaRtt = null; // Reset smoothed RTT on disconnect
+  _ctx.rttSmoother.reset(); // Reset smoothed RTT on disconnect
 }
 
 export function startHeartbeat(socket: WebSocket): void {
@@ -646,8 +648,7 @@ function _onPong(serverTs?: number): void {
     const pongRecvAt = Date.now();
     const rttMs = pongRecvAt - _ctx.lastPingSentAt;
     // EWMA: smoothed = alpha * new + (1 - alpha) * prev (first sample bootstraps)
-    _ctx.ewmaRtt = _ctx.ewmaRtt === null ? rttMs : EWMA_ALPHA * rttMs + (1 - EWMA_ALPHA) * _ctx.ewmaRtt;
-    const smoothed = Math.round(_ctx.ewmaRtt);
+    const smoothed = Math.round(_ctx.rttSmoother.update(rttMs));
     const quality: 'good' | 'fair' | 'poor' = smoothed < 200 ? 'good' : smoothed < 500 ? 'fair' : 'poor';
     useConnectionLifecycleStore.getState().setConnectionQuality(smoothed, quality);
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -132,6 +132,8 @@ import {
   splitRtt,
   // #5516 (epic #5514): adaptive client delta-flush interval.
   resolveDeltaFlushMs,
+  // #5556 (epic #5514): shared stateful EWMA RTT smoother.
+  RttSmoother,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -498,10 +500,10 @@ export function clearTerminalWriteBatching(): void {
 let _heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 let _pongTimeout: ReturnType<typeof setTimeout> | null = null;
 let _lastPingSentAt = 0;
-let _ewmaRtt: number | null = null; // EWMA-smoothed RTT for stable quality display
+// #5556: EWMA-smoothed RTT for stable quality display (shared smoother).
+const _rttSmoother = new RttSmoother();
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
-const EWMA_ALPHA = 0.3; // Weight for new samples (higher = more responsive)
 
 // #5515 (epic #5514): latency instrumentation. `_deltaServerTs` records the
 // server-stamped serverTs (and local recv time) of the OLDEST un-rendered
@@ -519,7 +521,7 @@ export function stopHeartbeat(): void {
   if (_heartbeatInterval) { clearInterval(_heartbeatInterval); _heartbeatInterval = null; }
   if (_pongTimeout) { clearTimeout(_pongTimeout); _pongTimeout = null; }
   _lastPingSentAt = 0;
-  _ewmaRtt = null; // Reset smoothed RTT on disconnect
+  _rttSmoother.reset(); // Reset smoothed RTT on disconnect
 }
 
 export function startHeartbeat(socket: WebSocket): void {
@@ -545,8 +547,7 @@ function _onPong(serverTs?: number): void {
     const pongRecvAt = Date.now();
     const rttMs = pongRecvAt - _lastPingSentAt;
     // EWMA: smoothed = alpha * new + (1 - alpha) * prev (first sample bootstraps)
-    _ewmaRtt = _ewmaRtt === null ? rttMs : EWMA_ALPHA * rttMs + (1 - EWMA_ALPHA) * _ewmaRtt;
-    const smoothed = Math.round(_ewmaRtt);
+    const smoothed = Math.round(_rttSmoother.update(rttMs));
     const quality: 'good' | 'fair' | 'poor' = smoothed < 200 ? 'good' : smoothed < 500 ? 'fair' : 'poor';
     getStore().setState({ latencyMs: smoothed, connectionQuality: quality });
 
@@ -578,7 +579,7 @@ export function setDeltaFlushIntervalOverride(ms: number | null): void {
   _deltaFlushOverrideMs = ms;
 }
 function currentDeltaFlushMs(): number {
-  return _deltaFlushOverrideMs != null ? _deltaFlushOverrideMs : resolveDeltaFlushMs(_ewmaRtt);
+  return _deltaFlushOverrideMs != null ? _deltaFlushOverrideMs : resolveDeltaFlushMs(_rttSmoother.value);
 }
 
 function flushPendingDeltas(): void {

--- a/packages/store-core/src/delta-flush.ts
+++ b/packages/store-core/src/delta-flush.ts
@@ -61,3 +61,53 @@ export function resolveDeltaFlushMs(ewmaRtt: number | null | undefined): number 
   const t = (ewmaRtt - DELTA_FLUSH_CHEAP_RTT_MS) / (DELTA_FLUSH_POOR_RTT_MS - DELTA_FLUSH_CHEAP_RTT_MS)
   return Math.round(DELTA_FLUSH_FLOOR_MS + t * (DELTA_FLUSH_MAX_MS - DELTA_FLUSH_FLOOR_MS))
 }
+
+/** Default EWMA weight for a new RTT sample (higher = more responsive). */
+export const DEFAULT_RTT_EWMA_ALPHA = 0.3
+
+/**
+ * Stateful EWMA (exponentially-weighted moving average) smoother for round-trip
+ * time. Extracted from the app/dashboard heartbeat handlers (#5556, epic #5514)
+ * so both clients share one implementation instead of hand-copied accumulators.
+ *
+ * Behavior (bit-for-bit identical to the prior inlined copies):
+ *   - The first sample bootstraps the average to its raw value.
+ *   - Each later sample folds in as `α·rtt + (1-α)·prev`.
+ *   - `value` is `null` until the first sample, matching the
+ *     `ewmaRtt: number | null` field both clients fed into
+ *     `resolveDeltaFlushMs` (null → flush floor).
+ *   - `reset()` returns to the un-sampled (`null`) state — the clients call
+ *     this on disconnect (in `stopHeartbeat`), so a reconnect re-bootstraps.
+ */
+export class RttSmoother {
+  private _value: number | null = null
+  private readonly _alpha: number
+
+  /**
+   * @param alpha - EWMA weight for new samples in (0, 1]. Defaults to
+   *   {@link DEFAULT_RTT_EWMA_ALPHA} (0.3).
+   */
+  constructor(alpha: number = DEFAULT_RTT_EWMA_ALPHA) {
+    this._alpha = alpha
+  }
+
+  /** The current smoothed RTT in ms, or `null` if no sample has arrived yet. */
+  get value(): number | null {
+    return this._value
+  }
+
+  /**
+   * Fold a new RTT measurement into the average and return the updated value.
+   * The first call initializes the average to `rttMs` exactly.
+   */
+  update(rttMs: number): number {
+    this._value =
+      this._value === null ? rttMs : this._alpha * rttMs + (1 - this._alpha) * this._value
+    return this._value
+  }
+
+  /** Clear the average back to the un-sampled (`null`) state. */
+  reset(): void {
+    this._value = null
+  }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -553,4 +553,9 @@ export {
   DELTA_FLUSH_MAX_MS,
   DELTA_FLUSH_CHEAP_RTT_MS,
   DELTA_FLUSH_POOR_RTT_MS,
+  // #5556 (epic #5514): shared stateful EWMA RTT smoother — one implementation
+  // for the app/dashboard heartbeat handlers, replacing two hand-copied
+  // accumulators with identical first-sample/α-weighting/reset semantics.
+  RttSmoother,
+  DEFAULT_RTT_EWMA_ALPHA,
 } from './delta-flush'

--- a/packages/store-core/src/rtt-smoother.test.ts
+++ b/packages/store-core/src/rtt-smoother.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { RttSmoother, DEFAULT_RTT_EWMA_ALPHA } from './delta-flush'
+
+describe('RttSmoother', () => {
+  it('exposes the documented default alpha', () => {
+    expect(DEFAULT_RTT_EWMA_ALPHA).toBe(0.3)
+  })
+
+  it('starts un-sampled (value is null)', () => {
+    const s = new RttSmoother()
+    expect(s.value).toBeNull()
+  })
+
+  it('bootstraps to the first sample exactly', () => {
+    const s = new RttSmoother()
+    expect(s.update(42)).toBe(42)
+    expect(s.value).toBe(42)
+  })
+
+  it('converges over a known input series (exact α=0.3 values)', () => {
+    // Mirrors the prior inlined math: v = 0.3*rtt + 0.7*prev, first sample = raw.
+    const s = new RttSmoother()
+    expect(s.update(100)).toBe(100) // bootstrap
+    // 0.3*200 + 0.7*100 = 60 + 70 = 130
+    expect(s.update(200)).toBeCloseTo(130, 10)
+    // 0.3*200 + 0.7*130 = 60 + 91 = 151
+    expect(s.update(200)).toBeCloseTo(151, 10)
+    // 0.3*50 + 0.7*151 = 15 + 105.7 = 120.7
+    expect(s.update(50)).toBeCloseTo(120.7, 10)
+    // 0.3*50 + 0.7*120.7 = 15 + 84.49 = 99.49
+    expect(s.update(50)).toBeCloseTo(99.49, 10)
+    expect(s.value).toBeCloseTo(99.49, 10)
+  })
+
+  it('converges toward a steady input', () => {
+    const s = new RttSmoother()
+    s.update(1000) // bootstrap high
+    for (let i = 0; i < 100; i++) s.update(50)
+    // EWMA with α=0.3 settles within float epsilon of the steady value.
+    expect(s.value).toBeCloseTo(50, 5)
+  })
+
+  it('reset() returns to the un-sampled state so the next sample re-bootstraps', () => {
+    const s = new RttSmoother()
+    s.update(100)
+    s.update(200)
+    expect(s.value).toBeCloseTo(130, 10)
+    s.reset()
+    expect(s.value).toBeNull()
+    // Next sample bootstraps again, exactly as on a fresh smoother.
+    expect(s.update(77)).toBe(77)
+  })
+
+  it('honors an alpha override (α=0.5)', () => {
+    const s = new RttSmoother(0.5)
+    expect(s.update(100)).toBe(100) // bootstrap unaffected by alpha
+    // 0.5*200 + 0.5*100 = 150
+    expect(s.update(200)).toBeCloseTo(150, 10)
+    // 0.5*0 + 0.5*150 = 75
+    expect(s.update(0)).toBeCloseTo(75, 10)
+  })
+
+  it('honors an alpha override (α=1 → tracks the latest sample)', () => {
+    const s = new RttSmoother(1)
+    s.update(100)
+    expect(s.update(250)).toBe(250)
+    expect(s.update(10)).toBe(10)
+  })
+
+  it('matches the legacy inlined accumulator over a random-ish series', () => {
+    // Reference implementation = the exact expression both clients inlined.
+    const ALPHA = 0.3
+    let ref: number | null = null
+    const s = new RttSmoother()
+    for (const rtt of [12, 350, 8, 9, 600, 40, 41, 39, 1200, 15]) {
+      ref = ref === null ? rtt : ALPHA * rtt + (1 - ALPHA) * ref
+      expect(s.update(rtt)).toBeCloseTo(ref, 10)
+    }
+    expect(s.value).toBeCloseTo(ref as number, 10)
+  })
+})


### PR DESCRIPTION
## Summary

Sub-item 1 of epic #5556 (client unification). The EWMA RTT accumulator — `EWMA_ALPHA = 0.3` plus `ewmaRtt = α·rtt + (1-α)·prev` — was copy-pasted in both clients' heartbeat handlers (`packages/app/src/store/message-handler.ts` and `packages/dashboard/src/store/message-handler.ts`), with zero tests on either copy. This extracts it into a single, tested `RttSmoother` class in store-core, next to `resolveDeltaFlushMs` (which already consumes the smoothed value).

- **`RttSmoother`** added to `packages/store-core/src/delta-flush.ts`, exported via `index.ts`:
  - `update(rttMs): number` — folds a sample in; the **first sample bootstraps** to its raw value, matching the prior `ewmaRtt === null ? rttMs : …` semantics.
  - `value` getter — returns `number | null` (null until the first sample), so `resolveDeltaFlushMs(null)` keeps returning the flush floor exactly as before.
  - `reset()` — returns to the un-sampled (`null`) state.
  - Default α `0.3`, overridable via constructor (`DEFAULT_RTT_EWMA_ALPHA` also exported).
- **App** — replaces the `_ctx.ewmaRtt` field with a `_ctx.rttSmoother: RttSmoother` instance; reset stays in `stopHeartbeat`.
- **Dashboard** — replaces the module-level `_ewmaRtt` var with a `_rttSmoother` instance; reset stays in `stopHeartbeat`.

## Behavior preservation

- **First-sample bootstrap**, **α = 0.3 weighting**, and **`Math.round`** at the call sites are bit-for-bit identical to the prior inlined math (a test asserts parity against the exact legacy expression over a series).
- **Reset points unchanged.** Both clients reset only in `stopHeartbeat()` (called on disconnect, and at the top of `startHeartbeat()` before each reconnect) — so a reconnect re-bootstraps from the first new sample, exactly as before.
- **`null → flush floor`** preserved: the `value` getter returns `null` pre-first-sample, fed unchanged into `resolveDeltaFlushMs`. Flush-interval behavior is unchanged.

## Test plan

- `packages/store-core` (vitest): new `rtt-smoother.test.ts` — convergence over a known input series (exact α=0.3 values), first-sample init, `reset()` re-bootstrap, α=0.5 / α=1 overrides, and a parity check against the legacy inlined accumulator. **1235 tests pass** (9 new).
- `packages/app` (jest): **1713 tests / 124 suites pass** (includes the message-handler heartbeat suite).
- `packages/dashboard` (vitest): **3477 tests pass** (includes the message-handler suite).
- `tsc --noEmit`: clean for store-core, app, and dashboard.
- No lockfile drift.

Related to #5556 (epic stays open).