### PR TITLE
fix(app): gate Expo push token log behind __DEV__

### DIFF
--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -89,7 +89,11 @@ export async function registerForPushNotifications(): Promise<string | null> {
     const tokenData = await Notifications.getExpoPushTokenAsync(
       projectId ? { projectId } : undefined
     );
-    console.log('[push] Expo push token:', tokenData.data);
+    // Gate the raw token behind __DEV__ — it's useful while developing but is a
+    // secret that must not land in production logs (#5646).
+    if (__DEV__) {
+      console.log('[push] Expo push token:', tokenData.data);
+    }
     return tokenData.data;
   } catch (err) {
     // Expo Go SDK 53+ removed push notification support — gracefully degrade


### PR DESCRIPTION
## Summary

`registerForPushNotifications()` in `packages/app/src/notifications.ts` logged the raw Expo push token via `console.log('[push] Expo push token:', tokenData.data)` on every successful registration, including production builds. The push token is a secret and shouldn't appear in production logs. This gates the log behind `__DEV__` so it still helps during development but is stripped from release builds (`__DEV__` is `false` in production). No push-registration behavior changes — only the logging is conditional.

While in the file I scanned for other secret logging: the only raw-token log was this line. The remaining `[push]` logs print non-sensitive info (status, requestId, decision, HTTP retry counts), and the `apiToken` used in the HTTP fallback is only sent in the `Authorization` header, never logged.

Closes #5646
