### PR TITLE
fix(settings): optimistic update + revert for thinking-level switch

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -118,6 +118,8 @@ import {
   registerModelChangeRequest,
   clearPendingModelReverts,
   registerPermissionModeChangeRequest,
+  registerThinkingLevelChangeRequest,
+  clearPendingThinkingLevelReverts,
   clearPendingPermissionModeReverts,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
@@ -1639,6 +1641,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       clearPendingTrustGrants();
       clearPendingModelReverts();
       clearPendingPermissionModeReverts();
+      clearPendingThinkingLevelReverts();
       // #3605: also clear the per-session pendingTrustGrants arrays
       // (added in #3588). disconnect() handles user-initiated closes, but
       // an unexpected drop here would otherwise leave the SkillsPanel
@@ -1750,6 +1753,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       clearPendingTrustGrants();
       clearPendingModelReverts();
       clearPendingPermissionModeReverts();
+      clearPendingThinkingLevelReverts();
       const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
 
       set({ socket: null, sessionStates: cleanedSessionStates });
@@ -1784,6 +1788,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     clearPendingTrustGrants();
     clearPendingModelReverts();
     clearPendingPermissionModeReverts();
+    clearPendingThinkingLevelReverts();
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -2581,10 +2586,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   setThinkingLevel: (level: string) => {
     const { socket, activeSessionId } = get();
+    // #5731 T9: remember the level we're switching FROM, keyed by a requestId the
+    // server echoes on a THINKING_LEVEL_NOT_APPLIED rejection, so the error
+    // handler can roll the optimistic update below back instead of leaving the
+    // dropdown showing a level the session never entered. Read the live value,
+    // mirroring the optimistic write below. (Sibling of setModel/setPermissionMode.)
+    const previousLevel = (activeSessionId && get().sessionStates[activeSessionId])
+      ? (get().sessionStates[activeSessionId]!.thinkingLevel ?? 'default')
+      : 'default';
+    const requestId = `set-thinking-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: Record<string, unknown> = { type: 'set_thinking_level', level };
+      registerThinkingLevelChangeRequest(requestId, { sessionId: activeSessionId, previousLevel });
+      const payload: Record<string, unknown> = { type: 'set_thinking_level', level, requestId };
       if (activeSessionId) payload.sessionId = activeSessionId;
       wsSend(socket, payload);
+    }
+    // Optimistically update the active session's thinking level so the controlled
+    // `<select>` doesn't snap back to the prior value before the server's
+    // `thinking_level_changed` broadcast lands. Idempotent — the broadcast
+    // re-sets the same value when it arrives. thinkingLevel is per-session only.
+    if (activeSessionId && get().sessionStates[activeSessionId]) {
+      updateActiveSession(() => ({ thinkingLevel: level as SessionState['thinkingLevel'] }));
     }
   },
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -41,6 +41,9 @@ import {
   registerPermissionModeChangeRequest,
   clearPendingPermissionModeReverts,
   _testPermissionModeRevertPendingSize,
+  registerThinkingLevelChangeRequest,
+  clearPendingThinkingLevelReverts,
+  _testThinkingLevelRevertPendingSize,
   setDeltaFlushIntervalOverride,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
@@ -650,6 +653,60 @@ describe('dashboard message-handler dispatch', () => {
         expect(_testPermissionModeRevertPendingSize()).toBe(2)
         clearPendingPermissionModeReverts()
         expect(_testPermissionModeRevertPendingSize()).toBe(0)
+      })
+    })
+
+    // #5731 T9 (sibling of #5711/#5716): set_thinking_level is optimistic too; a
+    // THINKING_LEVEL_NOT_APPLIED rejection (invalid level, provider without
+    // thinking-level control, or a setThinkingLevel throw) must roll the dropdown
+    // back instead of leaving it on a level the session never entered.
+    describe('THINKING_LEVEL_NOT_APPLIED revert (#5731 T9)', () => {
+      afterEach(() => { clearPendingThinkingLevelReverts() })
+
+      it('reverts the optimistic thinkingLevel for the rejected request\'s session', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessionStates: { s1: { ...createEmptySessionState(), thinkingLevel: 'high' } }, // optimistic value
+          }),
+        )
+        setStore(store)
+        registerThinkingLevelChangeRequest('set-thinking-1', { sessionId: 's1', previousLevel: 'default' })
+
+        handleMessage(
+          { type: 'error', requestId: 'set-thinking-1', code: 'THINKING_LEVEL_NOT_APPLIED', message: 'provider does not support thinking level control' },
+          ctx() as any,
+        )
+
+        expect((store.getState() as any).sessionStates.s1.thinkingLevel).toBe('default') // rolled back
+        expect(_testThinkingLevelRevertPendingSize()).toBe(0) // consumed
+      })
+
+      it('does NOT revert when the error requestId does not match a pending change', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessionStates: { s1: { ...createEmptySessionState(), thinkingLevel: 'max' } },
+          }),
+        )
+        setStore(store)
+        registerThinkingLevelChangeRequest('set-thinking-1', { sessionId: 's1', previousLevel: 'default' })
+
+        handleMessage(
+          { type: 'error', requestId: 'other', code: 'THINKING_LEVEL_NOT_APPLIED', message: 'x' },
+          ctx() as any,
+        )
+
+        expect((store.getState() as any).sessionStates.s1.thinkingLevel).toBe('max') // untouched
+        expect(_testThinkingLevelRevertPendingSize()).toBe(1) // still pending
+      })
+
+      it('clears all pending reverts on disconnect', () => {
+        registerThinkingLevelChangeRequest('req-a', { sessionId: 's1', previousLevel: 'default' })
+        registerThinkingLevelChangeRequest('req-b', { sessionId: 's2', previousLevel: 'high' })
+        expect(_testThinkingLevelRevertPendingSize()).toBe(2)
+        clearPendingThinkingLevelReverts()
+        expect(_testThinkingLevelRevertPendingSize()).toBe(0)
       })
     })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -398,6 +398,51 @@ export function _testPermissionModeRevertPendingSize(): number {
   return _pendingPermissionModeReverts.size;
 }
 
+// #5731 T9 (sibling of #5711/#5716): set_thinking_level is also applied
+// OPTIMISTICALLY (the dropdown flips immediately in setThinkingLevel) so it
+// doesn't snap back before the server's thinking_level_changed broadcast lands.
+// The server may reject it (THINKING_LEVEL_NOT_APPLIED — an invalid level, a
+// provider without thinking-level control, or setThinkingLevel throwing), in
+// which case the dropdown would otherwise stay on a level the session never
+// entered. Remember the level we switched FROM, keyed by the set_thinking_level
+// requestId the server echoes on its error, so the `error` handler can roll the
+// optimistic update back. Cleared on the matching error or on disconnect — NOT
+// on success (the server sends thinking_level_changed XOR error per requestId,
+// so clearing on success would drop a second in-flight revert, the #5715 class).
+// Bounded FIFO like the model/permission-mode revert maps.
+interface PendingThinkingLevelRevert {
+  sessionId: string | null;
+  previousLevel: string | null;
+}
+
+const _pendingThinkingLevelReverts = new Map<string, PendingThinkingLevelRevert>();
+const THINKING_LEVEL_REVERT_PENDING_CAP = 16;
+
+export function registerThinkingLevelChangeRequest(requestId: string, entry: PendingThinkingLevelRevert): void {
+  if (_pendingThinkingLevelReverts.size >= THINKING_LEVEL_REVERT_PENDING_CAP) {
+    const oldestKey = _pendingThinkingLevelReverts.keys().next().value;
+    if (oldestKey !== undefined) _pendingThinkingLevelReverts.delete(oldestKey);
+  }
+  _pendingThinkingLevelReverts.set(requestId, { ...entry });
+}
+
+function consumePendingThinkingLevelRevert(requestId: string): PendingThinkingLevelRevert | null {
+  const entry = _pendingThinkingLevelReverts.get(requestId);
+  if (!entry) return null;
+  _pendingThinkingLevelReverts.delete(requestId);
+  return entry;
+}
+
+/** Clear all pending thinking-level reverts — called on WebSocket close. */
+export function clearPendingThinkingLevelReverts(): void {
+  _pendingThinkingLevelReverts.clear();
+}
+
+/** @internal test seam. */
+export function _testThinkingLevelRevertPendingSize(): number {
+  return _pendingThinkingLevelReverts.size;
+}
+
 /** @internal Exposed for tests so they can inspect the in-flight map. */
 export function _testTrustGrantPendingSize(): number {
   return _pendingTrustGrants.size;
@@ -4543,6 +4588,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           if (revert.priorPreviousMode !== undefined && get().previousPermissionMode === revert.previousMode) {
             set({ previousPermissionMode: revert.priorPreviousMode });
           }
+        }
+      }
+      // #5731 T9: roll back the optimistic set_thinking_level when the server
+      // says it never applied (THINKING_LEVEL_NOT_APPLIED — invalid level,
+      // provider without thinking-level control, or a setThinkingLevel throw).
+      // thinkingLevel is per-session only (no flat ConnectionState mirror, unlike
+      // activeModel/permissionMode), so the revert writes to the session state —
+      // matching setThinkingLevel's optimistic updateActiveSession write.
+      if (errCode === 'THINKING_LEVEL_NOT_APPLIED' && errReqId) {
+        const revert = consumePendingThinkingLevelRevert(errReqId);
+        if (revert?.sessionId && get().sessionStates[revert.sessionId]) {
+          updateSession(revert.sessionId, () => ({ thinkingLevel: (revert.previousLevel ?? 'default') as SessionState['thinkingLevel'] }));
         }
       }
       // #3570: skill_trust_grant INVALID_AUTHOR carries a structured

--- a/packages/dashboard/src/store/permission-mode-optimistic.test.ts
+++ b/packages/dashboard/src/store/permission-mode-optimistic.test.ts
@@ -114,4 +114,23 @@ describe('#3693 — optimistic permission/model update', () => {
     const after = useConnectionStore.getState().sessionStates[sessionId]!
     expect(after.activeModel).toBe('claude-opus-4-7')
   })
+
+  // #5731 T9 — setThinkingLevel is optimistic too (the dropdown must not snap
+  // back while the WS round-trip is in flight).
+  it('setThinkingLevel updates active sessionState immediately', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sessionId = 'sess-4'
+    const ss = createEmptySessionState()
+    ss.thinkingLevel = 'default'
+    useConnectionStore.setState({
+      activeSessionId: sessionId,
+      sessionStates: { [sessionId]: ss },
+      socket: null,
+    })
+
+    useConnectionStore.getState().setThinkingLevel('high')
+
+    const after = useConnectionStore.getState().sessionStates[sessionId]!
+    expect(after.thinkingLevel).toBe('high')
+  })
 })

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -1340,17 +1340,31 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
 const VALID_THINKING_LEVELS = new Set(['default', 'high', 'max'])
 
 async function handleSetThinkingLevel(ws, client, msg, ctx) {
+  // #5731 T9: every rejection path echoes the client's requestId with a single
+  // THINKING_LEVEL_NOT_APPLIED code so the dashboard rolls back its optimistic
+  // dropdown update (mirrors set_model's MODEL_NOT_APPLIED and
+  // set_permission_mode's PERMISSION_MODE_NOT_APPLIED). The capability check is
+  // inlined (rather than routed through requireSessionMethod) so the
+  // unsupported-provider rejection carries the requestId + code too — otherwise
+  // a no-op on a provider without thinking-level control would leave the
+  // dropdown stuck on a level the session never entered. requestId is optional
+  // (older clients omit it); sendError tolerates null.
+  const requestId = msg?.requestId
   const level = typeof msg.level === 'string' ? msg.level.trim() : ''
   if (!VALID_THINKING_LEVELS.has(level)) {
-    sendSessionError(ws, ctx, `Invalid thinking level: ${level}`)
+    sendError(ws, requestId, 'THINKING_LEVEL_NOT_APPLIED', `Invalid thinking level: ${level}`, undefined, ctx)
     return
   }
 
   const sessionId = msg.sessionId || client.activeSessionId
-  const entry = resolveSessionOrError(ws, ctx, msg, client)
-  if (!entry) return
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    sendError(ws, requestId, 'THINKING_LEVEL_NOT_APPLIED', 'No active session', undefined, ctx)
+    return
+  }
 
-  if (!requireSessionMethod(ws, ctx, entry, 'setThinkingLevel', 'This provider does not support thinking level control')) {
+  if (!entry.session || typeof entry.session.setThinkingLevel !== 'function') {
+    sendError(ws, requestId, 'THINKING_LEVEL_NOT_APPLIED', 'This provider does not support thinking level control', undefined, ctx)
     return
   }
 
@@ -1358,7 +1372,7 @@ async function handleSetThinkingLevel(ws, client, msg, ctx) {
     await entry.session.setThinkingLevel(level)
     ctx.transport.broadcastToSession(sessionId, { type: 'thinking_level_changed', level })
   } catch (err) {
-    sendSessionError(ws, ctx, `Failed to set thinking level: ${err.message}`)
+    sendError(ws, requestId, 'THINKING_LEVEL_NOT_APPLIED', `Failed to set thinking level: ${err.message}`, undefined, ctx)
   }
 }
 

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -2342,4 +2342,78 @@ describe('settings-handlers', () => {
       }
     })
   })
+
+  // #5731 T9 — set_thinking_level is applied optimistically client-side; every
+  // rejection path must echo the requestId with THINKING_LEVEL_NOT_APPLIED so the
+  // dashboard rolls the dropdown back (mirrors set_model's MODEL_NOT_APPLIED).
+  describe('set_thinking_level', () => {
+    function sessionWithThinking(supported = true) {
+      const session = createMockSession()
+      if (supported) {
+        session.setThinkingLevel = createSpy(async () => {})
+      } else {
+        delete session.setThinkingLevel
+      }
+      return session
+    }
+
+    it('calls session.setThinkingLevel and broadcasts thinking_level_changed on success', async () => {
+      const sessions = new Map()
+      sessions.set('s1', { session: sessionWithThinking(true), name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await settingsHandlers.set_thinking_level(makeWs(), client, { level: 'high', requestId: 'r1' }, ctx)
+
+      assert.equal(ctx._sessionBroadcasts.length, 1)
+      assert.equal(ctx._sessionBroadcasts[0].msg.type, 'thinking_level_changed')
+      assert.equal(ctx._sessionBroadcasts[0].msg.level, 'high')
+      assert.equal(ctx._sent.filter((m) => m.type === 'error').length, 0)
+    })
+
+    it('rejects an invalid level with THINKING_LEVEL_NOT_APPLIED echoing the requestId', async () => {
+      const sessions = new Map()
+      sessions.set('s1', { session: sessionWithThinking(true), name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const ws = makeWs()
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await settingsHandlers.set_thinking_level(ws, client, { level: 'bogus', requestId: 'r-bad' }, ctx)
+
+      assert.equal(ws._messages[0].type, 'error')
+      assert.equal(ws._messages[0].code, 'THINKING_LEVEL_NOT_APPLIED')
+      assert.equal(ws._messages[0].requestId, 'r-bad')
+    })
+
+    it('rejects an unsupported provider with THINKING_LEVEL_NOT_APPLIED + requestId (revert-correlatable)', async () => {
+      const sessions = new Map()
+      sessions.set('s1', { session: sessionWithThinking(false), name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const ws = makeWs()
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await settingsHandlers.set_thinking_level(ws, client, { level: 'high', requestId: 'r-unsup' }, ctx)
+
+      assert.equal(ws._messages[0].type, 'error')
+      assert.equal(ws._messages[0].code, 'THINKING_LEVEL_NOT_APPLIED')
+      assert.equal(ws._messages[0].requestId, 'r-unsup')
+      assert.equal(ctx._sessionBroadcasts.length, 0, 'no broadcast on rejection')
+    })
+
+    it('surfaces a setThinkingLevel throw as THINKING_LEVEL_NOT_APPLIED + requestId', async () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.setThinkingLevel = createSpy(async () => { throw new Error('pty gone') })
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const ws = makeWs()
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await settingsHandlers.set_thinking_level(ws, client, { level: 'max', requestId: 'r-throw' }, ctx)
+
+      assert.equal(ws._messages[0].code, 'THINKING_LEVEL_NOT_APPLIED')
+      assert.equal(ws._messages[0].requestId, 'r-throw')
+      assert.match(ws._messages[0].message, /pty gone/)
+    })
+  })
 })


### PR DESCRIPTION
## What

`setThinkingLevel` sent `set_thinking_level` to the server but **never updated local state**, so the controlled `<select>` in the chat-settings dropdown snapped back to the prior value until the server's `thinking_level_changed` broadcast landed — and **stayed wrong with no correction** if the server rejected the change (unsupported provider, a `setThinkingLevel` throw). It was the last of the model (#5711) / permission-mode (#5716) optimistic-update siblings missing this treatment (the deferred Tier-2 item from the #5731 audit).

## Fix (mirrors #5711 / #5716)

**Server** (`handleSetThinkingLevel`): every rejection path now echoes the client's `requestId` with a single `THINKING_LEVEL_NOT_APPLIED` code, instead of a generic `session_error` with no correlation. The capability check is **inlined** (rather than routed through the shared `requireSessionMethod`/`resolveSessionOrError` helpers, which emit a code-less `session_error`) so the unsupported-provider and no-session rejections carry the `requestId` + code too — otherwise a no-op on a provider without thinking-level control would leave the dropdown stuck.

**Dashboard**:
- `setThinkingLevel` optimistically updates the active session's `thinkingLevel` and registers a revert keyed by `requestId`.
- The `error` handler rolls it back on `THINKING_LEVEL_NOT_APPLIED`.
- `thinkingLevel` is **per-session only** (no flat `ConnectionState` mirror, unlike `activeModel`/`permissionMode`), so the optimistic write and revert use only the session-state path.
- The pending-revert map is a bounded FIFO (cap 16) cleared on disconnect (onclose/onerror/disconnect), exactly like its siblings — and cleared on the matching error, **not** on success (the server sends `thinking_level_changed` XOR `error` per requestId; clearing on success would drop a second in-flight revert, the #5715 class).

**No protocol change** — `requestId` rides `set_thinking_level`'s existing `.passthrough()`, the same mechanism `set_model`/`set_permission_mode` use.

## Tests

- **Server** (`settings-handlers.test.js`): success broadcasts `thinking_level_changed` with no error; invalid level, unsupported provider, and a `setThinkingLevel` throw each emit `THINKING_LEVEL_NOT_APPLIED` echoing the `requestId` (and no broadcast on rejection).
- **Dashboard** (`message-handler.test.ts`): `THINKING_LEVEL_NOT_APPLIED` reverts the optimistic `thinkingLevel` for the matching request's session, doesn't touch a non-matching requestId, and clears all pending on disconnect. (`permission-mode-optimistic.test.ts`): `setThinkingLevel` updates the active session state immediately.

Full server suite (9484/9486 — the 2 failures are the pre-existing `service.test.js` `:8765` probes that false-fail against the locally-running daemon; green on CI), dashboard `tsc` + 3672 tests, and store-core 1488 tests all green. Custom server lints pass.

#5731 (Tier 2). Part of durability epic #5703.