### PR TITLE
refactor(store-core): shared client message dispatch table — first slice

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -140,7 +140,7 @@ import {
   // #5556 (epic #5514): shared delta-flusher wiring (accumulator + timer +
   // override) — the client supplies only its `applyDeltas` store mutation.
   createDeltaFlusher,
-  // #5556 (epic #5514, sub-item 3): shared client message dispatch table.
+  // epic #5556, sub-item 3: shared client message dispatch table.
   // Pure-delegation cases that were byte-identical with the dashboard route
   // through this table; a miss falls through to the switch below unchanged.
   createDispatchTable,
@@ -916,7 +916,7 @@ export function updateActiveSession(updater: (session: SessionState) => Partial<
 }
 
 // ---------------------------------------------------------------------------
-// Shared dispatch table (#5556 epic #5514, sub-item 3)
+// Shared dispatch table (epic #5556, sub-item 3)
 //
 // Pure-delegation message cases that were byte-identical with the dashboard's
 // handler are owned by the store-core table. `handleMessage` runs the table

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -29,16 +29,13 @@ import {
   handleMessage as sharedMessageHandler,
   handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
-  handleAvailablePermissionModes as sharedAvailablePermissionModes,
-  handleSessionUpdated as sharedSessionUpdated,
-  handleConfirmPermissionMode as sharedConfirmPermissionMode,
+  // available_permission_modes / session_updated / confirm_permission_mode /
+  // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
   handleClaudeReady as sharedClaudeReady,
   handleAgentIdle as sharedAgentIdle,
-  handleAgentBusy as sharedAgentBusy,
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
-  handleBudgetResumed as sharedBudgetResumed,
   handlePlanStarted as sharedPlanStarted,
   handlePlanReady as sharedPlanReady,
   handleInactivityWarning as sharedInactivityWarning,
@@ -68,7 +65,7 @@ import {
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
   handleClientFocusChanged as sharedClientFocusChanged,
-  handleConversationId as sharedConversationId,
+  // conversation_id migrated to the shared dispatch table (#5556)
   handleConversationsList as sharedConversationsList,
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
@@ -76,7 +73,7 @@ import {
   handlePermissionResolved as sharedPermissionResolved,
   handlePermissionExpired as sharedPermissionExpired,
   handlePermissionTimeout as sharedPermissionTimeout,
-  handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — remaining both-sides duplicates extracted into store-core
   handleRawOutput as sharedRawOutput,
   handleTokenRotated as sharedTokenRotated,
@@ -143,8 +140,13 @@ import {
   // #5556 (epic #5514): shared delta-flusher wiring (accumulator + timer +
   // override) — the client supplies only its `applyDeltas` store mutation.
   createDeltaFlusher,
+  // #5556 (epic #5514, sub-item 3): shared client message dispatch table.
+  // Pure-delegation cases that were byte-identical with the dashboard route
+  // through this table; a miss falls through to the switch below unchanged.
+  createDispatchTable,
+  runDispatch,
 } from '@chroxy/store-core';
-import type { DeltaFlusher } from '@chroxy/store-core';
+import type { DeltaFlusher, ClientStoreAdapter } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
 import { hapticSuccess } from '../utils/haptics';
@@ -914,6 +916,26 @@ export function updateActiveSession(updater: (session: SessionState) => Partial<
 }
 
 // ---------------------------------------------------------------------------
+// Shared dispatch table (#5556 epic #5514, sub-item 3)
+//
+// Pure-delegation message cases that were byte-identical with the dashboard's
+// handler are owned by the store-core table. `handleMessage` runs the table
+// first; a miss falls through to the switch below, so the remaining (and
+// genuinely divergent) cases stay exactly where they were.
+// ---------------------------------------------------------------------------
+
+const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
+  getActiveSessionId: () => getStore().getState().activeSessionId,
+  hasSession: (id) => !!getStore().getState().sessionStates[id],
+  updateSession: (id, updater) => updateSession(id, updater),
+  setState: (patch) => getStore().setState(patch as Partial<ConnectionState>),
+  addMessage: (m) => getStore().getState().addMessage(m),
+  getSessions: () => getStore().getState().sessions,
+};
+
+const _dispatchTable = createDispatchTable<SessionState>();
+
+// ---------------------------------------------------------------------------
 // Input preview helper
 // ---------------------------------------------------------------------------
 
@@ -1169,6 +1191,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       });
     }
   }
+
+  // #5556 — shared dispatch table first. A hit handles the message and returns;
+  // a miss falls through to the switch below, keeping migration incremental.
+  if (runDispatch(_dispatchTable, msg, _dispatchAdapter)) return;
 
   switch (msg.type) {
     case 'pong':
@@ -1519,13 +1545,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_updated': {
-      const updated = sharedSessionUpdated(msg, get().sessions);
-      if (updated) {
-        set({ sessions: updated });
-      }
-      break;
-    }
+    // session_updated — migrated to the shared dispatch table (#5556)
+
 
     case 'subscriptions_updated': {
       // Server confirms which sessions we're subscribed to — log for debugging
@@ -1583,16 +1604,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'conversation_id': {
-      // Parser is shared via store-core; the session-existence guard and the
-      // updateSession call stay here. Note: this handler does NOT fall back
-      // to activeSessionId — a missing sessionId skips the patch entirely.
-      const { sessionId: convSessionId, conversationId } = sharedConversationId(msg);
-      if (convSessionId && get().sessionStates[convSessionId]) {
-        updateSession(convSessionId, () => ({ conversationId }));
-      }
-      break;
-    }
+    // conversation_id — migrated to the shared dispatch table (#5556)
+
 
     case 'session_error': {
       // Crash branch: flip session health + notify; non-crash branch: special-
@@ -2052,21 +2065,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'confirm_permission_mode': {
-      const pending = sharedConfirmPermissionMode(msg);
-      if (pending) {
-        set({ pendingPermissionConfirm: pending });
-      }
-      break;
-    }
+    // confirm_permission_mode — migrated to the shared dispatch table (#5556)
 
-    case 'available_permission_modes': {
-      const modes = sharedAvailablePermissionModes(msg);
-      if (modes) {
-        set({ availablePermissionModes: modes });
-      }
-      break;
-    }
+
+    // available_permission_modes — migrated to the shared dispatch table (#5556)
+
 
     case 'raw': {
       const { data: rawData } = sharedRawOutput(msg);
@@ -2100,13 +2103,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'agent_busy': {
-      const targetId = resolveSessionId(msg, get().activeSessionId);
-      if (targetId && get().sessionStates[targetId]) {
-        updateSession(targetId, () => sharedAgentBusy());
-      }
-      break;
-    }
+    // agent_busy — migrated to the shared dispatch table (#5556)
+
 
     case 'agent_spawned': {
       const builder = sharedAgentSpawned(msg, get().activeSessionId);
@@ -2463,15 +2461,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'permission_rules_updated': {
-      const { sessionId: rulesExplicitSessionId, rules } =
-        sharedPermissionRulesUpdated(msg);
-      const rulesSessionId = rulesExplicitSessionId || get().activeSessionId;
-      if (rulesSessionId && get().sessionStates[rulesSessionId]) {
-        updateSession(rulesSessionId, () => ({ sessionRules: rules as PermissionRule[] }));
-      }
-      break;
-    }
+    // permission_rules_updated — migrated to the shared dispatch table (#5556)
+
 
     case 'user_question': {
       const parsed = sharedUserQuestion(msg, get().activeSessionId);
@@ -2885,18 +2876,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'budget_resumed': {
-      const { systemMessage } = sharedBudgetResumed();
-      const targetId = resolveSessionId(msg, get().activeSessionId);
-      if (targetId && get().sessionStates[targetId]) {
-        updateSession(targetId, (ss) => ({
-          messages: [...ss.messages, systemMessage],
-        }));
-      } else {
-        get().addMessage(systemMessage);
-      }
-      break;
-    }
+    // budget_resumed — migrated to the shared dispatch table (#5556)
+
 
     case 'dev_preview': {
       const builder = sharedDevPreview(msg, get().activeSessionId);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -19,16 +19,13 @@ import {
   handleMessage as sharedMessageHandler,
   handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
-  handleAvailablePermissionModes as sharedAvailablePermissionModes,
-  handleSessionUpdated as sharedSessionUpdated,
-  handleConfirmPermissionMode as sharedConfirmPermissionMode,
+  // available_permission_modes / session_updated / confirm_permission_mode /
+  // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
   handleClaudeReady as sharedClaudeReady,
   handleAgentIdle as sharedAgentIdle,
-  handleAgentBusy as sharedAgentBusy,
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
-  handleBudgetResumed as sharedBudgetResumed,
   handlePlanStarted as sharedPlanStarted,
   handlePlanReady as sharedPlanReady,
   handleInactivityWarning as sharedInactivityWarning,
@@ -57,11 +54,11 @@ import {
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
   handleClientFocusChanged as sharedClientFocusChanged,
-  handleConversationId as sharedConversationId,
+  // conversation_id migrated to the shared dispatch table (#5556)
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
   handlePermissionExpired as sharedPermissionExpired,
-  handlePermissionRulesUpdated as sharedPermissionRulesUpdated,
+  // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — dashboard adopts the shared permission family + the remaining
   // both-sides duplicates
   handlePermissionRequest as sharedPermissionRequest,
@@ -137,6 +134,12 @@ import {
   createDeltaFlusher,
   type DeltaFlusher,
   type PlatformAdapters, type StorageAdapter,
+  // #5556 (epic #5514, sub-item 3): shared client message dispatch table.
+  // Pure-delegation cases that were byte-identical with the app route through
+  // this table; a miss falls through to the HANDLERS map + switch unchanged.
+  createDispatchTable,
+  runDispatch,
+  type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
 import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema } from '@chroxy/protocol/schemas'
@@ -818,6 +821,26 @@ export function updateActiveSession(updater: (session: SessionState) => Partial<
 }
 
 // ---------------------------------------------------------------------------
+// Shared dispatch table (#5556 epic #5514, sub-item 3)
+//
+// Pure-delegation message cases that were byte-identical with the app's
+// handler are owned by the store-core table. `handleMessage` runs the table
+// first; a miss falls through to the HANDLERS map + switch below, so the
+// remaining (and genuinely divergent) cases stay exactly where they were.
+// ---------------------------------------------------------------------------
+
+const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
+  getActiveSessionId: () => getStore().getState().activeSessionId,
+  hasSession: (id) => !!getStore().getState().sessionStates[id],
+  updateSession: (id, updater) => updateSession(id, updater),
+  setState: (patch) => getStore().setState(patch as Partial<ConnectionState>),
+  addMessage: (m) => getStore().getState().addMessage(m),
+  getSessions: () => getStore().getState().sessions,
+};
+
+const _dispatchTable = createDispatchTable<SessionState>();
+
+// ---------------------------------------------------------------------------
 // Session notification helper
 // ---------------------------------------------------------------------------
 
@@ -1329,19 +1352,8 @@ function handlePermissionModeChanged(msg: Record<string, unknown>, get: MsgGet, 
   set({ pendingPermissionConfirm: null });
 }
 
-function handleAvailablePermissionModes(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const modes = sharedAvailablePermissionModes(msg);
-  if (modes) {
-    set({ availablePermissionModes: modes });
-  }
-}
-
-function handleSessionUpdated(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const updated = sharedSessionUpdated(msg, get().sessions);
-  if (updated) {
-    set({ sessions: updated });
-  }
-}
+// available_permission_modes + session_updated migrated to the shared
+// store-core dispatch table (#5556)
 
 function handleSessionSwitched(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const switched = sharedSessionSwitched(msg);
@@ -1424,12 +1436,7 @@ function handleAgentIdle(msg: Record<string, unknown>, get: MsgGet, set: MsgSet,
   }
 }
 
-function handleAgentBusy(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  const targetId = resolveSessionId(msg, get().activeSessionId);
-  if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, () => sharedAgentBusy());
-  }
-}
+// agent_busy migrated to the shared store-core dispatch table (#5556)
 
 function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const targetId = (msg.sessionId as string) || get().activeSessionId;
@@ -1930,17 +1937,7 @@ function handleBudgetExceeded(msg: Record<string, unknown>, get: MsgGet, _set: M
   }
 }
 
-function handleBudgetResumed(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  const { systemMessage } = sharedBudgetResumed();
-  const targetId = resolveSessionId(msg, get().activeSessionId);
-  if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, (ss) => ({
-      messages: [...ss.messages, systemMessage],
-    }));
-  } else {
-    get().addMessage(systemMessage);
-  }
-}
+// budget_resumed migrated to the shared store-core dispatch table (#5556)
 
 function handleServerError(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const { serverError, chatMessage: errorMsg } = sharedServerError(msg);
@@ -2304,12 +2301,11 @@ const HANDLERS: Record<string, Handler> = {
   skill_trust_granted: handleSkillTrustGranted,
   skill_trust_grant_ok: handleSkillTrustGrantOk,
   permission_mode_changed: handlePermissionModeChanged,
-  available_permission_modes: handleAvailablePermissionModes,
-  session_updated: handleSessionUpdated,
+  // available_permission_modes / session_updated / agent_busy migrated to the
+  // shared store-core dispatch table (#5556)
   session_switched: handleSessionSwitched,
   claude_ready: handleClaudeReady,
   agent_idle: handleAgentIdle,
-  agent_busy: handleAgentBusy,
   stream_start: handleStreamStart,
   stream_delta: handleStreamDelta,
   stream_end: handleStreamEnd,
@@ -2320,7 +2316,7 @@ const HANDLERS: Record<string, Handler> = {
   permission_resolved: handlePermissionResolved,
   budget_warning: handleBudgetWarning,
   budget_exceeded: handleBudgetExceeded,
-  budget_resumed: handleBudgetResumed,
+  // budget_resumed migrated to the shared store-core dispatch table (#5556)
   server_error: handleServerError,
   server_shutdown: handleServerShutdown,
   // #5163 (epic #5159): Control Room live activity tree.
@@ -2406,7 +2402,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
   }
 
-  // Dispatch to the handler map first — extracted, self-contained cases.
+  // #5556 — shared dispatch table first. A hit handles the message and
+  // returns; a miss falls through to the dashboard's own HANDLERS map +
+  // switch below, keeping migration incremental.
+  if (runDispatch(_dispatchTable, msg, _dispatchAdapter)) return;
+
+  // Dispatch to the handler map next — extracted, self-contained cases.
   const handler = HANDLERS[msg.type];
   if (handler) {
     handler(msg, get, set, ctx);
@@ -2839,16 +2840,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'conversation_id': {
-      // Parser is shared via store-core; the session-existence guard and the
-      // updateSession call stay here. Note: this handler does NOT fall back
-      // to activeSessionId — a missing sessionId skips the patch entirely.
-      const { sessionId: convSessionId, conversationId } = sharedConversationId(msg);
-      if (convSessionId && get().sessionStates[convSessionId]) {
-        updateSession(convSessionId, () => ({ conversationId }));
-      }
-      break;
-    }
+    // conversation_id — migrated to the shared dispatch table (#5556)
+
 
     case 'evaluate_draft_result': {
       // #3068: route to the resolver registered by the matching evaluateDraft()
@@ -3247,13 +3240,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'confirm_permission_mode': {
-      const pending = sharedConfirmPermissionMode(msg);
-      if (pending) {
-        set({ pendingPermissionConfirm: pending });
-      }
-      break;
-    }
+    // confirm_permission_mode — migrated to the shared dispatch table (#5556)
+
 
     case 'agent_spawned': {
       const builder = sharedAgentSpawned(msg, get().activeSessionId);
@@ -3494,17 +3482,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'permission_rules_updated': {
-      // Server broadcasts the full rule set for a session after a successful
-      // set_permission_rules call. Store it on the session so "Allow for
-      // Session" (#2834) can append new rules without clobbering existing ones.
-      const { sessionId: rulesExplicitSessionId, rules } = sharedPermissionRulesUpdated(msg);
-      const rulesSessionId = rulesExplicitSessionId || get().activeSessionId;
-      if (rulesSessionId && get().sessionStates[rulesSessionId]) {
-        updateSession(rulesSessionId, () => ({ sessionRules: rules }));
-      }
-      break;
-    }
+    // permission_rules_updated — migrated to the shared dispatch table (#5556)
+
 
     case 'user_question': {
       const parsed = sharedUserQuestion(msg, get().activeSessionId);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -134,7 +134,7 @@ import {
   createDeltaFlusher,
   type DeltaFlusher,
   type PlatformAdapters, type StorageAdapter,
-  // #5556 (epic #5514, sub-item 3): shared client message dispatch table.
+  // epic #5556, sub-item 3: shared client message dispatch table.
   // Pure-delegation cases that were byte-identical with the app route through
   // this table; a miss falls through to the HANDLERS map + switch unchanged.
   createDispatchTable,
@@ -821,7 +821,7 @@ export function updateActiveSession(updater: (session: SessionState) => Partial<
 }
 
 // ---------------------------------------------------------------------------
-// Shared dispatch table (#5556 epic #5514, sub-item 3)
+// Shared dispatch table (epic #5556, sub-item 3)
 //
 // Pure-delegation message cases that were byte-identical with the app's
 // handler are owned by the store-core table. `handleMessage` runs the table

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -139,7 +139,7 @@ const PLATFORM_SPECIFIC = {
 
 /**
  * Extract the message types owned by the SHARED store-core dispatch table
- * (#5556, epic #5514 sub-item 3). These cases were migrated OUT of both
+ * (epic #5556, sub-item 3). These cases were migrated OUT of both
  * clients' switches into `store-core/src/dispatch-table.ts`, so they no longer
  * appear as a `case` in app/dashboard source — but they ARE covered by both
  * clients (each routes through `runDispatch` before its own switch). The

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -137,6 +137,28 @@ const PLATFORM_SPECIFIC = {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Extract the message types owned by the SHARED store-core dispatch table
+ * (#5556, epic #5514 sub-item 3). These cases were migrated OUT of both
+ * clients' switches into `store-core/src/dispatch-table.ts`, so they no longer
+ * appear as a `case` in app/dashboard source — but they ARE covered by both
+ * clients (each routes through `runDispatch` before its own switch). The
+ * coverage checks below union this set into BOTH client type sets so a
+ * table-registered case counts as covered for both platforms.
+ *
+ * Source of truth is the `DISPATCH_TABLE_TYPES` array in dispatch-table.ts;
+ * static-parse it (same approach as the rest of this test — no runtime import).
+ */
+function extractSharedDispatchTypes(dispatchSrc) {
+  const block = dispatchSrc.match(
+    /DISPATCH_TABLE_TYPES:\s*readonly\s+DispatchMessageType\[\]\s*=\s*\[([\s\S]*?)\]/,
+  )
+  assert.ok(block, 'Should find DISPATCH_TABLE_TYPES array in dispatch-table.ts')
+  const types = [...block[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1])
+  assert.ok(types.length > 0, 'Should find shared dispatch-table types')
+  return new Set(types)
+}
+
 function extractServerMessageTypes(wsServerSrc) {
   // Extract server message types from the Server -> Client doc comment in ws-server.js
   const serverSection = wsServerSrc.match(/\* Server -> Client:\n([\s\S]*?)\n \*\n \* Encrypted envelope/)?.[1]
@@ -187,14 +209,20 @@ describe('handler coverage contract', () => {
   const wsServerPath = resolve(import.meta.dirname, '../../server/src/ws-server.js')
   const appHandlerPath = resolve(import.meta.dirname, '../../app/src/store/message-handler.ts')
   const dashHandlerPath = resolve(import.meta.dirname, '../../dashboard/src/store/message-handler.ts')
+  const dispatchTablePath = resolve(import.meta.dirname, '../../store-core/src/dispatch-table.ts')
 
   const wsServerSrc = readFileSync(wsServerPath, 'utf-8')
   const appSrc = readFileSync(appHandlerPath, 'utf-8')
   const dashSrc = readFileSync(dashHandlerPath, 'utf-8')
+  const dispatchSrc = readFileSync(dispatchTablePath, 'utf-8')
 
   const allServerTypes = extractServerMessageTypes(wsServerSrc)
-  const appTypes = extractAppHandlerTypes(appSrc)
-  const dashTypes = extractDashboardHandlerTypes(dashSrc)
+  // #5556 — cases owned by the shared store-core dispatch table count as
+  // covered by BOTH clients (each routes through `runDispatch` first). Union
+  // them into both per-client sets so a migrated case isn't reported missing.
+  const sharedDispatchTypes = extractSharedDispatchTypes(dispatchSrc)
+  const appTypes = new Set([...extractAppHandlerTypes(appSrc), ...sharedDispatchTypes])
+  const dashTypes = new Set([...extractDashboardHandlerTypes(dashSrc), ...sharedDispatchTypes])
 
   it('every ServerMessageType is handled by at least one handler (or explicitly excluded)', () => {
     const unhandled = []

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -6,6 +6,7 @@ import {
   type ClientStoreAdapter,
 } from './dispatch-table'
 import type { ChatMessage, SessionInfo } from './types'
+import type { PermissionRule } from './handlers'
 
 // ---------------------------------------------------------------------------
 // Fake adapter — a minimal in-memory store that records every mutation a
@@ -18,7 +19,7 @@ interface FakeSession {
   messages: ChatMessage[]
   isIdle?: boolean
   conversationId?: string | null
-  sessionRules?: unknown[]
+  sessionRules?: PermissionRule[]
   [k: string]: unknown
 }
 
@@ -231,7 +232,7 @@ describe('shared dispatch table', () => {
 
     it('defaults to an empty rule set when rules is not an array', () => {
       const env = makeAdapter({
-        sessions: { s1: { sessionId: 's1', messages: [], sessionRules: [{ x: 1 }] } },
+        sessions: { s1: { sessionId: 's1', messages: [], sessionRules: [{ tool: 'Bash', decision: 'allow' }] } },
       })
       dispatch(env, { type: 'permission_rules_updated', sessionId: 's1' })
       expect(env.sessions.s1.sessionRules).toEqual([])

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createDispatchTable,
+  runDispatch,
+  DISPATCH_TABLE_TYPES,
+  type ClientStoreAdapter,
+} from './dispatch-table'
+import type { ChatMessage, SessionInfo } from './types'
+
+// ---------------------------------------------------------------------------
+// Fake adapter — a minimal in-memory store that records every mutation a
+// dispatch handler makes. Generic over a loose session shape so the table's
+// `updateSession` updater type-checks against it.
+// ---------------------------------------------------------------------------
+
+interface FakeSession {
+  sessionId: string
+  messages: ChatMessage[]
+  isIdle?: boolean
+  conversationId?: string | null
+  sessionRules?: unknown[]
+  [k: string]: unknown
+}
+
+function makeAdapter(init?: {
+  activeSessionId?: string | null
+  sessions?: Record<string, FakeSession>
+  sessionList?: SessionInfo[]
+}) {
+  const sessions: Record<string, FakeSession> = init?.sessions ?? {}
+  let activeSessionId = init?.activeSessionId ?? null
+  let sessionList: SessionInfo[] = init?.sessionList ?? []
+  const flat: Record<string, unknown> = {}
+  const addedMessages: ChatMessage[] = []
+
+  const adapter: ClientStoreAdapter<FakeSession> = {
+    getActiveSessionId: () => activeSessionId,
+    hasSession: (id) => Object.prototype.hasOwnProperty.call(sessions, id),
+    updateSession: (id, updater) => {
+      const current = sessions[id]
+      if (!current) return
+      sessions[id] = { ...current, ...updater(current) }
+    },
+    setState: (patch) => Object.assign(flat, patch),
+    addMessage: (m) => addedMessages.push(m),
+    getSessions: () => sessionList,
+  }
+
+  return {
+    adapter,
+    sessions,
+    flat,
+    addedMessages,
+    setActive: (id: string | null) => {
+      activeSessionId = id
+    },
+    setSessionList: (l: SessionInfo[]) => {
+      sessionList = l
+    },
+  }
+}
+
+const table = createDispatchTable<FakeSession>()
+
+function dispatch(env: ReturnType<typeof makeAdapter>, msg: Record<string, unknown>): boolean {
+  return runDispatch(table, msg, env.adapter)
+}
+
+describe('shared dispatch table', () => {
+  describe('runner mechanics', () => {
+    it('returns false (table miss) for an unregistered type so the caller falls through', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'model_changed', model: 'opus' })).toBe(false)
+    })
+
+    it('returns false for a non-string type', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 42 } as unknown as Record<string, unknown>)).toBe(false)
+    })
+
+    it('returns true and runs the handler on a hit', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'available_permission_modes', modes: [] })).toBe(true)
+    })
+
+    it('does NOT treat inherited Object.prototype keys as registered types', () => {
+      const env = makeAdapter()
+      // 'toString' / 'constructor' live on Object.prototype but must not match.
+      expect(dispatch(env, { type: 'toString' })).toBe(false)
+      expect(dispatch(env, { type: 'constructor' })).toBe(false)
+    })
+
+    it('DISPATCH_TABLE_TYPES matches the table keys exactly', () => {
+      expect([...DISPATCH_TABLE_TYPES].sort()).toEqual(Object.keys(table).sort())
+    })
+  })
+
+  describe('available_permission_modes', () => {
+    it('sets availablePermissionModes when the payload parses', () => {
+      const env = makeAdapter()
+      dispatch(env, {
+        type: 'available_permission_modes',
+        modes: [
+          { id: 'default', label: 'Default' },
+          { id: 'plan', label: 'Plan', description: 'Plan mode' },
+        ],
+      })
+      expect(env.flat.availablePermissionModes).toEqual([
+        { id: 'default', label: 'Default' },
+        { id: 'plan', label: 'Plan', description: 'Plan mode' },
+      ])
+    })
+
+    it('leaves state untouched when modes is not an array', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'available_permission_modes' })
+      expect(env.flat.availablePermissionModes).toBeUndefined()
+    })
+  })
+
+  describe('session_updated', () => {
+    it('renames the matching session in the list', () => {
+      const env = makeAdapter({
+        sessionList: [
+          { sessionId: 's1', name: 'Old' } as SessionInfo,
+          { sessionId: 's2', name: 'Keep' } as SessionInfo,
+        ],
+      })
+      dispatch(env, { type: 'session_updated', sessionId: 's1', name: 'New' })
+      expect(env.flat.sessions).toEqual([
+        { sessionId: 's1', name: 'New' },
+        { sessionId: 's2', name: 'Keep' },
+      ])
+    })
+
+    it('no-ops (no setState) when name or sessionId is missing', () => {
+      const env = makeAdapter({ sessionList: [{ sessionId: 's1', name: 'Old' } as SessionInfo] })
+      dispatch(env, { type: 'session_updated', sessionId: 's1' } as unknown as Record<string, unknown>)
+      expect(env.flat.sessions).toBeUndefined()
+    })
+  })
+
+  describe('agent_busy', () => {
+    it('flips the explicit target session to non-idle', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], isIdle: true } },
+      })
+      dispatch(env, { type: 'agent_busy', sessionId: 's1' })
+      expect(env.sessions.s1.isIdle).toBe(false)
+    })
+
+    it('falls back to the active session when sessionId is absent', () => {
+      const env = makeAdapter({
+        activeSessionId: 'active',
+        sessions: { active: { sessionId: 'active', messages: [], isIdle: true } },
+      })
+      dispatch(env, { type: 'agent_busy' })
+      expect(env.sessions.active.isIdle).toBe(false)
+    })
+
+    it('no-ops when the resolved session does not exist locally', () => {
+      const env = makeAdapter({ activeSessionId: 'gone' })
+      dispatch(env, { type: 'agent_busy' })
+      expect(Object.keys(env.sessions)).toHaveLength(0)
+    })
+  })
+
+  describe('budget_resumed', () => {
+    it('appends the system message to the target session', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, { type: 'budget_resumed', sessionId: 's1' })
+      expect(env.sessions.s1.messages).toHaveLength(1)
+      expect(env.sessions.s1.messages[0]).toMatchObject({
+        type: 'system',
+        content: 'Cost budget override — session resumed',
+      })
+      expect(env.addedMessages).toHaveLength(0)
+    })
+
+    it('falls back to addMessage when there is no target session', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'budget_resumed' })
+      expect(env.addedMessages).toHaveLength(1)
+      expect(env.addedMessages[0]).toMatchObject({
+        type: 'system',
+        content: 'Cost budget override — session resumed',
+      })
+    })
+  })
+
+  describe('conversation_id', () => {
+    it('stamps the conversation id onto the explicit session', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, { type: 'conversation_id', sessionId: 's1', conversationId: 'conv-9' })
+      expect(env.sessions.s1.conversationId).toBe('conv-9')
+    })
+
+    it('does NOT fall back to the active session when sessionId is missing', () => {
+      const env = makeAdapter({
+        activeSessionId: 'active',
+        sessions: { active: { sessionId: 'active', messages: [] } },
+      })
+      dispatch(env, { type: 'conversation_id', conversationId: 'conv-9' })
+      expect(env.sessions.active.conversationId).toBeUndefined()
+    })
+  })
+
+  describe('permission_rules_updated', () => {
+    it('replaces the explicit session rule set', () => {
+      const rules = [{ tool: 'Bash', action: 'allow' }]
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], sessionRules: [] } },
+      })
+      dispatch(env, { type: 'permission_rules_updated', sessionId: 's1', rules })
+      expect(env.sessions.s1.sessionRules).toEqual(rules)
+    })
+
+    it('falls back to the active session when sessionId is absent', () => {
+      const rules = [{ tool: 'Edit', action: 'deny' }]
+      const env = makeAdapter({
+        activeSessionId: 'active',
+        sessions: { active: { sessionId: 'active', messages: [], sessionRules: [] } },
+      })
+      dispatch(env, { type: 'permission_rules_updated', rules })
+      expect(env.sessions.active.sessionRules).toEqual(rules)
+    })
+
+    it('defaults to an empty rule set when rules is not an array', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], sessionRules: [{ x: 1 }] } },
+      })
+      dispatch(env, { type: 'permission_rules_updated', sessionId: 's1' })
+      expect(env.sessions.s1.sessionRules).toEqual([])
+    })
+  })
+
+  describe('confirm_permission_mode', () => {
+    it('stores the pending confirmation with mode + warning', () => {
+      const env = makeAdapter()
+      dispatch(env, {
+        type: 'confirm_permission_mode',
+        mode: 'bypassPermissions',
+        warning: 'Dangerous',
+      })
+      expect(env.flat.pendingPermissionConfirm).toEqual({
+        mode: 'bypassPermissions',
+        warning: 'Dangerous',
+      })
+    })
+
+    it('defaults the warning when the server omits it', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'confirm_permission_mode', mode: 'plan' })
+      expect(env.flat.pendingPermissionConfirm).toEqual({
+        mode: 'plan',
+        warning: 'Are you sure?',
+      })
+    })
+
+    it('leaves state untouched when mode is missing', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'confirm_permission_mode' })
+      expect(env.flat.pendingPermissionConfirm).toBeUndefined()
+    })
+  })
+})

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -1,0 +1,337 @@
+/**
+ * Shared message dispatch table (#5556 sub-item 3, first slice).
+ *
+ * The mobile app and web dashboard each maintained a hand-copied `switch
+ * (msg.type)` wrapping the SAME store-core handler functions with the SAME
+ * glue. Every new wire message cost ~5 edits across 3 files, and the two
+ * copies drifted (the static handler-coverage guard only asserts a case
+ * EXISTS, not that behaviour matches).
+ *
+ * This module mirrors the server's `ws-message-handlers.js` registry pattern
+ * on the client side: a `Record<msgType, handler>` where each entry is a pure
+ * delegation into an existing store-core handler, driven through a thin,
+ * platform-supplied {@link ClientStoreAdapter}. Cases where the two clients
+ * genuinely diverge stay platform-local (in each client's own switch) and are
+ * NOT registered here — they become VISIBLE as divergent by their absence.
+ *
+ * Migration is incremental: a client dispatches through {@link runDispatch}
+ * first; a table MISS falls through to its existing switch unchanged. This
+ * lets us migrate 5-10 pure-delegation cases per PR without a big-bang rewrite.
+ *
+ * --- Adapter design rationale ---
+ *
+ * The pure-delegation cases need only a tiny, platform-agnostic surface:
+ *   - read the active session id (`getActiveSessionId`)
+ *   - test whether a session exists locally (`hasSession`)
+ *   - patch a specific session's state (`updateSession`)
+ *   - patch the flat connection state (`setState`)
+ *   - append a chat message (`addMessage`)
+ *   - read the session list (`getSessions`)
+ *
+ * Both clients already expose exactly these (app: `updateSession` /
+ * `getStore().setState` / `addMessage` / `get().sessions`; dashboard: the
+ * `Handler = (msg, get, set, ctx)` map's `get`/`set`/`updateSession`). The
+ * adapter is the narrowest interface that covers the migrated cases — it does
+ * NOT leak either client's `ConnectionState`/`SessionState` shape into
+ * store-core. The table is generic over the client's session-state type `S`
+ * so `updateSession`'s updater stays correctly typed per platform.
+ *
+ * --- Typing against the protocol union ---
+ *
+ * Each entry's `msg` param is narrowed to that type's wire shape via
+ * {@link DispatchMessageMap} — a local map from the migrated `type` literal to
+ * its message shape (derived from the protocol's per-type schemas). There is
+ * no single `ServerMessageSchema` discriminated union to infer from (the
+ * server schemas are individual objects), and store-core deliberately keeps a
+ * minimal `@chroxy/protocol` surface for mobile build size; the map gives the
+ * same per-entry narrowing without pulling the whole protocol in.
+ */
+
+import type { ChatMessage, SessionInfo } from './types'
+import {
+  handleAvailablePermissionModes,
+  handleSessionUpdated,
+  handleAgentBusy,
+  handleBudgetResumed,
+  handleConversationId,
+  handlePermissionRulesUpdated,
+  handleConfirmPermissionMode,
+  resolveSessionId,
+  type PermissionMode,
+  type PermissionRule,
+  type PendingPermissionConfirm,
+} from './handlers'
+
+// ---------------------------------------------------------------------------
+// Client adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimal session-state shape the migrated handlers read or write. Each
+ * client's real session-state type (app `SessionState`, dashboard
+ * `SessionState`) is a structural superset, so it satisfies this constraint
+ * without store-core importing either client's type. The fields are exactly
+ * those the current table touches:
+ *   - `messages` — read+rewritten by `budget_resumed`
+ *   - `conversationId` — written by `conversation_id`
+ *   - `sessionRules` — written by `permission_rules_updated`
+ *   - `isIdle` — written by `agent_busy`
+ * No index signature: both clients' real `SessionState` carry these exact
+ * fields (plus many more), so they satisfy the constraint structurally. A
+ * future pure case that writes a NEW session field adds it here (and both
+ * clients already have it).
+ */
+export interface DispatchSessionBase {
+  messages: ChatMessage[]
+  conversationId?: string | null
+  sessionRules?: unknown[]
+  isIdle?: boolean
+}
+
+/**
+ * The minimal store surface a dispatch-table handler needs. Each client
+ * supplies an implementation backed by its own Zustand store. Generic over the
+ * client's session-state type `S` so {@link ClientStoreAdapter.updateSession}'s
+ * updater is typed against the platform's real session shape.
+ *
+ * `Flat` is the flat (top-level) connection-state slice each client merges via
+ * `setState`. Defaults to a loose record so a client can pass a precise type
+ * (its `Partial<ConnectionState>`) or fall back to the structural default.
+ */
+export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record<string, unknown>> {
+  /** Active session id, or null when none is selected. */
+  getActiveSessionId(): string | null
+  /** True when a session with this id exists in the client's local store. */
+  hasSession(sessionId: string): boolean
+  /**
+   * Shallow-merge a partial patch into a specific session's state. The updater
+   * receives the current session and returns the fields to merge. No-ops when
+   * the session does not exist (matches both clients' `updateSession`).
+   */
+  updateSession(sessionId: string, updater: (session: S) => Partial<S>): void
+  /** Shallow-merge a patch into the flat connection state. */
+  setState(patch: Flat): void
+  /** Append a chat message via the client's own add-message path. */
+  addMessage(message: ChatMessage): void
+  /** Read the current session list (for `session_updated`). */
+  getSessions(): SessionInfo[]
+}
+
+// ---------------------------------------------------------------------------
+// Per-entry message shapes (protocol-derived narrowing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire shapes for the migrated message types, keyed by `type`. Each entry's
+ * handler narrows its `msg` param to the corresponding shape. Mirrors the
+ * protocol's per-type server schemas; fields not consumed by the pure handler
+ * are intentionally omitted.
+ */
+export interface DispatchMessageMap {
+  available_permission_modes: {
+    type: 'available_permission_modes'
+    modes?: unknown[]
+  }
+  session_updated: {
+    type: 'session_updated'
+    sessionId: string
+    name: string
+  }
+  agent_busy: {
+    type: 'agent_busy'
+    sessionId?: string
+  }
+  budget_resumed: {
+    type: 'budget_resumed'
+    sessionId?: string
+  }
+  conversation_id: {
+    type: 'conversation_id'
+    sessionId?: string
+    conversationId?: string
+  }
+  permission_rules_updated: {
+    type: 'permission_rules_updated'
+    sessionId?: string
+    rules?: unknown[]
+  }
+  confirm_permission_mode: {
+    type: 'confirm_permission_mode'
+    mode?: string
+    warning?: string
+  }
+}
+
+/** Union of message types this table currently handles. */
+export type DispatchMessageType = keyof DispatchMessageMap
+
+/** A single dispatch-table entry: a pure delegation into a store-core handler. */
+export type DispatchHandler<K extends DispatchMessageType, S extends DispatchSessionBase> = (
+  msg: DispatchMessageMap[K],
+  adapter: ClientStoreAdapter<S>,
+) => void
+
+/** The full dispatch table — every migrated type maps to its handler. */
+export type DispatchTable<S extends DispatchSessionBase> = {
+  [K in DispatchMessageType]: DispatchHandler<K, S>
+}
+
+// ---------------------------------------------------------------------------
+// Handlers — one pure delegation per migrated case
+//
+// Each was byte-for-byte identical between the app and dashboard switches
+// (see the PR body's per-case diff verdicts). Divergent cases (model_changed,
+// permission_mode_changed, agent_idle, budget_warning/exceeded, primary_changed,
+// available_models, notification_prefs, client_joined/left/focus_changed,
+// permission_expired) are deliberately NOT here — they stay platform-local.
+// ---------------------------------------------------------------------------
+
+/** `available_permission_modes` — replace the flat list when the payload parses. */
+function dispatchAvailablePermissionModes<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['available_permission_modes'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const modes = handleAvailablePermissionModes(msg as Record<string, unknown>)
+  if (modes) {
+    adapter.setState({ availablePermissionModes: modes } as Record<string, PermissionMode[]>)
+  }
+}
+
+/** `session_updated` — rename the matching session in the list. */
+function dispatchSessionUpdated<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_updated'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const updated = handleSessionUpdated(msg as Record<string, unknown>, adapter.getSessions())
+  if (updated) {
+    adapter.setState({ sessions: updated } as Record<string, SessionInfo[]>)
+  }
+}
+
+/** `agent_busy` — flip the target session to non-idle when it exists locally. */
+function dispatchAgentBusy<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['agent_busy'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (targetId && adapter.hasSession(targetId)) {
+    adapter.updateSession(targetId, () => handleAgentBusy() as Partial<S>)
+  }
+}
+
+/** `budget_resumed` — append the "budget resumed" system message. */
+function dispatchBudgetResumed<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['budget_resumed'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { systemMessage } = handleBudgetResumed()
+  const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (targetId && adapter.hasSession(targetId)) {
+    adapter.updateSession(
+      targetId,
+      (ss) =>
+        ({
+          messages: [...(ss as { messages: ChatMessage[] }).messages, systemMessage],
+        } as Partial<S>),
+    )
+  } else {
+    adapter.addMessage(systemMessage)
+  }
+}
+
+/** `conversation_id` — stamp the conversation id onto its (explicit) session. */
+function dispatchConversationId<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['conversation_id'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId, conversationId } = handleConversationId(msg as Record<string, unknown>)
+  // Intentionally does NOT fall back to activeSessionId — a missing sessionId
+  // skips the patch entirely (matches both clients' prior inline behaviour).
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => ({ conversationId } as Partial<S>))
+  }
+}
+
+/** `permission_rules_updated` — replace the target session's rule set. */
+function dispatchPermissionRulesUpdated<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['permission_rules_updated'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId: explicitId, rules } = handlePermissionRulesUpdated(
+    msg as Record<string, unknown>,
+  )
+  const rulesSessionId = explicitId || adapter.getActiveSessionId()
+  if (rulesSessionId && adapter.hasSession(rulesSessionId)) {
+    adapter.updateSession(
+      rulesSessionId,
+      () => ({ sessionRules: rules as PermissionRule[] } as Partial<S>),
+    )
+  }
+}
+
+/** `confirm_permission_mode` — store the pending mode-change confirmation. */
+function dispatchConfirmPermissionMode<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['confirm_permission_mode'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const pending = handleConfirmPermissionMode(msg as Record<string, unknown>)
+  if (pending) {
+    adapter.setState({
+      pendingPermissionConfirm: pending,
+    } as Record<string, PendingPermissionConfirm>)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Table + runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the shared dispatch table bound to a client's session-state type `S`.
+ *
+ * Returns a fresh, fully-typed table. Generic over `S` so each client gets an
+ * `updateSession` updater typed against its own session shape; the underlying
+ * handlers are shared and identical.
+ */
+export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTable<S> {
+  return {
+    available_permission_modes: dispatchAvailablePermissionModes,
+    session_updated: dispatchSessionUpdated,
+    agent_busy: dispatchAgentBusy,
+    budget_resumed: dispatchBudgetResumed,
+    conversation_id: dispatchConversationId,
+    permission_rules_updated: dispatchPermissionRulesUpdated,
+    confirm_permission_mode: dispatchConfirmPermissionMode,
+  }
+}
+
+/** The message types the shared table currently owns (for coverage tooling). */
+export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
+  'available_permission_modes',
+  'session_updated',
+  'agent_busy',
+  'budget_resumed',
+  'conversation_id',
+  'permission_rules_updated',
+  'confirm_permission_mode',
+]
+
+/**
+ * Run a message through the shared table.
+ *
+ * @returns `true` when the table owned (and handled) the message — the caller
+ *   should stop. `false` on a table MISS — the caller falls through to its own
+ *   switch, keeping incremental migration possible.
+ */
+export function runDispatch<S extends DispatchSessionBase>(
+  table: DispatchTable<S>,
+  msg: { type?: unknown } & Record<string, unknown>,
+  adapter: ClientStoreAdapter<S>,
+): boolean {
+  const type = msg.type
+  if (typeof type !== 'string') return false
+  if (!Object.prototype.hasOwnProperty.call(table, type)) return false
+  const handler = table[type as DispatchMessageType] as DispatchHandler<DispatchMessageType, S>
+  handler(msg as DispatchMessageMap[DispatchMessageType], adapter)
+  return true
+}

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -1,5 +1,5 @@
 /**
- * Shared message dispatch table (#5556 sub-item 3, first slice).
+ * Shared message dispatch table (epic #5556, sub-item 3, first slice).
  *
  * The mobile app and web dashboard each maintained a hand-copied `switch
  * (msg.type)` wrapping the SAME store-core handler functions with the SAME
@@ -84,7 +84,7 @@ import {
 export interface DispatchSessionBase {
   messages: ChatMessage[]
   conversationId?: string | null
-  sessionRules?: unknown[]
+  sessionRules?: PermissionRule[]
   isIdle?: boolean
 }
 
@@ -231,7 +231,7 @@ function dispatchBudgetResumed<S extends DispatchSessionBase>(
       targetId,
       (ss) =>
         ({
-          messages: [...(ss as { messages: ChatMessage[] }).messages, systemMessage],
+          messages: [...ss.messages, systemMessage],
         } as Partial<S>),
     )
   } else {
@@ -264,7 +264,7 @@ function dispatchPermissionRulesUpdated<S extends DispatchSessionBase>(
   if (rulesSessionId && adapter.hasSession(rulesSessionId)) {
     adapter.updateSession(
       rulesSessionId,
-      () => ({ sessionRules: rules as PermissionRule[] } as Partial<S>),
+      () => ({ sessionRules: rules } as Partial<S>),
     )
   }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -570,7 +570,7 @@ export type {
   DeltaFlushScheduler,
 } from './delta-flush'
 
-// #5556 (epic #5514, sub-item 3): shared client message dispatch table. A
+// epic #5556, sub-item 3: shared client message dispatch table. A
 // `Record<msgType, handler>` registry of pure-delegation cases that were
 // byte-identical between the app and dashboard switches, driven through a thin
 // per-client `ClientStoreAdapter`. Clients dispatch through `runDispatch`

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -569,3 +569,22 @@ export type {
   CreateDeltaFlusherOptions,
   DeltaFlushScheduler,
 } from './delta-flush'
+
+// #5556 (epic #5514, sub-item 3): shared client message dispatch table. A
+// `Record<msgType, handler>` registry of pure-delegation cases that were
+// byte-identical between the app and dashboard switches, driven through a thin
+// per-client `ClientStoreAdapter`. Clients dispatch through `runDispatch`
+// first; a table miss falls through to their existing switch, so migration
+// stays incremental. Divergent cases stay platform-local (not registered).
+export {
+  createDispatchTable,
+  runDispatch,
+  DISPATCH_TABLE_TYPES,
+} from './dispatch-table'
+export type {
+  ClientStoreAdapter,
+  DispatchTable,
+  DispatchHandler,
+  DispatchMessageMap,
+  DispatchMessageType,
+} from './dispatch-table'


### PR DESCRIPTION
## Summary

First slice of epic #5556 sub-item 3 — the **shared client dispatch table**. Today the mobile app (95 cases) and dashboard (71 cases) each hand-copy a `switch (msg.type)` that wraps the SAME store-core handlers with the SAME glue; every new wire message costs ~5 edits across 3 files, and the two copies have drifted (the static handler-coverage guard only asserts a case *exists*, not that behaviour matches).

This PR introduces a `Record<msgType, handler>` registry in store-core (mirroring the server's `ws-message-handlers.js` pattern), driven by a thin per-client adapter, and migrates the first **7 pure-delegation cases** into it. Both clients route through the table first; a table **miss falls through** to their existing switch unchanged, so the incremental march can continue.

## Adapter design rationale

The pure-delegation cases need only a tiny, platform-agnostic store surface, so `ClientStoreAdapter<S>` is exactly that:

| Method | Used by |
|---|---|
| `getActiveSessionId()` | session-fallback resolution |
| `hasSession(id)` | the `&& sessionStates[id]` guard both clients duplicate |
| `updateSession(id, updater)` | per-session patch (generic over the client's `SessionState`) |
| `setState(patch)` | flat connection-state patch |
| `addMessage(msg)` | `budget_resumed`'s no-active-session fallback |
| `getSessions()` | `session_updated`'s list rename |

Both clients already expose exactly these (app: `updateSession` / `getStore().setState` / `addMessage` / `get().sessions`; dashboard: its existing `Handler = (msg, get, set, ctx)` map). The adapter is the **narrowest** interface that covers the migrated cases and does **not** leak either client's `ConnectionState`/`SessionState` shape into store-core. The table is generic over `S extends DispatchSessionBase` so each client's `updateSession` updater stays correctly typed.

**Typing against the protocol union:** there is no single `ServerMessageSchema` discriminated union to infer from (the server schemas are individual objects), and store-core deliberately keeps a minimal `@chroxy/protocol` surface for mobile build size. So each entry narrows its `msg` param via a local `DispatchMessageMap` keyed by the migrated `type` literal — same per-entry narrowing without pulling the whole protocol in.

## Migrated cases — both-clients diff verdicts

Each case was diffed between app + dashboard before migrating. Only **byte-identical** pure-delegation cases were taken; anything that diverged was left platform-local.

| Case | Verdict | Notes |
|---|---|---|
| `available_permission_modes` | **identical** | `set({ availablePermissionModes })` when modes parse |
| `session_updated` | **identical** | rename in the list via `getSessions()` → `setState` |
| `agent_busy` | **identical** | resolve-session + `hasSession` guard + `updateSession(sharedAgentBusy())` |
| `budget_resumed` | **identical** | append system message, `addMessage` fallback when no session |
| `conversation_id` | **identical** | comment + code byte-for-byte equal; explicit-sessionId only (no active fallback) |
| `permission_rules_updated` | **identical** | active-fallback + replace `sessionRules` (app's `as PermissionRule[]` cast preserved) |
| `confirm_permission_mode` | **identical** | `set({ pendingPermissionConfirm })` when valid |

### Skipped — divergent (deliberately stay platform-local, now visible as such)

| Case | Why divergent |
|---|---|
| `model_changed` | app has `effectiveId` fallback + clears nothing flat; dashboard `else set({ activeModel })` |
| `permission_mode_changed` | app clears the pending-mode-request tracker; dashboard `else set` |
| `agent_idle` | dashboard has a no-session `else set(sharedAgentIdle())` fallback; app does not |
| `budget_warning` | app `Alert.alert`; dashboard `_adapters.alert.alert` |
| `budget_exceeded` | dashboard auto-resumes + appends "will auto-resume" copy; app shows a "Resume" alert button |
| `primary_changed` | app also syncs `useMultiClientStore.setPrimaryClientId` |
| `available_models` | dashboard also sets `availableModelsProvider` |
| `notification_prefs` | app inline-parses `ServerNotificationPrefsSchema`; dashboard uses `sharedNotificationPrefs` |
| `client_joined` / `client_left` | app appends to active session + syncs multi-client store; dashboard broadcasts to all sessions |
| `client_focus_changed` | app reads `useMultiClientStore`; dashboard reads `followMode`/`myClientId` off the store |
| `permission_expired` | dashboard has the #2833 already-resolved race branch; app does not |

## Behavioral safety / parity guard

The protocol `handler-coverage` test does **static regex analysis** over each client's `case`/`HANDLERS` source. Migrating cases out of both switches would make them read as "unhandled", so the test now static-parses `DISPATCH_TABLE_TYPES` from `dispatch-table.ts` and unions it into **both** client type sets — a table-registered case counts as covered for both platforms. All 9 coverage checks stay green.

## Tests

- store-core registry unit tests — `dispatch-table.test.ts`, 22 cases (each migrated case: message in → expected store mutation, plus runner mechanics incl. prototype-key safety and `DISPATCH_TABLE_TYPES` ↔ table-keys equality).
- Full suites + typechecks green:
  - store-core: 1282 tests, tsc clean
  - app: 1732 tests, tsc clean
  - dashboard: 3533 tests, tsc clean
  - protocol: 282 tests (incl. updated handler-coverage), all green

Related to #5556
