### PR TITLE
fix(app): use appVersion runtimeVersion policy (fingerprint breaks OTA build)

### DIFF
--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -41,7 +41,7 @@
     },
     "scheme": "chroxy",
     "runtimeVersion": {
-      "policy": "fingerprint"
+      "policy": "appVersion"
     },
     "updates": {
       "url": "https://u.expo.dev/5747b2cd-e15a-4742-9562-de949408f896",


### PR DESCRIPTION
The OTA pipeline (#5641) shipped `runtimeVersion: { policy: "fingerprint" }`, which **fails the EAS Android build** in the `Configure expo-updates` phase (structured error: `UNKNOWN_ERROR — See logs of the Configure expo-updates build phase`). Two preview builds errored identically at ~24 min; the M11 build (same setup minus OTA) succeeded — isolating the cause to the fingerprint policy. Fingerprint hashes native state including the stale committed `ios/` dir (#5642), which trips the configure phase.

**Fix:** switch to the `appVersion` runtimeVersion policy — the audit-blessed fallback (docs/audit-results/mobile-app-experience/06-expo-expert.md).

**Verified:** build `67ffc9a1` from this branch (commit f94fe2352) **succeeded** end-to-end and produced a working OTA-capable APK. This is the empirical proof the fix works — the build is the test.

Related: #5640, #5641. Follow-up #5642 (iOS native-config) would let us revisit fingerprint later.