### PR TITLE
feat(server): live claude-tui PTY mirror — server pipe (#5835 Phase 1)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -532,6 +532,14 @@ export declare const UnsubscribeSessionsSchema: z.ZodObject<{
     type: z.ZodLiteral<"unsubscribe_sessions">;
     sessionIds: z.ZodArray<z.ZodString>;
 }, z.core.$strip>;
+export declare const TerminalSubscribeSchema: z.ZodObject<{
+    type: z.ZodLiteral<"terminal_subscribe">;
+    sessionId: z.ZodString;
+}, z.core.$strip>;
+export declare const TerminalUnsubscribeSchema: z.ZodObject<{
+    type: z.ZodLiteral<"terminal_unsubscribe">;
+    sessionId: z.ZodString;
+}, z.core.$strip>;
 export declare const ClientVisibleSchema: z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;
@@ -921,6 +929,12 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"unsubscribe_sessions">;
     sessionIds: z.ZodArray<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"terminal_subscribe">;
+    sessionId: z.ZodString;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"terminal_unsubscribe">;
+    sessionId: z.ZodString;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -681,10 +681,12 @@ export const UnsubscribeSessionsSchema = z.object({
     sessionIds: z.array(z.string().max(256)).min(1).max(20),
 });
 // #5835 Phase 1: opt in / out of LIVE TERMINAL output (the claude-tui PTY
-// remote-viewer mirror) for a single session. Kept separate from
-// subscribe_sessions so a client viewing the Chat tab doesn't receive a
-// session's raw PTY bytes — only a client actually viewing the terminal does.
-// Single sessionId (you watch one terminal at a time); send again to switch.
+// remote-viewer mirror) for one session. Kept separate from subscribe_sessions
+// so a client viewing the Chat tab doesn't receive a session's raw PTY bytes —
+// only a client that opted into its terminal does. One message carries one
+// sessionId; the server tracks opt-ins as a SET, so a client may hold more than
+// one (the typical client opts into exactly the terminal it's viewing and opts
+// out on leave). Pair each subscribe with an unsubscribe.
 export const TerminalSubscribeSchema = z.object({
     type: z.literal('terminal_subscribe'),
     sessionId: z.string().max(256),

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -680,6 +680,19 @@ export const UnsubscribeSessionsSchema = z.object({
     type: z.literal('unsubscribe_sessions'),
     sessionIds: z.array(z.string().max(256)).min(1).max(20),
 });
+// #5835 Phase 1: opt in / out of LIVE TERMINAL output (the claude-tui PTY
+// remote-viewer mirror) for a single session. Kept separate from
+// subscribe_sessions so a client viewing the Chat tab doesn't receive a
+// session's raw PTY bytes — only a client actually viewing the terminal does.
+// Single sessionId (you watch one terminal at a time); send again to switch.
+export const TerminalSubscribeSchema = z.object({
+    type: z.literal('terminal_subscribe'),
+    sessionId: z.string().max(256),
+});
+export const TerminalUnsubscribeSchema = z.object({
+    type: z.literal('terminal_unsubscribe'),
+    sessionId: z.string().max(256),
+});
 // #3404: client signals foreground/background state. Mobile app sends
 // {visible:false} on AppState background/inactive so the server stops
 // treating its still-alive WS connection as an active viewer and lets
@@ -972,6 +985,8 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     RequestCostSummarySchema,
     SubscribeSessionsSchema,
     UnsubscribeSessionsSchema,
+    TerminalSubscribeSchema,
+    TerminalUnsubscribeSchema,
     ClientVisibleSchema,
     ClaimPrimarySchema,
     ListProvidersSchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -777,10 +777,12 @@ export const UnsubscribeSessionsSchema = z.object({
 })
 
 // #5835 Phase 1: opt in / out of LIVE TERMINAL output (the claude-tui PTY
-// remote-viewer mirror) for a single session. Kept separate from
-// subscribe_sessions so a client viewing the Chat tab doesn't receive a
-// session's raw PTY bytes — only a client actually viewing the terminal does.
-// Single sessionId (you watch one terminal at a time); send again to switch.
+// remote-viewer mirror) for one session. Kept separate from subscribe_sessions
+// so a client viewing the Chat tab doesn't receive a session's raw PTY bytes —
+// only a client that opted into its terminal does. One message carries one
+// sessionId; the server tracks opt-ins as a SET, so a client may hold more than
+// one (the typical client opts into exactly the terminal it's viewing and opts
+// out on leave). Pair each subscribe with an unsubscribe.
 export const TerminalSubscribeSchema = z.object({
   type: z.literal('terminal_subscribe'),
   sessionId: z.string().max(256),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -776,6 +776,21 @@ export const UnsubscribeSessionsSchema = z.object({
   sessionIds: z.array(z.string().max(256)).min(1).max(20),
 })
 
+// #5835 Phase 1: opt in / out of LIVE TERMINAL output (the claude-tui PTY
+// remote-viewer mirror) for a single session. Kept separate from
+// subscribe_sessions so a client viewing the Chat tab doesn't receive a
+// session's raw PTY bytes — only a client actually viewing the terminal does.
+// Single sessionId (you watch one terminal at a time); send again to switch.
+export const TerminalSubscribeSchema = z.object({
+  type: z.literal('terminal_subscribe'),
+  sessionId: z.string().max(256),
+})
+
+export const TerminalUnsubscribeSchema = z.object({
+  type: z.literal('terminal_unsubscribe'),
+  sessionId: z.string().max(256),
+})
+
 // #3404: client signals foreground/background state. Mobile app sends
 // {visible:false} on AppState background/inactive so the server stops
 // treating its still-alive WS connection as an active viewer and lets
@@ -1098,6 +1113,8 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   RequestCostSummarySchema,
   SubscribeSessionsSchema,
   UnsubscribeSessionsSchema,
+  TerminalSubscribeSchema,
+  TerminalUnsubscribeSchema,
   ClientVisibleSchema,
   ClaimPrimarySchema,
   ListProvidersSchema,

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -76,6 +76,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
+  'terminal_output', // #5835 Phase 1 (server pipe): live claude-tui PTY mirror — the server broadcast + opt-in lands first; the dashboard render handler is PR2 of the epic. Move to PLATFORM_SPECIFIC='dashboard' when PR2 adds the case.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -376,6 +376,13 @@ export class ClaudeTuiSession extends BaseSession {
     // UTF-8 strings already decoded, but the relevant control bytes
     // are 7-bit ASCII and survive the decode unchanged.
     this._outputTailRaw = Buffer.alloc(0)
+    // #5835 Phase 1: live remote-viewer mirror. PTY onData fires very frequently
+    // during a TUI redraw, so coalesce bytes into a buffer and flush one
+    // `terminal_output` event per tick (MIRROR_FLUSH_MS) — bounding the broadcast
+    // rate to the tunnel rather than emitting per byte. Buffer + timer are reset
+    // on flush and cleared on teardown.
+    this._mirrorBuffer = ''
+    this._mirrorTimer = null
     // #4278: when claude TUI calls AskUserQuestion, chroxy's PreToolUse
     // hook emits user_question and stashes the toolUseId here. The
     // dashboard's QuestionPrompt UI eventually sends a
@@ -664,6 +671,12 @@ export class ClaudeTuiSession extends BaseSession {
   // Tail length to keep + length to include in error diagnostics.
   static get PTY_TAIL_BYTES() { return 4096 }
   static get PTY_TAIL_DIAGNOSTIC_BYTES() { return 1024 }
+
+  // #5835 Phase 1: coalescing window for the live remote-viewer mirror. PTY
+  // onData fires many times per redraw; flushing one `terminal_output` per
+  // ~50ms caps the broadcast rate (the deliberate latency-for-bandwidth trade —
+  // a faithful-but-slightly-laggy mirror) without dropping any bytes.
+  static get MIRROR_FLUSH_MS() { return 50 }
 
   // #4269: per-character delay when writing the prompt to the PTY.
   // claude TUI's paste detector triggers on byte-arrival rate, not DEC
@@ -1083,6 +1096,9 @@ export class ClaudeTuiSession extends BaseSession {
     // the escalation only fires when onExit NEVER arrives, i.e. the process is
     // genuinely still alive, so the captured pid can't have been recycled.
     if (this._killTimer) { clearTimeout(this._killTimer); this._killTimer = null }
+    // #5835: drop any pending live-mirror flush so a dead PTY's leftover frame
+    // never broadcasts and the timer doesn't leak.
+    this._clearTerminalMirror()
     // Reset turn state so the next sendMessage() sees a clean idle.
     const hadActiveTurn = this._activeTurn !== null
     // #4022: clean up the in-flight turn's attachment dir BEFORE nulling
@@ -1500,7 +1516,13 @@ export class ClaudeTuiSession extends BaseSession {
     // the destroy-race guard above so an aborted (re)spawn doesn't clear it.
     this._firstTurnNudgedForSpawn = false
 
-    this._term.onData((data) => this._appendToOutputTail(data))
+    this._term.onData((data) => {
+      this._appendToOutputTail(data)
+      // #5835 Phase 1: feed the live remote-viewer mirror (the authenticity
+      // surface). Same raw bytes that go to _outputTail, but coalesced and
+      // broadcast to subscribed clients so they can watch the real TUI redraw.
+      this._feedTerminalMirror(data)
+    })
     this._term.onExit((info) => this._onPtyGone(info, 'exit'))
 
     // #5311 (WP-1.1) — keep a per-session PTY fault from crashing the WHOLE
@@ -1713,6 +1735,44 @@ export class ClaudeTuiSession extends BaseSession {
       .toString('utf8')
       .replace(ANSI_STRIP, '')
       .slice(-ClaudeTuiSession.PTY_TAIL_BYTES)
+  }
+
+  /**
+   * #5835 Phase 1: feed the live remote-viewer mirror. Appends a raw PTY chunk
+   * (ANSI intact — the viewer xterm renders it) to the coalescing buffer and
+   * arms a single flush timer if one isn't already pending. The bytes are NOT
+   * stripped or transformed: faithful reproduction is the whole point.
+   */
+  _feedTerminalMirror(data) {
+    this._mirrorBuffer += String(data)
+    if (this._mirrorTimer) return
+    this._mirrorTimer = setTimeout(() => this._flushTerminalMirror(), ClaudeTuiSession.MIRROR_FLUSH_MS)
+    // Don't keep the event loop alive for a mirror flush — teardown clears it.
+    if (typeof this._mirrorTimer.unref === 'function') this._mirrorTimer.unref()
+  }
+
+  /**
+   * Emit the coalesced mirror buffer as one `terminal_output` event and reset.
+   * No-op when the buffer is empty (e.g. a stray flush after teardown).
+   */
+  _flushTerminalMirror() {
+    this._mirrorTimer = null
+    const data = this._mirrorBuffer
+    if (!data) return
+    this._mirrorBuffer = ''
+    this.emit('terminal_output', { data })
+  }
+
+  /**
+   * Drop any pending mirror flush + buffered bytes. Called on teardown so a
+   * dead PTY's leftover frame never broadcasts and no timer leaks.
+   */
+  _clearTerminalMirror() {
+    if (this._mirrorTimer) {
+      clearTimeout(this._mirrorTimer)
+      this._mirrorTimer = null
+    }
+    this._mirrorBuffer = ''
   }
 
   /**

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -345,6 +345,23 @@ function handleUnsubscribeSessions(ws, client, msg, ctx) {
   })
 }
 
+// #5835 Phase 1: opt the client IN to a session's live PTY mirror. Only clients
+// in `terminalSessionIds` receive `terminal_output` (ws-forwarding's filter), so
+// a Chat-tab client never pays for raw bytes it isn't rendering. A bound client
+// may only watch its own session, mirroring handleSubscribeSessions.
+function handleTerminalSubscribe(ws, client, msg) {
+  const sid = msg.sessionId
+  if (client.boundSessionId && client.boundSessionId !== sid) return
+  if (!client.terminalSessionIds) client.terminalSessionIds = new Set()
+  client.terminalSessionIds.add(sid)
+}
+
+// #5835 Phase 1: opt the client OUT of a session's live PTY mirror (e.g. the
+// dashboard leaving the Output tab). Idempotent.
+function handleTerminalUnsubscribe(ws, client, msg) {
+  if (client.terminalSessionIds) client.terminalSessionIds.delete(msg.sessionId)
+}
+
 // #3404: mobile app sends this when foreground/background state changes so
 // the server can suppress idle/completion pushes only for foreground viewers.
 // Backgrounded clients with still-alive sockets must NOT be treated as active
@@ -427,6 +444,8 @@ export const sessionHandlers = {
   rename_session: handleRenameSession,
   subscribe_sessions: handleSubscribeSessions,
   unsubscribe_sessions: handleUnsubscribeSessions,
+  terminal_subscribe: handleTerminalSubscribe,
+  terminal_unsubscribe: handleTerminalUnsubscribe,
   client_visible: handleClientVisible,
   claim_primary: handleClaimPrimary,
 }

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -349,9 +349,12 @@ function handleUnsubscribeSessions(ws, client, msg, ctx) {
 // in `terminalSessionIds` receive `terminal_output` (ws-forwarding's filter), so
 // a Chat-tab client never pays for raw bytes it isn't rendering. A bound client
 // may only watch its own session, mirroring handleSubscribeSessions.
-function handleTerminalSubscribe(ws, client, msg) {
+function handleTerminalSubscribe(ws, client, msg, ctx) {
   const sid = msg.sessionId
   if (client.boundSessionId && client.boundSessionId !== sid) return
+  // Parity with handleSubscribeSessions: only track a REAL session, so a client
+  // can't grow terminalSessionIds unboundedly with junk ids.
+  if (!ctx?.sessions?.sessionManager?.getSession?.(sid)) return
   if (!client.terminalSessionIds) client.terminalSessionIds = new Set()
   client.terminalSessionIds.add(sid)
 }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2166,6 +2166,16 @@ export class SessionManager extends EventEmitter {
     const sessionLog = log.withSession(sessionId)
     // Events worth logging to the System tab (skip noisy delta/tool_result)
     const LOGGED_EVENTS = new Set(['ready', 'stream_start', 'stream_end', 'result', 'error'])
+
+    // #5835 Phase 1: claude-tui live PTY mirror (the "remote viewer" / authenticity
+    // surface). These are transient, high-frequency redraw bytes — proxy them to
+    // subscribed clients but keep them OUT of _recordHistory (not conversation
+    // history) and OUT of touchActivity (a mirror frame is not user activity).
+    // Wired separately from PROXIED_EVENTS for exactly that reason.
+    session.on('terminal_output', (data) => {
+      this.emit('session_event', { sessionId, event: 'terminal_output', data })
+    })
+
     for (const event of PROXIED_EVENTS) {
       session.on(event, (data) => {
         if (ACTIVITY_EVENTS.has(event)) this.touchActivity(sessionId)

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -144,6 +144,20 @@ function setupSessionForwarding(normalizer, ctx) {
       return
     }
 
+    // #5835 Phase 1: claude-tui live PTY mirror (the remote-viewer / authenticity
+    // surface). Broadcast ONLY to clients that explicitly opted into terminal
+    // output for THIS session (terminal_subscribe) — not every session
+    // subscriber — so a Chat-tab client never pays for raw PTY bytes it isn't
+    // rendering. Transient: no history, no normalizer, no serverTs.
+    if (event === 'terminal_output') {
+      broadcastToSession(
+        sessionId,
+        { type: 'terminal_output', sessionId, data: typeof data?.data === 'string' ? data.data : '' },
+        (client) => Boolean(client.terminalSessionIds && client.terminalSessionIds.has(sessionId)),
+      )
+      return
+    }
+
     // Sidebar activity feed: lightweight status broadcast to ALL authenticated clients
     if (event === 'stream_start') {
       broadcast({ type: 'session_activity', sessionId, isBusy: true, lastCost: null })

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -153,7 +153,16 @@ function setupSessionForwarding(normalizer, ctx) {
       broadcastToSession(
         sessionId,
         { type: 'terminal_output', sessionId, data: typeof data?.data === 'string' ? data.data : '' },
-        (client) => Boolean(client.terminalSessionIds && client.terminalSessionIds.has(sessionId)),
+        // A custom filter OVERRIDES broadcastToSession's default session scoping,
+        // so re-assert it here: deliver only to a client that is BOTH a viewer of
+        // the session (activeSessionId / subscribedSessionIds) AND opted into its
+        // terminal mirror. Opt-in alone must not bypass scoping, and unsubscribing
+        // from the session must stop the bytes.
+        (client) => Boolean(
+          client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
+          (client.activeSessionId === sessionId ||
+            (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))),
+        ),
       )
       return
     }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -297,6 +297,8 @@ function _isSecureRequest(req) {
  *   { type: 'search_conversations', query }             — search saved conversations
  *   { type: 'subscribe_sessions' }                      — subscribe to session discovery events
  *   { type: 'unsubscribe_sessions' }                    — unsubscribe from session discovery
+ *   { type: 'terminal_subscribe', sessionId }           — #5835 opt IN to a session's live PTY mirror (terminal_output); only opted-in clients receive raw bytes
+ *   { type: 'terminal_unsubscribe', sessionId }         — #5835 opt OUT of a session's live PTY mirror
  *   { type: 'set_thinking_level', level }               — set thinking budget level ('default'|'high'|'max')
  *   { type: 'set_permission_rules', rules, sessionId }  — set per-session auto-approval rules
  *   { type: 'set_prompt_evaluator', value: boolean, sessionId? } — toggle the per-session promptEvaluator (#3185)
@@ -325,6 +327,7 @@ function _isSecureRequest(req) {
  *   { type: 'stream_start', messageId: '...' }        — beginning of streaming response
  *   { type: 'stream_delta', messageId, delta }         — token-by-token text
  *   { type: 'stream_end',   messageId: '...' }        — streaming response complete
+ *   { type: 'terminal_output', sessionId, data }       — #5835 live claude-tui PTY mirror (raw, ANSI-intact, coalesced ~50ms); emitted from ws-forwarding.js to clients that opted in via terminal_subscribe; the remote-viewer / authenticity surface
  *   { type: 'tool_start',   messageId, toolUseId, tool, input, serverName? } — tool invocation (serverName present for MCP tools)
  *   { type: 'tool_input_delta', messageId, toolUseId, partialJson } — #4080/#4081: incremental partial JSON for the streaming tool_use `input`; concatenate per-toolUseId for the live bubble preview
  *   { type: 'tool_result',  toolUseId, result, truncated, images? }  — tool result (images: [{mediaType, data}])
@@ -1479,6 +1482,11 @@ export class WsServer {
         mode: 'chat', // default to chat view
         activeSessionId: null,
         subscribedSessionIds: new Set(),
+        // #5835 Phase 1: sessions this client opted into LIVE TERMINAL output for
+        // (terminal_subscribe). Kept separate from subscribedSessionIds so a
+        // Chat-tab client subscribed to a session doesn't receive its raw PTY
+        // mirror bytes — only clients actually viewing the terminal do.
+        terminalSessionIds: new Set(),
         isAlive: true,
         deviceInfo: null,
         ip,

--- a/packages/server/tests/claude-tui-mirror.test.js
+++ b/packages/server/tests/claude-tui-mirror.test.js
@@ -2,15 +2,25 @@
 // _feedTerminalMirror → _flushTerminalMirror → terminal_output emit path and
 // _clearTerminalMirror teardown WITHOUT spawning a PTY (the coalescer is pure
 // buffer + timer + emit). Timers are faked so the 50ms flush is deterministic.
-import { test, mock } from 'node:test'
+import { test, mock, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync } from 'fs'
+import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
 
+// Track the temp skillsDirs makeSession() mints so they don't accumulate under
+// /tmp across the suite (best-effort cleanup).
+const _tmpDirs = []
+afterEach(() => {
+  while (_tmpDirs.length) {
+    try { rmSync(_tmpDirs.pop(), { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
+})
+
 function makeSession() {
   const skillsDir = mkdtempSync(join(tmpdir(), 'tui-mirror-skills-'))
+  _tmpDirs.push(skillsDir)
   return new ClaudeTuiSession({ cwd: '/tmp', port: 0, skillsDir, repoSkillsDir: null })
 }
 

--- a/packages/server/tests/claude-tui-mirror.test.js
+++ b/packages/server/tests/claude-tui-mirror.test.js
@@ -1,0 +1,76 @@
+// #5835 Phase 1: the claude-tui live-mirror coalescer. Unit-tests the
+// _feedTerminalMirror → _flushTerminalMirror → terminal_output emit path and
+// _clearTerminalMirror teardown WITHOUT spawning a PTY (the coalescer is pure
+// buffer + timer + emit). Timers are faked so the 50ms flush is deterministic.
+import { test, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+
+function makeSession() {
+  const skillsDir = mkdtempSync(join(tmpdir(), 'tui-mirror-skills-'))
+  return new ClaudeTuiSession({ cwd: '/tmp', port: 0, skillsDir, repoSkillsDir: null })
+}
+
+test('coalesces onData chunks into one terminal_output flush per tick', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  try {
+    const s = makeSession()
+    const emitted = []
+    s.on('terminal_output', (e) => emitted.push(e.data))
+
+    s._feedTerminalMirror('a')
+    s._feedTerminalMirror('b')
+    s._feedTerminalMirror('c')
+    assert.equal(emitted.length, 0, 'nothing flushes before the timer fires')
+
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS)
+    assert.deepEqual(emitted, ['abc'], 'one coalesced flush of all buffered bytes')
+
+    // Buffer + timer reset — a later chunk flushes on its own next tick.
+    s._feedTerminalMirror('d')
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS)
+    assert.deepEqual(emitted, ['abc', 'd'])
+  } finally {
+    mock.timers.reset()
+  }
+})
+
+test('preserves raw bytes (ANSI intact) — no stripping in the mirror path', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  try {
+    const s = makeSession()
+    const emitted = []
+    s.on('terminal_output', (e) => emitted.push(e.data))
+    s._feedTerminalMirror('\x1b[?1049h\x1b[31mred\x1b[0m')
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS)
+    assert.deepEqual(emitted, ['\x1b[?1049h\x1b[31mred\x1b[0m'])
+  } finally {
+    mock.timers.reset()
+  }
+})
+
+test('_clearTerminalMirror cancels a pending flush and drops the buffer', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  try {
+    const s = makeSession()
+    const emitted = []
+    s.on('terminal_output', (e) => emitted.push(e.data))
+    s._feedTerminalMirror('x')
+    s._clearTerminalMirror()
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS * 2)
+    assert.equal(emitted.length, 0, 'cleared before flush → nothing emitted, no leaked timer')
+  } finally {
+    mock.timers.reset()
+  }
+})
+
+test('flush with an empty buffer is a no-op (stray flush after teardown)', () => {
+  const s = makeSession()
+  const emitted = []
+  s.on('terminal_output', (e) => emitted.push(e.data))
+  s._flushTerminalMirror()
+  assert.equal(emitted.length, 0)
+})

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -708,11 +708,19 @@ describe('session-handlers', () => {
   })
 
   describe('terminal_subscribe / terminal_unsubscribe (#5835)', () => {
-    it('terminal_subscribe adds the session to the client terminal set', () => {
+    it('terminal_subscribe adds an existing session to the client terminal set', () => {
       const ctx = makeCtx()
+      ctx._sessions.set('sess-1', { session: {}, cwd: '/tmp', name: 'S1' })
       const client = makeClient()
       sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
       assert.ok(client.terminalSessionIds.has('sess-1'))
+    })
+
+    it('terminal_subscribe to a non-existent session is a no-op (no junk-id growth)', () => {
+      const ctx = makeCtx()
+      const client = makeClient()
+      sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'ghost' }, ctx)
+      assert.ok(!client.terminalSessionIds || !client.terminalSessionIds.has('ghost'))
     })
 
     it('terminal_unsubscribe removes the session and is idempotent', () => {
@@ -727,6 +735,8 @@ describe('session-handlers', () => {
 
     it('a bound client cannot subscribe to a different session', () => {
       const ctx = makeCtx()
+      ctx._sessions.set('sess-other', { session: {}, cwd: '/tmp', name: 'O' })
+      ctx._sessions.set('sess-bound', { session: {}, cwd: '/tmp', name: 'B' })
       const client = makeClient({ boundSessionId: 'sess-bound' })
       sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-other' }, ctx)
       assert.ok(!client.terminalSessionIds || !client.terminalSessionIds.has('sess-other'))

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -706,4 +706,33 @@ describe('session-handlers', () => {
       assert.equal(ctx.clientManager.getPrimary('sess-1'), 'owner')
     })
   })
+
+  describe('terminal_subscribe / terminal_unsubscribe (#5835)', () => {
+    it('terminal_subscribe adds the session to the client terminal set', () => {
+      const ctx = makeCtx()
+      const client = makeClient()
+      sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
+      assert.ok(client.terminalSessionIds.has('sess-1'))
+    })
+
+    it('terminal_unsubscribe removes the session and is idempotent', () => {
+      const ctx = makeCtx()
+      const client = makeClient({ terminalSessionIds: new Set(['sess-1']) })
+      sessionHandlers.terminal_unsubscribe(makeWs(), client, { type: 'terminal_unsubscribe', sessionId: 'sess-1' }, ctx)
+      assert.ok(!client.terminalSessionIds.has('sess-1'))
+      // idempotent — unsubscribing again does not throw
+      sessionHandlers.terminal_unsubscribe(makeWs(), client, { type: 'terminal_unsubscribe', sessionId: 'sess-1' }, ctx)
+      assert.ok(!client.terminalSessionIds.has('sess-1'))
+    })
+
+    it('a bound client cannot subscribe to a different session', () => {
+      const ctx = makeCtx()
+      const client = makeClient({ boundSessionId: 'sess-bound' })
+      sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-other' }, ctx)
+      assert.ok(!client.terminalSessionIds || !client.terminalSessionIds.has('sess-other'))
+      // but it may watch its OWN bound session
+      sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-bound' }, ctx)
+      assert.ok(client.terminalSessionIds.has('sess-bound'))
+    })
+  })
 })

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -1441,11 +1441,14 @@ describe('terminal_output forwarding (#5835)', () => {
     assert.equal(msg.type, 'terminal_output')
     assert.equal(msg.sessionId, 'sess-1')
     assert.equal(msg.data, '\x1b[31mhi\x1b[0m')
-    // The filter admits only a client that opted into THIS session's terminal.
+    // The filter admits only a client that is BOTH a viewer of the session AND
+    // opted into its terminal — opt-in alone must not bypass session scoping.
     assert.equal(typeof filter, 'function')
-    assert.equal(filter({ terminalSessionIds: new Set(['sess-1']) }), true)
-    assert.equal(filter({ terminalSessionIds: new Set(['other']) }), false)
-    assert.equal(filter({ subscribedSessionIds: new Set(['sess-1']) }), false) // chat-only subscriber excluded
+    assert.equal(filter({ terminalSessionIds: new Set(['sess-1']), subscribedSessionIds: new Set(['sess-1']) }), true)
+    assert.equal(filter({ terminalSessionIds: new Set(['sess-1']), activeSessionId: 'sess-1' }), true) // active counts as viewing
+    assert.equal(filter({ terminalSessionIds: new Set(['sess-1']) }), false) // opted in but NOT subscribed → excluded
+    assert.equal(filter({ terminalSessionIds: new Set(['other']), subscribedSessionIds: new Set(['sess-1']) }), false) // opted into a different session
+    assert.equal(filter({ subscribedSessionIds: new Set(['sess-1']) }), false) // chat-only subscriber, not opted in
     assert.equal(filter({}), false)
   })
 

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -1423,3 +1423,46 @@ describe('forwarding listener throw containment (#5313)', () => {
     assert.ok(errLog, 'expected an error log naming the event and the containment site')
   })
 })
+
+describe('terminal_output forwarding (#5835)', () => {
+  it('broadcasts terminal_output ONLY to clients opted into the session terminal', () => {
+    const ctx = makeCtx()
+    setupForwarding(ctx)
+
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-1',
+      event: 'terminal_output',
+      data: { data: '\x1b[31mhi\x1b[0m' },
+    })
+
+    assert.equal(ctx.broadcastToSession.mock.callCount(), 1)
+    const [sid, msg, filter] = ctx.broadcastToSession.mock.calls[0].arguments
+    assert.equal(sid, 'sess-1')
+    assert.equal(msg.type, 'terminal_output')
+    assert.equal(msg.sessionId, 'sess-1')
+    assert.equal(msg.data, '\x1b[31mhi\x1b[0m')
+    // The filter admits only a client that opted into THIS session's terminal.
+    assert.equal(typeof filter, 'function')
+    assert.equal(filter({ terminalSessionIds: new Set(['sess-1']) }), true)
+    assert.equal(filter({ terminalSessionIds: new Set(['other']) }), false)
+    assert.equal(filter({ subscribedSessionIds: new Set(['sess-1']) }), false) // chat-only subscriber excluded
+    assert.equal(filter({}), false)
+  })
+
+  it('coerces a non-string/absent data payload to an empty string', () => {
+    const ctx = makeCtx()
+    setupForwarding(ctx)
+    ctx.sessionManager.emit('session_event', { sessionId: 'sess-1', event: 'terminal_output', data: {} })
+    const [, msg] = ctx.broadcastToSession.mock.calls[0].arguments
+    assert.equal(msg.data, '')
+  })
+
+  it('does not record terminal_output to history or touch activity', () => {
+    const ctx = makeCtx()
+    // session_event for terminal_output must not go through the normalizer path
+    // (no history write). It returns early — only broadcastToSession fires.
+    setupForwarding(ctx)
+    ctx.sessionManager.emit('session_event', { sessionId: 'sess-1', event: 'terminal_output', data: { data: 'x' } })
+    assert.equal(ctx.broadcast.mock.callCount(), 0) // not a global broadcast (no session_activity)
+  })
+})


### PR DESCRIPTION
## Summary

PR1 of the TUI live remote-viewer epic (**#5835**). Streams the **real `claude-tui` PTY bytes** to opted-in clients so the terminal view can become a faithful, trustworthy mirror of the actual TUI — the *authenticity surface*. **Server-only**; the dashboard render lands in PR2.

### The gap this closes
Before this, `claude-tui`'s PTY `onData` bytes were captured into a server-internal ring buffer **for crash diagnostics only** (`claude-tui-session.js`) and never reached clients. The "Output" tab showed the Stop-hook's final `last_assistant_message`, not the live redraw — a transcript in xterm clothing, not a mirror.

## What changed

- **`claude-tui-session.js`** — `onData` now also feeds a coalescing mirror: bytes are buffered and flushed as one `terminal_output` event per ~50ms tick (bounds the broadcast rate to the tunnel — the deliberate latency-for-bandwidth trade, "a bit laggier is fine"). **Raw bytes, ANSI intact** (alternate-screen buffer, cursor, colors all reproduce). Timer is `unref`'d and cleared on PTY teardown (no leak, no post-death frame).
- **`session-manager.js`** — proxies `terminal_output` as a `session_event`, wired **separately** from `PROXIED_EVENTS` so it's kept OUT of history and idle-activity (a mirror frame is neither conversation history nor user activity).
- **`ws-forwarding.js`** — broadcasts `terminal_output` **only to clients that opted in** via `terminal_subscribe` (not every session subscriber), so a Chat-tab client never pays for raw PTY bytes it isn't rendering.
- **protocol + handlers** — new `terminal_subscribe` / `terminal_unsubscribe` client messages (per-client `terminalSessionIds` set, bound-client guarded) and the `terminal_output` server message (documented in the ws-server protocol comment; in `INTENTIONALLY_UNHANDLED` until PR2 adds the dashboard case).

## Security
Bytes only reach clients that are authed + subscribed + explicitly opted in — the **same trust boundary `stream_delta` already crosses**. No new exposure. (Remote *control* / keystroke forwarding is Phase 3, where the auth review actually lands.)

## Not in this PR
- Dashboard render + gate-to-`claude-tui` + pinned 120×30 → **PR2**.
- Resize sync → Phase 2. Keystroke forwarding → Phase 3. (See #5835.)

## Testing
- `claude-tui-mirror.test.js` (new) — coalescer with fake timers (one flush per tick, buffer reset), raw-byte/ANSI fidelity, `_clearTerminalMirror` cancels a pending flush (no leak), empty-buffer flush no-op.
- `ws-forwarding.test.js` — `terminal_output` broadcasts with a filter admitting **only** opted-in clients (chat-only subscriber excluded); non-string data coerced to `''`; no global broadcast.
- `session-handlers.test.js` — subscribe adds / unsubscribe removes (idempotent) / bound-client guard.
- Schema-coverage + handler-coverage contract gates updated and green.

Full server suite: 9663 tests, 2 failures — both the known `service.test.js` `getFullServiceStatus` artifact from a live local `:8765` daemon (project memory); unrelated, green on CI. Protocol 289/289. Protocol `dist/` rebuilt (additive-only diff).
