### PR TITLE
feat(dashboard): aggregate "N pending" permission badge + jump-to-next (PR-3)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -27,7 +27,7 @@ import { MultiTerminalView } from './components/MultiTerminalView'
 import { InputBar, type FileAttachment, type ImageAttachment } from './components/InputBar'
 import { useVoiceInput } from './hooks/useVoiceInput'
 import { toWireAttachments } from './utils/attachment-utils'
-import { derivePendingPermissionSessions } from './utils/pendingPermissions'
+import { derivePendingPermissionCounts, totalPendingPermissions, selectNextPendingSession } from './utils/pendingPermissions'
 import { processImageFiles, filterImageFiles } from './utils/image-utils'
 import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
@@ -1010,8 +1010,8 @@ export function App() {
   // re-renders a tab when its pending state actually flips, not on every stream
   // delta. The `expiresAt > now` check (inside the helper) clears the indicator
   // on expiry/timeout, which set `options: undefined` but not `answered`.
-  const pendingPermissionSessionIds = useConnectionStore(
-    useShallow((s) => derivePendingPermissionSessions(s.sessionStates, Date.now())),
+  const pendingPermissionCounts = useConnectionStore(
+    useShallow((s) => derivePendingPermissionCounts(s.sessionStates, Date.now())),
   )
 
   const sessionTabs: SessionTabData[] = useMemo(
@@ -1042,11 +1042,24 @@ export function App() {
         stdinForwardingDisabled: s.stdinForwardingDisabled,
         // #5667: flag tabs with an unanswered permission prompt so a
         // background session's request is visible without switching to it.
-        pendingPermission: pendingPermissionSessionIds[s.sessionId] ?? false,
+        // #5693: also carry the count so the tab can show `!2`.
+        pendingPermission: (pendingPermissionCounts[s.sessionId] ?? 0) > 0,
+        pendingPermissionCount: pendingPermissionCounts[s.sessionId] ?? 0,
       }))
     },
-    [sessions, activeSessionId, getSessionVisualStatus, tabOrder, pendingPermissionSessionIds],
+    [sessions, activeSessionId, getSessionVisualStatus, tabOrder, pendingPermissionCounts],
   )
+
+  // #5693 (PR-3) — aggregate "N pending" badge + jump-to-next-waiting-session.
+  // Containment keeps each prompt in its own tab; this gives one place to see
+  // the total and one click to reach the next waiting session (cyclically, in
+  // visual tab order).
+  const pendingPermissionTotal = totalPendingPermissions(pendingPermissionCounts)
+  const handleJumpToPending = useCallback(() => {
+    const orderedIds = sessionTabs.map(t => t.sessionId)
+    const next = selectNextPendingSession(orderedIds, pendingPermissionCounts, activeSessionId)
+    if (next) handleSwitchSession(next)
+  }, [sessionTabs, pendingPermissionCounts, activeSessionId, handleSwitchSession])
 
   // Derive sidebar repo tree from sessions
   // #4120: dedicated selector for the cumulativeUsage slice the sidebar
@@ -1745,6 +1758,8 @@ export function App() {
               onActivate: openControlRoom,
               onClose: closeControlRoom,
             }}
+            pendingPermissionTotal={pendingPermissionTotal}
+            onJumpToPending={handleJumpToPending}
           />
         )}
 

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -78,6 +78,58 @@ describe('SessionBar', () => {
     expect(within(cleanTab).queryByTestId('tab-pending-permission')).not.toBeInTheDocument()
   })
 
+  it('shows the pending count on a tab with more than one prompt (#5693)', () => {
+    render(
+      <SessionBar
+        sessions={makeSessions([
+          { pendingPermission: true, pendingPermissionCount: 1 },
+          { pendingPermission: true, pendingPermissionCount: 3 },
+        ])}
+        onSwitch={vi.fn()}
+        onClose={vi.fn()}
+        onRename={vi.fn()}
+        onNewSession={vi.fn()}
+      />
+    )
+    // One pending → bare '!'; many → '!N'.
+    expect(within(screen.getByTestId('session-tab-s1')).getByTestId('tab-pending-permission').textContent).toBe('!')
+    expect(within(screen.getByTestId('session-tab-s2')).getByTestId('tab-pending-permission').textContent).toBe('!3')
+  })
+
+  it('renders the aggregate "N pending" badge and jumps on click (#5693)', () => {
+    const onJumpToPending = vi.fn()
+    render(
+      <SessionBar
+        sessions={makeSessions([{}, { pendingPermission: true, pendingPermissionCount: 2 }])}
+        onSwitch={vi.fn()}
+        onClose={vi.fn()}
+        onRename={vi.fn()}
+        onNewSession={vi.fn()}
+        pendingPermissionTotal={2}
+        onJumpToPending={onJumpToPending}
+      />
+    )
+    const badge = screen.getByTestId('pending-permission-total')
+    expect(badge.textContent).toContain('2 pending')
+    fireEvent.click(badge)
+    expect(onJumpToPending).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the aggregate badge when nothing is pending (#5693)', () => {
+    render(
+      <SessionBar
+        sessions={makeSessions()}
+        onSwitch={vi.fn()}
+        onClose={vi.fn()}
+        onRename={vi.fn()}
+        onNewSession={vi.fn()}
+        pendingPermissionTotal={0}
+        onJumpToPending={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('pending-permission-total')).not.toBeInTheDocument()
+  })
+
   it('calls onSwitch when clicking inactive tab', () => {
     const onSwitch = vi.fn()
     render(

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -49,6 +49,9 @@ export interface SessionTabData {
   // attention indicator on the tab so a background session's request is
   // visible without switching to it.
   pendingPermission?: boolean
+  // #5693 (PR-3): how many live unanswered permission prompts this session has.
+  // Renders as a count on the tab (`!2`) when > 1.
+  pendingPermissionCount?: number
 }
 
 /**
@@ -88,6 +91,14 @@ export interface SessionBarProps {
    * `open`, a pinned non-session tab renders at the left of the strip.
    */
   controlRoom?: ControlRoomTabState
+  /**
+   * #5693 (PR-3) — total live pending permissions across ALL sessions. When
+   * > 0, an aggregate "N pending" badge renders in the bar; clicking it calls
+   * `onJumpToPending` to focus the next waiting session.
+   */
+  pendingPermissionTotal?: number
+  /** #5693 (PR-3) — focus the next session with a pending permission. */
+  onJumpToPending?: () => void
 }
 
 function shortenModel(model: string): string {
@@ -149,7 +160,7 @@ export function reorderTabs(ids: string[], fromIndex: number, toIndex: number): 
   return next
 }
 
-export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession, onReorder, controlRoom }: SessionBarProps) {
+export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession, onReorder, controlRoom, pendingPermissionTotal = 0, onJumpToPending }: SessionBarProps) {
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
@@ -530,17 +541,21 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               )
             })()}
 
-            {/* #5667 — unanswered permission prompt waiting in this session. */}
-            {session.pendingPermission && (
-              <span
-                className="tab-pending-permission"
-                data-testid="tab-pending-permission"
-                title="Permission requested — waiting for your approval"
-                aria-label="Permission requested — waiting for your approval"
-              >
-                !
-              </span>
-            )}
+            {/* #5667 / #5693 — unanswered permission prompt(s) waiting in this
+                session. Shows the count when more than one is pending. */}
+            {session.pendingPermission && (() => {
+              const count = session.pendingPermissionCount ?? 1
+              return (
+                <span
+                  className="tab-pending-permission"
+                  data-testid="tab-pending-permission"
+                  title={`${count} permission request${count === 1 ? '' : 's'} — waiting for your approval`}
+                  aria-label={`${count} permission request${count === 1 ? '' : 's'} waiting for your approval`}
+                >
+                  {count > 1 ? `!${count}` : '!'}
+                </span>
+              )
+            })()}
 
             {renamingId === session.sessionId ? (
               <input
@@ -649,6 +664,23 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
       >
         +
       </button>
+
+      {/* #5693 (PR-3) — aggregate "N pending" badge across all sessions. One
+          place to see the total, and clicking it jumps to the next waiting
+          session (cyclically) so prompts stay contained in their own tab while
+          remaining one click away. */}
+      {pendingPermissionTotal > 0 && (
+        <button
+          className="session-bar-pending-total"
+          data-testid="pending-permission-total"
+          onClick={onJumpToPending}
+          aria-label={`${pendingPermissionTotal} permission request${pendingPermissionTotal === 1 ? '' : 's'} waiting — go to the next`}
+          title={`${pendingPermissionTotal} permission request${pendingPermissionTotal === 1 ? '' : 's'} waiting — click to go to the next`}
+          type="button"
+        >
+          <span aria-hidden="true">⚠ {pendingPermissionTotal} pending</span>
+        </button>
+      )}
 
       {/* #4951 — visually-hidden hint referenced via `aria-describedby`
           on each draggable tab. Renders unconditionally so the id stays

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1823,9 +1823,12 @@ button.sidebar-token-view-session-row:hover {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
+  /* #5693: grow past a circle when a count (`!2`) is shown. */
+  min-width: 14px;
   height: 14px;
-  border-radius: 50%;
+  padding: 0 3px;
+  box-sizing: border-box;
+  border-radius: 7px;
   font-size: 10px;
   font-weight: 800;
   line-height: 1;
@@ -1833,6 +1836,36 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-purple);
   border: 1px solid var(--border-permission, color-mix(in srgb, var(--accent-purple) 45%, transparent));
   cursor: help;
+}
+
+/* #5693 (PR-3) — aggregate "N pending" badge in the session bar. Clickable;
+   jumps to the next waiting session. */
+.session-bar-pending-total {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  padding: 2px 8px;
+  border-radius: 11px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  background: var(--bg-permission, color-mix(in srgb, var(--accent-purple) 22%, transparent));
+  color: var(--accent-purple);
+  border: 1px solid var(--border-permission, color-mix(in srgb, var(--accent-purple) 45%, transparent));
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.session-bar-pending-total:hover {
+  background: color-mix(in srgb, var(--accent-purple) 32%, transparent);
+}
+
+.session-bar-pending-total:focus-visible {
+  outline: 2px solid var(--accent-purple);
+  outline-offset: 1px;
 }
 
 .tab-close {

--- a/packages/dashboard/src/utils/pendingPermissions.test.ts
+++ b/packages/dashboard/src/utils/pendingPermissions.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import type { ChatMessage } from '@chroxy/store-core'
-import { derivePendingPermissionSessions } from './pendingPermissions'
+import {
+  derivePendingPermissionSessions,
+  derivePendingPermissionCounts,
+  totalPendingPermissions,
+  selectNextPendingSession,
+} from './pendingPermissions'
 
 const NOW = 1_000_000
 
@@ -71,5 +76,78 @@ describe('derivePendingPermissionSessions (#5667)', () => {
       NOW,
     )
     expect(result).toEqual({ s1: true })
+  })
+})
+
+describe('derivePendingPermissionCounts (#5693)', () => {
+  it('counts multiple live prompts in one session and omits zero-pending sessions', () => {
+    const counts = derivePendingPermissionCounts(
+      states({
+        s1: [prompt({ id: 'a', requestId: 'r-a' }), prompt({ id: 'b', requestId: 'r-b' })],
+        s2: [prompt({ id: 'c', requestId: 'r-c' })],
+        s3: [prompt({ id: 'd', requestId: 'r-d', answered: 'allow' })], // resolved → omitted
+        s4: [], // empty → omitted
+      }),
+      NOW,
+    )
+    expect(counts).toEqual({ s1: 2, s2: 1 })
+  })
+
+  it('excludes answered / expired / AskUserQuestion prompts from the count', () => {
+    const counts = derivePendingPermissionCounts(
+      states({
+        s1: [
+          prompt({ id: 'live', requestId: 'r1' }),
+          prompt({ id: 'answered', requestId: 'r2', answered: 'deny' }),
+          prompt({ id: 'expired', requestId: 'r3', expiresAt: NOW - 1 }),
+          prompt({ id: 'aukq', requestId: undefined, expiresAt: undefined }),
+        ],
+      }),
+      NOW,
+    )
+    expect(counts).toEqual({ s1: 1 })
+  })
+
+  it('stays consistent with the boolean derive', () => {
+    const s = states({ s1: [prompt({ id: 'a' })], s2: [prompt({ id: 'b', answered: 'allow' })] })
+    expect(derivePendingPermissionSessions(s, NOW)).toEqual({ s1: true })
+    expect(Object.keys(derivePendingPermissionCounts(s, NOW))).toEqual(['s1'])
+  })
+})
+
+describe('totalPendingPermissions (#5693)', () => {
+  it('sums counts across sessions', () => {
+    expect(totalPendingPermissions({ s1: 2, s2: 1 })).toBe(3)
+    expect(totalPendingPermissions({})).toBe(0)
+  })
+})
+
+describe('selectNextPendingSession (#5693)', () => {
+  const order = ['a', 'b', 'c', 'd']
+
+  it('returns null when nothing is pending', () => {
+    expect(selectNextPendingSession(order, {}, 'a')).toBeNull()
+    expect(selectNextPendingSession([], { a: 1 }, 'a')).toBeNull()
+  })
+
+  it('jumps to the next pending session AFTER the active tab, in tab order', () => {
+    // active = 'a'; pending b and d → next after a is b.
+    expect(selectNextPendingSession(order, { b: 1, d: 2 }, 'a')).toBe('b')
+    // active = 'b'; next pending after b is d.
+    expect(selectNextPendingSession(order, { b: 1, d: 2 }, 'b')).toBe('d')
+  })
+
+  it('wraps around cyclically', () => {
+    // active = 'd' (last); pending a → wrap to a.
+    expect(selectNextPendingSession(order, { a: 1 }, 'd')).toBe('a')
+  })
+
+  it('returns the active tab when it is the only pending one (no-op focus)', () => {
+    expect(selectNextPendingSession(order, { b: 3 }, 'b')).toBe('b')
+  })
+
+  it('scans from the start when the active id is not in the list', () => {
+    expect(selectNextPendingSession(order, { c: 1 }, 'unknown')).toBe('c')
+    expect(selectNextPendingSession(order, { c: 1 }, null)).toBe('c')
   })
 })

--- a/packages/dashboard/src/utils/pendingPermissions.ts
+++ b/packages/dashboard/src/utils/pendingPermissions.ts
@@ -23,26 +23,87 @@ import type { ChatMessage } from '@chroxy/store-core'
  * Scans each session newest-first and early-exits at the first live prompt; a
  * pending permission blocks its session, so it is at/near the tail in practice.
  */
+/** True iff `m` is a live, unanswered permission prompt (not an AskUserQuestion). */
+function isLivePermissionPrompt(m: ChatMessage, now: number): boolean {
+  return (
+    m.type === 'prompt' &&
+    !!m.requestId &&
+    !!m.expiresAt &&
+    m.expiresAt > now &&
+    !m.answered
+  )
+}
+
+/**
+ * #5693 (PR-3) — count the live, unanswered permission prompts in EACH session.
+ * Generalizes {@link derivePendingPermissionSessions} from a boolean to a count
+ * so the SessionBar can show a per-tab number (`!2`) and an aggregate "N
+ * pending" badge. Sessions with zero pending are omitted (so a `useShallow`
+ * selector re-renders a tab only when its count changes).
+ *
+ * Unlike the boolean derive, this does NOT early-exit — a session can hold more
+ * than one pending permission (e.g. parallel SDK tool calls), and the count is
+ * the point. Pending permissions are few, so the full scan is cheap.
+ */
+export function derivePendingPermissionCounts(
+  sessionStates: Record<string, { messages: ChatMessage[] }>,
+  now: number,
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const id in sessionStates) {
+    const msgs = sessionStates[id]!.messages
+    let count = 0
+    for (let i = 0; i < msgs.length; i++) {
+      if (isLivePermissionPrompt(msgs[i]!, now)) count++
+    }
+    if (count > 0) out[id] = count
+  }
+  return out
+}
+
+/**
+ * #5667 — which sessions have at least one live unanswered permission prompt.
+ * Thin boolean view over {@link derivePendingPermissionCounts} (single source of
+ * truth for the "is this a live permission prompt" predicate). Drives the
+ * per-tab attention dot.
+ */
 export function derivePendingPermissionSessions(
   sessionStates: Record<string, { messages: ChatMessage[] }>,
   now: number,
 ): Record<string, true> {
+  const counts = derivePendingPermissionCounts(sessionStates, now)
   const out: Record<string, true> = {}
-  for (const id in sessionStates) {
-    const msgs = sessionStates[id]!.messages
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      const m = msgs[i]!
-      if (
-        m.type === 'prompt' &&
-        m.requestId &&
-        m.expiresAt &&
-        m.expiresAt > now &&
-        !m.answered
-      ) {
-        out[id] = true
-        break
-      }
-    }
-  }
+  for (const id in counts) out[id] = true
   return out
+}
+
+/** Total live pending permissions across all sessions. */
+export function totalPendingPermissions(counts: Record<string, number>): number {
+  let total = 0
+  for (const id in counts) total += counts[id]!
+  return total
+}
+
+/**
+ * #5693 (PR-3) — pick the next session (in visual tab order) that has a pending
+ * permission, scanning cyclically AFTER the active tab so repeated "jump to
+ * pending" clicks cycle through every waiting session. Returns null when none
+ * are pending. If the active tab is the only one pending, returns it (a no-op
+ * focus). If `activeSessionId` isn't in the list, scans from the start.
+ */
+export function selectNextPendingSession(
+  orderedSessionIds: string[],
+  counts: Record<string, number>,
+  activeSessionId: string | null,
+): string | null {
+  const hasPending = (id: string) => (counts[id] ?? 0) > 0
+  const n = orderedSessionIds.length
+  if (n === 0 || !orderedSessionIds.some(hasPending)) return null
+  const activeIndex = activeSessionId ? orderedSessionIds.indexOf(activeSessionId) : -1
+  const from = activeIndex < 0 ? -1 : activeIndex
+  for (let step = 1; step <= n; step++) {
+    const id = orderedSessionIds[(from + step + n) % n]!
+    if (hasPending(id)) return id
+  }
+  return null
 }


### PR DESCRIPTION
Final piece of the permission-predictability epic #5693 (**PR-3 — aggregate badge**), completing the "containment + aggregate" design you chose. Builds on PR-1 (labels, #5694) and PR-2 (containment, #5705).

## What
Containment keeps each prompt in its own tab; this gives **one place to see the total and one click to triage** — exactly the chosen mockup:
```
┌─ Sessions ──────────── ⚠ 3 pending ┐
│ [chat-A] [chat-B ●!2] [chat-C ●!1] │
```
- **Per-tab count** — the tab attention badge shows `!2` when a session has more than one pending prompt (bare `!` for one).
- **Aggregate "⚠ N pending" pill** — renders in the session bar when any permission is waiting; **clicking it jumps to the next waiting session** (cyclically, after the active tab, in visual tab order), so repeated clicks cycle through every waiting session.

## How (pure, testable core)
- `derivePendingPermissionCounts(sessionStates, now)` — per-session count; the existing `derivePendingPermissionSessions` boolean is now a thin view over it (single source of truth for the "live permission prompt" predicate).
- `totalPendingPermissions(counts)` + `selectNextPendingSession(orderedIds, counts, activeId)` — aggregate total and the cyclic next-pick.
- `SessionBar` gains `pendingPermissionCount` per tab + `pendingPermissionTotal`/`onJumpToPending`; `App` wires both off the counts selector and `handleSwitchSession`.

## Tests
- Pure helpers: multi-count, exclusions (answered/expired/AskUserQuestion), boolean consistency, total sum, next-selection (after-active, wrap, only-active no-op, active-not-in-list).
- SessionBar: per-tab `!N`, aggregate badge text + click→jump, hidden when zero.
- Full dashboard suite green (3645); tsc clean.

## Scope
Dashboard only (the tab/aggregate concept lives here). Mobile aggregate parity can follow if wanted. No server change.