### PR TITLE
security(server): scope /qr, /pairing-code (+ /qr/session, /connect) to the primary token class

### DIFF
--- a/docs/security/bearer-token-authority.md
+++ b/docs/security/bearer-token-authority.md
@@ -82,6 +82,24 @@ Two host-level mutations are gated against bound tokens even though they arrive 
 
 Both gates branch on `client.boundSessionId` and reject via `sendError` (a generic `error` message) — the canonical pattern for "this operation requires host-level authority" on the WS path. New credential-touching or config-mutating handlers should follow it (see §9).
 
+### HTTP endpoints a bound token must NOT reach (`_validatePrimaryBearerAuth`, #5533)
+
+The WS path distinguishes a bound token via `client.boundSessionId`. HTTP requests are stateless, so the equivalent gate is **`_validatePrimaryBearerAuth(req, res)`** ([`ws-server.js`](../../packages/server/src/ws-server.js)): it accepts a token only if it validates **and** is NOT a `PairingManager`-issued session token, rejecting bound tokens with `403 { "error": "primary_token_required" }`. This is the HTTP analog of the WS host-authority gate — `403` (not `401`) because the token IS valid, just an insufficient class.
+
+The following HTTP routes ([`http-routes.js`](../../packages/server/src/http-routes.js)) are gated on the primary token class. Each one either **mints/exposes live pairing material** (a bound device could otherwise transitively onboard further peers — "pairing-bound tokens can transitively mint peers") or **discloses the primary token itself**:
+
+| Route | Why primary-only |
+|---|---|
+| `GET /qr` | Returns the linking-mode QR encoding a live pairing URL; scanning it onboards a new peer. |
+| `GET /qr/session/:sessionId` | MINTS a fresh **bound** pairing id (`generateBoundPairing`) — the share-a-session QR. |
+| `GET /pairing-code` | Returns the current typeable linking code (#5512) and extends its grace window. |
+| `GET /connect` | Returns `connection.json`, which carries the **raw primary `apiToken`** and a `connectionUrl` embedding it whenever auth is required. A bound token reaching this escalates straight to the primary token. The body's redaction branch only fires when auth is *disabled*, so it is NOT the boundary. |
+| `POST /pair-discord` | Mints a fresh approval-gated pairing id and posts its `chroxy://` link to Discord (#5513) — gated from day one. |
+
+All five are exercised only by the daemon's **own dashboard** (`getAuthToken()` → the host's primary token via `?token=`/cookie) or the local **CLI** (`chroxy pair-code` → `connection.json` apiToken). The desktop LAN client's "Have a code?" flow (#5512) does NOT fetch these over HTTP — it takes a code typed off the host's screen and drives the WebSocket `pair` handshake directly, so no legitimate caller relies on a pairing-bound token reaching these endpoints.
+
+The remaining bearer-gated HTTP routes (`/version`, `/metrics`, `/diagnostics`, `/api/snapshots*`, `/api/pool/stats`) are read-only operational telemetry that exposes no pairing or credential material, so they stay on `_validateBearerAuth` (any valid token).
+
 ## 5. Per-Session Hook Secrets
 
 Each `CliSession` mints a 32-byte hex secret in its constructor ([`cli-session.js`](../../packages/server/src/cli-session.js) ~line 193) and exports it to the spawned `claude` CLI subprocess as `CHROXY_HOOK_SECRET`. The CLI uses it on outbound `POST /permission` callbacks.
@@ -131,6 +149,7 @@ Each step here tightened a real bug. Read the PRs in order if extending any of t
 - **#4798** — unified `SESSION_TOKEN_MISMATCH` payload across WS and HTTP error surfaces
 - **#4820** — P0 fix for cross-session `permission_response` hijack on the WS path; the review of that PR is what motivated this doc (issue #4830)
 - **#5155** — gated provider-credential WRITES (set/delete/clear, both the #3855 generalized and #4052 BYOK paths) behind host-level authority; bound tokens can read masked status but not overwrite or clear keys
+- **#5533** — scoped the pairing-material / token-disclosing HTTP routes (`/qr`, `/qr/session/:id`, `/pairing-code`, `/connect`; `/pair-discord` was primary-only from day one) to the primary token class via `_validatePrimaryBearerAuth`, closing the transitive peer-minting path (a once-paired device could read the live QR/code) and the `/connect` primary-token disclosure
 
 ## 9. Adding a New Endpoint or Message Type — Checklist
 
@@ -138,7 +157,7 @@ Before merging any PR that adds a new HTTP route or WebSocket message handler th
 
 1. **Decide which token classes you accept.** Most HTTP endpoints accept the primary token only. `/permission` accepts hook secrets. `/api/events` accepts the daemon-level ingest secret only (never the primary token). WS handlers accept primary + pairing-bound.
 2. **If the operation is session-scoped**, branch on `client.boundSessionId` (WS) or call the equivalent of `pairingManager.getSessionIdForToken(token)` (HTTP) and reject mismatches with 403 + `buildSessionTokenMismatchPayload()`.
-3. **If the operation is global** (e.g. listing all sessions, changing config), explicitly reject bound tokens — do not let them silently see everything.
+3. **If the operation is global** (e.g. listing all sessions, changing config) or **mints/exposes pairing material or the primary token**, explicitly reject bound tokens — do not let them silently see everything. On HTTP, use **`_validatePrimaryBearerAuth(req, res)`** (403 + `primary_token_required`); see §4's HTTP table. `_validateBearerAuth` accepts ANY valid token, including pairing-bound ones, so it is only for read-only operational routes that leak no pairing/credential material.
 4. **Never log raw tokens.** `maskToken()` exists for a reason.
 5. **Use `safeTokenCompare()`** for any byte-equality check against a token.
 

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -433,9 +433,19 @@ export function createHttpHandler(server) {
       return
     }
 
-    // Connection info endpoint
+    // Connection info endpoint.
+    //
+    // Gated on the PRIMARY token class (#5533 sibling audit): when auth is
+    // required (the normal case), the response body carries the raw PRIMARY
+    // apiToken and a connectionUrl that embeds it (see startup-display.js →
+    // writeConnectionInfo). Accepting a pairing-bound session token here would
+    // hand a once-paired, session-scoped device the full primary token — a
+    // strict privilege escalation, worse than the /qr + /pairing-code leak.
+    // The redaction branch below only fires when auth is DISABLED, so it cannot
+    // be relied on as the boundary. The dashboard's ConsolePage / tunnel-ready
+    // probe both fetch /connect with the primary token, so they keep working.
     if (req.method === 'GET' && req.url === '/connect') {
-      if (!server._validateBearerAuth(req, res)) return
+      if (!server._validatePrimaryBearerAuth(req, res)) return
       const connInfo = readConnectionInfo()
       if (!connInfo) {
         res.writeHead(404, { 'Content-Type': 'application/json' })
@@ -459,10 +469,18 @@ export function createHttpHandler(server) {
 
     // Typeable pairing-code endpoint (#5512): GET /pairing-code returns the
     // current linking-mode pairing code as JSON so the dashboard/CLI can DISPLAY
-    // it beside the QR (the QR encodes the same id — one mechanism). Same bearer
-    // auth + grace-extension as /qr; camera-less devices enter this code by hand.
+    // it beside the QR (the QR encodes the same id — one mechanism). Grace-
+    // extension mirrors /qr; camera-less devices enter this code by hand.
+    //
+    // Gated on the PRIMARY token class (#5533): the displayed code is live
+    // pairing material — anyone who can read it can onboard a new peer. A
+    // pairing-bound session token is scoped to one session, NOT host-level, so
+    // letting it read the current code would let a once-paired device
+    // transitively mint further peers. The daemon's own dashboard and
+    // `chroxy pair-code` both present the primary token, so the display path is
+    // unaffected; only the escalation path closes.
     if (req.method === 'GET' && req.url?.split('?')[0] === '/pairing-code') {
-      if (!server._validateBearerAuth(req, res)) return
+      if (!server._validatePrimaryBearerAuth(req, res)) return
       const codeCors = matchAllowedOrigin(req.headers['origin'])
       const codeHeaders = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
       if (codeCors) {
@@ -547,8 +565,15 @@ export function createHttpHandler(server) {
     // QR whose pairing URL issues a session-bound token. The scanner can chat
     // into that one session but cannot list/switch/destroy others. Must be
     // matched BEFORE the generic /qr handler since both share the prefix.
+    //
+    // Gated on the PRIMARY token class (#5533): generating a share QR MINTS a
+    // fresh bound pairing id (live pairing material). Letting a pairing-bound
+    // token reach this would let a once-paired device transitively mint peers
+    // for its session — the same escalation the linking /qr and /pairing-code
+    // close. The "Share this session" dashboard button runs on the daemon's own
+    // dashboard with the primary token, so the legitimate path is unaffected.
     if (req.method === 'GET' && req.url?.startsWith('/qr/session/')) {
-      if (!server._validateBearerAuth(req, res)) return
+      if (!server._validatePrimaryBearerAuth(req, res)) return
       const shareCors = matchAllowedOrigin(req.headers['origin'])
       const sharePathParts = req.url.split('?')[0].split('/').filter(Boolean) // ['qr','session','<id>']
       const writeShareErr = (status, body) => {
@@ -622,9 +647,16 @@ export function createHttpHandler(server) {
       return
     }
 
-    // QR code endpoint — uses live pairing URL (not stale file) when available
+    // QR code endpoint — uses live pairing URL (not stale file) when available.
+    //
+    // Gated on the PRIMARY token class (#5533): the linking QR encodes a live
+    // pairing URL — scanning it onboards a new peer. A pairing-bound session
+    // token is scoped to one session, not host-level, so it must not be able to
+    // read the current QR and transitively mint further peers. The daemon's own
+    // dashboard fetches /qr with the primary token, so the modal keeps working;
+    // only the escalation path closes.
     if (req.method === 'GET' && req.url?.startsWith('/qr')) {
-      if (!server._validateBearerAuth(req, res)) return
+      if (!server._validatePrimaryBearerAuth(req, res)) return
       const qrCors = matchAllowedOrigin(req.headers['origin'])
 
       // Prefer live pairing URL from PairingManager (always current).

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -457,7 +457,10 @@ export function createHttpHandler(server) {
         delete connInfo.connectionUrl
       }
       const connectCors = matchAllowedOrigin(req.headers['origin'])
-      const connectHeaders = { 'Content-Type': 'application/json' }
+      // no-store: the body carries the raw primary apiToken (and a connectionUrl
+      // embedding it) when auth is required, so browsers/proxies must not cache
+      // it — mirrors /pairing-code, which is also live credential material.
+      const connectHeaders = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
       if (connectCors) {
         connectHeaders['Access-Control-Allow-Origin'] = connectCors
         connectHeaders['Vary'] = 'Origin'

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -50,6 +50,31 @@ function createMockServer(overrides = {}) {
       }
       return true
     },
+    // Primary-class gate (#5533): mirrors the real WsServer helper. A token is
+    // primary iff it validates AND is not a PairingManager-issued session token.
+    // The mock treats the literal 'pairing-bound' (and any token the wired
+    // pairing manager's isSessionTokenValid accepts) as a non-primary token.
+    _isPairingSessionToken(token) {
+      if (token === 'pairing-bound') return true
+      const mgr = this._pairingManager
+      return !!(mgr && typeof mgr.isSessionTokenValid === 'function' && mgr.isSessionTokenValid(token))
+    },
+    _validatePrimaryBearerAuth(req, res) {
+      if (!this.authRequired) return true
+      const authHeader = req.headers['authorization'] || ''
+      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+      if (!token || (!this._isTokenValid(token) && !this._isPairingSessionToken(token))) {
+        res.writeHead(403, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'unauthorized' }))
+        return false
+      }
+      if (this._isPairingSessionToken(token)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'primary_token_required' }))
+        return false
+      }
+      return true
+    },
     ...overrides,
   }
 }
@@ -229,6 +254,85 @@ describe('http-routes', () => {
       })
       assert.equal(res.status, 503)
     })
+
+    // #5533: the linking QR is live pairing material — a pairing-bound token
+    // must not be able to read it (transitive peer minting).
+    it('GET /qr returns 200 SVG for the primary token', async () => {
+      const mock = createMockServer({
+        _pairingManager: {
+          extendCurrentId() {},
+          currentPairingUrl: 'chroxy://example.com?pair=ABCD2345',
+        },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      assert.equal(res.headers.get('content-type'), 'image/svg+xml')
+      assert.ok((await res.text()).includes('<svg'))
+    })
+
+    it('GET /qr returns 403 for a pairing-bound (non-primary) token (#5533)', async () => {
+      const mock = createMockServer({
+        _pairingManager: {
+          extendCurrentId() {},
+          currentPairingUrl: 'chroxy://example.com?pair=ABCD2345',
+        },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr`, {
+        headers: { 'Authorization': 'Bearer pairing-bound' },
+      })
+      assert.equal(res.status, 403)
+      const body = await res.json()
+      assert.equal(body.error, 'primary_token_required')
+    })
+
+    it('GET /qr returns 403 without auth', async () => {
+      const mock = createMockServer({
+        _pairingManager: { extendCurrentId() {}, currentPairingUrl: 'chroxy://example.com?pair=X' },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr`)
+      assert.equal(res.status, 403)
+    })
+  })
+
+  // #5533 sibling audit: GET /connect returns the raw PRIMARY apiToken (and a
+  // connectionUrl embedding it) when auth is required, so it must be gated on
+  // the primary token class — a pairing-bound token reaching it would escalate
+  // straight to the primary token.
+  describe('connect endpoint primary-class gate (#5533)', () => {
+    it('GET /connect returns 403 for a pairing-bound (non-primary) token', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/connect`, {
+        headers: { 'Authorization': 'Bearer pairing-bound' },
+      })
+      assert.equal(res.status, 403)
+      const body = await res.json()
+      assert.equal(body.error, 'primary_token_required')
+    })
+
+    it('GET /connect returns 403 without auth', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/connect`)
+      assert.equal(res.status, 403)
+    })
+
+    it('GET /connect passes the primary token (404 here since conn info is hidden in this suite)', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/connect`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      // The suite renames ~/.chroxy/connection.json away, so readConnectionInfo
+      // returns null → 404. The point is the request got PAST the auth gate
+      // (not a 403), proving the primary token is accepted.
+      assert.equal(res.status, 404)
+    })
   })
 
   // #5512: typeable pairing-code endpoint
@@ -273,6 +377,21 @@ describe('http-routes', () => {
       await startWith(mock)
       const res = await globalThis.fetch(`http://127.0.0.1:${port}/pairing-code`)
       assert.equal(res.status, 403)
+    })
+
+    // #5533: a pairing-bound session token must NOT read the live code (it could
+    // transitively onboard further peers). Must not extend the grace period
+    // either — the gate runs before extendCurrentId().
+    it('returns 403 for a pairing-bound (non-primary) token (#5533)', async () => {
+      const mock = makeCodeMock({ code: 'ABCD2345', url: null, expiresAtMs: Date.now() + 45_000, ttlMs: 60_000 })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/pairing-code`, {
+        headers: { 'Authorization': 'Bearer pairing-bound' },
+      })
+      assert.equal(res.status, 403)
+      const body = await res.json()
+      assert.equal(body.error, 'primary_token_required')
+      assert.equal(mock._pairingManager._extendedCount(), 0, 'a rejected request must not extend the grace period')
     })
 
     it('returns 503 when no pairing manager is wired', async () => {
@@ -452,6 +571,20 @@ describe('http-routes', () => {
       await startWith(mock)
       const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr/session/sess-A`)
       assert.equal(res.status, 403)
+    })
+
+    // #5533: generating a share QR MINTS a fresh bound pairing — a pairing-bound
+    // token must not reach it (transitive peer minting for its own session).
+    it('returns 403 for a pairing-bound (non-primary) token without minting (#5533)', async () => {
+      const mock = makeSharedMock()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/qr/session/sess-A`, {
+        headers: { 'Authorization': 'Bearer pairing-bound' },
+      })
+      assert.equal(res.status, 403)
+      const body = await res.json()
+      assert.equal(body.error, 'primary_token_required')
+      assert.deepEqual(mock._issuedPairings, [], 'a rejected request must not mint a bound pairing')
     })
 
     it('returns 404 when the session does not exist', async () => {


### PR DESCRIPTION
## The gap

`GET /qr`, `GET /pairing-code`, and (sibling-audit finds) `GET /qr/session/:sessionId` and `GET /connect` all gated on `_validateBearerAuth`, which accepts **any** valid bearer — including pairing-issued session tokens. Consequences:

- **`/qr`, `/pairing-code`, `/qr/session/:id`** expose or mint **live pairing material**. A device that paired once could read the current code/QR (or mint a fresh bound pairing for its session) and **transitively onboard further peers** — exactly the escalation #5533 describes.
- **`/connect`** is worse: `connection.json` carries the **raw primary `apiToken`** and a `connectionUrl` that embeds it, and the route returns them in cleartext whenever auth is required (the redaction branch only fires when auth is *disabled*). A pairing-bound token reaching `/connect` therefore escalates **straight to the primary token**.

## The enforcement point

All four routes now call **`_validatePrimaryBearerAuth(req, res)`** ([`ws-server.js`](../blob/fix/scope-pairing-endpoints/packages/server/src/ws-server.js)) — the HTTP analog of the WS `boundSessionId` host-authority gate. It accepts a token only if it validates **and** is not a `PairingManager`-issued session token, rejecting bound tokens with **`403 { "error": "primary_token_required" }`**. `403` (not `401`) follows the codebase convention for "valid token, insufficient class" (same as the existing `/pair-discord` gate and the WS `SESSION_TOKEN_MISMATCH` path). No token still gets `403 unauthorized`, matching the pre-existing behavior of these routes.

The helper already existed — it shipped with #5533 day-one for `POST /pair-discord`; this PR applies it to the four routes the issue + audit identified.

## Sibling audit (bearer-token-authority §9 checklist)

Ran the checklist over every bearer-gated HTTP route in `http-routes.js`:

| Route | Mints/exposes pairing or token material? | Action |
|---|---|---|
| `GET /qr` | live linking QR (pairing URL) | **gated → primary** |
| `GET /qr/session/:id` | MINTS a bound pairing id | **gated → primary** (sibling) |
| `GET /pairing-code` | live typeable code | **gated → primary** |
| `GET /connect` | **raw primary apiToken** + url embedding it | **gated → primary** (sibling, highest severity) |
| `POST /pair-discord` | mints gated pairing id | already primary-only (#5533 day-one) |
| `/version`, `/metrics`, `/diagnostics`, `/api/snapshots*`, `/api/pool/stats` | read-only operational telemetry, no pairing/credential material | left on `_validateBearerAuth` (out of scope) |

`/connect` and `/qr/session/:id` are the two siblings beyond the two the issue named.

## Caller verification (no legitimate break)

Traced every caller of all four routes:

- **Dashboard** (`App.tsx`, `ConsolePage.tsx`) — fetches `/qr`, `/qr/session/:id`, `/pairing-code`, `/connect` with `getAuthToken()`, which reads the `?token=`/`chroxy_auth` cookie set when the **local daemon** serves its own dashboard = the **primary** token. ✅
- **CLI** `chroxy pair-code` (`pair-code-cmd.js`) — fetches `/pairing-code` with `connection.json`'s `apiToken` = primary. ✅
- **Mobile app / store-core** — do **not** fetch any of these over HTTP. ✅
- **LAN client "Have a code?" (#5512 / #5281)** — does **not** GET `/pairing-code` or `/qr` from the remote host. It takes a code typed off the host's screen and drives the WebSocket `pair` handshake (`parsePairingCodeEntry` → `pairServer`). So the legitimate camera-less flow is untouched. ✅

No legitimate caller relies on a pairing-bound token reaching these endpoints, so nothing breaks.

## Tests

Added primary-passes / pairing-bound-403 / no-token-403 coverage for every gated route in `http-routes.test.js` (the base mock now carries a `_validatePrimaryBearerAuth` mirroring the real helper):

- `/qr`: 200 SVG (primary), 403 `primary_token_required` (pairing-bound), 403 (no token)
- `/pairing-code`: 403 (pairing-bound) **and asserts the grace window is NOT extended** on rejection
- `/qr/session/:id`: 403 (pairing-bound) **and asserts no bound pairing is minted** on rejection
- `/connect`: 403 (pairing-bound), 403 (no token), past-the-gate (primary)

`packages/server` suite: **9326 pass / 2 fail**, both the known `service.test.js` flakes (fetch-timeout + port-parsing, unrelated). All 4 server lints + `eslint src/` green. Run with `--test-force-exit`.

## Docs

Updated `docs/security/bearer-token-authority.md`: new §4 HTTP primary-class-gated endpoint table, §8 audit-chain entry for #5533, and §9 checklist now points HTTP authors at `_validatePrimaryBearerAuth` for pairing/credential-touching routes.

Closes #5533