### PR TITLE
cleanup: consume the shared retry-ladder consts in both clients (#5621)

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -893,7 +893,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
-  // Initial connection uses bounded retries (CONNECT_MAX_RETRIES) with exponential backoff.
+  // Initial connection uses bounded retries (CONNECT_MAX_RETRIES) climbing the
+  // fixed CONNECT_RETRY_DELAYS ladder ([1000,2000,3000,5000,8000]ms).
   // This prevents infinite loops on bad credentials or missing servers.
   // Auto-reconnect (socket.onclose) calls connect() with _retryCount=0, resetting
   // the retry budget — intentional, since established connections should recover

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -157,6 +157,9 @@ import {
   // as callbacks. `resolveEndpoint` is the #5597/#5537 LAN/tunnel seam (static).
   runConnectAttempt,
   createReconnectScheduler,
+  // #5621 — the shared retry-ladder defaults (was duplicated verbatim here).
+  CONNECT_MAX_RETRIES,
+  CONNECT_RETRY_DELAYS,
   // #5537 — shared LAN→tunnel fast-fallback decision for the reconnect ladder.
   selectReconnectEndpoint,
   type ProbeResult,
@@ -227,9 +230,9 @@ const ENCRYPTED_PHASE_PLAINTEXT_ALLOWLIST = new Set([
 ]);
 
 // #5555.5 — the close/error-path reconnect delay is no longer a fixed
-// constant. Both handlers now climb the RETRY_DELAYS ladder (defined in
-// connect()) via the module-level reconnectAttempt counter, which resets on
-// `auth_ok`. See scheduleReconnect() below.
+// constant. Both handlers now climb the shared CONNECT_RETRY_DELAYS ladder
+// (from @chroxy/store-core) via the module-level reconnectAttempt counter,
+// which resets on `auth_ok`. See scheduleReconnect() below.
 
 // #4771: getWsCloseMessage and getHealthCheckErrorMessage are now
 // defined in `packages/store-core/src/ws-errors.ts` and exported from
@@ -890,7 +893,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
-  // Initial connection uses bounded retries (MAX_RETRIES) with exponential backoff.
+  // Initial connection uses bounded retries (CONNECT_MAX_RETRIES) with exponential backoff.
   // This prevents infinite loops on bad credentials or missing servers.
   // Auto-reconnect (socket.onclose) calls connect() with _retryCount=0, resetting
   // the retry budget — intentional, since established connections should recover
@@ -911,8 +914,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   ) => {
     const _retryCount = options?._retryCount ?? 0;
     const silent = options?.silent ?? false;
-    const MAX_RETRIES = 5;
-    const RETRY_DELAYS = [1000, 2000, 3000, 5000, 8000];
     // Honor a precheck only on the first attempt (retries must re-probe), and
     // only when it's recent enough that the host's liveness hasn't gone stale.
     const HEALTH_PRECHECK_MAX_AGE_MS = 2000;
@@ -956,7 +957,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     useConnectionLifecycleStore.getState().setUserDisconnected(false);
 
     if (_retryCount > 0) {
-      console.log(`[ws] Connection attempt ${_retryCount + 1}/${MAX_RETRIES + 1}...`);
+      console.log(`[ws] Connection attempt ${_retryCount + 1}/${CONNECT_MAX_RETRIES + 1}...`);
     }
 
     // #5555 — prewarm the device ID off the critical path. The `auth` frame in
@@ -986,13 +987,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // give-up decision tree now lives in the shared `runConnectAttempt`. The app
     // supplies the EFFECTS as callbacks (phase store writes, the Alert give-up,
     // the recursion entry point); the algorithm (which branch, when to retry,
-    // what delay) is shared with the dashboard. `MAX_RETRIES`/`RETRY_DELAYS`
-    // above are kept for the inline log strings and stay equal to the shared
-    // CONNECT_MAX_RETRIES / CONNECT_RETRY_DELAYS defaults.
+    // what delay) is shared with the dashboard. #5621 — consume the shared
+    // CONNECT_MAX_RETRIES / CONNECT_RETRY_DELAYS defaults directly instead of
+    // re-declaring the ladder verbatim here.
     void runConnectAttempt({
       attempt: _retryCount,
-      maxRetries: MAX_RETRIES,
-      retryDelays: RETRY_DELAYS,
+      maxRetries: CONNECT_MAX_RETRIES,
+      retryDelays: CONNECT_RETRY_DELAYS,
       // #5597/#5537 seam — re-resolve the endpoint per attempt instead of
       // dialing the closure-captured URL forever:
       //   • #5597: a tunnel rotation that landed mid-ladder (live
@@ -1049,7 +1050,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           restartingSince: currentState.restartingSince || Date.now(),
         });
         useConnectionLifecycleStore.getState().setConnectionPhase('server_restarting');
-        console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${MAX_RETRIES + 1})`);
+        console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${CONNECT_MAX_RETRIES + 1})`);
       },
       onProbeFailed: (reason) => {
         useConnectionLifecycleStore.getState().setConnectionError(reason, _retryCount);
@@ -1112,7 +1113,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // can still arm its own retry timer. The flag is bounded to this socket's
     // lifetime; first-write-wins on the reconnecting phase.
     //
-    // #5555.5 — the close/error path climbs the same RETRY_DELAYS ladder used by
+    // #5555.5 — the close/error path climbs the same CONNECT_RETRY_DELAYS ladder used by
     // the pre-WS health-check retries (1s → 2s → 3s → 5s → 8s, capped) instead
     // of a fixed 1.5s/2s. The ladder counter is module-level and only resets on
     // `auth_ok`, so a socket that opens but never authenticates keeps backing
@@ -1134,7 +1135,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // tunnel fast-fallback (keyed on the per-attempt index).
       reconnect: () => get().connect(resolveCurrentEndpointUrl(url, token), token),
       isStale: () => myAttemptId !== connectionAttemptId,
-      retryDelays: RETRY_DELAYS,
+      retryDelays: CONNECT_RETRY_DELAYS,
     });
     const scheduleReconnect = (): void => { reconnectScheduler.schedule(); };
 
@@ -1272,7 +1273,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         }
         // #3624 — dedup via the per-socket guard so a paired error → close
         // sequence arms exactly one retry. #5555.5 — delay comes from the
-        // RETRY_DELAYS ladder, not a fixed constant.
+        // CONNECT_RETRY_DELAYS ladder, not a fixed constant.
         scheduleReconnect();
       } else {
         // Connection dropped before it ever reached "connected" state. Previously

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -156,6 +156,9 @@ import {
   runConnectAttempt,
   createReconnectScheduler,
   RECONNECT_MAX_RUNG,
+  // #5621 — the shared retry-ladder defaults (was duplicated verbatim here).
+  CONNECT_MAX_RETRIES,
+  CONNECT_RETRY_DELAYS,
   type ProbeResult,
   type ConnectEndpoint,
 } from '@chroxy/store-core';
@@ -320,8 +323,8 @@ const EMPTY_TRANSCRIPT_BACKGROUND_TASKS: never[] = [];
 const EMPTY_INTERVENTIONS: never[] = [];
 
 // #5555.5 — the close/error-path reconnect delay is no longer a fixed
-// constant. Both handlers now climb the RETRY_DELAYS ladder (defined in
-// connect()) via the module-level reconnectAttempt counter, which resets on
+// constant. Both handlers now climb the shared CONNECT_RETRY_DELAYS ladder
+// (from @chroxy/store-core) via the module-level reconnectAttempt counter, which resets on
 // `auth_ok`. See scheduleReconnect() below.
 
 /**
@@ -1285,7 +1288,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ savedConnection: null });
   },
 
-  // Initial connection uses bounded retries (MAX_RETRIES) with exponential backoff.
+  // Initial connection uses bounded retries (CONNECT_MAX_RETRIES) with exponential backoff.
   // This prevents infinite loops on bad credentials or missing servers.
   // Auto-reconnect (socket.onclose) calls connect() with _retryCount=0, resetting
   // the retry budget — intentional, since established connections should recover
@@ -1302,8 +1305,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const pairingId = _retryCount === 0
       ? (() => { const id = pendingPairingId; pendingPairingId = null; return id; })()
       : (options?._pairingId ?? null);
-    const MAX_RETRIES = 5;
-    const RETRY_DELAYS = [1000, 2000, 3000, 5000, 8000];
 
     // Detect if connecting to a different server — clear old session data + queue
     const currentUrl = get().wsUrl;
@@ -1335,7 +1336,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ socket: null, connectionPhase: phase, connectionRetryCount: _retryCount, userDisconnected: false, ...errorPatch });
 
     if (_retryCount > 0) {
-      console.log(`[ws] Connection attempt ${_retryCount + 1}/${MAX_RETRIES + 1}...`);
+      console.log(`[ws] Connection attempt ${_retryCount + 1}/${CONNECT_MAX_RETRIES + 1}...`);
     }
 
     // #5597 — re-resolve the live endpoint (URL + token) for the active registry
@@ -1358,12 +1359,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // dashboard supplies the EFFECTS as callbacks (single-store `set()` writes,
     // the console give-up + clearSavedConnection, the `_pairingId`-threaded
     // recursion); the algorithm (which branch, when to retry, what delay) is
-    // shared with the app. `MAX_RETRIES`/`RETRY_DELAYS` above are kept for the
-    // inline log strings and stay equal to the shared defaults.
+    // shared with the app. #5621 — consume the shared CONNECT_MAX_RETRIES /
+    // CONNECT_RETRY_DELAYS defaults directly instead of re-declaring the ladder.
     void runConnectAttempt({
       attempt: _retryCount,
-      maxRetries: MAX_RETRIES,
-      retryDelays: RETRY_DELAYS,
+      maxRetries: CONNECT_MAX_RETRIES,
+      retryDelays: CONNECT_RETRY_DELAYS,
       // #5597 seam — re-resolve the endpoint per attempt instead of dialing the
       // closure-captured URL/token forever. The dashboard already re-read the
       // registry TOKEN per reconnect (#5281); this mirrors that for the URL, so
@@ -1416,7 +1417,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           restartEtaMs,
           restartingSince: currentState.restartingSince || Date.now(),
         });
-        console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${MAX_RETRIES + 1})`);
+        console.log(`[ws] Server is restarting, will retry (attempt ${_retryCount + 1}/${CONNECT_MAX_RETRIES + 1})`);
       },
       onProbeFailed: (reason) => {
         set({ connectionError: reason });
@@ -1489,7 +1490,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         get().connect(next.url, next.token);
       },
       isStale: () => myAttemptId !== connectionAttemptId,
-      retryDelays: RETRY_DELAYS,
+      retryDelays: CONNECT_RETRY_DELAYS,
       // #5698 — stop the reconnect ladder after RECONNECT_MAX_RUNG rungs and go
       // terminal instead of spinning forever. A user-initiated retryConnection()
       // resets the counter (resetReconnectAttempt), so this is not permanent.
@@ -1513,7 +1514,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (reconnectScheduler.scheduled) return;
       if (get().userDisconnected) return;
       if (disconnectedAttemptId === myAttemptId) return;
-      // #5555.5 — climb the RETRY_DELAYS ladder (was a fixed 1.5s/2s). The
+      // #5555.5 — climb the CONNECT_RETRY_DELAYS ladder (was a fixed 1.5s/2s). The
       // per-socket dedupe means a paired error → close drop advances the ladder
       // exactly once. The ladder resets on `auth_ok`, so a clean reconnect
       // starts back at the bottom (1s).

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1288,7 +1288,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ savedConnection: null });
   },
 
-  // Initial connection uses bounded retries (CONNECT_MAX_RETRIES) with exponential backoff.
+  // Initial connection uses bounded retries (CONNECT_MAX_RETRIES) climbing the
+  // fixed CONNECT_RETRY_DELAYS ladder ([1000,2000,3000,5000,8000]ms).
   // This prevents infinite loops on bad credentials or missing servers.
   // Auto-reconnect (socket.onclose) calls connect() with _retryCount=0, resetting
   // the retry budget — intentional, since established connections should recover


### PR DESCRIPTION
## Problem

`MAX_RETRIES = 5` and `RETRY_DELAYS = [1000, 2000, 3000, 5000, 8000]` were still hand-declared verbatim inside `connect()` in **both** `packages/app/src/store/connection.ts` and `packages/dashboard/src/store/connection.ts`, even though `connect-flow.ts` (#5598) already exports `CONNECT_MAX_RETRIES` / `CONNECT_RETRY_DELAYS` as the defaults that `runConnectAttempt` / `createReconnectScheduler` use. Three copies of the same ladder = drift risk.

## Fix

Drop the local consts in both clients and consume the shared `@chroxy/store-core` exports directly at every use site (the `runConnectAttempt` call, the close/error-path `createReconnectScheduler` call, and the inline progress-log strings), plus updated the comments that named the now-deleted locals. Tail of epic #5556 (the swarm-audit Minimalist finding, LOW).

**No behavior change** — the shared values are byte-identical to the removed locals (`5` / `[1000, 2000, 3000, 5000, 8000]`); this only removes the duplication.

## Verification

- app `tsc` + dashboard `tsc` clean; no bare `MAX_RETRIES`/`RETRY_DELAYS` references remain (only `CONNECT_*`).
- app connection suite 244/244 (10 suites, incl. `connection-reconnect-backoff`), dashboard connection suite 23/23 (4 files).

Closes #5621