### PR TITLE
fix(dashboard): polish New Session modal + preserve input on outside click (#5774, #5779)

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -504,7 +504,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   }, [submit])
 
   return (
-    <Modal open={open} onClose={onClose} title="New Session">
+    <Modal open={open} onClose={onClose} title="New Session" closeOnBackdrop={false}>
       <input
         type="text"
         placeholder="Session name"

--- a/packages/dashboard/src/components/Modal.test.tsx
+++ b/packages/dashboard/src/components/Modal.test.tsx
@@ -73,6 +73,28 @@ describe('Modal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('does not close on backdrop click when closeOnBackdrop is false (#5779)', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal open onClose={onClose} title="Sticky" closeOnBackdrop={false}>
+        <p>Content</p>
+      </Modal>
+    )
+    fireEvent.click(screen.getByTestId('modal-overlay'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('still closes on Escape when closeOnBackdrop is false (#5779)', () => {
+    const onClose = vi.fn()
+    render(
+      <Modal open onClose={onClose} title="Sticky" closeOnBackdrop={false}>
+        <p>Content</p>
+      </Modal>
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
   it('does not close when modal content clicked', () => {
     const onClose = vi.fn()
     render(
@@ -285,6 +307,19 @@ describe('CreateSessionModal', () => {
     )
     fireEvent.click(screen.getByText('Cancel'))
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not close (or discard input) on backdrop click (#5779)', () => {
+    const onClose = vi.fn()
+    render(
+      <CreateSessionModal open onClose={onClose} onCreate={vi.fn()} />
+    )
+    fireEvent.change(screen.getByPlaceholderText('Session name'), { target: { value: 'In progress' } })
+    fireEvent.click(screen.getByTestId('modal-overlay'))
+    expect(onClose).not.toHaveBeenCalled()
+    // The typed value survives the stray outside click.
+    const nameInput = screen.getByPlaceholderText('Session name') as HTMLInputElement
+    expect(nameInput.value).toBe('In progress')
   })
 
   it('clears fields when opened', () => {

--- a/packages/dashboard/src/components/Modal.tsx
+++ b/packages/dashboard/src/components/Modal.tsx
@@ -9,12 +9,21 @@ export interface ModalProps {
   title: string
   children: ReactNode
   maxWidth?: string
+  /**
+   * When false, clicking the backdrop does NOT close the modal — only the
+   * Escape key and the modal's own controls can dismiss it (#5779). Defaults
+   * to true to preserve the existing click-outside-to-close behaviour for
+   * lightweight modals (confirm dialogs, QR sheets). Forms that hold
+   * in-progress user input should pass false so a stray outside click can't
+   * silently discard typed/selected values.
+   */
+  closeOnBackdrop?: boolean
 }
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
 
-export function Modal({ open, onClose, title, children, maxWidth }: ModalProps) {
+export function Modal({ open, onClose, title, children, maxWidth, closeOnBackdrop = true }: ModalProps) {
   const titleId = useId()
   const overlayRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
@@ -99,7 +108,7 @@ export function Modal({ open, onClose, title, children, maxWidth }: ModalProps) 
       className="modal-overlay"
       data-modal-overlay
       data-testid="modal-overlay"
-      onClick={onClose}
+      onClick={closeOnBackdrop ? onClose : undefined}
     >
       <div
         ref={contentRef}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5293,11 +5293,16 @@ button.sidebar-token-view-session-row:hover {
   min-width: 0;
 }
 
-.advanced-section .form-field--checkbox {
+/* #5774: checkbox + radio rows stack their controls vertically (one per line)
+   rather than competing as wrapping flex items on the row — otherwise the
+   row's flex-wrap squeezes each label down to its min-content width and the
+   text breaks one word per line. */
+.advanced-section .form-field--checkbox,
+.advanced-section .form-field[role='radiogroup'] {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 2px;
+  gap: 4px;
 }
 
 .advanced-section .checkbox-label {
@@ -5305,6 +5310,9 @@ button.sidebar-token-view-session-row:hover {
   align-items: center;
   gap: 6px;
   min-width: unset;
+  /* #5774: keep the control glued to the start of its label and let the label
+     text flow on natural lines instead of wrapping per word. */
+  align-self: stretch;
   cursor: pointer;
   color: var(--text-secondary);
   font-size: var(--text-sm);
@@ -5312,6 +5320,7 @@ button.sidebar-token-view-session-row:hover {
 
 .advanced-section .checkbox-label input[type='checkbox'] {
   cursor: pointer;
+  flex-shrink: 0;
 }
 
 /* #4244: tri-state radio group for skip-permissions. Stacks vertically with
@@ -5319,7 +5328,11 @@ button.sidebar-token-view-session-row:hover {
    the modal looks consistent. */
 .advanced-section .radio-label {
   display: flex;
-  align-items: center;
+  /* #5774: align the radio to the top of multi-line label text rather than
+     vertically centering, and stretch the row full-width so the label text
+     wraps naturally instead of one word per line. */
+  align-items: flex-start;
+  align-self: stretch;
   gap: 6px;
   min-width: unset;
   cursor: pointer;
@@ -5329,6 +5342,9 @@ button.sidebar-token-view-session-row:hover {
 
 .advanced-section .radio-label input[type='radio'] {
   cursor: pointer;
+  flex-shrink: 0;
+  /* Nudge the radio onto the first text line's baseline. */
+  margin-top: 2px;
 }
 
 .advanced-section .form-field-label {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5301,6 +5301,11 @@ button.sidebar-token-view-session-row:hover {
 .advanced-section .form-field[role='radiogroup'] {
   display: flex;
   flex-direction: column;
+  /* #5774: override the wrapping inherited from `.advanced-section .form-field`
+     above — once these are column stacks, leaving flex-wrap: wrap lets the
+     controls break into adjacent columns under a constrained height. Force a
+     single vertical stack. */
+  flex-wrap: nowrap;
   align-items: flex-start;
   gap: 4px;
 }


### PR DESCRIPTION
## Summary

Two fixes to the dashboard **New Session** modal (`CreateSessionModal`).

### #5774 — Advanced section labels wrapped one-word-per-line

The Advanced section's `Isolate filesystem (worktree)` checkbox and the three `Permission prompts` radio options rendered with their labels broken one word per line, with the controls misaligned. Root cause: `.advanced-section .form-field` is a `display: flex; flex-wrap: wrap` row, so the radiogroup's label span + each radio label competed as flex items and were squeezed down to their min-content width.

Fix (CSS only, `theme/components.css`):
- Stack the checkbox field **and** the permission-prompts radiogroup vertically (`flex-direction: column`), one control per line.
- Stretch each `.checkbox-label` / `.radio-label` full-width and `flex-shrink: 0` the input so labels flow on natural lines.
- Align the radio input to the top of multi-line label text instead of vertically centering.

### #5779 — backdrop click discarded typed input

Clicking outside the modal closed it via the shared `Modal`'s `onClick={onClose}` overlay handler, silently wiping the in-progress form (folder, provider, name).

Fix:
- Added an opt-in `closeOnBackdrop` prop to the shared `Modal` (defaults to `true`, preserving click-outside-to-close for ConfirmDialog / QrModal / PastedTextModal).
- `CreateSessionModal` now passes `closeOnBackdrop={false}` — only Escape and the explicit Cancel/Create controls dismiss it. Form state is unchanged by an outside click.

## Tests

Added to `Modal.test.tsx` (matching existing style):
- `Modal`: backdrop click is a no-op when `closeOnBackdrop={false}`; Escape still closes.
- `CreateSessionModal`: backdrop click does not close and preserves a typed session name.

## Scope / verification

- All changes are inside `packages/dashboard/`.
- Per worktree constraints, `tsc` and `vitest` were **not** run locally (no node_modules in the worktree); the orchestrator runs typecheck + tests centrally before merge. The #5774 fix is CSS-only (no visual regression tests exist for the modal — the layout change should ideally be eyeballed in a browser + Tauri webview).

Closes #5774
Closes #5779