### PR TITLE
refactor(app): migrate file-ops/git wrapper cases to shared dispatch table

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -88,10 +88,8 @@ import {
   // Zod parse now routes through the shared handleNotificationPrefs.
   // #5454 — pure core of the #554 stream-split block (permission_request)
   resolvePermissionStreamSplit,
-  handleDirectoryListing as sharedDirectoryListing,
-  handleFileListing as sharedFileListing,
-  handleFileContent as sharedFileContent,
-  handleWriteFileResult as sharedWriteFileResult,
+  // directory_listing / file_listing / file_content / write_file_result —
+  // migrated to the shared dispatch table (#5556 slice 3 / #5653).
   buildSessionListPatches as sharedBuildSessionListPatches,
   cumulativeUsageEquals as sharedCumulativeUsageEquals,
   chunkSubscribeSessionIds as sharedChunkSubscribeSessionIds,
@@ -106,11 +104,9 @@ import {
   handleProviderList as sharedProviderList,
   handleAuthBootstrap as sharedAuthBootstrap,
   handleTunnelUrlChanged as sharedTunnelUrlChanged,
-  handleDiffResult as sharedDiffResult,
-  handleGitStatusResult as sharedGitStatusResult,
-  handleGitBranchesResult as sharedGitBranchesResult,
-  handleGitStageResult as sharedGitStageResult,
-  handleGitCommitResult as sharedGitCommitResult,
+  // diff_result / git_status_result / git_branches_result / git_stage_result /
+  // git_unstage_result / git_commit_result — migrated to the shared dispatch
+  // table (#5556 slice 3 / #5653).
   // agent_spawned / agent_completed / agent_event / background_work_changed /
   // mcp_servers / session_usage / web_task_list / web_feature_status migrated
   // to the shared dispatch table (#5556 slice 2)
@@ -144,7 +140,12 @@ import {
   createDispatchTable,
   runDispatch,
 } from '@chroxy/store-core';
-import type { DeltaFlusher, ClientStoreAdapter } from '@chroxy/store-core';
+import type {
+  DeltaFlusher,
+  ClientStoreAdapter,
+  DispatchCallbackName,
+  DispatchCallbackPayload,
+} from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
 import type {
@@ -153,8 +154,6 @@ import type {
   ConnectionContext,
   ConnectionState,
   CustomAgent,
-  DirectoryEntry,
-  FileEntry,
   QueuedMessage,
   ServerError,
   SessionInfo,
@@ -169,6 +168,7 @@ import { createEmptySessionState } from './utils';
 import { deriveActivityState } from './session-activity';
 import { clearPersistedSession, persistLastConversationId, loadLastConversationId } from './persistence';
 import { getCallback } from './imperative-callbacks';
+import type { CallbackName } from './imperative-callbacks';
 import { useMultiClientStore } from './multi-client';
 import { useWebStore } from './web';
 import { useCostStore } from './cost';
@@ -1088,6 +1088,17 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   setState: (patch) => getStore().setState(patch as Partial<ConnectionState>),
   addMessage: (m) => getStore().getState().addMessage(m),
   getSessions: () => getStore().getState().sessions,
+  // #5653 — file-ops / git wrapper cases route through the shared dispatch
+  // table; the app supplies its module-level imperative-callback registry so
+  // the parsed payload reaches the UI's registered callback exactly as the
+  // prior `getCallback(name) → shared*(msg) → cb(...)` switch arms did. The
+  // store-core handler narrows to a loose `(payload) => void`; the registered
+  // callback's concrete type (e.g. `(listing: DirectoryListing) => void`) is
+  // structurally compatible since the parsed payload is a superset.
+  getCallback: (name: DispatchCallbackName) =>
+    getCallback(name as CallbackName) as
+      | ((payload: DispatchCallbackPayload) => void)
+      | null,
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -3025,97 +3036,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'directory_listing': {
-      const cb = getCallback('directoryListing');
-      if (cb) {
-        const payload = sharedDirectoryListing(msg);
-        cb({ ...payload, entries: payload.entries as DirectoryEntry[] });
-      }
-      break;
-    }
-
-    case 'file_listing': {
-      const fileBrowserCb = getCallback('fileBrowser');
-      if (fileBrowserCb) {
-        const payload = sharedFileListing(msg);
-        fileBrowserCb({ ...payload, entries: payload.entries as FileEntry[] });
-      }
-      break;
-    }
-
-    case 'file_content': {
-      const fileContentCb = getCallback('fileContent');
-      if (fileContentCb) {
-        fileContentCb(sharedFileContent(msg));
-      }
-      break;
-    }
-
-    case 'write_file_result': {
-      const fileWriteCb = getCallback('fileWrite');
-      if (fileWriteCb) {
-        fileWriteCb(sharedWriteFileResult(msg));
-      }
-      break;
-    }
-
-    case 'diff_result': {
-      const diffCb = getCallback('diff');
-      if (diffCb) {
-        const payload = sharedDiffResult(msg);
-        // payload arrays are now strongly typed from store-core (#3132).
-        diffCb({
-          files: payload.files,
-          error: payload.error,
-        });
-      }
-      break;
-    }
-
-    case 'git_status_result': {
-      const cb = getCallback('gitStatus');
-      if (cb) {
-        const payload = sharedGitStatusResult(msg);
-        cb({
-          branch: payload.branch,
-          staged: payload.staged,
-          unstaged: payload.unstaged,
-          untracked: payload.untracked,
-          error: payload.error,
-        });
-      }
-      break;
-    }
-
-    case 'git_branches_result': {
-      const cb = getCallback('gitBranches');
-      if (cb) {
-        const payload = sharedGitBranchesResult(msg);
-        cb({
-          branches: payload.branches,
-          currentBranch: payload.currentBranch,
-          error: payload.error,
-        });
-      }
-      break;
-    }
-
-    case 'git_stage_result':
-    case 'git_unstage_result': {
-      const cb = getCallback('gitStage');
-      if (cb) {
-        cb(sharedGitStageResult(msg));
-      }
-      break;
-    }
-
-    case 'git_commit_result': {
-      const cb = getCallback('gitCommit');
-      if (cb) {
-        cb(sharedGitCommitResult(msg));
-      }
-      break;
-    }
+    // directory_listing / file_listing / file_content / write_file_result /
+    // diff_result / git_status_result / git_branches_result / git_stage_result /
+    // git_unstage_result / git_commit_result — migrated to the shared dispatch
+    // table (#5556 slice 3 / #5653). Each was the same `getCallback(name) →
+    // shared*(msg) → cb(payload)` wrapper; the table now parses and invokes the
+    // imperative callback via `_dispatchAdapter.getCallback`.
 
     case 'slash_commands': {
       const slashResult = sharedSlashCommands(msg, get().activeSessionId);

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -237,9 +237,30 @@ describe('handler coverage contract', () => {
   // #5556 — cases owned by the shared store-core dispatch table count as
   // covered by BOTH clients (each routes through `runDispatch` first). Union
   // them into both per-client sets so a migrated case isn't reported missing.
+  //
+  // #5653 — EXCEPTION for decline-capable cases: some shared-table handlers
+  // (the file-ops / git wrapper cases) require a client to opt its imperative
+  // -callback registry into the table via `adapter.getCallback`; a client that
+  // does not (the dashboard) DECLINES — `runDispatch` returns false and the
+  // case falls through to that client's own switch. So a shared-table type that
+  // is declared single-platform in PLATFORM_SPECIFIC is credited ONLY to its
+  // declared platform, not blindly to both (the other platform really does NOT
+  // handle it — it declines and has no local case). This keeps the
+  // "PLATFORM_SPECIFIC matches actual coverage" guard honest.
+  const platformSpecificSet = new Set(Object.keys(PLATFORM_SPECIFIC))
   const sharedDispatchTypes = extractSharedDispatchTypes(dispatchSrc)
-  const appTypes = new Set([...extractAppHandlerTypes(appSrc), ...sharedDispatchTypes])
-  const dashTypes = new Set([...extractDashboardHandlerTypes(dashSrc), ...sharedDispatchTypes])
+  const sharedForApp = new Set(
+    [...sharedDispatchTypes].filter(
+      (t) => !platformSpecificSet.has(t) || PLATFORM_SPECIFIC[t] === 'app',
+    ),
+  )
+  const sharedForDash = new Set(
+    [...sharedDispatchTypes].filter(
+      (t) => !platformSpecificSet.has(t) || PLATFORM_SPECIFIC[t] === 'dashboard',
+    ),
+  )
+  const appTypes = new Set([...extractAppHandlerTypes(appSrc), ...sharedForApp])
+  const dashTypes = new Set([...extractDashboardHandlerTypes(dashSrc), ...sharedForDash])
 
   it('every ServerMessageType is handled by at least one handler (or explicitly excluded)', () => {
     const unhandled = []

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -51,6 +51,14 @@ export interface AdapterResult {
   flat: Record<string, unknown>
   /** Messages pushed via `addMessage`, in order. */
   added: ChatMessage[]
+  /**
+   * Imperative callbacks the table invoked, in order (#5653). Only the APP
+   * adapter records these — it opts into `getCallback`; the dashboard adapter
+   * has no `getCallback`, so the file-ops / git cases DECLINE there and never
+   * reach a callback (the dashboard handles them in its local switch). An empty
+   * array on the dashboard side IS the contract for those cases.
+   */
+  callbacks: Array<{ name: string; payload: unknown }>
 }
 
 /** Which client an adapter models — drives the `updateSession` divergence. */
@@ -88,6 +96,7 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   let sessionList: SessionInfo[] = init?.sessionList ?? []
   const flat: Record<string, unknown> = {}
   const added: ChatMessage[] = []
+  const callbacks: Array<{ name: string; payload: unknown }> = []
 
   // Reproduce each client's real `updateSession`. Both share the
   // "no-op on missing session / empty patch" guard; they diverge only in the
@@ -119,12 +128,23 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     setState: (patch) => Object.assign(flat, patch),
     addMessage: (m) => added.push(m),
     getSessions: () => sessionList,
+    // #5653 — only the APP opts its imperative-callback registry into the table.
+    // Model it as "a callback IS registered for every channel" so the contract
+    // can observe the invocation + payload. The DASHBOARD omits `getCallback`
+    // entirely (no spread below), so the file-ops / git cases DECLINE there.
+    ...(kind === 'app'
+      ? {
+          getCallback: ((name: string) => (payload: unknown) => {
+            callbacks.push({ name, payload })
+          }) as ClientStoreAdapter<FixtureSession>['getCallback'],
+        }
+      : {}),
   }
 
   return {
     adapter,
     get result(): AdapterResult {
-      return { sessions, flat, added }
+      return { sessions, flat, added, callbacks }
     },
     setActive: (id: string | null) => {
       activeSessionId = id

--- a/packages/store-core/src/contract-fixtures/contract.test.ts
+++ b/packages/store-core/src/contract-fixtures/contract.test.ts
@@ -99,6 +99,15 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
       expect(result.added[i], `${fx.name}: added[${i}]`).toMatchObject(m)
     })
   }
+  if (exp.callbacks) {
+    expect(result.callbacks.length, `${fx.name}: callback count`).toBe(exp.callbacks.length)
+    exp.callbacks.forEach((cb, i) => {
+      expect(result.callbacks[i].name, `${fx.name}: callbacks[${i}].name`).toBe(cb.name)
+      expect(result.callbacks[i].payload, `${fx.name}: callbacks[${i}].payload`).toMatchObject(
+        cb.payload,
+      )
+    })
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -75,6 +75,13 @@ export interface FixtureExpectation {
   flat?: Record<string, unknown>
   /** Expected messages pushed via `addMessage` (partial deep-equal, in order). */
   added?: Array<Record<string, unknown>>
+  /**
+   * Expected imperative-callback invocations (#5653), in order. Each entry is
+   * `{ name, payload }`: the channel name and a partial deep-equal of the
+   * payload. An empty array asserts NO callback fired (the dashboard side of a
+   * file-ops / git case, which DECLINES). Omit the slice to "don't care".
+   */
+  callbacks?: Array<{ name: string; payload: Record<string, unknown> }>
   /** When true, assert NO mutation happened at all (state is untouched). */
   noop?: boolean
 }
@@ -486,6 +493,191 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     type: 'notification_prefs',
     message: { type: 'notification_prefs', prefs: 'not-an-object' },
     expect: { noop: true },
+  },
+
+  // -------------------------------------------------------------------------
+  // Slice 3 — file-ops / git wrapper cases (#5653).
+  //
+  // These do NOT mutate the store: their only effect is invoking a one-shot
+  // imperative callback with the parsed payload. They DIVERGE by design — the
+  // app routes through `adapter.getCallback` (so the callback fires through the
+  // shared table), while the dashboard does NOT plug its callbacks into the
+  // table and so DECLINES, handling these in its own switch. Each fixture
+  // documents that split: app fires the callback (store surface is a no-op);
+  // dashboard's shared-table surface is a no-op with NO callback.
+  // -------------------------------------------------------------------------
+  {
+    name: 'directory_listing → app fires directoryListing callback; dashboard declines',
+    type: 'directory_listing',
+    message: {
+      type: 'directory_listing',
+      path: '/root',
+      parentPath: '/',
+      entries: [{ name: 'a.ts' }],
+      error: null,
+    },
+    divergent: {
+      reason:
+        'app opts its imperative-callback registry into the shared table; dashboard reads _directoryListingCallback in its own switch (#5653)',
+      app: {
+        noop: true,
+        callbacks: [
+          {
+            name: 'directoryListing',
+            payload: { path: '/root', parentPath: '/', entries: [{ name: 'a.ts' }], error: null },
+          },
+        ],
+      },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'file_listing → app fires fileBrowser callback; dashboard declines',
+    type: 'file_listing',
+    message: { type: 'file_listing', path: '/p', entries: [], error: 'oops' },
+    divergent: {
+      reason: 'app routes file_listing through the shared table; dashboard handles it locally (#5653)',
+      app: {
+        noop: true,
+        callbacks: [{ name: 'fileBrowser', payload: { path: '/p', parentPath: null, entries: [], error: 'oops' } }],
+      },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'file_content → app fires fileContent callback; dashboard declines',
+    type: 'file_content',
+    message: {
+      type: 'file_content',
+      path: '/f.ts',
+      content: 'x',
+      language: 'typescript',
+      size: 1,
+      truncated: true,
+    },
+    divergent: {
+      reason: 'app routes file_content through the shared table; dashboard handles it locally (#5653)',
+      app: {
+        noop: true,
+        callbacks: [
+          {
+            name: 'fileContent',
+            payload: { path: '/f.ts', content: 'x', language: 'typescript', size: 1, truncated: true, error: null },
+          },
+        ],
+      },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'write_file_result → app fires fileWrite callback; dashboard declines (app-only type)',
+    type: 'write_file_result',
+    message: { type: 'write_file_result', path: '/f.ts' },
+    divergent: {
+      reason: 'app-only type; dashboard has no write_file_result handler and DECLINES via the shared table (#5653)',
+      app: { noop: true, callbacks: [{ name: 'fileWrite', payload: { path: '/f.ts', error: null } }] },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'diff_result → app fires diff callback with files + error; dashboard declines',
+    type: 'diff_result',
+    message: { type: 'diff_result', files: [], error: null },
+    divergent: {
+      reason: 'app routes diff_result through the shared table; dashboard handles it locally (#5653)',
+      app: { noop: true, callbacks: [{ name: 'diff', payload: { files: [], error: null } }] },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'git_status_result → app fires gitStatus callback (5-field payload); dashboard declines',
+    type: 'git_status_result',
+    message: {
+      type: 'git_status_result',
+      branch: 'main',
+      staged: [{ path: 'a.ts', status: 'modified' }],
+      unstaged: [{ path: 'b.ts', status: 'added' }],
+      untracked: ['c.ts'],
+      error: null,
+    },
+    divergent: {
+      reason: 'app routes git_status_result through the shared table; dashboard handles it locally (#5653)',
+      app: {
+        noop: true,
+        callbacks: [
+          {
+            name: 'gitStatus',
+            payload: {
+              branch: 'main',
+              staged: [{ path: 'a.ts', status: 'modified' }],
+              unstaged: [{ path: 'b.ts', status: 'added' }],
+              untracked: ['c.ts'],
+              error: null,
+            },
+          },
+        ],
+      },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'git_branches_result → app fires gitBranches callback; dashboard declines (app-only type)',
+    type: 'git_branches_result',
+    message: {
+      type: 'git_branches_result',
+      branches: [{ name: 'main', isCurrent: true, isRemote: false }],
+      currentBranch: 'main',
+    },
+    divergent: {
+      reason: 'app-only type; dashboard has no git_branches_result handler and DECLINES via the shared table (#5653)',
+      app: {
+        noop: true,
+        callbacks: [
+          {
+            name: 'gitBranches',
+            payload: {
+              branches: [{ name: 'main', isCurrent: true, isRemote: false }],
+              currentBranch: 'main',
+              error: null,
+            },
+          },
+        ],
+      },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'git_stage_result → app fires gitStage callback; dashboard declines (app-only type)',
+    type: 'git_stage_result',
+    message: { type: 'git_stage_result' },
+    divergent: {
+      reason: 'app-only type; dashboard has no git_stage_result handler and DECLINES via the shared table (#5653)',
+      app: { noop: true, callbacks: [{ name: 'gitStage', payload: { error: null } }] },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'git_unstage_result → app routes to the SAME gitStage callback; dashboard declines (app-only type)',
+    type: 'git_unstage_result',
+    message: { type: 'git_unstage_result', error: 'nope' },
+    divergent: {
+      reason: 'app-only type sharing the gitStage channel; dashboard DECLINES via the shared table (#5653)',
+      app: { noop: true, callbacks: [{ name: 'gitStage', payload: { error: 'nope' } }] },
+      dashboard: { noop: true, callbacks: [] },
+    },
+  },
+  {
+    name: 'git_commit_result → app fires gitCommit callback; dashboard declines (app-only type)',
+    type: 'git_commit_result',
+    message: { type: 'git_commit_result', hash: 'abc', message: 'feat: x' },
+    divergent: {
+      reason: 'app-only type; dashboard has no git_commit_result handler and DECLINES via the shared table (#5653)',
+      app: {
+        noop: true,
+        callbacks: [{ name: 'gitCommit', payload: { hash: 'abc', message: 'feat: x', error: null } }],
+      },
+      dashboard: { noop: true, callbacks: [] },
+    },
   },
 ]
 

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -37,6 +37,13 @@ function makeAdapter(init?: {
   activeSessionId?: string | null
   sessions?: Record<string, FakeSession>
   sessionList?: SessionInfo[]
+  /**
+   * When provided, the adapter implements `getCallback` (the app opts into the
+   * imperative-callback registry for the #5653 file-ops / git cases). When
+   * omitted, the adapter has NO `getCallback`, so those cases DECLINE (the
+   * dashboard's behaviour — fall through to the local switch).
+   */
+  callbacks?: Partial<Record<string, ((payload: unknown) => void) | null>>
 }) {
   const sessions: Record<string, FakeSession> = init?.sessions ?? {}
   let activeSessionId = init?.activeSessionId ?? null
@@ -55,6 +62,12 @@ function makeAdapter(init?: {
     setState: (patch) => Object.assign(flat, patch),
     addMessage: (m) => addedMessages.push(m),
     getSessions: () => sessionList,
+    ...(init?.callbacks
+      ? {
+          getCallback: ((name: string) =>
+            (init.callbacks?.[name] ?? null)) as ClientStoreAdapter<FakeSession>['getCallback'],
+        }
+      : {}),
   }
 
   return {
@@ -608,6 +621,137 @@ describe('shared dispatch table', () => {
       const env = makeAdapter()
       dispatch(env, { type: 'notification_prefs', prefs: 'not-an-object' })
       expect(env.flat.notificationPrefs).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Slice 3 — file-ops / git wrapper cases (#5653)
+  //
+  // These route through `adapter.getCallback`: parse the wire message, then
+  // invoke the registered imperative callback. A client whose adapter has no
+  // `getCallback` (the dashboard) DECLINES — `runDispatch` returns false so the
+  // caller falls through to its own switch.
+  // -------------------------------------------------------------------------
+  describe('file-ops / git wrapper cases', () => {
+    it('declines (runDispatch false) when the adapter has no getCallback', () => {
+      const env = makeAdapter() // no callbacks → no getCallback method
+      expect(dispatch(env, { type: 'directory_listing', path: '/a' })).toBe(false)
+      expect(dispatch(env, { type: 'git_status_result' })).toBe(false)
+      expect(dispatch(env, { type: 'git_commit_result' })).toBe(false)
+    })
+
+    it('owns the message (runDispatch true) when getCallback is present, even with no registered callback', () => {
+      // App opted in but nothing registered for this channel → no-op, still owned.
+      const env = makeAdapter({ callbacks: {} })
+      expect(dispatch(env, { type: 'directory_listing', path: '/a' })).toBe(true)
+      expect(dispatch(env, { type: 'git_status_result' })).toBe(true)
+    })
+
+    it('invokes directoryListing with the parsed payload', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { directoryListing: (p) => seen.push(p) } })
+      expect(
+        dispatch(env, {
+          type: 'directory_listing',
+          path: '/root',
+          parentPath: '/',
+          entries: [{ name: 'a' }],
+        }),
+      ).toBe(true)
+      expect(seen).toEqual([
+        { path: '/root', parentPath: '/', entries: [{ name: 'a' }], error: null },
+      ])
+    })
+
+    it('invokes fileBrowser for file_listing', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { fileBrowser: (p) => seen.push(p) } })
+      dispatch(env, { type: 'file_listing', path: '/p', entries: [], error: 'oops' })
+      expect(seen).toEqual([{ path: '/p', parentPath: null, entries: [], error: 'oops' }])
+    })
+
+    it('invokes fileContent for file_content', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { fileContent: (p) => seen.push(p) } })
+      dispatch(env, {
+        type: 'file_content',
+        path: '/f.ts',
+        content: 'x',
+        language: 'typescript',
+        size: 1,
+        truncated: true,
+      })
+      expect(seen).toEqual([
+        { path: '/f.ts', content: 'x', language: 'typescript', size: 1, truncated: true, error: null },
+      ])
+    })
+
+    it('invokes fileWrite for write_file_result', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { fileWrite: (p) => seen.push(p) } })
+      dispatch(env, { type: 'write_file_result', path: '/f.ts' })
+      expect(seen).toEqual([{ path: '/f.ts', error: null }])
+    })
+
+    it('invokes diff with only files + error', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { diff: (p) => seen.push(p) } })
+      dispatch(env, { type: 'diff_result', files: [], error: null })
+      expect(seen).toEqual([{ files: [], error: null }])
+    })
+
+    it('invokes gitStatus with the five-field payload', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { gitStatus: (p) => seen.push(p) } })
+      dispatch(env, {
+        type: 'git_status_result',
+        branch: 'main',
+        staged: [{ path: 'a.ts', status: 'modified' }],
+        unstaged: [{ path: 'b.ts', status: 'added' }],
+        untracked: ['c.ts'],
+        error: null,
+      })
+      expect(seen).toEqual([
+        {
+          branch: 'main',
+          staged: [{ path: 'a.ts', status: 'modified' }],
+          unstaged: [{ path: 'b.ts', status: 'added' }],
+          untracked: ['c.ts'],
+          error: null,
+        },
+      ])
+    })
+
+    it('invokes gitBranches with branches + currentBranch + error', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { gitBranches: (p) => seen.push(p) } })
+      dispatch(env, {
+        type: 'git_branches_result',
+        branches: [{ name: 'main', isCurrent: true, isRemote: false }],
+        currentBranch: 'main',
+      })
+      expect(seen).toEqual([
+        {
+          branches: [{ name: 'main', isCurrent: true, isRemote: false }],
+          currentBranch: 'main',
+          error: null,
+        },
+      ])
+    })
+
+    it('routes both git_stage_result and git_unstage_result to gitStage', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { gitStage: (p) => seen.push(p) } })
+      dispatch(env, { type: 'git_stage_result' })
+      dispatch(env, { type: 'git_unstage_result', error: 'nope' })
+      expect(seen).toEqual([{ error: null }, { error: 'nope' }])
+    })
+
+    it('invokes gitCommit with hash + message + error', () => {
+      const seen: unknown[] = []
+      const env = makeAdapter({ callbacks: { gitCommit: (p) => seen.push(p) } })
+      dispatch(env, { type: 'git_commit_result', hash: 'abc', message: 'feat: x' })
+      expect(seen).toEqual([{ hash: 'abc', message: 'feat: x', error: null }])
     })
   })
 })

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -79,11 +79,30 @@ import {
   handleWebTaskList,
   // notification_prefs (slice 2 reconcile — app dropped its inline copy)
   handleNotificationPrefs,
+  // --- slice 3 (epic #5556) — file-ops / git wrapper cases (#5653) ---
+  handleDirectoryListing,
+  handleFileListing,
+  handleFileContent,
+  handleWriteFileResult,
+  handleDiffResult,
+  handleGitStatusResult,
+  handleGitBranchesResult,
+  handleGitStageResult,
+  handleGitCommitResult,
   resolveSessionId,
   type PermissionMode,
   type PermissionRule,
   type PendingPermissionConfirm,
   type NotificationPrefsState,
+  type DirectoryListingPayload,
+  type FileListingPayload,
+  type FileContentPayload,
+  type WriteFileResultPayload,
+  type DiffResultPayload,
+  type GitStatusResultPayload,
+  type GitBranchesResultPayload,
+  type GitStageResultPayload,
+  type GitCommitResultPayload,
 } from './handlers'
 
 // ---------------------------------------------------------------------------
@@ -147,7 +166,57 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
   addMessage(message: ChatMessage): void
   /** Read the current session list (for `session_updated`). */
   getSessions(): SessionInfo[]
+  /**
+   * Resolve a one-shot imperative callback by name (#5653). Used by the
+   * file-ops / git wrapper cases, whose only effect is to invoke a callback the
+   * UI registered out-of-band with the parsed payload — there is NO store
+   * mutation. Returns the registered callback, or null when none is set.
+   *
+   * OPTIONAL: a client that does NOT plug an imperative-callback registry into
+   * the table (e.g. the dashboard, which reads its callbacks straight off the
+   * Zustand store) simply omits this. When it is absent, the file-ops / git
+   * dispatch handlers DECLINE (return `false`) so {@link runDispatch} falls
+   * through to that client's own switch — keeping migration per-client and
+   * behaviour-preserving for clients that have not opted in.
+   *
+   * The payload type is the union of all parsed file-ops / git payloads; the
+   * caller (which knows the concrete callback signature for `name`) narrows it.
+   */
+  getCallback?(name: DispatchCallbackName): ((payload: DispatchCallbackPayload) => void) | null | undefined
 }
+
+/**
+ * Names of the imperative callbacks the file-ops / git dispatch cases invoke
+ * (#5653). Mirrors the app's `CallbackName` union for the migrated subset;
+ * `terminalWrite` is NOT here because the terminal case is not table-migrated.
+ */
+export type DispatchCallbackName =
+  | 'directoryListing'
+  | 'fileBrowser'
+  | 'fileContent'
+  | 'fileWrite'
+  | 'diff'
+  | 'gitStatus'
+  | 'gitBranches'
+  | 'gitStage'
+  | 'gitCommit'
+
+/**
+ * Union of the parsed payloads the file-ops / git callbacks receive. Each
+ * dispatch handler invokes its callback with exactly the payload the prior
+ * inline `case` arm passed (entries cast to the concrete `DirectoryEntry[]` /
+ * `FileEntry[]` happens client-side via the registered callback's own type).
+ */
+export type DispatchCallbackPayload =
+  | DirectoryListingPayload
+  | FileListingPayload
+  | FileContentPayload
+  | WriteFileResultPayload
+  | DiffResultPayload
+  | GitStatusResultPayload
+  | GitBranchesResultPayload
+  | GitStageResultPayload
+  | GitCommitResultPayload
 
 // ---------------------------------------------------------------------------
 // Per-entry message shapes (protocol-derived narrowing)
@@ -268,16 +337,38 @@ export interface DispatchMessageMap {
     type: 'notification_prefs'
     prefs?: unknown
   }
+  // --- slice 3 (epic #5556) — file-ops / git wrapper cases (#5653) ---
+  // These all carry the raw fields the corresponding `handle*` parser reads;
+  // the parser does the per-field narrowing, so the map only needs `type`.
+  directory_listing: { type: 'directory_listing' }
+  file_listing: { type: 'file_listing' }
+  file_content: { type: 'file_content' }
+  write_file_result: { type: 'write_file_result' }
+  diff_result: { type: 'diff_result' }
+  git_status_result: { type: 'git_status_result' }
+  git_branches_result: { type: 'git_branches_result' }
+  git_stage_result: { type: 'git_stage_result' }
+  git_unstage_result: { type: 'git_unstage_result' }
+  git_commit_result: { type: 'git_commit_result' }
 }
 
 /** Union of message types this table currently handles. */
 export type DispatchMessageType = keyof DispatchMessageMap
 
-/** A single dispatch-table entry: a pure delegation into a store-core handler. */
+/**
+ * A single dispatch-table entry: a pure delegation into a store-core handler.
+ *
+ * Returns `void` (handled — the common case) or `false` to DECLINE, signalling
+ * {@link runDispatch} to fall through to the caller's own switch. Only the
+ * file-ops / git wrapper cases (#5653) decline — they need the client's
+ * imperative-callback registry via {@link ClientStoreAdapter.getCallback}, and
+ * a client that does not supply one (e.g. the dashboard) must keep handling
+ * those types in its local switch.
+ */
 export type DispatchHandler<K extends DispatchMessageType, S extends DispatchSessionBase> = (
   msg: DispatchMessageMap[K],
   adapter: ClientStoreAdapter<S>,
-) => void
+) => void | false
 
 /** The full dispatch table — every migrated type maps to its handler. */
 export type DispatchTable<S extends DispatchSessionBase> = {
@@ -606,6 +697,148 @@ function dispatchNotificationPrefs<S extends DispatchSessionBase>(
 }
 
 // ---------------------------------------------------------------------------
+// Slice 3 — file-ops / git wrapper cases (epic #5556, #5653)
+//
+// Each was the SAME `getCallback(name) → shared*(msg) → cb(payload)` shape in
+// the app switch: parse the wire message with an existing store-core handler,
+// then invoke a one-shot imperative callback the UI registered out-of-band.
+// There is NO store mutation — the only effect is the callback invocation — so
+// these route through `adapter.getCallback` instead of the session/flat-state
+// methods the other cases use.
+//
+// Each handler DECLINES (returns `false`) when the adapter has no
+// `getCallback`, so a client that has not opted its imperative-callback
+// registry into the table (the dashboard) falls through to its own switch
+// unchanged. A client that DID opt in (the app) always OWNS the message: it
+// invokes the callback when one is registered and no-ops otherwise — exactly
+// the prior inline `if (cb) cb(...)` behaviour.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the imperative callback for `name` through the adapter. Returns the
+ * special `DECLINE` sentinel when the adapter does not implement `getCallback`
+ * at all (client not opted in), or the (possibly null) callback otherwise.
+ */
+const DECLINE = Symbol('dispatch-decline')
+
+function resolveCallback<S extends DispatchSessionBase>(
+  adapter: ClientStoreAdapter<S>,
+  name: DispatchCallbackName,
+): ((payload: DispatchCallbackPayload) => void) | null | undefined | typeof DECLINE {
+  if (typeof adapter.getCallback !== 'function') return DECLINE
+  return adapter.getCallback(name)
+}
+
+/** `directory_listing` — invoke the registered directory-listing callback. */
+function dispatchDirectoryListing<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['directory_listing'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'directoryListing')
+  if (cb === DECLINE) return false
+  if (cb) cb(handleDirectoryListing(msg as Record<string, unknown>))
+}
+
+/** `file_listing` — invoke the registered file-browser callback. */
+function dispatchFileListing<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['file_listing'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'fileBrowser')
+  if (cb === DECLINE) return false
+  if (cb) cb(handleFileListing(msg as Record<string, unknown>))
+}
+
+/** `file_content` — invoke the registered file-content callback. */
+function dispatchFileContent<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['file_content'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'fileContent')
+  if (cb === DECLINE) return false
+  if (cb) cb(handleFileContent(msg as Record<string, unknown>))
+}
+
+/** `write_file_result` — invoke the registered file-write callback. */
+function dispatchWriteFileResult<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['write_file_result'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'fileWrite')
+  if (cb === DECLINE) return false
+  if (cb) cb(handleWriteFileResult(msg as Record<string, unknown>))
+}
+
+/** `diff_result` — invoke the registered diff callback. */
+function dispatchDiffResult<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['diff_result'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'diff')
+  if (cb === DECLINE) return false
+  if (cb) {
+    const payload = handleDiffResult(msg as Record<string, unknown>)
+    cb({ files: payload.files, error: payload.error })
+  }
+}
+
+/** `git_status_result` — invoke the registered git-status callback. */
+function dispatchGitStatusResult<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['git_status_result'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'gitStatus')
+  if (cb === DECLINE) return false
+  if (cb) {
+    const payload = handleGitStatusResult(msg as Record<string, unknown>)
+    cb({
+      branch: payload.branch,
+      staged: payload.staged,
+      unstaged: payload.unstaged,
+      untracked: payload.untracked,
+      error: payload.error,
+    })
+  }
+}
+
+/** `git_branches_result` — invoke the registered git-branches callback. */
+function dispatchGitBranchesResult<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['git_branches_result'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'gitBranches')
+  if (cb === DECLINE) return false
+  if (cb) {
+    const payload = handleGitBranchesResult(msg as Record<string, unknown>)
+    cb({
+      branches: payload.branches,
+      currentBranch: payload.currentBranch,
+      error: payload.error,
+    })
+  }
+}
+
+/** `git_stage_result` / `git_unstage_result` — invoke the git-stage callback. */
+function dispatchGitStageResult<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['git_stage_result'] | DispatchMessageMap['git_unstage_result'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'gitStage')
+  if (cb === DECLINE) return false
+  if (cb) cb(handleGitStageResult(msg as Record<string, unknown>))
+}
+
+/** `git_commit_result` — invoke the registered git-commit callback. */
+function dispatchGitCommitResult<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['git_commit_result'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  const cb = resolveCallback(adapter, 'gitCommit')
+  if (cb === DECLINE) return false
+  if (cb) cb(handleGitCommitResult(msg as Record<string, unknown>))
+}
+
+// ---------------------------------------------------------------------------
 // Table + runner
 // ---------------------------------------------------------------------------
 
@@ -640,6 +873,17 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     web_feature_status: dispatchWebFeatureStatus,
     web_task_list: dispatchWebTaskList,
     notification_prefs: dispatchNotificationPrefs,
+    // --- slice 3 (epic #5556) — file-ops / git wrapper cases (#5653) ---
+    directory_listing: dispatchDirectoryListing,
+    file_listing: dispatchFileListing,
+    file_content: dispatchFileContent,
+    write_file_result: dispatchWriteFileResult,
+    diff_result: dispatchDiffResult,
+    git_status_result: dispatchGitStatusResult,
+    git_branches_result: dispatchGitBranchesResult,
+    git_stage_result: dispatchGitStageResult,
+    git_unstage_result: dispatchGitStageResult,
+    git_commit_result: dispatchGitCommitResult,
   }
 }
 
@@ -667,14 +911,27 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'web_feature_status',
   'web_task_list',
   'notification_prefs',
+  // --- slice 3 (epic #5556) — file-ops / git wrapper cases (#5653) ---
+  'directory_listing',
+  'file_listing',
+  'file_content',
+  'write_file_result',
+  'diff_result',
+  'git_status_result',
+  'git_branches_result',
+  'git_stage_result',
+  'git_unstage_result',
+  'git_commit_result',
 ]
 
 /**
  * Run a message through the shared table.
  *
  * @returns `true` when the table owned (and handled) the message — the caller
- *   should stop. `false` on a table MISS — the caller falls through to its own
- *   switch, keeping incremental migration possible.
+ *   should stop. `false` on a table MISS, OR when the matched handler DECLINED
+ *   (returned `false`, e.g. a file-ops / git case on a client whose adapter has
+ *   no `getCallback`) — the caller falls through to its own switch, keeping
+ *   incremental, per-client migration possible.
  */
 export function runDispatch<S extends DispatchSessionBase>(
   table: DispatchTable<S>,
@@ -685,6 +942,6 @@ export function runDispatch<S extends DispatchSessionBase>(
   if (typeof type !== 'string') return false
   if (!Object.prototype.hasOwnProperty.call(table, type)) return false
   const handler = table[type as DispatchMessageType] as DispatchHandler<DispatchMessageType, S>
-  handler(msg as DispatchMessageMap[DispatchMessageType], adapter)
-  return true
+  // A handler returning `false` DECLINES — fall through to the caller's switch.
+  return handler(msg as DispatchMessageMap[DispatchMessageType], adapter) !== false
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -624,6 +624,9 @@ export type {
   DispatchHandler,
   DispatchMessageMap,
   DispatchMessageType,
+  // #5653 — file-ops / git wrapper-case adapter surface.
+  DispatchCallbackName,
+  DispatchCallbackPayload,
 } from './dispatch-table'
 
 // epic #5556, sub-item 4: shared client connect-flow orchestration. Owns the


### PR DESCRIPTION
Closes #5653

Advances the #5556 dispatch-table migration (slice 3) by moving the file-ops / git wrapper cases out of the app's `handleMessage` switch into the shared `store-core` dispatch table.

## Cases migrated (10 types)

`directory_listing`, `file_listing`, `file_content`, `write_file_result`, `diff_result`, `git_status_result`, `git_branches_result`, `git_stage_result`, `git_unstage_result`, `git_commit_result`

Each was the same `getCallback(name) → shared*(msg) → cb(payload)` wrapper: parse the wire message with an existing store-core handler, then invoke a one-shot imperative callback the UI registered out-of-band. There is **no store mutation** — the only effect is the callback invocation.

## Mechanism (follows the established pattern)

These cases don't fit the existing session/flat-state adapter methods (no store write), and the two clients genuinely diverge in *how* they obtain the callback (the app uses a module-level imperative registry via `getCallback`; the dashboard reads `get()._xxxCallback` and only handles a subset). Per the dispatch-table's own design rule ("divergent cases stay platform-local"), this is handled by:

- A new **optional** `ClientStoreAdapter.getCallback(name)`. The app supplies its imperative-callback registry; the parsed payload reaches the registered callback **exactly** as the prior inline switch arms did (same fields, same `if (cb)` guard).
- Handlers **DECLINE** (return `false`) when the adapter has no `getCallback`. `runDispatch` now returns `false` on a decline, so a client that hasn't opted in (the **dashboard**) falls through to its own switch **unchanged**. Migration stays per-client and incremental — the dashboard is not touched.

## Counts

- App switch: **77 → 67** case arms (−10).
- Shared dispatch table: **21 → 31** registered types.

## Behaviour-preserving — how it's guarded

- The app's `message-handler.test.ts` **git-result suite (8 cases)** still passes, now exercising the dispatch path (it seeds callbacks via `setCallback` and asserts they fire). Full app store suite: **590/590 green** (25/25 suites).
- New `dispatch-table.test.ts` cases: the **decline path** (no `getCallback` → `runDispatch` false) and **per-channel payload** assertions.
- **Ten new behavioural-contract fixtures** pinning the divergence (app fires the callback; dashboard declines). The contract harness was extended to observe callback invocations as a first-class surface. Full store-core suite: **1474 green**.
- `protocol/tests/handler-coverage.test.js` updated so a *decline-capable* shared-table type is credited only to its declared platform — keeping the `PLATFORM_SPECIFIC` app-only declarations (`write_file_result`, `git_branches_result`, `git_stage_result`, `git_unstage_result`, `git_commit_result`) honest. **9/9 green.**

## Verification

- `tsc --noEmit` clean for `store-core`. The app's `message-handler.ts` typechecks clean against the worktree `store-core` (the 3 errors on `main`'s tsc are only because `main`'s `store-core` doesn't yet carry the new exports — they ship in this same PR).
- No behaviour change: `directory_listing` / `file_listing` previously passed `{ ...payload, entries: ... }` (a fresh object with identical fields); the shared handler passes the same payload object — same field values reach the callback.