### PR TITLE
refactor(store-core): extract shared createConnectFlow orchestration

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -86,7 +86,7 @@ import type {
   SessionInfo,
   SessionState,
 } from './types';
-import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter, formatQuestionAnswerSummary } from './utils';
+import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, formatQuestionAnswerSummary } from './utils';
 import { selectConnectEndpoint } from '../utils/endpoint-selector';
 import {
   setStore,
@@ -149,6 +149,14 @@ import {
   getHistoryCursors,
   // #5555.4 — hard-reset the replay reconcile state on explicit disconnect.
   resetReplayReconcile,
+  // #5556 sub-item 4 — shared connect-flow orchestration: the retry ladder, the
+  // probe → restart → connect decision tree, and the per-socket reconnect
+  // dedup. The app supplies its store writes / Alert give-up / device-id wiring
+  // as callbacks. `resolveEndpoint` is the #5597/#5537 LAN/tunnel seam (static).
+  runConnectAttempt,
+  createReconnectScheduler,
+  type ProbeResult,
+  type ConnectEndpoint,
 } from '@chroxy/store-core';
 import type { InputSettings } from '@chroxy/store-core';
 import { setCallback as setImperativeCallback, getCallback, clearAllCallbacks } from './imperative-callbacks';
@@ -833,87 +841,106 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       return;
     }
 
-    // HTTP health check before WebSocket — verify tunnel is up
-    const httpUrl = url.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
-    fetch(httpUrl, { method: 'GET', signal: controller.signal })
-      .finally(() => clearTimeout(timeoutId))
-      .then(async (res) => {
-        if (myAttemptId !== connectionAttemptId) return;
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-        // Check if the server is in restart mode (supervisor standby)
+    // #5556 sub-item 4 — the HTTP health check / restart-detect / retry-or-
+    // give-up decision tree now lives in the shared `runConnectAttempt`. The app
+    // supplies the EFFECTS as callbacks (phase store writes, the Alert give-up,
+    // the recursion entry point); the algorithm (which branch, when to retry,
+    // what delay) is shared with the dashboard. `MAX_RETRIES`/`RETRY_DELAYS`
+    // above are kept for the inline log strings and stay equal to the shared
+    // CONNECT_MAX_RETRIES / CONNECT_RETRY_DELAYS defaults.
+    void runConnectAttempt({
+      attempt: _retryCount,
+      maxRetries: MAX_RETRIES,
+      retryDelays: RETRY_DELAYS,
+      // #5597/#5537 seam — static endpoint today (the url/token captured at
+      // connect-start). Returns null when this attempt is already superseded so
+      // the probe is skipped entirely.
+      resolveEndpoint: (): ConnectEndpoint | null =>
+        myAttemptId !== connectionAttemptId ? null : { url, token },
+      isStale: () => myAttemptId !== connectionAttemptId,
+      // The HTTP `/health` GET (bare origin — the server answers both `/` and
+      // `/health`) with the 5s abort, mapped to a ProbeResult. Probe failures
+      // map through getHealthCheckErrorMessage to a 'failed' result; the flow's
+      // own reject path is a safety net.
+      probe: async (endpoint): Promise<ProbeResult> => {
+        const httpUrl = endpoint.url.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
         try {
-          const body = await res.json();
-          console.log('[ws] Health check response:', body.status ?? 'no status field');
-          if (body.status === 'restarting') {
-            console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${MAX_RETRIES + 1})`);
-            const healthEta = typeof body.restartEtaMs === 'number' ? body.restartEtaMs : null;
-            const currentState = get();
-            set({
-              shutdownReason: currentState.shutdownReason ?? 'restart',
-              restartEtaMs: healthEta,
-              restartingSince: currentState.restartingSince || Date.now(),
-            });
-            useConnectionLifecycleStore.getState().setConnectionPhase('server_restarting');
-            if (_retryCount < MAX_RETRIES) {
-              const delay = withJitter(RETRY_DELAYS[Math.min(_retryCount, RETRY_DELAYS.length - 1)]);
-              setTimeout(() => {
-                if (myAttemptId !== connectionAttemptId) return;
-                get().connect(url, token, { silent, _retryCount: _retryCount + 1 });
-              }, delay);
-            } else {
-              useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
-              useConnectionLifecycleStore.getState().setConnectionError('Server restart timed out', _retryCount);
-              if (!silent) {
-                Alert.alert(
-                  'Connection Failed',
-                  'The server is still restarting. Try again later.',
-                  [
-                    { text: 'OK' },
-                    { text: 'Retry', onPress: () => get().connect(url, token) },
-                  ],
-                );
-              }
+          const res = await fetch(httpUrl, { method: 'GET', signal: controller.signal });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          try {
+            const body = await res.json();
+            console.log('[ws] Health check response:', body.status ?? 'no status field');
+            if (body.status === 'restarting') {
+              const restartEtaMs = typeof body.restartEtaMs === 'number' ? body.restartEtaMs : null;
+              return { kind: 'restarting', restartEtaMs };
             }
-            return;
+          } catch (err) {
+            console.log('[ws] Health check body unreadable:', err instanceof Error ? err.message : String(err));
           }
+          return { kind: 'ok' };
         } catch (err) {
-          console.log('[ws] Health check body unreadable:', err instanceof Error ? err.message : String(err));
+          console.log(`[ws] Health check failed: ${err instanceof Error ? err.message : String(err)}`);
+          return { kind: 'failed', reason: getHealthCheckErrorMessage(err as { name?: string; message?: string }) };
+        } finally {
+          clearTimeout(timeoutId);
         }
-
+      },
+      openSocket: () => {
         console.log('[ws] Health check passed, connecting WebSocket...');
         _connectWebSocket();
-      })
-      .catch((err) => {
-        if (myAttemptId !== connectionAttemptId) return;
-        console.log(`[ws] Health check failed: ${err.message}`);
-        const reason = getHealthCheckErrorMessage(err);
+      },
+      onRestarting: ({ restartEtaMs }) => {
+        const currentState = get();
+        set({
+          shutdownReason: currentState.shutdownReason ?? 'restart',
+          restartEtaMs,
+          restartingSince: currentState.restartingSince || Date.now(),
+        });
+        useConnectionLifecycleStore.getState().setConnectionPhase('server_restarting');
+        console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${MAX_RETRIES + 1})`);
+      },
+      onProbeFailed: (reason) => {
         useConnectionLifecycleStore.getState().setConnectionError(reason, _retryCount);
-        if (_retryCount < MAX_RETRIES) {
-          const delay = withJitter(RETRY_DELAYS[_retryCount]);
-          console.log(`[ws] Retrying in ${delay}ms...`);
-          setTimeout(() => {
-            if (myAttemptId !== connectionAttemptId) return;
-            get().connect(url, token, { silent, _retryCount: _retryCount + 1 });
-          }, delay);
-        } else {
-          useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
-          useConnectionLifecycleStore.getState().setConnectionError('Could not reach server', _retryCount);
-          if (!silent) {
-            Alert.alert(
-              'Connection Failed',
-              'Could not reach the Chroxy server. Make sure it\'s running.',
-              [
-                { text: 'OK' },
-                { text: 'Forget Server', style: 'destructive', onPress: () => { void get().clearSavedConnection(); } },
-                { text: 'Retry', onPress: () => get().connect(url, token) },
-              ],
-            );
-          }
+      },
+      scheduleRetry: (nextAttempt, delayMs) => {
+        console.log(`[ws] Retrying in ${delayMs}ms...`);
+        setTimeout(() => {
+          if (myAttemptId !== connectionAttemptId) return;
+          get().connect(url, token, { silent, _retryCount: nextAttempt });
+        }, delayMs);
+      },
+      onRestartGaveUp: () => {
+        useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
+        useConnectionLifecycleStore.getState().setConnectionError('Server restart timed out', _retryCount);
+        if (!silent) {
+          Alert.alert(
+            'Connection Failed',
+            'The server is still restarting. Try again later.',
+            [
+              { text: 'OK' },
+              { text: 'Retry', onPress: () => get().connect(url, token) },
+            ],
+          );
         }
-      });
+      },
+      onProbeGaveUp: () => {
+        useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
+        useConnectionLifecycleStore.getState().setConnectionError('Could not reach server', _retryCount);
+        if (!silent) {
+          Alert.alert(
+            'Connection Failed',
+            'Could not reach the Chroxy server. Make sure it\'s running.',
+            [
+              { text: 'OK' },
+              { text: 'Forget Server', style: 'destructive', onPress: () => { void get().clearSavedConnection(); } },
+              { text: 'Retry', onPress: () => get().connect(url, token) },
+            ],
+          );
+        }
+      },
+    });
 
     function _connectWebSocket() {
     // Reset encryption state for each new connection (forward secrecy)
@@ -921,36 +948,36 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     setPendingKeyPair(null);
     const socket = new WebSocket(url);
 
-    // #3624 (ported from dashboard) — shared reconnect scheduler for both
+    // #3624 (ported from dashboard) — per-socket reconnect scheduler for both
     // onclose and onerror. A single transport drop fires `error` → `close` on
     // most WebSocket implementations, so without dedupe we'd queue two
     // setTimeouts for one underlying failure.
     //
     // A per-socket flag (not phase-only dedupe) is correct here: each new socket
-    // gets a fresh scheduler with `reconnectScheduled = false`, so a *new*
-    // socket's failure mid-reconnect (when the global phase is already
-    // 'reconnecting') can still arm its own retry timer. The flag is bounded to
-    // this socket's lifetime; first-write-wins on the reconnecting phase.
+    // gets a fresh scheduler with its dedup flag cleared, so a *new* socket's
+    // failure mid-reconnect (when the global phase is already 'reconnecting')
+    // can still arm its own retry timer. The flag is bounded to this socket's
+    // lifetime; first-write-wins on the reconnecting phase.
     //
-    // #5555.5 — the close/error path no longer uses a FIXED delay (was
-    // 1.5s/2s). A flapping tunnel would hammer the full handshake at that
-    // fixed cadence. Instead we climb the same RETRY_DELAYS ladder used by the
-    // pre-WS health-check retries: each scheduled reconnect advances one rung
-    // (1s → 2s → 3s → 5s → 8s, capped). The ladder is module-level and only
-    // resets on `auth_ok` (proof the link is healthy), so a socket that opens
-    // but never authenticates keeps backing off. The per-socket dedupe means a
-    // paired error → close drop advances the ladder exactly once.
-    let reconnectScheduled = false;
-    const scheduleReconnect = (): void => {
-      if (reconnectScheduled) return;
-      reconnectScheduled = true;
-      const rung = nextReconnectAttempt();
-      const delayMs = withJitter(RETRY_DELAYS[Math.min(rung, RETRY_DELAYS.length - 1)]);
-      setTimeout(() => {
-        if (myAttemptId !== connectionAttemptId) return;
-        get().connect(url, token);
-      }, delayMs);
-    };
+    // #5555.5 — the close/error path climbs the same RETRY_DELAYS ladder used by
+    // the pre-WS health-check retries (1s → 2s → 3s → 5s → 8s, capped) instead
+    // of a fixed 1.5s/2s. The ladder counter is module-level and only resets on
+    // `auth_ok`, so a socket that opens but never authenticates keeps backing
+    // off; the per-socket dedupe means a paired error → close drop advances the
+    // ladder exactly once.
+    //
+    // #5556 sub-item 4 — the per-socket dedup + ladder-advance + jittered-delay
+    // mechanics now live in the shared `createReconnectScheduler`. The app keeps
+    // its platform guards in the onclose/onerror CALLERS (below) and reads
+    // `reconnectScheduler.scheduled` to gate its first-write-wins phase/error
+    // writes.
+    const reconnectScheduler = createReconnectScheduler({
+      nextRung: nextReconnectAttempt,
+      reconnect: () => get().connect(url, token),
+      isStale: () => myAttemptId !== connectionAttemptId,
+      retryDelays: RETRY_DELAYS,
+    });
+    const scheduleReconnect = (): void => { reconnectScheduler.schedule(); };
 
     socket.onopen = () => {
       // Include device info in auth for multi-client awareness
@@ -1105,7 +1132,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         // we skip the phase/error writes too. That preserves first-write-wins on
         // connectionError so a close-code-specific banner isn't clobbered by the
         // generic error copy.
-        if (!reconnectScheduled) {
+        if (!reconnectScheduler.scheduled) {
           console.log(`[ws] WebSocket error (${detail || 'no detail'}), reconnecting...`);
           useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
           useConnectionLifecycleStore.getState().setConnectionError(errorMsg, 0);

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -73,7 +73,7 @@ import {
   updateServerEntry,
   markServerConnected,
 } from './server-registry';
-import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter } from './utils';
+import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState } from './utils';
 import { registerSummarizeRequest, cancelSummarizeRequest, rejectAllSummarizeRequests } from './summarizeRequests';
 import { formatQuestionAnswerSummary } from '../utils/questionAnswerSummary';
 import { getAuthToken } from '../utils/auth';
@@ -138,6 +138,15 @@ import {
   getHistoryCursors,
   // #5555.4 — hard-reset the replay reconcile state on explicit disconnect.
   resetReplayReconcile,
+  // #5556 sub-item 4 — shared connect-flow orchestration: the retry ladder, the
+  // probe → restart → connect decision tree, and the per-socket reconnect
+  // dedup. The dashboard supplies its store writes / console give-up / registry
+  // token re-resolution as callbacks. `resolveEndpoint` is the #5597/#5537
+  // LAN/tunnel re-resolution seam (static today).
+  runConnectAttempt,
+  createReconnectScheduler,
+  type ProbeResult,
+  type ConnectEndpoint,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
 // #5184: header cost-badge mode union, default, and runtime guard. Lives in
@@ -1273,73 +1282,86 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       console.log(`[ws] Connection attempt ${_retryCount + 1}/${MAX_RETRIES + 1}...`);
     }
 
-    // HTTP health check before WebSocket — verify server is up.
-    // Use root path (/) not the WS path (/ws) — GET /ws returns 404.
-    const httpBase = url.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
-    const httpUrl = new URL('/', httpBase).href;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
-    fetch(httpUrl, { method: 'GET', signal: controller.signal })
-      .finally(() => clearTimeout(timeoutId))
-      .then(async (res) => {
-        if (myAttemptId !== connectionAttemptId) return;
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-        // Check if the server is in restart mode (supervisor standby)
+    // #5556 sub-item 4 — the HTTP health check / restart-detect / retry-or-
+    // give-up decision tree now lives in the shared `runConnectAttempt`. The
+    // dashboard supplies the EFFECTS as callbacks (single-store `set()` writes,
+    // the console give-up + clearSavedConnection, the `_pairingId`-threaded
+    // recursion); the algorithm (which branch, when to retry, what delay) is
+    // shared with the app. `MAX_RETRIES`/`RETRY_DELAYS` above are kept for the
+    // inline log strings and stay equal to the shared defaults.
+    void runConnectAttempt({
+      attempt: _retryCount,
+      maxRetries: MAX_RETRIES,
+      retryDelays: RETRY_DELAYS,
+      // #5597/#5537 seam — static endpoint today (the url/token captured at
+      // connect-start). Returns null when superseded so the probe is skipped.
+      resolveEndpoint: (): ConnectEndpoint | null =>
+        myAttemptId !== connectionAttemptId ? null : { url, token },
+      isStale: () => myAttemptId !== connectionAttemptId,
+      // The HTTP `/health` GET — root path (/) not /ws (GET /ws returns 404) —
+      // with the 5s abort, mapped to a ProbeResult. #4771: the shared
+      // getHealthCheckErrorMessage gives distinct copy for AbortError / HTTP
+      // 4xx / 5xx / other instead of the raw status string.
+      probe: async (endpoint): Promise<ProbeResult> => {
+        const httpBase = endpoint.url.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+        const httpUrl = new URL('/', httpBase).href;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
         try {
-          const body = await res.json();
-          console.log('[ws] Health check response:', body.status ?? 'no status field');
-          if (body.status === 'restarting') {
-            console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${MAX_RETRIES + 1})`);
-            const healthEta = typeof body.restartEtaMs === 'number' ? body.restartEtaMs : null;
-            const currentState = get();
-            set({
-              connectionPhase: 'server_restarting',
-              shutdownReason: currentState.shutdownReason ?? 'restart',
-              restartEtaMs: healthEta,
-              restartingSince: currentState.restartingSince || Date.now(),
-            });
-            if (_retryCount < MAX_RETRIES) {
-              const delay = withJitter(RETRY_DELAYS[Math.min(_retryCount, RETRY_DELAYS.length - 1)]!);
-              setTimeout(() => {
-                if (myAttemptId !== connectionAttemptId) return;
-                get().connect(url, token, { silent, _retryCount: _retryCount + 1, ...(pairingId ? { _pairingId: pairingId } : {}) });
-              }, delay);
-            } else {
-              set({ connectionPhase: 'disconnected', connectionError: 'Server restart timed out' });
-              console.warn(`[chroxy] Connection Failed: The server is still restarting. Try again later.`);
+          const res = await fetch(httpUrl, { method: 'GET', signal: controller.signal });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          try {
+            const body = await res.json();
+            console.log('[ws] Health check response:', body.status ?? 'no status field');
+            if (body.status === 'restarting') {
+              const restartEtaMs = typeof body.restartEtaMs === 'number' ? body.restartEtaMs : null;
+              return { kind: 'restarting', restartEtaMs };
             }
-            return;
+          } catch (err) {
+            console.log('[ws] Health check body unreadable:', err instanceof Error ? err.message : String(err));
           }
+          return { kind: 'ok' };
         } catch (err) {
-          console.log('[ws] Health check body unreadable:', err instanceof Error ? err.message : String(err));
+          console.log(`[ws] Health check failed: ${err instanceof Error ? err.message : String(err)}`);
+          return { kind: 'failed', reason: getHealthCheckErrorMessage(err as { name?: string; message?: string }) };
+        } finally {
+          clearTimeout(timeoutId);
         }
-
+      },
+      openSocket: () => {
         console.log('[ws] Health check passed, connecting WebSocket...');
         _connectWebSocket();
-      })
-      .catch((err) => {
-        if (myAttemptId !== connectionAttemptId) return;
-        console.log(`[ws] Health check failed: ${err.message}`);
-        // #4771: shared mapping with the app — AbortError, HTTP 4xx
-        // (bad token), HTTP 5xx (server restart), other HTTP, and
-        // generic network errors all get distinct copy instead of
-        // collapsing 4xx/5xx into the raw status string.
-        const reason = getHealthCheckErrorMessage(err);
+      },
+      onRestarting: ({ restartEtaMs }) => {
+        const currentState = get();
+        set({
+          connectionPhase: 'server_restarting',
+          shutdownReason: currentState.shutdownReason ?? 'restart',
+          restartEtaMs,
+          restartingSince: currentState.restartingSince || Date.now(),
+        });
+        console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${MAX_RETRIES + 1})`);
+      },
+      onProbeFailed: (reason) => {
         set({ connectionError: reason });
-        if (_retryCount < MAX_RETRIES) {
-          const delay = withJitter(RETRY_DELAYS[_retryCount]!);
-          console.log(`[ws] Retrying in ${delay}ms...`);
-          setTimeout(() => {
-            if (myAttemptId !== connectionAttemptId) return;
-            get().connect(url, token, { silent, _retryCount: _retryCount + 1, ...(pairingId ? { _pairingId: pairingId } : {}) });
-          }, delay);
-        } else {
-          set({ connectionPhase: 'disconnected', connectionError: 'Could not reach server' });
-          console.warn(`[chroxy] Connection Failed: Could not reach the Chroxy server. Make sure it's running.`);
-          void get().clearSavedConnection();
-        }
-      });
+      },
+      scheduleRetry: (nextAttempt, delayMs) => {
+        console.log(`[ws] Retrying in ${delayMs}ms...`);
+        setTimeout(() => {
+          if (myAttemptId !== connectionAttemptId) return;
+          get().connect(url, token, { silent, _retryCount: nextAttempt, ...(pairingId ? { _pairingId: pairingId } : {}) });
+        }, delayMs);
+      },
+      onRestartGaveUp: () => {
+        set({ connectionPhase: 'disconnected', connectionError: 'Server restart timed out' });
+        console.warn(`[chroxy] Connection Failed: The server is still restarting. Try again later.`);
+      },
+      onProbeGaveUp: () => {
+        set({ connectionPhase: 'disconnected', connectionError: 'Could not reach server' });
+        console.warn(`[chroxy] Connection Failed: Could not reach the Chroxy server. Make sure it's running.`);
+        void get().clearSavedConnection();
+      },
+    });
 
     function _connectWebSocket() {
     // Reset encryption state for each new connection (forward secrecy)
@@ -1364,23 +1386,45 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     //
     // First-write-wins on `connectionError`: both events carry equally generic
     // messages, so flipping mid-display would just be visual churn.
-    let reconnectScheduled = false;
+    // #5556 sub-item 4 — the per-socket dedup + ladder-advance + jittered-delay
+    // mechanics now live in the shared `createReconnectScheduler`. The
+    // dashboard keeps its PLATFORM guards (userDisconnected / stale-attempt) and
+    // its phase/error writes in the `scheduleReconnect` WRAPPER below — the app
+    // guards in its onclose/onerror callers, so the shared scheduler stays
+    // guard-free and both clients converge on the same dedup+ladder core.
+    //
+    // The `reconnect` callback re-resolves the token from the registry (#5281
+    // ③ PR 2): a paired connection started with an empty token; auth_ok wrote
+    // the issued session token back to the registry, so the reconnect must use
+    // that, not the stale captured (empty) token. The shared scheduler's own
+    // stale-attempt guard covers the timer-fire boundary.
+    const reconnectScheduler = createReconnectScheduler({
+      nextRung: nextReconnectAttempt,
+      reconnect: () => {
+        const sid = get().activeServerId;
+        const reconnectToken = sid
+          ? (get().serverRegistry.find((s) => s.id === sid)?.token ?? token)
+          : token;
+        get().connect(url, reconnectToken);
+      },
+      isStale: () => myAttemptId !== connectionAttemptId,
+      retryDelays: RETRY_DELAYS,
+    });
     const scheduleReconnect = (
       reasonText: string,
       errorMessage: string | null,
     ): void => {
-      if (reconnectScheduled) return;
+      // Platform guards run BEFORE the ladder advances, so a user-initiated
+      // close / superseded attempt doesn't burn a rung (these used to live
+      // inside scheduleReconnect's body — kept here verbatim).
+      if (reconnectScheduler.scheduled) return;
       if (get().userDisconnected) return;
       if (disconnectedAttemptId === myAttemptId) return;
-      reconnectScheduled = true;
       // #5555.5 — climb the RETRY_DELAYS ladder (was a fixed 1.5s/2s). The
-      // ladder advances only AFTER the user-disconnect / stale-attempt guards
-      // above, so a user-initiated close doesn't burn a rung. It resets on
-      // `auth_ok`, so a clean reconnect starts back at the bottom (1s). The
-      // per-socket `reconnectScheduled` dedupe means a paired error → close
-      // drop advances the ladder exactly once.
-      const rung = nextReconnectAttempt();
-      const delayMs = withJitter(RETRY_DELAYS[Math.min(rung, RETRY_DELAYS.length - 1)]!);
+      // per-socket dedupe means a paired error → close drop advances the ladder
+      // exactly once. The ladder resets on `auth_ok`, so a clean reconnect
+      // starts back at the bottom (1s).
+      reconnectScheduler.schedule();
       console.log(`[ws] ${reasonText}, reconnecting...`);
       // #4771: `errorMessage === null` means the close code was 1000
       // (normal server-initiated close — see getWsCloseMessage). Match
@@ -1391,18 +1435,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         ...(errorMessage !== null ? { connectionError: errorMessage } : {}),
         connectionRetryCount: 0,
       });
-      setTimeout(() => {
-        if (myAttemptId !== connectionAttemptId) return;
-        // #5281 ③ PR 2 — reconnect with the latest stored token for the active
-        // registry server. A paired connection started with an empty token;
-        // auth_ok wrote the issued session token back to the registry, so the
-        // reconnect must use that, not the stale captured (empty) token.
-        const sid = get().activeServerId;
-        const reconnectToken = sid
-          ? (get().serverRegistry.find((s) => s.id === sid)?.token ?? token)
-          : token;
-        get().connect(url, reconnectToken);
-      }, delayMs);
     };
 
     socket.onopen = () => {

--- a/packages/store-core/src/connect-flow.test.ts
+++ b/packages/store-core/src/connect-flow.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests for the shared connect-flow orchestration (#5556 sub-item 4).
+ *
+ * Ported from the app's connect() + reconnect-backoff suites so the SAME
+ * orchestration coverage now runs against the shared flow once, instead of
+ * being hand-maintained twice. The clients keep thin tests for their callback
+ * implementations (store writes, give-up UX); the algorithm — probe → restart →
+ * retry/give-up decision tree and the RETRY_DELAYS backoff ladder — is tested
+ * here.
+ *
+ * Uses a deterministic fake scheduler (records armed callbacks, fired by hand —
+ * no real time, no fake-timer global patching), mirroring the createDeltaFlusher
+ * suite. Jitter is stubbed to the identity so each rung delay is exactly
+ * RETRY_DELAYS[N].
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  runConnectAttempt,
+  createReconnectScheduler,
+  retryDelayForAttempt,
+  CONNECT_MAX_RETRIES,
+  CONNECT_RETRY_DELAYS,
+  type ConnectFlowScheduler,
+  type ProbeResult,
+  type ConnectEndpoint,
+} from './connect-flow'
+
+const RETRY_DELAYS = CONNECT_RETRY_DELAYS
+/** Jitter stub — identity, so each rung delay is exactly RETRY_DELAYS[N]. */
+const noJitter = (ms: number) => ms
+
+const ENDPOINT: ConnectEndpoint = { url: 'wss://example.com', token: 'tok' }
+
+/** Deterministic scheduler: records armed callbacks; fired by hand. */
+function makeFakeScheduler() {
+  const armed: { cb: () => void; ms: number }[] = []
+  const scheduler: ConnectFlowScheduler = {
+    setTimeout: (cb, ms) => {
+      armed.push({ cb, ms })
+      return armed.length as unknown as ReturnType<typeof setTimeout>
+    },
+    clearTimeout: () => {},
+  }
+  return {
+    scheduler,
+    /** The ms of the most recently armed timer. */
+    lastDelay: () => armed[armed.length - 1]?.ms,
+    count: () => armed.length,
+    /** Fire all armed callbacks in order (clearing the queue). */
+    fireAll: () => {
+      const pending = armed.splice(0)
+      for (const { cb } of pending) cb()
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// retryDelayForAttempt — ladder math
+// ---------------------------------------------------------------------------
+
+describe('retryDelayForAttempt', () => {
+  it('returns the rung at the given index', () => {
+    expect(retryDelayForAttempt(0)).toBe(1000)
+    expect(retryDelayForAttempt(1)).toBe(2000)
+    expect(retryDelayForAttempt(2)).toBe(3000)
+    expect(retryDelayForAttempt(3)).toBe(5000)
+    expect(retryDelayForAttempt(4)).toBe(8000)
+  })
+
+  it('clamps past the end of the ladder to the final rung', () => {
+    expect(retryDelayForAttempt(5)).toBe(8000)
+    expect(retryDelayForAttempt(99)).toBe(8000)
+  })
+
+  it('clamps a negative index to the first rung', () => {
+    expect(retryDelayForAttempt(-1)).toBe(1000)
+  })
+
+  it('honors a custom ladder', () => {
+    expect(retryDelayForAttempt(1, [10, 20, 30])).toBe(20)
+    expect(retryDelayForAttempt(9, [10, 20, 30])).toBe(30)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runConnectAttempt — probe → branch decision tree
+// ---------------------------------------------------------------------------
+
+describe('runConnectAttempt — success path', () => {
+  it('opens the socket on an ok probe', async () => {
+    const openSocket = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'ok' }),
+      isStale: () => false,
+      openSocket,
+      onRestarting: vi.fn(),
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry: vi.fn(),
+      jitter: noJitter,
+    })
+    expect(openSocket).toHaveBeenCalledTimes(1)
+    expect(openSocket).toHaveBeenCalledWith(ENDPOINT)
+  })
+
+  it('aborts silently when resolveEndpoint returns null (superseded)', async () => {
+    const probe = vi.fn()
+    const openSocket = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => null,
+      probe: probe as unknown as (e: ConnectEndpoint) => Promise<ProbeResult>,
+      isStale: () => false,
+      openSocket,
+      onRestarting: vi.fn(),
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry: vi.fn(),
+      jitter: noJitter,
+    })
+    expect(probe).not.toHaveBeenCalled()
+    expect(openSocket).not.toHaveBeenCalled()
+  })
+
+  it('does NOT open the socket when the attempt went stale during the probe', async () => {
+    const openSocket = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'ok' }),
+      isStale: () => true,
+      openSocket,
+      onRestarting: vi.fn(),
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry: vi.fn(),
+      jitter: noJitter,
+    })
+    expect(openSocket).not.toHaveBeenCalled()
+  })
+})
+
+describe('runConnectAttempt — restarting path', () => {
+  it('signals restarting and schedules the next retry on the ladder', async () => {
+    const onRestarting = vi.fn()
+    const scheduleRetry = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'restarting', restartEtaMs: 5000 }),
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting,
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(onRestarting).toHaveBeenCalledWith({ restartEtaMs: 5000 })
+    expect(scheduleRetry).toHaveBeenCalledWith(1, RETRY_DELAYS[0])
+  })
+
+  it('passes a null restartEtaMs straight through', async () => {
+    const onRestarting = vi.fn()
+    await runConnectAttempt({
+      attempt: 2,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'restarting', restartEtaMs: null }),
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting,
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry: vi.fn(),
+      jitter: noJitter,
+    })
+    expect(onRestarting).toHaveBeenCalledWith({ restartEtaMs: null })
+  })
+
+  it('gives up (restart timed out) once retries are exhausted', async () => {
+    const onRestartGaveUp = vi.fn()
+    const scheduleRetry = vi.fn()
+    await runConnectAttempt({
+      attempt: CONNECT_MAX_RETRIES,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'restarting', restartEtaMs: null }),
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp,
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(scheduleRetry).not.toHaveBeenCalled()
+    expect(onRestartGaveUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('clamps the restart-retry delay at the final rung past the ladder end', async () => {
+    const scheduleRetry = vi.fn()
+    // attempt 4 is < MAX_RETRIES(5), so it retries; delay clamps to RETRY_DELAYS[4].
+    await runConnectAttempt({
+      attempt: 4,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'restarting', restartEtaMs: null }),
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(scheduleRetry).toHaveBeenCalledWith(5, RETRY_DELAYS[4])
+  })
+})
+
+describe('runConnectAttempt — failed path', () => {
+  it('surfaces the reason and schedules a retry below the budget', async () => {
+    const onProbeFailed = vi.fn()
+    const scheduleRetry = vi.fn()
+    await runConnectAttempt({
+      attempt: 1,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'failed', reason: 'Could not reach server — check your network' }),
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed,
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(onProbeFailed).toHaveBeenCalledWith('Could not reach server — check your network')
+    expect(scheduleRetry).toHaveBeenCalledWith(2, RETRY_DELAYS[1])
+  })
+
+  it('gives up (could not reach) once retries are exhausted', async () => {
+    const onProbeGaveUp = vi.fn()
+    const scheduleRetry = vi.fn()
+    await runConnectAttempt({
+      attempt: CONNECT_MAX_RETRIES,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'failed', reason: 'boom' }),
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp,
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(scheduleRetry).not.toHaveBeenCalled()
+    expect(onProbeGaveUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a probe REJECTION as a failed probe (safety net)', async () => {
+    const onProbeFailed = vi.fn()
+    const scheduleRetry = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => { throw new Error('unexpected') },
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed,
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(onProbeFailed).toHaveBeenCalledTimes(1)
+    expect(scheduleRetry).toHaveBeenCalledWith(1, RETRY_DELAYS[0])
+  })
+
+  it('writes nothing when the attempt went stale during a failed probe', async () => {
+    const onProbeFailed = vi.fn()
+    const scheduleRetry = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'failed', reason: 'boom' }),
+      isStale: () => true,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed,
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(onProbeFailed).not.toHaveBeenCalled()
+    expect(scheduleRetry).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createReconnectScheduler — per-socket close/error reconnect (#3624 + #5594)
+// ---------------------------------------------------------------------------
+
+describe('createReconnectScheduler', () => {
+  it('arms a reconnect at the next rung and fires it', () => {
+    const fake = makeFakeScheduler()
+    const reconnect = vi.fn()
+    let rung = 0
+    const s = createReconnectScheduler({
+      nextRung: () => rung++,
+      reconnect,
+      isStale: () => false,
+      scheduler: fake.scheduler,
+      jitter: noJitter,
+    })
+
+    expect(s.schedule()).toBe(true)
+    expect(s.scheduled).toBe(true)
+    expect(fake.lastDelay()).toBe(RETRY_DELAYS[0])
+    expect(reconnect).not.toHaveBeenCalled()
+
+    fake.fireAll()
+    expect(reconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedups a paired error → close drop (single-arm, first-arm-wins)', () => {
+    const fake = makeFakeScheduler()
+    let rung = 0
+    const s = createReconnectScheduler({
+      nextRung: () => rung++,
+      reconnect: vi.fn(),
+      isStale: () => false,
+      scheduler: fake.scheduler,
+      jitter: noJitter,
+    })
+
+    expect(s.schedule()).toBe(true)
+    // Second call (the paired event) is a dedup no-op — no new timer, no rung advance.
+    expect(s.schedule()).toBe(false)
+    expect(fake.count()).toBe(1)
+    expect(rung).toBe(1) // advanced exactly once
+  })
+
+  it('climbs the ladder across separate sockets (counter is shared, dedup is per-socket)', () => {
+    const fake = makeFakeScheduler()
+    let rung = 0
+    const nextRung = () => rung++
+    const mk = () =>
+      createReconnectScheduler({
+        nextRung,
+        reconnect: vi.fn(),
+        isStale: () => false,
+        scheduler: fake.scheduler,
+        jitter: noJitter,
+      })
+
+    mk().schedule()
+    expect(fake.lastDelay()).toBe(RETRY_DELAYS[0])
+    mk().schedule()
+    expect(fake.lastDelay()).toBe(RETRY_DELAYS[1])
+    mk().schedule()
+    expect(fake.lastDelay()).toBe(RETRY_DELAYS[2])
+  })
+
+  it('caps at the final rung once the ladder is exhausted', () => {
+    const fake = makeFakeScheduler()
+    let rung = 6 // already past the ladder
+    const s = createReconnectScheduler({
+      nextRung: () => rung++,
+      reconnect: vi.fn(),
+      isStale: () => false,
+      scheduler: fake.scheduler,
+      jitter: noJitter,
+    })
+    s.schedule()
+    expect(fake.lastDelay()).toBe(RETRY_DELAYS[RETRY_DELAYS.length - 1])
+  })
+
+  it('skips the reconnect when the attempt went stale before the timer fired', () => {
+    const fake = makeFakeScheduler()
+    const reconnect = vi.fn()
+    let stale = false
+    const s = createReconnectScheduler({
+      nextRung: () => 0,
+      reconnect,
+      isStale: () => stale,
+      scheduler: fake.scheduler,
+      jitter: noJitter,
+    })
+    s.schedule()
+    stale = true // superseded while the timer was pending
+    fake.fireAll()
+    expect(reconnect).not.toHaveBeenCalled()
+  })
+
+  it('applies jitter to the rung delay', () => {
+    const fake = makeFakeScheduler()
+    const s = createReconnectScheduler({
+      nextRung: () => 0,
+      reconnect: vi.fn(),
+      isStale: () => false,
+      scheduler: fake.scheduler,
+      jitter: (ms) => ms + 250,
+    })
+    s.schedule()
+    expect(fake.lastDelay()).toBe(RETRY_DELAYS[0] + 250)
+  })
+})

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -174,11 +174,13 @@ export interface RunConnectAttemptOptions {
    * Recurse into the client's own `connect()` for the next retry. The client
    * owns this so each retry re-runs its full per-connect store setup (the same
    * recursion the hand-written flow used). `attempt` is the NEXT attempt index.
+   * The client's `scheduleRetry` owns the retry timer (its own `setTimeout`), so
+   * the flow itself never schedules — that's why there's no `scheduler` opt
+   * here (unlike {@link CreateReconnectSchedulerOptions}, which arms its own
+   * timer and therefore takes one).
    */
   scheduleRetry: (nextAttempt: number, delayMs: number) => void
 
-  /** Timer surface; defaults to the global `setTimeout`/`clearTimeout`. */
-  scheduler?: ConnectFlowScheduler
   /** Jitter fn; defaults to store-core's `withJitter` (0–50%). */
   jitter?: (delayMs: number) => number
 }

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -1,0 +1,356 @@
+/**
+ * Shared client connect-flow orchestration (#5556 sub-item 4, epic #5556).
+ *
+ * The app (`packages/app/src/store/connection.ts`) and the dashboard
+ * (`packages/dashboard/src/store/connection.ts`) hand-maintained two parallel
+ * `connect()` orchestrations: same constants, same recursion, same decision
+ * tree — only the *effects* (which store the phase is written to, the give-up
+ * UX, the pairing/device-id wiring) legitimately differ. That left ~120
+ * lockstep lines that had to be edited in two places forever (the #5594 backoff
+ * ladder, #5555 restart detection, the #3624 reconnect dedup were each ported by
+ * hand and drifted in their guard placement).
+ *
+ * This module owns the ALGORITHM — the attempt counting, the RETRY_DELAYS delay
+ * ladder, the probe → restart → connect decision tree, and the per-socket
+ * reconnect-schedule dedup. Each client supplies the *effects* as callbacks
+ * (probe the host, open the socket, write the phase, schedule a timer, surface a
+ * give-up). The clients keep their store writes + platform glue in those
+ * callbacks; the orchestration stops being copy-pasted.
+ *
+ * Mirrors the `createDeltaFlusher` template (#5588): pure, dependency-free,
+ * injectable scheduler so store-core's own tests run on a deterministic fake and
+ * the client call sites work with jest/vitest fake timers (which patch the
+ * globals) out of the box.
+ *
+ * ## Two cooperating pieces
+ *
+ * 1. `runConnectAttempt` — the pre-WebSocket orchestration for ONE connect
+ *    attempt: probe the host, branch on the result (ok / restarting / failed),
+ *    and either open the socket, schedule the next retry, or give up. Recurses
+ *    through the client's `connect()` for retries (the client owns the recursion
+ *    entry point so each retry re-runs its full store setup).
+ *
+ * 2. `createReconnectScheduler` — the per-socket close/error reconnect
+ *    scheduler: a single-arm dedup flag (#3624) wrapping the shared RETRY_DELAYS
+ *    backoff ladder (#5594). The client invokes it from `onclose`/`onerror`
+ *    after its own platform guards.
+ *
+ * ## #5597 / #5537 seam — `resolveEndpoint(attempt)`
+ *
+ * Endpoint selection is a PER-ATTEMPT callback, not a closure-captured constant.
+ * Today both clients return the same static `{ url, token }` they captured at
+ * connect-start (current behavior, byte-identical). The next PR (#5597/#5537)
+ * plugs LAN/tunnel re-resolution into exactly this seam: a retry can re-probe
+ * the registry and switch endpoints without restructuring the flow.
+ */
+
+/** Bounded initial-connect retry budget — initial attempt + this many retries. */
+export const CONNECT_MAX_RETRIES = 5
+
+/**
+ * Backoff ladder (ms) for both the pre-WS health-check retries and the
+ * post-connect close/error reconnects. Climbed by attempt index, capped at the
+ * last rung. Shared so the app and dashboard escalate identically. (#5594)
+ */
+export const CONNECT_RETRY_DELAYS: readonly number[] = [1000, 2000, 3000, 5000, 8000]
+
+/**
+ * Pick the backoff delay for a given attempt/rung index, clamping past the end
+ * of the ladder to the final rung. The raw (un-jittered) value — the caller
+ * applies `withJitter` so tests can pin `Math.random` and assert exact delays.
+ */
+export function retryDelayForAttempt(
+  attempt: number,
+  ladder: readonly number[] = CONNECT_RETRY_DELAYS,
+): number {
+  const idx = Math.min(Math.max(attempt, 0), ladder.length - 1)
+  // `?? 0` satisfies `noUncheckedIndexedAccess` (dashboard tsconfig); idx is
+  // always in-bounds for a non-empty ladder, so the fallback is unreachable.
+  return ladder[idx] ?? 0
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler surface (matches createDeltaFlusher's DeltaFlushScheduler)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal timer surface the flow schedules on. Defaults to the global
+ * `setTimeout`/`clearTimeout`, so jest/vitest fake timers (which patch the
+ * globals) work at the client call sites with no extra wiring; store-core's own
+ * unit tests inject a deterministic fake instead.
+ */
+export interface ConnectFlowScheduler {
+  setTimeout: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimeout: (handle: ReturnType<typeof setTimeout>) => void
+}
+
+const DEFAULT_SCHEDULER: ConnectFlowScheduler = {
+  setTimeout: (cb, ms) => setTimeout(cb, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+}
+
+/** Default jitter: add 0–50% of the delay (matches store-core `withJitter`). */
+function defaultJitter(delayMs: number): number {
+  return delayMs + Math.floor(Math.random() * delayMs * 0.5)
+}
+
+// ---------------------------------------------------------------------------
+// runConnectAttempt — the pre-WebSocket health-check / restart / retry tree
+// ---------------------------------------------------------------------------
+
+/** Result of the client's host probe (the HTTP `/health` GET). */
+export type ProbeResult =
+  | { kind: 'ok' }
+  | { kind: 'restarting'; restartEtaMs: number | null }
+  | { kind: 'failed'; reason: string }
+
+/**
+ * The endpoint to connect to for a given attempt. Returned by
+ * `resolveEndpoint(attempt)` — the #5597/#5537 seam. Today both clients return
+ * the static `{ url, token }` captured at connect-start; a future PR can
+ * re-resolve LAN/tunnel here per attempt.
+ */
+export interface ConnectEndpoint {
+  url: string
+  token: string
+}
+
+export interface RunConnectAttemptOptions {
+  /** Zero-based attempt index (0 = initial connect, 1.. = retries). */
+  attempt: number
+  /** Retry budget — initial attempt + this many retries. */
+  maxRetries?: number
+  /** Backoff ladder (ms). Defaults to {@link CONNECT_RETRY_DELAYS}. */
+  retryDelays?: readonly number[]
+
+  /**
+   * #5597/#5537 seam — resolve the endpoint (url + token) for THIS attempt.
+   * Read once at the top of the attempt. Today static; a future PR re-resolves
+   * LAN/tunnel here per retry. Return `null` to abort the attempt silently (the
+   * caller bumped the attempt id out from under us — a superseded connect).
+   */
+  resolveEndpoint: (attempt: number) => ConnectEndpoint | null
+
+  /**
+   * Probe the host (the HTTP `/health` GET with the 5s abort). Resolves to the
+   * branch the flow should take. MUST honor the stale-attempt guard itself
+   * (resolve to a value the caller ignores, or simply let `isStale()` short the
+   * post-probe handling) — the flow re-checks `isStale()` after the probe.
+   */
+  probe: (endpoint: ConnectEndpoint) => Promise<ProbeResult>
+
+  /**
+   * True when this attempt has been superseded by a newer top-level connect
+   * (the attempt-id guard). Checked after the probe and before every effect so
+   * a stale attempt writes no state.
+   */
+  isStale: () => boolean
+
+  /** Open the WebSocket for `endpoint` — the success path. */
+  openSocket: (endpoint: ConnectEndpoint) => void
+
+  /**
+   * The host is restarting (supervisor standby). Write the `server_restarting`
+   * phase + restart metadata. Called before the retry/give-up decision.
+   */
+  onRestarting: (info: { restartEtaMs: number | null }) => void
+
+  /** A probe failure (not restarting). Surface the mapped error reason. */
+  onProbeFailed: (reason: string) => void
+
+  /**
+   * Retries are exhausted because the host is still restarting. Write the
+   * terminal `disconnected` phase + the "restart timed out" copy/UX.
+   */
+  onRestartGaveUp: () => void
+
+  /**
+   * Retries are exhausted because the host was unreachable. Write the terminal
+   * `disconnected` phase + the "could not reach server" copy/UX.
+   */
+  onProbeGaveUp: () => void
+
+  /**
+   * Recurse into the client's own `connect()` for the next retry. The client
+   * owns this so each retry re-runs its full per-connect store setup (the same
+   * recursion the hand-written flow used). `attempt` is the NEXT attempt index.
+   */
+  scheduleRetry: (nextAttempt: number, delayMs: number) => void
+
+  /** Timer surface; defaults to the global `setTimeout`/`clearTimeout`. */
+  scheduler?: ConnectFlowScheduler
+  /** Jitter fn; defaults to store-core's `withJitter` (0–50%). */
+  jitter?: (delayMs: number) => number
+}
+
+/**
+ * Run one connect attempt's pre-WebSocket orchestration: probe → branch →
+ * (open socket | schedule retry | give up). The probe failure/restart branches
+ * climb the same {@link CONNECT_RETRY_DELAYS} ladder by attempt index.
+ *
+ * This is the body that lived inline in each client's `connect()` between the
+ * store setup and `_connectWebSocket()`. The client wires its effects through
+ * the callbacks; the decision tree (which branch, when to retry, when to give
+ * up, what delay) lives here once.
+ *
+ * Returns the Promise of the probe chain so callers/tests can await it.
+ */
+export function runConnectAttempt(options: RunConnectAttemptOptions): Promise<void> {
+  const {
+    attempt,
+    maxRetries = CONNECT_MAX_RETRIES,
+    retryDelays = CONNECT_RETRY_DELAYS,
+    resolveEndpoint,
+    probe,
+    isStale,
+    openSocket,
+    onRestarting,
+    onProbeFailed,
+    onRestartGaveUp,
+    onProbeGaveUp,
+    scheduleRetry,
+    jitter = defaultJitter,
+  } = options
+
+  const endpoint = resolveEndpoint(attempt)
+  // Superseded before we even probed — the caller already moved on.
+  if (endpoint === null) return Promise.resolve()
+
+  function delayFor(rung: number): number {
+    return jitter(retryDelayForAttempt(rung, retryDelays))
+  }
+
+  return probe(endpoint).then(
+    (result) => {
+      if (isStale()) return
+
+      if (result.kind === 'ok') {
+        openSocket(endpoint)
+        return
+      }
+
+      if (result.kind === 'restarting') {
+        onRestarting({ restartEtaMs: result.restartEtaMs })
+        if (attempt < maxRetries) {
+          // Restart retry historically clamped with Math.min(attempt, len-1).
+          scheduleRetry(attempt + 1, delayFor(attempt))
+        } else {
+          onRestartGaveUp()
+        }
+        return
+      }
+
+      // result.kind === 'failed'
+      onProbeFailed(result.reason)
+      if (attempt < maxRetries) {
+        scheduleRetry(attempt + 1, delayFor(attempt))
+      } else {
+        onProbeGaveUp()
+      }
+    },
+    // The probe rejected outright (not resolved to a 'failed' ProbeResult). The
+    // clients map this through getHealthCheckErrorMessage inside `probe` and
+    // resolve to a 'failed' result, so this rejection path is a safety net only
+    // — treat it as a failed probe with a generic reason.
+    () => {
+      if (isStale()) return
+      onProbeFailed('Could not reach server')
+      if (attempt < maxRetries) {
+        scheduleRetry(attempt + 1, delayFor(attempt))
+      } else {
+        onProbeGaveUp()
+      }
+    },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// createReconnectScheduler — the per-socket close/error reconnect scheduler
+// ---------------------------------------------------------------------------
+
+export interface CreateReconnectSchedulerOptions {
+  /**
+   * Advance the shared backoff ladder, returning the PRE-increment rung index
+   * (matches `nextReconnectAttempt()`). The counter is module-level in each
+   * client and resets on `auth_ok`, so a flapping link escalates. (#5594)
+   */
+  nextRung: () => number
+  /**
+   * Reconnect now — recurse into the client's `connect()`. The client resolves
+   * the freshest token here (the dashboard re-reads the registry; the app uses
+   * the captured token). Guarded by the stale-attempt check before the call.
+   */
+  reconnect: () => void
+  /** True when this socket's attempt has been superseded — skip the reconnect. */
+  isStale: () => boolean
+  /** Backoff ladder (ms). Defaults to {@link CONNECT_RETRY_DELAYS}. */
+  retryDelays?: readonly number[]
+  /** Timer surface; defaults to the global `setTimeout`/`clearTimeout`. */
+  scheduler?: ConnectFlowScheduler
+  /** Jitter fn; defaults to store-core's `withJitter` (0–50%). */
+  jitter?: (delayMs: number) => number
+}
+
+/**
+ * A per-socket reconnect scheduler. Returned by
+ * {@link createReconnectScheduler} — create ONE per opened socket (the dedup
+ * flag is socket-scoped, so a new socket's failure mid-reconnect still arms its
+ * own timer; see #3624).
+ */
+export interface ReconnectScheduler {
+  /**
+   * Arm a reconnect if not already armed for this socket. First-arm-wins, so a
+   * paired `error → close` (or `close → error`) drop schedules exactly ONE
+   * retry. Advances the ladder by one rung and fires `reconnect()` after the
+   * (jittered) delay, unless the attempt went stale in the meantime.
+   *
+   * @returns `true` if this call armed the timer, `false` if it was a dedup
+   *   no-op (already armed). The client uses the return to gate its own
+   *   first-write-wins phase/error writes (the app's `if (!reconnectScheduled)`
+   *   branch).
+   */
+  schedule: () => boolean
+  /** Whether a reconnect is already armed for this socket. */
+  readonly scheduled: boolean
+}
+
+/**
+ * Build a per-socket reconnect scheduler. The caller invokes `schedule()` from
+ * `onclose`/`onerror` AFTER its own platform guards (the app guards in the
+ * callers; the dashboard historically guarded inside scheduleReconnect — both
+ * now guard before this call, see the PR write-up). The scheduler owns the
+ * single-arm dedup + the ladder advance + the jittered delay.
+ */
+export function createReconnectScheduler(
+  options: CreateReconnectSchedulerOptions,
+): ReconnectScheduler {
+  const {
+    nextRung,
+    reconnect,
+    isStale,
+    retryDelays = CONNECT_RETRY_DELAYS,
+    scheduler = DEFAULT_SCHEDULER,
+    jitter = defaultJitter,
+  } = options
+
+  let scheduled = false
+
+  function schedule(): boolean {
+    if (scheduled) return false
+    scheduled = true
+    const rung = nextRung()
+    const delayMs = jitter(retryDelayForAttempt(rung, retryDelays))
+    scheduler.setTimeout(() => {
+      if (isStale()) return
+      reconnect()
+    }, delayMs)
+    return true
+  }
+
+  return {
+    schedule,
+    get scheduled() {
+      return scheduled
+    },
+  }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -604,3 +604,25 @@ export type {
   DispatchMessageMap,
   DispatchMessageType,
 } from './dispatch-table'
+
+// epic #5556, sub-item 4: shared client connect-flow orchestration. Owns the
+// retry-ladder math, the probe → restart → connect decision tree, and the
+// per-socket reconnect dedup that the app and dashboard hand-copied into two
+// drifting `connect()` orchestrations. Each client supplies its store
+// writes / give-up UX / pairing wiring as callbacks. The `resolveEndpoint`
+// callback is the #5597/#5537 LAN/tunnel re-resolution seam (static today).
+export {
+  runConnectAttempt,
+  createReconnectScheduler,
+  retryDelayForAttempt,
+  CONNECT_MAX_RETRIES,
+  CONNECT_RETRY_DELAYS,
+} from './connect-flow'
+export type {
+  ProbeResult,
+  ConnectEndpoint,
+  ConnectFlowScheduler,
+  RunConnectAttemptOptions,
+  CreateReconnectSchedulerOptions,
+  ReconnectScheduler,
+} from './connect-flow'


### PR DESCRIPTION
## What

Sub-item 4 of epic #5556. Both clients hand-maintained parallel `connect()` orchestrations (`packages/app/src/store/connection.ts`, `packages/dashboard/src/store/connection.ts`) — same retry-ladder constants, same recursion, same probe → restart → connect decision tree, differing only in *effects*. ~120 lockstep lines that drifted in their guard placement.

This extracts the **algorithm** into `packages/store-core/src/connect-flow.ts` and migrates both clients onto it. Following the `createDeltaFlusher` (#5588) template: pure, dependency-free, injectable scheduler.

## Callback interface rationale

Two cooperating pieces mirror the two distinct orchestration phases:

- **`runConnectAttempt(opts)`** — the pre-WebSocket probe → branch tree for ONE attempt. Owns: which branch (ok/restarting/failed), when to retry vs give up, what delay. Calls back for every effect: `resolveEndpoint`, `probe`, `isStale`, `openSocket`, `onRestarting`, `onProbeFailed`, `onRestartGaveUp`, `onProbeGaveUp`, `scheduleRetry`. The client owns the recursion entry point (`scheduleRetry` re-enters its own `connect()`) so each retry re-runs its full per-connect store setup — exactly the recursion the hand-written flow used.
- **`createReconnectScheduler(opts)`** — the per-socket close/error reconnect scheduler. Owns the single-arm dedup (#3624) + the ladder advance (#5594) + jittered delay. Created once per opened socket (dedup flag is socket-scoped). `schedule()` returns whether it armed, so callers gate their first-write-wins phase/error writes.

Effects stay in callbacks so each client keeps its store writes / give-up UX / pairing wiring platform-local and **visible as such**.

## `#5597 / #5537` seam

`resolveEndpoint(attempt)` is a **per-attempt** callback, not a closure-captured constant. Both clients return the static `{ url, token }` captured at connect-start today (byte-identical behavior). The next PR plugs LAN/tunnel re-resolution into exactly this seam: a retry can re-probe the registry and switch endpoints without restructuring the flow.

## Inventory — app vs dashboard `connect()`

### Identical (now shared, deleted from both)
| Behavior |
|---|
| `MAX_RETRIES = 5`, `RETRY_DELAYS = [1000,2000,3000,5000,8000]` |
| probe → `!ok` throw → `restarting` detect → ok → open socket |
| retry on restart/failed with ladder-by-attempt; give up at MAX |
| per-socket `reconnectScheduled` dedup + `nextReconnectAttempt()` ladder + `withJitter` |
| stale-attempt (`myAttemptId !== connectionAttemptId`) guards |
| auth_ok resets the ladder counter (module-level, unchanged) |

### Deliberate platform differences (kept in callbacks, named here)
| Dimension | App | Dashboard |
|---|---|---|
| Phase store | separate `useConnectionLifecycleStore` | single store `set()` |
| Health URL | bare origin | `new URL('/', httpBase)` |
| Give-up UX | `Alert.alert` (silent-aware, Retry/Forget) | `console.warn` + `clearSavedConnection()` |
| `healthPrecheck` fast path (#5555) | yes (bypasses probe) | no |
| device id | async `getDeviceId()` (prewarm + await) | sync |
| pairing | `pendingPairingId` global | `_pairingId` threaded through retries |
| capabilities | `mobile` | `desktop` |
| reconnect token | static captured `token` | re-resolved from `serverRegistry` (#5281) |
| onclose cleanup | inactivity sweep, plan/stream clear | evaluator/summarize/trust rejects + cancelling/reindex/relay sets |

### Drift found + resolved
**Guard placement (the #5594 reviewer's structural note).** The dashboard guarded `userDisconnected` + stale-attempt *inside* `scheduleReconnect`; the app guarded in its `onclose`/`onerror` callers. **Resolution:** the shared `createReconnectScheduler` stays guard-free (owns only dedup+ladder+delay); both clients now run their platform guards *before* calling `schedule()`. The dashboard wins on keeping its guards (it has more of them, e.g. `userDisconnected`), but they move to the wrapper so the shared core matches the app's caller-side model. Behavior is pixel-identical per client — no guard semantics changed, only where they live.

## LOC deleted per client

Inline orchestration (health-check fetch chain + scheduleReconnect mechanics) replaced by callback wiring into the shared flow. The decision-tree logic (~120 lockstep lines across both) now lives once in store-core's `connect-flow.ts` (356 LOC incl. docs) + `connect-flow.test.ts` (417 LOC, ported from the app's connect + backoff suites).

## Tests

- **store-core:** new `connect-flow.test.ts` — 21 tests (ladder math, probe-branch tree, scheduler dedup/ladder/stale/jitter). Full suite 1357 pass, typecheck clean.
- **app:** `connection-connect`, `connection-reconnect-backoff`, `connection-audit-phase1` (ConnectionPhase) all pass **unmodified**. Full suite 1750 pass, typecheck clean.
- **dashboard:** `connection-reconnect-backoff` (now exercises the shared flow), `connection-pairing`, `tunnel-url-changed`, `auth-ok-handler` pass unmodified. Full suite 3550 pass, typecheck clean.
- **protocol:** 282 pass, typecheck clean.

No test edits required — the #5594 ladder tests, ConnectionPhase tests, and restart-countdown paths keep passing as-is.

Related to #5556