### PR TITLE
refactor(app): migrate web_task upsert cases to shared dispatch table

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -116,7 +116,8 @@ import {
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
-  handleWebTaskUpsert as sharedWebTaskUpsert,
+  // web_task_created / web_task_updated — migrated to the shared dispatch table
+  // (#5556 slice 4); the app no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
   handleSearchResults as sharedSearchResults,
   handleUserQuestion as sharedUserQuestion,
@@ -1118,6 +1119,14 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   hasSession: (id) => !!getStore().getState().sessionStates[id],
   updateSession: (id, updater) => updateSession(id, updater),
   setState: (patch) => getStore().setState(patch as Partial<ConnectionState>),
+  // #5556 slice 4 — functional flat-state update for the web-task upsert cases.
+  // Mirrors the prior inline `set((state) => …)` exactly (Zustand merges the
+  // returned partial). The loose record in/out is cast to the store's
+  // ConnectionState shape, same as `setState` above.
+  updateState: (updater) =>
+    getStore().setState((state) =>
+      updater(state as unknown as Record<string, unknown>) as Partial<ConnectionState>,
+    ),
   addMessage: (m) => getStore().getState().addMessage(m),
   getSessions: () => getStore().getState().sessions,
   // #5653 — file-ops / git wrapper cases route through the shared dispatch
@@ -3277,16 +3286,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // web_feature_status — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'web_task_created':
-    case 'web_task_updated': {
-      const { task } = sharedWebTaskUpsert(msg);
-      if (!task) break;
-      set((state: ConnectionState) => {
-        const existing = state.webTasks.filter((t) => t.taskId !== task.taskId);
-        return { webTasks: [...existing, task] };
-      });
-      break;
-    }
+    // web_task_created / web_task_updated — migrated to the shared dispatch
+    // table (#5556 slice 4). Both were the byte-identical `sharedWebTaskUpsert`
+    // → filter-and-append upsert; the table now runs it via
+    // `_dispatchAdapter.updateState` (functional flat-state update).
 
     case 'web_task_error': {
       const {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -110,7 +110,8 @@ import {
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
-  handleWebTaskUpsert as sharedWebTaskUpsert,
+  // web_task_created / web_task_updated — migrated to the shared dispatch table
+  // (#5556 slice 4); the dashboard no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
   // web_task_list / web_feature_status migrated to the shared dispatch table
   // (#5556 slice 2)
@@ -878,6 +879,14 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   hasSession: (id) => !!getStore().getState().sessionStates[id],
   updateSession: (id, updater) => updateSession(id, updater),
   setState: (patch) => getStore().setState(patch as Partial<ConnectionState>),
+  // #5556 slice 4 — functional flat-state update for the web-task upsert cases.
+  // Mirrors the prior inline `set((state) => …)` exactly (Zustand merges the
+  // returned partial). The loose record in/out is cast to the store's
+  // ConnectionState shape, same as `setState` above.
+  updateState: (updater) =>
+    getStore().setState((state) =>
+      updater(state as unknown as Record<string, unknown>) as Partial<ConnectionState>,
+    ),
   addMessage: (m) => getStore().getState().addMessage(m),
   getSessions: () => getStore().getState().sessions,
 };
@@ -4152,16 +4161,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // -- Web tasks (Claude Code Web) --
 
-    case 'web_task_created':
-    case 'web_task_updated': {
-      const { task } = sharedWebTaskUpsert(msg);
-      if (!task) break;
-      set((state: ConnectionState) => {
-        const existing = state.webTasks.filter((t) => t.taskId !== task.taskId);
-        return { webTasks: [...existing, task] };
-      });
-      break;
-    }
+    // web_task_created / web_task_updated — migrated to the shared dispatch
+    // table (#5556 slice 4). Both were the byte-identical `sharedWebTaskUpsert`
+    // → filter-and-append upsert (identical to the app's), now run by the table
+    // via `_dispatchAdapter.updateState` (functional flat-state update).
 
     case 'web_task_error': {
       const { taskId: errTaskId, errorMessage, chatMessageContent } = sharedWebTaskError(msg);

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -126,6 +126,10 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     hasSession: (id) => Object.prototype.hasOwnProperty.call(sessions, id),
     updateSession,
     setState: (patch) => Object.assign(flat, patch),
+    // #5556 slice 4 — functional flat-state update. Both clients back it with
+    // their Zustand `set((state) => …)`, modelled here as a read-merge of the
+    // live `flat` ref so the web-task upsert fixtures observe identical results.
+    updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => added.push(m),
     getSessions: () => sessionList,
     // #5653 — only the APP opts its imperative-callback registry into the table.

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -679,6 +679,33 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
       dashboard: { noop: true, callbacks: [] },
     },
   },
+
+  // -------------------------------------------------------------------------
+  // Slice 4 (epic #5556) — web-task upsert. BYTE-IDENTICAL on both clients:
+  // validate the task, then filter-and-append into the flat `webTasks` list
+  // via the shared table's `adapter.updateState`. Both clients are a table HIT
+  // (NOT a decline) — so these use a single `expect`, not a `divergent` block.
+  // The dedup-against-existing-task path needs a pre-seeded flat list, which the
+  // fixture init does not model; it is covered in dispatch-table.test.ts.
+  // -------------------------------------------------------------------------
+  {
+    name: 'web_task_created appends the task to the (empty) flat webTasks list',
+    type: 'web_task_created',
+    message: { type: 'web_task_created', task: { taskId: 't1', status: 'running' } },
+    expect: { flat: { webTasks: [{ taskId: 't1', status: 'running' }] } },
+  },
+  {
+    name: 'web_task_updated appends the task to the (empty) flat webTasks list',
+    type: 'web_task_updated',
+    message: { type: 'web_task_updated', task: { taskId: 't1', status: 'completed' } },
+    expect: { flat: { webTasks: [{ taskId: 't1', status: 'completed' }] } },
+  },
+  {
+    name: 'web_task_created is a no-op when the task payload is malformed (no taskId)',
+    type: 'web_task_created',
+    message: { type: 'web_task_created', task: { status: 'running' } },
+    expect: { noop: true },
+  },
 ]
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -60,6 +60,7 @@ function makeAdapter(init?: {
       sessions[id] = { ...current, ...updater(current) }
     },
     setState: (patch) => Object.assign(flat, patch),
+    updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => addedMessages.push(m),
     getSessions: () => sessionList,
     ...(init?.callbacks
@@ -752,6 +753,54 @@ describe('shared dispatch table', () => {
       const env = makeAdapter({ callbacks: { gitCommit: (p) => seen.push(p) } })
       dispatch(env, { type: 'git_commit_result', hash: 'abc', message: 'feat: x' })
       expect(seen).toEqual([{ hash: 'abc', message: 'feat: x', error: null }])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Slice 4 — web-task upsert (#5556)
+  //
+  // `web_task_created` / `web_task_updated` filter-and-append the validated task
+  // into the flat `webTasks` list via `adapter.updateState`. Both clients are a
+  // table HIT (no decline). A malformed task payload is a no-op.
+  // -------------------------------------------------------------------------
+  describe('web_task_created / web_task_updated', () => {
+    it('owns the message (runDispatch true) for both create and update', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'web_task_created', task: { taskId: 't1' } })).toBe(true)
+      expect(dispatch(env, { type: 'web_task_updated', task: { taskId: 't1' } })).toBe(true)
+    })
+
+    it('appends a new task to the (empty) flat webTasks list', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'web_task_created', task: { taskId: 't1', status: 'running' } })
+      expect(env.flat.webTasks).toEqual([{ taskId: 't1', status: 'running' }])
+    })
+
+    it('upserts (replaces) an existing task with the same taskId, preserving order of others', () => {
+      const env = makeAdapter()
+      // Pre-seed the flat list the read-modify-write upsert reads from.
+      env.flat.webTasks = [
+        { taskId: 't1', status: 'running' },
+        { taskId: 't2', status: 'running' },
+      ]
+      dispatch(env, { type: 'web_task_updated', task: { taskId: 't1', status: 'completed' } })
+      // t1 is dropped then re-appended at the end with its new status; t2 stays.
+      expect(env.flat.webTasks).toEqual([
+        { taskId: 't2', status: 'running' },
+        { taskId: 't1', status: 'completed' },
+      ])
+    })
+
+    it('is a no-op when the task payload is missing taskId', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'web_task_created', task: { status: 'running' } })
+      expect(env.flat.webTasks).toBeUndefined()
+    })
+
+    it('is a no-op when the task payload is absent', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'web_task_updated' })
+      expect(env.flat.webTasks).toBeUndefined()
     })
   })
 })

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -89,6 +89,9 @@ import {
   handleGitBranchesResult,
   handleGitStageResult,
   handleGitCommitResult,
+  // --- slice 4 (epic #5556) — web-task upsert (#5653 follow-on) ---
+  handleWebTaskUpsert,
+  applyWebTaskUpsert,
   resolveSessionId,
   type PermissionMode,
   type PermissionRule,
@@ -162,6 +165,16 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
   updateSession(sessionId: string, updater: (session: S) => Partial<S>): void
   /** Shallow-merge a patch into the flat connection state. */
   setState(patch: Flat): void
+  /**
+   * Functional flat-state update (#5556 slice 4). The updater receives the
+   * current flat state and returns the partial patch to shallow-merge. Needed
+   * by the read-modify-write cases (`web_task_created` / `web_task_updated`),
+   * whose upsert filters the existing `webTasks` list before appending — the
+   * plain `setState(patch)` form cannot read prior state. Both clients back
+   * this with their Zustand `set((state) => patch)`, which is byte-identical to
+   * the inline `set((state) => …)` the migrated cases used.
+   */
+  updateState(updater: (flat: Flat) => Flat): void
   /** Append a chat message via the client's own add-message path. */
   addMessage(message: ChatMessage): void
   /** Read the current session list (for `session_updated`). */
@@ -350,6 +363,11 @@ export interface DispatchMessageMap {
   git_stage_result: { type: 'git_stage_result' }
   git_unstage_result: { type: 'git_unstage_result' }
   git_commit_result: { type: 'git_commit_result' }
+  // --- slice 4 (epic #5556) — web-task upsert ---
+  // Both carry a single `task` payload; `handleWebTaskUpsert` validates it and
+  // the dispatch handler filter-and-appends against the flat `webTasks` list.
+  web_task_created: { type: 'web_task_created'; task?: unknown }
+  web_task_updated: { type: 'web_task_updated'; task?: unknown }
 }
 
 /** Union of message types this table currently handles. */
@@ -839,6 +857,32 @@ function dispatchGitCommitResult<S extends DispatchSessionBase>(
 }
 
 // ---------------------------------------------------------------------------
+// Slice 4 — web-task upsert (epic #5556)
+//
+// `web_task_created` and `web_task_updated` were BYTE-IDENTICAL in both the app
+// and dashboard switches: validate the `task` payload via `handleWebTaskUpsert`,
+// then filter the flat `webTasks` list by `taskId` and append the new task. The
+// only reason they were not in slices 1-3 is the read-modify-write upsert needs
+// to read the prior `webTasks` list — hence the new `adapter.updateState`
+// functional-flat-update primitive (both clients back it with their Zustand
+// `set((state) => …)`, which is exactly what the inline cases used). A malformed
+// payload (`task: null`) is a no-op on both clients — same guard as before.
+// ---------------------------------------------------------------------------
+
+/** `web_task_created` / `web_task_updated` — upsert the task into the flat list. */
+function dispatchWebTaskUpsert<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['web_task_created'] | DispatchMessageMap['web_task_updated'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { task } = handleWebTaskUpsert(msg as Record<string, unknown>)
+  if (!task) return
+  adapter.updateState((flat) => {
+    const existing = (flat as { webTasks?: WebTask[] }).webTasks ?? []
+    return { webTasks: applyWebTaskUpsert(existing, task) } as unknown as typeof flat
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Table + runner
 // ---------------------------------------------------------------------------
 
@@ -884,6 +928,9 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     git_stage_result: dispatchGitStageResult,
     git_unstage_result: dispatchGitStageResult,
     git_commit_result: dispatchGitCommitResult,
+    // --- slice 4 (epic #5556) — web-task upsert ---
+    web_task_created: dispatchWebTaskUpsert,
+    web_task_updated: dispatchWebTaskUpsert,
   }
 }
 
@@ -922,6 +969,9 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'git_stage_result',
   'git_unstage_result',
   'git_commit_result',
+  // --- slice 4 (epic #5556) — web-task upsert ---
+  'web_task_created',
+  'web_task_updated',
 ]
 
 /**

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -89,6 +89,7 @@ import {
   handleServerShutdown,
   handleServerStatusLegacy,
   handleWebTaskUpsert,
+  applyWebTaskUpsert,
   handleWebTaskError,
   handleWebTaskList,
   handleWebFeatureStatus,
@@ -5289,6 +5290,39 @@ describe('handleWebTaskUpsert', () => {
       error: null,
     }
     expect(handleWebTaskUpsert({ task })).toEqual({ task })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyWebTaskUpsert (#5556 slice 4)
+// ---------------------------------------------------------------------------
+describe('applyWebTaskUpsert', () => {
+  const t = (taskId: string, status: string) =>
+    ({ taskId, status }) as unknown as Parameters<typeof applyWebTaskUpsert>[0][number]
+
+  it('appends a new task to the end of the list', () => {
+    const result = applyWebTaskUpsert([t('a', 'running')], t('b', 'running'))
+    expect(result).toEqual([
+      { taskId: 'a', status: 'running' },
+      { taskId: 'b', status: 'running' },
+    ])
+  })
+
+  it('replaces an existing task with the same taskId, re-appending it at the end', () => {
+    const result = applyWebTaskUpsert(
+      [t('a', 'running'), t('b', 'running')],
+      t('a', 'completed'),
+    )
+    expect(result).toEqual([
+      { taskId: 'b', status: 'running' },
+      { taskId: 'a', status: 'completed' },
+    ])
+  })
+
+  it('does not mutate the input list', () => {
+    const existing = [t('a', 'running')]
+    applyWebTaskUpsert(existing, t('a', 'completed'))
+    expect(existing).toEqual([{ taskId: 'a', status: 'running' }])
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3763,6 +3763,18 @@ export function handleWebTaskUpsert(
   return { task: task as WebTask }
 }
 
+/**
+ * Filter-and-append upsert against an existing `webTasks` list (#5556 slice 4).
+ * Drops any existing task with the same `taskId`, then appends `task` at the
+ * end — exactly the `state.webTasks.filter(t => t.taskId !== task.taskId)`
+ * then-spread the app and dashboard both performed inline. Both clients were
+ * byte-identical here, so this is the shared body the dispatch handler runs.
+ */
+export function applyWebTaskUpsert(existing: WebTask[], task: WebTask): WebTask[] {
+  const kept = existing.filter((t) => t.taskId !== task.taskId)
+  return [...kept, task]
+}
+
 // ---------------------------------------------------------------------------
 // web_task_error
 //

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -518,6 +518,8 @@ export {
   handleServerShutdown,
   handleServerStatusLegacy,
   handleWebTaskUpsert,
+  // #5556 slice 4 — shared filter-and-append upsert for web_task_created/updated.
+  applyWebTaskUpsert,
   handleWebTaskError,
   handleWebTaskList,
   handleWebFeatureStatus,


### PR DESCRIPTION
## Slice 4 — client message-dispatch migration (epic #5556)

Continues the incremental migration of byte-identical pure-delegation cases out of the app's and dashboard's hand-copied `switch (msg.type)` into the shared `dispatch-table.ts`, following the slice-3 pattern (#5659).

### What moved
`web_task_created` and `web_task_updated`. Both arms were **verbatim-identical** across the app and dashboard: validate the `task` payload via `handleWebTaskUpsert`, then filter the flat `webTasks` list by `taskId` and append. The shared body now lives in `applyWebTaskUpsert`, run by the table.

### Why they weren't in slices 1–3
The upsert is **read-modify-write** — it needs the prior `webTasks` list, which the existing `setState(patch)` adapter form can't read. This slice adds one minimal primitive: `updateState(updater)` (functional flat-state update). Both clients back it with their native Zustand `set((state) => patch)` — identical to the inline `set` the migrated cases used. The only behavioural delta is a defensive `webTasks ?? []` (strictly safer; the list is always initialised).

### Scope is honest, not thin
The byte-identical store-mutation seam is now essentially exhausted. Candidates evaluated and **rejected** for genuine divergence (documented in the migration comments): `checkpoint_*`, `slash_commands`, `agent_list`, `conversations_list`, `search_results` (app dual-writes `useConversationStore`); `provider_list` (different transform); `cost_update` (app `useCostStore` + flat fields); `budget_warning`/`budget_exceeded` (RN `Alert`); `available_models` (dashboard-only `availableModelsProvider`); `web_task_error` (app `SESSION_TOKEN_MISMATCH` branch); `token_rotated`/`tunnel_url_changed`/`push_token_error` (platform-local). Forcing these in would break the "absence = visible divergence" invariant the table relies on.

### Counts
- App switch: **67 → 65** case arms.
- Shared dispatch table: **31 → 33** types.

### Verification (local, full suites)
- store-core `tsc --noEmit`: clean
- store-core vitest: **1485 passed**
- protocol handler-coverage guard: **9/9** (credits `web_task_*` to both platforms)
- app `tsc --noEmit`: clean
- dashboard `tsc --noEmit`: clean
- app jest (`message-handler`): **221 passed**
- dashboard vitest (`message-handler`/`dispatch`/`tunnel-url-changed`): **343 passed**

### Guards added
- `dispatch-table.test.ts`: append, upsert-replace preserving order, malformed-payload no-op, ownership.
- `applyWebTaskUpsert` handler tests: append, replace, non-mutation.
- Three behavioural-contract fixtures pinning the shared upsert path.

Related to #5556. Pure refactor — zero behaviour change.
