### PR TITLE
fix(app): add navigation allow-list to the WebView terminal

### DIFF
--- a/packages/app/src/__tests__/components/TerminalView.test.tsx
+++ b/packages/app/src/__tests__/components/TerminalView.test.tsx
@@ -179,9 +179,11 @@ describe('TerminalView postMessage bridge (#5519)', () => {
 
 describe('TerminalView navigation allow-list (#5645)', () => {
   // The xterm document loads from an inline `source={{ html }}` with no baseUrl,
-  // so RN WebView reports the document URL as `about:blank` (or '' in some
-  // lifecycle phases). The crash-recovery reload() reloads that same document.
-  // Only those requests may proceed; any other navigation is blocked.
+  // so RN WebView reports the document URL as `about:blank` on iOS
+  // (loadHTMLString:baseURL:about:blank) and as the empty string '' on Android
+  // (loadDataWithBaseURL("", ...)). The crash-recovery reload() reloads that
+  // same document. Only those two exact URLs may proceed; any other navigation
+  // — including other `about:` pseudo-pages — is blocked.
   function makeRequest(
     overrides: Partial<ShouldStartLoadRequest>,
   ): ShouldStartLoadRequest {
@@ -205,7 +207,7 @@ describe('TerminalView navigation allow-list (#5645)', () => {
     ).toBe(true);
   });
 
-  it('allows an empty-url inline load (iOS lifecycle phase)', () => {
+  it('allows an empty-url inline load (Android loadDataWithBaseURL "")', () => {
     expect(
       shouldAllowTerminalNavigation(makeRequest({ url: '' })),
     ).toBe(true);
@@ -241,14 +243,31 @@ describe('TerminalView navigation allow-list (#5645)', () => {
     ).toBe(false);
   });
 
-  it('wires the guard onto the WebView with a narrowed originWhitelist', () => {
+  it('blocks other about: pseudo-pages (only about:blank is the inline doc)', () => {
+    // The guard must allow ONLY the exact inline-load URLs, not any about:* URL —
+    // about:srcdoc / about:version etc. are not the terminal document.
+    expect(
+      shouldAllowTerminalNavigation(makeRequest({ url: 'about:srcdoc' })),
+    ).toBe(false);
+    expect(
+      shouldAllowTerminalNavigation(makeRequest({ url: 'about:version' })),
+    ).toBe(false);
+    expect(
+      shouldAllowTerminalNavigation(makeRequest({ url: 'about:blank#evil' })),
+    ).toBe(false);
+  });
+
+  it('wires the guard onto the WebView with a permissive originWhitelist', () => {
     const handleRef = React.createRef<TerminalHandle>();
     let renderer!: ReactTestRenderer;
     act(() => {
       renderer = create(<TerminalView ref={handleRef} />);
     });
     const webView = renderer.root.findByProps({ testID: 'webview' });
-    expect(webView.props.originWhitelist).toEqual(['about:*']);
+    // originWhitelist stays `['*']` so RN's whitelist never rejects the Android
+    // empty ('') inline-load origin (see "RN whitelist wrapper" below). The real
+    // containment is onShouldStartLoadWithRequest, asserted next.
+    expect(webView.props.originWhitelist).toEqual(['*']);
     expect(webView.props.onShouldStartLoadWithRequest).toBe(
       shouldAllowTerminalNavigation,
     );
@@ -263,5 +282,61 @@ describe('TerminalView navigation allow-list (#5645)', () => {
         makeRequest({ url: 'about:blank' }),
       ),
     ).toBe(true);
+  });
+});
+
+describe('TerminalView originWhitelist passes RN whitelist for both inline-load origins (#5645)', () => {
+  // Regression guard for the latent Android-blanking trap: the previous PR
+  // narrowed originWhitelist to ['about:*'], which RN WebView's REAL whitelist
+  // does NOT pass for Android's empty-string ('') inline-load origin — only a
+  // future Android navigation routed through the whitelist would expose it, and
+  // it would blank the terminal with no recovery. Here we run RN WebView
+  // 13.15.0's actual compileWhitelist/passesWhitelist (replicated verbatim from
+  // react-native-webview/src/WebViewShared.tsx, with the real escape-string-regexp
+  // semantics) against the originWhitelist the component ships, and assert BOTH
+  // the iOS ('about:blank') and Android ('') inline-load URLs pass. If a future
+  // change re-narrows originWhitelist in a way that rejects '', this fails.
+
+  // --- escape-string-regexp@4 (RN webview's dep) ---
+  const escapeStringRegexp = (s: string): string =>
+    s.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
+
+  // --- verbatim from react-native-webview@13.15.0 WebViewShared.tsx ---
+  const extractOrigin = (url: string): string => {
+    const result = /^[A-Za-z][A-Za-z0-9+\-.]+:(\/\/)?[^/]*/.exec(url);
+    return result === null ? '' : result[0];
+  };
+  const originWhitelistToRegex = (ow: string): string =>
+    `^${escapeStringRegexp(ow).replace(/\\\*/g, '.*')}`;
+  const passesWhitelist = (compiled: readonly string[], url: string): boolean => {
+    const origin = extractOrigin(url);
+    return compiled.some((x) => new RegExp(x).test(origin));
+  };
+  const compileWhitelist = (ow: readonly string[]): readonly string[] =>
+    ['about:blank', ...(ow || [])].map(originWhitelistToRegex);
+  // --- end verbatim ---
+
+  function shippedOriginWhitelist(): string[] {
+    const handleRef = React.createRef<TerminalHandle>();
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<TerminalView ref={handleRef} />);
+    });
+    const webView = renderer.root.findByProps({ testID: 'webview' });
+    return webView.props.originWhitelist as string[];
+  }
+
+  it('passes both about:blank (iOS) and "" (Android) through the real RN filter', () => {
+    const ow = shippedOriginWhitelist();
+    const compiled = compileWhitelist(ow);
+    expect(passesWhitelist(compiled, 'about:blank')).toBe(true);
+    expect(passesWhitelist(compiled, '')).toBe(true);
+  });
+
+  it('sanity-check: ["about:*"] would NOT pass the Android "" origin', () => {
+    // Proves the test has teeth — the narrowed value the reviewer flagged fails.
+    const compiled = compileWhitelist(['about:*']);
+    expect(passesWhitelist(compiled, 'about:blank')).toBe(true);
+    expect(passesWhitelist(compiled, '')).toBe(false);
   });
 });

--- a/packages/app/src/__tests__/components/TerminalView.test.tsx
+++ b/packages/app/src/__tests__/components/TerminalView.test.tsx
@@ -23,7 +23,12 @@
  */
 import React from 'react';
 import { create, act, ReactTestRenderer } from 'react-test-renderer';
-import { TerminalView, TerminalHandle } from '../../components/TerminalView';
+import type { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes';
+import {
+  TerminalView,
+  TerminalHandle,
+  shouldAllowTerminalNavigation,
+} from '../../components/TerminalView';
 
 interface MockWebViewInstance {
   postMessage: jest.Mock;
@@ -169,5 +174,94 @@ describe('TerminalView postMessage bridge (#5519)', () => {
     // clear() emptied the pending buffer; nothing to flush, and clear() before
     // ready does not post (matches existing semantics).
     expect(wv.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerminalView navigation allow-list (#5645)', () => {
+  // The xterm document loads from an inline `source={{ html }}` with no baseUrl,
+  // so RN WebView reports the document URL as `about:blank` (or '' in some
+  // lifecycle phases). The crash-recovery reload() reloads that same document.
+  // Only those requests may proceed; any other navigation is blocked.
+  function makeRequest(
+    overrides: Partial<ShouldStartLoadRequest>,
+  ): ShouldStartLoadRequest {
+    return {
+      url: '',
+      navigationType: 'other',
+      title: '',
+      loading: false,
+      canGoBack: false,
+      canGoForward: false,
+      lockIdentifier: 0,
+      ...overrides,
+    } as ShouldStartLoadRequest;
+  }
+
+  it('allows the initial inline document load (about:blank)', () => {
+    expect(
+      shouldAllowTerminalNavigation(
+        makeRequest({ url: 'about:blank', navigationType: 'other' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('allows an empty-url inline load (iOS lifecycle phase)', () => {
+    expect(
+      shouldAllowTerminalNavigation(makeRequest({ url: '' })),
+    ).toBe(true);
+  });
+
+  it('allows the crash-recovery reload of the inline document', () => {
+    expect(
+      shouldAllowTerminalNavigation(
+        makeRequest({ url: 'about:blank', navigationType: 'reload' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('blocks an external https navigation (server-controlled ANSI / link tap)', () => {
+    expect(
+      shouldAllowTerminalNavigation(
+        makeRequest({ url: 'https://evil.example', navigationType: 'click' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('blocks http, data:, and deep-link navigations', () => {
+    expect(
+      shouldAllowTerminalNavigation(makeRequest({ url: 'http://evil.example' })),
+    ).toBe(false);
+    expect(
+      shouldAllowTerminalNavigation(
+        makeRequest({ url: 'data:text/html,<script>alert(1)</script>' }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldAllowTerminalNavigation(makeRequest({ url: 'chroxy://pair?token=x' })),
+    ).toBe(false);
+  });
+
+  it('wires the guard onto the WebView with a narrowed originWhitelist', () => {
+    const handleRef = React.createRef<TerminalHandle>();
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<TerminalView ref={handleRef} />);
+    });
+    const webView = renderer.root.findByProps({ testID: 'webview' });
+    expect(webView.props.originWhitelist).toEqual(['about:*']);
+    expect(webView.props.onShouldStartLoadWithRequest).toBe(
+      shouldAllowTerminalNavigation,
+    );
+    // The guard, as wired, blocks an external nav and allows the inline doc.
+    expect(
+      webView.props.onShouldStartLoadWithRequest(
+        makeRequest({ url: 'https://evil.example' }),
+      ),
+    ).toBe(false);
+    expect(
+      webView.props.onShouldStartLoadWithRequest(
+        makeRequest({ url: 'about:blank' }),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -1,8 +1,43 @@
 import React, { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState, useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
+import type { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes';
 import { buildXtermHtml } from './xterm-html';
 import { COLORS } from '../constants/colors';
+
+/**
+ * Navigation allow-list for the embedded xterm WebView (#5645).
+ *
+ * The terminal is rendered from an inline `source={{ html }}` document with no
+ * `baseUrl`. RN WebView's native code falls back to `about:blank` as the base
+ * URL on iOS (RNCWebViewImpl.m: `loadHTMLString:baseURL:about:blank`) and loads
+ * via `loadDataWithBaseURL("", ...)` on Android — so the document's request URL
+ * is reported as `about:blank` (iOS) or the empty string (Android). That
+ * document is purely display-only — it never navigates. The crash-recovery
+ * `reload()` path simply re-loads the *same* inline document, which again
+ * surfaces as `about:blank` / `''`.
+ *
+ * Defense-in-depth: server-controlled ANSI (or a future xterm web-links addon /
+ * regression) must never be able to trigger a navigation away from that
+ * document. So we allow ONLY the inline document load (and its reload) and block
+ * everything else — http/https, link taps, data: URLs, deep links, etc.
+ *
+ * `originWhitelist` is narrowed to `['about:*']` (the inline document's origin)
+ * from the previous `['*']`. The two are complementary: `originWhitelist` is a
+ * coarse origin filter applied before the callback; `onShouldStartLoadWithRequest`
+ * is the precise per-request gate.
+ */
+function isInlineDocumentRequest(request: ShouldStartLoadRequest): boolean {
+  // An inline `source={{ html }}` with no baseUrl resolves to `about:blank`.
+  // Some RN WebView lifecycle/platform combinations report it as an empty
+  // string; treat both as the legitimate initial/reload document load.
+  const url = request.url ?? '';
+  return url === '' || url === 'about:blank' || url.startsWith('about:');
+}
+
+export function shouldAllowTerminalNavigation(request: ShouldStartLoadRequest): boolean {
+  return isInlineDocumentRequest(request);
+}
 
 // -- Public handle --
 
@@ -115,7 +150,10 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
         ref={webViewRef}
         source={{ html }}
         style={styles.container}
-        originWhitelist={['*']}
+        // Containment (#5645): only the inline xterm document may load; block
+        // any server-/ANSI-triggered navigation. See shouldAllowTerminalNavigation.
+        originWhitelist={['about:*']}
+        onShouldStartLoadWithRequest={shouldAllowTerminalNavigation}
         onMessage={handleMessage}
         onContentProcessDidTerminate={handleWebViewCrash}
         onRenderProcessGone={handleWebViewCrash}

--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -20,19 +20,28 @@ import { COLORS } from '../constants/colors';
  * Defense-in-depth: server-controlled ANSI (or a future xterm web-links addon /
  * regression) must never be able to trigger a navigation away from that
  * document. So we allow ONLY the inline document load (and its reload) and block
- * everything else — http/https, link taps, data: URLs, deep links, etc.
+ * everything else — http/https, link taps, data: URLs, deep links, `about:`
+ * pseudo-pages like `about:srcdoc`/`about:version`, etc.
  *
- * `originWhitelist` is narrowed to `['about:*']` (the inline document's origin)
- * from the previous `['*']`. The two are complementary: `originWhitelist` is a
- * coarse origin filter applied before the callback; `onShouldStartLoadWithRequest`
- * is the precise per-request gate.
+ * `originWhitelist` is the coarse origin pre-filter; `onShouldStartLoadWithRequest`
+ * (this guard) is the precise per-request gate and the *real* containment control —
+ * it is consulted for every real navigation. We deliberately keep `originWhitelist`
+ * at the permissive `['*']`: RN WebView's own `compileWhitelist`/`passesWhitelist`
+ * (WebViewShared.tsx) compute `extractOrigin('') === ''`, and ONLY the compiled
+ * `'*'` -> `^.*` regex matches that empty origin. A narrower value such as
+ * `['about:*']` rejects Android's empty (`''`) inline-load origin, which would
+ * blank the terminal with no recovery the moment any Android navigation is routed
+ * through the whitelist. The narrowing lives in this guard instead, where it can't
+ * break the legitimate inline load on either platform. (Empirically verified
+ * against the real RN filter — see TerminalView.test.tsx "RN whitelist wrapper".)
  */
 function isInlineDocumentRequest(request: ShouldStartLoadRequest): boolean {
-  // An inline `source={{ html }}` with no baseUrl resolves to `about:blank`.
-  // Some RN WebView lifecycle/platform combinations report it as an empty
-  // string; treat both as the legitimate initial/reload document load.
+  // The inline `source={{ html }}` with no baseUrl resolves to exactly
+  // `about:blank` on iOS (loadHTMLString:baseURL:about:blank) and to the empty
+  // string `''` on Android (loadDataWithBaseURL("", ...)). Allow ONLY those two
+  // exact URLs — nothing else, including other `about:` pseudo-pages.
   const url = request.url ?? '';
-  return url === '' || url === 'about:blank' || url.startsWith('about:');
+  return url === '' || url === 'about:blank';
 }
 
 export function shouldAllowTerminalNavigation(request: ShouldStartLoadRequest): boolean {
@@ -151,8 +160,12 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
         source={{ html }}
         style={styles.container}
         // Containment (#5645): only the inline xterm document may load; block
-        // any server-/ANSI-triggered navigation. See shouldAllowTerminalNavigation.
-        originWhitelist={['about:*']}
+        // any server-/ANSI-triggered navigation. The real gate is
+        // onShouldStartLoadWithRequest below (consulted for every navigation).
+        // originWhitelist stays `['*']` because RN's whitelist rejects Android's
+        // empty (`''`) inline-load origin for any narrower glob — narrowing it
+        // would blank the terminal. See shouldAllowTerminalNavigation.
+        originWhitelist={['*']}
         onShouldStartLoadWithRequest={shouldAllowTerminalNavigation}
         onMessage={handleMessage}
         onContentProcessDidTerminate={handleWebViewCrash}


### PR DESCRIPTION
Closes #5645

## Problem

`packages/app/src/components/TerminalView.tsx` set `originWhitelist={['*']}` with no `onShouldStartLoadWithRequest`. Harmless today (the inline xterm page never navigates and xterm sanitizes ANSI), but it left no containment if a future xterm web-links addon — or a regression — let server-controlled ANSI trigger a navigation. Defense-in-depth gap flagged by the mobile swarm audit (Adversary F4).

## Change

- **`shouldAllowTerminalNavigation(request)`** — returns `true` ONLY for the inline xterm document load and its crash-recovery reload, `false` for everything else (http/https, link taps, `data:`, deep links).
- **Narrowed `originWhitelist`** from `['*']` to `['about:*']` (the inline document's origin). The coarse origin filter and the precise per-request gate are now both tight.
- Kept `javaScriptEnabled`, the page-side `disableStdin`, and all other WebView props intact.

## Guard logic + evidence

The terminal renders from an inline `source={{ html }}` with **no `baseUrl`**. Verified from RN WebView native source (v13.15.0):

- **iOS** (`apple/RNCWebViewImpl.m:841-845`): a missing `baseUrl` falls back to `about:blank`, loaded via `loadHTMLString:baseURL:`. The `onShouldStartLoadWithRequest` decision handler reports `url = request.URL.absoluteString` → `about:blank`.
- **Android** (`android/.../RNCWebViewManagerImpl.kt:391-398`): inline html with no baseUrl loads via `loadDataWithBaseURL("", html, ...)` → the page URL is the empty string (and `navigationType` is always `other` on Android per the type docs).

So the guard allows `url === 'about:blank'` (iOS) and `url === ''` (Android), plus any `about:*`. The crash-recovery `reload()` path re-runs the same inline document load, which surfaces the same `about:blank` / `''` URL — so reload is allowed too. Any real navigation (http/https/data:/deep-link) carries a concrete scheme and is blocked.

## Verification

- **App test suite:** 138 suites / 1841 tests green (Node 22). Added 6 tests in `TerminalView.test.tsx` asserting: initial `about:blank` load allowed, empty-url load allowed, `reload` navigationType allowed, `https://evil.example` blocked, http/`data:`/deep-link blocked, and that the guard is wired onto the WebView with `originWhitelist === ['about:*']`.
- **`tsc --noEmit`:** clean.
- **No blank-terminal regression:** the existing postMessage round-trip + ready-handshake + buffered-flush tests still pass unchanged, and the guard allows exactly the URL the inline document loads under (verified from native source above). A live Maestro run from the worktree was **not** performed — Metro can't watch the worktree (deps are hoisted to the repo root; symlinking `node_modules` into a worktree is a documented hazard), so a live device render of the worktree's changed JS wasn't feasible. Confidence is high: the allowed-URL set is derived directly from the RN WebView native load path for our exact `source` shape, and the round-trip/recovery behavior is exercised by the existing passing tests.