### PR TITLE
perf(server): sessionId→clients reverse index for broadcast + subscriber counts (#5563)

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -366,7 +366,14 @@ export function broadcastFocusChanged(client, sessionId, ctx) {
 export function autoSubscribeOtherClients(sessionId, excludeWs, ctx) {
   for (const [clientWs, c] of ctx.clients) {
     if (c.authenticated && clientWs !== excludeWs) {
-      c.subscribedSessionIds.add(sessionId)
+      // #5563: route through the index-maintaining helper so the
+      // sessionId→clients reverse index stays in sync. Falls back to a bare
+      // add for fixtures whose ctx predates the helper.
+      if (typeof ctx.subscribeClient === 'function') {
+        ctx.subscribeClient(c, sessionId)
+      } else {
+        c.subscribedSessionIds.add(sessionId)
+      }
     }
   }
 }

--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -78,7 +78,9 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
       cwd: checkpoint.cwd,
       name: `Rewind: ${checkpoint.name}`,
     })
-    client.activeSessionId = newSessionId
+    // #5563: index-maintaining helper. Checkpoint restore moves the active
+    // session WITHOUT subscribing, so the index must follow activeSessionId.
+    ctx.setActiveSession(client, newSessionId)
     const newEntry = ctx.sessionManager.getSession(newSessionId)
     ctx.send(ws, {
       type: 'checkpoint_restored',

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -94,8 +94,9 @@ async function handleResumeConversation(ws, client, msg, ctx) {
       cwd: cwd || undefined,
       name,
     })
-    client.activeSessionId = sessionId
-    client.subscribedSessionIds.add(sessionId)
+    // #5563: index-maintaining helpers.
+    ctx.setActiveSession(client, sessionId)
+    ctx.subscribeClient(client, sessionId)
     const entry = ctx.sessionManager.getSession(sessionId)
     ctx.send(ws, { type: 'session_switched', sessionId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
     ctx.sendSessionInfo(ws, sessionId)

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -48,8 +48,10 @@ function handleSwitchSession(ws, client, msg, ctx) {
     sendSessionError(ws, ctx, `Session not found: ${targetId}`)
     return
   }
-  client.activeSessionId = targetId
-  client.subscribedSessionIds.add(targetId)
+  // #5563: route active-session + subscription through the index-maintaining
+  // helpers so the sessionId→clients reverse index stays in sync.
+  ctx.setActiveSession(client, targetId)
+  ctx.subscribeClient(client, targetId)
   // #4835: persist the chosen session for this device so the next reconnect
   // restores it instead of snapping back to defaultSessionId. Bound
   // clients are excluded — their activeSessionId is locked to
@@ -151,8 +153,9 @@ function handleCreateSession(ws, client, msg, ctx) {
 
   try {
     const sessionId = ctx.sessionManager.createSession({ name, cwd, provider, model, permissionMode, worktree, sandbox, skipPermissions, ...envOpts })
-    client.activeSessionId = sessionId
-    client.subscribedSessionIds.add(sessionId)
+    // #5563: index-maintaining helpers.
+    ctx.setActiveSession(client, sessionId)
+    ctx.subscribeClient(client, sessionId)
     const entry = ctx.sessionManager.getSession(sessionId)
     ctx.send(ws, { type: 'session_switched', sessionId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
     ctx.sendSessionInfo(ws, sessionId)
@@ -207,9 +210,11 @@ async function handleDestroySession(ws, client, msg, ctx) {
 
   const firstId = ctx.sessionManager.firstSessionId
   for (const [clientWs, c] of ctx.clients) {
-    c.subscribedSessionIds?.delete(targetId)
+    // #5563: index-maintaining helpers — unsubscribe every client from the
+    // destroyed session, and re-home any client that was actively viewing it.
+    ctx.unsubscribeClient(c, targetId)
     if (c.authenticated && c.activeSessionId === targetId) {
-      c.activeSessionId = firstId
+      ctx.setActiveSession(c, firstId)
       const entry = ctx.sessionManager.getSession(firstId)
       if (entry) {
         ctx.send(clientWs, { type: 'session_switched', sessionId: firstId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
@@ -272,7 +277,8 @@ function handleSubscribeSessions(ws, client, msg, ctx) {
       if (!client.subscribedSessionIds.has(sid)) {
         newlySubscribed.push(sid)
       }
-      client.subscribedSessionIds.add(sid)
+      // #5563: index-maintaining helper.
+      ctx.subscribeClient(client, sid)
     }
   }
   ctx.send(ws, {
@@ -288,7 +294,10 @@ function handleSubscribeSessions(ws, client, msg, ctx) {
 function handleUnsubscribeSessions(ws, client, msg, ctx) {
   for (const sid of msg.sessionIds) {
     if (sid !== client.activeSessionId) {
-      client.subscribedSessionIds.delete(sid)
+      // #5563: index-maintaining helper. (The guard keeps the active session
+      // subscribed; the helper would also keep it indexed via activeSessionId,
+      // but preserving the explicit subscription matches prior behaviour.)
+      ctx.unsubscribeClient(client, sid)
     }
   }
   ctx.send(ws, {

--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -18,15 +18,27 @@ const log = createLogger('ws')
  * @param {object} opts
  * @param {Map} opts.clients             ws → client Map (shared reference with WsServer)
  * @param {function} opts.sendFn         (ws, message) => void — handles encryption, seq, etc.
+ * @param {object} [opts.clientManager]  WsClientManager owning the sessionId→clients reverse
+ *                                        index (#5563). When present, session-scoped broadcasts
+ *                                        and subscriber counts iterate the index Set instead of
+ *                                        scanning every client. Optional so unit-test fixtures
+ *                                        that construct WsBroadcaster with a bare `clients` Map
+ *                                        keep working via the full-scan fallback.
  * @param {number} [opts.backpressureThreshold]  bytes; skip send when bufferedAmount exceeds this
  * @param {number} [opts.backpressureMaxDrops]   close connection after this many consecutive drops
  */
 export class WsBroadcaster {
-  constructor({ clients, sendFn, backpressureThreshold, backpressureMaxDrops } = {}) {
+  constructor({ clients, clientManager, sendFn, backpressureThreshold, backpressureMaxDrops } = {}) {
     this._clients = clients
+    this._clientManager = clientManager ?? null
     this._sendFn = sendFn
     this._backpressureThreshold = backpressureThreshold ?? 1024 * 1024
     this._backpressureMaxDrops = backpressureMaxDrops ?? 10
+    // #5563 drift defense: set CHROXY_WS_INDEX_ASSERT=1 to verify, before every
+    // session broadcast, that the reverse index matches a full scan. OFF by
+    // default — checked once here, not per-broadcast, so the hot path stays a
+    // single boolean test. Intended for staging / reproduction, never prod.
+    this._assertIndexIntegrity = process.env.CHROXY_WS_INDEX_ASSERT === '1'
   }
 
   /** Public broadcast: send a message to all authenticated clients */
@@ -122,18 +134,51 @@ export class WsBroadcaster {
    * encounter an authenticated client without the Set, log a one-shot
    * warning to surface the real bug — the broadcast itself stays alive.
    */
-  _broadcastToSession(sessionId, message, filter = (client) => {
-    if (client.activeSessionId === sessionId) return true
-    if (client.subscribedSessionIds) return client.subscribedSessionIds.has(sessionId)
-    if (client.authenticated && !client._missingSubscribedSessionIdsWarned) {
-      log.warn(`Client ${client.id} is authenticated but has no subscribedSessionIds Set — falling back to activeSessionId match only (sessionId=${sessionId}, messageType=${message?.type || 'unknown'})`)
-      client._missingSubscribedSessionIdsWarned = true
-    }
-    return false
-  }) {
+  _broadcastToSession(sessionId, message, filter) {
     const tagged = { ...message, sessionId }
+
+    if (this._assertIndexIntegrity && this._clientManager) {
+      // Throws on drift, naming the offending session/client — surfaces the
+      // mutation site that bypassed a helper. Gated; off in prod.
+      this._clientManager.verifyIndexIntegrity()
+    }
+
+    // #5563 fast path: iterate the reverse index (clients active-or-subscribed
+    // to this session) instead of scanning every client. Only taken when no
+    // custom filter is supplied — a caller-provided filter overrides the
+    // default recipient selection entirely, so it may match clients that are
+    // NOT in the index (e.g. a broadcast to everyone), which the index can't
+    // serve. The remaining per-member conditions (authenticated, readyState)
+    // are still applied to each index member; index membership exactly equals
+    // the default filter's `activeSessionId === sessionId ||
+    // subscribedSessionIds.has(sessionId)` predicate by construction, so this
+    // path delivers to the identical recipient set the full scan would.
+    if (!filter && this._clientManager) {
+      // The index stores `client`; the send needs its `ws` for readyState +
+      // backpressure. Each client carries a stable `_ws` back-reference set at
+      // registration (ws-server.js addClient), so no per-send Map lookup is
+      // needed. The index Set holds only this session's viewers.
+      for (const client of this._clientManager.getSessionSubscribers(sessionId)) {
+        if (!client.authenticated) continue
+        const sock = client._ws
+        if (!sock || sock.readyState !== 1) continue
+        this._sendOneWithBackpressure(sock, client, tagged)
+      }
+      return
+    }
+
+    // Full-scan fallback: no index (test fixtures) or a custom filter.
+    const effectiveFilter = filter || ((client) => {
+      if (client.activeSessionId === sessionId) return true
+      if (client.subscribedSessionIds) return client.subscribedSessionIds.has(sessionId)
+      if (client.authenticated && !client._missingSubscribedSessionIdsWarned) {
+        log.warn(`Client ${client.id} is authenticated but has no subscribedSessionIds Set — falling back to activeSessionId match only (sessionId=${sessionId}, messageType=${message?.type || 'unknown'})`)
+        client._missingSubscribedSessionIdsWarned = true
+      }
+      return false
+    })
     for (const [ws, client] of this._clients) {
-      if (client.authenticated && filter(client) && ws.readyState === 1) {
+      if (client.authenticated && effectiveFilter(client) && ws.readyState === 1) {
         this._sendOneWithBackpressure(ws, client, tagged)
       }
     }
@@ -150,6 +195,24 @@ export class WsBroadcaster {
    * @returns {number}
    */
   _countSessionSubscribers(sessionId) {
+    // #5563 hot path: this runs once per buffered delta (per token) from
+    // EventNormalizer's coalescing-window heuristic (ws-server.js), so the old
+    // full-clients scan multiplied broadcast cost by delta frequency. Iterate
+    // only the reverse-index Set — its members already satisfy `activeSessionId
+    // === sessionId || subscribedSessionIds.has(sessionId)`, leaving just the
+    // per-member authenticated + readyState checks (cost ∝ subscribers, not
+    // total clients).
+    if (this._clientManager) {
+      let count = 0
+      for (const client of this._clientManager.getSessionSubscribers(sessionId)) {
+        if (!client.authenticated) continue
+        const sock = client._ws
+        if (!sock || sock.readyState !== 1) continue
+        count++
+      }
+      return count
+    }
+    // Full-scan fallback for fixtures constructed without a clientManager.
     let count = 0
     for (const [ws, client] of this._clients) {
       if (!client.authenticated || ws.readyState !== 1) continue

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -1,5 +1,10 @@
 import { EventEmitter } from 'node:events'
 
+// #5563: shared frozen empty Set returned by getSessionSubscribers when a
+// session has no indexed clients — avoids allocating per call on the hot path.
+// Frozen so a misbehaving caller can't mutate the shared singleton.
+const EMPTY_SET = Object.freeze(new Set())
+
 /**
  * Manages WebSocket client connections lifecycle.
  *
@@ -17,10 +22,128 @@ export class WsClientManager extends EventEmitter {
     super()
     /** @type {Map<WebSocket, object>} */
     this.clients = new Map()
+    // #5563: reverse index sessionId → Set<client> for O(subscribers) session
+    // broadcasts and O(1) subscriber counts, instead of an O(clients) scan per
+    // session-scoped message + a SECOND scan per buffered delta. A client is a
+    // member of the index for `sessionId` iff it would match
+    // `_broadcastToSession`'s default recipient filter: `activeSessionId ===
+    // sessionId` OR `subscribedSessionIds.has(sessionId)`. Both conditions
+    // change independently (e.g. checkpoint restore moves activeSessionId
+    // without subscribing; subscribe_sessions adds to the Set without touching
+    // activeSessionId), so the index tracks the UNION. Every mutation point for
+    // either condition MUST route through this class's helpers
+    // (subscribe / unsubscribe / setActiveSession / removeClient) so the index
+    // can never drift from the per-client Sets. The remaining per-member filter
+    // conditions (authenticated, readyState, bound checks) are still applied by
+    // the broadcaster per index member — the index only covers the
+    // active-or-subscribed predicate.
+    /** @type {Map<string, Set<object>>} sessionId → Set<client> */
+    this._sessionIndex = new Map()
   }
 
   /**
-   * Register a new client connection.
+   * Add `client` to the reverse index under `sessionId`. Idempotent: a Set
+   * dedups, so re-subscribing or active==subscribed never double-counts.
+   * @param {object} client
+   * @param {string} sessionId
+   * @private
+   */
+  _indexAdd(client, sessionId) {
+    if (!sessionId) return
+    let set = this._sessionIndex.get(sessionId)
+    if (!set) {
+      set = new Set()
+      this._sessionIndex.set(sessionId, set)
+    }
+    set.add(client)
+  }
+
+  /**
+   * Remove `client` from the index under `sessionId` ONLY if it no longer
+   * matches either index condition (active or subscribed). Called after a
+   * condition is cleared; the other condition may still hold (e.g. a client
+   * unsubscribes from a session it is still actively viewing — it must stay
+   * in the index). Empty sets are pruned to keep the map from leaking
+   * sessionId keys for destroyed sessions.
+   * @param {object} client
+   * @param {string} sessionId
+   * @private
+   */
+  _indexRemoveIfUnreferenced(client, sessionId) {
+    if (!sessionId) return
+    if (client.activeSessionId === sessionId) return
+    if (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId)) return
+    const set = this._sessionIndex.get(sessionId)
+    if (!set) return
+    set.delete(client)
+    if (set.size === 0) this._sessionIndex.delete(sessionId)
+  }
+
+  /**
+   * Subscribe `client` to `sessionId`: add to its `subscribedSessionIds` Set
+   * AND the reverse index, atomically. The single sanctioned way to add a
+   * subscription — direct `client.subscribedSessionIds.add()` would drift the
+   * index. Idempotent.
+   * @param {object} client
+   * @param {string} sessionId
+   */
+  subscribe(client, sessionId) {
+    if (!sessionId) return
+    if (!client.subscribedSessionIds) client.subscribedSessionIds = new Set()
+    client.subscribedSessionIds.add(sessionId)
+    this._indexAdd(client, sessionId)
+  }
+
+  /**
+   * Unsubscribe `client` from `sessionId`: remove from its
+   * `subscribedSessionIds` Set, then drop it from the index unless it is still
+   * the client's active session. The single sanctioned way to remove a
+   * subscription.
+   * @param {object} client
+   * @param {string} sessionId
+   */
+  unsubscribe(client, sessionId) {
+    if (!sessionId) return
+    client.subscribedSessionIds?.delete(sessionId)
+    this._indexRemoveIfUnreferenced(client, sessionId)
+  }
+
+  /**
+   * Move `client.activeSessionId` to `sessionId` (or null), keeping the index
+   * in sync for BOTH the old and new active session. The single sanctioned way
+   * to change a client's active session — a bare `client.activeSessionId = x`
+   * would drift the index. The previous active session is dropped from the
+   * index only if the client is not also subscribed to it.
+   * @param {object} client
+   * @param {string|null} sessionId
+   */
+  setActiveSession(client, sessionId) {
+    const prev = client.activeSessionId
+    if (prev === sessionId) return
+    client.activeSessionId = sessionId
+    // Re-evaluate the old session: it leaves the index only if no longer
+    // referenced (i.e. the client is not subscribed to it).
+    if (prev) this._indexRemoveIfUnreferenced(client, prev)
+    // The new active session always belongs in the index.
+    if (sessionId) this._indexAdd(client, sessionId)
+  }
+
+  /**
+   * Return the Set of clients indexed for `sessionId` (active or subscribed).
+   * The returned Set is the live index Set — callers MUST NOT mutate it, and
+   * MUST still apply the remaining per-member filter (authenticated /
+   * readyState / bound). Returns an empty Set when no clients are indexed.
+   * @param {string} sessionId
+   * @returns {Set<object>}
+   */
+  getSessionSubscribers(sessionId) {
+    return this._sessionIndex.get(sessionId) || EMPTY_SET
+  }
+
+  /**
+   * Register a new client connection. A fresh client has `activeSessionId:
+   * null` and an empty `subscribedSessionIds`, so it contributes no index
+   * entries until it subscribes or switches via the helpers above.
    * @param {WebSocket} ws
    * @param {object} clientInfo - Initial client state
    * @returns {object} the stored client info
@@ -31,7 +154,9 @@ export class WsClientManager extends EventEmitter {
   }
 
   /**
-   * Remove a client connection.
+   * Remove a client connection. Purges the client from EVERY index Set it
+   * belonged to (the disconnect / terminate mutation point) so a departed
+   * client can never linger as a phantom broadcast recipient.
    * If the client was authenticated, emits 'client_departed'.
    * @param {WebSocket} ws
    * @returns {object|undefined} the removed client info, or undefined
@@ -40,10 +165,74 @@ export class WsClientManager extends EventEmitter {
     const client = this.clients.get(ws)
     if (!client) return undefined
     this.clients.delete(ws)
+    this._purgeFromIndex(client)
     if (client.authenticated) {
       this.emit('client_departed', { client })
     }
     return client
+  }
+
+  /**
+   * Drop `client` from every index Set, pruning emptied sessionId keys.
+   * @param {object} client
+   * @private
+   */
+  _purgeFromIndex(client) {
+    for (const [sessionId, set] of this._sessionIndex) {
+      if (set.delete(client) && set.size === 0) {
+        this._sessionIndex.delete(sessionId)
+      }
+    }
+  }
+
+  /**
+   * #5563 drift defense: assert the reverse index exactly matches a full scan
+   * of every client's (activeSessionId ∪ subscribedSessionIds). Cheap O(clients
+   * × sessions) — intended for tests and the optional `CHROXY_WS_INDEX_ASSERT`
+   * debug flag, NOT the hot path. Throws on any drift with a description of the
+   * first mismatch so the offending mutation site is obvious.
+   * @throws {Error} on drift
+   */
+  verifyIndexIntegrity() {
+    // Build the oracle: sessionId → Set<client> from per-client state.
+    const oracle = new Map()
+    const add = (sid, client) => {
+      if (!sid) return
+      let s = oracle.get(sid)
+      if (!s) { s = new Set(); oracle.set(sid, s) }
+      s.add(client)
+    }
+    for (const client of this.clients.values()) {
+      add(client.activeSessionId, client)
+      if (client.subscribedSessionIds) {
+        for (const sid of client.subscribedSessionIds) add(sid, client)
+      }
+    }
+    // Every oracle entry must be present (and identical) in the index.
+    for (const [sid, expected] of oracle) {
+      const actual = this._sessionIndex.get(sid)
+      if (!actual) {
+        throw new Error(`ws index drift: session ${sid} missing from index (oracle has ${expected.size} client(s))`)
+      }
+      for (const client of expected) {
+        if (!actual.has(client)) {
+          throw new Error(`ws index drift: client ${client.id} missing from index for session ${sid}`)
+        }
+      }
+      if (actual.size !== expected.size) {
+        throw new Error(`ws index drift: session ${sid} has ${actual.size} indexed client(s), oracle expects ${expected.size} (stale member)`)
+      }
+    }
+    // No index entry may exist that the oracle doesn't account for (stale keys
+    // / stale members on sessions with no oracle entry).
+    for (const [sid, actual] of this._sessionIndex) {
+      if (actual.size === 0) {
+        throw new Error(`ws index drift: session ${sid} has an empty (unpruned) Set in the index`)
+      }
+      if (!oracle.has(sid)) {
+        throw new Error(`ws index drift: session ${sid} present in index but no client references it`)
+      }
+    }
   }
 
   /**

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -1,9 +1,19 @@
 import { EventEmitter } from 'node:events'
 
-// #5563: shared frozen empty Set returned by getSessionSubscribers when a
+// #5563: shared immutable empty Set returned by getSessionSubscribers when a
 // session has no indexed clients — avoids allocating per call on the hot path.
-// Frozen so a misbehaving caller can't mutate the shared singleton.
-const EMPTY_SET = Object.freeze(new Set())
+// `Object.freeze` does NOT stop `.add()`/`.delete()` on a Set's contents, so we
+// also override the mutators to throw: an accidental write to the shared
+// singleton fails loudly instead of silently leaking a phantom subscriber into
+// every empty-session lookup.
+const EMPTY_SET = (() => {
+  const s = new Set()
+  const fail = () => { throw new Error('getSessionSubscribers() returned the shared empty Set — it must not be mutated') }
+  s.add = fail
+  s.delete = fail
+  s.clear = fail
+  return Object.freeze(s)
+})()
 
 /**
  * Manages WebSocket client connections lifecycle.
@@ -144,11 +154,18 @@ export class WsClientManager extends EventEmitter {
    * Register a new client connection. A fresh client has `activeSessionId:
    * null` and an empty `subscribedSessionIds`, so it contributes no index
    * entries until it subscribes or switches via the helpers above.
+   *
+   * Centralizes the `_ws` back-reference invariant (#5563): the reverse-index
+   * fast path resolves each indexed client's socket via `client._ws`, so a
+   * client registered without it would be silently skipped by session
+   * broadcasts/counts. `addClient` already receives `ws`, so it backfills
+   * `clientInfo._ws` when missing — call sites need not remember to set it.
    * @param {WebSocket} ws
    * @param {object} clientInfo - Initial client state
    * @returns {object} the stored client info
    */
   addClient(ws, clientInfo) {
+    if (clientInfo && clientInfo._ws == null) clientInfo._ws = ws
     this.clients.set(ws, clientInfo)
     return clientInfo
   }

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -344,7 +344,14 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
       }
     }
 
-    client.activeSessionId = activeId
+    // #5563: route through the index-maintaining helper so the post-auth
+    // restore keeps the sessionId→clients reverse index in sync. Falls back to
+    // a bare assignment for test fixtures whose ctx predates the helper.
+    if (typeof ctx.setActiveSession === 'function') {
+      ctx.setActiveSession(client, activeId)
+    } else {
+      client.activeSessionId = activeId
+    }
 
     if (entry) {
       send(ws, { type: 'session_switched', sessionId: activeId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -595,6 +595,9 @@ export class WsServer {
     const sendFn = (ws, msg) => self._send(ws, msg)
     this._broadcaster = new WsBroadcaster({
       clients: this.clients,
+      // #5563: share the reverse index owner so session broadcasts + subscriber
+      // counts iterate the sessionId→clients index instead of scanning all clients.
+      clientManager: this._clientManager,
       sendFn,
       backpressureThreshold: this._backpressureThreshold,
       backpressureMaxDrops: this._backpressureMaxDrops,
@@ -657,6 +660,14 @@ export class WsServer {
       get webTaskManager() { return self._webTaskManager },
       primaryClients: this._primaryClients,
       get clients() { return self.clients },
+      // #5563: index-maintaining mutators for client subscription / active
+      // session. Handlers MUST route subscription + active-session changes
+      // through these (NOT bare `client.subscribedSessionIds.add()` /
+      // `client.activeSessionId = x`) so the sessionId→clients reverse index
+      // can never drift from the per-client Sets.
+      subscribeClient: (client, sid) => self._clientManager.subscribe(client, sid),
+      unsubscribeClient: (client, sid) => self._clientManager.unsubscribe(client, sid),
+      setActiveSession: (client, sid) => self._clientManager.setActiveSession(client, sid),
       permissionSessionMap: this._permissionSessionMap,
       questionSessionMap: this._questionSessionMap,
       // #3637: stable per-session auto-evaluator iteration counter (#3186).
@@ -689,6 +700,9 @@ export class WsServer {
     // Context objects for extracted modules (ws-auth.js, ws-history.js)
     this._historyCtx = {
       get clients() { return self.clients },
+      // #5563: index-maintaining active-session mutator for the post-auth
+      // restore path (ws-history.js sets activeSessionId once per connect).
+      setActiveSession: (client, sid) => self._clientManager.setActiveSession(client, sid),
       get sessionManager() { return self.sessionManager },
       get cliSession() { return self.cliSession },
       get defaultSessionId() { return self.defaultSessionId },
@@ -1257,6 +1271,10 @@ export class WsServer {
       const rateLimitKey = getRateLimitKey(socketIp, req)
       this._clientManager.addClient(ws, {
         id: clientId,
+        // #5563: stable back-reference to this client's socket so the
+        // sessionId→clients reverse index (which stores `client`) can resolve
+        // the `ws` for readyState + backpressure without a per-send Map lookup.
+        _ws: ws,
         authenticated: false,
         mode: 'chat', // default to chat view
         activeSessionId: null,
@@ -1754,7 +1772,8 @@ export class WsServer {
       // bound binding is the security contract for that client.
       if (client.boundSessionId && client.boundSessionId !== sessionId) continue
       if (!client.subscribedSessionIds) continue
-      client.subscribedSessionIds.add(sessionId)
+      // #5563: route through the index-maintaining helper.
+      this._clientManager.subscribe(client, sessionId)
     }
   }
 
@@ -1787,7 +1806,8 @@ export class WsServer {
       if (!client.authenticated) continue
       if (client.boundSessionId && client.boundSessionId !== sessionId) continue
       if (!client.subscribedSessionIds) continue
-      client.subscribedSessionIds.add(sessionId)
+      // #5563: route through the index-maintaining helper.
+      this._clientManager.subscribe(client, sessionId)
     }
   }
 

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { checkpointHandlers } from '../../src/handlers/checkpoint-handlers.js'
-import { createSpy, createMockSession } from '../test-helpers.js'
+import { createSpy, createMockSession, makeSessionIndexCtx } from '../test-helpers.js'
 
 function makeCtx(sessions = new Map(), overrides = {}) {
   const sent = []
@@ -34,7 +34,8 @@ function makeCtx(sessions = new Map(), overrides = {}) {
       })),
       deleteCheckpoint: createSpy(),
     },
-    clients: new Map(),
+    // #5563: index-maintaining helpers backed by a real WsClientManager.
+    ...makeSessionIndexCtx(),
     _sent: sent,
     _broadcasts: broadcasts,
     ...overrides,

--- a/packages/server/tests/handlers/conversation-handlers.test.js
+++ b/packages/server/tests/handlers/conversation-handlers.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { conversationHandlers } from '../../src/handlers/conversation-handlers.js'
-import { createSpy, createMockSession } from '../test-helpers.js'
+import { createSpy, createMockSession, makeSessionIndexCtx } from '../test-helpers.js'
 import { CliSession, buildClaudeCliArgs } from '../../src/cli-session.js'
 import { SdkSession } from '../../src/sdk-session.js'
 import { CodexSession } from '../../src/codex-session.js'
@@ -13,9 +13,10 @@ function makeCtx(sessions = new Map(), overrides = {}) {
     broadcast: createSpy(),
     broadcastToSession: createSpy(),
     broadcastSessionList: createSpy(),
-    // autoSubscribeOtherClients (handler-utils.js) iterates ctx.clients; empty
-    // Map is sufficient for handler-unit tests where no other clients exist.
-    clients: new Map(),
+    // #5563: index-maintaining helpers backed by a real WsClientManager.
+    // autoSubscribeOtherClients (handler-utils.js) iterates ctx.clients; the
+    // manager's empty Map is sufficient where no other clients exist.
+    ...makeSessionIndexCtx(),
     sendSessionInfo: createSpy(),
     replayHistory: createSpy(),
     // Default test stubs — never touch real ~/.claude/projects

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { sessionHandlers } from '../../src/handlers/session-handlers.js'
-import { createSpy, createMockSession, waitFor } from '../test-helpers.js'
+import { createSpy, createMockSession, waitFor, makeSessionIndexCtx } from '../test-helpers.js'
 
 function makeSent() {
   const sent = []
@@ -12,7 +12,11 @@ function makeCtx(overrides = {}) {
   const sent = []
   const broadcasts = []
   const sessions = new Map()
-  const clients = new Map()
+  // #5563: back the ctx with a real WsClientManager so the index-maintaining
+  // helpers exercise the production reverse-index path. The clients Map IS the
+  // manager's Map, so directly-inserted test clients are visible to the index.
+  const indexCtx = makeSessionIndexCtx()
+  const clients = indexCtx.clients
   const primaryClients = new Map()
 
   const ctx = {
@@ -23,7 +27,7 @@ function makeCtx(overrides = {}) {
     sendSessionInfo: createSpy(),
     replayHistory: createSpy(),
     updatePrimary: createSpy(),
-    clients,
+    ...indexCtx,
     primaryClients,
     permissionSessionMap: new Map(),
     questionSessionMap: new Map(),

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -1,7 +1,29 @@
 import { EventEmitter } from 'node:events'
+import { WsClientManager } from '../src/ws-client-manager.js'
 
 // Re-export GIT from the source module so test files can import it from here
 export { GIT } from '../src/git.js'
+
+/**
+ * #5563: build the index-maintaining ctx fields backed by a real
+ * WsClientManager so handler tests exercise the production sessionId→clients
+ * reverse-index path. Returns `{ clientManager, clients, subscribeClient,
+ * unsubscribeClient, setActiveSession }`. Spread the returned object into a
+ * handler ctx; `clients` IS the manager's Map, so clients inserted directly
+ * into it are visible to the index and to `verifyIndexIntegrity()`.
+ *
+ * @returns {{clientManager: WsClientManager, clients: Map, subscribeClient: Function, unsubscribeClient: Function, setActiveSession: Function}}
+ */
+export function makeSessionIndexCtx() {
+  const clientManager = new WsClientManager()
+  return {
+    clientManager,
+    clients: clientManager.clients,
+    subscribeClient: (client, sid) => clientManager.subscribe(client, sid),
+    unsubscribeClient: (client, sid) => clientManager.unsubscribe(client, sid),
+    setActiveSession: (client, sid) => clientManager.setActiveSession(client, sid),
+  }
+}
 
 /**
  * Poll until a predicate returns a truthy value, then return it.

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -648,15 +648,15 @@ describe('WsBroadcaster', () => {
       assert.equal(manager.clients.get(sentIdx[0].ws).id, 'open')
     })
 
-    it('a custom filter falls back to the full scan (overrides index path)', () => {
-      const a = reg('a', { activeSessionId: 'sess-1' })
-      const b = reg('b', { activeSessionId: 'sess-1' })
-      // Custom filter selects a client that is NOT indexed for sess-1, proving
-      // the filter path scans all clients and the index path is bypassed.
-      idxBroadcaster._broadcastToSession('sess-1', { type: 'm' }, (client) => client.id === 'b')
+    it('a custom filter falls back to the full scan (reaches clients outside the index)', () => {
+      reg('a', { activeSessionId: 'sess-1' })
+      // `outsider` is active on a DIFFERENT session, so it is NOT in sess-1's
+      // index. A custom filter targeting it must still deliver — proving the
+      // filter path scans every client and bypasses the index entirely.
+      const outsider = reg('outsider', { activeSessionId: 'sess-2' })
+      idxBroadcaster._broadcastToSession('sess-1', { type: 'm' }, (client) => client.id === 'outsider')
       assert.equal(sentIdx.length, 1)
-      assert.equal(sentIdx[0].ws, b.ws)
-      void a
+      assert.equal(sentIdx[0].ws, outsider.ws)
     })
 
     it('_countSessionSubscribers counts from the index (active + subscribed)', () => {

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { WsBroadcaster } from '../src/ws-broadcaster.js'
+import { WsClientManager } from '../src/ws-client-manager.js'
 import { metrics } from '../src/metrics.js'
 
 /** Create a fake WebSocket with configurable readyState and bufferedAmount */
@@ -574,6 +575,177 @@ describe('WsBroadcaster', () => {
       assert.equal(wsA.closed, true, 'client A closed')
       assert.equal(wsB.closed, true, 'client B closed')
       assert.equal(metrics.get('backpressure.disconnects'), 2, 'one disconnect per client')
+    })
+  })
+
+  // #5563: when wired with a WsClientManager, session-scoped broadcasts +
+  // subscriber counts take the reverse-index fast path. These tests verify the
+  // index path delivers to EXACTLY the recipient set the full-scan filter would
+  // (parity), and that the per-member conditions (authenticated, readyState,
+  // backpressure) still apply per index member.
+  describe('reverse-index fast path (#5563)', () => {
+    let manager
+    let sentIdx
+    let idxBroadcaster
+
+    /** Register an authenticated client with its ws back-ref (like ws-server addClient). */
+    function reg(id, { activeSessionId = null, subscribe = [], authenticated = true, readyState = 1 } = {}) {
+      const ws = createFakeWs({ readyState })
+      // Start with activeSessionId null (like a fresh client) so the helper
+      // performs a real transition and updates the index — passing it directly
+      // to createFakeClient would make setActiveSession a no-op (prev === new).
+      const client = createFakeClient({ id, authenticated })
+      client._ws = ws
+      manager.addClient(ws, client)
+      if (activeSessionId) manager.setActiveSession(client, activeSessionId)
+      for (const sid of subscribe) manager.subscribe(client, sid)
+      return { ws, client }
+    }
+
+    beforeEach(() => {
+      manager = new WsClientManager()
+      sentIdx = []
+      idxBroadcaster = new WsBroadcaster({
+        clients: manager.clients,
+        clientManager: manager,
+        sendFn: (ws, msg) => sentIdx.push({ ws, message: msg }),
+      })
+    })
+
+    it('delivers to active + subscribed clients via the index', () => {
+      const a = reg('a', { activeSessionId: 'sess-1' })
+      reg('b', { activeSessionId: 'sess-2' })
+      const c = reg('c', { activeSessionId: 'other', subscribe: ['sess-1'] })
+
+      idxBroadcaster._broadcastToSession('sess-1', { type: 'm' })
+
+      const recipients = sentIdx.map(e => e.ws).sort()
+      assert.deepEqual(recipients.length, 2)
+      assert.ok(recipients.includes(a.ws))
+      assert.ok(recipients.includes(c.ws))
+    })
+
+    it('tags the message with sessionId on the index path', () => {
+      reg('a', { activeSessionId: 'sess-1' })
+      idxBroadcaster._broadcastToSession('sess-1', { type: 'data', value: 42 })
+      assert.equal(sentIdx.length, 1)
+      assert.deepEqual(sentIdx[0].message, { type: 'data', value: 42, sessionId: 'sess-1' })
+    })
+
+    it('skips unauthenticated index members', () => {
+      reg('a', { activeSessionId: 'sess-1', authenticated: false })
+      reg('b', { activeSessionId: 'sess-1' })
+      idxBroadcaster._broadcastToSession('sess-1', { type: 'm' })
+      assert.equal(sentIdx.length, 1)
+      assert.equal(manager.clients.get(sentIdx[0].ws).id, 'b')
+    })
+
+    it('skips non-OPEN index members', () => {
+      reg('closed', { activeSessionId: 'sess-1', readyState: 3 })
+      reg('open', { activeSessionId: 'sess-1' })
+      idxBroadcaster._broadcastToSession('sess-1', { type: 'm' })
+      assert.equal(sentIdx.length, 1)
+      assert.equal(manager.clients.get(sentIdx[0].ws).id, 'open')
+    })
+
+    it('a custom filter falls back to the full scan (overrides index path)', () => {
+      const a = reg('a', { activeSessionId: 'sess-1' })
+      const b = reg('b', { activeSessionId: 'sess-1' })
+      // Custom filter selects a client that is NOT indexed for sess-1, proving
+      // the filter path scans all clients and the index path is bypassed.
+      idxBroadcaster._broadcastToSession('sess-1', { type: 'm' }, (client) => client.id === 'b')
+      assert.equal(sentIdx.length, 1)
+      assert.equal(sentIdx[0].ws, b.ws)
+      void a
+    })
+
+    it('_countSessionSubscribers counts from the index (active + subscribed)', () => {
+      reg('a', { activeSessionId: 'sess-1' })
+      reg('b', { activeSessionId: 'other', subscribe: ['sess-1'] })
+      reg('c', { activeSessionId: 'other' })
+      assert.equal(idxBroadcaster._countSessionSubscribers('sess-1'), 2)
+      assert.equal(idxBroadcaster._countSessionSubscribers('other'), 2)
+      assert.equal(idxBroadcaster._countSessionSubscribers('ghost'), 0)
+    })
+
+    it('_countSessionSubscribers excludes unauthenticated + non-OPEN members', () => {
+      reg('a', { activeSessionId: 'sess-1', authenticated: false })
+      reg('b', { activeSessionId: 'sess-1', readyState: 3 })
+      reg('c', { activeSessionId: 'sess-1' })
+      assert.equal(idxBroadcaster._countSessionSubscribers('sess-1'), 1)
+    })
+
+    it('returns 1 for a single-viewer session (the hot-path motivation)', () => {
+      reg('solo', { activeSessionId: 'solo-sess' })
+      assert.equal(idxBroadcaster._countSessionSubscribers('solo-sess'), 1)
+    })
+
+    // The decisive test: over a randomized op sequence, the index broadcaster's
+    // recipient set must equal a full-scan oracle broadcaster's recipient set,
+    // for every session, at every step.
+    it('parity: index recipients === full-scan recipients across randomized ops', () => {
+      let seed = 0x5563beef
+      const rand = () => {
+        seed |= 0; seed = (seed + 0x6D2B79F5) | 0
+        let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+      }
+      const pick = (arr) => arr[Math.floor(rand() * arr.length)]
+
+      const sessions = ['s1', 's2', 's3']
+      const wsById = new Map()
+      const register = (id) => {
+        const ws = createFakeWs({ readyState: 1 })
+        const client = createFakeClient({ id })
+        client._ws = ws
+        manager.addClient(ws, client)
+        wsById.set(id, ws)
+        return client
+      }
+      for (let i = 0; i < 4; i++) register('c' + i)
+
+      // Oracle: a broadcaster WITHOUT a clientManager → full-scan path over the
+      // SAME clients Map.
+      const sentOracle = []
+      const oracleBroadcaster = new WsBroadcaster({
+        clients: manager.clients,
+        sendFn: (ws, msg) => sentOracle.push(ws),
+      })
+
+      const live = () => [...manager.clients.values()]
+
+      for (let step = 0; step < 1500; step++) {
+        const clients = live()
+        const op = Math.floor(rand() * 6)
+        if (op === 0 && clients.length) manager.subscribe(pick(clients), pick(sessions))
+        else if (op === 1 && clients.length) manager.unsubscribe(pick(clients), pick(sessions))
+        else if (op === 2 && clients.length) manager.setActiveSession(pick(clients), pick(sessions))
+        else if (op === 3 && clients.length) manager.setActiveSession(pick(clients), null)
+        else if (op === 4 && clients.length > 1) {
+          const v = pick(clients)
+          manager.removeClient(wsById.get(v.id))
+          wsById.delete(v.id)
+        } else if (op === 5) register('n' + step)
+
+        // Compare recipient sets for every session.
+        for (const sid of sessions) {
+          sentIdx.length = 0
+          sentOracle.length = 0
+          idxBroadcaster._broadcastToSession(sid, { type: 'm' })
+          oracleBroadcaster._broadcastToSession(sid, { type: 'm' })
+          const idxWs = sentIdx.map(e => manager.clients.get(e.ws).id).sort()
+          const oracleWs = sentOracle.map(ws => manager.clients.get(ws).id).sort()
+          assert.deepStrictEqual(idxWs, oracleWs, `recipient drift at step ${step} for ${sid}`)
+          // Counts must also agree.
+          assert.strictEqual(
+            idxBroadcaster._countSessionSubscribers(sid),
+            oracleBroadcaster._countSessionSubscribers(sid),
+            `count drift at step ${step} for ${sid}`,
+          )
+        }
+        manager.verifyIndexIntegrity()
+      }
     })
   })
 

--- a/packages/server/tests/ws-client-manager.test.js
+++ b/packages/server/tests/ws-client-manager.test.js
@@ -276,4 +276,254 @@ describe('WsClientManager', () => {
       assert.strictEqual(entries[1][1], info2)
     })
   })
+
+  // #5563: sessionId→clients reverse index. Every mutation path that changes a
+  // client's activeSessionId or subscribedSessionIds membership must keep the
+  // index in lock-step. `verifyIndexIntegrity()` is the drift oracle (full scan
+  // vs index) and is asserted after each mutation so a regression in any helper
+  // surfaces immediately.
+  describe('reverse index (#5563)', () => {
+    /** Register an authenticated client with a back-ref ws, like ws-server addClient. */
+    function register(id, overrides = {}) {
+      const ws = createMockWs(1)
+      const info = createClientInfo({ id, authenticated: true, _ws: ws, ...overrides })
+      manager.addClient(ws, info)
+      return { ws, client: info }
+    }
+
+    /** Set of client ids the index holds for a session (order-independent). */
+    function indexedIds(sessionId) {
+      return [...manager.getSessionSubscribers(sessionId)].map(c => c.id).sort()
+    }
+
+    it('starts empty — a fresh client contributes no index entries', () => {
+      register('c1')
+      assert.deepStrictEqual(indexedIds('s1'), [])
+      manager.verifyIndexIntegrity()
+    })
+
+    it('getSessionSubscribers returns an empty Set for unknown session', () => {
+      const set = manager.getSessionSubscribers('nope')
+      assert.ok(set instanceof Set)
+      assert.strictEqual(set.size, 0)
+    })
+
+    it('subscribe adds to index and to the per-client Set', () => {
+      const { client } = register('c1')
+      manager.subscribe(client, 's1')
+      assert.deepStrictEqual(indexedIds('s1'), ['c1'])
+      assert.ok(client.subscribedSessionIds.has('s1'))
+      manager.verifyIndexIntegrity()
+    })
+
+    it('subscribe is idempotent (re-subscribe does not double-count)', () => {
+      const { client } = register('c1')
+      manager.subscribe(client, 's1')
+      manager.subscribe(client, 's1')
+      assert.strictEqual(manager.getSessionSubscribers('s1').size, 1)
+      manager.verifyIndexIntegrity()
+    })
+
+    it('unsubscribe removes from index when not the active session', () => {
+      const { client } = register('c1')
+      manager.subscribe(client, 's1')
+      manager.unsubscribe(client, 's1')
+      assert.deepStrictEqual(indexedIds('s1'), [])
+      assert.ok(!client.subscribedSessionIds.has('s1'))
+      // empty key pruned
+      assert.ok(!manager._sessionIndex.has('s1'))
+      manager.verifyIndexIntegrity()
+    })
+
+    it('unsubscribe keeps a client indexed if it is still actively viewing', () => {
+      const { client } = register('c1')
+      manager.setActiveSession(client, 's1')
+      manager.subscribe(client, 's1')
+      manager.unsubscribe(client, 's1') // active still references s1
+      assert.deepStrictEqual(indexedIds('s1'), ['c1'])
+      assert.strictEqual(client.activeSessionId, 's1')
+      manager.verifyIndexIntegrity()
+    })
+
+    it('setActiveSession indexes the new session and de-indexes the old', () => {
+      const { client } = register('c1')
+      manager.setActiveSession(client, 's1')
+      assert.deepStrictEqual(indexedIds('s1'), ['c1'])
+      manager.setActiveSession(client, 's2')
+      assert.deepStrictEqual(indexedIds('s1'), [])
+      assert.deepStrictEqual(indexedIds('s2'), ['c1'])
+      manager.verifyIndexIntegrity()
+    })
+
+    it('setActiveSession keeps the old session indexed if still subscribed', () => {
+      const { client } = register('c1')
+      manager.subscribe(client, 's1')
+      manager.setActiveSession(client, 's1')
+      manager.setActiveSession(client, 's2') // s1 still subscribed
+      assert.deepStrictEqual(indexedIds('s1'), ['c1'])
+      assert.deepStrictEqual(indexedIds('s2'), ['c1'])
+      manager.verifyIndexIntegrity()
+    })
+
+    it('setActiveSession(null) clears the active reference', () => {
+      const { client } = register('c1')
+      manager.setActiveSession(client, 's1')
+      manager.setActiveSession(client, null)
+      assert.deepStrictEqual(indexedIds('s1'), [])
+      assert.strictEqual(client.activeSessionId, null)
+      manager.verifyIndexIntegrity()
+    })
+
+    it('a client active AND subscribed appears exactly once in the index', () => {
+      const { client } = register('c1')
+      manager.setActiveSession(client, 's1')
+      manager.subscribe(client, 's1')
+      assert.strictEqual(manager.getSessionSubscribers('s1').size, 1)
+      manager.verifyIndexIntegrity()
+    })
+
+    it('removeClient purges the client from every index Set (disconnect)', () => {
+      const { ws, client } = register('c1')
+      manager.setActiveSession(client, 's1')
+      manager.subscribe(client, 's2')
+      manager.subscribe(client, 's3')
+      manager.removeClient(ws)
+      assert.deepStrictEqual(indexedIds('s1'), [])
+      assert.deepStrictEqual(indexedIds('s2'), [])
+      assert.deepStrictEqual(indexedIds('s3'), [])
+      // all keys pruned
+      assert.strictEqual(manager._sessionIndex.size, 0)
+      manager.verifyIndexIntegrity()
+    })
+
+    it('removeClient mid-subscription leaves other subscribers intact', () => {
+      const a = register('a')
+      const b = register('b')
+      manager.subscribe(a.client, 's1')
+      manager.subscribe(b.client, 's1')
+      manager.removeClient(a.ws)
+      assert.deepStrictEqual(indexedIds('s1'), ['b'])
+      manager.verifyIndexIntegrity()
+    })
+
+    it('destroyed-session cleanup: unsubscribe all + re-home active viewers', () => {
+      // Mirror handleDestroySession: every client unsubscribes from the dead
+      // session; clients active on it move to a fallback session.
+      const a = register('a')
+      const b = register('b')
+      // seed index for current active state
+      manager.setActiveSession(a.client, 's1')
+      manager.subscribe(b.client, 's1')
+      manager.subscribe(a.client, 's1')
+      assert.deepStrictEqual(indexedIds('s1'), ['a', 'b'])
+
+      // destroy s1
+      for (const [, c] of manager) {
+        manager.unsubscribe(c, 's1')
+        if (c.activeSessionId === 's1') manager.setActiveSession(c, 's0')
+      }
+      assert.deepStrictEqual(indexedIds('s1'), [])
+      assert.deepStrictEqual(indexedIds('s0'), ['a'])
+      assert.ok(!manager._sessionIndex.has('s1'))
+      manager.verifyIndexIntegrity()
+    })
+
+    it('verifyIndexIntegrity throws when the index is corrupted by a direct mutation', () => {
+      const { client } = register('c1')
+      manager.subscribe(client, 's1')
+      // Simulate drift: a rogue caller adds to the per-client Set WITHOUT the
+      // index (the exact bug the helpers + lint prevent).
+      client.subscribedSessionIds.add('s2')
+      assert.throws(() => manager.verifyIndexIntegrity(), /index drift/)
+    })
+
+    it('verifyIndexIntegrity throws on a stale index member', () => {
+      const { client } = register('c1')
+      manager.subscribe(client, 's1')
+      // Simulate drift: remove from the per-client Set but leave the index entry.
+      client.subscribedSessionIds.delete('s1')
+      assert.throws(() => manager.verifyIndexIntegrity(), /index drift/)
+    })
+  })
+
+  // #5563 parity oracle: over a randomized sequence of every mutation path, the
+  // reverse index must, at every step, deliver to exactly the recipient set the
+  // OLD full-scan filter (activeSessionId === sid || subscribedSessionIds.has)
+  // would. This is the regression net against any future helper that drifts.
+  describe('reverse index parity oracle (#5563)', () => {
+    /** The pre-#5563 recipient predicate, evaluated by full scan. */
+    function oracleRecipients(mgr, sessionId) {
+      const ids = []
+      for (const [, client] of mgr) {
+        if (client.activeSessionId === sessionId ||
+            (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))) {
+          ids.push(client.id)
+        }
+      }
+      return ids.sort()
+    }
+
+    function indexRecipients(mgr, sessionId) {
+      return [...mgr.getSessionSubscribers(sessionId)].map(c => c.id).sort()
+    }
+
+    it('index recipients equal full-scan recipients across randomized ops', () => {
+      // Deterministic PRNG (mulberry32) so a failure is reproducible.
+      let seed = 0x5563face
+      const rand = () => {
+        seed |= 0; seed = (seed + 0x6D2B79F5) | 0
+        let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+      }
+      const pick = (arr) => arr[Math.floor(rand() * arr.length)]
+
+      const mgr = new WsClientManager()
+      const sessions = ['s1', 's2', 's3', 's4']
+      const wsById = new Map()
+      const register = (id) => {
+        const ws = createMockWs(1)
+        const info = createClientInfo({ id, authenticated: true, _ws: ws })
+        mgr.addClient(ws, info)
+        wsById.set(id, ws)
+        return info
+      }
+      // Start with a few clients.
+      for (let i = 0; i < 5; i++) register('c' + i)
+
+      const liveClients = () => [...mgr].map(([, c]) => c)
+
+      for (let step = 0; step < 3000; step++) {
+        const clients = liveClients()
+        const op = Math.floor(rand() * 6)
+        if (op === 0 && clients.length > 0) {
+          mgr.subscribe(pick(clients), pick(sessions))
+        } else if (op === 1 && clients.length > 0) {
+          mgr.unsubscribe(pick(clients), pick(sessions))
+        } else if (op === 2 && clients.length > 0) {
+          mgr.setActiveSession(pick(clients), pick(sessions))
+        } else if (op === 3 && clients.length > 0) {
+          mgr.setActiveSession(pick(clients), null)
+        } else if (op === 4 && clients.length > 1) {
+          // disconnect a random client mid-subscription
+          const victim = pick(clients)
+          mgr.removeClient(wsById.get(victim.id))
+          wsById.delete(victim.id)
+        } else if (op === 5) {
+          register('c' + step) // new connection
+        }
+
+        // Index must match the oracle for EVERY session at EVERY step.
+        for (const sid of sessions) {
+          assert.deepStrictEqual(
+            indexRecipients(mgr, sid),
+            oracleRecipients(mgr, sid),
+            `parity drift at step ${step} for ${sid}`,
+          )
+        }
+        // And the structural integrity check must hold.
+        mgr.verifyIndexIntegrity()
+      }
+    })
+  })
 })

--- a/packages/server/tests/ws-handler-coverage.test.js
+++ b/packages/server/tests/ws-handler-coverage.test.js
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { homedir } from 'node:os'
 import { handleSessionMessage } from '../src/ws-message-handlers.js'
-import { createSpy, createMockSession, createMockSessionManager } from './test-helpers.js'
+import { createSpy, createMockSession, createMockSessionManager, makeSessionIndexCtx } from './test-helpers.js'
 
 /**
  * Integration tests for untested WebSocket message handlers (#994).
@@ -57,7 +57,9 @@ function createMockCtx(sessionManager, opts = {}) {
     devPreview,
     webTaskManager,
     primaryClients: new Map(),
-    clients: new Map(),
+    // #5563: index-maintaining helpers + clients Map backed by a real
+    // WsClientManager so create/destroy/switch handlers can route through them.
+    ...makeSessionIndexCtx(),
     permissionSessionMap: new Map(),
     questionSessionMap: new Map(),
     pendingPermissions: new Map(),

--- a/packages/server/tests/ws-server-log-broadcast.test.js
+++ b/packages/server/tests/ws-server-log-broadcast.test.js
@@ -102,7 +102,20 @@ describe('WsServer._logListener session scoping (#4787)', () => {
 
     for (const c of clients) {
       const ws = createMockWs()
-      server.clients.set(ws, c)
+      // #5563: register through the client manager so the sessionId→clients
+      // reverse index is seeded. These fixtures pre-set `activeSessionId` /
+      // `subscribedSessionIds` on the literal, so after insertion we replay
+      // those memberships through the index-maintaining helpers (a fresh
+      // `activeSessionId` is detected as a transition from null only if the
+      // field starts null — so we seed explicitly).
+      c._ws = ws
+      const active = c.activeSessionId
+      const subs = c.subscribedSessionIds ? [...c.subscribedSessionIds] : []
+      c.activeSessionId = null
+      c.subscribedSessionIds = new Set()
+      server._clientManager.addClient(ws, c)
+      if (active) server._clientManager.setActiveSession(c, active)
+      for (const sid of subs) server._clientManager.subscribe(c, sid)
     }
     return delivered
   }


### PR DESCRIPTION
## Summary

Session-scoped messages were an `O(clients)` scan with a per-client filter closure (`ws-broadcaster.js _broadcastToSession`), **plus a second** `O(clients)` scan per buffered delta for the coalescing-window subscriber count (`_countSessionSubscribers`, called once per token from the EventNormalizer). Broadcast cost multiplied by delta frequency — fine at 2 clients, a cliff at 8+.

This PR adds a `sessionId → Set<client>` **reverse index** in `WsClientManager`. Session broadcasts and subscriber counts now iterate the index Set (cost ∝ *subscribers*, not total clients) instead of scanning every client, with **exact** current filter semantics preserved.

Scope is the **indexing/caching half only**. The "primary/ownership semantics for shared sessions" design question is intentionally **left open** in #5563 for #5281 (shared-session join) planning — this PR does not touch `_primaryClients` / `_updatePrimary` beyond the existing call sites.

## Design

### The index predicate (why a UNION)
A client is indexed for `sessionId` iff it matches `_broadcastToSession`'s default recipient predicate:

```
activeSessionId === sessionId  ||  subscribedSessionIds.has(sessionId)
```

These two conditions change **independently** — e.g. checkpoint restore moves `activeSessionId` *without* subscribing; `subscribe_sessions` adds to the Set *without* touching `activeSessionId`. So the index tracks the **union** of both. The remaining per-member conditions (`authenticated`, `readyState`, backpressure) are still applied to each index member by the broadcaster — the index only covers the active-or-subscribed predicate.

### Centralized mutation (the real work — index must never drift)
All membership changes route through index-maintaining helpers on `WsClientManager`: `subscribe` / `unsubscribe` / `setActiveSession` / `removeClient` (purge). Handlers reach them via `ctx.subscribeClient` / `ctx.unsubscribeClient` / `ctx.setActiveSession`; `ws-history` (post-auth restore) and the auto-subscribe routes use the same path.

**Mutation points found and rerouted** (the scattered direct mutations that would have drifted the index):

| Site | Was | Now |
|---|---|---|
| `ws-server.js` `addClient` | `activeSessionId: null`, empty Set | adds stable `_ws` back-ref; no index entry (fresh client) |
| `ws-client-manager.js` `removeClient` | clients.delete | + `_purgeFromIndex` (disconnect / terminate) |
| `ws-server.js` `_registerQuestionRoute` | `subscribedSessionIds.add` | `clientManager.subscribe` |
| `ws-server.js` `_registerPermissionRoute` | `subscribedSessionIds.add` | `clientManager.subscribe` |
| `ws-history.js` restore (auth-time) | `client.activeSessionId =` | `ctx.setActiveSession` |
| `handlers/session-handlers` switch | `activeSessionId =` + `.add` | `ctx.setActiveSession` + `ctx.subscribeClient` |
| `handlers/session-handlers` create | `activeSessionId =` + `.add` | helpers |
| `handlers/session-handlers` destroy | `.delete` + `activeSessionId =` | `ctx.unsubscribeClient` + `ctx.setActiveSession` |
| `handlers/session-handlers` subscribe | `.add` | `ctx.subscribeClient` |
| `handlers/session-handlers` unsubscribe | `.delete` | `ctx.unsubscribeClient` |
| `handlers/conversation-handlers` resume | `activeSessionId =` + `.add` | helpers |
| `handlers/checkpoint-handlers` restore | `activeSessionId =` (no subscribe) | `ctx.setActiveSession` |
| `handler-utils` `autoSubscribeOtherClients` | `.add` | `ctx.subscribeClient` |

### Broadcaster (`ws-broadcaster.js`)
- `_broadcastToSession`: iterates `clientManager.getSessionSubscribers(sessionId)` and resolves each member's socket via a stable `_ws` back-ref (set at `addClient`). A **custom filter** still takes the full-scan path (it may select clients outside the index, e.g. broadcast-to-all). Fixtures constructed without a `clientManager` keep the full-scan fallback.
- `_countSessionSubscribers`: O(subscribers) from the index — the hot path that motivated the issue (one call per buffered delta, against the #5562-merged 8/16ms windows).

### Drift defense
`WsClientManager.verifyIndexIntegrity()` builds an oracle from per-client state and asserts the index matches a full scan exactly (missing entry / missing member / stale member / unpruned empty key all throw with a description of the first mismatch). It is:
- asserted after **every** mutation in the new unit tests, and
- gated behind `CHROXY_WS_INDEX_ASSERT=1` at runtime (checked once at broadcaster construction — the hot path stays a single boolean test; off in prod).

## Test plan

- **`ws-client-manager.test.js`** — index correctness across every mutation path: subscribe, unsubscribe (incl. "still active so stays indexed"), `setActiveSession` (new/old/null, "old stays if still subscribed"), active+subscribed counted once, `removeClient` mid-subscription, destroyed-session cleanup, idempotent re-subscribe, empty-key pruning; plus `verifyIndexIntegrity` throws on injected drift.
- **Parity oracle (both `ws-client-manager` and `ws-broadcaster`)** — a deterministic PRNG drives thousands of randomized subscribe/unsubscribe/switch/disconnect/re-subscribe ops; at every step the index recipients **and** counts must equal the pre-#5563 full-scan oracle's, for every session, with `verifyIndexIntegrity()` asserted each step.
- **`ws-broadcaster.test.js`** — index fast path delivers to active+subscribed, tags `sessionId`, skips unauthenticated / non-OPEN members, custom filter falls back to full scan; count correctness (active+subscribed, exclusions, single-viewer).
- Existing handler/integration suites updated to back their ctx with a real `WsClientManager` (`makeSessionIndexCtx` in `test-helpers.js`) so they exercise the production index path. `ws-server-log-broadcast.test.js` fixtures now seed the index through the helpers.

### Results (Node 22)
- Full server suite: **9069 pass, 2 fail** — the 2 failures are pre-existing `service.test.js` fetch-timeout/port-parsing flakes (confirmed identical on clean `main`, unrelated to this change).
- `subscribe-sessions.test.js` (live `WsServer`) passes **with `CHROXY_WS_INDEX_ASSERT=1`** — production mutation paths never drift the index under the strictest per-broadcast check.
- All custom CI lints (`lint-logger-session-scoping.sh`, `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`) and `eslint src/` pass (0 errors).
- No `package-lock.json` drift.

Related to #5563. (The primary/ownership-semantics half stays open on that issue for #5281; do **not** close on merge.)