### PR TITLE
fix: wire claude-tui multi-select reinject capability to the client — close the split-brain (#5791)

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -270,10 +270,14 @@ export function SessionScreen() {
     () => providerSupportsMultiQuestion(activeSessionProvider),
     [activeSessionProvider],
   );
-  const allowSingleMultiSelect = useMemo(
-    () => providerSupportsSingleMultiSelect(activeSessionProvider),
-    [activeSessionProvider],
-  );
+  // #5791 — claude-tui's single multiSelect is gated on the server-advertised
+  // `multiSelectReinject` capability (the CHROXY_TUI_MULTISELECT_REINJECT flag),
+  // not just the provider name, so the client doesn't offer a form the server
+  // would refuse. Pass the active provider's raw capabilities to the predicate.
+  const allowSingleMultiSelect = useMemo(() => {
+    const caps = availableProviders.find((p) => p.name === activeSessionProvider)?.capabilities;
+    return providerSupportsSingleMultiSelect(activeSessionProvider, caps);
+  }, [activeSessionProvider, availableProviders]);
   const viewingCachedSession = useConnectionStore((s) => s.viewingCachedSession);
   const exitCachedSession = useConnectionStore((s) => s.exitCachedSession);
   const savedConnection = useConnectionLifecycleStore((s) => s.savedConnection);

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -186,6 +186,11 @@ export interface ProviderCapabilities {
   // method existence — only providers whose session class implements
   // setPermissionRules report this as true (#3072).
   sessionRules?: boolean;
+  // #5791 — claude-tui only: true when the daemon will reinject a single
+  // multi-select AskUserQuestion answer (CHROXY_TUI_MULTISELECT_REINJECT).
+  // Gates the multi-select checkbox affordance so the client doesn't offer a
+  // form the server refuses.
+  multiSelectReinject?: boolean;
 }
 
 // #3404 audit (F1+F5): per-provider auth state for grey-out + billing detail.

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1562,6 +1562,16 @@ export function App() {
     startServer()
   }, [])
 
+  // #5791 — the active provider's advertised capabilities, so the renderer can
+  // gate the claude-tui single-multiSelect form on the server's
+  // `multiSelectReinject` bit (the CHROXY_TUI_MULTISELECT_REINJECT flag) rather
+  // than the provider name alone — the client must not offer a form the server
+  // would refuse.
+  const activeSessionCaps = useMemo(
+    () => availableProviders.find(p => p.name === activeSessionProvider)?.capabilities ?? null,
+    [availableProviders, activeSessionProvider],
+  )
+
   // #5560 — the custom chat-message renderer (permission prompts, question
   // prompts, tool bubbles/groups, evaluator banner, stall / resume chips) is
   // built by `useMessageRenderer`. Same deps array, same per-branch JSX.
@@ -1578,6 +1588,7 @@ export function App() {
     streamStallTimeoutMs,
     allowMultiQuestionForm,
     activeSessionProvider,
+    activeSessionCaps,
     setViewMode,
     stalledPromptIds,
     hasPendingAskUserQuestionPermission,

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -4,6 +4,7 @@ import type { ChatMessage, SessionInfo } from '@chroxy/store-core'
 import { providerSupportsSingleMultiSelect } from '@chroxy/store-core'
 import type { ChatViewMessage } from '../components/ChatView'
 import type { ConnectionState } from '../store/connection'
+import type { ProviderCapabilities } from '../store/types'
 import { ToolGroup } from '../components/ToolGroup'
 import { ToolBubble } from '../components/ToolBubble'
 import { PermissionPrompt } from '../components/PermissionPrompt'
@@ -26,6 +27,9 @@ export interface UseMessageRendererArgs {
   streamStallTimeoutMs: number | null
   allowMultiQuestionForm: boolean
   activeSessionProvider: string | null
+  // #5791 — the active provider's advertised capabilities, used to gate the
+  // claude-tui single-multiSelect form on the server's `multiSelectReinject` bit.
+  activeSessionCaps?: ProviderCapabilities | null
   setViewMode: ConnectionState['setViewMode']
   stalledPromptIds: Set<string>
   hasPendingAskUserQuestionPermission: boolean
@@ -76,6 +80,7 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
     streamStallTimeoutMs,
     allowMultiQuestionForm,
     activeSessionProvider,
+    activeSessionCaps,
     setViewMode,
     stalledPromptIds,
     hasPendingAskUserQuestionPermission,
@@ -156,7 +161,7 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
           // because their respondToQuestion takes only a single text answer
           // with no answersMap channel. #5795 — single source of truth in
           // @chroxy/store-core (keyed off the registered provider `type`).
-          allowSingleMultiSelect={providerSupportsSingleMultiSelect(activeSessionProvider)}
+          allowSingleMultiSelect={providerSupportsSingleMultiSelect(activeSessionProvider, activeSessionCaps)}
           // #4685 — gate the question content render on the matching
           // AskUserQuestion permission_request being resolved. Pre-fix
           // the user_question card rendered the moment the wire event
@@ -305,5 +310,5 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
 
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, allowMultiQuestionForm, activeSessionProvider, setViewMode, stalledPromptIds, hasPendingAskUserQuestionPermission, sessions])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, allowMultiQuestionForm, activeSessionProvider, activeSessionCaps, setViewMode, stalledPromptIds, hasPendingAskUserQuestionPermission, sessions])
 }

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -152,6 +152,11 @@ export interface ProviderCapabilities {
   // this with a visual badge + container settings knobs (image / memory /
   // cpu / containerUser) in the New Session modal's advanced section.
   containerized?: boolean;
+  // #5791 — claude-tui only: true when the daemon will reinject a single
+  // multi-select AskUserQuestion answer (CHROXY_TUI_MULTISELECT_REINJECT).
+  // Gates the multi-select checkbox affordance so the client doesn't offer a
+  // form the server refuses.
+  multiSelectReinject?: boolean;
 }
 
 // #3404 audit (F1+F5): per-provider auth state for grey-out + billing panel.

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -42,6 +42,7 @@ import {
 import {
   ASK_USER_QUESTION_WATCHDOG_MS,
   FormDriver,
+  multiSelectReinjectEnabled,
 } from './claude-tui/form-driver.js'
 
 // Re-export the public writeHookSettings helper so existing
@@ -113,6 +114,13 @@ export class ClaudeTuiSession extends BaseSession {
       thinkingLevel: false,
       streaming: false,
       tools: true,
+      // #5791 — advertise whether the server will actually honor a single
+      // multi-select AskUserQuestion (the #5776 reinject path, gated by
+      // CHROXY_TUI_MULTISELECT_REINJECT, default OFF). Clients gate the
+      // checkbox-form affordance on this so they don't render a form the
+      // server is wired to refuse. Read at access time (listProviders is
+      // called per connection), so it reflects the daemon's env.
+      multiSelectReinject: multiSelectReinjectEnabled(),
     }
   }
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -90,6 +90,27 @@ describe('ClaudeTuiSession', () => {
         'resume must be advertised so SessionManager round-trips the conversation uuid')
     })
 
+    it('capabilities.multiSelectReinject reflects CHROXY_TUI_MULTISELECT_REINJECT (#5791)', () => {
+      // The client gates its multi-select checkbox form on this bit, so it must
+      // track the daemon's actual reinject flag — not be hard-coded. Read at
+      // access time (listProviders calls the getter per connection).
+      const prev = process.env.CHROXY_TUI_MULTISELECT_REINJECT
+      try {
+        delete process.env.CHROXY_TUI_MULTISELECT_REINJECT
+        assert.equal(ClaudeTuiSession.capabilities.multiSelectReinject, false,
+          'default (flag unset) → false, matching the server refusing the form')
+        process.env.CHROXY_TUI_MULTISELECT_REINJECT = '1'
+        assert.equal(ClaudeTuiSession.capabilities.multiSelectReinject, true,
+          'flag on → true, so the client may offer the form')
+        process.env.CHROXY_TUI_MULTISELECT_REINJECT = '0'
+        assert.equal(ClaudeTuiSession.capabilities.multiSelectReinject, false,
+          'explicit 0 → false')
+      } finally {
+        if (prev === undefined) delete process.env.CHROXY_TUI_MULTISELECT_REINJECT
+        else process.env.CHROXY_TUI_MULTISELECT_REINJECT = prev
+      }
+    })
+
     it('fresh session: mints a uuid, exposes it via resumeSessionId, spawns with --session-id', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: emptySkillsDir, repoSkillsDir: null })
       assert.equal(session._sessionId, null, 'no uuid before start on a fresh session')

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -344,6 +344,7 @@ export {
 export type {
   ProviderType,
   ProviderDisplayInfo,
+  ProviderRenderCapabilities,
 } from './provider-labels'
 
 // #4569: curated IANA timezone short-list for the notification

--- a/packages/store-core/src/provider-labels.test.ts
+++ b/packages/store-core/src/provider-labels.test.ts
@@ -163,14 +163,31 @@ describe('providerSupportsMultiQuestion', () => {
 })
 
 describe('providerSupportsSingleMultiSelect', () => {
-  it('is true for structured-channel providers AND claude-tui (reinject)', () => {
+  it('is true for structured-channel providers regardless of caps', () => {
     expect(providerSupportsSingleMultiSelect('claude-sdk')).toBe(true)
     expect(providerSupportsSingleMultiSelect('claude-byok')).toBe(true)
     expect(providerSupportsSingleMultiSelect('docker-sdk')).toBe(true)
     expect(providerSupportsSingleMultiSelect('gemini')).toBe(true)
     expect(providerSupportsSingleMultiSelect('codex')).toBe(true)
-    // claude-tui: cli-type, but supported via the #5776 multi-select reinject.
-    expect(providerSupportsSingleMultiSelect('claude-tui')).toBe(true)
+  })
+
+  it('claude-tui is gated on the multiSelectReinject capability (#5791)', () => {
+    // Without the cap (server flag off / unknown) the client must NOT offer the
+    // form — the server refuses it (was the #5791 split-brain).
+    expect(providerSupportsSingleMultiSelect('claude-tui')).toBe(false)
+    expect(providerSupportsSingleMultiSelect('claude-tui', null)).toBe(false)
+    expect(providerSupportsSingleMultiSelect('claude-tui', {})).toBe(false)
+    expect(providerSupportsSingleMultiSelect('claude-tui', { multiSelectReinject: false })).toBe(false)
+    // With the cap the form is offered (server will reinject the answer).
+    expect(providerSupportsSingleMultiSelect('claude-tui', { multiSelectReinject: true })).toBe(true)
+  })
+
+  it('ignores the cap for non-claude-tui providers', () => {
+    // The cap only gates claude-tui; SDK providers are always structured-capable
+    // and CLI providers are never (the cap can't enable them).
+    expect(providerSupportsSingleMultiSelect('claude-sdk', { multiSelectReinject: false })).toBe(true)
+    expect(providerSupportsSingleMultiSelect('claude-cli', { multiSelectReinject: true })).toBe(false)
+    expect(providerSupportsSingleMultiSelect('docker-cli', { multiSelectReinject: true })).toBe(false)
   })
 
   it('is false for the plain CLI providers', () => {
@@ -183,15 +200,5 @@ describe('providerSupportsSingleMultiSelect', () => {
     expect(providerSupportsSingleMultiSelect(null)).toBe(false)
     expect(providerSupportsSingleMultiSelect(undefined)).toBe(false)
     expect(providerSupportsSingleMultiSelect('')).toBe(false)
-  })
-
-  it('matches the prior "everything except claude-cli" behavior for all known non-docker-cli providers', () => {
-    // Regression guard: the two old client formulas were both "not claude-cli"
-    // (modulo the docker-cli bug). Confirm parity for the providers that were
-    // never buggy.
-    for (const key of ['claude-sdk', 'claude-tui', 'claude-byok', 'docker-byok', 'docker-sdk', 'gemini', 'codex']) {
-      expect(providerSupportsSingleMultiSelect(key)).toBe(true)
-    }
-    expect(providerSupportsSingleMultiSelect('claude-cli')).toBe(false)
   })
 })

--- a/packages/store-core/src/provider-labels.ts
+++ b/packages/store-core/src/provider-labels.ts
@@ -140,19 +140,37 @@ export function providerSupportsMultiQuestion(provider: string | null | undefine
 }
 
 /**
- * Can this provider render a SINGLE-question multi-select AskUserQuestion as a
- * checkbox form? True for every structured-channel provider PLUS claude-tui,
- * which re-injects the chosen labels as one text string via the #5776 reinject
- * path. The plain text-channel CLI providers (claude-cli, docker-cli, docker)
- * cannot.
- *
- * Note: claude-tui's reinject is itself gated server-side by
- * CHROXY_TUI_MULTISELECT_REINJECT (default OFF). Wiring that capability to the
- * client so the form is only offered when the server will honor it is tracked
- * separately in #5791; this predicate preserves the existing name-based gate.
+ * The slice of a provider's advertised `capabilities` that the AskUserQuestion
+ * render predicates consult. Comes from the server over the wire
+ * (`availableProviders[].capabilities`, see server `providers.js`/`listProviders`).
  */
-export function providerSupportsSingleMultiSelect(provider: string | null | undefined): boolean {
+export interface ProviderRenderCapabilities {
+  /**
+   * #5791 — claude-tui only honors a single multi-select AskUserQuestion when
+   * CHROXY_TUI_MULTISELECT_REINJECT is enabled on the daemon. The server
+   * surfaces that as this capability bit so the client can gate the form.
+   */
+  multiSelectReinject?: boolean
+}
+
+/**
+ * Can this provider render a SINGLE-question multi-select AskUserQuestion as a
+ * checkbox form? True for every structured-channel provider. claude-tui can
+ * too — but ONLY when the server advertises `multiSelectReinject` (the #5776
+ * reinject path, gated by CHROXY_TUI_MULTISELECT_REINJECT, default OFF). The
+ * plain text-channel CLI providers (claude-cli, docker-cli, docker) cannot.
+ *
+ * #5791 — passing `caps` closes the split-brain: previously claude-tui got the
+ * form unconditionally on the client while the server refused it by default,
+ * so the user submitted a form that was torn down. Now the affordance tracks
+ * the server's real capability. With no `caps` (capability unknown) claude-tui
+ * is treated as NOT supported, matching the server's default-OFF refusal.
+ */
+export function providerSupportsSingleMultiSelect(
+  provider: string | null | undefined,
+  caps?: ProviderRenderCapabilities | null,
+): boolean {
   if (!provider) return false
-  if (provider === 'claude-tui') return true
+  if (provider === 'claude-tui') return caps?.multiSelectReinject === true
   return getProviderInfo(provider).type !== 'cli'
 }


### PR DESCRIPTION
## Summary
Closes the capability **split-brain** that all 6 SOLID/DRY audit agents flagged as the #1 finding. The client rendered the claude-tui multi-select checkbox form unconditionally, while the server only honors it behind `CHROXY_TUI_MULTISELECT_REINJECT` (default **OFF**) — so on a default-config daemon the user submitted a form the server tore down with "Tap Retry". Now the server's capability is authoritative and the client gates on it; the flag flips both sides in lockstep.

Builds on #5795 (the predicate hoist), which noted this as the follow-up.

## Changes
- **Server** (`claude-tui-session.js`): `capabilities` now advertises `multiSelectReinject: multiSelectReinjectEnabled()`, read at access time so it reflects the daemon env (`listProviders` calls the getter per connection).
- **store-core** (`provider-labels.ts`): `providerSupportsSingleMultiSelect(provider, caps?)` gates `claude-tui` on `caps.multiSelectReinject`; other providers unchanged. New `ProviderRenderCapabilities` type exported. With no caps (capability unknown) claude-tui is treated as **unsupported**, matching the server's default-OFF refusal.
- **Clients**: dashboard (`App.tsx` → `useMessageRenderer`) and app (`SessionScreen.tsx`) pass the active provider's advertised capabilities to the predicate. Both client `ProviderCapabilities` types gain `multiSelectReinject?`.

## Verification
- store-core: typecheck clean; **1521** tests incl. new #5791 cap-gating cases (claude-tui false without/with the cap; cap ignored for non-tui providers)
- dashboard: `tsc` clean; **52** QuestionPrompt/useMessageRenderer tests
- app: `tsc` clean; **9** MessageBubble multiQuestion tests
- server: **275** claude-tui-session tests incl. a new one asserting `capabilities.multiSelectReinject` tracks the env flag (unset/`1`/`0`); custom server lints green

## Behavior change
Default config (flag off): claude-tui no longer shows the multi-select checkbox form (it never worked there — the server refused it). With the flag on (e.g. the live daemon), the form is offered exactly as before. SDK-family providers are unaffected.

Closes #5791
