### PR TITLE
fix(dashboard): surface voice recognition errors instead of a silent mic-off (#5668)

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2409,6 +2409,7 @@ describe('InputBar push-to-talk (#5610)', () => {
     isRecording: boolean
     isAvailable: boolean
     transcript: string
+    error: string | null
     start: () => void
     stop: () => void
   }> = {}) {
@@ -2416,6 +2417,7 @@ describe('InputBar push-to-talk (#5610)', () => {
       isRecording: false,
       isAvailable: true,
       transcript: '',
+      error: null,
       start: vi.fn(),
       stop: vi.fn(),
       ...overrides,
@@ -2591,7 +2593,7 @@ describe('InputBar push-to-talk (#5610)', () => {
         onInterrupt={vi.fn()}
         controlledValue=""
         onValueChange={() => {}}
-        voiceInput={{ isRecording: false, isAvailable: true, transcript: '', start, stop: firstStop }}
+        voiceInput={{ isRecording: false, isAvailable: true, transcript: '', error: null, start, stop: firstStop }}
       />,
     )
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
@@ -2607,13 +2609,42 @@ describe('InputBar push-to-talk (#5610)', () => {
         onInterrupt={vi.fn()}
         controlledValue=""
         onValueChange={() => {}}
-        voiceInput={{ isRecording: true, isAvailable: true, transcript: '', start, stop: latestStop }}
+        voiceInput={{ isRecording: true, isAvailable: true, transcript: '', error: null, start, stop: latestStop }}
       />,
     )
 
     unmount()
     expect(firstStop).not.toHaveBeenCalled()
     expect(latestStop).toHaveBeenCalledTimes(1)
+  })
+
+  // #5668 — a voice failure must be surfaced, not flipped off silently.
+  it('renders voiceInput.error as an accessible alert', () => {
+    const { rerender } = render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={() => {}}
+        voiceInput={{ isRecording: false, isAvailable: true, transcript: '', error: null, start: vi.fn(), stop: vi.fn() }}
+      />,
+    )
+    // No error → nothing rendered.
+    expect(screen.queryByTestId('voice-error')).toBeNull()
+
+    // Error set (e.g. mic permission denied) → surfaced as a role="alert".
+    rerender(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={() => {}}
+        voiceInput={{ isRecording: false, isAvailable: true, transcript: '', error: 'Microphone access was denied.', start: vi.fn(), stop: vi.fn() }}
+      />,
+    )
+    const alert = screen.getByTestId('voice-error')
+    expect(alert).toHaveAttribute('role', 'alert')
+    expect(alert).toHaveTextContent('Microphone access was denied.')
   })
 
   it('does not arm PTT when voice is unavailable (Space types normally)', () => {

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -87,6 +87,11 @@ export interface InputBarProps {
     isRecording: boolean
     isAvailable: boolean
     transcript: string
+    /** #5668 — last recognition/helper error (e.g. mic permission denied,
+     * helper spawn failure). Captured by `useVoiceInput` but previously
+     * never surfaced, so a failed recording flipped the mic off silently.
+     * Cleared on the next `start()`. */
+    error: string | null
     start: () => void
     stop: () => void
   }
@@ -1098,6 +1103,16 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
           onApplyRewrite={applyRewrite}
           onDismiss={dismissEvaluator}
         />
+      )}
+      {/* #5668 — surface voice recognition/helper failures instead of
+          flipping the mic off silently. `voiceInput.error` is cleared on the
+          next start(), so retrying dismisses it. role="alert" announces it to
+          screen readers (the failure is otherwise invisible). */}
+      {voiceInput?.error && (
+        <div className="voice-error" data-testid="voice-error" role="alert">
+          <span className="voice-error-icon" aria-hidden="true">⚠</span>
+          <span className="voice-error-text">{voiceInput.error}</span>
+        </div>
       )}
       <div className={`input-bar-textarea-wrap${tokens ? ' has-overlay' : ''}`}>
         {tokens && (

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4650,7 +4650,7 @@ button.sidebar-token-view-session-row:hover {
   border: 1px solid var(--accent-red);
   border-radius: 6px;
   font-size: 12px;
-  color: var(--text-bright);
+  color: var(--text-error);
 }
 .voice-error-icon {
   color: var(--accent-red);

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4639,6 +4639,28 @@ button.sidebar-token-view-session-row:hover {
   outline-offset: 2px;
 }
 
+/* #5668 — voice recognition/helper failure, surfaced instead of a silent
+   mic-off. Mirrors the evaluator error treatment (red accent). */
+.voice-error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0;
+  padding: 6px 10px;
+  border: 1px solid var(--accent-red);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-bright);
+}
+.voice-error-icon {
+  color: var(--accent-red);
+  flex-shrink: 0;
+}
+.voice-error-text {
+  flex: 1;
+  min-width: 0;
+}
+
 .thinking-indicator {
   display: flex;
   align-items: center;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4645,6 +4645,10 @@ button.sidebar-token-view-session-row:hover {
   display: flex;
   align-items: center;
   gap: 6px;
+  /* `.input-bar` is a flex-wrap container, so claim a full-width row of our
+     own (same pattern as `.attachment-chips`) instead of sharing the row
+     with the textarea/actions on wider viewports. */
+  width: 100%;
   margin: 4px 0;
   padding: 6px 10px;
   border: 1px solid var(--accent-red);


### PR DESCRIPTION
Part of #5668 (the 'surface failures instead of a silent revert' half). From the 2026-06-13 swarm audit, ranked the **top felt-friction win**: `useVoiceInput` *captures* the error but the `voiceInput` prop passed to InputBar omitted the field, so a failed recording just flipped the mic off with no explanation.

## Change
- Add `error: string | null` to the InputBar `voiceInput` prop type (the hook already returns it).
- Render it as a `role="alert"` banner under the input row (cleared on the next `start()`, so retrying dismisses it).
- `.voice-error` styling mirroring the evaluator-error treatment.
- Test: asserts the alert renders only when `error` is set, with `role="alert"`.

## What this covers
- **Spawn failure** — `start()` returns `Err` → the hook's `invoke` rejects → `setError` → now rendered.
- **Helper-reported errors** — the native helper's `voice_error` Tauri event → `setError` → now rendered.
- **Web-speech `onerror`** (permission denied, no-speech, network, etc.) → now rendered.

## Follow-up (noted on #5668)
The native helper's *stderr-tail-on-early-exit* case (`speech.rs` sets `stderr(Stdio::null())` and emits a bare `voice_stopped` when the helper spawns OK but dies writing its reason to stderr) is left as a follow-up — it needs a desktop rebuild to verify and risks false errors on the hung-helper safety-net kill path, so it's not safe to ship unverified here.

Full dashboard suite green: 192 files / 3678 tests + tsc clean.