### PR TITLE
refactor(store-core): hoist AskUserQuestion render logic out of the twin clients (#5800)

### DIFF
--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -8,7 +8,7 @@ import {
   Image,
   LayoutAnimation,
 } from 'react-native';
-import { OTHER_OPTION_VALUE, bumpRenderCount, isRetryableAskUserQuestionError } from '@chroxy/store-core';
+import { OTHER_OPTION_VALUE, bumpRenderCount, isRetryableAskUserQuestionError, isSingleMultiSelectForm } from '@chroxy/store-core';
 // #4875: `OtherFreeformAnswer` moved to @chroxy/store-core/freeform-answer
 // so the mobile store, the mobile screen, and (eventually) the dashboard
 // can converge on a single declaration paired with the shared
@@ -206,9 +206,7 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
   // the multi-question case). `useMultiForm` collapses both into one condition:
   // a >1-question form when allowMultiQuestion, OR a single multiSelect when
   // allowSingleMultiSelect (claude-tui reinject + SDK-family; off for claude-cli).
-  const isSingleMultiSelect =
-    isPrompt && Array.isArray(message.questions) && message.questions.length === 1
-    && message.questions[0]?.multiSelect === true;
+  const isSingleMultiSelect = isPrompt && isSingleMultiSelectForm(message.questions);
   const useMultiForm =
     (isMultiQuestion && !!allowMultiQuestion) || (isSingleMultiSelect && !!allowSingleMultiSelect);
   const showMultiQuestionForm =

--- a/packages/app/src/components/chat/MultiQuestionForm.tsx
+++ b/packages/app/src/components/chat/MultiQuestionForm.tsx
@@ -28,7 +28,16 @@
  */
 import React, { useState, useRef } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import type { ChatMessageQuestion } from '@chroxy/store-core';
+import {
+  // #5800 — the multi-question form state machine now lives in store-core,
+  // shared with the dashboard's MultiQuestionForm.
+  buildAnswersMap,
+  computeCanSubmit,
+  setSingleSelect,
+  toggleMultiSelect,
+  type ChatMessageQuestion,
+  type MultiQuestionAnswersMap as SharedMultiQuestionAnswersMap,
+} from '@chroxy/store-core';
 import { COLORS } from '../../constants/colors';
 
 /**
@@ -36,8 +45,11 @@ import { COLORS } from '../../constants/colors';
  * Values are either a string (single-select chosen value) or a string[]
  * (multi-select chosen values). Mirrors the dashboard's
  * `MultiQuestionAnswersMap`.
+ *
+ * #5800 — the canonical declaration now lives in `@chroxy/store-core`;
+ * re-exported here under the same name so existing importers are unchanged.
  */
-export type MultiQuestionAnswersMap = Record<string, string | string[]>;
+export type MultiQuestionAnswersMap = SharedMultiQuestionAnswersMap;
 
 export interface MultiQuestionFormProps {
   questions: ChatMessageQuestion[];
@@ -64,45 +76,24 @@ export function MultiQuestionForm({ questions, onSubmit }: MultiQuestionFormProp
   // one `user_question_response`.
   const submittedRef = useRef(false);
 
+  // #5800 — selection state + canSubmit derivation + answersMap-builder now
+  // live in `@chroxy/store-core` (shared with the dashboard's
+  // MultiQuestionForm). Markup, testIDs, and the emitted answersMap shape are
+  // unchanged; only the logic moved.
   const handleRadioSelect = (idx: number, value: string) => {
-    setSingleSelectByIdx((prev) => ({ ...prev, [idx]: value }));
+    setSingleSelectByIdx((prev) => setSingleSelect(prev, idx, value));
   };
 
   const handleCheckboxToggle = (idx: number, value: string) => {
-    setMultiSelectByIdx((prev) => {
-      const curr = prev[idx] ?? [];
-      const next = curr.includes(value)
-        ? curr.filter((v) => v !== value)
-        : [...curr, value];
-      return { ...prev, [idx]: next };
-    });
+    setMultiSelectByIdx((prev) => toggleMultiSelect(prev, idx, value));
   };
 
-  // Submit enabled only when every single-select question has a choice.
-  // Multi-select is allowed to be empty (claude SDK accepts zero
-  // selections for multi-select) — parity with the dashboard's
-  // `canSubmit`.
-  const canSubmit = questions.every((q, idx) => {
-    if (q.multiSelect) return true;
-    return singleSelectByIdx[idx] != null;
-  });
+  const canSubmit = computeCanSubmit(questions, { singleSelectByIdx, multiSelectByIdx });
 
   const handleSubmit = () => {
     if (submittedRef.current || !canSubmit) return;
     submittedRef.current = true;
-    const answersMap: MultiQuestionAnswersMap = {};
-    questions.forEach((q, idx) => {
-      if (q.multiSelect) {
-        // #4621 / #4735 — emit multi-select as a native `string[]` via the
-        // widened wire shape; the server passes the array through to the
-        // SDK canUseTool callback unchanged.
-        answersMap[q.question] = multiSelectByIdx[idx] ?? [];
-      } else {
-        const chosen = singleSelectByIdx[idx];
-        if (chosen != null) answersMap[q.question] = chosen;
-      }
-    });
-    onSubmit(answersMap);
+    onSubmit(buildAnswersMap(questions, { singleSelectByIdx, multiSelectByIdx }));
   };
 
   return (

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -33,7 +33,18 @@ import { useId, useState, useRef, useEffect } from 'react'
 // converge on a single declaration paired with the shared
 // `isFreeformAnswer` guard. Re-exported below for the existing dashboard
 // call sites that import it from this file.
-import { OTHER_OPTION_VALUE, type ChatMessageQuestion, type OtherFreeformAnswer } from '@chroxy/store-core'
+import {
+  OTHER_OPTION_VALUE,
+  // #5800 — the multi-question form state machine now lives in store-core.
+  buildAnswersMap,
+  computeCanSubmit,
+  isSingleMultiSelectForm,
+  setSingleSelect,
+  toggleMultiSelect,
+  type ChatMessageQuestion,
+  type OtherFreeformAnswer,
+  type MultiQuestionAnswersMap as SharedMultiQuestionAnswersMap,
+} from '@chroxy/store-core'
 
 /**
  * #4735 — per-question answer payload emitted by the multi-question form.
@@ -43,8 +54,12 @@ import { OTHER_OPTION_VALUE, type ChatMessageQuestion, type OtherFreeformAnswer 
  * (`PermissionManager.respondToQuestion`, `ClaudeTuiSession`) accept
  * both shapes; pre-#4735 builds used to JSON-stringify the array into a
  * single string for back-compat, but the native form is preferred.
+ *
+ * #5800 — the canonical declaration now lives in `@chroxy/store-core`
+ * (alongside the shared form state machine); re-exported here under the
+ * same name so existing dashboard importers keep working unchanged.
  */
-export type MultiQuestionAnswersMap = Record<string, string | string[]>
+export type MultiQuestionAnswersMap = SharedMultiQuestionAnswersMap
 
 /**
  * #4651 — payload shape emitted when the user picks "Other" on a single-
@@ -172,8 +187,7 @@ export function QuestionPrompt({ question, options, answered, questions, allowMu
   // it would fall through to SingleQuestionPrompt's radio buttons and the user
   // could only pick one. Gated by allowSingleMultiSelect so claude-cli (no
   // structured-answer channel) keeps the single-select fallback.
-  const isSingleMultiSelect =
-    Array.isArray(questions) && questions.length === 1 && questions[0]?.multiSelect === true
+  const isSingleMultiSelect = isSingleMultiSelectForm(questions)
   if (isSingleMultiSelect && answered == null && allowSingleMultiSelect) {
     return <MultiQuestionForm questions={questions} onSelect={onSelect} />
   }
@@ -249,50 +263,25 @@ export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProp
   // and screen readers can announce the group label.
   const labelIdPrefix = useId()
 
+  // #5800 — selection state + answersMap-builder + canSubmit derivation
+  // now live in `@chroxy/store-core` (shared with the app's
+  // MultiQuestionForm). Markup, testIDs, and the emitted answersMap shape
+  // are unchanged; only the logic moved.
   const handleRadioChange = (idx: number, value: string) => {
-    setSingleSelectByIdx((prev) => ({ ...prev, [idx]: value }))
+    setSingleSelectByIdx((prev) => setSingleSelect(prev, idx, value))
   }
 
   const handleCheckboxToggle = (idx: number, value: string) => {
-    setMultiSelectByIdx((prev) => {
-      const curr = prev[idx] || []
-      const next = curr.includes(value)
-        ? curr.filter((v) => v !== value)
-        : [...curr, value]
-      return { ...prev, [idx]: next }
-    })
+    setMultiSelectByIdx((prev) => toggleMultiSelect(prev, idx, value))
   }
 
   const handleSubmit = () => {
     if (submittedRef.current) return
     submittedRef.current = true
-    const answersMap: MultiQuestionAnswersMap = {}
-    questions.forEach((q, idx) => {
-      if (q.multiSelect) {
-        // #4621 / #4735 — emit multi-select as a native `string[]` via
-        // the widened wire shape. Pre-#4621 dashboards JSON.stringified
-        // the array so the schema (`Record<string,string>`) accepted
-        // it; the server side already handled both forms (the TUI
-        // driver parses JSON or comma-joined strings; the SDK path
-        // passes the value through unchanged). Sending arrays natively
-        // gives the SDK canUseTool callback the structured shape it
-        // expects without a JSON.parse hop.
-        answersMap[q.question] = multiSelectByIdx[idx] || []
-      } else {
-        const chosen = singleSelectByIdx[idx]
-        if (chosen != null) answersMap[q.question] = chosen
-      }
-    })
-    onSelect(answersMap)
+    onSelect(buildAnswersMap(questions, { singleSelectByIdx, multiSelectByIdx }))
   }
 
-  // Submit enabled only when every single-select question has a choice
-  // (multi-select is allowed to be empty — claude SDK accepts zero
-  // selections for multi-select).
-  const canSubmit = questions.every((q, idx) => {
-    if (q.multiSelect) return true
-    return singleSelectByIdx[idx] != null
-  })
+  const canSubmit = computeCanSubmit(questions, { singleSelectByIdx, multiSelectByIdx })
 
   return (
     <div className="question-prompt question-prompt--multi" data-testid="question-prompt-multi">

--- a/packages/dashboard/src/lib/tool-result-text.test.ts
+++ b/packages/dashboard/src/lib/tool-result-text.test.ts
@@ -1,57 +1,27 @@
 import { describe, it, expect } from 'vitest'
 import { unwrapToolResultText } from './tool-result-text'
 
-describe('unwrapToolResultText (#5778)', () => {
+// #5800 — the implementation + its full case table moved to store-core
+// (packages/store-core/src/tool-result-text.test.ts). This dashboard test now
+// imports through the re-export shim (`./tool-result-text` →
+// `@chroxy/store-core`) to prove the shim resolves and the dashboard call sites
+// still get the unwrap behavior unchanged.
+describe('unwrapToolResultText re-export shim (#5800)', () => {
+  it('re-exports a callable unwrapToolResultText from store-core', () => {
+    expect(typeof unwrapToolResultText).toBe('function')
+  })
+
   it('passes plain strings through unchanged', () => {
     expect(unwrapToolResultText('total 0\ndrwxr-xr-x')).toBe('total 0\ndrwxr-xr-x')
   })
 
   it('unwraps a stdout/stderr JSON envelope to stdout text', () => {
-    const envelope = JSON.stringify({
-      stdout: 'total 0\ndrwxr-xr-x@ 2 blamechris staff 64 Jun 14',
-      stderr: '',
-      interrupted: false,
-    })
-    expect(unwrapToolResultText(envelope)).toBe('total 0\ndrwxr-xr-x@ 2 blamechris staff 64 Jun 14')
+    const envelope = JSON.stringify({ stdout: 'out line', stderr: '' })
+    expect(unwrapToolResultText(envelope)).toBe('out line')
   })
 
   it('appends stderr after stdout when both are present', () => {
     const envelope = JSON.stringify({ stdout: 'out line', stderr: 'err line' })
     expect(unwrapToolResultText(envelope)).toBe('out line\nerr line')
-  })
-
-  it('does not double a trailing newline when stdout already ends in one', () => {
-    const envelope = JSON.stringify({ stdout: 'out line\n', stderr: 'err line' })
-    // Exactly one newline between the streams — no blank line.
-    expect(unwrapToolResultText(envelope)).toBe('out line\nerr line')
-  })
-
-  it('coerces a non-string input to a safe string', () => {
-    expect(unwrapToolResultText(null as unknown as string)).toBe('')
-    expect(unwrapToolResultText(undefined as unknown as string)).toBe('')
-    expect(unwrapToolResultText(42 as unknown as string)).toBe('42')
-  })
-
-  it('renders stderr alone when stdout is empty', () => {
-    const envelope = JSON.stringify({ stdout: '', stderr: 'boom' })
-    expect(unwrapToolResultText(envelope)).toBe('boom')
-  })
-
-  it('leaves JSON objects without stdout/stderr untouched', () => {
-    const json = JSON.stringify({ foo: 'bar' })
-    expect(unwrapToolResultText(json)).toBe(json)
-  })
-
-  it('falls back to the original string on invalid JSON', () => {
-    expect(unwrapToolResultText('{not valid json')).toBe('{not valid json')
-  })
-
-  it('does not munge plain text that merely starts with a brace', () => {
-    expect(unwrapToolResultText('{ this is just text }')).toBe('{ this is just text }')
-  })
-
-  it('leaves JSON arrays untouched', () => {
-    const arr = JSON.stringify([1, 2, 3])
-    expect(unwrapToolResultText(arr)).toBe(arr)
   })
 })

--- a/packages/dashboard/src/lib/tool-result-text.ts
+++ b/packages/dashboard/src/lib/tool-result-text.ts
@@ -1,60 +1,10 @@
 /**
- * tool-result-text — unwrap a tool-result payload into human-readable text.
+ * tool-result-text — re-export shim (#5800).
  *
- * #5778: the Output tab (simulated terminal) was dumping the raw JSON envelope
- * of a tool result, e.g. `{"stdout":"total 0\n...","stderr":"",...}`, instead
- * of the stdout text rendered as terminal lines. A tool result reaches the
- * client as a plain string, but for shell-style tools (Bash, etc.) that string
- * is itself a JSON-stringified `{ stdout, stderr, ... }` envelope.
- *
- * `unwrapToolResultText` normalises any of those shapes back to the text a
- * terminal should show:
- *   - already-plain strings pass through unchanged
- *   - JSON objects with stdout/stderr render those streams (stderr appended)
- *   - anything else falls back to a sensible string (never throws)
+ * `unwrapToolResultText` (and its private `streamsToText`) was hoisted into
+ * `@chroxy/store-core` (`packages/store-core/src/tool-result-text.ts`) so the
+ * app gains the same `{stdout,stderr}` → terminal-text unwrap as the dashboard.
+ * This shim re-exports it under the original path so existing dashboard
+ * importers keep working unchanged. Zero behavior change.
  */
-
-function streamsToText(obj: Record<string, unknown>): string | null {
-  const hasStdout = typeof obj.stdout === 'string'
-  const hasStderr = typeof obj.stderr === 'string'
-  if (!hasStdout && !hasStderr) return null
-  const stdout = hasStdout && obj.stdout !== '' ? (obj.stdout as string) : ''
-  const stderr = hasStderr && obj.stderr !== '' ? (obj.stderr as string) : ''
-  if (!stdout) return stderr
-  if (!stderr) return stdout
-  // Append stderr directly after stdout, mirroring a real terminal. Only insert
-  // a separating newline when stdout doesn't already end in one, so shell output
-  // that ends with a trailing newline doesn't gain a spurious blank line.
-  const sep = stdout.endsWith('\n') ? '' : '\n'
-  return stdout + sep + stderr
-}
-
-/**
- * Unwrap a tool-result payload for terminal-style display. Returns the
- * human-readable text; never throws. Accepts `unknown` because callers forward
- * loosely-typed wire values — non-string inputs are coerced to a safe string.
- */
-export function unwrapToolResultText(resultText: unknown): string {
-  if (typeof resultText !== 'string') return String(resultText ?? '')
-
-  const trimmed = resultText.trim()
-  // Only attempt a parse when it looks like a JSON object — avoids munging
-  // plain output that happens to start with a brace-like character.
-  if (!trimmed.startsWith('{')) return resultText
-
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(trimmed)
-  } catch {
-    return resultText
-  }
-
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return resultText
-  }
-
-  const text = streamsToText(parsed as Record<string, unknown>)
-  // Recognised stdout/stderr envelope → render the streams. Otherwise the
-  // object isn't a shell-result shape; leave the original string untouched.
-  return text === null ? resultText : text
-}
+export { unwrapToolResultText } from '@chroxy/store-core'

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -709,6 +709,31 @@ export type {
   MemoryStore,
 } from './handshake-e2e/fake-ws'
 
+// #5800 — shared AskUserQuestion multi-question form state machine. Both the
+// dashboard's `QuestionPrompt.MultiQuestionForm` and the app's
+// `MultiQuestionForm` render against these pure helpers (store-core has no
+// `react` dependency, so this exports pure reducers/derivers rather than a
+// hook; each client keeps its own tiny `useState`). `isSingleMultiSelectForm`
+// replaces the shape-check that was computed independently in both renderers.
+export {
+  toggleMultiSelect,
+  setSingleSelect,
+  buildAnswersMap,
+  computeCanSubmit,
+  isSingleMultiSelectForm,
+} from './multi-question-form'
+export type {
+  MultiQuestionAnswersMap,
+  MultiQuestionFormState,
+} from './multi-question-form'
+
+// #5800 — shared tool-result-envelope unwrap, hoisted from the dashboard's
+// `lib/tool-result-text.ts` so the app gains the same `{stdout,stderr}` →
+// terminal-text normalisation. Zero behavior change for the dashboard.
+export {
+  unwrapToolResultText,
+} from './tool-result-text'
+
 // #5759 — shared pending-permission derivation (single source of truth for the
 // "live, unanswered permission prompt" predicate across both clients).
 export {

--- a/packages/store-core/src/multi-question-form.test.ts
+++ b/packages/store-core/src/multi-question-form.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import type { ChatMessageQuestion } from './types'
+import {
+  buildAnswersMap,
+  computeCanSubmit,
+  isSingleMultiSelectForm,
+  setSingleSelect,
+  toggleMultiSelect,
+} from './multi-question-form'
+
+const opt = (label: string, value = label) => ({ label, value })
+
+const singleQ = (question: string): ChatMessageQuestion => ({
+  question,
+  options: [opt('A'), opt('B')],
+})
+
+const multiQ = (question: string): ChatMessageQuestion => ({
+  question,
+  options: [opt('X'), opt('Y'), opt('Z')],
+  multiSelect: true,
+})
+
+describe('setSingleSelect (#5800)', () => {
+  it('sets the chosen value at the given index immutably', () => {
+    const prev = { 0: 'A' }
+    const next = setSingleSelect(prev, 1, 'B')
+    expect(next).toEqual({ 0: 'A', 1: 'B' })
+    expect(prev).toEqual({ 0: 'A' }) // unchanged
+  })
+
+  it('overwrites an existing single-select value', () => {
+    expect(setSingleSelect({ 0: 'A' }, 0, 'B')).toEqual({ 0: 'B' })
+  })
+})
+
+describe('toggleMultiSelect (#5800)', () => {
+  it('adds a value when absent', () => {
+    expect(toggleMultiSelect({}, 0, 'X')).toEqual({ 0: ['X'] })
+  })
+
+  it('removes a value when already present', () => {
+    expect(toggleMultiSelect({ 0: ['X', 'Y'] }, 0, 'X')).toEqual({ 0: ['Y'] })
+  })
+
+  it('appends to the existing array preserving order', () => {
+    expect(toggleMultiSelect({ 0: ['X'] }, 0, 'Y')).toEqual({ 0: ['X', 'Y'] })
+  })
+
+  it('treats a missing index as an empty selection', () => {
+    expect(toggleMultiSelect({ 1: ['Y'] }, 0, 'X')).toEqual({ 1: ['Y'], 0: ['X'] })
+  })
+
+  it('does not mutate the previous map', () => {
+    const prev = { 0: ['X'] }
+    toggleMultiSelect(prev, 0, 'Y')
+    expect(prev).toEqual({ 0: ['X'] })
+  })
+})
+
+describe('buildAnswersMap (#5800)', () => {
+  it('keys by question text, single-select emits the chosen string', () => {
+    const questions = [singleQ('Q1'), singleQ('Q2')]
+    const state = { singleSelectByIdx: { 0: 'A', 1: 'B' }, multiSelectByIdx: {} }
+    expect(buildAnswersMap(questions, state)).toEqual({ Q1: 'A', Q2: 'B' })
+  })
+
+  it('multi-select emits a native string[] of chosen values', () => {
+    const questions = [multiQ('Q1')]
+    const state = { singleSelectByIdx: {}, multiSelectByIdx: { 0: ['X', 'Z'] } }
+    expect(buildAnswersMap(questions, state)).toEqual({ Q1: ['X', 'Z'] })
+  })
+
+  it('multi-select with no selection emits an empty array (SDK accepts zero)', () => {
+    const questions = [multiQ('Q1')]
+    const state = { singleSelectByIdx: {}, multiSelectByIdx: {} }
+    expect(buildAnswersMap(questions, state)).toEqual({ Q1: [] })
+  })
+
+  it('omits an unanswered single-select question entirely', () => {
+    const questions = [singleQ('Q1'), singleQ('Q2')]
+    const state = { singleSelectByIdx: { 0: 'A' }, multiSelectByIdx: {} }
+    expect(buildAnswersMap(questions, state)).toEqual({ Q1: 'A' })
+  })
+
+  it('mixes single and multi questions by position', () => {
+    const questions = [singleQ('Q1'), multiQ('Q2')]
+    const state = { singleSelectByIdx: { 0: 'A' }, multiSelectByIdx: { 1: ['Y'] } }
+    expect(buildAnswersMap(questions, state)).toEqual({ Q1: 'A', Q2: ['Y'] })
+  })
+})
+
+describe('computeCanSubmit (#5800)', () => {
+  it('requires every single-select question to have a choice', () => {
+    const questions = [singleQ('Q1'), singleQ('Q2')]
+    expect(
+      computeCanSubmit(questions, { singleSelectByIdx: { 0: 'A' }, multiSelectByIdx: {} }),
+    ).toBe(false)
+    expect(
+      computeCanSubmit(questions, { singleSelectByIdx: { 0: 'A', 1: 'B' }, multiSelectByIdx: {} }),
+    ).toBe(true)
+  })
+
+  it('allows multi-select questions to be empty', () => {
+    const questions = [multiQ('Q1')]
+    expect(computeCanSubmit(questions, { singleSelectByIdx: {}, multiSelectByIdx: {} })).toBe(true)
+  })
+
+  it('mixed form: only single-selects gate submission', () => {
+    const questions = [singleQ('Q1'), multiQ('Q2')]
+    expect(
+      computeCanSubmit(questions, { singleSelectByIdx: {}, multiSelectByIdx: {} }),
+    ).toBe(false)
+    expect(
+      computeCanSubmit(questions, { singleSelectByIdx: { 0: 'A' }, multiSelectByIdx: {} }),
+    ).toBe(true)
+  })
+})
+
+describe('isSingleMultiSelectForm (#5800)', () => {
+  it('true for exactly one multiSelect question', () => {
+    expect(isSingleMultiSelectForm([multiQ('Q1')])).toBe(true)
+  })
+
+  it('false for a single single-select question', () => {
+    expect(isSingleMultiSelectForm([singleQ('Q1')])).toBe(false)
+  })
+
+  it('false for more than one question (even if multiSelect)', () => {
+    expect(isSingleMultiSelectForm([multiQ('Q1'), multiQ('Q2')])).toBe(false)
+  })
+
+  it('false for an empty array', () => {
+    expect(isSingleMultiSelectForm([])).toBe(false)
+  })
+
+  it('false for undefined / non-array', () => {
+    expect(isSingleMultiSelectForm(undefined)).toBe(false)
+  })
+})

--- a/packages/store-core/src/multi-question-form.ts
+++ b/packages/store-core/src/multi-question-form.ts
@@ -1,0 +1,130 @@
+/**
+ * multi-question-form — framework-agnostic state machine for the
+ * AskUserQuestion multi-question form (#5800).
+ *
+ * The dashboard (`packages/dashboard/src/components/QuestionPrompt.tsx`)
+ * and the app (`packages/app/src/components/chat/MultiQuestionForm.tsx`)
+ * rendered the SAME form state machine twice — only the render primitives
+ * (DOM+ARIA vs RN+StyleSheet) differed. This module hoists the shared
+ * business logic so an answer-shape change is a one-file edit.
+ *
+ * store-core has no `react` dependency (and must not gain one), so this
+ * exports PURE helpers rather than a React hook. Each client keeps its
+ * own tiny `useState` for `singleSelectByIdx` / `multiSelectByIdx` and
+ * delegates the per-question selection state shape, the answersMap
+ * builder, and the submit-enabled validation here.
+ *
+ * State is indexed by question POSITION so two questions with identical
+ * text track their selections independently while the form is open. The
+ * emitted `answersMap` is keyed by `question.question` TEXT — the wire
+ * shape `UserQuestionResponseSchema` /
+ * `PermissionManager.respondToQuestion` consume. If a payload ever
+ * carried two questions with the exact same text the later one overwrites
+ * the earlier in the emitted map; that is an inherent constraint of the
+ * question-text-keyed wire contract, not a client-specific one.
+ */
+import type { ChatMessageQuestion } from './types'
+
+/**
+ * #4735 — per-question answer payload emitted by the multi-question form.
+ * Values are either a string (single-select chosen value, free-form
+ * "Other" text) or a string[] (multi-select chosen values). The wire
+ * schema (`UserQuestionResponseSchema`) and server consumers
+ * (`PermissionManager.respondToQuestion`, `ClaudeTuiSession`) accept both
+ * shapes; the native form (string[] for multi-select) is preferred.
+ */
+export type MultiQuestionAnswersMap = Record<string, string | string[]>
+
+/**
+ * Per-question selection state, indexed by question POSITION. Single-select
+ * holds the chosen value string; multi-select holds an array of chosen
+ * value strings. Mirrors the `singleSelectByIdx` / `multiSelectByIdx`
+ * `useState` pair both clients carried inline.
+ */
+export interface MultiQuestionFormState {
+  singleSelectByIdx: Record<number, string>
+  multiSelectByIdx: Record<number, string[]>
+}
+
+/**
+ * Toggle a multi-select value for one question, returning the next
+ * `multiSelectByIdx` map (immutable update — safe to hand straight to a
+ * `setState` updater). Adds the value if absent, removes it if present.
+ */
+export function toggleMultiSelect(
+  prev: Record<number, string[]>,
+  idx: number,
+  value: string,
+): Record<number, string[]> {
+  const curr = prev[idx] ?? []
+  const next = curr.includes(value)
+    ? curr.filter((v) => v !== value)
+    : [...curr, value]
+  return { ...prev, [idx]: next }
+}
+
+/**
+ * Set the single-select chosen value for one question, returning the next
+ * `singleSelectByIdx` map (immutable update).
+ */
+export function setSingleSelect(
+  prev: Record<number, string>,
+  idx: number,
+  value: string,
+): Record<number, string> {
+  return { ...prev, [idx]: value }
+}
+
+/**
+ * Build the wire `answersMap` from the current selection state. Multi-select
+ * questions emit a native `string[]` (defaulting to `[]` so a multi-select
+ * question always has an entry — the SDK accepts zero selections);
+ * single-select questions emit the chosen string, and are omitted entirely
+ * when unanswered. Keyed by `question.question` text.
+ */
+export function buildAnswersMap(
+  questions: ChatMessageQuestion[],
+  state: MultiQuestionFormState,
+): MultiQuestionAnswersMap {
+  const answersMap: MultiQuestionAnswersMap = {}
+  questions.forEach((q, idx) => {
+    if (q.multiSelect) {
+      answersMap[q.question] = state.multiSelectByIdx[idx] ?? []
+    } else {
+      const chosen = state.singleSelectByIdx[idx]
+      if (chosen != null) answersMap[q.question] = chosen
+    }
+  })
+  return answersMap
+}
+
+/**
+ * Submit is enabled only when every single-select question has a choice.
+ * Multi-select questions are always allowed to be empty (the SDK accepts
+ * zero selections for multi-select).
+ */
+export function computeCanSubmit(
+  questions: ChatMessageQuestion[],
+  state: MultiQuestionFormState,
+): boolean {
+  return questions.every((q, idx) => {
+    if (q.multiSelect) return true
+    return state.singleSelectByIdx[idx] != null
+  })
+}
+
+/**
+ * #5800 — the single shared shape predicate for "this is a single-question
+ * multiSelect AskUserQuestion that should render as a checkbox form".
+ * Computed independently before in both renderers
+ * (`QuestionPrompt.tsx` and the app's `MessageBubble.tsx`).
+ */
+export function isSingleMultiSelectForm(
+  questions: ChatMessageQuestion[] | undefined,
+): boolean {
+  return (
+    Array.isArray(questions) &&
+    questions.length === 1 &&
+    questions[0]?.multiSelect === true
+  )
+}

--- a/packages/store-core/src/multi-question-form.ts
+++ b/packages/store-core/src/multi-question-form.ts
@@ -120,8 +120,8 @@ export function computeCanSubmit(
  * (`QuestionPrompt.tsx` and the app's `MessageBubble.tsx`).
  */
 export function isSingleMultiSelectForm(
-  questions: ChatMessageQuestion[] | undefined,
-): boolean {
+  questions: ChatMessageQuestion[] | undefined | null,
+): questions is ChatMessageQuestion[] {
   return (
     Array.isArray(questions) &&
     questions.length === 1 &&

--- a/packages/store-core/src/tool-result-text.test.ts
+++ b/packages/store-core/src/tool-result-text.test.ts
@@ -35,6 +35,11 @@ describe('unwrapToolResultText (#5778 / #5800)', () => {
     expect(unwrapToolResultText(42 as unknown as string)).toBe('42')
   })
 
+  it('never throws on exotic non-string values (null-prototype object)', () => {
+    // Object.create(null) has no toString/valueOf, so String() would throw.
+    expect(unwrapToolResultText(Object.create(null) as unknown as string)).toBe('')
+  })
+
   it('renders stderr alone when stdout is empty', () => {
     const envelope = JSON.stringify({ stdout: '', stderr: 'boom' })
     expect(unwrapToolResultText(envelope)).toBe('boom')

--- a/packages/store-core/src/tool-result-text.test.ts
+++ b/packages/store-core/src/tool-result-text.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { unwrapToolResultText } from './tool-result-text'
+
+// #5800 — moved verbatim from packages/dashboard/src/lib/tool-result-text.test.ts
+// when the implementation was hoisted into store-core. The dashboard keeps a
+// thin test (importing through the re-export shim) to prove the shim resolves.
+describe('unwrapToolResultText (#5778 / #5800)', () => {
+  it('passes plain strings through unchanged', () => {
+    expect(unwrapToolResultText('total 0\ndrwxr-xr-x')).toBe('total 0\ndrwxr-xr-x')
+  })
+
+  it('unwraps a stdout/stderr JSON envelope to stdout text', () => {
+    const envelope = JSON.stringify({
+      stdout: 'total 0\ndrwxr-xr-x@ 2 blamechris staff 64 Jun 14',
+      stderr: '',
+      interrupted: false,
+    })
+    expect(unwrapToolResultText(envelope)).toBe('total 0\ndrwxr-xr-x@ 2 blamechris staff 64 Jun 14')
+  })
+
+  it('appends stderr after stdout when both are present', () => {
+    const envelope = JSON.stringify({ stdout: 'out line', stderr: 'err line' })
+    expect(unwrapToolResultText(envelope)).toBe('out line\nerr line')
+  })
+
+  it('does not double a trailing newline when stdout already ends in one', () => {
+    const envelope = JSON.stringify({ stdout: 'out line\n', stderr: 'err line' })
+    // Exactly one newline between the streams — no blank line.
+    expect(unwrapToolResultText(envelope)).toBe('out line\nerr line')
+  })
+
+  it('coerces a non-string input to a safe string', () => {
+    expect(unwrapToolResultText(null as unknown as string)).toBe('')
+    expect(unwrapToolResultText(undefined as unknown as string)).toBe('')
+    expect(unwrapToolResultText(42 as unknown as string)).toBe('42')
+  })
+
+  it('renders stderr alone when stdout is empty', () => {
+    const envelope = JSON.stringify({ stdout: '', stderr: 'boom' })
+    expect(unwrapToolResultText(envelope)).toBe('boom')
+  })
+
+  it('leaves JSON objects without stdout/stderr untouched', () => {
+    const json = JSON.stringify({ foo: 'bar' })
+    expect(unwrapToolResultText(json)).toBe(json)
+  })
+
+  it('falls back to the original string on invalid JSON', () => {
+    expect(unwrapToolResultText('{not valid json')).toBe('{not valid json')
+  })
+
+  it('does not munge plain text that merely starts with a brace', () => {
+    expect(unwrapToolResultText('{ this is just text }')).toBe('{ this is just text }')
+  })
+
+  it('leaves JSON arrays untouched', () => {
+    const arr = JSON.stringify([1, 2, 3])
+    expect(unwrapToolResultText(arr)).toBe(arr)
+  })
+})

--- a/packages/store-core/src/tool-result-text.ts
+++ b/packages/store-core/src/tool-result-text.ts
@@ -40,7 +40,16 @@ function streamsToText(obj: Record<string, unknown>): string | null {
  * loosely-typed wire values — non-string inputs are coerced to a safe string.
  */
 export function unwrapToolResultText(resultText: unknown): string {
-  if (typeof resultText !== 'string') return String(resultText ?? '')
+  if (typeof resultText !== 'string') {
+    // String() can throw for exotic values (e.g. Object.create(null), which has
+    // no toString/valueOf), so guard the coercion to honor the never-throws
+    // contract for all inputs.
+    try {
+      return String(resultText ?? '')
+    } catch {
+      return ''
+    }
+  }
 
   const trimmed = resultText.trim()
   // Only attempt a parse when it looks like a JSON object — avoids munging

--- a/packages/store-core/src/tool-result-text.ts
+++ b/packages/store-core/src/tool-result-text.ts
@@ -1,0 +1,65 @@
+/**
+ * tool-result-text — unwrap a tool-result payload into human-readable text.
+ *
+ * #5778: the Output tab (simulated terminal) was dumping the raw JSON envelope
+ * of a tool result, e.g. `{"stdout":"total 0\n...","stderr":"",...}`, instead
+ * of the stdout text rendered as terminal lines. A tool result reaches the
+ * client as a plain string, but for shell-style tools (Bash, etc.) that string
+ * is itself a JSON-stringified `{ stdout, stderr, ... }` envelope.
+ *
+ * #5800: hoisted from `packages/dashboard/src/lib/tool-result-text.ts` into
+ * store-core (next to the other shared parsers like `partial-json.ts`) so the
+ * app gains the same tool-result-envelope unwrap as the dashboard. Zero
+ * behavior change for the dashboard.
+ *
+ * `unwrapToolResultText` normalises any of those shapes back to the text a
+ * terminal should show:
+ *   - already-plain strings pass through unchanged
+ *   - JSON objects with stdout/stderr render those streams (stderr appended)
+ *   - anything else falls back to a sensible string (never throws)
+ */
+
+function streamsToText(obj: Record<string, unknown>): string | null {
+  const hasStdout = typeof obj.stdout === 'string'
+  const hasStderr = typeof obj.stderr === 'string'
+  if (!hasStdout && !hasStderr) return null
+  const stdout = hasStdout && obj.stdout !== '' ? (obj.stdout as string) : ''
+  const stderr = hasStderr && obj.stderr !== '' ? (obj.stderr as string) : ''
+  if (!stdout) return stderr
+  if (!stderr) return stdout
+  // Append stderr directly after stdout, mirroring a real terminal. Only insert
+  // a separating newline when stdout doesn't already end in one, so shell output
+  // that ends with a trailing newline doesn't gain a spurious blank line.
+  const sep = stdout.endsWith('\n') ? '' : '\n'
+  return stdout + sep + stderr
+}
+
+/**
+ * Unwrap a tool-result payload for terminal-style display. Returns the
+ * human-readable text; never throws. Accepts `unknown` because callers forward
+ * loosely-typed wire values — non-string inputs are coerced to a safe string.
+ */
+export function unwrapToolResultText(resultText: unknown): string {
+  if (typeof resultText !== 'string') return String(resultText ?? '')
+
+  const trimmed = resultText.trim()
+  // Only attempt a parse when it looks like a JSON object — avoids munging
+  // plain output that happens to start with a brace-like character.
+  if (!trimmed.startsWith('{')) return resultText
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return resultText
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return resultText
+  }
+
+  const text = streamsToText(parsed as Record<string, unknown>)
+  // Recognised stdout/stderr envelope → render the streams. Otherwise the
+  // object isn't a shell-result shape; leave the original string untouched.
+  return text === null ? resultText : text
+}


### PR DESCRIPTION
## Summary
Hoists the AskUserQuestion render logic into `@chroxy/store-core` so the dashboard and app stop maintaining parallel copies — the audit's render-side DRY follow-up to #5795 (which hoisted the provider predicate). **Behavior-preserving: no markup, testID, or wire-payload change.**

## Approach
**Pure helpers, not a React hook.** `@chroxy/store-core` has no `react` dependency (adding one risks RN/web React-dedup issues), so the shared logic is exported as pure reducers/derivers and each client keeps its tiny `useState`.

## Changes
**store-core (new):**
- `multi-question-form.ts` — `toggleMultiSelect`, `setSingleSelect`, `buildAnswersMap`, `computeCanSubmit`, `isSingleMultiSelectForm` (a type predicate, so callers narrow `questions`), + `MultiQuestionFormState`/`MultiQuestionAnswersMap` types.
- `tool-result-text.ts` — `unwrapToolResultText` (+ private `streamsToText`) moved here verbatim.

**Clients (state/derivation logic swapped, markup/testIDs/submit payload untouched):**
- dashboard `QuestionPrompt.tsx` `MultiQuestionForm` → calls the shared reducers/derivers; `isSingleMultiSelectForm(questions)` replaces the inline shape check.
- app `MultiQuestionForm.tsx` → same swap; `MessageBubble.tsx:209` uses `isSingleMultiSelectForm` (keeps its local `isPrompt &&` guard).
- dashboard `lib/tool-result-text.ts` → re-export shim from store-core (so `message-handler.ts`'s import path is unchanged).

## Verification
- store-core: typecheck clean; **1570** tests incl. new `multi-question-form.test.ts` (reducers/derivers/predicate) + `tool-result-text.test.ts` (the 10-case table moved verbatim)
- dashboard: `tsc` clean; QuestionPrompt + tool-result-text tests pass
- app: `tsc` clean; MultiQuestionForm + MessageBubble.multiQuestion tests pass
- Fixed one type-narrowing regression found by central `tsc` (made `isSingleMultiSelectForm` a type predicate so `<MultiQuestionForm questions={questions}>` narrows as the old inline `Array.isArray` did)

Closes #5800
