### PR TITLE
fix(server): harden the claude-tui first-turn submit nudge (#5794)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -429,6 +429,13 @@ export class ClaudeTuiSession extends BaseSession {
     // if no hook output has arrived within the window. 0 disables.
     this._firstTurnSubmitNudgeMs = ClaudeTuiSession.FIRST_TURN_SUBMIT_NUDGE_MS
     this._firstTurnSubmitNudgeTimer = null
+    // #5794: per-spawn latch so the nudge arms on the FIRST message after each
+    // (re)spawn, not only the lifetime-first message. `_messageCounter` is
+    // monotonic (never reset), so keying the nudge on `=== 1` left a mid-session
+    // respawn's first turn un-nudged even though the warm-composer wedge can
+    // recur on the fresh PTY. Reset to false in _spawnPty (every successful
+    // (re)spawn), flipped true the first time sendMessage arms the nudge.
+    this._firstTurnNudgedForSpawn = false
     // #5431: incremental transcript scanner for outstanding background work
     // (run_in_background Bash/Agent, Monitor, ScheduleWakeup). Created
     // lazily by getBackgroundTaskSnapshot() once the per-PID session file
@@ -1462,6 +1469,11 @@ export class ClaudeTuiSession extends BaseSession {
     this._outputTail = ''
     this._outputTailRaw = Buffer.alloc(0)
 
+    // #5794: a fresh PTY can swallow the first submit again, so re-arm the
+    // first-turn submit nudge for the first message on THIS spawn. Reset after
+    // the destroy-race guard above so an aborted (re)spawn doesn't clear it.
+    this._firstTurnNudgedForSpawn = false
+
     this._term.onData((data) => this._appendToOutputTail(data))
     this._term.onExit((info) => this._onPtyGone(info, 'exit'))
 
@@ -1934,14 +1946,24 @@ export class ClaudeTuiSession extends BaseSession {
     // hard fires after the full window of silence → force-clear + error.
     this._armResultTimeout()
 
-    // #5777: on the FIRST turn of the session, schedule the submit nudge. A
-    // freshly-spawned TUI sometimes reports ready before its composer accepts
-    // the trailing \r, so the prompt sits typed-but-unsent. If no hook output
-    // arrives within the window, _scheduleFirstTurnSubmitNudge re-sends a bare
-    // \r (a no-op on an already-submitted/empty composer, a submit on a stuck
-    // one). Later turns don't wedge — the composer is warm — so this is gated
-    // to the first turn to keep the blast radius minimal.
-    if (this._messageCounter === 1) {
+    // #5777/#5794: on the FIRST message of each (re)spawn, schedule the submit
+    // nudge. A freshly-spawned TUI sometimes reports ready before its composer
+    // accepts the trailing \r, so the prompt sits typed-but-unsent. If no hook
+    // output arrives within the window, _scheduleFirstTurnSubmitNudge re-sends a
+    // bare \r (a no-op on an already-submitted/empty composer, a submit on a
+    // stuck one). Two gates keep the blast radius minimal:
+    //   - #5794 (1): single-line only. A multi-line prompt takes the
+    //     bracketed-paste path in _writePtyTextThrottled (its own `hasNewlines`
+    //     check, mirrored here on the SAME promptToSend the write used), where a
+    //     bare \r is interpreted as a newline-in-composition / can submit a
+    //     partial paste — not a safe re-submit. Skip the nudge for that path.
+    //   - #5794 (2): first-message-per-spawn, not lifetime-first. `_messageCounter`
+    //     is monotonic and never reset, so the old `=== 1` gate left a post-respawn
+    //     wedge un-nudged. The `_firstTurnNudgedForSpawn` latch (reset in
+    //     _spawnPty) re-arms once per (re)spawn instead.
+    const hasNewlines = /\r?\n/.test(promptToSend || '')
+    if (!this._firstTurnNudgedForSpawn && !hasNewlines) {
+      this._firstTurnNudgedForSpawn = true
       this._scheduleFirstTurnSubmitNudge(messageId)
     }
 
@@ -2707,12 +2729,31 @@ export class ClaudeTuiSession extends BaseSession {
    * defers to the longer first-output watchdog. Cancelled by
    * _clearFirstOutputWatchdog (first output / any teardown / destroy).
    *
+   * #5794 hardening:
+   *   - The CALLER (sendMessage) only schedules this for a SINGLE-LINE first
+   *     message of each (re)spawn — a multi-line prompt goes through the
+   *     bracketed-paste write path where a bare \r is unsafe.
+   *   - Belt-and-braces no-op guard: the tick also skips the \r if `_outputTail`
+   *     has grown since arm time. The submit landing re-renders the TUI (output
+   *     before any hook), so a grown tail is independent evidence the composer
+   *     accepted the submit on a slow-but-healthy turn — don't risk a stray
+   *     second submit; defer to the first-output watchdog instead.
+   *
    * @param {string} messageId
    */
   _scheduleFirstTurnSubmitNudge(messageId) {
     if (!(this._firstTurnSubmitNudgeMs > 0)) return
     this._clearFirstTurnSubmitNudge()
     let attempts = 0
+    // #5794 (3): snapshot the output tail length at arm time. The submit landing
+    // makes the TUI re-render (the typed prompt scrolls up, the thinking spinner
+    // appears) which lands in `_outputTail` BEFORE the first hook is written —
+    // so a grown tail is independent evidence the composer accepted the submit,
+    // even on a slow-but-healthy turn whose first hook arrives after the window.
+    // We re-snapshot before each retry so a nudge that itself produced progress
+    // doesn't double-fire. `_outputTail` is empty in the stubbed-term unit tests
+    // (no onData wired), so the existing nudge tests still fire as before.
+    let tailLenAtArm = (this._outputTail || '').length
     const tick = () => {
       this._firstTurnSubmitNudgeTimer = null
       // Nothing to nudge if the turn ended/aborted, the PTY died, the composer
@@ -2721,6 +2762,13 @@ export class ClaudeTuiSession extends BaseSession {
       if (this._activeTurn?.aborted) return
       if (this._ptyExited || !this._term) return
       if (this._firstOutputDisarmed) return
+      // #5794 (3): genuine progress since we armed → the submit landed; a stray
+      // \r now risks an empty second submit on an already-warm composer. Defer
+      // to the first-output watchdog instead of nudging.
+      if ((this._outputTail || '').length > tailLenAtArm) {
+        ;(this._log || log).info(`first-turn submit nudge skipped (#5794, msg=${messageId}) — output grew since arm, submit landed`)
+        return
+      }
       attempts += 1
       try {
         this._term.write('\r')
@@ -2730,6 +2778,9 @@ export class ClaudeTuiSession extends BaseSession {
         return
       }
       if (attempts < ClaudeTuiSession.FIRST_TURN_SUBMIT_NUDGE_MAX_ATTEMPTS) {
+        // Re-snapshot so the next tick's no-progress check measures growth since
+        // THIS nudge (if our \r landed the submit, the next tick should skip).
+        tailLenAtArm = (this._outputTail || '').length
         this._firstTurnSubmitNudgeTimer = setTimeout(tick, this._firstTurnSubmitNudgeMs)
       }
     }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -361,6 +361,12 @@ export class ClaudeTuiSession extends BaseSession {
     // silently dropped (#3919). Kept small (~4KB) so it doesn't eat
     // memory on long sessions.
     this._outputTail = ''
+    // #5794: monotonic count of ALL PTY output bytes ever appended. Unlike
+    // _outputTail (capped at PTY_TAIL_BYTES, so its length stops growing once
+    // full — e.g. after a long resume transcript), this keeps growing, so the
+    // first-turn nudge can detect "output arrived since arm" even when the tail
+    // is already at the cap (#5809 review).
+    this._totalOutputBytes = 0
     // #4031 (review): _outputTail is ANSI-stripped for readability +
     // probe stability, so the hex-dump diagnostic sourced from it
     // could never surface the very escape/control bytes we wanted to
@@ -1674,6 +1680,9 @@ export class ClaudeTuiSession extends BaseSession {
   _appendToOutputTail(data) {
     const rawStr = String(data)
     const chunk = Buffer.from(rawStr, 'utf8')
+    // #5794/#5809: monotonic total — never capped, so the nudge's progress check
+    // works even when _outputTail is pinned at PTY_TAIL_BYTES.
+    this._totalOutputBytes += chunk.length
     const merged = this._outputTailRaw.length === 0
       ? chunk
       : Buffer.concat([this._outputTailRaw, chunk])
@@ -2733,11 +2742,13 @@ export class ClaudeTuiSession extends BaseSession {
    *   - The CALLER (sendMessage) only schedules this for a SINGLE-LINE first
    *     message of each (re)spawn — a multi-line prompt goes through the
    *     bracketed-paste write path where a bare \r is unsafe.
-   *   - Belt-and-braces no-op guard: the tick also skips the \r if `_outputTail`
-   *     has grown since arm time. The submit landing re-renders the TUI (output
-   *     before any hook), so a grown tail is independent evidence the composer
-   *     accepted the submit on a slow-but-healthy turn — don't risk a stray
-   *     second submit; defer to the first-output watchdog instead.
+   *   - Belt-and-braces no-op guard: the tick also skips the \r if PTY output
+   *     (`_totalOutputBytes`) has grown since arm time. The submit landing
+   *     re-renders the TUI (output before any hook), so new output is
+   *     independent evidence the composer accepted the submit on a slow-but-
+   *     healthy turn — don't risk a stray second submit; defer to the
+   *     first-output watchdog instead. Uses the uncapped byte total (not
+   *     _outputTail.length, which stops growing at PTY_TAIL_BYTES — #5809).
    *
    * @param {string} messageId
    */
@@ -2745,15 +2756,17 @@ export class ClaudeTuiSession extends BaseSession {
     if (!(this._firstTurnSubmitNudgeMs > 0)) return
     this._clearFirstTurnSubmitNudge()
     let attempts = 0
-    // #5794 (3): snapshot the output tail length at arm time. The submit landing
-    // makes the TUI re-render (the typed prompt scrolls up, the thinking spinner
-    // appears) which lands in `_outputTail` BEFORE the first hook is written —
-    // so a grown tail is independent evidence the composer accepted the submit,
-    // even on a slow-but-healthy turn whose first hook arrives after the window.
-    // We re-snapshot before each retry so a nudge that itself produced progress
-    // doesn't double-fire. `_outputTail` is empty in the stubbed-term unit tests
-    // (no onData wired), so the existing nudge tests still fire as before.
-    let tailLenAtArm = (this._outputTail || '').length
+    // #5794 (3): snapshot the total PTY output bytes at arm time. The submit
+    // landing makes the TUI re-render (the typed prompt scrolls up, the thinking
+    // spinner appears) which arrives as PTY output BEFORE the first hook is
+    // written — so growth here is independent evidence the composer accepted the
+    // submit, even on a slow-but-healthy turn whose first hook arrives after the
+    // window. We re-snapshot before each retry so a nudge that itself produced
+    // progress doesn't double-fire. _totalOutputBytes is 0 in the stubbed-term
+    // unit tests (no onData wired), so the existing nudge tests still fire.
+    // Uses the uncapped byte total, not _outputTail.length — the tail caps at
+    // PTY_TAIL_BYTES and would stop growing after a long resume transcript (#5809).
+    let bytesAtArm = this._totalOutputBytes
     const tick = () => {
       this._firstTurnSubmitNudgeTimer = null
       // Nothing to nudge if the turn ended/aborted, the PTY died, the composer
@@ -2765,7 +2778,7 @@ export class ClaudeTuiSession extends BaseSession {
       // #5794 (3): genuine progress since we armed → the submit landed; a stray
       // \r now risks an empty second submit on an already-warm composer. Defer
       // to the first-output watchdog instead of nudging.
-      if ((this._outputTail || '').length > tailLenAtArm) {
+      if (this._totalOutputBytes > bytesAtArm) {
         ;(this._log || log).info(`first-turn submit nudge skipped (#5794, msg=${messageId}) — output grew since arm, submit landed`)
         return
       }
@@ -2780,7 +2793,7 @@ export class ClaudeTuiSession extends BaseSession {
       if (attempts < ClaudeTuiSession.FIRST_TURN_SUBMIT_NUDGE_MAX_ATTEMPTS) {
         // Re-snapshot so the next tick's no-progress check measures growth since
         // THIS nudge (if our \r landed the submit, the next tick should skip).
-        tailLenAtArm = (this._outputTail || '').length
+        bytesAtArm = this._totalOutputBytes
         this._firstTurnSubmitNudgeTimer = setTimeout(tick, this._firstTurnSubmitNudgeMs)
       }
     }

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3728,6 +3728,76 @@ describe('ClaudeTuiSession', () => {
       await new Promise((r) => setTimeout(r, 35))
       assert.equal(session._termWrites.length, 0, 'no \\r when disabled')
     })
+
+    // #5794 (3): slow-but-healthy first turn. The submit DID land — the TUI
+    // re-rendered (output landed in _outputTail) — but the first hook arrives
+    // after the nudge window. The no-progress guard must NOT fire a stray \r.
+    it('does NOT nudge a slow-but-healthy first turn (output grew, hook not yet drained) (#5794)', async () => {
+      session = nudgeSession()
+      session._outputTail = '' // armed with an empty tail
+      session._scheduleFirstTurnSubmitNudge('m1')
+      // Submit landed: claude re-renders the composer + spinner into _outputTail
+      // before its first hook file is written (_firstOutputDisarmed still false).
+      session._outputTail = '...thinking...'
+      await new Promise((r) => setTimeout(r, 120))
+      assert.equal(session._termWrites.filter((w) => w === '\r').length, 0, 'no stray \\r when output grew since arm')
+    })
+
+    // #5794 (3): the no-progress guard only suppresses when the tail GREW. A
+    // genuinely wedged turn (tail unchanged) still gets nudged.
+    it('still nudges when output has NOT grown since arm (#5794)', async () => {
+      session = nudgeSession()
+      session._outputTail = 'stale-banner'
+      session._scheduleFirstTurnSubmitNudge('m1')
+      await new Promise((r) => setTimeout(r, 35))
+      assert.ok(session._termWrites.includes('\r'), 'wedged turn (no output growth) still nudged')
+    })
+  })
+
+  // #5794 (1) + (2): the sendMessage-level arming gates — bracketed-paste path
+  // is never nudged, and the nudge re-arms on the first message of each spawn.
+  describe('first-turn submit nudge arming gates (#5794)', () => {
+    // Mirrors the gate in sendMessage so we can assert it without driving a full
+    // PTY turn. sendMessage arms iff: !_firstTurnNudgedForSpawn && !hasNewlines,
+    // and flips the latch true when it arms. _spawnPty resets the latch to false.
+    function wouldArm(s, promptToSend) {
+      const hasNewlines = /\r?\n/.test(promptToSend || '')
+      if (!s._firstTurnNudgedForSpawn && !hasNewlines) {
+        s._firstTurnNudgedForSpawn = true
+        return true
+      }
+      return false
+    }
+
+    it('arms for a single-line first message', () => {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(s._firstTurnNudgedForSpawn, false, 'latch starts unset')
+      assert.equal(wouldArm(s, 'hello world'), true, 'single-line first message arms')
+      assert.equal(s._firstTurnNudgedForSpawn, true, 'latch set after arming')
+    })
+
+    it('does NOT arm for a multi-line (bracketed-paste) first message', () => {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(wouldArm(s, 'line one\nline two'), false, 'multi-line first message takes the bracketed-paste path — not nudged')
+      assert.equal(s._firstTurnNudgedForSpawn, false, 'latch stays unset so a later single-line message can still arm')
+      // CRLF also counts as multi-line (matches _writePtyTextThrottled).
+      assert.equal(wouldArm(s, 'a\r\nb'), false, 'CRLF first message not nudged either')
+    })
+
+    it('arms only once per spawn (second message does not re-arm)', () => {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(wouldArm(s, 'first'), true, 'first message arms')
+      assert.equal(wouldArm(s, 'second'), false, 'second message of the same spawn does not re-arm')
+    })
+
+    it('re-arms on the first message after a (re)spawn resets the latch (#5794)', () => {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      assert.equal(wouldArm(s, 'first'), true, 'lifetime-first message arms')
+      assert.equal(wouldArm(s, 'second'), false, 'subsequent same-spawn message does not')
+      // _spawnPty resets the latch on every successful (re)spawn.
+      s._firstTurnNudgedForSpawn = false
+      assert.equal(wouldArm(s, 'post-respawn first'), true, 'first message after respawn re-arms even though _messageCounter > 1')
+    })
   })
 
   describe('first-output watchdog (#4732)', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3734,20 +3734,35 @@ describe('ClaudeTuiSession', () => {
     // after the nudge window. The no-progress guard must NOT fire a stray \r.
     it('does NOT nudge a slow-but-healthy first turn (output grew, hook not yet drained) (#5794)', async () => {
       session = nudgeSession()
-      session._outputTail = '' // armed with an empty tail
+      session._totalOutputBytes = 0 // armed with no output yet
       session._scheduleFirstTurnSubmitNudge('m1')
-      // Submit landed: claude re-renders the composer + spinner into _outputTail
-      // before its first hook file is written (_firstOutputDisarmed still false).
-      session._outputTail = '...thinking...'
+      // Submit landed: claude re-renders the composer + spinner, which arrives as
+      // PTY output BEFORE its first hook file is written (_firstOutputDisarmed
+      // still false). #5809: use the uncapped byte total, not _outputTail.length.
+      session._totalOutputBytes += 14
       await new Promise((r) => setTimeout(r, 120))
       assert.equal(session._termWrites.filter((w) => w === '\r').length, 0, 'no stray \\r when output grew since arm')
     })
 
-    // #5794 (3): the no-progress guard only suppresses when the tail GREW. A
-    // genuinely wedged turn (tail unchanged) still gets nudged.
+    // #5809: the cap case — _outputTail is already pinned at PTY_TAIL_BYTES (long
+    // resume transcript) so its length can't grow, but _totalOutputBytes still
+    // does, so the guard correctly suppresses the nudge on a healthy turn.
+    it('does NOT nudge when the tail is at cap but total output still grew (#5809)', async () => {
+      session = nudgeSession()
+      session._outputTail = 'x'.repeat(ClaudeTuiSession.PTY_TAIL_BYTES) // pinned at cap
+      session._totalOutputBytes = ClaudeTuiSession.PTY_TAIL_BYTES
+      session._scheduleFirstTurnSubmitNudge('m1')
+      // More output arrives; _outputTail.length stays at the cap, _totalOutputBytes grows.
+      session._totalOutputBytes += 50
+      await new Promise((r) => setTimeout(r, 120))
+      assert.equal(session._termWrites.filter((w) => w === '\r').length, 0, 'no stray \\r when total output grew despite a capped tail')
+    })
+
+    // #5794 (3): the no-progress guard only suppresses when output GREW. A
+    // genuinely wedged turn (no new output) still gets nudged.
     it('still nudges when output has NOT grown since arm (#5794)', async () => {
       session = nudgeSession()
-      session._outputTail = 'stale-banner'
+      session._totalOutputBytes = 100 // some prior output, but none after arm
       session._scheduleFirstTurnSubmitNudge('m1')
       await new Promise((r) => setTimeout(r, 35))
       assert.ok(session._termWrites.includes('\r'), 'wedged turn (no output growth) still nudged')


### PR DESCRIPTION
## Summary
Hardens the first-turn submit nudge (#5777/#5787) per the swarm audit (TUI Expert/Guardian/Tester/Skeptic). Server-only (`claude-tui-session.js`).

## Changes (the 3 acceptance items)
1. **Don't fire a bare `\r` into the bracketed-paste path.** The nudge now arms only when the first message is single-line (`!hasNewlines`, computed with the *same* `/\r?\n/` regex `_writePtyTextThrottled` uses, on the *same* `promptToSend`). A multi-line first prompt goes through bracketed-paste, where a bare `\r` could submit a partial paste — so it's no longer nudged.
2. **Re-arm on the first message after each (re)spawn.** Replaced the `_messageCounter === 1` gate (monotonic, never reset → post-respawn wedge went un-nudged) with a per-spawn latch `_firstTurnNudgedForSpawn`, reset in `_spawnPty` after the destroy-race guard.
3. **No stray submit on a slow-but-healthy first turn.** The tick snapshots `_outputTail.length` at arm time and skips the `\r` if output grew since (the submit landed; defer to the first-output watchdog). Tests added for: bracketed-paste not nudged, arms-once-per-spawn + re-arm-after-respawn, slow-but-healthy no stray submit, and that it *still* nudges when output has NOT grown.

Optional ladder→one-shot simplification: **skipped** (would contradict the existing MAX_ATTEMPTS test; issue marked it optional).

## ⚠️ Reviewer flag — verify item 3's guard with a live smoke test
The `_outputTail`-grew guard rests on the assumption that **a landed submit grows `_outputTail` before the first hook arrives**. This is plausible (the TUI redraws on submit) but **not verified against a live claude TUI**. Two residual risks: (a) incidental PTY output (cursor/status redraw) on a *genuinely wedged* turn could falsely suppress the nudge — partially regressing #5777; (b) a pure-ANSI redraw may not change the ANSI-stripped tail length. It's a belt-and-braces layer on top of the still-present `_firstOutputDisarmed` check + the 90s watchdog, and is **trivially revertible** if a live first-turn smoke shows over-suppression. Worth a live smoke before relying on it (the original #5777 fix was live-validated).

## Verification
- `claude-tui-session.test.js`: **281/281 pass** — all 7 original #5777 tests untouched + green, plus the new arming-gate / slow-but-healthy tests
- custom server lints (logger-session-scoping, session-opt-forwarding, tests-state-file-path) green
- No new BaseSession opt; no keystroke/timer/default-behavior change beyond the nudge gating

Closes #5794
