### PR TITLE
fix(server): surface checkpoint persistence failures to clients (#5731 T3)

### DIFF
--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -144,7 +144,12 @@ export class CheckpointManager extends EventEmitter {
     checkpoints.push(checkpoint)
     this._counters.set(sessionId, (this._counters.get(sessionId) || 0) + 1)
     this._checkpoints.set(sessionId, checkpoints)
-    this._persist(sessionId)
+    // #5731 (T3): the checkpoint exists in memory and is returned to the client,
+    // but if the disk write failed it'll be gone on restart — surface that so the
+    // user isn't told their rewind point is saved when it isn't.
+    if (!this._persist(sessionId)) {
+      this.emit('checkpoint_persist_failed', { sessionId, checkpointId: checkpoint.id, operation: 'create' })
+    }
 
     // #5335: opportunistically retry any refs whose delete previously failed
     // for this cwd, so transient `git tag -d` failures don't accrue. Race-free
@@ -233,7 +238,11 @@ export class CheckpointManager extends EventEmitter {
 
     checkpoints.splice(idx, 1)
     this._checkpoints.set(sessionId, checkpoints)
-    this._persist(sessionId)
+    // #5731 (T3): a failed write here means the deleted checkpoint reappears on
+    // restart — surface it rather than silently "deleting" something that comes back.
+    if (!this._persist(sessionId)) {
+      this.emit('checkpoint_persist_failed', { sessionId, checkpointId, operation: 'delete' })
+    }
   }
 
   /**
@@ -488,13 +497,19 @@ export class CheckpointManager extends EventEmitter {
     }
   }
 
+  // #5731 (T3): returns true on success, false if the write failed (disk full,
+  // locked file, read-only home). Callers emit `checkpoint_persist_failed` on
+  // false so the user is told their checkpoint wasn't durable instead of believing
+  // it was — the same silent-loss class fixed for session state in #5714.
   _persist(sessionId) {
     const file = join(this._checkpointsDir, `${sessionId}.json`)
     const data = { version: 1, checkpoints: this._getCheckpoints(sessionId) }
     try {
       writeFileRestricted(file, JSON.stringify(data, null, 2))
+      return true
     } catch (err) {
-      log.warn(`Failed to persist checkpoint: ${err.message}`)
+      log.warn(`Failed to persist checkpoint for ${sessionId}: ${err.message}`)
+      return false
     }
   }
 }

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -107,7 +107,7 @@ export function setupForwarding(ctx) {
 
 /** Multi-session forwarding via normalizer */
 function setupSessionForwarding(normalizer, ctx) {
-  const { sessionManager, devPreview, broadcast, broadcastToSession } = ctx
+  const { sessionManager, devPreview, checkpointManager, broadcast, broadcastToSession } = ctx
 
   sessionManager.on('session_event', ({ sessionId, event, data }) => {
     // #5313 (WP-1.3): this listener runs synchronously inside the
@@ -211,6 +211,24 @@ function setupSessionForwarding(normalizer, ctx) {
   sessionManager.on('session_persist_failed', safeForward('session_persist_failed', (payload) => {
     broadcast({ type: 'session_persist_failed', ...payload })
   }))
+
+  // #5731 (T3): a checkpoint create/delete that couldn't be flushed to disk will
+  // be lost (or reappear) on restart. Surface it as a per-session error banner —
+  // reuse the existing `session_error` message (both clients route it to their
+  // error toast) rather than minting a new wire type. checkpointManager is
+  // optional on ctx for legacy single-session callers that don't wire it.
+  if (checkpointManager && typeof checkpointManager.on === 'function') {
+    checkpointManager.on('checkpoint_persist_failed', safeForward('checkpoint_persist_failed', ({ sessionId, operation }) => {
+      if (!sessionId) return
+      broadcastToSession(sessionId, {
+        type: 'session_error',
+        code: 'CHECKPOINT_PERSIST_FAILED',
+        sessionId,
+        recoverable: true,
+        message: `Couldn't save your checkpoint ${operation === 'delete' ? 'deletion' : ''}— it may be lost on restart. Check the daemon's disk space and write permissions.`,
+      })
+    }))
+  }
 
   // Dev server preview: broadcast tunnel start/stop to clients
   devPreview.on('dev_preview_started', safeForward('dev_preview_started', ({ sessionId, port, url }) => {

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -220,12 +220,13 @@ function setupSessionForwarding(normalizer, ctx) {
   if (checkpointManager && typeof checkpointManager.on === 'function') {
     checkpointManager.on('checkpoint_persist_failed', safeForward('checkpoint_persist_failed', ({ sessionId, operation }) => {
       if (!sessionId) return
+      const what = operation === 'delete' ? 'checkpoint deletion' : 'checkpoint'
       broadcastToSession(sessionId, {
         type: 'session_error',
         code: 'CHECKPOINT_PERSIST_FAILED',
         sessionId,
         recoverable: true,
-        message: `Couldn't save your checkpoint ${operation === 'delete' ? 'deletion' : ''}— it may be lost on restart. Check the daemon's disk space and write permissions.`,
+        message: `Couldn't save your ${what} — it may be lost on restart. Check the daemon's disk space and write permissions.`,
       })
     }))
   }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1683,6 +1683,7 @@ export class WsServer {
       sessionManager: this.sessionManager,
       cliSession: this.cliSession,
       devPreview: this._devPreview,
+      checkpointManager: this._checkpointManager,
       pushManager: this.pushManager,
       permissionSessionMap: this._permissionSessionMap,
       questionSessionMap: this._questionSessionMap,

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
@@ -58,6 +58,30 @@ describe('CheckpointManager', () => {
     assert.equal(cp.messageCount, 5)
     assert.ok(cp.createdAt > 0)
     assert.ok(cp.gitRef) // should have a git tag
+  })
+
+  it('#5731 (T3): emits checkpoint_persist_failed when the disk write fails, but still returns the checkpoint', async () => {
+    // Read-only checkpoints dir → writeFileRestricted can't create the file.
+    const roDir = mkdtempSync(join(tmpdir(), 'chroxy-cp-ro-'))
+    chmodSync(roDir, 0o555)
+    const roManager = new CheckpointManager({ checkpointsDir: roDir })
+    let failed = null
+    roManager.on('checkpoint_persist_failed', (e) => { failed = e })
+    try {
+      const cp = await roManager.createCheckpoint({
+        sessionId: 'sess-ro', resumeSessionId: 'sdk-x', cwd: gitDir, name: 'x', messageCount: 1,
+      })
+      // The checkpoint exists in memory and is returned (the user sees it)...
+      assert.ok(cp.id)
+      assert.equal(roManager.listCheckpoints('sess-ro').length, 1)
+      // ...but the failed disk write is surfaced so the user knows it isn't durable.
+      assert.ok(failed, 'should emit checkpoint_persist_failed')
+      assert.equal(failed.sessionId, 'sess-ro')
+      assert.equal(failed.operation, 'create')
+    } finally {
+      chmodSync(roDir, 0o755)
+      try { rmSync(roDir, { recursive: true, force: true }) } catch {}
+    }
   })
 
   it('lists checkpoints for a session', async () => {

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -61,6 +61,10 @@ describe('CheckpointManager', () => {
   })
 
   it('#5731 (T3): emits checkpoint_persist_failed when the disk write fails, but still returns the checkpoint', async () => {
+    // Root bypasses DAC permission checks, so the read-only-dir trick can't force
+    // a write failure when run as uid 0 (Docker/devcontainer) — skip there, mirroring
+    // permission-hook-sidecar-integration.test.js.
+    if (process.getuid && process.getuid() === 0) return
     // Read-only checkpoints dir → writeFileRestricted can't create the file.
     const roDir = mkdtempSync(join(tmpdir(), 'chroxy-cp-ro-'))
     chmodSync(roDir, 0o555)

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -31,12 +31,14 @@ function makeCtx(overrides = {}) {
   const devPreview = new EventEmitter()
   devPreview.handleToolResult = mock.fn()
   devPreview.closeSession = mock.fn()
+  const checkpointManager = new EventEmitter()
 
   return {
     normalizer,
     sessionManager: sm,
     cliSession: null,
     devPreview,
+    checkpointManager,
     pushManager: null,
     permissionSessionMap: new Map(),
     questionSessionMap: new Map(),
@@ -363,6 +365,30 @@ describe('setupForwarding', () => {
       )
       assert.ok(call)
       assert.equal(call.arguments[0].name, null)
+    })
+  })
+
+  describe('checkpoint_persist_failed event (#5731 T3)', () => {
+    it('surfaces a checkpoint persist failure as a per-session session_error', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.checkpointManager.emit('checkpoint_persist_failed', { sessionId: 'sess-1', checkpointId: 'cp-1', operation: 'create' })
+
+      const call = ctx.broadcastToSession.mock.calls.find(c =>
+        c.arguments[1]?.type === 'session_error' && c.arguments[1]?.code === 'CHECKPOINT_PERSIST_FAILED'
+      )
+      assert.ok(call, 'should broadcast a CHECKPOINT_PERSIST_FAILED session_error to the session')
+      const [sessionId, msg] = call.arguments
+      assert.equal(sessionId, 'sess-1')
+      assert.equal(msg.sessionId, 'sess-1')
+      assert.equal(msg.recoverable, true)
+      assert.match(msg.message, /lost on restart/)
+    })
+
+    it('does not throw when checkpointManager is absent (legacy single-session ctx)', () => {
+      const ctx = makeCtx({ checkpointManager: null })
+      assert.doesNotThrow(() => setupForwarding(ctx))
     })
   })
 


### PR DESCRIPTION
## What

`checkpoint-manager._persist` swallowed write failures (disk full, locked file, read-only home) with a `log.warn` only, so `createCheckpoint`/`deleteCheckpoint` reported **success** while the checkpoint was silently lost (or a deleted one reappeared) on the next restart. The user believes their rewind point is saved when it isn't — the exact silent-loss class fixed for session-list state in #5714, but on a core trust feature.

Found by the hardening swarm-audit (#5731, finding T3).

## How

Mirrors the #5714 pattern, reusing the existing `session_error` message:

- `_persist` returns a boolean; `createCheckpoint`/`deleteCheckpoint` emit `checkpoint_persist_failed { sessionId, checkpointId, operation }` when it fails — **after** the in-memory op, so the user still sees the checkpoint.
- `ws-forwarding` subscribes to the (now ctx-wired) `checkpointManager` and broadcasts a per-session `session_error` with `code: 'CHECKPOINT_PERSIST_FAILED'`. Both clients already route `session_error` to their error toast, so **no new wire type / handler-coverage entry**. `checkpointManager` is optional on the ctx (legacy single-session callers no-op).

## Tests
- checkpoint-manager: emits `checkpoint_persist_failed` on a **real** write failure (read-only dir) yet still returns the checkpoint + keeps it in memory.
- ws-forwarding: broadcasts the `CHECKPOINT_PERSIST_FAILED` `session_error` to the session; no-throws when `checkpointManager` is absent.
- Server suites green. The change uses only the `broadcastToSession` transport helper (no reverse-index mutation).

Part of #5731 (hardening swarm-audit) · durability epic #5703.