### PR TITLE
feat(server): model-metadata foundation — fable, user overlay, graceful degradation

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -29,6 +29,11 @@ export function resolveClaudeContextWindow(fullId) {
   if (fullId.endsWith(ONE_M_SUFFIX)) return 1_000_000
   if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
   if (fullId.includes('opus-4-7') || fullId.includes('opus-4.7')) return 1_000_000
+  // opus-4-8 is treated as 1M for consistency with the rest of the opus 4.x
+  // family the heuristic already maps to 1M — this is a family-consistency
+  // default, not a verified spec. The SDK's authoritative
+  // modelUsage.contextWindow overrides it after the first turn if wrong.
+  if (fullId.includes('opus-4-8') || fullId.includes('opus-4.8')) return 1_000_000
   return DEFAULT_CONTEXT_WINDOW
 }
 
@@ -57,6 +62,10 @@ export function claudeDeriveId(fullId) {
 export const FALLBACK_MODELS = Object.freeze([
   Object.freeze({ id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: resolveClaudeContextWindow('claude-sonnet-4-6') }),
   Object.freeze({ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: resolveClaudeContextWindow('claude-opus-4-7') }),
+  // Fable falls through to the 200k DEFAULT_CONTEXT_WINDOW heuristic on
+  // purpose — the SDK's authoritative modelUsage.contextWindow ratchets it
+  // after the first turn; we don't invent a fable window here.
+  Object.freeze({ id: 'fable', label: 'Fable', fullId: 'claude-fable-5', contextWindow: resolveClaudeContextWindow('claude-fable-5') }),
   Object.freeze({ id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveClaudeContextWindow('claude-haiku-4-5') }),
 ])
 
@@ -158,8 +167,40 @@ function resolvePricingKey(modelId) {
  * directly.
  */
 export function getModelPricing(modelId) {
+  return resolveModelPricing(modelId, defaultOverlay)
+}
+
+/**
+ * Resolve pricing for a model id with an optional overlay consulted first.
+ * Precedence: overlay pricing (matched on the resolved full id) > static
+ * CLAUDE_PRICING_USD_PER_MTOK > null. A missing overlay pricing block does
+ * NOT shadow the static table (we only short-circuit when the overlay
+ * actually carries a `pricing` object), and an absent match everywhere
+ * yields null — never 0.
+ *
+ * @param {string} modelId
+ * @param {Map} [overlay] - fullId → overlay entry map (see loadModelsOverlay)
+ * @returns {object|null}
+ */
+function resolveModelPricing(modelId, overlay) {
+  if (overlay && overlay.size > 0 && typeof modelId === 'string' && modelId.length > 0) {
+    // Try the id verbatim, then the registry-resolved full id, against the
+    // overlay's fullId-keyed map. Short ids ('opus') resolve via the default
+    // registry so an operator can key the overlay on either form.
+    const candidates = new Set([modelId])
+    const resolvedFull = defaultRegistry.resolveModelId(modelId)
+    if (typeof resolvedFull === 'string' && resolvedFull.length > 0) candidates.add(resolvedFull)
+    for (const candidate of candidates) {
+      const entry = overlay.get(candidate)
+      if (entry && entry.pricing) return entry.pricing
+    }
+  }
   const key = resolvePricingKey(modelId)
-  return key ? CLAUDE_PRICING_USD_PER_MTOK[key] : null
+  // Coalesce a resolved-but-absent key (e.g. a short alias that resolves to a
+  // full id with no pricing row because we don't ship unverified pricing) to null, not
+  // undefined, so the documented "rates or null" contract holds and callers
+  // that branch on `=== null` work.
+  return (key && CLAUDE_PRICING_USD_PER_MTOK[key]) || null
 }
 
 // Public DeepSeek pricing in USD per million tokens (#4656). Source:
@@ -239,6 +280,85 @@ function getDefaultCachePath() {
   const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
   return join(configDir, 'models-cache.json')
 }
+
+/**
+ * User-extensible overlay path. Mirrors getDefaultCachePath's config-dir
+ * resolution EXACTLY (CHROXY_CONFIG_DIR || ~/.chroxy) so the overlay file
+ * lives next to the cache. The overlay lets operators surface a brand-new
+ * model id, override a label/contextWindow, or supply pricing for a model
+ * the static table doesn't carry — all without a code change.
+ */
+function getDefaultOverlayPath() {
+  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return join(configDir, 'models.json')
+}
+
+/**
+ * Load and normalise the user overlay from disk (boot-only — not hot-reload;
+ * that's a deferred follow-up). The file is an object keyed by full model id:
+ *
+ *   {
+ *     "claude-fable-5": {
+ *       "shortId": "fable",            // optional
+ *       "label": "Fable",              // optional
+ *       "fullId": "claude-fable-5",    // optional (defaults to the key)
+ *       "contextWindow": 200000,       // optional
+ *       "pricing": {                   // optional
+ *         "input": 10, "output": 50, "cacheRead": 1, "cacheWrite": 12.5
+ *       }
+ *     }
+ *   }
+ *
+ * Parses defensively: a missing file yields an empty overlay; malformed JSON
+ * (or a non-object root) logs a warn and yields an empty overlay. NEVER throws
+ * on boot. Returns a Map keyed by fullId for O(1) lookup; each value carries a
+ * normalised `{ fullId, shortId, label, contextWindow, pricing }` where any
+ * absent field is left undefined (NOT defaulted to 0/null) so downstream
+ * precedence can distinguish "overlay said nothing" from "overlay said X".
+ *
+ * @param {string} [path]
+ * @returns {Map<string, {fullId:string, shortId?:string, label?:string, contextWindow?:number, pricing?:object}>}
+ */
+function loadModelsOverlay(path = getDefaultOverlayPath()) {
+  const overlay = new Map()
+  let raw
+  try {
+    raw = readFileSync(path, 'utf-8')
+  } catch {
+    // Missing file is the common case — empty overlay, no log.
+    return overlay
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    log.warn(`loadModelsOverlay: malformed JSON in ${path}: ${err?.message || err} — ignoring overlay`)
+    return overlay
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    log.warn(`loadModelsOverlay: ${path} is not a JSON object keyed by model id — ignoring overlay`)
+    return overlay
+  }
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof key !== 'string' || key.length === 0) continue
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+    const fullId = typeof value.fullId === 'string' && value.fullId.length > 0 ? value.fullId : key
+    const entry = { fullId }
+    if (typeof value.shortId === 'string' && value.shortId.length > 0) entry.shortId = value.shortId
+    if (typeof value.label === 'string' && value.label.length > 0) entry.label = value.label
+    if (typeof value.contextWindow === 'number' && value.contextWindow > 0) entry.contextWindow = value.contextWindow
+    if (value.pricing && typeof value.pricing === 'object' && !Array.isArray(value.pricing)) {
+      entry.pricing = value.pricing
+    }
+    overlay.set(fullId, entry)
+  }
+  return overlay
+}
+
+// Module-level overlay, loaded once at boot. The default Claude registry and
+// the module-level getModelPricing() consult this. Per-provider registries
+// take their own overlay via the createModelsRegistry hook.
+const defaultOverlay = loadModelsOverlay()
 
 /**
  * Per-provider cache path resolver (#4413). Non-Claude providers
@@ -399,15 +519,62 @@ function humanizeModelId(id) {
  *   `~/.chroxy/models-cache.json`. Non-Claude providers should supply a
  *   provider-scoped path (e.g. `~/.chroxy/models-cache.codex.json`) so the
  *   default Claude cache stays untouched by per-provider learn-loops (#4413).
+ * @param {Map} [hooks.overlay] - User-extensible overlay (fullId → entry; see
+ *   loadModelsOverlay). Overlay entries SEED the registry like a
+ *   FALLBACK_MODELS row, so a brand-new model id appears with no code change
+ *   and survives loadCache()'s family prune. The default Claude registry gets
+ *   the module-level `defaultOverlay`; pass `new Map()` to opt out.
  */
 export function createModelsRegistry(hooks = {}) {
-  const fallbackModels = hooks.fallbackModels ?? FALLBACK_MODELS
+  const baseFallbackModels = hooks.fallbackModels ?? FALLBACK_MODELS
   const deriveIdFn = typeof hooks.deriveId === 'function' ? hooks.deriveId : claudeDeriveId
   const resolveContextWindowFn = typeof hooks.resolveContextWindow === 'function'
     ? hooks.resolveContextWindow
     : resolveClaudeContextWindow
   const cachePathFn = typeof hooks.cachePath === 'function' ? hooks.cachePath : getDefaultCachePath
   const getModelMetadataFn = typeof hooks.getModelMetadata === 'function' ? hooks.getModelMetadata : null
+  const overlay = hooks.overlay instanceof Map ? hooks.overlay : new Map()
+
+  // Fold overlay entries into the fallback set. An overlay entry for a fullId
+  // NOT already in the base fallbacks seeds the registry exactly like a
+  // FALLBACK_MODELS row would — so it appears in getModels(), resolves both
+  // ways, lands in the allowlist, and is unioned into the loadCache prune
+  // allowlist (its family survives boot). For an id already present in the
+  // base fallbacks, the overlay's label/contextWindow override the static
+  // heuristic (overlay > heuristic). Pricing is handled separately by
+  // resolveModelPricing. SDK live values still win over both at
+  // updateModels() time (the contextWindowOverrides / providerMeta lookups
+  // are consulted ahead of the fallback row's contextWindow).
+  const overlayRows = []
+  const overriddenBase = []
+  const baseByFullId = new Map(baseFallbackModels.map((m) => [m.fullId, m]))
+  for (const entry of overlay.values()) {
+    const baseRow = baseByFullId.get(entry.fullId)
+    if (baseRow) {
+      // Override the base row's label/window from the overlay when supplied.
+      if (entry.label !== undefined || entry.contextWindow !== undefined || entry.shortId !== undefined) {
+        baseByFullId.set(entry.fullId, Object.freeze({
+          id: entry.shortId ?? baseRow.id,
+          label: entry.label ?? baseRow.label,
+          fullId: baseRow.fullId,
+          contextWindow: entry.contextWindow ?? baseRow.contextWindow,
+        }))
+      }
+      continue
+    }
+    const shortId = entry.shortId ?? deriveIdFn(entry.fullId)
+    overlayRows.push(Object.freeze({
+      id: shortId,
+      label: entry.label ?? humanizeModelId(shortId),
+      fullId: entry.fullId,
+      contextWindow: entry.contextWindow ?? resolveContextWindowFn(entry.fullId),
+    }))
+  }
+  // Preserve base order, then append overlay-only rows.
+  for (const m of baseFallbackModels) overriddenBase.push(baseByFullId.get(m.fullId))
+  const fallbackModels = overlayRows.length > 0 || overriddenBase.some((m, i) => m !== baseFallbackModels[i])
+    ? Object.freeze([...overriddenBase, ...overlayRows])
+    : baseFallbackModels
 
   let activeModels = fallbackModels
   let defaultModelId = null
@@ -652,6 +819,28 @@ export function createModelsRegistry(hooks = {}) {
       }
       converted.push(...variants)
 
+      // #5631 — robustness: the `/^default\b/i` displayName regex is the only
+      // path that sets nextDefault. If the SDK ever drops or renames the
+      // "Default (…)" marker, nextDefault stays null and the registry has no
+      // default model at all. Pick a deterministic fallback so drift is
+      // visible and the picker still has a sensible default: prefer a stable
+      // family present in FALLBACK_MODELS (opus, then sonnet) — matched by the
+      // fallback row's fullId so SDK-derived ids like `opus-4-8` (not the
+      // short alias `opus`) still match — else the first converted entry.
+      // Warn so the regex miss surfaces in logs.
+      if (nextDefault === null && converted.length > 0) {
+        let picked = null
+        for (const preferredShortId of ['opus', 'sonnet']) {
+          const fb = fallbackModels.find((m) => m.id === preferredShortId)
+          if (!fb) continue
+          const match = converted.find((m) => m.fullId === fb.fullId)
+          if (match) { picked = match.id; break }
+        }
+        if (!picked) picked = converted[0].id
+        nextDefault = picked
+        log.warn(`updateModels: no SDK entry matched the /^default\\b/i displayName regex — falling back to '${picked}' as the default model. The SDK's "Default (…)" marker may have changed shape.`)
+      }
+
       applyModels(converted, nextDefault)
       return converted
     },
@@ -844,8 +1033,10 @@ export function createModelsRegistry(hooks = {}) {
   }
 }
 
-// Default instance — preserves backward compatibility for all existing imports
-const defaultRegistry = createModelsRegistry()
+// Default instance — preserves backward compatibility for all existing imports.
+// Seeded with the boot-loaded user overlay so an operator-supplied model id
+// appears in the picker / allowlist and survives the loadCache prune.
+const defaultRegistry = createModelsRegistry({ overlay: defaultOverlay })
 
 /**
  * Per-provider registries. Providers that expose static

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -66,12 +66,32 @@ describe('createModelsRegistry', () => {
     assert.equal(registry.getModels()[1].label, 'Opus')
   })
 
-  it('returns null defaultModelId when no model has Default prefix', () => {
+  it('falls back to a deterministic default when no model has the Default prefix (#5631)', () => {
+    // Before #5631 this returned null (the regex was the only path). Now
+    // updateModels picks a deterministic fallback — the opus family (merged
+    // in from FALLBACK_MODELS) — and warns, so registry drift is visible
+    // instead of leaving the picker with no default at all.
     const registry = createModelsRegistry()
     registry.updateModels([
       { value: 'claude-sonnet-4', displayName: 'Sonnet', description: '' },
     ])
-    assert.equal(registry.getDefaultModelId(), null)
+    // opus is always merged from FALLBACK_MODELS, so it wins the preference.
+    assert.equal(registry.getDefaultModelId(), 'opus-4-7')
+  })
+
+  it('picks the first converted entry when no opus/sonnet family is present (#5631)', () => {
+    // Non-Claude-shaped registry: supply our own fallback list with no
+    // opus/sonnet so the family-preference loop misses and the fallback is
+    // the first converted entry.
+    const registry = createModelsRegistry({
+      fallbackModels: [{ id: 'foo', label: 'Foo', fullId: 'foo-1', contextWindow: 1000 }],
+      deriveId: (id) => id,
+      resolveContextWindow: () => 1000,
+    })
+    registry.updateModels([
+      { value: 'zeta-9', displayName: 'Zeta', description: '' },
+    ])
+    assert.equal(registry.getDefaultModelId(), 'zeta-9')
   })
 
   it('resets defaultModelId on resetModels', () => {
@@ -386,10 +406,14 @@ describe('disk cache (loadCache / saveCache)', () => {
   // No-op load (nothing pruned, nothing changed) should NOT touch the disk.
   // Otherwise every server startup would needlessly rewrite the cache file.
   it('loadCache does not rewrite the disk file when no entries are pruned', async () => {
+    // The cache must hold exactly the current FALLBACK_MODELS set (no stale
+    // minor to prune, no fallback alias to merge) or loadCache would heal the
+    // file and bump mtime.
     writeFileSync(cachePath, JSON.stringify({
       models: [
         { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
         { id: 'sonnet-4-6', fullId: 'claude-sonnet-4-6', label: 'Sonnet 4.6', contextWindow: 200_000 },
+        { id: 'fable-5', fullId: 'claude-fable-5', label: 'Fable 5', contextWindow: 200_000 },
         { id: 'haiku-4-5', fullId: 'claude-haiku-4-5', label: 'Haiku 4.5', contextWindow: 200_000 },
       ],
     }))

--- a/packages/server/tests/models-per-provider.test.js
+++ b/packages/server/tests/models-per-provider.test.js
@@ -82,6 +82,8 @@ describe('provider static metadata hooks', () => {
     const allowed = new Set(SdkSession.getAllowedModels())
     assert.ok(allowed.has('opus'))
     assert.ok(allowed.has('claude-opus-4-7'))
+    assert.ok(allowed.has('fable'))
+    assert.ok(allowed.has('claude-fable-5'))
     assert.ok(!allowed.has('opus-4-6'))
     assert.ok(!allowed.has('claude-opus-4-6'))
   })
@@ -91,6 +93,8 @@ describe('provider static metadata hooks', () => {
     const allowed = new Set(CliSession.getAllowedModels())
     assert.ok(allowed.has('opus'))
     assert.ok(allowed.has('claude-opus-4-7'))
+    assert.ok(allowed.has('fable'))
+    assert.ok(allowed.has('claude-fable-5'))
     assert.ok(!allowed.has('opus-4-6'))
     assert.ok(!allowed.has('claude-opus-4-6'))
   })
@@ -172,7 +176,7 @@ describe('createModelsRegistry(providerHooks)', () => {
   it('backward compat: no args => Claude-style defaults (FALLBACK_MODELS, claude- stripping)', () => {
     const r = createModelsRegistry()
     const ids = r.getModels().map(m => m.id).sort()
-    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet'])
+    assert.deepEqual(ids, ['fable', 'haiku', 'opus', 'sonnet'])
     const converted = r.updateModels([
       { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
     ])

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -10,9 +10,9 @@ describe('FALLBACK_MODELS (default registry)', () => {
     }
   })
 
-  it('contains sonnet, opus, and haiku aliases only', () => {
+  it('contains sonnet, opus, fable, and haiku aliases', () => {
     const ids = FALLBACK_MODELS.map(m => m.id).sort()
-    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet'])
+    assert.deepEqual(ids, ['fable', 'haiku', 'opus', 'sonnet'])
   })
 
   it('each entry has id, label, fullId, and contextWindow', () => {
@@ -196,9 +196,10 @@ describe('updateModels', () => {
     assert.equal(result[1].fullId, 'claude-opus-4-6')
     assert.equal(result[1].contextWindow, 1_000_000)
 
-    // Fallback entries the SDK didn't list are appended (Opus 4.7, Haiku 4.5).
+    // Fallback entries the SDK didn't list are appended (Opus 4.7, Fable, Haiku 4.5).
     const fullIds = result.map(m => m.fullId)
     assert.ok(fullIds.includes('claude-opus-4-7'), 'opus 4.7 fallback should be merged in')
+    assert.ok(fullIds.includes('claude-fable-5'), 'fable fallback should be merged in')
     assert.ok(fullIds.includes('claude-haiku-4-5'), 'haiku 4.5 fallback should be merged in')
 
     // 1M variants are synthesized for any 1M-context model that lacks one.


### PR DESCRIPTION
## Foundation slice of #5631

Model metadata lived in several hand-maintained tables that drifted, and unknown models (e.g. `claude-fable-5`) degraded across the UI — the dropdown shows the raw id, pricing silently reads $0, the context meter mis-sizes. This slice makes adding a model a **config entry** rather than a code change, and degrades gracefully for anything unrecognized.

This is the **server-only, additive foundation** the maintainer chose to chain #5628 (dropdown) → #5630 (cost labels) → #5629 (June-15 billing copy) onto. No WS-schema, dashboard, or cost-contract changes.

### What's in
- **`FALLBACK_MODELS` += `claude-fable-5`** (short id `fable`) so it gets a short id, survives the `loadCache` prune, and is selectable on providers that never get a live `supportedModels()` push (CLI/TUI/channel). This directly fixes the #5628 dropdown trigger (fable had no short id, so its full id passed through).
- **User-extensible overlay** `~/.chroxy/models.json` (same config-dir resolution as the model cache). Object keyed by full model id, supplying short id / label / full id / context window / pricing for what the SDK doesn't describe. **Verified:** the SDK's `supportedModels()` returns `{value, displayName, description}` only — **no pricing, no context window** — so the overlay (or static table) is the only pricing source. Brand-new models become a config entry, no code change.
  - Precedence: SDK live values > overlay > static heuristic/table. Missing overlay pricing falls through to the static table, then `null` (never a fabricated `0`).
  - Defensive boot load: missing file → empty; malformed JSON → warn + ignore; `__proto__`/`constructor` keys are inert Map keys (no prototype pollution).
- **`loadCache` prune** unions overlay ids into the family allowlist, so a cached overlay-only model survives save→reload.
- **`defaultModelId` fallback**: when no `displayName` matches the `/^default\b/i` marker, pick a deterministic default (opus/sonnet by fullId, else first entry) + warn — instead of leaving no default.

### Deliberate non-changes (decisions)
- **opus stays at `claude-opus-4-7`** in `FALLBACK_MODELS` (it has a pricing row). An adversarial review found that bumping the `opus` alias to `claude-opus-4-8` (no pricing row) would make pure-**BYOK** "Opus" picks bill at **$0**. SDK/CLI sessions show the real 4-8 via the SDK push regardless; BYOK users add `claude-opus-4-8` (with pricing) via the overlay — the data-driven path this issue is about. **Net result: zero cost regression.**
- **No hardcoded fable/opus-4-8 pricing** — unverified numbers belong in the overlay or a verified table edit, not the source.
- **0→null cost-display contract and pricing-to-dashboard are deferred to #5630** (the cost-labeling work) where the dashboard cost UI is already being reworked.

### Verification (local)
- Model suites (`models`, `models-factory`, `models-per-provider`, `session-info-booted-model`, `event-normalizer`, `ws-history`): **407 pass, 0 fail**.
- Server custom lints (`lint-tests-state-file-path`, `lint-session-opt-forwarding`): exit 0.
- `eslint src/models.js`: 0 errors.

### New test coverage
fable resolves / round-trips / is in the allowlist; overlay precedence (overlay pricing wins over static; overlay context window beats heuristic but loses to SDK override); a brand-new overlay-only id appears in `getModels()` and survives `loadCache()` prune; `defaultModelId` fallback when no displayName matches the regex; unknown-model pricing degrades to null (not 0).

Related to #5631. Adversarially reviewed (overlay precedence, prune survival, prototype-pollution safety, undefined→null, defaultModelId determinism, the BYOK pricing path) — all clean after the opus decision above.
