### PR TITLE
feat(dashboard): render live claude-tui PTY mirror (#5835 Phase 1, PR2)

### DIFF
--- a/docs/reports/smoke-test-5769.html
+++ b/docs/reports/smoke-test-5769.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Smoke Test — PR #5769 (FormDriver injected collaborator)</title>
+<style>
+  :root {
+    --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --ink:#e7eaf0; --muted:#9aa3b2;
+    --accent:#5b9dff; --good:#3fb950; --warn:#d29922; --bad:#f85149; --line:#2a2f3a;
+    --code:#0b0d12; --mono:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--ink);
+    font:15px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; }
+  .wrap { max-width:920px; margin:0 auto; padding:32px 24px 96px; }
+  header.hero { border:1px solid var(--line); border-radius:14px; padding:22px 24px;
+    background:linear-gradient(135deg,#171a21,#1b2230); margin-bottom:24px; }
+  header.hero h1 { margin:0 0 6px; font-size:22px; }
+  header.hero .sub { color:var(--muted); font-size:14px; }
+  .pill { display:inline-block; font-size:11px; font-weight:600; letter-spacing:.04em;
+    text-transform:uppercase; padding:3px 9px; border-radius:999px; vertical-align:middle; }
+  .pill.gate { background:rgba(91,157,255,.15); color:var(--accent); border:1px solid rgba(91,157,255,.35); }
+  .pill.hold { background:rgba(210,153,34,.15); color:var(--warn); border:1px solid rgba(210,153,34,.35); }
+  h2 { font-size:17px; margin:34px 0 12px; padding-bottom:8px; border-bottom:1px solid var(--line); }
+  h2 .n { display:inline-block; width:26px; height:26px; line-height:26px; text-align:center;
+    background:var(--accent); color:#06122b; border-radius:7px; font-size:14px; font-weight:700; margin-right:10px; }
+  p { margin:10px 0; }
+  .muted { color:var(--muted); }
+  .panel { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:18px 20px; margin:14px 0; }
+  .why { border-left:3px solid var(--accent); }
+  code { font-family:var(--mono); font-size:13px; background:#22272f; padding:1px 6px; border-radius:5px; }
+  pre { background:var(--code); border:1px solid var(--line); border-radius:10px; padding:14px 16px;
+    overflow:auto; font-family:var(--mono); font-size:13px; line-height:1.55; position:relative; }
+  pre .cmt { color:#6b7686; }
+  .label { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--muted);
+    margin:0 0 6px; font-weight:600; }
+  ul.checks { list-style:none; padding:0; margin:8px 0; }
+  ul.checks li { padding:8px 0 8px 32px; position:relative; border-bottom:1px solid var(--line); }
+  ul.checks li:last-child { border-bottom:0; }
+  ul.checks li::before { content:'☐'; position:absolute; left:4px; top:7px; font-size:18px; color:var(--muted); }
+  .test { background:var(--panel2); border:1px solid var(--line); border-radius:12px; margin:16px 0; overflow:hidden; }
+  .test > .head { padding:14px 18px; display:flex; align-items:center; gap:12px; background:#202633; }
+  .test > .head .tag { font-size:11px; font-weight:700; padding:3px 8px; border-radius:6px;
+    background:var(--accent); color:#06122b; }
+  .test > .head h3 { margin:0; font-size:15px; }
+  .test > .body { padding:4px 18px 16px; }
+  .test .row { display:grid; grid-template-columns:130px 1fr; gap:12px; padding:10px 0; border-bottom:1px solid var(--line); align-items:start; }
+  .test .row:last-child { border-bottom:0; }
+  .test .row .k { color:var(--muted); font-size:12px; text-transform:uppercase; letter-spacing:.05em; font-weight:600; padding-top:2px; }
+  .expect { color:var(--good); }
+  .verdict { display:flex; gap:10px; margin-top:6px; }
+  .verdict span { flex:1; text-align:center; padding:8px; border-radius:8px; border:1px solid var(--line);
+    font-size:13px; font-weight:600; color:var(--muted); }
+  .verdict .pass { border-color:rgba(63,185,80,.4); }
+  .verdict .fail { border-color:rgba(248,81,73,.4); }
+  .note { font-size:13px; color:var(--muted); }
+  .danger { border-left:3px solid var(--bad); }
+  .ok { border-left:3px solid var(--good); }
+  kbd { font-family:var(--mono); font-size:12px; background:#2a2f3a; border:1px solid #3a4151;
+    border-bottom-width:2px; border-radius:5px; padding:1px 6px; }
+  a { color:var(--accent); }
+  .foot { margin-top:40px; color:var(--muted); font-size:12px; text-align:center; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="hero">
+  <div style="margin-bottom:8px">
+    <span class="pill gate">Gate-ready · CLEAN</span>
+    <span class="pill hold">Held for your live-PTY smoke test</span>
+  </div>
+  <h1>Smoke Test — PR #5769</h1>
+  <div class="sub">
+    <code>refactor(server): make claude-tui FormDriver an injected collaborator (#5617)</code><br>
+    Branch <code>refactor/5617-formdriver-injected-collaborator</code> ·
+    <a href="https://github.com/blamechris/chroxy/pull/5769">github.com/blamechris/chroxy/pull/5769</a>
+  </div>
+</header>
+
+<div class="panel why">
+  <p class="label">Why a human has to drive this</p>
+  <p>This PR refactors the <strong>most fragile, empirically-pinned code in the repo</strong> — the
+  AskUserQuestion form driving that types keystrokes into a live <code>claude</code> TUI. The change is a
+  <em>pure receiver swap</em> (mixin → injected collaborator) and is <strong>proven byte-for-byte
+  behavior-preserving by construction</strong> + 6 new isolated unit tests + 340 existing tests + Copilot.</p>
+  <p>But project memory (<code>tui_multi_question_form_keys</code>, <code>multi_question_post_deny_wedge</code>,
+  #4668) is blunt: some form-driving edge cases <strong>only ever surface against a real PTY</strong>. So before
+  we merge, we drive a couple of real AskUserQuestion forms through a live session and watch the TUI actually
+  land on the option you picked. ~10 minutes.</p>
+  <p class="note">The keystroke logic did <strong>not</strong> change in this PR — so if forms behaved correctly on
+  <code>main</code>, they must here. Any misbehavior you see is a real regression and a hard <strong>STOP</strong>
+  on the merge.</p>
+</div>
+
+<h2><span class="n">0</span>Pre-flight (~1 min)</h2>
+<div class="panel">
+  <p class="label">You should already be on the branch — confirm it</p>
+<pre><span class="cmt"># from the repo root: /Users/blamechris/Projects/chroxy</span>
+git branch --show-current   <span class="cmt"># → refactor/5617-formdriver-injected-collaborator</span>
+git status                  <span class="cmt"># → clean working tree</span></pre>
+  <ul class="checks">
+    <li>On branch <code>refactor/5617-formdriver-injected-collaborator</code>, clean tree.</li>
+    <li>The <code>claude</code> CLI is installed and logged in (the TUI provider spawns the real binary).</li>
+    <li>Your menu-bar <strong>Chroxy.app daemon on :8765 stays running</strong> — we use a different port so we never touch it.</li>
+  </ul>
+</div>
+
+<h2><span class="n">1</span>Start the branch server on a throwaway port (loopback only)</h2>
+<div class="panel">
+  <p>This runs <strong>this branch's source</strong> (not the published <code>npx chroxy</code>, not your :8765 daemon)
+  with the <code>claude-tui</code> provider, no tunnel, no auth, bound to loopback, on port <strong>8799</strong>.
+  Run it in its own terminal and leave it streaming logs — you'll watch them during the tests.</p>
+<pre>PORT=8799 PATH="/opt/homebrew/opt/node@22/bin:$PATH" \
+  node packages/server/src/cli.js start \
+  --provider claude-tui \
+  --no-auth \
+  --no-supervisor \
+  --host 127.0.0.1 \
+  --skip-checks \
+  --dangerously-skip-permissions \
+  --log-format text</pre>
+  <p class="note"><code>--no-auth</code> disables the tunnel and token (loopback dev only).
+  <code>--no-supervisor</code> keeps it a single foreground process so <kbd>Ctrl-C</kbd> cleanly stops it.
+  <code>--dangerously-skip-permissions</code> stops chroxy's permission gate from interrupting the form flow —
+  it does <em>not</em> affect FormDriver, it just keeps the run smooth. <code>PORT=8799</code> guarantees no
+  collision with the :8765 daemon.</p>
+  <p class="note">If the dashboard looks stale you can optionally rebuild it first (FormDriver is server-side, so
+  this is rarely needed): <code>npm run build -w @chroxy/dashboard</code></p>
+  <ul class="checks">
+    <li>Server logs <code>provider: claude-tui</code> in the startup banner and is listening on <code>127.0.0.1:8799</code>.</li>
+  </ul>
+</div>
+
+<h2><span class="n">2</span>Open the dashboard &amp; start a live session</h2>
+<div class="panel">
+  <p>Open the server-hosted dashboard in a browser:</p>
+<pre>open http://127.0.0.1:8799/dashboard</pre>
+  <ul class="checks">
+    <li>Dashboard loads (no token prompt, since <code>--no-auth</code>).</li>
+    <li>Start a new session / send a first message — confirm a <strong>real claude TUI session</strong> spins up
+        (you'll see PTY output stream into the terminal view).</li>
+  </ul>
+  <p class="note"><strong>What to watch in the server-log terminal during every answer:</strong> each time you
+  submit an answer you should see a line like<br>
+  <code>respondToQuestion: tool=… dashboardToolUseId=… text.length=… answersMap.keys=… questions=… options=…</code><br>
+  and for multi-question single-selects:
+  <code>AskUserQuestion multi-question: single-select pick at idx=N (option N+1) …</code></p>
+</div>
+
+<h2><span class="n">3</span>Run the four checks</h2>
+<p class="muted">Paste each trigger prompt into the chat as a message to claude. The model will call its built-in
+AskUserQuestion tool; answer it from the chroxy UI; confirm the live TUI lands on exactly what you chose and
+claude continues with that answer.</p>
+
+<!-- TEST A -->
+<div class="test">
+  <div class="head"><span class="tag">A</span><h3>Single multiple-choice question — option select</h3></div>
+  <div class="body">
+    <div class="row"><div class="k">Trigger</div><div>
+      <pre>Use the AskUserQuestion tool to ask me ONE single-select question:
+"Pick a fruit" with options Apple, Banana, Cherry. Then tell me which I picked.</pre>
+    </div></div>
+    <div class="row"><div class="k">Do</div><div>In the chroxy form, pick the <strong>3rd option (Cherry)</strong>.</div></div>
+    <div class="row"><div class="k">Expect</div><div class="expect">The TUI selects Cherry (the 1-indexed hotkey digit <code>3</code> is written — #4290),
+      the form submits, and claude replies confirming <strong>Cherry</strong>. No stray keystrokes, no wedge.</div></div>
+    <div class="row"><div class="k">Verdict</div><div class="verdict"><span class="pass">☐ PASS</span><span class="fail">☐ FAIL</span></div></div>
+  </div>
+</div>
+
+<!-- TEST B -->
+<div class="test">
+  <div class="head"><span class="tag">B</span><h3>Multi-question form — single-select + multi-select</h3></div>
+  <div class="body">
+    <div class="row"><div class="k">Trigger</div><div>
+      <pre>Use the AskUserQuestion tool to ask me TWO questions at once:
+1) single-select "Choose a size": Small, Medium, Large
+2) multi-select "Pick toppings": Cheese, Mushroom, Onion, Pepper
+Then summarize my answers.</pre>
+    </div></div>
+    <div class="row"><div class="k">Do</div><div>Q1 → pick <strong>Large</strong>. Q2 → check <strong>Cheese</strong> and <strong>Onion</strong>. Submit.</div></div>
+    <div class="row"><div class="k">Expect</div><div class="expect">TUI advances through both questions (digit auto-advance on the single-select,
+      Tab/space between the multi-select toggles, then Submit). claude summarizes back <strong>Large + Cheese, Onion</strong> —
+      no extra/missing toppings, no skipped question. This is the #4604/Chunk-B path the pinned byte sequences cover.</div></div>
+    <div class="row"><div class="k">Verdict</div><div class="verdict"><span class="pass">☐ PASS</span><span class="fail">☐ FAIL</span></div></div>
+  </div>
+</div>
+
+<!-- TEST C -->
+<div class="test">
+  <div class="head"><span class="tag">C</span><h3>"Other" / freeform answer — literal fallthrough</h3></div>
+  <div class="body">
+    <div class="row"><div class="k">Trigger</div><div>
+      <pre>Use the AskUserQuestion tool to ask me ONE single-select question:
+"What's your favorite color?" with options Red, Green, Blue.
+Then tell me my answer verbatim.</pre>
+    </div></div>
+    <div class="row"><div class="k">Do</div><div>Choose <strong>Other</strong> and type a freeform value, e.g. <code>chartreuse</code>. Submit.</div></div>
+    <div class="row"><div class="k">Expect</div><div class="expect">The two-stage Other flow fires: the Other hotkey is pressed, the TUI swaps to a
+      text prompt (settle delay #4651), then <code>chartreuse</code> is typed literally and submitted. claude echoes back
+      <strong>chartreuse</strong>. No truncation, no race where text lands before the prompt swap.</div></div>
+    <div class="row"><div class="k">Verdict</div><div class="verdict"><span class="pass">☐ PASS</span><span class="fail">☐ FAIL</span></div></div>
+  </div>
+</div>
+
+<!-- TEST D -->
+<div class="test">
+  <div class="head"><span class="tag">D</span><h3>Deny → retry (the #4668 post-deny wedge edge) — optional but valuable</h3></div>
+  <div class="body">
+    <div class="row"><div class="k">Trigger</div><div>Re-run Test A's prompt, but this time <strong>deny / dismiss</strong> the first
+      form (or let it time out), then ask claude to ask again and answer normally.</div></div>
+    <div class="row"><div class="k">Expect</div><div class="expect">After the deny, the retry form is answered cleanly — the second answer's keystrokes
+      go into the <em>new</em> form, not a stale one (the stale-toolUseId drop, #4668). No wedge, no keystrokes typed
+      into a dead prompt.</div></div>
+    <div class="row"><div class="k">Verdict</div><div class="verdict"><span class="pass">☐ PASS</span><span class="fail">☐ FAIL</span></div></div>
+    <div class="row"><div class="k">Note</div><div class="note">This path is the historically wedgiest one
+      (<code>multi_question_post_deny_wedge</code>). If A–C pass and you're short on time, this is the one worth the extra 2 min.</div></div>
+  </div>
+</div>
+
+<h2><span class="n">4</span>Tear down — never touch :8765</h2>
+<div class="panel danger">
+  <p>Stop <strong>only</strong> the branch server you started in Step 1: focus that terminal and press
+  <kbd>Ctrl-C</kbd> (sends SIGTERM — clean shutdown, flushes state). Your menu-bar Chroxy.app daemon on :8765
+  is a different process and must keep running.</p>
+  <p class="note">Do <strong>not</strong> <code>pkill -9</code> / <code>kill -9</code> anything — SIGKILL bypasses the
+  state-flush handler and wipes session state. Plain <kbd>Ctrl-C</kbd> only.</p>
+</div>
+
+<h2><span class="n">5</span>Verdict → what I do next</h2>
+<div class="panel ok">
+  <p><strong>If A–C (and ideally D) all PASS:</strong> tell me <em>"smoke test passed, merge #5769"</em>. I'll run the
+  final gate (CI green on the head SHA + threads resolved), then synchronously squash-merge and report the SHA.</p>
+  <p><strong>If anything FAILED:</strong> tell me which test and paste the
+  <code>respondToQuestion …</code> log line(s) from the server terminal plus what the TUI actually did. That's a real
+  regression — I'll <strong>STOP the merge</strong>, reopen #5617, and dig in (the reversal proof says it shouldn't
+  happen, so a failure is genuinely informative).</p>
+  <p class="note">Independent of the live test, the by-construction proof still holds — you can re-verify the
+  receiver swap is byte-identical to the #5559 source any time:</p>
+<pre><span class="cmt"># reversing this._host. → this. must reproduce the pre-#5617 file exactly</span>
+git show 8b0c2811b:packages/server/src/claude-tui/form-driver.js &gt; /tmp/base.js
+sed 's/this\._host\./this./g' packages/server/src/claude-tui/form-driver.js \
+  | diff - /tmp/base.js   <span class="cmt"># → method bodies identical (only header/decl differ)</span></pre>
+</div>
+
+<div class="foot">
+  Generated for the #5769 merge gate · chroxy · keep this file out of commits (docs/reports is fine to delete after).
+</div>
+
+</div>
+</body>
+</html>

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -441,16 +441,24 @@ export function App() {
   // non-tui session (e.g. after switching), fall back to chat — the tab is
   // hidden there, so the user shouldn't be stranded on it.
   useEffect(() => {
-    const isTui = activeSessionProvider === DEFAULT_PROVIDER
-    if (viewMode === 'terminal' && !isTui) {
+    // Only force away from the Output tab once we KNOW the active session is
+    // non-tui. During the initial-load / reconnect window the provider is still
+    // null/unknown — force-switching then would kick the operator out of a
+    // persisted Output view for a claude-tui session (Copilot #5838).
+    if (viewMode === 'terminal' && activeSessionProvider != null && activeSessionProvider !== DEFAULT_PROVIDER) {
       setViewMode('chat')
       return
     }
-    if (viewMode === 'terminal' && isTui && activeSessionId) {
+    // Gate the opt-in on a live socket and depend on connectionPhase, so a
+    // reconnect (which clears the server-side terminalSessionIds set) re-runs
+    // this effect and re-subscribes — otherwise the mirror silently stops
+    // updating until the user toggles tabs (Copilot #5838).
+    const isTui = activeSessionProvider === DEFAULT_PROVIDER
+    if (viewMode === 'terminal' && isTui && activeSessionId && connectionPhase === 'connected') {
       subscribeTerminalMirror(activeSessionId)
       return () => unsubscribeTerminalMirror(activeSessionId)
     }
-  }, [viewMode, activeSessionId, activeSessionProvider, subscribeTerminalMirror, unsubscribeTerminalMirror, setViewMode])
+  }, [viewMode, activeSessionId, activeSessionProvider, connectionPhase, subscribeTerminalMirror, unsubscribeTerminalMirror, setViewMode])
   const setModel = useConnectionStore(s => s.setModel)
   const setPermissionMode = useConnectionStore(s => s.setPermissionMode)
   const setThinkingLevel = useConnectionStore(s => s.setThinkingLevel)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -70,6 +70,7 @@ import { useControlRoomState } from './hooks/useControlRoomState'
 import { useMessageRenderer } from './hooks/useMessageRenderer'
 import { SplitPane } from './components/SplitPane'
 import { ViewSwitcher } from './components/ViewSwitcher'
+import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, persistInterventionPing, loadPersistedInterventionPing, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
 import { applyOrderById } from './utils/reorderById'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
@@ -153,6 +154,10 @@ export function App() {
   const sessionStates = useConnectionStore(s => s.sessionStates)
   const activeSessionId = useConnectionStore(s => s.activeSessionId)
   const viewMode = useConnectionStore(s => s.viewMode)
+  // #5835 (PR2): live claude-tui PTY mirror — the Output tab is the authenticity
+  // surface only for claude-tui (the only provider with a real PTY).
+  const subscribeTerminalMirror = useConnectionStore(s => s.subscribeTerminalMirror)
+  const unsubscribeTerminalMirror = useConnectionStore(s => s.unsubscribeTerminalMirror)
   const availableModels = useConnectionStore(s => s.availableModels)
   const availableModelsProvider = useConnectionStore(s => s.availableModelsProvider)
   // #5184: header cost-badge display mode (Settings-driven, persisted).
@@ -430,6 +435,22 @@ export function App() {
   const createSession = useConnectionStore(s => s.createSession)
   const confirmSessionClose = useConnectionStore(s => s.confirmSessionClose)
   const setViewMode = useConnectionStore(s => s.setViewMode)
+  // #5835 (PR2): drive the live PTY mirror's opt-in. While the Output tab is
+  // shown for a claude-tui session, opt into terminal_output; opt out on leave /
+  // session switch / provider change. If the Output tab is somehow active on a
+  // non-tui session (e.g. after switching), fall back to chat — the tab is
+  // hidden there, so the user shouldn't be stranded on it.
+  useEffect(() => {
+    const isTui = activeSessionProvider === DEFAULT_PROVIDER
+    if (viewMode === 'terminal' && !isTui) {
+      setViewMode('chat')
+      return
+    }
+    if (viewMode === 'terminal' && isTui && activeSessionId) {
+      subscribeTerminalMirror(activeSessionId)
+      return () => unsubscribeTerminalMirror(activeSessionId)
+    }
+  }, [viewMode, activeSessionId, activeSessionProvider, subscribeTerminalMirror, unsubscribeTerminalMirror, setViewMode])
   const setModel = useConnectionStore(s => s.setModel)
   const setPermissionMode = useConnectionStore(s => s.setPermissionMode)
   const setThinkingLevel = useConnectionStore(s => s.setThinkingLevel)
@@ -1988,6 +2009,7 @@ export function App() {
               splitMode={splitMode}
               setSplitMode={setSplitMode}
               persistSplitMode={persistSplitMode}
+              showTerminalTab={activeSessionProvider === DEFAULT_PROVIDER}
               showConsoleTab={showConsoleTab}
               unreadSystemCount={unreadSystemCount}
               checkpointsOpen={checkpointsOpen}

--- a/packages/dashboard/src/components/MultiTerminalView.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.tsx
@@ -8,14 +8,16 @@
  * On session switch: hide old → show new → fitAddon.fit().
  */
 import { useEffect, useRef, useCallback } from 'react'
+import { CLAUDE_TUI_PTY_SIZE } from '@chroxy/protocol'
 import { TerminalView, type TerminalHandle } from './TerminalView'
 import { useConnectionStore } from '../store/connection'
 
-// #5835 (PR2): the live claude-tui PTY mirror is a fixed 120×30 grid server-side
-// (claude-tui-session.js spawns the PTY at this size). The Output pane is
-// claude-tui-only, so render every terminal here at that exact size, letterboxed,
-// to keep the mirror 1:1 faithful. Phase 2 (resize sync) will make this dynamic.
-const MIRROR_SIZE = { cols: 120, rows: 30 }
+// #5835 (PR2): the live claude-tui PTY mirror is a fixed grid server-side
+// (claude-tui-session.js spawns the PTY at CLAUDE_TUI_PTY_SIZE). The Output pane
+// is claude-tui-only, so render every terminal here at that exact size,
+// letterboxed, to keep the mirror 1:1 faithful. Single-sourced from @chroxy/
+// protocol (#5839) so server + dashboard can't drift. Phase 2 makes it dynamic.
+const MIRROR_SIZE = CLAUDE_TUI_PTY_SIZE
 
 export interface MultiTerminalViewProps {
   sessions: { sessionId: string }[]

--- a/packages/dashboard/src/components/MultiTerminalView.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.tsx
@@ -11,6 +11,12 @@ import { useEffect, useRef, useCallback } from 'react'
 import { TerminalView, type TerminalHandle } from './TerminalView'
 import { useConnectionStore } from '../store/connection'
 
+// #5835 (PR2): the live claude-tui PTY mirror is a fixed 120×30 grid server-side
+// (claude-tui-session.js spawns the PTY at this size). The Output pane is
+// claude-tui-only, so render every terminal here at that exact size, letterboxed,
+// to keep the mirror 1:1 faithful. Phase 2 (resize sync) will make this dynamic.
+const MIRROR_SIZE = { cols: 120, rows: 30 }
+
 export interface MultiTerminalViewProps {
   sessions: { sessionId: string }[]
   activeSessionId: string | null
@@ -81,6 +87,7 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
             className="terminal-container"
             initialData={getInitialData(session.sessionId)}
             onReady={(handle) => handleReady(session.sessionId, handle)}
+            fixedSize={MIRROR_SIZE}
           />
         </div>
       ))}

--- a/packages/dashboard/src/components/TerminalView.tsx
+++ b/packages/dashboard/src/components/TerminalView.tsx
@@ -20,6 +20,15 @@ export interface TerminalViewProps {
   className?: string
   initialData?: string
   onReady?: (handle: TerminalHandle) => void
+  /**
+   * #5835 (PR2): pin the terminal to a fixed cols×rows and letterbox it
+   * (centered, no FitAddon stretch). Used for the live claude-tui PTY mirror,
+   * whose server-side PTY is a fixed 120×30 grid — rendering at exactly that
+   * size keeps the mirror 1:1 faithful (the authenticity surface) instead of
+   * scaling the xterm to the pane and misaligning the TUI's absolute cursor
+   * positioning. Omit for the normal fit-to-pane behaviour.
+   */
+  fixedSize?: { cols: number; rows: number }
 }
 
 export const BATCH_INTERVAL = 50 // ms — coalesce rapid writes
@@ -30,7 +39,7 @@ function safeFit(fit: FitAddon) {
   try { fit.fit() } catch { /* container not visible */ }
 }
 
-export function TerminalView({ className, initialData, onReady }: TerminalViewProps) {
+export function TerminalView({ className, initialData, onReady, fixedSize }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
@@ -80,10 +89,14 @@ export function TerminalView({ className, initialData, onReady }: TerminalViewPr
 
     const term = new Terminal({
       disableStdin: true,
-      convertEol: true,
+      // A fixed-size mirror reproduces the server PTY's exact line layout, so
+      // DON'T translate \n→\r\n (the PTY already emits the control bytes). For
+      // the normal fit mode keep convertEol for plain text streams.
+      convertEol: !fixedSize,
       scrollback: 5000,
       fontSize: 13,
       fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, Consolas, monospace",
+      ...(fixedSize ? { cols: fixedSize.cols, rows: fixedSize.rows } : {}),
       theme: {
         background: '#000000',
         foreground: '#e0e0e0',
@@ -92,10 +105,17 @@ export function TerminalView({ className, initialData, onReady }: TerminalViewPr
       },
     })
 
-    const fitAddon = new FitAddon()
-    term.loadAddon(fitAddon)
+    // #5835 (PR2): a fixedSize mirror renders at exactly cols×rows and is
+    // centered/letterboxed by the container — no FitAddon (stretching the xterm
+    // to the pane would make its grid disagree with the server PTY's 120×30 and
+    // misrender the TUI). FitAddon is only for the normal fit-to-pane mode.
+    let fitAddon: FitAddon | null = null
+    if (!fixedSize) {
+      fitAddon = new FitAddon()
+      term.loadAddon(fitAddon)
+    }
     term.open(containerRef.current)
-    safeFit(fitAddon)
+    if (fitAddon) safeFit(fitAddon)
 
     termRef.current = term
     fitRef.current = fitAddon
@@ -108,24 +128,26 @@ export function TerminalView({ className, initialData, onReady }: TerminalViewPr
     // Notify parent
     onReady?.({ write, clear, fit })
 
-    // Debounced resize handler — prevents excessive reflows during drag-resize
+    // Debounced resize handler — prevents excessive reflows during drag-resize.
+    // Skipped entirely in fixedSize mode: a letterboxed 120×30 mirror never
+    // re-fits (the container just centers it / adds scroll if the pane is small).
     let resizeTimer: ReturnType<typeof setTimeout> | null = null
+    let resizeObserver: ResizeObserver | undefined
     const debouncedFit = () => {
-      if (disposedRef.current) return
+      if (disposedRef.current || !fitAddon) return
       if (resizeTimer) clearTimeout(resizeTimer)
       resizeTimer = setTimeout(() => {
-        if (disposedRef.current) return
+        if (disposedRef.current || !fitAddon) return
         safeFit(fitAddon)
       }, RESIZE_DEBOUNCE)
     }
 
-    window.addEventListener('resize', debouncedFit)
-
-    // ResizeObserver for container-level resizing
-    let resizeObserver: ResizeObserver | undefined
-    if (typeof ResizeObserver !== 'undefined') {
-      resizeObserver = new ResizeObserver(debouncedFit)
-      resizeObserver.observe(containerRef.current)
+    if (fitAddon) {
+      window.addEventListener('resize', debouncedFit)
+      if (typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver(debouncedFit)
+        resizeObserver.observe(containerRef.current)
+      }
     }
 
     return () => {
@@ -153,7 +175,12 @@ export function TerminalView({ className, initialData, onReady }: TerminalViewPr
       ref={containerRef}
       className={className}
       data-testid="terminal-container"
-      style={{ width: '100%', height: '100%' }}
+      // #5835 (PR2): letterbox a fixed-size mirror — center the 120×30 grid in
+      // the pane, with scroll if the pane is smaller than the grid (faithful
+      // beats wrap-distorted). Normal mode fills the pane for FitAddon.
+      style={fixedSize
+        ? { width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'auto', background: '#000000' }
+        : { width: '100%', height: '100%' }}
     />
   )
 }

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -10,13 +10,16 @@ export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'cons
 /** Scrollable tab bar with arrow buttons when overflowing */
 export function ViewSwitcher({
   viewMode, setViewMode, splitMode, setSplitMode, persistSplitMode,
-  showConsoleTab, unreadSystemCount, checkpointsOpen, setCheckpointsOpen,
+  showTerminalTab = true, showConsoleTab, unreadSystemCount, checkpointsOpen, setCheckpointsOpen,
 }: {
   viewMode: string
   setViewMode: (m: ViewMode) => void
   splitMode: SplitDirection | null
   setSplitMode: (m: SplitDirection | null) => void
   persistSplitMode: (m: SplitDirection | null) => void
+  // #5835 (PR2): the "Output" tab is the live claude-tui PTY mirror — shown only
+  // for claude-tui sessions (the only provider with a real PTY to mirror).
+  showTerminalTab?: boolean
   showConsoleTab: boolean
   unreadSystemCount: number
   checkpointsOpen: boolean
@@ -99,7 +102,9 @@ export function ViewSwitcher({
         onPointerCancel={onPointerUp}
       >
         <button className={`view-tab${viewMode === 'chat' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('chat'); setSplitMode(null); persistSplitMode(null) }} type="button">Chat</button>
-        <button className={`view-tab${viewMode === 'terminal' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('terminal'); setSplitMode(null); persistSplitMode(null) }} type="button">Output</button>
+        {showTerminalTab && (
+          <button className={`view-tab${viewMode === 'terminal' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('terminal'); setSplitMode(null); persistSplitMode(null) }} type="button">Output</button>
+        )}
         {/* #5200/#5204: the Control Room is launched from the bottom sidebar
             panel slot (its header "Control Room" button) and opens as its own
             session-independent top-level tab in the SessionBar strip — not a

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -613,6 +613,23 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #5835 Phase 1 (PR2): opt in / out of a claude-tui session's live PTY mirror.
+  // Only opted-in clients receive terminal_output (server-side filter), so this
+  // is sent when the Output tab is shown for a claude-tui session and cleared on
+  // leave. Best-effort — a closed socket just means no mirror until reconnect.
+  subscribeTerminalMirror: (sessionId: string) => {
+    const { socket } = get();
+    if (sessionId && socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'terminal_subscribe', sessionId });
+    }
+  },
+  unsubscribeTerminalMirror: (sessionId: string) => {
+    const { socket } = get();
+    if (sessionId && socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'terminal_unsubscribe', sessionId });
+    }
+  },
+
   // Web tasks (Claude Code Web)
   webFeatures: { available: false, remote: false, teleport: false },
   webTasks: [],
@@ -2027,8 +2044,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       timestamp: Date.now(),
     };
 
-    // Write user message to terminal buffer for Output view
-    if (text) {
+    // Write user message to terminal buffer for the Output view. #5835 (PR2):
+    // skip this synthetic echo for claude-tui — its Output tab now shows the live
+    // PTY mirror (alternate-screen), where injecting an echo at the cursor would
+    // corrupt the redraw. The echo was only ever visible on the Output tab, which
+    // is now claude-tui-only, so suppressing it for tui loses nothing elsewhere.
+    if (text && get().sessions.find(s => s.sessionId === get().activeSessionId)?.provider !== DEFAULT_PROVIDER) {
       get().appendTerminalData(`\r\n\x1b[33m> ${text}\x1b[0m\r\n\r\n`);
     }
 
@@ -2386,7 +2407,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // line from yellow user-prompt echoes (\x1b[33m in sendInput). Skipped
     // for empty answers — nothing meaningful to render. Fires before the
     // wire send so the echo is present even when the socket queues.
-    if (answerSummary) {
+    // #5835 (PR2): suppress for claude-tui — same reason as the prompt echo
+    // above (the live PTY mirror must not get a synthetic line at its cursor).
+    if (answerSummary && get().sessions.find(s => s.sessionId === get().activeSessionId)?.provider !== DEFAULT_PROVIDER) {
       get().appendTerminalData(`\r\n\x1b[36m> User answered: ${answerSummary}\x1b[0m\r\n`);
     }
     // #4312: optimistically flip the active session into "running" so the

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -428,6 +428,14 @@ export function getCurrentDeviceKey(): string | null {
 const _initialServerId = loadPersistedActiveServer();
 if (_initialServerId) setServerScope(_initialServerId);
 
+// #5835 (PR2): true when the active session is claude-tui — its Output tab shows
+// the live PTY mirror, so the synthetic prompt/answer terminal echoes must be
+// suppressed (they'd inject a line at the altscreen cursor and corrupt the redraw).
+function activeSessionIsClaudeTui(get: () => ConnectionState): boolean {
+  const s = get();
+  return s.sessions.find(sess => sess.sessionId === s.activeSessionId)?.provider === DEFAULT_PROVIDER;
+}
+
 export const useConnectionStore = create<ConnectionState>((set, get) => ({
   connectionPhase: 'disconnected',
   wsUrl: null,
@@ -2049,7 +2057,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // PTY mirror (alternate-screen), where injecting an echo at the cursor would
     // corrupt the redraw. The echo was only ever visible on the Output tab, which
     // is now claude-tui-only, so suppressing it for tui loses nothing elsewhere.
-    if (text && get().sessions.find(s => s.sessionId === get().activeSessionId)?.provider !== DEFAULT_PROVIDER) {
+    if (text && !activeSessionIsClaudeTui(get)) {
       get().appendTerminalData(`\r\n\x1b[33m> ${text}\x1b[0m\r\n\r\n`);
     }
 
@@ -2409,7 +2417,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // wire send so the echo is present even when the socket queues.
     // #5835 (PR2): suppress for claude-tui — same reason as the prompt echo
     // above (the live PTY mirror must not get a synthetic line at its cursor).
-    if (answerSummary && get().sessions.find(s => s.sessionId === get().activeSessionId)?.provider !== DEFAULT_PROVIDER) {
+    if (answerSummary && !activeSessionIsClaudeTui(get)) {
       get().appendTerminalData(`\r\n\x1b[36m> User answered: ${answerSummary}\x1b[0m\r\n`);
     }
     // #4312: optimistically flip the active session into "running" so the

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -413,6 +413,13 @@ describe('dashboard message-handler dispatch', () => {
       handleMessage({ type: 'terminal_output', sessionId: 'sess-1', data: 123 }, ctx() as any)
       expect((store.getState() as any)._terminalWrites).toEqual([])
     })
+
+    it('ignores a terminal_output with a missing sessionId (no bleed into active terminal)', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_output', data: 'orphan' }, ctx() as any)
+      expect((store.getState() as any)._terminalWrites).toEqual([])
+    })
   })
 
   describe('error dispatch', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -392,6 +392,29 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('terminal_output dispatch (#5835 PR2)', () => {
+    it('appends terminal_output bytes for the active session to the terminal', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_output', sessionId: 'sess-1', data: '\x1b[31mhi\x1b[0m' }, ctx() as any)
+      expect((store.getState() as any)._terminalWrites).toEqual(['\x1b[31mhi\x1b[0m'])
+    })
+
+    it('ignores a terminal_output for a non-active session (stale post-switch frame)', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_output', sessionId: 'other', data: 'nope' }, ctx() as any)
+      expect((store.getState() as any)._terminalWrites).toEqual([])
+    })
+
+    it('ignores a terminal_output with non-string data', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_output', sessionId: 'sess-1', data: 123 }, ctx() as any)
+      expect((store.getState() as any)._terminalWrites).toEqual([])
+    })
+  })
+
   describe('error dispatch', () => {
     it('routes structured error messages to addServerError', () => {
       handleMessage(

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1221,7 +1221,11 @@ function handleRawBackground(msg: Record<string, unknown>, get: MsgGet, _set: Ms
 // new session's terminal.
 function handleTerminalOutput(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
   if (typeof msg.data !== 'string') return;
-  if (msg.sessionId && msg.sessionId !== get().activeSessionId) return;
+  // Require an explicit string sessionId that matches the active session. The
+  // server always stamps one (ws-forwarding.js); dropping a frame without one
+  // (malformed/legacy/empty) keeps it from bleeding into whatever terminal is
+  // currently active, matching the typeof guard the rest of this file uses.
+  if (typeof msg.sessionId !== 'string' || msg.sessionId !== get().activeSessionId) return;
   get().appendTerminalData(msg.data);
 }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1213,6 +1213,18 @@ function handleRawBackground(msg: Record<string, unknown>, get: MsgGet, _set: Ms
   get().appendTerminalData(sharedRawOutput(msg).data);
 }
 
+// #5835 (PR2): live claude-tui PTY mirror. The server delivers terminal_output
+// only to clients that opted in (terminal_subscribe) for a session they're
+// viewing — i.e. the active session whose Output tab is showing — so route the
+// raw bytes through appendTerminalData (active-session). Guard on the active id
+// anyway so a stale frame arriving just after a session switch can't paint the
+// new session's terminal.
+function handleTerminalOutput(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  if (typeof msg.data !== 'string') return;
+  if (msg.sessionId && msg.sessionId !== get().activeSessionId) return;
+  get().appendTerminalData(msg.data);
+}
+
 function handleTokenRotated(msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
   // Token parse shared via store-core (#5454); the URL-rewrite side effect
   // stays dashboard-specific.
@@ -2670,6 +2682,7 @@ const HANDLERS: Record<string, Handler> = {
   pong: handlePong,
   raw: handleRaw,
   raw_background: handleRawBackground,
+  terminal_output: handleTerminalOutput,
   token_rotated: handleTokenRotated,
   pairing_refreshed: handlePairingRefreshed,
   checkpoint_restored: handleCheckpointRestored,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -956,6 +956,10 @@ export interface ConnectionState {
   appendTerminalData: (data: string) => void;
   clearTerminalBuffer: () => void;
   setTerminalWriteCallback: (cb: ((data: string) => void) | null) => void;
+  // #5835 Phase 1 (PR2): opt in / out of a claude-tui session's live PTY mirror
+  // (terminal_output). Sent when the Output tab is shown for a claude-tui session.
+  subscribeTerminalMirror: (sessionId: string) => void;
+  unsubscribeTerminalMirror: (sessionId: string) => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   sendInput: (input: string, wireAttachments?: { type: string; name: string; [key: string]: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
   /**

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -46,6 +46,17 @@ export declare const MIN_PROTOCOL_VERSION = 1;
  * the drift fixed in #5823.
  */
 export declare const DEFAULT_PROVIDER = "claude-tui";
+/**
+ * #5835 / #5839: the fixed grid size of the claude-tui PTY. The server spawns
+ * the TUI at this size and the dashboard renders the live mirror at exactly this
+ * size (letterboxed), so the mirror stays 1:1 faithful. Single-sourced here so
+ * the server and dashboard literals can't drift and silently misalign the
+ * mirror. Phase 2 (resize sync) makes the size dynamic and retires this.
+ */
+export declare const CLAUDE_TUI_PTY_SIZE: Readonly<{
+    cols: 120;
+    rows: 30;
+}>;
 export * from './schemas/index.ts';
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
 export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, ServerCancelActivityAckMessage, ServerBudgetResumeAckMessage, } from './schemas/server.ts';

--- a/packages/protocol/dist/index.js
+++ b/packages/protocol/dist/index.js
@@ -46,6 +46,14 @@ export const MIN_PROTOCOL_VERSION = 1;
  * the drift fixed in #5823.
  */
 export const DEFAULT_PROVIDER = 'claude-tui';
+/**
+ * #5835 / #5839: the fixed grid size of the claude-tui PTY. The server spawns
+ * the TUI at this size and the dashboard renders the live mirror at exactly this
+ * size (letterboxed), so the mirror stays 1:1 faithful. Single-sourced here so
+ * the server and dashboard literals can't drift and silently misalign the
+ * mirror. Phase 2 (resize sync) makes the size dynamic and retires this.
+ */
+export const CLAUDE_TUI_PTY_SIZE = Object.freeze({ cols: 120, rows: 30 });
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from "./schemas/index.js";
 // Re-export client-side error-category detection (#3151)

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -51,6 +51,15 @@ export const MIN_PROTOCOL_VERSION = 1
  */
 export const DEFAULT_PROVIDER = 'claude-tui'
 
+/**
+ * #5835 / #5839: the fixed grid size of the claude-tui PTY. The server spawns
+ * the TUI at this size and the dashboard renders the live mirror at exactly this
+ * size (letterboxed), so the mirror stays 1:1 faithful. Single-sourced here so
+ * the server and dashboard literals can't drift and silently misalign the
+ * mirror. Phase 2 (resize sync) makes the size dynamic and retires this.
+ */
+export const CLAUDE_TUI_PTY_SIZE = Object.freeze({ cols: 120, rows: 30 })
+
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from './schemas/index.ts'
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -76,7 +76,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'terminal_output', // #5835 Phase 1 (server pipe): live claude-tui PTY mirror — the server broadcast + opt-in lands first; the dashboard render handler is PR2 of the epic. Move to PLATFORM_SPECIFIC='dashboard' when PR2 adds the case.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -137,6 +136,7 @@ const PLATFORM_SPECIFIC = {
   // and mobile app (#4764 / PR #4862); no PLATFORM_SPECIFIC entry needed.
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
+  'terminal_output': 'dashboard', // #5835 (PR2) live claude-tui PTY mirror — the dashboard renders the raw bytes in xterm; the mobile WebView terminal render is a deferred follow-up per the epic
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
   'activity_snapshot': 'dashboard', // Control Room live activity tree (#5161 schema / #5160 server / #5162 reducer / #5163 dashboard panel) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5159
   'activity_delta': 'dashboard',    // Control Room activity delta — see activity_snapshot above; dashboard-only for v1, mobile parity is Phase-2 per epic #5159

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -5,6 +5,7 @@ import { performance } from 'node:perf_hooks'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+import { CLAUDE_TUI_PTY_SIZE } from '@chroxy/protocol'
 // #5417 — the TUI shares CliSession's pinned "unknown resume id" patterns
 // (RESUME_UNKNOWN_STDERR_PATTERNS, #4929/#4950) via this matcher: the PTY
 // merges stdout+stderr, so claude's resume rejection lands in _outputTail.
@@ -1484,8 +1485,9 @@ export class ClaudeTuiSession extends BaseSession {
     try {
       this._term = ptyMod.spawn(CLAUDE, args, {
         name: 'xterm-256color',
-        cols: 120,
-        rows: 30,
+        // #5839: single-sourced so the dashboard mirror renders at the same grid.
+        cols: CLAUDE_TUI_PTY_SIZE.cols,
+        rows: CLAUDE_TUI_PTY_SIZE.rows,
         cwd: cwdReal,
         env,
       })


### PR DESCRIPTION
## Summary

PR2 of the TUI live remote-viewer epic (**#5835**) — the visible half. PR1 (#5836, merged) streams the real `claude-tui` PTY bytes; this PR renders them, so the **Output tab becomes a faithful 1:1 mirror of the actual Claude Code TUI** — the authenticity surface, DWService-style.

## What changed (dashboard + 1 protocol test)

- **`message-handler.ts`** — handle `terminal_output` → `appendTerminalData`, guarded on the active session so a stale frame arriving just after a session switch can't paint the new session's terminal.
- **`store` (connection.ts + types.ts)** — `subscribeTerminalMirror` / `unsubscribeTerminalMirror` actions (send `terminal_subscribe` / `terminal_unsubscribe`).
- **`App.tsx`** — while the Output tab is shown for a `claude-tui` session, opt into the mirror; opt out on leave / session switch / provider change. If the Output tab is somehow active on a non-tui session, fall back to chat (the tab is hidden there).
- **`ViewSwitcher.tsx`** — the Output tab is shown **only for `claude-tui`** (the only provider with a real PTY) via a new `showTerminalTab` prop.
- **`TerminalView.tsx`** — new `fixedSize` mode: render at an exact cols×rows, **letterboxed** (centered, no FitAddon stretch, `convertEol` off). `MultiTerminalView` pins the mirror to the server PTY's **120×30** so the TUI's absolute cursor positioning stays 1:1 instead of misaligning against a fitted grid.
- **`connection.ts`** — suppress the synthetic prompt/answer terminal echoes for `claude-tui`: they'd inject a line at the live altscreen's cursor and corrupt the redraw, and were only ever visible on the now-tui-only Output tab.
- **handler-coverage contract** — `terminal_output` moves from `INTENTIONALLY_UNHANDLED` to `PLATFORM_SPECIFIC='dashboard'`.

## UX decisions (confirmed with the user)
- **Letterbox at true 120×30** over scale-to-fit — faithful mirror beats a stretched grid that wraps wrong.
- **Hide the Output tab for non-tui** providers — the tab only appears where it's a real mirror; SDK/headless stay on Chat.

## Not in this PR
Phase 2 (resize sync — makes the size dynamic, replaces the hardcoded 120×30), Phase 3 (keystroke forwarding), the #5837 subscriber-gating optimization, and the mobile WebView render (deferred follow-up).

## Testing
- `message-handler.test.ts` — `terminal_output` dispatch: appends for the active session, ignores a non-active session (stale post-switch frame), ignores non-string data.
- Dashboard `tsc --noEmit` clean; full dashboard vitest **3717 passed**; protocol **289 passed** (handler-coverage now credits the dashboard for `terminal_output`).

Server is unchanged in this PR (PR1 shipped the pipe).
