### PR TITLE
feat(5665): monthly programmatic-credit budget meter for CLI/SDK sessions

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -146,6 +146,8 @@ export function App() {
   )
   const defaultCwd = useConnectionStore(s => s.defaultCwd)
   const sessions = useConnectionStore(s => s.sessions)
+  // #5665 — machine-wide monthly programmatic-credit meter (sidebar token view).
+  const monthlyBudget = useConnectionStore(s => s.monthlyBudget)
   const sessionStates = useConnectionStore(s => s.sessionStates)
   const activeSessionId = useConnectionStore(s => s.activeSessionId)
   const viewMode = useConnectionStore(s => s.viewMode)
@@ -1715,6 +1717,7 @@ export function App() {
           searchConversations={searchConversations}
           clearSearchResults={clearSearchResults}
           sessions={sessions}
+          monthlyBudget={monthlyBudget}
           initialPanelHeight={loadPersistedSidebarPanelHeight() ?? 200}
           initialPanelView={loadPersistedSidebarPanelView()}
           initialPanelCollapsed={loadPersistedSidebarPanelCollapsed()}

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ import { ServerPicker } from './ServerPicker'
 import { ViewersIndicator } from './ViewersIndicator'
 import { SidebarPanelSlot, type SidebarPanelView, type SidebarPanelLauncher } from './SidebarPanelSlot'
 import { SidebarTokenView, tokenViewCollapsedMetric } from './SidebarTokenView'
-import type { SearchResult, ConnectedClient } from '../store/types'
+import type { SearchResult, ConnectedClient, MonthlyBudgetState } from '../store/types'
 import {
   persistSidebarPanelHeight,
   persistSidebarPanelView,
@@ -93,6 +93,9 @@ export interface SidebarProps {
   // #4303 — full sessions list (used by the bottom slot's token view).
   // Optional so existing tests + callers don't break; defaults to [].
   sessions?: SessionInfo[]
+  // #5665 — machine-wide monthly programmatic-credit meter snapshot, passed
+  // through to the token view. Optional; null/omitted → no meter.
+  monthlyBudget?: MonthlyBudgetState | null
   // #4303 — initial state for the bottom panel slot (loaded from
   // localStorage in App.tsx; defaults applied here).
   initialPanelHeight?: number
@@ -144,6 +147,7 @@ export function Sidebar({
   clearSearchResults,
   onWidthChange,
   sessions = [],
+  monthlyBudget = null,
   initialPanelHeight = 200,
   initialPanelView = null,
   initialPanelCollapsed = false,
@@ -201,6 +205,7 @@ export function Sidebar({
           sessions={sessions}
           activeSessionId={activeSessionId}
           onSessionClick={onSessionClick}
+          monthlyBudget={monthlyBudget}
         />
       ),
       collapsedHeaderMetric: () => tokenViewCollapsedMetric(sessions),
@@ -208,7 +213,7 @@ export function Sidebar({
     // #5176 (epic #5170) — the Control Room v1 sidebar panel was retired here;
     // the per-session activity tree now drills down inside the main-tab
     // ControlRoomSection (mapped repo → active session → activity tree).
-  ]), [sessions, activeSessionId, onSessionClick])
+  ]), [sessions, activeSessionId, onSessionClick, monthlyBudget])
 
   // #5200 — Control Room launcher in the slot header. The host/repo table is
   // wide, so the launcher opens it in the main content area (via

--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -200,6 +200,65 @@ describe('SidebarTokenView (#4303 v0)', () => {
     })
   })
 
+  describe('monthly credit meter (#5665)', () => {
+    const budget = (over = {}) => ({
+      month: '2026-06',
+      spentUsd: 23.45,
+      turnsBilled: 12,
+      budgetUsd: 100,
+      warningPercent: 80,
+      percent: 23.45,
+      warning: false,
+      exceeded: false,
+      ...over,
+    })
+
+    it('renders spend / cap / percent and a progress bar when a cap is configured', () => {
+      render(<SidebarTokenView sessions={[]} monthlyBudget={budget()} />)
+      const meter = screen.getByTestId('sidebar-token-view-credit-meter')
+      expect(meter).toHaveAttribute('data-meter-state', 'ok')
+      expect(screen.getByTestId('sidebar-token-view-credit-meter-value')).toHaveTextContent('$23.45 / $100.00 · 23%')
+      const fill = screen.getByTestId('sidebar-token-view-credit-bar-fill')
+      expect(fill).toHaveStyle({ width: '23.45%' })
+    })
+
+    it('marks the meter warning / exceeded via data-meter-state', () => {
+      const { rerender } = render(
+        <SidebarTokenView sessions={[]} monthlyBudget={budget({ percent: 88, warning: true })} />,
+      )
+      expect(screen.getByTestId('sidebar-token-view-credit-meter')).toHaveAttribute('data-meter-state', 'warning')
+      rerender(
+        <SidebarTokenView sessions={[]} monthlyBudget={budget({ spentUsd: 110, percent: 110, warning: true, exceeded: true })} />,
+      )
+      expect(screen.getByTestId('sidebar-token-view-credit-meter')).toHaveAttribute('data-meter-state', 'exceeded')
+      // Bar clamps at 100%.
+      expect(screen.getByTestId('sidebar-token-view-credit-bar-fill')).toHaveStyle({ width: '100%' })
+    })
+
+    it('shows spend without a bar when no cap is configured', () => {
+      render(
+        <SidebarTokenView
+          sessions={[]}
+          monthlyBudget={budget({ budgetUsd: null, percent: null, spentUsd: 8.2 })}
+        />,
+      )
+      expect(screen.getByTestId('sidebar-token-view-credit-meter-value')).toHaveTextContent('$8.20 this month')
+      expect(screen.queryByTestId('sidebar-token-view-credit-bar-fill')).toBeNull()
+    })
+
+    it('hides the meter when there is no budget snapshot', () => {
+      render(<SidebarTokenView sessions={[]} monthlyBudget={null} />)
+      expect(screen.queryByTestId('sidebar-token-view-credit-meter')).toBeNull()
+    })
+
+    it('hides the meter when there is no cap and no spend', () => {
+      render(
+        <SidebarTokenView sessions={[]} monthlyBudget={budget({ budgetUsd: null, percent: null, spentUsd: 0 })} />,
+      )
+      expect(screen.queryByTestId('sidebar-token-view-credit-meter')).toBeNull()
+    })
+  })
+
   describe('per-session breakdown', () => {
     it('lists tracked sessions sorted by tokens desc', () => {
       const sessions = [

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -23,6 +23,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { BillingClass, CumulativeUsage, SessionInfo } from '@chroxy/store-core'
 import { formatCostBadge, formatTokens, getProviderLabel } from '@chroxy/store-core'
+import type { MonthlyBudgetState } from '../store/types'
 
 // Subscription/PTY providers that never emit token usage today (decision #1).
 // claude-tui is the only one in this set right now; if upstream adds usage
@@ -418,12 +419,20 @@ export interface SidebarTokenViewProps {
    * the rows as static (no click affordance).
    */
   onSessionClick?: (sessionId: string) => void
+  /**
+   * #5665 — machine-wide monthly programmatic-credit meter snapshot. When
+   * present (and there's a cap or some spend), a "Credit spend (chroxy-observed)"
+   * meter renders. Omitted/null → no meter (pre-era, pre-#5665 server, or no
+   * programmatic-credit activity).
+   */
+  monthlyBudget?: MonthlyBudgetState | null
 }
 
 export function SidebarTokenView({
   sessions,
   activeSessionId = null,
   onSessionClick,
+  monthlyBudget = null,
 }: SidebarTokenViewProps) {
   const agg = useMemo(() => aggregateUsage(sessions), [sessions])
   const totalTokens = agg.totals.inputTokens + agg.totals.outputTokens
@@ -529,6 +538,59 @@ export function SidebarTokenView({
             </div>
           )
         })}
+
+        {/* #5665 — machine-wide monthly programmatic-credit meter. Shows once
+            there's a configured cap or some observed spend this month. */}
+        {monthlyBudget && (monthlyBudget.budgetUsd != null || monthlyBudget.spentUsd > 0) && (() => {
+          const { spentUsd, budgetUsd, percent, warning, exceeded } = monthlyBudget
+          const clampedPercent = percent == null ? null : Math.min(100, Math.max(0, percent))
+          const state = exceeded ? 'exceeded' : warning ? 'warning' : 'ok'
+          return (
+            <div
+              className={`sidebar-token-view-credit-meter sidebar-token-view-credit-meter-${state}`}
+              data-testid="sidebar-token-view-credit-meter"
+              data-meter-state={state}
+            >
+              <div className="sidebar-token-view-aggregate-row">
+                <span className="sidebar-token-view-label">
+                  Credit spend{' '}
+                  <InfoDisclosure
+                    triggerText={'ⓘ'}
+                    ariaLabel="What does the credit spend meter count?"
+                    triggerClassName="sidebar-token-view-info"
+                    testIdBase="sidebar-token-view-credit-meter-info"
+                  >
+                    Chroxy-observed programmatic-credit spend (claude -p / SDK) this UTC month — only sessions THIS daemon ran. Not your full Anthropic credit-pool balance; sessions on other machines or outside chroxy aren't counted.
+                  </InfoDisclosure>
+                </span>
+                <span
+                  className="sidebar-token-view-value-secondary"
+                  data-testid="sidebar-token-view-credit-meter-value"
+                >
+                  {budgetUsd != null
+                    ? `${formatCostBadge(spentUsd)} / ${formatCostBadge(budgetUsd)}${clampedPercent != null ? ` · ${Math.round(clampedPercent)}%` : ''}`
+                    : `${formatCostBadge(spentUsd)} this month`}
+                </span>
+              </div>
+              {budgetUsd != null && clampedPercent != null && (
+                <div
+                  className="sidebar-token-view-credit-bar"
+                  role="progressbar"
+                  aria-valuenow={Math.round(clampedPercent)}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label="Monthly credit spend"
+                >
+                  <div
+                    className="sidebar-token-view-credit-bar-fill"
+                    data-testid="sidebar-token-view-credit-bar-fill"
+                    style={{ width: `${clampedPercent}%` }}
+                  />
+                </div>
+              )}
+            </div>
+          )
+        })()}
       </div>
 
       <div className="sidebar-token-view-section" data-testid="sidebar-token-view-by-provider">

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -540,6 +540,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   serverErrors: [],
   infoNotifications: [],
   sessionNotifications: [],
+  // #5665 — machine-wide monthly programmatic-credit meter; populated by the
+  // server's `monthly_budget` event (on connect + after each billed turn).
+  monthlyBudget: null,
   sessionNotFoundError: null,
   resolvedPermissions: {},
   serverPhase: null,

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -284,6 +284,53 @@ describe('dashboard message-handler dispatch', () => {
       handleMessage({ type: 'monthly_budget', spentUsd: 5 }, ctx() as any)
       expect((store.getState() as any).monthlyBudget).toBeNull()
     })
+
+    it('fires a one-time info toast on a fresh warning crossing (justWarned)', () => {
+      store = createMockStore(baseState({ monthlyBudget: null }))
+      setStore(store)
+      handleMessage(
+        {
+          type: 'monthly_budget',
+          month: '2026-06',
+          spentUsd: 85, turnsBilled: 7, budgetUsd: 100,
+          warningPercent: 80, percent: 85, warning: true, exceeded: false,
+          justWarned: true, justExceeded: false,
+        },
+        ctx() as any,
+      )
+      const infos = (store.getState() as any)._infoNotifications as string[]
+      expect(infos.length).toBe(1)
+      expect(infos[0]!).toContain('85%')
+      expect(infos[0]!).toContain('$85.00 of $100.00')
+    })
+
+    it('fires the exceeded toast on justExceeded but not on a steady-state snapshot', () => {
+      store = createMockStore(baseState({ monthlyBudget: null }))
+      setStore(store)
+      // Steady-state snapshot (no crossing) → no toast.
+      handleMessage(
+        {
+          type: 'monthly_budget', month: '2026-06',
+          spentUsd: 50, turnsBilled: 3, budgetUsd: 100,
+          warningPercent: 80, percent: 50, warning: false, exceeded: false,
+        },
+        ctx() as any,
+      )
+      expect(((store.getState() as any)._infoNotifications as string[]).length).toBe(0)
+      // Fresh exceeded crossing → toast.
+      handleMessage(
+        {
+          type: 'monthly_budget', month: '2026-06',
+          spentUsd: 105, turnsBilled: 8, budgetUsd: 100,
+          warningPercent: 80, percent: 105, warning: true, exceeded: true,
+          justWarned: false, justExceeded: true,
+        },
+        ctx() as any,
+      )
+      const infos = (store.getState() as any)._infoNotifications as string[]
+      expect(infos.length).toBe(1)
+      expect(infos[0]!.toLowerCase()).toContain('exceeded')
+    })
   })
 
   describe('pair_fail dispatch (#5281 ③ PR 2)', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -223,6 +223,69 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('monthly_budget dispatch (#5665)', () => {
+    it('stores the latest monthly credit-meter snapshot', () => {
+      store = createMockStore(baseState({ monthlyBudget: null }))
+      setStore(store)
+      handleMessage(
+        {
+          type: 'monthly_budget',
+          month: '2026-06',
+          spentUsd: 23.45,
+          turnsBilled: 12,
+          budgetUsd: 100,
+          warningPercent: 80,
+          percent: 23.45,
+          warning: false,
+          exceeded: false,
+          justWarned: false,
+          justExceeded: false,
+        },
+        ctx() as any,
+      )
+      expect((store.getState() as any).monthlyBudget).toEqual({
+        month: '2026-06',
+        spentUsd: 23.45,
+        turnsBilled: 12,
+        budgetUsd: 100,
+        warningPercent: 80,
+        percent: 23.45,
+        warning: false,
+        exceeded: false,
+      })
+    })
+
+    it('preserves a null cap / percent (no tier configured)', () => {
+      store = createMockStore(baseState({ monthlyBudget: null }))
+      setStore(store)
+      handleMessage(
+        {
+          type: 'monthly_budget',
+          month: '2026-06',
+          spentUsd: 8.2,
+          turnsBilled: 3,
+          budgetUsd: null,
+          warningPercent: 80,
+          percent: null,
+          warning: false,
+          exceeded: false,
+        },
+        ctx() as any,
+      )
+      const mb = (store.getState() as any).monthlyBudget
+      expect(mb.budgetUsd).toBeNull()
+      expect(mb.percent).toBeNull()
+      expect(mb.spentUsd).toBe(8.2)
+    })
+
+    it('ignores a malformed snapshot with no month', () => {
+      store = createMockStore(baseState({ monthlyBudget: null }))
+      setStore(store)
+      handleMessage({ type: 'monthly_budget', spentUsd: 5 }, ctx() as any)
+      expect((store.getState() as any).monthlyBudget).toBeNull()
+    })
+  })
+
   describe('pair_fail dispatch (#5281 ③ PR 2)', () => {
     it('removes the optimistic tokenless entry and alerts', () => {
       store = createMockStore(baseState({

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -3103,25 +3103,41 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'monthly_budget': {
       // #5665 — machine-wide monthly programmatic-credit meter snapshot/event.
       // Sent on connect and after each programmatic-credit-billed turn. Store
-      // the latest snapshot; the one-shot justWarned/justExceeded flags drive
-      // notifications elsewhere and are not persisted in store state.
+      // the latest snapshot for the sidebar meter, and fire a one-time info
+      // toast when the server reports a fresh threshold crossing
+      // (justWarned/justExceeded — latched once per month server-side, so the
+      // toast never spams turn-over-turn while over the threshold).
       const month = typeof msg.month === 'string' ? msg.month : null;
       if (month) {
         const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
         const numOrNull = (v: unknown): number | null =>
           v === null ? null : typeof v === 'number' && Number.isFinite(v) ? v : null;
+        const spentUsd = num(msg.spentUsd);
+        const budgetUsd = numOrNull(msg.budgetUsd);
         getStore().setState({
           monthlyBudget: {
             month,
-            spentUsd: num(msg.spentUsd),
+            spentUsd,
             turnsBilled: num(msg.turnsBilled),
-            budgetUsd: numOrNull(msg.budgetUsd),
+            budgetUsd,
             warningPercent: num(msg.warningPercent),
             percent: numOrNull(msg.percent),
             warning: msg.warning === true,
             exceeded: msg.exceeded === true,
           },
         });
+        const cap = budgetUsd != null ? `$${budgetUsd.toFixed(2)}` : '';
+        const spent = `$${spentUsd.toFixed(2)}`;
+        if (msg.justExceeded === true) {
+          get().addInfoNotification(
+            `Monthly programmatic-credit budget exceeded — ${spent}${cap ? ` of ${cap}` : ''} of your credit pool spent this month (chroxy-observed).`,
+          );
+        } else if (msg.justWarned === true) {
+          const pct = numOrNull(msg.percent);
+          get().addInfoNotification(
+            `Monthly credit budget at ${pct != null ? `${Math.round(pct)}%` : 'the warning threshold'} — ${spent}${cap ? ` of ${cap}` : ''} spent this month (chroxy-observed).`,
+          );
+        }
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -3100,6 +3100,32 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'monthly_budget': {
+      // #5665 — machine-wide monthly programmatic-credit meter snapshot/event.
+      // Sent on connect and after each programmatic-credit-billed turn. Store
+      // the latest snapshot; the one-shot justWarned/justExceeded flags drive
+      // notifications elsewhere and are not persisted in store state.
+      const month = typeof msg.month === 'string' ? msg.month : null;
+      if (month) {
+        const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+        const numOrNull = (v: unknown): number | null =>
+          v === null ? null : typeof v === 'number' && Number.isFinite(v) ? v : null;
+        getStore().setState({
+          monthlyBudget: {
+            month,
+            spentUsd: num(msg.spentUsd),
+            turnsBilled: num(msg.turnsBilled),
+            budgetUsd: numOrNull(msg.budgetUsd),
+            warningPercent: num(msg.warningPercent),
+            percent: numOrNull(msg.percent),
+            warning: msg.warning === true,
+            exceeded: msg.exceeded === true,
+          },
+        });
+      }
+      break;
+    }
+
     case 'session_activity': {
       // #4639: server-emitted busy/idle broadcast (ws-forwarding.js fires it
       // on stream_start and result for every session, to every authenticated

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -311,6 +311,23 @@ export interface EvaluatorResultPayload {
   error?: { code: string; message: string; status?: number };
 }
 
+/**
+ * #5665 — machine-wide monthly programmatic-credit budget meter snapshot.
+ * Mirrors the server's `monthly_budget` wire payload (minus the one-shot
+ * justWarned/justExceeded crossing flags). `budgetUsd`/`percent` are null when
+ * no cap is configured (chroxy can't detect the plan tier).
+ */
+export interface MonthlyBudgetState {
+  month: string; // "YYYY-MM" (UTC)
+  spentUsd: number;
+  turnsBilled: number;
+  budgetUsd: number | null;
+  warningPercent: number;
+  percent: number | null;
+  warning: boolean;
+  exceeded: boolean;
+}
+
 export interface SessionNotification {
   id: string;
   sessionId: string;
@@ -782,6 +799,12 @@ export interface ConnectionState {
 
   // Background session notifications (permission, question, completed, error)
   sessionNotifications: SessionNotification[];
+
+  // #5665 — machine-wide monthly programmatic-credit budget meter snapshot,
+  // set from the server's `monthly_budget` event (sent on connect and after
+  // each programmatic-credit-billed turn). null until the first one arrives or
+  // when the server predates the feature.
+  monthlyBudget: MonthlyBudgetState | null;
 
   // #4982 — set when the server emits `session_error{code:'SESSION_NOT_FOUND'}`.
   // Activated by message-handler.ts:case 'session_error' on the

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1047,6 +1047,40 @@
   align-items: baseline;
 }
 
+/* #5665 — monthly programmatic-credit meter. */
+.sidebar-token-view-credit-meter {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+}
+
+.sidebar-token-view-credit-bar {
+  margin-top: 4px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.10);
+  overflow: hidden;
+}
+
+.sidebar-token-view-credit-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent-purple, #8b7fd6);
+  transition: width 0.3s ease;
+}
+
+.sidebar-token-view-credit-meter-warning .sidebar-token-view-credit-bar-fill {
+  background: var(--accent-orange, #e0a458);
+}
+
+.sidebar-token-view-credit-meter-exceeded .sidebar-token-view-credit-bar-fill {
+  background: var(--accent-red, #d6685f);
+}
+
+.sidebar-token-view-credit-meter-exceeded .sidebar-token-view-value-secondary {
+  color: var(--accent-red, #d6685f);
+}
+
 .sidebar-token-view-label {
   color: var(--text-muted);
   font-size: 11px;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -2124,6 +2124,19 @@ export declare const ServerBudgetExceededSchema: z.ZodObject<{
     percent: z.ZodNumber;
     message: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerMonthlyBudgetSchema: z.ZodObject<{
+    type: z.ZodLiteral<"monthly_budget">;
+    month: z.ZodString;
+    spentUsd: z.ZodNumber;
+    turnsBilled: z.ZodNumber;
+    budgetUsd: z.ZodNullable<z.ZodNumber>;
+    warningPercent: z.ZodNumber;
+    percent: z.ZodNullable<z.ZodNumber>;
+    warning: z.ZodBoolean;
+    exceeded: z.ZodBoolean;
+    justWarned: z.ZodOptional<z.ZodBoolean>;
+    justExceeded: z.ZodOptional<z.ZodBoolean>;
+}, z.core.$strip>;
 export declare const ServerWebFeatureStatusSchema: z.ZodObject<{
     type: z.ZodLiteral<"web_feature_status">;
     available: z.ZodBoolean;
@@ -2275,6 +2288,7 @@ export type CumulativeUsage = z.infer<typeof CumulativeUsageSchema>;
 export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>;
 export type ServerSessionStoppedMessage = z.infer<typeof ServerSessionStoppedSchema>;
 export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>;
+export type ServerMonthlyBudgetMessage = z.infer<typeof ServerMonthlyBudgetSchema>;
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;
 export type ServerAuthBootstrapMessage = z.infer<typeof ServerAuthBootstrapSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -2116,6 +2116,25 @@ export const ServerBudgetExceededSchema = z.object({
     percent: z.number(),
     message: z.string(),
 });
+// #5665: machine-wide monthly programmatic-credit budget meter. Broadcast to
+// ALL clients after each programmatic-credit-billed turn, and sent once on
+// connect as a snapshot. `budgetUsd`/`percent` are null when no cap is
+// configured (chroxy can't detect the plan tier). `justWarned`/`justExceeded`
+// mark one-shot threshold crossings on the live event and are omitted from the
+// on-connect snapshot.
+export const ServerMonthlyBudgetSchema = z.object({
+    type: z.literal('monthly_budget'),
+    month: z.string(), // "YYYY-MM" (UTC calendar month)
+    spentUsd: z.number().finite().nonnegative(),
+    turnsBilled: z.number().int().nonnegative(),
+    budgetUsd: z.number().finite().nonnegative().nullable(),
+    warningPercent: z.number().finite(),
+    percent: z.number().finite().nullable(),
+    warning: z.boolean(),
+    exceeded: z.boolean(),
+    justWarned: z.boolean().optional(),
+    justExceeded: z.boolean().optional(),
+});
 // -- Web task schemas --
 const WebTaskSchema = z.object({
     taskId: z.string(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -2247,6 +2247,26 @@ export const ServerBudgetExceededSchema = z.object({
   message: z.string(),
 })
 
+// #5665: machine-wide monthly programmatic-credit budget meter. Broadcast to
+// ALL clients after each programmatic-credit-billed turn, and sent once on
+// connect as a snapshot. `budgetUsd`/`percent` are null when no cap is
+// configured (chroxy can't detect the plan tier). `justWarned`/`justExceeded`
+// mark one-shot threshold crossings on the live event and are omitted from the
+// on-connect snapshot.
+export const ServerMonthlyBudgetSchema = z.object({
+  type: z.literal('monthly_budget'),
+  month: z.string(), // "YYYY-MM" (UTC calendar month)
+  spentUsd: z.number().finite().nonnegative(),
+  turnsBilled: z.number().int().nonnegative(),
+  budgetUsd: z.number().finite().nonnegative().nullable(),
+  warningPercent: z.number().finite(),
+  percent: z.number().finite().nullable(),
+  warning: z.boolean(),
+  exceeded: z.boolean(),
+  justWarned: z.boolean().optional(),
+  justExceeded: z.boolean().optional(),
+})
+
 // -- Web task schemas --
 
 const WebTaskSchema = z.object({
@@ -2447,6 +2467,8 @@ export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>
 // #4756: typed alias for the user-initiated Stop confirmation broadcast.
 export type ServerSessionStoppedMessage = z.infer<typeof ServerSessionStoppedSchema>
 export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>
+// #5665: machine-wide monthly programmatic-credit meter snapshot/event.
+export type ServerMonthlyBudgetMessage = z.infer<typeof ServerMonthlyBudgetSchema>
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>
 export type ServerAuthBootstrapMessage = z.infer<typeof ServerAuthBootstrapSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -105,6 +105,7 @@ const PLATFORM_SPECIFIC = {
   'pairing_refreshed': 'dashboard',  // QR display and auto-refresh is dashboard-only (#2916)
   'pair_pending': 'dashboard',       // #5510 pairing-approval primitive — host-level approval banner fan-out is dashboard-only for v1 (the mobile app has no approve surface yet); mobile/desktop-tray approve is an explicit out-of-scope fast-follow per epic #5509
   'pair_resolved': 'dashboard',      // #5510 pairing-approval primitive — banner retraction pairs with pair_pending; dashboard-only for v1, mobile parity deferred per epic #5509
+  'monthly_budget': 'dashboard',     // #5665 monthly programmatic-credit meter renders in the dashboard sidebar; mobile parity tracked as a follow-up
   'log_entry': 'dashboard',          // console page is dashboard-only
   'file_list': 'dashboard',          // file explorer sidebar is dashboard-only
   'environment_created': 'dashboard', // environment panel is dashboard-only

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -1620,6 +1620,54 @@ describe('@chroxy/protocol schemas', () => {
       assert.ok(result.success)
     })
 
+    it('ServerMonthlyBudgetSchema validates the live event (with crossing flags) and the snapshot (#5665)', async () => {
+      const { ServerMonthlyBudgetSchema } = await import('../src/schemas/server.ts')
+      // Live event after a billed turn — includes the one-shot crossing flags.
+      const live = ServerMonthlyBudgetSchema.safeParse({
+        type: 'monthly_budget',
+        month: '2026-06',
+        spentUsd: 17,
+        turnsBilled: 4,
+        budgetUsd: 20,
+        warningPercent: 80,
+        percent: 85,
+        warning: true,
+        exceeded: false,
+        justWarned: true,
+        justExceeded: false,
+      })
+      assert.ok(live.success)
+      // On-connect snapshot — crossing flags omitted.
+      const snapshot = ServerMonthlyBudgetSchema.safeParse({
+        type: 'monthly_budget',
+        month: '2026-06',
+        spentUsd: 0,
+        turnsBilled: 0,
+        budgetUsd: 20,
+        warningPercent: 80,
+        percent: 0,
+        warning: false,
+        exceeded: false,
+      })
+      assert.ok(snapshot.success)
+    })
+
+    it('ServerMonthlyBudgetSchema permits a null cap / percent when no tier is configured (#5665)', async () => {
+      const { ServerMonthlyBudgetSchema } = await import('../src/schemas/server.ts')
+      const result = ServerMonthlyBudgetSchema.safeParse({
+        type: 'monthly_budget',
+        month: '2026-06',
+        spentUsd: 42,
+        turnsBilled: 9,
+        budgetUsd: null,
+        warningPercent: 80,
+        percent: null,
+        warning: false,
+        exceeded: false,
+      })
+      assert.ok(result.success)
+    })
+
     it('ServerSessionCostThresholdCrossedSchema validates the threshold-crossed payload', async () => {
       const { ServerSessionCostThresholdCrossedSchema } = await import('../src/schemas/server.ts')
       const result = ServerSessionCostThresholdCrossedSchema.safeParse({

--- a/packages/server/src/billing-budget.js
+++ b/packages/server/src/billing-budget.js
@@ -45,7 +45,10 @@ export function monthKeyUtc(now = Date.now()) {
  */
 export function resolveMonthlyCreditBudgetUsd(billingConfig = {}) {
   const override = billingConfig?.monthlyCreditBudgetUsd
-  if (Number.isFinite(override) && override >= 0) return override
+  // Require a POSITIVE override. `0` is treated as "no override" (fall through
+  // to the tier preset / null) rather than a real $0 cap — a $0 cap would
+  // render a permanently-"exceeded" $0/$0 meter the moment any session billed.
+  if (Number.isFinite(override) && override > 0) return override
   const tier = billingConfig?.creditTier
   if (typeof tier === 'string' && Object.prototype.hasOwnProperty.call(CREDIT_TIER_BUDGETS_USD, tier)) {
     return CREDIT_TIER_BUDGETS_USD[tier]
@@ -137,7 +140,11 @@ export class MonthlyProgrammaticBudgetManager {
   recordSpend(costUsd, now = Date.now()) {
     this._rollIfNeeded(now)
     if (Number.isFinite(costUsd)) {
-      this._state.spentUsd += costUsd
+      // Floor the running total at 0: a refund/credit turn (#4099, signed cost)
+      // reduces this month's spend but can never carry a NEGATIVE balance into
+      // later turns (which would silently mask subsequent real spend). "Spend
+      // this month" is a non-negative quantity.
+      this._state.spentUsd = Math.max(0, this._state.spentUsd + costUsd)
       this._state.turnsBilled += 1
     }
     const status = this.getStatus(now)

--- a/packages/server/src/billing-budget.js
+++ b/packages/server/src/billing-budget.js
@@ -15,7 +15,7 @@
 //   billing.monthlyCreditBudgetUsd raw USD override (wins over the tier preset)
 //   billing.budgetWarningPercent   warn threshold (default 80)
 
-import { readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs'
+import { readFileSync, writeFileSync, renameSync, mkdirSync, rmSync } from 'node:fs'
 import { dirname } from 'node:path'
 
 /** Per-tier monthly programmatic-credit caps (USD), per Anthropic's 2026-06-15 change. */
@@ -113,13 +113,17 @@ export class MonthlyProgrammaticBudgetManager {
 
   _save() {
     if (!this._statePath) return
+    const tmp = `${this._statePath}.tmp`
     try {
       mkdirSync(dirname(this._statePath), { recursive: true })
-      const tmp = `${this._statePath}.tmp`
       writeFileSync(tmp, JSON.stringify(this._state), 'utf8')
       renameSync(tmp, this._statePath)
     } catch {
       // Persistence is best-effort; a write failure must not break the turn.
+      // Clean up the temp file so a failed rename can't orphan a `.tmp` next
+      // to the state file (which would also block the atomic-write contract on
+      // the next save). Best-effort — ignore if it's already gone.
+      try { rmSync(tmp, { force: true }) } catch { /* ignore */ }
     }
   }
 

--- a/packages/server/src/billing-budget.js
+++ b/packages/server/src/billing-budget.js
@@ -1,0 +1,180 @@
+// #5665 — monthly programmatic-credit budget meter.
+//
+// As of 2026-06-15, `claude -p` (CLI) and the Agent SDK draw from a separate
+// monthly programmatic-usage credit pool (billed at API rates, refreshing
+// monthly with no rollover). This module tracks the *chroxy-observed* spend
+// against that pool: the sum of `programmatic-credit`-billed session cost this
+// daemon has seen in the current UTC calendar month, versus a configured cap.
+//
+// IMPORTANT — this is chroxy-observed, NOT an authoritative Anthropic balance.
+// It only counts sessions THIS daemon ran; sessions on other machines or
+// outside chroxy are invisible to it. The dashboard surfaces that caveat.
+//
+// The cap is configured (chroxy cannot detect the user's plan tier):
+//   billing.creditTier             pro | max5x | max20x  -> $20 / $100 / $200
+//   billing.monthlyCreditBudgetUsd raw USD override (wins over the tier preset)
+//   billing.budgetWarningPercent   warn threshold (default 80)
+
+import { readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+/** Per-tier monthly programmatic-credit caps (USD), per Anthropic's 2026-06-15 change. */
+export const CREDIT_TIER_BUDGETS_USD = Object.freeze({
+  pro: 20,
+  max5x: 100,
+  max20x: 200,
+})
+
+export const DEFAULT_BUDGET_WARNING_PERCENT = 80
+
+/**
+ * UTC calendar-month key, "YYYY-MM". The reset boundary matches the era
+ * boundary's timezone semantics (billing-class.js uses Date.UTC).
+ */
+export function monthKeyUtc(now = Date.now()) {
+  const d = new Date(now)
+  const y = d.getUTCFullYear()
+  const m = d.getUTCMonth() + 1
+  return `${y}-${m < 10 ? '0' : ''}${m}`
+}
+
+/**
+ * Resolve the configured monthly cap in USD. The raw override wins; otherwise
+ * a recognised tier preset; otherwise null — "no cap configured", in which case
+ * the meter reports spend with no percentage/warning (chroxy can't guess it).
+ */
+export function resolveMonthlyCreditBudgetUsd(billingConfig = {}) {
+  const override = billingConfig?.monthlyCreditBudgetUsd
+  if (Number.isFinite(override) && override >= 0) return override
+  const tier = billingConfig?.creditTier
+  if (typeof tier === 'string' && Object.prototype.hasOwnProperty.call(CREDIT_TIER_BUDGETS_USD, tier)) {
+    return CREDIT_TIER_BUDGETS_USD[tier]
+  }
+  return null
+}
+
+/** Resolve the warning threshold percent (1–100), defaulting to 80. */
+export function resolveWarningPercent(billingConfig = {}) {
+  const p = billingConfig?.budgetWarningPercent
+  if (Number.isFinite(p) && p > 0 && p <= 100) return p
+  return DEFAULT_BUDGET_WARNING_PERCENT
+}
+
+/**
+ * Tracks chroxy-observed programmatic-credit spend for the current UTC month
+ * against a configured cap. The cap/warning come from config (stable per
+ * process); only the running spend total is persisted, so changing tier
+ * mid-month re-evaluates the percentage against the new cap on restart.
+ */
+export class MonthlyProgrammaticBudgetManager {
+  /**
+   * @param {object}  opts
+   * @param {object}  [opts.billingConfig]  the `billing` config block
+   * @param {string|null} [opts.statePath]  JSON file for the running total;
+   *   null keeps it in-memory only (tests / no-persist). Production points it
+   *   next to the session-state file so a temp stateFilePath redirects it out
+   *   of the real ~/.chroxy (test-sandbox safe).
+   * @param {number} [opts.now]             injected clock for determinism
+   */
+  constructor({ billingConfig = {}, statePath = null, now = Date.now() } = {}) {
+    this._budgetUsd = resolveMonthlyCreditBudgetUsd(billingConfig)
+    this._warningPercent = resolveWarningPercent(billingConfig)
+    this._statePath = statePath || null
+    this._state = { month: monthKeyUtc(now), spentUsd: 0, turnsBilled: 0, warnNotified: false, exceededNotified: false }
+    this._load()
+    this._rollIfNeeded(now)
+  }
+
+  /** True iff a cap is configured (tier or override). */
+  get hasBudget() {
+    return this._budgetUsd != null
+  }
+
+  _load() {
+    if (!this._statePath) return
+    try {
+      const raw = JSON.parse(readFileSync(this._statePath, 'utf8'))
+      if (raw && typeof raw === 'object' && typeof raw.month === 'string') {
+        this._state = {
+          month: raw.month,
+          spentUsd: Number.isFinite(raw.spentUsd) ? raw.spentUsd : 0,
+          turnsBilled: Number.isFinite(raw.turnsBilled) && raw.turnsBilled >= 0 ? raw.turnsBilled : 0,
+          warnNotified: raw.warnNotified === true,
+          exceededNotified: raw.exceededNotified === true,
+        }
+      }
+    } catch {
+      // Missing / malformed file → start fresh (already initialised in ctor).
+    }
+  }
+
+  _save() {
+    if (!this._statePath) return
+    try {
+      mkdirSync(dirname(this._statePath), { recursive: true })
+      const tmp = `${this._statePath}.tmp`
+      writeFileSync(tmp, JSON.stringify(this._state), 'utf8')
+      renameSync(tmp, this._statePath)
+    } catch {
+      // Persistence is best-effort; a write failure must not break the turn.
+    }
+  }
+
+  /** Reset the running total when the UTC month rolls over. */
+  _rollIfNeeded(now) {
+    const key = monthKeyUtc(now)
+    if (this._state.month !== key) {
+      this._state = { month: key, spentUsd: 0, turnsBilled: 0, warnNotified: false, exceededNotified: false }
+      this._save()
+    }
+  }
+
+  /**
+   * Record a programmatic-credit turn's cost. Callers MUST gate on
+   * billingClass === 'programmatic-credit' — this manager does not re-check it.
+   * @returns {{ status: object, justWarned: boolean, justExceeded: boolean }}
+   */
+  recordSpend(costUsd, now = Date.now()) {
+    this._rollIfNeeded(now)
+    if (Number.isFinite(costUsd)) {
+      this._state.spentUsd += costUsd
+      this._state.turnsBilled += 1
+    }
+    const status = this.getStatus(now)
+    let justWarned = false
+    let justExceeded = false
+    if (status.warning && !this._state.warnNotified) {
+      this._state.warnNotified = true
+      justWarned = true
+    }
+    if (status.exceeded && !this._state.exceededNotified) {
+      this._state.exceededNotified = true
+      justExceeded = true
+    }
+    this._save()
+    return { status, justWarned, justExceeded }
+  }
+
+  /**
+   * Current meter snapshot. `spentUsd` floors at 0 (a refund turn can drive the
+   * raw total negative; a negative pool reading would be nonsense to surface).
+   */
+  getStatus(now = Date.now()) {
+    this._rollIfNeeded(now)
+    const spentUsd = Math.max(0, this._state.spentUsd)
+    const budgetUsd = this._budgetUsd
+    const percent = budgetUsd != null && budgetUsd > 0 ? (spentUsd / budgetUsd) * 100 : null
+    const warning = percent != null && percent >= this._warningPercent
+    const exceeded = budgetUsd != null && spentUsd >= budgetUsd
+    return {
+      month: this._state.month,
+      spentUsd,
+      turnsBilled: this._state.turnsBilled,
+      budgetUsd,
+      warningPercent: this._warningPercent,
+      percent,
+      warning,
+      exceeded,
+    }
+  }
+}

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -449,7 +449,12 @@ const MAX_DISCORD_COLOR = 16777215
  */
 /**
  * #5665: validate the `billing` block (monthly programmatic-credit budget
- * meter). Warn-only — never escalate to a fatal "Invalid type" error.
+ * meter). Per-FIELD problems (bad creditTier, out-of-range numbers) are
+ * "Invalid value" warnings — non-fatal, the meter clamps/ignores at runtime.
+ * A gross top-level non-object value additionally trips the generic
+ * `billing: 'object'` schema check ("Invalid type", fatal), matching the
+ * `notifications` / `environments` object blocks — a billing block that isn't
+ * even an object is a real misconfiguration worth failing fast on.
  */
 function validateBillingBlock(billing, warnings) {
   if (typeof billing !== 'object' || billing === null || Array.isArray(billing)) {
@@ -841,7 +846,7 @@ export function validateConfig(config, verbose = false) {
   // loadAndMergeConfig "Invalid type" escalation — the sink clamps bad
   // values to its defaults at runtime.
   // #5665: validate the `billing` block (monthly programmatic-credit meter).
-  // Warn-only — a cosmetic typo must never stop the daemon from booting.
+  // Per-field typos are warn-only "Invalid value"; see validateBillingBlock.
   if (config.billing !== undefined) {
     validateBillingBlock(config.billing, warnings)
   }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -86,6 +86,11 @@ const CONFIG_SCHEMA = {
   tokenExpiry: 'string',
   sessionTimeout: 'string',
   costBudget: 'number',
+  // #5665: monthly programmatic-credit budget meter config. Nested object:
+  //   billing.creditTier             pro | max5x | max20x
+  //   billing.monthlyCreditBudgetUsd raw USD cap (wins over the tier preset)
+  //   billing.budgetWarningPercent   warn threshold 1-100 (default 80)
+  billing: 'object',
   externalUrl: 'string',
   repos: 'array',
   // #5172 (Control Room v2): filesystem root the Host Status survey scans
@@ -442,6 +447,35 @@ const MAX_DISCORD_COLOR = 16777215
  * @param {*} discord - The `notifications.discord` value
  * @param {string[]} warnings - Accumulator the caller logs/returns
  */
+/**
+ * #5665: validate the `billing` block (monthly programmatic-credit budget
+ * meter). Warn-only — never escalate to a fatal "Invalid type" error.
+ */
+function validateBillingBlock(billing, warnings) {
+  if (typeof billing !== 'object' || billing === null || Array.isArray(billing)) {
+    warnings.push(`Invalid value for 'billing': expected object, got ${Array.isArray(billing) ? 'array' : typeof billing}`)
+    return
+  }
+  const VALID_TIERS = ['pro', 'max5x', 'max20x']
+  if (Object.prototype.hasOwnProperty.call(billing, 'creditTier')) {
+    if (typeof billing.creditTier !== 'string' || !VALID_TIERS.includes(billing.creditTier)) {
+      warnings.push(`Invalid value for 'billing.creditTier': expected one of ${VALID_TIERS.join(' | ')}, got ${JSON.stringify(billing.creditTier)}`)
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(billing, 'monthlyCreditBudgetUsd')) {
+    const v = billing.monthlyCreditBudgetUsd
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+      warnings.push(`Invalid value for 'billing.monthlyCreditBudgetUsd': expected a number >= 0, got ${JSON.stringify(v)}`)
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(billing, 'budgetWarningPercent')) {
+    const v = billing.budgetWarningPercent
+    if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0 || v > 100) {
+      warnings.push(`Invalid value for 'billing.budgetWarningPercent': expected a number 1-100, got ${JSON.stringify(v)}`)
+    }
+  }
+}
+
 function validateDiscordNotificationsBlock(discord, warnings) {
   if (typeof discord !== 'object' || discord === null || Array.isArray(discord)) {
     warnings.push(`Invalid value for 'notifications.discord': expected object, got ${Array.isArray(discord) ? 'array' : typeof discord}`)
@@ -806,6 +840,12 @@ export function validateConfig(config, verbose = false) {
   // typo in a cosmetic color can never become a fatal startup error via the
   // loadAndMergeConfig "Invalid type" escalation — the sink clamps bad
   // values to its defaults at runtime.
+  // #5665: validate the `billing` block (monthly programmatic-credit meter).
+  // Warn-only — a cosmetic typo must never stop the daemon from booting.
+  if (config.billing !== undefined) {
+    validateBillingBlock(config.billing, warnings)
+  }
+
   if (config.notifications !== undefined) {
     if (typeof config.notifications !== 'object' || config.notifications === null || Array.isArray(config.notifications)) {
       // "Invalid value", NOT "Invalid type" — loadAndMergeConfig escalates

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -635,6 +635,8 @@ export async function startCliServer(config) {
     sessionTimeout: config.sessionTimeout || null,
     sandbox: config.sandbox || null,
     costBudget: config.costBudget || null,
+    // #5665: monthly programmatic-credit budget meter config.
+    billing: config.billing || null,
     maxMessages: config.maxMessages || config.maxHistory || null,
     // #3749 / #3884 / #3899: SOFT-warning inactivity timeout (ms). null = BaseSession default (30 min).
     // #3899: HARD-cap inactivity timeout (ms). null = BaseSession default (2h).

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -6,7 +6,8 @@ import { homedir } from 'os'
 import { execFileSync } from 'child_process'
 import { getProvider, getProviderAuthInfo } from './providers.js'
 import { isClaudeProvider } from './models.js'
-import { billingClassForProvider } from './billing-class.js'
+import { billingClassForProvider, BILLING_CLASSES } from './billing-class.js'
+import { MonthlyProgrammaticBudgetManager } from './billing-budget.js'
 import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderCredentialMissingError } from './utils/preflight.js'
 import { GIT } from './git.js'
 import { resolveJsonlPath, readConversationHistoryAsync } from './jsonl-reader.js'
@@ -212,6 +213,9 @@ export class SessionManager extends EventEmitter {
     // passing null/undefined/NaN/Infinity/negative, falls back to the
     // 5.00 default (see _normalizeCostThreshold).
     costThresholdUsd,
+    // #5665: the `billing` config block (creditTier / monthlyCreditBudgetUsd /
+    // budgetWarningPercent) driving the monthly programmatic-credit meter.
+    billing,
     maxSkillBytes,
     maxTotalSkillBytes,
     providerSkillAllowlist,
@@ -415,6 +419,14 @@ export class SessionManager extends EventEmitter {
     // with a temp stateFilePath.
     this.skillsUsageRecorder = skillsUsageRecorder
       || new SkillsUsageRecorder({ filePath: join(dirname(this._stateFilePath), 'skills-usage.json') })
+    // #5665: monthly programmatic-credit budget meter. Its running-total state
+    // file sits next to the session-state file (same temp-redirect reasoning as
+    // skillsUsageRecorder), so a test's temp stateFilePath keeps it out of the
+    // real ~/.chroxy and the sandbox guard never fires.
+    this._creditBudget = new MonthlyProgrammaticBudgetManager({
+      billingConfig: billing || {},
+      statePath: join(dirname(this._stateFilePath), 'monthly-budget-state.json'),
+    })
     // #5553: per-repo session-preset trust ledger. Same temp-redirect logic as
     // skillsUsageRecorder — the default file sits next to the session-state
     // file so a test's temp stateFilePath keeps the ledger out of the real home.
@@ -2340,6 +2352,16 @@ export class SessionManager extends EventEmitter {
    * @param {string} sessionId
    * @param {{ usage?: object, cost?: number }} resultData
    */
+  /**
+   * #5665: current monthly programmatic-credit meter snapshot (machine-wide).
+   * Sent to a client on connect so a freshly-loaded dashboard shows the meter
+   * without waiting for the next billed turn. Shape mirrors the `monthly_budget`
+   * event payload (minus the one-shot justWarned/justExceeded flags).
+   */
+  getMonthlyBudgetStatus() {
+    return this._creditBudget.getStatus(Date.now())
+  }
+
   _trackUsage(sessionId, resultData) {
     const entry = this._sessions.get(sessionId)
     if (!entry) return
@@ -2392,6 +2414,20 @@ export class SessionManager extends EventEmitter {
       event: 'session_usage',
       data: { cumulativeUsage: { ...acc }, billingClass },
     })
+    // #5665: feed this turn's cost into the machine-wide monthly
+    // programmatic-credit meter, but ONLY for programmatic-credit sessions
+    // (claude-cli/sdk on/after the 2026-06-15 era). The era gate is implicit:
+    // billingClass only resolves to PROGRAMMATIC_CREDIT post-boundary. Broadcast
+    // the updated meter to ALL clients (it's per-machine, not per-session).
+    if (billingClass === BILLING_CLASSES.PROGRAMMATIC_CREDIT) {
+      const turnCost = finiteCost(Number(resultData?.cost))
+      const { status, justWarned, justExceeded } = this._creditBudget.recordSpend(turnCost, Date.now())
+      this.emit('session_event', {
+        sessionId,
+        event: 'monthly_budget',
+        data: { ...status, justWarned, justExceeded },
+      })
+    }
     // #4075: soft threshold crossing. Fire ONCE per session: the latch
     // (`costThresholdNotified`) stays true for the session's lifetime so
     // a tool-heavy turn that crosses the threshold doesn't spam the

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2352,16 +2352,6 @@ export class SessionManager extends EventEmitter {
    * @param {string} sessionId
    * @param {{ usage?: object, cost?: number }} resultData
    */
-  /**
-   * #5665: current monthly programmatic-credit meter snapshot (machine-wide).
-   * Sent to a client on connect so a freshly-loaded dashboard shows the meter
-   * without waiting for the next billed turn. Shape mirrors the `monthly_budget`
-   * event payload (minus the one-shot justWarned/justExceeded flags).
-   */
-  getMonthlyBudgetStatus() {
-    return this._creditBudget.getStatus(Date.now())
-  }
-
   _trackUsage(sessionId, resultData) {
     const entry = this._sessions.get(sessionId)
     if (!entry) return
@@ -2420,8 +2410,10 @@ export class SessionManager extends EventEmitter {
     // billingClass only resolves to PROGRAMMATIC_CREDIT post-boundary. Broadcast
     // the updated meter to ALL clients (it's per-machine, not per-session).
     if (billingClass === BILLING_CLASSES.PROGRAMMATIC_CREDIT) {
-      const turnCost = finiteCost(Number(resultData?.cost))
-      const { status, justWarned, justExceeded } = this._creditBudget.recordSpend(turnCost, Date.now())
+      // Pass the RAW cost (not finiteCost-coerced) so recordSpend's own
+      // Number.isFinite guard drops a non-finite turn entirely — coercing to 0
+      // here would still bump turnsBilled for a turn with no real cost.
+      const { status, justWarned, justExceeded } = this._creditBudget.recordSpend(Number(resultData?.cost), Date.now())
       this.emit('session_event', {
         sessionId,
         event: 'monthly_budget',
@@ -2454,6 +2446,16 @@ export class SessionManager extends EventEmitter {
         },
       })
     }
+  }
+
+  /**
+   * #5665: current monthly programmatic-credit meter snapshot (machine-wide).
+   * Sent to a client on connect so a freshly-loaded dashboard shows the meter
+   * without waiting for the next billed turn. Shape mirrors the `monthly_budget`
+   * event payload (minus the one-shot justWarned/justExceeded flags).
+   */
+  getMonthlyBudgetStatus() {
+    return this._creditBudget.getStatus(Date.now())
   }
 
   /**

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -136,6 +136,13 @@ function setupSessionForwarding(normalizer, ctx) {
       return
     }
 
+    // #5665: monthly programmatic-credit meter is machine-wide — broadcast to
+    // ALL authenticated clients, not per-session.
+    if (event === 'monthly_budget') {
+      broadcast({ type: 'monthly_budget', ...data })
+      return
+    }
+
     // Sidebar activity feed: lightweight status broadcast to ALL authenticated clients
     if (event === 'stream_start') {
       broadcast({ type: 'session_activity', sessionId, isBusy: true, lastCost: null })

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -374,6 +374,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     }
     send(ws, { type: 'session_list', sessions })
 
+    // #5665: send the current monthly programmatic-credit meter snapshot so a
+    // freshly-connected dashboard shows it immediately, not only after the next
+    // billed turn. Machine-wide, so it's sent regardless of boundSessionId.
+    if (typeof sessionManager.getMonthlyBudgetStatus === 'function') {
+      send(ws, { type: 'monthly_budget', ...sessionManager.getMonthlyBudgetStatus() })
+    }
+
     // Surface any sessions that failed to restore at startup (#2954) so newly
     // connecting clients see the "needs attention" state without having to
     // reconnect after the event fired.

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -438,6 +438,7 @@ function _isSecureRequest(req) {
  *   { type: 'session_cost_threshold_crossed', sessionId, costUsd, thresholdUsd } — soft "you've spent $X" warning; fires ONCE per session when cumulativeUsage.costUsd >= threshold (#4075)
  *   { type: 'budget_warning', sessionId, message, ... } — budget approaching limit
  *   { type: 'budget_exceeded', sessionId, message, ... } — budget exceeded
+ *   { type: 'monthly_budget', month, spentUsd, budgetUsd, percent, warning, exceeded, ... } — machine-wide monthly programmatic-credit meter (#5665); broadcast to ALL clients after each programmatic-credit turn + sent once on connect
  *   { type: 'web_feature_status', features }            — web feature availability
  *   { type: 'permission_rules_updated', rules }         — per-session auto-approval rules changed
  *   { type: 'extension_message', ... }                  — opaque extension payload (passthrough, no server handling)

--- a/packages/server/tests/billing-budget.test.js
+++ b/packages/server/tests/billing-budget.test.js
@@ -41,6 +41,13 @@ test('resolveMonthlyCreditBudgetUsd: null when unconfigured or unknown tier', ()
   assert.equal(resolveMonthlyCreditBudgetUsd({ monthlyCreditBudgetUsd: Infinity }), null)
 })
 
+test('resolveMonthlyCreditBudgetUsd: a zero override is "no override" (falls through to tier / null)', () => {
+  // A literal $0 cap would render a permanently-exceeded $0/$0 meter, so 0 is
+  // treated as unset rather than a real cap.
+  assert.equal(resolveMonthlyCreditBudgetUsd({ monthlyCreditBudgetUsd: 0 }), null)
+  assert.equal(resolveMonthlyCreditBudgetUsd({ creditTier: 'pro', monthlyCreditBudgetUsd: 0 }), 20)
+})
+
 test('resolveWarningPercent: default and validation', () => {
   assert.equal(resolveWarningPercent({}), DEFAULT_BUDGET_WARNING_PERCENT)
   assert.equal(resolveWarningPercent({ budgetWarningPercent: 90 }), 90)
@@ -104,11 +111,14 @@ test('rolls over and resets at the UTC month boundary', () => {
   assert.equal(r2.justWarned, true)
 })
 
-test('spentUsd floors at 0 when a refund drives the raw total negative', () => {
+test('a refund floors the running total at 0 and does not carry negative into later turns', () => {
   const m = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'pro' }, now: JUN_2026 })
   m.recordSpend(5, JUN_2026)
-  const { status } = m.recordSpend(-20, JUN_2026) // refund
-  assert.equal(status.spentUsd, 0)
+  const { status } = m.recordSpend(-20, JUN_2026) // large refund
+  assert.equal(status.spentUsd, 0, 'floors at 0, not -15')
+  // The next real spend starts from 0 — the refund did NOT mask it.
+  const after = m.recordSpend(3, JUN_2026)
+  assert.equal(after.status.spentUsd, 3)
 })
 
 test('ignores non-finite cost deltas', () => {

--- a/packages/server/tests/billing-budget.test.js
+++ b/packages/server/tests/billing-budget.test.js
@@ -1,0 +1,142 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  CREDIT_TIER_BUDGETS_USD,
+  DEFAULT_BUDGET_WARNING_PERCENT,
+  monthKeyUtc,
+  resolveMonthlyCreditBudgetUsd,
+  resolveWarningPercent,
+  MonthlyProgrammaticBudgetManager,
+} from '../src/billing-budget.js'
+
+const JUN_2026 = Date.UTC(2026, 5, 20) // 2026-06-20
+const JUL_2026 = Date.UTC(2026, 6, 3) //  2026-07-03
+
+test('monthKeyUtc formats YYYY-MM in UTC', () => {
+  assert.equal(monthKeyUtc(Date.UTC(2026, 5, 20)), '2026-06')
+  assert.equal(monthKeyUtc(Date.UTC(2026, 0, 1)), '2026-01')
+  assert.equal(monthKeyUtc(Date.UTC(2026, 11, 31)), '2026-12')
+  // Just before UTC midnight on the 1st of July is still June in UTC.
+  assert.equal(monthKeyUtc(Date.UTC(2026, 6, 1) - 1), '2026-06')
+})
+
+test('resolveMonthlyCreditBudgetUsd: override wins over tier preset', () => {
+  assert.equal(resolveMonthlyCreditBudgetUsd({ creditTier: 'pro', monthlyCreditBudgetUsd: 250 }), 250)
+})
+
+test('resolveMonthlyCreditBudgetUsd: tier presets map to documented caps', () => {
+  assert.equal(resolveMonthlyCreditBudgetUsd({ creditTier: 'pro' }), 20)
+  assert.equal(resolveMonthlyCreditBudgetUsd({ creditTier: 'max5x' }), 100)
+  assert.equal(resolveMonthlyCreditBudgetUsd({ creditTier: 'max20x' }), 200)
+  assert.deepEqual(CREDIT_TIER_BUDGETS_USD, { pro: 20, max5x: 100, max20x: 200 })
+})
+
+test('resolveMonthlyCreditBudgetUsd: null when unconfigured or unknown tier', () => {
+  assert.equal(resolveMonthlyCreditBudgetUsd({}), null)
+  assert.equal(resolveMonthlyCreditBudgetUsd({ creditTier: 'enterprise' }), null)
+  assert.equal(resolveMonthlyCreditBudgetUsd({ monthlyCreditBudgetUsd: -5 }), null)
+  assert.equal(resolveMonthlyCreditBudgetUsd({ monthlyCreditBudgetUsd: Infinity }), null)
+})
+
+test('resolveWarningPercent: default and validation', () => {
+  assert.equal(resolveWarningPercent({}), DEFAULT_BUDGET_WARNING_PERCENT)
+  assert.equal(resolveWarningPercent({ budgetWarningPercent: 90 }), 90)
+  assert.equal(resolveWarningPercent({ budgetWarningPercent: 0 }), 80)
+  assert.equal(resolveWarningPercent({ budgetWarningPercent: 150 }), 80)
+})
+
+test('recordSpend accumulates and reports percent against the cap', () => {
+  const m = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'pro' }, now: JUN_2026 })
+  assert.equal(m.hasBudget, true)
+  const { status } = m.recordSpend(5, JUN_2026)
+  assert.equal(status.month, '2026-06')
+  assert.equal(status.spentUsd, 5)
+  assert.equal(status.budgetUsd, 20)
+  assert.equal(status.percent, 25)
+  assert.equal(status.turnsBilled, 1)
+  assert.equal(status.warning, false)
+  assert.equal(status.exceeded, false)
+})
+
+test('no cap configured → percent null, never warns or exceeds', () => {
+  const m = new MonthlyProgrammaticBudgetManager({ billingConfig: {}, now: JUN_2026 })
+  assert.equal(m.hasBudget, false)
+  const { status, justWarned, justExceeded } = m.recordSpend(9999, JUN_2026)
+  assert.equal(status.budgetUsd, null)
+  assert.equal(status.percent, null)
+  assert.equal(status.warning, false)
+  assert.equal(status.exceeded, false)
+  assert.equal(justWarned, false)
+  assert.equal(justExceeded, false)
+  assert.equal(status.spentUsd, 9999)
+})
+
+test('warning + exceeded each fire exactly once per month', () => {
+  const m = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'pro', budgetWarningPercent: 80 }, now: JUN_2026 })
+  let r = m.recordSpend(10, JUN_2026) // 50%
+  assert.equal(r.justWarned, false)
+  r = m.recordSpend(7, JUN_2026) // 85% → crosses warning
+  assert.equal(r.justWarned, true)
+  assert.equal(r.status.warning, true)
+  r = m.recordSpend(1, JUN_2026) // 90% → already warned, no re-fire
+  assert.equal(r.justWarned, false)
+  r = m.recordSpend(3, JUN_2026) // 105% → crosses exceeded
+  assert.equal(r.justExceeded, true)
+  assert.equal(r.status.exceeded, true)
+  r = m.recordSpend(1, JUN_2026) // still over → no re-fire
+  assert.equal(r.justExceeded, false)
+})
+
+test('rolls over and resets at the UTC month boundary', () => {
+  const m = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'pro' }, now: JUN_2026 })
+  m.recordSpend(18, JUN_2026) // 90% June, warned
+  assert.equal(m.getStatus(JUN_2026).spentUsd, 18)
+  // A turn in July resets the running total and the notified latches.
+  const r = m.recordSpend(2, JUL_2026)
+  assert.equal(r.status.month, '2026-07')
+  assert.equal(r.status.spentUsd, 2)
+  assert.equal(r.status.warning, false)
+  // Re-crossing warning in the new month fires again.
+  const r2 = m.recordSpend(15, JUL_2026) // 85%
+  assert.equal(r2.justWarned, true)
+})
+
+test('spentUsd floors at 0 when a refund drives the raw total negative', () => {
+  const m = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'pro' }, now: JUN_2026 })
+  m.recordSpend(5, JUN_2026)
+  const { status } = m.recordSpend(-20, JUN_2026) // refund
+  assert.equal(status.spentUsd, 0)
+})
+
+test('ignores non-finite cost deltas', () => {
+  const m = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'pro' }, now: JUN_2026 })
+  const { status } = m.recordSpend(Infinity, JUN_2026)
+  assert.equal(status.spentUsd, 0)
+  assert.equal(status.turnsBilled, 0)
+})
+
+test('persists the running total across instances and resets a stale month', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-budget-'))
+  const statePath = join(dir, 'monthly-budget-state.json')
+  try {
+    const a = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'max5x' }, statePath, now: JUN_2026 })
+    a.recordSpend(40, JUN_2026)
+    const onDisk = JSON.parse(readFileSync(statePath, 'utf8'))
+    assert.equal(onDisk.month, '2026-06')
+    assert.equal(onDisk.spentUsd, 40)
+
+    // A fresh instance in the SAME month restores the running total.
+    const b = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'max5x' }, statePath, now: JUN_2026 })
+    assert.equal(b.getStatus(JUN_2026).spentUsd, 40)
+
+    // A fresh instance in a LATER month sees the stale total reset to 0.
+    const c = new MonthlyProgrammaticBudgetManager({ billingConfig: { creditTier: 'max5x' }, statePath, now: JUL_2026 })
+    assert.equal(c.getStatus(JUL_2026).spentUsd, 0)
+    assert.equal(c.getStatus(JUL_2026).month, '2026-07')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -4032,3 +4032,44 @@ describe('#5315 — respawn_exhausted destroys the session', () => {
     assert.ok(destroyedEvents.some((e) => e.sessionId === 's1'), 'session_destroyed emitted for the dropped session')
   })
 })
+
+// #5665 — monthly programmatic-credit budget meter wiring. The spend/era
+// behaviour is covered by billing-budget.test.js; this asserts the
+// SessionManager constructs the meter from the `billing` config block and
+// exposes the on-connect snapshot.
+describe('#5665 — monthly programmatic-credit budget meter', () => {
+  it('exposes a budget snapshot whose cap comes from the billing config', () => {
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      billing: { creditTier: 'max5x' },
+    })
+    const status = mgr.getMonthlyBudgetStatus()
+    assert.equal(status.budgetUsd, 100, 'max5x tier → $100 cap')
+    assert.equal(status.spentUsd, 0, 'no spend recorded yet')
+    assert.equal(status.warningPercent, 80, 'default warning threshold')
+    assert.match(status.month, /^\d{4}-\d{2}$/, 'UTC month key')
+  })
+
+  it('a raw monthlyCreditBudgetUsd override wins over the tier preset', () => {
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      billing: { creditTier: 'pro', monthlyCreditBudgetUsd: 250, budgetWarningPercent: 90 },
+    })
+    const status = mgr.getMonthlyBudgetStatus()
+    assert.equal(status.budgetUsd, 250)
+    assert.equal(status.warningPercent, 90)
+  })
+
+  it('reports a null cap when billing is unconfigured (meter shows spend, no percent)', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const status = mgr.getMonthlyBudgetStatus()
+    assert.equal(status.budgetUsd, null)
+    assert.equal(status.percent, null)
+    assert.equal(status.warning, false)
+    assert.equal(status.exceeded, false)
+  })
+})


### PR DESCRIPTION
## Summary
Builds the budget/cap layer deferred from the #5630/#5629 billing-class work. As of **2026-06-15**, `claude -p` (CLI) and the Agent SDK draw from a separate monthly programmatic-credit pool (API-rate billed, no rollover: Pro $20 / Max 5x $100 / Max 20x $200). This adds a **chroxy-observed** meter for that pool.

## Scoping decisions (confirmed before building)
- **Cap source:** `billing.creditTier` (pro/max5x/max20x → presets) + `billing.monthlyCreditBudgetUsd` raw override (wins) + `billing.budgetWarningPercent` (default 80). Chroxy can't detect the plan tier, so it's configured.
- **Scope + framing:** per-machine sum of programmatic-credit spend this month, labeled **"Credit spend"** with an ⓘ caveat that it counts only sessions THIS daemon ran — *not* the authoritative Anthropic balance.
- **Reset:** UTC calendar month (`YYYY-MM`), matching the era-boundary timezone semantics.

## What's included
**Server**
- `billing-budget.js` — `MonthlyProgrammaticBudgetManager`: month-keyed running total vs cap, persisted next to session-state (temp-redirect/test-sandbox safe), once-per-month warning + exceeded crossings, monthly rollover/reset.
- `config.js` — `billing` namespace + warn-only validation.
- `session-manager.js` — `_trackUsage` feeds each **programmatic-credit** turn into the meter (era gate is implicit: `billingClass` only resolves to `programmatic-credit` on/after 2026-06-15) and emits a machine-wide `monthly_budget` event; `getMonthlyBudgetStatus()` snapshot.
- `ws-forwarding.js` broadcasts `monthly_budget` to all clients; `ws-history.js` sends the snapshot on connect.

**Protocol** — `ServerMonthlyBudgetSchema` + type; handler-coverage contract registers it dashboard-only.

**Dashboard** — store handler + `SidebarTokenView` meter (spend / cap / % + progress bar, warning/exceeded states, ⓘ caveat). Hidden when no cap and no spend.

## Dormant until 2026-06-15
By design the meter only counts once programmatic-credit billing takes effect — before the era boundary, claude-cli/sdk resolve to `subscription` and nothing is recorded.

## Tests
- `billing-budget.test.js` (12): month key, cap resolution (override>tier>null), warning/exceeded once-per-month, rollover reset, refund floor, non-finite guard, persistence round-trip + stale-month reset.
- `session-manager.test.js` (+3): config→cap wiring, override precedence, null cap.
- Protocol schema (+2) and handler-coverage updated.
- Dashboard: `monthly_budget` store handler (+3), `SidebarTokenView` meter render (+5: cap/%/bar, warning/exceeded, no-cap, hidden cases).

Server suites green (session-manager 180, billing-budget 12, config 88, ws-history 137); protocol 289; dashboard 3629; tsc clean across server/protocol/dashboard/app; custom server lints green.

## Follow-up
Mobile meter parity (the app already receives `monthly_budget`; just no UI yet) — same pattern as the #5667 mobile follow-up.

Closes #5665