### PR TITLE
fix(app): stop silently losing input on resume, session-switch, and queue overflow

### DIFF
--- a/packages/app/__tests__/AppStateListener.test.ts
+++ b/packages/app/__tests__/AppStateListener.test.ts
@@ -17,3 +17,36 @@ describe('AppState listener cleanup (#1910)', () => {
     expect(src).not.toMatch(/^AppState\.addEventListener/m)
   })
 })
+
+describe('Resume zombie-socket liveness (#5633)', () => {
+  test('tracks how long the app was backgrounded', () => {
+    // A timestamp is recorded on the transition AWAY from foreground and read
+    // back on resume to compute the background duration.
+    expect(src).toMatch(/_backgroundedAt/)
+    expect(src).toMatch(/if \(nextState !== 'active'\)/)
+    expect(src).toMatch(/if \(_backgroundedAt === 0\) _backgroundedAt = Date\.now\(\)/)
+  })
+
+  test('uses the real heartbeat interval as the background threshold', () => {
+    // The threshold must be the actual heartbeat constant read from
+    // message-handler, not a separate magic number that could drift from it.
+    expect(src).toMatch(/HEARTBEAT_INTERVAL_MS/)
+    expect(src).toMatch(/backgroundedFor >= HEARTBEAT_INTERVAL_MS/)
+  })
+
+  test('reconnects even when the socket still claims OPEN after a long background', () => {
+    // The whole point of the fix: readyState === OPEN is untrustworthy after a
+    // background cycle, so a long-background resume must reconnect anyway.
+    expect(src).toMatch(/socket\.readyState === WebSocket\.OPEN &&\s*\n\s*longBackground/)
+  })
+
+  test('respects the resume cooldown and user-disconnect intent', () => {
+    expect(src).toMatch(/now - _lastResumeReconnectAt < RESUME_RECONNECT_COOLDOWN_MS/)
+    // The zombie-socket branch must not fire when the user explicitly disconnected.
+    expect(src).toMatch(/longBackground &&\s*\n\s*!userDisconnected/)
+  })
+
+  test('clears the backgrounded timestamp on every resume (clean next cycle)', () => {
+    expect(src).toMatch(/_backgroundedAt = 0/)
+  })
+})

--- a/packages/app/__tests__/MessageQueueDrops.test.ts
+++ b/packages/app/__tests__/MessageQueueDrops.test.ts
@@ -7,8 +7,12 @@
  *  2. TTL expiry on drain: a queued `interrupt` (5s TTL) could expire while a
  *     longer reconnect backoff ran, evaporating without trace.
  *
- * Both now surface a `system` message into the active session's transcript via
- * the store's addMessage — matching the existing "Message queued…" feedback.
+ * Both now surface a `system` message into the transcript of the session the
+ * dropped action belonged to (the queued payload's `sessionId`), falling back
+ * to the active session via addMessage only when the payload carried none —
+ * matching the existing "Message queued…" feedback. If the user switched
+ * sessions while disconnected, the notice must follow the action's session, not
+ * leak into whatever's active now.
  */
 
 // ---------------------------------------------------------------------------
@@ -87,19 +91,30 @@ import {
 import type { ChatMessage } from '../src/store/types';
 
 // ---------------------------------------------------------------------------
-// Test store — only needs addMessage + an active session so notifyQueueFailure
-// can land a system message we can assert on.
+// Test store — supports BOTH the active-session fallback (addMessage) and the
+// session-targeted append path (updateSession → setState({ sessionStates })).
+// `added` captures the active-session fallback; `sessionStates[sid].messages`
+// captures notices routed to a specific session so we can assert which
+// transcript a drop notice landed in.
 // ---------------------------------------------------------------------------
-function makeStore() {
+function makeStore(opts?: { activeSessionId?: string | null; sessionIds?: string[] }) {
   const added: ChatMessage[] = [];
-  const store = {
-    getState: () => ({
-      activeSessionId: 'sess-1',
-      addMessage: (m: ChatMessage) => added.push(m),
-    }),
-    setState: () => {},
+  const activeSessionId = opts?.activeSessionId === undefined ? 'sess-1' : opts.activeSessionId;
+  const sessionIds = opts?.sessionIds ?? ['sess-1'];
+  let state: any = {
+    activeSessionId,
+    sessionStates: Object.fromEntries(
+      sessionIds.map((id) => [id, { messages: [] as ChatMessage[] }]),
+    ),
+    addMessage: (m: ChatMessage) => added.push(m),
   };
-  return { store, added };
+  const store = {
+    getState: () => state,
+    setState: (patch: any) => {
+      state = { ...state, ...patch };
+    },
+  };
+  return { store, added, sessionMessages: (id: string) => store.getState().sessionStates[id]?.messages ?? [] };
 }
 
 describe('offline queue silent-drop surfacing (#5633)', () => {
@@ -118,11 +133,59 @@ describe('offline queue silent-drop surfacing (#5633)', () => {
     }
     expect(added).toHaveLength(0);
 
-    // The 11th overflows: returns false AND surfaces a system message.
+    // The 11th overflows: returns false AND surfaces a system message. No
+    // sessionId on the payload → falls back to the active session (addMessage).
     expect(enqueueMessage('input', { type: 'input', data: 'm10' })).toBe(false);
     expect(added).toHaveLength(1);
     expect(added[0].type).toBe('system');
     expect(added[0].content).toMatch(/too many pending/i);
+    expect(added[0].content).toMatch(/message/i);
+  });
+
+  it('routes an overflowed input notice to the payload session, not the active one (#5633)', () => {
+    // The user was typing into sess-2 while disconnected, then switched to view
+    // sess-1. The overflow notice must land in sess-2's transcript.
+    const { store, added, sessionMessages } = makeStore({
+      activeSessionId: 'sess-1',
+      sessionIds: ['sess-1', 'sess-2'],
+    });
+    setStore(store as any);
+
+    for (let i = 0; i < 10; i++) {
+      enqueueMessage('input', { type: 'input', data: `m${i}`, sessionId: 'sess-2' });
+    }
+    expect(enqueueMessage('input', { type: 'input', data: 'm10', sessionId: 'sess-2' })).toBe(false);
+
+    // Notice landed in sess-2 (the payload's session), NOT the active sess-1.
+    const target = sessionMessages('sess-2');
+    expect(target).toHaveLength(1);
+    expect(target[0].type).toBe('system');
+    expect(target[0].content).toMatch(/too many pending/i);
+    // Negative control: nothing leaked into the active session's fallback path
+    // or into sess-1's transcript.
+    expect(added).toHaveLength(0);
+    expect(sessionMessages('sess-1')).toHaveLength(0);
+  });
+
+  it('uses interrupt-specific copy on overflow, distinct from the message copy (#5633)', () => {
+    const { store, sessionMessages } = makeStore({
+      activeSessionId: 'sess-1',
+      sessionIds: ['sess-1'],
+    });
+    setStore(store as any);
+
+    // Fill the queue with interrupts targeting sess-1, then overflow with one.
+    for (let i = 0; i < 10; i++) {
+      enqueueMessage('interrupt', { type: 'interrupt', sessionId: 'sess-1' });
+    }
+    expect(enqueueMessage('interrupt', { type: 'interrupt', sessionId: 'sess-1' })).toBe(false);
+
+    const notices = sessionMessages('sess-1');
+    expect(notices).toHaveLength(1);
+    expect(notices[0].content).toMatch(/interrupt/i);
+    expect(notices[0].content).toMatch(/deliver/i);
+    // The interrupt copy must NOT call the dropped action a "message".
+    expect(notices[0].content).not.toMatch(/your message/i);
   });
 
   it('does NOT surface anything for non-queueable (excluded / no-TTL) types', () => {
@@ -154,6 +217,46 @@ describe('offline queue silent-drop surfacing (#5633)', () => {
     expect(added[0].content).toMatch(/interrupt expired/i);
     // The dead interrupt must NOT have been sent.
     expect((socket as any).send).not.toHaveBeenCalled();
+  });
+
+  it('routes a TTL-expired interrupt notice to the payload session, not the active one (#5633)', () => {
+    jest.useFakeTimers();
+    // Active session is sess-1, but the interrupt was fired against sess-2.
+    const { store, added, sessionMessages } = makeStore({
+      activeSessionId: 'sess-1',
+      sessionIds: ['sess-1', 'sess-2'],
+    });
+    setStore(store as any);
+
+    enqueueMessage('interrupt', { type: 'interrupt', sessionId: 'sess-2' });
+    jest.advanceTimersByTime(6_000);
+    const socket = { send: jest.fn(), readyState: 1 } as unknown as WebSocket;
+    drainMessageQueue(socket);
+
+    // Notice landed in sess-2, not the active sess-1.
+    const target = sessionMessages('sess-2');
+    expect(target).toHaveLength(1);
+    expect(target[0].content).toMatch(/interrupt expired/i);
+    // Negative control: active fallback + sess-1 untouched.
+    expect(added).toHaveLength(0);
+    expect(sessionMessages('sess-1')).toHaveLength(0);
+  });
+
+  it('uses distinct copy for an expired message vs an expired interrupt (#5633)', () => {
+    jest.useFakeTimers();
+    const { store, added } = makeStore();
+    setStore(store as any);
+
+    // An expired `input` (60s TTL) routes through the non-interrupt branch.
+    enqueueMessage('input', { type: 'input', data: 'late' });
+    jest.advanceTimersByTime(61_000);
+    drainMessageQueue({ send: jest.fn(), readyState: 1 } as unknown as WebSocket);
+
+    expect(added).toHaveLength(1);
+    const messageCopy = added[0].content;
+    expect(messageCopy).toMatch(/message expired/i);
+    // The message branch must NOT use the interrupt wording.
+    expect(messageCopy).not.toMatch(/interrupt/i);
   });
 
   it('drains still-valid messages without spurious drop notices', () => {

--- a/packages/app/__tests__/MessageQueueDrops.test.ts
+++ b/packages/app/__tests__/MessageQueueDrops.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #5633 — the offline queue must not drop user input/interrupts silently.
+ *
+ * Two failure modes are covered:
+ *  1. Queue overflow: the 11th message (QUEUE_MAX_SIZE = 10) was dropped and
+ *     enqueueMessage returned false with no user-visible signal.
+ *  2. TTL expiry on drain: a queued `interrupt` (5s TTL) could expire while a
+ *     longer reconnect backoff ran, evaporating without trace.
+ *
+ * Both now surface a `system` message into the active session's transcript via
+ * the store's addMessage — matching the existing "Message queued…" feedback.
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks — native modules pulled in transitively by message-handler.ts
+// ---------------------------------------------------------------------------
+jest.mock('../src/utils/crypto', () => ({
+  createKeyPair: jest.fn(),
+  deriveSharedKey: jest.fn(),
+  encrypt: jest.fn(),
+  decrypt: jest.fn(),
+  generateConnectionSalt: jest.fn(() => 'mock-salt'),
+  deriveConnectionKey: jest.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}));
+
+jest.mock('../src/notifications', () => ({
+  registerForPushNotifications: jest.fn(),
+}));
+
+jest.mock('../src/utils/haptics', () => ({
+  hapticSuccess: jest.fn(),
+}));
+
+jest.mock('../src/store/persistence', () => ({
+  clearPersistedSession: jest.fn(),
+}));
+
+jest.mock('../src/store/imperative-callbacks', () => ({
+  getCallback: jest.fn(() => undefined),
+}));
+
+jest.mock('../src/store/multi-client', () => ({
+  useMultiClientStore: { getState: jest.fn(() => ({ setClients: jest.fn() })), setState: jest.fn() },
+}));
+
+jest.mock('../src/store/web', () => ({
+  useWebStore: { getState: jest.fn(() => ({})), setState: jest.fn() },
+}));
+
+jest.mock('../src/store/cost', () => ({
+  useCostStore: { getState: jest.fn(() => ({ handleCostUpdate: jest.fn() })), setState: jest.fn() },
+}));
+
+jest.mock('../src/store/terminal', () => ({
+  useTerminalStore: { getState: jest.fn(() => ({ appendTerminalData: jest.fn() })), setState: jest.fn() },
+}));
+
+jest.mock('../src/store/notifications', () => ({
+  useNotificationStore: { getState: jest.fn(() => ({ addNotification: jest.fn(), dismissNotification: jest.fn() })), setState: jest.fn() },
+}));
+
+jest.mock('../src/store/conversations', () => ({
+  useConversationStore: { getState: jest.fn(() => ({})), setState: jest.fn() },
+}));
+
+jest.mock('../src/store/connection-lifecycle', () => ({
+  useConnectionLifecycleStore: { getState: jest.fn(() => ({})), setState: jest.fn() },
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+import {
+  setStore,
+  enqueueMessage,
+  drainMessageQueue,
+  clearMessageQueue,
+} from '../src/store/message-handler';
+import type { ChatMessage } from '../src/store/types';
+
+// ---------------------------------------------------------------------------
+// Test store — only needs addMessage + an active session so notifyQueueFailure
+// can land a system message we can assert on.
+// ---------------------------------------------------------------------------
+function makeStore() {
+  const added: ChatMessage[] = [];
+  const store = {
+    getState: () => ({
+      activeSessionId: 'sess-1',
+      addMessage: (m: ChatMessage) => added.push(m),
+    }),
+    setState: () => {},
+  };
+  return { store, added };
+}
+
+describe('offline queue silent-drop surfacing (#5633)', () => {
+  afterEach(() => {
+    clearMessageQueue();
+    jest.useRealTimers();
+  });
+
+  it('surfaces a system message when the queue overflows past QUEUE_MAX_SIZE', () => {
+    const { store, added } = makeStore();
+    setStore(store as any);
+
+    // First 10 enqueue cleanly.
+    for (let i = 0; i < 10; i++) {
+      expect(enqueueMessage('input', { type: 'input', data: `m${i}` })).toBe('queued');
+    }
+    expect(added).toHaveLength(0);
+
+    // The 11th overflows: returns false AND surfaces a system message.
+    expect(enqueueMessage('input', { type: 'input', data: 'm10' })).toBe(false);
+    expect(added).toHaveLength(1);
+    expect(added[0].type).toBe('system');
+    expect(added[0].content).toMatch(/too many pending/i);
+  });
+
+  it('does NOT surface anything for non-queueable (excluded / no-TTL) types', () => {
+    const { store, added } = makeStore();
+    setStore(store as any);
+
+    // Excluded type.
+    expect(enqueueMessage('resize', { type: 'resize' })).toBe(false);
+    // No TTL configured.
+    expect(enqueueMessage('totally_unknown', {})).toBe(false);
+    expect(added).toHaveLength(0);
+  });
+
+  it('surfaces a dropped interrupt when its TTL expires before drain', () => {
+    jest.useFakeTimers();
+    const { store, added } = makeStore();
+    setStore(store as any);
+
+    expect(enqueueMessage('interrupt', { type: 'interrupt' })).toBe('queued');
+    expect(added).toHaveLength(0);
+
+    // Advance past the interrupt's 5s TTL, then drain.
+    jest.advanceTimersByTime(6_000);
+    const socket = { send: jest.fn(), readyState: 1 } as unknown as WebSocket;
+    drainMessageQueue(socket);
+
+    expect(added).toHaveLength(1);
+    expect(added[0].type).toBe('system');
+    expect(added[0].content).toMatch(/interrupt expired/i);
+    // The dead interrupt must NOT have been sent.
+    expect((socket as any).send).not.toHaveBeenCalled();
+  });
+
+  it('drains still-valid messages without spurious drop notices', () => {
+    jest.useFakeTimers();
+    const { store, added } = makeStore();
+    setStore(store as any);
+
+    enqueueMessage('input', { type: 'input', data: 'hi' });
+    const wsSent: unknown[] = [];
+    const socket = {
+      send: (raw: string) => wsSent.push(raw),
+      readyState: 1,
+    } as unknown as WebSocket;
+
+    drainMessageQueue(socket);
+
+    // No drop notice; the message went out.
+    expect(added).toHaveLength(0);
+    expect(wsSent).toHaveLength(1);
+  });
+});

--- a/packages/app/__tests__/OptimisticSendSafetyNet.test.ts
+++ b/packages/app/__tests__/OptimisticSendSafetyNet.test.ts
@@ -1,0 +1,109 @@
+/**
+ * #5633 — the optimistic-send safety net must fire against the session that
+ * armed it, not whatever session happens to be active when the timer fires.
+ *
+ * Previously the ~5s setTimeout re-read get().activeSessionId at FIRE time, so
+ * switching sessions (or a slow stream_start on cellular) let it null
+ * `streamingMessageId` and wipe the "thinking" indicator for the wrong/live
+ * turn. The fix captures activeSessionId at arm time and only clears that exact
+ * session while it's still 'pending'.
+ */
+import { useConnectionStore } from '../src/store/connection';
+import { useConnectionLifecycleStore } from '../src/store/connection-lifecycle';
+import { createEmptySessionState } from '../src/store/utils';
+import type { SessionState } from '../src/store/types';
+
+function seedSessions(activeId: string, ids: string[], overrides: Record<string, Partial<SessionState>> = {}) {
+  const sessionStates: Record<string, SessionState> = {};
+  for (const id of ids) {
+    sessionStates[id] = { ...createEmptySessionState(), ...(overrides[id] ?? {}) };
+  }
+  useConnectionStore.setState({
+    activeSessionId: activeId,
+    sessions: ids.map((id) => ({ sessionId: id, name: id, provider: 'claude-sdk' })) as any,
+    sessionStates,
+  });
+}
+
+describe('optimistic-send safety net targets the arming session (#5633)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Default: no server-advertised stall window → 5s fallback.
+    useConnectionLifecycleStore.setState({ streamStallTimeoutMs: null });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('clears the arming session when no stream_start arrives', () => {
+    seedSessions('sess-a', ['sess-a']);
+    useConnectionStore.getState().addUserMessage('hello', undefined, { clientMessageId: 'u1' });
+
+    expect(useConnectionStore.getState().sessionStates['sess-a'].streamingMessageId).toBe('pending');
+
+    jest.advanceTimersByTime(5_000);
+
+    const ss = useConnectionStore.getState().sessionStates['sess-a'];
+    expect(ss.streamingMessageId).toBeNull();
+    // "thinking" placeholder removed.
+    expect(ss.messages.some((m) => m.id === 'thinking')).toBe(false);
+  });
+
+  it('does NOT wipe a DIFFERENT session the user switched to', () => {
+    seedSessions('sess-a', ['sess-a', 'sess-b']);
+
+    // Arm the safety net on sess-a.
+    useConnectionStore.getState().addUserMessage('on A', undefined, { clientMessageId: 'a1' });
+    expect(useConnectionStore.getState().sessionStates['sess-a'].streamingMessageId).toBe('pending');
+
+    // User switches to sess-b and that session begins streaming a live turn.
+    useConnectionStore.setState((s) => ({
+      activeSessionId: 'sess-b',
+      sessionStates: {
+        ...s.sessionStates,
+        'sess-b': { ...s.sessionStates['sess-b'], streamingMessageId: 'pending' },
+      },
+    }));
+
+    // sess-a's timer fires.
+    jest.advanceTimersByTime(5_000);
+
+    // sess-b (the live, currently-active turn) must be untouched.
+    expect(useConnectionStore.getState().sessionStates['sess-b'].streamingMessageId).toBe('pending');
+    // sess-a (the one that armed the net) is cleared.
+    expect(useConnectionStore.getState().sessionStates['sess-a'].streamingMessageId).toBeNull();
+  });
+
+  it('does NOT clear when the arming session has since started streaming', () => {
+    seedSessions('sess-a', ['sess-a']);
+    useConnectionStore.getState().addUserMessage('hi', undefined, { clientMessageId: 'x1' });
+
+    // stream_start landed: streamingMessageId is now a real id, not 'pending'.
+    useConnectionStore.setState((s) => ({
+      sessionStates: {
+        ...s.sessionStates,
+        'sess-a': { ...s.sessionStates['sess-a'], streamingMessageId: 'resp-1' },
+      },
+    }));
+
+    jest.advanceTimersByTime(5_000);
+
+    // The live stream id must survive — the net only clears a stuck 'pending'.
+    expect(useConnectionStore.getState().sessionStates['sess-a'].streamingMessageId).toBe('resp-1');
+  });
+
+  it('honours the server-advertised stream-stall window over the 5s fallback', () => {
+    useConnectionLifecycleStore.setState({ streamStallTimeoutMs: 12_000 });
+    seedSessions('sess-a', ['sess-a']);
+    useConnectionStore.getState().addUserMessage('slow net', undefined, { clientMessageId: 's1' });
+
+    // At 5s the old hardcoded net would have fired; with a 12s server window it must not.
+    jest.advanceTimersByTime(5_000);
+    expect(useConnectionStore.getState().sessionStates['sess-a'].streamingMessageId).toBe('pending');
+
+    // After the full advertised window it clears.
+    jest.advanceTimersByTime(7_000);
+    expect(useConnectionStore.getState().sessionStates['sess-a'].streamingMessageId).toBeNull();
+  });
+});

--- a/packages/app/__tests__/ResumeZombieSocketReconnect.test.ts
+++ b/packages/app/__tests__/ResumeZombieSocketReconnect.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Behavioural test for the resume zombie-socket liveness fix (#5633).
+ *
+ * The bug this guards against: the resume "Case 0" path fires when the socket
+ * still claims `readyState === OPEN` after a long background, and (saved-conn
+ * case) calls `connectAuto(savedConnection)`. But `connectAuto` had a no-op
+ * guard that early-returns when `connected && socket OPEN && currentUrl ===
+ * selection.url`. For a TUNNEL connection the selector returns the same tunnel
+ * URL with no health probe, so all three conditions held and connectAuto
+ * returned WITHOUT tearing down the zombie socket — making the whole liveness
+ * fix a no-op in exactly the scenario it targets.
+ *
+ * This test drives the real AppState listener registered by connection.ts
+ * (background → wait one heartbeat cycle → foreground) against a connected
+ * tunnel state, and asserts the zombie socket is actually REPLACED: the old
+ * socket is closed and a fresh connection attempt (new WebSocket + bumped
+ * attempt id) is started.
+ *
+ * It is written to FAIL against the pre-fix code (connectAuto no-ops, old
+ * socket never closes, no new WebSocket) and PASS after the `force` option is
+ * threaded through.
+ */
+
+import { AppState } from 'react-native';
+import type { SavedConnection } from '@chroxy/store-core';
+
+// Capture the AppState 'change' handler that connection.ts registers at import
+// time. The spy MUST be installed before connection.ts is first required, so we
+// install it here (module-eval, before the lazy require below) and load
+// connection.ts via require() afterwards rather than a top-level import.
+let appStateHandler: ((state: string) => void) | null = null;
+jest
+  .spyOn(AppState, 'addEventListener')
+  .mockImplementation(((type: string, handler: (state: string) => void) => {
+    if (type === 'change') appStateHandler = handler;
+    return { remove: jest.fn() };
+  }) as typeof AppState.addEventListener);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useConnectionStore } = require('../src/store/connection');
+const {
+  useConnectionLifecycleStore,
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('../src/store/connection-lifecycle');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const messageHandler = require('../src/store/message-handler');
+
+/** Flush pending microtasks (the connectAuto/connect promise chain). */
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) =>
+    jest.requireActual<typeof globalThis>('timers').setImmediate(resolve),
+  );
+}
+
+const TUNNEL_URL = 'wss://zombie-test.trycloudflare.com';
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+const savedTunnelConnection: SavedConnection = {
+  url: TUNNEL_URL,
+  tunnelUrl: TUNNEL_URL,
+  token: 'tok-zombie',
+  // No verified LAN candidate → selectConnectEndpoint returns the tunnel URL as
+  // the fallback with NO health probe (the canonical zombie scenario).
+};
+
+interface FakeSocket {
+  readyState: number;
+  url: string;
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((e: unknown) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+const originalFetch = global.fetch;
+const originalWebSocket = global.WebSocket;
+let newWsInstances: { url: string }[] = [];
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  newWsInstances = [];
+
+  // selectConnectEndpoint for a tunnel-only record never fetches, but connect()
+  // does its own /health GET before opening the WS. Return ok so the path runs.
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ status: 'ok' }),
+    text: () => Promise.resolve('{"status":"ok"}'),
+  } as unknown as Response);
+
+  // Record every NEW socket connect() opens.
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 0;
+    onopen: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    onmessage: ((e: unknown) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn();
+    constructor(url: string) {
+      this.url = url;
+      newWsInstances.push(this);
+    }
+  };
+
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+    apiToken: null,
+    userDisconnected: false,
+    savedConnection: null,
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  global.WebSocket = originalWebSocket;
+  jest.useRealTimers();
+});
+
+/** Seed a "connected over the tunnel" state with a zombie socket (claims OPEN). */
+function seedConnectedTunnelWithZombieSocket(): FakeSocket {
+  const zombie: FakeSocket = {
+    readyState: 1, // WebSocket.OPEN — the lie that makes this a zombie
+    url: TUNNEL_URL,
+    onopen: null,
+    onclose: null,
+    onerror: null,
+    onmessage: null,
+    send: jest.fn(),
+    close: jest.fn(),
+  };
+  useConnectionStore.setState({ socket: zombie as unknown as WebSocket });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'connected',
+    wsUrl: TUNNEL_URL,
+    apiToken: savedTunnelConnection.token,
+    userDisconnected: false,
+    savedConnection: savedTunnelConnection,
+  });
+  return zombie;
+}
+
+describe('Resume zombie-socket reconnect — behavioural (#5633)', () => {
+  it('registered an AppState change handler', () => {
+    expect(appStateHandler).toBeInstanceOf(Function);
+  });
+
+  it('REPLACES the zombie socket after a long background even though it still claims OPEN', async () => {
+    const handler = appStateHandler;
+    if (!handler) throw new Error('AppState handler not captured');
+
+    const zombie = seedConnectedTunnelWithZombieSocket();
+    const attemptIdBefore = messageHandler.connectionAttemptId;
+
+    // Background, wait at least one full heartbeat cycle, then foreground.
+    handler('background');
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS + 1_000);
+    handler('active');
+
+    // connectAuto → selectConnectEndpoint resolves async, then connect() runs
+    // synchronously (bumps attempt id + closes old socket before its fetch).
+    await flushPromises();
+    await flushPromises();
+
+    // 1) Fresh connection attempt was started (attempt id bumped).
+    expect(messageHandler.connectionAttemptId).toBeGreaterThan(attemptIdBefore);
+
+    // 2) The zombie socket was torn down (neutered + closed).
+    expect(zombie.close).toHaveBeenCalled();
+    expect(zombie.onclose).toBeNull();
+
+    // 3) A brand-new socket was created for the reconnect.
+    expect(newWsInstances.length).toBeGreaterThanOrEqual(1);
+    expect(newWsInstances[0].url).toBe(TUNNEL_URL);
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -790,18 +790,30 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // Used by the auto-reconnect paths (saved-connection load, app resume, network
   // change). The manual paths (QR scan, ServerPicker, manual entry) keep calling
   // `connect()` directly so an explicit user choice is never second-guessed.
-  connectAuto: async (saved: SavedConnection, options?: { silent?: boolean; preferTunnel?: boolean }) => {
+  connectAuto: async (
+    saved: SavedConnection,
+    options?: { silent?: boolean; preferTunnel?: boolean; force?: boolean },
+  ) => {
     const selection = await selectConnectEndpoint(saved, { preferTunnel: options?.preferTunnel });
     console.log(`[ws] Endpoint selected: ${selection.path} (${selection.url})`);
     // No-op when the chosen endpoint matches the live connection. Without this
     // guard a network-change event that re-selects the *same* path (LAN probe
     // still answers, or no LAN candidate so it stays on the tunnel) would tear
     // down a healthy socket and re-handshake, disrupting an active session.
+    //
+    // #5633: the resume zombie-socket path (Case 0) passes `force: true` to skip
+    // ONLY this guard. There the socket claims OPEN and the URL is unchanged
+    // (tunnel fallback has no health probe), so all three conditions hold and we
+    // would no-op — leaving the dead socket in place, the exact failure the
+    // liveness fix targets. We still run selectConnectEndpoint above so the
+    // endpoint re-resolution (LAN→tunnel fallback, tunnel rotation) is preserved;
+    // we just don't let an unchanged URL short-circuit the forced reconnect.
     const { socket } = get();
     const currentUrl = useConnectionLifecycleStore.getState().wsUrl;
     const connected =
       useConnectionLifecycleStore.getState().connectionPhase === 'connected';
     if (
+      !options?.force &&
       connected &&
       socket &&
       socket.readyState === WebSocket.OPEN &&
@@ -2215,7 +2227,13 @@ export const _appStateSub = AppState.addEventListener('change', (nextState) => {
       );
       _lastResumeReconnectAt = now;
       if (savedConnection?.url && savedConnection?.token) {
-        void useConnectionStore.getState().connectAuto(savedConnection);
+        // #5633: force past connectAuto's "already connected to this URL" no-op
+        // guard. The socket claims OPEN and the tunnel URL is unchanged, so
+        // without `force` connectAuto would short-circuit and never tear down the
+        // zombie socket — making this whole liveness path a no-op. connect()
+        // (called inside connectAuto) still bumps the attempt id and neuters +
+        // closes the old socket before opening the new one.
+        void useConnectionStore.getState().connectAuto(savedConnection, { force: true });
       } else {
         useConnectionStore.getState().connect(wsUrl, apiToken);
       }

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -127,6 +127,7 @@ import {
   clearPendingPermissionModeRequestsForSession,
   CLIENT_PROTOCOL_VERSION,
   isVisibleAppState,
+  HEARTBEAT_INTERVAL_MS,
 } from './message-handler';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
 import {
@@ -1379,21 +1380,36 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       timestamp: Date.now(),
     };
 
+    // #5633: capture the session this optimistic turn belongs to AT ARM TIME.
+    // The old safety net re-read `get().activeSessionId` when the timer FIRED,
+    // so switching sessions (or a legitimately slow stream_start on cellular)
+    // let it null `streamingMessageId` and wipe the "thinking" indicator for
+    // whatever session happened to be active then — the wrong/live turn.
+    const armedSessionId = get().activeSessionId;
+
     updateActiveSession((ss) => ({
       messages: [...filterThinking(ss.messages), userMsg, thinkingMsg],
       streamingMessageId: 'pending',
     }));
 
-    // Safety net: if no stream_start arrives, clear pending state after 5 seconds.
+    // Safety net: if no stream_start arrives, clear the pending state for THIS
+    // session. Prefer the server-advertised stream-stall window (#4497/#4766,
+    // already plumbed in connection-lifecycle) so the net matches the real
+    // server cadence; fall back to 5s when the server doesn't advertise one.
+    const stallMs = useConnectionLifecycleStore.getState().streamStallTimeoutMs;
+    const safetyNetMs = stallMs && stallMs > 0 ? stallMs : 5000;
     setTimeout(() => {
-      const sid = get().activeSessionId;
-      const ss = sid ? get().sessionStates[sid] : null;
+      if (!armedSessionId) return;
+      const ss = get().sessionStates[armedSessionId];
+      // Only clear if this exact session is still waiting on the same pending
+      // turn — never touch a session that has since started streaming, or a
+      // different session the user switched to.
       if (!ss || ss.streamingMessageId !== 'pending') return;
-      updateActiveSession((ss) => ({
-        messages: filterThinking(ss.messages),
+      updateSession(armedSessionId, (s) => ({
+        messages: filterThinking(s.messages),
         streamingMessageId: null,
       }));
-    }, 5000);
+    }, safetyNetMs);
   },
 
   appendTerminalData: (data) => {
@@ -2140,6 +2156,14 @@ if (global.__chroxy_appStateSub) {
 // toggles (e.g., switching apps quickly) don't spam connect(). Fixes #2813.
 const RESUME_RECONNECT_COOLDOWN_MS = 5000;
 let _lastResumeReconnectAt = 0;
+// #5633: timestamp of the most recent transition OUT of the foreground. iOS
+// suspends JS while backgrounded, freezing the heartbeat interval, and the
+// tunnel/NAT can silently drop the TCP connection. On foreground the socket
+// frequently still reports `readyState === OPEN` despite being dead, so for
+// ~20s `sendInput` ships into a black hole and reports 'sent'. We measure how
+// long we were away and, if it's at least one heartbeat cycle, treat
+// `readyState === OPEN` as untrustworthy and proactively reconnect.
+let _backgroundedAt = 0;
 
 export const _appStateSub = AppState.addEventListener('change', (nextState) => {
   // #3404: keep the server in sync with foreground/background state so it
@@ -2148,13 +2172,55 @@ export const _appStateSub = AppState.addEventListener('change', (nextState) => {
   const { socket } = useConnectionStore.getState();
   sendClientVisible(socket, isVisibleAppState(nextState));
 
+  if (nextState !== 'active') {
+    // Record the first transition away from foreground; later inactive→
+    // background hops (iOS emits both) must not reset the clock.
+    if (_backgroundedAt === 0) _backgroundedAt = Date.now();
+    return;
+  }
+
   if (nextState === 'active') {
     const now = Date.now();
+    // #5633: snapshot and clear the backgrounded timestamp up-front so every
+    // resume path (including the early cooldown return) starts the next cycle
+    // clean. A 0 (never backgrounded, e.g. cold start) yields duration 0.
+    const backgroundedFor = _backgroundedAt > 0 ? now - _backgroundedAt : 0;
+    _backgroundedAt = 0;
+
     if (now - _lastResumeReconnectAt < RESUME_RECONNECT_COOLDOWN_MS) {
       return;
     }
 
     const { connectionPhase, wsUrl, apiToken, userDisconnected, savedConnection } = useConnectionLifecycleStore.getState();
+
+    // #5633 Case 0 (zombie socket): we believe we're connected, the socket
+    // even still claims OPEN, but we were away at least one heartbeat cycle —
+    // long enough for iOS to have suspended JS and the connection to have
+    // silently died. `readyState` is not trustworthy here, so reconnect
+    // proactively rather than letting input fall into a dead socket for ~20s
+    // until the next heartbeat pong-timeout notices. The cooldown above (and
+    // the reconnect ladder inside connect/connectAuto) prevents storms.
+    const longBackground = backgroundedFor >= HEARTBEAT_INTERVAL_MS;
+    if (
+      connectionPhase === 'connected' &&
+      socket &&
+      socket.readyState === WebSocket.OPEN &&
+      longBackground &&
+      !userDisconnected &&
+      wsUrl &&
+      apiToken
+    ) {
+      console.log(
+        `[ws] App resumed after ${Math.round(backgroundedFor / 1000)}s — socket claims OPEN but may be a zombie; verifying via reconnect`,
+      );
+      _lastResumeReconnectAt = now;
+      if (savedConnection?.url && savedConnection?.token) {
+        void useConnectionStore.getState().connectAuto(savedConnection);
+      } else {
+        useConnectionStore.getState().connect(wsUrl, apiToken);
+      }
+      return;
+    }
 
     // Case 1: socket thinks it was connected but is actually stale
     if (connectionPhase === 'connected' && socket && socket.readyState !== WebSocket.OPEN && wsUrl && apiToken) {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -902,20 +902,45 @@ const QUEUE_EXCLUDED = new Set(['set_model', 'set_permission_mode', 'mode', 'res
  * reconnection..." feedback is rendered in SessionScreen. Silently dropping
  * input/interrupts here is exactly the "I sent it and nothing happened" class
  * of bug we're fixing — the user must see that the action did not land.
+ *
+ * The notice is routed to the session the dropped action belonged to
+ * (`targetSessionId`, read off the queued payload's `sessionId`) rather than
+ * whatever session happens to be active now. If the user switched sessions
+ * while disconnected, the notice must land in the transcript they were typing
+ * into — not the one they're looking at. Falls back to the active session
+ * (`addMessage`) only when the payload carried no usable `sessionId`.
  */
-function notifyQueueFailure(content: string): void {
+function notifyQueueFailure(content: string, targetSessionId?: string | null): void {
   try {
-    getStore().getState().addMessage({
+    const noticeMsg: ChatMessage = {
       id: nextMessageId('queue-drop'),
       type: 'system',
       content,
       timestamp: Date.now(),
-    });
+    };
+    if (targetSessionId && getStore().getState().sessionStates[targetSessionId]) {
+      updateSession(targetSessionId, (ss) => ({
+        messages: [...ss.messages, noticeMsg],
+      }));
+    } else {
+      // No (live) target session — fall back to the active session. addMessage
+      // targets the active session; if there's no active session the failure
+      // can't be surfaced inline, but never let feedback throw into the
+      // send/drain path.
+      getStore().getState().addMessage(noticeMsg);
+    }
   } catch {
-    // addMessage targets the active session; if there's no active session the
-    // failure can't be surfaced inline, but never let feedback throw into the
-    // send/drain path.
+    // Never let feedback throw into the send/drain path.
   }
+}
+
+/** Read the `sessionId` off a queued payload, if it carries one (#5633). */
+function payloadSessionId(payload: unknown): string | null {
+  if (payload && typeof payload === 'object') {
+    const sid = (payload as Record<string, unknown>).sessionId;
+    if (typeof sid === 'string' && sid.length > 0) return sid;
+  }
+  return null;
 }
 
 export function enqueueMessage(type: string, payload: unknown): 'queued' | false {
@@ -924,10 +949,15 @@ export function enqueueMessage(type: string, payload: unknown): 'queued' | false
   if (!maxAge) return false;
   if (_ctx.messageQueue.length >= QUEUE_MAX_SIZE) {
     // #5633: the queue is full — the 11th+ message would otherwise be dropped
-    // silently with sendInput still reporting nothing actionable. Tell the user.
+    // silently with sendInput still reporting nothing actionable. Tell the user,
+    // in the transcript the dropped action belonged to (not just whatever's
+    // active now), and with action-aware copy so an overflowed `interrupt`
+    // isn't called a "message".
     console.warn(`[queue] Queue full (${QUEUE_MAX_SIZE}) — dropping ${type}`);
+    const noun = type === 'interrupt' ? 'interrupt' : 'message';
     notifyQueueFailure(
-      `Couldn't queue your message — too many pending while disconnected (max ${QUEUE_MAX_SIZE}). Please resend after reconnecting.`,
+      `Couldn't ${type === 'interrupt' ? 'deliver' : 'queue'} your ${noun} — too many pending while disconnected (max ${QUEUE_MAX_SIZE}). Please resend after reconnecting.`,
+      payloadSessionId(payload),
     );
     return false;
   }
@@ -953,11 +983,23 @@ export function drainMessageQueue(socket: WebSocket): void {
   // Surface any expired entry so the user knows it didn't land.
   if (expired.length > 0) {
     console.warn(`[queue] Dropping ${expired.length} expired queued message(s) on drain`);
-    const hadInterrupt = expired.some((m) => m.type === 'interrupt');
-    if (hadInterrupt) {
-      notifyQueueFailure('Your interrupt expired before reconnecting and was not sent — tap Stop again if still needed.');
-    } else {
-      notifyQueueFailure('A queued message expired before reconnecting and was not sent — please resend.');
+    // #5633: route each expiry notice to the session the dropped action
+    // belonged to (the queued payload's `sessionId`) — if the user switched
+    // sessions while reconnecting, the notice must land in the transcript they
+    // were typing into, not the one now active.
+    const expiredInterrupt = expired.find((m) => m.type === 'interrupt');
+    if (expiredInterrupt) {
+      notifyQueueFailure(
+        'Your interrupt expired before reconnecting and was not sent — tap Stop again if still needed.',
+        payloadSessionId(expiredInterrupt.payload),
+      );
+    }
+    const expiredOther = expired.find((m) => m.type !== 'interrupt');
+    if (expiredOther) {
+      notifyQueueFailure(
+        'A queued message expired before reconnecting and was not sent — please resend.',
+        payloadSessionId(expiredOther.payload),
+      );
     }
   }
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -689,7 +689,11 @@ export function clearTerminalWriteBatching(): void {
  * app and dashboard can't drift apart (#4767).
  */
 export const SUBSCRIBE_SESSIONS_CHUNK_SIZE = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE;
-const HEARTBEAT_INTERVAL_MS = 15_000;
+// Exported (#5633) so the AppState resume handler can use the real heartbeat
+// cadence as its "was the app backgrounded long enough for the socket to have
+// silently died?" threshold, rather than hardcoding a separate magic number
+// that could drift from this one.
+export const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 // #5515 (epic #5514): throttle the dev latency readout so a streaming turn
 // can't spam the console — one line every few seconds is enough to watch the
@@ -892,11 +896,41 @@ const QUEUE_TTLS: Record<string, number> = {
 const QUEUE_MAX_SIZE = 10;
 const QUEUE_EXCLUDED = new Set(['set_model', 'set_permission_mode', 'mode', 'resize']);
 
+/**
+ * #5633: surface a queue failure to the user as a system message in the
+ * transcript, matching how the existing "Message queued — waiting for
+ * reconnection..." feedback is rendered in SessionScreen. Silently dropping
+ * input/interrupts here is exactly the "I sent it and nothing happened" class
+ * of bug we're fixing — the user must see that the action did not land.
+ */
+function notifyQueueFailure(content: string): void {
+  try {
+    getStore().getState().addMessage({
+      id: nextMessageId('queue-drop'),
+      type: 'system',
+      content,
+      timestamp: Date.now(),
+    });
+  } catch {
+    // addMessage targets the active session; if there's no active session the
+    // failure can't be surfaced inline, but never let feedback throw into the
+    // send/drain path.
+  }
+}
+
 export function enqueueMessage(type: string, payload: unknown): 'queued' | false {
   if (QUEUE_EXCLUDED.has(type)) return false;
   const maxAge = QUEUE_TTLS[type];
   if (!maxAge) return false;
-  if (_ctx.messageQueue.length >= QUEUE_MAX_SIZE) return false;
+  if (_ctx.messageQueue.length >= QUEUE_MAX_SIZE) {
+    // #5633: the queue is full — the 11th+ message would otherwise be dropped
+    // silently with sendInput still reporting nothing actionable. Tell the user.
+    console.warn(`[queue] Queue full (${QUEUE_MAX_SIZE}) — dropping ${type}`);
+    notifyQueueFailure(
+      `Couldn't queue your message — too many pending while disconnected (max ${QUEUE_MAX_SIZE}). Please resend after reconnecting.`,
+    );
+    return false;
+  }
   _ctx.messageQueue.push({ type, payload, queuedAt: Date.now(), maxAge });
   console.log(`[queue] Queued ${type} (${_ctx.messageQueue.length}/${QUEUE_MAX_SIZE})`);
   return 'queued';
@@ -905,8 +939,28 @@ export function enqueueMessage(type: string, payload: unknown): 'queued' | false
 export function drainMessageQueue(socket: WebSocket): void {
   if (_ctx.messageQueue.length === 0) return;
   const now = Date.now();
-  const valid = _ctx.messageQueue.filter((m) => now - m.queuedAt < m.maxAge);
+  const valid: QueuedMessage[] = [];
+  const expired: QueuedMessage[] = [];
+  for (const m of _ctx.messageQueue) {
+    if (now - m.queuedAt < m.maxAge) valid.push(m);
+    else expired.push(m);
+  }
   _ctx.messageQueue.length = 0;
+
+  // #5633: a queued message can expire before a longer backoff completes —
+  // notably an `interrupt` with its 5s TTL. That drop was invisible: the user
+  // tapped Stop, the reconnect took >5s, and the interrupt silently evaporated.
+  // Surface any expired entry so the user knows it didn't land.
+  if (expired.length > 0) {
+    console.warn(`[queue] Dropping ${expired.length} expired queued message(s) on drain`);
+    const hadInterrupt = expired.some((m) => m.type === 'interrupt');
+    if (hadInterrupt) {
+      notifyQueueFailure('Your interrupt expired before reconnecting and was not sent — tap Stop again if still needed.');
+    } else {
+      notifyQueueFailure('A queued message expired before reconnecting and was not sent — please resend.');
+    }
+  }
+
   if (valid.length === 0) return;
   console.log(`[queue] Draining ${valid.length} queued message(s)`);
   for (const m of valid) {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -386,7 +386,10 @@ export interface ConnectionActions {
    */
   connectAuto: (
     saved: SavedConnection,
-    options?: { silent?: boolean; preferTunnel?: boolean },
+    // #5633 — `force` skips connectAuto's "already connected to this URL" no-op
+    // guard so the resume zombie-socket path can force a fresh reconnect even
+    // when the socket still claims OPEN on an unchanged tunnel URL.
+    options?: { silent?: boolean; preferTunnel?: boolean; force?: boolean },
   ) => Promise<void>;
   disconnect: () => void;
   loadSavedConnection: () => Promise<void>;


### PR DESCRIPTION
Closes #5633

Fixes three related "I sent it and nothing happened" failures that silently lose user input on a real phone. All three live in `packages/app/src/store/`.

## 1. Zombie socket on resume (primary)
After the app is backgrounded, iOS suspends JS — freezing the 15s heartbeat — and the tunnel/NAT can drop the TCP connection. On foreground the socket frequently still reports `readyState === OPEN` while being dead. The old resume guard (`connectionPhase === 'connected' && socket.readyState !== WebSocket.OPEN`) took no action, so for ~20s `sendInput` shipped input into a dead socket, returned `'sent'`, and nothing was queued.

**Fix:** the `AppState` resume handler now records when the app left the foreground and computes the background duration on resume. If we were away at least one heartbeat cycle (`HEARTBEAT_INTERVAL_MS`, now exported from `message-handler.ts` so the threshold can't drift from the real cadence), `readyState === OPEN` is treated as untrustworthy and we proactively reconnect via the existing auto-connect path (`connectAuto` when a saved record exists, else `connect`). Respects the existing 5s resume cooldown and the reconnect ladder; skips when the user explicitly disconnected. The genuinely-dead-but-cooled-down case is still caught by the next heartbeat pong-timeout, so no reconnect storms.

## 2. Optimistic-send safety net fired against the wrong session
The `addUserMessage` safety timer re-read `get().activeSessionId` at **fire** time, so switching sessions (or a slow `stream_start` on cellular) nulled `streamingMessageId` and wiped the "thinking" indicator for the wrong/live turn.

**Fix:** capture the arming `activeSessionId` in the closure and only clear that exact session while `streamingMessageId === 'pending'`. Prefers the server-advertised `streamStallTimeoutMs` window (already plumbed in `connection-lifecycle.ts`) over the hardcoded 5s, falling back to 5s when the server doesn't advertise one.

## 3. Silent queue drops were invisible
`enqueueMessage` dropped the 11th message (`QUEUE_MAX_SIZE = 10`) and `drainMessageQueue` dropped a queued `interrupt` whose 5s TTL expired across a longer backoff — both silently, with `sendInput` returning `false` that callers didn't surface.

**Fix:** both paths now emit a `system` message into the transcript (matching the existing "Message queued — waiting for reconnection..." feedback in `SessionScreen.tsx`). Overflow and expired-interrupt get distinct, actionable copy. Non-queueable types (excluded / no TTL) stay silent.

## Tests
- `__tests__/MessageQueueDrops.test.ts` — overflow surfaces a system message; non-queueable types stay silent; expired interrupt on drain surfaces a notice and is not sent; valid messages drain cleanly.
- `__tests__/OptimisticSendSafetyNet.test.ts` — net clears the arming session; does NOT wipe a different session the user switched to; does NOT clear once the arming session is actually streaming; honours the server-advertised stall window over the 5s fallback.
- `__tests__/AppStateListener.test.ts` — extended with source-level assertions for the resume liveness logic (matching the repo's existing AppState/Network listener test convention, which asserts gating rather than mocking the native AppState emitter).

## Verification
- `npx tsc --noEmit` — clean (after `npm run bundle-xterm`, same as CI).
- `npm test` — 133 suites / 1793 tests pass.
- New tests: 15 pass.

No eslint config exists for the app package; CI runs jest + tsc for the app, both green.