### PR TITLE
feat(server): forward raw keystrokes to the live claude-tui PTY (#5835 Phase 3, server)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -546,6 +546,11 @@ export declare const TerminalResizeSchema: z.ZodObject<{
     cols: z.ZodNumber;
     rows: z.ZodNumber;
 }, z.core.$strip>;
+export declare const TerminalInputSchema: z.ZodObject<{
+    type: z.ZodLiteral<"terminal_input">;
+    sessionId: z.ZodString;
+    data: z.ZodString;
+}, z.core.$strip>;
 export declare const ClientVisibleSchema: z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;
@@ -946,6 +951,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     sessionId: z.ZodString;
     cols: z.ZodNumber;
     rows: z.ZodNumber;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"terminal_input">;
+    sessionId: z.ZodString;
+    data: z.ZodString;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"client_visible">;
     visible: z.ZodBoolean;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -708,6 +708,18 @@ export const TerminalResizeSchema = z.object({
     cols: z.number().int().min(1).max(1000),
     rows: z.number().int().min(1).max(1000),
 });
+// #5835 Phase 3: raw keystroke forwarding to a session's live PTY — true remote
+// control (the mirror becomes interactive). `data` is opaque terminal bytes (a
+// keypress, an escape sequence, or a bracketed-paste chunk) written verbatim to
+// the PTY. Authority mirrors `input`: a pairing-bound token may only drive its
+// bound session, and the server's primary-ownership gate keeps a single driver
+// (an observer's keystroke is rejected with input_conflict). The 100k cap bounds
+// a single message (a keystroke is a few bytes; the ceiling covers a paste).
+export const TerminalInputSchema = z.object({
+    type: z.literal('terminal_input'),
+    sessionId: z.string().max(256),
+    data: z.string().max(100000),
+});
 // #3404: client signals foreground/background state. Mobile app sends
 // {visible:false} on AppState background/inactive so the server stops
 // treating its still-alive WS connection as an active viewer and lets
@@ -1003,6 +1015,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     TerminalSubscribeSchema,
     TerminalUnsubscribeSchema,
     TerminalResizeSchema,
+    TerminalInputSchema,
     ClientVisibleSchema,
     ClaimPrimarySchema,
     ListProvidersSchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -807,6 +807,19 @@ export const TerminalResizeSchema = z.object({
   rows: z.number().int().min(1).max(1000),
 })
 
+// #5835 Phase 3: raw keystroke forwarding to a session's live PTY — true remote
+// control (the mirror becomes interactive). `data` is opaque terminal bytes (a
+// keypress, an escape sequence, or a bracketed-paste chunk) written verbatim to
+// the PTY. Authority mirrors `input`: a pairing-bound token may only drive its
+// bound session, and the server's primary-ownership gate keeps a single driver
+// (an observer's keystroke is rejected with input_conflict). The 100k cap bounds
+// a single message (a keystroke is a few bytes; the ceiling covers a paste).
+export const TerminalInputSchema = z.object({
+  type: z.literal('terminal_input'),
+  sessionId: z.string().max(256),
+  data: z.string().max(100000),
+})
+
 // #3404: client signals foreground/background state. Mobile app sends
 // {visible:false} on AppState background/inactive so the server stops
 // treating its still-alive WS connection as an active viewer and lets
@@ -1132,6 +1145,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   TerminalSubscribeSchema,
   TerminalUnsubscribeSchema,
   TerminalResizeSchema,
+  TerminalInputSchema,
   ClientVisibleSchema,
   ClaimPrimarySchema,
   ListProvidersSchema,

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1820,6 +1820,28 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
+   * #5835 Phase 3: write raw client keystrokes to the live PTY — true remote
+   * control (the read-only mirror becomes interactive). Bytes are written AS-IS:
+   * no prompt throttle (interactive keys arrive naturally paced over the wire;
+   * the throttle exists only for bulk programmatic prompts) and no transform
+   * (faithful remote keyboard, including control bytes like \x03 / escape seqs).
+   * The handler enforces authority (bound session + primary-ownership gate); this
+   * just writes. No-op (returns false) when there is no live PTY.
+   * @returns {boolean} true if the bytes were written to a live PTY.
+   */
+  writeTerminalInput(data) {
+    if (typeof data !== 'string' || data.length === 0) return false
+    if (!this._term || this._ptyExited || this._destroying) return false
+    try {
+      this._term.write(data)
+      return true
+    } catch (err) {
+      log.warn(`claude-tui terminal input write failed: ${err?.message || err}`)
+      return false
+    }
+  }
+
+  /**
    * Drop any pending mirror flush + buffered bytes. Called on teardown so a
    * dead PTY's leftover frame never broadcasts and no timer leaks.
    */

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -202,6 +202,18 @@ const FORBIDDEN_HOME_SUBDIRS = new Set([
  * trailing separator first to normalize. Found by Copilot review on
  * PR #2808.
  */
+// #5835: a client "views" a session iff it's its active session or in its
+// subscribed set — the SAME viewing clause ws-forwarding's terminalSubscriberFilter
+// uses to scope terminal_output/terminal_size broadcasts. Every PTY-touching
+// terminal handler (terminal_size send, terminal_resize, terminal_input) gates on
+// this so a client that merely knows a session id — but isn't watching it — can't
+// drive or leak its terminal (#5840 review; extended to terminal_input in #5842).
+// Shared here so the session-handlers and input-handlers copies can't drift.
+export function isSessionViewer(client, sid) {
+  return client.activeSessionId === sid ||
+    Boolean(client.subscribedSessionIds && client.subscribedSessionIds.has(sid))
+}
+
 export function isPathWithin(absPath, baseDir) {
   if (absPath === baseDir) return true
   // Normalize: strip a trailing separator so filesystem root and

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -921,9 +921,58 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
   }
 }
 
+// #5835 Phase 3: forward raw client keystrokes to the live claude-tui PTY — true
+// remote control (the read-only mirror becomes interactive). Authority mirrors
+// handleInput, deliberately reusing this file's gate primitives:
+//   - resolveSession enforces the pairing-bound session binding (a bound token may
+//     only drive its own session); a mismatch surfaces the canonical
+//     SESSION_TOKEN_MISMATCH envelope (same disambiguation as handleInput/interrupt).
+//   - The primary-ownership gate keeps a SINGLE driver: claimPrimary (NON-force)
+//     claims an unclaimed session for this client, no-ops if already primary, and
+//     REJECTS (input_conflict) if another client owns it. Unlike a chat send — which
+//     force-adopts an idle session — a stray keystroke must NOT silently steal a live
+//     TUI from its driver; taking over is the explicit claim_primary hand-off, and an
+//     observer rides along on the read-only mirror.
+// Only claude-tui sessions expose writeTerminalInput; other providers have no PTY,
+// so the keystroke is silently dropped for them.
+function handleTerminalInput(ws, client, msg, ctx) {
+  const sid = msg.sessionId || client.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    // Disambiguate a binding mismatch from a truly-missing session (same as
+    // handleInput/handleInterrupt) so a bound client aiming elsewhere sees the
+    // canonical SESSION_TOKEN_MISMATCH rather than a silent drop.
+    if (msg.sessionId && client.boundSessionId && client.boundSessionId !== msg.sessionId) {
+      log.info(`terminal_input rejected: session-token mismatch sessionId=${msg.sessionId} boundSessionId=${client.boundSessionId} client=${client.id}`)
+      ctx.transport.send(ws, {
+        type: 'session_error',
+        ...buildSessionTokenMismatchPayload({
+          sessionManager: ctx.sessions.sessionManager,
+          boundSessionId: client.boundSessionId,
+        }),
+      })
+    }
+    return
+  }
+  if (typeof entry.session.writeTerminalInput !== 'function') return
+  if (typeof msg.data !== 'string' || msg.data.length === 0) return
+  // Single-driver gate: claim (or confirm) primary; reject an observer's keystroke.
+  const res = ctx.transport.claimPrimary(sid, client.id)
+  if (res?.rejected) {
+    ctx.transport.send(ws, buildInputConflictError(
+      sid,
+      undefined,
+      'Another device is driving this session. Take over from the session menu to type into the terminal.',
+    ))
+    return
+  }
+  entry.session.writeTerminalInput(msg.data)
+}
+
 export const inputHandlers = {
   input: handleInput,
   interrupt: handleInterrupt,
+  terminal_input: handleTerminalInput,
   cancel_activity: handleCancelActivity,
   resume_budget: handleResumeBudget,
   register_push_token: handleRegisterPushToken,

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -6,7 +6,7 @@
  *          notification_prefs_set (#4541)
  */
 import { randomUUID } from 'node:crypto'
-import { validateAttachments, resolveFileRefAttachments, resolveSession, sendError, sendSessionError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
+import { validateAttachments, resolveFileRefAttachments, resolveSession, sendError, sendSessionError, buildSessionTokenMismatchPayload, isSessionViewer } from '../handler-utils.js'
 import { evaluateDraft as defaultEvaluateDraft, shouldSkipEvaluator } from '../prompt-evaluator.js'
 import { PushManager } from '../push.js'
 import { createLogger, sessionLogger } from '../logger.js'
@@ -941,7 +941,10 @@ function handleTerminalInput(ws, client, msg, ctx) {
   if (!entry) {
     // Disambiguate a binding mismatch from a truly-missing session (same as
     // handleInput/handleInterrupt) so a bound client aiming elsewhere sees the
-    // canonical SESSION_TOKEN_MISMATCH rather than a silent drop.
+    // canonical SESSION_TOKEN_MISMATCH rather than a silent drop. A truly-missing
+    // session returns silently (no SESSION_NOT_FOUND envelope, unlike handleInput):
+    // terminal_input is a high-frequency keystroke stream, so a per-key error toast
+    // would be noise — the dashboard already clears stale ids off the chat path.
     if (msg.sessionId && client.boundSessionId && client.boundSessionId !== msg.sessionId) {
       log.info(`terminal_input rejected: session-token mismatch sessionId=${msg.sessionId} boundSessionId=${client.boundSessionId} client=${client.id}`)
       ctx.transport.send(ws, {
@@ -955,6 +958,13 @@ function handleTerminalInput(ws, client, msg, ctx) {
     return
   }
   if (typeof entry.session.writeTerminalInput !== 'function') return
+  // Must be VIEWING the session to drive its PTY (#5842 review) — parity with
+  // terminal_resize/terminal_size (#5840): keystrokes are strictly more powerful
+  // than a resize, so they require at least the same viewer precondition. A client
+  // that merely knows an (even unclaimed) session id can't silently become its
+  // driver without watching it. The normal flow (Output tab open → activeSessionId
+  // === sid) passes; this only blocks blind cross-session poking.
+  if (!isSessionViewer(client, sid)) return
   if (typeof msg.data !== 'string' || msg.data.length === 0) return
   // Single-driver gate: claim (or confirm) primary; reject an observer's keystroke.
   const res = ctx.transport.claimPrimary(sid, client.id)

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -4,7 +4,7 @@
  * Handles: list_sessions, switch_session, create_session, destroy_session,
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
-import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError } from '../handler-utils.js'
+import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError, isSessionViewer } from '../handler-utils.js'
 import { getRegistryForProvider } from '../models.js'
 import { createLogger, loggerForSession } from '../logger.js'
 
@@ -343,17 +343,6 @@ function handleUnsubscribeSessions(ws, client, msg, ctx) {
     type: 'subscriptions_updated',
     subscribedSessionIds: [...client.subscribedSessionIds],
   })
-}
-
-// #5835 Phase 2: a client views a session iff it's its active session or in its
-// subscribed set — the SAME viewing clause ws-forwarding's terminalSubscriberFilter
-// uses to scope terminal_output/terminal_size broadcasts. Any direct terminal_size
-// send or PTY-mutating resize must gate on this too, so terminal state (incl. that
-// a session is claude-tui) never leaks to a non-viewer who merely knows the id
-// (#5840 Copilot review).
-function isSessionViewer(client, sid) {
-  return client.activeSessionId === sid ||
-    Boolean(client.subscribedSessionIds && client.subscribedSessionIds.has(sid))
 }
 
 // #5835 Phase 1: opt the client IN to a session's live PTY mirror. Only clients

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -300,6 +300,7 @@ function _isSecureRequest(req) {
  *   { type: 'terminal_subscribe', sessionId }           — #5835 opt IN to a session's live PTY mirror (terminal_output); only opted-in clients receive raw bytes
  *   { type: 'terminal_unsubscribe', sessionId }         — #5835 opt OUT of a session's live PTY mirror
  *   { type: 'terminal_resize', sessionId, cols, rows }  — #5835 Phase 2 request to resize the live claude-tui PTY; applied only for the session's primary owner (or an unclaimed session), then broadcast back as terminal_size
+ *   { type: 'terminal_input', sessionId, data }         — #5835 Phase 3 raw keystrokes → live claude-tui PTY (true remote control); authority mirrors `input` (bound-session check + single-driver primary gate; an observer's keystroke is rejected with input_conflict)
  *   { type: 'set_thinking_level', level }               — set thinking budget level ('default'|'high'|'max')
  *   { type: 'set_permission_rules', rules, sessionId }  — set per-session auto-approval rules
  *   { type: 'set_prompt_evaluator', value: boolean, sessionId? } — toggle the per-session promptEvaluator (#3185)

--- a/packages/server/tests/claude-tui-mirror.test.js
+++ b/packages/server/tests/claude-tui-mirror.test.js
@@ -146,3 +146,51 @@ test('a _term.resize throw is swallowed (no crash) and the size is still recorde
   assert.deepEqual(applied, { cols: 90, rows: 30 })
   assert.deepEqual(s.getTerminalSize(), { cols: 90, rows: 30 })
 })
+
+// #5835 Phase 3: writeTerminalInput forwards raw bytes to the live PTY as-is.
+
+test('writeTerminalInput writes raw bytes verbatim to a live PTY', () => {
+  const s = makeSession()
+  const writes = []
+  s._term = { write: (d) => writes.push(d) }
+  s._ptyExited = false
+  s._destroying = false
+  assert.equal(s.writeTerminalInput('a'), true)
+  assert.equal(s.writeTerminalInput('\x03'), true) // Ctrl-C control byte, untransformed
+  assert.equal(s.writeTerminalInput('\x1b[A'), true) // arrow-up escape sequence
+  assert.deepEqual(writes, ['a', '\x03', '\x1b[A'])
+})
+
+test('writeTerminalInput is a no-op with no live PTY / after exit / during teardown', () => {
+  const s = makeSession()
+  s._term = null
+  assert.equal(s.writeTerminalInput('x'), false)
+  const writes = []
+  s._term = { write: (d) => writes.push(d) }
+  s._ptyExited = true
+  assert.equal(s.writeTerminalInput('x'), false)
+  s._ptyExited = false
+  s._destroying = true
+  assert.equal(s.writeTerminalInput('x'), false)
+  assert.deepEqual(writes, [], 'nothing reaches a dead/exiting/tearing-down PTY')
+})
+
+test('writeTerminalInput ignores empty / non-string data', () => {
+  const s = makeSession()
+  const writes = []
+  s._term = { write: (d) => writes.push(d) }
+  s._ptyExited = false
+  s._destroying = false
+  assert.equal(s.writeTerminalInput(''), false)
+  assert.equal(s.writeTerminalInput(undefined), false)
+  assert.equal(s.writeTerminalInput(42), false)
+  assert.deepEqual(writes, [])
+})
+
+test('a _term.write throw is swallowed (no crash), returns false', () => {
+  const s = makeSession()
+  s._term = { write: () => { throw new Error('pty gone') } }
+  s._ptyExited = false
+  s._destroying = false
+  assert.equal(s.writeTerminalInput('x'), false)
+})

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -1905,4 +1905,76 @@ describe('input-handlers', () => {
       assert.equal(ctx.transport.updatePrimary.callCount, 1)
     })
   })
+
+  // #5835 Phase 3: raw keystroke forwarding → live PTY (true remote control).
+  describe('terminal_input', () => {
+    function makeTuiCtx() {
+      const sessions = new Map()
+      const writes = []
+      const session = { writeTerminalInput: createSpy((d) => { writes.push(d) }) }
+      sessions.set('s1', { session, name: 'S', cwd: '/work' })
+      const ctx = makeCtx(sessions)
+      return { ctx, writes, session }
+    }
+
+    it('claims an unclaimed session for the sender and writes the bytes', () => {
+      const { ctx, writes } = makeTuiCtx()
+      const client = makeClient({ id: 'me', activeSessionId: 's1' })
+      inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: '\x03' }, ctx)
+      assert.equal(ctx.transport.getPrimary('s1'), 'me', 'first keystroke claims primary')
+      assert.deepEqual(writes, ['\x03'])
+    })
+
+    it('writes when the sender is already primary (no spurious reject)', () => {
+      const { ctx, writes } = makeTuiCtx()
+      ctx.transport.claimPrimary('s1', 'me', { force: true })
+      const client = makeClient({ id: 'me', activeSessionId: 's1' })
+      inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: 'ls\r' }, ctx)
+      assert.deepEqual(writes, ['ls\r'])
+    })
+
+    it("rejects an observer's keystroke with input_conflict and does NOT write or steal primary", () => {
+      const { ctx, writes } = makeTuiCtx()
+      ctx.transport.claimPrimary('s1', 'owner', { force: true })
+      const observer = makeClient({ id: 'observer', activeSessionId: 's1' })
+      inputHandlers.terminal_input(makeWs(), observer, { sessionId: 's1', data: 'x' }, ctx)
+      assert.equal(writes.length, 0, 'no bytes written')
+      assert.equal(ctx.transport.getPrimary('s1'), 'owner', 'primary unchanged — no force-steal')
+      const err = ctx._sent.find(m => m.type === 'session_error')
+      assert.ok(err && err.category === 'input_conflict')
+    })
+
+    it('rejects a bound client aiming at a different session with SESSION_TOKEN_MISMATCH', () => {
+      const { ctx, writes } = makeTuiCtx()
+      const client = makeClient({ id: 'me', boundSessionId: 'other', activeSessionId: 'other' })
+      inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: 'x' }, ctx)
+      assert.equal(writes.length, 0)
+      const err = ctx._sent.find(m => m.type === 'session_error')
+      assert.ok(err, 'a SESSION_TOKEN_MISMATCH envelope was sent')
+    })
+
+    it('is a no-op (no throw) for a non-claude-tui session (no writeTerminalInput)', () => {
+      const sessions = new Map()
+      sessions.set('s1', { session: {}, name: 'S', cwd: '/work' }) // no PTY method
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ id: 'me', activeSessionId: 's1' })
+      assert.doesNotThrow(() =>
+        inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: 'x' }, ctx))
+    })
+
+    it('ignores empty data — does not write or claim primary', () => {
+      const { ctx, writes } = makeTuiCtx()
+      const client = makeClient({ id: 'me', activeSessionId: 's1' })
+      inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: '' }, ctx)
+      assert.equal(writes.length, 0)
+      assert.equal(ctx.transport.getPrimary('s1'), undefined, 'empty keystroke must not claim primary')
+    })
+
+    it('is a no-op for a missing session', () => {
+      const ctx = makeCtx(new Map())
+      const client = makeClient({ id: 'me', activeSessionId: 's1' })
+      assert.doesNotThrow(() =>
+        inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: 'x' }, ctx))
+    })
+  })
 })

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -1976,5 +1976,22 @@ describe('input-handlers', () => {
       assert.doesNotThrow(() =>
         inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: 'x' }, ctx))
     })
+
+    it('rejects a NON-viewer (not active, not subscribed) — no write, no primary claim', () => {
+      const { ctx, writes } = makeTuiCtx()
+      // Knows the id but isn't watching the session (activeSessionId is elsewhere).
+      const stranger = makeClient({ id: 'stranger', activeSessionId: 'other' })
+      inputHandlers.terminal_input(makeWs(), stranger, { sessionId: 's1', data: 'x' }, ctx)
+      assert.equal(writes.length, 0, 'no bytes written for a non-viewer')
+      assert.equal(ctx.transport.getPrimary('s1'), undefined, 'non-viewer must not claim primary')
+    })
+
+    it('a subscribed (non-active) viewer may drive', () => {
+      const { ctx, writes } = makeTuiCtx()
+      const client = makeClient({ id: 'me', activeSessionId: 'other', subscribedSessionIds: new Set(['s1']) })
+      inputHandlers.terminal_input(makeWs(), client, { sessionId: 's1', data: 'k' }, ctx)
+      assert.deepEqual(writes, ['k'])
+      assert.equal(ctx.transport.getPrimary('s1'), 'me')
+    })
   })
 })


### PR DESCRIPTION
## What

Phase 3 (server half) of the TUI live remote-viewer epic (#5835) — **true remote control**. The read-only mirror (Phases 1–2) becomes interactive: a new `terminal_input` message writes raw client keystrokes (including control bytes like `\x03` and escape sequences) to the session's live claude-tui PTY. This is the DWService-style "remote keyboard" — the operator drives the actual TUI, including its own native permission prompts.

Server-only, following the established server→UI split; the dashboard PR (make the xterm mirror interactive: `onData` → `terminal_input`, gated on drive authority) follows.

## Security — the load-bearing part

Authority **mirrors the existing `input` handler** and follows the [`bearer-token-authority.md` §9](docs/security/bearer-token-authority.md) checklist for a new session-scoped, session-mutating message:

- **Token classes**: primary + pairing-bound (same as `input`). A keystroke is "driving the session", squarely within both the primary token's full-session authority and a bound token's "chat into its own session" scope.
- **Session binding**: `resolveSession` enforces `boundSessionId`; a bound token aiming at another session gets the canonical `SESSION_TOKEN_MISMATCH` envelope (same disambiguation as `input`/`interrupt`).
- **Single-driver gate** via `claimPrimary` (**non-force**): the first keystroke claims an *unclaimed* session, a keystroke from the current primary is a no-op claim, and **an observer's keystroke is rejected with `input_conflict`**. Deliberately **stricter** than a chat send (which force-adopts an *idle* session) — a stray keystroke must not silently steal a live TUI from its driver. Taking over remains the explicit `claim_primary` hand-off; observers ride along on the read-only mirror.
- **Provider scope**: only claude-tui sessions expose `writeTerminalInput` (duck-typed); other providers have no PTY, so the keystroke is dropped.
- No permission-engine bypass concern: the claude TUI's *own* interactive prompts govern, and the human at the keyboard is the authority — exactly the "primary token = local access" model.

## How

- **`ClaudeTuiSession.writeTerminalInput(data)`** — writes bytes **verbatim** to the PTY: no prompt throttle (interactive keys are naturally paced over the wire; the `#4269` throttle is only for bulk programmatic prompts) and no transform (faithful remote keyboard). No-op (returns `false`) when there's no live PTY / after exit / during teardown; swallows a write throw.
- **`handleTerminalInput`** (in `input-handlers.js`, reusing this file's gate primitives: `resolveSession`, `buildSessionTokenMismatchPayload`, `buildInputConflictError`) — registered in `inputHandlers`.
- **protocol** — `TerminalInputSchema` (`sessionId` + `data`, 100k cap) in the client union; documented in `ws-server.js`. Schema-coverage test auto-enforces the handler↔schema pairing.

## Tests

- `claude-tui-mirror.test.js` — `writeTerminalInput`: verbatim writes incl. `\x03` / arrow-escape, no-op without a live PTY / after exit / during teardown, empty + non-string ignored, swallowed `_term.write` throw.
- `input-handlers.test.js` — `terminal_input` gate: claims unclaimed + writes; already-primary writes; **observer → `input_conflict`, no write, no force-steal**; bound mismatch → `SESSION_TOKEN_MISMATCH`; non-tui session no-op; empty data does not claim primary; missing session no-op.

Server suite green for the touched files (mirror, input-handlers, ws-message-handlers, claude-tui-session, handler/schema coverage); protocol 289; custom server lints + eslint clean.

Part of #5835 (Phase 3). The dashboard interactive PR and the mobile WebView render follow.