### PR TITLE
refactor(dashboard): Control Room tab registry — one descriptor array (#5557)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.registry.test.ts
+++ b/packages/dashboard/src/components/ControlRoomView.registry.test.ts
@@ -1,0 +1,84 @@
+/**
+ * #5557 — Control Room tab registry derivation.
+ *
+ * Adding a Control Room tab used to cost ~7 coordinated edits with nothing tying
+ * them together, so a `VALID_TABS`/`TABS` drift could ship a tab you could
+ * deep-link to but not render. The view now DERIVES the valid-tab set, the
+ * survey-tab set, and the rendered strip from one `CONTROL_ROOM_TABS` descriptor
+ * array. This suite is the drift guard: it asserts the derived sets stay
+ * consistent with the descriptors, so the class of bug the refactor kills can't
+ * silently reappear.
+ *
+ * (The strip's actual render — labels, default tab, persistence, auto-fetch — is
+ * covered by ControlRoomView.test.tsx; this file asserts only the derivation
+ * invariants that hold without a DOM.)
+ */
+import { describe, it, expect } from 'vitest'
+import { CONTROL_ROOM_TABS, SURVEY_TABS } from './ControlRoomView'
+
+describe('#5557 — Control Room tab registry derivation', () => {
+  it('has at least one tab and every descriptor carries a key + label', () => {
+    expect(CONTROL_ROOM_TABS.length).toBeGreaterThan(0)
+    for (const t of CONTROL_ROOM_TABS) {
+      expect(typeof t.key).toBe('string')
+      expect(t.key.length).toBeGreaterThan(0)
+      expect(typeof t.label).toBe('string')
+      expect(t.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('has unique tab keys (no duplicate descriptor would shadow the strip / deep-link set)', () => {
+    const keys = CONTROL_ROOM_TABS.map((t) => t.key)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('derives SURVEY_TABS to be exactly the survey:true descriptor keys', () => {
+    const expected = new Set(CONTROL_ROOM_TABS.filter((t) => t.survey).map((t) => t.key))
+    expect(SURVEY_TABS).toEqual(expected)
+  })
+
+  it('keeps SURVEY_TABS a subset of the full tab set (no orphan survey tab)', () => {
+    const allKeys = new Set<string>(CONTROL_ROOM_TABS.map((t) => t.key))
+    for (const key of SURVEY_TABS) {
+      expect(allKeys.has(key)).toBe(true)
+    }
+  })
+
+  it('gives every survey:true descriptor the store-key triple + a wire request type', () => {
+    for (const t of CONTROL_ROOM_TABS) {
+      if (!t.survey) continue
+      // The discriminated descriptor narrows to the surveyed shape here.
+      expect(typeof t.requestType).toBe('string')
+      expect(t.requestType.length).toBeGreaterThan(0)
+      expect(typeof t.snapshotKey).toBe('string')
+      expect(typeof t.loadingKey).toBe('string')
+      expect(typeof t.requestKey).toBe('string')
+    }
+  })
+
+  it('keeps the Settings tab (survey:false) out of the auto-fetch set', () => {
+    // The static tab must never appear in SURVEY_TABS or it would fetch on
+    // activation (#5544 regression guard).
+    const staticTabs = CONTROL_ROOM_TABS.filter((t) => !t.survey).map((t) => t.key)
+    expect(staticTabs).toContain('settings')
+    for (const key of staticTabs) {
+      expect(SURVEY_TABS.has(key as never)).toBe(false)
+    }
+  })
+
+  it('maps each surveyed tab to a distinct store snapshot/loading/request triple', () => {
+    const snapshotKeys = new Set<string>()
+    const loadingKeys = new Set<string>()
+    const requestKeys = new Set<string>()
+    for (const t of CONTROL_ROOM_TABS) {
+      if (!t.survey) continue
+      snapshotKeys.add(t.snapshotKey)
+      loadingKeys.add(t.loadingKey)
+      requestKeys.add(t.requestKey)
+    }
+    const surveyCount = CONTROL_ROOM_TABS.filter((t) => t.survey).length
+    expect(snapshotKeys.size).toBe(surveyCount)
+    expect(loadingKeys.size).toBe(surveyCount)
+    expect(requestKeys.size).toBe(surveyCount)
+  })
+})

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -13,6 +13,29 @@
  *
  * App.tsx renders this in place of the old `ControlRoomSection` and forwards the
  * `onInvestigate` action through to the repo table unchanged.
+ *
+ * #5557 — tab registry. Adding a tab used to cost ~7 coordinated edits (a
+ * `ControlRoomTab` union member, a `SURVEY_TABS` entry, a `VALID_TABS` entry, a
+ * `TABS` render-list entry, a store status/loading pair, a copy-paste
+ * `requestXStatus` store method, and the WS handler wiring) with nothing tying
+ * them together — a `VALID_TABS`/`TABS` drift ships a tab you can deep-link to
+ * but not render. They now all DERIVE from the single `CONTROL_ROOM_TABS`
+ * descriptor array below: the `ControlRoomTab` union, the valid-tab set, the
+ * survey-tab set, the rendered tab strip, and the auto-fetch effect's
+ * snapshot/loading/request lookups. A `registry-derivation.test` asserts the
+ * derived sets stay consistent so the drift class can't reappear.
+ *
+ * Design choice (documented in PR #5557): the store keeps its existing,
+ * heavily-tested per-tab triples (`hostStatus`/`hostStatusLoading`/
+ * `requestHostStatus`, etc.) and the on-the-wire WS message types
+ * (`host_status_request` …) are untouched — this is a CLIENT-SIDE refactor. The
+ * descriptor MAPS each surveyed tab to those existing store keys (`snapshotKey`,
+ * `loadingKey`, `requestKey`) so the generic effect drives them through a single
+ * keyed lookup instead of a hand-maintained `tab === '…' ? … : …` ladder. That
+ * kills the view-side edits (union/sets/strip/effect) outright and removes the
+ * need for any new copy-paste request method when a future surveyed tab is
+ * added — the smallest refactor that eliminates the per-tab edit cost without
+ * churning the tested store internals or the protocol.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
@@ -20,20 +43,118 @@ import { RunnerStatusSection } from './RunnerStatusSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { SettingsContent } from './SettingsPanel'
 import { useConnectionStore } from '../store/connection'
-
-// #5544: the Settings tab converges the scattered preference surfaces
-// (notification categories, appearance, session defaults, BYOK, Tauri
-// desktop options) into the Control Room. It embeds `SettingsContent` — the
-// same body the legacy slide-out modal renders — so there's a single home and
-// no duplicated controls.
-export type ControlRoomTab = 'repos' | 'runners' | 'integrations' | 'settings'
+import type { ConnectionState } from '../store/types'
 
 /**
- * #5544: the survey-backed tabs whose auto-fetch effect (#5543/#5546) shells
- * out to git/gh. The Settings tab is purely client/server-config driven and
- * must NOT trip the snapshot fetch, so the effect early-returns for it.
+ * #5557 — the keys of the store fields a surveyed tab drives. Each surveyed
+ * descriptor names exactly these three (the store keeps its tested per-tab
+ * triples — see the file header). Constrained to the matching store shape so a
+ * typo (or a renamed store field) fails `tsc` at the descriptor rather than
+ * silently no-op'ing the auto-fetch.
  */
-const SURVEY_TABS: ReadonlySet<ControlRoomTab> = new Set<ControlRoomTab>(['repos', 'runners', 'integrations'])
+type SnapshotKey = {
+  [K in keyof ConnectionState]: ConnectionState[K] extends { generatedAt?: string } | null ? K : never
+}[keyof ConnectionState]
+type LoadingKey = {
+  [K in keyof ConnectionState]: ConnectionState[K] extends boolean ? K : never
+}[keyof ConnectionState]
+type RequestKey = {
+  [K in keyof ConnectionState]: ConnectionState[K] extends () => boolean ? K : never
+}[keyof ConnectionState]
+
+/**
+ * #5557 — one descriptor per Control Room tab. The single source of truth from
+ * which the union, the sets, the strip, and the auto-fetch lookups all derive.
+ *
+ * - `survey: true` tabs auto-fetch on activation (#5543/#5546) and MUST supply
+ *   `requestType` (the WS message put on the wire), `snapshotKey`/`loadingKey`/
+ *   `requestKey` (the existing store fields the effect reads/calls). `tsc`
+ *   enforces the discriminant: a `survey: false` tab may not carry these, and a
+ *   `survey: true` tab may not omit them.
+ * - `survey: false` tabs (the #5544 Settings tab) are static (server/client
+ *   config only) and the effect early-returns for them — they never fetch.
+ */
+type SurveyTabDescriptor = {
+  readonly key: string
+  readonly label: string
+  readonly survey: true
+  /** The WS message type the request method puts on the wire (kept as-is). */
+  readonly requestType: string
+  /** Store field holding this tab's latest snapshot (staleness is judged here). */
+  readonly snapshotKey: SnapshotKey
+  /** Store boolean flipped while a request is in flight (the in-flight guard). */
+  readonly loadingKey: LoadingKey
+  /** Store action that dispatches the survey request. */
+  readonly requestKey: RequestKey
+}
+type StaticTabDescriptor = {
+  readonly key: string
+  readonly label: string
+  readonly survey: false
+}
+type ControlRoomTabDescriptor = SurveyTabDescriptor | StaticTabDescriptor
+
+export const CONTROL_ROOM_TABS = [
+  {
+    key: 'repos',
+    label: 'Project status',
+    survey: true,
+    requestType: 'host_status_request',
+    snapshotKey: 'hostStatus',
+    loadingKey: 'hostStatusLoading',
+    requestKey: 'requestHostStatus',
+  },
+  {
+    key: 'runners',
+    label: 'Self-hosted runners',
+    survey: true,
+    requestType: 'runner_status_request',
+    snapshotKey: 'runnerStatus',
+    loadingKey: 'runnerStatusLoading',
+    requestKey: 'requestRunnerStatus',
+  },
+  {
+    key: 'integrations',
+    label: 'Integrations',
+    survey: true,
+    requestType: 'integration_status_request',
+    snapshotKey: 'integrationStatus',
+    loadingKey: 'integrationStatusLoading',
+    requestKey: 'requestIntegrationStatus',
+  },
+  // #5544: the Settings tab converges the scattered preference surfaces
+  // (notification categories, appearance, session defaults, BYOK, Tauri desktop
+  // options) into the Control Room. It embeds `SettingsContent` — the same body
+  // the legacy slide-out modal renders — so there's a single home and no
+  // duplicated controls. It is `survey: false`: purely client/server-config
+  // driven, so the auto-fetch effect must NOT trip the snapshot fetch for it.
+  {
+    key: 'settings',
+    label: 'Settings',
+    survey: false,
+  },
+] as const satisfies ReadonlyArray<ControlRoomTabDescriptor>
+
+/** #5557 — the tab union, derived from the descriptor keys. */
+export type ControlRoomTab = (typeof CONTROL_ROOM_TABS)[number]['key']
+
+/** #5557 — survey-backed descriptors, narrowed for the auto-fetch effect. */
+type SurveyDescriptor = Extract<(typeof CONTROL_ROOM_TABS)[number], { survey: true }>
+
+/** #5557 — the set of valid deep-link / persisted tab keys, derived. */
+const VALID_TABS: ReadonlySet<string> = new Set(CONTROL_ROOM_TABS.map((t) => t.key))
+
+/**
+ * #5544/#5557: the survey-backed tabs whose auto-fetch effect (#5543/#5546)
+ * shells out to git/gh, keyed for O(1) lookup in the effect. The Settings tab is
+ * absent (it's `survey: false`), so the effect early-returns for it.
+ */
+const SURVEY_DESCRIPTORS: ReadonlyMap<ControlRoomTab, SurveyDescriptor> = new Map(
+  CONTROL_ROOM_TABS.filter((t): t is SurveyDescriptor => t.survey).map((t) => [t.key, t]),
+)
+
+/** #5557 — the survey-tab key set, derived from the descriptors (drift guard). */
+export const SURVEY_TABS: ReadonlySet<ControlRoomTab> = new Set(SURVEY_DESCRIPTORS.keys())
 
 /**
  * #5543: how old a tab's snapshot may be before opening/switching to that tab
@@ -46,7 +167,6 @@ const SURVEY_TABS: ReadonlySet<ControlRoomTab> = new Set<ControlRoomTab>(['repos
 export const CONTROL_ROOM_STALENESS_MS = 60_000
 
 const CR_TAB_STORAGE_KEY = 'chroxy_cr_tab'
-const VALID_TABS: ReadonlySet<string> = new Set<ControlRoomTab>(['repos', 'runners', 'integrations', 'settings'])
 
 function loadPersistedTab(): ControlRoomTab {
   try {
@@ -77,13 +197,6 @@ function isStale(generatedAt: string | undefined): boolean {
   if (Number.isNaN(ms)) return true
   return Date.now() - ms >= CONTROL_ROOM_STALENESS_MS
 }
-
-const TABS: ReadonlyArray<{ key: ControlRoomTab; label: string }> = [
-  { key: 'repos', label: 'Project status' },
-  { key: 'runners', label: 'Self-hosted runners' },
-  { key: 'integrations', label: 'Integrations' },
-  { key: 'settings', label: 'Settings' },
-]
 
 export interface ControlRoomViewProps {
   /** Forwarded to the repo table's actionable verdict tags (#5202). */
@@ -143,58 +256,44 @@ export function ControlRoomView({
     selectTab(forceTab)
   }, [forceTab, forceTabNonce, selectTab])
 
-  // #5543: auto-fetch the active tab's survey when the Control Room opens with a
-  // tab already active and on each tab switch, with a staleness guard. We only
-  // fire when the WS is up (the request actions no-op when the socket is closed,
-  // but gating here avoids churning the effect against a snapshot that will
-  // never arrive) and the tab isn't already loading (the server enforces a
+  // #5543/#5557: auto-fetch the active tab's survey when the Control Room opens
+  // with a tab already active and on each tab switch, with a staleness guard. We
+  // only fire when the WS is up (the request actions no-op when the socket is
+  // closed, but gating here avoids churning the effect against a snapshot that
+  // will never arrive) and the tab isn't already loading (the server enforces a
   // per-client in-flight guard — don't trip it). A snapshot newer than the
   // staleness window is left alone; the manual Refresh button still forces a
   // re-fetch regardless. No interval polling — fetch-on-activation only.
+  //
+  // #5557: the snapshot/loading/request triple is looked up via the active tab's
+  // descriptor (keyed store fields) rather than a `tab === '…' ? … : …` ladder,
+  // so a new surveyed tab needs no edit here — only a descriptor entry. We
+  // subscribe to exactly the active tab's snapshot + loading flag (keyed off the
+  // descriptor) so the effect re-runs on the same signals the old per-field
+  // selectors did — no over-subscription to unrelated store state.
   const connected = useConnectionStore((s) => s.connectionPhase === 'connected')
-  const hostStatus = useConnectionStore((s) => s.hostStatus)
-  const runnerStatus = useConnectionStore((s) => s.runnerStatus)
-  const integrationStatus = useConnectionStore((s) => s.integrationStatus)
-  const hostStatusLoading = useConnectionStore((s) => s.hostStatusLoading)
-  const runnerStatusLoading = useConnectionStore((s) => s.runnerStatusLoading)
-  const integrationStatusLoading = useConnectionStore((s) => s.integrationStatusLoading)
-  const requestHostStatus = useConnectionStore((s) => s.requestHostStatus)
-  const requestRunnerStatus = useConnectionStore((s) => s.requestRunnerStatus)
-  const requestIntegrationStatus = useConnectionStore((s) => s.requestIntegrationStatus)
+  const descriptor = SURVEY_DESCRIPTORS.get(tab)
+  const snapshot = useConnectionStore((s) =>
+    descriptor ? (s[descriptor.snapshotKey] as { generatedAt?: string } | null) : null,
+  )
+  const loading = useConnectionStore((s) => (descriptor ? (s[descriptor.loadingKey] as boolean) : false))
+  const request = useConnectionStore((s) =>
+    descriptor ? (s[descriptor.requestKey] as () => boolean) : undefined,
+  )
 
   useEffect(() => {
     if (!connected) return
-    // #5544: the Settings tab is static (no survey) — never fetch for it.
-    if (!SURVEY_TABS.has(tab)) return
-
-    const snapshot = tab === 'repos' ? hostStatus : tab === 'runners' ? runnerStatus : integrationStatus
-    const loading =
-      tab === 'repos' ? hostStatusLoading : tab === 'runners' ? runnerStatusLoading : integrationStatusLoading
+    // #5544: the Settings tab is static (no survey descriptor) — never fetch.
+    if (!descriptor || !request) return
     if (loading) return
-
     if (!isStale(snapshot?.generatedAt)) return
-
-    const request =
-      tab === 'repos' ? requestHostStatus : tab === 'runners' ? requestRunnerStatus : requestIntegrationStatus
     request()
-  }, [
-    tab,
-    connected,
-    hostStatus,
-    runnerStatus,
-    integrationStatus,
-    hostStatusLoading,
-    runnerStatusLoading,
-    integrationStatusLoading,
-    requestHostStatus,
-    requestRunnerStatus,
-    requestIntegrationStatus,
-  ])
+  }, [connected, descriptor, request, loading, snapshot])
 
   return (
     <div className="cr-view" data-testid="control-room-view">
       <div className="cr-tabs" role="tablist" aria-label="Control Room sections" data-testid="cr-tabs">
-        {TABS.map((t, i) => {
+        {CONTROL_ROOM_TABS.map((t, i) => {
           const active = tab === t.key
           return (
             <button
@@ -214,9 +313,9 @@ export function ControlRoomView({
                 e.preventDefault()
                 const next =
                   e.key === 'ArrowRight'
-                    ? (i + 1) % TABS.length
-                    : (i - 1 + TABS.length) % TABS.length
-                const target = TABS[next]!
+                    ? (i + 1) % CONTROL_ROOM_TABS.length
+                    : (i - 1 + CONTROL_ROOM_TABS.length) % CONTROL_ROOM_TABS.length
+                const target = CONTROL_ROOM_TABS[next]!
                 selectTab(target.key)
                 const tabs = (e.currentTarget.parentElement as HTMLElement)?.querySelectorAll<HTMLElement>(
                   '[role="tab"]',


### PR DESCRIPTION
## Summary

Adding a Control Room tab used to cost **~7 coordinated edits** with nothing tying them together — a `VALID_TABS`/`TABS` drift could ship a tab you can deep-link to but not render. This replaces the scattered view-side constants with **one `CONTROL_ROOM_TABS` descriptor array** as the single source of truth, from which everything derives.

### Before / after edit cost

| Adding a tab | Before | After |
|---|---|---|
| `ControlRoomTab` union | hand-edit | derived `typeof TABS[number]['key']` |
| `VALID_TABS` set | hand-edit | derived from descriptor keys |
| `SURVEY_TABS` set | hand-edit | derived from `survey:true` descriptors |
| `TABS` render strip | hand-edit | iterates the descriptors |
| auto-fetch effect (`tab === '…' ? … : …` ladder ×3) | hand-edit | keyed descriptor lookup — no edit |
| store snapshot/loading pair | hand-edit | unchanged (still a tested triple) |
| copy-paste `requestXStatus` store method | hand-edit | not needed — descriptor maps tab → existing keys |
| **New surveyed tab total** | **~7 edits** | **1 descriptor entry + panel + (if surveyed) server handler** |

### Design choice

Keep the store's existing, **heavily-tested per-tab triples** (`hostStatus`/`hostStatusLoading`/`requestHostStatus`, …) and the **on-the-wire WS message types** (`host_status_request` …) untouched — this is a client-side refactor. The descriptor **maps** each surveyed tab to those existing store keys (`snapshotKey`/`loadingKey`/`requestKey`), so the generic auto-fetch effect drives them through a single keyed lookup instead of a `tab === '…' ? … : …` ladder.

A **discriminated descriptor type** makes `survey:true` tabs require the store-key triple + wire `requestType`, and `survey:false` tabs (Settings) forbid them — so `tsc` enforces the shape at the descriptor. The mapped-type key constraints (`SnapshotKey`/`LoadingKey`/`RequestKey` over `ConnectionState`) catch a typo or a renamed store field at compile time rather than silently no-op'ing the fetch.

This is the smallest refactor that kills the per-tab edit cost without churning the tested store internals or the protocol.

### What keeps working (unchanged behaviour, covered by existing tests)

- #5546 auto-fetch on activation + staleness guard
- #5544 Settings tab (`survey:false` — never fetches; the effect early-returns when there's no survey descriptor)
- settings redirect nonce / `initialTab` plumbing

## Test plan

- `npx tsc --noEmit` — clean
- `npm test` — **178 files / 3484 tests pass**, including `ControlRoomView.test.tsx` **unmodified** (all tab routing, persistence, auto-fetch, staleness, in-flight guard, Settings-no-fetch, force-nonce cases)
- `npm run build` — succeeds (only pre-existing chunk-size / dynamic-import warnings)
- New `ControlRoomView.registry.test.ts` — asserts `SURVEY_TABS` equals exactly the `survey:true` descriptor keys, keys are unique, every surveyed descriptor carries the store-key triple + wire `requestType`, surveyed tabs map to distinct store triples, and the static Settings tab stays out of the auto-fetch set. This is the drift guard for the class of bug the refactor kills.

No store tests or wire types were touched; `dispatch-host-status` / `dispatch-runner-status` / `dispatch-integration-status` / `dispatch-host-status-request` all pass unchanged.

Closes #5557