### PR TITLE
fix(app): re-anchor dictation merges around mid-recognition manual edits (#5573)

### DIFF
--- a/packages/app/src/__tests__/hooks/useDictationComposer.test.tsx
+++ b/packages/app/src/__tests__/hooks/useDictationComposer.test.tsx
@@ -1,28 +1,26 @@
 /**
- * #5567 — `useDictationComposer` clears `isDictationUpdateRef` on every
- * dictation teardown path.
+ * #5573 — `useDictationComposer` re-anchors around mid-recognition manual edits.
  *
- * The dictation merge effect sets a private `isDictationUpdateRef = true` just
- * before writing the transcript into the composer via the InputBar's imperative
- * `setValue`. Pre-#5566 that programmatic write fired `onChangeText`, which
- * cleared the flag on the next tick. Since #5566 `setValue` is **silent**, so
- * the flag is only ever cleared by a *subsequent real user keystroke*. If
- * dictation stops or errors after a transcript arrived but before the user
- * types again, the flag wedges `true` and the next genuine keystroke is
- * mis-attributed as "our own dictation echo" — the manual-edit anchor re-point
- * (`dictationStartRef = text.length`) is skipped and paste/anchor behaviour is
- * corrupted.
+ * The dictation merge effect splices each transcript into the composer after a
+ * `dictationStartRef` anchor, via the InputBar's imperative `setValue`. Since
+ * #5566 that `setValue` is **silent** — it writes the draft directly and never
+ * fires `onChangeText`. So the ONLY thing that reaches `handleChangeText` is a
+ * real user keystroke.
  *
- * The flag is private, so these tests observe its EFFECT. `handleChangeText`
- * only runs the manual-edit re-anchor when the flag is false AND recognition is
- * active. So: drive a teardown, then start a fresh cycle, type mid-dictation,
- * and assert the next transcript splices at the user's edited length. That
- * holds only if the flag was cleared during teardown.
+ * Pre-#5573 the hook carried an `isDictationUpdateRef` flag (set true before
+ * each transcript write) to recognise the programmatic echo and skip
+ * re-anchoring on it. With the echo gone (#5566) that flag was dead code that
+ * actively broke the mid-recognition edit case: a transcript flipped the flag
+ * true, the user typed while still recognising, `handleChangeText` saw the stale
+ * `true` and SKIPPED the re-anchor, and the next transcript spliced over the
+ * typed text. #5573 removes the flag, so every `onChangeText` during recognition
+ * re-anchors unconditionally and the typed text is preserved.
  *
- * Each teardown path is isolated:
- *  - silence-end stop (isRecognizing → false with NO mic tap) → catch-all effect
- *  - speech error (error → end spec sequence)               → error effect
- *  - explicit user stop via handleMicPress                  → mic-stop clear
+ * These tests observe behaviour through the InputBar handle (the flag was always
+ * private). The headline test is the exact issue sequence:
+ *   recognising → partial transcript merged → user types mid-recognition →
+ *   next transcript arrives → BOTH the typed text and the new transcript present,
+ *   correctly ordered.
  *
  * No `@testing-library/react-native` in this repo — we drive the hook through a
  * controllable react-test-renderer harness (same pattern as
@@ -57,7 +55,7 @@ type HarnessProps = UseDictationComposerParams;
  * Render the hook in a controllable harness. `api.current` exposes the hook's
  * return so the test can drive `handleChangeText` / `handleMicPress`;
  * `update(props)` re-renders with fresh params (simulating prop changes from
- * the speech hook — `isRecognizing` / `transcript` / `speechError`).
+ * the speech hook — `isRecognizing` / `transcript`).
  */
 function renderHarness(initialProps: HarnessProps) {
   const apiRef: { current: UseDictationComposerReturn | null } = { current: null };
@@ -85,14 +83,28 @@ const baseProps = (overrides: Partial<HarnessProps> = {}): HarnessProps => ({
   inputRef: makeInputRef(),
   isRecognizing: false,
   transcript: '',
-  speechError: null,
   startListening: () => {},
   stopListening: () => {},
   onPasteCollapsed: () => {},
   ...overrides,
 });
 
-describe('useDictationComposer (#5567 dictation flag teardown)', () => {
+/**
+ * Simulate a real user keystroke the way the InputBar does: write the draft via
+ * the handle (the native TextInput's own state) AND fire `handleChangeText`
+ * with (next, prev) — exactly the pair InputBar passes up on each keypress.
+ */
+function typeInto(
+  inputRef: React.RefObject<InputBarHandle | null>,
+  api: { current: UseDictationComposerReturn | null },
+  next: string,
+) {
+  const prev = inputRef.current!.getValue();
+  inputRef.current!.setValue(next);
+  act(() => { api.current!.handleChangeText(next, prev); });
+}
+
+describe('useDictationComposer (#5573 mid-recognition re-anchor)', () => {
   it('handleMicPress starts when idle and stops when active', () => {
     const startListening = jest.fn();
     const stopListening = jest.fn();
@@ -123,75 +135,83 @@ describe('useDictationComposer (#5567 dictation flag teardown)', () => {
     expect(inputRef.current!.getValue()).toBe('hello world');
   });
 
-  it('clears the flag on silence-end stop (no mic tap) — later mid-dictation edit re-anchors', () => {
-    // Catch-all teardown: isRecognizing flips false WITHOUT handleMicPress (a
-    // silence-triggered `end`). If the flag stayed stuck, the next recognising
-    // cycle's mid-dictation manual edit would NOT re-anchor and the following
-    // transcript would overwrite the typed text instead of appending.
+  // ── The #5573 headline: mid-recognition manual edit must survive ──────────
+  it('preserves a manual edit typed mid-recognition and anchors the next transcript AFTER it', () => {
     const inputRef = makeInputRef('');
     const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
     const h = renderHarness(props());
 
-    // Cycle 1: start → transcript (flag := true).
+    // 1. Start dictation (anchor := 0).
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+
+    // 2. A partial transcript is merged into the composer.
+    h.update(props({ isRecognizing: true, transcript: 'hello' }));
+    expect(inputRef.current!.getValue()).toBe('hello');
+
+    // 3. The user types mid-recognition (still recognising) — appends ' there'.
+    //    This MUST re-anchor dictationStartRef to the new length.
+    typeInto(inputRef, h.api, 'hello there');
+
+    // 4. The NEXT transcript arrives. It must splice AFTER the typed edit, not
+    //    overwrite it. Pre-#5573 the stale flag skipped the re-anchor and this
+    //    would have collapsed to just 'bye'.
+    h.update(props({ isRecognizing: true, transcript: 'bye' }));
+
+    const result = inputRef.current!.getValue();
+    expect(result).toBe('hello there bye');
+    // Both the typed text and the new transcript are present and ordered.
+    expect(result).toContain('hello there');
+    expect(result.indexOf('there')).toBeLessThan(result.indexOf('bye'));
+  });
+
+  // ── Negative control: the failing-before behaviour, asserted as a guard ────
+  it('a mid-recognition edit that does NOT re-anchor would lose the typed text (control)', () => {
+    // Drives the merge math directly to demonstrate WHY re-anchoring matters:
+    // if the anchor is left at the pre-edit offset (0), the next transcript's
+    // prefix is empty and the typed text is overwritten. The production hook
+    // avoids this by re-anchoring on every keystroke (asserted in the test
+    // above); here we confirm the stale-anchor path is genuinely lossy.
+    const draft = 'hello there';
+    const staleAnchor = 0;   // anchor NOT moved after the manual edit
+    const freshAnchor = draft.length; // anchor moved to the edited length
+
+    const merge = (anchor: number, transcript: string) => {
+      const prefix = draft.slice(0, anchor);
+      const separator = prefix.length > 0 && !prefix.endsWith(' ') ? ' ' : '';
+      return prefix + separator + transcript;
+    };
+
+    // Stale anchor: typed text is lost.
+    expect(merge(staleAnchor, 'bye')).toBe('bye');
+    // Fresh (re-anchored): typed text preserved, transcript appended.
+    expect(merge(freshAnchor, 'bye')).toBe('hello there bye');
+  });
+
+  it('re-anchors after a dictation stop so a later mid-dictation edit is preserved', () => {
+    // Cross-cycle guard (covers the old #5567 teardown concern): a transcript in
+    // cycle 1, then the recogniser stops on its own (silence end) with no
+    // keystroke, then a fresh cycle where the user types mid-dictation. The edit
+    // must re-anchor and the next transcript must append after it.
+    const inputRef = makeInputRef('');
+    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
+    const h = renderHarness(props());
+
+    // Cycle 1: start → transcript.
     act(() => { h.api.current!.handleMicPress(); });
     h.update(props({ isRecognizing: true }));
     h.update(props({ isRecognizing: true, transcript: 'one' }));
     expect(inputRef.current!.getValue()).toBe('one');
 
-    // Silence-end: recogniser stops on its own, no keystroke to clear the flag.
+    // Silence-end: recogniser stops on its own, no keystroke.
     h.update(props({ isRecognizing: false, transcript: 'one' }));
 
-    // Cycle 2: fresh start, then the user types mid-dictation. This must
-    // re-anchor (flag was cleared) so the next transcript appends after it.
+    // Cycle 2: fresh start (anchors at length 3), user types mid-dictation.
     act(() => { h.api.current!.handleMicPress(); }); // anchors at length 3 ('one')
     h.update(props({ isRecognizing: true }));
-    inputRef.current!.setValue('one typed');
-    act(() => { h.api.current!.handleChangeText('one typed', 'one'); }); // re-anchor to 9
+    typeInto(inputRef, h.api, 'one typed'); // re-anchor to 9
     h.update(props({ isRecognizing: true, transcript: 'voice' }));
     expect(inputRef.current!.getValue()).toBe('one typed voice');
-  });
-
-  it('clears the flag on speech error (error → end) — later mid-dictation edit re-anchors', () => {
-    const inputRef = makeInputRef('');
-    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
-    const h = renderHarness(props());
-
-    // Cycle 1: start → transcript (flag := true).
-    act(() => { h.api.current!.handleMicPress(); });
-    h.update(props({ isRecognizing: true }));
-    h.update(props({ isRecognizing: true, transcript: 'draft' }));
-    expect(inputRef.current!.getValue()).toBe('draft');
-
-    // Spec sequence: error surfaces, recogniser stops.
-    h.update(props({ isRecognizing: false, transcript: 'draft', speechError: 'no-speech' }));
-
-    // Cycle 2: fresh start (error cleared), mid-dictation manual edit re-anchors.
-    act(() => { h.api.current!.handleMicPress(); }); // anchors at length 5 ('draft')
-    h.update(props({ isRecognizing: true, speechError: null }));
-    inputRef.current!.setValue('draft edit');
-    act(() => { h.api.current!.handleChangeText('draft edit', 'draft'); }); // re-anchor to 10
-    h.update(props({ isRecognizing: true, speechError: null, transcript: 'said' }));
-    expect(inputRef.current!.getValue()).toBe('draft edit said');
-  });
-
-  it('clears the flag on explicit user stop via handleMicPress', () => {
-    // Same wedge but torn down by an explicit mic tap (the stop branch).
-    const inputRef = makeInputRef('');
-    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
-    const h = renderHarness(props());
-
-    act(() => { h.api.current!.handleMicPress(); });
-    h.update(props({ isRecognizing: true }));
-    h.update(props({ isRecognizing: true, transcript: 'hi' }));
-    act(() => { h.api.current!.handleMicPress(); }); // explicit user stop
-    h.update(props({ isRecognizing: false, transcript: 'hi' }));
-
-    act(() => { h.api.current!.handleMicPress(); }); // anchors at length 2 ('hi')
-    h.update(props({ isRecognizing: true }));
-    inputRef.current!.setValue('hi more');
-    act(() => { h.api.current!.handleChangeText('hi more', 'hi'); }); // re-anchor to 7
-    h.update(props({ isRecognizing: true, transcript: 'voice' }));
-    expect(inputRef.current!.getValue()).toBe('hi more voice');
   });
 
   it('paste detection fires on genuine input after a dictation stop', () => {
@@ -202,21 +222,41 @@ describe('useDictationComposer (#5567 dictation flag teardown)', () => {
 
     const h = renderHarness(props());
 
-    // Dictation produced a transcript (flag := true), then stopped (silence end)
-    // with no intervening keystroke.
+    // Dictation produced a transcript, then stopped (silence end) with no
+    // intervening keystroke.
     act(() => { h.api.current!.handleMicPress(); });
     h.update(props({ isRecognizing: true }));
     h.update(props({ isRecognizing: true, transcript: 'note' }));
     h.update(props({ isRecognizing: false, transcript: 'note' }));
 
     // The user pastes a large block as their next genuine input. Paste detection
-    // must fire — the stale flag must not break the anchor path that precedes it.
+    // must fire normally.
     const big = 'note' + '\n'.repeat(40) + 'pasted-tail';
     act(() => { h.api.current!.handleChangeText(big, 'note'); });
 
     expect(onPasteCollapsed).toHaveBeenCalledTimes(1);
     const [inserted] = onPasteCollapsed.mock.calls[0];
     expect(inserted).toContain('pasted-tail');
+  });
+
+  it('does NOT re-anchor when a change arrives while not recognising', () => {
+    // Guard the `isRecognizing` gate: an edit made when the recogniser is idle
+    // must leave the anchor untouched, so when dictation next starts it anchors
+    // from handleMicPress (current draft length), not a stray mid-edit value.
+    const inputRef = makeInputRef('');
+    const props = (o: Partial<HarnessProps> = {}) => baseProps({ inputRef, ...o });
+    const h = renderHarness(props());
+
+    // User types while idle (not recognising) — no anchor move expected.
+    typeInto(inputRef, h.api, 'typed while idle');
+
+    // Start dictation: handleMicPress anchors at the CURRENT draft length.
+    act(() => { h.api.current!.handleMicPress(); });
+    h.update(props({ isRecognizing: true }));
+
+    // Transcript appends after the full idle-typed draft.
+    h.update(props({ isRecognizing: true, transcript: 'spoken' }));
+    expect(inputRef.current!.getValue()).toBe('typed while idle spoken');
   });
 
   it('consumeUsedVoice reports voice usage once then resets', () => {

--- a/packages/app/src/hooks/useDictationComposer.ts
+++ b/packages/app/src/hooks/useDictationComposer.ts
@@ -7,36 +7,36 @@ import {
 import type { InputBarHandle } from '../components/InputBar';
 
 /**
- * Dictation + composer-change bookkeeping for SessionScreen (#5567).
+ * Dictation + composer-change bookkeeping for SessionScreen (#5573).
  *
- * Owns the three composer refs that the voice-merge path coordinates:
+ * Owns the two composer refs that the voice-merge path coordinates:
  *
- * - `isDictationUpdateRef` — true for exactly one composer change: the echo of
- *   a programmatic dictation `setValue`. Used to distinguish "this change is our
- *   own transcript write" from "the user manually edited mid-dictation" so the
- *   anchor (`dictationStartRef`) isn't clobbered by our own write.
  * - `dictationStartRef` — index in the draft where the current dictation session
- *   began inserting; the transcript is spliced in after this offset.
+ *   began inserting; the transcript is spliced in after this offset. Every user
+ *   edit during recognition re-anchors this to `text.length` so the next
+ *   transcript appends after the typed text rather than overwriting it.
  * - `usedVoiceRef` — whether the pending message originated (partly) from voice,
  *   read by the send path to tag the outgoing message `isVoice`.
  *
- * ## The wedge this hook closes (#5567)
+ * ## Why there is no `isDictationUpdateRef` flag (#5573)
  *
  * Pre-#5566, the InputBar's `setValue` fired `onChangeText`, so the programmatic
- * dictation write produced its own `onChangeText` echo and `handleChangeText`
- * always cleared `isDictationUpdateRef` on the very next tick. After #5566,
- * `InputBarHandle.setValue` is **silent** — it does NOT fire `onChangeText`. So
- * the flag set just before the transcript write is now only ever cleared by a
- * *subsequent real user keystroke*. If dictation stops or errors after a
- * transcript arrived but before the user typed again, the flag stays stuck
- * `true`. The next genuine keystroke then hits the `isDictationUpdateRef` branch
- * in `handleChangeText` and is misread as "our own dictation echo" — the manual-
- * edit anchor re-point is skipped, corrupting paste detection / anchoring for
- * that input.
+ * transcript write produced its own `onChangeText` echo. The hook carried an
+ * `isDictationUpdateRef` flag — set `true` just before each transcript write —
+ * to recognise that echo and skip re-anchoring on it (otherwise our own write
+ * would have clobbered the anchor). That flag needed elaborate teardown clearing
+ * (#5567) to avoid wedging stale `true` across a recogniser stop.
  *
- * The fix: clear `isDictationUpdateRef` on every dictation teardown path —
- * `handleMicPress` stop, speech error, the `isRecognizing → false` transition,
- * and unmount — so a stale `true` can never bleed into the next genuine input.
+ * Since #5566, `InputBarHandle.setValue` is **silent** — it writes the draft
+ * directly and does NOT fire `onChangeText`. The only path that reaches
+ * `handleChangeText` is now a real user keystroke. There is no programmatic echo
+ * left to suppress, so the flag (and its four teardown effects) was dead code
+ * that actively caused the #5573 bug: a manual edit typed mid-recognition landed
+ * on a stuck-`true` flag and was misread as "our own write", so the re-anchor
+ * was skipped and the next transcript spliced over the typed text.
+ *
+ * Removing the flag means every `onChangeText` during recognition is treated as
+ * what it always is now — a user edit — and unconditionally re-anchors.
  */
 
 export interface UseDictationComposerParams {
@@ -46,8 +46,6 @@ export interface UseDictationComposerParams {
   isRecognizing: boolean;
   /** Latest transcript text from the recogniser (empty when none). */
   transcript: string;
-  /** Speech-recognition error string, or null. */
-  speechError: string | null;
   /** Begin a recogniser session. */
   startListening: () => void;
   /** Stop the recogniser session. */
@@ -66,7 +64,7 @@ export interface UseDictationComposerParams {
 export interface UseDictationComposerReturn {
   /** `onChangeText(next, prev)` handler for the InputBar. */
   handleChangeText: (text: string, prev: string) => void;
-  /** Mic toggle: start when idle, stop (and clear the dictation flag) when active. */
+  /** Mic toggle: start the recogniser when idle, stop it when active. */
   handleMicPress: () => void;
   /**
    * Read-and-reset the "used voice" flag for the send path. Returns whether the
@@ -82,15 +80,11 @@ export function useDictationComposer(
     inputRef,
     isRecognizing,
     transcript,
-    speechError,
     startListening,
     stopListening,
     onPasteCollapsed,
   } = params;
 
-  // True for exactly one composer change — the echo of a programmatic dictation
-  // write. See the module doc for why this must be cleared on every teardown.
-  const isDictationUpdateRef = useRef(false);
   // Index where the current dictation session began inserting (#5556).
   const dictationStartRef = useRef(0);
   // Whether the pending message used voice (read by the send path).
@@ -102,11 +96,13 @@ export function useDictationComposer(
   onPasteCollapsedRef.current = onPasteCollapsed;
 
   const handleChangeText = useCallback((text: string, prev: string) => {
-    if (!isDictationUpdateRef.current && isRecognizing) {
-      // User manually edited text during dictation — update anchor point
+    // Every `onChangeText` is a real user keystroke (the dictation write goes
+    // through the silent `setValue` since #5566). So while recognition is active
+    // this IS a manual mid-dictation edit — re-anchor so the next transcript
+    // appends after the typed text instead of overwriting it (#5573).
+    if (isRecognizing) {
       dictationStartRef.current = text.length;
     }
-    isDictationUpdateRef.current = false;
 
     // Paste detection — RN `TextInput` has no native paste event, so we detect
     // by diffing prev→next on each `onChangeText` and feeding the inserted span
@@ -120,13 +116,9 @@ export function useDictationComposer(
     }
   }, [isRecognizing]);
 
-  // Voice input: toggle start/stop and merge transcript into input text. On stop
-  // we MUST clear `isDictationUpdateRef` — a transcript may have set it true and,
-  // since `setValue` is silent post-#5556, nothing else will clear it before the
-  // next genuine keystroke (#5567).
+  // Voice input: toggle start/stop and merge transcript into input text.
   const handleMicPress = useCallback(() => {
     if (isRecognizing) {
-      isDictationUpdateRef.current = false;
       stopListening();
     } else {
       dictationStartRef.current = (inputRef.current?.getValue() ?? '').length;
@@ -134,47 +126,19 @@ export function useDictationComposer(
     }
   }, [isRecognizing, startListening, stopListening, inputRef]);
 
-  // Merge each transcript into the draft after the dictation anchor. Sets the
-  // dictation flag so the (silent) write isn't mistaken for a manual edit, and
-  // marks the message as voice-originated for the send path.
+  // Merge each transcript into the draft after the dictation anchor. The write
+  // goes through the silent `setValue` (#5566), so it never echoes back through
+  // `handleChangeText` as a spurious manual edit. Marks the message as
+  // voice-originated for the send path.
   useEffect(() => {
     if (isRecognizing && transcript) {
       const current = inputRef.current?.getValue() ?? '';
       const prefix = current.slice(0, dictationStartRef.current);
       const separator = prefix.length > 0 && !prefix.endsWith(' ') ? ' ' : '';
-      isDictationUpdateRef.current = true;
       usedVoiceRef.current = true;
       inputRef.current?.setValue(prefix + separator + transcript);
     }
   }, [transcript]); // eslint-disable-line react-hooks/exhaustive-deps -- only react to transcript changes
-
-  // #5567 — clear the dictation flag whenever a speech error surfaces. The spec
-  // sequence (error → end) can stop the recogniser after a transcript already
-  // flipped the flag true; without this the stale flag wedges the next input.
-  useEffect(() => {
-    if (speechError) {
-      isDictationUpdateRef.current = false;
-    }
-  }, [speechError]);
-
-  // #5567 — clear the dictation flag whenever recognition stops for ANY reason
-  // (user stop, silence timeout, hard error, system interruption). This is the
-  // catch-all: the flag is only meaningful while a transcript write is pending
-  // an echo, and once the recogniser is no longer active there is no pending
-  // dictation write to attribute the next change to.
-  useEffect(() => {
-    if (!isRecognizing) {
-      isDictationUpdateRef.current = false;
-    }
-  }, [isRecognizing]);
-
-  // #5567 — defensive unmount clear. Refs survive across renders but not across
-  // re-mounts; this keeps the teardown contract explicit and self-documenting.
-  useEffect(() => {
-    return () => {
-      isDictationUpdateRef.current = false;
-    };
-  }, []);
 
   const consumeUsedVoice = useCallback(() => {
     const used = usedVoiceRef.current;

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -846,19 +846,16 @@ export function SessionScreen() {
     inputRef.current?.setValue(prefix + marker + suffix);
   }, []);
 
-  // #5567 — dictation + composer-change bookkeeping (the three voice refs, the
+  // #5573 — dictation + composer-change bookkeeping (the voice refs, the
   // change/mic handlers, and the transcript-merge effect) lives in a dedicated
-  // hook so the `isDictationUpdateRef` teardown contract is explicit. The hook
-  // clears that flag on mic-stop, speech error, the `isRecognizing → false`
-  // transition, and unmount — closing the wedge where a stale flag (set by a
-  // transcript write whose silent `setValue` never echoes through
-  // `onChangeText` since #5556) suppressed anchoring/paste-detection on the next
-  // genuine keystroke.
+  // hook. Since `setValue` is silent (#5566), every `onChangeText` during
+  // recognition is a real user keystroke, so the hook re-anchors unconditionally
+  // on each one — a mid-recognition manual edit is preserved and the next
+  // transcript appends after it instead of overwriting it.
   const { handleChangeText, handleMicPress, consumeUsedVoice } = useDictationComposer({
     inputRef,
     isRecognizing,
     transcript,
-    speechError,
     startListening,
     stopListening,
     onPasteCollapsed: handlePasteCollapsed,


### PR DESCRIPTION
## Summary

A manual edit typed **while dictation is still recognising** was not re-anchored, so the next transcript merge spliced over the typed text and lost it.

**Option chosen: (b) — remove the `isDictationUpdateRef` flag entirely** (the deeper simplification Copilot suggested on #5571), not the targeted re-anchor patch.

Why (b) is the simpler *correct* option: the flag existed only to recognise the `onChangeText` **echo** of the programmatic transcript write and skip re-anchoring on it. Since #5566, `InputBarHandle.setValue` is **silent** — it writes the InputBar's internal draft directly and never fires `onChangeText` (verified in `InputBar.tsx`: `onChangeText` is wired *exclusively* to the native `TextInput`'s keypress path; the imperative `setValue`/`clear` bypass it). So post-#5566 the only thing that can reach `handleChangeText` is a **real user keystroke** — there is no programmatic echo left to suppress.

That makes the flag dead code that *actively caused* the bug:

1. Transcript `hello` arrives → merge effect sets `isDictationUpdateRef = true`, anchor = 0.
2. User types mid-recognition → `handleChangeText` sees the stale `true`, **skips** the `dictationStartRef = text.length` re-anchor, clears the flag.
3. Next transcript `bye` → `prefix = draft.slice(0, 0) = ''` → typed text overwritten.

Removing the flag means every `onChangeText` during recognition is treated as what it now always is — a user edit — and re-anchors unconditionally. The typed text is preserved and the next transcript appends after it. This also deletes the four teardown effects #5567 added to keep the flag from wedging (mic-stop / speech-error / `isRecognizing→false` / unmount), and drops the now-unused `speechError` param from the hook.

### Files
- `packages/app/src/hooks/useDictationComposer.ts` — remove `isDictationUpdateRef` + its set/clear sites + 4 teardown effects; `handleChangeText` re-anchors unconditionally while `isRecognizing`; drop unused `speechError` param; rewrite module doc.
- `packages/app/src/screens/SessionScreen.tsx` — stop passing `speechError` to the hook (still used locally for the error Alert); update the stale comment.
- `packages/app/src/__tests__/hooks/useDictationComposer.test.tsx` — re-frame for #5573; add the headline scenario + negative control + idle-edit guard.

## Test plan
- **Headline test** — the exact issue sequence: recognising → partial transcript `hello` merged → user types `hello there` mid-recognition → next transcript `bye` → result `hello there bye` (both present, `there` before `bye`).
- **Negative control** — drives the merge math directly to prove the stale-anchor path is genuinely lossy (`anchor=0` → `bye`; re-anchored → `hello there bye`).
- **Idle-edit guard** — a change while *not* recognising must not move the anchor.
- **Cross-cycle guard** — transcript → silence-stop → fresh cycle → mid-dictation edit still re-anchors (covers the old #5567 concern without the flag).
- Existing paste-detection / mic-toggle / consumeUsedVoice tests retained.

Results:
- `useDictationComposer` suite: **8/8 pass**.
- Full app jest: **125 suites / 1721 tests pass**.
- `npx tsc --noEmit` (packages/app): **exit 0**.
- No lockfile drift.

Closes #5573