### PR TITLE
fix(dashboard): refuse permission answers on a disconnected session (#5699)

### DIFF
--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -589,6 +589,41 @@ describe('PermissionPrompt', () => {
     fireEvent.click(allow)
     expect(onRespond).not.toHaveBeenCalled()
   })
+
+  // #5699 (review): the keyboard shortcuts must ALSO be gated. A disconnected
+  // keypress that reached respond() would latch `submitting` and wedge the prompt
+  // permanently (submitting never resets), so it must be a complete no-op.
+  it('ignores keyboard shortcuts while disconnected and does not wedge the prompt (#5699)', () => {
+    mockStoreState.connectionPhase = 'reconnecting'
+    const onRespond = vi.fn()
+    const { rerender } = render(
+      <PermissionPrompt
+        requestId="req-kbd"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })   // Cmd+Y allow
+    fireEvent.keyDown(document, { key: 'Escape' })             // deny
+    expect(onRespond).not.toHaveBeenCalled()
+
+    // Reconnect: the prompt must still be actionable (not wedged on a latched
+    // `submitting`). A keypress now answers for real.
+    mockStoreState.connectionPhase = 'connected'
+    rerender(
+      <PermissionPrompt
+        requestId="req-kbd"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.keyDown(document, { key: 'y', metaKey: true })
+    expect(onRespond).toHaveBeenCalledWith('req-kbd', 'allow')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -21,12 +21,16 @@ type MockStore = {
   activeSessionId: string | null
   sessions: { sessionId: string; provider?: string }[]
   availableProviders: { name: string; capabilities?: { sessionRules?: boolean } }[]
+  connectionPhase: string
 }
 const DEFAULT_MOCK_STORE: MockStore = {
   resolvedPermissions: {},
   activeSessionId: 's1',
   sessions: [{ sessionId: 's1', provider: 'claude-sdk' }],
   availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true } }],
+  // #5699 — answer buttons gate on connected; default the mock to connected so
+  // the existing button-interaction tests keep working.
+  connectionPhase: 'connected',
 }
 let mockStoreState: MockStore = { ...DEFAULT_MOCK_STORE }
 function resetMockStore() {
@@ -560,6 +564,30 @@ describe('PermissionPrompt', () => {
     if (allow) expect(allow.disabled).toBe(true)
     if (deny) expect(deny.disabled).toBe(true)
     if (allowSession) expect(allowSession.disabled).toBe(true)
+  })
+
+  // #5699 — when disconnected, answering is refused store-side; the buttons must
+  // disable + a hint must explain why, so a tap isn't a silent no-op.
+  it('disables the answer buttons and shows a hint when disconnected (#5699)', () => {
+    mockStoreState.connectionPhase = 'reconnecting'
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-disc"
+        tool="Write"
+        description="test"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    const allow = screen.getByText('Allow') as HTMLButtonElement
+    const deny = screen.getByText('Deny') as HTMLButtonElement
+    expect(allow.disabled).toBe(true)
+    expect(deny.disabled).toBe(true)
+    expect(screen.getByTestId('perm-disconnected-hint')).toBeInTheDocument()
+    // A click on the disabled button does not fire onRespond.
+    fireEvent.click(allow)
+    expect(onRespond).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -120,7 +120,13 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     // #2852: submittingRef short-circuits duplicate invocations from
     // double-click or keyboard auto-repeat before React re-renders with the
     // store's answered state.
-    if (submittingRef.current || answered || remaining <= 0) return
+    // #5699: also bail when disconnected — this is the single choke point for
+    // BOTH the buttons and the keyboard shortcuts (Cmd+Y / Cmd+Shift+Y / Escape).
+    // sendPermissionResponse refuses to send/resolve while the socket is down, so
+    // if we latched `submitting` here the prompt would wedge permanently
+    // (`submitting` only resets when `answered` flips, which never happens). Bail
+    // before the latch so the prompt stays actionable once reconnected.
+    if (submittingRef.current || answered || remaining <= 0 || !connected) return
     submittingRef.current = true
     setSubmitting(true)
     // 'allowSession' is only meaningful when both the tool is rule-eligible
@@ -134,7 +140,7 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
       decision === 'allowSession' && !allowSessionOk ? 'allow' : decision
     if (intervalRef.current) clearInterval(intervalRef.current)
     onRespond(requestId, effective)
-  }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules])
+  }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules, connected])
 
   // Keyboard shortcuts:
   //   Cmd/Ctrl+Y         -> allow

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -71,6 +71,13 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   // primitive subscription — useShallow / stable refs not needed.
   const answered = useConnectionStore((s) => s.resolvedPermissions?.[requestId] ?? null)
 
+  // #5699 — only allow answering while connected. The store's
+  // sendPermissionResponse refuses to send (or optimistically resolve) a
+  // permission answer when the socket is down, because the server expires the
+  // request on disconnect and a queued answer is silently lost. Disable the
+  // buttons so the operator gets visible feedback instead of a dead click.
+  const connected = useConnectionStore((s) => s.connectionPhase === 'connected')
+
   // #3072: gate the "Allow for Session" affordance on whether the active
   // session's provider supports session-scoped permission rules. Without
   // this, the button shows for every prompt and clicking on a non-supporting
@@ -203,7 +210,7 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
               type="button"
               aria-label={`Allow ${tool}`}
               title={`Allow (${allowHint})`}
-              disabled={submitting}
+              disabled={submitting || !connected}
             >
               Allow
             </button>
@@ -215,7 +222,7 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
                 aria-label={`Allow ${tool} for this session`}
                 data-testid="btn-allow-session"
                 title={`Allow for Session (${allowSessionHint})`}
-                disabled={submitting}
+                disabled={submitting || !connected}
               >
                 Allow for Session
               </button>
@@ -225,11 +232,18 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
               onClick={() => respond('deny')}
               type="button"
               aria-label={`Deny ${tool}`}
-              disabled={submitting}
+              disabled={submitting || !connected}
             >
               Deny
             </button>
           </div>
+          {!connected && (
+            // #5699 — explain why the buttons are disabled so a disconnected tap
+            // isn't a silent no-op. The prompt stays actionable once reconnected.
+            <div className="perm-disconnected-hint" data-testid="perm-disconnected-hint" role="status">
+              Disconnected — reconnect to answer.
+            </div>
+          )}
           <div className="perm-shortcut-hints" data-testid="perm-shortcut-hints" aria-hidden="true">
             <span className="perm-shortcut">
               <kbd className="perm-kbd">{allowHint}</kbd>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2211,8 +2211,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // though the server never received it. That's the #5699 silent-loss bug
     // (you tap Allow on a cached/disconnected session and nothing happens, but
     // the UI says you answered). Returning false leaves the prompt un-answered
-    // and actionable; the answer buttons gate on `connected` (App.tsx) so the
-    // operator gets clear feedback rather than a dead click.
+    // and actionable; the answer buttons + keyboard shortcuts gate on `connected`
+    // in PermissionPrompt.tsx (respond()) so the operator gets clear feedback
+    // rather than a dead click.
     if (!socket || socket.readyState !== WebSocket.OPEN) {
       return false;
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2203,18 +2203,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   sendPermissionResponse: (requestId: string, decision: 'allow' | 'deny' | 'allowSession') => {
     const { socket } = get();
+    // #5699 — refuse to answer a permission prompt while disconnected. A
+    // permission request is NOT safely queueable: the server expires the pending
+    // request when the socket drops, so the old `enqueueMessage` path either
+    // dropped the answer or replayed it against a dead request — and
+    // `markPermissionResolved` below would flip the prompt to "answered" even
+    // though the server never received it. That's the #5699 silent-loss bug
+    // (you tap Allow on a cached/disconnected session and nothing happens, but
+    // the UI says you answered). Returning false leaves the prompt un-answered
+    // and actionable; the answer buttons gate on `connected` (App.tsx) so the
+    // operator gets clear feedback rather than a dead click.
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return false;
+    }
     // allowSession: wire decision is still 'allow' — session-scoped behaviour
     // is implemented client-side via a follow-up set_permission_rules message
     // (the schema only accepts 'allow' | 'allowAlways' | 'deny').
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
     const payload = { type: 'permission_response', requestId, decision: wireDecision };
-    let result: 'sent' | 'queued' | false;
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, payload);
-      result = 'sent';
-    } else {
-      result = enqueueMessage('permission_response', payload);
-    }
+    wsSend(socket, payload);
+    const result: 'sent' | 'queued' | false = 'sent';
     // Persist the decision in the store so PermissionPrompt renders its
     // answered state across remounts (#2833 — tab switch regression).
     get().markPermissionResolved(requestId, decision);

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1351,6 +1351,8 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
 
   it('#5699: sendPermissionResponse refuses (no enqueue, no optimistic resolve) when disconnected', async () => {
     const { useConnectionStore } = await import('./connection');
+    const { _testQueueInternals } = await import('./message-handler');
+    _testQueueInternals.clear();
     // No socket (or a non-OPEN socket) — the disconnected case.
     useConnectionStore.setState({ socket: null, resolvedPermissions: {} });
 
@@ -1360,11 +1362,15 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     // bug (#5699): the UI would show "answered" for a request the server never got.
     expect(result).toBe(false);
     expect(useConnectionStore.getState().resolvedPermissions['req-x']).toBeUndefined();
+    // And must NOT queue the answer — a permission request expires server-side,
+    // so a queued answer would be replayed against a dead request.
+    expect(_testQueueInternals.getQueue()).toHaveLength(0);
 
     // A CLOSED socket (readyState !== OPEN) is treated the same as no socket.
     useConnectionStore.setState({ socket: { readyState: 3, send: () => {} } as unknown as WebSocket });
     expect(useConnectionStore.getState().sendPermissionResponse('req-y', 'deny')).toBe(false);
     expect(useConnectionStore.getState().resolvedPermissions['req-y']).toBeUndefined();
+    expect(_testQueueInternals.getQueue()).toHaveLength(0);
   });
 
   it('sendPermissionResponse with allowSession sends wire "allow" + set_permission_rules', async () => {

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1349,6 +1349,24 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(useConnectionStore.getState().resolvedPermissions['req-a']).toBe('deny');
   });
 
+  it('#5699: sendPermissionResponse refuses (no enqueue, no optimistic resolve) when disconnected', async () => {
+    const { useConnectionStore } = await import('./connection');
+    // No socket (or a non-OPEN socket) — the disconnected case.
+    useConnectionStore.setState({ socket: null, resolvedPermissions: {} });
+
+    const result = useConnectionStore.getState().sendPermissionResponse('req-x', 'allow');
+
+    // Must NOT optimistically mark the prompt answered — that's the silent-loss
+    // bug (#5699): the UI would show "answered" for a request the server never got.
+    expect(result).toBe(false);
+    expect(useConnectionStore.getState().resolvedPermissions['req-x']).toBeUndefined();
+
+    // A CLOSED socket (readyState !== OPEN) is treated the same as no socket.
+    useConnectionStore.setState({ socket: { readyState: 3, send: () => {} } as unknown as WebSocket });
+    expect(useConnectionStore.getState().sendPermissionResponse('req-y', 'deny')).toBe(false);
+    expect(useConnectionStore.getState().resolvedPermissions['req-y']).toBeUndefined();
+  });
+
   it('sendPermissionResponse with allowSession sends wire "allow" + set_permission_rules', async () => {
     const { useConnectionStore } = await import('./connection');
     const { createEmptySessionState } = await import('./utils');

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2951,6 +2951,14 @@ button.sidebar-token-view-session-row:hover {
   line-height: 1.2;
 }
 
+/* #5699 — disconnected hint under the (disabled) answer buttons. */
+.perm-disconnected-hint {
+  margin-top: 6px;
+  font-size: var(--text-xs, 11px);
+  color: var(--accent-orange);
+  line-height: 1.2;
+}
+
 .perm-shortcut {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What

Tapping **Allow/Deny on a cached or disconnected session** optimistically marked the prompt *answered* **and** queued the answer. But the server expires the pending permission request the moment the socket drops — so the queued answer was either dropped or replayed against a dead request, while the UI showed "answered". The operator believed they responded; the server never got it. This is the exact #5699 "optimistic action taken then silently lost" footgun, and the most dangerous variant (a phantom-approved tool).

## How

- **store** — `sendPermissionResponse` returns `false` immediately when the socket isn't `OPEN`: no `enqueueMessage`, no optimistic `markPermissionResolved`. A permission answer is **not** safely queueable (unlike input — the request has a server-side TTL), so refusing is the correct behavior.
- **PermissionPrompt** — the Allow / Allow-for-Session / Deny buttons disable while `connectionPhase !== 'connected'`, with a `Disconnected — reconnect to answer` hint, so a tap is *visibly* blocked instead of a silent no-op. The prompt stays actionable and is answered for real once reconnected.

## Tests
- store: refuses + doesn't optimistically resolve when the socket is null or CLOSED.
- PermissionPrompt: buttons disabled + hint shown when disconnected; a click fires no `onRespond`.
- Existing 70 PermissionPrompt + 135 store tests stay green (mock defaults to connected); full dashboard suite **3663** green; `tsc` clean.

## Scope
This is the **dangerous permission-answer half** of #5699. Input stays legitimately queued (it has no server-side expiry the way a permission request does), and tab-switch stays allowed (cached navigation re-syncs on reconnect) — so this is "Part of #5699", not a full close. The optional queued-count banner from the original triage is left for follow-up.

Part of durability epic #5703.