### PR TITLE
fix(ws): re-resolve reconnect endpoint per attempt + LAN→tunnel fast fallback

### DIFF
--- a/packages/app/src/__tests__/store/connection-reconnect-endpoint.test.ts
+++ b/packages/app/src/__tests__/store/connection-reconnect-endpoint.test.ts
@@ -1,0 +1,287 @@
+/**
+ * #5597 / #5537 — the connect/reconnect path re-resolves its endpoint per
+ * attempt instead of dialing the closure-captured URL forever.
+ *
+ *  - #5597: a tunnel URL that rotated mid-ladder (live `tunnel_url_changed` push,
+ *    or persisted from a prior session into `savedConnection.tunnelUrl`) is
+ *    picked up on the very next reconnect/retry — no wait for connectAuto/restart.
+ *  - #5537: a dead `ws://` LAN host's health-check retry budget is not burned in
+ *    full on the dead LAN URL: the first LAN_FALLBACK_THRESHOLD (2) attempts
+ *    retry LAN, then the ladder fast-falls-back to the tunnel.
+ *
+ * Reuses the fake-WebSocket / fake-timer harness from the reconnect-backoff
+ * suite. Math.random is pinned to 0 so each rung delay is exactly RETRY_DELAYS[N].
+ */
+import type { SavedConnection } from '@chroxy/store-core';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve('dev-id-123')),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { resetReconnectAttempt } from '../../store/message-handler';
+import { clearAllCallbacks } from '../../store/imperative-callbacks';
+
+const RETRY_DELAYS = [1000, 2000, 3000, 5000, 8000];
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) =>
+    jest.requireActual<typeof globalThis>('timers').setImmediate(resolve),
+  );
+}
+
+function mockResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  } as unknown as Response;
+}
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: ((event?: unknown) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onmessage: ((event: unknown) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+function installMockWebSocket(): { instances: FakeSocket[]; restore: () => void } {
+  const instances: FakeSocket[] = [];
+  const Original = global.WebSocket;
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 0;
+    onopen: (() => void) | null = null;
+    onclose: ((event?: unknown) => void) | null = null;
+    onerror: ((event?: unknown) => void) | null = null;
+    onmessage: ((event: unknown) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn();
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this as unknown as FakeSocket);
+    }
+  };
+  return { instances, restore: () => { global.WebSocket = Original; } };
+}
+
+const originalFetch = global.fetch;
+let randomSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  clearAllCallbacks();
+  __resetDeviceIdCacheForTests();
+  resetReconnectAttempt();
+  randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+  (SecureStore.getItemAsync as jest.Mock).mockReset();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('dev-id-123');
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+  useConnectionStore.setState({
+    serverErrors: [],
+    connectedClients: [],
+    sessionStates: {},
+    activeSessionId: null,
+    socket: null,
+    shutdownReason: null,
+    restartEtaMs: null,
+    restartingSince: null,
+  });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+    savedConnection: null,
+  });
+});
+
+afterEach(() => {
+  useConnectionStore.getState().disconnect();
+  randomSpy.mockRestore();
+  global.fetch = originalFetch;
+  jest.useRealTimers();
+});
+
+/** The URL the most recently created socket dialed. */
+function lastDialedUrl(ws: { instances: FakeSocket[] }): string {
+  return ws.instances[ws.instances.length - 1].url;
+}
+
+/** Convert a ws(s):// URL to its http(s):// health-probe origin (matches connect()). */
+function probeOriginOf(url: string): string {
+  return url.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+}
+
+// ---------------------------------------------------------------------------
+// #5597 — rotated tunnel URL picked up on the next reconnect (socket-close)
+// ---------------------------------------------------------------------------
+
+describe('#5597 — socket-close reconnect re-resolves a rotated tunnel URL', () => {
+  async function openConnectedSocket(url: string, saved: SavedConnection) {
+    global.fetch = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.getState().setSavedConnection(saved);
+    useConnectionStore.getState().connect(url, saved.token, { silent: true });
+    await flushPromises();
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+    return ws;
+  }
+
+  it('dials the rotated tunnelUrl on the next reconnect, not the dead captured URL', async () => {
+    const OLD = 'wss://old.trycloudflare.com';
+    const NEW = 'wss://new.trycloudflare.com';
+    const saved: SavedConnection = { url: OLD, token: 'tok', tunnelUrl: OLD };
+    const ws = await openConnectedSocket(OLD, saved);
+
+    // A live tunnel_url_changed push (simulated) repoints the saved record while
+    // this socket is still riding the now-dead old tunnel.
+    useConnectionLifecycleStore.getState().setSavedConnection({ ...saved, url: NEW, tunnelUrl: NEW });
+
+    // The socket drops; the reconnect must dial the NEW URL.
+    ws.instances[0].onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(RETRY_DELAYS[0]);
+    await flushPromises();
+
+    expect(ws.instances.length).toBe(2);
+    expect(lastDialedUrl(ws)).toBe(NEW);
+
+    ws.restore();
+  });
+
+  it('keeps dialing the same tunnel URL when nothing rotated (no-op case)', async () => {
+    const URL = 'wss://stable.trycloudflare.com';
+    const saved: SavedConnection = { url: URL, token: 'tok', tunnelUrl: URL };
+    const ws = await openConnectedSocket(URL, saved);
+
+    ws.instances[0].onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(RETRY_DELAYS[0]);
+    await flushPromises();
+
+    expect(lastDialedUrl(ws)).toBe(URL);
+
+    ws.restore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5537 — LAN→tunnel fast fallback on the inner health-check retry ladder
+// ---------------------------------------------------------------------------
+
+describe('#5537 — dead LAN host fast-falls-back to the tunnel mid health-check ladder', () => {
+  const LAN = 'ws://192.168.1.50:8080';
+  const TUNNEL = 'wss://abc.trycloudflare.com';
+
+  /**
+   * Fetch mock: the LAN origin is unreachable (rejects), the tunnel origin
+   * answers `{ status: 'ok' }`. So the health-check ladder fails on every LAN
+   * attempt and succeeds the moment it switches to the tunnel.
+   */
+  function installDeadLanFetch(): jest.Mock {
+    const lanOrigin = probeOriginOf(LAN);
+    const fetchMock = jest.fn((input: RequestInfo | URL) => {
+      const u = typeof input === 'string' ? input : input.toString();
+      if (u.startsWith(lanOrigin)) return Promise.reject(new Error('ECONNREFUSED'));
+      return Promise.resolve(mockResponse(200, { status: 'ok' }));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  }
+
+  it('retries LAN for two attempts, then opens a socket to the tunnel', async () => {
+    const saved: SavedConnection = {
+      url: LAN,
+      token: 'tok',
+      lanUrl: LAN,
+      lanVerified: true,
+      tunnelUrl: TUNNEL,
+    };
+    const fetchMock = installDeadLanFetch();
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.getState().setSavedConnection(saved);
+
+    // Initial connect against the (now dead) LAN URL.
+    useConnectionStore.getState().connect(LAN, 'tok', { silent: true });
+    await flushPromises();
+
+    // Attempt 0 probed LAN and failed → schedule retry at rung 0 (1000ms).
+    expect(ws.instances.length).toBe(0);
+    jest.advanceTimersByTime(RETRY_DELAYS[0]);
+    await flushPromises();
+    // Attempt 1 probed LAN again and failed → schedule retry at rung 1 (2000ms).
+    expect(ws.instances.length).toBe(0);
+    jest.advanceTimersByTime(RETRY_DELAYS[1]);
+    await flushPromises();
+    // Attempt 2 switched to the tunnel → probe ok → opened a socket to TUNNEL.
+    expect(ws.instances.length).toBe(1);
+    expect(lastDialedUrl(ws)).toBe(TUNNEL);
+
+    // The first two probes were the LAN origin; the third was the tunnel.
+    const probed = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(probed[0]).toContain('192.168.1.50');
+    expect(probed[1]).toContain('192.168.1.50');
+    expect(probed[2]).toContain('abc.trycloudflare.com');
+
+    ws.restore();
+  });
+
+  it('keeps retrying LAN (never reaches a socket) when the record has no tunnel', async () => {
+    const saved: SavedConnection = {
+      url: LAN,
+      token: 'tok',
+      lanUrl: LAN,
+      lanVerified: true,
+      // No tunnelUrl, and url is a ws:// LAN URL → deriveTunnelUrl returns null.
+    };
+    const fetchMock = installDeadLanFetch();
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.getState().setSavedConnection(saved);
+
+    useConnectionStore.getState().connect(LAN, 'tok', { silent: true });
+    await flushPromises();
+    // Walk the full ladder — every attempt stays on LAN and fails; no socket.
+    for (const delay of RETRY_DELAYS) {
+      jest.advanceTimersByTime(delay);
+      await flushPromises();
+    }
+    expect(ws.instances.length).toBe(0);
+    // Every probe targeted the LAN origin (no tunnel fallback existed).
+    for (const call of fetchMock.mock.calls) {
+      expect(String(call[0])).toContain('192.168.1.50');
+    }
+
+    ws.restore();
+  });
+
+  it('opens a socket immediately when the LAN host is actually reachable (no needless fallback)', async () => {
+    const saved: SavedConnection = {
+      url: LAN,
+      token: 'tok',
+      lanUrl: LAN,
+      lanVerified: true,
+      tunnelUrl: TUNNEL,
+    };
+    // LAN answers ok — the fallback must NOT trigger.
+    global.fetch = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.getState().setSavedConnection(saved);
+
+    useConnectionStore.getState().connect(LAN, 'tok', { silent: true });
+    await flushPromises();
+
+    expect(ws.instances.length).toBe(1);
+    expect(lastDialedUrl(ws)).toBe(LAN);
+
+    ws.restore();
+  });
+});

--- a/packages/app/src/__tests__/store/connection-reconnect-endpoint.test.ts
+++ b/packages/app/src/__tests__/store/connection-reconnect-endpoint.test.ts
@@ -172,6 +172,38 @@ describe('#5597 — socket-close reconnect re-resolves a rotated tunnel URL', ()
 
     ws.restore();
   });
+
+  // A manual connect to a DIFFERENT server (different token) must NOT be
+  // redirected back to the stale savedConnection's tunnel URL. savedConnection
+  // is only updated on auth_ok, so during the connect-to-server-B window it
+  // still holds server A's record — re-resolution is token-scoped to prevent
+  // the hijack.
+  it('does not redirect a manual connect to a different server (stale savedConnection ignored)', async () => {
+    const SERVER_A = 'wss://server-a.trycloudflare.com';
+    const SERVER_B = 'wss://server-b.trycloudflare.com';
+    // savedConnection still describes server A (token 'tok-a'); we dial server B
+    // with a different token before B's auth_ok lands.
+    useConnectionLifecycleStore.getState().setSavedConnection({
+      url: SERVER_A,
+      token: 'tok-a',
+      tunnelUrl: SERVER_A,
+    });
+    global.fetch = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    const ws = installMockWebSocket();
+
+    useConnectionStore.getState().connect(SERVER_B, 'tok-b', { silent: true });
+    await flushPromises();
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+
+    // The socket drops; the reconnect must dial SERVER_B, not server A's tunnel.
+    ws.instances[0].onclose?.({ code: 1006 });
+    jest.advanceTimersByTime(RETRY_DELAYS[0]);
+    await flushPromises();
+
+    expect(lastDialedUrl(ws)).toBe(SERVER_B);
+
+    ws.restore();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -214,11 +214,18 @@ export const selectShowSession = (s: ConnectionState): boolean =>
  * {@link resolveEndpointForAttempt} (#5537). Also unchanged when there's no
  * saved record, no tunnel, or the tunnel already matches `dialUrl` (the common
  * no-op case).
+ *
+ * Scoped to the dial's own credentials: `savedConnection` is only updated on
+ * `auth_ok`, so during a manual connect to a DIFFERENT server it still holds the
+ * previous server's record. Re-resolving against it would redirect the new dial
+ * to the old server's tunnel URL. We therefore only consult the saved record
+ * when its token matches `dialToken` (proof it describes this same connection);
+ * otherwise the captured `dialUrl` passes through untouched.
  */
-function resolveCurrentEndpointUrl(dialUrl: string): string {
+function resolveCurrentEndpointUrl(dialUrl: string, dialToken: string): string {
   if (isLanWsUrl(dialUrl)) return dialUrl;
   const saved = useConnectionLifecycleStore.getState().savedConnection;
-  if (!saved) return dialUrl;
+  if (!saved || saved.token !== dialToken) return dialUrl;
   const tunnelUrl = deriveTunnelUrl(saved);
   return tunnelUrl ?? dialUrl;
 }
@@ -239,11 +246,15 @@ function resolveCurrentEndpointUrl(dialUrl: string): string {
  *    was, or #5537 just switched to it), re-resolve the freshest `tunnelUrl` so
  *    a rotation that landed mid-ladder is dialed, not the dead captured URL.
  *
- * No-op (returns `dialUrl`) when there's no saved record.
+ * No-op (returns `dialUrl`) when there's no saved record, or when the saved
+ * record's token doesn't match `dialToken` — `savedConnection` only updates on
+ * `auth_ok`, so a manual connect to a DIFFERENT server still sees the previous
+ * server's record; gating on the token prevents redirecting the new dial to the
+ * old server's tunnel/LAN endpoints.
  */
-function resolveEndpointForAttempt(dialUrl: string, attempt: number): string {
+function resolveEndpointForAttempt(dialUrl: string, dialToken: string, attempt: number): string {
   const saved = useConnectionLifecycleStore.getState().savedConnection;
-  if (!saved) return dialUrl;
+  if (!saved || saved.token !== dialToken) return dialUrl;
   const tunnelUrl = deriveTunnelUrl(saved);
   const chosen = selectReconnectEndpoint({
     lastUrl: dialUrl,
@@ -921,7 +932,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // skipped entirely.
       resolveEndpoint: (attempt): ConnectEndpoint | null => {
         if (myAttemptId !== connectionAttemptId) return null;
-        return { url: resolveEndpointForAttempt(url, attempt), token };
+        return { url: resolveEndpointForAttempt(url, token, attempt), token };
       },
       isStale: () => myAttemptId !== connectionAttemptId,
       // The HTTP `/health` GET (bare origin — the server answers both `/` and
@@ -977,7 +988,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           // #5597/#5537 — re-resolve the URL for the NEXT attempt so a mid-ladder
           // tunnel rotation, or the LAN→tunnel fallback at the threshold, is
           // dialed instead of the dead captured URL.
-          get().connect(resolveEndpointForAttempt(url, nextAttempt), token, { silent, _retryCount: nextAttempt });
+          get().connect(resolveEndpointForAttempt(url, token, nextAttempt), token, { silent, _retryCount: nextAttempt });
         }, delayMs);
       },
       onRestartGaveUp: () => {
@@ -1048,7 +1059,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // dialed. The reconnect re-enters connect() with _retryCount=0, so the
       // inner health-check ladder's resolveEndpoint then owns the #5537 LAN→
       // tunnel fast-fallback (keyed on the per-attempt index).
-      reconnect: () => get().connect(resolveCurrentEndpointUrl(url), token),
+      reconnect: () => get().connect(resolveCurrentEndpointUrl(url, token), token),
       isStale: () => myAttemptId !== connectionAttemptId,
       retryDelays: RETRY_DELAYS,
     });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -87,7 +87,7 @@ import type {
   SessionState,
 } from './types';
 import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, formatQuestionAnswerSummary } from './utils';
-import { selectConnectEndpoint } from '../utils/endpoint-selector';
+import { selectConnectEndpoint, deriveTunnelUrl, isLanWsUrl } from '../utils/endpoint-selector';
 import {
   setStore,
   wsSend,
@@ -155,6 +155,8 @@ import {
   // as callbacks. `resolveEndpoint` is the #5597/#5537 LAN/tunnel seam (static).
   runConnectAttempt,
   createReconnectScheduler,
+  // #5537 — shared LAN→tunnel fast-fallback decision for the reconnect ladder.
+  selectReconnectEndpoint,
   type ProbeResult,
   type ConnectEndpoint,
 } from '@chroxy/store-core';
@@ -198,6 +200,61 @@ export { getWsCloseMessage, getHealthCheckErrorMessage } from '@chroxy/store-cor
 
 export const selectShowSession = (s: ConnectionState): boolean =>
   useConnectionLifecycleStore.getState().connectionPhase !== 'disconnected' || s.viewingCachedSession;
+
+/**
+ * #5597 — re-resolve the freshest tunnel URL for a dial that was started against
+ * `dialUrl`. The authoritative source is the SecureStore-backed saved
+ * connection's `tunnelUrl`, which `applyRotatedTunnelUrl` repoints on a live
+ * `tunnel_url_changed` push (or auth_bootstrap re-advertisement). When `dialUrl`
+ * is a `wss://` tunnel URL and the record has since rotated to a different
+ * tunnel, return the new one so a reconnect/retry stops hammering the dead URL.
+ *
+ * A `ws://` LAN `dialUrl` is returned unchanged — a rotation only concerns the
+ * tunnel endpoint, and the LAN→tunnel failover is handled by
+ * {@link resolveEndpointForAttempt} (#5537). Also unchanged when there's no
+ * saved record, no tunnel, or the tunnel already matches `dialUrl` (the common
+ * no-op case).
+ */
+function resolveCurrentEndpointUrl(dialUrl: string): string {
+  if (isLanWsUrl(dialUrl)) return dialUrl;
+  const saved = useConnectionLifecycleStore.getState().savedConnection;
+  if (!saved) return dialUrl;
+  const tunnelUrl = deriveTunnelUrl(saved);
+  return tunnelUrl ?? dialUrl;
+}
+
+/**
+ * #5597 + #5537 — pick the URL for connect attempt `attempt` (the inner
+ * health-check retry index, `_retryCount`), given this connect was started
+ * against `dialUrl`. Both re-resolutions read the authoritative saved record:
+ *
+ *  - #5537 LAN→tunnel fast fallback: when `dialUrl` is a `ws://` LAN URL and the
+ *    record has a tunnel, the first `LAN_FALLBACK_THRESHOLD` attempts stay on
+ *    LAN (so a momentary wifi blip recovers in place), then attempt
+ *    `LAN_FALLBACK_THRESHOLD`+ switches to the tunnel — instead of burning the
+ *    whole 5-retry health-check budget hammering the dead LAN host while the
+ *    daemon is still reachable over the tunnel. The decision is the shared,
+ *    tested `selectReconnectEndpoint`.
+ *  - #5597 tunnel rotation: once the URL is the tunnel (either `dialUrl` already
+ *    was, or #5537 just switched to it), re-resolve the freshest `tunnelUrl` so
+ *    a rotation that landed mid-ladder is dialed, not the dead captured URL.
+ *
+ * No-op (returns `dialUrl`) when there's no saved record.
+ */
+function resolveEndpointForAttempt(dialUrl: string, attempt: number): string {
+  const saved = useConnectionLifecycleStore.getState().savedConnection;
+  if (!saved) return dialUrl;
+  const tunnelUrl = deriveTunnelUrl(saved);
+  const chosen = selectReconnectEndpoint({
+    lastUrl: dialUrl,
+    attempt,
+    tunnelUrl,
+    lastUrlIsLan: isLanWsUrl(dialUrl),
+  });
+  // If #5537 fell back to (or stayed on) the tunnel, make sure it's the freshest
+  // rotated tunnel URL (#5597). A LAN URL we're still retrying passes through.
+  return isLanWsUrl(chosen) ? chosen : (tunnelUrl ?? chosen);
+}
 
 // Session-aware selectors — read from sessionStates[activeSessionId]
 const EMPTY_MESSAGES: ChatMessage[] = [];
@@ -852,11 +909,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       attempt: _retryCount,
       maxRetries: MAX_RETRIES,
       retryDelays: RETRY_DELAYS,
-      // #5597/#5537 seam — static endpoint today (the url/token captured at
-      // connect-start). Returns null when this attempt is already superseded so
-      // the probe is skipped entirely.
-      resolveEndpoint: (): ConnectEndpoint | null =>
-        myAttemptId !== connectionAttemptId ? null : { url, token },
+      // #5597/#5537 seam — re-resolve the endpoint per attempt instead of
+      // dialing the closure-captured URL forever:
+      //   • #5597: a tunnel rotation that landed mid-ladder (live
+      //     `tunnel_url_changed` push, or a URL persisted from a prior session
+      //     into `savedConnection.tunnelUrl`) is picked up on the next retry.
+      //   • #5537: a dead `ws://` LAN URL fast-falls-back to the tunnel after
+      //     LAN_FALLBACK_THRESHOLD health-check retries (keyed on `attempt`),
+      //     instead of burning the whole 5-retry budget on the unreachable host.
+      // Returns null when the attempt is already superseded so the probe is
+      // skipped entirely.
+      resolveEndpoint: (attempt): ConnectEndpoint | null => {
+        if (myAttemptId !== connectionAttemptId) return null;
+        return { url: resolveEndpointForAttempt(url, attempt), token };
+      },
       isStale: () => myAttemptId !== connectionAttemptId,
       // The HTTP `/health` GET (bare origin — the server answers both `/` and
       // `/health`) with the 5s abort, mapped to a ProbeResult. Probe failures
@@ -908,7 +974,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         console.log(`[ws] Retrying in ${delayMs}ms...`);
         setTimeout(() => {
           if (myAttemptId !== connectionAttemptId) return;
-          get().connect(url, token, { silent, _retryCount: nextAttempt });
+          // #5597/#5537 — re-resolve the URL for the NEXT attempt so a mid-ladder
+          // tunnel rotation, or the LAN→tunnel fallback at the threshold, is
+          // dialed instead of the dead captured URL.
+          get().connect(resolveEndpointForAttempt(url, nextAttempt), token, { silent, _retryCount: nextAttempt });
         }, delayMs);
       },
       onRestartGaveUp: () => {
@@ -973,7 +1042,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // writes.
     const reconnectScheduler = createReconnectScheduler({
       nextRung: nextReconnectAttempt,
-      reconnect: () => get().connect(url, token),
+      // #5597 — the socket-close reconnect no longer re-dials the closure-
+      // captured `url` forever: re-resolve the freshest tunnel URL so a rotation
+      // (live `tunnel_url_changed` push / persisted from a prior session) is
+      // dialed. The reconnect re-enters connect() with _retryCount=0, so the
+      // inner health-check ladder's resolveEndpoint then owns the #5537 LAN→
+      // tunnel fast-fallback (keyed on the per-attempt index).
+      reconnect: () => get().connect(resolveCurrentEndpointUrl(url), token),
       isStale: () => myAttemptId !== connectionAttemptId,
       retryDelays: RETRY_DELAYS,
     });

--- a/packages/dashboard/src/store/connection-reconnect-endpoint.test.ts
+++ b/packages/dashboard/src/store/connection-reconnect-endpoint.test.ts
@@ -1,0 +1,159 @@
+/**
+ * #5597 (dashboard) — the connect/reconnect path re-resolves its endpoint from
+ * the ACTIVE registry entry per attempt, instead of dialing the closure-captured
+ * URL forever.
+ *
+ * The dashboard already re-read the registry TOKEN per reconnect (#5281); this
+ * mirrors that for the URL. A registry entry whose `wsUrl` was repointed
+ * mid-ladder (another tab edited it, or a rotated endpoint was written back) is
+ * dialed on the next reconnect/health-check retry, not the dead captured URL.
+ *
+ * Mirrors the WebSocket/fetch fake-timer harness from
+ * connection-reconnect-backoff.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v },
+  removeItem: (k: string) => { delete store[k] },
+  clear: () => { for (const k of Object.keys(store)) delete store[k] },
+  get length() { return Object.keys(store).length },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+vi.mock('../utils/auth', () => ({ getAuthToken: () => null }))
+
+const RETRY_DELAYS: [number, number, number, number, number] = [1000, 2000, 3000, 5000, 8000]
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 1
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((e: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this) }
+  send(d: string) { this.sent.push(d) }
+  close() { this.readyState = 3 }
+}
+;(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket
+;(globalThis as unknown as { fetch: unknown }).fetch = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ status: 'ok' }),
+}))
+
+const { useConnectionStore } = await import('./connection')
+const mh = await import('./message-handler')
+const { resetReconnectAttempt } = mh
+
+const lastUrl = () =>
+  MockWebSocket.instances[MockWebSocket.instances.length - 1]?.url
+
+/** Connect via a registry server and walk to "connected". Returns the socket. */
+async function openConnectedServer(serverId: string, wsUrl: string, token: string) {
+  const before = MockWebSocket.instances.length
+  useConnectionStore.setState({
+    serverRegistry: [{ id: serverId, name: 's', wsUrl, token, lastConnectedAt: 0 }],
+    activeServerId: serverId,
+  })
+  useConnectionStore.getState().connect(wsUrl, token)
+  await vi.advanceTimersByTimeAsync(0)
+  const ws = MockWebSocket.instances[before]!
+  ws.readyState = 1
+  ws.onopen?.()
+  await vi.advanceTimersByTimeAsync(0)
+  useConnectionStore.setState({ connectionPhase: 'connected', userDisconnected: false })
+  return ws
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  MockWebSocket.instances = []
+  resetReconnectAttempt()
+  vi.spyOn(Math, 'random').mockReturnValue(0)
+  for (const k of Object.keys(store)) delete store[k]
+  useConnectionStore.setState({
+    serverRegistry: [],
+    activeServerId: null,
+    connectionPhase: 'disconnected',
+    wsUrl: null,
+    userDisconnected: false,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('#5597 — socket-close reconnect re-reads the active registry wsUrl', () => {
+  it('dials the repointed wsUrl on the next reconnect, not the captured URL', async () => {
+    const OLD = 'wss://old.example.com/ws'
+    const NEW = 'wss://new.example.com/ws'
+    const ws = await openConnectedServer('srv1', OLD, 'tok')
+
+    // The active registry entry is repointed to a new endpoint mid-session.
+    useConnectionStore.setState({
+      serverRegistry: [{ id: 'srv1', name: 's', wsUrl: NEW, token: 'tok', lastConnectedAt: 0 }],
+    })
+
+    ws.onclose?.({ code: 1006 })
+    const before = MockWebSocket.instances.length
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[0])
+    expect(MockWebSocket.instances.length).toBe(before + 1)
+    expect(lastUrl()).toBe(NEW)
+  })
+
+  it('re-reads the registry token alongside the URL on reconnect', async () => {
+    const URL = 'wss://srv.example.com/ws'
+    const ws = await openConnectedServer('srv1', URL, 'old-token')
+
+    // auth_ok-style token rotation written back to the registry.
+    useConnectionStore.setState({
+      serverRegistry: [{ id: 'srv1', name: 's', wsUrl: URL, token: 'new-token', lastConnectedAt: 0 }],
+    })
+
+    ws.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[0])
+    const next = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    next.readyState = 1
+    next.onopen?.()
+    await vi.advanceTimersByTimeAsync(0)
+    // The auth frame carries the freshest registry token, not the captured one.
+    const authFrame = next.sent.map((s) => JSON.parse(s)).find((m) => m.type === 'auth')
+    expect(authFrame?.token).toBe('new-token')
+  })
+
+  it('keeps dialing the same URL when nothing was repointed (no-op)', async () => {
+    const URL = 'wss://stable.example.com/ws'
+    const ws = await openConnectedServer('srv1', URL, 'tok')
+
+    ws.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[0])
+    expect(lastUrl()).toBe(URL)
+  })
+
+  it('falls back to the captured URL for the local (registry-less) target', async () => {
+    // No registry entry — activeServerId null (local same-origin connect).
+    const URL = 'wss://localhost/ws'
+    useConnectionStore.setState({ serverRegistry: [], activeServerId: null })
+    const before = MockWebSocket.instances.length
+    useConnectionStore.getState().connect(URL, 'tok')
+    await vi.advanceTimersByTimeAsync(0)
+    const ws = MockWebSocket.instances[before]!
+    ws.readyState = 1
+    ws.onopen?.()
+    await vi.advanceTimersByTimeAsync(0)
+    useConnectionStore.setState({ connectionPhase: 'connected' })
+
+    ws.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[0])
+    expect(lastUrl()).toBe(URL)
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1282,6 +1282,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       console.log(`[ws] Connection attempt ${_retryCount + 1}/${MAX_RETRIES + 1}...`);
     }
 
+    // #5597 — re-resolve the live endpoint (URL + token) for the active registry
+    // server. Falls back to the closure-captured `url`/`token` for the local
+    // same-origin target (no registry entry) or a stale/desynced active id, so
+    // a manual local connect or a mid-edit registry never loses its endpoint.
+    const resolveActiveEndpoint = (
+      fallbackUrl: string,
+      fallbackToken: string,
+    ): ConnectEndpoint => {
+      const sid = get().activeServerId;
+      if (!sid) return { url: fallbackUrl, token: fallbackToken };
+      const entry = get().serverRegistry.find((s) => s.id === sid);
+      if (!entry) return { url: fallbackUrl, token: fallbackToken };
+      return { url: entry.wsUrl, token: entry.token || fallbackToken };
+    };
+
     // #5556 sub-item 4 — the HTTP health check / restart-detect / retry-or-
     // give-up decision tree now lives in the shared `runConnectAttempt`. The
     // dashboard supplies the EFFECTS as callbacks (single-store `set()` writes,
@@ -1293,10 +1308,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       attempt: _retryCount,
       maxRetries: MAX_RETRIES,
       retryDelays: RETRY_DELAYS,
-      // #5597/#5537 seam — static endpoint today (the url/token captured at
-      // connect-start). Returns null when superseded so the probe is skipped.
+      // #5597 seam — re-resolve the endpoint per attempt instead of dialing the
+      // closure-captured URL/token forever. The dashboard already re-read the
+      // registry TOKEN per reconnect (#5281); this mirrors that for the URL, so
+      // a registry entry whose `wsUrl` was repointed mid-ladder (e.g. another
+      // tab edited it, or a rotated endpoint was written back) is dialed on the
+      // next health-check retry instead of the dead captured URL. Returns null
+      // when superseded so the probe is skipped.
       resolveEndpoint: (): ConnectEndpoint | null =>
-        myAttemptId !== connectionAttemptId ? null : { url, token },
+        myAttemptId !== connectionAttemptId ? null : resolveActiveEndpoint(url, token),
       isStale: () => myAttemptId !== connectionAttemptId,
       // The HTTP `/health` GET — root path (/) not /ws (GET /ws returns 404) —
       // with the 5s abort, mapped to a ProbeResult. #4771: the shared
@@ -1349,7 +1369,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         console.log(`[ws] Retrying in ${delayMs}ms...`);
         setTimeout(() => {
           if (myAttemptId !== connectionAttemptId) return;
-          get().connect(url, token, { silent, _retryCount: nextAttempt, ...(pairingId ? { _pairingId: pairingId } : {}) });
+          // #5597 — re-resolve the registry endpoint so a repointed `wsUrl`
+          // (or token) is dialed on the next attempt, not the dead captured one.
+          const next = resolveActiveEndpoint(url, token);
+          get().connect(next.url, next.token, { silent, _retryCount: nextAttempt, ...(pairingId ? { _pairingId: pairingId } : {}) });
         }, delayMs);
       },
       onRestartGaveUp: () => {
@@ -1400,12 +1423,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // stale-attempt guard covers the timer-fire boundary.
     const reconnectScheduler = createReconnectScheduler({
       nextRung: nextReconnectAttempt,
+      // #5597 — re-resolve the registry endpoint (URL + token) on each socket-
+      // close reconnect. Previously only the token was re-read (#5281); the URL
+      // was the closure-captured one, so a registry entry whose `wsUrl` was
+      // repointed kept re-dialing the dead URL up the whole ladder. Now both
+      // come from the live active registry entry.
       reconnect: () => {
-        const sid = get().activeServerId;
-        const reconnectToken = sid
-          ? (get().serverRegistry.find((s) => s.id === sid)?.token ?? token)
-          : token;
-        get().connect(url, reconnectToken);
+        const next = resolveActiveEndpoint(url, token);
+        get().connect(next.url, next.token);
       },
       isStale: () => myAttemptId !== connectionAttemptId,
       retryDelays: RETRY_DELAYS,

--- a/packages/store-core/src/connect-flow.test.ts
+++ b/packages/store-core/src/connect-flow.test.ts
@@ -18,8 +18,10 @@ import {
   runConnectAttempt,
   createReconnectScheduler,
   retryDelayForAttempt,
+  selectReconnectEndpoint,
   CONNECT_MAX_RETRIES,
   CONNECT_RETRY_DELAYS,
+  LAN_FALLBACK_THRESHOLD,
   type ConnectFlowScheduler,
   type ProbeResult,
   type ConnectEndpoint,
@@ -413,5 +415,64 @@ describe('createReconnectScheduler', () => {
     })
     s.schedule()
     expect(fake.lastDelay()).toBe(RETRY_DELAYS[0] + 250)
+  })
+
+})
+
+// ---------------------------------------------------------------------------
+// selectReconnectEndpoint — LAN→tunnel fast fallback (#5537)
+// ---------------------------------------------------------------------------
+
+describe('selectReconnectEndpoint (#5537 LAN→tunnel fallback)', () => {
+  const LAN = 'ws://192.168.1.50:8080'
+  const TUNNEL = 'wss://abc.trycloudflare.com'
+
+  it('stays on the LAN URL for the first threshold attempts', () => {
+    for (const attempt of [0, 1]) {
+      expect(
+        selectReconnectEndpoint({ lastUrl: LAN, attempt, tunnelUrl: TUNNEL, lastUrlIsLan: true }),
+      ).toBe(LAN)
+    }
+  })
+
+  it('switches to the tunnel at and beyond the threshold', () => {
+    for (const attempt of [2, 3, 5, 99]) {
+      expect(
+        selectReconnectEndpoint({ lastUrl: LAN, attempt, tunnelUrl: TUNNEL, lastUrlIsLan: true }),
+      ).toBe(TUNNEL)
+    }
+  })
+
+  it('honors a custom threshold', () => {
+    expect(
+      selectReconnectEndpoint({ lastUrl: LAN, attempt: 0, tunnelUrl: TUNNEL, lastUrlIsLan: true, threshold: 1 }),
+    ).toBe(LAN)
+    expect(
+      selectReconnectEndpoint({ lastUrl: LAN, attempt: 1, tunnelUrl: TUNNEL, lastUrlIsLan: true, threshold: 1 }),
+    ).toBe(TUNNEL)
+  })
+
+  it('keeps retrying the LAN URL when no tunnel fallback exists', () => {
+    for (const attempt of [0, 1, 2, 5]) {
+      expect(
+        selectReconnectEndpoint({ lastUrl: LAN, attempt, tunnelUrl: null, lastUrlIsLan: true }),
+      ).toBe(LAN)
+    }
+  })
+
+  it('never touches a non-LAN (tunnel) drop — out of scope (#5537)', () => {
+    for (const attempt of [0, 2, 5]) {
+      expect(
+        selectReconnectEndpoint({ lastUrl: TUNNEL, attempt, tunnelUrl: TUNNEL, lastUrlIsLan: false }),
+      ).toBe(TUNNEL)
+    }
+  })
+
+  it('LAN_FALLBACK_THRESHOLD is the documented default (2)', () => {
+    expect(LAN_FALLBACK_THRESHOLD).toBe(2)
+    // The default (no `threshold`) matches passing the constant explicitly.
+    const args = { lastUrl: LAN, tunnelUrl: TUNNEL, lastUrlIsLan: true } as const
+    expect(selectReconnectEndpoint({ ...args, attempt: 1 })).toBe(LAN)
+    expect(selectReconnectEndpoint({ ...args, attempt: LAN_FALLBACK_THRESHOLD })).toBe(TUNNEL)
   })
 })

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -38,10 +38,14 @@
  * ## #5597 / #5537 seam — `resolveEndpoint(attempt)`
  *
  * Endpoint selection is a PER-ATTEMPT callback, not a closure-captured constant.
- * Today both clients return the same static `{ url, token }` they captured at
- * connect-start (current behavior, byte-identical). The next PR (#5597/#5537)
- * plugs LAN/tunnel re-resolution into exactly this seam: a retry can re-probe
- * the registry and switch endpoints without restructuring the flow.
+ * Each client's `resolveEndpoint(attempt)` re-reads the CURRENT endpoint from
+ * its authoritative store every attempt (#5597): the app re-derives the tunnel
+ * URL from the saved connection (so a rotated `tunnel_url_changed` push / a URL
+ * persisted from a prior session is picked up on the next retry); the dashboard
+ * re-reads the active registry entry's `wsUrl` + token. The app additionally
+ * threads `attempt` into {@link selectReconnectEndpoint} for the #5537 LAN→tunnel
+ * fast fallback (a dead `ws://` LAN host fails over to the tunnel after
+ * {@link LAN_FALLBACK_THRESHOLD} attempts instead of burning the whole budget).
  */
 
 /** Bounded initial-connect retry budget — initial attempt + this many retries. */
@@ -106,13 +110,61 @@ export type ProbeResult =
 
 /**
  * The endpoint to connect to for a given attempt. Returned by
- * `resolveEndpoint(attempt)` — the #5597/#5537 seam. Today both clients return
- * the static `{ url, token }` captured at connect-start; a future PR can
- * re-resolve LAN/tunnel here per attempt.
+ * `resolveEndpoint(attempt)` — the #5597/#5537 seam. Each client re-resolves the
+ * live endpoint here per attempt (rotated tunnel URL / LAN→tunnel fallback)
+ * rather than returning a closure-captured constant.
  */
 export interface ConnectEndpoint {
   url: string
   token: string
+}
+
+/** How many attempts stay pinned to a dead LAN URL before the #5537 fallback
+ * switches to the tunnel. Attempts `0..(LAN_FALLBACK_THRESHOLD-1)` retry LAN;
+ * attempt `LAN_FALLBACK_THRESHOLD` (and beyond) switch to the tunnel. Two LAN
+ * retries cover a brief wifi blip (the link came back) without burning the rest
+ * of the health-check budget hammering a dead LAN URL when it didn't. */
+export const LAN_FALLBACK_THRESHOLD = 2
+
+export interface SelectReconnectEndpointInput {
+  /** The URL this connect/reconnect was dialing. */
+  lastUrl: string
+  /** Zero-based attempt index — the app threads the inner health-check ladder's
+   * `_retryCount` here (the rung that hammers the dead LAN URL). */
+  attempt: number
+  /** The tunnel (TLS) fallback for this connection, or null if none exists. */
+  tunnelUrl: string | null
+  /** True when `lastUrl` is a plaintext `ws://` LAN socket. Injected by the
+   * caller (each client owns its `isLanWsUrl` predicate). */
+  lastUrlIsLan: boolean
+  /** Override the fallback threshold (defaults to {@link LAN_FALLBACK_THRESHOLD}). */
+  threshold?: number
+}
+
+/**
+ * #5537 — pick the URL to dial for a given attempt, with LAN→tunnel fast
+ * fallback.
+ *
+ * When the connect was on a `ws://` LAN URL and a tunnel fallback exists, the
+ * first `threshold` attempts stay on the LAN URL (so a momentary wifi blip
+ * recovers in place), then every later attempt switches to the tunnel — instead
+ * of burning the whole health-check retry budget hammering a dead LAN URL while
+ * the daemon is still reachable over the tunnel.
+ *
+ * Pure: no store reads, no network. The caller resolves `lastUrl` / `tunnelUrl`
+ * / `lastUrlIsLan` from its own authoritative state and supplies the attempt
+ * index from the ladder, so this stays unit-testable and shared. Returns
+ * `lastUrl` unchanged for every non-LAN case (tunnel drops, LAN-only records
+ * with no tunnel) — the reverse direction (tunnel→LAN) is out of scope (#5537).
+ */
+export function selectReconnectEndpoint(input: SelectReconnectEndpointInput): string {
+  const { lastUrl, attempt, tunnelUrl, lastUrlIsLan } = input
+  const threshold = input.threshold ?? LAN_FALLBACK_THRESHOLD
+  // Only LAN drops with a real tunnel fallback are eligible. A tunnel drop, or a
+  // LAN-only record (no tunnel), keeps retrying the same URL.
+  if (!lastUrlIsLan || !tunnelUrl) return lastUrl
+  // Stay on LAN for the first `threshold` attempts; switch to the tunnel after.
+  return attempt >= threshold ? tunnelUrl : lastUrl
 }
 
 export interface RunConnectAttemptOptions {
@@ -125,9 +177,10 @@ export interface RunConnectAttemptOptions {
 
   /**
    * #5597/#5537 seam — resolve the endpoint (url + token) for THIS attempt.
-   * Read once at the top of the attempt. Today static; a future PR re-resolves
-   * LAN/tunnel here per retry. Return `null` to abort the attempt silently (the
-   * caller bumped the attempt id out from under us — a superseded connect).
+   * Read once at the top of the attempt; clients re-resolve the live endpoint
+   * here (rotated tunnel URL / LAN→tunnel fallback) per retry. Return `null` to
+   * abort the attempt silently (the caller bumped the attempt id out from under
+   * us — a superseded connect).
    */
   resolveEndpoint: (attempt: number) => ConnectEndpoint | null
 
@@ -279,8 +332,10 @@ export interface CreateReconnectSchedulerOptions {
   nextRung: () => number
   /**
    * Reconnect now — recurse into the client's `connect()`. The client resolves
-   * the freshest token here (the dashboard re-reads the registry; the app uses
-   * the captured token). Guarded by the stale-attempt check before the call.
+   * the freshest endpoint here (#5597): the dashboard re-reads the registry
+   * entry's `wsUrl` + token; the app re-derives the URL from the saved
+   * connection (and the inner health-check ladder then owns the #5537 LAN→tunnel
+   * fallback). Guarded by the stale-attempt check before the call.
    */
   reconnect: () => void
   /** True when this socket's attempt has been superseded — skip the reconnect. */

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -610,13 +610,16 @@ export type {
 // per-socket reconnect dedup that the app and dashboard hand-copied into two
 // drifting `connect()` orchestrations. Each client supplies its store
 // writes / give-up UX / pairing wiring as callbacks. The `resolveEndpoint`
-// callback is the #5597/#5537 LAN/tunnel re-resolution seam (static today).
+// callback is the #5597/#5537 LAN/tunnel re-resolution seam, and
+// `selectReconnectEndpoint` is the #5537 LAN→tunnel fast-fallback decision.
 export {
   runConnectAttempt,
   createReconnectScheduler,
   retryDelayForAttempt,
+  selectReconnectEndpoint,
   CONNECT_MAX_RETRIES,
   CONNECT_RETRY_DELAYS,
+  LAN_FALLBACK_THRESHOLD,
 } from './connect-flow'
 export type {
   ProbeResult,
@@ -625,4 +628,5 @@ export type {
   RunConnectAttemptOptions,
   CreateReconnectSchedulerOptions,
   ReconnectScheduler,
+  SelectReconnectEndpointInput,
 } from './connect-flow'


### PR DESCRIPTION
## Summary

Both clients' socket-close reconnect ladder re-dialed the **closure-captured** URL, so the inner reconnect path ignored a fresher endpoint until something triggered `connectAuto`/restart. Two issues fall out of that, fixed here using the `resolveEndpoint(attempt)` seam built for exactly this in PR #5598:

### #5597 — per-attempt URL re-resolution
A tunnel URL that rotated mid-ladder (a live `tunnel_url_changed` push whose socket rode the now-dead tunnel, or a URL persisted from a prior session) was hammered up the whole ladder. Now `resolveEndpoint(attempt)` re-reads the **current** endpoint from each client's authoritative store on every attempt:

- **app** — re-derives the tunnel URL from the saved connection (`deriveTunnelUrl(savedConnection)`, the same source `applyRotatedTunnelUrl` repoints on the push). A rotated `tunnelUrl` is picked up on the very next retry.
- **dashboard** — re-reads the active registry entry's `wsUrl` (it already re-resolved the **token** per attempt for #5281; this mirrors that for the URL). A repointed `wsUrl` is dialed on the next attempt.

### #5537 — LAN→tunnel fast fallback (app)
A mid-session `ws://` LAN drop burned the full 5-retry health-check budget on the dead LAN URL before failing over. Now the app's `resolveEndpoint` threads the attempt index into the new shared `selectReconnectEndpoint()`: the first **`LAN_FALLBACK_THRESHOLD` (2)** attempts retry LAN (so a brief wifi blip recovers in place), then attempt 2+ switches to the tunnel if the saved record has one. On tunnel success the existing connect flow takes over.

**Attempt-threshold choice (2):** two LAN retries cover a momentary wifi blip / AP roam (the link came back within ~1–3 s on the ladder) without making the user wait out all five rungs when it didn't. Tunable via the `threshold` override on `selectReconnectEndpoint`.

## Design

- **All shareable logic in store-core.** `selectReconnectEndpoint()` is a pure, dependency-free, fully-tested decision (no store reads, no network); each client injects `lastUrl` / `tunnelUrl` / `lastUrlIsLan` from its own state and supplies the attempt index. Platform URL-derivation (`deriveTunnelUrl`/`isLanWsUrl` in the app; the registry lookup in the dashboard) stays in the callbacks.
- **No regressions:** the #5594 ladder semantics, stale-attempt guards (`isStale`/`connectionAttemptId`), pairing-id threading, and the #5596 tunnel-url persistence are all untouched — the seam only changes *which URL* a given attempt dials, not *when* or *whether* it retries. The reverse direction (tunnel→LAN) is deliberately out of scope.

## Dashboard symmetry for #5537
The dashboard's `ServerEntry` carries a **single** `wsUrl` — there's no dual LAN/tunnel candidate per registry entry, so there's no second endpoint to fast-fall-back to and the LAN→tunnel fallback has no dashboard equivalent. The applicable dashboard fix is the #5597 per-attempt `wsUrl` re-read, which is implemented and tested here. If a future change gives registry entries a dual-endpoint shape (LAN-client epic #5281), the shared `selectReconnectEndpoint` is ready to wire in symmetrically.

## Tests
- **store-core** (`connect-flow.test.ts`): `selectReconnectEndpoint` — threshold progression (LAN for attempts 0–1, tunnel 2+), custom threshold, no-tunnel-saved (stays LAN), non-LAN/tunnel drop untouched, default-constant equality.
- **app** (`connection-reconnect-endpoint.test.ts`): rotated `tunnelUrl` dialed on the next socket-close reconnect; no-op when nothing rotated; dead-LAN health-check ladder retries LAN twice then opens a socket to the tunnel; no-tunnel record never leaves LAN; reachable LAN connects immediately (no needless fallback).
- **dashboard** (`connection-reconnect-endpoint.test.ts`): repointed registry `wsUrl` dialed on reconnect; registry token re-read alongside the URL; no-op when unchanged; local registry-less target falls back to the captured URL.
- Full suites + typechecks green: store-core (1363), app (1755), dashboard (3554).

Closes #5597
Closes #5537