### PR TITLE
chore(app): add preview-simulator EAS profile for no-credentials iOS validation

### DIFF
--- a/packages/app/eas.json
+++ b/packages/app/eas.json
@@ -13,6 +13,12 @@
       "distribution": "internal",
       "channel": "preview"
     },
+    "preview-simulator": {
+      "extends": "preview",
+      "ios": {
+        "simulator": true
+      }
+    },
     "production": {
       "autoIncrement": true,
       "channel": "production"


### PR DESCRIPTION
## Why

After the iOS CNG migration (#5642), there was no way to validate that EAS produces a working, OTA-capable **iOS** build without first doing the full interactive Apple credential setup (distribution cert + provisioning profiles for the app **and** the LiveActivity target + device UDID registration).

A **simulator** build needs none of that — no code signing — so it's the cheapest way to confirm the CNG prebuild compiles end-to-end on iOS with OTA enabled.

## What

Adds a `preview-simulator` build profile:
```json
"preview-simulator": {
  "extends": "preview",
  "ios": { "simulator": true }
}
```
- `extends: "preview"` → inherits `channel: preview`, so a simulator build subscribes to the same OTA channel as the pushed update group (`cd8d220e`) and can pick it up in the iOS Simulator.
- `ios.simulator: true` → produces a Simulator-compatible `.app`, no Apple credentials required.

## Validation in flight

Build `905a1b2d` was queued from this profile and got past the credential step that blocks the device build (proving simulator builds need no signing). Its success will confirm the CNG migration yields a buildable, OTA-capable iOS app.

Config-only; no app-code or runtime change. Device builds (`--profile preview`) are unaffected and still go through normal Apple credentials.
