### PR TITLE
feat(app): assertively announce a new permission prompt to screen readers (#5750 item 2)

### DIFF
--- a/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
+++ b/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
@@ -38,22 +38,22 @@ function permPrompt(over: Partial<ChatMessage> = {}): ChatMessage {
   } as ChatMessage;
 }
 
-function Harness({ messages }: { messages: ChatMessage[] }) {
-  usePermissionAnnouncer(messages);
+function Harness({ messages, sessionKey }: { messages: ChatMessage[]; sessionKey: string }) {
+  usePermissionAnnouncer(messages, sessionKey);
   return null;
 }
 
-function render(messages: ChatMessage[]) {
+function render(messages: ChatMessage[], sessionKey = 'A') {
   let tree!: renderer.ReactTestRenderer;
   act(() => {
-    tree = renderer.create(<Harness messages={messages} />);
+    tree = renderer.create(<Harness messages={messages} sessionKey={sessionKey} />);
   });
   return tree;
 }
 
-function update(tree: renderer.ReactTestRenderer, messages: ChatMessage[]) {
+function update(tree: renderer.ReactTestRenderer, messages: ChatMessage[], sessionKey = 'A') {
   act(() => {
-    tree.update(<Harness messages={messages} />);
+    tree.update(<Harness messages={messages} sessionKey={sessionKey} />);
   });
 }
 
@@ -115,5 +115,22 @@ describe('usePermissionAnnouncer', () => {
     update(tree, [permPrompt({ answered: 'allow' }), permPrompt({ id: 'p2', requestId: 'req-2', tool: 'Edit', toolInput: { file_path: '/a/b/c.ts' } })]);
     expect(announceMock).toHaveBeenCalledTimes(1);
     expect(announceMock).toHaveBeenCalledWith('Permission requested: Edit(c.ts)');
+  });
+
+  // #5760 review — ChatView isn't remounted on a tab-switch; it re-renders with
+  // the destination session's messages. Switching to a session that ALREADY
+  // has a live pending prompt must stay SILENT (re-seed on sessionKey change),
+  // not announce a prompt that was pending before the user navigated to it.
+  it('does NOT announce a pre-existing prompt when switching to another session', () => {
+    // Active session A, no prompt.
+    const tree = render([], 'A');
+    expect(announceMock).not.toHaveBeenCalled();
+    // Switch to session B, whose cache ALREADY holds a live prompt → silent.
+    update(tree, [permPrompt({ requestId: 'req-B' })], 'B');
+    expect(announceMock).not.toHaveBeenCalled();
+    // A genuinely NEW prompt arriving in B (after the switch settled) announces.
+    update(tree, [permPrompt({ requestId: 'req-B', answered: 'allow' }), permPrompt({ id: 'p3', requestId: 'req-B2', tool: 'Bash', toolInput: { command: 'rm x' } })], 'B');
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    expect(announceMock).toHaveBeenCalledWith('Permission requested: Bash(rm x)');
   });
 });

--- a/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
+++ b/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
@@ -117,6 +117,23 @@ describe('usePermissionAnnouncer', () => {
     expect(announceMock).toHaveBeenCalledWith('Permission requested: Edit(c.ts)');
   });
 
+  // #5760 review — more than one permission can be live at once (parallel SDK
+  // tool calls). A second prompt arriving while the first is still live must
+  // still announce (keying on the first-by-position would swallow it).
+  it('announces a second concurrent prompt while the first is still live', () => {
+    const tree = render([]);
+    update(tree, [permPrompt({ requestId: 'req-1' })]);
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    expect(announceMock).toHaveBeenLastCalledWith('Permission requested: Bash(ls)');
+    // Second prompt arrives; the first is STILL live (unanswered).
+    update(tree, [
+      permPrompt({ requestId: 'req-1' }),
+      permPrompt({ id: 'p2', requestId: 'req-2', tool: 'Edit', toolInput: { file_path: '/x/y/z.ts' } }),
+    ]);
+    expect(announceMock).toHaveBeenCalledTimes(2);
+    expect(announceMock).toHaveBeenLastCalledWith('Permission requested: Edit(z.ts)');
+  });
+
   // #5760 review — ChatView isn't remounted on a tab-switch; it re-renders with
   // the destination session's messages. Switching to a session that ALREADY
   // has a live pending prompt must stay SILENT (re-seed on sessionKey change),

--- a/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
+++ b/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * #5750 (item 2) — `usePermissionAnnouncer` assertive screen-reader
+ * announcement when a NEW permission prompt arrives.
+ *
+ * Mirrors the dashboard's #5733 assertive treatment on mobile:
+ *   - a prompt already present at mount stays silent (seed),
+ *   - a newly-arriving live permission prompt is announced once, with a
+ *     human summary,
+ *   - AskUserQuestion / answered / expired prompts never announce,
+ *   - after a prompt resolves, a genuinely new prompt announces again.
+ *
+ * Same react-test-renderer + mocked `announceForAccessibility` harness as
+ * `useConnectionAnnouncer.test.tsx`. The hook is timer-less (it reads
+ * `Date.now()` directly), so no fake timers are needed.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { AccessibilityInfo } from 'react-native';
+import type { ChatMessage } from '@chroxy/store-core';
+
+import {
+  usePermissionAnnouncer,
+  firstLivePermissionPrompt,
+} from '../../hooks/usePermissionAnnouncer';
+
+jest.spyOn(AccessibilityInfo, 'announceForAccessibility');
+const announceMock = AccessibilityInfo.announceForAccessibility as jest.Mock;
+
+function permPrompt(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'p',
+    type: 'prompt',
+    requestId: 'req-1',
+    expiresAt: Date.now() + 60_000,
+    tool: 'Bash',
+    toolInput: { command: 'ls' },
+    ...over,
+  } as ChatMessage;
+}
+
+function Harness({ messages }: { messages: ChatMessage[] }) {
+  usePermissionAnnouncer(messages);
+  return null;
+}
+
+function render(messages: ChatMessage[]) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(<Harness messages={messages} />);
+  });
+  return tree;
+}
+
+function update(tree: renderer.ReactTestRenderer, messages: ChatMessage[]) {
+  act(() => {
+    tree.update(<Harness messages={messages} />);
+  });
+}
+
+beforeEach(() => {
+  announceMock.mockClear();
+});
+
+describe('firstLivePermissionPrompt', () => {
+  const now = 1_000_000;
+  it('returns a live, unanswered permission prompt', () => {
+    expect(firstLivePermissionPrompt([permPrompt({ expiresAt: now + 1 })], now)?.requestId).toBe('req-1');
+  });
+  it('skips answered / expired / AskUserQuestion / non-prompt', () => {
+    expect(firstLivePermissionPrompt([permPrompt({ answered: 'allow' })], now)).toBeNull();
+    expect(firstLivePermissionPrompt([permPrompt({ expiresAt: now - 1 })], now)).toBeNull();
+    expect(firstLivePermissionPrompt([{ id: 'q', type: 'prompt' } as ChatMessage], now)).toBeNull();
+    expect(firstLivePermissionPrompt([{ id: 't', type: 'text' } as unknown as ChatMessage], now)).toBeNull();
+  });
+});
+
+describe('usePermissionAnnouncer', () => {
+  it('does NOT announce a prompt already present at mount (seed)', () => {
+    render([permPrompt()]);
+    expect(announceMock).not.toHaveBeenCalled();
+  });
+
+  it('announces a newly-arriving permission prompt once, with a summary', () => {
+    const tree = render([]);
+    expect(announceMock).not.toHaveBeenCalled();
+    update(tree, [permPrompt()]);
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    expect(announceMock).toHaveBeenCalledWith('Permission requested: Bash(ls)');
+    // A re-render with the same prompt does not re-announce.
+    update(tree, [permPrompt()]);
+    expect(announceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not announce an AskUserQuestion prompt (no requestId / expiresAt)', () => {
+    const tree = render([]);
+    update(tree, [{ id: 'q', type: 'prompt' } as ChatMessage]);
+    expect(announceMock).not.toHaveBeenCalled();
+  });
+
+  it('does not announce an answered or expired prompt', () => {
+    const tree = render([]);
+    update(tree, [permPrompt({ answered: 'allow' })]);
+    update(tree, [permPrompt({ requestId: 'req-x', expiresAt: Date.now() - 1 })]);
+    expect(announceMock).not.toHaveBeenCalled();
+  });
+
+  it('announces a genuinely new prompt after the previous one resolves', () => {
+    // Mount with a pending prompt (seeded → silent).
+    const tree = render([permPrompt()]);
+    expect(announceMock).not.toHaveBeenCalled();
+    // It gets answered → ref clears.
+    update(tree, [permPrompt({ answered: 'allow' })]);
+    expect(announceMock).not.toHaveBeenCalled();
+    // A new, different prompt arrives → announced.
+    update(tree, [permPrompt({ answered: 'allow' }), permPrompt({ id: 'p2', requestId: 'req-2', tool: 'Edit', toolInput: { file_path: '/a/b/c.ts' } })]);
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    expect(announceMock).toHaveBeenCalledWith('Permission requested: Edit(c.ts)');
+  });
+});

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -165,8 +165,10 @@ export function ChatView({
   // screen readers (the prompt auto-denies on timeout, so silence loses the
   // user an action they might have allowed). Mirrors the dashboard's #5733
   // assertive treatment; fires once per prompt and stays silent for a prompt
-  // already present at mount (see the hook).
-  usePermissionAnnouncer(messages);
+  // already present at mount OR in the session we just switched to (the hook
+  // re-seeds on activeSessionId change — ChatView isn't remounted per switch).
+  const announcerSessionId = useConnectionStore((s) => s.activeSessionId);
+  usePermissionAnnouncer(messages, announcerSessionId);
 
   // #5517: row expand/collapse registry, keyed by message id / activity
   // group key. The list is now a virtualized FlatList, so an off-screen tool

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -25,6 +25,7 @@ import type { SelectOptionValue } from './chat/MessageBubble';
 import type { MultiQuestionAnswersMap } from './chat/MultiQuestionForm';
 import { buildChatViewMessages } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
+import { usePermissionAnnouncer } from '../hooks/usePermissionAnnouncer';
 
 // -- Props --
 
@@ -159,6 +160,13 @@ export function ChatView({
   const showScrollToBottomRef = useRef(false);
   const [toolDetail, setToolDetail] = useState<{ toolName: string; content: string; toolResult?: string; toolResultTruncated?: boolean; toolResultImages?: ToolResultImage[]; serverName?: string } | null>(null);
   const [viewerUri, setViewerUri] = useState<string | null>(null);
+
+  // #5750 (item 2) — assertively announce a newly-arrived permission prompt to
+  // screen readers (the prompt auto-denies on timeout, so silence loses the
+  // user an action they might have allowed). Mirrors the dashboard's #5733
+  // assertive treatment; fires once per prompt and stays silent for a prompt
+  // already present at mount (see the hook).
+  usePermissionAnnouncer(messages);
 
   // #5517: row expand/collapse registry, keyed by message id / activity
   // group key. The list is now a virtualized FlatList, so an off-screen tool

--- a/packages/app/src/hooks/usePermissionAnnouncer.ts
+++ b/packages/app/src/hooks/usePermissionAnnouncer.ts
@@ -1,0 +1,63 @@
+/**
+ * usePermissionAnnouncer (#5750, item 2) — mobile assertive announcement when a
+ * NEW permission prompt appears, so a VoiceOver/TalkBack user is told
+ * immediately. The prompt auto-DENIES on timeout, so silence is a footgun: the
+ * user could lose an action they'd have allowed without ever knowing it was
+ * asked.
+ *
+ * Companion to the dashboard's #5733 `alertdialog` / assertive `aria-live`
+ * treatment. Mobile has no DOM live region, so this pushes through
+ * `AccessibilityInfo.announceForAccessibility` — the same one-shot primitive
+ * already used by `useConnectionAnnouncer`, `CheckInChip`, and
+ * `ThinkingIndicator`.
+ *
+ * Semantics (mirroring `useConnectionAnnouncer`):
+ *   - Watches the active session's messages for the first LIVE permission
+ *     prompt — `type:'prompt'` with a `requestId` + a future `expiresAt` and no
+ *     `answered` decision. (The requestId+expiresAt pair excludes
+ *     AskUserQuestion prompts, which are also `type:'prompt'`.)
+ *   - Announces once per prompt, keyed on `requestId`.
+ *   - Seeds the last-announced ref SYNCHRONOUSLY at first render with whatever
+ *     is already pending, so arriving at a session that ALREADY shows a prompt
+ *     stays silent — only genuinely newly-arriving prompts are announced.
+ *   - Clears the ref when no prompt is live, so the next arrival announces.
+ */
+import { useEffect, useRef } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+import type { ChatMessage } from '@chroxy/store-core';
+import { getPermissionSummary } from '../components/PermissionDetail';
+
+/** The first live, unanswered permission prompt in `messages`, or null. */
+export function firstLivePermissionPrompt(messages: ChatMessage[], now: number): ChatMessage | null {
+  for (const m of messages) {
+    if (m.type === 'prompt' && !!m.requestId && !!m.expiresAt && m.expiresAt > now && !m.answered) {
+      return m;
+    }
+  }
+  return null;
+}
+
+export function usePermissionAnnouncer(messages: ChatMessage[]): void {
+  // requestId of the prompt we last announced. `undefined` = not yet seeded;
+  // `null` = nothing pending. Seeded once on the first render so a prompt that
+  // is already present at mount isn't announced — only new arrivals are.
+  const lastAnnouncedRef = useRef<string | null | undefined>(undefined);
+  if (lastAnnouncedRef.current === undefined) {
+    lastAnnouncedRef.current = firstLivePermissionPrompt(messages, Date.now())?.requestId ?? null;
+  }
+
+  useEffect(() => {
+    const live = firstLivePermissionPrompt(messages, Date.now());
+    const id = live?.requestId ?? null;
+    if (id == null) {
+      // Nothing live → reset so a future prompt (new requestId) announces.
+      lastAnnouncedRef.current = null;
+      return;
+    }
+    if (id === lastAnnouncedRef.current) return;
+    lastAnnouncedRef.current = id;
+    const summary = getPermissionSummary(live!.tool, live!.toolInput);
+    AccessibilityInfo.announceForAccessibility?.(`Permission requested: ${summary}`);
+  }, [messages]);
+}

--- a/packages/app/src/hooks/usePermissionAnnouncer.ts
+++ b/packages/app/src/hooks/usePermissionAnnouncer.ts
@@ -35,41 +35,60 @@ import { AccessibilityInfo } from 'react-native';
 import type { ChatMessage } from '@chroxy/store-core';
 import { getPermissionSummary } from '../components/PermissionDetail';
 
+/** True iff `m` is a live, unanswered permission prompt (not an AskUserQuestion). */
+function isLivePermissionPrompt(m: ChatMessage, now: number): boolean {
+  return m.type === 'prompt' && !!m.requestId && !!m.expiresAt && m.expiresAt > now && !m.answered;
+}
+
 /** The first live, unanswered permission prompt in `messages`, or null. */
 export function firstLivePermissionPrompt(messages: ChatMessage[], now: number): ChatMessage | null {
   for (const m of messages) {
-    if (m.type === 'prompt' && !!m.requestId && !!m.expiresAt && m.expiresAt > now && !m.answered) {
-      return m;
-    }
+    if (isLivePermissionPrompt(m, now)) return m;
   }
   return null;
 }
 
+/** All live, unanswered permission prompts in `messages`, in order. */
+export function livePermissionPrompts(messages: ChatMessage[], now: number): ChatMessage[] {
+  return messages.filter((m) => isLivePermissionPrompt(m, now));
+}
+
 export function usePermissionAnnouncer(messages: ChatMessage[], sessionKey: string | null): void {
-  // requestId of the prompt we last announced. `undefined` = not yet seeded;
-  // `null` = nothing pending. Seeded so a prompt already present (at mount, or
-  // in the session we just switched to) isn't announced — only new arrivals.
-  const lastAnnouncedRef = useRef<string | null | undefined>(undefined);
-  // The session the ref is seeded for. A change means we navigated sessions and
-  // must re-seed against the destination's existing prompt (ChatView doesn't
-  // remount on switch, so the ref would otherwise leak across sessions).
+  // requestIds we've already announced. A Set (not a single id) because more
+  // than one permission can be live at once (parallel SDK tool calls) — keying
+  // on the *first* live prompt would never announce a second concurrent one
+  // while the first stayed live. Pruned each run to only still-live ids, which
+  // bounds it and (harmlessly, since requestIds are unique) allows re-use.
+  const announcedRef = useRef<Set<string>>(new Set());
+  // The session the set is seeded for. A change means we navigated sessions and
+  // must re-seed against the destination's existing prompts (ChatView doesn't
+  // remount on switch, so the set would otherwise leak across sessions and
+  // either re-announce or wrongly suppress).
   const seededSessionRef = useRef<string | null | undefined>(undefined);
   if (seededSessionRef.current !== sessionKey) {
     seededSessionRef.current = sessionKey;
-    lastAnnouncedRef.current = firstLivePermissionPrompt(messages, Date.now())?.requestId ?? null;
+    // Seed: treat the destination session's already-pending prompts as
+    // already-announced so arriving stays silent — only later arrivals speak.
+    announcedRef.current = new Set(
+      livePermissionPrompts(messages, Date.now()).map((m) => m.requestId as string),
+    );
   }
 
   useEffect(() => {
-    const live = firstLivePermissionPrompt(messages, Date.now());
-    const id = live?.requestId ?? null;
-    if (id == null) {
-      // Nothing live → reset so a future prompt (new requestId) announces.
-      lastAnnouncedRef.current = null;
-      return;
+    const now = Date.now();
+    const live = livePermissionPrompts(messages, now);
+    const liveIds = new Set(live.map((m) => m.requestId as string));
+    // Prune resolved/expired ids so the set stays bounded to what's live.
+    for (const id of announcedRef.current) {
+      if (!liveIds.has(id)) announcedRef.current.delete(id);
     }
-    if (id === lastAnnouncedRef.current) return;
-    lastAnnouncedRef.current = id;
-    const summary = getPermissionSummary(live!.tool, live!.toolInput);
+    // Announce the first not-yet-announced live prompt. Sequential arrivals
+    // (the common case — each tool call appends its own prompt message) each
+    // get their own effect run, so each announces once.
+    const fresh = live.find((m) => !announcedRef.current.has(m.requestId as string));
+    if (!fresh) return;
+    announcedRef.current.add(fresh.requestId as string);
+    const summary = getPermissionSummary(fresh.tool, fresh.toolInput);
     AccessibilityInfo.announceForAccessibility?.(`Permission requested: ${summary}`);
   }, [messages, sessionKey]);
 }

--- a/packages/app/src/hooks/usePermissionAnnouncer.ts
+++ b/packages/app/src/hooks/usePermissionAnnouncer.ts
@@ -17,10 +17,17 @@
  *     `answered` decision. (The requestId+expiresAt pair excludes
  *     AskUserQuestion prompts, which are also `type:'prompt'`.)
  *   - Announces once per prompt, keyed on `requestId`.
- *   - Seeds the last-announced ref SYNCHRONOUSLY at first render with whatever
- *     is already pending, so arriving at a session that ALREADY shows a prompt
- *     stays silent — only genuinely newly-arriving prompts are announced.
+ *   - Seeds the last-announced ref SYNCHRONOUSLY with whatever is already
+ *     pending, so arriving at a session that ALREADY shows a prompt stays
+ *     silent — only genuinely newly-arriving prompts are announced.
  *   - Clears the ref when no prompt is live, so the next arrival announces.
+ *
+ * Session-aware (#5760 review): ChatView is NOT remounted on a tab-switch — it
+ * just re-renders with the new session's `messages` — so a single persistent
+ * ref would carry across sessions and falsely announce the destination
+ * session's ALREADY-pending prompt. We therefore re-seed whenever `sessionKey`
+ * changes: the seed runs again for the new session, suppressing its existing
+ * prompt and announcing only what arrives after the switch settles.
  */
 import { useEffect, useRef } from 'react';
 import { AccessibilityInfo } from 'react-native';
@@ -38,12 +45,17 @@ export function firstLivePermissionPrompt(messages: ChatMessage[], now: number):
   return null;
 }
 
-export function usePermissionAnnouncer(messages: ChatMessage[]): void {
+export function usePermissionAnnouncer(messages: ChatMessage[], sessionKey: string | null): void {
   // requestId of the prompt we last announced. `undefined` = not yet seeded;
-  // `null` = nothing pending. Seeded once on the first render so a prompt that
-  // is already present at mount isn't announced — only new arrivals are.
+  // `null` = nothing pending. Seeded so a prompt already present (at mount, or
+  // in the session we just switched to) isn't announced — only new arrivals.
   const lastAnnouncedRef = useRef<string | null | undefined>(undefined);
-  if (lastAnnouncedRef.current === undefined) {
+  // The session the ref is seeded for. A change means we navigated sessions and
+  // must re-seed against the destination's existing prompt (ChatView doesn't
+  // remount on switch, so the ref would otherwise leak across sessions).
+  const seededSessionRef = useRef<string | null | undefined>(undefined);
+  if (seededSessionRef.current !== sessionKey) {
+    seededSessionRef.current = sessionKey;
     lastAnnouncedRef.current = firstLivePermissionPrompt(messages, Date.now())?.requestId ?? null;
   }
 
@@ -59,5 +71,5 @@ export function usePermissionAnnouncer(messages: ChatMessage[]): void {
     lastAnnouncedRef.current = id;
     const summary = getPermissionSummary(live!.tool, live!.toolInput);
     AccessibilityInfo.announceForAccessibility?.(`Permission requested: ${summary}`);
-  }, [messages]);
+  }, [messages, sessionKey]);
 }


### PR DESCRIPTION
Closes #5750. The second and final item of the mobile permission-attribution parity — item 1 (the per-tab indicator) shipped in #5758.

## The gap
The mobile permission prompt **auto-denies on timeout** but announced nothing to VoiceOver/TalkBack when it appeared, so a screen-reader user could lose an action they'd have allowed without ever knowing it was asked. The dashboard got an assertive `alertdialog`/`aria-live` treatment in #5733; this is the mobile mirror.

## Change
- **`usePermissionAnnouncer(messages)`** — watches the active session's messages for the first *live* permission prompt (`type:'prompt'` + `requestId` + future `expiresAt` + unanswered — the requestId+expiresAt pair excludes AskUserQuestion) and pushes `Permission requested: <summary>` through `AccessibilityInfo.announceForAccessibility` (the same one-shot primitive `useConnectionAnnouncer`/`CheckInChip`/`ThinkingIndicator` use).
- **Seed-at-mount semantics** (mirroring `useConnectionAnnouncer`): a prompt already present when you arrive at a session stays silent; only genuinely *new* arrivals announce, once per `requestId`. After a prompt resolves, the next one announces.
- Mounted in **`ChatView`** (the active session's chat).
- Tests: the `firstLivePermissionPrompt` predicate + the announce / seed / resolve lifecycle (7 cases).

Full app suite green: 143 suites / 1908 tests + tsc clean.