### PR TITLE
fix(server): guard unguarded error/push sends (#5702 8a + 8d)

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -563,14 +563,14 @@ export function sendError(ws, requestId, code, message, data, ctx) {
     try {
       ctx.transport.send(ws, payload)
     } catch (err) {
-      log.warn(`sendError: transport send failed for ${payload.code || 'error'}: ${err?.message || err}`)
+      log.warn(`sendError: transport send failed for ${payload.code || 'error'}: ${String(err?.message || err)}`)
     }
     return
   }
   try {
     ws.send(JSON.stringify(payload))
   } catch (err) {
-    log.warn(`sendError: raw send failed for ${payload.code || 'error'}: ${err?.message || err}`)
+    log.warn(`sendError: raw send failed for ${payload.code || 'error'}: ${String(err?.message || err)}`)
   }
 }
 

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -8,6 +8,9 @@
 import { statSync, realpathSync, readFileSync } from 'fs'
 import { homedir } from 'os'
 import { resolve, relative, sep } from 'path'
+import { createLogger } from './logger.js'
+
+const log = createLogger('handler-utils')
 
 // -- Permission modes --
 // `description` is a short, plain-English sentence the dashboard
@@ -551,11 +554,24 @@ export function sendError(ws, requestId, code, message, data, ctx) {
   }
   // #5632: prefer the encryption-aware transport so post-handshake errors are
   // encrypted; fall back to raw send for pre-auth call sites without a ctx.
+  // #5702 (8a): guard both sends. A throw here (e.g. a torn-down socket) would
+  // otherwise escape an error-reporting path — which often runs from a catch
+  // block — and could mask the original failure or take down the caller. The
+  // error frame failing to reach a half-open client is itself non-fatal, so we
+  // log and move on rather than rethrow.
   if (ctx && typeof ctx.transport?.send === 'function') {
-    ctx.transport.send(ws, payload)
+    try {
+      ctx.transport.send(ws, payload)
+    } catch (err) {
+      log.warn(`sendError: transport send failed for ${payload.code || 'error'}: ${err?.message || err}`)
+    }
     return
   }
-  ws.send(JSON.stringify(payload))
+  try {
+    ws.send(JSON.stringify(payload))
+  } catch (err) {
+    log.warn(`sendError: raw send failed for ${payload.code || 'error'}: ${err?.message || err}`)
+  }
 }
 
 // Issue #2912: every handler that rejects with SESSION_TOKEN_MISMATCH used to

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -52,7 +52,7 @@ export function settlePush(promise, label, logger = log) {
   // call sites simply ignore the return.
   return Promise.resolve(promise)
     .then((ok) => { if (ok === false) logger.warn(`push notification not delivered (${label})`) })
-    .catch((err) => { logger.warn(`push notification error (${label}): ${err?.message || err}`) })
+    .catch((err) => { logger.warn(`push notification error (${label}): ${String(err?.message || err)}`) })
 }
 
 // Rate limits per category (ms) — prevents notification spam.

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -40,6 +40,21 @@ import { DiscordWebhookSink } from './notifications/discord-webhook-sink.js'
 
 const log = createLogger('push')
 
+// #5702 (8d): settle a fire-and-forget pushManager.send() so neither a failed
+// delivery (resolves `false`) nor a dispatch error (rejects) is silently
+// dropped. A bare `pushManager.send(...)` leaves the rejection unhandled (it's
+// an async method) AND hides a half-open-link delivery failure while the
+// dashboard card still appears — the exact silent asymmetry #5702 calls out.
+// `label` names the call site so the log is greppable. `logger` defaults to the
+// push logger but call sites pass their own so the line is attributed correctly.
+export function settlePush(promise, label, logger = log) {
+  // Returns the settled chain so callers/tests CAN await it; the fire-and-forget
+  // call sites simply ignore the return.
+  return Promise.resolve(promise)
+    .then((ok) => { if (ok === false) logger.warn(`push notification not delivered (${label})`) })
+    .catch((err) => { logger.warn(`push notification error (${label}): ${err?.message || err}`) })
+}
+
 // Rate limits per category (ms) — prevents notification spam.
 //
 // History:

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -1,5 +1,6 @@
 import { createLogger } from './logger.js'
 import { getDefaultModelId, getRegistryForProvider } from './models.js'
+import { settlePush } from './push.js'
 
 const log = createLogger('ws-forwarding')
 
@@ -333,7 +334,13 @@ function executeSideEffects(sideEffects, sessionId, ctx) {
         break
       case 'push':
         if (pushManager) {
-          pushManager.send(effect.category, effect.title, effect.body, effect.data, effect.channelId)
+          // #5702 (8d): settle the fire-and-forget send so a failed delivery /
+          // dispatch error is logged (named), not silently dropped.
+          settlePush(
+            pushManager.send(effect.category, effect.title, effect.body, effect.data, effect.channelId),
+            `effect: ${effect.category}`,
+            log,
+          )
         }
         break
       case 'flush_deltas': {

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { createLogger } from './logger.js'
 import { RateLimiter, getRateLimitKey } from './rate-limiter.js'
 import { buildSessionTokenMismatchPayload } from './handler-utils.js'
+import { settlePush } from './push.js'
 import { createPermissionResolver } from './permission-resolver.js'
 import { sendOversizeResponse } from './http-oversize.js'
 
@@ -242,7 +243,14 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       })
 
       if (pushManager) {
-        pushManager.send('permission', 'Permission needed', `Claude wants to use: ${tool}`, { requestId, tool }, 'permission')
+        // #5702 (8d): settle the fire-and-forget send so a failed phone
+        // notification is logged (named), not silently dropped while the
+        // dashboard card still appears.
+        settlePush(
+          pushManager.send('permission', 'Permission needed', `Claude wants to use: ${tool}`, { requestId, tool }, 'permission'),
+          `permission requested: ${tool}`,
+          log,
+        )
       }
 
       let closed = false

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -1514,3 +1514,25 @@ describe('requireSessionMethod (#4773)', () => {
     assert.strictEqual(sent.length, 1)
   })
 })
+
+describe('sendError fail-safe send guard (#5702 8a)', () => {
+  it('does not throw when ctx.transport.send throws (torn-down socket)', () => {
+    const ws = { readyState: 1 }
+    const ctx = { transport: { send: () => { throw new Error('socket gone') } } }
+    // A throw here would escape an error-reporting path (often a catch block).
+    assert.doesNotThrow(() => sendError(ws, 'r1', 'BOOM', 'msg', undefined, ctx))
+  })
+
+  it('does not throw when the raw ws.send throws (no ctx / pre-auth)', () => {
+    const ws = { readyState: 1, send: () => { throw new Error('socket gone') } }
+    assert.doesNotThrow(() => sendError(ws, 'r2', 'BOOM', 'msg'))
+  })
+
+  it('still sends normally on the happy path', () => {
+    const sent = []
+    const ws = { readyState: 1, send: (raw) => sent.push(JSON.parse(raw)) }
+    sendError(ws, 'r3', 'CODE', 'message')
+    assert.strictEqual(sent.length, 1)
+    assert.strictEqual(sent[0].code, 'CODE')
+  })
+})

--- a/packages/server/tests/push.test.js
+++ b/packages/server/tests/push.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { PushManager } from '../src/push.js'
+import { PushManager, settlePush } from '../src/push.js'
 
 /**
  * PushManager unit tests (#1719)
@@ -450,5 +450,27 @@ describe('PushManager.setPrefs rollback on persist failure (#4550)', () => {
       true,
       'getPrefs snapshot must reflect the rolled-back in-memory state',
     )
+  })
+})
+
+describe('settlePush fire-and-forget guard (#5702 8d)', () => {
+  it('logs (named) and does not reject when the send rejects', async () => {
+    const warns = []
+    await settlePush(Promise.reject(new Error('boom')), 'test-label', { warn: (m) => warns.push(m) })
+    assert.equal(warns.length, 1)
+    assert.match(warns[0], /push notification error \(test-label\): boom/)
+  })
+
+  it('logs when delivery resolves false', async () => {
+    const warns = []
+    await settlePush(Promise.resolve(false), 'lbl', { warn: (m) => warns.push(m) })
+    assert.equal(warns.length, 1)
+    assert.match(warns[0], /not delivered \(lbl\)/)
+  })
+
+  it('stays quiet on a successful (true) delivery', async () => {
+    const warns = []
+    await settlePush(Promise.resolve(true), 'lbl', { warn: (m) => warns.push(m) })
+    assert.equal(warns.length, 0)
   })
 })


### PR DESCRIPTION
Durability sweep #5711 — the remaining fail-safe items from grab-bag #5702 (8c shipped as #5706). **Closes #5702.**

## 8a — `sendError` sends were unguarded
`handler-utils.js` `sendError` did `ctx.transport.send(ws, payload)` / `ws.send(...)` with no try/catch. `sendError` is frequently called **from a catch block**, so a throw on a torn-down socket could escape the error-reporting path and mask the original failure (the #5313 "contain throws" theme). → wrap both in try/catch with a named warn. A dropped error frame to a half-open client is non-fatal, so log and move on.

## 8d — fire-and-forget `pushManager.send()` was unguarded
`ws-permissions.js:245` and `ws-forwarding.js:336` called the **async** `pushManager.send()` with no `.catch` — a rejection went **unhandled**, and a half-open delivery failure was **silent** while the dashboard card still appeared (the exact asymmetry #5702 flags). → added `settlePush(promise, label, logger)` (push.js) that logs both a `false` (not delivered) and a rejection (dispatch error) with a named, greppable label; applied at both sites. `event-ingest.js` already settles its send — left unchanged.

## Tests
- `sendError` does not throw when transport/raw send throws (readyState-gated so the try/catch is actually exercised) + happy-path still sends.
- `settlePush` logs on reject and on `false`, stays quiet on success.
- Green: handler-utils, push, ws-permissions, ws-forwarding, event-ingest suites (325+); server lints pass. Acyclic import (push.js is a leaf — verified).