### PR TITLE
fix(perm): contain permission prompts to their owning session (PR-2)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -3757,6 +3757,9 @@ describe('permission_request message handler', () => {
     expect(bgPrompt!.originSessionId).toBe('s-bg');
     // The focused tab must NOT have received the background session's prompt.
     expect(state.sessionStates['s-active'].messages.find((m: any) => m.type === 'prompt')).toBeUndefined();
+    // Tab-invisibility: ensuring s-bg's state must not register a phantom tab —
+    // tabs derive from `sessions` (unchanged), not the `sessionStates` keys.
+    expect(state.sessions).toHaveLength(2);
   });
 
   it('sets expiresAt from remainingMs', () => {

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -3722,6 +3722,43 @@ describe('permission_request message handler', () => {
     expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny']);
   });
 
+  it('creates the owning session state and routes the prompt there when that session is NOT loaded (#5693)', () => {
+    // 's-bg' asks while 's-active' is focused and 's-bg' has no hydrated state.
+    // Containment fix: the handler creates s-bg's (tab-invisible) state and
+    // routes the prompt there — the app previously dropped it or routed to the
+    // active session. The active session must stay clean.
+    const store = createMockStore({
+      activeSessionId: 's-active',
+      sessions: [
+        { sessionId: 's-active', name: 'A', provider: 'claude-sdk' } as any,
+        { sessionId: 's-bg', name: 'B', provider: 'claude-sdk' } as any,
+      ],
+      sessionStates: { 's-active': createEmptySessionState() }, // NO s-bg
+      availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true } } as any],
+      sessionNotifications: [],
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    clearPermissionSplits();
+
+    _testMessageHandler.handle({
+      type: 'permission_request',
+      sessionId: 's-bg',
+      requestId: 'perm-unloaded',
+      tool: 'Bash',
+      input: { command: 'rm -rf /tmp/x' },
+      remainingMs: 300000,
+    });
+
+    const state = store.getState();
+    expect(state.sessionStates['s-bg']).toBeDefined();
+    const bgPrompt = state.sessionStates['s-bg'].messages.find((m: any) => m.type === 'prompt');
+    expect(bgPrompt).toBeDefined();
+    expect(bgPrompt!.originSessionId).toBe('s-bg');
+    // The focused tab must NOT have received the background session's prompt.
+    expect(state.sessionStates['s-active'].messages.find((m: any) => m.type === 'prompt')).toBeUndefined();
+  });
+
   it('sets expiresAt from remainingMs', () => {
     const before = Date.now();
     const store = createMockStore({

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2752,6 +2752,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // tapping the option on codex/gemini/claude-cli sessions hits a server
       // "not supported" error.
       const permTargetId = permPayload.sessionId || get().activeSessionId;
+      // #5693 containment: a permission MAPPED to a session must surface in THAT
+      // session's transcript, never whatever tab is focused. If the owning
+      // session isn't loaded on this client yet, create its empty state — which
+      // is tab-invisible (tabs come from `sessions`, not `sessionStates`) — so
+      // the prompt routes home instead of being dropped or injected into the
+      // active session. Unmapped prompts (no wire sessionId) intentionally stay
+      // in the active session (still answerable, not mislabeled — originSessionId
+      // stays undefined).
+      const ownerSessionId = permPayload.sessionId;
+      if (ownerSessionId && !get().sessionStates[ownerSessionId]) {
+        set((state) => ({
+          sessionStates: { ...state.sessionStates, [ownerSessionId]: createEmptySessionState() },
+        }));
+      }
       const permSession = permTargetId
         ? get().sessions.find((s) => s.sessionId === permTargetId)
         : null;

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -4133,6 +4133,41 @@ describe('dashboard message-handler dispatch', () => {
       expect((state.sessions || []).some((s: any) => s.sessionId === 's-bg')).toBe(false)
     })
 
+    it('does not clear the active tab\'s in-flight stream when a mapped prompt arrives for an unloaded session (#5693)', () => {
+      // s-active is mid-stream; s-bg (not loaded) asks for permission. The #554
+      // stream-split must read s-bg's stream (null after the containment guard
+      // creates its state), NOT fall back to the active session's
+      // streamingMessageId and null it — that would interrupt the focused tab's
+      // response just because a different session asked.
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's-active',
+          streamingMessageId: 'stream-active',
+          sessionNotifications: [],
+          sessionStates: {
+            's-active': { ...createEmptySessionState(), streamingMessageId: 'stream-active' },
+          }, // NO s-bg
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'permission_request',
+          sessionId: 's-bg',
+          requestId: 'perm-stream',
+          tool: 'Bash',
+          input: { command: 'ls' },
+          remainingMs: 300000,
+        },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      // The active tab's stream is preserved — not cleared by s-bg's permission.
+      expect(state.streamingMessageId).toBe('stream-active')
+      // Containment still holds: s-bg received its prompt.
+      expect(state.sessionStates['s-bg'].messages.find((m: any) => m.type === 'prompt')).toBeDefined()
+    })
+
     it('leaves originSessionId undefined for an unmapped request (no wire sessionId) (#5667)', () => {
       // No sessionId on the wire → the prompt falls back to the active tab for
       // routing, but originSessionId must stay undefined (not the active id) so

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -4127,6 +4127,10 @@ describe('dashboard message-handler dispatch', () => {
       expect(state.sessionStates['s-active'].messages.find((m: any) => m.type === 'prompt')).toBeUndefined()
       // ...and not the flat top-level messages that mirror the focused tab.
       expect((state.messages || []).find((m: any) => m.type === 'prompt')).toBeUndefined()
+      // Tab-invisibility (the whole safety basis): creating s-bg's state must
+      // NOT register it as a tab — tabs derive from `sessions`, not the
+      // `sessionStates` keys.
+      expect((state.sessions || []).some((s: any) => s.sessionId === 's-bg')).toBe(false)
     })
 
     it('leaves originSessionId undefined for an unmapped request (no wire sessionId) (#5667)', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -4093,6 +4093,42 @@ describe('dashboard message-handler dispatch', () => {
       expect(activeMsgs.find((m: any) => m.type === 'prompt')).toBeUndefined()
     })
 
+    it('creates the owning session state and routes the prompt there when that session is NOT loaded (#5693)', () => {
+      // 's-bg' is asking but its sessionState has not been hydrated on this
+      // client (only 's-active' is loaded). Containment fix: create s-bg's
+      // (tab-invisible) state and route the prompt there — never into the active
+      // tab's transcript or the flat top-level messages that mirror it.
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's-active',
+          sessionNotifications: [],
+          sessionStates: { 's-active': createEmptySessionState() }, // NO 's-bg'
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'permission_request',
+          sessionId: 's-bg',
+          requestId: 'perm-unloaded',
+          tool: 'Bash',
+          input: { command: 'rm -rf /tmp/x' },
+          remainingMs: 300000,
+        },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      // Owning session state was created and holds the labeled prompt.
+      expect(state.sessionStates['s-bg']).toBeDefined()
+      const bgPrompt = state.sessionStates['s-bg'].messages.find((m: any) => m.type === 'prompt')
+      expect(bgPrompt).toBeDefined()
+      expect(bgPrompt.originSessionId).toBe('s-bg')
+      // The active tab must NOT have received it — not its state...
+      expect(state.sessionStates['s-active'].messages.find((m: any) => m.type === 'prompt')).toBeUndefined()
+      // ...and not the flat top-level messages that mirror the focused tab.
+      expect((state.messages || []).find((m: any) => m.type === 'prompt')).toBeUndefined()
+    })
+
     it('leaves originSessionId undefined for an unmapped request (no wire sessionId) (#5667)', () => {
       // No sessionId on the wire → the prompt falls back to the active tab for
       // routing, but originSessionId must stay undefined (not the active id) so

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1983,6 +1983,19 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
   ];
   const newExpiresAt = permPayload.remainingMs !== null ? Date.now() + permPayload.remainingMs : undefined;
   const permTargetId = permPayload.sessionId || get().activeSessionId;
+  // #5693 containment: a permission MAPPED to a session must surface in THAT
+  // session's transcript, never whatever tab is focused. If the owning session
+  // isn't loaded on this client yet, create its empty state — tab-invisible
+  // (tabs come from `sessions`, not `sessionStates`) — so the prompt routes home
+  // instead of leaking into the active session via the flat-messages fallback.
+  // Unmapped prompts (no wire sessionId) intentionally stay in the active
+  // session (still answerable, not mislabeled — originSessionId stays undefined).
+  const ownerSessionId = permPayload.sessionId;
+  if (ownerSessionId && !get().sessionStates[ownerSessionId]) {
+    set((state) => ({
+      sessionStates: { ...state.sessionStates, [ownerSessionId]: createEmptySessionState() },
+    }));
+  }
 
   const targetMessages = permTargetId && get().sessionStates[permTargetId]
     ? get().sessionStates[permTargetId]!.messages

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1949,6 +1949,21 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
   // insert a prompt with an `undefined` requestId and still run the stream
   // split; such a message is unanswerable, so drop it outright.)
   if (!permPayload.requestId) return;
+  // #5693 containment: a permission MAPPED to a session must surface in THAT
+  // session's transcript, never whatever tab is focused — and must not disturb
+  // the focused tab's in-flight stream. Create the owning session's empty state
+  // (tab-invisible — tabs come from `sessions`, not `sessionStates`) BEFORE the
+  // #554 stream-split below, so the split reads the owning session's stream
+  // (null for a freshly-created state) instead of falling back to the ACTIVE
+  // session's `streamingMessageId` and clearing a different tab's stream.
+  // Unmapped prompts (no wire sessionId) intentionally stay with the active
+  // session (still answerable, not mislabeled — originSessionId stays undefined).
+  const ownerSessionId = permPayload.sessionId;
+  if (ownerSessionId && !get().sessionStates[ownerSessionId]) {
+    set((state) => ({
+      sessionStates: { ...state.sessionStates, [ownerSessionId]: createEmptySessionState() },
+    }));
+  }
   // Split streaming response at permission boundary (#554). The pure
   // split/remap-resolution core is shared via store-core (#5454); the side
   // effects below keep their original order.
@@ -1983,19 +1998,6 @@ function handlePermissionRequest(msg: Record<string, unknown>, get: MsgGet, set:
   ];
   const newExpiresAt = permPayload.remainingMs !== null ? Date.now() + permPayload.remainingMs : undefined;
   const permTargetId = permPayload.sessionId || get().activeSessionId;
-  // #5693 containment: a permission MAPPED to a session must surface in THAT
-  // session's transcript, never whatever tab is focused. If the owning session
-  // isn't loaded on this client yet, create its empty state — tab-invisible
-  // (tabs come from `sessions`, not `sessionStates`) — so the prompt routes home
-  // instead of leaking into the active session via the flat-messages fallback.
-  // Unmapped prompts (no wire sessionId) intentionally stay in the active
-  // session (still answerable, not mislabeled — originSessionId stays undefined).
-  const ownerSessionId = permPayload.sessionId;
-  if (ownerSessionId && !get().sessionStates[ownerSessionId]) {
-    set((state) => ({
-      sessionStates: { ...state.sessionStates, [ownerSessionId]: createEmptySessionState() },
-    }));
-  }
 
   const targetMessages = permTargetId && get().sessionStates[permTargetId]
     ? get().sessionStates[permTargetId]!.messages


### PR DESCRIPTION
Part of the permission-predictability epic #5693 (**PR-2 — containment routing**). Builds on PR-1 (#5694, session labels).

## Problem (the "wrong tab" durability bug)
A permission mapped to a background session **B** could appear in whatever tab you were focused on. Root cause: when B's session state isn't hydrated on this client, the dashboard's `handlePermissionRequest` falls back to the flat top-level `messages` — and **flat `messages` mirror the active tab's transcript** — so B's prompt leaks into session A's view. The app variant either routed to the active session or silently dropped the prompt.

## Fix (minimal, grounded by a design pass)
When a permission carries a wire `sessionId` whose state isn't loaded, **create that session's empty state before routing**. Key facts that make this safe:
- **Tabs derive from the `sessions` array, not `sessionStates` keys** — so creating an empty `sessionStates[B]` is *tab-invisible* (no phantom tab).
- The prompt then takes the existing owning-session branch instead of the flat/active fallback → it routes home.
- **Unmapped** prompts (no wire `sessionId`) intentionally stay in the active session: still answerable (the server keys responses by `requestId`, not session), and per PR-1 not mislabeled (`originSessionId` stays undefined).

Changed: `packages/dashboard/src/store/message-handler.ts` + `packages/app/src/store/message-handler.ts` (one ensure-state guard each). No server change.

## Tests
- New (both clients): a permission for a **not-loaded** owning session creates that session's state and lands there, while the focused tab's state AND the flat top-level `messages` stay clean.
- Full suites green: dashboard message-handler 225, app message-handler 188; both tsc clean.

## Scope / deferred (separate issues)
- Server-side teardown of the permission-induced auto-subscription → **#5704** (invisible after this fix; needs refcounting; low reward / medium risk).
- `permission_expired` all-sessions search hardening — optional, deferred (dismissal already works because expiry carries the same `sessionId` and the state now exists).

## Do-no-harm (verified)
- Did NOT touch `_registerPermissionRoute` auto-subscribe (#4798 respond-after-switch contract).
- Did NOT change the unmapped→active fallback or `originSessionId` semantics.
- Did NOT alter `permission_resolved`/`permission_timeout` all-sessions dismissal.