### PR TITLE
fix(server): reject set_model on providers without modelSwitch (#5731 T1)

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -119,6 +119,33 @@ function handleSetModel(ws, client, msg, ctx) {
   const modelSessionId = msg.sessionId || client.activeSessionId
   const entry = resolveSession(ctx, msg, client)
 
+  // #5731 (T1): reject set_model on a provider that can't switch models, mirroring
+  // the permissionModeSwitch guard in handleSetPermissionMode below. Without this,
+  // a provider whose setModel is a no-op (e.g. claude-tui, modelSwitch:false) still
+  // updates BaseSession.model and broadcasts `model_changed` while the running
+  // session keeps its original model — so every client (incl. the ungated mobile
+  // picker) shows a switch that never happened.
+  if (entry && entry.provider) {
+    let ModelProviderClass
+    try {
+      ModelProviderClass = getProvider(entry.provider)
+    } catch {
+      // Unknown provider — allow through (fail open for forward-compat).
+    }
+    if (ModelProviderClass && ModelProviderClass.capabilities?.modelSwitch === false) {
+      ;sessionLogger(modelSessionId).warn(`Rejected set_model on ${entry.provider} session ${modelSessionId} from ${client.id}: provider does not support modelSwitch`)
+      sendError(
+        ws,
+        msg?.requestId,
+        'CAPABILITY_NOT_SUPPORTED',
+        `The active provider '${entry.provider}' does not support model switching.`,
+        undefined,
+        ctx,
+      )
+      return
+    }
+  }
+
   // Per-provider allowlist: the global ALLOWED_MODEL_IDS is Claude-only, so
   // accepting any Claude model ID on a Gemini/Codex session and forwarding
   // it to setModel() would respawn the CLI with an unknown `-m` arg and

--- a/packages/server/tests/settings-handlers-permission-rules.test.js
+++ b/packages/server/tests/settings-handlers-permission-rules.test.js
@@ -406,7 +406,12 @@ describe('handleSetModel — provider modelSwitch capability guard (#5731)', () 
     const client = makeClient()
     const ws = { readyState: 1 }
 
-    settingsHandlers['set_model'](ws, client, { type: 'set_model', model: 'claude-opus-4-8', requestId: 'r1' }, ctx)
+    // Use a model that IS in claude-tui's allowlist and differs from the session's
+    // current one, so WITHOUT the guard the request would pass the allowlist and
+    // call setModel + broadcast — i.e. every assertion below distinguishes the
+    // fixed handler from the unfixed one (#5732 review). An out-of-allowlist model
+    // would already be rejected by the pre-existing MODEL_NOT_SUPPORTED branch.
+    settingsHandlers['set_model'](ws, client, { type: 'set_model', model: 'claude-opus-4-7', requestId: 'r1' }, ctx)
 
     // The PTY model is never touched and no false model_changed is broadcast.
     assert.equal(setModelSpy.mock.callCount(), 0, 'setModel must NOT be called for a non-switch provider')

--- a/packages/server/tests/settings-handlers-permission-rules.test.js
+++ b/packages/server/tests/settings-handlers-permission-rules.test.js
@@ -392,3 +392,29 @@ describe('SdkSession permission rules delegation', () => {
     session.destroy()
   })
 })
+
+// #5731 (T1): set_model must respect the provider's modelSwitch capability,
+// mirroring the existing permissionModeSwitch guard. claude-tui is the telling
+// case — it allows permission-mode switching (permissionModeSwitch: true) but
+// NOT model switching (modelSwitch: false), so only the new guard catches it.
+describe('handleSetModel — provider modelSwitch capability guard (#5731)', () => {
+  it('rejects set_model on claude-tui (modelSwitch:false) with CAPABILITY_NOT_SUPPORTED and no broadcast', () => {
+    const setModelSpy = mock.fn(() => true)
+    const session = makeSession({ setModel: setModelSpy, model: 'claude-sonnet-4-6' })
+    const entry = { session, cwd: '/tmp', name: 'tui', provider: 'claude-tui' }
+    const ctx = makeCtx(entry)
+    const client = makeClient()
+    const ws = { readyState: 1 }
+
+    settingsHandlers['set_model'](ws, client, { type: 'set_model', model: 'claude-opus-4-8', requestId: 'r1' }, ctx)
+
+    // The PTY model is never touched and no false model_changed is broadcast.
+    assert.equal(setModelSpy.mock.callCount(), 0, 'setModel must NOT be called for a non-switch provider')
+    assert.equal(ctx.transport.broadcastToSession.mock.callCount(), 0, 'no model_changed broadcast')
+    // A CAPABILITY_NOT_SUPPORTED error is returned, correlated by requestId.
+    assert.equal(ctx.transport.send.mock.callCount(), 1)
+    const payload = ctx.transport.send.mock.calls[0].arguments[1]
+    assert.equal(payload.code, 'CAPABILITY_NOT_SUPPORTED')
+    assert.equal(payload.requestId, 'r1')
+  })
+})


### PR DESCRIPTION
## What

`handleSetPermissionMode` rejects with `CAPABILITY_NOT_SUPPORTED` when the provider can't switch permission modes, but `handleSetModel` had **no parallel `modelSwitch` guard**. On **claude-tui** (`modelSwitch:false`, `permissionModeSwitch:true`) a `set_model` fell through to `BaseSession.setModel`, which updated the model field and broadcast `model_changed` — while the TUI never overrides `_onModelChanged`, so the running PTY kept its original model. Every client (including the un-gated mobile picker, per the swarm-audit) then showed a model switch **that never happened**.

The swarm-audit (#5731) flagged this as the "biggest single win" — one server defense closes the false-`model changed` footgun for all clients regardless of per-client UI gating drift.

## How

Add the parallel capability guard at the top of `handleSetModel`: when the session provider's `capabilities.modelSwitch === false`, reject with `CAPABILITY_NOT_SUPPORTED` (fail-open for unknown providers, matching the permission-mode guard). The dashboard already renders a read-only model badge for such providers; this is the server-side backstop.

## Tests

`claude-tui` `set_model` → `CAPABILITY_NOT_SUPPORTED`, `setModel` not called, no broadcast. claude-tui is the telling case — only the new `modelSwitch` guard catches it (its `permissionModeSwitch` is `true`). Adjacent server suites (per-session-settings, ws-message-handlers, claude-tui-session) + all 4 custom Server-Lint scripts green.

Part of #5731 (hardening swarm-audit) · durability epic #5703.