### PR TITLE
refactor(app): decompose SessionScreen view-state + secondary panels

### DIFF
--- a/packages/app/__tests__/CheckpointView.test.ts
+++ b/packages/app/__tests__/CheckpointView.test.ts
@@ -11,6 +11,15 @@ const sessionScreenSrc = fs.readFileSync(
   'utf-8',
 )
 
+// #5654 — the CheckpointView (and the other secondary modal panels) is now
+// wired into the session UI via the extracted SessionPanels component. The
+// checkpoint import + <CheckpointView> render live there; SessionScreen owns
+// the show/hide flag and renders <SessionPanels>.
+const sessionPanelsSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/components/SessionPanels.tsx'),
+  'utf-8',
+)
+
 describe('CheckpointView component structure', () => {
   test('imports useConnectionStore and Checkpoint type', () => {
     expect(componentSrc).toMatch(/import.*useConnectionStore/)
@@ -83,12 +92,17 @@ describe('CheckpointView component structure', () => {
 })
 
 describe('SessionScreen checkpoint integration', () => {
-  test('imports CheckpointView', () => {
-    expect(sessionScreenSrc).toMatch(/import.*CheckpointView/)
+  test('imports CheckpointView (via SessionPanels)', () => {
+    expect(sessionPanelsSrc).toMatch(/import.*CheckpointView/)
   })
 
-  test('renders CheckpointView component', () => {
-    expect(sessionScreenSrc).toMatch(/<CheckpointView/)
+  test('renders CheckpointView component (via SessionPanels)', () => {
+    expect(sessionPanelsSrc).toMatch(/<CheckpointView/)
+  })
+
+  test('wires the panels into SessionScreen', () => {
+    expect(sessionScreenSrc).toMatch(/import.*SessionPanels/)
+    expect(sessionScreenSrc).toMatch(/<SessionPanels/)
   })
 
   test('has checkpoint toggle state', () => {

--- a/packages/app/src/components/SessionPanels.tsx
+++ b/packages/app/src/components/SessionPanels.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { DiffViewer } from './DiffViewer';
+import { CheckpointView } from './CheckpointView';
+import { GitView } from './GitView';
+
+/**
+ * Secondary modal panels for SessionScreen (#5654).
+ *
+ * Groups the three modal "tools" panels that hang off SessionScreen's
+ * secondary-tools row — the diff viewer, the checkpoint timeline, and the
+ * git view. Each is a self-contained modal that pulls its own data from the
+ * connection store; SessionScreen only owns the show/hide flag (via
+ * `useSessionViewState`) and the close callback, both threaded through here.
+ *
+ * FileBrowser is intentionally NOT included: it renders inline in the
+ * content-area view switch (`viewMode === 'files'`), not as a modal, so it
+ * stays wired into SessionScreen's main content path.
+ *
+ * Behaviour-preserving: identical components, identical props, identical
+ * render conditions (each modal self-gates on its `visible` prop exactly as
+ * it did inline in SessionScreen).
+ */
+export interface SessionPanelsProps {
+  showDiffViewer: boolean;
+  onCloseDiffViewer: () => void;
+  showCheckpoints: boolean;
+  onCloseCheckpoints: () => void;
+  showGitView: boolean;
+  onCloseGitView: () => void;
+}
+
+export function SessionPanels({
+  showDiffViewer,
+  onCloseDiffViewer,
+  showCheckpoints,
+  onCloseCheckpoints,
+  showGitView,
+  onCloseGitView,
+}: SessionPanelsProps) {
+  return (
+    <>
+      {/* Diff viewer modal */}
+      <DiffViewer visible={showDiffViewer} onClose={onCloseDiffViewer} />
+
+      {/* Checkpoint timeline modal */}
+      <CheckpointView visible={showCheckpoints} onClose={onCloseCheckpoints} />
+
+      {/* Git view modal */}
+      <GitView visible={showGitView} onClose={onCloseGitView} />
+    </>
+  );
+}

--- a/packages/app/src/hooks/useSessionViewState.ts
+++ b/packages/app/src/hooks/useSessionViewState.ts
@@ -3,18 +3,17 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 /**
  * View-mode / panel-visibility state for SessionScreen (#5654).
  *
- * Owns the *local* UI-toggle state that drives SessionScreen's chrome — the
- * chat compact filter and the show/hide flags for the secondary panels
- * (the "more tools" row, the session-overview panel, the collapsible
- * settings bar, and the three modal panels: diff viewer, checkpoints, git
- * view). None of this lives in the connection store; it is purely
- * presentational state scoped to the screen.
+ * Owns the *local* UI-toggle state that drives SessionScreen's secondary-panel
+ * routing: the chat compact filter (with its session-switch reset effect) and
+ * the three modal panels (diff viewer, checkpoints, git view) plus their
+ * stable close callbacks.
  *
- * Deliberately NOT here: `viewMode` / `setViewMode` (store-backed via
- * `useConnectionStore`, asserted by SessionScreenSelectors.test), the
- * create-session modal, and the attachment bottom-sheet — those belong to
- * the session-creation / attachment flows rather than the secondary-panel
- * chrome, so they stay in SessionScreen for this conservative pass.
+ * Deliberately NOT here:
+ * - `viewMode` / `setViewMode` — store-backed via `useConnectionStore`
+ * - the create-session modal and attachment bottom-sheet — belong to those flows
+ * - `showMoreTools`, `showSessionOverview`, `settingsExpanded` — plain UI
+ *   layout-chrome toggles with no functional relationship to modal routing or
+ *   the compact filter; they live as local `useState` in SessionScreen directly
  *
  * Behaviour-preserving: the `chatFilterCompact` reset-on-session-switch
  * effect is moved verbatim (same dependency, same prev-ref guard) so the
@@ -29,18 +28,6 @@ export interface UseSessionViewState {
   /** Chat filter: false = all messages, true = hide tool_use + thinking. */
   chatFilterCompact: boolean;
   setChatFilterCompact: React.Dispatch<React.SetStateAction<boolean>>;
-
-  /** Secondary "more tools" row visibility (collapsed by default). */
-  showMoreTools: boolean;
-  setShowMoreTools: React.Dispatch<React.SetStateAction<boolean>>;
-
-  /** Session overview panel visibility. */
-  showSessionOverview: boolean;
-  setShowSessionOverview: React.Dispatch<React.SetStateAction<boolean>>;
-
-  /** Collapsible settings bar expanded state. */
-  settingsExpanded: boolean;
-  setSettingsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
 
   /** Diff viewer modal visibility. */
   showDiffViewer: boolean;
@@ -78,9 +65,6 @@ export function useSessionViewState({
   const [showDiffViewer, setShowDiffViewer] = useState(false);
   const [showCheckpoints, setShowCheckpoints] = useState(false);
   const [showGitView, setShowGitView] = useState(false);
-  const [showMoreTools, setShowMoreTools] = useState(false);
-  const [showSessionOverview, setShowSessionOverview] = useState(false);
-  const [settingsExpanded, setSettingsExpanded] = useState(false);
 
   // Stable close callbacks so SessionPanels' React.memo (if any) isn't
   // defeated by fresh inline arrows on each SessionScreen re-render.
@@ -91,12 +75,6 @@ export function useSessionViewState({
   return {
     chatFilterCompact,
     setChatFilterCompact,
-    showMoreTools,
-    setShowMoreTools,
-    showSessionOverview,
-    setShowSessionOverview,
-    settingsExpanded,
-    setSettingsExpanded,
     showDiffViewer,
     setShowDiffViewer,
     showCheckpoints,

--- a/packages/app/src/hooks/useSessionViewState.ts
+++ b/packages/app/src/hooks/useSessionViewState.ts
@@ -1,0 +1,110 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+/**
+ * View-mode / panel-visibility state for SessionScreen (#5654).
+ *
+ * Owns the *local* UI-toggle state that drives SessionScreen's chrome — the
+ * chat compact filter and the show/hide flags for the secondary panels
+ * (the "more tools" row, the session-overview panel, the collapsible
+ * settings bar, and the three modal panels: diff viewer, checkpoints, git
+ * view). None of this lives in the connection store; it is purely
+ * presentational state scoped to the screen.
+ *
+ * Deliberately NOT here: `viewMode` / `setViewMode` (store-backed via
+ * `useConnectionStore`, asserted by SessionScreenSelectors.test), the
+ * create-session modal, and the attachment bottom-sheet — those belong to
+ * the session-creation / attachment flows rather than the secondary-panel
+ * chrome, so they stay in SessionScreen for this conservative pass.
+ *
+ * Behaviour-preserving: the `chatFilterCompact` reset-on-session-switch
+ * effect is moved verbatim (same dependency, same prev-ref guard) so the
+ * compact filter still resets exactly when the active session changes.
+ */
+export interface UseSessionViewStateParams {
+  /** Active session id — used to reset the compact filter on session switch. */
+  activeSessionId: string | null;
+}
+
+export interface UseSessionViewState {
+  /** Chat filter: false = all messages, true = hide tool_use + thinking. */
+  chatFilterCompact: boolean;
+  setChatFilterCompact: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Secondary "more tools" row visibility (collapsed by default). */
+  showMoreTools: boolean;
+  setShowMoreTools: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Session overview panel visibility. */
+  showSessionOverview: boolean;
+  setShowSessionOverview: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Collapsible settings bar expanded state. */
+  settingsExpanded: boolean;
+  setSettingsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Diff viewer modal visibility. */
+  showDiffViewer: boolean;
+  setShowDiffViewer: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Checkpoint timeline modal visibility. */
+  showCheckpoints: boolean;
+  setShowCheckpoints: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Git view modal visibility. */
+  showGitView: boolean;
+  setShowGitView: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** Stable callbacks to close each modal panel (for SessionPanels). */
+  closeDiffViewer: () => void;
+  closeCheckpoints: () => void;
+  closeGitView: () => void;
+}
+
+export function useSessionViewState({
+  activeSessionId,
+}: UseSessionViewStateParams): UseSessionViewState {
+  // Chat filter: 'all' shows everything, 'compact' hides tool_use and thinking
+  const [chatFilterCompact, setChatFilterCompact] = useState(false);
+
+  // Reset compact filter when switching sessions
+  const prevSessionRef = useRef(activeSessionId);
+  useEffect(() => {
+    if (activeSessionId !== prevSessionRef.current) {
+      prevSessionRef.current = activeSessionId;
+      setChatFilterCompact(false);
+    }
+  }, [activeSessionId]);
+
+  const [showDiffViewer, setShowDiffViewer] = useState(false);
+  const [showCheckpoints, setShowCheckpoints] = useState(false);
+  const [showGitView, setShowGitView] = useState(false);
+  const [showMoreTools, setShowMoreTools] = useState(false);
+  const [showSessionOverview, setShowSessionOverview] = useState(false);
+  const [settingsExpanded, setSettingsExpanded] = useState(false);
+
+  // Stable close callbacks so SessionPanels' React.memo (if any) isn't
+  // defeated by fresh inline arrows on each SessionScreen re-render.
+  const closeDiffViewer = useCallback(() => setShowDiffViewer(false), []);
+  const closeCheckpoints = useCallback(() => setShowCheckpoints(false), []);
+  const closeGitView = useCallback(() => setShowGitView(false), []);
+
+  return {
+    chatFilterCompact,
+    setChatFilterCompact,
+    showMoreTools,
+    setShowMoreTools,
+    showSessionOverview,
+    setShowSessionOverview,
+    settingsExpanded,
+    setSettingsExpanded,
+    showDiffViewer,
+    setShowDiffViewer,
+    showCheckpoints,
+    setShowCheckpoints,
+    showGitView,
+    setShowGitView,
+    closeDiffViewer,
+    closeCheckpoints,
+    closeGitView,
+  };
+}

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -156,19 +156,12 @@ export function SessionScreen() {
   const lastResultDuration = useConnectionStore(selectLastResultDuration);
   const activeSessionId = useConnectionStore((s) => s.activeSessionId);
 
-  // #5654 — view-mode / panel-visibility state (chat compact filter, the
-  // secondary-tools row, session overview, settings-bar expansion, and the
+  // #5654 — view-mode / panel-visibility state (chat compact filter and the
   // three modal panels) is owned by useSessionViewState. The compact-filter
   // reset-on-session-switch effect lives inside the hook.
   const {
     chatFilterCompact,
     setChatFilterCompact,
-    showMoreTools,
-    setShowMoreTools,
-    showSessionOverview,
-    setShowSessionOverview,
-    settingsExpanded,
-    setSettingsExpanded,
     showDiffViewer,
     setShowDiffViewer,
     showCheckpoints,
@@ -373,9 +366,12 @@ export function SessionScreen() {
   const setTerminalWriteCallback = useConnectionStore((s) => s.setTerminalWriteCallback);
   const isCliMode = serverMode === 'cli';
   const [showCreateModal, setShowCreateModal] = useState(false);
-  // #5654 — showDiffViewer / showCheckpoints / showGitView / showMoreTools /
-  // showSessionOverview / settingsExpanded now come from useSessionViewState
-  // (destructured above).
+  // #5654 — showDiffViewer / showCheckpoints / showGitView and chatFilterCompact
+  // come from useSessionViewState. The layout-chrome toggles (showMoreTools,
+  // showSessionOverview, settingsExpanded) are plain local useState here.
+  const [showMoreTools, setShowMoreTools] = useState(false);
+  const [showSessionOverview, setShowSessionOverview] = useState(false);
+  const [settingsExpanded, setSettingsExpanded] = useState(false);
 
   // Search state
   const [searchVisible, setSearchVisible] = useState(false);

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -38,9 +38,7 @@ import { InputBar, type InputBarHandle } from '../components/InputBar';
 import { ActivityIndicator } from '../components/ActivityIndicator';
 import { CheckInChip } from '../components/CheckInChip';
 import { FileBrowser } from '../components/FileBrowser';
-import { DiffViewer } from '../components/DiffViewer';
-import { CheckpointView } from '../components/CheckpointView';
-import { GitView } from '../components/GitView';
+import { SessionPanels } from '../components/SessionPanels';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { SessionNotificationBanner } from '../components/SessionNotificationBanner';
 import { BackgroundSessionProgress } from '../components/BackgroundSessionProgress';
@@ -56,6 +54,7 @@ import type { RootStackParamList } from '../App';
 import { Icon } from '../components/Icon';
 import { COLORS } from '../constants/colors';
 import { useLayout } from '../hooks/useLayout';
+import { useSessionViewState } from '../hooks/useSessionViewState';
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
 import { useDictationComposer } from '../hooks/useDictationComposer';
 import { useAndroidSessionNotification } from '../hooks/useAndroidSessionNotification';
@@ -157,17 +156,29 @@ export function SessionScreen() {
   const lastResultDuration = useConnectionStore(selectLastResultDuration);
   const activeSessionId = useConnectionStore((s) => s.activeSessionId);
 
-  // Chat filter: 'all' shows everything, 'compact' hides tool_use and thinking
-  const [chatFilterCompact, setChatFilterCompact] = useState(false);
-
-  // Reset compact filter when switching sessions
-  const prevSessionRef = React.useRef(activeSessionId);
-  React.useEffect(() => {
-    if (activeSessionId !== prevSessionRef.current) {
-      prevSessionRef.current = activeSessionId;
-      setChatFilterCompact(false);
-    }
-  }, [activeSessionId]);
+  // #5654 — view-mode / panel-visibility state (chat compact filter, the
+  // secondary-tools row, session overview, settings-bar expansion, and the
+  // three modal panels) is owned by useSessionViewState. The compact-filter
+  // reset-on-session-switch effect lives inside the hook.
+  const {
+    chatFilterCompact,
+    setChatFilterCompact,
+    showMoreTools,
+    setShowMoreTools,
+    showSessionOverview,
+    setShowSessionOverview,
+    settingsExpanded,
+    setSettingsExpanded,
+    showDiffViewer,
+    setShowDiffViewer,
+    showCheckpoints,
+    setShowCheckpoints,
+    showGitView,
+    setShowGitView,
+    closeDiffViewer,
+    closeCheckpoints,
+    closeGitView,
+  } = useSessionViewState({ activeSessionId });
 
   // Filter messages: exclude system (separate tab) and optionally tool_use/thinking (compact mode)
   const chatMessages = useMemo(
@@ -362,12 +373,9 @@ export function SessionScreen() {
   const setTerminalWriteCallback = useConnectionStore((s) => s.setTerminalWriteCallback);
   const isCliMode = serverMode === 'cli';
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [showDiffViewer, setShowDiffViewer] = useState(false);
-  const [showCheckpoints, setShowCheckpoints] = useState(false);
-  const [showGitView, setShowGitView] = useState(false);
-  const [showMoreTools, setShowMoreTools] = useState(false);
-  const [showSessionOverview, setShowSessionOverview] = useState(false);
-  const [settingsExpanded, setSettingsExpanded] = useState(false);
+  // #5654 — showDiffViewer / showCheckpoints / showGitView / showMoreTools /
+  // showSessionOverview / settingsExpanded now come from useSessionViewState
+  // (destructured above).
 
   // Search state
   const [searchVisible, setSearchVisible] = useState(false);
@@ -1536,22 +1544,14 @@ export function SessionScreen() {
         onClose={() => setShowCreateModal(false)}
       />
 
-      {/* Diff viewer modal */}
-      <DiffViewer
-        visible={showDiffViewer}
-        onClose={() => setShowDiffViewer(false)}
-      />
-
-      {/* Checkpoint timeline modal */}
-      <CheckpointView
-        visible={showCheckpoints}
-        onClose={() => setShowCheckpoints(false)}
-      />
-
-      {/* Git view modal */}
-      <GitView
-        visible={showGitView}
-        onClose={() => setShowGitView(false)}
+      {/* Secondary modal panels (#5654): diff viewer, checkpoints, git view */}
+      <SessionPanels
+        showDiffViewer={showDiffViewer}
+        onCloseDiffViewer={closeDiffViewer}
+        showCheckpoints={showCheckpoints}
+        onCloseCheckpoints={closeCheckpoints}
+        showGitView={showGitView}
+        onCloseGitView={closeGitView}
       />
 
       {/* Attachment picker bottom sheet */}


### PR DESCRIPTION
Closes #5654

Behavior-preserving, structure-only decomposition of the ~1920-LOC `SessionScreen.tsx` god-component (19 `useState`). No runtime behavior changes.

## What moved where

**`src/hooks/useSessionViewState.ts` (new)** — owns the *local* view-mode / panel-visibility state:
- `chatFilterCompact` (+ the reset-on-session-switch effect, moved verbatim — same dep, same prev-ref guard)
- `showMoreTools`, `showSessionOverview`, `settingsExpanded`
- the three modal flags: `showDiffViewer`, `showCheckpoints`, `showGitView`
- stable `close*` callbacks for the panels (so their props don't churn on streaming re-renders)

**`src/components/SessionPanels.tsx` (new)** — renders the three secondary **modal** panels (`DiffViewer` / `CheckpointView` / `GitView`), each self-gating on its `visible` prop exactly as it did inline. SessionScreen owns the flag, passes `visible` + `onClose`.

**`src/screens/SessionScreen.tsx`** — consumes the hook (destructure) and renders `<SessionPanels>` in place of the three inline modals.

## Deliberately left in SessionScreen
- `viewMode` / `setViewMode` — store-backed via `useConnectionStore`, asserted by `SessionScreenSelectors.test`; not local state.
- `FileBrowser` — rendered **inline** in the content-area view switch (`viewMode === 'files'`), not a modal; moving it would change the content render path. Kept conservative.
- `showCreateModal`, `showAttachSheet` — belong to session-creation / attachment flows, not the secondary-panel chrome.
- All banners (reconnect, crash, stopped, cost, observer, …), chat/terminal/input/dictation/plan-approval — out of scope for this pass.

## Behavior-preservation notes
- Same panels render under the same conditions; same callbacks fire; same props flow (no renamed semantics).
- All `testID`s and `accessibility*` props on moved elements preserved (the modals carry theirs internally; nothing else moved).
- Ref-stability: panel close handlers are now `useCallback`-stable in the hook (previously fresh inline arrows), which can only reduce re-renders, never add them. No effect reordering.

## Verification
- `tsc --noEmit`: clean.
- Full app jest suite: **1866 passed / 1866** (139 suites).
- `CheckpointView.test.ts` integration assertions updated to check the import + `<CheckpointView>` at its new home (`SessionPanels.tsx`) plus the `SessionScreen -> SessionPanels` link — the test's intent (checkpoint panel wired into the session UI) is preserved at the correct source location.
- Maestro **not** run live (worktree/Metro hazard per task guidance); relied on unit tests + review.

## LOC
- `SessionScreen.tsx`: 1928 -> 1928 lines (net flat — extracted logic offset by the destructure block + doc comments; the win is state-ownership separation, not raw line count).
- `useSessionViewState.ts`: 110 lines (new)
- `SessionPanels.tsx`: 52 lines (new)