### PR TITLE
feat(server): opt-in datacenter-egress detection + push for billing canary

### DIFF
--- a/packages/app/src/components/settings/constants.ts
+++ b/packages/app/src/components/settings/constants.ts
@@ -20,6 +20,9 @@ export const NOTIFICATION_CATEGORY_LABELS: Record<string, { label: string; hint?
   activity_waiting: { label: 'Waiting for input', hint: 'Claude paused on a question or prompt.' },
   activity_error: { label: 'Session errors', hint: 'Crashes, tunnel drops, fatal session failures.' },
   inactivity_warning: { label: 'Inactivity warnings', hint: 'Heads-up before a long-idle session is paused.' },
+  // #5828: billing canary early-warnings (silent metered default, claude-tui
+  // reclassification, datacenter egress).
+  billing_warning: { label: 'Billing alerts', hint: 'Metered-credit and datacenter-egress warnings from the billing canary.' },
   live_activity: { label: 'Live Activity (iOS)', hint: 'iOS Dynamic Island / lock-screen updates.' },
   // #5413 Phase 3: external-session categories fed by POST /api/events.
   session_online: { label: 'External session online', hint: 'An external session reported in via /api/events.' },
@@ -34,6 +37,7 @@ export const NOTIFICATION_CATEGORY_ORDER = [
   'activity_error',
   'activity_update',
   'inactivity_warning',
+  'billing_warning',
   'result',
   // External-session categories (#5413) grouped together, ahead of the
   // platform-specific Live Activity entry which stays last.

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -90,6 +90,12 @@ const NOTIFICATION_CATEGORY_LABELS: Record<string, { label: string; hint?: strin
     label: 'Inactivity warnings',
     hint: 'Heads-up before a long-idle session is auto-paused.',
   },
+  // #5828: billing canary early-warnings (silent metered default, claude-tui
+  // reclassification, datacenter egress).
+  billing_warning: {
+    label: 'Billing alerts',
+    hint: 'Metered-credit and datacenter-egress warnings from the billing canary.',
+  },
   live_activity: {
     label: 'Live Activity (iOS)',
     hint: 'iOS Dynamic Island / lock-screen Live Activity updates.',
@@ -116,6 +122,7 @@ const NOTIFICATION_CATEGORY_ORDER = [
   'activity_error',
   'activity_update',
   'inactivity_warning',
+  'billing_warning',
   'result',
   // External-session categories (#5413) grouped together, ahead of the
   // platform-specific Live Activity entry which stays last.

--- a/packages/server/src/billing-canary-monitor.js
+++ b/packages/server/src/billing-canary-monitor.js
@@ -63,6 +63,7 @@ export class BillingCanaryMonitor {
     this._lastKey = null      // JSON of the last snapshot, for broadcast change-detection
     this._lastWarnKey = null  // signature of the last warning SET, for notify change-detection
     this._egressIp = null     // cached public egress IP (null until resolved / when disabled)
+    this._stopped = false     // true after stop(); guards an in-flight egress tick from refreshing
   }
 
   /**
@@ -140,6 +141,11 @@ export class BillingCanaryMonitor {
         this._egressIp = null
       }
     }
+    // The egress lookup is async (up to ~5s); if stop() landed while it was in
+    // flight, skip the trailing refresh so a shut-down monitor doesn't broadcast.
+    // `_stopped` (not `_timer`) is the signal — `_timer` is briefly null during
+    // start()'s first tick, before setInterval runs.
+    if (this._stopped) return
     try {
       this.refresh()
     } catch (err) {
@@ -154,6 +160,7 @@ export class BillingCanaryMonitor {
 
   /** Start the periodic recompute. Initial refresh runs immediately. */
   start() {
+    this._stopped = false
     // Immediate synchronous refresh so current() is populated for the auth_ok
     // seed right away (egress, if enabled, folds in on the async tick below).
     this.refresh()
@@ -170,6 +177,7 @@ export class BillingCanaryMonitor {
 
   /** Stop the periodic recompute. Idempotent. */
   stop() {
+    this._stopped = true
     if (this._timer) {
       clearInterval(this._timer)
       this._timer = null

--- a/packages/server/src/billing-canary-monitor.js
+++ b/packages/server/src/billing-canary-monitor.js
@@ -109,10 +109,12 @@ export class BillingCanaryMonitor {
     }
     // #5828: fire `notify` (e.g. push) when the warning SET changes to a
     // non-empty state — once per distinct warning state, NOT on all-clear and
-    // NOT on an unchanged re-broadcast. Signature over full warning identity so
-    // a session/cost change re-notifies (mirrors the dashboard dismissal logic).
+    // NOT on an unchanged re-broadcast. Signature includes the message so a
+    // meaning change with the same code re-notifies (e.g. DATACENTER_EGRESS with
+    // a new egress IP, or SILENT_METERED_DEFAULT for a different provider) —
+    // mirrors the dashboard dismissal signature.
     const warnKey = snapshot.warnings
-      .map((w) => `${w.code} ${w.sessionId ?? ''} ${w.costUsd ?? ''}`)
+      .map((w) => `${w.code} ${w.sessionId ?? ''} ${w.costUsd ?? ''} ${w.message ?? ''}`)
       .sort()
       .join('|')
     if (warnKey !== this._lastWarnKey) {

--- a/packages/server/src/billing-canary-monitor.js
+++ b/packages/server/src/billing-canary-monitor.js
@@ -7,13 +7,14 @@
 // connected client renders the banner immediately instead of waiting for the
 // next broadcast.
 //
-// Scope: this monitor runs the two checks that need only local daemon state —
-// `detectSilentMeteredDefault` (the live signal: a programmatic config default
-// without a key) and `detectBillingReclassification` (a zero-false-positive
+// Scope: this monitor always runs the two checks that need only local daemon
+// state — `detectSilentMeteredDefault` (the live signal: a programmatic config
+// default without a key) and `detectBillingReclassification` (a zero-false-positive
 // tripwire, dormant today because claude-tui reports `cost: null` so its
-// cumulative costUsd stays 0). The datacenter-egress check is intentionally
-// NOT run here: it needs an outbound IP lookup, which is deferred to an opt-in
-// follow-up rather than making every daemon phone out by default.
+// cumulative costUsd stays 0). The datacenter-egress check (#5828) is OPT-IN:
+// it needs an outbound public-IP lookup, so it only runs when the caller wires a
+// `resolveEgressIp` resolver (gated on `config.billing.egressCheck`). When a
+// warning set appears it can also fire a `notify` callback (push notification).
 import { runBillingCanary } from './doctor-billing.js'
 import { billingClassForProvider } from './billing-class.js'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
@@ -36,8 +37,17 @@ export class BillingCanaryMonitor {
    * @param {number} [opts.intervalMs] - recompute cadence (default 10 min).
    * @param {() => number} [opts.nowFn] - injectable clock for tests.
    * @param {{warn?: Function}} [opts.logger]
+   * @param {() => Promise<string|null>} [opts.resolveEgressIp] - #5828: when provided,
+   *   datacenter-egress detection is ON. The monitor resolves the public IP out-of-band
+   *   (best-effort, cached) and folds it into the canary. Absent = egress check OFF
+   *   (default) — the daemon makes no outbound lookup. The CALLER only provides this when
+   *   config.billing.egressCheck is true, so providing it IS the opt-in.
+   * @param {() => string[]} [opts.getDatacenterPrefixes] - extra IPv4 prefixes
+   *   (config.billing.datacenterPrefixes) merged into the egress classifier.
+   * @param {(warnings: Array) => void} [opts.notify] - #5828: fired when the warning
+   *   SET changes to a non-empty state (e.g. push notification). Not fired on all-clear.
    */
-  constructor({ getSessions, getDefaultProvider, getApiKeyAuth, broadcast, intervalMs = DEFAULT_INTERVAL_MS, nowFn = Date.now, logger } = {}) {
+  constructor({ getSessions, getDefaultProvider, getApiKeyAuth, broadcast, intervalMs = DEFAULT_INTERVAL_MS, nowFn = Date.now, logger, resolveEgressIp, getDatacenterPrefixes, notify } = {}) {
     this._getSessions = getSessions || (() => [])
     this._getDefaultProvider = getDefaultProvider || (() => DEFAULT_PROVIDER)
     this._getApiKeyAuth = getApiKeyAuth || (() => false)
@@ -45,9 +55,14 @@ export class BillingCanaryMonitor {
     this._intervalMs = intervalMs
     this._now = nowFn
     this._log = logger
+    this._resolveEgressIp = typeof resolveEgressIp === 'function' ? resolveEgressIp : null
+    this._getDatacenterPrefixes = getDatacenterPrefixes || (() => [])
+    this._notify = typeof notify === 'function' ? notify : null
     this._timer = null
-    this._last = null     // last computed snapshot
-    this._lastKey = null  // JSON of the last snapshot, for change detection
+    this._last = null         // last computed snapshot
+    this._lastKey = null      // JSON of the last snapshot, for broadcast change-detection
+    this._lastWarnKey = null  // signature of the last warning SET, for notify change-detection
+    this._egressIp = null     // cached public egress IP (null until resolved / when disabled)
   }
 
   /**
@@ -65,8 +80,10 @@ export class BillingCanaryMonitor {
       provider: s.provider,
       totalCostUsd: s && s.cumulativeUsage ? s.cumulativeUsage.costUsd : undefined,
     }))
-    // egressIp omitted on purpose — see the module header.
-    const { eraStarted, warnings } = runBillingCanary({ sessions, defaultProvider, now, apiKeyAuth })
+    // egressIp is the cached value from the out-of-band resolver — null when the
+    // egress check is OFF (default) or not yet resolved, so no egress warning.
+    const datacenterPrefixes = this._getDatacenterPrefixes() || []
+    const { eraStarted, warnings } = runBillingCanary({ sessions, defaultProvider, now, apiKeyAuth, egressIp: this._egressIp, datacenterPrefixes })
     const defaultBillingClass = billingClassForProvider(defaultProvider, now, { apiKeyAuth })
     return { eraStarted, defaultProvider, defaultBillingClass, warnings }
   }
@@ -89,7 +106,45 @@ export class BillingCanaryMonitor {
         this._log?.warn?.(`billing-canary broadcast failed: ${String(err?.message || err)}`)
       }
     }
+    // #5828: fire `notify` (e.g. push) when the warning SET changes to a
+    // non-empty state — once per distinct warning state, NOT on all-clear and
+    // NOT on an unchanged re-broadcast. Signature over full warning identity so
+    // a session/cost change re-notifies (mirrors the dashboard dismissal logic).
+    const warnKey = snapshot.warnings
+      .map((w) => `${w.code} ${w.sessionId ?? ''} ${w.costUsd ?? ''}`)
+      .sort()
+      .join('|')
+    if (warnKey !== this._lastWarnKey) {
+      this._lastWarnKey = warnKey
+      if (snapshot.warnings.length > 0 && this._notify) {
+        try {
+          this._notify(snapshot.warnings)
+        } catch (err) {
+          this._log?.warn?.(`billing-canary notify failed: ${String(err?.message || err)}`)
+        }
+      }
+    }
     return snapshot
+  }
+
+  /**
+   * One recompute cycle: refresh the cached egress IP first (best-effort, only
+   * when the egress check is enabled), then refresh the snapshot. Async because
+   * the egress lookup is a network call; never rejects (fail-open).
+   */
+  async _tick() {
+    if (this._resolveEgressIp) {
+      try {
+        this._egressIp = await this._resolveEgressIp()
+      } catch {
+        this._egressIp = null
+      }
+    }
+    try {
+      this.refresh()
+    } catch (err) {
+      this._log?.warn?.(`billing-canary refresh failed: ${String(err?.message || err)}`)
+    }
   }
 
   /** The latest snapshot, for seeding auth_ok. Computes once if never refreshed. */
@@ -99,13 +154,13 @@ export class BillingCanaryMonitor {
 
   /** Start the periodic recompute. Initial refresh runs immediately. */
   start() {
+    // Immediate synchronous refresh so current() is populated for the auth_ok
+    // seed right away (egress, if enabled, folds in on the async tick below).
     this.refresh()
+    // Kick the first egress-aware tick (no-op extra refresh when egress is off).
+    this._tick().catch(() => {})
     this._timer = setInterval(() => {
-      try {
-        this.refresh()
-      } catch (err) {
-        this._log?.warn?.(`billing-canary refresh failed: ${String(err?.message || err)}`)
-      }
+      this._tick().catch((err) => this._log?.warn?.(`billing-canary tick failed: ${String(err?.message || err)}`))
     }, this._intervalMs)
     // Don't keep the event loop alive for this; clean shutdown calls stop() and
     // the leaked-timer test guard (--test-force-exit) shouldn't trip on it.

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -479,6 +479,25 @@ function validateBillingBlock(billing, warnings) {
       warnings.push(`Invalid value for 'billing.budgetWarningPercent': expected a number 1-100, got ${JSON.stringify(v)}`)
     }
   }
+  // #5828: opt-in datacenter-egress check for the billing canary. Default OFF
+  // (no field) — when enabled, the daemon makes a best-effort public-IP lookup
+  // so it can warn when a subscription-billed provider runs from a cloud host
+  // (a documented ban signal). Off by default because it's an outbound network
+  // call the operator should consent to.
+  if (Object.prototype.hasOwnProperty.call(billing, 'egressCheck')) {
+    if (typeof billing.egressCheck !== 'boolean') {
+      warnings.push(`Invalid value for 'billing.egressCheck': expected a boolean, got ${JSON.stringify(billing.egressCheck)}`)
+    }
+  }
+  // #5828: operator-supplied extra IPv4 prefixes for the datacenter classifier
+  // (merged with the conservative built-in list). Lets a user on a known cloud
+  // add their provider's ranges without a code change.
+  if (Object.prototype.hasOwnProperty.call(billing, 'datacenterPrefixes')) {
+    const v = billing.datacenterPrefixes
+    if (!Array.isArray(v) || !v.every((p) => typeof p === 'string' && p.length > 0)) {
+      warnings.push(`Invalid value for 'billing.datacenterPrefixes': expected an array of non-empty strings, got ${JSON.stringify(v)}`)
+    }
+  }
 }
 
 function validateDiscordNotificationsBlock(discord, warnings) {

--- a/packages/server/src/doctor-billing.js
+++ b/packages/server/src/doctor-billing.js
@@ -105,11 +105,17 @@ const DATACENTER_IPV4_PREFIXES = [
 
 /**
  * @param {string} ip - public egress IPv4
+ * @param {string[]} [extraPrefixes] - operator-supplied extra IPv4 prefixes
+ *   (config.billing.datacenterPrefixes), merged with the built-in list. Lets a
+ *   user on a known cloud add their provider's ranges without a code change.
  * @returns {{datacenter:boolean, code?:string, message?:string}}
  */
-export function classifyEgressIp(ip) {
+export function classifyEgressIp(ip, extraPrefixes = []) {
   if (!ip || typeof ip !== 'string') return { datacenter: false }
-  const hit = DATACENTER_IPV4_PREFIXES.some((p) => ip.startsWith(p))
+  const prefixes = Array.isArray(extraPrefixes) && extraPrefixes.length > 0
+    ? [...DATACENTER_IPV4_PREFIXES, ...extraPrefixes.filter((p) => typeof p === 'string' && p.length > 0)]
+    : DATACENTER_IPV4_PREFIXES
+  const hit = prefixes.some((p) => ip.startsWith(p))
   if (!hit) return { datacenter: false }
   return {
     datacenter: true,
@@ -124,15 +130,16 @@ export function classifyEgressIp(ip) {
 /**
  * Aggregate the canary. Returns a flat warnings array (empty = all clear).
  *
- * @param {{sessions?:Array, defaultProvider?:string, egressIp?:string, now?:number, apiKeyAuth?:boolean}} input
+ * @param {{sessions?:Array, defaultProvider?:string, egressIp?:string, now?:number, apiKeyAuth?:boolean, datacenterPrefixes?:string[]}} input
  *   `apiKeyAuth: true` forwards billing-class's refinement to the silent-metered
  *   check so a BYOK (claude-sdk + ANTHROPIC_API_KEY) default isn't flagged.
+ *   `datacenterPrefixes` extends the built-in egress prefix list (#5828).
  */
-export function runBillingCanary({ sessions = [], defaultProvider, egressIp, now = Date.now(), apiKeyAuth = false } = {}) {
+export function runBillingCanary({ sessions = [], defaultProvider, egressIp, now = Date.now(), apiKeyAuth = false, datacenterPrefixes = [] } = {}) {
   const warnings = []
   warnings.push(...detectSilentMeteredDefault(defaultProvider, now, { apiKeyAuth }))
   warnings.push(...detectBillingReclassification(sessions, now))
-  const egress = classifyEgressIp(egressIp)
+  const egress = classifyEgressIp(egressIp, datacenterPrefixes)
   if (egress.datacenter) warnings.push({ code: egress.code, message: egress.message })
   return {
     eraStarted: isProgrammaticCreditEra(now),

--- a/packages/server/src/get-public-ip.js
+++ b/packages/server/src/get-public-ip.js
@@ -14,7 +14,10 @@
 const DEFAULT_IP_ECHO_URL = 'https://api.ipify.org'
 const DEFAULT_TIMEOUT_MS = 5000
 
-const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/
+// Each octet 0-255 — a loose \d{1,3} would accept junk like 999.999.999.999
+// from a captive-portal / error body.
+const OCTET = '(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)'
+const IPV4_RE = new RegExp(`^(${OCTET}\\.){3}${OCTET}$`)
 
 /**
  * Resolve the daemon's public egress IP, best-effort.

--- a/packages/server/src/get-public-ip.js
+++ b/packages/server/src/get-public-ip.js
@@ -1,0 +1,43 @@
+// get-public-ip.js — best-effort public egress IP lookup (#5828).
+//
+// Used ONLY when the operator opts into the billing canary's datacenter-egress
+// check (`config.billing.egressCheck`). Off by default — this is the one place
+// the daemon reaches out to a third-party service, so it's consent-gated.
+//
+// Fail-open by design: any error (timeout, network down, non-200, unparseable
+// body) resolves to `null`, never throws. A missed lookup just means no egress
+// warning — strictly better than crashing a periodic canary tick.
+
+// ipify returns a bare IPv4/IPv6 string for the text endpoint. Kept as a
+// default so the resolver works out of the box; injectable for tests / for an
+// operator who'd rather point at their own echo service.
+const DEFAULT_IP_ECHO_URL = 'https://api.ipify.org'
+const DEFAULT_TIMEOUT_MS = 5000
+
+const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/
+
+/**
+ * Resolve the daemon's public egress IP, best-effort.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.url] - IP-echo endpoint returning a bare IP string.
+ * @param {number} [opts.timeoutMs] - abort the request after this long.
+ * @param {typeof fetch} [opts.fetchImpl] - injectable for tests (defaults to global fetch).
+ * @returns {Promise<string|null>} the trimmed IPv4 string, or null on any failure.
+ */
+export async function resolvePublicIp({ url = DEFAULT_IP_ECHO_URL, timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = fetch } = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetchImpl(url, { signal: controller.signal })
+    if (!res || !res.ok) return null
+    const text = (await res.text()).trim()
+    // Only accept a plausible IPv4 — the classifier is IPv4-prefix based, and a
+    // junk/HTML body (captive portal, error page) must not be treated as an IP.
+    return IPV4_RE.test(text) ? text : null
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -84,6 +84,10 @@ export const ALL_CATEGORIES = Object.freeze([
   'session_online',
   'session_offline',
   'session_activity',
+  // #5828: billing-canary warnings (silent metered default; reclassification
+  // trip; opt-in datacenter egress). Listed so it's mutable in prefs and visible
+  // in snapshots; sanitizeCategoryMap would otherwise strip it as unknown.
+  'billing_warning',
 ])
 
 /**

--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -85,8 +85,8 @@ export const ALL_CATEGORIES = Object.freeze([
   'session_offline',
   'session_activity',
   // #5828: billing-canary warnings (silent metered default; reclassification
-  // trip; opt-in datacenter egress). Listed so it's mutable in prefs and visible
-  // in snapshots; sanitizeCategoryMap would otherwise strip it as unknown.
+  // trip; opt-in datacenter egress). Listed so they are mutable in prefs and
+  // visible in snapshots; sanitizeCategoryMap would otherwise strip them as unknown.
   'billing_warning',
 ])
 

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -82,6 +82,10 @@ const RATE_LIMITS = {
   session_online: 0,
   session_offline: 0,
   session_activity: 30_000,
+  // #5828: billing-canary warnings (silent metered default; reclassification
+  // trip). The monitor only emits on a CHANGED warning set, so this is already
+  // dedup'd at the source — immediate is fine, no extra throttle needed.
+  billing_warning: 0,
 }
 
 // Re-exported for existing importers/tests — the implementation moved to

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -5,6 +5,7 @@ import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { WsServer } from './ws-server.js'
 import { BillingCanaryMonitor } from './billing-canary-monitor.js'
+import { resolvePublicIp } from './get-public-ip.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 // #5368 slice (c): QUICK_TUNNEL_DNS_SETTLE_MS + TUNNEL_STATUS_MIN_PROTOCOL_VERSION
 // moved to tunnel-lifecycle-handler.js with the tunnel block; createTunnel +
@@ -901,14 +902,35 @@ export async function startCliServer(config) {
   // they change, so the dashboard can surface a banner during the 2026-06-15
   // programmatic-credit window. Created after wsServer (it broadcasts through
   // it); the provider is wired back into wsServer so the snapshot also seeds
-  // auth_ok for late joiners. Egress detection is deliberately not run here —
-  // it needs an outbound IP lookup (deferred to an opt-in follow-up).
+  // auth_ok for late joiners.
+  //
+  // #5828: datacenter-egress detection is OPT-IN via `config.billing.egressCheck`
+  // — only then do we pass `resolveEgressIp`, the one place the daemon makes an
+  // outbound IP lookup (consent-gated). `getDatacenterPrefixes` lets an operator
+  // add their cloud's ranges without a code change. `notify` fans a warning set
+  // out as a `billing_warning` push so an away operator hears about a metered
+  // default or a datacenter-egress flag without watching the dashboard.
+  const egressCheckEnabled = config.billing?.egressCheck === true
   const billingCanaryMonitor = new BillingCanaryMonitor({
     getSessions: () => sessionManager.listSessions(),
     getDefaultProvider: () => config.provider || DEFAULT_PROVIDER,
     getApiKeyAuth: () => (config.provider || DEFAULT_PROVIDER) === 'claude-sdk' && Boolean(process.env.ANTHROPIC_API_KEY),
     broadcast: (msg) => { try { wsServer?.broadcast(msg) } catch { /* best-effort */ } },
     logger: log,
+    resolveEgressIp: egressCheckEnabled ? () => resolvePublicIp() : undefined,
+    getDatacenterPrefixes: () => config.billing?.datacenterPrefixes || [],
+    notify: (warnings) => {
+      // One aggregate push per distinct warning set — billing_warning has no
+      // rate limit (RATE_LIMITS), so the monitor's own change-detection is the
+      // throttle. Codes ride in `data` for clients that key off them.
+      const count = warnings.length
+      const title = count > 1 ? `Billing alert (${count})` : 'Billing alert'
+      const body = warnings.map((w) => w.message).join('\n\n')
+      const codes = warnings.map((w) => w.code)
+      pushManager.send('billing_warning', title, body, { codes }).catch((err) => {
+        log?.warn?.(`billing-canary push failed: ${String(err?.message || err)}`)
+      })
+    },
   })
   wsServer.setBillingCanaryProvider(() => billingCanaryMonitor.current())
   // Recompute on session lifecycle (changes the session set the canary reads);

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -11,7 +11,7 @@ import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 // moved to tunnel-lifecycle-handler.js with the tunnel block; createTunnel +
 // waitForTunnel are still passed into the handler.
 import { waitForTunnel } from './tunnel-check.js'
-import { PushManager } from './push.js'
+import { PushManager, settlePush } from './push.js'
 import { ensureIngestSecret } from './event-ingest.js'
 import { PushNotificationHandler } from './server-cli/push-notification-handler.js'
 import { StartupDisplay } from './server-cli/startup-display.js'
@@ -927,9 +927,9 @@ export async function startCliServer(config) {
       const title = count > 1 ? `Billing alert (${count})` : 'Billing alert'
       const body = warnings.map((w) => w.message).join('\n\n')
       const codes = warnings.map((w) => w.code)
-      pushManager.send('billing_warning', title, body, { codes }).catch((err) => {
-        log?.warn?.(`billing-canary push failed: ${String(err?.message || err)}`)
-      })
+      // settlePush (#5702) logs both a thrown error AND a `false` not-delivered
+      // return (a half-open link), which a bare `.catch()` would drop silently.
+      settlePush(pushManager.send('billing_warning', title, body, { codes }), 'billing-canary', log)
     },
   })
   wsServer.setBillingCanaryProvider(() => billingCanaryMonitor.current())

--- a/packages/server/tests/billing-canary-monitor.test.js
+++ b/packages/server/tests/billing-canary-monitor.test.js
@@ -181,6 +181,23 @@ test('notify re-fires when the warning set changes (new code appears)', async ()
   assert.deepEqual(notified[1], ['DATACENTER_EGRESS', 'SILENT_METERED_DEFAULT'])
 })
 
+test('_tick after stop() does not refresh (in-flight egress lookup during shutdown)', async () => {
+  let release
+  const gate = new Promise((r) => { release = r })
+  const { monitor, broadcasts } = make({
+    getDefaultProvider: () => 'claude-sdk',
+    extra: { resolveEgressIp: async () => { await gate; return '5.9.1.2' } },
+  })
+  monitor.start()
+  const before = broadcasts.length
+  // start() kicks an async _tick whose egress lookup is parked on `gate`.
+  monitor.stop()      // shutdown lands mid-lookup
+  release('go')       // resolver completes after stop()
+  await new Promise((r) => setTimeout(r, 0))
+  // No extra broadcast from the post-stop tick.
+  assert.equal(broadcasts.length, before)
+})
+
 test('notify failure is swallowed (does not break refresh)', () => {
   const { monitor, broadcasts } = make({
     getDefaultProvider: () => 'claude-sdk',

--- a/packages/server/tests/billing-canary-monitor.test.js
+++ b/packages/server/tests/billing-canary-monitor.test.js
@@ -103,3 +103,89 @@ test('start sets an unref-d timer and stop clears it', () => {
   assert.equal(monitor._timer, null, 'timer should be cleared')
   monitor.stop() // idempotent
 })
+
+// #5828 — opt-in datacenter-egress detection.
+
+test('egress check OFF by default: compute makes no egress warning even on a datacenter IP', () => {
+  // No resolveEgressIp wired → _egressIp stays null → no DATACENTER_EGRESS.
+  const { monitor } = make({ getDefaultProvider: () => 'claude-tui' })
+  assert.deepEqual(monitor.compute().warnings, [])
+})
+
+test('_tick resolves the egress IP and folds a datacenter hit into the warnings', async () => {
+  const { monitor, broadcasts } = make({
+    getDefaultProvider: () => 'claude-tui',
+    extra: { resolveEgressIp: async () => '5.9.1.2' }, // Hetzner prefix
+  })
+  await monitor._tick()
+  const codes = monitor.current().warnings.map((w) => w.code)
+  assert.ok(codes.includes('DATACENTER_EGRESS'))
+  assert.ok(broadcasts.some((b) => b.warnings.some((w) => w.code === 'DATACENTER_EGRESS')))
+})
+
+test('_tick is fail-open: a throwing resolver leaves egress null and no warning', async () => {
+  const { monitor } = make({
+    getDefaultProvider: () => 'claude-tui',
+    extra: { resolveEgressIp: async () => { throw new Error('network down') } },
+  })
+  await monitor._tick()
+  assert.equal(monitor._egressIp, null)
+  assert.deepEqual(monitor.current().warnings, [])
+})
+
+test('getDatacenterPrefixes extends the built-in egress list', async () => {
+  const { monitor } = make({
+    getDefaultProvider: () => 'claude-tui',
+    extra: {
+      resolveEgressIp: async () => '203.0.113.4',
+      getDatacenterPrefixes: () => ['203.0.113.'],
+    },
+  })
+  await monitor._tick()
+  assert.ok(monitor.current().warnings.some((w) => w.code === 'DATACENTER_EGRESS'))
+})
+
+test('notify fires once per distinct non-empty warning set, not on all-clear', () => {
+  const notified = []
+  let provider = 'claude-sdk' // metered default → warning
+  const { monitor } = make({
+    getDefaultProvider: () => provider,
+    extra: { notify: (w) => notified.push(w) },
+  })
+
+  monitor.refresh()
+  assert.equal(notified.length, 1)
+  assert.equal(notified[0][0].code, 'SILENT_METERED_DEFAULT')
+
+  monitor.refresh() // unchanged warning set → no re-notify
+  assert.equal(notified.length, 1)
+
+  provider = 'claude-tui' // clears → must NOT notify on all-clear
+  monitor.refresh()
+  assert.equal(notified.length, 1)
+})
+
+test('notify re-fires when the warning set changes (new code appears)', async () => {
+  const notified = []
+  const { monitor } = make({
+    getDefaultProvider: () => 'claude-sdk', // metered default warning from the start
+    extra: {
+      resolveEgressIp: async () => '5.9.1.2', // adds DATACENTER_EGRESS on the tick
+      notify: (w) => notified.push(w.map((x) => x.code).sort()),
+    },
+  })
+  monitor.refresh() // just SILENT_METERED_DEFAULT
+  assert.deepEqual(notified, [['SILENT_METERED_DEFAULT']])
+  await monitor._tick() // egress resolves → set grows
+  assert.equal(notified.length, 2)
+  assert.deepEqual(notified[1], ['DATACENTER_EGRESS', 'SILENT_METERED_DEFAULT'])
+})
+
+test('notify failure is swallowed (does not break refresh)', () => {
+  const { monitor, broadcasts } = make({
+    getDefaultProvider: () => 'claude-sdk',
+    extra: { notify: () => { throw new Error('push down') } },
+  })
+  assert.doesNotThrow(() => monitor.refresh())
+  assert.equal(broadcasts.length, 1) // broadcast still happened
+})

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -301,6 +301,37 @@ describe('validateConfig', () => {
       assert.ok(result.warnings.some(w => w.includes('mcpToolCallTimeoutMs') && w.includes('number')))
     })
   })
+
+  describe('billing egress check (#5828)', () => {
+    it('accepts egressCheck boolean + datacenterPrefixes array', () => {
+      const result = validateConfig({ billing: { egressCheck: true, datacenterPrefixes: ['203.0.113.'] } })
+      assert.equal(result.valid, true)
+      assert.equal(result.warnings.length, 0)
+    })
+
+    it('accepts a billing block with neither egress field (default off)', () => {
+      const result = validateConfig({ billing: { creditTier: 'pro' } })
+      assert.equal(result.valid, true)
+    })
+
+    it('warns when egressCheck is not a boolean', () => {
+      const result = validateConfig({ billing: { egressCheck: 'yes' } })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('billing.egressCheck') && w.includes('boolean')))
+    })
+
+    it('warns when datacenterPrefixes is not an array', () => {
+      const result = validateConfig({ billing: { datacenterPrefixes: '203.0.113.' } })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('billing.datacenterPrefixes')))
+    })
+
+    it('warns when datacenterPrefixes contains a non-string or empty entry', () => {
+      const result = validateConfig({ billing: { datacenterPrefixes: ['203.0.113.', ''] } })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('billing.datacenterPrefixes')))
+    })
+  })
 })
 
 describe('mergeConfig', () => {

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -82,6 +82,27 @@ test('classifyEgressIp does NOT flag coarse /8 blocks (false-positive guard)', (
   }
 })
 
+test('classifyEgressIp honours operator-supplied extra prefixes (#5828)', () => {
+  // A residential-looking IP is clean by default but flagged once the operator
+  // adds their cloud's range via config.billing.datacenterPrefixes.
+  assert.equal(classifyEgressIp('203.0.113.9').datacenter, false)
+  assert.equal(classifyEgressIp('203.0.113.9', ['203.0.113.']).datacenter, true)
+  // The built-in list still applies alongside the extras.
+  assert.equal(classifyEgressIp('95.216.1.2', ['203.0.113.']).datacenter, true)
+  // Junk entries in the extras list are ignored, not crashed on.
+  assert.equal(classifyEgressIp('203.0.113.9', ['', null, 42]).datacenter, false)
+})
+
+test('runBillingCanary threads datacenterPrefixes into the egress classifier (#5828)', () => {
+  const out = runBillingCanary({
+    defaultProvider: 'claude-tui',
+    egressIp: '198.51.100.5',
+    datacenterPrefixes: ['198.51.100.'],
+    now: AFTER,
+  })
+  assert.ok(out.warnings.some((w) => w.code === 'DATACENTER_EGRESS'))
+})
+
 test('runBillingCanary aggregates all three signals', () => {
   const out = runBillingCanary({
     sessions: [{ id: 's1', provider: 'claude-tui', totalCostUsd: 1.5 }],

--- a/packages/server/tests/get-public-ip.test.js
+++ b/packages/server/tests/get-public-ip.test.js
@@ -21,6 +21,16 @@ test('returns null when the body is not a plausible IPv4 (captive portal / HTML)
   assert.equal(ip, null)
 })
 
+test('rejects out-of-range octets (999.999.999.999) — 0-255 only', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: true, text: async () => '999.999.999.999' })) })
+  assert.equal(ip, null)
+})
+
+test('accepts boundary octets (255.0.1.255)', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: true, text: async () => '255.0.1.255' })) })
+  assert.equal(ip, '255.0.1.255')
+})
+
 test('is fail-open: a throwing fetch resolves to null, never rejects', async () => {
   const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => { throw new Error('network down') }) })
   assert.equal(ip, null)

--- a/packages/server/tests/get-public-ip.test.js
+++ b/packages/server/tests/get-public-ip.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolvePublicIp } from '../src/get-public-ip.js'
+
+function fakeFetch(impl) {
+  return async (url, opts) => impl(url, opts)
+}
+
+test('returns the trimmed IPv4 on a 200 with a bare IP body', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: true, text: async () => '  203.0.113.7\n' })) })
+  assert.equal(ip, '203.0.113.7')
+})
+
+test('returns null on a non-200', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: false, text: async () => '203.0.113.7' })) })
+  assert.equal(ip, null)
+})
+
+test('returns null when the body is not a plausible IPv4 (captive portal / HTML)', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: true, text: async () => '<html>nope</html>' })) })
+  assert.equal(ip, null)
+})
+
+test('is fail-open: a throwing fetch resolves to null, never rejects', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => { throw new Error('network down') }) })
+  assert.equal(ip, null)
+})
+
+test('returns null on an abort (timeout)', async () => {
+  // Resolve immediately with a timeout of 0 so the abort path is exercised; the
+  // fetch impl honours the abort signal by rejecting like real fetch.
+  const ip = await resolvePublicIp({
+    timeoutMs: 0,
+    fetchImpl: (url, { signal }) =>
+      new Promise((_resolve, reject) => {
+        if (signal.aborted) return reject(new Error('aborted'))
+        signal.addEventListener('abort', () => reject(new Error('aborted')))
+      }),
+  })
+  assert.equal(ip, null)
+})
+
+test('passes a configurable url through to fetch', async () => {
+  let seen = null
+  await resolvePublicIp({
+    url: 'https://example.test/ip',
+    fetchImpl: fakeFetch(async (url) => { seen = url; return { ok: true, text: async () => '1.2.3.4' } }),
+  })
+  assert.equal(seen, 'https://example.test/ip')
+})


### PR DESCRIPTION
## Summary

Part of #5828. Surfaces the billing canary's warnings to an away operator (push) and adds a consent-gated datacenter-egress ban-signal check.

Builds on the live canary wiring from #5827. The canary already broadcasts a `billing_canary` message to the dashboard; this PR (1) lets it fire a push notification when a warning set appears, and (2) adds an **opt-in** datacenter-egress check that warns when a subscription-billed provider runs from a cloud host (a documented ~20-minute-ban signal per the June-15 audit).

## What changed

- **`get-public-ip.js` (new)** — best-effort, fail-open public egress IP resolver. Used **only** when the operator opts in via `config.billing.egressCheck` — the one place the daemon makes an outbound lookup, so it's consent-gated. Any error (timeout, non-200, junk body) resolves to `null`, never throws.
- **`billing-canary-monitor.js`** — folds the resolved egress IP into the canary on an async `_tick()` (network call, fail-open), and fires a `notify` callback once per **distinct non-empty** warning set — not on all-clear, not on an unchanged re-broadcast.
- **`server-cli.js`** — wires `resolveEgressIp` (only when `config.billing.egressCheck === true`), `getDatacenterPrefixes`, and `notify` → `pushManager.send('billing_warning', …)`.
- **`doctor-billing.js`** — `classifyEgressIp` accepts operator-supplied extra prefixes; `runBillingCanary` threads `datacenterPrefixes` through.
- **`config.js`** — validates `billing.egressCheck` (boolean) and `billing.datacenterPrefixes` (array of non-empty strings), warn-only.
- **`push.js` / `notification-prefs.js`** — register the `billing_warning` category (no rate limit — the monitor's own change-detection is the throttle).

## Off by default

The egress check makes no outbound lookup unless `config.billing.egressCheck` is `true`. Absent the config field, behaviour is identical to #5827.

## Deferred — Discord sink (tracked under #5828)

The Discord status-embed sink is **not** wired here. Its model is per-project session-state oriented (PATCH-per-project lifecycle keyed by `_projectKey`); a daemon-global billing alert doesn't fit without a synthetic project and a parallel code path. Left as the remaining follow-up so #5828 stays open.

## Testing

- `billing-canary-monitor.test.js` — egress OFF by default, `_tick` folds a datacenter hit, fail-open on a throwing resolver, `getDatacenterPrefixes` extends the list, `notify` fires once per distinct set (not on all-clear), re-fires when the set grows, swallows notify failure.
- `get-public-ip.test.js` (new) — IPv4 parse, non-200 → null, junk body → null, throwing fetch → null, abort/timeout → null, configurable url.
- `doctor-billing.test.js` — `classifyEgressIp` extra prefixes; `runBillingCanary` threads `datacenterPrefixes`.
- `config.test.js` — billing egress field validation (valid + each invalid shape).

Full server suite: 9600 pass / 2 fail. Both failures are the known `service.test.js` `getFullServiceStatus` artifact from a live `:8765` daemon answering the probe locally (see project memory) — unrelated to this change; green on CI runners.
