### PR TITLE
fix(desktop): bind embedded server to loopback by default (#5356)

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -2664,4 +2664,73 @@ describe('SettingsPanel', () => {
       expect(err.textContent).toContain('Could not register')
     })
   })
+
+  // #5356 — LAN-exposure toggle: defaults off (loopback), reflects the saved
+  // value on open, and persists via set_expose_on_lan. Tauri-only.
+  describe('expose on LAN (#5356)', () => {
+    const tauriInvoke = vi.fn()
+    const setTauriEnv = (tauri: boolean) => {
+      if (tauri) {
+        ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = { invoke: tauriInvoke }
+      } else {
+        delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+      }
+    }
+    const baseImpl = (cmd: string): Promise<unknown> => {
+      switch (cmd) {
+        case 'get_summon_hotkey': return Promise.resolve(null)
+        case 'get_tunnel_mode': return Promise.resolve('none')
+        case 'get_server_info': return Promise.resolve({ tunnelMode: 'none' })
+        case 'get_allow_auto_permission_mode': return Promise.resolve(false)
+        case 'get_expose_on_lan': return Promise.resolve(false)
+        default: return Promise.resolve(undefined)
+      }
+    }
+
+    beforeEach(() => {
+      tauriInvoke.mockReset()
+      tauriInvoke.mockImplementation(baseImpl)
+      setTauriEnv(true)
+    })
+
+    afterEach(() => {
+      tauriInvoke.mockReset()
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    })
+
+    it('defaults to off (loopback) when the saved setting is false', async () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const toggle = await screen.findByTestId('expose-on-lan-toggle') as HTMLInputElement
+      await waitFor(() => expect(toggle.checked).toBe(false))
+    })
+
+    it('reflects the saved on (LAN) value on open', async () => {
+      tauriInvoke.mockImplementation((cmd: string) =>
+        cmd === 'get_expose_on_lan' ? Promise.resolve(true) : baseImpl(cmd))
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const toggle = await screen.findByTestId('expose-on-lan-toggle') as HTMLInputElement
+      await waitFor(() => expect(toggle.checked).toBe(true))
+    })
+
+    it('persists the toggle via set_expose_on_lan', async () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const toggle = await screen.findByTestId('expose-on-lan-toggle') as HTMLInputElement
+      await waitFor(() => expect(toggle.checked).toBe(false))
+      fireEvent.click(toggle)
+      await waitFor(() =>
+        expect(tauriInvoke).toHaveBeenCalledWith('set_expose_on_lan', { expose: true }))
+    })
+
+    it('reverts the toggle when the save is rejected', async () => {
+      tauriInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'set_expose_on_lan') return Promise.reject(new Error('save failed'))
+        return baseImpl(cmd)
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const toggle = await screen.findByTestId('expose-on-lan-toggle') as HTMLInputElement
+      await waitFor(() => expect(toggle.checked).toBe(false))
+      fireEvent.click(toggle)
+      await waitFor(() => expect(toggle.checked).toBe(false))
+    })
+  })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -857,13 +857,20 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
       if (mode) setTunnelModeState(mode)
     })
     // #5356 — read saved LAN-exposure setting (false = loopback-only default).
+    // This effect only runs in Tauri (gated on inTauri above), so a `null`
+    // here means the IPC invoke failed (the shared helper converts errors to
+    // null) — surface it rather than silently presenting the default toggle.
     setExposeOnLanError(null)
     getExposeOnLan().then(value => {
       if (value !== null) {
         setExposeOnLanState(value)
         setSavedExposeOnLan(value)
+      } else {
+        setExposeOnLanError('Could not load the LAN-exposure setting.')
       }
-    }).catch(() => {})
+    }).catch(err => {
+      setExposeOnLanError(err instanceof Error ? err.message : String(err))
+    })
     // Read running server's actual mode (may differ if not restarted)
     getServerInfo().then(info => {
       if (info?.tunnelMode) setServerTunnelMode(info.tunnelMode)

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -32,6 +32,8 @@ import { getTauriInvoke } from '../utils/tauri-bridge'
 import {
   getTunnelMode,
   setTunnelMode,
+  getExposeOnLan,
+  setExposeOnLan,
   getSummonHotkey,
   setSummonHotkey,
   restartServer,
@@ -743,6 +745,12 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
   const [tunnelError, setTunnelError] = useState<string | null>(null)
   const [serverTunnelMode, setServerTunnelMode] = useState<string>('none')
   const [restarting, setRestarting] = useState(false)
+  // #5356 — LAN exposure of the embedded server. `exposeOnLan` is the saved
+  // setting; `savedExposeOnLan` tracks what's persisted so the panel can prompt
+  // for a restart when changed (bind address is fixed at server spawn).
+  const [exposeOnLan, setExposeOnLanState] = useState<boolean>(false)
+  const [savedExposeOnLan, setSavedExposeOnLan] = useState<boolean>(false)
+  const [exposeOnLanError, setExposeOnLanError] = useState<string | null>(null)
   // #5294 — global summon hotkey. `summonHotkeySaved` tracks the persisted
   // value so the Save button can disable when unchanged and Clear when empty.
   const [summonHotkeyInput, setSummonHotkeyInput] = useState<string>('')
@@ -848,6 +856,14 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
     getTunnelMode().then(mode => {
       if (mode) setTunnelModeState(mode)
     })
+    // #5356 — read saved LAN-exposure setting (false = loopback-only default).
+    setExposeOnLanError(null)
+    getExposeOnLan().then(value => {
+      if (value !== null) {
+        setExposeOnLanState(value)
+        setSavedExposeOnLan(value)
+      }
+    }).catch(() => {})
     // Read running server's actual mode (may differ if not restarted)
     getServerInfo().then(info => {
       if (info?.tunnelMode) setServerTunnelMode(info.tunnelMode)
@@ -1018,6 +1034,19 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
       setTunnelError(err instanceof Error ? err.message : String(err))
     }
   }, [tunnelMode])
+
+  // #5356 — persist the LAN-exposure toggle. Optimistic; revert on error.
+  const handleExposeOnLanChange = useCallback(async (expose: boolean) => {
+    setExposeOnLanError(null)
+    const previous = exposeOnLan
+    setExposeOnLanState(expose)
+    try {
+      await setExposeOnLan(expose)
+    } catch (err) {
+      setExposeOnLanState(previous)
+      setExposeOnLanError(err instanceof Error ? err.message : String(err))
+    }
+  }, [exposeOnLan])
 
   // #5294 — persist + live-register the summon hotkey. On a bad/conflicting
   // accelerator the Rust side throws; surface it and leave the field as-typed
@@ -1842,11 +1871,50 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
           {inTauri && (
             <section className="settings-section">
               <h3>Network</h3>
+              {/* #5356 — loopback by default; LAN exposure is an explicit opt-in. */}
+              <div className="settings-field">
+                <label htmlFor="expose-on-lan">Expose on local network</label>
+                <input
+                  id="expose-on-lan"
+                  type="checkbox"
+                  data-testid="expose-on-lan-toggle"
+                  checked={exposeOnLan}
+                  onChange={(e) => handleExposeOnLanChange(e.target.checked)}
+                />
+              </div>
+              <p className="settings-help">
+                Off (default): the server is reachable only from this machine
+                (loopback). On: binds all network interfaces so phones on the
+                same Wi-Fi can scan the QR code and connect. Leave off and use a
+                tunnel (below) for remote access.
+              </p>
+              <div className="settings-field">
+                {exposeOnLanError && (
+                  <p className="tunnel-mode-error" role="alert">{exposeOnLanError}</p>
+                )}
+                {exposeOnLan !== savedExposeOnLan ? (
+                  <button
+                    type="button"
+                    className="tunnel-restart-btn"
+                    disabled={restarting}
+                    onClick={async () => {
+                      setRestarting(true)
+                      await restartServer()
+                      setSavedExposeOnLan(exposeOnLan)
+                      setTimeout(() => setRestarting(false), 3000)
+                    }}
+                  >
+                    {restarting ? 'Restarting...' : 'Restart Server to Apply'}
+                  </button>
+                ) : (
+                  <p className="tunnel-mode-note">Server restart required after change</p>
+                )}
+              </div>
               <div className="settings-field">
                 <span id="tunnel-mode-label">Tunnel mode</span>
                 <div className="tunnel-mode-options" role="radiogroup" aria-labelledby="tunnel-mode-label">
                   {([
-                    { value: 'none', label: 'Off', desc: 'LAN only' },
+                    { value: 'none', label: 'Off', desc: 'No public tunnel' },
                     { value: 'quick', label: 'Quick Tunnel', desc: 'Random Cloudflare URL' },
                     { value: 'named', label: 'Named Tunnel', desc: 'Stable URL, requires setup' },
                   ] as const).map(opt => (

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -68,8 +68,11 @@ export async function getExposeOnLan(): Promise<boolean | null> {
  * on the next server restart (bind address is fixed at spawn). Throws on error.
  */
 export async function setExposeOnLan(expose: boolean): Promise<void> {
+  if (!isTauri()) return
   const invoke = getTauriInvoke()
-  if (!invoke) return
+  if (!invoke) {
+    throw new Error('Tauri invoke is unavailable')
+  }
   await invoke('set_expose_on_lan', { expose })
 }
 

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -55,6 +55,25 @@ export async function setTunnelMode(mode: string): Promise<void> {
 }
 
 /**
+ * Read whether the embedded server is set to bind all interfaces (LAN) or
+ * loopback-only (#5356). Returns `null` outside Tauri. `false` (loopback) is
+ * the safe default.
+ */
+export async function getExposeOnLan(): Promise<boolean | null> {
+  return tauriInvoke<boolean>('get_expose_on_lan')
+}
+
+/**
+ * Toggle LAN exposure for the embedded server (#5356). Persisted; takes effect
+ * on the next server restart (bind address is fixed at spawn). Throws on error.
+ */
+export async function setExposeOnLan(expose: boolean): Promise<void> {
+  const invoke = getTauriInvoke()
+  if (!invoke) return
+  await invoke('set_expose_on_lan', { expose })
+}
+
+/**
  * Read the configured global summon hotkey accelerator (#5294).
  *
  * Returns `null` outside Tauri, or when no hotkey is set (the Rust side returns

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -24,6 +24,8 @@ const APP_COMMANDS: &[&str] = &[
     "save_setup_config",
     "get_tunnel_mode",
     "set_tunnel_mode",
+    "get_expose_on_lan",
+    "set_expose_on_lan",
     "get_summon_hotkey",
     "set_summon_hotkey",
     "get_allow_auto_permission_mode",

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -32,6 +32,8 @@
     "allow-save-setup-config",
     "allow-get-tunnel-mode",
     "allow-set-tunnel-mode",
+    "allow-get-expose-on-lan",
+    "allow-set-expose-on-lan",
     "allow-get-summon-hotkey",
     "allow-set-summon-hotkey",
     "allow-get-allow-auto-permission-mode",

--- a/packages/desktop/src-tauri/permissions/autogenerated/get_expose_on_lan.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/get_expose_on_lan.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-get-expose-on-lan"
+description = "Enables the get_expose_on_lan command without any pre-configured scope."
+commands.allow = ["get_expose_on_lan"]
+
+[[permission]]
+identifier = "deny-get-expose-on-lan"
+description = "Denies the get_expose_on_lan command without any pre-configured scope."
+commands.deny = ["get_expose_on_lan"]

--- a/packages/desktop/src-tauri/permissions/autogenerated/set_expose_on_lan.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/set_expose_on_lan.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-expose-on-lan"
+description = "Enables the set_expose_on_lan command without any pre-configured scope."
+commands.allow = ["set_expose_on_lan"]
+
+[[permission]]
+identifier = "deny-set-expose-on-lan"
+description = "Denies the set_expose_on_lan command without any pre-configured scope."
+commands.deny = ["set_expose_on_lan"]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -327,6 +327,35 @@ fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
     Ok(())
 }
 
+/// #5356 — current "expose on LAN" setting. False (loopback-only) is the
+/// default and the safe posture for the control socket.
+#[tauri::command]
+fn get_expose_on_lan(settings_state: tauri::State<'_, Mutex<DesktopSettings>>) -> bool {
+    lock_or_recover(&settings_state).expose_on_lan
+}
+
+/// #5356 — toggle whether the embedded server binds all interfaces (LAN) or
+/// loopback-only. Persisted; applied on the next server start/restart (the bind
+/// address is fixed at spawn, so the dashboard prompts for a restart).
+#[tauri::command]
+fn set_expose_on_lan(app: tauri::AppHandle, expose: bool) -> Result<(), String> {
+    if let Some(settings_state) = app.try_state::<Mutex<DesktopSettings>>() {
+        let mut settings = lock_or_recover(&settings_state);
+        settings.expose_on_lan = expose;
+        settings
+            .save()
+            .map_err(|e| format!("Failed to save settings: {}", e))?;
+    }
+
+    // Update ServerManager so the next start/restart picks up the new bind host.
+    if let Some(mgr_state) = app.try_state::<Mutex<ServerManager>>() {
+        let mut mgr = lock_or_recover(&mgr_state);
+        mgr.set_expose_on_lan(expose);
+    }
+
+    Ok(())
+}
+
 /// #5294 — read the configured summon hotkey accelerator. Returns `None` when
 /// unset or blank (i.e. disabled), matching `effective_summon_hotkey()`.
 #[tauri::command]
@@ -825,6 +854,8 @@ pub fn run() {
             save_setup_config,
             get_tunnel_mode,
             set_tunnel_mode,
+            get_expose_on_lan,
+            set_expose_on_lan,
             get_summon_hotkey,
             set_summon_hotkey,
             get_allow_auto_permission_mode,
@@ -1683,14 +1714,21 @@ fn monitor_startup(app: &tauri::AppHandle, context: StartupContext) -> bool {
 }
 
 fn handle_start(app: &tauri::AppHandle) {
-    // Read settings and apply to server manager
-    let (tunnel_mode, node_path) = app
+    // Read settings and apply to server manager. #5356 — also carry the
+    // expose-on-LAN flag so the embedded server is pinned to loopback unless
+    // the user explicitly opted in; defaults to false (loopback) when settings
+    // state is unavailable.
+    let (tunnel_mode, node_path, expose_on_lan) = app
         .try_state::<Mutex<DesktopSettings>>()
         .map(|s| {
             let settings = lock_or_recover(&s);
-            (settings.tunnel_mode.clone(), settings.node_path.clone())
+            (
+                settings.tunnel_mode.clone(),
+                settings.node_path.clone(),
+                settings.expose_on_lan,
+            )
         })
-        .unwrap_or_else(|| ("quick".to_string(), None));
+        .unwrap_or_else(|| ("quick".to_string(), None, false));
 
     // Validate cloudflared for tunnel modes
     if tunnel_mode != "none" && !ServerManager::check_cloudflared() {
@@ -1713,6 +1751,7 @@ fn handle_start(app: &tauri::AppHandle) {
         };
         mgr.set_tunnel_mode(effective_mode);
         mgr.set_node_path(node_path.as_deref());
+        mgr.set_expose_on_lan(expose_on_lan);
         mgr.start()
     };
 

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -325,6 +325,11 @@ pub struct ServerManager {
     node_path: Option<PathBuf>,
     config: ChroxyConfig,
     tunnel_mode: String,
+    /// #5356 — when false (the default), the embedded server is spawned with
+    /// `CHROXY_HOST=127.0.0.1` so it binds loopback only. Set true (via the
+    /// desktop "Expose on LAN" toggle) to bind all interfaces for the LAN
+    /// QR-scan flow. Applied on the next `start()`.
+    expose_on_lan: bool,
     health_generation: Arc<AtomicU64>,
     /// Set by stop() to prevent auto-restart after user-initiated stop.
     user_stopped: Arc<AtomicBool>,
@@ -352,6 +357,7 @@ impl ServerManager {
             node_path: None,
             config: ChroxyConfig::default(),
             tunnel_mode: "quick".to_string(),
+            expose_on_lan: false,
             health_generation: Arc::new(AtomicU64::new(0)),
             user_stopped: Arc::new(AtomicBool::new(false)),
             auto_restart_pending: Arc::new(AtomicBool::new(false)),
@@ -381,6 +387,25 @@ impl ServerManager {
 
     pub fn set_tunnel_mode(&mut self, mode: &str) {
         self.tunnel_mode = mode.to_string();
+    }
+
+    pub fn expose_on_lan(&self) -> bool {
+        self.expose_on_lan
+    }
+
+    pub fn set_expose_on_lan(&mut self, expose: bool) {
+        self.expose_on_lan = expose;
+    }
+
+    /// #5356 — the bind host to hand the embedded server via `CHROXY_HOST`.
+    /// `None` when exposing on LAN (let the server keep its `0.0.0.0` default);
+    /// `Some("127.0.0.1")` otherwise so the control socket is loopback-only.
+    fn bind_host_env(&self) -> Option<&'static str> {
+        if self.expose_on_lan {
+            None
+        } else {
+            Some("127.0.0.1")
+        }
     }
 
     /// Set a custom Node binary path from settings.
@@ -954,6 +979,15 @@ impl ServerManager {
         }
         // Tunnel mode: "quick", "named", or "none"
         cmd.env("CHROXY_TUNNEL", &self.tunnel_mode);
+        // #5356 — loopback by default. Unless the user opted into LAN exposure,
+        // pin the embedded server to 127.0.0.1 so the control socket (which
+        // drives a billed claude PTY and takes a token over the wire) is not
+        // reachable from the LAN. CHROXY_HOST maps to config.host in the server,
+        // which binds that interface with auth still on. When exposed, we omit
+        // the var so the server keeps its 0.0.0.0 default (LAN QR-scan flow).
+        if let Some(host) = self.bind_host_env() {
+            cmd.env("CHROXY_HOST", host);
+        }
         // Mark this as a bundled .app launch so the doctor Dependencies check
         // downgrades to `warn` instead of `fail` — end users can't run
         // `npm install` to fix a broken bundle; they need to reinstall.
@@ -1338,6 +1372,35 @@ impl Drop for ServerManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- bind_host_env (#5356) --
+    //
+    // Loopback by default: the spawn must pin CHROXY_HOST=127.0.0.1 unless the
+    // user explicitly opted into LAN exposure, in which case the var is omitted
+    // and the server keeps its 0.0.0.0 default.
+
+    #[test]
+    fn bind_host_env_defaults_to_loopback() {
+        let mgr = ServerManager::new();
+        assert!(!mgr.expose_on_lan());
+        assert_eq!(mgr.bind_host_env(), Some("127.0.0.1"));
+    }
+
+    #[test]
+    fn bind_host_env_none_when_exposed_on_lan() {
+        let mut mgr = ServerManager::new();
+        mgr.set_expose_on_lan(true);
+        assert!(mgr.expose_on_lan());
+        assert_eq!(mgr.bind_host_env(), None);
+    }
+
+    #[test]
+    fn set_expose_on_lan_toggles_back_to_loopback() {
+        let mut mgr = ServerManager::new();
+        mgr.set_expose_on_lan(true);
+        mgr.set_expose_on_lan(false);
+        assert_eq!(mgr.bind_host_env(), Some("127.0.0.1"));
+    }
 
     // -- build_enriched_path --
     //

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -983,10 +983,18 @@ impl ServerManager {
         // pin the embedded server to 127.0.0.1 so the control socket (which
         // drives a billed claude PTY and takes a token over the wire) is not
         // reachable from the LAN. CHROXY_HOST maps to config.host in the server,
-        // which binds that interface with auth still on. When exposed, we omit
-        // the var so the server keeps its 0.0.0.0 default (LAN QR-scan flow).
-        if let Some(host) = self.bind_host_env() {
-            cmd.env("CHROXY_HOST", host);
+        // which binds that interface with auth still on. When exposed, we
+        // explicitly clear the var (rather than just omitting it) so an inherited
+        // CHROXY_HOST from the desktop app's own environment can't silently pin
+        // the server to a different interface and make the toggle ineffective —
+        // the server then keeps its 0.0.0.0 default (LAN QR-scan flow).
+        match self.bind_host_env() {
+            Some(host) => {
+                cmd.env("CHROXY_HOST", host);
+            }
+            None => {
+                cmd.env_remove("CHROXY_HOST");
+            }
         }
         // Mark this as a bundled .app launch so the doctor Dependencies check
         // downgrades to `warn` instead of `fail` — end users can't run

--- a/packages/desktop/src-tauri/src/settings.rs
+++ b/packages/desktop/src-tauri/src/settings.rs
@@ -14,6 +14,12 @@ pub struct DesktopSettings {
     pub node_path: Option<String>,
     #[serde(default = "default_tunnel_mode")]
     pub tunnel_mode: String,
+    /// #5356 — when false (the default), the embedded server binds loopback
+    /// (`127.0.0.1`) so the control socket is reachable only from this machine.
+    /// Set true to bind all interfaces (`0.0.0.0`) for the "scan QR from my
+    /// phone on the same wifi" LAN flow — explicit opt-in, not the default.
+    #[serde(default)]
+    pub expose_on_lan: bool,
     #[serde(default)]
     pub last_window_x: Option<f64>,
     #[serde(default)]
@@ -45,6 +51,7 @@ impl Default for DesktopSettings {
             auto_start_server: true,
             show_notifications: true,
             tunnel_mode: "none".to_string(),
+            expose_on_lan: false,
             node_path: None,
             last_window_x: None,
             last_window_y: None,
@@ -157,6 +164,23 @@ mod tests {
         assert!(settings.auto_start_server);
         assert!(settings.show_notifications);
         assert_eq!(settings.tunnel_mode, "none");
+    }
+
+    #[test]
+    fn expose_on_lan_defaults_to_false() {
+        // #5356 — loopback by default: the embedded server must NOT bind all
+        // interfaces unless the user explicitly opts into LAN exposure.
+        assert!(!DesktopSettings::default().expose_on_lan);
+        assert!(!DesktopSettings::from_json("{}").unwrap().expose_on_lan);
+    }
+
+    #[test]
+    fn expose_on_lan_round_trips() {
+        let mut settings = DesktopSettings::default();
+        settings.expose_on_lan = true;
+        let json = settings.to_json().unwrap();
+        let restored = DesktopSettings::from_json(&json).unwrap();
+        assert!(restored.expose_on_lan);
     }
 
     #[test]


### PR DESCRIPTION
Closes #5356

## Problem

Chroxy.app launched the embedded server with **no `--host`**, so it bound `0.0.0.0` (all interfaces) by default — publishing the chroxy control socket to the LAN. That socket drives an interactive, subscription-billed `claude` PTY and accepts a bearer token over the wire. "Loopback by default, exposure explicit" is the safer posture for a control plane.

## Bind-default decision — Option A (Tauri shell), not Option B (CLI default)

I flipped the default **only in the Tauri shell** (the embedded-server spawn), leaving the server CLI default at `0.0.0.0`.

- The issue's "Expected behavior" is literally *"Chroxy.app defaults to loopback"* — Option A is the exact ask.
- Smallest blast radius: power users running `chroxy start` directly, and headless/CI deployments that depend on `0.0.0.0`, are unaffected.
- The server already supports the safe path cleanly — `CHROXY_HOST=127.0.0.1` → `config.host` → `resolveBindHost()` → `wsServer.start('127.0.0.1')`, with auth still on (`bind-host.js`). The shell just feeds it.

`ServerManager` now sets `CHROXY_HOST=127.0.0.1` at spawn unless the user opted into LAN exposure, in which case the var is omitted and the server keeps its `0.0.0.0` default.

## Auto-tunnel finding — already user-gated, no change needed

The issue also flagged the auto public cloudflared tunnel. I traced the actual startup path:

- Every `start()` routes through `handle_start`, which reads `tunnel_mode` from `DesktopSettings`.
- `DesktopSettings::default()` / `default_tunnel_mode()` return **`"none"`** (and have since the file was created — verified via git history).

So a fresh Chroxy.app does **not** auto-start a quick tunnel; the public tunnel is already explicit opt-in via Settings → Network → Tunnel mode. The `"quick"` literal in `ServerManager::new()` is a vestigial fallback only reached if settings state is entirely missing. No change required for the tunnel; the remaining exposure was purely the bind, which this PR fixes.

## Preserved explicit-exposure path + LAN-workflow compat

Flipping to loopback would otherwise break the documented "scan QR from my phone on the same wifi" flow (root `CLAUDE.md`). To keep that working as an explicit opt-in:

- New persisted setting `DesktopSettings.expose_on_lan` (default `false`).
- New Tauri commands `get_expose_on_lan` / `set_expose_on_lan` (registered in `lib.rs` generate_handler, `build.rs` `APP_COMMANDS`, and `capabilities/default.json` per the command-drift guard #3742).
- Dashboard **Settings → Network** gains an **"Expose on local network"** toggle with a *Restart Server to Apply* prompt (bind address is fixed at spawn). The tunnel **"Off"** option label is corrected from *"LAN only"* (now inaccurate) to *"No public tunnel"*.

A user who wants LAN access flips one persistent toggle; remote access continues to work via the tunnel mode selector. Nothing is silently broken — it just requires one explicit opt-in.

## Upgrade behavior-change note

This is a behavior change. After updating, users who relied on the previous `0.0.0.0` default to reach the desktop server from another device on their LAN must enable the new **"Expose on local network"** toggle (or use a tunnel). The setting defaults off, including on first run (the setup wizard's start path goes through `handle_start`, which applies the loopback default).

## Tests

- **Rust (`cargo test --locked`)**: full desktop suite green. Added unit tests for `ServerManager::bind_host_env` (loopback default / `None` when exposed / toggles back) and `DesktopSettings.expose_on_lan` (default-false + serde round-trip). The `command_drift` guard passes with all three registration sites updated.
- **Dashboard (`vitest run`)**: 3567/3567 green, including 4 new `SettingsPanel` tests for the toggle (defaults off, reflects saved-on, persists via `set_expose_on_lan`, reverts on rejection) and `tsc --noEmit` clean.