### PR TITLE
feat(dashboard): drive + render the live claude-tui PTY mirror at the authoritative size (#5835 Phase 2, dashboard)

### DIFF
--- a/packages/dashboard/src/components/MultiTerminalView.test.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.test.tsx
@@ -283,5 +283,20 @@ describe('MultiTerminalView', () => {
       capturedOnMeasure[0]!(160, 40)
       expect(mockRequestTerminalResize).toHaveBeenCalledTimes(2)
     })
+
+    it('re-sends the same grid when the session authority (role) changes', () => {
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: { s1: { sessionRole: 'observer' } } })
+      renderMultiTerminal({ activeSessionId: 's1' })
+      capturedOnMeasure[0]!(200, 50)
+      expect(mockRequestTerminalResize).toHaveBeenCalledTimes(1)
+      // same size + same role → deduped
+      capturedOnMeasure[0]!(200, 50)
+      expect(mockRequestTerminalResize).toHaveBeenCalledTimes(1)
+      // role flips observer → primary: the same grid re-sends so claiming primary
+      // takes effect without needing a pane-size change
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: { s1: { sessionRole: 'primary' } } })
+      capturedOnMeasure[0]!(200, 50)
+      expect(mockRequestTerminalResize).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/packages/dashboard/src/components/MultiTerminalView.test.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.test.tsx
@@ -9,12 +9,19 @@ import { render, screen, cleanup, act } from '@testing-library/react'
 import { MultiTerminalView, type MultiTerminalViewProps } from './MultiTerminalView'
 import type { SessionInfo } from '../store/types'
 
+// #5835 Phase 2: capture each rendered TerminalView's onMeasure so tests can
+// drive a pane measurement, and the fixedSize it received.
+const capturedOnMeasure: Array<(cols: number, rows: number) => void> = []
+const capturedFixedSize: Array<{ cols: number; rows: number } | undefined> = []
+
 // Mock TerminalView — we don't want real xterm.js in unit tests
 vi.mock('./TerminalView', () => ({
-  TerminalView: ({ className, initialData, onReady }: {
+  TerminalView: ({ className, initialData, onReady, fixedSize, onMeasure }: {
     className?: string
     initialData?: string
     onReady?: (handle: { write: (d: string) => void; clear: () => void; fit: () => void }) => void
+    fixedSize?: { cols: number; rows: number }
+    onMeasure?: (cols: number, rows: number) => void
   }) => {
     // Auto-fire onReady on mount (simulates terminal initialization)
     if (onReady) {
@@ -24,11 +31,14 @@ vi.mock('./TerminalView', () => ({
         fit: vi.fn(),
       }), 0)
     }
+    if (onMeasure) capturedOnMeasure.push(onMeasure)
+    capturedFixedSize.push(fixedSize)
     return (
       <div
         data-testid="mock-terminal"
         data-classname={className}
         data-initial-data={initialData || ''}
+        data-fixed-size={fixedSize ? `${fixedSize.cols}x${fixedSize.rows}` : ''}
       />
     )
   },
@@ -36,6 +46,7 @@ vi.mock('./TerminalView', () => ({
 
 // Mock store
 const mockSetTerminalWriteCallback = vi.fn()
+const mockRequestTerminalResize = vi.fn()
 const mockGetState = vi.fn()
 
 let mockStoreState: Record<string, unknown> = {}
@@ -45,6 +56,7 @@ vi.mock('../store/connection', () => ({
     (selector: (state: unknown) => unknown) => {
       const state = {
         setTerminalWriteCallback: mockSetTerminalWriteCallback,
+        requestTerminalResize: mockRequestTerminalResize,
         sessionStates: mockStoreState.sessionStates ?? {},
         terminalRawBuffer: mockStoreState.terminalRawBuffer ?? '',
       }
@@ -59,6 +71,8 @@ vi.mock('../store/connection', () => ({
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  capturedOnMeasure.length = 0
+  capturedFixedSize.length = 0
 })
 
 function makeSessions(count: number): SessionInfo[] {
@@ -226,5 +240,48 @@ describe('MultiTerminalView', () => {
     const terminals = screen.getAllByTestId('mock-terminal')
     const s2Terminal = terminals[1]! // s2 is the second session
     expect(s2Terminal.dataset.initialData).toBe('')
+  })
+
+  // #5835 Phase 2: authoritative size passthrough + measure→resize glue.
+  describe('resize sync (#5835 Phase 2)', () => {
+    it('passes each session its stored terminalSize as fixedSize (falls back to default)', () => {
+      mockStoreState = {
+        sessionStates: {
+          s1: { terminalRawBuffer: 'd', terminalSize: { cols: 160, rows: 48 } },
+          s2: { terminalRawBuffer: 'd' }, // no terminalSize yet → default
+        },
+        terminalRawBuffer: 'd',
+      }
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal()
+      const terminals = screen.getAllByTestId('mock-terminal')
+      expect(terminals[0]!.dataset.fixedSize).toBe('160x48')
+      expect(terminals[1]!.dataset.fixedSize).toBe('120x30') // CLAUDE_TUI_PTY_SIZE default
+    })
+
+    it('forwards a measurement of the ACTIVE session as a resize request', () => {
+      renderMultiTerminal({ activeSessionId: 's1' })
+      // capturedOnMeasure[0] belongs to s1 (first rendered session)
+      capturedOnMeasure[0]!(200, 50)
+      expect(mockRequestTerminalResize).toHaveBeenCalledWith('s1', 200, 50)
+    })
+
+    it('ignores a measurement from a NON-active session', () => {
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal({ activeSessionId: 's1' })
+      // capturedOnMeasure[1] belongs to s2 (hidden) — must not drive the PTY
+      capturedOnMeasure[1]!(200, 50)
+      expect(mockRequestTerminalResize).not.toHaveBeenCalled()
+    })
+
+    it('dedupes identical sizes — the same grid is not re-sent', () => {
+      renderMultiTerminal({ activeSessionId: 's1' })
+      capturedOnMeasure[0]!(200, 50)
+      capturedOnMeasure[0]!(200, 50)
+      expect(mockRequestTerminalResize).toHaveBeenCalledTimes(1)
+      // a different size DOES send again
+      capturedOnMeasure[0]!(160, 40)
+      expect(mockRequestTerminalResize).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/packages/dashboard/src/components/MultiTerminalView.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.tsx
@@ -16,8 +16,13 @@ import { useConnectionStore } from '../store/connection'
 // (claude-tui-session.js spawns the PTY at CLAUDE_TUI_PTY_SIZE). The Output pane
 // is claude-tui-only, so render every terminal here at that exact size,
 // letterboxed, to keep the mirror 1:1 faithful. Single-sourced from @chroxy/
-// protocol (#5839) so server + dashboard can't drift. Phase 2 makes it dynamic.
-const MIRROR_SIZE = CLAUDE_TUI_PTY_SIZE
+// protocol (#5839) so server + dashboard can't drift.
+//
+// #5835 Phase 2: the size is now DYNAMIC — the server reports the authoritative
+// grid per session via terminal_size (stored on sessionStates[id].terminalSize),
+// and the viewer measures its pane and asks the server to resize the real PTY
+// (terminal_resize). MIRROR_DEFAULT is just the pre-terminal_size fallback.
+const MIRROR_DEFAULT = CLAUDE_TUI_PTY_SIZE
 
 export interface MultiTerminalViewProps {
   sessions: { sessionId: string }[]
@@ -28,12 +33,32 @@ export interface MultiTerminalViewProps {
 export function MultiTerminalView({ sessions, activeSessionId, className }: MultiTerminalViewProps) {
   const handlesRef = useRef(new Map<string, TerminalHandle>())
   const setTerminalWriteCallback = useConnectionStore(s => s.setTerminalWriteCallback)
+  const requestTerminalResize = useConnectionStore(s => s.requestTerminalResize)
+  // #5835 Phase 2: per-session authoritative sizes (server terminal_size). Reads
+  // the whole map so a size change re-renders and the new fixedSize flows to the
+  // affected TerminalView (which resizes its xterm in place).
+  const sessionStates = useConnectionStore(s => s.sessionStates)
 
   // Track whether active session has terminal data for empty state
   const activeBuffer = useConnectionStore(s => {
     if (!activeSessionId) return ''
     return s.sessionStates[activeSessionId]?.terminalRawBuffer || ''
   })
+
+  // #5835 Phase 2: forward a pane measurement to the server as a resize request.
+  // Only the ACTIVE (visible) session drives the shared PTY — hidden panes are
+  // display:none and measure 0, but guard on live activeSessionId anyway. Dedupe
+  // identical sizes so we don't re-send the same grid (the server also no-ops an
+  // unchanged size, but this saves the round trip). TerminalView already debounces
+  // the measurement itself.
+  const lastSentRef = useRef(new Map<string, string>())
+  const handleMeasure = useCallback((sessionId: string, cols: number, rows: number) => {
+    if (useConnectionStore.getState().activeSessionId !== sessionId) return
+    const key = `${cols}x${rows}`
+    if (lastSentRef.current.get(sessionId) === key) return
+    lastSentRef.current.set(sessionId, key)
+    requestTerminalResize(sessionId, cols, rows)
+  }, [requestTerminalResize])
 
   // Get initial data for a session from the store (one-time, at mount)
   const getInitialData = useCallback((sessionId: string) => {
@@ -63,12 +88,17 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
     }
   }, [setTerminalWriteCallback])
 
-  // Clean up handles for removed sessions
+  // Clean up handles + last-sent sizes for removed sessions
   useEffect(() => {
     const currentIds = new Set(sessions.map(s => s.sessionId))
     for (const id of handlesRef.current.keys()) {
       if (!currentIds.has(id)) {
         handlesRef.current.delete(id)
+      }
+    }
+    for (const id of lastSentRef.current.keys()) {
+      if (!currentIds.has(id)) {
+        lastSentRef.current.delete(id)
       }
     }
   }, [sessions])
@@ -89,7 +119,8 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
             className="terminal-container"
             initialData={getInitialData(session.sessionId)}
             onReady={(handle) => handleReady(session.sessionId, handle)}
-            fixedSize={MIRROR_SIZE}
+            fixedSize={sessionStates[session.sessionId]?.terminalSize ?? MIRROR_DEFAULT}
+            onMeasure={(cols, rows) => handleMeasure(session.sessionId, cols, rows)}
           />
         </div>
       ))}

--- a/packages/dashboard/src/components/MultiTerminalView.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.tsx
@@ -53,8 +53,14 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
   // the measurement itself.
   const lastSentRef = useRef(new Map<string, string>())
   const handleMeasure = useCallback((sessionId: string, cols: number, rows: number) => {
-    if (useConnectionStore.getState().activeSessionId !== sessionId) return
-    const key = `${cols}x${rows}`
+    const state = useConnectionStore.getState()
+    if (state.activeSessionId !== sessionId) return
+    // Include the session's authority role in the dedupe key (Copilot review): if
+    // we measured while an observer (the server ignored the resize) and later
+    // become primary/unclaimed, the role flips and the same grid re-sends — so
+    // claiming primary takes effect without needing a pane-size change.
+    const role = state.sessionStates[sessionId]?.sessionRole ?? 'none'
+    const key = `${cols}x${rows}@${role}`
     if (lastSentRef.current.get(sessionId) === key) return
     lastSentRef.current.set(sessionId, key)
     requestTerminalResize(sessionId, cols, rows)

--- a/packages/dashboard/src/components/TerminalView.test.tsx
+++ b/packages/dashboard/src/components/TerminalView.test.tsx
@@ -13,6 +13,10 @@ import { TerminalView, BATCH_INTERVAL } from './TerminalView'
 const writeSpy = vi.fn()
 const disposeSpy = vi.fn()
 const fitSpy = vi.fn()
+const resizeSpy = vi.fn()
+// #5835 Phase 2: mirror mode measures the pane via FitAddon.proposeDimensions().
+// Tests can override this to simulate different pane sizes.
+let proposeDimensionsResult: { cols: number; rows: number } | undefined = { cols: 200, rows: 50 }
 
 // Mock xterm.js since jsdom can't render canvas
 vi.mock('@xterm/xterm', () => {
@@ -33,6 +37,7 @@ vi.mock('@xterm/xterm', () => {
     dispose() { disposeSpy(); this._disposed = true }
     loadAddon(addon: unknown) { this._addons.push(addon) }
     onData(_cb: (data: string) => void) { return { dispose: () => {} } }
+    resize(cols: number, rows: number) { resizeSpy(cols, rows) }
   }
   return { Terminal: MockTerminal }
 })
@@ -41,6 +46,7 @@ vi.mock('@xterm/addon-fit', () => {
   class MockFitAddon {
     _fitted = false
     fit() { fitSpy(); this._fitted = true }
+    proposeDimensions() { return proposeDimensionsResult }
     dispose() {}
   }
   return { FitAddon: MockFitAddon }
@@ -54,6 +60,7 @@ describe('TerminalView', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    proposeDimensionsResult = { cols: 200, rows: 50 }
   })
 
   it('renders a container div', () => {
@@ -192,5 +199,51 @@ describe('TerminalView', () => {
     // Advance past debounce — fit() should NOT have been called again
     act(() => { vi.advanceTimersByTime(200) })
     expect(fitSpy).toHaveBeenCalledTimes(mountCalls)
+  })
+
+  // #5835 Phase 2: mirror mode — dynamic size + pane measurement.
+  describe('mirror mode (#5835 Phase 2)', () => {
+    it('does NOT auto-fit in fixedSize mode (would stretch the letterboxed grid)', () => {
+      fitSpy.mockClear()
+      render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} />)
+      expect(fitSpy).not.toHaveBeenCalled()
+    })
+
+    it('measures the pane via proposeDimensions and reports it through onMeasure on mount', () => {
+      proposeDimensionsResult = { cols: 200, rows: 50 }
+      const onMeasure = vi.fn()
+      render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} onMeasure={onMeasure} />)
+      expect(onMeasure).toHaveBeenCalledWith(200, 50)
+    })
+
+    it('does not call onMeasure when proposeDimensions returns nothing (hidden/0-size pane)', () => {
+      proposeDimensionsResult = undefined
+      const onMeasure = vi.fn()
+      render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} onMeasure={onMeasure} />)
+      expect(onMeasure).not.toHaveBeenCalled()
+    })
+
+    it('resizes the live terminal in place when fixedSize changes (preserves scrollback)', () => {
+      resizeSpy.mockClear()
+      const { rerender } = render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} />)
+      // mount runs the resize effect once with the initial size
+      resizeSpy.mockClear()
+      rerender(<TerminalView fixedSize={{ cols: 160, rows: 48 }} />)
+      expect(resizeSpy).toHaveBeenCalledWith(160, 48)
+    })
+
+    it('does not re-resize when fixedSize object identity changes but values do not', () => {
+      const { rerender } = render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} />)
+      resizeSpy.mockClear()
+      rerender(<TerminalView fixedSize={{ cols: 120, rows: 30 }} />)
+      expect(resizeSpy).not.toHaveBeenCalled()
+    })
+
+    it('normal (non-fixed) mode never resizes the terminal imperatively', () => {
+      resizeSpy.mockClear()
+      const { rerender } = render(<TerminalView />)
+      rerender(<TerminalView />)
+      expect(resizeSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/dashboard/src/components/TerminalView.test.tsx
+++ b/packages/dashboard/src/components/TerminalView.test.tsx
@@ -209,6 +209,16 @@ describe('TerminalView', () => {
       expect(fitSpy).not.toHaveBeenCalled()
     })
 
+    it('the exposed fit() handle is a no-op in mirror mode (never stretches the letterbox)', () => {
+      let fitFn: (() => void) | undefined
+      fitSpy.mockClear()
+      render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} onReady={({ fit }) => { fitFn = fit }} />)
+      expect(fitFn).toBeInstanceOf(Function)
+      fitSpy.mockClear() // ignore any mount-time activity
+      fitFn!()
+      expect(fitSpy).not.toHaveBeenCalled()
+    })
+
     it('measures the pane via proposeDimensions and reports it through onMeasure on mount', () => {
       proposeDimensionsResult = { cols: 200, rows: 50 }
       const onMeasure = vi.fn()

--- a/packages/dashboard/src/components/TerminalView.tsx
+++ b/packages/dashboard/src/components/TerminalView.tsx
@@ -21,14 +21,26 @@ export interface TerminalViewProps {
   initialData?: string
   onReady?: (handle: TerminalHandle) => void
   /**
-   * #5835 (PR2): pin the terminal to a fixed cols×rows and letterbox it
-   * (centered, no FitAddon stretch). Used for the live claude-tui PTY mirror,
-   * whose server-side PTY is a fixed 120×30 grid — rendering at exactly that
-   * size keeps the mirror 1:1 faithful (the authenticity surface) instead of
-   * scaling the xterm to the pane and misaligning the TUI's absolute cursor
-   * positioning. Omit for the normal fit-to-pane behaviour.
+   * #5835 (PR2): pin the terminal to a cols×rows grid and letterbox it (centered,
+   * no FitAddon stretch). Used for the live claude-tui PTY mirror, whose server
+   * PTY is a fixed grid — rendering at exactly that size keeps the mirror 1:1
+   * faithful (the authenticity surface) instead of scaling the xterm to the pane
+   * and misaligning the TUI's absolute cursor positioning. Omit for the normal
+   * fit-to-pane behaviour.
+   *
+   * #5835 Phase 2: this is now DYNAMIC — when it changes (the server reports a new
+   * authoritative size via terminal_size) the live terminal is resized in place,
+   * preserving scrollback. Pair with `onMeasure` to drive the size from the pane.
    */
   fixedSize?: { cols: number; rows: number }
+  /**
+   * #5835 Phase 2: in mirror (fixedSize) mode, called with the cols×rows that
+   * would fit the current pane (measured via FitAddon, never auto-applied) on
+   * mount and whenever the pane resizes. The parent debounces/dedupes and asks
+   * the server to resize the real PTY (terminal_resize); the authoritative size
+   * comes back via `fixedSize`. No-op in normal fit-to-pane mode.
+   */
+  onMeasure?: (cols: number, rows: number) => void
 }
 
 export const BATCH_INTERVAL = 50 // ms — coalesce rapid writes
@@ -39,13 +51,21 @@ function safeFit(fit: FitAddon) {
   try { fit.fit() } catch { /* container not visible */ }
 }
 
-export function TerminalView({ className, initialData, onReady, fixedSize }: TerminalViewProps) {
+export function TerminalView({ className, initialData, onReady, fixedSize, onMeasure }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
   const batchRef = useRef<string[]>([])
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const disposedRef = useRef(false)
+  // #5835 Phase 2: keep the latest onMeasure callback in a ref so the mount-once
+  // effect's resize/measure handler always calls the current one (the parent
+  // recreates the closure each render, but the terminal lifecycle is mount-once).
+  const onMeasureRef = useRef(onMeasure)
+  onMeasureRef.current = onMeasure
+  // Whether this terminal is a fixed-size letterboxed mirror. Captured per render
+  // for the mount effect; the live resize effect below reads fixedSize directly.
+  const isMirror = !!fixedSize
 
   const flush = useCallback(() => {
     if (disposedRef.current) {
@@ -106,16 +126,16 @@ export function TerminalView({ className, initialData, onReady, fixedSize }: Ter
     })
 
     // #5835 (PR2): a fixedSize mirror renders at exactly cols×rows and is
-    // centered/letterboxed by the container — no FitAddon (stretching the xterm
-    // to the pane would make its grid disagree with the server PTY's 120×30 and
-    // misrender the TUI). FitAddon is only for the normal fit-to-pane mode.
-    let fitAddon: FitAddon | null = null
-    if (!fixedSize) {
-      fitAddon = new FitAddon()
-      term.loadAddon(fitAddon)
-    }
+    // centered/letterboxed by the container — it must NOT stretch the xterm to
+    // the pane (that would make its grid disagree with the server PTY and
+    // misrender the TUI). #5835 Phase 2: still load a FitAddon in mirror mode,
+    // but ONLY to MEASURE the pane (proposeDimensions) — never fit() — so the
+    // parent can drive the server PTY to the pane's size. fit() (auto-apply) is
+    // still only for the normal fit-to-pane mode.
+    const fitAddon = new FitAddon()
+    term.loadAddon(fitAddon)
     term.open(containerRef.current)
-    if (fitAddon) safeFit(fitAddon)
+    if (!fixedSize) safeFit(fitAddon)
 
     termRef.current = term
     fitRef.current = fitAddon
@@ -129,30 +149,45 @@ export function TerminalView({ className, initialData, onReady, fixedSize }: Ter
     onReady?.({ write, clear, fit })
 
     // Debounced resize handler — prevents excessive reflows during drag-resize.
-    // Skipped entirely in fixedSize mode: a letterboxed 120×30 mirror never
-    // re-fits (the container just centers it / adds scroll if the pane is small).
+    // Normal mode: fit() the xterm to the pane. #5835 Phase 2 mirror mode: MEASURE
+    // the pane (proposeDimensions, no fit) and report the fitting cols×rows up so
+    // the parent can drive the server PTY — the xterm itself is resized only when
+    // the authoritative size comes back (the fixedSize effect below).
     let resizeTimer: ReturnType<typeof setTimeout> | null = null
     let resizeObserver: ResizeObserver | undefined
-    const debouncedFit = () => {
-      if (disposedRef.current || !fitAddon) return
+    const onResize = () => {
+      if (disposedRef.current) return
       if (resizeTimer) clearTimeout(resizeTimer)
       resizeTimer = setTimeout(() => {
-        if (disposedRef.current || !fitAddon) return
-        safeFit(fitAddon)
+        if (disposedRef.current) return
+        if (isMirror) {
+          // Measure only — proposeDimensions returns the grid that fits the pane.
+          const dims = fitAddon.proposeDimensions()
+          if (dims && dims.cols > 0 && dims.rows > 0) {
+            onMeasureRef.current?.(dims.cols, dims.rows)
+          }
+        } else {
+          safeFit(fitAddon)
+        }
       }, RESIZE_DEBOUNCE)
     }
 
-    if (fitAddon) {
-      window.addEventListener('resize', debouncedFit)
-      if (typeof ResizeObserver !== 'undefined') {
-        resizeObserver = new ResizeObserver(debouncedFit)
-        resizeObserver.observe(containerRef.current)
-      }
+    window.addEventListener('resize', onResize)
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(onResize)
+      resizeObserver.observe(containerRef.current)
+    }
+    // Mirror mode: take an initial measurement so the server can size the PTY to
+    // the pane on first view (the ResizeObserver also fires on mount in most
+    // browsers, but don't rely on it). Normal mode already fit() above.
+    if (isMirror) {
+      const dims = fitAddon.proposeDimensions()
+      if (dims && dims.cols > 0 && dims.rows > 0) onMeasureRef.current?.(dims.cols, dims.rows)
     }
 
     return () => {
       disposedRef.current = true
-      window.removeEventListener('resize', debouncedFit)
+      window.removeEventListener('resize', onResize)
       resizeObserver?.disconnect()
       if (resizeTimer) clearTimeout(resizeTimer)
       if (timerRef.current) {
@@ -169,6 +204,18 @@ export function TerminalView({ className, initialData, onReady, fixedSize }: Ter
     // prop changes. Re-running this effect would destroy and recreate the
     // terminal instance, losing all scrollback.
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // #5835 Phase 2: when the authoritative mirror size changes (the server reports
+  // a new terminal_size), resize the live xterm in place — preserving scrollback
+  // and avoiding the mount-once teardown. Depend on the primitive cols/rows (not
+  // the object identity) so a new {cols,rows} object with the same values is a
+  // no-op. Normal fit-to-pane mode has no fixedSize and skips this.
+  useEffect(() => {
+    if (!fixedSize || disposedRef.current || !termRef.current) return
+    try {
+      termRef.current.resize(fixedSize.cols, fixedSize.rows)
+    } catch { /* terminal not ready / disposed */ }
+  }, [fixedSize?.cols, fixedSize?.rows]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div

--- a/packages/dashboard/src/components/TerminalView.tsx
+++ b/packages/dashboard/src/components/TerminalView.tsx
@@ -63,8 +63,12 @@ export function TerminalView({ className, initialData, onReady, fixedSize, onMea
   // recreates the closure each render, but the terminal lifecycle is mount-once).
   const onMeasureRef = useRef(onMeasure)
   onMeasureRef.current = onMeasure
-  // Whether this terminal is a fixed-size letterboxed mirror. Captured per render
-  // for the mount effect; the live resize effect below reads fixedSize directly.
+  // Whether this terminal is a fixed-size letterboxed mirror. Mode is fixed at
+  // MOUNT — the xterm is constructed with mode-specific options (convertEol,
+  // initial cols/rows) and the mount-once onResize handler closes over this — so
+  // a caller must NOT toggle `fixedSize` between defined/undefined for a live
+  // terminal (the size VALUE may change freely; that's the resize effect below).
+  // The only consumer (MultiTerminalView) always passes a fixedSize.
   const isMirror = !!fixedSize
 
   const flush = useCallback(() => {

--- a/packages/dashboard/src/components/TerminalView.tsx
+++ b/packages/dashboard/src/components/TerminalView.tsx
@@ -142,7 +142,13 @@ export function TerminalView({ className, initialData, onReady, fixedSize, onMea
     if (!fixedSize) safeFit(fitAddon)
 
     termRef.current = term
-    fitRef.current = fitAddon
+    // #5835 Phase 2 (Copilot review): the exposed fit() handle must be a NO-OP in
+    // mirror mode — MultiTerminalView calls handle.fit() on tab switch, and now
+    // that a FitAddon is always loaded (for measurement) that would stretch the
+    // letterboxed mirror and break 1:1 PTY fidelity. Only publish the addon via
+    // fitRef (which fit() uses) in normal fit-to-pane mode; measurement below uses
+    // the local `fitAddon` directly, so it still works in mirror mode.
+    fitRef.current = fixedSize ? null : fitAddon
 
     // Write initial data if provided
     if (initialData) {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -642,18 +642,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // for a session (terminal_size). Stored per-session so a tab switch shows the
   // right size immediately; the mirror renders at exactly this size, letterboxed.
   setTerminalSize: (sessionId: string, cols: number, rows: number) => {
-    set((state) => {
-      const ss = state.sessionStates[sessionId];
-      if (!ss) return {};
-      const prev = ss.terminalSize;
-      if (prev && prev.cols === cols && prev.rows === rows) return {};
-      return {
-        sessionStates: {
-          ...state.sessionStates,
-          [sessionId]: { ...ss, terminalSize: { cols, rows } },
-        },
-      };
-    });
+    // Check BEFORE set(): a Zustand updater returning {} still produces a new
+    // state object and notifies every subscriber (Copilot review) — so for an
+    // unknown session or an unchanged size, skip the set() entirely. JS is
+    // single-threaded with no await here, so the get()→set() read is race-free.
+    const ss = get().sessionStates[sessionId];
+    if (!ss) return;
+    const prev = ss.terminalSize;
+    if (prev && prev.cols === cols && prev.rows === rows) return;
+    set((state) => ({
+      sessionStates: {
+        ...state.sessionStates,
+        [sessionId]: { ...ss, terminalSize: { cols, rows } },
+      },
+    }));
   },
 
   // #5835 Phase 2: ask the server to resize a session's live PTY so the real TUI

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -638,6 +638,36 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #5835 Phase 2: record the authoritative PTY grid size the server reported
+  // for a session (terminal_size). Stored per-session so a tab switch shows the
+  // right size immediately; the mirror renders at exactly this size, letterboxed.
+  setTerminalSize: (sessionId: string, cols: number, rows: number) => {
+    set((state) => {
+      const ss = state.sessionStates[sessionId];
+      if (!ss) return {};
+      const prev = ss.terminalSize;
+      if (prev && prev.cols === cols && prev.rows === rows) return {};
+      return {
+        sessionStates: {
+          ...state.sessionStates,
+          [sessionId]: { ...ss, terminalSize: { cols, rows } },
+        },
+      };
+    });
+  },
+
+  // #5835 Phase 2: ask the server to resize a session's live PTY so the real TUI
+  // uses the viewer's available pane. The server enforces the actual authority
+  // (only the primary owner / sole viewer drives the shared PTY) and broadcasts
+  // the applied size back as terminal_size, so this is a best-effort request — a
+  // closed socket or an observer role simply means the size doesn't change.
+  requestTerminalResize: (sessionId: string, cols: number, rows: number) => {
+    const { socket } = get();
+    if (sessionId && cols > 0 && rows > 0 && socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'terminal_resize', sessionId, cols, rows });
+    }
+  },
+
   // Web tasks (Claude Code Web)
   webFeatures: { available: false, remote: false, teleport: false },
   webTasks: [],

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -462,6 +462,15 @@ describe('dashboard message-handler dispatch', () => {
       handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: 80, rows: -1 }, ctx() as any)
       expect((store.getState() as any)._terminalSizeCalls).toEqual([])
     })
+
+    it('ignores terminal_size with NaN / Infinity / non-integer dimensions', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: NaN, rows: 24 }, ctx() as any)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: Infinity, rows: 24 }, ctx() as any)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: 80.5, rows: 24 }, ctx() as any)
+      expect((store.getState() as any)._terminalSizeCalls).toEqual([])
+    })
   })
 
   describe('error dispatch', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -82,6 +82,7 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
   const infoNotifications: unknown[] = []
   const grantCalls: Array<{ skillName: string; author: string }> = []
   const terminalWrites: string[] = []
+  const terminalSizeCalls: Array<{ sessionId: string; cols: number; rows: number }> = []
   // #4982 — capture every setSessionNotFoundError call (the SESSION_NOT_FOUND
   // branch of session_error wires through this setter; we assert on the
   // shape of the call).
@@ -126,6 +127,7 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
       grantCalls.push({ skillName, author })
     },
     appendTerminalData: (d: string) => { terminalWrites.push(d) },
+    setTerminalSize: (sessionId: string, cols: number, rows: number) => { terminalSizeCalls.push({ sessionId, cols, rows }) },
     // #5281 ③ PR 2 — server registry surface for the pairing auth_ok/pair_fail
     // paths. Captured so tests can assert token persistence + dead-entry cleanup.
     activeServerId: null,
@@ -133,6 +135,7 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
     updateServer: (serverId: string, patch: unknown) => { updateServerCalls.push({ serverId, patch }) },
     removeServer: (serverId: string) => { removeServerCalls.push(serverId) },
     _terminalWrites: terminalWrites,
+    _terminalSizeCalls: terminalSizeCalls,
     _serverErrorActions: serverErrorActions,
     _infoNotifications: infoNotifications,
     _grantCalls: grantCalls,
@@ -419,6 +422,37 @@ describe('dashboard message-handler dispatch', () => {
       setStore(store)
       handleMessage({ type: 'terminal_output', data: 'orphan' }, ctx() as any)
       expect((store.getState() as any)._terminalWrites).toEqual([])
+    })
+  })
+
+  describe('terminal_size dispatch (#5835 Phase 2)', () => {
+    it('records the authoritative size for the active session', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: 160, rows: 48 }, ctx() as any)
+      expect((store.getState() as any)._terminalSizeCalls).toEqual([{ sessionId: 'sess-1', cols: 160, rows: 48 }])
+    })
+
+    it('ignores terminal_size for a non-active session', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_size', sessionId: 'other', cols: 100, rows: 40 }, ctx() as any)
+      expect((store.getState() as any)._terminalSizeCalls).toEqual([])
+    })
+
+    it('ignores terminal_size with non-number / missing dimensions', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: '80', rows: 24 }, ctx() as any)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: 80 }, ctx() as any)
+      expect((store.getState() as any)._terminalSizeCalls).toEqual([])
+    })
+
+    it('ignores terminal_size with a missing sessionId', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_size', cols: 80, rows: 24 }, ctx() as any)
+      expect((store.getState() as any)._terminalSizeCalls).toEqual([])
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -454,6 +454,14 @@ describe('dashboard message-handler dispatch', () => {
       handleMessage({ type: 'terminal_size', cols: 80, rows: 24 }, ctx() as any)
       expect((store.getState() as any)._terminalSizeCalls).toEqual([])
     })
+
+    it('ignores terminal_size with non-positive dimensions', () => {
+      store = createMockStore(baseState({ activeSessionId: 'sess-1' }))
+      setStore(store)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: 0, rows: 24 }, ctx() as any)
+      handleMessage({ type: 'terminal_size', sessionId: 'sess-1', cols: 80, rows: -1 }, ctx() as any)
+      expect((store.getState() as any)._terminalSizeCalls).toEqual([])
+    })
   })
 
   describe('error dispatch', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1229,6 +1229,17 @@ function handleTerminalOutput(msg: Record<string, unknown>, get: MsgGet, _set: M
   get().appendTerminalData(msg.data);
 }
 
+// #5835 Phase 2: the server's authoritative live-PTY grid size for a session
+// (sent on terminal_subscribe and on every primary-driven resize). Record it so
+// the mirror renders at exactly this size, letterboxed. Same active-session +
+// string-sessionId guard as terminal_output: the server only sends this for a
+// session we're viewing, so an off-session/malformed frame is dropped.
+function handleTerminalSize(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  if (typeof msg.cols !== 'number' || typeof msg.rows !== 'number') return;
+  if (typeof msg.sessionId !== 'string' || msg.sessionId !== get().activeSessionId) return;
+  get().setTerminalSize(msg.sessionId, msg.cols, msg.rows);
+}
+
 function handleTokenRotated(msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
   // Token parse shared via store-core (#5454); the URL-rewrite side effect
   // stays dashboard-specific.
@@ -2687,6 +2698,7 @@ const HANDLERS: Record<string, Handler> = {
   raw: handleRaw,
   raw_background: handleRawBackground,
   terminal_output: handleTerminalOutput,
+  terminal_size: handleTerminalSize,
   token_rotated: handleTokenRotated,
   pairing_refreshed: handlePairingRefreshed,
   checkpoint_restored: handleCheckpointRestored,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1235,10 +1235,12 @@ function handleTerminalOutput(msg: Record<string, unknown>, get: MsgGet, _set: M
 // string-sessionId guard as terminal_output: the server only sends this for a
 // session we're viewing, so an off-session/malformed frame is dropped.
 function handleTerminalSize(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  // Positive numbers only — matches requestTerminalResize's outbound guard so a
-  // malformed 0/negative grid can't reach term.resize (the server sends sane
-  // clamped ints, so this is defensive).
-  if (typeof msg.cols !== 'number' || typeof msg.rows !== 'number' || msg.cols <= 0 || msg.rows <= 0) return;
+  // Positive integers only. The typeof check narrows for the setTerminalSize call
+  // below; Number.isInteger then rejects NaN/Infinity/floats and > 0 keeps a
+  // 0/negative grid out of term.resize. Matches the other numeric guards in this
+  // file (the server sends sane clamped ints; defensive).
+  if (typeof msg.cols !== 'number' || typeof msg.rows !== 'number') return;
+  if (!Number.isInteger(msg.cols) || !Number.isInteger(msg.rows) || msg.cols <= 0 || msg.rows <= 0) return;
   if (typeof msg.sessionId !== 'string' || msg.sessionId !== get().activeSessionId) return;
   get().setTerminalSize(msg.sessionId, msg.cols, msg.rows);
 }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1235,7 +1235,10 @@ function handleTerminalOutput(msg: Record<string, unknown>, get: MsgGet, _set: M
 // string-sessionId guard as terminal_output: the server only sends this for a
 // session we're viewing, so an off-session/malformed frame is dropped.
 function handleTerminalSize(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  if (typeof msg.cols !== 'number' || typeof msg.rows !== 'number') return;
+  // Positive numbers only — matches requestTerminalResize's outbound guard so a
+  // malformed 0/negative grid can't reach term.resize (the server sends sane
+  // clamped ints, so this is defensive).
+  if (typeof msg.cols !== 'number' || typeof msg.rows !== 'number' || msg.cols <= 0 || msg.rows <= 0) return;
   if (typeof msg.sessionId !== 'string' || msg.sessionId !== get().activeSessionId) return;
   get().setTerminalSize(msg.sessionId, msg.cols, msg.rows);
 }

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -670,6 +670,20 @@ describe('useConnectionStore', () => {
     expect(useConnectionStore.getState().sessionStates['ghost']).toBeUndefined();
   });
 
+  it('setTerminalSize does not produce a new sessionStates object on an unchanged size', async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({ sessionStates: { 'sess-1': createEmptySessionState() } });
+    useConnectionStore.getState().setTerminalSize('sess-1', 120, 30);
+    const after1 = useConnectionStore.getState().sessionStates;
+    // Same size again — must skip set() entirely (no new ref, no subscriber churn)
+    useConnectionStore.getState().setTerminalSize('sess-1', 120, 30);
+    expect(useConnectionStore.getState().sessionStates).toBe(after1);
+    // An unknown session also must not churn state
+    useConnectionStore.getState().setTerminalSize('ghost', 80, 24);
+    expect(useConnectionStore.getState().sessionStates).toBe(after1);
+    useConnectionStore.setState({ sessionStates: {} });
+  });
+
   it('requestTerminalResize sends terminal_resize over an open socket', async () => {
     const { useConnectionStore } = await import('./connection');
     const sent: string[] = [];

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -653,6 +653,44 @@ describe('useConnectionStore', () => {
     expect(terminalBuffer).toContain('ls');
     expect(terminalBuffer).toContain('file.txt');
   });
+
+  // #5835 Phase 2: live-PTY mirror resize actions.
+  it('setTerminalSize records the authoritative size on an existing session', async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({ sessionStates: { 'sess-1': createEmptySessionState() } });
+    useConnectionStore.getState().setTerminalSize('sess-1', 160, 48);
+    expect(useConnectionStore.getState().sessionStates['sess-1']!.terminalSize).toEqual({ cols: 160, rows: 48 });
+    useConnectionStore.setState({ sessionStates: {} });
+  });
+
+  it('setTerminalSize is a no-op for an unknown session', async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({ sessionStates: {} });
+    useConnectionStore.getState().setTerminalSize('ghost', 100, 40);
+    expect(useConnectionStore.getState().sessionStates['ghost']).toBeUndefined();
+  });
+
+  it('requestTerminalResize sends terminal_resize over an open socket', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const sent: string[] = [];
+    const mockSocket = { send: (d: string) => sent.push(d), readyState: 1 } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: mockSocket });
+    useConnectionStore.getState().requestTerminalResize('sess-1', 120, 36);
+    expect(sent).toHaveLength(1);
+    const parsed = JSON.parse(sent[0]!);
+    expect(parsed).toMatchObject({ type: 'terminal_resize', sessionId: 'sess-1', cols: 120, rows: 36 });
+    useConnectionStore.setState({ socket: null });
+  });
+
+  it('requestTerminalResize is a no-op for non-positive dimensions', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const sent: string[] = [];
+    const mockSocket = { send: (d: string) => sent.push(d), readyState: 1 } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: mockSocket });
+    useConnectionStore.getState().requestTerminalResize('sess-1', 0, 40);
+    expect(sent).toHaveLength(0);
+    useConnectionStore.setState({ socket: null });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -469,6 +469,11 @@ export interface PendingTrustGrant {
 
 export interface SessionState extends BaseSessionState {
   terminalRawBuffer: string;
+  // #5835 Phase 2: the authoritative live-PTY grid size the server last reported
+  // for this session (terminal_size). The mirror renders at exactly this size,
+  // letterboxed. Undefined until the server reports it; the view falls back to
+  // the shared default (CLAUDE_TUI_PTY_SIZE) meanwhile.
+  terminalSize?: { cols: number; rows: number };
   // Files tab: selected file path (persists across tab switches)
   selectedFilePath: string | null;
   thinkingLevel: ThinkingLevel;
@@ -960,6 +965,11 @@ export interface ConnectionState {
   // (terminal_output). Sent when the Output tab is shown for a claude-tui session.
   subscribeTerminalMirror: (sessionId: string) => void;
   unsubscribeTerminalMirror: (sessionId: string) => void;
+  // #5835 Phase 2: record the authoritative PTY size the server reported for a
+  // session (from a terminal_size message), and request a resize of a session's
+  // live PTY (terminal_resize) when the viewer pane can fit a different grid.
+  setTerminalSize: (sessionId: string, cols: number, rows: number) => void;
+  requestTerminalResize: (sessionId: string, cols: number, rows: number) => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   sendInput: (input: string, wireAttachments?: { type: string; name: string; [key: string]: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
   /**

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -76,7 +76,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'terminal_size', // #5835 Phase 2 (server PR) emits the authoritative live-PTY size; the dashboard receipt handler (letterbox to it) lands in the Phase 2 dashboard PR, which will move this to PLATFORM_SPECIFIC as 'dashboard' (exactly as terminal_output did across Phase 1's two PRs).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -138,6 +137,7 @@ const PLATFORM_SPECIFIC = {
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
   'terminal_output': 'dashboard', // #5835 (PR2) live claude-tui PTY mirror — the dashboard renders the raw bytes in xterm; the mobile WebView terminal render is a deferred follow-up per the epic
+  'terminal_size': 'dashboard', // #5835 Phase 2 authoritative live-PTY grid size — the dashboard letterboxes the mirror to it (setTerminalSize); same mobile follow-up as terminal_output
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
   'activity_snapshot': 'dashboard', // Control Room live activity tree (#5161 schema / #5160 server / #5162 reducer / #5163 dashboard panel) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5159
   'activity_delta': 'dashboard',    // Control Room activity delta — see activity_snapshot above; dashboard-only for v1, mobile parity is Phase-2 per epic #5159


### PR DESCRIPTION
## What

Completes **Phase 2** of the TUI live remote-viewer epic (#5835), the **dashboard half** (server half merged in #5840). The Output mirror now sizes the real claude-tui TUI to the viewer's available pane instead of the fixed 120×30 grid, and renders at the server's authoritative size.

The round-trip: the viewer measures its pane → asks the server to resize the PTY (`terminal_resize`) → the server (which enforces primary/viewer authority) applies + broadcasts the applied size back (`terminal_size`) → the dashboard resizes its xterm in place to match.

## How

- **`message-handler`** — `handleTerminalSize` records the server's authoritative grid for the active session (same active-session + string-`sessionId` guard as `terminal_output`; validates numeric `cols`/`rows`). Registered in the HANDLERS map.
- **store** — per-session `sessionStates[id].terminalSize`; `setTerminalSize` (deduped) and `requestTerminalResize` (best-effort `terminal_resize` send — the server enforces the actual authority, so an observer/closed-socket simply doesn't change the size).
- **`TerminalView`** — `fixedSize` is now **dynamic**: a new effect resizes the live xterm **in place** (preserving scrollback, no remount) when the authoritative size changes, keyed on the primitive `cols`/`rows`. In mirror mode it loads a `FitAddon` purely to **measure** the pane (`proposeDimensions`, **never** auto-`fit()` — that would stretch the letterbox) and reports the fitting grid via a new `onMeasure` callback, kept current via a ref across the mount-once lifecycle.
- **`MultiTerminalView`** — passes each session its stored `terminalSize` as `fixedSize` (falling back to `CLAUDE_TUI_PTY_SIZE` until the server reports), and forwards a measurement of the **active** session as a **deduped** resize request (hidden panes measure 0 and are ignored; identical sizes aren't re-sent).
- **handler-coverage** — `terminal_size` moves `INTENTIONALLY_UNHANDLED` → `PLATFORM_SPECIFIC` (`dashboard`), mirroring how `terminal_output` moved across Phase 1's two PRs.

## Safety / fidelity

- **Still read-only.** This sizes the viewport; no keystroke/input path (Phase 3).
- **Letterbox fidelity preserved** — the mirror still renders at an exact cols×rows grid, centered; the size is just no longer hard-coded. No auto-fit stretch.
- **Authority stays server-side** — the client only *requests*; #5840's primary/viewer gate decides. Observers ride along by rendering the broadcast size.

## Tests

- `TerminalView.test.tsx` — dynamic in-place resize on `fixedSize` change, measure-on-mount via `proposeDimensions`, no `onMeasure` when the pane is 0/hidden, **no** auto-fit in mirror mode, value-dedupe (object-identity change with same values is a no-op), normal mode never resizes imperatively.
- `MultiTerminalView.test.tsx` — per-session size passthrough (stored size vs default), active-only measure→resize, dedupe (same grid once; a different grid re-sends).
- `store.test.ts` — `setTerminalSize` (existing vs unknown session), `requestTerminalResize` (open socket vs non-positive dims).
- `message-handler.test.ts` — `terminal_size` dispatch (active-session record; non-active / non-number / missing-`sessionId` dropped).

Dashboard tsc clean; dashboard suite 3736 pass; protocol 289 pass.

Closes the Phase 2 work for #5835 (resize sync). Phase 3 (keystroke forwarding) and the mobile WebView render remain deferred follow-ups on the epic.