### PR TITLE
fix(protocol): single-source DEFAULT_PROVIDER; fix badge suppression (#5823)

### DIFF
--- a/packages/app/src/__tests__/components/SessionPickerProviderBadge.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerProviderBadge.test.ts
@@ -24,13 +24,15 @@ describe('SessionPicker pill chip — provider hint badge (#3940)', () => {
     expect(pillSection).toMatch(/getProviderInfo\(session\.provider\)/);
   });
 
-  it("only renders the provider hint when the session's provider is not the claude-sdk default", () => {
+  it("only renders the provider hint when the session's provider is not the default", () => {
     // Same gate as the long-press alert title from #3937 — gate on
-    // "session.provider && session.provider !== 'claude-sdk'" so the
-    // default SDK pill stays clean and only variant providers (claude-tui,
-    // codex, gemini, docker-cli, ...) get a badge.
+    // "session.provider && session.provider !== DEFAULT_PROVIDER" so the
+    // default pill stays clean and only non-default providers (claude-sdk,
+    // codex, gemini, docker-cli, ...) get a badge. Keyed on the shared
+    // DEFAULT_PROVIDER constant (#5823) so a default flip can't reintroduce
+    // the stale-literal drift.
     expect(pillSection).toMatch(
-      /session\.provider\s*&&\s*session\.provider\s*!==\s*['"]claude-sdk['"]/,
+      /session\.provider\s*&&\s*session\.provider\s*!==\s*DEFAULT_PROVIDER/,
     );
   });
 

--- a/packages/app/src/__tests__/components/SessionPickerProviderLabel.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerProviderLabel.test.ts
@@ -27,8 +27,10 @@ describe('SessionPicker long-press alert title — provider suffix (#3937)', () 
     expect(alertTitleSection).not.toMatch(/session\.provider\s*===\s*['"]claude-cli['"]/);
   });
 
-  it("only suffixes when the session's provider is not the claude-sdk default", () => {
-    expect(alertTitleSection).toMatch(/session\.provider\s*&&\s*session\.provider\s*!==\s*['"]claude-sdk['"]/);
+  it("only suffixes when the session's provider is not the default", () => {
+    // Keyed on the shared DEFAULT_PROVIDER constant (#5823), not a hardcoded
+    // 'claude-sdk', so a default flip can't reintroduce the stale-literal drift.
+    expect(alertTitleSection).toMatch(/session\.provider\s*&&\s*session\.provider\s*!==\s*DEFAULT_PROVIDER/);
   });
 
   it('feeds the computed providerLabel into the Alert.alert title argument', () => {

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -16,6 +16,7 @@ import type { SessionInfo, SessionHealth } from '../store/connection';
 // #5759 — shared with the dashboard so the "live permission prompt" rule can't
 // drift between clients (it operates on the shared ChatMessage).
 import { countLivePermissionPrompts } from '@chroxy/store-core';
+import { DEFAULT_PROVIDER } from '@chroxy/protocol';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 import { getProviderInfo } from '../constants/providers';
@@ -87,12 +88,13 @@ function SessionPill({ session, isActive, health, notificationCount, pendingShel
   const showPendingShells = !isCrashed && !showBusy && !showPendingPermission && pendingShellCount > 0;
   const hasIndicators = isCrashed || showPendingPermission || showBusy || hasNotification || showPendingShells;
   // Mobile parity with dashboard SessionBar chips (#3940): surface the
-  // provider's short label as a small badge on the pill so claude-tui,
-  // codex, gemini, docker-cli, etc. are distinguishable at-a-glance
-  // without long-pressing. Same gate as the long-press alert title from
-  // #3937 — skip the claude-sdk default and any session with no provider.
+  // provider's short label as a small badge on the pill so codex, gemini,
+  // claude-sdk, docker-cli, etc. are distinguishable at-a-glance without
+  // long-pressing. Same gate as the long-press alert title from #3937 —
+  // skip the current default provider (#5823) and any session with no
+  // provider.
   const providerInfo =
-    session.provider && session.provider !== 'claude-sdk'
+    session.provider && session.provider !== DEFAULT_PROVIDER
       ? getProviderInfo(session.provider)
       : null;
   return (
@@ -234,10 +236,10 @@ export function SessionPicker({ onCreatePress }: SessionPickerProps) {
     }
 
     // Suffix the alert title with the provider's short label for any
-    // non-default provider (default is claude-sdk). Pre-#3937 this only
-    // covered claude-cli; now it covers claude-tui, codex, gemini, and
-    // any future provider getProviderInfo knows about.
-    const providerLabel = session.provider && session.provider !== 'claude-sdk'
+    // non-default provider (the default is DEFAULT_PROVIDER, #5823).
+    // Pre-#3937 this only covered claude-cli; now it covers every
+    // non-default provider getProviderInfo knows about.
+    const providerLabel = session.provider && session.provider !== DEFAULT_PROVIDER
       ? ` (${getProviderInfo(session.provider).short})`
       : '';
     Alert.alert(

--- a/packages/dashboard/src/components/ProviderPicker.test.tsx
+++ b/packages/dashboard/src/components/ProviderPicker.test.tsx
@@ -57,8 +57,14 @@ describe('Provider picker in session creation (#1366)', () => {
     expect(connectionSrc).toMatch(/create_session[\s\S]*?provider/)
   })
 
-  test('default provider is claude-sdk', () => {
-    expect(modalSrc).toMatch(/claude-sdk/)
+  test('modal sources its default provider from the store, not a hardcoded id (#5823)', () => {
+    // The default lives in the shared @chroxy/protocol DEFAULT_PROVIDER and
+    // flows through the store's defaultProvider; the modal must read it from
+    // there so a default flip never needs a modal edit.
+    expect(modalSrc).toMatch(/useConnectionStore\(\s*s\s*=>\s*s\.defaultProvider\s*\)/)
+    expect(modalSrc).toMatch(/useState\(\s*defaultProvider\s*\)/)
+    // And the store seeds defaultProvider from the protocol constant.
+    expect(connectionSrc).toMatch(/loadPersistedSetting\(\s*'chroxy_default_provider',\s*DEFAULT_PROVIDER\s*\)/)
   })
 
   // --- New tests for dynamic provider list ---

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@
 import { useState, useCallback, useRef, useMemo } from 'react'
 import type { CumulativeUsage, SessionInfo, SessionVisualStatus, SessionRole } from '@chroxy/store-core'
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
+import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
 import { ViewersIndicator } from './ViewersIndicator'
@@ -866,7 +867,7 @@ export function Sidebar({
                                 W
                               </span>
                             )}
-                            {session.provider && session.provider !== 'claude-sdk' && (
+                            {session.provider && session.provider !== DEFAULT_PROVIDER && (
                               <span className="sidebar-provider-badge" title={session.provider}>
                                 {session.provider.replace(/^claude-/, '').toUpperCase()}
                               </span>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -123,7 +123,7 @@ import {
   clearPendingPermissionModeReverts,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
-import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
+import { CLIENT_CAPABILITIES, DEFAULT_PROVIDER } from '@chroxy/protocol';
 import {
   getWsCloseMessage,
   getHealthCheckErrorMessage,
@@ -508,12 +508,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   primaryClientId: null,
   followMode: false,
   activeTheme: loadPersistedSetting('chroxy_persist_theme', 'default'),
-  // #5819: default to claude-tui ahead of the 2026-06-15 programmatic-credit
-  // cutover so the dashboard's new-session picker doesn't pre-select a provider
-  // that silently draws metered credits. Mirrors the server's DEFAULT_PROVIDER
-  // (packages/server/src/providers.js). Users who explicitly chose a provider
-  // keep their persisted value.
-  defaultProvider: loadPersistedSetting('chroxy_default_provider', 'claude-tui'),
+  // #5819 / #5823: pre-select the shared DEFAULT_PROVIDER (claude-tui) so the
+  // new-session picker doesn't default to a provider that silently draws
+  // metered programmatic credits at the 2026-06-15 cutover. Sourced from
+  // @chroxy/protocol so server + clients agree. Users who explicitly chose a
+  // provider keep their persisted value.
+  defaultProvider: loadPersistedSetting('chroxy_default_provider', DEFAULT_PROVIDER),
   defaultModel: loadPersistedSetting('chroxy_default_model', ''),
   // #5184: header cost-badge display mode. Validated through the badge's
   // own `isCostBadgeMode` guard so a stale / corrupt localStorage value

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -29,6 +29,23 @@ export declare const CLIENT_CAPABILITIES: {
  * Clients below this version are rejected during auth.
  */
 export declare const MIN_PROTOCOL_VERSION = 1;
+/**
+ * The session provider used when neither `--provider` nor `config.provider`
+ * is set. Single source of truth shared by the server (`providers.js`
+ * re-exports this), the dashboard, and the mobile app, so the "which provider
+ * is the default?" decision lives in exactly one place.
+ *
+ * Flipped from `claude-sdk` to `claude-tui` ahead of the 2026-06-15
+ * programmatic-credit cutover (#5819): on/after that boundary the host
+ * claude-sdk / claude-cli providers draw from Anthropic's metered
+ * programmatic-credit pool, so a zero-config session would silently spend
+ * metered credits. `claude-tui` bills against the flat Claude subscription
+ * allowance today (a best-effort bet, not a sanctioned path — see the
+ * provider docs). Clients suppress the per-session provider badge for this
+ * value, so keeping it here means the next default flip doesn't reintroduce
+ * the drift fixed in #5823.
+ */
+export declare const DEFAULT_PROVIDER = "claude-tui";
 export * from './schemas/index.ts';
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
 export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, ServerCancelActivityAckMessage, ServerBudgetResumeAckMessage, } from './schemas/server.ts';

--- a/packages/protocol/dist/index.js
+++ b/packages/protocol/dist/index.js
@@ -29,6 +29,23 @@ export const CLIENT_CAPABILITIES = {
  * Clients below this version are rejected during auth.
  */
 export const MIN_PROTOCOL_VERSION = 1;
+/**
+ * The session provider used when neither `--provider` nor `config.provider`
+ * is set. Single source of truth shared by the server (`providers.js`
+ * re-exports this), the dashboard, and the mobile app, so the "which provider
+ * is the default?" decision lives in exactly one place.
+ *
+ * Flipped from `claude-sdk` to `claude-tui` ahead of the 2026-06-15
+ * programmatic-credit cutover (#5819): on/after that boundary the host
+ * claude-sdk / claude-cli providers draw from Anthropic's metered
+ * programmatic-credit pool, so a zero-config session would silently spend
+ * metered credits. `claude-tui` bills against the flat Claude subscription
+ * allowance today (a best-effort bet, not a sanctioned path — see the
+ * provider docs). Clients suppress the per-session provider badge for this
+ * value, so keeping it here means the next default flip doesn't reintroduce
+ * the drift fixed in #5823.
+ */
+export const DEFAULT_PROVIDER = 'claude-tui';
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from "./schemas/index.js";
 // Re-export client-side error-category detection (#3151)

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -33,6 +33,24 @@ export const CLIENT_CAPABILITIES = {
  */
 export const MIN_PROTOCOL_VERSION = 1
 
+/**
+ * The session provider used when neither `--provider` nor `config.provider`
+ * is set. Single source of truth shared by the server (`providers.js`
+ * re-exports this), the dashboard, and the mobile app, so the "which provider
+ * is the default?" decision lives in exactly one place.
+ *
+ * Flipped from `claude-sdk` to `claude-tui` ahead of the 2026-06-15
+ * programmatic-credit cutover (#5819): on/after that boundary the host
+ * claude-sdk / claude-cli providers draw from Anthropic's metered
+ * programmatic-credit pool, so a zero-config session would silently spend
+ * metered credits. `claude-tui` bills against the flat Claude subscription
+ * allowance today (a best-effort bet, not a sanctioned path — see the
+ * provider docs). Clients suppress the per-session provider badge for this
+ * value, so keeping it here means the next default flip doesn't reintroduce
+ * the drift fixed in #5823.
+ */
+export const DEFAULT_PROVIDER = 'claude-tui'
+
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from './schemas/index.ts'
 

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -24,6 +24,7 @@ import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
 import { registerProviderRegistry } from './models.js'
 import { BILLING_CLASSES } from './billing-class.js'
+import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 import {
   hasClaudeOAuthCreds,
   hasCodexOAuthCreds,
@@ -52,25 +53,13 @@ const PROVIDERS = {
   'codex': CodexSession,
 }
 
-/**
- * The provider used when neither `--provider` nor `config.provider` is set.
- *
- * Flipped from `claude-sdk` to `claude-tui` ahead of the 2026-06-15
- * programmatic-credit cutover (#5819). On/after that boundary the host
- * claude-sdk / claude-cli providers draw from Anthropic's monthly metered
- * programmatic-credit pool (see billing-class.js `PROGRAMMATIC_CREDIT_ERA_START`),
- * so a zero-config session would silently start spending metered credits.
- * `claude-tui` drives the interactive CLI, which bills against the flat Claude
- * subscription allowance today — keeping the out-of-the-box default off the
- * metered pool. This is a best-effort bet, not a sanctioned path (the
- * subscription-billing of a daemon-driven TUI is ToS-adverse and may be
- * reclassified/enforced against) — operators who want a guaranteed billing
- * model should set `--provider claude-byok` with their own ANTHROPIC_API_KEY.
- *
- * The single source of truth for the default — server-cli.js (runtime +
- * banner) and doctor.js import this rather than re-hardcoding the literal.
- */
-export const DEFAULT_PROVIDER = 'claude-tui'
+// The default provider lives in @chroxy/protocol so the server, dashboard,
+// and mobile app all agree on "which provider is the default?" from one
+// source (#5823). Re-exported here so existing server call sites
+// (server-cli.js, doctor.js, session-manager.js) keep importing it from the
+// provider registry. Flipped to claude-tui ahead of the 2026-06-15 cutover
+// (#5819) — see the protocol constant's doc for the billing rationale.
+export { DEFAULT_PROVIDER }
 
 // Names hidden from listProviders() (backward-compat aliases, etc.)
 const HIDDEN = new Set()


### PR DESCRIPTION
## Summary

Follow-up to PR #5822 (default flip `claude-sdk` → `claude-tui`). That flip inverted the provider-badge / label **suppression** semantics in the UIs, which still keyed on a hardcoded `'claude-sdk'`:
- New **default** `claude-tui` sessions rendered a provider badge (no longer the suppressed case).
- `claude-sdk` sessions — now an explicit non-default opt-in — rendered **no** badge.

This fixes it at the root by giving the default a single source of truth.

## Changes

- **`@chroxy/protocol`** gains `export const DEFAULT_PROVIDER = 'claude-tui'` — the one place server, dashboard, and app agree on the default. (dist rebuilt.)
- **Server** `providers.js` now imports + re-exports it; every server call site (`server-cli.js`, `doctor.js`, `session-manager.js`) is unchanged because they import from the registry.
- **Dashboard** `Sidebar.tsx` badge and **app** `SessionPicker.tsx` (pill chip + long-press alert) suppress for `DEFAULT_PROVIDER` instead of the literal.
- **Dashboard store** seeds `defaultProvider` from the constant.
- **Tests** — the source-text-pinning tests (app `SessionPickerProviderBadge`/`Label`, dashboard `ProviderPicker`) now assert the constant-based gate, so the next default flip can't reintroduce the drift. The misnamed dashboard "default provider is claude-sdk" test now asserts the modal sources its default from the store.

## Net effect

Badge now marks **non-default** provider sessions (codex, gemini, claude-sdk, docker-*, …) and stays clean for the current default — and the next default change is a one-line edit in `@chroxy/protocol`.

## Testing

- protocol: 289 pass · store-core: 1571 pass
- dashboard: typecheck clean, 961 pass (Sidebar + ProviderPicker + store)
- app: `tsc --noEmit` clean, SessionPicker provider tests 10 pass
- server: providers/banner/doctor/init/session-manager 356 pass; opt-forwarding + state-file-path lints clean

Closes #5823
