### PR TITLE
fix(dashboard): dogfooding UX fixes — session modal, sidebar pairing, control room affordance

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -2436,12 +2436,13 @@ describe('App', () => {
       }
     }
 
-    // Open the Control Room and click the repo's actionable Investigate verdict
-    // tag — this stashes the repo's note as the pending seed and opens the
+    // Open the Control Room and click the repo's dedicated Investigate row
+    // action (#5608 — moved off the verdict badge onto an explicit button) —
+    // this stashes the repo's note as the pending seed and opens the
     // create-session modal.
     function stashSeedViaInvestigate() {
       fireEvent.click(screen.getByTestId('sidebar-panel-slot-launcher-control-room'))
-      fireEvent.click(screen.getByTestId('cr-verdict-investigate'))
+      fireEvent.click(screen.getByTestId('cr-action-investigate-alpha'))
       // Modal opened (mock renders its node only when open=true).
       expect(screen.getByTestId('create-session-modal-mock')).toBeInTheDocument()
     }

--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -766,14 +766,31 @@ describe('ControlRoomSection control actions (#5272)', () => {
   })
 })
 
-describe('ControlRoomSection investigate action (#5202)', () => {
-  it('renders the investigate verdict as a non-interactive span when no handler is wired', () => {
+describe('ControlRoomSection investigate action (#5202 / #5608)', () => {
+  // #5608 — the verdict badge is now a pure status indicator on EVERY row;
+  // the session-creating action moved to an explicit "Investigate" button in
+  // the row's actions cell (shown only for actionable verdicts).
+  it('renders every verdict badge as a non-interactive span, even with a handler', () => {
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onInvestigate={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('cr-verdict-investigate').tagName).toBe('SPAN')
+    expect(screen.getByTestId('cr-verdict-live').tagName).toBe('SPAN')
+    expect(screen.getByTestId('cr-verdict-onboarded').tagName).toBe('SPAN')
+  })
+
+  it('does not render an Investigate action when no handler is wired', () => {
     render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
-    const tag = screen.getByTestId('cr-verdict-investigate')
-    expect(tag.tagName).toBe('SPAN')
+    expect(screen.queryByTestId('cr-action-investigate-medlens')).toBeNull()
   })
 
-  it('renders the investigate verdict as a button when onInvestigate is provided', () => {
+  it('renders the Investigate action button only for actionable verdicts', () => {
     render(
       <ControlRoomSection
         snapshot={makeSnapshot()}
@@ -783,12 +800,15 @@ describe('ControlRoomSection investigate action (#5202)', () => {
         onInvestigate={() => {}}
       />,
     )
-    const tag = screen.getByTestId('cr-verdict-investigate')
-    expect(tag.tagName).toBe('BUTTON')
-    expect(tag).toHaveClass('cr-tag-action')
+    // medlens is the investigate-verdict repo in the fixture → gets the action.
+    const btn = screen.getByTestId('cr-action-investigate-medlens')
+    expect(btn.tagName).toBe('BUTTON')
+    // Non-actionable verdicts (live=chroxy, onboarded=no-it-all) get no action.
+    expect(screen.queryByTestId('cr-action-investigate-chroxy')).toBeNull()
+    expect(screen.queryByTestId('cr-action-investigate-no-it-all')).toBeNull()
   })
 
-  it('gives the investigate button a per-row accessible name including the repo', () => {
+  it('gives the Investigate button a per-row accessible name including the repo', () => {
     render(
       <ControlRoomSection
         snapshot={makeSnapshot()}
@@ -798,8 +818,8 @@ describe('ControlRoomSection investigate action (#5202)', () => {
         onInvestigate={() => {}}
       />,
     )
-    const tag = screen.getByTestId('cr-verdict-investigate')
-    expect(tag).toHaveAttribute('aria-label', expect.stringContaining('medlens'))
+    const btn = screen.getByTestId('cr-action-investigate-medlens')
+    expect(btn).toHaveAttribute('aria-label', expect.stringContaining('medlens'))
   })
 
   it('calls onInvestigate with the repo cwd, name, and reason note on click', () => {
@@ -813,7 +833,7 @@ describe('ControlRoomSection investigate action (#5202)', () => {
         onInvestigate={onInvestigate}
       />,
     )
-    fireEvent.click(screen.getByTestId('cr-verdict-investigate'))
+    fireEvent.click(screen.getByTestId('cr-action-investigate-medlens'))
     expect(onInvestigate).toHaveBeenCalledWith({
       cwd: '/Users/me/Projects/medlens',
       name: 'medlens',
@@ -848,26 +868,12 @@ describe('ControlRoomSection investigate action (#5202)', () => {
     render(
       <ControlRoomSection snapshot={snap} loading={false} onRefresh={() => {}} now={() => NOW} onInvestigate={onInvestigate} />,
     )
-    fireEvent.click(screen.getByTestId('cr-verdict-investigate'))
+    fireEvent.click(screen.getByTestId('cr-action-investigate-noteless'))
     expect(onInvestigate).toHaveBeenCalledWith({
       cwd: '/Users/me/Projects/noteless',
       name: 'noteless',
       reason: '',
     })
-  })
-
-  it('leaves non-actionable verdicts (live, onboarded) as plain spans even with a handler', () => {
-    render(
-      <ControlRoomSection
-        snapshot={makeSnapshot()}
-        loading={false}
-        onRefresh={() => {}}
-        now={() => NOW}
-        onInvestigate={() => {}}
-      />,
-    )
-    expect(screen.getByTestId('cr-verdict-live').tagName).toBe('SPAN')
-    expect(screen.getByTestId('cr-verdict-onboarded').tagName).toBe('SPAN')
   })
 })
 

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -380,41 +380,16 @@ const SUMMARY_CHIPS: readonly SummaryChip[] = [
   { key: 'recent', label: 'Recent / your call', accent: 'warn' },
 ]
 
-function VerdictTag({
-  repo,
-  onInvestigate,
-}: {
-  repo: RepoStatus
-  /** #5202 — when provided and the verdict is actionable, the tag is a button. */
-  onInvestigate?: (req: RepoInvestigateRequest) => void
-}) {
+function VerdictTag({ repo }: { repo: RepoStatus }) {
   const { verdict } = repo
   const accent = VERDICT_ACCENT[verdict]
-  // #5202 — the only wired action today is Investigate. Keep the dispatch
-  // table-driven so adding e.g. an `abandoned` action is a one-line change.
-  const actionable = ACTIONABLE_VERDICTS[verdict] === true && !!onInvestigate
-
-  if (actionable) {
-    return (
-      <button
-        type="button"
-        className={`cr-tag cr-tag-${accent} cr-tag-action`}
-        data-testid={`cr-verdict-${verdict}`}
-        data-accent={accent}
-        // #5202 — the visible label is just "Investigate", identical on every
-        // row; give screen readers a per-row accessible name (the title tooltip
-        // is not a reliable accessible-name source).
-        aria-label={`Investigate ${repo.name} — open a session in ${repo.path}`}
-        title={`Investigate ${repo.name} — open a session in ${repo.path}`}
-        onClick={() =>
-          onInvestigate!({ cwd: repo.path, name: repo.name, reason: repo.note ?? '' })
-        }
-      >
-        {VERDICT_LABEL[verdict]}
-      </button>
-    )
-  }
-
+  // #5608 — verdict tags are pure status indicators. Pre-#5608 the
+  // `investigate` tag was secretly a button that opened the create-session
+  // modal (#5202), which read as an inconsistent affordance: one badge was
+  // clickable and the others weren't, with nothing to signal which. The
+  // session-creating action now lives on an explicit, discoverable "Investigate"
+  // button in the row's actions cell (see RowActions) — so every badge here is
+  // just a status chip again.
   return (
     <span
       className={`cr-tag cr-tag-${accent}`}
@@ -596,7 +571,11 @@ function AttributionCell({ attribution }: { attribution: boolean | null }) {
  * #5507 — adds an "Open session" action (shown on every row when `onOpenSession`
  * is wired) that opens the create-session modal pre-filled with this repo's cwd.
  */
-function RowActions({ repo, onOpenSession, onConfigureRepo }: { repo: RepoStatus; onOpenSession?: (req: RepoOpenSessionRequest) => void; onConfigureRepo?: (req: { path: string; name: string }) => void }) {
+function RowActions({ repo, onInvestigate, onOpenSession, onConfigureRepo }: { repo: RepoStatus; onInvestigate?: (req: RepoInvestigateRequest) => void; onOpenSession?: (req: RepoOpenSessionRequest) => void; onConfigureRepo?: (req: { path: string; name: string }) => void }) {
+  // #5608 — the Investigate action is shown only for actionable verdicts
+  // (currently just `investigate`). Table-driven via ACTIONABLE_VERDICTS so
+  // adding e.g. an `abandoned` action stays a one-line change.
+  const investigable = ACTIONABLE_VERDICTS[repo.verdict] === true && !!onInvestigate
   const [copied, setCopied] = useState(false)
   const copyPath = useCallback(() => {
     // Route through the shared clipboard helper, which uses the Tauri plugin
@@ -633,6 +612,24 @@ function RowActions({ repo, onOpenSession, onConfigureRepo }: { repo: RepoStatus
       >
         {copied ? 'Copied' : 'Copy path'}
       </button>
+      {investigable && (
+        // #5608 — explicit, discoverable session-creating affordance for an
+        // actionable verdict, replacing the pre-#5608 clickable `investigate`
+        // badge. Same plumbing as the badge used to have: opens the
+        // create-session modal pre-filled with the repo cwd AND seeds the
+        // composer with the investigation reason (the repo's `↳` note) — that
+        // reason seed is what distinguishes Investigate from plain Open session.
+        <button
+          type="button"
+          className="cr-action cr-action-investigate"
+          data-testid={`cr-action-investigate-${repo.name}`}
+          aria-label={`Investigate ${repo.name} — open a session in ${repo.path}`}
+          title={`Investigate ${repo.name} — open a session in ${repo.path}`}
+          onClick={() => onInvestigate!({ cwd: repo.path, name: repo.name, reason: repo.note ?? '' })}
+        >
+          Investigate
+        </button>
+      )}
       {onOpenSession && (
         <button
           type="button"
@@ -750,7 +747,7 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onI
             <AheadBehindBadge repo={repo} />
           </div>
         </td>
-        <td><VerdictTag repo={repo} onInvestigate={onInvestigate} /></td>
+        <td><VerdictTag repo={repo} /></td>
         {/* #5201: ellipsis-truncate on an inner block element, not the <td>
             itself — text-overflow on display:table-cell is unreliable and can
             still let long content widen the column. The branch cell already
@@ -761,7 +758,7 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onI
         <PrCell repo={repo} />
         <AttributionCell attribution={repo.attribution} />
         <td className="cr-dim cr-last">{relativeLast(repo.lastTouched)}</td>
-        <RowActions repo={repo} onOpenSession={onOpenSession} onConfigureRepo={onConfigureRepo} />
+        <RowActions repo={repo} onInvestigate={onInvestigate} onOpenSession={onOpenSession} onConfigureRepo={onConfigureRepo} />
       </tr>
       {repo.note && (
         <tr className="cr-act" data-testid={`cr-note-row-${repo.name}`}>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5132,10 +5132,15 @@ button.sidebar-token-view-session-row:hover {
   border-top: 1px solid var(--border-primary);
 }
 
+/* #5606: lay Advanced fields out like the Provider row above — label + control
+   on one row, help text as full-width secondary text below the control.
+   flex-wrap + a full-width .form-hint (below) lets the hint break to its own
+   line instead of being squeezed into a tall narrow far-right column. */
 .advanced-section .form-field {
   display: flex;
   align-items: center;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 6px 10px;
   margin-bottom: 8px;
 }
 
@@ -5147,6 +5152,7 @@ button.sidebar-token-view-session-row:hover {
 
 .advanced-section select {
   flex: 1;
+  min-width: 0;
 }
 
 .advanced-section .form-field--checkbox {
@@ -5198,6 +5204,16 @@ button.sidebar-token-view-session-row:hover {
   font-size: 11px;
   color: var(--text-muted);
   margin-left: 22px;
+}
+
+/* #5606: in the Advanced section's wrapping form rows the hint must break to a
+   full-width line under the control (label + control share the first row).
+   Without flex-basis:100% the hint becomes a third flex child and collapses
+   into a tall sliver on the far right. Drop the global 22px indent so it lines
+   up with the label, matching the Provider billing note's full-width layout. */
+.advanced-section .form-field > .form-hint {
+  flex-basis: 100%;
+  margin-left: 0;
 }
 
 .provider-select {
@@ -7705,12 +7721,16 @@ button.sidebar-token-view-session-row:hover {
   color: var(--text-dim);
 }
 
+/* #5607: stack the discovered-server row vertically so the pairing actions
+   below the server info get the full sidebar width. The previous horizontal
+   layout (info | actions) pushed the action row past the sidebar edge, clipping
+   "Add with token…" with no way to reach it. */
 .server-discover-item {
   width: 100%;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
   padding: 6px 8px;
   border: 1px dashed var(--border-primary);
   border-radius: 6px;
@@ -7718,10 +7738,12 @@ button.sidebar-token-view-session-row:hover {
   text-align: left;
 }
 
-/* #5511 — per-daemon actions: primary "Request to pair" + token-entry fallback. */
+/* #5511 — per-daemon actions: primary "Request to pair" + token-entry fallback.
+   #5607 — wrap so both buttons stay reachable when the sidebar is too narrow to
+   fit them side by side. */
 .server-discover-actions {
   display: flex;
-  flex-shrink: 0;
+  flex-wrap: wrap;
   gap: 6px;
   align-items: center;
 }
@@ -9683,24 +9705,18 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-red);
 }
 
-/* #5202 — an actionable verdict tag rendered as a <button> (e.g. Investigate).
- * Inherits the .cr-tag look; resets button chrome and adds a clickable
- * affordance (pointer, hover lift, focus ring) so it reads as interactive. */
-.cr-tag-action {
-  cursor: pointer;
-  font: inherit;
-  font-family: var(--font-mono);
-  font-weight: 700;
-  font-size: 11px;
-  transition: filter 0.12s, box-shadow 0.12s;
+/* #5608 — the "Investigate" row action (a real .cr-action button now, replacing
+ * the pre-#5608 clickable verdict badge). Tinted amber to match the
+ * investigate/warn verdict accent so the contextual action reads at a glance,
+ * while sharing .cr-action's geometry with the other row actions. */
+.cr-action-investigate {
+  border-color: var(--accent-orange-border);
+  color: var(--accent-orange);
 }
-.cr-tag-action:hover {
-  filter: brightness(1.12);
-  box-shadow: 0 0 0 1px currentColor inset;
-}
-.cr-tag-action:focus-visible {
-  outline: 2px solid var(--border-focus);
-  outline-offset: 1px;
+.cr-action-investigate:hover {
+  border-color: var(--accent-orange);
+  color: var(--accent-orange);
+  background: var(--accent-orange-subtle);
 }
 
 


### PR DESCRIPTION
Three independent dashboard dogfooding bugs found in v0.9.46. All are dashboard-local and small, so they ship as **one cohesive PR**. The #5608 behavior change stayed small (it reuses the existing per-row actions cell and an already-present create-session affordance), so no split was warranted.

## #5606 — New Session modal Advanced layout

The Advanced disclosure laid out each field as a 3-child flex row (`label | control | hint`), so the permission-mode help text was squeezed into a tall, narrow far-right sliver (~1-2 words/line) and the rows had an awkward empty gap.

**Fix:** Advanced fields now match the Provider row above — `label + control` on one row, help text breaking to a **full-width** secondary line below the control (`flex-wrap` + `flex-basis: 100%` on `.form-hint`, the same pattern the Provider billing note uses). The worktree checkbox keeps its column layout so its label stays inline with the box. Reuses existing `.form-field` / `.form-hint` classes — no new ones invented.

## #5607 — Sidebar SERVERS pairing actions clipped after Discover on LAN

The discovered-server row was a horizontal `info | actions` flex with the action group `flex-shrink: 0` and `nowrap` buttons, so in the narrow sidebar "Add with token…" overflowed the right edge and was unreachable.

**Fix:** stack the row vertically (info on top, actions below at full sidebar width) and let the action row `flex-wrap` so both "Request to pair" and "Add with token…" stay reachable. Chose wrap/stack over horizontal scroll — cleaner in a narrow sidebar, as the issue prefers.

## #5608 — Control Room: inconsistent badge affordance

Only the `investigate` verdict badge opened the New Session modal (#5202); the other badges did nothing, so it was undiscoverable that one badge was special.

**Affordance choice (reporter's preferred option 1):** a **dedicated row-action button**, not a clickable project name. Rationale: the row already has an actions cell with "Open session" / "Copy path" / gear, so a new "Investigate" button there is consistent with the established affordance pattern and keeps the project-name cell free for its existing drill-down disclosure toggle. Verdict badges are now pure status spans on every row. The button preserves the investigation-reason composer seed that distinguishes Investigate from plain Open session, and is shown only for actionable verdicts (table-driven via `ACTIONABLE_VERDICTS`).

## Verification

- `tsc --noEmit` clean
- `npm run build` (vite) green
- `vitest run` — 3576 passed (188 files); updated the #5202 badge tests to assert the new dedicated-button affordance, and the App.test seed-leak helper to click the new button.

Closes #5606
Closes #5607
Closes #5608