### PR TITLE
fix(ws): clear transient stream/plan state for all sessions on socket drop

### DIFF
--- a/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
+++ b/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
@@ -258,3 +258,54 @@ describe('reconnect ladder gives up → server_down (#5698)', () => {
     expect(mh.reconnectAttempt).toBe(0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// #5731 T4 — onclose clears transient streaming/plan state for EVERY session,
+// not just the active one (a background tab mid-stream otherwise keeps a
+// phantom "thinking" bubble that handleSessionSwitched surfaces on tab switch).
+// ---------------------------------------------------------------------------
+
+describe('onclose clears transient state across all sessions (#5731 T4)', () => {
+  it('nulls streamingMessageId / plan / inactivity on background sessions too', async () => {
+    const ws = await openConnected()
+
+    // Active session "a" and a background session "b", both mid-stream, with
+    // a pending plan + inactivity chip on the background session.
+    useConnectionStore.setState({
+      activeSessionId: 'a',
+      streamingMessageId: 'msg-a',
+      sessionStates: {
+        a: {
+          messages: [],
+          streamingMessageId: 'msg-a',
+          isPlanPending: false,
+          planAllowedPrompts: [],
+          pendingEvaluatorClarify: null,
+          inactivityWarning: null,
+        },
+        b: {
+          messages: [],
+          streamingMessageId: 'msg-b',
+          isPlanPending: true,
+          planAllowedPrompts: ['go'],
+          pendingEvaluatorClarify: { question: 'why?' },
+          inactivityWarning: { sinceMs: 1 },
+        },
+      } as never,
+    })
+
+    ws.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const st = useConnectionStore.getState()
+    // Active session cleared (and its flat mirror).
+    expect(st.sessionStates.a!.streamingMessageId).toBeNull()
+    expect(st.streamingMessageId).toBeNull()
+    // Background session cleared too — the bug was that it stayed set.
+    expect(st.sessionStates.b!.streamingMessageId).toBeNull()
+    expect(st.sessionStates.b!.isPlanPending).toBe(false)
+    expect(st.sessionStates.b!.planAllowedPrompts).toEqual([])
+    expect(st.sessionStates.b!.pendingEvaluatorClarify).toBeNull()
+    expect(st.sessionStates.b!.inactivityWarning).toBeNull()
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -106,6 +106,7 @@ import {
   clearMessageQueue,
   enqueueMessage,
   updateActiveSession,
+  updateSession,
   clearSavedCredentials,
   loadConnection,
   CLIENT_PROTOCOL_VERSION,
@@ -1667,7 +1668,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
-      updateActiveSession((ss) => {
+      // #5731 T4: clear transient state for EVERY session, not just the
+      // active one. A background tab mid-stream otherwise keeps its
+      // `streamingMessageId` (a phantom "thinking" bubble), pending plan,
+      // inactivity chip, or clarify question across the drop —
+      // `handleSessionSwitched` then surfaces that stale state when the
+      // user switches to the tab post-reconnect. `updateSession` syncs the
+      // active session's flat-state mirror for us, and is a no-op for any
+      // session that returns an empty patch.
+      const clearTransientSessionState = (
+        ss: import('./types').SessionState,
+      ): Partial<import('./types').SessionState> => {
         const patch: Partial<import('./types').SessionState> = {};
         if (ss.streamingMessageId) patch.streamingMessageId = null;
         if (ss.isPlanPending) {
@@ -1687,7 +1698,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         // the next soft-timeout firing will re-emit the warning.
         if (ss.inactivityWarning) patch.inactivityWarning = null;
         return Object.keys(patch).length > 0 ? patch : {};
-      });
+      };
+      for (const sid of Object.keys(get().sessionStates)) {
+        updateSession(sid, clearTransientSessionState);
+      }
 
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
       if (wasConnected && !get().userDisconnected && disconnectedAttemptId !== myAttemptId) {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1677,9 +1677,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // active session's flat-state mirror for us, and is a no-op for any
       // session that returns an empty patch.
       const clearTransientSessionState = (
-        ss: import('./types').SessionState,
-      ): Partial<import('./types').SessionState> => {
-        const patch: Partial<import('./types').SessionState> = {};
+        ss: SessionState,
+      ): Partial<SessionState> => {
+        const patch: Partial<SessionState> = {};
         if (ss.streamingMessageId) patch.streamingMessageId = null;
         if (ss.isPlanPending) {
           patch.isPlanPending = false;


### PR DESCRIPTION
## What

The dashboard `socket.onclose` handler cleared transient per-session UI state — `streamingMessageId`, pending plan, the inactivity check-in chip, and the evaluator-clarify question — for the **active session only**. A background tab that was mid-stream when the socket dropped kept its phantom "thinking" bubble (and any stale plan/inactivity/clarify state) across the reconnect; `handleSessionSwitched` then surfaced that stale state the moment the user switched to that tab.

## Fix

Iterate **every** session in `onclose` instead of only the active one. The clearing logic is unchanged — extracted into a `clearTransientSessionState` updater and applied to each session via `updateSession()`, which already:
- syncs the active session's flat-state mirror (so active-session behaviour is byte-identical to before), and
- is a no-op for any session that returns an empty patch (background sessions with nothing to clear cost nothing).

`onerror` is intentionally untouched — it's covered symmetrically by `onclose` (the close↔error ordering guarantees one runs). `disconnect()` is user-initiated and resets via a full-replay reconnect, out of scope for this drop-path bug.

## Test

`connection-reconnect-backoff.test.ts` gains a case seeding an active session **and** a background session both mid-stream (background also has a pending plan + inactivity chip + clarify question), fires `onclose`, and asserts all four transient fields are cleared on **both** sessions (and the active session's flat mirror).

- Full dashboard suite green (192 files / 3668 tests)
- `tsc --noEmit` clean

#5731 T4. Part of durability epic #5703.