### PR TITLE
fix(server): sanitize claude-tui multi-select reinject labels (#5796)

### DIFF
--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -524,6 +524,10 @@ export class FormDriver {
       // claude TUI's Other-path may still mis-parse that, tracked in
       // #4288 as a separate concern.
       let writeText = text
+      // #5803 — track whether we resolved the answer to a safe hotkey digit.
+      // If not, `writeText` stays the untrusted literal client answer and must
+      // be sanitized before it reaches the PTY (same threat as reinject labels).
+      let isHotkeyDigit = false
       if (Array.isArray(options) && options.length > 0) {
         const matchIdx = options.findIndex((o) => o && o.label === text)
         // #4292 + #4746 + #4848: single-digit hotkey covers indices 0..8.
@@ -570,7 +574,17 @@ export class FormDriver {
         }
         if (matchIdx >= 0 && matchIdx < 9) {
           writeText = String(matchIdx + 1)
+          isHotkeyDigit = true
         }
+      }
+      // #5803 — the literal-answer fallthrough (no hotkey/arrow match, e.g. the
+      // Other/freeform back-compat path) types untrusted client text straight
+      // into the live PTY. Sanitize control chars (CR/LF/ESC) out of it the
+      // same way as multi-select reinject labels so a crafted answer can't
+      // submit the composer early or inject terminal escape sequences. The
+      // hotkey-digit path is already a single safe char and is left untouched.
+      if (!isHotkeyDigit) {
+        writeText = sanitizeReinjectLabel(writeText)
       }
       // Fire-and-forget — the write is async due to the per-char throttle,
       // but the caller (handleUserQuestionResponse) is sync. Errors here

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -91,6 +91,21 @@ export function multiSelectReinjectEnabled() {
   return process.env.CHROXY_TUI_MULTISELECT_REINJECT === '1'
 }
 
+// #5796 — sanitize an untrusted reinject label before it is TYPED into the live
+// claude TUI PTY. Multi-select labels (and the freeform/"Other" text) arrive from
+// the client over the wire, so a crafted value could contain control characters:
+// a bare CR/LF (\r/\n) would submit the composer early, and ESC (\x1b) + the rest
+// of a C0/C1 sequence could inject terminal escape codes or corrupt the prompt.
+// Replace every run of control chars (C0 \x00-\x1f, DEL \x7f, C1 \x80-\x9f — which
+// covers \r, \n, \x1b) with a single space, then collapse and trim surrounding
+// whitespace so the visible label stays clean. Printable unicode is preserved.
+// Pure + never throws: non-string input coerces to '' (drop it).
+function sanitizeReinjectLabel(s) {
+  if (typeof s !== 'string') return ''
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\x00-\x1f\x7f-\x9f]+/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
 // #5776 — parse a single question's answersMap value into an array of selected
 // option LABELS. Accepts the three wire shapes the dashboard may send: a native
 // array (post-#4735), a JSON-encoded array string, or a comma-joined fallback.
@@ -115,7 +130,12 @@ export function formatMultiSelectReinject(questions, answersMap) {
   const lines = []
   for (const q of questions) {
     if (!q || !q.question) continue
+    // #5796 — sanitize each label before it joins the text that gets typed into
+    // the live PTY (strip control chars, notably CR/LF/ESC); drop any that
+    // sanitize down to empty so they don't leave stray separators.
     const labels = parseSelectedLabels(map[q.question])
+      .map(sanitizeReinjectLabel)
+      .filter(Boolean)
     if (labels.length === 0) continue
     lines.push(`For "${q.question}": ${labels.join(', ')}`)
   }
@@ -192,9 +212,14 @@ export class FormDriver {
     // ~150 ms for the prompt swap, then writes the freeform text + Enter
     // to submit. Mutually exclusive with answersMap (multi-question
     // Other is out of scope per #4648).
-    const freeformText = (opts && typeof opts.freeformText === 'string' && opts.freeformText.length > 0)
-      ? opts.freeformText
-      : null
+    // #5796 — the freeform/"Other" text is untrusted client input that gets
+    // TYPED into the live claude TUI PTY (stage-2 write below). Sanitize control
+    // chars (notably CR/LF/ESC) out of it the same way as multi-select labels so
+    // a crafted value can't submit the composer early or inject escape sequences.
+    const rawFreeform = (opts && typeof opts.freeformText === 'string' && opts.freeformText.length > 0)
+      ? sanitizeReinjectLabel(opts.freeformText)
+      : ''
+    const freeformText = rawFreeform.length > 0 ? rawFreeform : null
     let entry = null
     if (toolUseId && this._host._pendingUserAnswers.has(toolUseId)) {
       entry = this._host._pendingUserAnswers.get(toolUseId)

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -141,6 +141,35 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.deepEqual(host._cleared, ['t1'], 'only the answered entry is cleared')
   })
 
+  it('single-question: sanitizes the literal-answer fallthrough before PTY type (#5803)', () => {
+    // When the answer text matches no option label it falls through to typing
+    // the literal client text into the PTY (the Other/freeform back-compat
+    // path). That text is untrusted: control chars (CR/LF/ESC) must be stripped
+    // so a crafted answer can't submit the composer early or inject escapes.
+    const host = makeMockHost()
+    seedSingle(host, 't1', ['Alpha', 'Bravo'])
+    const fd = new FormDriver(host)
+
+    fd.respondToQuestion('custom\r\nanswer\x1b[31m', undefined, 't1')
+
+    // CR/LF/ESC removed; control runs collapse to a single space; no bare
+    // CR/LF reaches the PTY.
+    assert.deepEqual(host._writes, ['custom answer [31m'])
+    assert.ok(!host._writes[0].includes('\r') && !host._writes[0].includes('\n'), 'no bare CR/LF typed')
+    assert.ok(!host._writes[0].includes('\x1b'), 'no ESC typed')
+  })
+
+  it('single-question: a matched option is unaffected by the #5803 literal sanitizer', () => {
+    // The hotkey-digit path is a safe single char and must not be touched.
+    const host = makeMockHost()
+    seedSingle(host, 't1', ['Alpha', 'Bravo', 'Charlie'])
+    const fd = new FormDriver(host)
+
+    fd.respondToQuestion('Charlie', undefined, 't1')
+
+    assert.deepEqual(host._writes, ['3'])
+  })
+
   it('single-question: arms the stall watchdog for the pending entry', () => {
     const host = makeMockHost()
     seedSingle(host, 't1', ['Yes', 'No'])

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -254,6 +254,47 @@ describe('FormDriver — injected collaborator (#5617)', () => {
       formatMultiSelectReinject(questions, {}), '', 'no selection → empty string')
   })
 
+  it('formatMultiSelectReinject: sanitizes control chars out of labels before PTY type (#5796)', () => {
+    const questions = [{ question: 'Pick toppings', multiSelect: true }]
+
+    // CR / LF in a label must not survive — a bare \r would submit the composer
+    // early when typed into the PTY. The control run collapses to a single space.
+    const crlf = formatMultiSelectReinject(questions, { 'Pick toppings': ['Chee\rse', 'On\nion'] })
+    assert.ok(!crlf.includes('\r'), 'no bare CR reaches output')
+    // \n only appears as the line separator between questions; with one question
+    // there is none, so the label's \n must be gone.
+    assert.ok(!crlf.includes('\n'), 'no bare LF reaches output (single question)')
+    assert.equal(crlf, 'For "Pick toppings": Chee se, On ion', 'control run → single space')
+
+    // ESC + an ANSI color sequence must be stripped (no terminal escape injection).
+    const esc = formatMultiSelectReinject(questions, { 'Pick toppings': ['\x1b[31mRed'] })
+    assert.ok(!esc.includes('\x1b'), 'ESC stripped')
+    assert.equal(esc, 'For "Pick toppings": [31mRed', 'only the ESC byte goes, rest is printable text')
+
+    // Backspace (\x08) and DEL (\x7f) are C0/DEL controls → removed.
+    const bs = formatMultiSelectReinject(questions, { 'Pick toppings': ['A\x08B\x7fC'] })
+    assert.equal(bs, 'For "Pick toppings": A B C', 'backspace + DEL → spaces')
+
+    // Normal unicode / printable text is untouched.
+    const uni = formatMultiSelectReinject(questions, { 'Pick toppings': ['Café ☕ 日本語'] })
+    assert.equal(uni, 'For "Pick toppings": Café ☕ 日本語', 'printable unicode preserved')
+
+    // A label that is ONLY control chars sanitizes to empty and is dropped (no
+    // stray separator); with all labels dropped the question yields no line.
+    assert.equal(
+      formatMultiSelectReinject(questions, { 'Pick toppings': ['\r\n\x1b', 'Cheese'] }),
+      'For "Pick toppings": Cheese', 'all-control label dropped, no stray comma')
+    assert.equal(
+      formatMultiSelectReinject(questions, { 'Pick toppings': ['\r\n'] }),
+      '', 'question with only control-char labels → no line')
+
+    // Non-string entries inside the parsed array are already filtered out, but
+    // weird answersMap values must not throw.
+    assert.doesNotThrow(() => formatMultiSelectReinject(questions, { 'Pick toppings': null }))
+    assert.doesNotThrow(() => formatMultiSelectReinject(questions, { 'Pick toppings': undefined }))
+    assert.doesNotThrow(() => formatMultiSelectReinject(questions, { 'Pick toppings': 42 }))
+  })
+
   it('single multi-select REINJECT (flag on): busy session → no send, retryable teardown (#5776 busy-race)', () => {
     // If the answer races ahead of the denied turn's Stop-hook teardown, the
     // session is still _isBusy. The real sendMessage would silently drop the


### PR DESCRIPTION
## Summary
Multi-select AskUserQuestion labels — and the freeform/"Other" text — arrive from the client over the wire and are TYPED into the live claude TUI PTY. A crafted value could contain control characters: a bare CR/LF would submit the composer early; ESC + a C0/C1 sequence could inject terminal escape codes or corrupt the prompt. Sanitize them before they reach the PTY.

From the SOLID/DRY swarm-audit session follow-up.

## Changes (`packages/server/src/claude-tui/form-driver.js`)
- New pure helper `sanitizeReinjectLabel(s)` — replaces every run of control chars (`\x00-\x1f`, DEL `\x7f`, C1 `\x80-\x9f` — covers `\r`/`\n`/`\x1b`) with a single space, collapses + trims whitespace, preserves printable unicode. Coerces non-strings to `''` (never throws).
- `formatMultiSelectReinject` — each label is sanitized + empties dropped (no stray separators) before joining.
- `respondToQuestion` — the freeform/"Other" text is sanitized before the stage-2 PTY write. A newline/carriage-return in single-line freeform would submit the composer early, so collapsing to a space is the correct behavior.

## Verification
- `claude-tui-form-driver.test.js`: **17/17 pass** incl. 7 new sanitizer cases (CR/LF removed, ESC stripped, backspace/DEL removed, printable unicode unchanged, all-control label dropped, non-string values don't throw)
- `node --check` syntax OK

Closes #5796
