### PR TITLE
fix(session): surface a reason when a fresh session's async start() fails

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -129,6 +129,10 @@ const DEFAULT_WORKTREE_BASE = join(homedir(), '.chroxy', 'worktrees')
  *   session_restore_failed { sessionId, name, provider, cwd, model, permissionMode, errorCode, errorMessage, originalHistoryPreserved, historyLength }
  *     — emitted when a session in the persisted state file fails to restore (e.g. missing env var).
  *       History on disk is preserved so the user can retry after fixing the underlying issue.
+ *   session_create_failed { sessionId, name, provider, cwd, model, errorCode, errorMessage } — #5731 T6:
+ *     a FRESH session whose async provider start() rejected (e.g. claude-tui's PTY failed to spawn).
+ *     The session is fully destroyed (no history to preserve); this carries the reason so the
+ *     forwarder can surface a `session_error` toast before the `session_destroyed` lands.
  *   session_persist_failed { sessionId, name } — #5701: a synchronous flush of a
  *     session-list mutation (create/rename/destroy) failed to write to disk
  *     (disk full / locked file / read-only home), so the change may be lost on
@@ -1072,7 +1076,28 @@ export class SessionManager extends EventEmitter {
     log.error(`Async start() rejected for session ${sessionId}: ${message}${err?.stack ? '\n' + err.stack : ''}`)
 
     if (!entry._isRestore) {
-      // Fresh session — full teardown (removes the freshly-created worktree).
+      // #5731 T6: a fresh session whose async start() rejects (claude-tui's
+      // PTY failing to spawn is the main case) would otherwise vanish with
+      // only a `session_destroyed` — the client that just received
+      // `session_created` + a success ack for createSession gets no reason for
+      // the disappearance. Surface the failure FIRST so the client shows an
+      // error toast, THEN tear down. There's no history worth preserving, so
+      // this stays a full destroy (unlike the restore-rebind path below, which
+      // round-trips history for a retry). Stamp a default code so the message
+      // is consistent with the restore path's START_FAILED.
+      if (err && !err.code) err.code = 'START_FAILED'
+      this.emit('session_create_failed', {
+        sessionId,
+        name: entry.name,
+        provider: entry.provider || this._providerType,
+        cwd: entry.cwd,
+        model: entry.session?.model || null,
+        errorCode: err?.code || 'START_FAILED',
+        errorMessage: message,
+      })
+      // Full teardown (removes the freshly-created worktree). The emit above
+      // ran synchronously, so subscribers received the error while the session
+      // was still mapped, before this broadcasts `session_destroyed`.
       this.destroySession(sessionId)
       return
     }

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -212,6 +212,29 @@ function setupSessionForwarding(normalizer, ctx) {
     broadcast({ type: 'session_persist_failed', ...payload })
   }))
 
+  // #5731 (T6): a FRESH session whose async start() rejected (claude-tui's PTY
+  // failing to spawn) is fully destroyed. Without this the client — which just
+  // got `session_created` + a success ack — would see only `session_destroyed`
+  // and the session would vanish with no reason. Surface it as a per-session
+  // error toast, reusing the existing `session_error` message (both clients
+  // route it to their error toast) rather than minting a new wire type. The
+  // SessionManager emits this synchronously BEFORE `session_destroyed`, so the
+  // session is still mapped here and `broadcastToSession` reaches its
+  // subscribers. recoverable:false — there's no retry affordance for a fresh
+  // session (unlike a failed restore); the user must re-create it.
+  sessionManager.on('session_create_failed', safeForward('session_create_failed', ({ sessionId, errorCode, errorMessage, provider }) => {
+    if (!sessionId) return
+    broadcastToSession(sessionId, {
+      type: 'session_error',
+      code: errorCode || 'SESSION_START_FAILED',
+      sessionId,
+      recoverable: false,
+      message: errorMessage
+        ? `The session failed to start: ${errorMessage}`
+        : `The session failed to start${provider ? ` (${provider})` : ''}.`,
+    })
+  }))
+
   // #5731 (T3): a checkpoint create/delete that couldn't be flushed to disk will
   // be lost (or reappear) on restart. Surface it as a per-session error banner —
   // reuse the existing `session_error` message (both clients route it to their

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2084,6 +2084,38 @@ describe('#5316 (WP-2.2) — async start() rejection handling', () => {
     assert.equal(mgr.getFailedRestores().length, 0, 'no failed-restore for a fresh session')
   })
 
+  it('surfaces session_create_failed BEFORE session_destroyed for a FRESH session (#5731 T6)', async () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const { registerProvider } = await import('../src/providers.js')
+    registerProvider('test-async-fail-fresh-event', AsyncFailProvider)
+
+    // Capture both lifecycle events with order so we can prove the client gets
+    // the REASON (session_create_failed) while the session is still mapped,
+    // before it vanishes (session_destroyed). The forwarder relies on this
+    // ordering to broadcastToSession before subscribers are torn down.
+    const order = []
+    const createFailed = []
+    mgr.on('session_create_failed', (e) => { order.push('create_failed'); createFailed.push(e) })
+    mgr.on('session_destroyed', () => order.push('destroyed'))
+    const restoreFailed = []
+    mgr.on('session_restore_failed', (e) => restoreFailed.push(e))
+
+    const id = mgr.createSession({ cwd: '/tmp', provider: 'test-async-fail-fresh-event', name: 'Doomed' })
+    await tick()
+
+    assert.equal(createFailed.length, 1, 'exactly one session_create_failed for a fresh start failure')
+    assert.equal(restoreFailed.length, 0, 'fresh session must NOT surface as a restore failure')
+    const ev = createFailed[0]
+    assert.equal(ev.sessionId, id)
+    assert.equal(ev.name, 'Doomed')
+    assert.equal(ev.provider, 'test-async-fail-fresh-event')
+    assert.equal(ev.cwd, '/tmp')
+    assert.equal(ev.errorCode, 'START_FAILED', 'code-less Error is stamped START_FAILED')
+    assert.match(ev.errorMessage, /PTY exited during warmup/, 'carries the provider rejection reason')
+    assert.deepEqual(order, ['create_failed', 'destroyed'],
+      'reason is emitted before the session is destroyed so the client can toast it')
+  })
+
   it('PRESERVES restored history + surfaces session_restore_failed for a RESTORED session', async () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
     const { registerProvider } = await import('../src/providers.js')

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -392,6 +392,59 @@ describe('setupForwarding', () => {
     })
   })
 
+  describe('session_create_failed event (#5731 T6)', () => {
+    it('surfaces a fresh-session start failure as a per-session session_error', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_create_failed', {
+        sessionId: 'sess-1',
+        name: 'Doomed',
+        provider: 'claude-tui',
+        cwd: '/tmp',
+        model: null,
+        errorCode: 'START_FAILED',
+        errorMessage: 'claude PTY exited during warmup (code=1)',
+      })
+
+      const call = ctx.broadcastToSession.mock.calls.find(c =>
+        c.arguments[1]?.type === 'session_error' && c.arguments[1]?.code === 'START_FAILED'
+      )
+      assert.ok(call, 'should broadcast a START_FAILED session_error to the session')
+      const [sessionId, msg] = call.arguments
+      assert.equal(sessionId, 'sess-1')
+      assert.equal(msg.sessionId, 'sess-1')
+      assert.equal(msg.recoverable, false, 'fresh-session failure has no retry affordance')
+      assert.match(msg.message, /failed to start/)
+      assert.match(msg.message, /warmup/, 'includes the provider rejection reason when present')
+    })
+
+    it('falls back to SESSION_START_FAILED + provider-named message when fields are sparse', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_create_failed', { sessionId: 'sess-2', provider: 'claude-tui' })
+
+      const call = ctx.broadcastToSession.mock.calls.find(c =>
+        c.arguments[1]?.type === 'session_error' && c.arguments[1]?.sessionId === 'sess-2'
+      )
+      assert.ok(call, 'should still broadcast with default code')
+      const msg = call.arguments[1]
+      assert.equal(msg.code, 'SESSION_START_FAILED')
+      assert.match(msg.message, /\(claude-tui\)/)
+    })
+
+    it('ignores a session_create_failed with no sessionId', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+      ctx.sessionManager.emit('session_create_failed', { errorMessage: 'oops' })
+      const call = ctx.broadcastToSession.mock.calls.find(c =>
+        c.arguments[1]?.type === 'session_error'
+      )
+      assert.equal(call, undefined, 'no broadcast without a session to scope to')
+    })
+  })
+
   // #4756 — `stopped` event surfaces through the normalizer as a
   // `session_stopped` broadcast targeted at subscribers of the affected
   // session (NOT global broadcast). Pairs with the wiring in


### PR DESCRIPTION
## What

When a provider's **async** `start()` rejects — claude-tui's PTY failing to spawn is the primary case, routed through the `#1141` `.catch()` guard to `_handleAsyncStartFailure` — a **fresh** session is fully destroyed. But by that point `createSession` had already returned and emitted `session_created`, and `handleCreateSession` had already sent the client its success ack. So the client saw only a bare `session_destroyed`: the session it just successfully created vanished with **no reason**.

The restore-rebind path already handles this correctly (it emits `session_restore_failed` with the error + preserves history for retry). Only the fresh path was silent.

## Fix

- **`session-manager.js`** — in the fresh branch of `_handleAsyncStartFailure`, emit a new `session_create_failed` event (sessionId, name, provider, cwd, model, errorCode, errorMessage) **before** `destroySession()`. The emit is synchronous, so subscribers receive it while the session is still mapped, ahead of the `session_destroyed` broadcast. A code-less rejection (claude-tui rejects with a bare `Error`) is stamped `START_FAILED`, matching the restore path.
- **`ws-forwarding.js`** — forward `session_create_failed` as a per-session `session_error` (`recoverable: false`), reusing the existing wire type exactly like the `checkpoint_persist_failed` (#5731 T3) and `session_persist_failed` (#5714) paths. No new protocol type, no handler-coverage entry — both clients already route `session_error` to their error toast. `recoverable: false` because a fresh session has no retry affordance (the user must re-create), unlike a failed restore.

The **synchronous** `start()`-throw path is untouched — it already cleans up and `throw`s to `handleCreateSession`, surfacing as an error response (and `session_created` is never emitted in that case).

## Tests

- **`session-manager.test.js`** — new case asserts `session_create_failed` fires exactly once for a fresh async-start failure (and `session_restore_failed` does **not**), carries the right payload + `START_FAILED` code + rejection reason, and is ordered **before** `session_destroyed`.
- **`ws-forwarding.test.js`** — three cases: full payload → `START_FAILED` `session_error` (`recoverable: false`, reason in message); sparse payload → `SESSION_START_FAILED` default + provider-named message; no `sessionId` → no broadcast.

All targeted suites green (259 tests across both files). Full server suite: 9495/9497 pass — the 2 failures are the pre-existing `service.test.js` `:8765` port-probe tests that false-fail against the locally-running Chroxy.app daemon (they assert *no* server answers the default port); zero references to the changed code, green on CI. Custom server lints pass (the `ws-index-mutations` hit is the gitignored `dashboard-next/dist` built asset).

#5731 T6. Part of durability epic #5703.