### PR TITLE
fix(server): deny multi-select AskUserQuestion in the TUI provider (#5771)

### DIFF
--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -69,23 +69,41 @@ esac
 REQUEST=$(cat -)
 TOOL_NAME=$(echo "$REQUEST" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
 if [ "$TOOL_NAME" = "AskUserQuestion" ]; then
-  # Count `questions[]` length via python3 (stock macOS has it at /usr/bin/python3
-  # 3.9.6; Homebrew at /opt/homebrew/bin). On parse failure or python3 absence
-  # we get empty output → fall through to normal handling rather than
-  # crash/deny-everything. Worst case: same as today (the v0.9.23 watchdog
-  # catches the wedge), so this defaults safe.
-  QUESTION_COUNT=$(printf '%s' "$REQUEST" | python3 -c '
+  # Parse `questions[]` length AND whether any question is multiSelect via
+  # python3 (stock macOS has it at /usr/bin/python3 3.9.6; Homebrew at
+  # /opt/homebrew/bin). On parse failure or python3 absence we get empty
+  # output → fall through to normal handling rather than crash/deny-everything.
+  # Worst case: same as today (the v0.9.23 watchdog + the form-driver multiSelect
+  # guard catch the wedge), so this defaults safe.
+  #
+  # #5771: deny single-question multiSelect too. claude TUI is keyboard-only and
+  # has no reliable multi-toggle+submit keystroke sequence (0/7 production
+  # success — swarm audit 2026-06-13). Single-select single-questions stay on the
+  # empirically-validated happy path; everything multiSelect is refused here so
+  # the model decomposes into single-select asks. Output is "<count> <hasMulti>".
+  PARSED=$(printf '%s' "$REQUEST" | python3 -c '
 import sys, json
 try:
     d = json.load(sys.stdin)
     q = d.get("tool_input", {}).get("questions", [])
-    print(len(q) if isinstance(q, list) else 0)
+    if not isinstance(q, list):
+        q = []
+    has_multi = 1 if any(isinstance(x, dict) and x.get("multiSelect") is True for x in q) else 0
+    print(f"{len(q)} {has_multi}")
 except Exception:
     pass
 ' 2>/dev/null)
+  QUESTION_COUNT=$(printf '%s' "$PARSED" | cut -d' ' -f1)
+  HAS_MULTISELECT=$(printf '%s' "$PARSED" | cut -d' ' -f2)
   if [ -n "$QUESTION_COUNT" ] && [ "$QUESTION_COUNT" -gt 1 ]; then
     cat <<'EOF'
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Chroxy currently delivers AskUserQuestion forms one question at a time. Please re-issue this call as separate AskUserQuestion tool calls, ONE AT A TIME — issue the next one only after the previous one's tool_result has been returned. Do NOT issue multiple AskUserQuestion tool_use blocks in parallel within the same assistant turn."}}
+EOF
+    exit 0
+  fi
+  if [ "$QUESTION_COUNT" = "1" ] && [ "$HAS_MULTISELECT" = "1" ]; then
+    cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Chroxy's TUI provider does not support multi-select questions (multiSelect:true). Re-issue this as a single-select question (multiSelect:false), or — if the user genuinely needs to choose several items — ask one single-select AskUserQuestion per item (e.g. an include/skip choice for each), ONE AT A TIME, issuing the next only after the previous tool_result returns."}}
 EOF
     exit 0
   fi

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -238,6 +238,27 @@ export class FormDriver {
     // key), and the success paths re-arm with a fresh post-write window (the
     // Other-freeform IIFE with its longer second-stage window).
     this._host._armAskUserQuestionWatchdog(prevToolUseId)
+    // #5771: a SINGLE multi-select question is denied at the permission hook
+    // (permission-hook.sh) because claude TUI is keyboard-only and has no
+    // reliable single-toggle+submit keystroke sequence (0/7 production success —
+    // swarm audit 2026-06-13, see docs/audit-results/claude-tui-askuserquestion-
+    // form-driving/). Defense in depth: if a single multiSelect question reaches
+    // the driver anyway (hook failed open on a parse error, or a client bypassed
+    // it), refuse to drive it rather than write a wrong single digit, and tear
+    // down NOW so the turn recovers immediately instead of waiting out the 30s
+    // stall watchdog. (Multi-question forms are denied separately at the hook
+    // since #4648 and still flow through the assembler below if hook-bypassed —
+    // that dead path is removed in the follow-up cleanup.)
+    if (pendingQuestions.length <= 1 && pendingQuestions.some((q) => q && q.multiSelect === true)) {
+      ;(this._host._log || log).warn(`respondToQuestion: refusing single multiSelect AskUserQuestion (tool=${prevToolUseId || '?'}) — multi-select is denied at the permission hook; not driving keystrokes`)
+      this._teardownAskUserQuestion(prevToolUseId, {
+        synthResult: 'Multi-select questions aren\'t supported by the TUI provider. Ask one single-select question at a time.',
+        emitResultReason: 'ask_user_question_multiselect_unsupported',
+        errorCode: 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+        errorMessage: 'Multi-select questions aren\'t supported here. Tap Retry to resend your request.',
+      })
+      return
+    }
     // Single-question / free-text path requires a non-empty `text`. The
     // multi-question path is driven from answersMap (text is ignored when
     // a map is present) so an empty string is permitted there.

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -57,6 +57,18 @@ function seedSingle(host, toolUseId, optionLabels) {
   })
 }
 
+// A single multiSelect question — denied at the permission hook (#5771), so the
+// driver should never see it in production. Used to assert the defense-in-depth
+// refusal guard in respondToQuestion.
+function seedSingleMultiSelect(host, toolUseId, optionLabels) {
+  const options = optionLabels.map((label) => ({ label, value: label }))
+  host._pendingUserAnswers.set(toolUseId, {
+    toolUseId,
+    questions: [{ question: 'Pick toppings', options, multiSelect: true }],
+    options,
+  })
+}
+
 describe('FormDriver — injected collaborator (#5617)', () => {
   it('single-question: writes the 1-indexed digit for a matched option', () => {
     const host = makeMockHost()
@@ -79,6 +91,31 @@ describe('FormDriver — injected collaborator (#5617)', () => {
 
     assert.deepEqual(host._writes, ['2'])
     assert.ok(host._arms.some((a) => a.id === 't1'), 'watchdog armed for t1')
+  })
+
+  it('single multi-select: refuses to drive keystrokes and tears the turn down (#5771)', () => {
+    // multiSelect is denied at the permission hook (claude TUI is keyboard-only
+    // with no reliable multi-toggle+submit sequence — 0/7 production, swarm
+    // audit 2026-06-13). The driver is the defense-in-depth backstop: if a
+    // multiSelect entry reaches it anyway, it must NOT write a wrong single
+    // digit — it tears the turn down so the dashboard recovers immediately.
+    const host = makeMockHost()
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Mushroom', 'Onion', 'Pepper'])
+    const fd = new FormDriver(host)
+    // Spy on teardown (its internals are covered by the session tests); here we
+    // assert only the routing decision: refuse + tear down with the right code.
+    const tornDown = []
+    fd._teardownAskUserQuestion = (id, payload) => { tornDown.push({ id, payload }) }
+
+    // The dashboard would send an empty text + an answers map for a checkbox
+    // form; either way the guard fires on the entry's multiSelect flag.
+    fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+
+    assert.deepEqual(host._writes, [], 'no single-digit throttled write')
+    assert.deepEqual(host._multiSeqs, [], 'no multi-question keystroke sequence')
+    assert.equal(tornDown.length, 1, 'tore the turn down exactly once')
+    assert.equal(tornDown[0].id, 't1')
+    assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED')
   })
 
   it('single-question: an unmatched label falls through to the literal text', () => {

--- a/packages/server/tests/permission-hook-multi-question.test.js
+++ b/packages/server/tests/permission-hook-multi-question.test.js
@@ -148,3 +148,96 @@ describe('permission-hook.sh — multi-question AskUserQuestion deny (#4648)', (
       'non-array questions value must not trip the guard — defensive against shape drift')
   })
 })
+
+describe('permission-hook.sh — single multi-select AskUserQuestion deny (#5771)', () => {
+  // The multi-select guard is an orthogonal axis to the #4648 multi-question
+  // guard: a single question can still be unanswerable if it sets
+  // multiSelect:true (claude TUI is keyboard-only, no reliable multi-toggle
+  // sequence — 0/7 production, swarm audit 2026-06-13). Pin its reason on the
+  // load-bearing semantics ("multi-select" + "single-select"), not exact copy.
+  const firedMultiSelectGuard = (decision) => {
+    const d = decision.hookSpecificOutput
+    return d.permissionDecision === 'deny' && /multi-?select/i.test(d.permissionDecisionReason || '')
+      && /single-?select/i.test(d.permissionDecisionReason || '')
+  }
+
+  const singleMultiSelect = {
+    tool_name: 'AskUserQuestion',
+    tool_input: {
+      questions: [
+        {
+          question: 'Pick toppings',
+          header: 'Toppings',
+          multiSelect: true,
+          options: [{ label: 'Cheese', value: 'cheese' }, { label: 'Onion', value: 'onion' }],
+        },
+      ],
+    },
+  }
+
+  it('denies a single multiSelect question and steers toward single-select', async () => {
+    const { stdout, status } = await runHook(JSON.stringify(singleMultiSelect))
+    assert.equal(status, 0, 'exits cleanly')
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny')
+    assert.ok(firedMultiSelectGuard(decision),
+      'reason must name multi-select as unsupported and single-select as the fix')
+  })
+
+  it('denies single multiSelect REGARDLESS of permission mode', async () => {
+    for (const mode of ['auto', 'approve', 'acceptEdits', 'plan']) {
+      const { stdout } = await runHook(JSON.stringify(singleMultiSelect), { CHROXY_PERMISSION_MODE: mode })
+      const decision = JSON.parse(stdout.trim())
+      assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny',
+        `mode=${mode} must deny single multiSelect regardless`)
+    }
+  })
+
+  it('allows a single-select question (multiSelect:false) — no regression', async () => {
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: { questions: [{ question: 'one?', header: 'One', multiSelect: false, options: [{ label: 'A', value: 'a' }] }] },
+    }
+    const { stdout } = await runHook(JSON.stringify(payload), { CHROXY_PERMISSION_MODE: 'auto' })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'explicit multiSelect:false single-q stays on the v0.9.4 happy path')
+  })
+
+  it('allows a single-select question with NO multiSelect key — no regression', async () => {
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: { questions: [{ question: 'one?', header: 'One', options: [{ label: 'A', value: 'a' }] }] },
+    }
+    const { stdout } = await runHook(JSON.stringify(payload), { CHROXY_PERMISSION_MODE: 'auto' })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'omitted multiSelect (today\'s single-select shape) still allows')
+  })
+
+  it('does NOT trip the multi-select guard on malformed payload (parse failure defaults safe)', async () => {
+    const { stdout } = await runHook(JSON.stringify({ tool_name: 'AskUserQuestion' }))
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(firedMultiSelectGuard(decision), false,
+      'a parse failure must not deny every AskUserQuestion via the multi-select guard')
+  })
+
+  it('a multiSelect form with >1 questions trips the multi-question guard FIRST (order)', async () => {
+    // Both guards would deny, but the multi-question check runs first. Assert
+    // the user-facing reason is the multi-question one so the model gets the
+    // "one at a time" steer rather than the multi-select copy.
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          { question: 'a?', header: 'A', multiSelect: true, options: [{ label: 'x', value: 'x' }] },
+          { question: 'b?', header: 'B', multiSelect: true, options: [{ label: 'y', value: 'y' }] },
+        ],
+      },
+    }
+    const { stdout } = await runHook(JSON.stringify(payload))
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny')
+    assert.match(decision.hookSpecificOutput.permissionDecisionReason, /one question at a time/i)
+  })
+})


### PR DESCRIPTION
Closes #5771

## Why

The `claude-tui` provider drives AskUserQuestion forms by injecting keystrokes into the real interactive TUI's pseudo-terminal. For **multi-select** forms this has a **0/7 production success rate** (swarm audit 2026-06-13; prior audit 2026-05-31). Live evidence (2026-06-14): the keystrokes are delivered (`writeCompleted=true`) but the TUI ignores them in render states the parent process can't observe — `consumed=0 → first_output_timeout`, a silent 90s stall.

This is architectural, not a timing bug. The interactive TUI is **keyboard-only** and exposes **no external channel** to answer AskUserQuestion structurally (confirmed against Claude Code docs/SDK — a PreToolUse hook can only allow/deny/modify-input, never supply a tool result; cf. anthropics/claude-code#16712). chroxy's structured providers (`claude-cli` stream-json, `claude-sdk` canUseTool) answer it cleanly, but the **interactive TUI cannot** — so the durable fix in TUI mode is to **not attempt** the unanswerable shapes.

## What

Constrain AskUserQuestion in the TUI to the shape that reliably works (single-question, single-select, since v0.9.4) and refuse multi-select so the model decomposes into single-select asks instead of wedging the turn.

- **`permission-hook.sh`** — deny a single-question `multiSelect:true` form (mirrors the #4648 multi-question deny). The reason text steers the model to single-select / one-question-at-a-time decomposition. The python parse now reports `<count> <hasMultiSelect>`; on parse failure it still defaults safe (falls through to normal handling).
- **`form-driver.js`** — defense-in-depth guard: a single multiSelect entry that slips past the hook (fail-open) tears the turn down immediately (clean recovery via `_teardownAskUserQuestion`, error `ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED`) instead of writing a wrong single digit and waiting out the 30s stall watchdog.

Multi-**question** forms were already denied at the hook (#4648); this adds the missing single-question-multiSelect case.

## Tests

- `permission-hook-multi-question.test.js` — single multiSelect denied (all modes); single-select (explicit `false` and omitted) still allowed — no v0.9.4 regression; malformed payload defaults safe; multi-question-with-multiSelect trips the multi-question guard first.
- `claude-tui-form-driver.test.js` — a single multiSelect entry is refused without any keystroke write and tears down with the right error code.

## Verification

- Targeted + claude-tui/permission surface: 327/327 green.
- Full server suite: **9530/9538**. The 2 failures are `service.test.js` health-probe tests that assert nothing answers on default port 8765 — the local Chroxy.app daemon answers the probe (documented live-daemon artifact). Unrelated to this change; green in CI.
- eslint clean; `shellcheck` + `bash -n` clean; custom server lints (logger-scoping, opt-forwarding, tests-state-file) all pass.

## Follow-up (separate PR)

Delete the now-dead multi-question keystroke assembler (`form-driver.js` multi-question branch + `pty-driver.js` `_writePtyMultiQuestionSequence`) and its tests, after broadening the form-driver guard to refuse all non-single-single-select shapes.