### PR TITLE
refactor: converge the pending-permission predicate into @chroxy/store-core (#5759)

### DIFF
--- a/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerPendingPermission.test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { ChatMessage } from '@chroxy/store-core';
-import { countLivePermissionPrompts } from '../../components/SessionPicker';
+// #5759 — the predicate now lives in store-core (shared with the dashboard).
+import { countLivePermissionPrompts } from '@chroxy/store-core';
 
 /**
  * SessionPicker pill — "needs your permission" dot (#5750).

--- a/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
+++ b/packages/app/src/__tests__/hooks/usePermissionAnnouncer.test.tsx
@@ -18,10 +18,9 @@ import renderer, { act } from 'react-test-renderer';
 import { AccessibilityInfo } from 'react-native';
 import type { ChatMessage } from '@chroxy/store-core';
 
-import {
-  usePermissionAnnouncer,
-  firstLivePermissionPrompt,
-} from '../../hooks/usePermissionAnnouncer';
+import { usePermissionAnnouncer } from '../../hooks/usePermissionAnnouncer';
+// #5759 — the predicate now lives in store-core (shared with the dashboard).
+import { firstLivePermissionPrompt } from '@chroxy/store-core';
 
 jest.spyOn(AccessibilityInfo, 'announceForAccessibility');
 const announceMock = AccessibilityInfo.announceForAccessibility as jest.Mock;

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -13,37 +13,13 @@ import {
 } from 'react-native';
 import { useConnectionStore } from '../store/connection';
 import type { SessionInfo, SessionHealth } from '../store/connection';
-import type { ChatMessage } from '@chroxy/store-core';
+// #5759 — shared with the dashboard so the "live permission prompt" rule can't
+// drift between clients (it operates on the shared ChatMessage).
+import { countLivePermissionPrompts } from '@chroxy/store-core';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 import { getProviderInfo } from '../constants/providers';
 import { hapticMedium } from '../utils/haptics';
-
-/**
- * #5750 — count live, unanswered permission prompts in a session's messages so
- * a background tab can surface a "needs your permission" dot (mobile parity
- * with the dashboard's per-tab indicator, #5667/#5674).
- *
- * Mirrors the dashboard's `isLivePermissionPrompt` predicate
- * (packages/dashboard/src/utils/pendingPermissions.ts): a permission prompt is
- * `type:'prompt'` with a `requestId` + a future `expiresAt` and no `answered`
- * decision. The requestId+expiresAt pair distinguishes a permission prompt
- * from an AskUserQuestion (also `type:'prompt'`, but with neither), and the
- * `expiresAt > now` check clears the dot once the prompt times out (the expiry
- * handlers clear the prompt's options but do NOT set `answered`).
- *
- * NOTE: this predicate is duplicated from the dashboard. Converging both clients
- * onto a single store-core helper is tracked as a follow-up (see #5750).
- */
-export function countLivePermissionPrompts(messages: ChatMessage[], now: number): number {
-  let count = 0;
-  for (const m of messages) {
-    if (m.type === 'prompt' && !!m.requestId && !!m.expiresAt && m.expiresAt > now && !m.answered) {
-      count++;
-    }
-  }
-  return count;
-}
 
 /** Pulsing dot for busy sessions */
 function PulsingDot() {

--- a/packages/app/src/hooks/usePermissionAnnouncer.ts
+++ b/packages/app/src/hooks/usePermissionAnnouncer.ts
@@ -33,25 +33,10 @@ import { useEffect, useRef } from 'react';
 import { AccessibilityInfo } from 'react-native';
 
 import type { ChatMessage } from '@chroxy/store-core';
+// #5759 — the live-permission-prompt predicate is shared with the dashboard via
+// store-core so the two clients can't drift on what counts as "pending".
+import { livePermissionPrompts } from '@chroxy/store-core';
 import { getPermissionSummary } from '../components/PermissionDetail';
-
-/** True iff `m` is a live, unanswered permission prompt (not an AskUserQuestion). */
-function isLivePermissionPrompt(m: ChatMessage, now: number): boolean {
-  return m.type === 'prompt' && !!m.requestId && !!m.expiresAt && m.expiresAt > now && !m.answered;
-}
-
-/** The first live, unanswered permission prompt in `messages`, or null. */
-export function firstLivePermissionPrompt(messages: ChatMessage[], now: number): ChatMessage | null {
-  for (const m of messages) {
-    if (isLivePermissionPrompt(m, now)) return m;
-  }
-  return null;
-}
-
-/** All live, unanswered permission prompts in `messages`, in order. */
-export function livePermissionPrompts(messages: ChatMessage[], now: number): ChatMessage[] {
-  return messages.filter((m) => isLivePermissionPrompt(m, now));
-}
 
 export function usePermissionAnnouncer(messages: ChatMessage[], sessionKey: string | null): void {
   // requestIds we've already announced. A Set (not a single id) because more

--- a/packages/dashboard/src/utils/pendingPermissions.ts
+++ b/packages/dashboard/src/utils/pendingPermissions.ts
@@ -1,109 +1,20 @@
-import type { ChatMessage } from '@chroxy/store-core'
-
 /**
- * #5667 — derive which sessions have an unanswered, still-live permission
- * prompt, across ALL sessions. Drives the per-tab "permission waiting"
- * indicator so a background session's request is visible without switching to
- * it (the server now routes a prompt to its owning session, so it no longer
- * lands in the focused tab).
+ * #5667 / #5693 — pending-permission derivation for the per-tab "permission
+ * waiting" indicator and the "jump to next pending" control.
  *
- * A session counts as pending iff it has a `type: 'prompt'` message with a
- * `requestId`, a future `expiresAt`, and no `answered` decision:
- *   - `requestId` + `expiresAt` distinguishes a *permission* prompt from an
- *     AskUserQuestion prompt (which is `type: 'prompt'` but carries neither),
- *     so questions never trip the indicator.
- *   - `expiresAt > now` clears the indicator once the prompt has timed out or
- *     expired — the `permission_expired` / `permission_timeout` handlers clear
- *     the prompt's `options` but do NOT set `answered`, so without the expiry
- *     check an ignored background prompt would leave the indicator stuck on.
- *   - `!answered` clears it the moment the user allows/denies.
- *
- * Returns a plain `Record<sessionId, true>` (only pending sessions present) so
- * a `useShallow` selector re-renders a tab only when its pending state flips.
- * Scans each session newest-first and early-exits at the first live prompt; a
- * pending permission blocks its session, so it is at/near the tail in practice.
+ * #5759 — the predicate + derivations now live in `@chroxy/store-core` as the
+ * single source of truth shared with the mobile app (they all operate on the
+ * same `ChatMessage`), so this module is a thin re-export. Import sites and
+ * tests in the dashboard keep working unchanged; the rule can no longer drift
+ * between the two clients.
  */
-/** True iff `m` is a live, unanswered permission prompt (not an AskUserQuestion). */
-function isLivePermissionPrompt(m: ChatMessage, now: number): boolean {
-  return (
-    m.type === 'prompt' &&
-    !!m.requestId &&
-    !!m.expiresAt &&
-    m.expiresAt > now &&
-    !m.answered
-  )
-}
-
-/**
- * #5693 (PR-3) — count the live, unanswered permission prompts in EACH session.
- * Generalizes {@link derivePendingPermissionSessions} from a boolean to a count
- * so the SessionBar can show a per-tab number (`!2`) and an aggregate "N
- * pending" badge. Sessions with zero pending are omitted (so a `useShallow`
- * selector re-renders a tab only when its count changes).
- *
- * Unlike the boolean derive, this does NOT early-exit — a session can hold more
- * than one pending permission (e.g. parallel SDK tool calls), and the count is
- * the point. Pending permissions are few, so the full scan is cheap.
- */
-export function derivePendingPermissionCounts(
-  sessionStates: Record<string, { messages: ChatMessage[] }>,
-  now: number,
-): Record<string, number> {
-  const out: Record<string, number> = {}
-  for (const id in sessionStates) {
-    const msgs = sessionStates[id]!.messages
-    let count = 0
-    for (let i = 0; i < msgs.length; i++) {
-      if (isLivePermissionPrompt(msgs[i]!, now)) count++
-    }
-    if (count > 0) out[id] = count
-  }
-  return out
-}
-
-/**
- * #5667 — which sessions have at least one live unanswered permission prompt.
- * Thin boolean view over {@link derivePendingPermissionCounts} (single source of
- * truth for the "is this a live permission prompt" predicate). Drives the
- * per-tab attention dot.
- */
-export function derivePendingPermissionSessions(
-  sessionStates: Record<string, { messages: ChatMessage[] }>,
-  now: number,
-): Record<string, true> {
-  const counts = derivePendingPermissionCounts(sessionStates, now)
-  const out: Record<string, true> = {}
-  for (const id in counts) out[id] = true
-  return out
-}
-
-/** Total live pending permissions across all sessions. */
-export function totalPendingPermissions(counts: Record<string, number>): number {
-  let total = 0
-  for (const id in counts) total += counts[id]!
-  return total
-}
-
-/**
- * #5693 (PR-3) — pick the next session (in visual tab order) that has a pending
- * permission, scanning cyclically AFTER the active tab so repeated "jump to
- * pending" clicks cycle through every waiting session. Returns null when none
- * are pending. If the active tab is the only one pending, returns it (a no-op
- * focus). If `activeSessionId` isn't in the list, scans from the start.
- */
-export function selectNextPendingSession(
-  orderedSessionIds: string[],
-  counts: Record<string, number>,
-  activeSessionId: string | null,
-): string | null {
-  const hasPending = (id: string) => (counts[id] ?? 0) > 0
-  const n = orderedSessionIds.length
-  if (n === 0 || !orderedSessionIds.some(hasPending)) return null
-  const activeIndex = activeSessionId ? orderedSessionIds.indexOf(activeSessionId) : -1
-  const from = activeIndex < 0 ? -1 : activeIndex
-  for (let step = 1; step <= n; step++) {
-    const id = orderedSessionIds[(from + step + n) % n]!
-    if (hasPending(id)) return id
-  }
-  return null
-}
+export {
+  isLivePermissionPrompt,
+  firstLivePermissionPrompt,
+  livePermissionPrompts,
+  countLivePermissionPrompts,
+  derivePendingPermissionCounts,
+  derivePendingPermissionSessions,
+  totalPendingPermissions,
+  selectNextPendingSession,
+} from '@chroxy/store-core'

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -695,3 +695,16 @@ export type {
   HandshakeClientOptions,
   MemoryStore,
 } from './handshake-e2e/fake-ws'
+
+// #5759 — shared pending-permission derivation (single source of truth for the
+// "live, unanswered permission prompt" predicate across both clients).
+export {
+  isLivePermissionPrompt,
+  firstLivePermissionPrompt,
+  livePermissionPrompts,
+  countLivePermissionPrompts,
+  derivePendingPermissionCounts,
+  derivePendingPermissionSessions,
+  totalPendingPermissions,
+  selectNextPendingSession,
+} from './pending-permissions'

--- a/packages/store-core/src/pending-permissions.test.ts
+++ b/packages/store-core/src/pending-permissions.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import type { ChatMessage } from './types'
+import {
+  isLivePermissionPrompt,
+  firstLivePermissionPrompt,
+  livePermissionPrompts,
+  countLivePermissionPrompts,
+  derivePendingPermissionSessions,
+  derivePendingPermissionCounts,
+  totalPendingPermissions,
+  selectNextPendingSession,
+} from './pending-permissions'
+
+const NOW = 1_000_000
+
+function prompt(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'm1',
+    type: 'prompt',
+    content: 'Bash: ls',
+    tool: 'Bash',
+    requestId: 'req-1',
+    expiresAt: NOW + 60_000,
+    timestamp: NOW,
+    ...over,
+  }
+}
+
+function states(map: Record<string, ChatMessage[]>): Record<string, { messages: ChatMessage[] }> {
+  const out: Record<string, { messages: ChatMessage[] }> = {}
+  for (const id in map) out[id] = { messages: map[id]! }
+  return out
+}
+
+describe('isLivePermissionPrompt', () => {
+  it('is true only for a live, unanswered permission prompt', () => {
+    expect(isLivePermissionPrompt(prompt(), NOW)).toBe(true)
+    expect(isLivePermissionPrompt(prompt({ answered: 'allow' }), NOW)).toBe(false)
+    expect(isLivePermissionPrompt(prompt({ expiresAt: NOW - 1 }), NOW)).toBe(false)
+    expect(isLivePermissionPrompt(prompt({ requestId: undefined }), NOW)).toBe(false)
+    expect(isLivePermissionPrompt(prompt({ expiresAt: undefined }), NOW)).toBe(false)
+    expect(isLivePermissionPrompt({ id: 't', type: 'response', content: '', timestamp: NOW }, NOW)).toBe(false)
+  })
+})
+
+describe('firstLivePermissionPrompt / livePermissionPrompts / countLivePermissionPrompts', () => {
+  const msgs = [
+    prompt({ id: 'answered', requestId: 'r-ans', answered: 'allow' }),
+    { id: 'sys', type: 'system' as const, content: 'note', timestamp: NOW },
+    prompt({ id: 'live-1', requestId: 'r1' }),
+    prompt({ id: 'live-2', requestId: 'r2' }),
+    prompt({ id: 'expired', requestId: 'r-exp', expiresAt: NOW - 1 }),
+  ]
+  it('first returns the earliest live prompt', () => {
+    expect(firstLivePermissionPrompt(msgs, NOW)?.requestId).toBe('r1')
+    expect(firstLivePermissionPrompt([prompt({ answered: 'deny' })], NOW)).toBeNull()
+  })
+  it('live returns all live prompts in order', () => {
+    expect(livePermissionPrompts(msgs, NOW).map((m) => m.requestId)).toEqual(['r1', 'r2'])
+  })
+  it('count returns the number of live prompts', () => {
+    expect(countLivePermissionPrompts(msgs, NOW)).toBe(2)
+    expect(countLivePermissionPrompts([], NOW)).toBe(0)
+  })
+})
+
+describe('derivePendingPermissionSessions (#5667)', () => {
+  it('flags a session with a live unanswered permission prompt', () => {
+    expect(derivePendingPermissionSessions(states({ s1: [prompt()] }), NOW)).toEqual({ s1: true })
+  })
+  it('does NOT flag answered / expired / AskUserQuestion', () => {
+    expect(derivePendingPermissionSessions(states({ s1: [prompt({ answered: 'allow' })] }), NOW)).toEqual({})
+    expect(derivePendingPermissionSessions(states({ s1: [prompt({ expiresAt: NOW - 1 })] }), NOW)).toEqual({})
+    const aukq = prompt({ requestId: undefined, expiresAt: undefined, options: [{ label: 'A', value: 'a' }] })
+    expect(derivePendingPermissionSessions(states({ s1: [aukq] }), NOW)).toEqual({})
+  })
+  it('flags only the sessions that actually have a live prompt', () => {
+    const result = derivePendingPermissionSessions(
+      states({
+        active: [prompt({ id: 'a', answered: 'allow' })],
+        bg1: [{ ...prompt({ id: 'b' }), type: 'response', content: 'hi' }, prompt({ id: 'c' })],
+        bg2: [prompt({ id: 'd', expiresAt: NOW - 5 })],
+      }),
+      NOW,
+    )
+    expect(result).toEqual({ bg1: true })
+  })
+})
+
+describe('derivePendingPermissionCounts (#5693)', () => {
+  it('counts multiple live prompts in one session and omits zero-pending sessions', () => {
+    const counts = derivePendingPermissionCounts(
+      states({
+        s1: [prompt({ id: 'a', requestId: 'r-a' }), prompt({ id: 'b', requestId: 'r-b' })],
+        s2: [prompt({ id: 'c', requestId: 'r-c' })],
+        s3: [prompt({ id: 'd', requestId: 'r-d', answered: 'allow' })],
+        s4: [],
+      }),
+      NOW,
+    )
+    expect(counts).toEqual({ s1: 2, s2: 1 })
+  })
+  it('stays consistent with the boolean derive', () => {
+    const s = states({ s1: [prompt({ id: 'a' })], s2: [prompt({ id: 'b', answered: 'allow' })] })
+    expect(derivePendingPermissionSessions(s, NOW)).toEqual({ s1: true })
+    expect(Object.keys(derivePendingPermissionCounts(s, NOW))).toEqual(['s1'])
+  })
+})
+
+describe('totalPendingPermissions (#5693)', () => {
+  it('sums counts across sessions', () => {
+    expect(totalPendingPermissions({ s1: 2, s2: 1 })).toBe(3)
+    expect(totalPendingPermissions({})).toBe(0)
+  })
+})
+
+describe('selectNextPendingSession (#5693)', () => {
+  const order = ['a', 'b', 'c', 'd']
+  it('returns null when nothing is pending', () => {
+    expect(selectNextPendingSession(order, {}, 'a')).toBeNull()
+    expect(selectNextPendingSession([], { a: 1 }, 'a')).toBeNull()
+  })
+  it('jumps to the next pending session AFTER the active tab, in tab order', () => {
+    expect(selectNextPendingSession(order, { b: 1, d: 2 }, 'a')).toBe('b')
+    expect(selectNextPendingSession(order, { b: 1, d: 2 }, 'b')).toBe('d')
+  })
+  it('wraps around cyclically', () => {
+    expect(selectNextPendingSession(order, { a: 1 }, 'd')).toBe('a')
+  })
+  it('returns the active tab when it is the only pending one (no-op focus)', () => {
+    expect(selectNextPendingSession(order, { b: 3 }, 'b')).toBe('b')
+  })
+  it('scans from the start when the active id is not in the list', () => {
+    expect(selectNextPendingSession(order, { c: 1 }, 'unknown')).toBe('c')
+    expect(selectNextPendingSession(order, { c: 1 }, null)).toBe('c')
+  })
+})

--- a/packages/store-core/src/pending-permissions.ts
+++ b/packages/store-core/src/pending-permissions.ts
@@ -1,0 +1,123 @@
+/**
+ * Pending-permission derivation — the single source of truth for "which
+ * sessions / messages have a live, unanswered permission prompt", shared by
+ * both clients (#5759).
+ *
+ * Before this module the predicate lived in three places that all operated on
+ * the same shared `ChatMessage`: the dashboard's `utils/pendingPermissions.ts`
+ * (#5667/#5693) and two app copies (`SessionPicker.countLivePermissionPrompts`
+ * and `usePermissionAnnouncer`, #5750). If the rule drifted on one side the two
+ * clients would silently disagree on what counts as "waiting" — the exact
+ * cross-client drift the 2026-06-13 audit flagged. The dashboard util now
+ * re-exports from here; the app imports from here.
+ *
+ * A session/message counts as a *live permission prompt* iff it is a
+ * `type: 'prompt'` message with a `requestId`, a future `expiresAt`, and no
+ * `answered` decision:
+ *   - `requestId` + `expiresAt` distinguish a *permission* prompt from an
+ *     AskUserQuestion prompt (also `type:'prompt'` but carrying neither), so
+ *     questions never trip the indicator.
+ *   - `expiresAt > now` clears it once the prompt has timed out — the
+ *     `permission_expired` / `permission_timeout` handlers clear the prompt's
+ *     `options` but do NOT set `answered`, so without the expiry check an
+ *     ignored prompt would leave the indicator stuck on.
+ *   - `!answered` clears it the moment the user allows/denies.
+ */
+import type { ChatMessage } from './types'
+
+/** True iff `m` is a live, unanswered permission prompt (not an AskUserQuestion). */
+export function isLivePermissionPrompt(m: ChatMessage, now: number): boolean {
+  return (
+    m.type === 'prompt' &&
+    !!m.requestId &&
+    !!m.expiresAt &&
+    m.expiresAt > now &&
+    !m.answered
+  )
+}
+
+/** The first live, unanswered permission prompt in `messages`, or null. */
+export function firstLivePermissionPrompt(messages: ChatMessage[], now: number): ChatMessage | null {
+  for (const m of messages) {
+    if (isLivePermissionPrompt(m, now)) return m
+  }
+  return null
+}
+
+/** All live, unanswered permission prompts in `messages`, in order. */
+export function livePermissionPrompts(messages: ChatMessage[], now: number): ChatMessage[] {
+  return messages.filter((m) => isLivePermissionPrompt(m, now))
+}
+
+/** Count of live, unanswered permission prompts in `messages`. */
+export function countLivePermissionPrompts(messages: ChatMessage[], now: number): number {
+  let count = 0
+  for (const m of messages) {
+    if (isLivePermissionPrompt(m, now)) count++
+  }
+  return count
+}
+
+/**
+ * #5693 (PR-3) — count the live, unanswered permission prompts in EACH session.
+ * Sessions with zero pending are omitted (so a `useShallow` selector re-renders
+ * a tab only when its count changes). Does NOT early-exit — a session can hold
+ * more than one pending permission (parallel SDK tool calls), and the count is
+ * the point. Pending permissions are few, so the full scan is cheap.
+ */
+export function derivePendingPermissionCounts(
+  sessionStates: Record<string, { messages: ChatMessage[] }>,
+  now: number,
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const id in sessionStates) {
+    const count = countLivePermissionPrompts(sessionStates[id]!.messages, now)
+    if (count > 0) out[id] = count
+  }
+  return out
+}
+
+/**
+ * #5667 — which sessions have at least one live unanswered permission prompt.
+ * Thin boolean view over {@link derivePendingPermissionCounts}.
+ */
+export function derivePendingPermissionSessions(
+  sessionStates: Record<string, { messages: ChatMessage[] }>,
+  now: number,
+): Record<string, true> {
+  const counts = derivePendingPermissionCounts(sessionStates, now)
+  const out: Record<string, true> = {}
+  for (const id in counts) out[id] = true
+  return out
+}
+
+/** Total live pending permissions across all sessions. */
+export function totalPendingPermissions(counts: Record<string, number>): number {
+  let total = 0
+  for (const id in counts) total += counts[id]!
+  return total
+}
+
+/**
+ * #5693 (PR-3) — pick the next session (in visual tab order) that has a pending
+ * permission, scanning cyclically AFTER the active tab so repeated "jump to
+ * pending" clicks cycle through every waiting session. Returns null when none
+ * are pending. If the active tab is the only one pending, returns it (a no-op
+ * focus). If `activeSessionId` isn't in the list, scans from the start.
+ */
+export function selectNextPendingSession(
+  orderedSessionIds: string[],
+  counts: Record<string, number>,
+  activeSessionId: string | null,
+): string | null {
+  const hasPending = (id: string) => (counts[id] ?? 0) > 0
+  const n = orderedSessionIds.length
+  if (n === 0 || !orderedSessionIds.some(hasPending)) return null
+  const activeIndex = activeSessionId ? orderedSessionIds.indexOf(activeSessionId) : -1
+  const from = activeIndex < 0 ? -1 : activeIndex
+  for (let step = 1; step <= n; step++) {
+    const id = orderedSessionIds[(from + step + n) % n]!
+    if (hasPending(id)) return id
+  }
+  return null
+}


### PR DESCRIPTION
Closes #5759. De-dups the 'live, unanswered permission prompt' rule that the 2026-06-13 audit (Futurist) flagged as cross-client drift risk — it lived in **three** places that all operate on the shared `ChatMessage`:
- dashboard `utils/pendingPermissions.ts` (#5667/#5693),
- app `SessionPicker.countLivePermissionPrompts` (#5750 item 1),
- app `usePermissionAnnouncer` predicates (#5750 item 2).

If the rule changed on one side, the app and dashboard would silently disagree on which sessions are 'waiting'.

## Change
- **New `packages/store-core/src/pending-permissions.ts`** — single source of truth: `isLivePermissionPrompt` + message-level (`first`/`live`/`count`) + session-level (`derivePendingPermissionCounts`/`Sessions`, `totalPendingPermissions`, `selectNextPendingSession`) derivations. Exported from the store-core index.
- **dashboard `utils/pendingPermissions.ts`** → thin re-export from store-core (import sites + its existing test unchanged).
- **app** `SessionPicker` + `usePermissionAnnouncer` import from store-core; local copies removed; their tests import the predicate from store-core.
- **Canonical store-core test** covers the predicate, both derivations, totals, and `selectNextPendingSession`.

Additive store-core export, **no behavior change**. Per the shared-store-core discipline, ran all three full suites: **store-core 1503 · dashboard 3680 · app 1910 — all tsc clean.**