### PR TITLE
fix(ws): reconnect backoff ladder + keepalive coordination (#5555.5/.6)

### DIFF
--- a/packages/app/src/__tests__/store/connection-audit-phase1.test.ts
+++ b/packages/app/src/__tests__/store/connection-audit-phase1.test.ts
@@ -24,6 +24,7 @@ jest.mock('expo-secure-store', () => ({
 import * as SecureStore from 'expo-secure-store';
 import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
 import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { resetReconnectAttempt } from '../../store/message-handler';
 import { clearAllCallbacks } from '../../store/imperative-callbacks';
 
 // ---------------------------------------------------------------------------
@@ -109,6 +110,10 @@ beforeEach(() => {
   jest.useFakeTimers();
   clearAllCallbacks();
   __resetDeviceIdCacheForTests();
+  // #5555.5 — the close/error-path backoff ladder is module-level state; reset
+  // it between tests so a prior test's climbed rung doesn't push a later
+  // reconnect's delay past this file's fixed `advanceTimersByTime(5000)` budget.
+  resetReconnectAttempt();
   (SecureStore.getItemAsync as jest.Mock).mockReset();
   (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('dev-id-123');
   (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);

--- a/packages/app/src/__tests__/store/connection-reconnect-backoff.test.ts
+++ b/packages/app/src/__tests__/store/connection-reconnect-backoff.test.ts
@@ -1,0 +1,302 @@
+/**
+ * #5555.5 — reconnect backoff on the socket-close/error path.
+ *
+ * The close/error handlers used to schedule reconnects at a FIXED delay
+ * (AUTO_RECONNECT_DELAY=1500ms / ERROR_RECONNECT_DELAY=2000ms), so a flapping
+ * tunnel hammered the full handshake every ~1.5–2s. They now climb the shared
+ * RETRY_DELAYS ladder ([1000, 2000, 3000, 5000, 8000], jittered) via a
+ * module-level counter that RESETS on `auth_ok` (a successful connect), NOT on
+ * mere socket-open.
+ *
+ * Math.random is pinned to 0 so withJitter() is the identity and each rung's
+ * delay is exactly RETRY_DELAYS[N].
+ *
+ * Mirrors the fake-WebSocket / fake-timer harness in
+ * connection-audit-phase1.test.ts.
+ */
+import type { SavedConnection } from '@chroxy/store-core';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve('dev-id-123')),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import {
+  resetReconnectAttempt,
+  nextReconnectAttempt,
+  reconnectAttempt,
+} from '../../store/message-handler';
+import { clearAllCallbacks } from '../../store/imperative-callbacks';
+
+// The five-rung backoff ladder (kept in sync with connect()'s RETRY_DELAYS).
+const RETRY_DELAYS = [1000, 2000, 3000, 5000, 8000];
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) =>
+    jest.requireActual<typeof globalThis>('timers').setImmediate(resolve),
+  );
+}
+
+function mockResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  } as unknown as Response;
+}
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: ((event?: unknown) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onmessage: ((event: unknown) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+function installMockWebSocket(): { instances: FakeSocket[]; restore: () => void } {
+  const instances: FakeSocket[] = [];
+  const Original = global.WebSocket;
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 0;
+    onopen: (() => void) | null = null;
+    onclose: ((event?: unknown) => void) | null = null;
+    onerror: ((event?: unknown) => void) | null = null;
+    onmessage: ((event: unknown) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn();
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this as unknown as FakeSocket);
+    }
+  };
+  return { instances, restore: () => { global.WebSocket = Original; } };
+}
+
+const originalFetch = global.fetch;
+let randomSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  clearAllCallbacks();
+  __resetDeviceIdCacheForTests();
+  resetReconnectAttempt();
+  // Pin jitter to zero so each rung delay is exactly RETRY_DELAYS[N].
+  randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+  (SecureStore.getItemAsync as jest.Mock).mockReset();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('dev-id-123');
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+  useConnectionStore.setState({
+    serverErrors: [],
+    connectedClients: [],
+    myClientId: null,
+    primaryClientId: null,
+    sessionStates: {},
+    activeSessionId: null,
+    socket: null,
+    shutdownReason: null,
+    restartEtaMs: null,
+    restartingSince: null,
+  });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+  });
+});
+
+afterEach(() => {
+  useConnectionStore.getState().disconnect();
+  randomSpy.mockRestore();
+  global.fetch = originalFetch;
+  jest.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Ladder math (pure module-level counter)
+// ---------------------------------------------------------------------------
+
+describe('reconnect backoff ladder counter (#5555.5)', () => {
+  it('nextReconnectAttempt advances and resetReconnectAttempt rewinds', () => {
+    expect(reconnectAttempt).toBe(0);
+    expect(nextReconnectAttempt()).toBe(0); // pre-increment index
+    expect(nextReconnectAttempt()).toBe(1);
+    expect(nextReconnectAttempt()).toBe(2);
+    resetReconnectAttempt();
+    expect(reconnectAttempt).toBe(0);
+    expect(nextReconnectAttempt()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end close-path backoff
+// ---------------------------------------------------------------------------
+
+describe('socket-close reconnect backoff (#5555.5)', () => {
+  async function openConnectedSocket() {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    await flushPromises();
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+    return { ws, fetchMock };
+  }
+
+  /**
+   * Drives one drop → reconnect cycle and asserts the reconnect fires at exactly
+   * `expectedDelay` ms (no sooner). Marks the freshly created socket connected so
+   * the next drop takes the auto-reconnect branch again.
+   */
+  async function expectReconnectAt(ws: { instances: FakeSocket[] }, expectedDelay: number) {
+    const socket = ws.instances[ws.instances.length - 1];
+    const before = ws.instances.length;
+
+    socket.onclose?.({ code: 1006 });
+
+    // One tick short of the rung delay: still no new socket.
+    jest.advanceTimersByTime(expectedDelay - 1);
+    await flushPromises();
+    expect(ws.instances.length).toBe(before);
+
+    // Cross the boundary: the reconnect fires (connect() → fetch → new socket).
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(ws.instances.length).toBe(before + 1);
+
+    // Mark the new socket connected for the next cycle.
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+  }
+
+  it('escalates through the RETRY_DELAYS ladder across consecutive drops', async () => {
+    const { ws } = await openConnectedSocket();
+
+    // Rung 0 → 1000ms, rung 1 → 2000ms, rung 2 → 3000ms, rung 3 → 5000ms.
+    await expectReconnectAt(ws, RETRY_DELAYS[0]);
+    await expectReconnectAt(ws, RETRY_DELAYS[1]);
+    await expectReconnectAt(ws, RETRY_DELAYS[2]);
+    await expectReconnectAt(ws, RETRY_DELAYS[3]);
+
+    ws.restore();
+  });
+
+  it('caps at the top rung (8000ms) once the ladder is exhausted', async () => {
+    const { ws } = await openConnectedSocket();
+
+    // Walk to the last rung.
+    await expectReconnectAt(ws, RETRY_DELAYS[0]);
+    await expectReconnectAt(ws, RETRY_DELAYS[1]);
+    await expectReconnectAt(ws, RETRY_DELAYS[2]);
+    await expectReconnectAt(ws, RETRY_DELAYS[3]);
+    // Rung 4 and every subsequent drop clamp at the final 8000ms rung.
+    await expectReconnectAt(ws, RETRY_DELAYS[4]);
+    await expectReconnectAt(ws, RETRY_DELAYS[4]);
+
+    ws.restore();
+  });
+
+  it('does NOT use the old fixed 1500ms delay on the first close', async () => {
+    const { ws } = await openConnectedSocket();
+    const socket = ws.instances[0];
+    const before = ws.instances.length;
+
+    socket.onclose?.({ code: 1006 });
+    // At the legacy fixed delay the reconnect would already have fired — assert
+    // it has NOT (rung 0 is 1000ms, so by 1000ms it fires; we check that the
+    // delay is ladder-driven by confirming it fires at exactly 1000, see above).
+    // Here we just confirm 1500ms isn't the gate: it already fired by 1000.
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+    expect(ws.instances.length).toBe(before + 1);
+
+    ws.restore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reset-on-auth_ok (NOT on socket-open)
+// ---------------------------------------------------------------------------
+
+describe('backoff ladder resets on auth_ok, not socket-open (#5555.5)', () => {
+  async function openConnectedSocket() {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    await flushPromises();
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+    return { ws };
+  }
+
+  it('a successful auth_ok rewinds the ladder back to the bottom rung', async () => {
+    const { ws } = await openConnectedSocket();
+
+    // Two consecutive drops climb to rung 2 (the next drop would be 3000ms).
+    const s0 = ws.instances[0];
+    s0.onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(RETRY_DELAYS[0]); // rung 0 fires
+    await flushPromises();
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+
+    const s1 = ws.instances[1];
+    s1.onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(RETRY_DELAYS[1]); // rung 1 fires
+    await flushPromises();
+
+    // The reconnect opened a fresh socket; drive a real auth_ok through its
+    // onmessage so the production handler resets the ladder.
+    const s2 = ws.instances[2];
+    s2.readyState = 1;
+    s2.onopen?.();
+    await flushPromises();
+    expect(reconnectAttempt).toBe(2); // climbed but not yet reset
+
+    s2.onmessage?.({ data: JSON.stringify({ type: 'auth_ok', serverMode: 'cli' }) });
+    await flushPromises();
+
+    // auth_ok reset the ladder — the next drop schedules at rung 0 (1000ms).
+    expect(reconnectAttempt).toBe(0);
+
+    const before = ws.instances.length;
+    s2.onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(RETRY_DELAYS[0] - 1);
+    await flushPromises();
+    expect(ws.instances.length).toBe(before); // not yet — proves it's 1000ms not <1000ms
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(ws.instances.length).toBe(before + 1);
+
+    ws.restore();
+  });
+
+  it('socket-open alone does NOT reset the ladder (only auth_ok does)', async () => {
+    const { ws } = await openConnectedSocket();
+
+    const s0 = ws.instances[0];
+    s0.onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(RETRY_DELAYS[0]); // rung 0 fires
+    await flushPromises();
+
+    // The reconnect's socket OPENED (onopen) but never authenticated.
+    const s1 = ws.instances[1];
+    s1.readyState = 1;
+    s1.onopen?.();
+    await flushPromises();
+
+    // No auth_ok → ladder must NOT have reset; it's at rung 1.
+    expect(reconnectAttempt).toBe(1);
+
+    ws.restore();
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -105,6 +105,7 @@ import {
   setDisconnectedAttemptId,
   lastConnectedUrl,
   setLastConnectedUrl,
+  nextReconnectAttempt,
   pendingPairingId,
   setPendingPairingId,
   setPendingSwitchSessionId,
@@ -174,10 +175,10 @@ import {
 
 const STORAGE_KEY_INPUT_SETTINGS = 'chroxy_input_settings';
 
-/** Delay before auto-reconnecting after an unexpected socket close (ms) */
-const AUTO_RECONNECT_DELAY = 1500;
-/** Delay before reconnecting after a WebSocket error (ms) */
-const ERROR_RECONNECT_DELAY = 2000;
+// #5555.5 — the close/error-path reconnect delay is no longer a fixed
+// constant. Both handlers now climb the RETRY_DELAYS ladder (defined in
+// connect()) via the module-level reconnectAttempt counter, which resets on
+// `auth_ok`. See scheduleReconnect() below.
 
 // #4771: getWsCloseMessage and getHealthCheckErrorMessage are now
 // defined in `packages/store-core/src/ws-errors.ts` and exported from
@@ -923,22 +924,28 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // #3624 (ported from dashboard) — shared reconnect scheduler for both
     // onclose and onerror. A single transport drop fires `error` → `close` on
     // most WebSocket implementations, so without dedupe we'd queue two
-    // setTimeouts for one underlying failure. Previously mobile only avoided the
-    // double-reconnect by accident: the staggered AUTO_RECONNECT_DELAY (1500ms)
-    // vs ERROR_RECONNECT_DELAY (2000ms) delays plus the connectionAttemptId
-    // bump on the first-firing timer cancelled the second — timing-dependent,
-    // not a design guarantee.
+    // setTimeouts for one underlying failure.
     //
     // A per-socket flag (not phase-only dedupe) is correct here: each new socket
     // gets a fresh scheduler with `reconnectScheduled = false`, so a *new*
     // socket's failure mid-reconnect (when the global phase is already
     // 'reconnecting') can still arm its own retry timer. The flag is bounded to
-    // this socket's lifetime. Delay semantics are preserved by passing each
-    // handler's original delay; first-write-wins on the reconnecting phase.
+    // this socket's lifetime; first-write-wins on the reconnecting phase.
+    //
+    // #5555.5 — the close/error path no longer uses a FIXED delay (was
+    // 1.5s/2s). A flapping tunnel would hammer the full handshake at that
+    // fixed cadence. Instead we climb the same RETRY_DELAYS ladder used by the
+    // pre-WS health-check retries: each scheduled reconnect advances one rung
+    // (1s → 2s → 3s → 5s → 8s, capped). The ladder is module-level and only
+    // resets on `auth_ok` (proof the link is healthy), so a socket that opens
+    // but never authenticates keeps backing off. The per-socket dedupe means a
+    // paired error → close drop advances the ladder exactly once.
     let reconnectScheduled = false;
-    const scheduleReconnect = (delayMs: number): void => {
+    const scheduleReconnect = (): void => {
       if (reconnectScheduled) return;
       reconnectScheduled = true;
+      const rung = nextReconnectAttempt();
+      const delayMs = withJitter(RETRY_DELAYS[Math.min(rung, RETRY_DELAYS.length - 1)]);
       setTimeout(() => {
         if (myAttemptId !== connectionAttemptId) return;
         get().connect(url, token);
@@ -1059,8 +1066,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           useConnectionLifecycleStore.getState().setConnectionError(closeMsg, 0);
         }
         // #3624 — dedup via the per-socket guard so a paired error → close
-        // sequence arms exactly one retry. Preserves the AUTO_RECONNECT_DELAY.
-        scheduleReconnect(AUTO_RECONNECT_DELAY);
+        // sequence arms exactly one retry. #5555.5 — delay comes from the
+        // RETRY_DELAYS ladder, not a fixed constant.
+        scheduleReconnect();
       } else {
         // Connection dropped before it ever reached "connected" state. Previously
         // we silently marked as disconnected, swallowing the real close reason
@@ -1102,7 +1110,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
           useConnectionLifecycleStore.getState().setConnectionError(errorMsg, 0);
         }
-        scheduleReconnect(ERROR_RECONNECT_DELAY);
+        scheduleReconnect();
       }
     };
     } // end _connectWebSocket

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -593,8 +593,28 @@ export let connectionAttemptId = 0;
 export let disconnectedAttemptId = -1;
 export let lastConnectedUrl: string | null = null;
 
+// #5555.5 — consecutive close/error-path reconnect counter, used to index the
+// RETRY_DELAYS backoff ladder so a flapping tunnel escalates its retry spacing
+// (1s → 2s → 3s → 5s → 8s) instead of hammering the handshake at a fixed delay.
+// Reset to 0 on `auth_ok` (a *successful* connect — proof the link is healthy),
+// NOT on mere socket-open, so a socket that opens but never authenticates keeps
+// climbing the ladder. Lives here (not a connect() closure) because the count
+// must survive the connect() → drop → connect() cycle and be cleared from the
+// auth_ok handler.
+export let reconnectAttempt = 0;
+
 export function bumpConnectionAttemptId(): number {
   return ++connectionAttemptId;
+}
+
+/** Advance the backoff ladder, returning the pre-increment attempt index. */
+export function nextReconnectAttempt(): number {
+  return reconnectAttempt++;
+}
+
+/** Reset the backoff ladder — called from the `auth_ok` handler on a clean connect. */
+export function resetReconnectAttempt(): void {
+  reconnectAttempt = 0;
 }
 
 export function setDisconnectedAttemptId(id: number): void {
@@ -1254,6 +1274,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       resetReplayReconcile();
       _ctx.isSessionSwitchReplay = false;
       _ctx.pendingSwitchSessionId = null;
+      // #5555.5 — a successful auth is the ONLY proof the link is healthy, so
+      // reset the close/error-path backoff ladder here (not on socket-open). A
+      // socket that opens but never authenticates keeps climbing the ladder.
+      resetReconnectAttempt();
       if (!ctx.isReconnect) hapticSuccess();
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;

--- a/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
+++ b/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
@@ -1,0 +1,209 @@
+/**
+ * #5555.5 — reconnect backoff on the socket-close/error path (dashboard).
+ *
+ * The close/error handlers used to schedule reconnects at a FIXED delay
+ * (AUTO_RECONNECT_DELAY=1500ms / ERROR_RECONNECT_DELAY=2000ms). They now climb
+ * the shared RETRY_DELAYS ladder ([1000, 2000, 3000, 5000, 8000], jittered) via
+ * a module-level counter that RESETS on `auth_ok` (a successful connect), NOT on
+ * mere socket-open.
+ *
+ * Math.random is pinned to 0 so withJitter() is the identity and each rung's
+ * delay is exactly RETRY_DELAYS[N]. Mirrors the WebSocket/fetch mock harness in
+ * connection-pairing.test.ts, with fake timers so we can assert exact delays.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v },
+  removeItem: (k: string) => { delete store[k] },
+  clear: () => { for (const k of Object.keys(store)) delete store[k] },
+  get length() { return Object.keys(store).length },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+vi.mock('../utils/auth', () => ({ getAuthToken: () => null }))
+
+const RETRY_DELAYS: [number, number, number, number, number] = [1000, 2000, 3000, 5000, 8000]
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 1
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((e: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this) }
+  send(d: string) { this.sent.push(d) }
+  close() { this.readyState = 3 }
+}
+;(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket
+;(globalThis as unknown as { fetch: unknown }).fetch = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ status: 'ok' }),
+}))
+
+const { useConnectionStore } = await import('./connection')
+// Import the namespace (not a destructured binding) so `mh.reconnectAttempt`
+// reflects the live module-level counter — destructuring a `let` export copies
+// the value at import time and would always read 0.
+const mh = await import('./message-handler')
+const { resetReconnectAttempt, nextReconnectAttempt } = mh
+
+/**
+ * Open a connection, walk it through the health check + WS handshake, and mark
+ * it connected so a subsequent onclose takes the auto-reconnect branch.
+ * Returns the freshly opened socket.
+ */
+async function openConnected(): Promise<MockWebSocket> {
+  const before = MockWebSocket.instances.length
+  useConnectionStore.getState().connect('wss://tunnel.example.com/ws', 'tok')
+  // Flush the health-check fetch (microtasks) so the WS is constructed.
+  await vi.advanceTimersByTimeAsync(0)
+  const ws = MockWebSocket.instances[before]!
+  ws.readyState = 1
+  ws.onopen?.()
+  await vi.advanceTimersByTimeAsync(0)
+  useConnectionStore.setState({ connectionPhase: 'connected', userDisconnected: false })
+  return ws
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  MockWebSocket.instances = []
+  resetReconnectAttempt()
+  vi.spyOn(Math, 'random').mockReturnValue(0) // zero jitter
+  for (const k of Object.keys(store)) delete store[k]
+  useConnectionStore.setState({
+    serverRegistry: [],
+    activeServerId: null,
+    connectionPhase: 'disconnected',
+    wsUrl: null,
+    userDisconnected: false,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+// Ladder math
+// ---------------------------------------------------------------------------
+
+describe('reconnect backoff ladder counter (#5555.5)', () => {
+  it('nextReconnectAttempt advances and resetReconnectAttempt rewinds', () => {
+    expect(mh.reconnectAttempt).toBe(0)
+    expect(nextReconnectAttempt()).toBe(0)
+    expect(nextReconnectAttempt()).toBe(1)
+    resetReconnectAttempt()
+    expect(mh.reconnectAttempt).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-to-end close-path backoff
+// ---------------------------------------------------------------------------
+
+describe('socket-close reconnect backoff (#5555.5)', () => {
+  /**
+   * Drives one drop → reconnect cycle and asserts the reconnect fires at exactly
+   * `expectedDelay` ms (no sooner). Marks the new socket connected for reuse.
+   */
+  async function expectReconnectAt(expectedDelay: number) {
+    const socket = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    const before = MockWebSocket.instances.length
+
+    socket.onclose?.({ code: 1006 })
+
+    // One tick short: no reconnect yet.
+    await vi.advanceTimersByTimeAsync(expectedDelay - 1)
+    expect(MockWebSocket.instances.length).toBe(before)
+
+    // Cross the boundary: connect() → fetch → new socket.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances.length).toBe(before + 1)
+
+    const next = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    next.readyState = 1
+    next.onopen?.()
+    await vi.advanceTimersByTimeAsync(0)
+    useConnectionStore.setState({ connectionPhase: 'connected' })
+  }
+
+  it('escalates through the RETRY_DELAYS ladder across consecutive drops', async () => {
+    await openConnected()
+    await expectReconnectAt(RETRY_DELAYS[0])
+    await expectReconnectAt(RETRY_DELAYS[1])
+    await expectReconnectAt(RETRY_DELAYS[2])
+    await expectReconnectAt(RETRY_DELAYS[3])
+  })
+
+  it('caps at the top rung (8000ms) once the ladder is exhausted', async () => {
+    await openConnected()
+    await expectReconnectAt(RETRY_DELAYS[0])
+    await expectReconnectAt(RETRY_DELAYS[1])
+    await expectReconnectAt(RETRY_DELAYS[2])
+    await expectReconnectAt(RETRY_DELAYS[3])
+    await expectReconnectAt(RETRY_DELAYS[4])
+    await expectReconnectAt(RETRY_DELAYS[4]) // clamps
+  })
+
+  it('a user-disconnect short-circuit does NOT burn a ladder rung', async () => {
+    const ws = await openConnected()
+    // Mark a user disconnect: scheduleReconnect returns before advancing the ladder.
+    useConnectionStore.setState({ userDisconnected: true })
+    ws.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[4])
+    expect(mh.reconnectAttempt).toBe(0) // never advanced
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reset-on-auth_ok (NOT on socket-open)
+// ---------------------------------------------------------------------------
+
+describe('backoff ladder resets on auth_ok, not socket-open (#5555.5)', () => {
+  it('a successful auth_ok rewinds the ladder back to the bottom rung', async () => {
+    const s0 = await openConnected()
+
+    s0.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[0]) // rung 0 fires
+    const s1 = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    s1.readyState = 1
+    s1.onopen?.()
+    await vi.advanceTimersByTimeAsync(0)
+    useConnectionStore.setState({ connectionPhase: 'connected' })
+
+    s1.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[1]) // rung 1 fires
+    const s2 = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    s2.readyState = 1
+    s2.onopen?.()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mh.reconnectAttempt).toBe(2) // climbed, not yet reset
+
+    // Drive a real auth_ok through the production onmessage path.
+    s2.onmessage?.({ data: JSON.stringify({ type: 'auth_ok', serverMode: 'cli' }) })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mh.reconnectAttempt).toBe(0) // auth_ok reset it
+  })
+
+  it('socket-open alone does NOT reset the ladder (only auth_ok does)', async () => {
+    const s0 = await openConnected()
+
+    s0.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[0]) // rung 0 fires
+    const s1 = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    s1.readyState = 1
+    s1.onopen?.() // opened but never authenticated
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mh.reconnectAttempt).toBe(1) // NOT reset by socket-open
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -93,6 +93,7 @@ import {
   setDisconnectedAttemptId,
   lastConnectedUrl,
   setLastConnectedUrl,
+  nextReconnectAttempt,
   resetReplayFlags,
   clearPermissionSplits,
   clearTerminalWriteBatching,
@@ -259,10 +260,10 @@ const EMPTY_TRANSCRIPT_BACKGROUND_TASKS: never[] = [];
 // TypeScript widens `never[]` to any element type at the call site.
 const EMPTY_INTERVENTIONS: never[] = [];
 
-/** Delay before auto-reconnecting after an unexpected socket close (ms) */
-const AUTO_RECONNECT_DELAY = 1500;
-/** Delay before reconnecting after a WebSocket error (ms) */
-const ERROR_RECONNECT_DELAY = 2000;
+// #5555.5 — the close/error-path reconnect delay is no longer a fixed
+// constant. Both handlers now climb the RETRY_DELAYS ladder (defined in
+// connect()) via the module-level reconnectAttempt counter, which resets on
+// `auth_ok`. See scheduleReconnect() below.
 
 /**
  * #3605: Clear in-flight `pendingTrustGrants` arrays from every session.
@@ -1367,12 +1368,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const scheduleReconnect = (
       reasonText: string,
       errorMessage: string | null,
-      delayMs: number,
     ): void => {
       if (reconnectScheduled) return;
       if (get().userDisconnected) return;
       if (disconnectedAttemptId === myAttemptId) return;
       reconnectScheduled = true;
+      // #5555.5 — climb the RETRY_DELAYS ladder (was a fixed 1.5s/2s). The
+      // ladder advances only AFTER the user-disconnect / stale-attempt guards
+      // above, so a user-initiated close doesn't burn a rung. It resets on
+      // `auth_ok`, so a clean reconnect starts back at the bottom (1s). The
+      // per-socket `reconnectScheduled` dedupe means a paired error → close
+      // drop advances the ladder exactly once.
+      const rung = nextReconnectAttempt();
+      const delayMs = withJitter(RETRY_DELAYS[Math.min(rung, RETRY_DELAYS.length - 1)]!);
       console.log(`[ws] ${reasonText}, reconnecting...`);
       // #4771: `errorMessage === null` means the close code was 1000
       // (normal server-initiated close — see getWsCloseMessage). Match
@@ -1557,7 +1565,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         scheduleReconnect(
           typeof code === 'number' ? `Connection lost (code ${code})` : 'Connection lost',
           closeMsg,
-          AUTO_RECONNECT_DELAY,
         );
       } else if (disconnectedAttemptId === myAttemptId || get().userDisconnected) {
         set({ connectionPhase: 'disconnected' });
@@ -1592,7 +1599,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // ordering (onclose already armed the timer); the error → close
       // ordering is covered symmetrically by onclose's `wasConnected`
       // gate (handler defined above).
-      scheduleReconnect('WebSocket error', 'Connection error', ERROR_RECONNECT_DELAY);
+      scheduleReconnect('WebSocket error', 'Connection error');
     };
     } // end _connectWebSocket
   },

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -465,8 +465,28 @@ export let connectionAttemptId = 0;
 export let disconnectedAttemptId = -1;
 export let lastConnectedUrl: string | null = null;
 
+// #5555.5 — consecutive close/error-path reconnect counter, used to index the
+// RETRY_DELAYS backoff ladder so a flapping tunnel escalates its retry spacing
+// (1s → 2s → 3s → 5s → 8s) instead of hammering the handshake at a fixed delay.
+// Reset to 0 on `auth_ok` (a *successful* connect — proof the link is healthy),
+// NOT on mere socket-open, so a socket that opens but never authenticates keeps
+// climbing the ladder. Lives here (not a connect() closure) because the count
+// must survive the connect() → drop → connect() cycle and be cleared from the
+// auth_ok handler.
+export let reconnectAttempt = 0;
+
 export function bumpConnectionAttemptId(): number {
   return ++connectionAttemptId;
+}
+
+/** Advance the backoff ladder, returning the pre-increment attempt index. */
+export function nextReconnectAttempt(): number {
+  return reconnectAttempt++;
+}
+
+/** Reset the backoff ladder — called from the `auth_ok` handler on a clean connect. */
+export function resetReconnectAttempt(): void {
+  reconnectAttempt = 0;
 }
 
 export function setDisconnectedAttemptId(id: number): void {
@@ -2447,6 +2467,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // saw its history_replay_end before the socket dropped). Cursors are
       // intentionally RETAINED so this reconnect's replay can be incremental.
       resetReplayReconcile();
+      // #5555.5 — a successful auth is the ONLY proof the link is healthy, so
+      // reset the close/error-path backoff ladder here (not on socket-open). A
+      // socket that opens but never authenticates keeps climbing the ladder.
+      resetReconnectAttempt();
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
       // #4766: full wire-shape decode lives in the shared parser

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -173,6 +173,16 @@ export const TUNNEL_STATUS_MIN_PROTOCOL_VERSION = 2
 let _latestVersionCache = { version: null, checkedAt: 0 }
 const VERSION_CHECK_TTL = 3600_000 // 1 hour
 
+// #5555.6 — keepalive sweep cadence. Previously 30s, which (with the
+// two-phase mark-then-terminate cycle) held a zombie client up to ~60s — ~6×
+// longer than a client holds a zombie server (15s ping + 5s pong timeout =
+// 20s). We now (1) treat ANY inbound frame as proof of life (the client's own
+// 15s heartbeat ping suffices — see ws.on('message')), and (2) drop the sweep
+// to 15s so a client that goes truly silent is detected in 15–30s, ~2× the
+// client cadence. The server's own ws.ping() still fires each sweep to hold
+// Cloudflare / mobile-OS idle timeouts open for clients that don't initiate.
+export const KEEPALIVE_SWEEP_MS = 15_000
+
 async function checkLatestVersion(packageName) {
   const now = Date.now()
   if (_latestVersionCache.checkedAt > 0 && (now - _latestVersionCache.checkedAt) < VERSION_CHECK_TTL) {
@@ -1450,6 +1460,13 @@ export class WsServer {
         // reason string ('encryption required') is diagnostic enough for a
         // legitimate misconfigured client.
         const client = this.clients.get(ws)
+        // #5555.6 — any inbound frame is proof of life. The client's 15s
+        // heartbeat ping is the dominant signal, but ANY decoded frame (input,
+        // subscribe, pong-as-message, …) resets the liveness flag so the 15s
+        // keepalive sweep never terminates a client that is actively talking.
+        // This is the "client ping IS liveness" half of #5555.6; the protocol
+        // `pong` listener on the socket covers the server-initiated ping.
+        if (client) client.isAlive = true
         if (client?.encryptionState) {
           if (msg.type !== 'encrypted') {
             log.error(`Plaintext frame from ${client.id} after encryption established (type=${msg?.type}); closing connection`)
@@ -1598,23 +1615,9 @@ export class WsServer {
       broadcastSessionList: () => this._handlerCtx.transport.broadcastSessionList(),
     })
 
-    // Ping all authenticated clients every 30s to keep connections alive through
-    // Cloudflare/mobile OS idle timeouts. Terminate unresponsive clients.
-    this._pingInterval = setInterval(() => {
-      for (const [ws, client] of this.clients) {
-        if (!client.authenticated) continue
-        if (ws.readyState !== 1) continue
-        if (!client.isAlive) {
-          log.info(`Client ${client.id} unresponsive, terminating`)
-          this._handleClientDeparture(client)
-          this._clientManager.removeClient(ws)
-          try { ws.terminate() } catch {}
-          continue
-        }
-        client.isAlive = false
-        try { ws.ping() } catch {}
-      }
-    }, 30_000)
+    // #5555.6 — sweep authenticated clients every KEEPALIVE_SWEEP_MS. See
+    // _keepaliveSweep for the liveness/eviction contract.
+    this._pingInterval = setInterval(() => this._keepaliveSweep(), KEEPALIVE_SWEEP_MS)
 
     // Prune stale auth failure entries every 60s
     this._authCleanupInterval = setInterval(() => {
@@ -1903,6 +1906,40 @@ export class WsServer {
   /** Broadcast client_joined to all OTHER authenticated clients */
   _broadcastClientJoined(newClient, excludeWs) {
     this._broadcaster._broadcastClientJoined(newClient, excludeWs)
+  }
+
+  /**
+   * #5555.6 — one keepalive sweep over all authenticated clients.
+   *
+   * Liveness contract: `client.isAlive` is set true by ANY inbound frame
+   * (ws.on('message')) and by the protocol-level `pong` handler, so a client
+   * running its 15s heartbeat ping always reads alive at the 15s sweep. Each
+   * sweep clears the flag on live clients and pings them (to hold Cloudflare /
+   * mobile-OS idle timeouts open for peers that don't initiate). A client that
+   * goes truly silent fails the `!isAlive` check on the sweep AFTER the one that
+   * cleared its flag — detection in 15–30s, ~2× the client cadence (was up to
+   * ~60s with the old 30s sweep).
+   *
+   * Eviction goes through the sanctioned departure path so the
+   * sessionId→clients reverse index (WsClientManager) and any primary-client
+   * claim (#5589) are released atomically — the index lint rejects raw
+   * mutations. `_handleClientDeparture` runs first (it reads client state),
+   * then `removeClient` updates the index, then we terminate the socket.
+   */
+  _keepaliveSweep() {
+    for (const [ws, client] of this.clients) {
+      if (!client.authenticated) continue
+      if (ws.readyState !== 1) continue
+      if (!client.isAlive) {
+        log.info(`Client ${client.id} unresponsive, terminating`)
+        this._handleClientDeparture(client)
+        this._clientManager.removeClient(ws)
+        try { ws.terminate() } catch {}
+        continue
+      }
+      client.isAlive = false
+      try { ws.ping() } catch {}
+    }
   }
 
   /** Handle cleanup when an authenticated client disconnects or is terminated */

--- a/packages/server/tests/ws-server-keepalive.test.js
+++ b/packages/server/tests/ws-server-keepalive.test.js
@@ -1,0 +1,200 @@
+/**
+ * #5555.6 — keepalive coordination.
+ *
+ * Before: the server pinged every 30s with a two-phase mark-then-terminate
+ * cycle, so a zombie client could be held ~60s — ~6× longer than a client holds
+ * a zombie server (15s ping + 5s pong timeout = 20s).
+ *
+ * After:
+ *   1. ANY inbound frame (ws.on('message')) marks the client alive — the
+ *      client's own 15s heartbeat ping is the dominant liveness signal.
+ *   2. The sweep cadence (KEEPALIVE_SWEEP_MS) drops to 15s, so a client that
+ *      goes truly silent is detected in 15–30s, ~2× the client cadence.
+ *
+ * Eviction still flows through the sanctioned departure path
+ * (_handleClientDeparture → _clientManager.removeClient → ws.terminate) so the
+ * sessionId→clients reverse index and any primary-client claim are released
+ * atomically.
+ *
+ * No real SessionManager is constructed (a mock EventEmitter stands in), so the
+ * temp-stateFilePath rule (#4633) does not apply here.
+ */
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { WsServer as _WsServer, KEEPALIVE_SWEEP_MS } from '../src/ws-server.js'
+import { createMockSession, waitFor } from './test-helpers.js'
+import { setLogListener } from '../src/logger.js'
+import WebSocket from 'ws'
+
+// noEncrypt avoids the 5s key-exchange timeout; clearing the log listener keeps
+// log_entry broadcasts out of the message counters.
+class WsServer extends _WsServer {
+  constructor(opts = {}) {
+    super({ noEncrypt: true, ...opts })
+  }
+  start(...args) {
+    super.start(...args)
+    setLogListener(null)
+  }
+}
+
+function createMockSessionManager() {
+  const sessions = new Map()
+  const histories = new Map()
+  const manager = new EventEmitter()
+  manager.createSession = (opts = {}) => {
+    const session = createMockSession()
+    session.isReady = true
+    const id = `sess-${sessions.size + 1}`
+    sessions.set(id, { session, name: opts.name || id, cwd: opts.cwd || '/tmp' })
+    histories.set(id, [])
+    return id
+  }
+  manager.getSession = (id) => sessions.get(id) || null
+  manager.getHistory = (id) => histories.get(id) || []
+  manager.isHistoryTruncated = () => false
+  manager.listSessions = () =>
+    [...sessions].map(([id, e]) => ({ sessionId: id, name: e.name, cwd: e.cwd, isBusy: false, provider: 'claude-sdk' }))
+  manager.destroySession = (id) => { sessions.delete(id); histories.delete(id) }
+  Object.defineProperty(manager, 'firstSessionId', { get: () => sessions.keys().next().value || null })
+  return manager
+}
+
+async function startServerAndGetPort(server) {
+  server.start('127.0.0.1')
+  await new Promise((resolve, reject) => {
+    const httpServer = server.httpServer
+    function onListening() { httpServer.removeListener('error', onError); resolve() }
+    function onError(err) { httpServer.removeListener('listening', onListening); reject(err) }
+    httpServer.once('listening', onListening)
+    httpServer.once('error', onError)
+  })
+  return server.httpServer.address().port
+}
+
+function send(ws, msg) { ws.send(JSON.stringify(msg)) }
+
+async function createClient(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`)
+  const messages = []
+  ws.on('message', (data) => {
+    try { messages.push(JSON.parse(data.toString())) } catch { /* ignore non-JSON */ }
+  })
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve)
+    ws.once('error', reject)
+  })
+  // authRequired:false auto-authenticates; wait for auth_ok.
+  await waitFor(() => messages.find((m) => m.type === 'auth_ok'), { timeoutMs: 2000, label: 'auth_ok' })
+  return { ws, messages }
+}
+
+/** The single server-side client record (authRequired:false → exactly one). */
+function serverClient(server) {
+  for (const client of server.clients.values()) {
+    if (client.authenticated) return client
+  }
+  return null
+}
+
+describe('#5555.6 keepalive coordination', () => {
+  let server
+  afterEach(() => {
+    if (server) { server.close(); server = null }
+  })
+
+  it('sweep cadence is 15s — ~2× the client heartbeat cadence (15s ping + 5s pong)', () => {
+    // The client detects a zombie server in 15s (HEARTBEAT_INTERVAL_MS) + 5s
+    // (PONG_TIMEOUT_MS) = 20s. The server sweep at 15s gives 15–30s detection,
+    // no longer the ~60s the old 30s two-phase cycle allowed.
+    assert.equal(KEEPALIVE_SWEEP_MS, 15_000)
+  })
+
+  it('any inbound frame marks the client alive again', async () => {
+    server = new WsServer({ port: 0, sessionManager: createMockSessionManager(), authRequired: false })
+    const port = await startServerAndGetPort(server)
+    const { ws } = await createClient(port)
+
+    const client = serverClient(server)
+    assert.ok(client, 'authenticated client present')
+
+    // Simulate a sweep having cleared the liveness flag.
+    client.isAlive = false
+
+    // A client ping (or ANY frame) must flip it back to alive.
+    send(ws, { type: 'ping' })
+    await waitFor(() => client.isAlive === true, { timeoutMs: 1000, label: 'isAlive reset by inbound frame' })
+    assert.equal(client.isAlive, true)
+
+    ws.close()
+  })
+
+  it('_keepaliveSweep keeps a live client (clears flag + pings) and does not evict', async () => {
+    server = new WsServer({ port: 0, sessionManager: createMockSessionManager(), authRequired: false })
+    const port = await startServerAndGetPort(server)
+    const { ws } = await createClient(port)
+
+    const client = serverClient(server)
+    client.isAlive = true
+    const before = server.clients.size
+
+    server._keepaliveSweep()
+
+    // Live client survives, but the flag is cleared (must be re-set by the next
+    // inbound frame / pong before the following sweep).
+    assert.equal(server.clients.size, before, 'live client not evicted')
+    assert.equal(client.isAlive, false, 'liveness flag cleared by sweep')
+
+    ws.close()
+  })
+
+  it('_keepaliveSweep evicts a zombie via the departure path and purges the reverse index', async () => {
+    const sm = createMockSessionManager()
+    const sessionId = sm.createSession({ name: 'A' })
+    server = new WsServer({ port: 0, sessionManager: sm, authRequired: false })
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    // Subscribe the client to the session so the sessionId→clients reverse index
+    // carries an entry that eviction must purge.
+    send(ws, { type: 'subscribe_sessions', sessionIds: [sessionId] })
+    await waitFor(
+      () => messages.find((m) => m.type === 'subscriptions_updated' && m.subscribedSessionIds?.includes(sessionId)),
+      { timeoutMs: 2000, label: 'subscriptions_updated' },
+    )
+
+    const client = serverClient(server)
+    // Index has the subscription; integrity holds before eviction.
+    server._clientManager.verifyIndexIntegrity()
+
+    // Mark it a zombie (no inbound frames since the last sweep) and sweep.
+    client.isAlive = false
+    server._keepaliveSweep()
+
+    // Evicted from the clients map…
+    assert.equal(serverClient(server), null, 'zombie removed from clients map')
+    // …and the reverse index is clean (no phantom entry for the session).
+    server._clientManager.verifyIndexIntegrity()
+    assert.equal(server._clientManager.getClient(client._ws), undefined, 'reverse-index client lookup cleared')
+
+    ws.close()
+  })
+
+  it('_keepaliveSweep skips unauthenticated and non-open sockets', async () => {
+    server = new WsServer({ port: 0, sessionManager: createMockSessionManager(), authRequired: false })
+    const port = await startServerAndGetPort(server)
+    const { ws } = await createClient(port)
+
+    const client = serverClient(server)
+    // Force the unauth + non-open guards: an unauthenticated zombie must NOT be
+    // terminated by the keepalive sweep (auth cleanup owns that lifecycle).
+    client.authenticated = false
+    client.isAlive = false
+    const before = server.clients.size
+    server._keepaliveSweep()
+    assert.equal(server.clients.size, before, 'unauthenticated client untouched by sweep')
+
+    ws.close()
+  })
+})


### PR DESCRIPTION
Implements sub-items **5** and **6** of epic #5555. Two coupled connection-resilience fixes, one PR.

## #5555.5 — Reconnect backoff on the socket-close/error path

Both clients scheduled close/error-path reconnects at a **fixed** delay (`AUTO_RECONNECT_DELAY=1500ms` / `ERROR_RECONNECT_DELAY=2000ms`). A flapping tunnel therefore hammered the full handshake every ~1.5–2s, regardless of how many times it had already failed.

The close/error handlers now climb the existing `RETRY_DELAYS` ladder (`[1000, 2000, 3000, 5000, 8000]`, jittered via `withJitter`, capped at the top rung) — the same ladder the pre-WS health-check retries already use. A module-level `reconnectAttempt` counter indexes the ladder and **resets on `auth_ok`** — a *successful* connect, the only proof the link is actually healthy — **not on mere socket-open**. A socket that opens but never authenticates keeps backing off.

- The counter lives in each client's `message-handler` (next to `connectionAttemptId`) because it must survive the `connect() → drop → connect()` cycle and be cleared from the `auth_ok` handler.
- The existing per-socket reconnect dedup (#3624) is preserved, so a paired `error → close` for one transport drop advances the ladder **exactly once**.
- The removed `AUTO_RECONNECT_DELAY`/`ERROR_RECONNECT_DELAY` constants are gone from both clients.

### Banner note
The task flagged the dashboard reconnect-banner countdown as possibly surfacing the next-retry delay. On inspection it does **not** — `ReconnectBanner`'s countdown is driven by the server-supplied restart ETA (`restartEtaMs`/`restartingSince` from the `/health` *restarting* response), and the close-path reconnect just shows "Connection lost. Reconnecting…" with no displayed delay. So no banner wiring was needed for the close path. (Same for the mobile `SessionScreen` countdown — restart-ETA-driven.)

## #5555.6 — Keepalive coordination

The server pinged every 30s with a two-phase mark-then-terminate cycle, so a zombie client could be held **up to ~60s** — ~6× longer than a client holds a zombie server (15s heartbeat ping + 5s pong timeout = 20s).

**Design choice: treat client pings as liveness (the epic's preferred option) AND tighten the cadence to ~2× client.**
1. **Any inbound frame is proof of life** — `ws.on('message')` sets `client.isAlive = true` on every decoded frame. The client's own 15s heartbeat ping is the dominant signal, but *any* frame (input, subscribe, encrypted envelope, …) counts. The plumbing was trivial: the `message` handler already resolves the `client` record.
2. **Sweep cadence drops 30s → 15s** (`KEEPALIVE_SWEEP_MS`). A client that goes truly silent fails the `!isAlive` check on the sweep *after* the one that cleared its flag — detection in **15–30s, ~2× the client cadence**.

Eviction still flows through the **sanctioned departure path** (`_handleClientDeparture` → `_clientManager.removeClient` → `ws.terminate`), so the `sessionId→clients` reverse index (WsClientManager) and any primary-client claim (#5589) are released atomically — the index lint rejects raw mutations. The sweep body is extracted to `_keepaliveSweep()` for direct testability.

## Before / after flap behavior

| | Before | After |
|---|---|---|
| **Client reconnect on repeated drops** | fixed 1.5s/2s every time | 1s → 2s → 3s → 5s → 8s (jittered, capped), resets to 1s on a clean `auth_ok` |
| **Server zombie-client detection** | up to ~60s (30s mark + 30s terminate) | 15–30s; any inbound frame keeps a talking client alive |

## Drift found between the two client copies
The clients are not yet behaviorally unified (epic #5556 — `createConnectFlow` not extracted). Pre-existing structural drift: the dashboard's `scheduleReconnect` performs the `userDisconnected` / stale-attempt guards **inside** the function, while the mobile app performs them in the `onclose`/`onerror` **callers**. I kept the ladder advance *after* those guards in the dashboard so a user-initiated close doesn't burn a rung (covered by a test); the mobile app's callers already gate before calling `scheduleReconnect`. Behavior is equivalent; the structure still differs. No new drift introduced.

## Tests
- **Both clients** (fake timers): ladder counter math; end-to-end escalation through the ladder across consecutive drops; cap at the top rung; reset-on-`auth_ok` (driven through the real `onmessage` path); **and** proof that socket-open alone does NOT reset. Dashboard adds a user-disconnect-doesn't-burn-a-rung case.
- **Server** (`tests/ws-server-keepalive.test.js`, mock SessionManager — no real state file): inbound frame resets `isAlive`; `_keepaliveSweep` keeps a live client (clears flag + pings) and evicts a zombie via the departure path; reverse-index integrity (`verifyIndexIntegrity`) holds after eviction; unauth/non-open sockets skipped; cadence constant = 15s.
- `connection-audit-phase1.test.ts` now resets the module-level ladder in `beforeEach` (shared state would otherwise leak rung state into its fixed 5s timer budget).

## Results
- Server: all 4 custom lints green (opt-forwarding, state-file-path, ws-index-mutations, logger-scoping); eslint clean; full suite **9309 pass / 2 fail** — the 2 are the known pre-existing `service.test.js` fetch-timeout/port flakes, unrelated to this change.
- Dashboard: `tsc --noEmit` clean; full vitest suite **3544 pass**.
- App: `tsc --noEmit` clean; full jest suite **1742 pass**.

Related to #5555