### PR TITLE
fix(server): heartbeat watchdog downgrades abandoned online embeds (#5676)

### DIFF
--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -82,6 +82,22 @@ const DEFAULT_PRUNE_AFTER_MS = 86_400_000 // 24h
 // documented disable (parity with the heartbeatIntervalMs 10s floor).
 const MIN_PRUNE_AFTER_MS = 60_000 // 60s
 
+// #5676: two-stage staleness watchdog for the heartbeat. A hook-based external
+// session (chroxy-hooks) that dies WITHOUT emitting session_end — kill -9,
+// crash, OOM, terminal closed, laptop sleep, daemon restart mid-session — never
+// fires session_offline, so its `online` embed would stay "🟢 working" forever
+// while the heartbeat keeps re-rendering it as alive. The internal session
+// types emit `inactivity_warning` to cover this; the ingest hook path has no
+// equivalent. The heartbeat therefore watches silence = now - lastUpdateTs (the
+// last REAL event, NOT a heartbeat tick) and downgrades a quiet embed:
+//   online → stale  after STALE_AFTER_MS of silence,
+//   stale  → offline after OFFLINE_AFTER_MS of silence (final).
+// idle/permission are spared — those are legitimately waiting on the human, not
+// dead. A real event takes the normal update() path and restores the true
+// state, resetting the silence clock automatically.
+const DEFAULT_STALE_AFTER_MS = 10 * 60_000   // 10m
+const DEFAULT_OFFLINE_AFTER_MS = 30 * 60_000 // 30m
+
 // Embed sidebar color defaults — ported from claude-code-notify
 // (colors.conf.example + the CLAUDE_NOTIFY_*_COLOR defaults).
 const DEFAULT_PROJECT_COLOR = 5793266   // Discord blurple #5865F2
@@ -229,6 +245,12 @@ export class DiscordWebhookSink extends NotificationSink {
    *   0 disables pruning; invalid values and values below 60s fall back to
    *   the 24h default (#5457 — a tiny retention prunes the messageId between
    *   events and turns the status embed into message-per-event spam).
+   * @param {number} [opts.staleAfterMs] - #5676 watchdog: silence after which
+   *   an `online` embed is downgraded to `stale` in a heartbeat tick. Injected
+   *   small for tests; defaults to 10m.
+   * @param {number} [opts.offlineAfterMs] - #5676 watchdog: silence after which
+   *   a `stale` embed is downgraded to `offline` (final). Injected small for
+   *   tests; defaults to 30m.
    * @param {Function} [opts.resolveWebhookUrl] - Injection seam for tests;
    *   defaults to the env > 0600-credentials.json resolver.
    * @param {Function} [opts.sleepImpl] - Injection seam for tests (429/backoff
@@ -245,6 +267,8 @@ export class DiscordWebhookSink extends NotificationSink {
     updateThrottleMs = 15_000,
     heartbeatIntervalMs = 300_000,
     pruneAfterMs = DEFAULT_PRUNE_AFTER_MS,
+    staleAfterMs = DEFAULT_STALE_AFTER_MS,
+    offlineAfterMs = DEFAULT_OFFLINE_AFTER_MS,
     // Cached by default (#5427 review): isConfigured() is probed per
     // notification; the cache only re-reads credentials.json when its
     // mtime/size/mode or the env var changes.
@@ -266,6 +290,10 @@ export class DiscordWebhookSink extends NotificationSink {
     if (!Number.isFinite(pruneAfterMs) || pruneAfterMs < 0) pruneAfterMs = DEFAULT_PRUNE_AFTER_MS
     if (pruneAfterMs > 0 && pruneAfterMs < MIN_PRUNE_AFTER_MS) pruneAfterMs = DEFAULT_PRUNE_AFTER_MS
     this._pruneAfterMs = pruneAfterMs
+    // #5676 watchdog thresholds. Invalid values fall back to the defaults so a
+    // bad config can never disable the dead-session guard.
+    this._staleAfterMs = Number.isFinite(staleAfterMs) && staleAfterMs >= 0 ? staleAfterMs : DEFAULT_STALE_AFTER_MS
+    this._offlineAfterMs = Number.isFinite(offlineAfterMs) && offlineAfterMs >= 0 ? offlineAfterMs : DEFAULT_OFFLINE_AFTER_MS
     this._resolveWebhookUrl = resolveWebhookUrl
     this._sleep = sleepImpl
     this._now = now
@@ -787,21 +815,51 @@ export class DiscordWebhookSink extends NotificationSink {
   }
 
   /**
-   * One heartbeat pass: refresh each LIVE project's embed in place.
+   * One heartbeat pass: refresh each LIVE project's embed in place, and run the
+   * #5676 staleness watchdog so a dead external session doesn't sit "🟢 online"
+   * forever.
+   *
    * Offline entries are skipped (#5434) — the offline embed is final, and
-   * re-PATCHing it would both keep its elapsed-time footer counting up
-   * forever and spend a Discord call per dead project per tick. Stale
-   * entries never even reach the loop: _loadState prunes them, so the
-   * tick's work is bounded to live projects.
+   * re-PATCHing it would both keep its elapsed-time footer counting up forever
+   * and spend a Discord call per dead project per tick. Entries pruned by
+   * retention never even reach the loop: _loadState drops them.
+   *
+   * Watchdog (before the routine footer PATCH), measuring silence against
+   * `lastUpdateTs` — the last REAL event time, which the heartbeat NEVER writes,
+   * so repeated ticks let the clock keep climbing until it trips:
+   *   - `online` silent > staleAfterMs   → downgrade to `stale`
+   *   - `stale`  silent > offlineAfterMs → downgrade to `offline` (final)
+   * `idle` and `permission` are spared — they are legitimately waiting on the
+   * human, not dead. A downgraded state is rebuilt into the PATCH payload so the
+   * embed shows the new title/color. A real event (update()) restores the true
+   * state and resets `lastUpdateTs`, so recovery is automatic.
    */
   async _heartbeatTick() {
     const webhookUrl = this._configuredUrl()
     if (!webhookUrl) return
     const base = this._apiBase(webhookUrl)
     const store = this._loadState()
+    const now = this._now()
     let mutated = false
     for (const [project, entry] of Object.entries(store.projects)) {
       if (!entry?.messageId || entry.state === 'offline') continue
+
+      // #5676: staleness downgrade. Only `online`/`stale` decay; idle/permission
+      // are left to their normal footer refresh. silence reads lastUpdateTs (the
+      // last real event), which the heartbeat does not bump — so a long-silent
+      // entry eventually trips even with ticks firing in between.
+      const last = entry.lastUpdateTs
+      const silence = Number.isFinite(last) ? now - last : Infinity
+      if (entry.state === 'online' && silence > this._staleAfterMs) {
+        entry.state = 'stale'
+        entry.lastStateChangeTs = now
+        mutated = true
+      } else if (entry.state === 'stale' && silence > this._offlineAfterMs) {
+        entry.state = 'offline'
+        entry.lastStateChangeTs = now
+        mutated = true
+      }
+
       try {
         const res = await this._discordFetch(`${base}/messages/${entry.messageId}`, {
           method: 'PATCH',

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -830,9 +830,13 @@ export class DiscordWebhookSink extends NotificationSink {
    *   - `online` silent > staleAfterMs   → downgrade to `stale`
    *   - `stale`  silent > offlineAfterMs → downgrade to `offline` (final)
    * `idle` and `permission` are spared — they are legitimately waiting on the
-   * human, not dead. A downgraded state is rebuilt into the PATCH payload so the
-   * embed shows the new title/color. A real event (update()) restores the true
-   * state and resets `lastUpdateTs`, so recovery is automatic.
+   * human, not dead. A pending downgrade is rendered into the PATCH payload from
+   * a CANDIDATE state, and only committed to the entry once Discord confirms the
+   * PATCH (res.ok) — a failed PATCH must not persist `stale`/`offline` while the
+   * embed still shows the old state. That matters most for `offline`, which later
+   * ticks skip: persisting it on a failed PATCH would wedge the embed forever
+   * (the very ghost this watchdog exists to prevent). A real event (update())
+   * restores the true state and resets `lastUpdateTs`, so recovery is automatic.
    */
   async _heartbeatTick() {
     const webhookUrl = this._configuredUrl()
@@ -847,32 +851,44 @@ export class DiscordWebhookSink extends NotificationSink {
       // #5676: staleness downgrade. Only `online`/`stale` decay; idle/permission
       // are left to their normal footer refresh. silence reads lastUpdateTs (the
       // last real event), which the heartbeat does not bump — so a long-silent
-      // entry eventually trips even with ticks firing in between.
+      // entry eventually trips even with ticks firing in between. The downgrade
+      // is a CANDIDATE here; entry.state is mutated only after a successful PATCH.
       const last = entry.lastUpdateTs
       const silence = Number.isFinite(last) ? now - last : Infinity
+      let downgradeTo = null
       if (entry.state === 'online' && silence > this._staleAfterMs) {
-        entry.state = 'stale'
-        entry.lastStateChangeTs = now
-        mutated = true
+        downgradeTo = 'stale'
       } else if (entry.state === 'stale' && silence > this._offlineAfterMs) {
-        entry.state = 'offline'
-        entry.lastStateChangeTs = now
-        mutated = true
+        downgradeTo = 'offline'
       }
+
+      // Render from the candidate state when a downgrade is pending, else the
+      // current state for the routine footer refresh.
+      const payloadEntry = downgradeTo
+        ? { ...entry, state: downgradeTo, lastStateChangeTs: now }
+        : entry
 
       try {
         const res = await this._discordFetch(`${base}/messages/${entry.messageId}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(this._buildPayload(project, entry)),
+          body: JSON.stringify(this._buildPayload(project, payloadEntry)),
         })
         if (res.status === 404) {
           // Deleted externally — forget the id so the next real event POSTs.
           entry.messageId = null
           mutated = true
+        } else if (res.ok && downgradeTo) {
+          // Commit the downgrade only now that Discord has the new embed. A
+          // failed/non-ok PATCH leaves the entry untouched so the next tick
+          // retries without corrupting persisted state.
+          entry.state = downgradeTo
+          entry.lastStateChangeTs = now
+          mutated = true
         }
       } catch {
         // Heartbeat is best-effort; the next real event takes the full path.
+        // A pending downgrade is intentionally NOT committed — retried next tick.
       }
     }
     if (mutated) this._persistState(store)

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -821,6 +821,160 @@ describe('DiscordWebhookSink — heartbeat', () => {
   })
 })
 
+// #5676: two-stage staleness watchdog. A hook-based external session that dies
+// WITHOUT session_end (kill -9, crash, laptop sleep, daemon restart) would
+// otherwise leave its `online` embed "🟢 working" forever — the heartbeat keeps
+// re-rendering it alive. The watchdog downgrades a quiet embed online → stale →
+// offline, measuring silence against lastUpdateTs (the last REAL event, NOT a
+// heartbeat tick), and spares idle/permission (legitimately waiting on a human).
+describe('DiscordWebhookSink — staleness watchdog (#5676)', () => {
+  // Small injected thresholds + a controllable clock. prune stays at the 24h
+  // default so the watchdog (not retention) is what acts at these silences.
+  const watchdog = (over = {}) => makeSink({
+    staleAfterMs: 10 * 60_000,
+    offlineAfterMs: 30 * 60_000,
+    ...over,
+  })
+
+  // online entries come from the Phase-3 session lifecycle categories.
+  const online = (data = {}) => ({
+    category: 'session_online',
+    title: 'Session online',
+    body: 'External session started',
+    data: { project: 'proj1', ...data },
+  })
+  const activity = (data = {}) => ({
+    category: 'session_activity',
+    title: 'Tool activity',
+    body: 'Tool use completed',
+    data: { project: 'proj1', ...data },
+  })
+
+  it('online + silent past STALE_AFTER_MS → downgrades to stale (PATCH sent, persisted)', async () => {
+    const { sink, statePath, advance } = watchdog()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    assert.equal(readState(statePath).projects.proj1.state, 'online')
+
+    advance(11 * 60_000) // 11 min of silence — past the 10m stale threshold
+    const calls = scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+
+    const patches = calls.filter((c) => c.method === 'PATCH')
+    assert.equal(patches.length, 1, 'one PATCH issued for the downgrade')
+    const embed = JSON.parse(patches[0].body).embeds[0]
+    assert.match(embed.title, /proj1 — Quiet for a while/, 'stale title rendered')
+    assert.equal(readState(statePath).projects.proj1.state, 'stale', 'state persisted as stale')
+  })
+
+  it('stale + silent past OFFLINE_AFTER_MS → downgrades to offline', async () => {
+    const { sink, statePath, advance } = watchdog()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+
+    // Trip stale first.
+    advance(11 * 60_000)
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.proj1.state, 'stale')
+
+    // Now silent for >30 min total since the last real event.
+    advance(20 * 60_000) // total 31 min of silence
+    const calls = scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+
+    const patches = calls.filter((c) => c.method === 'PATCH')
+    assert.equal(patches.length, 1, 'one final PATCH for the offline downgrade')
+    const embed = JSON.parse(patches[0].body).embeds[0]
+    assert.match(embed.title, /proj1 — Session Offline/, 'offline title rendered')
+    assert.equal(readState(statePath).projects.proj1.state, 'offline', 'state persisted as offline')
+  })
+
+  it('online + recent (< STALE_AFTER_MS) → stays online (normal footer refresh only)', async () => {
+    const { sink, statePath, advance } = watchdog()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+
+    advance(5 * 60_000) // 5 min — under the 10m stale threshold
+    const calls = scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+
+    const patches = calls.filter((c) => c.method === 'PATCH')
+    assert.equal(patches.length, 1, 'still PATCHes to refresh the footer')
+    const embed = JSON.parse(patches[0].body).embeds[0]
+    assert.match(embed.title, /proj1 — Session Online/, 'still online')
+    assert.equal(readState(statePath).projects.proj1.state, 'online')
+  })
+
+  it('idle and permission entries of any age are left untouched', async () => {
+    const { sink, statePath, advance } = watchdog()
+    // idle (alpha) + permission (beta) tracked.
+    scriptFetch([
+      { status: 200, body: { id: 'm-alpha' } }, // idle POST
+      { status: 200, body: { id: 'm-beta' } },  // permission POST
+    ])
+    await sink.send(idle({ sessionName: 'alpha' }))
+    await sink.send(waiting({ sessionName: 'beta' }))
+    assert.equal(readState(statePath).projects.alpha.state, 'idle')
+    assert.equal(readState(statePath).projects.beta.state, 'permission')
+
+    advance(60 * 60_000) // an hour of silence — well past every threshold
+    scriptFetch([{ status: 200 }, { status: 200 }])
+    await sink._heartbeatTick()
+
+    const st = readState(statePath).projects
+    assert.equal(st.alpha.state, 'idle', 'idle is waiting on a human, never downgraded')
+    assert.equal(st.beta.state, 'permission', 'permission is waiting on a human, never downgraded')
+  })
+
+  it('a real event after a stale downgrade restores online and resets the silence clock', async () => {
+    const { sink, statePath, advance } = watchdog()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+
+    // Downgrade to stale.
+    advance(11 * 60_000)
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.proj1.state, 'stale')
+
+    // A real event arrives — normal update() path restores online + resets clock.
+    scriptFetch([{ status: 200 }]) // routine session_activity PATCH
+    await sink.send(activity())
+    assert.equal(readState(statePath).projects.proj1.state, 'online', 'real event restored online')
+
+    // The very next tick must NOT immediately re-downgrade: the clock reset.
+    advance(5 * 60_000) // under the stale threshold again
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.proj1.state, 'online', 'clock reset — still online')
+  })
+
+  it('a heartbeat tick alone does NOT advance lastUpdateTs (so repeated ticks eventually trip)', async () => {
+    const { sink, statePath, advance } = watchdog()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+    const ts0 = readState(statePath).projects.proj1.lastUpdateTs
+
+    // Two ticks while still under the stale threshold — neither should touch
+    // lastUpdateTs (a heartbeat is not real activity).
+    advance(3 * 60_000)
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    advance(3 * 60_000)
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.proj1.lastUpdateTs, ts0, 'ticks never bump lastUpdateTs')
+    assert.equal(readState(statePath).projects.proj1.state, 'online', 'still online under threshold')
+
+    // Because the clock never advanced, total silence now crosses the threshold.
+    advance(5 * 60_000) // 11 min total since the real event
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.proj1.state, 'stale', 'silence accumulated across ticks → tripped')
+  })
+})
+
 describe('PushManager integration (#5413 Phase 2)', () => {
   it('registers the Discord sink alongside Expo, off by default', () => {
     const pm = new PushManager({

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -973,6 +973,60 @@ describe('DiscordWebhookSink — staleness watchdog (#5676)', () => {
     await sink._heartbeatTick()
     assert.equal(readState(statePath).projects.proj1.state, 'stale', 'silence accumulated across ticks → tripped')
   })
+
+  it('a FAILED downgrade PATCH does not persist the new state — retried next tick', async () => {
+    const { sink, statePath, advance } = watchdog()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+
+    // Past the stale threshold, but the downgrade PATCH fails (5xx on all
+    // MAX_RETRIES=3 attempts, so _discordFetch returns the final 5xx).
+    advance(11 * 60_000)
+    scriptFetch([{ status: 500 }, { status: 502 }, { status: 503 }])
+    await sink._heartbeatTick()
+    assert.equal(
+      readState(statePath).projects.proj1.state,
+      'online',
+      'failed PATCH must NOT persist stale — embed never updated',
+    )
+
+    // Next tick with a working PATCH commits the downgrade.
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(
+      readState(statePath).projects.proj1.state,
+      'stale',
+      'retry succeeds → downgrade now committed',
+    )
+  })
+
+  it('a FAILED stale→offline PATCH does not wedge the entry as offline', async () => {
+    const { sink, statePath, advance } = watchdog()
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    await sink.send(online())
+
+    // Trip to stale (succeeds).
+    advance(11 * 60_000)
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.proj1.state, 'stale')
+
+    // Offline downgrade PATCH fails — must stay 'stale' (offline would be skipped
+    // on later ticks, freezing the embed: the exact ghost the watchdog prevents).
+    advance(20 * 60_000) // 31 min total silence
+    scriptFetch([{ status: 502 }, { status: 503 }, { status: 500 }])
+    await sink._heartbeatTick()
+    assert.equal(
+      readState(statePath).projects.proj1.state,
+      'stale',
+      'failed offline PATCH stays stale so the next tick can retry',
+    )
+
+    // Retry succeeds → offline commits.
+    scriptFetch([{ status: 200 }])
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.proj1.state, 'offline', 'retry commits offline')
+  })
 })
 
 describe('PushManager integration (#5413 Phase 2)', () => {


### PR DESCRIPTION
## Problem

A hook-based external session (Claude Code via `chroxy-hooks`) that dies **without** emitting `session_end` — `kill -9`, crash, OOM, terminal closed, laptop sleep, daemon restart mid-session — never fires `session_offline`. Its Discord embed stayed showing "🟢 {project} — Session Online / working" **forever**, because the heartbeat actively re-PATCHed it each interval to refresh the elapsed-time footer but never changed state. The internal session types emit `inactivity_warning` (→ `stale`) to cover this, but the ingest hook path had no equivalent, and the old claude-code-notify heartbeat that used to cover it is gone (#5413/#5439 cutover).

## Fix — two-stage staleness watchdog in `_heartbeatTick()`

Before the routine footer-refresh PATCH, the tick now measures silence as `now - entry.lastUpdateTs` (the last **real** event time) and downgrades a quiet live embed:

- `online` silent **> 10 min** (`STALE_AFTER_MS`) → downgrade to `stale` ("⏳ Quiet for a while"), PATCH, persist.
- `stale` silent **> 30 min** (`OFFLINE_AFTER_MS`) → downgrade to `offline` (final), PATCH, persist. (Offline entries are already `continue`'d at the top of the loop on later ticks.)

**`idle` and `permission` are spared** — those states are legitimately waiting on the human, not dead, so the watchdog skips the downgrade for them (they still get their normal footer-refresh PATCH).

**Recovery is automatic.** A real inbound event takes the normal `update()` path, which restores the true state and bumps `lastUpdateTs`, resetting the silence clock — no extra recovery logic needed.

The watchdog reads `lastUpdateTs`, which `update()` advances on real events and the heartbeat **never** writes (verified — the existing footer-refresh PATCH does not touch it), so the silence clock keeps climbing across ticks until it trips. Both thresholds are named constants overridable via constructor options (`staleAfterMs` / `offlineAfterMs`) for testing, mirroring how `heartbeatIntervalMs` / `pruneAfterMs` are injected.

## Tests

Extends `packages/server/tests/discord-webhook-sink.test.js` with a watchdog suite driving `_heartbeatTick` directly under injected small thresholds + a controllable clock:

- online + silent past `STALE_AFTER_MS` → becomes `stale`, PATCH issued, state persisted.
- stale + silent past `OFFLINE_AFTER_MS` → becomes `offline`.
- online + recent (< `STALE_AFTER_MS`) → stays online (footer refresh only).
- idle and permission of any age → unchanged.
- real `update()` after a stale downgrade → restores online, resets the clock (next tick does not re-downgrade).
- a heartbeat tick alone does **not** advance `lastUpdateTs` (asserted explicitly, so repeated ticks eventually trip).

Server-only; no protocol/hooks/client changes.

Closes #5676
