### PR TITLE
feat(ws): auth_bootstrap burst — collapse the post-auth connect round trip

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -5016,3 +5016,90 @@ describe('multi_question_intervention handler (#4764)', () => {
     expect(sB.interventions[0].toolUseId).toBe('toolu_b');
   });
 });
+
+// #5555 (auth_bootstrap) — the server folds the permission-mode enum into
+// auth_ok and, when it advertises capabilities.authBootstrap, pushes an
+// auth_bootstrap burst with the provider/slash/agent lists. The client then
+// SKIPS the 3 connect-time list requests; against an old server (no flag) it
+// requests them as before. The list_* refresh paths stay live.
+describe('auth_bootstrap (#5555)', () => {
+  function sentTypes(ctx: ReturnType<typeof createMockContext>) {
+    return (ctx.socket.send as jest.Mock).mock.calls.map((c) => JSON.parse(c[0]).type);
+  }
+
+  it('skips the 3 connect-time list requests when capabilities.authBootstrap is set', () => {
+    const store = createMockStore({ sessionStates: {} });
+    setStore(store as any);
+    const ctx = createMockContext();
+    _testMessageHandler.setContext(ctx as any);
+
+    _testMessageHandler.handle({
+      type: 'auth_ok',
+      clientId: 'client-1',
+      connectedClients: [],
+      capabilities: { authBootstrap: true },
+    });
+
+    const types = sentTypes(ctx);
+    expect(types).not.toContain('list_providers');
+    expect(types).not.toContain('list_slash_commands');
+    expect(types).not.toContain('list_agents');
+  });
+
+  it('requests the 3 lists when authBootstrap is absent (old server)', () => {
+    const store = createMockStore({ sessionStates: {} });
+    setStore(store as any);
+    const ctx = createMockContext();
+    _testMessageHandler.setContext(ctx as any);
+
+    _testMessageHandler.handle({
+      type: 'auth_ok',
+      clientId: 'client-1',
+      connectedClients: [],
+    });
+
+    const types = sentTypes(ctx);
+    expect(types).toContain('list_providers');
+    expect(types).toContain('list_slash_commands');
+    expect(types).toContain('list_agents');
+  });
+
+  it('folds availablePermissionModes from auth_ok into the store', () => {
+    const store = createMockStore({ sessionStates: {} });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'auth_ok',
+      clientId: 'client-1',
+      connectedClients: [],
+      availablePermissionModes: [{ id: 'approve', label: 'Approve' }],
+    });
+
+    expect(store.getState().availablePermissionModes).toEqual([{ id: 'approve', label: 'Approve' }]);
+  });
+
+  it('applies a subsequent auth_bootstrap burst to the provider/slash/agent stores', () => {
+    const store = createMockStore({ sessionStates: {}, activeSessionId: null });
+    setStore(store as any);
+    const ctx = createMockContext();
+    _testMessageHandler.setContext(ctx as any);
+
+    _testMessageHandler.handle({
+      type: 'auth_ok',
+      clientId: 'client-1',
+      connectedClients: [],
+      capabilities: { authBootstrap: true },
+    });
+    _testMessageHandler.handle({
+      type: 'auth_bootstrap',
+      providers: [{ name: 'anthropic' }],
+      slashCommands: [{ name: 'clear', source: 'builtin' }],
+      agents: [{ name: 'reviewer', source: 'project' }],
+    });
+
+    expect(store.getState().availableProviders).toEqual([{ name: 'anthropic' }]);
+    expect(store.getState().slashCommands).toEqual([{ name: 'clear', source: 'builtin' }]);
+    expect(store.getState().customAgents).toEqual([{ name: 'reviewer', source: 'project' }]);
+  });
+});

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -102,6 +102,7 @@ import {
   handleSlashCommands as sharedSlashCommands,
   handleAgentList as sharedAgentList,
   handleProviderList as sharedProviderList,
+  handleAuthBootstrap as sharedAuthBootstrap,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
   handleGitBranchesResult as sharedGitBranchesResult,
@@ -287,6 +288,12 @@ interface MessageHandlerContext extends EncryptionContext {
 
   // Message queue
   messageQueue: QueuedMessage[];
+
+  // #5555 (auth_bootstrap) — set from auth_ok's `capabilities.authBootstrap`.
+  // When true, the server pushes an `auth_bootstrap` burst frame carrying the
+  // provider / slash-command / agent lists, so the connect-time list_* request
+  // round trip is skipped (in BOTH the eager and discrete key-exchange paths).
+  serverWillBootstrap: boolean;
 }
 
 function createDefaultContext(): MessageHandlerContext {
@@ -316,6 +323,7 @@ function createDefaultContext(): MessageHandlerContext {
     clientRender: new RollingPercentiles(200),
     lastLatencyLogAt: 0,
     messageQueue: [],
+    serverWillBootstrap: false,
   };
   return ctx;
 }
@@ -340,6 +348,34 @@ export function resetAllHandlerState(): void {
   disconnectedAttemptId = -1;
   lastConnectedUrl = null;
   pendingPairingId = null;
+}
+
+/**
+ * #5555 — normalize a raw provider list (from either the `provider_list`
+ * response or the `auth_bootstrap` burst) into validated `ProviderInfo[]`.
+ * Guards against misbehaving servers / malicious endpoints that might send
+ * non-objects or objects without a string `name`, and preserves the
+ * capabilities + auth/billing summary (#3404). Shared so the discrete and
+ * bootstrap paths apply identical element validation.
+ */
+function mapProviderList(rawProviders: unknown[]): ProviderInfo[] {
+  return rawProviders
+    .filter(
+      (p): p is { name: string; capabilities?: unknown; auth?: unknown } =>
+        !!p &&
+        typeof p === 'object' &&
+        typeof (p as { name?: unknown }).name === 'string',
+    )
+    .map((p) => {
+      const entry: ProviderInfo = { name: p.name };
+      if (p.capabilities && typeof p.capabilities === 'object' && !Array.isArray(p.capabilities)) {
+        entry.capabilities = p.capabilities as ProviderInfo['capabilities'];
+      }
+      if (p.auth && typeof p.auth === 'object' && !Array.isArray(p.auth)) {
+        entry.auth = p.auth as ProviderInfo['auth'];
+      }
+      return entry;
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -1252,6 +1288,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       useConnectionLifecycleStore.getState().setConnectionError(null, 0);
       useConnectionLifecycleStore.getState().setUserDisconnected(false);
 
+      // #5555 — fold the static permission-mode enum out of auth_ok when the
+      // server provided it, so we don't have to wait for the discrete
+      // `available_permission_modes` burst frame. Older servers omit the field
+      // (null) and the discrete frame still lands; new servers send both and
+      // this just wins the race harmlessly (idempotent set).
+      if (auth.availablePermissionModes) {
+        set({ availablePermissionModes: auth.availablePermissionModes });
+      }
+
+      // #5555 (auth_bootstrap) — when the server advertises the bootstrap
+      // capability it pushes an `auth_bootstrap` burst frame carrying the
+      // provider / slash-command / agent lists right after auth_ok. In that
+      // case we SKIP the 3 connect-time list requests (they arrive unsolicited
+      // in the burst). Older servers don't set the flag, so we request as
+      // before. The list_* request paths stay live for post-connect refreshes.
+      _ctx.serverWillBootstrap = auth.serverCapabilities.authBootstrap === true;
+      const sendConnectListRequests = () => {
+        if (_ctx.serverWillBootstrap) return;
+        wsSend(ctx.socket, { type: 'list_providers' });
+        wsSend(ctx.socket, { type: 'list_slash_commands' });
+        wsSend(ctx.socket, { type: 'list_agents' });
+      };
+
       // Start client-side heartbeat for dead connection detection
       startHeartbeat(ctx.socket);
 
@@ -1264,26 +1323,44 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // _ctx.pendingSalt. If the server honoured the eager path it returns
         // its public key in auth_ok; derive the shared key immediately and
         // start the burst a full RTT earlier than the discrete handshake.
+        //
+        // #5555 follow-up (hardening) — `auth.serverPublicKey` is shared-parser
+        // normalized (empty/non-string → null) but a non-empty MALFORMED value
+        // (bad base64 / wrong length) still passes that filter and makes
+        // `deriveSharedKey` throw. The discrete `key_exchange_ok` handler
+        // guards against a bad key; mirror that here by wrapping the eager
+        // derivation in try/catch and FALLING BACK to the discrete handshake
+        // on any failure instead of letting the throw tear down the connection.
+        let eagerEstablished = false;
         if (auth.serverPublicKey && _ctx.pendingKeyPair) {
-          const rawSharedKey = deriveSharedKey(auth.serverPublicKey, _ctx.pendingKeyPair.secretKey);
-          const encryptionKey = _ctx.pendingSalt
-            ? deriveConnectionKey(rawSharedKey, _ctx.pendingSalt)
-            : rawSharedKey;
-          _ctx.encryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 };
-          _ctx.pendingKeyPair = null;
-          _ctx.pendingSalt = null;
-          console.log('[crypto] E2E encryption established (eager)');
-          // Burst un-gated: server already activated encryption after auth_ok.
-          wsSend(ctx.socket, { type: 'list_providers' });
-          wsSend(ctx.socket, { type: 'list_slash_commands' });
-          wsSend(ctx.socket, { type: 'list_agents' });
-          resetClientVisibleMemo();
-          sendClientVisible(ctx.socket, isVisibleAppState(AppState.currentState));
-        } else {
-          // Fallback (old server / eager derivation declined): the keypair is
-          // still stashed from onopen — send the discrete key_exchange so the
-          // server replies key_exchange_ok. If onopen never ran (defensive),
-          // regenerate so we never send an empty handshake.
+          try {
+            const rawSharedKey = deriveSharedKey(auth.serverPublicKey, _ctx.pendingKeyPair.secretKey);
+            const encryptionKey = _ctx.pendingSalt
+              ? deriveConnectionKey(rawSharedKey, _ctx.pendingSalt)
+              : rawSharedKey;
+            _ctx.encryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 };
+            _ctx.pendingKeyPair = null;
+            _ctx.pendingSalt = null;
+            eagerEstablished = true;
+            console.log('[crypto] E2E encryption established (eager)');
+            // Burst un-gated: server already activated encryption after auth_ok.
+            sendConnectListRequests();
+            resetClientVisibleMemo();
+            sendClientVisible(ctx.socket, isVisibleAppState(AppState.currentState));
+          } catch (err) {
+            // Malformed eager key — discard any partial state and fall through
+            // to the discrete handshake below (regenerating the keypair if the
+            // eager attempt consumed it).
+            console.warn('[crypto] Eager key derivation failed, falling back to discrete key_exchange', err);
+            _ctx.encryptionState = null;
+          }
+        }
+        if (!eagerEstablished) {
+          // Fallback (old server / no eager key / eager derivation failed): the
+          // keypair is still stashed from onopen — send the discrete
+          // key_exchange so the server replies key_exchange_ok. If onopen never
+          // ran (defensive) or the eager attempt nulled it, regenerate so we
+          // never send an empty handshake.
           if (!_ctx.pendingKeyPair) {
             _ctx.pendingKeyPair = createKeyPair();
             _ctx.pendingSalt = generateConnectionSalt();
@@ -1294,9 +1371,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       } else {
         // No encryption — send post-auth messages immediately
-        wsSend(ctx.socket, { type: 'list_providers' });
-        wsSend(ctx.socket, { type: 'list_slash_commands' });
-        wsSend(ctx.socket, { type: 'list_agents' });
+        sendConnectListRequests();
         useConnectionLifecycleStore.getState().setServerInfo({ isEncrypted: false });
         // #3404: server defaults visible=true on fresh connect; sync if we
         // reconnected while backgrounded so completion pushes still fire.
@@ -1334,10 +1409,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         _ctx.pendingKeyPair = null;
         _ctx.pendingSalt = null;
         console.log('[crypto] E2E encryption established');
-        // Now send the post-auth messages that were deferred
-        wsSend(ctx.socket, { type: 'list_providers' });
-        wsSend(ctx.socket, { type: 'list_slash_commands' });
-        wsSend(ctx.socket, { type: 'list_agents' });
+        // Now send the post-auth messages that were deferred. #5555: skip the
+        // 3 list requests when the server advertised the auth_bootstrap
+        // capability (the burst frame already carries that data, queued behind
+        // encryption and decrypted once this handshake completes).
+        if (!_ctx.serverWillBootstrap) {
+          wsSend(ctx.socket, { type: 'list_providers' });
+          wsSend(ctx.socket, { type: 'list_slash_commands' });
+          wsSend(ctx.socket, { type: 'list_agents' });
+        }
         // #3404: sync visibility once encryption is established (mirrors the
         // unencrypted auth_ok path above).
         resetClientVisibleMemo();
@@ -2698,31 +2778,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'provider_list': {
       const providerResult = sharedProviderList(msg);
       if (!providerResult) break;
-      // Validate element shape before storing — guard against misbehaving
-      // servers / malicious endpoints that might send non-objects or
-      // objects without a string `name`.
-      const providers: ProviderInfo[] = providerResult.providers
-        .filter(
-          (p): p is { name: string; capabilities?: unknown; auth?: unknown } =>
-            !!p &&
-            typeof p === 'object' &&
-            typeof (p as { name?: unknown }).name === 'string',
-        )
-        .map((p) => {
-          const entry: ProviderInfo = { name: p.name };
-          if (p.capabilities && typeof p.capabilities === 'object' && !Array.isArray(p.capabilities)) {
-            entry.capabilities = p.capabilities as ProviderInfo['capabilities'];
-          }
-          // #3404 audit (F1+F5): preserve the server's auth/billing summary so
-          // the create-session modal can disable unready chips and show the
-          // billing identity. Earlier code dropped the field, breaking the
-          // entire mobile UI surface for these features.
-          if (p.auth && typeof p.auth === 'object' && !Array.isArray(p.auth)) {
-            entry.auth = p.auth as ProviderInfo['auth'];
-          }
-          return entry;
-        });
-      set({ availableProviders: providers });
+      set({ availableProviders: mapProviderList(providerResult.providers) });
       break;
     }
 
@@ -2730,6 +2786,31 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const agentResult = sharedAgentList(msg, get().activeSessionId);
       if (!agentResult) break;
       const customAgents = agentResult.agents as CustomAgent[];
+      set({ customAgents });
+      useConversationStore.getState().setCustomAgents(customAgents);
+      break;
+    }
+
+    case 'auth_bootstrap': {
+      // #5555 — connect-time bootstrap burst folds the provider / slash-command
+      // / agent lists into one server-initiated frame so the client skips its
+      // 3-request connect-time round trip. Apply each list through the SAME
+      // store mutations + element validation the discrete responses use, so the
+      // bootstrap and refresh paths are behaviourally identical.
+      const boot = sharedAuthBootstrap(msg);
+      // Providers (server-wide, no session guard).
+      set({ availableProviders: mapProviderList(boot.providers) });
+      // Slash commands + agents are scoped to the connect-time active session.
+      // Guard against a stale burst: if a session switch already moved the
+      // active id off the burst's `sessionId`, skip the session-scoped lists
+      // (the post-switch session_switched flow re-requests them) but keep the
+      // server-wide provider list applied above.
+      const activeId = get().activeSessionId;
+      if (boot.sessionId && activeId && boot.sessionId !== activeId) break;
+      const slashCommands = boot.slashCommands as SlashCommand[];
+      set({ slashCommands });
+      useConversationStore.getState().setSlashCommands(slashCommands);
+      const customAgents = boot.agents as CustomAgent[];
       set({ customAgents });
       useConversationStore.getState().setCustomAgents(customAgents);
       break;

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -289,6 +289,63 @@ describe('auth_ok handler', () => {
     })
   })
 
+  // #5555 (auth_bootstrap) — when the server advertises capabilities.authBootstrap
+  // it pushes the provider/slash/agent lists in an auth_bootstrap burst, so the
+  // client skips the 3 connect-time list requests. Without the flag (old server)
+  // it requests them as before. Both folded permission modes and the skip apply.
+  describe('auth_bootstrap (#5555)', () => {
+    function typesFrom(socket: WebSocket) {
+      return (socket.send as ReturnType<typeof vi.fn>).mock.calls
+        .map((c: unknown[]) => JSON.parse(c[0] as string).type)
+    }
+
+    it('skips the 3 list requests when capabilities.authBootstrap is set (unencrypted)', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({ capabilities: { authBootstrap: true } }), ctx as any)
+
+      const types = typesFrom(mockSocket)
+      expect(types).not.toContain('list_providers')
+      expect(types).not.toContain('list_slash_commands')
+      expect(types).not.toContain('list_agents')
+    })
+
+    it('still requests the 3 lists when authBootstrap is absent (old server)', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage(), ctx as any)
+
+      const types = typesFrom(mockSocket)
+      expect(types).toContain('list_providers')
+      expect(types).toContain('list_slash_commands')
+      expect(types).toContain('list_agents')
+    })
+
+    it('folds availablePermissionModes from auth_ok into the store', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(
+        createAuthOkMessage({ availablePermissionModes: [{ id: 'approve', label: 'Approve' }] }),
+        ctx as any,
+      )
+      expect(store.getState().availablePermissionModes).toEqual([{ id: 'approve', label: 'Approve' }])
+    })
+
+    it('applies a subsequent auth_bootstrap burst to the provider/slash/agent stores', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({ capabilities: { authBootstrap: true } }), ctx as any)
+      handleMessage(
+        {
+          type: 'auth_bootstrap',
+          providers: [{ name: 'anthropic' }],
+          slashCommands: [{ name: 'clear', source: 'builtin' }],
+          agents: [{ name: 'reviewer', source: 'project' }],
+        },
+        ctx as any,
+      )
+      expect(store.getState().availableProviders).toEqual([{ name: 'anthropic' }])
+      expect(store.getState().slashCommands).toEqual([{ name: 'clear', source: 'builtin' }])
+      expect(store.getState().customAgents).toEqual([{ name: 'reviewer', source: 'project' }])
+    })
+  })
+
   // #5555 (eager key exchange) — when onopen prepared the keypair eagerly and
   // the server returns serverPublicKey in auth_ok, the client derives the
   // shared key inline and sends the post-auth burst immediately (no discrete
@@ -335,6 +392,30 @@ describe('auth_ok handler', () => {
       expect(types).not.toContain('list_providers')
       // Did not derive eagerly.
       expect(deriveSharedKey).not.toHaveBeenCalled()
+    })
+
+    // #5555 follow-up (hardening) — a non-empty MALFORMED serverPublicKey passes
+    // the shared-parser's empty/non-string filter but makes deriveSharedKey
+    // throw. The eager derivation must be wrapped so the throw degrades to the
+    // discrete handshake instead of tearing the connection down.
+    it('falls back to the discrete key_exchange when eager deriveSharedKey throws (malformed key)', () => {
+      ;(deriveSharedKey as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+        throw new Error('Invalid peer public key: expected length 32, got 5')
+      })
+      prepareEagerKeyExchange()
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(
+        createAuthOkMessage({ encryption: 'required', serverPublicKey: 'bogus' }),
+        ctx as any,
+      )
+
+      const types = sendsFrom(mockSocket).map((s) => s.type)
+      // Degraded to the discrete handshake — connection NOT torn down.
+      expect(types).toContain('key_exchange')
+      // Burst not sent in plaintext (still gated behind the discrete exchange).
+      expect(types).not.toContain('list_providers')
+      // Socket stays open (no close on a recoverable eager failure).
+      expect(mockSocket.close).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -90,6 +90,7 @@ import {
   handleSlashCommands as sharedSlashCommands,
   handleAgentList as sharedAgentList,
   handleProviderList as sharedProviderList,
+  handleAuthBootstrap as sharedAuthBootstrap,
   handleFileList as sharedFileList,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
@@ -314,6 +315,14 @@ export function _testTrustGrantPendingSize(): number {
 let _encryptionState: EncryptionState | null = null;
 let _pendingKeyPair: KeyPair | null = null;
 let _pendingSalt: string | null = null;
+
+// #5555 (auth_bootstrap) — set fresh from each auth_ok's
+// `capabilities.authBootstrap`. When true, the server pushes an
+// `auth_bootstrap` burst frame with the provider / slash-command / agent
+// lists, so the connect-time list_* request round trip is skipped (in both the
+// eager and discrete key-exchange paths). Defaults false (old server) and is
+// overwritten on every connect, so it never goes stale across reconnects.
+let _serverWillBootstrap = false;
 
 /**
  * Send a JSON message over WebSocket, encrypting if E2E encryption is active.
@@ -2499,6 +2508,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           customAgents: [],
         });
       }
+      // #5555 — fold the static permission-mode enum out of auth_ok when the
+      // server provided it, so we don't have to wait for the discrete
+      // `available_permission_modes` burst frame. Older servers omit the field
+      // (null) and the discrete frame still lands; new servers send both and
+      // this just wins the race harmlessly (idempotent set).
+      if (auth.availablePermissionModes) {
+        set({ availablePermissionModes: auth.availablePermissionModes });
+      }
+
+      // #5555 (auth_bootstrap) — when the server advertises the bootstrap
+      // capability it pushes an `auth_bootstrap` burst frame carrying the
+      // provider / slash-command / agent lists right after auth_ok. In that
+      // case we SKIP the 3 connect-time list requests (they arrive unsolicited
+      // in the burst). Older servers don't set the flag, so we request as
+      // before. The list_* request paths stay live for post-connect refreshes.
+      _serverWillBootstrap = auth.serverCapabilities.authBootstrap === true;
+      const sendConnectListRequests = () => {
+        if (_serverWillBootstrap) return;
+        wsSend(ctx.socket, { type: 'list_providers' });
+        wsSend(ctx.socket, { type: 'list_slash_commands' });
+        wsSend(ctx.socket, { type: 'list_agents' });
+      };
+
       // Start client-side heartbeat for dead connection detection
       startHeartbeat(ctx.socket);
 
@@ -2510,28 +2542,45 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // If the server honoured the eager path it returns its public key in
         // auth_ok; derive the shared key immediately and start the burst a full
         // RTT earlier than the discrete handshake.
+        //
+        // #5555 follow-up (hardening) — `auth.serverPublicKey` is shared-parser
+        // normalized (empty/non-string → null) but a non-empty MALFORMED value
+        // (bad base64 / wrong length) still passes that filter and makes
+        // `deriveSharedKey` throw. The discrete `key_exchange_ok` handler
+        // guards against a bad key; mirror that here by wrapping the eager
+        // derivation in try/catch and FALLING BACK to the discrete handshake
+        // on any failure instead of letting the throw tear down the connection.
+        let eagerEstablished = false;
         if (auth.serverPublicKey && _pendingKeyPair) {
-          const rawSharedKey = deriveSharedKey(auth.serverPublicKey, _pendingKeyPair.secretKey);
-          const encryptionKey = _pendingSalt
-            ? deriveConnectionKey(rawSharedKey, _pendingSalt)
-            : rawSharedKey;
-          _encryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 };
-          _pendingKeyPair = null;
-          _pendingSalt = null;
-          console.log('[crypto] E2E encryption established (eager)');
-          // Burst un-gated: server already activated encryption after auth_ok.
-          wsSend(ctx.socket, { type: 'list_providers' });
-          wsSend(ctx.socket, { type: 'list_slash_commands' });
-          wsSend(ctx.socket, { type: 'list_agents' });
-          resetClientVisibleMemo();
-          if (typeof document !== 'undefined') {
-            sendClientVisible(ctx.socket, document.visibilityState === 'visible');
+          try {
+            const rawSharedKey = deriveSharedKey(auth.serverPublicKey, _pendingKeyPair.secretKey);
+            const encryptionKey = _pendingSalt
+              ? deriveConnectionKey(rawSharedKey, _pendingSalt)
+              : rawSharedKey;
+            _encryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 };
+            _pendingKeyPair = null;
+            _pendingSalt = null;
+            eagerEstablished = true;
+            console.log('[crypto] E2E encryption established (eager)');
+            // Burst un-gated: server already activated encryption after auth_ok.
+            sendConnectListRequests();
+            resetClientVisibleMemo();
+            if (typeof document !== 'undefined') {
+              sendClientVisible(ctx.socket, document.visibilityState === 'visible');
+            }
+          } catch (err) {
+            // Malformed eager key — discard any partial state and fall through
+            // to the discrete handshake below (regenerating the keypair if the
+            // eager attempt consumed it).
+            console.warn('[crypto] Eager key derivation failed, falling back to discrete key_exchange', err);
+            _encryptionState = null;
           }
-        } else {
-          // Fallback (old server / eager derivation declined): the keypair is
-          // still stashed from onopen — send the discrete key_exchange. If
-          // onopen never ran (defensive), regenerate so we never send an empty
-          // handshake.
+        }
+        if (!eagerEstablished) {
+          // Fallback (old server / no eager key / eager derivation failed): the
+          // keypair is still stashed from onopen — send the discrete
+          // key_exchange. If onopen never ran (defensive) or the eager attempt
+          // nulled it, regenerate so we never send an empty handshake.
           if (!_pendingKeyPair) {
             _pendingKeyPair = createKeyPair();
             _pendingSalt = generateConnectionSalt();
@@ -2542,9 +2591,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       } else {
         // No encryption — send post-auth messages immediately
-        wsSend(ctx.socket, { type: 'list_providers' });
-        wsSend(ctx.socket, { type: 'list_slash_commands' });
-        wsSend(ctx.socket, { type: 'list_agents' });
+        sendConnectListRequests();
         // #3671: server defaults visible=true on a fresh connect; sync if we
         // reconnected while the tab was hidden so completion pushes fire.
         resetClientVisibleMemo();
@@ -2577,10 +2624,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         _pendingKeyPair = null;
         _pendingSalt = null;
         console.log('[crypto] E2E encryption established');
-        // Now send the post-auth messages that were deferred
-        wsSend(ctx.socket, { type: 'list_providers' });
-        wsSend(ctx.socket, { type: 'list_slash_commands' });
-        wsSend(ctx.socket, { type: 'list_agents' });
+        // Now send the post-auth messages that were deferred. #5555: skip the
+        // 3 list requests when the server advertised the auth_bootstrap
+        // capability (the burst frame already carries that data, queued behind
+        // encryption and decrypted once this handshake completes).
+        if (!_serverWillBootstrap) {
+          wsSend(ctx.socket, { type: 'list_providers' });
+          wsSend(ctx.socket, { type: 'list_slash_commands' });
+          wsSend(ctx.socket, { type: 'list_agents' });
+        }
         // #3671: sync visibility once encryption is established (mirrors the
         // unencrypted auth_ok path above).
         resetClientVisibleMemo();
@@ -3739,6 +3791,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const providerResult = sharedProviderList(msg);
       if (!providerResult) break;
       set({ availableProviders: providerResult.providers as ProviderInfo[] });
+      break;
+    }
+
+    case 'auth_bootstrap': {
+      // #5555 — connect-time bootstrap burst folds the provider / slash-command
+      // / agent lists into one server-initiated frame so the client skips its
+      // 3-request connect-time round trip. Apply each list through the SAME
+      // store mutations the discrete responses use.
+      const boot = sharedAuthBootstrap(msg);
+      set({ availableProviders: boot.providers as ProviderInfo[] });
+      // Slash commands + agents are scoped to the connect-time active session.
+      // Guard against a stale burst: if a session switch already moved the
+      // active id off the burst's `sessionId`, skip the session-scoped lists
+      // (the post-switch flow re-requests them) but keep the server-wide
+      // provider list applied above.
+      const activeId = get().activeSessionId;
+      if (boot.sessionId && activeId && boot.sessionId !== activeId) break;
+      set({ slashCommands: boot.slashCommands as SlashCommand[] });
+      set({ customAgents: boot.agents as CustomAgent[] });
       break;
     }
 

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -65,7 +65,11 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
         quickTunnel: z.ZodBoolean;
     }, z.core.$strip>>;
     serverPublicKey: z.ZodOptional<z.ZodString>;
-    availablePermissionModes: z.ZodOptional<z.ZodArray<z.ZodString>>;
+    availablePermissionModes: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        label: z.ZodString;
+        description: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;
@@ -1818,7 +1822,7 @@ export declare const ServerProviderListSchema: z.ZodObject<{
 }, z.core.$strip>;
 export declare const ServerAuthBootstrapSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_bootstrap">;
-    providers: z.ZodOptional<z.ZodArray<z.ZodObject<{
+    providers: z.ZodDefault<z.ZodArray<z.ZodObject<{
         name: z.ZodString;
         capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
         auth: z.ZodOptional<z.ZodObject<{
@@ -1834,12 +1838,12 @@ export declare const ServerAuthBootstrapSchema: z.ZodObject<{
             detail: z.ZodString;
         }, z.core.$strip>>;
     }, z.core.$strip>>>;
-    slashCommands: z.ZodOptional<z.ZodArray<z.ZodObject<{
+    slashCommands: z.ZodDefault<z.ZodArray<z.ZodObject<{
         name: z.ZodString;
         description: z.ZodOptional<z.ZodString>;
         source: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>>;
-    agents: z.ZodOptional<z.ZodArray<z.ZodObject<{
+    agents: z.ZodDefault<z.ZodArray<z.ZodObject<{
         name: z.ZodString;
         description: z.ZodOptional<z.ZodString>;
         source: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -65,6 +65,7 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
         quickTunnel: z.ZodBoolean;
     }, z.core.$strip>>;
     serverPublicKey: z.ZodOptional<z.ZodString>;
+    availablePermissionModes: z.ZodOptional<z.ZodArray<z.ZodString>>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;
@@ -1815,6 +1816,36 @@ export declare const ServerProviderListSchema: z.ZodObject<{
         }, z.core.$strip>>;
     }, z.core.$strip>>;
 }, z.core.$strip>;
+export declare const ServerAuthBootstrapSchema: z.ZodObject<{
+    type: z.ZodLiteral<"auth_bootstrap">;
+    providers: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        name: z.ZodString;
+        capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
+        auth: z.ZodOptional<z.ZodObject<{
+            ready: z.ZodBoolean;
+            source: z.ZodEnum<{
+                none: "none";
+                env: "env";
+                oauth: "oauth";
+            }>;
+            envVar: z.ZodNullable<z.ZodString>;
+            envVars: z.ZodArray<z.ZodString>;
+            hint: z.ZodString;
+            detail: z.ZodString;
+        }, z.core.$strip>>;
+    }, z.core.$strip>>>;
+    slashCommands: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        name: z.ZodString;
+        description: z.ZodOptional<z.ZodString>;
+        source: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>>;
+    agents: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        name: z.ZodString;
+        description: z.ZodOptional<z.ZodString>;
+        source: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ServerSkillsListSchema: z.ZodObject<{
     type: z.ZodLiteral<"skills_list">;
     skills: z.ZodArray<z.ZodObject<{
@@ -2215,6 +2246,7 @@ export type ServerSessionStoppedMessage = z.infer<typeof ServerSessionStoppedSch
 export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>;
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
+export type ServerAuthBootstrapMessage = z.infer<typeof ServerAuthBootstrapSchema>;
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>;
 export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewriteSchema>;
 export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -115,6 +115,12 @@ export const ServerAuthOkSchema = z.object({
     // the server predates #5555 (old server) — in every absent case the client
     // falls back to the discrete `key_exchange` handshake. No flag day.
     serverPublicKey: z.string().max(512).optional(),
+    // #5555 (auth_bootstrap) — fold the static permission-mode enum into auth_ok
+    // so a new client reads it here instead of waiting for the discrete
+    // `available_permission_modes` burst frame (still sent for older clients).
+    // Optional: servers from before #5555 omit it and clients fall back to the
+    // discrete frame.
+    availablePermissionModes: z.array(z.string()).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),
@@ -1674,6 +1680,35 @@ export const ServerProviderListSchema = z.object({
         auth: ProviderAuthSchema.optional(),
     })),
 });
+// #5555 (auth_bootstrap) — single connect-time burst frame that carries the
+// provider / slash-command / agent lists right after auth_ok, so a new client
+// can SKIP its 3-request `list_providers` / `list_slash_commands` /
+// `list_agents` round trip. Payloads mirror the respective request responses
+// (`provider_list`, `slash_commands`, `agent_list`) so clients reuse their
+// existing per-list handlers to consume them. Each list is optional and
+// defaults to empty so a partial server compute (e.g. an unreadable agents
+// dir) still parses. `passthrough()` keeps the frame forward-compatible.
+export const ServerAuthBootstrapSchema = z.object({
+    type: z.literal('auth_bootstrap'),
+    providers: z.array(z.object({
+        name: z.string(),
+        capabilities: z.record(z.string(), z.boolean()).optional(),
+        auth: ProviderAuthSchema.optional(),
+    })).optional(),
+    slashCommands: z.array(z.object({
+        name: z.string(),
+        description: z.string().optional(),
+        source: z.string().optional(),
+    })).optional(),
+    agents: z.array(z.object({
+        name: z.string(),
+        description: z.string().optional(),
+        source: z.string().optional(),
+    })).optional(),
+    // The active session id this burst was scoped to, when applicable. Lets a
+    // client ignore a stale burst if it has already switched sessions.
+    sessionId: z.string().optional(),
+}).passthrough();
 export const ServerSkillsListSchema = z.object({
     type: z.literal('skills_list'),
     skills: z.array(z.object({

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -120,7 +120,15 @@ export const ServerAuthOkSchema = z.object({
     // `available_permission_modes` burst frame (still sent for older clients).
     // Optional: servers from before #5555 omit it and clients fall back to the
     // discrete frame.
-    availablePermissionModes: z.array(z.string()).optional(),
+    // Object array — each entry is `{ id, label, description? }` (server
+    // `PERMISSION_MODES`), the SAME shape as the discrete
+    // `available_permission_modes` frame's `modes`. (#5592 review: a
+    // `z.array(z.string())` here would reject a real new-server auth_ok.)
+    availablePermissionModes: z.array(z.object({
+        id: z.string(),
+        label: z.string(),
+        description: z.string().optional(),
+    })).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),
@@ -1694,17 +1702,17 @@ export const ServerAuthBootstrapSchema = z.object({
         name: z.string(),
         capabilities: z.record(z.string(), z.boolean()).optional(),
         auth: ProviderAuthSchema.optional(),
-    })).optional(),
+    })).default([]),
     slashCommands: z.array(z.object({
         name: z.string(),
         description: z.string().optional(),
         source: z.string().optional(),
-    })).optional(),
+    })).default([]),
     agents: z.array(z.object({
         name: z.string(),
         description: z.string().optional(),
         source: z.string().optional(),
-    })).optional(),
+    })).default([]),
     // The active session id this burst was scoped to, when applicable. Lets a
     // client ignore a stale burst if it has already switched sessions.
     sessionId: z.string().optional(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -123,7 +123,15 @@ export const ServerAuthOkSchema = z.object({
   // `available_permission_modes` burst frame (still sent for older clients).
   // Optional: servers from before #5555 omit it and clients fall back to the
   // discrete frame.
-  availablePermissionModes: z.array(z.string()).optional(),
+  // Object array — each entry is `{ id, label, description? }` (server
+  // `PERMISSION_MODES`), the SAME shape as the discrete
+  // `available_permission_modes` frame's `modes`. (#5592 review: a
+  // `z.array(z.string())` here would reject a real new-server auth_ok.)
+  availablePermissionModes: z.array(z.object({
+    id: z.string(),
+    label: z.string(),
+    description: z.string().optional(),
+  })).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({
@@ -1794,17 +1802,17 @@ export const ServerAuthBootstrapSchema = z.object({
     name: z.string(),
     capabilities: z.record(z.string(), z.boolean()).optional(),
     auth: ProviderAuthSchema.optional(),
-  })).optional(),
+  })).default([]),
   slashCommands: z.array(z.object({
     name: z.string(),
     description: z.string().optional(),
     source: z.string().optional(),
-  })).optional(),
+  })).default([]),
   agents: z.array(z.object({
     name: z.string(),
     description: z.string().optional(),
     source: z.string().optional(),
-  })).optional(),
+  })).default([]),
   // The active session id this burst was scoped to, when applicable. Lets a
   // client ignore a stale burst if it has already switched sessions.
   sessionId: z.string().optional(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -118,6 +118,12 @@ export const ServerAuthOkSchema = z.object({
   // the server predates #5555 (old server) — in every absent case the client
   // falls back to the discrete `key_exchange` handshake. No flag day.
   serverPublicKey: z.string().max(512).optional(),
+  // #5555 (auth_bootstrap) — fold the static permission-mode enum into auth_ok
+  // so a new client reads it here instead of waiting for the discrete
+  // `available_permission_modes` burst frame (still sent for older clients).
+  // Optional: servers from before #5555 omit it and clients fall back to the
+  // discrete frame.
+  availablePermissionModes: z.array(z.string()).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({
@@ -1774,6 +1780,36 @@ export const ServerProviderListSchema = z.object({
   })),
 })
 
+// #5555 (auth_bootstrap) — single connect-time burst frame that carries the
+// provider / slash-command / agent lists right after auth_ok, so a new client
+// can SKIP its 3-request `list_providers` / `list_slash_commands` /
+// `list_agents` round trip. Payloads mirror the respective request responses
+// (`provider_list`, `slash_commands`, `agent_list`) so clients reuse their
+// existing per-list handlers to consume them. Each list is optional and
+// defaults to empty so a partial server compute (e.g. an unreadable agents
+// dir) still parses. `passthrough()` keeps the frame forward-compatible.
+export const ServerAuthBootstrapSchema = z.object({
+  type: z.literal('auth_bootstrap'),
+  providers: z.array(z.object({
+    name: z.string(),
+    capabilities: z.record(z.string(), z.boolean()).optional(),
+    auth: ProviderAuthSchema.optional(),
+  })).optional(),
+  slashCommands: z.array(z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    source: z.string().optional(),
+  })).optional(),
+  agents: z.array(z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    source: z.string().optional(),
+  })).optional(),
+  // The active session id this burst was scoped to, when applicable. Lets a
+  // client ignore a stale burst if it has already switched sessions.
+  sessionId: z.string().optional(),
+}).passthrough()
+
 export const ServerSkillsListSchema = z.object({
   type: z.literal('skills_list'),
   skills: z.array(z.object({
@@ -2351,6 +2387,7 @@ export type ServerSessionStoppedMessage = z.infer<typeof ServerSessionStoppedSch
 export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
+export type ServerAuthBootstrapMessage = z.infer<typeof ServerAuthBootstrapSchema>
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>
 export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewriteSchema>
 export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>

--- a/packages/server/src/ws-file-ops/browser.js
+++ b/packages/server/src/ws-file-ops/browser.js
@@ -398,7 +398,13 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
    *   to look up built-ins. Null/unknown providers skip the built-in merge
    *   (picker still shows project + user commands).
    */
-  async function listSlashCommands(ws, cwd, sessionId, providerName = null) {
+  /**
+   * Compute the merged slash-command list (built-ins + project/user .md files)
+   * without touching the socket. Shared by the `list_slash_commands` request
+   * path (`listSlashCommands`) and the connect-time `auth_bootstrap` burst
+   * (#5555) so both produce an identical `commands` array.
+   */
+  async function computeSlashCommands(cwd, providerName = null) {
     const commands = []
     const seen = new Set()
 
@@ -467,6 +473,11 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
       return a.name.localeCompare(b.name)
     })
 
+    return commands
+  }
+
+  async function listSlashCommands(ws, cwd, sessionId, providerName = null) {
+    const commands = await computeSlashCommands(cwd, providerName)
     const response = { type: 'slash_commands', commands }
     if (sessionId) response.sessionId = sessionId
     sendFn(ws, response)
@@ -482,7 +493,12 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
    * @param {string[]} [opts.userAgentsDirs] - Override the list of user-level agent directories
    *   to scan (#2965). When omitted, defaults to [~/.claude/agents].
    */
-  async function listAgents(ws, cwd, sessionId, opts = {}) {
+  /**
+   * Compute the merged custom-agent list (project + user `.claude/agents`)
+   * without touching the socket. Shared by the `list_agents` request path
+   * (`listAgents`) and the connect-time `auth_bootstrap` burst (#5555).
+   */
+  async function computeAgents(cwd, opts = {}) {
     /**
      * List the candidate agent .md files in a single directory. Returns
      * `{ dir, source, filenames[] }`. Errors (missing dir, unreadable, etc.)
@@ -556,6 +572,11 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
 
     agents.sort((a, b) => a.name.localeCompare(b.name))
 
+    return agents
+  }
+
+  async function listAgents(ws, cwd, sessionId, opts = {}) {
+    const agents = await computeAgents(cwd, opts)
     const response = { type: 'agent_list', agents }
     if (sessionId) response.sessionId = sessionId
     sendFn(ws, response)
@@ -567,5 +588,7 @@ export function createBrowserOps(sendFn, resolveSessionCwd, validatePathWithinCw
     listFiles,
     listSlashCommands,
     listAgents,
+    computeSlashCommands,
+    computeAgents,
   }
 }

--- a/packages/server/src/ws-file-ops/index.js
+++ b/packages/server/src/ws-file-ops/index.js
@@ -38,6 +38,10 @@ export function createFileOps(sendFn, workspaceRoot) {
     getDiff: reader.getDiff,
     listSlashCommands: browser.listSlashCommands,
     listAgents: browser.listAgents,
+    // #5555: socket-free compute variants for the connect-time auth_bootstrap
+    // burst — same payloads as the list_* request responses, no ws send.
+    computeSlashCommands: browser.computeSlashCommands,
+    computeAgents: browser.computeAgents,
     listFiles: browser.listFiles,
     gitStatus: git.gitStatus,
     gitBranches: git.gitBranches,

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -222,6 +222,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // arrive — instead the section either hides itself or surfaces a
     // "not supported on this server" message.
     notificationPrefs: true,
+    // #5555 — this server emits an `auth_bootstrap` burst frame carrying the
+    // provider / slash-command / agent lists right after auth_ok, so a new
+    // client can SKIP its 3-request connect-time round trip (list_providers /
+    // list_slash_commands / list_agents). Clients that don't see this flag
+    // (older server) fall back to requesting the three lists as before. The
+    // request handlers stay live either way for post-connect refreshes.
+    authBootstrap: true,
   }
 
   // #3760, #3905: surface the effective inactivity timeouts so clients
@@ -284,6 +291,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     webFeatures: webTaskManager.getFeatureStatus(),
     features,
     capabilities,
+    // #5555 — fold the static permission-mode enum into auth_ok so a new
+    // client never has to wait for (or react to) the discrete
+    // `available_permission_modes` burst frame. The discrete frame is still
+    // sent below for older clients that read the enum only from it.
+    availablePermissionModes: PERMISSION_MODES,
     resultTimeoutMs: effectiveResultTimeoutMs,
     hardTimeoutMs: effectiveHardTimeoutMs,
     streamStallTimeoutMs: effectiveStreamStallTimeoutMs,
@@ -465,6 +477,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     scheduleProviderModelsRefresh(ctx, ws, activeProvider)
     send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
     permissions.resendPendingPermissions(ws, client)
+    // #5555: fire the connect-time bootstrap burst (providers + slash commands
+    // + agents) so a new client never sends its 3-request list_* round trip.
+    // Fire-and-forget — the slash/agent compute is async (disk scans) and the
+    // synchronous post-auth burst above must not block on it.
+    sendAuthBootstrap(ctx, ws, { cwd: entry?.cwd || null, provider: activeProvider, sessionId: activeId })
     return
   }
 
@@ -493,6 +510,90 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   }
 
   permissions.resendPendingPermissions(ws)
+  // #5555: legacy single-session bootstrap burst — providers + slash commands
+  // + agents for the cliSession's cwd (no provider scoping in legacy mode).
+  sendAuthBootstrap(ctx, ws, { cwd: cliSession?.cwd || null, provider: null, sessionId: null })
+}
+
+/**
+ * #5555 (auth_bootstrap) — compute the provider / slash-command / agent lists
+ * and push them in a single `auth_bootstrap` burst frame right after the
+ * post-auth sync block. This is the server half of the round-trip collapse:
+ * a new client (one that saw `capabilities.authBootstrap` in auth_ok) consumes
+ * these payloads and SKIPS its connect-time `list_providers` /
+ * `list_slash_commands` / `list_agents` requests.
+ *
+ * Fire-and-forget by design: the slash-command and agent computes scan disk
+ * (project + user `.claude/{commands,agents}`), so awaiting them inline would
+ * stall the synchronous post-auth burst. We compute in the background and emit
+ * the frame when ready; if the socket has since closed, the send is a no-op.
+ *
+ * The payloads are byte-identical to the `provider_list` / `slash_commands` /
+ * `agent_list` request responses (same `listProviders()` and the shared
+ * `computeSlashCommands` / `computeAgents` used by the request handlers), so
+ * the client reuses its existing per-message handlers to consume them.
+ *
+ * Resilient: each list is computed independently; a failure in one (e.g. an
+ * unreadable agents dir) still ships the others. A total failure ships an
+ * empty bootstrap so the client doesn't sit waiting for data that never comes
+ * — it can always refresh later via the (still-live) list_* request paths.
+ *
+ * @param {object} ctx
+ * @param {WebSocket} ws
+ * @param {{ cwd: string|null, provider: string|null, sessionId: string|null }} info
+ */
+function sendAuthBootstrap(ctx, ws, info = {}) {
+  const { send, services } = ctx
+  const fileOps = ctx.fileOps || services?.fileOps || null
+  const cwd = info.cwd || null
+  const provider = info.provider || null
+
+  // providers is a cheap synchronous read off the registry — same source as
+  // the list_providers handler.
+  let providers = []
+  try {
+    providers = listProviders()
+  } catch (err) {
+    log.warn(`auth_bootstrap: listProviders failed: ${err.message}`)
+    providers = []
+  }
+
+  // slash commands + agents are async disk scans; compute in parallel and
+  // tolerate either failing on its own.
+  const slashP = fileOps && typeof fileOps.computeSlashCommands === 'function'
+    ? fileOps.computeSlashCommands(cwd, provider).catch(err => {
+        log.warn(`auth_bootstrap: computeSlashCommands failed: ${err.message}`)
+        return []
+      })
+    : Promise.resolve([])
+  const userAgentsDirs = ctx.userAgentsDirs
+  const agentsOpts = Array.isArray(userAgentsDirs) && userAgentsDirs.length > 0
+    ? { userAgentsDirs }
+    : {}
+  const agentsP = fileOps && typeof fileOps.computeAgents === 'function'
+    ? fileOps.computeAgents(cwd, agentsOpts).catch(err => {
+        log.warn(`auth_bootstrap: computeAgents failed: ${err.message}`)
+        return []
+      })
+    : Promise.resolve([])
+
+  Promise.all([slashP, agentsP]).then(([slashCommands, agents]) => {
+    // Socket may have closed while the disk scans were in flight — bail out
+    // rather than sending to a dead peer.
+    if (ws.readyState !== 1) return
+    send(ws, {
+      type: 'auth_bootstrap',
+      providers,
+      slashCommands,
+      agents,
+      ...(info.sessionId ? { sessionId: info.sessionId } : {}),
+    })
+  }).catch(err => {
+    // Defensive: Promise.all here can only reject if one of the .catch handlers
+    // above itself threw, which they don't — but never let a bootstrap failure
+    // surface as an unhandled rejection.
+    log.warn(`auth_bootstrap: burst failed for ${ctx.clients?.get(ws)?.id || 'client'}: ${err.message}`)
+  })
 }
 
 /**

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -305,6 +305,7 @@ function _isSecureRequest(req) {
  *   All session-scoped messages include a `sessionId` field for background sync.
  *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs } — auth succeeded (encryption: 'required'|'disabled'; resultTimeoutMs = soft-warning window in ms, hardTimeoutMs = hard-kill window in ms, streamStallTimeoutMs = stream-stall recovery window in ms (0 = disabled) — #3760, #3905, #4477)
  *   { type: 'key_exchange_ok', publicKey }               — server's ephemeral X25519 public key (E2E encryption)
+ *   { type: 'auth_bootstrap', providers, slashCommands, agents, sessionId? } — #5555: connect-time burst folding the provider/slash-command/agent lists so a new client skips its 3-request list_* round trip
  *   { type: 'auth_fail',    reason: '...' }           — auth failed
  *   { type: 'server_mode',  mode: 'cli' }             — which backend mode is active
  *   { type: 'message',      ... }                     — parsed chat message
@@ -785,6 +786,12 @@ export class WsServer {
       // surfaced in auth_ok so the dashboard can render a warning banner.
       // null until start() has bound a socket.
       get exposure() { return self.exposure },
+      // #5555 (auth_bootstrap): file ops + provider agent dirs so the
+      // connect-time bootstrap burst can compute the slash-command / agent
+      // lists inline (same payloads the list_* request handlers produce),
+      // letting the client skip its 3-request connect-time round trip.
+      get fileOps() { return self._fileOps },
+      get userAgentsDirs() { return getProviderDataDirs().map(d => join(d, 'agents')) },
     }
     this._authCtx = {
       get clients() { return self.clients },

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -792,6 +792,146 @@ describe('sendPostAuthInfo — eager key exchange (#5555)', () => {
   })
 })
 
+// ── #5555: auth_bootstrap burst coalescing ───────────────────────────────────
+//
+// The server folds the static permission-mode enum into auth_ok and advertises
+// `capabilities.authBootstrap: true`, then pushes a single `auth_bootstrap`
+// burst frame (providers + slashCommands + agents) so a new client can SKIP its
+// 3-request connect-time list_* round trip. The discrete frames
+// (available_permission_modes) stay for older clients. These tests assert the
+// new-client content, that old-client behaviour is unchanged, and that the
+// burst no-ops on a closed socket.
+
+/**
+ * Fake fileOps whose compute methods return fixed lists, so the bootstrap test
+ * can assert the exact payloads without touching the disk. Mirrors the
+ * production createFileOps surface used by sendAuthBootstrap.
+ */
+function makeFakeFileOps(slashCommands, agents) {
+  return {
+    computeSlashCommands: async () => slashCommands,
+    computeAgents: async () => agents,
+  }
+}
+
+describe('sendPostAuthInfo — auth_bootstrap (#5555)', () => {
+  it('auth_ok advertises capabilities.authBootstrap and folds availablePermissionModes', () => {
+    const ctx = makeCtx()
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    assert.equal(authOk.capabilities.authBootstrap, true)
+    assert.deepEqual(authOk.availablePermissionModes, PERMISSION_MODES)
+  })
+
+  it('still sends the discrete available_permission_modes frame (old-client compat)', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-1' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    const permModes = ctx._sends.find(m => m.type === 'available_permission_modes')
+    assert.ok(permModes, 'discrete available_permission_modes frame still sent')
+    assert.deepEqual(permModes.modes, PERMISSION_MODES)
+  })
+
+  it('multi-session: emits an auth_bootstrap burst with providers + slashCommands + agents', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    const slash = [{ name: 'clear', description: 'clear', source: 'builtin' }]
+    const agents = [{ name: 'reviewer', description: 'review', source: 'project' }]
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: 'sess-1',
+      fileOps: makeFakeFileOps(slash, agents),
+    })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    // Bootstrap is fire-and-forget (async disk compute) — drain microtasks.
+    await new Promise(r => setImmediate(r))
+
+    const boot = ctx._sends.find(m => m.type === 'auth_bootstrap')
+    assert.ok(boot, 'auth_bootstrap burst frame was sent')
+    assert.ok(Array.isArray(boot.providers), 'providers present')
+    assert.ok(boot.providers.length > 0, 'providers non-empty (registry seeded)')
+    assert.deepEqual(boot.slashCommands, slash)
+    assert.deepEqual(boot.agents, agents)
+    assert.equal(boot.sessionId, 'sess-1')
+  })
+
+  it('legacy single-session: emits an auth_bootstrap burst scoped to the cliSession cwd', async () => {
+    const slash = [{ name: 'help', description: 'help', source: 'builtin' }]
+    const agents = []
+    const cliSession = { cwd: '/opt/project', isReady: false, model: null, permissionMode: 'approve' }
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ cliSession, fileOps: makeFakeFileOps(slash, agents) })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    await new Promise(r => setImmediate(r))
+
+    const boot = ctx._sends.find(m => m.type === 'auth_bootstrap')
+    assert.ok(boot, 'auth_bootstrap burst sent in legacy mode')
+    assert.deepEqual(boot.slashCommands, slash)
+    assert.deepEqual(boot.agents, agents)
+    // No active session id in legacy mode.
+    assert.equal(Object.prototype.hasOwnProperty.call(boot, 'sessionId'), false)
+  })
+
+  it('ships empty lists when no fileOps is wired (graceful degrade)', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    const ws = makeFakeWs()
+    // No fileOps in ctx → slash/agents compute path falls back to [].
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-1' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    await new Promise(r => setImmediate(r))
+
+    const boot = ctx._sends.find(m => m.type === 'auth_bootstrap')
+    assert.ok(boot, 'auth_bootstrap still sent without fileOps')
+    assert.deepEqual(boot.slashCommands, [])
+    assert.deepEqual(boot.agents, [])
+    // Providers still come from the registry (synchronous, fileOps-independent).
+    assert.ok(Array.isArray(boot.providers))
+  })
+
+  it('does not send the burst when the socket closed before the compute resolved', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    // computeSlashCommands resolves on a later microtask; close the ws first.
+    let resolveSlash
+    const fileOps = {
+      computeSlashCommands: () => new Promise(r => { resolveSlash = () => r([]) }),
+      computeAgents: async () => [],
+    }
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-1', fileOps })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    // Socket closes while the compute is in flight.
+    ws.readyState = 3 // CLOSED
+    resolveSlash()
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+
+    const boot = ctx._sends.find(m => m.type === 'auth_bootstrap')
+    assert.equal(boot, undefined, 'no burst frame after the socket closed')
+  })
+})
+
 // ── sendSessionInfo ────────────────────────────────────────────────────────
 
 describe('sendSessionInfo', () => {

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1021,8 +1021,11 @@ describe('outbound message sequence numbers', () => {
 
     const { ws, messages } = await createClient(port, true)
 
-    // Wait for initial messages to settle (auth_ok, server_mode, status, etc.)
+    // Wait for initial messages to settle (auth_ok, server_mode, status, etc.).
+    // #5555: also wait for the async auth_bootstrap burst so it's included in
+    // the monotonic-seq sweep deterministically rather than racing the assert.
     await waitForMessage(messages, 'status')
+    await waitForMessage(messages, 'auth_bootstrap', 1000)
 
     // All messages should have a seq field
     assert.ok(messages.length > 0, 'Should have received messages')
@@ -1051,8 +1054,12 @@ describe('outbound message sequence numbers', () => {
 
     const { ws, messages } = await createClient(port, true)
 
-    // Wait for initial messages
+    // Wait for initial messages. #5555: the connect-time auth_bootstrap burst
+    // (providers + slash commands + agents) is fire-and-forget (async disk
+    // scans), so it can land AFTER `status`. Wait for it before snapshotting the
+    // count so the pong-seq continuity check isn't shifted by a late burst frame.
     await waitForMessage(messages, 'status')
+    await waitForMessage(messages, 'auth_bootstrap', 1000)
 
     const initialCount = messages.length
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -65,6 +65,7 @@ import {
   handleSlashCommands,
   handleAgentList,
   handleProviderList,
+  handleAuthBootstrap,
   handleFileList,
   handleDiffResult,
   handleGitStatusResult,
@@ -1456,6 +1457,11 @@ describe('handleAuthOk', () => {
       webFeatures: { available: true, remote: false, teleport: true },
       capabilities: { notificationPrefs: true, somethingElse: false },
       serverPublicKey: 'srv-pub-key',
+      // #5555 — folded static permission-mode enum.
+      availablePermissionModes: [
+        { id: 'approve', label: 'Approve' },
+        { id: 'auto', label: 'Auto' },
+      ],
     })
     expect(result).toEqual({
       serverMode: 'cli',
@@ -1473,6 +1479,10 @@ describe('handleAuthOk', () => {
       webFeatures: { available: true, remote: false, teleport: true },
       serverCapabilities: { notificationPrefs: true, somethingElse: false },
       serverPublicKey: 'srv-pub-key',
+      availablePermissionModes: [
+        { id: 'approve', label: 'Approve' },
+        { id: 'auto', label: 'Auto' },
+      ],
     })
   })
 
@@ -1708,6 +1718,7 @@ describe('handleAuthOk', () => {
       webFeatures: { available: false, remote: false, teleport: false },
       serverCapabilities: {},
       serverPublicKey: null,
+      availablePermissionModes: null,
     })
   })
 })
@@ -3485,6 +3496,40 @@ describe('handleProviderList', () => {
     expect(handleProviderList({ providers: 'oops' })).toBeNull()
     expect(handleProviderList({ providers: { x: 1 } })).toBeNull()
     expect(handleProviderList({ providers: null })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleAuthBootstrap (#5555)
+// ---------------------------------------------------------------------------
+describe('handleAuthBootstrap', () => {
+  it('extracts all three lists + sessionId', () => {
+    const providers = [{ name: 'anthropic' }]
+    const slashCommands = [{ name: 'clear', source: 'builtin' }]
+    const agents = [{ name: 'reviewer', source: 'project' }]
+    expect(
+      handleAuthBootstrap({ type: 'auth_bootstrap', providers, slashCommands, agents, sessionId: 'sess-1' }),
+    ).toEqual({ providers, slashCommands, agents, sessionId: 'sess-1' })
+  })
+
+  it('defaults each missing list to [] and sessionId to null', () => {
+    expect(handleAuthBootstrap({ type: 'auth_bootstrap' })).toEqual({
+      providers: [],
+      slashCommands: [],
+      agents: [],
+      sessionId: null,
+    })
+  })
+
+  it('coerces non-array lists to [] independently (partial-compute tolerance)', () => {
+    expect(
+      handleAuthBootstrap({ providers: [{ name: 'x' }], slashCommands: 'oops', agents: null }),
+    ).toEqual({ providers: [{ name: 'x' }], slashCommands: [], agents: [], sessionId: null })
+  })
+
+  it('treats empty/non-string sessionId as null', () => {
+    expect(handleAuthBootstrap({ sessionId: '' }).sessionId).toBeNull()
+    expect(handleAuthBootstrap({ sessionId: 42 as unknown as string }).sessionId).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -818,6 +818,14 @@ export interface AuthOkPayload {
    * validation as `handleKeyExchangeOk`'s `publicKey`.
    */
   serverPublicKey: string | null
+  /**
+   * #5555 (auth_bootstrap) — the static permission-mode enum folded into
+   * auth_ok so a new client doesn't have to wait for the discrete
+   * `available_permission_modes` burst frame. Validated with the same shape
+   * checks as `handleAvailablePermissionModes`. Null when the field is absent
+   * (older server) — consumers then fall back to the discrete frame.
+   */
+  availablePermissionModes: PermissionMode[] | null
 }
 
 const DEFAULT_WEB_FEATURES: AuthOkWebFeatures = {
@@ -890,6 +898,11 @@ export function handleAuthOk(msg: Record<string, unknown>): AuthOkPayload {
     // empty-string serverPublicKey is treated as absent, not a usable key.
     serverPublicKey:
       typeof msg.serverPublicKey === 'string' && msg.serverPublicKey ? msg.serverPublicKey : null,
+    // #5555 — reuse the discrete-frame parser on the folded field. Absent /
+    // non-array → null so the consumer falls back to the discrete frame.
+    availablePermissionModes: Array.isArray(msg.availablePermissionModes)
+      ? handleAvailablePermissionModes({ modes: msg.availablePermissionModes })
+      : null,
   }
 }
 
@@ -2563,6 +2576,34 @@ export function handleProviderList(
 ): { providers: unknown[] } | null {
   if (!Array.isArray(msg.providers)) return null
   return { providers: msg.providers as unknown[] }
+}
+
+/**
+ * #5555 (auth_bootstrap) — parse the connect-time bootstrap burst into the
+ * three list-replacement arrays. The frame folds `list_providers` /
+ * `list_slash_commands` / `list_agents` responses into one server-initiated
+ * push so a new client skips its connect-time request round trip.
+ *
+ * Each list is independent and defaults to `[]` when missing/non-array so a
+ * partial server compute (e.g. an unreadable agents dir shipped `[]` for that
+ * list only) still applies the lists that ARE present. Element shape is NOT
+ * validated here — consumers reuse the same per-list casts they apply to the
+ * discrete `provider_list` / `slash_commands` / `agent_list` messages.
+ *
+ * No session-id guard: providers are server-wide, and the slash/agent lists
+ * are scoped to the active session the server just restored for this connect
+ * (the same session the client lands on), so a connect-time burst is always
+ * for the right session. The optional `sessionId` is surfaced so a consumer
+ * CAN drop a stale burst if it has already switched away.
+ */
+export function handleAuthBootstrap(
+  msg: Record<string, unknown>,
+): { providers: unknown[]; slashCommands: unknown[]; agents: unknown[]; sessionId: string | null } {
+  const providers: unknown[] = Array.isArray(msg.providers) ? (msg.providers as unknown[]) : []
+  const slashCommands: unknown[] = Array.isArray(msg.slashCommands) ? (msg.slashCommands as unknown[]) : []
+  const agents: unknown[] = Array.isArray(msg.agents) ? (msg.agents as unknown[]) : []
+  const sessionId = typeof msg.sessionId === 'string' && msg.sessionId ? msg.sessionId : null
+  return { providers, slashCommands, agents, sessionId }
 }
 
 /**

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -459,6 +459,8 @@ export {
   handleSlashCommands,
   handleAgentList,
   handleProviderList,
+  // #5555 — connect-time bootstrap burst (providers + slash commands + agents)
+  handleAuthBootstrap,
   handleFileList,
   handleDiffResult,
   handleGitStatusResult,


### PR DESCRIPTION
Sub-item 2 of #5555 (cold-connect first-paint). The #5590 eager key exchange collapsed the handshake RTT; this collapses the *post-auth* burst — specifically the 3-request round trip a fresh client makes for `list_providers` / `list_slash_commands` / `list_agents` before it has the data it needs to render the create-session modal, slash-command palette, and agent picker.

## Round-trip / frame ledger (fresh connect)

Measured as discrete server→client frames + client→server requests after `auth_ok`, for an **encrypted** connect on a new client/new server.

| | Before | After |
|---|---|---|
| Client→server requests after auth_ok | **3** (`list_providers`, `list_slash_commands`, `list_agents`) | **0** |
| Connect-time application round trips | **1** (the 3 requests + their 3 responses) | **0** |
| Server burst frames carrying that data | 3 responses (`provider_list` + `slash_commands` + `agent_list`), each gated behind the client's request | **1** (`auth_bootstrap`, server-initiated) |
| `available_permission_modes` | discrete frame, client waits for it | folded into `auth_ok` (discrete frame still sent for old clients) |

Net: **−3 client→server requests, −1 application round trip** on every cold connect. The list data now arrives unsolicited in a single `auth_bootstrap` frame right after `auth_ok`, so first-paint of provider/slash/agent UI no longer waits a full RTT. `server_mode` / `status` are one-way burst frames (no RTT) and are left as-is for old-client compatibility — `auth_ok` already carries `serverMode`, and new clients read it from there.

## What changed

**Server** (`ws-history.js`, `ws-file-ops/`)
- `auth_ok` advertises `capabilities.authBootstrap: true` and folds the static `availablePermissionModes` enum. Discrete `server_mode` / `status` / `available_permission_modes` frames preserved unchanged.
- New fire-and-forget `auth_bootstrap` frame ships `providers` + `slashCommands` + `agents` (identical shapes to the `list_*` responses), scoped to the connect-time active session. The slash/agent payloads come from socket-free `computeSlashCommands` / `computeAgents` extracted from the existing request path (single source of truth — the request handlers now call the same compute). No-ops if the socket closed mid-compute; ships empty lists on a partial/failed disk scan so the client never blocks. Eager/discrete encryption gating preserved exactly (the burst is queued behind the discrete handshake, sent encrypted after the eager handshake).

**Protocol** (`@chroxy/protocol`, additive only, regenerated dist)
- `ServerAuthOkSchema` gains optional `availablePermissionModes`.
- New `ServerAuthBootstrapSchema` (every list optional, `passthrough`).

**Clients** (`app` + `dashboard`)
- Read `availablePermissionModes` from `auth_ok`; track `authBootstrap` and SKIP the 3 connect-time list requests in **both** the eager and discrete key-exchange paths when the flag is set. Fall back to requesting against an old server. The `list_*` request paths stay live for post-connect refresh.
- New `auth_bootstrap` handler applies the lists through the same store mutations + element validation the discrete responses use (shared `mapProviderList` on the app side), with a stale-session guard on the session-scoped lists.

**Hardening (#5590 review follow-up)**
The client eager-receive path passed `auth.serverPublicKey` to `deriveSharedKey` without the guard the discrete `key_exchange_ok` handler applies. The shared parser normalizes empty/non-string → null, but a **non-empty malformed** key (bad base64 / wrong length) passes that filter and makes `deriveSharedKey` throw, tearing down the whole connection. Both clients now wrap the eager derivation in try/catch and fall back to the discrete handshake on failure instead of throwing.

## Compatibility matrix

| Client \ Server | Old server (no `auth_bootstrap`) | New server |
|---|---|---|
| **Old client** | unchanged: 3 list requests, discrete frames | new server still sends the discrete frames + the 3 responses when requested; old client ignores `auth_bootstrap` / `availablePermissionModes` (additive fields) and the unsolicited burst |
| **New client** | no `authBootstrap` flag → requests the 3 lists as before | skips the 3 requests, consumes the burst; folds `availablePermissionModes` from `auth_ok` |

No flag day in either direction. All new wire fields/messages are additive and optional.

## Tests / lint

- **Server**: new `auth_bootstrap` content (multi-session + legacy), old-client discrete-frame compat, graceful degrade without `fileOps`, socket-closed no-op. `ws-history` 117/117, full suite green (the only 2 fails are the pre-existing `service.test.js` fetch-timeout flakes, confirmed failing on clean `origin/main`). All custom shell lints pass (opt-forwarding, state-file-path, ws-index-mutations) + eslint.
- **store-core**: `handleAuthBootstrap` + `availablePermissionModes` fold — 1264/1264.
- **app**: bootstrap skip / old-server fallback / permission-mode fold / burst consumption — full jest suite 1736/1736.
- **dashboard**: bootstrap skip / fallback / fold / burst + the malformed-eager-key fallback hardening test — full vitest suite 3538/3538.
- Typechecks green for protocol, store-core, app, dashboard.

Related to #5555