### PR TITLE
fix(app): encrypt at-rest AsyncStorage persistence cache

### DIFF
--- a/packages/app/src/__tests__/store/persist-crypto.test.ts
+++ b/packages/app/src/__tests__/store/persist-crypto.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for at-rest persistence-cache encryption (#5644).
+ *
+ * Uses an in-memory expo-secure-store mock so the cache key round-trips through
+ * a fake keychain. expo-crypto's real PRNG works under jest-expo.
+ */
+jest.mock('expo-secure-store', () => {
+  const mem: Record<string, string> = {};
+  return {
+    __mem: mem,
+    getItemAsync: jest.fn(async (k: string) => (k in mem ? mem[k] : null)),
+    setItemAsync: jest.fn(async (k: string, v: string) => {
+      mem[k] = v;
+    }),
+    deleteItemAsync: jest.fn(async (k: string) => {
+      delete mem[k];
+    }),
+  };
+});
+
+import * as SecureStore from 'expo-secure-store';
+import {
+  encryptForStorage,
+  decryptForStorage,
+  _resetKeyCacheForTesting,
+  PERSIST_CACHE_SECURE_STORE_KEY,
+} from '../../store/persist-crypto';
+
+type MockedStore = typeof SecureStore & { __mem: Record<string, string> };
+const store = SecureStore as unknown as MockedStore;
+
+beforeEach(() => {
+  for (const k of Object.keys(store.__mem)) delete store.__mem[k];
+  _resetKeyCacheForTesting();
+  jest.clearAllMocks();
+  // Restore the in-memory implementations — clearAllMocks wipes call data but
+  // NOT implementations, so a prior test's mockRejectedValue would persist.
+  (SecureStore.getItemAsync as jest.Mock).mockImplementation(async (k: string) =>
+    k in store.__mem ? store.__mem[k] : null,
+  );
+  (SecureStore.setItemAsync as jest.Mock).mockImplementation(async (k: string, v: string) => {
+    store.__mem[k] = v;
+  });
+});
+
+describe('persist-crypto', () => {
+  it('round-trips: encrypt then decrypt returns the original', async () => {
+    const original = JSON.stringify({ secret: 'sk-abc123', text: 'hello world' });
+    const blob = await encryptForStorage(original);
+    // Envelope is versioned and does NOT contain the plaintext.
+    expect(blob.startsWith('v1:')).toBe(true);
+    expect(blob).not.toContain('sk-abc123');
+    expect(blob).not.toContain('hello world');
+
+    const out = await decryptForStorage(blob);
+    expect(out).toBe(original);
+  });
+
+  it('generates the cache key on first use and stores it under a dedicated SecureStore key', async () => {
+    expect(PERSIST_CACHE_SECURE_STORE_KEY).toBe('chroxy_persist_cache_key');
+    expect(store.__mem[PERSIST_CACHE_SECURE_STORE_KEY]).toBeUndefined();
+    await encryptForStorage('x');
+    expect(store.__mem[PERSIST_CACHE_SECURE_STORE_KEY]).toBeDefined();
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+      PERSIST_CACHE_SECURE_STORE_KEY,
+      expect.any(String),
+    );
+  });
+
+  it('does not collide with bearer-token / device-id keys', () => {
+    expect(PERSIST_CACHE_SECURE_STORE_KEY).not.toBe('chroxy_last_token');
+    expect(PERSIST_CACHE_SECURE_STORE_KEY).not.toBe('chroxy_device_id');
+    expect(PERSIST_CACHE_SECURE_STORE_KEY).not.toBe('chroxy_last_url');
+  });
+
+  it('persists the key across loads — a second cold load reuses it and decrypts prior data', async () => {
+    const blob = await encryptForStorage('persisted-secret');
+    const keyAfterWrite = store.__mem[PERSIST_CACHE_SECURE_STORE_KEY];
+
+    // Simulate an app restart: drop the in-memory key cache but keep the
+    // keychain entry (as a real device would).
+    _resetKeyCacheForTesting();
+
+    const out = await decryptForStorage(blob);
+    expect(out).toBe('persisted-secret');
+    // Key was reused, not regenerated.
+    expect(store.__mem[PERSIST_CACHE_SECURE_STORE_KEY]).toBe(keyAfterWrite);
+  });
+
+  it('treats a legacy plaintext value as absent (returns null, never throws)', async () => {
+    // A value written before this change — raw JSON, no v1: prefix.
+    const legacy = JSON.stringify([{ id: '1', content: 'old message' }]);
+    await expect(decryptForStorage(legacy)).resolves.toBeNull();
+  });
+
+  it('returns null for null/empty/garbage input without throwing', async () => {
+    await expect(decryptForStorage(null)).resolves.toBeNull();
+    await expect(decryptForStorage(undefined)).resolves.toBeNull();
+    await expect(decryptForStorage('')).resolves.toBeNull();
+    await expect(decryptForStorage('v1:not-base64-!!!')).resolves.toBeNull();
+    await expect(decryptForStorage('v1:')).resolves.toBeNull();
+  });
+
+  it('returns null when the key was rotated (cannot decrypt old blob with new key)', async () => {
+    const blob = await encryptForStorage('top secret');
+    // Rotate: wipe keychain + cache so a fresh key is generated on next use.
+    delete store.__mem[PERSIST_CACHE_SECURE_STORE_KEY];
+    _resetKeyCacheForTesting();
+
+    const out = await decryptForStorage(blob);
+    expect(out).toBeNull(); // MAC failure under the new key → graceful null
+  });
+
+  it('detects tampering (flipped ciphertext byte → null)', async () => {
+    const blob = await encryptForStorage('integrity-protected');
+    const tampered = blob.slice(0, -4) + (blob.endsWith('AAAA') ? 'BBBB' : 'AAAA');
+    await expect(decryptForStorage(tampered)).resolves.toBeNull();
+  });
+
+  it('throws on encrypt when the key cannot be loaded or created (disabled path)', async () => {
+    // Both read and write of the keychain fail → no usable key.
+    (SecureStore.getItemAsync as jest.Mock).mockRejectedValue(new Error('keychain down'));
+    (SecureStore.setItemAsync as jest.Mock).mockRejectedValue(new Error('keychain down'));
+    _resetKeyCacheForTesting();
+    await expect(encryptForStorage('data')).rejects.toThrow('encryption key unavailable');
+  });
+
+  it('decrypt is safe (returns null) when the key cannot be loaded or created', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockRejectedValue(new Error('keychain down'));
+    (SecureStore.setItemAsync as jest.Mock).mockRejectedValue(new Error('keychain down'));
+    _resetKeyCacheForTesting();
+    await expect(decryptForStorage('v1:AAAA')).resolves.toBeNull();
+  });
+
+  it('regenerates a fresh key when the stored key is corrupt (wrong length)', async () => {
+    store.__mem[PERSIST_CACHE_SECURE_STORE_KEY] = 'dG9vc2hvcnQ='; // "tooshort", != 32 bytes
+    _resetKeyCacheForTesting();
+    // Should not throw; should overwrite with a valid 32-byte key and round-trip.
+    const blob = await encryptForStorage('recovered');
+    const out = await decryptForStorage(blob);
+    expect(out).toBe('recovered');
+  });
+});

--- a/packages/app/src/__tests__/store/persistence.test.ts
+++ b/packages/app/src/__tests__/store/persistence.test.ts
@@ -316,6 +316,63 @@ describe('persistSessionList', () => {
 // loadAllSessionMessages
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// At-rest encryption + legacy migration (#5644)
+// ---------------------------------------------------------------------------
+
+describe('at-rest encryption', () => {
+  it('stores message blobs encrypted (ciphertext on disk, not plaintext)', async () => {
+    persistSessionMessages('s1', [makeMsg('secret', { content: 'sk-LIVE-TOKEN-xyz' })]);
+    await jest.advanceTimersByTimeAsync(500);
+
+    const onDisk = await AsyncStorage.getItem('chroxy_persist_messages_s1');
+    expect(onDisk).toBeTruthy();
+    expect(onDisk!.startsWith('v1:')).toBe(true);
+    expect(onDisk).not.toContain('sk-LIVE-TOKEN-xyz');
+
+    // ...but decrypts back to the original on load.
+    const loaded = await loadSessionMessages('s1');
+    expect(loaded[0].content).toBe('sk-LIVE-TOKEN-xyz');
+  });
+
+  it('stores terminal buffer encrypted on disk', async () => {
+    persistTerminalBuffer('export API_KEY=sk-LIVE-9999');
+    await jest.advanceTimersByTimeAsync(1000);
+
+    const onDisk = await AsyncStorage.getItem('chroxy_persist_terminal_buffer');
+    expect(onDisk!.startsWith('v1:')).toBe(true);
+    expect(onDisk).not.toContain('sk-LIVE-9999');
+
+    const state = await loadPersistedState();
+    expect(state.terminalBuffer).toBe('export API_KEY=sk-LIVE-9999');
+  });
+
+  it('migrates a legacy-plaintext message blob to empty without crashing', async () => {
+    // A blob written before the encryption change — raw JSON, no v1: prefix.
+    await AsyncStorage.setItem(
+      'chroxy_persist_messages_legacy',
+      JSON.stringify([makeMsg('old')]),
+    );
+    const loaded = await loadSessionMessages('legacy');
+    expect(loaded).toEqual([]);
+  });
+
+  it('migrates a legacy-plaintext terminal buffer to null without crashing', async () => {
+    await AsyncStorage.setItem('chroxy_persist_terminal_buffer', 'legacy plaintext output');
+    const state = await loadPersistedState();
+    expect(state.terminalBuffer).toBeNull();
+  });
+
+  it('migrates a legacy-plaintext session list to empty without crashing', async () => {
+    await AsyncStorage.setItem(
+      'chroxy_persist_session_list',
+      JSON.stringify([makeSession('old')]),
+    );
+    const loaded = await loadSessionList();
+    expect(loaded).toEqual([]);
+  });
+});
+
 describe('loadAllSessionMessages', () => {
   it('loads messages for multiple sessions', async () => {
     // Persist s1, flush, then persist s2 (single debouncer — must flush between)

--- a/packages/app/src/store/persist-crypto.ts
+++ b/packages/app/src/store/persist-crypto.ts
@@ -1,0 +1,166 @@
+/**
+ * At-rest encryption for the AsyncStorage persistence cache (#5644).
+ *
+ * Message bodies and the terminal buffer can echo secrets (model output,
+ * pasted tokens, file contents). AsyncStorage writes them to the device
+ * filesystem in cleartext, where an OS backup or filesystem extraction can
+ * read them back. This module wraps those blobs in an authenticated-encryption
+ * envelope keyed by a random 32-byte key held in the OS keychain
+ * (expo-secure-store), so the on-disk representation is opaque.
+ *
+ * Primitive: XSalsa20-Poly1305 (`nacl.secretbox`) with a fresh random 24-byte
+ * nonce per write, prepended to the ciphertext — the same AEAD construction the
+ * transport layer uses, but self-contained (nonce travels with the blob) since
+ * there is no counter/replay context for at-rest data. We reuse the existing
+ * tweetnacl primitive rather than hand-rolling crypto.
+ *
+ * Importing `../utils/crypto` (transitively) calls `initPRNG()` so tweetnacl's
+ * `randomBytes` / `secretbox` work under the React Native JSC runtime.
+ */
+import * as SecureStore from 'expo-secure-store'
+import nacl from 'tweetnacl'
+import { encodeBase64, decodeBase64 } from 'tweetnacl-util'
+// Side-effect import: wires expo-crypto's PRNG into tweetnacl (initPRNG).
+import '../utils/crypto'
+
+/**
+ * SecureStore key for the persistence-cache key. Deliberately distinct from the
+ * bearer-token / device-id / input-settings keys so it can be rotated or wiped
+ * independently and never collides with identity material.
+ */
+const SECURE_STORE_KEY = 'chroxy_persist_cache_key'
+
+/**
+ * Envelope version prefix. Lets future format changes (different cipher, key
+ * derivation, etc.) be detected and migrated. `v1:` → base64(nonce ‖ ciphertext).
+ */
+const ENVELOPE_PREFIX = 'v1:'
+
+const KEY_BYTES = nacl.secretbox.keyLength // 32
+const NONCE_BYTES = nacl.secretbox.nonceLength // 24
+
+/**
+ * In-memory cache of the loaded/generated key so we hit the keychain at most
+ * once per app run. The promise is memoised to coalesce concurrent first reads.
+ */
+let _keyPromise: Promise<Uint8Array | null> | null = null
+
+/**
+ * Load the persistence key from SecureStore, generating and storing a fresh
+ * random key on first use. Returns `null` if SecureStore is unavailable AND we
+ * cannot persist a new key — callers must treat a null key as "encryption
+ * disabled" and fall back to a safe (non-crashing) path.
+ */
+async function loadOrCreateKey(): Promise<Uint8Array | null> {
+  // Try to read an existing key.
+  let stored: string | null = null
+  try {
+    stored = await SecureStore.getItemAsync(SECURE_STORE_KEY)
+  } catch {
+    // SecureStore read failed (keychain unavailable). Fall through to attempt a
+    // create; if that also fails we return null.
+    stored = null
+  }
+
+  if (stored) {
+    try {
+      const bytes = new Uint8Array(decodeBase64(stored))
+      if (bytes.length === KEY_BYTES) return bytes
+      // Wrong-length stored key (corrupt) — regenerate below.
+    } catch {
+      // Corrupt base64 — regenerate below.
+    }
+  }
+
+  // Generate a fresh key and persist it.
+  const fresh = nacl.randomBytes(KEY_BYTES)
+  try {
+    await SecureStore.setItemAsync(SECURE_STORE_KEY, encodeBase64(fresh))
+    return fresh
+  } catch {
+    // Could not persist the key. Returning null disables encryption so the app
+    // still launches and functions (cache becomes effectively non-persistent /
+    // best-effort) rather than crashing. We do NOT return the un-persisted key,
+    // because a key we cannot reload is useless for the next launch's reads.
+    return null
+  }
+}
+
+/** Get the (memoised) persistence key, or null if encryption is unavailable. */
+function getKey(): Promise<Uint8Array | null> {
+  if (!_keyPromise) {
+    _keyPromise = loadOrCreateKey()
+  }
+  return _keyPromise
+}
+
+/**
+ * Encrypt a plaintext string for at-rest storage. Returns a `v1:`-prefixed
+ * base64 envelope. If the persistence key is unavailable, returns the plaintext
+ * UNCHANGED is NOT acceptable (defeats the purpose); instead we throw so the
+ * caller's existing try/catch treats the write as a (silent) failure. In
+ * practice the key is virtually always available — SecureStore is required for
+ * the bearer token already.
+ */
+export async function encryptForStorage(plaintext: string): Promise<string> {
+  const key = await getKey()
+  if (!key) {
+    // No key → cannot encrypt. Signal failure; the debounced/try-wrapped caller
+    // logs and skips the write rather than persisting cleartext.
+    throw new Error('persist-crypto: encryption key unavailable')
+  }
+  const nonce = nacl.randomBytes(NONCE_BYTES)
+  const messageBytes = new Uint8Array(new TextEncoder().encode(plaintext))
+  const ciphertext = nacl.secretbox(messageBytes, nonce, key)
+  // Pack nonce ‖ ciphertext so decryption is self-contained.
+  const packed = new Uint8Array(nonce.length + ciphertext.length)
+  packed.set(nonce, 0)
+  packed.set(ciphertext, nonce.length)
+  return ENVELOPE_PREFIX + encodeBase64(packed)
+}
+
+/**
+ * Decrypt a value read from at-rest storage.
+ *
+ * Returns the plaintext on success, or `null` when the value cannot be
+ * decrypted — this is the graceful-migration contract:
+ *
+ *  - Legacy CLEARTEXT (written before this change): missing the `v1:` prefix →
+ *    return null (treated as empty/absent so the cache re-populates from the
+ *    live stream). We deliberately do NOT return the raw cleartext, so old
+ *    plaintext is dropped rather than indefinitely re-served.
+ *  - Missing / rotated key, corrupt or tampered envelope, MAC failure: return
+ *    null. Never throws — the app must still launch cleanly.
+ */
+export async function decryptForStorage(stored: string | null | undefined): Promise<string | null> {
+  if (typeof stored !== 'string' || stored.length === 0) return null
+  // Legacy plaintext (or any non-v1 value): not decryptable → treat as absent.
+  if (!stored.startsWith(ENVELOPE_PREFIX)) return null
+
+  const key = await getKey()
+  if (!key) return null
+
+  try {
+    const packed = new Uint8Array(decodeBase64(stored.slice(ENVELOPE_PREFIX.length)))
+    if (packed.length <= NONCE_BYTES) return null
+    const nonce = packed.slice(0, NONCE_BYTES)
+    const ciphertext = packed.slice(NONCE_BYTES)
+    const plaintext = nacl.secretbox.open(ciphertext, nonce, key)
+    if (!plaintext) return null // MAC failure / wrong (rotated) key
+    return new TextDecoder().decode(plaintext)
+  } catch {
+    // Malformed base64 / unexpected shape — treat as absent.
+    return null
+  }
+}
+
+/**
+ * Reset the in-memory key cache. Test-only: lets a test exercise a cold
+ * SecureStore read after seeding/clearing the mock keychain.
+ */
+export function _resetKeyCacheForTesting(): void {
+  _keyPromise = null
+}
+
+/** Exposed for tests that need to assert on the SecureStore key name. */
+export const PERSIST_CACHE_SECURE_STORE_KEY = SECURE_STORE_KEY

--- a/packages/app/src/store/persistence.ts
+++ b/packages/app/src/store/persistence.ts
@@ -5,10 +5,17 @@
  * app restarts. Large data (messages, terminal buffer) uses AsyncStorage
  * while sensitive data (tokens, URLs) remains in SecureStore.
  *
+ * Sensitive blobs (message bodies, terminal buffer, session list) are
+ * encrypted at rest with a key held in the OS keychain (see persist-crypto) —
+ * AsyncStorage writes plaintext to the device filesystem, where backups /
+ * extraction could read echoed secrets. Small non-sensitive identifiers
+ * (view mode, active/last session IDs) stay plaintext.
+ *
  * Data is debounced to avoid excessive writes on rapid message streams.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { ChatMessage, SessionInfo } from './types';
+import { encryptForStorage, decryptForStorage } from './persist-crypto';
 
 const KEY_PREFIX = 'chroxy_persist_';
 const KEY_VIEW_MODE = `${KEY_PREFIX}view_mode`;
@@ -94,7 +101,9 @@ export function persistSessionMessages(sessionId: string, messages: ChatMessage[
   getMessagePersister(sessionId).schedule(async () => {
     // Keep only the last N messages, strip large base64 data
     const trimmed = messages.slice(-MAX_MESSAGES).map(stripLargeData);
-    await AsyncStorage.setItem(sessionMessagesKey(sessionId), JSON.stringify(trimmed));
+    // Encrypt at rest — message bodies can echo secrets (#5644).
+    const blob = await encryptForStorage(JSON.stringify(trimmed));
+    await AsyncStorage.setItem(sessionMessagesKey(sessionId), blob);
   });
 }
 
@@ -126,14 +135,18 @@ export function persistTerminalBuffer(buffer: string): void {
     const trimmed = buffer.length > MAX_TERMINAL_SIZE
       ? buffer.slice(-MAX_TERMINAL_SIZE)
       : buffer;
-    await AsyncStorage.setItem(KEY_TERMINAL_BUFFER, trimmed);
+    // Encrypt at rest — terminal output can echo secrets (#5644).
+    const blob = await encryptForStorage(trimmed);
+    await AsyncStorage.setItem(KEY_TERMINAL_BUFFER, blob);
   });
 }
 
 /** Persist the session list (debounced) */
 export function persistSessionList(sessions: SessionInfo[]): void {
   _sessionListPersister.schedule(async () => {
-    await AsyncStorage.setItem(KEY_SESSION_LIST, JSON.stringify(sessions));
+    // Encrypt at rest — session metadata carries cwd / names (#5644).
+    const blob = await encryptForStorage(JSON.stringify(sessions));
+    await AsyncStorage.setItem(KEY_SESSION_LIST, blob);
   });
 }
 
@@ -184,10 +197,13 @@ export async function loadPersistedState(): Promise<PersistedState> {
       rawViewMode && (VALID_VIEW_MODES as readonly string[]).includes(rawViewMode)
         ? TRANSIENT_VIEW_MODES.has(rawViewMode) ? 'chat' : (rawViewMode as ViewMode)
         : null;
+    // Terminal buffer is encrypted at rest — decrypt; a legacy-plaintext or
+    // undecryptable value yields null (treated as absent, re-populates live).
+    const terminalBuffer_decrypted = await decryptForStorage(terminalBuffer[1]);
     return {
       viewMode: validatedViewMode,
       activeSessionId: activeSessionId[1] || null,
-      terminalBuffer: terminalBuffer[1] || null,
+      terminalBuffer: terminalBuffer_decrypted,
     };
   } catch {
     return { viewMode: null, activeSessionId: null, terminalBuffer: null };
@@ -197,7 +213,9 @@ export async function loadPersistedState(): Promise<PersistedState> {
 /** Load persisted messages for a specific session */
 export async function loadSessionMessages(sessionId: string): Promise<ChatMessage[]> {
   try {
-    const raw = await AsyncStorage.getItem(sessionMessagesKey(sessionId));
+    const blob = await AsyncStorage.getItem(sessionMessagesKey(sessionId));
+    // Decrypt at rest — legacy-plaintext / undecryptable → null → empty (#5644).
+    const raw = await decryptForStorage(blob);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed : [];
@@ -209,7 +227,9 @@ export async function loadSessionMessages(sessionId: string): Promise<ChatMessag
 /** Load persisted session list */
 export async function loadSessionList(): Promise<SessionInfo[]> {
   try {
-    const raw = await AsyncStorage.getItem(KEY_SESSION_LIST);
+    const blob = await AsyncStorage.getItem(KEY_SESSION_LIST);
+    // Decrypt at rest — legacy-plaintext / undecryptable → null → empty (#5644).
+    const raw = await decryptForStorage(blob);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed : [];


### PR DESCRIPTION
Closes #5644

## Problem
`packages/app/src/store/persistence.ts` persisted message bodies, the terminal buffer, and the session list to AsyncStorage in **cleartext**. Model output (and pasted tokens) can echo secrets, and AsyncStorage writes to the device filesystem where an OS backup or filesystem extraction can read them back.

## Change
Wrap the sensitive persisted blobs in an authenticated-encryption envelope keyed by a random key held in the OS keychain.

**Encrypted blobs:** session messages, terminal buffer, session list (carries cwd/names). Small non-sensitive identifiers (view mode, active-session-id, last-conversation-id) stay plaintext.

**Primitive:** XSalsa20-Poly1305 via `nacl.secretbox` (the existing tweetnacl dep — no hand-rolled crypto), with a fresh random 24-byte nonce per write packed `nonce ‖ ciphertext` into a versioned `v1:` base64 envelope (self-contained; no counter/replay context needed for at-rest data).

**Key:** 32 random bytes generated on first use and stored under a **dedicated** SecureStore key `chroxy_persist_cache_key` — distinct from the bearer-token / device-id / input-settings keys so it never collides and can be rotated/wiped independently. The key is memoised in-memory so the keychain is read at most once per app run.

**Wire protocol and store shapes are unchanged** — this is purely the on-disk representation.

## Migration / decrypt-failure behavior (no data-loss crash)
`decryptForStorage` returns `null` (treated as empty/absent) and **never throws** when a stored value can't be decrypted:
- **Legacy cleartext** written before this change (no `v1:` prefix) → null. The old plaintext is **dropped, not re-served**, so the change isn't defeated; the cache re-populates from the live stream.
- **Missing / rotated key**, **corrupt envelope**, or **tampered ciphertext** (MAC failure) → null.

The app launches cleanly in all of these cases. On the write side, if the keychain is entirely unavailable (cannot read or create a key), `encryptForStorage` throws and the existing debounced/try-wrapped caller logs and skips the write rather than persisting cleartext.

## Performance
Encryption stays on the existing async + debounced persistence path (per-session message debounce, 1s terminal-buffer debounce), off the render thread — unchanged structure. Buffers are already trimmed (100 messages / ~50 KB terminal) before encrypting.

## Tests
New `persist-crypto.test.ts` and additions to `persistence.test.ts`:
- round-trip write → read returns the original
- on-disk value is `v1:`-prefixed ciphertext and does NOT contain the plaintext secret
- legacy-plaintext value (messages / terminal / session list) is treated as empty and does NOT crash
- SecureStore key persists across cold loads (second load reuses it and decrypts prior data)
- key rotation → graceful null; tamper detection → null
- disabled/absent-key paths are safe (encrypt throws → write skipped; decrypt returns null)
- dedicated key name does not collide with bearer-token / device-id keys

## Verification (Node 22)
- `npx tsc --noEmit` — clean
- Full app suite: **139 suites / 1851 tests pass** (incl. 33 in persistence.test.ts, 11 in persist-crypto.test.ts)