### PR TITLE
fix(server): clear pending restart timer in startChild to prevent double-fork

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -365,6 +365,20 @@ export class Supervisor extends EventEmitter {
   startChild() {
     if (this._shuttingDown) return
 
+    // Defensive: cancel any pending crash-backoff restart so two startChild()
+    // calls can't fork two children. A child crash schedules
+    // `_restartTimer = setTimeout(startChild, backoff)`; if a restartChild()
+    // lands during that backoff window its `!this._child` branch calls
+    // startChild() immediately — without this, the still-pending backoff timer
+    // would later fire a SECOND startChild() and orphan the first child. The
+    // SIGUSR2 `_childReady` guard makes the race rare, but a direct/extra caller
+    // would otherwise double-fork. Clearing an already-fired timer is a no-op,
+    // so the normal timer-driven restart path is unaffected.
+    if (this._restartTimer) {
+      clearTimeout(this._restartTimer)
+      this._restartTimer = null
+    }
+
     const childScript = resolve(__dirname, 'server-cli-child.js')
     const childEnv = {
       ...process.env,

--- a/packages/server/tests/supervisor-restart-timer.test.js
+++ b/packages/server/tests/supervisor-restart-timer.test.js
@@ -191,17 +191,17 @@ describe('Supervisor restart timer (#1954)', () => {
     supervisor.restartChild()
 
     assert.equal(supervisor.childCount, 2, 'restartChild forked exactly one new child')
+    // The cleared timer is the complete proof there can be no delayed double-fork:
+    // a null `_restartTimer` cannot fire a second startChild(). (We assert on the
+    // handle rather than sleeping past the 2s backoff to keep the test fast +
+    // deterministic — old code leaves it non-null here, so this still gates.)
     assert.equal(
       supervisor._restartTimer,
       null,
       'the pending backoff timer was cleared, so it cannot fire a third (orphaning) fork',
     )
 
-    // Wait past the 2s first-restart backoff to prove no delayed fork lands.
     supervisor.lastChild.simulateReady()
-    await new Promise((r) => setTimeout(r, 2100))
-    assert.equal(supervisor.childCount, 2, 'no double-fork after the backoff window elapses')
-
     await supervisor.shutdown('SIGTERM')
   })
 })

--- a/packages/server/tests/supervisor-restart-timer.test.js
+++ b/packages/server/tests/supervisor-restart-timer.test.js
@@ -171,4 +171,37 @@ describe('Supervisor restart timer (#1954)', () => {
       'no new child should have been started — shutdown cancelled the restart timer'
     )
   })
+
+  it('startChild during a crash-backoff window cancels the pending timer (no double-fork) (#5731)', async () => {
+    // Scenario: child crashes → backoff restart timer is scheduled → a deploy
+    // restartChild() lands during the backoff. restartChild's `!this._child`
+    // branch calls startChild() immediately; without the guard the still-pending
+    // backoff timer fires LATER and forks a SECOND child, orphaning the first.
+    const { supervisor, tmpDir } = setup()
+    cleanups.push(() => rmSync(tmpDir, { recursive: true, force: true }))
+
+    supervisor.startChild()
+    supervisor.lastChild.simulateReady()
+    supervisor.lastChild.simulateExit(1, null) // crash → schedules _restartTimer (2s)
+
+    assert.ok(supervisor._restartTimer !== null, 'precondition: a backoff timer is pending')
+    assert.equal(supervisor.childCount, 1, 'precondition: one fork so far')
+
+    // Deploy restart during the backoff window → immediate startChild (child #2).
+    supervisor.restartChild()
+
+    assert.equal(supervisor.childCount, 2, 'restartChild forked exactly one new child')
+    assert.equal(
+      supervisor._restartTimer,
+      null,
+      'the pending backoff timer was cleared, so it cannot fire a third (orphaning) fork',
+    )
+
+    // Wait past the 2s first-restart backoff to prove no delayed fork lands.
+    supervisor.lastChild.simulateReady()
+    await new Promise((r) => setTimeout(r, 2100))
+    assert.equal(supervisor.childCount, 2, 'no double-fork after the backoff window elapses')
+
+    await supervisor.shutdown('SIGTERM')
+  })
 })


### PR DESCRIPTION
## What

A child crash schedules a backoff restart: `this._restartTimer = setTimeout(() => this.startChild(), backoff)`. If a `restartChild()` lands **during that backoff window**, its `if (!this._child)` branch (the child is already null after the crash) calls `startChild()` **immediately** — but the original backoff `_restartTimer` stayed pending. When it later fires, it calls `startChild()` a **second** time, forking another child and orphaning the first.

The SIGUSR2 deploy-restart path is guarded by the `_childReady` check (so it's ignored mid-backoff, making the race rare), but that's only an *indirect* guard — any direct/extra `startChild()` during a pending backoff double-forks.

## Fix

Clear `_restartTimer` at the top of `startChild()` (after the `_shuttingDown` guard) so any pending backoff restart is cancelled before forking. Clearing an already-fired timer is a no-op, so the normal timer-driven restart path is unaffected — and `shutdown()`'s existing timer-cancellation is unchanged.

## Test

`supervisor-restart-timer.test.js`: crash the child (schedules the 2s backoff), call `restartChild()` during the window, and assert exactly **one** new fork (`childCount === 2`), the pending `_restartTimer` is now `null`, and — after waiting past the 2s backoff — **still** only two children (no delayed double-fork). The test fails against the old code (the backoff timer would survive and fork a third child).

All supervisor suites green; full server suite 9522/9524 (the 2 failures are the pre-existing `service.test.js` `:8765` probes that false-fail against the locally-running daemon; green on CI). Custom server lints pass.

Part of durability epic #5703 (#5731 Tier 3).