### PR TITLE
feat: wire the billing canary into the daemon and dashboard (#5821)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -40,6 +40,7 @@ import { SessionNotFoundChip } from './components/SessionNotFoundChip'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
 import { ExposureWarningBanner } from './components/ExposureWarningBanner'
+import { BillingWarningBanner } from './components/BillingWarningBanner'
 import { ConnectionAnnouncer } from './components/ConnectionAnnouncer'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
@@ -168,6 +169,10 @@ export function App() {
   const serverExposure = useConnectionStore(s => s.serverExposure)
   const exposureBannerDismissed = useConnectionStore(s => s.exposureBannerDismissed)
   const dismissExposureBanner = useConnectionStore(s => s.dismissExposureBanner)
+  // #5821: billing-canary banner state.
+  const billingCanary = useConnectionStore(s => s.billingCanary)
+  const billingBannerDismissed = useConnectionStore(s => s.billingBannerDismissed)
+  const dismissBillingBanner = useConnectionStore(s => s.dismissBillingBanner)
   const serverStartupLogs = useConnectionStore(s => s.serverStartupLogs)
   const connectionRetryCount = useConnectionStore(s => s.connectionRetryCount)
   // #5556 — restart-countdown parity with mobile: feed the ETA/anchor/reason
@@ -1724,6 +1729,16 @@ export function App() {
           lanBind={serverExposure.lanBind}
           quickTunnel={serverExposure.quickTunnel}
           onDismiss={dismissExposureBanner}
+        />
+      )}
+
+      {/* #5821 — billing-canary warnings (silent metered default; claude-tui
+          reclassification tripwire) during the 2026-06-15 credit window. */}
+      {billingCanary && billingCanary.warnings.length > 0 && (
+        <BillingWarningBanner
+          warnings={billingCanary.warnings}
+          dismissed={billingBannerDismissed}
+          onDismiss={dismissBillingBanner}
         />
       )}
 

--- a/packages/dashboard/src/components/BillingWarningBanner.test.tsx
+++ b/packages/dashboard/src/components/BillingWarningBanner.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * BillingWarningBanner tests (#5821, live billing-canary wiring)
+ *
+ * The banner renders the daemon's billing-canary warnings (silent metered
+ * default; the dormant claude-tui reclassification tripwire) and is dismissible
+ * via the parent's onDismiss handler (which sets the store's
+ * `billingBannerDismissed` flag).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { BillingWarningBanner, type BillingWarning } from './BillingWarningBanner'
+
+afterEach(cleanup)
+
+const metered: BillingWarning = {
+  code: 'SILENT_METERED_DEFAULT',
+  message: "The default provider 'claude-sdk' bills against the metered programmatic-credit pool.",
+  provider: 'claude-sdk',
+}
+const reclass: BillingWarning = {
+  code: 'TUI_REPORTED_PROGRAMMATIC_COST',
+  message: 'claude-tui session s1 reported $0.5000 of programmatic cost.',
+  sessionId: 's1',
+  costUsd: 0.5,
+}
+
+describe('BillingWarningBanner', () => {
+  it('renders nothing when there are no warnings', () => {
+    render(<BillingWarningBanner warnings={[]} dismissed={false} onDismiss={vi.fn()} />)
+    expect(screen.queryByTestId('billing-warning-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when dismissed (even with warnings)', () => {
+    render(<BillingWarningBanner warnings={[metered]} dismissed onDismiss={vi.fn()} />)
+    expect(screen.queryByTestId('billing-warning-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders the silent-metered warning message', () => {
+    render(<BillingWarningBanner warnings={[metered]} dismissed={false} onDismiss={vi.fn()} />)
+    expect(screen.getByTestId('billing-warning-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('billing-warning-message').textContent).toMatch(/metered programmatic-credit pool/i)
+  })
+
+  it('concatenates multiple warning messages', () => {
+    render(<BillingWarningBanner warnings={[metered, reclass]} dismissed={false} onDismiss={vi.fn()} />)
+    const message = screen.getByTestId('billing-warning-message')
+    expect(message.textContent).toMatch(/metered programmatic-credit pool/i)
+    expect(message.textContent).toMatch(/reported \$0\.5000 of programmatic cost/i)
+  })
+
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(<BillingWarningBanner warnings={[metered]} dismissed={false} onDismiss={onDismiss} />)
+    fireEvent.click(screen.getByTestId('billing-dismiss-button'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses role="status" + aria-live="polite" (informative, not interruptive)', () => {
+    render(<BillingWarningBanner warnings={[metered]} dismissed={false} onDismiss={vi.fn()} />)
+    const banner = screen.getByTestId('billing-warning-banner')
+    expect(banner).toHaveAttribute('role', 'status')
+    expect(banner).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/packages/dashboard/src/components/BillingWarningBanner.tsx
+++ b/packages/dashboard/src/components/BillingWarningBanner.tsx
@@ -1,0 +1,62 @@
+/**
+ * BillingWarningBanner (#5821, live billing-canary wiring) — dismissible banner
+ * shown when the daemon's billing canary reports one or more warnings during the
+ * 2026-06-15 programmatic-credit window. Driven by the `billingCanary` snapshot
+ * the store seeds from `auth_ok` and updates from `billing_canary` broadcasts.
+ *
+ * Warnings surfaced:
+ * - SILENT_METERED_DEFAULT: the configured default provider draws the metered
+ *   programmatic-credit pool (e.g. a `claude-sdk` default without an API key) —
+ *   the live signal.
+ * - TUI_REPORTED_PROGRAMMATIC_COST: a `claude-tui` session reported programmatic
+ *   cost (a dormant tripwire — claude-tui normally bills as subscription).
+ *
+ * Empty warnings (or a dismissed banner) render nothing. Dismissal is
+ * per-connection; a later broadcast with a CHANGED warning set re-surfaces it
+ * (handled in the store).
+ */
+
+export interface BillingWarning {
+  code: string
+  message: string
+  provider?: string
+  sessionId?: string
+  costUsd?: number
+}
+
+export interface BillingWarningBannerProps {
+  warnings: BillingWarning[]
+  dismissed: boolean
+  onDismiss: () => void
+}
+
+export function BillingWarningBanner({ warnings, dismissed, onDismiss }: BillingWarningBannerProps) {
+  if (dismissed || !warnings || warnings.length === 0) return null
+
+  return (
+    // role="status" + aria-live="polite" per the dashboard convention
+    // (see ExposureWarningBanner / StdinDisabledBanner): a billing warning is
+    // informative, not an emergency interruption.
+    <div
+      className="exposure-warning-banner"
+      data-testid="billing-warning-banner"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="exposure-warning-icon" aria-hidden="true">
+        $
+      </span>
+      <span className="exposure-warning-message" data-testid="billing-warning-message">
+        {warnings.map((w) => w.message).join(' ')}
+      </span>
+      <button
+        className="btn-retry"
+        data-testid="billing-dismiss-button"
+        onClick={onDismiss}
+        type="button"
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -567,6 +567,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #5356: exposure snapshot from auth_ok + banner dismissal flag.
   serverExposure: null,
   exposureBannerDismissed: false,
+  // #5821: billing-canary snapshot from auth_ok / billing_canary + dismissal.
+  billingCanary: null,
+  billingBannerDismissed: false,
   shutdownReason: null,
   restartEtaMs: null,
   restartingSince: null,
@@ -1882,6 +1885,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // different server can't show a stale banner.
       serverExposure: null,
       exposureBannerDismissed: false,
+      // #5821: clear billing canary on disconnect so a reconnect against a
+      // different server can't show a stale billing banner.
+      billingCanary: null,
+      billingBannerDismissed: false,
       shutdownReason: null,
       restartEtaMs: null,
       restartingSince: null,
@@ -3177,6 +3184,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #5356: dismiss the exposure warning banner for this connection.
   dismissExposureBanner: () => {
     set({ exposureBannerDismissed: true });
+  },
+
+  // #5821: dismiss the billing warning banner for this connection. A later
+  // billing_canary broadcast with a CHANGED warning set re-surfaces it.
+  dismissBillingBanner: () => {
+    set({ billingBannerDismissed: true });
   },
 
   addInfoNotification: (message: string) => {

--- a/packages/dashboard/src/store/dispatch-billing-canary.test.ts
+++ b/packages/dashboard/src/store/dispatch-billing-canary.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Dispatch test for the `billing_canary` handler (#5821).
+ *
+ * Locks the store-update behavior: a billing_canary broadcast stores the
+ * snapshot, and the per-connection banner dismissal resets ONLY when the
+ * warning set changes — so an unchanged re-broadcast can't un-dismiss a banner
+ * the user already dismissed, but a new/cleared warning re-surfaces it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  setConnectionContext,
+  stopHeartbeat,
+} from './message-handler'
+import type { ConnectionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (
+      s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>),
+    ) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  const serverErrors: unknown[] = []
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    messages: [],
+    terminalBuffer: '',
+    terminalRawBuffer: '',
+    customAgents: [],
+    slashCommands: [],
+    connectedClients: [],
+    serverErrors,
+    addServerError: (e: unknown) => { serverErrors.push(e) },
+    appendTerminalData: () => undefined,
+    serverProtocolVersion: null,
+    billingCanary: null,
+    billingBannerDismissed: false,
+  } as unknown as Partial<ConnectionState>
+}
+
+const meteredMsg = {
+  type: 'billing_canary',
+  eraStarted: true,
+  defaultProvider: 'claude-sdk',
+  defaultBillingClass: 'programmatic-credit',
+  warnings: [{ code: 'SILENT_METERED_DEFAULT', message: 'metered', provider: 'claude-sdk' }],
+}
+
+describe('dashboard message-handler — billing_canary (#5821)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+    setConnectionContext(ctx() as any)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    setConnectionContext(null)
+  })
+
+  it('stores the snapshot from a billing_canary broadcast', () => {
+    handleMessage(meteredMsg, ctx() as any)
+    const bc = store.getState().billingCanary!
+    expect(bc.defaultProvider).toBe('claude-sdk')
+    expect(bc.warnings).toHaveLength(1)
+    expect(bc.warnings[0]!.code).toBe('SILENT_METERED_DEFAULT')
+  })
+
+  it('drops a malformed payload (safeParse) without crashing', () => {
+    handleMessage({ type: 'billing_canary', warnings: 'nope' }, ctx() as any)
+    expect(store.getState().billingCanary).toBeNull()
+  })
+
+  it('does NOT un-dismiss the banner on an unchanged re-broadcast', () => {
+    handleMessage(meteredMsg, ctx() as any)
+    store.setState({ billingBannerDismissed: true }) // user dismisses
+    handleMessage(meteredMsg, ctx() as any) // identical warning set
+    expect(store.getState().billingBannerDismissed).toBe(true)
+  })
+
+  it('re-surfaces the banner when the warning set changes', () => {
+    handleMessage(meteredMsg, ctx() as any)
+    store.setState({ billingBannerDismissed: true })
+    handleMessage(
+      { ...meteredMsg, warnings: [{ code: 'TUI_REPORTED_PROGRAMMATIC_COST', message: 'cost', sessionId: 's1', costUsd: 1 }] },
+      ctx() as any,
+    )
+    expect(store.getState().billingBannerDismissed).toBe(false)
+  })
+
+  it('clears warnings (all-clear broadcast) and re-surfaces (set changed)', () => {
+    handleMessage(meteredMsg, ctx() as any)
+    store.setState({ billingBannerDismissed: true })
+    handleMessage({ ...meteredMsg, warnings: [] }, ctx() as any)
+    expect(store.getState().billingCanary!.warnings).toHaveLength(0)
+    expect(store.getState().billingBannerDismissed).toBe(false)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -145,7 +145,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2633,11 +2633,29 @@ function handleSummarizeSessionResult(msg: Record<string, unknown>): void {
 }
 
 /**
+ * #5821 — `billing_canary` broadcast. Validated via the shared schema (drop on
+ * mismatch). Stores the snapshot; resets the per-connection dismissal ONLY when
+ * the warning set changed (a new/cleared warning re-surfaces the banner) so an
+ * unchanged re-broadcast doesn't un-dismiss what the user already dismissed.
+ */
+function handleBillingCanary(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerBillingCanarySchema.safeParse(msg);
+  if (!parsed.success) return;
+  const { eraStarted, defaultProvider, defaultBillingClass, warnings } = parsed.data;
+  const snapshot = { eraStarted, defaultProvider, defaultBillingClass, warnings };
+  const prev = get().billingCanary;
+  const sig = (s: typeof snapshot | null) => (s ? s.warnings.map((w) => w.code).sort().join('|') : '');
+  const changed = sig(prev) !== sig(snapshot);
+  set(changed ? { billingCanary: snapshot, billingBannerDismissed: false } : { billingCanary: snapshot });
+}
+
+/**
  * Map of message type → handler function for the simplest, most self-contained
  * cases. handleMessage() dispatches to this map first; unmatched types fall
  * through to the legacy switch statement below.
  */
 const HANDLERS: Record<string, Handler> = {
+  billing_canary: handleBillingCanary,
   pong: handlePong,
   raw: handleRaw,
   raw_background: handleRawBackground,
@@ -2822,6 +2840,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           ? { lanBind: rawExposure.lanBind === true, quickTunnel: rawExposure.quickTunnel === true }
           : null;
 
+      // #5821: billing-canary snapshot seed from auth_ok. Validated via the
+      // shared schema so a malformed/absent field → null (no banner). Live
+      // changes arrive via the `billing_canary` broadcast handled below.
+      const rawBillingCanary = (msg as { billingCanary?: unknown }).billingCanary;
+      const billingCanarySeed = rawBillingCanary
+        ? (BillingCanarySnapshotSchema.safeParse(rawBillingCanary).success
+            ? BillingCanarySnapshotSchema.parse(rawBillingCanary)
+            : null)
+        : null;
+
       // On reconnect, preserve messages and terminal buffer
       const connectedState = {
         connectionPhase: 'connected' as const,
@@ -2848,6 +2876,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         serverPhase: null,
         tunnelProgress: null,
         serverExposure,
+        billingCanary: billingCanarySeed,
         shutdownReason: null,
         restartEtaMs: null,
         restartingSince: null,
@@ -2862,6 +2891,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // #5356: a fresh (non-reconnect) connection re-surfaces the
           // exposure banner; silent reconnects keep the user's dismissal.
           exposureBannerDismissed: false,
+          // #5821: same for the billing banner — fresh connect re-surfaces it.
+          billingBannerDismissed: false,
           messages: [],
           terminalBuffer: '',
           terminalRawBuffer: '',

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2644,7 +2644,18 @@ function handleBillingCanary(msg: Record<string, unknown>, get: MsgGet, set: Msg
   const { eraStarted, defaultProvider, defaultBillingClass, warnings } = parsed.data;
   const snapshot = { eraStarted, defaultProvider, defaultBillingClass, warnings };
   const prev = get().billingCanary;
-  const sig = (s: typeof snapshot | null) => (s ? s.warnings.map((w) => w.code).sort().join('|') : '');
+  // Signature over the FULL warning content (not just `code`): a reclassification
+  // trip can emit multiple warnings sharing TUI_REPORTED_PROGRAMMATIC_COST but
+  // differing in session/cost, and a code-only signature would mask that change
+  // and leave a dismissed banner stale (#5829 / review). Serialize each warning's
+  // identifying fields, order-independent.
+  const sig = (s: typeof snapshot | null) =>
+    s
+      ? s.warnings
+          .map((w) => `${w.code} ${w.sessionId ?? ''} ${w.costUsd ?? ''} ${w.message}`)
+          .sort()
+          .join('')
+      : '';
   const changed = sig(prev) !== sig(snapshot);
   set(changed ? { billingCanary: snapshot, billingBannerDismissed: false } : { billingCanary: snapshot });
 }

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -862,6 +862,21 @@ export interface ConnectionState {
   exposureBannerDismissed: boolean;
   dismissExposureBanner: () => void;
 
+  // #5821: current billing-canary snapshot — seeded from auth_ok and updated by
+  // `billing_canary` broadcasts. null = server didn't report (older server).
+  // `warnings` empty = all clear (no banner). See the BillingWarningBanner.
+  billingCanary: {
+    eraStarted: boolean;
+    defaultProvider: string;
+    defaultBillingClass: string;
+    warnings: Array<{ code: string; message: string; provider?: string; sessionId?: string; costUsd?: number }>;
+  } | null;
+  // #5821: user dismissed the billing banner. Reset when the warning set
+  // changes (a NEW warning re-surfaces it) and on a fresh connect; preserved
+  // across silent reconnects and unchanged re-broadcasts.
+  billingBannerDismissed: boolean;
+  dismissBillingBanner: () => void;
+
   // Shutdown state (reason + ETA for restarting banner countdown)
   shutdownReason: 'restart' | 'shutdown' | 'crash' | null;
   restartEtaMs: number | null;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -29,6 +29,25 @@ import { z } from 'zod';
  * the sanity ceiling.
  */
 export declare const MAX_SANE_DURATION_MS: number;
+export declare const BillingCanaryWarningSchema: z.ZodObject<{
+    code: z.ZodString;
+    message: z.ZodString;
+    provider: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+    costUsd: z.ZodOptional<z.ZodNumber>;
+}, z.core.$strip>;
+export declare const BillingCanarySnapshotSchema: z.ZodObject<{
+    eraStarted: z.ZodBoolean;
+    defaultProvider: z.ZodString;
+    defaultBillingClass: z.ZodString;
+    warnings: z.ZodArray<z.ZodObject<{
+        code: z.ZodString;
+        message: z.ZodString;
+        provider: z.ZodOptional<z.ZodString>;
+        sessionId: z.ZodOptional<z.ZodString>;
+        costUsd: z.ZodOptional<z.ZodNumber>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
 export declare const ServerAuthOkSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_ok">;
     clientId: z.ZodString;
@@ -63,6 +82,18 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
         lanBind: z.ZodBoolean;
         bindHost: z.ZodNullable<z.ZodString>;
         quickTunnel: z.ZodBoolean;
+    }, z.core.$strip>>;
+    billingCanary: z.ZodOptional<z.ZodObject<{
+        eraStarted: z.ZodBoolean;
+        defaultProvider: z.ZodString;
+        defaultBillingClass: z.ZodString;
+        warnings: z.ZodArray<z.ZodObject<{
+            code: z.ZodString;
+            message: z.ZodString;
+            provider: z.ZodOptional<z.ZodString>;
+            sessionId: z.ZodOptional<z.ZodString>;
+            costUsd: z.ZodOptional<z.ZodNumber>;
+        }, z.core.$strip>>;
     }, z.core.$strip>>;
     serverPublicKey: z.ZodOptional<z.ZodString>;
     serverKeySig: z.ZodOptional<z.ZodString>;
@@ -2138,6 +2169,19 @@ export declare const ServerBudgetExceededSchema: z.ZodObject<{
     percent: z.ZodNumber;
     message: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerBillingCanarySchema: z.ZodObject<{
+    eraStarted: z.ZodBoolean;
+    defaultProvider: z.ZodString;
+    defaultBillingClass: z.ZodString;
+    warnings: z.ZodArray<z.ZodObject<{
+        code: z.ZodString;
+        message: z.ZodString;
+        provider: z.ZodOptional<z.ZodString>;
+        sessionId: z.ZodOptional<z.ZodString>;
+        costUsd: z.ZodOptional<z.ZodNumber>;
+    }, z.core.$strip>>;
+    type: z.ZodLiteral<"billing_canary">;
+}, z.core.$strip>;
 export declare const ServerBudgetResumeAckSchema: z.ZodObject<{
     type: z.ZodLiteral<"budget_resume_ack">;
     sessionId: z.ZodOptional<z.ZodString>;
@@ -2294,6 +2338,9 @@ export declare const ServerEvaluatorClarifySchema: z.ZodObject<{
     evaluatorIterationId: z.ZodString;
     evaluatorIteration: z.ZodNumber;
 }, z.core.$strip>;
+export type BillingCanaryWarning = z.infer<typeof BillingCanaryWarningSchema>;
+export type BillingCanarySnapshot = z.infer<typeof BillingCanarySnapshotSchema>;
+export type ServerBillingCanaryMessage = z.infer<typeof ServerBillingCanarySchema>;
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>;
 export type ServerPairRequestPendingMessage = z.infer<typeof ServerPairRequestPendingSchema>;
 export type ServerPairPendingMessage = z.infer<typeof ServerPairPendingSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -35,6 +35,26 @@ const ClientInfoSchema = z.object({
     deviceType: z.enum(['phone', 'tablet', 'desktop', 'unknown']),
     platform: z.string(),
 });
+// Billing canary (#5821 live wiring). A single billing early-warning entry —
+// `code` discriminates the kind (SILENT_METERED_DEFAULT, TUI_REPORTED_PROGRAMMATIC_COST,
+// DATACENTER_EGRESS); `message` is the human-facing copy. `provider` / `sessionId`
+// / `costUsd` are present only for the warnings that carry them. Defined ahead of
+// ServerAuthOkSchema so the snapshot can seed `auth_ok` for late-joining clients.
+export const BillingCanaryWarningSchema = z.object({
+    code: z.string(),
+    message: z.string(),
+    provider: z.string().optional(),
+    sessionId: z.string().optional(),
+    costUsd: z.number().finite().optional(),
+});
+// The canary's current state (no `type` — embedded in auth_ok as a seed and
+// extended into the billing_canary broadcast below). `warnings` empty = all clear.
+export const BillingCanarySnapshotSchema = z.object({
+    eraStarted: z.boolean(),
+    defaultProvider: z.string(),
+    defaultBillingClass: z.string(),
+    warnings: z.array(BillingCanaryWarningSchema),
+});
 export const ServerAuthOkSchema = z.object({
     type: z.literal('auth_ok'),
     clientId: z.string(),
@@ -105,6 +125,11 @@ export const ServerAuthOkSchema = z.object({
         bindHost: z.string().nullable(),
         quickTunnel: z.boolean(),
     }).optional(),
+    // #5821 (live wiring) — current billing-canary snapshot, seeded into auth_ok
+    // so a freshly-connected client renders the billing banner immediately rather
+    // than waiting for the next broadcast. Optional: older servers omit it; live
+    // changes still arrive via the `billing_canary` broadcast.
+    billingCanary: BillingCanarySnapshotSchema.optional(),
     // #5555 (eager key exchange) — the server's ephemeral X25519 public key,
     // present ONLY when the client supplied a valid `eagerPublicKey` + `eagerSalt`
     // in its `auth` message AND encryption is required. When present, the client
@@ -2129,6 +2154,15 @@ export const ServerBudgetExceededSchema = z.object({
     budget: z.number(),
     percent: z.number(),
     message: z.string(),
+});
+// #5821 (live wiring) — billing-canary broadcast. Pushed when the daemon's
+// billing early-warning state changes (silent metered default; the dormant
+// claude-tui reclassification tripwire). Empty `warnings` = all clear, so the
+// client clears its banner. The same snapshot also seeds `auth_ok` for late
+// joiners. Shares BillingCanarySnapshotSchema (defined near the top) so the
+// broadcast and the seed can't drift.
+export const ServerBillingCanarySchema = BillingCanarySnapshotSchema.extend({
+    type: z.literal('billing_canary'),
 });
 // #5752: positive ack for an actioned `resume_budget` request. The substantive
 // state change (un-pausing) is still broadcast as `budget_resumed` — but ONLY

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -38,6 +38,28 @@ const ClientInfoSchema = z.object({
   platform: z.string(),
 })
 
+// Billing canary (#5821 live wiring). A single billing early-warning entry —
+// `code` discriminates the kind (SILENT_METERED_DEFAULT, TUI_REPORTED_PROGRAMMATIC_COST,
+// DATACENTER_EGRESS); `message` is the human-facing copy. `provider` / `sessionId`
+// / `costUsd` are present only for the warnings that carry them. Defined ahead of
+// ServerAuthOkSchema so the snapshot can seed `auth_ok` for late-joining clients.
+export const BillingCanaryWarningSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  provider: z.string().optional(),
+  sessionId: z.string().optional(),
+  costUsd: z.number().finite().optional(),
+})
+
+// The canary's current state (no `type` — embedded in auth_ok as a seed and
+// extended into the billing_canary broadcast below). `warnings` empty = all clear.
+export const BillingCanarySnapshotSchema = z.object({
+  eraStarted: z.boolean(),
+  defaultProvider: z.string(),
+  defaultBillingClass: z.string(),
+  warnings: z.array(BillingCanaryWarningSchema),
+})
+
 export const ServerAuthOkSchema = z.object({
   type: z.literal('auth_ok'),
   clientId: z.string(),
@@ -108,6 +130,11 @@ export const ServerAuthOkSchema = z.object({
     bindHost: z.string().nullable(),
     quickTunnel: z.boolean(),
   }).optional(),
+  // #5821 (live wiring) — current billing-canary snapshot, seeded into auth_ok
+  // so a freshly-connected client renders the billing banner immediately rather
+  // than waiting for the next broadcast. Optional: older servers omit it; live
+  // changes still arrive via the `billing_canary` broadcast.
+  billingCanary: BillingCanarySnapshotSchema.optional(),
   // #5555 (eager key exchange) — the server's ephemeral X25519 public key,
   // present ONLY when the client supplied a valid `eagerPublicKey` + `eagerSalt`
   // in its `auth` message AND encryption is required. When present, the client
@@ -2262,6 +2289,16 @@ export const ServerBudgetExceededSchema = z.object({
   message: z.string(),
 })
 
+// #5821 (live wiring) — billing-canary broadcast. Pushed when the daemon's
+// billing early-warning state changes (silent metered default; the dormant
+// claude-tui reclassification tripwire). Empty `warnings` = all clear, so the
+// client clears its banner. The same snapshot also seeds `auth_ok` for late
+// joiners. Shares BillingCanarySnapshotSchema (defined near the top) so the
+// broadcast and the seed can't drift.
+export const ServerBillingCanarySchema = BillingCanarySnapshotSchema.extend({
+  type: z.literal('billing_canary'),
+})
+
 // #5752: positive ack for an actioned `resume_budget` request. The substantive
 // state change (un-pausing) is still broadcast as `budget_resumed` — but ONLY
 // when the session was actually paused, because that message injects a "session
@@ -2480,6 +2517,9 @@ export const ServerEvaluatorClarifySchema = z.object({
 
 // -- Inferred TypeScript types --
 
+export type BillingCanaryWarning = z.infer<typeof BillingCanaryWarningSchema>
+export type BillingCanarySnapshot = z.infer<typeof BillingCanarySnapshotSchema>
+export type ServerBillingCanaryMessage = z.infer<typeof ServerBillingCanarySchema>
 export type ServerAuthOkMessage = z.infer<typeof ServerAuthOkSchema>
 export type ServerPairRequestPendingMessage = z.infer<typeof ServerPairRequestPendingSchema>
 export type ServerPairPendingMessage = z.infer<typeof ServerPairPendingSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,6 +46,7 @@ const SYNTHETIC_TYPES = new Set([
   'budget_resumed',        // budget resume ack (server-internal)
   'budget_resume_ack',     // #5752 resume_budget positive ack — emitted from input-handlers.js (not the ws-server.js broadcast surface the extractor scans), handled by the shared store-core dispatch table
   'cancel_activity_ack',   // #5277 cancel correlation ack — emitted from input-handlers.js (not the ws-server.js broadcast surface the extractor scans), handled by the dashboard
+  'billing_canary',        // #5821 live billing canary — broadcast from billing-canary-monitor.js (not the ws-server.js broadcast surface the extractor scans), handled by the dashboard; also seeded into auth_ok
   'thinking_level_changed', // thinking level change ack (server-internal)
   'permission_timeout',     // handled by both clients for the future permission timeout event (not yet in protocol; dashboard gained parity in #5454)
 ])

--- a/packages/server/src/billing-canary-monitor.js
+++ b/packages/server/src/billing-canary-monitor.js
@@ -27,7 +27,11 @@ export class BillingCanaryMonitor {
    *   (SessionManager.listSessions() shape: { sessionId, provider, cumulativeUsage:{costUsd} }).
    * @param {() => string} opts.getDefaultProvider - resolved default provider id.
    * @param {() => boolean} [opts.getApiKeyAuth] - whether the default would auth via an
-   *   explicit ANTHROPIC_API_KEY (claude-sdk BYOK) — suppresses the silent-metered warning.
+   *   explicit ANTHROPIC_API_KEY and thus bill raw API (api-key), suppressing the
+   *   silent-metered warning. NOTE: billing-class's apiKeyAuth refinement nominally
+   *   covers both claude-cli and claude-sdk, but only claude-sdk honours an env key —
+   *   claude-cli strips ANTHROPIC_API_KEY before spawn, so it still meters with a key
+   *   set. The caller (server-cli) reflects that by setting this true ONLY for claude-sdk.
    * @param {(message: object) => void} opts.broadcast - global client broadcast.
    * @param {number} [opts.intervalMs] - recompute cadence (default 10 min).
    * @param {() => number} [opts.nowFn] - injectable clock for tests.

--- a/packages/server/src/billing-canary-monitor.js
+++ b/packages/server/src/billing-canary-monitor.js
@@ -1,0 +1,119 @@
+// billing-canary-monitor.js — live wiring for the billing canary (#5821).
+//
+// Runs the pure checks in doctor-billing.js inside the running daemon and
+// broadcasts a `billing_canary` message to clients when the result changes, so
+// the dashboard can surface a banner during the 2026-06-15 programmatic-credit
+// window. The same snapshot seeds `auth_ok` (via `current()`) so a freshly
+// connected client renders the banner immediately instead of waiting for the
+// next broadcast.
+//
+// Scope: this monitor runs the two checks that need only local daemon state —
+// `detectSilentMeteredDefault` (the live signal: a programmatic config default
+// without a key) and `detectBillingReclassification` (a zero-false-positive
+// tripwire, dormant today because claude-tui reports `cost: null` so its
+// cumulative costUsd stays 0). The datacenter-egress check is intentionally
+// NOT run here: it needs an outbound IP lookup, which is deferred to an opt-in
+// follow-up rather than making every daemon phone out by default.
+import { runBillingCanary } from './doctor-billing.js'
+import { billingClassForProvider } from './billing-class.js'
+import { DEFAULT_PROVIDER } from '@chroxy/protocol'
+
+const DEFAULT_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
+
+export class BillingCanaryMonitor {
+  /**
+   * @param {object} opts
+   * @param {() => Array} opts.getSessions - returns the live session list
+   *   (SessionManager.listSessions() shape: { sessionId, provider, cumulativeUsage:{costUsd} }).
+   * @param {() => string} opts.getDefaultProvider - resolved default provider id.
+   * @param {() => boolean} [opts.getApiKeyAuth] - whether the default would auth via an
+   *   explicit ANTHROPIC_API_KEY (claude-sdk BYOK) — suppresses the silent-metered warning.
+   * @param {(message: object) => void} opts.broadcast - global client broadcast.
+   * @param {number} [opts.intervalMs] - recompute cadence (default 10 min).
+   * @param {() => number} [opts.nowFn] - injectable clock for tests.
+   * @param {{warn?: Function}} [opts.logger]
+   */
+  constructor({ getSessions, getDefaultProvider, getApiKeyAuth, broadcast, intervalMs = DEFAULT_INTERVAL_MS, nowFn = Date.now, logger } = {}) {
+    this._getSessions = getSessions || (() => [])
+    this._getDefaultProvider = getDefaultProvider || (() => DEFAULT_PROVIDER)
+    this._getApiKeyAuth = getApiKeyAuth || (() => false)
+    this._broadcast = broadcast || (() => {})
+    this._intervalMs = intervalMs
+    this._now = nowFn
+    this._log = logger
+    this._timer = null
+    this._last = null     // last computed snapshot
+    this._lastKey = null  // JSON of the last snapshot, for change detection
+  }
+
+  /**
+   * Compute the current billing-canary snapshot. Pure — no broadcast, no state
+   * mutation. Maps the live session list to the {id, provider, totalCostUsd}
+   * shape the canary expects.
+   * @returns {{eraStarted:boolean, defaultProvider:string, defaultBillingClass:string, warnings:Array}}
+   */
+  compute() {
+    const now = this._now()
+    const defaultProvider = this._getDefaultProvider() || DEFAULT_PROVIDER
+    const apiKeyAuth = Boolean(this._getApiKeyAuth())
+    const sessions = (this._getSessions() || []).map((s) => ({
+      id: s.sessionId || s.id,
+      provider: s.provider,
+      totalCostUsd: s && s.cumulativeUsage ? s.cumulativeUsage.costUsd : undefined,
+    }))
+    // egressIp omitted on purpose — see the module header.
+    const { eraStarted, warnings } = runBillingCanary({ sessions, defaultProvider, now, apiKeyAuth })
+    const defaultBillingClass = billingClassForProvider(defaultProvider, now, { apiKeyAuth })
+    return { eraStarted, defaultProvider, defaultBillingClass, warnings }
+  }
+
+  /**
+   * Recompute and broadcast a `billing_canary` message IF the snapshot changed
+   * (including a transition back to all-clear, so the client clears its banner).
+   * Always updates `current()`.
+   * @returns {object} the fresh snapshot
+   */
+  refresh() {
+    const snapshot = this.compute()
+    const key = JSON.stringify(snapshot)
+    this._last = snapshot
+    if (key !== this._lastKey) {
+      this._lastKey = key
+      try {
+        this._broadcast({ type: 'billing_canary', ...snapshot })
+      } catch (err) {
+        this._log?.warn?.(`billing-canary broadcast failed: ${String(err?.message || err)}`)
+      }
+    }
+    return snapshot
+  }
+
+  /** The latest snapshot, for seeding auth_ok. Computes once if never refreshed. */
+  current() {
+    return this._last || this.compute()
+  }
+
+  /** Start the periodic recompute. Initial refresh runs immediately. */
+  start() {
+    this.refresh()
+    this._timer = setInterval(() => {
+      try {
+        this.refresh()
+      } catch (err) {
+        this._log?.warn?.(`billing-canary refresh failed: ${String(err?.message || err)}`)
+      }
+    }, this._intervalMs)
+    // Don't keep the event loop alive for this; clean shutdown calls stop() and
+    // the leaked-timer test guard (--test-force-exit) shouldn't trip on it.
+    if (this._timer && typeof this._timer.unref === 'function') this._timer.unref()
+    return this
+  }
+
+  /** Stop the periodic recompute. Idempotent. */
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer)
+      this._timer = null
+    }
+  }
+}

--- a/packages/server/src/doctor-billing.js
+++ b/packages/server/src/doctor-billing.js
@@ -124,11 +124,13 @@ export function classifyEgressIp(ip) {
 /**
  * Aggregate the canary. Returns a flat warnings array (empty = all clear).
  *
- * @param {{sessions?:Array, defaultProvider?:string, egressIp?:string, now?:number}} input
+ * @param {{sessions?:Array, defaultProvider?:string, egressIp?:string, now?:number, apiKeyAuth?:boolean}} input
+ *   `apiKeyAuth: true` forwards billing-class's refinement to the silent-metered
+ *   check so a BYOK (claude-sdk + ANTHROPIC_API_KEY) default isn't flagged.
  */
-export function runBillingCanary({ sessions = [], defaultProvider, egressIp, now = Date.now() } = {}) {
+export function runBillingCanary({ sessions = [], defaultProvider, egressIp, now = Date.now(), apiKeyAuth = false } = {}) {
   const warnings = []
-  warnings.push(...detectSilentMeteredDefault(defaultProvider, now))
+  warnings.push(...detectSilentMeteredDefault(defaultProvider, now, { apiKeyAuth }))
   warnings.push(...detectBillingReclassification(sessions, now))
   const egress = classifyEgressIp(egressIp)
   if (egress.datacenter) warnings.push({ code: egress.code, message: egress.message })

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -4,6 +4,7 @@ import { DEFAULT_TOOL_CALL_TIMEOUT_MS } from './byok-mcp-client.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { WsServer } from './ws-server.js'
+import { BillingCanaryMonitor } from './billing-canary-monitor.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 // #5368 slice (c): QUICK_TUNNEL_DNS_SETTLE_MS + TUNNEL_STATUS_MIN_PROTOCOL_VERSION
 // moved to tunnel-lifecycle-handler.js with the tunnel block; createTunnel +
@@ -894,6 +895,29 @@ export async function startCliServer(config) {
   maybeWarnNonLoopbackBind({ bindHost, log })
   wsServer.start(bindHost)
 
+  // #5821 (live wiring): the billing canary. Recomputes the daemon's billing
+  // early-warnings (silent metered default; the dormant claude-tui
+  // reclassification tripwire) and broadcasts a `billing_canary` message when
+  // they change, so the dashboard can surface a banner during the 2026-06-15
+  // programmatic-credit window. Created after wsServer (it broadcasts through
+  // it); the provider is wired back into wsServer so the snapshot also seeds
+  // auth_ok for late joiners. Egress detection is deliberately not run here —
+  // it needs an outbound IP lookup (deferred to an opt-in follow-up).
+  const billingCanaryMonitor = new BillingCanaryMonitor({
+    getSessions: () => sessionManager.listSessions(),
+    getDefaultProvider: () => config.provider || DEFAULT_PROVIDER,
+    getApiKeyAuth: () => (config.provider || DEFAULT_PROVIDER) === 'claude-sdk' && Boolean(process.env.ANTHROPIC_API_KEY),
+    broadcast: (msg) => { try { wsServer?.broadcast(msg) } catch { /* best-effort */ } },
+    logger: log,
+  })
+  wsServer.setBillingCanaryProvider(() => billingCanaryMonitor.current())
+  // Recompute on session lifecycle (changes the session set the canary reads);
+  // the periodic interval covers cost drift. These are additional listeners —
+  // they don't replace the logging ones above.
+  sessionManager.on('session_created', () => billingCanaryMonitor.refresh())
+  sessionManager.on('session_destroyed', () => billingCanaryMonitor.refresh())
+  billingCanaryMonitor.start()
+
   // #5053: wire the pool stats aggregator to the shared pool so the
   // dashboard's GET /api/pool/stats has rolling counters (hit rate,
   // eviction-by-reason, recent evictions) to read. Default-OFF — only the
@@ -1070,6 +1094,7 @@ export async function startCliServer(config) {
     tokenManager,
     pairingManager,
     pushManager,
+    billingCanaryMonitor,
     getWorktreeReapTimer: () => worktreeReapTimer,
     emergencyCleanupSync,
     removeConnectionInfo,

--- a/packages/server/src/server-cli/server-orchestrator.js
+++ b/packages/server/src/server-cli/server-orchestrator.js
@@ -32,6 +32,7 @@ export class ServerOrchestrator {
     tokenManager,
     pairingManager,
     pushManager = null,
+    billingCanaryMonitor = null,
     getWorktreeReapTimer,
     emergencyCleanupSync,
     removeConnectionInfo = defaultRemoveConnectionInfo,
@@ -49,6 +50,7 @@ export class ServerOrchestrator {
     this._tokenManager = tokenManager
     this._pairingManager = pairingManager
     this._pushManager = pushManager
+    this._billingCanaryMonitor = billingCanaryMonitor
     this._getWorktreeReapTimer = typeof getWorktreeReapTimer === 'function' ? getWorktreeReapTimer : () => null
     this._emergencyCleanupSync = emergencyCleanupSync
     this._removeConnectionInfo = removeConnectionInfo
@@ -92,6 +94,11 @@ export class ServerOrchestrator {
     // wouldn't block exit, but clearing it avoids a sweep racing shutdown.
     const worktreeReapTimer = this._getWorktreeReapTimer()
     if (worktreeReapTimer) clearInterval(worktreeReapTimer)
+    // #5821: stop the billing-canary recompute timer. It's unref'd so it
+    // wouldn't block exit, but clearing it avoids a recompute racing shutdown.
+    if (this._billingCanaryMonitor) {
+      try { this._billingCanaryMonitor.stop() } catch {}
+    }
     // Persist sessions before destroying (enables restore on restart)
     try { this._sessionManager.serializeState() } catch (err) {
       log.error(`Failed to serialize session state: ${err?.message || err}`)

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -183,6 +183,10 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // undefined when the server hasn't bound a socket (test harnesses) or the
     // ctx predates the field; the auth_ok field is omitted in that case.
     exposure,
+    // #5821: current billing-canary snapshot ({ eraStarted, defaultProvider,
+    // defaultBillingClass, warnings }) — null when no provider is wired; the
+    // auth_ok field is omitted in that case.
+    billingCanary,
     // #5536: long-lived identity keypair for signing the eager exchange key.
     serverIdentity,
   } = ctx
@@ -398,6 +402,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // #5356: exposure snapshot for the dashboard warning banner. Optional on
     // the wire — older servers omit it and clients treat that as "unknown".
     ...(exposure ? { exposure } : {}),
+    // #5821: current billing-canary snapshot, so a freshly-connected client
+    // renders the billing banner immediately. Optional — omitted when no
+    // provider is wired (older servers / tests); live changes arrive via the
+    // `billing_canary` broadcast.
+    ...(billingCanary ? { billingCanary } : {}),
     // #5555: when the eager handshake succeeded, carry the server's public key
     // so the client derives the shared key immediately. Absent otherwise (no
     // eager fields / encryption disabled / derivation failed) → client falls

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -573,6 +573,11 @@ export class WsServer {
     // reconnect and updated by session-handlers.handleSwitchSession after
     // every explicit switch.
     this._devicePreferences = devicePreferences || createDevicePreferences()
+    // #5821: provider for the current billing-canary snapshot, wired by
+    // server-cli after the monitor is constructed (the monitor depends on this
+    // WsServer's broadcast, so it's created after — set the provider here once
+    // it exists). null = no seed (older boot / tests); the ctx getter folds this in.
+    this._billingCanaryProvider = null
     // #4849: lazy startup prune. server-cli calls sessionManager.restoreState()
     // before constructing the WsServer, so any device-pref entry whose
     // activeSessionId is missing here is genuinely orphaned (a session
@@ -837,6 +842,14 @@ export class WsServer {
       // surfaced in auth_ok so the dashboard can render a warning banner.
       // null until start() has bound a socket.
       get exposure() { return self.exposure },
+      // #5821: current billing-canary snapshot, seeded into auth_ok so a
+      // freshly-connected client renders the billing banner immediately. null
+      // until a provider is wired (server-cli sets it post-construct) — live
+      // changes still arrive via the `billing_canary` broadcast.
+      get billingCanary() {
+        try { return self._billingCanaryProvider ? self._billingCanaryProvider() : null }
+        catch { return null }
+      },
       // #5555 (auth_bootstrap): file ops + provider agent dirs so the
       // connect-time bootstrap burst can compute the slash-command / agent
       // lists inline (same payloads the list_* request handlers produce),
@@ -1749,6 +1762,16 @@ export class WsServer {
     }, 60_000)
 
     log.info(`Server listening on ${host || '0.0.0.0'}:${this.port} (${this.serverMode} mode)`)
+  }
+
+  /**
+   * #5821: wire the billing-canary snapshot provider. server-cli calls this
+   * after constructing the monitor (which depends on this server's broadcast).
+   * The provider is read by the `_historyCtx.billingCanary` getter to seed
+   * `auth_ok`. `fn` returns the current snapshot or null.
+   */
+  setBillingCanaryProvider(fn) {
+    this._billingCanaryProvider = typeof fn === 'function' ? fn : null
   }
 
   /** Delegates to ws-history.js */

--- a/packages/server/tests/billing-canary-monitor.test.js
+++ b/packages/server/tests/billing-canary-monitor.test.js
@@ -1,0 +1,105 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { BillingCanaryMonitor } from '../src/billing-canary-monitor.js'
+
+const AFTER = Date.UTC(2026, 5, 16) // one day into the programmatic-credit era
+const BEFORE = Date.UTC(2026, 5, 1) // before the cutover
+
+function make(opts = {}) {
+  const broadcasts = []
+  const monitor = new BillingCanaryMonitor({
+    broadcast: (m) => broadcasts.push(m),
+    nowFn: () => opts.now ?? AFTER,
+    getSessions: opts.getSessions || (() => []),
+    getDefaultProvider: opts.getDefaultProvider || (() => 'claude-tui'),
+    getApiKeyAuth: opts.getApiKeyAuth || (() => false),
+    ...opts.extra,
+  })
+  return { monitor, broadcasts }
+}
+
+test('compute maps live sessions to the canary shape and reports the default billing class', () => {
+  const { monitor } = make({
+    getDefaultProvider: () => 'claude-tui',
+    getSessions: () => [{ sessionId: 's1', provider: 'claude-tui', cumulativeUsage: { costUsd: 0 } }],
+  })
+  const snap = monitor.compute()
+  assert.equal(snap.eraStarted, true)
+  assert.equal(snap.defaultProvider, 'claude-tui')
+  assert.equal(snap.defaultBillingClass, 'subscription')
+  assert.deepEqual(snap.warnings, [])
+})
+
+test('flags a silent metered default (claude-sdk, era, no key)', () => {
+  const { monitor } = make({ getDefaultProvider: () => 'claude-sdk' })
+  const snap = monitor.compute()
+  assert.equal(snap.defaultBillingClass, 'programmatic-credit')
+  assert.equal(snap.warnings.length, 1)
+  assert.equal(snap.warnings[0].code, 'SILENT_METERED_DEFAULT')
+})
+
+test('does NOT flag claude-sdk default when apiKeyAuth (BYOK)', () => {
+  const { monitor } = make({ getDefaultProvider: () => 'claude-sdk', getApiKeyAuth: () => true })
+  const snap = monitor.compute()
+  assert.equal(snap.defaultBillingClass, 'api-key')
+  assert.deepEqual(snap.warnings, [])
+})
+
+test('reclassification tripwire is dormant for a zero-cost claude-tui session', () => {
+  const { monitor } = make({
+    getDefaultProvider: () => 'claude-tui',
+    getSessions: () => [{ sessionId: 's1', provider: 'claude-tui', cumulativeUsage: { costUsd: 0 } }],
+  })
+  assert.deepEqual(monitor.compute().warnings, [])
+})
+
+test('reclassification tripwire fires if a claude-tui session ever reports cost', () => {
+  const { monitor } = make({
+    getDefaultProvider: () => 'claude-tui',
+    getSessions: () => [{ sessionId: 's1', provider: 'claude-tui', cumulativeUsage: { costUsd: 0.5 } }],
+  })
+  const codes = monitor.compute().warnings.map((w) => w.code)
+  assert.ok(codes.includes('TUI_REPORTED_PROGRAMMATIC_COST'))
+})
+
+test('refresh broadcasts on change, dedupes when unchanged, and broadcasts a clear', () => {
+  let provider = 'claude-sdk' // metered default → warning
+  const { monitor, broadcasts } = make({ getDefaultProvider: () => provider })
+
+  monitor.refresh()
+  assert.equal(broadcasts.length, 1)
+  assert.equal(broadcasts[0].type, 'billing_canary')
+  assert.equal(broadcasts[0].warnings.length, 1)
+
+  monitor.refresh() // unchanged → no new broadcast
+  assert.equal(broadcasts.length, 1)
+
+  provider = 'claude-tui' // clears the warning → broadcast the all-clear
+  monitor.refresh()
+  assert.equal(broadcasts.length, 2)
+  assert.deepEqual(broadcasts[1].warnings, [])
+})
+
+test('current() returns the latest snapshot, computing once if never refreshed', () => {
+  const { monitor } = make({ getDefaultProvider: () => 'claude-sdk' })
+  const c = monitor.current()
+  assert.equal(c.defaultProvider, 'claude-sdk')
+  assert.equal(c.warnings.length, 1)
+})
+
+test('pre-cutover: no metered warning even for a programmatic default', () => {
+  const { monitor } = make({ now: BEFORE, getDefaultProvider: () => 'claude-sdk' })
+  const snap = monitor.compute()
+  assert.equal(snap.eraStarted, false)
+  assert.deepEqual(snap.warnings, [])
+})
+
+test('start sets an unref-d timer and stop clears it', () => {
+  const { monitor, broadcasts } = make({ getDefaultProvider: () => 'claude-sdk', extra: { intervalMs: 999999 } })
+  monitor.start()
+  assert.equal(broadcasts.length, 1) // initial refresh broadcast
+  assert.ok(monitor._timer, 'timer should be set')
+  monitor.stop()
+  assert.equal(monitor._timer, null, 'timer should be cleared')
+  monitor.stop() // idempotent
+})

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -354,16 +354,23 @@ describe('Provider Registry', () => {
       }
     })
 
-    it('claude-cli reports source=oauth regardless of env (subscription always)', () => {
+    it('claude-cli reports source=oauth regardless of env (CLI strips the key)', () => {
       try {
         clearKeys()
         process.env.ANTHROPIC_API_KEY = 'sk-test'
         const list = listProviders()
         const cli = list.find(p => p.name === 'claude-cli')
-        // CLI strips ANTHROPIC_API_KEY before spawn — billing is always subscription
+        // CLI strips ANTHROPIC_API_KEY before spawn, so it always auths via the
+        // host OAuth/subscription pool — never the raw-API account, even with a
+        // key set. That's the invariant under test here.
         assert.equal(cli.auth.source, 'oauth')
         assert.equal(cli.auth.ready, true)
-        assert.match(cli.auth.detail, /subscription/i)
+        // The billing DETAIL is era-dependent (flat subscription before the
+        // 2026-06-15 cutover, metered programmatic-credit on/after) and listProviders
+        // reads the real clock — so accept either rather than coupling this test to
+        // the wall date. The exact era flip is pinned with injected time in
+        // billing-class.test.js.
+        assert.match(cli.auth.detail, /subscription|programmatic|credit/i)
       } finally {
         restoreKeys()
       }


### PR DESCRIPTION
## Summary

Turns the billing early-warning system **on live** — the canary now runs inside the running daemon and surfaces in the dashboard during the 2026-06-15 programmatic-credit window. Follow-up to #5821 (which added the pure checks + the standalone `chroxy doctor` wiring).

## Layers

**Protocol (`@chroxy/protocol`)**
- New `billing_canary` server→client message + a shared `BillingCanarySnapshot` schema, also embedded as an optional `billingCanary` seed in `auth_ok` (mirrors the `exposure` pattern) so a freshly-connected client renders the banner immediately rather than waiting for the next broadcast. dist rebuilt (additive).

**Daemon**
- New `BillingCanaryMonitor`: recomputes the canary on startup, on a 10-min `unref`'d timer, and on session create/destroy; broadcasts `billing_canary` **only when the result changes** (including a transition back to all-clear, so the banner clears). `current()` seeds `auth_ok`.
- Wired in `server-cli` with the provider fed back into `WsServer`; stopped cleanly on shutdown via `ServerOrchestrator`. `runBillingCanary` gained `apiKeyAuth` so a BYOK (`claude-sdk` + `ANTHROPIC_API_KEY`) default isn't flagged.

**Dashboard**
- Store `billingCanary` snapshot + per-connection dismissal (resets on a **changed** warning set / fresh connect; preserved across unchanged re-broadcasts and silent reconnects). `billing_canary` handler (safeParse) + `auth_ok` seed. `BillingWarningBanner` modeled on `ExposureWarningBanner`, mounted in `App`.

## Which signals are live (honest accounting)

- **SILENT_METERED_DEFAULT** — the live signal: fires when the configured default is a programmatic provider (`claude-sdk`/`claude-cli`) without a key, on/after the cutover. Narrow audience now that the default is `claude-tui`, but exactly the people who'd be surprised by metering.
- **TUI_REPORTED_PROGRAMMATIC_COST** — a **zero-false-positive dormant tripwire**: `claude-tui` emits `cost: null` by convention (`claude-tui-session.js`), so its cumulative `costUsd` stays 0 and this never fires today. It lights up only if a claude-tui session ever reports cost (i.e. the bet broke / cost became observable).

## Deferred (tracked follow-up)

- **Datacenter-egress detection** — needs an outbound IP lookup (the daemon phoning out) + a real cloud-IP dataset. Left exported (`classifyEgressIp`) but **not run** in the monitor; filing an opt-in follow-up rather than making every daemon phone out by default.
- **push/Discord sink** for billing warnings — the dashboard banner is the primary surface; notification-sink fan-out is a follow-up.

## Testing

- Server: `BillingCanaryMonitor` (10), full suite green bar the known `:8765` live-daemon artifact; opt-forwarding + state-file-path lints clean.
- Protocol: 289 pass. Dashboard: 3714 pass (banner 6, dispatch handler 5 new). Dashboard + app + protocol `tsc` clean.

Implements the live half of the audit's rec #4 (#5818).
