### PR TITLE
feat(server): Discord billing-alert sink (#5828)

### DIFF
--- a/docs/guides/discord-notifications.md
+++ b/docs/guides/discord-notifications.md
@@ -99,7 +99,8 @@ The non-secret knobs live in `~/.chroxy/config.json` under
       "errorColor": 15158332,
       "updateThrottleMs": 15000,
       "heartbeatIntervalMs": 300000,
-      "pruneAfterMs": 86400000
+      "pruneAfterMs": 86400000,
+      "billingAlerts": true
     }
   }
 }
@@ -139,8 +140,32 @@ The non-secret knobs live in `~/.chroxy/config.json` under
   Pruning only drops the bookkeeping entry — the last Discord message
   (typically the final offline embed) stays in the channel as a record.
 
+- **`billingAlerts`** — kill-switch for the billing-alert message (see below).
+  Default `true` when a webhook is configured; set `false` to keep billing
+  alerts off Discord while the per-project status embed stays on.
+
 See [packages/server/CONFIG.md](../../packages/server/CONFIG.md#discord-notifications-notificationsdiscord)
 for the full key reference.
+
+## Billing alerts
+
+Separate from the per-project status embed, chroxy posts a single **daemon-global
+billing-alert message** when the billing canary (the 2026-06-15
+programmatic-credit early-warning system) fires — for example a silently-metered
+default provider, a `claude-tui` session reclassified to metered credits, or a
+datacenter-egress ban signal. This is *not* a session state, so it does not touch
+the status embed: it is its own message.
+
+- A new or changed warning set **deletes the old alert and posts a fresh one**, so
+  Discord re-notifies and the alert surfaces at the bottom of the channel.
+- The same warning set again is a no-op (no repeat spam).
+- When the warnings clear, the alert message is **edited in place to a green
+  "Billing alerts cleared" embed**, so the channel reflects the resolved state.
+
+Billing alerts flow through the same pipeline gating as everything else — mute
+the `billing_warning` category or set quiet hours and they fall silent like any
+other category. The datacenter-egress part of the canary is itself opt-in
+(`billing.egressCheck`); see the billing canary docs.
 
 ## Where state lives
 
@@ -150,6 +175,11 @@ atomically. Deleting the file is safe — the next event posts a fresh status
 message. Entries untouched for longer than `pruneAfterMs` (24h by default)
 are swept automatically — on startup and on every subsequent load — so the
 file stays bounded even under heavy project/session rotation.
+
+The billing-alert message tracks its own id separately in
+`~/.chroxy/discord-billing-state.json` (one message, not per-project), so it
+never collides with the status store. Deleting it is safe — the next billing
+warning posts fresh.
 
 ## External sessions via `POST /api/events`
 

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -518,7 +518,8 @@ The non-secret knobs live under `notifications.discord` in `config.json`:
       "errorColor": 15158332,
       "updateThrottleMs": 15000,
       "heartbeatIntervalMs": 300000,
-      "pruneAfterMs": 86400000
+      "pruneAfterMs": 86400000,
+      "billingAlerts": true
     }
   }
 }
@@ -534,9 +535,11 @@ The non-secret knobs live under `notifications.discord` in `config.json`:
 | `updateThrottleMs` | number | Minimum interval between same-state routine embed updates per project (default `15000`; state changes always go out) |
 | `heartbeatIntervalMs` | number | Elapsed-time footer refresh interval for live embeds — offline embeds are final and never re-PATCHed (default `300000`; `0` disables; minimum `10000`) |
 | `pruneAfterMs` | number | Retention for state-store entries: entries untouched longer than this are dropped on load (default `86400000` / 24h; `0` disables; minimum `60000` / 60s — smaller values fall back to the default, since a retention shorter than the gap between events prunes the tracked message id in between and turns the embed into message-per-event spam; the last Discord message is kept). Heartbeat refreshes don't reset the clock — only real pipeline events do |
+| `billingAlerts` | boolean | Kill-switch for the daemon-global billing-alert message (the 2026-06-15 billing canary). Default `true` when a webhook is configured; `false` keeps billing alerts off Discord while the per-project status embed stays on |
 
 Status-message state (message ids, current state per project) persists in
-`~/.chroxy/discord-webhook-state.json`. Full setup walkthrough:
+`~/.chroxy/discord-webhook-state.json`; the billing-alert message tracks its own
+id in `~/.chroxy/discord-billing-state.json`. Full setup walkthrough:
 [docs/guides/discord-notifications.md](../../docs/guides/discord-notifications.md).
 
 ## Examples

--- a/packages/server/src/billing-canary-monitor.js
+++ b/packages/server/src/billing-canary-monitor.js
@@ -45,7 +45,10 @@ export class BillingCanaryMonitor {
    * @param {() => string[]} [opts.getDatacenterPrefixes] - extra IPv4 prefixes
    *   (config.billing.datacenterPrefixes) merged into the egress classifier.
    * @param {(warnings: Array) => void} [opts.notify] - #5828: fired when the warning
-   *   SET changes to a non-empty state (e.g. push notification). Not fired on all-clear.
+   *   SET changes (e.g. push notification). Called with the non-empty warning array
+   *   for each distinct alert state, and once with an EMPTY array on the
+   *   non-empty→empty (all-clear) transition so a sink can repaint "resolved". Not
+   *   fired on an unchanged re-broadcast, nor on a clear that follows startup.
    */
   constructor({ getSessions, getDefaultProvider, getApiKeyAuth, broadcast, intervalMs = DEFAULT_INTERVAL_MS, nowFn = Date.now, logger, resolveEgressIp, getDatacenterPrefixes, notify } = {}) {
     this._getSessions = getSessions || (() => [])
@@ -107,21 +110,33 @@ export class BillingCanaryMonitor {
         this._log?.warn?.(`billing-canary broadcast failed: ${String(err?.message || err)}`)
       }
     }
-    // #5828: fire `notify` (e.g. push) when the warning SET changes to a
-    // non-empty state — once per distinct warning state, NOT on all-clear and
-    // NOT on an unchanged re-broadcast. Signature includes the message so a
-    // meaning change with the same code re-notifies (e.g. DATACENTER_EGRESS with
-    // a new egress IP, or SILENT_METERED_DEFAULT for a different provider) —
-    // mirrors the dashboard dismissal signature.
+    // #5828: fire `notify` (e.g. push) when the warning SET changes — once per
+    // distinct non-empty state, AND once on the non-empty→empty (all-clear)
+    // transition with an empty array, so a downstream sink can repaint a
+    // "resolved" state. NOT fired on an unchanged re-broadcast, and NOT fired on
+    // a clear that follows startup (never warned → no spurious all-clear). The
+    // signature includes the message so a meaning change with the same code
+    // re-notifies (e.g. DATACENTER_EGRESS with a new egress IP, or
+    // SILENT_METERED_DEFAULT for a different provider) — mirrors the dashboard
+    // dismissal signature.
     const warnKey = snapshot.warnings
       .map((w) => `${w.code} ${w.sessionId ?? ''} ${w.costUsd ?? ''} ${w.message ?? ''}`)
       .sort()
       .join('|')
     if (warnKey !== this._lastWarnKey) {
+      const prevKey = this._lastWarnKey // null on startup; a non-empty signature otherwise
       this._lastWarnKey = warnKey
-      if (snapshot.warnings.length > 0 && this._notify) {
+      if (this._notify) {
         try {
-          this._notify(snapshot.warnings)
+          if (snapshot.warnings.length > 0) {
+            this._notify(snapshot.warnings)
+          } else if (prevKey) {
+            // Transition from a non-empty set to all-clear. prevKey is null only
+            // at startup (never warned), so a fresh clean daemon never fires a
+            // spurious all-clear; prevKey can never be '' here (that would equal
+            // the current empty warnKey and skip this branch).
+            this._notify([])
+          }
         } catch (err) {
           this._log?.warn?.(`billing-canary notify failed: ${String(err?.message || err)}`)
         }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -520,6 +520,13 @@ function validateDiscordNotificationsBlock(discord, warnings) {
     warnings.push(`Invalid value for 'notifications.discord.botName': expected a non-empty string`)
   }
 
+  // #5828: kill-switch for the Discord billing-alert sink. Default ON when a
+  // webhook resolves; set false to keep billing alerts off Discord while the
+  // status embed stays on.
+  if (Object.prototype.hasOwnProperty.call(discord, 'billingAlerts') && typeof discord.billingAlerts !== 'boolean') {
+    warnings.push(`Invalid value for 'notifications.discord.billingAlerts': expected a boolean, got ${JSON.stringify(discord.billingAlerts)}`)
+  }
+
   const isValidColor = (v) => Number.isInteger(v) && v >= 0 && v <= MAX_DISCORD_COLOR
   for (const key of ['defaultColor', 'permissionColor', 'errorColor']) {
     if (Object.prototype.hasOwnProperty.call(discord, key) && !isValidColor(discord[key])) {

--- a/packages/server/src/notifications/discord-billing-sink.js
+++ b/packages/server/src/notifications/discord-billing-sink.js
@@ -188,15 +188,22 @@ export class DiscordBillingSink extends NotificationSink {
     const webhookUrl = this._configuredUrl()
     if (!webhookUrl || !this._enabled) return true // unconfigured — registry normally skips us anyway
 
+    const data = notification.data || {}
+    const resolved = data.resolved === true
+
     const now0 = context.now ?? this._now()
     const isCategoryEnabled = context.isCategoryEnabled ?? (() => true)
     const isInQuietHours = context.isInQuietHours ?? (() => false)
     const shouldBypassQuietHours = context.shouldBypassQuietHours ?? (() => false)
     if (!isCategoryEnabled(BILLING_CATEGORY, null)) return true
-    if (isInQuietHours(now0, null) && !shouldBypassQuietHours(BILLING_CATEGORY, null)) return true
+    // Quiet hours gate a NEW alert (a ping), NOT the all-clear: the resolved
+    // repaint is a silent in-place PATCH of an existing message (state
+    // reconciliation, not a notification), so suppressing it would leave a stale
+    // red embed when warnings clear overnight, until the next distinct alert. The
+    // monitor fires the all-clear exactly once, so a dropped one is never retried
+    // — it must not be gated here (#5833). A NEW alert still respects quiet hours.
+    if (!resolved && isInQuietHours(now0, null) && !shouldBypassQuietHours(BILLING_CATEGORY, null)) return true
 
-    const data = notification.data || {}
-    const resolved = data.resolved === true
     const state = this._loadState()
 
     try {
@@ -292,6 +299,9 @@ export class DiscordBillingSink extends NotificationSink {
       fields.push({ name: resolved ? 'Resolved' : 'Warnings', value: escapeAndCap(body), inline: false })
     }
     if (!resolved && codes.length > 0) {
+      // 200 is a deliberate short cap — codes are short identifiers
+      // (SILENT_METERED_DEFAULT, …); a handful never approaches the 1024 field
+      // limit, and a runaway list is fine to truncate.
       fields.push({ name: 'Codes', value: escapeAndCap(codes.join(', '), 200), inline: false })
     }
     const title = resolved

--- a/packages/server/src/notifications/discord-billing-sink.js
+++ b/packages/server/src/notifications/discord-billing-sink.js
@@ -1,0 +1,313 @@
+/**
+ * DiscordBillingSink — daemon-global billing-alert message for Discord (#5828).
+ *
+ * The billing canary (doctor-billing.js / billing-canary-monitor.js) is about
+ * the DAEMON's billing posture — a silently-metered default provider, a
+ * datacenter egress ban-signal, a claude-tui session reclassified to metered
+ * credits. That is NOT a per-session lifecycle state, so it must NOT go through
+ * DiscordWebhookSink's per-project status state machine (idle/online/offline/…):
+ * a billing warning has no project, and routing it there would clobber a live
+ * session's status embed.
+ *
+ * This sink is therefore a separate, self-contained delivery channel that keeps
+ * ONE global "billing alert" message, independent of any session:
+ *
+ *   - a new / changed non-empty warning set → DELETE the old message + POST a
+ *     new one (re-ping, so Discord re-notifies and the alert surfaces at the
+ *     bottom of the channel)
+ *   - the same warning set again → no-op (dedup; the monitor already fires once
+ *     per distinct set, this is defense-in-depth against a double fan-out from a
+ *     supervisor + server both running a PushManager)
+ *   - all-clear (`data.resolved`) → PATCH the message to a green "resolved"
+ *     embed so the channel reflects the cleared state in place
+ *
+ * It plugs into the same SinkRegistry fan-out as the other sinks, so it inherits
+ * PushManager's shared gating (the `billing_warning` category prefs, quiet
+ * hours, rate limit) for free — no pipeline change. It only ever handles the
+ * `billing_warning` category; every other notification is skipped, so it never
+ * double-handles a session event the status sink owns.
+ *
+ * State (one global message, NOT per-project) lives in its own tiny JSON file
+ * under ~/.chroxy/, read fresh per send so a supervisor's short-lived
+ * PushManager and the long-lived server converge on the same message id rather
+ * than fighting over a cached copy — the same convergence trick the status sink
+ * uses. The webhook URL is a SECRET, sourced from the env / 0600
+ * credentials.json via discord-credentials.js, never from config.json, never
+ * logged.
+ */
+
+import { readFileSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import { writeFileRestricted } from '../platform.js'
+import { createLogger } from '../logger.js'
+import { sleep } from '../utils/sleep.js'
+import { NotificationSink } from './sink.js'
+import {
+  cachedResolveDiscordWebhookUrl,
+  isValidDiscordWebhookUrl,
+} from '../discord-credentials.js'
+import {
+  DEFAULT_ERROR_COLOR,
+  DEFAULT_ONLINE_COLOR,
+  isValidColor,
+  escapeAndCap,
+  apiBase,
+  fetchWithDiscordRetry,
+} from './discord-webhook-client.js'
+
+const log = createLogger('discord')
+
+const BILLING_CATEGORY = 'billing_warning'
+
+export class DiscordBillingSink extends NotificationSink {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.statePath] - Billing-message state file. Defaults to
+   *   ~/.chroxy/discord-billing-state.json (resolved lazily so tests that mutate
+   *   HOME, and the test sandbox guard, behave). Tests MUST inject a temp path.
+   * @param {string} [opts.botName] - Webhook display name + footer label.
+   * @param {boolean} [opts.billingAlerts] - Kill-switch
+   *   (notifications.discord.billingAlerts). Default ON when a webhook resolves;
+   *   set false to keep billing alerts off Discord while the status sink stays on.
+   * @param {number} [opts.alertColor] - Sidebar color for an active alert
+   *   (default: red).
+   * @param {number} [opts.resolvedColor] - Sidebar color for the cleared embed
+   *   (default: green).
+   * @param {Function} [opts.resolveWebhookUrl] - Injection seam for tests;
+   *   defaults to the env > 0600-credentials.json resolver.
+   * @param {Function} [opts.sleepImpl] - Injection seam for tests (429/backoff waits).
+   * @param {Function} [opts.now] - Clock seam for tests; defaults to Date.now.
+   */
+  constructor({
+    statePath = null,
+    botName = 'Chroxy',
+    billingAlerts = true,
+    alertColor = DEFAULT_ERROR_COLOR,
+    resolvedColor = DEFAULT_ONLINE_COLOR,
+    resolveWebhookUrl = cachedResolveDiscordWebhookUrl,
+    sleepImpl = sleep,
+    now = Date.now,
+  } = {}) {
+    super({ name: 'discord-billing' })
+    this._statePath = statePath || null
+    this._botName = typeof botName === 'string' && botName.length > 0 ? botName.slice(0, 80) : 'Chroxy'
+    this._enabled = billingAlerts !== false
+    this._alertColor = isValidColor(alertColor) ? alertColor : DEFAULT_ERROR_COLOR
+    this._resolvedColor = isValidColor(resolvedColor) ? resolvedColor : DEFAULT_ONLINE_COLOR
+    this._resolveWebhookUrl = resolveWebhookUrl
+    this._sleep = sleepImpl
+    this._now = now
+  }
+
+  /**
+   * Sink contract: configured iff billing alerts are enabled AND a syntactically
+   * valid webhook URL resolves. Off when either is missing — the registry then
+   * never asks this sink to send.
+   */
+  isConfigured() {
+    return this._enabled && this._configuredUrl() != null
+  }
+
+  /** Resolve + validate the webhook URL, or null. Never throws, never logs the URL. */
+  _configuredUrl() {
+    let resolved
+    try {
+      resolved = this._resolveWebhookUrl()
+    } catch {
+      return null
+    }
+    const url = resolved?.url
+    return typeof url === 'string' && isValidDiscordWebhookUrl(url) ? url : null
+  }
+
+  // -- State persistence ----------------------------------------------------
+
+  _resolvedStatePath() {
+    return this._statePath || join(homedir(), '.chroxy', 'discord-billing-state.json')
+  }
+
+  /** Load the single-message store fresh from disk (read-per-send). */
+  _loadState() {
+    try {
+      const data = JSON.parse(readFileSync(this._resolvedStatePath(), 'utf-8'))
+      if (data && typeof data === 'object' && !Array.isArray(data)) {
+        return {
+          messageId: typeof data.messageId === 'string' ? data.messageId : null,
+          warnSignature: typeof data.warnSignature === 'string' ? data.warnSignature : null,
+          firstSeenTs: Number.isFinite(data.firstSeenTs) ? data.firstSeenTs : null,
+        }
+      }
+    } catch {
+      // Missing or corrupt — start fresh; the next successful send rewrites it.
+    }
+    return { messageId: null, warnSignature: null, firstSeenTs: null }
+  }
+
+  /** Atomic persist (temp+rename, 0600) — mirrors how push.js persists tokens. */
+  _persistState(state) {
+    try {
+      const path = this._resolvedStatePath()
+      mkdirSync(dirname(path), { recursive: true })
+      writeFileRestricted(path, JSON.stringify({ version: 1, ...state }))
+    } catch (err) {
+      // State-file failure must not fail delivery — worst case the next event
+      // POSTs a duplicate alert message instead of PATCHing.
+      log.error(`Failed to persist Discord billing state: ${err.message}`)
+    }
+  }
+
+  /**
+   * Stable signature of a warning set, used to dedup repeat fan-outs of the
+   * same alert. Includes the codes AND the message body so a same-code meaning
+   * change (a new egress IP, a different metered provider) re-pings — mirrors
+   * the billing-canary monitor's own notify change-detection.
+   */
+  _signature(codes, body) {
+    const codePart = Array.isArray(codes)
+      ? codes.filter((c) => typeof c === 'string').slice().sort().join(',')
+      : ''
+    return `${codePart}|${typeof body === 'string' ? body : ''}`
+  }
+
+  // -- Sink contract --------------------------------------------------------
+
+  /**
+   * Deliver a billing alert (or its all-clear). Only the `billing_warning`
+   * category is handled; everything else is skipped so the status sink keeps
+   * sole ownership of session lifecycle events.
+   *
+   * Resolves `false` ONLY on a hard channel failure (final non-2xx, network
+   * throw), per the sink contract. The per-DEVICE context evaluators are run
+   * once with `deviceId = null` (a webhook has no device identity), matching how
+   * the status sink applies the global mute / quiet-hours setting.
+   */
+  async send(notification, context = {}) {
+    if (notification?.category !== BILLING_CATEGORY) return true // not ours — skip
+
+    const webhookUrl = this._configuredUrl()
+    if (!webhookUrl || !this._enabled) return true // unconfigured — registry normally skips us anyway
+
+    const now0 = context.now ?? this._now()
+    const isCategoryEnabled = context.isCategoryEnabled ?? (() => true)
+    const isInQuietHours = context.isInQuietHours ?? (() => false)
+    const shouldBypassQuietHours = context.shouldBypassQuietHours ?? (() => false)
+    if (!isCategoryEnabled(BILLING_CATEGORY, null)) return true
+    if (isInQuietHours(now0, null) && !shouldBypassQuietHours(BILLING_CATEGORY, null)) return true
+
+    const data = notification.data || {}
+    const resolved = data.resolved === true
+    const state = this._loadState()
+
+    try {
+      if (resolved) {
+        // All-clear. Nothing tracked → nothing to repaint.
+        if (!state.messageId) return true
+        return await this._patchResolved(webhookUrl, notification, state)
+      }
+
+      const signature = this._signature(data.codes, notification.body)
+      // Same alert already showing → no-op (dedup against a double fan-out).
+      if (state.messageId && state.warnSignature === signature) return true
+      // New / changed alert → re-ping (delete old + POST new).
+      return await this._repost(webhookUrl, notification, state, signature)
+    } catch (err) {
+      log.error(`Discord billing alert failed: ${err?.message || err}`)
+      return false
+    }
+  }
+
+  // -- Discord message operations -------------------------------------------
+
+  /** DELETE the old alert (best effort) + POST a fresh one → re-ping. */
+  async _repost(webhookUrl, notification, state, signature) {
+    const base = apiBase(webhookUrl)
+    if (state.messageId) {
+      try {
+        await this._discordFetch(`${base}/messages/${state.messageId}`, { method: 'DELETE' }, { retries: 1 })
+      } catch {
+        // best-effort — worst case the old message lingers; the POST still pings.
+      }
+    }
+    const now = this._now()
+    const payload = this._buildPayload(notification, { resolved: false })
+    const res = await this._discordFetch(`${base}?wait=true`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (!res.ok) {
+      log.error(`Discord billing POST failed (HTTP ${res.status})`)
+      return false
+    }
+    let messageId = null
+    try {
+      messageId = (await res.json())?.id ?? null
+    } catch {
+      // 204 / unparsable — posted but untrackable; next event self-heals.
+    }
+    this._persistState({ messageId, warnSignature: signature, firstSeenTs: now })
+    return true
+  }
+
+  /** PATCH the tracked alert to a green "resolved" embed. */
+  async _patchResolved(webhookUrl, notification, state) {
+    const base = apiBase(webhookUrl)
+    const payload = this._buildPayload(notification, { resolved: true })
+    const res = await this._discordFetch(`${base}/messages/${state.messageId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (res.status === 404) {
+      // Message deleted externally — forget it so the next alert POSTs fresh.
+      // No healing POST: re-creating a message just to mark it resolved would
+      // leave an orphan green embed for an alert nobody saw.
+      this._persistState({ messageId: null, warnSignature: null, firstSeenTs: null })
+      return true
+    }
+    if (!res.ok) {
+      log.error(`Discord billing PATCH failed (HTTP ${res.status})`)
+      return false
+    }
+    // Clear the signature so the next warning (even an identical one) re-pings.
+    this._persistState({ messageId: state.messageId, warnSignature: null, firstSeenTs: null })
+    return true
+  }
+
+  /** Delegate to the shared client's fetch policy, passing the injected sleep seam. */
+  async _discordFetch(url, options, opts = {}) {
+    return fetchWithDiscordRetry(url, options, { sleepImpl: this._sleep, ...opts })
+  }
+
+  // -- Embed building --------------------------------------------------------
+
+  _buildPayload(notification, { resolved }) {
+    const body = typeof notification.body === 'string' ? notification.body : ''
+    const codes = Array.isArray(notification?.data?.codes)
+      ? notification.data.codes.filter((c) => typeof c === 'string')
+      : []
+    const fields = []
+    if (body) {
+      fields.push({ name: resolved ? 'Resolved' : 'Warnings', value: escapeAndCap(body), inline: false })
+    }
+    if (!resolved && codes.length > 0) {
+      fields.push({ name: 'Codes', value: escapeAndCap(codes.join(', '), 200), inline: false })
+    }
+    const title = resolved
+      ? `\u{2705} ${this._botName} — Billing alerts cleared`
+      : codes.length > 1
+        ? `\u{26A0}\u{FE0F} ${this._botName} — Billing alert (${codes.length})`
+        : `\u{26A0}\u{FE0F} ${this._botName} — Billing alert`
+    return {
+      username: this._botName,
+      embeds: [{
+        title,
+        color: resolved ? this._resolvedColor : this._alertColor,
+        fields,
+        footer: { text: this._botName },
+        timestamp: new Date(this._now()).toISOString(),
+      }],
+    }
+  }
+}

--- a/packages/server/src/notifications/discord-webhook-client.js
+++ b/packages/server/src/notifications/discord-webhook-client.js
@@ -1,0 +1,187 @@
+/**
+ * discord-webhook-client.js — channel-level Discord webhook primitives shared
+ * by every Discord sink (#5828).
+ *
+ * Extracted verbatim from discord-webhook-sink.js so the per-project status sink
+ * and the daemon-global billing-alert sink share ONE tested implementation of
+ * the fetch policy, retry/429 handling, id/token extraction, and the markdown
+ * escaping used to render free-text into embed fields. This is a pure-swap
+ * extraction: the behaviour is byte-for-byte the status sink's previous private
+ * helpers — the status sink now delegates to these.
+ *
+ * None of this touches sink state (no per-project store, no heartbeat) — it is
+ * just the wire layer, so a sink with a completely different lifecycle (the
+ * billing sink keeps a single global message, not a per-project state machine)
+ * can reuse it without inheriting the status state machine.
+ */
+
+import { sleep, backoffDelay } from '../utils/sleep.js'
+import { extractWebhookIdToken } from '../discord-credentials.js'
+
+// Same envelope as the Expo sink's fetch policy; the 429 handling is the
+// Discord-specific addition.
+export const FETCH_TIMEOUT_MS = 10_000
+export const MAX_RETRIES = 3
+export const BACKOFF_BASE_MS = 1_000
+// Ceiling on how long a single 429 retry_after is honoured. Discord webhook
+// buckets are normally sub-second; a multi-minute retry_after means we're
+// globally limited and should give up (the call resolves with the 429 response;
+// the pipeline retries on the next event) rather than hold the fan-out hostage.
+export const MAX_RETRY_AFTER_MS = 30_000
+
+// Embed sidebar color defaults — ported from claude-code-notify
+// (colors.conf.example + the CLAUDE_NOTIFY_*_COLOR defaults).
+export const DEFAULT_PROJECT_COLOR = 5793266    // Discord blurple #5865F2
+export const DEFAULT_PERMISSION_COLOR = 16753920 // orange #FFA500
+export const DEFAULT_ERROR_COLOR = 15158332     // red #E74C3C
+export const DEFAULT_ONLINE_COLOR = 3066993     // green #2ECC71
+export const DEFAULT_OFFLINE_COLOR = 15158332   // red #E74C3C
+export const MAX_COLOR = 16777215               // 24-bit RGB
+
+/** Format seconds into a human-readable duration (port of format_duration). */
+export function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0s'
+  seconds = Math.floor(seconds)
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
+}
+
+export function isValidColor(color) {
+  return Number.isInteger(color) && color >= 0 && color <= MAX_COLOR
+}
+
+export function truncate(text, max = 1000) {
+  if (typeof text !== 'string') return ''
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text
+}
+
+/**
+ * Escape Discord markdown metacharacters so free-text user/transcript content
+ * (task descriptions, ScheduleWakeup reasons, session names, billing messages)
+ * renders literally in an embed field instead of being styled or swallowed
+ * (#5475).
+ *
+ * Example: a task described as `watch dist/*_test.js` would otherwise render
+ * with the `*…*`/`_…_` runs interpreted as italics, eating characters.
+ *
+ * The sink is webhook-based and intentionally dependency-free, so this is a
+ * local 5-liner rather than pulling in discord.js's escapeMarkdown. We escape
+ * the inline-format set (`\\ * _ ~ \` |`) plus a leading `>` (blockquote — only
+ * meaningful at line start; we escape every `>` for simplicity, which is
+ * harmless mid-line). Backslash is escaped FIRST so we don't double-escape the
+ * escapes we then insert.
+ *
+ * Escaping the already-truncated string keeps every inserted `\X` pair intact
+ * (escaping first could split a `\X` across the cut and leave a dangling `\`),
+ * so callers truncate FIRST and escape SECOND — see escapeAndCap.
+ */
+export function escapeMarkdown(text) {
+  if (typeof text !== 'string') return ''
+  return text.replace(/[\\*_~`|>]/g, '\\$&')
+}
+
+/**
+ * Truncate a free-text field, escape its markdown, and clamp the FINAL escaped
+ * string to `max` chars — the value that actually goes on the wire (#5475).
+ *
+ * Escaping after truncation can up to double the length (all-metachar input →
+ * ~2×). Discord's embed-field hard limit is 1024, so an un-clamped escaped
+ * value could exceed it and get the whole webhook PATCH/POST rejected with a
+ * 400. We re-truncate the escaped result to `max`; if the cut lands on a lone
+ * `\` inserted by escaping (i.e. the escape backslash without its metachar),
+ * we drop it so the field never ends in a dangling backslash.
+ *
+ * The inner truncate() appends a plain `...` marker (no metacharacters), so it
+ * is neither escaped nor split by the re-truncate.
+ */
+export function escapeAndCap(text, max = 1000) {
+  const escaped = escapeMarkdown(truncate(text, max))
+  if (escaped.length <= max) return escaped
+  const cut = escaped.slice(0, max)
+  // escapeMarkdown emits `\` only immediately before a metacharacter, so every
+  // backslash in `escaped` belongs to a `\X` pair. A run of trailing backslashes
+  // of ODD length means the final `\` is a lone escape whose metachar fell past
+  // the cut; drop it so the field never ends in a dangling escape. An EVEN run
+  // is whole `\\` pairs (escaped literal backslashes) and stays intact.
+  const trailing = cut.length - cut.replace(/\\+$/, '').length
+  return trailing % 2 === 1 ? cut.slice(0, -1) : cut
+}
+
+/** Build the Discord webhook API base from a validated webhook URL. */
+export function apiBase(webhookUrl) {
+  const parts = extractWebhookIdToken(webhookUrl)
+  // Callers validate the URL shape up front; belt-and-braces.
+  if (!parts) throw new Error('webhook URL failed id/token extraction')
+  return `https://discord.com/api/webhooks/${parts.id}/${parts.token}`
+}
+
+/**
+ * Extract the wait from a 429 response. Discord sends `retry_after` in
+ * SECONDS (float) in the JSON body and a Retry-After header (also seconds).
+ * Defaults to 2s when unparsable; clamped to MAX_RETRY_AFTER_MS.
+ */
+export async function retryAfterMs(res) {
+  let seconds = NaN
+  try {
+    const header = res.headers?.get?.('retry-after')
+    if (header != null) seconds = Number.parseFloat(header)
+  } catch { /* fall through to body */ }
+  if (!Number.isFinite(seconds)) {
+    try {
+      seconds = Number.parseFloat((await res.json())?.retry_after)
+    } catch { /* fall through to default */ }
+  }
+  if (!Number.isFinite(seconds) || seconds < 0) seconds = 2
+  return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS)
+}
+
+/**
+ * Fetch with timeout + bounded retry, Discord flavor:
+ *   - 429 → honour retry_after (JSON body seconds, or Retry-After header),
+ *     capped at MAX_RETRY_AFTER_MS, then retry
+ *   - 5xx / network error / timeout → exponential backoff retry
+ *   - other 4xx → return immediately (not retryable)
+ * Throws only when the LAST attempt threw (caller maps that to `false`).
+ *
+ * @param {string} url
+ * @param {object} options - fetch init (method/headers/body)
+ * @param {object} [opts]
+ * @param {number} [opts.retries] - max attempts (default MAX_RETRIES).
+ * @param {Function} [opts.sleepImpl] - injection seam for tests (429/backoff waits).
+ * @param {Function} [opts.fetchImpl] - injection seam for tests (defaults to global fetch).
+ */
+export async function fetchWithDiscordRetry(url, options, { retries = MAX_RETRIES, sleepImpl = sleep, fetchImpl = fetch } = {}) {
+  let res
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    try {
+      res = await fetchImpl(url, { ...options, signal: controller.signal })
+    } catch (err) {
+      clearTimeout(timer)
+      if (attempt < retries) {
+        await sleepImpl(backoffDelay(attempt, BACKOFF_BASE_MS))
+        continue
+      }
+      throw err
+    }
+    clearTimeout(timer)
+
+    if (res.status === 429) {
+      if (attempt < retries) {
+        await sleepImpl(await retryAfterMs(res))
+        continue
+      }
+      return res
+    }
+    if (res.ok || (res.status >= 400 && res.status < 500)) return res
+    // 5xx
+    if (attempt < retries) {
+      await sleepImpl(backoffDelay(attempt, BACKOFF_BASE_MS))
+      continue
+    }
+    return res
+  }
+  return res
+}

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -46,26 +46,34 @@ import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import { writeFileRestricted } from '../platform.js'
 import { createLogger } from '../logger.js'
-import { sleep, backoffDelay } from '../utils/sleep.js'
+import { sleep } from '../utils/sleep.js'
 import { NotificationSink } from './sink.js'
 import {
   cachedResolveDiscordWebhookUrl,
   isValidDiscordWebhookUrl,
-  extractWebhookIdToken,
 } from '../discord-credentials.js'
+// #5828: the channel-level wire primitives (fetch policy, 429 handling, id/token
+// extraction, markdown escaping, embed colors) moved to a shared client so the
+// billing-alert sink can reuse them. The status sink delegates to them below —
+// this is a pure-swap of the previous private helpers.
+import {
+  DEFAULT_PROJECT_COLOR,
+  DEFAULT_PERMISSION_COLOR,
+  DEFAULT_ERROR_COLOR,
+  DEFAULT_ONLINE_COLOR,
+  DEFAULT_OFFLINE_COLOR,
+  isValidColor,
+  escapeAndCap,
+  formatDuration,
+  apiBase,
+  fetchWithDiscordRetry,
+} from './discord-webhook-client.js'
 
 const log = createLogger('discord')
 
-// Same envelope as the Expo sink's fetch policy; the 429 handling is the
-// Discord-specific addition.
-const FETCH_TIMEOUT_MS = 10_000
-const MAX_RETRIES = 3
-const BACKOFF_BASE_MS = 1_000
-// Ceiling on how long a single 429 retry_after is honoured. Discord webhook
-// buckets are normally sub-second; a multi-minute retry_after means we're
-// globally limited and should give up (send() resolves false; the pipeline
-// retries on the next event) rather than hold the fan-out hostage.
-const MAX_RETRY_AFTER_MS = 30_000
+// Re-exported for back-compat: the status sink's test imports formatDuration
+// from here. The implementation now lives in discord-webhook-client.js.
+export { formatDuration }
 
 // #5429/#5434: retention for state-store entries. Project keys fall back to
 // session ids (and Phase 3 ingest accepts arbitrary project names), so
@@ -97,16 +105,6 @@ const MIN_PRUNE_AFTER_MS = 60_000 // 60s
 // state, resetting the silence clock automatically.
 const DEFAULT_STALE_AFTER_MS = 10 * 60_000   // 10m
 const DEFAULT_OFFLINE_AFTER_MS = 30 * 60_000 // 30m
-
-// Embed sidebar color defaults — ported from claude-code-notify
-// (colors.conf.example + the CLAUDE_NOTIFY_*_COLOR defaults).
-const DEFAULT_PROJECT_COLOR = 5793266   // Discord blurple #5865F2
-const DEFAULT_PERMISSION_COLOR = 16753920 // orange #FFA500
-const DEFAULT_ERROR_COLOR = 15158332    // red #E74C3C
-// #5413 Phase 3 — session lifecycle states (bash CLAUDE_NOTIFY_*_COLOR defaults)
-const DEFAULT_ONLINE_COLOR = 3066993    // green #2ECC71
-const DEFAULT_OFFLINE_COLOR = 15158332  // red #E74C3C
-const MAX_COLOR = 16777215              // 24-bit RGB
 
 // Pipeline notification category → embed state. Phase 2 maps chroxy's own
 // session events (the categories PushManager.send is called with). The
@@ -148,75 +146,6 @@ const STATE_TITLES = {
   stale: (project) => `\u{23F3} ${project} — Quiet for a while`,
   online: (project) => `\u{1F7E2} ${project} — Session Online`,
   offline: (project) => `\u{1F534} ${project} — Session Offline`,
-}
-
-/** Format seconds into a human-readable duration (port of format_duration). */
-export function formatDuration(seconds) {
-  if (!Number.isFinite(seconds) || seconds < 0) return '0s'
-  seconds = Math.floor(seconds)
-  if (seconds < 60) return `${seconds}s`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
-  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
-}
-
-function isValidColor(color) {
-  return Number.isInteger(color) && color >= 0 && color <= MAX_COLOR
-}
-
-function truncate(text, max = 1000) {
-  if (typeof text !== 'string') return ''
-  return text.length > max ? `${text.slice(0, max - 3)}...` : text
-}
-
-/**
- * Escape Discord markdown metacharacters so free-text user/transcript content
- * (task descriptions, ScheduleWakeup reasons, session names) renders literally
- * in an embed field instead of being styled or swallowed (#5475).
- *
- * Example: a task described as `watch dist/*_test.js` would otherwise render
- * with the `*…*`/`_…_` runs interpreted as italics, eating characters.
- *
- * The sink is webhook-based and intentionally dependency-free, so this is a
- * local 5-liner rather than pulling in discord.js's escapeMarkdown. We escape
- * the inline-format set (`\\ * _ ~ \` |`) plus a leading `>` (blockquote — only
- * meaningful at line start; we escape every `>` for simplicity, which is
- * harmless mid-line). Backslash is escaped FIRST so we don't double-escape the
- * escapes we then insert.
- *
- * Escaping the already-truncated string keeps every inserted `\X` pair intact
- * (escaping first could split a `\X` across the cut and leave a dangling `\`),
- * so callers truncate FIRST and escape SECOND — see escapeAndCap.
- */
-function escapeMarkdown(text) {
-  if (typeof text !== 'string') return ''
-  return text.replace(/[\\*_~`|>]/g, '\\$&')
-}
-
-/**
- * Truncate a free-text field, escape its markdown, and clamp the FINAL escaped
- * string to `max` chars — the value that actually goes on the wire (#5475).
- *
- * Escaping after truncation can up to double the length (all-metachar input →
- * ~2×). Discord's embed-field hard limit is 1024, so an un-clamped escaped
- * value could exceed it and get the whole webhook PATCH/POST rejected with a
- * 400. We re-truncate the escaped result to `max`; if the cut lands on a lone
- * `\` inserted by escaping (i.e. the escape backslash without its metachar),
- * we drop it so the field never ends in a dangling backslash.
- *
- * The inner truncate() appends a plain `...` marker (no metacharacters), so it
- * is neither escaped nor split by the re-truncate.
- */
-function escapeAndCap(text, max = 1000) {
-  const escaped = escapeMarkdown(truncate(text, max))
-  if (escaped.length <= max) return escaped
-  const cut = escaped.slice(0, max)
-  // escapeMarkdown emits `\` only immediately before a metacharacter, so every
-  // backslash in `escaped` belongs to a `\X` pair. A run of trailing backslashes
-  // of ODD length means the final `\` is a lone escape whose metachar fell past
-  // the cut; drop it so the field never ends in a dangling escape. An EVEN run
-  // is whole `\\` pairs (escaped literal backslashes) and stays intact.
-  const trailing = cut.length - cut.replace(/\\+$/, '').length
-  return trailing % 2 === 1 ? cut.slice(0, -1) : cut
 }
 
 export class DiscordWebhookSink extends NotificationSink {
@@ -580,10 +509,8 @@ export class DiscordWebhookSink extends NotificationSink {
   // -- Discord message operations -------------------------------------------
 
   _apiBase(webhookUrl) {
-    const parts = extractWebhookIdToken(webhookUrl)
-    // _configuredUrl() already validated the shape; belt-and-braces.
-    if (!parts) throw new Error('webhook URL failed id/token extraction')
-    return `https://discord.com/api/webhooks/${parts.id}/${parts.token}`
+    // _configuredUrl() already validated the shape; apiBase belt-and-braces.
+    return apiBase(webhookUrl)
   }
 
   /** DELETE the old status message (best effort) + POST a fresh one → re-ping. */
@@ -677,66 +604,11 @@ export class DiscordWebhookSink extends NotificationSink {
   }
 
   /**
-   * Fetch with timeout + bounded retry, Discord flavor:
-   *   - 429 → honour retry_after (JSON body seconds, or Retry-After header),
-   *     capped at MAX_RETRY_AFTER_MS, then retry
-   *   - 5xx / network error / timeout → exponential backoff retry
-   *   - other 4xx → return immediately (not retryable)
-   * Throws only when the LAST attempt threw (caller maps that to `false`).
+   * Delegate to the shared client's fetch policy (429/backoff/timeout), passing
+   * this sink's injected sleep seam so existing tests keep working unchanged.
    */
-  async _discordFetch(url, options, { retries = MAX_RETRIES } = {}) {
-    let res
-    for (let attempt = 1; attempt <= retries; attempt++) {
-      const controller = new AbortController()
-      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-      try {
-        res = await fetch(url, { ...options, signal: controller.signal })
-      } catch (err) {
-        clearTimeout(timer)
-        if (attempt < retries) {
-          await this._sleep(backoffDelay(attempt, BACKOFF_BASE_MS))
-          continue
-        }
-        throw err
-      }
-      clearTimeout(timer)
-
-      if (res.status === 429) {
-        if (attempt < retries) {
-          await this._sleep(await this._retryAfterMs(res))
-          continue
-        }
-        return res
-      }
-      if (res.ok || (res.status >= 400 && res.status < 500)) return res
-      // 5xx
-      if (attempt < retries) {
-        await this._sleep(backoffDelay(attempt, BACKOFF_BASE_MS))
-        continue
-      }
-      return res
-    }
-    return res
-  }
-
-  /**
-   * Extract the wait from a 429 response. Discord sends `retry_after` in
-   * SECONDS (float) in the JSON body and a Retry-After header (also
-   * seconds). Defaults to 2s when unparsable; clamped to MAX_RETRY_AFTER_MS.
-   */
-  async _retryAfterMs(res) {
-    let seconds = NaN
-    try {
-      const header = res.headers?.get?.('retry-after')
-      if (header != null) seconds = Number.parseFloat(header)
-    } catch { /* fall through to body */ }
-    if (!Number.isFinite(seconds)) {
-      try {
-        seconds = Number.parseFloat((await res.json())?.retry_after)
-      } catch { /* fall through to default */ }
-    }
-    if (!Number.isFinite(seconds) || seconds < 0) seconds = 2
-    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS)
+  async _discordFetch(url, options, opts = {}) {
+    return fetchWithDiscordRetry(url, options, { sleepImpl: this._sleep, ...opts })
   }
 
   // -- Embed building --------------------------------------------------------

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -37,6 +37,7 @@ import {
   BACKOFF_BASE_MS,
 } from './notifications/expo-push-sink.js'
 import { DiscordWebhookSink } from './notifications/discord-webhook-sink.js'
+import { DiscordBillingSink } from './notifications/discord-billing-sink.js'
 
 const log = createLogger('push')
 
@@ -103,6 +104,9 @@ export class PushManager {
    *   off by default — `isConfigured()` is true only when a webhook URL
    *   resolves from CHROXY_DISCORD_WEBHOOK_URL or the 0600
    *   ~/.chroxy/credentials.json, so unconfigured setups never touch it.
+   *   #5828: also feeds DiscordBillingSink — `billingStatePath` (its own state
+   *   file, kept separate from the status store) and `billingAlerts` (kill-switch,
+   *   default on when a webhook resolves).
    */
   constructor({ storagePath, prefsPath, discord = {} } = {}) {
     // #4541: notification-prefs path. Optional — when omitted PushManager
@@ -125,6 +129,21 @@ export class PushManager {
     // Expo, gated on configuration via the registry's isConfigured() skip.
     this._discordSink = new DiscordWebhookSink(discord)
     this._sinks.register(this._discordSink)
+    // #5828: the Discord billing-alert sink. Separate from the status sink (a
+    // billing warning is daemon-global, not a per-project session state), with
+    // its OWN state file so it never collides with the status store. Shares the
+    // same webhook + gating; off when no webhook resolves or billingAlerts is
+    // false.
+    this._discordBillingSink = new DiscordBillingSink({
+      statePath: discord.billingStatePath || null,
+      botName: discord.botName,
+      billingAlerts: discord.billingAlerts,
+      // Same channel as the status sink — forward the resolver injection seam so
+      // both sinks see the same webhook (undefined in production → the cached
+      // env/credentials resolver).
+      resolveWebhookUrl: discord.resolveWebhookUrl,
+    })
+    this._sinks.register(this._discordBillingSink)
   }
 
   /**

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -931,7 +931,7 @@ export async function startCliServer(config) {
       // not-delivered return that a bare `.catch()` would drop.
       if (warnings.length === 0) {
         settlePush(
-          pushManager.send('billing_warning', 'Billing alert cleared', 'All billing warnings have cleared.', { resolved: true, codes: [] }),
+          pushManager.send('billing_warning', 'Billing alert cleared', 'All billing warnings have cleared.', { resolved: true }),
           'billing-canary-clear',
           log,
         )

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -746,6 +746,9 @@ export async function startCliServer(config) {
     // notification state in ~/.chroxy.
     discord: {
       statePath: join(homedir(), '.chroxy', 'discord-webhook-state.json'),
+      // #5828: the billing-alert sink keeps its own state file, separate from
+      // the per-project status store above.
+      billingStatePath: join(homedir(), '.chroxy', 'discord-billing-state.json'),
       ...(config.notifications?.discord || {}),
     },
   })
@@ -920,6 +923,20 @@ export async function startCliServer(config) {
     resolveEgressIp: egressCheckEnabled ? () => resolvePublicIp() : undefined,
     getDatacenterPrefixes: () => config.billing?.datacenterPrefixes || [],
     notify: (warnings) => {
+      // #5828: the monitor fires this once per distinct warning SET, plus once
+      // on the non-empty→empty (all-clear) transition with an empty array. An
+      // empty set is the all-clear: send a `resolved` push so the Discord
+      // billing sink repaints its message green (and mobile gets a cleared
+      // note). settlePush (#5702) logs both a thrown error AND a `false`
+      // not-delivered return that a bare `.catch()` would drop.
+      if (warnings.length === 0) {
+        settlePush(
+          pushManager.send('billing_warning', 'Billing alert cleared', 'All billing warnings have cleared.', { resolved: true, codes: [] }),
+          'billing-canary-clear',
+          log,
+        )
+        return
+      }
       // One aggregate push per distinct warning set — billing_warning has no
       // rate limit (RATE_LIMITS), so the monitor's own change-detection is the
       // throttle. Codes ride in `data` for clients that key off them.
@@ -927,8 +944,6 @@ export async function startCliServer(config) {
       const title = count > 1 ? `Billing alert (${count})` : 'Billing alert'
       const body = warnings.map((w) => w.message).join('\n\n')
       const codes = warnings.map((w) => w.code)
-      // settlePush (#5702) logs both a thrown error AND a `false` not-delivered
-      // return (a half-open link), which a bare `.catch()` would drop silently.
       settlePush(pushManager.send('billing_warning', title, body, { codes }), 'billing-canary', log)
     },
   })

--- a/packages/server/tests/billing-canary-monitor.test.js
+++ b/packages/server/tests/billing-canary-monitor.test.js
@@ -145,7 +145,7 @@ test('getDatacenterPrefixes extends the built-in egress list', async () => {
   assert.ok(monitor.current().warnings.some((w) => w.code === 'DATACENTER_EGRESS'))
 })
 
-test('notify fires once per distinct non-empty warning set, not on all-clear', () => {
+test('notify fires once per distinct non-empty set, then once on the clear transition (#5828)', () => {
   const notified = []
   let provider = 'claude-sdk' // metered default → warning
   const { monitor } = make({
@@ -160,9 +160,24 @@ test('notify fires once per distinct non-empty warning set, not on all-clear', (
   monitor.refresh() // unchanged warning set → no re-notify
   assert.equal(notified.length, 1)
 
-  provider = 'claude-tui' // clears → must NOT notify on all-clear
+  provider = 'claude-tui' // clears → fire the all-clear once with an empty array
   monitor.refresh()
-  assert.equal(notified.length, 1)
+  assert.equal(notified.length, 2)
+  assert.deepEqual(notified[1], [])
+
+  monitor.refresh() // stays clear → no repeated all-clear
+  assert.equal(notified.length, 2)
+})
+
+test('notify does NOT fire a spurious all-clear at startup (never warned)', () => {
+  const notified = []
+  const { monitor } = make({
+    getDefaultProvider: () => 'claude-tui', // clean from the start
+    extra: { notify: (w) => notified.push(w) },
+  })
+  monitor.refresh()
+  monitor.refresh()
+  assert.equal(notified.length, 0)
 })
 
 test('notify re-fires when the warning set changes (new code appears)', async () => {

--- a/packages/server/tests/discord-billing-sink.test.js
+++ b/packages/server/tests/discord-billing-sink.test.js
@@ -1,0 +1,244 @@
+// #5828: DiscordBillingSink — the daemon-global billing-alert message. Separate
+// from the per-project status sink: one message, re-pinged on a changed warning
+// set, repainted green on all-clear.
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DiscordBillingSink } from '../src/notifications/discord-billing-sink.js'
+
+const WEBHOOK_ID = '123456789012345678'
+const WEBHOOK_TOKEN = 'aBcDeFgHiJkLmNoPqRsTuVwXyZ-0123456789_abcdefghijklmnopqrstuvwx'
+const WEBHOOK = `https://discord.com/api/webhooks/${WEBHOOK_ID}/${WEBHOOK_TOKEN}`
+
+let originalFetch
+beforeEach(() => { originalFetch = globalThis.fetch })
+afterEach(() => { globalThis.fetch = originalFetch; mock.restoreAll() })
+
+/** Scripted fetch — responses consumed in order; dry script returns 200 + fresh id. */
+function scriptFetch(script = []) {
+  const calls = []
+  let autoId = 0
+  globalThis.fetch = mock.fn(async (url, options = {}) => {
+    calls.push({ url: String(url), method: options.method || 'GET', body: options.body })
+    const next = script.length > 0 ? script.shift() : { status: 200, body: { id: `auto-${++autoId}` } }
+    if (next.throws) throw next.throws
+    const status = next.status ?? 200
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: (h) => next.headers?.[String(h).toLowerCase()] ?? null },
+      json: async () => next.body ?? {},
+    }
+  })
+  return calls
+}
+
+function makeSink(overrides = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'discord-billing-'))
+  const statePath = join(dir, 'billing-state.json')
+  const sink = new DiscordBillingSink({
+    statePath,
+    resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+    sleepImpl: async () => {},
+    now: () => 1_700_000_000_000,
+    ...overrides,
+  })
+  return { sink, dir, statePath }
+}
+
+const readState = (p) => JSON.parse(readFileSync(p, 'utf-8'))
+
+const alert = (codes, body = 'something is metered') => ({
+  category: 'billing_warning',
+  title: 'Billing alert',
+  body,
+  data: { codes },
+})
+const cleared = () => ({
+  category: 'billing_warning',
+  title: 'Billing alert cleared',
+  body: 'All billing warnings have cleared.',
+  data: { resolved: true, codes: [] },
+})
+
+describe('DiscordBillingSink — configuration gating', () => {
+  it('isConfigured() is false without a webhook URL', () => {
+    const { sink } = makeSink({ resolveWebhookUrl: () => null })
+    assert.equal(sink.isConfigured(), false)
+  })
+
+  it('isConfigured() is false when billingAlerts is disabled', () => {
+    const { sink } = makeSink({ billingAlerts: false })
+    assert.equal(sink.isConfigured(), false)
+  })
+
+  it('isConfigured() is true with a webhook URL and the default kill-switch', () => {
+    const { sink } = makeSink()
+    assert.equal(sink.isConfigured(), true)
+  })
+
+  it('a throwing resolver never throws out of isConfigured()', () => {
+    const { sink } = makeSink({ resolveWebhookUrl: () => { throw new Error('boom') } })
+    assert.equal(sink.isConfigured(), false)
+  })
+})
+
+describe('DiscordBillingSink — delivery', () => {
+  it('skips non-billing categories (status sink owns those)', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    const ok = await sink.send({ category: 'activity_update', title: 't', body: 'b', data: {} })
+    assert.equal(ok, true)
+    assert.equal(calls.length, 0)
+  })
+
+  it('no-op when unconfigured', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink({ resolveWebhookUrl: () => null })
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    assert.equal(ok, true)
+    assert.equal(calls.length, 0)
+  })
+
+  it('first alert POSTs a new message and persists id + signature', async () => {
+    const calls = scriptFetch([{ status: 200, body: { id: 'msg-1' } }])
+    const { sink, statePath } = makeSink()
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    assert.equal(ok, true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].method, 'POST')
+    assert.match(calls[0].url, /\?wait=true$/)
+    const st = readState(statePath)
+    assert.equal(st.messageId, 'msg-1')
+    assert.ok(st.warnSignature.includes('SILENT_METERED_DEFAULT'))
+  })
+
+  it('the same alert again is a no-op (dedup against double fan-out)', async () => {
+    const calls = scriptFetch([{ status: 200, body: { id: 'msg-1' } }])
+    const { sink } = makeSink()
+    await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    assert.equal(ok, true)
+    assert.equal(calls.length, 1) // no second POST/PATCH
+  })
+
+  it('a changed warning set re-pings: DELETE old + POST new', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'msg-1' } }, // first POST
+      { status: 200 },                         // DELETE old
+      { status: 200, body: { id: 'msg-2' } }, // second POST
+    ])
+    const { sink, statePath } = makeSink()
+    await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT', 'DATACENTER_EGRESS'], 'metered + egress'))
+    assert.equal(ok, true)
+    assert.deepEqual(calls.map((c) => c.method), ['POST', 'DELETE', 'POST'])
+    assert.match(calls[1].url, /\/messages\/msg-1$/)
+    assert.equal(readState(statePath).messageId, 'msg-2')
+  })
+
+  it('same codes but a changed message re-pings (new egress IP)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'msg-1' } },
+      { status: 200 },
+      { status: 200, body: { id: 'msg-2' } },
+    ])
+    const { sink } = makeSink()
+    await sink.send(alert(['DATACENTER_EGRESS'], 'egress 5.9.1.2'))
+    await sink.send(alert(['DATACENTER_EGRESS'], 'egress 5.9.9.9'))
+    assert.deepEqual(calls.map((c) => c.method), ['POST', 'DELETE', 'POST'])
+  })
+
+  it('all-clear PATCHes the tracked message to resolved and clears the signature', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'msg-1' } }, // alert POST
+      { status: 200 },                         // resolved PATCH
+    ])
+    const { sink, statePath } = makeSink()
+    await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    const ok = await sink.send(cleared())
+    assert.equal(ok, true)
+    assert.equal(calls[1].method, 'PATCH')
+    assert.match(calls[1].url, /\/messages\/msg-1$/)
+    const st = readState(statePath)
+    assert.equal(st.messageId, 'msg-1')
+    assert.equal(st.warnSignature, null) // cleared → next warning re-pings
+  })
+
+  it('all-clear with nothing tracked is a silent no-op', async () => {
+    const calls = scriptFetch()
+    const { sink, statePath } = makeSink()
+    const ok = await sink.send(cleared())
+    assert.equal(ok, true)
+    assert.equal(calls.length, 0)
+    assert.equal(existsSync(statePath), false) // never wrote state
+  })
+
+  it('a warning after a resolve re-pings even with identical codes', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'msg-1' } }, // alert POST
+      { status: 200 },                         // resolved PATCH
+      { status: 200 },                         // DELETE old on re-alert
+      { status: 200, body: { id: 'msg-2' } }, // re-alert POST
+    ])
+    const { sink } = makeSink()
+    await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    await sink.send(cleared())
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    assert.equal(ok, true)
+    assert.deepEqual(calls.map((c) => c.method), ['POST', 'PATCH', 'DELETE', 'POST'])
+  })
+
+  it('resolved PATCH on a 404 forgets the message (no healing POST)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'msg-1' } }, // alert POST
+      { status: 404 },                         // resolved PATCH — deleted externally
+    ])
+    const { sink, statePath } = makeSink()
+    await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    const ok = await sink.send(cleared())
+    assert.equal(ok, true)
+    assert.equal(calls.length, 2) // no extra POST
+    assert.equal(readState(statePath).messageId, null)
+  })
+
+  it('a hard POST failure resolves false', async () => {
+    scriptFetch([{ status: 500 }, { status: 500 }, { status: 500 }])
+    const { sink } = makeSink()
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    assert.equal(ok, false)
+  })
+
+  it('respects a globally muted billing_warning category', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT']), {
+      isCategoryEnabled: () => false,
+    })
+    assert.equal(ok, true)
+    assert.equal(calls.length, 0)
+  })
+
+  it('respects quiet hours without a bypass', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    const ok = await sink.send(alert(['SILENT_METERED_DEFAULT']), {
+      isInQuietHours: () => true,
+      shouldBypassQuietHours: () => false,
+    })
+    assert.equal(ok, true)
+    assert.equal(calls.length, 0)
+  })
+
+  it('escapes markdown in the warning body', async () => {
+    const calls = scriptFetch([{ status: 200, body: { id: 'msg-1' } }])
+    const { sink } = makeSink()
+    await sink.send(alert(['DATACENTER_EGRESS'], 'egress *5.9.1.2* via _cloud_'))
+    const payload = JSON.parse(calls[0].body)
+    const field = payload.embeds[0].fields.find((f) => f.name === 'Warnings')
+    assert.ok(field.value.includes('\\*5.9.1.2\\*'))
+    assert.ok(field.value.includes('\\_cloud\\_'))
+  })
+})

--- a/packages/server/tests/discord-billing-sink.test.js
+++ b/packages/server/tests/discord-billing-sink.test.js
@@ -232,6 +232,19 @@ describe('DiscordBillingSink — delivery', () => {
     assert.equal(calls.length, 0)
   })
 
+  it('all-clear repaint bypasses quiet hours (state reconciliation, not a ping) (#5833)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'msg-1' } }, // alert POST (outside quiet hours)
+      { status: 200 },                         // resolved PATCH must still fire in quiet hours
+    ])
+    const { sink } = makeSink()
+    await sink.send(alert(['SILENT_METERED_DEFAULT']))
+    const ok = await sink.send(cleared(), { isInQuietHours: () => true, shouldBypassQuietHours: () => false })
+    assert.equal(ok, true)
+    assert.equal(calls.length, 2)
+    assert.equal(calls[1].method, 'PATCH')
+  })
+
   it('escapes markdown in the warning body', async () => {
     const calls = scriptFetch([{ status: 200, body: { id: 'msg-1' } }])
     const { sink } = makeSink()

--- a/packages/server/tests/discord-webhook-client.test.js
+++ b/packages/server/tests/discord-webhook-client.test.js
@@ -1,0 +1,89 @@
+// #5828: discord-webhook-client — the channel primitives extracted from the
+// status sink so both Discord sinks share one implementation. The status sink's
+// own suite exercises these transitively; this pins the pure helpers directly.
+import { test, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  formatDuration,
+  isValidColor,
+  escapeAndCap,
+  apiBase,
+  retryAfterMs,
+  fetchWithDiscordRetry,
+  MAX_COLOR,
+} from '../src/notifications/discord-webhook-client.js'
+
+const WEBHOOK = 'https://discord.com/api/webhooks/123456789012345678/aBcDeFgHiJkLmNoPqRsTuVwXyZ-0123456789_abcdefghijklmnopqrstuvwx'
+
+test('formatDuration formats seconds, minutes, hours; clamps junk to 0s', () => {
+  assert.equal(formatDuration(45), '45s')
+  assert.equal(formatDuration(330), '5m 30s')
+  assert.equal(formatDuration(4500), '1h 15m')
+  assert.equal(formatDuration(-5), '0s')
+  assert.equal(formatDuration(NaN), '0s')
+})
+
+test('isValidColor accepts 0..MAX_COLOR, rejects out-of-range and non-integers', () => {
+  assert.equal(isValidColor(0), true)
+  assert.equal(isValidColor(MAX_COLOR), true)
+  assert.equal(isValidColor(MAX_COLOR + 1), false)
+  assert.equal(isValidColor(-1), false)
+  assert.equal(isValidColor(1.5), false)
+})
+
+test('escapeAndCap escapes markdown metacharacters', () => {
+  assert.equal(escapeAndCap('a *b* _c_'), 'a \\*b\\* \\_c\\_')
+})
+
+test('escapeAndCap never ends in a dangling escape after the cap', () => {
+  // All-metachar input doubles under escaping; the cap must not leave a lone `\`.
+  const out = escapeAndCap('*'.repeat(20), 5)
+  assert.ok(out.length <= 5)
+  assert.ok(!/\\$/.test(out) || out.endsWith('\\\\'))
+})
+
+test('apiBase builds the webhook endpoint from a valid URL', () => {
+  assert.equal(apiBase(WEBHOOK), 'https://discord.com/api/webhooks/123456789012345678/aBcDeFgHiJkLmNoPqRsTuVwXyZ-0123456789_abcdefghijklmnopqrstuvwx')
+})
+
+test('retryAfterMs reads the Retry-After header (seconds → ms), clamped', async () => {
+  const res = { headers: { get: (h) => (h.toLowerCase() === 'retry-after' ? '1.5' : null) } }
+  assert.equal(await retryAfterMs(res), 1500)
+})
+
+test('retryAfterMs falls back to the JSON body, then defaults to 2s', async () => {
+  const body = { headers: { get: () => null }, json: async () => ({ retry_after: 0.25 }) }
+  assert.equal(await retryAfterMs(body), 250)
+  const junk = { headers: { get: () => null }, json: async () => ({}) }
+  assert.equal(await retryAfterMs(junk), 2000)
+})
+
+test('fetchWithDiscordRetry honours a 429 then succeeds', async () => {
+  const sleeps = []
+  let n = 0
+  const fetchImpl = mock.fn(async () => {
+    n += 1
+    if (n === 1) return { ok: false, status: 429, headers: { get: () => '0.01' }, json: async () => ({}) }
+    return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({ id: 'x' }) }
+  })
+  const res = await fetchWithDiscordRetry('https://x', { method: 'POST' }, { sleepImpl: async (ms) => { sleeps.push(ms) }, fetchImpl })
+  assert.equal(res.status, 200)
+  assert.equal(fetchImpl.mock.callCount(), 2)
+  assert.equal(sleeps.length, 1)
+})
+
+test('fetchWithDiscordRetry returns immediately on a non-429 4xx (not retryable)', async () => {
+  const fetchImpl = mock.fn(async () => ({ ok: false, status: 404, headers: { get: () => null }, json: async () => ({}) }))
+  const res = await fetchWithDiscordRetry('https://x', { method: 'PATCH' }, { sleepImpl: async () => {}, fetchImpl })
+  assert.equal(res.status, 404)
+  assert.equal(fetchImpl.mock.callCount(), 1)
+})
+
+test('fetchWithDiscordRetry retries 5xx then throws-through only on the last network error', async () => {
+  const fetchImpl = mock.fn(async () => { throw new Error('network down') })
+  await assert.rejects(
+    fetchWithDiscordRetry('https://x', { method: 'POST' }, { retries: 2, sleepImpl: async () => {}, fetchImpl }),
+    /network down/,
+  )
+  assert.equal(fetchImpl.mock.callCount(), 2)
+})

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -1034,7 +1034,7 @@ describe('PushManager integration (#5413 Phase 2)', () => {
     const pm = new PushManager({
       discord: { resolveWebhookUrl: () => ({ url: null, source: 'none' }) },
     })
-    assert.deepEqual(pm._sinks.sinks.map((s) => s.name), ['expo-push', 'discord-webhook'])
+    assert.deepEqual(pm._sinks.sinks.map((s) => s.name), ['expo-push', 'discord-webhook', 'discord-billing'])
     assert.equal(pm.hasConfiguredSinks(), false)
     pm.destroy()
   })


### PR DESCRIPTION
## Summary

**Closes #5828.** Wires the billing canary's warnings to Discord as a single daemon-global alert message — the last remaining piece of #5828 after the egress + push work landed in #5830.

### Why a separate sink

A billing warning is **daemon-global**, not a per-session lifecycle state. `DiscordWebhookSink` is a per-project status state machine (idle/online/offline/…) keyed by project; routing `billing_warning` through it would hijack a live session's status embed (or collide on the `'chroxy'` fallback key). So this adds a dedicated sibling sink instead of bending the status machine.

## What changed

- **`discord-webhook-client.js` (new)** — the channel-level primitives (fetch policy + 429 `retry_after` handling, id/token extraction, markdown escaping, embed colors) extracted **verbatim** from the status sink so both sinks share one tested implementation. The status sink now delegates to it — a pure-swap (its **83 tests still pass unchanged**).
- **`discord-billing-sink.js` (new)** — keeps **one** global alert message in its own state file (`discord-billing-state.json`), read-per-send so a supervisor + server converge on one message id:
  - new/changed warning set → **delete old + POST new** (re-ping)
  - same set again → no-op (dedup against double fan-out)
  - all-clear → **PATCH to a green "resolved" embed**
  - only handles `billing_warning`; every other category is skipped (no double-handling of session events)
- **`push.js`** — registers the billing sink alongside the others; shares the webhook + pipeline gating, with its own `billingStatePath` and a `billingAlerts` kill-switch.
- **`billing-canary-monitor.js`** — `notify` now also fires once with an **empty array** on the non-empty→empty transition (Option B), so the sink can repaint resolved. Never on an unchanged re-broadcast, nor on a clear that follows startup (no spurious all-clear on a clean daemon). The previous "not fired on all-clear" test is updated to the new contract.
- **`server-cli.js`** — the notify handler sends a `resolved` push on all-clear.
- **`config.js`** — validates `notifications.discord.billingAlerts` (boolean, warn-only).
- **docs** — `discord-notifications.md` + `CONFIG.md` document the alert behavior, the kill-switch, and the separate state file.

## Design decisions (confirmed with the user)

- **All-clear → green "resolved" embed (Option B)** over leaving a stale red message. Routes through the normal pipeline, so mobile also gets a cleared note.
- **Respects quiet hours** — `billing_warning` is *not* added to the default bypass list; it falls silent overnight like other categories (user can still bypass per-prefs).
- **Extract the shared client now** rather than staging it — both sinks use one implementation from day one.

## Testing

- `discord-billing-sink.test.js` (new) — gating, skip-non-billing, first-POST, dedup, changed-set re-ping (including same-codes/changed-message), all-clear PATCH, all-clear-with-nothing-tracked no-op, warning-after-resolve re-ping, 404-on-resolve, hard-failure→false, category-mute, quiet-hours, markdown escaping.
- `discord-webhook-client.test.js` (new) — the extracted pure helpers + fetch retry/429/4xx/5xx behavior.
- `billing-canary-monitor.test.js` — updated for the all-clear notify; added startup-no-spurious-clear.
- `discord-webhook-sink.test.js` — 83 status-sink tests pass unchanged (proves the pure-swap); sink-list assertion updated for the new sink.

Full server suite: 9640 tests, 2 failures — both the known `service.test.js` `getFullServiceStatus` artifact from a live local `:8765` daemon answering the probe (see project memory); unrelated to this change, green on CI runners.
