### PR TITLE
feat(app): debounced connection-phase announcements for screen readers (#5581)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -14,6 +14,7 @@ import { PermissionHistoryScreen } from './screens/PermissionHistoryScreen';
 import { HistoryScreen } from './screens/HistoryScreen';
 import ActivityScreen from './screens/ActivityScreen';
 import { LockScreen } from './components/LockScreen';
+import { ConnectionAnnouncer } from './components/ConnectionAnnouncer';
 import { useConnectionStore } from './store/connection';
 import { useConnectionLifecycleStore } from './store/connection-lifecycle';
 import { setupNotificationResponseListener } from './notifications';
@@ -100,6 +101,9 @@ export default function App() {
   return (
     <NavigationContainer>
       <StatusBar style="light" />
+      {/* #5581 — single app-level live region: announces settled
+          connection-phase transitions to screen readers (debounced). */}
+      <ConnectionAnnouncer />
       <Stack.Navigator
         screenOptions={{
           headerStyle: { backgroundColor: '#1a1a2e' },

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -101,8 +101,9 @@ export default function App() {
   return (
     <NavigationContainer>
       <StatusBar style="light" />
-      {/* #5581 — single app-level live region: announces settled
-          connection-phase transitions to screen readers (debounced). */}
+      {/* #5581 — single app-level announcer: speaks settled connection-phase
+          transitions via AccessibilityInfo.announceForAccessibility (debounced,
+          renders nothing — no persistent live-region element). */}
       <ConnectionAnnouncer />
       <Stack.Navigator
         screenOptions={{

--- a/packages/app/src/__tests__/hooks/useConnectionAnnouncer.test.tsx
+++ b/packages/app/src/__tests__/hooks/useConnectionAnnouncer.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * #5581 — `useConnectionAnnouncer` debounced screen-reader announcements.
+ *
+ * Mirrors the dashboard's ConnectionAnnouncer semantics on mobile:
+ *   - rapid phase flaps within the debounce window coalesce into ONE
+ *     announcement of the settled phase,
+ *   - no announcement fires for the phase observed at mount (a cold open in
+ *     `disconnected` stays silent until a real connect/drop),
+ *   - each settled phase maps to the expected spoken label.
+ *
+ * No `@testing-library/react-native` in this repo — we drive the hook through
+ * a react-test-renderer harness (same pattern as
+ * `useDictationComposer.test.tsx`) and flush the debounce with fake timers.
+ * `AccessibilityInfo.announceForAccessibility` is mocked so we can assert on
+ * what (if anything) was spoken.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { AccessibilityInfo } from 'react-native';
+
+import {
+  useConnectionAnnouncer,
+  settledLabelFor,
+  type UseConnectionAnnouncerOptions,
+} from '../../hooks/useConnectionAnnouncer';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import type { ConnectionPhase } from '../../store/types';
+
+jest.spyOn(AccessibilityInfo, 'announceForAccessibility');
+const announceMock = AccessibilityInfo.announceForAccessibility as jest.Mock;
+
+const DEBOUNCE = 50;
+
+/** Render the hook. Returns the test renderer + an unmount helper. */
+function renderAnnouncer(opts: UseConnectionAnnouncerOptions = { debounceMs: DEBOUNCE }) {
+  function Harness() {
+    useConnectionAnnouncer(opts);
+    return null;
+  }
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(<Harness />);
+  });
+  return tree;
+}
+
+/** Drive the store's phase the way connect()/the FSM would. */
+function setPhase(phase: ConnectionPhase) {
+  act(() => {
+    useConnectionLifecycleStore.setState({ connectionPhase: phase });
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  announceMock.mockClear();
+  // Reset to the cold-open default before every test.
+  useConnectionLifecycleStore.setState({ connectionPhase: 'disconnected' });
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('useConnectionAnnouncer — initial mount', () => {
+  it('does not announce the phase present at mount (no cold-open disconnected blast)', () => {
+    const tree = renderAnnouncer();
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE * 3);
+    });
+    expect(announceMock).not.toHaveBeenCalled();
+    act(() => tree.unmount());
+  });
+
+  it('stays silent at mount even when the initial phase is connected', () => {
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+    const tree = renderAnnouncer();
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE * 3);
+    });
+    expect(announceMock).not.toHaveBeenCalled();
+    act(() => tree.unmount());
+  });
+});
+
+describe('useConnectionAnnouncer — settled transitions', () => {
+  it('announces a single settled transition after the debounce window', () => {
+    const tree = renderAnnouncer();
+    setPhase('connecting');
+    setPhase('connected');
+    // Before the window elapses, nothing has been spoken.
+    expect(announceMock).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE);
+    });
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    expect(announceMock).toHaveBeenCalledWith('Connected to Chroxy server');
+    act(() => tree.unmount());
+  });
+
+  it('coalesces a rapid reconnect-storm flap into ONE announcement of the settled phase', () => {
+    const tree = renderAnnouncer();
+    // connected → reconnecting → connecting → reconnecting → connected, all
+    // within one debounce window.
+    setPhase('connected');
+    setPhase('reconnecting');
+    setPhase('connecting');
+    setPhase('reconnecting');
+    setPhase('connected');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE);
+    });
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    expect(announceMock).toHaveBeenCalledWith('Connected to Chroxy server');
+    act(() => tree.unmount());
+  });
+
+  it('says nothing when a flap returns to the previously-announced phase', () => {
+    const tree = renderAnnouncer();
+    // First settle on connected.
+    setPhase('connected');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE);
+    });
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    announceMock.mockClear();
+    // Flap away and back within a window → nothing new to say.
+    setPhase('reconnecting');
+    setPhase('connected');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE);
+    });
+    expect(announceMock).not.toHaveBeenCalled();
+    act(() => tree.unmount());
+  });
+
+  it('announces each distinct settled phase in sequence', () => {
+    const tree = renderAnnouncer();
+    setPhase('connected');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE);
+    });
+    setPhase('reconnecting');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE);
+    });
+    setPhase('disconnected');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE);
+    });
+    expect(announceMock.mock.calls.map((c) => c[0])).toEqual([
+      'Connected to Chroxy server',
+      'Reconnecting to Chroxy server',
+      'Disconnected from Chroxy server',
+    ]);
+    act(() => tree.unmount());
+  });
+
+  it('does not fire after unmount (timer cleaned up)', () => {
+    const tree = renderAnnouncer();
+    setPhase('connected');
+    act(() => tree.unmount());
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE * 3);
+    });
+    expect(announceMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('settledLabelFor — phase → message mapping', () => {
+  it('maps every connection phase to its spoken label', () => {
+    expect(settledLabelFor('connected')).toBe('Connected to Chroxy server');
+    expect(settledLabelFor('connecting')).toBe('Connecting to Chroxy server');
+    expect(settledLabelFor('reconnecting')).toBe('Reconnecting to Chroxy server');
+    expect(settledLabelFor('server_restarting')).toBe('Chroxy server restarting');
+    expect(settledLabelFor('disconnected')).toBe('Disconnected from Chroxy server');
+  });
+
+  it('falls back to a generic label for an unknown phase', () => {
+    expect(settledLabelFor('weird' as ConnectionPhase)).toBe('Connection status: weird');
+  });
+});

--- a/packages/app/src/components/ConnectionAnnouncer.tsx
+++ b/packages/app/src/components/ConnectionAnnouncer.tsx
@@ -1,0 +1,20 @@
+/**
+ * ConnectionAnnouncer (#5581) — mobile parity for the dashboard's
+ * connection-phase live region.
+ *
+ * Renders nothing; it simply drives `useConnectionAnnouncer`, which pushes
+ * debounced settled-phase changes through `AccessibilityInfo`. Mount it once
+ * at the app level so a single announcer exists regardless of which screen is
+ * focused (see `App.tsx`).
+ */
+import {
+  useConnectionAnnouncer,
+  type UseConnectionAnnouncerOptions,
+} from '../hooks/useConnectionAnnouncer';
+
+export function ConnectionAnnouncer(
+  props: UseConnectionAnnouncerOptions = {},
+): null {
+  useConnectionAnnouncer(props);
+  return null;
+}

--- a/packages/app/src/hooks/useConnectionAnnouncer.ts
+++ b/packages/app/src/hooks/useConnectionAnnouncer.ts
@@ -77,24 +77,19 @@ export function useConnectionAnnouncer({
 }: UseConnectionAnnouncerOptions = {}): void {
   const phase = useConnectionLifecycleStore((s) => s.connectionPhase);
 
-  // Last phase we actually announced. Seeded lazily with the mount phase (see
-  // the mount-guard effect below) so the first paint does not announce — a
-  // cold open in `disconnected` must stay silent until a real connect/drop.
+  // Last phase we actually announced. Seeded SYNCHRONOUSLY during the first
+  // render (not in an effect — effects run after commit, and a store
+  // transition sneaking in before a mount effect would seed the wrong phase
+  // and could swallow the first real announcement). The lazy render-phase ref
+  // write is idempotent and React-sanctioned for one-time init; it guarantees
+  // the seed is exactly the first-render phase, so a cold open in
+  // `disconnected` stays silent until a genuine transition.
   const lastAnnouncedRef = useRef<ConnectionPhase | null>(null);
+  if (lastAnnouncedRef.current === null) {
+    lastAnnouncedRef.current = phase;
+  }
   // Pending debounce timer; successive phase changes cancel the prior one.
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Seed the last-announced ref with the phase present at mount, BEFORE the
-  // debounce effect runs, so the initial phase is treated as already-spoken
-  // and never scheduled. Empty dep array → runs once on mount.
-  useEffect(() => {
-    if (lastAnnouncedRef.current === null) {
-      lastAnnouncedRef.current = phase;
-    }
-    // Intentionally mount-only — we want the phase captured at first render,
-    // not on every phase change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     // Clear any pending timer — only the LAST change in a churn window fires.

--- a/packages/app/src/hooks/useConnectionAnnouncer.ts
+++ b/packages/app/src/hooks/useConnectionAnnouncer.ts
@@ -1,0 +1,125 @@
+/**
+ * useConnectionAnnouncer (#5581) — mobile port of the dashboard's debounced
+ * ConnectionAnnouncer (`packages/dashboard/src/components/ConnectionAnnouncer.tsx`).
+ *
+ * Background — a VoiceOver/TalkBack user on the phone gets no audible signal
+ * when the connection drops or recovers. The dashboard solved this with a
+ * single hidden `aria-live` region that announces only the SETTLED connection
+ * phase after a debounce window, so reconnect storms (the phase flips
+ * `connecting → reconnecting → connected → reconnecting…` many times per
+ * second) coalesce into one polite announcement of the resting state rather
+ * than spamming the screen reader.
+ *
+ * Mobile has no DOM live region, so this hook subscribes to
+ * `connectionPhase` from the connection-lifecycle store and pushes the
+ * settled phase through `AccessibilityInfo.announceForAccessibility` — the
+ * same one-shot announcement primitive already used by ThinkingIndicator and
+ * CheckInChip.
+ *
+ * Debounce semantics mirror the dashboard:
+ *   - A phase change schedules a `debounceMs` timer (default 1500ms).
+ *   - A subsequent change within the window cancels the prior timer, so only
+ *     the LAST (settled) phase fires.
+ *   - When the timer fires it re-checks the current phase against the last
+ *     announced value, so a flap that returns to the previously-announced
+ *     state says nothing.
+ *
+ * Difference from the dashboard — initial mount:
+ *   The dashboard mounts in `connecting` and intentionally schedules a timer
+ *   for that initial phase. Mobile mounts in `disconnected` on a cold open
+ *   (before the user has ever connected), and announcing "Disconnected" out
+ *   of the gate would be a confusing blast with no preceding "connected" to
+ *   close the loop. So we seed the last-announced ref with the phase observed
+ *   at mount and skip scheduling a timer for it — only genuine *transitions*
+ *   away from the mount phase are announced.
+ */
+import { useEffect, useRef } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+import type { ConnectionPhase } from '../store/types';
+import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
+
+/** Production debounce window — long enough to absorb reconnect-storm churn. */
+export const CONNECTION_ANNOUNCE_DEBOUNCE_MS = 1500;
+
+/**
+ * Settled-phase → spoken label. Mirrors the dashboard's `SETTLED_LABELS`
+ * mapping, adapted to the mobile phase union.
+ */
+const SETTLED_LABELS: Record<ConnectionPhase, string> = {
+  connected: 'Connected to Chroxy server',
+  connecting: 'Connecting to Chroxy server',
+  reconnecting: 'Reconnecting to Chroxy server',
+  server_restarting: 'Chroxy server restarting',
+  disconnected: 'Disconnected from Chroxy server',
+};
+
+export function settledLabelFor(phase: ConnectionPhase): string {
+  return SETTLED_LABELS[phase] ?? `Connection status: ${phase}`;
+}
+
+export interface UseConnectionAnnouncerOptions {
+  /**
+   * Debounce window in ms. Phase changes within this window are coalesced —
+   * only the final phase is announced. Exposed for tests to set very short
+   * windows; the production default is `CONNECTION_ANNOUNCE_DEBOUNCE_MS`.
+   */
+  debounceMs?: number;
+}
+
+/**
+ * Subscribe to the connection phase and announce settled transitions to
+ * assistive tech. Mount once at the app level (see `App.tsx`). Renders
+ * nothing — it is a pure side-effect hook.
+ */
+export function useConnectionAnnouncer({
+  debounceMs = CONNECTION_ANNOUNCE_DEBOUNCE_MS,
+}: UseConnectionAnnouncerOptions = {}): void {
+  const phase = useConnectionLifecycleStore((s) => s.connectionPhase);
+
+  // Last phase we actually announced. Seeded lazily with the mount phase (see
+  // the mount-guard effect below) so the first paint does not announce — a
+  // cold open in `disconnected` must stay silent until a real connect/drop.
+  const lastAnnouncedRef = useRef<ConnectionPhase | null>(null);
+  // Pending debounce timer; successive phase changes cancel the prior one.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Seed the last-announced ref with the phase present at mount, BEFORE the
+  // debounce effect runs, so the initial phase is treated as already-spoken
+  // and never scheduled. Empty dep array → runs once on mount.
+  useEffect(() => {
+    if (lastAnnouncedRef.current === null) {
+      lastAnnouncedRef.current = phase;
+    }
+    // Intentionally mount-only — we want the phase captured at first render,
+    // not on every phase change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    // Clear any pending timer — only the LAST change in a churn window fires.
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    // No-op change (re-render with same phase, or the seeded mount phase) →
+    // nothing to announce.
+    if (phase === lastAnnouncedRef.current) return;
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      // Re-check: the phase may have flapped back to the last-announced value
+      // by the time the timer fires, in which case there's nothing to say.
+      if (phase === lastAnnouncedRef.current) return;
+      lastAnnouncedRef.current = phase;
+      AccessibilityInfo.announceForAccessibility?.(settledLabelFor(phase));
+    }, debounceMs);
+
+    return () => {
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [phase, debounceMs]);
+}


### PR DESCRIPTION
## Summary

Ports the dashboard's debounced `ConnectionAnnouncer` pattern (`packages/dashboard/src/components/ConnectionAnnouncer.tsx`) to the mobile app so VoiceOver/TalkBack users get an audible signal when the connection drops or recovers. Previously the dashboard had an `aria-live` connection live region while mobile announced nothing on connection-phase changes — the parity gap called out in the issue's swarm audit.

What lands:

- **`useConnectionAnnouncer` hook** (`packages/app/src/hooks/useConnectionAnnouncer.ts`) — subscribes to `connectionPhase` from the connection-lifecycle store and pushes the *settled* phase through `AccessibilityInfo.announceForAccessibility` after a debounce window (default 1500ms). Rapid reconnect-storm flaps (`connecting → reconnecting → connected → …`) are coalesced into a single polite announcement of the resting state, matching the dashboard's debounce semantics.
- **Initial-mount guard** — seeds the last-announced phase with the phase observed at mount, so a cold open in `disconnected` stays silent until a real connect/drop. No "Disconnected" blast on app launch.
- **Phase → message mapping** mirrors the dashboard's `SETTLED_LABELS`, adapted to the mobile phase union (`connected` / `connecting` / `reconnecting` / `server_restarting` / `disconnected`), with a generic fallback for unknown phases.
- **`ConnectionAnnouncer` wrapper** (`packages/app/src/components/ConnectionAnnouncer.tsx`) — renders `null`, drives the hook; mounted once at the app level in `App.tsx` (inside `NavigationContainer`). App.tsx-level mount keeps this disjoint from SessionScreen (re: #5573 in flight).

Reuses the existing `AccessibilityInfo.announceForAccessibility` precedent already in `ThinkingIndicator.tsx` and `CheckInChip.tsx`.

## Test plan

New jest suite `packages/app/src/__tests__/hooks/useConnectionAnnouncer.test.tsx` (react-test-renderer harness + fake timers, `AccessibilityInfo` mocked):

- no announcement for the phase present at mount (cold-open `disconnected`, and also when mounting already `connected`)
- a single settled transition announces once after the debounce window
- a rapid reconnect-storm flap coalesces into ONE announcement of the settled phase
- a flap that returns to the previously-announced phase says nothing
- distinct settled phases announce in sequence
- no announcement fires after unmount (timer cleanup)
- `settledLabelFor` maps every phase + generic fallback

Verification (Node 22):

- `npx jest src/__tests__/hooks/useConnectionAnnouncer.test.tsx` — 9 passed
- Full app suite `npx jest` — **126 suites / 1729 tests passed**
- `npx tsc --noEmit` — clean
- No `package-lock.json` drift

Closes #5581