### PR TITLE
refactor(server): PathHashTrustLedger base + shared atomic JSON persistence (#5580)

### DIFF
--- a/packages/server/src/json-state-file.js
+++ b/packages/server/src/json-state-file.js
@@ -76,7 +76,10 @@ export function loadJsonState(filePath, fallback, opts = {}) {
   try {
     parsed = JSON.parse(raw)
   } catch (err) {
-    log.warn?.(`State file is malformed JSON (${err && err.message ? err.message : err}); starting fresh`)
+    // Deliberately do NOT echo err.message — JSON.parse errors can quote the
+    // offending input bytes, and this seam is reused for secret-adjacent state
+    // files (mirrors the session-preset.js leak-guard convention).
+    log.warn?.(`State file is malformed JSON (${(err && err.name) || 'SyntaxError'}); starting fresh`)
     onError?.('parse', err)
     return fallback()
   }

--- a/packages/server/src/json-state-file.js
+++ b/packages/server/src/json-state-file.js
@@ -1,0 +1,117 @@
+/**
+ * JsonStateFile (#5580) — the shared "fail-open load + atomic 0600 save" seam
+ * behind chroxy's hand-rolled JSON state files under `~/.chroxy/`.
+ *
+ * Chroxy carries ~15 small JSON state files (trust ledgers, usage logs,
+ * notification prefs, BYOK compose state, …) that all repeat the same two
+ * primitives:
+ *
+ *   1. LOAD: read + JSON.parse, fail OPEN to a caller-supplied empty value on
+ *      any read/parse error (missing file, malformed JSON, non-object root).
+ *      A corrupt state file must never throw into the caller — a single bad
+ *      write can't be allowed to brick session creation or skill loading.
+ *   2. SAVE: write atomically (temp + rename) at mode 0600, with a per-pid temp
+ *      suffix (#5309 / #5579) so two daemons mid-write can't tear the file.
+ *
+ * The SAVE half is NOT re-implemented here — it delegates to
+ * `writeFileRestricted` (platform.js), the established atomic-0600 writer that
+ * already handles the Windows ACL branch, rename-failure cleanup, and the
+ * orphaned-sidecar warn. This module is the thin promotion of that primitive
+ * into a load+save pair so new state stores stop copy-pasting the parse/empty
+ * guard and the mkdir+tmpSuffix dance. It is deliberately a function pair (not a
+ * heavyweight class) so existing module-level load/save exports can adopt it
+ * with a one-line body change and no behaviour drift.
+ *
+ * This is NOT a database and NOT a single-file migration: each caller keeps its
+ * own path, its own lifecycle, and its own security boundary. JsonStateFile only
+ * owns the read-bytes-or-empty and write-bytes-atomically mechanics that every
+ * one of them was duplicating.
+ */
+import { existsSync, readFileSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+import { writeFileRestricted } from './platform.js'
+import { createLogger } from './logger.js'
+
+const defaultLog = createLogger('json-state-file')
+
+/**
+ * Read + JSON.parse a state file, failing OPEN on any error.
+ *
+ * Returns `fallback()` (a freshly-built empty value) when the file is missing,
+ * unreadable, malformed JSON, or — when `requireObject` is set — has a
+ * non-object / array root. Never throws.
+ *
+ * The `fallback` is a factory (not a value) so each call gets its own fresh
+ * mutable container — returning a shared object would let one caller's mutations
+ * leak into the next failed load.
+ *
+ * @template T
+ * @param {string} filePath
+ * @param {() => T} fallback  Factory returning the empty value on any failure.
+ * @param {{
+ *   requireObject?: boolean,
+ *   log?: { warn?: (msg: string) => void, debug?: (msg: string) => void },
+ *   onError?: (stage: 'read' | 'parse' | 'shape', err: Error | null) => void,
+ * }} [opts]
+ * @returns {T}
+ */
+export function loadJsonState(filePath, fallback, opts = {}) {
+  const log = opts.log || defaultLog
+  const requireObject = opts.requireObject !== false
+  const onError = typeof opts.onError === 'function' ? opts.onError : null
+
+  let raw
+  try {
+    raw = readFileSync(filePath, 'utf8')
+  } catch (err) {
+    // ENOENT (first run) is normal and silent; other read errors warn once.
+    if (err && err.code !== 'ENOENT') {
+      log.warn?.(`Could not read state file (${err.code || err.message}); starting fresh`)
+      onError?.('read', err)
+    }
+    return fallback()
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    log.warn?.(`State file is malformed JSON (${err && err.message ? err.message : err}); starting fresh`)
+    onError?.('parse', err)
+    return fallback()
+  }
+
+  if (requireObject && (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))) {
+    log.warn?.('State file root is not an object; starting fresh')
+    onError?.('shape', null)
+    return fallback()
+  }
+
+  return parsed
+}
+
+/**
+ * Serialise `value` to pretty JSON (trailing newline) and write it atomically at
+ * mode 0600 via `writeFileRestricted`. Creates the parent directory (mode 0700)
+ * first if missing. The temp sidecar carries a per-pid suffix so concurrent
+ * writers to the same target never share an intermediate path (#5309 / #5579).
+ *
+ * Re-throws on write/rename failure — callers that must surface a read-only-HOME
+ * failure (e.g. SkillsTrustStore.flush) get the error; callers that treat
+ * persistence as best-effort wrap the call in their own try/catch.
+ *
+ * @param {string} filePath
+ * @param {unknown} value
+ * @param {{ pretty?: boolean, tmpSuffix?: string }} [opts]
+ */
+export function saveJsonState(filePath, value, opts = {}) {
+  const dir = dirname(filePath)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const payload = opts.pretty === false
+    ? JSON.stringify(value)
+    : JSON.stringify(value, null, 2) + '\n'
+  const tmpSuffix = typeof opts.tmpSuffix === 'string' && opts.tmpSuffix.length > 0
+    ? opts.tmpSuffix
+    : `.${process.pid}.tmp`
+  writeFileRestricted(filePath, payload, { tmpSuffix })
+}

--- a/packages/server/src/path-hash-trust-ledger.js
+++ b/packages/server/src/path-hash-trust-ledger.js
@@ -1,0 +1,323 @@
+/**
+ * PathHashTrustLedger (#5580) — the shared core of chroxy's path-keyed,
+ * SHA-256-pinned trust ledgers.
+ *
+ * Two security surfaces grew the same ledger independently:
+ *
+ *   - SkillsTrustStore (skills-trust.js, #3204): pins the hash of every skill
+ *     body the loader has seen; a changed hash re-gates (warn / block).
+ *   - SessionPresetTrustStore (session-preset-trust.js, #5553/#5576): pins the
+ *     hash of a repo-local `.chroxy/session.json`; a changed hash re-gates the
+ *     preset to INERT until an operator re-approves.
+ *
+ * Both store a path → `{ sha256, firstSeen, <approvalTs> }` map under a single
+ * top-level wrapper key, both key paths through a case-folding normaliser, both
+ * fail OPEN to an empty ledger on a corrupt/missing file (a single bad write
+ * must never lock every skill / preset out), and both persist atomically at
+ * mode 0600. This base owns exactly that shared mechanism. Everything that
+ * genuinely differs is a subclass override:
+ *
+ *   - the third timestamp FIELD NAME (`lastVerified` vs `approvedAt`)
+ *   - the on-disk WRAPPER key (`skills` vs `presets`) and any sibling indexes
+ *     (skills' `communityTrust`)
+ *   - whether `flush()` RE-THROWS a persistence failure (skills — so a handler
+ *     can surface TRUST_FLUSH_FAILED) or SWALLOWS it (preset — best-effort)
+ *   - any EXTRAS layered on top (skills' modes, v1→v2 migration, verify-throttle)
+ *
+ * SAFEST-default policy (per #5580): where the two stores diverged on a SAFETY
+ * mechanic, the base defaults to the more defensive variant and lets a subclass
+ * opt out explicitly. Concretely:
+ *
+ *   - PERSIST: writes go through a `openSync(tmp, 'wx', 0o600)` + `fsyncSync` +
+ *     `renameSync` dance with a per-pid + per-call RANDOM temp suffix. The
+ *     random suffix is the skills variant (#3238) — it survives two writers in
+ *     the SAME process flushing to the same default ledger path, which the
+ *     preset store's `pid + Date.now()` suffix could (in principle) collide on
+ *     within a millisecond. fsync-before-rename is also the skills variant; the
+ *     preset store had it too, so this is a no-op for preset and a strict
+ *     safety win as the shared default.
+ *   - KEY NORMALISATION: each subclass supplies its own `normalizeKey` (skills
+ *     and preset already share identical case-folding logic but import it from
+ *     different modules — kept as a hook so neither module's exported
+ *     `_normalizePathKey` identity changes).
+ *
+ * On-disk formats are BYTE-COMPATIBLE with the pre-extraction files — existing
+ * ledgers load unchanged and re-serialise to the same shape. No migration.
+ */
+import { readFileSync, mkdirSync, openSync, writeSync, closeSync, fsyncSync, renameSync, unlinkSync } from 'fs'
+import { dirname } from 'path'
+import { randomBytes } from 'crypto'
+
+/**
+ * @typedef {Object} TrustRecord
+ * @property {string} sha256       64-char lower-case hex digest
+ * @property {string} firstSeen    ISO timestamp of first sight
+ * @property {string} [approvalTs] The third timestamp (named per subclass)
+ */
+
+const HEX64 = /^[0-9a-f]{64}$/
+
+export class PathHashTrustLedger {
+  /**
+   * @param {{
+   *   filePath: string,
+   *   log: { warn: Function, info?: Function },
+   *   normalizeKey: (p: string) => string,
+   *   approvalField?: string,    // name of the third timestamp field (default 'approvedAt')
+   *   wrapperKey?: string,       // on-disk top-level key holding the records map (default 'records')
+   *   throwOnFlushError?: boolean, // re-throw persistence failures (default false — best-effort)
+   * }} opts
+   */
+  constructor(opts = {}) {
+    if (!opts.filePath) throw new Error('PathHashTrustLedger: filePath is required')
+    if (!opts.log) throw new Error('PathHashTrustLedger: log is required')
+    if (typeof opts.normalizeKey !== 'function') throw new Error('PathHashTrustLedger: normalizeKey is required')
+    this._filePath = opts.filePath
+    this._log = opts.log
+    this._normalizeKey = opts.normalizeKey
+    this._approvalField = opts.approvalField || 'approvedAt'
+    this._wrapperKey = opts.wrapperKey || 'records'
+    this._throwOnFlushError = opts.throwOnFlushError === true
+    // Subclasses run their own _load() (which may parse extra sibling indexes
+    // and set extra dirty state) — the base does not auto-load so a subclass
+    // can wire its constructor in whatever order it needs.
+    this._records = Object.create(null)
+    this._dirty = false
+  }
+
+  /**
+   * Read + parse the ledger's records map, failing open to empty on any error.
+   * Returns `{ records, parsed, migratedLegacy }` where:
+   *   - `records` is the validated, key-normalised path → record map
+   *   - `parsed` is the raw parsed JSON object (so a subclass can pull sibling
+   *     indexes like communityTrust out of it) or null on a read/parse failure
+   *   - `migratedLegacy` is whether a subclass legacy-shape hook claimed the file
+   *
+   * The records map is sourced from `parsed[wrapperKey]` (v2-style nesting). A
+   * subclass that supports a legacy flat-root format overrides `_extractLegacy`
+   * to detect + return it (skills v1).
+   *
+   * @returns {{ records: object, parsed: object|null, migratedLegacy: boolean }}
+   * @protected
+   */
+  _loadRecords() {
+    const empty = { records: Object.create(null), parsed: null, migratedLegacy: false }
+
+    let raw
+    try {
+      raw = readFileSync(this._filePath, 'utf8')
+    } catch (err) {
+      if (err && err.code !== 'ENOENT') {
+        this._log.warn(`Could not read trust file (${err.code || err.message}); starting fresh`)
+      }
+      return empty
+    }
+
+    let parsed
+    try {
+      parsed = JSON.parse(raw)
+    } catch (err) {
+      this._log.warn(`Trust file is malformed JSON (${err && err.message ? err.message : err}); starting fresh`)
+      return empty
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      this._log.warn('Trust file root is not an object; starting fresh')
+      return empty
+    }
+
+    // Locate the records map. v2 nesting under the wrapper key wins; otherwise
+    // a subclass legacy hook gets a chance to claim a flat-root format.
+    let rawMap = null
+    let migratedLegacy = false
+    const nested = parsed[this._wrapperKey]
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      rawMap = nested
+    } else {
+      const legacy = this._extractLegacy(parsed)
+      if (legacy && legacy.rawMap) {
+        rawMap = legacy.rawMap
+        migratedLegacy = legacy.migratedLegacy === true
+      } else if (Object.keys(parsed).length === 0) {
+        // Empty object — treat as an empty ledger (fresh).
+        rawMap = {}
+      } else {
+        this._log.warn('Trust file has unrecognised shape; starting fresh')
+        return empty
+      }
+    }
+
+    const records = Object.create(null)
+    for (const [key, value] of Object.entries(rawMap)) {
+      const rec = this._validateRecord(value)
+      if (rec) {
+        // Last-writer-wins on key collisions (only possible on a case-folding
+        // FS with mixed historical casings); Object.entries is insertion-order.
+        records[this._normalizeKey(key)] = rec
+      }
+    }
+    return { records, parsed, migratedLegacy }
+  }
+
+  /**
+   * Validate + coerce a single on-disk record. Drops any record that lacks a
+   * valid sha256 + firstSeen. The third timestamp falls back to firstSeen when
+   * missing/malformed (matches both stores' self-heal behaviour).
+   *
+   * @param {unknown} value
+   * @returns {TrustRecord|null}
+   * @protected
+   */
+  _validateRecord(value) {
+    if (
+      value && typeof value === 'object'
+      && typeof value.sha256 === 'string' && HEX64.test(value.sha256)
+      && typeof value.firstSeen === 'string'
+    ) {
+      const approval = typeof value[this._approvalField] === 'string'
+        ? value[this._approvalField]
+        : value.firstSeen
+      return {
+        sha256: value.sha256,
+        firstSeen: value.firstSeen,
+        [this._approvalField]: approval,
+      }
+    }
+    return null
+  }
+
+  /**
+   * Legacy-shape hook. Base returns null (no legacy format). A subclass that
+   * supports a flat-root legacy file (skills v1) overrides this to detect it and
+   * return `{ rawMap, migratedLegacy: true }`.
+   *
+   * @param {object} _parsed
+   * @returns {{ rawMap: object, migratedLegacy: boolean }|null}
+   * @protected
+   */
+  _extractLegacy(_parsed) {
+    return null
+  }
+
+  /**
+   * Is the path at `absPath` currently trusted for content hash `hash`?
+   * True only when a record exists AND its sha256 equals `hash`.
+   *
+   * @param {string} absPath
+   * @param {string} hash
+   * @returns {boolean}
+   */
+  isTrusted(absPath, hash) {
+    if (typeof absPath !== 'string' || typeof hash !== 'string') return false
+    const rec = this._records[this._normalizeKey(absPath)]
+    return !!rec && rec.sha256 === hash
+  }
+
+  /**
+   * Read-only clone of the stored record (or null). Lets a dashboard render
+   * firstSeen / the approval timestamp without mutating ledger state.
+   *
+   * @param {string} absPath
+   * @returns {TrustRecord|null}
+   */
+  getRecord(absPath) {
+    const rec = this._records[this._normalizeKey(absPath)]
+    if (!rec) return null
+    return {
+      sha256: rec.sha256,
+      firstSeen: rec.firstSeen,
+      [this._approvalField]: rec[this._approvalField],
+    }
+  }
+
+  /**
+   * Approve `hash` for `absPath`: records (or refreshes) the entry, preserving
+   * the original firstSeen, and stamps the approval timestamp to now. Persists
+   * synchronously so the grant survives a crash. Rejects a non-hex hash.
+   *
+   * @param {string} absPath
+   * @param {string} hash
+   * @returns {boolean} true when the grant was recorded
+   */
+  approve(absPath, hash) {
+    if (typeof absPath !== 'string' || !absPath) return false
+    if (typeof hash !== 'string' || !HEX64.test(hash)) return false
+    const key = this._normalizeKey(absPath)
+    const now = new Date().toISOString()
+    const existing = this._records[key]
+    this._records[key] = {
+      sha256: hash,
+      firstSeen: existing && typeof existing.firstSeen === 'string' ? existing.firstSeen : now,
+      [this._approvalField]: now,
+    }
+    this._dirty = true
+    this.flush()
+    return true
+  }
+
+  /**
+   * Revoke `absPath` — drops the record so the path goes inert again. Persists
+   * synchronously.
+   *
+   * @param {string} absPath
+   * @returns {boolean} true when a record was removed
+   */
+  revoke(absPath) {
+    if (typeof absPath !== 'string' || !absPath) return false
+    const key = this._normalizeKey(absPath)
+    if (!this._records[key]) return false
+    delete this._records[key]
+    this._dirty = true
+    this.flush()
+    return true
+  }
+
+  /**
+   * Serialise the in-memory ledger to the on-disk shape. A subclass overrides
+   * this to wrap the records map in its top-level key and emit any sibling
+   * indexes. The base wraps the records map under `wrapperKey`.
+   *
+   * @returns {object} the object to JSON.stringify
+   * @protected
+   */
+  _serialize() {
+    const map = {}
+    for (const [k, v] of Object.entries(this._records)) map[k] = v
+    return { [this._wrapperKey]: map }
+  }
+
+  /**
+   * Persist the ledger to disk. No-op when clean. Atomic-via-rename + 0600 with
+   * a per-pid + random temp suffix (the safest of the two source variants —
+   * tolerates concurrent writers in the same process, #3238). fsync before
+   * rename so the bytes are durable before the directory entry flips.
+   *
+   * On failure: best-effort cleanup of our own fd + temp, then either re-throw
+   * (subclass set `throwOnFlushError`) or swallow with a warn.
+   */
+  flush() {
+    if (!this._dirty) return
+    const tmpPath = `${this._filePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`
+    let fd = null
+    try {
+      mkdirSync(dirname(this._filePath), { recursive: true })
+      const payload = JSON.stringify(this._serialize(), null, 2) + '\n'
+      fd = openSync(tmpPath, 'wx', 0o600)
+      writeSync(fd, payload, 0, 'utf8')
+      fsyncSync(fd)
+      closeSync(fd)
+      fd = null
+      renameSync(tmpPath, this._filePath)
+      this._dirty = false
+    } catch (err) {
+      if (fd !== null) {
+        try { closeSync(fd) } catch { /* ignore */ }
+      }
+      try { unlinkSync(tmpPath) } catch { /* ignore */ }
+      this._log.warn(`Could not persist trust file (${err && err.code ? err.code : err.message || err})`)
+      if (this._throwOnFlushError) throw err
+    }
+  }
+}
+
+export { HEX64 as _HEX64 }

--- a/packages/server/src/session-preset-trust.js
+++ b/packages/server/src/session-preset-trust.js
@@ -26,13 +26,18 @@
  * operator approves the CURRENT hash via `approve(path, hash)`; `revoke(path)`
  * drops the record so the preset goes inert again.
  *
+ * Since #5580 the ledger mechanics (load/isTrusted/approve/revoke/getRecord +
+ * atomic 0600 persist + fail-open) live in `PathHashTrustLedger`; this class is
+ * a thin subclass that pins the `presets` wrapper key and the `approvedAt`
+ * timestamp field. The on-disk format is byte-identical to the pre-#5580 file.
+ *
  * Persistence safety mirrors SkillsTrustStore: atomic write-via-rename, mode
- * 0600, fail-open on a corrupt/missing file. Failures are non-fatal so a
- * read-only $HOME never breaks session creation.
+ * 0600, fail-open on a corrupt/missing file. Failures are non-fatal (best-effort
+ * flush) so a read-only $HOME never breaks session creation.
  */
-import { readFileSync, mkdirSync, existsSync, openSync, writeSync, closeSync, fsyncSync, renameSync, unlinkSync } from 'fs'
-import { dirname } from 'path'
+import { existsSync } from 'fs'
 import { createLogger } from './logger.js'
+import { PathHashTrustLedger } from './path-hash-trust-ledger.js'
 import { DEFAULT_PRESET_TRUST_FILE, _normalizePathKey } from './session-preset.js'
 
 const log = createLogger('session-preset-trust')
@@ -44,166 +49,22 @@ export { DEFAULT_PRESET_TRUST_FILE }
  * instance per daemon (constructed by SessionManager); tests pass an explicit
  * `filePath` so they never touch the real ledger.
  */
-export class SessionPresetTrustStore {
+export class SessionPresetTrustStore extends PathHashTrustLedger {
   /**
    * @param {{ filePath?: string }} [opts]
    */
   constructor({ filePath } = {}) {
-    this._filePath = filePath || DEFAULT_PRESET_TRUST_FILE
-    this._records = this._load()
+    super({
+      filePath: filePath || DEFAULT_PRESET_TRUST_FILE,
+      log,
+      normalizeKey: _normalizePathKey,
+      approvalField: 'approvedAt',
+      wrapperKey: 'presets',
+      throwOnFlushError: false, // best-effort: a read-only $HOME never breaks session creation
+    })
+    const loaded = this._loadRecords()
+    this._records = loaded.records
     this._dirty = false
-  }
-
-  /**
-   * Read + parse the ledger. Fails open to empty state on any error.
-   * @returns {Record<string, { sha256: string, firstSeen: string, approvedAt: string }>}
-   * @private
-   */
-  _load() {
-    const empty = Object.create(null)
-    let raw
-    try {
-      raw = readFileSync(this._filePath, 'utf8')
-    } catch (err) {
-      if (err && err.code !== 'ENOENT') {
-        log.warn(`Could not read preset-trust file (${err.code || err.message}); starting fresh`)
-      }
-      return empty
-    }
-
-    let parsed
-    try {
-      parsed = JSON.parse(raw)
-    } catch {
-      log.warn('Preset-trust file is malformed JSON; starting fresh')
-      return empty
-    }
-
-    const src = parsed && typeof parsed === 'object' && !Array.isArray(parsed) && parsed.presets
-      && typeof parsed.presets === 'object' && !Array.isArray(parsed.presets)
-      ? parsed.presets
-      : null
-    if (!src) {
-      if (parsed && Object.keys(parsed).length > 0) log.warn('Preset-trust file has unrecognised shape; starting fresh')
-      return empty
-    }
-
-    const out = Object.create(null)
-    for (const [key, value] of Object.entries(src)) {
-      if (
-        value && typeof value === 'object'
-        && typeof value.sha256 === 'string' && /^[0-9a-f]{64}$/.test(value.sha256)
-        && typeof value.firstSeen === 'string'
-      ) {
-        out[_normalizePathKey(key)] = {
-          sha256: value.sha256,
-          firstSeen: value.firstSeen,
-          approvedAt: typeof value.approvedAt === 'string' ? value.approvedAt : value.firstSeen,
-        }
-      }
-    }
-    return out
-  }
-
-  /**
-   * Is the preset at `absPath` with content hash `hash` currently trusted?
-   * True only when a record exists AND its sha256 matches `hash`. First sight
-   * records nothing here (recording is deferred to `noteSeen`) — an unknown
-   * path is simply untrusted.
-   *
-   * @param {string} absPath
-   * @param {string} hash  The current preset content hash (64 hex chars)
-   * @returns {boolean}
-   */
-  isTrusted(absPath, hash) {
-    if (typeof absPath !== 'string' || typeof hash !== 'string') return false
-    const rec = this._records[_normalizePathKey(absPath)]
-    return !!rec && rec.sha256 === hash
-  }
-
-  /**
-   * Read-only accessor for the dashboard — returns a clone of the stored
-   * record (or null). Lets the UI render firstSeen / approvedAt without
-   * mutating ledger state.
-   *
-   * @param {string} absPath
-   * @returns {{ sha256: string, firstSeen: string, approvedAt: string } | null}
-   */
-  getRecord(absPath) {
-    const rec = this._records[_normalizePathKey(absPath)]
-    if (!rec) return null
-    return { sha256: rec.sha256, firstSeen: rec.firstSeen, approvedAt: rec.approvedAt }
-  }
-
-  /**
-   * Approve the CURRENT content hash for `absPath`. Marks the preset trusted
-   * (and active for future sessions). Persists synchronously so the grant
-   * survives a crash.
-   *
-   * @param {string} absPath
-   * @param {string} hash  The content hash to trust (64 hex chars)
-   * @returns {boolean} true when the grant was recorded
-   */
-  approve(absPath, hash) {
-    if (typeof absPath !== 'string' || !absPath) return false
-    if (typeof hash !== 'string' || !/^[0-9a-f]{64}$/.test(hash)) return false
-    const key = _normalizePathKey(absPath)
-    const now = new Date().toISOString()
-    const existing = this._records[key]
-    this._records[key] = {
-      sha256: hash,
-      firstSeen: existing && typeof existing.firstSeen === 'string' ? existing.firstSeen : now,
-      approvedAt: now,
-    }
-    this._dirty = true
-    this.flush()
-    return true
-  }
-
-  /**
-   * Revoke trust for `absPath` — drops the record so the preset goes inert
-   * (pending) again. Persists synchronously.
-   *
-   * @param {string} absPath
-   * @returns {boolean} true when a record was removed
-   */
-  revoke(absPath) {
-    if (typeof absPath !== 'string' || !absPath) return false
-    const key = _normalizePathKey(absPath)
-    if (!this._records[key]) return false
-    delete this._records[key]
-    this._dirty = true
-    this.flush()
-    return true
-  }
-
-  /**
-   * Persist the ledger to disk. Atomic-via-rename + 0600; no-op when clean.
-   * Failure is non-fatal — keep the in-memory ledger and retry next grant.
-   */
-  flush() {
-    if (!this._dirty) return
-    const tmpPath = `${this._filePath}.${process.pid}.${Date.now()}.tmp`
-    let fd = null
-    try {
-      mkdirSync(dirname(this._filePath), { recursive: true })
-      const presets = {}
-      for (const [k, v] of Object.entries(this._records)) presets[k] = v
-      const payload = JSON.stringify({ presets }, null, 2) + '\n'
-      fd = openSync(tmpPath, 'wx', 0o600)
-      writeSync(fd, payload, 0, 'utf8')
-      fsyncSync(fd)
-      closeSync(fd)
-      fd = null
-      renameSync(tmpPath, this._filePath)
-      this._dirty = false
-    } catch (err) {
-      if (fd !== null) {
-        try { closeSync(fd) } catch { /* ignore */ }
-      }
-      try { unlinkSync(tmpPath) } catch { /* ignore */ }
-      log.warn(`Could not persist preset-trust file (${err && err.code ? err.code : err.message || err})`)
-    }
   }
 }
 

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -28,6 +28,14 @@
  * v1 (flat path-keyed object at root) is detected and migrated on first load
  * (#3297). The file is rewritten to v2 on the next flush.
  *
+ * Since #5580 the ledger mechanics (load/isTrusted/getRecord + atomic 0600
+ * persist + fail-open) live in `PathHashTrustLedger`; this class is a subclass
+ * that layers on the skills-specific EXTRAS — trust modes, the v1→v2 migration,
+ * the `inspect()` record/verify/mismatch path with its verify-throttle, the
+ * `communityTrust` sibling index, and `acceptHash`. The records map, key
+ * normalisation, and the atomic-write dance are inherited. The on-disk format
+ * is byte-identical to the pre-#5580 file.
+ *
  * Default location: `~/.chroxy/skills-trust.json`. Picked instead of
  * folding into `session-state.json` because session state is per-session,
  * frequently rewritten by the SessionStatePersistence debounce loop, and
@@ -62,14 +70,16 @@
  * every session. The recovery path is to delete the trust file and
  * re-trust on next load.
  *
- * Persistence safety (#3232):
- *   - Writes go through a `<path>.tmp` sibling and `fs.renameSync` so a
- *     mid-write crash leaves either the previous good file or a stale
- *     `.tmp` (which `_load` ignores). The target file is never observed
- *     in a half-written state.
+ * Persistence safety (#3232) is inherited from PathHashTrustLedger:
+ *   - Writes go through a `<path>.<pid>.<rand>.tmp` sibling and
+ *     `fs.renameSync` so a mid-write crash leaves either the previous good
+ *     file or a stale `.tmp` (which `_load` ignores). The target file is
+ *     never observed in a half-written state.
  *   - The temp file is created with mode `0600` (owner read/write only)
  *     so the ledger isn't world-readable on POSIX. `rename` preserves
  *     mode so the post-rename target keeps `0600`.
+ *   - The skills store re-throws a persistence failure (throwOnFlushError)
+ *     so a handler can surface TRUST_FLUSH_FAILED to the user.
  *
  * Case-insensitive ledger keys (#3233):
  *   - On case-insensitive filesystems (macOS APFS default, Windows NTFS
@@ -88,11 +98,13 @@
  *     the on-disk canonical casing, so the same inode resolves to the
  *     same byPath key regardless of how the caller spelled it.
  */
-import { readFileSync, mkdirSync, existsSync, openSync, writeSync, closeSync, fsyncSync, renameSync, unlinkSync } from 'fs'
-import { dirname, join, basename } from 'path'
+import { existsSync } from 'fs'
+import { basename } from 'path'
 import { homedir } from 'os'
-import { createHash, randomBytes } from 'crypto'
+import { join } from 'path'
+import { createHash } from 'crypto'
 import { createLogger } from './logger.js'
+import { PathHashTrustLedger } from './path-hash-trust-ledger.js'
 
 const log = createLogger('skills-trust')
 
@@ -182,12 +194,19 @@ export function sha256Hex(body) {
  * SessionManager). Operators who explicitly set `'warn'` or `'block'`
  * get those modes; everyone else gets the legacy no-op behaviour.
  */
-export class SkillsTrustStore {
+export class SkillsTrustStore extends PathHashTrustLedger {
   /**
    * @param {{ filePath?: string, mode?: 'warn'|'block', verifyThrottleMs?: number }} [opts]
    */
   constructor({ filePath, mode, verifyThrottleMs } = {}) {
-    this._filePath = filePath || DEFAULT_TRUST_FILE
+    super({
+      filePath: filePath || DEFAULT_TRUST_FILE,
+      log,
+      normalizeKey: _normalizePathKey,
+      approvalField: 'lastVerified',
+      wrapperKey: 'skills',
+      throwOnFlushError: true, // re-throw so handlers can surface TRUST_FLUSH_FAILED
+    })
     this._mode = VALID_TRUST_MODES.has(mode) ? mode : TRUST_MODE_WARN
     // How long a `lastVerified` timestamp stays "fresh enough" to skip
     // an update. Caller may override (tests pass 0 to force a bump on
@@ -196,16 +215,17 @@ export class SkillsTrustStore {
     this._verifyThrottleMs = Number.isFinite(verifyThrottleMs) && verifyThrottleMs >= 0
       ? verifyThrottleMs
       : DEFAULT_VERIFY_THROTTLE_MS
-    const loaded = this._load()
+    const loaded = this._loadRecords()
     this._records = loaded.records
     // Community trust indexes (#3297): byAuthor maps author -> grant record;
     // byPath maps realPath -> grant record. Either index is sufficient for
     // isCommunityTrusted() — a skill is trusted if its author OR its exact
-    // path has been granted.
-    this.communityTrust = loaded.communityTrust
+    // path has been granted. Parsed out of the same raw payload.
+    this.communityTrust = this._parseCommunityTrust(loaded.parsed)
     // Track whether anything changed since the last persist so we can
     // skip writes when a session loaded skills with no mismatches and no
-    // first-time records.
+    // first-time records. A v1→v2 migration marks dirty so the rewritten
+    // v2 shape is flushed on the next access.
     this._dirty = loaded.migratedLegacy || false
   }
 
@@ -236,144 +256,56 @@ export class SkillsTrustStore {
   }
 
   /**
-   * Read + JSON-parse the trust file. Returns `{ records, communityTrust, migratedLegacy }`.
-   * Fails open to empty state on any read/parse error.
+   * Legacy-shape hook (#3297): detect a v1 flat path-keyed root and claim it
+   * for migration. Called by PathHashTrustLedger._loadRecords when the v2
+   * `skills` wrapper key is absent.
    *
-   * #3232: a stale `<path>.tmp` from a prior crash is intentionally
-   * ignored — only the canonical target path is consulted. The next
-   * successful flush atomically replaces the target via rename, which
-   * also overwrites any stale temp file via the writer's pre-clean. So
-   * this read path doesn't need to inspect or clean up `.tmp`.
+   * #3306: we treat the file as v1 if ANY entry looks valid (the per-entry
+   * validation in the base drops malformed records), so a partially-corrupt
+   * v1 file self-heals to a clean v2 ledger keeping every legitimate hash.
    *
-   * #3233: keys read from disk are normalised through `_normalizePathKey`
-   * so a ledger written under one casing on a case-insensitive FS is
-   * still found when realpath resolves to a different casing later.
+   * #3511: the classifier must match the same shape gate as the per-entry
+   * parse loop (sha256 + firstSeen). Without the firstSeen check, a file whose
+   * entries have a valid-looking sha256 but no firstSeen was classified as v1,
+   * then the per-entry loop dropped every record → migration proceeded with an
+   * empty ledger → the next flush wiped the file. Requiring firstSeen here
+   * makes those files fall through to "unrecognised" and fail open instead.
    *
-   * #3297: v1 (flat path-keyed root) is detected and migrated to v2
-   * on load. `migratedLegacy: true` instructs the constructor to set
-   * `_dirty` so the rewritten v2 shape is flushed on the next access.
-   *
-   * @returns {{ records: object, communityTrust: { byAuthor: object, byPath: object }, migratedLegacy: boolean }}
+   * @param {object} parsed
+   * @returns {{ rawMap: object, migratedLegacy: boolean }|null}
+   * @protected
    */
-  _load() {
-    const emptyResult = {
-      records: Object.create(null),
-      communityTrust: { byAuthor: Object.create(null), byPath: Object.create(null) },
-      migratedLegacy: false,
+  _extractLegacy(parsed) {
+    const looksLikeV1Entry = (k) => {
+      const v = parsed[k]
+      return v
+        && typeof v === 'object'
+        && !Array.isArray(v)
+        && typeof v.sha256 === 'string'
+        && /^[0-9a-f]{64}$/.test(v.sha256)
+        && typeof v.firstSeen === 'string'
     }
-
-    let raw
-    try {
-      raw = readFileSync(this._filePath, 'utf8')
-    } catch (err) {
-      if (err && err.code !== 'ENOENT') {
-        log.warn(`Could not read trust file (${err.code || err.message}); starting fresh`)
-      }
-      return emptyResult
+    if (Object.keys(parsed).some(looksLikeV1Entry)) {
+      log.info('Trust file is v1 format; migrating to v2 on next flush')
+      return { rawMap: parsed, migratedLegacy: true }
     }
+    return null
+  }
 
-    let parsed
-    try {
-      parsed = JSON.parse(raw)
-    } catch (err) {
-      log.warn(`Trust file is malformed JSON (${err && err.message ? err.message : err}); starting fresh`)
-      return emptyResult
-    }
-
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      log.warn('Trust file root is not an object; starting fresh')
-      return emptyResult
-    }
-
-    // v2 detection: top-level `skills` key present.
-    // v1 detection: flat path-keyed sha256 records at the root (legacy format).
-    // Anything else treated as empty (fail open).
-    let rawSkillsMap
-    let rawCommunityTrust = null
-    let migratedLegacy = false
-
-    if (parsed.skills && typeof parsed.skills === 'object' && !Array.isArray(parsed.skills)) {
-      // v2 format
-      rawSkillsMap = parsed.skills
-      rawCommunityTrust = parsed.communityTrust && typeof parsed.communityTrust === 'object'
-        ? parsed.communityTrust
-        : null
-    } else {
-      // Detect v1: at least one top-level value has the full v1 shape
-      // (object with sha256 hex string AND firstSeen string).
-      //
-      // #3306: previously we required *every* entry to pass — a single
-      // corrupted record (missing / malformed sha256) made the whole
-      // file fall through to "unrecognised shape" and the user lost ALL
-      // trusted records on the next migration. We now treat the file as
-      // v1 if any entry looks valid; the per-entry loop below already
-      // drops malformed records, so a partially-corrupt v1 file
-      // self-heals to a clean v2 ledger keeping every legitimate hash.
-      //
-      // #3511: the classifier must match the same shape gate as the
-      // per-entry parse loop (sha256 + firstSeen). Without the
-      // firstSeen check, a file whose entries have a valid-looking
-      // sha256 but no firstSeen was classified as v1, then the
-      // per-entry loop dropped every record (no firstSeen) → migration
-      // proceeded with an empty ledger → the next flush wiped the file
-      // to an empty v2 shape. Requiring firstSeen here makes those
-      // files fall through to "unrecognised" and fail open instead.
-      // Arrays are also explicitly rejected as a defence-in-depth
-      // guard against accidentally array-valued entries passing
-      // `typeof === 'object'`.
-      const topLevelKeys = Object.keys(parsed)
-      const looksLikeV1Entry = (k) => {
-        const v = parsed[k]
-        return v
-          && typeof v === 'object'
-          && !Array.isArray(v)
-          && typeof v.sha256 === 'string'
-          && /^[0-9a-f]{64}$/.test(v.sha256)
-          && typeof v.firstSeen === 'string'
-      }
-      const hasAnyV1Entry = topLevelKeys.some(looksLikeV1Entry)
-      if (hasAnyV1Entry) {
-        log.info('Trust file is v1 format; migrating to v2 on next flush')
-        rawSkillsMap = parsed
-        migratedLegacy = true
-      } else if (topLevelKeys.length === 0) {
-        // Empty object — treat as v2 with no records
-        rawSkillsMap = {}
-      } else {
-        // Unrecognised shape — fail open
-        log.warn('Trust file has unrecognised shape; starting fresh')
-        return emptyResult
-      }
-    }
-
-    const out = Object.create(null)
-    for (const [key, value] of Object.entries(rawSkillsMap)) {
-      // Defensive: drop any record that lacks the required shape. A
-      // partially-corrupt record is treated as missing so the next
-      // load re-records cleanly. This matches the "malformed = empty"
-      // guarantee in the file-level catch above.
-      if (
-        value && typeof value === 'object'
-        && typeof value.sha256 === 'string' && /^[0-9a-f]{64}$/.test(value.sha256)
-        && typeof value.firstSeen === 'string'
-      ) {
-        const normKey = _normalizePathKey(key)
-        // Last-writer-wins on collisions — if two entries normalise to
-        // the same key (only possible on case-insensitive FS with mixed
-        // historical casings), keep the most recently iterated one.
-        // `Object.entries` iteration order is insertion-order so this
-        // matches the file's last write.
-        out[normKey] = {
-          sha256: value.sha256,
-          firstSeen: value.firstSeen,
-          lastVerified: typeof value.lastVerified === 'string' ? value.lastVerified : value.firstSeen,
-        }
-      }
-    }
-
-    // Parse community trust indexes from disk (kebab-case on disk → camelCase in memory)
+  /**
+   * Parse the `communityTrust` sibling index out of the raw payload (kebab-case
+   * on disk → camelCase in memory). Returns empty indexes when absent/malformed.
+   *
+   * @param {object|null} parsed
+   * @returns {{ byAuthor: object, byPath: object }}
+   * @private
+   */
+  _parseCommunityTrust(parsed) {
     const byAuthor = Object.create(null)
     const byPath = Object.create(null)
+    const rawCommunityTrust = parsed && parsed.communityTrust && typeof parsed.communityTrust === 'object'
+      ? parsed.communityTrust
+      : null
     if (rawCommunityTrust) {
       const rawByAuthor = rawCommunityTrust['by-author']
       if (rawByAuthor && typeof rawByAuthor === 'object' && !Array.isArray(rawByAuthor)) {
@@ -395,94 +327,30 @@ export class SkillsTrustStore {
         }
       }
     }
-
-    return { records: out, communityTrust: { byAuthor, byPath }, migratedLegacy }
+    return { byAuthor, byPath }
   }
 
   /**
-   * Persist the in-memory ledger to disk. Skipped when no change has
-   * been recorded since the last write to avoid pointless rewrites in
-   * the steady state.
+   * Serialise to the v2 on-disk shape:
+   * `{ skills: {...}, communityTrust: { "by-author": {...}, "by-path": {...} } }`.
+   * Null-prototype objects are converted to plain objects before serialisation.
    *
-   * #3232: writes are atomic-via-rename and chmod 0600.
-   *
-   *   1. The temp file `<path>.tmp` is created with `openSync(..., 'wx',
-   *      0o600)` so a partial / leaked temp from a prior crash is
-   *      cleaned first (`unlinkSync` on EEXIST). `wx` is exclusive-
-   *      create; combined with the unlink that means we never write
-   *      into a partially-populated temp.
-   *   2. After `writeSync` we `fsyncSync` the temp before rename so the
-   *      bytes are on disk before the directory entry flips. A crash
-   *      between writeSync and fsync would leave a stale temp (ignored
-   *      by `_load`); a crash between fsync and rename also leaves a
-   *      stale temp; only a successful rename advances the canonical
-   *      target.
-   *   3. `renameSync` is atomic on the same filesystem — readers see
-   *      either the old file or the new file, never a partial.
-   *
-   * Failure is non-fatal: the loader keeps the in-memory ledger and
-   * will retry on the next first-seen / mismatch. Don't throw — a
-   * read-only $HOME (containerised dev env) shouldn't break skill
-   * loading.
+   * @returns {object}
+   * @protected
    */
-  flush() {
-    if (!this._dirty) return
-    // Per-writer unique temp path. BaseSession constructs one
-    // SkillsTrustStore per session, all pointing at the same default
-    // ledger path, so flush() must tolerate concurrent writers. The
-    // pid+random suffix prevents two writers from racing on the same
-    // .tmp file (where one's unlinkSync would invalidate the other's
-    // open fd, breaking the wx exclusive-create guarantee). Each
-    // writer renames its own unique temp to the target — rename is
-    // atomic so last-writer-wins.
-    const tmpPath = `${this._filePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`
-    let fd = null
-    try {
-      mkdirSync(dirname(this._filePath), { recursive: true })
-      // Convert to v2 shape: { skills: {...}, communityTrust: { "by-author": {...}, "by-path": {...} } }
-      // Null-prototype objects are converted to plain objects before serialisation.
-      const skills = {}
-      for (const [k, v] of Object.entries(this._records)) {
-        skills[k] = v
-      }
-      const byAuthorOut = {}
-      for (const [k, v] of Object.entries(this.communityTrust.byAuthor)) {
-        byAuthorOut[k] = v
-      }
-      const byPathOut = {}
-      for (const [k, v] of Object.entries(this.communityTrust.byPath)) {
-        byPathOut[k] = v
-      }
-      const out = {
-        skills,
-        communityTrust: {
-          'by-author': byAuthorOut,
-          'by-path': byPathOut,
-        },
-      }
-      const payload = JSON.stringify(out, null, 2) + '\n'
-
-      // Open with exclusive-create + 0600. The unique temp path makes
-      // EEXIST effectively impossible (would require pid+random
-      // collision); `wx` is kept as a defence-in-depth guard.
-      fd = openSync(tmpPath, 'wx', 0o600)
-      writeSync(fd, payload, 0, 'utf8')
-      fsyncSync(fd)
-      closeSync(fd)
-      fd = null
-
-      renameSync(tmpPath, this._filePath)
-      this._dirty = false
-    } catch (err) {
-      // Best-effort cleanup of an open fd / our own orphan temp so a
-      // future flush isn't pre-blocked. We never touch other writers'
-      // temps — the unique suffix means our cleanup can't affect them.
-      if (fd !== null) {
-        try { closeSync(fd) } catch { /* ignore */ }
-      }
-      try { unlinkSync(tmpPath) } catch { /* ignore */ }
-      log.warn(`Could not persist trust file (${err && err.code ? err.code : err.message || err})`)
-      throw err
+  _serialize() {
+    const skills = {}
+    for (const [k, v] of Object.entries(this._records)) skills[k] = v
+    const byAuthorOut = {}
+    for (const [k, v] of Object.entries(this.communityTrust.byAuthor)) byAuthorOut[k] = v
+    const byPathOut = {}
+    for (const [k, v] of Object.entries(this.communityTrust.byPath)) byPathOut[k] = v
+    return {
+      skills,
+      communityTrust: {
+        'by-author': byAuthorOut,
+        'by-path': byPathOut,
+      },
     }
   }
 

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -41,11 +41,10 @@
  * aggregates (count / lastUsed / repos); the raw entries never cross the wire.
  */
 
-import { existsSync, readFileSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join, dirname } from 'node:path'
+import { join } from 'node:path'
 import { createLogger } from './logger.js'
-import { writeFileRestricted } from './platform.js'
+import { loadJsonState, saveJsonState } from './json-state-file.js'
 
 const log = createLogger('skills-usage')
 
@@ -136,14 +135,12 @@ function normalizeAggregate(agg) {
  * @returns {{ version: number, entries: object[], aggregates: object }}
  */
 export function loadUsageStore(filePath = defaultSkillsUsagePath()) {
-  if (!existsSync(filePath)) return emptyStore()
-  try {
-    const parsed = JSON.parse(readFileSync(filePath, 'utf8'))
-    return normalizeStore(parsed)
-  } catch (err) {
-    log.debug(`skills-usage: failed to parse ${filePath} — starting empty: ${err && err.message ? err.message : err}`)
-    return emptyStore()
-  }
+  // #5580: fail-open read+parse via the shared JsonStateFile seam. A missing or
+  // unparseable file degrades to an empty store (best-effort telemetry, never
+  // load-bearing). `requireObject: false` so normalizeStore — not the loader —
+  // owns the "non-object → empty" coercion, preserving the prior tolerant shape.
+  const parsed = loadJsonState(filePath, () => null, { requireObject: false, log })
+  return normalizeStore(parsed)
 }
 
 /**
@@ -164,9 +161,10 @@ export function loadUsageStore(filePath = defaultSkillsUsagePath()) {
  * @param {string} [filePath]
  */
 export function saveUsageStore(store, filePath = defaultSkillsUsagePath()) {
-  const dir = dirname(filePath)
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
-  writeFileRestricted(filePath, JSON.stringify(store, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
+  // #5580: atomic 0600 save via the shared JsonStateFile seam (which delegates
+  // to writeFileRestricted — same per-pid tmp suffix per #5579, same mkdir +
+  // rename-failure cleanup). Suffix kept byte-identical to the prior `.tmp-<pid>`.
+  saveJsonState(filePath, store, { tmpSuffix: `.tmp-${process.pid}` })
 }
 
 /**

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -139,7 +139,11 @@ export function loadUsageStore(filePath = defaultSkillsUsagePath()) {
   // unparseable file degrades to an empty store (best-effort telemetry, never
   // load-bearing). `requireObject: false` so normalizeStore — not the loader —
   // owns the "non-object → empty" coercion, preserving the prior tolerant shape.
-  const parsed = loadJsonState(filePath, () => null, { requireObject: false, log })
+  // Telemetry corruption is expected/benign — keep the prior debug-level
+  // logging by shimming warn→debug for this call site (the shared seam warns
+  // by default, which is right for load-bearing stores but noisy here).
+  const usageLog = { ...log, warn: (...args) => log.debug?.(...args) }
+  const parsed = loadJsonState(filePath, () => null, { requireObject: false, log: usageLog })
   return normalizeStore(parsed)
 }
 

--- a/packages/server/tests/json-state-file.test.js
+++ b/packages/server/tests/json-state-file.test.js
@@ -1,0 +1,129 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { loadJsonState, saveJsonState } from '../src/json-state-file.js'
+
+/**
+ * Unit tests for the #5580 JsonStateFile seam — fail-open load + atomic 0600
+ * save with a per-pid temp suffix. The save half delegates to
+ * writeFileRestricted (platform.js), so these tests focus on the load fail-open
+ * contract, the per-pid tmp suffix, and the atomic-write at-rest properties.
+ */
+
+const noopLog = { warn() {}, debug() {} }
+
+describe('JsonStateFile (#5580)', () => {
+  let dir
+  let filePath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'jsf-'))
+    filePath = join(dir, 'state.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  describe('loadJsonState — fail open', () => {
+    it('returns the fallback for a missing file', () => {
+      const out = loadJsonState(join(dir, 'nope.json'), () => ({ empty: true }), { log: noopLog })
+      assert.deepEqual(out, { empty: true })
+    })
+
+    it('returns the fallback for malformed JSON', () => {
+      writeFileSync(filePath, '{ broken')
+      const out = loadJsonState(filePath, () => ({ empty: true }), { log: noopLog })
+      assert.deepEqual(out, { empty: true })
+    })
+
+    it('returns the fallback for a non-object root when requireObject is set (default)', () => {
+      writeFileSync(filePath, '[1,2,3]')
+      const out = loadJsonState(filePath, () => ({ empty: true }), { log: noopLog })
+      assert.deepEqual(out, { empty: true })
+    })
+
+    it('returns the parsed array when requireObject is false', () => {
+      writeFileSync(filePath, '[1,2,3]')
+      const out = loadJsonState(filePath, () => null, { requireObject: false, log: noopLog })
+      assert.deepEqual(out, [1, 2, 3])
+    })
+
+    it('returns the parsed object on a clean read', () => {
+      writeFileSync(filePath, JSON.stringify({ a: 1, b: 'two' }))
+      const out = loadJsonState(filePath, () => ({}), { log: noopLog })
+      assert.deepEqual(out, { a: 1, b: 'two' })
+    })
+
+    it('the fallback is a fresh container per call (no shared-mutation leak)', () => {
+      const a = loadJsonState(join(dir, 'x.json'), () => ({ items: [] }), { log: noopLog })
+      a.items.push('mutated')
+      const b = loadJsonState(join(dir, 'y.json'), () => ({ items: [] }), { log: noopLog })
+      assert.deepEqual(b.items, [])
+    })
+
+    it('invokes onError on a parse failure', () => {
+      writeFileSync(filePath, '{ broken')
+      let stage = null
+      loadJsonState(filePath, () => ({}), { log: noopLog, onError: (s) => { stage = s } })
+      assert.equal(stage, 'parse')
+    })
+
+    it('does not throw or warn on a missing file (ENOENT is normal)', () => {
+      let warned = false
+      const out = loadJsonState(join(dir, 'absent.json'), () => ({}), { log: { warn() { warned = true } } })
+      assert.deepEqual(out, {})
+      assert.equal(warned, false)
+    })
+  })
+
+  describe('saveJsonState — atomic 0600', () => {
+    it('writes pretty JSON with a trailing newline by default', () => {
+      saveJsonState(filePath, { a: 1 })
+      const raw = readFileSync(filePath, 'utf8')
+      assert.ok(raw.endsWith('\n'))
+      assert.deepEqual(JSON.parse(raw), { a: 1 })
+      assert.ok(raw.includes('\n  '), 'pretty-printed (2-space indent)')
+    })
+
+    it('writes compact JSON when pretty is false', () => {
+      saveJsonState(filePath, { a: 1, b: 2 }, { pretty: false })
+      assert.equal(readFileSync(filePath, 'utf8'), '{"a":1,"b":2}')
+    })
+
+    it('writes the file at mode 0600 (POSIX)', { skip: process.platform === 'win32' }, () => {
+      saveJsonState(filePath, { a: 1 })
+      assert.equal(statSync(filePath).mode & 0o777, 0o600)
+    })
+
+    it('creates the parent directory if missing', () => {
+      const nested = join(dir, 'deep', 'nested', 'state.json')
+      saveJsonState(nested, { a: 1 })
+      assert.ok(existsSync(nested))
+    })
+
+    it('round-trips through loadJsonState', () => {
+      saveJsonState(filePath, { version: 1, items: ['x'] })
+      const out = loadJsonState(filePath, () => ({}), { log: noopLog })
+      assert.deepEqual(out, { version: 1, items: ['x'] })
+    })
+
+    it('uses a per-pid temp suffix by default (no fixed .tmp orphan)', () => {
+      saveJsonState(filePath, { a: 1 })
+      assert.ok(!existsSync(`${filePath}.tmp`), 'no fixed .tmp orphan')
+      assert.ok(!existsSync(`${filePath}.${process.pid}.tmp`), 'per-pid tmp renamed away')
+    })
+
+    it('honours a caller-supplied tmpSuffix', () => {
+      saveJsonState(filePath, { a: 1 }, { tmpSuffix: `.tmp-${process.pid}` })
+      assert.ok(existsSync(filePath))
+      assert.ok(!existsSync(`${filePath}.tmp-${process.pid}`), 'custom tmp renamed away')
+    })
+
+    it('re-throws on a write failure (target is a directory)', () => {
+      assert.throws(() => saveJsonState(dir, { a: 1 }), /EISDIR|illegal operation|EEXIST|EPERM/)
+    })
+  })
+})

--- a/packages/server/tests/path-hash-trust-ledger.test.js
+++ b/packages/server/tests/path-hash-trust-ledger.test.js
@@ -253,7 +253,7 @@ describe('PathHashTrustLedger (#5580)', () => {
 
     it('re-throws a write failure when throwOnFlushError is true', () => {
       const l = new TestLedger({ filePath: dir, throwOnFlushError: true })
-      assert.throws(() => l.approve('/x/file', sha('a')), /EISDIR|illegal operation|EEXIST/)
+      assert.throws(() => l.approve('/x/file', sha('a')), /EISDIR|illegal operation|EEXIST|EPERM|EACCES/)
     })
 
     it('a failed flush elsewhere does not corrupt an unrelated good target', () => {

--- a/packages/server/tests/path-hash-trust-ledger.test.js
+++ b/packages/server/tests/path-hash-trust-ledger.test.js
@@ -1,0 +1,276 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createHash } from 'crypto'
+import { PathHashTrustLedger } from '../src/path-hash-trust-ledger.js'
+
+/**
+ * Unit tests for the #5580 PathHashTrustLedger base — the shared core of the
+ * skills + session-preset trust ledgers. Exercises the contract the two
+ * subclasses inherit: trust lifecycle, hash-mismatch re-gate, fail-open-to-empty
+ * on corruption, atomic 0600 write, and the per-pid + random temp suffix.
+ *
+ * The base is exercised through a minimal concrete subclass (the same shape a
+ * real subclass uses) so we test the inherited mechanics, not subclass extras.
+ */
+
+const sha = (s) => createHash('sha256').update(s).digest('hex')
+const noopLog = { warn() {}, info() {} }
+
+// Minimal concrete ledger: identity key normaliser, `approvedAt` field,
+// `records` wrapper key, best-effort flush. Mirrors how a subclass wires it.
+class TestLedger extends PathHashTrustLedger {
+  constructor({ filePath, throwOnFlushError } = {}) {
+    super({
+      filePath,
+      log: noopLog,
+      normalizeKey: (p) => (typeof p === 'string' ? p : ''),
+      approvalField: 'approvedAt',
+      wrapperKey: 'records',
+      throwOnFlushError: throwOnFlushError === true,
+    })
+    const loaded = this._loadRecords()
+    this._records = loaded.records
+    this._migrated = loaded.migratedLegacy
+    this._dirty = loaded.migratedLegacy || false
+  }
+}
+
+describe('PathHashTrustLedger (#5580)', () => {
+  let dir
+  let ledgerPath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'phtl-'))
+    ledgerPath = join(dir, 'ledger.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  describe('constructor validation', () => {
+    it('throws without filePath', () => {
+      assert.throws(() => new PathHashTrustLedger({ log: noopLog, normalizeKey: (p) => p }), /filePath is required/)
+    })
+    it('throws without log', () => {
+      assert.throws(() => new PathHashTrustLedger({ filePath: ledgerPath, normalizeKey: (p) => p }), /log is required/)
+    })
+    it('throws without normalizeKey', () => {
+      assert.throws(() => new PathHashTrustLedger({ filePath: ledgerPath, log: noopLog }), /normalizeKey is required/)
+    })
+  })
+
+  describe('trust lifecycle (approve / isTrusted / getRecord / revoke)', () => {
+    it('an unseen path is untrusted', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.isTrusted('/x/file', sha('a')), false)
+      assert.equal(l.getRecord('/x/file'), null)
+    })
+
+    it('approve records the hash and marks it trusted', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      const h = sha('body')
+      assert.equal(l.approve('/x/file', h), true)
+      assert.equal(l.isTrusted('/x/file', h), true)
+      const rec = l.getRecord('/x/file')
+      assert.equal(rec.sha256, h)
+      assert.ok(typeof rec.firstSeen === 'string')
+      assert.ok(typeof rec.approvedAt === 'string')
+    })
+
+    it('approve rejects a non-hex hash', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.approve('/x/file', 'not-a-hash'), false)
+      assert.equal(l.approve('/x/file', ''), false)
+    })
+
+    it('approve preserves the original firstSeen on re-approval', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      l.approve('/x/file', sha('v1'))
+      const firstSeen = l.getRecord('/x/file').firstSeen
+      l.approve('/x/file', sha('v2'))
+      assert.equal(l.getRecord('/x/file').firstSeen, firstSeen)
+      assert.equal(l.getRecord('/x/file').sha256, sha('v2'))
+    })
+
+    it('getRecord returns a clone — caller mutation does not poison the ledger', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      const h = sha('body')
+      l.approve('/x/file', h)
+      const rec = l.getRecord('/x/file')
+      rec.sha256 = 'tampered'
+      assert.equal(l.isTrusted('/x/file', h), true)
+    })
+
+    it('revoke drops the record so the path goes untrusted', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      const h = sha('body')
+      l.approve('/x/file', h)
+      assert.equal(l.revoke('/x/file'), true)
+      assert.equal(l.isTrusted('/x/file', h), false)
+      assert.equal(l.getRecord('/x/file'), null)
+    })
+
+    it('revoke on an unseen path is a no-op returning false', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.revoke('/x/never'), false)
+    })
+  })
+
+  describe('hash-mismatch re-gate', () => {
+    it('a changed hash is no longer trusted (re-gated)', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      const oldHash = sha('original')
+      l.approve('/x/file', oldHash)
+      assert.equal(l.isTrusted('/x/file', oldHash), true)
+      // Content changed → different hash → untrusted until re-approved.
+      const newHash = sha('tampered')
+      assert.equal(l.isTrusted('/x/file', newHash), false)
+      l.approve('/x/file', newHash)
+      assert.equal(l.isTrusted('/x/file', newHash), true)
+      assert.equal(l.isTrusted('/x/file', oldHash), false)
+    })
+  })
+
+  describe('persistence round-trip', () => {
+    it('an approved record survives a reload from disk', () => {
+      const h = sha('body')
+      const l1 = new TestLedger({ filePath: ledgerPath })
+      l1.approve('/x/file', h)
+      const l2 = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l2.isTrusted('/x/file', h), true)
+    })
+
+    it('on-disk shape nests records under the wrapper key', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      const h = sha('body')
+      l.approve('/x/file', h)
+      const onDisk = JSON.parse(readFileSync(ledgerPath, 'utf8'))
+      assert.ok(onDisk.records, 'records wrapper key present')
+      assert.equal(onDisk.records['/x/file'].sha256, h)
+    })
+  })
+
+  describe('corruption fail-open-to-empty', () => {
+    it('a malformed JSON file loads as empty (no throw)', () => {
+      writeFileSync(ledgerPath, '{ not valid json')
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.isTrusted('/x/file', sha('a')), false)
+    })
+
+    it('a non-object root (array) loads as empty', () => {
+      writeFileSync(ledgerPath, '[1,2,3]')
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.getRecord('/x/file'), null)
+    })
+
+    it('an unrecognised-shape object loads as empty', () => {
+      writeFileSync(ledgerPath, JSON.stringify({ somethingElse: { a: 1 } }))
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.getRecord('/x/file'), null)
+    })
+
+    it('records missing required fields are dropped on load', () => {
+      writeFileSync(ledgerPath, JSON.stringify({
+        records: {
+          '/good': { sha256: sha('a'), firstSeen: '2026-01-01T00:00:00.000Z' },
+          '/nohash': { firstSeen: '2026-01-01T00:00:00.000Z' },
+          '/badhash': { sha256: 'xyz', firstSeen: '2026-01-01T00:00:00.000Z' },
+          '/nofirstseen': { sha256: sha('c') },
+        },
+      }))
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.isTrusted('/good', sha('a')), true)
+      assert.equal(l.getRecord('/nohash'), null)
+      assert.equal(l.getRecord('/badhash'), null)
+      assert.equal(l.getRecord('/nofirstseen'), null)
+    })
+
+    it('a missing file is treated as empty', () => {
+      const l = new TestLedger({ filePath: join(dir, 'does-not-exist.json') })
+      assert.equal(l.getRecord('/x/file'), null)
+    })
+
+    it('the approvalField falls back to firstSeen when missing on disk', () => {
+      writeFileSync(ledgerPath, JSON.stringify({
+        records: { '/x': { sha256: sha('a'), firstSeen: '2026-01-01T00:00:00.000Z' } },
+      }))
+      const l = new TestLedger({ filePath: ledgerPath })
+      assert.equal(l.getRecord('/x').approvedAt, '2026-01-01T00:00:00.000Z')
+    })
+  })
+
+  describe('atomic write + per-pid/random temp suffix', () => {
+    it('writes to the target and leaves no fixed .tmp sibling', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      l.approve('/x/file', sha('a'))
+      assert.ok(existsSync(ledgerPath))
+      assert.ok(!existsSync(`${ledgerPath}.tmp`), 'no fixed .tmp orphan')
+    })
+
+    it('writes the target at mode 0600 (POSIX)', { skip: process.platform === 'win32' }, () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      l.approve('/x/file', sha('a'))
+      assert.equal(statSync(ledgerPath).mode & 0o777, 0o600)
+    })
+
+    it('creates the parent directory if missing', () => {
+      const nested = join(dir, 'a', 'b', 'c', 'ledger.json')
+      const l = new TestLedger({ filePath: nested })
+      l.approve('/x/file', sha('a'))
+      assert.ok(existsSync(nested))
+    })
+
+    it('a stale fixed .tmp orphan does not break a fresh flush', () => {
+      writeFileSync(`${ledgerPath}.tmp`, '{ partial orphan')
+      const l = new TestLedger({ filePath: ledgerPath })
+      l.approve('/x/file', sha('a'))
+      assert.equal(l.isTrusted('/x/file', sha('a')), true)
+      const onDisk = JSON.parse(readFileSync(ledgerPath, 'utf8'))
+      assert.ok(onDisk.records['/x/file'])
+    })
+
+    it('two ledgers flushing to the same path do not collide (same-process)', () => {
+      const a = new TestLedger({ filePath: ledgerPath })
+      const b = new TestLedger({ filePath: ledgerPath })
+      a.approve('/x/a', sha('a'))
+      b.approve('/x/b', sha('b'))
+      a.approve('/x/a2', sha('a2'))
+      // Neither flush threw; the target is valid JSON.
+      const onDisk = JSON.parse(readFileSync(ledgerPath, 'utf8'))
+      assert.ok(onDisk && typeof onDisk === 'object')
+    })
+
+    it('best-effort flush swallows a write failure when throwOnFlushError is false', () => {
+      // Point at a directory so the open/rename fails.
+      const l = new TestLedger({ filePath: dir })
+      // approve() calls flush() internally; must not throw in best-effort mode.
+      assert.doesNotThrow(() => l.approve('/x/file', sha('a')))
+    })
+
+    it('re-throws a write failure when throwOnFlushError is true', () => {
+      const l = new TestLedger({ filePath: dir, throwOnFlushError: true })
+      assert.throws(() => l.approve('/x/file', sha('a')), /EISDIR|illegal operation|EEXIST/)
+    })
+
+    it('a failed flush elsewhere does not corrupt an unrelated good target', () => {
+      const good = new TestLedger({ filePath: ledgerPath })
+      good.approve('/x/file', sha('original'))
+      const before = readFileSync(ledgerPath, 'utf8')
+      const bad = new TestLedger({ filePath: dir, throwOnFlushError: true })
+      assert.throws(() => bad.approve('/x/y', sha('a')))
+      assert.equal(readFileSync(ledgerPath, 'utf8'), before)
+    })
+  })
+
+  describe('flush is a no-op when clean', () => {
+    it('does not write the file when nothing changed', () => {
+      const l = new TestLedger({ filePath: ledgerPath })
+      l.flush()
+      assert.equal(existsSync(ledgerPath), false, 'clean flush must not create the file')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Round-2 swarm-audit (#5580) flagged three path-keyed sha256 trust ledgers re-implementing the same `{sha256, firstSeen, <approvalTs>}` sidecar shape and the same atomic temp+rename+0600 dance, plus ~15 hand-rolled JSON state files repeating the persistence boilerplate. This extracts the duplicated seam.

### New modules

- **`PathHashTrustLedger`** (`path-hash-trust-ledger.js`) — the shared core of the path-keyed, sha256-pinned trust ledgers: `isTrusted` / `approve` / `revoke` / `getRecord`, fail-open-to-empty load, and atomic 0600 persist. `SkillsTrustStore` and `SessionPresetTrustStore` are now thin subclasses.
- **`JsonStateFile`** (`json-state-file.js`) — fail-open `loadJsonState` + atomic 0600 `saveJsonState`. The save half **promotes the existing `writeFileRestricted`** primitive (per-pid tmp per #5309/#5579) into a load+save pair rather than adding a parallel writer. Adopted in `skills-usage.js`.

### Semantic diff of the three stores — what differed and which behaviour won

| Aspect | skills-trust | session-preset-trust | byok-mcp-trust | Base default (why) |
|---|---|---|---|---|
| Entry shape | `{sha256, firstSeen, lastVerified}` | `{sha256, firstSeen, approvedAt}` | **tuple-keyed** (`{key,name,command,args0,trustedAt}` in a Set) | path → `{sha256, firstSeen, <approvalField>}` — subclass names the 3rd field |
| Key | path via `_normalizePathKey` (case-fold) | realpath via `_normalizePathKey` (case-fold) | JSON tuple `[name,command,arg0]` | subclass supplies `normalizeKey` (identity-preserved per module) |
| On-disk root | `{skills:{}, communityTrust:{}}` | `{presets:{}}` | `{trustedTuples:[]}` | subclass `wrapperKey` (`skills`/`presets`) + `_serialize` override for siblings |
| Legacy migration | v1 flat-root → v2 (#3297/#3306/#3511) | none | none | base `_extractLegacy` hook returns null; skills overrides it |
| Temp suffix | `.<pid>.<random>.tmp` (#3238) | `.<pid>.<Date.now()>.tmp` | `.tmp` (fixed) | **`.<pid>.<random>.tmp`** — survives two same-process writers to the default ledger; safest of the three |
| Open mode | `openSync wx 0600` + `fsync` | `openSync wx 0600` + `fsync` | `writeFileSync` + `chmod` | **`openSync wx 0600` + `fsync`-before-rename** — durable + exclusive-create; no-op upgrade for preset |
| Corrupt file | fail-open empty | fail-open empty | fail-open empty | fail-open empty |
| flush on write error | **re-throws** (handler surfaces `TRUST_FLUSH_FAILED`) | **swallows** (best-effort) | re-throws (rename only) | subclass `throwOnFlushError` flag (skills `true`, preset `false`) |

**Why byok-mcp stays standalone:** it is genuinely tuple-keyed (a `Set` of JSON tuples), not a path→hash ledger, so forcing it under `PathHashTrustLedger` would change its shape and on-disk format. Its #4463 rename-failure test also mocks `node:fs` directly, which the `platform.js` writer (importing from `'fs'`) would bypass — adopting the shared writer there would require editing that contract test. Per the zero-behaviour-change constraint it is **left unchanged** and noted as a follow-up candidate.

**SAFEST-default policy:** where the two path-hash stores diverged on a *safety* mechanic (temp suffix, fsync), the base takes the more defensive variant (skills') as the default and lets a subclass opt out. The preset store's persist was strictly upgraded (gains the random suffix + the same fsync it already had); its on-disk bytes are unchanged.

### Not migrated (incremental follow-up candidates)

`JsonStateFile` was adopted in the two new ledger subclasses (via the base) and in `skills-usage.js`. The remaining hand-rolled `~/.chroxy/` state files were deliberately **not** mass-migrated — each keeps its own lifecycle/security boundary. Candidates for a follow-up: `byok-mcp-trust.js` (after reconciling its `node:fs`-mocked test), `notification-prefs.js`, `byok-compose-state.js`, `device-preferences.js`, and the other ~10 `load*/save*` state files that already lean on `writeFileRestricted`.

## Test plan

- New unit suites: `tests/path-hash-trust-ledger.test.js` (27 cases — trust lifecycle, hash-mismatch re-gate, corruption fail-open-to-empty, atomic 0600 write, per-pid/random temp suffix, throw-vs-swallow flush) and `tests/json-state-file.test.js` (17 cases — fail-open load, atomic save, per-pid suffix, round-trip). **44 pass.**
- All three subclass suites pass **unmodified** (no test edits): `skills-trust` (58 pass / 1 platform-skip), `session-preset` + `session-preset-create-session` (34 pass), `byok-mcp-trust` (32 pass), `skills-usage` (17 pass).
- Downstream importers green unmodified: `base-session`, `codex-session`, `gemini-session`, `repo-handlers-preset`, `skills-loader`, `skills-manager`.
- Full server sweep (`--test-force-exit`): **9217 pass, 2 fail, 5 skip**. The 2 failures (`service.test.js` fetch-timeout / port-parsing) are **pre-existing on `main`** (verified on the pristine main checkout) and untouched by this branch — zero new failures.
- All four custom `lint-*.sh` pass; `eslint` clean (0 errors); sandbox guard not triggered (every test uses temp paths); no lockfile drift.

Closes #5580
