### PR TITLE
feat(dashboard): make the claude-tui mirror interactive (#5835 Phase 3, dashboard)

### DIFF
--- a/packages/dashboard/src/components/MultiTerminalView.test.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.test.tsx
@@ -9,19 +9,23 @@ import { render, screen, cleanup, act } from '@testing-library/react'
 import { MultiTerminalView, type MultiTerminalViewProps } from './MultiTerminalView'
 import type { SessionInfo } from '../store/types'
 
-// #5835 Phase 2: capture each rendered TerminalView's onMeasure so tests can
-// drive a pane measurement, and the fixedSize it received.
+// #5835 Phase 2/3: capture each rendered TerminalView's onMeasure/onInput so tests
+// can drive a measurement / keystroke, plus the fixedSize + interactive it received.
 const capturedOnMeasure: Array<(cols: number, rows: number) => void> = []
+const capturedOnInput: Array<((data: string) => void) | undefined> = []
 const capturedFixedSize: Array<{ cols: number; rows: number } | undefined> = []
+const capturedInteractive: Array<boolean | undefined> = []
 
 // Mock TerminalView — we don't want real xterm.js in unit tests
 vi.mock('./TerminalView', () => ({
-  TerminalView: ({ className, initialData, onReady, fixedSize, onMeasure }: {
+  TerminalView: ({ className, initialData, onReady, fixedSize, onMeasure, interactive, onInput }: {
     className?: string
     initialData?: string
     onReady?: (handle: { write: (d: string) => void; clear: () => void; fit: () => void }) => void
     fixedSize?: { cols: number; rows: number }
     onMeasure?: (cols: number, rows: number) => void
+    interactive?: boolean
+    onInput?: (data: string) => void
   }) => {
     // Auto-fire onReady on mount (simulates terminal initialization)
     if (onReady) {
@@ -32,13 +36,16 @@ vi.mock('./TerminalView', () => ({
       }), 0)
     }
     if (onMeasure) capturedOnMeasure.push(onMeasure)
+    capturedOnInput.push(onInput)
     capturedFixedSize.push(fixedSize)
+    capturedInteractive.push(interactive)
     return (
       <div
         data-testid="mock-terminal"
         data-classname={className}
         data-initial-data={initialData || ''}
         data-fixed-size={fixedSize ? `${fixedSize.cols}x${fixedSize.rows}` : ''}
+        data-interactive={interactive ? '1' : '0'}
       />
     )
   },
@@ -47,6 +54,7 @@ vi.mock('./TerminalView', () => ({
 // Mock store
 const mockSetTerminalWriteCallback = vi.fn()
 const mockRequestTerminalResize = vi.fn()
+const mockSendTerminalInput = vi.fn()
 const mockGetState = vi.fn()
 
 let mockStoreState: Record<string, unknown> = {}
@@ -57,6 +65,7 @@ vi.mock('../store/connection', () => ({
       const state = {
         setTerminalWriteCallback: mockSetTerminalWriteCallback,
         requestTerminalResize: mockRequestTerminalResize,
+        sendTerminalInput: mockSendTerminalInput,
         sessionStates: mockStoreState.sessionStates ?? {},
         terminalRawBuffer: mockStoreState.terminalRawBuffer ?? '',
       }
@@ -72,7 +81,9 @@ afterEach(() => {
   cleanup()
   vi.clearAllMocks()
   capturedOnMeasure.length = 0
+  capturedOnInput.length = 0
   capturedFixedSize.length = 0
+  capturedInteractive.length = 0
 })
 
 function makeSessions(count: number): SessionInfo[] {
@@ -297,6 +308,61 @@ describe('MultiTerminalView', () => {
       mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: { s1: { sessionRole: 'primary' } } })
       capturedOnMeasure[0]!(200, 50)
       expect(mockRequestTerminalResize).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // #5835 Phase 3: interactive remote control — role-gated input.
+  describe('interactive input (#5835 Phase 3)', () => {
+    it('marks a non-observer session interactive and an observer session read-only', () => {
+      mockStoreState = {
+        sessionStates: {
+          s1: { terminalRawBuffer: 'd', sessionRole: 'primary' },
+          s2: { terminalRawBuffer: 'd', sessionRole: 'observer' },
+        },
+        terminalRawBuffer: 'd',
+      }
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal()
+      const terminals = screen.getAllByTestId('mock-terminal')
+      expect(terminals[0]!.dataset.interactive).toBe('1') // primary → interactive
+      expect(terminals[1]!.dataset.interactive).toBe('0') // observer → read-only
+    })
+
+    it('treats an unclaimed (null role) session as interactive', () => {
+      mockStoreState = { sessionStates: { s1: { terminalRawBuffer: 'd' } }, terminalRawBuffer: 'd' }
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal({ sessions: makeSessions(1) })
+      const terminals = screen.getAllByTestId('mock-terminal')
+      expect(terminals[0]!.dataset.interactive).toBe('1')
+    })
+
+    it('forwards a keystroke from the ACTIVE session to sendTerminalInput', () => {
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal({ activeSessionId: 's1' })
+      // capturedOnInput[0] belongs to s1 (first rendered session)
+      capturedOnInput[0]!('\x03')
+      expect(mockSendTerminalInput).toHaveBeenCalledWith('s1', '\x03')
+    })
+
+    it('ignores a keystroke from a NON-active session', () => {
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal({ activeSessionId: 's1' })
+      capturedOnInput[1]!('x') // s2 (hidden)
+      expect(mockSendTerminalInput).not.toHaveBeenCalled()
+    })
+
+    it('shows the read-only badge when the active session is an observer', () => {
+      mockStoreState = { sessionStates: { s1: { terminalRawBuffer: 'd', sessionRole: 'observer' } }, terminalRawBuffer: 'd' }
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal({ activeSessionId: 's1', sessions: makeSessions(1) })
+      expect(screen.getByTestId('terminal-readonly-badge')).toBeTruthy()
+    })
+
+    it('hides the read-only badge when the active session can drive', () => {
+      mockStoreState = { sessionStates: { s1: { terminalRawBuffer: 'd', sessionRole: 'primary' } }, terminalRawBuffer: 'd' }
+      mockGetState.mockReturnValue({ activeSessionId: 's1', sessionStates: mockStoreState.sessionStates })
+      renderMultiTerminal({ activeSessionId: 's1', sessions: makeSessions(1) })
+      expect(screen.queryByTestId('terminal-readonly-badge')).toBeNull()
     })
   })
 })

--- a/packages/dashboard/src/components/MultiTerminalView.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.tsx
@@ -120,6 +120,11 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
     }
   }, [sessions])
 
+  // #5835 Phase 3: the active session is read-only iff this client observes it
+  // (another device holds primary) — same predicate as each pane's `interactive`,
+  // named once for the badge.
+  const activeIsObserver = !!activeSessionId && sessionStates[activeSessionId]?.sessionRole === 'observer'
+
   return (
     <div className={className} data-testid="multi-terminal-container" style={{ position: 'relative' }}>
       {sessions.map(session => (
@@ -147,7 +152,7 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
           />
         </div>
       ))}
-      {activeSessionId && sessionStates[activeSessionId]?.sessionRole === 'observer' && (
+      {activeIsObserver && (
         <div className="terminal-readonly-badge" data-testid="terminal-readonly-badge">
           Read-only — another device is driving this session
         </div>

--- a/packages/dashboard/src/components/MultiTerminalView.tsx
+++ b/packages/dashboard/src/components/MultiTerminalView.tsx
@@ -34,6 +34,7 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
   const handlesRef = useRef(new Map<string, TerminalHandle>())
   const setTerminalWriteCallback = useConnectionStore(s => s.setTerminalWriteCallback)
   const requestTerminalResize = useConnectionStore(s => s.requestTerminalResize)
+  const sendTerminalInput = useConnectionStore(s => s.sendTerminalInput)
   // #5835 Phase 2: per-session authoritative sizes (server terminal_size). Reads
   // the whole map so a size change re-renders and the new fixedSize flows to the
   // affected TerminalView (which resizes its xterm in place).
@@ -65,6 +66,16 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
     lastSentRef.current.set(sessionId, key)
     requestTerminalResize(sessionId, cols, rows)
   }, [requestTerminalResize])
+
+  // #5835 Phase 3: forward a keystroke from a terminal to the server. Only the
+  // ACTIVE (visible, focusable) session can emit onData, but guard on live
+  // activeSessionId anyway. Role gating happens upstream (TerminalView's
+  // `interactive` disables stdin for an observer, so onData never fires), and the
+  // server is the final authority — this is the thin forwarding seam.
+  const handleInput = useCallback((sessionId: string, data: string) => {
+    if (useConnectionStore.getState().activeSessionId !== sessionId) return
+    sendTerminalInput(sessionId, data)
+  }, [sendTerminalInput])
 
   // Get initial data for a session from the store (one-time, at mount)
   const getInitialData = useCallback((sessionId: string) => {
@@ -127,9 +138,20 @@ export function MultiTerminalView({ sessions, activeSessionId, className }: Mult
             onReady={(handle) => handleReady(session.sessionId, handle)}
             fixedSize={sessionStates[session.sessionId]?.terminalSize ?? MIRROR_DEFAULT}
             onMeasure={(cols, rows) => handleMeasure(session.sessionId, cols, rows)}
+            // #5835 Phase 3: interactive (keystrokes → PTY) unless this client is
+            // an OBSERVER of the session — another device holds primary. The
+            // server is the final authority; this keeps an observer's keys from
+            // spamming input_conflict and reflects read-only in the cursor/focus.
+            interactive={sessionStates[session.sessionId]?.sessionRole !== 'observer'}
+            onInput={(data) => handleInput(session.sessionId, data)}
           />
         </div>
       ))}
+      {activeSessionId && sessionStates[activeSessionId]?.sessionRole === 'observer' && (
+        <div className="terminal-readonly-badge" data-testid="terminal-readonly-badge">
+          Read-only — another device is driving this session
+        </div>
+      )}
       {!activeBuffer && (
         <div className="terminal-empty-state" data-testid="terminal-empty-state">
           <p>No terminal output yet.</p>

--- a/packages/dashboard/src/components/TerminalView.test.tsx
+++ b/packages/dashboard/src/components/TerminalView.test.tsx
@@ -17,6 +17,10 @@ const resizeSpy = vi.fn()
 // #5835 Phase 2: mirror mode measures the pane via FitAddon.proposeDimensions().
 // Tests can override this to simulate different pane sizes.
 let proposeDimensionsResult: { cols: number; rows: number } | undefined = { cols: 200, rows: 50 }
+// #5835 Phase 3: capture the most-recently-constructed terminal's onData callback
+// so tests can simulate a keystroke, and the live `options` (for disableStdin).
+let lastOnData: ((data: string) => void) | null = null
+let lastTermOptions: Record<string, unknown> | null = null
 
 // Mock xterm.js since jsdom can't render canvas
 vi.mock('@xterm/xterm', () => {
@@ -29,6 +33,7 @@ vi.mock('@xterm/xterm', () => {
 
     constructor(opts?: Record<string, unknown>) {
       this.options = opts || {}
+      lastTermOptions = this.options
     }
     open(el: HTMLElement) { this._element = el }
     write(data: string) { writeSpy(data); this._written.push(data) }
@@ -36,7 +41,7 @@ vi.mock('@xterm/xterm', () => {
     reset() { this._written = []; this._element = null }
     dispose() { disposeSpy(); this._disposed = true }
     loadAddon(addon: unknown) { this._addons.push(addon) }
-    onData(_cb: (data: string) => void) { return { dispose: () => {} } }
+    onData(cb: (data: string) => void) { lastOnData = cb; return { dispose: () => {} } }
     resize(cols: number, rows: number) { resizeSpy(cols, rows) }
   }
   return { Terminal: MockTerminal }
@@ -61,6 +66,8 @@ describe('TerminalView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     proposeDimensionsResult = { cols: 200, rows: 50 }
+    lastOnData = null
+    lastTermOptions = null
   })
 
   it('renders a container div', () => {
@@ -254,6 +261,48 @@ describe('TerminalView', () => {
       const { rerender } = render(<TerminalView />)
       rerender(<TerminalView />)
       expect(resizeSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // #5835 Phase 3: interactive remote control — keystrokes → onInput, role-driven
+  // disableStdin toggle.
+  describe('interactive mode (#5835 Phase 3)', () => {
+    it('forwards keystrokes via onInput when interactive', () => {
+      const onInput = vi.fn()
+      render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} interactive onInput={onInput} />)
+      expect(lastOnData).toBeTypeOf('function')
+      lastOnData!('\x03') // Ctrl-C
+      lastOnData!('ls\r')
+      expect(onInput).toHaveBeenNthCalledWith(1, '\x03')
+      expect(onInput).toHaveBeenNthCalledWith(2, 'ls\r')
+    })
+
+    it('enables stdin when interactive, disables it when not (mirror mode)', () => {
+      const { rerender } = render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} interactive />)
+      expect(lastTermOptions!.disableStdin).toBe(false)
+      rerender(<TerminalView fixedSize={{ cols: 120, rows: 30 }} interactive={false} />)
+      expect(lastTermOptions!.disableStdin).toBe(true)
+      // …and back, without remount (role flip primary↔observer)
+      rerender(<TerminalView fixedSize={{ cols: 120, rows: 30 }} interactive />)
+      expect(lastTermOptions!.disableStdin).toBe(false)
+    })
+
+    it('normal (non-mirror) mode is never interactive and wires no input path', () => {
+      const onInput = vi.fn()
+      render(<TerminalView interactive onInput={onInput} />)
+      // No fixedSize → not a mirror → no onData wiring, stdin stays disabled.
+      expect(lastOnData).toBeNull()
+      expect(lastTermOptions!.disableStdin).toBe(true)
+    })
+
+    it('uses the latest onInput across re-renders (ref-backed, mount-once safe)', () => {
+      const first = vi.fn()
+      const second = vi.fn()
+      const { rerender } = render(<TerminalView fixedSize={{ cols: 120, rows: 30 }} interactive onInput={first} />)
+      rerender(<TerminalView fixedSize={{ cols: 120, rows: 30 }} interactive onInput={second} />)
+      lastOnData!('k')
+      expect(first).not.toHaveBeenCalled()
+      expect(second).toHaveBeenCalledWith('k')
     })
   })
 })

--- a/packages/dashboard/src/components/TerminalView.tsx
+++ b/packages/dashboard/src/components/TerminalView.tsx
@@ -41,6 +41,20 @@ export interface TerminalViewProps {
    * comes back via `fixedSize`. No-op in normal fit-to-pane mode.
    */
   onMeasure?: (cols: number, rows: number) => void
+  /**
+   * #5835 Phase 3: when true (mirror mode only), the terminal accepts keystrokes
+   * and forwards them via `onInput` — true remote control. When false the mirror
+   * stays read-only (an observer, or a non-claude-tui pane). Toggled at runtime
+   * (xterm `disableStdin`) so a role change (primary↔observer) flips interactivity
+   * without remounting / losing scrollback.
+   */
+  interactive?: boolean
+  /**
+   * #5835 Phase 3: called with raw terminal bytes for each keystroke (xterm
+   * `onData`) when interactive. The parent forwards them to the server as
+   * `terminal_input`. Only fires in mirror mode while interactive.
+   */
+  onInput?: (data: string) => void
 }
 
 export const BATCH_INTERVAL = 50 // ms — coalesce rapid writes
@@ -51,18 +65,20 @@ function safeFit(fit: FitAddon) {
   try { fit.fit() } catch { /* container not visible */ }
 }
 
-export function TerminalView({ className, initialData, onReady, fixedSize, onMeasure }: TerminalViewProps) {
+export function TerminalView({ className, initialData, onReady, fixedSize, onMeasure, interactive = false, onInput }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
   const batchRef = useRef<string[]>([])
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const disposedRef = useRef(false)
-  // #5835 Phase 2: keep the latest onMeasure callback in a ref so the mount-once
-  // effect's resize/measure handler always calls the current one (the parent
-  // recreates the closure each render, but the terminal lifecycle is mount-once).
+  // #5835 Phase 2/3: keep the latest onMeasure/onInput callbacks in refs so the
+  // mount-once effect's handlers always call the current ones (the parent recreates
+  // the closures each render, but the terminal lifecycle is mount-once).
   const onMeasureRef = useRef(onMeasure)
   onMeasureRef.current = onMeasure
+  const onInputRef = useRef(onInput)
+  onInputRef.current = onInput
   // Whether this terminal is a fixed-size letterboxed mirror. Mode is fixed at
   // MOUNT — the xterm is constructed with mode-specific options (convertEol,
   // initial cols/rows) and the mount-once onResize handler closes over this — so
@@ -150,6 +166,14 @@ export function TerminalView({ className, initialData, onReady, fixedSize, onMea
     // the local `fitAddon` directly, so it still works in mirror mode.
     fitRef.current = fixedSize ? null : fitAddon
 
+    // #5835 Phase 3: forward keystrokes (true remote control). onData fires only
+    // when stdin is enabled (the interactive effect below toggles disableStdin),
+    // so an observer / non-interactive mirror never reaches here. Mirror mode only;
+    // the normal read-only output pane has no input path.
+    if (fixedSize) {
+      term.onData((data) => onInputRef.current?.(data))
+    }
+
     // Write initial data if provided
     if (initialData) {
       term.write(initialData)
@@ -226,6 +250,16 @@ export function TerminalView({ className, initialData, onReady, fixedSize, onMea
       termRef.current.resize(fixedSize.cols, fixedSize.rows)
     } catch { /* terminal not ready / disposed */ }
   }, [fixedSize?.cols, fixedSize?.rows]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // #5835 Phase 3: toggle interactivity at runtime so a role change (primary↔
+  // observer) flips the mirror between remote-control and read-only WITHOUT
+  // remounting (which would lose scrollback). Only mirror mode (fixedSize) can be
+  // interactive; the normal output pane and any non-interactive mirror stay
+  // read-only (disableStdin = true).
+  useEffect(() => {
+    if (disposedRef.current || !termRef.current) return
+    termRef.current.options.disableStdin = !(fixedSize && interactive)
+  }, [fixedSize, interactive]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div

--- a/packages/dashboard/src/components/TerminalView.tsx
+++ b/packages/dashboard/src/components/TerminalView.tsx
@@ -259,7 +259,10 @@ export function TerminalView({ className, initialData, onReady, fixedSize, onMea
   useEffect(() => {
     if (disposedRef.current || !termRef.current) return
     termRef.current.options.disableStdin = !(fixedSize && interactive)
-  }, [fixedSize, interactive]) // eslint-disable-line react-hooks/exhaustive-deps
+    // Depend on the primitive cols/rows (mode is mount-fixed, so fixedSize
+    // presence never changes) + interactive — consistent with the resize effect
+    // above and avoids re-running on an unrelated new {cols,rows} object.
+  }, [fixedSize?.cols, fixedSize?.rows, interactive]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -675,10 +675,32 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // the primary owner / sole viewer drives; an observer's keystroke is rejected
   // with input_conflict). The dashboard also gates locally on role, so an
   // observer's keys never reach here, avoiding per-keystroke input_conflict toasts.
+  //
+  // Chunk large payloads (Copilot review): a single keystroke is a few bytes, but
+  // a bracketed paste fires one onData with the whole clipboard, which can exceed
+  // TerminalInputSchema's 100k cap — the server would reject that frame and drop
+  // the paste. Split into sub-cap frames (the PTY is an ordered byte stream, so
+  // splitting is transparent), and never split a UTF-16 surrogate pair across a
+  // boundary so an emoji at the seam can't corrupt into lone surrogates.
   sendTerminalInput: (sessionId: string, data: string) => {
     const { socket } = get();
-    if (sessionId && data && socket && socket.readyState === WebSocket.OPEN) {
+    if (!sessionId || !data || !socket || socket.readyState !== WebSocket.OPEN) return;
+    const MAX = 65536; // comfortably under TerminalInputSchema.data.max(100000)
+    if (data.length <= MAX) {
       wsSend(socket, { type: 'terminal_input', sessionId, data });
+      return;
+    }
+    let i = 0;
+    while (i < data.length) {
+      let end = Math.min(i + MAX, data.length);
+      // If the boundary lands on a high surrogate, defer it to the next chunk so a
+      // surrogate pair is never split (which would write lone surrogates to the PTY).
+      if (end < data.length) {
+        const code = data.charCodeAt(end - 1);
+        if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+      }
+      wsSend(socket, { type: 'terminal_input', sessionId, data: data.slice(i, end) });
+      i = end;
     }
   },
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -670,6 +670,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #5835 Phase 3: forward raw keystrokes to a session's live PTY (true remote
+  // control). Best-effort — the server enforces the single-driver authority (only
+  // the primary owner / sole viewer drives; an observer's keystroke is rejected
+  // with input_conflict). The dashboard also gates locally on role, so an
+  // observer's keys never reach here, avoiding per-keystroke input_conflict toasts.
+  sendTerminalInput: (sessionId: string, data: string) => {
+    const { socket } = get();
+    if (sessionId && data && socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'terminal_input', sessionId, data });
+    }
+  },
+
   // Web tasks (Claude Code Web)
   webFeatures: { available: false, remote: false, teleport: false },
   webTasks: [],

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -705,6 +705,19 @@ describe('useConnectionStore', () => {
     expect(sent).toHaveLength(0);
     useConnectionStore.setState({ socket: null });
   });
+
+  it('sendTerminalInput sends terminal_input over an open socket; empty data is a no-op', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const sent: string[] = [];
+    const mockSocket = { send: (d: string) => sent.push(d), readyState: 1 } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: mockSocket });
+    useConnectionStore.getState().sendTerminalInput('sess-1', '\x03');
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0]!)).toMatchObject({ type: 'terminal_input', sessionId: 'sess-1', data: '\x03' });
+    useConnectionStore.getState().sendTerminalInput('sess-1', '');
+    expect(sent).toHaveLength(1);
+    useConnectionStore.setState({ socket: null });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -718,6 +718,34 @@ describe('useConnectionStore', () => {
     expect(sent).toHaveLength(1);
     useConnectionStore.setState({ socket: null });
   });
+
+  it('sendTerminalInput chunks a large paste into sub-cap frames without splitting surrogate pairs', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const sent: string[] = [];
+    const mockSocket = { send: (d: string) => sent.push(d), readyState: 1 } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: mockSocket });
+
+    const MAX = 65536;
+    // 150k chars → 3 frames; put an emoji (surrogate pair) exactly straddling the
+    // first 64k boundary so the surrogate-safe split is exercised.
+    const big = 'a'.repeat(MAX - 1) + '😀' + 'b'.repeat(90000);
+    useConnectionStore.getState().sendTerminalInput('sess-1', big);
+
+    expect(sent.length).toBeGreaterThan(1);
+    let reassembled = '';
+    for (const raw of sent) {
+      const m = JSON.parse(raw);
+      expect(m.type).toBe('terminal_input');
+      expect(m.sessionId).toBe('sess-1');
+      expect(m.data.length).toBeLessThanOrEqual(MAX);
+      // No chunk ends on a lone high surrogate (would mean a split pair).
+      const last = m.data.charCodeAt(m.data.length - 1);
+      expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+      reassembled += m.data;
+    }
+    expect(reassembled).toBe(big); // lossless
+    useConnectionStore.setState({ socket: null });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -970,6 +970,9 @@ export interface ConnectionState {
   // live PTY (terminal_resize) when the viewer pane can fit a different grid.
   setTerminalSize: (sessionId: string, cols: number, rows: number) => void;
   requestTerminalResize: (sessionId: string, cols: number, rows: number) => void;
+  // #5835 Phase 3: forward raw keystrokes to a session's live PTY (true remote
+  // control). Best-effort; the server enforces the single-driver authority.
+  sendTerminalInput: (sessionId: string, data: string) => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   sendInput: (input: string, wireAttachments?: { type: string; name: string; [key: string]: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
   /**

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5692,6 +5692,22 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.6;
 }
 
+/* #5835 Phase 3: read-only badge shown over the mirror when this client is an
+   observer (another device holds primary) — keystrokes won't reach the PTY. */
+.terminal-readonly-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  pointer-events: none;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm, 4px);
+  background: rgba(0, 0, 0, 0.6);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.12));
+}
+
 /* ---- Command Palette ---- */
 .command-palette {
   position: fixed;


### PR DESCRIPTION
## What

Completes **Phase 3** of the TUI live remote-viewer epic (#5835), the **dashboard half** (server half merged in #5842). The live mirror becomes a true remote keyboard for the session's driver: keystrokes typed into the Output xterm forward to the real claude-tui PTY (`terminal_input`). An observer (another device holds primary) stays read-only.

The round-trip is now end-to-end — you can drive the actual claude TUI from the dashboard (answer its native prompts, Ctrl-C, arrow-key menus), latency-tolerant, with the parsed Chat view still available as the readable lens.

## How

- **`TerminalView`** — new `interactive` + `onInput` props. In mirror mode it wires xterm `onData` → `onInput` (ref-backed so the mount-once lifecycle always calls the current callback) and **toggles `disableStdin` at runtime** from `interactive`, so a role flip (primary↔observer) switches between remote-control and read-only **without remounting** (scrollback preserved). The normal (non-mirror) output pane stays read-only with no input path.
- **store** — `sendTerminalInput(sessionId, data)`: best-effort `terminal_input` send (the server is the single-driver authority).
- **`MultiTerminalView`** — `interactive = (sessionRole !== 'observer')` per session (an unclaimed/`null` role counts as drivable — the first keystroke claims primary server-side); `onInput` forwards the **active** session's keystrokes to `sendTerminalInput`. The local role gate keeps an observer's keys from spamming `input_conflict`. A **read-only badge** overlays the mirror when the active session is an observer.

## Safety / fidelity

- **Authority is server-enforced** (#5842): the dashboard only *requests*; the server's bound-session + single-driver `claimPrimary` gate decides. The client-side role gate is just UX (avoids per-keystroke `input_conflict` toasts) and reflects read-only in the cursor/focus + badge.
- **Letterbox fidelity preserved** — interactivity is a `disableStdin` toggle; the mirror still renders at the authoritative grid. No FitAddon stretch.
- Taking over a session another device drives remains the explicit `claim_primary` hand-off (existing ViewersIndicator UI).

## Tests

- `TerminalView.test.tsx` — `onInput` forwards keystrokes (incl. `\x03`); `disableStdin` toggles with `interactive` including flip-back without remount; normal mode wires no input path + stays read-only; latest `onInput` used across re-renders.
- `MultiTerminalView.test.tsx` — `interactive` per role (primary/unclaimed → on, observer → off); keystroke forwarded only for the active session; read-only badge shown for observer / hidden when drivable.
- `store.test.ts` — `sendTerminalInput` over an open socket; empty-data no-op.

Dashboard tsc clean; dashboard suite 3752 pass; protocol 289 pass.

Closes the Phase 3 work for #5835. Deferred on the epic: mobile WebView interactivity and #5837 (mirror coalescer subscriber-gating).