### PR TITLE
fix(server): split ingest rate-limit buckets so keepalives can't starve transitions (#5675)

### DIFF
--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -82,7 +82,10 @@ const KEEPALIVE_EVENT_TYPES = new Set(['post_tool_use'])
 
 /**
  * Classify an ingest event type for rate limiting. Exported for unit testing.
- * @param {string} type
+ * Anything not in the keepalive set — including unknown, new, or
+ * undefined/empty types — classifies as 'lifecycle' (fail-safe: never
+ * silently route a meaningful event into the droppable keepalive bucket).
+ * @param {string | undefined} type
  * @returns {'keepalive' | 'lifecycle'}
  */
 export function ingestEventClass(type) {

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -44,14 +44,50 @@ const log = createLogger('ingest')
 export const MAX_INGEST_BODY_BYTES = 65536
 
 /**
- * Per-source rate limit: 60 events/min (+10 burst) per `source` bucket.
- * A runaway hook loop saturates its own bucket and gets 429s instead of
- * flooding the pipeline (PushManager's per-category limits are the second
- * layer; Discord's own 429 handling is the third).
+ * Per-source rate limit, split into two independent class buckets (#5675).
+ *
+ * The original single per-source bucket (keyed `source:${source}`) caused a
+ * priority inversion under parallel-subagent load: `post_tool_use` fires on
+ * EVERY tool call with no client throttle (5-20/sec under heavy parallelism),
+ * so it drained the shared 60/min bucket in seconds — and for the rest of the
+ * minute the transition events that actually matter (`stop`, `subagent_stop`,
+ * `notification`) got 429'd and dropped, leaving the Discord embed stale.
+ *
+ * The fix keys each bucket by `source:${source}:${class}` so a flood of
+ * keepalives can no longer starve the must-deliver tokens:
+ *   - KEEPALIVE (post_tool_use): small bucket, 60/min + 10 burst. Dropping
+ *     under load is harmless — with the #5541 turn edges, user_prompt_submit
+ *     already holds the embed in "working", so post_tool_use only freshens
+ *     the detail line.
+ *   - LIFECYCLE / must-deliver (session/subagent/notification/turn edges):
+ *     generous bucket, 300/min + 60 burst. Naturally bounded by real
+ *     transition rates even under heavy parallelism, so it never drops.
+ *
+ * PushManager's per-category limits are the second layer; Discord's own 429
+ * handling is the third; the pre-auth per-IP ceiling below is the outer guard.
  */
 const INGEST_WINDOW_MS = 60_000
 const INGEST_MAX_EVENTS = 60
 const INGEST_BURST = 10
+const INGEST_LIFECYCLE_MAX_EVENTS = 300
+const INGEST_LIFECYCLE_BURST = 60
+
+/**
+ * Event classes for the split per-source rate limit (#5675). KEEPALIVE is the
+ * single droppable type; everything else is a meaningful transition. Unknown
+ * types default to 'lifecycle' (fail safe — a new/unrecognized type must never
+ * be silently dropped into the small keepalive bucket).
+ */
+const KEEPALIVE_EVENT_TYPES = new Set(['post_tool_use'])
+
+/**
+ * Classify an ingest event type for rate limiting. Exported for unit testing.
+ * @param {string} type
+ * @returns {'keepalive' | 'lifecycle'}
+ */
+export function ingestEventClass(type) {
+  return KEEPALIVE_EVENT_TYPES.has(type) ? 'keepalive' : 'lifecycle'
+}
 
 /**
  * Pre-auth per-IP ceiling (#5432 review S1/S2): the per-source buckets
@@ -324,20 +360,43 @@ export function handleEventIngest(server, req, res) {
       }
       const event = result.data
 
-      // Per-source rate limit. Lazily constructed so http-routes' mock
-      // servers get one for free; ws-server can pre-seed `_ingestRateLimiter`
-      // if tighter knobs are ever needed.
-      if (!server._ingestRateLimiter) {
-        server._ingestRateLimiter = new RateLimiter({
-          windowMs: INGEST_WINDOW_MS,
-          maxMessages: INGEST_MAX_EVENTS,
-          burst: INGEST_BURST,
-          name: 'ingest',
-        })
+      // Per-source rate limit, split into two class buckets (#5675) so a
+      // flood of `post_tool_use` keepalives can't starve the must-deliver
+      // transition events. Both lazily constructed so http-routes' mock
+      // servers get them for free.
+      //
+      // `_ingestRateLimiter` is the KEEPALIVE bucket — this preserves the
+      // documented pre-seed knob: ws-server (and existing tests) pre-seed
+      // `_ingestRateLimiter` for tighter keepalive knobs, and that path keeps
+      // working. The generous lifecycle bucket is the second limiter alongside.
+      const eventClass = ingestEventClass(event.type)
+      let limiter
+      if (eventClass === 'keepalive') {
+        if (!server._ingestRateLimiter) {
+          server._ingestRateLimiter = new RateLimiter({
+            windowMs: INGEST_WINDOW_MS,
+            maxMessages: INGEST_MAX_EVENTS,
+            burst: INGEST_BURST,
+            name: 'ingest-keepalive',
+          })
+        }
+        limiter = server._ingestRateLimiter
+      } else {
+        if (!server._ingestLifecycleRateLimiter) {
+          server._ingestLifecycleRateLimiter = new RateLimiter({
+            windowMs: INGEST_WINDOW_MS,
+            maxMessages: INGEST_LIFECYCLE_MAX_EVENTS,
+            burst: INGEST_LIFECYCLE_BURST,
+            name: 'ingest-lifecycle',
+          })
+        }
+        limiter = server._ingestLifecycleRateLimiter
       }
-      const { allowed, retryAfterMs } = server._ingestRateLimiter.check(`source:${event.source}`)
+      // Independent token pools per class — keyed by class so neither can
+      // starve the other.
+      const { allowed, retryAfterMs } = limiter.check(`source:${event.source}:${eventClass}`)
       if (!allowed) {
-        log.warn(`Rate limited POST /api/events from source "${event.source}"`)
+        log.warn(`Rate limited POST /api/events from source "${event.source}" (${eventClass})`)
         sendJson(res, 429, { error: 'rate limited', retryAfterMs }, {
           'Retry-After': Math.ceil(retryAfterMs / 1000),
         })

--- a/packages/server/tests/event-ingest.test.js
+++ b/packages/server/tests/event-ingest.test.js
@@ -27,6 +27,7 @@ import {
   defaultIngestSecretPath,
   deriveProjectFromCwd,
   handleEventIngest,
+  ingestEventClass,
   INGEST_CATEGORY_FOR_TYPE,
   MAX_INGEST_BODY_BYTES,
 } from '../src/event-ingest.js'
@@ -218,14 +219,17 @@ describe('event-ingest', () => {
   })
 
   describe('rate limiting (per source)', () => {
-    it('429 with Retry-After once a source exceeds its bucket', async () => {
+    // #5675: the pre-seeded `_ingestRateLimiter` is now the KEEPALIVE bucket,
+    // so this exercises post_tool_use (the only keepalive type). The pre-seed
+    // knob (ws-server / tighter test knobs) keeps working.
+    it('429 with Retry-After once a source exceeds its keepalive bucket', async () => {
       const server = createMockServer({
         _ingestRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 2, burst: 0, name: 'ingest-test' }),
       })
       await startWith(server)
-      assert.equal((await post(validEvent())).status, 200)
-      assert.equal((await post(validEvent({ type: 'session_end' }))).status, 200)
-      const res = await post(validEvent({ type: 'notification' }))
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      const res = await post(validEvent({ type: 'post_tool_use' }))
       assert.equal(res.status, 429)
       assert.ok(res.headers.get('retry-after'), 'Retry-After header present')
       const body = await res.json()
@@ -237,9 +241,9 @@ describe('event-ingest', () => {
         _ingestRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 1, burst: 0, name: 'ingest-test' }),
       })
       await startWith(server)
-      assert.equal((await post(validEvent({ source: 'hooks-a' }))).status, 200)
-      assert.equal((await post(validEvent({ source: 'hooks-a' }))).status, 429)
-      assert.equal((await post(validEvent({ source: 'hooks-b' }))).status, 200)
+      assert.equal((await post(validEvent({ source: 'hooks-a', type: 'post_tool_use' }))).status, 200)
+      assert.equal((await post(validEvent({ source: 'hooks-a', type: 'post_tool_use' }))).status, 429)
+      assert.equal((await post(validEvent({ source: 'hooks-b', type: 'post_tool_use' }))).status, 200)
     })
 
     // #5432 review S1/S2 — the per-source buckets are keyed on a
@@ -269,6 +273,102 @@ describe('event-ingest', () => {
       // the auth check itself.
       const res = await post(validEvent(), { token: 'wrong-token' })
       assert.equal(res.status, 429)
+    })
+  })
+
+  // #5675: the per-source bucket is split by event class so a flood of
+  // droppable `post_tool_use` keepalives can't starve the must-deliver
+  // transition events (stop, subagent_stop, notification, ...).
+  describe('rate limiting (class split #5675)', () => {
+    // The core regression: flood the keepalive bucket until it 429s, then
+    // assert must-deliver transitions still pass — proving the priority
+    // inversion is fixed.
+    it('a keepalive flood does NOT starve must-deliver transitions', async () => {
+      const server = createMockServer({
+        // Tiny keepalive bucket so a short flood exhausts it; generous
+        // lifecycle bucket left to lazy default (300/min + 60 burst).
+        _ingestRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 3, burst: 0, name: 'keepalive-test' }),
+      })
+      await startWith(server)
+      // Flood post_tool_use until the keepalive bucket 429s.
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 429, 'keepalive bucket exhausted')
+      // The must-deliver transitions still pass — independent bucket.
+      assert.equal((await post(validEvent({ type: 'stop' }))).status, 200, 'stop still delivered')
+      assert.equal((await post(validEvent({ type: 'subagent_stop', sessionId: 's1' }))).status, 200, 'subagent_stop still delivered')
+      assert.equal((await post(validEvent({ type: 'notification' }))).status, 200, 'notification still delivered')
+    })
+
+    it('exhausting the lifecycle bucket does NOT 429 keepalives', async () => {
+      const server = createMockServer({
+        // Generous keepalive bucket; tiny lifecycle bucket.
+        _ingestRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 100, burst: 0, name: 'keepalive-test' }),
+        _ingestLifecycleRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 1, burst: 0, name: 'lifecycle-test' }),
+      })
+      await startWith(server)
+      assert.equal((await post(validEvent({ type: 'stop' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'stop' }))).status, 429, 'lifecycle bucket exhausted')
+      // Keepalives sail through their own bucket regardless.
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+    })
+
+    it('exhausting the keepalive bucket does NOT 429 lifecycle events', async () => {
+      const server = createMockServer({
+        _ingestRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 1, burst: 0, name: 'keepalive-test' }),
+        _ingestLifecycleRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 100, burst: 0, name: 'lifecycle-test' }),
+      })
+      await startWith(server)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 429, 'keepalive bucket exhausted')
+      // Lifecycle events pass through their own bucket.
+      assert.equal((await post(validEvent({ type: 'session_start' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'subagent_start', sessionId: 's1' }))).status, 200)
+    })
+
+    it('the per-IP ceiling still applies regardless of class', async () => {
+      const server = createMockServer({
+        _ingestIpRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 2, burst: 0, name: 'ingest-ip-test' }),
+        // Generous class buckets so only the IP ceiling can fire.
+        _ingestRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 100, burst: 0, name: 'keepalive-test' }),
+        _ingestLifecycleRateLimiter: new RateLimiter({ windowMs: 60_000, maxMessages: 100, burst: 0, name: 'lifecycle-test' }),
+      })
+      await startWith(server)
+      assert.equal((await post(validEvent({ type: 'stop' }))).status, 200)
+      assert.equal((await post(validEvent({ type: 'post_tool_use' }))).status, 200)
+      // Third request across either class is capped by the IP ceiling.
+      assert.equal((await post(validEvent({ type: 'stop' }))).status, 429, 'IP ceiling fires across classes')
+    })
+  })
+
+  describe('ingestEventClass (#5675)', () => {
+    it('maps post_tool_use to keepalive', () => {
+      assert.equal(ingestEventClass('post_tool_use'), 'keepalive')
+    })
+
+    it('maps every must-deliver transition type to lifecycle', () => {
+      for (const type of [
+        'session_start', 'session_end', 'subagent_start', 'subagent_stop',
+        'notification', 'user_prompt_submit', 'stop',
+      ]) {
+        assert.equal(ingestEventClass(type), 'lifecycle', `${type} should be lifecycle`)
+      }
+    })
+
+    it('defaults unknown/new types to lifecycle (fail safe — never silently drop)', () => {
+      assert.equal(ingestEventClass('some_future_type'), 'lifecycle')
+      assert.equal(ingestEventClass(''), 'lifecycle')
+      assert.equal(ingestEventClass(undefined), 'lifecycle')
+    })
+
+    it('covers the full ingest enum (no protocol type lands as keepalive by accident)', () => {
+      for (const type of INGEST_EVENT_TYPES) {
+        const cls = ingestEventClass(type)
+        if (type === 'post_tool_use') assert.equal(cls, 'keepalive')
+        else assert.equal(cls, 'lifecycle', `${type} should be lifecycle`)
+      }
     })
   })
 


### PR DESCRIPTION
## Problem — priority inversion in the ingest rate limiter

Under parallel-subagent load the Discord status embed goes stale: a finished turn keeps showing "working", a completed subagent doesn't decrement. Root cause is a priority inversion in `POST /api/events`.

The per-source bucket was keyed by **source only** (`source:${source}`, 60/min + 10 burst), so every event type from `claude-hooks` shared one token pool. `post_tool_use` fires on **every tool call** with no client throttle (5-20/sec under heavy parallelism), draining the shared bucket in seconds. For the rest of the minute the transition events that actually matter — `stop`, `subagent_stop`, `notification` — got 429'd and dropped. Harmless keepalives starved the must-deliver transitions.

## Fix — split the per-source bucket by event class (server-only)

Two independent `RateLimiter` instances, keyed `source:${source}:${class}` so the classes cannot starve each other:

- **keepalive** (`post_tool_use`): small — 60/min + 10 burst (reuses `INGEST_MAX_EVENTS`/`INGEST_BURST`). Dropping under load is **harmless**: with the #5541 turn edges, `user_prompt_submit` already holds the embed in "working", so `post_tool_use` only freshens the detail line.
- **must-deliver / lifecycle** (`session_start`, `session_end`, `subagent_start`, `subagent_stop`, `notification`, `user_prompt_submit`, `stop`): generous — 300/min + 60 burst (`INGEST_LIFECYCLE_MAX_EVENTS`/`INGEST_LIFECYCLE_BURST`). Naturally bounded by real transition rates even under heavy parallelism, so it never drops.

Classification lives in a small exported, unit-testable helper `ingestEventClass(type)` returning `'keepalive' | 'lifecycle'`. Unknown/new types **default to lifecycle (fail safe)** — a new meaningful type is never silently dropped into the small keepalive bucket.

The pre-seed knob is preserved: `server._ingestRateLimiter` now maps to the **keepalive** bucket (the natural legacy mapping), so ws-server's pre-seed and existing tests keep working; the generous lifecycle limiter (`_ingestLifecycleRateLimiter`) is constructed lazily alongside.

The outer pre-auth per-IP ceiling (`_ingestIpRateLimiter`, 240/min) is **unchanged** — it stays as the DoS guard across all classes. The 429 response shape + `Retry-After` header are identical; the log line now notes the class for observability.

## Tests

- `ingestEventClass`: maps each known type, full enum coverage, unknown/empty/undefined → lifecycle (fail safe).
- **Core regression**: flood the keepalive bucket until it 429s, then assert `stop`, `subagent_stop`, and `notification` still return 200 — proving must-deliver isn't starved.
- Independent buckets both directions (exhausting one class doesn't 429 the other).
- IP ceiling still fires across classes.
- Existing pre-seed tests updated to drive the keepalive (`post_tool_use`) path, preserving the pre-seed contract.

Full server suite: same environmental failure set as `main` (live-daemon / env-creation / service-fetch / file-ops in /tmp), **zero new failures**. Lint clean.

## Scope

Server-only. No changes to `packages/claude-hooks` or `packages/protocol`. No client or wire-protocol changes — inert risk.

Closes #5675