### PR TITLE
docs(report): autonomous durability marathon — decisions + merged PRs

### DIFF
--- a/docs/reports/status-2026-06-13.html
+++ b/docs/reports/status-2026-06-13.html
@@ -71,6 +71,34 @@
   <strong>Mic fixed + redeployed.</strong> The desktop app was rebuilt from current <code>main</code> and reinstalled to <code>/Applications/Chroxy.app</code> (v0.9.46, fresh universal <code>speech-helper</code>, code-signed, same bundle id so existing permission grants carry over). It now carries both the June-3 RunLoop fix and this session's push-to-talk fix. <span class="muted">Pending your confirmation on next launch.</span>
 </div>
 
+<h2>1.5 · Autonomous durability marathon — continuation</h2>
+<p>Picking up the durability epic <a href="https://github.com/blamechris/chroxy/issues/5703">#5703</a> (parity with the Claude Code CLI — "don't let me break stuff, don't make me lose my place"). Run as orchestrator + delegated review agents; every PR gated by adversarial review + full CI + resolved threads before a synchronous squash-merge. <strong>Design decisions made on your behalf are recorded below.</strong></p>
+<table>
+  <thead><tr><th>PR / issue</th><th>What</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td>#5722 → #5716</td><td>Dashboard rolls back an optimistic permission-mode switch the server rejects (<code>PERMISSION_MODE_NOT_APPLIED</code>) — incl. the Shift+Tab toggle target (Copilot-caught) via compare-and-swap</td><td><span class="pill ok">merged</span></td></tr>
+    <tr><td>#5724 → #5698</td><td>Caps the reconnect ladder (10 rungs ≈ 65s) and surfaces a terminal <code>server_down</code> state with a manual Reconnect, instead of spinning "Reconnecting…" forever (dashboard; FIX-2)</td><td><span class="pill warn">in review</span></td></tr>
+    <tr><td>#5697</td><td><code>handleStreamStart</code> response-reuse replay guard</td><td><span class="pill neutral">wontfix (decision below)</span></td></tr>
+  </tbody>
+</table>
+
+<h3>Design decisions taken on your behalf</h3>
+<div class="callout">
+  <strong>#5697 — closed wontfix, not "fixed for parity."</strong> The proposed guard (force a fresh response bubble whenever a live <code>stream_start</code> collides with a prior response id) is defensive against a bug the swarm confirmed is <em>unreachable</em> (server response ids are monotonic + per-boot-prefixed). Implementing it (PR #5723) failed CI because both clients <em>intentionally</em> reuse a response bubble on a live same-id stream_start (the post-<code>stream_end</code> continuation path, encoded in <code>connection.test.ts</code>). Changing core streaming behavior to defend an impossible collision fails the "do no harm" bar — so it was reverted and the issue closed with the trigger-to-revisit recorded.
+</div>
+<div class="callout">
+  <strong>#5698 reconnect — client cap first; server-lifecycle change deferred.</strong> The biggest decision here is whether the supervisor should park in a terminal "I'm down" standby (serving <code>{status:'down'}</code>) instead of <code>_exit(1)</code> on max-restarts. That changes process-exit semantics under launchd/the desktop app — real blast radius. <strong>Decision:</strong> ship the pure-client ladder cap first (zero server risk, fixes the core "spins forever" jank), and defer the server-side positive-down signal (FIX-1) until the lifecycle question can be made deliberately. The client cap alone takes the user from an infinite spinner to a clear "Server appears to be down — Reconnect."
+</div>
+<div class="callout">
+  <strong>Scope discipline.</strong> #5698 was split: FIX-2 (client cap, dashboard) shipped now; FIX-1 (server signal), FIX-3 (per-session terminal flag), and the mobile-app wiring + resume/network clear are tracked follow-ups (<a href="https://github.com/blamechris/chroxy/issues/5725">#5725</a> for mobile; FIX-1/FIX-3 under the open parent #5698). The dashboard is "the app" you use day-to-day, so it got the surface first.
+</div>
+
+<h3>Process lessons banked (project memory)</h3>
+<ul>
+  <li><strong>Review agents must be worktree-isolated</strong> — a non-isolated review agent ran <code>git checkout</code> and switched the working tree mid-edit. All review agents now run in a worktree or are forbidden from switching branches.</li>
+  <li><strong>Run the full package suite before pushing shared <code>store-core</code> changes</strong> — a targeted-file-green change went red on contract/integration tests in CI; the shared module ripples widely.</li>
+</ul>
+
 <h2>2 · Shipped this session</h2>
 <table>
   <thead><tr><th>PR</th><th>What</th><th>Issue</th><th>Status</th></tr></thead>

--- a/docs/reports/status-2026-06-13.html
+++ b/docs/reports/status-2026-06-13.html
@@ -72,31 +72,41 @@
 </div>
 
 <h2>1.5 · Autonomous durability marathon — continuation</h2>
-<p>Picking up the durability epic <a href="https://github.com/blamechris/chroxy/issues/5703">#5703</a> (parity with the Claude Code CLI — "don't let me break stuff, don't make me lose my place"). Run as orchestrator + delegated review agents; every PR gated by adversarial review + full CI + resolved threads before a synchronous squash-merge. <strong>Design decisions made on your behalf are recorded below.</strong></p>
+<p>Picking up the durability epic <a href="https://github.com/blamechris/chroxy/issues/5703">#5703</a> (parity with the Claude Code CLI — "don't let me break stuff, don't make me lose my place"). Run as orchestrator + delegated worktree-isolated review agents; every PR gated by adversarial review + full CI + resolved threads before a synchronous squash-merge. <strong>4 PRs merged; design decisions made on your behalf are recorded below.</strong></p>
+<div class="cards">
+  <div class="card"><div class="n" style="color:var(--green)">4</div><div class="l">Durability PRs merged</div></div>
+  <div class="card"><div class="n">3</div><div class="l">Decisions recorded</div></div>
+  <div class="card"><div class="n">2</div><div class="l">Follow-ups filed</div></div>
+  <div class="card"><div class="n" style="color:var(--green)">0</div><div class="l">Auto-merges / overrides</div></div>
+</div>
 <table>
-  <thead><tr><th>PR / issue</th><th>What</th><th>Status</th></tr></thead>
+  <thead><tr><th>PR → issue</th><th>What it fixes (the friction)</th><th>Status</th></tr></thead>
   <tbody>
-    <tr><td>#5722 → #5716</td><td>Dashboard rolls back an optimistic permission-mode switch the server rejects (<code>PERMISSION_MODE_NOT_APPLIED</code>) — incl. the Shift+Tab toggle target (Copilot-caught) via compare-and-swap</td><td><span class="pill ok">merged</span></td></tr>
-    <tr><td>#5724 → #5698</td><td>Caps the reconnect ladder (10 rungs ≈ 65s) and surfaces a terminal <code>server_down</code> state with a manual Reconnect, instead of spinning "Reconnecting…" forever (dashboard; FIX-2)</td><td><span class="pill warn">in review</span></td></tr>
+    <tr><td>#5722 → #5716</td><td>Roll back an optimistic permission-mode switch the server rejects (<code>PERMISSION_MODE_NOT_APPLIED</code>) — incl. the Shift+Tab toggle target (Copilot-caught) via compare-and-swap. No more phantom "auto"/bypass the session never entered.</td><td><span class="pill ok">merged</span></td></tr>
+    <tr><td>#5727 → #5710</td><td>Force escape hatch to delete a wedged/stuck-running session (server <code>force</code> bypass + dashboard "delete anyway?" confirm). Recovers the recoverability gap #5707 introduced — you can't get stuck unable to remove a dead tab.</td><td><span class="pill ok">merged</span></td></tr>
+    <tr><td>#5724 → #5698</td><td>Cap the reconnect ladder (10 rungs ≈ 59s) → terminal <code>server_down</code> state with a manual Reconnect + wake-recovery on tab-visible, instead of spinning "Reconnecting…" forever (FIX-2).</td><td><span class="pill ok">merged</span></td></tr>
+    <tr><td>#5728 → #5699</td><td>Refuse permission answers on a disconnected/cached session (store + buttons + keyboard) instead of optimistically marking them "answered" and silently losing them. The "did it actually send?" footgun.</td><td><span class="pill ok">merged</span></td></tr>
     <tr><td>#5697</td><td><code>handleStreamStart</code> response-reuse replay guard</td><td><span class="pill neutral">wontfix (decision below)</span></td></tr>
   </tbody>
 </table>
+<p class="muted">Every PR ran implement → worktree-isolated adversarial review (+ Copilot) → fix → full-suite + green CI → resolved threads → squash-merge. The reviews earned their keep every time: a cross-session toggle-target clobber (#5716), the <code>server_down</code> enum string leaking into the footer / server-picker / app-header (#5724, found across two rounds), and a permission-prompt that wedged <em>permanently</em> on a disconnected keypress (#5728). All caught and fixed before merge.</p>
 
 <h3>Design decisions taken on your behalf</h3>
 <div class="callout">
-  <strong>#5697 — closed wontfix, not "fixed for parity."</strong> The proposed guard (force a fresh response bubble whenever a live <code>stream_start</code> collides with a prior response id) is defensive against a bug the swarm confirmed is <em>unreachable</em> (server response ids are monotonic + per-boot-prefixed). Implementing it (PR #5723) failed CI because both clients <em>intentionally</em> reuse a response bubble on a live same-id stream_start (the post-<code>stream_end</code> continuation path, encoded in <code>connection.test.ts</code>). Changing core streaming behavior to defend an impossible collision fails the "do no harm" bar — so it was reverted and the issue closed with the trigger-to-revisit recorded.
+  <strong>#5697 — closed wontfix, not "fixed for parity."</strong> The proposed guard (force a fresh response bubble whenever a live <code>stream_start</code> collides with a prior response id) defends a bug the swarm confirmed is <em>unreachable</em> (server response ids are monotonic + per-boot-prefixed). Implementing it (PR #5723) failed CI because both clients <em>intentionally</em> reuse a response bubble on a live same-id stream_start (the post-<code>stream_end</code> continuation path, encoded in <code>connection.test.ts</code>). Changing core streaming behavior to defend an impossible collision fails the "do no harm" bar — reverted and closed, trigger-to-revisit recorded.
 </div>
 <div class="callout">
-  <strong>#5698 reconnect — client cap first; server-lifecycle change deferred.</strong> The biggest decision here is whether the supervisor should park in a terminal "I'm down" standby (serving <code>{status:'down'}</code>) instead of <code>_exit(1)</code> on max-restarts. That changes process-exit semantics under launchd/the desktop app — real blast radius. <strong>Decision:</strong> ship the pure-client ladder cap first (zero server risk, fixes the core "spins forever" jank), and defer the server-side positive-down signal (FIX-1) until the lifecycle question can be made deliberately. The client cap alone takes the user from an infinite spinner to a clear "Server appears to be down — Reconnect."
+  <strong>#5698 reconnect — client cap first; server-lifecycle change deferred.</strong> The biggest call was whether the supervisor should park in a terminal "I'm down" standby (serving <code>{status:'down'}</code>) instead of <code>_exit(1)</code> on max-restarts — which changes process-exit semantics under launchd/the desktop app (real blast radius). <strong>Decision:</strong> ship the pure-client ladder cap first (zero server risk, fixes the core "spins forever" jank), defer the server-side positive-down signal (FIX-1) until the lifecycle question can be made deliberately. The client cap alone takes you from an infinite spinner to a clear "Server appears to be down — Reconnect."
 </div>
 <div class="callout">
-  <strong>Scope discipline.</strong> #5698 was split: FIX-2 (client cap, dashboard) shipped now; FIX-1 (server signal), FIX-3 (per-session terminal flag), and the mobile-app wiring + resume/network clear are tracked follow-ups (<a href="https://github.com/blamechris/chroxy/issues/5725">#5725</a> for mobile; FIX-1/FIX-3 under the open parent #5698). The dashboard is "the app" you use day-to-day, so it got the surface first.
+  <strong>Scope discipline.</strong> #5698 split: FIX-2 (client cap) shipped; FIX-1 (server signal), FIX-3 (per-session terminal flag), mobile wiring + resume/network clear are follow-ups (<a href="https://github.com/blamechris/chroxy/issues/5725">#5725</a> for mobile; FIX-1/FIX-3 under the open parent #5698). #5728 shipped the dangerous half of #5699 (permission answers); input stays legitimately queued and tab-switch stays allowed (cached nav re-syncs), so #5699's switch-gate + queued-count banner remain optional follow-ups. #5704 (subscription teardown) deferred per its own triage — invisible traffic only, medium mis-teardown risk.
 </div>
 
 <h3>Process lessons banked (project memory)</h3>
 <ul>
-  <li><strong>Review agents must be worktree-isolated</strong> — a non-isolated review agent ran <code>git checkout</code> and switched the working tree mid-edit. All review agents now run in a worktree or are forbidden from switching branches.</li>
-  <li><strong>Run the full package suite before pushing shared <code>store-core</code> changes</strong> — a targeted-file-green change went red on contract/integration tests in CI; the shared module ripples widely.</li>
+  <li><strong>Review agents detach the orchestrator's HEAD via a case-folded duplicate workdir.</strong> A worktree-isolated agent <code>cd</code>'d into <code>/Users/blamechris/projects/chroxy</code> for node_modules — which on case-insensitive macOS is the <em>same</em> directory as the main checkout (<code>…/Projects/…</code>) — and ran git there, detaching HEAD mid-marathon. Recovered (all work was on origin); now re-assert the branch after every concurrent agent and forbid agents from <code>cd</code>-ing into either workdir path.</li>
+  <li><strong>Run the full package suite before pushing shared <code>store-core</code> changes</strong> — a targeted-file-green change went red on contract/integration tests in CI; the shared module ripples widely (two separate app message-handler files, a contract-fixture suite per client).</li>
+  <li><strong>A console-log-heavy test can flake CI at worker teardown</strong> — the reconnect-cycle integration test logged ~11× per run, racing vitest's <code>onUserConsoleLog</code> RPC at shutdown ("Closing rpc while … pending"). Silencing the test's console fixed a 3×-recurring red that was green locally.</li>
 </ul>
 
 <h2>2 · Shipped this session</h2>


### PR DESCRIPTION
Living status report for the autonomous durability-epic (#5703) work. Records design decisions made on the user's behalf (#5697 wontfix; #5698 client-cap-first / server-lifecycle deferred), merged/in-flight PRs (#5716, #5724), follow-ups (#5725), and process lessons. Docs-only (single HTML file under docs/reports/). I'll keep appending here as the marathon continues.