### PR TITLE
chore(server): round-2 audit hardening — index lint, CI assert, deep ctx assert, per-pid tmp (#5579)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
 
       - name: Run tests with coverage
         run: npm test
+        env:
+          # #5579: arm the reverse-index drift assert (#5563) so the production
+          # assert path runs across the full server suite, not just the
+          # in-test parity oracle. Cheap O(clients × sessions) check per
+          # mutation; surfaces a desync between the per-client Sets and the
+          # sessionId→clients reverse index immediately.
+          CHROXY_WS_INDEX_ASSERT: '1'
 
       - name: Upload server coverage
         if: always()
@@ -242,6 +249,22 @@ jobs:
             echo "OK — enforced modules use loggerForSession"
           else
             echo "::error::A session-aware module dropped its loggerForSession import or introduced a bare createLogger. See packages/server/scripts/lint-logger-session-scoping.sh."
+            exit 1
+          fi
+
+      - name: Check reverse-index mutations route through ws-client-manager
+        run: |
+          # Issue #5579 — the sessionId→clients reverse index (#5575) only
+          # stays correct if every change to a client's active session or
+          # subscription Set goes through the index-maintaining mutators on
+          # ws-client-manager.js. A bare `client.activeSessionId = x` or
+          # `client.subscribedSessionIds.add(...)` elsewhere silently drifts
+          # the index. This lint forbids those outside the owner file (the two
+          # guarded #5563 fixture fallbacks carry a lint-ignore comment).
+          if scripts/lint-ws-index-mutations.sh; then
+            echo "OK — no bare reverse-index mutations outside ws-client-manager.js"
+          else
+            echo "::error::A bare reverse-index mutation was found outside ws-client-manager.js. See packages/server/scripts/lint-ws-index-mutations.sh."
             exit 1
           fi
 

--- a/packages/server/scripts/lint-ws-index-mutations.mjs
+++ b/packages/server/scripts/lint-ws-index-mutations.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Lint: the sessionId→clients reverse index introduced in #5575 is only
+ * correct if every change to a client's subscription Set or active session
+ * routes through the index-maintaining mutators on `ws-client-manager.js`
+ * (`subscribe` / `unsubscribe` / `setActiveSession`). A bare
+ * `client.activeSessionId = x` or `client.subscribedSessionIds.add(...)`
+ * outside that file mutates the per-client state WITHOUT updating the reverse
+ * index, so the index silently drifts — exactly the failure #5575's comment
+ * contract warns against. This lint turns that comment contract into a CI gate.
+ *
+ * Forbidden OUTSIDE `ws-client-manager.js`:
+ *   - `<expr>.activeSessionId = <…>`            (bare active-session write)
+ *   - `<expr>.subscribedSessionIds.add(<…>)`    (bare subscribe)
+ *   - `<expr>.subscribedSessionIds.delete(<…>)` (bare unsubscribe)
+ *   - `<expr>.subscribedSessionIds.clear()`     (bare clear)
+ *
+ * NOT forbidden (and not matched):
+ *   - comparisons: `client.activeSessionId === sessionId`, `!==`, `==`
+ *   - reads: `if (client.activeSessionId)`, `client.subscribedSessionIds.has(...)`
+ *   - anything inside a `//` or block comment
+ *
+ * Allow-list / opt-out:
+ *   - `ws-client-manager.js` — the OWNER of the index; its mutators are the
+ *     sanctioned write path, so it is exempt wholesale.
+ *   - `// lint-ignore-ws-index-mutation` placed on the line immediately above an
+ *     offending statement whitelists that one site. Used for the two guarded
+ *     fixture-fallback else-branches in ws-history.js / handler-utils.js (#5563),
+ *     where the helper path is always taken in production and the bare write
+ *     only runs for legacy test fixtures whose ctx predates the helper.
+ *
+ * Issue: #5579 (this lint). Index it guards: #5575. Helper contract: #5563.
+ *
+ * Exit codes:
+ *   0 — no bare reverse-index mutations outside the owner / allow-list
+ *   1 — at least one offender found (printed with file:line)
+ *
+ * Flags:
+ *   --src-dir <path>   Override the src directory (used by tests against
+ *                      fixture trees). Defaults to `../src` relative to this
+ *                      script.
+ *   --dry-run          Print offenders without failing the exit code.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function parseArgs(argv) {
+  const out = { srcDir: null, dryRun: false }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--src-dir') out.srcDir = argv[++i]
+    else if (argv[i] === '--dry-run') out.dryRun = true
+  }
+  return out
+}
+
+const args = parseArgs(process.argv.slice(2))
+const SRC_DIR = args.srcDir ? resolve(args.srcDir) : resolve(__dirname, '..', 'src')
+
+// The owner of the reverse index — its mutators are the sanctioned write path.
+const OWNER_FILE = 'ws-client-manager.js'
+
+// Per-line opt-out comment (matched against the line ABOVE an offending line).
+const IGNORE_COMMENT = 'lint-ignore-ws-index-mutation'
+
+// Bare active-session write: `.activeSessionId =` but NOT `==` / `===` / `=>`.
+const ACTIVE_WRITE_RE = /\.activeSessionId\s*=(?![=>])/g
+// Bare subscription-Set mutation.
+const SET_MUTATE_RE = /\.subscribedSessionIds\.(add|delete|clear)\s*\(/g
+
+function walk(dir, acc = []) {
+  for (const ent of readdirSync(dir)) {
+    const p = join(dir, ent)
+    const st = statSync(p)
+    if (st.isDirectory()) walk(p, acc)
+    else if (st.isFile() && p.endsWith('.js')) acc.push(p)
+  }
+  return acc
+}
+
+function isInsideComment(src, idx) {
+  const lineStart = src.lastIndexOf('\n', idx) + 1
+  const lineSoFar = src.slice(lineStart, idx)
+  if (lineSoFar.trimStart().startsWith('//')) return true
+  if (lineSoFar.trimStart().startsWith('*')) return true
+  const lastOpen = src.lastIndexOf('/*', idx)
+  const lastClose = src.lastIndexOf('*/', idx)
+  return lastOpen > lastClose
+}
+
+function lineOf(src, idx) {
+  return src.slice(0, idx).split('\n').length
+}
+
+// True if the opt-out comment appears in the contiguous block of `//` comment
+// lines immediately preceding `idx`. Scanning the whole block (not just the
+// single line above) lets the marker lead a multi-line justification comment
+// without forcing it onto the last line.
+function hasIgnoreAbove(src, idx) {
+  let lineStart = src.lastIndexOf('\n', idx) + 1
+  while (lineStart > 0) {
+    const prevLineEnd = lineStart - 1
+    const prevLineStart = src.lastIndexOf('\n', prevLineEnd - 1) + 1
+    const prevLine = src.slice(prevLineStart, prevLineEnd).trim()
+    if (!prevLine.startsWith('//')) return false
+    if (prevLine.includes(IGNORE_COMMENT)) return true
+    lineStart = prevLineStart
+  }
+  return false
+}
+
+function findOffenders(src, label) {
+  const offenders = []
+  for (const re of [ACTIVE_WRITE_RE, SET_MUTATE_RE]) {
+    re.lastIndex = 0
+    let m
+    while ((m = re.exec(src)) !== null) {
+      const idx = m.index
+      if (isInsideComment(src, idx)) continue
+      if (hasIgnoreAbove(src, idx)) continue
+      offenders.push({ line: lineOf(src, idx), kind: label })
+    }
+  }
+  return offenders.sort((a, b) => a.line - b.line)
+}
+
+const errors = []
+for (const file of walk(SRC_DIR)) {
+  const rel = pathSep === '/' ? relative(SRC_DIR, file) : relative(SRC_DIR, file).split(pathSep).join('/')
+  if (rel === OWNER_FILE) continue
+  const src = readFileSync(file, 'utf8')
+  for (const o of findOffenders(src)) {
+    errors.push({ file, line: o.line })
+  }
+}
+
+if (errors.length) {
+  console.error('ERROR: bare reverse-index mutation(s) found outside ws-client-manager.js.')
+  console.error('')
+  console.error('The sessionId→clients reverse index (#5575) drifts silently when a client\'s')
+  console.error('active session or subscription Set is mutated without going through the')
+  console.error('index-maintaining mutators on ws-client-manager.js. Route the change through:')
+  console.error('  ctx.transport.setActiveSession(client, sessionId)')
+  console.error('  ctx.transport.subscribeClient(client, sessionId)')
+  console.error('  ctx.transport.unsubscribeClient(client, sessionId)')
+  console.error('instead of `client.activeSessionId = …` / `client.subscribedSessionIds.add(…)`.')
+  console.error('')
+  console.error('If a site is a guarded fixture fallback (the helper is always taken in prod),')
+  console.error(`add a \`// ${IGNORE_COMMENT}\` comment on the line immediately above it.`)
+  console.error('')
+  for (const e of errors) {
+    console.error(`  ${e.file}:${e.line}`)
+  }
+  console.error('')
+  console.error('Background: issue #5579 (this lint), #5575 (the index), #5563 (the helpers).')
+  if (args.dryRun) process.exit(0)
+  process.exit(1)
+}
+
+console.log('OK: no bare reverse-index mutations outside ws-client-manager.js')

--- a/packages/server/scripts/lint-ws-index-mutations.mjs
+++ b/packages/server/scripts/lint-ws-index-mutations.mjs
@@ -14,6 +14,7 @@
  *   - `<expr>.subscribedSessionIds.add(<…>)`    (bare subscribe)
  *   - `<expr>.subscribedSessionIds.delete(<…>)` (bare unsubscribe)
  *   - `<expr>.subscribedSessionIds.clear()`     (bare clear)
+ *   - `<expr>.subscribedSessionIds = <…>`       (whole-Set reassignment)
  *
  * NOT forbidden (and not matched):
  *   - comparisons: `client.activeSessionId === sessionId`, `!==`, `==`
@@ -70,6 +71,10 @@ const IGNORE_COMMENT = 'lint-ignore-ws-index-mutation'
 const ACTIVE_WRITE_RE = /\.activeSessionId\s*=(?![=>])/g
 // Bare subscription-Set mutation.
 const SET_MUTATE_RE = /\.subscribedSessionIds\.(add|delete|clear)\s*\(/g
+// Whole-Set reassignment (`.subscribedSessionIds = new Set()`) — corrupts the
+// reverse index exactly like `.add()` would, so it gets the same treatment as
+// the activeSessionId field write. NOT `==` / `===` / `=>`.
+const SET_ASSIGN_RE = /\.subscribedSessionIds\s*=(?![=>])/g
 
 function walk(dir, acc = []) {
   for (const ent of readdirSync(dir)) {
@@ -122,7 +127,7 @@ function hasIgnoreAbove(src, idx) {
 
 function findOffenders(src, label) {
   const offenders = []
-  for (const re of [ACTIVE_WRITE_RE, SET_MUTATE_RE]) {
+  for (const re of [ACTIVE_WRITE_RE, SET_MUTATE_RE, SET_ASSIGN_RE]) {
     re.lastIndex = 0
     let m
     while ((m = re.exec(src)) !== null) {

--- a/packages/server/scripts/lint-ws-index-mutations.mjs
+++ b/packages/server/scripts/lint-ws-index-mutations.mjs
@@ -86,6 +86,14 @@ function isInsideComment(src, idx) {
   const lineSoFar = src.slice(lineStart, idx)
   if (lineSoFar.trimStart().startsWith('//')) return true
   if (lineSoFar.trimStart().startsWith('*')) return true
+  // Trailing inline `//` comment: a `//` opener earlier on the SAME line puts
+  // `idx` inside a line comment (e.g. `foo() // client.activeSessionId = x`).
+  // Ignore a `://` (URL scheme) so an inline URL before the match doesn't
+  // spuriously suppress a real offense; the matched tokens are code-like so a
+  // `//` inside a string literal on the same line is vanishingly unlikely.
+  for (let i = lineSoFar.indexOf('//'); i !== -1; i = lineSoFar.indexOf('//', i + 1)) {
+    if (i === 0 || lineSoFar[i - 1] !== ':') return true
+  }
   const lastOpen = src.lastIndexOf('/*', idx)
   const lastClose = src.lastIndexOf('*/', idx)
   return lastOpen > lastClose

--- a/packages/server/scripts/lint-ws-index-mutations.sh
+++ b/packages/server/scripts/lint-ws-index-mutations.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-ws-index-mutations.mjs`
+# for the actual implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-ws-index-mutations.sh` without worrying about the
+# Node interpreter path on the runner image.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-ws-index-mutations.mjs "$@"

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -372,6 +372,10 @@ export function autoSubscribeOtherClients(sessionId, excludeWs, ctx) {
       if (typeof ctx.transport.subscribeClient === 'function') {
         ctx.transport.subscribeClient(c, sessionId)
       } else {
+        // lint-ignore-ws-index-mutation: guarded fixture fallback. This
+        // else-branch only runs for legacy test fixtures whose ctx predates the
+        // #5563 index-maintaining subscribeClient helper; production always takes
+        // the helper path above, so this bare add can't drift the reverse index.
         c.subscribedSessionIds.add(sessionId)
       }
     }

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -41,10 +41,11 @@
  * aggregates (count / lastUsed / repos); the raw entries never cross the wire.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, chmodSync, unlinkSync } from 'node:fs'
+import { existsSync, readFileSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { createLogger } from './logger.js'
+import { writeFileRestricted } from './platform.js'
 
 const log = createLogger('skills-usage')
 
@@ -147,8 +148,17 @@ export function loadUsageStore(filePath = defaultSkillsUsagePath()) {
 
 /**
  * Persist a store object to disk. Atomic temp+rename so a crashed write cannot
- * corrupt the file; on POSIX the file ends up at mode 0600. Mirrors
- * `notification-prefs.js` savePrefs (the #4463 cleanup pattern).
+ * corrupt the file; on POSIX the file ends up at mode 0600.
+ *
+ * #5579: the temp sidecar carries a per-pid suffix (`.tmp-<pid>`), mirroring
+ * the #5309 convention in `session-state-persistence.js`. A fixed `.tmp` meant
+ * two daemons writing concurrently (e.g. an old process still flushing while a
+ * restart spins up) shared one intermediate path and could clobber each other
+ * mid-write, tearing the file. The per-pid suffix gives each writer its own
+ * sidecar so the rename — the atomic step — is the only point of contention.
+ * Delegates to `writeFileRestricted` (platform.js), which also unlinks the
+ * orphaned sidecar on rename failure and warns on a non-ENOENT cleanup miss so
+ * a stale `.tmp-<pid>` can't go silently undeleted.
  *
  * @param {object} store
  * @param {string} [filePath]
@@ -156,15 +166,7 @@ export function loadUsageStore(filePath = defaultSkillsUsagePath()) {
 export function saveUsageStore(store, filePath = defaultSkillsUsagePath()) {
   const dir = dirname(filePath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
-  const tmp = `${filePath}.tmp`
-  writeFileSync(tmp, JSON.stringify(store, null, 2), { mode: 0o600 })
-  try { chmodSync(tmp, 0o600) } catch { /* best-effort perms */ }
-  try {
-    renameSync(tmp, filePath)
-  } catch (err) {
-    try { unlinkSync(tmp) } catch { /* cleanup race — swallow */ }
-    throw err
-  }
+  writeFileRestricted(filePath, JSON.stringify(store, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
 }
 
 /**

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -350,6 +350,10 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     if (typeof ctx.setActiveSession === 'function') {
       ctx.setActiveSession(client, activeId)
     } else {
+      // lint-ignore-ws-index-mutation: guarded fixture fallback. This else-branch
+      // only runs for legacy test fixtures whose ctx predates the #5563
+      // index-maintaining setActiveSession helper; production always takes the
+      // helper path above, so this bare write can't drift the reverse index.
       client.activeSessionId = activeId
     }
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -720,7 +720,13 @@ export class WsServer {
       },
     }
     // Fail loudly if the production ctx ever drifts from the declared shape.
-    assertCtxShape(this._handlerCtx)
+    // #5579: deep assert so a CTX_NAMESPACES field forgotten on _handlerCtx
+    // fails at construction, not as a silent `undefined` read in prod. The
+    // deep check uses `key in bucket`, which does NOT invoke getters — so the
+    // late-bound getter fields (config, skillsUsageRecorder, projectsDirs, …)
+    // are verified present without triggering their side effects. One-time
+    // cost at startup is acceptable.
+    assertCtxShape(this._handlerCtx, { deep: true })
 
     // Context objects for extracted modules (ws-auth.js, ws-history.js)
     this._historyCtx = {

--- a/packages/server/tests/lint-ws-index-mutations.test.js
+++ b/packages/server/tests/lint-ws-index-mutations.test.js
@@ -95,6 +95,16 @@ export function note() {
 }
 `
 
+// A mutation pattern that appears only in a TRAILING inline \`//\` comment —
+// must NOT be flagged (regression for the inline-comment false positive).
+const INLINE_COMMENT_SRC = `
+export function note(client, s) {
+  doThing() // client.activeSessionId = s — the wrong way; use ctx.setActiveSession
+  more() // client.subscribedSessionIds.add(s) is also forbidden
+  return true
+}
+`
+
 function setupFixtureTree(extraFiles = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'chroxy-lint-ws-idx-'))
   const srcDir = join(dir, 'src')
@@ -180,6 +190,13 @@ describe('lint-ws-index-mutations', () => {
     cleanups.push(dir)
     const { code } = runLint(srcDir)
     assert.equal(code, 0, 'comment-only references must not be flagged')
+  })
+
+  test('does not flag mutation patterns inside a trailing inline // comment', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'doc.js': INLINE_COMMENT_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `inline-comment references must not be flagged\nstderr:\n${stderr}`)
   })
 
   test('--dry-run reports offenders but exits 0', () => {

--- a/packages/server/tests/lint-ws-index-mutations.test.js
+++ b/packages/server/tests/lint-ws-index-mutations.test.js
@@ -63,6 +63,17 @@ export function badSubscribe(client, sid) {
 }
 `
 
+// A whole-Set reassignment outside the owner — must FAIL; a comparison and an
+// arrow after `=` must NOT (regression for the assignment-vs-comparison split).
+const SET_REASSIGN_SRC = `
+export function badReplace(client) {
+  client.subscribedSessionIds = new Set()
+}
+export function fineCompare(client, other) {
+  return client.subscribedSessionIds === other.subscribedSessionIds
+}
+`
+
 // A bare delete + clear outside the owner — must FAIL (two offenses).
 const BARE_DELETE_CLEAR_SRC = `
 export function badRemove(client, sid) {
@@ -167,6 +178,15 @@ describe('lint-ws-index-mutations', () => {
     const { code, stderr } = runLint(srcDir)
     assert.equal(code, 1, 'bare subscribe must fail')
     assert.match(stderr, /handler-utils\.js:3/, 'error should name the offending file:line')
+  })
+
+  test('fails on whole-Set reassignment but not comparison', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'bad-replace.js': SET_REASSIGN_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'whole-Set reassignment must fail')
+    assert.match(stderr, /bad-replace\.js:3/, 'should flag the reassignment line')
+    assert.doesNotMatch(stderr, /bad-replace\.js:6/, 'comparison must not be flagged')
   })
 
   test('fails on bare delete and clear (two offenses)', () => {

--- a/packages/server/tests/lint-ws-index-mutations.test.js
+++ b/packages/server/tests/lint-ws-index-mutations.test.js
@@ -1,0 +1,196 @@
+/**
+ * Tests for scripts/lint-ws-index-mutations.mjs (#5579).
+ *
+ * The lint guards the sessionId→clients reverse index (#5575): every change to
+ * a client's active session or subscription Set must route through the
+ * index-maintaining mutators on ws-client-manager.js, or the index drifts. A
+ * bare `client.activeSessionId = x` / `client.subscribedSessionIds.add(...)`
+ * outside that file is an offense.
+ *
+ * Strategy: run the lint as a child process against a temp fixture `src/` tree
+ * (via the `--src-dir` override) and assert exit code + offender output.
+ */
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-ws-index-mutations.mjs')
+
+// The owner file — exempt wholesale, because its mutators ARE the sanctioned
+// write path. A bare mutation here must pass.
+const OWNER_SRC = `
+export class WsClientManager {
+  setActiveSession(client, sid) {
+    client.activeSessionId = sid
+  }
+  subscribe(client, sid) {
+    client.subscribedSessionIds.add(sid)
+  }
+  unsubscribe(client, sid) {
+    client.subscribedSessionIds.delete(sid)
+  }
+  reset(client) {
+    client.subscribedSessionIds.clear()
+  }
+}
+`
+
+// A clean handler — only reads and comparisons, no bare mutation.
+const CLEAN_SRC = `
+export function pick(client, sessionId) {
+  if (client.activeSessionId === sessionId) return true
+  if (client.activeSessionId !== sessionId) return false
+  return client.subscribedSessionIds.has(sessionId)
+}
+`
+
+// A bare active-session write outside the owner — must FAIL.
+const BARE_ACTIVE_WRITE_SRC = `
+export function badAssign(client, sid) {
+  client.activeSessionId = sid
+}
+`
+
+// A bare subscribe outside the owner — must FAIL.
+const BARE_SUBSCRIBE_SRC = `
+export function badSubscribe(client, sid) {
+  client.subscribedSessionIds.add(sid)
+}
+`
+
+// A bare delete + clear outside the owner — must FAIL (two offenses).
+const BARE_DELETE_CLEAR_SRC = `
+export function badRemove(client, sid) {
+  client.subscribedSessionIds.delete(sid)
+  client.subscribedSessionIds.clear()
+}
+`
+
+// A guarded fixture fallback carrying the opt-out comment above the bare write
+// (with a multi-line justification between marker and the line) — must PASS.
+const IGNORED_FALLBACK_SRC = `
+export function restore(client, ctx, activeId) {
+  if (typeof ctx.setActiveSession === 'function') {
+    ctx.setActiveSession(client, activeId)
+  } else {
+    // lint-ignore-ws-index-mutation: guarded fixture fallback. This else-branch
+    // only runs for legacy fixtures whose ctx predates the helper; production
+    // always takes the helper path above.
+    client.activeSessionId = activeId
+  }
+}
+`
+
+// A bare write that sits inside a comment — must NOT be flagged.
+const COMMENT_ONLY_SRC = `
+export function note() {
+  // Handlers MUST route through ctx.setActiveSession, NOT bare
+  // \`client.activeSessionId = x\` or \`client.subscribedSessionIds.add(...)\`.
+  return true
+}
+`
+
+function setupFixtureTree(extraFiles = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-lint-ws-idx-'))
+  const srcDir = join(dir, 'src')
+  mkdirSync(srcDir, { recursive: true })
+  for (const [name, src] of Object.entries(extraFiles)) {
+    writeFileSync(join(srcDir, name), src, 'utf8')
+  }
+  return { dir, srcDir }
+}
+
+function runLint(srcDir) {
+  const result = spawnSync(
+    process.execPath,
+    [LINT_SCRIPT, '--src-dir', srcDir],
+    { encoding: 'utf8' },
+  )
+  return {
+    code: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  }
+}
+
+describe('lint-ws-index-mutations', () => {
+  const cleanups = []
+  after(() => {
+    for (const dir of cleanups) {
+      try { rmSync(dir, { recursive: true, force: true }) } catch {}
+    }
+  })
+
+  test('passes on a clean tree (owner + read-only handler)', () => {
+    const { dir, srcDir } = setupFixtureTree({
+      'ws-client-manager.js': OWNER_SRC,
+      'ws-broadcaster.js': CLEAN_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stdout, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `lint should pass on clean tree\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+  })
+
+  test('allows bare mutations inside the owner file', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'ws-client-manager.js': OWNER_SRC })
+    cleanups.push(dir)
+    const { code } = runLint(srcDir)
+    assert.equal(code, 0, 'bare mutations in ws-client-manager.js must be exempt')
+  })
+
+  test('fails on a bare activeSessionId write outside the owner', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'ws-history.js': BARE_ACTIVE_WRITE_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'bare activeSessionId write must fail')
+    assert.match(stderr, /ws-history\.js:3/, 'error should name the offending file:line')
+  })
+
+  test('fails on a bare subscribedSessionIds.add outside the owner', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'handler-utils.js': BARE_SUBSCRIBE_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'bare subscribe must fail')
+    assert.match(stderr, /handler-utils\.js:3/, 'error should name the offending file:line')
+  })
+
+  test('fails on bare delete and clear (two offenses)', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'bad.js': BARE_DELETE_CLEAR_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'bare delete/clear must fail')
+    assert.match(stderr, /bad\.js:3/, 'should flag the delete line')
+    assert.match(stderr, /bad\.js:4/, 'should flag the clear line')
+  })
+
+  test('respects the lint-ignore comment on a guarded fallback', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'ws-history.js': IGNORED_FALLBACK_SRC })
+    cleanups.push(dir)
+    const { code, stdout, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `lint-ignore comment should suppress the offense\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+  })
+
+  test('does not flag mutation patterns that appear only inside comments', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'doc.js': COMMENT_ONLY_SRC })
+    cleanups.push(dir)
+    const { code } = runLint(srcDir)
+    assert.equal(code, 0, 'comment-only references must not be flagged')
+  })
+
+  test('--dry-run reports offenders but exits 0', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'bad.js': BARE_ACTIVE_WRITE_SRC })
+    cleanups.push(dir)
+    const result = spawnSync(
+      process.execPath,
+      [LINT_SCRIPT, '--src-dir', srcDir, '--dry-run'],
+      { encoding: 'utf8' },
+    )
+    assert.equal(result.status, 0, '--dry-run should not fail the exit code')
+    assert.match(result.stderr || '', /bad\.js:3/, '--dry-run should still print offenders')
+  })
+})

--- a/packages/server/tests/skills-usage.test.js
+++ b/packages/server/tests/skills-usage.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, readdirSync } from 'node:fs'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, readdirSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -112,13 +112,50 @@ describe('loadUsageStore / saveUsageStore (atomic, temp paths only)', () => {
     assert.equal(loaded.aggregates['batch-merge'].count, 1)
   })
 
-  it('leaves no .tmp file behind after a successful write', () => {
+  it('leaves no temp sidecar behind after a successful write', () => {
     const store = { version: 1, entries: [], aggregates: {} }
     applyUsage(store, { skill: 'x', ts: 1 })
     saveUsageStore(store, filePath)
     const dir = join(tmpDir, 'nested')
-    const leftover = readdirSync(dir).filter((f) => f.endsWith('.tmp'))
-    assert.deepEqual(leftover, [], 'no .tmp file should remain after an atomic write')
+    // #5579: the sidecar is now `.tmp-<pid>` (per-pid), so match any `.tmp`
+    // fragment, not just a trailing `.tmp`, to catch a leaked per-pid sidecar.
+    const leftover = readdirSync(dir).filter((f) => f.includes('.tmp'))
+    assert.deepEqual(leftover, [], 'no temp sidecar should remain after an atomic write')
+  })
+
+  it('#5579: uses a per-pid temp sidecar so concurrent writers do not collide', () => {
+    // Simulate two daemons (different pids) writing the same target around the
+    // same time. The #5309 convention gives each writer its own `.tmp-<pid>`
+    // sidecar, so a stale sidecar pre-created by writer B can NOT be torn or
+    // clobbered by writer A's write — the only contended step is the atomic
+    // rename. We approximate the overlap by pre-creating a foreign-pid sidecar,
+    // running a save, and asserting (a) the foreign sidecar is untouched and
+    // (b) the final file is the save's intact JSON.
+    const dir = join(tmpDir, 'nested')
+    mkdirSync(dir, { recursive: true })
+    const foreignPid = process.pid + 1
+    const foreignSidecar = `${filePath}.tmp-${foreignPid}`
+    const foreignBytes = 'OTHER-WRITER-IN-FLIGHT'
+    writeFileSync(foreignSidecar, foreignBytes)
+
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: 'mine', ts: 7 })
+    saveUsageStore(store, filePath)
+
+    // Our writer used `.tmp-<our pid>` and renamed it away — the foreign
+    // writer's sidecar is left exactly as it was (no collision).
+    assert.ok(existsSync(foreignSidecar), 'foreign-pid sidecar must survive our write')
+    assert.equal(readFileSync(foreignSidecar, 'utf8'), foreignBytes, 'foreign sidecar bytes untouched')
+
+    // The final target is our intact JSON, not a torn interleave.
+    const loaded = loadUsageStore(filePath)
+    assert.equal(loaded.entries.length, 1)
+    assert.equal(loaded.entries[0].skill, 'mine')
+
+    // Our own per-pid sidecar was consumed by the rename — none left behind.
+    const ourSidecar = `skills-usage.json.tmp-${process.pid}`
+    const leftover = readdirSync(dir).filter((f) => f === ourSidecar)
+    assert.deepEqual(leftover, [], 'our per-pid sidecar must be renamed away')
   })
 
   it('degrades a corrupt file to an empty store rather than throwing', () => {

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -11,6 +11,7 @@ import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS } from '../src/base-
 import { createKeyPair, deriveSharedKey, deriveConnectionKey, generateConnectionSalt, encrypt, decrypt, DIRECTION_SERVER, DIRECTION_CLIENT } from '@chroxy/store-core/crypto'
 import { createMockSession, createMockSessionManager, waitFor, GIT } from './test-helpers.js'
 import { setLogListener } from '../src/logger.js'
+import { CTX_NAMESPACES, CTX_NAMESPACE_NAMES, assertCtxShape } from '../src/ws-handler-context.js'
 
 // Wrapper that defaults noEncrypt: true for all tests (avoids 5s key exchange timeouts)
 // Also clears the log listener that WsServer.start() registers, so log_entry broadcasts
@@ -4663,5 +4664,59 @@ describe('WsServer permessage-deflate locality (#5516)', () => {
       /permessage-deflate/.test(ext),
       `tunnel peer should keep deflate, got extensions: "${ext}"`,
     )
+  })
+})
+
+describe('#5579: production handler ctx is deep-asserted at construction', () => {
+  let server = null
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('a real WsServer constructs cleanly — every CTX_NAMESPACES field is wired', () => {
+    // ws-server.js calls `assertCtxShape(this._handlerCtx, { deep: true })` in
+    // the constructor. If any CTX_NAMESPACES field were missing from
+    // _handlerCtx, this `new WsServer(...)` would throw before returning. The
+    // act of constructing is the assertion.
+    assert.doesNotThrow(() => {
+      server = new WsServer({
+        port: 0,
+        apiToken: 'tok-ctx-deep',
+        cliSession: createMockSession(),
+        authRequired: true,
+      })
+    }, 'WsServer construction must pass the deep ctx assert')
+  })
+
+  it('a CTX_NAMESPACES field dropped from a construction-shaped ctx throws (deep)', () => {
+    // Build a ctx with EVERY declared field present (the production happy path),
+    // then delete exactly one field and confirm the deep assert — the same call
+    // ws-server.js makes at construction — throws naming the missing key. This
+    // is the guard that turns a forgotten _handlerCtx field from a silent
+    // `undefined` read in prod into a construction-time crash.
+    const ctx = {}
+    for (const ns of CTX_NAMESPACE_NAMES) {
+      ctx[ns] = {}
+      for (const key of CTX_NAMESPACES[ns]) ctx[ns][key] = null
+    }
+    // Sanity: the fully-populated ctx passes deep.
+    assert.doesNotThrow(() => assertCtxShape(ctx, { deep: true }))
+
+    const droppedNs = 'services'
+    const droppedKey = CTX_NAMESPACES[droppedNs][0]
+    delete ctx[droppedNs][droppedKey]
+    assert.throws(
+      () => assertCtxShape(ctx, { deep: true }),
+      new RegExp(`ctx\\.${droppedNs} is missing required key '${droppedKey}'`),
+      'deep assert must throw naming the dropped field',
+    )
+
+    // And the SHALLOW assert would NOT catch it — proving the deep upgrade is
+    // what closes the gap (the namespace object is still present).
+    assert.doesNotThrow(() => assertCtxShape(ctx), 'shallow assert misses a missing key — that is the bug deep closes')
   })
 })


### PR DESCRIPTION
Four small LOW-severity hardening items from the round-2 swarm-audit, batched in one PR. Each is independent.

---

### Item 1 — Reverse-index mutation lint

**Summary.** `#5575`'s `sessionId→clients` reverse index is only correct if every change to a client's active session or subscription Set routes through the index-maintaining mutators on `ws-client-manager.js`; until now that was a comment contract only. New `scripts/lint-ws-index-mutations.{mjs,sh}` forbids bare `client.activeSessionId = …` and `client.subscribedSessionIds.add|delete|clear(…)` anywhere under `packages/server/src/` except the owner file. The two guarded `#5563` fixture-fallback else-branches (`ws-history.js`, `handler-utils.js`) carry a `// lint-ignore-ws-index-mutation` comment (the same opt-out style as `lint-session-opt-forwarding`). Wired into the Server Lint CI job alongside the other `lint-*.sh`.

**Test plan.**
- `tests/lint-ws-index-mutations.test.js` — fixture-tree self-tests: clean tree passes, owner-file mutations exempt, bare write/add/delete/clear each fail with `file:line`, the lint-ignore comment suppresses a guarded fallback, comment-only references aren't flagged, `--dry-run` reports but exits 0.
- Ran against the real repo: clean (exit 0). Live mutation self-test: removing an ignore comment makes it fail (exit 1, names the line); restoring makes it pass.

### Item 2 — Arm `CHROXY_WS_INDEX_ASSERT=1` in CI

**Summary.** The `#5563` runtime drift assert (`O(clients × sessions)` integrity check per mutation, gated on `CHROXY_WS_INDEX_ASSERT`) ran only in the in-test parity oracle, never on the production assert path in CI. Added `CHROXY_WS_INDEX_ASSERT: '1'` to the `Run tests with coverage` step env in the Server Tests job — minimal, env-only.

**Test plan.** Full server suite run locally with `CHROXY_WS_INDEX_ASSERT=1` — no new failures from the armed assert (the 2 pre-existing `service.test.js` failures are environmental: a live daemon on :8765 on the dev box, unrelated to this change). YAML parses; the env resolves to `{"CHROXY_WS_INDEX_ASSERT":"1"}` on the test step.

### Item 3 — Deep-assert the production handler ctx

**Summary.** `ws-server.js` called `assertCtxShape(this._handlerCtx)` shallow at construction, so a `CTX_NAMESPACES` field forgotten on `_handlerCtx` would slip to a silent `undefined` read in prod while `CTX_NAMESPACES`-derived mocks passed. Changed to `{ deep: true }`. Verified every `CTX_NAMESPACES` field is wired at construction first. `assertCtxShape`'s deep check uses `key in bucket`, which does **not** invoke getters — so the late-bound getter fields (`config`, `skillsUsageRecorder`, `projectsDirs`, …) are confirmed present without triggering side effects. One-time startup cost.

**Test plan.** Added to `tests/ws-server.test.js`: (a) a real `new WsServer(...)` constructs cleanly — the deep assert is the construction-time guard, so a missing field would throw before returning; (b) a construction-shaped ctx with one `CTX_NAMESPACES` field deleted throws under deep assert naming the key, and the **shallow** assert misses it — proving the deep upgrade is what closes the gap.

### Item 4 — Per-pid tmp suffix for `skills-usage.json`

**Summary.** `skills-usage.js` wrote a fixed `${filePath}.tmp`, diverging from the `#5309` per-pid convention; a daemon-restart overlap (old process still flushing while the restart spins up) could tear a write. Replaced the hand-rolled write+chmod+rename+cleanup block with `writeFileRestricted(filePath, …, { tmpSuffix: \`.tmp-${process.pid}\` })`, mirroring `session-state-persistence.js` exactly. Each writer now gets its own `.tmp-<pid>` sidecar; the helper also unlinks the orphaned sidecar on rename failure and warns on a non-ENOENT cleanup miss.

**Test plan.** `tests/skills-usage.test.js`: existing leftover-sidecar assertion broadened to catch any `.tmp` fragment (the sidecar is no longer a trailing `.tmp`); new `#5579` test simulates a concurrent foreign-pid writer — pre-creates `…json.tmp-<other pid>`, runs a save, and asserts the foreign sidecar is untouched, the final file is our intact JSON, and our own per-pid sidecar was renamed away.

---

### Aggregate verification
- New + affected suites green with `--test-force-exit` (`lint-ws-index-mutations`, `skills-usage`, `ws-server`, `test-helpers`): 183/183 with the index assert armed.
- All `lint-*.sh` pass, including the new one.
- ESLint: 0 errors across changed files.
- No lockfile drift (no dependency changes).

Related: #5575, #5577, #5574, #5563, #5309.

Closes #5579
