### PR TITLE
fix(dashboard): surface CLI auto-switch turn interrupt in confirm copy (#5609)

### DIFF
--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -169,6 +169,12 @@ export interface ProviderCapabilities {
   inProcessPermissions?: boolean;
   modelSwitch?: boolean;
   permissionModeSwitch?: boolean;
+  // #5609: true when switching to 'auto' mid-turn interrupts the running turn
+  // (CLI respawns its `claude -p` subprocess — the #3729 panic-button). The
+  // app renders the server-provided `confirm_permission_mode` warning verbatim,
+  // so this flag is informational on the app side; the server derives the
+  // warning copy from it.
+  interruptsTurnOnAutoSwitch?: boolean;
   planMode?: boolean;
   resume?: boolean;
   terminal?: boolean;

--- a/packages/dashboard/src/lib/auto-mode-confirm.test.ts
+++ b/packages/dashboard/src/lib/auto-mode-confirm.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { buildAutoModeConfirmMessage } from './auto-mode-confirm'
+
+describe('buildAutoModeConfirmMessage (#5609)', () => {
+  it('warns about interrupting the turn when the provider interrupts AND a turn is streaming', () => {
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: true, isStreaming: true })
+    expect(msg).toMatch(/INTERRUPT/)
+    expect(msg).toMatch(/restart the session/)
+    // still explains the bypass consequence
+    expect(msg).toMatch(/without asking for permission/)
+  })
+
+  it('uses the plain copy when the provider interrupts but no turn is in flight', () => {
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: true, isStreaming: false })
+    expect(msg).not.toMatch(/INTERRUPT/)
+    expect(msg).toMatch(/Tools will run without asking for permission/)
+  })
+
+  it('uses the plain copy for non-interrupting providers (SDK/TUI) even mid-turn', () => {
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: false, isStreaming: true })
+    expect(msg).not.toMatch(/INTERRUPT/)
+    expect(msg).toMatch(/Tools will run without asking for permission/)
+  })
+
+  it('treats an undefined capability flag as non-interrupting', () => {
+    const msg = buildAutoModeConfirmMessage({ interruptsTurn: undefined, isStreaming: true })
+    expect(msg).not.toMatch(/INTERRUPT/)
+    expect(msg).toMatch(/Tools will run without asking for permission/)
+  })
+})

--- a/packages/dashboard/src/lib/auto-mode-confirm.ts
+++ b/packages/dashboard/src/lib/auto-mode-confirm.ts
@@ -1,0 +1,55 @@
+/**
+ * auto-mode-confirm — build the confirm-dialog copy for switching the active
+ * session's permission mode to "Auto" (bypass-permissions).
+ *
+ * #5609: switching to Auto mid-turn is destructive ONLY on the CLI provider,
+ * where it respawns the `claude -p` subprocess and drops the in-flight turn
+ * (the #3729 "panic-button"). SDK and TUI apply the same switch in-place and
+ * leave the running turn alone. Before this helper the dashboard showed one
+ * generic confirm ("Tools will run without asking for permission.") that never
+ * mentioned the kill — a silent footgun where flipping to Auto to stop being
+ * prompted would instead destroy the agent's running response, and only on
+ * CLI. This centralizes the wording so the copy reflects the ACTUAL
+ * per-provider consequence + whether a turn is currently in flight.
+ *
+ * The panic-button itself is preserved: the user can still confirm and
+ * interrupt a wedged CLI turn. This only makes the consequence explicit.
+ */
+
+export interface AutoModeConfirmInput {
+  /**
+   * Whether switching to Auto interrupts the running turn on the active
+   * session's provider. True for CLI (subprocess respawn), false/undefined for
+   * SDK/TUI (in-place). Sourced from the provider's
+   * `capabilities.interruptsTurnOnAutoSwitch`.
+   */
+  interruptsTurn?: boolean
+  /**
+   * Whether the active session is currently streaming a response (a turn is in
+   * flight). When false, even a CLI switch has no turn to interrupt, so the
+   * destructive warning is omitted.
+   */
+  isStreaming: boolean
+}
+
+const BASE_COPY = 'Switch to Auto mode? Tools will run without asking for permission.'
+
+const DESTRUCTIVE_COPY =
+  'Switch to Auto mode?\n\n' +
+  'This session is mid-response. On this provider, switching to Auto will ' +
+  'INTERRUPT the running turn and restart the session — the in-flight ' +
+  'response will be dropped.\n\n' +
+  'Tools will then run without asking for permission. Continue?'
+
+/**
+ * Returns the confirm-dialog message for the Auto switch. When the active
+ * provider interrupts the turn on auto-switch AND a turn is in flight, the
+ * message names the consequence (interrupt + restart). Otherwise it returns
+ * the standard non-destructive copy.
+ */
+export function buildAutoModeConfirmMessage(input: AutoModeConfirmInput): string {
+  if (input.interruptsTurn && input.isStreaming) {
+    return DESTRUCTIVE_COPY
+  }
+  return BASE_COPY
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -77,6 +77,7 @@ import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState } fro
 import { registerSummarizeRequest, cancelSummarizeRequest, rejectAllSummarizeRequests } from './summarizeRequests';
 import { formatQuestionAnswerSummary } from '../utils/questionAnswerSummary';
 import { getAuthToken } from '../utils/auth';
+import { buildAutoModeConfirmMessage } from '../lib/auto-mode-confirm';
 import {
   setStore,
   wsSend,
@@ -2386,8 +2387,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // toggle target, and overwriting it on cancel would silently break the
     // toggle.
     if (mode === 'auto') {
+      // #5609: word the confirm to match the ACTUAL consequence for the
+      // active session's provider. On CLI a mid-turn switch interrupts the
+      // running turn (subprocess respawn — the #3729 panic-button); on SDK/TUI
+      // it applies in-place. Sourced from the provider capability so the copy
+      // never silently differs from what actually happens.
+      const state = get();
+      const activeSession = activeSessionId
+        ? state.sessions.find((s) => s.sessionId === activeSessionId)
+        : undefined;
+      const activeProvider = activeSession?.provider ?? null;
+      const caps = state.availableProviders.find(
+        (p) => p.name === activeProvider,
+      )?.capabilities;
+      const isStreaming = !!get().getActiveSessionState().streamingMessageId;
       const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
-        ? window.confirm('Switch to Auto mode? Tools will run without asking for permission.')
+        ? window.confirm(
+            buildAutoModeConfirmMessage({
+              interruptsTurn: caps?.interruptsTurnOnAutoSwitch,
+              isStreaming,
+            }),
+          )
         : true;
       if (!ok) return;
     }

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -129,6 +129,12 @@ export interface ProviderCapabilities {
   inProcessPermissions: boolean;
   modelSwitch: boolean;
   permissionModeSwitch: boolean;
+  // #5609: true when switching to 'auto' mid-turn interrupts the running
+  // turn (CLI respawns its `claude -p` subprocess — the #3729 panic-button).
+  // SDK/TUI apply the switch in-place and leave the turn running, so they
+  // report false / omit it. The dashboard uses this + the active session's
+  // streaming state to word the auto-mode confirm dialog accurately.
+  interruptsTurnOnAutoSwitch?: boolean;
   planMode: boolean;
   resume: boolean;
   terminal: boolean;

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -97,6 +97,11 @@ export class ClaudeTuiSession extends BaseSession {
       // (which would lose the resumed conversation context), unlike
       // CliSession's restart-based setPermissionMode.
       permissionModeSwitch: true,
+      // #5609: the sidecar rewrite above means a mid-turn switch to 'auto'
+      // takes effect on the next tool call WITHOUT a PTY restart — the
+      // running turn survives. False keeps the matrix uniform; only CliSession
+      // interrupts the turn on the auto-switch.
+      interruptsTurnOnAutoSwitch: false,
       planMode: false,
       // #5307 (WP-0.1) — the TUI now persists its upstream conversation uuid
       // (get resumeSessionId) and, on restore, respawns claude with

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -213,6 +213,13 @@ export class CliSession extends BaseSession {
       inProcessPermissions: false,
       modelSwitch: true,
       permissionModeSwitch: true,
+      // #5609: switching to 'auto' mid-turn is the #3729 panic-button —
+      // BaseSession lets 'auto' bypass the _isBusy guard and CliSession's
+      // _onPermissionModeChanged respawns the `claude -p` subprocess, which
+      // DROPS the in-flight turn. Surfaced as a capability so the dashboard /
+      // app can word their confirm dialog accurately (CLI = interrupts;
+      // SDK/TUI = safe) instead of silently differing per provider.
+      interruptsTurnOnAutoSwitch: true,
       planMode: true,
       // #4887 — claude CLI supports `--resume <id>`; CliSession now wires
       // `_sessionId` into the spawn argv on respawn / restore so the model

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -270,10 +270,21 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
       if (msg.mode === 'auto' && !msg.confirmed) {
         // #4828: session-scoped (single-session fallback).
         ;sessionLogger(permModeSessionId).info(`Auto mode requested by ${client.id}, awaiting confirmation`)
+        // #5609: on providers where the auto-switch is destructive (CLI —
+        // _onPermissionModeChanged respawns the `claude -p` subprocess, the
+        // #3729 panic-button) AND a turn is currently in flight, name the
+        // consequence so the user isn't surprised by a dropped response. SDK
+        // and TUI apply the switch in-place and keep the turn running, so they
+        // keep the plain warning. The warning string is rendered verbatim by
+        // the mobile app's confirm Alert (SettingsBar.tsx).
+        const interruptsTurn = !!entry.session.constructor.capabilities?.interruptsTurnOnAutoSwitch
+        const warning = interruptsTurn && entry.session._isBusy
+          ? 'This session is mid-response. Switching to Auto will INTERRUPT the running turn and restart the session — the in-flight response will be dropped. Tools will then run without asking for permission.'
+          : 'Auto mode bypasses all permission checks. Claude will execute tools without asking.'
         ctx.transport.send(ws, {
           type: 'confirm_permission_mode',
           mode: 'auto',
-          warning: 'Auto mode bypasses all permission checks. Claude will execute tools without asking.',
+          warning,
         })
       } else {
         const previousMode = entry.session.permissionMode || 'unknown'

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -108,6 +108,11 @@ export class SdkSession extends BaseSession {
       inProcessPermissions: true,
       modelSwitch: true,
       permissionModeSwitch: true,
+      // #5609: SDK applies a mid-turn switch to 'auto' in-process (clears
+      // rules + auto-resolves pending prompts at the next tool check) without
+      // killing the turn. Declared false so the capability matrix is uniform —
+      // CliSession is the only provider where the auto-switch is destructive.
+      interruptsTurnOnAutoSwitch: false,
       planMode: false,
       resume: true,
       terminal: false,

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -314,6 +314,67 @@ describe('settings-handlers', () => {
       assert.equal(session.setPermissionMode.callCount, 0)
     })
 
+    // #5609: the confirm_permission_mode warning must name the interrupt
+    // consequence when (a) the provider interrupts the turn on auto-switch
+    // (CLI panic-button) AND (b) a turn is in flight. SDK/TUI and idle CLI
+    // keep the plain bypass warning.
+    describe('confirm warning copy (#5609)', () => {
+      function sessionWithCaps(caps, isBusy) {
+        const session = createMockSession()
+        // Override constructor so `session.constructor.capabilities` is
+        // read by the handler (mirrors the real static-getter contract).
+        Object.defineProperty(session, 'constructor', {
+          value: { capabilities: caps },
+          configurable: true,
+        })
+        session._isBusy = isBusy
+        return session
+      }
+
+      it('warns about interrupting the turn for an interrupting provider mid-turn (CLI)', () => {
+        const sessions = new Map()
+        const session = sessionWithCaps({ interruptsTurnOnAutoSwitch: true }, true)
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp', provider: 'claude-cli' })
+        const ctx = makeCtx(sessions, { config: { allowAutoPermissionMode: true } })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.set_permission_mode(makeWs(), client, { mode: 'auto' }, ctx)
+
+        assert.equal(ctx._sent.length, 1)
+        assert.equal(ctx._sent[0].type, 'confirm_permission_mode')
+        assert.match(ctx._sent[0].warning, /INTERRUPT/)
+        assert.match(ctx._sent[0].warning, /restart the session/)
+      })
+
+      it('keeps the plain warning for an interrupting provider when idle (CLI, no turn)', () => {
+        const sessions = new Map()
+        const session = sessionWithCaps({ interruptsTurnOnAutoSwitch: true }, false)
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp', provider: 'claude-cli' })
+        const ctx = makeCtx(sessions, { config: { allowAutoPermissionMode: true } })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.set_permission_mode(makeWs(), client, { mode: 'auto' }, ctx)
+
+        assert.equal(ctx._sent[0].type, 'confirm_permission_mode')
+        assert.doesNotMatch(ctx._sent[0].warning, /INTERRUPT/)
+        assert.match(ctx._sent[0].warning, /bypasses all permission checks/)
+      })
+
+      it('keeps the plain warning for a non-interrupting provider mid-turn (SDK/TUI)', () => {
+        const sessions = new Map()
+        const session = sessionWithCaps({ interruptsTurnOnAutoSwitch: false }, true)
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp', provider: 'claude-sdk' })
+        const ctx = makeCtx(sessions, { config: { allowAutoPermissionMode: true } })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        settingsHandlers.set_permission_mode(makeWs(), client, { mode: 'auto' }, ctx)
+
+        assert.equal(ctx._sent[0].type, 'confirm_permission_mode')
+        assert.doesNotMatch(ctx._sent[0].warning, /INTERRUPT/)
+        assert.match(ctx._sent[0].warning, /bypasses all permission checks/)
+      })
+    })
+
     it('sets auto mode when confirmed', () => {
       const sessions = new Map()
       const session = createMockSession()

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -132,6 +132,28 @@ describe('Provider Registry', () => {
     assert.equal(sdkEntry.capabilities.resume, true)
   })
 
+  // #5609: clients word the auto-mode confirm dialog off this flag. Only CLI
+  // interrupts the in-flight turn when switching to auto (subprocess respawn —
+  // the #3729 panic-button); SDK/TUI apply the switch in-place.
+  it('listProviders surfaces interruptsTurnOnAutoSwitch only for claude-cli', () => {
+    const list = listProviders()
+    const cliEntry = list.find(p => p.name === 'claude-cli')
+    assert.ok(cliEntry, 'claude-cli provider should be registered')
+    assert.equal(cliEntry.capabilities.interruptsTurnOnAutoSwitch, true,
+      'claude-cli respawns its subprocess on auto-switch so should report interruptsTurnOnAutoSwitch: true')
+
+    const sdkEntry = list.find(p => p.name === 'claude-sdk')
+    assert.ok(sdkEntry, 'claude-sdk provider should be registered')
+    assert.equal(sdkEntry.capabilities.interruptsTurnOnAutoSwitch, false,
+      'claude-sdk applies the auto-switch in-process so should report interruptsTurnOnAutoSwitch: false')
+
+    const tuiEntry = list.find(p => p.name === 'claude-tui')
+    if (tuiEntry) {
+      assert.equal(tuiEntry.capabilities.interruptsTurnOnAutoSwitch, false,
+        'claude-tui rewrites a sidecar (no PTY restart) so should report interruptsTurnOnAutoSwitch: false')
+    }
+  })
+
   // #3072: clients gate the "Allow for Session" affordance on this capability
   // so they don't surface a button that the server would reject as
   // "not supported by this provider".


### PR DESCRIPTION
## Problem

Switching the dashboard permission dropdown **Approve → Auto** while a CLI session is mid-response silently kills the in-flight turn. `CliSession._onPermissionModeChanged()` unconditionally respawns the `claude -p` subprocess (the #3729 "panic-button", pinned by #3735) — dropping the running response. But **SDK and TUI apply the exact same switch in-place** (SDK clears rules + auto-resolves pending prompts at the next tool check; TUI rewrites a sidecar with no PTY restart). The confirm dialog said only *"Tools will run without asking for permission."* — it never mentioned the kill, and the per-provider asymmetry was invisible from the UI (#5609).

## Chosen fix: accurate, provider-aware warning (preserve the panic button)

The brief offered *defer-until-idle* as a possible ceiling, but the panic-button exists specifically to **unstick a wedged session** — and a wedged turn never goes idle, so deferring would defeat the one use case the kill is for. The right fix is therefore to **keep the kill available but stop it being silent**: word the confirm so the user knows exactly what will happen on *their* provider, *right now*.

- **New capability `interruptsTurnOnAutoSwitch`** — `true` only on CLI (subprocess respawn), `false` on SDK/TUI (in-place). Declared on all three providers so the capability matrix stays uniform; flows through `listProviders()` to every client.
- **Server** (`settings-handlers.js`): the `confirm_permission_mode` warning now names the consequence — *"This session is mid-response. Switching to Auto will INTERRUPT the running turn and restart the session…"* — **only** when the active provider interrupts (`interruptsTurnOnAutoSwitch`) **and** the session is busy (`_isBusy`). SDK/TUI and idle CLI keep the plain bypass warning. The **mobile app renders this warning verbatim** (`SettingsBar.tsx`), so both clients are fixed by one server change.
- **Dashboard** (`connection.ts`): `setPermissionMode` builds its `window.confirm` copy via a new pure, unit-tested helper (`lib/auto-mode-confirm.ts`) off the active session's provider capability + `streamingMessageId`.

## Per-provider behavior this surfaces

| Provider | Mid-turn → Auto | Confirm copy (busy) |
|---|---|---|
| CLI | Interrupts + respawns (#3729) | Names the interrupt + restart |
| SDK | In-place, turn survives | Plain bypass warning |
| TUI | Sidecar rewrite, turn survives | Plain bypass warning |

## Panic-button preserved

This is **purely additive gating around** the #3729/#3735 mechanism — `CliSession._onPermissionModeChanged()` and `BaseSession.setPermissionMode`'s `'auto'`-bypasses-busy-guard are untouched. The user can still confirm and interrupt a wedged CLI turn. The pinned panic-button regression tests (`CliSession setPermissionMode panic-button mid-turn (#3735)`) still pass unchanged.

## Tests

- `auto-mode-confirm.test.ts` (dashboard) — 4 cases: interrupt copy only when interrupting-provider + streaming; plain copy otherwise (idle CLI / SDK / undefined flag).
- `settings-handlers.test.js` (server) — `confirm warning copy (#5609)`: interrupt copy for busy CLI; plain for idle CLI; plain for busy SDK.
- `providers.test.js` (server) — asserts `interruptsTurnOnAutoSwitch` is `true` only for `claude-cli`, `false` for SDK/TUI.
- Full dashboard suite (3580) green; server providers/settings-handlers/cli-session/sdk/base/ws-permissions suites green; #3735 panic-button tests green; dashboard + app typecheck clean; server eslint (0 errors) + all 4 custom shell lints pass.

Closes #5609