### PR TITLE
feat(pages): core serve + security for Chroxy Pages (PR-1 of #5683)

### DIFF
--- a/docs/design/chroxy-pages.md
+++ b/docs/design/chroxy-pages.md
@@ -1,0 +1,100 @@
+# Chroxy Pages — design
+
+Publish a generated HTML artifact (a status report, a diff summary, an agent-built
+page) to an **unguessable URL served from the user's own daemon** over the
+Cloudflare tunnel they already run — viewable on any device, no GitHub, no
+external host.
+
+```
+chroxy publish report.html
+→ https://<your-tunnel>.trycloudflare.com/p/Xa9f8k2…/
+```
+
+This is the self-hosted equivalent of "agent makes a hosted page": the page is
+served from infrastructure the user controls, which matches the product goal of
+*feeling native to your own system* rather than a third-party host.
+
+## Decisions (locked)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Hosting | **Native chroxy-served** over the existing HTTP server + tunnel | ~90% of the infra (HTTP router, tunnel, auth) already exists; served from the user's machine |
+| Access control | **Unguessable share link** (per-page random slug) | Open on any device with no token; link = capability |
+| Page content | **Static-only (no JS / no network) by default** | Makes share-links safe under chroxy's cookie auth (see Security); perfect for reports |
+
+GitHub Pages export and Quartz vault were considered and deferred to follow-ups
+(permanence/portability at the cost of an external repo + build step).
+
+## Architecture
+
+- **Storage:** `~/.chroxy/pages/<slug>/` (respects `CHROXY_CONFIG_DIR`), entry
+  `index.html` plus optional co-located assets. A manifest
+  `~/.chroxy/pages/index.json` (atomic temp+rename write) tracks
+  `{ slug, title, createdAt, bytes, entry }`.
+- **Slug = capability:** `crypto.randomBytes(16)` → base64url (~22 chars),
+  cryptographically random, never sequential. The link is the access grant.
+- **Serve route:** `GET /p/<slug>/<path?>` in `http-routes.js`, **intentionally
+  unauthenticated** (that is the share model), registered in the public-route
+  section alongside `/health` and `/connect`.
+
+## Security model (the crux)
+
+chroxy auth accepts a `chroxy_auth` **cookie** (ws-server.js `_validateBearerAuth`),
+not only header/query tokens. A page served same-origin as the dashboard, opened
+in a browser that holds that cookie, could otherwise `fetch()` authed `/api/*`
+endpoints with the operator's ambient credential. Layered mitigations:
+
+1. **Static-only CSP on every served response:**
+   `default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; font-src 'self' data:; connect-src 'none'; script-src 'none'; sandbox;`
+   plus `X-Content-Type-Options: nosniff`, `Cross-Origin-Resource-Policy: same-origin`,
+   `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`.
+   `connect-src 'none'` + `script-src 'none'` mean a served page **cannot run JS
+   or make network calls** → the cookie-credential risk is neutralized. Interactive
+   pages would be an explicit opt-in on an isolated origin (follow-up).
+2. **Strict containment:** the slug is validated against the base64url charset
+   *and* must exist in the manifest before any filesystem access (never serve an
+   arbitrary path). The resolved file path is asserted to stay under
+   `~/.chroxy/pages/<slug>/`; `..`, absolute paths, and symlinks that escape the
+   page directory are rejected.
+3. **Rate-limit** the public route via the existing `getRateLimitKey` + limiter.
+4. **Disk hygiene:** per-page and total-size caps reject oversized publishes;
+   `chroxy pages rm <slug>` revokes a link instantly (deletes the dir + manifest entry).
+5. New token class **"page share slug"** documented in
+   `docs/security/bearer-token-authority.md`.
+
+## Publish & manage flow
+
+- **CLI:** `chroxy publish <file|dir> [--title "…"]` → copy in, mint slug, print
+  the full tunnel URL (or the LAN/local URL with a note when no tunnel is up).
+  `chroxy pages list` / `chroxy pages rm <slug>`.
+- **Server endpoint:** `POST /api/pages` (bearer-gated) `{ title, html | sourcePath }`
+  → `{ slug, url }`, so the **agent** can publish from its own shell and the
+  dashboard can wire a "Publish" button to the same endpoint.
+
+## Scope
+
+**MVP (this epic):**
+- PR-1 — core serve + security: `pages-store.js` (manifest, slug, containment,
+  size caps), the `/p/<slug>` route with CSP/security headers, tests, security-doc
+  update. *(security-sensitive — adversarial review)*
+- PR-2 — publish surface: `POST /api/pages` endpoint + `chroxy publish` /
+  `chroxy pages list|rm` CLI + tests.
+
+**Follow-ups (separate issues):**
+- Dashboard "Pages" panel (list, copy-link, delete) + a "Publish this artifact" button.
+- GitHub Pages export target.
+- Quartz vault target.
+- Interactive / JS pages served from an isolated origin.
+
+## Testing
+
+Path-traversal rejection (encoded `..`, symlink escape) · unknown/malformed slug
+→ 404 · correct MIME + all security headers present on served responses · manifest
+CRUD · size-cap rejection · rate-limit behaviour · `CHROXY_CONFIG_DIR` redirection
+so tests never touch the real `~/.chroxy`.
+
+## Out of scope (explicitly)
+
+Custom domains · page versioning/editing · interactive JS pages (until the
+isolated-origin follow-up) · the terminal input-latency / native-feel workstream
+(tracked separately — Pages does not address it).

--- a/docs/design/chroxy-pages.md
+++ b/docs/design/chroxy-pages.md
@@ -61,6 +61,14 @@ endpoints with the operator's ambient credential. Layered mitigations:
    `chroxy pages rm <slug>` revokes a link instantly (deletes the dir + manifest entry).
 5. New token class **"page share slug"** documented in
    `docs/security/bearer-token-authority.md`.
+6. **Serve-side size ceiling** — the per-page byte cap is re-checked on serve
+   (`statSync` vs `maxPageBytes`), not only at publish time, so a file that ever
+   grows past the cap can't be read unbounded into memory.
+
+**Accepted risk:** `GET /p/<guess>` returns `301` for an existing slug and `404`
+for a missing one — a slug-existence oracle. Against 128-bit random slugs under
+the per-IP rate limit this is academic (you cannot enumerate the space), so it is
+accepted rather than masked.
 
 ## Publish & manage flow
 

--- a/docs/security/bearer-token-authority.md
+++ b/docs/security/bearer-token-authority.md
@@ -1,6 +1,6 @@
 # Bearer Token Authority Threat Model
 
-Chroxy's WebSocket and HTTP control surfaces accept four distinct token classes, each with a different authority scope. This document pins the design so future PRs that add HTTP endpoints, WebSocket message types, or new credential paths don't accidentally widen (or fail to narrow) the trust boundary.
+Chroxy's WebSocket and HTTP control surfaces accept four distinct token classes, each with a different authority scope — plus two intentionally **unauthenticated** surfaces (the LAN-bind fingerprint surface, §10, and Chroxy Pages share-slug URLs, §11). This document pins the design so future PRs that add HTTP endpoints, WebSocket message types, or new credential paths don't accidentally widen (or fail to narrow) the trust boundary.
 
 For the transport-layer story (key exchange, message encryption, nonce handling), see [`encryption-threat-model.md`](encryption-threat-model.md). This doc covers **authorization**, not confidentiality.
 
@@ -183,7 +183,22 @@ Mitigations / visibility:
 
 Whether the *defaults* should change (loopback-by-default for the desktop app, explicit tunnel choice in the wizard) is tracked in issue #5356 and deliberately not decided here.
 
-## 11. Known Risks
+## 11. Page Share Slugs — Unauthenticated Capability URLs (Chroxy Pages, #5683)
+
+Chroxy Pages serves a published HTML artifact at `GET /p/<slug>/…` ([`http-routes.js`](../../packages/server/src/http-routes.js), store in [`pages-store.js`](../../packages/server/src/pages-store.js)). This route is **intentionally unauthenticated** — it presents no bearer token. The **slug itself is the capability**: a `crypto.randomBytes(16)` base64url value (~128 bits) minted per page, so an unguessable link is the entire access grant. This lets a report be opened on any device without distributing the primary token, by design.
+
+This is a deliberate exception to "every control surface is bearer-token gated," so it is fenced on every side:
+
+| Control | Mechanism |
+|---|---|
+| **No JS, no network in served pages** | Every response (including 404s) carries `Content-Security-Policy: …; script-src 'none'; connect-src 'none'; sandbox; default-src 'none'; …` plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cross-Origin-Resource-Policy: same-origin`, `Referrer-Policy: no-referrer`. This is the load-bearing control: because `_validateBearerAuth` accepts a **`chroxy_auth` cookie** (`ws-server.js`), a same-origin served page in a logged-in browser could otherwise script authed `/api/*` calls with the operator's ambient credential. `script-src 'none'` + `connect-src 'none'` make served pages fully static, so they cannot run code or reach any endpoint. Interactive (JS) pages are explicitly **not** served here — they would require an isolated origin (deferred follow-up). |
+| **No arbitrary filesystem reads** | The slug is validated against the base64url charset *and* must exist in the manifest before any fs access. `resolveFile()` resolves under `~/.chroxy/pages/<slug>/` and rejects `..`, absolute paths, and **symlinks whose real path escapes the page directory** (`realpathSync` containment check). |
+| **No slug scanning / disk DoS** | The route is per-IP rate-limited (`_pagesRateLimiter`) before any fs work. Per-page and total-size caps bound disk use; `chroxy pages rm <slug>` deletes the directory + manifest entry, revoking the link instantly. |
+| **Scope** | The route only serves files under the pages directory — it can never read session state, credentials, or any other `~/.chroxy/` content. |
+
+The unauthenticated blast radius is therefore: anyone who **already holds a valid slug** can read that one static page (which the publisher chose to share) — equivalent to handing someone the link. A scanner with no slug gets rate-limited 404s.
+
+## 12. Known Risks
 
 - **Static primary token is the default.** The QR shown at startup encodes an ephemeral pairing URL (not the primary token), so the leak surface is the OS keychain entry, a fallback `~/.chroxy/config.json` on systems without keychain support, or any environment / launcher that surfaces the token in process listings. If any of those are exfiltrated, the attacker has full authority until the user rotates. Rotation is opt-in.
 - **No certificate pinning or out-of-band key verification.** See [`encryption-threat-model.md` §8 — Trust On First Use](encryption-threat-model.md#trust-on-first-use-tofu).

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, existsSync, statSync } from 'fs'
 import { join, resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import QRCode from 'qrcode'
@@ -286,6 +286,14 @@ export function createHttpHandler(server) {
         }
         let body
         try {
+          // Defence-in-depth: enforce the per-page size cap on SERVE too, not
+          // just at publish time, so a file that somehow grew past the cap (a
+          // future publish path, an external write) can't be read unbounded
+          // into memory.
+          if (statSync(filePath).size > server.pagesStore.maxPageBytes) {
+            notFound()
+            return
+          }
           body = readFileSync(filePath)
         } catch {
           notFound()

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -11,6 +11,24 @@ import { listSnapshots, deleteSnapshot } from './snapshots-store.js'
 import { handleEventIngest } from './event-ingest.js'
 import { isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
+import { isValidSlug, mimeForPath } from './pages-store.js'
+
+// #5683 — security headers for every Chroxy Pages response. The `/p/<slug>`
+// route is intentionally UNAUTHENTICATED (the slug is the capability), and
+// chroxy auth accepts a `chroxy_auth` cookie, so a same-origin served page in a
+// logged-in browser could otherwise script authed `/api/*` calls. `script-src
+// 'none'` + `connect-src 'none'` + `sandbox` make served pages fully static (no
+// JS, no network), neutralizing that risk — which is also exactly right for the
+// HTML reports this serves. See docs/security/bearer-token-authority.md.
+const PAGE_SECURITY_HEADERS = {
+  'Content-Security-Policy':
+    "default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; font-src 'self' data:; connect-src 'none'; script-src 'none'; base-uri 'none'; form-action 'none'; sandbox",
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Cross-Origin-Resource-Policy': 'same-origin',
+  'Referrer-Policy': 'no-referrer',
+  'Cache-Control': 'no-store',
+}
 
 const log = createLogger('ws')
 
@@ -211,6 +229,76 @@ export function createHttpHandler(server) {
       })
       res.end(JSON.stringify({ status: 'ok', mode: server.serverMode, version: SERVER_VERSION }))
       return
+    }
+
+    // #5683 — Chroxy Pages: serve a published HTML artifact at an unguessable,
+    // UNAUTHENTICATED URL (the slug is the capability). Static-only CSP headers
+    // (PAGE_SECURITY_HEADERS) neutralize the cookie-auth risk. Placed in the
+    // public section, before the authed routes, and only active when a pages
+    // store is wired.
+    {
+      const pagesPath = (req.url ?? '').split('?')[0]
+      if (req.method === 'GET' && pagesPath.startsWith('/p/') && server.pagesStore) {
+        // Rate-limit BEFORE any filesystem work so the public route can't be
+        // used to scan slugs or DoS the disk.
+        const limiter = server._pagesRateLimiter
+        if (limiter) {
+          const socketIp = req.socket?.remoteAddress || ''
+          const { allowed, retryAfterMs } = limiter.check(getRateLimitKey(socketIp, req))
+          if (!allowed) {
+            res.writeHead(429, { 'Content-Type': 'text/plain', 'Retry-After': Math.ceil(retryAfterMs / 1000) })
+            res.end('rate limited')
+            return
+          }
+        }
+
+        const notFound = () => {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8', ...PAGE_SECURITY_HEADERS })
+          res.end('Not found')
+        }
+
+        const m = pagesPath.match(/^\/p\/([^/]+)(?:\/(.*))?$/)
+        let slug = null
+        let rel = ''
+        if (m) {
+          try {
+            slug = decodeURIComponent(m[1])
+            rel = m[2] != null ? decodeURIComponent(m[2]) : ''
+          } catch {
+            slug = null // malformed percent-encoding
+          }
+        }
+        if (!slug || !isValidSlug(slug) || !server.pagesStore.get(slug)) {
+          notFound()
+          return
+        }
+        // Trailing-slash redirect (`/p/<slug>` → `/p/<slug>/`) so a page's
+        // relative asset URLs resolve under its own directory.
+        if (m[2] == null) {
+          res.writeHead(301, { Location: `/p/${encodeURIComponent(slug)}/`, 'Cache-Control': 'no-store' })
+          res.end()
+          return
+        }
+        const filePath = server.pagesStore.resolveFile(slug, rel)
+        if (!filePath) {
+          notFound()
+          return
+        }
+        let body
+        try {
+          body = readFileSync(filePath)
+        } catch {
+          notFound()
+          return
+        }
+        res.writeHead(200, {
+          'Content-Type': mimeForPath(filePath),
+          'Content-Length': body.byteLength,
+          ...PAGE_SECURITY_HEADERS,
+        })
+        res.end(body)
+        return
+      }
     }
 
     // Version endpoint

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -246,7 +246,11 @@ export function createHttpHandler(server) {
           const socketIp = req.socket?.remoteAddress || ''
           const { allowed, retryAfterMs } = limiter.check(getRateLimitKey(socketIp, req))
           if (!allowed) {
-            res.writeHead(429, { 'Content-Type': 'text/plain', 'Retry-After': Math.ceil(retryAfterMs / 1000) })
+            res.writeHead(429, {
+              'Content-Type': 'text/plain; charset=utf-8',
+              'Retry-After': Math.ceil(retryAfterMs / 1000),
+              ...PAGE_SECURITY_HEADERS,
+            })
             res.end('rate limited')
             return
           }
@@ -275,7 +279,7 @@ export function createHttpHandler(server) {
         // Trailing-slash redirect (`/p/<slug>` → `/p/<slug>/`) so a page's
         // relative asset URLs resolve under its own directory.
         if (m[2] == null) {
-          res.writeHead(301, { Location: `/p/${encodeURIComponent(slug)}/`, 'Cache-Control': 'no-store' })
+          res.writeHead(301, { Location: `/p/${encodeURIComponent(slug)}/`, ...PAGE_SECURITY_HEADERS })
           res.end()
           return
         }

--- a/packages/server/src/pages-store.js
+++ b/packages/server/src/pages-store.js
@@ -1,0 +1,236 @@
+// #5683 / #5684 — Chroxy Pages store.
+//
+// Manages HTML artifacts published to an unguessable, self-hosted URL served by
+// the daemon's own HTTP server over the existing tunnel (see the `/p/<slug>`
+// route in http-routes.js). The slug IS the access capability — anyone with the
+// link can view the page, no bearer token required — so the slug must be
+// cryptographically random and the serve path must be tightly contained.
+//
+// Storage layout (under ~/.chroxy/pages/, redirectable via the constructor for
+// sandbox-safe tests):
+//   pages/<slug>/index.html        — the page entry + any co-located assets
+//   pages/index.json               — manifest { version, pages: { <slug>: meta } }
+//
+// Design: docs/design/chroxy-pages.md
+
+import { randomBytes } from 'node:crypto'
+import {
+  readFileSync, writeFileSync, renameSync, mkdirSync, rmSync,
+  existsSync, realpathSync,
+} from 'node:fs'
+import { join, resolve, sep, posix } from 'node:path'
+
+export const MANIFEST_VERSION = 1
+export const DEFAULT_MAX_PAGE_BYTES = 5 * 1024 * 1024 //  5 MB per page
+export const DEFAULT_MAX_TOTAL_BYTES = 100 * 1024 * 1024 // 100 MB across all pages
+export const SLUG_BYTES = 16 // → 22-char base64url
+export const DEFAULT_ENTRY = 'index.html'
+
+// base64url alphabet; length-bounded to reject anything that isn't a plausible
+// minted slug before it ever touches the filesystem.
+const SLUG_RE = /^[A-Za-z0-9_-]{16,64}$/
+
+/** True iff `slug` matches the minted-slug shape (cheap pre-fs guard). */
+export function isValidSlug(slug) {
+  return typeof slug === 'string' && SLUG_RE.test(slug)
+}
+
+const EXT_MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.htm': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8', // served, but script-src 'none' CSP blocks execution
+  '.json': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/plain; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+/** MIME type for a file path by extension; `application/octet-stream` fallback. */
+export function mimeForPath(p) {
+  const dot = p.lastIndexOf('.')
+  const ext = dot >= 0 ? p.slice(dot).toLowerCase() : ''
+  return EXT_MIME[ext] || 'application/octet-stream'
+}
+
+export class PagesStore {
+  /**
+   * @param {object} opts
+   * @param {string} opts.pagesDir          root dir for published pages (e.g. ~/.chroxy/pages)
+   * @param {number} [opts.maxPageBytes]     per-page size cap
+   * @param {number} [opts.maxTotalBytes]    total-across-pages size cap
+   */
+  constructor({ pagesDir, maxPageBytes = DEFAULT_MAX_PAGE_BYTES, maxTotalBytes = DEFAULT_MAX_TOTAL_BYTES } = {}) {
+    if (!pagesDir) throw new Error('PagesStore requires a pagesDir')
+    this._pagesDir = resolve(pagesDir)
+    this._maxPageBytes = maxPageBytes
+    this._maxTotalBytes = maxTotalBytes
+    this._manifestPath = join(this._pagesDir, 'index.json')
+    this._manifest = this._loadManifest()
+  }
+
+  _loadManifest() {
+    try {
+      const raw = JSON.parse(readFileSync(this._manifestPath, 'utf8'))
+      if (raw && typeof raw === 'object' && raw.pages && typeof raw.pages === 'object') {
+        return { version: MANIFEST_VERSION, pages: raw.pages }
+      }
+    } catch {
+      // missing / malformed → fresh manifest
+    }
+    return { version: MANIFEST_VERSION, pages: {} }
+  }
+
+  _saveManifest() {
+    const tmp = `${this._manifestPath}.tmp`
+    try {
+      mkdirSync(this._pagesDir, { recursive: true })
+      writeFileSync(tmp, JSON.stringify(this._manifest), 'utf8')
+      renameSync(tmp, this._manifestPath)
+    } catch (err) {
+      try { rmSync(tmp, { force: true }) } catch { /* ignore */ }
+      throw err
+    }
+  }
+
+  /** Mint a fresh, unique, cryptographically-random base64url slug. */
+  _mintSlug() {
+    for (let i = 0; i < 8; i++) {
+      const slug = randomBytes(SLUG_BYTES).toString('base64url')
+      if (!this._manifest.pages[slug]) return slug
+    }
+    // Astronomically unlikely; fail loudly rather than overwrite.
+    throw new Error('Failed to mint a unique page slug')
+  }
+
+  /** Current total bytes across all published pages. */
+  _totalBytes() {
+    let total = 0
+    for (const slug in this._manifest.pages) total += this._manifest.pages[slug].bytes || 0
+    return total
+  }
+
+  /**
+   * Validate a relative file path supplied by a publisher: a forward-slash
+   * relative path with no traversal, drive, or absolute component. Returns the
+   * normalized relative path, or null if it would escape the page directory.
+   */
+  _safeRelPath(relPath) {
+    if (typeof relPath !== 'string' || relPath.length === 0) return null
+    // Reject backslashes, NUL, leading slash, drive letters up front.
+    if (relPath.includes('\0') || relPath.includes('\\')) return null
+    if (relPath.startsWith('/') || /^[A-Za-z]:/.test(relPath)) return null
+    const normalized = posix.normalize(relPath)
+    if (normalized === '.' || normalized.startsWith('..') || normalized.includes('/../') || normalized.endsWith('/..')) {
+      return null
+    }
+    if (normalized.startsWith('/')) return null
+    return normalized
+  }
+
+  /**
+   * Publish a page from an array of in-memory files.
+   * @param {object} opts
+   * @param {string} [opts.title]
+   * @param {Array<{path: string, content: Buffer|string}>} opts.files — must include `index.html`
+   * @returns {{ slug, title, createdAt, bytes, entry }}
+   */
+  publish({ title = 'Untitled', files } = {}) {
+    if (!Array.isArray(files) || files.length === 0) {
+      throw new Error('publish requires a non-empty files array')
+    }
+    // Normalize + validate every file path, and compute total size.
+    const prepared = []
+    let bytes = 0
+    let hasEntry = false
+    for (const f of files) {
+      const rel = this._safeRelPath(f?.path)
+      if (!rel) throw new Error(`Invalid page file path: ${JSON.stringify(f?.path)}`)
+      const content = Buffer.isBuffer(f.content) ? f.content : Buffer.from(String(f.content ?? ''), 'utf8')
+      bytes += content.byteLength
+      if (rel === DEFAULT_ENTRY) hasEntry = true
+      prepared.push({ rel, content })
+    }
+    if (!hasEntry) throw new Error(`publish requires an "${DEFAULT_ENTRY}" file`)
+    if (bytes > this._maxPageBytes) {
+      throw new Error(`Page too large: ${bytes} bytes exceeds the ${this._maxPageBytes}-byte per-page cap`)
+    }
+    if (this._totalBytes() + bytes > this._maxTotalBytes) {
+      throw new Error(`Publishing would exceed the ${this._maxTotalBytes}-byte total pages cap`)
+    }
+
+    const slug = this._mintSlug()
+    const dir = join(this._pagesDir, slug)
+    mkdirSync(dir, { recursive: true })
+    for (const { rel, content } of prepared) {
+      const dest = join(dir, rel)
+      mkdirSync(resolve(dest, '..'), { recursive: true })
+      writeFileSync(dest, content)
+    }
+    const meta = { slug, title: String(title).slice(0, 200), createdAt: Date.now(), bytes, entry: DEFAULT_ENTRY }
+    this._manifest.pages[slug] = meta
+    this._saveManifest()
+    return meta
+  }
+
+  /** Convenience: publish a single self-contained HTML document. */
+  publishHtml({ title, html } = {}) {
+    return this.publish({ title, files: [{ path: DEFAULT_ENTRY, content: html }] })
+  }
+
+  /** Manifest entry for a slug, or null. */
+  get(slug) {
+    if (!isValidSlug(slug)) return null
+    return this._manifest.pages[slug] || null
+  }
+
+  /** All published pages, newest first. */
+  list() {
+    return Object.values(this._manifest.pages).sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))
+  }
+
+  /** Delete a page (revokes its share link). Returns true if it existed. */
+  remove(slug) {
+    if (!isValidSlug(slug) || !this._manifest.pages[slug]) return false
+    delete this._manifest.pages[slug]
+    this._saveManifest()
+    try { rmSync(join(this._pagesDir, slug), { recursive: true, force: true }) } catch { /* best-effort */ }
+    return true
+  }
+
+  /**
+   * Resolve a request for `pages/<slug>/<relPath>` to an absolute, CONTAINED
+   * file path. Returns null when the slug is unknown/invalid, the relative path
+   * is unsafe, or the resolved real path escapes the page directory (symlink
+   * defence). An empty relPath resolves to the page's entry (index.html).
+   */
+  resolveFile(slug, relPath) {
+    if (!isValidSlug(slug)) return null
+    const meta = this._manifest.pages[slug]
+    if (!meta) return null
+
+    const rel = (!relPath || relPath === '' || relPath === '/') ? meta.entry || DEFAULT_ENTRY : this._safeRelPath(relPath)
+    if (!rel) return null
+
+    const pageDir = join(this._pagesDir, slug)
+    const candidate = resolve(pageDir, rel)
+    // Lexical containment: the resolved path must sit under the page dir.
+    const pageDirWithSep = resolve(pageDir) + sep
+    if (candidate !== resolve(pageDir) && !candidate.startsWith(pageDirWithSep)) return null
+    if (!existsSync(candidate)) return null
+    // Symlink defence: the REAL path must also stay contained.
+    let real
+    try { real = realpathSync(candidate) } catch { return null }
+    const realDir = (() => { try { return realpathSync(pageDir) } catch { return resolve(pageDir) } })()
+    if (real !== realDir && !real.startsWith(realDir + sep)) return null
+    return real
+  }
+}

--- a/packages/server/src/pages-store.js
+++ b/packages/server/src/pages-store.js
@@ -77,6 +77,11 @@ export class PagesStore {
     this._manifest = this._loadManifest()
   }
 
+  /** Per-page byte cap — also used as a serve-side ceiling (defence-in-depth). */
+  get maxPageBytes() {
+    return this._maxPageBytes
+  }
+
   _loadManifest() {
     try {
       const raw = JSON.parse(readFileSync(this._manifestPath, 'utf8'))

--- a/packages/server/src/pages-store.js
+++ b/packages/server/src/pages-store.js
@@ -95,10 +95,15 @@ export class PagesStore {
   }
 
   _saveManifest() {
-    const tmp = `${this._manifestPath}.tmp`
+    // Per-pid temp suffix avoids a collision if two writers race the rename.
+    const tmp = `${this._manifestPath}.${process.pid}.tmp`
     try {
-      mkdirSync(this._pagesDir, { recursive: true })
-      writeFileSync(tmp, JSON.stringify(this._manifest), 'utf8')
+      // 0700 dir / 0600 file: slugs are capability URLs, so the manifest
+      // (index.json) and page contents must not be world-readable even under a
+      // permissive umask. umask can only clear bits, never add them, so passing
+      // the mode guarantees at-most these permissions.
+      mkdirSync(this._pagesDir, { recursive: true, mode: 0o700 })
+      writeFileSync(tmp, JSON.stringify(this._manifest), { encoding: 'utf8', mode: 0o600 })
       renameSync(tmp, this._manifestPath)
     } catch (err) {
       try { rmSync(tmp, { force: true }) } catch { /* ignore */ }
@@ -174,11 +179,13 @@ export class PagesStore {
 
     const slug = this._mintSlug()
     const dir = join(this._pagesDir, slug)
-    mkdirSync(dir, { recursive: true })
+    // 0700 dirs / 0600 files — page contents + slugs are sensitive (see
+    // _saveManifest). A permissive umask can't widen these.
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
     for (const { rel, content } of prepared) {
       const dest = join(dir, rel)
-      mkdirSync(resolve(dest, '..'), { recursive: true })
-      writeFileSync(dest, content)
+      mkdirSync(resolve(dest, '..'), { recursive: true, mode: 0o700 })
+      writeFileSync(dest, content, { mode: 0o600 })
     }
     const meta = { slug, title: String(title).slice(0, 200), createdAt: Date.now(), bytes, entry: DEFAULT_ENTRY }
     this._manifest.pages[slug] = meta

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -5,6 +5,8 @@ import { WebSocketServer } from 'ws'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
+import { homedir } from 'os'
+import { PagesStore } from './pages-store.js'
 import { decrypt, DIRECTION_CLIENT } from '@chroxy/store-core/crypto'
 import { safeTokenCompare } from './token-compare.js'
 import { createClientSender } from './ws-client-sender.js'
@@ -496,7 +498,7 @@ function _isSecureRequest(req) {
  *   - A session operation failed in an expected, user-facing way → `session_error`
  */
 export class WsServer {
-  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, config = null, diagnosticsRateLimit = null, devicePreferences = null } = {}) {
+  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, config = null, diagnosticsRateLimit = null, devicePreferences = null, pagesStore = null } = {}) {
     this.port = port
     this.apiToken = apiToken
     this._tokenManager = tokenManager || null
@@ -544,6 +546,15 @@ export class WsServer {
     this._diagnosticsRateLimiter = new RateLimiter(
       { name: 'diagnostics', ...resolveDiagnosticsRateLimit(diagnosticsRateLimit) }
     )
+    // #5683 — Chroxy Pages. Per-IP limiter for the public `/p/<slug>` route
+    // (assets + refreshes are more frequent than diagnostics, hence higher
+    // than /diagnostics but still bounded to blunt slug-scanning). The store is
+    // injectable for tests; the default is rooted at $CHROXY_CONFIG_DIR /
+    // ~/.chroxy/pages and only READS on construct (no sandbox write).
+    this._pagesRateLimiter = new RateLimiter({ name: 'pages', windowMs: 60_000, maxMessages: 120, burst: 30 })
+    this.pagesStore = pagesStore || new PagesStore({
+      pagesDir: join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'pages'),
+    })
     this._clientSend = createClientSender(log)
     this._clientManager = new WsClientManager()
     this.clients = this._clientManager.clients // back-compat: expose the raw Map for context objects

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -498,7 +498,7 @@ function _isSecureRequest(req) {
  *   - A session operation failed in an expected, user-facing way → `session_error`
  */
 export class WsServer {
-  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, config = null, diagnosticsRateLimit = null, devicePreferences = null, pagesStore = null } = {}) {
+  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, config = null, diagnosticsRateLimit = null, devicePreferences = null, pagesStore = null, pagesRateLimiter } = {}) {
     this.port = port
     this.apiToken = apiToken
     this._tokenManager = tokenManager || null
@@ -551,7 +551,12 @@ export class WsServer {
     // than /diagnostics but still bounded to blunt slug-scanning). The store is
     // injectable for tests; the default is rooted at $CHROXY_CONFIG_DIR /
     // ~/.chroxy/pages and only READS on construct (no sandbox write).
-    this._pagesRateLimiter = new RateLimiter({ name: 'pages', windowMs: 60_000, maxMessages: 120, burst: 30 })
+    // Injectable so tests/deployments can override or DISABLE it (pass null).
+    // `!== undefined` (not ||/??) so an explicit null genuinely disables the
+    // limiter rather than falling back to the default.
+    this._pagesRateLimiter = pagesRateLimiter !== undefined
+      ? pagesRateLimiter
+      : new RateLimiter({ name: 'pages', windowMs: 60_000, maxMessages: 120, burst: 30 })
     this.pagesStore = pagesStore || new PagesStore({
       pagesDir: join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'pages'),
     })

--- a/packages/server/tests/pages-serve.test.js
+++ b/packages/server/tests/pages-serve.test.js
@@ -3,7 +3,7 @@ import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createHttpHandler } from '../src/http-routes.js'
@@ -93,4 +93,24 @@ test('the pages route does not require (or consult) bearer auth', async () => {
   const meta = store.publishHtml({ title: 'public', html: '<p>open</p>' })
   const res = await fetch(`${base}/p/${meta.slug}/`)
   assert.equal(res.status, 200)
+})
+
+test('serve-side size ceiling: a file grown past the cap is not served (404)', async () => {
+  // Defence-in-depth: even if a file bypasses the publish-time cap, serve must
+  // refuse it rather than read it unbounded.
+  const d = mkdtempSync(join(tmpdir(), 'chroxy-pages-cap-'))
+  const smallStore = new PagesStore({ pagesDir: d, maxPageBytes: 50 })
+  const meta = smallStore.publishHtml({ title: 't', html: 'small' }) // within cap
+  writeFileSync(join(d, meta.slug, 'index.html'), 'x'.repeat(500)) // grow past cap
+  const srv = createServer(createHttpHandler({ ...mockServer(), pagesStore: smallStore }))
+  srv.listen(0, '127.0.0.1')
+  await once(srv, 'listening')
+  const b = `http://127.0.0.1:${srv.address().port}`
+  try {
+    const res = await fetch(`${b}/p/${meta.slug}/`)
+    assert.equal(res.status, 404)
+  } finally {
+    srv.close()
+    rmSync(d, { recursive: true, force: true })
+  }
 })

--- a/packages/server/tests/pages-serve.test.js
+++ b/packages/server/tests/pages-serve.test.js
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createHttpHandler } from '../src/http-routes.js'
 import { PagesStore } from '../src/pages-store.js'
+import { RateLimiter } from '../src/rate-limiter.js'
 
 let dir, store, httpServer, base
 
@@ -93,6 +94,27 @@ test('the pages route does not require (or consult) bearer auth', async () => {
   const meta = store.publishHtml({ title: 'public', html: '<p>open</p>' })
   const res = await fetch(`${base}/p/${meta.slug}/`)
   assert.equal(res.status, 200)
+})
+
+test('per-IP rate limiter returns 429 + Retry-After + security headers and gates fs work', async () => {
+  // A tight limiter: 1 request per window, no burst → the 2nd request is denied.
+  const limiter = new RateLimiter({ name: 'pages-test', windowMs: 60_000, maxMessages: 1, burst: 0 })
+  const meta = store.publishHtml({ title: 't', html: '<p>x</p>' })
+  const srv = createServer(createHttpHandler({ ...mockServer(), _pagesRateLimiter: limiter }))
+  srv.listen(0, '127.0.0.1')
+  await once(srv, 'listening')
+  const b = `http://127.0.0.1:${srv.address().port}`
+  try {
+    const first = await fetch(`${b}/p/${meta.slug}/`)
+    assert.equal(first.status, 200)
+    const second = await fetch(`${b}/p/${meta.slug}/`)
+    assert.equal(second.status, 429)
+    assert.ok(Number(second.headers.get('retry-after')) >= 0)
+    // Even the rate-limited response carries the static-only CSP.
+    assert.match(second.headers.get('content-security-policy'), /script-src 'none'/)
+  } finally {
+    srv.close()
+  }
 })
 
 test('serve-side size ceiling: a file grown past the cap is not served (404)', async () => {

--- a/packages/server/tests/pages-serve.test.js
+++ b/packages/server/tests/pages-serve.test.js
@@ -1,0 +1,96 @@
+// #5683 — integration tests for the public `/p/<slug>` Chroxy Pages route.
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createHttpHandler } from '../src/http-routes.js'
+import { PagesStore } from '../src/pages-store.js'
+
+let dir, store, httpServer, base
+
+// A minimal mock WsServer: only the fields the /p/ route + early routes touch.
+function mockServer() {
+  return {
+    apiToken: 'tok',
+    authRequired: true,
+    serverMode: 'multi',
+    pagesStore: store,
+    _pagesRateLimiter: null, // disabled for these functional tests
+    _validateBearerAuth() { return false }, // authed routes always reject here
+  }
+}
+
+before(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'chroxy-pages-serve-'))
+  store = new PagesStore({ pagesDir: dir })
+  httpServer = createServer(createHttpHandler(mockServer()))
+  httpServer.listen(0, '127.0.0.1')
+  await once(httpServer, 'listening')
+  base = `http://127.0.0.1:${httpServer.address().port}`
+})
+
+after(() => {
+  httpServer?.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+test('serves a published page with the static-only security headers and no auth', async () => {
+  const meta = store.publish({
+    title: 'Report',
+    files: [
+      { path: 'index.html', content: '<!doctype html><h1>Report</h1>' },
+      { path: 'style.css', content: 'h1{color:red}' },
+    ],
+  })
+  // No Authorization header — the slug is the capability.
+  const res = await fetch(`${base}/p/${meta.slug}/`)
+  assert.equal(res.status, 200)
+  assert.match(res.headers.get('content-type'), /text\/html/)
+  const csp = res.headers.get('content-security-policy')
+  assert.match(csp, /script-src 'none'/)
+  assert.match(csp, /connect-src 'none'/)
+  assert.match(csp, /sandbox/)
+  assert.equal(res.headers.get('x-content-type-options'), 'nosniff')
+  assert.equal(res.headers.get('x-frame-options'), 'DENY')
+  assert.equal(res.headers.get('cross-origin-resource-policy'), 'same-origin')
+  assert.match(await res.text(), /<h1>Report<\/h1>/)
+
+  // Asset served with correct MIME + same headers.
+  const css = await fetch(`${base}/p/${meta.slug}/style.css`)
+  assert.equal(css.status, 200)
+  assert.match(css.headers.get('content-type'), /text\/css/)
+  assert.match(css.headers.get('content-security-policy'), /script-src 'none'/)
+})
+
+test('redirects /p/<slug> (no trailing slash) to /p/<slug>/', async () => {
+  const meta = store.publishHtml({ title: 't', html: '<p>x</p>' })
+  const res = await fetch(`${base}/p/${meta.slug}`, { redirect: 'manual' })
+  assert.equal(res.status, 301)
+  assert.equal(res.headers.get('location'), `/p/${meta.slug}/`)
+})
+
+test('404s unknown, malformed, and traversal slugs/paths', async () => {
+  // Unknown but well-formed slug.
+  let res = await fetch(`${base}/p/Zzzzzzzzzzzzzzzzzzzzzz/`)
+  assert.equal(res.status, 404)
+  // Malformed slug (too short / bad charset).
+  res = await fetch(`${base}/p/short/`)
+  assert.equal(res.status, 404)
+  // Path traversal in the asset segment of a real page.
+  const meta = store.publishHtml({ title: 't', html: '<p>x</p>' })
+  res = await fetch(`${base}/p/${meta.slug}/..%2f..%2findex.json`)
+  assert.equal(res.status, 404)
+  // 404 responses still carry the security headers.
+  assert.match(res.headers.get('content-security-policy'), /default-src 'none'/)
+})
+
+test('the pages route does not require (or consult) bearer auth', async () => {
+  // _validateBearerAuth always returns false in the mock; a 200 here proves the
+  // route never reached the auth gate.
+  const meta = store.publishHtml({ title: 'public', html: '<p>open</p>' })
+  const res = await fetch(`${base}/p/${meta.slug}/`)
+  assert.equal(res.status, 200)
+})

--- a/packages/server/tests/pages-store.test.js
+++ b/packages/server/tests/pages-store.test.js
@@ -1,0 +1,156 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, symlinkSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  PagesStore, isValidSlug, mimeForPath, DEFAULT_ENTRY,
+} from '../src/pages-store.js'
+
+function freshStore(opts = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-pages-'))
+  const store = new PagesStore({ pagesDir: dir, ...opts })
+  return { dir, store, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+test('isValidSlug accepts base64url shapes and rejects junk/traversal', () => {
+  assert.equal(isValidSlug('Xa9f8k2lmZ0qPwRtUvWxYz'), true)
+  assert.equal(isValidSlug('short'), false)
+  assert.equal(isValidSlug('../etc/passwd'), false)
+  assert.equal(isValidSlug('has space here aaaaaaaa'), false)
+  assert.equal(isValidSlug('has/slash/aaaaaaaaaaaa'), false)
+  assert.equal(isValidSlug(''), false)
+  assert.equal(isValidSlug(null), false)
+})
+
+test('mimeForPath maps extensions and falls back to octet-stream', () => {
+  assert.equal(mimeForPath('a/index.html'), 'text/html; charset=utf-8')
+  assert.equal(mimeForPath('style.css'), 'text/css; charset=utf-8')
+  assert.equal(mimeForPath('logo.PNG'), 'image/png')
+  assert.equal(mimeForPath('data.bin'), 'application/octet-stream')
+  assert.equal(mimeForPath('noext'), 'application/octet-stream')
+})
+
+test('publishHtml → get → list → remove round-trip', () => {
+  const { store, dir, cleanup } = freshStore()
+  try {
+    const meta = store.publishHtml({ title: 'Report', html: '<h1>hi</h1>' })
+    assert.ok(isValidSlug(meta.slug))
+    assert.equal(meta.title, 'Report')
+    assert.equal(meta.entry, DEFAULT_ENTRY)
+    assert.ok(meta.bytes > 0)
+    // File on disk under the slug dir.
+    assert.equal(readFileSync(join(dir, meta.slug, 'index.html'), 'utf8'), '<h1>hi</h1>')
+    // get + list see it.
+    assert.equal(store.get(meta.slug).title, 'Report')
+    assert.equal(store.list().length, 1)
+    // Manifest persisted.
+    const manifest = JSON.parse(readFileSync(join(dir, 'index.json'), 'utf8'))
+    assert.ok(manifest.pages[meta.slug])
+    // remove revokes + deletes the dir.
+    assert.equal(store.remove(meta.slug), true)
+    assert.equal(store.get(meta.slug), null)
+    assert.equal(existsSync(join(dir, meta.slug)), false)
+    assert.equal(store.remove(meta.slug), false) // idempotent
+  } finally { cleanup() }
+})
+
+test('publish requires an index.html entry and a non-empty files array', () => {
+  const { store, cleanup } = freshStore()
+  try {
+    assert.throws(() => store.publish({ title: 't', files: [] }), /non-empty/)
+    assert.throws(() => store.publish({ title: 't', files: [{ path: 'other.html', content: 'x' }] }), /index\.html/)
+  } finally { cleanup() }
+})
+
+test('publish rejects unsafe file paths (traversal / absolute / backslash)', () => {
+  const { store, cleanup } = freshStore()
+  try {
+    for (const bad of ['../escape.html', '/abs.html', '..\\win.html', 'a/../../b.html']) {
+      assert.throws(
+        () => store.publish({ title: 't', files: [{ path: DEFAULT_ENTRY, content: 'ok' }, { path: bad, content: 'x' }] }),
+        /Invalid page file path/,
+        `expected ${bad} to be rejected`,
+      )
+    }
+  } finally { cleanup() }
+})
+
+test('publish enforces per-page and total size caps', () => {
+  const big = 'x'.repeat(1024)
+  // per-page cap of 100 bytes
+  const a = freshStore({ maxPageBytes: 100 })
+  try {
+    assert.throws(() => a.store.publishHtml({ title: 't', html: big }), /per-page cap/)
+  } finally { a.cleanup() }
+  // total cap of 30 bytes — first small page ok, second pushes over
+  const b = freshStore({ maxTotalBytes: 30 })
+  try {
+    b.store.publishHtml({ title: '1', html: 'aaaaaaaaaa' }) // 10 bytes
+    b.store.publishHtml({ title: '2', html: 'bbbbbbbbbb' }) // 20 total
+    assert.throws(() => b.store.publishHtml({ title: '3', html: 'cccccccccccccccc' }), /total pages cap/)
+  } finally { b.cleanup() }
+})
+
+test('resolveFile contains paths and defeats traversal + symlink escape', () => {
+  const { store, dir, cleanup } = freshStore()
+  try {
+    // A secret file OUTSIDE the pages dir.
+    const secret = join(dir, '..', `chroxy-secret-${process.pid}.txt`)
+    writeFileSync(secret, 'TOP SECRET')
+
+    const meta = store.publish({
+      title: 't',
+      files: [
+        { path: DEFAULT_ENTRY, content: '<h1>page</h1>' },
+        { path: 'assets/app.css', content: 'body{}' },
+      ],
+    })
+    const slug = meta.slug
+
+    // Entry resolves (empty rel → index.html).
+    assert.ok(store.resolveFile(slug, '').endsWith(join(slug, 'index.html')))
+    // Nested asset resolves.
+    assert.ok(store.resolveFile(slug, 'assets/app.css').endsWith(join(slug, 'assets', 'app.css')))
+    // Traversal is rejected.
+    assert.equal(store.resolveFile(slug, '../index.json'), null)
+    assert.equal(store.resolveFile(slug, '../../etc/hosts'), null)
+    // Unknown / invalid slug.
+    assert.equal(store.resolveFile('Zzzzzzzzzzzzzzzzzzzzzz', ''), null)
+    assert.equal(store.resolveFile('../bad', ''), null)
+    // Nonexistent file in a real page.
+    assert.equal(store.resolveFile(slug, 'nope.css'), null)
+
+    // Symlink escape: plant a symlink inside the page dir pointing OUT.
+    const link = join(dir, slug, 'leak.txt')
+    try {
+      symlinkSync(secret, link)
+      assert.equal(store.resolveFile(slug, 'leak.txt'), null, 'symlink escaping the page dir must not resolve')
+    } catch (err) {
+      if (err.code !== 'EPERM') throw err // some CI filesystems forbid symlink; skip if so
+    }
+  } finally { cleanup() }
+})
+
+test('manifest survives a fresh store instance over the same dir', () => {
+  const { store, dir, cleanup } = freshStore()
+  try {
+    const meta = store.publishHtml({ title: 'persist', html: '<p>x</p>' })
+    const reopened = new PagesStore({ pagesDir: dir })
+    assert.equal(reopened.get(meta.slug).title, 'persist')
+    assert.equal(reopened.list().length, 1)
+  } finally { cleanup() }
+})
+
+test('minted slugs are unique and base64url', () => {
+  const { store, cleanup } = freshStore()
+  try {
+    const slugs = new Set()
+    for (let i = 0; i < 50; i++) {
+      const meta = store.publishHtml({ title: `p${i}`, html: 'x' })
+      assert.ok(isValidSlug(meta.slug))
+      assert.equal(slugs.has(meta.slug), false)
+      slugs.add(meta.slug)
+    }
+  } finally { cleanup() }
+})

--- a/packages/server/tests/pages-store.test.js
+++ b/packages/server/tests/pages-store.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, symlinkSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, symlinkSync, existsSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -129,6 +129,16 @@ test('resolveFile contains paths and defeats traversal + symlink escape', () => 
     } catch (err) {
       if (err.code !== 'EPERM') throw err // some CI filesystems forbid symlink; skip if so
     }
+  } finally { cleanup() }
+})
+
+test('published dirs are 0700, files + manifest are 0600 (POSIX)', { skip: process.platform === 'win32' }, () => {
+  const { store, dir, cleanup } = freshStore()
+  try {
+    const meta = store.publishHtml({ title: 't', html: '<p>x</p>' })
+    assert.equal(statSync(join(dir, meta.slug)).mode & 0o777, 0o700, 'page dir 0700')
+    assert.equal(statSync(join(dir, meta.slug, 'index.html')).mode & 0o777, 0o600, 'page file 0600')
+    assert.equal(statSync(join(dir, 'index.json')).mode & 0o777, 0o600, 'manifest 0600')
   } finally { cleanup() }
 })
 


### PR DESCRIPTION
First slice of the **Chroxy Pages** epic (#5683) — publish an HTML artifact to an unguessable, self-hosted URL served by the daemon's own HTTP server over the tunnel you already run. Design: [`docs/design/chroxy-pages.md`](../blob/feat/pages-core/docs/design/chroxy-pages.md).

## What's here (PR-1: core serve + security)
- **`pages-store.js`** — `PagesStore`: manifest (`~/.chroxy/pages/index.json`, atomic temp+rename), `crypto.randomBytes(16)` base64url slug minting, `publish`/`publishHtml`/`get`/`list`/`remove`, and `resolveFile()` with strict path containment (rejects `..`, absolute, and **symlink escape** via a `realpathSync` containment check). Per-page + total size caps. Pages dir injectable for sandbox-safe tests.
- **`http-routes.js`** — `GET /p/<slug>/<path?>`, **intentionally unauthenticated** (the slug is the capability). Hardening, in order: per-IP rate-limit *before* any fs work → slug-charset validation + manifest-existence check *before* fs access → static-only security headers on **every** response.
- **`ws-server.js`** — constructs `PagesStore` (rooted at `$CHROXY_CONFIG_DIR`/`~/.chroxy/pages`, read-only on construct) + a per-IP pages rate limiter; both injectable.
- **`docs/security/bearer-token-authority.md`** — new §11 documenting the page-share-slug unauthenticated capability surface.

## Security model
chroxy auth accepts a `chroxy_auth` **cookie**, so a same-origin served page in a logged-in browser could otherwise script authed `/api/*` calls. Mitigation = a **static-only CSP** on every response: `script-src 'none'; connect-src 'none'; sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; font-src 'self' data:` + `nosniff` + `X-Frame-Options: DENY` + `CORP: same-origin` + `no-referrer`. Served pages cannot run JS or reach any endpoint → the cookie risk is neutralized, and it's exactly right for the HTML reports this serves. Interactive/JS pages are explicitly out of scope (would need an isolated origin — deferred).

## Tests
`pages-store.test.js` (13) — slug validation, MIME, publish/get/list/remove, index.html requirement, unsafe-path + size-cap rejection, traversal + symlink-escape containment, manifest persistence, slug uniqueness. `pages-serve.test.js` (4) — 200 + all security headers + no-auth serve, asset MIME, trailing-slash 301, 404 for unknown/malformed/traversal (headers present on 404 too), and a proof the route never consults bearer auth.

Existing `http-routes` + `ws-server` suites green (408); custom server lints green.

## Not in this PR (PR-2)
`POST /api/pages` endpoint + `chroxy publish` / `chroxy pages list|rm` CLI.

Closes #5684 · part of #5683