### PR TITLE
feat(server): wire billing canary into chroxy doctor (#5821)

### DIFF
--- a/packages/server/src/doctor-billing.js
+++ b/packages/server/src/doctor-billing.js
@@ -1,0 +1,119 @@
+// doctor-billing.js — billing canary for the 2026-06-15 programmatic-credit cutover.
+//
+// DRAFT (rec #4 of docs/audit/june15-billing-strategy-2026-06-14.md). Early-warning
+// that the `claude-tui` subscription-billing bet may have stopped holding, plus a
+// datacenter-egress ban-signal warning. The checks here are PURE and injectable
+// (pass `now`, the session list, the egress ip) so they unit-test without timers or
+// network; a thin runner aggregates them for a future `chroxy doctor billing` command.
+//
+// Wiring left for review before shipping: (a) map live SessionManager sessions to the
+// {id, provider, totalCostUsd} shape `runBillingCanary` expects, (b) fetch the daemon's
+// public egress ip, (c) register the `doctor` subcommand in the CLI. None of that is
+// done yet — this module is the reviewable core.
+import {
+  BILLING_CLASSES,
+  PROGRAMMATIC_CREDIT_ERA_START,
+  billingClassForProvider,
+  isProgrammaticCreditEra,
+} from './billing-class.js'
+
+/**
+ * Loophole-closed canary. A `claude-tui` session is nominally subscription-billed
+ * (interactive allowance), so it should report no programmatic cost. If one reports
+ * a non-zero cost on/after the cutover, the bet may have been reclassified to metered
+ * credits — the single most important signal to surface.
+ *
+ * @param {Array<{id:string, provider:string, totalCostUsd?:number, apiKeyAuth?:boolean}>} sessions
+ * @param {number} [now]
+ * @returns {Array<{code:string, sessionId:string, costUsd:number, message:string}>}
+ */
+export function detectBillingReclassification(sessions = [], now = Date.now()) {
+  const warnings = []
+  for (const s of sessions || []) {
+    if (!s || s.provider !== 'claude-tui') continue
+    // claude-tui is always SUBSCRIPTION per billing-class; guard anyway so this
+    // stays correct if that ever changes.
+    if (billingClassForProvider('claude-tui', now) !== BILLING_CLASSES.SUBSCRIPTION) continue
+    const cost = Number(s.totalCostUsd)
+    if (Number.isFinite(cost) && cost > 0) {
+      warnings.push({
+        code: 'TUI_REPORTED_PROGRAMMATIC_COST',
+        sessionId: s.id,
+        costUsd: cost,
+        message:
+          `claude-tui session ${s.id} reported $${cost.toFixed(4)} of programmatic cost, but it ` +
+          `should bill against your subscription's interactive allowance. The cutover may have ` +
+          `reclassified it — verify in your Anthropic billing dashboard and consider BYOK (ANTHROPIC_API_KEY).`,
+      })
+    }
+  }
+  return warnings
+}
+
+/**
+ * Silent-metered-default canary. On/after the era boundary, a daemon whose default
+ * provider is a programmatic one meters credits with no prompt. (#5819.)
+ *
+ * @param {string} defaultProvider - the resolved default provider id
+ * @param {number} [now]
+ * @returns {Array<{code:string, provider:string, message:string}>}
+ */
+export function detectSilentMeteredDefault(defaultProvider, now = Date.now()) {
+  if (!isProgrammaticCreditEra(now)) return []
+  if (billingClassForProvider(defaultProvider, now) !== BILLING_CLASSES.PROGRAMMATIC_CREDIT) return []
+  return [{
+    code: 'SILENT_METERED_DEFAULT',
+    provider: defaultProvider,
+    message:
+      `The default provider '${defaultProvider}' bills against the metered programmatic-credit pool ` +
+      `since 2026-06-15. New default sessions draw credits silently — switch with --provider claude-tui ` +
+      `(subscription, best-effort) or set ANTHROPIC_API_KEY (BYOK).`,
+  }]
+}
+
+// Datacenter-egress ban-signal. Cloud-hosted daemons behind a tunnel are a documented
+// flag (the audit cites ~20-minute bans on Hetzner/Cloudflare ranges). This is a pure
+// classifier over a known-prefix list; the caller supplies the public egress ip.
+// DRAFT: the prefix list is a starting point, not exhaustive — curate before shipping.
+const DATACENTER_IPV4_PREFIXES = [
+  // Hetzner (cited in claude-code#21678)
+  '5.9.', '88.99.', '95.216.', '116.202.', '135.181.', '167.235.', '168.119.',
+  // common cloud egress ranges (illustrative; expand from a real dataset)
+  '13.', '18.', '34.', '35.', '52.', '54.', // AWS/GCP blocks (coarse — DRAFT)
+]
+
+/**
+ * @param {string} ip - public egress IPv4
+ * @returns {{datacenter:boolean, code?:string, message?:string}}
+ */
+export function classifyEgressIp(ip) {
+  if (!ip || typeof ip !== 'string') return { datacenter: false }
+  const hit = DATACENTER_IPV4_PREFIXES.some((p) => ip.startsWith(p))
+  if (!hit) return { datacenter: false }
+  return {
+    datacenter: true,
+    code: 'DATACENTER_EGRESS',
+    message:
+      `This daemon's public egress IP (${ip}) looks like a datacenter/cloud range. Driving a Claude ` +
+      `subscription login from a cloud host is a documented ban signal — prefer a residential network ` +
+      `for claude-tui, or use BYOK on cloud hosts.`,
+  }
+}
+
+/**
+ * Aggregate the canary. Returns a flat warnings array (empty = all clear).
+ *
+ * @param {{sessions?:Array, defaultProvider?:string, egressIp?:string, now?:number}} input
+ */
+export function runBillingCanary({ sessions = [], defaultProvider, egressIp, now = Date.now() } = {}) {
+  const warnings = []
+  warnings.push(...detectSilentMeteredDefault(defaultProvider, now))
+  warnings.push(...detectBillingReclassification(sessions, now))
+  const egress = classifyEgressIp(egressIp)
+  if (egress.datacenter) warnings.push({ code: egress.code, message: egress.message })
+  return {
+    eraStarted: isProgrammaticCreditEra(now),
+    eraStart: PROGRAMMATIC_CREDIT_ERA_START,
+    warnings,
+  }
+}

--- a/packages/server/src/doctor-billing.js
+++ b/packages/server/src/doctor-billing.js
@@ -33,6 +33,11 @@ import {
  */
 export function detectBillingReclassification(sessions = [], now = Date.now()) {
   const warnings = []
+  // Only meaningful on/after the cutover: before it, claude-tui and the host
+  // programmatic providers all bill as flat subscription, so a cost reading is
+  // not a reclassification signal. Gating here keeps the behaviour matching the
+  // docstring (no surprising pre-cutover warnings).
+  if (!isProgrammaticCreditEra(now)) return warnings
   for (const s of sessions || []) {
     if (!s || s.provider !== 'claude-tui') continue
     // claude-tui is always SUBSCRIPTION per billing-class; guard anyway so this
@@ -60,17 +65,24 @@ export function detectBillingReclassification(sessions = [], now = Date.now()) {
  *
  * @param {string} defaultProvider - the resolved default provider id
  * @param {number} [now]
+ * @param {{ apiKeyAuth?: boolean }} [opts] - `apiKeyAuth: true` forwards billing-class's
+ *   refinement: claude-sdk/claude-cli authed with an explicit ANTHROPIC_API_KEY bill the
+ *   raw API account (api-key), NOT the credit pool — so a BYOK default must NOT trip this
+ *   warning. The caller decides this (e.g. claude-sdk + ANTHROPIC_API_KEY set).
  * @returns {Array<{code:string, provider:string, message:string}>}
  */
-export function detectSilentMeteredDefault(defaultProvider, now = Date.now()) {
+export function detectSilentMeteredDefault(defaultProvider, now = Date.now(), { apiKeyAuth = false } = {}) {
   if (!isProgrammaticCreditEra(now)) return []
-  if (billingClassForProvider(defaultProvider, now) !== BILLING_CLASSES.PROGRAMMATIC_CREDIT) return []
+  if (billingClassForProvider(defaultProvider, now, { apiKeyAuth }) !== BILLING_CLASSES.PROGRAMMATIC_CREDIT) return []
+  // Derive the boundary date from the shared constant so a moved cutover can't
+  // leave a stale string here.
+  const cutover = new Date(PROGRAMMATIC_CREDIT_ERA_START).toISOString().slice(0, 10)
   return [{
     code: 'SILENT_METERED_DEFAULT',
     provider: defaultProvider,
     message:
       `The default provider '${defaultProvider}' bills against the metered programmatic-credit pool ` +
-      `since 2026-06-15. New default sessions draw credits silently — switch with --provider claude-tui ` +
+      `since ${cutover}. New default sessions draw credits silently — switch with --provider claude-tui ` +
       `(subscription, best-effort) or set ANTHROPIC_API_KEY (BYOK).`,
   }]
 }

--- a/packages/server/src/doctor-billing.js
+++ b/packages/server/src/doctor-billing.js
@@ -1,15 +1,19 @@
 // doctor-billing.js — billing canary for the 2026-06-15 programmatic-credit cutover.
 //
-// DRAFT (rec #4 of docs/audit/june15-billing-strategy-2026-06-14.md). Early-warning
-// that the `claude-tui` subscription-billing bet may have stopped holding, plus a
-// datacenter-egress ban-signal warning. The checks here are PURE and injectable
-// (pass `now`, the session list, the egress ip) so they unit-test without timers or
-// network; a thin runner aggregates them for a future `chroxy doctor billing` command.
+// rec #4 of docs/audit/june15-billing-strategy-2026-06-14.md. Early-warning that the
+// `claude-tui` subscription-billing bet may have stopped holding, plus a
+// datacenter-egress ban-signal warning. Every check here is PURE and injectable (pass
+// `now`, the session list, the egress ip) so they unit-test without timers or network.
 //
-// Wiring left for review before shipping: (a) map live SessionManager sessions to the
-// {id, provider, totalCostUsd} shape `runBillingCanary` expects, (b) fetch the daemon's
-// public egress ip, (c) register the `doctor` subcommand in the CLI. None of that is
-// done yet — this module is the reviewable core.
+// Wiring status:
+//   - detectSilentMeteredDefault — WIRED into `chroxy doctor` (doctor.js "Billing"
+//     check). It needs only the resolved default provider + the clock, both available
+//     in the standalone preflight.
+//   - detectBillingReclassification — exported for the DAEMON / dashboard to call: it
+//     needs live per-session `totalCostUsd`, which a standalone `chroxy doctor` (no
+//     running daemon) does not have. Not wired into the CLI for that reason.
+//   - classifyEgressIp — exported; needs the daemon's resolved public egress IP (a
+//     network lookup), so it is consumed by the daemon/dashboard, not standalone doctor.
 import {
   BILLING_CLASSES,
   PROGRAMMATIC_CREDIT_ERA_START,
@@ -72,14 +76,19 @@ export function detectSilentMeteredDefault(defaultProvider, now = Date.now()) {
 }
 
 // Datacenter-egress ban-signal. Cloud-hosted daemons behind a tunnel are a documented
-// flag (the audit cites ~20-minute bans on Hetzner/Cloudflare ranges). This is a pure
-// classifier over a known-prefix list; the caller supplies the public egress ip.
-// DRAFT: the prefix list is a starting point, not exhaustive — curate before shipping.
+// flag (the audit cites ~20-minute bans on Hetzner ranges). This is a pure classifier
+// over a known-prefix list; the caller supplies the public egress ip.
+//
+// CONSERVATIVE BY DESIGN: only specific, documented datacenter /16-ish ranges are
+// listed. Coarse /8 blocks (e.g. AWS/GCP `13.`, `34.`, `52.`) were deliberately
+// REMOVED — they span large amounts of residential/ISP space too and would fire false
+// positives, training users to ignore the warning. A comprehensive classifier needs a
+// maintained cloud-IP dataset (e.g. the published AWS/GCP/Azure range JSON); until that
+// is plumbed in, a precise-but-narrow list that never cries wolf beats a broad-but-noisy
+// one. A missed datacenter IP is a silent non-warning; a false hit erodes trust.
 const DATACENTER_IPV4_PREFIXES = [
-  // Hetzner (cited in claude-code#21678)
+  // Hetzner (cited in claude-code#21678) — specific allocated /16s.
   '5.9.', '88.99.', '95.216.', '116.202.', '135.181.', '167.235.', '168.119.',
-  // common cloud egress ranges (illustrative; expand from a real dataset)
-  '13.', '18.', '34.', '35.', '52.', '54.', // AWS/GCP blocks (coarse — DRAFT)
 ]
 
 /**

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -8,6 +8,13 @@ import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { getProvider, DEFAULT_PROVIDER } from './providers.js'
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
+import { detectSilentMeteredDefault } from './doctor-billing.js'
+import {
+  billingClassForProvider,
+  billingDetailForClass,
+  isProgrammaticCreditEra,
+  PROGRAMMATIC_CREDIT_ERA_START,
+} from './billing-class.js'
 import { checkDependencies } from './utils/check-dependencies.js'
 
 // Resolve the server package root (the directory containing package.json
@@ -123,7 +130,7 @@ function resolveProviders({ providers, configProvider }) {
  *   tests can point the check at a temp directory without mutating process.cwd().
  * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string, provider?: string }>, passed: boolean, providers: string[] }}
  */
-export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR } = {}) {
+export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR, now = Date.now() } = {}) {
   const checks = []
   const isMac = platform() === 'darwin'
   const isLinux = platform() === 'linux'
@@ -196,6 +203,39 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // 5. Config check — appended after provider checks so per-provider
   // sections group together in the output report.
   checks.push(configCheck)
+
+  // 5.5 Billing canary (#5821, audit rec #4). Standalone-feasible half of the
+  // canary: the silent-metered-default check needs only the resolved default
+  // provider + the clock. (The reclassification + datacenter-egress checks in
+  // doctor-billing.js need live daemon state / a network lookup, so they're
+  // consumed by the daemon/dashboard, not this preflight.) Use the same
+  // resolution as the provider checks above — explicit `providers` override
+  // wins (for tests), else config.provider, else DEFAULT_PROVIDER — so the
+  // billing line tracks whichever provider a zero-config session would use.
+  const effectiveDefault = resolvedProviders[0] || DEFAULT_PROVIDER
+  const meteredWarnings = detectSilentMeteredDefault(effectiveDefault, now)
+  if (meteredWarnings.length > 0) {
+    checks.push({ name: 'Billing', status: 'warn', message: meteredWarnings[0].message })
+  } else {
+    const billingClass = billingClassForProvider(effectiveDefault, now)
+    const detail = billingDetailForClass(billingClass)
+    if (isProgrammaticCreditEra(now)) {
+      checks.push({
+        name: 'Billing',
+        status: 'pass',
+        message: `Default provider '${effectiveDefault}' — ${detail}`,
+      })
+    } else {
+      // Pre-cutover: nothing meters yet, but surface the upcoming boundary and
+      // what the default will bill once it lands.
+      const cutover = new Date(PROGRAMMATIC_CREDIT_ERA_START).toISOString().slice(0, 10)
+      checks.push({
+        name: 'Billing',
+        status: 'pass',
+        message: `Default provider '${effectiveDefault}' — ${detail}. Programmatic-credit cutover: ${cutover}.`,
+      })
+    }
+  }
 
   // 6. Dependencies
   // Resolve deps relative to the server package, not process.cwd() — Tauri

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -213,11 +213,17 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // wins (for tests), else config.provider, else DEFAULT_PROVIDER — so the
   // billing line tracks whichever provider a zero-config session would use.
   const effectiveDefault = resolvedProviders[0] || DEFAULT_PROVIDER
-  const meteredWarnings = detectSilentMeteredDefault(effectiveDefault, now)
+  // billing-class refinement: claude-sdk authed with an explicit ANTHROPIC_API_KEY
+  // bills the raw API account (api-key), not the metered credit pool — so a BYOK
+  // default must not trip a false silent-metered warning. claude-cli strips the key
+  // before spawn, so the env var doesn't change its class; only claude-sdk honours
+  // it here, matching sdk-session's auth resolution.
+  const apiKeyAuth = effectiveDefault === 'claude-sdk' && Boolean(process.env.ANTHROPIC_API_KEY)
+  const meteredWarnings = detectSilentMeteredDefault(effectiveDefault, now, { apiKeyAuth })
   if (meteredWarnings.length > 0) {
     checks.push({ name: 'Billing', status: 'warn', message: meteredWarnings[0].message })
   } else {
-    const billingClass = billingClassForProvider(effectiveDefault, now)
+    const billingClass = billingClassForProvider(effectiveDefault, now, { apiKeyAuth })
     const detail = billingDetailForClass(billingClass)
     if (isProgrammaticCreditEra(now)) {
       checks.push({

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -41,6 +41,29 @@ test('detectSilentMeteredDefault flags a programmatic default in the era only', 
   assert.equal(detectSilentMeteredDefault('claude-byok', AFTER).length, 0) // api-key
 })
 
+test('detectSilentMeteredDefault does NOT flag claude-sdk when apiKeyAuth (BYOK)', () => {
+  // claude-sdk + explicit ANTHROPIC_API_KEY = raw-API billing, not the credit
+  // pool — so a BYOK default must not trip the silent-metered warning.
+  assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER, { apiKeyAuth: true }).length, 0)
+  // ...but without the key it still warns.
+  assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER, { apiKeyAuth: false }).length, 1)
+})
+
+test('detectSilentMeteredDefault derives the cutover date from the shared constant', () => {
+  // Guards against a hardcoded date drifting from PROGRAMMATIC_CREDIT_ERA_START.
+  assert.match(detectSilentMeteredDefault('claude-sdk', AFTER)[0].message, /since 2026-06-15\b/)
+})
+
+test('detectBillingReclassification stays silent before the cutover (era-gated)', () => {
+  // Matches the docstring: a cost reading is only a reclassification signal
+  // on/after the boundary; before it everything bills flat subscription.
+  const w = detectBillingReclassification(
+    [{ id: 's1', provider: 'claude-tui', totalCostUsd: 0.99 }],
+    BEFORE,
+  )
+  assert.equal(w.length, 0)
+})
+
 test('classifyEgressIp flags datacenter prefixes, not residential', () => {
   assert.equal(classifyEgressIp('95.216.1.2').datacenter, true)
   assert.equal(classifyEgressIp('95.216.1.2').code, 'DATACENTER_EGRESS')

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -1,0 +1,73 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  detectBillingReclassification,
+  detectSilentMeteredDefault,
+  classifyEgressIp,
+  runBillingCanary,
+} from '../src/doctor-billing.js'
+
+const AFTER = Date.UTC(2026, 5, 16) // one day into the programmatic-credit era
+const BEFORE = Date.UTC(2026, 5, 1) // before the cutover
+
+test('detectBillingReclassification flags a claude-tui session reporting programmatic cost', () => {
+  const w = detectBillingReclassification(
+    [{ id: 's1', provider: 'claude-tui', totalCostUsd: 0.42 }],
+    AFTER,
+  )
+  assert.equal(w.length, 1)
+  assert.equal(w[0].code, 'TUI_REPORTED_PROGRAMMATIC_COST')
+  assert.equal(w[0].sessionId, 's1')
+  assert.equal(w[0].costUsd, 0.42)
+})
+
+test('detectBillingReclassification ignores zero-cost and non-tui sessions', () => {
+  const w = detectBillingReclassification(
+    [
+      { id: 's1', provider: 'claude-tui', totalCostUsd: 0 },
+      { id: 's2', provider: 'claude-sdk', totalCostUsd: 5 },
+      { id: 's3', provider: 'claude-tui' },
+    ],
+    AFTER,
+  )
+  assert.equal(w.length, 0)
+})
+
+test('detectSilentMeteredDefault flags a programmatic default in the era only', () => {
+  assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER).length, 1)
+  assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER)[0].code, 'SILENT_METERED_DEFAULT')
+  assert.equal(detectSilentMeteredDefault('claude-sdk', BEFORE).length, 0) // subscription before cutover
+  assert.equal(detectSilentMeteredDefault('claude-tui', AFTER).length, 0) // always subscription
+  assert.equal(detectSilentMeteredDefault('claude-byok', AFTER).length, 0) // api-key
+})
+
+test('classifyEgressIp flags datacenter prefixes, not residential', () => {
+  assert.equal(classifyEgressIp('95.216.1.2').datacenter, true)
+  assert.equal(classifyEgressIp('95.216.1.2').code, 'DATACENTER_EGRESS')
+  assert.equal(classifyEgressIp('73.162.4.10').datacenter, false) // residential-ish
+  assert.equal(classifyEgressIp('').datacenter, false)
+  assert.equal(classifyEgressIp(undefined).datacenter, false)
+})
+
+test('runBillingCanary aggregates all three signals', () => {
+  const out = runBillingCanary({
+    sessions: [{ id: 's1', provider: 'claude-tui', totalCostUsd: 1.5 }],
+    defaultProvider: 'claude-sdk',
+    egressIp: '5.9.10.11',
+    now: AFTER,
+  })
+  assert.equal(out.eraStarted, true)
+  const codes = out.warnings.map((w) => w.code).sort()
+  assert.deepEqual(codes, ['DATACENTER_EGRESS', 'SILENT_METERED_DEFAULT', 'TUI_REPORTED_PROGRAMMATIC_COST'])
+})
+
+test('runBillingCanary is quiet before the era with a clean setup', () => {
+  const out = runBillingCanary({
+    sessions: [{ id: 's1', provider: 'claude-tui', totalCostUsd: 0 }],
+    defaultProvider: 'claude-sdk',
+    egressIp: '73.162.4.10',
+    now: BEFORE,
+  })
+  assert.equal(out.eraStarted, false)
+  assert.equal(out.warnings.length, 0)
+})

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -49,6 +49,16 @@ test('classifyEgressIp flags datacenter prefixes, not residential', () => {
   assert.equal(classifyEgressIp(undefined).datacenter, false)
 })
 
+test('classifyEgressIp does NOT flag coarse /8 blocks (false-positive guard)', () => {
+  // These broad AWS/GCP /8 prefixes were removed because they span huge
+  // amounts of residential/ISP space too. A false hit erodes trust in the
+  // warning, so the classifier stays conservative until a real cloud-IP
+  // dataset is plumbed in. Lock that out so they can't creep back.
+  for (const ip of ['13.52.1.1', '18.200.1.1', '34.120.1.1', '35.1.2.3', '52.10.20.30', '54.1.2.3']) {
+    assert.equal(classifyEgressIp(ip).datacenter, false, `${ip} must not be flagged`)
+  }
+})
+
 test('runBillingCanary aggregates all three signals', () => {
   const out = runBillingCanary({
     sessions: [{ id: 's1', provider: 'claude-tui', totalCostUsd: 1.5 }],

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -63,6 +63,35 @@ describe('runDoctorChecks', () => {
     assert.ok(configCheck)
   })
 
+  describe('Billing check (#5821)', () => {
+    const AFTER = Date.UTC(2026, 5, 16) // one day into the programmatic-credit era
+    const BEFORE = Date.UTC(2026, 5, 1) // before the cutover
+
+    it('warns when the default provider meters silently on/after the cutover', async () => {
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], now: AFTER })
+      const billing = checks.find(c => c.name === 'Billing')
+      assert.ok(billing)
+      assert.equal(billing.status, 'warn')
+      assert.match(billing.message, /metered programmatic-credit pool/)
+    })
+
+    it('passes for a subscription default (claude-tui) in the era', async () => {
+      const { checks } = await runDoctorChecks({ providers: ['claude-tui'], now: AFTER })
+      const billing = checks.find(c => c.name === 'Billing')
+      assert.ok(billing)
+      assert.equal(billing.status, 'pass')
+      assert.match(billing.message, /claude-tui/)
+    })
+
+    it('passes before the cutover and surfaces the upcoming date', async () => {
+      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], now: BEFORE })
+      const billing = checks.find(c => c.name === 'Billing')
+      assert.ok(billing)
+      assert.equal(billing.status, 'pass')
+      assert.match(billing.message, /cutover: 2026-06-15/)
+    })
+  })
+
   it('dependencies check is present', async () => {
     const { checks } = await runDoctorChecks({ providers: ['claude-sdk'] })
     const depsCheck = checks.find(c => c.name === 'Dependencies')

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -67,16 +67,36 @@ describe('runDoctorChecks', () => {
     const AFTER = Date.UTC(2026, 5, 16) // one day into the programmatic-credit era
     const BEFORE = Date.UTC(2026, 5, 1) // before the cutover
 
+    // The claude-sdk billing class depends on ANTHROPIC_API_KEY (env → api-key
+    // billing). Pin the env per test so results don't depend on the dev/CI shell.
+    const withEnv = async (apiKey, fn) => {
+      const saved = process.env.ANTHROPIC_API_KEY
+      if (apiKey === null) delete process.env.ANTHROPIC_API_KEY
+      else process.env.ANTHROPIC_API_KEY = apiKey
+      try { return await fn() } finally {
+        if (saved === undefined) delete process.env.ANTHROPIC_API_KEY
+        else process.env.ANTHROPIC_API_KEY = saved
+      }
+    }
+
     it('warns when the default provider meters silently on/after the cutover', async () => {
-      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], now: AFTER })
+      const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now: AFTER }))
       const billing = checks.find(c => c.name === 'Billing')
       assert.ok(billing)
       assert.equal(billing.status, 'warn')
       assert.match(billing.message, /metered programmatic-credit pool/)
     })
 
+    it('does NOT warn for claude-sdk when ANTHROPIC_API_KEY is set (BYOK)', async () => {
+      const { checks } = await withEnv('sk-test-key', () => runDoctorChecks({ providers: ['claude-sdk'], now: AFTER }))
+      const billing = checks.find(c => c.name === 'Billing')
+      assert.ok(billing)
+      assert.equal(billing.status, 'pass')
+      assert.match(billing.message, /API key/) // billingDetailForClass(api-key)
+    })
+
     it('passes for a subscription default (claude-tui) in the era', async () => {
-      const { checks } = await runDoctorChecks({ providers: ['claude-tui'], now: AFTER })
+      const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-tui'], now: AFTER }))
       const billing = checks.find(c => c.name === 'Billing')
       assert.ok(billing)
       assert.equal(billing.status, 'pass')
@@ -84,7 +104,7 @@ describe('runDoctorChecks', () => {
     })
 
     it('passes before the cutover and surfaces the upcoming date', async () => {
-      const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], now: BEFORE })
+      const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now: BEFORE }))
       const billing = checks.find(c => c.name === 'Billing')
       assert.ok(billing)
       assert.equal(billing.status, 'pass')


### PR DESCRIPTION
## Summary

Ships the standalone-feasible half of the audit's rec-#4 billing canary (`docs/audit/june15-billing-strategy-2026-06-14.md`) — an early-warning system for the 2026-06-15 programmatic-credit cutover.

## What's wired

- **`chroxy doctor` gains a "Billing" check.** `detectSilentMeteredDefault` needs only the resolved default provider + the clock, both available in the standalone preflight:
  - On/after the cutover, if the configured default would draw the metered programmatic-credit pool (e.g. an explicit `provider: 'claude-sdk'`), it **warns** with the switch-to-claude-tui / set-ANTHROPIC_API_KEY guidance.
  - Otherwise it **passes**, reporting the default's billing class — and pre-cutover, the upcoming cutover date.
  - `runDoctorChecks` now takes an injectable `now` for deterministic tests.

## What's exported but NOT CLI-wired (and why)

- `detectBillingReclassification` (claude-tui reporting programmatic cost = the bet broke) needs **live per-session `totalCostUsd`** — only a running daemon has that, not a standalone `chroxy doctor`. Exported for the daemon/dashboard to consume.
- `classifyEgressIp` needs the daemon's **resolved public egress IP** (a network lookup). Exported for the same reason.

## Hardening

The original draft's datacenter-egress prefix list had coarse `/8` AWS/GCP blocks (`13.`, `34.`, `52.`, …) that span large residential/ISP space and would cry wolf. **Removed** — kept only specific documented Hetzner ranges. A false hit erodes trust more than a missed one; a comprehensive classifier needs a real cloud-IP dataset, deferred. A regression test locks the coarse blocks out.

## Testing

- `doctor-billing.test.js`: 7 pure-unit tests (reclassification, silent-metered-default, egress incl. the new false-positive guard, aggregate).
- `doctor.test.js`: 3 new wiring tests (warn after cutover, pass for claude-tui, pre-cutover date surfaced).
- Full server suite green except the 2 known `:8765` live-daemon artifacts; opt-forwarding + state-file-path lints clean.

Implements rec #4 of the June-15 billing audit (#5818).
