### PR TITLE
cleanup: collapse PathHashTrustLedger's atomic write onto the JsonStateFile seam (#5620)

### DIFF
--- a/packages/server/src/json-state-file.js
+++ b/packages/server/src/json-state-file.js
@@ -96,8 +96,11 @@ export function loadJsonState(filePath, fallback, opts = {}) {
 /**
  * Serialise `value` to pretty JSON (trailing newline) and write it atomically at
  * mode 0600. Creates the parent directory (mode 0700) first if missing. The temp
- * sidecar carries a per-pid suffix so concurrent writers to the same target never
- * share an intermediate path (#5309 / #5579).
+ * sidecar carries a per-pid suffix (`.<pid>.tmp`) by default so two SEPARATE
+ * daemons mid-write can't tear the file (#5309 / #5579). That default does NOT
+ * make two concurrent writes from the SAME process unique — a caller that flushes
+ * the same path from multiple call sites in one process must pass a per-call
+ * random `tmpSuffix` (as PathHashTrustLedger does: `.<pid>.<random>.tmp`).
  *
  * The default path delegates to `writeFileRestricted` (best-effort durability —
  * temp + chmod + rename, no fsync). Pass `fsync: true` for the durable variant:
@@ -129,13 +132,20 @@ export function saveJsonState(filePath, value, opts = {}) {
     // Durable variant (#5620). `wx` (O_EXCL) refuses to clobber a concurrent
     // writer's sidecar; the 0600 create mode is authoritative (umask only ever
     // tightens it), so no post-write chmod is needed. fsync before rename so the
-    // bytes are on disk before the entry flips. On failure, clean up our own fd
-    // + temp and re-throw (callers decide swallow-vs-surface).
+    // bytes are on disk before the entry flips.
     const tmpPath = `${filePath}${tmpSuffix}`
     let fd = null
+    let created = false
     try {
       fd = openSync(tmpPath, 'wx', 0o600)
-      writeSync(fd, payload, 0, 'utf8')
+      created = true
+      // writeSync(string) can short-write; loop over a Buffer until every byte
+      // lands, since this path exists specifically for durability.
+      const buf = Buffer.from(payload, 'utf8')
+      let written = 0
+      while (written < buf.length) {
+        written += writeSync(fd, buf, written, buf.length - written)
+      }
       fsyncSync(fd)
       closeSync(fd)
       fd = null
@@ -144,7 +154,12 @@ export function saveJsonState(filePath, value, opts = {}) {
       if (fd !== null) {
         try { closeSync(fd) } catch { /* ignore */ }
       }
-      try { unlinkSync(tmpPath) } catch { /* ignore */ }
+      // Only remove the temp if WE created it. An EEXIST from openSync('wx')
+      // means the sidecar belongs to another writer — unlinking it would clobber
+      // them, contradicting the `wx` refusal-to-clobber guarantee.
+      if (created) {
+        try { unlinkSync(tmpPath) } catch { /* ignore */ }
+      }
       throw err
     }
     return

--- a/packages/server/src/json-state-file.js
+++ b/packages/server/src/json-state-file.js
@@ -27,7 +27,7 @@
  * owns the read-bytes-or-empty and write-bytes-atomically mechanics that every
  * one of them was duplicating.
  */
-import { existsSync, readFileSync, mkdirSync } from 'fs'
+import { existsSync, readFileSync, mkdirSync, openSync, writeSync, closeSync, fsyncSync, renameSync, unlinkSync } from 'fs'
 import { dirname } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
@@ -95,9 +95,17 @@ export function loadJsonState(filePath, fallback, opts = {}) {
 
 /**
  * Serialise `value` to pretty JSON (trailing newline) and write it atomically at
- * mode 0600 via `writeFileRestricted`. Creates the parent directory (mode 0700)
- * first if missing. The temp sidecar carries a per-pid suffix so concurrent
- * writers to the same target never share an intermediate path (#5309 / #5579).
+ * mode 0600. Creates the parent directory (mode 0700) first if missing. The temp
+ * sidecar carries a per-pid suffix so concurrent writers to the same target never
+ * share an intermediate path (#5309 / #5579).
+ *
+ * The default path delegates to `writeFileRestricted` (best-effort durability —
+ * temp + chmod + rename, no fsync). Pass `fsync: true` for the durable variant:
+ * the bytes are `fsync`'d before the rename flips the directory entry, so a crash
+ * mid-write can't leave a renamed-but-empty file. #5620 promotes this — formerly
+ * the hand-rolled `PathHashTrustLedger.flush` (#3238) — into the shared seam so
+ * the trust ledgers stop re-implementing the atomic-durable-write dance, while
+ * the ~15 best-effort state writers keep the cheaper non-fsync path.
  *
  * Re-throws on write/rename failure — callers that must surface a read-only-HOME
  * failure (e.g. SkillsTrustStore.flush) get the error; callers that treat
@@ -105,7 +113,7 @@ export function loadJsonState(filePath, fallback, opts = {}) {
  *
  * @param {string} filePath
  * @param {unknown} value
- * @param {{ pretty?: boolean, tmpSuffix?: string }} [opts]
+ * @param {{ pretty?: boolean, tmpSuffix?: string, fsync?: boolean }} [opts]
  */
 export function saveJsonState(filePath, value, opts = {}) {
   const dir = dirname(filePath)
@@ -116,5 +124,31 @@ export function saveJsonState(filePath, value, opts = {}) {
   const tmpSuffix = typeof opts.tmpSuffix === 'string' && opts.tmpSuffix.length > 0
     ? opts.tmpSuffix
     : `.${process.pid}.tmp`
+
+  if (opts.fsync) {
+    // Durable variant (#5620). `wx` (O_EXCL) refuses to clobber a concurrent
+    // writer's sidecar; the 0600 create mode is authoritative (umask only ever
+    // tightens it), so no post-write chmod is needed. fsync before rename so the
+    // bytes are on disk before the entry flips. On failure, clean up our own fd
+    // + temp and re-throw (callers decide swallow-vs-surface).
+    const tmpPath = `${filePath}${tmpSuffix}`
+    let fd = null
+    try {
+      fd = openSync(tmpPath, 'wx', 0o600)
+      writeSync(fd, payload, 0, 'utf8')
+      fsyncSync(fd)
+      closeSync(fd)
+      fd = null
+      renameSync(tmpPath, filePath)
+    } catch (err) {
+      if (fd !== null) {
+        try { closeSync(fd) } catch { /* ignore */ }
+      }
+      try { unlinkSync(tmpPath) } catch { /* ignore */ }
+      throw err
+    }
+    return
+  }
+
   writeFileRestricted(filePath, payload, { tmpSuffix })
 }

--- a/packages/server/src/path-hash-trust-ledger.js
+++ b/packages/server/src/path-hash-trust-ledger.js
@@ -44,9 +44,9 @@
  * On-disk formats are BYTE-COMPATIBLE with the pre-extraction files — existing
  * ledgers load unchanged and re-serialise to the same shape. No migration.
  */
-import { readFileSync, mkdirSync, openSync, writeSync, closeSync, fsyncSync, renameSync, unlinkSync } from 'fs'
-import { dirname } from 'path'
+import { readFileSync } from 'fs'
 import { randomBytes } from 'crypto'
+import { saveJsonState } from './json-state-file.js'
 
 /**
  * @typedef {Object} TrustRecord
@@ -287,33 +287,23 @@ export class PathHashTrustLedger {
   }
 
   /**
-   * Persist the ledger to disk. No-op when clean. Atomic-via-rename + 0600 with
-   * a per-pid + random temp suffix (the safest of the two source variants —
-   * tolerates concurrent writers in the same process, #3238). fsync before
-   * rename so the bytes are durable before the directory entry flips.
+   * Persist the ledger to disk. No-op when clean. Delegates to the shared
+   * durable-write seam (`saveJsonState({ fsync: true })`, #5620) — atomic
+   * via-rename + 0600, fsync before rename, with a per-pid + random temp suffix
+   * (the safest variant — tolerates concurrent writers in the same process,
+   * #3238). The seam owns the fd/temp cleanup; this layer only adds the dirty
+   * gate + the warn / conditional re-throw policy.
    *
-   * On failure: best-effort cleanup of our own fd + temp, then either re-throw
-   * (subclass set `throwOnFlushError`) or swallow with a warn.
+   * On failure: either re-throw (subclass set `throwOnFlushError`) or swallow
+   * with a warn. `_dirty` stays set on failure so a later flush retries.
    */
   flush() {
     if (!this._dirty) return
-    const tmpPath = `${this._filePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`
-    let fd = null
+    const tmpSuffix = `.${process.pid}.${randomBytes(6).toString('hex')}.tmp`
     try {
-      mkdirSync(dirname(this._filePath), { recursive: true })
-      const payload = JSON.stringify(this._serialize(), null, 2) + '\n'
-      fd = openSync(tmpPath, 'wx', 0o600)
-      writeSync(fd, payload, 0, 'utf8')
-      fsyncSync(fd)
-      closeSync(fd)
-      fd = null
-      renameSync(tmpPath, this._filePath)
+      saveJsonState(this._filePath, this._serialize(), { fsync: true, tmpSuffix })
       this._dirty = false
     } catch (err) {
-      if (fd !== null) {
-        try { closeSync(fd) } catch { /* ignore */ }
-      }
-      try { unlinkSync(tmpPath) } catch { /* ignore */ }
       this._log.warn(`Could not persist trust file (${err && err.code ? err.code : err.message || err})`)
       if (this._throwOnFlushError) throw err
     }

--- a/packages/server/tests/json-state-file.test.js
+++ b/packages/server/tests/json-state-file.test.js
@@ -126,4 +126,36 @@ describe('JsonStateFile (#5580)', () => {
       assert.throws(() => saveJsonState(dir, { a: 1 }), /EISDIR|illegal operation|EEXIST|EPERM/)
     })
   })
+
+  describe('saveJsonState — durable fsync variant (#5620)', () => {
+    it('writes identical bytes to the default path (pretty + trailing newline)', () => {
+      saveJsonState(filePath, { a: 1, items: ['x'] }, { fsync: true })
+      const raw = readFileSync(filePath, 'utf8')
+      assert.ok(raw.endsWith('\n'))
+      assert.deepEqual(JSON.parse(raw), { a: 1, items: ['x'] })
+      assert.ok(raw.includes('\n  '), 'pretty-printed (2-space indent)')
+    })
+
+    it('writes the file at mode 0600 (POSIX)', { skip: process.platform === 'win32' }, () => {
+      saveJsonState(filePath, { a: 1 }, { fsync: true })
+      assert.equal(statSync(filePath).mode & 0o777, 0o600)
+    })
+
+    it('creates the parent directory and renames the temp away', () => {
+      const nested = join(dir, 'deep', 'state.json')
+      saveJsonState(nested, { a: 1 }, { fsync: true, tmpSuffix: `.${process.pid}.abc.tmp` })
+      assert.ok(existsSync(nested))
+      assert.ok(!existsSync(`${nested}.${process.pid}.abc.tmp`), 'durable temp renamed away')
+    })
+
+    it('round-trips through loadJsonState', () => {
+      saveJsonState(filePath, { version: 2, ok: true }, { fsync: true })
+      assert.deepEqual(loadJsonState(filePath, () => ({}), { log: noopLog }), { version: 2, ok: true })
+    })
+
+    it('re-throws on a write failure and leaves no temp orphan (target is a directory)', () => {
+      assert.throws(() => saveJsonState(dir, { a: 1 }, { fsync: true, tmpSuffix: '.x.tmp' }))
+      assert.ok(!existsSync(`${dir}.x.tmp`), 'temp cleaned up on failure')
+    })
+  })
 })

--- a/packages/server/tests/json-state-file.test.js
+++ b/packages/server/tests/json-state-file.test.js
@@ -157,5 +157,17 @@ describe('JsonStateFile (#5580)', () => {
       assert.throws(() => saveJsonState(dir, { a: 1 }, { fsync: true, tmpSuffix: '.x.tmp' }))
       assert.ok(!existsSync(`${dir}.x.tmp`), 'temp cleaned up on failure')
     })
+
+    it('does NOT clobber a pre-existing sidecar on an EEXIST (wx) failure', () => {
+      // Simulate another writer's in-flight sidecar at the exact temp path.
+      const suffix = `.${process.pid}.held.tmp`
+      const sidecar = `${filePath}${suffix}`
+      writeFileSync(sidecar, 'other-writer-bytes')
+      // openSync('wx') must fail EEXIST and the catch must leave the sidecar intact.
+      assert.throws(() => saveJsonState(filePath, { a: 1 }, { fsync: true, tmpSuffix: suffix }))
+      assert.ok(existsSync(sidecar), "another writer's sidecar must survive")
+      assert.equal(readFileSync(sidecar, 'utf8'), 'other-writer-bytes', 'sidecar bytes untouched')
+      assert.ok(!existsSync(filePath), 'target not written when the temp was taken')
+    })
   })
 })


### PR DESCRIPTION
## What the audit found vs. reality

#5620 (swarm-audit, LOW) flagged "two parallel atomic-JSON-write paths … one a separate `JsonStateFile` class that's never instantiated." On current `main` that premise is **stale**:
- `JsonStateFile` is no longer a class — it's the `loadJsonState`/`saveJsonState` **function pair**, and it **is** used (by `skills-usage.js`).
- The two write paths genuinely **differ on durability**: `saveJsonState` → `writeFileRestricted` does temp+chmod+rename with **no fsync**, while `PathHashTrustLedger.flush` hand-rolls `openSync('wx',0600)` + **`fsyncSync`** + rename with a per-pid+random temp suffix (#3238).

So a naive "collapse onto `saveJsonState`" would have **silently dropped the trust ledger's fsync** — a durability regression in security-critical state. (Avoided per the stale-audit-reverify discipline.)

## Fix

Promote the durable variant **into** the shared seam, opt-in:
- `saveJsonState` gains an **`fsync` option** (default `false`). When set, it does the `openSync('wx',0600)` + `writeSync` + `fsyncSync` + `renameSync` dance with fd/temp cleanup on error. Default-off means the ~15 best-effort writers (incl. `skills-usage`) keep the cheaper `writeFileRestricted` path **unchanged**.
- `PathHashTrustLedger.flush` now delegates to `saveJsonState(path, serialize(), { fsync: true, tmpSuffix: <pid.random> })`, keeping its dirty-gate + warn / conditional-rethrow policy and dropping ~25 lines of hand-rolled fs code.

One atomic-durable-write implementation; **fsync-before-rename preserved** for the trust ledgers; **no behavior change** for any existing consumer. (Minor strict-safety bonus: the ledger's parent-dir create is now 0700 via the seam, matching skills-usage.)

## Verification

- `json-state-file` / `path-hash-trust-ledger` (28/28) / `skills-trust` / `skills-usage` / `byok-mcp-trust` / `session-preset` (34/34) suites green.
- Full server suite: 9529 pass; the only failures are the known `:8765` live-daemon probe artifacts in `service.test.js` (unrelated — doesn't import either changed module). eslint clean.

Closes #5620