### PR TITLE
refactor(store-core): hoist AskUserQuestion provider predicates + fix docker-cli mishandling (#5795)

### DIFF
--- a/packages/app/src/constants/providers.ts
+++ b/packages/app/src/constants/providers.ts
@@ -6,6 +6,8 @@ export {
   PROVIDER_LABELS,
   getProviderLabel,
   getProviderInfo,
+  providerSupportsMultiQuestion,
+  providerSupportsSingleMultiSelect,
 } from '@chroxy/store-core';
 
 export type {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -25,7 +25,7 @@ import type { SessionIntervention } from '@chroxy/store-core';
 // 'freeformText' in`) with the same 5-condition guard the store layer
 // uses, so widening `SelectOptionValue` to a third object shape can't
 // silently misroute it as freeform.
-import { isFreeformAnswer } from '@chroxy/store-core';
+import { isFreeformAnswer, providerSupportsMultiQuestion, providerSupportsSingleMultiSelect } from '@chroxy/store-core';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
@@ -260,21 +260,18 @@ export function SessionScreen() {
       permissionModeSwitchSupported: caps?.permissionModeSwitch !== false,
     };
   }, [availableProviders, activeSessionProvider]);
+  // #5795 — provider capability lives in @chroxy/store-core (single source of
+  // truth, keyed off the registered provider `type`), shared with the
+  // dashboard so the two clients can't drift. Multi-QUESTION forms need a
+  // structured answersMap (SDK family); a single multiSelect also renders for
+  // claude-tui via the #5776 reinject path. The plain CLI providers
+  // (claude-cli, docker-cli) are excluded — single text answer, no answersMap.
   const allowMultiQuestion = useMemo(
-    () =>
-      activeSessionProvider != null &&
-      activeSessionProvider !== 'claude-tui' &&
-      activeSessionProvider !== 'claude-cli',
+    () => providerSupportsMultiQuestion(activeSessionProvider),
     [activeSessionProvider],
   );
-  // #5776 — a single-question multiSelect renders as a checkbox form on every
-  // provider that can consume a structured/text multi-answer: the SDK family
-  // AND claude-tui (via the multi-select reinject path). Only claude-cli is
-  // excluded — its respondToQuestion takes a single text answer with no
-  // answersMap channel. (= everything except claude-cli, which is
-  // allowMultiQuestion || claude-tui.)
   const allowSingleMultiSelect = useMemo(
-    () => activeSessionProvider != null && activeSessionProvider !== 'claude-cli',
+    () => providerSupportsSingleMultiSelect(activeSessionProvider),
     [activeSessionProvider],
   );
   const viewingCachedSession = useConnectionStore((s) => s.viewingCachedSession);

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import {
   formatTokensCompact,
   expandPasteMarkers,
   resolveContextWindow,
+  providerSupportsMultiQuestion,
   type SessionInfo,
 } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
@@ -255,8 +256,11 @@ export function App() {
   // submits per-question answers (including multi-select arrays) on the
   // widened wire. Reuses the `activeSessionProvider` selector declared
   // above (#4603) so we don't re-derive the same value.
+  // #5795 — provider capability lives in @chroxy/store-core (single source of
+  // truth, keyed off the registered provider `type`), not a hand-rolled
+  // name check duplicated across the app + dashboard.
   const allowMultiQuestionForm = useMemo(
-    () => activeSessionProvider != null && activeSessionProvider !== 'claude-tui' && activeSessionProvider !== 'claude-cli',
+    () => providerSupportsMultiQuestion(activeSessionProvider),
     [activeSessionProvider],
   )
 

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import type { ReactNode } from 'react'
 import type { ChatMessage, SessionInfo } from '@chroxy/store-core'
+import { providerSupportsSingleMultiSelect } from '@chroxy/store-core'
 import type { ChatViewMessage } from '../components/ChatView'
 import type { ConnectionState } from '../store/connection'
 import { ToolGroup } from '../components/ToolGroup'
@@ -150,12 +151,12 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
           allowMultiQuestion={allowMultiQuestionForm}
           // #5776 — render a SINGLE-question multiSelect as a checkbox form.
           // True wherever a structured multi-answer can be consumed: the
-          // SDK-family providers (already gated by allowMultiQuestionForm) AND
-          // claude-tui via the multi-select reinject path. claude-cli is
-          // excluded (allowMultiQuestionForm is false for it and it isn't
-          // claude-tui) because its respondToQuestion takes only a single
-          // text answer with no answersMap channel.
-          allowSingleMultiSelect={allowMultiQuestionForm || activeSessionProvider === 'claude-tui'}
+          // SDK-family providers AND claude-tui via the multi-select reinject
+          // path. The plain CLI providers (claude-cli, docker-cli) are excluded
+          // because their respondToQuestion takes only a single text answer
+          // with no answersMap channel. #5795 — single source of truth in
+          // @chroxy/store-core (keyed off the registered provider `type`).
+          allowSingleMultiSelect={providerSupportsSingleMultiSelect(activeSessionProvider)}
           // #4685 — gate the question content render on the matching
           // AskUserQuestion permission_request being resolved. Pre-fix
           // the user_question card rendered the moment the wire event

--- a/packages/dashboard/src/lib/provider-labels.ts
+++ b/packages/dashboard/src/lib/provider-labels.ts
@@ -6,6 +6,8 @@ export {
   PROVIDER_LABELS,
   getProviderLabel,
   getProviderInfo,
+  providerSupportsMultiQuestion,
+  providerSupportsSingleMultiSelect,
 } from '@chroxy/store-core'
 
 export type {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -337,6 +337,8 @@ export {
   PROVIDER_LABELS,
   getProviderLabel,
   getProviderInfo,
+  providerSupportsMultiQuestion,
+  providerSupportsSingleMultiSelect,
 } from './provider-labels'
 
 export type {

--- a/packages/store-core/src/provider-labels.test.ts
+++ b/packages/store-core/src/provider-labels.test.ts
@@ -3,6 +3,8 @@ import {
   PROVIDER_LABELS,
   getProviderLabel,
   getProviderInfo,
+  providerSupportsMultiQuestion,
+  providerSupportsSingleMultiSelect,
 } from './provider-labels'
 
 describe('PROVIDER_LABELS', () => {
@@ -120,5 +122,76 @@ describe('getProviderInfo', () => {
       const info = getProviderInfo(key)
       expect(info.label).toBe(PROVIDER_LABELS[key])
     }
+  })
+})
+
+// #5795 — single source of truth for AskUserQuestion render capability,
+// hoisted out of four hand-rolled client derivations.
+describe('providerSupportsMultiQuestion', () => {
+  it('is true for structured-channel (sdk / other) providers', () => {
+    expect(providerSupportsMultiQuestion('claude-sdk')).toBe(true)
+    expect(providerSupportsMultiQuestion('claude-byok')).toBe(true)
+    expect(providerSupportsMultiQuestion('docker-byok')).toBe(true)
+    expect(providerSupportsMultiQuestion('docker-sdk')).toBe(true)
+    expect(providerSupportsMultiQuestion('gemini')).toBe(true)
+    expect(providerSupportsMultiQuestion('codex')).toBe(true)
+  })
+
+  it('is false for cli-type providers (single text answer, no answersMap)', () => {
+    expect(providerSupportsMultiQuestion('claude-cli')).toBe(false)
+    expect(providerSupportsMultiQuestion('claude-tui')).toBe(false)
+  })
+
+  it('is false for docker-cli and its docker alias (the #5795 latent bug)', () => {
+    // docker-cli is DockerSession extends CliSession — single-text
+    // respondToQuestion like claude-cli. The old `!= claude-cli && != claude-tui`
+    // checks let it fall through to true; keying off `type: cli` fixes it.
+    expect(providerSupportsMultiQuestion('docker-cli')).toBe(false)
+    expect(providerSupportsMultiQuestion('docker')).toBe(false)
+  })
+
+  it('is false for null/undefined/empty', () => {
+    expect(providerSupportsMultiQuestion(null)).toBe(false)
+    expect(providerSupportsMultiQuestion(undefined)).toBe(false)
+    expect(providerSupportsMultiQuestion('')).toBe(false)
+  })
+
+  it('treats unknown providers as structured-capable (matches the prior fallback)', () => {
+    expect(providerSupportsMultiQuestion('my-custom-sdk')).toBe(true)
+    expect(providerSupportsMultiQuestion('my-provider')).toBe(true)
+  })
+})
+
+describe('providerSupportsSingleMultiSelect', () => {
+  it('is true for structured-channel providers AND claude-tui (reinject)', () => {
+    expect(providerSupportsSingleMultiSelect('claude-sdk')).toBe(true)
+    expect(providerSupportsSingleMultiSelect('claude-byok')).toBe(true)
+    expect(providerSupportsSingleMultiSelect('docker-sdk')).toBe(true)
+    expect(providerSupportsSingleMultiSelect('gemini')).toBe(true)
+    expect(providerSupportsSingleMultiSelect('codex')).toBe(true)
+    // claude-tui: cli-type, but supported via the #5776 multi-select reinject.
+    expect(providerSupportsSingleMultiSelect('claude-tui')).toBe(true)
+  })
+
+  it('is false for the plain CLI providers', () => {
+    expect(providerSupportsSingleMultiSelect('claude-cli')).toBe(false)
+    expect(providerSupportsSingleMultiSelect('docker-cli')).toBe(false)
+    expect(providerSupportsSingleMultiSelect('docker')).toBe(false)
+  })
+
+  it('is false for null/undefined/empty', () => {
+    expect(providerSupportsSingleMultiSelect(null)).toBe(false)
+    expect(providerSupportsSingleMultiSelect(undefined)).toBe(false)
+    expect(providerSupportsSingleMultiSelect('')).toBe(false)
+  })
+
+  it('matches the prior "everything except claude-cli" behavior for all known non-docker-cli providers', () => {
+    // Regression guard: the two old client formulas were both "not claude-cli"
+    // (modulo the docker-cli bug). Confirm parity for the providers that were
+    // never buggy.
+    for (const key of ['claude-sdk', 'claude-tui', 'claude-byok', 'docker-byok', 'docker-sdk', 'gemini', 'codex']) {
+      expect(providerSupportsSingleMultiSelect(key)).toBe(true)
+    }
+    expect(providerSupportsSingleMultiSelect('claude-cli')).toBe(false)
   })
 })

--- a/packages/store-core/src/provider-labels.ts
+++ b/packages/store-core/src/provider-labels.ts
@@ -115,15 +115,24 @@ export function getProviderInfo(provider: string): ProviderDisplayInfo {
 // (b) silently mishandled docker-cli/docker (cli-type, single-text answer
 // channel like claude-cli, yet they fell through the bare `!= claude-cli`
 // checks and were treated as structured-capable). Keying off the registered
-// `type` fixes both: cli-type providers take a single TEXT answer only.
+// `type` fixes both: cli-type providers answer over a single TEXT channel.
+//
+// The distinction is the ANSWER CHANNEL, not a method signature: cli-type
+// providers deliver the answer as one text string over CLI stdin / TUI PTY
+// keystrokes, so they cannot receive a structured per-question answersMap from
+// the client the way the SDK-family providers do. (claude-tui's server-side
+// respondToQuestion does take an answersMap internally — it uses it only to
+// format the single multi-select reinject text, not to drive a multi-question
+// form — so it's the documented exception in the single-multiselect predicate
+// below.)
 
 /**
  * Can this provider render a multi-QUESTION AskUserQuestion form (several
  * questions at once, per-question answers incl. multi-select arrays)?
  *
- * Only providers with a structured answer channel can — i.e. NOT the
- * cli-type providers (claude-cli, claude-tui, docker-cli, docker), whose
- * respondToQuestion accepts a single text answer with no answersMap.
+ * Only providers with a structured (per-question) answer channel can — i.e.
+ * NOT the cli-type providers (claude-cli, claude-tui, docker-cli, docker),
+ * which answer over a single text channel (CLI stdin / TUI PTY keystrokes).
  */
 export function providerSupportsMultiQuestion(provider: string | null | undefined): boolean {
   if (!provider) return false
@@ -133,8 +142,9 @@ export function providerSupportsMultiQuestion(provider: string | null | undefine
 /**
  * Can this provider render a SINGLE-question multi-select AskUserQuestion as a
  * checkbox form? True for every structured-channel provider PLUS claude-tui,
- * which re-injects the chosen labels as text via the #5776 reinject path.
- * The plain CLI providers (claude-cli, docker-cli, docker) cannot.
+ * which re-injects the chosen labels as one text string via the #5776 reinject
+ * path. The plain text-channel CLI providers (claude-cli, docker-cli, docker)
+ * cannot.
  *
  * Note: claude-tui's reinject is itself gated server-side by
  * CHROXY_TUI_MULTISELECT_REINJECT (default OFF). Wiring that capability to the

--- a/packages/store-core/src/provider-labels.ts
+++ b/packages/store-core/src/provider-labels.ts
@@ -107,3 +107,42 @@ export function getProviderInfo(provider: string): ProviderDisplayInfo {
   const short = provider.replace(/^claude-/, '').toUpperCase()
   return { ...FALLBACK, label: short, short }
 }
+
+// #5795 — single source of truth for "which AskUserQuestion render shapes can
+// this provider's answer channel consume?". Previously these predicates were
+// hand-rolled four times across the dashboard and app with two different
+// spellings of the same boolean, which (a) drifts on the next provider and
+// (b) silently mishandled docker-cli/docker (cli-type, single-text answer
+// channel like claude-cli, yet they fell through the bare `!= claude-cli`
+// checks and were treated as structured-capable). Keying off the registered
+// `type` fixes both: cli-type providers take a single TEXT answer only.
+
+/**
+ * Can this provider render a multi-QUESTION AskUserQuestion form (several
+ * questions at once, per-question answers incl. multi-select arrays)?
+ *
+ * Only providers with a structured answer channel can — i.e. NOT the
+ * cli-type providers (claude-cli, claude-tui, docker-cli, docker), whose
+ * respondToQuestion accepts a single text answer with no answersMap.
+ */
+export function providerSupportsMultiQuestion(provider: string | null | undefined): boolean {
+  if (!provider) return false
+  return getProviderInfo(provider).type !== 'cli'
+}
+
+/**
+ * Can this provider render a SINGLE-question multi-select AskUserQuestion as a
+ * checkbox form? True for every structured-channel provider PLUS claude-tui,
+ * which re-injects the chosen labels as text via the #5776 reinject path.
+ * The plain CLI providers (claude-cli, docker-cli, docker) cannot.
+ *
+ * Note: claude-tui's reinject is itself gated server-side by
+ * CHROXY_TUI_MULTISELECT_REINJECT (default OFF). Wiring that capability to the
+ * client so the form is only offered when the server will honor it is tracked
+ * separately in #5791; this predicate preserves the existing name-based gate.
+ */
+export function providerSupportsSingleMultiSelect(provider: string | null | undefined): boolean {
+  if (!provider) return false
+  if (provider === 'claude-tui') return true
+  return getProviderInfo(provider).type !== 'cli'
+}


### PR DESCRIPTION
## Summary
Hoists the AskUserQuestion render-capability predicate into `@chroxy/store-core` as a single source of truth, and fixes a latent correctness bug it surfaced. From the SOLID/DRY swarm audit (2026-06-14), consensus across all 6 agents.

### The problem
`allowMultiQuestion` / `allowSingleMultiSelect` were hand-rolled **four times** across two packages in two different spellings of the same boolean:
- `dashboard/src/App.tsx` — `!= claude-tui && != claude-cli`
- `dashboard/src/hooks/useMessageRenderer.tsx` — `allowMultiQuestionForm || === claude-tui`
- `app/src/screens/SessionScreen.tsx` ×2 — `!= claude-tui && != claude-cli` and `!= claude-cli`

**Latent bug:** the bare `!= claude-cli` checks let **docker-cli** (and its `docker` alias) fall through. `docker-cli` is `DockerSession extends CliSession` — a single-text answer channel exactly like `claude-cli` — so a docker-cli session rendered an interactive multi-question / multi-select form whose answers would misroute.

### The fix
- Add `providerSupportsMultiQuestion()` and `providerSupportsSingleMultiSelect()` to `store-core/provider-labels.ts`, keyed off the registered provider `type` (`sdk`/`cli`/`other`). `cli`-type → single text answer only; `claude-tui` is the documented exception (single multi-select via the #5776 reinject path).
- Export through both client re-export shims; replace all four derivations.

**Behavior is preserved for every provider except `docker-cli`/`docker`,** which are now correctly excluded. A note in the code + PR flags that the single-multiSelect gate should later consume the server reinject capability flag (#5791).

## Verification
- store-core: typecheck clean; **1520/1520** tests pass incl. **20** provider-labels tests (8 new, covering the docker-cli fix, null/empty, unknown-provider fallback parity)
- dashboard: `tsc --noEmit` clean; **52** QuestionPrompt/useMessageRenderer tests pass
- app: `tsc --noEmit` clean; **9** MessageBubble multiQuestion tests pass

Closes #5795