### PR TITLE
feat(server): reinject TUI multi-select answers as text (#5776)

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -63,6 +63,12 @@ export interface ChatViewProps {
    * `allowMultiQuestionForm` gate.
    */
   allowMultiQuestion?: boolean;
+  /**
+   * #5773 — opt-in to render a SINGLE-question multiSelect as a checkbox form
+   * (passed through to MessageBubble). True for the SDK family and claude-tui
+   * (multi-select reinject); off for claude-cli.
+   */
+  allowSingleMultiSelect?: boolean;
   isCliMode: boolean;
   selectedIds: Set<string>;
   isSelecting: boolean;
@@ -140,6 +146,7 @@ export function ChatView({
   onSelectOption,
   onSubmitMultiQuestion,
   allowMultiQuestion,
+  allowSingleMultiSelect,
   isCliMode,
   selectedIds,
   isSelecting,
@@ -402,6 +409,7 @@ export function ChatView({
             reduceMotion={reduceMotion}
           >
             <MessageBubble
+              allowSingleMultiSelect={allowSingleMultiSelect}
               message={msg}
               onSelectOption={onSelectOption}
               onSubmitMultiQuestion={onSubmitMultiQuestion}
@@ -441,6 +449,7 @@ export function ChatView({
       onSelectOption,
       onSubmitMultiQuestion,
       allowMultiQuestion,
+      allowSingleMultiSelect,
       chatTailMessageId,
       lastUserInputContent,
       sendInput,

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -64,7 +64,7 @@ export interface ChatViewProps {
    */
   allowMultiQuestion?: boolean;
   /**
-   * #5773 — opt-in to render a SINGLE-question multiSelect as a checkbox form
+   * #5776 — opt-in to render a SINGLE-question multiSelect as a checkbox form
    * (passed through to MessageBubble). True for the SDK family and claude-tui
    * (multi-select reinject); off for claude-cli.
    */

--- a/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
@@ -64,6 +64,7 @@ function render(
   message: ChatMessage,
   props: {
     allowMultiQuestion?: boolean;
+    allowSingleMultiSelect?: boolean;
     onSubmitMultiQuestion?: jest.Mock;
     onSelectOption?: jest.Mock;
   } = {},
@@ -81,10 +82,40 @@ function render(
         onSelectOption={props.onSelectOption ?? jest.fn()}
         onSubmitMultiQuestion={props.onSubmitMultiQuestion}
         allowMultiQuestion={props.allowMultiQuestion}
+        allowSingleMultiSelect={props.allowSingleMultiSelect}
       />,
     );
   });
   return tree;
+}
+
+// #5773 — a single-question multiSelect.
+function singleMultiSelectPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'sm-1',
+    type: 'prompt',
+    content: 'Pick toppings',
+    timestamp: Date.now(),
+    toolUseId: 'toolu_single_multi',
+    tool: 'AskUserQuestion',
+    options: [
+      { label: 'Cheese', value: 'Cheese' },
+      { label: 'Onion', value: 'Onion' },
+      { label: 'Pepper', value: 'Pepper' },
+    ],
+    questions: [
+      {
+        question: 'Pick toppings',
+        multiSelect: true,
+        options: [
+          { label: 'Cheese', value: 'Cheese' },
+          { label: 'Onion', value: 'Onion' },
+          { label: 'Pepper', value: 'Pepper' },
+        ],
+      },
+    ],
+    ...overrides,
+  } as ChatMessage;
 }
 
 // react-test-renderer surfaces a testID on both the composite and the
@@ -217,5 +248,37 @@ describe('MessageBubble multi-question form (#4973)', () => {
     expect(flat.props.children).toBe(
       'Q1 — deploy to production?: approve | Q2 — which areas to verify?: app, server',
     );
+  });
+});
+
+describe('MessageBubble single-question multiSelect (#5773)', () => {
+  it('renders the checkbox form when allowSingleMultiSelect is true', () => {
+    const tree = render(singleMultiSelectPrompt(), { allowSingleMultiSelect: true });
+    expect(present(tree, 'question-prompt-multi')).toBe(true);
+    expect(present(tree, 'question-multi-submit')).toBe(true);
+  });
+
+  it('forwards a string[] answers map on submit', () => {
+    const onSubmitMultiQuestion = jest.fn();
+    const tree = render(singleMultiSelectPrompt(), {
+      allowSingleMultiSelect: true,
+      onSubmitMultiQuestion,
+    });
+    tap(tree, 'question-multi-option-0-Cheese');
+    tap(tree, 'question-multi-option-0-Pepper');
+    tap(tree, 'question-multi-submit');
+    expect(onSubmitMultiQuestion).toHaveBeenCalledTimes(1);
+    expect(onSubmitMultiQuestion).toHaveBeenCalledWith(
+      { 'Pick toppings': ['Cheese', 'Pepper'] },
+      'sm-1',
+      'toolu_single_multi',
+    );
+  });
+
+  it('falls back to single-select option buttons when allowSingleMultiSelect is false (claude-cli)', () => {
+    const tree = render(singleMultiSelectPrompt(), { allowSingleMultiSelect: false });
+    expect(present(tree, 'question-prompt-multi')).toBe(false);
+    expect(present(tree, 'approval-button-Cheese')).toBe(true);
+    expect(present(tree, 'approval-button-Onion')).toBe(true);
   });
 });

--- a/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
@@ -89,7 +89,7 @@ function render(
   return tree;
 }
 
-// #5773 — a single-question multiSelect.
+// #5776 — a single-question multiSelect.
 function singleMultiSelectPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
     id: 'sm-1',
@@ -251,7 +251,7 @@ describe('MessageBubble multi-question form (#4973)', () => {
   });
 });
 
-describe('MessageBubble single-question multiSelect (#5773)', () => {
+describe('MessageBubble single-question multiSelect (#5776)', () => {
   it('renders the checkbox form when allowSingleMultiSelect is true', () => {
     const tree = render(singleMultiSelectPrompt(), { allowSingleMultiSelect: true });
     expect(present(tree, 'question-prompt-multi')).toBe(true);

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -72,7 +72,7 @@ export function buildPromptSessionLabel(
   return provider ? `${name} · ${provider}` : name;
 }
 
-function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
+function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, allowSingleMultiSelect, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
   message: ChatMessage;
   onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
   /**
@@ -91,6 +91,15 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
    * there. Mirrors the dashboard's `allowMultiQuestionForm` gate.
    */
   allowMultiQuestion?: boolean;
+  /**
+   * #5773 — opt-in to render a SINGLE-question multiSelect as the checkbox
+   * `MultiQuestionForm` (it handles a length-1 array) instead of single-select
+   * option buttons. A multi-select AskUserQuestion from the TUI is almost
+   * always one question; without this the user could only pick one. True for
+   * the SDK-family providers (alongside `allowMultiQuestion`) and for claude-tui
+   * via the multi-select reinject path; off for claude-cli.
+   */
+  allowSingleMultiSelect?: boolean;
   isSelected: boolean;
   isSelecting: boolean;
   onLongPress: () => void;
@@ -191,8 +200,19 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
   // single-question pins keep passing.
   const isMultiQuestion =
     isPrompt && Array.isArray(message.questions) && message.questions.length > 1;
+  // #5773 — a single-question multiSelect uses the SAME checkbox form +
+  // structured-summary path as a multi-question form (the form handles a
+  // length-1 array, and submit routes through onSubmitMultiQuestion just like
+  // the multi-question case). `useMultiForm` collapses both into one condition:
+  // a >1-question form when allowMultiQuestion, OR a single multiSelect when
+  // allowSingleMultiSelect (claude-tui reinject + SDK-family; off for claude-cli).
+  const isSingleMultiSelect =
+    isPrompt && Array.isArray(message.questions) && message.questions.length === 1
+    && message.questions[0]?.multiSelect === true;
+  const useMultiForm =
+    (isMultiQuestion && !!allowMultiQuestion) || (isSingleMultiSelect && !!allowSingleMultiSelect);
   const showMultiQuestionForm =
-    isMultiQuestion && !!allowMultiQuestion && message.answered == null && !isExpired;
+    useMultiForm && message.answered == null && !isExpired;
   // #4973 — the per-question structured summary chip needs the
   // `answeredAnswers` map (recorded by `markPromptAnsweredMulti` on the
   // client that submitted). When a multi-question prompt is answered but
@@ -201,17 +221,15 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
   // flat `message.answered` summary text (Copilot review) so the answer
   // is never shown as blank.
   const hasMultiQuestionAnswers =
-    isMultiQuestion &&
-    !!allowMultiQuestion &&
+    useMultiForm &&
     message.answered != null &&
     message.answeredAnswers != null;
   const showMultiQuestionFallbackSummary =
-    isMultiQuestion &&
-    !!allowMultiQuestion &&
+    useMultiForm &&
     message.answered != null &&
     message.answeredAnswers == null;
   const showMultiQuestionSummary =
-    isMultiQuestion && !!allowMultiQuestion && message.answered != null;
+    useMultiForm && message.answered != null;
   // #4973 — per-question display labels for the post-answer summary chip.
   // Maps each question's chosen value(s) (from the structured
   // `answeredAnswers` map) back to its option label(s), comma-joined for

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -92,7 +92,7 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
    */
   allowMultiQuestion?: boolean;
   /**
-   * #5773 — opt-in to render a SINGLE-question multiSelect as the checkbox
+   * #5776 — opt-in to render a SINGLE-question multiSelect as the checkbox
    * `MultiQuestionForm` (it handles a length-1 array) instead of single-select
    * option buttons. A multi-select AskUserQuestion from the TUI is almost
    * always one question; without this the user could only pick one. True for
@@ -200,7 +200,7 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
   // single-question pins keep passing.
   const isMultiQuestion =
     isPrompt && Array.isArray(message.questions) && message.questions.length > 1;
-  // #5773 — a single-question multiSelect uses the SAME checkbox form +
+  // #5776 — a single-question multiSelect uses the SAME checkbox form +
   // structured-summary path as a multi-question form (the form handles a
   // length-1 array, and submit routes through onSubmitMultiQuestion just like
   // the multi-question case). `useMultiForm` collapses both into one condition:

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -267,6 +267,16 @@ export function SessionScreen() {
       activeSessionProvider !== 'claude-cli',
     [activeSessionProvider],
   );
+  // #5773 — a single-question multiSelect renders as a checkbox form on every
+  // provider that can consume a structured/text multi-answer: the SDK family
+  // AND claude-tui (via the multi-select reinject path). Only claude-cli is
+  // excluded — its respondToQuestion takes a single text answer with no
+  // answersMap channel. (= everything except claude-cli, which is
+  // allowMultiQuestion || claude-tui.)
+  const allowSingleMultiSelect = useMemo(
+    () => activeSessionProvider != null && activeSessionProvider !== 'claude-cli',
+    [activeSessionProvider],
+  );
   const viewingCachedSession = useConnectionStore((s) => s.viewingCachedSession);
   const exitCachedSession = useConnectionStore((s) => s.exitCachedSession);
   const savedConnection = useConnectionLifecycleStore((s) => s.savedConnection);
@@ -1418,6 +1428,7 @@ export function SessionScreen() {
                   onSelectOption={handleSelectOption}
                   onSubmitMultiQuestion={handleSubmitMultiQuestion}
                   allowMultiQuestion={allowMultiQuestion}
+              allowSingleMultiSelect={allowSingleMultiSelect}
                   isCliMode={isCliMode}
                   selectedIds={selectedIds}
                   isSelecting={isSelecting}
@@ -1451,6 +1462,7 @@ export function SessionScreen() {
               onSelectOption={handleSelectOption}
               onSubmitMultiQuestion={handleSubmitMultiQuestion}
               allowMultiQuestion={allowMultiQuestion}
+              allowSingleMultiSelect={allowSingleMultiSelect}
               isCliMode={isCliMode}
               selectedIds={selectedIds}
               isSelecting={isSelecting}
@@ -1478,6 +1490,7 @@ export function SessionScreen() {
               onSelectOption={handleSelectOption}
               onSubmitMultiQuestion={handleSubmitMultiQuestion}
               allowMultiQuestion={allowMultiQuestion}
+              allowSingleMultiSelect={allowSingleMultiSelect}
               isCliMode={isCliMode}
               selectedIds={selectedIds}
               isSelecting={isSelecting}

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -267,7 +267,7 @@ export function SessionScreen() {
       activeSessionProvider !== 'claude-cli',
     [activeSessionProvider],
   );
-  // #5773 — a single-question multiSelect renders as a checkbox form on every
+  // #5776 — a single-question multiSelect renders as a checkbox form on every
   // provider that can consume a structured/text multi-answer: the SDK family
   // AND claude-tui (via the multi-select reinject path). Only claude-cli is
   // excluded — its respondToQuestion takes a single text answer with no

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -955,11 +955,11 @@ describe('QuestionPrompt', () => {
   })
 })
 
-// #5773 — a SINGLE-question multiSelect must render as a checkbox form so the
+// #5776 — a SINGLE-question multiSelect must render as a checkbox form so the
 // user can pick several, gated by allowSingleMultiSelect (the multi-select
 // reinject path enables it for claude-tui; SDK-family providers via
 // allowMultiQuestion; claude-cli stays on single-select).
-describe('QuestionPrompt — single-question multiSelect (#5773)', () => {
+describe('QuestionPrompt — single-question multiSelect (#5776)', () => {
   const singleMultiOptions = [
     { label: 'Cheese', value: 'Cheese' },
     { label: 'Onion', value: 'Onion' },

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
-import { OTHER_OPTION_VALUE } from '@chroxy/store-core'
+import { OTHER_OPTION_VALUE, type ChatMessageQuestion } from '@chroxy/store-core'
 import { QuestionPrompt, MultiQuestionForm } from './QuestionPrompt'
 
 afterEach(cleanup)
@@ -952,5 +952,68 @@ describe('QuestionPrompt', () => {
       // And nothing leaks elsewhere in the rendered tree either.
       expect(screen.queryByText(/LEAK_ME/)).not.toBeInTheDocument()
     })
+  })
+})
+
+// #5773 — a SINGLE-question multiSelect must render as a checkbox form so the
+// user can pick several, gated by allowSingleMultiSelect (the multi-select
+// reinject path enables it for claude-tui; SDK-family providers via
+// allowMultiQuestion; claude-cli stays on single-select).
+describe('QuestionPrompt — single-question multiSelect (#5773)', () => {
+  const singleMultiOptions = [
+    { label: 'Cheese', value: 'Cheese' },
+    { label: 'Onion', value: 'Onion' },
+    { label: 'Pepper', value: 'Pepper' },
+  ]
+  const singleMulti: ChatMessageQuestion[] = [{ question: 'Pick toppings', multiSelect: true, options: singleMultiOptions }]
+
+  it('renders the checkbox form and emits a string[] answersMap when allowed', () => {
+    const onSelect = vi.fn()
+    render(
+      <QuestionPrompt
+        question="Pick toppings"
+        options={singleMultiOptions}
+        questions={singleMulti}
+        allowSingleMultiSelect
+        onSelect={onSelect}
+      />
+    )
+    expect(screen.getByTestId('question-prompt-multi')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('question-multi-option-0-Cheese').querySelector('input')!)
+    fireEvent.click(screen.getByTestId('question-multi-option-0-Pepper').querySelector('input')!)
+    fireEvent.click(screen.getByTestId('question-multi-submit'))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect.mock.calls[0]?.[0]).toEqual({ 'Pick toppings': ['Cheese', 'Pepper'] })
+  })
+
+  it('falls back to single-select buttons when NOT allowed (e.g. claude-cli)', () => {
+    const onSelect = vi.fn()
+    render(
+      <QuestionPrompt
+        question="Pick toppings"
+        options={singleMultiOptions}
+        questions={singleMulti}
+        onSelect={onSelect}
+      />
+    )
+    // No checkbox form; the legacy single-select card renders instead.
+    expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+    expect(screen.getByTestId('question-prompt')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Cheese'))
+    expect(onSelect).toHaveBeenCalledWith('Cheese')
+  })
+
+  it('does not render the checkbox form once answered', () => {
+    render(
+      <QuestionPrompt
+        question="Pick toppings"
+        options={singleMultiOptions}
+        questions={singleMulti}
+        allowSingleMultiSelect
+        answered="Cheese, Pepper"
+        onSelect={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
   })
 })

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -102,6 +102,17 @@ export interface QuestionPromptProps {
    */
   allowMultiQuestion?: boolean
   /**
+   * #5773 — opt-in to render a SINGLE-question multiSelect as a checkbox
+   * form (reusing MultiQuestionForm) instead of single-select buttons.
+   * A multi-select AskUserQuestion from the TUI is almost always one
+   * question, so without this it renders as radio buttons and the user
+   * can't pick several. True for providers that can consume a structured
+   * multi-answer: SDK/BYOK/Codex/Gemini natively, and claude-tui via the
+   * multi-select reinject path (CHROXY_TUI_MULTISELECT_REINJECT). Defaults
+   * off so the legacy single-select rendering is unchanged.
+   */
+  allowSingleMultiSelect?: boolean
+  /**
    * Fires with one of three shapes:
    * - `string` — legacy single-question / free-text-only path (back-compat).
    * - `MultiQuestionAnswersMap` (`Record<string, string | string[]>`) —
@@ -115,7 +126,7 @@ export interface QuestionPromptProps {
   onSelect: (answer: string | MultiQuestionAnswersMap | OtherFreeformAnswer) => void
 }
 
-export function QuestionPrompt({ question, options, answered, questions, allowMultiQuestion, pendingPermission, onSelect }: QuestionPromptProps) {
+export function QuestionPrompt({ question, options, answered, questions, allowMultiQuestion, allowSingleMultiSelect, pendingPermission, onSelect }: QuestionPromptProps) {
   // #4685 — gate ALL question content (text, options, multi-question
   // form, deferred notice, free-text input) behind the
   // `pendingPermission` flag. Render only a neutral placeholder until
@@ -153,6 +164,18 @@ export function QuestionPrompt({ question, options, answered, questions, allowMu
       return <MultiQuestionForm questions={questions} onSelect={onSelect} />
     }
     return <MultiQuestionDeferredNotice count={questions.length} />
+  }
+
+  // #5773 — a SINGLE-question multiSelect renders as a checkbox form (reusing
+  // MultiQuestionForm, which handles a length-1 array and emits an answersMap
+  // keyed by question text with the chosen labels as a string[]). Without this
+  // it would fall through to SingleQuestionPrompt's radio buttons and the user
+  // could only pick one. Gated by allowSingleMultiSelect so claude-cli (no
+  // structured-answer channel) keeps the single-select fallback.
+  const isSingleMultiSelect =
+    Array.isArray(questions) && questions.length === 1 && questions[0]?.multiSelect === true
+  if (isSingleMultiSelect && answered == null && allowSingleMultiSelect) {
+    return <MultiQuestionForm questions={questions} onSelect={onSelect} />
   }
 
   return (

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -102,7 +102,7 @@ export interface QuestionPromptProps {
    */
   allowMultiQuestion?: boolean
   /**
-   * #5773 — opt-in to render a SINGLE-question multiSelect as a checkbox
+   * #5776 — opt-in to render a SINGLE-question multiSelect as a checkbox
    * form (reusing MultiQuestionForm) instead of single-select buttons.
    * A multi-select AskUserQuestion from the TUI is almost always one
    * question, so without this it renders as radio buttons and the user
@@ -166,7 +166,7 @@ export function QuestionPrompt({ question, options, answered, questions, allowMu
     return <MultiQuestionDeferredNotice count={questions.length} />
   }
 
-  // #5773 — a SINGLE-question multiSelect renders as a checkbox form (reusing
+  // #5776 — a SINGLE-question multiSelect renders as a checkbox form (reusing
   // MultiQuestionForm, which handles a length-1 array and emits an answersMap
   // keyed by question text with the chosen labels as a string[]). Without this
   // it would fall through to SingleQuestionPrompt's radio buttons and the user

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -148,7 +148,7 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
           // `allowMultiQuestionForm` above so the flag flips correctly
           // on session-switch without a full re-render of every prompt.
           allowMultiQuestion={allowMultiQuestionForm}
-          // #5773 — render a SINGLE-question multiSelect as a checkbox form.
+          // #5776 — render a SINGLE-question multiSelect as a checkbox form.
           // True wherever a structured multi-answer can be consumed: the
           // SDK-family providers (already gated by allowMultiQuestionForm) AND
           // claude-tui via the multi-select reinject path. claude-cli is

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -148,6 +148,14 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
           // `allowMultiQuestionForm` above so the flag flips correctly
           // on session-switch without a full re-render of every prompt.
           allowMultiQuestion={allowMultiQuestionForm}
+          // #5773 — render a SINGLE-question multiSelect as a checkbox form.
+          // True wherever a structured multi-answer can be consumed: the
+          // SDK-family providers (already gated by allowMultiQuestionForm) AND
+          // claude-tui via the multi-select reinject path. claude-cli is
+          // excluded (allowMultiQuestionForm is false for it and it isn't
+          // claude-tui) because its respondToQuestion takes only a single
+          // text answer with no answersMap channel.
+          allowSingleMultiSelect={allowMultiQuestionForm || activeSessionProvider === 'claude-tui'}
           // #4685 — gate the question content render on the matching
           // AskUserQuestion permission_request being resolved. Pre-fix
           // the user_question card rendered the moment the wire event

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -102,6 +102,17 @@ EOF
     exit 0
   fi
   if [ "$QUESTION_COUNT" = "1" ] && [ "$HAS_MULTISELECT" = "1" ]; then
+    # #5773 (Phase 0) — when the multi-select reinject spike is enabled, the
+    # Chroxy client renders the multi-select form itself and delivers the user's
+    # selection as a follow-up message. Steer the model to STOP and wait for that
+    # message rather than decompose into single-select asks. Still a deny (that is
+    # what suppresses claude TUI's own un-drivable form); only the reason differs.
+    if [ "$CHROXY_TUI_MULTISELECT_REINJECT" = "1" ]; then
+      cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"The Chroxy client is collecting this multi-select choice from the user directly. Do NOT re-ask, do NOT decompose into single-select questions, and do NOT call any further tools. Stop here — the user's selection will arrive as your next user message; continue from it then."}}
+EOF
+      exit 0
+    fi
     cat <<'EOF'
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Chroxy's TUI provider does not support multi-select questions (multiSelect:true). Re-issue this as a single-select question (multiSelect:false), or — if the user genuinely needs to choose several items — ask one single-select AskUserQuestion per item (e.g. an include/skip choice for each), ONE AT A TIME, issuing the next only after the previous tool_result returns."}}
 EOF

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -102,7 +102,7 @@ EOF
     exit 0
   fi
   if [ "$QUESTION_COUNT" = "1" ] && [ "$HAS_MULTISELECT" = "1" ]; then
-    # #5773 (Phase 0) — when the multi-select reinject spike is enabled, the
+    # #5776 (Phase 0) — when the multi-select reinject spike is enabled, the
     # Chroxy client renders the multi-select form itself and delivers the user's
     # selection as a follow-up message. Steer the model to STOP and wait for that
     # message rather than decompose into single-select asks. Still a deny (that is

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1578,7 +1578,10 @@ export class ClaudeTuiSession extends BaseSession {
       // untouched; one-shot latch so even when enabled it logs at most once.
       if (ready && !this._readyTailDumped && process.env.CHROXY_TUI_DUMP_READY_TAIL === '1') {
         this._readyTailDumped = true
-        const tail = (this._outputTail || '').slice(-1500)
+        // #5322 redaction: route through _outputTailDiagnostic() (redactSensitive
+        // + bounded slice) instead of dumping raw _outputTail, so an enabled
+        // diagnostic can't leak token-shaped secrets into the server log.
+        const tail = this._outputTailDiagnostic()
         log.info(`waitForPrompt ready-path tail (FIX-0 #5777, msg=${this._activeTurn?.messageId ?? 'none'}):\n${tail}`)
       }
       return ready

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1565,6 +1565,22 @@ export class ClaudeTuiSession extends BaseSession {
         this._activeTurn.waitForPromptSawStatus = this._lastProbeSawStatus
       }
       log.info(`waitForPrompt (msg=${this._activeTurn?.messageId ?? 'none'} elapsedMs=${elapsedMs} sawStatus=${this._lastProbeSawStatus} ready=${ready})`)
+      // #5777 FIX-0 (diagnostic) — readiness is a session-FILE status check,
+      // decoupled from what the TUI renders, so claude can report status:idle
+      // (ready=true) WHILE a one-shot startup interstitial (trust dialog,
+      // release-notes / opus-notice / remote-control upsell / onboarding) is
+      // on screen and silently swallowing the injected first prompt → the
+      // consumed=0 first_output_timeout wedge (#5777). The existing tail dumps
+      // only fire on !ready, so that wedged-but-"ready" screen was invisible.
+      // Dump the readable tail ONCE per session on the first ready so the exact
+      // interstitial can be named and FIX-1's detector anchored on a real
+      // token. Opt-in (CHROXY_TUI_DUMP_READY_TAIL=1) so healthy sessions are
+      // untouched; one-shot latch so even when enabled it logs at most once.
+      if (ready && !this._readyTailDumped && process.env.CHROXY_TUI_DUMP_READY_TAIL === '1') {
+        this._readyTailDumped = true
+        const tail = (this._outputTail || '').slice(-1500)
+        log.info(`waitForPrompt ready-path tail (FIX-0 #5777, msg=${this._activeTurn?.messageId ?? 'none'}):\n${tail}`)
+      }
       return ready
     }
     const pid = this._term && this._term.pid

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -35,7 +35,10 @@
  *    `_clearAskUserQuestionWatchdog`, `_clearAskUserQuestionLock`,
  *    `_clearFirstOutputWatchdog`, `_streamStallTimeout`, `_resultTimeout`,
  *    `_hardTimeout`, `_nowMonotonic`.
- *  - Misc: `_term`, `_log`, `emit` (the session is an EventEmitter).
+ *  - Misc: `_term`, `_log`, `emit` (the session is an EventEmitter),
+ *    `sendMessage` (#5773 multi-select reinject — start a new turn with the
+ *    formatted answer text when the denied multi-select form has no live form
+ *    to drive).
  *
  * @typedef {import('../claude-tui-session.js').ClaudeTuiSession} FormDriverHost
  */
@@ -111,6 +114,53 @@ const OTHER_FREEFORM_WATCHDOG_MS = 30 * 1000
 // The 30s ASK_USER_QUESTION watchdog remains the safety net for any shape
 // not yet captured. Prior wedge analysis: #4635, #4867.
 export const MULTI_QUESTION_SUBMIT_SETTLE_MS = 150
+
+// #5773 (Phase 0) — multi-select reinject spike. claude TUI is keyboard-only
+// and exposes no structured answer channel, so multi-select forms are denied at
+// permission-hook.sh and (defense-in-depth) refused here. The reinject path
+// flips the strategy: instead of refusing, format the user's selection into a
+// plain-text answer and feed it to claude as a NEW turn via sendMessage(). This
+// works because the form was denied BEFORE it rendered (so there is no live form
+// to drive and no PostToolUse coming), and because a multi-select answer reaches
+// the model as comma-joined TEXT anyway (verified live 2026-06-13 — see project
+// memory tui_askuserquestion_keyboard_only). Gated behind an env flag so the
+// default (refuse) behavior is untouched; the same flag steers the hook's deny
+// reason. Read at call time so tests can toggle it per-case.
+export function multiSelectReinjectEnabled() {
+  return process.env.CHROXY_TUI_MULTISELECT_REINJECT === '1'
+}
+
+// #5773 — parse a single question's answersMap value into an array of selected
+// option LABELS. Mirrors the multi-select parsing in resolveQuestionKeystrokes
+// (native array post-#4735 / JSON-encoded array / comma-joined fallback) so the
+// reinject formatter and the keystroke driver agree on what the user picked.
+function parseSelectedLabels(raw) {
+  if (Array.isArray(raw)) return raw.filter((s) => typeof s === 'string')
+  if (typeof raw === 'string' && raw.length > 0) {
+    let parsed = null
+    try { parsed = JSON.parse(raw) } catch { parsed = null }
+    if (Array.isArray(parsed)) return parsed.filter((s) => typeof s === 'string')
+    return raw.split(',').map((s) => s.trim()).filter(Boolean)
+  }
+  return []
+}
+
+// #5773 — format the pending questions + answersMap into the plain-text answer
+// chroxy reinjects as the next user message. Uses option LABELS (not positional
+// digits/letters) so the answer is unambiguous to the model regardless of option
+// ordering. Returns '' when nothing resolvable was selected (caller falls back to
+// teardown). Free-text/"Other" combine is deferred to Phase 1 (#5773 option B).
+export function formatMultiSelectReinject(questions, answersMap) {
+  const map = (answersMap && typeof answersMap === 'object') ? answersMap : {}
+  const lines = []
+  for (const q of questions) {
+    if (!q || !q.question) continue
+    const labels = parseSelectedLabels(map[q.question])
+    if (labels.length === 0) continue
+    lines.push(`For "${q.question}": ${labels.join(', ')}`)
+  }
+  return lines.join('\n')
+}
 
 // --- interactive-form driver: an injected collaborator of ClaudeTuiSession (#5617) ---
 export class FormDriver {
@@ -250,6 +300,42 @@ export class FormDriver {
     // since #4648 and still flow through the assembler below if hook-bypassed —
     // that dead path is removed in the follow-up cleanup.)
     if (pendingQuestions.length <= 1 && pendingQuestions.some((q) => q && q.multiSelect === true)) {
+      // #5773 (Phase 0) — reinject path: format the selection into text and feed
+      // it to claude as a new turn instead of driving (un-drivable) keystrokes.
+      // The form was denied at permission-hook.sh before it rendered, so there is
+      // no live form and no PostToolUse — claude has stopped and is waiting for
+      // the next user message (verified live 2026-06-13). Gated by the env flag;
+      // when off, fall through to the original refuse-and-teardown behavior.
+      if (multiSelectReinjectEnabled()) {
+        const reinjectText = formatMultiSelectReinject(pendingQuestions, answersMap)
+        if (opts && typeof opts.freeformText === 'string' && opts.freeformText.length > 0) {
+          // Phase 1 (#5773 option B) — free-text combine deferred. Log so a
+          // dropped custom answer is visible rather than silent.
+          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject dropping freeformText (Phase 1, #5773 option B) tool=${prevToolUseId || '?'}`)
+        }
+        if (reinjectText.length === 0) {
+          // Nothing resolvable selected — recover via teardown rather than send
+          // an empty turn.
+          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject produced empty text (tool=${prevToolUseId || '?'}) — tearing down`)
+          this._teardownAskUserQuestion(prevToolUseId, {
+            synthResult: 'No selection received for the multi-select question.',
+            emitResultReason: 'ask_user_question_multiselect_empty',
+            errorCode: 'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+            errorMessage: 'No selection received. Tap Retry to resend your request.',
+          })
+          return
+        }
+        ;(this._host._log || log).info(`respondToQuestion: multiSelect reinject (flag on) tool=${prevToolUseId || '?'} text="${reinjectText.slice(0, 80)}"`)
+        // The denied form left a pending entry + armed watchdog; clear both, plus
+        // the sibling lock, before starting the new turn.
+        this._host._clearPendingAnswerByToolUseId(prevToolUseId)
+        this._host._clearAskUserQuestionWatchdog(prevToolUseId)
+        this._host._clearAskUserQuestionLock()
+        Promise.resolve(this._host.sendMessage(reinjectText)).catch((err) => {
+          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject sendMessage failed: ${err?.message || err} (tool=${prevToolUseId || '?'})`)
+        })
+        return
+      }
       ;(this._host._log || log).warn(`respondToQuestion: refusing single multiSelect AskUserQuestion (tool=${prevToolUseId || '?'}) — multi-select is denied at the permission hook; not driving keystrokes`)
       this._teardownAskUserQuestion(prevToolUseId, {
         synthResult: 'Multi-select questions aren\'t supported by the TUI provider. Ask one single-select question at a time.',

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -36,7 +36,7 @@
  *    `_clearFirstOutputWatchdog`, `_streamStallTimeout`, `_resultTimeout`,
  *    `_hardTimeout`, `_nowMonotonic`.
  *  - Misc: `_term`, `_log`, `emit` (the session is an EventEmitter),
- *    `sendMessage` (#5773 multi-select reinject — start a new turn with the
+ *    `sendMessage` (#5776 multi-select reinject — start a new turn with the
  *    formatted answer text when the denied multi-select form has no live form
  *    to drive).
  *
@@ -115,7 +115,7 @@ const OTHER_FREEFORM_WATCHDOG_MS = 30 * 1000
 // not yet captured. Prior wedge analysis: #4635, #4867.
 export const MULTI_QUESTION_SUBMIT_SETTLE_MS = 150
 
-// #5773 (Phase 0) — multi-select reinject spike. claude TUI is keyboard-only
+// #5776 (Phase 0) — multi-select reinject spike. claude TUI is keyboard-only
 // and exposes no structured answer channel, so multi-select forms are denied at
 // permission-hook.sh and (defense-in-depth) refused here. The reinject path
 // flips the strategy: instead of refusing, format the user's selection into a
@@ -130,7 +130,7 @@ export function multiSelectReinjectEnabled() {
   return process.env.CHROXY_TUI_MULTISELECT_REINJECT === '1'
 }
 
-// #5773 — parse a single question's answersMap value into an array of selected
+// #5776 — parse a single question's answersMap value into an array of selected
 // option LABELS. Mirrors the multi-select parsing in resolveQuestionKeystrokes
 // (native array post-#4735 / JSON-encoded array / comma-joined fallback) so the
 // reinject formatter and the keystroke driver agree on what the user picked.
@@ -145,11 +145,11 @@ function parseSelectedLabels(raw) {
   return []
 }
 
-// #5773 — format the pending questions + answersMap into the plain-text answer
+// #5776 — format the pending questions + answersMap into the plain-text answer
 // chroxy reinjects as the next user message. Uses option LABELS (not positional
 // digits/letters) so the answer is unambiguous to the model regardless of option
 // ordering. Returns '' when nothing resolvable was selected (caller falls back to
-// teardown). Free-text/"Other" combine is deferred to Phase 1 (#5773 option B).
+// teardown). Free-text/"Other" combine is deferred to Phase 1 (#5776 option B).
 export function formatMultiSelectReinject(questions, answersMap) {
   const map = (answersMap && typeof answersMap === 'object') ? answersMap : {}
   const lines = []
@@ -300,7 +300,7 @@ export class FormDriver {
     // since #4648 and still flow through the assembler below if hook-bypassed —
     // that dead path is removed in the follow-up cleanup.)
     if (pendingQuestions.length <= 1 && pendingQuestions.some((q) => q && q.multiSelect === true)) {
-      // #5773 (Phase 0) — reinject path: format the selection into text and feed
+      // #5776 (Phase 0) — reinject path: format the selection into text and feed
       // it to claude as a new turn instead of driving (un-drivable) keystrokes.
       // The form was denied at permission-hook.sh before it rendered, so there is
       // no live form and no PostToolUse — claude has stopped and is waiting for
@@ -309,9 +309,9 @@ export class FormDriver {
       if (multiSelectReinjectEnabled()) {
         const reinjectText = formatMultiSelectReinject(pendingQuestions, answersMap)
         if (opts && typeof opts.freeformText === 'string' && opts.freeformText.length > 0) {
-          // Phase 1 (#5773 option B) — free-text combine deferred. Log so a
+          // Phase 1 (#5776 option B) — free-text combine deferred. Log so a
           // dropped custom answer is visible rather than silent.
-          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject dropping freeformText (Phase 1, #5773 option B) tool=${prevToolUseId || '?'}`)
+          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject dropping freeformText (Phase 1, #5776 option B) tool=${prevToolUseId || '?'}`)
         }
         if (reinjectText.length === 0) {
           // Nothing resolvable selected — recover via teardown rather than send
@@ -325,7 +325,7 @@ export class FormDriver {
           })
           return
         }
-        // #5773 — the reinject only works once the in-flight (denied) turn has
+        // #5776 — the reinject only works once the in-flight (denied) turn has
         // wound down to idle. sendMessage() early-returns (emit 'error' + bare
         // return — NOT a Promise rejection, so the .catch below can't observe it)
         // when _isBusy is still true. In the normal flow the model stops on the

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -348,6 +348,24 @@ export class FormDriver {
           })
           return
         }
+        // sendMessage() has a SECOND fail-open guard beyond _isBusy: if the
+        // session isn't runnable (!_processReady / no _term / _ptyExited) it
+        // emit('error')s + bare-returns without starting a turn. We clear the
+        // pending entry + watchdog + lock just below, so reaching sendMessage in
+        // that state would drop the selection with no retry path (same wedge
+        // class the _isBusy guard closes). Mirror that guard here: tear down with
+        // a retryable error BEFORE clearing state so the user can resend once the
+        // session is back. (#5781 review / #5784)
+        if (!this._host._processReady || !this._host._term || this._host._ptyExited) {
+          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject deferred — session not runnable (tool=${prevToolUseId || '?'}); PTY exited or not yet started`)
+          this._teardownAskUserQuestion(prevToolUseId, {
+            synthResult: 'Multi-select answer could not be delivered; the session was not running.',
+            emitResultReason: 'ask_user_question_multiselect_unavailable',
+            errorCode: 'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+            errorMessage: 'Your selection could not be delivered — the session wasn\'t running. Tap Retry once it\'s back.',
+          })
+          return
+        }
         ;(this._host._log || log).info(`respondToQuestion: multiSelect reinject (flag on) tool=${prevToolUseId || '?'} text="${reinjectText.slice(0, 80)}"`)
         // The denied form left a pending entry + armed watchdog; clear both, plus
         // the sibling lock, before starting the new turn.

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -325,6 +325,29 @@ export class FormDriver {
           })
           return
         }
+        // #5773 — the reinject only works once the in-flight (denied) turn has
+        // wound down to idle. sendMessage() early-returns (emit 'error' + bare
+        // return — NOT a Promise rejection, so the .catch below can't observe it)
+        // when _isBusy is still true. In the normal flow the model stops on the
+        // deny, its Stop hook drains, and the session is idle by the time the
+        // human answers seconds later (verified live 2026-06-13). But if the
+        // answer races ahead of that Stop-hook teardown, or the model ignored the
+        // deny, the turn is still busy — and silently dropping the selection would
+        // wedge the session until the 2h hard cap. Surface a retryable error
+        // instead so the user can resend once the turn has settled (the teardown
+        // is a no-op-safe interleave with the Stop-hook drain via the poll loop's
+        // !_isBusy early return). A future Phase 1 robustness pass can await-idle
+        // and deliver seamlessly; for the spike, fail loud + recoverable.
+        if (this._host._isBusy) {
+          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject deferred — session still busy (tool=${prevToolUseId || '?'}); the answer raced the turn teardown`)
+          this._teardownAskUserQuestion(prevToolUseId, {
+            synthResult: 'Multi-select answer arrived before the previous turn finished; not delivered.',
+            emitResultReason: 'ask_user_question_multiselect_busy',
+            errorCode: 'ASK_USER_QUESTION_MULTISELECT_BUSY',
+            errorMessage: 'Your selection arrived while the previous turn was still finishing. Tap Retry to resend it.',
+          })
+          return
+        }
         ;(this._host._log || log).info(`respondToQuestion: multiSelect reinject (flag on) tool=${prevToolUseId || '?'} text="${reinjectText.slice(0, 80)}"`)
         // The denied form left a pending entry + armed watchdog; clear both, plus
         // the sibling lock, before starting the new turn.

--- a/packages/server/src/claude-tui/pty-driver.js
+++ b/packages/server/src/claude-tui/pty-driver.js
@@ -140,11 +140,21 @@ export function ensureCwdTrusted(cwd) {
     config.projects = {}
   }
   const existing = config.projects[realCwd]
-  if (existing && existing.hasTrustDialogAccepted === true) return
+  // #5777 FIX-2 — also require hasCompletedProjectOnboarding. Pre-#5777 the
+  // early-return fired on trust alone, so a trusted-but-unonboarded cwd (every
+  // fresh worktree-isolated spawn — ensureCwdTrusted set trust but never the
+  // onboarding flag) still rendered claude's project-onboarding interstitial,
+  // which swallows the injected first prompt → the consumed=0 first_output
+  // wedge. Pre-writing both flags suppresses that screen. NOTE: this does NOT
+  // cover account-level one-shot notices (release notes / opus / remote-control
+  // upsell) which render even on a fully-onboarded trusted folder — those are
+  // gated/surfaced by FIX-1, not by per-project config.
+  if (existing && existing.hasTrustDialogAccepted === true && existing.hasCompletedProjectOnboarding === true) return
 
   config.projects[realCwd] = {
     ...(existing || {}),
     hasTrustDialogAccepted: true,
+    hasCompletedProjectOnboarding: true,
     projectOnboardingSeenCount: existing?.projectOnboardingSeenCount ?? 0,
   }
   // Atomic write via temp + rename. Use a per-call random suffix rather

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -38,12 +38,19 @@ function makeMockHost(overrides = {}) {
   const wdCleared = []       // #5773 _clearAskUserQuestionWatchdog ids
   const locksCleared = []    // #5773 _clearAskUserQuestionLock calls
   const sent = []            // #5773 sendMessage payloads (reinject)
+  const warns = []           // #5773 _log.warn messages
+  const errors = []          // #5773 emit('error', ...) payloads from sendMessage guard
   const host = {
     _pendingUserAnswers: new Map(),
     _term: {},               // truthy = a live PTY
     _destroying: false,
+    // #5773 — model the real sendMessage busy contract. Defaults idle (false),
+    // which is the designed reinject state (model stopped on the deny → Stop hook
+    // drained → idle by the time the human answers). Tests flip it to exercise the
+    // busy-race guard.
+    _isBusy: false,
     _activeTurn: { hexDumpEmitted: false, aborted: false, messageId: 'm1' },
-    _log: { info() {}, warn() {} },
+    _log: { info() {}, warn: (m) => warns.push(m) },
     _outputTailHexDump: () => '',
     _writePtyTextThrottled: (t) => { writes.push(t); return Promise.resolve(true) },
     _writePtyMultiQuestionSequence: (seq) => { multiSeqs.push(seq); return Promise.resolve(true) },
@@ -53,7 +60,14 @@ function makeMockHost(overrides = {}) {
     // #5773 — surface the multi-select reinject path touches on success.
     _clearAskUserQuestionWatchdog: (id) => { wdCleared.push(id) },
     _clearAskUserQuestionLock: () => { locksCleared.push(true) },
-    sendMessage: (text) => { sent.push(text); return Promise.resolve() },
+    // #5773 — mirror claude-tui-session.js sendMessage's busy guard: when busy it
+    // emit('error') + returns WITHOUT sending (and resolves, not rejects), so a
+    // .catch can't observe the drop. The form-driver guards on _isBusy before
+    // calling, so this stub primarily proves the call is not made when busy.
+    sendMessage: (text) => {
+      if (host._isBusy) { errors.push('Already processing a message'); return Promise.resolve() }
+      sent.push(text); return Promise.resolve()
+    },
     // Back-compat getter: most-recently-set entry (the no-toolUseId path).
     get _pendingUserAnswer() {
       const vals = [...host._pendingUserAnswers.values()]
@@ -69,6 +83,8 @@ function makeMockHost(overrides = {}) {
   host._wdCleared = wdCleared
   host._locksCleared = locksCleared
   host._sent = sent
+  host._warns = warns
+  host._errors = errors
   return host
 }
 
@@ -212,6 +228,83 @@ describe('FormDriver — injected collaborator (#5617)', () => {
       'For "Pick toppings": Cheese, Onion', 'comma-joined fallback')
     assert.equal(
       formatMultiSelectReinject(questions, {}), '', 'no selection → empty string')
+  })
+
+  it('single multi-select REINJECT (flag on): busy session → no send, retryable teardown (#5773 busy-race)', () => {
+    // If the answer races ahead of the denied turn's Stop-hook teardown, the
+    // session is still _isBusy. The real sendMessage would silently drop the
+    // selection (emit error + return, no throw), wedging until the 2h hard cap.
+    // The driver must instead NOT send and surface a retryable error.
+    const host = makeMockHost()
+    host._isBusy = true
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    const tornDown = []
+    fd._teardownAskUserQuestion = (id, payload) => { tornDown.push({ id, payload }) }
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+
+    assert.deepEqual(host._sent, [], 'does NOT call sendMessage while busy')
+    assert.deepEqual(host._errors, [], 'never reached the sendMessage busy guard')
+    assert.equal(tornDown.length, 1, 'tears down with a retryable error instead of silently dropping')
+    assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_BUSY')
+  })
+
+  it('single multi-select REINJECT (flag on): drops freeformText but still sends the labels (#5773 option B deferral)', () => {
+    const host = makeMockHost()
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    fd._teardownAskUserQuestion = () => { throw new Error('should not tear down') }
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese'] }, 't1', { freeformText: 'extra anchovies' })
+    })
+
+    assert.deepEqual(host._sent, ['For "Pick toppings": Cheese'],
+      'freeformText is NOT appended to the reinjected answer (Phase 1)')
+    assert.ok(host._warns.some((w) => /dropping freeformText/.test(w)),
+      'logs that the custom answer was dropped rather than silently discarding it')
+  })
+
+  it('single multi-select REINJECT (flag on): a rejecting sendMessage is caught, not thrown (#5773)', async () => {
+    const host = makeMockHost({ sendMessage: () => Promise.reject(new Error('boom')) })
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    fd._teardownAskUserQuestion = () => { throw new Error('should not tear down on the send path') }
+
+    withReinjectFlag('1', () => {
+      // Must not throw synchronously — the send is fire-and-forget.
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+    await Promise.resolve()  // let the .catch microtask run
+    await Promise.resolve()
+    assert.ok(host._warns.some((w) => /reinject sendMessage failed/.test(w)),
+      'the rejection is logged via the .catch, not surfaced as an unhandled throw')
+  })
+
+  it('multi-QUESTION (length>1) multiSelect never takes the reinject path — single-question only (#5773)', () => {
+    // The reinject guard is `pendingQuestions.length <= 1 && some(multiSelect)`.
+    // A >1-question form (denied separately at the hook since #4648) must NOT
+    // reinject even with the flag on — pins the single-question-only boundary.
+    const host = makeMockHost()
+    const options = [{ label: 'A' }, { label: 'B' }]
+    host._pendingUserAnswers.set('t1', {
+      toolUseId: 't1',
+      questions: [
+        { question: 'Q1', options, multiSelect: true },
+        { question: 'Q2', options, multiSelect: false },
+      ],
+      options,
+    })
+    const fd = new FormDriver(host)
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { Q1: ['A'], Q2: 'B' }, 't1')
+    })
+
+    assert.deepEqual(host._sent, [], 'reinject path is single-question only')
   })
 
   it('single-question: an unmatched label falls through to the literal text', () => {

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -9,7 +9,20 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { FormDriver } from '../src/claude-tui/form-driver.js'
+import { FormDriver, formatMultiSelectReinject } from '../src/claude-tui/form-driver.js'
+
+// #5773 — run `fn` with CHROXY_TUI_MULTISELECT_REINJECT forced to `value`,
+// restoring the prior value afterward so tests don't leak the flag into each
+// other (the driver reads it at call time via multiSelectReinjectEnabled()).
+function withReinjectFlag(value, fn) {
+  const prev = process.env.CHROXY_TUI_MULTISELECT_REINJECT
+  if (value === undefined) delete process.env.CHROXY_TUI_MULTISELECT_REINJECT
+  else process.env.CHROXY_TUI_MULTISELECT_REINJECT = value
+  try { return fn() } finally {
+    if (prev === undefined) delete process.env.CHROXY_TUI_MULTISELECT_REINJECT
+    else process.env.CHROXY_TUI_MULTISELECT_REINJECT = prev
+  }
+}
 
 /**
  * Build a mock FormDriverHost that records the PTY writes + watchdog arms and
@@ -22,6 +35,9 @@ function makeMockHost(overrides = {}) {
   const arrowNavs = []       // _writePtyArrowNavSequence indices
   const arms = []            // _armAskUserQuestionWatchdog (toolUseId, ms?)
   const cleared = []         // _clearPendingAnswerByToolUseId ids
+  const wdCleared = []       // #5773 _clearAskUserQuestionWatchdog ids
+  const locksCleared = []    // #5773 _clearAskUserQuestionLock calls
+  const sent = []            // #5773 sendMessage payloads (reinject)
   const host = {
     _pendingUserAnswers: new Map(),
     _term: {},               // truthy = a live PTY
@@ -34,6 +50,10 @@ function makeMockHost(overrides = {}) {
     _writePtyArrowNavSequence: (idx) => { arrowNavs.push(idx); return Promise.resolve(true) },
     _armAskUserQuestionWatchdog: (id, ms) => { arms.push({ id, ms }) },
     _clearPendingAnswerByToolUseId: (id) => { cleared.push(id) },
+    // #5773 — surface the multi-select reinject path touches on success.
+    _clearAskUserQuestionWatchdog: (id) => { wdCleared.push(id) },
+    _clearAskUserQuestionLock: () => { locksCleared.push(true) },
+    sendMessage: (text) => { sent.push(text); return Promise.resolve() },
     // Back-compat getter: most-recently-set entry (the no-toolUseId path).
     get _pendingUserAnswer() {
       const vals = [...host._pendingUserAnswers.values()]
@@ -46,6 +66,9 @@ function makeMockHost(overrides = {}) {
   host._arrowNavs = arrowNavs
   host._arms = arms
   host._cleared = cleared
+  host._wdCleared = wdCleared
+  host._locksCleared = locksCleared
+  host._sent = sent
   return host
 }
 
@@ -116,6 +139,79 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.equal(tornDown.length, 1, 'tore the turn down exactly once')
     assert.equal(tornDown[0].id, 't1')
     assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED')
+  })
+
+  it('single multi-select REINJECT (flag on): formats the selection to text and sends a new turn (#5773)', () => {
+    // With CHROXY_TUI_MULTISELECT_REINJECT=1 the driver does NOT tear down or
+    // drive keystrokes — it formats the picked labels into a plain-text answer
+    // and feeds it to claude via sendMessage() as a fresh turn (the denied form
+    // never rendered, so there's no live form and no PostToolUse).
+    const host = makeMockHost()
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Mushroom', 'Onion', 'Pepper'])
+    const fd = new FormDriver(host)
+    const tornDown = []
+    fd._teardownAskUserQuestion = (id, payload) => { tornDown.push({ id, payload }) }
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+
+    assert.deepEqual(host._writes, [], 'no single-digit throttled write')
+    assert.deepEqual(host._multiSeqs, [], 'no multi-question keystroke sequence')
+    assert.equal(tornDown.length, 0, 'reinject does NOT tear the turn down')
+    assert.deepEqual(host._sent, ['For "Pick toppings": Cheese, Onion'],
+      'sends the label-based answer text as a new turn')
+    assert.deepEqual(host._cleared, ['t1'], 'clears the denied pending entry')
+    assert.deepEqual(host._wdCleared, ['t1'], 'clears the armed stall watchdog')
+    assert.equal(host._locksCleared.length, 1, 'clears the sibling AskUserQuestion lock')
+  })
+
+  it('single multi-select REINJECT (flag on): empty selection falls back to teardown (#5773)', () => {
+    const host = makeMockHost()
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Mushroom'])
+    const fd = new FormDriver(host)
+    const tornDown = []
+    fd._teardownAskUserQuestion = (id, payload) => { tornDown.push({ id, payload }) }
+
+    withReinjectFlag('1', () => {
+      // No matching answersMap key → nothing resolvable → empty formatted text.
+      fd.respondToQuestion('', { 'Some other question': ['X'] }, 't1')
+    })
+
+    assert.deepEqual(host._sent, [], 'no empty turn is sent')
+    assert.equal(tornDown.length, 1, 'recovers via teardown')
+    assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_EMPTY')
+  })
+
+  it('single multi-select: flag OFF still refuses + tears down (default behavior preserved) (#5773)', () => {
+    const host = makeMockHost()
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    const tornDown = []
+    fd._teardownAskUserQuestion = (id, payload) => { tornDown.push({ id, payload }) }
+
+    withReinjectFlag(undefined, () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+
+    assert.deepEqual(host._sent, [], 'no reinject when the flag is off')
+    assert.equal(tornDown.length, 1)
+    assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED')
+  })
+
+  it('formatMultiSelectReinject: parses array / JSON-string / comma-string into label text (#5773)', () => {
+    const questions = [{ question: 'Pick toppings', multiSelect: true }]
+    assert.equal(
+      formatMultiSelectReinject(questions, { 'Pick toppings': ['Cheese', 'Onion'] }),
+      'For "Pick toppings": Cheese, Onion', 'native array')
+    assert.equal(
+      formatMultiSelectReinject(questions, { 'Pick toppings': '["Cheese","Onion"]' }),
+      'For "Pick toppings": Cheese, Onion', 'JSON-encoded array (legacy client)')
+    assert.equal(
+      formatMultiSelectReinject(questions, { 'Pick toppings': 'Cheese, Onion' }),
+      'For "Pick toppings": Cheese, Onion', 'comma-joined fallback')
+    assert.equal(
+      formatMultiSelectReinject(questions, {}), '', 'no selection → empty string')
   })
 
   it('single-question: an unmatched label falls through to the literal text', () => {

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -148,7 +148,11 @@ describe('FormDriver — injected collaborator (#5617)', () => {
 
     // The dashboard would send an empty text + an answers map for a checkbox
     // form; either way the guard fires on the entry's multiSelect flag.
-    fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    // Pin the flag OFF so an ambient CHROXY_TUI_MULTISELECT_REINJECT can't route
+    // this default-behavior assertion down the reinject path.
+    withReinjectFlag(undefined, () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
 
     assert.deepEqual(host._writes, [], 'no single-digit throttled write')
     assert.deepEqual(host._multiSeqs, [], 'no multi-question keystroke sequence')

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -11,7 +11,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { FormDriver, formatMultiSelectReinject } from '../src/claude-tui/form-driver.js'
 
-// #5773 — run `fn` with CHROXY_TUI_MULTISELECT_REINJECT forced to `value`,
+// #5776 — run `fn` with CHROXY_TUI_MULTISELECT_REINJECT forced to `value`,
 // restoring the prior value afterward so tests don't leak the flag into each
 // other (the driver reads it at call time via multiSelectReinjectEnabled()).
 function withReinjectFlag(value, fn) {
@@ -35,16 +35,16 @@ function makeMockHost(overrides = {}) {
   const arrowNavs = []       // _writePtyArrowNavSequence indices
   const arms = []            // _armAskUserQuestionWatchdog (toolUseId, ms?)
   const cleared = []         // _clearPendingAnswerByToolUseId ids
-  const wdCleared = []       // #5773 _clearAskUserQuestionWatchdog ids
-  const locksCleared = []    // #5773 _clearAskUserQuestionLock calls
-  const sent = []            // #5773 sendMessage payloads (reinject)
-  const warns = []           // #5773 _log.warn messages
-  const errors = []          // #5773 emit('error', ...) payloads from sendMessage guard
+  const wdCleared = []       // #5776 _clearAskUserQuestionWatchdog ids
+  const locksCleared = []    // #5776 _clearAskUserQuestionLock calls
+  const sent = []            // #5776 sendMessage payloads (reinject)
+  const warns = []           // #5776 _log.warn messages
+  const errors = []          // #5776 emit('error', ...) payloads from sendMessage guard
   const host = {
     _pendingUserAnswers: new Map(),
     _term: {},               // truthy = a live PTY
     _destroying: false,
-    // #5773 — model the real sendMessage busy contract. Defaults idle (false),
+    // #5776 — model the real sendMessage busy contract. Defaults idle (false),
     // which is the designed reinject state (model stopped on the deny → Stop hook
     // drained → idle by the time the human answers). Tests flip it to exercise the
     // busy-race guard.
@@ -57,10 +57,10 @@ function makeMockHost(overrides = {}) {
     _writePtyArrowNavSequence: (idx) => { arrowNavs.push(idx); return Promise.resolve(true) },
     _armAskUserQuestionWatchdog: (id, ms) => { arms.push({ id, ms }) },
     _clearPendingAnswerByToolUseId: (id) => { cleared.push(id) },
-    // #5773 — surface the multi-select reinject path touches on success.
+    // #5776 — surface the multi-select reinject path touches on success.
     _clearAskUserQuestionWatchdog: (id) => { wdCleared.push(id) },
     _clearAskUserQuestionLock: () => { locksCleared.push(true) },
-    // #5773 — mirror claude-tui-session.js sendMessage's busy guard: when busy it
+    // #5776 — mirror claude-tui-session.js sendMessage's busy guard: when busy it
     // emit('error') + returns WITHOUT sending (and resolves, not rejects), so a
     // .catch can't observe the drop. The form-driver guards on _isBusy before
     // calling, so this stub primarily proves the call is not made when busy.
@@ -161,7 +161,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED')
   })
 
-  it('single multi-select REINJECT (flag on): formats the selection to text and sends a new turn (#5773)', () => {
+  it('single multi-select REINJECT (flag on): formats the selection to text and sends a new turn (#5776)', () => {
     // With CHROXY_TUI_MULTISELECT_REINJECT=1 the driver does NOT tear down or
     // drive keystrokes — it formats the picked labels into a plain-text answer
     // and feeds it to claude via sendMessage() as a fresh turn (the denied form
@@ -186,7 +186,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.equal(host._locksCleared.length, 1, 'clears the sibling AskUserQuestion lock')
   })
 
-  it('single multi-select REINJECT (flag on): empty selection falls back to teardown (#5773)', () => {
+  it('single multi-select REINJECT (flag on): empty selection falls back to teardown (#5776)', () => {
     const host = makeMockHost()
     seedSingleMultiSelect(host, 't1', ['Cheese', 'Mushroom'])
     const fd = new FormDriver(host)
@@ -203,7 +203,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_EMPTY')
   })
 
-  it('single multi-select: flag OFF still refuses + tears down (default behavior preserved) (#5773)', () => {
+  it('single multi-select: flag OFF still refuses + tears down (default behavior preserved) (#5776)', () => {
     const host = makeMockHost()
     seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
     const fd = new FormDriver(host)
@@ -219,7 +219,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED')
   })
 
-  it('formatMultiSelectReinject: parses array / JSON-string / comma-string into label text (#5773)', () => {
+  it('formatMultiSelectReinject: parses array / JSON-string / comma-string into label text (#5776)', () => {
     const questions = [{ question: 'Pick toppings', multiSelect: true }]
     assert.equal(
       formatMultiSelectReinject(questions, { 'Pick toppings': ['Cheese', 'Onion'] }),
@@ -234,7 +234,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
       formatMultiSelectReinject(questions, {}), '', 'no selection → empty string')
   })
 
-  it('single multi-select REINJECT (flag on): busy session → no send, retryable teardown (#5773 busy-race)', () => {
+  it('single multi-select REINJECT (flag on): busy session → no send, retryable teardown (#5776 busy-race)', () => {
     // If the answer races ahead of the denied turn's Stop-hook teardown, the
     // session is still _isBusy. The real sendMessage would silently drop the
     // selection (emit error + return, no throw), wedging until the 2h hard cap.
@@ -256,7 +256,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_BUSY')
   })
 
-  it('single multi-select REINJECT (flag on): drops freeformText but still sends the labels (#5773 option B deferral)', () => {
+  it('single multi-select REINJECT (flag on): drops freeformText but still sends the labels (#5776 option B deferral)', () => {
     const host = makeMockHost()
     seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
     const fd = new FormDriver(host)
@@ -272,7 +272,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
       'logs that the custom answer was dropped rather than silently discarding it')
   })
 
-  it('single multi-select REINJECT (flag on): a rejecting sendMessage is caught, not thrown (#5773)', async () => {
+  it('single multi-select REINJECT (flag on): a rejecting sendMessage is caught, not thrown (#5776)', async () => {
     const host = makeMockHost({ sendMessage: () => Promise.reject(new Error('boom')) })
     seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
     const fd = new FormDriver(host)
@@ -288,7 +288,7 @@ describe('FormDriver — injected collaborator (#5617)', () => {
       'the rejection is logged via the .catch, not surfaced as an unhandled throw')
   })
 
-  it('multi-QUESTION (length>1) multiSelect never takes the reinject path — single-question only (#5773)', () => {
+  it('multi-QUESTION (length>1) multiSelect never takes the reinject path — single-question only (#5776)', () => {
     // The reinject guard is `pendingQuestions.length <= 1 && some(multiSelect)`.
     // A >1-question form (denied separately at the hook since #4648) must NOT
     // reinject even with the flag on — pins the single-question-only boundary.

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -18,10 +18,25 @@ function withReinjectFlag(value, fn) {
   const prev = process.env.CHROXY_TUI_MULTISELECT_REINJECT
   if (value === undefined) delete process.env.CHROXY_TUI_MULTISELECT_REINJECT
   else process.env.CHROXY_TUI_MULTISELECT_REINJECT = value
-  try { return fn() } finally {
+  const restore = () => {
     if (prev === undefined) delete process.env.CHROXY_TUI_MULTISELECT_REINJECT
     else process.env.CHROXY_TUI_MULTISELECT_REINJECT = prev
   }
+  // #5781 review: restore synchronously for sync callbacks, but if fn() returns
+  // a thenable, defer the restore to .finally() so an async callback doesn't get
+  // the flag reverted out from under it before its promise settles.
+  let result
+  try {
+    result = fn()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (result && typeof result.then === 'function') {
+    return result.finally(restore)
+  }
+  restore()
+  return result
 }
 
 /**
@@ -43,6 +58,11 @@ function makeMockHost(overrides = {}) {
   const host = {
     _pendingUserAnswers: new Map(),
     _term: {},               // truthy = a live PTY
+    // #5781 review: model sendMessage's SECOND guard (runnable session). Defaults
+    // to a started, alive session; tests flip these to exercise the not-runnable
+    // reinject guard.
+    _processReady: true,
+    _ptyExited: false,
     _destroying: false,
     // #5776 — model the real sendMessage busy contract. Defaults idle (false),
     // which is the designed reinject state (model stopped on the deny → Stop hook
@@ -254,6 +274,30 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.deepEqual(host._errors, [], 'never reached the sendMessage busy guard')
     assert.equal(tornDown.length, 1, 'tears down with a retryable error instead of silently dropping')
     assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_BUSY')
+  })
+
+  it('single multi-select REINJECT (flag on): not-runnable session → no send, retryable teardown (#5781 review)', () => {
+    // sendMessage has a SECOND fail-open guard beyond _isBusy: if the session is
+    // not runnable (PTY exited / not started) it emit('error')s + returns without
+    // starting a turn. Reaching it after the pending entry was cleared would drop
+    // the selection with no retry path. The driver must preflight and tear down
+    // with a retryable error instead of clearing state then dropping silently.
+    for (const notRunnable of [{ _ptyExited: true }, { _processReady: false }, { _term: null }]) {
+      const host = makeMockHost(notRunnable)
+      seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+      const fd = new FormDriver(host)
+      const tornDown = []
+      fd._teardownAskUserQuestion = (id, payload) => { tornDown.push({ id, payload }) }
+
+      withReinjectFlag('1', () => {
+        fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+      })
+
+      assert.deepEqual(host._sent, [], `does NOT call sendMessage when not runnable (${JSON.stringify(notRunnable)})`)
+      assert.deepEqual(host._cleared, [], 'does NOT clear the pending entry before bailing — selection stays retryable')
+      assert.equal(tornDown.length, 1, 'tears down with a retryable error')
+      assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE')
+    }
   })
 
   it('single multi-select REINJECT (flag on): drops freeformText but still sends the labels (#5776 option B deferral)', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -217,11 +217,13 @@ describe('ClaudeTuiSession', () => {
         `expected a /tmp-ish trust entry, got: ${entries.map(([k]) => k).join(', ')}`)
     })
 
-    it('is idempotent when cwd is already trusted', async () => {
+    it('is idempotent when cwd is already trusted AND onboarded (#5777)', async () => {
       const cwdReal = '/tmp'
       const initial = { projects: {} }
       const { realpathSync } = await import('fs')
-      initial.projects[realpathSync(cwdReal)] = { hasTrustDialogAccepted: true }
+      // #5777 FIX-2: the early-return now requires BOTH flags, so a fully
+      // configured entry (trust + onboarding) must not be rewritten.
+      initial.projects[realpathSync(cwdReal)] = { hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true }
       writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify(initial))
       const before = readFileSync(join(fakeHome, '.claude.json'), 'utf8')
 
@@ -229,7 +231,25 @@ describe('ClaudeTuiSession', () => {
       await session.start()
 
       const after = readFileSync(join(fakeHome, '.claude.json'), 'utf8')
-      assert.equal(before, after, 'no rewrite when already trusted')
+      assert.equal(before, after, 'no rewrite when already trusted + onboarded')
+    })
+
+    it('adds hasCompletedProjectOnboarding to a trusted-but-unonboarded cwd (#5777 FIX-2)', async () => {
+      const cwdReal = '/tmp'
+      const initial = { projects: {} }
+      const { realpathSync } = await import('fs')
+      // Trusted but NOT onboarded — the worktree-isolation hole that rendered
+      // claude's project-onboarding interstitial and swallowed the first prompt.
+      initial.projects[realpathSync(cwdReal)] = { hasTrustDialogAccepted: true }
+      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify(initial))
+
+      session = new ClaudeTuiSession({ cwd: cwdReal, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      await session.start()
+
+      const config = JSON.parse(readFileSync(join(fakeHome, '.claude.json'), 'utf8'))
+      const entry = config.projects[realpathSync(cwdReal)]
+      assert.equal(entry.hasTrustDialogAccepted, true, 'trust preserved')
+      assert.equal(entry.hasCompletedProjectOnboarding, true, 'onboarding flag added by FIX-2')
     })
 
     it('creates sink dir, writes settings.json, and assigns a session uuid', async () => {

--- a/packages/server/tests/permission-hook-multi-question.test.js
+++ b/packages/server/tests/permission-hook-multi-question.test.js
@@ -241,3 +241,62 @@ describe('permission-hook.sh — single multi-select AskUserQuestion deny (#5771
     assert.match(decision.hookSpecificOutput.permissionDecisionReason, /one question at a time/i)
   })
 })
+
+describe('permission-hook.sh — single multi-select reinject deny-reason (#5773)', () => {
+  // With CHROXY_TUI_MULTISELECT_REINJECT=1 the multi-select form is STILL denied
+  // (that suppresses claude TUI's un-drivable form) but the reason steers the
+  // model to STOP and wait for the selection as its next message instead of
+  // decomposing into single-select asks. This reason is the only thing steering
+  // the reinject flow, so it's load-bearing and deserves its own coverage.
+  const ON = { CHROXY_TUI_MULTISELECT_REINJECT: '1' }
+  const singleMultiSelect = {
+    tool_name: 'AskUserQuestion',
+    tool_input: {
+      questions: [{
+        question: 'Pick toppings', header: 'Toppings', multiSelect: true,
+        options: [{ label: 'Cheese', value: 'cheese' }, { label: 'Onion', value: 'onion' }],
+      }],
+    },
+  }
+
+  it('flag on: still DENIES the multi-select (the un-drivable form must be suppressed)', async () => {
+    const { stdout, status } = await runHook(JSON.stringify(singleMultiSelect), ON)
+    assert.equal(status, 0)
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny')
+  })
+
+  it('flag on: reason steers STOP-and-wait, not single-select decomposition', async () => {
+    const { stdout } = await runHook(JSON.stringify(singleMultiSelect), ON)
+    const reason = JSON.parse(stdout.trim()).hookSpecificOutput.permissionDecisionReason
+    assert.match(reason, /next user message/i, 'tells the model the selection arrives as its next message')
+    assert.match(reason, /do not re-ask/i, 'tells the model to stop, not re-ask')
+  })
+
+  it('flag on: single-select question is unaffected (must not deny via the multiSelect branch)', async () => {
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: { questions: [{ question: 'one?', header: 'One', multiSelect: false, options: [{ label: 'A', value: 'a' }] }] },
+    }
+    const { stdout } = await runHook(JSON.stringify(payload), { ...ON, CHROXY_PERMISSION_MODE: 'auto' })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'the reinject flag must only affect multiSelect questions')
+  })
+
+  it('flag on: a >1-question multiSelect still trips the multi-question guard FIRST', async () => {
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          { question: 'a?', header: 'A', multiSelect: true, options: [{ label: 'x', value: 'x' }] },
+          { question: 'b?', header: 'B', multiSelect: true, options: [{ label: 'y', value: 'y' }] },
+        ],
+      },
+    }
+    const { stdout } = await runHook(JSON.stringify(payload), ON)
+    const reason = JSON.parse(stdout.trim()).hookSpecificOutput.permissionDecisionReason
+    assert.match(reason, /one question at a time/i,
+      'multi-question guard runs before the single-question reinject branch')
+  })
+})

--- a/packages/server/tests/permission-hook-multi-question.test.js
+++ b/packages/server/tests/permission-hook-multi-question.test.js
@@ -242,7 +242,7 @@ describe('permission-hook.sh — single multi-select AskUserQuestion deny (#5771
   })
 })
 
-describe('permission-hook.sh — single multi-select reinject deny-reason (#5773)', () => {
+describe('permission-hook.sh — single multi-select reinject deny-reason (#5776)', () => {
   // With CHROXY_TUI_MULTISELECT_REINJECT=1 the multi-select form is STILL denied
   // (that suppresses claude TUI's un-drivable form) but the reason steers the
   // model to STOP and wait for the selection as its next message instead of


### PR DESCRIPTION
## Summary

Makes single-question **multi-select** AskUserQuestion work in the `claude-tui` provider, which previously could only drive a single single-select prompt (multi-select/multi-question were denied at the permission hook). The model only ever consumes an AskUserQuestion answer as text (a comma-joined string), so chroxy owns the rich input UI (checkboxes) and feeds claude the collapsed text — no keystroke-driving of the un-observable TUI form.

**Flag-gated** behind `CHROXY_TUI_MULTISELECT_REINJECT=1` (default off; the existing deny→decompose behavior is unchanged when the flag is unset). Flipping the default on is a deliberate follow-up once soaked.

### Mechanism (Phase 0 — server)
- `permission-hook.sh`: when the flag is on, a single-question `multiSelect` AskUserQuestion is denied with a reinject-oriented reason ("Chroxy client is collecting this multi-select… it will arrive as your next user message. Do NOT re-ask.") instead of the decompose reason.
- `form-driver.js`: `formatMultiSelectReinject(questions, answersMap)` collapses the dashboard's checkbox selection to `For "<question>": label1, label2` and reinjects it via `sendMessage()` as the next turn. Guarded against the `_isBusy` busy-turn race (retryable teardown rather than a silent drop).

### Rendering (Phase 1 — clients)
- Dashboard `QuestionPrompt` / `useMessageRenderer`: render a single-question `multiSelect` as the existing checkbox `MultiQuestionForm`, gated by `allowSingleMultiSelect` (every provider except `claude-cli`).
- Mobile `MessageBubble` / `ChatView` / `SessionScreen`: same `allowSingleMultiSelect` plumbing.
- AskUserQuestion options are `{label, value:label}`, so the dashboard's value-keyed answersMap == labels == what `formatMultiSelectReinject` feeds claude.

### TUI startup robustness (groundwork for #5777)
- `claude-tui/pty-driver.js` `ensureCwdTrusted`: also pre-writes `hasCompletedProjectOnboarding` and requires both trust+onboarding flags on the early-return, closing the trusted-but-unonboarded hole that rendered claude's onboarding screen.
- `claude-tui-session.js`: opt-in (`CHROXY_TUI_DUMP_READY_TAIL=1`) one-shot ready-path tail dump for diagnosing startup interstitials.

## Testing
- ✅ **Smoke-tested live end-to-end through the desktop dashboard** — claude asked a multi-select, the hook denied + reinjected, the dashboard rendered checkboxes, the selection (`auth, logs`) reached claude, which replied "Got it — auth and logs selected." First time a multi-select AskUserQuestion was handled in the TUI provider.
- ✅ Server custom lints (state-file-path, opt-forwarding, logger-scoping, ws-index) green.
- ✅ Server suite green (the only local failures are the unrelated `service.test.js` :8765 live-daemon probe artifact).
- ✅ Dashboard tsc + 3683 tests; app tsc + multi-question render tests (9).

Closes #5776
Partially addresses #5777 (onboarding pre-write + diagnostics; the first-message submit-timing fix follows in a separate PR).