### PR TITLE
refactor: extract shared createDeltaFlusher — one delta-flush wiring, tested (#5556)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -138,11 +138,13 @@ import {
   // #5515 (epic #5514): latency instrumentation primitives.
   RollingPercentiles,
   splitRtt,
-  // #5516 (epic #5514): adaptive client delta-flush interval.
-  resolveDeltaFlushMs,
   // #5556 (epic #5514): shared stateful EWMA RTT smoother.
   RttSmoother,
+  // #5556 (epic #5514): shared delta-flusher wiring (accumulator + timer +
+  // override) — the client supplies only its `applyDeltas` store mutation.
+  createDeltaFlusher,
 } from '@chroxy/store-core';
+import type { DeltaFlusher } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
 import { hapticSuccess } from '../utils/haptics';
@@ -267,9 +269,11 @@ interface MessageHandlerContext extends EncryptionContext {
   // #5556: EWMA-smoothed RTT (replaces the inlined `ewmaRtt` accumulator).
   rttSmoother: RttSmoother;
 
-  // Delta batching
-  pendingDeltas: Map<string, { sessionId: string | null; delta: string }>;
-  deltaFlushTimer: ReturnType<typeof setTimeout> | null;
+  // Delta batching (#5556): the accumulator map + coalescing timer + adaptive
+  // window now live inside the shared `createDeltaFlusher`. The hot path writes
+  // into `deltaFlusher.pendingDeltas`; `applyDeltas` (the store mutation) is
+  // the only platform-specific piece — see `createDefaultContext`.
+  deltaFlusher: DeltaFlusher;
 
   // #5515 (epic #5514): latency instrumentation. `deltaServerTs` records the
   // server-stamped serverTs (and local recv time) of the OLDEST un-rendered
@@ -286,7 +290,8 @@ interface MessageHandlerContext extends EncryptionContext {
 }
 
 function createDefaultContext(): MessageHandlerContext {
-  return {
+  const rttSmoother = new RttSmoother();
+  const ctx: MessageHandlerContext = {
     ...INITIAL_ENCRYPTION_CONTEXT,
     replayingSessions: new Set<string>(),
     isSessionSwitchReplay: false,
@@ -298,15 +303,21 @@ function createDefaultContext(): MessageHandlerContext {
     heartbeatInterval: null,
     pongTimeout: null,
     lastPingSentAt: 0,
-    rttSmoother: new RttSmoother(),
-    pendingDeltas: new Map<string, { sessionId: string | null; delta: string }>(),
-    deltaFlushTimer: null,
+    rttSmoother,
+    // #5556: the flusher owns the accumulator + coalescing timer + adaptive
+    // window, sizing it off this context's own RttSmoother. `applyDeltas` is
+    // the app's session-only store mutation (no flat-`messages` fallback).
+    deltaFlusher: createDeltaFlusher({
+      getEwmaRtt: () => rttSmoother.value,
+      applyDeltas: applyDeltaBatch,
+    }),
     deltaServerTs: new Map<string, { serverTs: number; recvAt: number }>(),
     tokenToRender: new RollingPercentiles(200),
     clientRender: new RollingPercentiles(200),
     lastLatencyLogAt: 0,
     messageQueue: [],
   };
+  return ctx;
 }
 
 let _ctx: MessageHandlerContext = createDefaultContext();
@@ -321,7 +332,7 @@ export function resetAllHandlerState(): void {
   if (_ctx.terminalWriteTimer) clearTimeout(_ctx.terminalWriteTimer);
   if (_ctx.heartbeatInterval) clearInterval(_ctx.heartbeatInterval);
   if (_ctx.pongTimeout) clearTimeout(_ctx.pongTimeout);
-  if (_ctx.deltaFlushTimer) clearTimeout(_ctx.deltaFlushTimer);
+  _ctx.deltaFlusher.dispose();
   _ctx = createDefaultContext();
   _pendingPermissionModeRequests.clear();
   // Reset connection-attempt tracking (kept as export let for live-binding semantics)
@@ -605,17 +616,11 @@ const LATENCY_LOG_INTERVAL_MS = 3_000;
 
 // #5516 (epic #5514): adaptive delta-flush interval. Production reads the
 // current EWMA RTT and adapts (16-33ms cheap → 100ms poor) via
-// `resolveDeltaFlushMs`. Tests pin it to a constant by calling
-// `setDeltaFlushIntervalOverride(N)`; `null` (the default) restores adaptive
-// behavior. Kept testable per the issue's "constant override testable" ask.
-let _deltaFlushOverrideMs: number | null = null;
+// `resolveDeltaFlushMs` inside the shared flusher. Tests pin it to a constant by
+// calling `setDeltaFlushIntervalOverride(N)`; `null` (the default) restores
+// adaptive behavior. #5556: now delegates to the flusher's own override.
 export function setDeltaFlushIntervalOverride(ms: number | null): void {
-  _deltaFlushOverrideMs = ms;
-}
-function currentDeltaFlushMs(): number {
-  return _deltaFlushOverrideMs != null
-    ? _deltaFlushOverrideMs
-    : resolveDeltaFlushMs(_ctx.rttSmoother.value);
+  _ctx.deltaFlusher.setIntervalOverride(ms);
 }
 
 export function stopHeartbeat(): void {
@@ -669,12 +674,11 @@ function _onPong(serverTs?: number): void {
 // ---------------------------------------------------------------------------
 // Delta batching
 // ---------------------------------------------------------------------------
-function flushPendingDeltas(): void {
-  _ctx.deltaFlushTimer = null;
-  if (_ctx.pendingDeltas.size === 0) return;
-  const updates = new Map(_ctx.pendingDeltas);
-  _ctx.pendingDeltas.clear();
-
+// #5556: the store-mutation half of the old `flushPendingDeltas`. The shared
+// flusher owns the accumulator/timer and snapshots+clears `pendingDeltas`, then
+// hands us the batch. App-side this writes session state only (no flat-
+// `messages` fallback). `flushNow()`/`schedule()` invoke this via the flusher.
+function applyDeltaBatch(updates: Map<string, { sessionId: string | null; delta: string }>): void {
   const state = getStore().getState();
 
   const bySession = new Map<string | null, Map<string, string>>();
@@ -786,11 +790,9 @@ function recordLatencySamples(messageIds: Iterable<string>): void {
 }
 
 export function clearDeltaBuffers(): void {
-  if (_ctx.deltaFlushTimer) {
-    clearTimeout(_ctx.deltaFlushTimer);
-    _ctx.deltaFlushTimer = null;
-  }
-  _ctx.pendingDeltas.clear();
+  // #5556: the flusher cancels its timer and drops the accumulator (teardown,
+  // not flush — these deltas belong to a connection that's going away).
+  _ctx.deltaFlusher.clear();
   // #5515: drop any un-flushed latency stamps so they can't survive a reset
   // and pollute the next session's token-to-render window.
   _ctx.deltaServerTs.clear();
@@ -1757,7 +1759,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // context hooks are no-ops / session-only here.
       sharedStreamDelta(msg, {
         activeSessionId: get().activeSessionId,
-        pendingDeltas: _ctx.pendingDeltas,
+        pendingDeltas: _ctx.deltaFlusher.pendingDeltas,
         deltaIdRemaps: _ctx.deltaIdRemaps,
         postPermissionSplits: _ctx.postPermissionSplits,
         replayingSessions: _ctx.replayingSessions,
@@ -1811,12 +1813,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           }));
         },
 
+        // #5556 — arm the shared coalescing window (adaptive interval; was a
+        // fixed 100ms). Memoized bubbles (step 1) make the tighter flush cheap:
+        // only the tail re-renders. First-arm-wins inside the flusher.
         scheduleFlush: () => {
-          if (!_ctx.deltaFlushTimer) {
-            // #5516 — adaptive interval (was a fixed 100ms). Memoized bubbles
-            // (step 1) make the tighter flush cheap: only the tail re-renders.
-            _ctx.deltaFlushTimer = setTimeout(flushPendingDeltas, currentDeltaFlushMs());
-          }
+          _ctx.deltaFlusher.schedule();
         },
       });
       break;
@@ -1824,10 +1825,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'stream_end':
       // Flush any buffered deltas immediately before clearing streaming state
-      if (_ctx.deltaFlushTimer) {
-        clearTimeout(_ctx.deltaFlushTimer);
-      }
-      flushPendingDeltas();
+      _ctx.deltaFlusher.flushNow();
       {
         const out = sharedStreamEnd(msg, get().activeSessionId);
         // Clean up permission boundary split tracking. messageId is null for
@@ -1932,10 +1930,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'result': {
       hapticSuccess();
       // Flush any buffered deltas before clearing streaming state
-      if (_ctx.deltaFlushTimer) {
-        clearTimeout(_ctx.deltaFlushTimer);
-      }
-      flushPendingDeltas();
+      _ctx.deltaFlusher.flushNow();
       // Clean up permission boundary split tracking
       _ctx.postPermissionSplits.clear();
       _ctx.deltaIdRemaps.clear();
@@ -2224,10 +2219,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const currentStreamId = permSs ? permSs.streamingMessageId : null;
         const split = resolvePermissionStreamSplit(currentStreamId, _ctx.deltaIdRemaps);
         if (split) {
-          if (_ctx.deltaFlushTimer) {
-            clearTimeout(_ctx.deltaFlushTimer);
-          }
-          flushPendingDeltas();
+          _ctx.deltaFlusher.flushNow();
           _ctx.postPermissionSplits.add(split.serverStreamId);
           const clearTarget = permTargetId || get().activeSessionId;
           if (clearTarget && get().sessionStates[clearTarget]) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -130,10 +130,12 @@ import {
   // #5515 (epic #5514): latency instrumentation primitives.
   RollingPercentiles,
   splitRtt,
-  // #5516 (epic #5514): adaptive client delta-flush interval.
-  resolveDeltaFlushMs,
   // #5556 (epic #5514): shared stateful EWMA RTT smoother.
   RttSmoother,
+  // #5556 (epic #5514): shared delta-flusher wiring (accumulator + timer +
+  // override) — the dashboard supplies only its `applyDeltas` store mutation.
+  createDeltaFlusher,
+  type DeltaFlusher,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -567,27 +569,31 @@ function _onPong(serverTs?: number): void {
 // ---------------------------------------------------------------------------
 // Delta batching
 // ---------------------------------------------------------------------------
-const pendingDeltas = new Map<string, { sessionId: string | null; delta: string }>();
-let deltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
+// #5556 (epic #5514): the accumulator map + coalescing timer + adaptive window
+// now live inside the shared `createDeltaFlusher`, sized off `_rttSmoother`. The
+// dashboard supplies `applyDeltaBatch` — its store mutation, which (unlike the
+// app) keeps a flat-`messages` fallback. The hot path writes into
+// `deltaFlusher.pendingDeltas`; teardown goes through `deltaFlusher.clear()`.
+const deltaFlusher: DeltaFlusher = createDeltaFlusher({
+  getEwmaRtt: () => _rttSmoother.value,
+  applyDeltas: applyDeltaBatch,
+});
+const pendingDeltas = deltaFlusher.pendingDeltas;
 
 // #5516 (epic #5514): adaptive delta-flush interval (was a fixed 100ms).
 // Production adapts to the current EWMA RTT via `resolveDeltaFlushMs`
 // (16-33ms cheap → 100ms poor). Tests pin it with
 // `setDeltaFlushIntervalOverride(N)`; `null` restores adaptive behavior.
-let _deltaFlushOverrideMs: number | null = null;
+// #5556: delegates to the flusher's own override.
 export function setDeltaFlushIntervalOverride(ms: number | null): void {
-  _deltaFlushOverrideMs = ms;
-}
-function currentDeltaFlushMs(): number {
-  return _deltaFlushOverrideMs != null ? _deltaFlushOverrideMs : resolveDeltaFlushMs(_rttSmoother.value);
+  deltaFlusher.setIntervalOverride(ms);
 }
 
-function flushPendingDeltas(): void {
-  deltaFlushTimer = null;
-  if (pendingDeltas.size === 0) return;
-  const updates = new Map(pendingDeltas);
-  pendingDeltas.clear();
-
+// #5556: the store-mutation half of the old `flushPendingDeltas`. The shared
+// flusher owns the accumulator/timer, snapshots+clears `pendingDeltas`, then
+// hands us the batch. Dashboard-side this writes session state AND a flat-
+// `messages` fallback (the app has only the former).
+function applyDeltaBatch(updates: Map<string, { sessionId: string | null; delta: string }>): void {
   const state = getStore().getState();
 
   const bySession = new Map<string | null, Map<string, string>>();
@@ -683,11 +689,9 @@ function recordLatencySamples(messageIds: Iterable<string>): void {
 }
 
 export function clearDeltaBuffers(): void {
-  if (deltaFlushTimer) {
-    clearTimeout(deltaFlushTimer);
-    deltaFlushTimer = null;
-  }
-  pendingDeltas.clear();
+  // #5556: the flusher cancels its timer and drops the accumulator (teardown,
+  // not flush — these deltas belong to a connection that's going away).
+  deltaFlusher.clear();
   // #5515: drop un-flushed latency stamps so they can't survive a reset.
   _deltaServerTs.clear();
 }
@@ -1568,22 +1572,18 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
       }
     },
 
+    // #5556 — arm the shared coalescing window (adaptive interval; was a fixed
+    // 100ms). Memoized rows (step 1) make the tighter flush cheap: only the tail
+    // re-renders. First-arm-wins inside the flusher.
     scheduleFlush: () => {
-      if (!deltaFlushTimer) {
-        // #5516 — adaptive interval (was a fixed 100ms). Memoized rows
-        // (step 1) make the tighter flush cheap: only the tail re-renders.
-        deltaFlushTimer = setTimeout(flushPendingDeltas, currentDeltaFlushMs());
-      }
+      deltaFlusher.schedule();
     },
   });
 }
 
 function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   // Flush any buffered deltas immediately before clearing streaming state
-  if (deltaFlushTimer) {
-    clearTimeout(deltaFlushTimer);
-  }
-  flushPendingDeltas();
+  deltaFlusher.flushNow();
   // Add newline separator after response ends for Output view readability
   get().appendTerminalData('\r\n');
   const out = sharedStreamEnd(msg, get().activeSessionId);
@@ -1737,10 +1737,7 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
       : get().streamingMessageId;
     const split = resolvePermissionStreamSplit(currentStreamId, _deltaIdRemaps);
     if (split) {
-      if (deltaFlushTimer) {
-        clearTimeout(deltaFlushTimer);
-      }
-      flushPendingDeltas();
+      deltaFlusher.flushNow();
       _postPermissionSplits.add(split.serverStreamId);
       if (permTargetId && get().sessionStates[permTargetId]) {
         updateSession(permTargetId, () => ({ streamingMessageId: null }));
@@ -3114,10 +3111,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'result': {
       // Flush any buffered deltas before clearing streaming state
-      if (deltaFlushTimer) {
-        clearTimeout(deltaFlushTimer);
-      }
-      flushPendingDeltas();
+      deltaFlusher.flushNow();
       // Clean up permission boundary split tracking
       _postPermissionSplits.clear();
       _deltaIdRemaps.clear();

--- a/packages/store-core/src/delta-flush.ts
+++ b/packages/store-core/src/delta-flush.ts
@@ -111,3 +111,172 @@ export class RttSmoother {
     this._value = null
   }
 }
+
+// ---------------------------------------------------------------------------
+// Delta flusher (#5556, epic #5514)
+//
+// Both clients hand-copied the WIRING around the already-shared pure math
+// (`resolveDeltaFlushMs` above): a `pendingDeltas` accumulator Map, a single
+// coalescing-window `setTimeout`, an override hook for tests, and the
+// schedule / flush-now / clear / dispose idioms. Only the inner store mutation
+// (the "apply this batch to the store" body) legitimately differs between the
+// app (session-only) and the dashboard (session + flat-`messages` fallback).
+//
+// `createDeltaFlusher` OWNS the accumulator + timer + override; each client
+// supplies just `getEwmaRtt` (so the window resolves off its own RttSmoother)
+// and `applyDeltas` (its store mutation). Disconnect/teardown that used to call
+// the client's `clearDeltaBuffers` now goes through the flusher's `clear()`;
+// forced pre-state-change flushes (stream_end / result / permission split) go
+// through `flushNow()`.
+// ---------------------------------------------------------------------------
+
+// One accumulated delta is `{ sessionId, delta }` — the same shape the
+// stream-delta hot path writes. Reuse the canonical `PendingDelta` from the
+// handlers barrel rather than redeclaring it, so the accumulator value type is
+// shared with `sharedStreamDelta` (#5556).
+import type { PendingDelta } from './handlers'
+export type { PendingDelta }
+
+/**
+ * Minimal timer surface the flusher schedules on. Defaults to the global
+ * `setTimeout`/`clearTimeout`, so jest/vitest fake timers (which patch the
+ * globals) work at the client call sites with no extra wiring; store-core's
+ * own unit tests inject a deterministic fake instead.
+ */
+export interface DeltaFlushScheduler {
+  setTimeout: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimeout: (handle: ReturnType<typeof setTimeout>) => void
+}
+
+export interface CreateDeltaFlusherOptions {
+  /**
+   * Returns the current EWMA-smoothed RTT (ms), or `null` when no ping/pong has
+   * completed yet. Fed into {@link resolveDeltaFlushMs} to size the coalescing
+   * window. Read lazily on each schedule so the interval tracks live RTT.
+   */
+  getEwmaRtt: () => number | null
+  /**
+   * Apply one coalesced batch to the store. Receives a SNAPSHOT of the
+   * accumulator (already detached and cleared on the flusher's side), so the
+   * client is free to iterate it without racing further appends. This is the
+   * only platform-specific piece — the app writes session state only, the
+   * dashboard also has a flat-`messages` fallback. Any post-flush bookkeeping
+   * the client needs (e.g. latency sampling keyed off `updates.keys()`) belongs
+   * inside this closure.
+   */
+  applyDeltas: (updates: Map<string, PendingDelta>) => void
+  /** Timer surface; defaults to the global `setTimeout`/`clearTimeout`. */
+  scheduler?: DeltaFlushScheduler
+}
+
+/**
+ * A scheduled, coalescing delta flusher. Returned by {@link createDeltaFlusher}.
+ *
+ * The `pendingDeltas` Map is exposed (not private) because the shared
+ * `sharedStreamDelta` hot path writes directly into the client's accumulator;
+ * the client passes `flusher.pendingDeltas` straight through to it, then calls
+ * `flusher.schedule()` from its `scheduleFlush` hook.
+ */
+export interface DeltaFlusher {
+  /** The live accumulator. Mutated in place by the stream-delta hot path. */
+  readonly pendingDeltas: Map<string, PendingDelta>
+  /**
+   * Arm the coalescing-window timer if it isn't already armed. The window is
+   * the override (when `setIntervalOverride(ms)` is set), else
+   * `resolveDeltaFlushMs(getEwmaRtt())`. A no-op while a flush is already
+   * pending — first-arm-wins, so a burst of deltas shares one window.
+   */
+  schedule: () => void
+  /**
+   * Cancel any pending timer and flush the accumulator immediately (synchronous
+   * `applyDeltas`). Safe to call with an empty accumulator (no-op apply). Used
+   * before any state change that must observe the fully-applied transcript
+   * (stream_end, result, permission boundary split).
+   */
+  flushNow: () => void
+  /**
+   * Cancel any pending timer and DROP the accumulator without applying it.
+   * This is the teardown path (disconnect) — the buffered deltas belong to a
+   * connection that's going away.
+   */
+  clear: () => void
+  /**
+   * Pin the coalescing window to a constant (tests), or `null` to restore the
+   * adaptive `resolveDeltaFlushMs` behavior.
+   */
+  setIntervalOverride: (ms: number | null) => void
+  /** Resolve the window the next `schedule()` would use, in ms (for tests). */
+  currentIntervalMs: () => number
+  /** Tear down: cancel the timer and drop the accumulator. Alias of `clear()`. */
+  dispose: () => void
+}
+
+const DEFAULT_SCHEDULER: DeltaFlushScheduler = {
+  setTimeout: (cb, ms) => setTimeout(cb, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+}
+
+/**
+ * Build a delta flusher that owns the accumulator + coalescing timer, leaving
+ * the client only its store-mutation closure. See the block comment above and
+ * {@link CreateDeltaFlusherOptions}.
+ */
+export function createDeltaFlusher(options: CreateDeltaFlusherOptions): DeltaFlusher {
+  const { getEwmaRtt, applyDeltas, scheduler = DEFAULT_SCHEDULER } = options
+
+  const pendingDeltas = new Map<string, PendingDelta>()
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let overrideMs: number | null = null
+
+  function currentIntervalMs(): number {
+    return overrideMs != null ? overrideMs : resolveDeltaFlushMs(getEwmaRtt())
+  }
+
+  /** Snapshot + clear the accumulator, then apply. Shared by both flush paths. */
+  function drain(): void {
+    if (pendingDeltas.size === 0) return
+    const updates = new Map(pendingDeltas)
+    pendingDeltas.clear()
+    applyDeltas(updates)
+  }
+
+  function flushNow(): void {
+    if (timer != null) {
+      scheduler.clearTimeout(timer)
+      timer = null
+    }
+    drain()
+  }
+
+  function schedule(): void {
+    if (timer != null) return
+    timer = scheduler.setTimeout(() => {
+      // The timer reference is consumed; null it BEFORE applying so a
+      // re-entrant schedule() from within applyDeltas re-arms cleanly.
+      timer = null
+      drain()
+    }, currentIntervalMs())
+  }
+
+  function clear(): void {
+    if (timer != null) {
+      scheduler.clearTimeout(timer)
+      timer = null
+    }
+    pendingDeltas.clear()
+  }
+
+  function setIntervalOverride(ms: number | null): void {
+    overrideMs = ms
+  }
+
+  return {
+    pendingDeltas,
+    schedule,
+    flushNow,
+    clear,
+    setIntervalOverride,
+    currentIntervalMs,
+    dispose: clear,
+  }
+}

--- a/packages/store-core/src/delta-flusher.test.ts
+++ b/packages/store-core/src/delta-flusher.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createDeltaFlusher,
+  DELTA_FLUSH_MIN_MS,
+  DELTA_FLUSH_FLOOR_MS,
+  DELTA_FLUSH_MAX_MS,
+  type DeltaFlushScheduler,
+  type PendingDelta,
+} from './delta-flush'
+
+// Deterministic scheduler: records armed callbacks keyed by a synthetic handle
+// so a test can fire the pending timer by hand (no real time, no fake-timer
+// global patching). `fire()` runs the one armed callback (the flusher only ever
+// arms a single timer at a time). `armed()` reports whether one is pending.
+function makeFakeScheduler() {
+  let nextHandle = 1
+  const pending = new Map<number, { cb: () => void; ms: number }>()
+  const scheduler: DeltaFlushScheduler = {
+    setTimeout: (cb, ms) => {
+      const handle = nextHandle++
+      pending.set(handle, { cb, ms })
+      return handle as unknown as ReturnType<typeof setTimeout>
+    },
+    clearTimeout: (handle) => {
+      pending.delete(handle as unknown as number)
+    },
+  }
+  return {
+    scheduler,
+    armed: () => pending.size > 0,
+    /** The ms the single armed timer was scheduled with (or null). */
+    armedMs: () => {
+      const first = pending.values().next()
+      return first.done ? null : first.value.ms
+    },
+    /** Fire the single armed callback (mimics the coalescing window elapsing). */
+    fire: () => {
+      const entry = pending.values().next()
+      if (entry.done) return
+      const handle = pending.keys().next().value as number
+      pending.delete(handle)
+      entry.value.cb()
+    },
+  }
+}
+
+describe('createDeltaFlusher', () => {
+  let applied: Array<Map<string, PendingDelta>>
+  let ewmaRtt: number | null
+
+  beforeEach(() => {
+    applied = []
+    ewmaRtt = null
+  })
+
+  function build(scheduler: DeltaFlushScheduler) {
+    return createDeltaFlusher({
+      getEwmaRtt: () => ewmaRtt,
+      applyDeltas: (updates) => {
+        applied.push(updates)
+      },
+      scheduler,
+    })
+  }
+
+  it('exposes a live accumulator map the hot path writes into', () => {
+    const { scheduler } = makeFakeScheduler()
+    const f = build(scheduler)
+    expect(f.pendingDeltas).toBeInstanceOf(Map)
+    expect(f.pendingDeltas.size).toBe(0)
+    f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'hi' })
+    expect(f.pendingDeltas.size).toBe(1)
+  })
+
+  it('accumulates deltas and flushes the batch when the window elapses', () => {
+    const fake = makeFakeScheduler()
+    const f = build(fake.scheduler)
+
+    f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+    f.schedule()
+    f.pendingDeltas.set('m2', { sessionId: 's1', delta: 'b' })
+    f.schedule() // second schedule is a no-op — one shared window
+
+    expect(applied).toHaveLength(0) // nothing applied until the timer fires
+    fake.fire()
+
+    expect(applied).toHaveLength(1)
+    expect([...applied[0]!.entries()]).toEqual([
+      ['m1', { sessionId: 's1', delta: 'a' }],
+      ['m2', { sessionId: 's1', delta: 'b' }],
+    ])
+    expect(f.pendingDeltas.size).toBe(0) // accumulator cleared on flush
+  })
+
+  it('coalesces a burst into a single window (first-arm-wins)', () => {
+    const fake = makeFakeScheduler()
+    const f = build(fake.scheduler)
+
+    for (let i = 0; i < 5; i++) {
+      f.pendingDeltas.set(`m${i}`, { sessionId: 's1', delta: String(i) })
+      f.schedule()
+    }
+    // Only ONE timer is armed for the whole burst.
+    expect(fake.armed()).toBe(true)
+    fake.fire()
+    expect(applied).toHaveLength(1)
+    expect(applied[0]!.size).toBe(5)
+    expect(fake.armed()).toBe(false)
+  })
+
+  it('passes a detached snapshot to applyDeltas (further appends do not leak in)', () => {
+    const fake = makeFakeScheduler()
+    const f = build(fake.scheduler)
+    f.pendingDeltas.set('m1', { sessionId: null, delta: 'first' })
+    f.schedule()
+    fake.fire()
+    // Mutating the accumulator after the flush must not touch the snapshot.
+    f.pendingDeltas.set('m2', { sessionId: null, delta: 'later' })
+    expect(applied[0]!.has('m2')).toBe(false)
+    expect(applied[0]!.size).toBe(1)
+  })
+
+  describe('EWMA-driven window resolution (through resolveDeltaFlushMs)', () => {
+    it('uses the flush floor when RTT is unknown (null)', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      ewmaRtt = null
+      f.pendingDeltas.set('m', { sessionId: null, delta: 'x' })
+      f.schedule()
+      expect(fake.armedMs()).toBe(DELTA_FLUSH_FLOOR_MS)
+      expect(f.currentIntervalMs()).toBe(DELTA_FLUSH_FLOOR_MS)
+    })
+
+    it('uses the tight floor on a cheap link', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      ewmaRtt = 10 // <= cheap threshold
+      f.pendingDeltas.set('m', { sessionId: null, delta: 'x' })
+      f.schedule()
+      expect(fake.armedMs()).toBe(DELTA_FLUSH_MIN_MS)
+    })
+
+    it('uses the max window on a poor link', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      ewmaRtt = 1000 // >= poor threshold
+      f.pendingDeltas.set('m', { sessionId: null, delta: 'x' })
+      f.schedule()
+      expect(fake.armedMs()).toBe(DELTA_FLUSH_MAX_MS)
+    })
+
+    it('reads RTT lazily on each schedule (interval tracks live RTT)', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      ewmaRtt = 10
+      f.pendingDeltas.set('m', { sessionId: null, delta: 'x' })
+      f.schedule()
+      expect(fake.armedMs()).toBe(DELTA_FLUSH_MIN_MS)
+      fake.fire()
+      // RTT degrades before the next window — the next schedule must re-resolve.
+      ewmaRtt = 1000
+      f.pendingDeltas.set('m2', { sessionId: null, delta: 'y' })
+      f.schedule()
+      expect(fake.armedMs()).toBe(DELTA_FLUSH_MAX_MS)
+    })
+  })
+
+  describe('setIntervalOverride', () => {
+    it('pins the window to a constant regardless of RTT', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      ewmaRtt = 1000 // would otherwise be MAX
+      f.setIntervalOverride(7)
+      f.pendingDeltas.set('m', { sessionId: null, delta: 'x' })
+      f.schedule()
+      expect(fake.armedMs()).toBe(7)
+      expect(f.currentIntervalMs()).toBe(7)
+    })
+
+    it('restores adaptive behavior when set back to null', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.setIntervalOverride(7)
+      expect(f.currentIntervalMs()).toBe(7)
+      f.setIntervalOverride(null)
+      ewmaRtt = null
+      expect(f.currentIntervalMs()).toBe(DELTA_FLUSH_FLOOR_MS)
+    })
+
+    it('treats an override of 0 as a real value (not "unset")', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      ewmaRtt = 1000
+      f.setIntervalOverride(0)
+      expect(f.currentIntervalMs()).toBe(0)
+    })
+  })
+
+  describe('flushNow', () => {
+    it('applies the accumulator immediately and cancels the pending timer', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.schedule()
+      expect(fake.armed()).toBe(true)
+
+      f.flushNow()
+      expect(applied).toHaveLength(1)
+      expect(applied[0]!.size).toBe(1)
+      expect(fake.armed()).toBe(false) // timer cancelled
+      expect(f.pendingDeltas.size).toBe(0)
+    })
+
+    it('is a no-op apply when the accumulator is empty', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.flushNow()
+      expect(applied).toHaveLength(0)
+    })
+
+    it('does not double-apply when the timer later fires (timer was cleared)', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.schedule()
+      f.flushNow()
+      // If a stale handle somehow fired, the accumulator is empty → no-op.
+      fake.fire()
+      expect(applied).toHaveLength(1)
+    })
+  })
+
+  describe('clear / dispose (teardown)', () => {
+    it('drops buffered deltas WITHOUT applying them', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.schedule()
+
+      f.clear()
+      expect(applied).toHaveLength(0) // dropped, not flushed
+      expect(f.pendingDeltas.size).toBe(0)
+      expect(fake.armed()).toBe(false) // timer cancelled
+    })
+
+    it('a fired timer after clear is inert (accumulator empty)', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.schedule()
+      f.clear()
+      fake.fire()
+      expect(applied).toHaveLength(0)
+    })
+
+    it('dispose is an alias of clear', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.schedule()
+      f.dispose()
+      expect(applied).toHaveLength(0)
+      expect(f.pendingDeltas.size).toBe(0)
+      expect(fake.armed()).toBe(false)
+    })
+
+    it('can schedule again after a clear (re-armable)', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.schedule()
+      f.clear()
+      expect(fake.armed()).toBe(false)
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.schedule()
+      expect(fake.armed()).toBe(true)
+      fake.fire()
+      expect(applied).toHaveLength(1)
+    })
+  })
+
+  describe('key handling', () => {
+    it('last-write-wins on a duplicate key within one window (Map semantics)', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      // The hot path (sharedStreamDelta) appends by re-setting the same key; the
+      // accumulator is a Map so the same id holds one merged entry.
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'ab' })
+      f.schedule()
+      fake.fire()
+      expect(applied[0]!.size).toBe(1)
+      expect(applied[0]!.get('m1')).toEqual({ sessionId: 's1', delta: 'ab' })
+    })
+
+    it('preserves insertion order across distinct keys', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.pendingDeltas.set('z', { sessionId: null, delta: '1' })
+      f.pendingDeltas.set('a', { sessionId: null, delta: '2' })
+      f.pendingDeltas.set('m', { sessionId: null, delta: '3' })
+      f.schedule()
+      fake.fire()
+      expect([...applied[0]!.keys()]).toEqual(['z', 'a', 'm'])
+    })
+
+    it('keeps deltas tagged by their originating session across a multi-session batch', () => {
+      const fake = makeFakeScheduler()
+      const f = build(fake.scheduler)
+      f.pendingDeltas.set('m1', { sessionId: 's1', delta: 'a' })
+      f.pendingDeltas.set('m2', { sessionId: 's2', delta: 'b' })
+      f.pendingDeltas.set('m3', { sessionId: null, delta: 'c' })
+      f.schedule()
+      fake.fire()
+      expect(applied[0]!.get('m1')!.sessionId).toBe('s1')
+      expect(applied[0]!.get('m2')!.sessionId).toBe('s2')
+      expect(applied[0]!.get('m3')!.sessionId).toBeNull()
+    })
+  })
+
+  describe('re-entrancy', () => {
+    it('lets applyDeltas re-arm the next window from inside the flush', () => {
+      const fake = makeFakeScheduler()
+      let pass = 0
+      const f = createDeltaFlusher({
+        getEwmaRtt: () => null,
+        applyDeltas: (updates) => {
+          applied.push(updates)
+          // Simulate a downstream producer enqueuing more work during the flush.
+          if (pass === 0) {
+            pass = 1
+            f.pendingDeltas.set('m2', { sessionId: null, delta: 'b' })
+            f.schedule()
+          }
+        },
+        scheduler: fake.scheduler,
+      })
+      f.pendingDeltas.set('m1', { sessionId: null, delta: 'a' })
+      f.schedule()
+      fake.fire() // applies m1, re-arms for m2
+      expect(fake.armed()).toBe(true)
+      fake.fire() // applies m2
+      expect(applied).toHaveLength(2)
+      expect(applied[1]!.get('m2')).toEqual({ sessionId: null, delta: 'b' })
+    })
+  })
+
+  it('defaults to the global timer surface when no scheduler is injected', async () => {
+    const f = createDeltaFlusher({
+      getEwmaRtt: () => null,
+      applyDeltas: (updates) => {
+        applied.push(updates)
+      },
+    })
+    f.setIntervalOverride(1)
+    f.pendingDeltas.set('m1', { sessionId: null, delta: 'a' })
+    f.schedule()
+    await new Promise((r) => setTimeout(r, 15))
+    expect(applied).toHaveLength(1)
+    f.dispose()
+  })
+})

--- a/packages/store-core/src/delta-flusher.test.ts
+++ b/packages/store-core/src/delta-flusher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   createDeltaFlusher,
   DELTA_FLUSH_MIN_MS,
@@ -344,18 +344,26 @@ describe('createDeltaFlusher', () => {
     })
   })
 
-  it('defaults to the global timer surface when no scheduler is injected', async () => {
-    const f = createDeltaFlusher({
-      getEwmaRtt: () => null,
-      applyDeltas: (updates) => {
-        applied.push(updates)
-      },
-    })
-    f.setIntervalOverride(1)
-    f.pendingDeltas.set('m1', { sessionId: null, delta: 'a' })
-    f.schedule()
-    await new Promise((r) => setTimeout(r, 15))
-    expect(applied).toHaveLength(1)
-    f.dispose()
+  it('defaults to the global timer surface when no scheduler is injected', () => {
+    // Fake timers patch the global setTimeout/clearTimeout, so advancing the
+    // clock only fires the flush if the flusher really armed a GLOBAL timer —
+    // deterministic, no real sleep.
+    vi.useFakeTimers()
+    try {
+      const f = createDeltaFlusher({
+        getEwmaRtt: () => null,
+        applyDeltas: (updates) => {
+          applied.push(updates)
+        },
+      })
+      f.setIntervalOverride(1)
+      f.pendingDeltas.set('m1', { sessionId: null, delta: 'a' })
+      f.schedule()
+      vi.advanceTimersByTime(1)
+      expect(applied).toHaveLength(1)
+      f.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -558,4 +558,14 @@ export {
   // accumulators with identical first-sample/α-weighting/reset semantics.
   RttSmoother,
   DEFAULT_RTT_EWMA_ALPHA,
+  // #5556 (epic #5514): shared delta-flusher wiring — owns the `pendingDeltas`
+  // accumulator + coalescing timer + test override, leaving each client only
+  // its `applyDeltas` store-mutation closure. Replaces the hand-copied
+  // accumulator/timer/scheduleFlush glue in both message-handlers.
+  createDeltaFlusher,
+} from './delta-flush'
+export type {
+  DeltaFlusher,
+  CreateDeltaFlusherOptions,
+  DeltaFlushScheduler,
 } from './delta-flush'


### PR DESCRIPTION
## Summary

Sub-item 2 of epic #5556 (client unification). Both clients hand-copied the delta-flush **wiring** around the already-shared pure math (`resolveDeltaFlushMs` + the `RttSmoother` from #5569): a `pendingDeltas` accumulator `Map`, a single coalescing-window `setTimeout`, a test override (`setDeltaFlushIntervalOverride`), and the `scheduleFlush` / flush-then-clear-timer idioms — with the accumulator **untested in both copies**. This extracts that wiring into a single, tested `createDeltaFlusher` in store-core (mirroring how `RttSmoother` was lifted in #5569), leaving each client only its `applyDeltas` store-mutation closure.

## API shape and why

```ts
createDeltaFlusher({ getEwmaRtt, applyDeltas, scheduler? }): DeltaFlusher
```

The shape is driven by what both call sites actually need:

- **`getEwmaRtt: () => number | null`** — read **lazily on each `schedule()`** so the coalescing window tracks live RTT (each client's own `RttSmoother.value`), fed straight into `resolveDeltaFlushMs`. `null` → flush floor, unchanged.
- **`applyDeltas: (updates: Map<string, PendingDelta>) => void`** — the only platform-specific piece. The flusher snapshots + clears the accumulator, then hands the client a detached batch. Any post-flush bookkeeping the client needs (e.g. the #5515 latency sampling keyed off `updates.keys()`) lives inside this closure.
- **`scheduler?: { setTimeout, clearTimeout }`** — injectable timer surface. Defaults to the **global** `setTimeout`/`clearTimeout`, so jest/vitest fake timers (which patch the globals) keep working at the client call sites with zero extra wiring; store-core's own unit tests inject a deterministic fake instead of leaning on fake-timer globals.

Returned `DeltaFlusher`:
- `pendingDeltas` — **exposed** (not private): the shared `sharedStreamDelta` hot path writes directly into the client's accumulator, so the client passes `flusher.pendingDeltas` straight through.
- `schedule()` — arm one window (**first-arm-wins**, matching both old guards), sized by override-or-`resolveDeltaFlushMs(getEwmaRtt())`.
- `flushNow()` — cancel the timer + apply immediately. Replaces the repeated `if (timer) clearTimeout(timer); flushPendingDeltas()` idiom at `stream_end` / `result` / permission-split. **Teardown is part of the API**, per the task.
- `clear()` / `dispose()` — cancel the timer and **drop** the buffer (the disconnect path: those deltas belong to a connection that's going away). `clearDeltaBuffers()` in both `connection.ts` teardowns now routes here.
- `setIntervalOverride(ms | null)`, `currentIntervalMs()` — test hooks.

## Drift found between the two copies

I compared both `flushPendingDeltas` bodies carefully before unifying. **They diverge in the no-session-context branch**, and the divergence is the well-known app-vs-dashboard architectural one:

- **App** is session-only: with no `sessionId`, it applies deltas to the **active session** in `sessionStates` (orphan safety-net included); there is no flat-`messages` array on the app side. In the session-matched branch it writes only `sessionStates`.
- **Dashboard** additionally maintains a flat **`messages`** array: the no-context branch mutates `messages` via `setState((s) => …)`, and the session-matched branch also mirrors into the flat `messages` when `sessionId === activeSessionId`.

**Decision: this divergence is NOT unified — it is preserved, deliberately, by keeping it inside each client's `applyDeltas` closure.** The flat-`messages` fallback is a real platform difference (the dashboard's Output/flat view has no app equivalent), not accidental drift, and is already documented as such in the `StreamDeltaContext` doc comment. What WAS pure copy-paste — the accumulator Map, the timer, the adaptive-window resolution, the override, the schedule/flush/clear idioms — is identical in both copies and is what gets shared here. So the unified surface is the **wiring**; the **mutation** stays platform-local and visibly so.

No behavioral drift was found in the wiring itself (both used `EWMA → resolveDeltaFlushMs`, first-arm-wins scheduling, snapshot-then-clear, and the same flush-on-`stream_end`/`result`/permission-split points) — it is bit-for-bit preserved.

## LOC deleted per client

| File | +/− |
|------|-----|
| `packages/app/src/store/message-handler.ts` | +41 / −49 |
| `packages/dashboard/src/store/message-handler.ts` | +31 / −37 |

Each client loses its `pendingDeltas` map, `deltaFlushTimer`, `_deltaFlushOverrideMs` + `currentDeltaFlushMs()`, the `setTimeout(flushPendingDeltas, …)` scheduling, and the three duplicated `if (timer) clearTimeout(timer); flushPendingDeltas()` idioms — replaced by one-line `deltaFlusher.{schedule,flushNow,clear}()` calls. The `PendingDelta` value type is reused from the existing handlers barrel rather than redeclared (avoids a duplicate-identifier collision).

## Test coverage added

`packages/store-core/src/delta-flusher.test.ts` (23 tests, deterministic injected scheduler — no real time):
- accumulation + window-elapsed flush, burst **coalescing** into one window (first-arm-wins)
- detached-snapshot guarantee (post-flush appends don't leak into the batch)
- EWMA-driven window resolution through `resolveDeltaFlushMs` (null → floor, cheap → MIN, poor → MAX, **lazy re-resolution** as RTT changes)
- `setIntervalOverride` (pin, restore-to-adaptive, `0` is a real value not "unset")
- `flushNow` (immediate apply + timer cancel, empty no-op, no double-apply)
- `clear`/`dispose` (drop-without-apply, inert fired-after-clear, re-armable)
- key handling: last-write-wins on duplicate key, insertion-order preserved, multi-session tagging
- re-entrant `schedule()` from inside `applyDeltas`

## Test plan

- **store-core** (vitest): `28 files / 1258 tests pass` (23 new). `tsc --noEmit` clean.
- **app** (jest): `1730 tests pass` across all suites (1546 in the full run + the 4 xterm-dependent suites which need the gitignored `xterm-bundle.generated.ts` build artifact — 184 tests, green once generated). The message-handler suite (170) passes. `tsc --noEmit` clean.
- **dashboard** (vitest): `184 files / 3531 tests pass`. message-handler suite (212) passes. `tsc --noEmit` clean.
- No lockfile drift.

Related to #5556 (epic stays open).