### PR TITLE
fix(server): fail closed on a stale/unmapped question toolUseId (#5753)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -805,8 +805,32 @@ function handleNotificationPrefsSet(ws, client, msg, ctx) {
 }
 
 function handleUserQuestionResponse(ws, client, msg, ctx) {
-  const questionSessionId = (msg.toolUseId && ctx.permissions.questionSessionMap.get(msg.toolUseId))
-    || client.activeSessionId
+  // #5753 — route by toolUseId when one is supplied. `_registerQuestionRoute`
+  // maps every question that has a toolUseId at DISPATCH time (before the
+  // client can answer) and the entry is pruned the moment the question is
+  // answered (below) or its session is destroyed (ws-server `_questionSessionMap`
+  // sweep). So a toolUseId that is PRESENT but NO LONGER MAPPED means the
+  // question is already gone — answered, expired-and-cleared, or a double
+  // submit. Falling back to `client.activeSessionId` in that case (the old
+  // behavior) would mis-deliver the late answer to whatever DIFFERENT question
+  // that session is now waiting on — a deny meant for one tool landing on
+  // another (Guardian's #5731 finding). Fail CLOSED: drop it.
+  //
+  // Only fall back to the active session when NO toolUseId was supplied at all
+  // (legacy single-session mode / clients that don't send one), where there is
+  // a single question in flight and no cross-question mis-route risk.
+  let questionSessionId
+  if (msg.toolUseId) {
+    questionSessionId = ctx.permissions.questionSessionMap.get(msg.toolUseId)
+    if (!questionSessionId) {
+      sessionLogger(client.activeSessionId || undefined).info(
+        `user_question_response dropped: stale/unknown toolUseId=${msg.toolUseId} (question already resolved or its session is gone)`,
+      )
+      return
+    }
+  } else {
+    questionSessionId = client.activeSessionId
+  }
 
   // Enforce session binding before consuming the mapping — if the client
   // is bound to a different session, leave the mapping intact so the

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -809,25 +809,32 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
   // maps every question that has a toolUseId at DISPATCH time (before the
   // client can answer) and the entry is pruned the moment the question is
   // answered (below) or its session is destroyed (ws-server `_questionSessionMap`
-  // sweep). So a toolUseId that is PRESENT but NO LONGER MAPPED means the
+  // sweep). So a toolUseId that is supplied but NO LONGER IN THE MAP means the
   // question is already gone — answered, expired-and-cleared, or a double
   // submit. Falling back to `client.activeSessionId` in that case (the old
   // behavior) would mis-deliver the late answer to whatever DIFFERENT question
   // that session is now waiting on — a deny meant for one tool landing on
   // another (Guardian's #5731 finding). Fail CLOSED: drop it.
   //
+  // Gate on `.has()`, not value-truthiness: legacy-cli forwarding registers the
+  // route with a NULL sessionId (single default session, `getSession(null)`
+  // serves the default entry), so a mapped-but-null value is a VALID route, not
+  // a drop. And use `typeof === 'string'` (not truthiness) so an empty-string
+  // toolUseId — allowed by the wire schema — is treated as supplied (and thus
+  // dropped when unmapped), never as "no toolUseId".
+  //
   // Only fall back to the active session when NO toolUseId was supplied at all
   // (legacy single-session mode / clients that don't send one), where there is
   // a single question in flight and no cross-question mis-route risk.
   let questionSessionId
-  if (msg.toolUseId) {
-    questionSessionId = ctx.permissions.questionSessionMap.get(msg.toolUseId)
-    if (!questionSessionId) {
+  if (typeof msg.toolUseId === 'string') {
+    if (!ctx.permissions.questionSessionMap.has(msg.toolUseId)) {
       sessionLogger(client.activeSessionId || undefined).info(
         `user_question_response dropped: stale/unknown toolUseId=${msg.toolUseId} (question already resolved or its session is gone)`,
       )
       return
     }
+    questionSessionId = ctx.permissions.questionSessionMap.get(msg.toolUseId)
   } else {
     questionSessionId = client.activeSessionId
   }

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -1146,6 +1146,26 @@ describe('input-handlers', () => {
           'no toolUseId → active-session fallback preserved')
         assert.equal(sessionA.respondToQuestion.lastCall[0], 'yes')
       })
+
+      // #5753 (Copilot) — the wire schema allows an empty-string toolUseId.
+      // Empty string is falsy, but it IS a supplied toolUseId, so it must be
+      // treated as "supplied but unmapped" → dropped, NOT routed to the active
+      // session (the `typeof === 'string'` gate, not truthiness).
+      it('drops an empty-string toolUseId rather than active-fallback (#5753)', () => {
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ id: 'empty-tid', boundSessionId: null, activeSessionId: 's1' })
+
+        inputHandlers.user_question_response(makeWs(), client, {
+          answer: 'yes',
+          toolUseId: '',
+        }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 0,
+          'empty-string toolUseId is supplied-but-unmapped → dropped, not active-fallback')
+      })
     })
   })
 

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -867,6 +867,9 @@ describe('input-handlers', () => {
       const session = createMockSession()
       sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
       const ctx = makeCtx(sessions)
+      // #5753 — a real toolUseId is always registered at dispatch; seed it so
+      // routing resolves to the question's session.
+      ctx.permissions.questionSessionMap.set('tool-1', 's1')
       const client = makeClient({ activeSessionId: 's1' })
 
       inputHandlers.user_question_response(makeWs(), client, {
@@ -886,6 +889,8 @@ describe('input-handlers', () => {
       const session = createMockSession()
       sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
       const ctx = makeCtx(sessions)
+      // #5753 — seed the dispatch-time route for this toolUseId.
+      ctx.permissions.questionSessionMap.set('tool-2', 's1')
       const client = makeClient({ activeSessionId: 's1' })
 
       inputHandlers.user_question_response(makeWs(), client, {
@@ -1090,6 +1095,56 @@ describe('input-handlers', () => {
 
         assert.equal(sessionA.respondToQuestion.callCount, 0,
           'undefined subscribedSessionIds + non-matching active must drop')
+      })
+
+      // #5753 — a toolUseId that's PRESENT but no longer mapped means the
+      // question is already gone (answered / expired-cleared / double-submit;
+      // the entry is pruned on answer + on session destroy). The old code fell
+      // back to client.activeSessionId, mis-delivering the stale answer to
+      // whatever DIFFERENT question that session was waiting on (a deny meant
+      // for one tool landing on another). Fail closed: drop it.
+      it('drops a stale/unmapped toolUseId instead of routing to the active session (#5753)', () => {
+        const sessions = new Map()
+        const sessionA = createMockSession() // the (gone) question's real session
+        const sessionB = createMockSession() // now-active, waiting on a DIFFERENT question
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        sessions.set('s2', { session: sessionB, name: 'B', cwd: '/b' })
+        const ctx = makeCtx(sessions)
+        // The map does NOT contain 'stale-tool' — its question was already
+        // answered, so the entry was pruned. The client is now active on s2.
+        const client = makeClient({
+          id: 'late-answerer',
+          boundSessionId: null,
+          activeSessionId: 's2',
+          subscribedSessionIds: new Set(['s1', 's2']),
+        })
+
+        inputHandlers.user_question_response(makeWs(), client, {
+          answer: 'allow',
+          toolUseId: 'stale-tool',
+        }, ctx)
+
+        assert.equal(sessionB.respondToQuestion.callCount, 0,
+          'a stale answer must NOT bleed onto the active session B')
+        assert.equal(sessionA.respondToQuestion.callCount, 0,
+          'and must not reach A either — the question is gone')
+      })
+
+      // The absent-toolUseId path is unchanged: legacy single-session mode and
+      // clients that never send a toolUseId still fall back to the active
+      // session (one question in flight, no cross-question mis-route risk).
+      it('still falls back to the active session when NO toolUseId is supplied (#5753)', () => {
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ id: 'legacy', boundSessionId: null, activeSessionId: 's1' })
+
+        inputHandlers.user_question_response(makeWs(), client, { answer: 'yes' }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 1,
+          'no toolUseId → active-session fallback preserved')
+        assert.equal(sessionA.respondToQuestion.lastCall[0], 'yes')
       })
     })
   })

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -529,6 +529,9 @@ describe('handleSessionMessage', () => {
       const ctx = makeCtx()
       const client = makeClient({ activeSessionId: 'sess-1' })
       const entry = addSession(ctx, 'sess-1')
+      // #5753 — a real toolUseId is registered at dispatch; seed it so routing
+      // resolves (an unmapped toolUseId is now dropped, not active-fallback'd).
+      ctx.permissions.questionSessionMap.set('tool-xyz', 'sess-1')
       await handleSessionMessage(WS, client, {
         type: 'user_question_response',
         toolUseId: 'tool-xyz',
@@ -549,6 +552,8 @@ describe('handleSessionMessage', () => {
       const client = makeClient({ activeSessionId: 'sess-1' })
       const entry = addSession(ctx, 'sess-1')
       const answersMap = { 'Allow?': 'yes' }
+      // #5753 — seed the dispatch-time route for this toolUseId.
+      ctx.permissions.questionSessionMap.set('tool-abc', 'sess-1')
       await handleSessionMessage(WS, client, {
         type: 'user_question_response',
         toolUseId: 'tool-abc',

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -782,7 +782,13 @@ describe('permission/question routing to originating session', () => {
     ws.close()
   })
 
-  it('falls back to activeSessionId for unknown question toolUseId', async () => {
+  it('drops a stale/unknown question toolUseId instead of routing to activeSessionId (#5753)', async () => {
+    // #5753 — a toolUseId is registered for every question at dispatch and
+    // pruned on answer / session-destroy, so a toolUseId that arrives NOT in
+    // the routing map means its question is already gone. Falling back to the
+    // active session (the old behavior) mis-delivered that stale answer to
+    // whatever DIFFERENT question the active session was now waiting on (a
+    // deny meant for one tool landing on another). It must be dropped.
     const { manager, sessionsMap } = createTwoSessionManager()
 
     let sessionBGotQuestion = false
@@ -798,16 +804,18 @@ describe('permission/question routing to originating session', () => {
     const port = await startServerAndGetPort(server)
     const { ws, messages } = await createClient(port, true)
 
-    // Switch to Session B
+    // Switch to Session B (now the active session).
     send(ws, { type: 'switch_session', sessionId: 'sess-b' })
     await waitForMessage(messages, 'session_switched', 2000)
 
-    // Send question response with unknown toolUseId — no entry in routing map
-    // Should fall back to activeSessionId (sess-b)
+    // A late answer carrying a toolUseId that is NOT in the routing map.
     send(ws, { type: 'user_question_response', toolUseId: 'unknown-tool-use-id', answer: 'yes' })
-    await waitFor(() => sessionBGotQuestion, { label: 'sessionB fallback question' })
+    // No ack is sent for a dropped answer; give the server a beat to process,
+    // then assert the active session did NOT receive the stale answer.
+    await new Promise((r) => setTimeout(r, 150))
 
-    assert.equal(sessionBGotQuestion, true, 'Should fall back to activeSessionId when toolUseId not in routing map')
+    assert.equal(sessionBGotQuestion, false,
+      'a stale/unknown toolUseId must be dropped, not routed to the active session')
 
     ws.close()
   })

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -810,9 +810,12 @@ describe('permission/question routing to originating session', () => {
 
     // A late answer carrying a toolUseId that is NOT in the routing map.
     send(ws, { type: 'user_question_response', toolUseId: 'unknown-tool-use-id', answer: 'yes' })
-    // No ack is sent for a dropped answer; give the server a beat to process,
-    // then assert the active session did NOT receive the stale answer.
-    await new Promise((r) => setTimeout(r, 150))
+    // A dropped answer has no ack. Instead of racing a fixed delay, send a
+    // follow-up request with a deterministic response and wait for IT — WS
+    // messages are processed in order, so once the second answer round-trips
+    // the (dropped) first one is guaranteed to have been processed too.
+    send(ws, { type: 'switch_session', sessionId: 'sess-a' })
+    await waitForMessage(messages, 'session_switched', 2000)
 
     assert.equal(sessionBGotQuestion, false,
       'a stale/unknown toolUseId must be dropped, not routed to the active session')


### PR DESCRIPTION
Closes #5753. Guardian's integrity finding from the 2026-06-13 audit.

## The hole
`_registerQuestionRoute` maps every question's `toolUseId → sessionId` at **dispatch** (before any client can answer) and prunes the entry the moment the question is **answered** or its **session is destroyed**. So a `toolUseId` that arrives in `user_question_response` but is **NOT in the map** means its question is already *gone*.

The old routing fell back to `client.activeSessionId` in that case:
```js
const questionSessionId = (msg.toolUseId && map.get(msg.toolUseId)) || client.activeSessionId
```
So a **late answer to a resolved question** (timeout, double-tap, the prompt rotated) was mis-delivered to whatever **different** question the active session was now waiting on — **a deny meant for one tool could land as an approve on another.** Cross-session is already gated (#4788), so the blast radius is intra-session, but it's a real authorization-integrity bug.

## The fix
`handleUserQuestionResponse` now **fails closed**: a `toolUseId` that's present but unmapped is **dropped** (with a log line). The **absent-`toolUseId`** path is unchanged — legacy single-session mode and clients that never send one still fall back to the active session (one question in flight, no mis-route risk). This is the complete fix for Guardian's repro, **server-only**, no protocol/client change.

## Why it's safe
A live question's `toolUseId` is *always* mapped (registered at dispatch, before the client receives the question), so a legitimate answer never hits the present-but-unmapped branch — only stale/resolved ones do, and dropping those is strictly safer than mis-routing.

## Tests
- New: drops a stale/unmapped `toolUseId`; still falls back when no `toolUseId` is supplied.
- Updated `ws-server-permissions.test.js` — the `falls back for unknown toolUseId` test **encoded the buggy behavior**; rewritten to assert the drop.
- Seeded the routing map in 4 existing tests that passed a `toolUseId` without registering it (unrealistic — production always maps one).
- Server suites green (input-handlers 83/83, ws-server-permissions 49/49, ws-message-handlers 45/45); the only red is the known `:8765` local-daemon `service.test.js` artifact, green in CI.