### PR TITLE
fix(dashboard): roll back optimistic model on MODEL_NOT_APPLIED (durability)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -113,6 +113,8 @@ import {
   rejectAllEvaluatorRequests,
   registerTrustGrantRequest,
   clearPendingTrustGrants,
+  registerModelChangeRequest,
+  clearPendingModelReverts,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
@@ -1613,6 +1615,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // never), and a stale toast action would call grantCommunitySkillTrust
       // against a closed socket.
       clearPendingTrustGrants();
+      clearPendingModelReverts();
       // #3605: also clear the per-session pendingTrustGrants arrays
       // (added in #3588). disconnect() handles user-initiated closes, but
       // an unexpected drop here would otherwise leave the SkillsPanel
@@ -1709,6 +1712,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       rejectAllEvaluatorRequests('Connection errored before evaluator response arrived');
       rejectAllSummarizeRequests('Connection errored before the summary arrived');
       clearPendingTrustGrants();
+      clearPendingModelReverts();
       const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
 
       set({ socket: null, sessionStates: cleanedSessionStates });
@@ -1741,6 +1745,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // skill_trust_grant correlations so a stale toast button can't fire
     // against the disconnected socket.
     clearPendingTrustGrants();
+    clearPendingModelReverts();
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -2420,8 +2425,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   setModel: (model: string) => {
     const { socket, activeSessionId } = get();
+    // #5711: remember the model we're switching FROM so a server
+    // MODEL_NOT_APPLIED rejection (e.g. a mid-turn no-op, #5696) can roll the
+    // optimistic update below back, instead of leaving the dropdown showing a
+    // model the session never actually switched to.
+    const previousModel = (activeSessionId && get().sessionStates[activeSessionId])
+      ? (get().sessionStates[activeSessionId]!.activeModel ?? null)
+      : (get().activeModel ?? null);
     if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'set_model', model };
+      // Correlate the optimistic update with the server's ack/rejection. The
+      // requestId rides set_model's passthrough schema; the server echoes it on
+      // a MODEL_NOT_APPLIED error so the handler can revert the right request.
+      const requestId = `set-model-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      registerModelChangeRequest(requestId, { sessionId: activeSessionId, previousModel });
+      const payload: Record<string, unknown> = { type: 'set_model', model, requestId };
       if (activeSessionId) payload.sessionId = activeSessionId;
       wsSend(socket, payload);
     }

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -430,7 +430,38 @@ describe('dashboard message-handler dispatch', () => {
 
         const state = store.getState() as any
         expect(state.sessionStates.s1.activeModel).toBe('sonnet') // rolled back
+        // The flat top-level activeModel (what the dropdown renders for the
+        // active session) is rolled back too.
+        expect(state.activeModel).toBe('sonnet')
         expect(_testModelRevertPendingSize()).toBe(0) // consumed
+      })
+
+      it('reverts the SECOND of two rapid changes even after the first acks (per-request, not per-session)', () => {
+        // A→B (req1) then B→C (req2) on s1, both in-flight. Server acks req1
+        // (model_changed B) and rejects req2 (mid-turn). The revert must restore
+        // B (req2's previousModel), not leave the dropdown on C — i.e. req1's
+        // success must NOT drop req2's pending revert.
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            activeModel: 'C',
+            sessionStates: { s1: { ...createEmptySessionState(), activeModel: 'C' } },
+          }),
+        )
+        setStore(store)
+        registerModelChangeRequest('req1', { sessionId: 's1', previousModel: 'A' })
+        registerModelChangeRequest('req2', { sessionId: 's1', previousModel: 'B' })
+
+        // req1 succeeds first.
+        handleMessage({ type: 'model_changed', sessionId: 's1', model: 'B' }, ctx() as any)
+        // req2 is then rejected.
+        handleMessage(
+          { type: 'error', requestId: 'req2', code: 'MODEL_NOT_APPLIED', message: 'mid-turn' },
+          ctx() as any,
+        )
+
+        const state = store.getState() as any
+        expect(state.sessionStates.s1.activeModel).toBe('B') // req2 rolled back to B, not stuck on C
       })
 
       it('does NOT revert when the error requestId does not match a pending change', () => {
@@ -452,25 +483,12 @@ describe('dashboard message-handler dispatch', () => {
         expect(_testModelRevertPendingSize()).toBe(1) // still pending
       })
 
-      it('a model_changed success drops the pending revert so a later error can\'t roll it back', () => {
-        store = createMockStore(
-          baseState({
-            activeSessionId: 's1',
-            sessionStates: { s1: { ...createEmptySessionState(), activeModel: 'haiku' } },
-          }),
-        )
-        setStore(store)
-        registerModelChangeRequest('set-model-1', { sessionId: 's1', previousModel: 'sonnet' })
-
-        handleMessage({ type: 'model_changed', sessionId: 's1', model: 'haiku' }, ctx() as any)
-        expect(_testModelRevertPendingSize()).toBe(0) // cleared on success
-
-        // A stale/duplicate error must now be a no-op (nothing to revert).
-        handleMessage(
-          { type: 'error', requestId: 'set-model-1', code: 'MODEL_NOT_APPLIED', message: 'late' },
-          ctx() as any,
-        )
-        expect((store.getState() as any).sessionStates.s1.activeModel).toBe('haiku')
+      it('clears all pending reverts on disconnect', () => {
+        registerModelChangeRequest('req-a', { sessionId: 's1', previousModel: 'sonnet' })
+        registerModelChangeRequest('req-b', { sessionId: 's2', previousModel: 'opus' })
+        expect(_testModelRevertPendingSize()).toBe(2)
+        clearPendingModelReverts()
+        expect(_testModelRevertPendingSize()).toBe(0)
       })
     })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -35,6 +35,9 @@ import {
   registerTrustGrantRequest,
   clearPendingTrustGrants,
   _testTrustGrantPendingSize,
+  registerModelChangeRequest,
+  clearPendingModelReverts,
+  _testModelRevertPendingSize,
   setDeltaFlushIntervalOverride,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
@@ -398,6 +401,77 @@ describe('dashboard message-handler dispatch', () => {
       const state = store.getState() as any
       expect(state.serverErrors).toHaveLength(1)
       expect(typeof state.serverErrors[0]).toBe('string')
+    })
+
+    // #5711 (Gap 2, client half): set_model is optimistic; a MODEL_NOT_APPLIED
+    // rejection (e.g. a mid-turn no-op the server #5696 now reports) must roll
+    // the dropdown back instead of leaving it on a model the session never
+    // switched to.
+    describe('MODEL_NOT_APPLIED revert (#5711)', () => {
+      afterEach(() => { clearPendingModelReverts() })
+
+      it('reverts the optimistic activeModel for the rejected request\'s session', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            activeModel: 'haiku', // optimistic value already applied by setModel
+            sessionStates: { s1: { ...createEmptySessionState(), activeModel: 'haiku' } },
+          }),
+        )
+        setStore(store)
+        // setModel would have registered this before sending; previousModel is
+        // what the session was on BEFORE the optimistic flip.
+        registerModelChangeRequest('set-model-1', { sessionId: 's1', previousModel: 'sonnet' })
+
+        handleMessage(
+          { type: 'error', requestId: 'set-model-1', code: 'MODEL_NOT_APPLIED', message: 'mid-turn' },
+          ctx() as any,
+        )
+
+        const state = store.getState() as any
+        expect(state.sessionStates.s1.activeModel).toBe('sonnet') // rolled back
+        expect(_testModelRevertPendingSize()).toBe(0) // consumed
+      })
+
+      it('does NOT revert when the error requestId does not match a pending change', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessionStates: { s1: { ...createEmptySessionState(), activeModel: 'haiku' } },
+          }),
+        )
+        setStore(store)
+        registerModelChangeRequest('set-model-1', { sessionId: 's1', previousModel: 'sonnet' })
+
+        handleMessage(
+          { type: 'error', requestId: 'some-other-request', code: 'MODEL_NOT_APPLIED', message: 'x' },
+          ctx() as any,
+        )
+
+        expect((store.getState() as any).sessionStates.s1.activeModel).toBe('haiku') // untouched
+        expect(_testModelRevertPendingSize()).toBe(1) // still pending
+      })
+
+      it('a model_changed success drops the pending revert so a later error can\'t roll it back', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessionStates: { s1: { ...createEmptySessionState(), activeModel: 'haiku' } },
+          }),
+        )
+        setStore(store)
+        registerModelChangeRequest('set-model-1', { sessionId: 's1', previousModel: 'sonnet' })
+
+        handleMessage({ type: 'model_changed', sessionId: 's1', model: 'haiku' }, ctx() as any)
+        expect(_testModelRevertPendingSize()).toBe(0) // cleared on success
+
+        // A stale/duplicate error must now be a no-op (nothing to revert).
+        handleMessage(
+          { type: 'error', requestId: 'set-model-1', code: 'MODEL_NOT_APPLIED', message: 'late' },
+          ctx() as any,
+        )
+        expect((store.getState() as any).sessionStates.s1.activeModel).toBe('haiku')
+      })
     })
 
     // #3570: INVALID_AUTHOR error from skill_trust_grant carries the

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -308,6 +308,54 @@ export function clearPendingTrustGrants(): void {
   _pendingTrustGrants.clear();
 }
 
+// #5711 (Gap 2, client half): set_model is applied OPTIMISTICALLY (the dropdown
+// flips immediately), but the server may reject it (MODEL_NOT_APPLIED — e.g. a
+// mid-turn change is a no-op server-side, fixed in #5696). Without a rollback
+// the dashboard keeps showing a model the session never switched to. Remember
+// the model we switched FROM, keyed by the set_model requestId the server
+// echoes on its error, so the `error` handler can roll the optimistic update
+// back. Cleared on the matching `model_changed` success, on a matching error,
+// or on disconnect. Bounded FIFO like the trust-grant map.
+interface PendingModelRevert {
+  sessionId: string | null;
+  previousModel: string | null;
+}
+
+const _pendingModelReverts = new Map<string, PendingModelRevert>();
+const MODEL_REVERT_PENDING_CAP = 16;
+
+export function registerModelChangeRequest(requestId: string, entry: PendingModelRevert): void {
+  if (_pendingModelReverts.size >= MODEL_REVERT_PENDING_CAP) {
+    const oldestKey = _pendingModelReverts.keys().next().value;
+    if (oldestKey !== undefined) _pendingModelReverts.delete(oldestKey);
+  }
+  _pendingModelReverts.set(requestId, { ...entry });
+}
+
+function consumePendingModelRevert(requestId: string): PendingModelRevert | null {
+  const entry = _pendingModelReverts.get(requestId);
+  if (!entry) return null;
+  _pendingModelReverts.delete(requestId);
+  return entry;
+}
+
+/** A model_changed for `sessionId` landed — drop any pending revert for it. */
+function clearPendingModelRevertForSession(sessionId: string | null): void {
+  for (const [reqId, entry] of _pendingModelReverts) {
+    if (entry.sessionId === sessionId) _pendingModelReverts.delete(reqId);
+  }
+}
+
+/** Clear all pending model reverts — called on WebSocket close. */
+export function clearPendingModelReverts(): void {
+  _pendingModelReverts.clear();
+}
+
+/** @internal test seam. */
+export function _testModelRevertPendingSize(): number {
+  return _pendingModelReverts.size;
+}
+
 /** @internal Exposed for tests so they can inspect the in-flight map. */
 export function _testTrustGrantPendingSize(): number {
   return _pendingTrustGrants.size;
@@ -1179,6 +1227,9 @@ function handleModelChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgS
   } else {
     set({ activeModel: model });
   }
+  // #5711: the change landed for this session — drop any pending revert so a
+  // later unrelated error can't roll back a model that's now correct.
+  clearPendingModelRevertForSession(targetId);
 }
 
 function handleThinkingLevelChanged(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
@@ -4392,6 +4443,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const errReqId = typeof msg.requestId === 'string' ? msg.requestId : null;
       if (errReqId) {
         clearPendingTrustGrantByRequestId(errReqId, get);
+      }
+      // #5711 (Gap 2, client half): roll back the optimistic set_model when the
+      // server says it never applied (MODEL_NOT_APPLIED — e.g. a mid-turn
+      // change). Without this the dropdown keeps showing a model the session
+      // never switched to. Mirror handleModelChanged's session-vs-flat write so
+      // the revert lands exactly where the optimistic update did.
+      if (errCode === 'MODEL_NOT_APPLIED' && errReqId) {
+        const revert = consumePendingModelRevert(errReqId);
+        if (revert) {
+          if (revert.sessionId && get().sessionStates[revert.sessionId]) {
+            updateSession(revert.sessionId, () => ({ activeModel: revert.previousModel }));
+          } else {
+            set({ activeModel: revert.previousModel });
+          }
+        }
       }
       // #3570: skill_trust_grant INVALID_AUTHOR carries a structured
       // `actualAuthor` field (#3568, locked by

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -339,13 +339,6 @@ function consumePendingModelRevert(requestId: string): PendingModelRevert | null
   return entry;
 }
 
-/** A model_changed for `sessionId` landed — drop any pending revert for it. */
-function clearPendingModelRevertForSession(sessionId: string | null): void {
-  for (const [reqId, entry] of _pendingModelReverts) {
-    if (entry.sessionId === sessionId) _pendingModelReverts.delete(reqId);
-  }
-}
-
 /** Clear all pending model reverts — called on WebSocket close. */
 export function clearPendingModelReverts(): void {
   _pendingModelReverts.clear();
@@ -1227,9 +1220,13 @@ function handleModelChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgS
   } else {
     set({ activeModel: model });
   }
-  // #5711: the change landed for this session — drop any pending revert so a
-  // later unrelated error can't roll back a model that's now correct.
-  clearPendingModelRevertForSession(targetId);
+  // #5711: deliberately do NOT clear pending reverts here. The server sends
+  // model_changed XOR error per requestId (never both), so a successful change
+  // never receives a later error to mis-consume. Clearing by sessionId would be
+  // too coarse — with two rapid changes on one session (A→B, B→C), the ack for
+  // the first would drop the SECOND's still-in-flight revert, stranding the
+  // dropdown if the second is then rejected. Stale success entries are bounded
+  // by the FIFO cap and cleared on disconnect.
 }
 
 function handleThinkingLevelChanged(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {


### PR DESCRIPTION
Completes the **client half** of #5696 / durability sweep #5711. Surfaced by the adversarial review of the (now-closed, redundant) #5713.

## Problem
`set_model` is applied **optimistically** on the dashboard (`connection.ts:setModel` flips `activeModel` immediately so the `<select>` doesn't snap back). #5696 made the server stop broadcasting `model_changed` on a mid-turn no-op and send `MODEL_NOT_APPLIED` instead — but the dashboard **never rolled the optimistic value back**. Net: switch model mid-turn on desktop → dropdown shows the new model, engine keeps the old one. The phantom-switch #5696 killed for every other client still happens on the requesting dashboard. (The mobile app is unaffected — it doesn't optimistically update.)

## Fix
- `setModel` tags the request with a `requestId` (rides `set_model`'s `.passthrough()` schema — **no server/protocol change**; the server already echoes `msg.requestId` on the error) and registers the model it switched **from**.
- The `error` handler reverts that session's `activeModel` on a matching `MODEL_NOT_APPLIED`, mirroring `handleModelChanged`'s session-vs-flat write so the rollback lands exactly where the optimistic update did.
- `model_changed` success drops the pending revert (so a later unrelated error can't roll back a now-correct model). All pending reverts cleared on disconnect. Bounded FIFO map, mirroring the existing trust-grant correlation pattern.

## Tests
- Revert on matching requestId; no revert on mismatch; `model_changed` clears pending so a stale error is a no-op.
- Full dashboard suite green (3648); tsc clean.

## Sibling follow-up
`set_permission_mode` has the **same** optimistic-no-rollback gap (no client handling of `PERMISSION_MODE_NOT_APPLIED`) — filed separately to keep this PR focused.