### PR TITLE
fix(ws): re-sync session_role on reconnect so the presence badge isn't stale

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -749,6 +749,23 @@ export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
     }
   }
 
+  // #5731 T5 / #5623 / #5613: re-sync the session's primary owner so the
+  // presence badge ("Observing" / "Take over" / driver name) doesn't go
+  // stale across a reconnect or tab switch. `session_role` is otherwise only
+  // broadcast on an actual primary change (_announcePrimary), so a client
+  // that dropped while a role was assigned would never re-learn it — mirroring
+  // the model / permission-mode / thinking-level re-sync above. Always send:
+  // primaryClientId null (unclaimed) is a valid state the client must be able
+  // to clear a stale role to. Both clients' `session_role` handlers are pure
+  // state-setters (no toast), so re-emitting on every reconnect is idempotent.
+  if (typeof ctx.getPrimary === 'function') {
+    send(ws, {
+      type: 'session_role',
+      sessionId,
+      primaryClientId: ctx.getPrimary(sessionId) ?? null,
+    })
+  }
+
   // #5160: snapshot-on-subscribe for the Control Room activity tree. A fresh
   // subscriber (new client, tab switch, reconnect) gets the full current tree
   // in one `activity_snapshot` so it reaches canonical state without replaying

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -754,9 +754,11 @@ export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
   // stale across a reconnect or tab switch. `session_role` is otherwise only
   // broadcast on an actual primary change (_announcePrimary), so a client
   // that dropped while a role was assigned would never re-learn it — mirroring
-  // the model / permission-mode / thinking-level re-sync above. Always send:
-  // primaryClientId null (unclaimed) is a valid state the client must be able
-  // to clear a stale role to. Both clients' `session_role` handlers are pure
+  // the model / permission-mode / thinking-level re-sync above. When the ctx
+  // exposes getPrimary (always true for production wiring; a legacy/direct
+  // caller without it simply skips this), send unconditionally — including the
+  // unclaimed case as `primaryClientId: null`, a valid payload the client uses
+  // to CLEAR a stale role. Both clients' `session_role` handlers are pure
   // state-setters (no toast), so re-emitting on every reconnect is idempotent.
   if (typeof ctx.getPrimary === 'function') {
     send(ws, {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -792,6 +792,11 @@ export class WsServer {
       // #5563: index-maintaining active-session mutator for the post-auth
       // restore path (ws-history.js sets activeSessionId once per connect).
       setActiveSession: (client, sid) => self._clientManager.setActiveSession(client, sid),
+      // #5731 T5 / #5623 / #5613: current primary owner for a session, so
+      // sendSessionInfo can re-sync `session_role` on reconnect/tab-switch
+      // (otherwise the presence badge goes stale — the role is only ever
+      // broadcast on an actual primary change via _announcePrimary).
+      getPrimary: (sid) => self._clientManager.getPrimary(sid),
       get sessionManager() { return self.sessionManager },
       get cliSession() { return self.cliSession },
       get defaultSessionId() { return self.defaultSessionId },

--- a/packages/server/tests/session-info-role-resync.test.js
+++ b/packages/server/tests/session-info-role-resync.test.js
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createSpy, createMockSessionManager } from './test-helpers.js'
+import { sendSessionInfo } from '../src/ws-history.js'
+// Side-effect: registers built-in providers so getRegistryForProvider() works
+// inside sendSessionInfo (it sends `available_models` keyed on provider).
+import '../src/providers.js'
+
+/**
+ * #5731 T5 / #5623 / #5613 — sendSessionInfo re-syncs `session_role` on
+ * reconnect / tab-switch.
+ *
+ * The presence badge ("Observing" / "Take over" / driver name) is driven by
+ * the `session_role` envelope, which is otherwise only broadcast on an actual
+ * primary change (_announcePrimary). A client that dropped while a role was
+ * assigned would never re-learn it, so the badge went stale across a reconnect.
+ * sendSessionInfo now re-emits the current primary (sourced from
+ * ctx.getPrimary) alongside the existing model / permission-mode / thinking
+ * re-syncs — including the unclaimed (null) case so a client can clear a stale
+ * role.
+ */
+
+function makeCtx(overrides = {}) {
+  const sends = []
+  const ctx = {
+    sessionManager: null,
+    send: createSpy((ws, msg) => sends.push(msg)),
+    ...overrides,
+  }
+  ctx._sends = sends
+  return ctx
+}
+
+function makeFakeWs(readyState = 1) {
+  return { readyState, send: () => {}, close: () => {} }
+}
+
+describe('sendSessionInfo — session_role re-sync (#5731 T5 / #5623)', () => {
+  it('emits session_role with the current primary clientId from ctx.getPrimary', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    const getPrimary = createSpy((sid) => (sid === 'sess-1' ? 'client-abc' : undefined))
+    const ctx = makeCtx({ sessionManager: manager, getPrimary })
+
+    sendSessionInfo(ctx, makeFakeWs(), 'sess-1')
+
+    const roleMsg = ctx._sends.find((m) => m.type === 'session_role')
+    assert.ok(roleMsg, 'session_role was not sent on reconnect/tab-switch')
+    assert.equal(roleMsg.sessionId, 'sess-1')
+    assert.equal(roleMsg.primaryClientId, 'client-abc',
+      'the re-sync must carry the session owner so clients recompute their role')
+  })
+
+  it('emits session_role with primaryClientId null when the session is unclaimed', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    // getPrimary returns undefined for an unclaimed session — the wire must
+    // normalise that to null so a client can CLEAR a stale role (vs leaving
+    // the field absent, which the client treats as "no update").
+    const getPrimary = createSpy(() => undefined)
+    const ctx = makeCtx({ sessionManager: manager, getPrimary })
+
+    sendSessionInfo(ctx, makeFakeWs(), 'sess-1')
+
+    const roleMsg = ctx._sends.find((m) => m.type === 'session_role')
+    assert.ok(roleMsg, 'session_role must still be sent for an unclaimed session')
+    assert.equal(roleMsg.primaryClientId, null,
+      'undefined primary normalises to null so a stale role can be cleared')
+  })
+
+  it('omits session_role when ctx.getPrimary is unavailable (legacy ctx)', () => {
+    // Defensive: a ctx without getPrimary (older wiring / a direct caller)
+    // must not throw — it simply skips the role re-sync.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    const ctx = makeCtx({ sessionManager: manager })
+
+    sendSessionInfo(ctx, makeFakeWs(), 'sess-1')
+
+    assert.equal(ctx._sends.find((m) => m.type === 'session_role'), undefined,
+      'no getPrimary → no session_role (and no throw)')
+  })
+})


### PR DESCRIPTION
## What

`sendSessionInfo` (the reconnect / tab-switch re-sync in `ws-history.js`) already re-emits `model_changed`, `permission_mode_changed`, `thinking_level_changed`, and `permission_rules_updated` so a reconnecting client lands on canonical state. It never re-emitted `session_role`.

`session_role` is otherwise **only** broadcast on an actual primary change (`_announcePrimary`). So a client that dropped while a role was assigned never re-learned it — the presence badge (`Observing` / `Take over` / driver name, driven by `sessionRole` + `primaryClientId`) stayed stale across the reconnect. That's the #5623 / #5613 symptom.

## Fix

- Expose the session's current primary via the history ctx: `getPrimary: (sid) => self._clientManager.getPrimary(sid)` (mirrors the transport ctx already wired for handlers).
- In `sendSessionInfo`, emit a `session_role` re-sync alongside the existing ones, normalising an unclaimed session (`getPrimary` → `undefined`) to `primaryClientId: null` so a client can **clear** a stale role (an absent field is treated as "no update").

### Why it's safe to re-emit on every reconnect

Both clients' `session_role` handlers (`dashboard/src/store/message-handler.ts:4033`, `app/src/store/message-handler.ts:3068`) are **pure state-setters** — they update `sessionRole` + `primaryClientId` and fire no toast/notification. Re-emitting the current primary is idempotent. The defensive `typeof ctx.getPrimary === 'function'` guard means a legacy/direct caller without `getPrimary` simply skips the re-sync (no throw).

## Test

`tests/session-info-role-resync.test.js` (new): asserts `sendSessionInfo` emits `session_role` with the primary from `ctx.getPrimary`, normalises an unclaimed session to `primaryClientId: null`, and omits the message (no throw) when `getPrimary` is absent.

- Related existing suites green (`session-info-booted-model`, `ws-history`, `ws-handler-coverage` — 186 tests).
- Full server suite: 9491/9493 pass. The 2 failures are pre-existing `service.test.js` `:8765` port-probe tests that false-fail against the locally-running Chroxy.app daemon (they assert `health === null`, i.e. *no* server on the default port) — zero references to the changed code; green on CI where no daemon is bound.
- All custom server lints pass (the `ws-index-mutations` hit is the gitignored `dashboard-next/dist` built asset, not tracked source).

#5731 T5. Fixes #5623, #5613. Part of durability epic #5703.