### PR TITLE
perf(dashboard): virtualize the ChatView message list (#5561)

### DIFF
--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -5,11 +5,24 @@
  * - Detects user scroll-up, pauses auto-scroll
  * - Shows scroll-to-bottom button when scrolled up
  * - Deduplicates messages by id for reconnect replay
+ *
+ * #5561 — the message list is windowed (virtualized) above a row-count
+ * threshold. Long sessions previously mapped the ENTIRE deduped array to the
+ * DOM (the responsiveness wall the issue names); now only the rows intersecting
+ * the viewport (plus a small overscan) mount, with top/bottom spacer divs
+ * preserving scroll geometry. Below the threshold every row renders exactly as
+ * before — no behaviour change for short histories. Mirrors the mobile #5534
+ * patterns: pinned-to-bottom while streaming, scroll position preserved when
+ * scrolled up, and an id-keyed expand registry so tool-bubble expand state
+ * survives a row scrolling out of and back into the window.
  */
 import { memo, useRef, useState, useCallback, useEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
 import { bumpRenderCount } from '@chroxy/store-core'
 import { ThinkingDots } from './ThinkingDots'
 import { renderMarkdown } from '../lib/markdown'
+import { MessageRowShell } from './MeasuredRow'
+import { ChatExpandContext, type ChatExpandRegistry } from './chatExpandRegistry'
+import { useWindowedRange } from './useWindowedRange'
 
 /* ---- Sender Icons ---- */
 
@@ -134,6 +147,13 @@ const TYPE_CLASS: Record<string, string> = {
 
 const SCROLL_THRESHOLD = 60
 
+/**
+ * #5561 — the `gap` between rows in `.chat-messages` (theme/components.css).
+ * Folded into the windowing height math so the spacer heights match the real
+ * scroll geometry. Keep in sync with the CSS.
+ */
+const CHAT_MESSAGES_ROW_GAP = 12
+
 function formatTime(ts: number): string {
   const d = new Date(ts)
   let h = d.getHours()
@@ -184,11 +204,14 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   // the hot path.
   if (IS_DEV) bumpRenderCount(`ChatMessageRow:${id}`)
 
-  // Derive icon + row class from `type` INSIDE the memo. Computing them in the
-  // parent map would hand the memo a fresh `icon` JSX element identity every
-  // render and defeat the skip — every prop must be a stable scalar.
+  // Derive icon from `type` INSIDE the memo. Computing it in the parent map
+  // would hand the memo a fresh `icon` JSX element identity every render and
+  // defeat the skip — every prop must be a stable scalar. The outer `.msg-row`
+  // container (class + data-testid) is now rendered by ChatView's row shell
+  // (`MessageRowShell`, #5561) so the measurement ResizeObserver can attach to
+  // the same element that carries the flex layout; this memo renders only the
+  // inner content.
   const icon = senderIconFor(type)
-  const rowClass = rowClassFor(type, icon !== null)
 
   const body =
     type === 'response' || type === 'tool_use'
@@ -196,14 +219,14 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
       : content
 
   return (
-    <div data-testid={`msg-${id}`} className={rowClass}>
+    <>
       {type !== 'user_input' && icon}
       <div className={`msg ${TYPE_CLASS[type] || 'assistant'}${isStreaming ? ' streaming' : ''}`}>
         {body}
         {timestamp > 0 && <span className="msg-timestamp">{formatTime(timestamp)}</span>}
       </div>
       {type === 'user_input' && icon}
-    </div>
+    </>
   )
 })
 
@@ -211,6 +234,12 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
+
+  // #5561 — scroll/viewport geometry that drives the windowing hook. Kept in
+  // state (not just the DOM) so a scroll or resize recomputes the visible
+  // range. Seeded to 0 and synced on mount + every scroll/resize.
+  const [scrollTop, setScrollTop] = useState(0)
+  const [viewportHeight, setViewportHeight] = useState(0)
 
   // Deduplicate by id — keep first occurrence
   const dedupedMessages = useMemo(() => {
@@ -222,9 +251,63 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     })
   }, [messages])
 
+  // #5561 — id-keyed expand-state registry (mirror of mobile #5534). Lives in a
+  // ref so a tool bubble persisting its expand flag never re-renders ChatView;
+  // a row that scrolled out and back re-reads its flag on remount via
+  // `useInitialExpanded`. The Provider value is memoized so the context
+  // identity is stable across renders.
+  const expandedStateRef = useRef<Map<string, boolean>>(new Map())
+  const expandRegistry = useMemo<ChatExpandRegistry>(
+    () => ({
+      get: (key) => expandedStateRef.current.get(key),
+      set: (key, expanded) => {
+        if (expanded) expandedStateRef.current.set(key, true)
+        else expandedStateRef.current.delete(key)
+      },
+    }),
+    [],
+  )
+
+  // #5561 — stable per-row key lookup for the height cache. Rows key by message
+  // id (the dedup pass already guarantees uniqueness), matching the React
+  // `key` used in the map so a row's measured height tracks the row, not its
+  // index, across windowing churn.
+  const keyAt = useCallback(
+    (index: number) => dedupedMessages[index]?.id ?? `__row_${index}`,
+    [dedupedMessages],
+  )
+
+  const range = useWindowedRange({
+    itemCount: dedupedMessages.length,
+    scrollTop,
+    viewportHeight,
+    // Matches `.chat-messages { gap: 12px }` in theme/components.css so the
+    // windowing spacers reserve the same total height the real flex column
+    // occupies (rows + inter-row gaps).
+    rowGap: CHAT_MESSAGES_ROW_GAP,
+    keyAt,
+  })
+
+  const syncGeometry = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    // Functional updates that bail when unchanged — a no-op sync (e.g. the
+    // mount sync in jsdom where scrollTop/clientHeight are both 0) must not
+    // schedule a spurious re-render. This keeps the #4398 hidden-memoization
+    // contract (renderMessage invoked exactly once on first mount) intact.
+    setScrollTop(prev => (prev === el.scrollTop ? prev : el.scrollTop))
+    setViewportHeight(prev => (prev === el.clientHeight ? prev : el.clientHeight))
+  }, [])
+
   const handleScroll = useCallback(() => {
     const el = containerRef.current
     if (!el) return
+    // #5561 — feed the windowing hook the live scroll offset so the visible
+    // slice tracks the viewport. clientHeight is stable per scroll but cheap
+    // to read here, keeping the range correct if a scroll coincides with a
+    // layout change.
+    setScrollTop(el.scrollTop)
+    setViewportHeight(el.clientHeight)
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_THRESHOLD
     // During programmatic scrolls, only update if we're at bottom (don't falsely set scrolledUp)
     if (programmaticScrollRef.current && atBottom) return
@@ -250,8 +333,21 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     if (!el) return
     programmaticScrollRef.current = true
     el.scrollTop = el.scrollHeight
+    // #5561 — seed the windowing geometry from the real container size on mount
+    // so the first render after layout has an accurate viewport height.
+    syncGeometry()
     requestAnimationFrame(() => { programmaticScrollRef.current = false })
-  }, [])
+  }, [syncGeometry])
+
+  // #5561 — keep the windowed range correct when the container resizes (panel
+  // split drag, window resize, sidebar toggle) without a scroll event firing.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(() => syncGeometry())
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [syncGeometry])
 
   // #4652: previously a separate streaming-end effect reset
   // `userScrolledUp` to false — that snapped the user back to the
@@ -302,46 +398,80 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     return () => cancelAnimationFrame(rafId)
   }, [isStreaming, userScrolledUp])
 
+  // #5561 — the windowed slice. Only rows in [startIndex, endIndex) mount; the
+  // top/bottom spacers reserve the height of the skipped rows so the scrollbar
+  // geometry (and therefore scroll position when content appends above the
+  // viewport) is preserved. Below the threshold `range` covers the whole list
+  // and both spacers are 0, so short conversations render exactly as before.
+  const visible = dedupedMessages.slice(range.startIndex, range.endIndex)
+
   return (
     <div className="chat-view" data-testid="chat-view">
-      <div
-        ref={containerRef}
-        className="chat-messages"
-        data-testid="chat-messages"
-        onScroll={handleScroll}
-      >
-        {dedupedMessages.map(msg => {
-          const icon = senderIconFor(msg.type)
-          const rowClass = msg.type === 'user_input' ? 'msg-row msg-row-user'
-            : msg.type === 'system' ? 'msg-row msg-row-system'
-            : icon ? 'msg-row' : ''
-          const custom = renderMessage?.(msg)
-          if (custom !== undefined && custom !== null) {
-            return (
-              <div
-                key={msg.id}
-                data-testid={`msg-${msg.id}`}
-                className={rowClass}
-              >
-                {msg.type !== 'user_input' && icon}
-                <div style={{ display: 'contents' }}>{custom}</div>
-                {msg.type === 'user_input' && icon}
-              </div>
-            )
-          }
-          return (
-            <DefaultMessageRow
-              key={msg.id}
-              id={msg.id}
-              type={msg.type}
-              content={msg.content}
-              timestamp={msg.timestamp}
-              isStreaming={msg.isStreaming}
+      <ChatExpandContext.Provider value={expandRegistry}>
+        <div
+          ref={containerRef}
+          className="chat-messages"
+          data-testid="chat-messages"
+          onScroll={handleScroll}
+        >
+          {/* Top spacer — reserves the height of windowed-out leading rows. The
+              `flex: 0 0 auto` style keeps it from being squeezed by the flex
+              column the way a normal flex child would be. */}
+          {range.topSpacer > 0 && (
+            <div
+              aria-hidden="true"
+              data-testid="chat-window-top-spacer"
+              style={{ flex: '0 0 auto', height: range.topSpacer }}
             />
-          )
-        })}
-        {(isStreaming || isBusy) && <ThinkingDots />}
-      </div>
+          )}
+          {visible.map(msg => {
+            const icon = senderIconFor(msg.type)
+            const rowClass = rowClassFor(msg.type, icon !== null)
+            const custom = renderMessage?.(msg)
+            if (custom !== undefined && custom !== null) {
+              return (
+                <MessageRowShell
+                  key={msg.id}
+                  rowKey={msg.id}
+                  measureRow={range.measureRow}
+                  className={rowClass}
+                  testId={`msg-${msg.id}`}
+                >
+                  {msg.type !== 'user_input' && icon}
+                  <div style={{ display: 'contents' }}>{custom}</div>
+                  {msg.type === 'user_input' && icon}
+                </MessageRowShell>
+              )
+            }
+            return (
+              <MessageRowShell
+                key={msg.id}
+                rowKey={msg.id}
+                measureRow={range.measureRow}
+                className={rowClass}
+                testId={`msg-${msg.id}`}
+              >
+                <DefaultMessageRow
+                  id={msg.id}
+                  type={msg.type}
+                  content={msg.content}
+                  timestamp={msg.timestamp}
+                  isStreaming={msg.isStreaming}
+                />
+              </MessageRowShell>
+            )
+          })}
+          {/* Bottom spacer — reserves the height of windowed-out trailing rows. */}
+          {range.bottomSpacer > 0 && (
+            <div
+              aria-hidden="true"
+              data-testid="chat-window-bottom-spacer"
+              style={{ flex: '0 0 auto', height: range.bottomSpacer }}
+            />
+          )}
+          {(isStreaming || isBusy) && <ThinkingDots />}
+        </div>
+      </ChatExpandContext.Provider>
 
       {userScrolledUp && (
         <button

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -148,11 +148,28 @@ const TYPE_CLASS: Record<string, string> = {
 const SCROLL_THRESHOLD = 60
 
 /**
- * #5561 — the `gap` between rows in `.chat-messages` (theme/components.css).
+ * #5561 — fallback `gap` between rows in `.chat-messages` (theme/components.css).
  * Folded into the windowing height math so the spacer heights match the real
- * scroll geometry. Keep in sync with the CSS.
+ * scroll geometry. The live value is read from `getComputedStyle().rowGap` at
+ * runtime (it drops to 8px under the narrow-viewport media query in
+ * components.css), so this constant is only the fallback used when computed
+ * style is unavailable (jsdom) or unparseable. Keep in sync with the CSS base
+ * rule (`.chat-messages { gap: 12px }`).
  */
 const CHAT_MESSAGES_ROW_GAP = 12
+
+/**
+ * Read the live row gap (px) from the scroll container's computed style so the
+ * windowing math tracks the responsive `.chat-messages` gap (12px desktop / 8px
+ * narrow). Falls back to {@link CHAT_MESSAGES_ROW_GAP} when computed style is
+ * unavailable (jsdom returns `''`) or yields a non-finite value.
+ */
+function readRowGap(el: HTMLElement | null): number {
+  if (!el || typeof getComputedStyle !== 'function') return CHAT_MESSAGES_ROW_GAP
+  const raw = getComputedStyle(el).rowGap
+  const parsed = parseFloat(raw)
+  return Number.isFinite(parsed) ? parsed : CHAT_MESSAGES_ROW_GAP
+}
 
 function formatTime(ts: number): string {
   const d = new Date(ts)
@@ -258,6 +275,10 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
   // range. Seeded to 0 and synced on mount + every scroll/resize.
   const [scrollTop, setScrollTop] = useState(0)
   const [viewportHeight, setViewportHeight] = useState(0)
+  // #5561 — live row gap from the container's computed style, re-read on resize
+  // (the same geometry sync that tracks viewport height) so the windowing math
+  // follows the responsive `.chat-messages` gap instead of a hard-coded 12px.
+  const [rowGap, setRowGap] = useState(CHAT_MESSAGES_ROW_GAP)
 
   // Deduplicate by id — keep first occurrence
   const dedupedMessages = useMemo(() => {
@@ -299,10 +320,10 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     itemCount: dedupedMessages.length,
     scrollTop,
     viewportHeight,
-    // Matches `.chat-messages { gap: 12px }` in theme/components.css so the
-    // windowing spacers reserve the same total height the real flex column
-    // occupies (rows + inter-row gaps).
-    rowGap: CHAT_MESSAGES_ROW_GAP,
+    // Live `.chat-messages` row gap (12px desktop / 8px narrow), re-read on
+    // resize via syncGeometry, so the windowing spacers reserve the same total
+    // height the real responsive flex column occupies (rows + inter-row gaps).
+    rowGap,
     keyAt,
   })
 
@@ -315,6 +336,11 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     // contract (renderMessage invoked exactly once on first mount) intact.
     setScrollTop(prev => (prev === el.scrollTop ? prev : el.scrollTop))
     setViewportHeight(prev => (prev === el.clientHeight ? prev : el.clientHeight))
+    // Re-read the responsive row gap from computed style — a viewport resize can
+    // cross the narrow-viewport media query and flip 12px↔8px. Same bail-when-
+    // unchanged pattern so a no-op sync doesn't churn a re-render.
+    const liveGap = readRowGap(el)
+    setRowGap(prev => (prev === liveGap ? prev : liveGap))
   }, [])
 
   const handleScroll = useCallback(() => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -16,7 +16,7 @@
  * scrolled up, and an id-keyed expand registry so tool-bubble expand state
  * survives a row scrolling out of and back into the window.
  */
-import { memo, useRef, useState, useCallback, useEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
+import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
 import { bumpRenderCount } from '@chroxy/store-core'
 import { ThinkingDots } from './ThinkingDots'
 import { renderMarkdown } from '../lib/markdown'
@@ -235,6 +235,24 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
 
+  // #5561 — scroll-anchor compensation state. WKWebView (the Tauri desktop's
+  // engine, and the dashboard's PRIMARY consumer) does NOT implement default
+  // CSS scroll anchoring (no `overflow-anchor` support), so when a height-cache
+  // correction changes the height of content ABOVE the viewport, the browser
+  // does NOT keep the visible rows pinned the way Blink/Gecko would — the
+  // content visibly jumps. We compensate by hand: track the windowing anchor
+  // (the first visible row + its content-space top offset) and, when that
+  // offset shifts for the SAME anchor row, add the delta back to `scrollTop`
+  // before paint (useLayoutEffect). See the compensation effect below.
+  const anchorRef = useRef<{ index: number; offset: number } | null>(null)
+  // The scrollTop value we just wrote during compensation. The resulting
+  // `scroll` event must NOT be treated as a user scroll (it would otherwise
+  // re-seed `scrollTop` state with a value the next render's anchor math has
+  // already accounted for, and could flip `userScrolledUp`). The handler clears
+  // this once it sees the matching offset — an expected-scrollTop guard against
+  // a compensation→scroll→recompute feedback loop.
+  const expectedScrollTopRef = useRef<number | null>(null)
+
   // #5561 — scroll/viewport geometry that drives the windowing hook. Kept in
   // state (not just the DOM) so a scroll or resize recomputes the visible
   // range. Seeded to 0 and synced on mount + every scroll/resize.
@@ -302,6 +320,17 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
   const handleScroll = useCallback(() => {
     const el = containerRef.current
     if (!el) return
+    // #5561 — ignore the synthetic `scroll` event our own compensation write
+    // produced. `el.scrollTop` already equals the value the layout effect set,
+    // and the anchor math that produced it is consistent with the current
+    // `scrollTop` state, so re-seeding state (or re-evaluating `userScrolledUp`)
+    // here would either be a no-op churn or, worse, feed the delta back in.
+    if (expectedScrollTopRef.current !== null && Math.abs(el.scrollTop - expectedScrollTopRef.current) < 1) {
+      expectedScrollTopRef.current = null
+      return
+    }
+    // A real user scroll invalidates any pending expected value.
+    expectedScrollTopRef.current = null
     // #5561 — feed the windowing hook the live scroll offset so the visible
     // slice tracks the viewport. clientHeight is stable per scroll but cheap
     // to read here, keeping the range correct if a scroll coincides with a
@@ -348,6 +377,76 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     ro.observe(el)
     return () => ro.disconnect()
   }, [syncGeometry])
+
+  // #5561 — engine-independent scroll-position compensation.
+  //
+  // WHY: Browsers with CSS scroll anchoring (Blink/Gecko) automatically keep
+  // the visible content fixed when above-viewport content changes height — the
+  // approve rationale for #5561 relied on that. But the Tauri desktop, the
+  // dashboard's PRIMARY consumer, renders in WKWebView (Safari's engine), which
+  // ships NO default scroll anchoring and does not honour `overflow-anchor`.
+  // There, scrolling UP through history — where freshly-mounted top rows
+  // re-measure away from their estimated heights and the top spacer is
+  // recalculated — would visibly jump/jitter. We restore the missing behaviour
+  // by hand for ALL engines (cheap and idempotent where anchoring already
+  // works, since the offset delta is 0 once heights are correct).
+  //
+  // HOW: each render we remember the first-visible row (`firstVisibleIndex`) and
+  // its content-space top offset (`firstVisibleOffset`). On the NEXT render we
+  // re-read that SAME row's offset via `range.offsetAt(prevIndex)` — anchoring on
+  // the fixed row identity, not on "whatever is first-visible now", because a
+  // remeasure above the viewport shifts which row is first-visible at a fixed
+  // scrollTop. The change in that fixed row's offset is exactly how far the
+  // content under the viewport moved; we add it to `scrollTop` synchronously
+  // (useLayoutEffect → before paint) so the anchor row stays under the same
+  // pixel. The pinned-to-bottom path is left alone — the streaming /
+  // count-change effects already force it to the bottom, and compensating there
+  // would fight them.
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    const prev = anchorRef.current
+    // The anchor we remember for NEXT render is the current first-visible row.
+    const next = { index: range.firstVisibleIndex, offset: range.firstVisibleOffset }
+
+    if (!el || !range.virtualized) {
+      anchorRef.current = next
+      return
+    }
+    // Only compensate while the user is reading history. When pinned to bottom
+    // (and especially while streaming) the dedicated effects own scrollTop.
+    if (!userScrolledUp || programmaticScrollRef.current || !prev) {
+      anchorRef.current = next
+      return
+    }
+
+    // KEY POINT: a re-measure of a row ABOVE the viewport shifts which row is
+    // first-visible *at a fixed scrollTop* (more content above the same pixel),
+    // so we must NOT compare first-visible-row to first-visible-row. Instead we
+    // re-read the offset of the SAME anchor row we recorded last render (its
+    // index is stable — the row did not move in the array). If that fixed row's
+    // content-space top edge moved, the delta is exactly how far the content
+    // under the viewport shifted, and we add it back to scrollTop so the anchor
+    // stays under the same pixel. WKWebView (the Tauri desktop's engine) has no
+    // native scroll anchoring, so without this the content visibly jumps.
+    const prevAnchorNowOffset = range.offsetAt(prev.index)
+    const delta = prevAnchorNowOffset - prev.offset
+    if (delta === 0) {
+      anchorRef.current = next
+      return
+    }
+    const target = el.scrollTop + delta
+    // Record the value we're about to write so the synthetic scroll event the
+    // assignment fires is recognised and ignored (feedback-loop guard).
+    expectedScrollTopRef.current = target
+    el.scrollTop = target
+    // Keep `scrollTop` state consistent with the DOM so the next windowing
+    // recompute starts from the compensated position rather than re-deriving the
+    // pre-shift one (which would re-introduce the jump on the following render).
+    // The settling render restores the original anchor row as first-visible at
+    // its new offset, so store THAT as the anchor for the next round.
+    anchorRef.current = { index: prev.index, offset: prevAnchorNowOffset }
+    setScrollTop(target)
+  }, [range, userScrolledUp])
 
   // #4652: previously a separate streaming-end effect reset
   // `userScrolledUp` to false — that snapped the user back to the

--- a/packages/dashboard/src/components/ChatView.virtualization.test.tsx
+++ b/packages/dashboard/src/components/ChatView.virtualization.test.tsx
@@ -233,6 +233,130 @@ describe('ChatView virtualization (#5561)', () => {
     }
   })
 
+  it('compensates scrollTop when an above-viewport row re-measures taller (WKWebView has no native scroll anchoring)', async () => {
+    // jsdom has no ResizeObserver, so install a controllable one: it records the
+    // (element, callback) pairs and lets the test fire a re-measure for a chosen
+    // row — the production path by which a tool bubble / streaming markdown grows
+    // an already-mounted row's height. We give each row a per-id height (the
+    // anchor row keeps its estimate; an above-viewport row in the overscan band
+    // corrects taller), then fire its observer and assert the layout effect added
+    // exactly the height delta back into scrollTop so the anchor stays pinned.
+    type Entry = { el: HTMLElement; cb: ResizeObserverCallback }
+    const observers: Entry[] = []
+    class MockRO {
+      cb: ResizeObserverCallback
+      constructor(cb: ResizeObserverCallback) { this.cb = cb }
+      observe(el: Element) { observers.push({ el: el as HTMLElement, cb: this.cb }) }
+      unobserve() {}
+      disconnect() {}
+    }
+    const origRO = globalThis.ResizeObserver
+    ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      MockRO as unknown as typeof ResizeObserver
+
+    // Per-row height store, keyed by the `data-row-key` MeasuredRow stamps on its
+    // element. Defaults to ROW_HEIGHT; we mutate a single row to grow it.
+    const rowHeights = new Map<string, number>()
+    const offsetHeight = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (this: HTMLElement) {
+      const key = this.getAttribute('data-row-key')
+      if (key && rowHeights.has(key)) return rowHeights.get(key) as number
+      return ROW_HEIGHT
+    })
+    const clientHeight = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(VIEWPORT)
+    const scrollHeight = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(200 * ROW_HEIGHT)
+    try {
+      render(<ChatView messages={makeMessages(200)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+
+      // Land mid-history scrolled up. Anchor ≈ row 50 (scrollTop / ROW_SLOT).
+      setScrollTop(container, 50 * ROW_SLOT)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+      const scrollTopBefore = container.scrollTop
+
+      // Pick a mounted row ABOVE the anchor (in the overscan band) and grow it by
+      // +60px, then fire its ResizeObserver — the real reflow path.
+      const aboveRow = observers.find((o) => {
+        const key = o.el.getAttribute('data-row-key')
+        if (!key) return false
+        const idx = Number(key.replace('msg-msg-', '').replace('msg-', ''))
+        return idx < 50 && idx >= 44 // overscan band above the anchor
+      })
+      expect(aboveRow).toBeTruthy()
+      const grownKey = aboveRow!.el.getAttribute('data-row-key') as string
+      rowHeights.set(grownKey, ROW_HEIGHT + 60)
+      await act(async () => {
+        aboveRow!.cb([], aboveRow as unknown as ResizeObserver)
+      })
+
+      // Compensation added the +60 above-viewport delta back into scrollTop so the
+      // anchor row stays under the same pixel (WKWebView would have left it at
+      // scrollTopBefore and jumped the content up by 60px).
+      expect(container.scrollTop).toBe(scrollTopBefore + 60)
+      // Still scrolled up — compensation must not flip us to pinned/bottom.
+      expect(screen.queryByTestId('scroll-to-bottom')).toBeInTheDocument()
+    } finally {
+      offsetHeight.mockRestore()
+      clientHeight.mockRestore()
+      scrollHeight.mockRestore()
+      ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = origRO
+    }
+  })
+
+  it('does not compensate (or jump) while pinned to the bottom', async () => {
+    // At the bottom the dedicated streaming/count-change effects own scrollTop;
+    // the compensation effect must stay out of their way even when an
+    // above-viewport row re-measures.
+    type Entry = { el: HTMLElement; cb: ResizeObserverCallback }
+    const observers: Entry[] = []
+    class MockRO {
+      cb: ResizeObserverCallback
+      constructor(cb: ResizeObserverCallback) { this.cb = cb }
+      observe(el: Element) { observers.push({ el: el as HTMLElement, cb: this.cb }) }
+      unobserve() {}
+      disconnect() {}
+    }
+    const origRO = globalThis.ResizeObserver
+    ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      MockRO as unknown as typeof ResizeObserver
+    const rowHeights = new Map<string, number>()
+    const offsetHeight = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (this: HTMLElement) {
+      const key = this.getAttribute('data-row-key')
+      if (key && rowHeights.has(key)) return rowHeights.get(key) as number
+      return ROW_HEIGHT
+    })
+    const clientHeight = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(VIEWPORT)
+    const scrollHeight = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(200 * ROW_HEIGHT)
+    try {
+      render(<ChatView messages={makeMessages(200)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+      // Pin to the bottom.
+      setScrollTop(container, 200 * ROW_HEIGHT - VIEWPORT)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+      const before = container.scrollTop
+      const anyRow = observers.find((o) => o.el.getAttribute('data-row-key'))
+      if (anyRow) {
+        const key = anyRow.el.getAttribute('data-row-key') as string
+        rowHeights.set(key, ROW_HEIGHT + 60)
+        await act(async () => {
+          anyRow.cb([], anyRow as unknown as ResizeObserver)
+        })
+      }
+      // Compensation stayed out of the pinned path — no jump from the layout effect.
+      expect(container.scrollTop).toBe(before)
+    } finally {
+      offsetHeight.mockRestore()
+      clientHeight.mockRestore()
+      scrollHeight.mockRestore()
+      ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = origRO
+    }
+  })
+
   it('resets expand state when ChatView remounts (registry is per-instance)', async () => {
     // Sanity guard: the registry is scoped to a ChatView instance, so a fresh
     // ChatView starts every bubble collapsed. (A new session unmounts/remounts.)

--- a/packages/dashboard/src/components/ChatView.virtualization.test.tsx
+++ b/packages/dashboard/src/components/ChatView.virtualization.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * ChatView virtualization — #5561
+ *
+ * Pins the behaviours the issue requires of the windowed dashboard ChatView:
+ *
+ *  1. Above the threshold only the rows intersecting the viewport (plus
+ *     overscan) mount — the entire message array is no longer mapped to the DOM.
+ *  2. Below the threshold every row renders (no behaviour change for short
+ *     histories).
+ *  3. Bottom-pinning: a new message appended while the user is at the bottom
+ *     scrolls the container to the new bottom.
+ *  4. Expand state of a tool bubble survives the row scrolling out of the window
+ *     and back (id-keyed registry, mirroring mobile #5534).
+ *
+ * jsdom reports 0 for layout geometry, so we stub `offsetHeight` (per-row
+ * height), and the container's `clientHeight` / `scrollHeight` / `scrollTop`.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { useState } from 'react'
+import { ChatView, type ChatViewMessage } from './ChatView'
+import { ToolBubble } from './ToolBubble'
+
+afterEach(cleanup)
+
+const ROW_HEIGHT = 80
+const VIEWPORT = 400
+// ChatView folds the `.chat-messages` gap (12px) into each row's windowing
+// height, so a windowed-out row reserves ROW_HEIGHT + ROW_GAP of spacer.
+const ROW_GAP = 12
+const ROW_SLOT = ROW_HEIGHT + ROW_GAP
+
+/**
+ * Stub layout geometry. Every element reports ROW_HEIGHT as offsetHeight (rows
+ * are uniform for the test); the scroll container reports a fixed viewport and a
+ * scrollHeight derived from the row count, with a settable scrollTop.
+ */
+function installLayoutStubs(rowCount: number) {
+  const offsetHeight = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(ROW_HEIGHT)
+  const clientHeight = vi
+    .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+    .mockReturnValue(VIEWPORT)
+  const scrollHeight = vi
+    .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+    .mockReturnValue(rowCount * ROW_HEIGHT)
+  return () => {
+    offsetHeight.mockRestore()
+    clientHeight.mockRestore()
+    scrollHeight.mockRestore()
+  }
+}
+
+function setScrollTop(el: HTMLElement, value: number) {
+  Object.defineProperty(el, 'scrollTop', { value, writable: true, configurable: true })
+}
+
+function makeMessages(count: number): ChatViewMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `msg-${i}`,
+    type: 'response' as const,
+    content: `Message ${i}`,
+    timestamp: 1000 + i,
+  }))
+}
+
+describe('ChatView virtualization (#5561)', () => {
+  it('renders every row below the threshold (no behaviour change)', () => {
+    const restore = installLayoutStubs(10)
+    try {
+      render(<ChatView messages={makeMessages(10)} isStreaming={false} />)
+      // All 10 rows present; no spacers.
+      expect(screen.getAllByTestId(/^msg-msg-\d+$/).length).toBe(10)
+      expect(screen.queryByTestId('chat-window-top-spacer')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('chat-window-bottom-spacer')).not.toBeInTheDocument()
+    } finally {
+      restore()
+    }
+  })
+
+  it('renders only the visible window above the threshold', async () => {
+    const restore = installLayoutStubs(200)
+    try {
+      render(<ChatView messages={makeMessages(200)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+      // Scroll to the middle and let the windowing recompute.
+      setScrollTop(container, 4000)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      const rendered = screen.getAllByTestId(/^msg-msg-\d+$/)
+      // Far fewer than 200 rows are in the DOM.
+      expect(rendered.length).toBeLessThan(40)
+      expect(rendered.length).toBeGreaterThan(0)
+      // Spacers reserve the windowed-out rows.
+      expect(screen.getByTestId('chat-window-top-spacer')).toBeInTheDocument()
+      expect(screen.getByTestId('chat-window-bottom-spacer')).toBeInTheDocument()
+      // A row near the scroll offset (≈ row 50) is present; row 0 is windowed out.
+      expect(screen.getByTestId('msg-msg-50')).toBeInTheDocument()
+      expect(screen.queryByTestId('msg-msg-0')).not.toBeInTheDocument()
+    } finally {
+      restore()
+    }
+  })
+
+  it('keeps the top spacer height equal to the windowed-out leading rows', async () => {
+    const restore = installLayoutStubs(200)
+    try {
+      render(<ChatView messages={makeMessages(200)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+      setScrollTop(container, 8000)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      const topSpacer = screen.getByTestId('chat-window-top-spacer')
+      const bottomSpacer = screen.getByTestId('chat-window-bottom-spacer')
+      const topPx = parseInt(topSpacer.style.height, 10)
+      const bottomPx = parseInt(bottomSpacer.style.height, 10)
+      const renderedCount = screen.getAllByTestId(/^msg-msg-\d+$/).length
+      // Reserved + rendered slots ≈ total list slots (row + gap each).
+      expect(topPx + renderedCount * ROW_SLOT + bottomPx).toBe(200 * ROW_SLOT)
+      // Top spacer is an exact multiple of the windowed-out leading row slots.
+      expect(topPx % ROW_SLOT).toBe(0)
+      // We scrolled down, so there is meaningful leading reserved space.
+      expect(topPx).toBeGreaterThan(0)
+    } finally {
+      restore()
+    }
+  })
+
+  it('pins to the bottom when a message is appended while at the bottom', async () => {
+    const restore = installLayoutStubs(60)
+    try {
+      const { rerender } = render(<ChatView messages={makeMessages(60)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+      // Make scrollTop settable and place the user at the bottom.
+      setScrollTop(container, 60 * ROW_HEIGHT - VIEWPORT)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      // scrollHeight grows when a message is appended.
+      const grown = installLayoutStubs(61)
+      try {
+        rerender(<ChatView messages={makeMessages(61)} isStreaming={false} />)
+        await act(async () => {
+          await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null))))
+        })
+        // The count-change auto-scroll snapped the container to the new bottom.
+        expect(container.scrollTop).toBe(61 * ROW_HEIGHT)
+      } finally {
+        grown()
+      }
+    } finally {
+      restore()
+    }
+  })
+
+  it('does not yank a scrolled-up reader to the bottom on append', async () => {
+    const restore = installLayoutStubs(60)
+    try {
+      const { rerender } = render(<ChatView messages={makeMessages(60)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+      // User scrolled up to the top.
+      setScrollTop(container, 0)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+      const grown = installLayoutStubs(61)
+      try {
+        rerender(<ChatView messages={makeMessages(61)} isStreaming={false} />)
+        await act(async () => {
+          await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null))))
+        })
+        // Reading position preserved — the new message did not snap us down.
+        expect(container.scrollTop).toBe(0)
+      } finally {
+        grown()
+      }
+    } finally {
+      restore()
+    }
+  })
+
+  it('preserves tool-bubble expand state across a scroll-out / scroll-in', async () => {
+    const restore = installLayoutStubs(200)
+    try {
+      // A tool bubble lives near the top (row 5). renderMessage surfaces it as
+      // a real ToolBubble (the production path) so its expand state is governed
+      // by the ChatView-held registry.
+      const messages: ChatViewMessage[] = makeMessages(200)
+      const renderMessage = (m: ChatViewMessage) =>
+        m.id === 'msg-5' ? (
+          <ToolBubble toolName="Bash" toolUseId="tool-5" input="ls -la" result="output" />
+        ) : null
+
+      render(
+        <ChatView messages={messages} isStreaming={false} renderMessage={renderMessage} />,
+      )
+      const container = screen.getByTestId('chat-messages')
+
+      // ChatView scrolls to the bottom on mount; scroll back to the top so the
+      // row-5 bubble is inside the window.
+      setScrollTop(container, 0)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+
+      // The bubble is collapsed by default — expand it.
+      const bubble = screen.getByTestId('tool-bubble-tool-5')
+      expect(bubble).not.toHaveClass('expanded')
+      await act(async () => {
+        fireEvent.click(bubble)
+      })
+      expect(screen.getByTestId('tool-bubble-tool-5')).toHaveClass('expanded')
+
+      // Scroll far down so the bubble's row windows out and unmounts.
+      setScrollTop(container, 12000)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      expect(screen.queryByTestId('tool-bubble-tool-5')).not.toBeInTheDocument()
+
+      // Scroll back to the top — the bubble remounts and must re-read its
+      // expanded flag from the registry (id-keyed, mirror of mobile #5534).
+      setScrollTop(container, 0)
+      await act(async () => {
+        fireEvent.scroll(container)
+      })
+      const remounted = screen.getByTestId('tool-bubble-tool-5')
+      expect(remounted).toHaveClass('expanded')
+    } finally {
+      restore()
+    }
+  })
+
+  it('resets expand state when ChatView remounts (registry is per-instance)', async () => {
+    // Sanity guard: the registry is scoped to a ChatView instance, so a fresh
+    // ChatView starts every bubble collapsed. (A new session unmounts/remounts.)
+    const restore = installLayoutStubs(10)
+    try {
+      function Harness() {
+        const [key, setKey] = useState(0)
+        return (
+          <>
+            <button onClick={() => setKey((k) => k + 1)}>remount</button>
+            <ChatView
+              key={key}
+              messages={makeMessages(10)}
+              isStreaming={false}
+              renderMessage={(m) =>
+                m.id === 'msg-2' ? (
+                  <ToolBubble toolName="Bash" toolUseId="tool-2" input="x" result="y" />
+                ) : null
+              }
+            />
+          </>
+        )
+      }
+      render(<Harness />)
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('tool-bubble-tool-2'))
+      })
+      expect(screen.getByTestId('tool-bubble-tool-2')).toHaveClass('expanded')
+      await act(async () => {
+        fireEvent.click(screen.getByText('remount'))
+      })
+      expect(screen.getByTestId('tool-bubble-tool-2')).not.toHaveClass('expanded')
+    } finally {
+      restore()
+    }
+  })
+})

--- a/packages/dashboard/src/components/ChatView.virtualization.test.tsx
+++ b/packages/dashboard/src/components/ChatView.virtualization.test.tsx
@@ -25,10 +25,17 @@ afterEach(cleanup)
 
 const ROW_HEIGHT = 80
 const VIEWPORT = 400
-// ChatView folds the `.chat-messages` gap (12px) into each row's windowing
-// height, so a windowed-out row reserves ROW_HEIGHT + ROW_GAP of spacer.
+// ChatView folds the `.chat-messages` gap into each row's windowing height. In
+// jsdom getComputedStyle().rowGap is unavailable, so ChatView falls back to the
+// CHAT_MESSAGES_ROW_GAP constant (12px) — that is the gap the windowing math
+// uses here. A flex column of N rows is `N*ROW_HEIGHT + (N-1)*ROW_GAP` tall: the
+// inter-row gap renders N-1 times, NOT N. The spacers reserve the skipped rows'
+// heights minus one boundary gap each (the spacer↔row seam gap is rendered by
+// the DOM), so windowed scrollHeight matches a non-windowed render exactly.
 const ROW_GAP = 12
 const ROW_SLOT = ROW_HEIGHT + ROW_GAP
+// Total height of an un-windowed flex column of `n` uniform rows.
+const unwindowedHeight = (n: number) => n * ROW_HEIGHT + (n - 1) * ROW_GAP
 
 /**
  * Stub layout geometry. Every element reports ROW_HEIGHT as offsetHeight (rows
@@ -116,10 +123,18 @@ describe('ChatView virtualization (#5561)', () => {
       const topPx = parseInt(topSpacer.style.height, 10)
       const bottomPx = parseInt(bottomSpacer.style.height, 10)
       const renderedCount = screen.getAllByTestId(/^msg-msg-\d+$/).length
-      // Reserved + rendered slots ≈ total list slots (row + gap each).
-      expect(topPx + renderedCount * ROW_SLOT + bottomPx).toBe(200 * ROW_SLOT)
-      // Top spacer is an exact multiple of the windowed-out leading row slots.
-      expect(topPx % ROW_SLOT).toBe(0)
+      // Total windowed scrollHeight === a non-windowed render of all 200 rows.
+      // Children: [topSpacer] r[s]…r[e-1] [bottomSpacer], with the column gap
+      // rendered between every adjacent pair — including the two spacer↔row
+      // seams. The visible block of `renderedCount` rows is itself a flex column
+      // (renderedCount-1 internal gaps); the two boundary gaps wrap it.
+      const visibleBlock = renderedCount * ROW_HEIGHT + (renderedCount - 1) * ROW_GAP
+      const windowedTotal = topPx + ROW_GAP + visibleBlock + ROW_GAP + bottomPx
+      expect(windowedTotal).toBe(unwindowedHeight(200))
+      // Top spacer reserves the leading rows minus one boundary gap, i.e.
+      // startIndex*ROW_HEIGHT + (startIndex-1)*ROW_GAP === startIndex*ROW_SLOT −
+      // ROW_GAP. So (topPx + ROW_GAP) is an exact multiple of ROW_SLOT.
+      expect((topPx + ROW_GAP) % ROW_SLOT).toBe(0)
       // We scrolled down, so there is meaningful leading reserved space.
       expect(topPx).toBeGreaterThan(0)
     } finally {

--- a/packages/dashboard/src/components/MeasuredRow.tsx
+++ b/packages/dashboard/src/components/MeasuredRow.tsx
@@ -1,0 +1,60 @@
+/**
+ * MessageRowShell — the outer `.msg-row` container for one ChatView row, with
+ * height measurement wired in for the windowing hook (#5561).
+ *
+ * This IS the flex child inside `.chat-messages` (it carries the `rowClass` and
+ * `data-testid` the rows used before #5561). It attaches a `ResizeObserver` to
+ * itself and reports its `offsetHeight` to `measureRow(rowKey, height)` so the
+ * windowing hook (`useWindowedRange`) can compute spacers and the visible range
+ * for variable-height content. Putting the observer on the layout element (not a
+ * nested wrapper) keeps the `.chat-messages` flex layout byte-identical to the
+ * pre-#5561 DOM while adding measurement.
+ *
+ * The shell is memoized on its props, and ChatView hands it a memoized child
+ * (`DefaultMessageRow` or the renderMessage node), so a streaming delta that
+ * only changes the tail row does not re-run the observer wiring for untouched
+ * rows.
+ */
+import { memo, useCallback, useEffect, useRef, type ReactNode } from 'react'
+
+export interface MessageRowShellProps {
+  /** Stable per-row key (message id / group key) — used as the height-cache key. */
+  rowKey: string
+  /** Reports this row's measured pixel height to the windowing hook. */
+  measureRow: (key: string, height: number) => void
+  /** Flex row class (`msg-row`, `msg-row-user`, …) or '' for icon-less rows. */
+  className: string
+  /** Test id for the row container (kept identical to the pre-#5561 `msg-<id>`). */
+  testId: string
+  children: ReactNode
+}
+
+function MessageRowShellImpl({ rowKey, measureRow, className, testId, children }: MessageRowShellProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  const report = useCallback(() => {
+    const el = ref.current
+    if (el) measureRow(rowKey, el.offsetHeight)
+  }, [rowKey, measureRow])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    // Measure immediately on mount (also covers the no-ResizeObserver test env),
+    // then observe for reflows: streaming markdown growth and tool-bubble
+    // expand/collapse both change row height and must update the cache.
+    report()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(() => report())
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [report])
+
+  return (
+    <div ref={ref} className={className || undefined} data-testid={testId} data-row-key={rowKey}>
+      {children}
+    </div>
+  )
+}
+
+export const MessageRowShell = memo(MessageRowShellImpl)

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -32,6 +32,7 @@ import {
 import type { ChildAgentEvent, ToolResultImage } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
 import { ChildAgentEventList } from './ChildAgentEventList'
+import { useInitialExpanded } from './chatExpandRegistry'
 
 export interface ToolBubbleProps {
   toolName: string
@@ -113,7 +114,19 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   // #4313 — tail bubbles mount expanded so the singleton trailing-tool
   // case matches the #4309 tail-group behavior. Initial-state only via
   // the lazy `useState` initializer.
-  const [expanded, setExpanded] = useState(isTail)
+  //
+  // #5561 — under ChatView virtualization an off-screen bubble unmounts and
+  // remounts as the user scrolls. The id-keyed expand registry (mobile #5534
+  // parity) persists the toggle OUTSIDE this row: `useInitialExpanded` seeds
+  // from the registry on mount (falling back to `isTail` the first time the
+  // bubble is ever seen) so a recycled bubble reopens to the user's last
+  // choice instead of snapping shut. Outside a ChatExpandContext provider the
+  // registry is a no-op and behaviour is unchanged from pre-#5561.
+  const { initial: initialExpanded, persist: persistExpanded } = useInitialExpanded(
+    `tool:${toolUseId}`,
+    isTail,
+  )
+  const [expanded, setExpanded] = useState(initialExpanded)
   // #4317: a tool that resolved with images-only (no text) still leaves
   // `result === undefined`. Treat that as resolved so the pulse marker
   // hides — same shape as ToolGroup's `hasResult` and
@@ -186,7 +199,13 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
     return { text: inputPartial, parsed: false }
   }, [expanded, hasResult, inputPartial, suppressRawInput])
 
-  const toggle = () => setExpanded(prev => !prev)
+  const toggle = () => setExpanded(prev => {
+    const next = !prev
+    // #5561 — write through to the id-keyed registry so the choice survives a
+    // window-recycle remount.
+    persistExpanded(next)
+    return next
+  })
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -8,7 +8,7 @@
  * Default state: collapsed when the run is done, expanded while it is
  * still active so users see progress as tools fire.
  */
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useContext } from 'react'
 import type { ChatMessage } from '@chroxy/store-core'
 import {
   summarizeToolCounts,
@@ -18,6 +18,7 @@ import {
   getInputSummary,
 } from '@chroxy/store-core'
 import { ChildAgentEventList } from './ChildAgentEventList'
+import { ChatExpandContext, useInitialExpanded } from './chatExpandRegistry'
 
 export interface ToolGroupProps {
   messages: ChatMessage[]
@@ -213,12 +214,26 @@ function ToolGroupEntry({
 }
 
 export function ToolGroup({ messages, isActive, isTail = false }: ToolGroupProps) {
+  // #5561 — id-keyed expand registry (mobile #5534 parity). The group is keyed
+  // by its first message id; under ChatView virtualization the whole group can
+  // unmount when scrolled out, so the group-level toggle AND each entry's
+  // toggle persist here and re-seed on remount. Outside a provider the registry
+  // is a no-op (pre-#5561 behaviour).
+  const groupKey = `group:${messages[0]?.id ?? 'empty'}`
+  const expandRegistry = useContext(ChatExpandContext)
   // Auto-collapse on completion: expand while active, collapse when the
   // run ends. Subsequent expand state lives in component state so a user
   // who toggled stays toggled until the run lifecycle flips again.
   // #4305 — tail groups (no follow-up summary) start expanded and skip
   // the on-completion collapse, so trailing tools remain visible.
-  const [expanded, setExpanded] = useState(isActive || isTail)
+  // #5561 — seed from the registry first so a recycled group reopens to the
+  // user's last choice; fall back to the lifecycle default the first time the
+  // group is ever seen.
+  const { initial: initialExpanded, persist: persistGroupExpanded } = useInitialExpanded(
+    groupKey,
+    isActive || isTail,
+  )
+  const [expanded, setExpanded] = useState(initialExpanded)
   const wasActiveRef = useRef(isActive)
   // Latch isTail while the group is still active so the on-completion
   // collapse path reads the *pre-flip* tail status. #4314 — if a single
@@ -233,23 +248,36 @@ export function ToolGroup({ messages, isActive, isTail = false }: ToolGroupProps
   const wasTailRef = useRef(isTail)
   if (isActive) wasTailRef.current = isTail
   useEffect(() => {
+    // #5561 — mirror lifecycle-driven group expand flips into the registry so a
+    // remount during the same run re-seeds the correct (current) state, not the
+    // first-seen default.
     if (wasActiveRef.current && !isActive) {
-      if (!wasTailRef.current) setExpanded(false)
+      if (!wasTailRef.current) { setExpanded(false); persistGroupExpanded(false) }
     }
-    if (!wasActiveRef.current && isActive) setExpanded(true)
+    if (!wasActiveRef.current && isActive) { setExpanded(true); persistGroupExpanded(true) }
     wasActiveRef.current = isActive
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- persistGroupExpanded is stable; isActive is the intended trigger (matches the pre-#5561 dep list)
   }, [isActive])
 
   // #4279: per-entry expansion state lives here so multiple entries can be
   // open simultaneously and the parent group's expand/collapse logic doesn't
   // touch entry state. We track open entries in a Set keyed by message id —
   // toggling an entry flips its membership.
-  const [expandedEntryIds, setExpandedEntryIds] = useState<Set<string>>(() => new Set())
+  // #5561 — seed the open-entry set from the registry on mount so a recycled
+  // group reopens the same entries the user had open. Entry flags are
+  // namespaced `entry:<id>` so they never collide with a sibling row's own id.
+  const [expandedEntryIds, setExpandedEntryIds] = useState<Set<string>>(() => {
+    const seeded = new Set<string>()
+    for (const m of messages) {
+      if (expandRegistry.get(`entry:${m.id}`)) seeded.add(m.id)
+    }
+    return seeded
+  })
   const toggleEntry = (id: string) => {
     setExpandedEntryIds((prev) => {
       const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
+      if (next.has(id)) { next.delete(id); expandRegistry.set(`entry:${id}`, false) }
+      else { next.add(id); expandRegistry.set(`entry:${id}`, true) }
       return next
     })
   }
@@ -261,7 +289,11 @@ export function ToolGroup({ messages, isActive, isTail = false }: ToolGroupProps
     : `${toolCount} tool${toolCount !== 1 ? 's' : ''} used`
   const summary = breakdown ? `${baseSummary} — ${breakdown}` : baseSummary
 
-  const toggle = () => setExpanded((prev) => !prev)
+  const toggle = () => setExpanded((prev) => {
+    const next = !prev
+    persistGroupExpanded(next)
+    return next
+  })
 
   // #4282: the outer container is a plain non-interactive <div>. The
   // group's expand/collapse toggle lives on a real <button> header, and

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -256,8 +256,11 @@ export function ToolGroup({ messages, isActive, isTail = false }: ToolGroupProps
     }
     if (!wasActiveRef.current && isActive) { setExpanded(true); persistGroupExpanded(true) }
     wasActiveRef.current = isActive
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- persistGroupExpanded is stable; isActive is the intended trigger (matches the pre-#5561 dep list)
-  }, [isActive])
+    // persistGroupExpanded is now genuinely stable (memoized in
+    // useInitialExpanded on the registry ref + key), so it can be listed
+    // honestly — its identity never changes for this group, so adding it does
+    // not re-fire the effect. isActive remains the real trigger.
+  }, [isActive, persistGroupExpanded])
 
   // #4279: per-entry expansion state lives here so multiple entries can be
   // open simultaneously and the parent group's expand/collapse logic doesn't

--- a/packages/dashboard/src/components/chatExpandRegistry.ts
+++ b/packages/dashboard/src/components/chatExpandRegistry.ts
@@ -32,7 +32,7 @@
  *   a different surface) the context falls back to a no-op registry, so the
  *   component keeps its pre-#5561 row-local behaviour unchanged.
  */
-import { createContext, useContext } from 'react'
+import { createContext, useCallback, useContext } from 'react'
 
 export interface ChatExpandRegistry {
   /**
@@ -68,9 +68,19 @@ export function useInitialExpanded(key: string, fallback: boolean): {
 } {
   const registry = useContext(ChatExpandContext)
   const stored = registry.get(key)
+  // Memoize `persist` on its only inputs (the registry — a stable map ref held
+  // in a ChatView `useRef` — and the row key) so consumers can list it in effect
+  // dep arrays honestly. ChatView's registry identity is stable for the
+  // component's lifetime, so this returns the SAME function across renders for a
+  // given key; without it the closure was fresh every render and ToolGroup had
+  // to silence react-hooks/exhaustive-deps with a (misleading) "stable" comment.
+  const persist = useCallback(
+    (expanded: boolean) => registry.set(key, expanded),
+    [registry, key],
+  )
   return {
     initial: stored ?? fallback,
-    persist: (expanded: boolean) => registry.set(key, expanded),
+    persist,
   }
 }
 

--- a/packages/dashboard/src/components/chatExpandRegistry.ts
+++ b/packages/dashboard/src/components/chatExpandRegistry.ts
@@ -1,0 +1,77 @@
+/**
+ * chatExpandRegistry — id-keyed expand-state registry for the virtualized
+ * ChatView (#5561, mirroring the mobile #5534 pattern).
+ *
+ * Why this exists
+ * ---------------
+ * Before #5561 the dashboard ChatView mounted every message row at once, so a
+ * tool bubble / tool group's local `useState(expanded)` survived for the whole
+ * session — scrolling never unmounted it. #5561 virtualizes the list: rows that
+ * scroll out of the window unmount and remount when scrolled back. A row-local
+ * `useState` resets to its initial value on every remount, so a user who
+ * expanded a Bash result, scrolled past it, and scrolled back would find it
+ * snapped shut.
+ *
+ * The mobile app (#5534) solved the identical problem by lifting the expand
+ * flags OUT of the recyclable row into a parent-held registry keyed by message
+ * id, threaded down as `getInitialExpanded` / `onExpandedChange`. This module is
+ * the dashboard equivalent: a tiny registry exposed through React context so the
+ * `renderMessage`-produced `ToolBubble` / `ToolGroup` rows (defined in App.tsx,
+ * not ChatView) can read and write it without ChatView having to grow new props
+ * on every renderer.
+ *
+ * Design notes
+ * ------------
+ * - The registry lives in a `useRef` inside ChatView (one per ChatView
+ *   instance) so writes never trigger a ChatView re-render — a recycled row
+ *   re-reads it on its own mount, exactly like the mobile `expandedIdsRef`.
+ * - Keys are message ids for single bubbles and the synthetic group key for
+ *   tool groups; per-entry expand flags inside a group are namespaced with an
+ *   `entry:` prefix so they never collide with a sibling row's id.
+ * - Outside a provider (e.g. a ToolBubble rendered in a non-virtualized test or
+ *   a different surface) the context falls back to a no-op registry, so the
+ *   component keeps its pre-#5561 row-local behaviour unchanged.
+ */
+import { createContext, useContext } from 'react'
+
+export interface ChatExpandRegistry {
+  /**
+   * Read the persisted expand flag for `key`. Returns `undefined` when the
+   * registry has never seen the key — callers treat that as "use the
+   * component's own default" (e.g. `isTail`), so first-mount behaviour is
+   * unchanged.
+   */
+  get(key: string): boolean | undefined
+  /** Persist `expanded` for `key`. Cleared keys are deleted to keep the map small. */
+  set(key: string, expanded: boolean): void
+}
+
+/** A registry that remembers nothing — the off-context fallback. */
+const NOOP_REGISTRY: ChatExpandRegistry = {
+  get: () => undefined,
+  set: () => {},
+}
+
+export const ChatExpandContext = createContext<ChatExpandRegistry>(NOOP_REGISTRY)
+
+/**
+ * Resolve the persisted expand state for a row, falling back to the
+ * component's own default when the registry has no opinion yet.
+ *
+ * `fallback` is the pre-registry initial value (e.g. `isTail` for a trailing
+ * bubble) so a row that has never been toggled mounts exactly as it did before
+ * #5561.
+ */
+export function useInitialExpanded(key: string, fallback: boolean): {
+  initial: boolean
+  persist: (expanded: boolean) => void
+} {
+  const registry = useContext(ChatExpandContext)
+  const stored = registry.get(key)
+  return {
+    initial: stored ?? fallback,
+    persist: (expanded: boolean) => registry.set(key, expanded),
+  }
+}
+
+export { NOOP_REGISTRY }

--- a/packages/dashboard/src/components/useWindowedRange.test.tsx
+++ b/packages/dashboard/src/components/useWindowedRange.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * useWindowedRange — windowing math (#5561)
+ *
+ * Pins the dependency-free variable-height windowing the dashboard ChatView
+ * uses to stop mapping the entire message array to the DOM on long sessions:
+ *
+ *  1. Below the threshold the hook is a pass-through (full range, no spacers,
+ *     not virtualized) — short conversations render exactly as before.
+ *  2. Above the threshold only the rows intersecting the viewport (plus
+ *     overscan) are in [startIndex, endIndex); the rest become top/bottom
+ *     spacer height so scroll geometry is preserved.
+ *  3. Measured row heights feed the range so variable-height rows window
+ *     correctly.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useWindowedRange } from './useWindowedRange'
+
+const keyAt = (i: number) => `row-${i}`
+
+describe('useWindowedRange (#5561)', () => {
+  it('renders the full list with no spacers below the threshold', () => {
+    const { result } = renderHook(() =>
+      useWindowedRange({
+        itemCount: 10,
+        scrollTop: 0,
+        viewportHeight: 500,
+        threshold: 40,
+        keyAt,
+      }),
+    )
+    expect(result.current.virtualized).toBe(false)
+    expect(result.current.startIndex).toBe(0)
+    expect(result.current.endIndex).toBe(10)
+    expect(result.current.topSpacer).toBe(0)
+    expect(result.current.bottomSpacer).toBe(0)
+  })
+
+  it('windows to the visible range (plus overscan) above the threshold', () => {
+    // 200 rows × 80px estimated = 16000px tall. Viewport 400px scrolled to
+    // 4000px shows rows ~50..54; with overscan 2 the window is ~48..57.
+    const { result } = renderHook(() =>
+      useWindowedRange({
+        itemCount: 200,
+        scrollTop: 4000,
+        viewportHeight: 400,
+        threshold: 40,
+        overscan: 2,
+        estimatedRowHeight: 80,
+        keyAt,
+      }),
+    )
+    expect(result.current.virtualized).toBe(true)
+    // Only a small slice of the 200 rows is rendered.
+    const rendered = result.current.endIndex - result.current.startIndex
+    expect(rendered).toBeLessThan(20)
+    // First visible row (scrollTop 4000 / 80 = 50) minus overscan 2.
+    expect(result.current.startIndex).toBe(48)
+    // Spacers reserve the height of the windowed-out rows.
+    expect(result.current.topSpacer).toBe(48 * 80)
+    expect(result.current.bottomSpacer).toBe((200 - result.current.endIndex) * 80)
+    // Total reserved + rendered estimate ≈ full list height.
+    const renderedEstimate = rendered * 80
+    expect(result.current.topSpacer + renderedEstimate + result.current.bottomSpacer).toBe(200 * 80)
+  })
+
+  it('starts at the top with a zero top spacer when not scrolled', () => {
+    const { result } = renderHook(() =>
+      useWindowedRange({
+        itemCount: 200,
+        scrollTop: 0,
+        viewportHeight: 400,
+        threshold: 40,
+        overscan: 2,
+        estimatedRowHeight: 80,
+        keyAt,
+      }),
+    )
+    expect(result.current.startIndex).toBe(0)
+    expect(result.current.topSpacer).toBe(0)
+    expect(result.current.bottomSpacer).toBeGreaterThan(0)
+  })
+
+  it('accounts for measured (variable) heights when computing the range', () => {
+    // Make the first 10 rows very tall (1000px each) so a 400px viewport at
+    // scrollTop 0 shows only the first row regardless of the 80px estimate.
+    const { result } = renderHook(() =>
+      useWindowedRange({
+        itemCount: 200,
+        scrollTop: 0,
+        viewportHeight: 400,
+        threshold: 40,
+        overscan: 0,
+        estimatedRowHeight: 80,
+        keyAt,
+      }),
+    )
+    act(() => {
+      for (let i = 0; i < 10; i++) result.current.measureRow(`row-${i}`, 1000)
+    })
+    // With 1000px rows, only row 0 intersects a 400px viewport.
+    expect(result.current.startIndex).toBe(0)
+    expect(result.current.endIndex).toBe(1)
+    // Bottom spacer reflects the measured tall rows + estimated tail.
+    expect(result.current.bottomSpacer).toBe(9 * 1000 + (200 - 10) * 80)
+  })
+})

--- a/packages/dashboard/src/components/useWindowedRange.test.tsx
+++ b/packages/dashboard/src/components/useWindowedRange.test.tsx
@@ -104,4 +104,82 @@ describe('useWindowedRange (#5561)', () => {
     // Bottom spacer reflects the measured tall rows + estimated tail.
     expect(result.current.bottomSpacer).toBe(9 * 1000 + (200 - 10) * 80)
   })
+
+  it('reports the first-visible anchor index and its content-space offset', () => {
+    // 200 rows × 80px, viewport 400px scrolled to 4000px: the first row whose
+    // bottom edge passes 4000 is row 50 (its top edge is exactly 50×80 = 4000).
+    const { result } = renderHook(() =>
+      useWindowedRange({
+        itemCount: 200,
+        scrollTop: 4000,
+        viewportHeight: 400,
+        threshold: 40,
+        overscan: 2,
+        estimatedRowHeight: 80,
+        keyAt,
+      }),
+    )
+    expect(result.current.firstVisibleIndex).toBe(50)
+    // The anchor's top edge in content space = cumulative height of rows 0..49.
+    expect(result.current.firstVisibleOffset).toBe(50 * 80)
+  })
+
+  it('shifts the anchor when an above-viewport row re-measures, and the +delta scrollTop restores it (WKWebView compensation loop)', () => {
+    // Scrolled-up reader: viewport sits over rows ~50+. A row ABOVE the anchor
+    // (row 10) corrects from its 80px estimate to 180px (+100px). Without moving
+    // scrollTop, the content above the fixed scrollTop now occupies 100px more,
+    // so the SAME pixel offset now intersects an EARLIER row — the anchor index
+    // drifts down. That drift is the WKWebView jump (no native scroll
+    // anchoring). ChatView corrects it by adding the +100 delta to scrollTop,
+    // which restores the original anchor row at its new (+100) offset.
+    let scrollTop = 4000
+    const { result, rerender } = renderHook(
+      (props: { scrollTop: number }) =>
+        useWindowedRange({
+          itemCount: 200,
+          scrollTop: props.scrollTop,
+          viewportHeight: 400,
+          threshold: 40,
+          overscan: 0,
+          estimatedRowHeight: 80,
+          keyAt,
+        }),
+      { initialProps: { scrollTop } },
+    )
+
+    expect(result.current.firstVisibleIndex).toBe(50)
+    expect(result.current.firstVisibleOffset).toBe(50 * 80)
+
+    act(() => {
+      result.current.measureRow('row-10', 180) // 80 → 180, +100px above the anchor
+    })
+
+    // At the unchanged scrollTop the anchor row index drifted earlier (the jump).
+    expect(result.current.firstVisibleIndex).toBeLessThan(50)
+    const drift = result.current.firstVisibleIndex
+
+    // Apply the compensation ChatView performs: bump scrollTop by exactly the
+    // above-viewport height delta (+100). The original anchor row 50 is restored,
+    // now sitting 100px lower in content space.
+    scrollTop = 4100
+    rerender({ scrollTop })
+    expect(result.current.firstVisibleIndex).toBe(50)
+    expect(result.current.firstVisibleOffset).toBe(50 * 80 + 100)
+    expect(drift).toBeLessThan(50) // the uncompensated drift was real
+  })
+
+  it('reports a zero-offset anchor below the threshold (no compensation needed)', () => {
+    const { result } = renderHook(() =>
+      useWindowedRange({
+        itemCount: 10,
+        scrollTop: 0,
+        viewportHeight: 500,
+        threshold: 40,
+        keyAt,
+      }),
+    )
+    expect(result.current.virtualized).toBe(false)
+    expect(result.current.firstVisibleIndex).toBe(0)
+    expect(result.current.firstVisibleOffset).toBe(0)
+  })
 })

--- a/packages/dashboard/src/components/useWindowedRange.ts
+++ b/packages/dashboard/src/components/useWindowedRange.ts
@@ -80,6 +80,30 @@ export interface WindowedRange {
   virtualized: boolean
   /** Record a measured row height. Stable identity. */
   measureRow: (key: string, height: number) => void
+  /**
+   * Index of the first row whose bottom edge is past the top of the viewport —
+   * i.e. the topmost row the user is actually looking at. Used as the scroll
+   * anchor for engine-independent scroll compensation (see ChatView).
+   */
+  firstVisibleIndex: number
+  /**
+   * Cumulative height (px) of every row strictly above `firstVisibleIndex` —
+   * the content-space offset of that row's top edge. When a height-cache
+   * correction above the viewport changes this value, the delta is the amount
+   * the viewport content shifted and must be added back to `scrollTop` so the
+   * anchor row stays put (WKWebView has no native scroll anchoring).
+   */
+  firstVisibleOffset: number
+  /**
+   * Content-space top edge (px) of the row at `index` — the cumulative height of
+   * every row above it given the CURRENT height cache. ChatView anchors scroll
+   * compensation on a *fixed* row index across renders (the row identity does
+   * not move in the array between re-measures), so it reads this for the
+   * remembered anchor index even after a remeasure shifts which row is
+   * first-visible. Recomputes a prefix sum on each call (O(index)); only invoked
+   * once per render for the anchor, so cheap for a chat list.
+   */
+  offsetAt: (index: number) => number
 }
 
 const DEFAULT_ESTIMATED_ROW_HEIGHT = 80
@@ -135,6 +159,20 @@ export function useWindowedRange({
     [keyAt, estimatedRowHeight, rowGap],
   )
 
+  // Cumulative height of all rows above `index` from the live cache — the
+  // content-space top edge of that row. Re-created when `heightAt` changes; the
+  // caller (ChatView) reads it inside the same render the windowed range is
+  // computed, so it always reflects the current measureTick.
+  const offsetAt = useCallback(
+    (index: number): number => {
+      const clamped = Math.max(0, Math.min(index, itemCount))
+      let sum = 0
+      for (let k = 0; k < clamped; k++) sum += heightAt(k)
+      return sum
+    },
+    [heightAt, itemCount],
+  )
+
   return useMemo<WindowedRange>(() => {
     // Touch measureTick so the memo recomputes when a row is (re)measured.
     void measureTick
@@ -147,6 +185,9 @@ export function useWindowedRange({
         bottomSpacer: 0,
         virtualized: false,
         measureRow,
+        firstVisibleIndex: 0,
+        firstVisibleOffset: 0,
+        offsetAt,
       }
     }
 
@@ -173,6 +214,10 @@ export function useWindowedRange({
       // Scrolled past the end (can happen mid-resize) — clamp to the last row.
       firstVisible = itemCount - 1
     }
+    // `offset` here is the content-space top edge of `firstVisible` — the
+    // cumulative height of every row above it. Capture it as the scroll anchor
+    // before the visible-row walk mutates `offset` further.
+    const firstVisibleOffset = offset
 
     // `offset` is the top edge of `firstVisible`. A row is visible while its
     // top edge is above the viewport bottom; once a row starts at/below
@@ -201,6 +246,9 @@ export function useWindowedRange({
       bottomSpacer: trailingHeight,
       virtualized: true,
       measureRow,
+      firstVisibleIndex: firstVisible,
+      firstVisibleOffset,
+      offsetAt,
     }
   }, [
     itemCount,
@@ -209,6 +257,7 @@ export function useWindowedRange({
     virtualizing,
     overscan,
     heightAt,
+    offsetAt,
     measureRow,
     measureTick,
   ])

--- a/packages/dashboard/src/components/useWindowedRange.ts
+++ b/packages/dashboard/src/components/useWindowedRange.ts
@@ -72,9 +72,18 @@ export interface WindowedRange {
   startIndex: number
   /** One past the last row index to render (exclusive). */
   endIndex: number
-  /** Spacer height above the rendered slice (px). */
+  /**
+   * Spacer height above the rendered slice (px). Reserves the skipped leading
+   * rows' heights MINUS one `rowGap` — the column gap at the spacer↔first-row
+   * seam is rendered by the DOM, so folding it into the spacer too would
+   * double-count it. Zero when no leading rows are skipped.
+   */
   topSpacer: number
-  /** Spacer height below the rendered slice (px). */
+  /**
+   * Spacer height below the rendered slice (px). Same boundary-gap correction
+   * as `topSpacer`: skipped trailing rows' heights minus one `rowGap` for the
+   * last-row↔spacer seam. Zero when no trailing rows are skipped.
+   */
   bottomSpacer: number
   /** True when windowing is active (itemCount > threshold). */
   virtualized: boolean
@@ -234,10 +243,24 @@ export function useWindowedRange({
     const endIndex = Math.min(itemCount, lastVisible + 1 + overscan)
 
     // Convert the trimmed leading/trailing rows back into spacer heights.
+    //
+    // GAP MATH: each spacer is itself a flex child, so the column `gap` (rowGap)
+    // ALSO renders between the spacer and the adjacent rendered row (spacer↔r[s]
+    // and r[e-1]↔spacer). `heightAt(k)` folds one rowGap into every row, so
+    // naively summing it over the skipped rows over-counts by exactly one rowGap
+    // per spacer — the boundary gap is double-counted (once in the spacer sum,
+    // once rendered by the DOM at the spacer/row seam). Subtract that single
+    // rowGap so the windowed `scrollHeight` matches a non-windowed render
+    // exactly: full height = Σ heightAt(i) − rowGap (n−1 gaps, not n).
+    //
+    // N=0 edge cases: a spacer with no skipped rows is 0 (no boundary gap to
+    // render either), so guard each sum on its row count being > 0.
     let leadingHeight = 0
     for (let k = 0; k < startIndex; k++) leadingHeight += heightAt(k)
+    if (startIndex > 0) leadingHeight -= rowGap
     let trailingHeight = 0
     for (let k = endIndex; k < itemCount; k++) trailingHeight += heightAt(k)
+    if (endIndex < itemCount) trailingHeight -= rowGap
 
     return {
       startIndex,
@@ -256,6 +279,7 @@ export function useWindowedRange({
     viewportHeight,
     virtualizing,
     overscan,
+    rowGap,
     heightAt,
     offsetAt,
     measureRow,

--- a/packages/dashboard/src/components/useWindowedRange.ts
+++ b/packages/dashboard/src/components/useWindowedRange.ts
@@ -1,0 +1,217 @@
+/**
+ * useWindowedRange — dependency-free variable-height windowing for the
+ * dashboard ChatView (#5561).
+ *
+ * Why hand-rolled instead of a dep
+ * --------------------------------
+ * The dashboard already ships zero list-virtualization deps (react-window /
+ * virtua / @tanstack/virtual are all absent from package.json), and the chat
+ * list has exactly one consumer. A ~150-line measure-cache windowing hook keeps
+ * the dependency tree (and the audited bundle) unchanged while delivering the
+ * one behaviour the issue asks for: stop mapping the entire message array to the
+ * DOM on long sessions. Mobile uses FlashList because RN has no DOM scroller;
+ * the web has `scrollTop` + `ResizeObserver`, so a small native implementation
+ * is the right tool here.
+ *
+ * How it works
+ * ------------
+ * - Rows are variable height (markdown, tool results), so we cannot assume a
+ *   fixed row size. We keep a per-id height cache that the row component feeds
+ *   via a `ResizeObserver`; unmeasured rows use `estimatedRowHeight`.
+ * - From `scrollTop` + viewport height we walk the cumulative offsets to find
+ *   the first and last rows intersecting the viewport, then pad the range by
+ *   `overscan` rows on each side so scrolling reveals already-mounted rows.
+ * - The caller renders a top spacer (height = summed heights of skipped leading
+ *   rows) and a bottom spacer (summed heights of skipped trailing rows) so the
+ *   scrollbar geometry — and therefore scroll position when appending above —
+ *   stays correct.
+ * - Below `threshold` items the hook returns the full range and zero spacers,
+ *   so short histories render exactly as before (no behaviour change, no
+ *   measurement overhead).
+ *
+ * The hook is intentionally pure-ish: it derives the visible range from
+ * `scrollTop`/`viewportHeight` state that the caller updates on scroll/resize.
+ * It owns the height cache (a ref) and exposes a stable `measureRow` callback.
+ */
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+export interface WindowedRangeOptions {
+  /** Total number of rows in the list. */
+  itemCount: number
+  /** Current scroll offset of the scroll container. */
+  scrollTop: number
+  /** Visible height of the scroll container. */
+  viewportHeight: number
+  /** Height assumed for rows that have not been measured yet. */
+  estimatedRowHeight?: number
+  /** Extra rows mounted above/below the viewport to smooth fast scrolls. */
+  overscan?: number
+  /**
+   * Only virtualize once the list grows past this many rows. Below it the hook
+   * renders everything (start=0, end=itemCount) with no spacers, so short
+   * conversations behave identically to the pre-#5561 full-map render.
+   */
+  threshold?: number
+  /**
+   * The flex `gap` (px) between rows in the scroll container. `measureRow`
+   * reports the bare `offsetHeight`; the gap that the column layout adds
+   * between each row is folded in here so the spacer heights match the real
+   * scroll geometry. Defaults to 0 (no gap).
+   */
+  rowGap?: number
+  /**
+   * Stable key for each row by index — the measurement cache is keyed by this
+   * so a row's height survives reordering / windowing churn (an index-keyed
+   * cache would mis-attribute heights as rows shift).
+   */
+  keyAt: (index: number) => string
+}
+
+export interface WindowedRange {
+  /** First row index to render (inclusive). */
+  startIndex: number
+  /** One past the last row index to render (exclusive). */
+  endIndex: number
+  /** Spacer height above the rendered slice (px). */
+  topSpacer: number
+  /** Spacer height below the rendered slice (px). */
+  bottomSpacer: number
+  /** True when windowing is active (itemCount > threshold). */
+  virtualized: boolean
+  /** Record a measured row height. Stable identity. */
+  measureRow: (key: string, height: number) => void
+}
+
+const DEFAULT_ESTIMATED_ROW_HEIGHT = 80
+const DEFAULT_OVERSCAN = 6
+const DEFAULT_THRESHOLD = 40
+
+export function useWindowedRange({
+  itemCount,
+  scrollTop,
+  viewportHeight,
+  estimatedRowHeight = DEFAULT_ESTIMATED_ROW_HEIGHT,
+  overscan = DEFAULT_OVERSCAN,
+  threshold = DEFAULT_THRESHOLD,
+  rowGap = 0,
+  keyAt,
+}: WindowedRangeOptions): WindowedRange {
+  // Per-id measured heights. A ref (not state) so a measurement never triggers
+  // a re-render on its own — the scroll/resize state changes drive recompute.
+  const heightCacheRef = useRef<Map<string, number>>(new Map())
+  // A monotonically bumped tick so a *new* measurement (height we did not have
+  // before, or a changed height) can opt into a recompute without making every
+  // identical re-measure churn the range.
+  const [measureTick, setMeasureTick] = useState(0)
+
+  // Below the threshold the list renders in full and no spacers/range math
+  // runs, so row heights are irrelevant — a no-op `measureRow` keeps short
+  // conversations from scheduling re-renders on every row mount (and preserves
+  // the #4398 hidden-memoization contract: renderMessage fires exactly once on
+  // first mount).
+  const virtualizing = itemCount > threshold
+
+  const measureRow = useCallback(
+    (key: string, height: number) => {
+      if (!virtualizing) return
+      const cache = heightCacheRef.current
+      const prev = cache.get(key)
+      // Ignore sub-pixel noise from ResizeObserver so streaming reflows don't
+      // spin the recompute loop.
+      if (prev !== undefined && Math.abs(prev - height) < 1) return
+      cache.set(key, height)
+      setMeasureTick((t) => t + 1)
+    },
+    [virtualizing],
+  )
+
+  // Each row occupies its measured (or estimated) height plus the column gap
+  // that follows it. Folding the gap in here keeps the spacer sums aligned with
+  // the real `scrollHeight` so scroll position is anchored correctly when
+  // content appends above the viewport.
+  const heightAt = useCallback(
+    (index: number): number =>
+      (heightCacheRef.current.get(keyAt(index)) ?? estimatedRowHeight) + rowGap,
+    [keyAt, estimatedRowHeight, rowGap],
+  )
+
+  return useMemo<WindowedRange>(() => {
+    // Touch measureTick so the memo recomputes when a row is (re)measured.
+    void measureTick
+
+    if (!virtualizing) {
+      return {
+        startIndex: 0,
+        endIndex: itemCount,
+        topSpacer: 0,
+        bottomSpacer: 0,
+        virtualized: false,
+        measureRow,
+      }
+    }
+
+    // Walk cumulative offsets to find the first row whose bottom edge is past
+    // the top of the viewport, and the last row whose top edge is above the
+    // bottom of the viewport. Linear in itemCount; for a chat list that is
+    // cheap and avoids a parallel prefix-sum array that would need rebuilding
+    // on every measure.
+    const top = Math.max(0, scrollTop)
+    const bottom = top + Math.max(0, viewportHeight)
+
+    let offset = 0
+    let firstVisible = 0
+    let i = 0
+    for (; i < itemCount; i++) {
+      const h = heightAt(i)
+      if (offset + h > top) {
+        firstVisible = i
+        break
+      }
+      offset += h
+    }
+    if (i === itemCount) {
+      // Scrolled past the end (can happen mid-resize) — clamp to the last row.
+      firstVisible = itemCount - 1
+    }
+
+    // `offset` is the top edge of `firstVisible`. A row is visible while its
+    // top edge is above the viewport bottom; once a row starts at/below
+    // `bottom` it (and everything after) is off-screen, so stop BEFORE counting
+    // it as visible.
+    let lastVisible = firstVisible
+    for (let j = firstVisible; j < itemCount; j++) {
+      if (offset >= bottom) break
+      lastVisible = j
+      offset += heightAt(j)
+    }
+
+    const startIndex = Math.max(0, firstVisible - overscan)
+    const endIndex = Math.min(itemCount, lastVisible + 1 + overscan)
+
+    // Convert the trimmed leading/trailing rows back into spacer heights.
+    let leadingHeight = 0
+    for (let k = 0; k < startIndex; k++) leadingHeight += heightAt(k)
+    let trailingHeight = 0
+    for (let k = endIndex; k < itemCount; k++) trailingHeight += heightAt(k)
+
+    return {
+      startIndex,
+      endIndex,
+      topSpacer: leadingHeight,
+      bottomSpacer: trailingHeight,
+      virtualized: true,
+      measureRow,
+    }
+  }, [
+    itemCount,
+    scrollTop,
+    viewportHeight,
+    virtualizing,
+    overscan,
+    heightAt,
+    measureRow,
+    measureTick,
+  ])
+}
+
+export { DEFAULT_ESTIMATED_ROW_HEIGHT, DEFAULT_OVERSCAN, DEFAULT_THRESHOLD }


### PR DESCRIPTION
## Summary

`packages/dashboard/src/components/ChatView.tsx` previously mapped the **entire** deduped message array to the DOM — the long-session responsiveness wall #5561 names. This PR windows (virtualizes) the message list above a row-count threshold so only the rows intersecting the viewport (plus a small overscan) mount, with top/bottom spacer divs preserving scroll geometry. Below the threshold every row renders exactly as before, so there is **no behaviour change for short histories**.

Mirrors the mobile #5534 patterns: pinned-to-bottom while streaming, scroll position preserved when scrolled up, and an id-keyed expand-state registry so tool-bubble expand state survives a row scrolling out of and back into the window.

Closes #5561

## Design notes

**No new dependency.** The dashboard ships zero list-virtualization deps (`react-window` / `virtua` / `@tanstack/virtual` are all absent from `package.json`), the chat list has exactly one consumer, and the web has `scrollTop` + `ResizeObserver`. A ~150-line measure-cache windowing hook delivers the one behaviour the issue asks for while keeping the dependency tree (and the audited bundle) unchanged. Mobile uses FlashList only because React Native has no DOM scroller — a small native implementation is the right tool on web. No lockfile change.

- **`useWindowedRange`** — variable-height windowing derived from `scrollTop` + viewport height. Rows are variable height (markdown, tool results), so it keeps a per-id height cache (a ref, fed by a `ResizeObserver`) with an estimate for unmeasured rows, walks cumulative offsets to find the visible range, and converts windowed-out leading/trailing rows into spacer heights. The `.chat-messages` flex `gap` (12px) is folded into the height math so spacers match the real `scrollHeight` and scroll position stays anchored when content appends above the viewport. Below `threshold` (40) it is a pass-through (full range, no spacers, no measurement) — short conversations are untouched.
- **`MessageRowShell`** — the `.msg-row` flex child is now the *measured* element (observer on the layout box, not a nested wrapper), so the `.chat-messages` DOM stays byte-identical while reporting `offsetHeight`. The `DefaultMessageRow` memo was refactored to render only its inner content; the outer row `<div>` (class + `data-testid`) moves to the shell.
- **`chatExpandRegistry`** — an id-keyed expand registry exposed through React context (mobile `expandedIdsRef` parity). `ToolBubble` and `ToolGroup` seed their expand state from it on mount (falling back to their pre-existing `isTail` / lifecycle default the first time a row is seen) and write through on toggle, so a bubble/group that scrolls out of the window and remounts reopens to the user's last choice instead of snapping shut. Outside a `ChatExpandContext` provider the registry is a no-op, so the components behave exactly as before #5561 in any other surface.

**Preserved unchanged:** pinned-to-bottom while streaming (RAF loop), the count-change auto-scroll only-when-at-bottom (#4652), scroll position when scrolled up, the scroll-to-bottom affordance, keyboard/ARIA on the rows and tool bubbles, the #4398 hidden-memo contract (renderMessage fires once on first mount), and the #5516 per-row markdown-reparse skip.

## Test plan

`cd packages/dashboard && npx tsc --noEmit && npm test && npm run build` — all green (typecheck clean, **3488 tests pass across 179 files**, build succeeds).

New coverage:
- `useWindowedRange.test.tsx` — threshold pass-through (full range / no spacers below threshold), visible-range + spacer math above threshold, measured variable heights changing the range.
- `ChatView.virtualization.test.tsx` — only the visible window renders above the threshold (row 50 present, row 0 windowed out); every row renders below the threshold; top-spacer height equals the windowed-out leading rows; bottom-pinning when a message appends while at the bottom; a scrolled-up reader is not yanked down on append; **tool-bubble expand state survives a scroll-out / scroll-in**; and the registry is per-ChatView-instance (resets on remount).

Existing `ChatView.test.tsx` (scroll/auto-scroll/dedup), `ChatView.memoization.test.tsx` (#5516), `ToolBubble.test.tsx`, `ToolGroup.test.tsx`, and the `App.test.tsx` integration suite all pass against the new path.