### PR TITLE
feat(app): label permission prompts with their owning session (mobile parity)

### DIFF
--- a/packages/app/src/components/__tests__/MessageBubble.sessionLabel.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.sessionLabel.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * MessageBubble permission-prompt session label — #5674 (epic #5693)
+ *
+ * When several chats run at once, a permission prompt must say WHICH session is
+ * asking, so the operator never approves the wrong agent's action. The
+ * dashboard already labels prompts (#5667); this is the mobile parity:
+ *
+ *   1. `buildPromptSessionLabel` derives a short "name · provider" label from a
+ *      prompt's `originSessionId`, and returns undefined when there's nothing to
+ *      disambiguate (no origin, unknown session, or a single session).
+ *   2. The bubble renders that label (testID `prompt-session-label`) on a live
+ *      prompt when 2+ sessions exist, and omits it for a single session.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { MessageBubble, buildPromptSessionLabel } from '../chat/MessageBubble';
+import { useConnectionStore } from '../../store/connection';
+import type { ChatMessage } from '../../store/types';
+import type { SessionInfo } from '../../store/types';
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    sessionId: 's-1',
+    name: 'chat-A',
+    cwd: '/tmp',
+    type: 'cli',
+    hasTerminal: false,
+    model: null,
+    permissionMode: null,
+    isBusy: false,
+    createdAt: 0,
+    conversationId: null,
+    ...overrides,
+  } as SessionInfo;
+}
+
+function makePrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'q-1',
+    type: 'prompt',
+    content: 'Run this command?',
+    timestamp: Date.now(),
+    toolUseId: 'toolu_label',
+    requestId: 'req-label',
+    tool: 'Bash(rm -rf build)',
+    options: [
+      { label: 'Approve', value: 'approve' },
+      { label: 'Deny', value: 'deny' },
+    ],
+    ...overrides,
+  } as ChatMessage;
+}
+
+function render(message: ChatMessage) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+        onSelectOption={() => {}}
+      />,
+    );
+  });
+  return tree;
+}
+
+describe('buildPromptSessionLabel (#5674)', () => {
+  const two = [
+    makeSession({ sessionId: 's-1', name: 'chat-A', provider: 'claude' }),
+    makeSession({ sessionId: 's-2', name: 'chat-B', provider: 'codex' }),
+  ];
+
+  it('returns undefined when there is nothing to disambiguate', () => {
+    expect(buildPromptSessionLabel(undefined, two)).toBeUndefined(); // no origin
+    expect(buildPromptSessionLabel('s-1', [two[0]])).toBeUndefined(); // single session
+    expect(buildPromptSessionLabel('s-unknown', two)).toBeUndefined(); // origin not in list
+  });
+
+  it('labels with the owning session name', () => {
+    expect(buildPromptSessionLabel('s-2', two)).toBe('chat-B · codex');
+  });
+
+  it('omits the provider suffix when absent and falls back to the id for an empty name', () => {
+    const sessions = [
+      makeSession({ sessionId: 's-1', name: 'chat-A' }),
+      makeSession({ sessionId: 's-2', name: '   ', provider: '' }),
+    ];
+    expect(buildPromptSessionLabel('s-1', sessions)).toBe('chat-A'); // no provider
+    expect(buildPromptSessionLabel('s-2', sessions)).toBe('s-2'); // blank name → id
+  });
+});
+
+describe('MessageBubble session label render (#5674)', () => {
+  afterEach(() => {
+    act(() => {
+      useConnectionStore.setState({ sessions: [] });
+    });
+  });
+
+  it('renders the owning-session label on a live prompt when 2+ sessions exist', () => {
+    act(() => {
+      useConnectionStore.setState({
+        sessions: [
+          makeSession({ sessionId: 's-1', name: 'chat-A', provider: 'claude' }),
+          makeSession({ sessionId: 's-2', name: 'chat-B', provider: 'codex' }),
+        ],
+      });
+    });
+    const tree = render(makePrompt({ originSessionId: 's-2' }));
+    const label = tree.root.findByProps({ testID: 'prompt-session-label' });
+    expect(label.props.children).toBe('chat-B · codex');
+  });
+
+  it('omits the label when only one session exists', () => {
+    act(() => {
+      useConnectionStore.setState({
+        sessions: [makeSession({ sessionId: 's-1', name: 'chat-A' })],
+      });
+    });
+    const tree = render(makePrompt({ originSessionId: 's-1' }));
+    expect(tree.root.findAllByProps({ testID: 'prompt-session-label' })).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/__tests__/MessageBubble.sessionLabel.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.sessionLabel.test.tsx
@@ -51,6 +51,12 @@ function makePrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
   } as ChatMessage;
 }
 
+// MessageBubble subscribes to useConnectionStore, so every mounted tree must be
+// torn down — otherwise an orphan subscriber survives the test and re-renders
+// (with an act() warning, or a flaky failure) when a later suite mutates the
+// store outside act. Track each tree and unmount in afterEach.
+const mountedTrees: renderer.ReactTestRenderer[] = [];
+
 function render(message: ChatMessage) {
   let tree!: renderer.ReactTestRenderer;
   act(() => {
@@ -66,6 +72,7 @@ function render(message: ChatMessage) {
       />,
     );
   });
+  mountedTrees.push(tree);
   return tree;
 }
 
@@ -98,6 +105,9 @@ describe('buildPromptSessionLabel (#5674)', () => {
 describe('MessageBubble session label render (#5674)', () => {
   afterEach(() => {
     act(() => {
+      // Unmount every tree BEFORE resetting the store so no orphan subscriber
+      // re-renders on the sessions change (avoids cross-suite act() warnings).
+      while (mountedTrees.length) mountedTrees.pop()!.unmount();
       useConnectionStore.setState({ sessions: [] });
     });
   });

--- a/packages/app/src/components/__tests__/MessageBubble.sessionLabel.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.sessionLabel.test.tsx
@@ -125,4 +125,19 @@ describe('MessageBubble session label render (#5674)', () => {
     const tree = render(makePrompt({ originSessionId: 's-1' }));
     expect(tree.root.findAllByProps({ testID: 'prompt-session-label' })).toHaveLength(0);
   });
+
+  it('omits the label once the prompt is answered (no stale "who is asking" on a resolved prompt)', () => {
+    act(() => {
+      useConnectionStore.setState({
+        sessions: [
+          makeSession({ sessionId: 's-1', name: 'chat-A' }),
+          makeSession({ sessionId: 's-2', name: 'chat-B' }),
+        ],
+      });
+    });
+    // An answered AskUserQuestion prompt (no requestId) still reaches the main
+    // render path — the !message.answered gate must keep the label off it.
+    const tree = render(makePrompt({ originSessionId: 's-2', requestId: undefined, answered: 'approve' }));
+    expect(tree.root.findAllByProps({ testID: 'prompt-session-label' })).toHaveLength(0);
+  });
 });

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -15,7 +15,8 @@ import { OTHER_OPTION_VALUE, bumpRenderCount } from '@chroxy/store-core';
 // `isFreeformAnswer` guard. Re-exported below for the existing call sites
 // (SessionScreen, ChatView, MessageBubble's own onSelectOption signature).
 import type { OtherFreeformAnswer } from '@chroxy/store-core';
-import type { ChatMessage, ToolResultImage } from '../../store/connection';
+import type { ChatMessage, ToolResultImage, SessionInfo } from '../../store/connection';
+import { useConnectionStore } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { FormattedResponse } from '../MarkdownRenderer';
@@ -51,6 +52,25 @@ import type { MultiQuestionAnswersMap } from './MultiQuestionForm';
 export type { OtherFreeformAnswer };
 
 export type SelectOptionValue = string | OtherFreeformAnswer;
+
+/**
+ * #5674 — mobile parity with the dashboard's `buildSessionLabel` (#5667):
+ * a short "which session is asking" label for a permission prompt, derived
+ * from the message's `originSessionId`. Returns undefined when there's no
+ * origin, the owning session is unknown, or only one session exists (nothing
+ * to disambiguate) — so single-session users see no extra chrome.
+ */
+export function buildPromptSessionLabel(
+  originSessionId: string | undefined,
+  sessions: SessionInfo[],
+): string | undefined {
+  if (!originSessionId || sessions.length <= 1) return undefined;
+  const session = sessions.find((s) => s.sessionId === originSessionId);
+  if (!session) return undefined;
+  const name = session.name?.trim() || originSessionId;
+  const provider = session.provider?.trim();
+  return provider ? `${name} · ${provider}` : name;
+}
 
 function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
   message: ChatMessage;
@@ -137,6 +157,16 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
   const isPrompt = message.type === 'prompt';
   const isError = message.type === 'error';
   const isSystem = message.type === 'system';
+
+  // #5674 — resolve the owning-session label for permission prompts so a user
+  // juggling multiple chats can see WHICH session is asking (dashboard parity,
+  // #5667). Read via a selector returning a stable string|undefined: non-prompt
+  // bubbles (no originSessionId) resolve to undefined and never re-render on a
+  // sessions change, and the #5516 memo skip on delta flushes is preserved (the
+  // label only changes when the session list itself does).
+  const promptSessionLabel = useConnectionStore((s) =>
+    buildPromptSessionLabel(message.originSessionId, s.sessions),
+  );
 
   // Reset "Other" UI mode when the prompt becomes answered (#3746 review).
   // Without this, otherActive would stay true after an answer arrives from
@@ -333,6 +363,18 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
           <PermissionCountdown expiresAt={message.expiresAt} onExpire={() => setIsExpired(true)} />
         )}
       </View>
+      {/* #5674 — which session is asking. Rendered as its own line under the
+          header so it never crowds the tool name / countdown row, and only
+          when there's more than one session to disambiguate. */}
+      {isPrompt && promptSessionLabel && (
+        <Text
+          testID="prompt-session-label"
+          style={styles.promptSessionLabel}
+          numberOfLines={1}
+        >
+          {promptSessionLabel}
+        </Text>
+      )}
       {/* #4973 — when the multi-question form / summary renders, suppress
           the body content Text. The top-level `message.content` mirrors
           Q[0]'s question (store-core handleUserQuestion), so rendering it
@@ -656,6 +698,12 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 4,
+  },
+  promptSessionLabel: {
+    color: COLORS.textMuted,
+    fontSize: 11,
+    fontWeight: '500',
+    marginBottom: 6,
   },
   promptOptions: {
     flexDirection: 'row',

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -364,9 +364,14 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
         )}
       </View>
       {/* #5674 — which session is asking. Rendered as its own line under the
-          header so it never crowds the tool name / countdown row, and only
-          when there's more than one session to disambiguate. */}
-      {isPrompt && promptSessionLabel && (
+          header so it never crowds the tool name / countdown row, and only on
+          an UNANSWERED prompt with 2+ sessions to disambiguate. Intentionally
+          broader than the dashboard (which labels only live permission
+          prompts): an AskUserQuestion prompt benefits from the same "which
+          chat wants my input" attribution, so we gate on the prompt being
+          live rather than on requestId. Answered+collapsed permission prompts
+          take the PermissionPill early-return above and never reach here. */}
+      {isPrompt && !message.answered && promptSessionLabel && (
         <Text
           testID="prompt-session-label"
           style={styles.promptSessionLabel}


### PR DESCRIPTION
Part of the permission-predictability epic #5693. **Closes #5674.**

## Problem
When several chats run at once, a mobile permission prompt shows only the tool name (`MessageBubble.tsx` header = `message.tool`). With 3 agents running you can't tell *which* session is asking — so you risk approving the wrong agent's `Bash(rm …)`. The dashboard already attributes prompts to their owning session (#5667); mobile had no parity.

## Change
- **`buildPromptSessionLabel(originSessionId, sessions)`** — derives a short `name · provider` label from the prompt's `originSessionId`; returns `undefined` when there's nothing to disambiguate (no origin, unknown session, or a single session — so single-session users see no extra chrome). Mirrors the dashboard's `buildSessionLabel`.
- **MessageBubble** renders the label (testID `prompt-session-label`) as its own line under the prompt header, on live prompts only.
- Resolved via a **stable store selector**: non-prompt bubbles (no `originSessionId`) resolve to `undefined` and never re-render on a sessions change, so the #5516 memo skip on streaming delta flushes is preserved (memoization test still green).

## Tests
- Pure helper: no-origin / single-session / unknown-session → undefined; `name · provider`; provider-absent; blank-name → id fallback.
- Render: label present with 2+ sessions + matching origin; absent with one session.
- Full MessageBubble suite (33) + memoization test green; app tsc clean.

## Notes / follow-ups (separate PRs in #5693)
- Notification titles aren't yet session-scoped, and the collapsed answered-pill doesn't show the label — both deferred to later epic PRs.
- PR-2 (containment routing) will stop background-session prompts from ever landing in the focused tab in the first place.