### PR TITLE
feat(control-room): Skills tab — inventory + usage history (#5554)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -41,6 +41,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
 import { RunnerStatusSection } from './RunnerStatusSection'
 import { IntegrationsSection } from './IntegrationsSection'
+import { SkillsInventorySection } from './SkillsInventorySection'
 import { SettingsContent } from './SettingsPanel'
 import { useConnectionStore } from '../store/connection'
 import type { ConnectionState } from '../store/types'
@@ -121,6 +122,20 @@ export const CONTROL_ROOM_TABS = [
     snapshotKey: 'integrationStatus',
     loadingKey: 'integrationStatusLoading',
     requestKey: 'requestIntegrationStatus',
+  },
+  // #5554 (epic #5159): the Skills tab — inventory of installed chroxy skills
+  // (global ~/.chroxy/skills/ + per-repo .chroxy/skills/ overlays) with
+  // descriptions / trust / hashes / install dates plus usage history. Same
+  // survey:true request/snapshot flow as Integrations; the #5546 staleness
+  // guard comes free via the registry.
+  {
+    key: 'skills',
+    label: 'Skills',
+    survey: true,
+    requestType: 'skills_inventory_request',
+    snapshotKey: 'skillsInventory',
+    loadingKey: 'skillsInventoryLoading',
+    requestKey: 'requestSkillsInventory',
   },
   // #5544: the Settings tab converges the scattered preference surfaces
   // (notification categories, appearance, session defaults, BYOK, Tauri desktop
@@ -334,6 +349,8 @@ export function ControlRoomView({
         <RunnerStatusSection />
       ) : tab === 'integrations' ? (
         <IntegrationsSection />
+      ) : tab === 'skills' ? (
+        <SkillsInventorySection />
       ) : (
         // #5544: scrollable wrapper so the (often long) settings body scrolls
         // inside the tab panel rather than the whole Control Room view. The

--- a/packages/dashboard/src/components/SkillsInventorySection.test.tsx
+++ b/packages/dashboard/src/components/SkillsInventorySection.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * SkillsInventorySection (#5554) — renderer tests.
+ *
+ * Covers the surface against a mocked `skills_inventory_snapshot`:
+ *   - empty / loading / not-connected states before the first snapshot
+ *   - summary chips (global / repos-with-overlay / used)
+ *   - the Global card + one card per repo overlay
+ *   - skill rows: usage line, manual / inactive / overrides-global / trust tags
+ *   - expandable description (tap to expand)
+ *   - default sort = recently used
+ *   - per-repo error chip degradation + globalError + top-level error callout
+ *   - Refresh dispatches the request (and is disabled while loading)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { SkillInventoryEntry, SkillInventoryRepo, ServerSkillsInventorySnapshotMessage } from '@chroxy/protocol'
+
+// The component reads the store unconditionally (React hooks must be called
+// every render); our tests drive it via props, so a minimal store stub keeps
+// the unused store selectors from touching a real zustand store.
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      skillsInventory: null,
+      skillsInventoryLoading: false,
+      connectionPhase: 'connected',
+      requestSkillsInventory: () => false,
+    }),
+}))
+import { SkillsInventorySection, sortByRecentlyUsed } from './SkillsInventorySection'
+
+afterEach(cleanup)
+
+const NOW = Date.parse('2026-06-11T12:00:00.000Z')
+
+function skill(over: Partial<SkillInventoryEntry> = {}): SkillInventoryEntry {
+  return {
+    name: 'batch-merge',
+    description: 'Merge a batch of PRs',
+    source: 'global',
+    activation: 'auto',
+    active: true,
+    providers: [],
+    version: null,
+    trustState: null,
+    communityAuthor: null,
+    hash: '0a76684',
+    installed: '2026-06-03',
+    lastUsed: '2026-06-10T00:00:00.000Z',
+    useCount: 12,
+    usedRepos: ['/Users/x/Projects/chroxy'],
+    ...over,
+  }
+}
+
+function snapshot(over: Partial<ServerSkillsInventorySnapshotMessage> = {}): ServerSkillsInventorySnapshotMessage {
+  return {
+    type: 'skills_inventory_snapshot',
+    generatedAt: '2026-06-11T11:50:00.000Z',
+    root: '/Users/x/Projects',
+    global: [skill()],
+    globalError: null,
+    repos: [
+      {
+        name: 'chroxy',
+        path: '/Users/x/Projects/chroxy',
+        skills: [skill({ name: 'coding-style', source: 'repo', hash: null, installed: null, overridesGlobal: true, lastUsed: null, useCount: 0, usedRepos: [] })],
+        error: null,
+      },
+    ],
+    ...over,
+  }
+}
+
+const baseProps = { connected: true, loading: false, onRefresh: () => {}, now: () => NOW }
+
+describe('SkillsInventorySection — empty / loading states', () => {
+  it('shows the empty state with a Run survey button before the first snapshot', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={null} />)
+    expect(screen.getByTestId('skills-empty')).toBeTruthy()
+    expect(screen.getByTestId('skills-empty-refresh')).toBeTruthy()
+  })
+
+  it('shows a loading message while a survey is in flight', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={null} loading />)
+    expect(screen.getByTestId('skills-empty').textContent).toContain('Running the skills inventory survey')
+  })
+
+  it('shows a not-connected note when disconnected', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={null} connected={false} />)
+    expect(screen.getByTestId('skills-not-connected')).toBeTruthy()
+  })
+})
+
+describe('SkillsInventorySection — snapshot rendering', () => {
+  it('renders the summary chips', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot()} />)
+    expect(screen.getByTestId('skills-chip-count-global').textContent).toBe('1')
+    expect(screen.getByTestId('skills-chip-count-overlays').textContent).toBe('1')
+    // batch-merge is used (count 12); coding-style is not — so 1 used.
+    expect(screen.getByTestId('skills-chip-count-used').textContent).toBe('1')
+  })
+
+  it('renders the Global card and one card per repo overlay', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot()} />)
+    expect(screen.getByTestId('skills-card-global')).toBeTruthy()
+    expect(screen.getByTestId('skills-card-repo-chroxy')).toBeTruthy()
+    expect(screen.getByTestId('skills-card-global-count').textContent).toBe('1 skill')
+  })
+
+  it('renders the usage line + hash/installed on a used global skill', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot()} />)
+    expect(screen.getByTestId('skill-usage-global-batch-merge').textContent).toContain('12×')
+    expect(screen.getByTestId('skill-sub-global-batch-merge').textContent).toContain('0a76684')
+    expect(screen.getByTestId('skill-sub-global-batch-merge').textContent).toContain('installed 2026-06-03')
+  })
+
+  it('flags a repo skill that overrides a global one', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot()} />)
+    expect(screen.getByTestId('skill-override-repo-chroxy-coding-style')).toBeTruthy()
+  })
+
+  it('shows "never used" for a skill with no usage', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot()} />)
+    expect(screen.getByTestId('skill-usage-repo-chroxy-coding-style').textContent).toContain('never used')
+  })
+
+  it('expands the description on tap', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot()} />)
+    expect(screen.queryByTestId('skill-desc-global-batch-merge')).toBeNull()
+    fireEvent.click(screen.getByTestId('skill-head-global-batch-merge'))
+    expect(screen.getByTestId('skill-desc-global-batch-merge').textContent).toContain('Merge a batch of PRs')
+  })
+
+  it('renders manual + inactive tags', () => {
+    const snap = snapshot({ global: [skill({ name: 'risky', activation: 'manual', active: false })] })
+    render(<SkillsInventorySection {...baseProps} snapshot={snap} />)
+    expect(screen.getByTestId('skill-manual-global-risky')).toBeTruthy()
+    expect(screen.getByTestId('skill-inactive-global-risky')).toBeTruthy()
+  })
+
+  it('renders a trust-pending flag for a community skill', () => {
+    const snap = snapshot({ global: [skill({ name: 'shared', trustState: 'pending', communityAuthor: 'alice' })] })
+    render(<SkillsInventorySection {...baseProps} snapshot={snap} />)
+    expect(screen.getByTestId('skill-trust-global-shared').textContent).toContain('Trust pending')
+  })
+})
+
+describe('SkillsInventorySection — degradation', () => {
+  it('renders an error chip + detail on a repo whose overlay scan failed', () => {
+    const repos: SkillInventoryRepo[] = [
+      { name: 'broken', path: '/p/broken', skills: [], error: 'overlay blew up' },
+    ]
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot({ repos })} />)
+    expect(screen.getByTestId('skills-card-repo-broken-error').textContent).toContain('scan failed')
+    expect(screen.getByTestId('skills-card-repo-broken-error-detail').textContent).toContain('overlay blew up')
+  })
+
+  it('renders the global error chip when the global tier scan failed', () => {
+    render(<SkillsInventorySection {...baseProps} snapshot={snapshot({ global: [], globalError: 'global blew up' })} />)
+    expect(screen.getByTestId('skills-card-global-error').textContent).toContain('scan failed')
+  })
+
+  it('renders the top-level degraded-survey callout', () => {
+    const snap = snapshot({ global: [], repos: [], error: { code: 'FORBIDDEN', message: 'no authority' } })
+    render(<SkillsInventorySection {...baseProps} snapshot={snap} />)
+    expect(screen.getByTestId('skills-error').textContent).toContain('no authority')
+    expect(screen.getByTestId('skills-error').textContent).toContain('FORBIDDEN')
+  })
+})
+
+describe('SkillsInventorySection — refresh', () => {
+  it('dispatches the request on Refresh and disables it while loading', () => {
+    let called = 0
+    const { rerender } = render(
+      <SkillsInventorySection {...baseProps} snapshot={snapshot()} onRefresh={() => { called++ }} />,
+    )
+    fireEvent.click(screen.getByTestId('skills-refresh'))
+    expect(called).toBe(1)
+
+    rerender(<SkillsInventorySection {...baseProps} snapshot={snapshot()} loading onRefresh={() => { called++ }} />)
+    const btn = screen.getByTestId('skills-refresh') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+})
+
+describe('sortByRecentlyUsed', () => {
+  it('orders used skills newest-first, never-used last by name', () => {
+    const skills = [
+      skill({ name: 'old', lastUsed: '2026-06-01T00:00:00.000Z', useCount: 1 }),
+      skill({ name: 'zeta', lastUsed: null, useCount: 0 }),
+      skill({ name: 'new', lastUsed: '2026-06-10T00:00:00.000Z', useCount: 1 }),
+      skill({ name: 'alpha', lastUsed: null, useCount: 0 }),
+    ]
+    expect(sortByRecentlyUsed(skills).map((s) => s.name)).toEqual(['new', 'old', 'alpha', 'zeta'])
+  })
+})

--- a/packages/dashboard/src/components/SkillsInventorySection.test.tsx
+++ b/packages/dashboard/src/components/SkillsInventorySection.test.tsx
@@ -101,6 +101,25 @@ describe('SkillsInventorySection — snapshot rendering', () => {
     expect(screen.getByTestId('skills-chip-count-used').textContent).toBe('1')
   })
 
+  it('counts a skill used in both the global tier and a repo overlay only once', () => {
+    // Usage aggregates are keyed by name and joined onto BOTH the global entry
+    // and the same-named repo overlay entry — the "Used" chip must dedupe by
+    // name so a cross-tier skill isn't double-counted.
+    const snap = snapshot({
+      global: [skill({ name: 'batch-merge', useCount: 12 })],
+      repos: [
+        {
+          name: 'chroxy',
+          path: '/Users/x/Projects/chroxy',
+          skills: [skill({ name: 'batch-merge', source: 'repo', overridesGlobal: true, useCount: 12 })],
+          error: null,
+        },
+      ],
+    })
+    render(<SkillsInventorySection {...baseProps} snapshot={snap} />)
+    expect(screen.getByTestId('skills-chip-count-used').textContent).toBe('1')
+  })
+
   it('renders the Global card and one card per repo overlay', () => {
     render(<SkillsInventorySection {...baseProps} snapshot={snapshot()} />)
     expect(screen.getByTestId('skills-card-global')).toBeTruthy()

--- a/packages/dashboard/src/components/SkillsInventorySection.tsx
+++ b/packages/dashboard/src/components/SkillsInventorySection.tsx
@@ -1,0 +1,346 @@
+/**
+ * SkillsInventorySection (#5554, epic #5159) — the "Skills" Control Room tab.
+ *
+ * Renders the host's skill inventory the server returns in a
+ * `skills_inventory_snapshot`: an eyebrow + title + Refresh + subtitle, a row of
+ * summary chips (global skills / repos with an overlay / skills used), and a set
+ * of cards:
+ *
+ *   - Global card: every skill in `~/.chroxy/skills/` — name, description
+ *     (expandable), activation mode, trust state, content hash + installed date
+ *     (joined from `skills.lock`), and usage (last used / count / repos).
+ *   - Per-repo cards: each surveyed repo's `.chroxy/skills/` overlay — which
+ *     skills a session in that repo gains or OVERRIDES (an `overridesGlobal`
+ *     skill is flagged). A repo with no overlay renders a quiet "no overlay"
+ *     note; a repo whose scan FAILED renders an error chip on the card, never a
+ *     dead tab.
+ *
+ * Skill BODIES never reach the client (the server's #5554 security boundary) —
+ * this panel only ever has names / descriptions / metadata to render.
+ *
+ * Default sort is RECENTLY USED (the "previously used skills" ask): skills with
+ * a `lastUsed` sort newest-first, never-used skills fall to the bottom in
+ * name order.
+ *
+ * Same pull-on-Refresh data flow as the sibling Integrations tab: the Refresh
+ * button dispatches `skills_inventory_request` via the store's
+ * `requestSkillsInventory`; the server replies with one
+ * `skills_inventory_snapshot` handled into `skillsInventory`. No delta stream —
+ * each refresh replaces the whole inventory. The #5546 staleness guard +
+ * auto-fetch-on-activation come free via the Control Room tab registry.
+ */
+import { useState } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { SkillInventoryEntry, SkillInventoryRepo, ServerSkillsInventorySnapshotMessage } from '@chroxy/protocol'
+import { formatGeneratedAgo } from './ControlRoomSection'
+
+/** ISO date (no time) for the eyebrow, e.g. "2026-06-11". */
+function isoDate(iso: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
+  return m ? m[1]! : iso
+}
+
+/** Relative "ago" string for a usage cell, or "never". */
+function formatUsedAgo(iso: string | null, nowMs: number): string {
+  if (!iso) return 'never'
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return 'never'
+  const deltaSec = Math.floor((nowMs - ms) / 1000)
+  if (!Number.isFinite(deltaSec) || deltaSec < 60) return 'just now'
+  const min = Math.floor(deltaSec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const days = Math.floor(hr / 24)
+  if (days < 30) return `${days}d ago`
+  return `${Math.floor(days / 30)}mo ago`
+}
+
+/** basename of a repo path for compact "used in" chips. */
+function repoBase(p: string): string {
+  const parts = p.replace(/\/+$/, '').split('/')
+  return parts[parts.length - 1] || p
+}
+
+/**
+ * Default inventory sort: recently used first (lastUsed desc), then never-used
+ * skills by name. The "previously used skills" ask — the most recently fired
+ * skill bubbles to the top of each card.
+ */
+export function sortByRecentlyUsed(skills: readonly SkillInventoryEntry[]): SkillInventoryEntry[] {
+  return skills.slice().sort((a, b) => {
+    const aMs = a.lastUsed ? Date.parse(a.lastUsed) : NaN
+    const bMs = b.lastUsed ? Date.parse(b.lastUsed) : NaN
+    const aUsed = !Number.isNaN(aMs)
+    const bUsed = !Number.isNaN(bMs)
+    if (aUsed && bUsed) return bMs - aMs
+    if (aUsed) return -1
+    if (bUsed) return 1
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+  })
+}
+
+/** Trust flag for a skill, or null when it's a plain (implicitly-trusted) skill. */
+function trustFlag(skill: SkillInventoryEntry): { label: string; accent: 'warn' | 'bad' } | null {
+  if (skill.trustState === 'pending') return { label: 'Trust pending', accent: 'warn' }
+  return null
+}
+
+/** One inventory skill row: a header line + an expandable description body. */
+function SkillRow({ skill, nowMs, testIdPrefix }: { skill: SkillInventoryEntry; nowMs: number; testIdPrefix: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const trust = trustFlag(skill)
+  const hasDescription = typeof skill.description === 'string' && skill.description.trim().length > 0
+  const rowId = `${testIdPrefix}-${skill.name}`
+
+  return (
+    <li className="cr-skill" data-testid={`skill-row-${rowId}`}>
+      <button
+        type="button"
+        className="cr-skill-head"
+        data-testid={`skill-head-${rowId}`}
+        onClick={() => hasDescription && setExpanded((v) => !v)}
+        aria-expanded={hasDescription ? expanded : undefined}
+        disabled={!hasDescription}
+      >
+        <span className="cr-skill-name" data-testid={`skill-name-${rowId}`}>{skill.name}</span>
+
+        {skill.activation === 'manual' && (
+          <span className="cr-tag" data-testid={`skill-manual-${rowId}`} title="Manual activation — opt in per session">manual</span>
+        )}
+        {skill.active === false && (
+          <span className="cr-tag" data-testid={`skill-inactive-${rowId}`} title="Not in the default-active set">inactive</span>
+        )}
+        {skill.overridesGlobal && (
+          <span className="cr-tag cr-tag-warn" data-testid={`skill-override-${rowId}`} title="Shadows a global skill of the same name">overrides global</span>
+        )}
+        {trust && (
+          <span className={`cr-tag cr-tag-${trust.accent}`} data-testid={`skill-trust-${rowId}`} title={skill.communityAuthor ? `community/${skill.communityAuthor}` : undefined}>
+            {trust.label}
+          </span>
+        )}
+
+        <span className="cr-skill-meta cr-dim" data-testid={`skill-usage-${rowId}`}>
+          {skill.useCount > 0
+            ? `used ${formatUsedAgo(skill.lastUsed, nowMs)} · ${skill.useCount}×`
+            : 'never used'}
+        </span>
+      </button>
+
+      <div className="cr-skill-sub cr-dim cr-mono" data-testid={`skill-sub-${rowId}`}>
+        {skill.providers.length > 0 ? skill.providers.join(', ') : 'all providers'}
+        {skill.version ? ` · v${skill.version}` : ''}
+        {skill.hash ? ` · ${skill.hash}` : ''}
+        {skill.installed ? ` · installed ${skill.installed}` : ''}
+        {skill.usedRepos.length > 0 ? ` · in ${skill.usedRepos.map(repoBase).join(', ')}` : ''}
+      </div>
+
+      {hasDescription && expanded && (
+        <p className="cr-skill-desc" data-testid={`skill-desc-${rowId}`}>{skill.description}</p>
+      )}
+    </li>
+  )
+}
+
+/** A card listing a set of skills (the Global card or one repo's overlay). */
+function SkillCard({
+  title,
+  subtitle,
+  skills,
+  nowMs,
+  testId,
+  testIdPrefix,
+  error,
+  emptyNote,
+}: {
+  title: string
+  subtitle?: React.ReactNode
+  skills: readonly SkillInventoryEntry[]
+  nowMs: number
+  testId: string
+  testIdPrefix: string
+  error?: string | null
+  emptyNote: string
+}) {
+  const sorted = sortByRecentlyUsed(skills)
+  return (
+    <section className="cr-skill-card" data-testid={testId}>
+      <header className="cr-skill-card-head">
+        <h2 className="cr-skill-card-title" data-testid={`${testId}-title`}>{title}</h2>
+        {error ? (
+          <span className="cr-tag cr-tag-bad" data-testid={`${testId}-error`} title={error}>scan failed</span>
+        ) : (
+          <span className="cr-chip" data-testid={`${testId}-count`}>{skills.length} skill{skills.length === 1 ? '' : 's'}</span>
+        )}
+      </header>
+      {subtitle && <p className="cr-sub cr-dim" data-testid={`${testId}-sub`}>{subtitle}</p>}
+      {error ? (
+        <p className="cr-callout" data-testid={`${testId}-error-detail`}><b>Overlay scan failed:</b> {error}</p>
+      ) : sorted.length === 0 ? (
+        <p className="cr-dim" data-testid={`${testId}-empty`}>{emptyNote}</p>
+      ) : (
+        <ul className="cr-skill-list" data-testid={`${testId}-list`}>
+          {sorted.map((skill) => (
+            <SkillRow key={skill.name} skill={skill} nowMs={nowMs} testIdPrefix={testIdPrefix} />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export interface SkillsInventorySectionProps {
+  /** Snapshot override (defaults to the store's `skillsInventory`). For tests. */
+  snapshot?: ServerSkillsInventorySnapshotMessage | null
+  /** Loading override (defaults to `skillsInventoryLoading`). For tests. */
+  loading?: boolean
+  /** Connected override (defaults to `connectionPhase === 'connected'`). For tests. */
+  connected?: boolean
+  /** Refresh override (defaults to `requestSkillsInventory`). For tests. */
+  onRefresh?: () => void
+  /** `now` seam for deterministic "ago" rendering. For tests. */
+  now?: () => number
+}
+
+export function SkillsInventorySection({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  now = Date.now,
+}: SkillsInventorySectionProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.skillsInventory)
+  const storeLoading = useConnectionStore((s) => s.skillsInventoryLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestSkillsInventory = useConnectionStore((s) => s.requestSkillsInventory)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestSkillsInventory
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+  const nowMs = now()
+
+  // Summary tallies for the chip row.
+  const repos: readonly SkillInventoryRepo[] = snapshot?.repos ?? []
+  const reposWithOverlay = repos.filter((r) => r.skills.length > 0).length
+  const usedCount = (snapshot
+    ? [...snapshot.global, ...repos.flatMap((r) => r.skills)].filter((s) => s.useCount > 0).length
+    : 0)
+
+  return (
+    <div className="cr-section" data-testid="skills-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="skills-eyebrow">
+          host · skills{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h1 className="cr-title">Skills</h1>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="skills-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot && (
+          <p className="cr-sub" data-testid="skills-sub">
+            Installed chroxy skills across the global <span className="cr-mono">~/.chroxy/skills/</span> tier and the
+            per-repo <span className="cr-mono">.chroxy/skills/</span> overlays under{' '}
+            <span className="cr-mono">{snapshot.root}</span> — descriptions, trust state, hashes, install dates, and
+            usage history. Sorted by most recently used.
+          </p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="skills-generated">
+            {formatGeneratedAgo(generatedAtMs, nowMs)}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="skills-empty">
+          {loading ? (
+            <span>Running the skills inventory survey…</span>
+          ) : (
+            <>
+              <p>No skills inventory yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="skills-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="skills-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot && (
+        <>
+          <div className="cr-chips" data-testid="skills-chips">
+            <span className="cr-chip" data-testid="skills-chip-global">
+              Global: <b data-testid="skills-chip-count-global">{snapshot.global.length}</b>
+            </span>
+            <span className="cr-chip" data-testid="skills-chip-overlays">
+              Repos with overlay: <b data-testid="skills-chip-count-overlays">{reposWithOverlay}</b>
+            </span>
+            <span className="cr-chip" data-testid="skills-chip-used">
+              Used: <b data-testid="skills-chip-count-used">{usedCount}</b>
+            </span>
+          </div>
+
+          {snapshot.error && (
+            <div className="cr-callout" data-testid="skills-error">
+              <b>Survey degraded:</b> {snapshot.error.message} <span className="cr-dim cr-mono">({snapshot.error.code})</span>
+            </div>
+          )}
+
+          <SkillCard
+            title="Global"
+            subtitle={<span className="cr-mono">~/.chroxy/skills/</span>}
+            skills={snapshot.global}
+            nowMs={nowMs}
+            testId="skills-card-global"
+            testIdPrefix="global"
+            error={snapshot.globalError ?? null}
+            emptyNote="No global skills installed."
+          />
+
+          {repos.map((repo) => (
+            <SkillCard
+              key={repo.path}
+              title={repo.name}
+              subtitle={<span className="cr-mono">{repo.path}/.chroxy/skills/</span>}
+              skills={repo.skills}
+              nowMs={nowMs}
+              testId={`skills-card-repo-${repo.name}`}
+              testIdPrefix={`repo-${repo.name}`}
+              error={repo.error}
+              emptyNote="No repo-local skills overlay."
+            />
+          ))}
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/SkillsInventorySection.tsx
+++ b/packages/dashboard/src/components/SkillsInventorySection.tsx
@@ -231,8 +231,15 @@ export function SkillsInventorySection({
   // Summary tallies for the chip row.
   const repos: readonly SkillInventoryRepo[] = snapshot?.repos ?? []
   const reposWithOverlay = repos.filter((r) => r.skills.length > 0).length
+  // Distinct skills used. Usage aggregates are keyed by skill NAME and joined
+  // onto every inventory row of that name, so a skill present in both the global
+  // tier and a repo overlay would otherwise be counted twice — dedupe by name.
   const usedCount = (snapshot
-    ? [...snapshot.global, ...repos.flatMap((r) => r.skills)].filter((s) => s.useCount > 0).length
+    ? new Set(
+        [...snapshot.global, ...repos.flatMap((r) => r.skills)]
+          .filter((s) => s.useCount > 0)
+          .map((s) => s.name),
+      ).size
     : 0)
 
   return (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -408,6 +408,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // integration_status_snapshot handler. Null until the first survey lands.
   integrationStatus: null,
   integrationStatusLoading: false,
+  // #5554 (epic #5159): Control Room Skills inventory snapshot, fed by the
+  // skills_inventory_snapshot handler. Null until the first survey lands.
+  skillsInventory: null,
+  skillsInventoryLoading: false,
   // #5500: repo-memory Reindex action — in-flight repo paths + last outcome
   // per repo for inline display (same lifecycle as cancellingActivityIds).
   reindexingRepoPaths: new Set<string>(),
@@ -748,6 +752,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       set({ integrationStatusLoading: true });
       wsSend(socket, { type: 'integration_status_request' });
+      return true;
+    }
+    return false;
+  },
+
+  // #5554 (epic #5159): request a Skills inventory survey. Mirrors
+  // requestIntegrationStatus — flips skillsInventoryLoading and sends a
+  // skills_inventory_request; the reply is a single skills_inventory_snapshot
+  // handled into skillsInventory. Returns false (and does NOT set loading) when
+  // the socket is closed.
+  requestSkillsInventory: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ skillsInventoryLoading: true });
+      wsSend(socket, { type: 'skills_inventory_request' });
       return true;
     }
     return false;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -137,7 +137,7 @@ import {
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerPairPendingSchema, ServerPairResolvedSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerPairPendingSchema, ServerPairResolvedSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2133,6 +2133,18 @@ function handleIntegrationStatusSnapshot(msg: Record<string, unknown>, _get: Msg
 }
 
 /**
+ * #5554 (epic #5159) — Skills inventory survey `skills_inventory_snapshot`:
+ * REPLACE the stored inventory and clear the loading flag. Same defensive,
+ * full-replace, clear-loading-only-on-valid-parse contract as the host /
+ * runner / integration survey handlers above.
+ */
+function handleSkillsInventorySnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerSkillsInventorySnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ skillsInventory: parsed.data, skillsInventoryLoading: false });
+}
+
+/**
  * #5500 — resolve one repo's pending Reindex state: drop the repoPath from
  * `reindexingRepoPaths` and record the outcome (ack counts or failure
  * message) in `reindexResults` for inline display. Shared by the success ack
@@ -2279,6 +2291,7 @@ const HANDLERS: Record<string, Handler> = {
   runner_status_snapshot: handleRunnerStatusSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
+  skills_inventory_snapshot: handleSkillsInventorySnapshot,
   // #5500: positive ack correlating an integration_action (repo-memory
   // Reindex) request to its outcome.
   integration_action_ack: handleIntegrationActionAck,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -644,6 +644,19 @@ export interface ConnectionState {
    */
   integrationStatusLoading: boolean;
   /**
+   * #5554 — latest Control Room Skills inventory survey snapshot (global tier +
+   * per-repo overlays, with descriptions / trust / hashes / usage). `null`
+   * until the first snapshot lands (the Skills section renders an empty/loading
+   * state). Replaced wholesale on each snapshot (no delta stream).
+   */
+  skillsInventory: ServerSkillsInventorySnapshotMessage | null;
+  /**
+   * #5554 — true between dispatching a `skills_inventory_request` and the
+   * matching `skills_inventory_snapshot` arriving, so the Skills-tab Refresh
+   * button can spin. Cleared when a snapshot lands.
+   */
+  skillsInventoryLoading: boolean;
+  /**
    * #5500 — repo paths with an in-flight `integration_action` reindex request:
    * set when sendRepoMemoryReindex is called, cleared on the
    * `integration_action_ack` (success) or the INTEGRATION_ACTION_FAILED
@@ -1168,6 +1181,13 @@ export interface ConnectionState {
   // whether the message went on the wire (false = socket closed). Sets
   // `integrationStatusLoading` while in flight.
   requestIntegrationStatus: () => boolean;
+
+  // #5554 (epic #5159): request a Skills inventory survey. Dispatches a
+  // `skills_inventory_request`; the server replies with a single
+  // `skills_inventory_snapshot` handled into `skillsInventory`. Returns whether
+  // the message went on the wire (false = socket closed). Sets
+  // `skillsInventoryLoading` while in flight.
+  requestSkillsInventory: () => boolean;
 
   // #5500 (epic #5498): run the repo-memory Reindex action for one surveyed
   // repo. Dispatches an `integration_action` (action: repo_memory_reindex)

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9145,6 +9145,90 @@ button.sidebar-token-view-session-row:hover {
   background: var(--accent-red);
 }
 
+/* ---------------------------------------------------------------------------
+ * #5554 — Skills inventory tab cards (SkillsInventorySection).
+ * Card-per-tier layout (Global + one per repo overlay), each listing expandable
+ * skill rows. Reuses the cr-tag / cr-chip / cr-mono / cr-dim primitives.
+ * ------------------------------------------------------------------------- */
+.cr-skill-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 12px;
+  padding: 16px 18px;
+  margin: 14px 0;
+}
+
+.cr-skill-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.cr-skill-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.cr-skill-list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+}
+
+.cr-skill {
+  border-top: 1px solid var(--border-primary);
+  padding: 10px 0;
+}
+
+.cr-skill:first-child {
+  border-top: none;
+}
+
+.cr-skill-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+
+.cr-skill-head:disabled {
+  cursor: default;
+}
+
+.cr-skill-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cr-skill-meta {
+  margin-left: auto;
+  font-size: 12px;
+}
+
+.cr-skill-sub {
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.cr-skill-desc {
+  margin: 8px 0 2px;
+  font-size: 13px;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+}
+
 /* Live agent dot next to a repo name */
 .cr-live-dot {
   display: inline-block;

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -36,8 +36,10 @@ export type { RepoVerdict, RepoTree, RepoStatus, HostStatusSummary, ServerHostSt
 export type { RunnerVerdict, RunnerServiceState, RunnerInfo, RepoRunners, RunnerStatusSummary, ServerRunnerStatusSnapshotMessage, } from './schemas/server.ts';
 export type { RepoMemoryCache, RepoMemoryReport, RepoMemoryStatus, RepoRelayRun, RepoRelayVerdict, RepoRelayStatus, IntegrationRepo, IntegrationStatusSummary, IntegrationCliStatus, ServerIntegrationStatusSnapshotMessage, } from './schemas/server.ts';
 export type { IntegrationActionCounts, ServerIntegrationActionAckMessage, } from './schemas/server.ts';
+export type { SkillInventoryEntry, SkillInventoryRepo, ServerSkillsInventorySnapshotMessage, } from './schemas/server.ts';
 export type { HostStatusRequestMessage } from './schemas/client.ts';
 export type { RunnerStatusRequestMessage } from './schemas/client.ts';
 export type { IntegrationStatusRequestMessage } from './schemas/client.ts';
 export type { IntegrationActionMessage } from './schemas/client.ts';
+export type { SkillsInventoryRequestMessage } from './schemas/client.ts';
 export * from './error-categories.ts';

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -593,6 +593,10 @@ export declare const IntegrationStatusRequestSchema: z.ZodObject<{
     type: z.ZodLiteral<"integration_status_request">;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SkillsInventoryRequestSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skills_inventory_request">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const IntegrationActionSchema: z.ZodObject<{
     type: z.ZodLiteral<"integration_action">;
     action: z.ZodEnum<{
@@ -967,6 +971,9 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"integration_status_request">;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"skills_inventory_request">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"integration_action">;
     action: z.ZodEnum<{
         repo_memory_reindex: "repo_memory_reindex";
@@ -1002,6 +1009,7 @@ export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>;
 export type HostStatusRequestMessage = z.infer<typeof HostStatusRequestSchema>;
 export type RunnerStatusRequestMessage = z.infer<typeof RunnerStatusRequestSchema>;
 export type IntegrationStatusRequestMessage = z.infer<typeof IntegrationStatusRequestSchema>;
+export type SkillsInventoryRequestMessage = z.infer<typeof SkillsInventoryRequestSchema>;
 export type IntegrationActionMessage = z.infer<typeof IntegrationActionSchema>;
 export type SummarizeSessionMessage = z.infer<typeof SummarizeSessionSchema>;
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -743,6 +743,20 @@ export const IntegrationStatusRequestSchema = z.object({
     type: z.literal('integration_status_request'),
     requestId: z.string().max(128).optional(),
 });
+// #5554 (epic #5159): the dashboard's Control Room "Skills" tab asks the server
+// for an inventory of installed chroxy skills — the global `~/.chroxy/skills/`
+// tier plus the per-repo `.chroxy/skills/` overlays for the surveyed repos, with
+// descriptions, trust state, content hashes, install dates, and per-skill usage
+// history (last used / count / repos). The server scans on request only (NOT in
+// the periodic survey — overlay scans are too costly to run on the survey
+// cadence) and replies with a single `skills_inventory_snapshot` (see
+// server.ts). Pull-on-Refresh, same host-level authority as the host / runner /
+// integration surveys. The optional `requestId` lets the dashboard correlate a
+// Refresh click to its snapshot.
+export const SkillsInventoryRequestSchema = z.object({
+    type: z.literal('skills_inventory_request'),
+    requestId: z.string().max(128).optional(),
+});
 // #5500 (epic #5498): a MUTATING Control Room integration action — the
 // observe half of the tab is `integration_status_request`; this is the
 // control half. Actions:
@@ -883,6 +897,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     HostStatusRequestSchema,
     RunnerStatusRequestSchema,
     IntegrationStatusRequestSchema,
+    SkillsInventoryRequestSchema,
     IntegrationActionSchema,
     SummarizeSessionSchema,
     PairApproveSchema,

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -1369,6 +1369,173 @@ export declare const ServerIntegrationActionAckSchema: z.ZodObject<{
     }, z.core.$strip>>;
 }, z.core.$loose>;
 /**
+ * #5554 — one skill in the inventory snapshot. Carries only names /
+ * descriptions / metadata — never the skill BODY (the security boundary: skill
+ * bodies never leave the server). Fields:
+ *
+ *   - `name` / `description` — from the file + frontmatter (description is the
+ *     frontmatter `description:` or the first non-empty body line).
+ *   - `source` — which tier this entry came from: `global` (~/.chroxy/skills/)
+ *     or `repo` (a repo-local `.chroxy/skills/` overlay).
+ *   - `activation` — `auto` (always active) or `manual` (opt-in per session).
+ *   - `active` — whether the skill is in the default-active set (a manual skill
+ *     not yet activated reports `active: false`).
+ *   - `providers` — frontmatter provider scoping (empty = applies to all).
+ *   - `version` — frontmatter `version:` if present.
+ *   - `trustState` — `trusted` / `pending` for community-namespaced skills;
+ *     null for plain skills (implicitly trusted).
+ *   - `communityAuthor` — the `community/<author>/` namespace, when applicable.
+ *   - `hash` / `installed` — joined from the paired `skills.lock` (null when
+ *     the lock has no entry for this skill).
+ *   - `overridesGlobal` — set on a repo-tier entry that shadows a global skill
+ *     of the same name (the per-session loader's repo-wins precedence).
+ *   - `lastUsed` / `useCount` / `usedRepos` — the #5554 Phase 2 usage rollup
+ *     (lastUsed null + count 0 when never recorded).
+ */
+export declare const SkillInventoryEntrySchema: z.ZodObject<{
+    name: z.ZodString;
+    description: z.ZodString;
+    source: z.ZodEnum<{
+        repo: "repo";
+        global: "global";
+    }>;
+    activation: z.ZodEnum<{
+        auto: "auto";
+        manual: "manual";
+    }>;
+    active: z.ZodBoolean;
+    providers: z.ZodArray<z.ZodString>;
+    version: z.ZodNullable<z.ZodString>;
+    trustState: z.ZodNullable<z.ZodEnum<{
+        pending: "pending";
+        trusted: "trusted";
+    }>>;
+    communityAuthor: z.ZodNullable<z.ZodString>;
+    hash: z.ZodNullable<z.ZodString>;
+    installed: z.ZodNullable<z.ZodString>;
+    overridesGlobal: z.ZodOptional<z.ZodBoolean>;
+    lastUsed: z.ZodNullable<z.ZodString>;
+    useCount: z.ZodNumber;
+    usedRepos: z.ZodArray<z.ZodString>;
+}, z.core.$strip>;
+/**
+ * #5554 — one surveyed repo's skill overlay. `skills` is the repo-local
+ * `.chroxy/skills/` overlay (empty when the repo has no overlay — absence is
+ * signal, not an error). `error` carries a per-repo scan-failure reason so a
+ * single broken overlay degrades to a chip on that card rather than a dead
+ * snapshot.
+ */
+export declare const SkillInventoryRepoSchema: z.ZodObject<{
+    name: z.ZodString;
+    path: z.ZodString;
+    skills: z.ZodArray<z.ZodObject<{
+        name: z.ZodString;
+        description: z.ZodString;
+        source: z.ZodEnum<{
+            repo: "repo";
+            global: "global";
+        }>;
+        activation: z.ZodEnum<{
+            auto: "auto";
+            manual: "manual";
+        }>;
+        active: z.ZodBoolean;
+        providers: z.ZodArray<z.ZodString>;
+        version: z.ZodNullable<z.ZodString>;
+        trustState: z.ZodNullable<z.ZodEnum<{
+            pending: "pending";
+            trusted: "trusted";
+        }>>;
+        communityAuthor: z.ZodNullable<z.ZodString>;
+        hash: z.ZodNullable<z.ZodString>;
+        installed: z.ZodNullable<z.ZodString>;
+        overridesGlobal: z.ZodOptional<z.ZodBoolean>;
+        lastUsed: z.ZodNullable<z.ZodString>;
+        useCount: z.ZodNumber;
+        usedRepos: z.ZodArray<z.ZodString>;
+    }, z.core.$strip>>;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+/**
+ * #5554 — full Skills inventory snapshot, emitted in reply to a
+ * `skills_inventory_request` (see client.ts). `global` is the
+ * `~/.chroxy/skills/` tier; `repos` are the per-repo overlays for the surveyed
+ * repo set (same set the host / integration surveys resolve). `globalError`
+ * degrades the global tier the same way a repo `error` degrades a repo card.
+ * `root` is the Control Room discovery root the repo set was resolved under.
+ * Same degraded-snapshot-with-`error` posture as the sibling surveys: on a
+ * forbidden / in-progress / failed request the handler returns an otherwise
+ * valid empty snapshot plus the top-level `error`.
+ */
+export declare const ServerSkillsInventorySnapshotSchema: z.ZodObject<{
+    type: z.ZodLiteral<"skills_inventory_snapshot">;
+    requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    generatedAt: z.ZodString;
+    root: z.ZodString;
+    global: z.ZodArray<z.ZodObject<{
+        name: z.ZodString;
+        description: z.ZodString;
+        source: z.ZodEnum<{
+            repo: "repo";
+            global: "global";
+        }>;
+        activation: z.ZodEnum<{
+            auto: "auto";
+            manual: "manual";
+        }>;
+        active: z.ZodBoolean;
+        providers: z.ZodArray<z.ZodString>;
+        version: z.ZodNullable<z.ZodString>;
+        trustState: z.ZodNullable<z.ZodEnum<{
+            pending: "pending";
+            trusted: "trusted";
+        }>>;
+        communityAuthor: z.ZodNullable<z.ZodString>;
+        hash: z.ZodNullable<z.ZodString>;
+        installed: z.ZodNullable<z.ZodString>;
+        overridesGlobal: z.ZodOptional<z.ZodBoolean>;
+        lastUsed: z.ZodNullable<z.ZodString>;
+        useCount: z.ZodNumber;
+        usedRepos: z.ZodArray<z.ZodString>;
+    }, z.core.$strip>>;
+    globalError: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    repos: z.ZodArray<z.ZodObject<{
+        name: z.ZodString;
+        path: z.ZodString;
+        skills: z.ZodArray<z.ZodObject<{
+            name: z.ZodString;
+            description: z.ZodString;
+            source: z.ZodEnum<{
+                repo: "repo";
+                global: "global";
+            }>;
+            activation: z.ZodEnum<{
+                auto: "auto";
+                manual: "manual";
+            }>;
+            active: z.ZodBoolean;
+            providers: z.ZodArray<z.ZodString>;
+            version: z.ZodNullable<z.ZodString>;
+            trustState: z.ZodNullable<z.ZodEnum<{
+                pending: "pending";
+                trusted: "trusted";
+            }>>;
+            communityAuthor: z.ZodNullable<z.ZodString>;
+            hash: z.ZodNullable<z.ZodString>;
+            installed: z.ZodNullable<z.ZodString>;
+            overridesGlobal: z.ZodOptional<z.ZodBoolean>;
+            lastUsed: z.ZodNullable<z.ZodString>;
+            useCount: z.ZodNumber;
+            usedRepos: z.ZodArray<z.ZodString>;
+        }, z.core.$strip>>;
+        error: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    error: z.ZodOptional<z.ZodObject<{
+        code: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+/**
  * #5547: reply to a `summarize_session` request — the model-written
  * continuation brief built from the session's persisted history. Sent only to
  * the requesting client. `summary` is the editable brief the dashboard seeds
@@ -2027,4 +2194,7 @@ export type IntegrationCliStatus = z.infer<typeof IntegrationCliStatusSchema>;
 export type ServerIntegrationStatusSnapshotMessage = z.infer<typeof ServerIntegrationStatusSnapshotSchema>;
 export type IntegrationActionCounts = z.infer<typeof IntegrationActionCountsSchema>;
 export type ServerIntegrationActionAckMessage = z.infer<typeof ServerIntegrationActionAckSchema>;
+export type SkillInventoryEntry = z.infer<typeof SkillInventoryEntrySchema>;
+export type SkillInventoryRepo = z.infer<typeof SkillInventoryRepoSchema>;
+export type ServerSkillsInventorySnapshotMessage = z.infer<typeof ServerSkillsInventorySnapshotSchema>;
 export type ServerSummarizeSessionResultMessage = z.infer<typeof ServerSummarizeSessionResultSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -1271,6 +1271,89 @@ export const ServerIntegrationActionAckSchema = z.object({
     runId: z.number().int().nonnegative().finite().nullable().optional(),
     counts: IntegrationActionCountsSchema.nullable(),
 }).passthrough();
+// ───────────────────────────────────────────────────────────────────────────
+// #5554 (epic #5159) — Control Room "Skills" tab: inventory + usage history.
+// ───────────────────────────────────────────────────────────────────────────
+/**
+ * #5554 — one skill in the inventory snapshot. Carries only names /
+ * descriptions / metadata — never the skill BODY (the security boundary: skill
+ * bodies never leave the server). Fields:
+ *
+ *   - `name` / `description` — from the file + frontmatter (description is the
+ *     frontmatter `description:` or the first non-empty body line).
+ *   - `source` — which tier this entry came from: `global` (~/.chroxy/skills/)
+ *     or `repo` (a repo-local `.chroxy/skills/` overlay).
+ *   - `activation` — `auto` (always active) or `manual` (opt-in per session).
+ *   - `active` — whether the skill is in the default-active set (a manual skill
+ *     not yet activated reports `active: false`).
+ *   - `providers` — frontmatter provider scoping (empty = applies to all).
+ *   - `version` — frontmatter `version:` if present.
+ *   - `trustState` — `trusted` / `pending` for community-namespaced skills;
+ *     null for plain skills (implicitly trusted).
+ *   - `communityAuthor` — the `community/<author>/` namespace, when applicable.
+ *   - `hash` / `installed` — joined from the paired `skills.lock` (null when
+ *     the lock has no entry for this skill).
+ *   - `overridesGlobal` — set on a repo-tier entry that shadows a global skill
+ *     of the same name (the per-session loader's repo-wins precedence).
+ *   - `lastUsed` / `useCount` / `usedRepos` — the #5554 Phase 2 usage rollup
+ *     (lastUsed null + count 0 when never recorded).
+ */
+export const SkillInventoryEntrySchema = z.object({
+    name: z.string(),
+    description: z.string(),
+    source: z.enum(['global', 'repo']),
+    activation: z.enum(['auto', 'manual']),
+    active: z.boolean(),
+    providers: z.array(z.string()),
+    version: z.string().nullable(),
+    trustState: z.enum(['trusted', 'pending']).nullable(),
+    communityAuthor: z.string().nullable(),
+    hash: z.string().nullable(),
+    installed: z.string().nullable(),
+    overridesGlobal: z.boolean().optional(),
+    lastUsed: z.string().datetime().nullable(),
+    useCount: z.number().int().nonnegative().finite(),
+    usedRepos: z.array(z.string()),
+});
+/**
+ * #5554 — one surveyed repo's skill overlay. `skills` is the repo-local
+ * `.chroxy/skills/` overlay (empty when the repo has no overlay — absence is
+ * signal, not an error). `error` carries a per-repo scan-failure reason so a
+ * single broken overlay degrades to a chip on that card rather than a dead
+ * snapshot.
+ */
+export const SkillInventoryRepoSchema = z.object({
+    name: z.string(),
+    path: z.string(),
+    skills: z.array(SkillInventoryEntrySchema),
+    error: z.string().nullable(),
+});
+/**
+ * #5554 — full Skills inventory snapshot, emitted in reply to a
+ * `skills_inventory_request` (see client.ts). `global` is the
+ * `~/.chroxy/skills/` tier; `repos` are the per-repo overlays for the surveyed
+ * repo set (same set the host / integration surveys resolve). `globalError`
+ * degrades the global tier the same way a repo `error` degrades a repo card.
+ * `root` is the Control Room discovery root the repo set was resolved under.
+ * Same degraded-snapshot-with-`error` posture as the sibling surveys: on a
+ * forbidden / in-progress / failed request the handler returns an otherwise
+ * valid empty snapshot plus the top-level `error`.
+ */
+export const ServerSkillsInventorySnapshotSchema = z.object({
+    type: z.literal('skills_inventory_snapshot'),
+    requestId: z.string().max(128).nullable().optional(),
+    generatedAt: z.string().datetime(),
+    root: z.string(),
+    global: z.array(SkillInventoryEntrySchema),
+    globalError: z.string().nullable().optional(),
+    repos: z.array(SkillInventoryRepoSchema),
+    error: z
+        .object({
+        code: z.string(),
+        message: z.string(),
+    })
+        .optional(),
+});
 /**
  * #5547: reply to a `summarize_session` request — the model-written
  * continuation brief built from the session's persisted history. Sent only to

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -109,6 +109,15 @@ export type {
   ServerIntegrationActionAckMessage,
 } from './schemas/server.ts'
 
+// #5554 (epic #5159): pin the Skills tab contract at the entry point so the
+// dashboard panel + store import `SkillInventoryEntry` / `SkillInventoryRepo` /
+// `ServerSkillsInventorySnapshotMessage` as a stable public contract.
+export type {
+  SkillInventoryEntry,
+  SkillInventoryRepo,
+  ServerSkillsInventorySnapshotMessage,
+} from './schemas/server.ts'
+
 // #5171: the client→server request type is pinned at the entry point too so
 // consumers can import the alias without reaching into `./schemas/client.ts`.
 export type { HostStatusRequestMessage } from './schemas/client.ts'
@@ -118,6 +127,8 @@ export type { RunnerStatusRequestMessage } from './schemas/client.ts'
 export type { IntegrationStatusRequestMessage } from './schemas/client.ts'
 // #5500: integrations Reindex action request alias.
 export type { IntegrationActionMessage } from './schemas/client.ts'
+// #5554: skills inventory survey request alias.
+export type { SkillsInventoryRequestMessage } from './schemas/client.ts'
 
 // Re-export client-side error-category detection (#3151)
 export * from './error-categories.ts'

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -858,6 +858,21 @@ export const IntegrationStatusRequestSchema = z.object({
   requestId: z.string().max(128).optional(),
 })
 
+// #5554 (epic #5159): the dashboard's Control Room "Skills" tab asks the server
+// for an inventory of installed chroxy skills — the global `~/.chroxy/skills/`
+// tier plus the per-repo `.chroxy/skills/` overlays for the surveyed repos, with
+// descriptions, trust state, content hashes, install dates, and per-skill usage
+// history (last used / count / repos). The server scans on request only (NOT in
+// the periodic survey — overlay scans are too costly to run on the survey
+// cadence) and replies with a single `skills_inventory_snapshot` (see
+// server.ts). Pull-on-Refresh, same host-level authority as the host / runner /
+// integration surveys. The optional `requestId` lets the dashboard correlate a
+// Refresh click to its snapshot.
+export const SkillsInventoryRequestSchema = z.object({
+  type: z.literal('skills_inventory_request'),
+  requestId: z.string().max(128).optional(),
+})
+
 // #5500 (epic #5498): a MUTATING Control Room integration action — the
 // observe half of the tab is `integration_status_request`; this is the
 // control half. Actions:
@@ -1002,6 +1017,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   HostStatusRequestSchema,
   RunnerStatusRequestSchema,
   IntegrationStatusRequestSchema,
+  SkillsInventoryRequestSchema,
   IntegrationActionSchema,
   SummarizeSessionSchema,
   PairApproveSchema,
@@ -1026,6 +1042,7 @@ export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>
 export type HostStatusRequestMessage = z.infer<typeof HostStatusRequestSchema>
 export type RunnerStatusRequestMessage = z.infer<typeof RunnerStatusRequestSchema>
 export type IntegrationStatusRequestMessage = z.infer<typeof IntegrationStatusRequestSchema>
+export type SkillsInventoryRequestMessage = z.infer<typeof SkillsInventoryRequestSchema>
 export type IntegrationActionMessage = z.infer<typeof IntegrationActionSchema>
 export type SummarizeSessionMessage = z.infer<typeof SummarizeSessionSchema>
 export type ClientMessage = z.infer<typeof ClientMessageSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -1349,6 +1349,93 @@ export const ServerIntegrationActionAckSchema = z.object({
   counts: IntegrationActionCountsSchema.nullable(),
 }).passthrough()
 
+// ───────────────────────────────────────────────────────────────────────────
+// #5554 (epic #5159) — Control Room "Skills" tab: inventory + usage history.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * #5554 — one skill in the inventory snapshot. Carries only names /
+ * descriptions / metadata — never the skill BODY (the security boundary: skill
+ * bodies never leave the server). Fields:
+ *
+ *   - `name` / `description` — from the file + frontmatter (description is the
+ *     frontmatter `description:` or the first non-empty body line).
+ *   - `source` — which tier this entry came from: `global` (~/.chroxy/skills/)
+ *     or `repo` (a repo-local `.chroxy/skills/` overlay).
+ *   - `activation` — `auto` (always active) or `manual` (opt-in per session).
+ *   - `active` — whether the skill is in the default-active set (a manual skill
+ *     not yet activated reports `active: false`).
+ *   - `providers` — frontmatter provider scoping (empty = applies to all).
+ *   - `version` — frontmatter `version:` if present.
+ *   - `trustState` — `trusted` / `pending` for community-namespaced skills;
+ *     null for plain skills (implicitly trusted).
+ *   - `communityAuthor` — the `community/<author>/` namespace, when applicable.
+ *   - `hash` / `installed` — joined from the paired `skills.lock` (null when
+ *     the lock has no entry for this skill).
+ *   - `overridesGlobal` — set on a repo-tier entry that shadows a global skill
+ *     of the same name (the per-session loader's repo-wins precedence).
+ *   - `lastUsed` / `useCount` / `usedRepos` — the #5554 Phase 2 usage rollup
+ *     (lastUsed null + count 0 when never recorded).
+ */
+export const SkillInventoryEntrySchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  source: z.enum(['global', 'repo']),
+  activation: z.enum(['auto', 'manual']),
+  active: z.boolean(),
+  providers: z.array(z.string()),
+  version: z.string().nullable(),
+  trustState: z.enum(['trusted', 'pending']).nullable(),
+  communityAuthor: z.string().nullable(),
+  hash: z.string().nullable(),
+  installed: z.string().nullable(),
+  overridesGlobal: z.boolean().optional(),
+  lastUsed: z.string().datetime().nullable(),
+  useCount: z.number().int().nonnegative().finite(),
+  usedRepos: z.array(z.string()),
+})
+
+/**
+ * #5554 — one surveyed repo's skill overlay. `skills` is the repo-local
+ * `.chroxy/skills/` overlay (empty when the repo has no overlay — absence is
+ * signal, not an error). `error` carries a per-repo scan-failure reason so a
+ * single broken overlay degrades to a chip on that card rather than a dead
+ * snapshot.
+ */
+export const SkillInventoryRepoSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  skills: z.array(SkillInventoryEntrySchema),
+  error: z.string().nullable(),
+})
+
+/**
+ * #5554 — full Skills inventory snapshot, emitted in reply to a
+ * `skills_inventory_request` (see client.ts). `global` is the
+ * `~/.chroxy/skills/` tier; `repos` are the per-repo overlays for the surveyed
+ * repo set (same set the host / integration surveys resolve). `globalError`
+ * degrades the global tier the same way a repo `error` degrades a repo card.
+ * `root` is the Control Room discovery root the repo set was resolved under.
+ * Same degraded-snapshot-with-`error` posture as the sibling surveys: on a
+ * forbidden / in-progress / failed request the handler returns an otherwise
+ * valid empty snapshot plus the top-level `error`.
+ */
+export const ServerSkillsInventorySnapshotSchema = z.object({
+  type: z.literal('skills_inventory_snapshot'),
+  requestId: z.string().max(128).nullable().optional(),
+  generatedAt: z.string().datetime(),
+  root: z.string(),
+  global: z.array(SkillInventoryEntrySchema),
+  globalError: z.string().nullable().optional(),
+  repos: z.array(SkillInventoryRepoSchema),
+  error: z
+    .object({
+      code: z.string(),
+      message: z.string(),
+    })
+    .optional(),
+})
+
 /**
  * #5547: reply to a `summarize_session` request — the model-written
  * continuation brief built from the session's persisted history. Sent only to
@@ -2258,4 +2345,11 @@ export type ServerIntegrationStatusSnapshotMessage = z.infer<typeof ServerIntegr
 // `IntegrationActionMessage` in client.ts.
 export type IntegrationActionCounts = z.infer<typeof IntegrationActionCountsSchema>
 export type ServerIntegrationActionAckMessage = z.infer<typeof ServerIntegrationActionAckSchema>
+// #5554 — Skills inventory tab (epic #5159); request side is
+// `SkillsInventoryRequestMessage` in client.ts. Consumed by the server emitter
+// (control-room/skills-inventory.js), the dashboard store handler, and the
+// SkillsInventorySection panel.
+export type SkillInventoryEntry = z.infer<typeof SkillInventoryEntrySchema>
+export type SkillInventoryRepo = z.infer<typeof SkillInventoryRepoSchema>
+export type ServerSkillsInventorySnapshotMessage = z.infer<typeof ServerSkillsInventorySnapshotSchema>
 export type ServerSummarizeSessionResultMessage = z.infer<typeof ServerSummarizeSessionResultSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -123,6 +123,7 @@ const PLATFORM_SPECIFIC = {
   'runner_status_snapshot': 'dashboard', // Control Room self-hosted runner survey reply (#5253) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_status_snapshot': 'dashboard', // Control Room Integrations survey reply (#5499, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_action_ack': 'dashboard', // Control Room Integrations Reindex action ack (#5500, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)
   // 'agent_event' (#5016) is now handled by both dashboard and mobile
   // app (#5060 — mobile renders the same nested sub-bubbles inside the

--- a/packages/server/src/control-room/skills-inventory.js
+++ b/packages/server/src/control-room/skills-inventory.js
@@ -1,0 +1,305 @@
+/**
+ * Control Room — Skills inventory survey (#5554 Phase 1, epic #5159).
+ *
+ * Sibling to the host survey (survey.js), the runner survey (runners.js), and
+ * the integrations survey (integrations.js). Where those classify repos /
+ * runners / integration status, this one answers "what skills exist on this
+ * host, what does each do, which are trusted, and which have I been using?".
+ *
+ * Two tiers, mirroring the per-session skills loader's overlay model
+ * (skills-loader.js):
+ *   - global:  every skill in `~/.chroxy/skills/` (the configured global
+ *     skills dir) — name, description (frontmatter), activation mode, provider
+ *     scoping, trust state, content hash + installed date (joined from
+ *     `skills.lock`), and usage (lastUsed / count / repos).
+ *   - repos:   for each surveyed repo (the SAME repo set the host/integrations
+ *     surveys resolve), the repo-local `.chroxy/skills/` overlay — which skills
+ *     a session in that repo would gain or OVERRIDE. A repo-local skill that
+ *     shares a name with a global one is flagged `overridesGlobal: true`.
+ *
+ * SECURITY (docs/security/bearer-token-authority.md): skill BODIES never leave
+ * the server — this survey carries only names, descriptions, and metadata. The
+ * `loadActiveSkills` result is mapped through `toInventoryEntry`, which drops
+ * the `body` and the absolute filesystem `path` before anything is returned.
+ * The lock-join is read-only and bounded to the scanned roots.
+ *
+ * Degradation: a per-repo scan failure degrades to an `error` string on that
+ * repo's entry — never a dead snapshot. The global tier degrades the same way
+ * (a `globalError` on the snapshot) so a broken `~/.chroxy/skills/` doesn't
+ * blank the whole tab.
+ *
+ * Scan-on-request only: this is invoked from the WS handler in reply to a
+ * `skills_inventory_request`, never from the periodic survey — disk scans of
+ * every repo's overlay are too costly to run on the survey cadence.
+ *
+ * Every external interaction is injectable so tests never touch real fs:
+ *   - `_loadActiveSkills(dir, opts)` — the skills-loader scan (returns the
+ *     loader's per-skill descriptors).
+ *   - `_readLock(path)` — sync read of a `skills.lock` file, returns a string
+ *     or throws when absent.
+ *   - `_findRepoSkillsDir(repoPath)` — resolves a repo's `.chroxy/skills/`.
+ *   - `_now()` — returns a `Date`.
+ *   - `usage` — a `Map<string, { lastUsed, count, repos }>` (from the
+ *     SkillsUsageRecorder); absent → no usage data joined.
+ */
+
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { loadActiveSkills, findRepoSkillsDir, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
+
+/** Per-repo concurrency cap (matches the sibling surveys). */
+export const DEFAULT_CONCURRENCY = 5
+
+/**
+ * Parse a `skills.lock` file into a name → { hash, installed } map. The lock
+ * shares the shape the Claude Code skill registry writes (and the chroxy
+ * skills lock mirrors):
+ *
+ *   { "registry": "...", "skills": { "<name>": { "hash": "...", "installed": "2026-06-02" } } }
+ *
+ * Tolerant: a missing/unparseable/wrong-shape lock yields an empty map — the
+ * inventory simply reports null hash/installed for those skills.
+ *
+ * @param {string|null} text - raw lock contents, or null when absent.
+ * @returns {Map<string, { hash: string|null, installed: string|null }>}
+ */
+export function parseSkillsLock(text) {
+  const out = new Map()
+  if (typeof text !== 'string' || text.length === 0) return out
+  let parsed
+  try {
+    parsed = JSON.parse(text.replace(/^﻿/, ''))
+  } catch {
+    return out
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return out
+  const skills = parsed.skills
+  if (!skills || typeof skills !== 'object' || Array.isArray(skills)) return out
+  for (const [name, rec] of Object.entries(skills)) {
+    if (typeof name !== 'string' || name.length === 0) continue
+    if (!rec || typeof rec !== 'object') continue
+    out.set(name, {
+      hash: typeof rec.hash === 'string' && rec.hash.length > 0 ? rec.hash : null,
+      installed: typeof rec.installed === 'string' && rec.installed.length > 0 ? rec.installed : null,
+    })
+  }
+  return out
+}
+
+/**
+ * The on-disk `skills.lock` path that pairs with a skills dir. The lock lives
+ * ALONGSIDE the skills directory (a sibling, not inside it), matching how the
+ * Claude Code registry writes `.claude/skills.lock` next to `.claude/commands/`:
+ *
+ *   ~/.chroxy/skills/        → ~/.chroxy/skills.lock
+ *   <repo>/.chroxy/skills/   → <repo>/.chroxy/skills.lock
+ *
+ * @param {string} skillsDir - a skills directory path.
+ * @returns {string} the paired lock path.
+ */
+export function lockPathForSkillsDir(skillsDir) {
+  return join(dirname(skillsDir), 'skills.lock')
+}
+
+/**
+ * Read + parse the `skills.lock` paired with a skills dir. Never throws — an
+ * absent or unreadable lock degrades to an empty map.
+ *
+ * @param {Function} readFn - sync read seam (throws when absent).
+ * @param {string} skillsDir
+ * @returns {Map<string, { hash: string|null, installed: string|null }>}
+ */
+function readLockFor(readFn, skillsDir) {
+  let text = null
+  try {
+    text = readFn(lockPathForSkillsDir(skillsDir))
+  } catch {
+    text = null
+  }
+  return parseSkillsLock(typeof text === 'string' ? text : null)
+}
+
+/**
+ * Map one skills-loader descriptor into a wire-safe inventory entry, joining
+ * the lock + usage data. Drops `body` and the absolute `path` — only
+ * names/descriptions/metadata cross the wire (the #5554 security boundary).
+ *
+ * @param {object} skill - a `loadActiveSkills` descriptor.
+ * @param {Map<string, { hash, installed }>} lock
+ * @param {Map<string, { lastUsed, count, repos }>|null} usage
+ * @param {Set<string>|null} globalNames - global skill names, to flag overrides.
+ * @returns {object} an inventory entry (matches SkillInventoryEntrySchema minus type).
+ */
+export function toInventoryEntry(skill, lock, usage, globalNames) {
+  const name = typeof skill?.name === 'string' ? skill.name : ''
+  const meta = skill && typeof skill.metadata === 'object' && skill.metadata ? skill.metadata : null
+  const activationRaw = meta && typeof meta.activation === 'string' ? meta.activation.trim().toLowerCase() : null
+  const activation = activationRaw === 'manual' ? 'manual' : 'auto'
+
+  // providers: tolerate both list and scalar shapes the frontmatter parser may
+  // produce; normalise to a string[] (empty = applies to all).
+  let providers = []
+  if (meta) {
+    if (Array.isArray(meta.providers)) {
+      providers = meta.providers.filter((p) => typeof p === 'string' && p.length > 0)
+    } else if (typeof meta.providers === 'string' && meta.providers.trim().length > 0) {
+      providers = [meta.providers.trim()]
+    }
+  }
+
+  const lockRec = lock.get(name) || null
+  const usageRec = usage ? usage.get(name) || null : null
+
+  const entry = {
+    name,
+    description: typeof skill?.description === 'string' ? skill.description : '',
+    source: skill?.source === 'repo' ? 'repo' : 'global',
+    activation,
+    active: skill?.active !== false,
+    providers,
+    version: meta && typeof meta.version === 'string' && meta.version.length > 0 ? meta.version : null,
+    // Trust: only community-namespaced skills carry trustState off the loader;
+    // a plain skill is implicitly trusted.
+    trustState: typeof skill?.trustState === 'string' ? skill.trustState : null,
+    communityAuthor: typeof skill?.communityAuthor === 'string' ? skill.communityAuthor : null,
+    hash: lockRec ? lockRec.hash : null,
+    installed: lockRec ? lockRec.installed : null,
+    // Usage rollup (#5554 Phase 2). Null when never recorded.
+    lastUsed: usageRec && typeof usageRec.lastUsed === 'number' ? new Date(usageRec.lastUsed).toISOString() : null,
+    useCount: usageRec ? usageRec.count : 0,
+    usedRepos: usageRec && Array.isArray(usageRec.repos) ? usageRec.repos.slice() : [],
+  }
+  // A repo-local skill that shadows a global one of the same name overrides it.
+  if (entry.source === 'repo' && globalNames && globalNames.has(name)) {
+    entry.overridesGlobal = true
+  }
+  return entry
+}
+
+/**
+ * Scan ONE skills directory into inventory entries. Throws are the caller's to
+ * catch (it degrades the tier/repo with an error string).
+ *
+ * @param {object} ctx - { loadFn, readFn, usage }
+ * @param {string} dir - the skills directory.
+ * @param {'global'|'repo'} source
+ * @param {Set<string>|null} globalNames
+ * @returns {object[]} inventory entries (sorted by name).
+ */
+function scanDir(ctx, dir, source, globalNames) {
+  const { loadFn, readFn, usage } = ctx
+  // includeInactive + includeAllProviders → the full "browse all installed
+  // skills" view (#3226 path), so a manual or provider-scoped skill still shows
+  // in the inventory. Bodies are loaded by the loader but dropped in mapping.
+  const skills = loadFn(dir, { source, includeInactive: true, includeAllProviders: true })
+  const lock = readLockFor(readFn, dir)
+  const entries = (Array.isArray(skills) ? skills : []).map(
+    (s) => toInventoryEntry(s, lock, usage, globalNames),
+  )
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+  return entries
+}
+
+/** Run `tasks` with a concurrency cap, preserving order (sibling-survey helper). */
+async function mapWithCap(tasks, cap) {
+  const results = new Array(tasks.length)
+  let cursor = 0
+  const limit = Math.max(1, Math.min(cap, tasks.length || 1))
+  async function worker() {
+    while (cursor < tasks.length) {
+      const i = cursor++
+      results[i] = await tasks[i]()
+    }
+  }
+  const workers = []
+  for (let i = 0; i < limit; i++) workers.push(worker())
+  await Promise.all(workers)
+  return results
+}
+
+/** First line of a thrown error, for a per-tier/per-repo `error` string. */
+function failureReason(err) {
+  if (err && typeof err === 'object' && typeof err.message === 'string' && err.message.length > 0) {
+    return err.message
+  }
+  return 'unknown error'
+}
+
+/**
+ * Survey the skills inventory across the global tier and the resolved repo set.
+ *
+ * @param {Array<{ name: string, path: string }>} repoSet - from resolveRepoSet.
+ * @param {object} [opts]
+ * @param {string} [opts.globalDir] - the global skills dir (defaults to
+ *   `~/.chroxy/skills/`). Tests pass a temp dir.
+ * @param {string} [opts.root] - the discovery root the repo set was resolved
+ *   under (reported on the snapshot, same as the sibling surveys).
+ * @param {Map<string, { lastUsed, count, repos }>} [opts.usage] - per-skill
+ *   usage aggregates from the SkillsUsageRecorder.
+ * @param {number} [opts.concurrency]
+ * @param {Function} [opts._loadActiveSkills] - loader seam.
+ * @param {Function} [opts._readLock] - sync read seam for skills.lock.
+ * @param {Function} [opts._findRepoSkillsDir] - repo overlay resolver seam.
+ * @param {Function} [opts._now] - returns a `Date`.
+ * @returns {Promise<{ generatedAt: string, root: string, global: object[],
+ *   globalError: string|null, repos: object[] }>}
+ */
+export async function surveySkillsInventory(repoSet, opts = {}) {
+  const {
+    globalDir = DEFAULT_SKILLS_DIR,
+    root = '',
+    usage = null,
+    concurrency = DEFAULT_CONCURRENCY,
+    _loadActiveSkills = loadActiveSkills,
+    _readLock = (p) => readFileSync(p, 'utf8'),
+    _findRepoSkillsDir = findRepoSkillsDir,
+    _now = () => new Date(),
+  } = opts
+
+  const now = _now()
+  const repos = Array.isArray(repoSet) ? repoSet.filter((r) => r && typeof r.path === 'string') : []
+  const ctx = { loadFn: _loadActiveSkills, readFn: _readLock, usage }
+
+  // Global tier first — its names drive the per-repo `overridesGlobal` flag.
+  let globalEntries = []
+  let globalError = null
+  let globalNames = new Set()
+  try {
+    globalEntries = scanDir(ctx, globalDir, 'global', null)
+    globalNames = new Set(globalEntries.map((e) => e.name))
+  } catch (err) {
+    globalError = failureReason(err)
+  }
+
+  const tasks = repos.map((repo) => async () => {
+    let skillsDir = null
+    try {
+      // A repo's overlay lives at `<repo>/.chroxy/skills/`. findRepoSkillsDir
+      // walks up from the path; for a repo ROOT that resolves to the root's own
+      // overlay (or null when the repo has no `.chroxy/skills/`).
+      skillsDir = _findRepoSkillsDir(repo.path)
+    } catch {
+      skillsDir = null
+    }
+    if (!skillsDir) {
+      // Quiet "no overlay" row — absence is signal, not an error.
+      return { name: repo.name, path: repo.path, skills: [], error: null }
+    }
+    try {
+      const entries = scanDir(ctx, skillsDir, 'repo', globalNames)
+      return { name: repo.name, path: repo.path, skills: entries, error: null }
+    } catch (err) {
+      return { name: repo.name, path: repo.path, skills: [], error: failureReason(err) }
+    }
+  })
+
+  const surveyedRepos = await mapWithCap(tasks, concurrency)
+
+  return {
+    generatedAt: now.toISOString(),
+    root,
+    global: globalEntries,
+    globalError,
+    repos: surveyedRepos,
+  }
+}

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -35,6 +35,7 @@ import { resolveRepoSet, DEFAULT_CONTROL_ROOM_ROOT } from '../control-room/repo-
 import { surveyRepos } from '../control-room/survey.js'
 import { surveyRunners, DEFAULT_RUNNER_ROOT } from '../control-room/runners.js'
 import { surveyIntegrations, runRepoMemoryIndex, runRepoRelayRerun } from '../control-room/integrations.js'
+import { surveySkillsInventory } from '../control-room/skills-inventory.js'
 
 const log = createLogger('ws')
 
@@ -47,6 +48,8 @@ const inFlight = new WeakSet()
 const runnerInFlight = new WeakSet()
 // #5499: same again for the integrations survey — independent of both above.
 const integrationInFlight = new WeakSet()
+// #5554: same again for the skills inventory survey — independent of all above.
+const skillsInventoryInFlight = new WeakSet()
 
 /**
  * #5377 — shared builder for the survey error-snapshots. The error reply is a
@@ -325,6 +328,107 @@ async function handleIntegrationStatusRequest(ws, client, msg, ctx) {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// #5554 (epic #5159) — Skills inventory survey handler.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * #5554 — `skills_inventory_snapshot` error reply. The skills snapshot has a
+ * different shape from the host/runner/integration trio (global/repos tiers,
+ * no `summary`), so it gets its own degraded-snapshot builder rather than
+ * reusing `buildSurveyErrorSnapshot`. Same posture though: a schema-valid empty
+ * snapshot (empty global + repos, the real root, a fresh timestamp) plus an
+ * additive `error` the dashboard branches on, with the request's `requestId`
+ * echoed.
+ */
+function skillsInventoryErrorSnapshot(root, requestId, error) {
+  return {
+    type: 'skills_inventory_snapshot',
+    requestId,
+    generatedAt: new Date().toISOString(),
+    root,
+    global: [],
+    globalError: null,
+    repos: [],
+    error,
+  }
+}
+
+/**
+ * #5554 — Skills inventory survey handler. Same authority + in-flight +
+ * degraded-reply contract as the sibling surveys: the inventory exposes
+ * host-wide skill metadata (the global tier + every surveyed repo's overlay),
+ * so it is served only to host-level (unbound) clients, one survey per client
+ * at a time. The repo set is the same one the host survey resolves
+ * (config.repos ∪ auto-discovered under controlRoomRoot).
+ *
+ * Scan-on-request only — the global + per-repo overlay scans are NOT part of
+ * the periodic survey. SECURITY: skill BODIES never leave the server; the
+ * survey carries names / descriptions / metadata only (see
+ * control-room/skills-inventory.js).
+ */
+async function handleSkillsInventoryRequest(ws, client, msg, ctx) {
+  const requestId = typeof msg?.requestId === 'string' ? msg.requestId : null
+
+  const config = ctx?.config || {}
+  const root = typeof config.controlRoomRoot === 'string' && config.controlRoomRoot.length > 0
+    ? config.controlRoomRoot
+    : DEFAULT_CONTROL_ROOM_ROOT
+  const repos = Array.isArray(config.repos) ? config.repos : []
+
+  // Authority gate: a host-wide skills inventory is for host-level clients only.
+  if (client?.boundSessionId) {
+    ctx.send(ws, skillsInventoryErrorSnapshot(root, requestId, {
+      code: 'FORBIDDEN',
+      message: 'skills_inventory_request requires host-level authority (a session-bound token cannot survey the host)',
+    }))
+    return
+  }
+
+  if (skillsInventoryInFlight.has(client)) {
+    ctx.send(ws, skillsInventoryErrorSnapshot(root, requestId, {
+      code: 'SURVEY_IN_PROGRESS',
+      message: 'A skills inventory survey is already in progress for this client',
+    }))
+    return
+  }
+
+  // Tests inject `ctx.resolveRepoSet` / `ctx.surveySkillsInventory` to stub the
+  // fs scans without patching modules.
+  const resolveFn = typeof ctx?.resolveRepoSet === 'function' ? ctx.resolveRepoSet : resolveRepoSet
+  const surveyFn = typeof ctx?.surveySkillsInventory === 'function' ? ctx.surveySkillsInventory : surveySkillsInventory
+
+  // Per-skill usage aggregates from the recorder (when the daemon wired one).
+  // Absent → the inventory simply reports zeroed usage.
+  const recorder = ctx?.skillsUsageRecorder
+  const usage = recorder && typeof recorder.aggregatesByName === 'function'
+    ? recorder.aggregatesByName()
+    : null
+
+  skillsInventoryInFlight.add(client)
+  try {
+    const repoSet = resolveFn({ repos, root })
+    const snapshot = await surveyFn(repoSet, { root, usage })
+    ctx.send(ws, {
+      type: 'skills_inventory_snapshot',
+      requestId,
+      generatedAt: snapshot.generatedAt,
+      root: snapshot.root,
+      global: snapshot.global,
+      globalError: snapshot.globalError ?? null,
+      repos: snapshot.repos,
+    })
+  } catch (err) {
+    log.warn(`skills_inventory_request failed: ${err && err.message ? err.message : 'unknown error'}`)
+    ctx.send(ws, skillsInventoryErrorSnapshot(root, requestId, {
+      code: 'SURVEY_FAILED',
+      message: err && err.message ? err.message : 'skills inventory survey failed',
+    }))
+  } finally {
+    skillsInventoryInFlight.delete(client)
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // #5500/#5502 (epic #5498) — integration_action: repo-memory Reindex and
 // repo-relay Re-run
 // ───────────────────────────────────────────────────────────────────────────
@@ -595,5 +699,6 @@ export const controlRoomHandlers = {
   host_status_request: handleHostStatusRequest,
   runner_status_request: handleRunnerStatusRequest,
   integration_status_request: handleIntegrationStatusRequest,
+  skills_inventory_request: handleSkillsInventoryRequest,
   integration_action: handleIntegrationAction,
 }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import { randomBytes } from 'crypto'
 import { statSync, mkdirSync, rmSync } from 'fs'
-import { join, resolve } from 'path'
+import { join, resolve, dirname } from 'path'
 import { homedir } from 'os'
 import { execFileSync } from 'child_process'
 import { getProvider } from './providers.js'
@@ -16,6 +16,7 @@ import { CostBudgetManager } from './cost-budget-manager.js'
 import { SessionStatePersistence } from './session-state-persistence.js'
 import { SessionTimeoutManager, formatIdleDuration } from './session-timeout-manager.js'
 import { SessionMessageHistory } from './session-message-history.js'
+import { SkillsUsageRecorder } from './skills-usage.js'
 import { createLogger } from './logger.js'
 import { metrics } from './metrics.js'
 import {
@@ -250,6 +251,13 @@ export class SessionManager extends EventEmitter {
     stateTtlMs,
     persistDebounceMs = 2000,
 
+    // #5554: per-skill usage recorder. Records which skills activate in each
+    // session, powering the Control Room Skills tab's "previously used" surface.
+    // Tests pass their own (temp-pathed) recorder; production wires a default
+    // whose file sits next to the session-state file (so a temp stateFilePath
+    // keeps the usage log out of the real ~/.chroxy too).
+    skillsUsageRecorder,
+
     // Message history
     maxMessages,
     maxHistory,
@@ -387,6 +395,14 @@ export class SessionManager extends EventEmitter {
     this._stateFilePath = this._persistence._stateFilePath
     this._stateTtlMs = this._persistence._stateTtlMs
     this._persistDebounceMs = this._persistence._persistDebounceMs
+
+    // #5554: usage recorder. Use the caller-supplied one (tests pin a temp
+    // path), else default to a file alongside the session-state file so a temp
+    // stateFilePath also redirects the usage log away from the real home — the
+    // sandbox guard (#4633) then never fires from a SessionManager constructed
+    // with a temp stateFilePath.
+    this.skillsUsageRecorder = skillsUsageRecorder
+      || new SkillsUsageRecorder({ filePath: join(dirname(this._stateFilePath), 'skills-usage.json') })
     Object.defineProperty(this, '_persistTimer', {
       get: () => this._persistence._persistTimer,
       set: (v) => { this._persistence._persistTimer = v },
@@ -901,6 +917,25 @@ export class SessionManager extends EventEmitter {
 
     log.info(`Created session ${sessionId} "${sessionName}" (${this._sessions.size}/${this.maxSessions})`)
     this.emit('session_created', { sessionId, name: sessionName, cwd: resolvedCwd })
+
+    // #5554 Phase 2: record the skills that ACTIVATED for this fresh session.
+    // The narrowest reliable point — `session._skills` is the active set the
+    // loader actually injected into this session's prompt (provider-scoped,
+    // manual-activation-resolved), and the sessionId + repo (resolvedCwd) are
+    // now known. Skip restores (re-hydrating a session is not a new use) and
+    // guard everything so a usage-log failure can never break session creation.
+    if (!isRestore) {
+      try {
+        const activeSkills = Array.isArray(session?._skills)
+          ? session._skills.map(s => (s && typeof s.name === 'string' ? s.name : null)).filter(Boolean)
+          : []
+        if (activeSkills.length > 0) {
+          this.skillsUsageRecorder?.record({ sessionId, repo: resolvedCwd, skills: activeSkills })
+        }
+      } catch (err) {
+        log.debug(`skills-usage: failed to record activation for ${sessionId} (non-fatal): ${err && err.message ? err.message : err}`)
+      }
+    }
     // Flush synchronously — a new session must survive an abrupt shutdown,
     // otherwise rebuilds / crashes during the 2s debounce window lose it.
     // Exception: restoreState calls us in a loop and seeds history/budget
@@ -1295,6 +1330,8 @@ export class SessionManager extends EventEmitter {
     this._timeoutManager.destroy()
     this._history.clear()
     this._costBudget.clear()
+    // #5554: persist any pending usage records on shutdown (best-effort).
+    try { this.skillsUsageRecorder?.flush() } catch { /* non-fatal */ }
   }
 
   /**

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -1,0 +1,330 @@
+/**
+ * Skills usage log (#5554 Phase 2) — a bounded, server-side record of which
+ * skills have actually ACTIVATED in sessions, powering the Skills tab's
+ * "previously used" surface (last used, use count, which repos).
+ *
+ * Until now the only usage signal was the dashboard's client-only localStorage
+ * MRU of command IDs (store/commands.ts); the server tracked skill TRUST events
+ * (`skill_changed` / `skill_trust_*`) but never skill USE. This module closes
+ * that gap with a small persistent log.
+ *
+ * On-disk shape (~/.chroxy/skills-usage.json, mode 0600):
+ *
+ *   {
+ *     "version": 1,
+ *     "entries": [                      // ring buffer, newest LAST, bounded
+ *       { "skill": "batch-merge", "sessionId": "ab…", "repo": "/p/chroxy", "ts": 1718000000000 },
+ *       …
+ *     ],
+ *     "aggregates": {                   // per-skill rollup, kept in sync on record
+ *       "batch-merge": { "count": 12, "lastUsed": 1718000000000, "repos": ["/p/chroxy", "/p/foo"] }
+ *     }
+ *   }
+ *
+ * Bounding (pruned like the Discord webhook state):
+ *   - `entries` is capped at MAX_ENTRIES (default 500); the oldest are dropped
+ *     when the cap is exceeded.
+ *   - `aggregates` is the durable rollup so per-skill count / lastUsed / repos
+ *     survive even after a skill's individual entries age out of the ring. Its
+ *     per-skill `repos` list is capped at MAX_REPOS_PER_SKILL so a skill used
+ *     across a huge number of repos can't grow an entry unbounded.
+ *   - `aggregates` itself is capped at MAX_SKILLS distinct skills (least-
+ *     recently-used eviction) so a churn of one-off skill names can't grow the
+ *     file without limit.
+ *
+ * Atomic writes: temp + rename + cleanup-on-failure, mirroring
+ * `notification-prefs.js` / `byok-mcp-trust.js`. A single process owns the file
+ * so no mutex is needed, but rename failures still clean up the .tmp file.
+ *
+ * SECURITY: this store records only skill NAMES, the session id, the repo path,
+ * and a timestamp — never any skill body. The Skills-tab snapshot surfaces the
+ * aggregates (count / lastUsed / repos); the raw entries never cross the wire.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, chmodSync, unlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { createLogger } from './logger.js'
+
+const log = createLogger('skills-usage')
+
+/** Default on-disk location for the usage log. */
+export function defaultSkillsUsagePath() {
+  return join(homedir(), '.chroxy', 'skills-usage.json')
+}
+
+/** Ring-buffer cap on the raw entries kept on disk. */
+export const MAX_ENTRIES = 500
+/** Cap on distinct skills tracked in the durable aggregates rollup. */
+export const MAX_SKILLS = 1000
+/** Cap on distinct repos remembered per skill in the aggregates. */
+export const MAX_REPOS_PER_SKILL = 25
+
+/**
+ * A fresh, empty store object.
+ * @returns {{ version: number, entries: object[], aggregates: object }}
+ */
+function emptyStore() {
+  return { version: 1, entries: [], aggregates: {} }
+}
+
+/**
+ * Coerce an arbitrary parsed JSON value into a well-formed store. Tolerant —
+ * a corrupt/partial file degrades to whatever fields are usable rather than
+ * throwing (a usage log is best-effort telemetry, never load-bearing).
+ *
+ * @param {unknown} parsed
+ * @returns {{ version: number, entries: object[], aggregates: object }}
+ */
+function normalizeStore(parsed) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return emptyStore()
+  const out = emptyStore()
+  if (Array.isArray(parsed.entries)) {
+    for (const e of parsed.entries) {
+      const norm = normalizeEntry(e)
+      if (norm) out.entries.push(norm)
+    }
+  }
+  if (parsed.aggregates && typeof parsed.aggregates === 'object' && !Array.isArray(parsed.aggregates)) {
+    for (const [skill, agg] of Object.entries(parsed.aggregates)) {
+      const norm = normalizeAggregate(agg)
+      if (typeof skill === 'string' && skill.length > 0 && norm) out.aggregates[skill] = norm
+    }
+  }
+  return out
+}
+
+/** Validate + coerce one raw entry; returns null when unusable. */
+function normalizeEntry(e) {
+  if (!e || typeof e !== 'object') return null
+  const skill = typeof e.skill === 'string' && e.skill.length > 0 ? e.skill : null
+  const ts = typeof e.ts === 'number' && Number.isFinite(e.ts) && e.ts > 0 ? e.ts : null
+  if (!skill || !ts) return null
+  return {
+    skill,
+    sessionId: typeof e.sessionId === 'string' && e.sessionId.length > 0 ? e.sessionId : null,
+    repo: typeof e.repo === 'string' && e.repo.length > 0 ? e.repo : null,
+    ts,
+  }
+}
+
+/** Validate + coerce one aggregate; returns null when unusable. */
+function normalizeAggregate(agg) {
+  if (!agg || typeof agg !== 'object') return null
+  const count = typeof agg.count === 'number' && Number.isFinite(agg.count) && agg.count >= 0
+    ? Math.trunc(agg.count)
+    : 0
+  const lastUsed = typeof agg.lastUsed === 'number' && Number.isFinite(agg.lastUsed) && agg.lastUsed > 0
+    ? agg.lastUsed
+    : null
+  const repos = []
+  if (Array.isArray(agg.repos)) {
+    for (const r of agg.repos) {
+      if (typeof r === 'string' && r.length > 0 && !repos.includes(r)) repos.push(r)
+      if (repos.length >= MAX_REPOS_PER_SKILL) break
+    }
+  }
+  return { count, lastUsed, repos }
+}
+
+/**
+ * Load the usage store from disk. Missing file → empty store; unparseable file
+ * → empty store with a debug log (never throws — best-effort telemetry).
+ *
+ * @param {string} [filePath]
+ * @returns {{ version: number, entries: object[], aggregates: object }}
+ */
+export function loadUsageStore(filePath = defaultSkillsUsagePath()) {
+  if (!existsSync(filePath)) return emptyStore()
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8'))
+    return normalizeStore(parsed)
+  } catch (err) {
+    log.debug(`skills-usage: failed to parse ${filePath} — starting empty: ${err && err.message ? err.message : err}`)
+    return emptyStore()
+  }
+}
+
+/**
+ * Persist a store object to disk. Atomic temp+rename so a crashed write cannot
+ * corrupt the file; on POSIX the file ends up at mode 0600. Mirrors
+ * `notification-prefs.js` savePrefs (the #4463 cleanup pattern).
+ *
+ * @param {object} store
+ * @param {string} [filePath]
+ */
+export function saveUsageStore(store, filePath = defaultSkillsUsagePath()) {
+  const dir = dirname(filePath)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const tmp = `${filePath}.tmp`
+  writeFileSync(tmp, JSON.stringify(store, null, 2), { mode: 0o600 })
+  try { chmodSync(tmp, 0o600) } catch { /* best-effort perms */ }
+  try {
+    renameSync(tmp, filePath)
+  } catch (err) {
+    try { unlinkSync(tmp) } catch { /* cleanup race — swallow */ }
+    throw err
+  }
+}
+
+/**
+ * Apply one usage record to an in-memory store, enforcing all bounds. Pure —
+ * mutates and returns the passed store so callers can batch multiple records
+ * before a single save.
+ *
+ * @param {object} store - a normalized store (see {@link loadUsageStore}).
+ * @param {{ skill: string, sessionId?: string|null, repo?: string|null, ts?: number }} record
+ * @returns {object} the same store, mutated.
+ */
+export function applyUsage(store, record) {
+  const skill = record && typeof record.skill === 'string' && record.skill.length > 0 ? record.skill : null
+  if (!skill) return store
+  const ts = typeof record.ts === 'number' && Number.isFinite(record.ts) && record.ts > 0 ? record.ts : Date.now()
+  const sessionId = typeof record.sessionId === 'string' && record.sessionId.length > 0 ? record.sessionId : null
+  const repo = typeof record.repo === 'string' && record.repo.length > 0 ? record.repo : null
+
+  // 1. Append to the ring buffer, then prune the oldest past the cap.
+  store.entries.push({ skill, sessionId, repo, ts })
+  if (store.entries.length > MAX_ENTRIES) {
+    store.entries.splice(0, store.entries.length - MAX_ENTRIES)
+  }
+
+  // 2. Update the durable per-skill aggregate.
+  let agg = store.aggregates[skill]
+  if (!agg) agg = store.aggregates[skill] = { count: 0, lastUsed: null, repos: [] }
+  agg.count += 1
+  // lastUsed only advances — an out-of-order (older) record never rolls it back.
+  if (agg.lastUsed === null || ts > agg.lastUsed) agg.lastUsed = ts
+  if (repo && !agg.repos.includes(repo)) {
+    agg.repos.push(repo)
+    if (agg.repos.length > MAX_REPOS_PER_SKILL) {
+      // Drop the oldest-remembered repo (front of the list) past the cap.
+      agg.repos.splice(0, agg.repos.length - MAX_REPOS_PER_SKILL)
+    }
+  }
+
+  // 3. Cap distinct tracked skills — evict the least-recently-used aggregate(s).
+  const skillNames = Object.keys(store.aggregates)
+  if (skillNames.length > MAX_SKILLS) {
+    skillNames
+      .sort((a, b) => (store.aggregates[a].lastUsed ?? 0) - (store.aggregates[b].lastUsed ?? 0))
+      .slice(0, skillNames.length - MAX_SKILLS)
+      .forEach((name) => { delete store.aggregates[name] })
+  }
+
+  return store
+}
+
+/**
+ * SkillsUsageRecorder — load-once, record-many, debounced-save wrapper around
+ * the on-disk store. One instance is created per daemon (by SessionManager) and
+ * its `record` callback is handed to each session at creation time.
+ *
+ * Saves are debounced (DEFAULT_SAVE_DEBOUNCE_MS) so a burst of activations on
+ * session creation collapses into a single write. A best-effort synchronous
+ * `flush()` lets the daemon persist on shutdown.
+ */
+export const DEFAULT_SAVE_DEBOUNCE_MS = 1000
+
+export class SkillsUsageRecorder {
+  /**
+   * @param {{ filePath?: string, saveDebounceMs?: number, now?: () => number,
+   *   _load?: typeof loadUsageStore, _save?: typeof saveUsageStore }} [opts]
+   */
+  constructor(opts = {}) {
+    this._filePath = typeof opts.filePath === 'string' && opts.filePath.length > 0
+      ? opts.filePath
+      : defaultSkillsUsagePath()
+    this._saveDebounceMs = Number.isFinite(opts.saveDebounceMs) && opts.saveDebounceMs >= 0
+      ? opts.saveDebounceMs
+      : DEFAULT_SAVE_DEBOUNCE_MS
+    this._now = typeof opts.now === 'function' ? opts.now : () => Date.now()
+    this._load = typeof opts._load === 'function' ? opts._load : loadUsageStore
+    this._save = typeof opts._save === 'function' ? opts._save : saveUsageStore
+    this._store = this._load(this._filePath)
+    this._saveTimer = null
+    this._dirty = false
+  }
+
+  /**
+   * Record one or more skill activations for a session. `skills` is an array of
+   * skill names (the active set the session loaded). Repo + sessionId are shared
+   * across the batch. Never throws — a usage-log failure must never break
+   * session creation.
+   *
+   * @param {{ sessionId?: string|null, repo?: string|null, skills: string[], ts?: number }} batch
+   */
+  record(batch) {
+    try {
+      const skills = Array.isArray(batch?.skills) ? batch.skills : []
+      if (skills.length === 0) return
+      const ts = typeof batch?.ts === 'number' && Number.isFinite(batch.ts) ? batch.ts : this._now()
+      const sessionId = batch?.sessionId ?? null
+      const repo = batch?.repo ?? null
+      let changed = false
+      const seen = new Set()
+      for (const skill of skills) {
+        if (typeof skill !== 'string' || skill.length === 0) continue
+        // De-dupe within a single activation batch — one session loading the
+        // same skill name twice (global + repo overlay collapsed) is one use.
+        if (seen.has(skill)) continue
+        seen.add(skill)
+        applyUsage(this._store, { skill, sessionId, repo, ts })
+        changed = true
+      }
+      if (changed) this._scheduleSave()
+    } catch (err) {
+      log.debug(`skills-usage: record failed (non-fatal): ${err && err.message ? err.message : err}`)
+    }
+  }
+
+  /**
+   * Per-skill aggregate snapshot for the inventory join. Returns a Map keyed by
+   * skill name → { lastUsed, count, repos } (a copy, so callers can't mutate
+   * the live store).
+   *
+   * @returns {Map<string, { lastUsed: number|null, count: number, repos: string[] }>}
+   */
+  aggregatesByName() {
+    const out = new Map()
+    for (const [name, agg] of Object.entries(this._store.aggregates)) {
+      out.set(name, {
+        lastUsed: agg.lastUsed ?? null,
+        count: agg.count ?? 0,
+        repos: Array.isArray(agg.repos) ? agg.repos.slice() : [],
+      })
+    }
+    return out
+  }
+
+  /** Schedule a debounced save; coalesces a burst into one write. */
+  _scheduleSave() {
+    this._dirty = true
+    if (this._saveDebounceMs === 0) {
+      this.flush()
+      return
+    }
+    if (this._saveTimer) return
+    this._saveTimer = setTimeout(() => {
+      this._saveTimer = null
+      this.flush()
+    }, this._saveDebounceMs)
+    // Don't keep the event loop alive for a pending usage flush.
+    if (this._saveTimer && typeof this._saveTimer.unref === 'function') this._saveTimer.unref()
+  }
+
+  /** Persist synchronously if dirty. Best-effort — never throws to callers. */
+  flush() {
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer)
+      this._saveTimer = null
+    }
+    if (!this._dirty) return
+    try {
+      this._save(this._store, this._filePath)
+      this._dirty = false
+    } catch (err) {
+      log.warn(`skills-usage: save failed: ${err && err.message ? err.message : err}`)
+    }
+  }
+}

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -402,6 +402,7 @@ function _isSecureRequest(req) {
  *   { type: 'runner_status_snapshot', requestId?, generatedAt, root, summary, repos, error? } — Control Room self-hosted runner survey reply (#5253 schema + emitter); reply to a `runner_status_request`. Same degraded-snapshot-with-`error` posture as `host_status_snapshot`: always the full shape; on failure `repos` is empty, `summary` is zeroed, and an additive `error: { code, message }` is present. `requestId` echoes the request when provided.
  *   { type: 'integration_status_snapshot', requestId?, generatedAt, root, summary, repos, repoMemoryCli?, error? } — Control Room Integrations survey reply (#5499 schema + emitter, epic #5498); reply to an `integration_status_request`. Per-repo repo-memory status (config, cache stats, telemetry report); `repoMemoryCli` notes the once-per-snapshot binary probe. Same degraded-snapshot-with-`error` posture as the host/runner surveys. `requestId` echoes the request when provided.
  *   { type: 'integration_action_ack', action, repoPath, requestId?, counts } — Control Room Integrations action ack (#5500, epic #5498); reply to a successful `integration_action` (currently `repo_memory_reindex`). Echoes `action`/`repoPath` (+ `requestId` when provided) cloning the cancel_activity_ack correlation contract; `counts` carries the parsed scanned/summarized/fresh/skipped index result, or null when the CLI output was unparseable. Failures surface as an INTEGRATION_ACTION_FAILED `session_error` echoing the same correlation fields.
+ *   { type: 'skills_inventory_snapshot', requestId?, generatedAt, root, global, globalError?, repos, error? } — Control Room Skills inventory survey reply (#5554 schema + emitter, epic #5159); reply to a `skills_inventory_request`. `global` is the `~/.chroxy/skills/` tier and `repos` the per-repo `.chroxy/skills/` overlays, each entry carrying name/description/activation/trust/hash/installed + usage (lastUsed/count/repos). Skill BODIES never leave the server. Same degraded-snapshot-with-`error` posture as the host/runner/integration surveys; `globalError` / per-repo `error` degrade a single tier without blanking the snapshot. `requestId` echoes the request when provided.
  *   { type: 'summarize_session_result', sessionId, summary, truncated?, requestId? } — reply to a `summarize_session` (#5547); the model-written continuation brief built from the session's persisted history, seeded editable into the dashboard's create-session composer. `truncated` flags a windowed history. Failures surface as a SUMMARIZE_FAILED `session_error` echoing `sessionId`/`requestId` (curated message — no token/key material).
  *   { type: 'provider_list', providers }                — available providers
  *   { type: 'byok_credentials_status', requestId?, status, source, masked?, reason? } — BYOK credentials state for the dashboard (#4052)
@@ -648,6 +649,10 @@ export class WsServer {
       get sessionManager() { return self.sessionManager },
       get cliSession() { return self.cliSession },
       get pushManager() { return self.pushManager },
+      // #5554: the per-skill usage recorder lives on the SessionManager (it
+      // records activations at session creation); the Skills inventory handler
+      // reads its aggregates to join lastUsed / count / repos onto the snapshot.
+      get skillsUsageRecorder() { return self.sessionManager?.skillsUsageRecorder ?? null },
       // #5510: pairing-approval primitive — host-level approve/deny handlers.
       get pairingManager() { return self._pairingManager },
       resolvePairRequester: (requestId, result) => self._resolvePairRequester(requestId, result),

--- a/packages/server/tests/skills-inventory-handler.test.js
+++ b/packages/server/tests/skills-inventory-handler.test.js
@@ -1,0 +1,174 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { controlRoomHandlers } from '../src/handlers/control-room-handlers.js'
+import { registeredMessageTypes } from '../src/ws-message-handlers.js'
+import { createSpy, createMockSessionManager } from './test-helpers.js'
+import { ServerSkillsInventorySnapshotSchema } from '@chroxy/protocol'
+
+/**
+ * #5554 — tests for the Control Room Skills inventory WS handler.
+ *
+ * The survey itself (control-room/skills-inventory.js) is injected via
+ * `ctx.surveySkillsInventory` so the handler test never touches the real
+ * filesystem or the user's home directory.
+ */
+
+const SAMPLE_SNAPSHOT = {
+  generatedAt: '2026-06-11T00:00:00.000Z',
+  root: '/home/user/Projects',
+  global: [
+    {
+      name: 'batch-merge', description: 'Merge PRs in a batch', source: 'global',
+      activation: 'auto', active: true, providers: [], version: null,
+      trustState: null, communityAuthor: null, hash: '0a76684', installed: '2026-06-03',
+      lastUsed: '2026-06-10T00:00:00.000Z', useCount: 12, usedRepos: ['/home/user/Projects/chroxy'],
+    },
+  ],
+  globalError: null,
+  repos: [
+    {
+      name: 'chroxy', path: '/home/user/Projects/chroxy',
+      skills: [
+        {
+          name: 'coding-style', description: 'Repo coding style', source: 'repo',
+          activation: 'auto', active: true, providers: [], version: null,
+          trustState: null, communityAuthor: null, hash: null, installed: null,
+          overridesGlobal: false, lastUsed: null, useCount: 0, usedRepos: [],
+        },
+      ],
+      error: null,
+    },
+  ],
+}
+
+function makeCtx(overrides = {}) {
+  const sendSpy = createSpy()
+  const { manager } = createMockSessionManager([
+    { id: 'sess-1', name: 'Work', cwd: '/home/user/Projects/chroxy' },
+  ])
+  return {
+    send: sendSpy,
+    sessionManager: manager,
+    config: { repos: [], controlRoomRoot: '/home/user/Projects' },
+    surveySkillsInventory: createSpy(async () => SAMPLE_SNAPSHOT),
+    resolveRepoSet: createSpy(() => SAMPLE_SNAPSHOT.repos.map(r => ({ name: r.name, path: r.path }))),
+    ...overrides,
+    _send: sendSpy,
+  }
+}
+
+describe('skills_inventory_request handler (#5554)', () => {
+  let ctx, client, ws
+
+  beforeEach(() => {
+    ctx = makeCtx()
+    client = { id: 'client-A' }
+    ws = {}
+  })
+
+  it('is registered in the WS handler registry', () => {
+    assert.ok(
+      registeredMessageTypes.includes('skills_inventory_request'),
+      'skills_inventory_request should be in registeredMessageTypes',
+    )
+    assert.equal(typeof controlRoomHandlers.skills_inventory_request, 'function')
+  })
+
+  it('replies with a schema-conformant skills_inventory_snapshot', async () => {
+    const handler = controlRoomHandlers.skills_inventory_request
+    await handler(ws, client, { type: 'skills_inventory_request', requestId: 'r1' }, ctx)
+
+    assert.equal(ctx._send.callCount, 1)
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.type, 'skills_inventory_snapshot')
+    assert.equal(payload.requestId, 'r1')
+
+    const { requestId, ...rest } = payload
+    void requestId
+    const parsed = ServerSkillsInventorySnapshotSchema.safeParse(rest)
+    assert.ok(parsed.success, `snapshot should be schema-valid: ${JSON.stringify(parsed.error?.issues)}`)
+    assert.equal(payload.root, SAMPLE_SNAPSHOT.root)
+    assert.equal(payload.global.length, 1)
+    assert.equal(payload.repos.length, 1)
+    assert.equal(payload.repos[0].skills[0].name, 'coding-style')
+  })
+
+  it('resolves the repo set from config.repos and controlRoomRoot', async () => {
+    ctx = makeCtx({ config: { repos: [{ path: '/x', name: 'x' }], controlRoomRoot: '/root' } })
+    const handler = controlRoomHandlers.skills_inventory_request
+    await handler(ws, client, { type: 'skills_inventory_request' }, ctx)
+
+    assert.equal(ctx.resolveRepoSet.callCount, 1)
+    const [arg] = ctx.resolveRepoSet.lastCall
+    assert.deepEqual(arg.repos, [{ path: '/x', name: 'x' }])
+    assert.equal(arg.root, '/root')
+  })
+
+  it('joins usage aggregates from the recorder', async () => {
+    const aggregates = new Map([['batch-merge', { lastUsed: 123, count: 4, repos: ['/r'] }]])
+    ctx = makeCtx({
+      skillsUsageRecorder: { aggregatesByName: () => aggregates },
+    })
+    const handler = controlRoomHandlers.skills_inventory_request
+    await handler(ws, client, { type: 'skills_inventory_request' }, ctx)
+
+    assert.equal(ctx.surveySkillsInventory.callCount, 1)
+    const [, opts] = ctx.surveySkillsInventory.lastCall
+    assert.strictEqual(opts.usage, aggregates, 'recorder aggregates should be passed to the survey')
+  })
+
+  it('passes null usage when no recorder is wired', async () => {
+    const handler = controlRoomHandlers.skills_inventory_request
+    await handler(ws, client, { type: 'skills_inventory_request' }, ctx)
+    const [, opts] = ctx.surveySkillsInventory.lastCall
+    assert.equal(opts.usage, null)
+  })
+
+  it('rejects a session-bound client with a schema-valid FORBIDDEN snapshot', async () => {
+    client.boundSessionId = 'sess-1'
+    const handler = controlRoomHandlers.skills_inventory_request
+    await handler(ws, client, { type: 'skills_inventory_request', requestId: 'rf' }, ctx)
+
+    assert.equal(ctx.surveySkillsInventory.callCount, 0, 'survey must not run for a bound client')
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.type, 'skills_inventory_snapshot')
+    assert.equal(payload.error.code, 'FORBIDDEN')
+    assert.equal(payload.requestId, 'rf')
+    assert.deepEqual(payload.global, [])
+    assert.deepEqual(payload.repos, [])
+    const { requestId, ...rest } = payload
+    void requestId
+    assert.ok(ServerSkillsInventorySnapshotSchema.safeParse(rest).success, 'FORBIDDEN reply must be a valid snapshot')
+  })
+
+  it('rejects an overlapping in-flight survey with SURVEY_IN_PROGRESS', async () => {
+    // A survey that never settles pins the in-flight guard for this client.
+    let release
+    const gate = new Promise((res) => { release = res })
+    ctx = makeCtx({ surveySkillsInventory: createSpy(() => gate.then(() => SAMPLE_SNAPSHOT)) })
+    const handler = controlRoomHandlers.skills_inventory_request
+
+    const first = handler(ws, client, { type: 'skills_inventory_request' }, ctx)
+    // Second request lands while the first is still in flight.
+    await handler(ws, client, { type: 'skills_inventory_request' }, ctx)
+
+    const rejected = ctx._send.lastCall
+    assert.equal(rejected[1].error.code, 'SURVEY_IN_PROGRESS')
+
+    release()
+    await first
+  })
+
+  it('degrades a thrown survey to a SURVEY_FAILED snapshot', async () => {
+    ctx = makeCtx({ surveySkillsInventory: createSpy(async () => { throw new Error('boom') }) })
+    const handler = controlRoomHandlers.skills_inventory_request
+    await handler(ws, client, { type: 'skills_inventory_request' }, ctx)
+
+    const [, payload] = ctx._send.lastCall
+    assert.equal(payload.error.code, 'SURVEY_FAILED')
+    assert.equal(payload.error.message, 'boom')
+    const { requestId, ...rest } = payload
+    void requestId
+    assert.ok(ServerSkillsInventorySnapshotSchema.safeParse(rest).success)
+  })
+})

--- a/packages/server/tests/skills-inventory-survey.test.js
+++ b/packages/server/tests/skills-inventory-survey.test.js
@@ -1,0 +1,225 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  surveySkillsInventory,
+  parseSkillsLock,
+  lockPathForSkillsDir,
+  toInventoryEntry,
+} from '../src/control-room/skills-inventory.js'
+
+/**
+ * #5554 — tests for the Skills inventory survey (control-room/skills-inventory.js).
+ *
+ * All filesystem access is injected (`_loadActiveSkills` / `_readLock` /
+ * `_findRepoSkillsDir`) so the survey never touches the real disk or the user's
+ * home directory.
+ */
+
+/** A loader descriptor like loadActiveSkills returns (body present, dropped on map). */
+function loaderSkill(name, extra = {}) {
+  return {
+    name,
+    description: `desc for ${name}`,
+    body: 'SECRET BODY — must never leave the server',
+    metadata: null,
+    source: extra.source || 'global',
+    active: extra.active !== false,
+    path: `/real/${name}.md`,
+    ...extra,
+  }
+}
+
+describe('parseSkillsLock', () => {
+  it('parses the registry lock shape into a name → { hash, installed } map', () => {
+    const lock = parseSkillsLock(JSON.stringify({
+      registry: 'blamechris/skill-templates',
+      skills: {
+        'batch-merge': { hash: '0a76684', installed: '2026-06-03' },
+        'bug-hunt': { hash: 'ebdb14e', installed: '2026-06-02' },
+      },
+    }))
+    assert.equal(lock.get('batch-merge').hash, '0a76684')
+    assert.equal(lock.get('batch-merge').installed, '2026-06-03')
+    assert.equal(lock.get('bug-hunt').hash, 'ebdb14e')
+  })
+
+  it('degrades a missing / unparseable / wrong-shape lock to an empty map', () => {
+    assert.equal(parseSkillsLock(null).size, 0)
+    assert.equal(parseSkillsLock('not json').size, 0)
+    assert.equal(parseSkillsLock(JSON.stringify([1, 2, 3])).size, 0)
+    assert.equal(parseSkillsLock(JSON.stringify({ skills: 'oops' })).size, 0)
+  })
+})
+
+describe('lockPathForSkillsDir', () => {
+  it('pairs the lock as a sibling of the skills dir', () => {
+    assert.equal(lockPathForSkillsDir('/home/u/.chroxy/skills'), '/home/u/.chroxy/skills.lock')
+    assert.equal(lockPathForSkillsDir('/repo/.chroxy/skills'), '/repo/.chroxy/skills.lock')
+  })
+})
+
+describe('toInventoryEntry', () => {
+  it('drops the body + absolute path and joins lock + usage', () => {
+    const lock = new Map([['batch-merge', { hash: 'abc1234', installed: '2026-06-03' }]])
+    const usage = new Map([['batch-merge', { lastUsed: Date.parse('2026-06-10T00:00:00.000Z'), count: 7, repos: ['/p/chroxy'] }]])
+    const entry = toInventoryEntry(loaderSkill('batch-merge'), lock, usage, null)
+
+    assert.equal(entry.name, 'batch-merge')
+    assert.equal(entry.description, 'desc for batch-merge')
+    assert.ok(!('body' in entry), 'body must never appear on a wire entry')
+    assert.ok(!('path' in entry), 'absolute path must never appear on a wire entry')
+    assert.equal(entry.hash, 'abc1234')
+    assert.equal(entry.installed, '2026-06-03')
+    assert.equal(entry.lastUsed, '2026-06-10T00:00:00.000Z')
+    assert.equal(entry.useCount, 7)
+    assert.deepEqual(entry.usedRepos, ['/p/chroxy'])
+  })
+
+  it('reports null hash/installed + zeroed usage when the joins miss', () => {
+    const entry = toInventoryEntry(loaderSkill('lonely'), new Map(), new Map(), null)
+    assert.equal(entry.hash, null)
+    assert.equal(entry.installed, null)
+    assert.equal(entry.lastUsed, null)
+    assert.equal(entry.useCount, 0)
+    assert.deepEqual(entry.usedRepos, [])
+  })
+
+  it('derives activation + providers from frontmatter and flags overrides', () => {
+    const skill = loaderSkill('coding-style', {
+      source: 'repo',
+      metadata: { activation: 'manual', providers: ['claude-sdk'], version: '2' },
+      active: false,
+    })
+    const globalNames = new Set(['coding-style'])
+    const entry = toInventoryEntry(skill, new Map(), new Map(), globalNames)
+    assert.equal(entry.activation, 'manual')
+    assert.equal(entry.active, false)
+    assert.deepEqual(entry.providers, ['claude-sdk'])
+    assert.equal(entry.version, '2')
+    assert.equal(entry.overridesGlobal, true)
+  })
+
+  it('carries community trust state through', () => {
+    const skill = loaderSkill('shared', { trustState: 'pending', communityAuthor: 'alice' })
+    const entry = toInventoryEntry(skill, new Map(), new Map(), null)
+    assert.equal(entry.trustState, 'pending')
+    assert.equal(entry.communityAuthor, 'alice')
+  })
+})
+
+describe('surveySkillsInventory', () => {
+  function makeSeams(byDir) {
+    return {
+      _loadActiveSkills: (dir, opts) => {
+        // Assert the inventory always asks for the full browse-all view.
+        assert.equal(opts.includeInactive, true)
+        assert.equal(opts.includeAllProviders, true)
+        return (byDir[dir] || []).map((s) => ({ ...s, source: opts.source }))
+      },
+      _readLock: (lockPath) => {
+        const text = byDir[`__lock__${lockPath}`]
+        if (text === undefined) throw new Error('ENOENT')
+        return text
+      },
+      _findRepoSkillsDir: (repoPath) => byDir[`__repodir__${repoPath}`] ?? null,
+      _now: () => new Date('2026-06-11T00:00:00.000Z'),
+    }
+  }
+
+  it('scans global + per-repo overlays and flags repo overrides of global', async () => {
+    const globalDir = '/g/skills'
+    const repoDir = '/repo/.chroxy/skills'
+    const seams = makeSeams({
+      [globalDir]: [loaderSkill('batch-merge'), loaderSkill('coding-style')],
+      [repoDir]: [loaderSkill('coding-style'), loaderSkill('repo-only')],
+      '__repodir__/repo': repoDir,
+    })
+    const result = await surveySkillsInventory([{ name: 'repo', path: '/repo' }], {
+      globalDir, root: '/root', ...seams,
+    })
+
+    assert.equal(result.generatedAt, '2026-06-11T00:00:00.000Z')
+    assert.equal(result.root, '/root')
+    assert.equal(result.globalError, null)
+    assert.deepEqual(result.global.map((e) => e.name), ['batch-merge', 'coding-style'])
+
+    const repo = result.repos[0]
+    assert.equal(repo.error, null)
+    // Sorted by name; coding-style overrides the global of the same name.
+    const codingStyle = repo.skills.find((s) => s.name === 'coding-style')
+    const repoOnly = repo.skills.find((s) => s.name === 'repo-only')
+    assert.equal(codingStyle.overridesGlobal, true, 'repo skill shadowing a global one is an override')
+    assert.ok(!repoOnly.overridesGlobal, 'a repo-only skill is not an override')
+  })
+
+  it('reports a quiet empty overlay (no error) when a repo has no .chroxy/skills/', async () => {
+    const seams = makeSeams({ '/g/skills': [] }) // no __repodir__ entry → findRepoSkillsDir returns null
+    const result = await surveySkillsInventory([{ name: 'bare', path: '/bare' }], {
+      globalDir: '/g/skills', root: '/root', ...seams,
+    })
+    assert.deepEqual(result.repos[0].skills, [])
+    assert.equal(result.repos[0].error, null)
+  })
+
+  it('degrades a per-repo scan failure to an error chip, never a dead snapshot', async () => {
+    const repoDir = '/repo/.chroxy/skills'
+    const seams = {
+      _loadActiveSkills: (dir) => {
+        if (dir === repoDir) throw new Error('overlay blew up')
+        return []
+      },
+      _readLock: () => { throw new Error('ENOENT') },
+      _findRepoSkillsDir: () => repoDir,
+      _now: () => new Date('2026-06-11T00:00:00.000Z'),
+    }
+    const result = await surveySkillsInventory([{ name: 'repo', path: '/repo' }], {
+      globalDir: '/g/skills', root: '/root', ...seams,
+    })
+    // Global tier survived; the repo card carries the error.
+    assert.equal(result.globalError, null)
+    assert.deepEqual(result.global, [])
+    assert.equal(result.repos[0].error, 'overlay blew up')
+    assert.deepEqual(result.repos[0].skills, [])
+  })
+
+  it('degrades a global-tier scan failure to globalError without blanking repos', async () => {
+    const repoDir = '/repo/.chroxy/skills'
+    const seams = {
+      _loadActiveSkills: (dir, opts) => {
+        if (dir === '/g/skills') throw new Error('global blew up')
+        return (dir === repoDir ? [loaderSkill('repo-only', { source: opts.source })] : [])
+      },
+      _readLock: () => { throw new Error('ENOENT') },
+      _findRepoSkillsDir: () => repoDir,
+      _now: () => new Date('2026-06-11T00:00:00.000Z'),
+    }
+    const result = await surveySkillsInventory([{ name: 'repo', path: '/repo' }], {
+      globalDir: '/g/skills', root: '/root', ...seams,
+    })
+    assert.equal(result.globalError, 'global blew up')
+    assert.deepEqual(result.global, [])
+    assert.equal(result.repos[0].skills[0].name, 'repo-only')
+  })
+
+  it('joins the skills.lock paired with each scanned dir', async () => {
+    const globalDir = '/g/skills'
+    const lockPath = lockPathForSkillsDir(globalDir) // /g/skills.lock
+    const seams = makeSeams({
+      [globalDir]: [loaderSkill('batch-merge')],
+      [`__lock__${lockPath}`]: JSON.stringify({ skills: { 'batch-merge': { hash: 'deadbee', installed: '2026-06-03' } } }),
+    })
+    const result = await surveySkillsInventory([], { globalDir, root: '/root', ...seams })
+    assert.equal(result.global[0].hash, 'deadbee')
+    assert.equal(result.global[0].installed, '2026-06-03')
+  })
+
+  it('joins usage aggregates onto the entries', async () => {
+    const globalDir = '/g/skills'
+    const usage = new Map([['batch-merge', { lastUsed: Date.parse('2026-06-09T00:00:00.000Z'), count: 3, repos: ['/p'] }]])
+    const seams = makeSeams({ [globalDir]: [loaderSkill('batch-merge')] })
+    const result = await surveySkillsInventory([], { globalDir, root: '/root', usage, ...seams })
+    assert.equal(result.global[0].useCount, 3)
+    assert.equal(result.global[0].lastUsed, '2026-06-09T00:00:00.000Z')
+    assert.deepEqual(result.global[0].usedRepos, ['/p'])
+  })
+})

--- a/packages/server/tests/skills-usage.test.js
+++ b/packages/server/tests/skills-usage.test.js
@@ -1,0 +1,199 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  applyUsage,
+  loadUsageStore,
+  saveUsageStore,
+  SkillsUsageRecorder,
+  MAX_ENTRIES,
+  MAX_REPOS_PER_SKILL,
+  MAX_SKILLS,
+} from '../src/skills-usage.js'
+
+/**
+ * #5554 Phase 2 — tests for the bounded, atomic skills usage log
+ * (skills-usage.js). All disk access targets a temp dir — the real
+ * ~/.chroxy/skills-usage.json is never touched (the #4633 sandbox guard would
+ * throw otherwise).
+ */
+
+describe('applyUsage (bounding + aggregates)', () => {
+  it('appends an entry and updates the per-skill aggregate', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: 'batch-merge', sessionId: 's1', repo: '/p/a', ts: 1000 })
+    applyUsage(store, { skill: 'batch-merge', sessionId: 's2', repo: '/p/b', ts: 2000 })
+
+    assert.equal(store.entries.length, 2)
+    const agg = store.aggregates['batch-merge']
+    assert.equal(agg.count, 2)
+    assert.equal(agg.lastUsed, 2000)
+    assert.deepEqual(agg.repos, ['/p/a', '/p/b'])
+  })
+
+  it('lastUsed only advances — an out-of-order older record never rolls it back', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: 'x', ts: 5000 })
+    applyUsage(store, { skill: 'x', ts: 3000 })
+    assert.equal(store.aggregates['x'].lastUsed, 5000)
+    assert.equal(store.aggregates['x'].count, 2)
+  })
+
+  it('bounds the ring buffer at MAX_ENTRIES (oldest dropped)', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    for (let i = 0; i < MAX_ENTRIES + 50; i++) {
+      applyUsage(store, { skill: `s${i}`, ts: i + 1 })
+    }
+    assert.equal(store.entries.length, MAX_ENTRIES)
+    // The oldest 50 are gone; the first surviving entry is s50.
+    assert.equal(store.entries[0].skill, 's50')
+  })
+
+  it('caps the per-skill repos list at MAX_REPOS_PER_SKILL', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    for (let i = 0; i < MAX_REPOS_PER_SKILL + 10; i++) {
+      applyUsage(store, { skill: 'busy', repo: `/p/${i}`, ts: i + 1 })
+    }
+    assert.equal(store.aggregates['busy'].repos.length, MAX_REPOS_PER_SKILL)
+    // count still reflects every activation, even past the repo cap.
+    assert.equal(store.aggregates['busy'].count, MAX_REPOS_PER_SKILL + 10)
+  })
+
+  it('caps distinct tracked skills at MAX_SKILLS, evicting least-recently-used', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    // Seed MAX_SKILLS skills with ascending lastUsed.
+    for (let i = 0; i < MAX_SKILLS; i++) {
+      applyUsage(store, { skill: `s${i}`, ts: i + 1 })
+    }
+    assert.equal(Object.keys(store.aggregates).length, MAX_SKILLS)
+    // One more distinct skill (newest) should evict the oldest (s0).
+    applyUsage(store, { skill: 'newest', ts: MAX_SKILLS + 1000 })
+    assert.equal(Object.keys(store.aggregates).length, MAX_SKILLS)
+    assert.ok(!('s0' in store.aggregates), 'least-recently-used skill should be evicted')
+    assert.ok('newest' in store.aggregates)
+  })
+
+  it('ignores a record with no skill name', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: '', ts: 1 })
+    applyUsage(store, { ts: 1 })
+    assert.equal(store.entries.length, 0)
+    assert.equal(Object.keys(store.aggregates).length, 0)
+  })
+})
+
+describe('loadUsageStore / saveUsageStore (atomic, temp paths only)', () => {
+  let tmpDir, filePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-skills-usage-'))
+    filePath = join(tmpDir, 'nested', 'skills-usage.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns an empty store for a missing file', () => {
+    const store = loadUsageStore(filePath)
+    assert.deepEqual(store, { version: 1, entries: [], aggregates: {} })
+  })
+
+  it('round-trips a store through save → load (creating parent dirs)', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: 'batch-merge', sessionId: 's1', repo: '/p/a', ts: 1000 })
+    saveUsageStore(store, filePath)
+
+    assert.ok(existsSync(filePath))
+    const loaded = loadUsageStore(filePath)
+    assert.equal(loaded.entries.length, 1)
+    assert.equal(loaded.aggregates['batch-merge'].count, 1)
+  })
+
+  it('leaves no .tmp file behind after a successful write', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: 'x', ts: 1 })
+    saveUsageStore(store, filePath)
+    const dir = join(tmpDir, 'nested')
+    const leftover = readdirSync(dir).filter((f) => f.endsWith('.tmp'))
+    assert.deepEqual(leftover, [], 'no .tmp file should remain after an atomic write')
+  })
+
+  it('degrades a corrupt file to an empty store rather than throwing', () => {
+    writeFileSync(filePath.replace('/nested/', '/'), 'not json at all')
+    const store = loadUsageStore(filePath.replace('/nested/', '/'))
+    assert.deepEqual(store, { version: 1, entries: [], aggregates: {} })
+  })
+})
+
+describe('SkillsUsageRecorder', () => {
+  let tmpDir, filePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-skills-rec-'))
+    filePath = join(tmpDir, 'skills-usage.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('records a batch of skills, de-dupes within the batch, and flushes to disk', () => {
+    const rec = new SkillsUsageRecorder({ filePath, saveDebounceMs: 0, now: () => 4242 })
+    rec.record({ sessionId: 'sess', repo: '/p/chroxy', skills: ['a', 'b', 'a'] })
+
+    const agg = rec.aggregatesByName()
+    assert.equal(agg.get('a').count, 1, 'a duplicated skill in one batch counts once')
+    assert.equal(agg.get('b').count, 1)
+    assert.equal(agg.get('a').lastUsed, 4242)
+    assert.deepEqual(agg.get('a').repos, ['/p/chroxy'])
+
+    // saveDebounceMs:0 flushes synchronously.
+    const loaded = loadUsageStore(filePath)
+    assert.equal(loaded.aggregates['a'].count, 1)
+  })
+
+  it('aggregatesByName returns copies that cannot mutate the live store', () => {
+    const rec = new SkillsUsageRecorder({ filePath, saveDebounceMs: 0 })
+    rec.record({ sessionId: 's', repo: '/p', skills: ['a'] })
+    const agg = rec.aggregatesByName()
+    agg.get('a').repos.push('/evil')
+    assert.deepEqual(rec.aggregatesByName().get('a').repos, ['/p'], 'live store must be insulated from caller mutation')
+  })
+
+  it('ignores an empty skills batch (no write)', () => {
+    const rec = new SkillsUsageRecorder({ filePath, saveDebounceMs: 0 })
+    rec.record({ sessionId: 's', repo: '/p', skills: [] })
+    assert.ok(!existsSync(filePath), 'an empty batch should not create the file')
+  })
+
+  it('record never throws even when the underlying save fails', () => {
+    const rec = new SkillsUsageRecorder({
+      filePath,
+      saveDebounceMs: 0,
+      _save: () => { throw new Error('disk full') },
+    })
+    // Must not throw — a usage-log failure can never break session creation.
+    assert.doesNotThrow(() => rec.record({ sessionId: 's', repo: '/p', skills: ['a'] }))
+  })
+
+  it('flush persists pending debounced records', () => {
+    const rec = new SkillsUsageRecorder({ filePath, saveDebounceMs: 10_000 })
+    rec.record({ sessionId: 's', repo: '/p', skills: ['a'] })
+    assert.ok(!existsSync(filePath), 'debounced write should not have landed yet')
+    rec.flush()
+    assert.ok(existsSync(filePath))
+    assert.equal(loadUsageStore(filePath).aggregates['a'].count, 1)
+  })
+
+  it('survives a daemon restart (load existing → continue counting)', () => {
+    const rec1 = new SkillsUsageRecorder({ filePath, saveDebounceMs: 0 })
+    rec1.record({ sessionId: 's1', repo: '/p', skills: ['a'] })
+
+    const rec2 = new SkillsUsageRecorder({ filePath, saveDebounceMs: 0 })
+    rec2.record({ sessionId: 's2', repo: '/p', skills: ['a'] })
+    assert.equal(rec2.aggregatesByName().get('a').count, 2, 'count should accumulate across restarts')
+  })
+})


### PR DESCRIPTION
## Summary

Adds a fifth Control Room tab, **Skills**, surfacing an inventory of installed chroxy skills with descriptions, trust state, content hashes, install dates, and a server-side usage log powering "previously used". Implements **Phase 1 (inventory)** and **Phase 2 (usage history)** of #5554. Phase 3 (`.claude/commands` listing) is **deferred — out of scope**.

The tab follows the Integrations request/snapshot pattern end-to-end: protocol schema → server handler (host-level authority, scan-on-request) → store triple → panel. Adding it through the new #5557 tab registry was one `CONTROL_ROOM_TABS` descriptor entry + a panel + the store triple it references.

## Design

**Inventory source (no re-implemented parsing).** `control-room/skills-inventory.js` reuses the `skills-loader` browse-all path (`loadActiveSkills(dir, { includeInactive: true, includeAllProviders: true })`) for both the global `~/.chroxy/skills/` tier and each surveyed repo's `.chroxy/skills/` overlay (resolved via the loader's own `findRepoSkillsDir`). Each loader descriptor is mapped through `toInventoryEntry`, which **drops the `body` and the absolute `path`** before anything crosses the wire — names/descriptions/metadata only (the #5554 security boundary). It joins the paired `skills.lock` (sibling of the skills dir, same `{ skills: { name: { hash, installed } } }` shape the registry writes) for hash + install date, and the usage aggregates for last-used/count/repos. A repo-local skill shadowing a global one of the same name is flagged `overridesGlobal` (the loader's repo-wins precedence).

**Scan-on-request only.** The overlay scans are NOT part of the periodic survey — they run only in reply to a `skills_inventory_request`, mirroring the Integrations survey's pull-on-Refresh cadence.

**Degradation.** A per-repo overlay scan failure degrades to an `error` string on that repo's card; the global tier degrades to a top-level `globalError`; neither blanks the snapshot. The handler's authority/in-flight/SURVEY_FAILED envelope mirrors the host/runner/integration trio exactly.

**Activation hook point (usage log).** The narrowest reliable point is `SessionManager.createSession`, right after the session is registered and started: at that moment `session._skills` is the active set the loader *actually injected* into this session's prompt (provider-scoped, manual-activation-resolved), and the real `sessionId` + repo (`resolvedCwd`) are known. Restores are skipped (re-hydrating is not a new use), and the whole block is guarded so a usage-log failure can never break session creation. This beats hooking inside `SkillsManager.loadSkills()` (which lacks the stable sessionId) or a periodic scan (which can't attribute a use to a session/repo).

**Usage-store bounds.** `skills-usage.js` persists to `~/.chroxy/skills-usage.json` with atomic temp+rename (the `notification-prefs.js`/#4463 pattern). Bounds: ring buffer of the last **500** entries (oldest dropped); durable per-skill aggregates so count/lastUsed/repos survive after entries age out; per-skill `repos` capped at **25**; distinct tracked skills capped at **1000** with least-recently-used eviction. `lastUsed` only advances (an out-of-order older record never rolls it back). Writes are debounced and flushed on `destroyAll`. The recorder's file sits next to the session-state file, so a temp `stateFilePath` keeps tests (and the #4633 sandbox guard) out of the real `~/.chroxy`.

**Dashboard.** One `CONTROL_ROOM_TABS` descriptor (`survey: true`, `snapshotKey: skillsInventory` / `loadingKey: skillsInventoryLoading` / `requestKey: requestSkillsInventory` / `requestType: skills_inventory_request`), the store triple, a `skills_inventory_snapshot` message-handler case, and the `SkillsInventorySection` panel: a Global card + one card per repo overlay, with manual/inactive/overrides-global/trust-pending flags, default sort = recently used, and an expandable description per row. The #5546 staleness guard + auto-fetch-on-activation come free via the registry.

## Test plan

- **Server** (temp paths only; `_setup.mjs` sandbox guard; `--test-force-exit`):
  - `skills-usage.test.js` — applyUsage aggregates, lastUsed-only-advances, ring-buffer/repos/skills bounding + LRU eviction, atomic round-trip (no `.tmp` leak), corrupt-file degradation, recorder de-dupe/flush/never-throws/restart-accumulation.
  - `skills-inventory-survey.test.js` — snapshot shape, `skills.lock` join, usage join, overlay-precedence `overridesGlobal` matching skills-loader, body/path never leak, per-repo + global-tier degradation.
  - `skills-inventory-handler.test.js` — registration, schema-conformant snapshot, repo-set resolution, usage join, authority rejection (FORBIDDEN), SURVEY_IN_PROGRESS, SURVEY_FAILED.
  - Protocol suite (282/282 incl. handler-coverage + dist-freshness); `ws-schema-coverage` (new handler ↔ client schema); `control-room-handlers`, `session-manager`, `skills-manager`, `base-session` suites green (no regressions).
  - All `packages/server/scripts/lint-*.sh` pass; `eslint src/` 0 errors.
- **Dashboard**: `SkillsInventorySection.test.tsx` (16 tests); full `vitest run` 3500/3500 green; `tsc --noEmit` clean; `vite build` succeeds.

Closes #5554