### PR TITLE
fix(pricing): price gemini-2.0-pro + warn on unpriced offered models

### DIFF
--- a/packages/dashboard/src/lib/model-pricing.test.ts
+++ b/packages/dashboard/src/lib/model-pricing.test.ts
@@ -25,7 +25,15 @@ function sig(n: number, digits = 6): number {
 // ---------------------------------------------------------------------------
 
 describe('calculateCost — unknown model', () => {
+  // Suppress the drift warning's stderr (asserted separately below) and keep the
+  // module-level deduped set clean across files.
+  afterEach(() => {
+    _resetPricingDriftWarnings()
+    vi.restoreAllMocks()
+  })
+
   it('returns null for an unrecognised model id', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(calculateCost('some-unknown-model-xyz', 1000, 500)).toBeNull()
   })
 })

--- a/packages/dashboard/src/lib/model-pricing.test.ts
+++ b/packages/dashboard/src/lib/model-pricing.test.ts
@@ -4,8 +4,8 @@
  * Verifies that Codex and Gemini models return sensible cost estimates and
  * that unknown models return null rather than NaN or incorrect values.
  */
-import { describe, it, expect } from 'vitest'
-import { calculateCost, getModelPricing, MODEL_PRICING } from './model-pricing'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { calculateCost, getModelPricing, MODEL_PRICING, _resetPricingDriftWarnings } from './model-pricing'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -169,5 +169,46 @@ describe('MODEL_PRICING table integrity', () => {
     for (const model of required) {
       expect(MODEL_PRICING[model], `${model} missing`).toBeDefined()
     }
+  })
+
+  // #5731 Tier-2: gemini-2.0-pro is offered by the Gemini provider but had no
+  // pricing row, so its cost badge rendered blank.
+  it('prices gemini-2.0-pro (was an offered-but-unpriced model)', () => {
+    expect(MODEL_PRICING['gemini-2.0-pro']).toBeDefined()
+    const cost = calculateCost('gemini-2.0-pro', 1000, 1000)
+    expect(cost).not.toBeNull()
+    expect(cost).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Drift detection (#5731 Tier-2)
+// ---------------------------------------------------------------------------
+
+describe('calculateCost — unknown-model drift warning', () => {
+  afterEach(() => {
+    _resetPricingDriftWarnings()
+    vi.restoreAllMocks()
+  })
+
+  it('warns once (deduped) for an unpriced model and still returns null', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(calculateCost('totally-new-model-v9', 1000, 500)).toBeNull()
+    expect(calculateCost('totally-new-model-v9', 10, 10)).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain('totally-new-model-v9')
+  })
+
+  it('does not warn for a known model', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    calculateCost('gemini-2.0-pro', 1000, 500)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('warns separately for distinct unknown models', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    calculateCost('unknown-a', 1, 1)
+    calculateCost('unknown-b', 1, 1)
+    expect(warn).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -139,7 +139,6 @@ export function calculateCost(
   if (!pricing) {
     if (modelId && !_warnedUnknownModels.has(modelId)) {
       _warnedUnknownModels.add(modelId)
-      // eslint-disable-next-line no-console
       console.warn(
         `[model-pricing] no pricing entry for "${modelId}" — its cost estimate will be blank. Add it to model-pricing.ts.`,
       )

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -82,6 +82,10 @@ const GEMINI_PRICING: Record<string, ModelPricing> = {
   // https://ai.google.dev/pricing#2_5flash
   'gemini-2.5-flash': { inputPer1k: 0.0003, outputPer1k: 0.0025, label: 'Gemini 2.5 Flash' },
   'gemini-2.5-flash-preview-04-17': { inputPer1k: 0.0003, outputPer1k: 0.0025, label: 'Gemini 2.5 Flash Preview' },
+  // Gemini 2.0 Pro — offered by the Gemini provider (gemini-session.js) but had
+  // no GA pricing as an experimental model; use the 2.5 Pro >200k rate as a
+  // conservative estimation proxy so its cost badge isn't blank.
+  'gemini-2.0-pro': { inputPer1k: 0.00125, outputPer1k: 0.01, label: 'Gemini 2.0 Pro' },
   // Gemini 2.0 Flash — https://ai.google.dev/pricing#2_0flash
   'gemini-2.0-flash': { inputPer1k: 0.0001, outputPer1k: 0.0004, label: 'Gemini 2.0 Flash' },
   'gemini-2.0-flash-001': { inputPer1k: 0.0001, outputPer1k: 0.0004, label: 'Gemini 2.0 Flash 001' },
@@ -106,6 +110,18 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   ...GEMINI_PRICING,
 }
 
+// Drift detection: an offered model that has no pricing row renders a BLANK
+// cost badge — silent, so the table quietly falls behind as providers ship new
+// models. Warn once per unknown model id (deduped) so the gap is visible in the
+// dev console instead of going unnoticed. Module-level so it persists across
+// calls; `_resetPricingDriftWarnings` is a test seam.
+const _warnedUnknownModels = new Set<string>()
+
+/** @internal test seam — clear the deduped drift-warning set. */
+export function _resetPricingDriftWarnings(): void {
+  _warnedUnknownModels.clear()
+}
+
 /**
  * Calculate the estimated cost in USD for a model invocation.
  *
@@ -120,7 +136,16 @@ export function calculateCost(
   outputTokens: number,
 ): number | null {
   const pricing = MODEL_PRICING[modelId]
-  if (!pricing) return null
+  if (!pricing) {
+    if (modelId && !_warnedUnknownModels.has(modelId)) {
+      _warnedUnknownModels.add(modelId)
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[model-pricing] no pricing entry for "${modelId}" — its cost estimate will be blank. Add it to model-pricing.ts.`,
+      )
+    }
+    return null
+  }
   return (
     (inputTokens / 1000) * pricing.inputPer1k +
     (outputTokens / 1000) * pricing.outputPer1k


### PR DESCRIPTION
## What

Two parts of the same #5731 Tier-2 finding (dashboard pricing table stale):

1. **`gemini-2.0-pro` was blank.** It's offered by the Gemini provider (`gemini-session.js:60`, 2M context) but had no row in `MODEL_PRICING`, so `calculateCost` returned `null` → a blank cost badge for any Gemini-2.0-Pro session. Added it at the **Gemini 2.5 Pro >200k rate** (`0.00125` in / `0.01` out per 1k) as a conservative estimation proxy — 2.0 Pro shipped as an experimental model with no GA pricing, and the table already documents using conservative/proxy rates.

2. **Silent drift.** When a provider ships a model the table hasn't caught up with, `calculateCost` silently returns `null` and the badge just goes blank — nothing surfaces the gap. `calculateCost` now emits a **deduped** `console.warn` (once per unknown model id, module-level) naming the missing model, so the drift is visible in the dev console. `_resetPricingDriftWarnings()` is a test seam.

Note: the Claude pricing rows remain (dead-code per the audit, since Claude sessions aren't client-cost-estimated) — left untouched to keep this scoped to the actual defect.

## Tests

`model-pricing.test.ts`: `gemini-2.0-pro` now returns a non-null positive cost; the drift warning fires **once** for a repeated unknown model (and still returns null), doesn't fire for a known model, and fires separately for distinct unknown models.

Dashboard `tsc` + full suite (3676 tests) green.

Part of durability epic #5703 (#5731 Tier 2).