### PR TITLE
feat(app): per-tab 'needs your permission' indicator (mobile parity #5750)

### DIFF
--- a/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ChatMessage } from '@chroxy/store-core';
+import { countLivePermissionPrompts } from '../../components/SessionPicker';
+
+/**
+ * SessionPicker pill — "needs your permission" dot (#5750).
+ *
+ * Mobile parity with the dashboard's per-tab pending-permission indicator
+ * (#5667 / #5674): a background session blocked on a permission prompt now
+ * surfaces an amber dot so the user can find which session is waiting without
+ * tab-hunting. Two layers covered here:
+ *
+ *  1. `countLivePermissionPrompts` — the predicate (behavioral unit test).
+ *  2. The pill wiring (source-text, mirroring SessionPickerPendingShells).
+ */
+
+const now = 1_000_000;
+function prompt(over: Partial<ChatMessage> = {}): ChatMessage {
+  // Minimal live permission prompt: type:'prompt' + requestId + future expiresAt + no answer.
+  return { id: 'm', type: 'prompt', requestId: 'req-1', expiresAt: now + 60_000, ...over } as ChatMessage;
+}
+
+describe('countLivePermissionPrompts (#5750)', () => {
+  it('counts a live, unanswered permission prompt', () => {
+    expect(countLivePermissionPrompts([prompt()], now)).toBe(1);
+  });
+
+  it('counts multiple live prompts (e.g. parallel SDK tool calls)', () => {
+    expect(countLivePermissionPrompts([prompt(), prompt({ requestId: 'req-2' })], now)).toBe(2);
+  });
+
+  it('ignores an answered prompt', () => {
+    expect(countLivePermissionPrompts([prompt({ answered: 'allow' })], now)).toBe(0);
+  });
+
+  it('ignores an expired prompt (expiresAt <= now)', () => {
+    expect(countLivePermissionPrompts([prompt({ expiresAt: now - 1 })], now)).toBe(0);
+  });
+
+  it('ignores an AskUserQuestion prompt (no requestId / no expiresAt)', () => {
+    // type:'prompt' but without the requestId+expiresAt pair that marks a
+    // *permission* prompt — must not trip the indicator.
+    expect(countLivePermissionPrompts([{ id: 'q', type: 'prompt' } as ChatMessage], now)).toBe(0);
+    expect(countLivePermissionPrompts([prompt({ expiresAt: undefined })], now)).toBe(0);
+    expect(countLivePermissionPrompts([prompt({ requestId: undefined })], now)).toBe(0);
+  });
+
+  it('ignores non-prompt messages', () => {
+    expect(countLivePermissionPrompts([{ id: 't', type: 'text' } as unknown as ChatMessage], now)).toBe(0);
+  });
+
+  it('returns 0 for an empty message list', () => {
+    expect(countLivePermissionPrompts([], now)).toBe(0);
+  });
+});
+
+describe('SessionPicker pill — pending-permission dot wiring (#5750)', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/SessionPicker.tsx'),
+    'utf-8',
+  );
+  const pillStartIdx = source.indexOf('function SessionPill');
+  const pillEndIdx = source.indexOf('interface SessionPickerProps', source.indexOf('interface SessionPillProps'));
+  const pillSection = source.slice(pillStartIdx, source.indexOf('const styles', pillStartIdx));
+
+  it('the pill takes a pendingPermissionCount prop', () => {
+    expect(source).toMatch(/pendingPermissionCount:\s*number/);
+    expect(pillSection).toMatch(/pendingPermissionCount/);
+  });
+
+  it('shows the permission dot only on a non-active, non-crashed tab with a pending prompt', () => {
+    expect(pillSection).toMatch(/showPendingPermission\s*=\s*!isCrashed\s*&&\s*!isActive\s*&&\s*pendingPermissionCount\s*>\s*0/);
+  });
+
+  it('the permission state takes precedence over the generic busy pulse', () => {
+    // A session waiting on the user is more actionable than "processing".
+    expect(pillSection).toMatch(/showBusy\s*=\s*!isCrashed\s*&&\s*!showPendingPermission/);
+  });
+
+  it('renders a permissionDot with its dedicated style', () => {
+    expect(pillSection).toMatch(/styles\.permissionDot/);
+    expect(source).toMatch(/permissionDot:\s*\{/);
+  });
+
+  it('announces the waiting state to screen readers', () => {
+    expect(pillSection).toMatch(/waiting for your permission/);
+    expect(pillSection).toMatch(/allow or deny a permission request/);
+  });
+
+  it('SessionPicker derives per-session counts and passes them to the pill', () => {
+    expect(source).toMatch(/countLivePermissionPrompts/);
+    expect(source).toMatch(/pendingPermissionCount=\{pendingPermissionCounts\.get/);
+  });
+});

--- a/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
@@ -61,7 +61,6 @@ describe('SessionPicker pill — pending-permission dot wiring (#5750)', () => {
     'utf-8',
   );
   const pillStartIdx = source.indexOf('function SessionPill');
-  const pillEndIdx = source.indexOf('interface SessionPickerProps', source.indexOf('interface SessionPillProps'));
   const pillSection = source.slice(pillStartIdx, source.indexOf('const styles', pillStartIdx));
 
   it('the pill takes a pendingPermissionCount prop', () => {

--- a/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
@@ -61,7 +61,11 @@ describe('SessionPicker pill — pending-permission dot wiring (#5750)', () => {
     'utf-8',
   );
   const pillStartIdx = source.indexOf('function SessionPill');
-  const pillSection = source.slice(pillStartIdx, source.indexOf('const styles', pillStartIdx));
+  const pillEndIdx = source.indexOf('const styles', pillStartIdx);
+  if (pillStartIdx < 0 || pillEndIdx < 0 || pillEndIdx <= pillStartIdx) {
+    throw new Error('Unable to locate the SessionPill render block in SessionPicker.tsx');
+  }
+  const pillSection = source.slice(pillStartIdx, pillEndIdx);
 
   it('the pill takes a pendingPermissionCount prop', () => {
     expect(source).toMatch(/pendingPermissionCount:\s*number/);

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -13,10 +13,37 @@ import {
 } from 'react-native';
 import { useConnectionStore } from '../store/connection';
 import type { SessionInfo, SessionHealth } from '../store/connection';
+import type { ChatMessage } from '@chroxy/store-core';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 import { getProviderInfo } from '../constants/providers';
 import { hapticMedium } from '../utils/haptics';
+
+/**
+ * #5750 — count live, unanswered permission prompts in a session's messages so
+ * a background tab can surface a "needs your permission" dot (mobile parity
+ * with the dashboard's per-tab indicator, #5667/#5674).
+ *
+ * Mirrors the dashboard's `isLivePermissionPrompt` predicate
+ * (packages/dashboard/src/utils/pendingPermissions.ts): a permission prompt is
+ * `type:'prompt'` with a `requestId` + a future `expiresAt` and no `answered`
+ * decision. The requestId+expiresAt pair distinguishes a permission prompt
+ * from an AskUserQuestion (also `type:'prompt'`, but with neither), and the
+ * `expiresAt > now` check clears the dot once the prompt times out (the expiry
+ * handlers clear the prompt's options but do NOT set `answered`).
+ *
+ * NOTE: this predicate is duplicated from the dashboard. Converging both clients
+ * onto a single store-core helper is tracked as a follow-up (see #5750).
+ */
+export function countLivePermissionPrompts(messages: ChatMessage[], now: number): number {
+  let count = 0;
+  for (const m of messages) {
+    if (m.type === 'prompt' && !!m.requestId && !!m.expiresAt && m.expiresAt > now && !m.answered) {
+      count++;
+    }
+  }
+  return count;
+}
 
 /** Pulsing dot for busy sessions */
 function PulsingDot() {
@@ -56,23 +83,33 @@ interface SessionPillProps {
   // long-running shell. SECONDARY to the busy pulse — the busy dot wins
   // during an active turn.
   pendingShellCount: number;
+  // #5750 — number of live, unanswered permission prompts the session is
+  // blocked on. Projected from its messages so a background tab surfaces a
+  // "needs your permission" dot (parity with the dashboard per-tab indicator).
+  pendingPermissionCount: number;
   onPress: () => void;
   onLongPress: () => void;
   onLayout: (e: LayoutChangeEvent) => void;
 }
 
-function SessionPill({ session, isActive, health, notificationCount, pendingShellCount, onPress, onLongPress, onLayout }: SessionPillProps) {
+function SessionPill({ session, isActive, health, notificationCount, pendingShellCount, pendingPermissionCount, onPress, onLongPress, onLayout }: SessionPillProps) {
   const isCrashed = health === 'crashed';
   const hasNotification = notificationCount > 0 && !isActive;
-  const showBusy = !isCrashed && session.isBusy;
+  // #5750 — a session blocked on a permission prompt is the most actionable
+  // (non-crashed) state: it can't progress until the user answers. Surface it
+  // on background tabs (on the active tab the prompt itself is already on
+  // screen). It takes precedence over the generic busy pulse — a session
+  // waiting on you isn't merely "processing".
+  const showPendingPermission = !isCrashed && !isActive && pendingPermissionCount > 0;
+  const showBusy = !isCrashed && !showPendingPermission && session.isBusy;
   // #4422 — only surface the pending-shells dot when the session is idle
   // (showBusy=false). During an active turn the busy pulse already conveys
   // "work happening"; the pending-shells indicator is for the "idle but
   // waiting on background work" gap the dashboard ActivityIndicator now
   // surfaces (#4419). Skip on crashed too — a crashed session's red dot is
   // the more urgent signal.
-  const showPendingShells = !isCrashed && !showBusy && pendingShellCount > 0;
-  const hasIndicators = isCrashed || showBusy || hasNotification || showPendingShells;
+  const showPendingShells = !isCrashed && !showBusy && !showPendingPermission && pendingShellCount > 0;
+  const hasIndicators = isCrashed || showPendingPermission || showBusy || hasNotification || showPendingShells;
   // Mobile parity with dashboard SessionBar chips (#3940): surface the
   // provider's short label as a small badge on the pill so claude-tui,
   // codex, gemini, docker-cli, etc. are distinguishable at-a-glance
@@ -95,13 +132,14 @@ function SessionPill({ session, isActive, health, notificationCount, pendingShel
       onLayout={onLayout}
       activeOpacity={0.7}
       accessibilityRole="tab"
-      accessibilityLabel={`Session ${session.name}${providerInfo ? `, ${providerInfo.short} provider` : ''}${session.worktree ? ', isolated worktree' : ''}${showPendingShells ? `, waiting on ${pendingShellCount} background ${pendingShellCount === 1 ? 'shell' : 'shells'}` : ''}`}
+      accessibilityLabel={`Session ${session.name}${providerInfo ? `, ${providerInfo.short} provider` : ''}${session.worktree ? ', isolated worktree' : ''}${showPendingPermission ? ', waiting for your permission' : ''}${showPendingShells ? `, waiting on ${pendingShellCount} background ${pendingShellCount === 1 ? 'shell' : 'shells'}` : ''}`}
       accessibilityState={{ selected: isActive }}
-      accessibilityHint={isCrashed ? 'Session has crashed and needs attention' : showBusy ? 'Session is currently processing' : showPendingShells ? 'Session is idle but waiting on a backgrounded shell' : undefined}
+      accessibilityHint={isCrashed ? 'Session has crashed and needs attention' : showPendingPermission ? 'Session is waiting for you to allow or deny a permission request' : showBusy ? 'Session is currently processing' : showPendingShells ? 'Session is idle but waiting on a backgrounded shell' : undefined}
     >
       {hasIndicators && (
         <View style={styles.indicators} importantForAccessibility="no-hide-descendants" accessibilityElementsHidden>
           {isCrashed && <View style={styles.crashDot} />}
+          {showPendingPermission && <View style={styles.permissionDot} />}
           {showBusy && <PulsingDot />}
           {showPendingShells && <View style={styles.pendingShellsDot} />}
           {hasNotification && <NotificationBadge count={notificationCount} />}
@@ -279,6 +317,24 @@ export function SessionPicker({ onCreatePress }: SessionPickerProps) {
     return counts;
   }, [sessionNotifications]);
 
+  // #5750 — per-session live permission-prompt counts, for the "needs your
+  // permission" tab dot. Recomputes when any session's messages change (which
+  // is also when a prompt is answered or its expiry handler fires, clearing
+  // the dot). `Date.now()` is read at compute time; an unanswered prompt that
+  // simply times out clears on the next message change via the `expiresAt >
+  // now` check — matching the dashboard's behavior.
+  const pendingPermissionCounts = useMemo(() => {
+    const now = Date.now();
+    const counts = new Map<string, number>();
+    for (const id in sessionStates) {
+      const messages = sessionStates[id]?.messages;
+      if (!messages || messages.length === 0) continue;
+      const c = countLivePermissionPrompts(messages, now);
+      if (c > 0) counts.set(id, c);
+    }
+    return counts;
+  }, [sessionStates]);
+
   return (
     <View style={styles.container}>
       <ScrollView
@@ -302,6 +358,7 @@ export function SessionPicker({ onCreatePress }: SessionPickerProps) {
             // is undefined) and sessions whose state slot hasn't been seeded
             // yet (no entry in sessionStates).
             pendingShellCount={sessionStates[session.sessionId]?.pendingBackgroundShells?.length ?? 0}
+            pendingPermissionCount={pendingPermissionCounts.get(session.sessionId) || 0}
             onPress={() => switchSession(session.sessionId)}
             onLongPress={() => handleLongPress(session)}
             onLayout={(e) => handlePillLayout(session.sessionId, e)}
@@ -440,6 +497,16 @@ const styles = StyleSheet.create({
     height: 6,
     borderRadius: 3,
     backgroundColor: COLORS.accentRed,
+  },
+  // #5750 — "needs your permission" dot. Amber (the warning/attention accent)
+  // so it reads as actionable, distinct from the blue busy pulse and the green
+  // pending-shells dot. Static (no pulse) — the urgency is "you must answer",
+  // not "work is happening".
+  permissionDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: COLORS.accentOrange,
   },
   busyDot: {
     width: 6,


### PR DESCRIPTION
**Part of #5750** (item 1 — the per-tab indicator). The parity half of the audit backlog.

Follow-up to the now-closed #5674. The mobile `SessionPicker` showed crash / busy / pending-shells dots + a notification badge, but a background session **blocked on a permission prompt looked identical to one merely thinking** — you had to tab-hunt to find which session was waiting.

## Change
- **`countLivePermissionPrompts()`** — a pure predicate mirroring the dashboard's `isLivePermissionPrompt` (`type:'prompt'` + `requestId` + future `expiresAt` + unanswered). Excludes AskUserQuestion prompts; the expiry check clears the dot on timeout.
- `SessionPicker` derives per-session counts (`useMemo` over `sessionStates`) and passes them to the pill.
- The pill renders an **amber `permissionDot`** on non-active tabs, taking **precedence over the busy pulse** (waiting on *you* > 'processing'), plus a screen-reader label + hint.
- Tests: predicate edge cases + pill wiring.

## Scope (does NOT close #5750)
#5750 has a **second item** — an *assertive* screen-reader announcement when a new permission prompt appears (`PermissionDetail.tsx`/the prompt mount point). That's a distinct a11y mechanism at a different component, so it ships as a **focused follow-up PR**; #5750 stays open until then. (Caught by Copilot review.)

## Known follow-ups
- The assertive-announcement item above.
- The predicate is **duplicated from the dashboard**; converging both onto a `@chroxy/store-core` helper is tracked as **#5759**.

## Parity notes (intentional divergences, from review)
- Dot gated on `!isActive` (the live prompt is already on screen on the active tab); the dashboard chip shows on the active tab too.
- The generic notification badge already fires for permissions (predates this PR); the amber dot adds *specificity*.

Full app suite green: 142 suites / 1901 tests + tsc clean.