### PR TITLE
fix(checkpoint): refuse restore when another busy session shares the cwd

### DIFF
--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -5,6 +5,9 @@
  */
 import { realpathSync } from 'fs'
 import { sendSessionError } from '../handler-utils.js'
+import { createLogger } from '../logger.js'
+
+const log = createLogger('ws')
 
 /**
  * Normalize a cwd for collision comparison so two sessions on the SAME physical
@@ -100,21 +103,30 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
   // "two tabs on one repo" case would be more surprising than helpful);
   // worktree-isolated sessions each have a distinct cwd and never collide.
   // listSessions() already excludes sessions mid-destroy. Both accessors are
-  // feature-detected so a partial/legacy manager can't crash the restore path.
-  const checkpointMgr = ctx.services.checkpointManager
-  const sessionMgr = ctx.sessions.sessionManager
-  if (typeof checkpointMgr.getCheckpoint === 'function' && typeof sessionMgr.listSessions === 'function') {
-    const cp = checkpointMgr.getCheckpoint(sid, msg.checkpointId)
-    if (cp?.cwd) {
-      const targetCwd = normalizeCwd(cp.cwd)
-      const busyShare = sessionMgr.listSessions().find(
-        (s) => s.sessionId !== sid && s.isBusy && normalizeCwd(s.cwd) === targetCwd,
-      )
-      if (busyShare) {
-        sendSessionError(ws, ctx, `Cannot restore checkpoint: another session ("${busyShare.name}") is busy in the same working directory and would lose its in-progress changes. Wait for it to finish or interrupt it first.`)
-        return
+  // feature-detected so a partial/legacy manager can't crash the restore path,
+  // and the whole scan is wrapped so an unexpected accessor failure (throw or a
+  // non-array return) fails OPEN — the guard is defense-in-depth, so on its own
+  // error we fall through to the normal restore (the pre-#5731 behaviour) rather
+  // than crashing the WS message handler.
+  try {
+    const checkpointMgr = ctx.services.checkpointManager
+    const sessionMgr = ctx.sessions.sessionManager
+    if (typeof checkpointMgr.getCheckpoint === 'function' && typeof sessionMgr.listSessions === 'function') {
+      const cp = checkpointMgr.getCheckpoint(sid, msg.checkpointId)
+      const liveSessions = sessionMgr.listSessions()
+      if (cp?.cwd && Array.isArray(liveSessions)) {
+        const targetCwd = normalizeCwd(cp.cwd)
+        const busyShare = liveSessions.find(
+          (s) => s && s.sessionId !== sid && s.isBusy && normalizeCwd(s.cwd) === targetCwd,
+        )
+        if (busyShare) {
+          sendSessionError(ws, ctx, `Cannot restore checkpoint: another session ("${busyShare.name}") is busy in the same working directory and would lose its in-progress changes. Wait for it to finish or interrupt it first.`)
+          return
+        }
       }
     }
+  } catch (err) {
+    log.warn(`Shared-cwd restore guard skipped (accessor error, failing open): ${err?.message || err}`)
   }
   try {
     const checkpoint = await ctx.services.checkpointManager.restoreCheckpoint(sid, msg.checkpointId)

--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -71,6 +71,30 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
     sendSessionError(ws, ctx, 'Cannot restore checkpoint while session is busy. Wait for the current task to finish or interrupt first.')
     return
   }
+  // #5731 T8 (confirms deferred #5700): restoring hard-resets the working tree
+  // at the checkpoint's cwd. If ANOTHER non-destroying session shares that cwd
+  // (the default for non-worktree sessions) and is mid-turn, the reset yanks
+  // files out from under its active work. Refuse and name it — mirroring the
+  // current-session busy guard above and the destroy-while-busy guard. Idle
+  // co-located sessions aren't blocked (recoverable, and blocking the common
+  // "two tabs on one repo" case would be more surprising than helpful);
+  // worktree-isolated sessions each have a distinct cwd and never collide.
+  // listSessions() already excludes sessions mid-destroy. Both accessors are
+  // feature-detected so a partial/legacy manager can't crash the restore path.
+  const checkpointMgr = ctx.services.checkpointManager
+  const sessionMgr = ctx.sessions.sessionManager
+  if (typeof checkpointMgr.getCheckpoint === 'function' && typeof sessionMgr.listSessions === 'function') {
+    const cp = checkpointMgr.getCheckpoint(sid, msg.checkpointId)
+    if (cp?.cwd) {
+      const busyShare = sessionMgr.listSessions().find(
+        (s) => s.sessionId !== sid && s.cwd === cp.cwd && s.isBusy,
+      )
+      if (busyShare) {
+        sendSessionError(ws, ctx, `Cannot restore checkpoint: another session ("${busyShare.name}") is busy in the same working directory and would lose its in-progress changes. Wait for it to finish or interrupt it first.`)
+        return
+      }
+    }
+  }
   try {
     const checkpoint = await ctx.services.checkpointManager.restoreCheckpoint(sid, msg.checkpointId)
     const newSessionId = await ctx.sessions.sessionManager.createSession({

--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -3,7 +3,27 @@
  *
  * Handles: create_checkpoint, list_checkpoints, restore_checkpoint, delete_checkpoint
  */
+import { realpathSync } from 'fs'
 import { sendSessionError } from '../handler-utils.js'
+
+/**
+ * Normalize a cwd for collision comparison so two sessions on the SAME physical
+ * directory reached via different strings (trailing slash, symlink, an explicit
+ * path vs the equivalent default) still compare equal. realpathSync resolves
+ * symlinks and drops trailing slashes; if the path doesn't exist (or perms),
+ * fall back to a trailing-slash-stripped form so '/repo' and '/repo/' still
+ * match. Without this the #5731 T8 shared-cwd guard would miss a real collision.
+ * @param {*} p
+ * @returns {*}
+ */
+function normalizeCwd(p) {
+  if (typeof p !== 'string' || !p) return p
+  try {
+    return realpathSync(p)
+  } catch {
+    return p.replace(/\/+$/, '') || p
+  }
+}
 
 async function handleCreateCheckpoint(ws, client, msg, ctx) {
   const sid = client.activeSessionId
@@ -86,8 +106,9 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
   if (typeof checkpointMgr.getCheckpoint === 'function' && typeof sessionMgr.listSessions === 'function') {
     const cp = checkpointMgr.getCheckpoint(sid, msg.checkpointId)
     if (cp?.cwd) {
+      const targetCwd = normalizeCwd(cp.cwd)
       const busyShare = sessionMgr.listSessions().find(
-        (s) => s.sessionId !== sid && s.cwd === cp.cwd && s.isBusy,
+        (s) => s.sessionId !== sid && s.isBusy && normalizeCwd(s.cwd) === targetCwd,
       )
       if (busyShare) {
         sendSessionError(ws, ctx, `Cannot restore checkpoint: another session ("${busyShare.name}") is busy in the same working directory and would lose its in-progress changes. Wait for it to finish or interrupt it first.`)

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -15,6 +15,10 @@ function makeCtx(sessions = new Map(), overrides = {}) {
       getSession: createSpy((id) => sessions.get(id)),
       createSession: createSpy(async () => 'restored-session-id'),
       getHistoryCount: createSpy(() => 5),
+      // #5731 T8: the shared-cwd guard scans the live session list. Default to
+      // only the active session (no co-located sibling) so existing tests don't
+      // trip the guard; the guard tests override this.
+      listSessions: createSpy(() => []),
     },
     checkpointManager: {
       createCheckpoint: createSpy(async () => ({
@@ -26,6 +30,8 @@ function makeCtx(sessions = new Map(), overrides = {}) {
         gitRef: null,
       })),
       listCheckpoints: createSpy(() => []),
+      // #5731 T8: the shared-cwd guard reads the checkpoint's cwd up front.
+      getCheckpoint: createSpy(() => ({ id: 'cp-1', name: 'Checkpoint 1', cwd: '/tmp', resumeSessionId: 'conv-1' })),
       restoreCheckpoint: createSpy(async () => ({
         id: 'cp-1',
         name: 'Checkpoint 1',
@@ -165,6 +171,69 @@ describe('checkpoint-handlers', () => {
       const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
       assert.ok(restored, 'checkpoint_restored not sent')
       assert.equal(restored.newSessionId, 'restored-session-id')
+    })
+
+    // #5731 T8 (confirms deferred #5700) — restoring hard-resets the working
+    // tree at the checkpoint's cwd. Refuse when another non-destroying session
+    // is BUSY in that same cwd (it would lose in-progress work). Idle co-located
+    // sessions are not blocked.
+    describe('shared-cwd busy guard (#5731 T8)', () => {
+      function makeRestoreCtx({ checkpointCwd = '/repo', siblings = [], activeBusy = false }) {
+        const sessions = new Map()
+        const active = createMockSession()
+        active.isRunning = activeBusy
+        sessions.set('s1', { session: active, name: 'Active', cwd: checkpointCwd })
+        sessions.set('restored-session-id', { session: createMockSession(), name: 'Rewind: Checkpoint 1', cwd: checkpointCwd })
+        const ctx = makeCtx(sessions)
+        ctx.services.checkpointManager.getCheckpoint = createSpy(() => ({ id: 'cp-1', name: 'Checkpoint 1', cwd: checkpointCwd, resumeSessionId: 'conv-1' }))
+        ctx.sessions.sessionManager.listSessions = createSpy(() => [
+          { sessionId: 's1', name: 'Active', cwd: checkpointCwd, isBusy: activeBusy },
+          ...siblings,
+        ])
+        return ctx
+      }
+
+      it('refuses (naming the session) when a sibling is BUSY in the same cwd, before any restore', async () => {
+        const ctx = makeRestoreCtx({
+          checkpointCwd: '/repo',
+          siblings: [{ sessionId: 's2', name: 'Sibling', cwd: '/repo', isBusy: true }],
+        })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        const err = ctx._sent.find(m => m.type === 'session_error')
+        assert.ok(err, 'should refuse with a session_error')
+        assert.match(err.message, /Sibling/, 'names the conflicting busy session')
+        assert.match(err.message, /same working directory/)
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 0, 'must NOT hard-reset the shared tree')
+        assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0, 'must NOT create the rewind session')
+      })
+
+      it('allows the restore when the co-located sibling is IDLE', async () => {
+        const ctx = makeRestoreCtx({
+          checkpointCwd: '/repo',
+          siblings: [{ sessionId: 's2', name: 'Sibling', cwd: '/repo', isBusy: false }],
+        })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1)
+        assert.ok(ctx._sent.find(m => m.type === 'checkpoint_restored'), 'restore proceeds for an idle sibling')
+      })
+
+      it('allows the restore when a busy session is in a DIFFERENT cwd', async () => {
+        const ctx = makeRestoreCtx({
+          checkpointCwd: '/repo',
+          siblings: [{ sessionId: 's2', name: 'Elsewhere', cwd: '/other', isBusy: true }],
+        })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1, 'a busy session in another cwd is irrelevant')
+      })
     })
   })
 

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -223,6 +223,23 @@ describe('checkpoint-handlers', () => {
         assert.ok(ctx._sent.find(m => m.type === 'checkpoint_restored'), 'restore proceeds for an idle sibling')
       })
 
+      it('refuses across trailing-slash cwd spellings (normalized comparison)', async () => {
+        // checkpoint cwd '/repo' vs a busy sibling on '/repo/' — these are the
+        // same directory. The paths don't exist on disk, so normalizeCwd falls
+        // back to stripping the trailing slash; the guard must still match.
+        const ctx = makeRestoreCtx({
+          checkpointCwd: '/repo',
+          siblings: [{ sessionId: 's2', name: 'Sibling', cwd: '/repo/', isBusy: true }],
+        })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        const err = ctx._sent.find(m => m.type === 'session_error')
+        assert.ok(err, 'trailing-slash spelling must still be detected as the same cwd')
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 0)
+      })
+
       it('allows the restore when a busy session is in a DIFFERENT cwd', async () => {
         const ctx = makeRestoreCtx({
           checkpointCwd: '/repo',

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -240,6 +240,29 @@ describe('checkpoint-handlers', () => {
         assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 0)
       })
 
+      it('fails OPEN (proceeds, no crash) when a guard accessor throws', async () => {
+        const ctx = makeRestoreCtx({ checkpointCwd: '/repo' })
+        ctx.sessions.sessionManager.listSessions = createSpy(() => { throw new Error('boom') })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        // Must not throw out of the handler; the guard is defense-in-depth.
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1,
+          'a guard-accessor error falls through to the normal restore')
+        assert.ok(ctx._sent.find(m => m.type === 'checkpoint_restored'))
+      })
+
+      it('tolerates a non-array listSessions return', async () => {
+        const ctx = makeRestoreCtx({ checkpointCwd: '/repo' })
+        ctx.sessions.sessionManager.listSessions = createSpy(() => null)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1)
+      })
+
       it('allows the restore when a busy session is in a DIFFERENT cwd', async () => {
         const ctx = makeRestoreCtx({
           checkpointCwd: '/repo',


### PR DESCRIPTION
## What

Restoring a checkpoint **hard-resets the working tree** at the checkpoint's `cwd`. The handler only guarded against the *restoring* session being busy. But when **another** non-worktree session shares that `cwd` (the default) and is mid-turn, the reset yanks files out from under its active work — silently discarding in-progress changes. This is the semantic rug-pull behind deferred **#5700**: the per-cwd mutex prevents git corruption, but not the surprise of one session resetting another's tree.

## Fix

In `handleRestoreCheckpoint`, after the existing current-session busy guard, scan the live session list for another session on the **same cwd** that is **busy**, and refuse the restore — naming the conflicting session so the user knows what to wait for or interrupt. `listSessions()` already excludes sessions mid-destroy ("non-destroying" per the audit).

Design decisions:
- **Busy-only, not any-live.** Idle co-located sessions are *not* blocked — the reset is recoverable, and blocking the common "two tabs on one repo" case would be more surprising than helpful. This mirrors the existing current-session busy guard (which also just refuses, no force flag).
- **Worktree-isolated sessions never collide** — each has a distinct cwd.
- **Feature-detected accessors** (`typeof getCheckpoint === 'function' && typeof listSessions === 'function'`) so a partial/legacy manager can't crash the restore path.

No protocol change, no client change — reuses `session_error`.

## Tests

`tests/handlers/checkpoint-handlers.test.js` gains a `shared-cwd busy guard` block: refuses (naming the session) when a sibling is busy in the same cwd *before any restore/createSession*, allows the restore when the co-located sibling is idle, and allows it when a busy session is in a different cwd. The shared mock now provides `getCheckpoint` + `listSessions` so the guard path is exercised; existing tests default `listSessions` to no siblings.

All checkpoint + ws-server suites green (133 tests). Full server suite: 9474/9476 pass — the 2 failures are the pre-existing `service.test.js` `:8765` port-probe tests that false-fail against the locally-running Chroxy.app daemon (assert *no* server answers the default port); zero references to the changed code, green on CI. Custom server lints pass (the `ws-index-mutations` hit is the gitignored `dashboard-next/dist` built asset).

#5731 T8. Part of durability epic #5703.