### PR TITLE
cleanup(server): remove dead _multiQuestionSubmitAt forensic timing (#5790)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -394,17 +394,6 @@ export class ClaudeTuiSession extends BaseSession {
     // answering / stalling one no longer disarms the others. Cleared per-id on
     // PostToolUse and cleared wholesale on the turn-ending paths + destroy().
     this._askUserQuestionWatchdogs = new Map()
-    // #4884: forensic timing for the defensive trailing '\r' added in
-    // #4867 / #4886 — record the wall-clock at which Submit-'1' is written
-    // to the PTY for each multi-question form, keyed by toolUseId. On the
-    // matching PostToolUse we log the delta at INFO so live mixed-form
-    // submissions generate evidence that the trailing '\r' (which lands
-    // ~1ms after Submit-'1' on the mixed path) is harmless. Map (not
-    // single field) to mirror _pendingUserAnswers — parallel AskUserQuestion
-    // tool_use blocks in one turn each get an independent submit-time entry.
-    // Entries are pruned when the matching PostToolUse fires OR when the
-    // teardown / watchdog stall path clears the form.
-    this._multiQuestionSubmitAt = new Map()
     // #4732: effective pre-first-output timeout in ms. Distinct from
     // _streamStallTimeoutMs (#4638) — that watchdog only re-arms BETWEEN
     // hook events, so a turn where claude TUI accepts the prompt write
@@ -500,21 +489,12 @@ export class ClaudeTuiSession extends BaseSession {
   _pendingUserAnswers_clearAll() {
     this._pendingUserAnswers.clear()
     this._lastPendingAnswerToolUseId = null
-    // #4884: parallel cleanup so stale submit-timing entries don't leak
-    // when a teardown path wipes the pending answers (the forensic log
-    // only fires when PostToolUse arrives; if teardown won the race, the
-    // submit-time entry would otherwise sit there until destroy()).
-    if (this._multiQuestionSubmitAt) this._multiQuestionSubmitAt.clear()
   }
 
   /** Internal: drop a specific pending answer entry (PostToolUse cleanup). */
   _clearPendingAnswerByToolUseId(toolUseId) {
     if (!toolUseId) return
     this._pendingUserAnswers.delete(toolUseId)
-    // #4884: parallel cleanup of the submit-timing entry for the same
-    // toolUseId. Idempotent — no-op when the entry was already consumed
-    // by PostToolUse's delta log.
-    if (this._multiQuestionSubmitAt) this._multiQuestionSubmitAt.delete(toolUseId)
     if (this._lastPendingAnswerToolUseId === toolUseId) {
       // Advance the "most recent" pointer to whichever entry was set most
       // recently after the one we just removed (insertion-order via Map
@@ -2333,22 +2313,6 @@ export class ClaudeTuiSession extends BaseSession {
     // above stores the pending entry under THAT synthesized id. Gating
     // cleanup on `payload.tool_use_id` would skip the clear for those
     // builds and leak Map entries indefinitely.
-    // #4884: forensic timing for the defensive trailing '\r' (#4867 / #4886).
-    // If this PostToolUse matches a multi-question form we just drove,
-    // log the wall-clock from Submit-'1' write to PostToolUse arrival at
-    // INFO. The trailing '\r' is sent ~1ms after Submit-'1' (per-char
-    // throttle), so any "spurious empty-prompt activity" theory shows up
-    // as an outlier-large delta. After ~10 captured submissions show
-    // clean numbers, this log line can be downgraded to DEBUG. MUST run
-    // before _clearPendingAnswerByToolUseId below — that helper also
-    // clears _multiQuestionSubmitAt in lockstep with _pendingUserAnswers,
-    // so the timestamp would be gone by the time we read it.
-    if (toolName === 'AskUserQuestion' && toolUseId && this._multiQuestionSubmitAt.has(toolUseId)) {
-      const submitAt = this._multiQuestionSubmitAt.get(toolUseId)
-      this._multiQuestionSubmitAt.delete(toolUseId)
-      const deltaMs = this._nowMonotonic() - submitAt
-      ;(this._log || log).info(`AskUserQuestion multi-question: Submit→PostToolUse=${deltaMs}ms (tool=${toolUseId}) — forensic for #4884 trailing-'\\r' verification`)
-    }
     if (toolName === 'AskUserQuestion' && toolUseId) {
       this._clearPendingAnswerByToolUseId(toolUseId)
     }


### PR DESCRIPTION
## Summary
Finishes the dead-code sweep #5789 started. The `_multiQuestionSubmitAt` Map was fed **only** by `_writePtyMultiQuestionSequence` (deleted in #5789). With no writer left, the Map is permanently empty — the `.has()` guard in the PostToolUse path is always false and the #4884 forensic `Submit→PostToolUse` timing log is unreachable.

Surfaced by the SOLID/DRY swarm audit (2026-06-14), confirmed by all 6 agents against `main` @ 67d9fc0a3 (verified: pure inert dead code, no behavioral impact).

## Changes (`claude-tui-session.js`)
- Remove the field alloc (was `:407`) + its comment block
- Remove the two lockstep clear/delete sites in `_pendingUserAnswers_clearAll` and `_clearPendingAnswerByToolUseId`
- Remove the unreachable #4884 forensic block in the PostToolUse path

## Verification
- `grep` confirms zero remaining references (`_multiQuestionSubmitAt`, `#4884`, `Submit→PostToolUse`)
- `claude-tui-session.test.js`: **274/274 pass**
- Custom server lints (logger-session-scoping, session-opt-forwarding, tests-state-file-path) green

Closes #5790