### PR TITLE
fix(dashboard): unwrap tool-result JSON in the Output tab (#5778)

### DIFF
--- a/packages/dashboard/src/lib/tool-result-text.test.ts
+++ b/packages/dashboard/src/lib/tool-result-text.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { unwrapToolResultText } from './tool-result-text'
+
+describe('unwrapToolResultText (#5778)', () => {
+  it('passes plain strings through unchanged', () => {
+    expect(unwrapToolResultText('total 0\ndrwxr-xr-x')).toBe('total 0\ndrwxr-xr-x')
+  })
+
+  it('unwraps a stdout/stderr JSON envelope to stdout text', () => {
+    const envelope = JSON.stringify({
+      stdout: 'total 0\ndrwxr-xr-x@ 2 blamechris staff 64 Jun 14',
+      stderr: '',
+      interrupted: false,
+    })
+    expect(unwrapToolResultText(envelope)).toBe('total 0\ndrwxr-xr-x@ 2 blamechris staff 64 Jun 14')
+  })
+
+  it('appends stderr after stdout when both are present', () => {
+    const envelope = JSON.stringify({ stdout: 'out line', stderr: 'err line' })
+    expect(unwrapToolResultText(envelope)).toBe('out line\nerr line')
+  })
+
+  it('renders stderr alone when stdout is empty', () => {
+    const envelope = JSON.stringify({ stdout: '', stderr: 'boom' })
+    expect(unwrapToolResultText(envelope)).toBe('boom')
+  })
+
+  it('leaves JSON objects without stdout/stderr untouched', () => {
+    const json = JSON.stringify({ foo: 'bar' })
+    expect(unwrapToolResultText(json)).toBe(json)
+  })
+
+  it('falls back to the original string on invalid JSON', () => {
+    expect(unwrapToolResultText('{not valid json')).toBe('{not valid json')
+  })
+
+  it('does not munge plain text that merely starts with a brace', () => {
+    expect(unwrapToolResultText('{ this is just text }')).toBe('{ this is just text }')
+  })
+
+  it('leaves JSON arrays untouched', () => {
+    const arr = JSON.stringify([1, 2, 3])
+    expect(unwrapToolResultText(arr)).toBe(arr)
+  })
+})

--- a/packages/dashboard/src/lib/tool-result-text.test.ts
+++ b/packages/dashboard/src/lib/tool-result-text.test.ts
@@ -20,6 +20,18 @@ describe('unwrapToolResultText (#5778)', () => {
     expect(unwrapToolResultText(envelope)).toBe('out line\nerr line')
   })
 
+  it('does not double a trailing newline when stdout already ends in one', () => {
+    const envelope = JSON.stringify({ stdout: 'out line\n', stderr: 'err line' })
+    // Exactly one newline between the streams — no blank line.
+    expect(unwrapToolResultText(envelope)).toBe('out line\nerr line')
+  })
+
+  it('coerces a non-string input to a safe string', () => {
+    expect(unwrapToolResultText(null as unknown as string)).toBe('')
+    expect(unwrapToolResultText(undefined as unknown as string)).toBe('')
+    expect(unwrapToolResultText(42 as unknown as string)).toBe('42')
+  })
+
   it('renders stderr alone when stdout is empty', () => {
     const envelope = JSON.stringify({ stdout: '', stderr: 'boom' })
     expect(unwrapToolResultText(envelope)).toBe('boom')

--- a/packages/dashboard/src/lib/tool-result-text.ts
+++ b/packages/dashboard/src/lib/tool-result-text.ts
@@ -18,17 +18,23 @@ function streamsToText(obj: Record<string, unknown>): string | null {
   const hasStdout = typeof obj.stdout === 'string'
   const hasStderr = typeof obj.stderr === 'string'
   if (!hasStdout && !hasStderr) return null
-  const parts: string[] = []
-  if (hasStdout && obj.stdout !== '') parts.push(obj.stdout as string)
-  if (hasStderr && obj.stderr !== '') parts.push(obj.stderr as string)
-  return parts.join('\n')
+  const stdout = hasStdout && obj.stdout !== '' ? (obj.stdout as string) : ''
+  const stderr = hasStderr && obj.stderr !== '' ? (obj.stderr as string) : ''
+  if (!stdout) return stderr
+  if (!stderr) return stdout
+  // Append stderr directly after stdout, mirroring a real terminal. Only insert
+  // a separating newline when stdout doesn't already end in one, so shell output
+  // that ends with a trailing newline doesn't gain a spurious blank line.
+  const sep = stdout.endsWith('\n') ? '' : '\n'
+  return stdout + sep + stderr
 }
 
 /**
- * Unwrap a tool-result string for terminal-style display. Returns the
- * human-readable text; never throws.
+ * Unwrap a tool-result payload for terminal-style display. Returns the
+ * human-readable text; never throws. Accepts `unknown` because callers forward
+ * loosely-typed wire values — non-string inputs are coerced to a safe string.
  */
-export function unwrapToolResultText(resultText: string): string {
+export function unwrapToolResultText(resultText: unknown): string {
   if (typeof resultText !== 'string') return String(resultText ?? '')
 
   const trimmed = resultText.trim()

--- a/packages/dashboard/src/lib/tool-result-text.ts
+++ b/packages/dashboard/src/lib/tool-result-text.ts
@@ -1,0 +1,54 @@
+/**
+ * tool-result-text — unwrap a tool-result payload into human-readable text.
+ *
+ * #5778: the Output tab (simulated terminal) was dumping the raw JSON envelope
+ * of a tool result, e.g. `{"stdout":"total 0\n...","stderr":"",...}`, instead
+ * of the stdout text rendered as terminal lines. A tool result reaches the
+ * client as a plain string, but for shell-style tools (Bash, etc.) that string
+ * is itself a JSON-stringified `{ stdout, stderr, ... }` envelope.
+ *
+ * `unwrapToolResultText` normalises any of those shapes back to the text a
+ * terminal should show:
+ *   - already-plain strings pass through unchanged
+ *   - JSON objects with stdout/stderr render those streams (stderr appended)
+ *   - anything else falls back to a sensible string (never throws)
+ */
+
+function streamsToText(obj: Record<string, unknown>): string | null {
+  const hasStdout = typeof obj.stdout === 'string'
+  const hasStderr = typeof obj.stderr === 'string'
+  if (!hasStdout && !hasStderr) return null
+  const parts: string[] = []
+  if (hasStdout && obj.stdout !== '') parts.push(obj.stdout as string)
+  if (hasStderr && obj.stderr !== '') parts.push(obj.stderr as string)
+  return parts.join('\n')
+}
+
+/**
+ * Unwrap a tool-result string for terminal-style display. Returns the
+ * human-readable text; never throws.
+ */
+export function unwrapToolResultText(resultText: string): string {
+  if (typeof resultText !== 'string') return String(resultText ?? '')
+
+  const trimmed = resultText.trim()
+  // Only attempt a parse when it looks like a JSON object — avoids munging
+  // plain output that happens to start with a brace-like character.
+  if (!trimmed.startsWith('{')) return resultText
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return resultText
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return resultText
+  }
+
+  const text = streamsToText(parsed as Record<string, unknown>)
+  // Recognised stdout/stderr envelope → render the streams. Otherwise the
+  // object isn't a shell-result shape; leave the original string untouched.
+  return text === null ? resultText : text
+}

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3684,6 +3684,55 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  // #5778 — the Output tab (terminal preview) must show the unwrapped
+  // stdout/stderr text of a tool result, not the raw `{"stdout":...}` JSON
+  // envelope. These guard the wiring in handleToolResult, not just the helper.
+  describe('Output-tab tool_result unwrap (#5778)', () => {
+    it('forwards only the unwrapped stdout to appendTerminalData', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        }),
+      )
+      setStore(store)
+      const envelope = JSON.stringify({
+        stdout: 'total 0\ndrwxr-xr-x',
+        stderr: '',
+        interrupted: false,
+      })
+      handleMessage(
+        { type: 'tool_result', toolUseId: 'tu-1', result: envelope, sessionId: 's1' },
+        ctx() as any,
+      )
+      const writes = (store.getState() as any)._terminalWrites as string[]
+      expect(writes).toHaveLength(1)
+      // Dim-styled preview wraps the unwrapped text — assert no JSON braces leak.
+      expect(writes[0]).toContain('total 0\ndrwxr-xr-x')
+      expect(writes[0]).not.toContain('"stdout"')
+      expect(writes[0]).not.toContain('{')
+    })
+
+    it('passes a plain-string result through unchanged', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        { type: 'tool_result', toolUseId: 'tu-2', result: 'plain output line', sessionId: 's1' },
+        ctx() as any,
+      )
+      const writes = (store.getState() as any)._terminalWrites as string[]
+      expect(writes).toHaveLength(1)
+      expect(writes[0]).toContain('plain output line')
+    })
+  })
+
   // Regression for #3171: when the Agent SDK shuts down abnormally, agent_idle
   // can fire without a closing stream_end/result. Pre-#3171 the only paths that
   // cleared streamingMessageId mid-turn were stream_end, result, disconnect, or

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -159,6 +159,7 @@ import {
 import { filterThinking, nextMessageId } from './utils';
 import { calculateCost } from '../lib/model-pricing';
 import { CLIENT_ESTIMATED_COST_PROVIDERS } from '../lib/client-estimated-cost-providers';
+import { unwrapToolResultText } from '../lib/tool-result-text';
 import type {
   ChatMessage,
   ConnectionContext,
@@ -2051,10 +2052,13 @@ function handleToolResult(msg: Record<string, unknown>, get: MsgGet, set: MsgSet
   const result = sharedToolResult(msg, get().activeSessionId);
   if (!result) return;
   // Forward tool result to terminal view (dashboard-only side effect).
+  // #5778: unwrap the result envelope first so the Output tab shows the
+  // stdout/stderr text rather than the raw `{"stdout":...}` JSON.
   if (result.resultText) {
-    const preview = result.resultText.length > 500
-      ? result.resultText.slice(0, 500) + '...'
-      : result.resultText;
+    const text = unwrapToolResultText(result.resultText);
+    const preview = text.length > 500
+      ? text.slice(0, 500) + '...'
+      : text;
     get().appendTerminalData(`\x1b[2m${preview}\x1b[0m\r\n`);
   }
   const targetId = result.sessionId;


### PR DESCRIPTION
## Problem

The Output tab (the simulated terminal view of session output) rendered the **raw JSON envelope** of a tool result, e.g.:

```
{"stdout":"total 0\ndrwxr-xr-x@ 2 blamechris staff 64 Jun 14 ...","stderr":"",...}
```

instead of the clean stdout text rendered as terminal lines. For shell-style tools (Bash, etc.) the tool-result string is itself a JSON-stringified `{ stdout, stderr, ... }` envelope, and `handleToolResult` forwarded that string verbatim to `appendTerminalData`.

## Fix

New pure helper `packages/dashboard/src/lib/tool-result-text.ts` → `unwrapToolResultText()`:

- **plain strings** pass through unchanged
- **`{ stdout, stderr }` envelopes** → render the streams (stdout, with stderr appended); empty streams omitted
- **any other shape** (non-envelope object, JSON array, invalid JSON, non-string) → falls back to the original string, never throws

Wired into the terminal-write side effect in `handleToolResult` (message-handler.ts). The chat-side `ToolBubble` and `result.resultText`/`toolResult` history are untouched — only the Output tab's terminal preview is affected.

## Tests

`tool-result-text.test.ts` covers plain text, stdout-only, stdout+stderr, stderr-only, non-envelope objects, invalid JSON, brace-leading plain text, and arrays.

## Verification notes

This worktree has no node_modules (workspace hoist), so I could not run `tsc`/`vitest` locally — central verification needed. The helper is pure and self-contained; risk is low. The only behavioral surface beyond the helper is the single call site on the terminal preview path.

Closes #5778