### PR TITLE
docs(skills): wire repo-memory exploration protocol into CLAUDE.md + exploration skills

### DIFF
--- a/.claude/commands/agent-review.md
+++ b/.claude/commands/agent-review.md
@@ -23,7 +23,7 @@ gh pr view ${PR_NUM}
 gh pr diff ${PR_NUM}
 ```
 
-**Use repo-memory to gather surrounding context cheaply.** This repo has the `repo-memory` MCP. For files the diff touches, call `get_file_summary` (or `batch_file_summaries`) and `get_dependency_graph` to understand the change's blast radius in ~50 tokens/file instead of fully re-reading each one — then `Read` the changed regions in full to review the actual lines. Use `search_by_purpose` to locate related code the diff should have updated.
+**Use repo-memory to gather surrounding context cheaply.** This repo has the `repo-memory` MCP. For files the diff touches, call `get_file_summary` (or `batch_file_summaries`) and `get_dependency_graph` to understand the change's blast radius for a fraction of a full Read instead of fully re-reading each one — then `Read` the changed regions in full to review the actual lines. Use `search_by_purpose` to locate related code the diff should have updated.
 
 ### 2. Review Criteria
 
@@ -191,6 +191,8 @@ Then below the table, list:
 **Chroxy Inspector** — expert in Node.js, React Native/Expo, WebSocket protocol, Claude Code CLI, Cloudflare tunnels, mobile connectivity.
 
 Mindset: "Will this code work reliably over a cellular connection through a tunnel to a remote dev machine?"
+
+When this persona runs as a spawned subagent (fresh context, no CLAUDE.md), use the **repo-memory** MCP to gather surrounding context cheaply: `get_file_summary`/`batch_file_summaries` and `get_dependency_graph` for the files the diff touches (blast radius for a fraction of a full Read), `search_by_purpose` to locate related code the diff should have updated — then `Read` the changed regions in full to review the actual lines.
 
 ## Review Philosophy
 

--- a/.claude/commands/agent-review.md
+++ b/.claude/commands/agent-review.md
@@ -23,6 +23,8 @@ gh pr view ${PR_NUM}
 gh pr diff ${PR_NUM}
 ```
 
+**Use repo-memory to gather surrounding context cheaply.** This repo has the `repo-memory` MCP. For files the diff touches, call `get_file_summary` (or `batch_file_summaries`) and `get_dependency_graph` to understand the change's blast radius in ~50 tokens/file instead of fully re-reading each one — then `Read` the changed regions in full to review the actual lines. Use `search_by_purpose` to locate related code the diff should have updated.
+
 ### 2. Review Criteria
 
 The agent reviews against these standards:

--- a/.claude/commands/bug-hunt.md
+++ b/.claude/commands/bug-hunt.md
@@ -105,7 +105,7 @@ Your job is to **find bugs that would make good GitHub issues** in the following
 
 ## Rules
 
-1. READ actual source code. Verify each finding against the code, not against vibes. **Use repo-memory to save tokens:** call `get_file_summary` (or `batch_file_summaries`) before a full `Read` to scope where to look (~50 tokens vs ~800), and `search_by_purpose` instead of grep — then `Read` the suspect lines in full to confirm the bug.
+1. READ actual source code. Verify each finding against the code, not against vibes. **Use repo-memory to save tokens:** call `get_file_summary` (or `batch_file_summaries`) before a full `Read` to scope where to look (a fraction of a full Read), and `search_by_purpose` instead of grep — then `Read` the suspect lines in full to confirm the bug.
 2. Every finding must be **concrete and reproducible**. "This might fail" is rejected. "Calling foo() with input=null on line 42 hits the unguarded `.length` on line 47 and throws" is accepted.
 3. Stay in your lens. If you stray into other hunters' lanes (e.g., Tester writing security findings), dedup later eats your work.
 4. Do NOT suggest fixes longer than 1-2 lines. Issue authors decide the fix; you describe the bug.

--- a/.claude/commands/bug-hunt.md
+++ b/.claude/commands/bug-hunt.md
@@ -105,7 +105,7 @@ Your job is to **find bugs that would make good GitHub issues** in the following
 
 ## Rules
 
-1. READ actual source code. Verify each finding against the code, not against vibes.
+1. READ actual source code. Verify each finding against the code, not against vibes. **Use repo-memory to save tokens:** call `get_file_summary` (or `batch_file_summaries`) before a full `Read` to scope where to look (~50 tokens vs ~800), and `search_by_purpose` instead of grep — then `Read` the suspect lines in full to confirm the bug.
 2. Every finding must be **concrete and reproducible**. "This might fail" is rejected. "Calling foo() with input=null on line 42 hits the unguarded `.length` on line 47 and throws" is accepted.
 3. Stay in your lens. If you stray into other hunters' lanes (e.g., Tester writing security findings), dedup later eats your work.
 4. Do NOT suggest fixes longer than 1-2 lines. Issue authors decide the fix; you describe the bug.

--- a/.claude/commands/project-audit.md
+++ b/.claude/commands/project-audit.md
@@ -168,6 +168,7 @@ You are auditing a project from the lens of **{LENS}**.
 You MUST explore the codebase thoroughly. Read source files, configuration, tests, and documentation. Do NOT base your audit on file names alone.
 
 ### Exploration Strategy
+0. **Use repo-memory first to save tokens** (this repo has it, ~1,500 files pre-indexed): `get_project_map` for structure, `get_file_summary`/`batch_file_summaries` to scan files (~50 tokens each vs ~800 for a full Read), `search_by_purpose` to find files by concept, `get_dependency_graph` to trace impact. `Read` files in full only for exact implementation/control flow or when a summary returns `suggestFullRead: true`.
 1. Start with entry points: main files, index files, app entry, CLI entry
 2. Trace key flows end-to-end (at least 2-3 major flows)
 3. Read configuration and build files

--- a/.claude/commands/project-audit.md
+++ b/.claude/commands/project-audit.md
@@ -168,7 +168,7 @@ You are auditing a project from the lens of **{LENS}**.
 You MUST explore the codebase thoroughly. Read source files, configuration, tests, and documentation. Do NOT base your audit on file names alone.
 
 ### Exploration Strategy
-0. **Use repo-memory first to save tokens** (this repo has it, ~1,500 files pre-indexed): `get_project_map` for structure, `get_file_summary`/`batch_file_summaries` to scan files (~50 tokens each vs ~800 for a full Read), `search_by_purpose` to find files by concept, `get_dependency_graph` to trace impact. `Read` files in full only for exact implementation/control flow or when a summary returns `suggestFullRead: true`.
+0. **Use repo-memory first to save tokens** (this repo has it, ~1,500 files pre-indexed): `get_project_map` for structure, `get_file_summary`/`batch_file_summaries` to scan files (a fraction of a full Read each), `search_by_purpose` to find files by concept, `get_dependency_graph` to trace impact. `Read` files in full only for exact implementation/control flow or when a summary returns `suggestFullRead: true`.
 1. Start with entry points: main files, index files, app entry, CLI entry
 2. Trace key flows end-to-end (at least 2-3 major flows)
 3. Read configuration and build files

--- a/.claude/commands/recon.md
+++ b/.claude/commands/recon.md
@@ -103,7 +103,7 @@ You MUST read actual files. Do not infer from filenames alone.
 
 ## Exploration — use repo-memory to save tokens
 
-This repo has the **repo-memory** MCP (~1,500 files pre-indexed). Before you `Read` a file, call `get_file_summary` (or `batch_file_summaries` for several at once) — it returns exports/imports/purpose in ~50 tokens vs ~800 for a full Read. Use `search_by_purpose` to find files by concept instead of grepping, and `get_related_files`/`get_dependency_graph` to trace dependencies. Read the full file only when you need exact implementation, control flow, or to match code style — or when a summary returns `suggestFullRead: true`.
+This repo has the **repo-memory** MCP (~1,500 files pre-indexed). Before you `Read` a file, call `get_file_summary` (or `batch_file_summaries` for several at once) — it returns exports/imports/purpose for a fraction of a full Read. Use `search_by_purpose` to find files by concept instead of grepping, and `get_related_files`/`get_dependency_graph` to trace dependencies. Read the full file only when you need exact implementation, control flow, or to match code style — or when a summary returns `suggestFullRead: true`.
 
 ## Output (use these exact sections)
 

--- a/.claude/commands/recon.md
+++ b/.claude/commands/recon.md
@@ -101,6 +101,10 @@ You are reconning the following target so a future engineer (or agent) can start
 
 You MUST read actual files. Do not infer from filenames alone.
 
+## Exploration — use repo-memory to save tokens
+
+This repo has the **repo-memory** MCP (~1,500 files pre-indexed). Before you `Read` a file, call `get_file_summary` (or `batch_file_summaries` for several at once) — it returns exports/imports/purpose in ~50 tokens vs ~800 for a full Read. Use `search_by_purpose` to find files by concept instead of grepping, and `get_related_files`/`get_dependency_graph` to trace dependencies. Read the full file only when you need exact implementation, control flow, or to match code style — or when a summary returns `suggestFullRead: true`.
+
 ## Output (use these exact sections)
 
 ### One-Line Summary

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -8,12 +8,12 @@
 
 ## Repo-memory exploration protocol (cross-cutting)
 This repo has the `repo-memory` MCP (~1,500 files pre-indexed, AST summaries, warm cache via a `post-merge` hook). It is heavily underused. Any skill that **spawns code-exploring subagents or reads source heavily** must carry the exploration protocol so spawned agents (fresh context, don't inherit CLAUDE.md) actually use it:
-- Before `Read` → `get_file_summary` / `batch_file_summaries` (~50 tokens vs ~800).
+- Before `Read` → `get_file_summary` / `batch_file_summaries` (a fraction of a full Read).
 - Before grep → `search_by_purpose`; for impact/dependents → `get_related_files` / `get_dependency_graph`.
 - Full `Read` only for exact implementation/control flow, style matching, or when a summary returns `suggestFullRead: true`.
 - Tasks group (`create_task`/`mark_explored`) is **off** in chroxy's `.repo-memory.json` — do not reference those tools.
 
-Already wired inline (2026-06-12): `recon` (scout template), `bug-hunt` (hunter rules), `project-audit` (exploration strategy), `agent-review` (context gathering), plus the CLAUDE.md `## Repo Memory MCP` section. When re-installing/updating any of these, preserve the repo-memory block. Candidates not yet wired (covered by CLAUDE.md on the main thread): `check-pr`, `start-working`, `tackle-issues`, `full-review`.
+Already wired inline (2026-06-12): `recon` (scout template), `bug-hunt` (hunter rules), `project-audit` (exploration strategy), `agent-review` (context-gathering step + reviewer persona block), plus the CLAUDE.md `## Repo Memory MCP` section. When re-installing/updating any of these, preserve the repo-memory block. Candidates not yet wired (covered by CLAUDE.md on the main thread): `check-pr`, `start-working`, `tackle-issues`, `full-review`.
 
 ## Merge Gate
 - **Enabled:** Yes — branch protection requires conversation resolution (noted in check-pr line 15)

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -6,6 +6,15 @@
 - **Main branch:** main
 - **CI:** Copilot review + CodeQL ruleset
 
+## Repo-memory exploration protocol (cross-cutting)
+This repo has the `repo-memory` MCP (~1,500 files pre-indexed, AST summaries, warm cache via a `post-merge` hook). It is heavily underused. Any skill that **spawns code-exploring subagents or reads source heavily** must carry the exploration protocol so spawned agents (fresh context, don't inherit CLAUDE.md) actually use it:
+- Before `Read` → `get_file_summary` / `batch_file_summaries` (~50 tokens vs ~800).
+- Before grep → `search_by_purpose`; for impact/dependents → `get_related_files` / `get_dependency_graph`.
+- Full `Read` only for exact implementation/control flow, style matching, or when a summary returns `suggestFullRead: true`.
+- Tasks group (`create_task`/`mark_explored`) is **off** in chroxy's `.repo-memory.json` — do not reference those tools.
+
+Already wired inline (2026-06-12): `recon` (scout template), `bug-hunt` (hunter rules), `project-audit` (exploration strategy), `agent-review` (context gathering), plus the CLAUDE.md `## Repo Memory MCP` section. When re-installing/updating any of these, preserve the repo-memory block. Candidates not yet wired (covered by CLAUDE.md on the main thread): `check-pr`, `start-working`, `tackle-issues`, `full-review`.
+
 ## Merge Gate
 - **Enabled:** Yes — branch protection requires conversation resolution (noted in check-pr line 15)
 - See `generic/merge-gate.md` for the CLAUDE.md snippet

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -11,7 +11,7 @@ This repo has the `repo-memory` MCP (~1,500 files pre-indexed, AST summaries, wa
 - Before `Read` → `get_file_summary` / `batch_file_summaries` (a fraction of a full Read).
 - Before grep → `search_by_purpose`; for impact/dependents → `get_related_files` / `get_dependency_graph`.
 - Full `Read` only for exact implementation/control flow, style matching, or when a summary returns `suggestFullRead: true`.
-- Tasks group (`create_task`/`mark_explored`) is **off** in chroxy's `.repo-memory.json` — do not reference those tools.
+- Tasks group (`create_task`/`mark_explored`/`get_task_context`) is **off by default** and `.repo-memory.json` is gitignored (per-machine), so don't reference those tools unless you've confirmed the local config enables them — check `.repo-memory.json` if in doubt.
 
 Already wired inline (2026-06-12): `recon` (scout template), `bug-hunt` (hunter rules), `project-audit` (exploration strategy), `agent-review` (context-gathering step + reviewer persona block), plus the CLAUDE.md `## Repo Memory MCP` section. When re-installing/updating any of these, preserve the repo-memory block. Candidates not yet wired (covered by CLAUDE.md on the main thread): `check-pr`, `start-working`, `tackle-issues`, `full-review`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,22 @@ This keeps the app dependency-free (no debug menu, no URL scheme handler) and te
 
 ## Repo Memory MCP
 
-The `repo-memory` MCP is available. Prefer `get_file_summary` over `Read` when exploring code you won't edit — it returns cached summaries and saves tokens. Also available: `get_project_map`, `get_related_files`, `search_by_purpose`. Use `Read` when you need exact lines or plan to edit. When launching subagents, tell them repo-memory tools are available.
+This repo has the `repo-memory` MCP server configured, with ~1,500 files pre-indexed (AST summaries) and a `post-merge` hook that keeps the cache warm. Use it to avoid re-reading files and save tokens — it is heavily underused (the cache is warm but agents rarely call it).
+
+### Exploration protocol — try repo-memory before Read/grep
+
+- **Before you `Read` a file, call `get_file_summary`** — it returns exports, imports, purpose, and line count in ~50 tokens vs ~800 for the full file. Use `batch_file_summaries` for several related files at once (preferred over N× `get_file_summary`).
+- **Before you grep for a concept** (auth, validation, tunnel, pairing…), call `search_by_purpose`.
+- Use `get_related_files` to find what else to look at, and `get_dependency_graph` to trace imports/dependents (useful for review-impact checks).
+- `get_project_map` for structure/entry points at the start of a task; `get_changed_files` to see what moved since the last session.
+
+### When to Read the full file anyway
+
+Read the full file (not just the summary) when you need exact implementation details, control flow, or to write code that matches the file's style — or when a summary returns `suggestFullRead: true` (low-quality summary, read instead).
+
+### Subagents
+
+Spawned subagents get a fresh context and **do not inherit this guidance** — when a skill or prompt launches an exploration/review subagent, repeat the exploration protocol in that subagent's prompt (the exploration-heavy skills already do). `get_token_report` summarizes savings; the `repo-memory report` CLI reads the same data at zero token cost.
 
 ## Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,7 @@ This repo has the `repo-memory` MCP server configured, with ~1,500 files pre-ind
 
 ### Exploration protocol — try repo-memory before Read/grep
 
-- **Before you `Read` a file, call `get_file_summary`** — it returns exports, imports, purpose, and line count in ~50 tokens vs ~800 for the full file. Use `batch_file_summaries` for several related files at once (preferred over N× `get_file_summary`).
+- **Before you `Read` a file, call `get_file_summary`** — it returns exports, imports, purpose, and line count for a fraction of a full Read (a summary runs ~150–400 tokens; a full Read of a large file is several thousand). Use `batch_file_summaries` for several related files at once (preferred over N× `get_file_summary`).
 - **Before you grep for a concept** (auth, validation, tunnel, pairing…), call `search_by_purpose`.
 - Use `get_related_files` to find what else to look at, and `get_dependency_graph` to trace imports/dependents (useful for review-impact checks).
 - `get_project_map` for structure/entry points at the start of a task; `get_changed_files` to see what moved since the last session.


### PR DESCRIPTION
## What

Operationalizes the **repo-memory** MCP server, which is installed and warm (~1,500 files pre-indexed, AST summaries, `post-merge` prewarm hook) but near-unused: a usage scan found **22 repo-memory MCP calls vs ~17,800 `Read` calls** across recent sessions. The token-saving directive lived in a 3-line CLAUDE.md note that spawned subagents (fresh context) never see.

## Changes

- **CLAUDE.md** — replace the thin `## Repo Memory MCP` note with a concrete exploration protocol: `get_file_summary`/`batch_file_summaries` before `Read` (~50 tokens vs ~800), `search_by_purpose` before grep, `get_dependency_graph` for impact, explicit when-to-Read-full rules, and the `suggestFullRead` escape hatch. Adds a subagent note (spawned agents don't inherit CLAUDE.md).
- **Exploration skills** — add the protocol inline to each code-exploring **subagent prompt**, where the token spend actually happens:
  - `recon` — scout prompt template
  - `bug-hunt` — hunter rules
  - `project-audit` — agent exploration strategy
  - `agent-review` — context gathering (summaries + dependency graph for blast radius)
- **skill-profile.md** — record the cross-cutting protocol so future `/skill add`/`update` re-bakes it rather than overwriting the inline blocks.

## Notes

- The `tasks` group (`create_task`/`mark_explored`) is **off** in chroxy's `.repo-memory.json`, so those tools are intentionally not referenced.
- `check-pr` / `start-working` / `tackle-issues` / `full-review` are not wired inline (lighter, mostly main-thread reads) — they're covered by the CLAUDE.md change. Listed as candidates in skill-profile.md.
- Registry `skill-lint.sh` passes on all four edited skills (guards + version stamps intact).
- Docs-only / instruction-only change — no runtime code touched.

## Test plan

- [x] `skill-lint.sh` clean on recon / bug-hunt / project-audit / agent-review
- [ ] Spot-check a `/recon` or `/bug-hunt` run uses repo-memory summaries (manual, follow-up)