### PR TITLE
feat(server): log when the model ignores the reinject stop-and-wait steer (#5798)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -408,6 +408,20 @@ export class ClaudeTuiSession extends BaseSession {
     // answering / stalling one no longer disarms the others. Cleared per-id on
     // PostToolUse and cleared wholesale on the turn-ending paths + destroy().
     this._askUserQuestionWatchdogs = new Map()
+    // #5798: observability-only marker for the multi-select reinject "stop and
+    // wait" steer. When CHROXY_TUI_MULTISELECT_REINJECT is on and a multi-select
+    // AskUserQuestion is denied, the deny reason steers the model to STOP its
+    // turn so the reinjected selection (sendMessage) lands as a fresh turn. The
+    // FormDriver sets this marker right after the flag-on sendMessage; if the
+    // model instead emits another tool_use before the reinjected turn's first
+    // output clears it, we log a loud WARN (greppable: reinject_stop_wait_violation
+    // / #5798) — the signal the steer was NOT honored. Shape when set:
+    // { deniedToolUseId, at } where `at` is _nowMonotonic(). Null = no window
+    // open. Set ONLY on the flag-on reinject path; cleared one-shot on the WARN,
+    // on the reinjected turn's first consumed hook (_clearFirstOutputWatchdog),
+    // and on every teardown/destroy/pty-gone path so a stale marker can't leak.
+    // This NEVER changes behavior — it is a measurement aid only.
+    this._reinjectStopWaitWatch = null
     // #4732: effective pre-first-output timeout in ms. Distinct from
     // _streamStallTimeoutMs (#4638) — that watchdog only re-arms BETWEEN
     // hook events, so a turn where claude TUI accepts the prompt write
@@ -1085,6 +1099,12 @@ export class ClaudeTuiSession extends BaseSession {
     // saved by the tick's !_isBusy guard — fragile. Clear before the
     // _destroying early-return so it runs on both the destroy and respawn paths.
     this._clearFirstTurnSubmitNudge()
+    // #5798: _onPtyGone does NOT route through _clearFirstOutputWatchdog, so
+    // close the reinject stop-and-wait window explicitly here (before the
+    // _destroying early-return, so it runs on both the destroy and respawn
+    // paths) — a dead/respawning PTY can't legitimately emit the reinjected
+    // turn, and a stale marker must not leak into a later turn. Observability-only.
+    this._reinjectStopWaitWatch = null
     if (this._destroying) return
     // #5311 review — the socket 'close'/'error' paths have no exit info, so
     // render a clear "unknown" instead of a bare "code=undefined". The
@@ -2234,6 +2254,36 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     if (kind === 'PreToolUse') {
+      // #5798: observability-only — did the model honor the reinject "stop and
+      // wait" steer? When a flag-on multi-select reinject fired, the FormDriver
+      // opened a watch window (this._reinjectStopWaitWatch). The model SHOULD
+      // have ended its turn so the reinjected selection becomes a fresh turn; a
+      // PreToolUse arriving while the window is still open means it kept going
+      // and tool-called instead. Log a loud WARN with greppable fields, then
+      // clear the marker (one-shot — log once per reinject). The window is also
+      // cleared on the reinjected turn's first consumed hook
+      // (_clearFirstOutputWatchdog) and on teardown/destroy/pty-gone, so this
+      // fires ONLY for a tool_use in the gap between the deny and the reinjected
+      // turn's start.
+      //
+      // Heuristic + honest false-pos/neg profile (this is a tunable measurement
+      // aid, not a gate): the detector is "any PreToolUse observed while the
+      // post-reinject-deny watch is open". FALSE POSITIVE risk: a leftover
+      // pre-*.json hook file from the DENIED turn that drains after the marker is
+      // set could trip the WARN even though it predates the reinject (the denied
+      // form is denied before it renders, so no PostToolUse is expected, but a
+      // racing pre- file is theoretically possible). FALSE NEGATIVE risk: if the
+      // reinjected turn's own first legitimate output is a non-tool hook (or its
+      // first PreToolUse is preceded by another consumed hook in the same drain
+      // pass that clears the window first), a later "didn't stop" tool_use would
+      // be missed. Both are acceptable for a default-on gating signal — count the
+      // greppable token and tune later if the rate is noisy.
+      if (this._reinjectStopWaitWatch) {
+        const watch = this._reinjectStopWaitWatch
+        this._reinjectStopWaitWatch = null
+        const deltaMs = Math.round(this._nowMonotonic() - watch.at)
+        ;(this._log || log).warn(`reinject stop-and-wait NOT honored (#5798, reinject_stop_wait_violation): model emitted tool_use after a multi-select reinject deny instead of stopping | deniedToolUseId=${watch.deniedToolUseId || '?'} newTool=${toolName} newToolUseId=${toolUseId} deltaMs=${deltaMs}`)
+      }
       // #4307: stash the command text so the matching PostToolUse can
       // record the resulting shellId with the original command. Same
       // behaviour as sdk-session.js _handleToolUseBlock — keeps TUI
@@ -2712,6 +2762,14 @@ export class ClaudeTuiSession extends BaseSession {
     // this one site covers all of them.
     this._clearFirstTurnSubmitNudge()
     this._firstOutputDisarmed = true
+    // #5798: first consumed hook of a turn (or any teardown that routes through
+    // here) is the legitimate turn-start boundary — close the reinject
+    // stop-and-wait window so a tool_use in a LATER, unrelated turn can't trip
+    // the violation WARN. In the hook-drain loop this runs AFTER the per-event
+    // _emitToolHookEvent pass (line ~2046 vs the clear at ~2076), so a PreToolUse
+    // that IS the first hook of the reinjected turn still fires the WARN first;
+    // this clear then prevents any spurious re-fire. Observability-only.
+    this._reinjectStopWaitWatch = null
   }
 
   /**

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -677,6 +677,15 @@ export class FormDriver {
       Promise.resolve(this._host.sendMessage(reinjectText)).catch((err) => {
         ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject sendMessage failed: ${err?.message || err} (tool=${prevToolUseId || '?'})`)
       })
+      // #5798 (observability-only): open the stop-and-wait watch window. The
+      // deny reason steered the model to STOP its turn so this reinjected
+      // selection lands as a fresh turn; if instead the model emits another
+      // tool_use before the reinjected turn's first output clears this marker,
+      // _emitToolHookEvent(PreToolUse) logs a loud WARN (reinject_stop_wait_
+      // violation / #5798). Set ONLY here on the flag-on reinject path — never on
+      // the flag-off refusal. No behavior change: just a marker field the session
+      // reads to decide whether to emit a measurement WARN.
+      this._host._reinjectStopWaitWatch = { deniedToolUseId: prevToolUseId, at: this._host._nowMonotonic() }
       return
     }
     this._refuseReinject(prevToolUseId, 'unsupported',

--- a/packages/server/src/claude-tui/form-driver.js
+++ b/packages/server/src/claude-tui/form-driver.js
@@ -674,9 +674,6 @@ export class FormDriver {
       this._host._clearPendingAnswerByToolUseId(prevToolUseId)
       this._host._clearAskUserQuestionWatchdog(prevToolUseId)
       this._host._clearAskUserQuestionLock()
-      Promise.resolve(this._host.sendMessage(reinjectText)).catch((err) => {
-        ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject sendMessage failed: ${err?.message || err} (tool=${prevToolUseId || '?'})`)
-      })
       // #5798 (observability-only): open the stop-and-wait watch window. The
       // deny reason steered the model to STOP its turn so this reinjected
       // selection lands as a fresh turn; if instead the model emits another
@@ -684,8 +681,23 @@ export class FormDriver {
       // _emitToolHookEvent(PreToolUse) logs a loud WARN (reinject_stop_wait_
       // violation / #5798). Set ONLY here on the flag-on reinject path — never on
       // the flag-off refusal. No behavior change: just a marker field the session
-      // reads to decide whether to emit a measurement WARN.
+      // reads to decide whether to emit a measurement WARN. Set BEFORE the send
+      // so a failed send can close it again (below).
       this._host._reinjectStopWaitWatch = { deniedToolUseId: prevToolUseId, at: this._host._nowMonotonic() }
+      Promise.resolve(this._host.sendMessage(reinjectText)).then((result) => {
+        // #5798: if the reinject never actually started a turn (busy/not-runnable
+        // race → { ok:false }), close the watch so it can't produce a spurious
+        // violation WARN against a turn that never began. Guard on the toolUseId
+        // so a stale resolution can't clear a newer reinject's watch.
+        if (result && result.ok === false && this._host._reinjectStopWaitWatch?.deniedToolUseId === prevToolUseId) {
+          this._host._reinjectStopWaitWatch = null
+        }
+      }).catch((err) => {
+        if (this._host._reinjectStopWaitWatch?.deniedToolUseId === prevToolUseId) {
+          this._host._reinjectStopWaitWatch = null
+        }
+        ;(this._host._log || log).warn(`respondToQuestion: multiSelect reinject sendMessage failed: ${err?.message || err} (tool=${prevToolUseId || '?'})`)
+      })
       return
     }
     this._refuseReinject(prevToolUseId, 'unsupported',

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -71,6 +71,13 @@ function makeMockHost(overrides = {}) {
     _isBusy: false,
     _activeTurn: { hexDumpEmitted: false, aborted: false, messageId: 'm1' },
     _log: { info() {}, warn: (m) => warns.push(m) },
+    // #5798 — the flag-on reinject path stamps a stop-and-wait watch marker with
+    // _nowMonotonic(); the real session has it (claude-tui-session.js:648). A
+    // fixed clock is enough for the form-driver tests (they only assert the marker
+    // shape, not deltas).
+    _nowMonotonic: () => 1000,
+    // #5798 — observability-only marker; starts unset, set by the flag-on reinject.
+    _reinjectStopWaitWatch: null,
     _outputTailHexDump: () => '',
     _writePtyTextThrottled: (t) => { writes.push(t); return Promise.resolve(true) },
     _writePtyMultiQuestionSequence: (seq) => { multiSeqs.push(seq); return Promise.resolve(true) },
@@ -271,6 +278,55 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.deepEqual(host._sent, [], 'no reinject when the flag is off')
     assert.equal(tornDown.length, 1)
     assert.equal(tornDown[0].payload.errorCode, 'ASK_USER_QUESTION_MULTISELECT_UNSUPPORTED')
+  })
+
+  it('single multi-select REINJECT (flag on): opens the stop-and-wait watch marker (#5798)', () => {
+    // Observability-only: after the flag-on reinject sends the new turn, the
+    // driver stamps host._reinjectStopWaitWatch so the session can detect a
+    // model that tool-calls instead of honoring the "stop and wait" steer.
+    const host = makeMockHost()
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Mushroom', 'Onion'])
+    const fd = new FormDriver(host)
+    fd._teardownAskUserQuestion = () => {}
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+
+    assert.deepEqual(host._sent, ['For "Pick toppings": Cheese, Onion'], 'reinject sent the turn')
+    assert.ok(host._reinjectStopWaitWatch, 'stop-and-wait watch marker is set')
+    assert.equal(host._reinjectStopWaitWatch.deniedToolUseId, 't1', 'marker records the denied tool id')
+    assert.equal(host._reinjectStopWaitWatch.at, 1000, 'marker stamps _nowMonotonic()')
+  })
+
+  it('single multi-select: flag OFF does NOT open the stop-and-wait watch marker (#5798)', () => {
+    const host = makeMockHost()
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    fd._teardownAskUserQuestion = () => {}
+
+    withReinjectFlag(undefined, () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+
+    assert.equal(host._reinjectStopWaitWatch, null, 'no watch marker on the flag-off refusal path')
+  })
+
+  it('single multi-select REINJECT (flag on): a refused pre-flight (busy) does NOT open the watch marker (#5798)', () => {
+    // The marker is set ONLY after the actual reinject sendMessage. A pre-flight
+    // refusal (busy / not-runnable / empty) tears down without sending, so it
+    // must not open a false stop-and-wait window.
+    const host = makeMockHost({ _isBusy: true })
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    fd._teardownAskUserQuestion = () => {}
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+
+    assert.deepEqual(host._sent, [], 'busy pre-flight does not send')
+    assert.equal(host._reinjectStopWaitWatch, null, 'no watch marker when the reinject is refused pre-flight')
   })
 
   it('formatMultiSelectReinject: parses array / JSON-string / comma-string into label text (#5776)', () => {

--- a/packages/server/tests/claude-tui-form-driver.test.js
+++ b/packages/server/tests/claude-tui-form-driver.test.js
@@ -299,6 +299,36 @@ describe('FormDriver — injected collaborator (#5617)', () => {
     assert.equal(host._reinjectStopWaitWatch.at, 1000, 'marker stamps _nowMonotonic()')
   })
 
+  it('single multi-select REINJECT (flag on): closes the watch when sendMessage resolves { ok:false } (#5798)', async () => {
+    // Race: the busy/not-runnable preflight passed, but sendMessage resolves
+    // { ok:false } (state changed) → the reinjected turn never started, so the
+    // marker must be cleared and not leak a spurious violation WARN later.
+    const host = makeMockHost({ sendMessage: () => Promise.resolve({ ok: false, reason: 'busy' }) })
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    fd._teardownAskUserQuestion = () => {}
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+    // Marker is opened synchronously, then closed when the send resolves.
+    await new Promise((r) => setTimeout(r, 0))
+    assert.equal(host._reinjectStopWaitWatch, null, 'watch closed when the reinject turn never started ({ ok:false })')
+  })
+
+  it('single multi-select REINJECT (flag on): closes the watch when sendMessage rejects (#5798)', async () => {
+    const host = makeMockHost({ sendMessage: () => Promise.reject(new Error('boom')) })
+    seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])
+    const fd = new FormDriver(host)
+    fd._teardownAskUserQuestion = () => {}
+
+    withReinjectFlag('1', () => {
+      fd.respondToQuestion('', { 'Pick toppings': ['Cheese', 'Onion'] }, 't1')
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    assert.equal(host._reinjectStopWaitWatch, null, 'watch closed when the reinject send rejected')
+  })
+
   it('single multi-select: flag OFF does NOT open the stop-and-wait watch marker (#5798)', () => {
     const host = makeMockHost()
     seedSingleMultiSelect(host, 't1', ['Cheese', 'Onion'])

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4383,6 +4383,82 @@ describe('ClaudeTuiSession', () => {
       session._emitToolHookEvent('PreToolUse', { tool_name: 'Bash' }, 'msg-1')
     })
 
+    // #5798 — observability-only: detect when the model ignores the multi-select
+    // reinject "stop and wait" steer (emits a tool_use instead of stopping).
+    describe('#5798 — reinject stop-and-wait violation telemetry', () => {
+      function captureWarns() {
+        const warns = []
+        const logSpy = (entry) => { if (entry.level === 'warn') warns.push(entry.message) }
+        addLogListener(logSpy)
+        return { warns, stop: () => removeLogListener(logSpy) }
+      }
+
+      it('WARNs (greppable #5798 / reinject_stop_wait_violation) when a PreToolUse arrives while the watch is open', () => {
+        // Simulate the FormDriver having opened the window after a flag-on reinject.
+        session._reinjectStopWaitWatch = { deniedToolUseId: 'toolu_denied', at: session._nowMonotonic() }
+        const { warns, stop } = captureWarns()
+        try {
+          session._emitToolHookEvent('PreToolUse', {
+            tool_use_id: 'toolu_after',
+            tool_name: 'Bash',
+            tool_input: { command: 'ls' },
+          }, 'msg-violation')
+        } finally {
+          stop()
+        }
+        const hit = warns.find((w) => /reinject_stop_wait_violation/.test(w))
+        assert.ok(hit, 'a violation WARN fired')
+        assert.match(hit, /#5798/, 'WARN carries the issue token')
+        assert.match(hit, /deniedToolUseId=toolu_denied/, 'WARN names the denied tool id')
+        assert.match(hit, /newTool=Bash/, 'WARN names the offending tool')
+        assert.match(hit, /newToolUseId=toolu_after/, 'WARN names the offending tool id')
+        assert.match(hit, /deltaMs=\d+/, 'WARN includes a deltaMs')
+        // One-shot: the marker is cleared so a later tool_use does not re-fire.
+        assert.equal(session._reinjectStopWaitWatch, null, 'marker cleared after the WARN')
+      })
+
+      it('fires the violation WARN exactly once (one-shot per reinject)', () => {
+        session._reinjectStopWaitWatch = { deniedToolUseId: 'toolu_denied', at: session._nowMonotonic() }
+        const { warns, stop } = captureWarns()
+        try {
+          session._emitToolHookEvent('PreToolUse', { tool_use_id: 'a', tool_name: 'Bash' }, 'm')
+          session._emitToolHookEvent('PreToolUse', { tool_use_id: 'b', tool_name: 'Read' }, 'm')
+        } finally {
+          stop()
+        }
+        const hits = warns.filter((w) => /reinject_stop_wait_violation/.test(w))
+        assert.equal(hits.length, 1, 'only the first post-reinject tool_use trips the WARN')
+      })
+
+      it('does NOT WARN when the watch was never opened', () => {
+        assert.equal(session._reinjectStopWaitWatch, null, 'precondition: no watch open')
+        const { warns, stop } = captureWarns()
+        try {
+          session._emitToolHookEvent('PreToolUse', { tool_use_id: 'x', tool_name: 'Bash' }, 'm')
+        } finally {
+          stop()
+        }
+        assert.ok(!warns.some((w) => /reinject_stop_wait_violation/.test(w)), 'no spurious violation WARN')
+      })
+
+      it('does NOT WARN when the legit turn-start clear runs BEFORE any tool_use', () => {
+        // The reinjected turn legitimately starts (first consumed hook →
+        // _clearFirstOutputWatchdog) before the model tool-calls; the window
+        // closes, so a subsequent tool_use is a normal in-turn tool, not a
+        // violation.
+        session._reinjectStopWaitWatch = { deniedToolUseId: 'toolu_denied', at: session._nowMonotonic() }
+        session._clearFirstOutputWatchdog()
+        assert.equal(session._reinjectStopWaitWatch, null, 'turn-start clear closed the window')
+        const { warns, stop } = captureWarns()
+        try {
+          session._emitToolHookEvent('PreToolUse', { tool_use_id: 'legit', tool_name: 'Edit' }, 'm')
+        } finally {
+          stop()
+        }
+        assert.ok(!warns.some((w) => /reinject_stop_wait_violation/.test(w)), 'no violation after a legit turn-start clear')
+      })
+    })
+
     // #4307: parity with SdkSession — PreToolUse with Bash +
     // run_in_background stashes the command; PostToolUse with the
     // canonical "Command running in background with ID:" text


### PR DESCRIPTION
## Summary
Adds **observability-only** telemetry to measure whether the model honors the reinject "stop and wait" steer — the last open item from the SOLID/DRY audit (TUI Expert). When `CHROXY_TUI_MULTISELECT_REINJECT=1`, a multi-select deny steers the model to stop and wait for the reinjected selection; whether it actually stops vs. immediately calls another tool is model/version-dependent and was unmeasured. This logs it so the future default-on decision can be gated on real data. **Zero behavior change — one nullable field + one WARN.**

## How it works
- New `_reinjectStopWaitWatch` field (constructor-init `null`), set `{ deniedToolUseId, at }` **only** on the flag-on reinject path (`_reinjectMultiSelect`, right after `sendMessage(reinjectText)`).
- In the `PreToolUse` hook observer (`_emitToolHookEvent`), if the watch is open when a tool_use arrives, emit a loud WARN (greppable `#5798` / `reinject_stop_wait_violation`, with `deniedToolUseId`/`newTool`/`newToolUseId`/`deltaMs`) and one-shot clear it.
- Cleared on the legit turn-start boundary (`_clearFirstOutputWatchdog`, which also funnels teardown/turn-end), plus `_onPtyGone` and `destroy`, so it can't leak or fire spuriously.

## Heuristic profile (documented inline; it's a measurement aid, not a gate)
- **False positive:** a racing leftover `pre-*.json` from the denied turn draining after the marker is set.
- **False negative:** if the reinjected turn's first consumed hook is a non-tool event, the window closes before a later "didn't stop" tool_use.
Acceptable for a counting signal; tunable if noisy.

## Verification
- `claude-tui-session.test.js` + `claude-tui-form-driver.test.js`: **308/308 pass**, incl. new #5798 tests (WARN fires with all fields + one-shot clear; flag-off/busy paths don't set the marker; legit turn-start clear → no WARN)
- All 4 custom server lints green; `git diff` confirms pure additions (no source lines removed/modified)

Closes #5798
