### PR TITLE
fix(dashboard): roll back optimistic permission mode on PERMISSION_MODE_NOT_APPLIED

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -115,6 +115,8 @@ import {
   clearPendingTrustGrants,
   registerModelChangeRequest,
   clearPendingModelReverts,
+  registerPermissionModeChangeRequest,
+  clearPendingPermissionModeReverts,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
 import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
@@ -1616,6 +1618,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // against a closed socket.
       clearPendingTrustGrants();
       clearPendingModelReverts();
+      clearPendingPermissionModeReverts();
       // #3605: also clear the per-session pendingTrustGrants arrays
       // (added in #3588). disconnect() handles user-initiated closes, but
       // an unexpected drop here would otherwise leave the SkillsPanel
@@ -1713,6 +1716,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       rejectAllSummarizeRequests('Connection errored before the summary arrived');
       clearPendingTrustGrants();
       clearPendingModelReverts();
+      clearPendingPermissionModeReverts();
       const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
 
       set({ socket: null, sessionStates: cleanedSessionStates });
@@ -1746,6 +1750,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // against the disconnected socket.
     clearPendingTrustGrants();
     clearPendingModelReverts();
+    clearPendingPermissionModeReverts();
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -2490,17 +2495,28 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (permissionMode && permissionMode !== mode) {
       set({ previousPermissionMode: permissionMode });
     }
+    // #5716: remember the mode we're switching FROM, keyed by a requestId the
+    // server echoes on a PERMISSION_MODE_NOT_APPLIED rejection, so the error
+    // handler can roll the optimistic update below back instead of leaving the
+    // dropdown showing a mode the session never entered (a phantom bypass is the
+    // dangerous case). Read the live optimistic target, mirroring the write below.
+    const previousMode = (activeSessionId && get().sessionStates[activeSessionId])
+      ? (get().sessionStates[activeSessionId]!.permissionMode ?? null)
+      : (get().permissionMode ?? null);
+    const requestId = `set-perm-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     if (mode === 'auto') {
       // Send with confirmed:true so the server skips its own confirmation
       // round-trip and broadcasts `permission_mode_changed` directly.
       if (socket && socket.readyState === WebSocket.OPEN) {
-        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, confirmed: true };
+        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode });
+        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, confirmed: true, requestId };
         if (activeSessionId) payload.sessionId = activeSessionId;
         wsSend(socket, payload);
       }
     } else {
       if (socket && socket.readyState === WebSocket.OPEN) {
-        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode };
+        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode });
+        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, requestId };
         if (activeSessionId) payload.sessionId = activeSessionId;
         wsSend(socket, payload);
       }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2491,6 +2491,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         : true;
       if (!ok) return;
     }
+    // #5716: capture the Shift+Tab toggle target BEFORE we overwrite it below,
+    // so a rejected change can restore it too (Copilot review on #5722) — without
+    // this, a rejected switch leaves previousPermissionMode pointing at the
+    // current mode and the toggle silently becomes a no-op.
+    const priorPreviousMode = get().previousPermissionMode ?? null;
     // Save current mode before switching (for Shift+Tab toggle)
     if (permissionMode && permissionMode !== mode) {
       set({ previousPermissionMode: permissionMode });
@@ -2508,14 +2513,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // Send with confirmed:true so the server skips its own confirmation
       // round-trip and broadcasts `permission_mode_changed` directly.
       if (socket && socket.readyState === WebSocket.OPEN) {
-        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode });
+        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode, priorPreviousMode });
         const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, confirmed: true, requestId };
         if (activeSessionId) payload.sessionId = activeSessionId;
         wsSend(socket, payload);
       }
     } else {
       if (socket && socket.readyState === WebSocket.OPEN) {
-        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode });
+        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode, priorPreviousMode });
         const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, requestId };
         if (activeSessionId) payload.sessionId = activeSessionId;
         wsSend(socket, payload);

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -454,9 +454,15 @@ describe('dashboard message-handler dispatch', () => {
         setStore(store)
         registerModelChangeRequest('req1', { sessionId: 's1', previousModel: 'A' })
         registerModelChangeRequest('req2', { sessionId: 's1', previousModel: 'B' })
+        expect(_testModelRevertPendingSize()).toBe(2)
 
         // req1 succeeds first.
         handleMessage({ type: 'model_changed', sessionId: 's1', model: 'B' }, ctx() as any)
+        // Discriminating assertion: success must NOT consume/clear either pending
+        // revert (the clear-on-success regression). Without this, the test passes
+        // either way — req2's revert target ('B') equals the success value ('B'),
+        // so the final activeModel is 'B' whether or not the revert actually fired.
+        expect(_testModelRevertPendingSize()).toBe(2)
         // req2 is then rejected.
         handleMessage(
           { type: 'error', requestId: 'req2', code: 'MODEL_NOT_APPLIED', message: 'mid-turn' },
@@ -465,6 +471,7 @@ describe('dashboard message-handler dispatch', () => {
 
         const state = store.getState() as any
         expect(state.sessionStates.s1.activeModel).toBe('B') // req2 rolled back to B, not stuck on C
+        expect(_testModelRevertPendingSize()).toBe(1) // req2 consumed; req1 still pending
       })
 
       it('does NOT revert when the error requestId does not match a pending change', () => {
@@ -538,8 +545,15 @@ describe('dashboard message-handler dispatch', () => {
         setStore(store)
         registerPermissionModeChangeRequest('req1', { sessionId: 's1', previousMode: 'approve' })
         registerPermissionModeChangeRequest('req2', { sessionId: 's1', previousMode: 'plan' })
+        expect(_testPermissionModeRevertPendingSize()).toBe(2)
 
         handleMessage({ type: 'permission_mode_changed', sessionId: 's1', mode: 'plan' }, ctx() as any)
+        // Discriminating assertion: the success broadcast must NOT consume/clear
+        // either pending revert (the #5715 clear-on-success regression). The final
+        // permissionMode check alone can't catch that here — req2's revert target
+        // ('plan') equals the success value ('plan'), so the state is 'plan'
+        // whether or not the revert fired.
+        expect(_testPermissionModeRevertPendingSize()).toBe(2)
         handleMessage(
           { type: 'error', requestId: 'req2', code: 'PERMISSION_MODE_NOT_APPLIED', message: 'mid-turn' },
           ctx() as any,
@@ -547,6 +561,7 @@ describe('dashboard message-handler dispatch', () => {
 
         const state = store.getState() as any
         expect(state.sessionStates.s1.permissionMode).toBe('plan') // req2 rolled back to plan, not stuck on auto
+        expect(_testPermissionModeRevertPendingSize()).toBe(1) // req2 consumed; req1 still pending
       })
 
       it('does NOT revert when the error requestId does not match a pending change', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -38,6 +38,9 @@ import {
   registerModelChangeRequest,
   clearPendingModelReverts,
   _testModelRevertPendingSize,
+  registerPermissionModeChangeRequest,
+  clearPendingPermissionModeReverts,
+  _testPermissionModeRevertPendingSize,
   setDeltaFlushIntervalOverride,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
@@ -489,6 +492,88 @@ describe('dashboard message-handler dispatch', () => {
         expect(_testModelRevertPendingSize()).toBe(2)
         clearPendingModelReverts()
         expect(_testModelRevertPendingSize()).toBe(0)
+      })
+    })
+
+    // #5716 (sibling of #5711): set_permission_mode is optimistic too; a
+    // PERMISSION_MODE_NOT_APPLIED rejection (mid-turn change or same-mode no-op)
+    // must roll the dropdown back — the dangerous case being a phantom switch to
+    // 'auto'/bypass the session never actually entered.
+    describe('PERMISSION_MODE_NOT_APPLIED revert (#5716)', () => {
+      afterEach(() => { clearPendingPermissionModeReverts() })
+
+      it('reverts the optimistic permissionMode for the rejected request\'s session', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            permissionMode: 'auto', // optimistic value already applied by setPermissionMode
+            sessionStates: { s1: { ...createEmptySessionState(), permissionMode: 'auto' } },
+          }),
+        )
+        setStore(store)
+        registerPermissionModeChangeRequest('set-perm-1', { sessionId: 's1', previousMode: 'approve' })
+
+        handleMessage(
+          { type: 'error', requestId: 'set-perm-1', code: 'PERMISSION_MODE_NOT_APPLIED', message: 'session busy' },
+          ctx() as any,
+        )
+
+        const state = store.getState() as any
+        expect(state.sessionStates.s1.permissionMode).toBe('approve') // rolled back from phantom bypass
+        expect(state.permissionMode).toBe('approve') // flat top-level reverted too
+        expect(_testPermissionModeRevertPendingSize()).toBe(0) // consumed
+      })
+
+      it('reverts the SECOND of two rapid changes even after the first acks (per-request, not per-session)', () => {
+        // approve→plan (req1) then plan→auto (req2) on s1, both in-flight. Server
+        // acks req1 (permission_mode_changed plan) and rejects req2 (mid-turn). The
+        // revert must restore 'plan' (req2's previousMode), not leave a phantom auto.
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            permissionMode: 'auto',
+            sessionStates: { s1: { ...createEmptySessionState(), permissionMode: 'auto' } },
+          }),
+        )
+        setStore(store)
+        registerPermissionModeChangeRequest('req1', { sessionId: 's1', previousMode: 'approve' })
+        registerPermissionModeChangeRequest('req2', { sessionId: 's1', previousMode: 'plan' })
+
+        handleMessage({ type: 'permission_mode_changed', sessionId: 's1', mode: 'plan' }, ctx() as any)
+        handleMessage(
+          { type: 'error', requestId: 'req2', code: 'PERMISSION_MODE_NOT_APPLIED', message: 'mid-turn' },
+          ctx() as any,
+        )
+
+        const state = store.getState() as any
+        expect(state.sessionStates.s1.permissionMode).toBe('plan') // req2 rolled back to plan, not stuck on auto
+      })
+
+      it('does NOT revert when the error requestId does not match a pending change', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessionStates: { s1: { ...createEmptySessionState(), permissionMode: 'auto' } },
+          }),
+        )
+        setStore(store)
+        registerPermissionModeChangeRequest('set-perm-1', { sessionId: 's1', previousMode: 'approve' })
+
+        handleMessage(
+          { type: 'error', requestId: 'some-other-request', code: 'PERMISSION_MODE_NOT_APPLIED', message: 'x' },
+          ctx() as any,
+        )
+
+        expect((store.getState() as any).sessionStates.s1.permissionMode).toBe('auto') // untouched
+        expect(_testPermissionModeRevertPendingSize()).toBe(1) // still pending
+      })
+
+      it('clears all pending reverts on disconnect', () => {
+        registerPermissionModeChangeRequest('req-a', { sessionId: 's1', previousMode: 'approve' })
+        registerPermissionModeChangeRequest('req-b', { sessionId: 's2', previousMode: 'plan' })
+        expect(_testPermissionModeRevertPendingSize()).toBe(2)
+        clearPendingPermissionModeReverts()
+        expect(_testPermissionModeRevertPendingSize()).toBe(0)
       })
     })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -531,6 +531,67 @@ describe('dashboard message-handler dispatch', () => {
         expect(_testPermissionModeRevertPendingSize()).toBe(0) // consumed
       })
 
+      // #5722 review (Copilot): setPermissionMode also overwrites
+      // previousPermissionMode (the Shift+Tab toggle target). A rejected change
+      // must restore THAT too, else the toggle silently becomes a no-op
+      // (previous == current). Compare-and-swap so a later success isn't clobbered.
+      it('also restores previousPermissionMode (the Shift+Tab toggle target) on revert', () => {
+        // Session was on 'plan' with the toggle pointing back at 'approve'. The user
+        // switches plan→auto; setPermissionMode optimistically sets permissionMode
+        // 'auto' AND previousPermissionMode 'plan'. The server then rejects it.
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            permissionMode: 'auto', // optimistic value
+            previousPermissionMode: 'plan', // optimistic toggle target (was 'approve' before)
+            sessionStates: { s1: { ...createEmptySessionState(), permissionMode: 'auto' } },
+          }),
+        )
+        setStore(store)
+        registerPermissionModeChangeRequest('set-perm-1', {
+          sessionId: 's1',
+          previousMode: 'plan', // restore permissionMode → plan
+          priorPreviousMode: 'approve', // restore the toggle target → approve
+        })
+
+        handleMessage(
+          { type: 'error', requestId: 'set-perm-1', code: 'PERMISSION_MODE_NOT_APPLIED', message: 'mid-turn' },
+          ctx() as any,
+        )
+
+        const state = store.getState() as any
+        expect(state.sessionStates.s1.permissionMode).toBe('plan') // mode rolled back
+        expect(state.previousPermissionMode).toBe('approve') // toggle target rolled back too
+      })
+
+      it('does NOT clobber previousPermissionMode if a later change already moved it (compare-and-swap)', () => {
+        // Same rejected req (previousMode 'plan'), but by the time the error lands a
+        // newer successful change has set previousPermissionMode to 'acceptEdits'.
+        // The CAS must leave that newer value intact (current !== revert.previousMode).
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            permissionMode: 'auto',
+            previousPermissionMode: 'acceptEdits', // a later change moved it
+            sessionStates: { s1: { ...createEmptySessionState(), permissionMode: 'auto' } },
+          }),
+        )
+        setStore(store)
+        registerPermissionModeChangeRequest('set-perm-1', {
+          sessionId: 's1',
+          previousMode: 'plan',
+          priorPreviousMode: 'approve',
+        })
+
+        handleMessage(
+          { type: 'error', requestId: 'set-perm-1', code: 'PERMISSION_MODE_NOT_APPLIED', message: 'mid-turn' },
+          ctx() as any,
+        )
+
+        const state = store.getState() as any
+        expect(state.previousPermissionMode).toBe('acceptEdits') // newer value preserved, not clobbered
+      })
+
       it('reverts the SECOND of two rapid changes even after the first acks (per-request, not per-session)', () => {
         // approve→plan (req1) then plan→auto (req2) on s1, both in-flight. Server
         // acks req1 (permission_mode_changed plan) and rejects req2 (mid-turn). The

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -349,6 +349,51 @@ export function _testModelRevertPendingSize(): number {
   return _pendingModelReverts.size;
 }
 
+// #5716 (sibling of #5711): set_permission_mode is also applied OPTIMISTICALLY
+// (the dropdown flips immediately in setPermissionMode), but the server may
+// reject it (PERMISSION_MODE_NOT_APPLIED — a mid-turn change or same-mode no-op
+// is rejected server-side, settings-handlers.js). Without a rollback the
+// dashboard keeps showing a permission mode the session never switched to —
+// the most dangerous case being a phantom "auto"/bypass that the session never
+// entered. Remember the mode we switched FROM, keyed by the set_permission_mode
+// requestId the server echoes on its error, so the `error` handler can roll the
+// optimistic update back. Cleared on the matching error or on disconnect — NOT
+// on success: the server sends permission_mode_changed XOR error per requestId,
+// so clearing on success would drop a second in-flight revert (the #5715 bug).
+// Bounded FIFO like the model-revert map.
+interface PendingPermissionModeRevert {
+  sessionId: string | null;
+  previousMode: string | null;
+}
+
+const _pendingPermissionModeReverts = new Map<string, PendingPermissionModeRevert>();
+const PERMISSION_MODE_REVERT_PENDING_CAP = 16;
+
+export function registerPermissionModeChangeRequest(requestId: string, entry: PendingPermissionModeRevert): void {
+  if (_pendingPermissionModeReverts.size >= PERMISSION_MODE_REVERT_PENDING_CAP) {
+    const oldestKey = _pendingPermissionModeReverts.keys().next().value;
+    if (oldestKey !== undefined) _pendingPermissionModeReverts.delete(oldestKey);
+  }
+  _pendingPermissionModeReverts.set(requestId, { ...entry });
+}
+
+function consumePendingPermissionModeRevert(requestId: string): PendingPermissionModeRevert | null {
+  const entry = _pendingPermissionModeReverts.get(requestId);
+  if (!entry) return null;
+  _pendingPermissionModeReverts.delete(requestId);
+  return entry;
+}
+
+/** Clear all pending permission-mode reverts — called on WebSocket close. */
+export function clearPendingPermissionModeReverts(): void {
+  _pendingPermissionModeReverts.clear();
+}
+
+/** @internal test seam. */
+export function _testPermissionModeRevertPendingSize(): number {
+  return _pendingPermissionModeReverts.size;
+}
+
 /** @internal Exposed for tests so they can inspect the in-flight map. */
 export function _testTrustGrantPendingSize(): number {
   return _pendingTrustGrants.size;
@@ -4453,6 +4498,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             updateSession(revert.sessionId, () => ({ activeModel: revert.previousModel }));
           } else {
             set({ activeModel: revert.previousModel });
+          }
+        }
+      }
+      // #5716: roll back the optimistic set_permission_mode when the server says
+      // it never applied (PERMISSION_MODE_NOT_APPLIED — mid-turn or no-op). Mirror
+      // setPermissionMode's session-vs-flat optimistic write so the revert lands
+      // exactly where the optimistic update did. Critical for a rejected switch to
+      // 'auto'/bypass: without it the dropdown shows bypass the session never entered.
+      if (errCode === 'PERMISSION_MODE_NOT_APPLIED' && errReqId) {
+        const revert = consumePendingPermissionModeRevert(errReqId);
+        if (revert) {
+          if (revert.sessionId && get().sessionStates[revert.sessionId]) {
+            updateSession(revert.sessionId, () => ({ permissionMode: revert.previousMode }));
+          } else {
+            set({ permissionMode: revert.previousMode });
           }
         }
       }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -364,6 +364,10 @@ export function _testModelRevertPendingSize(): number {
 interface PendingPermissionModeRevert {
   sessionId: string | null;
   previousMode: string | null;
+  // The Shift+Tab toggle target (previousPermissionMode) as it was BEFORE the
+  // optimistic change overwrote it, so a rejected change can restore it too
+  // (#5722 review). Optional for back-compat with entries that predate the field.
+  priorPreviousMode?: string | null;
 }
 
 const _pendingPermissionModeReverts = new Map<string, PendingPermissionModeRevert>();
@@ -4513,6 +4517,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             updateSession(revert.sessionId, () => ({ permissionMode: revert.previousMode }));
           } else {
             set({ permissionMode: revert.previousMode });
+          }
+          // #5722 review: also roll back the Shift+Tab toggle target. The
+          // optimistic setPermissionMode overwrote previousPermissionMode with the
+          // mode we tried to switch FROM (revert.previousMode); restore the value
+          // it had before. Compare-and-swap on that exact value so a later
+          // successful change (which re-set previousPermissionMode) is not clobbered.
+          if (revert.priorPreviousMode !== undefined && get().previousPermissionMode === revert.previousMode) {
+            set({ previousPermissionMode: revert.priorPreviousMode });
           }
         }
       }


### PR DESCRIPTION
## What

`set_permission_mode` is applied optimistically in the dashboard — the dropdown flips the moment you pick a mode. But the server rejects mid-turn changes and same-mode no-ops with `PERMISSION_MODE_NOT_APPLIED` (settings-handlers.js). Without a client rollback, the dashboard kept rendering a mode the session never entered. The dangerous case: a rejected switch to `auto`/bypass leaves the UI showing bypass while the session is still asking for permission on every tool.

## How

Direct mirror of the merged #5715 model-revert plumbing:

- **connection.ts** — tag `set_permission_mode` with a `requestId` (rides the schema's `.passthrough()`; the server already echoes `msg?.requestId` on the error). Capture the previous mode from the live optimistic target and `registerPermissionModeChangeRequest(...)` before sending. Wire `clearPendingPermissionModeReverts()` into all three disconnect-cleanup sites.
- **message-handler.ts** — bounded-FIFO revert map (cap 16) + a `PERMISSION_MODE_NOT_APPLIED` branch in the `error` handler that consumes the entry and restores the previous mode, mirroring `setPermissionMode`'s session-vs-flat write so the revert lands exactly where the optimistic update did.
- Cleared on the matching error or on disconnect — **not** on success. The server sends `permission_mode_changed` XOR `error` per `requestId`, so clearing on success would drop a second in-flight revert (the exact regression caught in #5715 review).

## Tests

4 mirrored cases (single revert, rapid double-change per-request isolation, non-matching requestId no-op, disconnect-clears). Full `message-handler.test.ts` (234) green; `tsc --noEmit` clean.

Closes #5716

Part of durability epic #5703.