### PR TITLE
fix(ws): clear sessionRole on disconnect so the Observing badge doesn't survive a reconnect (#5623)

### DIFF
--- a/packages/app/src/__tests__/store/connection-reconnect-backoff.test.ts
+++ b/packages/app/src/__tests__/store/connection-reconnect-backoff.test.ts
@@ -300,3 +300,54 @@ describe('backoff ladder resets on auth_ok, not socket-open (#5555.5)', () => {
     ws.restore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #5623 — onclose clears the presence role on every session so a stale
+// "Observing"/driver badge doesn't survive the reconnect gap. The server
+// re-emits session_role on reconnect/tab-switch, re-establishing the role.
+// ---------------------------------------------------------------------------
+
+describe('onclose clears sessionRole/primaryClientId on all sessions (#5623)', () => {
+  async function openConnectedSocket() {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' }));
+    global.fetch = fetchMock;
+    const ws = installMockWebSocket();
+
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    await flushPromises();
+    useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+    return { ws };
+  }
+
+  it('nulls sessionRole and primaryClientId across active + background sessions', async () => {
+    const { ws } = await openConnectedSocket();
+
+    useConnectionStore.setState({
+      activeSessionId: 'a',
+      sessionStates: {
+        a: {
+          messages: [],
+          sessionRole: 'observer',
+          primaryClientId: 'other-device',
+        },
+        b: {
+          messages: [],
+          sessionRole: 'primary',
+          primaryClientId: 'me',
+        },
+      } as never,
+    });
+
+    const socket = ws.instances[ws.instances.length - 1];
+    socket.onclose?.({ code: 1006 });
+    await flushPromises();
+
+    const st = useConnectionStore.getState();
+    expect(st.sessionStates.a!.sessionRole).toBeNull();
+    expect(st.sessionStates.a!.primaryClientId).toBeNull();
+    expect(st.sessionStates.b!.sessionRole).toBeNull();
+    expect(st.sessionStates.b!.primaryClientId).toBeNull();
+
+    ws.restore();
+  });
+});

--- a/packages/app/src/__tests__/store/connection-reconnect-backoff.test.ts
+++ b/packages/app/src/__tests__/store/connection-reconnect-backoff.test.ts
@@ -350,4 +350,29 @@ describe('onclose clears sessionRole/primaryClientId on all sessions (#5623)', (
 
     ws.restore();
   });
+
+  // User-initiated disconnect() nulls socket.onclose, so the onclose clear
+  // never runs — the role-clear must be mirrored here too (#5623).
+  it('also clears roles on user-initiated disconnect()', async () => {
+    const { ws } = await openConnectedSocket();
+
+    useConnectionStore.setState({
+      activeSessionId: 'a',
+      sessionStates: {
+        a: { messages: [], sessionRole: 'observer', primaryClientId: 'other-device' },
+        b: { messages: [], sessionRole: 'primary', primaryClientId: 'me' },
+      } as never,
+    });
+
+    useConnectionStore.getState().disconnect();
+    await flushPromises();
+
+    const st = useConnectionStore.getState();
+    expect(st.sessionStates.a!.sessionRole).toBeNull();
+    expect(st.sessionStates.a!.primaryClientId).toBeNull();
+    expect(st.sessionStates.b!.sessionRole).toBeNull();
+    expect(st.sessionStates.b!.primaryClientId).toBeNull();
+
+    ws.restore();
+  });
 });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -444,6 +444,44 @@ function clearInactivityWarningsAcrossSessions(
   if (changed) set({ sessionStates: next });
 }
 
+/**
+ * #5623 — clear the presence role (`sessionRole` + `primaryClientId`) on
+ * every session in the store.
+ *
+ * Used by both the `socket.onclose` cleanup (transport-level drop) and the
+ * user-initiated `disconnect()` path (which nulls `socket.onclose` so the
+ * close handler never runs) — same dual-call contract as
+ * `clearInactivityWarningsAcrossSessions`. Iterating all sessions matters
+ * because a stale "Observing"/driver badge on any session (and the
+ * `ObserverBanner`'s `accessibilityRole="alert"` live-region re-announcing
+ * it) must not survive the drop. The server re-emits `session_role` on
+ * reconnect/re-subscribe, so the correct role re-establishes once the socket
+ * is back; a null role in the meantime reads as "unclaimed" (neutral).
+ *
+ * Pure shape: skips the mutation when no roles are set so we don't churn
+ * referential equality.
+ */
+function clearSessionRolesAcrossSessions(
+  set: (s: Partial<ConnectionState> | ((state: ConnectionState) => Partial<ConnectionState>)) => void,
+  get: () => ConnectionState,
+): void {
+  const sessionStates = get().sessionStates;
+  const ids = Object.keys(sessionStates);
+  if (ids.length === 0) return;
+  let changed = false;
+  const next: Record<string, SessionState> = {};
+  for (const id of ids) {
+    const ss = sessionStates[id];
+    if (ss && (ss.sessionRole !== null || ss.primaryClientId !== null)) {
+      next[id] = { ...ss, sessionRole: null, primaryClientId: null };
+      changed = true;
+    } else if (ss) {
+      next[id] = ss;
+    }
+  }
+  if (changed) set({ sessionStates: next });
+}
+
 export const useConnectionStore = create<ConnectionState>((set, get) => ({
   socket: null,
   sessions: [],
@@ -1219,22 +1257,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // agent is still quiet post-reconnect, the next soft-timeout
       // firing server-side will re-emit.
       clearInactivityWarningsAcrossSessions(set, get);
-      // #5623: clear the presence role across ALL sessions on disconnect
-      // so a stale "Observing" / driver badge — and the ObserverBanner's
-      // accessibilityRole="alert" live-region re-announcing it — doesn't
-      // persist through the reconnect gap. #5737 added the server re-emit
-      // but the client never reset its own copy, so the old role survived
-      // the drop. The server re-emits `session_role` on reconnect/tab-
-      // switch, so the correct role re-establishes once the socket is
-      // back; a null role in the meantime reads as "unclaimed" (neutral).
-      for (const sid of Object.keys(get().sessionStates)) {
-        updateSession(sid, (ss) => {
-          const patch: Partial<import('./types').SessionState> = {};
-          if (ss.sessionRole !== null) patch.sessionRole = null;
-          if (ss.primaryClientId !== null) patch.primaryClientId = null;
-          return Object.keys(patch).length > 0 ? patch : {};
-        });
-      }
+      // #5623: clear the presence role across ALL sessions so a stale
+      // "Observing"/driver badge doesn't survive the reconnect gap.
+      clearSessionRolesAcrossSessions(set, get);
 
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
       if (wasConnected && disconnectedAttemptId !== myAttemptId) {
@@ -1314,6 +1339,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // and any outstanding check-in chip would survive into the next
     // connection. Mirror the cleanup across all sessions here.
     clearInactivityWarningsAcrossSessions(set, get);
+    // #5623: same dual-call contract — user-initiated disconnect nulls
+    // socket.onclose above, so the onclose role-clear never runs; mirror
+    // it here so a stale "Observing"/driver badge doesn't survive into
+    // the next connect.
+    clearSessionRolesAcrossSessions(set, get);
     // Reset replay flags in case disconnect happened mid-replay
     resetReplayFlags();
     // #5555.3/.4 — explicit disconnect is a hard reset: drop the replay

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1219,6 +1219,22 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // agent is still quiet post-reconnect, the next soft-timeout
       // firing server-side will re-emit.
       clearInactivityWarningsAcrossSessions(set, get);
+      // #5623: clear the presence role across ALL sessions on disconnect
+      // so a stale "Observing" / driver badge — and the ObserverBanner's
+      // accessibilityRole="alert" live-region re-announcing it — doesn't
+      // persist through the reconnect gap. #5737 added the server re-emit
+      // but the client never reset its own copy, so the old role survived
+      // the drop. The server re-emits `session_role` on reconnect/tab-
+      // switch, so the correct role re-establishes once the socket is
+      // back; a null role in the meantime reads as "unclaimed" (neutral).
+      for (const sid of Object.keys(get().sessionStates)) {
+        updateSession(sid, (ss) => {
+          const patch: Partial<import('./types').SessionState> = {};
+          if (ss.sessionRole !== null) patch.sessionRole = null;
+          if (ss.primaryClientId !== null) patch.primaryClientId = null;
+          return Object.keys(patch).length > 0 ? patch : {};
+        });
+      }
 
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
       if (wasConnected && disconnectedAttemptId !== myAttemptId) {

--- a/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
+++ b/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
@@ -308,4 +308,46 @@ describe('onclose clears transient state across all sessions (#5731 T4)', () => 
     expect(st.sessionStates.b!.pendingEvaluatorClarify).toBeNull()
     expect(st.sessionStates.b!.inactivityWarning).toBeNull()
   })
+
+  // #5623 — onclose also clears the presence role (sessionRole/primaryClientId)
+  // on every session so a stale "Observing"/driver badge doesn't persist through
+  // the reconnect gap. The server re-emits session_role on reconnect/tab-switch.
+  it('nulls sessionRole / primaryClientId on all sessions (#5623)', async () => {
+    const ws = await openConnected()
+
+    useConnectionStore.setState({
+      activeSessionId: 'a',
+      sessionStates: {
+        a: {
+          messages: [],
+          streamingMessageId: null,
+          isPlanPending: false,
+          planAllowedPrompts: [],
+          pendingEvaluatorClarify: null,
+          inactivityWarning: null,
+          sessionRole: 'observer',
+          primaryClientId: 'other-device',
+        },
+        b: {
+          messages: [],
+          streamingMessageId: null,
+          isPlanPending: false,
+          planAllowedPrompts: [],
+          pendingEvaluatorClarify: null,
+          inactivityWarning: null,
+          sessionRole: 'primary',
+          primaryClientId: 'me',
+        },
+      } as never,
+    })
+
+    ws.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const st = useConnectionStore.getState()
+    expect(st.sessionStates.a!.sessionRole).toBeNull()
+    expect(st.sessionStates.a!.primaryClientId).toBeNull()
+    expect(st.sessionStates.b!.sessionRole).toBeNull()
+    expect(st.sessionStates.b!.primaryClientId).toBeNull()
+  })
 })

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1700,6 +1700,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         // state. Clear it; if the agent is still quiet post-reconnect,
         // the next soft-timeout firing will re-emit the warning.
         if (ss.inactivityWarning) patch.inactivityWarning = null;
+        // #5623: clear the presence role on disconnect so a stale
+        // "Observing" / driver badge doesn't persist through the
+        // reconnect gap. #5737 added the server-side re-emit, but the
+        // client never reset its own copy — so the old role survived
+        // the drop (and `ObserverBanner`'s a11y alert re-announced a
+        // soon-to-be-cleared "Observing" on every reconnect). The
+        // server re-emits `session_role` on reconnect/tab-switch, so
+        // the correct role re-establishes once the socket is back; a
+        // null role in the meantime reads as "unclaimed" (neutral),
+        // not a false "you're observing".
+        if (ss.sessionRole !== null) patch.sessionRole = null;
+        if (ss.primaryClientId !== null) patch.primaryClientId = null;
         return Object.keys(patch).length > 0 ? patch : {};
       };
       for (const sid of Object.keys(get().sessionStates)) {


### PR DESCRIPTION
Closes #5623.

## The bug
#5737 added the server-side `session_role` re-emit on reconnect, which is why #5623 looked resolved — but the swarm audit (#5754) found **the client-side clear this issue actually asks for was never implemented**. Neither client resets its own `sessionRole`/`primaryClientId` on disconnect, so:
- a stale **'Observing' / driver badge persists through the reconnect gap** until the server round-trip lands, and
- the app's `ObserverBanner` is `accessibilityRole="alert"` + a live-region, so screen readers **re-announce** a soon-to-be-cleared 'Observing' on every reconnect (an audible false alarm).

## The fix
Clear `sessionRole`/`primaryClientId` across **all** sessions in both clients' `socket.onclose`:
- **dashboard** (`packages/dashboard/src/store/connection.ts`) — folded into the existing #5736 cross-session transient-clear.
- **app** (`packages/app/src/store/connection.ts`) — an all-sessions clear next to the inactivity sweep.

The server re-emits `session_role` on reconnect/tab-switch (#5737), so the correct role re-establishes once the socket is back; a `null` role in the gap reads as 'unclaimed' (neutral), not a false 'you're observing'.

## Tests
- `connection-reconnect-backoff.test.ts` in both packages: assert `sessionRole`/`primaryClientId` are nulled on active + background sessions after `onclose`.
- Full suites green: dashboard 192 files / 3677 tests + tsc; app 141 suites / 1887 tests + tsc.

First of the Tier-A friction fixes from the 2026-06-13 backlog re-baseline (#5754).