### PR TITLE
fix(ws): reject post-handshake plaintext frames once encrypted

### DIFF
--- a/packages/app/src/__tests__/store/connection-encryption-guard.test.ts
+++ b/packages/app/src/__tests__/store/connection-encryption-guard.test.ts
@@ -150,16 +150,74 @@ describe('#5632 post-handshake plaintext guard', () => {
     expect(useConnectionStore.getState().serverErrors).toHaveLength(0);
   });
 
-  it('still accepts cleartext handshake frames when encryption is active', async () => {
+  it('still DISPATCHES cleartext terminal handshake frames (auth_fail) when encryption is active', async () => {
     const socket = await connectAndGetSocket();
     establishEncryption();
 
-    // key_exchange_ok / auth_fail are on the handshake allow-list — the guard
-    // must NOT close the socket for them. (They never carry app state; the
-    // dispatch is a no-op here because no pendingKeyPair is set, which is fine —
-    // the assertion is purely that the GUARD did not tear the socket down.)
-    socket.onmessage!({ data: JSON.stringify({ type: 'key_exchange_ok', publicKey: 'x' }) });
+    // auth_fail is a terminal handshake frame the server may legitimately emit
+    // cleartext — the guard must allow-list it so it reaches handleMessage. The
+    // handler itself tears the connection down (sets a connectionError +
+    // disconnected phase), which the guard's reject path never does. Asserting on
+    // that handler side effect proves the frame was DISPATCHED, not rejected.
+    socket.onmessage!({ data: JSON.stringify({ type: 'auth_fail', reason: 'token-expired' }) });
+
+    const err = useConnectionLifecycleStore.getState().connectionError;
+    expect(err).toMatch(/Auth failed/i);
+    expect(err).toMatch(/token-expired/);
+  });
+
+  it('DROPS a late plaintext auth_ok after encryption — no dispatch, socket stays open (#5632 Copilot)', async () => {
+    const socket = await connectAndGetSocket();
+    establishEncryption();
+
+    // Seed identity/UI state that a re-entered handshake would clobber.
+    useConnectionStore.setState({
+      myClientId: 'client-real',
+      connectedClients: [{ clientId: 'client-real', deviceName: 'real' } as never],
+    });
+
+    // A MITM injects a plaintext auth_ok AFTER encryption is established. It must
+    // be DROPPED (logged + return) — not re-dispatched into the handshake state
+    // machine — and the socket must stay OPEN (closing would let a forged frame
+    // DoS the connection).
+    socket.onmessage!({
+      data: JSON.stringify({ type: 'auth_ok', clientId: 'attacker', connectedClients: [] }),
+    });
+
     expect(socket.close).not.toHaveBeenCalled();
+    // State the forged handshake would have overwritten is untouched.
+    expect(useConnectionStore.getState().myClientId).toBe('client-real');
+    expect(useConnectionStore.getState().connectedClients).toHaveLength(1);
+  });
+
+  it('DROPS a late plaintext key_exchange_ok after encryption — no dispatch, socket stays open (#5632 Copilot)', async () => {
+    const socket = await connectAndGetSocket();
+    establishEncryption();
+
+    const before = getEncryptionState();
+    // A forged key_exchange_ok would re-enter the key-exchange path and could
+    // force a fresh re-key. It must be dropped without dispatch and without
+    // tearing the socket down.
+    socket.onmessage!({ data: JSON.stringify({ type: 'key_exchange_ok', publicKey: 'attacker' }) });
+
+    expect(socket.close).not.toHaveBeenCalled();
+    // Encryption state untouched — the drop happened before any handler ran.
+    expect(getEncryptionState()).toBe(before);
+  });
+
+  it('REJECTS a forged plaintext `error` frame after encryption (server now sends it encrypted) — closes socket', async () => {
+    const socket = await connectAndGetSocket();
+    establishEncryption();
+
+    // Since #5632 the server routes sendError() through the encrypting
+    // transport, so a legitimate post-handshake `error` arrives as an
+    // `encrypted` envelope. A plaintext `error` is therefore a forged/downgrade
+    // frame and must be rejected + closed.
+    socket.onmessage!({
+      data: JSON.stringify({ type: 'error', code: 'INVALID_MODEL', message: 'pwned' }),
+    });
+
+    expect(socket.close).toHaveBeenCalledTimes(1);
   });
 
   it('decrypts and dispatches a genuine encrypted frame when encryption is active', async () => {

--- a/packages/app/src/__tests__/store/connection-encryption-guard.test.ts
+++ b/packages/app/src/__tests__/store/connection-encryption-guard.test.ts
@@ -1,0 +1,196 @@
+/**
+ * #5632 — post-handshake plaintext guard (consensus C3 / Adversary F1).
+ *
+ * Once E2E encryption is established, the socket.onmessage handler in
+ * connection.ts must reject any non-`encrypted` frame that is not a permitted
+ * cleartext handshake frame, failing closed on the same path a decrypt failure
+ * takes (log + socket.close, no dispatch). These tests drive the real connect()
+ * → socket.onmessage path with a mock WebSocket and exercise the guard directly.
+ */
+import { Alert } from 'react-native';
+import { useConnectionStore } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { clearAllCallbacks } from '../../store/imperative-callbacks';
+import {
+  setEncryptionState,
+  getEncryptionState,
+} from '../../store/message-handler';
+import {
+  createKeyPair,
+  deriveSharedKey,
+  encrypt,
+  DIRECTION_SERVER,
+} from '../../utils/crypto';
+
+// Spy on Alert.alert — avoids jest.mock('react-native') which triggers native modules
+jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => jest.requireActual<typeof globalThis>('timers').setImmediate(resolve));
+}
+
+function mockResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  } as unknown as Response;
+}
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+const wsInstances: FakeSocket[] = [];
+const originalFetch = global.fetch;
+const OriginalWebSocket = global.WebSocket;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  clearAllCallbacks();
+  wsInstances.length = 0;
+  useConnectionStore.setState({
+    terminalBuffer: '',
+    terminalRawBuffer: '',
+    serverErrors: [],
+    connectedClients: [],
+    myClientId: null,
+    primaryClientId: null,
+    sessionStates: {},
+    activeSessionId: null,
+    socket: null,
+    shutdownReason: null,
+    restartEtaMs: null,
+    restartingSince: null,
+  });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+  });
+
+  global.fetch = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket implements FakeSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 1;
+    onopen: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn();
+    constructor(url: string) {
+      this.url = url;
+      wsInstances.push(this as unknown as FakeSocket);
+    }
+  };
+});
+
+afterEach(() => {
+  setEncryptionState(null);
+  useConnectionStore.getState().disconnect();
+  global.fetch = originalFetch;
+  global.WebSocket = OriginalWebSocket;
+  jest.useRealTimers();
+});
+
+/** Drive connect() to the point a mock socket exists with onmessage wired. */
+async function connectAndGetSocket(): Promise<FakeSocket> {
+  useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
+  await flushPromises();
+  const socket = wsInstances[0];
+  if (!socket || !socket.onmessage) {
+    throw new Error('mock socket onmessage was not wired');
+  }
+  return socket;
+}
+
+/** Install a deterministic encryption state shared with a peer "server" key. */
+function establishEncryption(): { serverShared: Uint8Array } {
+  const clientKp = createKeyPair();
+  const serverKp = createKeyPair();
+  const clientShared = deriveSharedKey(serverKp.publicKey, clientKp.secretKey);
+  const serverShared = deriveSharedKey(clientKp.publicKey, serverKp.secretKey);
+  setEncryptionState({ sharedKey: clientShared, sendNonce: 0, recvNonce: 0 });
+  return { serverShared };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('#5632 post-handshake plaintext guard', () => {
+  it('rejects a plaintext app frame received AFTER encryption is established', async () => {
+    const socket = await connectAndGetSocket();
+    establishEncryption();
+
+    expect(useConnectionStore.getState().serverErrors).toHaveLength(0);
+
+    // A forged plaintext server_error (not an `encrypted` envelope, not a
+    // handshake frame) must be dropped and the socket closed.
+    socket.onmessage!({ data: JSON.stringify({ type: 'server_error', error: 'pwned' }) });
+
+    expect(socket.close).toHaveBeenCalledTimes(1);
+    // The frame must NOT have been dispatched — serverErrors stays empty.
+    expect(useConnectionStore.getState().serverErrors).toHaveLength(0);
+  });
+
+  it('still accepts cleartext handshake frames when encryption is active', async () => {
+    const socket = await connectAndGetSocket();
+    establishEncryption();
+
+    // key_exchange_ok / auth_fail are on the handshake allow-list — the guard
+    // must NOT close the socket for them. (They never carry app state; the
+    // dispatch is a no-op here because no pendingKeyPair is set, which is fine —
+    // the assertion is purely that the GUARD did not tear the socket down.)
+    socket.onmessage!({ data: JSON.stringify({ type: 'key_exchange_ok', publicKey: 'x' }) });
+    expect(socket.close).not.toHaveBeenCalled();
+  });
+
+  it('decrypts and dispatches a genuine encrypted frame when encryption is active', async () => {
+    const socket = await connectAndGetSocket();
+    const { serverShared } = establishEncryption();
+
+    // Server encrypts a server_error at recvNonce 0 — the guard's `encrypted`
+    // branch should decrypt it and dispatch normally.
+    const envelope = encrypt(
+      JSON.stringify({ type: 'server_error', error: 'real' }),
+      serverShared,
+      0,
+      DIRECTION_SERVER,
+    );
+    socket.onmessage!({ data: JSON.stringify(envelope) });
+
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().serverErrors.length).toBeGreaterThan(0);
+    // recvNonce advanced after a successful decrypt.
+    expect(getEncryptionState()?.recvNonce).toBe(1);
+  });
+
+  it('leaves plaintext-mode (encryption disabled) sessions unaffected', async () => {
+    const socket = await connectAndGetSocket();
+    // No encryption established — encState is null.
+    expect(getEncryptionState()).toBeNull();
+
+    socket.onmessage!({ data: JSON.stringify({ type: 'server_error', error: 'plain' }) });
+
+    // The guard must NOT fire: the frame is dispatched and the socket stays open.
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().serverErrors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -185,6 +185,29 @@ import {
 
 const STORAGE_KEY_INPUT_SETTINGS = 'chroxy_input_settings';
 
+// #5632 — post-handshake plaintext guard (consensus C3 / Adversary F1).
+// Once E2E encryption is established (encState set), every server→client frame
+// MUST arrive inside an `encrypted` envelope. The #5614 downgrade gate only
+// protects the `auth_ok` handshake frame; without this guard a MITM could still
+// inject a forged plaintext app frame (e.g. permission_request) AFTER the
+// handshake and have the client act on it. We fail closed exactly like a
+// decrypt failure.
+//
+// The allow-list is the set of cleartext handshake frames the server
+// legitimately emits before encryption is active (auth_ok / key_exchange_ok /
+// auth_fail / pair_fail — see packages/server/src/ws-auth.js). In practice
+// these all arrive while encState is still null (the eager path sets encState
+// WHILE handling auth_ok, but the onmessage decrypt-check for that frame already
+// ran with encState null), so they never actually hit this guard on a normal
+// connection — they are listed so a benign duplicate/terminal handshake frame
+// is tolerated rather than tearing down the socket.
+const ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST = new Set([
+  'auth_ok',
+  'key_exchange_ok',
+  'auth_fail',
+  'pair_fail',
+]);
+
 // #5555.5 — the close/error-path reconnect delay is no longer a fixed
 // constant. Both handlers now climb the RETRY_DELAYS ladder (defined in
 // connect()) via the module-level reconnectAttempt counter, which resets on
@@ -1137,6 +1160,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           socket.close();
           return;
         }
+      } else if (encState && !ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST.has(msg.type)) {
+        // #5632 — encryption is active but this frame is NOT an `encrypted`
+        // envelope and NOT a permitted cleartext handshake frame. Treat it as a
+        // downgrade/injection attempt and fail closed on the same path a decrypt
+        // failure takes (log + close, no dispatch).
+        console.error('[crypto] Rejected plaintext frame after encryption established:', msg.type);
+        socket.close();
+        return;
       }
       handleMessage(msg, socketCtx);
     };

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -191,19 +191,35 @@ const STORAGE_KEY_INPUT_SETTINGS = 'chroxy_input_settings';
 // protects the `auth_ok` handshake frame; without this guard a MITM could still
 // inject a forged plaintext app frame (e.g. permission_request) AFTER the
 // handshake and have the client act on it. We fail closed exactly like a
-// decrypt failure.
+// decrypt failure (log + socket.close, no dispatch).
 //
-// The allow-list is the set of cleartext handshake frames the server
-// legitimately emits before encryption is active (auth_ok / key_exchange_ok /
-// auth_fail / pair_fail — see packages/server/src/ws-auth.js). In practice
-// these all arrive while encState is still null (the eager path sets encState
-// WHILE handling auth_ok, but the onmessage decrypt-check for that frame already
-// ran with encState null), so they never actually hit this guard on a normal
-// connection — they are listed so a benign duplicate/terminal handshake frame
-// is tolerated rather than tearing down the socket.
-const ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST = new Set([
+// Post-encState cleartext frames fall into three buckets, handled below:
+//
+//   1. auth_ok / key_exchange_ok — re-entry handshake frames. On a normal
+//      connection these arrive while encState is still null, so they never hit
+//      this guard. After encState is set, a plaintext copy is a forged
+//      re-handshake attempt (a MITM replaying it re-enters the handshake state
+//      machine and can clobber connectedClients / myClientId / UI state and
+//      trigger a fresh key_exchange re-key — see message-handler.ts). We DROP
+//      these silently (log + return, NO dispatch) rather than close, so a
+//      forged frame cannot weaponise the guard into a DoS disconnect.
+//
+//   2. auth_fail / pair_fail — terminal handshake frames the server may
+//      legitimately emit cleartext (e.g. a late rejection). These are safe to
+//      dispatch — they only surface an error / tear the connection down — so
+//      they stay allow-listed and flow through to handleMessage.
+//
+//   3. everything else (including `error`, which since #5632 the server now
+//      sends ENCRYPTED post-handshake) — treated as a downgrade/injection
+//      attempt: log + socket.close, no dispatch.
+//
+// (Encryption-disabled / plaintext sessions never set encState, so the guard is
+// inert for them.)
+const ENCRYPTED_PHASE_HANDSHAKE_DROP = new Set([
   'auth_ok',
   'key_exchange_ok',
+]);
+const ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST = new Set([
   'auth_fail',
   'pair_fail',
 ]);
@@ -1160,9 +1176,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           socket.close();
           return;
         }
+      } else if (encState && ENCRYPTED_PHASE_HANDSHAKE_DROP.has(msg.type)) {
+        // #5632 — a plaintext re-handshake frame (auth_ok / key_exchange_ok)
+        // after encryption is established. A MITM replaying it re-enters the
+        // handshake state machine and can clobber client/UI state or force a
+        // re-key. DROP it silently (no dispatch, no close — closing would let a
+        // forged frame DoS the connection).
+        console.error('[crypto] Dropped plaintext handshake frame after encryption established:', msg.type);
+        return;
       } else if (encState && !ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST.has(msg.type)) {
         // #5632 — encryption is active but this frame is NOT an `encrypted`
-        // envelope and NOT a permitted cleartext handshake frame. Treat it as a
+        // envelope and NOT a permitted terminal handshake frame. Treat it as a
         // downgrade/injection attempt and fail closed on the same path a decrypt
         // failure takes (log + close, no dispatch).
         console.error('[crypto] Rejected plaintext frame after encryption established:', msg.type);

--- a/packages/dashboard/src/store/connection-encryption-guard.test.ts
+++ b/packages/dashboard/src/store/connection-encryption-guard.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #5632 — post-handshake plaintext guard (consensus C3 / Adversary F1), dashboard.
+ *
+ * Once E2E encryption is established, the socket.onmessage handler in
+ * connection.ts must reject any non-`encrypted` frame that is not a permitted
+ * cleartext handshake frame, failing closed on the same path a decrypt failure
+ * takes (log + socket.close, no dispatch). Mirrors the app-side guard test.
+ *
+ * Harness mirrors connection-reconnect-backoff.test.ts (mock WebSocket + fetch).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v },
+  removeItem: (k: string) => { delete store[k] },
+  clear: () => { for (const k of Object.keys(store)) delete store[k] },
+  get length() { return Object.keys(store).length },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+vi.mock('../utils/auth', () => ({ getAuthToken: () => null }))
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 1
+  sent: string[] = []
+  closed = 0
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this) }
+  send(d: string) { this.sent.push(d) }
+  close() { this.closed += 1; this.readyState = 3 }
+}
+;(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket
+;(globalThis as unknown as { fetch: unknown }).fetch = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ status: 'ok' }),
+}))
+
+const { useConnectionStore } = await import('./connection')
+const { setEncryptionState, getEncryptionState, setPendingKeyPair } = await import('./message-handler')
+const { createKeyPair, deriveSharedKey, encrypt, DIRECTION_SERVER } = await import('./crypto')
+
+/** Open a connection and walk it through health check + WS construction. */
+async function openConnected(): Promise<MockWebSocket> {
+  const before = MockWebSocket.instances.length
+  useConnectionStore.getState().connect('wss://tunnel.example.com/ws', 'tok')
+  await vi.advanceTimersByTimeAsync(0)
+  const ws = MockWebSocket.instances[before]!
+  ws.readyState = 1
+  ws.onopen?.()
+  await vi.advanceTimersByTimeAsync(0)
+  if (!ws.onmessage) throw new Error('mock socket onmessage was not wired')
+  return ws
+}
+
+/** Install a deterministic encryption state shared with a peer "server" key. */
+function establishEncryption(): { serverShared: Uint8Array } {
+  const clientKp = createKeyPair()
+  const serverKp = createKeyPair()
+  const clientShared = deriveSharedKey(serverKp.publicKey, clientKp.secretKey)
+  const serverShared = deriveSharedKey(clientKp.publicKey, serverKp.secretKey)
+  setEncryptionState({ sharedKey: clientShared, sendNonce: 0, recvNonce: 0 })
+  return { serverShared }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  MockWebSocket.instances = []
+  for (const k of Object.keys(store)) delete store[k]
+  useConnectionStore.setState({
+    serverRegistry: [],
+    activeServerId: null,
+    connectionPhase: 'disconnected',
+    wsUrl: null,
+    userDisconnected: false,
+    serverErrors: [],
+  })
+})
+
+afterEach(() => {
+  setEncryptionState(null)
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('#5632 post-handshake plaintext guard (dashboard)', () => {
+  it('rejects a plaintext app frame received AFTER encryption is established', async () => {
+    const socket = await openConnected()
+    establishEncryption()
+
+    expect(useConnectionStore.getState().serverErrors).toHaveLength(0)
+
+    socket.onmessage!({ data: JSON.stringify({ type: 'server_error', error: 'pwned' }) })
+
+    expect(socket.closed).toBe(1)
+    expect(useConnectionStore.getState().serverErrors).toHaveLength(0)
+  })
+
+  it('still accepts cleartext handshake frames when encryption is active', async () => {
+    const socket = await openConnected()
+    establishEncryption()
+    // Null the pending keypair so the key_exchange_ok handler early-returns —
+    // the assertion is purely that the GUARD did not tear the socket down.
+    setPendingKeyPair(null)
+
+    socket.onmessage!({ data: JSON.stringify({ type: 'key_exchange_ok', publicKey: 'x' }) })
+    expect(socket.closed).toBe(0)
+  })
+
+  it('decrypts and dispatches a genuine encrypted frame when encryption is active', async () => {
+    const socket = await openConnected()
+    const { serverShared } = establishEncryption()
+
+    const envelope = encrypt(
+      JSON.stringify({ type: 'server_error', error: 'real' }),
+      serverShared,
+      0,
+      DIRECTION_SERVER,
+    )
+    socket.onmessage!({ data: JSON.stringify(envelope) })
+
+    expect(socket.closed).toBe(0)
+    expect(useConnectionStore.getState().serverErrors.length).toBeGreaterThan(0)
+    expect(getEncryptionState()?.recvNonce).toBe(1)
+  })
+
+  it('leaves plaintext-mode (encryption disabled) sessions unaffected', async () => {
+    const socket = await openConnected()
+    expect(getEncryptionState()).toBeNull()
+
+    socket.onmessage!({ data: JSON.stringify({ type: 'server_error', error: 'plain' }) })
+
+    expect(socket.closed).toBe(0)
+    expect(useConnectionStore.getState().serverErrors.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/dashboard/src/store/connection-encryption-guard.test.ts
+++ b/packages/dashboard/src/store/connection-encryption-guard.test.ts
@@ -104,15 +104,73 @@ describe('#5632 post-handshake plaintext guard (dashboard)', () => {
     expect(useConnectionStore.getState().serverErrors).toHaveLength(0)
   })
 
-  it('still accepts cleartext handshake frames when encryption is active', async () => {
+  it('still DISPATCHES cleartext terminal handshake frames (auth_fail) when encryption is active', async () => {
     const socket = await openConnected()
     establishEncryption()
-    // Null the pending keypair so the key_exchange_ok handler early-returns —
-    // the assertion is purely that the GUARD did not tear the socket down.
-    setPendingKeyPair(null)
+    // Seed a non-null socket in the store so the handler's `set({ socket: null })`
+    // is an observable side effect (the guard's reject path never nulls it).
+    useConnectionStore.setState({ socket: socket as unknown as WebSocket, connectionPhase: 'connected' })
 
-    socket.onmessage!({ data: JSON.stringify({ type: 'key_exchange_ok', publicKey: 'x' }) })
+    // auth_fail is a terminal handshake frame the server may legitimately emit
+    // cleartext — the guard must allow-list it so it reaches handleMessage. The
+    // handler tears the connection down (connectionPhase → disconnected, socket →
+    // null), which the guard's reject path never does — proving DISPATCH.
+    socket.onmessage!({ data: JSON.stringify({ type: 'auth_fail', reason: 'token-expired' }) })
+
+    expect(useConnectionStore.getState().connectionPhase).toBe('disconnected')
+    expect(useConnectionStore.getState().socket).toBeNull()
+  })
+
+  it('DROPS a late plaintext auth_ok after encryption — no dispatch, socket stays open (#5632 Copilot)', async () => {
+    const socket = await openConnected()
+    establishEncryption()
+
+    // Seed identity/UI state a re-entered handshake would clobber.
+    useConnectionStore.setState({
+      myClientId: 'client-real',
+      connectedClients: [{ clientId: 'client-real', deviceName: 'real' } as never],
+    })
+
+    // A MITM injects a plaintext auth_ok AFTER encryption is established. It must
+    // be DROPPED (logged + return) — not re-dispatched into the handshake state
+    // machine — and the socket must stay OPEN.
+    socket.onmessage!({
+      data: JSON.stringify({ type: 'auth_ok', clientId: 'attacker', connectedClients: [] }),
+    })
+
     expect(socket.closed).toBe(0)
+    expect(useConnectionStore.getState().myClientId).toBe('client-real')
+    expect(useConnectionStore.getState().connectedClients).toHaveLength(1)
+  })
+
+  it('DROPS a late plaintext key_exchange_ok after encryption — no dispatch, socket stays open (#5632 Copilot)', async () => {
+    const socket = await openConnected()
+    establishEncryption()
+    // A re-key handler would run if dispatched. Keep a pending keypair set so the
+    // handler WOULD have done work — proving the drop happened before dispatch.
+    setPendingKeyPair(createKeyPair())
+    const before = getEncryptionState()
+
+    socket.onmessage!({ data: JSON.stringify({ type: 'key_exchange_ok', publicKey: 'attacker' }) })
+
+    expect(socket.closed).toBe(0)
+    // Encryption state untouched — the drop happened before any handler ran.
+    expect(getEncryptionState()).toBe(before)
+  })
+
+  it('REJECTS a forged plaintext `error` frame after encryption (server now sends it encrypted) — closes socket', async () => {
+    const socket = await openConnected()
+    establishEncryption()
+
+    // Since #5632 the server routes sendError() through the encrypting
+    // transport, so a legitimate post-handshake `error` arrives as an
+    // `encrypted` envelope. A plaintext `error` is therefore a forged/downgrade
+    // frame and must be rejected + closed.
+    socket.onmessage!({
+      data: JSON.stringify({ type: 'error', code: 'INVALID_MODEL', message: 'pwned' }),
+    })
+
+    expect(socket.closed).toBe(1)
   })
 
   it('decrypts and dispatches a genuine encrypted frame when encryption is active', async () => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -178,6 +178,26 @@ import {
 
 const STORAGE_KEY_INPUT_SETTINGS = 'chroxy_input_settings';
 
+// #5632 — post-handshake plaintext guard (consensus C3 / Adversary F1).
+// Once E2E encryption is established (encState set), every server→client frame
+// MUST arrive inside an `encrypted` envelope. The #5614 downgrade gate only
+// protects the `auth_ok` handshake frame; without this guard a MITM could still
+// inject a forged plaintext app frame AFTER the handshake and have the client
+// act on it. We fail closed exactly like a decrypt failure.
+//
+// The allow-list is the set of cleartext handshake frames the server
+// legitimately emits before encryption is active (auth_ok / key_exchange_ok /
+// auth_fail / pair_fail — see packages/server/src/ws-auth.js). On a normal
+// connection these all arrive while encState is still null, so they never hit
+// this guard; they are listed so a benign duplicate/terminal handshake frame is
+// tolerated rather than tearing down the socket.
+const ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST = new Set([
+  'auth_ok',
+  'key_exchange_ok',
+  'auth_fail',
+  'pair_fail',
+]);
+
 /**
  * Tools eligible for session-scoped auto-approval via the "Allow for Session"
  * button (#2834). Mirrors packages/app/src/store/connection.ts:924 — kept in
@@ -1532,6 +1552,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           socket.close();
           return;
         }
+      } else if (encState && !ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST.has(msg.type)) {
+        // #5632 — encryption is active but this frame is NOT an `encrypted`
+        // envelope and NOT a permitted cleartext handshake frame. Treat it as a
+        // downgrade/injection attempt and fail closed on the same path a decrypt
+        // failure takes (log + close, no dispatch).
+        console.error('[crypto] Rejected plaintext frame after encryption established:', msg.type);
+        socket.close();
+        return;
       }
       handleMessage(msg, socketCtx);
     };

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -183,17 +183,36 @@ const STORAGE_KEY_INPUT_SETTINGS = 'chroxy_input_settings';
 // MUST arrive inside an `encrypted` envelope. The #5614 downgrade gate only
 // protects the `auth_ok` handshake frame; without this guard a MITM could still
 // inject a forged plaintext app frame AFTER the handshake and have the client
-// act on it. We fail closed exactly like a decrypt failure.
+// act on it. We fail closed exactly like a decrypt failure (log + socket.close,
+// no dispatch).
 //
-// The allow-list is the set of cleartext handshake frames the server
-// legitimately emits before encryption is active (auth_ok / key_exchange_ok /
-// auth_fail / pair_fail — see packages/server/src/ws-auth.js). On a normal
-// connection these all arrive while encState is still null, so they never hit
-// this guard; they are listed so a benign duplicate/terminal handshake frame is
-// tolerated rather than tearing down the socket.
-const ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST = new Set([
+// Post-encState cleartext frames fall into three buckets, handled below:
+//
+//   1. auth_ok / key_exchange_ok — re-entry handshake frames. On a normal
+//      connection these arrive while encState is still null, so they never hit
+//      this guard. After encState is set, a plaintext copy is a forged
+//      re-handshake attempt (a MITM replaying it re-enters the handshake state
+//      machine and can clobber connectedClients / myClientId / UI state and
+//      trigger a fresh key_exchange re-key — see message-handler.ts). We DROP
+//      these silently (log + return, NO dispatch) rather than close, so a
+//      forged frame cannot weaponise the guard into a DoS disconnect.
+//
+//   2. auth_fail / pair_fail — terminal handshake frames the server may
+//      legitimately emit cleartext (e.g. a late rejection). These are safe to
+//      dispatch — they only surface an error / tear the connection down — so
+//      they stay allow-listed and flow through to handleMessage.
+//
+//   3. everything else (including `error`, which since #5632 the server now
+//      sends ENCRYPTED post-handshake) — treated as a downgrade/injection
+//      attempt: log + socket.close, no dispatch.
+//
+// (Encryption-disabled / plaintext sessions never set encState, so the guard is
+// inert for them.)
+const ENCRYPTED_PHASE_HANDSHAKE_DROP = new Set([
   'auth_ok',
   'key_exchange_ok',
+]);
+const ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST = new Set([
   'auth_fail',
   'pair_fail',
 ]);
@@ -1552,9 +1571,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           socket.close();
           return;
         }
+      } else if (encState && ENCRYPTED_PHASE_HANDSHAKE_DROP.has(msg.type)) {
+        // #5632 — a plaintext re-handshake frame (auth_ok / key_exchange_ok)
+        // after encryption is established. A MITM replaying it re-enters the
+        // handshake state machine and can clobber client/UI state or force a
+        // re-key. DROP it silently (no dispatch, no close — closing would let a
+        // forged frame DoS the connection).
+        console.error('[crypto] Dropped plaintext handshake frame after encryption established:', msg.type);
+        return;
       } else if (encState && !ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST.has(msg.type)) {
         // #5632 — encryption is active but this frame is NOT an `encrypted`
-        // envelope and NOT a permitted cleartext handshake frame. Treat it as a
+        // envelope and NOT a permitted terminal handshake frame. Treat it as a
         // downgrade/injection attempt and fail closed on the same path a decrypt
         // failure takes (log + close, no dispatch).
         console.error('[crypto] Rejected plaintext frame after encryption established:', msg.type);

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -514,13 +514,27 @@ export function requireSessionMethod(ws, ctx, entry, method, message) {
  * `data` keys named `type`/`requestId`/`code`/`message` are ignored, so a
  * misbehaving caller cannot spoof the wire shape.
  *
+ * #5632: routes through the encryption-aware transport when a handler `ctx`
+ * is supplied. `sendError` emits a plaintext `{ type: 'error' }` frame, and the
+ * client's post-handshake plaintext guard (connection.ts) closes the socket on
+ * any non-`encrypted` frame that isn't a handshake frame once E2E encryption is
+ * established. Passing `ctx` makes the error go out through `ctx.transport.send`
+ * (→ WsServer._send → the per-client encrypting sender), so a post-handshake
+ * error is encrypted (the client decrypts it normally) and a pre-handshake one
+ * stays cleartext (the client's guard is inactive while encState is null —
+ * correct). When `ctx` is absent (pre-auth call sites with no handler context,
+ * e.g. pairing rejectIfBound) we fall back to the raw `ws.send`; those paths run
+ * before encryption is established, so cleartext is correct there too.
+ *
  * @param {WebSocket} ws - Target WebSocket connection
  * @param {string|null} requestId - Correlating request ID (may be null)
  * @param {string} code - Machine-readable error code (e.g. 'HANDLER_ERROR')
  * @param {string} message - Human-readable error description
  * @param {object} [data] - Optional structured fields merged into the payload
+ * @param {object} [ctx] - Handler context; when present routes via
+ *   `ctx.transport.send` so the frame is encrypted for post-handshake clients
  */
-export function sendError(ws, requestId, code, message, data) {
+export function sendError(ws, requestId, code, message, data, ctx) {
   if (!ws || ws.readyState !== 1) return
   const payload = { type: 'error', requestId: requestId ?? null, code, message }
   if (data && typeof data === 'object' && !Array.isArray(data)) {
@@ -534,6 +548,12 @@ export function sendError(ws, requestId, code, message, data) {
       if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
       payload[key] = value
     }
+  }
+  // #5632: prefer the encryption-aware transport so post-handshake errors are
+  // encrypted; fall back to raw send for pre-auth call sites without a ctx.
+  if (ctx && typeof ctx.transport?.send === 'function') {
+    ctx.transport.send(ws, payload)
+    return
   }
   ws.send(JSON.stringify(payload))
 }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -734,7 +734,7 @@ function handleRegisterPushToken(ws, client, msg, ctx) {
  */
 function handleNotificationPrefsGet(ws, client, msg, ctx) {
   if (!ctx.services.pushManager) {
-    sendError(ws, msg?.requestId, 'NOT_AVAILABLE', 'notification prefs unavailable (no push manager)')
+    sendError(ws, msg?.requestId, 'NOT_AVAILABLE', 'notification prefs unavailable (no push manager)', undefined, ctx)
     return
   }
   ctx.transport.send(ws, {
@@ -746,12 +746,12 @@ function handleNotificationPrefsGet(ws, client, msg, ctx) {
 
 function handleNotificationPrefsSet(ws, client, msg, ctx) {
   if (!ctx.services.pushManager) {
-    sendError(ws, msg?.requestId, 'NOT_AVAILABLE', 'notification prefs unavailable (no push manager)')
+    sendError(ws, msg?.requestId, 'NOT_AVAILABLE', 'notification prefs unavailable (no push manager)', undefined, ctx)
     return
   }
   const patch = msg?.prefs
   if (!patch || typeof patch !== 'object') {
-    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'prefs object is required')
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'prefs object is required', undefined, ctx)
     return
   }
   // #4551 — validate every device-key against the same gate
@@ -771,12 +771,12 @@ function handleNotificationPrefsSet(ws, client, msg, ctx) {
     // shape-specific message so misbehaving clients get a clear
     // signal that `devices` must be a map keyed by push token.
     if (Array.isArray(patch.devices)) {
-      sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'devices must be an object, not an array')
+      sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'devices must be an object, not an array', undefined, ctx)
       return
     }
     for (const key of Object.keys(patch.devices)) {
       if (!PushManager.isValidPushTokenFormat(key)) {
-        sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'Invalid device token format in notification_prefs_set')
+        sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'Invalid device token format in notification_prefs_set', undefined, ctx)
         return
       }
     }
@@ -790,7 +790,7 @@ function handleNotificationPrefsSet(ws, client, msg, ctx) {
     next = ctx.services.pushManager.setPrefs(patch, { platform: client.deviceInfo?.platform || null })
   } catch (err) {
     log.warn(`notification_prefs_set persist failed: ${err?.message}`)
-    sendError(ws, msg?.requestId, 'NOTIFICATION_PREFS_WRITE_FAILED', err?.message || 'write failed')
+    sendError(ws, msg?.requestId, 'NOTIFICATION_PREFS_WRITE_FAILED', err?.message || 'write failed', undefined, ctx)
     return
   }
   // Reply to the originating client with the requestId so promise-style

--- a/packages/server/src/handlers/pairing-handlers.js
+++ b/packages/server/src/handlers/pairing-handlers.js
@@ -30,19 +30,22 @@ import { sendError } from '../handler-utils.js'
 const log = createLogger('ws')
 
 /** Reject a bound (non-host) client. Mirrors the host_status_request gate. */
-function rejectIfBound(ws, client, msg) {
+function rejectIfBound(ws, client, msg, ctx) {
   if (!client?.boundSessionId) return false
+  // #5632: route through ctx.transport so the error is encrypted for a
+  // post-handshake host; the bound client invoking pair_approve may already
+  // have E2E encryption established.
   sendError(ws, msg?.requestId ?? null, 'FORBIDDEN',
-    'pair approval requires host-level authority (a session-bound token cannot approve new devices)')
+    'pair approval requires host-level authority (a session-bound token cannot approve new devices)', undefined, ctx)
   return true
 }
 
 async function handlePairApprove(ws, client, msg, ctx) {
-  if (rejectIfBound(ws, client, msg)) return
+  if (rejectIfBound(ws, client, msg, ctx)) return
   const pairingManager = ctx?.services?.pairingManager
   const requestId = typeof msg?.requestId === 'string' ? msg.requestId : null
   if (!pairingManager || !requestId) {
-    sendError(ws, requestId, 'PAIR_APPROVE_FAILED', 'pairing is not enabled or requestId is missing')
+    sendError(ws, requestId, 'PAIR_APPROVE_FAILED', 'pairing is not enabled or requestId is missing', undefined, ctx)
     return
   }
 
@@ -50,7 +53,7 @@ async function handlePairApprove(ws, client, msg, ctx) {
   if (!result.ok) {
     // not_found / expired / already_resolved — surface to the approver so the
     // dashboard can drop its banner. Never logs a token.
-    sendError(ws, requestId, 'PAIR_APPROVE_FAILED', `cannot approve request: ${result.reason}`, { reason: result.reason })
+    sendError(ws, requestId, 'PAIR_APPROVE_FAILED', `cannot approve request: ${result.reason}`, { reason: result.reason }, ctx)
     // Retract the banner on every host surface for a stale request.
     if (result.reason !== 'not_found') ctx.services.broadcastPairResolved(requestId, result.reason)
     return
@@ -68,11 +71,11 @@ async function handlePairApprove(ws, client, msg, ctx) {
 }
 
 async function handlePairDeny(ws, client, msg, ctx) {
-  if (rejectIfBound(ws, client, msg)) return
+  if (rejectIfBound(ws, client, msg, ctx)) return
   const pairingManager = ctx?.services?.pairingManager
   const requestId = typeof msg?.requestId === 'string' ? msg.requestId : null
   if (!pairingManager || !requestId) {
-    sendError(ws, requestId, 'PAIR_DENY_FAILED', 'pairing is not enabled or requestId is missing')
+    sendError(ws, requestId, 'PAIR_DENY_FAILED', 'pairing is not enabled or requestId is missing', undefined, ctx)
     return
   }
 

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -112,7 +112,7 @@ function getProviderAllowedModels(providerName) {
 function handleSetModel(ws, client, msg, ctx) {
   if (typeof msg.model !== 'string') {
     log.warn(`Rejected invalid model from ${client.id}: ${JSON.stringify(msg.model)}`)
-    sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`)
+    sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`, undefined, ctx)
     return
   }
 
@@ -136,7 +136,7 @@ function handleSetModel(ws, client, msg, ctx) {
       const model = msg.model.trim()
       if (model.length === 0) {
         log.warn(`Rejected empty model id on ${entry.provider} session ${modelSessionId} from ${client.id}`)
-        sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`)
+        sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`, undefined, ctx)
         return
       }
       ;sessionLogger(modelSessionId).info(`Model change from ${client.id} on session ${modelSessionId}: ${model}`)
@@ -157,6 +157,8 @@ function handleSetModel(ws, client, msg, ctx) {
           msg?.requestId,
           'MODEL_NOT_SUPPORTED_BY_PROVIDER',
           `Model '${msg.model}' is not supported by the active provider '${entry.provider}'. Supported models: ${providerAllowed.join(', ')}`,
+          undefined,
+          ctx,
         )
         return
       }
@@ -185,7 +187,7 @@ function handleSetModel(ws, client, msg, ctx) {
   }
 
   log.warn(`Rejected invalid model from ${client.id}: ${JSON.stringify(msg.model)}`)
-  sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`)
+  sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`, undefined, ctx)
 }
 
 function handleSetPermissionMode(ws, client, msg, ctx) {
@@ -215,6 +217,8 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
             msg?.requestId,
             'CAPABILITY_NOT_SUPPORTED',
             `The active provider '${entry.provider}' does not support permission mode switching.`,
+            undefined,
+            ctx,
           )
           return
         }
@@ -256,14 +260,16 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
           // session the rejection belongs to.
           loggerForSession('ws', client.boundSessionId).warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to flip to auto permission mode — rejected`)
           sendError(ws, msg?.requestId, 'AUTO_MODE_FORBIDDEN_BOUND_CLIENT',
-            'Pairing-issued session tokens cannot enable auto permission mode. Use the primary API token from a device with physical access to this machine.')
+            'Pairing-issued session tokens cannot enable auto permission mode. Use the primary API token from a device with physical access to this machine.',
+            undefined, ctx)
           return
         }
         if (ctx.services.config?.allowAutoPermissionMode !== true) {
           // #4828: session-scoped (single-session fallback).
           ;sessionLogger(permModeSessionId).warn(`Client ${client.id} attempted to flip to auto permission mode but allowAutoPermissionMode is not enabled in server config`)
           sendError(ws, msg?.requestId, 'AUTO_MODE_DISABLED_BY_CONFIG',
-            'Auto permission mode is disabled on this server. To enable, set allowAutoPermissionMode:true in the server config file (requires local filesystem access). Default is disabled for security.')
+            'Auto permission mode is disabled on this server. To enable, set allowAutoPermissionMode:true in the server config file (requires local filesystem access). Default is disabled for security.',
+            undefined, ctx)
           return
         }
       }
@@ -313,7 +319,8 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
           // #4828: session-scoped (single-session fallback).
           ;sessionLogger(permModeSessionId).warn(`set_permission_mode rejected (session busy or no-op): requested ${msg.mode}, still ${actualMode}`)
           sendError(ws, msg?.requestId, 'PERMISSION_MODE_NOT_APPLIED',
-            `Permission mode change to '${msg.mode}' was not applied (session busy or already in that mode).`)
+            `Permission mode change to '${msg.mode}' was not applied (session busy or already in that mode).`,
+            undefined, ctx)
           return
         }
         if (ctx.permissions.permissionAudit) {
@@ -329,7 +336,7 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
     }
   } else {
     log.warn(`Rejected invalid permission mode from ${client.id}: ${JSON.stringify(msg.mode)}`)
-    sendError(ws, msg?.requestId, 'INVALID_PERMISSION_MODE', `Invalid permission mode: ${msg.mode}`)
+    sendError(ws, msg?.requestId, 'INVALID_PERMISSION_MODE', `Invalid permission mode: ${msg.mode}`, undefined, ctx)
   }
 }
 
@@ -483,11 +490,13 @@ function handleListProviders(ws, client, msg, ctx) {
  * @param {object} msg
  * @returns {boolean} true if the write was rejected.
  */
-function rejectCredentialWriteIfBound(ws, client, msg) {
+function rejectCredentialWriteIfBound(ws, client, msg, ctx) {
   if (!client?.boundSessionId) return false
   loggerForSession('ws', client.boundSessionId).warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to modify provider credentials — rejected`)
+  // #5632: route through ctx.transport so the error is encrypted for a
+  // post-handshake host.
   sendError(ws, msg?.requestId, 'CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT',
-    'Pairing-issued session tokens cannot modify provider credentials. Use the primary API token from a device with physical access to this machine.')
+    'Pairing-issued session tokens cannot modify provider credentials. Use the primary API token from a device with physical access to this machine.', undefined, ctx)
   return true
 }
 
@@ -510,13 +519,13 @@ function handleByokGetCredentialsStatus(ws, client, msg, ctx) {
 }
 
 function handleByokSetCredentials(ws, client, msg, ctx) {
-  if (rejectCredentialWriteIfBound(ws, client, msg)) return
+  if (rejectCredentialWriteIfBound(ws, client, msg, ctx)) return
   // Trim leading/trailing whitespace — pastes often carry surrounding
   // spaces/newlines that would otherwise be persisted into the credentials
   // file and silently fail when the SDK tries to use the key.
   const key = typeof msg?.anthropicApiKey === 'string' ? msg.anthropicApiKey.trim() : msg?.anthropicApiKey
   if (typeof key !== 'string' || key.length === 0) {
-    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'anthropicApiKey is required')
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'anthropicApiKey is required', undefined, ctx)
     return
   }
   // Reject anything that doesn't even look like a key. The Anthropic key
@@ -524,14 +533,14 @@ function handleByokSetCredentials(ws, client, msg, ctx) {
   // evolve — but the prefix check catches obvious pastes-of-the-wrong-
   // thing (e.g. OpenAI keys, OAuth tokens) before we persist them.
   if (!key.startsWith('sk-ant-')) {
-    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'API key must start with sk-ant-')
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'API key must start with sk-ant-', undefined, ctx)
     return
   }
   try {
     writeAnthropicApiKey(key)
   } catch (err) {
     log.warn(`byok_set_credentials write failed: ${err?.message}`)
-    sendError(ws, msg?.requestId, 'CREDENTIALS_WRITE_FAILED', err?.message || 'write failed')
+    sendError(ws, msg?.requestId, 'CREDENTIALS_WRITE_FAILED', err?.message || 'write failed', undefined, ctx)
     return
   }
   const status = getAnthropicApiKeyStatus()
@@ -546,11 +555,11 @@ function handleByokSetCredentials(ws, client, msg, ctx) {
 }
 
 function handleByokClearCredentials(ws, client, msg, ctx) {
-  if (rejectCredentialWriteIfBound(ws, client, msg)) return
+  if (rejectCredentialWriteIfBound(ws, client, msg, ctx)) return
   try {
     clearAnthropicApiKey()
   } catch (err) {
-    sendError(ws, msg?.requestId, 'CREDENTIALS_CLEAR_FAILED', err?.message || 'clear failed')
+    sendError(ws, msg?.requestId, 'CREDENTIALS_CLEAR_FAILED', err?.message || 'clear failed', undefined, ctx)
     return
   }
   const status = getAnthropicApiKeyStatus()
@@ -600,14 +609,14 @@ function handleGetCredentialsStatus(ws, client, msg, ctx) {
 }
 
 function handleSetCredential(ws, client, msg, ctx) {
-  if (rejectCredentialWriteIfBound(ws, client, msg)) return
+  if (rejectCredentialWriteIfBound(ws, client, msg, ctx)) return
   const key = typeof msg?.key === 'string' ? msg.key : ''
   if (!isKnownCredentialKey(key)) {
-    sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`)
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`, undefined, ctx)
     return
   }
   if (typeof msg?.value !== 'string' || msg.value.trim().length === 0) {
-    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'value is required')
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'value is required', undefined, ctx)
     return
   }
   try {
@@ -617,23 +626,23 @@ function handleSetCredential(ws, client, msg, ctx) {
   } catch (err) {
     // err.message is validation text or a file-mode reason — never the value.
     log.warn(`set_credential failed for ${key}: ${err?.message}`)
-    sendError(ws, msg?.requestId, 'CREDENTIAL_WRITE_FAILED', err?.message || 'write failed')
+    sendError(ws, msg?.requestId, 'CREDENTIAL_WRITE_FAILED', err?.message || 'write failed', undefined, ctx)
     return
   }
   _sendCredentialsStatus(ctx, ws, msg?.requestId)
 }
 
 function handleDeleteCredential(ws, client, msg, ctx) {
-  if (rejectCredentialWriteIfBound(ws, client, msg)) return
+  if (rejectCredentialWriteIfBound(ws, client, msg, ctx)) return
   const key = typeof msg?.key === 'string' ? msg.key : ''
   if (!isKnownCredentialKey(key)) {
-    sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`)
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`, undefined, ctx)
     return
   }
   try {
     deleteStoredCredential(key)
   } catch (err) {
-    sendError(ws, msg?.requestId, 'CREDENTIAL_CLEAR_FAILED', err?.message || 'clear failed')
+    sendError(ws, msg?.requestId, 'CREDENTIAL_CLEAR_FAILED', err?.message || 'clear failed', undefined, ctx)
     return
   }
   _sendCredentialsStatus(ctx, ws, msg?.requestId)
@@ -642,7 +651,7 @@ function handleDeleteCredential(ws, client, msg, ctx) {
 async function handleTestCredential(ws, client, msg, ctx) {
   const key = typeof msg?.key === 'string' ? msg.key : ''
   if (!isKnownCredentialKey(key)) {
-    sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`)
+    sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`, undefined, ctx)
     return
   }
   let result
@@ -837,6 +846,8 @@ function handleSkillActivate(ws, client, msg, ctx) {
       msg?.requestId,
       'SKILL_TOGGLE_UNSUPPORTED',
       `Provider '${entry.provider}' does not support runtime skill toggling. Restart the session with the skill in 'activeManualSkills' instead.`,
+      undefined,
+      ctx,
     )
     return
   }
@@ -875,6 +886,8 @@ function handleSkillDeactivate(ws, client, msg, ctx) {
       msg?.requestId,
       'SKILL_TOGGLE_UNSUPPORTED',
       `Provider '${entry.provider}' does not support runtime skill toggling. Restart the session without the skill in 'activeManualSkills' instead.`,
+      undefined,
+      ctx,
     )
     return
   }
@@ -934,6 +947,8 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
       msg?.requestId,
       'TRUST_NOT_ENABLED',
       'This session has no skills trust store wired (operator did not opt into warn/block mode).',
+      undefined,
+      ctx,
     )
     return
   }
@@ -983,6 +998,8 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
       msg?.requestId,
       'SKILL_NOT_FOUND',
       `No skill named '${msg.skillName}' found in the session's skill directories.`,
+      undefined,
+      ctx,
     )
     return
   }
@@ -1004,6 +1021,8 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
         msg?.requestId,
         'TRUST_FLUSH_FAILED',
         'Accepted in memory but the trust ledger could not be persisted. Retry; the next restart may re-flag this skill.',
+        undefined,
+        ctx,
       )
       return
     }
@@ -1122,11 +1141,11 @@ function _scanCommunityForSkillName(skillsRoots, skillName, claimedAuthor) {
  */
 function handleSkillTrustGrant(ws, client, msg, ctx) {
   if (typeof msg.skillName !== 'string' || msg.skillName === '') {
-    sendError(ws, msg?.requestId, 'INVALID_SKILL_NAME', 'skill_trust_grant requires a non-empty `skillName`')
+    sendError(ws, msg?.requestId, 'INVALID_SKILL_NAME', 'skill_trust_grant requires a non-empty `skillName`', undefined, ctx)
     return
   }
   if (typeof msg.author !== 'string' || msg.author === '') {
-    sendError(ws, msg?.requestId, 'INVALID_AUTHOR', 'skill_trust_grant requires a non-empty `author`')
+    sendError(ws, msg?.requestId, 'INVALID_AUTHOR', 'skill_trust_grant requires a non-empty `author`', undefined, ctx)
     return
   }
 
@@ -1136,7 +1155,7 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
 
   const trustStore = entry?.session?.getTrustStore?.() ?? null
   if (!trustStore || typeof trustStore.grantCommunityTrust !== 'function') {
-    sendError(ws, msg?.requestId, 'TRUST_NOT_ENABLED', 'This session has no skills trust store wired.')
+    sendError(ws, msg?.requestId, 'TRUST_NOT_ENABLED', 'This session has no skills trust store wired.', undefined, ctx)
     return
   }
 
@@ -1211,6 +1230,7 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
         `Community skill '${msg.skillName}' resolves to a different author than '${msg.author}'.`,
         // #3538: structured field for client suggestions ("did you mean X?").
         { actualAuthor: mismatchActualAuthor },
+        ctx,
       )
       return
     }
@@ -1227,10 +1247,11 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
         `Community skill '${msg.skillName}' is owned by '${actualAuthor}', not '${msg.author}'.`,
         // #3538: structured field for client suggestions ("did you mean X?").
         { actualAuthor },
+        ctx,
       )
       return
     }
-    sendError(ws, msg?.requestId, 'SKILL_NOT_FOUND', `No community skill '${msg.skillName}' found for author '${msg.author}'.`)
+    sendError(ws, msg?.requestId, 'SKILL_NOT_FOUND', `No community skill '${msg.skillName}' found for author '${msg.author}'.`, undefined, ctx)
     return
   }
 
@@ -1244,6 +1265,8 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
       msg?.requestId,
       'TRUST_FLUSH_FAILED',
       'Granted in memory but the trust ledger could not be persisted. Retry; the next restart may re-prompt for trust.',
+      undefined,
+      ctx,
     )
     return
   }

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -14,6 +14,8 @@ import {
 import { join } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { nsCtx } from './test-helpers.js'
+import { createClientSender } from '../src/ws-client-sender.js'
+import { createKeyPair, deriveSharedKey, decrypt, DIRECTION_SERVER } from '@chroxy/store-core/crypto'
 import {
   validateAttachments,
   resolveFileRefAttachments,
@@ -1066,6 +1068,95 @@ describe('sendError', () => {
     assert.strictEqual(sent[0].safeField, 'kept')
     // And global Object.prototype must remain unpolluted.
     assert.strictEqual({}.polluted, undefined)
+  })
+
+  // #5632: sendError now accepts an optional handler `ctx` and, when present,
+  // routes the error through `ctx.transport.send` (→ WsServer._send → the
+  // per-client encrypting sender) instead of the raw `ws.send`. This makes a
+  // post-handshake error frame ENCRYPTED so the client's plaintext guard
+  // (connection.ts) doesn't reject it as a downgrade. A forged plaintext
+  // `error` post-encryption is then correctly rejected client-side.
+  describe('encryption-aware routing (#5632)', () => {
+    it('routes through ctx.transport.send when a ctx is supplied', () => {
+      const sent = []
+      const ws = { readyState: 1, send: () => { throw new Error('raw ws.send must not be used when ctx is present') } }
+      const ctx = { transport: { send: (targetWs, payload) => sent.push({ targetWs, payload }) } }
+
+      sendError(ws, 'req-1', 'INVALID_MODEL', 'nope', undefined, ctx)
+
+      assert.strictEqual(sent.length, 1)
+      assert.strictEqual(sent[0].targetWs, ws)
+      assert.strictEqual(sent[0].payload.type, 'error')
+      assert.strictEqual(sent[0].payload.code, 'INVALID_MODEL')
+      assert.strictEqual(sent[0].payload.message, 'nope')
+    })
+
+    it('falls back to raw ws.send when no ctx is supplied (pre-auth call sites)', () => {
+      const sent = []
+      const ws = { readyState: 1, send: (data) => sent.push(JSON.parse(data)) }
+      sendError(ws, 'req-2', 'FORBIDDEN', 'pre-auth')
+      assert.strictEqual(sent.length, 1)
+      assert.strictEqual(sent[0].type, 'error')
+      assert.strictEqual(sent[0].code, 'FORBIDDEN')
+    })
+
+    it('still merges data fields through the ctx.transport path', () => {
+      const sent = []
+      const ws = { readyState: 1, send: () => {} }
+      const ctx = { transport: { send: (_ws, payload) => sent.push(payload) } }
+      sendError(ws, 'req-3', 'INVALID_AUTHOR', 'wrong', { actualAuthor: 'alice' }, ctx)
+      assert.strictEqual(sent[0].actualAuthor, 'alice')
+      assert.strictEqual(sent[0].type, 'error')
+    })
+
+    // End-to-end through the real WsServer send pipeline shape: ctx.transport.send
+    // is `(ws, msg) => server._send(ws, msg)` and _send looks the client up by ws
+    // and hands off to the per-client encrypting sender. We reconstruct that path
+    // here with the real createClientSender to prove the wire frame is `encrypted`
+    // when the client's encryptionState is set, and a plaintext `error` when it is
+    // not — matching the client guard's expectation either side of the handshake.
+    it('produces an ENCRYPTED frame when the client encryptionState is established', () => {
+      const serverKp = createKeyPair()
+      const clientKp = createKeyPair()
+      const serverShared = deriveSharedKey(clientKp.publicKey, serverKp.secretKey)
+      const clientShared = deriveSharedKey(serverKp.publicKey, clientKp.secretKey)
+
+      const sent = []
+      const ws = { readyState: 1, send: (data) => sent.push(data) }
+      const client = { _seq: 0, encryptionState: { sharedKey: serverShared, sendNonce: 0, recvNonce: 0 } }
+      const clientSend = createClientSender({ error: () => {}, warn: () => {} })
+      // Mirror WsServer._send: (ws, msg) => clientSend(ws, client, msg)
+      const ctx = { transport: { send: (targetWs, payload) => clientSend(targetWs, client, payload) } }
+
+      sendError(ws, 'req-enc', 'INVALID_MODEL', 'gpt-9000', undefined, ctx)
+
+      assert.strictEqual(sent.length, 1)
+      const envelope = JSON.parse(sent[0])
+      // Wire frame is an `encrypted` envelope, NOT a plaintext { type: 'error' }.
+      assert.strictEqual(envelope.type, 'encrypted')
+      assert.strictEqual(typeof envelope.d, 'string')
+      assert.strictEqual(typeof envelope.n, 'number')
+      // The client can decrypt it back to the original error frame.
+      const plain = decrypt(envelope, clientShared, 0, DIRECTION_SERVER)
+      assert.strictEqual(plain.type, 'error')
+      assert.strictEqual(plain.code, 'INVALID_MODEL')
+      assert.strictEqual(plain.message, 'gpt-9000')
+    })
+
+    it('produces a PLAINTEXT error frame when the client has no encryptionState (pre-handshake)', () => {
+      const sent = []
+      const ws = { readyState: 1, send: (data) => sent.push(data) }
+      const client = { _seq: 0 } // no encryptionState
+      const clientSend = createClientSender({ error: () => {}, warn: () => {} })
+      const ctx = { transport: { send: (targetWs, payload) => clientSend(targetWs, client, payload) } }
+
+      sendError(ws, 'req-plain', 'FORBIDDEN', 'no auth yet', undefined, ctx)
+
+      assert.strictEqual(sent.length, 1)
+      const frame = JSON.parse(sent[0])
+      assert.strictEqual(frame.type, 'error')
+      assert.strictEqual(frame.code, 'FORBIDDEN')
+    })
   })
 })
 

--- a/packages/server/tests/handlers/byok-credentials-handlers.test.js
+++ b/packages/server/tests/handlers/byok-credentials-handlers.test.js
@@ -19,7 +19,15 @@ import { createSpy, nsCtx } from '../test-helpers.js'
 function makeCtx() {
   const sent = []
   return nsCtx({
-    send: createSpy((_ws, msg) => { sent.push(msg) }),
+    // #5632: sendError now routes through ctx.transport.send. Mirror the real
+    // WsServer._send → ws.send step so the existing `ws._messages` assertions
+    // still observe error frames.
+    send: createSpy((_ws, msg) => {
+      sent.push(msg)
+      if (_ws && typeof _ws.send === 'function' && _ws.readyState === 1) {
+        _ws.send(JSON.stringify(msg))
+      }
+    }),
     broadcast: createSpy(() => {}),
     _sent: sent,
   })

--- a/packages/server/tests/handlers/notification-prefs-handlers.test.js
+++ b/packages/server/tests/handlers/notification-prefs-handlers.test.js
@@ -23,7 +23,15 @@ function makeCtx(pushManager) {
   const broadcast = []
   return nsCtx({
     pushManager,
-    send: createSpy((_ws, msg) => { sent.push(msg) }),
+    // #5632: sendError now routes through ctx.transport.send. Mirror the real
+    // WsServer._send → ws.send step so the existing `ws._messages` assertions
+    // still observe error frames.
+    send: createSpy((_ws, msg) => {
+      sent.push(msg)
+      if (_ws && typeof _ws.send === 'function' && _ws.readyState === 1) {
+        _ws.send(JSON.stringify(msg))
+      }
+    }),
     broadcast: createSpy((msg) => { broadcast.push(msg) }),
     _sent: sent,
     _broadcast: broadcast,
@@ -80,7 +88,8 @@ describe('notification prefs handlers (#4541)', () => {
       ctx.transport.send = createSpy((_ws, msg) => { ctx._sent.push(msg) })
       const ws = makeWs()
       inputHandlers.notification_prefs_get(ws, { id: 'c1' }, { requestId: 'r1' }, ctx)
-      const err = ws._messages.find((m) => m.type === 'error')
+      // #5632: sendError routes through ctx.transport.send (here capturing to _sent).
+      const err = ctx._sent.find((m) => m.type === 'error')
       assert.ok(err, 'expected an error reply')
       assert.equal(err.code, 'NOT_AVAILABLE')
     })
@@ -174,7 +183,8 @@ describe('notification prefs handlers (#4541)', () => {
         { requestId: 'r1', prefs: { categories: { result: false } } },
         ctx,
       )
-      const err = ws._messages.find((m) => m.type === 'error')
+      // #5632: sendError routes through ctx.transport.send (here capturing to _sent).
+      const err = ctx._sent.find((m) => m.type === 'error')
       assert.ok(err)
       assert.equal(err.code, 'NOT_AVAILABLE')
     })

--- a/packages/server/tests/handlers/settings-handlers-community-scan-order.test.js
+++ b/packages/server/tests/handlers/settings-handlers-community-scan-order.test.js
@@ -76,7 +76,15 @@ if (typeof mock.module !== 'function') {
   function makeCtx(sessions = new Map()) {
     const sent = []
     return nsCtx({
-      send: createSpy((_ws, msg) => { sent.push(msg) }),
+      // #5632: sendError now routes through ctx.transport.send. Mirror the real
+      // WsServer._send → ws.send step so the existing `ws._messages` assertions
+      // still observe error frames.
+      send: createSpy((_ws, msg) => {
+        sent.push(msg)
+        if (_ws && typeof _ws.send === 'function' && _ws.readyState === 1) {
+          _ws.send(JSON.stringify(msg))
+        }
+      }),
       broadcast: createSpy(() => {}),
       broadcastToSession: createSpy(() => {}),
       sessionManager: { getSession: createSpy((id) => sessions.get(id)) },

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -12,8 +12,19 @@ function makeCtx(sessions = new Map(), overrides = {}) {
   const broadcasts = []
   const sessionBroadcasts = []
 
+  // #5632: sendError now routes through ctx.transport.send (the encryption-aware
+  // path) instead of a raw ws.send. To keep the existing `ws._messages` wire-shape
+  // assertions valid, the mock transport mirrors the real WsServer._send → ws.send
+  // step: it records the frame on `ctx._sent` AND delivers it to the target ws so
+  // `ws._messages` still observes error frames. (Production encrypts first; the
+  // wire-shape assertions here only care about the decrypted payload.)
   return nsCtx({
-    send: createSpy((_ws, msg) => { sent.push(msg) }),
+    send: createSpy((_ws, msg) => {
+      sent.push(msg)
+      if (_ws && typeof _ws.send === 'function' && _ws.readyState === 1) {
+        _ws.send(JSON.stringify(msg))
+      }
+    }),
     broadcast: createSpy((msg) => { broadcasts.push(msg) }),
     broadcastToSession: createSpy((sessionId, msg) => { sessionBroadcasts.push({ sessionId, msg }) }),
     sessionManager: {
@@ -84,10 +95,15 @@ describe('settings-handlers', () => {
       const ctx = makeCtx(sessions)
       const client = makeClient({ activeSessionId: 's1' })
 
-      settingsHandlers.set_model(makeWs(), client, { model: 'gpt-4' }, ctx)
+      const ws = makeWs()
+      settingsHandlers.set_model(ws, client, { model: 'gpt-4', requestId: 'r-gpt4' }, ctx)
 
       assert.equal(session.setModel.callCount, 0)
-      assert.equal(ctx.transport.send.callCount, 0)
+      // #5632: the INVALID_MODEL rejection now routes through the encryption-aware
+      // transport (ctx.transport.send → ws), not a raw ws.send.
+      assert.equal(ws._messages.length, 1)
+      assert.equal(ws._messages[0].type, 'error')
+      assert.equal(ws._messages[0].code, 'INVALID_MODEL')
     })
 
     // #2946 — set_model must consult the session's provider, not a global

--- a/packages/server/tests/pairing-approval-handlers.test.js
+++ b/packages/server/tests/pairing-approval-handlers.test.js
@@ -117,6 +117,10 @@ describe('pair_approve / pair_deny (#5510 host-level)', () => {
     const broadcasts = []
     const ctx = nsCtx({
       pairingManager: pm,
+      // #5632: pair_approve / pair_deny errors now route through
+      // ctx.transport.send. Mirror the real WsServer._send → ws.send step so the
+      // existing `ws.sent()` assertions still observe the error envelopes.
+      send: (socket, msg) => { if (socket && typeof socket.send === 'function') socket.send(JSON.stringify(msg)) },
       resolvePairRequester: (requestId, result) => resolved.push({ requestId, result }),
       broadcastPairResolved: (requestId, reason) => broadcasts.push({ requestId, reason }),
     })

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -250,12 +250,13 @@ describe('handleSessionMessage', () => {
       const ctx = makeCtx()
       const client = makeClient({ activeSessionId: 'sess-1' })
       const entry = addSession(ctx, 'sess-1', makeSession({ provider: 'ollama' }))
-      // sendError writes to the ws handle directly (not ctx.transport.send), so a
-      // live fake is needed to observe the rejection envelope.
+      // #5632: sendError now routes through ctx.transport.send (the
+      // encryption-aware path), not a raw ws.send. The rejection envelope is the
+      // payload (arguments[1]) of the last transport.send call.
       const ws = { readyState: 1, send: mock.fn() }
       await handleSessionMessage(ws, client, { type: 'set_model', model: '   ' }, ctx)
       assert.equal(entry.session.setModel.callCount, 0)
-      const sent = JSON.parse(ws.send.mock.calls.at(-1).arguments[0])
+      const sent = ctx.transport.send.mock.calls.at(-1).arguments[1]
       assert.equal(sent.type, 'error')
       assert.equal(sent.code, 'INVALID_MODEL')
     })
@@ -269,7 +270,8 @@ describe('handleSessionMessage', () => {
       const ws = { readyState: 1, send: mock.fn() }
       await handleSessionMessage(ws, client, { type: 'set_model', model: 'my-custom-finetune:7b' }, ctx)
       assert.equal(entry.session.setModel.callCount, 0)
-      const sent = JSON.parse(ws.send.mock.calls.at(-1).arguments[0])
+      // #5632: rejection routes through ctx.transport.send (encryption-aware path).
+      const sent = ctx.transport.send.mock.calls.at(-1).arguments[1]
       assert.equal(sent.code, 'MODEL_NOT_SUPPORTED_BY_PROVIDER')
     })
   })
@@ -407,11 +409,11 @@ describe('handleSessionMessage', () => {
       // Mapping must NOT have been consumed so the legit bound client can still respond
       assert.ok(ctx.permissions.permissionSessionMap.has('cross-req'),
         'permissionSessionMap entry must be preserved for the legit client')
-      // (We can't assert on the SESSION_TOKEN_MISMATCH error reaching the
-      // client here: sendError writes directly to ws.send, and the WS mock
-      // at the top of the file has no readyState=1 so the send is a no-op.
-      // The "no cross-session resolve" + "mapping preserved" assertions
-      // above are what actually prevent the attack.)
+      // (We don't assert on the SESSION_TOKEN_MISMATCH error reaching the client
+      // here: since #5632 sendError routes through ctx.transport.send, but the
+      // opaque WS handle at the top of the file isn't readyState=1 so the
+      // delivery is a no-op anyway. The "no cross-session resolve" + "mapping
+      // preserved" assertions above are what actually prevent the attack.)
     })
 
     it('allows bound client to respond to permission for its own bound session', async () => {


### PR DESCRIPTION
Closes #5632

## Summary

Once an E2E-encrypted session is established, the client still accepted and acted on plaintext (non-`encrypted`) WebSocket frames. The `auth_ok` downgrade gate (#5614) protects only the handshake frame, not post-handshake traffic. This closes that gap (consensus C3 / Adversary F1).

In the `socket.onmessage` handler of both clients, once the encryption state is set, any frame that is **not** an `encrypted` envelope and **not** one of a minimal cleartext-handshake allow-list is now dropped and the socket is closed — failing closed on the **exact same path a decrypt failure takes** (`console.error` + `socket.close()` + no dispatch).

Applied symmetrically to:
- `packages/app/src/store/connection.ts` (mobile app)
- `packages/dashboard/src/store/connection.ts` (web dashboard)

## Threat closed

A MITM (or compromised tunnel hop) could previously forge a **plaintext** application frame after the handshake — e.g. a `permission_request`, `server_error`, or a stream frame — and the client would parse and act on it, bypassing the confidentiality/integrity guarantees of the established session. The handshake-only gate did nothing for these post-handshake frames. The guard now treats them as a downgrade/injection attempt and tears the socket down.

## Handshake allow-list (and why)

`auth_ok`, `key_exchange_ok`, `auth_fail`, `pair_fail` — the complete set of cleartext server→client frames the server legitimately emits **before** encryption is active (verified against `packages/server/src/ws-auth.js`: `key_exchange_ok` is the last cleartext frame in the discrete handshake; `auth_ok` carries the eager `serverPublicKey` in cleartext; `auth_fail`/`pair_fail` are terminal cleartext frames).

On a normal connection none of these actually reach the guard: `setEncryptionState(null)` is called at the top of every new connection, and the encryption state is only set *during* the handshake (the eager path sets it while handling `auth_ok`, but the onmessage decrypt-check for that same frame already ran with `encState` still null). The four frames are allow-listed defensively so a benign duplicate/terminal handshake frame is tolerated rather than killing the socket. Anything else arriving in cleartext after `encState` is set is rejected.

Plaintext (encryption-disabled) sessions are **unchanged** — the guard branch is gated on `encState` being truthy, exactly like the existing decrypt branch.

## Verification

Added focused tests (mock WebSocket driving the real `connect()` → `socket.onmessage` path) on both sides:

- **app** — `packages/app/src/__tests__/store/connection-encryption-guard.test.ts` (jest), 4 tests
- **dashboard** — `packages/dashboard/src/store/connection-encryption-guard.test.ts` (vitest), 4 tests

Each suite proves: (a) a plaintext app frame (`server_error`) received **after** encryption is established is rejected and closes the socket without dispatch; (b) a cleartext handshake frame (`key_exchange_ok`) is still accepted by the guard; (c) a genuine encrypted frame still decrypts, dispatches, and advances `recvNonce`; (d) plaintext-mode (no `encState`) sessions dispatch normally and the socket stays open.

```
app:       Tests: 4 passed, 4 total  (connection-encryption-guard.test.ts)
           store + crypto suites: 204 passed, 204 total
dashboard: Test Files 1 passed (1) / Tests 4 passed (4)
```

`tsc --noEmit` reports no new errors in the changed files. (Pre-existing, unrelated failures in this checkout: the dashboard test suite and typecheck flag a missing `@testing-library/react` dependency, and the app `connection.test.ts` can't resolve a generated `xterm-bundle` artifact — neither is touched by this PR.)