### PR TITLE
feat(dashboard): cap the reconnect ladder + terminal "server down" state (#5698 FIX-2)

### DIFF
--- a/packages/app/src/hooks/useConnectionAnnouncer.ts
+++ b/packages/app/src/hooks/useConnectionAnnouncer.ts
@@ -51,6 +51,7 @@ const SETTLED_LABELS: Record<ConnectionPhase, string> = {
   connecting: 'Connecting to Chroxy server',
   reconnecting: 'Reconnecting to Chroxy server',
   server_restarting: 'Chroxy server restarting',
+  server_down: 'Chroxy server appears to be down. Reconnect to try again.',
   disconnected: 'Disconnected from Chroxy server',
 };
 

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -26,8 +26,12 @@ const VALID_TRANSITIONS: Record<ConnectionPhase, ConnectionPhase[]> = {
   disconnected: ['connecting'],
   connecting: ['connecting', 'connected', 'disconnected', 'reconnecting', 'server_restarting'],
   connected: ['disconnected', 'reconnecting', 'server_restarting'],
-  reconnecting: ['reconnecting', 'connected', 'disconnected', 'server_restarting'],
+  // #5698 — the reconnect ladder gives up → terminal 'server_down'.
+  reconnecting: ['reconnecting', 'connected', 'disconnected', 'server_restarting', 'server_down'],
   server_restarting: ['connecting', 'reconnecting', 'disconnected'],
+  // #5698 — terminal; only a user-initiated reconnect (→ connecting) or an
+  // explicit disconnect leaves it.
+  server_down: ['connecting', 'disconnected'],
 };
 
 interface ServerInfo {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1570,6 +1570,8 @@ export function App() {
 
   const isConnected = connectionPhase === 'connected'
   const isReconnecting = connectionPhase === 'reconnecting' || connectionPhase === 'server_restarting'
+  // #5698 — the reconnect ladder gave up; terminal state, manual reconnect only.
+  const isServerDown = connectionPhase === 'server_down'
   const isStartupError = connectionPhase === 'disconnected' && !!connectionError && sessions.length === 0
   const showWelcome = isConnected && sessions.length === 0
 
@@ -1609,10 +1611,15 @@ export function App() {
       <ConnectionAnnouncer phase={connectionPhase} />
       {/* Reconnect banner */}
       <ReconnectBanner
-        visible={isReconnecting}
+        visible={isReconnecting || isServerDown}
         attempt={connectionRetryCount}
         maxAttempts={5}
-        message={connectionPhase === 'server_restarting' ? 'Server restarting...' : undefined}
+        message={
+          isServerDown
+            ? 'Server appears to be down'
+            : connectionPhase === 'server_restarting' ? 'Server restarting...' : undefined
+        }
+        terminal={isServerDown}
         restartEtaMs={connectionPhase === 'server_restarting' ? restartEtaMs : null}
         restartingSince={connectionPhase === 'server_restarting' ? restartingSince : null}
         shutdownReason={connectionPhase === 'server_restarting' ? shutdownReason : null}

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -117,6 +117,7 @@ export function AppHeader(props: AppHeaderProps) {
             connecting: warming ? 'Tunnel warming up…' : 'Connecting to Chroxy server…',
             reconnecting: 'Reconnecting to Chroxy server…',
             server_restarting: 'Server restarting…',
+            server_down: 'Chroxy server appears to be down', // #5698 — terminal; don't leak the raw enum
             disconnected: 'Disconnected from Chroxy server',
           }
           const label = STATUS_LABELS[phase] ?? `Connection status: ${phase}`

--- a/packages/dashboard/src/components/ConnectionAnnouncer.tsx
+++ b/packages/dashboard/src/components/ConnectionAnnouncer.tsx
@@ -47,6 +47,7 @@ const SETTLED_LABELS: Record<string, string> = {
   connecting: 'Connecting to Chroxy server',
   reconnecting: 'Reconnecting to Chroxy server',
   server_restarting: 'Chroxy server restarting',
+  server_down: 'Chroxy server appears to be down. Reconnect to try again.',
   disconnected: 'Disconnected from Chroxy server',
 }
 

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -30,6 +30,14 @@ describe('FooterBar', () => {
     expect(screen.getByText('Reconnecting')).toBeInTheDocument()
   })
 
+  // #5698 — the terminal server_down phase must map to a human label, not leak
+  // the raw enum string into the footer chip (#5724 review finding A).
+  it('shows a human label for the terminal server_down phase', () => {
+    render(<FooterBar {...baseProps} connectionPhase={'server_down' as never} />)
+    expect(screen.getByText('Server down')).toBeInTheDocument()
+    expect(screen.queryByText('server_down')).not.toBeInTheDocument()
+  })
+
   it('shows abbreviated cwd', () => {
     render(<FooterBar {...baseProps} cwd="/Users/me/Projects/chroxy" />)
     expect(screen.getByText('Projects/chroxy')).toBeInTheDocument()

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -79,6 +79,7 @@ const STATUS_LABELS: Record<string, string> = {
   connecting: 'Connecting',
   reconnecting: 'Reconnecting',
   server_restarting: 'Restarting',
+  server_down: 'Server down', // #5698 — terminal; avoid leaking the raw enum string
   disconnected: 'Disconnected',
 }
 

--- a/packages/dashboard/src/components/ReconnectBanner.test.tsx
+++ b/packages/dashboard/src/components/ReconnectBanner.test.tsx
@@ -240,4 +240,44 @@ describe('ReconnectBanner', () => {
       }).not.toThrow()
     })
   })
+
+  // #5698 — terminal "server_down" mode: the reconnect ladder gave up.
+  describe('terminal mode (#5698 server_down)', () => {
+    it('renders the terminal message without the attempt counter', () => {
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          attempt={10}
+          terminal
+          message="Server appears to be down"
+        />,
+      )
+      const text = screen.getByTestId('reconnect-banner').textContent || ''
+      expect(text).toContain('Server appears to be down')
+      // No "(attempt N/M)" suffix in terminal mode.
+      expect(text).not.toContain('attempt')
+    })
+
+    it('still offers a manual Reconnect button in terminal mode', () => {
+      const onRetry = vi.fn()
+      render(<ReconnectBanner {...baseProps} terminal message="Server appears to be down" onRetry={onRetry} />)
+      fireEvent.click(screen.getByTestId('retry-button'))
+      expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows no restart countdown even if an ETA is somehow present', () => {
+      render(
+        <ReconnectBanner
+          {...baseProps}
+          terminal
+          message="Server appears to be down"
+          restartEtaMs={30_000}
+          restartingSince={5_000_000}
+        />,
+      )
+      const text = screen.getByTestId('reconnect-banner').textContent || ''
+      expect(text).toContain('Server appears to be down')
+      expect(text).not.toMatch(/~\d+:\d{2}/)
+    })
+  })
 })

--- a/packages/dashboard/src/components/ReconnectBanner.tsx
+++ b/packages/dashboard/src/components/ReconnectBanner.tsx
@@ -38,6 +38,13 @@ export interface ReconnectBannerProps {
    * recovering, `'shutdown'` → terminal (no countdown).
    */
   shutdownReason?: ShutdownReason
+  /**
+   * #5698 — terminal "reconnect ladder gave up" state (connectionPhase
+   * `server_down`). Renders `message` with NO attempt counter and NO countdown —
+   * the only way out is the manual Reconnect button. Distinct from
+   * `shutdownReason: 'shutdown'` (which is a server-announced shutdown).
+   */
+  terminal?: boolean
 }
 
 /**
@@ -64,12 +71,14 @@ export function ReconnectBanner({
   restartEtaMs,
   restartingSince,
   shutdownReason,
+  terminal,
 }: ReconnectBannerProps) {
   // Restart-countdown mode is active only when both the ETA and the anchor
-  // timestamp are populated. `shutdownReason === 'shutdown'` is terminal and
-  // shows no countdown even if an ETA is somehow present.
+  // timestamp are populated. `shutdownReason === 'shutdown'` and the #5698
+  // `terminal` (server_down) state are both terminal and show no countdown even
+  // if an ETA is somehow present.
   const inRestartMode =
-    !!restartEtaMs && restartEtaMs > 0 && !!restartingSince && shutdownReason !== 'shutdown'
+    !terminal && !!restartEtaMs && restartEtaMs > 0 && !!restartingSince && shutdownReason !== 'shutdown'
 
   // Client-side ticking countdown. Mirrors the mobile SessionScreen effect:
   // recompute every second, clear the interval once it hits zero, and reset to
@@ -102,7 +111,9 @@ export function ReconnectBanner({
 
   // Build the primary status line. Restart mode overrides the plain message.
   let statusText: string
-  if (shutdownReason === 'shutdown') {
+  if (terminal) {
+    statusText = message || 'Server appears to be down'
+  } else if (shutdownReason === 'shutdown') {
     statusText = 'Server shut down'
   } else if (inRestartMode && countdown != null && countdown > 0) {
     statusText = `Server restarting... ${formatCountdown(countdown)}`
@@ -123,7 +134,7 @@ export function ReconnectBanner({
   return (
     <div className="reconnect-banner" data-testid="reconnect-banner" role="status" aria-live="polite">
       <span className="reconnect-message">
-        {statusText} (attempt {attempt}/{maxAttempts})
+        {statusText}{terminal ? '' : ` (attempt ${attempt}/${maxAttempts})`}
       </span>
       {detail && (
         <span className="reconnect-detail" data-testid="reconnect-detail">

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -19,6 +19,7 @@ function statusDot(phase: ConnectionPhase, isActive: boolean): string {
     case 'connecting':
     case 'reconnecting': return 'server-dot connecting'
     case 'server_restarting': return 'server-dot restarting'
+    case 'server_down': return 'server-dot down' // #5698 — terminal
     default: return 'server-dot disconnected'
   }
 }
@@ -30,6 +31,7 @@ function statusLabel(phase: ConnectionPhase, isActive: boolean): string {
     case 'connecting': return 'Connecting...'
     case 'reconnecting': return 'Reconnecting...'
     case 'server_restarting': return 'Restarting...'
+    case 'server_down': return 'Server down' // #5698 — terminal
     default: return 'Disconnected'
   }
 }

--- a/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
+++ b/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
@@ -79,6 +79,14 @@ beforeEach(() => {
   MockWebSocket.instances = []
   resetReconnectAttempt()
   vi.spyOn(Math, 'random').mockReturnValue(0) // zero jitter
+  // Silence the per-cycle reconnect logging. These tests drive many
+  // close→reconnect cycles (the #5698 give-up test alone runs 11), and that
+  // console.log volume races vitest's onUserConsoleLog RPC at worker teardown
+  // ("Closing rpc while onUserConsoleLog was pending"), surfacing as a flaky
+  // EnvironmentTeardownError in CI even though every test passes. Restored by
+  // vi.restoreAllMocks() in afterEach.
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
   for (const k of Object.keys(store)) delete store[k]
   useConnectionStore.setState({
     serverRegistry: [],

--- a/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
+++ b/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
@@ -12,6 +12,7 @@
  * connection-pairing.test.ts, with fake timers so we can assert exact delays.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { RECONNECT_MAX_RUNG } from '@chroxy/store-core'
 
 const store: Record<string, string> = {}
 const localStorageMock = {
@@ -205,5 +206,47 @@ describe('backoff ladder resets on auth_ok, not socket-open (#5555.5)', () => {
     s1.onopen?.() // opened but never authenticated
     await vi.advanceTimersByTimeAsync(0)
     expect(mh.reconnectAttempt).toBe(1) // NOT reset by socket-open
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5698 — ladder gives up → terminal server_down + manual-retry recovery
+// ---------------------------------------------------------------------------
+
+describe('reconnect ladder gives up → server_down (#5698)', () => {
+  // Drive one drop. If a reconnect socket is created, mark it connected (but
+  // never auth_ok, so the ladder keeps climbing) and return true; if the ladder
+  // gave up (no new socket), return false.
+  async function driveDrop(): Promise<boolean> {
+    const socket = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    const before = MockWebSocket.instances.length
+    socket.onclose?.({ code: 1006 })
+    // Advance well past the top rung so any armed timer fires.
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS[4] * 2)
+    if (MockWebSocket.instances.length === before) return false // gave up
+    const next = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    next.readyState = 1
+    next.onopen?.()
+    await vi.advanceTimersByTimeAsync(0)
+    useConnectionStore.setState({ connectionPhase: 'connected' })
+    return true
+  }
+
+  it('goes terminal after RECONNECT_MAX_RUNG failed reconnects and a manual retry resets the ladder', async () => {
+    await openConnected()
+    let cycles = 0
+    while (await driveDrop()) {
+      cycles++
+      if (cycles > RECONNECT_MAX_RUNG + 2) throw new Error('ladder never gave up')
+    }
+    // The ladder armed rungs 0..RECONNECT_MAX_RUNG-1 (that many reconnects), then
+    // the next drop hit the cap and gave up instead of arming.
+    expect(cycles).toBe(RECONNECT_MAX_RUNG)
+    expect(useConnectionStore.getState().connectionPhase).toBe('server_down')
+
+    // A user-initiated retry resets the ladder (resetReconnectAttempt runs even
+    // though the local-daemon connect no-ops here — getAuthToken is mocked null).
+    useConnectionStore.getState().retryConnection()
+    expect(mh.reconnectAttempt).toBe(0)
   })
 })

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3401,7 +3401,15 @@ if (typeof document !== 'undefined') {
     sendClientVisible(socket, visible);
 
     if (visible) {
-      if (connectionPhase === 'connected' && socket && socket.readyState !== WebSocket.OPEN && wsUrl && apiToken) {
+      if (connectionPhase === 'server_down') {
+        // #5698 — the reconnect ladder gave up while the tab was hidden (e.g. the
+        // laptop slept through the whole backoff budget). The server is very
+        // likely fine now, so a wake is the natural moment to try again. Reuse
+        // the manual-retry path (resets the ladder + reconnects) so the user
+        // doesn't have to hunt for the Reconnect button after every sleep.
+        console.log('[ws] Tab became visible while server_down — retrying');
+        state.retryConnection();
+      } else if (connectionPhase === 'connected' && socket && socket.readyState !== WebSocket.OPEN && wsUrl && apiToken) {
         console.log('[ws] Tab became visible, socket stale — reconnecting');
         state.connect(wsUrl, apiToken);
       } else if (connectionPhase === 'connected' && activeSessionId && sessionStates[activeSessionId]) {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -96,6 +96,7 @@ import {
   lastConnectedUrl,
   setLastConnectedUrl,
   nextReconnectAttempt,
+  resetReconnectAttempt,
   resetReplayFlags,
   clearPermissionSplits,
   clearTerminalWriteBatching,
@@ -149,6 +150,7 @@ import {
   // LAN/tunnel re-resolution seam (static today).
   runConnectAttempt,
   createReconnectScheduler,
+  RECONNECT_MAX_RUNG,
   type ProbeResult,
   type ConnectEndpoint,
 } from '@chroxy/store-core';
@@ -1483,6 +1485,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       },
       isStale: () => myAttemptId !== connectionAttemptId,
       retryDelays: RETRY_DELAYS,
+      // #5698 — stop the reconnect ladder after RECONNECT_MAX_RUNG rungs and go
+      // terminal instead of spinning forever. A user-initiated retryConnection()
+      // resets the counter (resetReconnectAttempt), so this is not permanent.
+      maxRung: RECONNECT_MAX_RUNG,
+      onGaveUp: () => {
+        if (myAttemptId !== connectionAttemptId) return; // superseded — don't clobber a newer attempt
+        console.log('[ws] reconnect ladder exhausted — server appears down');
+        set({
+          connectionPhase: 'server_down',
+          connectionError: 'Server appears to be down',
+        });
+      },
     });
     const scheduleReconnect = (
       reasonText: string,
@@ -1498,7 +1512,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // per-socket dedupe means a paired error → close drop advances the ladder
       // exactly once. The ladder resets on `auth_ok`, so a clean reconnect
       // starts back at the bottom (1s).
-      reconnectScheduler.schedule();
+      const armed = reconnectScheduler.schedule();
+      // #5698 — schedule() returns false here only when the ladder hit maxRung
+      // (the top `scheduled` guard already handled the dedup case). onGaveUp has
+      // set the terminal 'server_down' phase; don't overwrite it with
+      // 'reconnecting'.
+      if (!armed) return;
       console.log(`[ws] ${reasonText}, reconnecting...`);
       // #4771: `errorMessage === null` means the close code was 1000
       // (normal server-initiated close — see getWsCloseMessage). Match
@@ -3244,6 +3263,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
    * reuses connectToServer's no-reset reconnect for the registry case.
    */
   retryConnection: () => {
+    // #5698 — a user-initiated retry starts a fresh reconnect ladder. Without
+    // this, retrying from the terminal 'server_down' state would immediately
+    // re-exhaust the (still-maxed) counter and give up again on the first failure.
+    resetReconnectAttempt();
     const activeServerId = get().activeServerId;
     if (activeServerId) {
       // Registry server. connectToServer no-ops on an id absent from the

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -451,6 +451,7 @@
 .status-dot.connecting { background: var(--status-connecting); }
 .status-dot.reconnecting { background: var(--status-restarting); }
 .status-dot.server_restarting { background: var(--status-restarting); }
+.status-dot.server_down { background: var(--accent-red); } /* #5698 — terminal */
 
 /* ---- Sidebar ---- */
 .sidebar {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4824,6 +4824,7 @@ button.sidebar-token-view-session-row:hover {
 .footer-status-dot.connected { background: var(--accent-green); }
 .footer-status-dot.connecting, .footer-status-dot.reconnecting { background: var(--accent-orange); }
 .footer-status-dot.server_restarting { background: var(--accent-orange); }
+.footer-status-dot.server_down { background: var(--accent-red); } /* #5698 — terminal */
 .footer-status-dot.disconnected { background: var(--text-muted); }
 
 .footer-status-label {
@@ -7926,6 +7927,7 @@ button.sidebar-token-view-session-row:hover {
 .server-dot.connected { background: var(--accent-green); }
 .server-dot.connecting { background: var(--accent-yellow); animation: pulse 1.5s ease-in-out infinite; }
 .server-dot.restarting { background: var(--accent-orange, var(--accent-yellow)); }
+.server-dot.down { background: var(--accent-red); } /* #5698 — terminal */
 .server-dot.disconnected { background: var(--text-dim); opacity: 0.5; }
 
 .server-remove-btn {

--- a/packages/store-core/src/connect-flow.test.ts
+++ b/packages/store-core/src/connect-flow.test.ts
@@ -417,6 +417,72 @@ describe('createReconnectScheduler', () => {
     expect(fake.lastDelay()).toBe(RETRY_DELAYS[0] + 250)
   })
 
+  // #5698 — ladder cap: once the rung reaches maxRung the scheduler gives up
+  // (terminal) instead of arming another retry forever.
+  it('gives up at maxRung instead of arming a retry (#5698)', () => {
+    const fake = makeFakeScheduler()
+    const reconnect = vi.fn()
+    const onGaveUp = vi.fn()
+    let rung = 0
+    const s = createReconnectScheduler({
+      nextRung: () => rung++,
+      reconnect,
+      isStale: () => false,
+      scheduler: fake.scheduler,
+      jitter: noJitter,
+      maxRung: 3,
+      onGaveUp,
+    })
+
+    // Rungs 0,1,2 arm retries as usual.
+    expect(s.schedule()).toBe(true)  // rung 0
+    fake.fireAll()
+    // Re-create per socket (the client builds a fresh scheduler each connect),
+    // but here we reuse one and reset its arm by simulating fresh sockets:
+    const mk = () => createReconnectScheduler({
+      nextRung: () => rung++, reconnect, isStale: () => false,
+      scheduler: fake.scheduler, jitter: noJitter, maxRung: 3, onGaveUp,
+    })
+    expect(mk().schedule()).toBe(true)  // rung 1
+    expect(mk().schedule()).toBe(true)  // rung 2
+    // rung 3 >= maxRung 3 → give up.
+    expect(mk().schedule()).toBe(false)
+    expect(onGaveUp).toHaveBeenCalledTimes(1)
+    expect(reconnect).toHaveBeenCalledTimes(1) // only the rung-0 timer fired
+  })
+
+  it('does not re-arm or re-fire onGaveUp on a paired event after giving up (#5698)', () => {
+    const fake = makeFakeScheduler()
+    const onGaveUp = vi.fn()
+    const s = createReconnectScheduler({
+      nextRung: () => 5, // already at/over the cap
+      reconnect: vi.fn(),
+      isStale: () => false,
+      scheduler: fake.scheduler,
+      jitter: noJitter,
+      maxRung: 3,
+      onGaveUp,
+    })
+    expect(s.schedule()).toBe(false) // gave up
+    expect(s.scheduled).toBe(true)   // marked so a paired event is a no-op
+    expect(s.schedule()).toBe(false) // paired event: dedup no-op
+    expect(onGaveUp).toHaveBeenCalledTimes(1) // fired exactly once
+    expect(fake.count()).toBe(0)     // no timer ever armed
+  })
+
+  it('never gives up when maxRung is omitted (legacy behavior)', () => {
+    const fake = makeFakeScheduler()
+    const onGaveUp = vi.fn()
+    let rung = 100 // way past any ladder
+    const mk = () => createReconnectScheduler({
+      nextRung: () => rung++, reconnect: vi.fn(), isStale: () => false,
+      scheduler: fake.scheduler, jitter: noJitter, onGaveUp,
+    })
+    expect(mk().schedule()).toBe(true)
+    expect(mk().schedule()).toBe(true)
+    expect(onGaveUp).not.toHaveBeenCalled()
+  })
+
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -425,12 +425,14 @@ export function createReconnectScheduler(
     if (scheduled) return false
     const rung = nextRung()
     // #5698: cap the ladder. Once the rung reaches maxRung, stop arming retries
-    // and hand off to the terminal handler instead of spinning forever. Mark the
-    // socket as "scheduled" so a paired close/error (or a later event on this
-    // dead socket) is a dedup no-op and onGaveUp fires exactly once. A manual
-    // connect() builds a fresh socket + scheduler with a reset counter.
+    // and hand off to the terminal handler instead of spinning forever. NOTE: no
+    // timer is armed here — `scheduled = true` is purely a terminal/dedup LATCH
+    // (NOT "a reconnect is pending"), so a paired close/error or any later event
+    // on this dead socket short-circuits at the `if (scheduled) return` guard
+    // above and `onGaveUp` fires exactly once. A manual connect() builds a fresh
+    // socket + scheduler with a reset counter, so the latch is per-socket.
     if (maxRung != null && rung >= maxRung) {
-      scheduled = true
+      scheduled = true // terminal latch; intentionally no timer (see note above)
       if (onGaveUp) onGaveUp()
       return false
     }

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -52,6 +52,16 @@
 export const CONNECT_MAX_RETRIES = 5
 
 /**
+ * #5698 — how many post-connect reconnect rungs to climb before the ladder gives
+ * up and the client shows a terminal "server appears down" state (instead of
+ * spinning forever). The ladder caps its delay at the last RETRY_DELAYS rung
+ * (8s), so ~10 rungs ≈ 1+2+3+5+8·6 ≈ 65s of trying before going terminal — long
+ * enough to ride out a normal restart, short enough not to spin indefinitely. A
+ * user-initiated reconnect resets the counter, so this cap is not permanent.
+ */
+export const RECONNECT_MAX_RUNG = 10
+
+/**
  * Backoff ladder (ms) for both the pre-WS health-check retries and the
  * post-connect close/error reconnects. Climbed by attempt index, capped at the
  * last rung. Shared so the app and dashboard escalate identically. (#5594)
@@ -346,6 +356,22 @@ export interface CreateReconnectSchedulerOptions {
   scheduler?: ConnectFlowScheduler
   /** Jitter fn; defaults to store-core's `withJitter` (0–50%). */
   jitter?: (delayMs: number) => number
+  /**
+   * Maximum rung before the ladder gives up (#5698). When `nextRung()` returns a
+   * value `>= maxRung`, the scheduler does NOT arm another retry — it invokes
+   * `onGaveUp()` once for this socket and stops, so the client can show a
+   * terminal "server appears down" state with a manual-reconnect affordance
+   * instead of spinning the reconnect ladder forever. Omit (or `Infinity`) for
+   * the legacy never-give-up behavior. A fresh socket from a manual `connect()`
+   * gets a new scheduler with a reset counter, so giving up is not permanent.
+   */
+  maxRung?: number
+  /**
+   * Called once (per socket) when the ladder reaches `maxRung` instead of arming
+   * another retry. The client transitions to its terminal `server_down` phase
+   * here. Must be idempotent. No-op when `maxRung` is omitted.
+   */
+  onGaveUp?: () => void
 }
 
 /**
@@ -388,14 +414,26 @@ export function createReconnectScheduler(
     retryDelays = CONNECT_RETRY_DELAYS,
     scheduler = DEFAULT_SCHEDULER,
     jitter = defaultJitter,
+    maxRung,
+    onGaveUp,
   } = options
 
   let scheduled = false
 
   function schedule(): boolean {
     if (scheduled) return false
-    scheduled = true
     const rung = nextRung()
+    // #5698: cap the ladder. Once the rung reaches maxRung, stop arming retries
+    // and hand off to the terminal handler instead of spinning forever. Mark the
+    // socket as "scheduled" so a paired close/error (or a later event on this
+    // dead socket) is a dedup no-op and onGaveUp fires exactly once. A manual
+    // connect() builds a fresh socket + scheduler with a reset counter.
+    if (maxRung != null && rung >= maxRung) {
+      scheduled = true
+      if (onGaveUp) onGaveUp()
+      return false
+    }
+    scheduled = true
     const delayMs = jitter(retryDelayForAttempt(rung, retryDelays))
     scheduler.setTimeout(() => {
       if (isStale()) return

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -55,9 +55,10 @@ export const CONNECT_MAX_RETRIES = 5
  * #5698 — how many post-connect reconnect rungs to climb before the ladder gives
  * up and the client shows a terminal "server appears down" state (instead of
  * spinning forever). The ladder caps its delay at the last RETRY_DELAYS rung
- * (8s), so ~10 rungs ≈ 1+2+3+5+8·6 ≈ 65s of trying before going terminal — long
- * enough to ride out a normal restart, short enough not to spin indefinitely. A
- * user-initiated reconnect resets the counter, so this cap is not permanent.
+ * (8s), so 10 rungs (0–9) ≈ 1+2+3+5+8·6 ≈ 59s of trying before going terminal —
+ * long enough to ride out a normal restart, short enough not to spin
+ * indefinitely. A user-initiated reconnect resets the counter, so the cap is not
+ * permanent.
  */
 export const RECONNECT_MAX_RUNG = 10
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -647,6 +647,7 @@ export {
   selectReconnectEndpoint,
   CONNECT_MAX_RETRIES,
   CONNECT_RETRY_DELAYS,
+  RECONNECT_MAX_RUNG,
   LAN_FALLBACK_THRESHOLD,
 } from './connect-flow'
 export type {

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -718,7 +718,8 @@ export type ConnectionPhase =
   | 'connecting'          // Initial connection attempt
   | 'connected'           // WebSocket open + authenticated
   | 'reconnecting'        // Auto-reconnecting after unexpected disconnect
-  | 'server_restarting';  // Health check returns { status: 'restarting' }
+  | 'server_restarting'   // Health check returns { status: 'restarting' }
+  | 'server_down';        // Reconnect ladder gave up (#5698) — terminal, manual reconnect only
 
 /** Context captured from connect() closure for use by the extracted handleMessage(). */
 export interface ConnectionContext {


### PR DESCRIPTION
## What

The post-connect reconnect ladder re-armed **forever**. When a daemon was gone for good, the dashboard spun "Reconnecting…" indefinitely with no signal that the server was actually down — the exact "feels janky vs. the terminal" friction from the durability epic (#5703). This caps the ladder and shows a terminal, manual-reconnect-only state.

This is **#5698 FIX-2 (client ladder cap), dashboard surface**. Deliberately scoped — see *Deferred* below.

## How

**store-core**
- `createReconnectScheduler` gains `maxRung` + `onGaveUp`. When the shared backoff ladder reaches `maxRung`, it stops arming retries, marks the socket `scheduled` (so a paired close/error is a dedup no-op and `onGaveUp` fires exactly once), and hands off to the terminal handler. Inert when `maxRung` is omitted.
- New `RECONNECT_MAX_RUNG = 10` (~65s of trying — long enough to ride out a normal restart, short enough to stop spinning) and a `server_down` `ConnectionPhase`.

**dashboard**
- `connection.ts`: wires the cap; `onGaveUp` sets `connectionPhase: 'server_down'`; `scheduleReconnect` no longer overwrites it with `'reconnecting'`. `retryConnection()` resets the ladder so a manual reconnect gets a fresh budget instead of immediately re-exhausting the maxed counter.
- `ReconnectBanner` gains a `terminal` mode (custom message, **no** attempt counter, **no** countdown, manual Reconnect only); `App.tsx` shows it on `server_down`; `ConnectionAnnouncer` announces it for screen readers.

**app (mobile)** — minimal `server_down` entries in the two exhaustive `ConnectionPhase` maps (transition table + announcer labels) so the shared-type addition compiles. The mobile app does **not** yet enter the state.

## Tests
- store-core: scheduler cap — gives up at `maxRung`, no re-fire on a paired event, never gives up when `maxRung` omitted.
- dashboard: a **connection-layer integration test** driving 10 failed reconnects → `server_down`, then a manual retry resetting the ladder; ReconnectBanner terminal-mode (message/no-counter/manual-retry/no-countdown).
- Full suites green: store-core 1488, dashboard 3653, app 1880; all `tsc --noEmit` clean.

## Deferred (follow-ups)
- **FIX-1** — server give-up signal (`{status:'down'}` from the standby server). Needs a supervisor-lifecycle decision (park-in-terminal-standby vs `_exit(1)`); intentionally not bundled here.
- **FIX-3** — per-session terminal flag (flapping session → terminal banner).
- **Mobile wiring** + resume/network-change clear of `server_down` (the mobile app sleeps/resumes; the dashboard's manual-reconnect is the right model for a desktop surface).

Part of durability epic #5703.