### PR TITLE
fix(server): nudge the first-message submit on a freshly-spawned TUI (#5777)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1078,6 +1078,12 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
+    // #5777 (#5788): cancel a pending first-turn submit nudge directly here.
+    // _onPtyGone is the one teardown path that does NOT route through
+    // _clearFirstOutputWatchdog, so without this an armed nudge would only be
+    // saved by the tick's !_isBusy guard — fragile. Clear before the
+    // _destroying early-return so it runs on both the destroy and respawn paths.
+    this._clearFirstTurnSubmitNudge()
     if (this._destroying) return
     // #5311 review — the socket 'close'/'error' paths have no exit info, so
     // render a clear "unknown" instead of a bare "code=undefined". The

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -424,6 +424,14 @@ export class ClaudeTuiSession extends BaseSession {
     // don't re-arm the first-output timer. Reset to false on each new
     // turn via `_resetFirstOutputWatchdogForTurn` (sendMessage entry path).
     this._firstOutputDisarmed = false
+    // #5777: first-message submit nudge. A freshly-spawned TUI can report
+    // status:idle (ready) before its composer actually accepts the submit, so
+    // the FIRST message's trailing \r lands on a not-yet-interactive prompt and
+    // the text sits unsent until a second message nudges it (the manual "go"
+    // workaround). On the first turn only, a one-shot timer re-sends a bare \r
+    // if no hook output has arrived within the window. 0 disables.
+    this._firstTurnSubmitNudgeMs = ClaudeTuiSession.FIRST_TURN_SUBMIT_NUDGE_MS
+    this._firstTurnSubmitNudgeTimer = null
     // #5431: incremental transcript scanner for outstanding background work
     // (run_in_background Bash/Agent, Monitor, ScheduleWakeup). Created
     // lazily by getBackgroundTaskSnapshot() once the per-PID session file
@@ -670,6 +678,16 @@ export class ClaudeTuiSession extends BaseSession {
   // dashboard chip surfaces within a minute or two of a real stall so
   // the user can retry without waiting for the 2h hard cap.
   static get FIRST_OUTPUT_TIMEOUT_MS() { return 90 * 1000 }
+
+  // #5777: first-turn submit-nudge interval (ms) and max attempts. A freshly-
+  // spawned TUI can report ready before its composer accepts the submit, so the
+  // first message's \r is dropped. If no hook output arrives within this window
+  // the nudge re-sends a bare \r. 1.5s is long enough that a normally-submitted
+  // turn has usually produced its first hook (so the nudge no-ops), short enough
+  // that a real wedge unsticks in seconds instead of waiting for the 90s
+  // first-output watchdog. Two attempts (≈1.5s, ≈3s) then defer to the watchdog.
+  static get FIRST_TURN_SUBMIT_NUDGE_MS() { return 1500 }
+  static get FIRST_TURN_SUBMIT_NUDGE_MAX_ATTEMPTS() { return 2 }
 
   // #4276: per-char throttling is O(N) blocking latency. For huge
   // prompts (pasted file contents, JSON dumps) the cumulative cost
@@ -1912,6 +1930,17 @@ export class ClaudeTuiSession extends BaseSession {
     // hard fires after the full window of silence → force-clear + error.
     this._armResultTimeout()
 
+    // #5777: on the FIRST turn of the session, schedule the submit nudge. A
+    // freshly-spawned TUI sometimes reports ready before its composer accepts
+    // the trailing \r, so the prompt sits typed-but-unsent. If no hook output
+    // arrives within the window, _scheduleFirstTurnSubmitNudge re-sends a bare
+    // \r (a no-op on an already-submitted/empty composer, a submit on a stuck
+    // one). Later turns don't wedge — the composer is warm — so this is gated
+    // to the first turn to keep the blast radius minimal.
+    if (this._messageCounter === 1) {
+      this._scheduleFirstTurnSubmitNudge(messageId)
+    }
+
     // Poll the sink dir for new hook files. mktemp-named filenames make each
     // turn's Stop / Pre / Post events distinct from previous turns'; the
     // session-level _consumedFiles Set ensures we never re-process a file
@@ -2657,6 +2686,12 @@ export class ClaudeTuiSession extends BaseSession {
       clearTimeout(this._firstOutputTimeout)
       this._firstOutputTimeout = null
     }
+    // #5777: first output (or any teardown) means the submit landed / the turn
+    // is over — cancel any pending first-turn submit nudge so a late \r can't
+    // land on an idle composer. _clearFirstOutputWatchdog is called from the
+    // hook-drain loop on first consumed event and from every teardown path, so
+    // this one site covers all of them.
+    this._clearFirstTurnSubmitNudge()
     this._firstOutputDisarmed = true
   }
 
@@ -2669,6 +2704,59 @@ export class ClaudeTuiSession extends BaseSession {
    */
   _resetFirstOutputWatchdogForTurn() {
     this._firstOutputDisarmed = false
+  }
+
+  /**
+   * #5777: schedule the first-turn submit nudge. A freshly-spawned claude TUI
+   * can write status:idle (readiness is a session-FILE check, decoupled from
+   * what's rendered) before its composer is actually interactive, so the first
+   * message's trailing \r is swallowed and the prompt sits typed-but-unsent
+   * until a later keystroke submits it (the manual "go" workaround). This
+   * re-sends a bare \r after the nudge window if no hook output has been
+   * consumed yet (`!_firstOutputDisarmed`). A bare \r is a no-op on an
+   * already-submitted (empty) composer and a submit on a stuck one, so it is
+   * safe either way. Retries up to FIRST_TURN_SUBMIT_NUDGE_MAX_ATTEMPTS, then
+   * defers to the longer first-output watchdog. Cancelled by
+   * _clearFirstOutputWatchdog (first output / any teardown / destroy).
+   *
+   * @param {string} messageId
+   */
+  _scheduleFirstTurnSubmitNudge(messageId) {
+    if (!(this._firstTurnSubmitNudgeMs > 0)) return
+    this._clearFirstTurnSubmitNudge()
+    let attempts = 0
+    const tick = () => {
+      this._firstTurnSubmitNudgeTimer = null
+      // Nothing to nudge if the turn ended/aborted, the PTY died, the composer
+      // is gone, or first output already arrived (the submit landed).
+      if (!this._isBusy) return
+      if (this._activeTurn?.aborted) return
+      if (this._ptyExited || !this._term) return
+      if (this._firstOutputDisarmed) return
+      attempts += 1
+      try {
+        this._term.write('\r')
+        ;(this._log || log).info(`first-turn submit nudge #${attempts} (#5777, msg=${messageId}) — no hook output yet, re-sent \\r`)
+      } catch (err) {
+        ;(this._log || log).warn(`first-turn submit nudge write failed (#5777, msg=${messageId}): ${err.message}`)
+        return
+      }
+      if (attempts < ClaudeTuiSession.FIRST_TURN_SUBMIT_NUDGE_MAX_ATTEMPTS) {
+        this._firstTurnSubmitNudgeTimer = setTimeout(tick, this._firstTurnSubmitNudgeMs)
+      }
+    }
+    this._firstTurnSubmitNudgeTimer = setTimeout(tick, this._firstTurnSubmitNudgeMs)
+  }
+
+  /**
+   * #5777: cancel any pending first-turn submit nudge. Idempotent and safe to
+   * call when no nudge was ever scheduled.
+   */
+  _clearFirstTurnSubmitNudge() {
+    if (this._firstTurnSubmitNudgeTimer) {
+      clearTimeout(this._firstTurnSubmitNudgeTimer)
+      this._firstTurnSubmitNudgeTimer = null
+    }
   }
 
   _handleInactivityWarning() {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3623,6 +3623,72 @@ describe('ClaudeTuiSession', () => {
   // _armResultTimeout() time and disarms on the first consumed hook
   // event, surfacing a stream_stall with the same dashboard chip the
   // inter-stream watchdog uses so the user can retry within minutes.
+  describe('first-turn submit nudge (#5777)', () => {
+    // A freshly-spawned TUI can report ready before its composer accepts the
+    // submit, so the first message's \r is dropped. _scheduleFirstTurnSubmitNudge
+    // re-sends a bare \r if no hook output arrives within the window.
+    function nudgeSession(overrides = {}) {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      s._isBusy = true
+      s._ptyExited = false
+      s._firstOutputDisarmed = false
+      s._activeTurn = { startedAt: Date.now(), aborted: false }
+      s._firstTurnSubmitNudgeMs = 20
+      const writes = []
+      s._term = { write: (b) => writes.push(b), kill: () => {} }
+      Object.assign(s, overrides)
+      s._termWrites = writes
+      return s
+    }
+
+    it('re-sends a bare \\r when no hook output arrives within the window', async () => {
+      session = nudgeSession()
+      session._scheduleFirstTurnSubmitNudge('m1')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.ok(session._termWrites.includes('\r'), 'bare \\r re-sent to nudge the submit')
+    })
+
+    it('does NOT nudge once first output arrived (disarm clears the timer)', async () => {
+      session = nudgeSession()
+      session._scheduleFirstTurnSubmitNudge('m1')
+      // First consumed hook → _clearFirstOutputWatchdog also cancels the nudge.
+      session._clearFirstOutputWatchdog()
+      assert.equal(session._firstTurnSubmitNudgeTimer, null, 'nudge timer cancelled on first output')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.equal(session._termWrites.length, 0, 'no \\r written after first output')
+    })
+
+    it('stops after FIRST_TURN_SUBMIT_NUDGE_MAX_ATTEMPTS', async () => {
+      session = nudgeSession()
+      session._scheduleFirstTurnSubmitNudge('m1')
+      await new Promise((r) => setTimeout(r, 120))
+      const crs = session._termWrites.filter((w) => w === '\r').length
+      assert.equal(crs, ClaudeTuiSession.FIRST_TURN_SUBMIT_NUDGE_MAX_ATTEMPTS, 'caps at MAX_ATTEMPTS then defers to the first-output watchdog')
+    })
+
+    it('does not nudge when the PTY has exited or the turn aborted', async () => {
+      session = nudgeSession({ _ptyExited: true })
+      session._scheduleFirstTurnSubmitNudge('m1')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.equal(session._termWrites.length, 0, 'no \\r when PTY exited')
+
+      const s2 = nudgeSession()
+      s2._activeTurn.aborted = true
+      s2._scheduleFirstTurnSubmitNudge('m2')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.equal(s2._termWrites.length, 0, 'no \\r when turn aborted')
+      s2.destroy?.()
+    })
+
+    it('is disabled when _firstTurnSubmitNudgeMs <= 0', async () => {
+      session = nudgeSession({ _firstTurnSubmitNudgeMs: 0 })
+      session._scheduleFirstTurnSubmitNudge('m1')
+      assert.equal(session._firstTurnSubmitNudgeTimer, null, 'no timer scheduled when disabled')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.equal(session._termWrites.length, 0, 'no \\r when disabled')
+    })
+  })
+
   describe('first-output watchdog (#4732)', () => {
     it('fires after _firstOutputTimeoutMs of zero hook events, clears busy state, emits stream_stall', async () => {
       session = new ClaudeTuiSession({

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3680,6 +3680,26 @@ describe('ClaudeTuiSession', () => {
       s2.destroy?.()
     })
 
+    it('cancels a live armed nudge on PTY death (_onPtyGone) (#5788)', async () => {
+      session = nudgeSession({ _destroying: true })  // _destroying → _onPtyGone returns early after clearing
+      session._scheduleFirstTurnSubmitNudge('m1')
+      assert.ok(session._firstTurnSubmitNudgeTimer, 'nudge armed')
+      session._onPtyGone({ exitCode: 1 }, 'test')
+      assert.equal(session._firstTurnSubmitNudgeTimer, null, 'nudge cancelled by _onPtyGone')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.equal(session._termWrites.length, 0, 'no \\r after PTY death')
+    })
+
+    it('cancels a live armed nudge on destroy() (via _clearFirstOutputWatchdog)', async () => {
+      session = nudgeSession()
+      session._scheduleFirstTurnSubmitNudge('m1')
+      assert.ok(session._firstTurnSubmitNudgeTimer, 'nudge armed')
+      session.destroy()
+      assert.equal(session._firstTurnSubmitNudgeTimer, null, 'nudge cancelled by destroy()')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.equal(session._termWrites.length, 0, 'no \\r after destroy')
+    })
+
     it('is disabled when _firstTurnSubmitNudgeMs <= 0', async () => {
       session = nudgeSession({ _firstTurnSubmitNudgeMs: 0 })
       session._scheduleFirstTurnSubmitNudge('m1')


### PR DESCRIPTION
## Problem (#5777)

The first message sent to a freshly-spawned `claude-tui` session frequently doesn't submit. TUI readiness is a session-**file** `status:idle` check, decoupled from what the TUI actually renders — claude can report ready before its composer is interactive, so the first message's trailing `\r` is swallowed and the prompt sits typed-but-unsent. The workaround during smoke-testing was to send a second message ("go") to nudge it, which corrupts the intended first prompt.

Confirmed from daemon logs: the first turn's write completes (`writeCompleted=true`) but no hook output arrives; a later keystroke submits the queued text.

## Fix

On the **first turn only**, schedule a one-shot submit nudge after the prompt write:
- If no hook output has been consumed within `FIRST_TURN_SUBMIT_NUDGE_MS` (1.5s, up to 2 attempts ≈1.5s/3s), re-send a bare `\r`.
- A bare `\r` is a **no-op** on an already-submitted (empty) composer and a **submit** on a stuck one — safe either way. A normally-submitted turn has usually produced its first hook by 1.5s, so the nudge no-ops.
- Gated to the first turn (later turns don't wedge — the composer is warm) to keep the blast radius minimal.
- Cancelled by `_clearFirstOutputWatchdog` (first output / any teardown / destroy), then defers to the existing 90s first-output watchdog for a true stall.

## Testing
- 5 new unit tests: re-send on silence, disarm cancels the nudge, `MAX_ATTEMPTS` cap, no-nudge on exited/aborted turn, disabled at `_firstTurnSubmitNudgeMs=0`.
- Full `claude-tui-session.test.js` suite green (307/307); custom server lints green.

Closes #5777