### PR TITLE
fix(app): compare allowSingleMultiSelect in MessageBubble memo comparator

### DIFF
--- a/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
@@ -281,4 +281,46 @@ describe('MessageBubble single-question multiSelect (#5776)', () => {
     expect(present(tree, 'approval-button-Cheese')).toBe(true);
     expect(present(tree, 'approval-button-Onion')).toBe(true);
   });
+
+  // #5791 review: the React.memo comparator must compare allowSingleMultiSelect,
+  // or the bubble keeps stale gating when the prop flips under a LIVE prompt
+  // (same message ref) — e.g. claude-tui's multiSelectReinject capability
+  // arriving in availableProviders after the prompt mounted. Render with it
+  // false, then re-render the SAME message with it true, and assert the form
+  // appears (the memo no longer blocks the update).
+  it('re-renders the checkbox form when allowSingleMultiSelect flips true under a live prompt (#5791)', () => {
+    const message = singleMultiSelectPrompt();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <MessageBubble
+          message={message}
+          isSelected={false}
+          isSelecting={false}
+          onLongPress={() => {}}
+          onPress={() => {}}
+          onOpenDetail={() => {}}
+          onSelectOption={jest.fn()}
+          allowSingleMultiSelect={false}
+        />,
+      );
+    });
+    expect(present(tree, 'question-prompt-multi')).toBe(false);
+    // Same message ref; only allowSingleMultiSelect changes.
+    act(() => {
+      tree.update(
+        <MessageBubble
+          message={message}
+          isSelected={false}
+          isSelecting={false}
+          onLongPress={() => {}}
+          onPress={() => {}}
+          onOpenDetail={() => {}}
+          onSelectOption={jest.fn()}
+          allowSingleMultiSelect={true}
+        />,
+      );
+    });
+    expect(present(tree, 'question-prompt-multi')).toBe(true);
+  });
 });

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -657,6 +657,13 @@ export const MessageBubble = React.memo(MessageBubbleImpl, (prev, next) => {
     prev.isSelected === next.isSelected &&
     prev.isSelecting === next.isSelecting &&
     prev.allowMultiQuestion === next.allowMultiQuestion &&
+    // #5791 — allowSingleMultiSelect gates the single-question multiSelect
+    // checkbox form and (unlike allowMultiQuestion) depends on the provider's
+    // server-advertised multiSelectReinject capability, which can flip under a
+    // live prompt when availableProviders updates. Must be compared or the
+    // bubble keeps stale gating (the dashboard re-renders via useMessageRenderer's
+    // deps; the app relies on this comparator).
+    prev.allowSingleMultiSelect === next.allowSingleMultiSelect &&
     (prev.onRetryStreamStall == null) === (next.onRetryStreamStall == null)
   );
 });


### PR DESCRIPTION
## Summary
Fixes a correctness regression surfaced by the marathon convergence accuracy-audit (adversarially verified). #5791 threaded the new `allowSingleMultiSelect` gating prop into the app's `MessageBubble`, but its custom `React.memo` comparator (added in #5532) was never updated to compare it.

Unlike `allowMultiQuestion` (which depends only on the provider name), `allowSingleMultiSelect` also depends on the server-advertised `multiSelectReinject` capability — which can flip **under a live prompt** when `availableProviders` updates. With the prop uncompared, `React.memo` skipped the re-render and the bubble kept **stale gating** (the single-multiSelect checkbox form never appeared, or persisted after it should hide). The dashboard has no such trap — `useMessageRenderer` recomputes with `activeSessionCaps` in its deps — so this was an app-only divergence introduced by the convergence work.

## Fix
One line added to the comparator (`packages/app/src/components/chat/MessageBubble.tsx`), matching the existing scalar-boolean pattern, + a regression test that re-renders the **same message ref** with `allowSingleMultiSelect` flipped true and asserts the form appears.

## Verification
- app `tsc --noEmit` clean
- `MessageBubble.multiQuestion` jest: **10/10** incl. the new live-flip regression test (fails without the comparator change)

Found-by: marathon convergence accuracy swarm-audit (2026-06-14).
