### PR TITLE
fix(server,dashboard): attribute permission prompts to the session that asked (#5667)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2804,6 +2804,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           options: newOptions,
           expiresAt: newExpiresAt,
           timestamp: Date.now(),
+          // #5667 — record which session asked so the prompt can be labelled.
+          originSessionId: permTargetId ?? undefined,
         };
         {
           const effectiveId = (permTargetId && get().sessionStates[permTargetId]) ? permTargetId : get().activeSessionId;

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2804,8 +2804,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           options: newOptions,
           expiresAt: newExpiresAt,
           timestamp: Date.now(),
-          // #5667 — record which session asked so the prompt can be labelled.
-          originSessionId: permTargetId ?? undefined,
+          // #5667 — record the OWNING session (the wire sessionId) so the
+          // prompt can be labelled. Not `permTargetId`: that falls back to the
+          // active session for unmapped/legacy requests and would mislabel them.
+          // Undefined when the request maps to no session.
+          originSessionId: permPayload.sessionId ?? undefined,
         };
         {
           const effectiveId = (permTargetId && get().sessionStates[permTargetId]) ? permTargetId : get().activeSessionId;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -27,6 +27,7 @@ import { MultiTerminalView } from './components/MultiTerminalView'
 import { InputBar, type FileAttachment, type ImageAttachment } from './components/InputBar'
 import { useVoiceInput } from './hooks/useVoiceInput'
 import { toWireAttachments } from './utils/attachment-utils'
+import { derivePendingPermissionSessions } from './utils/pendingPermissions'
 import { processImageFiles, filterImageFiles } from './utils/image-utils'
 import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
@@ -999,28 +1000,16 @@ export function App() {
   // the server's natural order at the end. Stale ids in `tabOrder` (server
   // removed the session) are harmlessly ignored because we filter against
   // the live `sessions` list.
-  // #5667 — which sessions have an unanswered permission prompt, across ALL
-  // sessions (not just the active one). Now that the server routes a prompt to
-  // its owning session, a background session's prompt no longer lands in the
-  // focused tab — without a per-tab indicator it would be invisible until the
-  // operator happened to switch to that session. Shallow-equal Record so this
-  // only re-renders a tab when its pending state actually flips, not on every
-  // stream delta. Scans newest-first and early-exits at the first match.
+  // #5667 — which sessions have an unanswered, still-live permission prompt,
+  // across ALL sessions (not just the active one). Now that the server routes a
+  // prompt to its owning session, a background session's prompt no longer lands
+  // in the focused tab — without a per-tab indicator it would be invisible until
+  // the operator switched to that session. Shallow-equal Record so this only
+  // re-renders a tab when its pending state actually flips, not on every stream
+  // delta. The `expiresAt > now` check (inside the helper) clears the indicator
+  // on expiry/timeout, which set `options: undefined` but not `answered`.
   const pendingPermissionSessionIds = useConnectionStore(
-    useShallow((s) => {
-      const out: Record<string, true> = {}
-      for (const id in s.sessionStates) {
-        const msgs = s.sessionStates[id]!.messages
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const m = msgs[i]!
-          if (m.type === 'prompt' && m.requestId && m.expiresAt && !m.answered) {
-            out[id] = true
-            break
-          }
-        }
-      }
-      return out
-    }),
+    useShallow((s) => derivePendingPermissionSessions(s.sessionStates, Date.now())),
   )
 
   const sessionTabs: SessionTabData[] = useMemo(

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -999,6 +999,30 @@ export function App() {
   // the server's natural order at the end. Stale ids in `tabOrder` (server
   // removed the session) are harmlessly ignored because we filter against
   // the live `sessions` list.
+  // #5667 — which sessions have an unanswered permission prompt, across ALL
+  // sessions (not just the active one). Now that the server routes a prompt to
+  // its owning session, a background session's prompt no longer lands in the
+  // focused tab — without a per-tab indicator it would be invisible until the
+  // operator happened to switch to that session. Shallow-equal Record so this
+  // only re-renders a tab when its pending state actually flips, not on every
+  // stream delta. Scans newest-first and early-exits at the first match.
+  const pendingPermissionSessionIds = useConnectionStore(
+    useShallow((s) => {
+      const out: Record<string, true> = {}
+      for (const id in s.sessionStates) {
+        const msgs = s.sessionStates[id]!.messages
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          const m = msgs[i]!
+          if (m.type === 'prompt' && m.requestId && m.expiresAt && !m.answered) {
+            out[id] = true
+            break
+          }
+        }
+      }
+      return out
+    }),
+  )
+
   const sessionTabs: SessionTabData[] = useMemo(
     () => {
       const byId = new Map(sessions.map(s => [s.sessionId, s]))
@@ -1025,9 +1049,12 @@ export function App() {
         status: getSessionVisualStatus(s),
         // #3567: surface latched stdin-disabled flag from session_list.
         stdinForwardingDisabled: s.stdinForwardingDisabled,
+        // #5667: flag tabs with an unanswered permission prompt so a
+        // background session's request is visible without switching to it.
+        pendingPermission: pendingPermissionSessionIds[s.sessionId] ?? false,
       }))
     },
-    [sessions, activeSessionId, getSessionVisualStatus, tabOrder],
+    [sessions, activeSessionId, getSessionVisualStatus, tabOrder, pendingPermissionSessionIds],
   )
 
   // Derive sidebar repo tree from sessions
@@ -1492,6 +1519,7 @@ export function App() {
     setViewMode,
     stalledPromptIds,
     hasPendingAskUserQuestionPermission,
+    sessions,
   })
 
   // #4412: registry-driven cheat sheet. Recomputed on every render —

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -77,6 +77,35 @@ describe('PermissionPrompt', () => {
     expect(screen.getByText(/Write to \/tmp\/file.txt/)).toBeInTheDocument()
   })
 
+  it('renders the session-origin badge when sessionLabel is provided (#5667)', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="Run command"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+        sessionLabel="ltl · claude-cli"
+      />
+    )
+    const badge = screen.getByTestId('perm-session')
+    expect(badge).toHaveTextContent('ltl · claude-cli')
+    expect(badge).toHaveAttribute('title', 'Requested by ltl · claude-cli')
+  })
+
+  it('omits the session badge when no sessionLabel is provided', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="Run command"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('perm-session')).not.toBeInTheDocument()
+  })
+
   it('shows countdown timer', () => {
     render(
       <PermissionPrompt

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -29,6 +29,14 @@ export interface PermissionPromptProps {
   description: string
   remainingMs: number
   onRespond: (requestId: string, decision: PermissionDecision) => void
+  /**
+   * #5667 — human label for the session that asked (e.g. "ltl · CLI"),
+   * derived by the renderer from the message's `originSessionId`. Rendered as
+   * a badge so an operator running multiple agents can tell which one is
+   * requesting before approving. Omitted when only one session exists (no
+   * ambiguity to disambiguate).
+   */
+  sessionLabel?: string
 }
 
 function formatCountdown(ms: number): string {
@@ -38,7 +46,7 @@ function formatCountdown(ms: number): string {
   return `${mins}:${secs < 10 ? '0' : ''}${secs}`
 }
 
-export function PermissionPrompt({ requestId, tool, description, remainingMs, onRespond }: PermissionPromptProps) {
+export function PermissionPrompt({ requestId, tool, description, remainingMs, onRespond, sessionLabel }: PermissionPromptProps) {
   const [remaining, setRemaining] = useState(remainingMs)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   // #3619: anchor on monotonic `performance.now()` so an NTP sync /
@@ -168,6 +176,11 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
 
   return (
     <div className={`permission-prompt${answered ? ' answered' : ''}`} data-testid="permission-prompt">
+      {sessionLabel && (
+        <div className="perm-session" data-testid="perm-session" title={`Requested by ${sessionLabel}`}>
+          {sessionLabel}
+        </div>
+      )}
       <div className="perm-desc">
         <span className="perm-tool">{tool}</span>: {description || 'Permission requested'}
       </div>

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -60,6 +60,24 @@ describe('SessionBar', () => {
     expect(within(busyTab).getByTestId('status-dot')).toHaveClass('status-working')
   })
 
+  it('shows a pending-permission indicator on tabs with an unanswered prompt (#5667)', () => {
+    render(
+      <SessionBar
+        sessions={makeSessions([{}, { pendingPermission: true }])}
+        onSwitch={vi.fn()}
+        onClose={vi.fn()}
+        onRename={vi.fn()}
+        onNewSession={vi.fn()}
+      />
+    )
+    // s2 (background) has the prompt → indicator present.
+    const pendingTab = screen.getByTestId('session-tab-s2')
+    expect(within(pendingTab).getByTestId('tab-pending-permission')).toBeInTheDocument()
+    // s1 has no pending prompt → no indicator.
+    const cleanTab = screen.getByTestId('session-tab-s1')
+    expect(within(cleanTab).queryByTestId('tab-pending-permission')).not.toBeInTheDocument()
+  })
+
   it('calls onSwitch when clicking inactive tab', () => {
     const onSwitch = vi.fn()
     render(

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -45,6 +45,10 @@ export interface SessionTabData {
   // is visible even when another session is active and the bigger
   // banner isn't shown.
   stdinForwardingDisabled?: boolean
+  // #5667: this session has an unanswered permission prompt. Renders an
+  // attention indicator on the tab so a background session's request is
+  // visible without switching to it.
+  pendingPermission?: boolean
 }
 
 /**
@@ -525,6 +529,18 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
                 />
               )
             })()}
+
+            {/* #5667 — unanswered permission prompt waiting in this session. */}
+            {session.pendingPermission && (
+              <span
+                className="tab-pending-permission"
+                data-testid="tab-pending-permission"
+                title="Permission requested — waiting for your approval"
+                aria-label="Permission requested — waiting for your approval"
+              >
+                !
+              </span>
+            )}
 
             {renamingId === session.sessionId ? (
               <input

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import type { ReactNode } from 'react'
-import type { ChatMessage } from '@chroxy/store-core'
+import type { ChatMessage, SessionInfo } from '@chroxy/store-core'
 import type { ChatViewMessage } from '../components/ChatView'
 import type { ConnectionState } from '../store/connection'
 import { ToolGroup } from '../components/ToolGroup'
@@ -28,6 +28,29 @@ export interface UseMessageRendererArgs {
   setViewMode: ConnectionState['setViewMode']
   stalledPromptIds: Set<string>
   hasPendingAskUserQuestionPermission: boolean
+  /**
+   * #5667 — all connected sessions, used to label a permission prompt with the
+   * session that asked (from the message's `originSessionId`). Only consulted
+   * when more than one session exists.
+   */
+  sessions: SessionInfo[]
+}
+
+/**
+ * #5667 — build a short "which session is asking" label, e.g. "ltl · CLI",
+ * from a prompt's `originSessionId`. Returns undefined when there's no origin,
+ * the session is unknown, or only one session exists (nothing to disambiguate).
+ */
+function buildSessionLabel(
+  originSessionId: string | undefined,
+  sessions: SessionInfo[],
+): string | undefined {
+  if (!originSessionId || sessions.length <= 1) return undefined
+  const session = sessions.find(s => s.sessionId === originSessionId)
+  if (!session) return undefined
+  const name = session.name?.trim() || originSessionId
+  const provider = session.provider?.trim()
+  return provider ? `${name} · ${provider}` : name
 }
 
 /**
@@ -55,6 +78,7 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
     setViewMode,
     stalledPromptIds,
     hasPendingAskUserQuestionPermission,
+    sessions,
   } = args
 
   return useCallback((msg: ChatViewMessage) => {
@@ -97,6 +121,7 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
           description={storeMsg.content}
           remainingMs={remainingMs}
           onRespond={(reqId, decision) => sendPermissionResponse(reqId, decision)}
+          sessionLabel={buildSessionLabel(storeMsg.originSessionId, sessions)}
         />
       )
     }
@@ -271,5 +296,5 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
 
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, allowMultiQuestionForm, activeSessionProvider, setViewMode, stalledPromptIds, hasPendingAskUserQuestionPermission])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, allowMultiQuestionForm, activeSessionProvider, setViewMode, stalledPromptIds, hasPendingAskUserQuestionPermission, sessions])
 }

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3944,6 +3944,44 @@ describe('dashboard message-handler dispatch', () => {
       expect(promptMsg).toBeDefined()
       expect(promptMsg.content).toBe('Permission required')
     })
+
+    it('routes the prompt to its owning (non-active) session and records originSessionId (#5667)', () => {
+      // 's-bg' is asking while 's-active' is focused. The prompt must land in
+      // s-bg's message list (not the active tab) and carry originSessionId so
+      // the renderer can label which session asked.
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's-active',
+          // Background session asking → pushSessionNotification runs (it
+          // early-returns only for the active session), so seed the array it
+          // mutates. Exercises the real cross-session notification path.
+          sessionNotifications: [],
+          sessionStates: {
+            's-active': createEmptySessionState(),
+            's-bg': createEmptySessionState(),
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'permission_request',
+          sessionId: 's-bg',
+          requestId: 'perm-bg',
+          tool: 'Bash',
+          input: { command: 'rm -rf /tmp/x' },
+          remainingMs: 300000,
+        },
+        ctx() as any,
+      )
+      const bgMsgs = (store.getState() as any).sessionStates['s-bg'].messages
+      const activeMsgs = (store.getState() as any).sessionStates['s-active'].messages
+      const promptMsg = bgMsgs.find((m: any) => m.type === 'prompt')
+      expect(promptMsg).toBeDefined()
+      expect(promptMsg.originSessionId).toBe('s-bg')
+      // The active tab must NOT have received the background session's prompt.
+      expect(activeMsgs.find((m: any) => m.type === 'prompt')).toBeUndefined()
+    })
   })
 
   // #3247 — direct unit coverage for the three skill message handlers.

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3982,6 +3982,33 @@ describe('dashboard message-handler dispatch', () => {
       // The active tab must NOT have received the background session's prompt.
       expect(activeMsgs.find((m: any) => m.type === 'prompt')).toBeUndefined()
     })
+
+    it('leaves originSessionId undefined for an unmapped request (no wire sessionId) (#5667)', () => {
+      // No sessionId on the wire → the prompt falls back to the active tab for
+      // routing, but originSessionId must stay undefined (not the active id) so
+      // it is not mislabelled as the active session's own prompt.
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's-active',
+          sessionStates: { 's-active': createEmptySessionState() },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'permission_request',
+          requestId: 'perm-unmapped',
+          tool: 'Bash',
+          input: { command: 'ls' },
+          remainingMs: 300000,
+        },
+        ctx() as any,
+      )
+      const msgs = (store.getState() as any).sessionStates['s-active'].messages
+      const promptMsg = msgs.find((m: any) => m.type === 'prompt')
+      expect(promptMsg).toBeDefined()
+      expect(promptMsg.originSessionId).toBeUndefined()
+    })
   })
 
   // #3247 — direct unit coverage for the three skill message handlers.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2023,8 +2023,13 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
       options: newOptions,
       expiresAt: newExpiresAt,
       timestamp: Date.now(),
-      // #5667 — record which session asked so the renderer can label it.
-      originSessionId: permTargetId ?? undefined,
+      // #5667 — record the OWNING session (the wire sessionId), so the renderer
+      // can label which session asked. Deliberately not `permTargetId`: that
+      // falls back to the active session for unmapped/legacy requests, which
+      // would mislabel them as the active session's own prompt. Undefined when
+      // the request maps to no session (contract: originSessionId is the owner
+      // or absent).
+      originSessionId: permPayload.sessionId ?? undefined,
     };
     if (permTargetId && get().sessionStates[permTargetId]) {
       updateSession(permTargetId, (ss) => ({

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2023,6 +2023,8 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
       options: newOptions,
       expiresAt: newExpiresAt,
       timestamp: Date.now(),
+      // #5667 — record which session asked so the renderer can label it.
+      originSessionId: permTargetId ?? undefined,
     };
     if (permTargetId && get().sessionStates[permTargetId]) {
       updateSession(permTargetId, (ss) => ({

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1783,6 +1783,24 @@ button.sidebar-token-view-session-row:hover {
   letter-spacing: 0.4px;
 }
 
+/* #5667 — per-tab "permission waiting" indicator. */
+.tab-pending-permission {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  background: var(--bg-permission, color-mix(in srgb, var(--accent-purple) 22%, transparent));
+  color: var(--accent-purple);
+  border: 1px solid var(--border-permission, color-mix(in srgb, var(--accent-purple) 45%, transparent));
+  cursor: help;
+}
+
 .tab-close {
   background: none;
   border: none;
@@ -2775,6 +2793,23 @@ button.sidebar-token-view-session-row:hover {
   padding: 12px 14px;
   align-self: flex-start;
   max-width: 85%;
+}
+
+/* #5667 — session-origin badge so multi-agent operators see which session asks. */
+.perm-session {
+  display: inline-block;
+  font-size: var(--text-xs, 11px);
+  font-weight: 600;
+  color: var(--accent-purple);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border-permission);
+  border-radius: 6px;
+  padding: 1px 7px;
+  margin-bottom: 6px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .perm-desc {

--- a/packages/dashboard/src/utils/pendingPermissions.test.ts
+++ b/packages/dashboard/src/utils/pendingPermissions.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import type { ChatMessage } from '@chroxy/store-core'
+import { derivePendingPermissionSessions } from './pendingPermissions'
+
+const NOW = 1_000_000
+
+function prompt(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'm1',
+    type: 'prompt',
+    content: 'Bash: ls',
+    tool: 'Bash',
+    requestId: 'req-1',
+    expiresAt: NOW + 60_000,
+    timestamp: NOW,
+    ...over,
+  }
+}
+
+function states(map: Record<string, ChatMessage[]>): Record<string, { messages: ChatMessage[] }> {
+  const out: Record<string, { messages: ChatMessage[] }> = {}
+  for (const id in map) out[id] = { messages: map[id]! }
+  return out
+}
+
+describe('derivePendingPermissionSessions (#5667)', () => {
+  it('flags a session with a live unanswered permission prompt', () => {
+    const result = derivePendingPermissionSessions(states({ s1: [prompt()] }), NOW)
+    expect(result).toEqual({ s1: true })
+  })
+
+  it('does NOT flag an answered prompt', () => {
+    const result = derivePendingPermissionSessions(
+      states({ s1: [prompt({ answered: 'allow' })] }),
+      NOW,
+    )
+    expect(result).toEqual({})
+  })
+
+  it('does NOT flag an expired/timed-out prompt (expiresAt in the past)', () => {
+    // Regression: permission_expired / permission_timeout clear `options` but
+    // not `answered`, so without the expiry check the indicator stuck on.
+    const result = derivePendingPermissionSessions(
+      states({ s1: [prompt({ expiresAt: NOW - 1 })] }),
+      NOW,
+    )
+    expect(result).toEqual({})
+  })
+
+  it('does NOT flag an AskUserQuestion prompt (no requestId / expiresAt)', () => {
+    const aukq = prompt({ requestId: undefined, expiresAt: undefined, options: [{ label: 'A', value: 'a' }] })
+    const result = derivePendingPermissionSessions(states({ s1: [aukq] }), NOW)
+    expect(result).toEqual({})
+  })
+
+  it('flags only the sessions that actually have a live prompt', () => {
+    const result = derivePendingPermissionSessions(
+      states({
+        active: [prompt({ id: 'a', answered: 'allow' })],
+        bg1: [{ ...prompt({ id: 'b' }), type: 'response', content: 'hi' }, prompt({ id: 'c' })],
+        bg2: [prompt({ id: 'd', expiresAt: NOW - 5 })],
+      }),
+      NOW,
+    )
+    expect(result).toEqual({ bg1: true })
+  })
+
+  it('finds a live prompt even when a later non-prompt message follows it', () => {
+    const result = derivePendingPermissionSessions(
+      states({ s1: [prompt({ id: 'p' }), { id: 'sys', type: 'system', content: 'note', timestamp: NOW }] }),
+      NOW,
+    )
+    expect(result).toEqual({ s1: true })
+  })
+})

--- a/packages/dashboard/src/utils/pendingPermissions.ts
+++ b/packages/dashboard/src/utils/pendingPermissions.ts
@@ -1,0 +1,48 @@
+import type { ChatMessage } from '@chroxy/store-core'
+
+/**
+ * #5667 — derive which sessions have an unanswered, still-live permission
+ * prompt, across ALL sessions. Drives the per-tab "permission waiting"
+ * indicator so a background session's request is visible without switching to
+ * it (the server now routes a prompt to its owning session, so it no longer
+ * lands in the focused tab).
+ *
+ * A session counts as pending iff it has a `type: 'prompt'` message with a
+ * `requestId`, a future `expiresAt`, and no `answered` decision:
+ *   - `requestId` + `expiresAt` distinguishes a *permission* prompt from an
+ *     AskUserQuestion prompt (which is `type: 'prompt'` but carries neither),
+ *     so questions never trip the indicator.
+ *   - `expiresAt > now` clears the indicator once the prompt has timed out or
+ *     expired — the `permission_expired` / `permission_timeout` handlers clear
+ *     the prompt's `options` but do NOT set `answered`, so without the expiry
+ *     check an ignored background prompt would leave the indicator stuck on.
+ *   - `!answered` clears it the moment the user allows/denies.
+ *
+ * Returns a plain `Record<sessionId, true>` (only pending sessions present) so
+ * a `useShallow` selector re-renders a tab only when its pending state flips.
+ * Scans each session newest-first and early-exits at the first live prompt; a
+ * pending permission blocks its session, so it is at/near the tail in practice.
+ */
+export function derivePendingPermissionSessions(
+  sessionStates: Record<string, { messages: ChatMessage[] }>,
+  now: number,
+): Record<string, true> {
+  const out: Record<string, true> = {}
+  for (const id in sessionStates) {
+    const msgs = sessionStates[id]!.messages
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i]!
+      if (
+        m.type === 'prompt' &&
+        m.requestId &&
+        m.expiresAt &&
+        m.expiresAt > now &&
+        !m.answered
+      ) {
+        out[id] = true
+        break
+      }
+    }
+  }
+  return out
+}

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -235,8 +235,9 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         // #5667: carry the owning session so clients route the prompt to the
         // session that actually asked, instead of falling back to whatever tab
         // is focused. Matches the resend-on-reconnect (line ~485) and SDK
-        // (line ~406) paths, which already include sessionId. Only present when
-        // the request mapped to a chroxy session (null for unmapped requests).
+        // (line ~406) paths, which already include sessionId. The `sessionId`
+        // property is omitted entirely (absent, not null) when the request maps
+        // to no chroxy session — clients then fall back to the active session.
         ...(ownerSessionId ? { sessionId: ownerSessionId } : {}),
       })
 

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -232,6 +232,12 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         description,
         input: sanitizedInput,
         remainingMs: 300_000,
+        // #5667: carry the owning session so clients route the prompt to the
+        // session that actually asked, instead of falling back to whatever tab
+        // is focused. Matches the resend-on-reconnect (line ~485) and SDK
+        // (line ~406) paths, which already include sessionId. Only present when
+        // the request mapped to a chroxy session (null for unmapped requests).
+        ...(ownerSessionId ? { sessionId: ownerSessionId } : {}),
       })
 
       if (pushManager) {

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -335,6 +335,34 @@ describe('createPermissionHandler', () => {
       assert.equal(mappedSessionId, 'chroxy-sess-7')
 
       assert.equal(ownerSession.notifyPermissionPending.mock.calls.length, 1)
+
+      // #5667 — the HTTP broadcast must carry the owning sessionId so clients
+      // route the prompt to the session that asked instead of the active tab.
+      assert.equal(opts.broadcastFn.mock.calls.length, 1)
+      const broadcast = opts.broadcastFn.mock.calls[0].arguments[0]
+      assert.equal(broadcast.type, 'permission_request')
+      assert.equal(broadcast.sessionId, 'chroxy-sess-7',
+        'mapped HTTP requests must broadcast sessionId for client routing (#5667)')
+    })
+
+    it('omits sessionId from the broadcast when the request maps to no chroxy session (#5667)', async () => {
+      // No hook secret → ownerSessionId stays null → the broadcast must NOT
+      // invent a sessionId (clients fall back to the active session for these
+      // genuinely unmapped legacy requests).
+      const opts = makeHandlerOpts()
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      destroyFn = destroy
+      const body = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+      const req = makeReq(body)
+      const res = makeRes()
+      handlePermissionRequest(req, res)
+      await new Promise(r => setImmediate(r))
+
+      assert.equal(opts.broadcastFn.mock.calls.length, 1)
+      const broadcast = opts.broadcastFn.mock.calls[0].arguments[0]
+      assert.equal(broadcast.type, 'permission_request')
+      assert.equal(Object.prototype.hasOwnProperty.call(broadcast, 'sessionId'), false,
+        'unmapped requests must not carry a sessionId in the broadcast')
     })
 
     it('does not populate permissionSessionMap when hookSecret has no chroxy sessionId (legacy single-session mode)', async () => {

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -73,6 +73,19 @@ export interface ChatMessage {
    */
   questions?: ChatMessageQuestion[];
   requestId?: string;
+  /**
+   * #5667: the chroxy session that originated this message, captured at
+   * creation time. Set on permission `prompt` messages so the renderer can
+   * label *which* session is asking — without this, a prompt routed to a
+   * background session is indistinguishable from the active session's own
+   * prompts once the operator switches tabs. Distinct from the message's
+   * physical location (`sessionStates[id].messages`): this is self-describing
+   * data that survives independent of which array the message lives in, and
+   * mirrors the on-the-fly lookup `PermissionHistoryScreen` already does.
+   * Undefined for messages with no owning session (top-level fallback) and for
+   * pre-#5667 messages.
+   */
+  originSessionId?: string;
   toolInput?: Record<string, unknown>;
   toolUseId?: string;
   toolResult?: string;


### PR DESCRIPTION
## Problem
With multiple agents running, permission prompts from background sessions surfaced in the **currently focused** tab with nothing identifying which agent was asking — blind approval once 2+ agents run in parallel.

## Root cause
- **Server drops sessionId on broadcast** — the HTTP `permission_request` broadcast (`ws-permissions.js`) omitted `sessionId`, even though the owning session was in scope. The resend-on-reconnect and SDK paths already include it; only the HTTP path (CLI/TUI sessions, which route through the permission hook — exactly the "multiple Fable agents" case) was missing it.
- Clients route on `payload.sessionId || activeSessionId`, so the missing field is what forced every prompt into the active tab.

## Fix
- **Server:** include `sessionId` in the HTTP broadcast when the request maps to a chroxy session (omitted for genuinely unmapped legacy requests, matching the resend/SDK behaviour). This alone corrects routing.
- **store-core:** new `originSessionId` on `ChatMessage`; both dashboard + app handlers stamp it on the prompt.
- **Dashboard `PermissionPrompt`:** session-origin badge (`name · provider`) shown when >1 session exists.
- **Dashboard `SessionBar`:** per-tab pending-permission indicator. Correct routing means a background prompt no longer lands in the focused tab — without a surface it would be invisible until the operator switched to that session, so this **must** ship together. Derived across all `sessionStates` via a shallow-equal selector (a tab re-renders only when its pending state flips, not on every stream delta).

## Coupling note
The server change *alone* re-routes background prompts to their own (possibly inactive) tab. Splitting the SessionBar surfacing into a follow-up would make those prompts invisible — hence one PR.

## Tests
- Server: broadcast includes sessionId when mapped; omits it when unmapped.
- Dashboard handler: prompt routes to its owning (non-active) session + records `originSessionId`; active tab does not receive it.
- `PermissionPrompt`: badge present with `sessionLabel`, absent without.
- `SessionBar`: pending indicator on the flagged tab only.

Full dashboard (3614), store-core (1485), app permission, and server `ws-permissions` (58) suites green; `tsc --noEmit` clean across store-core / dashboard / app.

## Scope
Mobile **live-prompt** badge is a tracked follow-up — mobile already has `PermissionHistoryScreen` for multi-session attribution, runs typically one session, and gets the routing fix for free from the server change. Protocol schema already permitted `sessionId` (no change).

Closes #5667