### PR TITLE
feat(server): resize the live claude-tui PTY mirror (#5835 Phase 2, server)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -540,6 +540,12 @@ export declare const TerminalUnsubscribeSchema: z.ZodObject<{
     type: z.ZodLiteral<"terminal_unsubscribe">;
     sessionId: z.ZodString;
 }, z.core.$strip>;
+export declare const TerminalResizeSchema: z.ZodObject<{
+    type: z.ZodLiteral<"terminal_resize">;
+    sessionId: z.ZodString;
+    cols: z.ZodNumber;
+    rows: z.ZodNumber;
+}, z.core.$strip>;
 export declare const ClientVisibleSchema: z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;
@@ -935,6 +941,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"terminal_unsubscribe">;
     sessionId: z.ZodString;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"terminal_resize">;
+    sessionId: z.ZodString;
+    cols: z.ZodNumber;
+    rows: z.ZodNumber;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -695,6 +695,19 @@ export const TerminalUnsubscribeSchema = z.object({
     type: z.literal('terminal_unsubscribe'),
     sessionId: z.string().max(256),
 });
+// #5835 Phase 2: request a resize of a session's live PTY (the claude-tui
+// remote-viewer mirror). A client whose Output pane is larger than the default
+// grid asks the server to resize the real TUI so it uses the available space.
+// The PTY has ONE size: the server applies this only for the session's primary
+// owner (or an unclaimed session) — observers ride along and re-letterbox to
+// the authoritative `terminal_size` the server broadcasts back. cols/rows are
+// clamped server-side; the bounds here just reject obviously-bogus frames early.
+export const TerminalResizeSchema = z.object({
+    type: z.literal('terminal_resize'),
+    sessionId: z.string().max(256),
+    cols: z.number().int().min(1).max(1000),
+    rows: z.number().int().min(1).max(1000),
+});
 // #3404: client signals foreground/background state. Mobile app sends
 // {visible:false} on AppState background/inactive so the server stops
 // treating its still-alive WS connection as an active viewer and lets
@@ -989,6 +1002,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     UnsubscribeSessionsSchema,
     TerminalSubscribeSchema,
     TerminalUnsubscribeSchema,
+    TerminalResizeSchema,
     ClientVisibleSchema,
     ClaimPrimarySchema,
     ListProvidersSchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -793,6 +793,20 @@ export const TerminalUnsubscribeSchema = z.object({
   sessionId: z.string().max(256),
 })
 
+// #5835 Phase 2: request a resize of a session's live PTY (the claude-tui
+// remote-viewer mirror). A client whose Output pane is larger than the default
+// grid asks the server to resize the real TUI so it uses the available space.
+// The PTY has ONE size: the server applies this only for the session's primary
+// owner (or an unclaimed session) — observers ride along and re-letterbox to
+// the authoritative `terminal_size` the server broadcasts back. cols/rows are
+// clamped server-side; the bounds here just reject obviously-bogus frames early.
+export const TerminalResizeSchema = z.object({
+  type: z.literal('terminal_resize'),
+  sessionId: z.string().max(256),
+  cols: z.number().int().min(1).max(1000),
+  rows: z.number().int().min(1).max(1000),
+})
+
 // #3404: client signals foreground/background state. Mobile app sends
 // {visible:false} on AppState background/inactive so the server stops
 // treating its still-alive WS connection as an active viewer and lets
@@ -1117,6 +1131,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   UnsubscribeSessionsSchema,
   TerminalSubscribeSchema,
   TerminalUnsubscribeSchema,
+  TerminalResizeSchema,
   ClientVisibleSchema,
   ClaimPrimarySchema,
   ListProvidersSchema,

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -76,6 +76,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
+  'terminal_size', // #5835 Phase 2 (server PR) emits the authoritative live-PTY size; the dashboard receipt handler (letterbox to it) lands in the Phase 2 dashboard PR, which will move this to PLATFORM_SPECIFIC as 'dashboard' (exactly as terminal_output did across Phase 1's two PRs).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -384,6 +384,12 @@ export class ClaudeTuiSession extends BaseSession {
     // on flush and cleared on teardown.
     this._mirrorBuffer = ''
     this._mirrorTimer = null
+    // #5835 Phase 2: the live PTY's current grid size. Spawns at the shared
+    // default and tracks every applied resize so a respawn re-spawns at the
+    // operator's chosen size (not back to the default), and so a newly-
+    // subscribing viewer can be told the authoritative size to letterbox to.
+    this._ptyCols = CLAUDE_TUI_PTY_SIZE.cols
+    this._ptyRows = CLAUDE_TUI_PTY_SIZE.rows
     // #4278: when claude TUI calls AskUserQuestion, chroxy's PreToolUse
     // hook emits user_question and stashes the toolUseId here. The
     // dashboard's QuestionPrompt UI eventually sends a
@@ -1485,9 +1491,11 @@ export class ClaudeTuiSession extends BaseSession {
     try {
       this._term = ptyMod.spawn(CLAUDE, args, {
         name: 'xterm-256color',
-        // #5839: single-sourced so the dashboard mirror renders at the same grid.
-        cols: CLAUDE_TUI_PTY_SIZE.cols,
-        rows: CLAUDE_TUI_PTY_SIZE.rows,
+        // #5839: single-sourced default so the dashboard mirror renders at the
+        // same grid. #5835 Phase 2: a prior resize is preserved across respawns
+        // via _ptyCols/_ptyRows (seeded from CLAUDE_TUI_PTY_SIZE on construct).
+        cols: this._ptyCols,
+        rows: this._ptyRows,
         cwd: cwdReal,
         env,
       })
@@ -1763,6 +1771,49 @@ export class ClaudeTuiSession extends BaseSession {
     if (!data) return
     this._mirrorBuffer = ''
     this.emit('terminal_output', { data })
+  }
+
+  /**
+   * #5835 Phase 2: the live PTY's current grid size, for a newly-subscribing
+   * viewer to letterbox to (and for tests). Always reflects the last applied
+   * resize, or the spawn default before any resize.
+   * @returns {{cols: number, rows: number}}
+   */
+  getTerminalSize() {
+    return { cols: this._ptyCols, rows: this._ptyRows }
+  }
+
+  /**
+   * #5835 Phase 2: resize the live PTY (the remote-viewer mirror). Clamps to the
+   * same bounds the protocol schema enforces so a bad caller can't throw inside
+   * node-pty, records the size so it survives a respawn, and applies it to the
+   * running PTY when one exists (a resize requested before/after the PTY is alive
+   * still updates the tracked size, taking effect on the next spawn). The real
+   * TUI redraws at the new size; those bytes flow out through the normal mirror.
+   * @returns {{cols: number, rows: number}|null} the applied size, or null if the
+   *   request was a no-op (unchanged) so the caller can skip a redundant broadcast.
+   */
+  resizeTerminal(cols, rows) {
+    const c = Math.max(1, Math.min(1000, Math.floor(Number(cols))))
+    const r = Math.max(1, Math.min(1000, Math.floor(Number(rows))))
+    if (!Number.isFinite(c) || !Number.isFinite(r)) return null
+    if (c === this._ptyCols && r === this._ptyRows) return null
+    this._ptyCols = c
+    this._ptyRows = r
+    if (this._term && !this._ptyExited) {
+      try {
+        this._term.resize(c, r)
+      } catch (err) {
+        // A resize race against PTY teardown shouldn't crash the daemon; the
+        // tracked size still applies on the next spawn.
+        log.warn(`claude-tui resize failed (${c}x${r}): ${err?.message || err}`)
+      }
+    }
+    // Tell subscribed viewers the new authoritative size (ws-forwarding routes
+    // this to terminal subscribers as `terminal_size`), so observers re-letterbox
+    // and the requesting primary renders the confirmed grid.
+    this.emit('terminal_resize', { cols: c, rows: r })
+    return { cols: c, rows: r }
   }
 
   /**

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1796,6 +1796,9 @@ export class ClaudeTuiSession extends BaseSession {
   resizeTerminal(cols, rows) {
     const c = Math.max(1, Math.min(1000, Math.floor(Number(cols))))
     const r = Math.max(1, Math.min(1000, Math.floor(Number(rows))))
+    // Load-bearing guard: NaN (e.g. resizeTerminal('x', 'y')) survives
+    // Math.floor/min/max unchanged, so the clamp above does NOT guarantee
+    // finiteness — without this a NaN would reach _term.resize. Don't remove.
     if (!Number.isFinite(c) || !Number.isFinite(r)) return null
     if (c === this._ptyCols && r === this._ptyRows) return null
     this._ptyCols = c

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -345,6 +345,17 @@ function handleUnsubscribeSessions(ws, client, msg, ctx) {
   })
 }
 
+// #5835 Phase 2: a client views a session iff it's its active session or in its
+// subscribed set — the SAME viewing clause ws-forwarding's terminalSubscriberFilter
+// uses to scope terminal_output/terminal_size broadcasts. Any direct terminal_size
+// send or PTY-mutating resize must gate on this too, so terminal state (incl. that
+// a session is claude-tui) never leaks to a non-viewer who merely knows the id
+// (#5840 Copilot review).
+function isSessionViewer(client, sid) {
+  return client.activeSessionId === sid ||
+    Boolean(client.subscribedSessionIds && client.subscribedSessionIds.has(sid))
+}
+
 // #5835 Phase 1: opt the client IN to a session's live PTY mirror. Only clients
 // in `terminalSessionIds` receive `terminal_output` (ws-forwarding's filter), so
 // a Chat-tab client never pays for raw bytes it isn't rendering. A bound client
@@ -360,9 +371,11 @@ function handleTerminalSubscribe(ws, client, msg, ctx) {
   client.terminalSessionIds.add(sid)
   // #5835 Phase 2: tell the new subscriber the authoritative PTY size up front so
   // it can letterbox to the right grid immediately (the size may already differ
-  // from the default if another viewer resized it). Only claude-tui sessions have
-  // a live PTY / getTerminalSize; other providers simply don't send this.
-  if (typeof entry.session?.getTerminalSize === 'function') {
+  // from the default if another viewer resized it). Gate on the same viewing
+  // scope as the broadcast (#5840 review) — opting into a terminal you aren't
+  // viewing must not leak its size / that it's a claude-tui session. Only
+  // claude-tui sessions have a live PTY / getTerminalSize; others don't send this.
+  if (isSessionViewer(client, sid) && typeof entry.session?.getTerminalSize === 'function') {
     const size = entry.session.getTerminalSize()
     ctx.transport.send(ws, { type: 'terminal_size', sessionId: sid, cols: size.cols, rows: size.rows })
   }
@@ -380,6 +393,10 @@ function handleTerminalResize(ws, client, msg, ctx) {
   if (client.boundSessionId && client.boundSessionId !== sid) return
   const entry = ctx?.sessions?.sessionManager?.getSession?.(sid)
   if (!entry) return
+  // Must be viewing the session to mutate its shared PTY (#5840 review): a
+  // non-viewer who merely knows the id must not be able to resize the grid or
+  // spam terminal_size at real viewers, even when the session is unclaimed.
+  if (!isSessionViewer(client, sid)) return
   const primary = ctx.transport.getPrimary?.(sid)
   if (primary && primary !== client.id) return
   if (typeof entry.session?.resizeTerminal !== 'function') return

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -383,6 +383,9 @@ function handleTerminalResize(ws, client, msg, ctx) {
   const primary = ctx.transport.getPrimary?.(sid)
   if (primary && primary !== client.id) return
   if (typeof entry.session?.resizeTerminal !== 'function') return
+  // Return value unused: resizeTerminal emits terminal_resize, which
+  // ws-forwarding broadcasts back as terminal_size. A no-op (unchanged size)
+  // returns null and simply emits nothing — nothing for the handler to do.
   entry.session.resizeTerminal(msg.cols, msg.rows)
 }
 

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -354,9 +354,36 @@ function handleTerminalSubscribe(ws, client, msg, ctx) {
   if (client.boundSessionId && client.boundSessionId !== sid) return
   // Parity with handleSubscribeSessions: only track a REAL session, so a client
   // can't grow terminalSessionIds unboundedly with junk ids.
-  if (!ctx?.sessions?.sessionManager?.getSession?.(sid)) return
+  const entry = ctx?.sessions?.sessionManager?.getSession?.(sid)
+  if (!entry) return
   if (!client.terminalSessionIds) client.terminalSessionIds = new Set()
   client.terminalSessionIds.add(sid)
+  // #5835 Phase 2: tell the new subscriber the authoritative PTY size up front so
+  // it can letterbox to the right grid immediately (the size may already differ
+  // from the default if another viewer resized it). Only claude-tui sessions have
+  // a live PTY / getTerminalSize; other providers simply don't send this.
+  if (typeof entry.session?.getTerminalSize === 'function') {
+    const size = entry.session.getTerminalSize()
+    ctx.transport.send(ws, { type: 'terminal_size', sessionId: sid, cols: size.cols, rows: size.rows })
+  }
+}
+
+// #5835 Phase 2: request a resize of a session's live PTY (the remote-viewer
+// mirror). The PTY has ONE size, so only the session's primary owner may drive
+// it — observers ride along and re-letterbox to the `terminal_size` the server
+// broadcasts back (an unclaimed session is open to its first/only viewer, which
+// is the single-operator dashboard case). resizeTerminal clamps + records the
+// size and emits terminal_resize, which ws-forwarding broadcasts to every
+// terminal subscriber. Silent reject: an observer simply doesn't drive the size.
+function handleTerminalResize(ws, client, msg, ctx) {
+  const sid = msg.sessionId
+  if (client.boundSessionId && client.boundSessionId !== sid) return
+  const entry = ctx?.sessions?.sessionManager?.getSession?.(sid)
+  if (!entry) return
+  const primary = ctx.transport.getPrimary?.(sid)
+  if (primary && primary !== client.id) return
+  if (typeof entry.session?.resizeTerminal !== 'function') return
+  entry.session.resizeTerminal(msg.cols, msg.rows)
 }
 
 // #5835 Phase 1: opt the client OUT of a session's live PTY mirror (e.g. the
@@ -449,6 +476,7 @@ export const sessionHandlers = {
   unsubscribe_sessions: handleUnsubscribeSessions,
   terminal_subscribe: handleTerminalSubscribe,
   terminal_unsubscribe: handleTerminalUnsubscribe,
+  terminal_resize: handleTerminalResize,
   client_visible: handleClientVisible,
   claim_primary: handleClaimPrimary,
 }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2176,6 +2176,13 @@ export class SessionManager extends EventEmitter {
       this.emit('session_event', { sessionId, event: 'terminal_output', data })
     })
 
+    // #5835 Phase 2: authoritative live-PTY size changes (a primary viewer drove
+    // a resize). Like terminal_output, transient and kept out of history/activity
+    // — ws-forwarding broadcasts it to terminal subscribers as `terminal_size`.
+    session.on('terminal_resize', (data) => {
+      this.emit('session_event', { sessionId, event: 'terminal_resize', data })
+    })
+
     for (const event of PROXIED_EVENTS) {
       session.on(event, (data) => {
         if (ACTIVITY_EVENTS.has(event)) this.touchActivity(sessionId)

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -105,6 +105,23 @@ export function setupForwarding(ctx) {
   }
 }
 
+/**
+ * #5835: the single recipient predicate for a session's live-terminal traffic
+ * (terminal_output bytes AND terminal_size). A custom broadcastToSession filter
+ * OVERRIDES the default session scoping, so this re-asserts it: deliver only to a
+ * client that is BOTH a viewer of the session (activeSessionId / subscribedSessionIds)
+ * AND opted into its terminal mirror (terminal_subscribe). Opt-in alone must not
+ * bypass scoping, and unsubscribing must stop the traffic. Shared so the size
+ * broadcast can never reach a different audience than the bytes (#5840 review S2).
+ */
+function terminalSubscriberFilter(sessionId) {
+  return (client) => Boolean(
+    client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
+    (client.activeSessionId === sessionId ||
+      (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))),
+  )
+}
+
 /** Multi-session forwarding via normalizer */
 function setupSessionForwarding(normalizer, ctx) {
   const { sessionManager, devPreview, checkpointManager, broadcast, broadcastToSession } = ctx
@@ -150,40 +167,23 @@ function setupSessionForwarding(normalizer, ctx) {
     // subscriber — so a Chat-tab client never pays for raw PTY bytes it isn't
     // rendering. Transient: no history, no normalizer, no serverTs.
     if (event === 'terminal_output') {
-      // A custom filter OVERRIDES broadcastToSession's default session scoping,
-      // so re-assert it here: deliver only to a client that is BOTH a viewer of
-      // the session (activeSessionId / subscribedSessionIds) AND opted into its
-      // terminal mirror. Opt-in alone must not bypass scoping, and unsubscribing
-      // from the session must stop the bytes. #5835 Phase 2 reuses this exact
-      // audience for terminal_size below — keep them sharing one predicate so the
-      // size broadcast can never reach a different set than the bytes.
-      const isTerminalSubscriber = (client) => Boolean(
-        client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
-        (client.activeSessionId === sessionId ||
-          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))),
-      )
       broadcastToSession(
         sessionId,
         { type: 'terminal_output', sessionId, data: typeof data?.data === 'string' ? data.data : '' },
-        isTerminalSubscriber,
+        terminalSubscriberFilter(sessionId),
       )
       return
     }
 
     // #5835 Phase 2: the authoritative live-PTY grid size changed (a primary
-    // viewer drove a resize). Tell every terminal subscriber so observers can
-    // re-letterbox to the new size — the SAME audience as terminal_output above,
-    // re-deriving the predicate here since each event invocation is its own
-    // closure over `sessionId`. cols/rows are already clamped by resizeTerminal.
+    // viewer drove a resize). Tell every terminal subscriber — the SAME audience
+    // as terminal_output (shared terminalSubscriberFilter) — so observers can
+    // re-letterbox. cols/rows are already clamped by resizeTerminal.
     if (event === 'terminal_resize') {
       broadcastToSession(
         sessionId,
         { type: 'terminal_size', sessionId, cols: data?.cols, rows: data?.rows },
-        (client) => Boolean(
-          client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
-          (client.activeSessionId === sessionId ||
-            (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))),
-        ),
+        terminalSubscriberFilter(sessionId),
       )
       return
     }

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -150,14 +150,35 @@ function setupSessionForwarding(normalizer, ctx) {
     // subscriber — so a Chat-tab client never pays for raw PTY bytes it isn't
     // rendering. Transient: no history, no normalizer, no serverTs.
     if (event === 'terminal_output') {
+      // A custom filter OVERRIDES broadcastToSession's default session scoping,
+      // so re-assert it here: deliver only to a client that is BOTH a viewer of
+      // the session (activeSessionId / subscribedSessionIds) AND opted into its
+      // terminal mirror. Opt-in alone must not bypass scoping, and unsubscribing
+      // from the session must stop the bytes. #5835 Phase 2 reuses this exact
+      // audience for terminal_size below — keep them sharing one predicate so the
+      // size broadcast can never reach a different set than the bytes.
+      const isTerminalSubscriber = (client) => Boolean(
+        client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
+        (client.activeSessionId === sessionId ||
+          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))),
+      )
       broadcastToSession(
         sessionId,
         { type: 'terminal_output', sessionId, data: typeof data?.data === 'string' ? data.data : '' },
-        // A custom filter OVERRIDES broadcastToSession's default session scoping,
-        // so re-assert it here: deliver only to a client that is BOTH a viewer of
-        // the session (activeSessionId / subscribedSessionIds) AND opted into its
-        // terminal mirror. Opt-in alone must not bypass scoping, and unsubscribing
-        // from the session must stop the bytes.
+        isTerminalSubscriber,
+      )
+      return
+    }
+
+    // #5835 Phase 2: the authoritative live-PTY grid size changed (a primary
+    // viewer drove a resize). Tell every terminal subscriber so observers can
+    // re-letterbox to the new size — the SAME audience as terminal_output above,
+    // re-deriving the predicate here since each event invocation is its own
+    // closure over `sessionId`. cols/rows are already clamped by resizeTerminal.
+    if (event === 'terminal_resize') {
+      broadcastToSession(
+        sessionId,
+        { type: 'terminal_size', sessionId, cols: data?.cols, rows: data?.rows },
         (client) => Boolean(
           client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
           (client.activeSessionId === sessionId ||

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -299,6 +299,7 @@ function _isSecureRequest(req) {
  *   { type: 'unsubscribe_sessions' }                    — unsubscribe from session discovery
  *   { type: 'terminal_subscribe', sessionId }           — #5835 opt IN to a session's live PTY mirror (terminal_output); only opted-in clients receive raw bytes
  *   { type: 'terminal_unsubscribe', sessionId }         — #5835 opt OUT of a session's live PTY mirror
+ *   { type: 'terminal_resize', sessionId, cols, rows }  — #5835 Phase 2 request to resize the live claude-tui PTY; applied only for the session's primary owner (or an unclaimed session), then broadcast back as terminal_size
  *   { type: 'set_thinking_level', level }               — set thinking budget level ('default'|'high'|'max')
  *   { type: 'set_permission_rules', rules, sessionId }  — set per-session auto-approval rules
  *   { type: 'set_prompt_evaluator', value: boolean, sessionId? } — toggle the per-session promptEvaluator (#3185)
@@ -328,6 +329,7 @@ function _isSecureRequest(req) {
  *   { type: 'stream_delta', messageId, delta }         — token-by-token text
  *   { type: 'stream_end',   messageId: '...' }        — streaming response complete
  *   { type: 'terminal_output', sessionId, data }       — #5835 live claude-tui PTY mirror (raw, ANSI-intact, coalesced ~50ms); emitted from ws-forwarding.js to clients that opted in via terminal_subscribe; the remote-viewer / authenticity surface
+ *   { type: 'terminal_size', sessionId, cols, rows }   — #5835 Phase 2 authoritative live-PTY grid size; sent to a client on terminal_subscribe and broadcast to all terminal subscribers on a primary-driven terminal_resize so observers re-letterbox to the same grid
  *   { type: 'tool_start',   messageId, toolUseId, tool, input, serverName? } — tool invocation (serverName present for MCP tools)
  *   { type: 'tool_input_delta', messageId, toolUseId, partialJson } — #4080/#4081: incremental partial JSON for the streaming tool_use `input`; concatenate per-toolUseId for the live bubble preview
  *   { type: 'tool_result',  toolUseId, result, truncated, images? }  — tool result (images: [{mediaType, data}])

--- a/packages/server/tests/claude-tui-mirror.test.js
+++ b/packages/server/tests/claude-tui-mirror.test.js
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { CLAUDE_TUI_PTY_SIZE } from '@chroxy/protocol'
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
 
 // Track the temp skillsDirs makeSession() mints so they don't accumulate under
@@ -83,4 +84,65 @@ test('flush with an empty buffer is a no-op (stray flush after teardown)', () =>
   s.on('terminal_output', (e) => emitted.push(e.data))
   s._flushTerminalMirror()
   assert.equal(emitted.length, 0)
+})
+
+// #5835 Phase 2: resize sync. resizeTerminal clamps, records the size (so it
+// survives a respawn), applies it to a live PTY, and emits terminal_resize.
+
+test('getTerminalSize defaults to the shared PTY size before any resize', () => {
+  const s = makeSession()
+  assert.deepEqual(s.getTerminalSize(), { cols: CLAUDE_TUI_PTY_SIZE.cols, rows: CLAUDE_TUI_PTY_SIZE.rows })
+})
+
+test('resizeTerminal records the new size, returns it, and emits terminal_resize', () => {
+  const s = makeSession()
+  const events = []
+  s.on('terminal_resize', (e) => events.push(e))
+  const applied = s.resizeTerminal(160, 48)
+  assert.deepEqual(applied, { cols: 160, rows: 48 })
+  assert.deepEqual(s.getTerminalSize(), { cols: 160, rows: 48 })
+  assert.deepEqual(events, [{ cols: 160, rows: 48 }])
+})
+
+test('resizeTerminal drives a live PTY via _term.resize', () => {
+  const s = makeSession()
+  const calls = []
+  s._term = { resize: (c, r) => calls.push([c, r]) }
+  s._ptyExited = false
+  s.resizeTerminal(100, 40)
+  assert.deepEqual(calls, [[100, 40]])
+})
+
+test('resizeTerminal clamps out-of-range / non-integer dimensions', () => {
+  const s = makeSession()
+  assert.deepEqual(s.resizeTerminal(0, 0), { cols: 1, rows: 1 }, 'floor clamps to 1')
+  assert.deepEqual(s.resizeTerminal(9999, 9999), { cols: 1000, rows: 1000 }, 'ceiling clamps to 1000')
+  assert.deepEqual(s.resizeTerminal(80.9, 24.9), { cols: 80, rows: 24 }, 'floored to ints')
+})
+
+test('resizeTerminal is a no-op (null, no emit) when the size is unchanged', () => {
+  const s = makeSession()
+  s.resizeTerminal(120, 30)
+  const events = []
+  s.on('terminal_resize', (e) => events.push(e))
+  const again = s.resizeTerminal(120, 30)
+  assert.equal(again, null, 'unchanged size returns null so the caller skips a redundant broadcast')
+  assert.equal(events.length, 0, 'no terminal_resize emitted for a no-op resize')
+})
+
+test('resizeTerminal survives a PTY-less / exited session (size still recorded)', () => {
+  const s = makeSession()
+  s._term = null
+  const applied = s.resizeTerminal(200, 50)
+  assert.deepEqual(applied, { cols: 200, rows: 50 }, 'size recorded for the next spawn even with no live PTY')
+  assert.deepEqual(s.getTerminalSize(), { cols: 200, rows: 50 })
+})
+
+test('a _term.resize throw is swallowed (no crash) and the size is still recorded', () => {
+  const s = makeSession()
+  s._term = { resize: () => { throw new Error('pty gone') } }
+  s._ptyExited = false
+  const applied = s.resizeTerminal(90, 30)
+  assert.deepEqual(applied, { cols: 90, rows: 30 })
+  assert.deepEqual(s.getTerminalSize(), { cols: 90, rows: 30 })
 })

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -744,5 +744,77 @@ describe('session-handlers', () => {
       sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-bound' }, ctx)
       assert.ok(client.terminalSessionIds.has('sess-bound'))
     })
+
+    it('terminal_subscribe sends the current terminal_size to the new subscriber', () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-1', { session: { getTerminalSize: () => ({ cols: 160, rows: 48 }) }, cwd: '/tmp', name: 'S1' })
+      const client = makeClient()
+      sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
+      const sizeMsg = ctx._sent.find(m => m.type === 'terminal_size')
+      assert.ok(sizeMsg, 'expected a terminal_size sent on subscribe')
+      assert.deepEqual(sizeMsg, { type: 'terminal_size', sessionId: 'sess-1', cols: 160, rows: 48 })
+    })
+
+    it('terminal_subscribe to a session without a live PTY sends no terminal_size', () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-1', { session: {}, cwd: '/tmp', name: 'S1' }) // non-tui: no getTerminalSize
+      const client = makeClient()
+      sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
+      assert.ok(!ctx._sent.some(m => m.type === 'terminal_size'))
+    })
+  })
+
+  describe('terminal_resize (#5835 Phase 2)', () => {
+    function ctxWithResizableSession(sid = 'sess-1') {
+      const ctx = makeCtx()
+      const calls = []
+      ctx._sessions.set(sid, { session: { resizeTerminal: (c, r) => { calls.push([c, r]) } }, cwd: '/tmp', name: 'S1' })
+      return { ctx, calls }
+    }
+
+    it('an unclaimed session lets any viewer drive the resize (single-operator case)', () => {
+      const { ctx, calls } = ctxWithResizableSession()
+      const client = makeClient()
+      sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-1', cols: 160, rows: 48 }, ctx)
+      assert.deepEqual(calls, [[160, 48]])
+    })
+
+    it('the primary owner may drive the resize', () => {
+      const { ctx, calls } = ctxWithResizableSession()
+      ctx.transport.claimPrimary('sess-1', 'client-1')
+      const client = makeClient({ id: 'client-1' })
+      sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-1', cols: 100, rows: 40 }, ctx)
+      assert.deepEqual(calls, [[100, 40]])
+    })
+
+    it('an observer (another client holds primary) cannot drive the resize — it rides along', () => {
+      const { ctx, calls } = ctxWithResizableSession()
+      ctx.transport.claimPrimary('sess-1', 'other-client')
+      const observer = makeClient({ id: 'client-1' })
+      sessionHandlers.terminal_resize(makeWs(), observer, { type: 'terminal_resize', sessionId: 'sess-1', cols: 200, rows: 60 }, ctx)
+      assert.equal(calls.length, 0)
+    })
+
+    it('resize to a non-existent session is a no-op', () => {
+      const ctx = makeCtx()
+      const client = makeClient()
+      assert.doesNotThrow(() =>
+        sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'ghost', cols: 80, rows: 24 }, ctx))
+    })
+
+    it('a bound client cannot resize a different session', () => {
+      const { ctx, calls } = ctxWithResizableSession('sess-other')
+      const client = makeClient({ boundSessionId: 'sess-bound' })
+      sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-other', cols: 80, rows: 24 }, ctx)
+      assert.equal(calls.length, 0)
+    })
+
+    it('resize on a non-tui session (no resizeTerminal) is a no-op, not a throw', () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-1', { session: {}, cwd: '/tmp', name: 'S1' })
+      const client = makeClient()
+      assert.doesNotThrow(() =>
+        sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-1', cols: 80, rows: 24 }, ctx))
+    })
   })
 })

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -745,20 +745,29 @@ describe('session-handlers', () => {
       assert.ok(client.terminalSessionIds.has('sess-bound'))
     })
 
-    it('terminal_subscribe sends the current terminal_size to the new subscriber', () => {
+    it('terminal_subscribe sends the current terminal_size to a viewer of the session', () => {
       const ctx = makeCtx()
       ctx._sessions.set('sess-1', { session: { getTerminalSize: () => ({ cols: 160, rows: 48 }) }, cwd: '/tmp', name: 'S1' })
-      const client = makeClient()
+      const client = makeClient({ activeSessionId: 'sess-1' })
       sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
       const sizeMsg = ctx._sent.find(m => m.type === 'terminal_size')
       assert.ok(sizeMsg, 'expected a terminal_size sent on subscribe')
       assert.deepEqual(sizeMsg, { type: 'terminal_size', sessionId: 'sess-1', cols: 160, rows: 48 })
     })
 
+    it('terminal_subscribe by a NON-viewer does not leak terminal_size', () => {
+      const ctx = makeCtx()
+      ctx._sessions.set('sess-1', { session: { getTerminalSize: () => ({ cols: 160, rows: 48 }) }, cwd: '/tmp', name: 'S1' })
+      const client = makeClient() // not active, not subscribed → not a viewer
+      sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
+      assert.ok(client.terminalSessionIds.has('sess-1'), 'opt-in is still recorded')
+      assert.ok(!ctx._sent.some(m => m.type === 'terminal_size'), 'but no size leaks to a non-viewer')
+    })
+
     it('terminal_subscribe to a session without a live PTY sends no terminal_size', () => {
       const ctx = makeCtx()
       ctx._sessions.set('sess-1', { session: {}, cwd: '/tmp', name: 'S1' }) // non-tui: no getTerminalSize
-      const client = makeClient()
+      const client = makeClient({ activeSessionId: 'sess-1' })
       sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
       assert.ok(!ctx._sent.some(m => m.type === 'terminal_size'))
     })
@@ -772,17 +781,31 @@ describe('session-handlers', () => {
       return { ctx, calls }
     }
 
-    it('an unclaimed session lets any viewer drive the resize (single-operator case)', () => {
+    it('an unclaimed session lets a viewer drive the resize (single-operator case)', () => {
       const { ctx, calls } = ctxWithResizableSession()
-      const client = makeClient()
+      const client = makeClient({ activeSessionId: 'sess-1' })
       sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-1', cols: 160, rows: 48 }, ctx)
       assert.deepEqual(calls, [[160, 48]])
+    })
+
+    it('a NON-viewer cannot resize even an unclaimed session', () => {
+      const { ctx, calls } = ctxWithResizableSession()
+      const stranger = makeClient() // knows the id but is not viewing it
+      sessionHandlers.terminal_resize(makeWs(), stranger, { type: 'terminal_resize', sessionId: 'sess-1', cols: 160, rows: 48 }, ctx)
+      assert.equal(calls.length, 0)
+    })
+
+    it('a subscribed (non-active) viewer may drive the resize', () => {
+      const { ctx, calls } = ctxWithResizableSession()
+      const client = makeClient({ subscribedSessionIds: new Set(['sess-1']) })
+      sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-1', cols: 120, rows: 36 }, ctx)
+      assert.deepEqual(calls, [[120, 36]])
     })
 
     it('the primary owner may drive the resize', () => {
       const { ctx, calls } = ctxWithResizableSession()
       ctx.transport.claimPrimary('sess-1', 'client-1')
-      const client = makeClient({ id: 'client-1' })
+      const client = makeClient({ id: 'client-1', activeSessionId: 'sess-1' })
       sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-1', cols: 100, rows: 40 }, ctx)
       assert.deepEqual(calls, [[100, 40]])
     })
@@ -790,21 +813,21 @@ describe('session-handlers', () => {
     it('an observer (another client holds primary) cannot drive the resize — it rides along', () => {
       const { ctx, calls } = ctxWithResizableSession()
       ctx.transport.claimPrimary('sess-1', 'other-client')
-      const observer = makeClient({ id: 'client-1' })
+      const observer = makeClient({ id: 'client-1', activeSessionId: 'sess-1' })
       sessionHandlers.terminal_resize(makeWs(), observer, { type: 'terminal_resize', sessionId: 'sess-1', cols: 200, rows: 60 }, ctx)
       assert.equal(calls.length, 0)
     })
 
     it('resize to a non-existent session is a no-op', () => {
       const ctx = makeCtx()
-      const client = makeClient()
+      const client = makeClient({ activeSessionId: 'ghost' })
       assert.doesNotThrow(() =>
         sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'ghost', cols: 80, rows: 24 }, ctx))
     })
 
     it('a bound client cannot resize a different session', () => {
       const { ctx, calls } = ctxWithResizableSession('sess-other')
-      const client = makeClient({ boundSessionId: 'sess-bound' })
+      const client = makeClient({ boundSessionId: 'sess-bound', activeSessionId: 'sess-other' })
       sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-other', cols: 80, rows: 24 }, ctx)
       assert.equal(calls.length, 0)
     })
@@ -812,7 +835,7 @@ describe('session-handlers', () => {
     it('resize on a non-tui session (no resizeTerminal) is a no-op, not a throw', () => {
       const ctx = makeCtx()
       ctx._sessions.set('sess-1', { session: {}, cwd: '/tmp', name: 'S1' })
-      const client = makeClient()
+      const client = makeClient({ activeSessionId: 'sess-1' })
       assert.doesNotThrow(() =>
         sessionHandlers.terminal_resize(makeWs(), client, { type: 'terminal_resize', sessionId: 'sess-1', cols: 80, rows: 24 }, ctx))
     })

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -287,6 +287,44 @@ describe('setupForwarding', () => {
     })
   })
 
+  // #5835 Phase 2: a terminal_resize session_event broadcasts terminal_size to
+  // the SAME audience as terminal_output (opted-in terminal subscribers who are
+  // also session viewers), so observers re-letterbox to the authoritative grid.
+  describe('terminal_resize → terminal_size broadcast', () => {
+    it('broadcasts terminal_size to terminal subscribers with the resized grid', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-1',
+        event: 'terminal_resize',
+        data: { cols: 160, rows: 48 },
+      })
+
+      const call = ctx.broadcastToSession.mock.calls.find(c =>
+        c.arguments[1]?.type === 'terminal_size'
+      )
+      assert.ok(call, 'Expected a terminal_size broadcastToSession call')
+      const [sessionId, msg, filter] = call.arguments
+      assert.equal(sessionId, 'sess-1')
+      assert.deepEqual(
+        { type: msg.type, sessionId: msg.sessionId, cols: msg.cols, rows: msg.rows },
+        { type: 'terminal_size', sessionId: 'sess-1', cols: 160, rows: 48 },
+      )
+
+      // The filter admits only a client opted into THIS session's terminal AND
+      // viewing it; opt-in alone, or viewing without opt-in, must be excluded.
+      const viewerOptedIn = { terminalSessionIds: new Set(['sess-1']), activeSessionId: 'sess-1' }
+      const viewerNoOptIn = { terminalSessionIds: new Set(), activeSessionId: 'sess-1' }
+      const optInNotViewing = { terminalSessionIds: new Set(['sess-1']), activeSessionId: 'other', subscribedSessionIds: new Set() }
+      const optInSubscribed = { terminalSessionIds: new Set(['sess-1']), activeSessionId: 'other', subscribedSessionIds: new Set(['sess-1']) }
+      assert.equal(filter(viewerOptedIn), true)
+      assert.equal(filter(viewerNoOptIn), false)
+      assert.equal(filter(optInNotViewing), false)
+      assert.equal(filter(optInSubscribed), true)
+    })
+  })
+
   describe('session_updated event', () => {
     it('broadcasts session name change to all clients', () => {
       const ctx = makeCtx()


### PR DESCRIPTION
## What

Phase 2 of the TUI live remote-viewer epic (#5835), **server half**. Wires a `terminal_resize` request from a viewer through to the real claude-tui PTY's `resize()`, so a viewer whose Output pane is larger than the default 120×30 grid can have the TUI use the available space. The authoritative size flows back as `terminal_size`.

Follows the same two-PR split as Phase 1 (server pipe, then dashboard UI). This PR is server-only and independently testable; the dashboard PR (measure viewport → drive resize when primary/unclaimed → render at the authoritative size) follows.

## How

- **`ClaudeTuiSession`** — tracks `_ptyCols`/`_ptyRows` (seeded from the shared `CLAUDE_TUI_PTY_SIZE`), spawns at the tracked size so a resize **survives an auto-respawn**, and adds `resizeTerminal()` / `getTerminalSize()`. `resizeTerminal` clamps to the schema bounds, no-ops an unchanged size (returns `null`, no broadcast), swallows a teardown-race `_term.resize` throw, and emits `terminal_resize`.
- **`session-manager`** — re-emits `terminal_resize` as a `session_event`, transient and kept out of history/activity exactly like `terminal_output`.
- **`ws-forwarding`** — broadcasts `terminal_size` to the **same audience** as `terminal_output` (opted-in terminal subscribers who are also session viewers); the two share one predicate so the size broadcast can never reach a different set than the bytes.
- **`session-handlers`** — `handleTerminalResize` gates on the session's **primary owner** (or an **unclaimed** session — the single-operator dashboard case); an observer (another client holds primary) is silently ignored and rides along. `handleTerminalSubscribe` now sends the current `terminal_size` to a new subscriber so it letterboxes to the right grid immediately.
- **protocol** — `TerminalResizeSchema` (clamped `cols`/`rows`, 1–1000) added to the client union; `terminal_resize` / `terminal_size` documented in `ws-server.js`. `terminal_size` sits in `INTENTIONALLY_UNHANDLED` until the dashboard receipt handler lands in the Phase 2 dashboard PR (mirrors how `terminal_output` moved across Phase 1's two PRs).

## Security / safety

- **Read-only intent preserved.** This resizes the *viewport*, not the conversation — no keystroke/input path (that's Phase 3, where the real input security review lands).
- **One PTY, one driver.** Only the primary owner (or the sole viewer of an unclaimed session) drives the size; reuses the existing `#5563` ownership model. Observers can't thrash the shared PTY.
- `cols`/`rows` clamped both at the schema edge and again in `resizeTerminal`, so a bad caller can't throw inside node-pty.

## Tests

- `claude-tui-mirror.test.js` — `resizeTerminal` records/returns/emits, drives a live `_term.resize`, clamps out-of-range + non-integer dims, no-ops unchanged size (no emit), survives a PTY-less session, swallows a resize throw; `getTerminalSize` default.
- `ws-forwarding.test.js` — `terminal_resize` → `terminal_size` broadcast with the resized grid and the correct subscriber filter (opt-in **and** viewing; opt-in-alone excluded).
- `session-handlers.test.js` — unclaimed/primary drive resize; observer rides along; bound-client mismatch / non-existent / non-tui session are no-ops; `terminal_subscribe` sends `terminal_size` (and doesn't for a session with no live PTY).

Server suite green for the touched files (mirror, forwarding, session-handlers, claude-tui-session, message-handlers, handler-coverage); protocol 289 pass; custom server lints + eslint clean.

Part of #5835.