### PR TITLE
fix(app): clear isDictationUpdateRef on dictation stop/error (#5567)

### DIFF
--- a/packages/app/src/__tests__/hooks/useDictationComposer.test.tsx
+++ b/packages/app/src/__tests__/hooks/useDictationComposer.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * #5567 — `useDictationComposer` clears `isDictationUpdateRef` on every
+ * dictation teardown path.
+ *
+ * The dictation merge effect sets a private `isDictationUpdateRef = true` just
+ * before writing the transcript into the composer via the InputBar's imperative
+ * `setValue`. Pre-#5566 that programmatic write fired `onChangeText`, which
+ * cleared the flag on the next tick. Since #5566 `setValue` is **silent**, so
+ * the flag is only ever cleared by a *subsequent real user keystroke*. If
+ * dictation stops or errors after a transcript arrived but before the user
+ * types again, the flag wedges `true` and the next genuine keystroke is
+ * mis-attributed as "our own dictation echo" — the manual-edit anchor re-point
+ * (`dictationStartRef = text.length`) is skipped and paste/anchor behaviour is
+ * corrupted.
+ *
+ * The flag is private, so these tests observe its EFFECT. `handleChangeText`
+ * only runs the manual-edit re-anchor when the flag is false AND recognition is
+ * active. So: drive a teardown, then start a fresh cycle, type mid-dictation,
+ * and assert the next transcript splices at the user's edited length. That
+ * holds only if the flag was cleared during teardown.
+ *
+ * Each teardown path is isolated:
+ *  - silence-end stop (isRecognizing → false with NO mic tap) → catch-all effect
+ *  - speech error (error → end spec sequence)               → error effect
+ *  - explicit user stop via handleMicPress                  → mic-stop clear
+ *
+ * No `@testing-library/react-native` in this repo — we drive the hook through a
+ * controllable react-test-renderer harness (same pattern as
+ * `useSpeechRecognition.test.ts`).
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+import {
+  useDictationComposer,
+  type UseDictationComposerParams,
+  type UseDictationComposerReturn,
+} from '../../hooks/useDictationComposer';
+import type { InputBarHandle } from '../../components/InputBar';
+
+/** Minimal in-memory stand-in for the InputBar imperative handle (#5556). */
+function makeInputRef(initial = ''): React.RefObject<InputBarHandle | null> {
+  let value = initial;
+  const handle: InputBarHandle = {
+    focus: () => {},
+    getValue: () => value,
+    // Silent programmatic write — does NOT call onChangeText (mirrors #5566).
+    setValue: (next: string) => { value = next; },
+    clear: () => { value = ''; },
+  };
+  return { current: handle };
+}
+
+type HarnessProps = UseDictationComposerParams;
+
+/**
+ * Render the hook in a controllable harness. `api.current` exposes the hook's
+ * return so the test can drive `handleChangeText` / `handleMicPress`;
+ * `update(props)` re-renders with fresh params (simulating prop changes from
+ * the speech hook — `isRecognizing` / `transcript` / `speechError`).
+ */
+function renderHarness(initialProps: HarnessProps) {
+  const apiRef: { current: UseDictationComposerReturn | null } = { current: null };
+
+  function Harness(props: HarnessProps) {
+    apiRef.current = useDictationComposer(props);
+    return null;
+  }
+
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(<Harness {...initialProps} />);
+  });
+
+  return {
+    api: apiRef,
+    update: (props: HarnessProps) => {
+      act(() => { tree.update(<Harness {...props} />); });
+    },
+    unmount: () => { act(() => { tree.unmount(); }); },
+  };
+}
+
+const baseProps = (overrides: Partial<HarnessProps> = {}): HarnessProps => ({
+  inputRef: makeInputRef(),
+  isRecognizing: false,
+  transcript: '',
+  speechError: null,
+  startListening: () => {},
+  stopListening: () => {},
+  onPasteCollapsed: () => {},
+  ...overrides,
+});
+
+describe('useDictationComposer (#5567 dictation flag teardown)', () => {
+  it('handleMicPress starts when idle and stops when active', () => {
+    const startListening = jest.fn();
+    const stopListening = jest.fn();
+    const inputRef = makeInputRef('hello');
+
+    const h = renderHarness(baseProps({ inputRef, startListening, stopListening }));
+    act(() => { h.api.current!.handleMicPress(); });
+    expect(startListening).toHaveBeenCalledTimes(1);
+    expect(stopListening).not.toHaveBeenCalled();
+
+    // Now recognising — mic press should stop.
+    h.update(baseProps({ inputRef, startListening, stopListening, isRecognizing: true }));
+    act(() => { h.api.current!.handleMicPress(); });
+    expect(stopListening).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges each transcript into the draft after the dictation anchor', () => {
+    const inputRef = makeInputRef('');
+    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
+    const h = renderHarness(props());
+
+    // Start dictation (anchors at draft length 0).
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+
+    // Transcript arrives → merged into the empty draft.
+    h.update(props({ isRecognizing: true, transcript: 'hello world' }));
+    expect(inputRef.current!.getValue()).toBe('hello world');
+  });
+
+  it('clears the flag on silence-end stop (no mic tap) — later mid-dictation edit re-anchors', () => {
+    // Catch-all teardown: isRecognizing flips false WITHOUT handleMicPress (a
+    // silence-triggered `end`). If the flag stayed stuck, the next recognising
+    // cycle's mid-dictation manual edit would NOT re-anchor and the following
+    // transcript would overwrite the typed text instead of appending.
+    const inputRef = makeInputRef('');
+    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
+    const h = renderHarness(props());
+
+    // Cycle 1: start → transcript (flag := true).
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+    h.update(props({ isRecognizing: true, transcript: 'one' }));
+    expect(inputRef.current!.getValue()).toBe('one');
+
+    // Silence-end: recogniser stops on its own, no keystroke to clear the flag.
+    h.update(props({ isRecognizing: false, transcript: 'one' }));
+
+    // Cycle 2: fresh start, then the user types mid-dictation. This must
+    // re-anchor (flag was cleared) so the next transcript appends after it.
+    act(() => { h.api.current!.handleMicPress(); }); // anchors at length 3 ('one')
+    h.update(props({ isRecognizing: true }));
+    inputRef.current!.setValue('one typed');
+    act(() => { h.api.current!.handleChangeText('one typed', 'one'); }); // re-anchor to 9
+    h.update(props({ isRecognizing: true, transcript: 'voice' }));
+    expect(inputRef.current!.getValue()).toBe('one typed voice');
+  });
+
+  it('clears the flag on speech error (error → end) — later mid-dictation edit re-anchors', () => {
+    const inputRef = makeInputRef('');
+    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
+    const h = renderHarness(props());
+
+    // Cycle 1: start → transcript (flag := true).
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+    h.update(props({ isRecognizing: true, transcript: 'draft' }));
+    expect(inputRef.current!.getValue()).toBe('draft');
+
+    // Spec sequence: error surfaces, recogniser stops.
+    h.update(props({ isRecognizing: false, transcript: 'draft', speechError: 'no-speech' }));
+
+    // Cycle 2: fresh start (error cleared), mid-dictation manual edit re-anchors.
+    act(() => { h.api.current!.handleMicPress(); }); // anchors at length 5 ('draft')
+    h.update(props({ isRecognizing: true, speechError: null }));
+    inputRef.current!.setValue('draft edit');
+    act(() => { h.api.current!.handleChangeText('draft edit', 'draft'); }); // re-anchor to 10
+    h.update(props({ isRecognizing: true, speechError: null, transcript: 'said' }));
+    expect(inputRef.current!.getValue()).toBe('draft edit said');
+  });
+
+  it('clears the flag on explicit user stop via handleMicPress', () => {
+    // Same wedge but torn down by an explicit mic tap (the stop branch).
+    const inputRef = makeInputRef('');
+    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
+    const h = renderHarness(props());
+
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+    h.update(props({ isRecognizing: true, transcript: 'hi' }));
+    act(() => { h.api.current!.handleMicPress(); }); // explicit user stop
+    h.update(props({ isRecognizing: false, transcript: 'hi' }));
+
+    act(() => { h.api.current!.handleMicPress(); }); // anchors at length 2 ('hi')
+    h.update(props({ isRecognizing: true }));
+    inputRef.current!.setValue('hi more');
+    act(() => { h.api.current!.handleChangeText('hi more', 'hi'); }); // re-anchor to 7
+    h.update(props({ isRecognizing: true, transcript: 'voice' }));
+    expect(inputRef.current!.getValue()).toBe('hi more voice');
+  });
+
+  it('paste detection fires on genuine input after a dictation stop', () => {
+    const inputRef = makeInputRef('');
+    const onPasteCollapsed = jest.fn();
+    const props = (o: Partial<HarnessProps> = {}) =>
+      baseProps({ inputRef, onPasteCollapsed, ...o });
+
+    const h = renderHarness(props());
+
+    // Dictation produced a transcript (flag := true), then stopped (silence end)
+    // with no intervening keystroke.
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+    h.update(props({ isRecognizing: true, transcript: 'note' }));
+    h.update(props({ isRecognizing: false, transcript: 'note' }));
+
+    // The user pastes a large block as their next genuine input. Paste detection
+    // must fire — the stale flag must not break the anchor path that precedes it.
+    const big = 'note' + '\n'.repeat(40) + 'pasted-tail';
+    act(() => { h.api.current!.handleChangeText(big, 'note'); });
+
+    expect(onPasteCollapsed).toHaveBeenCalledTimes(1);
+    const [inserted] = onPasteCollapsed.mock.calls[0];
+    expect(inserted).toContain('pasted-tail');
+  });
+
+  it('consumeUsedVoice reports voice usage once then resets', () => {
+    const inputRef = makeInputRef('');
+    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
+    const h = renderHarness(props());
+
+    // No voice yet.
+    expect(h.api.current!.consumeUsedVoice()).toBe(false);
+
+    // A transcript merge sets usedVoiceRef.
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+    h.update(props({ isRecognizing: true, transcript: 'spoken' }));
+
+    expect(h.api.current!.consumeUsedVoice()).toBe(true);
+    // Second read resets to false.
+    expect(h.api.current!.consumeUsedVoice()).toBe(false);
+  });
+});

--- a/packages/app/src/hooks/useDictationComposer.ts
+++ b/packages/app/src/hooks/useDictationComposer.ts
@@ -1,0 +1,186 @@
+import { useRef, useCallback, useEffect } from 'react';
+import {
+  shouldCollapsePaste,
+  detectPasteFromDiff,
+} from '@chroxy/store-core';
+
+import type { InputBarHandle } from '../components/InputBar';
+
+/**
+ * Dictation + composer-change bookkeeping for SessionScreen (#5567).
+ *
+ * Owns the three composer refs that the voice-merge path coordinates:
+ *
+ * - `isDictationUpdateRef` — true for exactly one composer change: the echo of
+ *   a programmatic dictation `setValue`. Used to distinguish "this change is our
+ *   own transcript write" from "the user manually edited mid-dictation" so the
+ *   anchor (`dictationStartRef`) isn't clobbered by our own write.
+ * - `dictationStartRef` — index in the draft where the current dictation session
+ *   began inserting; the transcript is spliced in after this offset.
+ * - `usedVoiceRef` — whether the pending message originated (partly) from voice,
+ *   read by the send path to tag the outgoing message `isVoice`.
+ *
+ * ## The wedge this hook closes (#5567)
+ *
+ * Pre-#5566, the InputBar's `setValue` fired `onChangeText`, so the programmatic
+ * dictation write produced its own `onChangeText` echo and `handleChangeText`
+ * always cleared `isDictationUpdateRef` on the very next tick. After #5566,
+ * `InputBarHandle.setValue` is **silent** — it does NOT fire `onChangeText`. So
+ * the flag set just before the transcript write is now only ever cleared by a
+ * *subsequent real user keystroke*. If dictation stops or errors after a
+ * transcript arrived but before the user typed again, the flag stays stuck
+ * `true`. The next genuine keystroke then hits the `isDictationUpdateRef` branch
+ * in `handleChangeText` and is misread as "our own dictation echo" — the manual-
+ * edit anchor re-point is skipped, corrupting paste detection / anchoring for
+ * that input.
+ *
+ * The fix: clear `isDictationUpdateRef` on every dictation teardown path —
+ * `handleMicPress` stop, speech error, the `isRecognizing → false` transition,
+ * and unmount — so a stale `true` can never bleed into the next genuine input.
+ */
+
+export interface UseDictationComposerParams {
+  /** Imperative handle for the InputBar composer draft (#5556). */
+  inputRef: React.RefObject<InputBarHandle | null>;
+  /** Whether the speech recogniser is currently active. */
+  isRecognizing: boolean;
+  /** Latest transcript text from the recogniser (empty when none). */
+  transcript: string;
+  /** Speech-recognition error string, or null. */
+  speechError: string | null;
+  /** Begin a recogniser session. */
+  startListening: () => void;
+  /** Stop the recogniser session. */
+  stopListening: () => void;
+  /**
+   * Called when a composer change is detected as a paste large enough to
+   * collapse. The host owns the pasted-block id counter + block state (it must
+   * survive across this hook and reset on send), so the host assigns the id,
+   * formats the marker, writes it back into the draft via `inputRef.setValue`,
+   * and records the original content. `prefix`/`suffix` are the draft text on
+   * either side of the inserted span.
+   */
+  onPasteCollapsed: (inserted: string, prefix: string, suffix: string) => void;
+}
+
+export interface UseDictationComposerReturn {
+  /** `onChangeText(next, prev)` handler for the InputBar. */
+  handleChangeText: (text: string, prev: string) => void;
+  /** Mic toggle: start when idle, stop (and clear the dictation flag) when active. */
+  handleMicPress: () => void;
+  /**
+   * Read-and-reset the "used voice" flag for the send path. Returns whether the
+   * pending message used voice, then clears the flag.
+   */
+  consumeUsedVoice: () => boolean;
+}
+
+export function useDictationComposer(
+  params: UseDictationComposerParams,
+): UseDictationComposerReturn {
+  const {
+    inputRef,
+    isRecognizing,
+    transcript,
+    speechError,
+    startListening,
+    stopListening,
+    onPasteCollapsed,
+  } = params;
+
+  // True for exactly one composer change — the echo of a programmatic dictation
+  // write. See the module doc for why this must be cleared on every teardown.
+  const isDictationUpdateRef = useRef(false);
+  // Index where the current dictation session began inserting (#5556).
+  const dictationStartRef = useRef(0);
+  // Whether the pending message used voice (read by the send path).
+  const usedVoiceRef = useRef(false);
+
+  // Keep the latest paste callback without re-creating handleChangeText, so the
+  // InputBar's onChangeText identity stays stable across streaming re-renders.
+  const onPasteCollapsedRef = useRef(onPasteCollapsed);
+  onPasteCollapsedRef.current = onPasteCollapsed;
+
+  const handleChangeText = useCallback((text: string, prev: string) => {
+    if (!isDictationUpdateRef.current && isRecognizing) {
+      // User manually edited text during dictation — update anchor point
+      dictationStartRef.current = text.length;
+    }
+    isDictationUpdateRef.current = false;
+
+    // Paste detection — RN `TextInput` has no native paste event, so we detect
+    // by diffing prev→next on each `onChangeText` and feeding the inserted span
+    // through the shared `shouldCollapsePaste` predicate (covers both the char
+    // and the line thresholds).
+    if (text.length > prev.length) {
+      const diff = detectPasteFromDiff(prev, text);
+      if (diff && shouldCollapsePaste(diff.inserted)) {
+        onPasteCollapsedRef.current(diff.inserted, diff.prefix, diff.suffix);
+      }
+    }
+  }, [isRecognizing]);
+
+  // Voice input: toggle start/stop and merge transcript into input text. On stop
+  // we MUST clear `isDictationUpdateRef` — a transcript may have set it true and,
+  // since `setValue` is silent post-#5556, nothing else will clear it before the
+  // next genuine keystroke (#5567).
+  const handleMicPress = useCallback(() => {
+    if (isRecognizing) {
+      isDictationUpdateRef.current = false;
+      stopListening();
+    } else {
+      dictationStartRef.current = (inputRef.current?.getValue() ?? '').length;
+      startListening();
+    }
+  }, [isRecognizing, startListening, stopListening, inputRef]);
+
+  // Merge each transcript into the draft after the dictation anchor. Sets the
+  // dictation flag so the (silent) write isn't mistaken for a manual edit, and
+  // marks the message as voice-originated for the send path.
+  useEffect(() => {
+    if (isRecognizing && transcript) {
+      const current = inputRef.current?.getValue() ?? '';
+      const prefix = current.slice(0, dictationStartRef.current);
+      const separator = prefix.length > 0 && !prefix.endsWith(' ') ? ' ' : '';
+      isDictationUpdateRef.current = true;
+      usedVoiceRef.current = true;
+      inputRef.current?.setValue(prefix + separator + transcript);
+    }
+  }, [transcript]); // eslint-disable-line react-hooks/exhaustive-deps -- only react to transcript changes
+
+  // #5567 — clear the dictation flag whenever a speech error surfaces. The spec
+  // sequence (error → end) can stop the recogniser after a transcript already
+  // flipped the flag true; without this the stale flag wedges the next input.
+  useEffect(() => {
+    if (speechError) {
+      isDictationUpdateRef.current = false;
+    }
+  }, [speechError]);
+
+  // #5567 — clear the dictation flag whenever recognition stops for ANY reason
+  // (user stop, silence timeout, hard error, system interruption). This is the
+  // catch-all: the flag is only meaningful while a transcript write is pending
+  // an echo, and once the recogniser is no longer active there is no pending
+  // dictation write to attribute the next change to.
+  useEffect(() => {
+    if (!isRecognizing) {
+      isDictationUpdateRef.current = false;
+    }
+  }, [isRecognizing]);
+
+  // #5567 — defensive unmount clear. Refs survive across renders but not across
+  // re-mounts; this keeps the teardown contract explicit and self-documenting.
+  useEffect(() => {
+    return () => {
+      isDictationUpdateRef.current = false;
+    };
+  }, []);
+
+  const consumeUsedVoice = useCallback(() => {
+    const used = usedVoiceRef.current;
+    usedVoiceRef.current = false;
+    return used;
+  }, []);
+
+  return { handleChangeText, handleMicPress, consumeUsedVoice };
+}

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -56,10 +56,11 @@ import { Icon } from '../components/Icon';
 import { COLORS } from '../constants/colors';
 import { useLayout } from '../hooks/useLayout';
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
+import { useDictationComposer } from '../hooks/useDictationComposer';
 import { useAndroidSessionNotification } from '../hooks/useAndroidSessionNotification';
 import { pickFromCamera, pickFromGallery, pickDocument, toWireAttachments, MAX_ATTACHMENTS } from '../utils/attachments';
 import type { Attachment } from '../utils/attachments';
-import { shouldCollapsePaste, formatPasteMarker, expandPasteMarkers, detectPasteFromDiff } from '@chroxy/store-core';
+import { formatPasteMarker, expandPasteMarkers } from '@chroxy/store-core';
 import { PastedTextModal } from '../components/PastedTextModal';
 
 
@@ -369,11 +370,6 @@ export function SessionScreen() {
   const { isRecognizing, transcript, isAvailable: speechAvailable, startListening, stopListening, error: speechError } = useSpeechRecognition({
     mode: inputSettings.voiceInputMode,
   });
-  // Anchor index where the current dictation session began inserting. Seeded
-  // to 0 and reset in handleMicPress (and on manual edits during dictation)
-  // from the live draft length read off the InputBar ref (#5556).
-  const dictationStartRef = useRef(0);
-  const usedVoiceRef = useRef(false);
 
   // Surface speech recognition errors to the user
   useEffect(() => {
@@ -662,8 +658,7 @@ export function SessionScreen() {
 
     // PTY sessions: append CR so text + submit arrive as a single atomic write.
     // CLI sessions: the server handles the full message directly (no CR needed).
-    const isVoice = usedVoiceRef.current;
-    usedVoiceRef.current = false;
+    const isVoice = consumeUsedVoice();
     const result = sendInput(hasTerminal ? (text || '') + '\r' : (text || ''), wire, { isVoice, clientMessageId });
     if (result === 'queued') {
       const { addMessage } = useConnectionStore.getState();
@@ -825,9 +820,6 @@ export function SessionScreen() {
     inputRef.current?.focus();
   }, []);
 
-  // Track whether the latest draft change came from dictation (vs manual edit)
-  const isDictationUpdateRef = useRef(false);
-
   // Pasted-text-block storage for the composer (#3797). React Native
   // `TextInput` has no native paste event, so we detect large pastes by
   // diffing the previous and next text on each `onChangeText` — anything
@@ -839,37 +831,38 @@ export function SessionScreen() {
   const [inspectedPastedTextId, setInspectedPastedTextId] = useState<number | null>(null);
 
   // #5556 — InputBar owns the draft and has already applied the user's
-  // keystroke before calling this; we only react to it. `prev` is supplied by
-  // InputBar (the value before this change) so paste-diff no longer needs the
-  // draft in SessionScreen's render-scope state. On a collapse we push the
-  // marker-substituted value BACK into InputBar via the imperative setValue.
-  const handleChangeText = useCallback((text: string, prev: string) => {
-    if (!isDictationUpdateRef.current && isRecognizing) {
-      // User manually edited text during dictation — update anchor point
-      dictationStartRef.current = text.length;
-    }
-    isDictationUpdateRef.current = false;
+  // keystroke before calling this; we only react to the diff. On a paste
+  // collapse we assign the id, format the marker, record the original content,
+  // and push the marker-substituted value BACK into InputBar via setValue.
+  // The previous implementation short-circuited on a char-only fast-path which
+  // missed multi-line pastes that fell below 1500 chars but crossed the 20-line
+  // threshold (#3798 review, #3799); `detectPasteFromDiff` on every grow (inside
+  // the hook) keeps both clients honouring the same criteria.
+  const handlePasteCollapsed = useCallback((inserted: string, prefix: string, suffix: string) => {
+    const nextId = pastedTextNextIdRef.current + 1;
+    pastedTextNextIdRef.current = nextId;
+    const marker = formatPasteMarker(nextId, inserted);
+    setPastedTextBlocks(prevBlocks => [...prevBlocks, { id: nextId, content: inserted }]);
+    inputRef.current?.setValue(prefix + marker + suffix);
+  }, []);
 
-    // Paste detection — RN `TextInput` has no native paste event, so we
-    // detect by diffing prev→next on each `onChangeText` and feeding the
-    // inserted span through the shared `shouldCollapsePaste` predicate
-    // (covers both the char and the line thresholds). The previous
-    // implementation short-circuited on a char-only fast-path which
-    // missed multi-line pastes that fell below 1500 chars but crossed
-    // the 20-line threshold (#3798 review, #3799). Running
-    // `detectPasteFromDiff` on every grow keeps both clients honouring
-    // the same criteria.
-    if (text.length > prev.length) {
-      const diff = detectPasteFromDiff(prev, text);
-      if (diff && shouldCollapsePaste(diff.inserted)) {
-        const nextId = pastedTextNextIdRef.current + 1;
-        pastedTextNextIdRef.current = nextId;
-        const marker = formatPasteMarker(nextId, diff.inserted);
-        setPastedTextBlocks(prevBlocks => [...prevBlocks, { id: nextId, content: diff.inserted }]);
-        inputRef.current?.setValue(diff.prefix + marker + diff.suffix);
-      }
-    }
-  }, [isRecognizing]);
+  // #5567 — dictation + composer-change bookkeeping (the three voice refs, the
+  // change/mic handlers, and the transcript-merge effect) lives in a dedicated
+  // hook so the `isDictationUpdateRef` teardown contract is explicit. The hook
+  // clears that flag on mic-stop, speech error, the `isRecognizing → false`
+  // transition, and unmount — closing the wedge where a stale flag (set by a
+  // transcript write whose silent `setValue` never echoes through
+  // `onChangeText` since #5556) suppressed anchoring/paste-detection on the next
+  // genuine keystroke.
+  const { handleChangeText, handleMicPress, consumeUsedVoice } = useDictationComposer({
+    inputRef,
+    isRecognizing,
+    transcript,
+    speechError,
+    startListening,
+    stopListening,
+    onPasteCollapsed: handlePasteCollapsed,
+  });
 
   const handleRemovePastedText = useCallback((id: number) => {
     setPastedTextBlocks(prev => prev.filter(b => b.id !== id));
@@ -885,29 +878,6 @@ export function SessionScreen() {
   const handleInspectPastedText = useCallback((id: number) => {
     setInspectedPastedTextId(id);
   }, []);
-
-  // Voice input: toggle start/stop and merge transcript into input text.
-  // #5556 — anchor the dictation start at the live draft length read off the
-  // InputBar ref, and merge the transcript back through the ref.
-  const handleMicPress = useCallback(() => {
-    if (isRecognizing) {
-      stopListening();
-    } else {
-      dictationStartRef.current = (inputRef.current?.getValue() ?? '').length;
-      startListening();
-    }
-  }, [isRecognizing, startListening, stopListening]);
-
-  useEffect(() => {
-    if (isRecognizing && transcript) {
-      const current = inputRef.current?.getValue() ?? '';
-      const prefix = current.slice(0, dictationStartRef.current);
-      const separator = prefix.length > 0 && !prefix.endsWith(' ') ? ' ' : '';
-      isDictationUpdateRef.current = true;
-      usedVoiceRef.current = true;
-      inputRef.current?.setValue(prefix + separator + transcript);
-    }
-  }, [transcript]); // eslint-disable-line react-hooks/exhaustive-deps -- only react to transcript changes
 
   // Check if Enter key should send based on current mode and settings
   const enterToSend = viewMode === 'terminal'


### PR DESCRIPTION
## Summary

Fixes a pre-existing wedge in mobile dictation, surfaced during #5566's review (Copilot thread, triaged FOLLOW-UP — mechanism pre-existing on `main`, not introduced by the InputBar decoupling).

`SessionScreen`'s dictation merge effect sets `isDictationUpdateRef = true` right before writing the transcript into the composer via the InputBar imperative handle. The flag distinguishes "this composer change is the echo of our own programmatic dictation write" from "the user manually edited mid-dictation" — the latter re-anchors `dictationStartRef` so the next transcript splices at the right offset.

**The wedge:** Before #5566, `InputBar.setValue` fired `onChangeText`, whose handler cleared the flag on the next tick. Since #5566 `InputBarHandle.setValue` is **silent** (no `onChangeText`), so the flag is now only ever cleared by a *subsequent real user keystroke*. If dictation stops or errors after a transcript arrived but before the user types again, the flag wedges `true`. The next genuine keystroke is then mis-attributed as the dictation echo — the manual-edit anchor re-point is skipped, corrupting anchoring / paste detection for that input.

### Lifecycle map (every set/clear site)

`isDictationUpdateRef` before this PR (all in `SessionScreen.tsx`):
- **set `true`** — transcript-merge effect, just before the silent `setValue` (`~:906`)
- **clear `false`** — `handleChangeText`, unconditionally, after the anchor branch (`~:851`) — the **only** clear, and post-#5566 it only runs on a real user keystroke

Speech lifecycle (`useSpeechRecognition`): `start` → `result`(transcript) → `end` (silence re-arm in continuous mode, else stop) / `error` (hard → stop + `isRecognizing=false`; soft+continuous → stays live; soft+auto-pause → stop) / unmount (`abort`). Several of these drop `isRecognizing` to `false` **without** a composer keystroke, leaving the flag stuck.

### Fix

Extract the dictation + composer-change bookkeeping (the three voice refs, the change/mic handlers, the transcript-merge effect) into a dedicated `useDictationComposer` hook so the teardown contract is explicit and unit-testable, and clear `isDictationUpdateRef` on **every** teardown path:
- `handleMicPress` stop branch
- speech-error effect (the spec `error → end` sequence)
- the `isRecognizing → false` transition (silence-end / hard error / system interruption — the catch-all)
- unmount

`SessionScreen` keeps ownership of the pasted-block state + id counter and receives paste collapses via an `onPasteCollapsed` callback (the id counter must reset on send, so it stays in the screen). Behaviour is otherwise identical.

## Test plan

New `src/__tests__/hooks/useDictationComposer.test.tsx` drives the wedge: start → transcript (flag set) → teardown → user types, then asserts the next transcript anchors at the user's edited length and paste detection fires. Each teardown path is isolated:
- silence-end stop (`isRecognizing → false`, no mic tap) → catch-all effect
- speech error (`error → end`) → error effect
- explicit user stop via `handleMicPress` → mic-stop clear
- paste detection fires on genuine input after a dictation stop

Verified the suite **fails with the clears removed** (negative control: the three teardown tests show `'hi voice'` instead of `'hi more voice'` — the stale flag swallowing the mid-dictation edit).

- App: `npx tsc --noEmit` clean (only the pre-existing, gitignored `xterm-bundle.generated` artifact, present after `postinstall`).
- Full jest suite: **125 suites / 1720 tests pass**.

Closes #5567