### PR TITLE
perf(server): deflate-aware coalescing window (#5578)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -17,6 +17,23 @@ const log = createLogger('event-normalizer')
 const MAX_DELTA_KEY_BYTES = 256 * 1024 // 256 KB per stream
 const MAX_DELTA_TOTAL_BYTES = 2 * 1024 * 1024 // 2 MB across all streams
 
+// #5578: deflate-aware coalescing windows. The #5568 floors (8ms single / 16ms
+// multi) are correct for LAN/loopback peers — deflate is stripped at upgrade,
+// each tiny stream_delta is cheap, and a fast emitter producing ~125 frames/sec
+// is fine. They are WRONG for deflate-negotiated (tunnel/cellular) peers: every
+// stream_delta is ~40-75 bytes including serverTs, UNDER the permessage-deflate
+// threshold:1024, so it ships UNCOMPRESSED. The 8ms floor then triples the
+// small-packet count (~40 frames/sec at the old 25ms → ~125/sec at 8ms) on
+// exactly the links where per-frame cost dominates (small-packet overhead,
+// cellular radio wake-ups, tunnel framing). We re-coalesce a beat longer when
+// any subscriber is on a deflate socket: ~16ms single / ~25ms multi. These are
+// still fixed micro-batch windows below the client-side adaptive EWMA floor
+// (store-core resolveDeltaFlushMs, 16-100ms), so they don't reintroduce the
+// pre-#5562 server/client window stacking — they only halve the frame rate on
+// the links that pay for each frame. LAN sessions keep the tight floors.
+const DEFLATE_FLUSH_INTERVAL_MS = 25 // any deflate subscriber, multi-client
+const DEFLATE_SINGLE_CLIENT_FLUSH_INTERVAL_MS = 16 // any deflate subscriber, single client
+
 /**
  * Declarative event-to-WS-message mapping.
  *
@@ -697,11 +714,25 @@ export class EventNormalizer {
    *   - returns how many clients are subscribed to `sessionId`, or null when
    *   unknown (e.g. legacy single-session mode). When the count is exactly 1 the
    *   single-client window is used; otherwise (0, ≥2, or null) the default.
+   * @param {number} [opts.deflateFlushIntervalMs=25] - #5578: multi-client
+   *   window used when ANY subscriber of the session is on a deflate-negotiated
+   *   (tunnel/cellular) socket. Wider than the LAN default because each
+   *   sub-threshold delta ships uncompressed; see DEFLATE_FLUSH_INTERVAL_MS.
+   * @param {number} [opts.deflateSingleClientFlushIntervalMs=16] - #5578:
+   *   single-client window when the sole subscriber is on a deflate socket.
+   * @param {(sessionId: string|null) => boolean} [opts.getHasDeflateSubscriber]
+   *   - returns true when ANY subscriber of `sessionId` is on a
+   *   deflate-negotiated socket. Resolved O(subscribers) via the reverse index
+   *   (#5575). When absent (legacy mode) the deflate-aware widening is disabled
+   *   and the LAN floors apply.
    */
-  constructor({ flushIntervalMs = 16, singleClientFlushIntervalMs = 8, getSubscriberCount = null, maxKeyBytes = MAX_DELTA_KEY_BYTES, maxTotalBytes = MAX_DELTA_TOTAL_BYTES } = {}) {
+  constructor({ flushIntervalMs = 16, singleClientFlushIntervalMs = 8, getSubscriberCount = null, getHasDeflateSubscriber = null, deflateFlushIntervalMs = DEFLATE_FLUSH_INTERVAL_MS, deflateSingleClientFlushIntervalMs = DEFLATE_SINGLE_CLIENT_FLUSH_INTERVAL_MS, maxKeyBytes = MAX_DELTA_KEY_BYTES, maxTotalBytes = MAX_DELTA_TOTAL_BYTES } = {}) {
     this._flushIntervalMs = flushIntervalMs
     this._singleClientFlushIntervalMs = singleClientFlushIntervalMs
+    this._deflateFlushIntervalMs = deflateFlushIntervalMs
+    this._deflateSingleClientFlushIntervalMs = deflateSingleClientFlushIntervalMs
     this._getSubscriberCount = typeof getSubscriberCount === 'function' ? getSubscriberCount : null
+    this._getHasDeflateSubscriber = typeof getHasDeflateSubscriber === 'function' ? getHasDeflateSubscriber : null
     // #5555: residency caps for the coalescing buffer. A runaway provider (huge
     // tool output, model repetition loop) can grow this Map between flushes
     // faster than ws-broadcaster's socket backpressure can react — the data
@@ -732,19 +763,32 @@ export class EventNormalizer {
   }
 
   /**
-   * #5516/#5562: resolve the fixed micro-batch window for the session currently
-   * being buffered. Single-subscriber sessions get the tighter window;
-   * everything else (0, 2+, or unknown count) keeps the default. No
-   * subscriber-count resolver wired (legacy mode) → always the default. This is
-   * a fixed window, not an adaptive throttle — the adaptive part lives in the
-   * client's resolveDeltaFlushMs EWMA (store-core).
+   * #5516/#5562/#5578: resolve the fixed micro-batch window for the session
+   * currently being buffered. Two axes:
+   *   - subscriber COUNT: exactly 1 → tighter single-client window; else (0, 2+,
+   *     unknown) → the multi-client window.
+   *   - deflate LOCALITY: any subscriber on a deflate-negotiated (tunnel/
+   *     cellular) socket → widen to the deflate window for the resolved count.
+   *     #5578 — on those links each sub-1024B stream_delta ships uncompressed,
+   *     so the LAN floors (8/16ms) triple the small-packet count where per-frame
+   *     cost dominates. All-LAN sessions keep the tight floors.
+   * No subscriber-count resolver wired (legacy mode) → always the default LAN
+   * window. This is a fixed window, not an adaptive throttle — the adaptive part
+   * lives in the client's resolveDeltaFlushMs EWMA (store-core).
    * @param {string|null} sessionId
    * @returns {number} flush interval in ms
    */
   _resolveFlushIntervalMs(sessionId) {
     if (!this._getSubscriberCount) return this._flushIntervalMs
     const count = this._getSubscriberCount(sessionId)
-    return count === 1 ? this._singleClientFlushIntervalMs : this._flushIntervalMs
+    const single = count === 1
+    // #5578: prefer the deflate window when any subscriber sits on a deflate
+    // socket. The predicate is O(subscribers) and short-circuits on the first
+    // match (ws-broadcaster._hasDeflateSubscriber) — no O(all-clients) scan.
+    if (this._getHasDeflateSubscriber && this._getHasDeflateSubscriber(sessionId)) {
+      return single ? this._deflateSingleClientFlushIntervalMs : this._deflateFlushIntervalMs
+    }
+    return single ? this._singleClientFlushIntervalMs : this._flushIntervalMs
   }
 
   /**
@@ -844,9 +888,11 @@ export class EventNormalizer {
       }
       return
     }
-    // #5516/#5562: fixed micro-batch window (NOT an adaptive coalescing window)
-    // — tighter (8ms) when this session has a single subscriber, default (16ms)
-    // otherwise. Its only job is to absorb the per-token burst into one
+    // #5516/#5562/#5578: fixed micro-batch window (NOT an adaptive coalescing
+    // window) — tighter (8ms) when this session has a single LAN subscriber,
+    // default (16ms) for multi/LAN, and WIDER (16/25ms) when any subscriber is
+    // on a deflate (tunnel/cellular) socket where each sub-threshold frame ships
+    // uncompressed. Its only job is to absorb the per-token burst into one
     // emit/broadcast and bound that overhead; the ADAPTIVE throttle lives
     // client-side in store-core resolveDeltaFlushMs (16-100ms EWMA). The flush
     // timer is shared across all buffered sessions, so a single-client session

--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -224,6 +224,45 @@ export class WsBroadcaster {
     return count
   }
 
+  /**
+   * #5578: does ANY authenticated, connected subscriber of this session sit on a
+   * deflate-negotiated socket (i.e. tunnel/cellular, NOT a LAN/loopback peer for
+   * which deflate was stripped at upgrade — ws-server.js)? Used by the
+   * EventNormalizer to widen the delta-coalescing window on links where each
+   * sub-threshold (<1024B) stream_delta ships UNCOMPRESSED and the per-frame
+   * small-packet cost dominates. Mirrors `_countSessionSubscribers`'s recipient
+   * filter so it reflects exactly who would receive a session-scoped broadcast.
+   *
+   * O(subscribers): iterates only the reverse-index Set (members already satisfy
+   * the active-or-subscribed predicate), short-circuiting on the first deflate
+   * peer — never an O(all-clients) scan on the per-token hot path. `usesDeflate`
+   * is a per-client flag stamped once at connection setup from the unspoofable
+   * socket-locality decision, so this is a cheap boolean read per member.
+   * @param {string} sessionId
+   * @returns {boolean}
+   */
+  _hasDeflateSubscriber(sessionId) {
+    if (this._clientManager) {
+      for (const client of this._clientManager.getSessionSubscribers(sessionId)) {
+        if (!client.authenticated) continue
+        const sock = client._ws
+        if (!sock || sock.readyState !== 1) continue
+        if (client.usesDeflate) return true
+      }
+      return false
+    }
+    // Full-scan fallback for fixtures constructed without a clientManager.
+    for (const [ws, client] of this._clients) {
+      if (!client.authenticated || ws.readyState !== 1) continue
+      if (!client.usesDeflate) continue
+      if (client.activeSessionId === sessionId ||
+          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))) {
+        return true
+      }
+    }
+    return false
+  }
+
   /** Broadcast client_joined to all OTHER authenticated clients */
   _broadcastClientJoined(newClient, excludeWs) {
     const info = newClient.deviceInfo || {}

--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -226,8 +226,12 @@ export class WsBroadcaster {
 
   /**
    * #5578: does ANY authenticated, connected subscriber of this session sit on a
-   * deflate-negotiated socket (i.e. tunnel/cellular, NOT a LAN/loopback peer for
-   * which deflate was stripped at upgrade — ws-server.js)? Used by the
+   * non-LAN socket that KEPT permessage-deflate (i.e. tunnel/cellular, NOT a
+   * LAN/loopback peer for which deflate was stripped at upgrade — ws-server.js)?
+   * Driven by `client.usesDeflate`, the upgrade-time locality decision (deflate
+   * permitted vs stripped), not the per-client negotiated extension — a remote
+   * client that declines deflate still counts, which is the intended direction
+   * (same WAN per-frame cost). Used by the
    * EventNormalizer to widen the delta-coalescing window on links where each
    * sub-threshold (<1024B) stream_delta ships UNCOMPRESSED and the per-frame
    * small-packet cost dominates. Mirrors `_countSessionSubscribers`'s recipient

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1327,9 +1327,13 @@ export class WsServer {
         ip,
         socketIp,
         rateLimitKey,
-        // #5578: true when this socket negotiated permessage-deflate (tunnel /
-        // remote peer); false for LAN/loopback peers whose extension header was
-        // stripped at upgrade. Drives the deflate-aware delta-coalescing window
+        // #5578: true for a non-LAN peer (tunnel / remote) that kept the
+        // server-level permessage-deflate; false for LAN/loopback peers whose
+        // extension header was stripped at upgrade. This is the upgrade-time
+        // LOCALITY decision, not the actual negotiated extension — a remote
+        // client that declines deflate in its handshake still reads true, which
+        // is the intended (and safe) direction: those links pay the same WAN
+        // per-frame cost. Drives the deflate-aware delta-coalescing window
         // — see EventNormalizer._resolveFlushIntervalMs. Set from the
         // unspoofable upgrade-time locality decision (req._chroxyUsesDeflate).
         usesDeflate: req._chroxyUsesDeflate === true,

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -938,9 +938,18 @@ export class WsServer {
     // shrank the server window from 25/50ms so it no longer stacks on top of
     // that EWMA. Legacy single-session mode (sessionId === null) reports null
     // (unknown), which the normalizer treats as "keep the default window".
+    // #5578: also hand it a deflate-subscriber predicate so the window can
+    // widen (8/16 → 16/25ms) when any subscriber is on a deflate-negotiated
+    // (tunnel/cellular) socket, where each sub-1024B stream_delta ships
+    // uncompressed and the per-frame small-packet cost dominates. O(subscribers)
+    // via the #5575 reverse index — never an O(all-clients) scan on the
+    // per-token hot path. Legacy single-session mode (sessionId === null) can't
+    // resolve subscribers, so it reports false → keeps the LAN window.
     this._normalizer = new EventNormalizer({
       getSubscriberCount: (sessionId) =>
         sessionId == null ? null : this._broadcaster._countSessionSubscribers(sessionId),
+      getHasDeflateSubscriber: (sessionId) =>
+        sessionId == null ? false : this._broadcaster._hasDeflateSubscriber(sessionId),
     })
     this._gitInfo = getGitInfo()
     this._startedAt = Date.now()
@@ -1272,7 +1281,16 @@ export class WsServer {
       // Security: isLocalOrLanPeer keys off the unspoofable socket peer; a
       // forged proxy header can only KEEP deflate (the safe default), never
       // remove it. See connection-locality.js.
-      if (isLocalOrLanPeer(req)) {
+      // #5578: stash the locality decision on `req` so the 'connection' handler
+      // can stamp a per-client `usesDeflate` flag without re-classifying. A
+      // LAN/loopback peer had its extension header stripped (no deflate); any
+      // other peer keeps the server-level permessage-deflate. The flag drives
+      // the deflate-aware delta-coalescing window (see EventNormalizer /
+      // ws-broadcaster `_hasDeflateSubscriber`). Keyed off the unspoofable
+      // socket peer, identical to the strip decision — they can never diverge.
+      const localPeer = isLocalOrLanPeer(req)
+      req._chroxyUsesDeflate = !localPeer
+      if (localPeer) {
         delete req.headers['sec-websocket-extensions']
       }
       this.wss.handleUpgrade(req, socket, head, (ws) => {
@@ -1309,6 +1327,12 @@ export class WsServer {
         ip,
         socketIp,
         rateLimitKey,
+        // #5578: true when this socket negotiated permessage-deflate (tunnel /
+        // remote peer); false for LAN/loopback peers whose extension header was
+        // stripped at upgrade. Drives the deflate-aware delta-coalescing window
+        // — see EventNormalizer._resolveFlushIntervalMs. Set from the
+        // unspoofable upgrade-time locality decision (req._chroxyUsesDeflate).
+        usesDeflate: req._chroxyUsesDeflate === true,
         // #3404: visible defaults to true; mobile flips to false on backgrounding
         // so completion push notifications fire instead of being suppressed by
         // a still-alive but invisible WS connection.

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1176,6 +1176,152 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
   })
 })
 
+describe('EventNormalizer deflate-aware flush window (#5578)', () => {
+  // Same setTimeout spy as the #5516 block: record the scheduled flush delay
+  // without letting the timer fire.
+  function withSetTimeoutSpy(fn) {
+    const delays = []
+    const orig = global.setTimeout
+    mock.method(global, 'setTimeout', (cb, ms, ...rest) => {
+      delays.push(ms)
+      return orig(() => {}, 1_000_000, ...rest)
+    })
+    try { fn(delays) } finally { mock.restoreAll() }
+  }
+
+  // Policy table (#5578):
+  //   subscribers      | all-LAN | any-deflate
+  //   ---------------- | ------- | -----------
+  //   single (count 1) |   8ms   |    16ms
+  //   multi  (count≥2) |  16ms   |    25ms
+  // "any-deflate" = at least one subscriber on a deflate-negotiated
+  // (tunnel/cellular) socket, where each sub-1024B stream_delta ships
+  // uncompressed and the LAN floors triple the small-packet count.
+
+  it('keeps the 8ms LAN floor for a single all-LAN subscriber', () => {
+    const n = new EventNormalizer({
+      getSubscriberCount: () => 1,
+      getHasDeflateSubscriber: () => false,
+    })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 8)
+    })
+    n.destroy()
+  })
+
+  it('keeps the 16ms LAN floor for multiple all-LAN subscribers', () => {
+    const n = new EventNormalizer({
+      getSubscriberCount: () => 3,
+      getHasDeflateSubscriber: () => false,
+    })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 16)
+    })
+    n.destroy()
+  })
+
+  it('widens to 16ms when the sole subscriber is on a deflate socket', () => {
+    const n = new EventNormalizer({
+      getSubscriberCount: () => 1,
+      getHasDeflateSubscriber: () => true,
+    })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 16)
+    })
+    n.destroy()
+  })
+
+  it('widens to 25ms when a multi-client session has any deflate subscriber (mixed)', () => {
+    // 3 subscribers, at least one on a deflate socket → the widened multi window.
+    const n = new EventNormalizer({
+      getSubscriberCount: () => 3,
+      getHasDeflateSubscriber: () => true,
+    })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 25)
+    })
+    n.destroy()
+  })
+
+  it('re-resolves the window when subscribers join/leave mid-session', () => {
+    // The predicates are read live on every bufferDelta, so a join (LAN→deflate)
+    // or a leave (deflate→LAN) flips the window without any cached state.
+    const state = { count: 1, deflate: false }
+    const n = new EventNormalizer({
+      getSubscriberCount: () => state.count,
+      getHasDeflateSubscriber: () => state.deflate,
+    })
+    withSetTimeoutSpy((delays) => {
+      // 1 LAN viewer → 8ms.
+      n.bufferDelta('sess-1', 'm1', 'a')
+      assert.equal(delays.at(-1), 8)
+      // A phone on cellular joins (now a deflate subscriber present, still single
+      // would be 16, but it's now 2 clients) → widened multi window 25ms. The
+      // delta buffers into the SAME pending window, which only shortens, so to
+      // observe the new resolve we flush first.
+      n.flushSession('sess-1')
+      state.count = 2
+      state.deflate = true
+      n.bufferDelta('sess-1', 'm2', 'b')
+      assert.equal(delays.at(-1), 25)
+      // The cellular peer leaves; back to a single LAN viewer → 8ms floor.
+      n.flushSession('sess-1')
+      state.count = 1
+      state.deflate = false
+      n.bufferDelta('sess-1', 'm3', 'c')
+      assert.equal(delays.at(-1), 8)
+    })
+    n.destroy()
+  })
+
+  it('honors custom deflate interval overrides', () => {
+    const n = new EventNormalizer({
+      deflateFlushIntervalMs: 40,
+      deflateSingleClientFlushIntervalMs: 20,
+      getSubscriberCount: () => 1,
+      getHasDeflateSubscriber: () => true,
+    })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 20)
+    })
+    n.destroy()
+  })
+
+  it('ignores the deflate predicate when no subscriber-count resolver is wired (legacy)', () => {
+    // Legacy single-session mode has no way to resolve subscribers; the LAN
+    // default stands regardless of the deflate predicate.
+    const n = new EventNormalizer({ getHasDeflateSubscriber: () => true })
+    withSetTimeoutSpy((delays) => {
+      n.bufferDelta('sess-1', 'msg-1', 'hi')
+      assert.equal(delays[0], 16)
+    })
+    n.destroy()
+  })
+
+  it('does NOT re-scan all clients — resolves via the wired O(subscribers) predicates only', () => {
+    // Guard against a regression that reintroduces an O(all-clients) scan on the
+    // per-token hot path: bufferDelta must consult ONLY the injected resolvers,
+    // once each per call, never iterate a client collection itself.
+    let countCalls = 0
+    let deflateCalls = 0
+    const n = new EventNormalizer({
+      getSubscriberCount: () => { countCalls++; return 1 },
+      getHasDeflateSubscriber: () => { deflateCalls++; return true },
+    })
+    withSetTimeoutSpy(() => {
+      n.bufferDelta('sess-1', 'm1', 'a')
+    })
+    assert.equal(countCalls, 1, 'subscriber count resolved exactly once per buffered delta')
+    assert.equal(deflateCalls, 1, 'deflate predicate resolved exactly once per buffered delta')
+    n.destroy()
+  })
+})
+
 // ---- registerEventType() ----
 
 describe('registerEventType()', () => {

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -271,6 +271,52 @@ describe('WsBroadcaster', () => {
     })
   })
 
+  // #5578: does any subscriber sit on a deflate-negotiated (tunnel/cellular)
+  // socket? Drives the deflate-aware delta-coalescing window. Mirrors the
+  // _countSessionSubscribers recipient filter; short-circuits on first match.
+  // These exercise the full-scan FALLBACK path (no clientManager wired).
+  describe('_hasDeflateSubscriber() — full-scan fallback', () => {
+    function lan(id, opts) { return createFakeClient({ id, ...opts }) } // usesDeflate undefined → falsey
+    function tunnel(id, opts) { const c = createFakeClient({ id, ...opts }); c.usesDeflate = true; return c }
+
+    it('false when every subscriber is on a LAN socket', () => {
+      clients.set(createFakeWs(), lan('c1', { activeSessionId: 'sess-1' }))
+      clients.set(createFakeWs(), lan('c2', { activeSessionId: 'other', subscribedSessionIds: new Set(['sess-1']) }))
+      assert.equal(broadcaster._hasDeflateSubscriber('sess-1'), false)
+    })
+
+    it('true when at least one subscriber is on a deflate socket (mixed)', () => {
+      clients.set(createFakeWs(), lan('c1', { activeSessionId: 'sess-1' }))
+      clients.set(createFakeWs(), tunnel('c2', { activeSessionId: 'sess-1' }))
+      assert.equal(broadcaster._hasDeflateSubscriber('sess-1'), true)
+    })
+
+    it('true when every subscriber is on a deflate socket', () => {
+      clients.set(createFakeWs(), tunnel('c1', { activeSessionId: 'sess-1' }))
+      clients.set(createFakeWs(), tunnel('c2', { activeSessionId: 'other', subscribedSessionIds: new Set(['sess-1']) }))
+      assert.equal(broadcaster._hasDeflateSubscriber('sess-1'), true)
+    })
+
+    it('ignores a deflate client subscribed to a DIFFERENT session', () => {
+      clients.set(createFakeWs(), lan('c1', { activeSessionId: 'sess-1' }))
+      clients.set(createFakeWs(), tunnel('c2', { activeSessionId: 'sess-2' }))
+      assert.equal(broadcaster._hasDeflateSubscriber('sess-1'), false)
+    })
+
+    it('excludes unauthenticated and non-OPEN deflate clients', () => {
+      clients.set(createFakeWs({ readyState: 1 }), tunnel('c1', { activeSessionId: 'sess-1', authenticated: false }))
+      clients.set(createFakeWs({ readyState: 3 }), tunnel('c2', { activeSessionId: 'sess-1' }))
+      assert.equal(broadcaster._hasDeflateSubscriber('sess-1'), false)
+    })
+
+    it('does not throw when a client lacks subscribedSessionIds (#4799 parity)', () => {
+      const c = tunnel('c1', { activeSessionId: 'other' })
+      c.subscribedSessionIds = undefined
+      clients.set(createFakeWs(), c)
+      assert.equal(broadcaster._hasDeflateSubscriber('sess-1'), false)
+    })
+  })
+
   describe('_broadcastClientJoined()', () => {
     it('sends client_joined to all except the joining client ws', () => {
       const wsNew = createFakeWs()
@@ -589,13 +635,14 @@ describe('WsBroadcaster', () => {
     let idxBroadcaster
 
     /** Register an authenticated client with its ws back-ref (like ws-server addClient). */
-    function reg(id, { activeSessionId = null, subscribe = [], authenticated = true, readyState = 1 } = {}) {
+    function reg(id, { activeSessionId = null, subscribe = [], authenticated = true, readyState = 1, usesDeflate = false } = {}) {
       const ws = createFakeWs({ readyState })
       // Start with activeSessionId null (like a fresh client) so the helper
       // performs a real transition and updates the index — passing it directly
       // to createFakeClient would make setActiveSession a no-op (prev === new).
       const client = createFakeClient({ id, authenticated })
       client._ws = ws
+      client.usesDeflate = usesDeflate
       manager.addClient(ws, client)
       if (activeSessionId) manager.setActiveSession(client, activeSessionId)
       for (const sid of subscribe) manager.subscribe(client, sid)
@@ -678,6 +725,48 @@ describe('WsBroadcaster', () => {
     it('returns 1 for a single-viewer session (the hot-path motivation)', () => {
       reg('solo', { activeSessionId: 'solo-sess' })
       assert.equal(idxBroadcaster._countSessionSubscribers('solo-sess'), 1)
+    })
+
+    // #5578: deflate-subscriber detection over the same reverse index.
+    it('_hasDeflateSubscriber resolves from the index (all-LAN / mixed / all-tunnel)', () => {
+      // all-LAN
+      reg('a', { activeSessionId: 'lan-sess' })
+      reg('b', { activeSessionId: 'other', subscribe: ['lan-sess'] })
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('lan-sess'), false)
+      // mixed: one tunnel peer among LAN
+      reg('c', { activeSessionId: 'mixed-sess' })
+      reg('d', { activeSessionId: 'mixed-sess', usesDeflate: true })
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('mixed-sess'), true)
+      // all-tunnel
+      reg('e', { activeSessionId: 'tun-sess', usesDeflate: true })
+      reg('f', { activeSessionId: 'other2', subscribe: ['tun-sess'], usesDeflate: true })
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('tun-sess'), true)
+      // unknown session
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('ghost'), false)
+    })
+
+    it('_hasDeflateSubscriber excludes unauthenticated + non-OPEN deflate members', () => {
+      reg('a', { activeSessionId: 'sess-1', usesDeflate: true, authenticated: false })
+      reg('b', { activeSessionId: 'sess-1', usesDeflate: true, readyState: 3 })
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('sess-1'), false)
+      // A healthy deflate member flips it true.
+      reg('c', { activeSessionId: 'sess-1', usesDeflate: true })
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('sess-1'), true)
+    })
+
+    it('_hasDeflateSubscriber re-resolves when a deflate subscriber joins/leaves', () => {
+      const lanViewer = reg('lan', { activeSessionId: 'sess-1' })
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('sess-1'), false)
+      // A phone on cellular subscribes → now true.
+      const phone = reg('phone', { usesDeflate: true })
+      manager.subscribe(phone.client, 'sess-1')
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('sess-1'), true)
+      // The phone unsubscribes → back to all-LAN.
+      manager.unsubscribe(phone.client, 'sess-1')
+      assert.equal(idxBroadcaster._hasDeflateSubscriber('sess-1'), false)
+      // Sanity: the LAN viewer is still indexed.
+      assert.equal(idxBroadcaster._countSessionSubscribers('sess-1'), 1)
+      assert.ok(lanViewer)
     })
 
     // The decisive test: over a randomized op sequence, the index broadcaster's


### PR DESCRIPTION
## Summary

The #5568 8ms single-subscriber delta-coalescing floor lets a fast emitter produce up to ~125 `stream_delta` frames/sec (was ~40/sec at the old 25ms). Each frame is ~40-75 bytes including `serverTs` — **under** the `permessage-deflate` `threshold:1024` (`ws-server.js`), so it ships **uncompressed**. On deflate-negotiated (tunnel/cellular) sockets that triples the small-packet count on exactly the links where per-frame cost dominates (small-packet overhead, cellular radio wake-ups, tunnel framing). LAN is unaffected — deflate is stripped at upgrade for LAN/loopback peers, so those frames are cheap.

This makes the coalescing window **deflate-aware**: keep the tight floors for all-LAN sessions, re-coalesce a beat longer when any subscriber is on a deflate socket.

### Window policy

| subscribers        | all-LAN | any deflate subscriber |
|--------------------|:-------:|:----------------------:|
| single (count = 1) |  8 ms   |        16 ms           |
| multi  (count ≥ 2) | 16 ms   |        25 ms           |

"any deflate subscriber" = at least one subscriber of the session sits on a deflate-negotiated socket. The widened windows still sit **below** the client-side adaptive EWMA floor (store-core `resolveDeltaFlushMs`, 16-100ms), so they don't reintroduce the pre-#5562 server/client window stacking — they only halve the wire-frame rate on the links that pay per frame. Constants `DEFLATE_FLUSH_INTERVAL_MS` / `DEFLATE_SINGLE_CLIENT_FLUSH_INTERVAL_MS` are documented in `event-normalizer.js` with the WHY.

### Plumbing (no O(all-clients) scan on the hot path)

- **`ws-server.js`** — stamp a per-client `usesDeflate` flag at connection setup, derived once from the upgrade-time `isLocalOrLanPeer(req)` decision (the same unspoofable socket-locality check that strips the deflate extension header). A LAN/loopback peer → `false`; any other peer → `true`. They can never diverge from the strip decision. (Kept minimal/focused — flag plumbing only, mindful of #5579 in flight on this file.)
- **`ws-broadcaster.js`** — new `_hasDeflateSubscriber(sessionId)`, mirroring `_countSessionSubscribers`'s recipient filter. Iterates **only** the #5575 reverse-index Set (O(subscribers)) and short-circuits on the first deflate peer. Full-scan fallback retained for fixtures without a `clientManager`.
- **`event-normalizer.js`** — `_resolveFlushIntervalMs` consults the injected deflate predicate (exactly once per buffered delta, alongside the existing subscriber-count resolver). Legacy single-session mode (sessionId === null) can't resolve subscribers, so it reports `false` → keeps the LAN window.

### serverTs decision: **KEPT**

The issue asked to evaluate dropping `serverTs` from `stream_delta` wire frames if only the #5520 instrumentation consumes it. It does **not**: the app (`packages/app/src/store/message-handler.ts`) and dashboard (`packages/dashboard/src/store/message-handler.ts`) both record `deltaServerTs` per messageId and compute the **token-to-render** half (`now - serverTs`) feeding the displayed p50/p95 latency stats (`recordLatencySamples`). Removing it would break a client-facing metric. So `serverTs` stays on the frame — **no protocol schema change, no dist rebuild.**

### Interplay preserved

- **#5565 buffer caps** — the cap force-flush path (`_forceFlushKey` / total-bytes `_flushDeltas` in `bufferDelta`) still bypasses the window deliberately; untouched, returns before the timer-arming block.
- **#5575 reverse index** — both `_countSessionSubscribers` and the new `_hasDeflateSubscriber` resolve from the same index; no new scan.

## Test plan

`packages/server` (Node 22, `--test-force-exit`):

- **`event-normalizer.test.js`** — new `#5578` block: all-LAN keeps 8/16ms; single deflate → 16ms; mixed multi → 25ms; window **re-resolves** on subscriber join/leave mid-session; custom deflate-interval overrides; legacy mode (no count resolver) ignores the predicate; a guard asserting both predicates are consulted **exactly once per buffered delta** (no O(clients) regression).
- **`ws-broadcaster.test.js`** — `_hasDeflateSubscriber` over the full-scan fallback (all-LAN / mixed / all-tunnel / wrong-session / unauth+closed exclusion) **and** the reverse-index fast path (all-LAN / mixed / all-tunnel, unauth+closed exclusion, join/leave re-resolution).
- Affected suites green: `event-normalizer.test.js` + `ws-broadcaster.test.js` = **173/173 pass**.
- Full `npm test`: **9161 pass**, 2 failures pre-existing & unrelated (`service.test.js` fetch-timeout/port-parsing flakes — confirmed identical on untouched `main`).
- All `scripts/lint-*.sh` pass; `npm run lint` (eslint) 0 errors; no `package-lock.json` drift; tests use the temp-`stateFilePath` convention (no `SessionManager` constructed here).

Closes #5578