### PR TITLE
fix(dashboard): snap chat to bottom on approve/answer + dedup scroll primitive (#5786)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1520,19 +1520,24 @@ export function App() {
   // #5786 — approving a permission/plan or answering an AskUserQuestion is, like
   // sending, an explicit "show me the latest" action: snap the chat to the
   // bottom so the follow-up response scrolls into view even if the user had
-  // scrolled up to read history. These wrappers bump the same nonce handleSend
-  // does, then forward to the underlying store actions unchanged (same args,
-  // same return). They're passed to useMessageRenderer (and the banner handlers
-  // below) in place of the raw store actions so every approve/answer call site
-  // gets the snap for free.
+  // scrolled up to read history. These wrappers forward to the underlying store
+  // actions unchanged (same args, same return) and bump the same nonce
+  // handleSend does — but AFTER the action runs and only when it was accepted
+  // (sendPermissionResponse / sendUserQuestionResponse return false when the
+  // socket isn't OPEN; review #5786). Bumping after the call lets the action's
+  // store updates land first, so ChatView's RAF scroll runs once the follow-up
+  // has rendered. A non-false result (incl. 'queued') still bumps — the message
+  // will send and produce a response.
   const respondToPermission = useCallback<typeof sendPermissionResponse>((...args) => {
-    setScrollToBottomSignal(n => n + 1)
-    return sendPermissionResponse(...args)
+    const result = sendPermissionResponse(...args)
+    if (result !== false) setScrollToBottomSignal(n => n + 1)
+    return result
   }, [sendPermissionResponse])
 
   const respondToUserQuestion = useCallback<typeof sendUserQuestionResponse>((...args) => {
-    setScrollToBottomSignal(n => n + 1)
-    return sendUserQuestionResponse(...args)
+    const result = sendUserQuestionResponse(...args)
+    if (result !== false) setScrollToBottomSignal(n => n + 1)
+    return result
   }, [sendUserQuestionResponse])
 
   const handleBannerApprove = useCallback((requestId: string, notificationId: string) => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -405,10 +405,10 @@ export function App() {
   const retryConnection = useConnectionStore(s => s.retryConnection)
   const sendInput = useConnectionStore(s => s.sendInput)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
-  // #5780 — nonce bumped on the explicit "jump to latest" user action. Today
-  // that is send (handleSend); wiring approve/answer is tracked in #5786.
-  // Passed to every ChatView so it snaps to the bottom even
-  // when the user had scrolled up to read history — see ChatView's
+  // #5780 — nonce bumped on the explicit "jump to latest" user action. Those
+  // actions are: send (handleSend), approving a permission/plan, and answering
+  // an AskUserQuestion (#5786). Passed to every ChatView so it snaps to the
+  // bottom even when the user had scrolled up to read history — see ChatView's
   // scrollToBottomSignal effect.
   const [scrollToBottomSignal, setScrollToBottomSignal] = useState(0)
   const evaluateDraft = useConnectionStore(s => s.evaluateDraft)
@@ -1449,6 +1449,9 @@ export function App() {
 
   const handlePlanApprove = useCallback(() => {
     sendInput('approve')
+    // #5786 — approving a plan is an explicit "show me the latest" action: snap
+    // to the bottom so the follow-up response scrolls into view.
+    setScrollToBottomSignal(n => n + 1)
   }, [sendInput])
 
   const handlePlanFeedback = useCallback(() => {
@@ -1514,17 +1517,35 @@ export function App() {
     setPermissionMode,
   })
 
+  // #5786 — approving a permission/plan or answering an AskUserQuestion is, like
+  // sending, an explicit "show me the latest" action: snap the chat to the
+  // bottom so the follow-up response scrolls into view even if the user had
+  // scrolled up to read history. These wrappers bump the same nonce handleSend
+  // does, then forward to the underlying store actions unchanged (same args,
+  // same return). They're passed to useMessageRenderer (and the banner handlers
+  // below) in place of the raw store actions so every approve/answer call site
+  // gets the snap for free.
+  const respondToPermission = useCallback<typeof sendPermissionResponse>((...args) => {
+    setScrollToBottomSignal(n => n + 1)
+    return sendPermissionResponse(...args)
+  }, [sendPermissionResponse])
+
+  const respondToUserQuestion = useCallback<typeof sendUserQuestionResponse>((...args) => {
+    setScrollToBottomSignal(n => n + 1)
+    return sendUserQuestionResponse(...args)
+  }, [sendUserQuestionResponse])
+
   const handleBannerApprove = useCallback((requestId: string, notificationId: string) => {
-    sendPermissionResponse(requestId, 'allow')
+    respondToPermission(requestId, 'allow')
     markPromptAnsweredByRequestId(requestId, 'Allowed')
     dismissSessionNotification(notificationId)
-  }, [sendPermissionResponse, markPromptAnsweredByRequestId, dismissSessionNotification])
+  }, [respondToPermission, markPromptAnsweredByRequestId, dismissSessionNotification])
 
   const handleBannerDeny = useCallback((requestId: string, notificationId: string) => {
-    sendPermissionResponse(requestId, 'deny')
+    respondToPermission(requestId, 'deny')
     markPromptAnsweredByRequestId(requestId, 'Denied')
     dismissSessionNotification(notificationId)
-  }, [sendPermissionResponse, markPromptAnsweredByRequestId, dismissSessionNotification])
+  }, [respondToPermission, markPromptAnsweredByRequestId, dismissSessionNotification])
 
   // Retry reconnects to the *active* server (remote registry entry or local),
   // not unconditionally to local — see retryConnection / #5284.
@@ -1543,8 +1564,9 @@ export function App() {
     storeMsgMap,
     chatToolGroupPayloads,
     chatTailMessageId,
-    sendPermissionResponse,
-    sendUserQuestionResponse,
+    // #5786 — wrapped so approve/answer also snaps the chat to the bottom.
+    sendPermissionResponse: respondToPermission,
+    sendUserQuestionResponse: respondToUserQuestion,
     markPromptAnswered,
     storeMessages,
     sendInput,

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -212,6 +212,66 @@ describe('ChatView', () => {
     vi.useRealTimers()
   })
 
+  it('does not snap to bottom when scrollToBottomSignal is unchanged across a rerender (#5786)', async () => {
+    // After the #5786 DRY refactor the signal effect routes through the shared
+    // scrollToBottomNow() helper. This guards the lastScrollSignalRef compare on
+    // a *live* rerender (distinct from the initial-value test): a prop churn that
+    // re-renders ChatView without bumping the nonce must NOT force-scroll a user
+    // who has scrolled up to read history.
+    vi.useFakeTimers()
+    const messages = makeMessages(3)
+    const { rerender } = render(
+      <ChatView messages={messages} isStreaming={false} scrollToBottomSignal={2} />,
+    )
+    const container = screen.getByTestId('chat-messages')
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+    await act(() => { vi.advanceTimersByTime(50) })
+
+    // User scrolls up to read history.
+    container.scrollTop = 100
+    await act(() => { fireEvent.scroll(container) })
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+    // Rerender with the SAME signal value (a no-op prop churn, e.g. a new
+    // renderMessage identity). The view must stay put.
+    rerender(<ChatView messages={messages} isStreaming={false} scrollToBottomSignal={2} />)
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(100)
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it('snaps to bottom via the shared helper when scrollToBottomSignal bumps after refactor (#5786)', async () => {
+    // Companion to the #5780 bump test: confirms the extracted scrollToBottomNow()
+    // path still snaps to bottom (programmaticScrollRef + scrollTop = scrollHeight
+    // + RAF reset) when the nonce changes across two distinct, non-initial values.
+    vi.useFakeTimers()
+    const messages = makeMessages(3)
+    const { rerender } = render(
+      <ChatView messages={messages} isStreaming={false} scrollToBottomSignal={5} />,
+    )
+    const container = screen.getByTestId('chat-messages')
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+    await act(() => { vi.advanceTimersByTime(50) })
+
+    container.scrollTop = 100
+    await act(() => { fireEvent.scroll(container) })
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+    // Approve/answer-style bump (the App-level wiring increments the same nonce).
+    rerender(<ChatView messages={messages} isStreaming={false} scrollToBottomSignal={6} />)
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(1000)
+    expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
   it('preserves scrolled-up position when streaming ends mid-history-read (#4652)', async () => {
     // Repro for the AskUserQuestion scenario: streaming flips to false
     // when the question arrives. Previously, the streaming-end effect

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -390,14 +390,27 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
     setUserScrolledUp(!atBottom)
   }, [])
 
-  const scrollToBottom = useCallback(() => {
+  // The bare "snap to bottom" primitive shared by the mount, count-follow, and
+  // scrollToBottomSignal effects: flag the write as programmatic (so the
+  // resulting synthetic scroll event isn't misread as a user scroll-up), write
+  // scrollTop to scrollHeight, then clear the flag on the next frame. Reads the
+  // container ref itself and no-ops when unmounted, so callers don't repeat the
+  // null guard. Does NOT touch userScrolledUp — that's the caller's contract
+  // (the signal effect clears it; the count-follow effect only runs when already
+  // at bottom). Keeping the suppression contract in one place is the #5786 DRY
+  // ask — do not change its behavior.
+  const scrollToBottomNow = useCallback(() => {
     const el = containerRef.current
     if (!el) return
     programmaticScrollRef.current = true
     el.scrollTop = el.scrollHeight
-    setUserScrolledUp(false)
     requestAnimationFrame(() => { programmaticScrollRef.current = false })
   }, [])
+
+  const scrollToBottom = useCallback(() => {
+    scrollToBottomNow()
+    setUserScrolledUp(false)
+  }, [scrollToBottomNow])
 
   // Scroll to the bottom on initial mount so switching back to the chat
   // tab always lands on the most-recent message above the input bar.
@@ -405,15 +418,12 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
   // ChatView when the parent toggles viewMode away and back, so this
   // effect re-runs naturally on every tab return.
   useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-    programmaticScrollRef.current = true
-    el.scrollTop = el.scrollHeight
+    if (!containerRef.current) return
+    scrollToBottomNow()
     // #5561 — seed the windowing geometry from the real container size on mount
     // so the first render after layout has an accurate viewport height.
     syncGeometry()
-    requestAnimationFrame(() => { programmaticScrollRef.current = false })
-  }, [syncGeometry])
+  }, [syncGeometry, scrollToBottomNow])
 
   // #5561 — keep the windowed range correct when the container resizes (panel
   // split drag, window resize, sidebar toggle) without a scroll event firing.
@@ -516,24 +526,18 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
     const countChanged = dedupedMessages.length !== prevCountRef.current
     prevCountRef.current = dedupedMessages.length
     if (countChanged && !userScrolledUp) {
-      requestAnimationFrame(() => {
-        const el = containerRef.current
-        if (el) {
-          programmaticScrollRef.current = true
-          el.scrollTop = el.scrollHeight
-          requestAnimationFrame(() => { programmaticScrollRef.current = false })
-        }
-      })
+      requestAnimationFrame(() => { scrollToBottomNow() })
     }
-  }, [dedupedMessages.length, userScrolledUp, isBusy])
+  }, [dedupedMessages.length, userScrolledUp, isBusy, scrollToBottomNow])
 
-  // #5780 — explicit "jump to latest" on a user action (currently send;
-  // approve/answer wiring tracked in #5786). Watches the parent's
-  // `scrollToBottomSignal` nonce: whenever it
-  // changes we force the view to the bottom and clear `userScrolledUp`, even if
-  // the user had scrolled up to read history. This is the deliberate exception
-  // to the count-change auto-follow above — sending a message is the user
-  // asking to see their input plus the response, so we always follow. Seeded
+  // #5780 / #5786 — explicit "jump to latest" on a user action: send, approving
+  // a permission/plan, or answering an AskUserQuestion (the parent bumps the
+  // nonce for all three). Watches the parent's `scrollToBottomSignal` nonce:
+  // whenever it changes we force the view to the bottom and clear
+  // `userScrolledUp`, even if the user had scrolled up to read history. This is
+  // the deliberate exception to the count-change auto-follow above — those
+  // actions are the user asking to see the resulting response, so we always
+  // follow. Seeded
   // with the initial value so the first render (and mount) is a no-op; only a
   // genuine bump scrolls. Robust to rapid sends: each distinct nonce fires
   // once, and the RAF defers the write until after the new row has laid out so
@@ -543,14 +547,8 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
     if (scrollToBottomSignal === lastScrollSignalRef.current) return
     lastScrollSignalRef.current = scrollToBottomSignal
     setUserScrolledUp(false)
-    requestAnimationFrame(() => {
-      const el = containerRef.current
-      if (!el) return
-      programmaticScrollRef.current = true
-      el.scrollTop = el.scrollHeight
-      requestAnimationFrame(() => { programmaticScrollRef.current = false })
-    })
-  }, [scrollToBottomSignal])
+    requestAnimationFrame(() => { scrollToBottomNow() })
+  }, [scrollToBottomSignal, scrollToBottomNow])
 
   // During streaming, continuously scroll to bottom via RAF
   useEffect(() => {


### PR DESCRIPTION
## Summary
Wires the dashboard `scrollToBottomSignal` (added in #5785) to the **approve** and **answer** actions, and DRYs the scroll primitive. Previously only message-send bumped the signal, so the response after a permission/plan approval or an AskUserQuestion answer could render off-screen.

From the SOLID/DRY swarm-audit session follow-up.

## Changes
**`App.tsx` — bump the signal on approve/answer.** App-level wrappers (`respondToPermission`, `respondToUserQuestion`) bump the nonce then forward to the store action with identical args/return; passed into `useMessageRenderer` so renderer call sites are unchanged. `handlePlanApprove` (plan-mode approve via `sendInput('approve')`) and the banner approve/deny paths also bump. All four explicit user actions now bump exactly once: send, plan-approve, permission-respond, question-respond. (`markPromptAnswered` left raw to avoid a double-bump.)

**`ChatView.tsx` — DRY.** Extracted `scrollToBottomNow()` (the `programmaticScrollRef` + `scrollTop = scrollHeight` + RAF-reset primitive) and call it from the mount, count-follow, and signal effects (it was written 3×). The `lastScrollSignalRef` mount-skip and `SCROLL_THRESHOLD` near-bottom logic are untouched; the streaming-tick effect (no-RAF, deliberately different) is left as-is.

## Verification
- `tsc --noEmit` clean
- ChatView vitest: **39/39 pass**, incl. 2 new (#5786): a live-rerender no-op skip, and a bump-between-non-initial-values snap via the extracted helper.

## Note
Permission **deny** also bumps the signal (it flows through the same single store action). Judged correct — a deny resolves the prompt and the model continues, so snapping is desirable; only observable when the user had scrolled up. Splitting allow/deny would need a store-action change out of scope here.

Closes #5786
