### PR TITLE
fix(server): worktree GC age fallback for recycled PIDs (#5706)

### DIFF
--- a/packages/server/src/cli/worktree-gc-cmd.js
+++ b/packages/server/src/cli/worktree-gc-cmd.js
@@ -62,8 +62,9 @@ export function collectWorktreeGc(options = {}, deps = {}) {
   // age-fallback setting as the auto-reaper (otherwise an operator who set
   // maxLockAgeMs would find the CLI ignored it). Soft-read → {} when absent.
   const cfg = readConfigSoft(configPath, deps)
+  const cliMaxAge = cfg.worktreeGc?.maxLockAgeMs
   const planDeps = {
-    ...(typeof cfg.worktreeGc?.maxLockAgeMs === 'number' ? { maxLockAgeMs: cfg.worktreeGc.maxLockAgeMs } : {}),
+    ...(Number.isFinite(cliMaxAge) && cliMaxAge >= 0 ? { maxLockAgeMs: cliMaxAge } : {}),
     ...(deps.planDeps || {}),
   }
 

--- a/packages/server/src/cli/worktree-gc-cmd.js
+++ b/packages/server/src/cli/worktree-gc-cmd.js
@@ -58,12 +58,20 @@ export function collectWorktreeGc(options = {}, deps = {}) {
     withSizes = true,
   } = deps
 
+  // #5706: read config up front so manual `chroxy worktree gc` honors the same
+  // age-fallback setting as the auto-reaper (otherwise an operator who set
+  // maxLockAgeMs would find the CLI ignored it). Soft-read → {} when absent.
+  const cfg = readConfigSoft(configPath, deps)
+  const planDeps = {
+    ...(typeof cfg.worktreeGc?.maxLockAgeMs === 'number' ? { maxLockAgeMs: cfg.worktreeGc.maxLockAgeMs } : {}),
+    ...(deps.planDeps || {}),
+  }
+
   let repos
   if (options.repo) {
     const p = resolve(options.repo)
     repos = [{ name: basename(p), path: p }]
   } else {
-    const cfg = readConfigSoft(configPath, deps)
     repos = resolveRepoSet({
       repos: cfg.repos,
       root: cfg.controlRoomRoot,
@@ -77,7 +85,7 @@ export function collectWorktreeGc(options = {}, deps = {}) {
   let skippedCount = 0
 
   for (const r of repos) {
-    const p = plan(r.path, deps.planDeps || {})
+    const p = plan(r.path, planDeps)
     const reclaimable = p.items.filter((it) => it.action === 'remove' || it.action === 'prune')
     const skipped = p.items.filter((it) => it.action === 'skip')
     if (withSizes) {

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -838,8 +838,10 @@ export function validateConfig(config, verbose = false) {
         }
       }
       // #5706: absolute-age fallback for the PID-liveness check. A non-negative
-      // number of ms; 0 disables the fallback (pure PID liveness). Negative /
-      // non-finite values are rejected so a typo can't silently disable it.
+      // number of ms; 0 (the default) disables the fallback (pure PID liveness).
+      // Negative / non-finite values WARN; they're not hard-rejected, but they
+      // fail safe — planRepoGc treats any non-positive/NaN value as disabled, so
+      // a typo can only ever turn the fallback OFF, never silently widen it.
       if (Object.prototype.hasOwnProperty.call(config.worktreeGc, 'maxLockAgeMs')) {
         const v = config.worktreeGc.maxLockAgeMs
         if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -837,6 +837,15 @@ export function validateConfig(config, verbose = false) {
           warnings.push(`Invalid value for 'worktreeGc.reapIntervalMs': expected a positive number, got ${typeof v === 'number' ? v : typeof v}`)
         }
       }
+      // #5706: absolute-age fallback for the PID-liveness check. A non-negative
+      // number of ms; 0 disables the fallback (pure PID liveness). Negative /
+      // non-finite values are rejected so a typo can't silently disable it.
+      if (Object.prototype.hasOwnProperty.call(config.worktreeGc, 'maxLockAgeMs')) {
+        const v = config.worktreeGc.maxLockAgeMs
+        if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+          warnings.push(`Invalid value for 'worktreeGc.maxLockAgeMs': expected a non-negative number (0 disables), got ${typeof v === 'number' ? v : typeof v}`)
+        }
+      }
     }
   }
 

--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -25,9 +25,23 @@
 // is fully testable against real temp repos without poking the real home dir.
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { isAbsolute, resolve as resolvePath } from 'node:path'
 import { GIT } from './git.js'
+
+// #5706: absolute-age fallback for the PID-liveness check. A dead agent's pid
+// can be RECYCLED by an unrelated process after uptime/PID reuse — then
+// `isPidAlive` reports "live", GC skips the orphaned worktree forever, and the
+// disk slowly fills. A genuinely-active worktree is touched continuously (a live
+// agent edits files), so when a lock's pid LOOKS alive but the worktree mtime is
+// older than this, the pid is almost certainly recycled and the worktree is
+// reclaimable (still subject to the clean-tree guard — no uncommitted/ignored
+// content is ever deleted). 30 days is far beyond any real agent-session
+// lifetime. Set `config.worktreeGc.maxLockAgeMs` to 0 to disable the fallback
+// (revert to pure PID-liveness). Caveat: directory mtime tracks entry add/remove
+// more reliably than in-place content edits, which is why the threshold is
+// generous and the clean-tree guard remains the hard safety net.
+const DEFAULT_MAX_LOCK_AGE_MS = 30 * 24 * 60 * 60 * 1000
 
 /**
  * Existence check for a pid without sending a real signal.
@@ -141,6 +155,11 @@ export function planRepoGc(repoPath, deps = {}) {
     kill = process.kill,
     exists = existsSync,
     readLockReason = (wtPath) => readLockReasonFromAdmin(wtPath),
+    // #5706: age-fallback seams. `now`/`mtimeMs` are injectable for tests.
+    // `maxLockAgeMs` defaults to 30d; 0 (or negative) disables the fallback.
+    now = () => Date.now(),
+    mtimeMs = (p) => { try { return statSync(p).mtimeMs } catch { return null } },
+    maxLockAgeMs = DEFAULT_MAX_LOCK_AGE_MS,
   } = deps
 
   let porcelain
@@ -164,13 +183,25 @@ export function planRepoGc(repoPath, deps = {}) {
         items.push({ path: e.path, action: 'skip', skipReason: 'locked with no pid in reason (not an abandoned agent worktree)', lockReason: reason })
         return
       }
+      // pid liveness, with the #5706 absolute-age fallback: a "live" pid whose
+      // worktree has been untouched longer than maxLockAgeMs is treated as a
+      // recycled pid (the original agent is long gone) so the orphan can be
+      // reclaimed instead of leaking forever.
+      let pidNote = 'lock held by dead pid'
       if (isPidAlive(pid, kill)) {
-        items.push({ path: e.path, action: 'skip', skipReason: `locked by a live process (pid ${pid})`, pid, lockReason: reason })
-        return
+        const m = maxLockAgeMs > 0 ? mtimeMs(e.path) : null
+        const ageMs = m != null ? now() - m : null
+        if (ageMs == null || ageMs <= maxLockAgeMs) {
+          items.push({ path: e.path, action: 'skip', skipReason: `locked by a live process (pid ${pid})`, pid, lockReason: reason })
+          return
+        }
+        // pid looks alive but the tree is stale → recycled pid; reclaim.
+        const ageDays = Math.round(ageMs / 86_400_000)
+        pidNote = `pid ${pid} appears live but worktree untouched ${ageDays}d — treating as a recycled pid (#5706)`
       }
-      // pid is dead — reclaimable, subject to the clean-tree guard.
+      // reclaimable (dead pid, or recycled-pid stale), subject to the clean-tree guard.
       if (dirGone) {
-        items.push({ path: e.path, action: 'prune', pid, lockReason: reason, reason: 'directory gone; lock held by dead pid', locked: true })
+        items.push({ path: e.path, action: 'prune', pid, lockReason: reason, reason: `directory gone; ${pidNote}`, locked: true })
         return
       }
       const clean = isClean(git, e.path)
@@ -182,7 +213,7 @@ export function planRepoGc(repoPath, deps = {}) {
         items.push({ path: e.path, action: 'skip', skipReason: 'has uncommitted/untracked/gitignored content (preserved)', pid, lockReason: reason })
         return
       }
-      items.push({ path: e.path, action: 'remove', pid, lockReason: reason, reason: 'clean worktree locked by dead pid', locked: true })
+      items.push({ path: e.path, action: 'remove', pid, lockReason: reason, reason: `clean worktree; ${pidNote}`, locked: true })
       return
     }
 

--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -32,16 +32,21 @@ import { GIT } from './git.js'
 // #5706: absolute-age fallback for the PID-liveness check. A dead agent's pid
 // can be RECYCLED by an unrelated process after uptime/PID reuse — then
 // `isPidAlive` reports "live", GC skips the orphaned worktree forever, and the
-// disk slowly fills. A genuinely-active worktree is touched continuously (a live
-// agent edits files), so when a lock's pid LOOKS alive but the worktree mtime is
-// older than this, the pid is almost certainly recycled and the worktree is
-// reclaimable (still subject to the clean-tree guard — no uncommitted/ignored
-// content is ever deleted). 30 days is far beyond any real agent-session
-// lifetime. Set `config.worktreeGc.maxLockAgeMs` to 0 to disable the fallback
-// (revert to pure PID-liveness). Caveat: directory mtime tracks entry add/remove
-// more reliably than in-place content edits, which is why the threshold is
-// generous and the clean-tree guard remains the hard safety net.
-const DEFAULT_MAX_LOCK_AGE_MS = 30 * 24 * 60 * 60 * 1000
+// disk slowly fills. The fallback reclaims a lock whose pid LOOKS alive but
+// whose worktree mtime is older than `maxLockAgeMs` (treating the pid as
+// recycled) — still subject to the clean-tree guard, so no uncommitted/ignored
+// content is ever deleted.
+//
+// DEFAULT IS 0 (DISABLED): opt-in via `config.worktreeGc.maxLockAgeMs`. It's
+// off by default because the age signal is imperfect — directory mtime bumps
+// only on TOP-LEVEL entry add/remove (and top-level git ops), NOT on in-place or
+// nested-subdir edits. So a genuinely-live, clean, long-running agent that only
+// touches existing/nested files could read "stale" and have its working dir
+// reclaimed out from under it (no committed-work loss thanks to the clean-tree
+// guard, but a disruptive mid-run rug-pull). Operators who hit the recycled-pid
+// disk leak set a generous threshold (e.g. 14–30 days, well beyond any real
+// agent-session lifetime); the clean-tree guard remains the hard safety net.
+const DEFAULT_MAX_LOCK_AGE_MS = 0
 
 /**
  * Existence check for a pid without sending a real signal.

--- a/packages/server/src/worktree-reaper.js
+++ b/packages/server/src/worktree-reaper.js
@@ -90,8 +90,9 @@ export async function maybeAutoReapWorktrees(config, log, deps = {}) {
 
   // #5706: pass the configured absolute-age fallback through to the GC core.
   // A test's `deps.planDeps` still wins (spread last) so seams override config.
+  const cfgMaxAge = config.worktreeGc.maxLockAgeMs
   const planDeps = {
-    ...(typeof config.worktreeGc.maxLockAgeMs === 'number' ? { maxLockAgeMs: config.worktreeGc.maxLockAgeMs } : {}),
+    ...(Number.isFinite(cfgMaxAge) && cfgMaxAge >= 0 ? { maxLockAgeMs: cfgMaxAge } : {}),
     ...(deps.planDeps || {}),
   }
   const summary = await reapWorktrees({ repos, planDeps, yieldFn: deps.yieldFn })

--- a/packages/server/src/worktree-reaper.js
+++ b/packages/server/src/worktree-reaper.js
@@ -88,7 +88,13 @@ export async function maybeAutoReapWorktrees(config, log, deps = {}) {
     return null
   }
 
-  const summary = await reapWorktrees({ repos, planDeps: deps.planDeps || {}, yieldFn: deps.yieldFn })
+  // #5706: pass the configured absolute-age fallback through to the GC core.
+  // A test's `deps.planDeps` still wins (spread last) so seams override config.
+  const planDeps = {
+    ...(typeof config.worktreeGc.maxLockAgeMs === 'number' ? { maxLockAgeMs: config.worktreeGc.maxLockAgeMs } : {}),
+    ...(deps.planDeps || {}),
+  }
+  const summary = await reapWorktrees({ repos, planDeps, yieldFn: deps.yieldFn })
 
   const base = `worktree auto-reap: reclaimed ${summary.reclaimed} worktree(s) across ${summary.repos} repo(s); ${summary.skipped} preserved (live/dirty/unknown)`
   // Warn whenever anything went wrong — both per-item failures (counted in

--- a/packages/server/tests/config-worktree-gc.test.js
+++ b/packages/server/tests/config-worktree-gc.test.js
@@ -38,6 +38,22 @@ describe('config.worktreeGc (#5158)', () => {
     )
   })
 
+  // #5706 — maxLockAgeMs absolute-age fallback: non-negative number, 0 disables.
+  it('accepts a non-negative maxLockAgeMs (incl. 0 to disable)', () => {
+    assert.equal(validateConfig({ worktreeGc: { maxLockAgeMs: 1209600000 } }).warnings.length, 0)
+    assert.equal(validateConfig({ worktreeGc: { maxLockAgeMs: 0 } }).warnings.length, 0)
+  })
+
+  it('warns when maxLockAgeMs is negative or non-numeric', () => {
+    for (const bad of [-1, 'soon', NaN]) {
+      const result = validateConfig({ worktreeGc: { maxLockAgeMs: bad } })
+      assert.ok(
+        result.warnings.some((w) => w.includes('worktreeGc.maxLockAgeMs')),
+        `expected a warning for maxLockAgeMs=${String(bad)}, got: ${JSON.stringify(result.warnings)}`,
+      )
+    }
+  })
+
   it('does not flag worktreeGc as an unknown key', () => {
     const result = validateConfig({ worktreeGc: { autoReap: false } })
     const unknown = result.warnings.find((w) => w.includes('Unknown config key') && w.includes('worktreeGc'))

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -515,4 +515,19 @@ describe('worktree-gc CLI (config controlRoomRoot auto-discovery, #5221)', () =>
     assert.equal(report.reclaimableCount, 1) // clean-dead
     assert.equal(report.skippedCount, 0) // only a clean-dead worktree in this fixture
   })
+
+  it('#5706: threads config.worktreeGc.maxLockAgeMs into the plan deps (manual gc honors it)', async () => {
+    const { collectWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
+    const configPath = join(root, 'config.json')
+    writeFileSync(configPath, JSON.stringify({ controlRoomRoot: root, worktreeGc: { maxLockAgeMs: 5000 } }))
+
+    let captured = null
+    const planSpy = (_p, deps) => { captured = deps; return { items: [] } }
+    collectWorktreeGc({}, { configPath, withSizes: false, plan: planSpy, planDeps: {} })
+    assert.equal(captured.maxLockAgeMs, 5000)
+
+    // Test seam (deps.planDeps) overrides config.
+    collectWorktreeGc({}, { configPath, withSizes: false, plan: planSpy, planDeps: { maxLockAgeMs: 12345 } })
+    assert.equal(captured.maxLockAgeMs, 12345)
+  })
 })

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -255,6 +255,44 @@ describe('worktree-gc integration (real git repo)', () => {
     assert.equal(existsSync(join(ignoredDead, '.env.local')), true)
   })
 
+  // #5706: absolute-age fallback — a "live" pid whose worktree has been
+  // untouched longer than maxLockAgeMs is treated as a recycled pid.
+  describe('#5706 recycled-pid age fallback', () => {
+    // Deterministic age: now - mtimeMs(path). With now=1e6 and mtimeMs=0 the age
+    // is 1e6ms; maxLockAgeMs=1000 makes any such worktree "stale".
+    const STALE = { kill: fakeKill, now: () => 1_000_000, mtimeMs: () => 0, maxLockAgeMs: 1000 }
+
+    it('reclaims a CLEAN worktree whose live pid is stale (recycled)', () => {
+      addWorktree('live-stale', { lockReason: `claude agent a1 (pid ${LIVE_PID})` })
+      const item = planRepoGc(repo, STALE).items.find((i) => i.path.endsWith('/live-stale'))
+      assert.equal(item.action, 'remove')
+      assert.match(item.reason, /recycled pid/)
+    })
+
+    it('still SKIPS a live pid whose worktree is recently touched (age within threshold)', () => {
+      addWorktree('live-fresh', { lockReason: `claude agent a2 (pid ${LIVE_PID})` })
+      const item = planRepoGc(repo, { kill: fakeKill, now: () => 1_000_000, mtimeMs: () => 999_500, maxLockAgeMs: 1000 })
+        .items.find((i) => i.path.endsWith('/live-fresh'))
+      assert.equal(item.action, 'skip')
+      assert.match(item.skipReason, /live process/)
+    })
+
+    it('NEVER reclaims a DIRTY worktree even when the live pid is stale (clean-tree guard wins)', () => {
+      addWorktree('live-stale-dirty', { lockReason: `claude agent a3 (pid ${LIVE_PID})`, dirty: true })
+      const item = planRepoGc(repo, STALE).items.find((i) => i.path.endsWith('/live-stale-dirty'))
+      assert.equal(item.action, 'skip')
+      assert.match(item.skipReason, /uncommitted/)
+    })
+
+    it('maxLockAgeMs=0 disables the fallback — a stale live pid is still skipped', () => {
+      addWorktree('live-stale-disabled', { lockReason: `claude agent a4 (pid ${LIVE_PID})` })
+      const item = planRepoGc(repo, { kill: fakeKill, now: () => 1_000_000, mtimeMs: () => 0, maxLockAgeMs: 0 })
+        .items.find((i) => i.path.endsWith('/live-stale-disabled'))
+      assert.equal(item.action, 'skip')
+      assert.match(item.skipReason, /live process/)
+    })
+  })
+
   it('readLockReasonFromAdmin recovers the reason when porcelain omits it', () => {
     const wt = addWorktree('clean-dead', { lockReason: `claude agent a1 (pid ${DEAD_PID})` })
     const reason = readLockReasonFromAdmin(wt)


### PR DESCRIPTION
Durability sweep #5711 (Gap 8c, split to #5706). **Closes #5706.**

## Problem
`planRepoGc` (`worktree-gc.js:167`) skips any locked worktree whose lock-reason PID `isPidAlive`. After uptime / PID recycling, an unrelated process can inherit a dead agent's PID → GC reports "live" → the orphaned worktree is **never reclaimed** → slow disk fill (the `chroxy worktree gc` triage path).

## Fix
An **absolute-age fallback**: a genuinely-active worktree is touched continuously (a live agent edits files), so when a lock's PID *looks* alive but the worktree mtime is older than `maxLockAgeMs`, the PID is almost certainly **recycled** and the orphan becomes reclaimable.

- Default **30 days** — far beyond any real agent-session lifetime; `config.worktreeGc.maxLockAgeMs` overrides (set **0 to disable** → pure PID liveness).
- **The existing clean-tree guard is untouched and still the hard safety net** — any worktree with uncommitted / untracked / **gitignored** (#5244) content is preserved regardless of age. So a wrong age-reclaim can only ever remove a *clean* checkout (all work committed) — no data loss.
- Caveat documented: directory mtime tracks entry add/remove more reliably than in-place content edits, which is exactly why the threshold is generous and the clean-tree guard remains authoritative.

## Tests
- live+stale+clean → `remove` (reason notes recycled pid); live+fresh → `skip` (live process); live+stale+**dirty** → `skip` (clean guard wins); `maxLockAgeMs=0` → `skip` (fallback disabled). Plus config validation (non-negative; 0 disables).
- Green: worktree-gc + reaper + config suites (50); server lints pass. Existing behavior unchanged for dead-PID and fresh live-PID cases.