### PR TITLE
feat(app,dashboard): surface session-role (primary/observer) state in both clients

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -2139,3 +2139,41 @@ describe('sendUserQuestionResponse Other / freeform shape (#4755)', () => {
     expect(payload).not.toHaveProperty('toolUseId');
   });
 });
+
+// #5589 / #5281 — explicit primary (driver) ownership claim. The action sends
+// a `claim_primary` wire message; `force` overrides the current owner.
+describe('claimPrimary wire payload (#5589 / #5281)', () => {
+  function makeMockSocket(): { socket: WebSocket; sent: string[] } {
+    const sent: string[] = [];
+    const socket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(data); },
+    } as unknown as WebSocket;
+    return { socket, sent };
+  }
+
+  it('emits a plain claim (no force) by default', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().claimPrimary('s1');
+    expect(sent).toHaveLength(1);
+    const payload = JSON.parse(sent[0]);
+    expect(payload).toEqual({ type: 'claim_primary', sessionId: 's1' });
+    expect(payload).not.toHaveProperty('force');
+  });
+
+  it('emits force:true for an explicit take-over', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().claimPrimary('s1', { force: true });
+    expect(JSON.parse(sent[0])).toEqual({ type: 'claim_primary', sessionId: 's1', force: true });
+  });
+
+  it('no-ops when the socket is not open', () => {
+    const sent: string[] = [];
+    const socket = { readyState: 0, send: (d: string) => { sent.push(d); } } as unknown as WebSocket;
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().claimPrimary('s1');
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -164,6 +164,152 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
   });
 });
 
+// #5589 / #5281 — explicit primary-ownership. The server names the primary
+// (`primaryClientId`); the app derives THIS device's role (vs the canonical
+// myClientId in useMultiClientStore) and stores it per-session on sessionRole.
+describe('session_role handler (#5589 / #5281)', () => {
+  beforeEach(() => {
+    useMultiClientStore.getState().reset();
+  });
+
+  it('derives observer when another device holds primary', () => {
+    useMultiClientStore.getState().setMyClientId('me');
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: 'other' });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.sessionRole).toBe('observer');
+    expect(ss.primaryClientId).toBe('other');
+  });
+
+  it('derives primary when THIS device holds primary', () => {
+    useMultiClientStore.getState().setMyClientId('me');
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: 'me' });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.sessionRole).toBe('primary');
+    expect(ss.primaryClientId).toBe('me');
+  });
+
+  it('derives unclaimed when the slot is vacated (nobody-until-claim)', () => {
+    useMultiClientStore.getState().setMyClientId('me');
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), sessionRole: 'observer', primaryClientId: 'other' } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_role', sessionId: 's1', primaryClientId: null });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.sessionRole).toBe('unclaimed');
+    expect(ss.primaryClientId).toBeNull();
+  });
+
+  it('ignores a session_role for a session not in the local store', () => {
+    useMultiClientStore.getState().setMyClientId('me');
+    const store = createMockStore({ activeSessionId: null, sessionStates: {} });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_role', sessionId: 'ghost', primaryClientId: 'other' });
+
+    expect(store.getState().sessionStates.ghost).toBeUndefined();
+  });
+});
+
+// #5589 / #5281 — input_conflict (incl. a PRIMARY_HELD claim rejection) is an
+// expected shared-session event, NOT a failure: it must surface a calm inline
+// system notice rather than the loud generic Alert, and drop the stranded
+// optimistic send.
+describe('session_error input_conflict handler (#5589 / #5281)', () => {
+  it('appends a calm system notice and drops the rejected optimistic send (no Alert)', () => {
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [
+            { id: 'older', type: 'user_input', content: 'earlier', timestamp: 0 } as any,
+            { id: 'user-123', type: 'user_input', content: 'hi', timestamp: 1 } as any,
+            { id: 'thinking', type: 'thinking', content: '', timestamp: 2 } as any,
+          ],
+          streamingMessageId: 'pending',
+        },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    const reason = 'Session is already processing input from another device. Wait for it to finish or interrupt first.';
+    _testMessageHandler.handle({
+      type: 'session_error',
+      category: 'input_conflict',
+      sessionId: 's1',
+      clientMessageId: 'user-123',
+      message: reason,
+    });
+
+    // No loud modal — the calm path was taken.
+    expect(alertSpy).not.toHaveBeenCalled();
+    const ss = store.getState().sessionStates.s1;
+    // Stranded optimistic send + spinner gone; prior real message untouched.
+    expect(ss.messages.find((m: any) => m.id === 'user-123')).toBeUndefined();
+    expect(ss.messages.find((m: any) => m.type === 'thinking')).toBeUndefined();
+    expect(ss.messages.find((m: any) => m.id === 'older')).toBeDefined();
+    expect(ss.streamingMessageId).toBeNull();
+    // A calm system notice carrying the server's reason was appended.
+    const notice = ss.messages.find((m: any) => m.type === 'system' && m.content === reason);
+    expect(notice).toBeDefined();
+  });
+
+  it('surfaces a PRIMARY_HELD claim rejection as the same calm notice', () => {
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    const reason = 'Another device is the primary for this session. Request a hand-off or wait for it to release.';
+    _testMessageHandler.handle({
+      type: 'session_error',
+      category: 'input_conflict',
+      sessionId: 's1',
+      code: 'PRIMARY_HELD',
+      primaryClientId: 'other',
+      message: reason,
+    });
+
+    expect(alertSpy).not.toHaveBeenCalled();
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.messages.find((m: any) => m.type === 'system' && m.content === reason)).toBeDefined();
+  });
+});
+
 // #4879: quiet "user-initiated Stop" confirmation. The wire path (CliSession
 // → SessionManager → ws-forwarding → ServerSessionStoppedSchema) was wired
 // in #4868; this branch surfaces it to the mobile UX as a subtle status

--- a/packages/app/src/components/ObserverBanner.tsx
+++ b/packages/app/src/components/ObserverBanner.tsx
@@ -1,0 +1,112 @@
+/**
+ * ObserverBanner — surfaces this device's shared-session role (#5589 / #5281).
+ *
+ * The chroxy daemon fans a single session out to every connected client and
+ * (since #5589) tracks an explicit *primary* (driver). When ANOTHER device is
+ * the primary, this device is an observer: it sees the same output but its
+ * input is rejected with `input_conflict` while the agent is mid-request. This
+ * banner makes that state legible (an unobtrusive strip, not a disabled input —
+ * the server still lets an observer adopt an *idle* session per #5589), names
+ * the driving device when known, and offers an explicit "Take over" affordance
+ * that sends `claim_primary { force: true }`.
+ *
+ * Renders nothing unless the active session's role is `'observer'` — primary
+ * and unclaimed sessions show no banner (the operator is/can be the driver).
+ *
+ * Scope: this is the role-AWARENESS surface (#5281 milestone ①.3 slice). The
+ * full shared-session-join UX and the desktop-as-LAN-client connect flow are
+ * out of scope here.
+ */
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { COLORS } from '../constants/colors';
+import { Icon } from './Icon';
+
+export interface ObserverBannerProps {
+  /** True only when the active session's role is `'observer'`. */
+  visible: boolean;
+  /** The active session id (claim target). */
+  sessionId: string | null;
+  /**
+   * Human-friendly name of the device currently driving, or null when unknown
+   * (the roster hasn't resolved the primary client id to a name yet).
+   */
+  driverName: string | null;
+  /** Send `claim_primary { force: true }` for an explicit take-over. */
+  onTakeOver: (sessionId: string) => void;
+}
+
+export function ObserverBanner({
+  visible,
+  sessionId,
+  driverName,
+  onTakeOver,
+}: ObserverBannerProps) {
+  if (!visible || !sessionId) return null;
+
+  const label = driverName
+    ? `Observing — ${driverName} is driving`
+    : 'Observing — another device is driving';
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={`${label}. Your input may be rejected while it is busy. Take over to drive.`}
+      testID="observer-banner"
+    >
+      <View style={styles.content}>
+        <Icon name="eye" size={16} color={COLORS.accentBlue} />
+        <Text style={styles.text} numberOfLines={2} testID="observer-banner-text">
+          {label}
+        </Text>
+      </View>
+      <TouchableOpacity
+        style={styles.takeOverButton}
+        onPress={() => onTakeOver(sessionId)}
+        accessibilityRole="button"
+        accessibilityLabel="Take over as primary"
+        testID="observer-banner-takeover-button"
+      >
+        <Text style={styles.takeOverText}>Take over</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: COLORS.accentBlueLight,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.accentBlueBorder,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  text: {
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    flex: 1,
+  },
+  takeOverButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+    backgroundColor: COLORS.accentBlue,
+    marginLeft: 8,
+  },
+  takeOverText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/packages/app/src/components/__tests__/ObserverBanner.test.tsx
+++ b/packages/app/src/components/__tests__/ObserverBanner.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Render tests for the mobile ObserverBanner (#5589 / #5281).
+ *
+ * Covers: hidden unless visible (observer role) + a session id, names the
+ * driver when known, falls back to neutral copy when unknown, and the
+ * "Take over" button fires onTakeOver with the session id.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { ObserverBanner } from '../ObserverBanner';
+
+function findByTestId(root: ReactTestInstance, testID: string): ReactTestInstance | null {
+  const matches = root.findAll((n) => n.props?.testID === testID);
+  return matches.length > 0 ? matches[0] : null;
+}
+
+function collectText(root: ReactTestInstance): string {
+  return root
+    .findAllByType(Text)
+    .map((node) => {
+      const c = node.props.children;
+      if (typeof c === 'string' || typeof c === 'number') return String(c);
+      if (Array.isArray(c)) return c.map((x) => (typeof x === 'string' ? x : '')).join('');
+      return '';
+    })
+    .join(' ');
+}
+
+describe('ObserverBanner', () => {
+  let tree: renderer.ReactTestRenderer | null = null;
+  afterEach(() => {
+    if (tree) { act(() => tree!.unmount()); tree = null; }
+  });
+
+  function render(props: React.ComponentProps<typeof ObserverBanner>): renderer.ReactTestRenderer {
+    let t!: renderer.ReactTestRenderer;
+    act(() => { t = renderer.create(<ObserverBanner {...props} />); });
+    tree = t;
+    return t;
+  }
+
+  it('renders nothing when not visible', () => {
+    const t = render({ visible: false, sessionId: 's1', driverName: 'iPhone', onTakeOver: jest.fn() });
+    expect(findByTestId(t.root, 'observer-banner')).toBeNull();
+  });
+
+  it('renders nothing when there is no session id', () => {
+    const t = render({ visible: true, sessionId: null, driverName: 'iPhone', onTakeOver: jest.fn() });
+    expect(findByTestId(t.root, 'observer-banner')).toBeNull();
+  });
+
+  it('names the driving device when known', () => {
+    const t = render({ visible: true, sessionId: 's1', driverName: 'iPhone 17 Pro', onTakeOver: jest.fn() });
+    expect(findByTestId(t.root, 'observer-banner')).not.toBeNull();
+    expect(collectText(t.root)).toContain('iPhone 17 Pro is driving');
+  });
+
+  it('falls back to neutral copy when the driver is unknown', () => {
+    const t = render({ visible: true, sessionId: 's1', driverName: null, onTakeOver: jest.fn() });
+    expect(collectText(t.root)).toContain('another device is driving');
+  });
+
+  it('fires onTakeOver with the session id when the button is pressed', () => {
+    const onTakeOver = jest.fn();
+    const t = render({ visible: true, sessionId: 's1', driverName: 'iPhone', onTakeOver });
+    const btn = findByTestId(t.root, 'observer-banner-takeover-button');
+    expect(btn).not.toBeNull();
+    act(() => { btn!.props.onPress(); });
+    expect(onTakeOver).toHaveBeenCalledWith('s1');
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -48,6 +48,7 @@ import { DevPreviewBanner } from '../components/DevPreviewBanner';
 import { SessionTimeoutBanner } from '../components/SessionTimeoutBanner';
 import { StdinDisabledBanner } from '../components/StdinDisabledBanner';
 import { CostThresholdBanner } from '../components/CostThresholdBanner';
+import { ObserverBanner } from '../components/ObserverBanner';
 import { SessionOverview } from '../components/SessionOverview';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -314,6 +315,17 @@ export function SessionScreen() {
     return id && s.sessionStates[id] ? s.sessionStates[id].costThresholdWarning : null;
   });
   const costBudget = useConnectionStore((s) => s.costBudget);
+  // #5589 / #5281 — this device's shared-session role + the current driver, for
+  // the observer banner. Both are per-session.
+  const sessionRole = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].sessionRole : null;
+  });
+  const activePrimaryClientId = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].primaryClientId : null;
+  });
+  const claimPrimary = useConnectionStore((s) => s.claimPrimary);
   // #4764 — chroxy-side intervention ring for the active session. Drives the
   // session-header counter badge and the tap-to-expand recent-interventions
   // sheet (mirrors the dashboard's FooterBar surface from #4758).
@@ -1306,6 +1318,18 @@ export function SessionScreen() {
         visible={!!activeSession?.stdinForwardingDisabled}
         sessionId={activeSessionId}
         onRestart={handleRestartStdinSession}
+      />
+
+      {/* #5589 / #5281: observer role banner. Shows only when ANOTHER device is
+          the primary (driver) for the active session; names it (when the roster
+          resolves the id) and offers an explicit force take-over. */}
+      <ObserverBanner
+        visible={sessionRole === 'observer'}
+        sessionId={activeSessionId}
+        driverName={
+          connectedClients.find((c) => c.clientId === activePrimaryClientId)?.deviceName ?? null
+        }
+        onTakeOver={(sid) => claimPrimary(sid, { force: true })}
       />
 
       {/* #4075: cost-threshold soft warning banner. Server fires once per

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1842,6 +1842,22 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   // Session actions
 
+  // #5589 / #5281 — explicitly request primary (driver) ownership of a session.
+  // `force: true` is an operator-driven take-over that overrides the current
+  // owner; without it the server rejects a claim another device holds with a
+  // PRIMARY_HELD `session_error` (input_conflict), surfaced as a calm notice.
+  // The authoritative role lands via the resulting `session_role` broadcast.
+  claimPrimary: (sessionId: string, options?: { force?: boolean }) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'claim_primary',
+        sessionId,
+        ...(options?.force ? { force: true } : {}),
+      });
+    }
+  },
+
   switchSession: (sessionId: string, options?: { serverNotify?: boolean; haptic?: boolean }) => {
     const { socket, activeSessionId, sessionStates } = get();
     const serverNotify = options?.serverNotify ?? true;

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -62,6 +62,7 @@ import {
   handleClientJoined as sharedClientJoined,
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
+  handleSessionRole as sharedSessionRole,
   handleClientFocusChanged as sharedClientFocusChanged,
   // conversation_id migrated to the shared dispatch table (#5556)
   handleConversationsList as sharedConversationsList,
@@ -1904,6 +1905,42 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           updateSession(crashedId, () => ({ health: 'crashed' as const }));
           pushSessionNotification(crashedId, 'error', 'Session crashed');
         }
+      } else if (parsed.category === 'input_conflict') {
+        // #5281 ①.3 / #5589 — an expected "can't send / can't claim right now"
+        // event, NOT a failure: either another device's request is mid-flight,
+        // this session is still evaluating a previous draft, or a `claim_primary`
+        // was rejected because another device holds it (code PRIMARY_HELD). The
+        // generic Alert below would be the wrong register (loud modal). Instead:
+        // drop the stranded optimistic user message (its send was rejected) +
+        // its thinking spinner, and append a calm inline system notice.
+        const conflictSessionId =
+          typeof msg.sessionId === 'string' ? msg.sessionId : get().activeSessionId;
+        const rejectedId =
+          typeof msg.clientMessageId === 'string' && msg.clientMessageId.length > 0
+            ? msg.clientMessageId
+            : null;
+        const noticeText =
+          parsed.message ||
+          'Your message wasn’t sent — the session is busy. Wait for it to finish, or interrupt the current run.';
+        const noticeMsg: ChatMessage = {
+          id: nextMessageId('input-conflict'),
+          type: 'system',
+          content: noticeText,
+          timestamp: Date.now(),
+        };
+        const dropGhost = (messages: ChatMessage[]) =>
+          filterThinking(messages).filter(
+            (m) => !(rejectedId && m.id === rejectedId && m.type === 'user_input'),
+          );
+        if (conflictSessionId && get().sessionStates[conflictSessionId]) {
+          updateSession(conflictSessionId, (ss) => ({
+            messages: [...dropGhost(ss.messages), noticeMsg],
+            streamingMessageId:
+              ss.streamingMessageId === 'pending' ? null : ss.streamingMessageId,
+          }));
+        } else {
+          get().addMessage(noticeMsg);
+        }
       } else if (parsed.category !== 'crash') {
         if (parsed.code === 'SESSION_TOKEN_MISMATCH' && parsed.boundSessionName) {
           showBoundSessionMismatchAlert(
@@ -2815,6 +2852,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
       } else if (!primarySessionId || primarySessionId === 'default') {
         set({ primaryClientId });
+      }
+      break;
+    }
+
+    case 'session_role': {
+      // #5589 / #5281 — explicit primary-ownership. The server names the
+      // primary; we derive THIS client's role by comparing it to our own id
+      // (learned from auth_ok, canonical source: useMultiClientStore.myClientId).
+      // Stored per-session on `sessionRole` so the SessionScreen can surface an
+      // observer banner / claim affordance. We also mirror `primaryClientId`
+      // (the raw pointer) so the existing presence UI stays in sync without
+      // depending on a separate legacy `primary_changed` arriving.
+      const myClientId = useMultiClientStore.getState().myClientId;
+      const role = sharedSessionRole(msg, myClientId);
+      if (role.sessionId && get().sessionStates[role.sessionId]) {
+        updateSession(role.sessionId, () => ({
+          sessionRole: role.role,
+          primaryClientId: role.primaryClientId,
+        }));
       }
       break;
     }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -416,6 +416,12 @@ export interface CreateSessionOptions {
  */
 export interface MultiClientSessionActions {
   switchSession: (sessionId: string, options?: { serverNotify?: boolean; haptic?: boolean }) => void;
+  /**
+   * #5589 / #5281 — request primary (driver) ownership of a shared session.
+   * `force` overrides the current owner (operator-driven take-over). The
+   * resulting `session_role` broadcast is the authoritative role update.
+   */
+  claimPrimary: (sessionId: string, options?: { force?: boolean }) => void;
   createSession: (opts: CreateSessionOptions) => void;
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -182,6 +182,14 @@ export function App() {
   // #5281 ①.3 — global primary (last-driver) fallback for the pre-session /
   // 'default' case; per-session primary is read from sessionStates below.
   const globalPrimaryClientId = useConnectionStore(s => s.primaryClientId)
+  // #5589 / #5281 — this client's explicit role for the active session, derived
+  // from the server's `session_role` broadcast. Drives the ViewersIndicator's
+  // observer state + take-over affordance.
+  const activeSessionRole = useConnectionStore(s => {
+    const id = s.activeSessionId
+    return id && s.sessionStates[id] ? s.sessionStates[id].sessionRole : null
+  })
+  const claimPrimary = useConnectionStore(s => s.claimPrimary)
   const pairingRefreshedCount = useConnectionStore(s => s.pairingRefreshedCount)
   // #4497: server-advertised stream-stall window — threaded into the
   // StreamStallChip render path so the headline humanises to e.g.
@@ -1674,6 +1682,8 @@ export function App() {
           tunnelUrl={null}
           connectedClients={connectedClients}
           activePrimaryClientId={resolveActivePrimaryClientId(activeSessionId, sessionStates, globalPrimaryClientId)}
+          activeSessionRole={activeSessionRole}
+          onTakeOverPrimary={() => { if (activeSessionId) claimPrimary(activeSessionId, { force: true }) }}
           onFilterChange={setSidebarFilter}
           onSessionClick={handleSwitchSession}
           onResumeSession={resumeConversation}

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@
  * Collapsible with Cmd+B toggle.
  */
 import { useState, useCallback, useRef, useMemo } from 'react'
-import type { CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/store-core'
+import type { CumulativeUsage, SessionInfo, SessionVisualStatus, SessionRole } from '@chroxy/store-core'
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
@@ -74,6 +74,10 @@ export interface SidebarProps {
   connectedClients: ConnectedClient[]
   /** Active session's primary (last-driver) client id, or null. */
   activePrimaryClientId: string | null
+  /** #5589 / #5281 — this client's explicit role for the active session. */
+  activeSessionRole?: SessionRole | null
+  /** #5589 / #5281 — force-claim primary for the active session (take over). */
+  onTakeOverPrimary?: () => void
   onFilterChange: (value: string) => void
   onSessionClick: (sessionId: string) => void
   onResumeSession: (conversationId: string, cwd?: string) => void
@@ -125,6 +129,8 @@ export function Sidebar({
   tunnelUrl,
   connectedClients,
   activePrimaryClientId,
+  activeSessionRole,
+  onTakeOverPrimary,
   onFilterChange,
   onSessionClick,
   onResumeSession,
@@ -986,6 +992,8 @@ export function Sidebar({
               clients={connectedClients}
               primaryClientId={activePrimaryClientId}
               connected={serverStatus === 'connected'}
+              sessionRole={activeSessionRole ?? null}
+              onTakeOver={onTakeOverPrimary}
             />
           </div>
         </>

--- a/packages/dashboard/src/components/ViewersIndicator.test.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.test.tsx
@@ -1,7 +1,7 @@
 /**
  * ViewersIndicator (#5281 ①.3) — shared-session presence surface tests.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { ViewersIndicator, resolveActivePrimaryClientId } from './ViewersIndicator'
 import type { ConnectedClient } from '../store/types'
@@ -183,6 +183,70 @@ describe('ViewersIndicator', () => {
       'title',
       '2 clients sharing this session',
     )
+  })
+
+  // #5589 / #5281 — observer-role surfacing.
+  describe('observer role (#5589)', () => {
+    it('shows an "Observing" badge on the trigger when this client is an observer', () => {
+      render(
+        <ViewersIndicator
+          connected
+          clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1', deviceName: 'iPhone' })]}
+          primaryClientId="c1"
+          sessionRole="observer"
+        />,
+      )
+      expect(screen.getByTestId('viewers-observing-badge')).toHaveTextContent('Observing')
+      // The trigger names the driver in its accessible name + title.
+      expect(screen.getByTestId('viewers-indicator-trigger')).toHaveAttribute(
+        'title',
+        'Observing — iPhone is driving',
+      )
+    })
+
+    it('does NOT show the observing badge when this client is primary', () => {
+      render(
+        <ViewersIndicator
+          connected
+          clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+          primaryClientId="c0"
+          sessionRole="primary"
+        />,
+      )
+      expect(screen.queryByTestId('viewers-observing-badge')).not.toBeInTheDocument()
+    })
+
+    it('renders a Take over button in the popover and fires onTakeOver', () => {
+      const onTakeOver = vi.fn()
+      render(
+        <ViewersIndicator
+          connected
+          clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1', deviceName: 'iPhone' })]}
+          primaryClientId="c1"
+          sessionRole="observer"
+          onTakeOver={onTakeOver}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+      const btn = screen.getByTestId('viewers-takeover-button')
+      expect(screen.getByTestId('viewers-observing-footer')).toHaveTextContent('iPhone is driving')
+      fireEvent.click(btn)
+      expect(onTakeOver).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows no Take over affordance for a primary/unclaimed session', () => {
+      render(
+        <ViewersIndicator
+          connected
+          clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+          primaryClientId={null}
+          sessionRole="unclaimed"
+        />,
+      )
+      fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+      expect(screen.queryByTestId('viewers-takeover-button')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('viewers-observing-footer')).not.toBeInTheDocument()
+    })
   })
 
   it('swaps the solo label for the interactive chip when a second device joins', () => {

--- a/packages/dashboard/src/components/ViewersIndicator.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.tsx
@@ -19,6 +19,7 @@
  * session is genuinely shared (≥2 devices).
  */
 import { useEffect, useId, useRef, useState } from 'react'
+import type { SessionRole } from '@chroxy/store-core'
 import type { ConnectedClient } from '../store/types'
 
 export interface ViewersIndicatorProps {
@@ -31,6 +32,15 @@ export interface ViewersIndicatorProps {
   primaryClientId: string | null
   /** Footer renders nothing useful while disconnected; mirrors the old gate. */
   connected: boolean
+  /**
+   * #5589 / #5281 — THIS client's explicit role for the active session. When
+   * `'observer'`, the trigger gains an "Observing" badge and the popover gains
+   * a "Take over" affordance. Null/undefined or `'primary'`/`'unclaimed'`
+   * render the prior neutral presence UI.
+   */
+  sessionRole?: SessionRole | null
+  /** #5589 / #5281 — force-claim primary (take over) for the active session. */
+  onTakeOver?: () => void
 }
 
 function deviceGlyph(type: ConnectedClient['deviceType']): string {
@@ -71,7 +81,7 @@ export function resolveActivePrimaryClientId(
   return globalPrimaryClientId
 }
 
-export function ViewersIndicator({ clients, primaryClientId, connected }: ViewersIndicatorProps) {
+export function ViewersIndicator({ clients, primaryClientId, connected, sessionRole, onTakeOver }: ViewersIndicatorProps) {
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
@@ -113,6 +123,9 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
   if (total === 0) return null
 
   const countText = `${total} client${total === 1 ? '' : 's'}`
+  // #5589 / #5281 — this client is read-only-while-running because ANOTHER
+  // device holds primary. Surfaced unobtrusively on the trigger + popover.
+  const isObserving = sessionRole === 'observer'
 
   // Solo: keep the plain, non-interactive label the footer always showed.
   if (total === 1) {
@@ -123,8 +136,15 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
     )
   }
 
+  // Resolve the driving device's display name for the observer copy.
+  const driver = primaryClientId ? clients.find(c => c.clientId === primaryClientId) : null
+  const driverLabel = driver ? clientLabel(driver) : 'another device'
+
   return (
-    <div className="viewers-indicator sidebar-client-count" data-testid="viewers-indicator">
+    <div
+      className={`viewers-indicator sidebar-client-count${isObserving ? ' observing' : ''}`}
+      data-testid="viewers-indicator"
+    >
       <button
         ref={triggerRef}
         type="button"
@@ -136,12 +156,22 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
         aria-controls={popoverId}
         // The visible content is a decorative glyph + bare number, which a
         // screen reader would announce as just "2" — give the control an
-        // explicit name describing what it does.
-        aria-label={`${countText} sharing this session — show devices`}
-        title={`${countText} sharing this session`}
+        // explicit name describing what it does. When observing, fold the role
+        // into the name so a screen reader announces it too.
+        aria-label={
+          isObserving
+            ? `Observing — ${driverLabel} is driving. ${countText} sharing this session — show devices`
+            : `${countText} sharing this session — show devices`
+        }
+        title={isObserving ? `Observing — ${driverLabel} is driving` : `${countText} sharing this session`}
       >
         <span className="viewers-trigger-glyph" aria-hidden="true">{'\u{1F465}'}</span>
         <span className="viewers-trigger-count">{total}</span>
+        {isObserving && (
+          <span className="viewers-observing-badge" data-testid="viewers-observing-badge">
+            Observing
+          </span>
+        )}
       </button>
       {open && (
         <div
@@ -187,6 +217,24 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
               )
             })}
           </ul>
+          {isObserving && (
+            <div className="viewers-observing-footer" data-testid="viewers-observing-footer">
+              <p className="viewers-observing-note">
+                {driverLabel} is driving. Your input is rejected while the agent is
+                busy — take over to drive.
+              </p>
+              {onTakeOver && (
+                <button
+                  type="button"
+                  className="viewers-takeover-button"
+                  data-testid="viewers-takeover-button"
+                  onClick={() => { onTakeOver(); setOpen(false) }}
+                >
+                  Take over
+                </button>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1140,6 +1140,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       isPlanPending: false,
       planAllowedPrompts: EMPTY_PROMPTS,
       primaryClientId: null,
+      // #5589 / #5281: null until the first session_role for this session
+      // arrives (the UI treats null as unclaimed).
+      sessionRole: null,
       conversationId: null,
       sessionContext: null,
       mcpServers: EMPTY_MCP_SERVERS,
@@ -2686,6 +2689,22 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   // Session actions
+
+  // #5589 / #5281 — explicitly request primary (driver) ownership of a session.
+  // `force: true` overrides the current owner (operator-driven take-over);
+  // without it a claim another device holds is rejected with a PRIMARY_HELD
+  // `session_error` (input_conflict), surfaced as a calm notice. The resulting
+  // `session_role` broadcast is the authoritative role update.
+  claimPrimary: (sessionId: string, options?: { force?: boolean }) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'claim_primary',
+        sessionId,
+        ...(options?.force ? { force: true } : {}),
+      });
+    }
+  },
 
   switchSession: (sessionId: string) => {
     const { socket, activeSessionId, sessionStates } = get();

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -854,6 +854,100 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  // #5589 / #5281 — explicit primary-ownership. The server names the primary
+  // (`primaryClientId`); the dashboard derives THIS client's role by comparing
+  // it to its own id (`myClientId`) and stores both per-session.
+  describe('session_role dispatch (#5589 / #5281)', () => {
+    it('derives observer when another device holds primary', () => {
+      store = createMockStore(baseState({
+        myClientId: 'me',
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      }))
+      setStore(store)
+      handleMessage(
+        { type: 'session_role', sessionId: 's1', primaryClientId: 'other' },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.sessionRole).toBe('observer')
+      expect(ss.primaryClientId).toBe('other')
+    })
+
+    it('derives primary when this device holds primary', () => {
+      store = createMockStore(baseState({
+        myClientId: 'me',
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      }))
+      setStore(store)
+      handleMessage(
+        { type: 'session_role', sessionId: 's1', primaryClientId: 'me' },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.sessionRole).toBe('primary')
+      expect(ss.primaryClientId).toBe('me')
+    })
+
+    it('derives unclaimed when the slot is vacated (nobody-until-claim)', () => {
+      store = createMockStore(baseState({
+        myClientId: 'me',
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: { ...createEmptySessionState(), messages: [], sessionRole: 'observer', primaryClientId: 'other' },
+        },
+      }))
+      setStore(store)
+      handleMessage(
+        { type: 'session_role', sessionId: 's1', primaryClientId: null },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.sessionRole).toBe('unclaimed')
+      expect(ss.primaryClientId).toBeNull()
+    })
+
+    it('ignores a session_role for a session not in the local store', () => {
+      store = createMockStore(baseState({ myClientId: 'me', sessionStates: {} }))
+      setStore(store)
+      handleMessage(
+        { type: 'session_role', sessionId: 'ghost', primaryClientId: 'other' },
+        ctx() as any,
+      )
+      expect((store.getState() as any).sessionStates.ghost).toBeUndefined()
+    })
+  })
+
+  // #5589 / #5281 — a `claim_primary` rejection (PRIMARY_HELD) arrives as a
+  // `session_error` of category input_conflict, so it rides the same calm
+  // notice path as a busy-session conflict (no red alert).
+  describe('PRIMARY_HELD claim rejection (#5589)', () => {
+    it('surfaces the rejection as a calm info notice, not a red error', () => {
+      store = createMockStore(baseState({
+        myClientId: 'me',
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      }))
+      setStore(store)
+      const reason = 'Another device is the primary for this session. Request a hand-off or wait for it to release.'
+      handleMessage(
+        {
+          type: 'session_error',
+          category: 'input_conflict',
+          sessionId: 's1',
+          code: 'PRIMARY_HELD',
+          primaryClientId: 'other',
+          message: reason,
+        },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.serverErrors).toEqual([])
+      expect(state._infoNotifications).toEqual([reason])
+    })
+  })
+
   // #4878 — user-initiated Stop confirmation. The wire path was wired by
   // PR #4868; this is the dashboard UX follow-up. Renders a quiet info
   // toast (NOT the red `addServerError` reserved for crashes), so the

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -53,6 +53,7 @@ import {
   handleClientJoined as sharedClientJoined,
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
+  handleSessionRole as sharedSessionRole,
   handleClientFocusChanged as sharedClientFocusChanged,
   // conversation_id migrated to the shared dispatch table (#5556)
   handleHistoryReplayStart as sharedHistoryReplayStart,
@@ -3802,6 +3803,26 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
       } else if (!primarySessionId || primarySessionId === 'default') {
         set({ primaryClientId });
+      }
+      break;
+    }
+
+    case 'session_role': {
+      // #5589 / #5281 — explicit primary-ownership. Derive THIS client's role
+      // by comparing the server-named primary to our own id (from auth_ok,
+      // stored flat as `myClientId`). Stored per-session on `sessionRole` to
+      // drive the ViewersIndicator's observer state + claim affordance, and we
+      // mirror `primaryClientId` so presence stays in sync without depending on
+      // a separate legacy `primary_changed`. Kept platform-local (not in the
+      // shared dispatch table) for the same reason `primary_changed` is — the
+      // app's dedicated multi-client store vs the dashboard's flat+per-session
+      // slots diverge (see dispatch-table.ts divergent-cases note).
+      const role = sharedSessionRole(msg, get().myClientId);
+      if (role.sessionId && get().sessionStates[role.sessionId]) {
+        updateSession(role.sessionId, () => ({
+          sessionRole: role.role,
+          primaryClientId: role.primaryClientId,
+        }));
       }
       break;
     }

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1015,6 +1015,12 @@ export interface ConnectionState {
 
   // Session actions
   switchSession: (sessionId: string) => void;
+  /**
+   * #5589 / #5281 — request primary (driver) ownership of a shared session.
+   * `force` overrides the current owner (operator-driven take-over). The
+   * resulting `session_role` broadcast is the authoritative role update.
+   */
+  claimPrimary: (sessionId: string, options?: { force?: boolean }) => void;
   createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string; skipPermissions?: boolean }) => void;
   destroySession: (sessionId: string) => void;
   renameSession: (sessionId: string, name: string) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1553,6 +1553,48 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent, var(--text-primary));
 }
 
+/* #5589 / #5281 — observer-role surface on the shared-session presence chip. */
+.viewers-observing-badge {
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--accent-muted, var(--border-primary));
+  color: var(--accent, var(--text-primary));
+}
+
+.viewers-observing-footer {
+  border-top: 1px solid var(--border-primary);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.viewers-observing-note {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.viewers-takeover-button {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border: 1px solid var(--accent, var(--border-primary));
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent, var(--text-primary));
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.viewers-takeover-button:hover {
+  background: var(--accent-muted, var(--border-primary));
+}
+
 /* ---- Session Bar ---- */
 .session-bar {
   display: flex;

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -369,6 +369,7 @@ function _isSecureRequest(req) {
  *   { type: 'checkpoint_list', sessionId, checkpoints }   — list of checkpoints
  *   { type: 'checkpoint_restored', checkpointId, newSessionId, name } — checkpoint restored (new session created)
  *   { type: 'primary_changed', sessionId, clientId } — last-writer-wins primary changed (null on disconnect)
+ *   { type: 'session_role', sessionId, primaryClientId } — #5589/#5281: explicit primary-ownership; client derives its role (primary iff primaryClientId === own clientId, observer if another holds it, null = unclaimed)
  *   { type: 'pong' }                                    — heartbeat response
  *   { type: 'permission_expired', requestId, sessionId, message }  — permission response could not be routed (expired/handled)
  *   { type: 'token_rotated', expiresAt }                — API token was rotated, client must re-authenticate

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -38,6 +38,7 @@ import {
   handleClientJoined,
   handleClientLeft,
   handlePrimaryChanged,
+  handleSessionRole,
   handleClientFocusChanged,
   handleConversationId,
   handleConversationsList,
@@ -2074,6 +2075,66 @@ describe('handlePrimaryChanged', () => {
     expect(
       handlePrimaryChanged({ sessionId: 'default', clientId: 'c' }),
     ).toEqual({ sessionId: 'default', primaryClientId: 'c' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionRole (#5589 / #5281)
+// ---------------------------------------------------------------------------
+describe('handleSessionRole', () => {
+  it('derives primary when the primary is THIS client', () => {
+    expect(
+      handleSessionRole({ sessionId: 's1', primaryClientId: 'me' }, 'me'),
+    ).toEqual({ sessionId: 's1', primaryClientId: 'me', role: 'primary' })
+  })
+
+  it('derives observer when another client is primary', () => {
+    expect(
+      handleSessionRole({ sessionId: 's1', primaryClientId: 'other' }, 'me'),
+    ).toEqual({ sessionId: 's1', primaryClientId: 'other', role: 'observer' })
+  })
+
+  it('derives unclaimed when primaryClientId is null (nobody-until-claim)', () => {
+    expect(
+      handleSessionRole({ sessionId: 's1', primaryClientId: null }, 'me'),
+    ).toEqual({ sessionId: 's1', primaryClientId: null, role: 'unclaimed' })
+  })
+
+  it('derives unclaimed when primaryClientId is missing', () => {
+    expect(handleSessionRole({ sessionId: 's1' }, 'me')).toEqual({
+      sessionId: 's1',
+      primaryClientId: null,
+      role: 'unclaimed',
+    })
+  })
+
+  it('treats a known primary as observer when own id is unknown (pre-auth race)', () => {
+    expect(
+      handleSessionRole({ sessionId: 's1', primaryClientId: 'other' }, null),
+    ).toEqual({ sessionId: 's1', primaryClientId: 'other', role: 'observer' })
+  })
+
+  it('stays unclaimed when own id is unknown and the slot is empty', () => {
+    expect(
+      handleSessionRole({ sessionId: 's1', primaryClientId: null }, null),
+    ).toEqual({ sessionId: 's1', primaryClientId: null, role: 'unclaimed' })
+  })
+
+  it('returns null sessionId when missing or non-string', () => {
+    expect(handleSessionRole({ primaryClientId: 'me' }, 'me')).toEqual({
+      sessionId: null,
+      primaryClientId: 'me',
+      role: 'primary',
+    })
+    expect(
+      handleSessionRole({ sessionId: 42, primaryClientId: 'me' }, 'me'),
+    ).toEqual({ sessionId: null, primaryClientId: 'me', role: 'primary' })
+  })
+
+  it('returns null primaryClientId when non-string', () => {
+    expect(
+      handleSessionRole({ sessionId: 's1', primaryClientId: 42 }, 'me'),
+    ).toEqual({ sessionId: 's1', primaryClientId: null, role: 'unclaimed' })
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -31,6 +31,7 @@ import type {
   ServerError,
   SessionInfo,
   SessionIntervention,
+  SessionRole,
   ToolResultImage,
   WebTask,
 } from '../types'
@@ -1501,6 +1502,64 @@ export function handlePrimaryChanged(msg: Record<string, unknown>): PrimaryChang
     sessionId: typeof msg.sessionId === 'string' ? msg.sessionId : null,
     primaryClientId: typeof msg.clientId === 'string' ? msg.clientId : null,
   }
+}
+
+// ---------------------------------------------------------------------------
+// session_role (#5589 / #5281)
+// ---------------------------------------------------------------------------
+
+export interface SessionRoleInfo {
+  /**
+   * Target session id. Unlike `primary_changed`, the server always sends
+   * `session_role` with an explicit `sessionId` (it is broadcast per-session
+   * via `_broadcastToSession`); null only on a malformed payload.
+   */
+  sessionId: string | null
+  /**
+   * The session's primary client id, or null when the session is unclaimed
+   * (nobody-until-claim — e.g. after the previous primary disconnected).
+   */
+  primaryClientId: string | null
+  /**
+   * THIS client's role, derived from `primaryClientId` vs the client's own id:
+   *   - `'primary'`   — this client owns the session (drives input)
+   *   - `'observer'`  — another client owns it (read-only while running; can
+   *                     still adopt an idle session per #5589)
+   *   - `'unclaimed'` — nobody owns it yet
+   */
+  role: SessionRole
+}
+
+/**
+ * Extract THIS client's role from a `session_role` message (#5589).
+ *
+ * Pure derivation: the server names the primary (`primaryClientId`, null when
+ * unclaimed); the client computes its own role by comparing that to its own
+ * id (`myClientId`, learned from `auth_ok`). Identical across both clients —
+ * the storage of the result diverges (the app's dedicated `useMultiClientStore`
+ * vs the dashboard's flat + per-session slots), so only this parse is shared,
+ * mirroring `handlePrimaryChanged`.
+ *
+ * When `myClientId` is unknown (null — e.g. a pre-auth race) the role is
+ * `'unclaimed'` if the slot is empty, else `'observer'` (we cannot be the
+ * primary if we don't yet know our own id).
+ */
+export function handleSessionRole(
+  msg: Record<string, unknown>,
+  myClientId: string | null,
+): SessionRoleInfo {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const primaryClientId =
+    typeof msg.primaryClientId === 'string' ? msg.primaryClientId : null
+  let role: SessionRole
+  if (!primaryClientId) {
+    role = 'unclaimed'
+  } else if (myClientId && primaryClientId === myClientId) {
+    role = 'primary'
+  } else {
+    role = 'observer'
+  }
+  return { sessionId, primaryClientId, role }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -46,6 +46,8 @@ export {
 } from './replay-reconcile'
 
 export type {
+  // #5589 / #5281 — this client's derived role for a shared session
+  SessionRole,
   MessageAttachment,
   ToolResultImage,
   ChatMessage,
@@ -369,6 +371,7 @@ export type {
   ClientJoinedResult,
   ClientLeftResult,
   PrimaryChanged,
+  SessionRoleInfo,
   ClientFocusChanged,
   ConversationIdPayload,
   HistoryReplayStartPayload,
@@ -458,6 +461,7 @@ export {
   handleClientJoined,
   handleClientLeft,
   handlePrimaryChanged,
+  handleSessionRole,
   handleClientFocusChanged,
   handleConversationId,
   handleConversationsList,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -758,7 +758,7 @@ export interface SessionIntervention {
  * #5589 / #5281 — THIS client's role for a shared session, derived from the
  * server's `session_role` broadcast. See `handleSessionRole`.
  */
-export type SessionRole = 'primary' | 'observer' | 'unclaimed'
+export type SessionRole = 'primary' | 'observer' | 'unclaimed';
 
 /**
  * Base session state shared by both the mobile app and web dashboard.

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -755,6 +755,12 @@ export interface SessionIntervention {
 }
 
 /**
+ * #5589 / #5281 — THIS client's role for a shared session, derived from the
+ * server's `session_role` broadcast. See `handleSessionRole`.
+ */
+export type SessionRole = 'primary' | 'observer' | 'unclaimed'
+
+/**
  * Base session state shared by both the mobile app and web dashboard.
  *
  * Each consumer extends this with platform-specific fields:
@@ -874,6 +880,17 @@ export interface BaseSessionState {
   isPlanPending: boolean;
   planAllowedPrompts: { tool: string; prompt: string }[];
   primaryClientId: string | null;
+  /**
+   * #5589 / #5281 — THIS client's explicit role for this session, derived from
+   * the server's `session_role` broadcast (`primaryClientId` vs own clientId):
+   *   - `'primary'`   — this client owns the session (drives input)
+   *   - `'observer'`  — another client owns it (input rejected while running)
+   *   - `'unclaimed'` — nobody owns it yet (first input/claim takes over)
+   * `null` until the first `session_role` for this session arrives (treated as
+   * unclaimed by the UI). Distinct from `primaryClientId` (the raw "who owns
+   * it" pointer driven by both `primary_changed` and `session_role`).
+   */
+  sessionRole: SessionRole | null;
   conversationId: string | null;
   sessionContext: SessionContext | null;
   mcpServers: McpServer[];

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -39,6 +39,7 @@ describe('createEmptyBaseSessionState', () => {
       isPlanPending: false,
       planAllowedPrompts: [],
       primaryClientId: null,
+      sessionRole: null,
       conversationId: null,
       sessionContext: null,
       mcpServers: [],

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -96,6 +96,9 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     isPlanPending: false,
     planAllowedPrompts: [],
     primaryClientId: null,
+    // #5589 / #5281: null until the first session_role for this session arrives
+    // (the UI treats null as unclaimed).
+    sessionRole: null,
     conversationId: null,
     sessionContext: null,
     mcpServers: [],


### PR DESCRIPTION
Builds on the server's explicit primary-ownership semantics from #5589: the new `session_role` broadcast (`{type:'session_role', sessionId, primaryClientId}`) was handled by **neither** client — both routed it to the unknown-type `default:` and silently ignored it (#5595 dispatch-table review). This makes both clients role-aware.

## How the client learns its own id

The server already issues a self-identifying `clientId` in the **`auth_ok`** payload (`ws-server.js` `auth_ok`), and both clients already capture it:
- store-core's `parseAuthOkContext` extracts `myClientId` from `auth_ok.clientId`.
- App: stored canonically in `useMultiClientStore.myClientId` (set on `auth_ok`).
- Dashboard: stored flat as `myClientId`.

So no new wire field was needed — the role is derived client-side by comparing the server-named `primaryClientId` to the already-known own id.

## Shared vs platform-local decision

**Shared parser, platform-local storage/dispatch.** The role derivation is identical across clients, so it lives in store-core as `handleSessionRole(msg, myClientId)` (mirrors the existing `handlePrimaryChanged`), returning `{ sessionId, primaryClientId, role }` where role is `primary` (own id holds it), `observer` (another holds it), or `unclaimed` (null).

The `session_role` **case itself stays platform-local** (each client's own switch), NOT in the shared dispatch table — for the same reason `primary_changed`/`client_joined`/`client_left` are explicitly excluded there (see `dispatch-table.ts` divergent-cases note): the app uses a dedicated `useMultiClientStore` for its own id while the dashboard reads it flat, and the two write role state into different store shapes. A new per-session `sessionRole` field was added to the shared `BaseSessionState` so both store it uniformly.

## The three UI surfaces

1. **Observer state** — App: new `ObserverBanner` ("Observing — <driver> is driving") in the SessionScreen, with the driver name resolved from the connected-clients roster. Dashboard: the existing `ViewersIndicator` gains an unobtrusive "Observing" badge on its trigger + an observing footer in its popover. Input is **not** disabled (the server lets an observer adopt an idle session per #5589's adoption semantics) — the state is just made legible.
2. **input_conflict / PRIMARY_HELD feedback** — A `claim_primary` rejection arrives as a `session_error` of `category: 'input_conflict'` (`code: PRIMARY_HELD`). The dashboard already routed input_conflict to a calm info-notice + ghost-drop (#5281 ①.3), so PRIMARY_HELD rides that for free. The app previously raised a loud generic `Alert` for all session_errors — added a matching calm branch (inline system notice + drop the stranded optimistic send).
3. **Claim/hand-off affordance** — both clients gain a `claimPrimary(sessionId, { force })` action. The observer UI exposes a minimal "Take over" button (sends `claim_primary { force: true }` for an explicit take-over).

Protocol: `claim_primary` (`ClaimPrimarySchema`) already shipped in #5589; verified present, no schema change needed. Added the `session_role` envelope line to the ws-server Server→Client doc comment (the cross-package handler-coverage contract derives `ServerMessageType` from it — without it both clients handling `session_role` tripped the contract).

## Tests

- store-core `handleSessionRole`: primary/observer/unclaimed derivation, missing/non-string fields, pre-auth (null own id) race.
- App: `session_role` → per-session role state; input_conflict + PRIMARY_HELD calm-notice surfacing (no Alert); `claimPrimary` wire payload (plain / force / socket-closed); ObserverBanner render + take-over.
- Dashboard: `session_role` → role state; PRIMARY_HELD calm notice; ViewersIndicator observing badge + Take-over button.

Full suites + typechecks green: store-core (1441), app (1780), dashboard (3572), protocol (282).

## Deferred (out of scope)

This is the role-AWARENESS + surfacing chunk. Deferred to #5281: the desktop-as-LAN-client connect affordance (①.2), the full shared-session-join UX (①.3), and mDNS discovery (③).

Related to #5281