### PR TITLE
feat(server): IPv6 datacenter-egress detection for the billing canary (#5831)

### DIFF
--- a/packages/server/src/doctor-billing.js
+++ b/packages/server/src/doctor-billing.js
@@ -20,6 +20,7 @@ import {
   billingClassForProvider,
   isProgrammaticCreditEra,
 } from './billing-class.js'
+import { expandIpv6, normalizeIpv6Prefix } from './ip-utils.js'
 
 /**
  * Loophole-closed canary. A `claude-tui` session is nominally subscription-billed
@@ -89,33 +90,60 @@ export function detectSilentMeteredDefault(defaultProvider, now = Date.now(), { 
 
 // Datacenter-egress ban-signal. Cloud-hosted daemons behind a tunnel are a documented
 // flag (the audit cites ~20-minute bans on Hetzner ranges). This is a pure classifier
-// over a known-prefix list; the caller supplies the public egress ip.
+// over known-prefix lists (IPv4 and IPv6); the caller supplies the public egress ip.
 //
-// CONSERVATIVE BY DESIGN: only specific, documented datacenter /16-ish ranges are
-// listed. Coarse /8 blocks (e.g. AWS/GCP `13.`, `34.`, `52.`) were deliberately
-// REMOVED — they span large amounts of residential/ISP space too and would fire false
-// positives, training users to ignore the warning. A comprehensive classifier needs a
-// maintained cloud-IP dataset (e.g. the published AWS/GCP/Azure range JSON); until that
-// is plumbed in, a precise-but-narrow list that never cries wolf beats a broad-but-noisy
-// one. A missed datacenter IP is a silent non-warning; a false hit erodes trust.
+// CONSERVATIVE BY DESIGN: only specific, documented datacenter ranges are listed.
+// Coarse blocks (e.g. AWS/GCP /8s `13.`, `34.`, `52.`) were deliberately REMOVED —
+// they span large amounts of residential/ISP space too and would fire false positives,
+// training users to ignore the warning. A comprehensive classifier needs a maintained
+// cloud-IP dataset (e.g. the published AWS/GCP/Azure range JSON); until that is plumbed
+// in, a precise-but-narrow list that never cries wolf beats a broad-but-noisy one. A
+// missed datacenter IP is a silent non-warning; a false hit erodes trust.
 const DATACENTER_IPV4_PREFIXES = [
   // Hetzner (cited in claude-code#21678) — specific allocated /16s.
   '5.9.', '88.99.', '95.216.', '116.202.', '135.181.', '167.235.', '168.119.',
 ]
 
+// #5831: IPv6 datacenter ranges, matched against the CANONICAL expanded form
+// (8 zero-padded groups) so a compressed `2a01:4f8::1` and a padded
+// `2a01:04f8:...` compare equal. Same conservative stance as the IPv4 list —
+// only documented Hetzner blocks. Matching the leading two groups is NARROWER
+// than the announced /29s on purpose: a missed datacenter IP is a silent
+// non-warning, a false hit erodes trust. Listed pre-normalised (lowercase,
+// zero-padded) so they prefix-match expandIpv6 output directly.
+const DATACENTER_IPV6_PREFIXES = [
+  '2a01:04f8:', // Hetzner Online (dedicated)
+  '2a01:04f9:', // Hetzner Online
+  '2a01:04ff:', // Hetzner Cloud
+]
+
 /**
- * @param {string} ip - public egress IPv4
- * @param {string[]} [extraPrefixes] - operator-supplied extra IPv4 prefixes
- *   (config.billing.datacenterPrefixes), merged with the built-in list. Lets a
- *   user on a known cloud add their provider's ranges without a code change.
+ * @param {string} ip - public egress IP (IPv4 or IPv6)
+ * @param {string[]} [extraPrefixes] - operator-supplied extra prefixes
+ *   (config.billing.datacenterPrefixes), merged with the built-in lists. A
+ *   prefix containing `:` is treated as IPv6, otherwise IPv4. Lets a user on a
+ *   known cloud add their provider's ranges without a code change.
  * @returns {{datacenter:boolean, code?:string, message?:string}}
  */
 export function classifyEgressIp(ip, extraPrefixes = []) {
   if (!ip || typeof ip !== 'string') return { datacenter: false }
-  const prefixes = Array.isArray(extraPrefixes) && extraPrefixes.length > 0
-    ? [...DATACENTER_IPV4_PREFIXES, ...extraPrefixes.filter((p) => typeof p === 'string' && p.length > 0)]
-    : DATACENTER_IPV4_PREFIXES
-  const hit = prefixes.some((p) => ip.startsWith(p))
+  const extra = Array.isArray(extraPrefixes)
+    ? extraPrefixes.filter((p) => typeof p === 'string' && p.length > 0)
+    : []
+
+  let hit = false
+  if (ip.includes(':')) {
+    // IPv6: compare canonical expanded forms so spelling doesn't matter.
+    const expanded = expandIpv6(ip)
+    if (expanded) {
+      const v6 = [...DATACENTER_IPV6_PREFIXES, ...extra.filter((p) => p.includes(':')).map(normalizeIpv6Prefix)]
+      hit = v6.some((p) => expanded.startsWith(p))
+    }
+  } else {
+    const v4 = [...DATACENTER_IPV4_PREFIXES, ...extra.filter((p) => !p.includes(':'))]
+    hit = v4.some((p) => ip.startsWith(p))
+  }
+
   if (!hit) return { datacenter: false }
   return {
     datacenter: true,

--- a/packages/server/src/doctor-billing.js
+++ b/packages/server/src/doctor-billing.js
@@ -127,8 +127,10 @@ const DATACENTER_IPV6_PREFIXES = [
  */
 export function classifyEgressIp(ip, extraPrefixes = []) {
   if (!ip || typeof ip !== 'string') return { datacenter: false }
+  // Trim operator prefixes — a copy/pasted `" 2a02:1370: "` passes config
+  // validation (non-empty string) but would otherwise never match.
   const extra = Array.isArray(extraPrefixes)
-    ? extraPrefixes.filter((p) => typeof p === 'string' && p.length > 0)
+    ? extraPrefixes.filter((p) => typeof p === 'string').map((p) => p.trim()).filter((p) => p.length > 0)
     : []
 
   let hit = false

--- a/packages/server/src/get-public-ip.js
+++ b/packages/server/src/get-public-ip.js
@@ -36,6 +36,11 @@ export async function resolvePublicIp({ url = DEFAULT_IP_ECHO_URL, timeoutMs = D
     const res = await fetchImpl(url, { signal: controller.signal })
     if (!res || !res.ok) return null
     const text = (await res.text()).trim()
+    // Keep this strictly an IP-literal parser: a real IP literal is short (IPv6
+    // tops out at 45 chars), so cap the body BEFORE the validators — a large
+    // captive-portal / error page (which may contain `:`) must not be fed through
+    // isIpv6's splitting work. Over the cap → not an IP.
+    if (text.length > 45) return null
     // Only accept a plausible IPv4 or IPv6 — the classifier handles both — so a
     // junk/HTML body (captive portal, error page) is never treated as an IP.
     return (isIpv4(text) || isIpv6(text)) ? text : null

--- a/packages/server/src/get-public-ip.js
+++ b/packages/server/src/get-public-ip.js
@@ -8,16 +8,17 @@
 // body) resolves to `null`, never throws. A missed lookup just means no egress
 // warning — strictly better than crashing a periodic canary tick.
 
-// ipify returns a bare IPv4/IPv6 string for the text endpoint. Kept as a
-// default so the resolver works out of the box; injectable for tests / for an
-// operator who'd rather point at their own echo service.
-const DEFAULT_IP_ECHO_URL = 'https://api.ipify.org'
-const DEFAULT_TIMEOUT_MS = 5000
+import { isIpv4, isIpv6 } from './ip-utils.js'
 
-// Each octet 0-255 — a loose \d{1,3} would accept junk like 999.999.999.999
-// from a captive-portal / error body.
-const OCTET = '(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)'
-const IPV4_RE = new RegExp(`^(${OCTET}\\.){3}${OCTET}$`)
+// ipify's api64 endpoint returns a bare IP string — the host's IPv6 when it
+// egresses over IPv6, otherwise its IPv4. The dual-stack endpoint matters for
+// #5831: an IPv6-only cloud host (Hetzner increasingly assigns these) cannot
+// reach the IPv4-only `api.ipify.org`, so the datacenter-egress check would
+// never fire on exactly the host it exists to catch. Kept as a default so the
+// resolver works out of the box; injectable for tests / for an operator who'd
+// rather point at their own echo service.
+const DEFAULT_IP_ECHO_URL = 'https://api64.ipify.org'
+const DEFAULT_TIMEOUT_MS = 5000
 
 /**
  * Resolve the daemon's public egress IP, best-effort.
@@ -26,7 +27,7 @@ const IPV4_RE = new RegExp(`^(${OCTET}\\.){3}${OCTET}$`)
  * @param {string} [opts.url] - IP-echo endpoint returning a bare IP string.
  * @param {number} [opts.timeoutMs] - abort the request after this long.
  * @param {typeof fetch} [opts.fetchImpl] - injectable for tests (defaults to global fetch).
- * @returns {Promise<string|null>} the trimmed IPv4 string, or null on any failure.
+ * @returns {Promise<string|null>} the trimmed IPv4 or IPv6 string, or null on any failure.
  */
 export async function resolvePublicIp({ url = DEFAULT_IP_ECHO_URL, timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = fetch } = {}) {
   const controller = new AbortController()
@@ -35,9 +36,9 @@ export async function resolvePublicIp({ url = DEFAULT_IP_ECHO_URL, timeoutMs = D
     const res = await fetchImpl(url, { signal: controller.signal })
     if (!res || !res.ok) return null
     const text = (await res.text()).trim()
-    // Only accept a plausible IPv4 — the classifier is IPv4-prefix based, and a
-    // junk/HTML body (captive portal, error page) must not be treated as an IP.
-    return IPV4_RE.test(text) ? text : null
+    // Only accept a plausible IPv4 or IPv6 — the classifier handles both — so a
+    // junk/HTML body (captive portal, error page) is never treated as an IP.
+    return (isIpv4(text) || isIpv6(text)) ? text : null
   } catch {
     return null
   } finally {

--- a/packages/server/src/ip-utils.js
+++ b/packages/server/src/ip-utils.js
@@ -1,0 +1,80 @@
+// ip-utils.js — minimal, dependency-free IP validation + IPv6 canonicalisation
+// shared by the billing canary's egress path (#5831).
+//
+// get-public-ip.js uses isIpv4/isIpv6 to validate an echo-endpoint body before
+// trusting it as an egress IP; doctor-billing.js uses expandIpv6 to prefix-match
+// an address against documented datacenter ranges. Both need the SAME notion of
+// "a valid IPv6 address", so expansion (which doubles as validation) lives here
+// as the single source of truth rather than two slightly-different regexes.
+
+// Each octet 0-255 — a loose \d{1,3} would accept junk like 999.999.999.999
+// from a captive-portal / error body.
+const OCTET = '(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)'
+const IPV4_RE = new RegExp(`^(${OCTET}\\.){3}${OCTET}$`)
+
+/** True for a dotted-quad IPv4 string with every octet in 0-255. */
+export function isIpv4(s) {
+  return typeof s === 'string' && IPV4_RE.test(s)
+}
+
+/**
+ * Expand an IPv6 address to its canonical lowercase, fully-grouped form
+ * (8 groups of 4 hex digits, e.g. `2a01:04f8:0000:0000:0000:0000:0000:0001`),
+ * or null if it is not a valid IPv6 address. Handles `::` zero-compression, a
+ * trailing zone id (`%eth0`), and surrounding brackets. IPv4-mapped forms
+ * (`::ffff:1.2.3.4`) are intentionally NOT supported — they return null, which
+ * the classifier treats as "unknown" (a silent non-hit, never a false hit).
+ *
+ * Doubling as the validator keeps a single definition of "valid IPv6": prefix
+ * matching compares against this canonical form so compressed and padded
+ * spellings of the same address compare equal.
+ */
+export function expandIpv6(ip) {
+  if (typeof ip !== 'string' || !ip.includes(':')) return null
+  // Strip brackets and any zone id (`fe80::1%eth0`).
+  const addr = ip.trim().replace(/^\[/, '').replace(/\]$/, '').split('%')[0]
+  const halves = addr.split('::')
+  if (halves.length > 2) return null // more than one `::` is invalid
+
+  const head = halves[0] ? halves[0].split(':') : []
+  const tail = halves.length === 2 ? (halves[1] ? halves[1].split(':') : []) : []
+
+  let groups
+  if (halves.length === 2) {
+    const missing = 8 - head.length - tail.length
+    if (missing < 1) return null // `::` must stand in for at least one zero group
+    groups = [...head, ...Array(missing).fill('0'), ...tail]
+  } else {
+    groups = head // no `::` — must be exactly 8 explicit groups
+  }
+  if (groups.length !== 8) return null
+
+  const out = []
+  for (const g of groups) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null
+    out.push(g.toLowerCase().padStart(4, '0'))
+  }
+  return out.join(':')
+}
+
+/** True for a valid IPv6 address (anything expandIpv6 can canonicalise). */
+export function isIpv6(s) {
+  return expandIpv6(s) != null
+}
+
+/**
+ * Normalise an operator-supplied IPv6 PREFIX (e.g. `2a02:1370:` from
+ * config.billing.datacenterPrefixes) into the same zero-padded, lowercase,
+ * group-aligned form expandIpv6 produces, so a startsWith() against an expanded
+ * address matches regardless of how the operator spelled the groups. A partial
+ * prefix is not a full address, so this only pads each group — it does not
+ * expand `::`.
+ */
+export function normalizeIpv6Prefix(prefix) {
+  if (typeof prefix !== 'string') return ''
+  return prefix
+    .toLowerCase()
+    .split(':')
+    .map((g) => (g.length ? g.padStart(4, '0') : g))
+    .join(':')
+}

--- a/packages/server/src/ip-utils.js
+++ b/packages/server/src/ip-utils.js
@@ -69,6 +69,11 @@ export function isIpv6(s) {
  * address matches regardless of how the operator spelled the groups. A partial
  * prefix is not a full address, so this only pads each group — it does not
  * expand `::`.
+ *
+ * Operator prefixes must be WHOLE `:`-delimited groups: a partial trailing group
+ * pads on its own boundary and won't match across the group, e.g. `2a02:13` →
+ * `2a02:0013` does NOT match `2a02:1300::…`. Prefixes ending in `:` (the
+ * built-in list, and the natural way to write a block) are immune.
  */
 export function normalizeIpv6Prefix(prefix) {
   if (typeof prefix !== 'string') return ''

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -102,6 +102,9 @@ test('classifyEgressIp honours operator-supplied IPv6 prefixes (#5831)', () => {
   // v4 extras do not bleed into v6 matching and vice versa.
   assert.equal(classifyEgressIp('2a02:1370:c000::5', ['203.0.113.']).datacenter, false)
   assert.equal(classifyEgressIp('203.0.113.9', ['2a02:1370:']).datacenter, false)
+  // Copy/paste whitespace around an operator prefix is trimmed (both families).
+  assert.equal(classifyEgressIp('2a02:1370:c000::5', ['  2a02:1370:  ']).datacenter, true)
+  assert.equal(classifyEgressIp('198.51.100.5', [' 198.51.100. ']).datacenter, true)
 })
 
 test('classifyEgressIp honours operator-supplied extra prefixes (#5828)', () => {

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -82,6 +82,28 @@ test('classifyEgressIp does NOT flag coarse /8 blocks (false-positive guard)', (
   }
 })
 
+test('classifyEgressIp flags a known IPv6 datacenter range, not residential v6 (#5831)', () => {
+  // Hetzner IPv6 — compressed and padded spellings both match.
+  assert.equal(classifyEgressIp('2a01:4f8::1').datacenter, true)
+  assert.equal(classifyEgressIp('2a01:4f8::1').code, 'DATACENTER_EGRESS')
+  assert.equal(classifyEgressIp('2a01:04f8:0:1::dead').datacenter, true)
+  assert.equal(classifyEgressIp('2a01:4ff:f0:b1::1').datacenter, true) // Hetzner Cloud /32
+  // Residential / non-datacenter IPv6 is NOT flagged.
+  assert.equal(classifyEgressIp('2601:200:c000:1::5').datacenter, false) // Comcast
+  assert.equal(classifyEgressIp('2606:4700::1111').datacenter, false)    // Cloudflare DNS
+  // Malformed v6 is a silent non-hit, never a false positive.
+  assert.equal(classifyEgressIp('2a01:4f8:zzzz::1').datacenter, false)
+})
+
+test('classifyEgressIp honours operator-supplied IPv6 prefixes (#5831)', () => {
+  // A residential-looking v6 is clean by default but flagged once added.
+  assert.equal(classifyEgressIp('2a02:1370:c000::5').datacenter, false)
+  assert.equal(classifyEgressIp('2a02:1370:c000::5', ['2a02:1370:']).datacenter, true)
+  // v4 extras do not bleed into v6 matching and vice versa.
+  assert.equal(classifyEgressIp('2a02:1370:c000::5', ['203.0.113.']).datacenter, false)
+  assert.equal(classifyEgressIp('203.0.113.9', ['2a02:1370:']).datacenter, false)
+})
+
 test('classifyEgressIp honours operator-supplied extra prefixes (#5828)', () => {
   // A residential-looking IP is clean by default but flagged once the operator
   // adds their cloud's range via config.billing.datacenterPrefixes.

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -88,9 +88,9 @@ test('classifyEgressIp flags a known IPv6 datacenter range, not residential v6 (
   assert.equal(classifyEgressIp('2a01:4f8::1').code, 'DATACENTER_EGRESS')
   assert.equal(classifyEgressIp('2a01:04f8:0:1::dead').datacenter, true)
   assert.equal(classifyEgressIp('2a01:4ff:f0:b1::1').datacenter, true) // Hetzner Cloud /32
-  // Residential / non-datacenter IPv6 is NOT flagged.
-  assert.equal(classifyEgressIp('2601:200:c000:1::5').datacenter, false) // Comcast
-  assert.equal(classifyEgressIp('2606:4700::1111').datacenter, false)    // Cloudflare DNS
+  // Non-datacenter IPv6 (residential ISP + a non-listed network) is NOT flagged.
+  assert.equal(classifyEgressIp('2601:200:c000:1::5').datacenter, false) // Comcast residential
+  assert.equal(classifyEgressIp('2606:4700::1111').datacenter, false)    // Cloudflare (anycast, not a listed range)
   // Malformed v6 is a silent non-hit, never a false positive.
   assert.equal(classifyEgressIp('2a01:4f8:zzzz::1').datacenter, false)
 })

--- a/packages/server/tests/get-public-ip.test.js
+++ b/packages/server/tests/get-public-ip.test.js
@@ -31,6 +31,22 @@ test('accepts boundary octets (255.0.1.255)', async () => {
   assert.equal(ip, '255.0.1.255')
 })
 
+test('accepts a valid IPv6 body (#5831)', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: true, text: async () => '2a01:4f8::1' })) })
+  assert.equal(ip, '2a01:4f8::1')
+})
+
+test('returns null for a malformed IPv6 body', async () => {
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: true, text: async () => '2a01:4f8:zzzz::1' })) })
+  assert.equal(ip, null)
+})
+
+test('defaults to a dual-stack echo endpoint so IPv6-only hosts resolve (#5831)', async () => {
+  let seen = null
+  await resolvePublicIp({ fetchImpl: fakeFetch(async (url) => { seen = url; return { ok: true, text: async () => '2a01:4f8::1' } }) })
+  assert.match(seen, /api64\.ipify\.org/)
+})
+
 test('is fail-open: a throwing fetch resolves to null, never rejects', async () => {
   const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => { throw new Error('network down') }) })
   assert.equal(ip, null)

--- a/packages/server/tests/get-public-ip.test.js
+++ b/packages/server/tests/get-public-ip.test.js
@@ -41,6 +41,12 @@ test('returns null for a malformed IPv6 body', async () => {
   assert.equal(ip, null)
 })
 
+test('caps an oversized body before validation (captive portal / error page)', async () => {
+  const big = `${':'.repeat(100)}` // long, colon-laden, not an IP
+  const ip = await resolvePublicIp({ fetchImpl: fakeFetch(async () => ({ ok: true, text: async () => big })) })
+  assert.equal(ip, null)
+})
+
 test('defaults to a dual-stack echo endpoint so IPv6-only hosts resolve (#5831)', async () => {
   let seen = null
   await resolvePublicIp({ fetchImpl: fakeFetch(async (url) => { seen = url; return { ok: true, text: async () => '2a01:4f8::1' } }) })

--- a/packages/server/tests/ip-utils.test.js
+++ b/packages/server/tests/ip-utils.test.js
@@ -1,0 +1,55 @@
+// #5831: ip-utils — IPv4/IPv6 validation + IPv6 canonicalisation shared by the
+// egress resolver and the datacenter classifier.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isIpv4, isIpv6, expandIpv6, normalizeIpv6Prefix } from '../src/ip-utils.js'
+
+test('isIpv4 accepts dotted quads in range, rejects junk and out-of-range', () => {
+  assert.equal(isIpv4('1.2.3.4'), true)
+  assert.equal(isIpv4('255.0.1.255'), true)
+  assert.equal(isIpv4('999.999.999.999'), false)
+  assert.equal(isIpv4('1.2.3'), false)
+  assert.equal(isIpv4('2a01:4f8::1'), false)
+  assert.equal(isIpv4(''), false)
+  assert.equal(isIpv4(undefined), false)
+})
+
+test('expandIpv6 canonicalises compressed, padded, and full forms', () => {
+  assert.equal(expandIpv6('2a01:4f8::1'), '2a01:04f8:0000:0000:0000:0000:0000:0001')
+  assert.equal(expandIpv6('::1'), '0000:0000:0000:0000:0000:0000:0000:0001')
+  assert.equal(expandIpv6('::'), '0000:0000:0000:0000:0000:0000:0000:0000')
+  assert.equal(
+    expandIpv6('2001:0db8:0000:0000:0000:0000:0000:0001'),
+    '2001:0db8:0000:0000:0000:0000:0000:0001',
+  )
+  // uppercase is lowercased
+  assert.equal(expandIpv6('2A01:4F8::1'), '2a01:04f8:0000:0000:0000:0000:0000:0001')
+})
+
+test('expandIpv6 strips a zone id and brackets', () => {
+  assert.equal(expandIpv6('[2a01:4f8::1]'), '2a01:04f8:0000:0000:0000:0000:0000:0001')
+  assert.equal(expandIpv6('fe80::1%eth0'), 'fe80:0000:0000:0000:0000:0000:0000:0001')
+})
+
+test('expandIpv6 rejects invalid addresses', () => {
+  assert.equal(expandIpv6('not-an-ip'), null)
+  assert.equal(expandIpv6('1.2.3.4'), null)          // no colon
+  assert.equal(expandIpv6('2a01::4f8::1'), null)     // two `::`
+  assert.equal(expandIpv6('1:2:3:4:5:6:7'), null)    // too few groups, no `::`
+  assert.equal(expandIpv6('1:2:3:4:5:6:7:8:9'), null) // too many groups
+  assert.equal(expandIpv6('2a01:4f8:zzzz::1'), null) // non-hex group
+  assert.equal(expandIpv6('1:2:3:4:5:6:7:8::'), null) // `::` standing in for nothing
+})
+
+test('isIpv6 mirrors expandIpv6 validity', () => {
+  assert.equal(isIpv6('2a01:4f8::1'), true)
+  assert.equal(isIpv6('::1'), true)
+  assert.equal(isIpv6('1.2.3.4'), false)
+  assert.equal(isIpv6('garbage'), false)
+})
+
+test('normalizeIpv6Prefix zero-pads each group, preserving the trailing colon', () => {
+  assert.equal(normalizeIpv6Prefix('2a02:1370:'), '2a02:1370:')
+  assert.equal(normalizeIpv6Prefix('2A01:4F8:'), '2a01:04f8:')
+  assert.equal(normalizeIpv6Prefix('2001:db8:'), '2001:0db8:')
+})


### PR DESCRIPTION
## Summary

**Closes #5831.** The billing canary's datacenter-egress check was IPv4-only end to end, so an IPv6-only cloud host — increasingly common on Hetzner, the very provider the check targets — was a silent miss: the resolver returned `null` and the warning never fired on exactly the cloud-host case it exists to catch.

## What changed

- **`ip-utils.js` (new)** — `isIpv4` / `isIpv6` / `expandIpv6` / `normalizeIpv6Prefix`. `expandIpv6` canonicalises an address to 8 zero-padded lowercase groups (handling `::` compression, a zone id, brackets) and **doubles as the validator**, so the resolver and the classifier share one notion of "valid IPv6" and a compressed `2a01:4f8::1` compares equal to a padded `2a01:04f8:…`.
- **`get-public-ip.js`** — default to the dual-stack **`api64.ipify.org`** (an IPv6-only host can't reach the v4-only `api.ipify.org`), and accept a validated IPv6 body in addition to IPv4.
- **`doctor-billing.js`** — `classifyEgressIp` now branches on address family: a narrow, **documented IPv6 prefix list** (Hetzner `2a01:4f8`/`4f9`/`4ff`, matched against the canonical expanded form) plus operator-supplied v6 prefixes routed by the `:` in them. Same conservative "never cry wolf" stance as the IPv4 list — matching the leading groups is intentionally narrower than the announced /29s, because a miss is a silent non-warning while a false hit erodes trust.

## Acceptance criteria (from the issue)

- ✅ `resolvePublicIp` can return a validated IPv6 string.
- ✅ `classifyEgressIp` flags a known IPv6 datacenter range.
- ✅ Tests cover the IPv6 happy path + a residential IPv6 non-hit.

## Testing

- `ip-utils.test.js` (new) — `isIpv4`/`isIpv6`, `expandIpv6` (compression, zone id, brackets, uppercase, and the full invalid set: double `::`, wrong group counts, non-hex), `normalizeIpv6Prefix`.
- `doctor-billing.test.js` — Hetzner v6 flagged (compressed + padded + Cloud /32), residential v6 (Comcast, Cloudflare) not flagged, malformed-v6 silent non-hit, operator v6 prefixes, v4/v6 extras don't cross-bleed.
- `get-public-ip.test.js` — accepts a valid IPv6 body, rejects malformed v6, defaults to the dual-stack endpoint.

Full server suite: 9644 pass / 2 fail — both the known `service.test.js` `getFullServiceStatus` artifact from a live local `:8765` daemon (see project memory); unrelated, green on CI.

This closes the last open follow-up from the billing-canary egress work (#5830 / #5832).
