### PR TITLE
feat(pages): publish surface — POST /api/pages + chroxy publish CLI (PR-2 of #5683)

### DIFF
--- a/autonomous-session-6-11-26.md
+++ b/autonomous-session-6-11-26.md
@@ -1,0 +1,304 @@
+- **PR #5589** (#5563 primary semantics, CLOSES #5563) — reviewer died mid-CI-monitor after triaging+fixing 2 Copilot threads (c4eff6609); orchestrator completed the review. D11: found and fixed a real product regression in the agent's design — rejecting adoption on accepted idle input strands a solo user's second device behind input_conflict mid-run (phone↔desktop flow); revised to force-adoption on accepted input, sticky PRIMARY_HELD kept on the explicit claim_primary wire path for #5281 roles (a83b7d72b). 269 tests + 3 lints green w/ CHROXY_WS_INDEX_ASSERT; CI green on head; merged a9bd2f97f; issue #5563 CLOSED; cleaned.
+- **PR #5590** (#5555.1 eager key exchange) — review: Approve after adversarial security pass (eager ≡ discrete crypto verified; no plaintext downgrade on any branch; eager stash gated behind isTokenValid; TOFU #5536 unchanged). Reviewer merged main twice into the branch (stale base vs #5588+#5589), caught a genuine merged-state CI failure (leaked pendingKeyPair between app tests, 31ea6339e) + fixed Copilot thread 3 (clear eager stash when encryption disabled, bff24330b); 2 missing-salt threads FALSE POSITIVE; all 3 resolved. CI 15/15 green on final head 4a09e3d09; merged e1c2ac645; cleaned.
+
+**Marathon 4 complete: 3/3.** Cold connect now 1 RTT lighter (every reconnect too); client flush layer unified; shared-session ownership semantics in place ahead of #5281. Also GC'd 5 stale worktrees + 3 merged branches from prior sessions (verified each tip ⊆ merged PR head before deletion).
+Follow-up noted (non-blocking, from #5590 review): client eager-receive path could mirror the discrete handler's empty/format guard on serverPublicKey — fold into the next #5555 chunk.
+
+---
+
+## Marathon 5 (user: "Start marathon 5 and after you can rebuild and restart")
+
+| Lane | Issue | Scope | Branch |
+|------|-------|-------|--------|
+| A | #5555.2 | auth_bootstrap burst coalescing (kill 3-request connect round trip + redundant frames) + serverPublicKey eager-receive guard (#5590 follow-up) | feat/auth-bootstrap-burst |
+| B | #5555.3+4 | lastSeq delta replay + newest-first/no-blank-flash replay UX — DISPATCHED AFTER A MERGES (both rework ws-history.js) | (pending) |
+| C | #5556.3 | shared dispatch table slice 1 (5-10 pure-delegation cases) | refactor/store-core-dispatch-table |
+
+D12: B serialized behind A rather than parallel — ws-history.js sendPostAuthInfo is the shared hot file; the #5576/#5577-style auto-merge hazard outweighs the wall-clock win. Close-out: rebuild dashboard + Tauri app, reinstall, restart, verify health.
+
+### Marathon 5 ledger (running)
+- **PR #5591** (#5556.3 dispatch table slice 1) — review: Approve (all 7 cases re-verified byte-identical against origin/main; no double-handling; parity guard fails on empty parse). Reviewer fixed 7 Copilot threads (wrong epic breadcrumbs, sessionRules typing) in 8a0b6e1; DispatchMessageMap↔protocol drift flagged as FOLLOW-UP (silent but decorative). CI 15/15 green; merged e908d1ef1; cleaned. Epic #5556: registry exists, 7 cases shared, 12 documented-divergent.
+- **PR #5592** (#5555.2 auth_bootstrap burst + serverPublicKey guard) — review: Approve. Reviewer merged main (post-#5591) semantically clean; verified bootstrap frame rides the encrypted channel on both eager+discrete paths (no plaintext workspace-info leak); caught 2 real Copilot schema bugs and fixed them itself (a49ae4ed3: availablePermissionModes was z.array(z.string()) vs actual object array — would have rejected real auth_ok; missing .default([])). −3 connect requests / −1 RTT. CI green on final head; merged 4acf646a2; cleaned.
+- Lane B dispatched post-#5592: #5555.3 lastSeq delta replay + #5555.4 preserve-then-reconcile replay UX, one PR, branch feat/lastseq-delta-replay.
+- **PR #5593** (#5555.3+4 lastSeq delta replay + preserve-then-reconcile UX) — review: Approve after 9-case adversarial trace. Orchestrator-predicted cursor-ahead-of-server bug (post-restart seq reassignment → empty delta + permanently wedged cursor) CONFIRMED REAL and fixed (16346b0: lastSeq > latestSeq forces fullHistory) + regression tests; Copilot independently flagged the same case. 2 more fixes (649b74a: LRU-cap client cursor map at 64; honest ws-auth cursor test). Replay×live dedup refuted-as-regression (pre-existing, handled). Implementation kept ALL backpressure machinery with justification (bounded-but-fat tails still cross the 1MB line) — epic prediction of dead code was wrong, documented. CI 16/16 green on 649b74a; merged 2df17b795; cleaned.
+
+**Marathon 5 code-complete: 3/3 merged** (#5591 dispatch table, #5592 auth_bootstrap, #5593 lastSeq replay). Epic #5555: sub-items 1-4 done, 5-7 remain. Epic #5556: sub-items 1-3(slice 1) done. Proceeding to rebuild+restart.
+
+**Marathon 5 close-out:** Chroxy.app rebuilt from main 2df17b795, installed, relaunched. /health ok 0.9.46. Verified in installed bundle: authBootstrap+historyCursors in server ws-auth.js/ws-history.js; auth_bootstrap+historyCursors strings in dashboard dist. Zero open PRs; main synced; no leftover worktrees/branches.
+
+---
+
+## Marathon 6 (user: "keep going with marathon 6 after the rebuild")
+
+| Lane | Issue | Scope | Branch |
+|------|-------|-------|--------|
+| A | #5555.5+6 | Reconnect backoff ladder on close/error (reset on auth_ok, banner reads ladder) + keepalive coordination (zombie eviction via departure path) | fix/reconnect-backoff-keepalive |
+| B | #5555.7 | tunnel_url_changed client push + tunnelUrl in bootstrap; persisted-URL update so reconnects chase the new URL | feat/tunnel-url-changed-push |
+| C | #5556.3 slice 2 | Next byte-identical batch + deliberate reconciliation of 2-4 documented-divergent cases (drift-kill) | refactor/dispatch-table-slice-2 |
+
+All three parallel (disjoint-enough surfaces: connection close-path / tunnel plumbing / dispatch cases). B completes the last open #5555 sub-item — epic close is maintainer's call. Close-out: rebuild+reinstall+restart.
+
+### Marathon 6 ledger (running)
+- **PR #5594** (#5555.5+6 backoff ladder + keepalive) — review: Approve, no fixes needed. Both orchestrator-flagged concerns ruled out with evidence (pre-auth sockets bounded by 10s authTimeout independent of frame flooding; cross-host ladder leak bounded ≤8s + self-corrects on auth_ok — logged as cosmetic follow-up). 1 Copilot thread FALSE POSITIVE (node --test per-file isolation), resolved. Zombie detection 60s→15-30s; flap-storm now rides RETRY_DELAYS ladder. CI green; merged 0be7a2fb2; cleaned.
+- **PR #5595** (#5556.3 slice 2) — review: Approve. 13/13 byte-identical re-verified from origin/main; notification_prefs reconciliation confirmed failure-mode-parity (fail-closed both paths) → **issue #5488 closed as superseded**. 2 Copilot threads FIXED by reviewer (agent_event tests + hardened drift-guard regex, 1bd2ede5f); 0 unresolved. session_role swallow verified (silent default). Dispatch table now 21 cases. CI green; merged 913dc3822; cleaned.
+- **PR #5596** (#5555.7 tunnel_url_changed push) — review: Approve (reviewer hit a transient API error mid-run, then recovered and completed; verdict + 3 FIXed threads: shared asWssUrl() validation on both parsers + legacy-record repoint). Repoint correctly scoped to the connected server's entry only; rides the encrypted path; ws://evil rejected. Gate caught a CI failure the reviewer's monitor missed: event-normalizer adaptive-window flake (passed 114/114 locally at the PR head; rerun green) — merged only after the rerun. Merged e22d01cca; cleaned.
+- Follow-up filed: #5597 (inner reconnect ladder re-dials closure-captured URL; adjacent to #5537).
+- **Epic #5555 CLOSED — all 7 sub-items landed.** Issue #5488 closed as superseded (via #5595).
+
+**Marathon 6 complete: 3/3 merged** (#5594, #5595, #5596). Rebuild+restart in progress.
+
+**Marathon 6 close-out:** Chroxy.app rebuilt from main e22d01cca, installed, relaunched. /health ok 0.9.46. Verified in installed bundle: broadcastTunnelUrlChanged + 15s keepalive sweep in server ws-server.js; tunnel_url_changed strings in dashboard dist. Zero open PRs; main synced; only the primary worktree remains.
+
+---
+
+## Marathon 7 (user: "keep going with marathon 7")
+
+| Lane | Issue | Scope | Branch |
+|------|-------|-------|--------|
+| B | #5556.4 | createConnectFlow extraction (shared connect orchestration; per-attempt resolveEndpoint seam designed in for A) | refactor/store-core-connect-flow |
+| C | #5559 | claude-tui-session 4435-LOC pure-move 3-way split (PTY driver / form driver / session shell) | refactor/claude-tui-split |
+| A | #5597+#5537 | Reconnect endpoint fixes (per-attempt URL re-resolution + LAN→tunnel fast fallback) — AFTER B, plugged into the shared seam | (pending) |
+
+D13: A serialized behind B by design — fixing endpoint selection in the duplicated code means fixing it twice; the extraction lands first with a resolveEndpoint(attempt) seam, then A implements both bug fixes ONCE in shared code. C runs parallel (server-only, fully disjoint). C is high-risk-pure-move: prompt pins all empirical TUI behaviors (paste throttle, hotkey digits, pinned form sequences, monotonic watchdog, #4638 invariant) and demands moved-vs-changed accounting + unmodified test suite.
+
+### Marathon 7 ledger (running)
+- **PR #5599** (#5559 claude-tui 3-way split, CLOSES #5559) — review: Approve via independent byte-identity audit (1322/1407 added lines byte-moved; 85 scaffolding; sole difference = path-depth compensation verified to resolve to identical absolute path; reviewer's own audit pipeline initially produced false diffs from shell escape-mangling and it re-verified from disk before concluding). No shadowing; non-enumerable descriptor copy preserved; opt-forwarding lint still parses the class (1 of 8 subclasses). Zero test edits. 4435→~3100 LOC shell + 2 drivers. CI 15/15; merged be3eb8d7c; cleaned.
+- **PR #5598** (#5556.4 createConnectFlow) — review: Approve. Pixel-identical trace held per client (incl. the subtle unclamped-vs-clamped RETRY_DELAYS indexing proof); resolveEndpoint(attempt) confirmed per-attempt not memoized; zero-test-edit claim audited true; 1 Copilot thread FIXED (dead scheduler opt removed, a6050261b). Dashboard guard relocation verified verbatim. CI 15/15 on final head; merged d39f1ac45; cleaned. Epic #5556: sub-items 1,2,3(two slices),4 done; 5-6 remain.
+- Lane A dispatched into the fresh seam: #5597+#5537 per-attempt endpoint re-resolution + LAN→tunnel fallback, branch fix/reconnect-endpoint-resolution.
+- **PR #5600** (#5597+#5537 reconnect endpoint fixes, CLOSES both) — review: Approve after fixing a REAL redirect bug Copilot+reviewer caught: savedConnection-based re-resolution wasn't token-scoped, so a manual connect to a different server could be redirected to the OLD server's tunnel URL mid-ladder (fixed 3c21804c9 + regression test). Worst-case time-to-tunnel computed: ~14-16s (vs ~44s full-budget burn before), dominated by two unavoidable 5s dead-LAN health timeouts — ladders confirmed non-stacking. Post-fallback sticks to tunnel; LAN re-probed by the next connectAuto (deliberate, lanVerified preserved). Dashboard confirmed single-wsUrl (no #5537 equivalent). CI green first try; merged 35dc5b9d4; issues #5597+#5537 both CLOSED; cleaned.
+
+**Marathon 7 complete: 3/3 merged** (#5598 connect flow, #5599 claude-tui split, #5600 reconnect fixes). Issues closed: #5559, #5597, #5537. Close-out: Chroxy.app rebuilt from main 35dc5b9d4, installed, relaunched; /health ok 0.9.46; claude-tui/{pty-driver,form-driver}.js present in installed server; resolveEndpoint plumbing in dashboard dist. Zero open PRs; main synced; only primary worktree remains.
+
+---
+
+## Marathon 8 (user: "keep going with marathon 8 after the rebuild")
+
+| Lane | Issue | Scope | Branch |
+|------|-------|-------|--------|
+| B | #5560 | App.tsx (~3092 LOC, dashboard) → feature hooks + Shell; #5599 pure-move playbook; hook extraction over component splitting (render semantics) | refactor/dashboard-app-shell |
+| C | #5536 | E2E key pinning from pairing (kills pure TOFU); both exchange paths; honesty clause — no crypto theater, stop at largest sound subset | feat/e2e-key-pinning |
+| D | #5533 | /qr + /pairing-code primary-token scoping + sibling-endpoint audit per bearer-token-authority checklist | fix/scope-pairing-endpoints |
+| A | #5556.5+6 | Behavioral-contract fixtures + encrypted-handshake e2e — AFTER C merges (tests must pin the pinned-key handshake); closes epic #5556 | (pending) |
+
+D14: A serialized behind C so the handshake e2e pins post-pinning behavior. D14b: #5536 prompt carries an explicit anti-theater clause (fingerprint must not ride the channel it authenticates; defer what the primitives can't soundly support, candidly).
+
+### Marathon 8 ledger (running)
+- **PR #5601** (#5533 token-class scoping, CLOSES #5533) — review: Approve. **/connect escalation CONFIRMED from pre-PR code**: pairing-bound token → raw primary apiToken in cleartext (redaction only fired when auth disabled). Reviewer's independent full-route classification table matched; 403 oracle assessed acceptable (class-membership check, constant-time compare); callers verified unbroken (dashboard primary token, CLI connection.json, LAN flow never GETs these). Reviewer added Cache-Control: no-store on /connect (856739867) + resolved 1 thread, then died mid-CI-watch; orchestrator finished the watch. CI green; merged ce22f5fc8; cleaned.
+- **PR #5602** (#5560 App.tsx → hooks + Shell, CLOSES #5560) — review: Approve with line-number-level invariant proof (seed-effect #5202 ordering preserved L860<L1265 matching base; terminal ancestry byte-identical; AppHeader/AppModals stateless; no widened selectors). 1 thread FIXED (docstring), 1 FALSE-POSITIVE-by-policy (byte-identical moved condition). 3127→2217 LOC; composer + terminal subtree deliberately inline (documented invariants). Merged c60c021c7. NOTE: `Closes #5560` was in backticks → GH didn't auto-close; closed manually with scope rationale. Gotcha for future PR bodies: closing keywords must not be inside code spans.
+- Incident (caught at gate): #5603's implementer wrote the regenerated protocol dist into the MAIN checkout's working tree instead of its worktree (cross-worktree leak, known hazard) — and the PR itself shipped src/schemas/server.ts WITHOUT any dist. Stray main-checkout edits discarded (change is deterministic from src); a dedicated agent dispatched to regenerate + commit dist on the PR branch and verify server tests resolve against the committed dist. Merge held until consistent.
+- Incident update: dist verified PRESENT on the #5603 branch (dedicated regen commit, byte-identical to fresh build; store-core dist/crypto also verified; server-side serverKeySig writes validate through committed dist). The commit appeared after the orchestrator's file-list check — hold released. Stray main-checkout edits remain correctly discarded (duplicate of committed work).
+- **PR #5603** (#5536 E2E key pinning, CLOSES #5536) — review: Approve after adversarial crypto pass. Downgrade matrix code-verified fail-closed in all 9 cells (incl. pinned×old-server REFUSE, eager→discrete fallback re-verifies); pin-overwrite via chroxy:// link ruled out (fresh-entry mint / pin-and-connect only when unpinned); replay = DoS-at-worst (ephemeral DH key never transmitted). 3 on-branch fixes: protocol dist regen (262dbfbeb — explains the earlier stray-dist incident), atomic writeFileRestricted for the 0600 identity secret, exchange-key length validation (aa15be7df). Domain-separation prefix flagged as follow-up. #5601 merge overlap resolved clean (gate + payload coexist). CI green; merged 55837f5c7; cleaned. TOFU is dead for paired clients.
+- **PR #5605** (#5556.5+6 contract fixtures + handshake e2e, CLOSES EPIC #5556) — reviewer died mid-CI-wait after triaging+fixing 3 threads (693f32ddd: per-frame send nonces in the test driver, tightened no-op assertion; 1 FALSE POSITIVE documented); orchestrator completed the review incl. THE empirical drift check: injected isIdle drift into dispatchAgentBusy → 3 tests red (incl. the dedicated guard-gap test) → revert green. First mutation attempt was a silent sed no-op (false pass) — lesson: verify the mutation landed before trusting a mutation test. Real-path imports verified (runDispatch from ../dispatch-table). CI green; merged 9532c96d0; **epic #5556 CLOSED — all 6 sub-items landed**. Cleaned.
+
+**Marathon 8 complete: 4/4 merged** (#5601 token scoping + /connect escalation, #5602 App shell, #5603 E2E key pinning, #5605 contract fixtures + handshake e2e). Issues closed: #5533, #5560, #5536, #5556 (EPIC — final audit epic done). Filed: #5604 (domain separation). Close-out: Chroxy.app rebuilt from main 9532c96d0, installed, relaunched; /health ok 0.9.46; verified in bundle: server-identity.js present, serverKeySig in ws-auth+ws-history, primary-gate in http-routes (6 sites), pinnedIdentityKey in dashboard dist. Zero open PRs; main synced; only primary worktree remains.
+
+---
+
+## Marathon 9 (user: "keep going with marathon 9 no rebuild as an agent is working in the current version")
+
+NO REBUILD this marathon — running daemon stays untouched (user agent active on it). Agents are code-only on branches; no process restart, no ~/.chroxy/ writes.
+
+| Lane | Issue | Scope | Branch |
+|------|-------|-------|--------|
+| A | #5356 | Loopback-by-default for Chroxy.app + auto-tunnel exposure assessment; explicit-exposure toggle preserved | fix/loopback-default |
+| B | #5281 | session_role surfacing in both clients (server done in #5589; clients currently ignore it); observer indicator + input_conflict/PRIMARY_HELD UX + claim/hand-off affordance | feat/session-role-ui |
+| C | round 3 | swarm-audit 8-lens vs 3.4/3.8 baselines — AFTER A+B merge; local gitignored report | (after merge) |
+
+D15: #5356 lane A leans Option A (Tauri-shell --host 127.0.0.1) per issue's literal "Chroxy.app defaults to loopback" + smallest blast radius; agent to assess auto-tunnel separately (loopback bind is moot if a public tunnel forwards to localhost). Security-default change → close review.
+
+### Marathon 9 ledger (running)
+- **PR #5611** (#5356 loopback-by-default, CLOSES #5356) — review: Approve. Fresh-install posture verified DEFINITIVELY safe: new Chroxy.app spawns CHROXY_HOST=127.0.0.1 AND tunnel=none (the "quick" seed in ServerManager::new is overwritten by handle_start reading settings default "none" before every spawn). expose_on_lan toggle round-trips end-to-end (not theater). 3 threads FIXED incl. a real one — omitting CHROXY_HOST ≠ unsetting it, inherited env could defeat the default → env_remove (9ae9f0e65). Command-drift guard consistent across 4 surfaces. Zero binaries. Auto-tunnel was already user-gated (no change needed). CI green; merged bd706fac8; cleaned. NO REBUILD — change ships to users next packaged release; running daemon unaffected.
+- **PR #5612** (#5281 session-role surfacing) — review: Approve. clientId id-space verified consistent end-to-end (role not stuck-observer); session_error calm branch scoped to input_conflict only; force-claim behind explicit button; 1 thread FIXED (semicolon). Reconnect role-staleness flagged → filed #5613. Merged f690d286d; cleaned.
+
+### Marathon 9-C: swarm-audit ROUND 3 — **4.19/5** (R1 3.4 → R2 3.8 → R3 4.19)
+8-lens workflow (parallel auditors + synthesis). Per-lens: Skeptic 4.3, Builder 4.0, Guardian 4.2 (ONLY down-vote, 4.3→4.2 — pinning re-opened a downgrade cell), Minimalist 3.9 (down-vote reversed), Futurist 4.2, Tunneler 4.4, Operator 4.5, Tester 4.1 (+1.6 over two rounds — biggest climber). Reports: docs/audit-results/.../00-master-assessment-round3.md + r3-*.md (local, gitignored).
+Consensus: C1 connect-path RTT cuts real (5 lenses); C2 dispatch migration genuine but incomplete (+968 LOC mid-migration); C3 key-pinning re-opened a downgrade/self-lockout surface (Guardian+Futurist, the round's most important negative); C4 claude-tui split is file-move not boundary; C5 trust-ledger consolidation real.
+10 issues filed: #5614/#5615/#5616 (C3 security — pinned-requires-encryption HIGH, keychain-no-silent-rotate HIGH, rotation-handoff MED), #5617 (form-driver collaborator), #5618 (finish dispatch migration), #5619 (contract lint + maestro key_exchange), #5620/#5621 (cleanup), #5622 (eager-derivation concurrency), #5623 (app sessionRole reset).
+
+**Marathon 9 complete: 2 PRs merged (#5611 #5356-closed, #5612) + round-3 audit. NO REBUILD (running daemon preserved for active agent). Issues closed: #5356. Filed: #5613 + 10 audit issues = 11.**
+
+---
+
+## Marathon 10 (user: "go and we have some new gh issues too")
+
+New dogfooding issues #5606-5610 (filed today from v0.9.46 use) + the two HIGH security regressions the round-3 audit surfaced. NO REBUILD assumption carried (running daemon may still host an agent) — rebuild decision deferred to close-out.
+
+| Lane | Issues | Scope | Branch |
+|------|--------|-------|--------|
+| A | #5614+#5615 | Key-pinning hardening (HIGH): pinned-requires-encryption downgrade cell + keychain-no-silent-rotate. Fixes #5536 regressions from audit C3 | fix/key-pinning-hardening |
+| B | #5609 | Gate/defer perm-mode Approve→Auto while busy (CLI _killAndRespawn footgun); preserve #3729/#3735 panic button | fix/perm-mode-switch-busy |
+| C | #5606+#5607+#5608 | Dashboard UX trio: New Session Advanced layout, sidebar pairing-action clip, Control Room create-session affordance | fix/dashboard-ux-dogfooding |
+| D | #5610 | Push-to-talk hold-Space in dashboard chat input (reuse voice infra; tap still types space) | feat/push-to-talk-space |
+
+D16: paired the user's dogfooding bugs with the audit's 2 HIGH security items (fix-what-we-broke before building further). 4 parallel lanes, disjoint surfaces (crypto / session+dropdown / dashboard modals+sidebar+control-room / chat input). B/C/D all brush dashboard but different components — merge-order conflict triage at gate.
+
+### Marathon 10 ledger (running)
+- **PR #5624** (#5606+#5607+#5608 dashboard UX trio, CLOSES all 3) — review: Approve. CSS-scope regression check passed (.advanced-section + .server-discover-item scoped to their modals, no global .form-field shift); #5608 dedicated button fires byte-identical investigate payload {cwd,name,reason}, seed-context preserved end-to-end; badges now pure spans. 0 threads. CI green; merged e1041ac9f; cleaned. (Worktree-inspector hazard recurred — main checkout left on review/5624; restored + pruned review/* branches.)
+- **PR #5626** (#5609 perm-mode-switch gating, CLOSES #5609) — review: Approve. Chosen design: provider-accurate warning (rejected defer-until-idle — a wedged turn never goes idle, defeating the #3729 panic button's purpose). #3735 panic-button tests unchanged 3/3; interruptsTurnOnAutoSwitch capability correct across ALL providers incl BYOK/Codex/Gemini/Docker subclasses; one server change fixes both clients (app renders warning verbatim); dashboard helper pure + matches server predicate. Stale-streamingMessageId divergence = cosmetic (confirm is advisory; server warning authoritative). 0 threads. CI green; merged fde8014bc; cleaned.
+- **PR #5625** (#5610 push-to-talk hold-Space, CLOSES #5610) — review: Approve after fixing 2 REAL bugs: (1) suffix truncation data-loss (618717c5c — transcript merge dropped everything after the caret anchor; invisible for mic button which anchors at end, but PTT anchors mid-draft → silent tail deletion) + (2) mic leak on unmount-while-recording (1df13dfba — useVoiceInput re-memoizes stop on [engine] selected post-mount, empty-deps cleanup held the stale none-engine no-op). Suppress-then-reinsert disambiguation; fake timers (no real sleeps); Cmd+Space not hijacked. IME-compose-guard deferred (matches existing Enter-to-send pattern). 3 threads FIXED. CI green; merged 00b492527; cleaned.
+- **PR #5627** (#5614+#5615 key-pinning hardening, CLOSES both) — review: Approve. Downgrade gate verified runs-before-keying on both paths/both clients; full matrix code+test verified incl. the critical encryption=ABSENT→REFUSE cell (uses !== 'required' not === 'none'); real-crypto handshake-e2e, not always-agree mock. Keychain exit-code mapping fail-safe (unexpected→error→don't-mint); escape hatch CHROXY_ALLOW_UNPINNED_BOOT boots pinning-off without minting. Reviewer found+fixed a REAL CI bug the impl mislabeled environmental (getTokenStatus absent test asserting unconditionally on Linux runner → 5c1a25d0d) + 4 threads. Residual follow-up noted: headless Linux secret-tool-no-backend refuses first boot. CI green; merged 755596e4e; cleaned.
+
+**Marathon 10 complete: 4/4 merged** (#5624 UX trio, #5625 push-to-talk, #5626 perm-mode gating, #5627 key-pinning hardening). Issues closed: #5606 #5607 #5608 #5609 #5610 #5614 #5615 (7). The 2 audit-surfaced HIGH security regressions are CLOSED. NO REBUILD performed (running daemon preserved for active agent) — rebuild deferred to user.
+
+---
+
+## Marathon 11 — Mobile audit findings → PRs (2026-06-12)
+
+Driven from the 2026-06-12 mobile swarm-audit (aggregate 3.6/5). Four consensus findings filed as issues #5632–#5635 and taken through implement → adversarial review → fix-cycle → confirm → squash-merge. Three of four required a real fix-cycle after review caught genuine bugs.
+
+| PR | Issue | Finding | Review arc | Merge SHA |
+|----|-------|---------|-----------|-----------|
+| #5636 | #5634 | A11y: permission Approve/Deny 44pt + accessibility props (Operator C3) | APPROVE; Copilot flagged contradictory Compact/All label+selected → fixed (label reflects state, action→hint) + Cancel assertion → resolved | `933ecd11e` |
+| #5637 | #5633 | Resilience: zombie-socket resume liveness + surfaced dropped/queued input (Guardian C2) | REQUEST CHANGES — Fix 1 inert (connectAuto no-op guard swallowed the reconnect); forced via `{force:true}` + behavioural negative-control test; 3 Copilot threads (queue notice routed to wrong session) → fixed via `updateSession` + action-aware copy; confirm-review APPROVE | `f9fc10b56` |
+| #5638 | #5635 | Tests: encryption/identity-refusal gate + offline queue coverage (Tester C3) | APPROVE; reviewer mutation-tested 5/5 controls caught; 1 Copilot thread (spy restore) triaged FALSE POSITIVE + resolved | `c1374c5ee` |
+| #5639 | #5632 | Security: reject post-handshake plaintext frames on encrypted socket, app+dashboard (Adversary F1) | REQUEST CHANGES — allow-list incomplete (plaintext `error` via raw ws.send tore down live connections); fixed server-side by routing `sendError` through encrypting transport + dropping late `auth_ok`/`key_exchange_ok`; 2 Copilot threads resolved; confirm-review APPROVE (all sendError sites forward ctx, app/dashboard guards byte-identical, Server Tests green in clean CI) | `131e68b3b` |
+
+All four: full review pipeline clean verdict + all CI green on final head + 0 unresolved threads before squash-merge. No `--auto`/`--admin`. Branches + worktrees cleaned; `main` checkout restored each time.
+
+### Builds
+- Android preview APK (EAS `e65ec181`) built — https://expo.dev/artifacts/eas/qJos1c0g9eF1Q0DZR7u9aGk08znSpeu1DlCCHtSo-rM.apk (carries through v0.9.46 + Marathons 9/10; Marathon 11 fixes need a fresh build).
+- Desktop: Marathon 9/10 rebuild + restart done mid-session; close-out rebuild for Marathon 11 in progress.
+
+---
+
+## Marathon 12 — OTA pipeline (2026-06-12)
+
+| PR | Issue | What shipped | Review arc | Merge SHA |
+|----|-------|-------------|-----------|-----------|
+| #5641 | #5640 | EAS Update (OTA): expo-updates ~29.0.18, `runtimeVersion: fingerprint`, per-profile channels | APPROVE (reviewer ran prebuild + inspected generated plist to confirm launch is non-blocking, EXUpdatesLaunchWaitMs=0); iOS native-config follow-up filed #5642 | `57814d75e` |
+
+After one more OTA-capable native build, JS-only changes ship via `eas update --branch preview` with no rebuild. Android ready; iOS needs native-config regen (#5642).
+
+## Marathon 13 — Mobile security hardening (2026-06-12)
+
+Adversary F2–F5 from the mobile audit. 4 lanes; F4 needed a fix-cycle (review caught the originWhitelist would blank Android).
+
+| PR | Issue | What shipped | Review arc | Merge SHA |
+|----|-------|-------------|-----------|-----------|
+| #5648 | #5643 | F2: biometric lock engages on cold start, gates navigator mount (token not used before unlock) | APPROVE — reviewer traced no token-use-before-unlock + all lockout exits + render-latch safe | `3bf746743` |
+| #5649 | #5644 | F3: encrypt at-rest AsyncStorage cache (messages/terminal/session-list) with nacl.secretbox + SecureStore key, graceful legacy migration | APPROVE — reviewer verified PRNG seeding + traced no-transient-miss-data-loss; 33 tests | `314f89d37` |
+| #5650 | #5645 | F4: WebView terminal nav allow-list (exact about:blank/'' guard, blocks all real navs) | REQUEST CHANGES — review (ran RN's real whitelist filter) found `['about:*']` would blank Android; fixed (exact guard + originWhitelist reverted to `['*']`, guard is containment) + wrapper-level test; confirm APPROVE | `23356db94` |
+| #5647 | #5646 | F5: gate Expo push-token log behind `__DEV__` | APPROVE | `00d51ee8d` |
+
+All four cleared the full gate (clean verdict + CI green + 0 threads). All app-only → no desktop rebuild required.
+
+### Builds
+- APK `2b014f7c` (cut post-Marathon-11): carries M11 but NOT OTA (M12) or M13 — predates them. The first OTA-capable build (with expo-updates) must be cut from post-M12 main; after that, M13 + future JS ships OTA.
+
+---
+
+## Marathon 14 — Code quality (2026-06-12)
+
+Audit C1/C4. 4 lanes on 4 different god-files (clean parallel, no conflicts). 3 of 4 needed a fix-cycle.
+
+| PR | Issue | What shipped | Review arc | Merge SHA |
+|----|-------|-------------|-----------|-----------|
+| #5657 | #5652 | `sendIfOpen()` helper — 33 socket guards collapsed, 13 preserved (incl. the #5637 enqueue-on-closed input paths); connection.ts −95 LOC | APPROVE (Opus); Copilot caught a real `getStore()`-throws-if-unwired crash the Opus review missed → guard + 4 tests added | `4a3d19112` |
+| #5659 | #5653 | Dispatch-migration batch: 10 file-ops/git types moved to shared table (app switch 77→67) via decline-adapter; dashboard byte-for-byte unchanged | APPROVE (Opus) — verified CI green incl. cross-workspace store-core build, decline mechanism, 10-type payload preservation, coverage-guard strengthened | `5706c2bfa` |
+| #5656 | #5654 | Decompose SessionScreen → `useSessionViewState` + `SessionPanels` | REQUEST CHANGES (hook cohesion: 3 layout-chrome toggles bag-bundled) → moved out → APPROVE | `3ef794176` |
+| #5658 | #5655 | Decompose SettingsScreen 1683→601 LOC → NotificationPrefs/VoiceInput/Security sections in new settings/ dir | REQUEST CHANGES (moved const broke a dashboard sync test) → fixed → APPROVE | `c8bb1196e` |
+
+All cleared the full gate. **Process note:** on #5657 hit the merge-then-cleanup hazard ([[feedback_verify_merge_before_cleanup]]) — merge failed on a race-window Copilot thread and chained cleanup deleted the branch + closed the PR; fully recovered (re-push + reopen, head commit survived). Corrected for the rest: merge → verify MERGED → then clean, as separate steps.
+
+---
+
+## Marathon 15 — Dispatch-migration slice 4 (2026-06-12)
+
+Continuation of the #5556 client-dispatch migration (after #5659's slice 3). Serial on shared files (dispatch-table.ts / both message-handlers), so one well-scoped PR, not parallel lanes. Implementation agent did honest scoping — migrated only the 2 genuinely byte-identical cases left and rejected the rest with concrete divergence evidence (the byte-identical store-mutation seam is now essentially exhausted).
+
+| PR | Issue | What shipped | Review arc | Merge SHA |
+|----|-------|-------------|-----------|-----------|
+| #5662 | #5556 | `web_task_created`/`web_task_updated` → shared table; needed a new minimal `updateState(updater)` adapter primitive (read-modify-write upsert can't use `setState(patch)`). App switch 67→65, table 31→33. | APPROVE — adversarial reviewer refuted all 5 vectors (merge-not-replace Zustand semantics, byte-identical arms, table-hit short-circuit, coverage honesty, no dangling imports) w/ file:line evidence. No Copilot threads. | `fd22f1e47` |
+
+Verified locally pre-merge: store-core tsc+vitest (1485), protocol coverage 9/9, app/dashboard tsc clean, app jest 221, dashboard vitest 343. Clean gate (review APPROVE + all CI pass + 0 threads).
+
+**Rejected candidates (documents real divergence, future-proofing):** `checkpoint_*`/`slash_commands`/`agent_list`/`conversations_list`/`search_results` (app dual-writes useConversationStore), `provider_list` (different transform), `cost_update` (app useCostStore), `budget_*` (RN Alert), `available_models` (dashboard-only field), `web_task_error` (app SESSION_TOKEN_MISMATCH branch), `token_rotated`/`tunnel_url_changed`/`push_token_error` (platform-local). Remaining dispatch migration would need a divergence-tolerant mechanism beyond decline+updateState.
+
+---
+
+## Marathon 16 — Model-metadata foundation (#5631 slice 1) (2026-06-12)
+
+User picked: foundation-first chain (#5631 → #5628 → #5630 → #5629), pricing sourced from SDK-runtime + user overlay (no hardcoded numbers). Plan agent verified the SDK's `supportedModels()` returns `{value,displayName,description}` only — NO pricing/context — so the overlay is the pricing path. Scoped PR to server-only + additive (deferred 0→null cost contract + dashboard pricing-push into #5630).
+
+| PR | Issue | What shipped | Review arc | Merge SHA |
+|----|-------|-------------|-----------|-----------|
+| #5663 | #5631 | `claude-fable-5` in FALLBACK_MODELS (fixes #5628 trigger); user overlay `~/.chroxy/models.json` (short id/label/full id/context/pricing for what the SDK omits); loadCache prune unions overlay ids; defaultModelId fallback when `/^default\b/i` misses. | Opus adversarial review found 1 real regression → maintainer-decided fix → re-verified | `cc424e310` |
+
+**Adversarial review (Opus) caught a real BYOK cost regression the impl missed:** bumping the `opus` short alias to `claude-opus-4-8` (no pricing row) made pure-BYOK "Opus" picks bill $0 (Claude SDK/CLI unaffected — they emit `total_cost_usd` directly). Asked the user (genuine fork vs their "no hardcoded pricing" choice); they chose **keep FALLBACK opus at 4-7** (priced). A focused agent reverted just the opus bump + its test fallout (event-normalizer + booted-model files fully reverted), kept fable/overlay/prune/defaultModelId-fallback. Net: zero regression, no invented pricing. Verified 407 tests pass, lints + eslint clean, `getModelPricing('opus').output===75` restored. Clean gate (review clean post-decision + all CI + 0 threads).
+
+**Process win:** brought worktree changes onto a main-checkout branch to run the REAL test suites (worktree had no node_modules — the impl agent's tsc/symlink workaround wasn't enough to trust). Don't merge on worktree-only verification for cross-package/SDK-importing code.
+
+**#5618 annotated:** dispatch-migration byte-identical seam is exhausted; remaining cases need a divergence-tolerant mechanism (per-platform side-effect hooks), not more mechanical migration.
+
+### Chain status
+- [x] #5631 foundation (fable + overlay + degradation) — **MERGED #5663**
+- [ ] #5628 dropdown reads active session model (next)
+- [ ] #5630 billing-class flag → cost labels (carries the deferred 0→null + pricing-to-dashboard)
+- [ ] #5629 provider copy + docs for June 15 (deadline: 2026-06-15, 3 days)
+
+---
+
+## Marathon 17 — Header dropdown reflects active model (#5628) (2026-06-12)
+
+Chain step 2. Implemented directly (small, fully-understood dashboard fix), sonnet adversarial review, gated self-merge.
+
+| PR | Issue | What shipped | Review arc | Merge SHA |
+|----|-------|-------------|-----------|-----------|
+| #5664 | #5628 | Header model `<select>` resolves activeModel by id\|\|fullId (like the status bar) so a full-id model ('claude-fable-5') no longer renders as "Default (Sonnet 4.6)"; synthetic option carries the raw id for unlisted models (#5631 degradation spirit) | sonnet review SAFE (collision guard, handleModelChange no-op re-send, default-comparison normalization, common-case no-regression all clean) | `e0a4b7c3f` |
+
+Root cause: native `<select value=fullId>` with `<option value=shortId>` finds no match → renders first option ("Default"). Status bar looked right because it dual-matches before rendering a string. Fix verified: 39 dropdown tests (4 new) + full dashboard suite 3601 pass; tsc clean. **#5628 CLOSED.**
+
+### Chain status
+- [x] #5631 foundation — MERGED #5663
+- [x] #5628 dropdown — MERGED #5664
+- [ ] #5630 cost labels (billing-class flag → labels; carries deferred 0→null + pricing-to-dashboard)
+- [ ] #5629 provider copy + docs for June 15 (deadline 2026-06-15)
+
+---
+
+## Marathon 18 — Era-aware billing class: cost labels + June-15 copy (#5630 + #5629) (2026-06-12)
+
+Chain steps 3+4, done as ONE coherent PR (the billing class is the shared seam: it's date-gated for CLI/SDK, so both the cost label AND the provider copy derive from it). Plan agent → Opus impl (worktree) → my docker correction → Opus adversarial review → review-caveat cleanup → gated self-merge. Credit-pool meter deferred to filed issue #5665.
+
+| PR | Issues | What shipped | Review arc | Merge SHA |
+|----|--------|-------------|-----------|-----------|
+| #5669 | #5630, #5629 | billing class per session (api-key / subscription / programmatic-credit, era-gated for host CLI/SDK on 2026-06-15 UTC); SidebarTokenView per-class cost labels + tooltips; date-gated provider copy (server `resolveAuth` primary + dashboard fallback mirror); computePromptCostUsd 0→null per-turn honesty; docs/providers.md | Opus review SAFE-WITH-CAVEATS (docker bug caught pre-review; caveats fixed); 4 Copilot threads (docker billing comments, unused import, labels) replied+resolved | `b6c7ea8c8` |
+
+**Two bugs caught before merge:**
+1. **docker-cli/docker-sdk mis-bucketed as programmatic-credit** (caught via a failing providers.test.js auth-status assertion). They forward ANTHROPIC_API_KEY into the container with NO OAuth fallback → always api-key, era-independent. Fixed mapping + restored "Anthropic API (forwarded to container)" detail. Only the HOST claude-cli/claude-sdk (subscription OAuth) are programmatic-credit.
+2. **formatCostBadgeOrNa was dead code** (Opus review): the sidebar hides priced 0-cost rows, and the always-finite cumulativeUsage accumulator already drops null per-turn costs, so "n/a" never reaches a renderer. Removed the helper; kept the 0→null per-turn honesty. #5665 can re-add with a real consumer.
+
+**Process:** worktree had no node_modules → moved to a main-checkout branch to run the REAL dashboard/app tsc + SDK-importing server tests (the cross-package surface the worktree couldn't verify). App tsc clean confirmed the new optional auth.billingClass field is non-breaking (app copies auth verbatim, no strict Zod). Verified: protocol 233, store-core 1485, dashboard 3606, server affected 1013, app tsc clean.
+
+### Chain status — COMPLETE
+- [x] #5631 foundation — #5663
+- [x] #5628 dropdown — #5664
+- [x] #5630 cost labels — #5669
+- [x] #5629 June-15 copy — #5669 (date-gated, ships before the deadline)
+- [ ] #5665 credit-pool budget meter (deferred, scoping issue filed)
+
+**Closing-keyword gotcha hit again ([[feedback_gh_closing_keywords_list]]):** "Closes #5630 and #5629" auto-closed only #5630; closed #5629 manually with the merge ref. Filed #5665 (credit meter, deferred).
+
+**MODEL/BILLING CHAIN COMPLETE** — #5631→#5628→#5630→#5629 all merged & closed (#5663/#5664/#5669), credit-meter deferred to #5665. June-15 copy ships date-gated 3 days ahead of the deadline.
+
+---
+
+## Marathon 19 — iOS CNG migration / OTA enablement (#5642) (2026-06-13)
+
+User asked me to fix the bare-workflow papercut hit during the OTA push (eas update rejected the runtimeVersion policy). Root cause = committed `packages/app/ios/` → EAS bare workflow → (a) iOS builds shipped OTA-disabled (stale Expo.plist) and (b) eas update needs a manual runtimeVersion string. Only CNG (gitignore ios/) fixes both.
+
+| PR | Issue | What shipped | Review arc | Merge SHA |
+|----|-------|-------------|-----------|-----------|
+| #5670 | #5642 | gitignore ios/ (CNG, mirrors android/); EAS regenerates it each build with OTA enabled; PrivacyInfo via app.json `ios.privacyManifests`; bump-version.sh + ci.yml integration updates | Opus review SAFE-WITH-CAVEATS (verified ZERO native customization lost — clean prebuild byte-identical) → fixed the 1 defect + 2 CI failures it/CI surfaced | `b6e164293` |
+
+**Verified CNG is loss-free:** clean `expo prebuild -p ios --clean` regenerates every native file byte-identical (LiveActivity Swift is plugin-shipped, not custom — `expo-live-activity` `ios-files/` match), and flips Expo.plist `EXUpdatesEnabled false→true` + runtimeVersion 0.9.46 + URL. PrivacyInfo.xcprivacy preserved via app.json config.
+
+**Three defects caught + fixed before merge:**
+1. (review) Dangling `echo "$IOS_INFO_PLIST"` in bump-version.sh summary after removing the var → `set -u` abort.
+2. (CI) Same bug failed 10 Scripts Tests on Linux — but PASSED locally on macOS (bash 3.2 doesn't abort on unbound-var-in-echo the way Linux bash 5.x does). **macOS-local green ≠ Linux-CI green for `set -u` scripts.**
+3. (CI) A SERVER test (`bump-version-trap-cleanup.test.js`) pinned the removed Info.plist awk block → retargeted to the Cargo.lock awk-into-place site. Non-obvious coupling: server tests audit the bump-version shell script.
+
+### OTA pipeline now fully unblocked
+- `eas update` runs with the runtimeVersion policy directly (no manual string dance).
+- Next iOS EAS build will be OTA-capable (was shipping OTA-disabled).
+- OTA update group `cd8d220e` already live on preview (LAN fix + accumulated app JS) for the dogfood phone.

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -24,6 +24,7 @@ import { registerPairDiscordCommand } from './cli/pair-discord-cmd.js'
 import { registerWorktreeCommand } from './cli/worktree-gc-cmd.js'
 import { registerCredentialsCommand } from './cli/credentials-cmd.js'
 import { registerProvidersCommand } from './cli/providers-cmd.js'
+import { registerPagesCommands } from './cli/pages-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -50,5 +51,6 @@ registerPairDiscordCommand(program)
 registerWorktreeCommand(program)
 registerCredentialsCommand(program)
 registerProvidersCommand(program)
+registerPagesCommands(program)
 
 program.parse()

--- a/packages/server/src/cli/pages-cmd.js
+++ b/packages/server/src/cli/pages-cmd.js
@@ -34,7 +34,12 @@ async function daemonRequest(method, path, deps, { body } = {}) {
   const info = readConnectionInfo()
   if (!info) return { ok: false, reason: 'not_running' }
   if (!info.apiToken) return { ok: false, reason: 'no_token' }
-  const port = portFromUrl(info.httpUrl) || portFromUrl(info.wsUrl) || defaultPort
+  // Prefer the explicit local `port` (#5683) — in tunnel mode httpUrl/wsUrl are
+  // public URLs with no :port to parse, so without this the loopback request
+  // would always fall back to 8765 and miss a daemon on a custom PORT.
+  const port = (Number.isInteger(info.port) && info.port > 0)
+    ? info.port
+    : (portFromUrl(info.httpUrl) || portFromUrl(info.wsUrl) || defaultPort)
 
   const headers = { Authorization: `Bearer ${info.apiToken}`, Accept: 'application/json' }
   if (body !== undefined) headers['Content-Type'] = 'application/json'

--- a/packages/server/src/cli/pages-cmd.js
+++ b/packages/server/src/cli/pages-cmd.js
@@ -1,0 +1,162 @@
+/**
+ * chroxy publish / chroxy pages — publish HTML artifacts to a self-hosted,
+ * unguessable URL served by the running daemon (Chroxy Pages, #5683).
+ *
+ *   chroxy publish report.html [--title "..."]   → prints the share URL
+ *   chroxy pages list                            → list published pages
+ *   chroxy pages rm <slug>                       → revoke a page
+ *
+ * All three talk to the LOCAL daemon over loopback with the primary token from
+ * connection.json (the daemon owns the in-memory pages manifest, so publishing
+ * must go through it — see the design doc). The shareable URL is built from the
+ * daemon's public `httpUrl` (the tunnel/LAN base) so it opens on any device.
+ */
+
+import { basename } from 'path'
+
+function portFromUrl(url) {
+  if (typeof url !== 'string') return null
+  const m = url.match(/:(\d+)(?:\/|$)/)
+  return m ? parseInt(m[1], 10) : null
+}
+
+/** Strip a trailing slash so we can append a rooted path cleanly. */
+function trimSlash(s) {
+  return typeof s === 'string' ? s.replace(/\/+$/, '') : s
+}
+
+async function daemonRequest(method, path, deps, { body } = {}) {
+  const readConnectionInfo =
+    deps.readConnectionInfo || (await import('../connection-info.js')).readConnectionInfo
+  const fetchFn = deps.fetchFn || globalThis.fetch
+  const defaultPort = deps.defaultPort || 8765
+
+  const info = readConnectionInfo()
+  if (!info) return { ok: false, reason: 'not_running' }
+  if (!info.apiToken) return { ok: false, reason: 'no_token' }
+  const port = portFromUrl(info.httpUrl) || portFromUrl(info.wsUrl) || defaultPort
+
+  const headers = { Authorization: `Bearer ${info.apiToken}`, Accept: 'application/json' }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  try {
+    const res = await fetchFn(`http://127.0.0.1:${port}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(10_000),
+    })
+    let json = null
+    try { json = await res.json() } catch { /* non-JSON */ }
+    if (!res.ok) {
+      return { ok: false, reason: 'http_error', status: res.status, message: json?.error || `HTTP ${res.status}` }
+    }
+    return { ok: true, json, publicBase: trimSlash(info.httpUrl) || null }
+  } catch (err) {
+    return { ok: false, reason: 'unavailable', message: err?.message || 'request failed' }
+  }
+}
+
+function reportFailure(result, writeErr) {
+  if (result.reason === 'not_running') {
+    writeErr('Chroxy server is not running. Start it with `chroxy start`.')
+  } else if (result.reason === 'no_token') {
+    writeErr('Server is running without an auth token — publishing is unavailable.')
+  } else {
+    writeErr(`Request failed: ${result.message || result.reason}`)
+  }
+}
+
+export async function runPublishCmd(filePath, options = {}, deps = {}) {
+  const readFileFn = deps.readFile || (await import('fs')).readFileSync
+  const write = deps.write || console.log
+  const writeErr = deps.writeErr || console.error
+
+  let html
+  try {
+    html = readFileFn(filePath, 'utf8')
+  } catch (err) {
+    writeErr(`Cannot read ${filePath}: ${err?.message || err}`)
+    return { ok: false, reason: 'read_failed' }
+  }
+  const title = options.title || basename(filePath).replace(/\.[^.]+$/, '') || 'Untitled'
+
+  const result = await daemonRequest('POST', '/api/pages', deps, { body: { title, html } })
+  if (!result.ok) {
+    if (options.json) write(JSON.stringify(result, null, 2))
+    else reportFailure(result, writeErr)
+    return result
+  }
+  const url = result.publicBase ? `${result.publicBase}${result.json.path}` : result.json.path
+  const out = { ok: true, slug: result.json.slug, url, title: result.json.title }
+  if (options.json) write(JSON.stringify(out, null, 2))
+  else write(`Published "${out.title}" → ${url}`)
+  return out
+}
+
+export async function runPagesListCmd(options = {}, deps = {}) {
+  const write = deps.write || console.log
+  const writeErr = deps.writeErr || console.error
+  const result = await daemonRequest('GET', '/api/pages', deps)
+  if (!result.ok) {
+    if (options.json) write(JSON.stringify(result, null, 2))
+    else reportFailure(result, writeErr)
+    return result
+  }
+  const pages = (result.json?.pages || []).map((p) => ({
+    ...p,
+    url: result.publicBase ? `${result.publicBase}${p.path}` : p.path,
+  }))
+  if (options.json) {
+    write(JSON.stringify({ ok: true, pages }, null, 2))
+  } else if (pages.length === 0) {
+    write('No published pages.')
+  } else {
+    for (const p of pages) write(`${p.slug}  ${p.title}\n  ${p.url}`)
+  }
+  return { ok: true, pages }
+}
+
+export async function runPagesRmCmd(slug, options = {}, deps = {}) {
+  const write = deps.write || console.log
+  const writeErr = deps.writeErr || console.error
+  const result = await daemonRequest('DELETE', `/api/pages/${encodeURIComponent(slug)}`, deps)
+  if (!result.ok) {
+    if (options.json) write(JSON.stringify(result, null, 2))
+    else reportFailure(result, writeErr)
+    return result
+  }
+  const removed = result.json?.removed === true
+  if (options.json) write(JSON.stringify({ ok: true, removed }, null, 2))
+  else write(removed ? `Removed ${slug}` : `No page with slug ${slug}`)
+  return { ok: true, removed }
+}
+
+export function registerPagesCommands(program) {
+  program
+    .command('publish <file>')
+    .description('Publish an HTML file to an unguessable share URL served by the running daemon')
+    .option('--title <title>', 'Title for the page (defaults to the filename)')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (file, options) => {
+      const result = await runPublishCmd(file, options)
+      if (!result.ok) process.exitCode = 1
+    })
+
+  const pages = program.command('pages').description('Manage published Chroxy Pages')
+  pages
+    .command('list')
+    .description('List published pages')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (options) => {
+      const result = await runPagesListCmd(options)
+      if (!result.ok) process.exitCode = 1
+    })
+  pages
+    .command('rm <slug>')
+    .description('Remove a published page (revokes its share link)')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (slug, options) => {
+      const result = await runPagesRmCmd(slug, options)
+      if (!result.ok) process.exitCode = 1
+    })
+}

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -12,6 +12,54 @@ import { handleEventIngest } from './event-ingest.js'
 import { isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
 import { isValidSlug, mimeForPath } from './pages-store.js'
+import { sendOversizeResponse } from './http-oversize.js'
+
+/**
+ * #5683 — read + JSON-parse a request body with a byte cap. Resolves to the
+ * parsed object, or `null` when it has already responded (413 oversize / 400
+ * invalid JSON). Mirrors the byte-counted, utf8-safe streaming guard in
+ * event-ingest.js (#5433): the violating chunk is never buffered, and the
+ * `end` body is wrapped so a parse throw can't escape to uncaughtException.
+ */
+function readJsonBodyCapped(req, res, maxBytes) {
+  return new Promise((resolve) => {
+    req.setEncoding('utf8')
+    let body = ''
+    let bytes = 0
+    let oversized = false
+    req.on('data', (chunk) => {
+      if (oversized) return
+      bytes += Buffer.byteLength(chunk, 'utf8')
+      if (bytes > maxBytes) {
+        oversized = true
+        sendOversizeResponse(req, res, { error: 'body too large' })
+        resolve(null)
+        return
+      }
+      body += chunk
+    })
+    req.on('end', () => {
+      if (oversized) return
+      let parsed
+      try {
+        parsed = JSON.parse(body)
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'invalid JSON' }))
+        resolve(null)
+        return
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'body must be a JSON object' }))
+        resolve(null)
+        return
+      }
+      resolve(parsed)
+    })
+    req.on('error', () => resolve(null))
+  })
+}
 
 // #5683 — security headers for every Chroxy Pages response. The `/p/<slug>`
 // route is intentionally UNAUTHENTICATED (the slug is the capability), and
@@ -444,6 +492,77 @@ export function createHttpHandler(server) {
     // Test seams: `server._poolStatsEnabled` / `server._poolStats` override
     // the env probe + aggregator so http-routes tests don't depend on
     // process.env or a live pool.
+    // #5683 (PR-2) — Chroxy Pages publish/manage API. PRIMARY-token only: each
+    // call writes to the host disk and mints a PUBLIC capability URL, so it is
+    // host-authority (a bound/pairing token is rejected with primary_token_required,
+    // matching the other host-write routes — see bearer-token-authority.md §4).
+    if (req.method === 'POST' && snapPath === '/api/pages' && server.pagesStore) {
+      if (!server._validatePrimaryBearerAuth(req, res)) return
+      // Body cap a little above the per-page byte cap to allow JSON overhead.
+      const maxBody = server.pagesStore.maxPageBytes + 1024 * 1024
+      readJsonBodyCapped(req, res, maxBody)
+        .then((parsed) => {
+          if (parsed === null) return // 413/400 already sent
+          const title = typeof parsed.title === 'string' ? parsed.title : 'Untitled'
+          // Accept either { html } (single self-contained page) or
+          // { files: [{ path, content }] } (multi-file). `html` is shorthand.
+          let files
+          if (typeof parsed.html === 'string') {
+            files = [{ path: 'index.html', content: parsed.html }]
+          } else if (Array.isArray(parsed.files)) {
+            files = parsed.files.map((f) => ({ path: f?.path, content: typeof f?.content === 'string' ? f.content : '' }))
+          } else {
+            res.writeHead(400, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: 'body must include `html` (string) or `files` (array)' }))
+            return
+          }
+          let meta
+          try {
+            meta = server.pagesStore.publish({ title, files })
+          } catch (err) {
+            res.writeHead(400, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: err?.message || 'publish failed' }))
+            return
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ slug: meta.slug, path: `/p/${meta.slug}/`, title: meta.title, bytes: meta.bytes, createdAt: meta.createdAt }))
+        })
+        .catch((err) => {
+          log.warn(`POST /api/pages failed: ${err?.message || err}`)
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: 'publish failed' }))
+          }
+        })
+      return
+    }
+
+    if (req.method === 'GET' && snapPath === '/api/pages' && server.pagesStore) {
+      if (!server._validatePrimaryBearerAuth(req, res)) return
+      const pages = server.pagesStore.list().map((p) => ({
+        slug: p.slug, title: p.title, createdAt: p.createdAt, bytes: p.bytes, path: `/p/${p.slug}/`,
+      }))
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ pages }))
+      return
+    }
+
+    if (req.method === 'DELETE' && snapPath.startsWith('/api/pages/') && server.pagesStore) {
+      if (!server._validatePrimaryBearerAuth(req, res)) return
+      let slug
+      try {
+        slug = decodeURIComponent(snapPath.slice('/api/pages/'.length))
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'invalid slug' }))
+        return
+      }
+      const removed = server.pagesStore.remove(slug)
+      res.writeHead(removed ? 200 : 404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ removed }))
+      return
+    }
+
     if (req.method === 'GET' && snapPath === '/api/pool/stats') {
       if (!server._validateBearerAuth(req, res)) return
       const enabled = typeof server._poolStatsEnabled === 'boolean'

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -39,25 +39,36 @@ function readJsonBodyCapped(req, res, maxBytes) {
       body += chunk
     })
     req.on('end', () => {
-      if (oversized) return
-      let parsed
+      // Wrap the WHOLE handler (not just JSON.parse): this listener runs on a
+      // later tick inside the Promise executor, OUTSIDE the dispatch try/catch
+      // (#5313), so an unguarded throw here (e.g. res write on a torn-down
+      // socket) would escape to uncaughtException.
       try {
-        parsed = JSON.parse(body)
+        if (oversized) return
+        let parsed
+        try {
+          parsed = JSON.parse(body)
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'invalid JSON' }))
+          resolve(null)
+          return
+        }
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'body must be a JSON object' }))
+          resolve(null)
+          return
+        }
+        resolve(parsed)
       } catch {
-        res.writeHead(400, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'invalid JSON' }))
         resolve(null)
-        return
       }
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        res.writeHead(400, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'body must be a JSON object' }))
-        resolve(null)
-        return
-      }
-      resolve(parsed)
     })
+    // Settle on error AND close so a client abort / half-open socket can never
+    // leak a pending promise (resolve is idempotent, so a later `end` is a no-op).
     req.on('error', () => resolve(null))
+    req.on('close', () => resolve(null))
   })
 }
 
@@ -557,8 +568,11 @@ export function createHttpHandler(server) {
         res.end(JSON.stringify({ error: 'invalid slug' }))
         return
       }
+      // Idempotent: deleting an absent slug returns 200 { removed: false }
+      // rather than 404, so `chroxy pages rm` of an already-gone page reports
+      // cleanly instead of failing.
       const removed = server.pagesStore.remove(slug)
-      res.writeHead(removed ? 200 : 404, { 'Content-Type': 'application/json' })
+      res.writeHead(200, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ removed }))
       return
     }

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -521,7 +521,16 @@ export function createHttpHandler(server) {
           if (typeof parsed.html === 'string') {
             files = [{ path: 'index.html', content: parsed.html }]
           } else if (Array.isArray(parsed.files)) {
-            files = parsed.files.map((f) => ({ path: f?.path, content: typeof f?.content === 'string' ? f.content : '' }))
+            // Validate every entry instead of coercing a non-string `content` to
+            // '' — silent coercion turns an invalid client payload into a
+            // successfully published but empty/garbled page.
+            const invalid = parsed.files.find((f) => !f || typeof f.path !== 'string' || typeof f.content !== 'string')
+            if (invalid !== undefined) {
+              res.writeHead(400, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ error: 'each `files` entry requires a string `path` and string `content`' }))
+              return
+            }
+            files = parsed.files.map((f) => ({ path: f.path, content: f.content }))
           } else {
             res.writeHead(400, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ error: 'body must include `html` (string) or `files` (array)' }))
@@ -531,8 +540,18 @@ export function createHttpHandler(server) {
           try {
             meta = server.pagesStore.publish({ title, files })
           } catch (err) {
-            res.writeHead(400, { 'Content-Type': 'application/json' })
-            res.end(JSON.stringify({ error: err?.message || 'publish failed' }))
+            // publish() throws for BOTH client validation errors (plain Errors —
+            // bad paths, missing index.html, size/count caps) AND server-side I/O
+            // faults (which carry an errno `code` like EACCES/ENOSPC). Don't
+            // misreport an I/O fault as a 400, and don't leak fs detail in it.
+            if (err && typeof err.code === 'string') {
+              log.warn(`POST /api/pages publish I/O error: ${err.code} ${err?.message || ''}`)
+              res.writeHead(500, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ error: 'publish failed' }))
+            } else {
+              res.writeHead(400, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ error: err?.message || 'publish failed' }))
+            }
             return
           }
           res.writeHead(200, { 'Content-Type': 'application/json' })

--- a/packages/server/src/pages-store.js
+++ b/packages/server/src/pages-store.js
@@ -25,6 +25,10 @@ export const DEFAULT_MAX_PAGE_BYTES = 5 * 1024 * 1024 //  5 MB per page
 export const DEFAULT_MAX_TOTAL_BYTES = 100 * 1024 * 1024 // 100 MB across all pages
 export const SLUG_BYTES = 16 // → 22-char base64url
 export const DEFAULT_ENTRY = 'index.html'
+// Cap the file COUNT independently of total bytes: thousands of zero-byte files
+// pass the byte cap but still amplify into inode/dir-entry exhaustion + a long
+// synchronous mkdir/write loop. A page is a report, not a filesystem.
+export const MAX_FILES_PER_PAGE = 256
 
 // base64url alphabet; length-bounded to reject anything that isn't a plausible
 // minted slug before it ever touches the filesystem.
@@ -156,6 +160,9 @@ export class PagesStore {
   publish({ title = 'Untitled', files } = {}) {
     if (!Array.isArray(files) || files.length === 0) {
       throw new Error('publish requires a non-empty files array')
+    }
+    if (files.length > MAX_FILES_PER_PAGE) {
+      throw new Error(`Too many files: ${files.length} exceeds the ${MAX_FILES_PER_PAGE}-file per-page cap`)
     }
     // Normalize + validate every file path, and compute total size.
     const prepared = []

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -277,6 +277,7 @@ export class Supervisor extends EventEmitter {
         writeConnectionInfo({
           wsUrl: newWsUrl,
           httpUrl: newHttpUrl,
+          port: this._port, // #5683 — local loopback port for the CLI
           apiToken: this._apiToken,
           connectionUrl,
           tunnelMode: this._modeLabel,
@@ -321,6 +322,10 @@ export class Supervisor extends EventEmitter {
       writeConnectionInfo({
         wsUrl,
         httpUrl,
+        // #5683: the LOCAL listen port, so loopback CLIs (chroxy publish / pages)
+        // hit the right port even in tunnel mode, where httpUrl is the public
+        // trycloudflare URL with no :port to parse.
+        port: this._port,
         apiToken: this._apiToken,
         connectionUrl,
         tunnelMode: this._modeLabel,

--- a/packages/server/tests/pages-api.test.js
+++ b/packages/server/tests/pages-api.test.js
@@ -97,6 +97,39 @@ test('POST 413s on an oversized body', async () => {
   assert.equal(res.status, 413)
 })
 
+test('POST 400s on a files entry with a non-string content (no silent coercion)', async () => {
+  const res = await fetch(`${base}/api/pages`, {
+    method: 'POST', headers: auth(),
+    body: JSON.stringify({ title: 't', files: [{ path: 'index.html', content: '<p>ok</p>' }, { path: 'bad.txt', content: 123 }] }),
+  })
+  assert.equal(res.status, 400)
+  assert.match((await res.json()).error, /string `content`/)
+})
+
+test('POST 500s (generic, no fs detail) when publish throws an I/O fault', async () => {
+  // A pagesStore whose publish raises an errno-coded fs error: the route must
+  // classify it as a 500 and not leak the path/message as a client 400.
+  const ioServer = {
+    ...mockServer(),
+    pagesStore: {
+      maxPageBytes: 2 * 1024 * 1024,
+      publish() { const e = new Error('EACCES: permission denied, mkdir \'/root/.chroxy/pages/x\''); e.code = 'EACCES'; throw e },
+    },
+  }
+  const srv = createServer(createHttpHandler(ioServer))
+  srv.listen(0, '127.0.0.1')
+  await once(srv, 'listening')
+  try {
+    const res = await fetch(`http://127.0.0.1:${srv.address().port}/api/pages`, {
+      method: 'POST', headers: auth(), body: JSON.stringify({ html: '<p>x</p>' }),
+    })
+    assert.equal(res.status, 500)
+    const body = await res.json()
+    assert.equal(body.error, 'publish failed')
+    assert.doesNotMatch(body.error, /EACCES|root|mkdir/)
+  } finally { srv.close() }
+})
+
 test('GET /api/pages lists published pages with their public paths', async () => {
   const res = await fetch(`${base}/api/pages`, { headers: auth() })
   assert.equal(res.status, 200)

--- a/packages/server/tests/pages-api.test.js
+++ b/packages/server/tests/pages-api.test.js
@@ -1,0 +1,125 @@
+// #5683 (PR-2) — tests for the POST/GET/DELETE /api/pages publish API.
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createHttpHandler } from '../src/http-routes.js'
+import { PagesStore } from '../src/pages-store.js'
+
+let dir, store, httpServer, base
+
+function mockServer() {
+  return {
+    apiToken: 'tok',
+    serverMode: 'multi',
+    pagesStore: store,
+    _pagesRateLimiter: null,
+    _validateBearerAuth() { return false },
+    // Primary-token gate: only the literal primary token 'tok' passes; 'bound'
+    // models a pairing-bound token (rejected as insufficient class).
+    _validatePrimaryBearerAuth(req, res) {
+      const h = req.headers['authorization'] || ''
+      const tok = h.startsWith('Bearer ') ? h.slice(7) : null
+      if (tok === 'tok') return true
+      res.writeHead(403, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: tok === 'bound' ? 'primary_token_required' : 'unauthorized' }))
+      return false
+    },
+  }
+}
+
+before(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'chroxy-pages-api-'))
+  store = new PagesStore({ pagesDir: dir, maxPageBytes: 2 * 1024 * 1024 })
+  httpServer = createServer(createHttpHandler(mockServer()))
+  httpServer.listen(0, '127.0.0.1')
+  await once(httpServer, 'listening')
+  base = `http://127.0.0.1:${httpServer.address().port}`
+})
+
+after(() => {
+  httpServer?.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const auth = (tok = 'tok') => ({ Authorization: `Bearer ${tok}`, 'Content-Type': 'application/json' })
+
+test('POST /api/pages publishes and the page is then served at its slug', async () => {
+  const res = await fetch(`${base}/api/pages`, {
+    method: 'POST', headers: auth(), body: JSON.stringify({ title: 'Report', html: '<h1>R</h1>' }),
+  })
+  assert.equal(res.status, 200)
+  const body = await res.json()
+  assert.match(body.slug, /^[A-Za-z0-9_-]{16,64}$/)
+  assert.equal(body.path, `/p/${body.slug}/`)
+  assert.equal(body.title, 'Report')
+  // The freshly published page serves over the public route.
+  const page = await fetch(`${base}/p/${body.slug}/`)
+  assert.equal(page.status, 200)
+  assert.match(await page.text(), /<h1>R<\/h1>/)
+})
+
+test('POST accepts a multi-file payload', async () => {
+  const res = await fetch(`${base}/api/pages`, {
+    method: 'POST', headers: auth(),
+    body: JSON.stringify({ title: 'multi', files: [{ path: 'index.html', content: '<p>i</p>' }, { path: 'a.css', content: 'p{}' }] }),
+  })
+  assert.equal(res.status, 200)
+  const { slug } = await res.json()
+  const css = await fetch(`${base}/p/${slug}/a.css`)
+  assert.equal(css.status, 200)
+  assert.match(css.headers.get('content-type'), /text\/css/)
+})
+
+test('POST requires the primary token (no auth → 403, bound → 403)', async () => {
+  const noauth = await fetch(`${base}/api/pages`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+  assert.equal(noauth.status, 403)
+  const bound = await fetch(`${base}/api/pages`, { method: 'POST', headers: auth('bound'), body: JSON.stringify({ html: 'x' }) })
+  assert.equal(bound.status, 403)
+  assert.equal((await bound.json()).error, 'primary_token_required')
+})
+
+test('POST 400s on missing html/files, invalid JSON, and non-object body', async () => {
+  const noContent = await fetch(`${base}/api/pages`, { method: 'POST', headers: auth(), body: JSON.stringify({ title: 't' }) })
+  assert.equal(noContent.status, 400)
+  const badJson = await fetch(`${base}/api/pages`, { method: 'POST', headers: auth(), body: '{not json' })
+  assert.equal(badJson.status, 400)
+  const arr = await fetch(`${base}/api/pages`, { method: 'POST', headers: auth(), body: '[]' })
+  assert.equal(arr.status, 400)
+})
+
+test('POST 413s on an oversized body', async () => {
+  const huge = 'x'.repeat(3 * 1024 * 1024) // > maxPageBytes (2MB) + 1MB slack
+  const res = await fetch(`${base}/api/pages`, { method: 'POST', headers: auth(), body: JSON.stringify({ html: huge }) })
+  assert.equal(res.status, 413)
+})
+
+test('GET /api/pages lists published pages with their public paths', async () => {
+  const res = await fetch(`${base}/api/pages`, { headers: auth() })
+  assert.equal(res.status, 200)
+  const { pages } = await res.json()
+  assert.ok(Array.isArray(pages))
+  assert.ok(pages.length >= 1)
+  assert.ok(pages.every((p) => p.path === `/p/${p.slug}/`))
+})
+
+test('DELETE /api/pages/<slug> revokes the page (then the slug 404s)', async () => {
+  const pub = await (await fetch(`${base}/api/pages`, { method: 'POST', headers: auth(), body: JSON.stringify({ html: '<p>bye</p>' }) })).json()
+  const del = await fetch(`${base}/api/pages/${pub.slug}`, { method: 'DELETE', headers: auth() })
+  assert.equal(del.status, 200)
+  assert.equal((await del.json()).removed, true)
+  const gone = await fetch(`${base}/p/${pub.slug}/`)
+  assert.equal(gone.status, 404)
+  // Deleting an unknown slug → 404 { removed: false }.
+  const missing = await fetch(`${base}/api/pages/Zzzzzzzzzzzzzzzzzzzzzz`, { method: 'DELETE', headers: auth() })
+  assert.equal(missing.status, 404)
+  assert.equal((await missing.json()).removed, false)
+})
+
+test('GET + DELETE also require the primary token', async () => {
+  assert.equal((await fetch(`${base}/api/pages`, { headers: auth('bound') })).status, 403)
+  assert.equal((await fetch(`${base}/api/pages/whatever`, { method: 'DELETE' })).status, 403)
+})

--- a/packages/server/tests/pages-api.test.js
+++ b/packages/server/tests/pages-api.test.js
@@ -113,9 +113,9 @@ test('DELETE /api/pages/<slug> revokes the page (then the slug 404s)', async () 
   assert.equal((await del.json()).removed, true)
   const gone = await fetch(`${base}/p/${pub.slug}/`)
   assert.equal(gone.status, 404)
-  // Deleting an unknown slug → 404 { removed: false }.
+  // Deleting an unknown slug is idempotent → 200 { removed: false }.
   const missing = await fetch(`${base}/api/pages/Zzzzzzzzzzzzzzzzzzzzzz`, { method: 'DELETE', headers: auth() })
-  assert.equal(missing.status, 404)
+  assert.equal(missing.status, 200)
   assert.equal((await missing.json()).removed, false)
 })
 

--- a/packages/server/tests/pages-cmd.test.js
+++ b/packages/server/tests/pages-cmd.test.js
@@ -3,7 +3,9 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { runPublishCmd, runPagesListCmd, runPagesRmCmd } from '../src/cli/pages-cmd.js'
 
-const CONN = { apiToken: 'primary-tok', httpUrl: 'https://abc.trycloudflare.com', wsUrl: 'wss://abc.trycloudflare.com' }
+// Tunnel-mode connection.json: public URLs with no :port, plus the explicit
+// local `port` (#5683) the CLI must use for loopback.
+const CONN = { apiToken: 'primary-tok', httpUrl: 'https://abc.trycloudflare.com', wsUrl: 'wss://abc.trycloudflare.com', port: 9123 }
 
 function mockFetch(responder) {
   const calls = []
@@ -30,8 +32,9 @@ test('publish reads the file, POSTs to the local daemon, prints the public URL',
     fetchFn, write: s.write, writeErr: s.writeErr,
   })
   assert.equal(res.ok, true)
-  // Hits the LOCAL daemon (loopback, default port since trycloudflare has none).
-  assert.equal(calls[0].url, 'http://127.0.0.1:8765/api/pages')
+  // Hits the LOCAL daemon at the explicit connection.json port (NOT the public
+  // tunnel host, NOT a hardcoded 8765 fallback).
+  assert.equal(calls[0].url, 'http://127.0.0.1:9123/api/pages')
   assert.equal(calls[0].opts.method, 'POST')
   assert.equal(calls[0].opts.headers.Authorization, 'Bearer primary-tok')
   const sent = JSON.parse(calls[0].opts.body)
@@ -106,6 +109,21 @@ test('pages rm sends DELETE and reports the result', async () => {
   assert.equal(res.ok, true)
   assert.equal(res.removed, true)
   assert.equal(calls[0].opts.method, 'DELETE')
-  assert.equal(calls[0].url, 'http://127.0.0.1:8765/api/pages/MySlug')
+  assert.equal(calls[0].url, 'http://127.0.0.1:9123/api/pages/MySlug')
   assert.ok(s.out.some((l) => /Removed MySlug/.test(l)))
+})
+
+test('falls back to the httpUrl port (then 8765) when connection.json has no explicit port', async () => {
+  // Legacy connection.json (pre-#5683) with a LAN httpUrl that carries a port.
+  const lan = { apiToken: 't', httpUrl: 'http://192.168.1.5:7000', wsUrl: 'ws://192.168.1.5:7000' }
+  const withPort = mockFetch(() => jsonRes(200, { pages: [] }))
+  await runPagesListCmd({}, { readConnectionInfo: () => lan, fetchFn: withPort.fetchFn, write: () => {}, writeErr: () => {} })
+  assert.equal(withPort.calls[0].url, 'http://127.0.0.1:7000/api/pages')
+  // No port anywhere → hardcoded 8765 fallback.
+  const none = mockFetch(() => jsonRes(200, { pages: [] }))
+  await runPagesListCmd({}, {
+    readConnectionInfo: () => ({ apiToken: 't', httpUrl: 'https://x.trycloudflare.com' }),
+    fetchFn: none.fetchFn, write: () => {}, writeErr: () => {},
+  })
+  assert.equal(none.calls[0].url, 'http://127.0.0.1:8765/api/pages')
 })

--- a/packages/server/tests/pages-cmd.test.js
+++ b/packages/server/tests/pages-cmd.test.js
@@ -1,0 +1,111 @@
+// #5683 (PR-2) — unit tests for the `chroxy publish` / `chroxy pages` CLI.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { runPublishCmd, runPagesListCmd, runPagesRmCmd } from '../src/cli/pages-cmd.js'
+
+const CONN = { apiToken: 'primary-tok', httpUrl: 'https://abc.trycloudflare.com', wsUrl: 'wss://abc.trycloudflare.com' }
+
+function mockFetch(responder) {
+  const calls = []
+  const fetchFn = async (url, opts) => {
+    calls.push({ url, opts })
+    return responder(url, opts)
+  }
+  return { fetchFn, calls }
+}
+function jsonRes(status, body) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+function sink() {
+  const out = [], err = []
+  return { out, err, write: (s) => out.push(s), writeErr: (s) => err.push(s) }
+}
+
+test('publish reads the file, POSTs to the local daemon, prints the public URL', async () => {
+  const { fetchFn, calls } = mockFetch(() => jsonRes(200, { slug: 'Slug0000000000000000', path: '/p/Slug0000000000000000/', title: 'report' }))
+  const s = sink()
+  const res = await runPublishCmd('report.html', {}, {
+    readConnectionInfo: () => CONN,
+    readFile: () => '<h1>hi</h1>',
+    fetchFn, write: s.write, writeErr: s.writeErr,
+  })
+  assert.equal(res.ok, true)
+  // Hits the LOCAL daemon (loopback, default port since trycloudflare has none).
+  assert.equal(calls[0].url, 'http://127.0.0.1:8765/api/pages')
+  assert.equal(calls[0].opts.method, 'POST')
+  assert.equal(calls[0].opts.headers.Authorization, 'Bearer primary-tok')
+  const sent = JSON.parse(calls[0].opts.body)
+  assert.equal(sent.html, '<h1>hi</h1>')
+  assert.equal(sent.title, 'report') // derived from filename
+  // Prints the PUBLIC share URL (httpUrl base + path).
+  assert.equal(res.url, 'https://abc.trycloudflare.com/p/Slug0000000000000000/')
+  assert.ok(s.out.some((l) => l.includes('https://abc.trycloudflare.com/p/Slug0000000000000000/')))
+})
+
+test('publish --title overrides the derived title', async () => {
+  const { fetchFn, calls } = mockFetch(() => jsonRes(200, { slug: 'X', path: '/p/X/', title: 'Custom' }))
+  await runPublishCmd('foo.html', { title: 'Custom' }, {
+    readConnectionInfo: () => CONN, readFile: () => '<p>x</p>', fetchFn, write: () => {}, writeErr: () => {},
+  })
+  assert.equal(JSON.parse(calls[0].opts.body).title, 'Custom')
+})
+
+test('publish reports when the daemon is not running', async () => {
+  const s = sink()
+  const res = await runPublishCmd('r.html', {}, {
+    readConnectionInfo: () => null, readFile: () => '<p>x</p>', fetchFn: async () => { throw new Error('should not fetch') },
+    write: s.write, writeErr: s.writeErr,
+  })
+  assert.equal(res.ok, false)
+  assert.equal(res.reason, 'not_running')
+  assert.ok(s.err.some((l) => /not running/i.test(l)))
+})
+
+test('publish surfaces a server error (e.g. 413)', async () => {
+  const { fetchFn } = mockFetch(() => jsonRes(413, { error: 'body too large' }))
+  const s = sink()
+  const res = await runPublishCmd('r.html', {}, {
+    readConnectionInfo: () => CONN, readFile: () => 'x', fetchFn, write: s.write, writeErr: s.writeErr,
+  })
+  assert.equal(res.ok, false)
+  assert.equal(res.status, 413)
+  assert.ok(s.err.some((l) => /body too large/.test(l)))
+})
+
+test('publish fails cleanly on an unreadable file (no fetch)', async () => {
+  let fetched = false
+  const s = sink()
+  const res = await runPublishCmd('missing.html', {}, {
+    readConnectionInfo: () => CONN,
+    readFile: () => { throw new Error('ENOENT') },
+    fetchFn: async () => { fetched = true; return jsonRes(200, {}) },
+    write: s.write, writeErr: s.writeErr,
+  })
+  assert.equal(res.ok, false)
+  assert.equal(fetched, false)
+  assert.ok(s.err.some((l) => /Cannot read missing\.html/.test(l)))
+})
+
+test('pages list builds public URLs and handles the empty case', async () => {
+  const { fetchFn } = mockFetch(() => jsonRes(200, { pages: [{ slug: 'AAA', title: 'one', path: '/p/AAA/' }] }))
+  const s = sink()
+  const res = await runPagesListCmd({}, { readConnectionInfo: () => CONN, fetchFn, write: s.write, writeErr: s.writeErr })
+  assert.equal(res.ok, true)
+  assert.equal(res.pages[0].url, 'https://abc.trycloudflare.com/p/AAA/')
+
+  const empty = mockFetch(() => jsonRes(200, { pages: [] }))
+  const s2 = sink()
+  await runPagesListCmd({}, { readConnectionInfo: () => CONN, fetchFn: empty.fetchFn, write: s2.write, writeErr: s2.writeErr })
+  assert.ok(s2.out.some((l) => /No published pages/.test(l)))
+})
+
+test('pages rm sends DELETE and reports the result', async () => {
+  const { fetchFn, calls } = mockFetch(() => jsonRes(200, { removed: true }))
+  const s = sink()
+  const res = await runPagesRmCmd('MySlug', {}, { readConnectionInfo: () => CONN, fetchFn, write: s.write, writeErr: s.writeErr })
+  assert.equal(res.ok, true)
+  assert.equal(res.removed, true)
+  assert.equal(calls[0].opts.method, 'DELETE')
+  assert.equal(calls[0].url, 'http://127.0.0.1:8765/api/pages/MySlug')
+  assert.ok(s.out.some((l) => /Removed MySlug/.test(l)))
+})

--- a/packages/server/tests/pages-store.test.js
+++ b/packages/server/tests/pages-store.test.js
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, symlinkSyn
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
-  PagesStore, isValidSlug, mimeForPath, DEFAULT_ENTRY,
+  PagesStore, isValidSlug, mimeForPath, DEFAULT_ENTRY, MAX_FILES_PER_PAGE,
 } from '../src/pages-store.js'
 
 function freshStore(opts = {}) {
@@ -129,6 +129,16 @@ test('resolveFile contains paths and defeats traversal + symlink escape', () => 
     } catch (err) {
       if (err.code !== 'EPERM') throw err // some CI filesystems forbid symlink; skip if so
     }
+  } finally { cleanup() }
+})
+
+test('publish rejects a file count over the per-page cap (zero-byte amplification guard)', () => {
+  const { store, cleanup } = freshStore()
+  try {
+    // All zero-byte → passes the byte cap, but the file COUNT must be bounded.
+    const files = [{ path: DEFAULT_ENTRY, content: '' }]
+    for (let i = 0; i < MAX_FILES_PER_PAGE; i++) files.push({ path: `a${i}`, content: '' })
+    assert.throws(() => store.publish({ title: 't', files }), /per-page cap/)
   } finally { cleanup() }
 })
 


### PR DESCRIPTION
Second slice of **Chroxy Pages** (#5683) — the operator/agent surface on top of the PR-1 (#5685) serve core. Now you can actually publish that status report with one command.

```
chroxy publish docs/reports/status-2026-06-13.html
→ Published "status-2026-06-13" → https://<your-tunnel>.trycloudflare.com/p/Xa9f…/
```

## API (`http-routes.js`) — all PRIMARY-token only
Publishing writes to host disk **and** mints a public capability URL, so it's host-authority — gated on `_validatePrimaryBearerAuth` (a bound/pairing token gets `primary_token_required`, matching the other host-write routes per bearer-token-authority.md §4).
- **`POST /api/pages`** — `{ title, html }` (single self-contained page) or `{ title, files: [{path, content}] }` → `{ slug, path, title, bytes, createdAt }`. Byte-capped JSON body reader (mirrors the event-ingest #5433 streaming guard) → `400` bad body / `413` oversize.
- **`GET /api/pages`** — list, each with its `/p/<slug>/` path.
- **`DELETE /api/pages/<slug>`** — revoke (`200 {removed:true}` / `404 {removed:false}`).

## CLI (`cli/pages-cmd.js`)
- **`chroxy publish <file> [--title]`** — reads the file, POSTs to the **local** daemon over loopback with the primary token from `connection.json`, and prints the **public** share URL (`httpUrl` base + `/p/<slug>/`). Errors cleanly when the daemon isn't running or the file can't be read (no fetch on read failure).
- **`chroxy pages list`** / **`chroxy pages rm <slug>`**.

The CLI goes through the daemon (not direct disk) because the daemon owns the in-memory pages manifest — single writer, no cache-coherence gap.

## Tests (30 new)
- `pages-api.test.js` — publish→serve round-trip, multi-file, primary-token gate (no-auth + bound → 403), 400/413 body cases, list, delete→404.
- `pages-cmd.test.js` — publish file→POST→public URL, `--title`, not-running, server-error surfacing, unreadable-file (no fetch), list/rm — all with injected `fetchFn`/`readConnectionInfo`/`readFile`.

`http-routes` regression suite green (49); custom server lints green.

## Not in this PR (follow-ups)
Dashboard "Pages" panel + "Publish this artifact" button · directory/binary-asset publishing via the CLI (endpoint already accepts `files`) · GitHub Pages / Quartz export.

Closes #5686 · part of #5683