### PR TITLE
fix(dashboard): push-to-talk no longer corrupts fast typing or hijacks active recordings

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2681,6 +2681,27 @@ describe('InputBar push-to-talk (#5610)', () => {
       nowSpy.mockRestore()
     })
 
+    it('a navigation key (Arrow) right before a Space hold does NOT block PTT (caret-anchored dictation)', () => {
+      vi.useFakeTimers()
+      const nowSpy = vi.spyOn(performance, 'now')
+      const voice = makeVoice()
+      render(<ControlledBar voiceInput={voice} initial="hello world" />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      textarea.setSelectionRange(11, 11)
+
+      // Arrow the caret into place, then immediately (0ms later) hold Space to
+      // dictate at that caret. Arrow is not text typing, so it must not poison
+      // the cadence guard — PTT must still arm.
+      nowSpy.mockReturnValue(1000)
+      fireEvent.keyDown(textarea, { key: 'ArrowLeft' })
+      nowSpy.mockReturnValue(1000)
+      fireEvent.keyDown(textarea, { key: ' ' })
+      act(() => { vi.advanceTimersByTime(300) })
+
+      expect(voice.start).toHaveBeenCalledTimes(1)
+      nowSpy.mockRestore()
+    })
+
     it('a deliberate Space hold after a typing pause still arms PTT', () => {
       vi.useFakeTimers()
       const nowSpy = vi.spyOn(performance, 'now')

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2643,4 +2643,84 @@ describe('InputBar push-to-talk (#5610)', () => {
 
     expect(voice.start).not.toHaveBeenCalled()
   })
+
+  // #5666 — fast typing must never hit the suppress-then-reinsert path that
+  // races overlapping keystrokes and reorders characters around spaces.
+  describe('typing-cadence guard (#5666)', () => {
+    it('a Space typed right after another key takes the native path (no arm, no programmatic splice)', () => {
+      vi.useFakeTimers()
+      const nowSpy = vi.spyOn(performance, 'now')
+      const voice = makeVoice()
+      const onValueChange = vi.fn()
+      render(
+        <InputBar
+          onSend={vi.fn()}
+          onInterrupt={vi.fn()}
+          controlledValue="hello"
+          onValueChange={onValueChange}
+          voiceInput={voice}
+        />,
+      )
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      textarea.setSelectionRange(5, 5)
+
+      // A letter at t=1000, then Space 100ms later — well inside the 250ms
+      // typing window, so the user is clearly typing words, not holding to talk.
+      nowSpy.mockReturnValue(1000)
+      fireEvent.keyDown(textarea, { key: 'o' })
+      nowSpy.mockReturnValue(1100)
+      fireEvent.keyDown(textarea, { key: ' ' })
+      act(() => { vi.advanceTimersByTime(300) })
+
+      // Never armed → never started recording.
+      expect(voice.start).not.toHaveBeenCalled()
+      // Native path → we never programmatically spliced a space (which is what
+      // raced the fast keystrokes in #5625). onValueChange is only called by the
+      // deferred re-insert, so it must not have fired.
+      expect(onValueChange).not.toHaveBeenCalled()
+      nowSpy.mockRestore()
+    })
+
+    it('a deliberate Space hold after a typing pause still arms PTT', () => {
+      vi.useFakeTimers()
+      const nowSpy = vi.spyOn(performance, 'now')
+      const voice = makeVoice()
+      render(<ControlledBar voiceInput={voice} initial="hi" />)
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      textarea.setSelectionRange(2, 2)
+
+      // Last key at t=1000; the Space comes 400ms later — past the guard, so a
+      // hold is a genuine push-to-talk gesture and must still arm.
+      nowSpy.mockReturnValue(1000)
+      fireEvent.keyDown(textarea, { key: 'i' })
+      nowSpy.mockReturnValue(1400)
+      fireEvent.keyDown(textarea, { key: ' ' })
+      act(() => { vi.advanceTimersByTime(300) })
+
+      expect(voice.start).toHaveBeenCalledTimes(1)
+      expect(textarea.value).toBe('hi')
+      nowSpy.mockRestore()
+    })
+  })
+
+  // #5668 — a Space hold landing on top of an already-running (button-started)
+  // recording must not arm PTT: arming would let the later release stop a
+  // recording PTT never started, and re-enter start() (wiping the transcript).
+  it('does not arm PTT when a recording is already in progress, and release does not stop it (#5668)', () => {
+    vi.useFakeTimers()
+    const start = vi.fn()
+    const stop = vi.fn()
+    const voice = makeVoice({ isRecording: true, start, stop })
+    render(<ControlledBar voiceInput={voice} initial="" />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    fireEvent.keyDown(textarea, { key: ' ' })
+    act(() => { vi.advanceTimersByTime(300) })
+    fireEvent.keyUp(textarea, { key: ' ' })
+
+    // PTT never armed → never re-invoked start() and never stopped the button
+    // recording on release.
+    expect(start).not.toHaveBeenCalled()
+    expect(stop).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -643,7 +643,15 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     } else {
       // #5666 — record typing activity so a Space arriving right after this key
       // takes the native path instead of arming PTT (see PTT_TYPING_GUARD_MS).
-      lastNonSpaceKeyAtRef.current = performance.now()
+      // Only *text-producing* keys count as typing: a single-character key with
+      // no command modifier (letters, digits, punctuation). Navigation/editing
+      // keys (Arrow, Backspace, Enter, Escape, Tab) and bare modifiers (Shift)
+      // must NOT poison the guard — otherwise arrowing the caret into place and
+      // then holding Space to dictate mid-draft (the caret-anchored dictation
+      // gesture) would be wrongly blocked.
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        lastNonSpaceKeyAtRef.current = performance.now()
+      }
       cancelPttArmOnOtherKey()
     }
 

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -159,6 +159,15 @@ type EvaluatorState =
 // long enough to feel deliberate without lagging a fast typist.
 const PTT_HOLD_MS = 300
 
+// #5666 — typing-cadence guard. If the user pressed a non-Space key within this
+// window, the next Space is treated as ordinary inter-word typing and takes the
+// native path (no suppress/arm). Push-to-talk only makes sense from an idle
+// hold; a typist tapping Space mid-sentence should never trigger the
+// suppress-then-reinsert path that races fast keystrokes. 250ms comfortably
+// covers fast typing (sub-200ms inter-key) while still letting a deliberate
+// Space-hold from a pause arm dictation.
+const PTT_TYPING_GUARD_MS = 250
+
 // #5610 — internal push-to-talk arming state, tracked on a ref so the
 // repeated keydown events that fire while a key is held don't restart the
 // arm timer or re-suppress characters incorrectly.
@@ -185,6 +194,10 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   // so we can cancel it on early release or on any disqualifying keypress.
   const pttStateRef = useRef<PttState>('idle')
   const pttTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // #5666 — timestamp (performance.now()) of the last non-Space keydown, used
+  // by the typing-cadence guard above. Initialised to -Infinity so the very
+  // first Space (no prior typing) is free to arm PTT.
+  const lastNonSpaceKeyAtRef = useRef(-Infinity)
   const [filePickerOpen, setFilePickerOpen] = useState(false)
   const [fileSelectedIndex, setFileSelectedIndex] = useState(0)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -473,9 +486,17 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   // past the inserted space on the next frame.
   const insertSpaceAtCaret = useCallback(() => {
     const el = textareaRef.current
-    const start = el?.selectionStart ?? value.length
-    const end = el?.selectionEnd ?? value.length
-    const next = value.slice(0, start) + ' ' + value.slice(end)
+    // #5666 — read the LIVE value and caret off the DOM element, not the
+    // closure `value`/captured caret. In controlled mode `setValue` is a plain
+    // string callback (no functional updater), so the closure `value` lags the
+    // DOM whenever subsequent keystrokes are still flushing through React — the
+    // splice would then run against stale text and clobber the caret the user
+    // has already moved past. The textarea's own `.value`/`.selectionStart`
+    // always reflect the freshest committed state.
+    const live = el?.value ?? value
+    const start = el?.selectionStart ?? live.length
+    const end = el?.selectionEnd ?? live.length
+    const next = live.slice(0, start) + ' ' + live.slice(end)
     setValue(next)
     const caret = start + 1
     requestAnimationFrame(() => {
@@ -508,6 +529,20 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
       e.preventDefault()
       return true
     }
+
+    // #5666 — typing-cadence guard. If the user pressed another key very
+    // recently they're typing words, not holding to dictate. Take the native
+    // space path (no suppress, no arm) so fast typing never hits the deferred
+    // re-insert race that reorders characters around spaces.
+    if (performance.now() - lastNonSpaceKeyAtRef.current < PTT_TYPING_GUARD_MS) {
+      return false
+    }
+
+    // #5668 — a recording is already live (e.g. the mic button was clicked).
+    // Don't arm PTT on top of it: arming would let a later release call
+    // voiceInput.stop() and kill a recording PTT never started. Treat Space as
+    // an ordinary character instead.
+    if (voiceInput.isRecording) return false
 
     // First Space down: suppress the native character, remember the caret as
     // the dictation anchor, and start the hold timer.
@@ -606,6 +641,9 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     if (e.key === ' ' || e.key === 'Spacebar') {
       if (handlePttKeyDown(e)) return
     } else {
+      // #5666 — record typing activity so a Space arriving right after this key
+      // takes the native path instead of arming PTT (see PTT_TYPING_GUARD_MS).
+      lastNonSpaceKeyAtRef.current = performance.now()
       cancelPttArmOnOtherKey()
     }
 


### PR DESCRIPTION
## Summary

Two regressions from the push-to-talk merge (#5625), both in `InputBar.tsx`.

### #5666 — fast typing corrupted around spaces
The PTT Space disambiguation suppressed the native space and **re-inserted** it later via `insertSpaceAtCaret()`, which read a stale controlled-value closure and forced the caret. During fast typing, the next letter's keydown/insertion overlaps the Space keyup, so the deferred space spliced against stale text → characters reordered around spaces and the caret jumped backward (`re a put`, `il asee`, `thenswf`).

**Fix:**
- **Typing-cadence guard** (primary): if a non-Space key was pressed within `PTT_TYPING_GUARD_MS` (250ms), the Space takes the native path — no suppress, no arm. PTT only arms from an idle hold, so a typist never hits the deferred-reinsert path.
- **Hardened re-insert** (defensive, for the idle-tap case): `insertSpaceAtCaret()` now splices against the **live** `textarea.value`/`selectionStart` instead of the stale closure (controlled mode has no functional updater, so the closure lags the DOM mid-flush).

### #5668 (hypothesis 2) — PTT hijacking a button recording
A Space hold landing on top of an already-running mic-button recording armed PTT; the later release then called `voiceInput.stop()`, killing a recording PTT never started (and re-entering `start()`, which wipes the transcript). **Fix:** skip arming when `voiceInput.isRecording` is already true — Space is just a character.

## Tests
Adds regression cases the original suite lacked (it covered tap/hold/unmount but not overlapping keystrokes):
- Space right after another key → native path, no arm, no programmatic splice
- deliberate Space hold after a typing pause → still arms (guard expires)
- recording already in progress → no arm, release does not stop it

Full dashboard suite green (3609 tests), `tsc --noEmit` clean.

## Scope note on #5668
This closes the **code** half of #5668 (hypothesis 2). The issue's *primary* hypothesis 1 — a stale installed `Chroxy.app` bundling the pre-June-3 Swift helper — is a rebuild/reinstall concern with no code change here, plus a separate "surface helper spawn failure instead of a silent revert" enhancement. Leaving #5668 open for those; this PR is referenced, not closing it.

Closes #5666