### PR TITLE
fix: give the new AskUserQuestion error codes the same retry UX as STALL (#5793)

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -23,7 +23,7 @@ import { ToolDetailModal } from './chat/ToolDetailModal';
 import { MessageBubble } from './chat/MessageBubble';
 import type { SelectOptionValue } from './chat/MessageBubble';
 import type { MultiQuestionAnswersMap } from './chat/MultiQuestionForm';
-import { buildChatViewMessages } from '@chroxy/store-core';
+import { buildChatViewMessages, isRetryableAskUserQuestionError } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 import { usePermissionAnnouncer } from '../hooks/usePermissionAnnouncer';
 
@@ -423,10 +423,13 @@ export function ChatView({
               getInitialExpanded={getInitialExpanded}
               onExpandedChange={handleExpandedChange}
               onRetryStreamStall={
-                // #4496: only wire retry when this stall is the tail bubble
-                // AND there's a user_input to resend.
+                // #4496 / #5793: only wire retry when this stall/teardown is
+                // the tail bubble AND there's a user_input to resend. Covers
+                // stream_stall plus the retryable AskUserQuestion codes
+                // (ASK_USER_QUESTION_STALL + the MULTISELECT/MULTI_QUESTION
+                // teardown codes) so all of them get the resend affordance.
                 msg.type === 'error' &&
-                msg.code === 'stream_stall' &&
+                (msg.code === 'stream_stall' || isRetryableAskUserQuestionError(msg.code)) &&
                 msg.id === chatTailMessageId &&
                 lastUserInputContent != null
                   ? () => sendInput(lastUserInputContent)

--- a/packages/app/src/components/StreamStallChip.tsx
+++ b/packages/app/src/components/StreamStallChip.tsx
@@ -32,9 +32,18 @@ export interface StreamStallChipProps {
    * misleading.
    */
   onRetry?: () => void;
+  /**
+   * #5793 — chip headline + accessibility label. Defaults to the
+   * stream-stall copy; callers reuse this same amber "recoverable, retry"
+   * chip for the AskUserQuestion teardown codes by passing the
+   * question-delivery copy (the dashboard has a separate
+   * AskUserQuestionStallChip; mobile reuses this one with a different
+   * headline to avoid duplicating the whole amber-chip layout).
+   */
+  headline?: string;
 }
 
-export function StreamStallChip({ errorText, onRetry }: StreamStallChipProps) {
+export function StreamStallChip({ errorText, onRetry, headline = 'Stream stalled — retry?' }: StreamStallChipProps) {
   const [detailVisible, setDetailVisible] = useState(false);
 
   const handleRetry = useCallback(() => {
@@ -50,7 +59,7 @@ export function StreamStallChip({ errorText, onRetry }: StreamStallChipProps) {
       testID="stream-stall-chip"
       accessibilityRole="alert"
       accessibilityLiveRegion="polite"
-      accessibilityLabel="Stream stalled — retry?"
+      accessibilityLabel={headline}
       accessibilityHint={errorText}
       // Long-press reveals the underlying server diagnostic text without
       // an always-on text wall on the chip — preserves the "raw error
@@ -59,7 +68,7 @@ export function StreamStallChip({ errorText, onRetry }: StreamStallChipProps) {
       style={styles.container}
     >
       <View style={styles.dot} />
-      <Text style={styles.label}>Stream stalled — retry?</Text>
+      <Text style={styles.label}>{headline}</Text>
       {onRetry && (
         <Pressable
           testID="stream-stall-chip-retry"

--- a/packages/app/src/components/__tests__/MessageBubble.streamStall.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.streamStall.test.tsx
@@ -82,3 +82,46 @@ describe('MessageBubble stream-stall handling (#4496)', () => {
     expect(retries).toHaveLength(0);
   });
 });
+
+describe('MessageBubble retryable AskUserQuestion errors (#5793)', () => {
+  function makeAskMessage(code: string): ChatMessage {
+    return {
+      id: 'err-3',
+      type: 'error',
+      code,
+      content: "Couldn't deliver your answers. Tap Retry to resend your request.",
+      timestamp: Date.now(),
+    } as ChatMessage;
+  }
+
+  // The five new codes (plus the long-handled STALL) all carry "Tap Retry"
+  // copy — they must render the StreamStallChip, not the generic red bubble.
+  it.each([
+    'ASK_USER_QUESTION_STALL',
+    'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+    'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+    'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+    'ASK_USER_QUESTION_MULTISELECT_BUSY',
+    'ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED',
+  ])('renders the StreamStallChip for error{code: "%s"}', (code) => {
+    const tree = render(makeAskMessage(code));
+    const chip = tree.root.findByProps({ testID: 'stream-stall-chip' });
+    expect(chip).toBeDefined();
+  });
+
+  it('forwards onRetryStreamStall to the chip for a new code (tail)', () => {
+    const onRetry = jest.fn();
+    const tree = render(makeAskMessage('ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED'), onRetry);
+    const retry = tree.root.findByProps({ testID: 'stream-stall-chip-retry' });
+    act(() => {
+      retry.props.onPress?.();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses question-delivery copy (not stream-stall copy) for the ask-question codes', () => {
+    const tree = render(makeAskMessage('ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED'));
+    const chip = tree.root.findByProps({ testID: 'stream-stall-chip' });
+    expect(chip.props.accessibilityLabel).toBe('Question delivery failed — retry?');
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -8,7 +8,7 @@ import {
   Image,
   LayoutAnimation,
 } from 'react-native';
-import { OTHER_OPTION_VALUE, bumpRenderCount } from '@chroxy/store-core';
+import { OTHER_OPTION_VALUE, bumpRenderCount, isRetryableAskUserQuestionError } from '@chroxy/store-core';
 // #4875: `OtherFreeformAnswer` moved to @chroxy/store-core/freeform-answer
 // so the mobile store, the mobile screen, and (eventually) the dashboard
 // can converge on a single declaration paired with the shared
@@ -297,19 +297,30 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
     );
   }
 
-  // #4496: distinct chip for stream-stall errors (server PR #4475 emits
-  // `error{code: 'stream_stall'}` after the configured inactivity window).
-  // Generic red bubble reads as "broken"; this affordance signals
+  // #4496 / #5793: distinct chip for stream-stall errors (server PR #4475
+  // emits `error{code: 'stream_stall'}` after the configured inactivity
+  // window) AND for the retryable AskUserQuestion teardown codes
+  // (ASK_USER_QUESTION_STALL + five MULTISELECT/MULTI_QUESTION codes — see
+  // `isRetryableAskUserQuestionError`). Both end in "Tap Retry" copy; a
+  // generic red bubble reads as "broken", so this affordance signals
   // "recoverable, just retry". `onRetryStreamStall` is only wired by
-  // ChatView when this stall is the tail message — historical replayed
-  // stalls render the chip text with the raw error reachable on
-  // long-press, but no retry button (resending an ancient user_input
-  // from a long-finished turn would be misleading).
-  if (isError && message.code === 'stream_stall') {
+  // ChatView when this is the tail message — historical replayed stalls
+  // render the chip text with the raw error reachable on long-press, but no
+  // retry button (resending an ancient user_input from a long-finished turn
+  // would be misleading).
+  if (isError && (message.code === 'stream_stall' || isRetryableAskUserQuestionError(message.code))) {
     return (
       <StreamStallChip
         errorText={message.content?.trim() || ''}
         onRetry={onRetryStreamStall}
+        // #5793: the AskUserQuestion teardown codes are a question-delivery
+        // failure, not a stream stall — use copy that matches the dashboard's
+        // AskUserQuestionStallChip ("Question delivery failed — retry?").
+        headline={
+          isRetryableAskUserQuestionError(message.code)
+            ? 'Question delivery failed — retry?'
+            : undefined
+        }
       />
     );
   }

--- a/packages/dashboard/src/hooks/useMessageRenderer.test.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * useMessageRenderer routing tests — #5793
+ *
+ * Focused coverage of the error-bubble branch ladder: a retryable
+ * AskUserQuestion teardown error (ASK_USER_QUESTION_STALL + the five
+ * MULTISELECT/MULTI_QUESTION codes) must route to the dedicated
+ * `AskUserQuestionStallChip` (with a Retry control on the tail entry), NOT the
+ * generic error bubble. Before #5793 only ASK_USER_QUESTION_STALL was
+ * special-cased, so the new codes fell through to a dead generic bubble.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, renderHook } from '@testing-library/react'
+import type { ChatMessage } from '@chroxy/store-core'
+import { useMessageRenderer, type UseMessageRendererArgs } from './useMessageRenderer'
+import type { ChatViewMessage } from '../components/ChatView'
+
+afterEach(cleanup)
+
+function errorMsg(id: string, code: string): ChatMessage {
+  return {
+    id,
+    type: 'error',
+    content: "Couldn't deliver your answers. Tap Retry to resend your request.",
+    timestamp: 0,
+    code,
+  } as ChatMessage
+}
+
+function userInput(id: string, content: string): ChatMessage {
+  return { id, type: 'user_input', content, timestamp: 0 } as ChatMessage
+}
+
+function makeArgs(overrides: Partial<UseMessageRendererArgs>): UseMessageRendererArgs {
+  return {
+    storeMsgMap: new Map(),
+    chatToolGroupPayloads: new Map(),
+    chatTailMessageId: null,
+    sendPermissionResponse: vi.fn(),
+    sendUserQuestionResponse: vi.fn(),
+    markPromptAnswered: vi.fn(),
+    storeMessages: [],
+    sendInput: vi.fn(),
+    streamStallTimeoutMs: null,
+    allowMultiQuestionForm: false,
+    activeSessionProvider: null,
+    activeSessionCaps: null,
+    setViewMode: vi.fn(),
+    stalledPromptIds: new Set<string>(),
+    hasPendingAskUserQuestionPermission: false,
+    sessions: [],
+    ...overrides,
+  } as UseMessageRendererArgs
+}
+
+const NEW_CODES = [
+  'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+  'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+  'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+  'ASK_USER_QUESTION_MULTISELECT_BUSY',
+  'ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED',
+] as const
+
+describe('useMessageRenderer — retryable AskUserQuestion errors (#5793)', () => {
+  it.each(NEW_CODES)('routes %s to the AskUserQuestionStallChip with a Retry control', (code) => {
+    const err = errorMsg('e1', code)
+    const ui = userInput('u1', 'original request')
+    const sendInput = vi.fn()
+    const args = makeArgs({
+      storeMsgMap: new Map([['e1', err]]),
+      chatTailMessageId: 'e1',
+      storeMessages: [ui, err],
+      sendInput,
+    })
+    const { result } = renderHook(() => useMessageRenderer(args))
+    const node = result.current({ id: 'e1', type: 'error', content: err.content, timestamp: 0, code } as ChatViewMessage)
+    render(<>{node}</>)
+    expect(screen.getByTestId('ask-user-question-stall-chip')).toBeInTheDocument()
+    // Tail entry with a user_input to resend → Retry button is wired.
+    const retry = screen.getByTestId('ask-user-question-stall-chip-retry')
+    retry.click()
+    expect(sendInput).toHaveBeenCalledWith('original request')
+  })
+
+  it('still routes ASK_USER_QUESTION_STALL to the chip (no regression)', () => {
+    const err = errorMsg('e1', 'ASK_USER_QUESTION_STALL')
+    const args = makeArgs({
+      storeMsgMap: new Map([['e1', err]]),
+      chatTailMessageId: 'e1',
+      storeMessages: [err],
+    })
+    const { result } = renderHook(() => useMessageRenderer(args))
+    const node = result.current({ id: 'e1', type: 'error', content: err.content, timestamp: 0, code: 'ASK_USER_QUESTION_STALL' } as ChatViewMessage)
+    render(<>{node}</>)
+    expect(screen.getByTestId('ask-user-question-stall-chip')).toBeInTheDocument()
+  })
+
+  it('leaves an unrelated error code to the generic fallback (no stall chip)', () => {
+    const err = errorMsg('e1', 'SESSION_TOKEN_MISMATCH')
+    const args = makeArgs({
+      storeMsgMap: new Map([['e1', err]]),
+      chatTailMessageId: 'e1',
+      storeMessages: [err],
+    })
+    const { result } = renderHook(() => useMessageRenderer(args))
+    const node = result.current({ id: 'e1', type: 'error', content: err.content, timestamp: 0, code: 'SESSION_TOKEN_MISMATCH' } as ChatViewMessage)
+    render(<>{node}</>)
+    expect(screen.queryByTestId('ask-user-question-stall-chip')).toBeNull()
+  })
+})

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import type { ReactNode } from 'react'
 import type { ChatMessage, SessionInfo } from '@chroxy/store-core'
-import { providerSupportsSingleMultiSelect } from '@chroxy/store-core'
+import { providerSupportsSingleMultiSelect, isRetryableAskUserQuestionError } from '@chroxy/store-core'
 import type { ChatViewMessage } from '../components/ChatView'
 import type { ConnectionState } from '../store/connection'
 import type { ProviderCapabilities } from '../store/types'
@@ -258,16 +258,18 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
       )
     }
 
-    // #4615: dedicated chip for ASK_USER_QUESTION_STALL errors. The server
-    // emits `error{code: 'ASK_USER_QUESTION_STALL'}` (PR #4614) when the
-    // Claude TUI never acknowledges an AskUserQuestion answer — typically
-    // a multi-question form wedge. Generic red toast reads as "broken";
-    // this affordance signals "recoverable, just retry your original
-    // request" and offers a one-tap resend of the last user message.
-    // Mirrors the StreamStallChip pattern (#4476): retry only on tail
-    // entries so replayed historical stalls show the chip + tooltip for
-    // diagnostics but don't offer a misleading resend button.
-    if (storeMsg.type === 'error' && storeMsg.code === 'ASK_USER_QUESTION_STALL') {
+    // #4615 / #5793: dedicated chip for retryable AskUserQuestion teardown
+    // errors. The server emits ASK_USER_QUESTION_STALL (PR #4614) plus five
+    // MULTISELECT/MULTI_QUESTION codes (see `isRetryableAskUserQuestionError`)
+    // when the Claude TUI never acknowledges an AskUserQuestion answer or
+    // denies a multi-select / multi-question form — all carry "Tap Retry" in
+    // their copy. Generic red toast reads as "broken"; this affordance
+    // signals "recoverable, just retry your original request" and offers a
+    // one-tap resend of the last user message. Mirrors the StreamStallChip
+    // pattern (#4476): retry only on tail entries so replayed historical
+    // stalls show the chip + tooltip for diagnostics but don't offer a
+    // misleading resend button.
+    if (storeMsg.type === 'error' && isRetryableAskUserQuestionError(storeMsg.code)) {
       const isTail = msg.id === chatTailMessageId
       const lastUserInput = isTail
         ? [...storeMessages].reverse().find(m => m.type === 'user_input')

--- a/packages/store-core/src/ask-user-question-errors.test.ts
+++ b/packages/store-core/src/ask-user-question-errors.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for the retryable AskUserQuestion error predicate (#5793).
+ *
+ * Single source of truth for "is this an AskUserQuestion teardown error the
+ * user can recover from by resending?" — narrowed by both clients' stall-chip
+ * / retry render paths and by `buildChatViewMessages`' stalled-prompt
+ * suppression. A drift here silently drops the retry UX on a code, so the set
+ * is pinned exactly.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  RETRYABLE_ASK_USER_QUESTION_ERROR_CODES,
+  isRetryableAskUserQuestionError,
+} from './ask-user-question-errors'
+
+describe('isRetryableAskUserQuestionError (#5793)', () => {
+  it.each([
+    'ASK_USER_QUESTION_STALL',
+    'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+    'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+    'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+    'ASK_USER_QUESTION_MULTISELECT_BUSY',
+    'ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED',
+  ])('is true for %s', (code) => {
+    expect(isRetryableAskUserQuestionError(code)).toBe(true)
+  })
+
+  it.each([
+    'stream_stall',
+    'resume_unknown',
+    'SESSION_TOKEN_MISMATCH',
+    'UNKNOWN',
+    '',
+    'ASK_USER_QUESTION', // prefix-only must not match
+  ])('is false for unrelated code %s', (code) => {
+    expect(isRetryableAskUserQuestionError(code)).toBe(false)
+  })
+
+  it('is false for null / undefined', () => {
+    expect(isRetryableAskUserQuestionError(null)).toBe(false)
+    expect(isRetryableAskUserQuestionError(undefined)).toBe(false)
+  })
+
+  it('exports the exact set of six codes', () => {
+    expect([...RETRYABLE_ASK_USER_QUESTION_ERROR_CODES].sort()).toEqual(
+      [
+        'ASK_USER_QUESTION_MULTISELECT_BUSY',
+        'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+        'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+        'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+        'ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED',
+        'ASK_USER_QUESTION_STALL',
+      ].sort(),
+    )
+  })
+})

--- a/packages/store-core/src/ask-user-question-errors.ts
+++ b/packages/store-core/src/ask-user-question-errors.ts
@@ -1,0 +1,53 @@
+/**
+ * Retryable AskUserQuestion error codes (#5793).
+ *
+ * `packages/server/src/claude-tui/form-driver.js` tears down a wedged
+ * AskUserQuestion prompt by emitting `error{code, toolUseId}` whose copy ends
+ * in "Tap Retry to resend your request." The long-handled
+ * `ASK_USER_QUESTION_STALL` (#4614) was the first such code; the multi-select /
+ * multi-question denial path now emits five more with the same shape and the
+ * same "Tap Retry" affordance in their copy:
+ *   - ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED
+ *   - ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE
+ *   - ASK_USER_QUESTION_MULTISELECT_EMPTY
+ *   - ASK_USER_QUESTION_MULTISELECT_BUSY
+ *   - ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED
+ *
+ * Both clients originally hard-coded `=== 'ASK_USER_QUESTION_STALL'` for the
+ * stall-chip / retry path, so the five new codes fell through to a generic red
+ * error bubble with no retry control — a dead promise. This module is the
+ * single source of truth for "is this an AskUserQuestion error that the user
+ * can recover from by resending their original request?" Both the shared
+ * `buildChatViewMessages` stalled-prompt suppression and the per-client
+ * retry-chip renderers narrow off this predicate, so adding a future code is a
+ * one-line change here that lights up the retry UX everywhere.
+ */
+
+/**
+ * The set of AskUserQuestion teardown error codes that carry a "Tap Retry to
+ * resend your request" affordance. Frozen so callers can't mutate it.
+ */
+export const RETRYABLE_ASK_USER_QUESTION_ERROR_CODES: ReadonlySet<string> =
+  new Set([
+    'ASK_USER_QUESTION_STALL',
+    'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+    'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+    'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+    'ASK_USER_QUESTION_MULTISELECT_BUSY',
+    'ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED',
+  ])
+
+/**
+ * True when `code` is an AskUserQuestion teardown error whose copy ends in
+ * "Tap Retry to resend your request." — i.e. the prompt is dead but the user
+ * can recover by resending. Renderers route these through the stall-chip /
+ * retry path; `buildChatViewMessages` adds the invalidated prompt's id to
+ * `stalledPromptIds` so the now-dead interactive prompt is suppressed.
+ *
+ * Returns false for `undefined` / `null` / unrelated codes.
+ */
+export function isRetryableAskUserQuestionError(
+  code: string | null | undefined,
+): boolean {
+  return code != null && RETRYABLE_ASK_USER_QUESTION_ERROR_CODES.has(code)
+}

--- a/packages/store-core/src/ask-user-question-errors.ts
+++ b/packages/store-core/src/ask-user-question-errors.ts
@@ -25,7 +25,10 @@
 
 /**
  * The set of AskUserQuestion teardown error codes that carry a "Tap Retry to
- * resend your request" affordance. Frozen so callers can't mutate it.
+ * resend your request" affordance. Typed as `ReadonlySet` so TS consumers can't
+ * `.add()`/`.delete()` it — the runtime Set is not actually frozen (Object.freeze
+ * doesn't lock a Set's contents), so treat it as immutable by contract. Prefer
+ * `isRetryableAskUserQuestionError()` over reaching into the set directly.
  */
 export const RETRYABLE_ASK_USER_QUESTION_ERROR_CODES: ReadonlySet<string> =
   new Set([

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -202,6 +202,24 @@ describe('buildChatViewMessages', () => {
       const out = buildChatViewMessages(messages, null)
       expect(out.stalledPromptIds.size).toBe(0)
     })
+
+    // #5793 — the multi-select / multi-question teardown codes carry the same
+    // "Tap Retry" affordance as ASK_USER_QUESTION_STALL, so they must also
+    // suppress the now-dead prompt.
+    it.each([
+      'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED',
+      'ASK_USER_QUESTION_MULTISELECT_UNAVAILABLE',
+      'ASK_USER_QUESTION_MULTISELECT_EMPTY',
+      'ASK_USER_QUESTION_MULTISELECT_BUSY',
+      'ASK_USER_QUESTION_MULTI_QUESTION_UNSUPPORTED',
+    ])('marks unanswered prompts before a %s error as stalled', (code) => {
+      const messages: ChatMessage[] = [
+        msg({ id: 'p1', type: 'prompt', content: 'q1' }),
+        msg({ id: 'e1', type: 'error', content: 'teardown', code }),
+      ]
+      const out = buildChatViewMessages(messages, null)
+      expect(out.stalledPromptIds.has('p1')).toBe(true)
+    })
   })
 
   // #4975 — when the LLM interrupts a text content block to call a tool,

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -45,6 +45,7 @@ import {
   applyStreamingOverlay,
   type DisplayGroup,
 } from './group-messages'
+import { isRetryableAskUserQuestionError } from './ask-user-question-errors'
 import type { ChatMessage } from './types'
 
 /**
@@ -175,19 +176,22 @@ export function buildChatViewMessages(
   // can look up system events too.
   const storeMsgMap = new Map(storeMessages.map(m => [m.id, m]))
 
-  // #4615: track which `type: 'prompt'` bubbles have been invalidated by
-  // a subsequent ASK_USER_QUESTION_STALL error. The server emits the
-  // error when the Claude TUI never acknowledges an AskUserQuestion
-  // answer — typically a multi-question form wedge. The pending
-  // QuestionPrompt is now dead, so submitting it would fire keystrokes
-  // into a session that already discarded the prompt context. We
-  // suppress the interactive prompt render (the AskUserQuestionStallChip
-  // rendered for the error bubble below it carries the retry affordance).
+  // #4615 / #5793: track which `type: 'prompt'` bubbles have been
+  // invalidated by a subsequent retryable AskUserQuestion teardown error.
+  // The server emits one of these codes (ASK_USER_QUESTION_STALL plus the
+  // five MULTISELECT/MULTI_QUESTION codes — see
+  // `isRetryableAskUserQuestionError`) when the Claude TUI never
+  // acknowledges an AskUserQuestion answer or denies a multi-select /
+  // multi-question form. The pending QuestionPrompt is now dead, so
+  // submitting it would fire keystrokes into a session that already
+  // discarded the prompt context. We suppress the interactive prompt
+  // render (the AskUserQuestionStallChip rendered for the error bubble
+  // below it carries the retry affordance).
   const stalledPromptIds = new Set<string>()
   let lastStallIndex = -1
   for (let i = storeMessages.length - 1; i >= 0; i -= 1) {
     const m = storeMessages[i]!
-    if (m.type === 'error' && m.code === 'ASK_USER_QUESTION_STALL') {
+    if (m.type === 'error' && isRetryableAskUserQuestionError(m.code)) {
       lastStallIndex = i
       break
     }

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -188,16 +188,19 @@ export function buildChatViewMessages(
   // render (the AskUserQuestionStallChip rendered for the error bubble
   // below it carries the retry affordance).
   const stalledPromptIds = new Set<string>()
-  let lastStallIndex = -1
+  // Index of the most recent retryable AskUserQuestion teardown error (STALL
+  // plus the multi-select / multi-question codes — see
+  // isRetryableAskUserQuestionError); prompts before it are dead and suppressed.
+  let lastRetryableErrorIndex = -1
   for (let i = storeMessages.length - 1; i >= 0; i -= 1) {
     const m = storeMessages[i]!
     if (m.type === 'error' && isRetryableAskUserQuestionError(m.code)) {
-      lastStallIndex = i
+      lastRetryableErrorIndex = i
       break
     }
   }
-  if (lastStallIndex >= 0) {
-    for (let i = 0; i < lastStallIndex; i += 1) {
+  if (lastRetryableErrorIndex >= 0) {
+    for (let i = 0; i < lastRetryableErrorIndex; i += 1) {
       const m = storeMessages[i]!
       if (m.type === 'prompt' && !m.answered) stalledPromptIds.add(m.id)
     }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -312,6 +312,16 @@ export {
   toChatViewMessage,
 } from './buildChatViewMessages'
 
+// #5793: single source of truth for "is this an AskUserQuestion teardown
+// error the user can recover from by resending?" The server's form-driver
+// emits ASK_USER_QUESTION_STALL + five MULTISELECT/MULTI_QUESTION codes whose
+// copy ends in "Tap Retry"; both clients narrow off this predicate so all of
+// them get the stall-chip / retry path (not a dead generic error bubble).
+export {
+  RETRYABLE_ASK_USER_QUESTION_ERROR_CODES,
+  isRetryableAskUserQuestionError,
+} from './ask-user-question-errors'
+
 // #4243: shared tool-input summary helpers — both dashboard and mobile
 // ToolBubble derive the collapsed-preview string from the same
 // field-priority extraction (`command` → `file_path` → `path` →


### PR DESCRIPTION
## Summary
The claude-tui form driver emits `ASK_USER_QUESTION_MULTISELECT_{UNSUPPORTED,UNAVAILABLE,EMPTY,BUSY}` and `MULTI_QUESTION_UNSUPPORTED`, whose copy ends in "Tap Retry" — but the clients only special-cased `ASK_USER_QUESTION_STALL`, so the new codes rendered a generic red bubble with **no retry control** (a dead promise). From the SOLID/DRY audit follow-up (Builder/Tester).

## Fix — single source of truth in store-core
- New `packages/store-core/src/ask-user-question-errors.ts`: `RETRYABLE_ASK_USER_QUESTION_ERROR_CODES` (frozen set of STALL + the 5 new codes) and `isRetryableAskUserQuestionError(code)` (null-safe). Exported from the store-core index.
- Every hard-coded `=== 'ASK_USER_QUESTION_STALL'` retry/stall check now uses the predicate: `buildChatViewMessages.ts` (the `stalledPromptIds` suppression), dashboard `useMessageRenderer.tsx` (the stall-chip branch), app `MessageBubble.tsx` + `ChatView.tsx` (chip + retry wiring). grep confirms no functional literal STALL check remains.

## Retry wiring
- **Dashboard:** the new codes now reach the `AskUserQuestionStallChip` branch whose Retry resolves the last `user_input` and calls `sendInput(...)` — identical recovery to STALL.
- **App:** the app had **no chip for ASK_USER_QUESTION_STALL at all** (it fell through to a generic bubble). Routed all retryable codes through the existing `StreamStallChip` + `onRetryStreamStall` path — so this also gives the app a retry control for the original STALL it never had. Added an optional `headline` prop to `StreamStallChip` (default unchanged) and pass "Question delivery failed — retry?" for the ask-question codes so a delivery failure isn't mislabeled "Stream stalled".
- Non-retryable codes: generic fallback unchanged.

## Verification
- store-core: typecheck clean; **1540** tests incl. new `ask-user-question-errors.test.ts` (true for STALL + all 5 new codes; false for unrelated/empty/null/prefix-only) + extended `buildChatViewMessages.test.ts` (each new code adds the prior prompt to `stalledPromptIds`)
- dashboard: `tsc` clean; new `useMessageRenderer.test.tsx` — each new code routes to the stall chip with a working Retry → `sendInput('original request')`; STALL still routes; unrelated code does not
- app: `tsc` clean; extended `MessageBubble.streamStall.test.tsx` — all 6 codes render the chip + forward retry + use the question-delivery headline

Closes #5793
