### PR TITLE
fix(server): ack resume_budget so the resume control is never a dead button

### DIFF
--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -31,7 +31,7 @@ export declare const CLIENT_CAPABILITIES: {
 export declare const MIN_PROTOCOL_VERSION = 1;
 export * from './schemas/index.ts';
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
-export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, ServerCancelActivityAckMessage, } from './schemas/server.ts';
+export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, ServerCancelActivityAckMessage, ServerBudgetResumeAckMessage, } from './schemas/server.ts';
 export type { RepoVerdict, RepoTree, RepoStatus, HostStatusSummary, ServerHostStatusSnapshotMessage, } from './schemas/server.ts';
 export type { RunnerVerdict, RunnerServiceState, RunnerInfo, RepoRunners, RunnerStatusSummary, ServerRunnerStatusSnapshotMessage, } from './schemas/server.ts';
 export type { RepoMemoryCache, RepoMemoryReport, RepoMemoryStatus, RepoRelayRun, RepoRelayVerdict, RepoRelayStatus, IntegrationRepo, IntegrationStatusSummary, IntegrationCliStatus, ServerIntegrationStatusSnapshotMessage, } from './schemas/server.ts';

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -472,7 +472,8 @@ export declare const GitCommitSchema: z.ZodObject<{
 export declare const ResumeBudgetSchema: z.ZodObject<{
     type: z.ZodLiteral<"resume_budget">;
     sessionId: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ListCheckpointsSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_checkpoints">;
 }, z.core.$strip>;
@@ -875,7 +876,8 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"resume_budget">;
     sessionId: z.ZodOptional<z.ZodString>;
-}, z.core.$strip>, z.ZodObject<{
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_checkpoints">;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"restore_checkpoint">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -612,7 +612,13 @@ export const GitCommitSchema = z.object({
 export const ResumeBudgetSchema = z.object({
     type: z.literal('resume_budget'),
     sessionId: z.string().max(256).optional(),
-});
+    // #5752: opaque client-generated correlation id echoed back on the
+    // `budget_resume_ack`, so a client can tie a specific Resume click to its
+    // outcome. Capped at 128 inbound (single enforcement point) so the echoed
+    // ack always satisfies ServerBudgetResumeAckSchema — clones the
+    // `cancel_activity` correlation contract (#5277).
+    requestId: z.string().max(128).optional(),
+}).passthrough();
 export const ListCheckpointsSchema = z.object({
     type: z.literal('list_checkpoints'),
 });

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -2138,6 +2138,12 @@ export declare const ServerBudgetExceededSchema: z.ZodObject<{
     percent: z.ZodNumber;
     message: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerBudgetResumeAckSchema: z.ZodObject<{
+    type: z.ZodLiteral<"budget_resume_ack">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    wasPaused: z.ZodBoolean;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ServerMonthlyBudgetSchema: z.ZodObject<{
     type: z.ZodLiteral<"monthly_budget">;
     month: z.ZodString;
@@ -2322,6 +2328,7 @@ export type ActivityEntry = z.infer<typeof ActivityEntrySchema>;
 export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapshotSchema>;
 export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>;
 export type ServerCancelActivityAckMessage = z.infer<typeof ServerCancelActivityAckSchema>;
+export type ServerBudgetResumeAckMessage = z.infer<typeof ServerBudgetResumeAckSchema>;
 export type RepoVerdict = z.infer<typeof RepoVerdictSchema>;
 export type RepoTree = z.infer<typeof RepoTreeSchema>;
 export type RepoStatus = z.infer<typeof RepoStatusSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -2130,6 +2130,22 @@ export const ServerBudgetExceededSchema = z.object({
     percent: z.number(),
     message: z.string(),
 });
+// #5752: positive ack for an actioned `resume_budget` request. The substantive
+// state change (un-pausing) is still broadcast as `budget_resumed` — but ONLY
+// when the session was actually paused, because that message injects a "session
+// resumed" chat note. The ack is sent to the *requesting* client unconditionally
+// so the resume control is never a dead button: a click on an already-resumed
+// session (e.g. a second client in a shared session, or a stale tap) resolves
+// cleanly with `wasPaused: false` instead of silence. Mirrors the
+// `cancel_activity_ack` correlation contract (#5277).
+export const ServerBudgetResumeAckSchema = z.object({
+    type: z.literal('budget_resume_ack'),
+    sessionId: z.string().optional(),
+    // True when this request actually un-paused the session (a `budget_resumed`
+    // broadcast accompanied it); false when the session was not paused (no-op).
+    wasPaused: z.boolean(),
+    requestId: z.string().max(128).optional(),
+}).passthrough();
 // #5665: machine-wide monthly programmatic-credit budget meter. Broadcast to
 // ALL clients after each programmatic-credit-billed turn, and sent once on
 // connect as a snapshot. `budgetUsd`/`percent` are null when no cap is

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -57,6 +57,8 @@ export type {
   ServerActivitySnapshotMessage,
   ServerActivityDeltaMessage,
   ServerCancelActivityAckMessage,
+  // #5752: resume_budget positive-ack contract.
+  ServerBudgetResumeAckMessage,
 } from './schemas/server.ts'
 
 // #5171: pin the Host/Repo Status Control Room contract (#5170 epic) at the

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -690,7 +690,13 @@ export const GitCommitSchema = z.object({
 export const ResumeBudgetSchema = z.object({
   type: z.literal('resume_budget'),
   sessionId: z.string().max(256).optional(),
-})
+  // #5752: opaque client-generated correlation id echoed back on the
+  // `budget_resume_ack`, so a client can tie a specific Resume click to its
+  // outcome. Capped at 128 inbound (single enforcement point) so the echoed
+  // ack always satisfies ServerBudgetResumeAckSchema — clones the
+  // `cancel_activity` correlation contract (#5277).
+  requestId: z.string().max(128).optional(),
+}).passthrough()
 
 export const ListCheckpointsSchema = z.object({
   type: z.literal('list_checkpoints'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -2262,6 +2262,23 @@ export const ServerBudgetExceededSchema = z.object({
   message: z.string(),
 })
 
+// #5752: positive ack for an actioned `resume_budget` request. The substantive
+// state change (un-pausing) is still broadcast as `budget_resumed` — but ONLY
+// when the session was actually paused, because that message injects a "session
+// resumed" chat note. The ack is sent to the *requesting* client unconditionally
+// so the resume control is never a dead button: a click on an already-resumed
+// session (e.g. a second client in a shared session, or a stale tap) resolves
+// cleanly with `wasPaused: false` instead of silence. Mirrors the
+// `cancel_activity_ack` correlation contract (#5277).
+export const ServerBudgetResumeAckSchema = z.object({
+  type: z.literal('budget_resume_ack'),
+  sessionId: z.string().optional(),
+  // True when this request actually un-paused the session (a `budget_resumed`
+  // broadcast accompanied it); false when the session was not paused (no-op).
+  wasPaused: z.boolean(),
+  requestId: z.string().max(128).optional(),
+}).passthrough()
+
 // #5665: machine-wide monthly programmatic-credit budget meter. Broadcast to
 // ALL clients after each programmatic-credit-billed turn, and sent once on
 // connect as a snapshot. `budgetUsd`/`percent` are null when no cap is
@@ -2509,6 +2526,8 @@ export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapsho
 export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>
 // #5277: positive ack for an actioned cancel_activity request.
 export type ServerCancelActivityAckMessage = z.infer<typeof ServerCancelActivityAckSchema>
+// #5752: positive ack for an actioned resume_budget request.
+export type ServerBudgetResumeAckMessage = z.infer<typeof ServerBudgetResumeAckSchema>
 // #5171: Host/Repo Status Control Room wire contract (#5170 epic). Consumed by
 // the server emitter, store-core reducer, and dashboard panel in sibling issues.
 export type RepoVerdict = z.infer<typeof RepoVerdictSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -44,6 +44,7 @@ const SYNTHETIC_TYPES = new Set([
   'conversations_list',    // legacy alias for list response
   'search_results',        // legacy alias for search response
   'budget_resumed',        // budget resume ack (server-internal)
+  'budget_resume_ack',     // #5752 resume_budget positive ack — emitted from input-handlers.js (not the ws-server.js broadcast surface the extractor scans), handled by the shared store-core dispatch table
   'cancel_activity_ack',   // #5277 cancel correlation ack — emitted from input-handlers.js (not the ws-server.js broadcast surface the extractor scans), handled by the dashboard
   'thinking_level_changed', // thinking level change ack (server-internal)
   'permission_timeout',     // handled by both clients for the future permission timeout event (not yet in protocol; dashboard gained parity in #5454)

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -686,6 +686,9 @@ function handleResumeBudget(ws, client, msg, ctx) {
     type: 'budget_resume_ack',
     sessionId: budgetSessionId,
     wasPaused,
+    // Echo requestId for correlation. The inbound ResumeBudgetSchema caps it at
+    // 128 (#5752), so the ack always satisfies ServerBudgetResumeAckSchema —
+    // same single-enforcement-point pattern as cancel_activity_ack (#5277).
     ...(typeof msg.requestId === 'string' ? { requestId: msg.requestId } : {}),
   })
 }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -669,11 +669,25 @@ function handleResumeBudget(ws, client, msg, ctx) {
     sendSessionError(ws, ctx, 'No valid session for budget resume')
     return
   }
-  if (ctx.sessions.sessionManager.isBudgetPaused(budgetSessionId)) {
+  // #5752: only un-pause + broadcast `budget_resumed` (which injects a "session
+  // resumed" chat note) when the session was actually paused. Always ack the
+  // requesting client so the resume control is never a dead button — a click on
+  // an already-resumed session (a second client in a shared session, or a stale
+  // tap) resolves cleanly with wasPaused:false instead of silence.
+  const wasPaused = ctx.sessions.sessionManager.isBudgetPaused(budgetSessionId)
+  if (wasPaused) {
     ctx.sessions.sessionManager.resumeBudget(budgetSessionId)
     ctx.transport.broadcastToSession(budgetSessionId, { type: 'budget_resumed', sessionId: budgetSessionId })
     log.info(`Budget resumed for session ${budgetSessionId} by ${client.id}`)
+  } else {
+    log.info(`resume_budget no-op for session ${budgetSessionId} (not paused) by ${client.id}`)
   }
+  ctx.transport.send(ws, {
+    type: 'budget_resume_ack',
+    sessionId: budgetSessionId,
+    wasPaused,
+    ...(typeof msg.requestId === 'string' ? { requestId: msg.requestId } : {}),
+  })
 }
 
 function handleRegisterPushToken(ws, client, msg, ctx) {

--- a/packages/server/tests/ws-handlers.test.js
+++ b/packages/server/tests/ws-handlers.test.js
@@ -441,6 +441,30 @@ describe('WS handler: resume_budget', () => {
 
     ws.close()
   })
+
+  it('echoes a within-cap requestId for correlation', async () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Default', cwd: '/tmp' },
+    ])
+    manager.isBudgetPaused = () => false
+    manager.resumeBudget = createSpy()
+
+    server = new WsServer({
+      port: 0, apiToken: 'test-token', authRequired: false,
+      sessionManager: manager,
+    })
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    messages.length = 0
+    send(ws, { type: 'resume_budget', requestId: 'req-42' })
+
+    const ack = await waitForMessage(messages, 'budget_resume_ack')
+    assert.ok(ack, 'Should receive budget_resume_ack')
+    assert.equal(ack.requestId, 'req-42')
+
+    ws.close()
+  })
 })
 
 describe('WS handler: register_push_token', () => {

--- a/packages/server/tests/ws-handlers.test.js
+++ b/packages/server/tests/ws-handlers.test.js
@@ -384,7 +384,7 @@ describe('WS handler: resume_budget', () => {
   let server
   afterEach(() => { if (server) { server.close(); server = null } })
 
-  it('resumes a paused budget and broadcasts', async () => {
+  it('resumes a paused budget, broadcasts, and acks with wasPaused:true', async () => {
     const { manager } = createMockSessionManager([
       { id: 'sess-1', name: 'Default', cwd: '/tmp' },
     ])
@@ -404,11 +404,15 @@ describe('WS handler: resume_budget', () => {
     const resumed = await waitForMessage(messages, 'budget_resumed')
     assert.ok(resumed, 'Should receive budget_resumed')
     assert.equal(manager.resumeBudget.callCount, 1)
+    // #5752: the requesting client also gets a dedicated ack.
+    const ack = await waitForMessage(messages, 'budget_resume_ack')
+    assert.ok(ack, 'Should receive budget_resume_ack')
+    assert.equal(ack.wasPaused, true)
 
     ws.close()
   })
 
-  it('does nothing when budget is not paused', async () => {
+  it('acks with wasPaused:false without broadcasting when budget is not paused', async () => {
     const { manager } = createMockSessionManager([
       { id: 'sess-1', name: 'Default', cwd: '/tmp' },
     ])
@@ -425,8 +429,12 @@ describe('WS handler: resume_budget', () => {
     messages.length = 0
     send(ws, { type: 'resume_budget' })
 
-    // Wait a bit to ensure no message is sent
-    await new Promise(r => setTimeout(r, 200))
+    // #5752: even when not paused, the client gets a dedicated ack so the resume
+    // control is never silently dead — deterministic instead of a sleep+poll.
+    const ack = await waitForMessage(messages, 'budget_resume_ack')
+    assert.ok(ack, 'Should receive budget_resume_ack')
+    assert.equal(ack.wasPaused, false)
+    // But NO un-pause and NO budget_resumed (which would inject a false note).
     const resumed = messages.find(m => m.type === 'budget_resumed')
     assert.equal(resumed, undefined, 'Should NOT receive budget_resumed when not paused')
     assert.equal(manager.resumeBudget.callCount, 0)

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -217,6 +217,33 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { added: [sysMsg('Cost budget override — session resumed')] },
   },
 
+  // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the
+  // session was not paused; no-op when it was (budget_resumed already noted it)
+  {
+    name: 'budget_resume_ack appends the "nothing to resume" note when not paused',
+    type: 'budget_resume_ack',
+    init: { sessions: { s1: {} } },
+    message: { type: 'budget_resume_ack', sessionId: 's1', wasPaused: false },
+    expect: {
+      sessions: {
+        s1: { messages: [sysMsg('Budget was not paused — nothing to resume')] },
+      },
+    },
+  },
+  {
+    name: 'budget_resume_ack falls back to addMessage for the not-paused note',
+    type: 'budget_resume_ack',
+    message: { type: 'budget_resume_ack', wasPaused: false },
+    expect: { added: [sysMsg('Budget was not paused — nothing to resume')] },
+  },
+  {
+    name: 'budget_resume_ack is a no-op when the session was actually paused',
+    type: 'budget_resume_ack',
+    init: { sessions: { s1: {} } },
+    message: { type: 'budget_resume_ack', sessionId: 's1', wasPaused: true },
+    expect: { noop: true },
+  },
+
   // 5. conversation_id — stamp onto explicit session (NO active fallback)
   {
     name: 'conversation_id stamps the conversation id onto the explicit session',

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -215,6 +215,40 @@ describe('shared dispatch table', () => {
     })
   })
 
+  describe('budget_resume_ack', () => {
+    it('appends a "nothing to resume" note when the session was not paused', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, { type: 'budget_resume_ack', sessionId: 's1', wasPaused: false })
+      expect(env.sessions.s1.messages).toHaveLength(1)
+      expect(env.sessions.s1.messages[0]).toMatchObject({
+        type: 'system',
+        content: 'Budget was not paused — nothing to resume',
+      })
+      expect(env.addedMessages).toHaveLength(0)
+    })
+
+    it('is a no-op when the session was actually paused (budget_resumed already noted it)', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, { type: 'budget_resume_ack', sessionId: 's1', wasPaused: true })
+      expect(env.sessions.s1.messages).toHaveLength(0)
+      expect(env.addedMessages).toHaveLength(0)
+    })
+
+    it('falls back to addMessage for the not-paused note when there is no target session', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'budget_resume_ack', wasPaused: false })
+      expect(env.addedMessages).toHaveLength(1)
+      expect(env.addedMessages[0]).toMatchObject({
+        type: 'system',
+        content: 'Budget was not paused — nothing to resume',
+      })
+    })
+  })
+
   describe('conversation_id', () => {
     it('stamps the conversation id onto the explicit session', () => {
       const env = makeAdapter({

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -263,7 +263,8 @@ export interface DispatchMessageMap {
   budget_resume_ack: {
     type: 'budget_resume_ack'
     sessionId?: string
-    wasPaused?: boolean
+    // Required, matching ServerBudgetResumeAckSchema — the server always sends it.
+    wasPaused: boolean
   }
   conversation_id: {
     type: 'conversation_id'

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -60,6 +60,7 @@ import {
   handleSessionUpdated,
   handleAgentBusy,
   handleBudgetResumed,
+  handleBudgetResumeAck,
   handleConversationId,
   handlePermissionRulesUpdated,
   handleConfirmPermissionMode,
@@ -259,6 +260,11 @@ export interface DispatchMessageMap {
     type: 'budget_resumed'
     sessionId?: string
   }
+  budget_resume_ack: {
+    type: 'budget_resume_ack'
+    sessionId?: string
+    wasPaused?: boolean
+  }
   conversation_id: {
     type: 'conversation_id'
     sessionId?: string
@@ -446,6 +452,32 @@ function dispatchBudgetResumed<S extends DispatchSessionBase>(
   adapter: ClientStoreAdapter<S>,
 ): void {
   const { systemMessage } = handleBudgetResumed()
+  const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (targetId && adapter.hasSession(targetId)) {
+    adapter.updateSession(
+      targetId,
+      (ss) =>
+        ({
+          messages: [...ss.messages, systemMessage],
+        } as Partial<S>),
+    )
+  } else {
+    adapter.addMessage(systemMessage)
+  }
+}
+
+/**
+ * `budget_resume_ack` (#5752) — acknowledge an actioned `resume_budget`. A
+ * no-op when the session was actually paused (the accompanying `budget_resumed`
+ * broadcast already showed the "resumed" note); appends a quiet "nothing to
+ * resume" note otherwise, so the resume control is never silently dead.
+ */
+function dispatchBudgetResumeAck<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['budget_resume_ack'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { systemMessage } = handleBudgetResumeAck(msg as Record<string, unknown>)
+  if (!systemMessage) return
   const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
   if (targetId && adapter.hasSession(targetId)) {
     adapter.updateSession(
@@ -899,6 +931,7 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     session_updated: dispatchSessionUpdated,
     agent_busy: dispatchAgentBusy,
     budget_resumed: dispatchBudgetResumed,
+    budget_resume_ack: dispatchBudgetResumeAck,
     conversation_id: dispatchConversationId,
     permission_rules_updated: dispatchPermissionRulesUpdated,
     confirm_permission_mode: dispatchConfirmPermissionMode,
@@ -940,6 +973,7 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'session_updated',
   'agent_busy',
   'budget_resumed',
+  'budget_resume_ack',
   'conversation_id',
   'permission_rules_updated',
   'confirm_permission_mode',

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -383,6 +383,35 @@ export function handleBudgetResumed(): { systemMessage: ChatMessage } {
 }
 
 // ---------------------------------------------------------------------------
+// budget_resume_ack (#5752)
+// ---------------------------------------------------------------------------
+
+/**
+ * Acknowledge an actioned `resume_budget` request.
+ *
+ * When the session was actually paused (`wasPaused === true`) the server also
+ * broadcast a `budget_resumed`, which already injected the "session resumed"
+ * note — so the ack adds nothing and returns `{ systemMessage: null }`. When the
+ * session was NOT paused the ack is the only feedback the clicking client gets,
+ * so it appends a quiet note rather than leaving the control silently dead
+ * (e.g. a second client in a shared session tapping Resume after the first
+ * already resumed).
+ */
+export function handleBudgetResumeAck(
+  msg: Record<string, unknown>,
+): { systemMessage: ChatMessage | null } {
+  if (msg.wasPaused === true) return { systemMessage: null }
+  return {
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: 'Budget was not paused — nothing to resume',
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
 // plan_started
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`resume_budget`'s production handler already un-pauses + broadcasts `budget_resumed` when a session is paused — but it returns **silently** when the session is **not** paused (`packages/server/src/handlers/input-handlers.js`). In a shared session, a second client tapping **Resume** after the first already resumed (or any stale/raced tap) gets no feedback: a **dead button**.

`budget_resumed` can't double as the acknowledgement, because it injects a "session resumed" chat note — false when nothing was actually paused. That's why the 2026-06-13 swarm audit (Guardian) deferred it.

> Note: the `resumeBudget: () => {}` at `ws-message-handlers.js:136` cited in the issue is the **legacy single-CLI adapter** stub (unused in production per its own header comment); the real `SessionManager` path was already wired. The genuine gap is the silent not-paused branch above.

## Fix

A dedicated **`budget_resume_ack`** wire-type:

- **server** — `handleResumeBudget` captures `wasPaused`, un-pauses + broadcasts `budget_resumed` **only** when actually paused, and **always** sends `budget_resume_ack { sessionId, wasPaused, requestId? }` to the requesting client.
- **protocol** — `ServerBudgetResumeAckSchema` (+ type alias, entry-point re-export, regenerated `dist`), mirroring the `cancel_activity_ack` correlation contract (#5277).
- **store-core** — `handleBudgetResumeAck` + a dispatch-table entry, so **both clients** pick it up for free: a no-op when `wasPaused` (the `budget_resumed` broadcast already showed the note), a quiet *"Budget was not paused — nothing to resume"* note otherwise.

## Tests

- `ws-handlers`: paused → resume + broadcast + ack `wasPaused:true`; not-paused → ack `wasPaused:false` only, **no** `budget_resumed`, **no** un-pause (replaces a flaky `setTimeout(200)` poll with a deterministic `waitForMessage`).
- store-core dispatch-table unit tests + behavioral-contract fixtures (paused no-op, not-paused note, flat fallback).
- protocol handler-coverage synthetic-type entry.

## Verification

- Full server suite: **9515/9517** — the only 2 failures are the documented `:8765` live-daemon artifacts (`service.test.js` timeout/port-fallback) which fail only because the dev daemon is running locally; unrelated to this change and green in CI.
- store-core (vitest) + protocol (node:test) suites green; dashboard + app + protocol + store-core `tsc` clean (both clients absorb the new type via the shared table with **zero** per-client edits); server eslint + `lint-session-opt-forwarding` + `lint-tests-state-file-path` clean.

Closes #5752