### PR TITLE
fix(server): abort handshake when key_exchange_ok send fails (#5702 8b)

### DIFF
--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -584,7 +584,18 @@ export function handleKeyExchange(ctx, ws, msg) {
         ...(serverKeySig ? { serverKeySig } : {}),
       }))
     } catch (err) {
-      log.error(`Failed to send key_exchange_ok: ${err.message}`)
+      // #5702 (8b): the client never received the exchange key, so we must NOT
+      // mark E2E established or flush the post-auth queue. `encryptionState` was
+      // already set above, so proceeding would encrypt frames the client can't
+      // decrypt — a wedged session (the client waits forever for key_exchange_ok
+      // while the server speaks ciphertext it can't read). Roll the crypto state
+      // back and close so the client reconnects and retries the handshake.
+      log.error(`Failed to send key_exchange_ok to ${client.id}: ${String(err?.message || err)} — aborting handshake`)
+      client.encryptionState = null
+      client.encryptionPending = false
+      client.postAuthQueue = null
+      try { ws.close(1011, 'Key exchange failed') } catch { /* socket already gone */ }
+      return true
     }
     log.info(`E2E encryption established with ${client.id}`)
     const queue = client.postAuthQueue

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -1556,6 +1556,33 @@ describe('handleKeyExchange', () => {
       assert.equal(ws.closed, false)
     })
 
+    it('aborts the handshake (rolls back crypto state, closes) when key_exchange_ok send fails (#5702 8b)', () => {
+      const clientKp = nacl.box.keyPair()
+      const clientPubB64 = naclUtil.encodeBase64(clientKp.publicKey)
+      const salt = generateConnectionSalt()
+
+      const ws = makeMockWs()
+      const { ctx, client, flushPostAuthQueue } = makeKeyExchangeCtx({ ws })
+      client.postAuthQueue = [{ type: 'session_list' }]
+      // The key_exchange_ok send fails (half-open / torn-down socket). It's the
+      // only ws.send on the valid path, so this isolates the failure to it.
+      ws.send = () => { throw new Error('socket gone') }
+
+      const result = handleKeyExchange(ctx, ws, { type: 'key_exchange', publicKey: clientPubB64, salt })
+      assert.equal(result, true)
+
+      // Crypto state rolled back — the server must NOT believe E2E is established
+      // (else it would encrypt frames the client never got the key for).
+      assert.equal(client.encryptionState, null)
+      assert.equal(client.encryptionPending, false)
+      // The post-auth queue must NOT be flushed.
+      assert.equal(flushPostAuthQueue.callCount, 0)
+      assert.equal(client.postAuthQueue, null)
+      // Connection closed so the client reconnects and retries the handshake.
+      assert.equal(ws.closed, true)
+      assert.equal(ws.closeCode, 1011)
+    })
+
     it('derives per-connection sub-key when client sends salt', () => {
       const clientKp = nacl.box.keyPair()
       const clientPubB64 = naclUtil.encodeBase64(clientKp.publicKey)


### PR DESCRIPTION
Durability sweep #5711 — the last fail-safe item from grab-bag #5702 (8a/8d shipped in #5719, 8c in #5706).

## Problem
`handleKeyExchange` (`ws-auth.js`) derives the shared key and sets `client.encryptionState` **before** sending `key_exchange_ok`. On a send failure it merely logged the error and **fell through** to `E2E encryption established` + `flushPostAuthQueue`. But the client never received the key — so the server then encrypts every subsequent frame with a key the client can't decrypt: a **wedged session** (the client waits forever for `key_exchange_ok` while the server speaks unreadable ciphertext).

## Fix
On a `key_exchange_ok` send failure, **roll the crypto state back** and tear down instead of establishing:
- `encryptionState = null` (so nothing else tries to encrypt to this client)
- `encryptionPending = false`, `postAuthQueue = null` (nothing flushes)
- `ws.close(1011, 'Key exchange failed')` so the client reconnects and retries the handshake cleanly

Mirrors the existing teardown the handler already does for the "non-key_exchange message while pending" path.

## Tests
- `key_exchange_ok` send throws → `encryptionState` null, `encryptionPending` false, queue **not** flushed, `ws` closed with 1011. Full ws-auth suite green (99).

## Scope note
This fixes the **synchronous** send-failure path the audit identified (the try/catch that previously swallowed-then-established). The **async** half-open case (send buffered but never delivered) is already backstopped by the heartbeat pong-timeout that closes dead sockets; a dedicated client-side handshake timeout ("handshake failed, reconnect") would tighten that window and is noted as a separate follow-up rather than bundled into this crypto-path change.