### PR TITLE
feat: force escape hatch to destroy a wedged/stuck-running session (#5710)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -651,7 +651,7 @@ export function App() {
 
   // The actual session teardown, shared by the confirm path and the
   // no-confirm path (#5206).
-  const performCloseSession = useCallback((sessionId: string) => {
+  const performCloseSession = useCallback((sessionId: string, force?: boolean) => {
     // #3800: evict the per-session composer state (draft + collapsed-paste
     // blocks + next-id counter) so the refs further down don't leak the
     // pasted-text content for the lifetime of <App />. `handleSend` already
@@ -660,10 +660,28 @@ export function App() {
     // backstop for server-driven removals, but evicting synchronously here
     // keeps the cleanup tied to the click.
     evictSessionComposerState(sessionId)
-    destroySession(sessionId)
+    // Only thread `force` when set, so the normal close path stays a single-arg
+    // call (no spurious `undefined` second argument).
+    if (force) destroySession(sessionId, true)
+    else destroySession(sessionId)
   }, [destroySession])
 
   const handleCloseSession = useCallback((sessionId: string) => {
+    // #5710 — a busy/running session is rejected by the server's #5695 guard
+    // ("interrupt it first"). For a WEDGED session that never reports turn-end
+    // that's a dead end, so offer an explicit force-delete confirm here that
+    // sends `force: true`. `isBusy` is the client-visible proxy for the server's
+    // `isRunning`. window.confirm is synchronous and matches the auto-mode
+    // confirm pattern used elsewhere in the dashboard.
+    const session = sessions.find(s => s.sessionId === sessionId)
+    if (session?.isBusy) {
+      const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm('This session is still running. Delete it anyway? The in-flight turn will be interrupted and any uncommitted work in its worktree may be lost.')
+        : true
+      if (!ok) return
+      performCloseSession(sessionId, true)
+      return
+    }
     // #5206 — gate the teardown behind a styled confirm dialog when the
     // setting is enabled (the default). When disabled, close immediately.
     // The Control Room tab closes via its own non-session path and never
@@ -673,7 +691,7 @@ export function App() {
       return
     }
     performCloseSession(sessionId)
-  }, [confirmSessionClose, performCloseSession])
+  }, [sessions, confirmSessionClose, performCloseSession])
 
   // #3567 / #3602: dedicated restart handler for the StdinDisabledBanner.
   // Creates a replacement session FIRST and then destroys the broken one so

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2915,10 +2915,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  destroySession: (sessionId: string) => {
+  destroySession: (sessionId: string, force?: boolean) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'destroy_session', sessionId });
+      // #5710 — `force` bypasses the server's #5695 "is running" guard so a
+      // wedged session can be deleted. Only sent when the user explicitly
+      // confirms the destructive force-delete (see App.handleCloseSession).
+      wsSend(socket, force ? { type: 'destroy_session', sessionId, force: true } : { type: 'destroy_session', sessionId });
     }
   },
 

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -385,6 +385,25 @@ describe('useConnectionStore', () => {
     expect(useConnectionStore.getState().cancellingActivityIds.has('s1:act-1')).toBe(false);
   });
 
+  it('#5710: destroySession sends force:true only when forced', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const send = vi.fn();
+    const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: openSocket });
+
+    // Normal delete — no force field on the wire.
+    useConnectionStore.getState().destroySession('s1');
+    const normal = JSON.parse(send.mock.calls[0]![0] as string);
+    expect(normal).toEqual({ type: 'destroy_session', sessionId: 's1' });
+    expect(normal.force).toBeUndefined();
+
+    // Forced delete (a wedged running session) — carries force:true to bypass
+    // the server's #5695 busy guard.
+    useConnectionStore.getState().destroySession('s2', true);
+    const forced = JSON.parse(send.mock.calls[1]![0] as string);
+    expect(forced).toEqual({ type: 'destroy_session', sessionId: 's2', force: true });
+  });
+
   it('#5500: sendRepoMemoryReindex marks the repo pending, clears its stale result, and sends', async () => {
     const { useConnectionStore } = await import('./connection');
     const send = vi.fn();

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1056,7 +1056,7 @@ export interface ConnectionState {
    */
   claimPrimary: (sessionId: string, options?: { force?: boolean }) => void;
   createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string; skipPermissions?: boolean }) => void;
-  destroySession: (sessionId: string) => void;
+  destroySession: (sessionId: string, force?: boolean) => void;
   renameSession: (sessionId: string, name: string) => void;
   forgetSession: () => void;
   _resetSessionMemory: () => void;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -314,6 +314,7 @@ export declare const CreateSessionSchema: z.ZodObject<{
 export declare const DestroySessionSchema: z.ZodObject<{
     type: z.ZodLiteral<"destroy_session">;
     sessionId: z.ZodString;
+    force: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export declare const RenameSessionSchema: z.ZodObject<{
     type: z.ZodLiteral<"rename_session">;
@@ -790,6 +791,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"destroy_session">;
     sessionId: z.ZodString;
+    force: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"rename_session">;
     sessionId: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -360,6 +360,12 @@ export const CreateSessionSchema = z.object({
 export const DestroySessionSchema = z.object({
     type: z.literal('destroy_session'),
     sessionId: z.string().max(256),
+    // #5710 — force escape hatch: bypass the #5695 "is running" guard to delete a
+    // wedged session whose `isRunning` is stuck true (a crashed provider that never
+    // emits turn-end, or a leaked background-shell tracker entry). The client gates
+    // this behind an explicit "delete anyway?" confirm. Omitted/false = the normal
+    // guarded path.
+    force: z.boolean().optional(),
 });
 export const RenameSessionSchema = z.object({
     type: z.literal('rename_session'),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -402,6 +402,12 @@ export const CreateSessionSchema = z.object({
 export const DestroySessionSchema = z.object({
   type: z.literal('destroy_session'),
   sessionId: z.string().max(256),
+  // #5710 — force escape hatch: bypass the #5695 "is running" guard to delete a
+  // wedged session whose `isRunning` is stuck true (a crashed provider that never
+  // emits turn-end, or a leaked background-shell tracker entry). The client gates
+  // this behind an explicit "delete anyway?" confirm. Omitted/false = the normal
+  // guarded path.
+  force: z.boolean().optional(),
 })
 
 export const RenameSessionSchema = z.object({

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -222,10 +222,19 @@ async function handleDestroySession(ws, client, msg, ctx) {
   // is actively streaming or has pending background shells — that orphans the
   // in-flight turn and can lose uncommitted worktree work. The CLI won't delete
   // the session you're running in either. Interrupt first, then delete.
-  // (A `force` escape hatch for a wedged session is tracked as a follow-up.)
   if (targetEntry.session?.isRunning) {
-    sendSessionError(ws, ctx, 'Cannot destroy a session while it is running — interrupt it first, then delete.')
-    return
+    // #5710: force escape hatch. A wedged session whose `isRunning` is stuck true
+    // (a crashed provider that never emits turn-end, or a leaked background-shell
+    // tracker entry) could otherwise NEVER be deleted from any client. When the
+    // client sends `force: true` (gated behind an explicit "delete anyway?"
+    // confirm), bypass the guard and proceed — logged loudly so a forced teardown
+    // of a genuinely-running session is auditable.
+    if (msg.force === true) {
+      log.warn(`Force-destroying session ${targetId} while isRunning=true (client ${client.id}) — bypassing #5695 busy guard`)
+    } else {
+      sendSessionError(ws, ctx, 'Cannot destroy a session while it is running — interrupt it first, then delete.')
+      return
+    }
   }
 
   if (typeof ctx.sessions.sessionManager.destroySessionLocked === 'function') {

--- a/packages/server/tests/ws-handlers.test.js
+++ b/packages/server/tests/ws-handlers.test.js
@@ -232,6 +232,33 @@ describe('WS handler: destroy_session', () => {
     ws.close()
   })
 
+  it('force-destroys a running session when force:true bypasses the guard (#5710)', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'First', cwd: '/tmp' },
+      { id: 'sess-2', name: 'Wedged', cwd: '/tmp', isRunning: true },
+    ])
+    manager.destroySession = createSpy(() => {})
+    manager.destroySessionLocked = createSpy(() => Promise.resolve())
+
+    server = new WsServer({
+      port: 0, apiToken: 'test-token', authRequired: false,
+      sessionManager: manager,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    messages.length = 0
+    // force:true must bypass the #5695 isRunning guard so a wedged session can
+    // still be deleted (the schema now carries `force` after the dist rebuild).
+    send(ws, { type: 'destroy_session', sessionId: 'sess-2', force: true })
+
+    const destroyed = await waitForMessage(messages, 'session_destroyed')
+    assert.equal(destroyed.sessionId, 'sess-2', 'the wedged session is destroyed')
+    assert.equal(manager.destroySessionLocked.callCount, 1, 'destroySessionLocked SHOULD be called despite isRunning')
+
+    ws.close()
+  })
+
   it('awaits destroySessionLocked when present', async () => {
     const { manager, sessionsMap } = createMockSessionManager([
       { id: 'sess-1', name: 'First', cwd: '/tmp' },


### PR DESCRIPTION
## What

#5707 made `destroy_session` reject while the session `isRunning` (the #5695 data-loss guard — deleting a running session orphans the turn + can lose worktree work). That closed the footgun but left a **recoverability gap**: a *wedged* session whose `isRunning` is stuck true (a crashed provider that never emits turn-end, or a leaked background-shell tracker) can no longer be deleted from any client.

This adds the deferred `force: true` escape hatch.

## How

- **protocol** — `DestroySessionSchema` gains `force?: boolean` (+ `dist` rebuild, since the server consumes the built schema; `force` was previously stripped as an unknown field).
- **server** — `handleDestroySession` bypasses the `isRunning` guard when `msg.force === true`, logging the forced teardown loudly (auditable). Non-force still rejects with the same "interrupt it first" message.
- **dashboard** — the store's `destroySession(sessionId, force?)` sends `force:true` on the wire; `App.handleCloseSession` shows an explicit **"This session is still running. Delete it anyway?"** confirm when the target `isBusy` (the client-visible proxy for `isRunning`), sending `force:true` on confirm. A non-busy close is unchanged (styled dialog / immediate).

## Tests
- server: `force:true` bypasses the guard and destroys the wedged session; non-force still rejects (the existing #5707 test).
- dashboard: store sends `force` only when forced; the #5206 close-confirm + #3800 composer-eviction tests stay green (normal path is single-arg).
- Full dashboard suite (3656) + server `ws-handlers` + all tscs green.

Closes #5710

Part of durability epic #5703.