### PR TITLE
feat(server): push tunnel_url_changed to clients on quick-tunnel rotation

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -5102,4 +5102,72 @@ describe('auth_bootstrap (#5555)', () => {
     expect(store.getState().slashCommands).toEqual([{ name: 'clear', source: 'builtin' }]);
     expect(store.getState().customAgents).toEqual([{ name: 'reviewer', source: 'project' }]);
   });
+
+  it('#5555 (sub-item 7): an auth_bootstrap burst with tunnelUrl re-learns the rotated URL', () => {
+    const store = createMockStore({ sessionStates: {}, activeSessionId: null });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'wss://old.trycloudflare.com',
+      token: 'tok',
+      tunnelUrl: 'wss://old.trycloudflare.com',
+    });
+
+    _testMessageHandler.handle({
+      type: 'auth_bootstrap',
+      providers: [],
+      slashCommands: [],
+      agents: [],
+      tunnelUrl: 'wss://new.trycloudflare.com',
+    });
+
+    expect(useConnectionLifecycleStore.getState().savedConnection?.tunnelUrl).toBe(
+      'wss://new.trycloudflare.com',
+    );
+  });
+});
+
+// #5555 (sub-item 7) — live tunnel-url rotation push.
+describe('tunnel_url_changed (#5555 sub-item 7)', () => {
+  afterEach(() => {
+    useConnectionLifecycleStore.getState().reset();
+    useConnectionLifecycleStore.getState().setSavedConnection(null);
+  });
+
+  it('repoints the persisted tunnelUrl when the push arrives', () => {
+    const store = createMockStore({ sessionStates: {} });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'wss://old.trycloudflare.com',
+      token: 'tok',
+      tunnelUrl: 'wss://old.trycloudflare.com',
+    });
+
+    _testMessageHandler.handle({
+      type: 'tunnel_url_changed',
+      url: 'wss://new.trycloudflare.com',
+      previousUrl: 'wss://old.trycloudflare.com',
+    });
+
+    expect(useConnectionLifecycleStore.getState().savedConnection?.tunnelUrl).toBe(
+      'wss://new.trycloudflare.com',
+    );
+  });
+
+  it('ignores a malformed push (no url) without throwing', () => {
+    const store = createMockStore({ sessionStates: {} });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'wss://old.trycloudflare.com',
+      token: 'tok',
+      tunnelUrl: 'wss://old.trycloudflare.com',
+    });
+
+    expect(() => _testMessageHandler.handle({ type: 'tunnel_url_changed' })).not.toThrow();
+    expect(useConnectionLifecycleStore.getState().savedConnection?.tunnelUrl).toBe(
+      'wss://old.trycloudflare.com',
+    );
+  });
 });

--- a/packages/app/src/__tests__/store/tunnel-url-changed.test.ts
+++ b/packages/app/src/__tests__/store/tunnel-url-changed.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #5555 (sub-item 7) — the app applies a rotated tunnel URL.
+ *
+ * Quick-tunnel recovery rotates the public URL. The server pushes it live
+ * (`tunnel_url_changed`) and re-advertises it on every reconnect (the
+ * `auth_bootstrap` burst's `tunnelUrl`). The app repoints the SecureStore-backed
+ * `SavedConnection.tunnelUrl` so the next reconnect dials the working endpoint
+ * instead of hammering the dead one — and the fix survives an app restart.
+ */
+
+// In-memory SecureStore so the persistence helpers hit a real key/value store.
+jest.mock('expo-secure-store', () => {
+  const mem: Record<string, string> = {};
+  return {
+    __mem: mem,
+    getItemAsync: jest.fn(async (k: string) => (k in mem ? mem[k] : null)),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+import * as SecureStore from 'expo-secure-store';
+import { applyRotatedTunnelUrl, loadConnection } from '../../store/message-handler';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+const mem = (SecureStore as unknown as { __mem: Record<string, string> }).__mem;
+
+beforeEach(() => {
+  for (const k of Object.keys(mem)) delete mem[k];
+  useConnectionLifecycleStore.getState().reset();
+  // reset() does not clear savedConnection — null it explicitly per test.
+  useConnectionLifecycleStore.getState().setSavedConnection(null);
+});
+
+describe('applyRotatedTunnelUrl (#5555 sub-item 7)', () => {
+  it('repoints tunnelUrl and the canonical url for a tunnel-only record', () => {
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'wss://old.trycloudflare.com',
+      token: 'tok',
+      tunnelUrl: 'wss://old.trycloudflare.com',
+    });
+
+    const changed = applyRotatedTunnelUrl('wss://new.trycloudflare.com');
+
+    expect(changed).toBe(true);
+    const saved = useConnectionLifecycleStore.getState().savedConnection;
+    expect(saved?.tunnelUrl).toBe('wss://new.trycloudflare.com');
+    // url was the old tunnel endpoint, so it follows the rotation.
+    expect(saved?.url).toBe('wss://new.trycloudflare.com');
+  });
+
+  it('updates tunnelUrl but PRESERVES a verified ws:// LAN url', () => {
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'ws://192.168.1.5:8765',
+      token: 'tok',
+      lanUrl: 'ws://192.168.1.5:8765',
+      lanVerified: true,
+      tunnelUrl: 'wss://old.trycloudflare.com',
+    });
+
+    const changed = applyRotatedTunnelUrl('wss://new.trycloudflare.com');
+
+    expect(changed).toBe(true);
+    const saved = useConnectionLifecycleStore.getState().savedConnection;
+    expect(saved?.tunnelUrl).toBe('wss://new.trycloudflare.com');
+    // The ws:// LAN url is the canonical dial target and must NOT be clobbered.
+    expect(saved?.url).toBe('ws://192.168.1.5:8765');
+    expect(saved?.lanVerified).toBe(true);
+  });
+
+  it('persists the rotation to SecureStore (survives an app restart)', async () => {
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'wss://old.trycloudflare.com',
+      token: 'tok',
+      tunnelUrl: 'wss://old.trycloudflare.com',
+    });
+
+    applyRotatedTunnelUrl('wss://new.trycloudflare.com');
+    // Flush the fire-and-forget saveConnection microtask.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const reloaded = await loadConnection();
+    expect(reloaded?.tunnelUrl).toBe('wss://new.trycloudflare.com');
+    expect(reloaded?.url).toBe('wss://new.trycloudflare.com');
+  });
+
+  it('is a no-op when there is no saved connection', () => {
+    expect(applyRotatedTunnelUrl('wss://new.trycloudflare.com')).toBe(false);
+    expect(useConnectionLifecycleStore.getState().savedConnection).toBeNull();
+  });
+
+  it('is a no-op (idempotent) when the URL is unchanged', () => {
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'ws://192.168.1.5:8765',
+      token: 'tok',
+      tunnelUrl: 'wss://same.trycloudflare.com',
+    });
+    expect(applyRotatedTunnelUrl('wss://same.trycloudflare.com')).toBe(false);
+  });
+
+  it('rejects a non-wss URL defensively', () => {
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: 'wss://old.trycloudflare.com',
+      token: 'tok',
+      tunnelUrl: 'wss://old.trycloudflare.com',
+    });
+    expect(applyRotatedTunnelUrl('ws://192.168.1.9:8765')).toBe(false);
+    expect(useConnectionLifecycleStore.getState().savedConnection?.tunnelUrl).toBe(
+      'wss://old.trycloudflare.com',
+    );
+  });
+});

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1199,14 +1199,19 @@ export function applyRotatedTunnelUrl(newTunnelUrl: string): boolean {
   if (!newTunnelUrl || !/^wss:\/\//i.test(newTunnelUrl)) return false;
   const prev = useConnectionLifecycleStore.getState().savedConnection;
   if (!prev) return false;
-  const oldTunnelUrl = prev.tunnelUrl ?? null;
+  // A legacy record predating the `tunnelUrl` field carries its tunnel endpoint
+  // only in `url` (a non-LAN `wss://` URL). Treat that as the implicit old
+  // tunnel URL so the gates below still recognise + repoint it.
+  const oldTunnelUrl =
+    prev.tunnelUrl ?? (prev.url && /^wss:\/\//i.test(prev.url) ? prev.url : null);
   // Idempotent: the auth_bootstrap path re-advertises the URL on every connect,
   // so skip when nothing changed.
   if (oldTunnelUrl === newTunnelUrl && prev.url !== oldTunnelUrl) return false;
   const next: SavedConnection = { ...prev, tunnelUrl: newTunnelUrl };
   // Repoint the canonical dial URL only when it WAS the old tunnel endpoint
-  // (a tunnel-only record). Never clobber a verified ws:// LAN `url`.
-  if (prev.url === oldTunnelUrl || prev.url === prev.tunnelUrl) {
+  // (a tunnel-only record, including a legacy `wss://` url). Never clobber a
+  // verified ws:// LAN `url`.
+  if (prev.url === oldTunnelUrl) {
     next.url = newTunnelUrl;
   }
   if (next.url === prev.url && next.tunnelUrl === prev.tunnelUrl) return false;

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -106,6 +106,7 @@ import {
   handleAgentList as sharedAgentList,
   handleProviderList as sharedProviderList,
   handleAuthBootstrap as sharedAuthBootstrap,
+  handleTunnelUrlChanged as sharedTunnelUrlChanged,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
   handleGitBranchesResult as sharedGitBranchesResult,
@@ -1150,6 +1151,52 @@ export function persistVerifiedConnection(connectedUrl: string, token: string): 
     tunnelUrl: next.tunnelUrl,
   });
   useConnectionLifecycleStore.getState().setSavedConnection(next);
+}
+
+/**
+ * #5555 (sub-item 7) — apply a rotated tunnel URL to the persisted connection.
+ *
+ * A quick-tunnel recovery rotated the public URL; the server pushed it (live,
+ * via `tunnel_url_changed`) or re-advertised it (on reconnect, via the
+ * `auth_bootstrap` burst's `tunnelUrl`). We repoint the saved record's
+ * `tunnelUrl` to the new endpoint so the next reconnect dials it instead of the
+ * dead URL — and because the record is SecureStore-backed, the fix survives an
+ * app restart.
+ *
+ * `url` (the canonical "what to dial" field) is also repointed when it was the
+ * old tunnel URL, so a tunnel-only record (no separate LAN endpoint) keeps
+ * working. A `ws://` LAN `url` is left untouched — the rotation only concerns
+ * the `wss://` tunnel endpoint.
+ *
+ * No-op when there is no saved connection, when the new URL equals the stored
+ * one (idempotent re-advertisement on every reconnect), or when the new URL is
+ * not a `wss://` URL (defensive — the server only rotates the tunnel endpoint).
+ *
+ * @param newTunnelUrl the rotated `wss://` endpoint
+ * @returns true when the persisted record changed, false on a no-op
+ */
+export function applyRotatedTunnelUrl(newTunnelUrl: string): boolean {
+  if (!newTunnelUrl || !/^wss:\/\//i.test(newTunnelUrl)) return false;
+  const prev = useConnectionLifecycleStore.getState().savedConnection;
+  if (!prev) return false;
+  const oldTunnelUrl = prev.tunnelUrl ?? null;
+  // Idempotent: the auth_bootstrap path re-advertises the URL on every connect,
+  // so skip when nothing changed.
+  if (oldTunnelUrl === newTunnelUrl && prev.url !== oldTunnelUrl) return false;
+  const next: SavedConnection = { ...prev, tunnelUrl: newTunnelUrl };
+  // Repoint the canonical dial URL only when it WAS the old tunnel endpoint
+  // (a tunnel-only record). Never clobber a verified ws:// LAN `url`.
+  if (prev.url === oldTunnelUrl || prev.url === prev.tunnelUrl) {
+    next.url = newTunnelUrl;
+  }
+  if (next.url === prev.url && next.tunnelUrl === prev.tunnelUrl) return false;
+  void saveConnection(next.url, next.token, {
+    lanUrl: next.lanUrl,
+    lanVerified: next.lanVerified,
+    tunnelUrl: next.tunnelUrl,
+  });
+  useConnectionLifecycleStore.getState().setSavedConnection(next);
+  return true;
 }
 
 /**
@@ -2835,6 +2882,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // store mutations + element validation the discrete responses use, so the
       // bootstrap and refresh paths are behaviourally identical.
       const boot = sharedAuthBootstrap(msg);
+      // #5555 (sub-item 7): re-learn the live tunnel URL on every connect. If a
+      // quick-tunnel rotation happened while the app was offline (so it missed
+      // the live `tunnel_url_changed` push), this repoints the persisted record
+      // to the working endpoint. Applied before the session-scope guard below
+      // so a stale-session burst still refreshes the URL.
+      if (boot.tunnelUrl) applyRotatedTunnelUrl(boot.tunnelUrl);
       // Providers (server-wide, no session guard).
       set({ availableProviders: mapProviderList(boot.providers) });
       // Slash commands + agents are scoped to the connect-time active session.
@@ -2850,6 +2903,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const customAgents = boot.agents as CustomAgent[];
       set({ customAgents });
       useConversationStore.getState().setCustomAgents(customAgents);
+      break;
+    }
+
+    case 'tunnel_url_changed': {
+      // #5555 (sub-item 7): a quick-tunnel recovery rotated the public URL.
+      // Repoint the persisted tunnel endpoint so the next reconnect dials the
+      // working URL instead of hammering the dead one (and survives an app
+      // restart — the record is SecureStore-backed).
+      //
+      // BEST-EFFORT for us: this client is connected THROUGH the tunnel, so the
+      // socket carrying this frame rode the now-dead old tunnel — we often will
+      // NOT receive it. The durable recovery is the `tunnelUrl` re-advertised in
+      // the `auth_bootstrap` burst on the next reconnect (handled above).
+      const rotated = sharedTunnelUrlChanged(msg);
+      if (rotated) applyRotatedTunnelUrl(rotated.url);
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -94,6 +94,7 @@ import {
   handleAgentList as sharedAgentList,
   handleProviderList as sharedProviderList,
   handleAuthBootstrap as sharedAuthBootstrap,
+  handleTunnelUrlChanged as sharedTunnelUrlChanged,
   handleFileList as sharedFileList,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
@@ -954,6 +955,48 @@ function handleTokenRotated(msg: Record<string, unknown>, _get: MsgGet, _set: Ms
     } catch { /* non-critical */ }
   } else {
     console.log('[ws] Server token rotated — re-authentication required');
+  }
+}
+
+/**
+ * #5555 (sub-item 7) — repoint the active server-registry entry's `wsUrl` to a
+ * rotated tunnel URL so the dashboard's reconnect path dials the new endpoint
+ * instead of the dead one. localStorage-backed, so the fix survives a tab
+ * refresh / process restart.
+ *
+ * Only mutates a NON-localhost registry entry (`activeServerId !== null`): the
+ * same-origin "this machine" connection (`activeServerId === null`) dials
+ * `window.location` and never the tunnel URL, so a rotation does not affect it.
+ * The entry is updated only when its current `wsUrl` is a `wss://` URL — i.e. it
+ * really is a tunnel endpoint, not a `ws://` LAN entry. When the server told us
+ * the `previousUrl`, we additionally require the stored URL to match it, so we
+ * never clobber an entry the operator pointed at a different host.
+ *
+ * @returns true when an entry was updated, false on a no-op.
+ */
+function applyRotatedTunnelUrlDashboard(
+  get: MsgGet,
+  newUrl: string,
+  previousUrl: string | null,
+): boolean {
+  if (!newUrl || !/^wss:\/\//i.test(newUrl)) return false;
+  const state = get();
+  const activeServerId = state.activeServerId;
+  if (!activeServerId) return false;
+  const entry = state.serverRegistry.find((s) => s.id === activeServerId);
+  if (!entry) return false;
+  // Only repoint a tunnel (wss://) entry; never a ws:// LAN entry.
+  if (!/^wss:\/\//i.test(entry.wsUrl)) return false;
+  if (entry.wsUrl === newUrl) return false;
+  // When the server told us the prior URL, require the stored URL to match it
+  // so we don't repoint an entry the operator aimed at a different host.
+  if (previousUrl && entry.wsUrl !== previousUrl) return false;
+  try {
+    state.updateServer(activeServerId, { wsUrl: newUrl });
+    return true;
+  } catch {
+    // validateWsUrl rejected the new URL — leave the stored entry untouched.
+    return false;
   }
 }
 
@@ -3833,6 +3876,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // 3-request connect-time round trip. Apply each list through the SAME
       // store mutations the discrete responses use.
       const boot = sharedAuthBootstrap(msg);
+      // #5555 (sub-item 7): re-learn the live tunnel URL on every connect. If a
+      // quick-tunnel rotation happened while this dashboard was disconnected
+      // (so it missed the live `tunnel_url_changed` push), repoint the stored
+      // server entry to the working endpoint. No-op for the same-origin
+      // connection and for LAN entries.
+      if (boot.tunnelUrl) applyRotatedTunnelUrlDashboard(get, boot.tunnelUrl, null);
       set({ availableProviders: boot.providers as ProviderInfo[] });
       // Slash commands + agents are scoped to the connect-time active session.
       // Guard against a stale burst: if a session switch already moved the
@@ -3843,6 +3892,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (boot.sessionId && activeId && boot.sessionId !== activeId) break;
       set({ slashCommands: boot.slashCommands as SlashCommand[] });
       set({ customAgents: boot.agents as CustomAgent[] });
+      break;
+    }
+
+    case 'tunnel_url_changed': {
+      // #5555 (sub-item 7): a quick-tunnel recovery rotated the public URL.
+      // Repoint the active server-registry entry so the next reconnect dials
+      // the working URL (and survives a tab refresh — localStorage-backed).
+      //
+      // A localhost dashboard (served by the local daemon, activeServerId ===
+      // null) keeps its socket across the rotation and so RELIABLY receives
+      // this push — but it dials window.location, not the tunnel, so the
+      // helper is a no-op for it. A remote/LAN dashboard reaches the server
+      // THROUGH the tunnel, so it usually will NOT receive this frame (the old
+      // tunnel just died); its durable recovery is the `tunnelUrl` in the
+      // auth_bootstrap burst on the next reconnect (handled above).
+      const rotated = sharedTunnelUrlChanged(msg);
+      if (rotated) applyRotatedTunnelUrlDashboard(get, rotated.url, rotated.previousUrl);
       break;
     }
 

--- a/packages/dashboard/src/store/tunnel-url-changed.test.ts
+++ b/packages/dashboard/src/store/tunnel-url-changed.test.ts
@@ -1,0 +1,172 @@
+/**
+ * #5555 (sub-item 7) — the dashboard repoints the active server-registry entry
+ * when a quick-tunnel rotation pushes a new URL (`tunnel_url_changed`) or
+ * re-advertises it on reconnect (`auth_bootstrap` burst's `tunnelUrl`).
+ *
+ * Only a NON-localhost entry (activeServerId !== null) and only a `wss://`
+ * (tunnel) entry are repointed; the same-origin connection and `ws://` LAN
+ * entries are left alone. The update flows through the store's `updateServer`
+ * action, which persists to localStorage.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import { handleMessage, setStore, stopHeartbeat, clearDeltaBuffers } from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerEntry } from './server-registry'
+
+interface MockStoreOpts {
+  activeServerId: string | null
+  serverRegistry: ServerEntry[]
+}
+
+function createMockStore({ activeServerId, serverRegistry }: MockStoreOpts) {
+  let state = {
+    activeServerId,
+    serverRegistry,
+    activeSessionId: null,
+    availableProviders: [],
+    slashCommands: [],
+    customAgents: [],
+    // The real store action the helper calls. Mutates the registry in place
+    // (the production action also re-saves to localStorage; here we just track
+    // the resulting list so the test can assert on it).
+    updateServer: (serverId: string, patch: Partial<Pick<ServerEntry, 'name' | 'wsUrl' | 'token'>>) => {
+      state = {
+        ...state,
+        serverRegistry: state.serverRegistry.map((s) =>
+          s.id === serverId ? { ...s, ...patch } : s,
+        ),
+      }
+    },
+  } as unknown as ConnectionState
+
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function entry(id: string, wsUrl: string): ServerEntry {
+  return { id, name: id, wsUrl, token: 'tok', lastConnectedAt: null }
+}
+
+/** Read a registry entry's wsUrl by index, asserting it exists (test-only). */
+function urlAt(store: { getState: () => ConnectionState }, idx: number): string {
+  const e = store.getState().serverRegistry[idx]
+  expect(e).toBeDefined()
+  return e!.wsUrl
+}
+
+const ctx = { url: 'wss://old.trycloudflare.com', token: 'tok', isReconnect: false, silent: false }
+
+describe('dashboard tunnel_url_changed (#5555 sub-item 7)', () => {
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+  })
+
+  it('repoints the active wss entry to the rotated URL', () => {
+    const store = createMockStore({
+      activeServerId: 'srv1',
+      serverRegistry: [entry('srv1', 'wss://old.trycloudflare.com')],
+    })
+    setStore(store as any)
+
+    handleMessage(
+      { type: 'tunnel_url_changed', url: 'wss://new.trycloudflare.com', previousUrl: 'wss://old.trycloudflare.com' },
+      ctx as any,
+    )
+
+    expect(urlAt(store, 0)).toBe('wss://new.trycloudflare.com')
+  })
+
+  it('is a no-op for the same-origin connection (activeServerId === null)', () => {
+    const store = createMockStore({
+      activeServerId: null,
+      serverRegistry: [entry('srv1', 'wss://old.trycloudflare.com')],
+    })
+    setStore(store as any)
+
+    handleMessage({ type: 'tunnel_url_changed', url: 'wss://new.trycloudflare.com' }, ctx as any)
+
+    expect(urlAt(store, 0)).toBe('wss://old.trycloudflare.com')
+  })
+
+  it('does NOT repoint a ws:// LAN entry', () => {
+    const store = createMockStore({
+      activeServerId: 'lan1',
+      serverRegistry: [entry('lan1', 'ws://192.168.1.5:8765')],
+    })
+    setStore(store as any)
+
+    handleMessage({ type: 'tunnel_url_changed', url: 'wss://new.trycloudflare.com' }, ctx as any)
+
+    expect(urlAt(store, 0)).toBe('ws://192.168.1.5:8765')
+  })
+
+  it('does NOT repoint when previousUrl is given but does not match the stored entry', () => {
+    const store = createMockStore({
+      activeServerId: 'srv1',
+      serverRegistry: [entry('srv1', 'wss://current.trycloudflare.com')],
+    })
+    setStore(store as any)
+
+    handleMessage(
+      { type: 'tunnel_url_changed', url: 'wss://new.trycloudflare.com', previousUrl: 'wss://some-other.trycloudflare.com' },
+      ctx as any,
+    )
+
+    expect(urlAt(store, 0)).toBe('wss://current.trycloudflare.com')
+  })
+
+  it('an auth_bootstrap burst with tunnelUrl re-learns the rotated URL', () => {
+    const store = createMockStore({
+      activeServerId: 'srv1',
+      serverRegistry: [entry('srv1', 'wss://old.trycloudflare.com')],
+    })
+    setStore(store as any)
+
+    handleMessage(
+      {
+        type: 'auth_bootstrap',
+        providers: [],
+        slashCommands: [],
+        agents: [],
+        tunnelUrl: 'wss://new.trycloudflare.com',
+      },
+      ctx as any,
+    )
+
+    expect(urlAt(store, 0)).toBe('wss://new.trycloudflare.com')
+  })
+
+  it('ignores a malformed push (no url) without throwing', () => {
+    const store = createMockStore({
+      activeServerId: 'srv1',
+      serverRegistry: [entry('srv1', 'wss://old.trycloudflare.com')],
+    })
+    setStore(store as any)
+
+    expect(() => handleMessage({ type: 'tunnel_url_changed' }, ctx as any)).not.toThrow()
+    expect(urlAt(store, 0)).toBe('wss://old.trycloudflare.com')
+  })
+})

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -1849,6 +1849,12 @@ export declare const ServerAuthBootstrapSchema: z.ZodObject<{
         source: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>>;
     sessionId: z.ZodOptional<z.ZodString>;
+    tunnelUrl: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+export declare const ServerTunnelUrlChangedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"tunnel_url_changed">;
+    url: z.ZodString;
+    previousUrl: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
 export declare const ServerSkillsListSchema: z.ZodObject<{
     type: z.ZodLiteral<"skills_list">;
@@ -2251,6 +2257,7 @@ export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSess
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
 export type ServerAuthBootstrapMessage = z.infer<typeof ServerAuthBootstrapSchema>;
+export type ServerTunnelUrlChangedMessage = z.infer<typeof ServerTunnelUrlChangedSchema>;
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>;
 export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewriteSchema>;
 export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -1716,6 +1716,40 @@ export const ServerAuthBootstrapSchema = z.object({
     // The active session id this burst was scoped to, when applicable. Lets a
     // client ignore a stale burst if it has already switched sessions.
     sessionId: z.string().optional(),
+    // #5555 (sub-item 7) — the server's current public tunnel URL as a `wss://`
+    // endpoint, when a tunnel is up. Carried in every connect-time bootstrap so a
+    // reconnecting client always re-learns the live URL (covers the case where a
+    // quick-tunnel rotation happened while the client was offline and it could
+    // not receive the live `tunnel_url_changed` push). Absent in LAN / no-tunnel
+    // deployments. Never a secret — the QR code already shares this URL.
+    tunnelUrl: z.string().optional(),
+}).passthrough();
+// #5555 (sub-item 7) — quick-tunnel recovery rotates the public URL. The
+// server pushes this to every connected client so they can update the stored
+// endpoint their reconnect path dials instead of hammering the dead URL.
+//
+// TIMING / BEST-EFFORT: when the tunnel URL rotates, tunnel-connected clients
+// are reaching the server THROUGH the old tunnel, which has just died — they
+// usually will NOT receive this frame (the socket is already gone). It is
+// genuinely best-effort for them; the durable recovery path for those clients
+// is `tunnelUrl` in the `auth_bootstrap` burst on their next reconnect. The
+// real beneficiaries are LAN-connected clients (desktop dashboard over
+// localhost, LAN clients) whose socket survives the rotation — they get the
+// fresh URL immediately and persist it.
+//
+// SECURITY: the tunnel URL is connection metadata, not a secret (it is shared
+// in the QR code), so it is broadcast to ALL authenticated clients including
+// pairing-bound ones — a bound client already knows the URL it connected to,
+// and a rotated URL is the same trust level. See
+// docs/security/bearer-token-authority.md.
+export const ServerTunnelUrlChangedSchema = z.object({
+    type: z.literal('tunnel_url_changed'),
+    // The new public endpoint as a `wss://` URL the client should dial on its
+    // next reconnect.
+    url: z.string(),
+    // The previous `wss://` URL, when known — lets a client match the rotation
+    // against a specific stored entry instead of guessing.
+    previousUrl: z.string().optional(),
 }).passthrough();
 export const ServerSkillsListSchema = z.object({
     type: z.literal('skills_list'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -1816,6 +1816,41 @@ export const ServerAuthBootstrapSchema = z.object({
   // The active session id this burst was scoped to, when applicable. Lets a
   // client ignore a stale burst if it has already switched sessions.
   sessionId: z.string().optional(),
+  // #5555 (sub-item 7) — the server's current public tunnel URL as a `wss://`
+  // endpoint, when a tunnel is up. Carried in every connect-time bootstrap so a
+  // reconnecting client always re-learns the live URL (covers the case where a
+  // quick-tunnel rotation happened while the client was offline and it could
+  // not receive the live `tunnel_url_changed` push). Absent in LAN / no-tunnel
+  // deployments. Never a secret — the QR code already shares this URL.
+  tunnelUrl: z.string().optional(),
+}).passthrough()
+
+// #5555 (sub-item 7) — quick-tunnel recovery rotates the public URL. The
+// server pushes this to every connected client so they can update the stored
+// endpoint their reconnect path dials instead of hammering the dead URL.
+//
+// TIMING / BEST-EFFORT: when the tunnel URL rotates, tunnel-connected clients
+// are reaching the server THROUGH the old tunnel, which has just died — they
+// usually will NOT receive this frame (the socket is already gone). It is
+// genuinely best-effort for them; the durable recovery path for those clients
+// is `tunnelUrl` in the `auth_bootstrap` burst on their next reconnect. The
+// real beneficiaries are LAN-connected clients (desktop dashboard over
+// localhost, LAN clients) whose socket survives the rotation — they get the
+// fresh URL immediately and persist it.
+//
+// SECURITY: the tunnel URL is connection metadata, not a secret (it is shared
+// in the QR code), so it is broadcast to ALL authenticated clients including
+// pairing-bound ones — a bound client already knows the URL it connected to,
+// and a rotated URL is the same trust level. See
+// docs/security/bearer-token-authority.md.
+export const ServerTunnelUrlChangedSchema = z.object({
+  type: z.literal('tunnel_url_changed'),
+  // The new public endpoint as a `wss://` URL the client should dial on its
+  // next reconnect.
+  url: z.string(),
+  // The previous `wss://` URL, when known — lets a client match the rotation
+  // against a specific stored entry instead of guessing.
+  previousUrl: z.string().optional(),
 }).passthrough()
 
 export const ServerSkillsListSchema = z.object({
@@ -2396,6 +2431,8 @@ export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSess
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
 export type ServerAuthBootstrapMessage = z.infer<typeof ServerAuthBootstrapSchema>
+// #5555 (sub-item 7) — quick-tunnel URL rotation push.
+export type ServerTunnelUrlChangedMessage = z.infer<typeof ServerTunnelUrlChangedSchema>
 export type ServerEvaluateDraftResultMessage = z.infer<typeof ServerEvaluateDraftResultSchema>
 export type ServerEvaluatorRewriteMessage = z.infer<typeof ServerEvaluatorRewriteSchema>
 export type ServerEvaluatorClarifyMessage = z.infer<typeof ServerEvaluatorClarifySchema>

--- a/packages/server/src/server-cli/tunnel-lifecycle-handler.js
+++ b/packages/server/src/server-cli/tunnel-lifecycle-handler.js
@@ -108,6 +108,9 @@ export class TunnelLifecycleHandler {
       return { ok: false, tunnel }
     }
     startupDisplay.currentWsUrl = wsUrl
+    // #5555 (sub-item 7): seed the WsServer's current public URL so the
+    // auth_bootstrap burst can carry it to (re)connecting clients.
+    wsServer.setTunnelUrl(wsUrl)
 
     // 5. Wire up tunnel lifecycle events (before waitForTunnel to catch early failures)
     this._wireTunnelEvents(tunnel, wsServer)
@@ -128,10 +131,18 @@ export class TunnelLifecycleHandler {
 
         // Only display new QR code if URL actually changed
         if (newWsUrl !== startupDisplay.currentWsUrl) {
+          const previousWsUrl = startupDisplay.currentWsUrl
           startupDisplay.currentWsUrl = newWsUrl
           if (pairingManager) pairingManager.refresh()
           await startupDisplay.displayQr(newWsUrl, newHttpUrl, modeLabel)
           wsServer.broadcastStatus(`Tunnel reconnected with new URL: ${newWsUrl}`)
+          // #5555 (sub-item 7): push the rotated URL to every connected client
+          // so their reconnect path dials the new endpoint instead of the dead
+          // one. Best-effort for tunnel-connected clients (their socket rode
+          // the now-dead old tunnel); LAN clients keep their socket and get it
+          // immediately. Also records the URL on the WsServer so reconnecting
+          // clients re-learn it via auth_bootstrap.
+          wsServer.broadcastTunnelUrlChanged(newWsUrl, previousWsUrl)
         } else {
           log.info(`Tunnel URL unchanged: ${newWsUrl}`)
           wsServer.broadcastStatus('Tunnel connection recovered')

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -587,6 +587,12 @@ function sendAuthBootstrap(ctx, ws, info = {}) {
       slashCommands,
       agents,
       ...(info.sessionId ? { sessionId: info.sessionId } : {}),
+      // #5555 (sub-item 7): the live public tunnel URL, so a reconnecting
+      // client re-learns it on every connect — durable recovery for the case
+      // where a quick-tunnel rotation happened while the client was offline
+      // and it could not receive the live `tunnel_url_changed` push. Omitted
+      // for LAN / no-tunnel deployments (tunnelUrl is null).
+      ...(ctx.tunnelUrl ? { tunnelUrl: ctx.tunnelUrl } : {}),
     })
   }).catch(err => {
     // Defensive: Promise.all here can only reject if one of the .catch handlers

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -305,7 +305,8 @@ function _isSecureRequest(req) {
  *   All session-scoped messages include a `sessionId` field for background sync.
  *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs } — auth succeeded (encryption: 'required'|'disabled'; resultTimeoutMs = soft-warning window in ms, hardTimeoutMs = hard-kill window in ms, streamStallTimeoutMs = stream-stall recovery window in ms (0 = disabled) — #3760, #3905, #4477)
  *   { type: 'key_exchange_ok', publicKey }               — server's ephemeral X25519 public key (E2E encryption)
- *   { type: 'auth_bootstrap', providers, slashCommands, agents, sessionId? } — #5555: connect-time burst folding the provider/slash-command/agent lists so a new client skips its 3-request list_* round trip
+ *   { type: 'auth_bootstrap', providers, slashCommands, agents, sessionId?, tunnelUrl? } — #5555: connect-time burst folding the provider/slash-command/agent lists so a new client skips its 3-request list_* round trip; tunnelUrl re-advertises the live public URL (sub-item 7)
+ *   { type: 'tunnel_url_changed', url, previousUrl? } — #5555 (sub-item 7): quick-tunnel recovery rotated the public URL; clients repoint their stored endpoint. Best-effort for tunnel-connected clients (their socket rode the now-dead old tunnel); durable recovery is auth_bootstrap.tunnelUrl on reconnect
  *   { type: 'auth_fail',    reason: '...' }           — auth failed
  *   { type: 'server_mode',  mode: 'cli' }             — which backend mode is active
  *   { type: 'message',      ... }                     — parsed chat message
@@ -504,6 +505,12 @@ export class WsServer {
     // quick (trycloudflare) tunnel is configured.
     this._boundHost = undefined
     this._quickTunnelActive = false
+    // #5555 (sub-item 7): the server's current public tunnel URL as a `wss://`
+    // endpoint, set by server-cli once the tunnel is up and updated on a
+    // quick-tunnel URL rotation. Surfaced in the auth_bootstrap burst so a
+    // reconnecting client always re-learns the live URL. `null` for LAN /
+    // no-tunnel deployments.
+    this._tunnelUrl = null
     this._backpressureThreshold = backpressureThreshold ?? 1024 * 1024 // 1MB default
     this._backpressureMaxDrops = 10 // close connection after this many consecutive drops
     // #3996: name each limiter so eviction logs and /diagnostics
@@ -792,6 +799,11 @@ export class WsServer {
       // letting the client skip its 3-request connect-time round trip.
       get fileOps() { return self._fileOps },
       get userAgentsDirs() { return getProviderDataDirs().map(d => join(d, 'agents')) },
+      // #5555 (sub-item 7): the current public tunnel URL (wss://), folded into
+      // the auth_bootstrap burst so a reconnecting client always re-learns the
+      // live URL — the durable recovery path when a quick-tunnel rotation
+      // happened while the client was offline. null for LAN / no-tunnel.
+      get tunnelUrl() { return self._tunnelUrl },
     }
     this._authCtx = {
       get clients() { return self.clients },
@@ -1245,6 +1257,53 @@ export class WsServer {
    */
   setQuickTunnelActive(active) {
     this._quickTunnelActive = !!active
+  }
+
+  /**
+   * #5555 (sub-item 7): record the server's current public tunnel URL as a
+   * `wss://` endpoint. Called by server-cli once the tunnel is up (and on a
+   * URL rotation via broadcastTunnelUrlChanged). Surfaced in the
+   * auth_bootstrap burst so a reconnecting client always re-learns the live
+   * URL — the durable recovery path when a rotation happened while the client
+   * was offline. Pass `null` to clear (no tunnel).
+   * @param {string|null} wsUrl
+   */
+  setTunnelUrl(wsUrl) {
+    this._tunnelUrl = wsUrl || null
+  }
+
+  /** #5555 (sub-item 7): the current `wss://` tunnel URL, or null. */
+  get tunnelUrl() {
+    return this._tunnelUrl
+  }
+
+  /**
+   * #5555 (sub-item 7): a quick-tunnel recovery rotated the public URL. Record
+   * the new URL (so reconnecting clients get it via auth_bootstrap) and push a
+   * `tunnel_url_changed` frame to every authenticated client so they can
+   * update the stored endpoint their reconnect path dials.
+   *
+   * BEST-EFFORT for tunnel-connected clients: they reach the server THROUGH
+   * the old tunnel, which has just died, so the push usually will not arrive —
+   * their durable recovery is the auth_bootstrap `tunnelUrl` on next connect.
+   * LAN-connected clients (localhost dashboard, LAN clients) keep their socket
+   * across the rotation and get the new URL immediately.
+   *
+   * SECURITY: the tunnel URL is connection metadata, not a secret (the QR code
+   * shares it), so it goes to ALL authenticated clients including
+   * pairing-bound ones — see docs/security/bearer-token-authority.md.
+   *
+   * @param {string} newWsUrl  the new `wss://` endpoint
+   * @param {string|null} [previousWsUrl]  the prior `wss://` endpoint, if known
+   */
+  broadcastTunnelUrlChanged(newWsUrl, previousWsUrl = null) {
+    if (!newWsUrl) return
+    this.setTunnelUrl(newWsUrl)
+    this._broadcast({
+      type: 'tunnel_url_changed',
+      url: newWsUrl,
+      ...(previousWsUrl ? { previousUrl: previousWsUrl } : {}),
+    })
   }
 
   /**

--- a/packages/server/tests/tunnel-lifecycle-handler.test.js
+++ b/packages/server/tests/tunnel-lifecycle-handler.test.js
@@ -28,9 +28,14 @@ function makeWsServer() {
     broadcasts: [],
     statuses: [],
     errors: [],
+    // #5555 (sub-item 7): capture tunnel-url state + the rotation push.
+    tunnelUrl: null,
+    urlChangedPushes: [],
     broadcastMinProtocolVersion(v, payload) { this.broadcasts.push({ v, payload }) },
     broadcastStatus(s) { this.statuses.push(s) },
     broadcastError(...a) { this.errors.push(a) },
+    setTunnelUrl(url) { this.tunnelUrl = url },
+    broadcastTunnelUrlChanged(url, previousUrl) { this.urlChangedPushes.push({ url, previousUrl }) },
   }
 }
 
@@ -115,6 +120,10 @@ describe('TunnelLifecycleHandler — success path', () => {
     assert.equal(pairingManager.extended, 1, 'extendCurrentId called (#2599)')
     const kinds = wsServer.broadcasts.map((b) => b.payload.kind)
     assert.ok(kinds.includes('warming') && kinds.includes('ready'), 'warming + ready status broadcast')
+    // #5555 (sub-item 7): the WsServer is seeded with the initial tunnel URL so
+    // the auth_bootstrap burst can advertise it; no rotation push on first start.
+    assert.equal(wsServer.tunnelUrl, 'wss://t.example', 'initial tunnel URL seeded on the WsServer')
+    assert.equal(wsServer.urlChangedPushes.length, 0, 'no url-changed push on first start')
   })
 })
 
@@ -132,6 +141,19 @@ describe('TunnelLifecycleHandler — tunnel_recovered', () => {
     assert.equal(pairingManager.refreshed, 1, 'pairing refreshed on a new url')
   })
 
+  it('#5555: pushes tunnel_url_changed with old+new URLs when the URL rotates', async () => {
+    const { handler, tunnel, wsServer } = build()
+    await handler.createAndStart()
+    assert.equal(wsServer.urlChangedPushes.length, 0)
+
+    tunnel.emit('tunnel_recovered', { httpUrl: 'https://new.example', wsUrl: 'wss://new.example', attempt: 2 })
+    await new Promise((r) => setImmediate(r))
+
+    assert.deepEqual(wsServer.urlChangedPushes, [
+      { url: 'wss://new.example', previousUrl: 'wss://t.example' },
+    ], 'rotation push carries the new + previous wss URLs')
+  })
+
   it('does NOT re-render when the URL is unchanged (status broadcast only)', async () => {
     const { handler, tunnel, wsServer, startupDisplay } = build()
     await handler.createAndStart()
@@ -143,6 +165,8 @@ describe('TunnelLifecycleHandler — tunnel_recovered', () => {
 
     assert.equal(startupDisplay.calls.length, 0, 'no QR re-render for an unchanged url')
     assert.ok(wsServer.statuses.some((s) => s.includes('recovered')), 'recovery status broadcast')
+    // #5555 (sub-item 7): no rotation push when the URL did not actually change.
+    assert.equal(wsServer.urlChangedPushes.length, 0, 'no url-changed push for an unchanged url')
   })
 
   it('a recovery DURING the initial waitForTunnel re-renders (modeLabel available — #5402 TDZ fix)', async () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -887,6 +887,44 @@ describe('sendPostAuthInfo — auth_bootstrap (#5555)', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(boot, 'sessionId'), false)
   })
 
+  it('#5555 (sub-item 7): includes tunnelUrl when ctx.tunnelUrl is set', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: 'sess-1',
+      fileOps: makeFakeFileOps([], []),
+      tunnelUrl: 'wss://abc.trycloudflare.com',
+    })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    await new Promise(r => setImmediate(r))
+
+    const boot = ctx._sends.find(m => m.type === 'auth_bootstrap')
+    assert.ok(boot)
+    assert.equal(boot.tunnelUrl, 'wss://abc.trycloudflare.com')
+  })
+
+  it('#5555 (sub-item 7): omits tunnelUrl for a LAN / no-tunnel server', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    const ws = makeFakeWs()
+    // ctx.tunnelUrl unset → null → field omitted.
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-1', fileOps: makeFakeFileOps([], []) })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    await new Promise(r => setImmediate(r))
+
+    const boot = ctx._sends.find(m => m.type === 'auth_bootstrap')
+    assert.ok(boot)
+    assert.equal(Object.prototype.hasOwnProperty.call(boot, 'tunnelUrl'), false)
+  })
+
   it('ships empty lists when no fileOps is wired (graceful degrade)', async () => {
     const { manager } = createMockSessionManager([
       { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },

--- a/packages/server/tests/ws-tunnel-url-changed.test.js
+++ b/packages/server/tests/ws-tunnel-url-changed.test.js
@@ -1,0 +1,110 @@
+/**
+ * #5555 (sub-item 7) — `tunnel_url_changed` client push + auth_bootstrap
+ * tunnelUrl re-advertisement.
+ *
+ * Quick-tunnel recovery rotates the public URL. Before this, the
+ * `tunnel_url_changed` event dead-ended server-side and users discovered the
+ * dead URL via failed reconnects. The server now:
+ *   1. tracks the current public URL (`setTunnelUrl` / `tunnelUrl` getter),
+ *   2. broadcasts a `tunnel_url_changed` frame to ALL authenticated clients on
+ *      a rotation (`broadcastTunnelUrlChanged`),
+ *   3. folds the live URL into the auth_bootstrap burst so a reconnecting
+ *      client always re-learns it.
+ *
+ * These tests drive the WsServer's broadcast surface directly with fake clients
+ * in the map (no real socket / tunnel), so no network is touched.
+ */
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { WsServer } from '../src/ws-server.js'
+import { createMockSession } from './test-helpers.js'
+
+function makeServer() {
+  return new WsServer({
+    port: 0,
+    apiToken: 'test-token',
+    cliSession: createMockSession(),
+    authRequired: false,
+    noEncrypt: true,
+  })
+}
+
+/** Inject a fake authenticated client straight into the clients map + capture sends. */
+function addFakeClient(server, { id, authenticated = true, boundSessionId = null } = {}) {
+  const sent = []
+  const ws = { readyState: 1, bufferedAmount: 0, send(data) { sent.push(JSON.parse(data)) }, close() {} }
+  server.clients.set(ws, {
+    id,
+    authenticated,
+    boundSessionId,
+    activeSessionId: null,
+    subscribedSessionIds: new Set(),
+    deviceInfo: null,
+    protocolVersion: null,
+    _backpressureDrops: 0,
+  })
+  return { ws, sent }
+}
+
+describe('WsServer tunnel URL tracking (#5555)', () => {
+  let server
+  beforeEach(() => { server = makeServer() })
+
+  it('tunnelUrl is null until set, then reflects setTunnelUrl', () => {
+    assert.equal(server.tunnelUrl, null)
+    server.setTunnelUrl('wss://abc.trycloudflare.com')
+    assert.equal(server.tunnelUrl, 'wss://abc.trycloudflare.com')
+    // Empty / falsy clears back to null.
+    server.setTunnelUrl('')
+    assert.equal(server.tunnelUrl, null)
+  })
+})
+
+describe('WsServer.broadcastTunnelUrlChanged (#5555)', () => {
+  let server
+  beforeEach(() => { server = makeServer() })
+
+  it('pushes tunnel_url_changed to every authenticated client (bound included)', () => {
+    const a = addFakeClient(server, { id: 'host', boundSessionId: null })
+    const b = addFakeClient(server, { id: 'bound', boundSessionId: 'sess-1' })
+
+    server.broadcastTunnelUrlChanged('wss://new.trycloudflare.com', 'wss://old.trycloudflare.com')
+
+    // The tunnel URL is connection metadata (the QR shares it), not a secret —
+    // so a pairing-bound client receives it too.
+    for (const sent of [a.sent, b.sent]) {
+      const frame = sent.find((m) => m.type === 'tunnel_url_changed')
+      assert.ok(frame, 'each authenticated client got the frame')
+      assert.equal(frame.url, 'wss://new.trycloudflare.com')
+      assert.equal(frame.previousUrl, 'wss://old.trycloudflare.com')
+    }
+  })
+
+  it('records the new URL on the server so auth_bootstrap re-advertises it', () => {
+    addFakeClient(server, { id: 'host' })
+    assert.equal(server.tunnelUrl, null)
+    server.broadcastTunnelUrlChanged('wss://new.trycloudflare.com')
+    assert.equal(server.tunnelUrl, 'wss://new.trycloudflare.com')
+  })
+
+  it('omits previousUrl when not provided', () => {
+    const a = addFakeClient(server, { id: 'host' })
+    server.broadcastTunnelUrlChanged('wss://new.trycloudflare.com')
+    const frame = a.sent.find((m) => m.type === 'tunnel_url_changed')
+    assert.ok(frame)
+    assert.equal('previousUrl' in frame, false)
+  })
+
+  it('is a no-op for a falsy URL (no push, no state change)', () => {
+    const a = addFakeClient(server, { id: 'host' })
+    server.broadcastTunnelUrlChanged('')
+    assert.equal(a.sent.some((m) => m.type === 'tunnel_url_changed'), false)
+    assert.equal(server.tunnelUrl, null)
+  })
+
+  it('does not push to unauthenticated clients', () => {
+    const pending = addFakeClient(server, { id: 'pending', authenticated: false })
+    server.broadcastTunnelUrlChanged('wss://new.trycloudflare.com')
+    assert.equal(pending.sent.some((m) => m.type === 'tunnel_url_changed'), false)
+  })
+})

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -66,6 +66,7 @@ import {
   handleAgentList,
   handleProviderList,
   handleAuthBootstrap,
+  handleTunnelUrlChanged,
   handleFileList,
   handleDiffResult,
   handleGitStatusResult,
@@ -3524,7 +3525,7 @@ describe('handleAuthBootstrap', () => {
     const agents = [{ name: 'reviewer', source: 'project' }]
     expect(
       handleAuthBootstrap({ type: 'auth_bootstrap', providers, slashCommands, agents, sessionId: 'sess-1' }),
-    ).toEqual({ providers, slashCommands, agents, sessionId: 'sess-1' })
+    ).toEqual({ providers, slashCommands, agents, sessionId: 'sess-1', tunnelUrl: null })
   })
 
   it('defaults each missing list to [] and sessionId to null', () => {
@@ -3533,18 +3534,59 @@ describe('handleAuthBootstrap', () => {
       slashCommands: [],
       agents: [],
       sessionId: null,
+      tunnelUrl: null,
     })
   })
 
   it('coerces non-array lists to [] independently (partial-compute tolerance)', () => {
     expect(
       handleAuthBootstrap({ providers: [{ name: 'x' }], slashCommands: 'oops', agents: null }),
-    ).toEqual({ providers: [{ name: 'x' }], slashCommands: [], agents: [], sessionId: null })
+    ).toEqual({ providers: [{ name: 'x' }], slashCommands: [], agents: [], sessionId: null, tunnelUrl: null })
   })
 
   it('treats empty/non-string sessionId as null', () => {
     expect(handleAuthBootstrap({ sessionId: '' }).sessionId).toBeNull()
     expect(handleAuthBootstrap({ sessionId: 42 as unknown as string }).sessionId).toBeNull()
+  })
+
+  it('#5555 (sub-item 7): extracts a wss tunnelUrl, else null', () => {
+    expect(handleAuthBootstrap({ tunnelUrl: 'wss://abc.trycloudflare.com' }).tunnelUrl).toBe(
+      'wss://abc.trycloudflare.com',
+    )
+    expect(handleAuthBootstrap({ tunnelUrl: '' }).tunnelUrl).toBeNull()
+    expect(handleAuthBootstrap({ tunnelUrl: 42 as unknown as string }).tunnelUrl).toBeNull()
+    expect(handleAuthBootstrap({}).tunnelUrl).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleTunnelUrlChanged (#5555 sub-item 7)
+// ---------------------------------------------------------------------------
+describe('handleTunnelUrlChanged', () => {
+  it('extracts url + previousUrl when both present', () => {
+    expect(
+      handleTunnelUrlChanged({
+        type: 'tunnel_url_changed',
+        url: 'wss://new.trycloudflare.com',
+        previousUrl: 'wss://old.trycloudflare.com',
+      }),
+    ).toEqual({ url: 'wss://new.trycloudflare.com', previousUrl: 'wss://old.trycloudflare.com' })
+  })
+
+  it('previousUrl defaults to null when missing or non-string', () => {
+    expect(handleTunnelUrlChanged({ url: 'wss://new.example' })).toEqual({
+      url: 'wss://new.example',
+      previousUrl: null,
+    })
+    expect(
+      handleTunnelUrlChanged({ url: 'wss://new.example', previousUrl: 42 as unknown as string })!.previousUrl,
+    ).toBeNull()
+  })
+
+  it('returns null when url is missing or non-string (caller skips the apply)', () => {
+    expect(handleTunnelUrlChanged({ type: 'tunnel_url_changed' })).toBeNull()
+    expect(handleTunnelUrlChanged({ url: '' })).toBeNull()
+    expect(handleTunnelUrlChanged({ url: 99 as unknown as string })).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -3556,6 +3556,9 @@ describe('handleAuthBootstrap', () => {
     expect(handleAuthBootstrap({ tunnelUrl: '' }).tunnelUrl).toBeNull()
     expect(handleAuthBootstrap({ tunnelUrl: 42 as unknown as string }).tunnelUrl).toBeNull()
     expect(handleAuthBootstrap({}).tunnelUrl).toBeNull()
+    // Rejects a non-wss scheme — the parser only ever yields a secure endpoint.
+    expect(handleAuthBootstrap({ tunnelUrl: 'ws://evil.example' }).tunnelUrl).toBeNull()
+    expect(handleAuthBootstrap({ tunnelUrl: 'http://nope' }).tunnelUrl).toBeNull()
   })
 })
 
@@ -3587,6 +3590,16 @@ describe('handleTunnelUrlChanged', () => {
     expect(handleTunnelUrlChanged({ type: 'tunnel_url_changed' })).toBeNull()
     expect(handleTunnelUrlChanged({ url: '' })).toBeNull()
     expect(handleTunnelUrlChanged({ url: 99 as unknown as string })).toBeNull()
+  })
+
+  it('rejects a non-wss url and drops a non-wss previousUrl', () => {
+    // A bogus scheme on `url` means the whole push is skipped.
+    expect(handleTunnelUrlChanged({ url: 'ws://evil.example' })).toBeNull()
+    expect(handleTunnelUrlChanged({ url: 'http://nope' })).toBeNull()
+    // A valid wss `url` with a non-wss `previousUrl` keeps the url, drops prev.
+    expect(
+      handleTunnelUrlChanged({ url: 'wss://new.example', previousUrl: 'ws://old.example' }),
+    ).toEqual({ url: 'wss://new.example', previousUrl: null })
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2611,12 +2611,45 @@ export function handleProviderList(
  */
 export function handleAuthBootstrap(
   msg: Record<string, unknown>,
-): { providers: unknown[]; slashCommands: unknown[]; agents: unknown[]; sessionId: string | null } {
+): {
+  providers: unknown[]
+  slashCommands: unknown[]
+  agents: unknown[]
+  sessionId: string | null
+  tunnelUrl: string | null
+} {
   const providers: unknown[] = Array.isArray(msg.providers) ? (msg.providers as unknown[]) : []
   const slashCommands: unknown[] = Array.isArray(msg.slashCommands) ? (msg.slashCommands as unknown[]) : []
   const agents: unknown[] = Array.isArray(msg.agents) ? (msg.agents as unknown[]) : []
   const sessionId = typeof msg.sessionId === 'string' && msg.sessionId ? msg.sessionId : null
-  return { providers, slashCommands, agents, sessionId }
+  // #5555 (sub-item 7): the server's live public tunnel URL, when a tunnel is
+  // up. Lets a reconnecting client re-learn a URL that rotated while it was
+  // offline. Absent in LAN / no-tunnel deployments.
+  const tunnelUrl = typeof msg.tunnelUrl === 'string' && msg.tunnelUrl ? msg.tunnelUrl : null
+  return { providers, slashCommands, agents, sessionId, tunnelUrl }
+}
+
+/**
+ * #5555 (sub-item 7) — parse a `tunnel_url_changed` push (quick-tunnel URL
+ * rotation). Returns the new `wss://` URL and the previous URL (when the server
+ * knew it), or null when the payload is malformed so the caller skips it.
+ *
+ * The tunnel URL is connection metadata, not a secret (the QR code shares it),
+ * so this is delivered to every authenticated client. Both clients apply it the
+ * same way conceptually — repoint the stored endpoint their reconnect path
+ * dials — but the STORAGE differs per platform (mobile: SecureStore-backed
+ * SavedConnection.tunnelUrl; dashboard: the server-registry entry's wsUrl in
+ * localStorage), so the apply step stays platform-local rather than living in
+ * the shared dispatch table.
+ */
+export function handleTunnelUrlChanged(
+  msg: Record<string, unknown>,
+): { url: string; previousUrl: string | null } | null {
+  const url = typeof msg.url === 'string' && msg.url ? msg.url : null
+  if (!url) return null
+  const previousUrl =
+    typeof msg.previousUrl === 'string' && msg.previousUrl ? msg.previousUrl : null
+  return { url, previousUrl }
 }
 
 /**

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2624,9 +2624,21 @@ export function handleAuthBootstrap(
   const sessionId = typeof msg.sessionId === 'string' && msg.sessionId ? msg.sessionId : null
   // #5555 (sub-item 7): the server's live public tunnel URL, when a tunnel is
   // up. Lets a reconnecting client re-learn a URL that rotated while it was
-  // offline. Absent in LAN / no-tunnel deployments.
-  const tunnelUrl = typeof msg.tunnelUrl === 'string' && msg.tunnelUrl ? msg.tunnelUrl : null
+  // offline. Absent in LAN / no-tunnel deployments. Validated as `wss://` here
+  // (not just non-empty) so the parser matches its documented contract and a
+  // bogus scheme is dropped before either client's apply step.
+  const tunnelUrl = asWssUrl(msg.tunnelUrl)
   return { providers, slashCommands, agents, sessionId, tunnelUrl }
+}
+
+/**
+ * #5555 (sub-item 7) — coerce a wire value to a `wss://` URL string, or null.
+ * The tunnel URL is always a secure WebSocket endpoint; rejecting any other
+ * scheme (or non-string) here keeps the shared tunnel-URL parsers honest so the
+ * platform apply steps never have to re-defend against `ws://`/garbage.
+ */
+function asWssUrl(value: unknown): string | null {
+  return typeof value === 'string' && /^wss:\/\//i.test(value) ? value : null
 }
 
 /**
@@ -2645,10 +2657,12 @@ export function handleAuthBootstrap(
 export function handleTunnelUrlChanged(
   msg: Record<string, unknown>,
 ): { url: string; previousUrl: string | null } | null {
-  const url = typeof msg.url === 'string' && msg.url ? msg.url : null
+  // Validate as `wss://` (the parser's documented contract) rather than just
+  // non-empty, so a malformed scheme is dropped here instead of relying on each
+  // client's apply step to re-check it.
+  const url = asWssUrl(msg.url)
   if (!url) return null
-  const previousUrl =
-    typeof msg.previousUrl === 'string' && msg.previousUrl ? msg.previousUrl : null
+  const previousUrl = asWssUrl(msg.previousUrl)
   return { url, previousUrl }
 }
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -473,6 +473,8 @@ export {
   handleProviderList,
   // #5555 — connect-time bootstrap burst (providers + slash commands + agents)
   handleAuthBootstrap,
+  // #5555 (sub-item 7) — quick-tunnel URL rotation push
+  handleTunnelUrlChanged,
   handleFileList,
   handleDiffResult,
   handleGitStatusResult,


### PR DESCRIPTION
## What

Quick-tunnel recovery rotates the public URL. The `tunnel_url_changed` event (`tunnel/base.js`) dead-ended server-side, so users only discovered the dead URL via failed reconnects. This wires the rotation through to clients. Completes **the last open sub-item (7) of epic #5555**.

## Server

- **WsServer URL tracking** — `setTunnelUrl(wsUrl)` / `tunnelUrl` getter. The tunnel lifecycle handler seeds it when the tunnel comes up.
- **`broadcastTunnelUrlChanged(newUrl, previousUrl?)`** — records the new URL and pushes a `tunnel_url_changed` frame to every authenticated client. Wired into the existing `tunnel_recovered` URL-changed branch in `TunnelLifecycleHandler` (it already has the re-verified `wss://` URLs and the changed-vs-unchanged gate, so this is the natural emit point rather than the raw `base.js` event).
- **`auth_bootstrap` re-advertisement** — the live `tunnelUrl` is folded into the connect-time bootstrap burst (#5592). A reconnecting client re-learns the URL on every connect.

## Timing — honest best-effort

When the tunnel URL rotates, **tunnel-connected clients reach the server _through_ the old tunnel, which has just died** — they usually will NOT receive the `tunnel_url_changed` push (the socket is already gone). It is genuinely best-effort for them. Their durable recovery path is `tunnelUrl` in the `auth_bootstrap` burst on the next reconnect.

The real beneficiaries of the live push are **LAN-connected clients** (desktop dashboard over localhost, LAN clients) whose socket survives the rotation — they get the fresh URL immediately and persist it.

## Security

Read `docs/security/bearer-token-authority.md` first. The tunnel URL is **connection metadata, not a secret** — the QR code already shares it. So the frame is broadcast to ALL authenticated clients **including pairing-bound ones**: a bound client already knows the URL it connected to, and a rotated URL is the same trust level. No new authority is granted (it carries no token, no session data). This is consistent with the §9 checklist — the message is global/non-secret and intentionally not gated on `boundSessionId`.

## Clients & persistence

- **App** (`message-handler.ts`): `tunnel_url_changed` and `auth_bootstrap.tunnelUrl` repoint the **SecureStore-backed** `SavedConnection.tunnelUrl` (and the canonical `url` when it was the old tunnel endpoint). A verified `ws://` LAN `url` is preserved. Because the record is SecureStore-backed, **the fix survives an app restart**.
- **Dashboard** (`message-handler.ts`): repoint the active **non-localhost `wss://`** server-registry entry via `updateServer` (localStorage-backed). The same-origin "this machine" connection (`activeServerId === null`) and `ws://` LAN entries are left alone. When the server provides `previousUrl`, the stored entry must match it before repointing.

### Dispatch table?

`tunnel_url_changed` is **not** a pure-delegation case, so it stays platform-local (justified per the dispatch-table doc): the two clients' apply steps genuinely diverge in STORAGE — mobile writes SecureStore-backed `SavedConnection.tunnelUrl`; dashboard mutates a localStorage server-registry entry's `wsUrl`. The shared adapter surface (`setState`/`updateSession`/`addMessage`) covers neither. The shared parse (`handleTunnelUrlChanged` in store-core) IS shared.

## Protocol

Additive: `ServerTunnelUrlChangedSchema` (`{ url, previousUrl? }`, `.passthrough()`) + optional `tunnelUrl` on `ServerAuthBootstrapSchema`. Tracked dist regenerated (`tsc`).

## Old-client compat

Both clients' `default:` case logs and ignores unknown message types (covered by existing tests). A pre-#5555 server simply omits `tunnelUrl` from the bootstrap and never sends the push — no behaviour change.

## Tests

- Server: `broadcastTunnelUrlChanged` reaches all authenticated clients incl. bound, omits `previousUrl` when absent, no-op on falsy URL, skips unauthenticated; lifecycle handler emits the rotation push on a changed URL (with old+new) and not on an unchanged one; `auth_bootstrap` includes/omits `tunnelUrl`. (`--test-force-exit`, temp `stateFilePath` rules respected.)
- store-core: `handleTunnelUrlChanged` parse + `handleAuthBootstrap` tunnelUrl extraction.
- App: `applyRotatedTunnelUrl` (repoint, LAN-preserve, SecureStore persistence round-trip, no-ops) + message-handler integration.
- Dashboard: registry repoint on push/bootstrap, same-origin & LAN no-ops, previousUrl mismatch guard, malformed-push tolerance.

## Verification

- Server: full suite `9313 pass, 2 fail` — the 2 failures are the known pre-existing `service.test.js` flakes (fetch-timeout / default-port-8765) on main, unrelated.
- store-core: 1311 pass · dashboard: 264 pass · app touched suites green · protocol: 282 pass.
- All 4 server custom lints + server eslint green; typechecks green for protocol / store-core / app / dashboard.

## Epic

This completes the LAST open sub-item of #5555. Whether to close the epic is the maintainer's call.

Related to #5555