### PR TITLE
refactor(app): collapse WS send guards into a single sendIfOpen helper

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -298,8 +298,14 @@ describe('connection.ts — notification-prefs WS-closed return values (#4559)',
   });
 
   it('refreshNotificationPrefs returns true on send and false on closed socket', () => {
+    // #5652: refreshNotificationPrefs now routes through the canonical
+    // `sendIfOpen` helper, which returns `true` when the frame was sent
+    // (socket open) and `false` on the closed-socket no-op — the same
+    // boolean contract the inline `return true`/`return false` guard
+    // encoded pre-#5652. SettingsScreen still drives its inline
+    // "server disconnected" banner off this boolean.
     expect(connectionSource).toMatch(
-      /refreshNotificationPrefs[\s\S]{0,400}wsSend\(socket,[\s\S]{0,150}notification_prefs_get[\s\S]{0,80}return true[\s\S]{0,80}return false/,
+      /refreshNotificationPrefs[\s\S]{0,200}return sendIfOpen\(\{[\s\S]{0,80}notification_prefs_get/,
     );
   });
 

--- a/packages/app/src/__tests__/store/file-operations-store.test.js
+++ b/packages/app/src/__tests__/store/file-operations-store.test.js
@@ -4,18 +4,28 @@ import { getCallback, clearAllCallbacks } from '../../store/imperative-callbacks
 // Track wsSend calls
 const wsSendCalls = []
 
-// Mock message-handler's wsSend
-jest.mock('../../store/message-handler', () => ({
-  wsSend: (socket, payload) => {
-    wsSendCalls.push({ socket, payload })
-  },
-}))
-
 // Mock useConnectionStore to provide a fake socket
 const mockSocket = { readyState: 1 }
 jest.mock('../../store/connection', () => ({
   useConnectionStore: {
     getState: () => ({ socket: mockSocket }),
+  },
+}))
+
+// Mock message-handler's wsSend + sendIfOpen. sendIfOpen mirrors the real
+// "send iff the live socket is open" semantics against the mocked socket so the
+// store's request methods (which now route through sendIfOpen) behave as in
+// production: send the payload when open, no-op (and report false) when closed.
+jest.mock('../../store/message-handler', () => ({
+  wsSend: (socket, payload) => {
+    wsSendCalls.push({ socket, payload })
+  },
+  sendIfOpen: (payload) => {
+    if (mockSocket && mockSocket.readyState === 1) {
+      wsSendCalls.push({ socket: mockSocket, payload })
+      return true
+    }
+    return false
   },
 }))
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -8,6 +8,8 @@ import { Alert } from 'react-native';
 import {
   _testMessageHandler,
   setStore,
+  sendIfOpen,
+  _testResetStore,
   CLIENT_PROTOCOL_VERSION,
   SUBSCRIBE_SESSIONS_CHUNK_SIZE,
   clearPermissionSplits,
@@ -5315,5 +5317,45 @@ describe('tunnel_url_changed (#5555 sub-item 7)', () => {
     expect(useConnectionLifecycleStore.getState().savedConnection?.tunnelUrl).toBe(
       'wss://old.trycloudflare.com',
     );
+  });
+});
+
+// #5657: sendIfOpen must not throw when the store hasn't been wired yet.
+// file-operations.ts imports sendIfOpen directly, so it can be called before
+// setStore() runs (e.g. during module initialisation or early mount).
+describe('sendIfOpen — uninitialized store guard (#5657)', () => {
+  afterEach(() => {
+    // Restore module-level _store reference so later tests aren't affected.
+    _testResetStore();
+  });
+
+  it('returns false and does NOT throw before setStore() is called', () => {
+    _testResetStore(); // ensure clean slate
+    let result: boolean | undefined;
+    expect(() => {
+      result = sendIfOpen({ type: 'ping' });
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
+
+  it('returns false when store is set but socket is null', () => {
+    const store = createMockStore({ socket: null });
+    setStore(store as any);
+    expect(sendIfOpen({ type: 'ping' })).toBe(false);
+  });
+
+  it('returns false when store is set but socket is not OPEN (CONNECTING)', () => {
+    const store = createMockStore({ socket: { readyState: WebSocket.CONNECTING, send: jest.fn() } as any });
+    setStore(store as any);
+    expect(sendIfOpen({ type: 'ping' })).toBe(false);
+  });
+
+  it('returns true and calls wsSend when store is set and socket is OPEN', () => {
+    const sendMock = jest.fn();
+    const store = createMockStore({ socket: { readyState: WebSocket.OPEN, send: sendMock } as any });
+    setStore(store as any);
+    const result = sendIfOpen({ type: 'ping' });
+    expect(result).toBe(true);
+    expect(sendMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -91,6 +91,7 @@ import { selectConnectEndpoint, deriveTunnelUrl, isLanWsUrl } from '../utils/end
 import {
   setStore,
   wsSend,
+  sendIfOpen,
   sendClientVisible,
   handleMessage,
   setConnectionContext,
@@ -499,10 +500,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   terminalRawBuffer: '',
 
   closeDevPreview: (port: number) => {
-    const { socket, activeSessionId } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'close_dev_preview', port, sessionId: activeSessionId });
-    }
+    const { activeSessionId } = get();
+    sendIfOpen({ type: 'close_dev_preview', port, sessionId: activeSessionId });
   },
 
   // Web tasks (Claude Code Web)
@@ -510,28 +509,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   webTasks: [],
 
   launchWebTask: (prompt: string, cwd?: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'launch_web_task', prompt };
-      if (cwd) payload.cwd = cwd;
-      wsSend(socket, payload);
-      return 'sent';
-    }
-    return false;
+    const payload: Record<string, unknown> = { type: 'launch_web_task', prompt };
+    if (cwd) payload.cwd = cwd;
+    return sendIfOpen(payload) ? 'sent' : false;
   },
 
   listWebTasks: () => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'list_web_tasks' });
-    }
+    sendIfOpen({ type: 'list_web_tasks' });
   },
 
   teleportWebTask: (taskId: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'teleport_web_task', taskId });
-    }
+    sendIfOpen({ type: 'teleport_web_task', taskId });
   },
 
   viewCachedSession: () => {
@@ -559,12 +547,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // error on `false` so the user knows their change did not reach the
   // server — pre-#4559 the silent-drop made the Switch look unresponsive.
   refreshNotificationPrefs: (): boolean => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'notification_prefs_get' });
-      return true;
-    }
-    return false;
+    return sendIfOpen({ type: 'notification_prefs_get' });
   },
 
   // #4558: optimistic update. The Switch should flip the moment the user
@@ -1702,12 +1685,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   setModel: (model: string) => {
-    const { socket, activeSessionId } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'set_model', model };
-      if (activeSessionId) payload.sessionId = activeSessionId;
-      wsSend(socket, payload);
-    }
+    const { activeSessionId } = get();
+    const payload: Record<string, unknown> = { type: 'set_model', model };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    sendIfOpen(payload);
   },
 
   setPermissionMode: (mode: string) => {
@@ -1741,12 +1722,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   setPermissionRules: (rules) => {
-    const { socket, activeSessionId } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'set_permission_rules', rules };
-      if (activeSessionId) payload.sessionId = activeSessionId;
-      wsSend(socket, payload);
-    }
+    const { activeSessionId } = get();
+    const payload: Record<string, unknown> = { type: 'set_permission_rules', rules };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    sendIfOpen(payload);
   },
 
   confirmPermissionMode: (mode: string) => {
@@ -1785,12 +1764,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   resize: (cols, rows) => {
-    const { socket, activeSessionId } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'resize', cols, rows };
-      if (activeSessionId) payload.sessionId = activeSessionId;
-      wsSend(socket, payload);
-    }
+    const { activeSessionId } = get();
+    const payload: Record<string, unknown> = { type: 'resize', cols, rows };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    sendIfOpen(payload);
   },
 
   // Directory listing
@@ -1800,12 +1777,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   requestDirectoryListing: (path?: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const msg: Record<string, string> = { type: 'list_directory' };
-      if (path) msg.path = path;
-      wsSend(socket, msg);
-    }
+    const msg: Record<string, string> = { type: 'list_directory' };
+    if (path) msg.path = path;
+    sendIfOpen(msg);
   },
 
   // File browser
@@ -1819,19 +1793,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   requestFileListing: (path?: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const msg: Record<string, string> = { type: 'browse_files' };
-      if (path) msg.path = path;
-      wsSend(socket, msg);
-    }
+    const msg: Record<string, string> = { type: 'browse_files' };
+    if (path) msg.path = path;
+    sendIfOpen(msg);
   },
 
   requestFileContent: (path: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'read_file', path });
-    }
+    sendIfOpen({ type: 'read_file', path });
   },
 
   setFileWriteCallback: (cb) => {
@@ -1839,10 +1807,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   requestFileWrite: (path: string, content: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'write_file', path, content });
-    }
+    sendIfOpen({ type: 'write_file', path, content });
   },
 
   // Diff viewer
@@ -1852,12 +1817,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   requestDiff: (base?: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const msg: Record<string, string> = { type: 'get_diff' };
-      if (base) msg.base = base;
-      wsSend(socket, msg);
-    }
+    const msg: Record<string, string> = { type: 'get_diff' };
+    if (base) msg.base = base;
+    sendIfOpen(msg);
   },
 
   // Git operations
@@ -1868,59 +1830,35 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setGitCommitCallback: (cb) => { setImperativeCallback('gitCommit', cb); },
 
   requestGitStatus: () => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'git_status' });
-    }
+    sendIfOpen({ type: 'git_status' });
   },
 
   requestGitBranches: () => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'git_branches' });
-    }
+    sendIfOpen({ type: 'git_branches' });
   },
 
   requestGitStage: (paths: string[]) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'git_stage', files: paths });
-    }
+    sendIfOpen({ type: 'git_stage', files: paths });
   },
 
   requestGitUnstage: (paths: string[]) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'git_unstage', files: paths });
-    }
+    sendIfOpen({ type: 'git_unstage', files: paths });
   },
 
   requestGitCommit: (message: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'git_commit', message });
-    }
+    sendIfOpen({ type: 'git_commit', message });
   },
 
   fetchProviders: () => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'list_providers' });
-    }
+    sendIfOpen({ type: 'list_providers' });
   },
 
   fetchSlashCommands: () => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'list_slash_commands' });
-    }
+    sendIfOpen({ type: 'list_slash_commands' });
   },
 
   fetchCustomAgents: () => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'list_agents' });
-    }
+    sendIfOpen({ type: 'list_agents' });
   },
 
   // Session actions
@@ -1931,18 +1869,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // PRIMARY_HELD `session_error` (input_conflict), surfaced as a calm notice.
   // The authoritative role lands via the resulting `session_role` broadcast.
   claimPrimary: (sessionId: string, options?: { force?: boolean }) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, {
-        type: 'claim_primary',
-        sessionId,
-        ...(options?.force ? { force: true } : {}),
-      });
-    }
+    sendIfOpen({
+      type: 'claim_primary',
+      sessionId,
+      ...(options?.force ? { force: true } : {}),
+    });
   },
 
   switchSession: (sessionId: string, options?: { serverNotify?: boolean; haptic?: boolean }) => {
-    const { socket, activeSessionId, sessionStates } = get();
+    const { activeSessionId } = get();
     const serverNotify = options?.serverNotify ?? true;
     const haptic = options?.haptic ?? true;
 
@@ -1958,8 +1893,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     );
     set({ activeSessionId: sessionId, sessionNotifications: filteredNotifications });
 
-    if (serverNotify && socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'switch_session', sessionId });
+    if (serverNotify) {
+      sendIfOpen({ type: 'switch_session', sessionId });
     }
   },
 
@@ -1969,32 +1904,23 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // accepts these fields plus others (e.g. `sandbox`) — see
   // packages/server/src/handlers/session-handlers.js for the full set.
   createSession: ({ name, cwd, worktree, provider, model, permissionMode, environmentId }) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const msg: Record<string, unknown> = { type: 'create_session' };
-      if (name) msg.name = name;
-      if (cwd) msg.cwd = cwd;
-      if (worktree) msg.worktree = true;
-      if (provider) msg.provider = provider;
-      if (model) msg.model = model;
-      if (permissionMode) msg.permissionMode = permissionMode;
-      if (environmentId) msg.environmentId = environmentId;
-      wsSend(socket, msg);
-    }
+    const msg: Record<string, unknown> = { type: 'create_session' };
+    if (name) msg.name = name;
+    if (cwd) msg.cwd = cwd;
+    if (worktree) msg.worktree = true;
+    if (provider) msg.provider = provider;
+    if (model) msg.model = model;
+    if (permissionMode) msg.permissionMode = permissionMode;
+    if (environmentId) msg.environmentId = environmentId;
+    sendIfOpen(msg);
   },
 
   destroySession: (sessionId: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'destroy_session', sessionId });
-    }
+    sendIfOpen({ type: 'destroy_session', sessionId });
   },
 
   renameSession: (sessionId: string, name: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'rename_session', sessionId, name });
-    }
+    sendIfOpen({ type: 'rename_session', sessionId, name });
   },
 
   fetchConversationHistory: () => {
@@ -2015,12 +1941,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   resumeConversation: (conversationId: string, cwd?: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'resume_conversation', conversationId };
-      if (cwd) payload.cwd = cwd;
-      wsSend(socket, payload);
-    }
+    const payload: Record<string, unknown> = { type: 'resume_conversation', conversationId };
+    if (cwd) payload.cwd = cwd;
+    sendIfOpen(payload);
   },
 
   searchConversations: (query: string) => {
@@ -2054,42 +1977,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   requestFullHistory: (sessionId?: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const msg: Record<string, string> = { type: 'request_full_history' };
-      if (sessionId) msg.sessionId = sessionId;
-      wsSend(socket, msg);
-    }
+    const msg: Record<string, string> = { type: 'request_full_history' };
+    if (sessionId) msg.sessionId = sessionId;
+    sendIfOpen(msg);
   },
 
   createCheckpoint: (name?: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const msg: Record<string, string> = { type: 'create_checkpoint' };
-      if (name) msg.name = name;
-      wsSend(socket, msg);
-    }
+    const msg: Record<string, string> = { type: 'create_checkpoint' };
+    if (name) msg.name = name;
+    sendIfOpen(msg);
   },
 
   listCheckpoints: () => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'list_checkpoints' });
-    }
+    sendIfOpen({ type: 'list_checkpoints' });
   },
 
   restoreCheckpoint: (checkpointId: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'restore_checkpoint', checkpointId });
-    }
+    sendIfOpen({ type: 'restore_checkpoint', checkpointId });
   },
 
   deleteCheckpoint: (checkpointId: string) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'delete_checkpoint', checkpointId });
-    }
+    sendIfOpen({ type: 'delete_checkpoint', checkpointId });
   },
 
   clearPlanState: () => {
@@ -2100,11 +2008,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   sendPlanResponse: (sessionId: string, approve: boolean) => {
-    const { socket } = get();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const data = approve ? 'Go ahead with the plan' : 'n';
-      wsSend(socket, { type: 'input', data, sessionId });
-    }
+    const data = approve ? 'Go ahead with the plan' : 'n';
+    sendIfOpen({ type: 'input', data, sessionId });
     // Clear plan state for the target session
     if (get().sessionStates[sessionId]) {
       const store = get();

--- a/packages/app/src/store/file-operations.ts
+++ b/packages/app/src/store/file-operations.ts
@@ -9,7 +9,7 @@
  */
 import { create } from 'zustand';
 import { setCallback } from './imperative-callbacks';
-import { wsSend } from './message-handler';
+import { sendIfOpen } from './message-handler';
 import type {
   DirectoryListing,
   FileListing,
@@ -21,19 +21,6 @@ import type {
   GitStageResult,
   GitCommitResult,
 } from './types';
-
-// Lazy import to avoid circular dependency — connection.ts imports from message-handler.ts
-// which this module also imports from. We break the cycle by deferring the import.
-let _getSocket: (() => WebSocket | null) | null = null;
-
-function getSocket(): WebSocket | null {
-  if (!_getSocket) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { useConnectionStore } = require('./connection');
-    _getSocket = () => useConnectionStore.getState().socket;
-  }
-  return _getSocket();
-}
 
 interface FileOperationsActions {
   // Callback setters
@@ -58,13 +45,6 @@ interface FileOperationsActions {
   requestGitStage: (paths: string[]) => void;
   requestGitUnstage: (paths: string[]) => void;
   requestGitCommit: (message: string) => void;
-}
-
-function sendIfOpen(payload: Record<string, unknown>): void {
-  const socket = getSocket();
-  if (socket && socket.readyState === WebSocket.OPEN) {
-    wsSend(socket, payload);
-  }
 }
 
 export const useFileOperationsStore = create<FileOperationsActions>(() => ({

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -392,6 +392,29 @@ export function wsSend(socket: WebSocket, payload: Record<string, unknown>): voi
   }
 }
 
+/**
+ * Canonical "send a WS frame iff the socket is open" helper.
+ *
+ * Collapses the `const { socket } = get(); if (socket && socket.readyState ===
+ * WebSocket.OPEN) { wsSend(socket, payload) }` boilerplate repeated across the
+ * connection store and file-operations store into one place (#5652). Reads the
+ * live socket from the connection store (set via setStore), so callers never
+ * have to thread it through.
+ *
+ * Returns `true` when the frame was sent (socket open), `false` when it was a
+ * no-op (no socket / not OPEN). Most callers ignore the result (a silent no-op
+ * on a closed socket is the existing behavior); the few that surface an error or
+ * return a status on the closed path read the boolean.
+ */
+export function sendIfOpen(payload: Record<string, unknown>): boolean {
+  const socket = getStore().getState().socket;
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    wsSend(socket, payload);
+    return true;
+  }
+  return false;
+}
+
 // #3672: treat iOS `inactive` as visible. `inactive` is a transient state for
 // app-switcher gesture, control-center pulldown, biometric prompt, incoming
 // call, and the brief moment between unlock and foreground promotion — the

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -196,6 +196,11 @@ export function setStore(store: StoreApi): void {
   _store = store;
 }
 
+/** @internal Exposed for testing only — resets the store reference to null. */
+export function _testResetStore(): void {
+  _store = null;
+}
+
 function getStore(): StoreApi {
   if (!_store) throw new Error('Store not initialized — call setStore() first');
   return _store;
@@ -407,6 +412,10 @@ export function wsSend(socket: WebSocket, payload: Record<string, unknown>): voi
  * return a status on the closed path read the boolean.
  */
 export function sendIfOpen(payload: Record<string, unknown>): boolean {
+  // Treat an uninitialized store the same as "socket not open": the store
+  // hasn't been wired yet (file-operations.ts imports this directly, so it
+  // can be called before setStore() runs).  Return false — no send, no throw.
+  if (!_store) return false;
   const socket = getStore().getState().socket;
   if (socket && socket.readyState === WebSocket.OPEN) {
     wsSend(socket, payload);


### PR DESCRIPTION
Closes #5652

## What

`packages/app/src/store/connection.ts` repeated the
`const { socket } = get(); if (socket && socket.readyState === WebSocket.OPEN) { wsSend(socket, payload) }`
guard at ~33 send sites, and `file-operations.ts` carried a *second* local copy of the same `sendIfOpen` helper.

This promotes **one canonical** `sendIfOpen(payload)` into `message-handler.ts` (next to `wsSend`), reading the live socket from the connection store via the existing `getStore()` accessor and returning a boolean (`true` = sent, `false` = closed no-op). Both `connection.ts` and `file-operations.ts` now route through it.

## Behavior-preserving

This is a pure structure refactor. Sites whose closed path is **not** a silent no-op, or that do extra conditional work inside the guard, are deliberately left unchanged:

- **4 optimistic-patch notification-prefs setters** (`setNotificationPrefsCategory` / `Device` / `QuietHours` / `BypassCategories`) — they run an optimistic `set()` *inside* the open guard, ordered before the send, and return a boolean.
- **4 enqueue-on-closed senders** (`sendInput`, `sendInterrupt`, `sendPermissionResponse`, `sendUserQuestionResponse`) — the closed path calls `enqueueMessage`, plus haptics inside the open path.
- **`sendPermissionResponse`'s second (allowSession-rule) guard** — reads several vars and builds a session-rule payload inside the guard.
- **`setPermissionMode` / `confirmPermissionMode`** — generate a requestId, register a pending request, and apply an optimistic `updateSession`, all conditioned on open.
- **`fetchConversationHistory` / `searchConversations`** — set loading state on the open path and **error** state on the closed path.

`refreshNotificationPrefs` and `launchWebTask` returned a value on the open/closed split; they reuse `sendIfOpen`'s boolean so their contract is identical.

The connect/socket-machinery `readyState` checks (`connectAuto` no-op guard, `socket.onopen` auth/pair send, the AppState resume zombie-socket guard) are not send sites and are untouched.

## Numbers

- **Collapsed:** 33 send sites in `connection.ts`.
- **Preserved:** the 13 guards above (all with reasons).
- **`connection.ts`:** 2370 → 2275 lines (−95).
- **`file-operations.ts`:** local `sendIfOpen` + lazy `getSocket` cycle-break removed (−20 net).

## Verify

- `tsc --noEmit`: clean.
- Full app jest suite: **1865 passed / 1865** (139 suites). The `connection.test.ts` send assertions — the behavior guard — all still pass.
- Two source-text guard tests updated to match the new shape: `file-operations-store.test.js` (mock now exposes `sendIfOpen`) and one `#4559` assertion for `refreshNotificationPrefs` (its true/false contract now flows through `sendIfOpen`'s boolean).