### PR TITLE
fix(dashboard): auto-scroll chat to bottom on send + follow when near bottom (#5780)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -401,8 +401,9 @@ export function App() {
   const retryConnection = useConnectionStore(s => s.retryConnection)
   const sendInput = useConnectionStore(s => s.sendInput)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
-  // #5780 — nonce bumped on explicit "jump to latest" user actions (send,
-  // approve, answer). Passed to every ChatView so it snaps to the bottom even
+  // #5780 — nonce bumped on the explicit "jump to latest" user action. Today
+  // that is send (handleSend); wiring approve/answer is tracked in #5786.
+  // Passed to every ChatView so it snaps to the bottom even
   // when the user had scrolled up to read history — see ChatView's
   // scrollToBottomSignal effect.
   const [scrollToBottomSignal, setScrollToBottomSignal] = useState(0)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -401,6 +401,11 @@ export function App() {
   const retryConnection = useConnectionStore(s => s.retryConnection)
   const sendInput = useConnectionStore(s => s.sendInput)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
+  // #5780 — nonce bumped on explicit "jump to latest" user actions (send,
+  // approve, answer). Passed to every ChatView so it snaps to the bottom even
+  // when the user had scrolled up to read history — see ChatView's
+  // scrollToBottomSignal effect.
+  const [scrollToBottomSignal, setScrollToBottomSignal] = useState(0)
   const evaluateDraft = useConnectionStore(s => s.evaluateDraft)
   const sendPermissionResponse = useConnectionStore(s => s.sendPermissionResponse)
   const switchSession = useConnectionStore(s => s.switchSession)
@@ -1375,6 +1380,9 @@ export function App() {
     const blockMap = new Map(blocks.map(b => [b.id, b.content]))
     const expanded = blockMap.size > 0 ? expandPasteMarkers(text, blockMap) : text
     sendInput(expanded, wire.length > 0 ? wire : undefined)
+    // #5780 — sending is an explicit "show me the latest" action: snap the
+    // chat to the bottom even if the user had scrolled up before typing.
+    setScrollToBottomSignal(n => n + 1)
     setFileAttachments([])
     setImageAttachments([])
     // Clear draft + pasted-text blocks for the session that sent the message.
@@ -1957,6 +1965,7 @@ export function App() {
                         isStreaming={streamingMessageId !== null}
                         isBusy={!isIdle}
                         renderMessage={renderMessage}
+                        scrollToBottomSignal={scrollToBottomSignal}
                       />
                     }
                     second={
@@ -1998,6 +2007,7 @@ export function App() {
                         isBusy={!isIdle}
                         renderMessage={renderMessage}
                         hidden={viewMode !== 'chat'}
+                        scrollToBottomSignal={scrollToBottomSignal}
                       />
                     </div>
                     <div

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -162,6 +162,56 @@ describe('ChatView', () => {
     vi.useRealTimers()
   })
 
+  it('snaps to bottom when scrollToBottomSignal bumps, even if scrolled up (#5780)', async () => {
+    vi.useFakeTimers()
+    const messages = makeMessages(3)
+    const { rerender } = render(
+      <ChatView messages={messages} isStreaming={false} scrollToBottomSignal={0} />,
+    )
+    const container = screen.getByTestId('chat-messages')
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+    await act(() => { vi.advanceTimersByTime(50) })
+
+    // User scrolls up to read history — the scroll-to-bottom button appears
+    // and the count-change auto-follow would now leave them in place.
+    container.scrollTop = 100
+    await act(() => { fireEvent.scroll(container) })
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+    // User sends a message: the parent bumps the signal. Even though they were
+    // scrolled up, the explicit action snaps the view back to the bottom and
+    // clears the scrolled-up flag (button disappears).
+    rerender(<ChatView messages={makeMessages(4)} isStreaming={false} scrollToBottomSignal={1} />)
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(1000)
+    expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it('does not scroll on the initial scrollToBottomSignal value (#5780)', async () => {
+    vi.useFakeTimers()
+    const messages = makeMessages(3)
+    render(<ChatView messages={messages} isStreaming={false} scrollToBottomSignal={7} />)
+    const container = screen.getByTestId('chat-messages')
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+    await act(() => { vi.advanceTimersByTime(50) })
+
+    // Scroll up; the initial signal value must NOT pull the view back down
+    // (only a genuine change to the nonce triggers the jump).
+    container.scrollTop = 100
+    await act(() => { fireEvent.scroll(container) })
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(100)
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
   it('preserves scrolled-up position when streaming ends mid-history-read (#4652)', async () => {
     // Repro for the AskUserQuestion scenario: streaming flips to false
     // when the question arrives. Previously, the streaming-end effect

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -134,6 +134,20 @@ export interface ChatViewProps {
    * hidden window because the component instance never unmounts.
    */
   hidden?: boolean
+  /**
+   * #5780 — monotonically-increasing nonce the parent bumps when the user
+   * performs an explicit "jump to the latest" action (sending a message,
+   * approving a plan, answering a question). Unlike the count-change
+   * auto-follow — which deliberately leaves a scrolled-up reader in place —
+   * a bump here ALWAYS snaps the view to the bottom and clears
+   * `userScrolledUp`, because the user just acted on the conversation and
+   * expects to see their input plus the incoming response. A nonce (rather
+   * than an imperative ref handle) keeps ChatView's memo wrapper intact and
+   * is robust to rapid sends: each distinct value fires the effect exactly
+   * once. The initial value is ignored (the mount effect already lands at
+   * the bottom); only changes trigger a scroll.
+   */
+  scrollToBottomSignal?: number
 }
 
 const TYPE_CLASS: Record<string, string> = {
@@ -145,7 +159,14 @@ const TYPE_CLASS: Record<string, string> = {
   tool_use: 'tool',
 }
 
-const SCROLL_THRESHOLD = 60
+/**
+ * #5780 — "near the bottom" tolerance (px). A new incoming message/tool result
+ * auto-follows ONLY when the viewport is within this distance of the bottom, so
+ * a user who has scrolled up to read history keeps their position. Widened from
+ * 60 to 100 to match the standard chat affordance (a small manual nudge off the
+ * very bottom still counts as "following the conversation").
+ */
+const SCROLL_THRESHOLD = 100
 
 /**
  * #5561 — fallback `gap` between rows in `.chat-messages` (theme/components.css).
@@ -247,7 +268,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBottomSignal }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
@@ -505,6 +526,30 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
       })
     }
   }, [dedupedMessages.length, userScrolledUp, isBusy])
+
+  // #5780 — explicit "jump to latest" on a user action (send / approve /
+  // answer). Watches the parent's `scrollToBottomSignal` nonce: whenever it
+  // changes we force the view to the bottom and clear `userScrolledUp`, even if
+  // the user had scrolled up to read history. This is the deliberate exception
+  // to the count-change auto-follow above — sending a message is the user
+  // asking to see their input plus the response, so we always follow. Seeded
+  // with the initial value so the first render (and mount) is a no-op; only a
+  // genuine bump scrolls. Robust to rapid sends: each distinct nonce fires
+  // once, and the RAF defers the write until after the new row has laid out so
+  // `scrollHeight` already includes it.
+  const lastScrollSignalRef = useRef(scrollToBottomSignal)
+  useEffect(() => {
+    if (scrollToBottomSignal === lastScrollSignalRef.current) return
+    lastScrollSignalRef.current = scrollToBottomSignal
+    setUserScrolledUp(false)
+    requestAnimationFrame(() => {
+      const el = containerRef.current
+      if (!el) return
+      programmaticScrollRef.current = true
+      el.scrollTop = el.scrollHeight
+      requestAnimationFrame(() => { programmaticScrollRef.current = false })
+    })
+  }, [scrollToBottomSignal])
 
   // During streaming, continuously scroll to bottom via RAF
   useEffect(() => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -136,9 +136,9 @@ export interface ChatViewProps {
   hidden?: boolean
   /**
    * #5780 — monotonically-increasing nonce the parent bumps when the user
-   * performs an explicit "jump to the latest" action (sending a message,
-   * approving a plan, answering a question). Unlike the count-change
-   * auto-follow — which deliberately leaves a scrolled-up reader in place —
+   * performs an explicit "jump to the latest" action. Today that is sending a
+   * message; wiring approve/answer flows is tracked in #5786. Unlike the
+   * count-change auto-follow — which deliberately leaves a scrolled-up reader in place —
    * a bump here ALWAYS snaps the view to the bottom and clears
    * `userScrolledUp`, because the user just acted on the conversation and
    * expects to see their input plus the incoming response. A nonce (rather
@@ -527,8 +527,9 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
     }
   }, [dedupedMessages.length, userScrolledUp, isBusy])
 
-  // #5780 — explicit "jump to latest" on a user action (send / approve /
-  // answer). Watches the parent's `scrollToBottomSignal` nonce: whenever it
+  // #5780 — explicit "jump to latest" on a user action (currently send;
+  // approve/answer wiring tracked in #5786). Watches the parent's
+  // `scrollToBottomSignal` nonce: whenever it
   // changes we force the view to the bottom and clear `userScrolledUp`, even if
   // the user had scrolled up to read history. This is the deliberate exception
   // to the count-change auto-follow above — sending a message is the user


### PR DESCRIPTION
## Summary

Fixes #5780 — the dashboard chat did not scroll to the bottom when the user sent a message; newly sent/received content appeared below the fold and the user had to drag the scrollbar manually.

## Changes

- **`scrollToBottomSignal` prop on `ChatView`** — a monotonically-increasing nonce the parent bumps on explicit "jump to latest" user actions. When it changes, ChatView always snaps to the bottom and clears `userScrolledUp`, even if the user had scrolled up to read history. A nonce (rather than an imperative ref handle) keeps the existing memo wrapper intact and is robust to rapid sends. The initial value is ignored — only changes scroll.
- **`App.handleSend` bumps the signal** after `sendInput`, so sending follows the user's input + the incoming response.
- **Near-bottom auto-follow threshold widened 60px → 100px** (`SCROLL_THRESHOLD`). New incoming messages/tool results still auto-follow ONLY when the viewport is within this distance of the bottom — a user reading history is left in place (existing `#4652` behaviour, preserved).
- **Tests** — added two ChatView tests: the signal-driven snap (fires even when scrolled up) and the ignored-initial-value case.

## Behaviour preserved

- Initial mount / session-switch still lands at the bottom (existing mount effect).
- Streaming RAF auto-scroll and the "leave a scrolled-up reader in place on new messages" path (#4652) are unchanged.
- The system tab's ChatView intentionally does not receive the send signal.

Closes #5780
