### PR TITLE
fix(app): a11y + 44pt touch targets for permission buttons

### DIFF
--- a/packages/app/src/components/__tests__/MessageBubble.a11y.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.a11y.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * MessageBubble accessibility / touch-target — #5634
+ *
+ * The permission Approve/Deny option buttons are the single most
+ * security-sensitive tap in the app (approving e.g. `Bash(rm …)`). They
+ * must expose proper VoiceOver semantics so a screen-reader user knows
+ * exactly what they are approving, and reflect their disabled/selected
+ * state. This suite asserts:
+ *
+ *   1. Option buttons carry `accessibilityRole="button"`, an
+ *      `accessibilityLabel` that combines the option label with the tool
+ *      context, and an `accessibilityState` wired to the real
+ *      disabled/chosen variables in scope.
+ *   2. Answering the prompt flips `accessibilityState.disabled` true on all
+ *      options and `selected` true on the chosen one.
+ *   3. The freeform Other Send/Cancel buttons carry role + label, and Send
+ *      reflects the empty-input disabled state.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { OTHER_OPTION_VALUE } from '@chroxy/store-core';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+
+function makePrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'q-1',
+    type: 'prompt',
+    content: 'Run this command?',
+    timestamp: Date.now(),
+    toolUseId: 'toolu_a11y',
+    requestId: 'req-a11y',
+    tool: 'Bash(rm -rf build)',
+    options: [
+      { label: 'Approve', value: 'approve' },
+      { label: 'Deny', value: 'deny' },
+      { label: 'Other', value: OTHER_OPTION_VALUE },
+    ],
+    ...overrides,
+  } as ChatMessage;
+}
+
+function render(message: ChatMessage, onSelectOption: jest.Mock = jest.fn()) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+        onSelectOption={onSelectOption}
+      />,
+    );
+  });
+  return tree;
+}
+
+describe('MessageBubble accessibility (#5634)', () => {
+  it('gives option buttons role, tool-aware label, and unanswered state', () => {
+    const tree = render(makePrompt());
+    const approve = tree.root.findByProps({ testID: 'approval-button-approve' });
+    expect(approve.props.accessibilityRole).toBe('button');
+    // Label combines the option label with the tool context so a
+    // screen-reader user hears what they are approving.
+    expect(approve.props.accessibilityLabel).toBe('Approve, Bash(rm -rf build)');
+    // Unanswered → not disabled, not selected.
+    expect(approve.props.accessibilityState).toEqual({ disabled: false, selected: false });
+  });
+
+  it('falls back to the bare option label when there is no tool context', () => {
+    const tree = render(makePrompt({ tool: undefined }));
+    const approve = tree.root.findByProps({ testID: 'approval-button-approve' });
+    expect(approve.props.accessibilityLabel).toBe('Approve');
+  });
+
+  it('flips accessibilityState to disabled+selected once answered', () => {
+    // Drop requestId so the bubble keeps rendering the option buttons (a
+    // permission prompt with a requestId collapses to a pill once answered;
+    // user_question prompts keep the disabled+chosen buttons visible — that is
+    // the path that exercises the accessibilityState wiring).
+    const tree = render(makePrompt({ answered: 'approve', requestId: undefined }));
+    const approve = tree.root.findByProps({ testID: 'approval-button-approve' });
+    const deny = tree.root.findByProps({ testID: 'approval-button-deny' });
+    // The chosen option is disabled AND selected.
+    expect(approve.props.accessibilityState).toEqual({ disabled: true, selected: true });
+    // The non-chosen option is disabled but not selected.
+    expect(deny.props.accessibilityState).toEqual({ disabled: true, selected: false });
+  });
+
+  it('gives the Other Send/Cancel buttons role + label and disabled Send when empty', () => {
+    const tree = render(makePrompt());
+    const otherBtn = tree.root.findByProps({ testID: `approval-button-${OTHER_OPTION_VALUE}` });
+    act(() => {
+      otherBtn.props.onPress?.();
+    });
+    const send = tree.root.findByProps({ testID: 'approval-freetext-send' });
+    expect(send.props.accessibilityRole).toBe('button');
+    expect(send.props.accessibilityLabel).toBe('Send response, Bash(rm -rf build)');
+    // Empty input → Send is disabled.
+    expect(send.props.accessibilityState).toEqual({ disabled: true });
+
+    // After typing, Send is no longer disabled.
+    const inputs = tree.root.findAllByProps({ testID: 'approval-freetext-input' });
+    act(() => {
+      inputs[0].props.onChangeText?.('do something else');
+    });
+    const sendAfter = tree.root.findByProps({ testID: 'approval-freetext-send' });
+    expect(sendAfter.props.accessibilityState).toEqual({ disabled: false });
+  });
+});

--- a/packages/app/src/components/__tests__/MessageBubble.a11y.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.a11y.test.tsx
@@ -102,6 +102,12 @@ describe('MessageBubble accessibility (#5634)', () => {
     // Empty input → Send is disabled.
     expect(send.props.accessibilityState).toEqual({ disabled: true });
 
+    // Cancel carries the same button role and an explicit label so a
+    // screen-reader user can back out of the freeform response.
+    const cancel = tree.root.findByProps({ testID: 'approval-freetext-cancel' });
+    expect(cancel.props.accessibilityRole).toBe('button');
+    expect(cancel.props.accessibilityLabel).toBe('Cancel response');
+
     // After typing, Send is no longer disabled.
     const inputs = tree.root.findAllByProps({ testID: 'approval-freetext-input' });
     act(() => {

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -423,6 +423,15 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
                   isDisabled && !isChosen && styles.promptOptionDisabled,
                   isChosen && styles.promptOptionChosen,
                 ]}
+                accessibilityRole="button"
+                // #5634 — combine the option label with the tool context so a
+                // screen-reader user hears what they are approving/denying
+                // (e.g. "Approve, Bash(rm …)"). `message.tool` is the same tool
+                // string shown in the bubble header.
+                accessibilityLabel={
+                  message.tool ? `${opt.label}, ${message.tool}` : opt.label
+                }
+                accessibilityState={{ disabled: isDisabled, selected: isChosen }}
                 disabled={isDisabled}
                 onPress={() => {
                   if (opt.value === OTHER_OPTION_VALUE) {
@@ -491,6 +500,10 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
           <TouchableOpacity
             style={[styles.promptFreetextSend, !otherText.trim() && styles.promptOptionDisabled]}
             disabled={!otherText.trim()}
+            accessibilityRole="button"
+            // #5634 — name the freeform response in the tool context.
+            accessibilityLabel={message.tool ? `Send response, ${message.tool}` : 'Send response'}
+            accessibilityState={{ disabled: !otherText.trim() }}
             // #4755 — see input testID comment above.
             testID="approval-freetext-send"
             onPress={() => {
@@ -509,6 +522,9 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.promptFreetextCancel}
+            accessibilityRole="button"
+            // #5634 — cancel the freeform response and return to the options.
+            accessibilityLabel="Cancel response"
             onPress={() => {
               setOtherActive(false);
               setOtherText('');
@@ -650,6 +666,10 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.accentOrangeMedium,
     paddingHorizontal: 16,
     paddingVertical: 8,
+    // #5634 — guarantee a 44pt minimum touch target for the security-sensitive
+    // approve/deny taps. paddingVertical 8 alone leaves the button ~30pt.
+    minHeight: 44,
+    justifyContent: 'center',
     borderRadius: 8,
     borderWidth: 1,
     borderColor: COLORS.accentOrangeBorderStrong,

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -525,6 +525,7 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
             accessibilityRole="button"
             // #5634 — cancel the freeform response and return to the options.
             accessibilityLabel="Cancel response"
+            testID="approval-freetext-cancel"
             onPress={() => {
               setOtherActive(false);
               setOtherText('');

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -956,6 +956,7 @@ export function SessionScreen() {
             onPress={() => setViewMode('chat')}
             accessibilityRole="button"
             accessibilityLabel="Chat"
+            accessibilityState={{ selected: viewMode === 'chat' }}
           >
             <Text style={[styles.modeButtonText, viewMode === 'chat' && styles.modeButtonTextActive]}>
               Chat
@@ -967,6 +968,7 @@ export function SessionScreen() {
               onPress={() => { setChatFilterCompact((v) => !v); clearSelection(); }}
               accessibilityRole="button"
               accessibilityLabel={chatFilterCompact ? 'Show all messages' : 'Show chat only'}
+              accessibilityState={{ selected: chatFilterCompact }}
             >
               <Text style={[styles.modeButtonText, chatFilterCompact && styles.modeButtonTextActive]}>
                 {chatFilterCompact ? 'Compact' : 'All'}
@@ -980,6 +982,7 @@ export function SessionScreen() {
               onPress={() => setViewMode('terminal')}
               accessibilityRole="button"
               accessibilityLabel="Terminal"
+              accessibilityState={{ selected: viewMode === 'terminal' }}
             >
               <Text style={[styles.modeButtonText, viewMode === 'terminal' && styles.modeButtonTextActive]}>
                 Term
@@ -991,6 +994,7 @@ export function SessionScreen() {
             onPress={() => setViewMode('files')}
             accessibilityRole="button"
             accessibilityLabel="Files"
+            accessibilityState={{ selected: viewMode === 'files' }}
           >
             <Text style={[styles.modeButtonText, viewMode === 'files' && styles.modeButtonTextActive]}>
               Files
@@ -1644,7 +1648,10 @@ const styles = StyleSheet.create({
     flex: 0,
     paddingHorizontal: 16,
     paddingVertical: 8,
+    // #5634 — 44pt minimum touch target for the primary view-mode tabs.
+    minHeight: 44,
     alignItems: 'center',
+    justifyContent: 'center',
     borderRadius: 8,
   },
   modeButtonActive: {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -967,7 +967,8 @@ export function SessionScreen() {
               style={[styles.modeButton, chatFilterCompact && styles.modeButtonActive]}
               onPress={() => { setChatFilterCompact((v) => !v); clearSelection(); }}
               accessibilityRole="button"
-              accessibilityLabel={chatFilterCompact ? 'Show all messages' : 'Show chat only'}
+              accessibilityLabel={chatFilterCompact ? 'Compact messages' : 'All messages'}
+              accessibilityHint={chatFilterCompact ? 'Show all messages' : 'Show compact messages only'}
               accessibilityState={{ selected: chatFilterCompact }}
             >
               <Text style={[styles.modeButtonText, chatFilterCompact && styles.modeButtonTextActive]}>


### PR DESCRIPTION
Closes #5634

## Summary

The permission Approve/Deny option buttons — the single most security-sensitive tap in the app (approving e.g. `Bash(rm …)`) — were sub-44pt and invisible to VoiceOver. The primary view-mode tabs were also sub-44pt and lacked a screen-reader selected state. This fixes both touch-target size and accessibility semantics with no visual change.

## Changes

**`packages/app/src/components/chat/MessageBubble.tsx`**
- `promptOptionButton` style: add `minHeight: 44` + `justifyContent: 'center'` (paddingVertical 8 alone left the button ~30pt).
- Permission option `TouchableOpacity`: add `accessibilityRole="button"`, an `accessibilityLabel` that combines the option label with the tool context (`message.tool`) so a screen-reader user hears what they're approving (e.g. `"Approve, Bash(rm …)"`, falling back to the bare label when no tool), and `accessibilityState={{ disabled: isDisabled, selected: isChosen }}` wired to the existing `isDisabled`/`isChosen` variables in scope.
- Freeform Other Send button: add role + tool-aware label + `accessibilityState={{ disabled: !otherText.trim() }}`. Cancel button: add role + label. (`minHeight: 44` already present on both per the audit.)

**`packages/app/src/screens/SessionScreen.tsx`**
- `modeButton` style: add `minHeight: 44` + `justifyContent: 'center'` (~33pt before).
- Mode tabs (Chat/Term/Files + the Compact/All chat filter) already had role + label; added `accessibilityState={{ selected }}` wired to the real `viewMode === '…'` / `chatFilterCompact` variables.

**`packages/app/src/components/__tests__/MessageBubble.a11y.test.tsx`** (new)
- Asserts option-button role, tool-aware label, label fallback, and that answering flips `accessibilityState` to `disabled`/`selected` on the chosen vs non-chosen option; asserts the Other Send/Cancel role + label and Send's empty-input disabled state.

Accessibility props follow the existing patterns in `InputBar.tsx` / `ConnectScreen.tsx`.

## Verification
- `npx tsc --noEmit` — clean (after generating the gitignored `xterm-bundle.generated.ts` build artifact).
- New suite: 4/4 pass. Full app suite: **132 suites / 1784 tests pass**.
- No layout change: the existing padding keeps small buttons unchanged; `minHeight` only raises sub-44pt buttons to the 44pt floor.