### PR TITLE
fix(server): surface session-state flush failures instead of swallowing them (#5701)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -129,6 +129,10 @@ const DEFAULT_WORKTREE_BASE = join(homedir(), '.chroxy', 'worktrees')
  *   session_restore_failed { sessionId, name, provider, cwd, model, permissionMode, errorCode, errorMessage, originalHistoryPreserved, historyLength }
  *     — emitted when a session in the persisted state file fails to restore (e.g. missing env var).
  *       History on disk is preserved so the user can retry after fixing the underlying issue.
+ *   session_persist_failed { sessionId, name } — #5701: a synchronous flush of a
+ *     session-list mutation (create/rename/destroy) failed to write to disk
+ *     (disk full / locked file / read-only home), so the change may be lost on
+ *     restart. Observable signal; a client-facing surface is a follow-up.
  */
 
 // Re-export formatIdleDuration from SessionTimeoutManager for backward compatibility
@@ -1036,7 +1040,7 @@ export class SessionManager extends EventEmitter {
     // Exception: restoreState calls us in a loop and seeds history/budget
     // AFTER this returns; flushing here would write empty history to disk
     // and permanently discard the data being restored.
-    if (!skipPersist) this._flushPersist()
+    if (!skipPersist) this._flushPersistOrWarn(sessionId)
     return sessionId
   }
 
@@ -1454,7 +1458,7 @@ export class SessionManager extends EventEmitter {
     this.emit('session_updated', { sessionId, name })
     // Flush synchronously — before this, renames were never persisted at all,
     // so a restart would show the pre-rename label.
-    this._flushPersist()
+    this._flushPersistOrWarn(sessionId, name)
     return true
   }
 
@@ -1493,8 +1497,9 @@ export class SessionManager extends EventEmitter {
     }
     log.info(`Destroyed session ${sessionId} "${entry.name}" (${this._sessions.size}/${this.maxSessions})`)
     this.emit('session_destroyed', { sessionId })
-    // Flush synchronously so the deletion survives an abrupt shutdown.
-    this._flushPersist()
+    // Flush synchronously so the deletion survives an abrupt shutdown. The
+    // entry is already out of `_sessions` by now, so pass its name explicitly.
+    this._flushPersistOrWarn(sessionId, entry.name)
     return true
   }
 
@@ -1514,7 +1519,11 @@ export class SessionManager extends EventEmitter {
     try {
       this.serializeState()
     } catch (err) {
-      log.error(`Failed to serialize state during destroyAll: ${err?.stack || err}`)
+      // #5701: this is the final write before the process exits — a failure
+      // here loses the whole session list on the next start. Log loudly so the
+      // operator can act (disk space / permissions) rather than discovering it
+      // silently gone after restart.
+      log.error(`CRITICAL: failed to serialize session state during shutdown — sessions may NOT be restored on next start (check disk space and ~/.chroxy permissions): ${err?.stack || err}`)
     }
     // Set the destroying flag AFTER the final write — every persist call from
     // here on (duplicate shutdown handler, late-arriving session event) will
@@ -2085,7 +2094,29 @@ export class SessionManager extends EventEmitter {
    * using the debounced path to avoid write amplification.
    */
   _flushPersist() {
-    this._persistence.flushPersist(() => this.serializeState())
+    return this._persistence.flushPersist(() => this.serializeState())
+  }
+
+  /**
+   * #5701: flush a session-list mutation and surface a failure instead of
+   * swallowing it. flushPersist used to catch-and-log write errors (disk full,
+   * locked file, read-only home), so a create/rename/destroy could succeed in
+   * memory yet never reach disk and silently revert on the next restart. Now a
+   * failed flush is logged at error level with an operator-actionable hint and
+   * emits `session_persist_failed` so it is observable. (A client-facing banner
+   * is a follow-up — it needs a new wire message type; `session_warning` is
+   * reserved for the idle-timeout countdown UI and must not be overloaded.)
+   * @param {string} sessionId
+   * @param {string|null} name - pass explicitly when the entry is already gone
+   *   from `_sessions` (e.g. destroySession flushes after cleanup).
+   * @returns {boolean} true if the write succeeded.
+   */
+  _flushPersistOrWarn(sessionId, name = null) {
+    if (this._flushPersist()) return true
+    const resolvedName = name || this._sessions.get(sessionId)?.name || null
+    log.error(`Session state for ${sessionId}${resolvedName ? ` ("${resolvedName}")` : ''} was NOT persisted — it may be lost on restart. Check disk space and ~/.chroxy permissions.`)
+    this.emit('session_persist_failed', { sessionId, name: resolvedName })
+    return false
   }
 
   /**

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1523,7 +1523,7 @@ export class SessionManager extends EventEmitter {
       // here loses the whole session list on the next start. Log loudly so the
       // operator can act (disk space / permissions) rather than discovering it
       // silently gone after restart.
-      log.error(`CRITICAL: failed to serialize session state during shutdown — sessions may NOT be restored on next start (check disk space and ~/.chroxy permissions): ${err?.stack || err}`)
+      log.error(`CRITICAL: failed to serialize session state during shutdown — sessions may NOT be restored on next start (check disk space and write permissions for ${this._stateFilePath}): ${err?.stack || err}`)
     }
     // Set the destroying flag AFTER the final write — every persist call from
     // here on (duplicate shutdown handler, late-arriving session event) will
@@ -2107,14 +2107,16 @@ export class SessionManager extends EventEmitter {
    * is a follow-up — it needs a new wire message type; `session_warning` is
    * reserved for the idle-timeout countdown UI and must not be overloaded.)
    * @param {string} sessionId
-   * @param {string|null} name - pass explicitly when the entry is already gone
-   *   from `_sessions` (e.g. destroySession flushes after cleanup).
+   * @param {string|null} name - pass explicitly to control the logged label:
+   *   the new name on rename, or the entry's name on destroy (where the entry
+   *   is already removed from `_sessions` before this flush, so a lookup would
+   *   be nameless). Omit to look it up from `_sessions`.
    * @returns {boolean} true if the write succeeded.
    */
   _flushPersistOrWarn(sessionId, name = null) {
     if (this._flushPersist()) return true
     const resolvedName = name || this._sessions.get(sessionId)?.name || null
-    log.error(`Session state for ${sessionId}${resolvedName ? ` ("${resolvedName}")` : ''} was NOT persisted — it may be lost on restart. Check disk space and ~/.chroxy permissions.`)
+    log.error(`Session state for ${sessionId}${resolvedName ? ` ("${resolvedName}")` : ''} was NOT persisted — it may be lost on restart. Check disk space and write permissions for ${this._stateFilePath}.`)
     this.emit('session_persist_failed', { sessionId, name: resolvedName })
     return false
   }

--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -250,14 +250,23 @@ export class SessionStatePersistence {
    * Used for session-list mutations that must survive an abrupt shutdown —
    * callers include createSession / destroySession / renameSession, where
    * losing the write would erase a user's session from the sidebar.
+   *
+   * #5701: returns whether the write succeeded so callers can surface the
+   * failure instead of silently losing the mutation on disk-full / locked-file
+   * / read-only-home conditions. (The write itself is still atomic — see
+   * serializeState — so a failure leaves the prior good file intact; the risk
+   * being signalled is the lost mutation, not corruption.)
    * @param {() => void} serializeFn
+   * @returns {boolean} true if the write succeeded, false if it threw.
    */
   flushPersist(serializeFn) {
     this.cancelPersist()
     try {
       serializeFn()
+      return true
     } catch (err) {
       log.error(`Failed to flush session state: ${err?.stack || err}`)
+      return false
     }
   }
 

--- a/packages/server/tests/session-persist-failure.test.js
+++ b/packages/server/tests/session-persist-failure.test.js
@@ -1,0 +1,63 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { SessionManager } from '../src/session-manager.js'
+
+/**
+ * #5701 — flush failures on session-list mutations must be surfaced, not
+ * swallowed. Before this, a create/rename/destroy could succeed in memory but
+ * silently fail to write to disk (disk full / locked file / read-only home)
+ * and revert on the next restart with no signal. `_flushPersistOrWarn` now
+ * logs loudly and emits `session_persist_failed`.
+ */
+function makeMgr() {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'sm-persist-fail-'))
+  const mgr = new SessionManager({
+    skipPreflight: true,
+    maxSessions: 10,
+    defaultCwd: '/tmp',
+    stateFilePath: join(tmpDir, 'state.json'),
+  })
+  mgr._tmpDir = tmpDir
+  return mgr
+}
+
+function cleanup(mgr) {
+  mgr.destroyAll()
+  rmSync(mgr._tmpDir, { recursive: true, force: true })
+}
+
+describe('session_persist_failed (#5701)', () => {
+  let mgr
+  afterEach(() => { if (mgr) { cleanup(mgr); mgr = null } })
+
+  it('emits session_persist_failed and returns false when the flush fails', () => {
+    mgr = makeMgr()
+    // Force the underlying write to report failure (as on disk-full / EACCES).
+    mgr._persistence.flushPersist = () => false
+
+    const events = []
+    mgr.on('session_persist_failed', (e) => events.push(e))
+
+    const ok = mgr._flushPersistOrWarn('sess-x', 'My Session')
+
+    assert.strictEqual(ok, false, 'returns false on a failed flush')
+    assert.equal(events.length, 1, 'emits exactly one session_persist_failed')
+    assert.deepEqual(events[0], { sessionId: 'sess-x', name: 'My Session' })
+  })
+
+  it('returns true and emits nothing when the flush succeeds', () => {
+    mgr = makeMgr()
+    mgr._persistence.flushPersist = () => true
+
+    const events = []
+    mgr.on('session_persist_failed', (e) => events.push(e))
+
+    const ok = mgr._flushPersistOrWarn('sess-y', 'Fine')
+
+    assert.strictEqual(ok, true)
+    assert.equal(events.length, 0, 'no failure event on success')
+  })
+})

--- a/packages/server/tests/session-state-persistence.test.js
+++ b/packages/server/tests/session-state-persistence.test.js
@@ -95,6 +95,32 @@ describe('SessionStatePersistence.serializeState', () => {
   })
 })
 
+describe('SessionStatePersistence.flushPersist (#5701)', () => {
+  let tempDir
+  let stateFile
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'chroxy-flush-test-'))
+    stateFile = join(tempDir, 'session-state.json')
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns true when the write succeeds', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    const ok = p.flushPersist(() => p.serializeState({ version: 1, timestamp: Date.now(), sessions: [] }))
+    assert.strictEqual(ok, true)
+  })
+
+  it('returns false (no longer swallows) when the serialize throws', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    const ok = p.flushPersist(() => { throw new Error('ENOSPC: no space left on device') })
+    assert.strictEqual(ok, false)
+  })
+})
+
 describe('SessionStatePersistence.restoreState', () => {
   let tempDir
   let stateFile


### PR DESCRIPTION
## What

Makes session-state persistence failures observable instead of silently swallowed.

Closes #5701.

## Why

`flushPersist`/`_flushPersist` caught-and-logged write errors and returned nothing. A `createSession`/`renameSession`/`destroySession` could succeed in memory but silently fail to reach disk (disk full, locked file, read-only `~/.chroxy`) and then revert on the next restart — a create/rename lost, or a deleted "zombie" session reappearing — with no signal. The on-disk write is already atomic (rotate-to-`.bak` + temp-file + rename), so this is a *lost-mutation* signaling gap, not corruption.

## Change

- `session-state-persistence.js`: `flushPersist` returns a boolean.
- `session-manager.js`: `_flushPersist` returns it; new `_flushPersistOrWarn(sessionId, name)` logs the failure at error level with an actionable hint and emits a `session_persist_failed` event. Wired at create/rename/destroy. Shutdown serialize failure now logs `CRITICAL`.
- Tests: `flushPersist` returns true/false (persistence unit); `session_persist_failed` emitted + returns false on failure, silent on success (manager).

## Scope note

No client-facing banner in this PR. Surfacing it to clients needs a **new wire message type** (`session_warning` is reserved for the idle-timeout countdown UI and must not be overloaded), which means a protocol schema + `dist` rebuild — not doable cleanly from a node_modules-less worktree. Deferred as a follow-up; the server now logs loudly and emits an observable event.

## Verification

- `node --check` on all edited files; `lint-tests-state-file-path` and `lint-logger-session-scoping` pass.
- Full server suite runs in CI (local full-suite deferred — main checkout in use by another change).

Part of the durability-parity epic #5703.