### PR TITLE
fix(dashboard): announce permission/plan prompts to screen readers + label controls (#5731 T2)

### DIFF
--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -178,6 +178,7 @@ export function ChatSettingsDropdown({
       {showPermissionMode && availablePermissionModes.length > 0 && (
         <select
           data-kind="permission"
+          aria-label="Permission mode"
           value={permissionMode || ''}
           onChange={e => onPermissionModeChange(e.target.value)}
           // #4019: server-side PERMISSION_MODES carries a `description` for
@@ -199,6 +200,7 @@ export function ChatSettingsDropdown({
       {showThinkingLevel && (
         <select
           data-kind="thinking"
+          aria-label="Thinking level"
           value={thinkingLevel || 'default'}
           onChange={e => onThinkingLevelChange(e.target.value)}
         >

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -227,7 +227,9 @@ export function FooterBar({
             Share
           </button>
         )}
-        {isBusy && <span className="footer-busy" />}
+        {/* #5731 (a11y): accessible name for the motion-only busy dot (no live
+            region — see StatusBar rationale). */}
+        {isBusy && <span className="footer-busy" role="img" aria-label="Agent working" />}
         {/*
          * #4653 — chroxy-side intervention counter. Renders only when at
          * least one intervention has fired for the active session. Click

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -67,6 +67,28 @@ describe('PermissionPrompt', () => {
     vi.useRealTimers()
   })
 
+  // #5731 (a11y): the prompt auto-denies on timeout, so a screen-reader user
+  // must hear it the moment it appears — it's an assertive alertdialog with an
+  // accessible name + description association.
+  it('is an assertive alertdialog with an accessible name and description (#5731)', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-a11y"
+        tool="Write"
+        description="write the file"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    const prompt = screen.getByTestId('permission-prompt')
+    expect(prompt).toHaveAttribute('role', 'alertdialog')
+    expect(prompt).toHaveAttribute('aria-live', 'assertive')
+    expect(prompt.getAttribute('aria-label')).toMatch(/permission request/i)
+    // The description is associated for SR context.
+    expect(prompt).toHaveAttribute('aria-describedby', 'perm-desc-req-a11y')
+    expect(document.getElementById('perm-desc-req-a11y')).toBeInTheDocument()
+  })
+
   it('renders tool name and description', () => {
     render(
       <PermissionPrompt

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -87,6 +87,9 @@ describe('PermissionPrompt', () => {
     // The description is associated for SR context.
     expect(prompt).toHaveAttribute('aria-describedby', 'perm-desc-req-a11y')
     expect(document.getElementById('perm-desc-req-a11y')).toBeInTheDocument()
+    // The 1s countdown is muted so the assertive region announces the request
+    // ONCE on appearance, not re-announcing the ticking time every second.
+    expect(screen.getByTestId('perm-countdown')).toHaveAttribute('aria-live', 'off')
   })
 
   it('renders tool name and description', () => {

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -215,6 +215,13 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
         <div
           className={`perm-countdown${isUrgent ? ' urgent' : ''}${isExpired ? ' expired' : ''}`}
           data-testid="perm-countdown"
+          // #5731 (a11y): the countdown ticks every second INSIDE the assertive
+          // alertdialog container. Without muting it, the live region would
+          // re-announce the changing time every second (worse than silence — the
+          // #4873 reconnect-storm spam class). aria-live="off" excludes the tick
+          // from announcements while the container still announces the request
+          // ONCE on appearance. The visual urgent/expired styling is unaffected.
+          aria-live="off"
         >
           {isExpired ? 'Timed out' : formatCountdown(remaining)}
         </div>

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -188,13 +188,26 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   if (dismissed) return null
 
   return (
-    <div className={`permission-prompt${answered ? ' answered' : ''}`} data-testid="permission-prompt">
+    // #5731 (a11y): a permission request is a time-critical decision that
+    // auto-DENIES on timeout, but the bare div announced nothing to a
+    // screen-reader user reading the dashboard. Mark it as an assertive
+    // alertdialog with an accessible name + description so it's spoken the moment
+    // it appears (the OS-notification fallback only fires when the window is
+    // unfocused, leaving the in-focus SR case uncovered).
+    <div
+      className={`permission-prompt${answered ? ' answered' : ''}`}
+      data-testid="permission-prompt"
+      role="alertdialog"
+      aria-live="assertive"
+      aria-label={`Permission request${sessionLabel ? ` from ${sessionLabel}` : ''}`}
+      aria-describedby={`perm-desc-${requestId}`}
+    >
       {sessionLabel && (
         <div className="perm-session" data-testid="perm-session" title={`Requested by ${sessionLabel}`}>
           {sessionLabel}
         </div>
       )}
-      <div className="perm-desc">
+      <div className="perm-desc" id={`perm-desc-${requestId}`}>
         <span className="perm-tool">{tool}</span>: {description || 'Permission requested'}
       </div>
 

--- a/packages/dashboard/src/components/PlanApproval.tsx
+++ b/packages/dashboard/src/components/PlanApproval.tsx
@@ -17,7 +17,17 @@ export function PlanApproval({ planHtml, onApprove, onFeedback }: PlanApprovalPr
   if (!planHtml) return null
 
   return (
-    <div className="plan-approval" data-testid="plan-approval">
+    // #5731 (a11y): a plan appearing is a blocking decision point; the bare div
+    // announced nothing to a screen-reader user. Mark it as a labelled live
+    // region so its arrival is spoken (polite — a plan isn't as time-critical as
+    // the auto-denying permission prompt, which is assertive).
+    <div
+      className="plan-approval"
+      data-testid="plan-approval"
+      role="region"
+      aria-label="Plan ready for approval"
+      aria-live="polite"
+    >
       <div
         className="plan-content"
         data-testid="plan-content"

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -127,8 +127,12 @@ export function StatusBar({
       )}
     </div>
     <div className="status-bar-group status-bar-right">
+      {/* #5731 (a11y): the busy spinner was motion-only. role=img + aria-label
+          gives it an accessible name on focus/hover WITHOUT a role=status live
+          region (which would announce on every turn — the #4873 spam the status
+          dots already dropped role=status to avoid). */}
       {isBusy && (
-        <span className="busy-indicator" data-testid="busy-indicator" />
+        <span className="busy-indicator" data-testid="busy-indicator" role="img" aria-label="Agent working" />
       )}
       {costBadgeMode ? (
         // #5184: configurable badge. The display mode comes from Settings


### PR DESCRIPTION
## What

Accessibility pass on the **most time-critical surfaces** flagged by the swarm-audit (#5731). The dashboard has strong a11y bones (Modal focus-trap, WAI-ARIA menus, the #4873 debounced connection announcer), but a few high-stakes surfaces fell through that same convention.

- **PermissionPrompt** — a bare `<div>` that announced **nothing** to an in-focus screen-reader user, yet it **auto-DENIES** on timeout. Now `role="alertdialog"` + `aria-live="assertive"` + `aria-label` + `aria-describedby` → spoken the moment it appears. (The OS-notification fallback only fires when the window is *unfocused*, leaving the in-focus SR case uncovered.)
- **PlanApproval** — same bare-div gap; now a labelled `role="region"` + `aria-live="polite"` (a plan isn't as time-critical as the auto-denying prompt).
- **ChatSettingsDropdown** — the permission-mode + thinking-level `<select>`s had no `aria-label` (only the model one did); a SR user heard the *value* but not what the control governs. Added both.
- **StatusBar + FooterBar** busy spinner — motion-only; gave it `role="img"` + `aria-label="Agent working"`. Deliberately **not** `role="status"` — a per-turn live region would spam SR users (the #4873 reason the status dots dropped `role=status`).

## Tests
PermissionPrompt asserts the `alertdialog` role + assertive live region + accessible name + description association. Full dashboard suite (**3667**) + `tsc` green.

Part of #5731 (hardening swarm-audit) · durability epic #5703.