### PR TITLE
fix(app): engage biometric lock on cold start, not just on resume

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform, UIManager, TouchableOpacity, Text } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { NavigationContainer } from '@react-navigation/native';
@@ -61,7 +61,7 @@ export default function App() {
     const parts = cwd.split('/');
     return parts.length > 2 ? parts.slice(-2).join('/') : cwd;
   });
-  const { isLocked, unlock } = useBiometricLock();
+  const { isLocked, gateReady, unlock } = useBiometricLock();
   const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -86,6 +86,14 @@ export default function App() {
     setOnboardingDone(true);
   }, []);
 
+  // #5643 — cold-start biometric gate. The navigator (and its ConnectScreen,
+  // which auto-reconnects using the stored token) must not mount until the
+  // biometric-lock decision has resolved AND any cold-start lock is cleared.
+  // navigatorMounted records that the navigator has already come up once, so a
+  // later resume-lock (background→foreground) stays an overlay rather than
+  // tearing the live session down.
+  const navigatorMounted = useRef(false);
+
   // Still loading onboarding state
   if (onboardingDone === null) return null;
 
@@ -97,6 +105,23 @@ export default function App() {
       </>
     );
   }
+
+  // Gate cold start: while the lock decision is unresolved render nothing (no
+  // flash of app content); if locked before the navigator has ever mounted,
+  // render only the LockScreen so auto-reconnect can't fire behind it.
+  if (!gateReady) {
+    return <StatusBar style="light" />;
+  }
+  if (isLocked && !navigatorMounted.current) {
+    return (
+      <>
+        <StatusBar style="light" />
+        <LockScreen onUnlock={unlock} />
+      </>
+    );
+  }
+
+  navigatorMounted.current = true;
 
   return (
     <NavigationContainer>

--- a/packages/app/src/__tests__/hooks/useBiometricLock.test.ts
+++ b/packages/app/src/__tests__/hooks/useBiometricLock.test.ts
@@ -216,6 +216,69 @@ describe('useBiometricLock', () => {
     expect(result.current.isLocked).toBe(false);
   });
 
+  // -------------------------------------------------------------------------
+  // Cold-start gate (#5643)
+  // -------------------------------------------------------------------------
+
+  it('cold start: locked + gate opens when preference enabled and biometrics available', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.isLocked).toBe(true);
+    expect(result.current.gateReady).toBe(true);
+  });
+
+  it('cold start: NOT locked, gate ready when preference disabled', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('false');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.isLocked).toBe(false);
+    expect(result.current.gateReady).toBe(true);
+  });
+
+  it('cold start: unlock() clears the lock so the navigator can mount', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+    expect(result.current.isLocked).toBe(true);
+
+    let success: boolean | undefined;
+    await actAsync(async () => { success = await result.current.unlock(); });
+    expect(success).toBe(true);
+    expect(result.current.isLocked).toBe(false);
+    expect(result.current.gateReady).toBe(true);
+  });
+
+  it('cold start: auto-disables and unlocks if enrollment was revoked', async () => {
+    // Preference enabled but biometrics no longer available (enrollment removed)
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    (LocalAuthentication.isEnrolledAsync as jest.Mock).mockResolvedValue(false);
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    // Auto-disabled to avoid a permanent lockout
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('chroxy_biometric_enabled', 'false');
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.isLocked).toBe(false);
+    expect(result.current.gateReady).toBe(true);
+  });
+
+  it('cold start: auto-disables and unlocks if hardware is absent', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('true');
+    (LocalAuthentication.hasHardwareAsync as jest.Mock).mockResolvedValue(false);
+    const { result } = renderHookSimple(() => useBiometricLock());
+    await actAsync(async () => { await flushMicrotasks(); });
+
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('chroxy_biometric_enabled', 'false');
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.isLocked).toBe(false);
+    expect(result.current.gateReady).toBe(true);
+  });
+
   it('cleans up AppState listener on unmount', () => {
     const { unmount } = renderHookSimple(() => useBiometricLock());
     unmount();

--- a/packages/app/src/hooks/useBiometricLock.ts
+++ b/packages/app/src/hooks/useBiometricLock.ts
@@ -60,17 +60,62 @@ export async function authenticate(): Promise<boolean> {
 /**
  * Hook that manages biometric lock state. Returns:
  * - isLocked: whether the app is currently locked
+ * - gateReady: whether the cold-start lock decision has resolved. The app must
+ *   NOT mount the navigator (and thus must not auto-reconnect using the stored
+ *   token) until this is true — otherwise a cold start races the async
+ *   preference read and opens straight into the app, bypassing the lock (#5643).
  * - unlock: trigger biometric prompt
+ * - refresh: re-read the preference (e.g. after a Settings toggle)
+ * - enabled: current biometric-lock preference
  */
 export function useBiometricLock() {
+  // Cold-start default is LOCKED-pending: until the async preference read
+  // resolves we keep the gate closed (gateReady=false) so no app content or
+  // auto-reconnect can run. We do NOT default isLocked=true here because that
+  // would flash the LockScreen even for users with the preference disabled;
+  // instead the gate hides everything until we know which state to land in.
   const [isLocked, setIsLocked] = useState(false);
   const [enabled, setEnabled] = useState(false);
+  const [gateReady, setGateReady] = useState(false);
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);
   const wentBackground = useRef(false);
 
-  // Load setting on mount
+  // Resolve the cold-start lock decision on mount. This MUST complete before
+  // the navigator mounts (App gates on gateReady), so the stored-token
+  // auto-reconnect can't fire while the app should be locked.
   useEffect(() => {
-    getBiometricEnabled().then(setEnabled);
+    let cancelled = false;
+    getBiometricEnabled().then(async (val) => {
+      if (cancelled) return;
+      setEnabled(val);
+      if (!val) {
+        // Preference disabled — never lock, open the gate immediately.
+        setIsLocked(false);
+        setGateReady(true);
+        return;
+      }
+      // Preference enabled. Guard against a permanent lockout: if biometric
+      // enrollment was revoked (e.g. all fingerprints/Face ID removed) the
+      // unlock prompt would always fail, so auto-disable and open the gate —
+      // mirrors the SettingsScreen auto-disable path.
+      const available = await isBiometricAvailable();
+      if (cancelled) return;
+      if (!available) {
+        await setBiometricEnabled(false);
+        if (cancelled) return;
+        setEnabled(false);
+        setIsLocked(false);
+        setGateReady(true);
+        return;
+      }
+      // Enabled and available — lock on cold start, then open the gate so the
+      // LockScreen renders (the navigator stays unmounted until unlock).
+      setIsLocked(true);
+      setGateReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Track app state transitions and re-sync preference on foreground
@@ -119,5 +164,5 @@ export function useBiometricLock() {
     if (!val) setIsLocked(false);
   }, []);
 
-  return { isLocked, unlock, refresh, enabled };
+  return { isLocked, gateReady, unlock, refresh, enabled };
 }


### PR DESCRIPTION
Closes #5643

## Problem
`useBiometricLock` initialized `isLocked=false` and only flipped to `true` on a background→foreground transition. On a full **cold start** (app killed then relaunched), `wentBackground.current` is false, so the lock never engaged — the app opened straight into `ConnectScreen`, which auto-reconnects using the SecureStore token, bypassing the lock. The lock was also only an overlay over a live `NavigationContainer`, not a true gate.

## Fix
**`useBiometricLock.ts`**
- Resolves the cold-start lock decision on mount and exposes a new `gateReady` flag, so the locked/unlocked state is known *before* the navigator mounts.
- Preference enabled → defaults to **LOCKED on cold start**; preference disabled → opens the gate immediately (no extra async delay, no flash).
- Lockout guard: if biometric enrollment was revoked while the preference was on, cold start auto-disables the preference and opens the gate (mirrors the existing `SettingsScreen` auto-disable path) instead of trapping the user behind an unsatisfiable prompt.
- Resume-lock (background→foreground) behavior is unchanged.

**`App.tsx`**
- Gates the `NavigationContainer` mount on `gateReady` + `isLocked`. While the decision is pending, renders nothing (just `StatusBar`) — no content flash. A cold-start lock renders **only** the `LockScreen`, so `ConnectScreen`'s stored-token auto-reconnect cannot fire behind it.
- A `navigatorMounted` ref latch keeps a later resume-lock an overlay over the live session (existing behavior), rather than tearing the navigator down.

## How the gate beats auto-reconnect
Auto-reconnect runs in `ConnectScreen`'s mount `useEffect` (`loadSavedConnection().then(connect)`). `ConnectScreen` only mounts when the navigator mounts. Because the navigator mount is now gated behind `gateReady && (!isLocked || already-mounted)`, the token-based reconnect cannot run on a cold start until the user unlocks.

## Verification
- `packages/app` jest: **138 suites / 1840 tests pass** (24 in `useBiometricLock.test.ts`, including the new cold-start cases).
- `tsc --noEmit`: clean.
- New tests: enabled → locked on cold start; disabled → not locked; `unlock()` clears the gate; enrollment-revoked and no-hardware → auto-disable + unlock.