### PR TITLE
perf(server): bound concurrent eager key derivations per event-loop iteration

### DIFF
--- a/packages/server/eslint.config.js
+++ b/packages/server/eslint.config.js
@@ -13,6 +13,7 @@ export default [
         setInterval: 'readonly',
         clearInterval: 'readonly',
         setImmediate: 'readonly',
+        clearImmediate: 'readonly',
         URL: 'readonly',
         Buffer: 'readonly',
         AbortController: 'readonly',

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -46,6 +46,69 @@ const BACKPRESSURE_PAUSE_THRESHOLD = 256 * 1024
 const BACKPRESSURE_POLL_INTERVAL_MS = 20
 const BACKPRESSURE_MAX_WAIT_MS = 30_000
 
+// #5622 — bound the eager X25519 key derivations done SYNCHRONOUSLY per
+// event-loop iteration.
+//
+// The #5590 eager fold concentrates createKeyPair + DH (deriveSharedKey) + HKDF
+// (deriveConnectionKey) into the synchronous auth-frame handler (sendPostAuthInfo
+// below) for every connect. A reconnect storm delivers N auth frames in a single
+// poll phase, so the N scalar-mults run back-to-back on the event loop and can
+// delay the timer phase past the 15s keepalive sweep (#5594) — event-loop
+// starvation that bites only at fan-out scale (swarm-audit round 3, Tunneler).
+//
+// A classic async semaphore is meaningless here: the crypto is synchronous, so
+// no two derivations ever truly overlap — the cost is serialization within one
+// loop iteration, not concurrency. The correct analog of a concurrency cap for
+// synchronous work is therefore a per-iteration budget: run at most
+// MAX_EAGER_DERIVATIONS_PER_TICK derivations inline, and let any further connects
+// in the same iteration fall back to the DISCRETE key_exchange handshake. That
+// fallback is already wired (the `!eagerServerPublicKey` branch below engages
+// encryptionPending + the post-auth queue) and its derivation lands on a later
+// frame/tick, which de-concentrates the work so the timer phase — and the
+// keepalive sweep — gets to run between iterations.
+//
+// The counter resets on each setImmediate (fires once per loop iteration, in the
+// check phase, after timers), so the budget is genuinely per-iteration. Under
+// normal load (< CAP connects per iteration) the eager path is unchanged; only a
+// storm degrades, and only to the pre-#5590 discrete handshake (one extra RTT),
+// never to a failed connection.
+const MAX_EAGER_DERIVATIONS_PER_TICK = 8
+let _eagerDerivationsThisTick = 0
+let _eagerResetScheduled = false
+
+/**
+ * Reserve a slot for one synchronous eager key derivation in the current
+ * event-loop iteration. Returns true if under the per-iteration budget (caller
+ * should derive inline), false if the budget is spent (caller should skip the
+ * eager fold and let the client use the discrete handshake). Schedules a
+ * one-shot reset of the counter for the next iteration on first use.
+ *
+ * Exported for direct unit testing of the budget + reset behaviour.
+ */
+export function _reserveEagerDerivationSlot() {
+  if (_eagerDerivationsThisTick >= MAX_EAGER_DERIVATIONS_PER_TICK) return false
+  _eagerDerivationsThisTick++
+  if (!_eagerResetScheduled) {
+    _eagerResetScheduled = true
+    setImmediate(() => {
+      _eagerDerivationsThisTick = 0
+      _eagerResetScheduled = false
+    })
+  }
+  return true
+}
+
+/**
+ * Reset the per-iteration eager-derivation budget synchronously. Test-only — the
+ * module-global counter is reset by setImmediate in production, but node:test can
+ * run several synchronous test bodies within one macrotask, so a test that
+ * exhausts the budget would otherwise leak into the next. Call in a `beforeEach`.
+ */
+export function _resetEagerDerivationBudgetForTests() {
+  _eagerDerivationsThisTick = 0
+  _eagerResetScheduled = false
+}
+
 /**
  * Schedule `fn` once ws.bufferedAmount falls below BACKPRESSURE_PAUSE_THRESHOLD,
  * or immediately (via setImmediate) if the buffer is already drained. Polls
@@ -180,7 +243,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   let eagerServerKeySig = null
   let eagerEncryptionState = null
   if (client.eagerKeyExchange) {
-    if (requireEncryption) {
+    // #5622: only run the eager derivation inline while under the per-iteration
+    // budget. Over budget (reconnect storm) we skip the fold and leave
+    // eagerServerPublicKey null, so the `requireEncryption && !eagerServerPublicKey`
+    // branch below transparently engages the discrete key_exchange handshake —
+    // its scalar-mult lands on a later tick, keeping this iteration short enough
+    // for the keepalive sweep to run.
+    if (requireEncryption && _reserveEagerDerivationSlot()) {
       try {
         const serverKp = createKeyPair()
         const rawSharedKey = deriveSharedKey(client.eagerKeyExchange.publicKey, serverKp.secretKey)

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -75,6 +75,7 @@ const BACKPRESSURE_MAX_WAIT_MS = 30_000
 const MAX_EAGER_DERIVATIONS_PER_TICK = 8
 let _eagerDerivationsThisTick = 0
 let _eagerResetScheduled = false
+let _eagerResetHandle = null
 
 /**
  * Reserve a slot for one synchronous eager key derivation in the current
@@ -90,9 +91,12 @@ export function _reserveEagerDerivationSlot() {
   _eagerDerivationsThisTick++
   if (!_eagerResetScheduled) {
     _eagerResetScheduled = true
-    setImmediate(() => {
+    // Retain the handle so the test reset helper can cancel a still-pending
+    // reset and keep test isolation tight (#5764 review).
+    _eagerResetHandle = setImmediate(() => {
       _eagerDerivationsThisTick = 0
       _eagerResetScheduled = false
+      _eagerResetHandle = null
     })
   }
   return true
@@ -105,6 +109,12 @@ export function _reserveEagerDerivationSlot() {
  * exhausts the budget would otherwise leak into the next. Call in a `beforeEach`.
  */
 export function _resetEagerDerivationBudgetForTests() {
+  // Cancel any reset still queued from a prior test/tick so it can't fire mid
+  // test (after an `await`) and mutate the budget unexpectedly (#5764 review).
+  if (_eagerResetHandle) {
+    clearImmediate(_eagerResetHandle)
+    _eagerResetHandle = null
+  }
   _eagerDerivationsThisTick = 0
   _eagerResetScheduled = false
 }

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -12,6 +12,8 @@ import {
   flushPostAuthQueue,
   scheduleAfterDrain,
   scheduleProviderModelsRefresh,
+  _reserveEagerDerivationSlot,
+  _resetEagerDerivationBudgetForTests,
 } from '../src/ws-history.js'
 import { PERMISSION_MODES } from '../src/handler-utils.js'
 import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
@@ -157,6 +159,69 @@ describe('sendPostAuthInfo — base auth_ok payload', () => {
     assert.equal(serverMode.mode, 'multi')
     const status = ctx._sends.find(m => m.type === 'status')
     assert.equal(status.connected, true)
+  })
+})
+
+// ── #5622: per-iteration eager-derivation budget ────────────────────────────
+
+describe('_reserveEagerDerivationSlot — per-iteration budget (#5622)', () => {
+  beforeEach(_resetEagerDerivationBudgetForTests)
+
+  it('grants exactly the per-tick cap, then refuses within the same tick', () => {
+    let granted = 0
+    for (let i = 0; i < 20; i++) {
+      if (_reserveEagerDerivationSlot()) granted++
+    }
+    assert.equal(granted, 8, 'grants exactly MAX_EAGER_DERIVATIONS_PER_TICK slots per tick')
+  })
+
+  it('restores the budget on the next event-loop iteration', async () => {
+    while (_reserveEagerDerivationSlot()) { /* drain this tick's budget */ }
+    assert.equal(_reserveEagerDerivationSlot(), false, 'budget spent within the tick')
+    // Real setImmediate reset (production path), not the test helper.
+    await new Promise((r) => setImmediate(r))
+    assert.equal(_reserveEagerDerivationSlot(), true, 'budget restored on the next iteration')
+  })
+})
+
+// #5622: under a reconnect storm, the eager X25519 fold is capped per event-loop
+// iteration so the synchronous scalar-mults don't starve the keepalive sweep.
+// Connects beyond the cap fall back to the (already-tested) discrete handshake.
+describe('sendPostAuthInfo — eager-derivation storm fallback (#5622)', () => {
+  beforeEach(_resetEagerDerivationBudgetForTests)
+
+  it('serves the first CAP eager exchanges, then degrades to discrete within one tick', () => {
+    const results = []
+    // CAP + 1 (= 9) eager connects, all in ONE synchronous tick so they share
+    // the same per-iteration budget.
+    for (let i = 0; i < 9; i++) {
+      const ctx = makeCtx({ encryptionEnabled: true })
+      const ws = makeFakeWs()
+      const clientKp = createKeyPair()
+      const client = registerClient(ctx, ws, {
+        id: `storm-client-${i}`,
+        socketIp: '10.0.0.1', // not localhost → encryption required
+        eagerKeyExchange: { publicKey: clientKp.publicKey, salt: generateConnectionSalt() },
+      })
+      sendPostAuthInfo(ctx, ws)
+      results.push({ authOk: ctx._sends.find((m) => m.type === 'auth_ok'), client })
+    }
+
+    const withEager = results.filter((r) => r.authOk.serverPublicKey)
+    const withoutEager = results.filter((r) => !r.authOk.serverPublicKey)
+    assert.equal(withEager.length, 8, 'first 8 connects in the tick get the eager fold')
+    assert.equal(withoutEager.length, 1, 'the 9th degrades to the discrete handshake')
+
+    // Eager clients: encryption established inline, never marked pending.
+    for (const r of withEager) {
+      assert.ok(r.client.encryptionState, 'eager client has encryption established')
+      assert.notEqual(r.client.encryptionPending, true)
+    }
+    // Fallback client: awaits the discrete key_exchange (pending + queued burst).
+    const fb = withoutEager[0].client
+    assert.equal(fb.encryptionPending, true, 'fallback client awaits discrete key_exchange')
+    assert.ok(Array.isArray(fb.postAuthQueue), 'fallback client queues the post-auth burst')
+    clearTimeout(fb._keyExchangeTimeout) // cleanup the discrete-handshake timeout
   })
 })
 
@@ -676,6 +741,10 @@ function makeEncryptingCtx(overrides = {}) {
 }
 
 describe('sendPostAuthInfo — eager key exchange (#5555)', () => {
+  // #5622: these single-connect eager tests must start with a full per-tick
+  // budget, independent of any storm test that ran in the same macrotask.
+  beforeEach(_resetEagerDerivationBudgetForTests)
+
   it('derives the shared key inline and returns serverPublicKey, un-gating the queue', () => {
     const ws = makeFakeWs()
     const ctx = makeEncryptingCtx({ encryptionEnabled: true, keyExchangeTimeoutMs: 60000 })


### PR DESCRIPTION
## Problem

The #5590 eager key-exchange fold concentrates `createKeyPair` + X25519 DH (`deriveSharedKey`) + HKDF (`deriveConnectionKey`) into the **synchronous** auth-frame handler (`sendPostAuthInfo`, `ws-history.js`) for every connect. A reconnect storm delivers N auth frames in a single event-loop poll phase, so the N scalar-mults run back-to-back on the loop and can delay the timer phase past the **15s keepalive sweep** (#5594) — event-loop starvation that bites only at fan-out scale (swarm-audit round 3, Tunneler; LOW severity).

## Approach — why a per-iteration budget, not an async semaphore

A classic async semaphore is meaningless for this code: the crypto is **synchronous**, so no two derivations ever overlap — the cost is *serialization within one loop iteration*, not concurrency. The correct analog of a concurrency cap for synchronous work is a **per-iteration budget**:

- Run at most `MAX_EAGER_DERIVATIONS_PER_TICK` (8) eager derivations inline per event-loop iteration.
- Any further connects in the same iteration **fall back to the discrete `key_exchange` handshake** — which is *already wired*: the `requireEncryption && !eagerServerPublicKey` branch engages `encryptionPending` + the post-auth queue. Its derivation lands on a later frame/tick, de-concentrating the work so the timer phase (and the keepalive sweep) runs between iterations.

The counter resets on each `setImmediate` (fires once per loop iteration, in the check phase after timers), so the budget is genuinely per-iteration. **Under normal load (< 8 connects/iteration) the eager path is unchanged**; only a storm degrades, and only to the pre-#5590 discrete handshake (one extra RTT) — never to a failed connection.

## Changes

- `_reserveEagerDerivationSlot()` — the per-iteration gate; wraps the eager block in `sendPostAuthInfo`.
- `_resetEagerDerivationBudgetForTests()` — the counter is process-global, and node:test runs synchronous bodies in one macrotask, so a storm test would leak budget into the next; this resets it in `beforeEach` (idiomatic — mirrors `_resetProviderRegistryCacheForTests`).
- Tests: per-tick budget grant/refuse/reset; storm fallback (first 8 connects in a tick get the eager fold, the 9th degrades to discrete with `encryptionPending` + queued burst). Also guards the existing #5555 single-connect eager tests with the reset.

## Verification

- Full server suite clean except the two known environmental artifacts (`service.test.js` `:8765` live-daemon probes, `tunnel.integration.test.js` cloudflared) — zero eager / ws-history / ws-auth / crypto failures. `ws-history.test.js` 140/140. eslint clean.
- No wire-protocol change (the discrete fallback is an existing path); no client changes.

Closes #5622