### PR TITLE
fix(store-core): guard handleStreamStart response reuse on replay context (#5697)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -1745,6 +1745,9 @@ describe('stream_start handler', () => {
     });
     setStore(store as any);
     _testMessageHandler.setContext(createMockContext() as any);
+    // #5697: reuse is correct ONLY while replaying — the server re-sends the
+    // same id for an already-rendered turn. Enter replay mode for s1 first.
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
 
     _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
 
@@ -1753,6 +1756,30 @@ describe('stream_start handler', () => {
     expect(ss.streamingMessageId).toBe('msg-1');
     expect(ss.messages).toHaveLength(1);
     expect(ss.messages[0].content).toBe('partial');
+    resetReplayFlags();
+  });
+
+  it('#5697: a LIVE stream_start colliding with a prior response starts a fresh bubble (no concatenation)', () => {
+    // Not replaying — a stream_start whose id matches a completed response is a
+    // NEW turn. Reusing the old bubble would concatenate two turns; instead a
+    // fresh response bubble is created so the new turn renders separately.
+    const existing = { id: 'msg-1', type: 'response' as const, content: 'first turn', timestamp: 1 };
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [existing], streamingMessageId: null } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'stream_start', messageId: 'msg-1', sessionId: 's1' });
+
+    const ss = store.getState().sessionStates.s1;
+    // Fresh bubble added; the original response is untouched.
+    expect(ss.messages).toHaveLength(2);
+    expect(ss.messages[0].content).toBe('first turn');
+    expect(ss.messages[1]).toMatchObject({ id: 'msg-1-response', type: 'response', content: '' });
+    expect(ss.streamingMessageId).toBe('msg-1-response');
   });
 
   it('ID collision: creates suffixed response message when ID is already used by tool_use', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2323,9 +2323,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'stream_start': {
       const targetId = (msg.sessionId as string) || get().activeSessionId;
+      // #5697 — only reuse an existing response bubble when THIS session is
+      // replaying history; a live colliding id starts a fresh bubble (per-session
+      // scope, matching the tool_start case's replayingSessions gate).
+      const streamStartIsReplay = targetId ? _ctx.replayingSessions.has(targetId) : false;
       if (targetId && get().sessionStates[targetId]) {
         updateSession(targetId, (ss) => {
-          const out = sharedStreamStart(msg, get().activeSessionId, ss.messages);
+          const out = sharedStreamStart(msg, get().activeSessionId, streamStartIsReplay, ss.messages);
           if (out.remap) {
             _ctx.deltaIdRemaps.set(out.remap.from, out.remap.to);
           }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1677,9 +1677,13 @@ function handleAgentIdle(msg: Record<string, unknown>, get: MsgGet, set: MsgSet,
 
 function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const targetId = (msg.sessionId as string) || get().activeSessionId;
+  // #5697 — only reuse an existing response bubble when THIS session is
+  // replaying history; a live colliding id starts a fresh bubble (per-session
+  // scope, matching handleToolStart's _replayingSessions gate).
+  const streamStartIsReplay = targetId ? _replayingSessions.has(targetId) : false;
   if (targetId && get().sessionStates[targetId]) {
     updateSession(targetId, (ss) => {
-      const out = sharedStreamStart(msg, get().activeSessionId, ss.messages);
+      const out = sharedStreamStart(msg, get().activeSessionId, streamStartIsReplay, ss.messages);
       if (out.remap) {
         _deltaIdRemaps.set(out.remap.from, out.remap.to);
       }
@@ -1694,7 +1698,7 @@ function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
     });
   } else {
     set((state: ConnectionState) => {
-      const out = sharedStreamStart(msg, get().activeSessionId, state.messages);
+      const out = sharedStreamStart(msg, get().activeSessionId, streamStartIsReplay, state.messages);
       if (out.remap) {
         _deltaIdRemaps.set(out.remap.from, out.remap.to);
       }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -7699,13 +7699,14 @@ describe('handleToolInputDelta', () => {
 // handleStreamStart
 // ---------------------------------------------------------------------------
 describe('handleStreamStart', () => {
-  it('reuses existing response message (no new message, no remap)', () => {
+  it('reuses existing response message during replay (no new message, no remap)', () => {
     const existing: ChatMessage[] = [
       { id: 'msg-1', type: 'response', content: 'partial', timestamp: 1 },
     ]
     const out = handleStreamStart(
       { messageId: 'msg-1', sessionId: 'sess-1' },
       'sess-active',
+      true, // receivingHistoryReplay — same id replayed for an already-rendered turn
       existing,
     )
     expect(out.sessionId).toBe('sess-1')
@@ -7715,11 +7716,53 @@ describe('handleStreamStart', () => {
     expect(out.remap).toBeNull()
   })
 
+  // #5697: a LIVE (non-replay) stream_start whose id collides with a prior
+  // response must NOT reuse that bubble — its deltas would concatenate two
+  // turns into one. It starts a fresh bubble + remaps deltas to it.
+  it('starts a FRESH bubble when a live stream_start collides with a prior response id (#5697)', () => {
+    const existing: ChatMessage[] = [
+      { id: 'msg-1', type: 'response', content: 'first turn', timestamp: 1 },
+    ]
+    const out = handleStreamStart(
+      { messageId: 'msg-1', sessionId: 'sess-1' },
+      'sess-active',
+      false, // live turn, not replay
+      existing,
+    )
+    expect(out.isNewMessage).toBe(true)
+    expect(out.streamingMessageId).toBe('msg-1-response')
+    expect(out.newMessage).not.toBeNull()
+    expect(out.newMessage!.id).toBe('msg-1-response')
+    expect(out.newMessage!.type).toBe('response')
+    expect(out.newMessage!.content).toBe('')
+    // deltas for the colliding id route to the fresh bubble
+    expect(out.remap).toEqual({ from: 'msg-1', to: 'msg-1-response' })
+  })
+
+  it('synthesizes a unique id when the live-collision suffix also exists (#5697)', () => {
+    const existing: ChatMessage[] = [
+      { id: 'msg-1', type: 'response', content: 'first', timestamp: 1 },
+      { id: 'msg-1-response', type: 'response', content: 'second', timestamp: 2 },
+    ]
+    const out = handleStreamStart(
+      { messageId: 'msg-1', sessionId: 'sess-1' },
+      'sess-active',
+      false,
+      existing,
+    )
+    expect(out.isNewMessage).toBe(true)
+    expect(out.streamingMessageId).not.toBe('msg-1')
+    expect(out.streamingMessageId).not.toBe('msg-1-response')
+    expect(out.streamingMessageId.length).toBeGreaterThan(0)
+    expect(out.remap).toEqual({ from: 'msg-1', to: out.streamingMessageId })
+  })
+
   it('creates a new response message when no existing message matches', () => {
     const before = Date.now()
     const out = handleStreamStart(
       { messageId: 'msg-1', sessionId: 'sess-1' },
       'sess-active',
+      false,
       [],
     )
     const after = Date.now()
@@ -7742,6 +7785,7 @@ describe('handleStreamStart', () => {
     const out = handleStreamStart(
       { messageId: 'msg-1', sessionId: 'sess-1' },
       'sess-active',
+      false,
       existing,
     )
     expect(out.sessionId).toBe('sess-1')
@@ -7757,6 +7801,7 @@ describe('handleStreamStart', () => {
     const out = handleStreamStart(
       { messageId: 'msg-1' },
       'sess-active',
+      false,
       [],
     )
     expect(out.sessionId).toBe('sess-active')
@@ -7766,6 +7811,7 @@ describe('handleStreamStart', () => {
     const out = handleStreamStart(
       { messageId: 'msg-1', sessionId: 'sess-from-msg' },
       'sess-active',
+      false,
       [],
     )
     expect(out.sessionId).toBe('sess-from-msg')
@@ -7775,6 +7821,7 @@ describe('handleStreamStart', () => {
     const out = handleStreamStart(
       { messageId: 'msg-1' },
       null,
+      false,
       [],
     )
     expect(out.sessionId).toBeNull()
@@ -7788,6 +7835,7 @@ describe('handleStreamStart', () => {
     const out = handleStreamStart(
       { messageId: 42, sessionId: 'sess-1' },
       'sess-active',
+      false,
       [],
     )
     expect(out.sessionId).toBe('sess-1')
@@ -7803,6 +7851,7 @@ describe('handleStreamStart', () => {
     const out = handleStreamStart(
       { messageId: 'msg-1', sessionId: 42 },
       'sess-active',
+      false,
       [],
     )
     expect(out.sessionId).toBe('sess-active')

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -4839,25 +4839,54 @@ export interface StreamStartPayload {
 export function handleStreamStart(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
+  receivingHistoryReplay: boolean,
   existingMessages: readonly ChatMessage[],
 ): StreamStartPayload {
   const streamId = typeof msg.messageId === 'string' ? msg.messageId : nextMessageId('msg')
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
   const existing = existingMessages.find((m) => m.id === streamId)
-  const { resolvedId, remap } = resolveStreamId(existing, streamId)
 
   if (existing && existing.type === 'response') {
-    // Reuse existing response message (reconnect replay dedup) — caller only
-    // updates streamingMessageId.
+    // #5697: a stream_start whose messageId already exists as a response is only
+    // legitimately a REUSE during reconnect history replay — the server replays
+    // the same ids for already-rendered turns. Reuse the bubble so the caller
+    // just re-points streamingMessageId. Mirrors the receivingHistoryReplay
+    // guard the sibling handlers (handleMessage, handleToolStart) already take.
+    if (receivingHistoryReplay) {
+      return {
+        sessionId,
+        streamingMessageId: streamId,
+        isNewMessage: false,
+        newMessage: null,
+        remap: null,
+      }
+    }
+    // LIVE turn colliding with a prior response id: this is a NEW turn, not a
+    // replay. Reusing the old bubble would concatenate two turns into one (the
+    // response/response case of the stream_id collision class). Start a fresh
+    // bubble at a suffixed id and remap so this turn's stream_deltas route to
+    // it. (The server's ids are monotonic + per-boot-prefixed, so this path is
+    // not currently reachable — it's defensive parity with the siblings.)
+    let freshId = `${streamId}-response`
+    if (existingMessages.some((m) => m.id === freshId)) freshId = nextMessageId('msg')
+    const newMessage: ChatMessage = {
+      id: freshId,
+      type: 'response',
+      content: '',
+      timestamp: Date.now(),
+    }
     return {
       sessionId,
-      streamingMessageId: resolvedId,
-      isNewMessage: false,
-      newMessage: null,
-      remap: null,
+      streamingMessageId: freshId,
+      isNewMessage: true,
+      newMessage,
+      remap: { from: streamId, to: freshId },
     }
   }
 
+  // Non-response collision (e.g. the server reuses a tool_start id for the
+  // post-tool stream_start) — resolveStreamId suffixes + remaps as before.
+  const { resolvedId, remap } = resolveStreamId(existing, streamId)
   const newMessage: ChatMessage = {
     id: resolvedId,
     type: 'response',


### PR DESCRIPTION
## What

`handleStreamStart` reused an existing `response` bubble **unconditionally** when an incoming `stream_start` carried a `messageId` that already existed as a response. That reuse is only correct during **reconnect history replay** (the server re-sends the same ids for already-rendered turns). For a **live** turn a colliding id is a NEW turn, and reusing the old bubble concatenates two turns into one — the response/response case of the `stream_id` collision class. The two sibling handlers (`handleMessage`, `handleToolStart`) already take a `receivingHistoryReplay` flag; this one didn't.

## Decision (recorded for the durability epic)

The audit on #5697 confirmed the **mechanism** but found the **trigger is not currently reachable** — the server assigns monotonic, per-boot-prefixed ids that never collide for a fresh turn. The issue left it as *"thread the flag for parity, or close wontfix."*

**Chosen: parity fix, not wontfix.** It's cheap, makes the three stream handlers consistent, and removes a latent footgun if the server's id scheme ever changes — directly in line with the durability north star (predictable, "don't let you break stuff"). The fix is inert under today's server behavior.

## How

- **store-core** — thread `receivingHistoryReplay: boolean` into `handleStreamStart`. When replaying, reuse the existing response bubble as before. When live, start a fresh `response` bubble at a suffixed id (`${id}-response`, or a synthesized id if that also collides) and emit a `remap` so the new turn's `stream_delta`s route to the fresh bubble.
- **both clients** — pass the per-session replay flag (`replayingSessions.has(targetId)`), exactly as `handleToolStart` already derives it. Per-session scope avoids suppressing live `stream_start`s for session B while A is replaying.

## Tests

- store-core: replay-reuse vs live-split, plus the suffix-also-collides synthesized-id path.
- app integration: the existing "reuses on reconnect replay" test now genuinely enters replay (it previously relied on the old unconditional reuse); a new live-collision test asserts a fresh second bubble with no concatenation.
- All green: store-core handlers, dashboard `message-handler` (234), app `message-handler` (189), dashboard + app `tsc --noEmit`.

Closes #5697

Part of durability epic #5703 (the last deferred/defensive child).