### PR TITLE
refactor(server): make claude-tui FormDriver an injected collaborator (#5617)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -41,7 +41,7 @@ import {
 } from './claude-tui/pty-driver.js'
 import {
   ASK_USER_QUESTION_WATCHDOG_MS,
-  FormDriverMixin,
+  FormDriver,
 } from './claude-tui/form-driver.js'
 
 // Re-export the public writeHookSettings helper so existing
@@ -380,6 +380,11 @@ export class ClaudeTuiSession extends BaseSession {
     // tests + callers that read the single field keep working.
     this._pendingUserAnswers = new Map()
     this._lastPendingAnswerToolUseId = null
+    // #5617 — the interactive-form driver is an injected collaborator rather than
+    // a prototype mixin; it reaches session state/PTY writers through `this` as
+    // its host. `respondToQuestion` (below) delegates to it; the stall watchdog
+    // calls `this._formDriver._onAskUserQuestionStall`.
+    this._formDriver = new FormDriver(this)
     // #4604 / #5319 (WP-3.2): per-toolUseId stall watchdogs armed in
     // respondToQuestion(). If PostToolUse never arrives after we write an answer
     // (multi-question form wedge), the matching watchdog fires
@@ -512,20 +517,30 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
+   * #5617 — delegate the AskUserQuestion answer to the injected FormDriver.
+   * Kept on the session because external callers (input-handlers.js) and the
+   * provider contract call `session.respondToQuestion(...)`; the driving logic
+   * lives in form-driver.js, reaching session state/PTY writers via its host.
+   */
+  respondToQuestion(text, answersMap, toolUseId, opts) {
+    return this._formDriver.respondToQuestion(text, answersMap, toolUseId, opts)
+  }
+
+  /**
    * #5319 (WP-3.2): arm (or re-arm) the per-toolUseId AskUserQuestion stall
    * watchdog. Each toolUseId gets its own timer so a parallel sibling's arm
    * can't clobber this one. On fire it deletes its own Map entry, then calls
-   * _onAskUserQuestionStall. A null/undefined toolUseId is keyed verbatim
-   * (one anonymous slot) so the defensive no-toolUseId path keeps a watchdog.
-   * `ms` defaults to the standard window but the Other-freeform two-stage flow
-   * passes OTHER_FREEFORM_WATCHDOG_MS for its longer second stage.
+   * _formDriver._onAskUserQuestionStall. A null/undefined toolUseId is keyed
+   * verbatim (one anonymous slot) so the defensive no-toolUseId path keeps a
+   * watchdog. `ms` defaults to the standard window but the Other-freeform
+   * two-stage flow passes OTHER_FREEFORM_WATCHDOG_MS for its longer second stage.
    */
   _armAskUserQuestionWatchdog(toolUseId, ms = ASK_USER_QUESTION_WATCHDOG_MS) {
     const existing = this._askUserQuestionWatchdogs.get(toolUseId)
     if (existing) clearTimeout(existing)
     const t = setTimeout(() => {
       this._askUserQuestionWatchdogs.delete(toolUseId)
-      this._onAskUserQuestionStall(toolUseId)
+      this._formDriver._onAskUserQuestionStall(toolUseId)
     }, ms)
     this._askUserQuestionWatchdogs.set(toolUseId, t)
   }
@@ -3123,4 +3138,6 @@ function applyMixin(targetClass, mixinClass) {
 }
 
 applyMixin(ClaudeTuiSession, PtyDriverMixin)
-applyMixin(ClaudeTuiSession, FormDriverMixin)
+// #5617 — FormDriver is no longer mixed onto the prototype; it's an injected
+// collaborator constructed per-session (see the constructor) and reached via
+// the `respondToQuestion` delegator + `this._formDriver` for the stall callback.

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -1,15 +1,43 @@
 // claude-tui/form-driver.js — interactive AskUserQuestion form driver for ClaudeTuiSession.
 //
-// #5559 — pure-move extraction of the interactive-form driver out of
-// claude-tui-session.js. respondToQuestion assembles the empirically-pinned
-// keystroke sequences (project memory: tui_multi_question_form_keys,
-// multi_question_post_deny_wedge) — digit auto-advance, Tab between multi-
-// selects, the Submit-settle, the Other/freeform two-stage flow, arrow-nav for
-// 10+ option picks — and the stall watchdog teardown. Bodies are moved
-// BYTE-IDENTICAL; only the module location changed. The methods live on
-// `FormDriverMixin` and are copied onto ClaudeTuiSession.prototype via
-// applyMixin() in claude-tui-session.js, so `this` still refers to the session
-// instance and every `this._*` reference resolves as before.
+// respondToQuestion assembles the empirically-pinned keystroke sequences
+// (project memory: tui_multi_question_form_keys, multi_question_post_deny_wedge)
+// — digit auto-advance, Tab between multi-selects, the Submit-settle, the
+// Other/freeform two-stage flow, arrow-nav for 10+ option picks — and the stall
+// watchdog teardown.
+//
+// #5559 first moved these bodies out of claude-tui-session.js byte-identical,
+// but re-coupled them onto ClaudeTuiSession.prototype via applyMixin(), so they
+// still reached into 28 private session fields/methods through `this`.
+//
+// #5617 makes FormDriver an INJECTED COLLABORATOR: the session constructs it as
+// `this._formDriver = new FormDriver(this)` and delegates `respondToQuestion()`;
+// every former `this._field` is now `this._host._field` against the explicit
+// {@link FormDriverHost} surface below. The byte-sequence bodies are otherwise
+// UNCHANGED (the #5617 diff reverses to the #5559 source exactly — a pure
+// receiver swap). The point is testability: a unit test injects a mock host and
+// asserts the keystroke sequences against the pinned recordings WITHOUT a live
+// PTY (see tests/claude-tui-form-driver.test.js).
+//
+/**
+ * The slice of ClaudeTuiSession that FormDriver drives. The session satisfies
+ * this structurally (FormDriver receives `this`); tests pass a mock. Grouped:
+ *
+ *  - PTY writers: `_writePtyTextThrottled`, `_writePtyMultiQuestionSequence`,
+ *    `_writePtyArrowNavSequence` — emit the keystroke bytes.
+ *  - Pending-answer state: `_pendingUserAnswers` (Map), `_pendingUserAnswer`
+ *    (back-compat getter), `_clearPendingAnswerByToolUseId`.
+ *  - Turn/result state: `_activeTurn`, `_isBusy`, `_currentMessageId`,
+ *    `_destroying`, `_assertBusyHasMessageId`, `_emitResult`, `_trackToolResult`,
+ *    `_cleanupTurnAttachments`, `_outputTailHexDump`, `_sessionId`.
+ *  - Timers/watchdogs: `_armAskUserQuestionWatchdog`,
+ *    `_clearAskUserQuestionWatchdog`, `_clearAskUserQuestionLock`,
+ *    `_clearFirstOutputWatchdog`, `_streamStallTimeout`, `_resultTimeout`,
+ *    `_hardTimeout`, `_nowMonotonic`.
+ *  - Misc: `_term`, `_log`, `emit` (the session is an EventEmitter).
+ *
+ * @typedef {import('../claude-tui-session.js').ClaudeTuiSession} FormDriverHost
+ */
 import { createLogger } from '../logger.js'
 
 const log = createLogger('claude-tui-session')
@@ -83,8 +111,15 @@ const OTHER_FREEFORM_WATCHDOG_MS = 30 * 1000
 // not yet captured. Prior wedge analysis: #4635, #4867.
 export const MULTI_QUESTION_SUBMIT_SETTLE_MS = 150
 
-// --- interactive-form driver methods (mixed onto ClaudeTuiSession.prototype) ---
-export class FormDriverMixin {
+// --- interactive-form driver: an injected collaborator of ClaudeTuiSession (#5617) ---
+export class FormDriver {
+  /**
+   * @param {FormDriverHost} host — the owning ClaudeTuiSession (or a mock in tests).
+   */
+  constructor(host) {
+    this._host = host
+  }
+
   /**
    * Send a response to an AskUserQuestion prompt (#4278, multi-question
    * support added in #4604 Chunk B). The dashboard's QuestionPrompt UI
@@ -157,16 +192,16 @@ export class FormDriverMixin {
       ? opts.freeformText
       : null
     let entry = null
-    if (toolUseId && this._pendingUserAnswers.has(toolUseId)) {
-      entry = this._pendingUserAnswers.get(toolUseId)
-    } else if (toolUseId && this._pendingUserAnswers.size > 0) {
+    if (toolUseId && this._host._pendingUserAnswers.has(toolUseId)) {
+      entry = this._host._pendingUserAnswers.get(toolUseId)
+    } else if (toolUseId && this._host._pendingUserAnswers.size > 0) {
       // Dashboard sent a toolUseId we don't have a pending entry for.
       // Common cause: stale answer arriving after the turn's teardown
       // cleared the Map (watchdog fire, user gave up + the late answer
       // came in). Log + drop rather than write keystrokes into whatever
       // form happens to be currently rendered.
       // #4828: session-scoped — respondToQuestion runs strictly post-start.
-      ;(this._log || log).warn(`respondToQuestion: dashboard sent toolUseId=${toolUseId} but no matching pending entry (Map.size=${this._pendingUserAnswers.size} keys=${[...this._pendingUserAnswers.keys()].join(',')}) — dropping`)
+      ;(this._host._log || log).warn(`respondToQuestion: dashboard sent toolUseId=${toolUseId} but no matching pending entry (Map.size=${this._host._pendingUserAnswers.size} keys=${[...this._host._pendingUserAnswers.keys()].join(',')}) — dropping`)
       return
     } else {
       // Legacy / unidentified path: route to the most-recent entry via
@@ -178,30 +213,30 @@ export class FormDriverMixin {
       // multiple pending entries — the back-compat fallback picks the
       // most-recent entry by insertion order, which may not be what
       // the user intended. Loud log so the wedge symptom is greppable.
-      if (!toolUseId && this._pendingUserAnswers.size > 1) {
+      if (!toolUseId && this._host._pendingUserAnswers.size > 1) {
         // #4828: session-scoped.
-        ;(this._log || log).warn(`respondToQuestion: dashboard omitted toolUseId but ${this._pendingUserAnswers.size} pending entries exist (keys=${[...this._pendingUserAnswers.keys()].join(',')}) — falling back to most-recent which may misroute`)
+        ;(this._host._log || log).warn(`respondToQuestion: dashboard omitted toolUseId but ${this._host._pendingUserAnswers.size} pending entries exist (keys=${[...this._host._pendingUserAnswers.keys()].join(',')}) — falling back to most-recent which may misroute`)
       }
-      entry = this._pendingUserAnswer
+      entry = this._host._pendingUserAnswer
     }
     const prevToolUseId = entry?.toolUseId || null
     const pendingQuestions = entry?.questions || []
     const answersMapKeyCount = answersMap && typeof answersMap === 'object' ? Object.keys(answersMap).length : 0
     // #4828: session-scoped.
-    ;(this._log || log).info(`respondToQuestion: tool=${prevToolUseId || '?'} dashboardToolUseId=${toolUseId || 'none'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${entry?.options?.length || 0} pendingMapSize=${this._pendingUserAnswers.size}`)
+    ;(this._host._log || log).info(`respondToQuestion: tool=${prevToolUseId || '?'} dashboardToolUseId=${toolUseId || 'none'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${entry?.options?.length || 0} pendingMapSize=${this._host._pendingUserAnswers.size}`)
     if (!entry) return
     // #5320 (WP-3.3) — arm the stall watchdog the MOMENT we have a live pending
     // entry the dashboard tried to answer, BEFORE any early-return below. The
     // dashboard clears its QuestionPrompt UI when it sends an answer, so ANY
     // respondToQuestion that finds an entry but then bails — the unactionable
     // cases here (non-string / empty text + no answersMap), the validation drops
-    // in the freeform path (no options, option-not-found), or `!this._term` —
+    // in the freeform path (no options, option-not-found), or `!this._host._term` —
     // would otherwise leave the turn wedged until the 2h hard cap with no
     // dashboard prompt. Arming here (it does NOT clear the pending) gives every
     // such path recovery; a real follow-up answer re-arms idempotently (same
     // key), and the success paths re-arm with a fresh post-write window (the
     // Other-freeform IIFE with its longer second-stage window).
-    this._armAskUserQuestionWatchdog(prevToolUseId)
+    this._host._armAskUserQuestionWatchdog(prevToolUseId)
     // Single-question / free-text path requires a non-empty `text`. The
     // multi-question path is driven from answersMap (text is ignored when
     // a map is present) so an empty string is permitted there.
@@ -211,8 +246,8 @@ export class FormDriverMixin {
     const questions = pendingQuestions
     // #4668: clear only this specific entry; sibling pending answers
     // (from parallel AskUserQuestion calls in the same turn) survive.
-    this._clearPendingAnswerByToolUseId(entry.toolUseId)
-    if (!this._term) return
+    this._host._clearPendingAnswerByToolUseId(entry.toolUseId)
+    if (!this._host._term) return
     // #4668 diagnostic: capture the PTY output tail just before we write
     // the answer keystroke. The wedge symptom observed 2026-06-01 was
     // "chroxy wrote bytes=1 → TUI silent for 30s → watchdog fires" with
@@ -237,10 +272,10 @@ export class FormDriverMixin {
     // respondToQuestion. Routing them through the session-bound logger
     // makes the audit story clean: only operators bound to this session
     // (or unbound) see the dump (#4787 fan-out filter).
-    const slog = this._log || log
-    const turn = this._activeTurn
+    const slog = this._host._log || log
+    const turn = this._host._activeTurn
     if (turn && !turn.hexDumpEmitted) {
-      slog.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
+      slog.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._host._outputTailHexDump()}`)
       turn.hexDumpEmitted = true
     } else if (turn) {
       slog.info(`respondToQuestion PTY tail hex dump skipped (tool=${prevToolUseId || '?'}) — already emitted for turn msg=${turn.messageId || '?'}`)
@@ -248,7 +283,7 @@ export class FormDriverMixin {
       // No active turn (defensive — tests that drive respondToQuestion
       // directly without sendMessage(), late watchdog teardown races).
       // Emit the dump so the diagnostic is still useful in those paths.
-      slog.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
+      slog.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._host._outputTailHexDump()}`)
     }
 
     const armWatchdog = () => {
@@ -259,7 +294,7 @@ export class FormDriverMixin {
       // retry. Cancelled on PostToolUse (happy path) and on destroy().
       // #5319 (WP-3.2): keyed by this tool's id so a parallel sibling's arm
       // doesn't clobber it.
-      this._armAskUserQuestionWatchdog(prevToolUseId)
+      this._host._armAskUserQuestionWatchdog(prevToolUseId)
     }
 
     // Single-question / no-questions-array path (back-compat with the
@@ -285,13 +320,13 @@ export class FormDriverMixin {
       if (freeformText) {
         if (!Array.isArray(options) || options.length === 0) {
           // #4828: session-scoped.
-          ;(this._log || log).warn(`respondToQuestion: freeformText supplied for question with no options (tool=${prevToolUseId || '?'}) — dropping`)
+          ;(this._host._log || log).warn(`respondToQuestion: freeformText supplied for question with no options (tool=${prevToolUseId || '?'}) — dropping`)
           return
         }
         const otherIdx = options.findIndex((o) => o && o.label === text)
         if (otherIdx < 0 || otherIdx >= 9) {
           // #4828: session-scoped.
-          ;(this._log || log).warn(`respondToQuestion: freeformText supplied but chosen option "${text}" not found (or beyond single-digit hotkey range) in pending options for tool=${prevToolUseId || '?'} — dropping`)
+          ;(this._host._log || log).warn(`respondToQuestion: freeformText supplied but chosen option "${text}" not found (or beyond single-digit hotkey range) in pending options for tool=${prevToolUseId || '?'} — dropping`)
           return
         }
         const otherDigit = String(otherIdx + 1)
@@ -315,19 +350,19 @@ export class FormDriverMixin {
           //     a `_term` that destroy() set to null, throwing inside
           //     the inner write loop
           // Bail out at every await boundary instead.
-          const stage1ok = await this._writePtyTextThrottled(otherDigit).catch((err) => {
+          const stage1ok = await this._host._writePtyTextThrottled(otherDigit).catch((err) => {
             // #4828: session-scoped.
-            ;(this._log || log).warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
+            ;(this._host._log || log).warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
             return false
           })
           // #5320 (WP-3.3) — also bail if the turn was ABORTED (interrupt() sets
           // _activeTurn.aborted but does not flip _destroying). Without this the
           // IIFE would keep driving keystrokes into a turn the user already
           // interrupted, and re-arm a watchdog interrupt() just cleared.
-          if (this._destroying || this._activeTurn?.aborted) return
+          if (this._host._destroying || this._host._activeTurn?.aborted) return
           if (!stage1ok) return
           await new Promise((resolve) => setTimeout(resolve, OTHER_FREEFORM_SETTLE_MS))
-          if (this._destroying || this._activeTurn?.aborted) return
+          if (this._host._destroying || this._host._activeTurn?.aborted) return
           // Belt-and-braces: destroy() sets _destroying before nulling
           // _term in the same synchronous frame, so the guard above
           // already covers the destroy() race. This null-check is
@@ -336,15 +371,15 @@ export class FormDriverMixin {
           // skip the re-arm AND the stage-2 write together so the
           // watchdog never fires for a session that no longer has a
           // PTY behind it.
-          if (!this._term) return
+          if (!this._host._term) return
           // Re-arm the watchdog so the freeform write phase has a fresh
           // OTHER_FREEFORM_WATCHDOG_MS window — the stage-1 arm already
           // counted the settle delay against the original 30s budget.
           // #5319 (WP-3.2): keyed by this tool's id, longer second-stage window.
-          this._armAskUserQuestionWatchdog(prevToolUseId, OTHER_FREEFORM_WATCHDOG_MS)
-          await this._writePtyTextThrottled(freeformText).catch((err) => {
+          this._host._armAskUserQuestionWatchdog(prevToolUseId, OTHER_FREEFORM_WATCHDOG_MS)
+          await this._host._writePtyTextThrottled(freeformText).catch((err) => {
             // #4828: session-scoped.
-            ;(this._log || log).warn(`respondToQuestion Other-freeform PTY write failed: ${err.message} (tool=${tag})`)
+            ;(this._host._log || log).warn(`respondToQuestion Other-freeform PTY write failed: ${err.message} (tool=${tag})`)
           })
         })()
         armWatchdog()
@@ -399,9 +434,9 @@ export class FormDriverMixin {
         // path) so the Other / freeform back-compat case is preserved.
         if (matchIdx >= 9) {
           const total = options.length
-          ;(this._log || log).info(`AskUserQuestion single-question: question has ${total} options and the user picked option ${matchIdx + 1} ("${(text || '').slice(0, 40)}") — driving via arrow-key navigation (#4848) (tool=${prevToolUseId || '?'})`)
-          this._writePtyArrowNavSequence(matchIdx).catch((err) => {
-            ;(this._log || log).warn(`respondToQuestion arrow-nav PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+          ;(this._host._log || log).info(`AskUserQuestion single-question: question has ${total} options and the user picked option ${matchIdx + 1} ("${(text || '').slice(0, 40)}") — driving via arrow-key navigation (#4848) (tool=${prevToolUseId || '?'})`)
+          this._host._writePtyArrowNavSequence(matchIdx).catch((err) => {
+            ;(this._host._log || log).warn(`respondToQuestion arrow-nav PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
           })
           armWatchdog()
           return
@@ -413,9 +448,9 @@ export class FormDriverMixin {
       // Fire-and-forget — the write is async due to the per-char throttle,
       // but the caller (handleUserQuestionResponse) is sync. Errors here
       // are non-fatal; worst case the user re-sends the answer.
-      this._writePtyTextThrottled(writeText).catch((err) => {
+      this._host._writePtyTextThrottled(writeText).catch((err) => {
         // #4828: session-scoped.
-        ;(this._log || log).warn(`respondToQuestion PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+        ;(this._host._log || log).warn(`respondToQuestion PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
       })
       armWatchdog()
       return
@@ -429,7 +464,7 @@ export class FormDriverMixin {
     const haveMap = Object.keys(map).length > 0
     if (!haveMap) {
       // #4828: session-scoped.
-      ;(this._log || log).warn(`AskUserQuestion multi-question: dashboard didn't send answersMap (tool=${prevToolUseId || '?'}, questions=${questions.length}) — defaulting every question to option 1. Update the client to populate the per-question answers map.`)
+      ;(this._host._log || log).warn(`AskUserQuestion multi-question: dashboard didn't send answersMap (tool=${prevToolUseId || '?'}, questions=${questions.length}) — defaulting every question to option 1. Update the client to populate the per-question answers map.`)
     }
 
     // #4625 + #4848 — claude TUI's single-digit hotkey alphabet ('1'..'9')
@@ -489,7 +524,7 @@ export class FormDriverMixin {
       }
       if (unrepresentableMultiSelect.length > 0) {
         const first = unrepresentableMultiSelect[0]
-        ;(this._log || log).warn(`AskUserQuestion multi-question: multi-select question has ${first.total} options and the user toggled option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet AND beyond the arrow-nav single-select fallback (#4848 deliberately scopes arrow-nav to single-select only) — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS (tool=${prevToolUseId || '?'})`)
+        ;(this._host._log || log).warn(`AskUserQuestion multi-question: multi-select question has ${first.total} options and the user toggled option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet AND beyond the arrow-nav single-select fallback (#4848 deliberately scopes arrow-nav to single-select only) — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS (tool=${prevToolUseId || '?'})`)
         // Full AskUserQuestion teardown: synth tool_result + Ctrl-C the
         // TUI + clear inactivity timers + stream_end + _emitResult +
         // error (in that order). Without the full teardown the dashboard
@@ -561,7 +596,7 @@ export class FormDriverMixin {
         }
         if (digits.length === 0 && defaultDigit) {
           // #4828: session-scoped (closure runs inside respondToQuestion, post-start).
-          ;(this._log || log).warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (multi-select) — defaulting to option 1`)
+          ;(this._host._log || log).warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (multi-select) — defaulting to option 1`)
           digits.push(defaultDigit)
         }
         return digits
@@ -596,7 +631,7 @@ export class FormDriverMixin {
       }
       if (defaultDigit) {
         // #4828: session-scoped (closure runs inside respondToQuestion, post-start).
-        if (haveMap) (this._log || log).warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (single-select) — defaulting to option 1`)
+        if (haveMap) (this._host._log || log).warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (single-select) — defaulting to option 1`)
         return [defaultDigit]
       }
       return []
@@ -640,7 +675,7 @@ export class FormDriverMixin {
     // (JSON.stringify drops undefined-valued keys) but in-code shapes can.
     const lastQuestion = questions.length > 0 ? questions[questions.length - 1] : null
     if (lastQuestion && 'multiSelect' in lastQuestion && typeof lastQuestion.multiSelect !== 'boolean') {
-      ;(this._log || log).warn(`AskUserQuestion multi-question: last question has non-boolean multiSelect=${JSON.stringify(lastQuestion.multiSelect)} (q="${(lastQuestion.question || '').slice(0, 40)}") — assuming single-select for settle (#4883)`)
+      ;(this._host._log || log).warn(`AskUserQuestion multi-question: last question has non-boolean multiSelect=${JSON.stringify(lastQuestion.multiSelect)} (q="${(lastQuestion.question || '').slice(0, 40)}") — assuming single-select for settle (#4883)`)
     }
     const lastIsSingleSelect = !!(lastQuestion && lastQuestion.multiSelect !== true)
     if (lastIsSingleSelect) {
@@ -675,11 +710,11 @@ export class FormDriverMixin {
     sequence.push('\r')
 
     const keystrokeCount = sequence.filter((x) => typeof x === 'string').length
-    ;(this._log || log).info(`AskUserQuestion multi-question: tool=${prevToolUseId || '?'} questions=${questions.length} keystrokes=${keystrokeCount} haveAnswersMap=${haveMap}`)
+    ;(this._host._log || log).info(`AskUserQuestion multi-question: tool=${prevToolUseId || '?'} questions=${questions.length} keystrokes=${keystrokeCount} haveAnswersMap=${haveMap}`)
 
-    this._writePtyMultiQuestionSequence(sequence).catch((err) => {
+    this._host._writePtyMultiQuestionSequence(sequence).catch((err) => {
       // #4828: session-scoped.
-      ;(this._log || log).warn(`respondToQuestion multi-question PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+      ;(this._host._log || log).warn(`respondToQuestion multi-question PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
     })
     armWatchdog()
   }
@@ -723,12 +758,12 @@ export class FormDriverMixin {
    * in the normal flow before the watchdog timer fired).
    */
   _onAskUserQuestionStall(toolUseId) {
-    if (this._destroying) return
-    if (!this._pendingUserAnswer && !this._isBusy) return
+    if (this._host._destroying) return
+    if (!this._host._pendingUserAnswer && !this._host._isBusy) return
 
-    this._assertBusyHasMessageId('_onAskUserQuestionStall')
+    this._host._assertBusyHasMessageId('_onAskUserQuestionStall')
     // #4828: session-scoped — stall watchdog fires strictly post-start.
-    ;(this._log || log).warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Tearing down turn so the session is recoverable.`)
+    ;(this._host._log || log).warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Tearing down turn so the session is recoverable.`)
 
     this._teardownAskUserQuestion(toolUseId, {
       synthResult: 'AskUserQuestion stalled — no response from claude TUI within 30s. Likely a multi-question form (#4604).',
@@ -765,8 +800,8 @@ export class FormDriverMixin {
    * keep.
    */
   _teardownAskUserQuestion(toolUseId, { synthResult, emitResultReason, errorCode, errorMessage }) {
-    const messageId = this._currentMessageId
-    const duration = this._activeTurn ? this._nowMonotonic() - this._activeTurn.startedAt : 0
+    const messageId = this._host._currentMessageId
+    const duration = this._host._activeTurn ? this._host._nowMonotonic() - this._host._activeTurn.startedAt : 0
 
     // #4691: surgical clear — drop ONLY the entry for the tool that
     // timed out. The other teardown sites (_finishTurnError, hard
@@ -784,13 +819,13 @@ export class FormDriverMixin {
     // Map is empty — a late retry-as-singles answer with toolUseId B
     // would hit the "no matching pending entry — dropping" path and
     // wedge the next form silently).
-    this._clearPendingAnswerByToolUseId(toolUseId)
+    this._host._clearPendingAnswerByToolUseId(toolUseId)
     // #5319 (WP-3.2): cancel THIS tool's stall watchdog. The 30s-stall path
     // arrives here after its own watchdog already self-deleted, but the
     // too-many-options (#4625) path tears down WITHOUT a prior fire, so clear
     // it explicitly. Idempotent; leaves any sibling watchdog intact.
-    this._clearAskUserQuestionWatchdog(toolUseId)
-    this._clearAskUserQuestionLock()
+    this._host._clearAskUserQuestionWatchdog(toolUseId)
+    this._host._clearAskUserQuestionLock()
     // #4616: emit a synthetic tool_result FIRST so the dashboard's
     // activeTools entry for this AskUserQuestion is cleared. Without it
     // the footer "Running AskUserQuestion · Ns" pill keeps ticking
@@ -798,40 +833,40 @@ export class FormDriverMixin {
     // toast. The handler ignores any fields beyond {toolUseId, result,
     // truncated, images} (see store-core handleToolResult); pairing-by-
     // toolUseId is what drives the activeTools removal in store-core handlers.
-    this.emit('tool_result', {
+    this._host.emit('tool_result', {
       toolUseId,
       result: synthResult,
       truncated: false,
     })
     // #4628: matching tool_start resolved — drop from the in-flight map.
-    this._trackToolResult(toolUseId)
+    this._host._trackToolResult(toolUseId)
 
     // #4645: best-effort Ctrl-C so claude TUI itself unsticks from the
     // form screen. Without this the next sendMessage's prompt write
     // would queue behind the still-displayed form and silently desync.
     // Mirrors _handleStreamStall / _handleHardTimeout.
-    if (this._term) {
-      try { this._term.write('\x03') } catch { /* ignore */ }
+    if (this._host._term) {
+      try { this._host._term.write('\x03') } catch { /* ignore */ }
     }
 
     // Clear all four inactivity timers — turn is over, nothing to
     // backstop, leaving them armed would fire stale callbacks on a
     // session that's already idle.
-    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
-    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
-    if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }
+    if (this._host._resultTimeout) { clearTimeout(this._host._resultTimeout); this._host._resultTimeout = null }
+    if (this._host._hardTimeout) { clearTimeout(this._host._hardTimeout); this._host._hardTimeout = null }
+    if (this._host._streamStallTimeout) { clearTimeout(this._host._streamStallTimeout); this._host._streamStallTimeout = null }
     // #4732: pre-first-output watchdog. AskUserQuestion only fires
     // mid-turn (post-stream_start), so the first-output watchdog has
     // typically been disarmed already, but clear it explicitly so a
     // pathological race can't leak a live handle past the stall.
-    this._clearFirstOutputWatchdog()
+    this._host._clearFirstOutputWatchdog()
 
     // #4022: drop per-turn attachment dir (same as the other teardown
     // paths) so a failed turn doesn't leak materialized files until destroy().
-    this._cleanupTurnAttachments(this._activeTurn)
-    this._activeTurn = null
-    this._isBusy = false
-    this._currentMessageId = null
+    this._host._cleanupTurnAttachments(this._host._activeTurn)
+    this._host._activeTurn = null
+    this._host._isBusy = false
+    this._host._currentMessageId = null
 
     // #4645: pair the stream_start fired at turn-start with stream_end +
     // result so the dashboard's streamingMessageId + Working banner +
@@ -840,12 +875,12 @@ export class FormDriverMixin {
     // — silent skip is acceptable here because the only way messageId
     // is null is a contract violation (_isBusy=true without an active
     // turn), tracked in #4642.
-    if (messageId) this.emit('stream_end', { messageId })
-    this._emitResult(
-      { cost: null, duration, usage: null, sessionId: this._sessionId },
+    if (messageId) this._host.emit('stream_end', { messageId })
+    this._host._emitResult(
+      { cost: null, duration, usage: null, sessionId: this._host._sessionId },
       emitResultReason,
     )
-    this.emit('error', {
+    this._host.emit('error', {
       code: errorCode,
       message: errorMessage,
       toolUseId,

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -12,8 +12,9 @@
 //
 // #5617 makes FormDriver an INJECTED COLLABORATOR: the session constructs it as
 // `this._formDriver = new FormDriver(this)` and delegates `respondToQuestion()`;
-// every former `this._field` is now `this._host._field` against the explicit
-// {@link FormDriverHost} surface below. The byte-sequence bodies are otherwise
+// every former session access `this._<member>` is now `this._host._<member>`
+// against the explicit {@link FormDriverHost} surface below (the `_<member>`s are
+// enumerated there). The byte-sequence bodies are otherwise
 // UNCHANGED (the #5617 diff reverses to the #5559 source exactly — a pure
 // receiver swap). The point is testability: a unit test injects a mock host and
 // asserts the keystroke sequences against the pinned recordings WITHOUT a live

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -1,0 +1,127 @@
+// #5617 — isolated unit tests for the FormDriver collaborator.
+//
+// Before #5617 the interactive-form driver was mixed onto ClaudeTuiSession.prototype,
+// so respondToQuestion could only be exercised through a full session (PTY, term,
+// timers, real provider). FormDriver is now an injected collaborator that reaches
+// everything through its `host`, so these tests drive the empirically-pinned
+// keystroke logic against a MOCK host — no live PTY — and assert exactly which
+// bytes get written. This is the testability the audit (#5617) asked for.
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { FormDriver } from '../src/claude-tui/form-driver.js'
+
+/**
+ * Build a mock FormDriverHost that records the PTY writes + watchdog arms and
+ * stands in for the session state FormDriver reads. Only the surface the driver
+ * actually touches is implemented (the @typedef FormDriverHost in form-driver.js).
+ */
+function makeMockHost(overrides = {}) {
+  const writes = []          // _writePtyTextThrottled payloads
+  const multiSeqs = []       // _writePtyMultiQuestionSequence payloads
+  const arrowNavs = []       // _writePtyArrowNavSequence indices
+  const arms = []            // _armAskUserQuestionWatchdog (toolUseId, ms?)
+  const cleared = []         // _clearPendingAnswerByToolUseId ids
+  const host = {
+    _pendingUserAnswers: new Map(),
+    _term: {},               // truthy = a live PTY
+    _destroying: false,
+    _activeTurn: { hexDumpEmitted: false, aborted: false, messageId: 'm1' },
+    _log: { info() {}, warn() {} },
+    _outputTailHexDump: () => '',
+    _writePtyTextThrottled: (t) => { writes.push(t); return Promise.resolve(true) },
+    _writePtyMultiQuestionSequence: (seq) => { multiSeqs.push(seq); return Promise.resolve(true) },
+    _writePtyArrowNavSequence: (idx) => { arrowNavs.push(idx); return Promise.resolve(true) },
+    _armAskUserQuestionWatchdog: (id, ms) => { arms.push({ id, ms }) },
+    _clearPendingAnswerByToolUseId: (id) => { cleared.push(id) },
+    // Back-compat getter: most-recently-set entry (the no-toolUseId path).
+    get _pendingUserAnswer() {
+      const vals = [...host._pendingUserAnswers.values()]
+      return vals.length ? vals[vals.length - 1] : null
+    },
+    ...overrides,
+  }
+  host._writes = writes
+  host._multiSeqs = multiSeqs
+  host._arrowNavs = arrowNavs
+  host._arms = arms
+  host._cleared = cleared
+  return host
+}
+
+function seedSingle(host, toolUseId, optionLabels) {
+  host._pendingUserAnswers.set(toolUseId, {
+    toolUseId,
+    questions: [{ question: 'Pick one' }],
+    options: optionLabels.map((label) => ({ label })),
+  })
+}
+
+describe('FormDriver — injected collaborator (#5617)', () => {
+  it('single-question: writes the 1-indexed digit for a matched option', () => {
+    const host = makeMockHost()
+    seedSingle(host, 't1', ['Alpha', 'Bravo', 'Charlie'])
+    const fd = new FormDriver(host)
+
+    fd.respondToQuestion('Charlie', undefined, 't1')
+
+    // #4290 — matched label → its 1-indexed TUI hotkey digit, not the label text.
+    assert.deepEqual(host._writes, ['3'])
+    assert.deepEqual(host._cleared, ['t1'], 'only the answered entry is cleared')
+  })
+
+  it('single-question: arms the stall watchdog for the pending entry', () => {
+    const host = makeMockHost()
+    seedSingle(host, 't1', ['Yes', 'No'])
+    const fd = new FormDriver(host)
+
+    fd.respondToQuestion('No', undefined, 't1')
+
+    assert.deepEqual(host._writes, ['2'])
+    assert.ok(host._arms.some((a) => a.id === 't1'), 'watchdog armed for t1')
+  })
+
+  it('single-question: an unmatched label falls through to the literal text', () => {
+    const host = makeMockHost()
+    seedSingle(host, 't1', ['Yes', 'No'])
+    const fd = new FormDriver(host)
+
+    // The dashboard "Other"/freeform back-compat path types the answer literally.
+    fd.respondToQuestion('Maybe later', undefined, 't1')
+
+    assert.deepEqual(host._writes, ['Maybe later'])
+  })
+
+  it('drops a stale toolUseId with no matching pending entry — no PTY write', () => {
+    const host = makeMockHost()
+    seedSingle(host, 't1', ['A', 'B'])
+    const fd = new FormDriver(host)
+
+    fd.respondToQuestion('A', undefined, 'gone-tool-id')
+
+    assert.deepEqual(host._writes, [], 'no keystrokes written into a foreign form')
+    assert.deepEqual(host._cleared, [], 'nothing cleared')
+  })
+
+  it('no pending entries at all → no-op (no write, no watchdog)', () => {
+    const host = makeMockHost()
+    const fd = new FormDriver(host)
+
+    fd.respondToQuestion('A', undefined, undefined)
+
+    assert.deepEqual(host._writes, [])
+    assert.deepEqual(host._arms, [])
+  })
+
+  it('does not write when the host has no live PTY (_term null)', () => {
+    const host = makeMockHost({ _term: null })
+    seedSingle(host, 't1', ['A', 'B'])
+    const fd = new FormDriver(host)
+
+    fd.respondToQuestion('A', undefined, 't1')
+
+    // Arms the watchdog (so the turn recovers) but writes nothing.
+    assert.deepEqual(host._writes, [])
+    assert.ok(host._arms.some((a) => a.id === 't1'))
+  })
+})


### PR DESCRIPTION
> ⚠️ **Needs a live-PTY smoke test before merge.** This refactors the most fragile, empirically-pinned code in the repo (the AskUserQuestion form driving). The change is *proven* behavior-preserving by construction + tests (below), but per the project's hard-won memory (`tui_multi_question_form_keys`, `multi_question_post_deny_wedge`, #4668) some edge cases only surface against a real `claude` TUI. Please drive a multi-question + an Other/freeform AskUserQuestion through a live session before merging.

## Problem

#5559 moved the interactive form driver out of `claude-tui-session.js` byte-identical, but re-coupled it onto `ClaudeTuiSession.prototype` via `applyMixin()`. So `respondToQuestion` still reached into **28** private session fields/methods through `this`, and could only be exercised through a full session (PTY, term, timers, real provider). The audit (#5617, HIGH) flagged it as the most fragile, most-patched, **least-testable** code in the repo.

## Fix — injected collaborator, pure receiver swap

`FormDriverMixin` → an injected **`FormDriver`** class with a typed host interface:
- The session constructs `this._formDriver = new FormDriver(this)` (no longer `applyMixin`'d), delegates `respondToQuestion(...)`, and the stall watchdog calls `this._formDriver._onAskUserQuestionStall`.
- Every former `this._field` is now `this._host._field` against an explicit `@typedef FormDriverHost` (PTY writers · pending-answer state · turn/result state · timers · EventEmitter).

**The byte-sequence bodies are otherwise UNCHANGED.** This is a mechanical receiver swap, and it's verifiable as such:

```
$ sed 's/this\._host\./this./g' form-driver.js  ==  the #5559 source, byte-for-byte
```

(I generated it deterministically — protect the 3 own-method names, `s/this./this._host./`, restore — and confirmed the reversal reproduces the original exactly. No keystroke logic, timing constant, or control-flow line changed.)

## Testability (the deliverable)

New `tests/claude-tui-form-driver.test.js` — **6 isolated unit tests** that construct `FormDriver` with a **mock host** (no live PTY) and assert the pinned single-question keystrokes: matched option → 1-indexed digit (#4290), unmatched → literal fallthrough, stale-toolUseId drop (#4668), empty no-op, and the no-`_term` guard. This is exactly the "unit-test the pinned byte sequences without a live PTY" the issue asked for; the multi-question / Other-freeform paths remain covered by the existing 340-test suite and are the focus of the requested live smoke test.

## Verification

- **346/346** claude-tui tests pass (340 existing behavior + 6 new isolated).
- Full server suite clean — only the known `:8765` live-daemon probe artifacts in `service.test.js` remain (unrelated; doesn't import claude-tui).
- eslint + `lint-session-opt-forwarding` + `lint-tests-state-file-path` green.

Closes #5617