### PR TITLE
fix(dev-preview): surface a tunnel-stop failure instead of faking a clean stop

### DIFF
--- a/packages/server/src/dev-preview.js
+++ b/packages/server/src/dev-preview.js
@@ -18,9 +18,10 @@ const log = createLogger('dev-preview')
  *   - Manual close via closePreview()
  *
  * Events emitted:
- *   dev_preview_started  { sessionId, port, url }
- *   dev_preview_stopped  { sessionId, port }
- *   dev_preview_error    { sessionId, port, error }
+ *   dev_preview_started     { sessionId, port, url }
+ *   dev_preview_stopped     { sessionId, port }
+ *   dev_preview_error       { sessionId, port, error }   — tunnel START failure
+ *   dev_preview_stop_failed { sessionId, port, error }   — tunnel STOP failure (#5731)
  */
 
 // Patterns that indicate a dev server started on localhost

--- a/packages/server/src/dev-preview.js
+++ b/packages/server/src/dev-preview.js
@@ -169,9 +169,12 @@ export class DevPreviewManager extends EventEmitter {
 
     if (stopError) {
       // Surface it so the user can verify / kill cloudflared manually instead of
-      // assuming the port is no longer exposed.
-      log.error(`Failed to stop tunnel for session ${sessionId} port ${port}: ${stopError.message}`)
-      this.emit('dev_preview_stop_failed', { sessionId, port, error: stopError.message })
+      // assuming the port is no longer exposed. Normalize the message — a promise
+      // rejection isn't guaranteed to be an Error (could be a string/null), so
+      // `.message` alone can drop the actual detail.
+      const stopMsg = stopError?.message || String(stopError)
+      log.error(`Failed to stop tunnel for session ${sessionId} port ${port}: ${stopMsg}${stopError?.stack ? '\n' + stopError.stack : ''}`)
+      this.emit('dev_preview_stop_failed', { sessionId, port, error: stopMsg })
     } else {
       log.info(`Tunnel stopped for session ${sessionId} port ${port}`)
     }

--- a/packages/server/src/dev-preview.js
+++ b/packages/server/src/dev-preview.js
@@ -145,18 +145,36 @@ export class DevPreviewManager extends EventEmitter {
     const tunnel = this._getTunnel(sessionId, port)
     if (!tunnel) return
 
+    // #5731: capture (don't swallow) a stop() failure. The previous code
+    // signalled a clean stop unconditionally — if tunnel.stop() threw, the
+    // public tunnel (and thus the exposed local port) could still be live while
+    // the user was told it was shut down.
+    let stopError = null
     try {
       await tunnel.stop()
-    } catch { /* ignore */ }
+    } catch (err) {
+      stopError = err
+    }
 
+    // Drop our tracking entry regardless: the tunnel handle is unusable for a
+    // retry whether or not stop() succeeded, so keeping it would only wedge the
+    // port slot. The UI still gets dev_preview_stopped so it doesn't show a
+    // phantom live preview.
     const sessionTunnels = this._tunnels.get(sessionId)
     if (sessionTunnels) {
       sessionTunnels.delete(port)
       if (sessionTunnels.size === 0) this._tunnels.delete(sessionId)
     }
 
+    if (stopError) {
+      // Surface it so the user can verify / kill cloudflared manually instead of
+      // assuming the port is no longer exposed.
+      log.error(`Failed to stop tunnel for session ${sessionId} port ${port}: ${stopError.message}`)
+      this.emit('dev_preview_stop_failed', { sessionId, port, error: stopError.message })
+    } else {
+      log.info(`Tunnel stopped for session ${sessionId} port ${port}`)
+    }
     this.emit('dev_preview_stopped', { sessionId, port })
-    log.info(`Tunnel stopped for session ${sessionId} port ${port}`)
   }
 
   /**

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -261,6 +261,21 @@ function setupSessionForwarding(normalizer, ctx) {
   devPreview.on('dev_preview_stopped', safeForward('dev_preview_stopped', ({ sessionId, port }) => {
     broadcastToSession(sessionId, { type: 'dev_preview_stopped', port })
   }))
+  // #5731: a tunnel.stop() that failed during closePreview — the public tunnel
+  // (and the exposed local port) may still be live. Surface it as a per-session
+  // error banner (reusing `session_error`, like the checkpoint/persist failure
+  // paths) so the user can verify / kill cloudflared instead of assuming the
+  // port is closed. recoverable:true — informational; the slot is already freed.
+  devPreview.on('dev_preview_stop_failed', safeForward('dev_preview_stop_failed', ({ sessionId, port, error }) => {
+    if (!sessionId) return
+    broadcastToSession(sessionId, {
+      type: 'session_error',
+      code: 'DEV_PREVIEW_STOP_FAILED',
+      sessionId,
+      recoverable: true,
+      message: `Couldn't fully stop the preview tunnel on port ${port} — it may still be exposed. Check the daemon logs and kill cloudflared manually if needed.${error ? ` (${error})` : ''}`,
+    })
+  }))
 
   // Dev server preview: cleanup on session destroy
   sessionManager.on('session_destroyed', safeForward('session_destroyed', ({ sessionId }) => {

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -363,6 +363,20 @@ function setupCliForwarding(normalizer, ctx) {
       broadcast({ type: 'dev_preview_stopped', port })
     }
   }))
+  // #5731: same don't-claim-a-clean-stop surfacing on the legacy CLI path — a
+  // failed tunnel.stop() must not be silently dropped here either. Global
+  // broadcast (CLI is single-session) so the lone client learns the port may
+  // still be exposed.
+  devPreview.on('dev_preview_stop_failed', safeForward('cli:dev_preview_stop_failed', ({ sessionId, port, error }) => {
+    if (sessionId === '__legacy__') {
+      broadcast({
+        type: 'session_error',
+        code: 'DEV_PREVIEW_STOP_FAILED',
+        recoverable: true,
+        message: `Couldn't fully stop the preview tunnel on port ${port} — it may still be exposed. Check the daemon logs and kill cloudflared manually if needed.${error ? ` (${error})` : ''}`,
+      })
+    }
+  }))
 
   // models_updated bypasses normalizer — global broadcast.
   // CLI mode is always a Claude session; include provider so clients can

--- a/packages/server/tests/dev-preview.test.js
+++ b/packages/server/tests/dev-preview.test.js
@@ -356,4 +356,51 @@ describe('DevPreviewManager', () => {
       assert.equal(manager._tunnels.size, 0)
     })
   })
+
+  // #5731 — closePreview must NOT signal a clean stop when tunnel.stop() fails;
+  // the public tunnel (exposed port) may still be live, so it surfaces a
+  // dev_preview_stop_failed event instead of silently swallowing the error.
+  describe('closePreview stop-failure (#5731)', () => {
+    it('emits dev_preview_stop_failed AND dev_preview_stopped when stop() throws, and frees the slot', async () => {
+      const events = []
+      manager.on('dev_preview_stop_failed', (e) => events.push({ type: 'stop_failed', ...e }))
+      manager.on('dev_preview_stopped', (e) => events.push({ type: 'stopped', ...e }))
+      manager._tunnels.set('sess-1', new Map([
+        [3000, { stop: async () => { throw new Error('cloudflared kill failed') }, url: 'https://a.trycloudflare.com' }],
+      ]))
+
+      await manager.closePreview('sess-1', 3000)
+
+      const failed = events.find((e) => e.type === 'stop_failed')
+      assert.ok(failed, 'dev_preview_stop_failed must be emitted on a stop() failure')
+      assert.equal(failed.sessionId, 'sess-1')
+      assert.equal(failed.port, 3000)
+      assert.match(failed.error, /cloudflared kill failed/)
+      assert.ok(events.find((e) => e.type === 'stopped'), 'dev_preview_stopped still emitted so the UI updates')
+      assert.equal(manager._tunnels.has('sess-1'), false, 'tracking slot is freed even on stop failure')
+    })
+
+    it('emits only dev_preview_stopped (no stop_failed) on a clean stop', async () => {
+      const events = []
+      manager.on('dev_preview_stop_failed', (e) => events.push({ type: 'stop_failed', ...e }))
+      manager.on('dev_preview_stopped', (e) => events.push({ type: 'stopped', ...e }))
+      manager._tunnels.set('sess-1', new Map([
+        [3000, { stop: async () => {}, url: 'https://a.trycloudflare.com' }],
+      ]))
+
+      await manager.closePreview('sess-1', 3000)
+
+      assert.equal(events.filter((e) => e.type === 'stop_failed').length, 0, 'no stop_failed on a clean stop')
+      assert.equal(events.filter((e) => e.type === 'stopped').length, 1)
+      assert.equal(manager._tunnels.has('sess-1'), false)
+    })
+
+    it('is a no-op for an unknown tunnel', async () => {
+      const events = []
+      manager.on('dev_preview_stop_failed', () => events.push('failed'))
+      manager.on('dev_preview_stopped', () => events.push('stopped'))
+      await manager.closePreview('nope', 9999)
+      assert.equal(events.length, 0)
+    })
+  })
 })

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -445,6 +445,35 @@ describe('setupForwarding', () => {
     })
   })
 
+  describe('dev_preview_stop_failed event (#5731)', () => {
+    it('surfaces a tunnel-stop failure as a per-session session_error', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.devPreview.emit('dev_preview_stop_failed', { sessionId: 'sess-1', port: 3000, error: 'kill failed' })
+
+      const call = ctx.broadcastToSession.mock.calls.find(c =>
+        c.arguments[1]?.type === 'session_error' && c.arguments[1]?.code === 'DEV_PREVIEW_STOP_FAILED'
+      )
+      assert.ok(call, 'should broadcast a DEV_PREVIEW_STOP_FAILED session_error to the session')
+      const [sessionId, msg] = call.arguments
+      assert.equal(sessionId, 'sess-1')
+      assert.equal(msg.recoverable, true)
+      assert.match(msg.message, /port 3000/)
+      assert.match(msg.message, /may still be exposed/)
+    })
+
+    it('ignores a dev_preview_stop_failed with no sessionId', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+      ctx.devPreview.emit('dev_preview_stop_failed', { port: 3000, error: 'x' })
+      const call = ctx.broadcastToSession.mock.calls.find(c =>
+        c.arguments[1]?.type === 'session_error' && c.arguments[1]?.code === 'DEV_PREVIEW_STOP_FAILED'
+      )
+      assert.equal(call, undefined)
+    })
+  })
+
   // #4756 — `stopped` event surfaces through the normalizer as a
   // `session_stopped` broadcast targeted at subscribers of the affected
   // session (NOT global broadcast). Pairs with the wiring in

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -651,6 +651,32 @@ describe('setupCliForwarding', () => {
     assert.equal(ctx.broadcast.mock.calls.length, 0)
   })
 
+  // #5731: legacy CLI path must also surface a tunnel-stop failure (global
+  // broadcast) instead of silently claiming a clean stop.
+  it('broadcasts a DEV_PREVIEW_STOP_FAILED session_error for a legacy stop failure', () => {
+    const ctx = makeCliCtx()
+    setupForwarding(ctx)
+
+    ctx.devPreview.emit('dev_preview_stop_failed', { sessionId: '__legacy__', port: 3000, error: 'kill failed' })
+
+    const calls = ctx.broadcast.mock.calls.map(c => c.arguments[0])
+    const errMsg = calls.find(m => m.type === 'session_error' && m.code === 'DEV_PREVIEW_STOP_FAILED')
+    assert.ok(errMsg, 'expected a DEV_PREVIEW_STOP_FAILED session_error broadcast')
+    assert.equal(errMsg.recoverable, true)
+    assert.match(errMsg.message, /port 3000/)
+    assert.match(errMsg.message, /may still be exposed/)
+  })
+
+  it('does not broadcast a stop failure for a non-legacy sessionId in cli mode', () => {
+    const ctx = makeCliCtx()
+    setupForwarding(ctx)
+
+    ctx.devPreview.emit('dev_preview_stop_failed', { sessionId: 'sess-x', port: 3000, error: 'x' })
+
+    const calls = ctx.broadcast.mock.calls.map(c => c.arguments[0])
+    assert.equal(calls.find(m => m.type === 'session_error'), undefined)
+  })
+
   // #4756: legacy-cli mode must also forward the `stopped` event so the
   // single-CLI confirmation reaches connected clients. The legacy path
   // uses `broadcast` (no per-session routing) since there's only one CLI.


### PR DESCRIPTION
## What

`DevPreviewManager.closePreview` swallowed a `tunnel.stop()` rejection (`catch { /* ignore */ }`) and then **unconditionally** emitted `dev_preview_stopped` + logged `"Tunnel stopped"`. So if the stop actually failed, the public Cloudflare tunnel — and thus the exposed local dev port — could still be live while the user was told it had shut down. (#5731 Tier-2: "port may stay exposed.")

## Fix

Capture the `stop()` error instead of swallowing it:
- **Still** free the tracking slot and emit `dev_preview_stopped` — the tunnel handle is unusable for a retry whether or not stop succeeded, and the UI must stop showing a live preview.
- **On failure**, also emit a new `dev_preview_stop_failed` event, which `ws-forwarding` surfaces as a per-session `session_error` (`DEV_PREVIEW_STOP_FAILED`, `recoverable: true`) — reusing the existing wire type exactly like the checkpoint (#5731 T3) / persist (#5714) / create (T6) failure paths. The message tells the user the port may still be exposed and to verify / kill `cloudflared` manually.

No new protocol type, no client change (both clients route unknown `session_error` codes to their error toast). The success path is behaviourally unchanged.

## Tests

- **`dev-preview.test.js`**: a throwing `stop()` emits both `dev_preview_stop_failed` (with the error) and `dev_preview_stopped` and frees the slot; a clean stop emits only `dev_preview_stopped`; an unknown tunnel is a no-op.
- **`ws-forwarding.test.js`**: `dev_preview_stop_failed` → `DEV_PREVIEW_STOP_FAILED` `session_error` (recoverable, message names the port + "may still be exposed"); ignored when `sessionId` is absent.

Full server suite 9488/9490 (the 2 failures are the pre-existing `service.test.js` `:8765` probes that false-fail against the locally-running daemon; green on CI). Custom server lints pass.

Part of durability epic #5703 (#5731 Tier 2).