### PR TITLE
feat(app): wire up EAS Update (OTA) pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3187,9 +3187,9 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -8167,6 +8167,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.8.tgz",
+      "integrity": "sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "19.0.21",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
@@ -8274,12 +8280,12 @@
       }
     },
     "node_modules/expo-manifests": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.10.tgz",
-      "integrity": "sha512-oxDUnURPcL4ZsOBY6X1DGWGuoZgVAFzp6PISWV7lPP2J0r8u1/ucuChBgpK7u1eLGFp6sDIPwXyEUCkI386XSQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.11.tgz",
+      "integrity": "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~12.0.11",
+        "@expo/config": "~12.0.13",
         "expo-json-utils": "~0.15.0"
       },
       "peerDependencies": {
@@ -8396,6 +8402,42 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+      "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "29.0.18",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-29.0.18.tgz",
+      "integrity": "sha512-qn0YDM7wVwghQAaxb9NYzzwrmj+v8Djz5H+Zft4/myG9SPg4ICAfDy52IVF0K+/GH/oNgsFfzmmLl6hIkDu42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/plist": "^0.4.9",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~1.0.8",
+        "expo-manifests": "~1.0.11",
+        "expo-structured-headers": "~5.0.0",
+        "expo-updates-interface": "~2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-updates-interface": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
@@ -8404,6 +8446,12 @@
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/expo/node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -16907,6 +16955,7 @@
         "expo-secure-store": "~15.0.8",
         "expo-speech-recognition": "^3.1.0",
         "expo-status-bar": "~3.0.9",
+        "expo-updates": "~29.0.18",
         "react": "19.1.0",
         "react-native": "0.81.5",
         "react-native-safe-area-context": "~5.6.0",

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -40,6 +40,13 @@
       "favicon": "./assets/favicon.png"
     },
     "scheme": "chroxy",
+    "runtimeVersion": {
+      "policy": "fingerprint"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/5747b2cd-e15a-4742-9562-de949408f896",
+      "enabled": true
+    },
     "plugins": [
       [
         "expo-camera",

--- a/packages/app/eas.json
+++ b/packages/app/eas.json
@@ -6,13 +6,16 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "development"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "preview"
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "channel": "production"
     }
   },
   "submit": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,6 +68,7 @@
     "expo-secure-store": "~15.0.8",
     "expo-speech-recognition": "^3.1.0",
     "expo-status-bar": "~3.0.9",
+    "expo-updates": "~29.0.18",
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
Wires up the EAS Update (over-the-air) pipeline for the Expo SDK 54 mobile app in \`packages/app/\`. Config + native dependency only — no app source/UI changes.

Closes #5640

## What changed

- **Installed \`expo-updates ~29.0.18\`** (the SDK-54-aligned version, via \`npx expo install\`). \`package.json\` + root \`package-lock.json\` updated; new transitive deps are \`expo-eas-client\`, \`expo-structured-headers\`, and a scoped \`arg\`.
- **\`app.json\` (\`expo\`):**
  - \`updates: { "url": "https://u.expo.dev/5747b2cd-e15a-4742-9562-de949408f896", "enabled": true }\` — points at the provisioned EAS project's update endpoint. No \`fallbackToCacheTimeout\` set, so launch is never blocked on a network fetch (default 0 = check in background, use embedded bundle immediately).
  - \`runtimeVersion: { "policy": "fingerprint" }\` — native-aware. The fingerprint hashes native config/deps, so an OTA JS bundle can never land on an incompatible binary; a native dependency change automatically bumps the runtime version and forces a rebuild.
- **\`eas.json\`:** added \`channel\` to each build profile — \`development\` → \`development\`, \`preview\` → \`preview\`, \`production\` → \`production\`. All existing keys (\`appVersionSource: remote\`, \`autoIncrement\`, \`developmentClient\`, \`distribution\`) are intact.

## fingerprint vs appVersion

Chose **fingerprint** (the preferred, native-aware policy). Validated it works with this toolchain: \`@expo/fingerprint\` computes a real hash for the project (e.g. \`fc952432…\`) and \`expo config\` resolves \`runtimeVersion: { policy: "fingerprint" }\` cleanly. No fallback to \`appVersion\` was needed.

## Verification

- **\`expo-doctor\`:** 15/18 — the 3 failing checks are pre-existing on \`main\` (identical 15/18 baseline): non-CNG project config-sync warning, unmaintained \`expo-live-activity\`, and patch-version drift in 7 unrelated packages. \`expo-updates\` is NOT in the version-mismatch list, confirming it installed at the correct SDK-54 patch.
- **Type-check:** \`tsc --noEmit\` clean (ran \`npm run bundle-xterm\` first).
- **Tests:** 138 suites / 1835 tests pass. No expo-updates mock needed — nothing imports it (it's config-driven and inert in dev under \`__DEV__\`), so no Metro/dev regression.

## Rollout

1. **OTA is not yet live on installed apps.** It activates only after a *native* build that bundles \`expo-updates\`. The current preview APK \`2b014f7c\` predates this change and is the **last rebuild-required install**.
2. **The next \`eas build --profile preview\`** produces the first OTA-capable binary (and is itself a required rebuild to pick up the native module + updates config).
3. **Thereafter**, \`eas update --branch preview --message "…"\` ships JS-only changes to installed apps with **no rebuild**.
4. **Required-rebuild trigger under the fingerprint policy:** any change that alters the native fingerprint — i.e. a native dependency change (new native module, SDK bump, native config change) — bumps the runtime version and requires a fresh \`eas build\`. Pure JS/TS/asset changes do not, and ship via OTA.