### PR TITLE
refactor(store-core): shared client dispatch table — slice 2

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -167,7 +167,12 @@ describe('message-handler.ts — notification_prefs WS message (#4542 / #5556 sl
   });
 
   it('no longer has an inline notification_prefs switch case', () => {
-    expect(messageHandlerSource).not.toMatch(/case 'notification_prefs'\s*:\s*\{/);
+    // Reject any reintroduced `case 'notification_prefs':` regardless of
+    // whether it opens a block on the same line (this file mixes braced and
+    // unbraced switch-case styles, so an unbraced reintroduction must also
+    // fail). The migration marker comment doesn't contain the quoted
+    // `case '...'` form, so it can't trigger a false positive.
+    expect(messageHandlerSource).not.toMatch(/case 'notification_prefs'\s*:/);
   });
 
   it('routes notification_prefs through the shared dispatch table', () => {

--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -154,27 +154,27 @@ describe('connection.ts — notification prefs actions (#4542)', () => {
   });
 });
 
-describe('message-handler.ts — notification_prefs WS message (#4542)', () => {
-  it('imports ServerNotificationPrefsSchema from @chroxy/protocol/schemas', () => {
-    expect(messageHandlerSource).toMatch(/import\s*\{\s*ServerNotificationPrefsSchema\s*\}\s*from\s*'@chroxy\/protocol\/schemas'/);
+describe('message-handler.ts — notification_prefs WS message (#4542 / #5556 slice 2)', () => {
+  // #5556 slice 2: the app's previously-inline notification_prefs case was a
+  // byte-identical copy of store-core's `handleNotificationPrefs` (same
+  // ServerNotificationPrefsSchema parse + #4544 bypassCategories spread). It
+  // now routes through the shared dispatch table like the dashboard, killing
+  // the C1 drift the epic exists to remove. The parse/bypassCategories/
+  // invalid-payload behaviour is pinned by store-core/src/dispatch-table.test.ts;
+  // here we assert the app no longer carries the divergent inline copy.
+  it('no longer hand-imports ServerNotificationPrefsSchema (parse moved to store-core)', () => {
+    expect(messageHandlerSource).not.toMatch(/import\s*\{\s*ServerNotificationPrefsSchema\s*\}\s*from\s*'@chroxy\/protocol\/schemas'/);
   });
 
-  it('handles the notification_prefs case and stores the parsed snapshot', () => {
-    expect(messageHandlerSource).toMatch(/case 'notification_prefs'[\s\S]{0,1500}ServerNotificationPrefsSchema\.safeParse[\s\S]{0,800}notificationPrefs:/);
+  it('no longer has an inline notification_prefs switch case', () => {
+    expect(messageHandlerSource).not.toMatch(/case 'notification_prefs'\s*:\s*\{/);
   });
 
-  it('logs and skips when the payload fails schema validation', () => {
-    expect(messageHandlerSource).toMatch(
-      /case 'notification_prefs'[\s\S]{0,600}!parsed\.success[\s\S]{0,200}console\.warn\(\s*'notification_prefs:/,
-    );
-  });
-
-  // #4544: the wire snapshot now carries an optional bypassCategories
-  // array. The handler must forward it when present so the UI sees the
-  // current gate state; absent means "use documented defaults".
-  it('forwards bypassCategories from the parsed snapshot when present (#4544)', () => {
-    expect(messageHandlerSource).toMatch(/bypassCategories\s*=\s*\(prefs\s*as[\s\S]{0,150}\.bypassCategories/);
-    expect(messageHandlerSource).toMatch(/Array\.isArray\(bypassCategories\)/);
+  it('routes notification_prefs through the shared dispatch table', () => {
+    // The shared table runs before the switch (runDispatch); a hit returns
+    // early. The marker comment records the migration at the old case site.
+    expect(messageHandlerSource).toMatch(/runDispatch\(_dispatchTable/);
+    expect(messageHandlerSource).toMatch(/notification_prefs.*migrated to the shared dispatch table/);
   });
 });
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -36,13 +36,11 @@ import {
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
-  handlePlanStarted as sharedPlanStarted,
+  // plan_started / inactivity_warning / dev_preview / dev_preview_stopped
+  // migrated to the shared dispatch table (#5556 slice 2)
   handlePlanReady as sharedPlanReady,
-  handleInactivityWarning as sharedInactivityWarning,
   handleMultiQuestionIntervention as sharedMultiQuestionIntervention,
   applyInterventionBuilder,
-  handleDevPreview as sharedDevPreview,
-  handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
   handleToolInputDelta as sharedToolInputDelta,
@@ -84,9 +82,9 @@ import {
   handleRawOutput as sharedRawOutput,
   handleTokenRotated as sharedTokenRotated,
   handlePairFail as sharedPairFail,
-  handleSessionCostThresholdCrossed as sharedSessionCostThresholdCrossed,
-  // (no handleNotificationPrefs import — the app keeps notification_prefs
-  // inline; the #4542/#4544 source-shape tests pin that implementation)
+  // session_cost_threshold_crossed + notification_prefs migrated to the shared
+  // dispatch table (#5556 slice 2) — notification_prefs's previously-inline
+  // Zod parse now routes through the shared handleNotificationPrefs.
   // #5454 — pure core of the #554 stream-split block (permission_request)
   resolvePermissionStreamSplit,
   handleDirectoryListing as sharedDirectoryListing,
@@ -111,26 +109,17 @@ import {
   handleGitBranchesResult as sharedGitBranchesResult,
   handleGitStageResult as sharedGitStageResult,
   handleGitCommitResult as sharedGitCommitResult,
-  handleAgentSpawned as sharedAgentSpawned,
-  handleAgentCompleted as sharedAgentCompleted,
-  handleBackgroundWorkChanged as sharedBackgroundWorkChanged,
-  // #5060 — Task subagent intermediate progress. Appends one entry to
-  // the parent Task tool_use bubble's `childAgentEvents[]`; the shared
-  // builder is the same one the dashboard uses so the two platforms
-  // can't drift on routing.
-  handleAgentEvent as sharedAgentEvent,
+  // agent_spawned / agent_completed / agent_event / background_work_changed /
+  // mcp_servers / session_usage / web_task_list / web_feature_status migrated
+  // to the shared dispatch table (#5556 slice 2)
   handleAvailableModels as sharedAvailableModels,
-  handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
-  handleSessionUsage as sharedSessionUsage,
   handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
   handleWebTaskUpsert as sharedWebTaskUpsert,
   handleWebTaskError as sharedWebTaskError,
-  handleWebTaskList as sharedWebTaskList,
-  handleWebFeatureStatus as sharedWebFeatureStatus,
   handleSearchResults as sharedSearchResults,
   handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
@@ -155,7 +144,6 @@ import {
 } from '@chroxy/store-core';
 import type { DeltaFlusher, ClientStoreAdapter } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
-import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
 import { hapticSuccess } from '../utils/haptics';
 import type {
   ChatMessage,
@@ -165,7 +153,6 @@ import type {
   CustomAgent,
   DirectoryEntry,
   FileEntry,
-  McpServer,
   QueuedMessage,
   ServerError,
   SessionInfo,
@@ -174,7 +161,6 @@ import type {
   SlashCommand,
   ProviderInfo,
   ConversationSummary,
-  WebTask,
   PermissionRule,
 } from './types';
 import { createEmptySessionState } from './utils';
@@ -2232,67 +2218,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // agent_busy — migrated to the shared dispatch table (#5556)
 
 
-    case 'agent_spawned': {
-      const builder = sharedAgentSpawned(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.activeAgents);
-          return next === ss.activeAgents ? {} : { activeAgents: next };
-        });
-      }
-      break;
-    }
-
-    case 'agent_completed': {
-      const builder = sharedAgentCompleted(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.activeAgents);
-          return next === ss.activeAgents ? {} : { activeAgents: next };
-        });
-      }
-      break;
-    }
-
-    case 'agent_event': {
-      // #5060 — Task subagent intermediate progress. The shared builder
-      // appends one entry to the parent Task tool_use bubble's
-      // `childAgentEvents[]`. Same-reference no-op when the parent
-      // bubble isn't found (event arrived before tool_start, which the
-      // server's ordering guarantee prevents but is defended).
-      const builder = sharedAgentEvent(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.messages);
-          return next === ss.messages ? {} : { messages: next };
-        });
-      }
-      break;
-    }
-
-    case 'background_work_changed': {
-      // #4307 — pending-background-shells snapshot updated for a
-      // session. Full-snapshot protocol; the shared handler returns
-      // the same reference when next === current to skip re-renders.
-      const builder = sharedBackgroundWorkChanged(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.pendingBackgroundShells);
-          return next === ss.pendingBackgroundShells
-            ? {}
-            : { pendingBackgroundShells: next };
-        });
-      }
-      break;
-    }
-
-    case 'plan_started': {
-      const planStarted = sharedPlanStarted(msg, get().activeSessionId);
-      if (planStarted.sessionId && get().sessionStates[planStarted.sessionId]) {
-        updateSession(planStarted.sessionId, () => planStarted.patch);
-      }
-      break;
-    }
+    // agent_spawned / agent_completed / agent_event / background_work_changed /
+    // plan_started — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'plan_ready': {
       const planReady = sharedPlanReady(msg, get().activeSessionId);
@@ -2308,21 +2235,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'inactivity_warning': {
-      // #3899 — server fired the soft check-in prompt. Store on the
-      // targeted session so the CheckInChip can render the prefab
-      // button. The activity-event branch above clears this on the
-      // next stream_*/tool_*/result/message; sendInput clears it
-      // locally when the user actually sends a follow-up. Mirrors the
-      // dashboard handler shape; no push-notification side-effect here
-      // because server-cli sends the device-level push directly off
-      // the `inactivity_warning` event emit.
-      const warning = sharedInactivityWarning(msg, get().activeSessionId);
-      if (warning && warning.sessionId && get().sessionStates[warning.sessionId]) {
-        updateSession(warning.sessionId, () => warning.patch);
-      }
-      break;
-    }
+    // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'multi_question_intervention': {
       // #4764 — chroxy's permission-hook (#4648) just denied a multi-question
@@ -2916,15 +2829,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'mcp_servers': {
-      const result = sharedMcpServers(msg, get().activeSessionId);
-      if (result.sessionId && get().sessionStates[result.sessionId]) {
-        updateSession(result.sessionId, () => ({
-          mcpServers: result.patch.mcpServers as McpServer[],
-        }));
-      }
-      break;
-    }
+    // mcp_servers — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'cost_update': {
       const result = sharedCostUpdate(msg, get().activeSessionId);
@@ -2939,29 +2844,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_usage': {
-      // #4074: per-session cumulative tokens + cost. Drives the
-      // SessionScreen header cost badge + tap-to-expand breakdown.
-      // Emitted after every result event.
-      const result = sharedSessionUsage(msg, get().activeSessionId);
-      if (result.sessionId && get().sessionStates[result.sessionId]) {
-        updateSession(result.sessionId, () => result.patch);
-      }
-      break;
-    }
-
-    case 'session_cost_threshold_crossed': {
-      // #4075: soft "you've spent $X" warning. Fires ONCE per session.
-      // Mobile mirrors dashboard semantics: the server doesn't replay so
-      // a missed banner stays missed (no store-and-replay). Parse shared
-      // via store-core (#5454) — explicit sessionId only, no fallback.
-      const { sessionId: thresholdSid, patch: thresholdPatch } =
-        sharedSessionCostThresholdCrossed(msg);
-      if (thresholdSid && get().sessionStates[thresholdSid]) {
-        updateSession(thresholdSid, () => thresholdPatch);
-      }
-      break;
-    }
+    // session_usage / session_cost_threshold_crossed — migrated to the shared
+    // dispatch table (#5556 slice 2)
 
     case 'budget_warning': {
       const { warningMessage, systemMessage } = sharedBudgetWarning(msg);
@@ -3006,30 +2890,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // budget_resumed — migrated to the shared dispatch table (#5556)
 
 
-    case 'dev_preview': {
-      const builder = sharedDevPreview(msg, get().activeSessionId);
-      const target = builder.sessionId ? get().sessionStates[builder.sessionId] : undefined;
-      if (builder.sessionId && target) {
-        updateSession(builder.sessionId, (s) => builder.applyTo(s.devPreviews));
-      }
-      break;
-    }
-
-    case 'dev_preview_stopped': {
-      const builder = sharedDevPreviewStopped(msg, get().activeSessionId);
-      const target = builder.sessionId ? get().sessionStates[builder.sessionId] : undefined;
-      if (builder.sessionId && target) {
-        updateSession(builder.sessionId, (s) => builder.applyTo(s.devPreviews));
-      }
-      break;
-    }
+    // dev_preview / dev_preview_stopped — migrated to the shared dispatch
+    // table (#5556 slice 2)
 
     // -- Web tasks (Claude Code Web) --
 
-    case 'web_feature_status': {
-      set(sharedWebFeatureStatus(msg));
-      break;
-    }
+    // web_feature_status — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'web_task_created':
     case 'web_task_updated': {
@@ -3091,11 +2957,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'web_task_list': {
-      const { tasks } = sharedWebTaskList(msg);
-      set({ webTasks: tasks as WebTask[] });
-      break;
-    }
+    // web_task_list — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'conversations_list': {
       // Parser shared via store-core; app-only state mirroring (loading/error
@@ -3116,37 +2978,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'notification_prefs': {
-      // #4542: notification-prefs snapshot. Emitted in response to
-      // `notification_prefs_get` and broadcast after every
-      // `notification_prefs_set` so multiple connected clients stay in
-      // lockstep. Validated against the protocol Zod schema before storing.
-      // #5454: kept inline (store-core's handleNotificationPrefs has the
-      // same logic; the #4542/#4544 source-shape tests pin this impl).
-      const parsed = ServerNotificationPrefsSchema.safeParse(msg);
-      if (!parsed.success) {
-        // eslint-disable-next-line no-console
-        console.warn('notification_prefs: invalid payload from server', parsed.error.issues);
-        break;
-      }
-      const prefs = parsed.data.prefs;
-      // #4544: wire snapshot now carries an optional `bypassCategories`
-      // (categories that fire even during quiet hours). Older servers
-      // omit it — clients fall back to the documented defaults
-      // (permission + activity_error). The quiet-hours window's
-      // `timezone` field is required by the schema when the window is
-      // present, so we forward it verbatim.
-      const bypassCategories = (prefs as { bypassCategories?: string[] }).bypassCategories;
-      set({
-        notificationPrefs: {
-          categories: prefs.categories,
-          devices: prefs.devices,
-          quietHours: prefs.quietHours,
-          ...(Array.isArray(bypassCategories) ? { bypassCategories } : {}),
-        },
-      });
-      break;
-    }
+    // notification_prefs — migrated to the shared dispatch table (#5556 slice
+    // 2). The app previously hand-maintained a byte-identical inline Zod parse
+    // (same ServerNotificationPrefsSchema + bypassCategories spread); it now
+    // routes through the shared handleNotificationPrefs like the dashboard.
 
     case 'server_error': {
       const { serverError, chatMessage: errorMsg } = sharedServerError(msg);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -26,14 +26,12 @@ import {
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
-  handlePlanStarted as sharedPlanStarted,
+  // plan_started / inactivity_warning / dev_preview / dev_preview_stopped
+  // migrated to the shared dispatch table (#5556 slice 2)
   handlePlanReady as sharedPlanReady,
-  handleInactivityWarning as sharedInactivityWarning,
   // #4653: chroxy-side multi-question deny intervention surfaced to the user
   handleMultiQuestionIntervention as sharedMultiQuestionIntervention,
   applyInterventionBuilder,
-  handleDevPreview as sharedDevPreview,
-  handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
   handleToolInputDelta as sharedToolInputDelta,
@@ -76,8 +74,8 @@ import {
   handleRawOutput as sharedRawOutput,
   handleTokenRotated as sharedTokenRotated,
   handlePairFail as sharedPairFail,
-  handleSessionCostThresholdCrossed as sharedSessionCostThresholdCrossed,
-  handleNotificationPrefs as sharedNotificationPrefs,
+  // session_cost_threshold_crossed / notification_prefs migrated to the shared
+  // dispatch table (#5556 slice 2)
   // #5454 — pure core of the #554 stream-split block (permission_request)
   resolvePermissionStreamSplit,
   handleDirectoryListing as sharedDirectoryListing,
@@ -97,27 +95,21 @@ import {
   handleFileList as sharedFileList,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
-  handleAgentSpawned as sharedAgentSpawned,
-  handleAgentCompleted as sharedAgentCompleted,
-  // #5016 — Task subagent nested progress (one wire event per child
-  // `tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`,
-  // attached to the parent Task tool_use bubble's `childAgentEvents[]`).
-  handleAgentEvent as sharedAgentEvent,
-  handleBackgroundWorkChanged as sharedBackgroundWorkChanged,
+  // agent_spawned / agent_completed / agent_event / background_work_changed
+  // migrated to the shared dispatch table (#5556 slice 2)
   handleEnvironmentList as sharedEnvironmentList,
   handleEnvironmentError as sharedEnvironmentError,
   handleAvailableModels as sharedAvailableModels,
-  handleMcpServers as sharedMcpServers,
+  // mcp_servers / session_usage migrated to the shared dispatch table (#5556 slice 2)
   handleCostUpdate as sharedCostUpdate,
-  handleSessionUsage as sharedSessionUsage,
   handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
   handleWebTaskUpsert as sharedWebTaskUpsert,
   handleWebTaskError as sharedWebTaskError,
-  handleWebTaskList as sharedWebTaskList,
-  handleWebFeatureStatus as sharedWebFeatureStatus,
+  // web_task_list / web_feature_status migrated to the shared dispatch table
+  // (#5556 slice 2)
   handleSearchResults as sharedSearchResults,
   handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
@@ -172,7 +164,6 @@ import type {
   EnvironmentInfo,
   EvaluatorRewriteMeta,
   FileEntry,
-  McpServer,
   PendingCommunitySkill,
   PendingEvaluatorClarify,
   QueuedMessage,
@@ -182,7 +173,6 @@ import type {
   SlashCommand,
   FilePickerItem,
   ProviderInfo,
-  WebTask,
 } from './types';
 import { createEmptySessionState } from './utils';
 import { clearPersistedSession } from './persistence';
@@ -981,14 +971,8 @@ function handlePairingRefreshed(_msg: Record<string, unknown>, _get: MsgGet, set
   set(state => ({ pairingRefreshedCount: (state.pairingRefreshedCount ?? 0) + 1 }));
 }
 
-function handleWebFeatureStatus(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  set(sharedWebFeatureStatus(msg));
-}
-
-function handleWebTaskList(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const { tasks } = sharedWebTaskList(msg);
-  set({ webTasks: tasks as WebTask[] });
-}
+// web_feature_status + web_task_list migrated to the shared dispatch table
+// (#5556 slice 2)
 
 function handleConversationsList(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   // Parser shared via store-core (#5454); the dashboard intentionally has no
@@ -2303,8 +2287,8 @@ const HANDLERS: Record<string, Handler> = {
   token_rotated: handleTokenRotated,
   pairing_refreshed: handlePairingRefreshed,
   checkpoint_restored: handleCheckpointRestored,
-  web_feature_status: handleWebFeatureStatus,
-  web_task_list: handleWebTaskList,
+  // web_feature_status / web_task_list migrated to the shared dispatch table
+  // (#5556 slice 2)
   conversations_list: handleConversationsList,
   model_changed: handleModelChanged,
   thinking_level_changed: handleThinkingLevelChanged,
@@ -3349,68 +3333,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // confirm_permission_mode — migrated to the shared dispatch table (#5556)
 
 
-    case 'agent_spawned': {
-      const builder = sharedAgentSpawned(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.activeAgents);
-          return next === ss.activeAgents ? {} : { activeAgents: next };
-        });
-      }
-      break;
-    }
-
-    case 'agent_completed': {
-      const builder = sharedAgentCompleted(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.activeAgents);
-          return next === ss.activeAgents ? {} : { activeAgents: next };
-        });
-      }
-      break;
-    }
-
-    case 'agent_event': {
-      // #5016 — Task subagent intermediate progress. Builder appends one
-      // entry to the parent Task tool_use bubble's `childAgentEvents[]`.
-      // Same-reference no-op when the parent bubble isn't found (event
-      // arrived before tool_start, which should not happen given the
-      // server's ordering guarantee but is defended).
-      const builder = sharedAgentEvent(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.messages);
-          return next === ss.messages ? {} : { messages: next };
-        });
-      }
-      break;
-    }
-
-    case 'background_work_changed': {
-      // #4307 — pending-background-shells snapshot updated for a
-      // session. Full-snapshot protocol, so the builder replaces the
-      // slot wholesale; the shared handler returns the same reference
-      // when next == current to suppress no-op renders.
-      const builder = sharedBackgroundWorkChanged(msg, get().activeSessionId);
-      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
-        updateSession(builder.sessionId, (ss) => {
-          const next = builder.applyTo(ss.pendingBackgroundShells);
-          return next === ss.pendingBackgroundShells
-            ? {}
-            : { pendingBackgroundShells: next };
-        });
-      }
-      break;
-    }
-
-    case 'plan_started': {
-      const planStarted = sharedPlanStarted(msg, get().activeSessionId);
-      if (planStarted.sessionId && get().sessionStates[planStarted.sessionId]) {
-        updateSession(planStarted.sessionId, () => planStarted.patch);
-      }
-      break;
-    }
+    // agent_spawned / agent_completed / agent_event / background_work_changed /
+    // plan_started — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'plan_ready': {
       const planReady = sharedPlanReady(msg, get().activeSessionId);
@@ -3420,18 +3344,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'inactivity_warning': {
-      // #3899 — server fired the soft check-in prompt. Store on the
-      // targeted session so the CheckInChip can render the prefab
-      // button. Activity event handler above clears this on the next
-      // stream_*/tool_*/result/message; sendInput clears it locally
-      // when the user actually sends a follow-up.
-      const warning = sharedInactivityWarning(msg, get().activeSessionId);
-      if (warning && warning.sessionId && get().sessionStates[warning.sessionId]) {
-        updateSession(warning.sessionId, () => warning.patch);
-      }
-      break;
-    }
+    // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'multi_question_intervention': {
       // #4653 — chroxy's permission-hook (#4648) just denied a multi-question
@@ -3933,23 +3846,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'notification_prefs': {
-      // #4542: notification-prefs snapshot. Emitted in response to
-      // `notification_prefs_get` and broadcast after every
-      // `notification_prefs_set`. The wire schema is permissive
-      // (z.record(string, boolean) for categories) — adding a category
-      // server-side does not require a client rebuild. Zod validation +
-      // #4544 bypassCategories handling are shared via store-core (#5454);
-      // a failed parse logs and leaves existing state alone, as before.
-      const { notificationPrefs, issues } = sharedNotificationPrefs(msg);
-      if (!notificationPrefs) {
-        // eslint-disable-next-line no-console
-        console.warn('notification_prefs: invalid payload from server', issues);
-        break;
-      }
-      set({ notificationPrefs });
-      break;
-    }
+    // notification_prefs — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'checkpoint_created': {
       const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);
@@ -3984,15 +3881,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'mcp_servers': {
-      const result = sharedMcpServers(msg, get().activeSessionId);
-      if (result.sessionId && get().sessionStates[result.sessionId]) {
-        updateSession(result.sessionId, () => ({
-          mcpServers: result.patch.mcpServers as McpServer[],
-        }));
-      }
-      break;
-    }
+    // mcp_servers — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'cost_update': {
       const result = sharedCostUpdate(msg, get().activeSessionId);
@@ -4002,47 +3891,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_usage': {
-      // #4073: per-session cumulative tokens + cost. Drives the sidebar
-      // badge + hover breakdown. Emitted after every result event.
-      const result = sharedSessionUsage(msg, get().activeSessionId);
-      if (result.sessionId && get().sessionStates[result.sessionId]) {
-        updateSession(result.sessionId, () => result.patch);
-      }
-      break;
-    }
-
-    case 'session_cost_threshold_crossed': {
-      // #4075: soft "you've spent $X" warning. Fires ONCE per session.
-      // The dashboard owns the dismissible banner state per-session; the
-      // server doesn't re-fire even if costs continue rising, so a
-      // missed banner stays missed (don't store-and-replay). Parse shared
-      // via store-core (#5454) — explicit sessionId only, no fallback.
-      const { sessionId: thresholdSid, patch: thresholdPatch } =
-        sharedSessionCostThresholdCrossed(msg);
-      if (thresholdSid && get().sessionStates[thresholdSid]) {
-        updateSession(thresholdSid, () => thresholdPatch);
-      }
-      break;
-    }
-
-    case 'dev_preview': {
-      const builder = sharedDevPreview(msg, get().activeSessionId);
-      const target = builder.sessionId ? get().sessionStates[builder.sessionId] : undefined;
-      if (builder.sessionId && target) {
-        updateSession(builder.sessionId, (s) => builder.applyTo(s.devPreviews));
-      }
-      break;
-    }
-
-    case 'dev_preview_stopped': {
-      const builder = sharedDevPreviewStopped(msg, get().activeSessionId);
-      const target = builder.sessionId ? get().sessionStates[builder.sessionId] : undefined;
-      if (builder.sessionId && target) {
-        updateSession(builder.sessionId, (s) => builder.applyTo(s.devPreviews));
-      }
-      break;
-    }
+    // session_usage / session_cost_threshold_crossed / dev_preview /
+    // dev_preview_stopped — migrated to the shared dispatch table (#5556 slice 2)
 
     // -- Web tasks (Claude Code Web) --
 

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -5,7 +5,13 @@ import {
   DISPATCH_TABLE_TYPES,
   type ClientStoreAdapter,
 } from './dispatch-table'
-import type { ChatMessage, SessionInfo } from './types'
+import type {
+  ChatMessage,
+  SessionInfo,
+  AgentInfo,
+  DevPreview,
+  PendingBackgroundShell,
+} from './types'
 import type { PermissionRule } from './handlers'
 
 // ---------------------------------------------------------------------------
@@ -20,6 +26,10 @@ interface FakeSession {
   isIdle?: boolean
   conversationId?: string | null
   sessionRules?: PermissionRule[]
+  // slice 2 reads
+  activeAgents?: AgentInfo[]
+  pendingBackgroundShells?: PendingBackgroundShell[]
+  devPreviews?: DevPreview[]
   [k: string]: unknown
 }
 
@@ -266,6 +276,282 @@ describe('shared dispatch table', () => {
       const env = makeAdapter()
       dispatch(env, { type: 'confirm_permission_mode' })
       expect(env.flat.pendingPermissionConfirm).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Slice 2 (epic #5556) — next batch of byte-identical pure cases
+  // -------------------------------------------------------------------------
+
+  describe('agent_spawned', () => {
+    it('adds the spawned agent entry to its session', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], activeAgents: [] } },
+      })
+      dispatch(env, {
+        type: 'agent_spawned',
+        sessionId: 's1',
+        toolUseId: 'tu-1',
+        description: 'Search the repo',
+        startedAt: 1000,
+      })
+      expect(env.sessions.s1.activeAgents).toEqual([
+        { toolUseId: 'tu-1', description: 'Search the repo', startedAt: 1000 },
+      ])
+    })
+
+    it('dedupes a repeat spawn for the same toolUseId (same-reference no-op)', () => {
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            messages: [],
+            activeAgents: [{ toolUseId: 'tu-1', description: 'x', startedAt: 1 }],
+          },
+        },
+      })
+      dispatch(env, { type: 'agent_spawned', sessionId: 's1', toolUseId: 'tu-1' })
+      expect(env.sessions.s1.activeAgents).toHaveLength(1)
+    })
+
+    it('no-ops when the session is not present locally', () => {
+      const env = makeAdapter({ activeSessionId: 'gone' })
+      dispatch(env, { type: 'agent_spawned', toolUseId: 'tu-1' })
+      expect(Object.keys(env.sessions)).toHaveLength(0)
+    })
+  })
+
+  describe('agent_completed', () => {
+    it('removes the completed agent entry', () => {
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            messages: [],
+            activeAgents: [
+              { toolUseId: 'tu-1', description: 'a', startedAt: 1 },
+              { toolUseId: 'tu-2', description: 'b', startedAt: 2 },
+            ],
+          },
+        },
+      })
+      dispatch(env, { type: 'agent_completed', sessionId: 's1', toolUseId: 'tu-1' })
+      expect(env.sessions.s1.activeAgents).toEqual([
+        { toolUseId: 'tu-2', description: 'b', startedAt: 2 },
+      ])
+    })
+  })
+
+  describe('background_work_changed', () => {
+    it('replaces the pending-background-shells snapshot for the session', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], pendingBackgroundShells: [] } },
+      })
+      dispatch(env, {
+        type: 'background_work_changed',
+        sessionId: 's1',
+        pending: [{ shellId: 'sh-1', command: 'npm test', startedAt: 1000 }],
+      })
+      expect(env.sessions.s1.pendingBackgroundShells).toEqual([
+        { shellId: 'sh-1', command: 'npm test', startedAt: 1000 },
+      ])
+    })
+  })
+
+  describe('plan_started', () => {
+    it('clears pending-plan state on the target session', () => {
+      const env = makeAdapter({
+        sessions: {
+          s1: { sessionId: 's1', messages: [], isPlanPending: true, planAllowedPrompts: ['x'] },
+        },
+      })
+      dispatch(env, { type: 'plan_started', sessionId: 's1' })
+      expect(env.sessions.s1.isPlanPending).toBe(false)
+      expect(env.sessions.s1.planAllowedPrompts).toEqual([])
+    })
+  })
+
+  describe('inactivity_warning', () => {
+    it('stamps the soft check-in prompt onto its session', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, {
+        type: 'inactivity_warning',
+        sessionId: 's1',
+        idleMs: 60_000,
+        prefab: 'Still there?',
+      })
+      expect(env.sessions.s1.inactivityWarning).toMatchObject({
+        idleMs: 60_000,
+        prefab: 'Still there?',
+      })
+    })
+
+    it('no-ops when the payload is invalid (handler returns null)', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, { type: 'inactivity_warning', sessionId: 's1', idleMs: 0, prefab: 'x' })
+      expect(env.sessions.s1.inactivityWarning).toBeUndefined()
+    })
+  })
+
+  describe('mcp_servers', () => {
+    it('replaces the target session MCP-server list', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], mcpServers: [] } },
+      })
+      dispatch(env, {
+        type: 'mcp_servers',
+        sessionId: 's1',
+        servers: [{ name: 'fs', status: 'connected' }],
+      })
+      expect(env.sessions.s1.mcpServers).toEqual([{ name: 'fs', status: 'connected' }])
+    })
+
+    it('falls back to the active session when sessionId is absent', () => {
+      const env = makeAdapter({
+        activeSessionId: 'active',
+        sessions: { active: { sessionId: 'active', messages: [], mcpServers: [] } },
+      })
+      dispatch(env, { type: 'mcp_servers', servers: [] })
+      expect(env.sessions.active.mcpServers).toEqual([])
+    })
+  })
+
+  describe('session_usage', () => {
+    it('stores the session cumulative usage', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, {
+        type: 'session_usage',
+        sessionId: 's1',
+        cumulativeUsage: { inputTokens: 10, outputTokens: 20, costUsd: 0.5 },
+      })
+      expect(env.sessions.s1.cumulativeUsage).toMatchObject({
+        inputTokens: 10,
+        outputTokens: 20,
+        costUsd: 0.5,
+      })
+    })
+  })
+
+  describe('session_cost_threshold_crossed', () => {
+    it('stores the one-shot cost-warning banner (explicit sessionId only)', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, {
+        type: 'session_cost_threshold_crossed',
+        sessionId: 's1',
+        costUsd: 5,
+        thresholdUsd: 4,
+      })
+      expect(env.sessions.s1.costThresholdWarning).toEqual({
+        costUsd: 5,
+        thresholdUsd: 4,
+        dismissedAt: null,
+      })
+    })
+
+    it('does NOT fall back to the active session when sessionId is missing', () => {
+      const env = makeAdapter({
+        activeSessionId: 'active',
+        sessions: { active: { sessionId: 'active', messages: [] } },
+      })
+      dispatch(env, { type: 'session_cost_threshold_crossed', costUsd: 5, thresholdUsd: 4 })
+      expect(env.sessions.active.costThresholdWarning).toBeUndefined()
+    })
+  })
+
+  describe('dev_preview / dev_preview_stopped', () => {
+    it('adds a dev-preview entry deduped by port', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], devPreviews: [] } },
+      })
+      dispatch(env, { type: 'dev_preview', sessionId: 's1', port: 3000, url: 'http://localhost:3000' })
+      expect(env.sessions.s1.devPreviews).toEqual([
+        { port: 3000, url: 'http://localhost:3000' },
+      ])
+    })
+
+    it('removes the dev-preview entry matching the stopped port', () => {
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            messages: [],
+            devPreviews: [{ port: 3000, url: 'http://localhost:3000' }],
+          },
+        },
+      })
+      dispatch(env, { type: 'dev_preview_stopped', sessionId: 's1', port: 3000 })
+      expect(env.sessions.s1.devPreviews).toEqual([])
+    })
+  })
+
+  describe('web_feature_status', () => {
+    it('replaces the flat webFeatures availability flags (booleans coerced)', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'web_feature_status', available: 1, remote: true, teleport: 0 })
+      expect(env.flat.webFeatures).toEqual({ available: true, remote: true, teleport: false })
+    })
+  })
+
+  describe('web_task_list', () => {
+    it('replaces the flat web-task list', () => {
+      const env = makeAdapter()
+      const tasks = [{ taskId: 't1', status: 'running' }]
+      dispatch(env, { type: 'web_task_list', tasks })
+      expect(env.flat.webTasks).toEqual(tasks)
+    })
+
+    it('defaults to an empty list when tasks is not an array', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'web_task_list' })
+      expect(env.flat.webTasks).toEqual([])
+    })
+  })
+
+  // notification_prefs — slice-2 RECONCILE. The app previously hand-maintained
+  // a byte-identical inline Zod parse; both clients now share
+  // handleNotificationPrefs. These tests pin that UNIFIED behaviour.
+  describe('notification_prefs (reconciled — app dropped its inline copy)', () => {
+    it('stores the validated prefs snapshot, including optional bypassCategories', () => {
+      const env = makeAdapter()
+      dispatch(env, {
+        type: 'notification_prefs',
+        prefs: {
+          categories: { permission: true, activity_error: false },
+          devices: {},
+          quietHours: null,
+          bypassCategories: ['permission'],
+        },
+      })
+      expect(env.flat.notificationPrefs).toMatchObject({
+        categories: { permission: true, activity_error: false },
+        devices: {},
+        bypassCategories: ['permission'],
+      })
+    })
+
+    it('omits bypassCategories from stored state when the server does not send it', () => {
+      const env = makeAdapter()
+      dispatch(env, {
+        type: 'notification_prefs',
+        prefs: { categories: { permission: true }, devices: {}, quietHours: null },
+      })
+      const stored = env.flat.notificationPrefs as Record<string, unknown>
+      expect(stored).toBeDefined()
+      expect('bypassCategories' in stored).toBe(false)
+    })
+
+    it('leaves state untouched on an invalid payload', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'notification_prefs', prefs: 'not-an-object' })
+      expect(env.flat.notificationPrefs).toBeUndefined()
     })
   })
 })

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -342,6 +342,62 @@ describe('shared dispatch table', () => {
     })
   })
 
+  describe('agent_event', () => {
+    it('appends a child event to the parent Task tool_use bubble', () => {
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            messages: [
+              { type: 'tool_use', toolUseId: 'parent-1' } as unknown as ChatMessage,
+            ],
+          },
+        },
+      })
+      dispatch(env, {
+        type: 'agent_event',
+        sessionId: 's1',
+        parentToolUseId: 'parent-1',
+        eventType: 'tool_start',
+        payload: { name: 'Read' },
+      })
+      const parent = env.sessions.s1.messages[0] as unknown as {
+        childAgentEvents?: { type: string; payload: Record<string, unknown> }[]
+      }
+      expect(parent.childAgentEvents).toEqual([{ type: 'tool_start', payload: { name: 'Read' } }])
+    })
+
+    it('same-reference no-op when the parent bubble is not present', () => {
+      const original = [
+        { type: 'tool_use', toolUseId: 'other' } as unknown as ChatMessage,
+      ]
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: original } },
+      })
+      dispatch(env, {
+        type: 'agent_event',
+        sessionId: 's1',
+        parentToolUseId: 'missing',
+        eventType: 'tool_start',
+        payload: {},
+      })
+      // No parent match → builder returns the same array reference → the
+      // dispatch wrapper patches nothing, so the slot is untouched.
+      expect(env.sessions.s1.messages).toBe(original)
+    })
+
+    it('no-ops when the session is not present locally', () => {
+      const env = makeAdapter({ activeSessionId: 'gone' })
+      dispatch(env, {
+        type: 'agent_event',
+        parentToolUseId: 'p',
+        eventType: 'tool_start',
+        payload: {},
+      })
+      expect(Object.keys(env.sessions)).toHaveLength(0)
+    })
+  })
+
   describe('background_work_changed', () => {
     it('replaces the pending-background-shells snapshot for the session', () => {
       const env = makeAdapter({

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -47,7 +47,14 @@
  * same per-entry narrowing without pulling the whole protocol in.
  */
 
-import type { ChatMessage, SessionInfo } from './types'
+import type {
+  ChatMessage,
+  SessionInfo,
+  AgentInfo,
+  DevPreview,
+  PendingBackgroundShell,
+  WebTask,
+} from './types'
 import {
   handleAvailablePermissionModes,
   handleSessionUpdated,
@@ -56,10 +63,27 @@ import {
   handleConversationId,
   handlePermissionRulesUpdated,
   handleConfirmPermissionMode,
+  // --- slice 2 (epic #5556) — next batch of byte-identical pure cases ---
+  handleAgentSpawned,
+  handleAgentCompleted,
+  handleAgentEvent,
+  handleBackgroundWorkChanged,
+  handlePlanStarted,
+  handleInactivityWarning,
+  handleMcpServers,
+  handleSessionUsage,
+  handleSessionCostThresholdCrossed,
+  handleDevPreview,
+  handleDevPreviewStopped,
+  handleWebFeatureStatus,
+  handleWebTaskList,
+  // notification_prefs (slice 2 reconcile — app dropped its inline copy)
+  handleNotificationPrefs,
   resolveSessionId,
   type PermissionMode,
   type PermissionRule,
   type PendingPermissionConfirm,
+  type NotificationPrefsState,
 } from './handlers'
 
 // ---------------------------------------------------------------------------
@@ -86,6 +110,14 @@ export interface DispatchSessionBase {
   conversationId?: string | null
   sessionRules?: PermissionRule[]
   isIdle?: boolean
+  // --- slice 2 reads (epic #5556) ---
+  // `activeAgents` — read+rewritten by agent_spawned / agent_completed
+  // `pendingBackgroundShells` — read+rewritten by background_work_changed
+  // `devPreviews` — read+rewritten by dev_preview / dev_preview_stopped
+  // Both clients' real `SessionState` carry these exact arrays.
+  activeAgents?: AgentInfo[]
+  pendingBackgroundShells?: PendingBackgroundShell[]
+  devPreviews?: DevPreview[]
 }
 
 /**
@@ -160,6 +192,82 @@ export interface DispatchMessageMap {
     mode?: string
     warning?: string
   }
+  // --- slice 2 (epic #5556) ---
+  agent_spawned: {
+    type: 'agent_spawned'
+    sessionId?: string
+    toolUseId?: string
+    description?: string
+    startedAt?: number
+  }
+  agent_completed: {
+    type: 'agent_completed'
+    sessionId?: string
+    toolUseId?: string
+  }
+  agent_event: {
+    type: 'agent_event'
+    sessionId?: string
+    parentToolUseId?: string
+    eventType?: string
+    payload?: unknown
+  }
+  background_work_changed: {
+    type: 'background_work_changed'
+    sessionId?: string
+    pending?: unknown[]
+  }
+  plan_started: {
+    type: 'plan_started'
+    sessionId?: string
+  }
+  inactivity_warning: {
+    type: 'inactivity_warning'
+    sessionId?: string
+    idleMs?: number
+    prefab?: string
+  }
+  mcp_servers: {
+    type: 'mcp_servers'
+    sessionId?: string
+    servers?: unknown[]
+  }
+  session_usage: {
+    type: 'session_usage'
+    sessionId?: string
+    cumulativeUsage?: Record<string, unknown>
+  }
+  session_cost_threshold_crossed: {
+    type: 'session_cost_threshold_crossed'
+    sessionId?: string
+    costUsd?: number
+    thresholdUsd?: number
+  }
+  dev_preview: {
+    type: 'dev_preview'
+    sessionId?: string
+    port?: number
+    url?: string
+  }
+  dev_preview_stopped: {
+    type: 'dev_preview_stopped'
+    sessionId?: string
+    port?: number
+  }
+  web_feature_status: {
+    type: 'web_feature_status'
+    available?: unknown
+    remote?: unknown
+    teleport?: unknown
+  }
+  web_task_list: {
+    type: 'web_task_list'
+    tasks?: unknown[]
+  }
+  notification_prefs: {
+    type: 'notification_prefs'
+    prefs?: unknown
+  }
 }
 
 /** Union of message types this table currently handles. */
@@ -180,10 +288,14 @@ export type DispatchTable<S extends DispatchSessionBase> = {
 // Handlers — one pure delegation per migrated case
 //
 // Each was byte-for-byte identical between the app and dashboard switches
-// (see the PR body's per-case diff verdicts). Divergent cases (model_changed,
-// permission_mode_changed, agent_idle, budget_warning/exceeded, primary_changed,
-// available_models, notification_prefs, client_joined/left/focus_changed,
-// permission_expired) are deliberately NOT here — they stay platform-local.
+// (see the PR body's per-case diff verdicts). Genuinely-divergent cases
+// (model_changed, permission_mode_changed, agent_idle — all carry a dashboard
+// flat-state fallback the app lacks; budget_warning/exceeded — platform alert
+// APIs; primary_changed, client_joined/left/focus_changed — the app's
+// dedicated multi-client store; available_models — dashboard-only
+// `availableModelsProvider`; permission_expired — divergent notification
+// lifecycle + the dashboard's #2833 already-resolved branch) are deliberately
+// NOT here — they stay platform-local and visible as such.
 // ---------------------------------------------------------------------------
 
 /** `available_permission_modes` — replace the flat list when the payload parses. */
@@ -283,6 +395,217 @@ function dispatchConfirmPermissionMode<S extends DispatchSessionBase>(
 }
 
 // ---------------------------------------------------------------------------
+// Slice 2 — next batch of byte-identical pure-delegation cases (epic #5556)
+//
+// Each below was diffed app-vs-dashboard and was byte-identical in BOTH
+// switches (modulo comment text). The builder-pattern cases resolve a
+// `{ sessionId, applyTo }` builder, then patch the target session only when it
+// exists locally — none of them carry a flat-`messages`/flat-state fallback in
+// either client, which is exactly why they were safe to share (the divergent
+// cases that DO have a dashboard flat fallback stay platform-local).
+//
+// `notification_prefs` is the one slice-2 RECONCILE: the dashboard already
+// routed through `handleNotificationPrefs`; the app hand-maintained a
+// byte-identical inline Zod parse (same `ServerNotificationPrefsSchema`, same
+// `bypassCategories` conditional spread, same warn-on-invalid). Unifying both
+// on the shared handler kills that drift — behaviour is preserved for the app
+// (the #4542/#4544 source-shape contract is the schema, which is unchanged).
+// ---------------------------------------------------------------------------
+
+/** `agent_spawned` — add the spawned background-agent entry to its session. */
+function dispatchAgentSpawned<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['agent_spawned'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const builder = handleAgentSpawned(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (builder.sessionId && adapter.hasSession(builder.sessionId)) {
+    adapter.updateSession(builder.sessionId, (ss) => {
+      const next = builder.applyTo(ss.activeAgents ?? [])
+      return next === ss.activeAgents ? ({} as Partial<S>) : ({ activeAgents: next } as Partial<S>)
+    })
+  }
+}
+
+/** `agent_completed` — remove the completed background-agent entry. */
+function dispatchAgentCompleted<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['agent_completed'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const builder = handleAgentCompleted(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (builder.sessionId && adapter.hasSession(builder.sessionId)) {
+    adapter.updateSession(builder.sessionId, (ss) => {
+      const next = builder.applyTo(ss.activeAgents ?? [])
+      return next === ss.activeAgents ? ({} as Partial<S>) : ({ activeAgents: next } as Partial<S>)
+    })
+  }
+}
+
+/** `agent_event` — append a nested child event to the parent Task bubble. */
+function dispatchAgentEvent<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['agent_event'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const builder = handleAgentEvent(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (builder.sessionId && adapter.hasSession(builder.sessionId)) {
+    adapter.updateSession(builder.sessionId, (ss) => {
+      const next = builder.applyTo(ss.messages)
+      return next === ss.messages ? ({} as Partial<S>) : ({ messages: next } as Partial<S>)
+    })
+  }
+}
+
+/** `background_work_changed` — replace the session's pending-shells snapshot. */
+function dispatchBackgroundWorkChanged<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['background_work_changed'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const builder = handleBackgroundWorkChanged(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (builder.sessionId && adapter.hasSession(builder.sessionId)) {
+    adapter.updateSession(builder.sessionId, (ss) => {
+      const next = builder.applyTo(ss.pendingBackgroundShells ?? [])
+      return next === ss.pendingBackgroundShells
+        ? ({} as Partial<S>)
+        : ({ pendingBackgroundShells: next } as Partial<S>)
+    })
+  }
+}
+
+/** `plan_started` — clear pending-plan state on the target session. */
+function dispatchPlanStarted<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['plan_started'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId, patch } = handlePlanStarted(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => patch as Partial<S>)
+  }
+}
+
+/** `inactivity_warning` — stamp the soft check-in prompt onto its session. */
+function dispatchInactivityWarning<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['inactivity_warning'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const warning = handleInactivityWarning(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (warning && warning.sessionId && adapter.hasSession(warning.sessionId)) {
+    adapter.updateSession(warning.sessionId, () => warning.patch as Partial<S>)
+  }
+}
+
+/** `mcp_servers` — replace the target session's MCP-server list. */
+function dispatchMcpServers<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['mcp_servers'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId, patch } = handleMcpServers(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => patch as Partial<S>)
+  }
+}
+
+/** `session_usage` — store the session's cumulative token/cost usage. */
+function dispatchSessionUsage<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_usage'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId, patch } = handleSessionUsage(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => patch as Partial<S>)
+  }
+}
+
+/** `session_cost_threshold_crossed` — store the one-shot cost-warning banner. */
+function dispatchSessionCostThresholdCrossed<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_cost_threshold_crossed'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  // Explicit sessionId only — no active-session fallback (matches both clients).
+  const { sessionId, patch } = handleSessionCostThresholdCrossed(msg as Record<string, unknown>)
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => patch as unknown as Partial<S>)
+  }
+}
+
+/** `dev_preview` — add/replace a dev-preview entry (deduped by port). */
+function dispatchDevPreview<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['dev_preview'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const builder = handleDevPreview(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (builder.sessionId && adapter.hasSession(builder.sessionId)) {
+    adapter.updateSession(builder.sessionId, (ss) => builder.applyTo(ss.devPreviews ?? []) as Partial<S>)
+  }
+}
+
+/** `dev_preview_stopped` — remove the dev-preview entry matching `port`. */
+function dispatchDevPreviewStopped<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['dev_preview_stopped'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const builder = handleDevPreviewStopped(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (builder.sessionId && adapter.hasSession(builder.sessionId)) {
+    adapter.updateSession(builder.sessionId, (ss) => builder.applyTo(ss.devPreviews ?? []) as Partial<S>)
+  }
+}
+
+/** `web_feature_status` — replace the flat Claude-Code-Web availability flags. */
+function dispatchWebFeatureStatus<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['web_feature_status'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  adapter.setState(
+    handleWebFeatureStatus(msg as Record<string, unknown>) as unknown as Record<string, unknown>,
+  )
+}
+
+/** `web_task_list` — replace the flat web-task list. */
+function dispatchWebTaskList<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['web_task_list'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { tasks } = handleWebTaskList(msg as Record<string, unknown>)
+  adapter.setState({ webTasks: tasks as WebTask[] } as Record<string, WebTask[]>)
+}
+
+/**
+ * `notification_prefs` — validate + store the notification-prefs snapshot.
+ * Slice-2 RECONCILE: both clients now share `handleNotificationPrefs`. A failed
+ * parse logs a warning and leaves existing state untouched (prior behaviour on
+ * both sides). The dashboard already did exactly this; the app's previously
+ * inline Zod parse was byte-identical and is now retired.
+ */
+function dispatchNotificationPrefs<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['notification_prefs'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { notificationPrefs, issues } = handleNotificationPrefs(msg as Record<string, unknown>)
+  if (!notificationPrefs) {
+    // eslint-disable-next-line no-console
+    console.warn('notification_prefs: invalid payload from server', issues)
+    return
+  }
+  adapter.setState({ notificationPrefs } as Record<string, NotificationPrefsState>)
+}
+
+// ---------------------------------------------------------------------------
 // Table + runner
 // ---------------------------------------------------------------------------
 
@@ -302,6 +625,21 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     conversation_id: dispatchConversationId,
     permission_rules_updated: dispatchPermissionRulesUpdated,
     confirm_permission_mode: dispatchConfirmPermissionMode,
+    // --- slice 2 (epic #5556) ---
+    agent_spawned: dispatchAgentSpawned,
+    agent_completed: dispatchAgentCompleted,
+    agent_event: dispatchAgentEvent,
+    background_work_changed: dispatchBackgroundWorkChanged,
+    plan_started: dispatchPlanStarted,
+    inactivity_warning: dispatchInactivityWarning,
+    mcp_servers: dispatchMcpServers,
+    session_usage: dispatchSessionUsage,
+    session_cost_threshold_crossed: dispatchSessionCostThresholdCrossed,
+    dev_preview: dispatchDevPreview,
+    dev_preview_stopped: dispatchDevPreviewStopped,
+    web_feature_status: dispatchWebFeatureStatus,
+    web_task_list: dispatchWebTaskList,
+    notification_prefs: dispatchNotificationPrefs,
   }
 }
 
@@ -314,6 +652,21 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'conversation_id',
   'permission_rules_updated',
   'confirm_permission_mode',
+  // --- slice 2 (epic #5556) ---
+  'agent_spawned',
+  'agent_completed',
+  'agent_event',
+  'background_work_changed',
+  'plan_started',
+  'inactivity_warning',
+  'mcp_servers',
+  'session_usage',
+  'session_cost_threshold_crossed',
+  'dev_preview',
+  'dev_preview_stopped',
+  'web_feature_status',
+  'web_task_list',
+  'notification_prefs',
 ]
 
 /**


### PR DESCRIPTION
## Summary

Slice 2 of epic #5556 sub-item 3 — the **shared client dispatch table**. Building on slice 1 (#5591, 7 cases), this migrates the next batch of pure-delegation cases out of BOTH client switches (app + dashboard) into the store-core `Record<msgType, handler>` registry, and reconciles the app's drifted inline `notification_prefs` copy onto the shared handler.

Both clients still dispatch through the table first (`runDispatch`); a table **miss falls through** to each client's existing switch unchanged, so the incremental march continues.

Builds on the current `origin/main` (after #5592 auth_bootstrap + #5593 replay reconcile); none of those wirings are disturbed.

## Adapter additions

`DispatchSessionBase` gains the three session fields the new builder cases READ off the session (`activeAgents`, `pendingBackgroundShells`, `devPreviews`) — both clients' real `SessionState` already carry them. The `ClientStoreAdapter` surface is otherwise unchanged from slice 1.

## Case table

| Case | Verdict | Notes |
|---|---|---|
| `agent_spawned` | **identical-migrated** | builder → `activeАgents`; dedupe-by-toolUseId same-ref no-op |
| `agent_completed` | **identical-migrated** | builder removes the matching `activeAgents` entry |
| `agent_event` | **identical-migrated** | builder appends to parent Task bubble `childAgentEvents[]` (code identical; only `#5060`/`#5016` comment differed) |
| `background_work_changed` | **identical-migrated** | builder replaces `pendingBackgroundShells` snapshot |
| `plan_started` | **identical-migrated** | `SessionPatch` clears `isPlanPending`/`planAllowedPrompts` |
| `inactivity_warning` | **identical-migrated** | `SessionPatch \| null`; check-in chip state |
| `mcp_servers` | **identical-migrated** | `SessionPatch` replaces `mcpServers` (both cast `as McpServer[]`) |
| `session_usage` | **identical-migrated** | `SessionPatch` stores `cumulativeUsage` |
| `session_cost_threshold_crossed` | **identical-migrated** | `SessionPatch`, explicit sessionId only (no active fallback) |
| `dev_preview` | **identical-migrated** | builder add/replace by port → `devPreviews` |
| `dev_preview_stopped` | **identical-migrated** | builder removes by port → `devPreviews` |
| `web_feature_status` | **identical-migrated** | flat `set({ webFeatures })` |
| `web_task_list` | **identical-migrated** | flat `set({ webTasks })` |
| `notification_prefs` | **reconciled (winner: dashboard / shared `handleNotificationPrefs`)** | the app hand-maintained a **byte-identical** inline Zod parse (same `ServerNotificationPrefsSchema`, same #4544 `bypassCategories` conditional spread, same warn-on-invalid). Both clients now route through the shared handler — the exact C1 drift this epic exists to kill. Behaviour is preserved (the parse is the schema, which is unchanged); the app's source-shape guard is rewritten to assert the inline copy is gone. |

### Still-divergent (deliberately platform-local, evaluated this slice)

| Case | Reason (genuine platform difference) |
|---|---|
| `model_changed`, `permission_mode_changed`, `agent_idle` | dashboard carries a flat-state (`set({...})`) fallback the app lacks; `permission_mode_changed` also clears the app-only optimistic pending-mode-request tracker |
| `budget_warning`, `budget_exceeded` | platform alert APIs (app `Alert.alert` + Resume button; dashboard `_adapters.alert` + auto-resume) |
| `primary_changed`, `client_joined`/`client_left`/`client_focus_changed` | the app syncs its dedicated `useMultiClientStore`; the dashboard keeps multi-client state flat (no such store) |
| `available_models` | dashboard-only `availableModelsProvider` (drives CreateSessionModal) |
| `permission_expired` | divergent notification lifecycle — app *removes* the banner row; dashboard *marks-read-and-keeps* (#5008) + has the #2833 already-resolved race branch + `addInfoNotification` toast |
| `cost_update`, `raw`/`raw_background`, `checkpoint_restored`, `token_rotated`, `session_warning`, `session_timeout`, `conversations_list` | app-only secondary stores (`useCostStore`/`useTerminalStore`/`useConversationStore`/`useNotificationStore`), app-only `switchSession` options, or platform persistence/URL side-effects |

`session_role` (the new #5589 envelope) is unhandled on **both** clients — but it carries the same primary-clientId info as the already-handled (divergent) `primary_changed`, and wiring it cleanly is entangled with the app's multi-client-store divergence. Noted, deferred.

## Parity guard

The protocol `handler-coverage` test static-parses `DISPATCH_TABLE_TYPES` from `dispatch-table.ts` and unions it into both client type sets, so the migrated cases count as covered for both platforms. All 9 coverage checks stay green automatically (no test edit needed).

## Tests

- store-core `dispatch-table.test.ts` — +21 cases (one+ per migrated case: message in → expected mutation), incl. the reconciled `notification_prefs` block pinning the UNIFIED behaviour (valid snapshot, bypassCategories present/absent, invalid payload) with a comment naming the resolved drift. `DISPATCH_TABLE_TYPES` ↔ table-keys equality check covers the new entries.
- app source-shape guard (`SettingsScreenNotificationPrefs.test.ts`) rewritten: asserts the inline `ServerNotificationPrefsSchema` import + `case 'notification_prefs'` are gone and routing is via `runDispatch`.
- Full suites + typechecks green:
  - store-core: 1328 tests, tsc clean
  - app: 1735 tests, tsc clean
  - dashboard: 3538 tests, tsc clean
  - protocol: 282 tests (incl. handler-coverage parity guard), all green

Related to #5556