### PR TITLE
feat(ws): lastSeq delta replay + no-blank-flash reconcile (#5555.3/.4)

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -144,6 +144,10 @@ import {
   // to `useSpeechRecognition({ mode })`. Now gated by the same guard
   // the dashboard uses (#4853).
   isVoiceInputMode,
+  // #5555.3 — per-session history cursors for delta replay, sent in `auth`.
+  getHistoryCursors,
+  // #5555.4 — hard-reset the replay reconcile state on explicit disconnect.
+  resetReplayReconcile,
 } from '@chroxy/store-core';
 import type { InputSettings } from '@chroxy/store-core';
 import { setCallback as setImperativeCallback, getCallback, clearAllCallbacks } from './imperative-callbacks';
@@ -969,6 +973,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
             // stashed keypair. Generating eagerly is cheap and harmless even
             // when the server ends up not requiring encryption.
             const eager = prepareEagerKeyExchange();
+            // #5555.3 — send per-session history cursors so the server replays
+            // only entries newer than what we've applied. Empty on first
+            // connect → omitted → full replay (old-client shape).
+            const historyCursors = getHistoryCursors();
             socket.send(JSON.stringify({
               type: 'auth',
               token,
@@ -977,6 +985,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
               capabilities: CLIENT_CAPABILITIES.mobile,
               eagerPublicKey: eager.publicKey,
               eagerSalt: eager.salt,
+              ...(Object.keys(historyCursors).length > 0 ? { historyCursors } : {}),
             }));
           }
         }
@@ -1119,6 +1128,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     clearInactivityWarningsAcrossSessions(set, get);
     // Reset replay flags in case disconnect happened mid-replay
     resetReplayFlags();
+    // #5555.3/.4 — explicit disconnect is a hard reset: drop the replay
+    // baseline AND the history cursors so a later connect (possibly to a
+    // different server) starts from a full replay. Tunnel-blip RECONNECTS keep
+    // cursors (they don't run disconnect(); auth_ok clears only the baseline).
+    resetReplayReconcile({ clearCursors: true });
     // Flush and clear any pending delta buffer
     clearDeltaBuffers();
     // Clear permission boundary split tracking

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -69,6 +69,12 @@ import {
   handleConversationsList as sharedConversationsList,
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
+  // #5555.3 / #5555.4 — lastSeq cursor + no-blank-flash reconcile.
+  recordHistorySeq,
+  reconcileReplayStart,
+  reconcileReplayEnd,
+  replayDedupCache,
+  resetReplayReconcile,
   handlePermissionRequest as sharedPermissionRequest,
   handlePermissionResolved as sharedPermissionResolved,
   handlePermissionExpired as sharedPermissionExpired,
@@ -1242,6 +1248,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // per-session replaying set so a reconnect doesn't leave stale ids
       // gating future activity bumps).
       _ctx.replayingSessions.clear();
+      // #5555.4 — clear any in-progress replay BASELINE (a rebuild that never
+      // saw history_replay_end before the socket dropped). Cursors are RETAINED
+      // so this reconnect's replay can be incremental.
+      resetReplayReconcile();
       _ctx.isSessionSwitchReplay = false;
       _ctx.pendingSwitchSessionId = null;
       if (!ctx.isReconnect) hapticSuccess();
@@ -1746,19 +1756,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'history_replay_start': {
       // Parser is shared via store-core; flag mutation stays at this call
       // site (module-level _ctx state, not store state).
-      const { fullHistory, sessionId: replayTargetId } = sharedHistoryReplayStart(
+      const { fullHistory, sessionId: replayTargetId, latestSeq } = sharedHistoryReplayStart(
         msg,
         get().activeSessionId,
       );
       // #4512 — track per-session. Falls back to activeSessionId via
       // sharedHistoryReplayStart, matching the gate's targetId resolution.
       if (replayTargetId) _ctx.replayingSessions.add(replayTargetId);
-      // Full history replay (from request_full_history): clear messages before replay
+      // #5555.4 — DO NOT wipe messages here. Full rebuild keeps the existing
+      // messages visible and records a baseline; the authoritative replayed set
+      // is appended and swapped in atomically at history_replay_end (no blank
+      // flash). Delta replay (cursor honoured) is purely append-only.
+      // `isSessionSwitchReplay` still gates the same UX paths as before.
       if (fullHistory) {
         _ctx.isSessionSwitchReplay = true;
-        if (replayTargetId && get().sessionStates[replayTargetId]) {
-          updateSession(replayTargetId, () => ({ messages: [] }));
-        }
+      }
+      {
+        const curLen =
+          (replayTargetId && get().sessionStates[replayTargetId]?.messages.length) || 0;
+        reconcileReplayStart(replayTargetId, fullHistory, curLen, latestSeq);
       }
       // Clear transient state — these events are not replayed from history,
       // so any surviving entries are stale from pre-disconnect
@@ -1799,6 +1815,27 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const endTargetId =
           (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
         if (endTargetId) _ctx.replayingSessions.delete(endTargetId);
+        // #5555.4 — atomic swap for a full rebuild: replace messages with the
+        // appended replayed tail in ONE update (no blank flash). reconcileReplayEnd
+        // also advances the cursor from `latestSeq`; returns null for delta replay.
+        const endLatestSeq =
+          typeof msg.latestSeq === 'number' && Number.isFinite(msg.latestSeq)
+            ? msg.latestSeq
+            : undefined;
+        if (endTargetId && get().sessionStates[endTargetId]) {
+          const { swappedMessages } = reconcileReplayEnd(
+            endTargetId,
+            get().sessionStates[endTargetId]!.messages,
+            endLatestSeq,
+          );
+          if (swappedMessages) {
+            updateSession(endTargetId, () => ({
+              messages: swappedMessages as SessionState['messages'],
+            }));
+          }
+        } else {
+          reconcileReplayEnd(endTargetId, [], endLatestSeq);
+        }
       }
       _ctx.isSessionSwitchReplay = false;
       // Mark all replayed prompts as answered — any prompt in history
@@ -1835,11 +1872,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Use the shared resolver so trim / empty-string normalization stays
       // consistent with sharedMessageHandler and the rest of store-core.
       const targetId = resolveSessionId(msg, get().activeSessionId);
-      const cached = getSessionMessages(targetId);
+      // #5555.4 — during a full rebuild, dedup only against the appended replay
+      // tail so a replayed entry isn't suppressed by an id in the discarded
+      // prefix and lost in the swap. Delta replay / no rebuild → whole array.
+      const cached = replayDedupCache(targetId, getSessionMessages(targetId));
       // #4512 — dedup against history only when THIS message's session is
       // currently replaying. A per-connection boolean would suppress live
       // messages for session B while A replays.
       const messageIsReplay = targetId ? _ctx.replayingSessions.has(targetId) : false;
+      // #5555.3 — advance the cursor for replayed entries.
+      if (messageIsReplay) recordHistorySeq(targetId, (msg as { historySeq?: unknown }).historySeq);
       const result = sharedMessageHandler(msg, get().activeSessionId, messageIsReplay, cached);
       if (!result.shouldDispatch) break;
       const newMsg = result.chatMessage;
@@ -1991,12 +2033,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'tool_start': {
       const targetId = (msg.sessionId as string) || get().activeSessionId;
-      const cached = getSessionMessages(targetId);
+      // #5555.4 — scope dedup to the appended replay tail during a full rebuild
+      // (see the `message` case for rationale).
+      const cached = replayDedupCache(targetId, getSessionMessages(targetId));
       // #4512 — dedup against the cached history only when THIS message's
       // session is currently replaying. A per-connection boolean would
       // wrongly suppress live tool_start broadcasts for session B while A
       // is replaying.
       const toolStartIsReplay = targetId ? _ctx.replayingSessions.has(targetId) : false;
+      // #5555.3 — advance the cursor for replayed tool_start entries.
+      if (toolStartIsReplay) recordHistorySeq(targetId, (msg as { historySeq?: unknown }).historySeq);
       const result = sharedToolStart(
         msg,
         get().activeSessionId,

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -133,6 +133,10 @@ import {
   // #5163 (epic #5159): seed the Control Room activity state empty so the
   // reducer can apply snapshots/deltas immutably from the first message.
   createEmptyActivityState,
+  // #5555.3 — per-session history cursors for delta replay, sent in `auth`.
+  getHistoryCursors,
+  // #5555.4 — hard-reset the replay reconcile state on explicit disconnect.
+  resetReplayReconcile,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
 // #5184: header cost-badge mode union, default, and runtime guard. Lives in
@@ -1417,12 +1421,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           // encryption disabled) the fields are ignored and the auth_ok handler
           // falls back to the discrete handshake using the same stashed keypair.
           const eager = prepareEagerKeyExchange();
+          // #5555.3 — send the per-session history cursors so the server
+          // replays only entries newer than what we've already applied. Empty
+          // on a first connect → omitted → full replay (old-client shape).
+          const historyCursors = getHistoryCursors();
           socket.send(JSON.stringify({
             type: 'auth',
             token,
             ...common,
             eagerPublicKey: eager.publicKey,
             eagerSalt: eager.salt,
+            ...(Object.keys(historyCursors).length > 0 ? { historyCursors } : {}),
           }));
         }
       }
@@ -1612,6 +1621,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     // Reset replay flags in case disconnect happened mid-replay
     resetReplayFlags();
+    // #5555.3/.4 — explicit disconnect is a hard reset: drop the replay
+    // baseline AND the history cursors so a later connect (possibly to a
+    // different server) starts from a full replay rather than presenting a
+    // stale cursor. (Tunnel-blip RECONNECTS keep cursors — they don't run
+    // disconnect(); auth_ok clears only the baseline.)
+    resetReplayReconcile({ clearCursors: true });
     // Flush and clear any pending delta buffer
     clearDeltaBuffers();
     // Clear permission boundary split tracking

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -2744,30 +2744,31 @@ describe('dashboard message-handler dispatch', () => {
       expect(msgs[0].id).toBe('tool-1')
     })
 
-    it('deduplicates tool_use by stable messageId during session-switch replay', () => {
-      seedWithTool('tool-1')
+    it('deduplicates tool_use by stable messageId during a full-rebuild replay (#5555.4)', () => {
+      // #5555.4 — full rebuild no longer wipes at start; the old prefix stays
+      // visible and the replayed set is appended then swapped at end. Dedup
+      // during rebuild is scoped to the appended tail, so a replay that sends
+      // the SAME tool twice still collapses to one entry, and the atomic swap
+      // drops the pre-replay prefix.
+      seedWithTool('tool-1') // pre-replay prefix (stays visible, no flash)
       handleMessage(
         { type: 'history_replay_start', sessionId: 's1', fullHistory: true },
         ctx() as any,
       )
-      // session-switch replay clears messages first, so re-seed a tool to
-      // simulate the replay sending the same tool a client already cached
-      // (e.g. from a previous fetch). We bypass the clear by re-injecting.
-      ;(store.getState() as any).sessionStates.s1.messages = [
-        { id: 'tool-1', type: 'tool_use', content: 'Bash: ls', tool: 'Bash', timestamp: 1 },
-      ]
-      handleMessage(
-        {
-          type: 'tool_start',
-          messageId: 'tool-1',
-          tool: 'Bash',
-          input: 'ls',
-          sessionId: 's1',
-        },
-        ctx() as any,
-      )
+      // Messages are NOT cleared — the prefix is still there.
+      expect((store.getState() as any).sessionStates.s1.messages).toHaveLength(1)
+      const send = (id: string) =>
+        handleMessage(
+          { type: 'tool_start', messageId: id, tool: 'Bash', input: 'ls', sessionId: 's1' },
+          ctx() as any,
+        )
+      send('tool-1') // first replayed copy → appended to tail
+      send('tool-1') // duplicate within the replay → deduped against the tail
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      // Atomic swap → only the replayed tail (one tool-1), prefix dropped.
       const msgs = (store.getState() as any).sessionStates.s1.messages
       expect(msgs).toHaveLength(1)
+      expect(msgs[0].id).toBe('tool-1')
     })
 
     it('appends new tool_use whose id is not yet in cache (legitimate replay)', () => {
@@ -5274,17 +5275,17 @@ describe('dashboard message-handler dispatch', () => {
         messages: [originalToolMsg as any],
       })
       // Step 1: tab switch → server sends history_replay_start with
-      // fullHistory:true. The dashboard clears the messages array — this
-      // is what makes the cached-message dedup miss on the replayed
-      // tool_start that follows.
+      // fullHistory:true. #5555.4 — messages are NO LONGER wiped here (no blank
+      // flash); the prefix stays visible until the atomic swap at end. The
+      // replay-dedup cache is scoped to the appended tail, so the cached-message
+      // dedup still "misses" the replayed tool_start (it's not in the tail yet).
       handleMessage(
         { type: 'history_replay_start', sessionId: 's1', fullHistory: true },
         ctx() as any,
       )
-      // After history_replay_start: messages is [] but activeTools must still
-      // hold the original entry with its original startedAt.
+      // After history_replay_start: prefix preserved; activeTools intact.
       let ss = (store.getState() as any).sessionStates.s1
-      expect(ss.messages).toEqual([])
+      expect(ss.messages).toHaveLength(1)
       expect(ss.activeTools).toHaveLength(1)
       expect(ss.activeTools[0].startedAt).toBe(originalStartedAt)
       // Step 2: server replays the original tool_start (same messageId and

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -57,6 +57,12 @@ import {
   // conversation_id migrated to the shared dispatch table (#5556)
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
+  // #5555.3 / #5555.4 — lastSeq cursor + no-blank-flash reconcile.
+  recordHistorySeq,
+  reconcileReplayStart,
+  reconcileReplayEnd,
+  replayDedupCache,
+  resetReplayReconcile,
   handlePermissionExpired as sharedPermissionExpired,
   // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — dashboard adopts the shared permission family + the remaining
@@ -1651,11 +1657,18 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
   const toolStartTargetId = typeof msg.sessionId === 'string' ? msg.sessionId : get().activeSessionId;
   const cached = (() => {
     const targetState = toolStartTargetId ? get().sessionStates[toolStartTargetId] : null;
-    return targetState ? targetState.messages : get().messages;
+    // #5555.4 — scope to the appended replay tail during a full rebuild (see
+    // the `message` case for the rationale).
+    return replayDedupCache(
+      toolStartTargetId,
+      targetState ? targetState.messages : get().messages,
+    );
   })();
   // #4493 — per-session replay scoping. Dedup against the cached history
   // only when THIS message's session is currently replaying.
   const toolStartIsReplay = toolStartTargetId ? _replayingSessions.has(toolStartTargetId) : false;
+  // #5555.3 — advance the cursor for replayed tool_start entries.
+  if (toolStartIsReplay) recordHistorySeq(toolStartTargetId, (msg as { historySeq?: unknown }).historySeq);
   const result = sharedToolStart(msg, get().activeSessionId, toolStartIsReplay, cached);
   if (!result.shouldDispatch || !result.chatMessage) return;
   const toolMsg = result.chatMessage;
@@ -2430,6 +2443,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // per-session replaying set so a reconnect doesn't leave stale ids
       // gating future activity bumps).
       _replayingSessions.clear();
+      // #5555.4 — clear any in-progress replay BASELINE (a rebuild that never
+      // saw its history_replay_end before the socket dropped). Cursors are
+      // intentionally RETAINED so this reconnect's replay can be incremental.
+      resetReplayReconcile();
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
       // #4766: full wire-shape decode lives in the shared parser
@@ -3081,18 +3098,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'history_replay_start': {
       // Parser is shared via store-core; flag mutation stays at this call
       // site (module-level state, not store state).
-      const { fullHistory, sessionId: replayTargetId } = sharedHistoryReplayStart(
+      const { fullHistory, sessionId: replayTargetId, latestSeq } = sharedHistoryReplayStart(
         msg,
         get().activeSessionId,
       );
       // #4493 — track per-session. Falls back to activeSessionId via
       // sharedHistoryReplayStart, matching the gate's targetId resolution.
       if (replayTargetId) _replayingSessions.add(replayTargetId);
-      // Full history replay (from request_full_history): clear messages before replay
-      if (fullHistory) {
-        if (replayTargetId && get().sessionStates[replayTargetId]) {
-          updateSession(replayTargetId, () => ({ messages: [] }));
-        }
+      // #5555.4 — DO NOT wipe messages here. For a full rebuild we record the
+      // pre-replay baseline and keep the existing messages visible; the
+      // authoritative replayed set is appended after the baseline and swapped
+      // in atomically at history_replay_end (no blank flash). For a delta
+      // replay (cursor honoured) this is purely append-only. `latestSeq` seeds
+      // the cursor so an already-current empty replay still advances it.
+      {
+        const curLen =
+          (replayTargetId && get().sessionStates[replayTargetId]?.messages.length) || 0;
+        reconcileReplayStart(replayTargetId, fullHistory, curLen, latestSeq);
       }
       // Clear transient state — these events are not replayed from history,
       // so any surviving entries are stale from pre-disconnect
@@ -3127,6 +3149,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const endTargetId =
           (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
         if (endTargetId) _replayingSessions.delete(endTargetId);
+        // #5555.4 — atomic swap for a full rebuild: replace messages with the
+        // appended replayed tail in ONE update (old prefix dropped here, not at
+        // start → no blank flash). reconcileReplayEnd also advances the cursor
+        // from `latestSeq`. Returns null for a delta replay (nothing to swap).
+        const endLatestSeq =
+          typeof msg.latestSeq === 'number' && Number.isFinite(msg.latestSeq)
+            ? msg.latestSeq
+            : undefined;
+        if (endTargetId && get().sessionStates[endTargetId]) {
+          const { swappedMessages } = reconcileReplayEnd(
+            endTargetId,
+            get().sessionStates[endTargetId]!.messages,
+            endLatestSeq,
+          );
+          if (swappedMessages) {
+            updateSession(endTargetId, () => ({
+              messages: swappedMessages as SessionState['messages'],
+            }));
+          }
+        } else {
+          // Session vanished mid-replay — still settle the cursor.
+          reconcileReplayEnd(endTargetId, [], endLatestSeq);
+        }
       }
       // Mark all replayed prompts as answered — any prompt in history
       // has already been resolved by the server.
@@ -3179,11 +3224,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Resolve the cache used for replay-dedup (target session if known,
       // else the global message log).
       const targetState = targetId ? get().sessionStates[targetId] : null;
-      const cached = targetState ? targetState.messages : get().messages;
+      // #5555.4 — during a FULL rebuild, dedup only against the appended replay
+      // tail (replayDedupCache slices off the about-to-be-discarded prefix) so a
+      // replayed entry isn't suppressed by an id in the prefix and then lost in
+      // the swap. For delta replay / no rebuild this returns the whole array.
+      const cached = replayDedupCache(
+        targetId,
+        targetState ? targetState.messages : get().messages,
+      );
       // #4493 — dedup against history only when THIS message's session is
       // currently replaying. A module-wide boolean would suppress live
       // messages for session B while A replays.
       const messageIsReplay = targetId ? _replayingSessions.has(targetId) : false;
+      // #5555.3 — advance this session's cursor as we apply a replayed entry.
+      if (messageIsReplay) recordHistorySeq(targetId, (msg as { historySeq?: unknown }).historySeq);
       const result = sharedMessageHandler(msg, get().activeSessionId, messageIsReplay, cached);
       if (!result.shouldDispatch) break;
       const newMsg = result.chatMessage;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -32,6 +32,7 @@ export declare const AuthSchema: z.ZodObject<{
     capabilities: z.ZodDefault<z.ZodCatch<z.ZodOptional<z.ZodArray<z.ZodString>>>>;
     eagerPublicKey: z.ZodOptional<z.ZodString>;
     eagerSalt: z.ZodOptional<z.ZodString>;
+    historyCursors: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>;
 }, z.core.$loose>;
 export declare const PairSchema: z.ZodObject<{
     type: z.ZodLiteral<"pair">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -53,6 +53,18 @@ export const AuthSchema = z.object({
     // `serverPublicKey` in auth_ok and falls back the same way. No flag day.
     eagerPublicKey: z.string().max(512).optional(),
     eagerSalt: z.string().max(512).optional(),
+    // #5555.3 (lastSeq delta replay) — optional per-session history cursor map
+    // ({ [sessionId]: lastSeq }). On reconnect the client sends the highest
+    // `historySeq` it has applied for each session it has cached, so the server
+    // replays ONLY entries newer than that cursor instead of the full ring
+    // buffer. Old clients omit the field and get the full replay unchanged; a
+    // new client talking to an old server gets a full replay too (the server
+    // ignores the field). The server falls back to a full replay (flagged with
+    // `fullHistory: true` on `history_replay_start`) whenever it cannot honour a
+    // cursor — history trimmed past it, unknown session, or a server restart
+    // reset the seqs. `seq` is a non-negative finite int; the server caps the
+    // number of honoured keys defensively so a fat map can't bloat the auth path.
+    historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).optional(),
 }).passthrough();
 export const PairSchema = z.object({
     type: z.literal('pair'),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -59,6 +59,18 @@ export const AuthSchema = z.object({
   // `serverPublicKey` in auth_ok and falls back the same way. No flag day.
   eagerPublicKey: z.string().max(512).optional(),
   eagerSalt: z.string().max(512).optional(),
+  // #5555.3 (lastSeq delta replay) — optional per-session history cursor map
+  // ({ [sessionId]: lastSeq }). On reconnect the client sends the highest
+  // `historySeq` it has applied for each session it has cached, so the server
+  // replays ONLY entries newer than that cursor instead of the full ring
+  // buffer. Old clients omit the field and get the full replay unchanged; a
+  // new client talking to an old server gets a full replay too (the server
+  // ignores the field). The server falls back to a full replay (flagged with
+  // `fullHistory: true` on `history_replay_start`) whenever it cannot honour a
+  // cursor — history trimmed past it, unknown session, or a server restart
+  // reset the seqs. `seq` is a non-negative finite int; the server caps the
+  // number of honoured keys defensively so a fat map can't bloat the auth path.
+  historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).optional(),
 }).passthrough()
 
 export const PairSchema = z.object({

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -66,7 +66,12 @@ function handleSwitchSession(ws, client, msg, ctx) {
   loggerForSession('ws', targetId).info(`Client ${client.id} switched to session ${targetId}`)
   ctx.transport.send(ws, { type: 'session_switched', sessionId: targetId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
   ctx.transport.sendSessionInfo(ws, targetId)
-  ctx.transport.replayHistory(ws, targetId)
+  // #5555.3 — forceFull: a session SWITCH gets the authoritative full rebuild,
+  // not a cursor delta. Background sessions accumulate live broadcasts in the
+  // client's per-session message list while viewed elsewhere, so the replay
+  // cursor lags and a delta would re-send/duplicate them. The connect handshake
+  // (not this path) is where the cursor delta-replay win applies.
+  ctx.transport.replayHistory(ws, targetId, { forceFull: true })
   // Re-send provider-scoped available_models so clients that switch from a
   // Claude session to a Codex/Gemini session (or vice-versa) update their
   // model dropdown immediately (#2956).
@@ -230,7 +235,8 @@ async function handleDestroySession(ws, client, msg, ctx) {
       if (entry) {
         ctx.transport.send(clientWs, { type: 'session_switched', sessionId: firstId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
         ctx.transport.sendSessionInfo(clientWs, firstId)
-        ctx.transport.replayHistory(clientWs, firstId)
+        // #5555.3 — forced re-home after a destroy: authoritative full rebuild.
+        ctx.transport.replayHistory(clientWs, firstId, { forceFull: true })
       }
       broadcastFocusChanged(c, firstId, ctx)
     }
@@ -298,7 +304,9 @@ function handleSubscribeSessions(ws, client, msg, ctx) {
   })
   for (const sid of newlySubscribed) {
     ctx.transport.sendSessionInfo(ws, sid)
-    ctx.transport.replayHistory(ws, sid)
+    // #5555.3 — new subscription: authoritative full rebuild (the client may
+    // hold stale cached state for this session; cursor delta is connect-only).
+    ctx.transport.replayHistory(ws, sid, { forceFull: true })
   }
 }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1941,6 +1941,27 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
+   * #5555.3 — seq of the oldest history entry still retained in the ring
+   * buffer (null when empty). The cursor-replay path compares a client's
+   * `lastSeq` against this to detect a trim gap.
+   * @param {string} sessionId
+   * @returns {number|null}
+   */
+  getOldestHistorySeq(sessionId) {
+    return this._history.getOldestSeq(sessionId)
+  }
+
+  /**
+   * #5555.3 — seq of the newest history entry (0 when empty). When a client's
+   * `lastSeq >= this`, there is nothing newer to replay.
+   * @param {string} sessionId
+   * @returns {number}
+   */
+  getLatestHistorySeq(sessionId) {
+    return this._history.getLatestSeq(sessionId)
+  }
+
+  /**
    * Get the conversation ID (SDK session ID) for a session.
    * @returns {string|null}
    */

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -24,9 +24,57 @@ export class SessionMessageHistory extends EventEmitter {
     super()
     this._maxHistory = maxMessages ?? maxHistory ?? 1000
     this._maxToolInput = maxToolInput || null
-    this._messageHistory = new Map()    // sessionId -> Array<{ type, ...data }>
+    this._messageHistory = new Map()    // sessionId -> Array<{ type, _seq, ...data }>
     this._pendingStreams = new Map()     // sessionId:messageId -> accumulated delta text
     this._historyTruncated = new Map()  // sessionId -> boolean
+    // #5555.3 (lastSeq delta replay) — per-session monotonic history sequence.
+    // Every entry pushed into the ring buffer is stamped with a strictly
+    // increasing `_seq` (1-based). The counter NEVER resets while a session
+    // lives, even as the ring buffer trims old entries off the front — so a
+    // client cursor (`lastSeq`) can be compared against the oldest RETAINED
+    // entry's seq to detect a trim gap and fall back to a full replay. The
+    // seq is server-internal bookkeeping; the wire only exposes it as
+    // `historySeq` on replayed entries (see ws-history.js).
+    this._seqCounters = new Map()        // sessionId -> next seq to assign (>= 1)
+  }
+
+  /**
+   * #5555.3 — allocate the next monotonic seq for a session.
+   * @param {string} sessionId
+   * @returns {number}
+   */
+  _nextSeq(sessionId) {
+    const next = this._seqCounters.get(sessionId) || 1
+    this._seqCounters.set(sessionId, next + 1)
+    return next
+  }
+
+  /**
+   * #5555.3 — seq of the oldest entry still retained in the ring buffer, or
+   * null when the session has no history. Used by the cursor-replay path to
+   * detect whether a client's cursor points at an entry that has since been
+   * trimmed off the front (gap → full-replay fallback).
+   * @param {string} sessionId
+   * @returns {number|null}
+   */
+  getOldestSeq(sessionId) {
+    const history = this._messageHistory.get(sessionId)
+    if (!history || history.length === 0) return null
+    const seq = history[0]._seq
+    return typeof seq === 'number' ? seq : null
+  }
+
+  /**
+   * #5555.3 — seq of the newest entry, or 0 when the session has no history
+   * (so `lastSeq >= getLatestSeq` cleanly means "nothing newer to replay").
+   * @param {string} sessionId
+   * @returns {number}
+   */
+  getLatestSeq(sessionId) {
+    const history = this._messageHistory.get(sessionId)
+    if (!history || history.length === 0) return 0
+    const seq = history[history.length - 1]._seq
+    return typeof seq === 'number' ? seq : 0
   }
 
   /**
@@ -106,6 +154,19 @@ export class SessionMessageHistory extends EventEmitter {
    * @param {Array} history
    */
   setHistory(sessionId, history) {
+    // #5555.3 — restored entries predate the seq scheme (it is server-internal
+    // and not persisted), so stamp them with a fresh 1..N sequence and advance
+    // the counter past the end. A reconnecting client's cursor from a PRIOR
+    // server process can't be honoured across a restart (seqs reset to 1), so
+    // it will simply fall through to a full replay — the safe default.
+    if (Array.isArray(history)) {
+      let seq = 1
+      for (const entry of history) {
+        if (entry && typeof entry === 'object') entry._seq = seq
+        seq++
+      }
+      this._seqCounters.set(sessionId, seq)
+    }
     this._messageHistory.set(sessionId, history)
   }
 
@@ -327,6 +388,12 @@ export class SessionMessageHistory extends EventEmitter {
    * @param {string} sessionId
    */
   _pushHistory(history, entry, sessionId) {
+    // #5555.3 — stamp the monotonic per-session seq before pushing. The counter
+    // keeps climbing past any front-trim below, so a cursor can always be
+    // compared against the oldest retained entry's seq to detect a trim gap.
+    if (entry && typeof entry === 'object' && entry._seq === undefined) {
+      entry._seq = this._nextSeq(sessionId)
+    }
     history.push(entry)
     if (history.length > this._maxHistory) {
       history.shift()
@@ -343,6 +410,9 @@ export class SessionMessageHistory extends EventEmitter {
   truncateEntry(entry) {
     const MAX = 50 * 1024
     const clone = { ...entry }
+    // #5555.3 — `_seq` is per-process server bookkeeping (reassigned 1..N on
+    // restore via setHistory), so keep it out of the persisted state file.
+    delete clone._seq
     if (typeof clone.content === 'string' && clone.content.length > MAX) {
       clone.content = clone.content.slice(0, MAX) + '[truncated]'
     }
@@ -396,6 +466,7 @@ export class SessionMessageHistory extends EventEmitter {
   cleanupSession(sessionId) {
     this._messageHistory.delete(sessionId)
     this._historyTruncated.delete(sessionId)
+    this._seqCounters.delete(sessionId)
 
     // Clean up pending stream state (composite keys: `${sessionId}:messageId`)
     const prefix = sessionId + ':'
@@ -413,5 +484,6 @@ export class SessionMessageHistory extends EventEmitter {
     this._messageHistory.clear()
     this._historyTruncated.clear()
     this._pendingStreams.clear()
+    this._seqCounters.clear()
   }
 }

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -15,6 +15,12 @@ const log = createLogger('ws')
  *  When the cap is reached the oldest entry is evicted before inserting. */
 export const MAX_AUTH_FAILURE_ENTRIES = 10_000
 
+/** #5555.3 — cap on the number of per-session history cursors honoured from a
+ *  single `auth` message. A client only ever replays its bound/active session
+ *  on connect, so a handful is the realistic case; this bound keeps a
+ *  malformed/oversized map from inflating the post-auth path. */
+export const MAX_HISTORY_CURSORS = 64
+
 /** Lenient counter for benign pairing failures (already_used / expired).
  *
  *  These reasons are exempt from the strict brute-force `authFailures` bucket
@@ -183,6 +189,26 @@ export function handleAuthMessage(ctx, ws, msg) {
     if (typeof authData.eagerPublicKey === 'string' && authData.eagerPublicKey &&
         typeof authData.eagerSalt === 'string' && authData.eagerSalt) {
       client.eagerKeyExchange = { publicKey: authData.eagerPublicKey, salt: authData.eagerSalt }
+    }
+
+    // #5555.3 (lastSeq delta replay) — stash the per-session history cursor map
+    // so replayHistory (via sendPostAuthInfo → onAuthSuccess) can send only the
+    // entries newer than the client's cursor. The schema already coerced it to
+    // a { [sessionId]: nonNegativeInt } record; cap the honoured keys
+    // defensively (MAX_HISTORY_CURSORS) so an oversized map can't bloat the
+    // post-auth path. Absent → client.historyCursors stays undefined → full
+    // replay (the backward-compatible default).
+    if (authData.historyCursors && typeof authData.historyCursors === 'object') {
+      const cursors = {}
+      let n = 0
+      for (const [sid, seq] of Object.entries(authData.historyCursors)) {
+        if (n >= MAX_HISTORY_CURSORS) break
+        if (typeof seq === 'number' && Number.isFinite(seq) && seq >= 0) {
+          cursors[sid] = seq
+          n++
+        }
+      }
+      if (n > 0) client.historyCursors = cursors
     }
 
     onAuthSuccess(ws, client)

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -747,12 +747,21 @@ export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
  * Fallback to full replay (fullHistory: true, startOffset 0) when:
  *   - no cursor supplied (old client, or first connect),
  *   - cursor <= 0 (client has nothing yet),
+ *   - cursor > latestSeq — the client's cursor is numerically AHEAD of the
+ *     newest retained entry. This is the server-restart reassignment trap:
+ *     `_seq` is server-internal and reassigned 1..N on state restore, so a
+ *     client reconnecting after a restart can hold a cursor (e.g. 500) far
+ *     above the freshly-reassigned latest (e.g. 300). The trim-gap check below
+ *     does NOT catch this (oldest is 1, not `> 501`), and a delta replay would
+ *     hand the client an EMPTY slice while it keeps stale messages and never
+ *     rebuilds — and the cursor (500) would never recover past latest (300).
+ *     Force a full rebuild so the client re-syncs to the authoritative set.
  *   - the oldest RETAINED entry's seq is `> lastSeq + 1` — i.e. the entry the
  *     cursor pointed just-after has been trimmed off the front (or the seqs
  *     reset on a server restart), so a delta replay would leave a gap. The
  *     client can't append across a gap, so it must rebuild.
  *
- * When `lastSeq >= latestSeq` the client is already current: cursor replay with
+ * When `lastSeq === latestSeq` the client is already current: cursor replay with
  * an empty slice (startOffset === history.length). The caller still emits the
  * start/end frames so the client clears its `receivingHistoryReplay` flag and
  * resolves any stale prompts — just with nothing to append.
@@ -761,11 +770,26 @@ export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
  * @param {Array} history - the retained ring buffer (already fetched)
  * @param {string} sessionId
  * @param {number|null|undefined} lastSeq - client cursor, if any
+ * @param {number} [latestSeq] - seq of the newest retained entry (0 when empty)
  * @returns {{ fullHistory: boolean, startOffset: number }}
  */
-export function resolveReplayPlan(sessionManager, history, sessionId, lastSeq) {
+export function resolveReplayPlan(sessionManager, history, sessionId, lastSeq, latestSeq) {
   // No cursor / nothing applied yet → full replay (backward compatible).
   if (typeof lastSeq !== 'number' || !Number.isFinite(lastSeq) || lastSeq <= 0) {
+    return { fullHistory: true, startOffset: 0 }
+  }
+  // Cursor ahead of the newest retained entry (server-restart seq reassignment,
+  // or any seq regression): a delta replay would yield an empty slice and leave
+  // the client wedged on stale messages with a cursor that never recovers. Force
+  // a full rebuild. `latestSeq` is sourced by the caller from
+  // getLatestHistorySeq; fall back to a fetch here so a direct caller / test
+  // that omits it still gets the guard.
+  const resolvedLatest = typeof latestSeq === 'number' && Number.isFinite(latestSeq)
+    ? latestSeq
+    : (typeof sessionManager.getLatestHistorySeq === 'function'
+        ? sessionManager.getLatestHistorySeq(sessionId)
+        : 0)
+  if (lastSeq > resolvedLatest) {
     return { fullHistory: true, startOffset: 0 }
   }
   const oldestSeq = typeof sessionManager.getOldestHistorySeq === 'function'
@@ -832,15 +856,17 @@ export function replayHistory(ctx, ws, sessionId, opts = {}) {
   // semantics and the atomic swap (#5555.4) hides the rebuild with no flash.
   const client = clients && typeof clients.get === 'function' ? clients.get(ws) : null
   const lastSeq = opts.forceFull ? undefined : client?.historyCursors?.[sessionId]
-  const { fullHistory, startOffset } = resolveReplayPlan(sessionManager, history, sessionId, lastSeq)
 
   // `latestSeq` rides the start frame so the client can advance its cursor even
   // when the slice is empty (already-current reconnect) — there'd be no entry
   // to read a `historySeq` off otherwise. Defensive against legacy ctx fixtures
-  // whose manager predates the seq helper.
+  // whose manager predates the seq helper. Computed BEFORE resolveReplayPlan so
+  // the cursor-ahead-of-latest guard (#5555.3 server-restart trap) can use it.
   const latestSeq = typeof sessionManager.getLatestHistorySeq === 'function'
     ? sessionManager.getLatestHistorySeq(sessionId)
     : 0
+  const { fullHistory, startOffset } = resolveReplayPlan(sessionManager, history, sessionId, lastSeq, latestSeq)
+
   send(ws, { type: 'history_replay_start', sessionId, truncated, fullHistory, latestSeq })
 
   const CHUNK_SIZE = 20

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -731,26 +731,117 @@ export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
 }
 
 /**
- * Replay message history for a session to a single client.
- * Sends the full ring buffer in batches to yield the event loop.
+ * #5555.3 — resolve a client's history cursor for a session into a replay plan.
  *
- * Marks the replay as `fullHistory: true` so clients clear their per-session
- * messages array before applying the replayed events. Without this, every
- * reconnect (the client re-enters `replayHistory` each time it reconnects to
- * an existing session) appends a fresh copy of the ring buffer on top of
- * whatever the client already had. `isReplayDuplicate` cannot save us when
- * ring-buffer entries and live-broadcast entries have different messageIds —
- * the user-visible failure is duplicated assistant turns and scrambled order
- * (#3743; discovered during the v0.7.16 dogfood smoke-test in #3741).
+ * Given the client's `lastSeq` for this session (the highest `historySeq` it
+ * has already applied), decide:
+ *   - `fullHistory`: true  → replay the WHOLE retained ring buffer; the client
+ *                            must REBUILD (swap) its message set. This is the
+ *                            backward-compatible default and the fallback for
+ *                            every case we can't honour a cursor.
+ *   - `fullHistory`: false → CURSOR replay; replay only entries with
+ *                            `_seq > lastSeq`. Naturally append-only on the
+ *                            client; near-zero on a quick reconnect.
+ *   - `startOffset`: index into `history` of the first entry to send.
+ *
+ * Fallback to full replay (fullHistory: true, startOffset 0) when:
+ *   - no cursor supplied (old client, or first connect),
+ *   - cursor <= 0 (client has nothing yet),
+ *   - the oldest RETAINED entry's seq is `> lastSeq + 1` — i.e. the entry the
+ *     cursor pointed just-after has been trimmed off the front (or the seqs
+ *     reset on a server restart), so a delta replay would leave a gap. The
+ *     client can't append across a gap, so it must rebuild.
+ *
+ * When `lastSeq >= latestSeq` the client is already current: cursor replay with
+ * an empty slice (startOffset === history.length). The caller still emits the
+ * start/end frames so the client clears its `receivingHistoryReplay` flag and
+ * resolves any stale prompts — just with nothing to append.
+ *
+ * @param {object} sessionManager
+ * @param {Array} history - the retained ring buffer (already fetched)
+ * @param {string} sessionId
+ * @param {number|null|undefined} lastSeq - client cursor, if any
+ * @returns {{ fullHistory: boolean, startOffset: number }}
  */
-export function replayHistory(ctx, ws, sessionId) {
-  const { sessionManager, send } = ctx
+export function resolveReplayPlan(sessionManager, history, sessionId, lastSeq) {
+  // No cursor / nothing applied yet → full replay (backward compatible).
+  if (typeof lastSeq !== 'number' || !Number.isFinite(lastSeq) || lastSeq <= 0) {
+    return { fullHistory: true, startOffset: 0 }
+  }
+  const oldestSeq = typeof sessionManager.getOldestHistorySeq === 'function'
+    ? sessionManager.getOldestHistorySeq(sessionId)
+    : null
+  // Empty history can't happen here (caller guards history.length), but be safe.
+  if (oldestSeq === null) return { fullHistory: true, startOffset: 0 }
+  // Trim gap (or post-restart seq reset): the entry just after the cursor is
+  // gone, so a delta replay would skip entries. Rebuild instead.
+  if (oldestSeq > lastSeq + 1) {
+    return { fullHistory: true, startOffset: 0 }
+  }
+  // Cursor honoured — find the first entry strictly newer than lastSeq. The
+  // ring buffer is seq-ordered, so a linear scan from the front is fine (and
+  // typically lands on the tail for a quick reconnect).
+  let startOffset = 0
+  while (startOffset < history.length && (history[startOffset]._seq || 0) <= lastSeq) {
+    startOffset++
+  }
+  return { fullHistory: false, startOffset }
+}
+
+/**
+ * Replay message history for a session to a single client.
+ * Sends the retained ring buffer in batches to yield the event loop.
+ *
+ * #5555.3 — honours an optional per-session client cursor
+ * (`client.historyCursors[sessionId]`). When the cursor can be honoured the
+ * replay is INCREMENTAL: only entries newer than the cursor are sent and the
+ * `history_replay_start` frame carries `fullHistory: false`, telling the client
+ * to APPEND (no message wipe, no blank flash). When the cursor can't be honoured
+ * (no cursor / trimmed past / seq reset) the replay falls back to FULL, with
+ * `fullHistory: true` — the long-standing rebuild path.
+ *
+ * Each replayed entry carries its `historySeq` (the server-internal monotonic
+ * seq) so the client can advance its cursor for the next reconnect.
+ *
+ * The `fullHistory: true` flag is why every reconnect doesn't stack duplicate
+ * ring buffers: without it, the client would append a fresh copy on top of what
+ * it already had. `isReplayDuplicate` cannot save us when ring-buffer entries
+ * and live-broadcast entries have different messageIds — the user-visible
+ * failure is duplicated assistant turns and scrambled order (#3743; discovered
+ * during the v0.7.16 dogfood smoke-test in #3741).
+ */
+export function replayHistory(ctx, ws, sessionId, opts = {}) {
+  const { sessionManager, send, clients } = ctx
   if (!sessionManager) return
   const history = sessionManager.getHistory(sessionId)
   if (history.length === 0) return
 
   const truncated = sessionManager.isHistoryTruncated(sessionId)
-  send(ws, { type: 'history_replay_start', sessionId, truncated, fullHistory: true })
+
+  // #5555.3 — resolve the client's cursor into a replay plan. clients map may
+  // be absent in some test fixtures → treat as no cursor (full replay).
+  //
+  // `opts.forceFull` short-circuits the cursor and forces a FULL rebuild. The
+  // CONNECT handshake (sendPostAuthInfo) honours the cursor — the client was
+  // fully disconnected, so no background live messages arrived to desync it.
+  // SESSION SWITCH (session-handlers.js) passes forceFull: a background session
+  // streams live broadcasts into the client's per-session messages WHILE it's
+  // viewed elsewhere, so the cursor lags behind those live appends and a delta
+  // replay would re-send (and, with mismatched ids, duplicate) them. Forcing a
+  // full rebuild on switch keeps the long-standing authoritative-replace
+  // semantics and the atomic swap (#5555.4) hides the rebuild with no flash.
+  const client = clients && typeof clients.get === 'function' ? clients.get(ws) : null
+  const lastSeq = opts.forceFull ? undefined : client?.historyCursors?.[sessionId]
+  const { fullHistory, startOffset } = resolveReplayPlan(sessionManager, history, sessionId, lastSeq)
+
+  // `latestSeq` rides the start frame so the client can advance its cursor even
+  // when the slice is empty (already-current reconnect) — there'd be no entry
+  // to read a `historySeq` off otherwise. Defensive against legacy ctx fixtures
+  // whose manager predates the seq helper.
+  const latestSeq = typeof sessionManager.getLatestHistorySeq === 'function'
+    ? sessionManager.getLatestHistorySeq(sessionId)
+    : 0
+  send(ws, { type: 'history_replay_start', sessionId, truncated, fullHistory, latestSeq })
 
   const CHUNK_SIZE = 20
   const sendChunk = (offset) => {
@@ -772,7 +863,11 @@ export function replayHistory(ctx, ws, sessionId) {
     let nextOffset = end
     for (let i = offset; i < end; i++) {
       const entry = history[i]
-      send(ws, { ...entry, sessionId })
+      // #5555.3 — surface the server-internal `_seq` to the client as
+      // `historySeq` (and strip the underscore-prefixed internal field) so the
+      // client can advance its per-session cursor as it applies each entry.
+      const { _seq, ...wireEntry } = entry
+      send(ws, { ...wireEntry, sessionId, ...(typeof _seq === 'number' ? { historySeq: _seq } : {}) })
       // #4628: mirror the live `result → agent_idle` fan-out from
       // event-normalizer.js. The dashboard's handler dispatch table has
       // no `result` entry — only `agent_idle` — so a raw `result` in
@@ -808,10 +903,18 @@ export function replayHistory(ctx, ws, sessionId) {
       // tool_result payloads.
       scheduleAfterDrain(ws, () => sendChunk(nextOffset))
     } else {
-      send(ws, { type: 'history_replay_end', sessionId })
+      send(ws, { type: 'history_replay_end', sessionId, latestSeq })
     }
   }
-  sendChunk(0)
+  // #5555.3 — start at the resolved offset: 0 for a full replay, the
+  // first-newer-than-cursor index for a delta replay. When the client is
+  // already current (startOffset === history.length) this immediately falls
+  // through to the empty-slice path and emits start+end with nothing between.
+  if (startOffset >= history.length) {
+    send(ws, { type: 'history_replay_end', sessionId, latestSeq })
+  } else {
+    sendChunk(startOffset)
+  }
 }
 
 /**

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -683,7 +683,7 @@ export class WsServer {
         isPrimary: (sid, cid) => self._clientManager.isPrimary(sid, cid),
         clearPrimary: (sid) => self._clearPrimary(sid),
         sendSessionInfo: (ws, sid) => self._sendSessionInfo(ws, sid),
-        replayHistory: (ws, sid) => self._replayHistory(ws, sid),
+        replayHistory: (ws, sid, opts) => self._replayHistory(ws, sid, opts),
         get clients() { return self.clients },
       },
       sessions: {
@@ -1641,7 +1641,7 @@ export class WsServer {
 
   /** Delegates to ws-history.js */
   _sendPostAuthInfo(ws, extra) { sendPostAuthInfo(this._historyCtx, ws, extra) }
-  _replayHistory(ws, sessionId) { replayHistory(this._historyCtx, ws, sessionId) }
+  _replayHistory(ws, sessionId, opts) { replayHistory(this._historyCtx, ws, sessionId, opts) }
   _flushPostAuthQueue(ws, queue) { flushPostAuthQueue(this._historyCtx, ws, queue) }
   _sendSessionInfo(ws, sessionId) { sendSessionInfo(this._historyCtx, ws, sessionId) }
 

--- a/packages/server/tests/session-message-history.test.js
+++ b/packages/server/tests/session-message-history.test.js
@@ -526,4 +526,68 @@ describe('SessionMessageHistory', () => {
       assert.equal(synthetics.length, 1)
     })
   })
+
+  // #5555.3 — monotonic per-session history seq used by lastSeq delta replay.
+  describe('history seq (#5555.3)', () => {
+    it('stamps a strictly increasing 1-based _seq on each pushed entry', () => {
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'a', timestamp: 1 })
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'b', timestamp: 2 })
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'c', timestamp: 3 })
+      const seqs = history.getHistory('s1').map(e => e._seq)
+      assert.deepStrictEqual(seqs, [1, 2, 3])
+    })
+
+    it('keeps seq climbing past a ring-buffer front-trim (gap detection input)', () => {
+      const h = new SessionMessageHistory({ maxMessages: 3 })
+      for (let i = 0; i < 5; i++) {
+        h.recordHistory('s1', 'message', { type: 'user_input', content: `m${i}`, timestamp: i })
+      }
+      // Buffer holds the last 3 entries; their seqs are 3,4,5 (1 and 2 trimmed).
+      assert.deepStrictEqual(h.getHistory('s1').map(e => e._seq), [3, 4, 5])
+      assert.equal(h.getOldestSeq('s1'), 3)
+      assert.equal(h.getLatestSeq('s1'), 5)
+    })
+
+    it('seq is per-session (counters do not bleed across sessions)', () => {
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'a', timestamp: 1 })
+      history.recordHistory('s2', 'message', { type: 'user_input', content: 'x', timestamp: 1 })
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'b', timestamp: 2 })
+      assert.deepStrictEqual(history.getHistory('s1').map(e => e._seq), [1, 2])
+      assert.deepStrictEqual(history.getHistory('s2').map(e => e._seq), [1])
+    })
+
+    it('getOldestSeq/getLatestSeq on an empty session', () => {
+      assert.equal(history.getOldestSeq('nope'), null)
+      assert.equal(history.getLatestSeq('nope'), 0)
+    })
+
+    it('setHistory re-stamps restored entries 1..N and advances the counter', () => {
+      history.setHistory('s1', [
+        { type: 'message', content: 'a' },
+        { type: 'message', content: 'b' },
+      ])
+      assert.deepStrictEqual(history.getHistory('s1').map(e => e._seq), [1, 2])
+      // Next recorded entry continues the sequence.
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'c', timestamp: 1 })
+      assert.equal(history.getHistory('s1')[2]._seq, 3)
+    })
+
+    it('truncateEntry strips _seq so it never reaches the persisted state file', () => {
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'a', timestamp: 1 })
+      const entry = history.getHistory('s1')[0]
+      assert.equal(entry._seq, 1)
+      const serialized = history.truncateEntry(entry)
+      assert.equal(serialized._seq, undefined)
+      // original entry retains its seq (truncateEntry clones)
+      assert.equal(entry._seq, 1)
+    })
+
+    it('cleanupSession resets the seq counter for that session', () => {
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'a', timestamp: 1 })
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'b', timestamp: 2 })
+      history.cleanupSession('s1')
+      history.recordHistory('s1', 'message', { type: 'user_input', content: 'c', timestamp: 3 })
+      assert.equal(history.getHistory('s1')[0]._seq, 1)
+    })
+  })
 })

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -261,6 +261,20 @@ export function createMockSessionManager(sessions = [], overrides = {}) {
     return list
   }
   manager.getHistory = () => []
+  // #5555.3 — seq helpers used by replayHistory's cursor logic. Default to the
+  // _seq stamped on the (overridable) getHistory entries so cursor-replay tests
+  // can drive them by supplying entries with `_seq`; tests that don't care get
+  // the no-history defaults (null oldest, 0 latest).
+  manager.getOldestHistorySeq = () => {
+    const h = manager.getHistory()
+    if (!Array.isArray(h) || h.length === 0) return null
+    return typeof h[0]._seq === 'number' ? h[0]._seq : null
+  }
+  manager.getLatestHistorySeq = () => {
+    const h = manager.getHistory()
+    if (!Array.isArray(h) || h.length === 0) return 0
+    return typeof h[h.length - 1]._seq === 'number' ? h[h.length - 1]._seq : 0
+  }
   manager.recordUserInput = () => {}
   manager.touchActivity = () => {}
   manager.getFullHistoryAsync = async () => []

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -298,6 +298,47 @@ describe('handleAuthMessage', () => {
     })
   })
 
+  // #5555.3 (lastSeq delta replay) — the per-session history cursor map stashed
+  // off `auth` so replayHistory can send only entries newer than the cursor.
+  describe('history cursors (#5555.3)', () => {
+    it('stashes a valid per-session history cursor map', () => {
+      const { ctx, ws, client } = makeAuthCtx({ authRequired: true, isTokenValid: () => true })
+      handleAuthMessage(ctx, ws, {
+        type: 'auth',
+        token: 'good-token',
+        historyCursors: { 'sess-1': 42, 'sess-2': 0 },
+      })
+      assert.deepEqual(client.historyCursors, { 'sess-1': 42, 'sess-2': 0 })
+    })
+
+    it('leaves historyCursors undefined for old clients (field absent)', () => {
+      const { ctx, ws, client } = makeAuthCtx({ authRequired: true, isTokenValid: () => true })
+      handleAuthMessage(ctx, ws, { type: 'auth', token: 'good-token' })
+      assert.equal(client.historyCursors, undefined)
+    })
+
+    it('drops non-numeric / negative / non-finite cursor values', () => {
+      const { ctx, ws, client } = makeAuthCtx({ authRequired: true, isTokenValid: () => true })
+      // Zod coerces the record; invalid entries that survive parsing are
+      // filtered in the handler. Pass through .passthrough() with mixed values.
+      handleAuthMessage(ctx, ws, {
+        type: 'auth',
+        token: 'good-token',
+        historyCursors: { ok: 7 },
+      })
+      assert.deepEqual(client.historyCursors, { ok: 7 })
+    })
+
+    it('caps the number of honoured cursors at MAX_HISTORY_CURSORS', () => {
+      const big = {}
+      for (let i = 0; i < 200; i++) big[`s${i}`] = i + 1
+      const { ctx, ws, client } = makeAuthCtx({ authRequired: true, isTokenValid: () => true })
+      handleAuthMessage(ctx, ws, { type: 'auth', token: 'good-token', historyCursors: big })
+      assert.ok(client.historyCursors)
+      assert.equal(Object.keys(client.historyCursors).length, 64)
+    })
+  })
+
   describe('invalid token — auth failure tracking', () => {
     it('rejects invalid token with auth_fail', () => {
       const { ctx, ws } = makeAuthCtx({

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -317,16 +317,37 @@ describe('handleAuthMessage', () => {
       assert.equal(client.historyCursors, undefined)
     })
 
-    it('drops non-numeric / negative / non-finite cursor values', () => {
+    it('rejects auth when a cursor value is invalid (negative / non-finite / non-integer / non-numeric)', () => {
+      // AuthSchema validates historyCursors as
+      // z.record(z.string(), z.number().int().nonnegative()), so a single bad
+      // VALUE fails the whole safeParse → auth_fail (invalid_message), not a
+      // silent filter. The handler's defensive value-filter loop is therefore
+      // belt-and-suspenders only — these inputs never reach it. We pin the real
+      // wire behaviour here so a future schema relaxation can't regress to
+      // silently honouring a malformed cursor.
+      for (const bad of [-1, Infinity, NaN, 1.5, 'x', null]) {
+        const { ctx, ws, client } = makeAuthCtx({ authRequired: true, isTokenValid: () => true })
+        handleAuthMessage(ctx, ws, {
+          type: 'auth',
+          token: 'good-token',
+          historyCursors: { ok: 7, bad },
+        })
+        const last = ws.lastSent()
+        assert.equal(last?.type, 'auth_fail', `bad value ${String(bad)} must reject auth`)
+        assert.equal(last?.reason, 'invalid_message')
+        assert.equal(client.authenticated, false)
+        assert.equal(client.historyCursors, undefined)
+      }
+    })
+
+    it('honours a fully-valid cursor map (handler filter passes every entry through)', () => {
       const { ctx, ws, client } = makeAuthCtx({ authRequired: true, isTokenValid: () => true })
-      // Zod coerces the record; invalid entries that survive parsing are
-      // filtered in the handler. Pass through .passthrough() with mixed values.
       handleAuthMessage(ctx, ws, {
         type: 'auth',
         token: 'good-token',
-        historyCursors: { ok: 7 },
+        historyCursors: { ok: 7, zero: 0 },
       })
-      assert.deepEqual(client.historyCursors, { ok: 7 })
+      assert.deepEqual(client.historyCursors, { ok: 7, zero: 0 })
     })
 
     it('caps the number of honoured cursors at MAX_HISTORY_CURSORS', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1503,6 +1503,40 @@ describe('replayHistory — lastSeq delta replay (#5555.3)', () => {
     assert.deepEqual(plan, { fullHistory: false, startOffset: 0 })
   })
 
+  // #5555.3 server-restart trap: `_seq` is server-internal and reassigned 1..N
+  // on state restore, so a client reconnecting after a restart can hold a cursor
+  // NUMERICALLY AHEAD of the freshly-reassigned latest. The trim-gap check
+  // (oldest > cursor+1) does NOT catch this (oldest is 1, not > cursor+1). Without
+  // a cursor>latest guard the client would get an EMPTY delta, keep stale
+  // messages, never rebuild, and its cursor would never recover past latest.
+  it('resolveReplayPlan: cursor AHEAD of latest (server-restart seq reassignment) → full replay', () => {
+    // Restored history reassigned 1..N (oldest=1, latest=300, but only 3 entries
+    // modelled here); client cursor from a prior process is 500.
+    const history = [1, 2, 3].map(s => ({ type: 'm', _seq: s }))
+    const manager = managerWith(history)
+    // managerWith leaves getLatestHistorySeq deriving from getHistory → latest=3.
+    const plan = resolveReplayPlan(manager, history, 'sess-1', 500)
+    assert.deepEqual(plan, { fullHistory: true, startOffset: 0 },
+      'cursor ahead of latest must force a full rebuild, not an empty delta')
+  })
+
+  it('resolveReplayPlan: cursor exactly one above latest → full replay (boundary)', () => {
+    const history = [1, 2, 3].map(s => ({ type: 'm', _seq: s }))
+    const manager = managerWith(history)
+    const plan = resolveReplayPlan(manager, history, 'sess-1', 4) // latest=3
+    assert.deepEqual(plan, { fullHistory: true, startOffset: 0 })
+  })
+
+  it('resolveReplayPlan: explicit latestSeq arg drives the cursor-ahead guard', () => {
+    // Caller passes latestSeq directly (the production path in replayHistory).
+    const history = [1, 2, 3].map(s => ({ type: 'm', _seq: s }))
+    const manager = managerWith(history)
+    // latestSeq passed = 3; cursor 4 > 3 → full replay even though the manager
+    // helper would agree. Verifies the arg is honoured (no double-fetch needed).
+    const plan = resolveReplayPlan(manager, history, 'sess-1', 4, 3)
+    assert.deepEqual(plan, { fullHistory: true, startOffset: 0 })
+  })
+
   it('delta replay: start frame carries fullHistory:false + latestSeq, only newer entries sent', async () => {
     const history = [1, 2, 3, 4, 5].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
     const manager = managerWith(history)
@@ -1556,6 +1590,27 @@ describe('replayHistory — lastSeq delta replay (#5555.3)', () => {
     assert.equal(start.truncated, true)
     const replayed = ctx._sends.filter(m => m.type === 'response')
     assert.deepEqual(replayed.map(m => m.historySeq), [10, 11, 12], 'full replay sends every retained entry')
+  })
+
+  it('cursor AHEAD of latest (server restart) → full replay rebuild, every entry sent', async () => {
+    // Reconnect after a server restart: history reassigned 1..3, but the client
+    // still presents its pre-restart cursor (500). A delta would yield nothing;
+    // the client must rebuild from the authoritative set instead.
+    const history = [1, 2, 3].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history)
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws, { historyCursors: { 'sess-1': 500 } })
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const start = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.fullHistory, true, 'cursor-ahead must flag a full rebuild')
+    assert.equal(start.latestSeq, 3)
+    const replayed = ctx._sends.filter(m => m.type === 'response')
+    assert.deepEqual(replayed.map(m => m.historySeq), [1, 2, 3],
+      'full replay re-sends every retained entry so the client re-syncs')
   })
 
   it('unknown session cursor (no cursor for THIS session) → full replay', async () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -8,6 +8,7 @@ import {
   sendPostAuthInfo,
   sendSessionInfo,
   replayHistory,
+  resolveReplayPlan,
   flushPostAuthQueue,
   scheduleAfterDrain,
   scheduleProviderModelsRefresh,
@@ -1439,6 +1440,194 @@ describe('replayHistory', () => {
 
     const types = ctx._sends.map(m => m.type)
     assert.ok(!types.includes('agent_idle'), 'no result → no synthetic agent_idle')
+  })
+})
+
+// #5555.3 — lastSeq delta replay. The client sends a per-session cursor in
+// `auth` (stashed on client.historyCursors); replayHistory sends only entries
+// newer than the cursor, flagging fullHistory:false so the client appends
+// rather than rebuilds. Falls back to a full replay (fullHistory:true) when the
+// cursor can't be honoured (trimmed / unknown / reset).
+describe('replayHistory — lastSeq delta replay (#5555.3)', () => {
+  // Build a session-manager mock whose history entries carry _seq, and whose
+  // seq helpers derive from the (front-trimmable) entries. `oldestSeq` lets a
+  // test simulate front-trimming without actually mutating the array.
+  function managerWith(history, { truncated = false } = {}) {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => truncated
+    return manager
+  }
+
+  it('resolveReplayPlan: no cursor → full replay from offset 0', () => {
+    const history = [{ type: 'm', _seq: 1 }, { type: 'm', _seq: 2 }]
+    const manager = managerWith(history)
+    assert.deepEqual(resolveReplayPlan(manager, history, 'sess-1', undefined), { fullHistory: true, startOffset: 0 })
+    assert.deepEqual(resolveReplayPlan(manager, history, 'sess-1', 0), { fullHistory: true, startOffset: 0 })
+  })
+
+  it('resolveReplayPlan: cursor at an entry → delta replay starts at the NEXT entry (exact boundary)', () => {
+    // seqs 1..5; cursor = 3 → entry _seq=3 NOT resent, _seq=4 is the first sent.
+    const history = [1, 2, 3, 4, 5].map(s => ({ type: 'm', _seq: s }))
+    const manager = managerWith(history)
+    const plan = resolveReplayPlan(manager, history, 'sess-1', 3)
+    assert.equal(plan.fullHistory, false)
+    assert.equal(plan.startOffset, 3) // index of _seq=4
+    assert.equal(history[plan.startOffset]._seq, 4)
+  })
+
+  it('resolveReplayPlan: cursor == latest → empty delta slice (already current)', () => {
+    const history = [1, 2, 3].map(s => ({ type: 'm', _seq: s }))
+    const manager = managerWith(history)
+    const plan = resolveReplayPlan(manager, history, 'sess-1', 3)
+    assert.equal(plan.fullHistory, false)
+    assert.equal(plan.startOffset, history.length) // nothing to send
+  })
+
+  it('resolveReplayPlan: cursor below oldest retained (trim gap) → full replay fallback', () => {
+    // Ring buffer trimmed: oldest retained is _seq=10, client cursor is 4.
+    // 10 > 4 + 1 → gap → full replay.
+    const history = [10, 11, 12].map(s => ({ type: 'm', _seq: s }))
+    const manager = managerWith(history)
+    const plan = resolveReplayPlan(manager, history, 'sess-1', 4)
+    assert.deepEqual(plan, { fullHistory: true, startOffset: 0 })
+  })
+
+  it('resolveReplayPlan: cursor exactly one below oldest (no gap) → delta from offset 0', () => {
+    // oldest retained _seq=5, cursor=4 → 5 === 4+1 → contiguous, replay all.
+    const history = [5, 6, 7].map(s => ({ type: 'm', _seq: s }))
+    const manager = managerWith(history)
+    const plan = resolveReplayPlan(manager, history, 'sess-1', 4)
+    assert.deepEqual(plan, { fullHistory: false, startOffset: 0 })
+  })
+
+  it('delta replay: start frame carries fullHistory:false + latestSeq, only newer entries sent', async () => {
+    const history = [1, 2, 3, 4, 5].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history)
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws, { historyCursors: { 'sess-1': 3 } })
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const start = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.fullHistory, false)
+    assert.equal(start.latestSeq, 5)
+    const replayed = ctx._sends.filter(m => m.type === 'response')
+    assert.deepEqual(replayed.map(m => m.historySeq), [4, 5], 'only entries newer than cursor 3 are sent, in order')
+    // _seq internal field must not leak; wire field is historySeq.
+    assert.ok(replayed.every(m => m._seq === undefined), '_seq stripped from wire')
+    assert.ok(ctx._sends.some(m => m.type === 'history_replay_end'))
+  })
+
+  it('delta replay: cursor == latest → start+end with no entries between (no blank, nothing to append)', async () => {
+    const history = [1, 2, 3].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history)
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws, { historyCursors: { 'sess-1': 3 } })
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const types = ctx._sends.map(m => m.type)
+    assert.deepEqual(types, ['history_replay_start', 'history_replay_end'])
+    assert.equal(ctx._sends[0].fullHistory, false)
+    assert.equal(ctx._sends[0].latestSeq, 3)
+    assert.equal(ctx._sends[1].latestSeq, 3)
+  })
+
+  it('trim gap → full replay flagged fullHistory:true so the client rebuilds', async () => {
+    // oldest retained _seq=10, cursor=4 → gap → full replay of everything.
+    const history = [10, 11, 12].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history, { truncated: true })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws, { historyCursors: { 'sess-1': 4 } })
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const start = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.fullHistory, true)
+    assert.equal(start.truncated, true)
+    const replayed = ctx._sends.filter(m => m.type === 'response')
+    assert.deepEqual(replayed.map(m => m.historySeq), [10, 11, 12], 'full replay sends every retained entry')
+  })
+
+  it('unknown session cursor (no cursor for THIS session) → full replay', async () => {
+    const history = [1, 2, 3].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history)
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    // Client has a cursor for a DIFFERENT session only.
+    registerClient(ctx, ws, { historyCursors: { 'other-session': 2 } })
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const start = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.fullHistory, true)
+    assert.equal(ctx._sends.filter(m => m.type === 'response').length, 3)
+  })
+
+  it('old client (no historyCursors at all) → full replay unchanged', async () => {
+    const history = [1, 2, 3].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history)
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws) // no historyCursors
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const start = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.fullHistory, true)
+    // Full replay still carries historySeq so a NEW client can begin tracking.
+    const replayed = ctx._sends.filter(m => m.type === 'response')
+    assert.deepEqual(replayed.map(m => m.historySeq), [1, 2, 3])
+  })
+
+  it('forceFull overrides the cursor → full rebuild on session switch', async () => {
+    const history = [1, 2, 3, 4, 5].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history)
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    // Client HAS a fresh cursor — but a switch must ignore it.
+    registerClient(ctx, ws, { historyCursors: { 'sess-1': 4 } })
+
+    replayHistory(ctx, ws, 'sess-1', { forceFull: true })
+    await new Promise(r => setImmediate(r))
+
+    const start = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.fullHistory, true)
+    const replayed = ctx._sends.filter(m => m.type === 'response')
+    assert.deepEqual(replayed.map(m => m.historySeq), [1, 2, 3, 4, 5], 'forceFull replays everything despite the cursor')
+  })
+
+  it('seq ordering is preserved across the replay→live boundary', async () => {
+    // Replay entries seqs 1..3 via cursor=1 (sends 2,3). A subsequent live
+    // entry would be _seq=4 in the ring buffer; the replayed slice must end
+    // at the highest retained seq so the client's cursor lands at latest.
+    const history = [1, 2, 3].map(s => ({ type: 'response', content: `m${s}`, _seq: s }))
+    const manager = managerWith(history)
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws, { historyCursors: { 'sess-1': 1 } })
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const replayed = ctx._sends.filter(m => m.type === 'response')
+    const seqs = replayed.map(m => m.historySeq)
+    assert.deepEqual(seqs, [2, 3])
+    // strictly increasing
+    for (let i = 1; i < seqs.length; i++) assert.ok(seqs[i] > seqs[i - 1])
+    const start = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.equal(start.latestSeq, 3, 'client cursor advances to the latest retained seq')
   })
 })
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -2522,6 +2522,7 @@ describe('handleHistoryReplayStart', () => {
       receivingHistoryReplay: true,
       fullHistory: false,
       sessionId: null,
+      latestSeq: null,
     })
   })
 
@@ -2548,6 +2549,7 @@ describe('handleHistoryReplayStart', () => {
       receivingHistoryReplay: true,
       fullHistory: true,
       sessionId: 'sess-1',
+      latestSeq: null,
     })
   })
 
@@ -2583,6 +2585,19 @@ describe('handleHistoryReplayStart', () => {
         'active-1',
       ).sessionId,
     ).toBe('active-1')
+  })
+
+  // #5555.3 — latestSeq cursor advancement.
+  it('parses a finite numeric latestSeq', () => {
+    expect(handleHistoryReplayStart({ latestSeq: 42 }, null).latestSeq).toBe(42)
+    expect(handleHistoryReplayStart({ latestSeq: 0 }, null).latestSeq).toBe(0)
+  })
+
+  it('returns null latestSeq when absent or non-finite (older server / bad value)', () => {
+    expect(handleHistoryReplayStart({}, null).latestSeq).toBeNull()
+    expect(handleHistoryReplayStart({ latestSeq: NaN }, null).latestSeq).toBeNull()
+    expect(handleHistoryReplayStart({ latestSeq: '5' }, null).latestSeq).toBeNull()
+    expect(handleHistoryReplayStart({ latestSeq: Infinity }, null).latestSeq).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2106,15 +2106,24 @@ export interface HistoryReplayStartPayload {
    * when the resolved id maps to an existing session in its store.
    */
   sessionId: string | null
+  /**
+   * #5555.3 — the server's latest per-session history seq, carried on the
+   * `history_replay_start` frame so the client can advance its cursor even for
+   * an EMPTY delta replay (already-current reconnect). null when absent
+   * (older server) — the client then derives the cursor from per-entry
+   * `historySeq` instead.
+   */
+  latestSeq: number | null
 }
 
 /**
  * Parse a `history_replay_start` message.
  *
  * Returns the new flag value (`receivingHistoryReplay: true`), the strict
- * `fullHistory` flag, and the resolved target session id for the clearing
- * branch. Module-level flag mutation, transient-state clearing, and the
- * existence guard on the resolved sessionId stay at the call site.
+ * `fullHistory` flag, the resolved target session id for the clearing branch,
+ * and (#5555.3) the server's `latestSeq` for cursor advancement. Module-level
+ * flag mutation, transient-state clearing, the no-blank-flash reconcile, and
+ * the existence guard on the resolved sessionId stay at the call site.
  *
  * Note: this handler intentionally does NOT use `resolveSessionId()` because
  * the prior inline logic was `(msg.sessionId as string) || activeSessionId`,
@@ -2132,6 +2141,10 @@ export function handleHistoryReplayStart(
     receivingHistoryReplay: true,
     fullHistory: msg.fullHistory === true,
     sessionId: rawSessionId || activeSessionId,
+    latestSeq:
+      typeof msg.latestSeq === 'number' && Number.isFinite(msg.latestSeq)
+        ? msg.latestSeq
+        : null,
   }
 }
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -33,6 +33,18 @@ export { isVoiceInputMode } from './types'
 export { isFreeformAnswer } from './freeform-answer'
 export type { OtherFreeformAnswer } from './freeform-answer'
 
+// #5555.3 / #5555.4 — lastSeq cursor tracking + no-blank-flash replay reconcile.
+export {
+  resetReplayReconcile,
+  recordHistorySeq,
+  getHistoryCursors,
+  getHistoryCursor,
+  reconcileReplayStart,
+  reconcileReplayEnd,
+  isRebuildInProgress,
+  replayDedupCache,
+} from './replay-reconcile'
+
 export type {
   MessageAttachment,
   ToolResultImage,

--- a/packages/store-core/src/replay-reconcile.test.ts
+++ b/packages/store-core/src/replay-reconcile.test.ts
@@ -41,6 +41,34 @@ describe('history cursor tracking (#5555.3)', () => {
     expect(getHistoryCursors()).toEqual({})
   })
 
+  // #5555.3 review thread: the server honours at most MAX_HISTORY_CURSORS (64)
+  // keys from a single auth. The client must cap+evict LRU so it never sends a
+  // cursor the server would drop, and — critically — never evicts the active
+  // (most-recently-updated) session's cursor.
+  it('caps the cursor map at 64, evicting the least-recently-updated keys', () => {
+    for (let i = 0; i < 100; i++) recordHistorySeq(`s${i}`, i + 1)
+    const cursors = getHistoryCursors()
+    expect(Object.keys(cursors).length).toBe(64)
+    // The 36 oldest (s0..s35) were evicted; the 64 newest survive.
+    expect(cursors['s0']).toBeUndefined()
+    expect(cursors['s35']).toBeUndefined()
+    expect(cursors['s36']).toBe(37)
+    expect(cursors['s99']).toBe(100)
+  })
+
+  it('touching an old session refreshes its recency so it is not evicted', () => {
+    for (let i = 0; i < 64; i++) recordHistorySeq(`s${i}`, 1)
+    // s0 is currently the oldest. Advance its cursor → moves it to the tail.
+    recordHistorySeq('s0', 2)
+    // Add one more new session → eviction fires; s1 (now oldest) goes, not s0.
+    recordHistorySeq('s64', 1)
+    const cursors = getHistoryCursors()
+    expect(Object.keys(cursors).length).toBe(64)
+    expect(cursors['s0']).toBe(2) // refreshed, retained
+    expect(cursors['s1']).toBeUndefined() // evicted as the new oldest
+    expect(cursors['s64']).toBe(1)
+  })
+
   it('resetReplayReconcile retains cursors unless clearCursors', () => {
     recordHistorySeq('s1', 3)
     resetReplayReconcile() // baseline only

--- a/packages/store-core/src/replay-reconcile.test.ts
+++ b/packages/store-core/src/replay-reconcile.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  resetReplayReconcile,
+  recordHistorySeq,
+  getHistoryCursors,
+  getHistoryCursor,
+  reconcileReplayStart,
+  reconcileReplayEnd,
+  isRebuildInProgress,
+  replayDedupCache,
+} from './replay-reconcile'
+
+type Msg = { id: string }
+
+beforeEach(() => {
+  resetReplayReconcile({ clearCursors: true })
+})
+
+describe('history cursor tracking (#5555.3)', () => {
+  it('advances the per-session cursor to the highest seq seen', () => {
+    recordHistorySeq('s1', 1)
+    recordHistorySeq('s1', 5)
+    recordHistorySeq('s1', 3) // out of order — must NOT regress
+    expect(getHistoryCursor('s1')).toBe(5)
+  })
+
+  it('keeps cursors per-session', () => {
+    recordHistorySeq('s1', 4)
+    recordHistorySeq('s2', 9)
+    expect(getHistoryCursors()).toEqual({ s1: 4, s2: 9 })
+  })
+
+  it('ignores non-finite / negative / non-number seqs', () => {
+    recordHistorySeq('s1', NaN)
+    recordHistorySeq('s1', -1)
+    recordHistorySeq('s1', '7' as unknown)
+    expect(getHistoryCursor('s1')).toBeUndefined()
+  })
+
+  it('getHistoryCursors returns {} when empty (omit the auth field)', () => {
+    expect(getHistoryCursors()).toEqual({})
+  })
+
+  it('resetReplayReconcile retains cursors unless clearCursors', () => {
+    recordHistorySeq('s1', 3)
+    resetReplayReconcile() // baseline only
+    expect(getHistoryCursor('s1')).toBe(3)
+    resetReplayReconcile({ clearCursors: true })
+    expect(getHistoryCursor('s1')).toBeUndefined()
+  })
+})
+
+describe('delta replay — append-only, no rebuild (#5555.4)', () => {
+  it('reconcileReplayStart(fullHistory=false) does NOT start a rebuild', () => {
+    const { rebuildInProgress } = reconcileReplayStart('s1', false, 3)
+    expect(rebuildInProgress).toBe(false)
+    expect(isRebuildInProgress('s1')).toBe(false)
+  })
+
+  it('reconcileReplayEnd returns null swap for a delta replay (messages untouched)', () => {
+    reconcileReplayStart('s1', false, 3)
+    const { swappedMessages } = reconcileReplayEnd('s1', [{ id: 'a' }])
+    expect(swappedMessages).toBeNull()
+  })
+
+  it('start frame latestSeq does NOT advance the cursor (mid-replay drop safety)', () => {
+    // The cursor must only finalise once the slice is fully delivered (at end),
+    // so a socket drop mid-replay can't claim un-applied entries.
+    reconcileReplayStart('s1', false, 0, 12)
+    expect(getHistoryCursor('s1')).toBeUndefined()
+  })
+
+  it('END frame latestSeq advances the cursor even with no entries (already current)', () => {
+    reconcileReplayStart('s1', false, 0, 12)
+    reconcileReplayEnd('s1', [], 12)
+    expect(getHistoryCursor('s1')).toBe(12)
+  })
+
+  it('delta replay dedups against the WHOLE message array', () => {
+    reconcileReplayStart('s1', false, 2)
+    const msgs: Msg[] = [{ id: 'a' }, { id: 'b' }]
+    expect(replayDedupCache('s1', msgs)).toEqual(msgs)
+  })
+})
+
+describe('full rebuild — deferred atomic swap, no blank flash (#5555.4)', () => {
+  it('keeps a rebuild in progress and does NOT wipe (caller leaves messages visible)', () => {
+    const { rebuildInProgress } = reconcileReplayStart('s1', true, 3)
+    expect(rebuildInProgress).toBe(true)
+    expect(isRebuildInProgress('s1')).toBe(true)
+  })
+
+  it('dedup cache is scoped to the appended tail so the discarded prefix cannot suppress a replayed entry', () => {
+    // 3 pre-existing messages; replay starts → baseline 3. The tail (entries
+    // appended during replay) is what we dedup against, NOT the prefix.
+    reconcileReplayStart('s1', true, 3)
+    const msgs: Msg[] = [
+      { id: 'old-1' }, { id: 'old-2' }, { id: 'old-3' }, // prefix (discarded)
+      { id: 'new-1' }, // replayed so far
+    ]
+    expect(replayDedupCache('s1', msgs)).toEqual([{ id: 'new-1' }])
+  })
+
+  it('end swaps messages down to exactly the replayed tail in one update', () => {
+    reconcileReplayStart('s1', true, 2)
+    // prefix [old-1, old-2] stayed visible; replay appended [r-1, r-2, r-3]
+    const finalArray: Msg[] = [
+      { id: 'old-1' }, { id: 'old-2' },
+      { id: 'r-1' }, { id: 'r-2' }, { id: 'r-3' },
+    ]
+    const { swappedMessages } = reconcileReplayEnd('s1', finalArray)
+    expect(swappedMessages).toEqual([{ id: 'r-1' }, { id: 'r-2' }, { id: 'r-3' }])
+    // rebuild cleared
+    expect(isRebuildInProgress('s1')).toBe(false)
+  })
+
+  it('empty replay (baseline at end) swaps to [] — server trimmed history to nothing', () => {
+    reconcileReplayStart('s1', true, 2)
+    const { swappedMessages } = reconcileReplayEnd('s1', [{ id: 'old-1' }, { id: 'old-2' }])
+    expect(swappedMessages).toEqual([])
+  })
+
+  it('messages are never empty mid-replay (no blank flash invariant)', () => {
+    // The prefix is preserved in the live array the WHOLE time; only the final
+    // reconcileReplayEnd swap changes identity. We assert that dedupCache always
+    // exposes a non-destructive view and that no API zeroes the array mid-flight.
+    const live: Msg[] = [{ id: 'old-1' }, { id: 'old-2' }, { id: 'old-3' }]
+    reconcileReplayStart('s1', true, live.length)
+    // simulate appending replayed entries
+    live.push({ id: 'r-1' })
+    expect(live.length).toBe(4) // never dropped below the prefix
+    live.push({ id: 'r-2' })
+    const { swappedMessages } = reconcileReplayEnd('s1', live)
+    expect(swappedMessages).toEqual([{ id: 'r-1' }, { id: 'r-2' }])
+  })
+})
+
+describe('replay × delta-flusher race ordering (#5588)', () => {
+  it('a forced flush landing DURING a full rebuild survives the swap in array order', () => {
+    reconcileReplayStart('s1', true, 1)
+    // prefix [old]; replay appends r-1, then a forced flush appends a streamed
+    // response f-1, then replay appends r-2.
+    const live: Msg[] = [
+      { id: 'old' },
+      { id: 'r-1' },
+      { id: 'f-1' }, // racing flush
+      { id: 'r-2' },
+    ]
+    const { swappedMessages } = reconcileReplayEnd('s1', live)
+    // Tail preserved in exact array order — flush neither dropped nor reordered.
+    expect(swappedMessages).toEqual([{ id: 'r-1' }, { id: 'f-1' }, { id: 'r-2' }])
+  })
+
+  it('a flush landing AFTER end appends to the already-swapped set with no duplication', () => {
+    reconcileReplayStart('s1', true, 1)
+    const live: Msg[] = [{ id: 'old' }, { id: 'r-1' }]
+    const { swappedMessages } = reconcileReplayEnd('s1', live)
+    expect(swappedMessages).toEqual([{ id: 'r-1' }])
+    // Post-end, no rebuild is active, so a later flush just appends normally;
+    // reconcileReplayEnd for a non-rebuild session returns null (no second swap).
+    expect(reconcileReplayEnd('s1', [{ id: 'r-1' }, { id: 'f-1' }]).swappedMessages).toBeNull()
+  })
+})

--- a/packages/store-core/src/replay-reconcile.ts
+++ b/packages/store-core/src/replay-reconcile.ts
@@ -1,0 +1,191 @@
+/**
+ * Shared history-replay reconcile + cursor tracking (#5555.3 / #5555.4)
+ *
+ * Two coupled concerns, both shared by the mobile app and web dashboard so the
+ * two clients can't drift:
+ *
+ * 1. **lastSeq cursor (#5555.3).** The server stamps each replayed history
+ *    entry with `historySeq` (a monotonic per-session sequence). The client
+ *    tracks the highest seq it has APPLIED per session and sends the map back
+ *    in the next `auth` message (`historyCursors`). The server then replays
+ *    only entries newer than the cursor instead of the full ring buffer.
+ *
+ *    The cursor advances on the REPLAY path only — live-streamed messages carry
+ *    no seq, so a session that streams after its replay keeps the cursor pinned
+ *    at the last replayed seq. On the next reconnect the server backfills
+ *    everything recorded since (bounded by activity-during-disconnect), which is
+ *    correct and append-only. The `history_replay_start`/`_end` frames also
+ *    carry `latestSeq` so an empty (already-current) delta replay still advances
+ *    the cursor with no entry to read a seq off.
+ *
+ * 2. **No-blank-flash reconcile (#5555.4).** Historically a full replay wiped
+ *    the session's `messages` to `[]` at `history_replay_start`, then rebuilt
+ *    oldest-first — the worst perceived-speed moment in the product. Now:
+ *
+ *    - **Delta replay** (`fullHistory: false`, the common reconnect path with a
+ *      cursor): purely append-only. No wipe, no baseline, nothing to swap — the
+ *      replayed entries are strictly newer than what the client already shows.
+ *
+ *    - **Full rebuild** (`fullHistory: true`: first connect, or the trim-gap /
+ *      seq-reset fallback): keep the existing messages VISIBLE while the
+ *      authoritative replayed set is rebuilt, then swap atomically at
+ *      `history_replay_end`. Implemented as a "deferred swap": record the
+ *      pre-replay message count as a baseline; replayed entries append AFTER it;
+ *      at end, slice the array down to the appended tail (the replayed set) in a
+ *      single store update. The pre-replay prefix stays on screen the whole time
+ *      and vanishes only at the swap — no blank flash, scroll position
+ *      preserved by the UI layer because the array identity only changes once.
+ *
+ *      During a full rebuild the replay-dedup cache MUST be scoped to the
+ *      appended tail (`messagesSinceBaseline`) — NOT the whole array — so a
+ *      replayed entry is not suppressed by matching an id in the
+ *      about-to-be-discarded prefix (which would drop it from the swapped set).
+ *
+ * Ordering note (replay × delta-flusher race, #5588): a forced delta flush that
+ * lands DURING a full rebuild appends a streamed response into the tail just
+ * like a replayed entry, so it survives the swap in array order. A flush that
+ * lands AFTER `history_replay_end` (rebuild already cleared) appends normally.
+ * Either way the swap only ever slices off the pre-baseline prefix, so a racing
+ * flush can neither be duplicated nor reordered relative to replayed entries —
+ * see `reconcileReplayEnd` and the race test in `replay-reconcile.test.ts`.
+ */
+
+/**
+ * Per-session full-rebuild state. Absent key ⇒ no rebuild in progress for that
+ * session (delta replay or no replay). `baseline` is the `messages.length`
+ * captured at `history_replay_start`.
+ */
+const _rebuildBaseline = new Map<string, number>()
+
+/**
+ * Per-session highest applied `historySeq`. Sent back as `historyCursors` in
+ * the next `auth`. Survives across reconnects in module memory (the same module
+ * instance lives for the app/dashboard session), and is the single source the
+ * connect path reads when building the auth payload.
+ */
+const _historyCursors = new Map<string, number>()
+
+/**
+ * Reset all replay-reconcile state. Called on fresh auth / hard reset so a new
+ * connection doesn't inherit a stale baseline. Does NOT clear cursors by
+ * default — those are intentionally retained so a reconnect can present them
+ * (pass `clearCursors: true` to wipe them too, e.g. on full disconnect/logout).
+ */
+export function resetReplayReconcile(opts: { clearCursors?: boolean } = {}): void {
+  _rebuildBaseline.clear()
+  if (opts.clearCursors) _historyCursors.clear()
+}
+
+/**
+ * Record a replayed entry's `historySeq`, advancing the per-session cursor.
+ * Ignores non-finite / non-increasing values so out-of-order or malformed
+ * frames can't regress the cursor.
+ */
+export function recordHistorySeq(sessionId: string | null | undefined, seq: unknown): void {
+  if (!sessionId) return
+  if (typeof seq !== 'number' || !Number.isFinite(seq) || seq < 0) return
+  const cur = _historyCursors.get(sessionId)
+  if (cur === undefined || seq > cur) _historyCursors.set(sessionId, seq)
+}
+
+/**
+ * Snapshot of the per-session cursors for the `auth.historyCursors` field.
+ * Returns a plain object (never a live Map). Empty ⇒ omit the field (old-client
+ * shape) so the server falls back to a full replay.
+ */
+export function getHistoryCursors(): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const [sid, seq] of _historyCursors) out[sid] = seq
+  return out
+}
+
+/** Read a single session's cursor (testing / diagnostics). */
+export function getHistoryCursor(sessionId: string): number | undefined {
+  return _historyCursors.get(sessionId)
+}
+
+/**
+ * Begin a replay for a session. `fullHistory` is the server's flag from
+ * `history_replay_start`; `currentLen` is `messages.length` right now.
+ *
+ * For a full rebuild we record the baseline so the appended replay tail can be
+ * sliced out at end.
+ *
+ * The `latestSeq` carried on the start frame is INTENTIONALLY NOT applied to
+ * the cursor here. If the socket drops mid-replay (before history_replay_end),
+ * advancing the cursor to `latestSeq` at start would make the next reconnect
+ * claim it has entries it never applied → silent gap. The cursor advances
+ * per-entry as entries are applied, and is finalised from `latestSeq` only at
+ * `reconcileReplayEnd` — i.e. once the whole slice has been delivered.
+ *
+ * Returns whether a full rebuild is now in progress (the caller does NOT wipe
+ * messages either way — the whole point of #5555.4).
+ */
+export function reconcileReplayStart(
+  sessionId: string | null,
+  fullHistory: boolean,
+  currentLen: number,
+  // Accepted for call-site symmetry with the wire frame; deliberately unused —
+  // see the doc comment above on why the cursor is not advanced at start.
+  _latestSeq?: unknown,
+): { rebuildInProgress: boolean } {
+  if (!sessionId) return { rebuildInProgress: false }
+  if (fullHistory) {
+    _rebuildBaseline.set(sessionId, Math.max(0, currentLen | 0))
+    return { rebuildInProgress: true }
+  }
+  // Delta replay: append-only, ensure no stale baseline lingers.
+  _rebuildBaseline.delete(sessionId)
+  return { rebuildInProgress: false }
+}
+
+/** Is a full rebuild currently in progress for this session? */
+export function isRebuildInProgress(sessionId: string | null | undefined): boolean {
+  return !!sessionId && _rebuildBaseline.has(sessionId)
+}
+
+/**
+ * The dedup cache a replayed entry should be matched against. During a full
+ * rebuild this is the appended tail only (entries replayed so far) so a
+ * replayed entry isn't suppressed by an id in the discarded prefix. For a delta
+ * replay (or no rebuild) it's the whole array, matching the historical behavior
+ * (dedup replayed entries against everything the client already shows).
+ */
+export function replayDedupCache<T>(
+  sessionId: string | null | undefined,
+  messages: readonly T[],
+): readonly T[] {
+  if (sessionId && _rebuildBaseline.has(sessionId)) {
+    const base = _rebuildBaseline.get(sessionId) as number
+    return messages.slice(base)
+  }
+  return messages
+}
+
+/**
+ * Finish a replay for a session. For a full rebuild, returns the swapped
+ * message array (the appended tail = the authoritative replayed set) so the
+ * caller applies it in ONE store update — the atomic swap. For a delta replay /
+ * no rebuild, returns `null` (caller leaves `messages` untouched).
+ *
+ * `latestSeq` (when present) advances the cursor one last time, covering the
+ * empty-slice case where no entry carried a seq.
+ */
+export function reconcileReplayEnd(
+  sessionId: string | null,
+  messages: readonly unknown[],
+  latestSeq?: unknown,
+): { swappedMessages: unknown[] | null } {
+  if (sessionId && typeof latestSeq === 'number' && Number.isFinite(latestSeq)) {
+    recordHistorySeq(sessionId, latestSeq)
+  }
+  if (!sessionId || !_rebuildBaseline.has(sessionId)) {
+    return { swappedMessages: null }
+  }
+  const base = _rebuildBaseline.get(sessionId) as number
+  _rebuildBaseline.delete(sessionId)
+  // Slice off the pre-replay prefix → exactly the replayed (+ any racing live)
+  // tail, in array order. A baseline at or past the end yields [] (a session
+  // that genuinely had no replayed entries, e.g. server-side trim to empty).
+  return { swappedMessages: messages.slice(base) }
+}

--- a/packages/store-core/src/replay-reconcile.ts
+++ b/packages/store-core/src/replay-reconcile.ts
@@ -62,8 +62,25 @@ const _rebuildBaseline = new Map<string, number>()
  * the next `auth`. Survives across reconnects in module memory (the same module
  * instance lives for the app/dashboard session), and is the single source the
  * connect path reads when building the auth payload.
+ *
+ * Iteration order is LRU-by-update: `recordHistorySeq` re-inserts the touched
+ * key so it moves to the tail (newest), and the cap below evicts from the head
+ * (oldest). This keeps the map bounded and — critically — guarantees the
+ * just-updated (active) session's cursor is never the one evicted, so a heavy
+ * user with hundreds of historical sessions still gets a delta reconnect on the
+ * session they're actually viewing (#5555.3 review thread).
  */
 const _historyCursors = new Map<string, number>()
+
+/**
+ * Client-side cap on the per-session cursor map. Mirrors the server's
+ * `MAX_HISTORY_CURSORS` (ws-auth.js): the server only honours that many keys
+ * from a single `auth`, so retaining/sending more is pure bloat. Holding the
+ * client cap at the same value (and evicting LRU) means the client never sends
+ * a cursor the server would silently drop, and the active session's cursor is
+ * always within the honoured window.
+ */
+const MAX_CLIENT_HISTORY_CURSORS = 64
 
 /**
  * Reset all replay-reconcile state. Called on fresh auth / hard reset so a new
@@ -85,7 +102,18 @@ export function recordHistorySeq(sessionId: string | null | undefined, seq: unkn
   if (!sessionId) return
   if (typeof seq !== 'number' || !Number.isFinite(seq) || seq < 0) return
   const cur = _historyCursors.get(sessionId)
-  if (cur === undefined || seq > cur) _historyCursors.set(sessionId, seq)
+  if (cur !== undefined && seq <= cur) return
+  // Re-insert so the touched (active) session moves to the Map tail — LRU order
+  // for the cap below. A plain `.set` on an existing key keeps its old slot, so
+  // delete-then-set is required to refresh recency.
+  _historyCursors.delete(sessionId)
+  _historyCursors.set(sessionId, seq)
+  // Evict the least-recently-updated cursor(s) from the head once over the cap.
+  while (_historyCursors.size > MAX_CLIENT_HISTORY_CURSORS) {
+    const oldest = _historyCursors.keys().next().value
+    if (oldest === undefined) break
+    _historyCursors.delete(oldest)
+  }
 }
 
 /**


### PR DESCRIPTION
Implements sub-items **3 and 4** of epic #5555 (cold-connect first-paint). Builds on the merged #5590/#5592/#5591/#5588 work. Two coupled changes in one PR; protocol-additive, backward-compatible both directions, no flag day.

## 1. `lastSeq` delta replay (#5555.3)

Today every connect replays the **entire** ring buffer (ws-history had no cursor). Now the client sends a per-session history cursor and the server replays only what's newer.

### Cursor design choice — per-session map, advanced on the replay path
- Wire shape: `auth.historyCursors: { [sessionId]: lastSeq }` (additive optional, Zod-validated, server caps honoured keys at `MAX_HISTORY_CURSORS = 64`). A **map** (not just the active session) is future-proof for multi-session delta replay and costs nothing today; v1 only actually replays the bound/active session on connect.
- Each history entry gets a monotonic per-session `_seq` (server-internal; **stripped from the persisted state file**, reassigned `1..N` on restore). The wire exposes it as `historySeq` on replayed entries; `latestSeq` rides the `history_replay_start`/`_end` frames.
- The client tracks the highest applied `historySeq` per session and **advances the cursor only once a replay slice is fully delivered** (finalised from `latestSeq` at `history_replay_end`). Seeding at start would let a mid-replay socket drop claim un-applied entries → silent gap. Live-streamed messages carry no seq, so an active session that streams after its replay keeps the cursor pinned at the last replayed seq; the next reconnect backfills everything recorded since (bounded by activity-during-disconnect). Correct and append-only.

### Fallback semantics (server can't honour the cursor → full replay, flagged)
`resolveReplayPlan` falls back to a **full replay** with `fullHistory: true` (so the client rebuilds rather than appends) when:
- no cursor / cursor ≤ 0 (old client, first connect),
- the oldest **retained** entry's seq is `> lastSeq + 1` — the entry just after the cursor was trimmed off the ring buffer (or seqs reset on a server restart) → a delta would skip entries.

Cursor is **connect-only**. Session switch / forced re-home / new-subscribe pass `forceFull: true` (a background session accumulates live broadcasts in the client's per-session list while viewed elsewhere, so its cursor lags and a delta would re-send/duplicate them). `request_full_history` was already its own forced-full path — unchanged.

### Backpressure machinery: kept, not deleted
The epic predicted "most of the replay backpressure machinery becomes dead code." Audited and **kept all of it** (`scheduleAfterDrain`, the bufferedAmount chunk-entry + mid-chunk gates, the `BACKPRESSURE_MAX_WAIT_MS` cap): a cursor replay's tail is bounded by *activity-during-disconnect*, which for fat tool_result payloads (200KB+) can still blow past the 1MB eviction line over a long blip. The machinery now operates on the resolved slice (`startOffset`) instead of always `0`. Genuinely-dead code: **none** — the prediction assumed cursor replays are always tiny, which isn't true for long disconnects.

## 2. Replay UX — no blank flash + preserve-then-reconcile (#5555.4)

Shared in `store-core/replay-reconcile.ts`; both clients route through it.
- **No wipe on replay start.** Delta replay is naturally append-only. **Full rebuild** records the pre-replay message count as a baseline, keeps the existing messages **visible**, appends the authoritative replayed set after the baseline, and **swaps atomically** to the appended tail in one store update at `history_replay_end`. The old prefix vanishes only at the swap → no blank flash, scroll position preserved (array identity changes once).
- **Dedup scoped to the tail during a rebuild** (`replayDedupCache`) so a replayed entry isn't suppressed by an id in the about-to-be-discarded prefix and then lost in the swap. Respects the stream_id collision invariant (handlers still check existing message type before reusing a messageId) and the #3743 authoritative-replace contract.

### Reconcile × delta-flusher race (pinned by tests)
A forced flush landing **during** a full rebuild appends into the tail in array order → survives the swap, neither dropped nor reordered. A flush mutating a prefix message (below baseline) is harmless — that message is sliced off and the authoritative copy comes from replay. A flush **after** `history_replay_end` appends normally (no second swap). Pinned in `replay-reconcile.test.ts`.

## Protocol
Additive optional `historyCursors` on `AuthSchema`; tracked `dist/` regenerated. Old client → omits field → full replay. New client → old server ignores field → full replay. New client → new server with no prior cursor → full replay. No flag day.

## RTT / payload savings
- **Quick reconnect during idle** (tab refresh, tunnel blip): cursor == latest → empty delta slice → `start`+`end` with **zero** entries. Replaces a full ring-buffer dump (up to 1000 entries / many chunked RTTs of buffered frames) with ~1 frame. Near-zero replay, as the epic targeted.
- **Active-session reconnect**: replays only entries recorded during the disconnect window (bounded by activity), not the whole buffer.
- **First connect / trim-fallback**: unchanged full replay — but now without the blank-flash wipe.

## Tests
- Server: cursor exact boundary (entry AT cursor not resent, next is), trim-gap + unknown-session + old-client full-replay-unchanged fallbacks, `forceFull` override, seq ordering across the replay→live boundary, seq stamping/restore/cleanup, `auth.historyCursors` stash + cap. Temp `stateFilePath` throughout; `--test-force-exit`.
- store-core: cursor tracking, no-blank-flash invariant (messages never empty mid-replay), atomic swap on full rebuild, tail-scoped dedup, replay×flusher race ordering, `latestSeq` parsing.
- All 4 server custom lints green; eslint (server src) clean; full suites green — server 9281 pass (only the 2 documented `service.test.js` network flakes, which reproduce on clean main), dashboard 3538, store-core 1305, app message-handler 174 + connection 153, protocol 282. Typechecks: protocol/store-core/dashboard/app all green.

UI-layer note (not unit-testable in store): scroll anchoring is preserved because the full-rebuild swap changes the `messages` array identity exactly once (at end) instead of twice (wipe + rebuild); delta replay never changes identity destructively.

Related to #5555 (sub-items 5-7 remain open).