### PR TITLE
feat(ws): eager key exchange folded into auth handshake (#5555)

### DIFF
--- a/docs/security/encryption-threat-model.md
+++ b/docs/security/encryption-threat-model.md
@@ -41,6 +41,14 @@ Chroxy uses the TweetNaCl library (`tweetnacl`) on both the server and mobile ap
 
 5. **Timeout enforcement**: If the client does not send a `key_exchange` message within the configured timeout (default 10 seconds), the server disconnects the client. The server never downgrades to plaintext -- if encryption is enabled, any non-`key_exchange` message during the pending phase causes immediate disconnection.
 
+### Eager Key Exchange (#5555)
+
+As a latency optimisation, the client may fold its half of the handshake into the `auth` message: it generates the ephemeral keypair + salt up front and sends `eagerPublicKey` + `eagerSalt` alongside the token. When the server honours this (encryption required, both fields present and well-formed), it derives the shared key inline and returns its own ephemeral public key as `serverPublicKey` in the **plaintext** `auth_ok` frame, then activates encryption for every subsequent frame. This collapses the two-round-trip handshake into one — replay starts a full RTT earlier.
+
+**The eager path is cryptographically identical to the discrete `key_exchange`.** It uses the same `nacl.box` Curve25519 DH (step 3) and the same per-connection salt sub-key derivation; only the transport timing of the two public keys changes (one frame instead of two). It is fully backward compatible in both directions: an old client that omits the eager fields, or a new client talking to an old server that omits `serverPublicKey`, falls back to the discrete `key_exchange` with no behavioural change. The server still refuses to downgrade to plaintext, still queues nothing-until-keyed on the discrete fallback, and still enforces the key-exchange timeout when the eager path was not taken.
+
+**Interaction with TOFU (#5536).** The eager path does **not** change the trust model. As with the discrete handshake, the server's ephemeral public key travels in the clear over the (TLS-protected) tunnel and is accepted on first use without out-of-band pinning — see "Trust On First Use" below. Moving that key one frame earlier (into `auth_ok`) does not widen the MITM window: an attacker who could relay the discrete `key_exchange_ok` could equally relay the `serverPublicKey` field of `auth_ok`. No server-identity assurance is gained or lost; #5536 is neither improved nor worsened by eager key exchange.
+
 ### Key Properties
 
 - **Ephemeral keys**: New keypairs are generated for every connection. The server creates a fresh keypair per client session; the app resets encryption state on every new WebSocket connection.

--- a/packages/app/__tests__/auth-ok-handler.test.ts
+++ b/packages/app/__tests__/auth-ok-handler.test.ts
@@ -118,6 +118,7 @@ import {
   setConnectionContext,
   clearDeltaBuffers,
   stopHeartbeat,
+  resetAllHandlerState,
 } from '../src/store/message-handler';
 import type { ConnectionState } from '../src/store/types';
 import { hapticSuccess } from '../src/utils/haptics';
@@ -181,6 +182,11 @@ describe('auth_ok handler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     clearDeltaBuffers();
+    // #5555: reset module-level handler state (notably _ctx.pendingKeyPair) so
+    // the eager-key-exchange fallback's `if (!_ctx.pendingKeyPair)` guard sees a
+    // clean slate. Without this, a pendingKeyPair leaked from a prior test makes
+    // the fallback skip createKeyPair() and the call-count assertion fails.
+    resetAllHandlerState();
 
     mockSocket = createMockSocket();
     store = createMockStore({

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -13,6 +13,13 @@ import {
 } from '../../store/connection';
 import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
 import { clearAllCallbacks, getCallback } from '../../store/imperative-callbacks';
+import {
+  prepareEagerKeyExchange,
+  setPendingKeyPair,
+  getEncryptionState,
+  setEncryptionState,
+} from '../../store/message-handler';
+import { createKeyPair } from '@chroxy/store-core';
 
 // Reset store between tests
 beforeEach(() => {
@@ -928,6 +935,62 @@ describe('WS message handler (direct)', () => {
       const state = useConnectionStore.getState();
       expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connected');
       expect(state.connectedClients).toEqual([]);
+    });
+
+    // #5555 (eager key exchange) — onopen prepares the keypair eagerly and
+    // sends pubkey+salt with auth; if auth_ok carries serverPublicKey the
+    // client derives the shared key inline and sends the burst immediately,
+    // skipping the discrete key_exchange RTT. Uses real store-core crypto.
+    describe('eager key exchange (#5555)', () => {
+      afterEach(() => {
+        setEncryptionState(null);
+        setPendingKeyPair(null);
+      });
+
+      it('derives encryption inline and sends the burst when serverPublicKey is present', () => {
+        // Simulate onopen having generated + sent the eager keypair.
+        prepareEagerKeyExchange();
+        const serverKp = createKeyPair();
+        (mockSocket.send as jest.Mock).mockClear();
+
+        _testMessageHandler.handle({
+          type: 'auth_ok',
+          clientId: 'me-123',
+          serverMode: 'cli',
+          encryption: 'required',
+          serverPublicKey: serverKp.publicKey,
+        });
+
+        // Shared key established without a discrete key_exchange round trip.
+        expect(getEncryptionState()).not.toBeNull();
+        const sentTypes = (mockSocket.send as jest.Mock).mock.calls
+          .map((c) => JSON.parse(c[0] as string).type);
+        expect(sentTypes).not.toContain('key_exchange');
+        // Burst sends are encrypted envelopes (encryptionState is active).
+        expect(sentTypes).toContain('encrypted');
+      });
+
+      it('falls back to the discrete key_exchange when serverPublicKey is absent (old server)', () => {
+        prepareEagerKeyExchange();
+        (mockSocket.send as jest.Mock).mockClear();
+
+        _testMessageHandler.handle({
+          type: 'auth_ok',
+          clientId: 'me-123',
+          serverMode: 'cli',
+          encryption: 'required',
+          // no serverPublicKey → old server
+        });
+
+        // No shared key yet — waiting on key_exchange_ok.
+        expect(getEncryptionState()).toBeNull();
+        const sent = (mockSocket.send as jest.Mock).mock.calls
+          .map((c) => JSON.parse(c[0] as string));
+        const ke = sent.find((m) => m.type === 'key_exchange');
+        expect(ke).toBeTruthy();
+        expect(typeof ke.publicKey).toBe('string');
+        expect(typeof ke.salt).toBe('string');
+      });
     });
   });
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -96,6 +96,7 @@ import {
   setConnectionContext,
   setEncryptionState,
   setPendingKeyPair,
+  prepareEagerKeyExchange,
   getEncryptionState,
   getPendingKeyPair,
   connectionAttemptId,
@@ -959,12 +960,23 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
               deviceInfo: { deviceId, ...info },
             }));
           } else {
+            // #5555 (eager key exchange) — generate this connection's ephemeral
+            // keypair + salt now and send them WITH auth. If the server honours
+            // the eager path it returns serverPublicKey in auth_ok and the
+            // discrete key_exchange RTT is skipped; otherwise (old server /
+            // encryption disabled) the fields are ignored and the auth_ok
+            // handler falls back to the discrete handshake using the same
+            // stashed keypair. Generating eagerly is cheap and harmless even
+            // when the server ends up not requiring encryption.
+            const eager = prepareEagerKeyExchange();
             socket.send(JSON.stringify({
               type: 'auth',
               token,
               protocolVersion: CLIENT_PROTOCOL_VERSION,
               deviceInfo: { deviceId, ...info },
               capabilities: CLIENT_CAPABILITIES.mobile,
+              eagerPublicKey: eager.publicKey,
+              eagerSalt: eager.salt,
             }));
           }
         }

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -509,6 +509,25 @@ export function setPendingKeyPair(kp: KeyPair | null): void {
   _ctx.pendingKeyPair = kp;
 }
 
+/**
+ * #5555 (eager key exchange) — generate this connection's ephemeral X25519
+ * keypair + per-connection salt and stash them on the handler context so they
+ * can be sent WITH the `auth` message (in `socket.onopen`). Returns the public
+ * key + salt to inline into auth.
+ *
+ * The discrete `key_exchange_ok` / fallback handler reads the same
+ * `_ctx.pendingKeyPair` + `_ctx.pendingSalt`, so if the server omits
+ * `serverPublicKey` from auth_ok (old server, encryption disabled, eager
+ * derivation failed) the client still has everything it needs to fall back to
+ * the discrete handshake without regenerating keys. Crypto is identical to the
+ * discrete path — only the send timing changes.
+ */
+export function prepareEagerKeyExchange(): { publicKey: string; salt: string } {
+  _ctx.pendingKeyPair = createKeyPair();
+  _ctx.pendingSalt = generateConnectionSalt();
+  return { publicKey: _ctx.pendingKeyPair.publicKey, salt: _ctx.pendingSalt };
+}
+
 // ---------------------------------------------------------------------------
 // Connection attempt tracking
 // These are kept as export let (not in _ctx) to preserve ES module live-binding
@@ -1236,12 +1255,41 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
       // Initiate key exchange if server requires encryption
       if (auth.encryption === 'required') {
-        _ctx.pendingKeyPair = createKeyPair();
-        _ctx.pendingSalt = generateConnectionSalt();
-        // Send key_exchange plaintext (before encryption is active)
-        ctx.socket.send(JSON.stringify({ type: 'key_exchange', publicKey: _ctx.pendingKeyPair.publicKey, salt: _ctx.pendingSalt }));
-        // Post-auth messages will be sent after key_exchange_ok arrives
         useConnectionLifecycleStore.getState().setServerInfo({ isEncrypted: true });
+        // #5555 (eager key exchange) — the ephemeral keypair + salt were
+        // already generated and sent WITH the auth message (socket.onopen →
+        // prepareEagerKeyExchange), stashed on _ctx.pendingKeyPair /
+        // _ctx.pendingSalt. If the server honoured the eager path it returns
+        // its public key in auth_ok; derive the shared key immediately and
+        // start the burst a full RTT earlier than the discrete handshake.
+        if (auth.serverPublicKey && _ctx.pendingKeyPair) {
+          const rawSharedKey = deriveSharedKey(auth.serverPublicKey, _ctx.pendingKeyPair.secretKey);
+          const encryptionKey = _ctx.pendingSalt
+            ? deriveConnectionKey(rawSharedKey, _ctx.pendingSalt)
+            : rawSharedKey;
+          _ctx.encryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 };
+          _ctx.pendingKeyPair = null;
+          _ctx.pendingSalt = null;
+          console.log('[crypto] E2E encryption established (eager)');
+          // Burst un-gated: server already activated encryption after auth_ok.
+          wsSend(ctx.socket, { type: 'list_providers' });
+          wsSend(ctx.socket, { type: 'list_slash_commands' });
+          wsSend(ctx.socket, { type: 'list_agents' });
+          resetClientVisibleMemo();
+          sendClientVisible(ctx.socket, isVisibleAppState(AppState.currentState));
+        } else {
+          // Fallback (old server / eager derivation declined): the keypair is
+          // still stashed from onopen — send the discrete key_exchange so the
+          // server replies key_exchange_ok. If onopen never ran (defensive),
+          // regenerate so we never send an empty handshake.
+          if (!_ctx.pendingKeyPair) {
+            _ctx.pendingKeyPair = createKeyPair();
+            _ctx.pendingSalt = generateConnectionSalt();
+          }
+          // Send key_exchange plaintext (before encryption is active)
+          ctx.socket.send(JSON.stringify({ type: 'key_exchange', publicKey: _ctx.pendingKeyPair.publicKey, salt: _ctx.pendingSalt }));
+          // Post-auth messages will be sent after key_exchange_ok arrives
+        }
       } else {
         // No encryption — send post-auth messages immediately
         wsSend(ctx.socket, { type: 'list_providers' });

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -12,7 +12,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 vi.mock('./crypto', () => ({
   createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
   deriveSharedKey: vi.fn(),
-  encrypt: vi.fn(),
+  // #5555 — return a parseable envelope so the eager-path burst (which is
+  // encrypted once encryptionState is active) serialises to valid JSON.
+  encrypt: vi.fn((_json: string, _key: unknown, n: number) => ({ type: 'encrypted', d: 'cipher', n })),
   decrypt: vi.fn(),
   generateConnectionSalt: vi.fn(() => 'mock-salt'),
   deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
@@ -30,8 +32,10 @@ import {
   setConnectionContext,
   clearDeltaBuffers,
   stopHeartbeat,
+  prepareEagerKeyExchange,
+  setPendingKeyPair,
 } from './message-handler'
-import { createKeyPair } from './crypto'
+import { createKeyPair, deriveSharedKey, deriveConnectionKey } from './crypto'
 import type { ConnectionState } from './types'
 
 // ---------------------------------------------------------------------------
@@ -94,6 +98,9 @@ describe('auth_ok handler', () => {
     vi.clearAllMocks()
     localStorage.clear()
     clearDeltaBuffers()
+    // #5555 — reset the module-level eager keypair so a prior test's
+    // prepareEagerKeyExchange() doesn't bleed into the discrete-fallback cases.
+    setPendingKeyPair(null)
 
     mockSocket = createMockSocket()
     store = createMockStore({
@@ -279,6 +286,55 @@ describe('auth_ok handler', () => {
       )
       const keyExchange = sends.find((s: Record<string, unknown>) => s.type === 'key_exchange')
       expect(keyExchange).toEqual({ type: 'key_exchange', publicKey: 'mock-pub', salt: 'mock-salt' })
+    })
+  })
+
+  // #5555 (eager key exchange) — when onopen prepared the keypair eagerly and
+  // the server returns serverPublicKey in auth_ok, the client derives the
+  // shared key inline and sends the post-auth burst immediately (no discrete
+  // key_exchange RTT). When the server omits serverPublicKey (old server), the
+  // client falls back to the discrete handshake.
+  describe('eager key exchange (#5555)', () => {
+    function sendsFrom(socket: WebSocket) {
+      return (socket.send as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c: unknown[]) => JSON.parse(c[0] as string),
+      )
+    }
+
+    it('derives the shared key inline and sends the burst when serverPublicKey is present', () => {
+      // Simulate onopen having prepared the eager keypair.
+      prepareEagerKeyExchange()
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(
+        createAuthOkMessage({ encryption: 'required', serverPublicKey: 'server-pub-key' }),
+        ctx as any,
+      )
+
+      // Eager path derives from the server's public key + our stashed secret.
+      expect(deriveSharedKey).toHaveBeenCalledWith('server-pub-key', 'mock-sec')
+      expect(deriveConnectionKey).toHaveBeenCalled()
+
+      const types = sendsFrom(mockSocket).map((s) => s.type)
+      // No discrete key_exchange frame — the burst flows immediately. The
+      // post-auth burst (list_providers/list_slash_commands/list_agents) goes
+      // out as encrypted envelopes because encryptionState is now active, so
+      // we see 'encrypted' frames, not plaintext list_* types.
+      expect(types).not.toContain('key_exchange')
+      expect(types).not.toContain('list_providers') // encrypted now
+      expect(types.filter((t) => t === 'encrypted').length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('falls back to the discrete key_exchange when serverPublicKey is absent (old server)', () => {
+      prepareEagerKeyExchange()
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      // encryption required but NO serverPublicKey → old server.
+      handleMessage(createAuthOkMessage({ encryption: 'required' }), ctx as any)
+
+      const types = sendsFrom(mockSocket).map((s) => s.type)
+      expect(types).toContain('key_exchange')
+      expect(types).not.toContain('list_providers')
+      // Did not derive eagerly.
+      expect(deriveSharedKey).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -85,6 +85,7 @@ import {
   setConnectionContext,
   setEncryptionState,
   setPendingKeyPair,
+  prepareEagerKeyExchange,
   getEncryptionState,
   connectionAttemptId,
   bumpConnectionAttemptId,
@@ -1409,7 +1410,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         if (pairingId) {
           socket.send(JSON.stringify({ type: 'pair', pairingId, ...common }));
         } else {
-          socket.send(JSON.stringify({ type: 'auth', token, ...common }));
+          // #5555 (eager key exchange) — generate this connection's ephemeral
+          // keypair + salt now and send them WITH auth. If the server honours
+          // the eager path it returns serverPublicKey in auth_ok and the
+          // discrete key_exchange RTT is skipped; otherwise (old server /
+          // encryption disabled) the fields are ignored and the auth_ok handler
+          // falls back to the discrete handshake using the same stashed keypair.
+          const eager = prepareEagerKeyExchange();
+          socket.send(JSON.stringify({
+            type: 'auth',
+            token,
+            ...common,
+            eagerPublicKey: eager.publicKey,
+            eagerSalt: eager.salt,
+          }));
         }
       }
     };

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -419,6 +419,25 @@ export function setPendingKeyPair(kp: KeyPair | null): void {
   _pendingKeyPair = kp;
 }
 
+/**
+ * #5555 (eager key exchange) — generate this connection's ephemeral X25519
+ * keypair + per-connection salt and stash them so they can be sent WITH the
+ * `auth` message (in `socket.onopen`). Returns the public key + salt to inline
+ * into auth.
+ *
+ * The discrete `key_exchange_ok` / fallback handler reads the same module-level
+ * `_pendingKeyPair` + `_pendingSalt`, so if the server omits `serverPublicKey`
+ * from auth_ok (old server, encryption disabled, eager derivation failed) the
+ * client still has everything it needs to fall back to the discrete handshake
+ * without regenerating keys. Crypto is identical to the discrete path — only
+ * the send timing changes.
+ */
+export function prepareEagerKeyExchange(): { publicKey: string; salt: string } {
+  _pendingKeyPair = createKeyPair();
+  _pendingSalt = generateConnectionSalt();
+  return { publicKey: _pendingKeyPair.publicKey, salt: _pendingSalt };
+}
+
 // ---------------------------------------------------------------------------
 // Connection attempt tracking
 // ---------------------------------------------------------------------------
@@ -2488,11 +2507,42 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
       // Initiate key exchange if server requires encryption
       if (auth.encryption === 'required') {
-        _pendingKeyPair = createKeyPair();
-        _pendingSalt = generateConnectionSalt();
-        // Send key_exchange plaintext (before encryption is active)
-        ctx.socket.send(JSON.stringify({ type: 'key_exchange', publicKey: _pendingKeyPair.publicKey, salt: _pendingSalt }));
-        // Post-auth messages will be sent after key_exchange_ok arrives
+        // #5555 (eager key exchange) — the ephemeral keypair + salt were
+        // already generated and sent WITH the auth message (socket.onopen →
+        // prepareEagerKeyExchange), stashed on _pendingKeyPair / _pendingSalt.
+        // If the server honoured the eager path it returns its public key in
+        // auth_ok; derive the shared key immediately and start the burst a full
+        // RTT earlier than the discrete handshake.
+        if (auth.serverPublicKey && _pendingKeyPair) {
+          const rawSharedKey = deriveSharedKey(auth.serverPublicKey, _pendingKeyPair.secretKey);
+          const encryptionKey = _pendingSalt
+            ? deriveConnectionKey(rawSharedKey, _pendingSalt)
+            : rawSharedKey;
+          _encryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 };
+          _pendingKeyPair = null;
+          _pendingSalt = null;
+          console.log('[crypto] E2E encryption established (eager)');
+          // Burst un-gated: server already activated encryption after auth_ok.
+          wsSend(ctx.socket, { type: 'list_providers' });
+          wsSend(ctx.socket, { type: 'list_slash_commands' });
+          wsSend(ctx.socket, { type: 'list_agents' });
+          resetClientVisibleMemo();
+          if (typeof document !== 'undefined') {
+            sendClientVisible(ctx.socket, document.visibilityState === 'visible');
+          }
+        } else {
+          // Fallback (old server / eager derivation declined): the keypair is
+          // still stashed from onopen — send the discrete key_exchange. If
+          // onopen never ran (defensive), regenerate so we never send an empty
+          // handshake.
+          if (!_pendingKeyPair) {
+            _pendingKeyPair = createKeyPair();
+            _pendingSalt = generateConnectionSalt();
+          }
+          // Send key_exchange plaintext (before encryption is active)
+          ctx.socket.send(JSON.stringify({ type: 'key_exchange', publicKey: _pendingKeyPair.publicKey, salt: _pendingSalt }));
+          // Post-auth messages will be sent after key_exchange_ok arrives
+        }
       } else {
         // No encryption — send post-auth messages immediately
         wsSend(ctx.socket, { type: 'list_providers' });

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -30,6 +30,8 @@ export declare const AuthSchema: z.ZodObject<{
         platform: z.ZodOptional<z.ZodString>;
     }, z.core.$loose>>;
     capabilities: z.ZodDefault<z.ZodCatch<z.ZodOptional<z.ZodArray<z.ZodString>>>>;
+    eagerPublicKey: z.ZodOptional<z.ZodString>;
+    eagerSalt: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
 export declare const PairSchema: z.ZodObject<{
     type: z.ZodLiteral<"pair">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -41,6 +41,18 @@ export const AuthSchema = z.object({
     protocolVersion: z.number().int().min(0).optional(),
     deviceInfo: DeviceInfoSchema.optional(),
     capabilities: z.array(z.string()).optional().catch([]).default([]),
+    // #5555 (eager key exchange) — optional ephemeral X25519 public key + salt
+    // sent WITH the auth message so the server can derive the shared key and
+    // return its public key in auth_ok, collapsing the discrete `key_exchange`
+    // round trip. Field shapes mirror KeyExchangeSchema's `publicKey` / `salt`
+    // (same base64 size cap, same per-connection salt semantics) — the eager
+    // path is cryptographically identical to the discrete one, only the
+    // transport timing differs. Both fields are optional and only honoured
+    // together: old clients omit them and the server falls back to the discrete
+    // `key_exchange`; a new client talking to an old server gets no
+    // `serverPublicKey` in auth_ok and falls back the same way. No flag day.
+    eagerPublicKey: z.string().max(512).optional(),
+    eagerSalt: z.string().max(512).optional(),
 }).passthrough();
 export const PairSchema = z.object({
     type: z.literal('pair'),

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -64,6 +64,7 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
         bindHost: z.ZodNullable<z.ZodString>;
         quickTunnel: z.ZodBoolean;
     }, z.core.$strip>>;
+    serverPublicKey: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -105,6 +105,16 @@ export const ServerAuthOkSchema = z.object({
         bindHost: z.string().nullable(),
         quickTunnel: z.boolean(),
     }).optional(),
+    // #5555 (eager key exchange) — the server's ephemeral X25519 public key,
+    // present ONLY when the client supplied a valid `eagerPublicKey` + `eagerSalt`
+    // in its `auth` message AND encryption is required. When present, the client
+    // derives the shared key immediately from this and the post-auth queue is
+    // already un-gated server-side, so the discrete `key_exchange` round trip is
+    // skipped. Field shape mirrors `key_exchange_ok`'s `publicKey`. Absent when:
+    // the client sent no eager fields (old client), encryption is disabled, or
+    // the server predates #5555 (old server) — in every absent case the client
+    // falls back to the discrete `key_exchange` handshake. No flag day.
+    serverPublicKey: z.string().max(512).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -47,6 +47,18 @@ export const AuthSchema = z.object({
   protocolVersion: z.number().int().min(0).optional(),
   deviceInfo: DeviceInfoSchema.optional(),
   capabilities: z.array(z.string()).optional().catch([]).default([]),
+  // #5555 (eager key exchange) — optional ephemeral X25519 public key + salt
+  // sent WITH the auth message so the server can derive the shared key and
+  // return its public key in auth_ok, collapsing the discrete `key_exchange`
+  // round trip. Field shapes mirror KeyExchangeSchema's `publicKey` / `salt`
+  // (same base64 size cap, same per-connection salt semantics) — the eager
+  // path is cryptographically identical to the discrete one, only the
+  // transport timing differs. Both fields are optional and only honoured
+  // together: old clients omit them and the server falls back to the discrete
+  // `key_exchange`; a new client talking to an old server gets no
+  // `serverPublicKey` in auth_ok and falls back the same way. No flag day.
+  eagerPublicKey: z.string().max(512).optional(),
+  eagerSalt: z.string().max(512).optional(),
 }).passthrough()
 
 export const PairSchema = z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -108,6 +108,16 @@ export const ServerAuthOkSchema = z.object({
     bindHost: z.string().nullable(),
     quickTunnel: z.boolean(),
   }).optional(),
+  // #5555 (eager key exchange) — the server's ephemeral X25519 public key,
+  // present ONLY when the client supplied a valid `eagerPublicKey` + `eagerSalt`
+  // in its `auth` message AND encryption is required. When present, the client
+  // derives the shared key immediately from this and the post-auth queue is
+  // already un-gated server-side, so the discrete `key_exchange` round trip is
+  // skipped. Field shape mirrors `key_exchange_ok`'s `publicKey`. Absent when:
+  // the client sent no eager fields (old client), encryption is disabled, or
+  // the server predates #5555 (old server) — in every absent case the client
+  // falls back to the discrete `key_exchange` handshake. No flag day.
+  serverPublicKey: z.string().max(512).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -171,6 +171,20 @@ export function handleAuthMessage(ctx, ws, msg) {
 
     client.clientCapabilities = new Set(authData.capabilities ?? [])
 
+    // #5555 (eager key exchange) — stash the client's ephemeral public key +
+    // salt if it supplied BOTH in the auth message. sendPostAuthInfo (called
+    // from onAuthSuccess) consumes these to derive the shared key inline and
+    // returns the server's public key in auth_ok, skipping the discrete
+    // `key_exchange` round trip. Both fields are required together; a client
+    // that sends only one (or empty strings) is treated as not-eager and falls
+    // through to the discrete handshake. The derivation is identical to the
+    // discrete path (deriveSharedKey → deriveConnectionKey with the same salt
+    // semantics) — only the transport timing changes.
+    if (typeof authData.eagerPublicKey === 'string' && authData.eagerPublicKey &&
+        typeof authData.eagerSalt === 'string' && authData.eagerSalt) {
+      client.eagerKeyExchange = { publicKey: authData.eagerPublicKey, salt: authData.eagerSalt }
+    }
+
     onAuthSuccess(ws, client)
     log.info(`Client ${client.id} authenticated`)
     return true

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -8,6 +8,7 @@ import { toShortModelId, getModels, getDefaultModelId, getRegistryForProvider } 
 import { PERMISSION_MODES } from './handler-utils.js'
 import { listProviders, getProvider } from './providers.js'
 import { createLogger } from './logger.js'
+import { createKeyPair, deriveSharedKey, deriveConnectionKey } from '@chroxy/store-core/crypto'
 import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STALL_TIMEOUT_MS } from './base-session.js'
 import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 
@@ -145,6 +146,53 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   const isLocalhost = localhostBypass && (client.socketIp === '127.0.0.1' || client.socketIp === '::1' || client.socketIp === '::ffff:127.0.0.1')
   const requireEncryption = encryptionEnabled && !isLocalhost
 
+  // #5555 (eager key exchange) — if the client supplied its ephemeral public
+  // key + salt in the auth message (stashed as client.eagerKeyExchange in
+  // handleAuthMessage), derive the shared key inline NOW and return the
+  // server's public key in auth_ok below. This collapses the discrete
+  // `key_exchange` round trip: the post-auth queue never has to gate, so
+  // replay starts a full RTT earlier.
+  //
+  // Crypto is identical to handleKeyExchange's discrete path:
+  // deriveSharedKey (X25519 DH) → deriveConnectionKey (per-connection sub-key
+  // from the client salt, so the nonce counter can restart at 0 safely on
+  // reconnect without reusing a (key, nonce) pair). Only the transport timing
+  // differs — the eager path folds the second handshake leg into auth_ok
+  // instead of a separate frame, so the TOFU exposure (#5536: no server
+  // identity pinning) is unchanged: the server's public key still travels in
+  // the clear over the same TLS-protected tunnel, just one frame earlier.
+  //
+  // Any failure to derive (malformed eager public key) falls back to the
+  // discrete handshake rather than failing the connection — the client still
+  // has its keypair and will send `key_exchange` when auth_ok arrives without
+  // a serverPublicKey.
+  //
+  // IMPORTANT ordering: the derived encryptionState is NOT assigned to the
+  // client yet. The auth_ok frame that carries serverPublicKey must go out in
+  // PLAINTEXT — the client can't decrypt it because it derives the shared key
+  // *from* that serverPublicKey. We assign client.encryptionState only AFTER
+  // auth_ok is sent (see below), so the subsequent burst (server_mode, status,
+  // session_list, …) is encrypted. This mirrors the discrete path, where
+  // key_exchange_ok is plaintext and encryptionState is set right after.
+  let eagerServerPublicKey = null
+  let eagerEncryptionState = null
+  if (requireEncryption && client.eagerKeyExchange) {
+    try {
+      const serverKp = createKeyPair()
+      const rawSharedKey = deriveSharedKey(client.eagerKeyExchange.publicKey, serverKp.secretKey)
+      const encryptionKey = deriveConnectionKey(rawSharedKey, client.eagerKeyExchange.salt)
+      eagerEncryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 }
+      eagerServerPublicKey = serverKp.publicKey
+    } catch (err) {
+      log.warn(`Eager key exchange failed for ${client.id}, falling back to discrete handshake: ${err.message}`)
+      eagerEncryptionState = null
+      eagerServerPublicKey = null
+    }
+    // Consumed (or failed) — never leave it set so a later discrete
+    // key_exchange isn't shadowed by stale eager state.
+    client.eagerKeyExchange = null
+  }
+
   const providers = listProviders()
   const features = {
     environments: providers.some(p => p.capabilities?.containerized),
@@ -238,11 +286,31 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // #5356: exposure snapshot for the dashboard warning banner. Optional on
     // the wire — older servers omit it and clients treat that as "unknown".
     ...(exposure ? { exposure } : {}),
+    // #5555: when the eager handshake succeeded, carry the server's public key
+    // so the client derives the shared key immediately. Absent otherwise (no
+    // eager fields / encryption disabled / derivation failed) → client falls
+    // back to the discrete key_exchange.
+    ...(eagerServerPublicKey ? { serverPublicKey: eagerServerPublicKey } : {}),
     ...extra,
   })
 
+  // #5555: now that the plaintext auth_ok (carrying serverPublicKey) has been
+  // flushed, activate encryption for this client so every subsequent frame in
+  // the post-auth burst is encrypted. The client derives the same shared key
+  // from auth_ok.serverPublicKey + its own secret, so both sides start at
+  // nonce 0 in lockstep. This is the un-gated eager path — no postAuthQueue.
+  if (eagerEncryptionState) {
+    client.encryptionState = eagerEncryptionState
+    log.info(`E2E encryption established eagerly with ${client.id}`)
+  }
+
+  // #5555: the eager handshake already established the shared key above, so
+  // the post-auth queue must NOT gate — it's un-gated immediately and the
+  // burst frames flow encrypted right after auth_ok. Only fall into the
+  // discrete-handshake gating below when encryption is required AND the eager
+  // path did not run (old client, or derivation failed).
   // If encryption required, queue all subsequent messages until key exchange completes
-  if (requireEncryption) {
+  if (requireEncryption && !eagerServerPublicKey) {
     client.encryptionPending = true
     client.postAuthQueue = []
     client._keyExchangeTimeout = setTimeout(() => {

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -176,20 +176,24 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   // key_exchange_ok is plaintext and encryptionState is set right after.
   let eagerServerPublicKey = null
   let eagerEncryptionState = null
-  if (requireEncryption && client.eagerKeyExchange) {
-    try {
-      const serverKp = createKeyPair()
-      const rawSharedKey = deriveSharedKey(client.eagerKeyExchange.publicKey, serverKp.secretKey)
-      const encryptionKey = deriveConnectionKey(rawSharedKey, client.eagerKeyExchange.salt)
-      eagerEncryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 }
-      eagerServerPublicKey = serverKp.publicKey
-    } catch (err) {
-      log.warn(`Eager key exchange failed for ${client.id}, falling back to discrete handshake: ${err.message}`)
-      eagerEncryptionState = null
-      eagerServerPublicKey = null
+  if (client.eagerKeyExchange) {
+    if (requireEncryption) {
+      try {
+        const serverKp = createKeyPair()
+        const rawSharedKey = deriveSharedKey(client.eagerKeyExchange.publicKey, serverKp.secretKey)
+        const encryptionKey = deriveConnectionKey(rawSharedKey, client.eagerKeyExchange.salt)
+        eagerEncryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 }
+        eagerServerPublicKey = serverKp.publicKey
+      } catch (err) {
+        log.warn(`Eager key exchange failed for ${client.id}, falling back to discrete handshake: ${err.message}`)
+        eagerEncryptionState = null
+        eagerServerPublicKey = null
+      }
     }
-    // Consumed (or failed) — never leave it set so a later discrete
-    // key_exchange isn't shadowed by stale eager state.
+    // Consumed (encryption required), unused (encryption disabled / localhost
+    // bypass), or failed — never leave it set so a later discrete key_exchange
+    // isn't shadowed by stale eager state and no handshake material lingers on
+    // the client object longer than the one auth pass that could use it.
     client.eagerKeyExchange = null
   }
 

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -255,6 +255,47 @@ describe('handleAuthMessage', () => {
       handleAuthMessage(ctx, ws, { type: 'auth', token: 'good-token' })
       assert.equal(authFailures.has('127.0.0.1'), false)
     })
+
+    // #5555 (eager key exchange) — when the auth message carries both
+    // eagerPublicKey and eagerSalt, stash them on the client so
+    // sendPostAuthInfo can derive the shared key inline.
+    it('stashes eager key-exchange fields when both are present', () => {
+      const { ctx, ws, client } = makeAuthCtx({
+        authRequired: true,
+        isTokenValid: () => true,
+      })
+      handleAuthMessage(ctx, ws, {
+        type: 'auth',
+        token: 'good-token',
+        eagerPublicKey: 'client-pub-key',
+        eagerSalt: 'client-salt',
+      })
+      assert.deepEqual(client.eagerKeyExchange, {
+        publicKey: 'client-pub-key',
+        salt: 'client-salt',
+      })
+    })
+
+    it('does NOT stash eager fields when only one is present (old/partial client)', () => {
+      for (const partial of [
+        { eagerPublicKey: 'pub-only' },
+        { eagerSalt: 'salt-only' },
+        { eagerPublicKey: '', eagerSalt: 'salt' },
+        { eagerPublicKey: 'pub', eagerSalt: '' },
+        {}, // neither — the old-client wire shape
+      ]) {
+        const { ctx, ws, client } = makeAuthCtx({
+          authRequired: true,
+          isTokenValid: () => true,
+        })
+        handleAuthMessage(ctx, ws, { type: 'auth', token: 'good-token', ...partial })
+        assert.equal(
+          client.eagerKeyExchange,
+          undefined,
+          `partial eager fields ${JSON.stringify(partial)} must not stash`,
+        )
+      }
+    })
   })
 
   describe('invalid token — auth failure tracking', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -763,6 +763,9 @@ describe('sendPostAuthInfo — eager key exchange (#5555)', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(authOk, 'serverPublicKey'), false)
     assert.equal(client.encryptionState, undefined)
     assert.equal(client.encryptionPending, false)
+    // eagerKeyExchange is cleared even when encryption is disabled so no
+    // stale handshake material lingers on the client object (#5555 review).
+    assert.equal(client.eagerKeyExchange, null)
   })
 
   it('falls back to the discrete handshake when the eager public key is malformed', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -21,6 +21,15 @@ import { getRegistryForProvider, _resetProviderRegistryCacheForTests } from '../
 // registerProvider is used by the scheduleProviderModelsRefresh suite to
 // inject fake provider classes (#5450).
 import { registerProvider } from '../src/providers.js'
+import {
+  createKeyPair,
+  deriveSharedKey,
+  deriveConnectionKey,
+  generateConnectionSalt,
+  encrypt,
+  decrypt,
+  DIRECTION_SERVER,
+} from '@chroxy/store-core/crypto'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -633,6 +642,150 @@ describe('sendPostAuthInfo — encryption', () => {
     // Clean up timeout
     const client = ctx.clients.get(ws)
     if (client._keyExchangeTimeout) clearTimeout(client._keyExchangeTimeout)
+  })
+})
+
+// ── #5555: eager key exchange ────────────────────────────────────────────────
+//
+// The eager path collapses the discrete key_exchange RTT: the client supplies
+// its ephemeral pubkey + salt as client.eagerKeyExchange (stashed by
+// handleAuthMessage), and sendPostAuthInfo derives the shared key inline,
+// returns the server pubkey in auth_ok, and un-gates the post-auth queue.
+// These tests cover the eager success path, the discrete fallback (old client),
+// the encryption-disabled case, and a malformed-eager-key fallback. They use a
+// production-grade send (createClientSender) so the queue/encrypt gating is the
+// real wire behaviour, not a test stub.
+
+import { createClientSender } from '../src/ws-client-sender.js'
+
+/** ctx whose `send` is the real client-sender (queues + encrypts per client state). */
+function makeEncryptingCtx(overrides = {}) {
+  const sends = []
+  const clientSend = createClientSender({ error: () => {}, warn: () => {} })
+  const ctx = makeCtx({
+    send: (ws, msg) => {
+      const client = ctx.clients.get(ws)
+      sends.push(msg)
+      clientSend(ws, client, msg)
+    },
+    ...overrides,
+  })
+  ctx._plainSends = sends
+  return ctx
+}
+
+describe('sendPostAuthInfo — eager key exchange (#5555)', () => {
+  it('derives the shared key inline and returns serverPublicKey, un-gating the queue', () => {
+    const ws = makeFakeWs()
+    const ctx = makeEncryptingCtx({ encryptionEnabled: true, keyExchangeTimeoutMs: 60000 })
+    // Client-side ephemeral keypair + salt, exactly as the client would send.
+    const clientKp = createKeyPair()
+    const salt = generateConnectionSalt()
+    const client = registerClient(ctx, ws, {
+      socketIp: '203.0.113.7',
+      eagerKeyExchange: { publicKey: clientKp.publicKey, salt },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._plainSends.find(m => m.type === 'auth_ok')
+    // Server returned its ephemeral public key on the eager path.
+    assert.ok(authOk.serverPublicKey, 'auth_ok carries serverPublicKey on the eager path')
+    assert.equal(authOk.encryption, 'required')
+
+    // Queue is un-gated: NOT pending, no postAuthQueue, no key-exchange timeout.
+    assert.equal(client.encryptionPending, false)
+    assert.equal(client.postAuthQueue, null)
+    assert.equal(client._keyExchangeTimeout, undefined)
+    // eagerKeyExchange is consumed (cleared) so a stray key_exchange can't reuse it.
+    assert.equal(client.eagerKeyExchange, null)
+    // Server established its encryption state.
+    assert.ok(client.encryptionState, 'client.encryptionState set after eager derivation')
+    assert.equal(client.encryptionState.sendNonce > 0, true) // burst frames consumed nonces
+
+    // The client derives the SAME shared key from auth_ok.serverPublicKey.
+    const rawShared = deriveSharedKey(authOk.serverPublicKey, clientKp.secretKey)
+    const clientKey = deriveConnectionKey(rawShared, salt)
+    assert.deepEqual(
+      Array.from(clientKey),
+      Array.from(client.encryptionState.sharedKey),
+      'eager-derived key matches on both sides (identical to the discrete path)',
+    )
+
+    // auth_ok itself went out in plaintext (the client must read serverPublicKey
+    // before it can derive the key). Subsequent burst frames are encrypted.
+    const rawFrames = ws._rawSent.map(s => JSON.parse(s))
+    assert.equal(rawFrames[0].type, 'auth_ok', 'auth_ok is the first frame, plaintext')
+    const firstBurst = rawFrames[1]
+    assert.equal(firstBurst.type, 'encrypted', 'frames after auth_ok are encrypted')
+
+    // And the client can actually decrypt that first burst frame with the shared key.
+    const decrypted = decrypt(firstBurst, clientKey, 0, DIRECTION_SERVER)
+    assert.equal(typeof decrypted.type, 'string')
+  })
+
+  it('falls back to the discrete handshake when the client sends NO eager fields (old client)', () => {
+    const ws = makeFakeWs()
+    const ctx = makeEncryptingCtx({ encryptionEnabled: true, keyExchangeTimeoutMs: 60000 })
+    // No eagerKeyExchange — the old-client wire shape.
+    const client = registerClient(ctx, ws, { socketIp: '203.0.113.8' })
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._plainSends.find(m => m.type === 'auth_ok')
+    assert.equal(authOk.encryption, 'required')
+    // No serverPublicKey → client knows to send the discrete key_exchange.
+    assert.equal(Object.prototype.hasOwnProperty.call(authOk, 'serverPublicKey'), false)
+    // Discrete path still gates the queue exactly as before.
+    assert.equal(client.encryptionPending, true)
+    assert.ok(Array.isArray(client.postAuthQueue))
+    assert.ok(client._keyExchangeTimeout, 'discrete path arms the key-exchange timeout')
+    assert.equal(client.encryptionState, undefined)
+    // Burst frames were queued (gated), not sent on the wire yet.
+    const burstFramesOnWire = ws._rawSent.map(s => JSON.parse(s)).filter(m => m.type !== 'auth_ok')
+    assert.equal(burstFramesOnWire.length, 0, 'post-auth burst is queued, not sent, until key_exchange')
+    clearTimeout(client._keyExchangeTimeout)
+  })
+
+  it('ignores eager fields when encryption is disabled (no serverPublicKey, no encryptionState)', () => {
+    const ws = makeFakeWs()
+    const ctx = makeEncryptingCtx({ encryptionEnabled: false })
+    const clientKp = createKeyPair()
+    const client = registerClient(ctx, ws, {
+      socketIp: '203.0.113.9',
+      eagerKeyExchange: { publicKey: clientKp.publicKey, salt: generateConnectionSalt() },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._plainSends.find(m => m.type === 'auth_ok')
+    assert.equal(authOk.encryption, 'disabled')
+    assert.equal(Object.prototype.hasOwnProperty.call(authOk, 'serverPublicKey'), false)
+    assert.equal(client.encryptionState, undefined)
+    assert.equal(client.encryptionPending, false)
+  })
+
+  it('falls back to the discrete handshake when the eager public key is malformed', () => {
+    const ws = makeFakeWs()
+    const ctx = makeEncryptingCtx({ encryptionEnabled: true, keyExchangeTimeoutMs: 60000 })
+    const client = registerClient(ctx, ws, {
+      socketIp: '203.0.113.10',
+      // Invalid base64 / wrong length → deriveSharedKey throws → discrete fallback.
+      eagerKeyExchange: { publicKey: 'not-a-valid-key', salt: generateConnectionSalt() },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._plainSends.find(m => m.type === 'auth_ok')
+    assert.equal(authOk.encryption, 'required')
+    assert.equal(Object.prototype.hasOwnProperty.call(authOk, 'serverPublicKey'), false)
+    // Degrades to the discrete handshake rather than failing the connection.
+    assert.equal(client.encryptionPending, true)
+    assert.ok(Array.isArray(client.postAuthQueue))
+    assert.equal(client.encryptionState, undefined)
+    // eagerKeyExchange cleared even on failure.
+    assert.equal(client.eagerKeyExchange, null)
+    clearTimeout(client._keyExchangeTimeout)
   })
 })
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1455,6 +1455,7 @@ describe('handleAuthOk', () => {
       clientId: 'client-1',
       webFeatures: { available: true, remote: false, teleport: true },
       capabilities: { notificationPrefs: true, somethingElse: false },
+      serverPublicKey: 'srv-pub-key',
     })
     expect(result).toEqual({
       serverMode: 'cli',
@@ -1471,7 +1472,22 @@ describe('handleAuthOk', () => {
       myClientId: 'client-1',
       webFeatures: { available: true, remote: false, teleport: true },
       serverCapabilities: { notificationPrefs: true, somethingElse: false },
+      serverPublicKey: 'srv-pub-key',
     })
+  })
+
+  // #5555 (eager key exchange) — serverPublicKey carries the server's
+  // ephemeral X25519 key on the eager path; null means "fall back to the
+  // discrete key_exchange handshake".
+  it('extracts serverPublicKey when the server honoured the eager path', () => {
+    expect(handleAuthOk({ serverPublicKey: 'abc123' }).serverPublicKey).toBe('abc123')
+  })
+
+  it('returns null serverPublicKey when absent, empty, or non-string (discrete fallback)', () => {
+    expect(handleAuthOk({}).serverPublicKey).toBeNull()
+    expect(handleAuthOk({ serverPublicKey: '' }).serverPublicKey).toBeNull()
+    expect(handleAuthOk({ serverPublicKey: 42 }).serverPublicKey).toBeNull()
+    expect(handleAuthOk({ serverPublicKey: null }).serverPublicKey).toBeNull()
   })
 
   it('rejects unknown serverMode values', () => {
@@ -1691,6 +1707,7 @@ describe('handleAuthOk', () => {
       myClientId: null,
       webFeatures: { available: false, remote: false, teleport: false },
       serverCapabilities: {},
+      serverPublicKey: null,
     })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -808,6 +808,16 @@ export interface AuthOkPayload {
    * spread it into state without an existence check.
    */
   serverCapabilities: Record<string, boolean>
+  /**
+   * #5555 (eager key exchange) — the server's ephemeral X25519 public key,
+   * present only when this client sent `eagerPublicKey` + `eagerSalt` in its
+   * `auth` message AND the server honoured the eager path. When non-null the
+   * client derives the shared key immediately and skips the discrete
+   * `key_exchange` round trip; null means fall back to the discrete handshake
+   * (old server, encryption disabled, or no eager fields were sent). Same
+   * validation as `handleKeyExchangeOk`'s `publicKey`.
+   */
+  serverPublicKey: string | null
 }
 
 const DEFAULT_WEB_FEATURES: AuthOkWebFeatures = {
@@ -874,6 +884,12 @@ export function handleAuthOk(msg: Record<string, unknown>): AuthOkPayload {
     myClientId: parseRawStringField(msg, 'clientId'),
     webFeatures,
     serverCapabilities,
+    // #5555 — null for missing/empty/non-string, exactly the "fall back to
+    // discrete key_exchange" signal the call sites key off. Mirrors
+    // handleKeyExchangeOk's `typeof raw === 'string' && raw` validation so an
+    // empty-string serverPublicKey is treated as absent, not a usable key.
+    serverPublicKey:
+      typeof msg.serverPublicKey === 'string' && msg.serverPublicKey ? msg.serverPublicKey : null,
   }
 }
 


### PR DESCRIPTION
## Sub-item 1 of epic #5555 — Eager key exchange

Collapses the discrete post-auth `key_exchange` round trip into the auth handshake. Today the E2E key exchange is a separate post-auth RTT that gates the **entire** post-auth queue (`ws-history.js` `sendPostAuthInfo` → `encryptionPending` + `postAuthQueue`). This change lets the client send its ephemeral public key + salt **with** the `auth` message; the server returns its public key in `auth_ok` and activates encryption immediately, so the post-auth burst (and history replay) starts a full RTT earlier on cold connect.

### How it works

- **Client (`onopen`)**: generates the ephemeral X25519 keypair + per-connection salt up front and sends them as optional `eagerPublicKey` / `eagerSalt` fields in `auth`.
- **Server (`ws-auth` → `ws-history`)**: `handleAuthMessage` stashes the eager fields on the client; `sendPostAuthInfo` derives the shared key inline (same `deriveSharedKey` → `deriveConnectionKey` as the discrete path), returns its public key as `serverPublicKey` in the **plaintext** `auth_ok`, then activates `encryptionState` for every subsequent frame. The `encryptionPending` / `postAuthQueue` gating block is skipped entirely.
- **Client (`auth_ok`)**: if `serverPublicKey` is present, derive the shared key immediately and send the post-auth burst (no discrete `key_exchange`); otherwise fall back.

`auth_ok` itself is sent in plaintext — the client must read `serverPublicKey` before it can derive the key — exactly mirroring the discrete `key_exchange_ok` ordering. Both sides start at nonce 0 in lockstep.

### Compatibility matrix (as implemented)

| Client \ Server | Old server (no `serverPublicKey`) | New server (#5555) |
|---|---|---|
| **Old client** (no eager fields) | Discrete `key_exchange` — **unchanged** | Server sees no `eagerKeyExchange` → omits `serverPublicKey` → discrete `key_exchange` (gates queue, arms timeout) |
| **New client** (#5555) | `auth_ok` has no `serverPublicKey` → client falls back to discrete `key_exchange` using the already-stashed keypair | Single-RTT eager handshake — queue un-gated immediately |

Additional fallbacks on the new×new path that also degrade to the discrete handshake (never to plaintext): encryption disabled (`--no-encrypt` / localhost bypass) → no `serverPublicKey`; malformed eager public key → server logs and falls back. No flag days in either direction.

### Security argument — why eager ≡ discrete

The eager path is **cryptographically identical** to the discrete `key_exchange`:

- Same Curve25519 DH (`nacl.box.before`) and the same per-connection salt sub-key derivation (`deriveConnectionKey`) — the salt semantics that prevent nonce reuse on reconnect (audit `1fa8eda5e`) are preserved; the client still supplies the salt.
- Only the **transport timing** of the two ephemeral public keys changes: one `auth_ok` frame instead of a separate `key_exchange_ok` frame. The bytes derived and the key material are bit-for-bit the same.
- The server still **refuses to downgrade to plaintext**; the discrete fallback still gates the queue and enforces the key-exchange timeout.

**TOFU interaction (#5536):** unchanged. The server's ephemeral public key already travels in the clear over the TLS-protected tunnel and is accepted on first use with no out-of-band pinning. Moving it one frame earlier (into `auth_ok`) does not widen the MITM window — an attacker who could relay `key_exchange_ok` could equally relay the `serverPublicKey` field of `auth_ok`. No server-identity assurance is gained or lost; #5536 is neither improved nor worsened. Documented in `docs/security/encryption-threat-model.md` §3.

### RTT saving

On cold connect over a tunnel, the discrete handshake costs one full application round trip that gates the entire post-auth queue (12+ burst frames + history replay). The eager path folds that into the existing `auth` → `auth_ok` exchange, so **replay begins ~1 RTT sooner** (the C2 swarm-audit measured the discrete `key_exchange` as one of ~5 serialized RTTs before first history byte). This is sub-item 1 of the cold-connect first-paint chain (1 → 2 → 3 land server-first).

### Tests

- **store-core** (`handlers.test.ts`): `handleAuthOk` extracts `serverPublicKey`; null on absent/empty/non-string (discrete-fallback signal).
- **server** (`ws-auth.test.js`): `handleAuthMessage` stashes eager fields only when both are present; partial/empty fields do not stash.
- **server** (`ws-history.test.js`): eager success (serverPublicKey returned, queue un-gated, key matches client derivation, auth_ok plaintext + burst encrypted & decryptable), discrete fallback when no eager fields (old client — queue gated, timeout armed, burst queued), encryption-disabled ignores eager fields, malformed eager key degrades to discrete.
- **app** (`connection.test.ts`) + **dashboard** (`auth-ok-handler.test.ts`): eager derivation inline + burst when `serverPublicKey` present; discrete `key_exchange` fallback when absent.

All package tests + typechecks green; server custom lints (`lint-session-opt-forwarding`, `lint-tests-state-file-path`, `lint-logger-session-scoping`, `lint-ws-index-mutations`) + eslint pass.

Related to #5555
