### PR TITLE
feat: surface session_persist_failed to clients (#5714)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -3206,6 +3206,31 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'session_persist_failed': {
+      // #5714/#5701: a session-list mutation (create/rename/destroy) could not be
+      // flushed to disk and will be lost on restart. The write is atomic so
+      // on-disk state isn't corrupted — surface a recoverable error so the user
+      // isn't left silently believing the change persisted.
+      const persistSid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
+      const persistName = typeof msg.name === 'string' ? msg.name : null;
+      const label = persistName ? `"${persistName}"` : (persistSid ? `session ${persistSid}` : 'your session change');
+      const persistError: ServerError = {
+        id: nextMessageId('persist'),
+        category: 'session',
+        message: `Couldn't save ${label} — the change may be lost on restart. Check the daemon's disk space and write permissions.`,
+        recoverable: true,
+        timestamp: Date.now(),
+        ...(persistSid ? { sessionId: persistSid } : {}),
+      };
+      set((state: ConnectionState) => ({
+        serverErrors: [...state.serverErrors, persistError].slice(-10),
+      }));
+      useNotificationStore.getState().addServerError(persistError);
+      // eslint-disable-next-line no-console
+      console.warn('[session_persist_failed]', { sessionId: persistSid, name: persistName });
+      break;
+    }
+
     case 'checkpoint_created': {
       const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);
       if (next) {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1393,6 +1393,28 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('session_persist_failed dispatch (#5714)', () => {
+    it('surfaces an unsaved session-list mutation through addServerError', () => {
+      handleMessage(
+        { type: 'session_persist_failed', sessionId: 'sess-1', name: 'My Session' },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.serverErrors).toHaveLength(1)
+      expect(state.serverErrors[0]).toContain('"My Session"')
+      expect(state.serverErrors[0]).toContain('may be lost on restart')
+    })
+
+    it('falls back to the sessionId label when name is null (destroy path)', () => {
+      handleMessage(
+        { type: 'session_persist_failed', sessionId: 'sess-gone', name: null },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.serverErrors[0]).toContain('session sess-gone')
+    })
+  })
+
   describe('stream_delta dispatch', () => {
     // Fake timers for the 100ms delta batcher — runAllTimers() flushes
     // synchronously instead of waiting on real wall-clock setTimeout(150).

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -4307,6 +4307,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'session_persist_failed': {
+      // #5714/#5701: a session-list mutation (create/rename/destroy) could not be
+      // flushed to disk and will be lost on restart. The write is atomic so
+      // on-disk state isn't corrupted — this is purely the "your change wasn't
+      // saved" signal, surfaced as an error banner so the user isn't left
+      // silently believing it persisted.
+      const persistSid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
+      const persistName = typeof msg.name === 'string' ? msg.name : null;
+      const label = persistName ? `"${persistName}"` : (persistSid ? `session ${persistSid}` : 'your session change');
+      get().addServerError(
+        `Couldn't save ${label} — the change may be lost on restart. Check the daemon's disk space and write permissions.`,
+      );
+      // eslint-disable-next-line no-console
+      console.warn('[session_persist_failed]', { sessionId: persistSid, name: persistName });
+      break;
+    }
+
     // mcp_servers — migrated to the shared dispatch table (#5556 slice 2)
 
     case 'cost_update': {

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -1788,6 +1788,20 @@ export declare const ServerSessionRestoreFailedSchema: z.ZodObject<{
     historyLength: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 /**
+ * #5714 / #5701: emitted when a session-list mutation (create / rename / destroy)
+ * could not be flushed to disk — disk full, locked file, read-only home. The
+ * write is atomic so on-disk state isn't corrupted, but the in-memory change
+ * will be lost on the next restart. Clients surface this as an error banner so
+ * the operator knows their change wasn't saved (instead of silently believing it
+ * was). `name` is null when the entry was already removed before the flush
+ * (destroy path) and no label could be resolved.
+ */
+export declare const ServerSessionPersistFailedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_persist_failed">;
+    sessionId: z.ZodString;
+    name: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+/**
  * #4756: user-initiated Stop confirmation broadcast. CliSession emits a
  * `stopped` event from `_handleChildClose` when the child process exits
  * cleanly after a Stop click (interrupt() set `_intentionalStop`). The

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -1659,6 +1659,20 @@ export const ServerSessionRestoreFailedSchema = z.object({
     historyLength: z.number().optional(),
 });
 /**
+ * #5714 / #5701: emitted when a session-list mutation (create / rename / destroy)
+ * could not be flushed to disk — disk full, locked file, read-only home. The
+ * write is atomic so on-disk state isn't corrupted, but the in-memory change
+ * will be lost on the next restart. Clients surface this as an error banner so
+ * the operator knows their change wasn't saved (instead of silently believing it
+ * was). `name` is null when the entry was already removed before the flush
+ * (destroy path) and no label could be resolved.
+ */
+export const ServerSessionPersistFailedSchema = z.object({
+    type: z.literal('session_persist_failed'),
+    sessionId: z.string(),
+    name: z.string().nullable(),
+});
+/**
  * #4756: user-initiated Stop confirmation broadcast. CliSession emits a
  * `stopped` event from `_handleChildClose` when the child process exits
  * cleanly after a Stop click (interrupt() set `_intentionalStop`). The

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -1756,6 +1756,21 @@ export const ServerSessionRestoreFailedSchema = z.object({
 })
 
 /**
+ * #5714 / #5701: emitted when a session-list mutation (create / rename / destroy)
+ * could not be flushed to disk — disk full, locked file, read-only home. The
+ * write is atomic so on-disk state isn't corrupted, but the in-memory change
+ * will be lost on the next restart. Clients surface this as an error banner so
+ * the operator knows their change wasn't saved (instead of silently believing it
+ * was). `name` is null when the entry was already removed before the flush
+ * (destroy path) and no label could be resolved.
+ */
+export const ServerSessionPersistFailedSchema = z.object({
+  type: z.literal('session_persist_failed'),
+  sessionId: z.string(),
+  name: z.string().nullable(),
+})
+
+/**
  * #4756: user-initiated Stop confirmation broadcast. CliSession emits a
  * `stopped` event from `_handleChildClose` when the child process exits
  * cleanly after a Stop click (interrupt() set `_intentionalStop`). The

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -203,6 +203,15 @@ function setupSessionForwarding(normalizer, ctx) {
     broadcast({ type: 'session_restore_failed', ...payload })
   }))
 
+  // Persist failures — surface to clients so the user knows a session-list
+  // mutation (create/rename/destroy) did NOT make it to disk and will be lost on
+  // restart, instead of silently believing it was saved (#5714 / #5701). The
+  // write is atomic so on-disk state isn't corrupted; this is purely the
+  // "your change wasn't saved" signal.
+  sessionManager.on('session_persist_failed', safeForward('session_persist_failed', (payload) => {
+    broadcast({ type: 'session_persist_failed', ...payload })
+  }))
+
   // Dev server preview: broadcast tunnel start/stop to clients
   devPreview.on('dev_preview_started', safeForward('dev_preview_started', ({ sessionId, port, url }) => {
     broadcastToSession(sessionId, { type: 'dev_preview', port, url })

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -345,6 +345,8 @@ function _isSecureRequest(req) {
  *   { type: 'session_stopped', sessionId?, code? } — user-initiated Stop confirmation (#4756); CliSession emitted `stopped` after a clean SIGINT exit; pairs with the louder `session_error` crash toast
  *   { type: 'session_restore_failed', sessionId, name, provider, cwd?, model?, permissionMode?, errorCode, errorMessage, originalHistoryPreserved, historyLength? }
  *     — session in persisted state could not be restored (e.g. missing env var); history kept on disk for retry
+ *   { type: 'session_persist_failed', sessionId, name }
+ *     — a session-list mutation (create/rename/destroy) could not be flushed to disk and will be lost on restart (#5714)
  *   { type: 'session_error', message, category?, sessionId?, recoverable? } — session operation error
  *   { type: 'history_replay_start', sessionId, fullHistory?, truncated? } — beginning of history replay
  *   { type: 'history_replay_end', sessionId }         — end of history replay

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -345,8 +345,9 @@ function _isSecureRequest(req) {
  *   { type: 'session_stopped', sessionId?, code? } — user-initiated Stop confirmation (#4756); CliSession emitted `stopped` after a clean SIGINT exit; pairs with the louder `session_error` crash toast
  *   { type: 'session_restore_failed', sessionId, name, provider, cwd?, model?, permissionMode?, errorCode, errorMessage, originalHistoryPreserved, historyLength? }
  *     — session in persisted state could not be restored (e.g. missing env var); history kept on disk for retry
- *   { type: 'session_persist_failed', sessionId, name }
- *     — a session-list mutation (create/rename/destroy) could not be flushed to disk and will be lost on restart (#5714)
+ *   { type: 'session_persist_failed', sessionId, name|null }
+ *     — a session-list mutation (create/rename/destroy) could not be flushed to disk and will be lost on restart (#5714).
+ *       `name` is null on the destroy path where the entry was already removed before the flush.
  *   { type: 'session_error', message, category?, sessionId?, recoverable? } — session operation error
  *   { type: 'history_replay_start', sessionId, fullHistory?, truncated? } — beginning of history replay
  *   { type: 'history_replay_end', sessionId }         — end of history replay

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -337,6 +337,35 @@ describe('setupForwarding', () => {
     })
   })
 
+  describe('session_persist_failed event (#5714)', () => {
+    it('broadcasts a persist failure to all clients', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_persist_failed', { sessionId: 'sess-1', name: 'My Session' })
+
+      const call = ctx.broadcast.mock.calls.find(c =>
+        c.arguments[0].type === 'session_persist_failed'
+      )
+      assert.ok(call, 'should broadcast session_persist_failed')
+      assert.equal(call.arguments[0].sessionId, 'sess-1')
+      assert.equal(call.arguments[0].name, 'My Session')
+    })
+
+    it('forwards a null name (destroy path) without throwing', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_persist_failed', { sessionId: 'sess-gone', name: null })
+
+      const call = ctx.broadcast.mock.calls.find(c =>
+        c.arguments[0].type === 'session_persist_failed'
+      )
+      assert.ok(call)
+      assert.equal(call.arguments[0].name, null)
+    })
+  })
+
   // #4756 — `stopped` event surfaces through the normalizer as a
   // `session_stopped` broadcast targeted at subscribers of the affected
   // session (NOT global broadcast). Pairs with the wiring in


### PR DESCRIPTION
## What

The SessionManager already emits `session_persist_failed` (#5701) when a session-list mutation (create / rename / destroy) can't be flushed to disk — disk full, locked file, read-only home. The in-memory change succeeds but **silently reverts on the next restart**, and it was observable only in the server log. This surfaces it to the user.

## How

A clean end-to-end mirror of the existing `session_restore_failed` path:

- **server** (`ws-forwarding.js`) — subscribe to the SM event and `broadcast({ type: 'session_persist_failed', sessionId, name })` (wrapped in `safeForward` like its siblings). Documented in the `ws-server.js` Server→Client list so the handler-coverage guard recognizes the new type.
- **protocol** — `ServerSessionPersistFailedSchema` (`{ type, sessionId, name: string|null }`) + dist rebuild.
- **dashboard + app** — handle the message → an error banner: *"Couldn't save «label» — the change may be lost on restart. Check the daemon's disk space and write permissions."* `«label»` falls back to `session <id>` when `name` is null (the destroy path, where the entry was already removed before the flush).

The on-disk write is atomic, so state isn't corrupted — this is purely the "your change wasn't saved" signal, so the user isn't left believing it persisted.

## Tests
- `ws-forwarding`: broadcasts the failure (incl. the null-name destroy path).
- dashboard handler: routes to `addServerError` (name label + sessionId-fallback).
- `handler-coverage` green (both clients now cover `session_persist_failed`).
- Full suites: dashboard **3666**, app **1880**, protocol **289**; both tscs clean.

Closes #5714

Part of durability epic #5703 (the client half of #5701's persistence-signaling gap).