### PR TITLE
docs: swarm audit + closeout of the 2026-06-13 report backlog

### DIFF
--- a/docs/reports/audit-results/00-master-assessment.md
+++ b/docs/reports/audit-results/00-master-assessment.md
@@ -1,0 +1,148 @@
+# Master Assessment — Swarm Audit of the 2026-06-13 Status Report Backlog
+
+**Date**: 2026-06-13
+**Target**: open backlog in `docs/reports/status-2026-06-13.html` — §3 friction items, §4 harness-preamble feature, the #5731 "dregs"
+**Panel**: 6 agents (4 core + Operator + Futurist), each verifying every claim against current `main`
+**Aggregate rating of the report's *forward plan* (§5 next-moves)**: **3.1 / 5** — the engineering *narrative* (§1.5) is trustworthy and every "merged" claim spot-checked real; the *forward-looking* §3 table and §5 list are a snapshot from the **start** of the marathon and never re-baselined against the 19 PRs the same report documents merging.
+
+---
+
+## a. Auditor panel
+
+| Agent | Lens | Rating | Key contribution |
+|-------|------|:------:|------------------|
+| Skeptic | Claims vs reality | 2.5 / 5 | Proved §3/§5 are stale: #5623 + #5674 already CLOSED, #5613 fixed-in-code but orphaned-open, #5631 ~60% done by pre-session #5663 |
+| Builder | Implementability | 4 / 5 | File-by-file build order; flagged #5631 as a 4-package pricing-reconciliation iceberg mislabeled "cleanup"; verified harness-preamble is genuinely S |
+| Guardian | Failure modes | 3 / 5 | #5622 is unbounded **synchronous** crypto on the main loop, self-DoS on restart fan-in; elevated qa-stale-`toolUseId` to a real intra-session integrity hole |
+| Minimalist | YAGNI / cuts | 3 / 5 | Argues harness-preamble is ~95% covered by existing per-repo `sessionPreset`; close all 3 dregs + 4 cleanup issues |
+| Operator | Daily UX | 3 / 5 | The missing #1 felt pain: **#5668 desktop voice error is silently swallowed** (concrete wiring gap); reconnect flash also an a11y false-alarm |
+| Futurist | Architecture | 4 / 5 | Harness-preamble must get its own `_buildSystemPrompt` slot + own cap (not the shared 4000 budget); the real #5631 fix is wiring pricing through the wire schema to retire the dashboard's drift table |
+
+---
+
+## b. Consensus findings (4+ agents agree)
+
+### C1 — The report's §3 friction table and §5 next-moves are STALE. (6/6)
+The report body (§1.5) documents merging #5737, #5694, #5673 this marathon, but the §3 table and §5 list still treat their issues as open:
+- **#5623** ("stale Observing flash") — **CLOSED 2026-06-13** (subsumed by #5737's server re-emit).
+- **#5674** ("mobile permission attribution") — **CLOSED 2026-06-13** via #5694; yet §5 re-recommends it as next-move #5.
+- **#5613** ("session_role not re-emitted") — **fixed in code** by #5737 (`ws-history.js:752-769`, comment cites `#5613`) but the **issue is still OPEN** — GitHub's closing-keyword regex only auto-closes the *first* id in `Fixes #5623, #5613` (the documented `feedback_gh_closing_keywords_list.md` gotcha).
+- **#5631** — **~60% already shipped** by pre-session #5663 (`cc424e310`): `FALLBACK_MODELS` now has a `fable`/`claude-fable-5` entry, user overlay, default-model fallback.
+
+**Action:** re-baseline before planning. The "reconnect sprint" the report headlines collapses to essentially one perf task (#5622) plus a residual client-side flash fix.
+
+### C2 — A residual client-side reconnect flash survives #5737. (Operator, Guardian, Skeptic, Builder)
+#5737 fixed the *server re-emit*, but **neither client clears `sessionRole`/`primaryClientId` on disconnect**:
+- App: `packages/app/src/store/connection.ts` `socket.onclose` (~1195-1248) clears streaming/plan/inactivity state but not `sessionRole`.
+- Dashboard: `packages/dashboard/src/store/connection.ts` (~1682-1707) — identical hole.
+
+So a stale "Observing"/driver badge persists through the reconnect gap until the server round-trip lands. Worse (Operator): `ObserverBanner` is `accessibilityRole="alert"` + live-region, so screen readers **re-announce** a soon-to-be-cleared "Observing" on every reconnect. **Fix is a symmetric ~2-line clear in both `onclose` paths** — highest frequency × cheapest fix in the whole backlog.
+
+### C3 — #5631's real remaining work is narrow and structural, not a UI-wide rewrite. (Skeptic, Builder, Operator, Futurist)
+The **server** is already overlay-driven and graceful (`models.js` `createModelsRegistry`, `~/.chroxy/models.json` overlay, `null`-not-`0` for unknown pricing). The unfixed seam is the **dashboard**: `packages/dashboard/src/lib/model-pricing.ts` is an independent, stale table (mislabels `claude-sonnet-4-5` as "Claude 3.7 Sonnet", no 4.x/fable), and the wire schema `ServerAvailableModelsEntrySchema` carries `{id,label,fullId,contextWindow}` but **no pricing** — so the two tables *structurally cannot converge*. Quick win: bump `FALLBACK_MODELS` opus→4-8 + fix the dashboard labels. Structural fix: add optional `pricing` to the wire entry, demote the dashboard table to fallback. Plus server gap: `session-manager.js` never validates the initial model against `getAllowedModelIds()` (#5631 point 6).
+
+### C4 — The #5731 dregs should be reconciled, not silently carried. (5/6)
+- `resume_budget` — Guardian found it's a literal **no-op stub** (`ws-message-handlers.js:136 resumeBudget: () => {}`) while the real `sessionManager.resumeBudget()` exists unused (`session-manager.js:2653`). It's a **dead button**, not just "no-op when not paused." Wiring the stub is trivial; the *clean ack* needs a dedicated `budget_resume_ack` wire-type (reusing `budget_resumed` injects a false "session resumed" chat message).
+- standby `EADDRINUSE` — confirmed `MAX_STANDBY_EADDRINUSE_RETRIES=20 × 500ms ≈ 10s` (`supervisor.js:33`). One-line cap bump; niche.
+- question-answer stale-`toolUseId` — Guardian elevates this above "dreg": cli/sdk `respondToQuestion` route on a bare `_waitingForAnswer` boolean with **no toolUseId match**, and unmapped answers fall back to `client.activeSessionId` (`input-handlers.js:808`). A late answer to a rotated prompt can land on the *current* prompt (a deny becoming an approve). Intra-session only (cross-session is gated), but real.
+
+---
+
+## c. Contested points
+
+### P1 — #5622 severity: HIGH or DEFER?
+- **Guardian (HIGH):** unbounded **synchronous** pure-JS X25519 scalar-mults + Ed25519 sign per *authenticated* reconnect, on the main loop (`ws-history.js:185-197`, `crypto.ts` tweetnacl). The only backstop (`maxPendingConnections=20`) counts **unauthenticated** sockets — wrong layer. Trigger = supervisor restart / tunnel flap fanning N clients in simultaneously → self-DoS on cold start.
+- **Minimalist/Operator (DEFER):** invisible to a 1-2 device daily driver; the 20-cap likely bounds real storms; #5724's ladder cap already de-amplifies. Don't build a worker-pool on spec.
+- **Builder (middle):** a cheap **concurrency gate** (cap in-flight derivations, `setImmediate`-yield) is the right unattended scope; the worker-thread offload is a deliberate design call, not autonomous work.
+
+**My assessment:** Guardian is technically right that the *mitigation in the report is aimed at the wrong layer* (client backoff is already bounded; server derivation throughput is the uncapped surface). But Minimalist is right it's **not user-felt for the solo driver**. Resolution: **don't fold #5622 into a "reconnect sprint" as if user-facing**; file it as a server-bounding task (per-identity throttle + optional crypto offload) with Guardian's analysis attached, prioritized below the felt-friction items. Severity = real-but-not-urgent.
+
+### P2 — harness-preamble: build it, or YAGNI?
+- **Minimalist (CUT):** existing per-repo `sessionPreset` + `foldPreamble` already deliver ~95%; the global key is a DRY convenience; per-provider notes are pure speculation; it's a permanent per-turn token tax.
+- **Futurist/Builder (BUILD, minimal):** it's genuinely S and server-only, but **only if** it gets its own `_buildSystemPrompt` slot + own cap (not the shared 4000 budget — else a verbose global blurb silently truncates the user's trusted repo/session text) and routes through `BASE_SESSION_OPT_KEYS`. Per-provider notes should be **generated from `static capabilities`**, never hand-authored (hand-authoring re-creates the #5631 drift).
+
+**My assessment:** both are right about something. Ship **only** if it earns the Futurist design (own slot, own cap, picker-forwarded, capability-*generated* notes); **cut** the hand-authored per-provider tailoring entirely. Given it's a *new feature* and every agent ranks the friction fixes above it, it's a follow-up, not this session's lead. Defer with a precise design note so it doesn't calcify if/when built.
+
+---
+
+## d. Factual corrections to the report
+
+| Report claim | Correction | Found by |
+|--------------|-----------|----------|
+| §3 lists #5623 as open friction | CLOSED 2026-06-13 (subsumed by #5737) | Skeptic, Builder |
+| §3 lists #5674 as open; §5 re-recommends it as move #5 | CLOSED 2026-06-13 via #5694 | Skeptic, Builder |
+| §3/§5 treat #5613 as open | Fixed in code (#5737); issue only orphaned-open by the comma-list closing-keyword bug | Skeptic |
+| §5 move #4 frames #5631 as untouched, degrading "across the UI" | ~60% shipped by #5663; server authoritative for Claude cost; real defect is dashboard table drift + pricing-less wire schema | Skeptic, Operator, Futurist |
+| §5 "confirm the mic" treats #5668 as resolved-pending-launch | The "surface spawn failures" half is a **live, unfixed wiring gap** (`voiceInput.error` never rendered) | Operator |
+| §5 bundles #5622 into a reconnect sprint as user-felt | Server-CPU only; invisible to a solo driver; mitigation aimed at the wrong layer | Guardian, Minimalist, Operator |
+
+---
+
+## e. Risk heatmap
+
+```
+            IMPACT →
+          LOW            MEDIUM           HIGH
+        +--------------+----------------+----------------+
+  HIGH  |              | #5622 eager    |                |
+        |              | key-deriv      |                |
+        +--------------+----------------+----------------+
+  MED   | resume_budget| harness cap/   | qa-stale-      |
+        | dead button  | precedence     | toolUseId      |
+        |              |                | mis-route      |
+        +--------------+----------------+----------------+
+  LOW   | standby      | #5631 table    | #5668 voice    |
+        | EADDRINUSE   | drift / #5674  | silent fail*   |
+        | #5613 fixed  | residual       | (*felt, not    |
+        |              |                |  integrity)    |
+        +--------------+----------------+----------------+
+```
+
+Two different problems pull top-right: **#5622** (high-likelihood, medium-impact — volume) and **qa-stale-toolUseId** (low-likelihood, high-impact — integrity). #5668 is high *felt* pain, low technical risk.
+
+---
+
+## f. Recommended action plan (prioritized: consensus × felt-friction × effort)
+
+**Tier A — ship now (cheap, high felt-friction, no protocol/client coordination):**
+1. **#5668 — surface desktop voice errors.** Add `error` to the `voiceInput` prop (`InputBar.tsx`) and render it (`App.tsx:2132`); the hook already exposes `error` (`useVoiceInput.ts:300,479`). Operator's #1 felt pain on a headline feature. *(S)*
+2. **#5623/#5613 residual — clear `sessionRole`/`primaryClientId` on disconnect** in both `connection.ts` `onclose` paths. Kills the most-frequent reconnect jank + the a11y false-alarm. *(S, symmetric)*
+3. **#5631 quick-win — bump `FALLBACK_MODELS` opus→4-8 + fix the dashboard `model-pricing.ts` stale labels/4.x rows.** Stops the worst degradation. *(S)*
+
+**Tier B — parity + structural (this session if time, else issues):**
+4. **#5674 residual — mobile per-tab pending-permission dot** in `SessionPicker.tsx` (+ assertive a11y announcement of a new prompt, the mobile mirror of #5733). Port the dashboard's `derivePendingPermissionSessions`. *(M)*
+5. **#5631 structural — add `pricing` to `ServerAvailableModelsEntrySchema`**, populate from the overlay-aware registry, demote the dashboard table to fallback. Ends the drift treadmill. *(M, protocol + both clients)*
+
+**Tier C — file as issues, decide deliberately:**
+6. **#5622 server-bounding** — per-identity derivation throttle + optional crypto offload (Guardian's analysis). *(M/L, not user-felt)*
+7. **harness-preamble (§4)** — only as the Futurist-minimal design; cut per-provider hand-authoring. *(S feature, deferred)*
+8. **resume_budget** — wire the stub + add `budget_resume_ack` wire-type. *(M, protocol)*
+9. **session-manager initial-model soft-validate** (#5631 point 6). *(S)*
+
+**Reconcile (backlog hygiene):**
+- **Close #5613** (fixed by #5737, orphaned by the comma-list gotcha).
+- Confirm #5623, #5674 are closed (they are).
+- Update #5731: close the EADDRINUSE + question-answer dregs decisions explicitly; keep resume_budget as a real (if minor) bug.
+
+**Cleanup list verdicts:** #5618 dispatch-table = **real debt** (Futurist: bend the dual-table drift curve down) — prioritize; #5621 retry-ladder dedupe = real-but-small (two straggler constants); #5620 dual JSON-write = cosmetic/dead-code, defer.
+
+---
+
+## g. Final verdict
+
+**Aggregate: 3.1 / 5** (core panel 1.0×: 2.5/4/3/3; extended 0.8×: Operator 3, Futurist 4 → weighted ≈ 3.1).
+
+The report's *record of work done* is excellent and honest — every merged PR I sampled is real on `main`, and the scope-discipline calls (closing #5697 wontfix, the `switchSession` no-op verification) show good instincts. But its *forward plan* was never re-baselined against its own marathon: half the §3/§5 items already shipped, and the two genuinely-open felt-friction wins (desktop voice silent-fail, the residual reconnect flash) aren't even on the next-moves list. The path forward is mostly **finishing convergence** (clear role on disconnect, retire the dashboard pricing table, port the mobile pending dot) rather than greenfield — with exactly one item (the harness-preamble) that needs a deliberate design call before it calcifies. Re-baseline, close the three already-done issues, ship Tier A, and the backlog snaps back to reality.
+
+---
+
+## h. Appendix — individual reports
+
+| Agent | File |
+|-------|------|
+| Skeptic | [`01-skeptic.md`](01-skeptic.md) |
+| Builder | [`02-builder.md`](02-builder.md) |
+| Guardian | [`03-guardian.md`](03-guardian.md) |
+| Minimalist | [`04-minimalist.md`](04-minimalist.md) |
+| Operator | [`05-operator.md`](05-operator.md) |
+| Futurist | [`06-futurist.md`](06-futurist.md) |

--- a/docs/reports/audit-results/01-skeptic.md
+++ b/docs/reports/audit-results/01-skeptic.md
@@ -1,0 +1,38 @@
+# Skeptic's Audit: Status Report Backlog
+
+**Agent**: Skeptic — cynical systems engineer; cross-references every claim against actual code
+**Overall Rating**: 2.5 / 5 (implementation-readiness of §5 next-moves)
+**Date**: 2026-06-13
+
+---
+
+**Bottom line up front:** The report's §3 "Friction backlog" table is **stale and self-contradicting**. It lists 6 open friction items, but **2 are already CLOSED** (#5623, #5674), **1 is fixed-but-not-auto-closed** (#5613, victim of the `Fixes #A, #B` GH gotcha), and **1 is structurally half-done by a pre-session PR the report under-credits** (#5631). The report's own narrative body (§1.5) correctly describes shipping #5737 which closes these — but nobody updated the §3 table to match. Someone reading only §3 + §5 would re-do work that's already merged.
+
+## Per-item verdicts
+
+| Item | Verdict | Evidence |
+|------|---------|----------|
+| **#5623** stale "Observing" banner | **ALREADY FIXED (closed)** | Issue `CLOSED/COMPLETED` (18:41:57Z), auto-closed by PR #5737 (`Fixes #5623`). Server re-emits `session_role` in `sendSessionInfo` (`ws-history.js:763-769`), `getPrimary` wired at `ws-server.js:726,799`. App handler is a pure state-setter (`message-handler.ts:3068-3084`). **Caveat:** the pure client-side reset-on-disconnect the issue body called "a one-liner worth having regardless" was NOT implemented — app `connection.ts` never nulls `sessionRole` on `onclose`, so a flash window survives between disconnect and the reconnect re-emit. Closed anyway. |
+| **#5613** session_role not re-emitted | **FIXED IN CODE, issue STILL OPEN (stale)** | Code fix is live (`ws-history.js:752-769`, comment cites `#5613`). But #5613 is still `OPEN`, zero comments. Cause: PR #5737's `Fixes #5623, #5613` — GitHub's closing-keyword regex only auto-closes the **first** id in a comma list (`feedback_gh_closing_keywords_list.md`). **Action: manually close #5613.** |
+| **#5631** model metadata hardcoded | **PARTIALLY FIXED (~60%), report under-credits it** | Pre-session PR **#5663** (`cc424e310`, June 12) landed a big slice. Point 1 FIXED — `FALLBACK_MODELS` has a `fable`/`claude-fable-5` entry (`models.js:68`). Points 3+5 addressed via the user overlay + deterministic fallback. Point 4 partially via #5745. **STILL REAL:** Point 2 (pricing rows — opus still `4-7` only) and **Point 6 (session-manager never validates model against `getAllowedModelIds()` — zero matches in `session-manager.js`).** #5732 is irrelevant to #5631 (it guards `set_model` capability, not metadata). |
+| **#5622** reconnect-storm | **STILL REAL** | No concurrency cap. `deriveSharedKey`+`createKeyPair`+HKDF run synchronously + unbounded in the eager auth path (`ws-history.js:182-208`). No semaphore anywhere. The biggest genuinely-unfixed perf item. |
+| **#5674** mobile permission attribution | **ALREADY FIXED (closed)** | `CLOSED/COMPLETED` (08:33:03Z). #5673 routed `sessionId` server-side + stamped `originSessionId` in the app handler. Report lists it open AND re-recommends it as next-move #5 — both wrong. |
+| **#5668** mic helper-spawn silent revert | **PARTIALLY FIXED / mostly stale** | Code half fixed in #5672. Issue stays open only for the "surface helper-spawn failures" nicety — NOT implemented (no spawn-error surfacing in the speech helper). Real-world fix was the .app rebuild. Low value remaining. |
+
+## #5731 dregs — all three verified STILL REAL and accurately described
+- **resume_budget no-op:** `input-handlers.js:666-677` returns with no ack/error when not paused.
+- **standby EADDRINUSE:** `supervisor.js:33-34,542` — 20 × 500ms ≈ 10s then gives up.
+- **question-answer stale toolUseId:** consistent with "mostly mitigated"; lowest value.
+
+## Harness preamble (§4)
+Accurately scoped. `sessionPreamble` → `_buildSystemPrompt()` plumbing + `set_session_preamble` exist; the global `harnessPreamble` key genuinely doesn't. The one item that's cleanly real and implementation-ready.
+
+## Top 5 findings
+1. **#5613 is done but the issue is still open** — comma-list closing-keyword bug. Don't reimplement; close it.
+2. **The §3 table contradicts the report's own §1.5 narrative** — lists #5623 and #5674 as open when both are CLOSED.
+3. **#5631 is ~60% done by pre-session #5663** — remaining work is narrow: point 6 (session-manager validation) + point 2 (pricing rows).
+4. **#5622 is the one genuinely-untouched perf item and bigger than its LOW label** — unbounded synchronous X25519 DH per connect.
+5. **The "reconnect sprint" is two-thirds already done** — #5623 + #5613 merged via #5737; only #5622 remains.
+
+## Verdict
+The engineering narrative (§1.5) is honest and well-evidenced. But §3/§5 are a snapshot from the *start* of the session: they re-list closed issues and frame #5631 as untouched when its foundation landed the day before. Cleanly-real open items: **#5622**, the residual ~40% of **#5631**, the **harness-preamble**, the **three dregs** — and **#5613 should just be closed**.

--- a/docs/reports/audit-results/02-builder.md
+++ b/docs/reports/audit-results/02-builder.md
@@ -1,0 +1,42 @@
+# Builder's Audit: Status Report Backlog
+
+**Agent**: Builder — pragmatic full-stack dev who will implement this; file-by-file change lists + realistic estimates
+**Overall Rating**: 4 / 5 (implementation-readiness)
+**Date**: 2026-06-13
+
+---
+
+**The status report is stale on three items** — #5623, #5674, and the substance of #5613 all shipped *today* (2026-06-13). Plan around current `main`, not the report.
+
+## Plumbing verification (report §4 claims) — VERIFIED, the global-preamble feature is genuinely small
+- `BaseSession._buildSystemPrompt()` — `base-session.js:1091-1107`. Folds `[sessionPreamble, CHROXY_CONTEXT_HINT_TEXT, skillsText].join('\n\n')`. The user preamble rides at the FRONT (1103). Exactly where a global harness preamble folds in.
+- Repo→session folding upstream in `session-manager.js:776-887`: `foldPreamble(resolved.preamble, sessionPreamble)` → `effectiveSessionPreamble` (789-790), forwarded via `forwardPerSessionSettingsToProviderOpts` (879-887).
+- `set_session_preamble` runtime wire path exists (`setSessionPreamble` at base-session.js:949).
+- `BASE_SESSION_OPT_KEYS` picker (base-session.js:125) means a new ctor opt propagates to every provider for free.
+
+**Conclusion:** harness preamble = config-read + one more `foldPreamble` call, not a plumbing build.
+
+## Item-by-item
+- **Global harness preamble — S.** `config.js` add `harnessPreamble` to `CONFIG_SCHEMA`+`validateConfig` (copy `validateBillingBlock`); `session-manager.js:776-816` fold before repo: `foldPreamble(harness, foldPreamble(repo, session))`. Risk: shared 4000-char cap — a fat harness preamble eats the repo/session budget. Provider-specific notes = M and optional, skip for v1. No protocol/client changes.
+- **#5631 — L (deceptively large, cross-package).** Spans 4 packages. `models.js` pins opus 4-7 (current 4-8); dashboard `model-pricing.ts:28-41` badly stale (3.5/3.7 era, zero 4.x). Two independent pricing tables (`server/models.js` vs `dashboard/model-pricing.ts`). **Split:** (a) S quick win — opus→4-8 + dashboard 4.x rows; (b) L — unify behind discovery. Don't do (b) blind.
+- **#5613 — DONE (verify & close).** Shipped via #5737; `handleSessionRole` shared in `store-core/handlers/index.ts:1547`. Close it.
+- **#5623 — DONE.** Closed today; subsumed by #5737's re-emit.
+- **#5674 — DONE.** Closed today via #5694. Report listing it open is stale.
+- **#5622 — M.** Confirmed `ws-auth.js:559-564` runs `createKeyPair()`+`deriveSharedKey()`+`deriveConnectionKey()` synchronously per connect. Cheap fix (S/M): concurrency gate + `setImmediate` yields. Proper fix (L): worker_thread pool (bigger blast radius — sync crypto crosses a thread boundary). Auth-critical; gate is the right unattended scope.
+- **#5668 — S (desktop/Rust).** `speech.rs:114` sets `.stderr(Stdio::null())`; early exit emits a bare `voice_stopped` (167). Fix: `Stdio::piped()`, check exit status after `child.wait()`, emit `voice_error` (struct already exists) before `voice_stopped`. Needs a desktop rebuild to verify.
+- **resume_budget — S+protocol (M).** Needs a new wire type (`budget_resume_ack`); no such type exists. Reusing `budget_resumed` injects a false "resumed" chat event. Protocol + both clients. Defer.
+- **EADDRINUSE cap — S (trivial).** `supervisor.js:33` bump the constant.
+- **question-answer toolUseId — leave it.** Legacy single-session subtlety.
+
+## Top 5 findings
+1. Report stale on 3 of 6 friction items (#5613/#5623/#5674). Reconnect cluster mostly done — only #5622 remains.
+2. #5631 is the deceptively-large item — 4 packages, two pricing tables. Split it.
+3. Global harness preamble = best ROI, verified S, server-only, no ripple.
+4. resume_budget dreg is a protocol change in disguise (no `budget_resume_ack` type). Defer.
+5. #5622 is auth-critical — concurrency gate (S/M) is the right unattended scope; worker pool is a deliberate call.
+
+## Recommended build order
+1. Global harness preamble (S) → 2. #5631 quick-win half (S) → 3. #5668 mic surfacing (S, batch with a desktop rebuild) → 4. #5622 concurrency gate (M) → 5. EADDRINUSE cap (S). **Defer:** #5631 discovery-unification (L), resume_budget ack (M), toolUseId fallback. Verify-and-close #5613.
+
+## Verdict: 4 / 5
+Plumbing claims check out exactly; harness preamble is genuinely small + server-local; half the friction list already shipped. Two traps: #5631 is a multi-package pricing iceberg mislabeled cleanup, and two "small" dregs are secretly protocol/cross-client changes.

--- a/docs/reports/audit-results/03-guardian.md
+++ b/docs/reports/audit-results/03-guardian.md
@@ -1,0 +1,53 @@
+# Guardian's Audit: Reconnect / Lifecycle Cluster
+
+**Agent**: Guardian — paranoid SRE/security; races, data-integrity, 3am pages
+**Overall Rating**: 3 / 5
+**Date**: 2026-06-13
+
+---
+
+## #5622 — Reconnect-storm starves the event loop (HEADLINE)
+Confirmed, and worse than the title implies, but narrower than "anonymous DoS." The eager E2E handshake runs **inline, synchronously, on the main loop** for every successful auth: client `prepareEagerKeyExchange()` fires in `socket.onopen` on every reconnect (`message-handler.ts:2912-2913`); server derives per connection — `createKeyPair()`, `deriveSharedKey()` (`nacl.box.before`), `signExchangeKey()` (Ed25519), `deriveConnectionKey()` (SHA-512) at `ws-history.js:185-197`. All pure-JS tweetnacl (`crypto.ts`), no worker offload, no `crypto.subtle`.
+
+**Rate-limiting doesn't save you:** `authFailures` throttling only fires on auth *failure* (`ws-auth.js:219-227`); a valid token is never rate-limited and the derivation happens *after* auth succeeds. The `_maxPendingConnections=20` cap counts only *unauthenticated* sockets (`ws-client-manager.js:400-406`) — bounds concurrent in-flight handshakes, not derivation throughput. No cap on authenticated connections.
+
+**Realistic trigger = fan-in:** a supervisor restart / tunnel flap drops every client; phone + N desktop tabs all reconnect in the same window, each firing a synchronous handshake on the cold-starting child. Self-DoS amplification on restart. **RISK: likelihood HIGH × impact MEDIUM = HIGH.**
+
+## #5623 / #5613 — stale session_role across reconnect
+#5613 (server re-emit) fixed (`ws-history.js:763-769`, clears stale role via `primaryClientId:null`). **Residual:** the re-sync is inside `sendSessionInfo`, called only for the *active* session on reconnect (`ws-history.js:480`) — background subscribed sessions don't get a fresh `session_role`. **RISK: likelihood MED × impact LOW = LOW.**
+
+## Standby EADDRINUSE give-up
+`20 × 500ms = 10s` then resets `_standbyRetries=0` and returns silently (`supervisor.js:543-546`); child restart proceeds independently — correct. **Adjacent hazard:** the retry path schedules a `setTimeout` that nulls `_standbyServer` then re-enters `_startStandbyServer`; if `_stopStandbyServer()` runs between the error firing and the timeout, you can flap a half-open listener. Won't crash (guarded), but flap-leaks under exactly the contended restart it exists for. **RISK: LOW × LOW = LOW.** Bump the cap + tighten the close/re-enter race.
+
+## resume_budget silent no-op
+The WS handler is a literal no-op stub: `resumeBudget: () => {}` (`ws-message-handlers.js:136`), while the real `sessionManager.resumeBudget()` exists unused (`session-manager.js:2653`). A client clicking resume gets no ack and nothing happens — a **dead button**. No false-ack desync as-is; the *proposed* fix (reuse `budget_resumed`) is what would create one. Needs a dedicated ack wire-type. **RISK: MED × LOW = LOW** (stuck-control footgun, no integrity hole).
+
+## Question-answer stale-toolUseId fallback (the one I'd lose sleep over)
+Two layered weaknesses: (1) routing falls back to active session when toolUseId is absent/unmapped — `const questionSessionId = (msg.toolUseId && questionSessionMap.get(msg.toolUseId)) || client.activeSessionId` (`input-handlers.js:808`); (2) cli/sdk `respondToQuestion(text)` writes to stdin if `_waitingForAnswer` is true with **no toolUseId match** (`cli-session.js:1487-1503`). Repro: Q1(A) times out → turn advances → Q2(B) sets waiting again → a late answer to Q1 arrives → A unmapped → falls back to active session → fed to Q2. Cross-session is gated (subscribe check at 825-828), so damage is **intra-session answer-to-wrong-question** — a deny can become an approve on a different tool. **RISK: likelihood LOW × impact HIGH = MEDIUM-HIGH.**
+
+## Harness-preamble — trust
+The global key from `~/.chroxy/config.json` is operator-owned (pre-trusted daemon class) — right boundary. Get right: apply the 4000-char cap to the **folded total**, not per-segment, else a long global preamble silently squeezes out the operator's trusted repo/session text. Keep the global slot writable only from local config (no remote `set_session_preamble` into it). **RISK: LOW.**
+
+## #5668 / #5631 / #5674 — scanned for safety only
+All LOW: reliability/UX/parity, no new attack surface; #5673 already stamps `sessionId` server-side so #5674 is display-only (no wire-level mis-attribution).
+
+## Risk heatmap
+```
+            IMPACT →
+          LOW         MEDIUM        HIGH
+  HIGH  |           | #5622       |             |
+  MED   | resume_   |             | qa-stale-   |
+        | budget    |             | toolUseId   |
+  LOW   | EADDRINUSE | harness cap | (mis-route) |
+        | #5613 fixd | #5631/#5674 |             |
+```
+
+## Recommendations (hard gates before the reconnect sprint)
+- **#5622:** bound the *derivation*, not just the client ladder — per-token throttle on the authenticated path, cap authenticated connections per token, offload/stagger the scalar-mults, add a handshake-per-sec metric.
+- **qa-stale-toolUseId:** when toolUseId is present but unmapped, **drop + log, do NOT fall back to active session**; pass toolUseId into cli/sdk `respondToQuestion` to refuse id-mismatched answers (claude-tui already does).
+- **resume_budget:** wire the stub + dedicated `budget_resume_ack`.
+- **#5623 residual:** re-emit `session_role` for all subscribed sessions on reconnect.
+- **harness-preamble:** cap the folded total; global slot local-config-only.
+
+## Verdict: 3 / 5
+The cluster is structurally sound (trust gates, #5737 re-emit, #5748 double-fork fix, bounded client ladder all real), but #5622's mitigation is aimed at the wrong layer and the qa-stale-toolUseId hole needs a fail-closed guard regardless of whether its fix ships.

--- a/docs/reports/audit-results/04-minimalist.md
+++ b/docs/reports/audit-results/04-minimalist.md
@@ -1,0 +1,45 @@
+# Minimalist's Audit: Status Report Backlog
+
+**Agent**: Minimalist — ruthless YAGNI; best code is no code
+**Overall Rating**: 3 / 5 (plan leanness)
+**Date**: 2026-06-13
+
+---
+
+## Per-item verdicts
+
+### Friction backlog (§3)
+| Item | Verdict | Justification |
+|---|---|---|
+| #5631 model-metadata | **SIMPLIFY → KEEP-thin** | Much already fixed; #5745 added drift-warn. Remaining = a fallback-rendering pass (unknown model → show id, gate off capability chips), not a metadata service. Cut any "fetch model catalog from API" ambition. |
+| #5623/#5613 reconnect role | **KEEP — but already shipped** | #5737 re-emits `session_role`; effectively closed on dashboard. Verify+close. Only live remainder = app-side `sessionRole` reset. |
+| #5622 reconnect-storm perf | **DEFER (until measured)** | `maxPendingConnections=20` (`ws-server.js:524`) already bounds pre-auth sockets. "Starves the event loop" is plausible-but-unproven. Don't build a derivation queue/worker-pool on spec — defer until a flamegraph shows `box.before` dominating under a real storm. |
+| #5674 mobile attribution | **KEEP** | Genuine parity gap; `buildPromptSessionLabel` exists + tested. Finish-the-port, cheapest real win. |
+| #5668 mic surfacing | **SIMPLIFY → tiny** | Code half shipped; real fix was the .app rebuild. What remains = one `session_error` on spawn-fail. Don't build a mic-diagnostics panel. |
+
+### Cleanup list
+| Item | Verdict | Justification |
+|---|---|---|
+| #5618 dispatch-table | DEFER | Handlers already modular via `handlerRegistry`. Further migration = refactor-for-elegance, zero user payoff. |
+| #5620 dual JSON-write | DEFER/CUT | Silent-loss risk already addressed (#5729/#5734). Remaining "collapse" is cosmetic. |
+| #5621 retry-ladder dedupe | DEFER | Ladder just reworked (#5724); user-facing behavior already correct. |
+| #5617 claude-tui FormDriver | DEFER (unless it fixes a wedge) | If it reduces wedge risk → KEEP; if just testability → DEFER. |
+| #5619 both-clients contract | SIMPLIFY → KEEP-thin | Real leverage given store-core ripple pain. Scope to a lint that'd have caught actual regressions, not a full contract DSL. |
+
+### #5731 dregs — all three CUT (wontfix)
+- `resume_budget`: `resume()` is `this._budgetPaused.delete(sessionId)` (`cost-budget-manager.js:132`); harmless when never paused. Clean fix needs a new wire type. **Fix more complex than the bug.**
+- standby EADDRINUSE: already retries 20×500ms=10s (`supervisor.js:33-34,542`). One-line cap bump at most.
+- question-answer toolUseId: high-blast-radius for a near-unreachable legacy case.
+
+## Harness-preamble (§4) — YAGNI. CUT, or build the 30-minute version.
+`_buildSystemPrompt()` already concatenates `sessionPreamble → hint → skills` (`base-session.js:1091-1107`); per-repo presets already fold automatically (`repos[].sessionPreset`, `findRepoPresetFile`, `foldPreamble` at `session-preset.js:201`, `session-manager.js:789`). **A motivated user gets ~95% today** by dropping onboarding text into `~/.chroxy/config.json` `sessionPreset.preamble`. The global key only adds "one preamble across all repos." The §4 framing oversells the gap. If built: one `harnessPreamble` string, folded first via the existing chain. **Cut the per-provider notes entirely** — pure YAGNI, multiplies config surface + test matrix. Real uncosted risk: a global preamble burns context tokens on *every turn of every session* — a permanent tax for a hunch.
+
+## Top 5 smallest-change-biggest-friction
+1. **Verify+close #5623/#5613** — already paid for.
+2. **#5674 mobile attribution** — port the shipped `buildPromptSessionLabel`.
+3. **#5631 unknown-model graceful default** — one fallback path (reuse the #5747 capability-gating pattern).
+4. **#5668 mic spawn-fail surfacing** — one `session_error` broadcast.
+5. **Close #5731 (3 dregs wontfix) + close §4 as "use per-repo preset"** — backlog hygiene, removes 4 phantom items.
+
+## Verdict: 3 / 5
+The plan is *half* lean. Discipline on shipped work was genuinely good (closing #5697 wontfix, the `switchSession` no-op). But §5 drifts toward capability: a "reconnect sprint" around #5622 (likely already bounded by the 20-cap), and "build the harness preamble" when per-repo presets already deliver ~95%. **Single highest-leverage cut: kill the harness-preamble feature.** It's the only new surface proposed, it's YAGNI against working plumbing, its per-provider sub-feature is unbounded speculation, and it imposes a permanent per-turn token tax. Then close #5731 + the cleanup issues to stop the backlog masquerading as work.

--- a/docs/reports/audit-results/05-operator.md
+++ b/docs/reports/audit-results/05-operator.md
@@ -1,0 +1,41 @@
+# Operator's Audit: Daily UX Friction
+
+**Agent**: Operator — walks every flow as a real phone + desktop user; weights reconnect, voice, a11y
+**Overall Rating**: 3 / 5 (§5 next-moves vs real daily pain)
+**Date**: 2026-06-13
+
+---
+
+Headline: the report's instinct is right (reconnect + voice are the felt pain) but two priorities are miscalibrated — #5674 is essentially shipped, #5631 barely touches daily Claude use, and the genuine live bug it under-rates (#5668 silent voice revert) is concretely confirmed in the wiring.
+
+## Per-item UX verdict (friction = frequency × hurt)
+| Item | Frequency | Hurt | Friction | Verdict |
+|---|---|---|---|---|
+| #5623/#5613 stale "Observing" flash | High (every drop) | Medium (false "observing" + audible SR alarm; ~1s) | **HIGH** | Server re-emit (#5737) shrinks but doesn't close — neither client clears `sessionRole` on disconnect. |
+| #5668 mic silent revert (desktop) | Low-med | **High** (headline feature appears broken, no explanation) | **HIGH** | Confirmed live: error captured in hook, never rendered. |
+| #5674 mobile attribution | Medium | — | **LOW (mostly done)** | Label + containment shipped; residual = no per-tab "needs you" signal. |
+| #5631 model metadata | Low | Low-med (raw-id label; blank cost on Codex/Gemini only) | **LOW-MED** | Over-weighted; server authoritative for Claude cost. |
+| #5622 reconnect-storm | Rare | Low (server CPU, invisible to 1-2 device user) | **LOW** | Already de-amplified by #5724. |
+| harness-preamble | Every session | — (invisible plumbing) | **LOW (felt)** | Nice-to-have, not a papercut. |
+
+## Top 5 papercuts that most erode "use chroxy instead of the CLI"
+1. **Voice failure is silent on desktop (#5668).** `useVoiceInput` captures the error (`useVoiceInput.ts:300`, sets `error`+reverts `isRecording`) — but the `voiceInput` prop passed to InputBar (`InputBar.tsx:85-92`) **omits `error`**, and `App.tsx:2132` never reads `voiceInput.error` (returned at `useVoiceInput.ts:479`). The mic flips on for a frame, flips off, says nothing. **Fix: add `error` to the prop and render it.**
+2. **Stale "Observing" flash on every reconnect (#5623).** `app/src/store/connection.ts:1195-1248` (`onclose`) clears streaming/plan/inactivity across sessions but **never `sessionRole`/`primaryClientId`**. Dashboard identical (`dashboard/src/store/connection.ts:1682-1707`). #5737 fixed the server re-emit, not the client flash. **Fix: clear `sessionRole`/`primaryClientId` in both onclose transient-clears (symmetric, cheap).**
+3. **No per-tab "blocked on you" signal on mobile (#5674 residual).** The prompt label shipped (`MessageBubble.tsx:63-73,374-380`) but the session-tab pill (`SessionPicker.tsx:102-108`) renders crash/busy/notification/shells dots — **no pending-permission indicator**. A background session blocked on a permission looks identical to one just thinking. Dashboard has `derivePendingPermissionSessions`/`selectNextPendingSession`; mobile doesn't.
+4. **Model labels degrade to raw ids (#5631, the real-felt half).** `modelInfo?.label || activeModel` (`SettingsBar.tsx:318`) falls back to raw id. Dashboard's `model-pricing.ts` mislabels `claude-sonnet-4-5` as "Claude 3.7 Sonnet" (line 30), no opus-4-7/sonnet-4-6/fable. But cost impact is contained: `calculateCost` is only a fallback for Codex/Gemini (`message-handler.ts:3693-3706`); Claude cost comes from the server (`models.js:62-100`, current, has `claude-fable-5`). Daily Claude user sees an ugly raw-id label, not a blank cost. The two-table drift is the defect.
+5. **Reconnect a11y false alarm (compounds #5623).** `ObserverBanner` is `accessibilityRole="alert"` + `accessibilityLiveRegion="polite"` (`ObserverBanner.tsx:54-56`). Stale role survives the drop → every reconnect re-announces "Observing — another device is driving" before clearing. Fixing #5623 fixes this for free.
+
+## Accessibility gaps adjacent
+- #5733 landed dashboard-only (`PermissionPrompt.tsx:200-202` `alertdialog`+`aria-live`, countdown muted — right).
+- **Mobile has no "prompt arrived" announcement.** `PermissionDetail.tsx` has control labels + a polite countdown (399) but **no assertive live-region announcing a new prompt bubble** — the mobile parallel to #5733. Open a11y gap.
+- ObserverBanner announces a soon-to-be-cleared state (finding 5).
+
+## Recommended user-facing priority order
+1. #5668 — surface voice errors (desktop). Tiny, kills "feature looks broken."
+2. #5623/#5613 — clear `sessionRole` on disconnect (both clients). ~2 lines; most-frequent jank + a11y alarm.
+3. #5674 residual — per-tab pending dot on mobile + assertive prompt announcement.
+4. #5631 — collapse to one model table + fix the stale `claude-sonnet-4-5` label.
+5. #5622 / harness-preamble — defer.
+
+## Verdict: 3 / 5
+§5 correctly identifies reconnect as the jank epicenter and is right to put #5674 last. But it **omits #5668's surfacing gap from the priority list** (only "confirm the mic"), yet that's a concretely-wired live bug on a headline feature; it **inflates #5631 to #4** when the real defect is server↔dashboard table drift, not UI-wide degradation; and it **over-weights #5622** as user-felt when it's server-CPU a 1-2 device user never notices.

--- a/docs/reports/audit-results/06-futurist.md
+++ b/docs/reports/audit-results/06-futurist.md
@@ -1,0 +1,43 @@
+# Futurist's Audit: Long-Term Architecture
+
+**Agent**: Futurist — extensibility, tech-debt forecast, decisions that calcify
+**Overall Rating**: 4 / 5 (architectural soundness of the forward plan)
+**Date**: 2026-06-13
+
+---
+
+## 1. Harness-preamble — SOUND, with one revision (don't invent a new fold mechanism)
+Prompt assembled in `BaseSession._buildSystemPrompt()` (`base-session.js:1091-1107`): a 3-way concat (preamble / hint / skills). **Repo+session folding happens at create time, not here** — `session-manager.js:777-816` calls `resolveSessionPreset()` then `foldPreamble(resolved.preamble, sessionPreamble)` (`session-preset.js:201-213`) and stores the *single folded string* into `sessionPreamble`. The 4000-char cap (`SESSION_PREAMBLE_MAX_LENGTH`, base-session.js:42) is enforced on that folded result.
+
+**Load-bearing finding:** if the global harness text is prepended into the same `sessionPreamble` slot, it **competes for the same 4000-char budget** and will silently truncate the user's trusted repo/session voice; the existing `capped` disclosure fires on content the user didn't author.
+
+**Revision (clean, non-calcifying):**
+1. Keep the harness preamble as its **own `parts.push()` entry in `_buildSystemPrompt()`**, not folded into `sessionPreamble`. Add `harnessPreamble` to the `BaseSession` ctor destructure AND `BASE_SESSION_OPT_KEYS` (same PR — the #5367 picker contract forwards it to every provider for free). Order: `harnessPreamble → sessionPreamble(folded) → hint → skills`.
+2. Give it its **own cap** (or none — operator-authored in `~/.chroxy/config.json`, same trust class as the daemon override). Do NOT route through `foldPreamble`'s shared budget.
+
+**Per-provider tailoring:** maps cleanly onto the existing `static capabilities` getter (`claude-tui-session.js:87-114`). **Generate** the note from `ProviderClass.capabilities` at create — don't let operators hand-author per-provider variants (that re-creates the #5631 drift one layer up).
+
+## 2. Model-metadata (#5631) — STRUCTURAL; the server is mostly there, the debt is the dashboard
+Server side already structurally fixed: `models.js` is a real registry (`createModelsRegistry()` line 536) with a **user-extensible overlay** (`~/.chroxy/models.json`, `loadModelsOverlay` line 330) seeding new ids/labels/windows/pricing with no code change. `FALLBACK_MODELS` now has `fable`/`claude-fable-5`+`opus-4-7`. Graceful degradation real: `humanizeModelId` (490), `computePromptCostUsd` returns `null` not `0` (263-284), warn-once drift guard (819-825).
+
+**Unfixed seam = the dashboard.** `model-pricing.ts` is an independent hardcoded 3.7/3.5-era table that can't see the overlay and is the single source for `CLIENT_ESTIMATED_COST_PROVIDERS`. The wire makes it worse: `ServerAvailableModelsEntrySchema` (`protocol/server.ts:409-418`) carries `{id,label,fullId,contextWindow}` but **no pricing** — server *knows* overlay pricing, dashboard *can't receive it*. #5745 was a manual patch — the treadmill.
+
+**Recommendation (structural):** extend `ServerAvailableModelsEntrySchema` with optional `pricing`, populate from `resolveModelPricing` (overlay-aware), demote `model-pricing.ts` to fallback-only. Single source of truth end-to-end; a new model = one overlay entry priced in both. The remaining #5631 work is ~80% "wire pricing through + retire the dashboard table," not greenfield. One valid server gap: `session-manager.js` doesn't validate the initial model against `getAllowedModelIds()` (point 6) — soft-validate-and-warn for non-Claude.
+
+## 3. Top 5 long-term findings
+1. **Dual pricing tables with a wire gap that forbids convergence.** Highest-leverage structural debt. Fix = add `pricing` to the wire entry; demote the dashboard table.
+2. **Harness-preamble 4000-char budget collision** if folded into `sessionPreamble`. Pre-empt with its own slot + own cap.
+3. **`BASE_SESSION_OPT_KEYS` is the most important extension contract** (lint-enforced). Any new preamble/metadata opt MUST route through the picker — else re-open the #3224/#4790 middle-layer trap.
+4. **Per-provider tailoring is tempting to hand-author and will rot.** `static capabilities` is the correct *generative* source; any parallel table becomes drift.
+5. **`humanizeModelId` is a Claude-shaped heuristic doing double duty as the universal fallback** — latent mis-render as providers proliferate; ensure new providers supply `getModelMetadata`.
+
+## 4. Cleanup items — real vs cosmetic
+- **#5618 dispatch-table — REAL debt (prioritize).** The twin message-handlers grew +968 lines with only ~21 of ~95 cases on the shared `runDispatch` table; the rest unprotected from drift — the same dual-table failure mode as the pricing tables, at the handler layer.
+- **#5621 retry-ladder dedupe — REAL but small.** `MAX_RETRIES`/`RETRY_DELAYS` hand-redeclared in both `connection.ts` despite `connect-flow.ts` exporting them. Two stragglers that can silently diverge.
+- **#5620 dual JSON-write — COSMETIC/dead-code.** `JsonStateFile` never instantiated. Defer/opportunistic.
+
+## 5. Reconnect items — point fixes correct, no missing abstraction
+The reconnect state machine already exists + is shared (`ConnectionPhase` + `createReconnectScheduler` + `RECONNECT_MAX_RUNG`, `connection.ts:151-158,1480`). #5724/#5737 *extended* it rather than scattering fixes — the abstraction is holding. #5623/#5613 are state-resync gaps, not a missing machine; #5622 is an orthogonal backpressure gap. No rewrite warranted.
+
+## Verdict: 4 / 5
+The codebase is healthier than the report's framing — the server has the overlay registry and shared reconnect machine that #5631 and the reconnect backlog ostensibly need, so most "new feature" work is *finishing convergence*, not greenfield. The one place the plan would calcify is the harness-preamble if folded into the existing `sessionPreamble` slot sharing the 4000-char budget; its own slot + own cap + picker-forwarding + capability-*generated* notes turns it into the cleanest extension point. Docked one point: the report treats the dual pricing tables + pricing-less wire schema as a UX nit when it's the load-bearing extensibility decision, and proposes per-provider tailoring without naming the capability registry as the source.

--- a/docs/reports/status-2026-06-13.html
+++ b/docs/reports/status-2026-06-13.html
@@ -59,7 +59,7 @@
 </header>
 
 <div class="callout good">
-  <strong>✓ Closed out &amp; re-baselined — 2026-06-13.</strong> A 6-agent swarm audit (Skeptic · Builder · Guardian · Minimalist · Operator · Futurist) verified every backlog item below against current <code>main</code>. Full results: <a href="audit-results/00-master-assessment.md"><code>docs/reports/audit-results/</code></a>. Verdict on the forward plan: <strong>3.1 / 5 — the §3 friction table and §5 next-moves are a snapshot from the <em>start</em> of the marathon and were never re-baselined against the 19 PRs this report documents merging.</strong> The §1.5 record-of-work is accurate; the forward-looking sections below are <span class="muted">superseded by the reconciliation in the next box</span>.
+  <strong>✓ Closed out &amp; re-baselined — 2026-06-13.</strong> A 6-agent swarm audit (Skeptic · Builder · Guardian · Minimalist · Operator · Futurist) verified every backlog item below against current <code>main</code>. Full results: <a href="audit-results/00-master-assessment.md"><code>audit-results/00-master-assessment.md</code></a> (in <code>docs/reports/audit-results/</code>). Verdict on the forward plan: <strong>3.1 / 5 — the §3 friction table and §5 next-moves are a snapshot from the <em>start</em> of the marathon and were never re-baselined against the 19 PRs this report documents merging.</strong> The §1.5 record-of-work is accurate; the forward-looking sections below are <span class="muted">superseded by the reconciliation in the next box</span>.
 </div>
 
 <div class="callout">

--- a/docs/reports/status-2026-06-13.html
+++ b/docs/reports/status-2026-06-13.html
@@ -58,6 +58,24 @@
   <div class="sub">Generated 2026-06-13 · remote terminal harness for Claude Code · monorepo (server · app · desktop · dashboard · protocol · store-core · claude-hooks)</div>
 </header>
 
+<div class="callout good">
+  <strong>✓ Closed out &amp; re-baselined — 2026-06-13.</strong> A 6-agent swarm audit (Skeptic · Builder · Guardian · Minimalist · Operator · Futurist) verified every backlog item below against current <code>main</code>. Full results: <a href="audit-results/00-master-assessment.md"><code>docs/reports/audit-results/</code></a>. Verdict on the forward plan: <strong>3.1 / 5 — the §3 friction table and §5 next-moves are a snapshot from the <em>start</em> of the marathon and were never re-baselined against the 19 PRs this report documents merging.</strong> The §1.5 record-of-work is accurate; the forward-looking sections below are <span class="muted">superseded by the reconciliation in the next box</span>.
+</div>
+
+<div class="callout">
+  <strong>Backlog reconciliation (what's actually open).</strong>
+  <ul>
+    <li><span class="pill ok">closed</span> <strong>#5613</strong> — fixed in code by #5737, only orphaned-open by GitHub's comma-list closing-keyword quirk. Closed.</li>
+    <li><span class="pill warn">reopened</span> <strong>#5623</strong> — its literal ask (clear <code>sessionRole</code> on disconnect, both clients) was <em>never</em> implemented; #5737 only shipped the server re-emit, leaving a flash window + an a11y false-alarm. Scope expanded to both clients.</li>
+    <li><span class="pill neutral">already shipped</span> <strong>#5674</strong> stays closed (#5694). Residual mobile parity (per-tab pending-permission dot + assertive a11y announcement) filed as <strong>#5750</strong>.</li>
+    <li><span class="pill info">re-scoped</span> <strong>#5631</strong> — ~60% done by #5663; real remaining work is the dashboard pricing-table drift + the pricing-less wire schema, not UI-wide degradation (annotated on the issue).</li>
+    <li><span class="pill info">re-aimed</span> <strong>#5622</strong> — the fix must bound the <em>server</em> derivation throughput (the only backstop counts the wrong sockets), and it's not user-felt for a solo driver (annotated).</li>
+    <li><span class="pill bad">live bug</span> <strong>#5668</strong> — the desktop "surface voice failures" half is a concrete unfixed wiring gap (<code>voiceInput.error</code> captured but never rendered); the audit's top felt-friction win.</li>
+    <li><span class="pill info">new</span> <strong>#5751</strong> harness-preamble (Futurist-minimal design) · <strong>#5752</strong> <code>resume_budget</code> dead-button · <strong>#5753</strong> question-answer fail-closed <code>toolUseId</code> guard.</li>
+  </ul>
+  <p class="muted"><strong>Ship order (Tier A — cheap, high felt-friction):</strong> #5668 desktop voice-error surfacing → #5623 clear role on disconnect (both clients) → #5631 quick-win (opus→4-8 + dashboard labels). Then #5750 mobile parity, #5631 structural.</p>
+</div>
+
 <div class="cards">
   <div class="card"><div class="n" style="color:var(--green)">4 / 4</div><div class="l">Target bugs resolved</div></div>
   <div class="card"><div class="n">3</div><div class="l">PRs merged this session</div></div>


### PR DESCRIPTION
Runs the user-requested `/swarm-audit` over the open backlog in `docs/reports/status-2026-06-13.html`, then closes the report out and re-baselines it.

## What's here
- **6-agent swarm audit** (`docs/reports/audit-results/`): Skeptic · Builder · Guardian · Minimalist · Operator · Futurist, each verifying every backlog item against current `main`. Master assessment + 6 per-agent reports.
- **Report closeout banner** on `status-2026-06-13.html` recording the verdict (3.1/5 on the forward plan) and the reconciled issue states.

## Headline finding
The report's forward tables (§3/§5) were a snapshot from the *start* of the marathon and never re-baselined against the 19 PRs the report itself documents merging:
- **#5623, #5674 already closed**; **#5613 fixed-in-code but orphaned-open** (comma-list closing-keyword quirk); **#5631 ~60% shipped** by #5663.
- Two genuinely-open felt-friction wins were *missing* from §5: the **desktop voice silent-fail** (#5668 — `voiceInput.error` captured but never rendered) and the **residual client-side reconnect role flash** (#5623's literal, un-implemented ask).

## Backlog reconciliation done with this PR
- Closed **#5613** · reopened **#5623** (scope = both clients) · annotated **#5631 / #5622 / #5668** with concrete findings.
- Filed **#5750** (mobile pending-permission parity) · **#5751** (harness-preamble, Futurist-minimal design) · **#5752** (resume_budget dead-button) · **#5753** (question-answer fail-closed toolUseId guard).

Docs-only; no code paths touched.