### PR TITLE
fix(app): gate SettingsBar model/permission chips on provider capabilities

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -90,6 +90,16 @@ export interface SettingsBarProps {
   // window (ollama) the usage meter renders the raw token count without
   // a percentage/progress bar instead of a misleading "% of 200k".
   provider?: string | null;
+  // #5731 — provider capability gating (mirrors the dashboard's dropdownFlags).
+  // Default to `true` (the value is undefined for older callers / before the
+  // provider list lands) so behaviour is unchanged unless the active provider
+  // explicitly reports the capability as false. When `modelSwitchSupported` is
+  // false (e.g. claude-tui — model fixed at boot), the model row renders a
+  // read-only badge instead of an interactive picker that can't actually
+  // switch; when `permissionModeSwitchSupported` is false the permission-mode
+  // chips are hidden entirely.
+  modelSwitchSupported?: boolean;
+  permissionModeSwitchSupported?: boolean;
 }
 
 // -- Helpers --
@@ -203,6 +213,8 @@ export function SettingsBar({
   connectionQuality,
   activePath,
   provider,
+  modelSwitchSupported = true,
+  permissionModeSwitchSupported = true,
 }: SettingsBarProps) {
   // Elapsed time ticker — only runs when expanded with active agents
   const [now, setNow] = useState(Date.now());
@@ -447,7 +459,12 @@ export function SettingsBar({
               </Text>
             </View>
           )}
-          {availableModels.length > 0 && (
+          {/* #5731: gate the interactive model picker on the provider's
+              modelSwitch capability. A provider that can't switch mid-session
+              (claude-tui) gets a non-interactive badge of its fixed model
+              instead of chips that silently do nothing on tap. Mirrors the
+              dashboard's `showModelPicker` / `readOnlyModel` split. */}
+          {availableModels.length > 0 && modelSwitchSupported && (
                 <View style={styles.chipRow}>
                   {availableModels.map((m) => {
                     const isActive = activeModel === m.id || activeModel === m.fullId
@@ -467,7 +484,20 @@ export function SettingsBar({
                   })}
                 </View>
               )}
-              {availablePermissionModes.length > 0 && (
+              {!modelSwitchSupported && activeModel && (() => {
+                const fixed = availableModels.find((m) => m.id === activeModel || m.fullId === activeModel);
+                return (
+                  <View style={styles.chipRow}>
+                    <View style={[styles.chip, styles.chipReadOnly]} accessibilityRole="text">
+                      <Text style={styles.chipReadOnlyText}>{fixed?.label || activeModel} · fixed</Text>
+                    </View>
+                  </View>
+                );
+              })()}
+              {/* #5731: hide the permission-mode chips when the provider can't
+                  switch permission modes (mirrors the dashboard's
+                  `showPermissionMode`). */}
+              {availablePermissionModes.length > 0 && permissionModeSwitchSupported && (
                 <View style={styles.chipRow}>
                   {availablePermissionModes.map((m) => {
                     const isActive = permissionMode === m.id;
@@ -492,7 +522,7 @@ export function SettingsBar({
                   description (older server) so mobile users still get the
                   trade-off explanation. Mirrors CreateSessionModal's #4019
                   hint pattern. */}
-              {permissionMode && availablePermissionModes.length > 0 && (() => {
+              {permissionMode && availablePermissionModes.length > 0 && permissionModeSwitchSupported && (() => {
                 const selected = availablePermissionModes.find((m) => m.id === permissionMode);
                 let hint = selected?.description;
                 if (!hint) {
@@ -873,6 +903,21 @@ const styles = StyleSheet.create({
   },
   chipTextActive: {
     color: COLORS.accentBlue,
+  },
+  // #5731: non-interactive model badge for providers that can't switch models.
+  chipReadOnly: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 10,
+    backgroundColor: COLORS.backgroundCard,
+    borderWidth: 1,
+    borderColor: COLORS.borderTransparent,
+    opacity: 0.7,
+  },
+  chipReadOnlyText: {
+    color: COLORS.textDim,
+    fontSize: 11,
+    fontWeight: '500',
   },
   contextRow: {
     flexDirection: 'row',

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -484,12 +484,17 @@ export function SettingsBar({
                   })}
                 </View>
               )}
-              {!modelSwitchSupported && activeModel && (() => {
-                const fixed = availableModels.find((m) => m.id === activeModel || m.fullId === activeModel);
+              {!modelSwitchSupported && (() => {
+                // Fall back to defaultModelId when there's no explicit override,
+                // mirroring the interactive chip's `!activeModel && defaultModelId`
+                // active-match so a non-switching provider still shows its model.
+                const fixedId = activeModel || defaultModelId;
+                if (!fixedId) return null;
+                const fixed = availableModels.find((m) => m.id === fixedId || m.fullId === fixedId);
                 return (
                   <View style={styles.chipRow}>
                     <View style={[styles.chip, styles.chipReadOnly]} accessibilityRole="text">
-                      <Text style={styles.chipReadOnlyText}>{fixed?.label || activeModel} · fixed</Text>
+                      <Text style={styles.chipReadOnlyText}>{fixed?.label || fixedId} · fixed</Text>
                     </View>
                   </View>
                 );

--- a/packages/app/src/components/__tests__/SettingsBar.capabilityGating.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBar.capabilityGating.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * #5731 — SettingsBar gates the model + permission-mode chips on the active
+ * provider's capabilities (mirrors the dashboard's dropdownFlags). A provider
+ * that can't switch mid-session (e.g. claude-tui) must not render interactive
+ * chips that silently do nothing on tap.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text, TouchableOpacity } from 'react-native';
+import { SettingsBar } from '../SettingsBar';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    expanded: true, // chips render in the expanded section
+    onToggle: () => {},
+    activeModel: 'opus',
+    defaultModelId: null,
+    availableModels: [{ id: 'opus', label: 'Opus' }, { id: 'sonnet', label: 'Sonnet' }],
+    permissionMode: 'approve',
+    availablePermissionModes: [{ id: 'approve', label: 'Approve' }, { id: 'plan', label: 'Plan' }],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextUsage: null,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    interventions: [],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    ...overrides,
+  };
+}
+
+function render(props: Record<string, unknown>) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tree = renderer.create(<SettingsBar {...(props as any)} />);
+  });
+  return tree;
+}
+
+describe('SettingsBar capability gating (#5731)', () => {
+  it('renders interactive model chips when modelSwitch is supported (default)', () => {
+    const tree = render(makeProps());
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Opus');
+    expect(text).toContain('Sonnet');
+    expect(text).not.toContain('fixed');
+  });
+
+  it('renders a read-only model badge (no interactive chips) when modelSwitch is false', () => {
+    const setModel = jest.fn();
+    const tree = render(makeProps({ modelSwitchSupported: false, setModel }));
+    const text = collectVisibleText(tree.root);
+    // The fixed-model badge shows the active model label + "fixed".
+    expect(text).toContain('Opus');
+    expect(text).toContain('fixed');
+    // The non-active model ('Sonnet') must NOT appear as a switchable chip.
+    expect(text).not.toContain('Sonnet');
+  });
+
+  it('hides the permission-mode chips when permissionModeSwitch is false', () => {
+    const tree = render(makeProps({ permissionModeSwitchSupported: false }));
+    const text = collectVisibleText(tree.root);
+    // 'Plan' is only ever rendered as a permission-mode chip → absent when gated off.
+    expect(text).not.toContain('Plan');
+  });
+
+  it('shows the permission-mode chips when permissionModeSwitch is supported (default)', () => {
+    const tree = render(makeProps());
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Approve');
+    expect(text).toContain('Plan');
+  });
+
+  it('falls back to interactive (supported) when the flags are omitted', () => {
+    // Older callers that don't pass the flags get the prior behaviour.
+    const tree = render(makeProps({ modelSwitchSupported: undefined, permissionModeSwitchSupported: undefined }));
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Sonnet');
+    expect(text).toContain('Plan');
+    expect(text).not.toContain('fixed');
+  });
+});

--- a/packages/app/src/components/__tests__/SettingsBar.capabilityGating.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBar.capabilityGating.test.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { Text, TouchableOpacity } from 'react-native';
+import { Text } from 'react-native';
 import { SettingsBar } from '../SettingsBar';
 
 function collectVisibleText(root: ReactTestInstance): string {
@@ -76,6 +76,18 @@ describe('SettingsBar capability gating (#5731)', () => {
     expect(text).toContain('fixed');
     // The non-active model ('Sonnet') must NOT appear as a switchable chip.
     expect(text).not.toContain('Sonnet');
+  });
+
+  it('uses defaultModelId for the fixed badge when there is no explicit activeModel', () => {
+    const tree = render(makeProps({
+      modelSwitchSupported: false,
+      activeModel: null,
+      defaultModelId: 'sonnet',
+    }));
+    const text = collectVisibleText(tree.root);
+    // Falls back to the default model's label rather than rendering no model row.
+    expect(text).toContain('Sonnet');
+    expect(text).toContain('fixed');
   });
 
   it('hides the permission-mode chips when permissionModeSwitch is false', () => {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -247,6 +247,19 @@ export function SessionScreen() {
     const id = s.activeSessionId;
     return id ? s.sessions.find((sess) => sess.sessionId === id)?.provider ?? null : null;
   });
+  // #5731 — gate the SettingsBar model/permission chips on the active provider's
+  // capabilities, mirroring the dashboard's dropdownFlags. Default to supported
+  // (true) unless the provider explicitly reports the capability as false, so a
+  // provider that can't switch (e.g. claude-tui — model fixed at boot) doesn't
+  // render chips that silently do nothing on tap.
+  const availableProviders = useConnectionStore((s) => s.availableProviders);
+  const providerCaps = useMemo(() => {
+    const caps = availableProviders.find((p) => p.name === activeSessionProvider)?.capabilities;
+    return {
+      modelSwitchSupported: caps?.modelSwitch !== false,
+      permissionModeSwitchSupported: caps?.permissionModeSwitch !== false,
+    };
+  }, [availableProviders, activeSessionProvider]);
   const allowMultiQuestion = useMemo(
     () =>
       activeSessionProvider != null &&
@@ -1134,6 +1147,8 @@ export function SessionScreen() {
           // that legitimately report no window (ollama) the usage meter shows
           // the raw token count instead of a percentage against 200k.
           provider={activeSessionProvider}
+          modelSwitchSupported={providerCaps.modelSwitchSupported}
+          permissionModeSwitchSupported={providerCaps.permissionModeSwitchSupported}
         />
       )}
 


### PR DESCRIPTION
## What

The mobile `SettingsBar` rendered the model picker and permission-mode chips whenever the lists were non-empty — **ignoring the active provider's capabilities**. So a provider that can't switch mid-session (e.g. **claude-tui**, whose model is fixed at boot) showed interactive chips that silently did nothing on tap. The dashboard already gates these via its `dropdownFlags` (`showModelPicker`/`readOnlyModel`/`showPermissionMode`); mobile was the gap — the audit's mobile-parity follow-up (#5731 Tier-2).

## Fix

`SessionScreen` derives `modelSwitchSupported` / `permissionModeSwitchSupported` from `availableProviders[activeProvider].capabilities` (the store already carries this — it gates `sessionRules` the same way) and threads them into `SettingsBar`:

- **Model:** interactive chips when `modelSwitch !== false`; otherwise a non-interactive **"`<model>` · fixed"** badge (mirrors the dashboard's `readOnlyModel`).
- **Permission mode:** the chips *and* the mode-description hint are hidden when `permissionModeSwitch === false` (mirrors `showPermissionMode`).

Both flags **default to `true`**, so behaviour is unchanged for providers that support switching and before the provider list lands (older callers / undefined → supported).

Scope note: I left the dashboard's `modelsMatchProvider` refinement (suppress the picker transiently when the pushed model list is tagged to a different provider) out of this PR — it's a separate stale-list concern, not the capability gap.

## Tests

New `SettingsBar.capabilityGating.test.tsx`: interactive chips when `modelSwitch` supported; a read-only "fixed" badge with **no** switchable chips when `modelSwitch` is false; permission chips hidden when `permissionModeSwitch` is false; chips shown when supported; and supported-by-default when the flags are omitted.

App `tsc` clean; full app jest suite green (141 suites / 1885 tests).

Part of durability epic #5703 (#5731 Tier-2 — mobile parity).