### PR TITLE
fix(server): truthful model_changed broadcast (durability Gap 2)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -545,6 +545,16 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
+   * #5711 (Gap 2): true while a turn is actively streaming (mid-turn). Distinct
+   * from `isRunning`, which also counts pending background shells — handlers use
+   * this to tell a deferred mid-turn setting change (e.g. setModel returning
+   * false because the session is busy) apart from a same-value no-op.
+   */
+  get isBusy() {
+    return this._isBusy
+  }
+
+  /**
    * #4307: read-only snapshot of pending background shells.
    * #5376: delegates to BackgroundShellTracker.
    */

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -109,6 +109,27 @@ function getProviderAllowedModels(providerName) {
   }
 }
 
+// #5711 (Gap 2): apply a model change and broadcast model_changed ONLY when it
+// actually lands. setModel() returns false when the session is mid-turn (the
+// change is a server-side no-op) — the old code broadcast model_changed
+// regardless, so every client's dropdown showed the new model while the engine
+// (in-flight AND next turn) kept the old one. Mirrors the #3729 set_permission_mode
+// contract: no broadcast unless applied; a busy rejection tells the requester so
+// the UI can surface "deferred" instead of a phantom switch. A same-model no-op
+// is silent (the model already matches — nothing to report).
+function applyModelChange(ws, ctx, entry, sessionId, modelArg, broadcastModel, requestId) {
+  if (entry.session.setModel(modelArg)) {
+    ctx.transport.broadcastToSession(sessionId, { type: 'model_changed', model: broadcastModel })
+    return
+  }
+  if (entry.session.isBusy) {
+    sessionLogger(sessionId).warn(`set_model deferred (session mid-turn): requested ${modelArg}`)
+    sendError(ws, requestId, 'MODEL_NOT_APPLIED',
+      `Model change to '${modelArg}' was not applied — the session is mid-turn. Wait for it to finish or interrupt it, then switch.`,
+      { sessionId }, ctx)
+  }
+}
+
 function handleSetModel(ws, client, msg, ctx) {
   if (typeof msg.model !== 'string') {
     log.warn(`Rejected invalid model from ${client.id}: ${JSON.stringify(msg.model)}`)
@@ -140,8 +161,7 @@ function handleSetModel(ws, client, msg, ctx) {
         return
       }
       ;sessionLogger(modelSessionId).info(`Model change from ${client.id} on session ${modelSessionId}: ${model}`)
-      entry.session.setModel(model)
-      ctx.transport.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(model) })
+      applyModelChange(ws, ctx, entry, modelSessionId, model, toShortModelId(model), msg?.requestId)
       return
     }
     if (providerAllowed) {
@@ -164,12 +184,11 @@ function handleSetModel(ws, client, msg, ctx) {
       }
       // #4828: session-scoped (single-session fallback as above).
       ;sessionLogger(modelSessionId).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
-      entry.session.setModel(msg.model)
       // Non-Claude providers use opaque model IDs (e.g. 'gemini-2.5-pro') —
       // broadcast them verbatim. toShortModelId() is a Claude-specific
       // alias collapse (claude-sonnet-4-6 → sonnet) and returns the input
       // unchanged for non-Claude IDs, so applying it uniformly is safe.
-      ctx.transport.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
+      applyModelChange(ws, ctx, entry, modelSessionId, msg.model, toShortModelId(msg.model), msg?.requestId)
       return
     }
     // Fall through to the legacy global allowlist when the provider hasn't
@@ -180,8 +199,7 @@ function handleSetModel(ws, client, msg, ctx) {
     if (entry) {
       // #4828: session-scoped (single-session fallback).
       ;sessionLogger(modelSessionId).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
-      entry.session.setModel(msg.model)
-      ctx.transport.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
+      applyModelChange(ws, ctx, entry, modelSessionId, msg.model, toShortModelId(msg.model), msg?.requestId)
     }
     return
   }

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -88,6 +88,44 @@ describe('settings-handlers', () => {
       assert.equal(msg.type, 'model_changed')
     })
 
+    it('does not broadcast model_changed when the session is mid-turn; sends MODEL_NOT_APPLIED (#5711)', () => {
+      // Gap 2: setModel() returns false mid-turn (server no-op). Broadcasting
+      // model_changed anyway told every client the model switched while the
+      // engine kept the old one. Now: no broadcast, and the requester gets a
+      // clear "deferred" error.
+      const sessions = new Map()
+      const session = createMockSession()
+      session.isBusy = true
+      session.setModel = createSpy(() => false) // real setModel returns false mid-turn
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+      const ws = makeWs()
+
+      settingsHandlers.set_model(ws, client, { model: 'haiku', requestId: 'r-busy' }, ctx)
+
+      assert.equal(session.setModel.callCount, 1)
+      assert.equal(ctx.transport.broadcastToSession.callCount, 0) // no phantom switch
+      assert.equal(ws._messages.length, 1)
+      assert.equal(ws._messages[0].type, 'error')
+      assert.equal(ws._messages[0].code, 'MODEL_NOT_APPLIED')
+    })
+
+    it('stays silent on a same-model no-op — no broadcast, no error (#5711)', () => {
+      const sessions = new Map()
+      const session = createMockSession() // isBusy false by default
+      session.setModel = createSpy(() => false) // no-op: model unchanged
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+      const ws = makeWs()
+
+      settingsHandlers.set_model(ws, client, { model: 'sonnet', requestId: 'r-noop' }, ctx)
+
+      assert.equal(ctx.transport.broadcastToSession.callCount, 0)
+      assert.equal(ws._messages.length, 0) // a harmless no-op must not nag the user
+    })
+
     it('ignores invalid model ids', () => {
       const sessions = new Map()
       const session = createMockSession()

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -337,7 +337,18 @@ export function createMockSession(overrides = {}) {
   session.sessionPreamble = ''
   session.sendMessage = createSpy()
   session.interrupt = createSpy()
-  session.setModel = createSpy()
+  // #5711 (Gap 2): the real setModel returns true only when the model actually
+  // changed (false when mid-turn or a same-model no-op), and the handler now
+  // broadcasts model_changed only on a true return. Mirror that contract:
+  // mutate `session.model` and report changed; `isBusy` defaults false so the
+  // common "applied" path is the default. Tests that want the busy/no-op path
+  // override `session.setModel` / `session.isBusy` after creation.
+  session.isBusy = false
+  session.setModel = createSpy((model) => {
+    if (model === session.model) return false
+    session.model = model
+    return true
+  })
   // #3729: handler now reads session.permissionMode AFTER setPermissionMode
   // returns to detect silently-rejected mid-turn changes. Mock the real
   // contract: state mutates on a successful set so handler tests don't


### PR DESCRIPTION
First fix from the durability sweep #5711. **Gap 2 — the UI tells you the model changed mid-turn when the server silently ignored it.**

## Problem
`BaseSession.setModel()` returns `false` when the session is mid-turn (`base-session.js:821-824`) — the change is a server-side no-op. But `handleSetModel` broadcast `model_changed` **unconditionally** at all three sites (`settings-handlers.js` :144/:172/:184), ignoring the return. Result: switch model while a turn is streaming → every client's dropdown flips to the new model, but the in-flight turn **and the next turn** keep running on the old one. The user believes the switch took effect. That's the kind of unpredictability that makes chroxy feel less trustworthy than the CLI (where `/model` reflects real state).

## Fix
Mirror the established **#3729 `set_permission_mode`** contract (which already does exactly this for mode):
- Only broadcast `model_changed` when `setModel()` actually applied the change.
- On a **busy** rejection, send `MODEL_NOT_APPLIED` so the client can surface "deferred — finish/interrupt the turn first" instead of a phantom success.
- On a **same-model no-op**, stay silent (the model already matches — nothing to report or nag about).

Added a precise `isBusy` getter to `BaseSession` to distinguish busy from no-op (`isRunning` also counts background shells, so it's wrong here). All three model paths (ollama-unrestricted, per-provider allowlist, global allowlist) route through one `applyModelChange` helper.

## Tests
- mid-turn → no broadcast + `MODEL_NOT_APPLIED` error; same-model no-op → no broadcast, no error.
- Mock `setModel` updated to honor the real true/false contract (was a no-op spy).
- Green: settings-handlers 106, base-session 148, coupled mock/broadcast suites 133; server lints pass.

Part of #5711.