### PR TITLE
fix(server): reject destroy_session while the session is running (#5695)

### DIFF
--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -202,7 +202,8 @@ async function handleDestroySession(ws, client, msg, ctx) {
     return
   }
 
-  if (!ctx.sessions.sessionManager.getSession(targetId)) {
+  const targetEntry = ctx.sessions.sessionManager.getSession(targetId)
+  if (!targetEntry) {
     sendSessionError(ws, ctx, `Session not found: ${targetId}`)
     return
   }
@@ -214,6 +215,16 @@ async function handleDestroySession(ws, client, msg, ctx) {
 
   if (ctx.sessions.sessionManager.isSessionLocked?.(targetId)) {
     sendSessionError(ws, ctx, 'Session is being modified by another operation')
+    return
+  }
+
+  // #5695: never tear down a session (which also deletes its worktree) while it
+  // is actively streaming or has pending background shells — that orphans the
+  // in-flight turn and can lose uncommitted worktree work. The CLI won't delete
+  // the session you're running in either. Interrupt first, then delete.
+  // (A `force` escape hatch for a wedged session is tracked as a follow-up.)
+  if (targetEntry.session?.isRunning) {
+    sendSessionError(ws, ctx, 'Cannot destroy a session while it is running — interrupt it first, then delete.')
     return
   }
 

--- a/packages/server/tests/ws-handlers.test.js
+++ b/packages/server/tests/ws-handlers.test.js
@@ -206,6 +206,32 @@ describe('WS handler: destroy_session', () => {
     ws.close()
   })
 
+  it('rejects destroying a session while it is running', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'First', cwd: '/tmp' },
+      { id: 'sess-2', name: 'Busy', cwd: '/tmp', isRunning: true },
+    ])
+    manager.destroySession = createSpy(() => {})
+    manager.destroySessionLocked = createSpy(() => Promise.resolve())
+
+    server = new WsServer({
+      port: 0, apiToken: 'test-token', authRequired: false,
+      sessionManager: manager,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    messages.length = 0
+    send(ws, { type: 'destroy_session', sessionId: 'sess-2' })
+
+    const error = await waitForMessage(messages, 'session_error')
+    assert.ok(error.message.includes('running'), 'Error should mention the session is running')
+    assert.equal(manager.destroySession.callCount, 0, 'destroySession should NOT be called')
+    assert.equal(manager.destroySessionLocked.callCount, 0, 'destroySessionLocked should NOT be called')
+
+    ws.close()
+  })
+
   it('awaits destroySessionLocked when present', async () => {
     const { manager, sessionsMap } = createMockSessionManager([
       { id: 'sess-1', name: 'First', cwd: '/tmp' },


### PR DESCRIPTION
## What

Adds a busy guard to `handleDestroySession`: refuse to destroy a session while `entry.session.isRunning` (actively streaming or has pending background shells).

Closes #5695.

## Why

Destroying a session also deletes its worktree (`session-manager.js` → `_removeWorktree`). The handler already guarded the *last-session* and *locked-session* cases but never checked whether the session was mid-stream — so a second client, or the same user on another device in a shared session, could tear down a running session and lose uncommitted worktree work, with no confirmation. The Claude Code CLI won't delete the session you're running in; this brings parity.

## Change

- `packages/server/src/handlers/session-handlers.js`: capture the session entry at the existence check and reject with `session_error` ("interrupt it first, then delete.") when `isRunning`.
- Test in `ws-handlers.test.js`: a running session is not destroyed and the client gets an error.

## Scope note

No `force` escape hatch in this PR. That needs a `force` field on `DestroySessionSchema` (protocol) + a `dist` rebuild, which can't be done cleanly from a node_modules-less worktree. Tracked as a follow-up on #5695 — interrupt-then-delete covers the common case.

## Verification

- `node --check` passes on both edited files.
- Full server suite runs in CI (local full-suite verification deferred — the main checkout is in use by another change; will confirm locally when free). Targeted test added to `WS handler: destroy_session`.

Part of the durability-parity epic #5703.