### PR TITLE
feat(dashboard): push-to-talk — hold Space to dictate in the chat input

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2558,8 +2558,9 @@ describe('InputBar push-to-talk (#5610)', () => {
       />,
     )
 
-    // The transcript is spliced at the anchor (index 3), not appended at the end.
-    expect(captured).toBe('foo hello world')
+    // The transcript is spliced *in place* at the anchor (index 3): the prefix
+    // "foo" and the suffix "bar" both survive, with the transcript in between.
+    expect(captured).toBe('foo hello world bar')
   })
 
   it('cleans up the open mic when the input loses focus mid-recording', () => {

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2577,6 +2577,45 @@ describe('InputBar push-to-talk (#5610)', () => {
     expect(voice.stop).toHaveBeenCalledTimes(1)
   })
 
+  it('stops the mic on unmount mid-recording using the latest stop (not a stale closure)', () => {
+    vi.useFakeTimers()
+    // The engine — and therefore the memoised stop — is selected after mount,
+    // so the unmount cleanup must call the *current* stop, not the one captured
+    // on the first render. Re-render with a fresh stop before unmounting and
+    // assert that one is invoked.
+    const firstStop = vi.fn()
+    const start = vi.fn()
+    const { rerender, unmount } = render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={() => {}}
+        voiceInput={{ isRecording: false, isAvailable: true, transcript: '', start, stop: firstStop }}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(start).toHaveBeenCalledTimes(1)
+
+    // Engine selected → a new memoised stop replaces the original.
+    const latestStop = vi.fn()
+    rerender(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={() => {}}
+        voiceInput={{ isRecording: true, isAvailable: true, transcript: '', start, stop: latestStop }}
+      />,
+    )
+
+    unmount()
+    expect(firstStop).not.toHaveBeenCalled()
+    expect(latestStop).toHaveBeenCalledTimes(1)
+  })
+
   it('does not arm PTT when voice is unavailable (Space types normally)', () => {
     vi.useFakeTimers()
     const voice = makeVoice({ isAvailable: false })

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2,7 +2,8 @@
  * InputBar tests (#1162)
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react'
+import { useState } from 'react'
 import { InputBar } from './InputBar'
 import type { EvaluatorResultPayload } from '../store/types'
 
@@ -2396,5 +2397,210 @@ describe('InputBar — thinking-keyword highlight overlay (#4306)', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const secondOnScroll = (textarea as any)[propsKey!].onScroll
     expect(secondOnScroll).toBe(firstOnScroll)
+  })
+})
+
+// #5610 — push-to-talk (hold Space to dictate).
+describe('InputBar push-to-talk (#5610)', () => {
+  // Controlled wrapper so we can read the textarea value back after the
+  // component's setValue() flows through React. Mirrors how App.tsx drives
+  // InputBar (controlledValue + onValueChange for per-session drafts).
+  function makeVoice(overrides: Partial<{
+    isRecording: boolean
+    isAvailable: boolean
+    transcript: string
+    start: () => void
+    stop: () => void
+  }> = {}) {
+    return {
+      isRecording: false,
+      isAvailable: true,
+      transcript: '',
+      start: vi.fn(),
+      stop: vi.fn(),
+      ...overrides,
+    }
+  }
+
+  function ControlledBar(props: { voiceInput: ReturnType<typeof makeVoice>; initial?: string }) {
+    const [value, setValue] = useState(props.initial ?? '')
+    return (
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue={value}
+        onValueChange={setValue}
+        voiceInput={props.voiceInput}
+      />
+    )
+  }
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('a quick tap of Space types a normal space and does NOT start recording', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice()
+    render(<ControlledBar voiceInput={voice} initial="hi" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    // Caret at end.
+    textarea.setSelectionRange(2, 2)
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    // Released well before the 300ms threshold.
+    act(() => { vi.advanceTimersByTime(100) })
+    fireEvent.keyUp(textarea, { key: ' ' })
+
+    expect(voice.start).not.toHaveBeenCalled()
+    expect(textarea.value).toBe('hi ')
+  })
+
+  it('holding Space past the threshold starts recording', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice()
+    render(<ControlledBar voiceInput={voice} initial="hi" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    textarea.setSelectionRange(2, 2)
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+
+    expect(voice.start).toHaveBeenCalledTimes(1)
+    // The held Space must not have flooded the field.
+    expect(textarea.value).toBe('hi')
+  })
+
+  it('does not flood the field with spaces while recording (key-repeat suppressed)', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice()
+    render(<ControlledBar voiceInput={voice} initial="" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+    // Browser key-repeat fires more keydowns while the key stays held.
+    fireEvent.keyDown(textarea, { key: ' ' })
+    fireEvent.keyDown(textarea, { key: ' ' })
+    fireEvent.keyDown(textarea, { key: ' ' })
+
+    expect(voice.start).toHaveBeenCalledTimes(1)
+    expect(textarea.value).toBe('')
+  })
+
+  it('pressing another key during the arm window cancels PTT and re-inserts the space', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice()
+    render(<ControlledBar voiceInput={voice} initial="" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    // User starts typing before the threshold — they meant a real space + char.
+    act(() => { vi.advanceTimersByTime(100) })
+    fireEvent.keyDown(textarea, { key: 'a' })
+    // Let any (cancelled) timer elapse.
+    act(() => { vi.advanceTimersByTime(300) })
+
+    expect(voice.start).not.toHaveBeenCalled()
+    // The suppressed space was re-inserted; the 'a' itself is delivered by the
+    // browser's native input (jsdom doesn't synthesise it from keyDown), so we
+    // only assert the space came back.
+    expect(textarea.value).toBe(' ')
+  })
+
+  it('releasing Space while recording stops capture', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice()
+    render(<ControlledBar voiceInput={voice} initial="" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(voice.start).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyUp(textarea, { key: ' ' })
+    expect(voice.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('inserts the transcript at the caret anchor captured when the hold began', () => {
+    vi.useFakeTimers()
+    // Drive the real lifecycle: start() flips isRecording true, and only then
+    // does a transcript arrive. The anchor is the caret at the arming keydown,
+    // so the transcript must splice there rather than append at the end.
+    const { rerender } = render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="foobar"
+        onValueChange={() => {}}
+        voiceInput={makeVoice()}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    // Caret in the middle: "foo|bar".
+    textarea.setSelectionRange(3, 3)
+
+    const voiceRecording = makeVoice({ isRecording: true, transcript: 'hello world' })
+    // Hold past the threshold (still on the non-recording voiceInput) to set
+    // the anchor at index 3, then re-render as the hook would once recording
+    // is live and the first transcript chunk has streamed in.
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+
+    let captured = 'foobar'
+    rerender(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue={captured}
+        onValueChange={v => { captured = v }}
+        voiceInput={voiceRecording}
+      />,
+    )
+
+    // The transcript is spliced at the anchor (index 3), not appended at the end.
+    expect(captured).toBe('foo hello world')
+  })
+
+  it('cleans up the open mic when the input loses focus mid-recording', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice()
+    render(<ControlledBar voiceInput={voice} initial="" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(voice.start).toHaveBeenCalledTimes(1)
+
+    fireEvent.blur(textarea)
+    expect(voice.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not arm PTT when voice is unavailable (Space types normally)', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice({ isAvailable: false })
+    render(<ControlledBar voiceInput={voice} initial="hi" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    textarea.setSelectionRange(2, 2)
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+
+    expect(voice.start).not.toHaveBeenCalled()
+    // preventDefault was never called, so the native space falls through —
+    // jsdom doesn't synthesise the character from keyDown, but the important
+    // contract is that we didn't suppress it or start recording.
+  })
+
+  it('Space with a modifier does not arm PTT', () => {
+    vi.useFakeTimers()
+    const voice = makeVoice()
+    render(<ControlledBar voiceInput={voice} initial="" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    fireEvent.keyDown(textarea, { key: ' ', ctrlKey: true })
+    act(() => { vi.advanceTimersByTime(300) })
+
+    expect(voice.start).not.toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -153,11 +153,32 @@ type EvaluatorState =
   | { kind: 'result', result: EvaluatorResultPayload }
   | { kind: 'error', message: string }
 
+// #5610 — push-to-talk hold threshold. Space must be held for at least this
+// long (with no other keys pressed) before voice capture begins; a quicker
+// tap types a normal space. 300ms matches Claude Code's affordance and is
+// long enough to feel deliberate without lagging a fast typist.
+const PTT_HOLD_MS = 300
+
+// #5610 — internal push-to-talk arming state, tracked on a ref so the
+// repeated keydown events that fire while a key is held don't restart the
+// arm timer or re-suppress characters incorrectly.
+//   - 'idle'      : nothing happening (the common case)
+//   - 'arming'    : Space is down, its character has been suppressed, and the
+//                   hold timer is counting toward PTT_HOLD_MS
+//   - 'recording' : the timer fired while still held → voice capture is live
+type PttState = 'idle' | 'arming' | 'recording'
+
 export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory, highlightThinkingKeywords }: InputBarProps) {
   const [internalValue, setInternalValue] = useState('')
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
   const dictationStartRef = useRef(0)
+  // #5610 — push-to-talk (hold Space). `pttStateRef` tracks arming/recording
+  // so repeated keydown events (browser key-repeat while Space is held) don't
+  // re-arm or restart the timer. `pttTimerRef` holds the pending hold timer
+  // so we can cancel it on early release or on any disqualifying keypress.
+  const pttStateRef = useRef<PttState>('idle')
+  const pttTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [filePickerOpen, setFilePickerOpen] = useState(false)
   const [fileSelectedIndex, setFileSelectedIndex] = useState(0)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -428,7 +449,148 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     })
   }, [userMessageHistory, setValue])
 
+  // #5610 — push-to-talk helpers.
+  //
+  // Disambiguation approach: on the first Space keydown we *suppress* the
+  // native space character (preventDefault) and arm a PTT_HOLD_MS timer.
+  //   - released before the timer fires → it was a tap → re-insert the single
+  //     space we suppressed (so quick taps still type a space).
+  //   - timer fires while still held → start voice capture; the space stays
+  //     suppressed and subsequent key-repeat keydowns are also suppressed so
+  //     the field is not flooded with spaces while recording.
+  // Suppress-then-reinsert (rather than insert-then-delete) avoids any race
+  // where a dropped or doubled character could slip through under React's
+  // controlled value.
+
+  // Insert a literal space at the current caret (used when a hold turns out to
+  // be a tap). Splices into the controlled value and restores the caret just
+  // past the inserted space on the next frame.
+  const insertSpaceAtCaret = useCallback(() => {
+    const el = textareaRef.current
+    const start = el?.selectionStart ?? value.length
+    const end = el?.selectionEnd ?? value.length
+    const next = value.slice(0, start) + ' ' + value.slice(end)
+    setValue(next)
+    const caret = start + 1
+    requestAnimationFrame(() => {
+      const t = textareaRef.current
+      if (!t) return
+      t.setSelectionRange(caret, caret)
+    })
+  }, [value, setValue])
+
+  // Cancel a pending arm timer (no-op if none is pending).
+  const clearPttTimer = useCallback(() => {
+    if (pttTimerRef.current !== null) {
+      clearTimeout(pttTimerRef.current)
+      pttTimerRef.current = null
+    }
+  }, [])
+
+  // Space keydown — the arming path. Returns true if the event was handled as
+  // a PTT trigger (caller should not fall through to normal Space handling).
+  const handlePttKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    if (e.key !== ' ' && e.key !== 'Spacebar') return false
+    // Only plain Space (no modifiers) and only when voice is actually wired
+    // and usable arms PTT. With a modifier the Space is a shortcut, not text.
+    if (!voiceInput?.isAvailable || disabled) return false
+    if (e.metaKey || e.ctrlKey || e.altKey) return false
+
+    // Already armed or recording → swallow key-repeat so the field isn't
+    // flooded with spaces while the key is held.
+    if (pttStateRef.current !== 'idle') {
+      e.preventDefault()
+      return true
+    }
+
+    // First Space down: suppress the native character, remember the caret as
+    // the dictation anchor, and start the hold timer.
+    e.preventDefault()
+    const el = textareaRef.current
+    dictationStartRef.current = el?.selectionStart ?? value.length
+    pttStateRef.current = 'arming'
+    clearPttTimer()
+    pttTimerRef.current = setTimeout(() => {
+      pttTimerRef.current = null
+      // Still arming (not cancelled by release / another key) → go live.
+      if (pttStateRef.current === 'arming') {
+        pttStateRef.current = 'recording'
+        voiceInput?.start()
+      }
+    }, PTT_HOLD_MS)
+    return true
+  }, [voiceInput, disabled, value.length, clearPttTimer])
+
+  // Cancel an in-progress arm because the user pressed some *other* key — they
+  // were typing, not holding to talk. Re-inserts the space we suppressed so no
+  // character is lost. No-op once recording has started (a different key while
+  // recording does not abort capture — release of Space ends it).
+  const cancelPttArmOnOtherKey = useCallback(() => {
+    if (pttStateRef.current === 'arming') {
+      clearPttTimer()
+      pttStateRef.current = 'idle'
+      insertSpaceAtCaret()
+    }
+  }, [clearPttTimer, insertSpaceAtCaret])
+
+  // Space keyup — the release path.
+  const handlePttKeyUp = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== ' ' && e.key !== 'Spacebar') return
+    if (pttStateRef.current === 'arming') {
+      // Released before the threshold → it was a tap. Re-insert the space.
+      clearPttTimer()
+      pttStateRef.current = 'idle'
+      insertSpaceAtCaret()
+    } else if (pttStateRef.current === 'recording') {
+      // Released while live → stop capture; the transcript-merge effect
+      // splices the result in at dictationStartRef.
+      pttStateRef.current = 'idle'
+      voiceInput?.stop()
+    }
+  }, [clearPttTimer, insertSpaceAtCaret, voiceInput])
+
+  // Blur — if focus leaves mid-arm or mid-record, clean up so the mic doesn't
+  // stay open. We do NOT re-insert a space on blur-while-arming: the user has
+  // navigated away, and silently appending a space to a draft they've left is
+  // more surprising than dropping the still-suppressed tap.
+  const handlePttBlur = useCallback(() => {
+    if (pttStateRef.current === 'arming') {
+      clearPttTimer()
+      pttStateRef.current = 'idle'
+    } else if (pttStateRef.current === 'recording') {
+      pttStateRef.current = 'idle'
+      voiceInput?.stop()
+    }
+  }, [clearPttTimer, voiceInput])
+
+  // Unmount cleanup — never leave a timer or an open mic behind.
+  useEffect(() => {
+    return () => {
+      if (pttTimerRef.current !== null) {
+        clearTimeout(pttTimerRef.current)
+        pttTimerRef.current = null
+      }
+      if (pttStateRef.current === 'recording') {
+        voiceInput?.stop()
+      }
+      pttStateRef.current = 'idle'
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // #5610 — push-to-talk. Space (no modifiers) arms voice capture on hold;
+    // any other key while arming means the user is typing, so cancel the arm
+    // and re-insert the suppressed space. Run this before the pickers so the
+    // arming Space isn't consumed by another handler. The pickers don't bind
+    // Space, so there's no conflict; we still guard the arm path on voice
+    // availability inside handlePttKeyDown.
+    if (e.key === ' ' || e.key === 'Spacebar') {
+      if (handlePttKeyDown(e)) return
+    } else {
+      cancelPttArmOnOtherKey()
+    }
+
     // Slash command picker keyboard handling
     if (pickerOpen) {
       if (e.key === 'Escape') {
@@ -583,7 +745,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
         e.preventDefault()
       }
     }
-  }, [pickerOpen, filePickerOpen, filteredFiles, fileSelectedIndex, selectFile, send, onInterrupt, closePicker, selectCommand, filteredCommands, selectedIndex, sendOnEnter, clearComposer, userMessageHistory, value, historyIndex, draftBeforeCycle, recallHistoryAtDepth, setValue])
+  }, [pickerOpen, filePickerOpen, filteredFiles, fileSelectedIndex, selectFile, send, onInterrupt, closePicker, selectCommand, filteredCommands, selectedIndex, sendOnEnter, clearComposer, userMessageHistory, value, historyIndex, draftBeforeCycle, recallHistoryAtDepth, setValue, handlePttKeyDown, cancelPttArmOnOtherKey])
 
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value
@@ -900,6 +1062,8 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
           value={value}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
+          onKeyUp={handlePttKeyUp}
+          onBlur={handlePttBlur}
           onPaste={handlePaste}
           // Scroll-sync the overlay to the textarea so multi-line drafts
           // keep keyword highlights aligned as the user scrolls within the

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -573,6 +573,14 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     }
   }, [clearPttTimer, voiceInput])
 
+  // #5610 — keep the live `stop` in a ref so the unmount cleanup below (which
+  // runs only on true unmount, hence the empty deps) doesn't fire a stale
+  // closure. `useVoiceInput` re-memoises start/stop when the engine is selected
+  // after mount, so a cleanup pinned to the first render would otherwise call
+  // the engine==='none' no-op stop and leave the mic open.
+  const voiceStopRef = useRef<(() => void) | undefined>(undefined)
+  voiceStopRef.current = voiceInput?.stop
+
   // Unmount cleanup — never leave a timer or an open mic behind.
   useEffect(() => {
     return () => {
@@ -581,7 +589,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
         pttTimerRef.current = null
       }
       if (pttStateRef.current === 'recording') {
-        voiceInput?.stop()
+        voiceStopRef.current?.()
       }
       pttStateRef.current = 'idle'
     }

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -173,6 +173,12 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
   const dictationStartRef = useRef(0)
+  // #5610 — text that sat *after* the dictation anchor when capture began.
+  // The transcript is spliced between the prefix and this suffix so caret-
+  // anchored dictation (push-to-talk mid-draft) doesn't truncate everything
+  // past the caret. For the mic button the anchor is the end of the value, so
+  // the suffix is empty and behaviour is unchanged.
+  const dictationSuffixRef = useRef('')
   // #5610 — push-to-talk (hold Space). `pttStateRef` tracks arming/recording
   // so repeated keydown events (browser key-repeat while Space is held) don't
   // re-arm or restart the timer. `pttTimerRef` holds the pending hold timer
@@ -507,7 +513,11 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     // the dictation anchor, and start the hold timer.
     e.preventDefault()
     const el = textareaRef.current
-    dictationStartRef.current = el?.selectionStart ?? value.length
+    const anchor = el?.selectionStart ?? value.length
+    dictationStartRef.current = anchor
+    // Capture the text after the caret so the transcript splices in place when
+    // recording starts (rather than truncating the rest of the draft).
+    dictationSuffixRef.current = value.slice(el?.selectionEnd ?? anchor)
     pttStateRef.current = 'arming'
     clearPttTimer()
     pttTimerRef.current = setTimeout(() => {
@@ -519,7 +529,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
       }
     }, PTT_HOLD_MS)
     return true
-  }, [voiceInput, disabled, value.length, clearPttTimer])
+  }, [voiceInput, disabled, value, clearPttTimer])
 
   // Cancel an in-progress arm because the user pressed some *other* key — they
   // were typing, not holding to talk. Re-inserts the space we suppressed so no
@@ -829,7 +839,11 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
       prevTranscriptRef.current = voiceInput.transcript
       const prefix = value.slice(0, dictationStartRef.current)
       const separator = prefix.length > 0 && !prefix.endsWith(' ') ? ' ' : ''
-      setValue(prefix + separator + voiceInput.transcript)
+      // #5610 — preserve any text that followed the anchor so caret-anchored
+      // dictation splices in place instead of truncating the rest of the draft.
+      const suffix = dictationSuffixRef.current
+      const trailing = suffix.length > 0 && !suffix.startsWith(' ') ? ' ' : ''
+      setValue(prefix + separator + voiceInput.transcript + trailing + suffix)
     }
     if (!voiceInput?.isRecording && prevTranscriptRef.current) {
       prevTranscriptRef.current = ''
@@ -842,6 +856,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
       voiceInput.stop()
     } else {
       dictationStartRef.current = value.length
+      dictationSuffixRef.current = ''
       voiceInput.start()
     }
   }, [voiceInput, value.length])


### PR DESCRIPTION
## Summary

Adds push-to-talk to the dashboard chat input (Claude Code parity, #5610): hold **Space** while focused in the message input to start voice transcription, release to stop and insert the transcript at the cursor. Reuses the existing voice pipeline (`useVoiceInput` — macOS Swift helper / Web Speech) behind the mic button next to Evaluate/Send.

## Space disambiguation (the whole trick)

The hard part is letting a quick Space still type a normal space while a sustained hold triggers capture, without flooding the field or dropping characters. Approach — **suppress-then-reinsert**:

- **First Space keydown** → `preventDefault()` (suppress the native character), record the caret as the dictation anchor, arm a `PTT_HOLD_MS` (300ms) timer.
- **Released before the timer fires** → it was a tap → re-insert the single suppressed space at the caret. Quick taps still type a space.
- **Timer fires while still held** → start capture; the space stays suppressed, and subsequent **key-repeat** keydowns (the browser fires keydown repeatedly while a key is held) are also `preventDefault`'d so the field isn't flooded with spaces while recording.
- **Any other key during the arm window** → cancel PTT and re-insert the suppressed space (the user was typing, not holding to talk).
- Arming/recording state lives on a **ref** so key-repeat can't re-arm or restart the timer.

Suppress-then-reinsert (rather than insert-then-delete) avoids any race where a character could be dropped or doubled under React's controlled value.

### Threshold choice

300ms — matches Claude Code's affordance; long enough to feel deliberate, short enough not to lag a fast typist. Exported as `PTT_HOLD_MS`.

## Recording indicator

PTT calls the same `voiceInput.start()` / `stop()` as the mic button, so `isRecording` flips and the existing mic-button recording state/UI lights up automatically — no new indicator.

## Focus / cleanup handling

- **Release while recording** → `stop()`; the existing transcript-merge effect splices the transcript at the dictation anchor (cursor at hold-start), not appended at the end.
- **Blur while arming** → cancel the timer (we deliberately do *not* re-insert a space on blur — silently appending to a draft the user left is more surprising than dropping the suppressed tap).
- **Blur while recording** → stop the mic so it never stays open.
- **Unmount** → clear any pending timer and stop the mic.
- PTT only arms on plain Space (no Cmd/Ctrl/Alt) and only when `voiceInput.isAvailable`.

## Tests

New `InputBar push-to-talk (#5610)` block with the voice pipeline mocked (no real mic):
- tap-Space types a space and does **not** record
- hold-past-threshold starts recording and suppresses the space
- key-repeat while recording doesn't flood the field
- other-key-during-arm cancels and re-inserts the space
- release while recording stops capture
- transcript splices at the caret anchor (not appended)
- blur-while-recording cleans up the open mic
- voice-unavailable and Space-with-modifier don't arm

`tsc --noEmit`, `vite build`, and the full dashboard suite (**3585 tests**) are green.

## Deferred

Mobile app push-to-talk (long-press mic is the more natural affordance there, per the issue) is left for a follow-up — this PR is dashboard-only.

Closes #5610