### PR TITLE
fix(dashboard): header model dropdown reflects the active session model

### DIFF
--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -163,6 +163,45 @@ describe('ChatSettingsDropdown', () => {
     expect(onModelChange).toHaveBeenCalledWith('sonnet')
   })
 
+  // #5628 — the active model can arrive as a FULL id ('claude-opus-4-7')
+  // while the <option> values are short ids ('opus'). A native <select> with
+  // an unmatched value renders its FIRST option, so the header showed
+  // "Default (…)" even though a non-default model was active. The select must
+  // resolve the active model the same way the status bar does (id || fullId).
+  describe('#5628 — header reflects the active session model', () => {
+    it('resolves a full-id activeModel to its short-id option (not Default)', () => {
+      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'claude-opus-4-7' })
+      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
+      expect(modelSelect.value).toBe('opus')
+    })
+
+    it('shows Default only when the full-id activeModel IS the default', () => {
+      renderDropdown({ defaultModelId: 'opus', activeModel: 'claude-opus-4-7' })
+      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
+      expect(modelSelect.value).toBe('')
+    })
+
+    it('renders a synthetic option with the raw id for a model not in the list', () => {
+      // fable is active but not broadcast in availableModels — degrade to the
+      // raw id rather than misrendering as "Default" (#5631 spirit).
+      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'claude-fable-5' })
+      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
+      expect(modelSelect.value).toBe('claude-fable-5')
+      const opt = Array.from(modelSelect.querySelectorAll('option')).find(
+        o => o.value === 'claude-fable-5',
+      )
+      expect(opt).toBeDefined()
+      expect(opt!.textContent).toBe('claude-fable-5')
+    })
+
+    it('does not add a synthetic option when the active model is already listed', () => {
+      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'opus' })
+      const modelSelect = screen.getByTestId('chat-settings-trigger')
+      // sonnet (filtered to Default) + haiku + opus = 3 options total
+      expect(modelSelect.querySelectorAll('option').length).toBe(3)
+    })
+  })
+
   // #3888 — header model-picker tooltip surfaces model + context-window
   // #5181 (C3): the model dropdown must be robust to any-length model
   // name. The actual truncation is CSS (`text-overflow: ellipsis` +

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -103,6 +103,32 @@ export function ChatSettingsDropdown({
     [availableModels, activeModel],
   )
 
+  // #5628: the session's active model arrives as either a short id ('fable')
+  // or a full id ('claude-fable-5'), but the <option> values are short ids
+  // (m.id). A native <select> whose `value` matches no <option> silently
+  // renders the FIRST option — so a full-id activeModel made the header show
+  // "Default (Sonnet 4.6)" even while the status bar (which dual-matches on
+  // id||fullId) showed the real model. Resolve the active model the same way
+  // the status bar does, then drive the <select> off the resolved short id so
+  // it matches its option. `activeEntry` is null for a model not in the list
+  // (e.g. unknown/unbroadcast) — we then render a synthetic option carrying the
+  // raw id so the picker degrades to the real id rather than misrendering as
+  // "Default" (#5631 graceful-degradation).
+  const activeEntry = useMemo(
+    () => availableModels.find(m => m.id === activeModel || m.fullId === activeModel) ?? null,
+    [availableModels, activeModel],
+  )
+  // The <option> value that represents the active model: its short id when
+  // known, else the raw activeModel string (matched by the synthetic option).
+  const activeOptionValue = activeEntry?.id ?? activeModel ?? ''
+  // True only when the active model genuinely IS the server default — compared
+  // on the normalized short id so a full-id activeModel still resolves.
+  const activeIsDefault = defaultModelId != null && activeOptionValue === defaultModelId
+  // Render a synthetic option ONLY when the active model is set, isn't the
+  // default, and isn't already one of the listed options.
+  const needsSyntheticOption =
+    !activeIsDefault && !!activeModel && activeEntry === null
+
   return (
     <>
       {/* Model */}
@@ -110,7 +136,7 @@ export function ChatSettingsDropdown({
         <select
           data-testid="chat-settings-trigger"
           data-kind="model"
-          value={activeModel === defaultModelId ? '' : (activeModel || '')}
+          value={activeIsDefault ? '' : activeOptionValue}
           onChange={handleModelChange}
           title={modelTitle}
           aria-label={modelTitle}
@@ -120,6 +146,9 @@ export function ChatSettingsDropdown({
               ? availableModels.find(m => m.id === defaultModelId)?.label
               : availableModels[0]?.label) ?? 'recommended'})
           </option>
+          {needsSyntheticOption && (
+            <option value={activeOptionValue}>{activeModel}</option>
+          )}
           {availableModels
             .filter(m => m.id !== defaultModelId)
             .map(m => (


### PR DESCRIPTION
## Closes #5628 (chain step 2 of #5631 foundation → #5628 → #5630 → #5629)

The header model picker rendered **"Default (Sonnet 4.6)"** while a non-default model (e.g. `claude-fable-5`) was actively running — the most prominent model indicator in the UI was wrong whenever the session's model differed from the server default. The status bar, the session model line, and the tab badge all showed the real model.

### Root cause
The session's active model arrives as **either a short id** (`fable`) **or a full id** (`claude-fable-5`), but the `<option>` values are short ids (`m.id`). A native `<select>` whose `value` matches no `<option>` silently renders its **first** option — which is the "Default (…)" entry. The other surfaces looked right because they dual-match on `id || fullId` before rendering a string (App.tsx:1515/1535); the `<select>` couldn't.

### Fix
- Resolve the active model the same way the status bar does (`id || fullId`) and drive the `<select>` value off the resolved short id, so it matches its option.
- When the active model isn't in `availableModels` at all (unknown / not yet broadcast), render a **synthetic option** carrying the raw id, so the picker degrades to the real id instead of misrendering as "Default" (the #5631 graceful-degradation spirit).
- The default-comparison normalizes to the short id too, so a full-id `activeModel` that genuinely *is* the default still correctly shows "Default (…)".

### Tests (new, `ChatSettingsDropdown.test.tsx`)
- full-id `activeModel` (`claude-opus-4-7`) resolves to its short-id option (`opus`), not Default
- full-id `activeModel` that IS the default still shows Default (`''`)
- a model not in the list (`claude-fable-5`) renders a synthetic option with the raw id and selects it
- no synthetic option when the active model is already listed

### Verification
- `ChatSettingsDropdown` suite: 39 pass (35 existing + 4 new)
- Full dashboard suite: **3601 pass, 0 fail** (190 files)
- `tsc --noEmit`: clean

Pure dashboard fix, no server/protocol change.
