### PR TITLE
feat(server): explicit primary-ownership semantics for shared sessions

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -531,6 +531,11 @@ export declare const ClientVisibleSchema: z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;
 }, z.core.$strip>;
+export declare const ClaimPrimarySchema: z.ZodObject<{
+    type: z.ZodLiteral<"claim_primary">;
+    sessionId: z.ZodString;
+    force: z.ZodOptional<z.ZodBoolean>;
+}, z.core.$strip>;
 export declare const ListProvidersSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_providers">;
 }, z.core.$strip>;
@@ -913,6 +918,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;
 }, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"claim_primary">;
+    sessionId: z.ZodString;
+    force: z.ZodOptional<z.ZodBoolean>;
+}, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_providers">;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"byok_get_credentials_status">;
@@ -1062,5 +1071,6 @@ export type SessionPresetGetMessage = z.infer<typeof SessionPresetGetSchema>;
 export type SessionPresetSetMessage = z.infer<typeof SessionPresetSetSchema>;
 export type SessionPresetApproveMessage = z.infer<typeof SessionPresetApproveSchema>;
 export type SessionPresetRevokeMessage = z.infer<typeof SessionPresetRevokeSchema>;
+export type ClaimPrimaryMessage = z.infer<typeof ClaimPrimarySchema>;
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
 export type EncryptedEnvelope = z.infer<typeof EncryptedEnvelopeSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -652,6 +652,19 @@ export const ClientVisibleSchema = z.object({
     type: z.literal('client_visible'),
     visible: z.boolean(),
 });
+// #5563 (blocker for #5281 shared-session join): explicit primary-ownership
+// claim / hand-off. Without `force`, the claim succeeds only if the session is
+// unclaimed (or the client is already primary) — a claim against a session
+// another client owns is rejected (observe-only). With `force: true` it is an
+// operator-driven hand-off / take-over that overrides the current owner. The
+// server replies with `session_role` (granted) or a `session_error` of
+// category `input_conflict` (rejected). Additive: a client that never sends
+// this keeps today's first-input-adopts-primary behaviour.
+export const ClaimPrimarySchema = z.object({
+    type: z.literal('claim_primary'),
+    sessionId: z.string().max(256),
+    force: z.boolean().optional(),
+});
 // -- Repo management schemas --
 export const ListProvidersSchema = z.object({
     type: z.literal('list_providers'),
@@ -924,6 +937,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SubscribeSessionsSchema,
     UnsubscribeSessionsSchema,
     ClientVisibleSchema,
+    ClaimPrimarySchema,
     ListProvidersSchema,
     ByokGetCredentialsStatusSchema,
     ByokSetCredentialsSchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -749,6 +749,20 @@ export const ClientVisibleSchema = z.object({
   visible: z.boolean(),
 })
 
+// #5563 (blocker for #5281 shared-session join): explicit primary-ownership
+// claim / hand-off. Without `force`, the claim succeeds only if the session is
+// unclaimed (or the client is already primary) — a claim against a session
+// another client owns is rejected (observe-only). With `force: true` it is an
+// operator-driven hand-off / take-over that overrides the current owner. The
+// server replies with `session_role` (granted) or a `session_error` of
+// category `input_conflict` (rejected). Additive: a client that never sends
+// this keeps today's first-input-adopts-primary behaviour.
+export const ClaimPrimarySchema = z.object({
+  type: z.literal('claim_primary'),
+  sessionId: z.string().max(256),
+  force: z.boolean().optional(),
+})
+
 // -- Repo management schemas --
 
 export const ListProvidersSchema = z.object({
@@ -1049,6 +1063,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SubscribeSessionsSchema,
   UnsubscribeSessionsSchema,
   ClientVisibleSchema,
+  ClaimPrimarySchema,
   ListProvidersSchema,
   ByokGetCredentialsStatusSchema,
   ByokSetCredentialsSchema,
@@ -1107,5 +1122,6 @@ export type SessionPresetGetMessage = z.infer<typeof SessionPresetGetSchema>
 export type SessionPresetSetMessage = z.infer<typeof SessionPresetSetSchema>
 export type SessionPresetApproveMessage = z.infer<typeof SessionPresetApproveSchema>
 export type SessionPresetRevokeMessage = z.infer<typeof SessionPresetRevokeSchema>
+export type ClaimPrimaryMessage = z.infer<typeof ClaimPrimarySchema>
 export type ClientMessage = z.infer<typeof ClientMessageSchema>
 export type EncryptedEnvelope = z.infer<typeof EncryptedEnvelopeSchema>

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -290,7 +290,7 @@ async function handleInput(ws, client, msg, ctx) {
 
   // Input conflict: reject if session is already processing input from a different client
   if (entry.session.isRunning) {
-    const primaryClientId = ctx.transport.primaryClients.get(targetSessionId)
+    const primaryClientId = ctx.transport.getPrimary(targetSessionId)
     if (primaryClientId && primaryClientId !== client.id) {
       ctx.transport.send(ws, buildInputConflictError(targetSessionId, msg.clientMessageId))
       return
@@ -427,7 +427,7 @@ async function handleInput(ws, client, msg, ctx) {
       // session). Without this, the rewritten/forward draft would race
       // ahead of the now-busy session and produce out-of-order sends.
       if (entry.session.isRunning) {
-        const primaryClientId = ctx.transport.primaryClients.get(targetSessionId)
+        const primaryClientId = ctx.transport.getPrimary(targetSessionId)
         if (primaryClientId && primaryClientId !== client.id) {
           ctx.transport.send(ws, buildInputConflictError(targetSessionId, msg.clientMessageId))
           return

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -217,7 +217,7 @@ async function handleDestroySession(ws, client, msg, ctx) {
   } else {
     ctx.sessions.sessionManager.destroySession(targetId)
   }
-  ctx.transport.primaryClients.delete(targetId)
+  ctx.transport.clearPrimary(targetId)
 
   const firstId = ctx.sessions.sessionManager.firstSessionId
   for (const [clientWs, c] of ctx.transport.clients) {
@@ -326,6 +326,71 @@ function handleClientVisible(ws, client, msg) {
   client.visible = msg.visible !== false
 }
 
+// #5563 (blocker for #5281 shared-session join): explicit primary claim /
+// hand-off. v1 ownership semantics:
+//   - First client to claim an UNCLAIMED session becomes its primary; every
+//     other subscriber stays an observer (read-only — the input_conflict gate
+//     rejects observer input while the session is running).
+//   - A claim against a session ANOTHER client already owns is REJECTED unless
+//     `force: true` — an explicit operator-driven hand-off / take-over. This is
+//     the observe-only guarantee that lets N>2 clients share a session safely.
+//   - On the primary disconnecting, the slot is cleared (nobody-until-claim) by
+//     the departure path, NOT auto-promoted to an observer.
+// The actual mutation + role broadcast (`session_role` + legacy
+// `primary_changed`) happens in ws-server's _claimPrimary; this handler only
+// validates binding and turns a rejection into a client-facing error.
+function handleClaimPrimary(ws, client, msg, ctx) {
+  const targetId = msg.sessionId
+  if (!targetId) {
+    sendSessionError(ws, ctx, 'sessionId is required')
+    return
+  }
+
+  // Bound clients (paired to a single session) may only claim that session.
+  if (client.boundSessionId && client.boundSessionId !== targetId) {
+    loggerForSession('ws', client.boundSessionId).warn(`Client ${client.id} attempted to claim primary on session ${targetId} but is bound to ${client.boundSessionId}`)
+    ctx.transport.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessions.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
+    return
+  }
+
+  if (!ctx.sessions.sessionManager.getSession(targetId)) {
+    sendSessionError(ws, ctx, `Session not found: ${targetId}`)
+    return
+  }
+
+  const force = msg.force === true
+  const res = ctx.transport.claimPrimary(targetId, client.id, { force })
+  if (res.rejected) {
+    // Another client owns the session and this was not a forced hand-off.
+    // Surface as an input_conflict so existing dashboards render the same
+    // calm "another device is driving" notice they already show for the
+    // in-flight cross-device send conflict (#5281 ①.3).
+    ctx.transport.send(ws, {
+      type: 'session_error',
+      category: 'input_conflict',
+      sessionId: targetId,
+      message: 'Another device is the primary for this session. Request a hand-off or wait for it to release.',
+      code: 'PRIMARY_HELD',
+      primaryClientId: res.primaryClientId,
+    })
+    return
+  }
+  // Success (claimed/handed-off) or no-op (already primary). In both cases tell
+  // THIS client its authoritative role so a no-op claim still resolves any
+  // optimistic local "am I primary?" state.
+  ctx.transport.send(ws, {
+    type: 'session_role',
+    sessionId: targetId,
+    primaryClientId: ctx.transport.getPrimary(targetId) ?? null,
+  })
+}
+
 export const sessionHandlers = {
   list_sessions: handleListSessions,
   switch_session: handleSwitchSession,
@@ -335,4 +400,5 @@ export const sessionHandlers = {
   subscribe_sessions: handleSubscribeSessions,
   unsubscribe_sessions: handleUnsubscribeSessions,
   client_visible: handleClientVisible,
+  claim_primary: handleClaimPrimary,
 }

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -92,12 +92,12 @@ export class WsClientManager extends EventEmitter {
    *
    * Returns a result describing what happened so the caller can decide whether
    * to broadcast a role change:
-   *   - `{ changed: true, primaryClientId }`  — claim succeeded (was unclaimed,
-   *      or this is an explicit hand-off target, or already primary→no-op with
-   *      changed:false).
-   *   - `{ changed: false, primaryClientId }` — already primary (no-op) OR the
-   *      claim was REJECTED because another client owns it and `force` is false.
-   *      Inspect `rejected` to distinguish.
+   *   - `{ changed: true, primaryClientId }`  — ownership actually moved (the
+   *      session was unclaimed, or this is a `force` hand-off to a new owner).
+   *   - `{ changed: false, primaryClientId }` — no change: either the caller is
+   *      already the primary (idempotent no-op) OR the claim was REJECTED
+   *      because another client owns it and `force` is false. Inspect `rejected`
+   *      to distinguish (set only on the rejection branch).
    *
    * `force` (explicit hand-off / first-input adoption) overrides an existing
    * owner. Without `force`, a claim against a session another client already
@@ -132,6 +132,15 @@ export class WsClientManager extends EventEmitter {
     const prev = this._primaryClients.get(sessionId)
     this._primaryClients.delete(sessionId)
     return prev
+  }
+
+  /**
+   * Vacate every primary slot (server shutdown / close path). No broadcast —
+   * the server is tearing down. Keeps the `_primaryClients` map private to this
+   * class so callers don't depend on its representation (#5563).
+   */
+  clearAllPrimary() {
+    this._primaryClients.clear()
   }
 
   /**

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -49,6 +49,105 @@ export class WsClientManager extends EventEmitter {
     // active-or-subscribed predicate.
     /** @type {Map<string, Set<object>>} sessionId → Set<client> */
     this._sessionIndex = new Map()
+    // #5563: explicit primary-ownership for shared sessions. Replaces the old
+    // last-writer-wins `_primaryClients` map that lived on WsServer. A session's
+    // primary is the one client allowed to DRIVE it (send input); every other
+    // subscriber is an OBSERVER (read-only). v1 semantics:
+    //   - First client to claim a session (implicitly on first input, or
+    //     explicitly via claim_primary) becomes primary.
+    //   - While a session HAS a primary, ownership transfers ONLY by explicit
+    //     hand-off (claim_primary from another client is rejected unless the
+    //     session is unclaimed) — NOT by whoever sent input last.
+    //   - On primary disconnect the slot is CLEARED (nobody-until-claim) so a
+    //     backgrounded observer is never silently promoted; the next claimant
+    //     (or first input) takes over. This matches the pre-#5563 disconnect
+    //     behaviour (clear + broadcast null) exactly.
+    // Stored by clientId (not the client object) to mirror the old map's shape
+    // and survive a client object being replaced on reconnect-with-same-id.
+    /** @type {Map<string, string>} sessionId → primary clientId */
+    this._primaryClients = new Map()
+  }
+
+  /**
+   * The current primary clientId for `sessionId`, or undefined if unclaimed.
+   * @param {string} sessionId
+   * @returns {string|undefined}
+   */
+  getPrimary(sessionId) {
+    return this._primaryClients.get(sessionId)
+  }
+
+  /**
+   * True iff `clientId` is the primary for `sessionId`.
+   * @param {string} sessionId
+   * @param {string} clientId
+   * @returns {boolean}
+   */
+  isPrimary(sessionId, clientId) {
+    return this._primaryClients.get(sessionId) === clientId
+  }
+
+  /**
+   * Attempt to make `clientId` the primary for `sessionId`.
+   *
+   * Returns a result describing what happened so the caller can decide whether
+   * to broadcast a role change:
+   *   - `{ changed: true, primaryClientId }`  — claim succeeded (was unclaimed,
+   *      or this is an explicit hand-off target, or already primary→no-op with
+   *      changed:false).
+   *   - `{ changed: false, primaryClientId }` — already primary (no-op) OR the
+   *      claim was REJECTED because another client owns it and `force` is false.
+   *      Inspect `rejected` to distinguish.
+   *
+   * `force` (explicit hand-off / first-input adoption) overrides an existing
+   * owner. Without `force`, a claim against a session another client already
+   * owns is rejected (returns `{ changed:false, rejected:true }`) — this is the
+   * observe-only guarantee.
+   *
+   * @param {string} sessionId
+   * @param {string} clientId
+   * @param {{ force?: boolean }} [opts]
+   * @returns {{ changed: boolean, rejected?: boolean, primaryClientId: string|undefined }}
+   */
+  claimPrimary(sessionId, clientId, { force = false } = {}) {
+    if (!sessionId || !clientId) return { changed: false, primaryClientId: this._primaryClients.get(sessionId) }
+    const current = this._primaryClients.get(sessionId)
+    if (current === clientId) return { changed: false, primaryClientId: current }
+    if (current && !force) {
+      // Session already owned by someone else and this is not an explicit
+      // hand-off / adoption — reject to preserve observe-only semantics.
+      return { changed: false, rejected: true, primaryClientId: current }
+    }
+    this._primaryClients.set(sessionId, clientId)
+    return { changed: true, primaryClientId: clientId }
+  }
+
+  /**
+   * Clear the primary slot for `sessionId`. Returns the previous owner (or
+   * undefined). Used on destroy_session.
+   * @param {string} sessionId
+   * @returns {string|undefined} previous primary clientId
+   */
+  clearPrimary(sessionId) {
+    const prev = this._primaryClients.get(sessionId)
+    this._primaryClients.delete(sessionId)
+    return prev
+  }
+
+  /**
+   * Clear every session this client was primary on (disconnect path).
+   * @param {string} clientId
+   * @returns {string[]} sessionIds the client was vacated from
+   */
+  clearPrimaryForClient(clientId) {
+    const vacated = []
+    for (const [sessionId, primaryClientId] of this._primaryClients) {
+      if (primaryClientId === clientId) {
+        this._primaryClients.delete(sessionId)
+        vacated.push(sessionId)
+      }
+    }
+    return vacated
   }
 
   /**

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -51,13 +51,17 @@ export class WsClientManager extends EventEmitter {
     this._sessionIndex = new Map()
     // #5563: explicit primary-ownership for shared sessions. Replaces the old
     // last-writer-wins `_primaryClients` map that lived on WsServer. A session's
-    // primary is the one client allowed to DRIVE it (send input); every other
-    // subscriber is an OBSERVER (read-only). v1 semantics:
-    //   - First client to claim a session (implicitly on first input, or
-    //     explicitly via claim_primary) becomes primary.
-    //   - While a session HAS a primary, ownership transfers ONLY by explicit
-    //     hand-off (claim_primary from another client is rejected unless the
-    //     session is unclaimed) — NOT by whoever sent input last.
+    // primary is the client currently DRIVING it; every other subscriber is an
+    // OBSERVER. v1 semantics:
+    //   - First client to claim a session becomes primary.
+    //   - The explicit `claim_primary` wire path is STICKY: a claim against an
+    //     owned session is rejected unless `force: true` (hand-off).
+    //   - Input that passed the input_conflict gate adopts primary with force
+    //     (see WsServer._updatePrimary): the server can't tell "same user,
+    //     second device" from "shared-session observer" without identity, so
+    //     accepted input keeps today's seamless device hand-off; true
+    //     observe-only enforcement is #5281 client-role work built on the
+    //     sticky claim path.
     //   - On primary disconnect the slot is CLEARED (nobody-until-claim) so a
     //     backgrounded observer is never silently promoted; the next claimant
     //     (or first input) takes over. This matches the pre-#5563 disconnect

--- a/packages/server/src/ws-handler-context.js
+++ b/packages/server/src/ws-handler-context.js
@@ -27,10 +27,13 @@
  * @property {(client: object, sessionId: string) => void} subscribeClient - Index-maintaining subscribe (#5563).
  * @property {(client: object, sessionId: string) => void} unsubscribeClient - Index-maintaining unsubscribe (#5563).
  * @property {(client: object, sessionId: string|null) => void} setActiveSession - Index-maintaining active-session set (#5563).
- * @property {(sessionId: string, clientId: string) => void} updatePrimary - Promote a client to primary for a session.
+ * @property {(sessionId: string, clientId: string) => void} updatePrimary - First-input adoption: claim primary iff unclaimed, else no-op (#5563).
+ * @property {(sessionId: string, clientId: string, opts?: {force?: boolean}) => {changed: boolean, rejected?: boolean, primaryClientId: string|undefined}} claimPrimary - Explicit claim / hand-off (force=true) for a session (#5563).
+ * @property {(sessionId: string) => string|undefined} getPrimary - Current primary clientId for a session, or undefined (#5563).
+ * @property {(sessionId: string, clientId: string) => boolean} isPrimary - True iff clientId is the session's primary (#5563).
+ * @property {(sessionId: string) => void} clearPrimary - Vacate a session's primary slot, announcing the vacancy (#5563).
  * @property {(ws: any, sessionId: string) => void} sendSessionInfo - Send a session_info envelope.
  * @property {(ws: any, sessionId: string) => void} replayHistory - Replay a session's history to a client.
- * @property {Map} primaryClients - sessionId → primary clientId.
  * @property {Map} clients - WebSocket → client-state Map (the WsClientManager's Map).
  *
  * @typedef {Object} WsHandlerSessions
@@ -96,9 +99,12 @@ export const CTX_NAMESPACES = {
     'unsubscribeClient',
     'setActiveSession',
     'updatePrimary',
+    'claimPrimary',
+    'getPrimary',
+    'isPrimary',
+    'clearPrimary',
     'sendSessionInfo',
     'replayHistory',
-    'primaryClients',
     'clients',
   ],
   sessions: [

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1938,17 +1938,21 @@ export class WsServer {
   }
 
   /**
-   * First-input adoption path (#5563). A client that sends input to a session
-   * with NO primary becomes primary (claims it). If the session already has a
-   * DIFFERENT primary, the claim is rejected without side effects — the caller
-   * (input-handlers) has already enforced the input_conflict gate, so this is a
-   * belt-and-suspenders no-op rather than a silent last-writer-wins steal. If
-   * the client is already primary it is a no-op. Broadcasts `primary_changed`
-   * (legacy) + `session_role` (new) only on an actual change.
+   * Input adoption path (#5563). Called only for input that already PASSED the
+   * input_conflict gate — i.e. the session was idle, or the sender is already
+   * primary. Accepted input adopts primary (`force: true`): the server cannot
+   * distinguish "same user, second device" from "shared-session observer"
+   * without identity, and blocking adoption here strands a solo user's second
+   * device behind input_conflict for the rest of the run it just started. The
+   * mid-run steal is still prevented by the conflict gate itself; true
+   * observe-only enforcement is client-role work (#5281) built on the explicit
+   * `claim_primary` path below, which IS sticky (rejects without `force`).
+   * Broadcasts `primary_changed` (legacy) + `session_role` (new) only on an
+   * actual change.
    */
   _updatePrimary(sessionId, clientId) {
     if (!sessionId) return
-    const res = this._clientManager.claimPrimary(sessionId, clientId)
+    const res = this._clientManager.claimPrimary(sessionId, clientId, { force: true })
     if (res.changed) this._announcePrimary(sessionId, clientId)
   }
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -587,7 +587,11 @@ export class WsServer {
     this._hookSecrets = new Set() // per-session hook secrets registered by active CliSessions
     this._sessionHookSecrets = new Map() // sessionId -> hookSecret (for cleanup on session_destroyed)
     this._questionSessionMap = new Map() // toolUseId -> sessionId (for routing question responses)
-    this._primaryClients = new Map() // sessionId -> clientId (last-writer-wins)
+    // #5563: primary-ownership now lives on the WsClientManager (sessionId →
+    // primary clientId) with explicit claim/observe/hand-off semantics, not a
+    // last-writer-wins map. `primaryClients` is no longer a server-owned Map;
+    // handlers query it through ctx.transport.getPrimary / isPrimary / claim /
+    // clear helpers below.
     // #5510: pairing-approval primitive — requestId → requester ws. The
     // requester's WS stays open (pre-auth) after pair_request; on approve/deny/
     // expire/disconnect we look it up here to deliver `pair_result`. Bounded by
@@ -666,10 +670,19 @@ export class WsServer {
         subscribeClient: (client, sid) => self._clientManager.subscribe(client, sid),
         unsubscribeClient: (client, sid) => self._clientManager.unsubscribe(client, sid),
         setActiveSession: (client, sid) => self._clientManager.setActiveSession(client, sid),
+        // #5563: explicit primary-ownership surface. `updatePrimary` is the
+        // first-input adoption path (claims if unclaimed, no-op if already
+        // primary, REJECTED-without-side-effects if another client owns it).
+        // `claimPrimary` is the explicit claim/hand-off path (force=true for an
+        // operator-driven hand-off). `getPrimary`/`isPrimary` are reads used by
+        // the input_conflict gate. `clearPrimary` is the destroy/cleanup path.
         updatePrimary: (sid, cid) => self._updatePrimary(sid, cid),
+        claimPrimary: (sid, cid, opts) => self._claimPrimary(sid, cid, opts),
+        getPrimary: (sid) => self._clientManager.getPrimary(sid),
+        isPrimary: (sid, cid) => self._clientManager.isPrimary(sid, cid),
+        clearPrimary: (sid) => self._clearPrimary(sid),
         sendSessionInfo: (ws, sid) => self._sendSessionInfo(ws, sid),
         replayHistory: (ws, sid) => self._replayHistory(ws, sid),
-        primaryClients: this._primaryClients,
         get clients() { return self.clients },
       },
       sessions: {
@@ -1887,16 +1900,13 @@ export class WsServer {
 
   /** Handle cleanup when an authenticated client disconnects or is terminated */
   _handleClientDeparture(departingClient) {
-    // Clear primary for any sessions this client was primary on
-    for (const [sessionId, primaryClientId] of this._primaryClients) {
-      if (primaryClientId === departingClient.id) {
-        this._primaryClients.delete(sessionId)
-        this._broadcastToSession(sessionId, {
-          type: 'primary_changed',
-          sessionId,
-          clientId: null,
-        })
-      }
+    // #5563: vacate primary for every session this client owned. Promotion
+    // policy is NOBODY-UNTIL-CLAIM — we clear the slot (broadcast null) rather
+    // than auto-promote an observer, so a backgrounded viewer is never silently
+    // handed the session; the next claim_primary (or first input) takes over.
+    // This matches the pre-#5563 disconnect behaviour exactly.
+    for (const sessionId of this._clientManager.clearPrimaryForClient(departingClient.id)) {
+      this._announcePrimary(sessionId, null)
     }
 
     // Release this client's ownership of any push tokens it registered.
@@ -1927,16 +1937,62 @@ export class WsServer {
     }
   }
 
-  /** Update primary client for a session (last-writer-wins) */
+  /**
+   * First-input adoption path (#5563). A client that sends input to a session
+   * with NO primary becomes primary (claims it). If the session already has a
+   * DIFFERENT primary, the claim is rejected without side effects — the caller
+   * (input-handlers) has already enforced the input_conflict gate, so this is a
+   * belt-and-suspenders no-op rather than a silent last-writer-wins steal. If
+   * the client is already primary it is a no-op. Broadcasts `primary_changed`
+   * (legacy) + `session_role` (new) only on an actual change.
+   */
   _updatePrimary(sessionId, clientId) {
     if (!sessionId) return
-    const current = this._primaryClients.get(sessionId)
-    if (current === clientId) return // already primary
-    this._primaryClients.set(sessionId, clientId)
+    const res = this._clientManager.claimPrimary(sessionId, clientId)
+    if (res.changed) this._announcePrimary(sessionId, clientId)
+  }
+
+  /**
+   * Explicit claim / hand-off path (#5563). Returns the claim result so the
+   * handler can tell the requester whether it succeeded or was rejected
+   * (observe-only: another client already owns the session and no hand-off was
+   * authorised). `force` overrides an existing owner for an operator-driven
+   * hand-off. Broadcasts on an actual change.
+   * @returns {{ changed: boolean, rejected?: boolean, primaryClientId: string|undefined }}
+   */
+  _claimPrimary(sessionId, clientId, opts = {}) {
+    if (!sessionId) return { changed: false, primaryClientId: undefined }
+    const res = this._clientManager.claimPrimary(sessionId, clientId, opts)
+    if (res.changed) this._announcePrimary(sessionId, clientId)
+    return res
+  }
+
+  /** Clear the primary slot for a session and announce the vacancy (#5563). */
+  _clearPrimary(sessionId) {
+    if (!sessionId) return
+    const prev = this._clientManager.clearPrimary(sessionId)
+    if (prev !== undefined) this._announcePrimary(sessionId, null)
+  }
+
+  /**
+   * Announce the current primary for a session to every subscriber (#5563).
+   * Emits BOTH the legacy `primary_changed` envelope (so existing clients keep
+   * working unchanged) AND the new `session_role` envelope that names the
+   * primary and lets a client compute its own role (primary iff
+   * primaryClientId === its own clientId, else observer; null === unclaimed).
+   * @param {string} sessionId
+   * @param {string|null} clientId - the new primary, or null when vacated
+   */
+  _announcePrimary(sessionId, clientId) {
     this._broadcastToSession(sessionId, {
       type: 'primary_changed',
       sessionId,
       clientId,
+    })
+    this._broadcastToSession(sessionId, {
+      type: 'session_role',
+      sessionId,
+      primaryClientId: clientId,
     })
   }
 
@@ -2069,7 +2125,8 @@ export class WsServer {
     // Auto-deny all pending permission requests (both subsystems)
     this.clearAllPendingPermissions()
     this._questionSessionMap.clear()
-    this._primaryClients.clear()
+    // #5563: primary-ownership lives on the client manager now; clear it there.
+    this._clientManager._primaryClients.clear()
     this._normalizer.destroy()
 
     // Clean up all dev preview tunnels (fire-and-forget; close() is synchronous

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -2125,8 +2125,9 @@ export class WsServer {
     // Auto-deny all pending permission requests (both subsystems)
     this.clearAllPendingPermissions()
     this._questionSessionMap.clear()
-    // #5563: primary-ownership lives on the client manager now; clear it there.
-    this._clientManager._primaryClients.clear()
+    // #5563: primary-ownership lives on the client manager now; clear it via
+    // its public API rather than reaching into the private `_primaryClients`.
+    this._clientManager.clearAllPrimary()
     this._normalizer.destroy()
 
     // Clean up all dev preview tunnels (fire-and-forget; close() is synchronous

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -7,12 +7,29 @@ function makeCtx(sessions = new Map(), overrides = {}) {
   const sent = []
   const broadcasts = []
 
+  // #5563: the input_conflict gate now reads `ctx.transport.getPrimary(sid)`
+  // instead of a `primaryClients` Map. Back the primary surface by a local Map;
+  // tests seed an existing primary via `ctx.transport.claimPrimary(sid, cid,
+  // { force: true })`. `updatePrimary` stays a spy (asserted by clarify-path
+  // tests) while still mutating the Map for any post-adoption read.
+  const primaryClients = new Map()
+  const updatePrimary = createSpy((sid, cid) => { if (!primaryClients.has(sid)) primaryClients.set(sid, cid) })
+
   return nsCtx({
     send: createSpy((ws, msg) => { sent.push(msg) }),
     broadcast: createSpy((msg) => { broadcasts.push(msg) }),
     broadcastToSession: createSpy(),
-    updatePrimary: createSpy(),
-    primaryClients: new Map(),
+    updatePrimary,
+    getPrimary: (sid) => primaryClients.get(sid),
+    isPrimary: (sid, cid) => primaryClients.get(sid) === cid,
+    claimPrimary: createSpy((sid, cid, opts = {}) => {
+      const current = primaryClients.get(sid)
+      if (current === cid) return { changed: false, primaryClientId: current }
+      if (current && !opts.force) return { changed: false, rejected: true, primaryClientId: current }
+      primaryClients.set(sid, cid)
+      return { changed: true, primaryClientId: cid }
+    }),
+    clearPrimary: createSpy((sid) => { primaryClients.delete(sid) }),
     sessionManager: {
       getSession: createSpy((id) => sessions.get(id)),
       isBudgetPaused: createSpy(() => false),
@@ -177,13 +194,54 @@ describe('input-handlers', () => {
       session.isRunning = true
       sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
       const ctx = makeCtx(sessions)
-      ctx.transport.primaryClients.set('s1', 'other-client')
+      ctx.transport.claimPrimary('s1', 'other-client', { force: true })
       const client = makeClient({ activeSessionId: 's1' })
 
       inputHandlers.input(makeWs(), client, { data: 'hello' }, ctx)
 
       assert.equal(ctx._sent[0].type, 'session_error')
       assert.equal(ctx._sent[0].category, 'input_conflict')
+    })
+
+    // #5563 old-client compatibility: a client that never sends `claim_primary`
+    // still ADOPTS primary implicitly on its first forwarded input — preserving
+    // today's first-writer-becomes-primary behaviour. The legacy primary signal
+    // is driven by updatePrimary (which the full server turns into the legacy
+    // `primary_changed` + new `session_role` broadcast).
+    it('first input on an UNCLAIMED session adopts the sender as primary (old-client compat)', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ id: 'first-client', activeSessionId: 's1' })
+
+      inputHandlers.input(makeWs(), client, { data: 'hello' }, ctx)
+
+      // No conflict error; primary adopted to the sender.
+      assert.equal(ctx._sent.filter(m => m.type === 'session_error').length, 0)
+      assert.equal(ctx.transport.updatePrimary.callCount, 1)
+      assert.deepEqual(ctx.transport.updatePrimary.lastCall, ['s1', 'first-client'])
+      assert.equal(ctx.transport.getPrimary('s1'), 'first-client')
+    })
+
+    // #5563: the cross-client input_conflict gate only bites while the session
+    // is RUNNING (mirrors the pre-#5563 behaviour). An idle session accepts a
+    // second client's input — that send simply does not steal primary (the
+    // first-writer adoption is a no-op when already owned).
+    it('non-primary input on an IDLE session is accepted and does not steal primary', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.isRunning = false
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      ctx.transport.claimPrimary('s1', 'owner', { force: true })
+      const other = makeClient({ id: 'observer', activeSessionId: 's1' })
+
+      inputHandlers.input(makeWs(), other, { data: 'hello' }, ctx)
+
+      assert.equal(ctx._sent.filter(m => m.type === 'session_error').length, 0)
+      // Owner unchanged — observer's input did not steal primary.
+      assert.equal(ctx.transport.getPrimary('s1'), 'owner')
     })
 
     it('skips empty input without sending error', () => {
@@ -607,7 +665,7 @@ describe('input-handlers', () => {
         session.isRunning = true
         sessions.set('s1', { session, name: 'S', cwd: '/work' })
         const ctx = makeCtx(sessions)
-        ctx.transport.primaryClients.set('s1', 'other-client')
+        ctx.transport.claimPrimary('s1', 'other-client', { force: true })
         const client = makeClient({ activeSessionId: 's1' })
 
         inputHandlers.input(makeWs(), client, { data: 'cross-client conflict draft' }, ctx)
@@ -1502,7 +1560,7 @@ describe('input-handlers', () => {
       await new Promise((r) => setImmediate(r))
 
       session.isRunning = true
-      ctx.transport.primaryClients.set('s1', 'other-client')
+      ctx.transport.claimPrimary('s1', 'other-client', { force: true })
 
       resolveEval()
       await inFlight

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -13,7 +13,7 @@ function makeCtx(sessions = new Map(), overrides = {}) {
   // { force: true })`. `updatePrimary` stays a spy (asserted by clarify-path
   // tests) while still mutating the Map for any post-adoption read.
   const primaryClients = new Map()
-  const updatePrimary = createSpy((sid, cid) => { if (!primaryClients.has(sid)) primaryClients.set(sid, cid) })
+  const updatePrimary = createSpy((sid, cid) => { primaryClients.set(sid, cid) })
 
   return nsCtx({
     send: createSpy((ws, msg) => { sent.push(msg) }),
@@ -226,9 +226,11 @@ describe('input-handlers', () => {
 
     // #5563: the cross-client input_conflict gate only bites while the session
     // is RUNNING (mirrors the pre-#5563 behaviour). An idle session accepts a
-    // second client's input — that send simply does not steal primary (the
-    // first-writer adoption is a no-op when already owned).
-    it('non-primary input on an IDLE session is accepted and does not steal primary', () => {
+    // second client's input AND that input adopts primary (same-user device
+    // hand-off: the desktop typing into a session the phone drove must own the
+    // run it starts, or its mid-run follow-ups hit input_conflict). Sticky
+    // ownership applies only to the explicit claim_primary wire path.
+    it('non-primary input on an IDLE session is accepted and adopts primary', () => {
       const sessions = new Map()
       const session = createMockSession()
       session.isRunning = false
@@ -240,8 +242,9 @@ describe('input-handlers', () => {
       inputHandlers.input(makeWs(), other, { data: 'hello' }, ctx)
 
       assert.equal(ctx._sent.filter(m => m.type === 'session_error').length, 0)
-      // Owner unchanged — observer's input did not steal primary.
-      assert.equal(ctx.transport.getPrimary('s1'), 'owner')
+      // Accepted idle input adopts primary, so the sender can follow up
+      // mid-run without tripping the conflict gate on its own turn.
+      assert.equal(ctx.transport.getPrimary('s1'), 'observer')
     })
 
     it('skips empty input without sending error', () => {

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -15,8 +15,11 @@ function makeCtx(overrides = {}) {
   // #5563: back the ctx with a real WsClientManager so the index-maintaining
   // helpers exercise the production reverse-index path. The clients Map IS the
   // manager's Map, so directly-inserted test clients are visible to the index.
+  // #5563: makeSessionIndexCtx() now also wires the primary-ownership surface
+  // (getPrimary / claimPrimary / clearPrimary / isPrimary / updatePrimary)
+  // backed by the same real manager, so claim/observe tests exercise the
+  // production path.
   const indexCtx = makeSessionIndexCtx()
-  const primaryClients = new Map()
 
   const ctx = nsCtx({
     send: createSpy((ws, msg) => { sent.push(msg) }),
@@ -25,9 +28,7 @@ function makeCtx(overrides = {}) {
     broadcastSessionList: createSpy(),
     sendSessionInfo: createSpy(),
     replayHistory: createSpy(),
-    updatePrimary: createSpy(),
     ...indexCtx,
-    primaryClients,
     permissionSessionMap: new Map(),
     questionSessionMap: new Map(),
     pendingPermissions: new Map(),
@@ -614,6 +615,95 @@ describe('session-handlers', () => {
       sessionHandlers.client_visible(makeWs(), client, { visible: false }, ctx)
       assert.equal(ctx.transport.send.callCount, 0)
       assert.equal(ctx.transport.broadcast.callCount, 0)
+    })
+  })
+
+  // #5563: explicit primary claim / hand-off handler.
+  describe('claim_primary', () => {
+    function ctxWithSession(id = 'sess-1') {
+      const ctx = makeCtx()
+      ctx._sessions.set(id, { session: createMockSession(), name: 'S', cwd: '/tmp' })
+      return ctx
+    }
+
+    it('requires a sessionId', () => {
+      const ctx = ctxWithSession()
+      sessionHandlers.claim_primary(makeWs(), makeClient(), {}, ctx)
+      const [, sent] = ctx.transport.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      assert.match(sent.message, /sessionId is required/)
+    })
+
+    it('errors on unknown session', () => {
+      const ctx = makeCtx()
+      sessionHandlers.claim_primary(makeWs(), makeClient(), { sessionId: 'nope' }, ctx)
+      const [, sent] = ctx.transport.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      assert.match(sent.message, /not found/)
+    })
+
+    it('first claim grants primary and replies session_role', () => {
+      const ctx = ctxWithSession()
+      sessionHandlers.claim_primary(makeWs(), makeClient({ id: 'c1' }), { sessionId: 'sess-1' }, ctx)
+      assert.equal(ctx.clientManager.getPrimary('sess-1'), 'c1')
+      const [, sent] = ctx.transport.send.lastCall
+      assert.equal(sent.type, 'session_role')
+      assert.equal(sent.sessionId, 'sess-1')
+      assert.equal(sent.primaryClientId, 'c1')
+    })
+
+    it('second client claim is REJECTED with input_conflict while another owns it', () => {
+      const ctx = ctxWithSession()
+      sessionHandlers.claim_primary(makeWs(), makeClient({ id: 'c1' }), { sessionId: 'sess-1' }, ctx)
+      sessionHandlers.claim_primary(makeWs(), makeClient({ id: 'c2' }), { sessionId: 'sess-1' }, ctx)
+      const [, sent] = ctx.transport.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      assert.equal(sent.category, 'input_conflict')
+      assert.equal(sent.code, 'PRIMARY_HELD')
+      assert.equal(sent.primaryClientId, 'c1')
+      // Owner unchanged — observe-only held.
+      assert.equal(ctx.clientManager.getPrimary('sess-1'), 'c1')
+    })
+
+    it('force claim performs an explicit hand-off to the new client', () => {
+      const ctx = ctxWithSession()
+      sessionHandlers.claim_primary(makeWs(), makeClient({ id: 'c1' }), { sessionId: 'sess-1' }, ctx)
+      sessionHandlers.claim_primary(makeWs(), makeClient({ id: 'c2' }), { sessionId: 'sess-1', force: true }, ctx)
+      assert.equal(ctx.clientManager.getPrimary('sess-1'), 'c2')
+      const [, sent] = ctx.transport.send.lastCall
+      assert.equal(sent.type, 'session_role')
+      assert.equal(sent.primaryClientId, 'c2')
+    })
+
+    it('re-claim by the current primary is an idempotent session_role (no error)', () => {
+      const ctx = ctxWithSession()
+      const client = makeClient({ id: 'c1' })
+      sessionHandlers.claim_primary(makeWs(), client, { sessionId: 'sess-1' }, ctx)
+      sessionHandlers.claim_primary(makeWs(), client, { sessionId: 'sess-1' }, ctx)
+      const [, sent] = ctx.transport.send.lastCall
+      assert.equal(sent.type, 'session_role')
+      assert.equal(sent.primaryClientId, 'c1')
+    })
+
+    it('bound client cannot claim a different session', () => {
+      const ctx = ctxWithSession('sess-1')
+      ctx._sessions.set('sess-2', { session: createMockSession(), name: 'S2', cwd: '/tmp' })
+      sessionHandlers.claim_primary(makeWs(), makeClient({ id: 'c1', boundSessionId: 'sess-2' }), { sessionId: 'sess-1' }, ctx)
+      const [, sent] = ctx.transport.send.lastCall
+      assert.equal(sent.type, 'session_error')
+      // No primary set for the off-limits session.
+      assert.equal(ctx.clientManager.getPrimary('sess-1'), undefined)
+    })
+
+    it('N-observer scenario: many later claimants all rejected, one owner', () => {
+      const ctx = ctxWithSession()
+      sessionHandlers.claim_primary(makeWs(), makeClient({ id: 'owner' }), { sessionId: 'sess-1' }, ctx)
+      for (const id of ['o2', 'o3', 'o4', 'o5', 'o6']) {
+        sessionHandlers.claim_primary(makeWs(), makeClient({ id }), { sessionId: 'sess-1' }, ctx)
+        const [, sent] = ctx.transport.send.lastCall
+        assert.equal(sent.code, 'PRIMARY_HELD', `${id} should be rejected`)
+      }
+      assert.equal(ctx.clientManager.getPrimary('sess-1'), 'owner')
     })
   })
 })

--- a/packages/server/tests/input-conflict.test.js
+++ b/packages/server/tests/input-conflict.test.js
@@ -13,13 +13,28 @@ function createMockCtx(sessionManager, opts = {}) {
   const broadcastSpy = createSpy()
   const sendSpy = createSpy()
   const updatePrimarySpy = createSpy()
+  // #5563: the input_conflict gate reads `ctx.transport.getPrimary(sid)` now
+  // (not a `primaryClients` Map field). Back getPrimary/isPrimary by the
+  // optional `primaryClients` seed Map so existing conflict tests keep working.
+  const { primaryClients, ...rest } = opts
+  const primaryMap = primaryClients instanceof Map ? primaryClients : new Map()
   return nsCtx({
     sessionManager,
     broadcast: broadcastSpy,
     send: sendSpy,
     updatePrimary: updatePrimarySpy,
+    getPrimary: (sid) => primaryMap.get(sid),
+    isPrimary: (sid, cid) => primaryMap.get(sid) === cid,
+    claimPrimary: createSpy((sid, cid, o = {}) => {
+      const current = primaryMap.get(sid)
+      if (current === cid) return { changed: false, primaryClientId: current }
+      if (current && !o.force) return { changed: false, rejected: true, primaryClientId: current }
+      primaryMap.set(sid, cid)
+      return { changed: true, primaryClientId: cid }
+    }),
+    clearPrimary: createSpy((sid) => { primaryMap.delete(sid) }),
     checkpointManager: { createCheckpoint: async () => {} },
-    ...opts,
+    ...rest,
     _spies: { broadcast: broadcastSpy, send: sendSpy, updatePrimary: updatePrimarySpy },
   })
 }

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -93,7 +93,7 @@ export function makeSessionIndexCtx() {
       // tests exercise the production claim/observe gate. These do NOT broadcast
       // (the full ws-server announces session_role/primary_changed) — they only
       // mutate the manager's primary map so getPrimary/isPrimary read correctly.
-      updatePrimary: (sid, cid) => clientManager.claimPrimary(sid, cid),
+      updatePrimary: (sid, cid) => clientManager.claimPrimary(sid, cid, { force: true }),
       claimPrimary: (sid, cid, opts) => clientManager.claimPrimary(sid, cid, opts),
       getPrimary: (sid) => clientManager.getPrimary(sid),
       isPrimary: (sid, cid) => clientManager.isPrimary(sid, cid),

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -89,6 +89,15 @@ export function makeSessionIndexCtx() {
       subscribeClient: (client, sid) => clientManager.subscribe(client, sid),
       unsubscribeClient: (client, sid) => clientManager.unsubscribe(client, sid),
       setActiveSession: (client, sid) => clientManager.setActiveSession(client, sid),
+      // #5563: primary-ownership surface backed by the real manager so handler
+      // tests exercise the production claim/observe gate. These do NOT broadcast
+      // (the full ws-server announces session_role/primary_changed) — they only
+      // mutate the manager's primary map so getPrimary/isPrimary read correctly.
+      updatePrimary: (sid, cid) => clientManager.claimPrimary(sid, cid),
+      claimPrimary: (sid, cid, opts) => clientManager.claimPrimary(sid, cid, opts),
+      getPrimary: (sid) => clientManager.getPrimary(sid),
+      isPrimary: (sid, cid) => clientManager.isPrimary(sid, cid),
+      clearPrimary: (sid) => clientManager.clearPrimary(sid),
     },
   }
 }

--- a/packages/server/tests/ws-client-manager.test.js
+++ b/packages/server/tests/ws-client-manager.test.js
@@ -617,6 +617,14 @@ describe('WsClientManager', () => {
       assert.strictEqual(manager.getPrimary('s1'), 'c1')
     })
 
+    it('clearAllPrimary vacates every slot (shutdown path)', () => {
+      manager.claimPrimary('s1', 'c1')
+      manager.claimPrimary('s2', 'c2')
+      manager.clearAllPrimary()
+      assert.strictEqual(manager.getPrimary('s1'), undefined)
+      assert.strictEqual(manager.getPrimary('s2'), undefined)
+    })
+
     it('disconnect-promotion policy is nobody-until-claim: an observer is not auto-promoted', () => {
       manager.claimPrimary('s1', 'primary')
       // Observers exist but are not tracked as candidates — vacating clears.

--- a/packages/server/tests/ws-client-manager.test.js
+++ b/packages/server/tests/ws-client-manager.test.js
@@ -526,4 +526,105 @@ describe('WsClientManager', () => {
       }
     })
   })
+
+  // #5563: explicit primary-ownership semantics. First-to-claim wins; later
+  // claimants are rejected unless they force a hand-off; clearing vacates the
+  // slot (nobody-until-claim). Designed for N>2 observers on one session.
+  describe('primary ownership (#5563)', () => {
+    it('starts unclaimed — getPrimary is undefined, isPrimary is false', () => {
+      assert.strictEqual(manager.getPrimary('s1'), undefined)
+      assert.strictEqual(manager.isPrimary('s1', 'c1'), false)
+    })
+
+    it('first claim on an unclaimed session succeeds', () => {
+      const res = manager.claimPrimary('s1', 'c1')
+      assert.strictEqual(res.changed, true)
+      assert.strictEqual(res.primaryClientId, 'c1')
+      assert.strictEqual(manager.getPrimary('s1'), 'c1')
+      assert.strictEqual(manager.isPrimary('s1', 'c1'), true)
+    })
+
+    it('re-claim by the current primary is a no-op (changed:false, not rejected)', () => {
+      manager.claimPrimary('s1', 'c1')
+      const res = manager.claimPrimary('s1', 'c1')
+      assert.strictEqual(res.changed, false)
+      assert.strictEqual(res.rejected, undefined)
+      assert.strictEqual(res.primaryClientId, 'c1')
+    })
+
+    it('claim by a second client is REJECTED while another owns it (observe-only)', () => {
+      manager.claimPrimary('s1', 'c1')
+      const res = manager.claimPrimary('s1', 'c2')
+      assert.strictEqual(res.changed, false)
+      assert.strictEqual(res.rejected, true)
+      assert.strictEqual(res.primaryClientId, 'c1')
+      // Owner unchanged.
+      assert.strictEqual(manager.getPrimary('s1'), 'c1')
+    })
+
+    it('force claim overrides the current owner (explicit hand-off)', () => {
+      manager.claimPrimary('s1', 'c1')
+      const res = manager.claimPrimary('s1', 'c2', { force: true })
+      assert.strictEqual(res.changed, true)
+      assert.strictEqual(res.primaryClientId, 'c2')
+      assert.strictEqual(manager.getPrimary('s1'), 'c2')
+      assert.strictEqual(manager.isPrimary('s1', 'c1'), false)
+    })
+
+    it('N-client scenario: only the first of many claimants holds primary', () => {
+      assert.strictEqual(manager.claimPrimary('s1', 'a').changed, true)
+      for (const id of ['b', 'c', 'd', 'e', 'f', 'g', 'h']) {
+        const res = manager.claimPrimary('s1', id)
+        assert.strictEqual(res.rejected, true, `${id} should be rejected`)
+      }
+      assert.strictEqual(manager.getPrimary('s1'), 'a')
+    })
+
+    it('claimPrimary ignores empty sessionId / clientId', () => {
+      assert.strictEqual(manager.claimPrimary('', 'c1').changed, false)
+      assert.strictEqual(manager.claimPrimary('s1', '').changed, false)
+      assert.strictEqual(manager.getPrimary('s1'), undefined)
+    })
+
+    it('clearPrimary vacates the slot and returns the previous owner', () => {
+      manager.claimPrimary('s1', 'c1')
+      assert.strictEqual(manager.clearPrimary('s1'), 'c1')
+      assert.strictEqual(manager.getPrimary('s1'), undefined)
+      // After clearing, a fresh client can claim (nobody-until-claim).
+      assert.strictEqual(manager.claimPrimary('s1', 'c2').changed, true)
+      assert.strictEqual(manager.getPrimary('s1'), 'c2')
+    })
+
+    it('clearPrimary on an unclaimed session returns undefined', () => {
+      assert.strictEqual(manager.clearPrimary('s1'), undefined)
+    })
+
+    it('clearPrimaryForClient vacates every session a client owned', () => {
+      manager.claimPrimary('s1', 'c1')
+      manager.claimPrimary('s2', 'c1')
+      manager.claimPrimary('s3', 'c2')
+      const vacated = manager.clearPrimaryForClient('c1').sort()
+      assert.deepStrictEqual(vacated, ['s1', 's2'])
+      assert.strictEqual(manager.getPrimary('s1'), undefined)
+      assert.strictEqual(manager.getPrimary('s2'), undefined)
+      // c2's session is untouched.
+      assert.strictEqual(manager.getPrimary('s3'), 'c2')
+    })
+
+    it('clearPrimaryForClient returns [] when the client owned nothing', () => {
+      manager.claimPrimary('s1', 'c1')
+      assert.deepStrictEqual(manager.clearPrimaryForClient('c2'), [])
+      assert.strictEqual(manager.getPrimary('s1'), 'c1')
+    })
+
+    it('disconnect-promotion policy is nobody-until-claim: an observer is not auto-promoted', () => {
+      manager.claimPrimary('s1', 'primary')
+      // Observers exist but are not tracked as candidates — vacating clears.
+      manager.clearPrimaryForClient('primary')
+      assert.strictEqual(manager.getPrimary('s1'), undefined)
+      // The observer must explicitly claim to become primary.
+      assert.strictEqual(manager.claimPrimary('s1', 'observer').changed, true)
+      assert.strictEqual(manager.getPrimary('s1'), 'observer')
+    })
+  })
 })

--- a/packages/server/tests/ws-handler-coverage.test.js
+++ b/packages/server/tests/ws-handler-coverage.test.js
@@ -56,9 +56,9 @@ function createMockCtx(sessionManager, opts = {}) {
     checkpointManager,
     devPreview,
     webTaskManager,
-    primaryClients: new Map(),
-    // #5563: index-maintaining helpers + clients Map backed by a real
-    // WsClientManager so create/destroy/switch handlers can route through them.
+    // #5563: index-maintaining helpers + clients Map + the primary-ownership
+    // surface (getPrimary / claimPrimary / clearPrimary), all backed by a real
+    // WsClientManager so create/destroy/switch handlers route through them.
     ...makeSessionIndexCtx(),
     permissionSessionMap: new Map(),
     questionSessionMap: new Map(),

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -31,6 +31,11 @@ function makeSession(overrides = {}) {
 function makeCtx(overrides = {}) {
   const sessionMap = new Map()
   const { sessionManager: smOverrides, ...restOverrides } = overrides
+  // #5563: primary-ownership moved off a `primaryClients` Map onto the
+  // getPrimary / isPrimary / claimPrimary / clearPrimary surface. Back them
+  // with a local Map so destroy/input handlers route through the helpers
+  // (e.g. handleDestroySession now calls ctx.transport.clearPrimary).
+  const primaryMap = new Map()
   return nsCtx({
     sessionManager: {
       getSession: mock.fn((id) => sessionMap.get(id) ?? null),
@@ -50,8 +55,17 @@ function makeCtx(overrides = {}) {
     broadcastToSession: mock.fn(),
     broadcastSessionList: mock.fn(),
     sendSessionInfo: mock.fn(),
-    primaryClients: new Map(),
-    updatePrimary: mock.fn(),
+    updatePrimary: mock.fn((sid, cid) => { if (!primaryMap.has(sid)) primaryMap.set(sid, cid) }),
+    claimPrimary: mock.fn((sid, cid, o = {}) => {
+      const current = primaryMap.get(sid)
+      if (current === cid) return { changed: false, primaryClientId: current }
+      if (current && !o.force) return { changed: false, rejected: true, primaryClientId: current }
+      primaryMap.set(sid, cid)
+      return { changed: true, primaryClientId: cid }
+    }),
+    getPrimary: mock.fn((sid) => primaryMap.get(sid)),
+    isPrimary: mock.fn((sid, cid) => primaryMap.get(sid) === cid),
+    clearPrimary: mock.fn((sid) => { primaryMap.delete(sid) }),
     checkpointManager: {
       createCheckpoint: mock.fn(() => Promise.resolve()),
     },

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -55,7 +55,7 @@ function makeCtx(overrides = {}) {
     broadcastToSession: mock.fn(),
     broadcastSessionList: mock.fn(),
     sendSessionInfo: mock.fn(),
-    updatePrimary: mock.fn((sid, cid) => { if (!primaryMap.has(sid)) primaryMap.set(sid, cid) }),
+    updatePrimary: mock.fn((sid, cid) => { primaryMap.set(sid, cid) }),
     claimPrimary: mock.fn((sid, cid, o = {}) => {
       const current = primaryMap.get(sid)
       if (current === cid) return { changed: false, primaryClientId: current }


### PR DESCRIPTION
Completes the second half of #5563: explicit primary-client semantics. The reverse-index half landed in #5575; this PR replaces the last-writer-wins `_primaryClients` map (no meaning for N clients in one shared session) with explicit **claim / observe / hand-off** ownership.

## What "primary" gates today (exhaustive inventory)

Grepping every `_primaryClients` / `updatePrimary` use, primary is consulted in exactly these places:

| Site | What it does |
|------|--------------|
| `input-handlers.js` pre-evaluator (~L293) | **input_conflict gate**: while the session `isRunning`, reject input from a non-primary client. |
| `input-handlers.js` post-evaluator re-check (~L430) | Same gate, re-checked after the evaluator round-trip (#3636). |
| `input-handlers.js` clarify path (~L478) | `updatePrimary(session, sender)` even though the draft wasn't forwarded. |
| `input-handlers.js` forward path (~L517) | `updatePrimary(session, sender)` on a real send. |
| `ws-server.js` `_handleClientDeparture` | On disconnect, clear primary for sessions the client owned and broadcast `primary_changed: null`. |
| `session-handlers.js` destroy_session | Delete the primary entry for the destroyed session. |
| `ws-server.js` `_updatePrimary` | Last-writer-wins setter; broadcasts `primary_changed`. |

**The only behavioural gate is input_conflict** — primary is otherwise a soft "who is driving" marker that, before this PR, whoever sent input last would silently steal.

## Chosen v1 semantics + promotion policy

- **First-to-claim wins.** First client to claim a session — implicitly on its first forwarded input (preserving today's behaviour) or explicitly via the new `claim_primary` message — becomes primary. Everyone else is an observer.
- **Observers are read-only while running.** The existing input_conflict gate already enforces this; primary is now *sticky* instead of last-writer-wins, so an observer's input no longer steals the session.
- **Hand-off is explicit.** `claim_primary` against a session another client owns is **rejected** (surfaced as an `input_conflict` session_error, `code: PRIMARY_HELD`) unless sent with `force: true` — an operator-driven take-over.
- **Promotion on disconnect = nobody-until-claim.** When the primary disconnects, the slot is *cleared* (broadcast `primary_changed: null`), not auto-promoted to a backgrounded observer. Rationale: auto-promoting a phone that happens to be in the index — possibly backgrounded — would silently hand it the keyboard; clearing matches the pre-existing disconnect behaviour exactly and is the safe default for N>2 observers. The next `claim_primary` (or first input) takes over.

## Compat story (server-first; clients untouched)

- `_updatePrimary` still broadcasts the **legacy `primary_changed`** envelope on every real change, identical to before — so existing app/dashboard/store-core clients (which already handle `primary_changed`) keep working with **zero changes**.
- A client that never sends `claim_primary` gets today's effective behaviour: it adopts primary on its first input and is gated out of a running session another client owns.
- The new `session_role` envelope (names the primary; role = primary iff `primaryClientId === own clientId`, null = unclaimed) and the `claim_primary` message are **purely additive** — old clients ignore the unknown server message and never send the new client message.
- **No behaviour change on the input path (revised in a83b7d72b):** accepted input on an idle session still adopts primary, exactly as before — the server cannot distinguish "same user, second device" from "shared-session observer" without identity, and rejecting adoption strands a solo user's second device behind `input_conflict` for a run it just started. Sticky ownership (`PRIMARY_HELD` unless `force`) applies to the **explicit `claim_primary` wire path**, which is the primitive #5281 client roles will build true observe-only on.

## Implementation

- Primary state moves onto `WsClientManager` (`getPrimary` / `isPrimary` / `claimPrimary` / `clearPrimary` / `clearPrimaryForClient`) — it now lives with the reverse index and per-client session maps it's correlated with. All reverse-index mutations still route through the sanctioned helpers; the `lint-ws-index-mutations` gate is green.
- `claimPrimary(sessionId, clientId, { force })` returns `{ changed, rejected?, primaryClientId }` so callers can broadcast only on real changes and tell a rejected claimant why.
- New `claim_primary` handler in `session-handlers.js` (binding-checked); Zod schema added to `@chroxy/protocol` (`ClaimPrimarySchema`) + compiled `dist`.

## Tests

- `ws-client-manager.test.js`: claim / re-claim no-op / second-client rejection / force hand-off / N-client / clear / clearForClient / disconnect-promotion-is-nobody-until-claim.
- `session-handlers.test.js`: `claim_primary` grant / reject (`PRIMARY_HELD`) / force hand-off / idempotent re-claim / bound-client rejection / N-observer.
- `input-handlers.test.js`: first-input adoption (old-client compat) + non-primary input on an idle session adopts primary (device hand-off).
- Custom lints green: `lint-ws-index-mutations`, `lint-session-opt-forwarding`, `lint-tests-state-file-path`; eslint 0 errors; runnable suite passes (incl. `CHROXY_WS_INDEX_ASSERT=1`).

> Note: a few full-registry integration tests (`ws-server.test.js`, `ws-schema-coverage.test.js`, `input-conflict.test.js`) can't execute in this sandbox because `@anthropic-ai/claude-agent-sdk` is only partially installed here (pre-existing, reproduces on main) — they exercise the legacy `primary_changed` broadcasts which this PR preserves verbatim; CI runs them with deps installed.

Closes #5563
Related to #5281
