### PR TITLE
refactor(server): break up claude-tui respondToQuestion + sendMessage typed return (#5799)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1773,13 +1773,23 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   async sendMessage(prompt, attachments, _options = {}) {
+    // #5800: these two guards signal failure to callers via a typed result
+    // ({ ok: false, reason }) IN ADDITION to the legacy emit('error', ...).
+    // The emit is unchanged (existing error surfacing relies on it); the
+    // typed return lets a caller (e.g. the multi-select reinject path in
+    // form-driver.js) observe the failure via the call result instead of
+    // mirroring these host internals from the outside. The happy path
+    // returns undefined as before — callers branch only on the failure
+    // shape. input-handlers.js (the non-reinject caller) ignores the
+    // resolved value entirely; it only attaches a defensive .catch, which a
+    // resolved typed object never trips.
     if (this._isBusy) {
       this.emit('error', { message: 'Already processing a message' })
-      return
+      return { ok: false, reason: 'busy' }
     }
     if (!this._processReady || !this._term || this._ptyExited) {
       this.emit('error', { message: 'Session not started or PTY no longer alive' })
-      return
+      return { ok: false, reason: 'not_runnable' }
     }
 
     this._isBusy = true

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -142,6 +142,51 @@ export function formatMultiSelectReinject(questions, answersMap) {
   return lines.join('\n')
 }
 
+// #5800 — refusal table for the multi-select reinject pre-flight guards. Each
+// reinject guard (empty selection / busy session / not-runnable session /
+// flag-off unsupported) used to inline a near-identical
+// warn → _teardownAskUserQuestion(...) → return block that differed only by
+// these four strings. The strings are the WIRE CONTRACT — the dashboard + app
+// branch on errorCode, and tests assert the exact codes — so they are pinned
+// here verbatim. _refuseReinject() looks a reason up here and tears down; the
+// distinct rationale comment for each guard stays at the call site.
+const REINJECT_REFUSALS = {
+  // Nothing resolvable was selected — recover via teardown rather than send an
+  // empty turn.
+  empty: {
+    synthResult: 'No selection received for the multi-select question.',
+    emitResultReason: 'ask_user_question_multiselect_empty',
+    errorCode: 'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+    errorMessage: 'No selection received. Tap Retry to resend your request.',
+  },
+  // The answer raced ahead of the denied turn's Stop-hook teardown, so the
+  // session is still busy; surface a retryable error instead of silently
+  // dropping the selection (#5776 busy-race).
+  busy: {
+    synthResult: 'Multi-select answer arrived before the previous turn finished; not delivered.',
+    emitResultReason: 'ask_user_question_multiselect_busy',
+    errorCode: 'ASK_USER_QUESTION_MULTISELECT_BUSY',
+    errorMessage: 'Your selection arrived while the previous turn was still finishing. Tap Retry to resend it.',
+  },
+  // The session isn't runnable (PTY exited / not yet started); tear down with a
+  // retryable error BEFORE clearing state so the user can resend once it's back
+  // (#5781 review / #5784).
+  unavailable: {
+    synthResult: 'Multi-select answer could not be delivered; the session was not running.',
+    emitResultReason: 'ask_user_question_multiselect_unavailable',
+    errorCode: 'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+    errorMessage: 'Your selection could not be delivered — the session wasn\'t running. Tap Retry once it\'s back.',
+  },
+  // Default (flag-off) behavior: multi-select is denied at the permission hook;
+  // refuse to drive keystrokes for a form we can't reliably toggle+submit.
+  unsupported: {
+    synthResult: 'Multi-select questions aren\'t supported by the TUI provider. Ask one single-select question at a time.',
+    emitResultReason: 'ask_user_question_multiselect_unsupported',
+    errorCode: 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+    errorMessage: 'Multi-select questions aren\'t supported here. Tap Retry to resend your request.',
+  },
+}
+
 // --- interactive-form driver: an injected collaborator of ClaudeTuiSession (#5617) ---
 export class FormDriver {
   /**
@@ -278,90 +323,10 @@ export class FormDriver {
     // since #4648 and still flow through the assembler below if hook-bypassed —
     // that dead path is removed in the follow-up cleanup.)
     if (pendingQuestions.length <= 1 && pendingQuestions.some((q) => q && q.multiSelect === true)) {
-      // #5776 (Phase 0) — reinject path: format the selection into text and feed
-      // it to claude as a new turn instead of driving (un-drivable) keystrokes.
-      // The form was denied at permission-hook.sh before it rendered, so there is
-      // no live form and no PostToolUse — claude has stopped and is waiting for
-      // the next user message (verified live 2026-06-13). Gated by the env flag;
-      // when off, fall through to the original refuse-and-teardown behavior.
-      if (multiSelectReinjectEnabled()) {
-        const reinjectText = formatMultiSelectReinject(pendingQuestions, answersMap)
-        if (opts && typeof opts.freeformText === 'string' && opts.freeformText.length > 0) {
-          // Phase 1 (#5776 option B) — free-text combine deferred. Log so a
-          // dropped custom answer is visible rather than silent.
-          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject dropping freeformText (Phase 1, #5776 option B) tool=${prevToolUseId || '?'}`)
-        }
-        if (reinjectText.length === 0) {
-          // Nothing resolvable selected — recover via teardown rather than send
-          // an empty turn.
-          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject produced empty text (tool=${prevToolUseId || '?'}) — tearing down`)
-          this._teardownAskUserQuestion(prevToolUseId, {
-            synthResult: 'No selection received for the multi-select question.',
-            emitResultReason: 'ask_user_question_multiselect_empty',
-            errorCode: 'ASK_USER_QUESTION_MULTISELECT_EMPTY',
-            errorMessage: 'No selection received. Tap Retry to resend your request.',
-          })
-          return
-        }
-        // #5776 — the reinject only works once the in-flight (denied) turn has
-        // wound down to idle. sendMessage() early-returns (emit 'error' + bare
-        // return — NOT a Promise rejection, so the .catch below can't observe it)
-        // when _isBusy is still true. In the normal flow the model stops on the
-        // deny, its Stop hook drains, and the session is idle by the time the
-        // human answers seconds later (verified live 2026-06-13). But if the
-        // answer races ahead of that Stop-hook teardown, or the model ignored the
-        // deny, the turn is still busy — and silently dropping the selection would
-        // wedge the session until the 2h hard cap. Surface a retryable error
-        // instead so the user can resend once the turn has settled (the teardown
-        // is a no-op-safe interleave with the Stop-hook drain via the poll loop's
-        // !_isBusy early return). A future Phase 1 robustness pass can await-idle
-        // and deliver seamlessly; for the spike, fail loud + recoverable.
-        if (this._host._isBusy) {
-          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject deferred — session still busy (tool=${prevToolUseId || '?'}); the answer raced the turn teardown`)
-          this._teardownAskUserQuestion(prevToolUseId, {
-            synthResult: 'Multi-select answer arrived before the previous turn finished; not delivered.',
-            emitResultReason: 'ask_user_question_multiselect_busy',
-            errorCode: 'ASK_USER_QUESTION_MULTISELECT_BUSY',
-            errorMessage: 'Your selection arrived while the previous turn was still finishing. Tap Retry to resend it.',
-          })
-          return
-        }
-        // sendMessage() has a SECOND fail-open guard beyond _isBusy: if the
-        // session isn't runnable (!_processReady / no _term / _ptyExited) it
-        // emit('error')s + bare-returns without starting a turn. We clear the
-        // pending entry + watchdog + lock just below, so reaching sendMessage in
-        // that state would drop the selection with no retry path (same wedge
-        // class the _isBusy guard closes). Mirror that guard here: tear down with
-        // a retryable error BEFORE clearing state so the user can resend once the
-        // session is back. (#5781 review / #5784)
-        if (!this._host._processReady || !this._host._term || this._host._ptyExited) {
-          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject deferred — session not runnable (tool=${prevToolUseId || '?'}); PTY exited or not yet started`)
-          this._teardownAskUserQuestion(prevToolUseId, {
-            synthResult: 'Multi-select answer could not be delivered; the session was not running.',
-            emitResultReason: 'ask_user_question_multiselect_unavailable',
-            errorCode: 'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
-            errorMessage: 'Your selection could not be delivered — the session wasn\'t running. Tap Retry once it\'s back.',
-          })
-          return
-        }
-        ;(this._host._log || log).info(`respondToQuestion: multiSelect reinject (flag on) tool=${prevToolUseId || '?'} text="${reinjectText.slice(0, 80)}"`)
-        // The denied form left a pending entry + armed watchdog; clear both, plus
-        // the sibling lock, before starting the new turn.
-        this._host._clearPendingAnswerByToolUseId(prevToolUseId)
-        this._host._clearAskUserQuestionWatchdog(prevToolUseId)
-        this._host._clearAskUserQuestionLock()
-        Promise.resolve(this._host.sendMessage(reinjectText)).catch((err) => {
-          ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject sendMessage failed: ${err?.message || err} (tool=${prevToolUseId || '?'})`)
-        })
-        return
-      }
-      ;(this._host._log || log).warn(`respondToQuestion: refusing single multiSelect AskUserQuestion (tool=${prevToolUseId || '?'}) — multi-select is denied at the permission hook; not driving keystrokes`)
-      this._teardownAskUserQuestion(prevToolUseId, {
-        synthResult: 'Multi-select questions aren\'t supported by the TUI provider. Ask one single-select question at a time.',
-        emitResultReason: 'ask_user_question_multiselect_unsupported',
-        errorCode: 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
-        errorMessage: 'Multi-select questions aren\'t supported here. Tap Retry to resend your request.',
-      })
+      // #5800: the single multi-select branch (reinject when flag-on, refuse
+      // when flag-off) is its own strategy — extracted so respondToQuestion
+      // reads as a router. Pure restructure: no keystroke/timer/teardown change.
+      this._reinjectMultiSelect(prevToolUseId, pendingQuestions, answersMap, opts)
       return
     }
     // Single-question / free-text path requires a non-empty `text`. The single
@@ -613,6 +578,109 @@ export class FormDriver {
       errorCode: 'ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED',
       errorMessage: 'Multi-question forms aren\'t supported here. Tap Retry to resend as single questions.',
     })
+  }
+
+  /**
+   * #5800 — refuse a multi-select reinject: warn + tear the turn down with the
+   * pinned wire payload for `reason` (a key of REINJECT_REFUSALS). Collapses the
+   * four near-identical warn → _teardownAskUserQuestion → return blocks the
+   * reinject guards used to inline. The error codes/messages/synthResults are
+   * UNCHANGED (they're the wire contract); only the duplication is gone.
+   * Callers still `return` after calling this (it does not itself return).
+   *
+   * @param {string|null} toolUseId — the pending entry's tool id.
+   * @param {'empty'|'busy'|'unavailable'|'unsupported'} reason — refusal kind.
+   * @param {string} warnMessage — the (reason-specific) diagnostic log line.
+   */
+  _refuseReinject(toolUseId, reason, warnMessage) {
+    ;(this._host._log || log).warn(warnMessage)
+    this._teardownAskUserQuestion(toolUseId, REINJECT_REFUSALS[reason])
+  }
+
+  /**
+   * #5800 — the single multi-select strategy, extracted from respondToQuestion
+   * so it reads as a router. When the reinject flag is ON, format the picked
+   * labels into plain text and feed claude a fresh turn via sendMessage() (the
+   * denied form never rendered → no live form, no PostToolUse). When OFF, refuse
+   * + tear down (default behavior preserved). Pre-flight guards (empty / busy /
+   * not-runnable) tear down with a retryable error via _refuseReinject instead
+   * of reaching sendMessage in a state where the selection would be dropped with
+   * no retry path. Pure restructure of the former inline block (#5776/#5781):
+   * same control flow, same teardown payloads, same clear ordering.
+   *
+   * @param {string|null} prevToolUseId — the pending entry's tool id.
+   * @param {object[]} pendingQuestions — the entry's questions array.
+   * @param {object} [answersMap] — `{ [questionText]: string | string[] }`.
+   * @param {object} [opts] — extra options (freeformText is dropped, Phase 1).
+   */
+  _reinjectMultiSelect(prevToolUseId, pendingQuestions, answersMap, opts) {
+    // #5776 (Phase 0) — reinject path: format the selection into text and feed
+    // it to claude as a new turn instead of driving (un-drivable) keystrokes.
+    // The form was denied at permission-hook.sh before it rendered, so there is
+    // no live form and no PostToolUse — claude has stopped and is waiting for
+    // the next user message (verified live 2026-06-13). Gated by the env flag;
+    // when off, fall through to the original refuse-and-teardown behavior.
+    if (multiSelectReinjectEnabled()) {
+      const reinjectText = formatMultiSelectReinject(pendingQuestions, answersMap)
+      if (opts && typeof opts.freeformText === 'string' && opts.freeformText.length > 0) {
+        // Phase 1 (#5776 option B) — free-text combine deferred. Log so a
+        // dropped custom answer is visible rather than silent.
+        ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject dropping freeformText (Phase 1, #5776 option B) tool=${prevToolUseId || '?'}`)
+      }
+      if (reinjectText.length === 0) {
+        // Nothing resolvable selected — recover via teardown rather than send
+        // an empty turn.
+        this._refuseReinject(prevToolUseId, 'empty',
+          `respondToQuestion: multiSelect reinject produced empty text (tool=${prevToolUseId || '?'}) — tearing down`)
+        return
+      }
+      // #5776 — the reinject only works once the in-flight (denied) turn has
+      // wound down to idle. sendMessage() reports failure via a typed result
+      // (#5800: { ok:false, reason:'busy' }) — and still emit('error')s — when
+      // _isBusy is true, so a .catch can't observe the drop. In the normal flow
+      // the model stops on the deny, its Stop hook drains, and the session is
+      // idle by the time the human answers seconds later (verified live
+      // 2026-06-13). But if the answer races ahead of that Stop-hook teardown,
+      // or the model ignored the deny, the turn is still busy — and silently
+      // dropping the selection would wedge the session until the 2h hard cap.
+      // Pre-flight on _isBusy here (rather than calling sendMessage and reading
+      // its result) so we surface a retryable error WITHOUT firing a redundant
+      // emit('error') and WITHOUT clearing the pending state first; the user can
+      // resend once the turn has settled (the teardown is a no-op-safe interleave
+      // with the Stop-hook drain via the poll loop's !_isBusy early return). A
+      // future Phase 1 robustness pass can await-idle and deliver seamlessly.
+      if (this._host._isBusy) {
+        this._refuseReinject(prevToolUseId, 'busy',
+          `respondToQuestion: multiSelect reinject deferred — session still busy (tool=${prevToolUseId || '?'}); the answer raced the turn teardown`)
+        return
+      }
+      // sendMessage() has a SECOND fail-open guard beyond _isBusy: if the
+      // session isn't runnable (!_processReady / no _term / _ptyExited) it
+      // emit('error')s + returns { ok:false, reason:'not_runnable' } (#5800)
+      // without starting a turn. We clear the pending entry + watchdog + lock
+      // just below, so reaching sendMessage in that state would drop the
+      // selection with no retry path (same wedge class the _isBusy guard
+      // closes). Mirror that guard here: tear down with a retryable error BEFORE
+      // clearing state so the user can resend once the session is back. (#5781
+      // review / #5784)
+      if (!this._host._processReady || !this._host._term || this._host._ptyExited) {
+        this._refuseReinject(prevToolUseId, 'unavailable',
+          `respondToQuestion: multiSelect reinject deferred — session not runnable (tool=${prevToolUseId || '?'}); PTY exited or not yet started`)
+        return
+      }
+      ;(this._host._log || log).info(`respondToQuestion: multiSelect reinject (flag on) tool=${prevToolUseId || '?'} text="${reinjectText.slice(0, 80)}"`)
+      // The denied form left a pending entry + armed watchdog; clear both, plus
+      // the sibling lock, before starting the new turn.
+      this._host._clearPendingAnswerByToolUseId(prevToolUseId)
+      this._host._clearAskUserQuestionWatchdog(prevToolUseId)
+      this._host._clearAskUserQuestionLock()
+      Promise.resolve(this._host.sendMessage(reinjectText)).catch((err) => {
+        ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject sendMessage failed: ${err?.message || err} (tool=${prevToolUseId || '?'})`)
+      })
+      return
+    }
+    this._refuseReinject(prevToolUseId, 'unsupported',
+      `respondToQuestion: refusing single multiSelect AskUserQuestion (tool=${prevToolUseId || '?'}) — multi-select is denied at the permission hook; not driving keystrokes`)
   }
 
   /**

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -84,8 +84,12 @@ function makeMockHost(overrides = {}) {
     // emit('error') + returns WITHOUT sending (and resolves, not rejects), so a
     // .catch can't observe the drop. The form-driver guards on _isBusy before
     // calling, so this stub primarily proves the call is not made when busy.
+    // #5800 — sendMessage now also returns a typed result on its guard paths
+    // ({ ok:false, reason } on busy/not-runnable; undefined on the happy path).
+    // The stub mirrors that contract; the form-driver still preflights before
+    // calling, so the typed shape is consumed only by callers that branch on it.
     sendMessage: (text) => {
-      if (host._isBusy) { errors.push('Already processing a message'); return Promise.resolve() }
+      if (host._isBusy) { errors.push('Already processing a message'); return Promise.resolve({ ok: false, reason: 'busy' }) }
       sent.push(text); return Promise.resolve()
     },
     // Back-compat getter: most-recently-set entry (the no-toolUseId path).

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -90,6 +90,7 @@ function makeMockHost(overrides = {}) {
     // calling, so the typed shape is consumed only by callers that branch on it.
     sendMessage: (text) => {
       if (host._isBusy) { errors.push('Already processing a message'); return Promise.resolve({ ok: false, reason: 'busy' }) }
+      if (!host._processReady || !host._term || host._ptyExited) { errors.push('Session not running'); return Promise.resolve({ ok: false, reason: 'not_runnable' }) }
       sent.push(text); return Promise.resolve()
     },
     // Back-compat getter: most-recently-set entry (the no-toolUseId path).


### PR DESCRIPTION
## Summary
Breaks up the ~400-line `respondToQuestion` and restores the host/driver seam, per the SOLID/DRY swarm audit (Architect/Guardian/Minimalist/Tester). Pure restructure — **no change to keystroke sequences, timers, error codes/messages, or the default (flag-off) refusal behavior.**

## Changes
1. **`sendMessage` typed return** (`claude-tui-session.js`): the busy / not-runnable guards now `return { ok: false, reason }` **in addition to** the existing `emit('error', ...)`, giving the reinject path an honest contract instead of relying on emit+bare-return. Happy path return is unchanged (`undefined`). The one non-reinject caller (`input-handlers.js:509`) only attaches `.catch` to the returned promise and never inspects the resolution value — verified unaffected.
2. **`_refuseReinject` helper + `REINJECT_REFUSALS` const table** (`form-driver.js`): the four near-identical guard→teardown blocks (empty/busy/unavailable/unsupported) collapse onto one helper backed by a reason→payload table. The wire error codes/messages/synthResult/emitResultReason are **byte-identical** to the originals; each call site keeps its rationale comment.
3. **`_reinjectMultiSelect` extraction** (`form-driver.js`): the multi-select reinject block moves to its own method so `respondToQuestion` reads as a router. The other strategies (single-digit, Other/freeform, arrow-nav, multi-question refusal) stay in place.

## Scoping note
The audit suggested routing the busy/not-runnable preflights *through* the new `sendMessage` result. I deliberately **kept them as preflight guards** — the existing tests pin that `sendMessage` is **not** called on the busy path and that pending state is **not** cleared before bailing on not-runnable. Switching to result-driven would break those invariants. The typed return is the honest contract; the guards stay.

## Verification
- `claude-tui-form-driver.test.js` + `claude-tui-session.test.js` + `input-handlers.test.js`: **294/294 pass** (the busy/not-runnable reinject invariants hold)
- Full server suite: only the known live-`:8765`-daemon integration flakes (`service` / `encryption-integration`) fail locally — unrelated to claude-tui; CI runs clean without the daemon
- Custom server lints (logger-session-scoping, session-opt-forwarding) green
- form-driver test mock host's `sendMessage` updated to return the typed shape

Closes #5799
