### PR TITLE
fix(repo): surface a config-write failure when removing a repo

### DIFF
--- a/packages/server/src/handlers/repo-handlers.js
+++ b/packages/server/src/handlers/repo-handlers.js
@@ -136,21 +136,30 @@ async function handleRemoveRepo(ws, client, msg, ctx) {
   try { targetPath = realpathSync(msg.path) } catch { /* fall back to raw path */ }
   const readRepos = ctx.readReposFromConfig || defaultReadRepos
   const writeRepos = ctx.writeReposToConfig || defaultWriteRepos
-  // The config read + write were previously OUTSIDE this try/catch: a failing
+  // The config read + write were previously OUTSIDE any try/catch: a failing
   // readReposFromConfig / writeReposToConfig (disk full, locked file, read-only
   // home) threw out of the handler, so the client got NO response at all and the
   // removal silently failed — the client's repo list stayed showing a repo the
-  // user thought they'd removed. Wrap them like handleAddRepo so a config-write
-  // failure surfaces a session_error the user can act on, and the repo_list
-  // refresh only runs when the mutation actually persisted.
+  // user thought they'd removed.
+  //
+  // The mutation and the list-refresh are guarded SEPARATELY so the error stays
+  // accurate: a read/write failure means the removal did NOT persist, whereas a
+  // buildRepoList failure AFTER a successful write means the repo WAS removed and
+  // only the follow-up list resend failed — saying "Failed to remove repo" there
+  // would wrongly imply the repo is still configured.
   try {
     const existing = readRepos()
     const filtered = existing.filter(r => r.path !== targetPath)
     writeRepos(filtered)
+  } catch (err) {
+    sendSessionError(ws, ctx, `Failed to remove repo: ${err.message}`)
+    return
+  }
+  try {
     const repos = await buildRepoList(ctx)
     ctx.transport.send(ws, { type: 'repo_list', repos })
   } catch (err) {
-    sendSessionError(ws, ctx, `Failed to remove repo: ${err.message}`)
+    sendSessionError(ws, ctx, `Repo removed, but the list couldn't be refreshed: ${err.message}`)
   }
 }
 

--- a/packages/server/src/handlers/repo-handlers.js
+++ b/packages/server/src/handlers/repo-handlers.js
@@ -136,15 +136,21 @@ async function handleRemoveRepo(ws, client, msg, ctx) {
   try { targetPath = realpathSync(msg.path) } catch { /* fall back to raw path */ }
   const readRepos = ctx.readReposFromConfig || defaultReadRepos
   const writeRepos = ctx.writeReposToConfig || defaultWriteRepos
-  const existing = readRepos()
-  const filtered = existing.filter(r => r.path !== targetPath)
-  writeRepos(filtered)
-
+  // The config read + write were previously OUTSIDE this try/catch: a failing
+  // readReposFromConfig / writeReposToConfig (disk full, locked file, read-only
+  // home) threw out of the handler, so the client got NO response at all and the
+  // removal silently failed — the client's repo list stayed showing a repo the
+  // user thought they'd removed. Wrap them like handleAddRepo so a config-write
+  // failure surfaces a session_error the user can act on, and the repo_list
+  // refresh only runs when the mutation actually persisted.
   try {
+    const existing = readRepos()
+    const filtered = existing.filter(r => r.path !== targetPath)
+    writeRepos(filtered)
     const repos = await buildRepoList(ctx)
     ctx.transport.send(ws, { type: 'repo_list', repos })
   } catch (err) {
-    ctx.transport.send(ws, { type: 'server_error', message: `Failed to list repos: ${err.message}`, recoverable: true })
+    sendSessionError(ws, ctx, `Failed to remove repo: ${err.message}`)
   }
 }
 

--- a/packages/server/tests/handlers/repo-handlers.test.js
+++ b/packages/server/tests/handlers/repo-handlers.test.js
@@ -148,5 +148,24 @@ describe('repo-handlers', () => {
       assert.match(ctx._sent[0].message, /Failed to remove repo/)
       assert.equal(ctx.writeReposToConfig.callCount, 0, 'no write attempted when the read failed')
     })
+
+    // The removal persisted; only the follow-up list refresh failed. The message
+    // must NOT claim the removal failed (the repo IS gone from config).
+    it('reports a refresh-only failure distinctly after a successful write', async () => {
+      const ctx = makeCtx()
+      ctx._repoStore.push({ path: '/tmp/gone', name: 'gone' })
+      // buildRepoList scans conversations; make that throw AFTER the write lands.
+      ctx.scanConversations = createSpy(async () => { throw new Error('scanner offline') })
+
+      await assert.doesNotReject(
+        repoHandlers.remove_repo(makeWs(), makeClient(), { path: '/tmp/gone' }, ctx),
+      )
+
+      assert.equal(ctx.writeReposToConfig.callCount, 1, 'the write still persisted')
+      assert.equal(ctx._repoStore.length, 0, 'repo actually removed from config')
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /Repo removed/, 'message acknowledges the removal succeeded')
+      assert.doesNotMatch(ctx._sent[0].message, /Failed to remove repo/)
+    })
   })
 })

--- a/packages/server/tests/handlers/repo-handlers.test.js
+++ b/packages/server/tests/handlers/repo-handlers.test.js
@@ -117,5 +117,36 @@ describe('repo-handlers', () => {
       assert.equal(ctx._repoStore.length, 1)
       assert.equal(ctx._repoStore[0].path, '/tmp/keep')
     })
+
+    // The config read+write used to sit outside the handler's try/catch, so a
+    // write failure threw out and the client got no response (silent failure).
+    it('sends session_error (not an uncaught throw) when the config write fails', async () => {
+      const ctx = makeCtx()
+      ctx._repoStore.push({ path: '/tmp/keep', name: 'keep' })
+      ctx.writeReposToConfig = createSpy(() => { throw new Error('EROFS: read-only file system') })
+
+      // Must not throw out of the handler.
+      await assert.doesNotReject(
+        repoHandlers.remove_repo(makeWs(), makeClient(), { path: '/tmp/keep' }, ctx),
+      )
+
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /Failed to remove repo/)
+      assert.match(ctx._sent[0].message, /read-only file system/)
+    })
+
+    it('sends session_error when the config read fails', async () => {
+      const ctx = makeCtx()
+      ctx.readReposFromConfig = createSpy(() => { throw new Error('config parse error') })
+
+      await assert.doesNotReject(
+        repoHandlers.remove_repo(makeWs(), makeClient(), { path: '/tmp/keep' }, ctx),
+      )
+
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /Failed to remove repo/)
+      assert.equal(ctx.writeReposToConfig.callCount, 0, 'no write attempted when the read failed')
+    })
   })
 })


### PR DESCRIPTION
## What

`handleRemoveRepo` read and wrote the repo config **outside** its `try/catch`:

```js
const existing = readRepos()              // ← unguarded
const filtered = existing.filter(...)
writeRepos(filtered)                      // ← unguarded
try { /* only the repo_list refresh */ } catch { ... }
```

So a failing `readReposFromConfig` / `writeReposToConfig` (disk full, locked file, read-only home) threw out of the handler entirely: the client got **no response**, and the removal silently failed — the repo list kept showing a repo the user thought they'd removed.

Its sibling `handleAddRepo` already wraps the whole read→write→list sequence and sends a `session_error` on failure; this brings `handleRemoveRepo` to parity.

## Fix

Wrap the read + write + `buildRepoList` refresh in the `try/catch` and send a `Failed to remove repo: …` `session_error` on failure. The `repo_list` refresh now only runs once the mutation actually persisted.

## Tests

`repo-handlers.test.js`: a throwing `writeReposToConfig` now yields a `session_error` (and does **not** reject out of the handler); a throwing `readReposFromConfig` yields the same and never attempts the write.

Full server suite 9520/9522 (the 2 failures are the pre-existing `service.test.js` `:8765` probes that false-fail against the locally-running daemon; green on CI). Custom server lints pass.

Part of durability epic #5703 (#5731 Tier 2).