### PR TITLE
refactor(store-core): migrate session_context onto the shared dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -94,7 +94,6 @@ import {
   cumulativeUsageEquals as sharedCumulativeUsageEquals,
   chunkSubscribeSessionIds as sharedChunkSubscribeSessionIds,
   SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
-  handleSessionContext as sharedSessionContext,
   handleSessionTimeout as sharedSessionTimeout,
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
@@ -2031,13 +2030,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_context': {
-      const { sessionId: ctxSessionId, patch } = sharedSessionContext(msg, get().activeSessionId);
-      if (ctxSessionId && get().sessionStates[ctxSessionId]) {
-        updateSession(ctxSessionId, () => patch);
-      }
-      break;
-    }
+    // session_context — migrated to the shared store-core dispatch table (#5618)
 
     case 'session_switched': {
       const switched = sharedSessionSwitched(msg);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -86,7 +86,6 @@ import {
   handleFileContent as sharedFileContent,
   buildSessionListPatches as sharedBuildSessionListPatches,
   cumulativeUsageEquals as sharedCumulativeUsageEquals,
-  handleSessionContext as sharedSessionContext,
   handleSessionTimeout as sharedSessionTimeout,
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
@@ -3249,13 +3248,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_context': {
-      const { sessionId: ctxSessionId, patch } = sharedSessionContext(msg, get().activeSessionId);
-      if (ctxSessionId && get().sessionStates[ctxSessionId]) {
-        updateSession(ctxSessionId, () => patch);
-      }
-      break;
-    }
+    // session_context — migrated to the shared store-core dispatch table (#5618)
 
     case 'monthly_budget': {
       // #5665 — machine-wide monthly programmatic-credit meter snapshot/event.

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -432,6 +432,37 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     },
   },
 
+  // 15b. session_context — merge the per-session git/project context (#5618)
+  {
+    name: 'session_context merges the git/project context into the target session',
+    type: 'session_context',
+    init: { sessions: { s1: {} } },
+    message: {
+      type: 'session_context',
+      sessionId: 's1',
+      gitBranch: 'main',
+      gitDirty: 3,
+      gitAhead: 1,
+      projectName: 'chroxy',
+    },
+    expect: {
+      sessions: {
+        s1: { sessionContext: { gitBranch: 'main', gitDirty: 3, gitAhead: 1, projectName: 'chroxy' } },
+      },
+    },
+  },
+  {
+    name: 'session_context coerces missing/typed fields to null/0 defaults',
+    type: 'session_context',
+    init: { sessions: { s1: {} } },
+    message: { type: 'session_context', sessionId: 's1' },
+    expect: {
+      sessions: {
+        s1: { sessionContext: { gitBranch: null, gitDirty: 0, gitAhead: 0, projectName: null } },
+      },
+    },
+  },
+
   // 16. session_cost_threshold_crossed — one-shot cost banner (no active fallback)
   {
     name: 'session_cost_threshold_crossed stores the one-shot cost-warning banner',

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -73,6 +73,7 @@ import {
   handleInactivityWarning,
   handleMcpServers,
   handleSessionUsage,
+  handleSessionContext,
   handleSessionCostThresholdCrossed,
   handleDevPreview,
   handleDevPreviewStopped,
@@ -325,6 +326,14 @@ export interface DispatchMessageMap {
     type: 'session_usage'
     sessionId?: string
     cumulativeUsage?: Record<string, unknown>
+  }
+  session_context: {
+    type: 'session_context'
+    sessionId?: string
+    gitBranch?: unknown
+    gitDirty?: unknown
+    gitAhead?: unknown
+    projectName?: unknown
   }
   session_cost_threshold_crossed: {
     type: 'session_cost_threshold_crossed'
@@ -671,6 +680,20 @@ function dispatchSessionUsage<S extends DispatchSessionBase>(
   }
 }
 
+/** `session_context` — merge the per-session git/project context patch. */
+function dispatchSessionContext<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_context'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId, patch } = handleSessionContext(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => patch as Partial<S>)
+  }
+}
+
 /** `session_cost_threshold_crossed` — store the one-shot cost-warning banner. */
 function dispatchSessionCostThresholdCrossed<S extends DispatchSessionBase>(
   msg: DispatchMessageMap['session_cost_threshold_crossed'],
@@ -945,6 +968,7 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     inactivity_warning: dispatchInactivityWarning,
     mcp_servers: dispatchMcpServers,
     session_usage: dispatchSessionUsage,
+    session_context: dispatchSessionContext,
     session_cost_threshold_crossed: dispatchSessionCostThresholdCrossed,
     dev_preview: dispatchDevPreview,
     dev_preview_stopped: dispatchDevPreviewStopped,
@@ -987,6 +1011,7 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'inactivity_warning',
   'mcp_servers',
   'session_usage',
+  'session_context',
   'session_cost_threshold_crossed',
   'dev_preview',
   'dev_preview_stopped',


### PR DESCRIPTION
## What

`session_context` was **byte-identical** in both client message-handlers — both call the existing store-core `handleSessionContext(msg, activeSessionId)` and apply the patch gated on `sessionStates[id]`. Migrate it onto the shared dispatch table (`dispatchSessionContext`, mirroring `dispatchSessionUsage`) and delete the inline `case` + the now-orphaned `sharedSessionContext` import from both `app` and `dashboard`. One more wire type is now drift-protected.

## Survey finding (re-scoping #5618)

I surveyed every type still handled locally in **both** clients. With `session_context` migrated, **the byte-identical migration well is effectively dry.** The remaining duplication is *intentional per-platform divergence*, not lazy copy-paste:
- the app's auxiliary Zustand sub-stores (`useConversationStore`, `useCostStore`, `useNotificationStore`, `useMultiClientStore`) that the dashboard doesn't have;
- the dashboard's flat-state fallback + `localStorage`/registry persistence adapters (vs the app's SecureStore);
- platform notification APIs (RN `Alert` vs `_adapters.alert`).

Verified-divergent examples (do **not** lift): `cost_update`, `slash_commands`, `agent_list`, `provider_list`, `checkpoint_*`, `session_warning/timeout`, `session_*_failed`, `auth_bootstrap`, `tunnel_url_changed`, `search_results`, `session_role`/`client_focus_changed` (multi-client store). **Further shrinking the handlers requires reconciliation decisions** (e.g. whether the app's auxiliary-store mirrors can move behind the adapter) — a design call, not a mechanical batch. Recommend #5618 be re-scoped to that, or closed. (Posting this on the issue too.)

## Tests

- store-core: 2 contract fixtures (populated + coerced-`null`/`0` defaults) driven through **both** clients' real dispatch tables; full store-core suite **1511/1511**.
- `handler-coverage` passes (the type is now covered for both clients via `runDispatch`).
- app + dashboard `tsc` clean (confirms the removed imports were unused).

Part of #5618.