### PR TITLE
test(server): pin the programmatic-credit era boundary instant (#5825)

### DIFF
--- a/packages/server/tests/billing-class.test.js
+++ b/packages/server/tests/billing-class.test.js
@@ -31,6 +31,14 @@ describe('isProgrammaticCreditEra(now)', () => {
   it('is true one second after the boundary', () => {
     assert.equal(isProgrammaticCreditEra(ONE_SEC_AFTER), true)
   })
+  // #5825 — pin the inclusivity to the exact millisecond tick, not just a
+  // whole second clear of the boundary. This is what makes a future `>=` → `>`
+  // off-by-one (or a date drift) fail CI: at START the era is on; at START-1ms
+  // it is not.
+  it('is true AT the constant instant and false exactly one ms before it', () => {
+    assert.equal(isProgrammaticCreditEra(PROGRAMMATIC_CREDIT_ERA_START), true)
+    assert.equal(isProgrammaticCreditEra(PROGRAMMATIC_CREDIT_ERA_START - 1), false)
+  })
 })
 
 describe('billingClassForProvider — era-independent classes', () => {
@@ -66,6 +74,11 @@ describe('billingClassForProvider — era-gated programmatic providers', () => {
     })
     it(`${p} is programmatic-credit AFTER the boundary`, () => {
       assert.equal(billingClassForProvider(p, ONE_SEC_AFTER), BILLING_CLASSES.PROGRAMMATIC_CREDIT)
+    })
+    // #5825 — millisecond-precision flip at the exact constant.
+    it(`${p} flips exactly at the constant instant (START vs START-1ms)`, () => {
+      assert.equal(billingClassForProvider(p, PROGRAMMATIC_CREDIT_ERA_START), BILLING_CLASSES.PROGRAMMATIC_CREDIT)
+      assert.equal(billingClassForProvider(p, PROGRAMMATIC_CREDIT_ERA_START - 1), BILLING_CLASSES.SUBSCRIPTION)
     })
   }
 })


### PR DESCRIPTION
## Summary

Closes #5825 (filed during #5821 review). Adds millisecond-precision boundary assertions to `billing-class.test.js`.

Existing coverage already exercised the flip a whole *second* clear of the boundary (`23:59:59Z` / `+1s`) and asserts `isProgrammaticCreditEra(AT_BOUNDARY) === true`. This pins the exact tick the issue asked for:

- `isProgrammaticCreditEra(PROGRAMMATIC_CREDIT_ERA_START)` === `true`, and `… - 1` (ms) === `false`.
- `billingClassForProvider('claude-cli'|'claude-sdk', START)` === `programmatic-credit`, and `… - 1` === `subscription`.

This is what makes a future `>=` → `>` off-by-one (or a constant drift) fail CI. Test-only; no production change.

## Testing
`billing-class.test.js`: 27 pass.
