### PR TITLE
fix(dashboard): price + correctly label current-gen Claude models (#5631 quick-win)

### DIFF
--- a/packages/dashboard/src/lib/model-pricing.test.ts
+++ b/packages/dashboard/src/lib/model-pricing.test.ts
@@ -200,7 +200,9 @@ describe('MODEL_PRICING table integrity', () => {
     // Rates mirror the server's authoritative table (USD/Mtok → USD/1k).
     expect(MODEL_PRICING['claude-opus-4-7']!.inputPer1k).toBe(0.015)
     expect(MODEL_PRICING['claude-opus-4-7']!.outputPer1k).toBe(0.075)
+    expect(MODEL_PRICING['claude-sonnet-4-6']!.inputPer1k).toBe(0.003)
     expect(MODEL_PRICING['claude-sonnet-4-6']!.outputPer1k).toBe(0.015)
+    expect(MODEL_PRICING['claude-haiku-4-5']!.inputPer1k).toBe(0.001)
     expect(MODEL_PRICING['claude-haiku-4-5']!.outputPer1k).toBe(0.005)
   })
 

--- a/packages/dashboard/src/lib/model-pricing.test.ts
+++ b/packages/dashboard/src/lib/model-pricing.test.ts
@@ -188,8 +188,11 @@ describe('MODEL_PRICING table integrity', () => {
     expect(cost).toBeGreaterThan(0)
   })
 
-  // #5631 — current-generation Claude models were missing (only 3.x/3.5/3.7
-  // rows existed), so a current model fell back to a raw id / blank badge.
+  // #5631 — current-generation Claude models were missing from the table
+  // (only 3.x/3.5/3.7 rows existed). These rows keep MODEL_PRICING correct +
+  // consistent with the server's authoritative table. (Note: the table is not
+  // on a live Claude cost path today — CLIENT_ESTIMATED_COST_PROVIDERS is
+  // {codex, gemini} — so this guards table correctness, not a rendered cost.)
   it('prices the current-generation Claude models (#5631)', () => {
     for (const id of ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5']) {
       expect(MODEL_PRICING[id], `${id} missing`).toBeDefined()

--- a/packages/dashboard/src/lib/model-pricing.test.ts
+++ b/packages/dashboard/src/lib/model-pricing.test.ts
@@ -187,6 +187,27 @@ describe('MODEL_PRICING table integrity', () => {
     expect(cost).not.toBeNull()
     expect(cost).toBeGreaterThan(0)
   })
+
+  // #5631 — current-generation Claude models were missing (only 3.x/3.5/3.7
+  // rows existed), so a current model fell back to a raw id / blank badge.
+  it('prices the current-generation Claude models (#5631)', () => {
+    for (const id of ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5']) {
+      expect(MODEL_PRICING[id], `${id} missing`).toBeDefined()
+      const cost = calculateCost(id, 1000, 1000)
+      expect(cost, `${id} cost`).not.toBeNull()
+      expect(cost, `${id} cost`).toBeGreaterThan(0)
+    }
+    // Rates mirror the server's authoritative table (USD/Mtok → USD/1k).
+    expect(MODEL_PRICING['claude-opus-4-7']!.inputPer1k).toBe(0.015)
+    expect(MODEL_PRICING['claude-opus-4-7']!.outputPer1k).toBe(0.075)
+    expect(MODEL_PRICING['claude-sonnet-4-6']!.outputPer1k).toBe(0.015)
+    expect(MODEL_PRICING['claude-haiku-4-5']!.outputPer1k).toBe(0.005)
+  })
+
+  // #5631 — claude-sonnet-4-5 was mislabeled "Claude 3.7 Sonnet".
+  it('labels claude-sonnet-4-5 correctly (was "Claude 3.7 Sonnet")', () => {
+    expect(MODEL_PRICING['claude-sonnet-4-5']!.label).toBe('Claude Sonnet 4.5')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -26,15 +26,17 @@ export interface ModelPricing {
 // ---------------------------------------------------------------------------
 
 const CLAUDE_PRICING: Record<string, ModelPricing> = {
-  // #5631 — current-generation Claude models. Rates mirror the server's
-  // authoritative CLAUDE_PRICING_USD_PER_MTOK table (packages/server/src/
-  // models.js), converted from USD/Mtok to USD/1k. The server registry is
-  // the source of truth for Claude cost; these rows are the client-side
-  // estimate fallback (CLIENT_ESTIMATED_COST_PROVIDERS) so a current model
-  // renders a real label + cost instead of a raw id / blank badge.
-  // (opus-4-8 + fable-5 are intentionally absent — the server doesn't price
-  // them yet either; #5630 owns opus-4-8. The drift-warn in calculateCost
-  // surfaces any offered-but-unpriced model.)
+  // #5631 — current-generation Claude models, kept correct and consistent
+  // with the server's authoritative CLAUDE_PRICING_USD_PER_MTOK table
+  // (packages/server/src/models.js), converted from USD/Mtok to USD/1k.
+  // NOTE: this table only feeds calculateCost behind CLIENT_ESTIMATED_COST_
+  // PROVIDERS, which today is {codex, gemini} — Claude is NOT in it, so these
+  // Claude rows are not currently on any live cost path (Claude cost is
+  // server-authoritative). They exist to remove the stale 3.x-era data and
+  // keep the table right for any future consumer / if Claude is ever added to
+  // that set. (opus-4-8 + fable-5 are intentionally absent — the server
+  // doesn't price them yet either; tracked under #5631. The drift-warn in
+  // calculateCost surfaces any offered-but-unpriced model.)
   'claude-opus-4-7': { inputPer1k: 0.015, outputPer1k: 0.075, label: 'Claude Opus 4.7' },
   'claude-sonnet-4-6': { inputPer1k: 0.003, outputPer1k: 0.015, label: 'Claude Sonnet 4.6' },
   'claude-haiku-4-5': { inputPer1k: 0.001, outputPer1k: 0.005, label: 'Claude Haiku 4.5' },

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -26,8 +26,22 @@ export interface ModelPricing {
 // ---------------------------------------------------------------------------
 
 const CLAUDE_PRICING: Record<string, ModelPricing> = {
+  // #5631 — current-generation Claude models. Rates mirror the server's
+  // authoritative CLAUDE_PRICING_USD_PER_MTOK table (packages/server/src/
+  // models.js), converted from USD/Mtok to USD/1k. The server registry is
+  // the source of truth for Claude cost; these rows are the client-side
+  // estimate fallback (CLIENT_ESTIMATED_COST_PROVIDERS) so a current model
+  // renders a real label + cost instead of a raw id / blank badge.
+  // (opus-4-8 + fable-5 are intentionally absent — the server doesn't price
+  // them yet either; #5630 owns opus-4-8. The drift-warn in calculateCost
+  // surfaces any offered-but-unpriced model.)
+  'claude-opus-4-7': { inputPer1k: 0.015, outputPer1k: 0.075, label: 'Claude Opus 4.7' },
+  'claude-sonnet-4-6': { inputPer1k: 0.003, outputPer1k: 0.015, label: 'Claude Sonnet 4.6' },
+  'claude-haiku-4-5': { inputPer1k: 0.001, outputPer1k: 0.005, label: 'Claude Haiku 4.5' },
+  // Claude Sonnet 4.5 — previously mislabeled "Claude 3.7 Sonnet" (the rate
+  // is the standard Sonnet tier, only the display name was wrong).
+  'claude-sonnet-4-5': { inputPer1k: 0.003, outputPer1k: 0.015, label: 'Claude Sonnet 4.5' },
   // Claude 3.7 Sonnet
-  'claude-sonnet-4-5': { inputPer1k: 0.003, outputPer1k: 0.015, label: 'Claude 3.7 Sonnet' },
   'claude-3-7-sonnet-20250219': { inputPer1k: 0.003, outputPer1k: 0.015, label: 'Claude 3.7 Sonnet' },
   // Claude 3.5 Sonnet
   'claude-3-5-sonnet-20241022': { inputPer1k: 0.003, outputPer1k: 0.015, label: 'Claude 3.5 Sonnet' },


### PR DESCRIPTION
The quick-win slice of #5631. The dashboard's local pricing table (`model-pricing.ts`) was stale (3.x/3.5/3.7 era, no 4.x rows) and `claude-sonnet-4-5` was mislabeled **"Claude 3.7 Sonnet"**. This corrects the data.

## Change
- Add **`claude-opus-4-7`** (0.015/0.075), **`claude-sonnet-4-6`** (0.003/0.015), **`claude-haiku-4-5`** (0.001/0.005). Rates **mirror the server's authoritative `CLAUDE_PRICING_USD_PER_MTOK` table** (`packages/server/src/models.js`), converted USD/Mtok → USD/1k — verified exact by review, not invented.
- Correct `claude-sonnet-4-5` label → **"Claude Sonnet 4.5"**.
- Tests pin both rates + the label.

## Honest scope (corrected after review)
Adversarial review found this change is **currently inert in the UI**, and the original description overstated it:
- `MODEL_PRICING` is only consumed by `calculateCost` behind `CLIENT_ESTIMATED_COST_PROVIDERS = {codex, gemini}` — **Claude is not in that set**, so these Claude rows aren't on any live cost path (Claude cost stays server-authoritative).
- The UI model **label comes from the server `availableModels` list**, not `MODEL_PRICING.label`, so the label fix has no rendered effect today.

So this is **correctness / table-hygiene / future-proofing** (removes objectively-wrong data; makes the table right for any future consumer or if Claude is ever added to the estimate set), **not** a visible papercut fix. The genuinely *felt* part of #5631 (model labels in the UI) lives on the **server** `FALLBACK_MODELS` / `humanizeModelId` path and the structural wire-through — both remain tracked on #5631 (annotated).

## Deliberately omitted
`opus-4-8` + `fable-5` — the server doesn't price them yet either (#5630 owns opus-4-8); the `calculateCost` drift-warn surfaces them. Full dashboard suite green: 192 files / 3681 tests + tsc clean.