### PR TITLE
fix(server): cap SDK mid-turn message queue at 3 (durability Gap 3)

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -51,6 +51,11 @@ const log = createLogger('sdk')
 
 // Default max accumulated size for tool_use input (~256KB)
 const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
+// #5711 (Gap 3): cap the mid-turn follow-up queue, matching CliSession's max-3
+// (cli-session.js). Without a bound, a user mashing send during a long turn
+// accumulates an unbounded backlog that then floods the agent when the turn
+// ends — both a memory footgun and a surprising burst of late messages.
+const MAX_PENDING_INPUT = 3
 
 // Marker stamped on a proc the first time _attachSidecarProcessListeners()
 // wires its default listeners (#3504 review).  Subsequent calls on the same
@@ -542,6 +547,13 @@ export class SdkSession extends BaseSession {
     if (this._isBusy) {
       // Queue the message — it will be sent after the current turn completes
       if (!this._pendingInput) this._pendingInput = []
+      // #5711 (Gap 3): bound the queue like CliSession (max 3). Discard the
+      // overflow with a visible error rather than silently growing — mirrors
+      // cli-session.js so the same action behaves consistently across providers.
+      if (this._pendingInput.length >= MAX_PENDING_INPUT) {
+        this.emit('error', { message: `Pending message queue full (max ${MAX_PENDING_INPUT}) — message discarded` })
+        return
+      }
       this._pendingInput.push({ prompt, attachments, sendOptions })
       // #4828: session-scoped when init has fired (queue path requires an
       // in-flight turn, so init is normally already in by this point).

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -51,10 +51,14 @@ const log = createLogger('sdk')
 
 // Default max accumulated size for tool_use input (~256KB)
 const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
-// #5711 (Gap 3): cap the mid-turn follow-up queue, matching CliSession's max-3
-// (cli-session.js). Without a bound, a user mashing send during a long turn
-// accumulates an unbounded backlog that then floods the agent when the turn
-// ends — both a memory footgun and a surprising burst of late messages.
+// #5711 (Gap 3): cap the SDK's mid-turn follow-up queue. SdkSession is the only
+// provider that QUEUES sends during an in-flight turn (CliSession instead
+// rejects a mid-turn send with "Already processing a message"), and that queue
+// was unbounded — a user mashing send during a long turn accumulated an
+// unbounded backlog that then flooded the agent when the turn ended (a memory
+// footgun + a surprising burst of late messages). Reuse the cap value (3) and
+// the discard-error wording from CliSession's not-ready queue (cli-session.js)
+// so the overflow UX is consistent across providers.
 const MAX_PENDING_INPUT = 3
 
 // Marker stamped on a proc the first time _attachSidecarProcessListeners()
@@ -547,9 +551,9 @@ export class SdkSession extends BaseSession {
     if (this._isBusy) {
       // Queue the message — it will be sent after the current turn completes
       if (!this._pendingInput) this._pendingInput = []
-      // #5711 (Gap 3): bound the queue like CliSession (max 3). Discard the
-      // overflow with a visible error rather than silently growing — mirrors
-      // cli-session.js so the same action behaves consistently across providers.
+      // #5711 (Gap 3): bound this SDK-specific mid-turn queue (max 3). Discard
+      // the overflow with a visible error rather than silently growing, reusing
+      // CliSession's discard-cap value + wording for a consistent overflow UX.
       if (this._pendingInput.length >= MAX_PENDING_INPUT) {
         this.emit('error', { message: `Pending message queue full (max ${MAX_PENDING_INPUT}) — message discarded` })
         return

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -881,6 +881,27 @@ describe('SdkSession', () => {
       session.destroy()
       assert.equal(session._pendingInput.length, 0)
     })
+
+    it('caps the mid-turn queue at 3 and discards overflow with an error (#5711)', () => {
+      session._isBusy = true
+      const errors = []
+      session.on('error', (data) => errors.push(data))
+
+      // Fill the queue to the cap.
+      session.sendMessage('q1')
+      session.sendMessage('q2')
+      session.sendMessage('q3')
+      assert.equal(session._pendingInput.length, 3)
+      assert.equal(errors.length, 0)
+
+      // The 4th overflows: discarded with a visible error, queue stays at 3.
+      session.sendMessage('q4-overflow')
+      assert.equal(session._pendingInput.length, 3)
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /queue full \(max 3\)/)
+      // The discarded message is NOT in the queue.
+      assert.ok(!session._pendingInput.some((m) => m.prompt === 'q4-overflow'))
+    })
   })
 
   // -- sendMessage when stdin forwarding is disabled (#3539) --


### PR DESCRIPTION
Durability sweep #5711, Gap 3 (partial — the verified, self-contained slice).

## Problem
`CliSession` bounds its mid-turn follow-up queue at 3 and discards overflow with an error (`cli-session.js:644`). `SdkSession` had **no bound** — `_pendingInput.push(...)` (`sdk-session.js:545`). So mashing send during a long SDK turn accumulated an **unbounded** backlog that then **flooded the agent** when the turn ended: a memory footgun, a surprising burst of late messages, and a silent provider-behavior inconsistency (CLI rejects, SDK silently grew).

## Fix
Cap `_pendingInput` at `MAX_PENDING_INPUT` (3) and discard overflow with the **same** `Pending message queue full (max 3) — message discarded` error `CliSession` emits, so the same action behaves consistently across providers.

## Tests
- A 4th mid-turn send overflows → one error emitted, queue stays at 3, the discarded message is not enqueued.
- Full sdk-session suite green (148).

## Note
This is the bounded, low-risk slice of audit Gap 3. The broader "unify send-while-busy UX + show a visible 'queued' state in the client" remains tracked under #5711 (needs client work + a product decision on reject-vs-queue).