### PR TITLE
perf(server): gate the claude-tui mirror coalescer on having a subscriber (#5837)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -384,6 +384,14 @@ export class ClaudeTuiSession extends BaseSession {
     // on flush and cleared on teardown.
     this._mirrorBuffer = ''
     this._mirrorTimer = null
+    // #5837: gate the coalescer on having ≥1 subscriber. The mirror is OFF until a
+    // client opts in (terminal_subscribe), so a claude-tui session nobody is
+    // watching pays nothing per PTY redraw (no string concat, no timer, no
+    // session_event). WsServer toggles this via setTerminalMirrorActive when the
+    // terminal-subscriber count for the session crosses 0↔1 (subscribe / unsubscribe
+    // / client departure). Forward-only: a subscriber sees redraws from when it
+    // subscribed onward — same as Phase 1, the mirror was never a snapshot.
+    this._terminalMirrorActive = false
     // #5835 Phase 2: the live PTY's current grid size. Spawns at the shared
     // default and tracks every applied resize so a respawn re-spawns at the
     // operator's chosen size (not back to the default), and so a newly-
@@ -1754,11 +1762,30 @@ export class ClaudeTuiSession extends BaseSession {
    * stripped or transformed: faithful reproduction is the whole point.
    */
   _feedTerminalMirror(data) {
+    // #5837: skip ALL coalescer work when nobody is subscribed to this session's
+    // mirror. This is the common case (the Output tab is closed), and onData fires
+    // very frequently — gating here saves the per-redraw string concat + timer +
+    // session_event for the whole life of an unwatched session.
+    if (!this._terminalMirrorActive) return
     this._mirrorBuffer += String(data)
     if (this._mirrorTimer) return
     this._mirrorTimer = setTimeout(() => this._flushTerminalMirror(), ClaudeTuiSession.MIRROR_FLUSH_MS)
     // Don't keep the event loop alive for a mirror flush — teardown clears it.
     if (typeof this._mirrorTimer.unref === 'function') this._mirrorTimer.unref()
+  }
+
+  /**
+   * #5837: turn the live mirror coalescer on/off based on whether any client is
+   * subscribed to this session's terminal. WsServer calls this when the
+   * terminal-subscriber count crosses 0↔1. When turning OFF, drop any pending
+   * buffer/timer (nobody is watching, so a trailing flush is pure waste) — this
+   * reuses the same teardown as _clearTerminalMirror.
+   */
+  setTerminalMirrorActive(active) {
+    const next = !!active
+    if (next === this._terminalMirrorActive) return
+    this._terminalMirrorActive = next
+    if (!next) this._clearTerminalMirror()
   }
 
   /**

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -358,6 +358,8 @@ function handleTerminalSubscribe(ws, client, msg, ctx) {
   if (!entry) return
   if (!client.terminalSessionIds) client.terminalSessionIds = new Set()
   client.terminalSessionIds.add(sid)
+  // #5837: this may be the FIRST subscriber — turn the coalescer on.
+  ctx.transport.syncTerminalMirror?.(sid)
   // #5835 Phase 2: tell the new subscriber the authoritative PTY size up front so
   // it can letterbox to the right grid immediately (the size may already differ
   // from the default if another viewer resized it). Gate on the same viewing
@@ -397,8 +399,11 @@ function handleTerminalResize(ws, client, msg, ctx) {
 
 // #5835 Phase 1: opt the client OUT of a session's live PTY mirror (e.g. the
 // dashboard leaving the Output tab). Idempotent.
-function handleTerminalUnsubscribe(ws, client, msg) {
-  if (client.terminalSessionIds) client.terminalSessionIds.delete(msg.sessionId)
+function handleTerminalUnsubscribe(ws, client, msg, ctx) {
+  if (!client.terminalSessionIds) return
+  if (!client.terminalSessionIds.delete(msg.sessionId)) return
+  // #5837: this may have been the LAST subscriber — turn the coalescer off if so.
+  ctx?.transport?.syncTerminalMirror?.(msg.sessionId)
 }
 
 // #3404: mobile app sends this when foreground/background state changes so

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -357,9 +357,12 @@ function handleTerminalSubscribe(ws, client, msg, ctx) {
   const entry = ctx?.sessions?.sessionManager?.getSession?.(sid)
   if (!entry) return
   if (!client.terminalSessionIds) client.terminalSessionIds = new Set()
+  const alreadySubscribed = client.terminalSessionIds.has(sid)
   client.terminalSessionIds.add(sid)
-  // #5837: this may be the FIRST subscriber — turn the coalescer on.
-  ctx.transport.syncTerminalMirror?.(sid)
+  // #5837: re-evaluate the coalescer gate only on an ACTUAL new subscription
+  // (symmetric with terminal_unsubscribe, which syncs only when it removed one) —
+  // a re-subscribe is a no-op for the gate. This may be the first viewer → ON.
+  if (!alreadySubscribed) ctx?.transport?.syncTerminalMirror?.(sid)
   // #5835 Phase 2: tell the new subscriber the authoritative PTY size up front so
   // it can letterbox to the right grid immediately (the size may already differ
   // from the default if another viewer resized it). Gate on the same viewing

--- a/packages/server/src/ws-handler-context.js
+++ b/packages/server/src/ws-handler-context.js
@@ -32,6 +32,7 @@
  * @property {(sessionId: string) => string|undefined} getPrimary - Current primary clientId for a session, or undefined (#5563).
  * @property {(sessionId: string, clientId: string) => boolean} isPrimary - True iff clientId is the session's primary (#5563).
  * @property {(sessionId: string) => void} clearPrimary - Vacate a session's primary slot, announcing the vacancy (#5563).
+ * @property {(sessionId: string) => void} syncTerminalMirror - Re-evaluate the terminal-mirror coalescer gate for a session after its subscriber set changes (#5837).
  * @property {(ws: any, sessionId: string) => void} sendSessionInfo - Send a session_info envelope.
  * @property {(ws: any, sessionId: string) => void} replayHistory - Replay a session's history to a client.
  * @property {Map} clients - WebSocket → client-state Map (the WsClientManager's Map).
@@ -103,6 +104,7 @@ export const CTX_NAMESPACES = {
     'getPrimary',
     'isPrimary',
     'clearPrimary',
+    'syncTerminalMirror',
     'sendSessionInfo',
     'replayHistory',
     'clients',

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -2192,7 +2192,16 @@ export class WsServer {
     if (typeof entry?.session?.setTerminalMirrorActive !== 'function') return
     let active = false
     for (const client of this.clients.values()) {
-      if (client.terminalSessionIds && client.terminalSessionIds.has(sessionId)) {
+      // Count a client only if it would actually RECEIVE terminal_output — i.e. it
+      // matches ws-forwarding's terminalSubscriberFilter: opted into the terminal
+      // (terminalSessionIds) AND a viewer of the session (active or subscribed).
+      // An opted-in-but-not-viewing client gets nothing, so it must not keep the
+      // coalescer running (#5844 review — align the gate with the delivery audience).
+      if (
+        client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
+        (client.activeSessionId === sessionId ||
+          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId)))
+      ) {
         active = true
         break
       }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -737,6 +737,10 @@ export class WsServer {
         getPrimary: (sid) => self._clientManager.getPrimary(sid),
         isPrimary: (sid, cid) => self._clientManager.isPrimary(sid, cid),
         clearPrimary: (sid) => self._clearPrimary(sid),
+        // #5837: re-evaluate the terminal-mirror coalescer gate for a session
+        // after its subscriber set changes (handlers call this on subscribe/
+        // unsubscribe; departure is handled server-side in _handleClientDeparture).
+        syncTerminalMirror: (sid) => self._syncTerminalMirror(sid),
         sendSessionInfo: (ws, sid) => self._sendSessionInfo(ws, sid),
         replayHistory: (ws, sid, opts) => self._replayHistory(ws, sid, opts),
         get clients() { return self.clients },
@@ -2096,6 +2100,16 @@ export class WsServer {
       this._announcePrimary(sessionId, null)
     }
 
+    // #5837: this client's terminal subscriptions are gone. Clear them first (the
+    // client is still in `this.clients` until removeClient runs after departure),
+    // then re-sync each watched session's mirror so the coalescer stops when this
+    // was the last viewer.
+    if (departingClient.terminalSessionIds && departingClient.terminalSessionIds.size > 0) {
+      const watched = [...departingClient.terminalSessionIds]
+      departingClient.terminalSessionIds.clear()
+      for (const sessionId of watched) this._syncTerminalMirror(sessionId)
+    }
+
     // Release this client's ownership of any push tokens it registered.
     // Uses ref-counted release so a token registered by multiple
     // concurrent connections (multi-device or reconnect-race) isn't
@@ -2163,6 +2177,27 @@ export class WsServer {
     if (!sessionId) return
     const prev = this._clientManager.clearPrimary(sessionId)
     if (prev !== undefined) this._announcePrimary(sessionId, null)
+  }
+
+  /**
+   * #5837: recompute whether ANY connected client is subscribed to a session's
+   * live terminal mirror, and toggle the session's coalescer accordingly. Called
+   * after every terminal-subscription change (subscribe / unsubscribe / client
+   * departure) so the mirror runs only while at least one viewer is watching.
+   * Only claude-tui sessions expose setTerminalMirrorActive; others have no PTY.
+   */
+  _syncTerminalMirror(sessionId) {
+    if (!sessionId) return
+    const entry = this.sessionManager.getSession?.(sessionId)
+    if (typeof entry?.session?.setTerminalMirrorActive !== 'function') return
+    let active = false
+    for (const client of this.clients.values()) {
+      if (client.terminalSessionIds && client.terminalSessionIds.has(sessionId)) {
+        active = true
+        break
+      }
+    }
+    entry.session.setTerminalMirrorActive(active)
   }
 
   /**

--- a/packages/server/tests/claude-tui-mirror.test.js
+++ b/packages/server/tests/claude-tui-mirror.test.js
@@ -29,6 +29,7 @@ test('coalesces onData chunks into one terminal_output flush per tick', () => {
   mock.timers.enable({ apis: ['setTimeout'] })
   try {
     const s = makeSession()
+    s.setTerminalMirrorActive(true) // #5837: coalescer is gated on a subscriber
     const emitted = []
     s.on('terminal_output', (e) => emitted.push(e.data))
 
@@ -53,6 +54,7 @@ test('preserves raw bytes (ANSI intact) — no stripping in the mirror path', ()
   mock.timers.enable({ apis: ['setTimeout'] })
   try {
     const s = makeSession()
+    s.setTerminalMirrorActive(true) // #5837
     const emitted = []
     s.on('terminal_output', (e) => emitted.push(e.data))
     s._feedTerminalMirror('\x1b[?1049h\x1b[31mred\x1b[0m')
@@ -67,6 +69,7 @@ test('_clearTerminalMirror cancels a pending flush and drops the buffer', () => 
   mock.timers.enable({ apis: ['setTimeout'] })
   try {
     const s = makeSession()
+    s.setTerminalMirrorActive(true) // #5837
     const emitted = []
     s.on('terminal_output', (e) => emitted.push(e.data))
     s._feedTerminalMirror('x')
@@ -84,6 +87,63 @@ test('flush with an empty buffer is a no-op (stray flush after teardown)', () =>
   s.on('terminal_output', (e) => emitted.push(e.data))
   s._flushTerminalMirror()
   assert.equal(emitted.length, 0)
+})
+
+// #5837: the coalescer is gated on having a subscriber. Default OFF.
+
+test('mirror is inactive by default — _feedTerminalMirror does no work and emits nothing', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  try {
+    const s = makeSession()
+    const emitted = []
+    s.on('terminal_output', (e) => emitted.push(e.data))
+    s._feedTerminalMirror('a')
+    s._feedTerminalMirror('b')
+    assert.equal(s._mirrorBuffer, '', 'nothing buffered while inactive')
+    assert.equal(s._mirrorTimer, null, 'no flush timer armed while inactive')
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS)
+    assert.equal(emitted.length, 0, 'no terminal_output when nobody is subscribed')
+  } finally {
+    mock.timers.reset()
+  }
+})
+
+test('setTerminalMirrorActive(true) turns the coalescer on; (false) turns it off + drops pending', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  try {
+    const s = makeSession()
+    const emitted = []
+    s.on('terminal_output', (e) => emitted.push(e.data))
+
+    s.setTerminalMirrorActive(true)
+    s._feedTerminalMirror('hi')
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS)
+    assert.deepEqual(emitted, ['hi'], 'active → coalesces + flushes')
+
+    // Going inactive drops any pending buffer/timer (no trailing flush for nobody).
+    s._feedTerminalMirror('pending')
+    s.setTerminalMirrorActive(false)
+    assert.equal(s._mirrorBuffer, '', 'pending buffer dropped on deactivate')
+    assert.equal(s._mirrorTimer, null, 'pending timer cleared on deactivate')
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS)
+    assert.deepEqual(emitted, ['hi'], 'nothing else flushes after deactivate')
+
+    // And feeding while inactive again is a no-op.
+    s._feedTerminalMirror('more')
+    mock.timers.tick(ClaudeTuiSession.MIRROR_FLUSH_MS)
+    assert.deepEqual(emitted, ['hi'])
+  } finally {
+    mock.timers.reset()
+  }
+})
+
+test('setTerminalMirrorActive is idempotent for the same value', () => {
+  const s = makeSession()
+  s.setTerminalMirrorActive(true)
+  // Re-asserting true must not clear an in-flight buffer.
+  s._feedTerminalMirror('x')
+  s.setTerminalMirrorActive(true)
+  assert.equal(s._mirrorBuffer, 'x', 'same-value activate is a no-op, buffer intact')
 })
 
 // #5835 Phase 2: resize sync. resizeTerminal clamps, records the size (so it

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -28,6 +28,7 @@ function makeCtx(overrides = {}) {
     broadcastSessionList: createSpy(),
     sendSessionInfo: createSpy(),
     replayHistory: createSpy(),
+    syncTerminalMirror: createSpy(),
     ...indexCtx,
     permissionSessionMap: new Map(),
     questionSessionMap: new Map(),
@@ -708,12 +709,14 @@ describe('session-handlers', () => {
   })
 
   describe('terminal_subscribe / terminal_unsubscribe (#5835)', () => {
-    it('terminal_subscribe adds an existing session to the client terminal set', () => {
+    it('terminal_subscribe adds an existing session to the client terminal set + syncs the mirror gate', () => {
       const ctx = makeCtx()
       ctx._sessions.set('sess-1', { session: {}, cwd: '/tmp', name: 'S1' })
       const client = makeClient()
       sessionHandlers.terminal_subscribe(makeWs(), client, { type: 'terminal_subscribe', sessionId: 'sess-1' }, ctx)
       assert.ok(client.terminalSessionIds.has('sess-1'))
+      // #5837: subscribing may be the first viewer → re-evaluate the coalescer gate.
+      assert.ok(ctx.transport.syncTerminalMirror.calls.some(c => c[0] === 'sess-1'))
     })
 
     it('terminal_subscribe to a non-existent session is a no-op (no junk-id growth)', () => {
@@ -723,14 +726,18 @@ describe('session-handlers', () => {
       assert.ok(!client.terminalSessionIds || !client.terminalSessionIds.has('ghost'))
     })
 
-    it('terminal_unsubscribe removes the session and is idempotent', () => {
+    it('terminal_unsubscribe removes the session, syncs the gate, and is idempotent', () => {
       const ctx = makeCtx()
       const client = makeClient({ terminalSessionIds: new Set(['sess-1']) })
       sessionHandlers.terminal_unsubscribe(makeWs(), client, { type: 'terminal_unsubscribe', sessionId: 'sess-1' }, ctx)
       assert.ok(!client.terminalSessionIds.has('sess-1'))
-      // idempotent — unsubscribing again does not throw
+      // #5837: removing a subscriber re-evaluates the coalescer gate (may be the last).
+      assert.equal(ctx.transport.syncTerminalMirror.callCount, 1)
+      assert.equal(ctx.transport.syncTerminalMirror.lastCall[0], 'sess-1')
+      // idempotent — unsubscribing again does not throw AND does not re-sync (nothing removed).
       sessionHandlers.terminal_unsubscribe(makeWs(), client, { type: 'terminal_unsubscribe', sessionId: 'sess-1' }, ctx)
       assert.ok(!client.terminalSessionIds.has('sess-1'))
+      assert.equal(ctx.transport.syncTerminalMirror.callCount, 1, 'no re-sync when nothing was removed')
     })
 
     it('a bound client cannot subscribe to a different session', () => {

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4742,20 +4742,34 @@ describe('#5579: production handler ctx is deep-asserted at construction', () =>
       const srv = new WsServer({ port: 0, apiToken: 't', sessionManager: manager, authRequired: false })
       return { srv, calls }
     }
+    // A viewer subscribed to the terminal: opted-in AND subscribed to the session
+    // (the terminalSubscriberFilter audience that actually receives terminal_output).
     function fakeClient(id, terminalSids = []) {
-      return { id, authenticated: true, terminalSessionIds: new Set(terminalSids), subscribedSessionIds: new Set(), _ownedPushTokens: null }
+      return { id, authenticated: true, terminalSessionIds: new Set(terminalSids), subscribedSessionIds: new Set(terminalSids), _ownedPushTokens: null }
     }
     // A ws is the clients-Map KEY; srv.close() calls ws.close()/terminate() on each.
     const fakeWs = () => ({ readyState: 3, close: () => {}, terminate: () => {} })
 
-    it('_syncTerminalMirror toggles ON iff some connected client subscribes', () => {
+    it('_syncTerminalMirror toggles ON iff a connected viewer subscribes', () => {
       const { srv, calls } = makeMirrorServer()
       try {
         srv._syncTerminalMirror('s1')
         assert.deepEqual(calls, [false], 'no subscribers → OFF')
         srv.clients.set(fakeWs(), fakeClient('c1', ['s1']))
         srv._syncTerminalMirror('s1')
-        assert.deepEqual(calls, [false, true], 'one subscriber → ON')
+        assert.deepEqual(calls, [false, true], 'one viewing subscriber → ON')
+      } finally { srv.close() }
+    })
+
+    it('_syncTerminalMirror ignores an opted-in client that is NOT viewing the session (#5844 review)', () => {
+      const { srv, calls } = makeMirrorServer()
+      try {
+        // Opted into the terminal but neither active nor subscribed → receives no
+        // bytes, so it must not keep the coalescer on.
+        const c = { id: 'c1', authenticated: true, terminalSessionIds: new Set(['s1']), subscribedSessionIds: new Set(), activeSessionId: 'other', _ownedPushTokens: null }
+        srv.clients.set(fakeWs(), c)
+        srv._syncTerminalMirror('s1')
+        assert.deepEqual(calls, [false], 'opted-in non-viewer → OFF')
       } finally { srv.close() }
     })
 

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -4726,4 +4726,60 @@ describe('#5579: production handler ctx is deep-asserted at construction', () =>
     // what closes the gap (the namespace object is still present).
     assert.doesNotThrow(() => assertCtxShape(ctx), 'shallow assert misses a missing key — that is the bug deep closes')
   })
+
+  // #5837: the terminal-mirror coalescer gate. These drive _syncTerminalMirror /
+  // _handleClientDeparture directly (no socket) to lock in the 0↔1 crossing on
+  // the disconnect path — the riskiest one (a stuck-OFF mirror = a viewer sees a
+  // dead terminal; a stuck-ON mirror = wasted work forever).
+  describe('terminal-mirror gate (#5837)', () => {
+    function makeMirrorServer() {
+      const calls = []
+      const session = { setTerminalMirrorActive: (a) => { calls.push(a) } }
+      const sessionsMap = new Map([['s1', { session, name: 'S', cwd: '/tmp', type: 'cli' }]])
+      const manager = new EventEmitter()
+      manager.getSession = (id) => sessionsMap.get(id)
+      manager.listSessions = () => []
+      const srv = new WsServer({ port: 0, apiToken: 't', sessionManager: manager, authRequired: false })
+      return { srv, calls }
+    }
+    function fakeClient(id, terminalSids = []) {
+      return { id, authenticated: true, terminalSessionIds: new Set(terminalSids), subscribedSessionIds: new Set(), _ownedPushTokens: null }
+    }
+    // A ws is the clients-Map KEY; srv.close() calls ws.close()/terminate() on each.
+    const fakeWs = () => ({ readyState: 3, close: () => {}, terminate: () => {} })
+
+    it('_syncTerminalMirror toggles ON iff some connected client subscribes', () => {
+      const { srv, calls } = makeMirrorServer()
+      try {
+        srv._syncTerminalMirror('s1')
+        assert.deepEqual(calls, [false], 'no subscribers → OFF')
+        srv.clients.set(fakeWs(), fakeClient('c1', ['s1']))
+        srv._syncTerminalMirror('s1')
+        assert.deepEqual(calls, [false, true], 'one subscriber → ON')
+      } finally { srv.close() }
+    })
+
+    it('last-viewer departure turns the mirror OFF; a remaining viewer keeps it ON', () => {
+      const { srv, calls } = makeMirrorServer()
+      try {
+        const wsA = fakeWs()
+        const wsB = fakeWs()
+        const a = fakeClient('a', ['s1'])
+        const b = fakeClient('b', ['s1'])
+        srv.clients.set(wsA, a)
+        srv.clients.set(wsB, b)
+
+        // b departs while still in the map (production order: removeClient comes
+        // after departure). a still subscribes → mirror stays ON.
+        srv._handleClientDeparture(b)
+        assert.equal(b.terminalSessionIds.size, 0, 'departing client subs cleared')
+        assert.equal(calls[calls.length - 1], true, 'non-last departure → still ON')
+
+        // removeClient would now drop b; then a (the last viewer) departs → OFF.
+        srv.clients.delete(wsB)
+        srv._handleClientDeparture(a)
+        assert.equal(calls[calls.length - 1], false, 'last-viewer departure → OFF')
+      } finally { srv.close() }
+    })
+  })
 })


### PR DESCRIPTION
## What

Closes #5837 (deferred from PR #5836 / #5835 Phase 1). The live-mirror coalescer ran on **every PTY redraw for the whole life of every claude-tui session** — a string concat into `_mirrorBuffer`, a `setTimeout`, a `session_event` re-emit, and the `ws-forwarding` filter scan that drops everyone — even when nobody had the Output tab open. Gate it so an **unwatched session pays nothing per redraw**.

## How (issue's option A — gate the source)

- **`ClaudeTuiSession`** — `_terminalMirrorActive` (default **OFF**); `_feedTerminalMirror` early-returns when inactive (skips all per-redraw work); `setTerminalMirrorActive(active)` toggles it and, on OFF, drops any pending buffer/timer (no trailing flush for nobody).
- **`ws-server`** — `_syncTerminalMirror(sessionId)` recomputes whether **any** connected client is subscribed (`terminalSessionIds.has(sid)`) and toggles the session; exposed on the handler ctx as `syncTerminalMirror` (added to the canonical `ws-handler-context` shape + JSDoc).
- **Handlers** — `terminal_subscribe` syncs (first viewer → ON); `terminal_unsubscribe` syncs only when a sub was actually removed (last viewer → OFF).
- **`_handleClientDeparture`** — clears the departing client's terminal subscriptions, then re-syncs each watched session so a dropped **last** viewer turns the mirror OFF (the client is still in `this.clients` until `removeClient`, so it's cleared first).

## Behavior

- **No client-visible change.** Forward-only: a subscriber still sees redraws from when it subscribed onward — the mirror was never a snapshot in Phase 1 either (a non-subscriber got nothing; the diagnostics `_outputTail` is separate and never sent).
- Crossings are correct on all three paths: subscribe, unsubscribe, and disconnect.

## Tests

- `claude-tui-mirror.test.js` — mirror **inactive by default**: `_feedTerminalMirror` buffers nothing, arms no timer, emits nothing on tick; `setTerminalMirrorActive(true)`→coalesce→flush; `(false)` drops pending + stops further flushes; idempotent same-value (doesn't clear an in-flight buffer). Existing coalescer tests updated to activate first.
- `session-handlers.test.js` — `terminal_subscribe`/`terminal_unsubscribe` call `syncTerminalMirror(sid)`; unsubscribe does **not** re-sync when nothing was removed.

Server suite green for the touched files (mirror, session-handlers, ws-handlers, ws-message-handlers, ws-server shape, ws-handler-coverage); eslint + custom lints clean.