### PR TITLE
fix(permissions): drain a session's pending HTTP-hook permissions on destroy

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -560,11 +560,20 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     for (const requestId of toDeny) {
       const pending = pendingPermissions.get(requestId)
       if (!pending) continue
+      // Count before resolving: resolve() runs cleanup() (clears the timer +
+      // deletes both maps + releases the inactivity pause) FIRST and only then
+      // writes the HTTP deny response. So even if that response write throws on
+      // an already torn-down socket, the entry IS drained — the leak is gone.
+      // Treat such a throw as a debug-level note (the drain succeeded; only the
+      // best-effort response write failed) rather than a misleading warning on
+      // a mass session-destroy. A pending entry is never already-closed here:
+      // cleanup() deletes it from pendingPermissions, so a closed one wouldn't
+      // be in the map for us to fetch.
+      drained++
       try {
         pending.resolve('deny')
-        drained++
       } catch (err) {
-        log.warn(`Failed to drain pending permission ${requestId} for destroyed session ${sessionId}: ${err?.message || err}`)
+        log.debug(`Pending permission ${requestId} drained for destroyed session ${sessionId}, but the deny response write failed (socket likely gone): ${err?.message || err}`)
       }
     }
     if (drained > 0) {

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -537,6 +537,42 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     }
   }
 
+  /**
+   * #5731 T7: auto-deny + clear any pending HTTP-hook permissions belonging to
+   * a single session. Called when that session is destroyed. Without it, the
+   * hook's POST /permission stays parked on a held response with a 5-min
+   * auto-deny timer: the tool call blocks for the full timeout, then the timer
+   * fires against a session that no longer exists, and the held `res` +
+   * resolve closure leak until then. `resolve('deny')` runs the shared
+   * cleanup() (clears the timer, deletes both maps, sends the deny response,
+   * releases the #2831 inactivity-pause). Collect the ids first so the
+   * resolve→cleanup→delete doesn't mutate permissionSessionMap mid-iteration.
+   * @param {string} sessionId
+   * @returns {number} how many pending permissions were drained
+   */
+  function drainSessionPermissions(sessionId) {
+    if (!sessionId) return 0
+    const toDeny = []
+    for (const [requestId, sid] of permissionSessionMap) {
+      if (sid === sessionId) toDeny.push(requestId)
+    }
+    let drained = 0
+    for (const requestId of toDeny) {
+      const pending = pendingPermissions.get(requestId)
+      if (!pending) continue
+      try {
+        pending.resolve('deny')
+        drained++
+      } catch (err) {
+        log.warn(`Failed to drain pending permission ${requestId} for destroyed session ${sessionId}: ${err?.message || err}`)
+      }
+    }
+    if (drained > 0) {
+      log.info(`Drained ${drained} pending HTTP permission(s) for destroyed session ${sessionId}`)
+    }
+    return drained
+  }
+
   /** Clean up: auto-deny all pending permissions */
   function destroy() {
     for (const [, pending] of pendingPermissions) {
@@ -552,6 +588,7 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     handlePermissionResponseHttp,
     resendPendingPermissions,
     resolvePermission,
+    drainSessionPermissions,
     destroy,
     // #3996: expose the HTTP-permission limiter so /diagnostics can include
     // its eviction stats alongside the three WsServer-owned limiters.

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -934,6 +934,19 @@ export class WsServer {
         } catch (err) {
           log.warn(`Failed to clear checkpoints for destroyed session ${sessionId}: ${err.message}`)
         }
+        // #5731 T7: auto-deny any pending HTTP-hook permission for this session
+        // BEFORE we drop its map entries below. Otherwise the hook's parked
+        // POST /permission blocks the tool call for the full 5-min timeout,
+        // then fires on a destroyed session, leaking the held response until
+        // then. drainSessionPermissions() resolves each as 'deny' (its shared
+        // cleanup also removes the requestId from _permissionSessionMap); the
+        // loop below then only mops up any orphaned mapping with no live
+        // pending entry.
+        try {
+          this._permissions?.drainSessionPermissions?.(sessionId)
+        } catch (err) {
+          log.warn(`Failed to drain pending permissions for destroyed session ${sessionId}: ${err.message}`)
+        }
         for (const [key, sid] of this._permissionSessionMap) {
           if (sid === sessionId) this._permissionSessionMap.delete(key)
         }

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -115,6 +115,70 @@ describe('createPermissionHandler', () => {
     })
   })
 
+  describe('drainSessionPermissions (#5731 T7)', () => {
+    it('auto-denies only the destroyed session\'s pending permissions', () => {
+      const opts = makeHandlerOpts()
+      const { drainSessionPermissions } = createPermissionHandler(opts)
+      const resolveA1 = mock.fn()
+      const resolveA2 = mock.fn()
+      const resolveB = mock.fn()
+      opts.pendingPermissions.set('a1', { resolve: resolveA1, timer: null })
+      opts.pendingPermissions.set('a2', { resolve: resolveA2, timer: null })
+      opts.pendingPermissions.set('b1', { resolve: resolveB, timer: null })
+      opts.permissionSessionMap.set('a1', 'sess-A')
+      opts.permissionSessionMap.set('a2', 'sess-A')
+      opts.permissionSessionMap.set('b1', 'sess-B')
+
+      const drained = drainSessionPermissions('sess-A')
+
+      assert.equal(drained, 2, 'both of sess-A\'s permissions drained')
+      assert.equal(resolveA1.mock.calls[0].arguments[0], 'deny')
+      assert.equal(resolveA2.mock.calls[0].arguments[0], 'deny')
+      assert.equal(resolveB.mock.calls.length, 0, 'sess-B\'s permission left untouched')
+    })
+
+    it('returns 0 and is a no-op for a session with no pending permissions', () => {
+      const opts = makeHandlerOpts()
+      const { drainSessionPermissions } = createPermissionHandler(opts)
+      opts.pendingPermissions.set('b1', { resolve: mock.fn(), timer: null })
+      opts.permissionSessionMap.set('b1', 'sess-B')
+
+      assert.equal(drainSessionPermissions('sess-A'), 0)
+    })
+
+    it('returns 0 for a falsy sessionId without scanning', () => {
+      const opts = makeHandlerOpts()
+      const { drainSessionPermissions } = createPermissionHandler(opts)
+      assert.equal(drainSessionPermissions(undefined), 0)
+      assert.equal(drainSessionPermissions(''), 0)
+    })
+
+    it('skips a mapping whose pending entry is already gone (orphaned map)', () => {
+      const opts = makeHandlerOpts()
+      const { drainSessionPermissions } = createPermissionHandler(opts)
+      // Mapping exists but the pending permission already resolved/expired —
+      // drain must not throw and must report 0 drained for the orphan.
+      opts.permissionSessionMap.set('stale', 'sess-A')
+      assert.equal(drainSessionPermissions('sess-A'), 0)
+    })
+
+    it('counts only the entries it actually resolved when resolve throws', () => {
+      const opts = makeHandlerOpts()
+      const { drainSessionPermissions } = createPermissionHandler(opts)
+      const ok = mock.fn()
+      const boom = mock.fn(() => { throw new Error('socket torn down') })
+      opts.pendingPermissions.set('ok', { resolve: ok, timer: null })
+      opts.pendingPermissions.set('boom', { resolve: boom, timer: null })
+      opts.permissionSessionMap.set('ok', 'sess-A')
+      opts.permissionSessionMap.set('boom', 'sess-A')
+
+      // Must not throw; counts only the successful resolve.
+      const drained = drainSessionPermissions('sess-A')
+      assert.equal(drained, 1)
+      assert.equal(ok.mock.calls.length, 1)
+    })
+  })
+
   describe('resendPendingPermissions', () => {
     it('sends nothing when no pending permissions', () => {
       const opts = makeHandlerOpts()

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -162,20 +162,23 @@ describe('createPermissionHandler', () => {
       assert.equal(drainSessionPermissions('sess-A'), 0)
     })
 
-    it('counts only the entries it actually resolved when resolve throws', () => {
+    it('does not throw and still counts an entry whose resolve write fails', () => {
       const opts = makeHandlerOpts()
       const { drainSessionPermissions } = createPermissionHandler(opts)
       const ok = mock.fn()
+      // In production resolve() runs cleanup() BEFORE the response write, so a
+      // write-throw on a torn-down socket still means the entry was drained —
+      // the drain must swallow the error and count it.
       const boom = mock.fn(() => { throw new Error('socket torn down') })
       opts.pendingPermissions.set('ok', { resolve: ok, timer: null })
       opts.pendingPermissions.set('boom', { resolve: boom, timer: null })
       opts.permissionSessionMap.set('ok', 'sess-A')
       opts.permissionSessionMap.set('boom', 'sess-A')
 
-      // Must not throw; counts only the successful resolve.
       const drained = drainSessionPermissions('sess-A')
-      assert.equal(drained, 1)
+      assert.equal(drained, 2, 'both entries counted as drained (cleanup runs before the write)')
       assert.equal(ok.mock.calls.length, 1)
+      assert.equal(boom.mock.calls.length, 1, 'the throwing resolve was still attempted')
     })
   })
 

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1965,7 +1965,11 @@ describe('WsServer drains pending permissions on session_destroyed (#5731 T7)', 
     // closure mimics the real handler's cleanup (clears the timer + removes
     // both map entries) so the test faithfully exercises the production path.
     let doomedDecision = null
+    // unref() so a failed assertion before the drain clears this can't hold the
+    // event loop open for the full 5 minutes (mirrors the long-fuse timers in
+    // cli-session.test.js).
     const timer = setTimeout(() => {}, 300_000)
+    timer.unref?.()
     server._pendingPermissions.set('req-doomed', {
       resolve: (decision) => {
         doomedDecision = decision

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1934,3 +1934,71 @@ describe('audit trail for auto-deny resolution paths (#3057)', () => {
       'session_destroyed listener must be removed on close()')
   })
 })
+
+// ---------------------------------------------------------------------------
+// #5731 T7 — destroying a session drains its parked HTTP-hook permission
+// ---------------------------------------------------------------------------
+
+describe('WsServer drains pending permissions on session_destroyed (#5731 T7)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('auto-denies a destroyed session\'s parked HTTP permission and leaves other sessions alone', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-doomed', name: 'Doomed', cwd: '/tmp' },
+    ])
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: manager,
+      authRequired: false,
+    })
+    await startServerAndGetPort(server)
+
+    // Seed a parked HTTP-hook permission for the doomed session. The resolve
+    // closure mimics the real handler's cleanup (clears the timer + removes
+    // both map entries) so the test faithfully exercises the production path.
+    let doomedDecision = null
+    const timer = setTimeout(() => {}, 300_000)
+    server._pendingPermissions.set('req-doomed', {
+      resolve: (decision) => {
+        doomedDecision = decision
+        clearTimeout(timer)
+        server._pendingPermissions.delete('req-doomed')
+        server._permissionSessionMap.delete('req-doomed')
+      },
+      timer,
+    })
+    server._permissionSessionMap.set('req-doomed', 'sess-doomed')
+
+    // A permission belonging to a DIFFERENT session must survive the destroy.
+    let otherDecision = null
+    server._pendingPermissions.set('req-other', {
+      resolve: (decision) => { otherDecision = decision },
+      timer: null,
+    })
+    server._permissionSessionMap.set('req-other', 'sess-other')
+
+    // Destroy the session — the WsServer destroy handler must drain its parked
+    // permission instead of leaving the hook's POST /permission wedged for the
+    // full 5-minute auto-deny timeout.
+    manager.emit('session_destroyed', { sessionId: 'sess-doomed' })
+
+    assert.equal(doomedDecision, 'deny',
+      'the destroyed session\'s parked permission is auto-denied')
+    assert.equal(server._pendingPermissions.has('req-doomed'), false,
+      'drained entry removed from _pendingPermissions')
+    assert.equal(server._permissionSessionMap.has('req-doomed'), false,
+      'drained entry removed from _permissionSessionMap')
+    assert.equal(otherDecision, null,
+      'a different session\'s pending permission is untouched')
+    assert.equal(server._pendingPermissions.has('req-other'), true,
+      'the other session\'s permission survives the destroy')
+  })
+})


### PR DESCRIPTION
## What

When a session is destroyed, the WsServer `session_destroyed` handler cleared the permission/question **session maps** (`_permissionSessionMap` / `_questionSessionMap`) but never resolved the actual entries in **`_pendingPermissions`**. A hook's parked `POST /permission` kept its held HTTP response, 5-minute auto-deny `timer`, and `resolve` closure alive. The result:

- the tool call blocked for the **full 5-minute** timeout,
- the timer then fired against a session that no longer existed,
- the held `res` + closure leaked until then.

## Fix

- **`ws-permissions.js`** — add a session-scoped `drainSessionPermissions(sessionId)` to the permission handler. It collects the requestIds mapped to the session (collect-first to avoid mutating `permissionSessionMap` mid-iteration) and calls `pending.resolve('deny')` on each, which runs the **same shared `cleanup()`** a normal resolution does: clears the timer, deletes both maps, sends the `{decision:'deny'}` response, and releases the #2831 inactivity-pause. Returns the drained count; tolerates a throwing `resolve` (torn-down socket) and orphaned mappings.
- **`ws-server.js`** — call `this._permissions?.drainSessionPermissions?.(sessionId)` in the destroy handler **before** the existing `_permissionSessionMap` cleanup loop, which now only mops up any orphaned mapping with no live pending entry. Guarded with `?.` + try/catch so a legacy/partial wiring can't throw in the lifecycle handler.

Scope note: this targets the **WsServer-level HTTP-hook** `_pendingPermissions`. SDK in-process permissions (`session._permissions`) are already cleared by `session.destroy()`. There is no analogous question wedge — questions resolve over WS, not a held HTTP response.

## Tests

- **`ws-permissions.test.js`** — new `drainSessionPermissions` block: denies only the target session's permissions (leaves siblings untouched), returns the count, no-ops for a session with no pending / a falsy sessionId / an orphaned mapping, and counts only successful resolves when one `resolve` throws.
- **`ws-server-permissions.test.js`** — WsServer-level integration test: seed a parked permission for a session (resolve closure mimics the real cleanup) plus one for another session, emit `session_destroyed`, and assert the doomed one is auto-denied and removed from both maps while the other survives.

All targeted permission suites green (112 tests across both files). Full server suite: 9501/9503 pass — the 2 failures are the pre-existing `service.test.js` `:8765` port-probe tests that false-fail against the locally-running Chroxy.app daemon (they assert *no* server answers the default port); zero references to the changed code, green on CI. Custom server lints pass (the `ws-index-mutations` hit is the gitignored `dashboard-next/dist` built asset).

#5731 T7. Part of durability epic #5703.