### PR TITLE
feat(config): warn on unknown keys in notifications.discord (#5453)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -446,6 +446,12 @@ const DISCORD_SUPPORTED_KEYS = new Set([
   // (discord-webhook-sink.js: staleAfterMs/offlineAfterMs, default 10m/30m), so
   // they are real config knobs, not test seams (PR #5845 review).
   'staleAfterMs', 'offlineAfterMs',
+  // State-store paths: the caller (server-cli.js / supervisor.js) defaults these
+  // then lets the config spread override them, and push.js honors them
+  // (statePath → DiscordWebhookSink, billingStatePath → DiscordBillingSink). They
+  // are string value knobs (override → works), unlike the function test seams, so
+  // an operator relocating them must not warn as unknown (PR #5845 review).
+  'statePath', 'billingStatePath',
 ])
 const DISCORD_SECRET_KEYS = ['webhookUrl', 'webhook', 'url']
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -433,6 +433,18 @@ function validateRancherBlock(rancher, warnings) {
 /** #5413: decimal 24-bit RGB range for Discord embed sidebar colors. */
 const MAX_DISCORD_COLOR = 16777215
 
+// #5453: the recognised `notifications.discord` config knobs. The unknown-key
+// check warns on anything outside this set so a typo (e.g. `botname`) or a
+// test-injection seam (`resolveWebhookUrl`/`sleepImpl`/`now`, reachable via the
+// `{ ...config.notifications.discord }` spread into the sink) surfaces instead of
+// silently no-op'ing / failing the sink closed. Keep in sync with the per-key
+// validation below. The webhook URL is a SECRET (its own warning) — not a knob.
+const DISCORD_SUPPORTED_KEYS = new Set([
+  'botName', 'billingAlerts', 'defaultColor', 'permissionColor', 'errorColor',
+  'colors', 'updateThrottleMs', 'heartbeatIntervalMs', 'pruneAfterMs',
+])
+const DISCORD_SECRET_KEYS = ['webhookUrl', 'webhook', 'url']
+
 /**
  * #5413: validate the `notifications.discord` block (the Discord
  * status-embed sink's non-secret knobs). Every field is optional; only
@@ -508,7 +520,7 @@ function validateDiscordNotificationsBlock(discord, warnings) {
 
   // Secrets do not belong in config.json (not permission-restricted, echoed
   // in verbose output). Warn loudly and point at the right place.
-  for (const key of ['webhookUrl', 'webhook', 'url']) {
+  for (const key of DISCORD_SECRET_KEYS) {
     if (Object.prototype.hasOwnProperty.call(discord, key)) {
       warnings.push(
         `'notifications.discord.${key}' is not supported: the webhook URL is a secret — set CHROXY_DISCORD_WEBHOOK_URL or add "discordWebhookUrl" to ~/.chroxy/credentials.json (mode 0600) instead`,
@@ -575,6 +587,15 @@ function validateDiscordNotificationsBlock(discord, warnings) {
     } else if (v !== 0 && v < 60_000) {
       warnings.push(`Invalid value for 'notifications.discord.pruneAfterMs': ${v} (minimum 60000 / 60s; set 0 to disable pruning — the sink falls back to its default)`)
     }
+  }
+
+  // #5453: warn on any unrecognised key. A typo'd knob is silently ignored
+  // (operator gets default behavior with no hint), and a test-seam key spread
+  // into the sink constructor fails it closed — both silent foot-guns. Skip the
+  // secret keys, which already got their specific "it's a secret" warning above.
+  for (const key of Object.keys(discord)) {
+    if (DISCORD_SUPPORTED_KEYS.has(key) || DISCORD_SECRET_KEYS.includes(key)) continue
+    warnings.push(`Invalid value for 'notifications.discord.${key}': unknown key (supported: ${[...DISCORD_SUPPORTED_KEYS].join(', ')})`)
   }
 }
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -442,6 +442,10 @@ const MAX_DISCORD_COLOR = 16777215
 const DISCORD_SUPPORTED_KEYS = new Set([
   'botName', 'billingAlerts', 'defaultColor', 'permissionColor', 'errorColor',
   'colors', 'updateThrottleMs', 'heartbeatIntervalMs', 'pruneAfterMs',
+  // #5676 status-watchdog tunables — the sink reads these from the config spread
+  // (discord-webhook-sink.js: staleAfterMs/offlineAfterMs, default 10m/30m), so
+  // they are real config knobs, not test seams (PR #5845 review).
+  'staleAfterMs', 'offlineAfterMs',
 ])
 const DISCORD_SECRET_KEYS = ['webhookUrl', 'webhook', 'url']
 
@@ -586,6 +590,18 @@ function validateDiscordNotificationsBlock(discord, warnings) {
       warnings.push(`Invalid value for 'notifications.discord.pruneAfterMs': expected a number >= 0 (0 disables pruning), got ${JSON.stringify(v)}`)
     } else if (v !== 0 && v < 60_000) {
       warnings.push(`Invalid value for 'notifications.discord.pruneAfterMs': ${v} (minimum 60000 / 60s; set 0 to disable pruning — the sink falls back to its default)`)
+    }
+  }
+
+  // #5676 status-watchdog tunables: the sink honors any finite >= 0 value, else
+  // falls back to its default (10m stale / 30m offline). Validate to keep
+  // DISCORD_SUPPORTED_KEYS in sync with the per-key checks (PR #5845 review).
+  for (const key of ['staleAfterMs', 'offlineAfterMs']) {
+    if (Object.prototype.hasOwnProperty.call(discord, key)) {
+      const v = discord[key]
+      if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+        warnings.push(`Invalid value for 'notifications.discord.${key}': expected a number >= 0 (the sink falls back to its default), got ${JSON.stringify(v)}`)
+      }
     }
   }
 

--- a/packages/server/tests/config-discord-validation.test.js
+++ b/packages/server/tests/config-discord-validation.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateConfig } from '../src/config.js'
+
+// #5453: validateConfig warns on unrecognised notifications.discord keys so a
+// typo'd knob (silently ignored → default behavior) or a test-injection seam
+// (spread into the sink → fails it closed) surfaces instead of silently no-op'ing.
+function discordWarnings(discord) {
+  return validateConfig({ notifications: { discord } }).warnings.filter(w => w.includes('notifications.discord'))
+}
+
+describe('validateConfig — notifications.discord unknown keys (#5453)', () => {
+  it("warns on a typo'd knob, naming the key and the supported set", () => {
+    const ws = discordWarnings({ botname: 'oops' }) // typo of botName
+    const w = ws.find(x => x.includes("'notifications.discord.botname'"))
+    assert.ok(w, 'expected an unknown-key warning for the typo')
+    assert.match(w, /unknown key/)
+    assert.match(w, /botName/) // names the supported set
+  })
+
+  it('warns on a test-injection seam key spread into the sink', () => {
+    const ws = discordWarnings({ resolveWebhookUrl: 'x', sleepImpl: 1, now: 2 })
+    for (const seam of ['resolveWebhookUrl', 'sleepImpl', 'now']) {
+      assert.ok(ws.some(w => w.includes(`'notifications.discord.${seam}'`) && w.includes('unknown key')), `expected unknown-key warning for ${seam}`)
+    }
+  })
+
+  it('uses non-fatal "Invalid value"-style wording and never throws (cosmetic typo must not abort startup)', () => {
+    let result
+    assert.doesNotThrow(() => { result = validateConfig({ notifications: { discord: { botname: 'x' } } }) })
+    assert.ok(result.warnings.some(w => w.startsWith("Invalid value for 'notifications.discord.botname'")))
+  })
+
+  it('does NOT warn-as-unknown for recognised knobs', () => {
+    const ws = discordWarnings({
+      botName: 'Bot', billingAlerts: true, defaultColor: 0, permissionColor: 1, errorColor: 2,
+      colors: {}, updateThrottleMs: 0, heartbeatIntervalMs: 0, pruneAfterMs: 0,
+    })
+    assert.ok(!ws.some(w => w.includes('unknown key')), `recognised knobs should not warn as unknown, got: ${JSON.stringify(ws)}`)
+  })
+
+  it('does NOT double-warn secret keys as unknown (they get their own secret warning)', () => {
+    const ws = discordWarnings({ webhookUrl: 'https://x', webhook: 'y', url: 'z' })
+    assert.ok(!ws.some(w => w.includes('unknown key')), 'secret keys must not be reported as unknown')
+    // …but they still get the specific "it's a secret" warning.
+    assert.ok(ws.some(w => w.includes("'notifications.discord.webhookUrl'") && w.includes('secret')))
+  })
+})

--- a/packages/server/tests/config-discord-validation.test.js
+++ b/packages/server/tests/config-discord-validation.test.js
@@ -36,8 +36,14 @@ describe('validateConfig — notifications.discord unknown keys (#5453)', () => 
       botName: 'Bot', billingAlerts: true, defaultColor: 0, permissionColor: 1, errorColor: 2,
       colors: {}, updateThrottleMs: 0, heartbeatIntervalMs: 0, pruneAfterMs: 0,
       staleAfterMs: 600000, offlineAfterMs: 1800000,
+      statePath: '/tmp/state.json', billingStatePath: '/tmp/billing.json',
     })
     assert.ok(!ws.some(w => w.includes('unknown key')), `recognised knobs should not warn as unknown, got: ${JSON.stringify(ws)}`)
+  })
+
+  it('does NOT warn on the runtime-honored state-store paths (statePath/billingStatePath)', () => {
+    const ws = discordWarnings({ statePath: '/custom/state.json', billingStatePath: '/custom/billing.json' })
+    assert.ok(!ws.some(w => w.includes('unknown key')), `state-store paths are config-overridable runtime knobs, got: ${JSON.stringify(ws)}`)
   })
 
   it('validates the #5676 watchdog tunables as numbers >= 0 (not unknown)', () => {

--- a/packages/server/tests/config-discord-validation.test.js
+++ b/packages/server/tests/config-discord-validation.test.js
@@ -31,12 +31,27 @@ describe('validateConfig — notifications.discord unknown keys (#5453)', () => 
     assert.ok(result.warnings.some(w => w.startsWith("Invalid value for 'notifications.discord.botname'")))
   })
 
-  it('does NOT warn-as-unknown for recognised knobs', () => {
+  it('does NOT warn-as-unknown for recognised knobs (incl. #5676 watchdog tunables)', () => {
     const ws = discordWarnings({
       botName: 'Bot', billingAlerts: true, defaultColor: 0, permissionColor: 1, errorColor: 2,
       colors: {}, updateThrottleMs: 0, heartbeatIntervalMs: 0, pruneAfterMs: 0,
+      staleAfterMs: 600000, offlineAfterMs: 1800000,
     })
     assert.ok(!ws.some(w => w.includes('unknown key')), `recognised knobs should not warn as unknown, got: ${JSON.stringify(ws)}`)
+  })
+
+  it('validates the #5676 watchdog tunables as numbers >= 0 (not unknown)', () => {
+    const ws = discordWarnings({ staleAfterMs: -1, offlineAfterMs: 'nope' })
+    assert.ok(ws.some(w => w.includes("'notifications.discord.staleAfterMs'") && w.includes('number >= 0')))
+    assert.ok(ws.some(w => w.includes("'notifications.discord.offlineAfterMs'") && w.includes('number >= 0')))
+    assert.ok(!ws.some(w => w.includes('unknown key')), 'known-but-invalid knobs get a value warning, not unknown-key')
+  })
+
+  it('an empty or non-object discord block produces no unknown-key warnings', () => {
+    assert.ok(!discordWarnings({}).some(w => w.includes('unknown key')), 'empty block → no unknown keys')
+    // a non-object block early-returns with a type warning and never enters the key loop
+    assert.doesNotThrow(() => discordWarnings('nope'))
+    assert.ok(!discordWarnings('nope').some(w => w.includes('unknown key')))
   })
 
   it('does NOT double-warn secret keys as unknown (they get their own secret warning)', () => {


### PR DESCRIPTION
## What

Closes #5453 (from PR #5451 review). `validateDiscordNotificationsBlock` validated the known knobs and warned on the secret keys (`webhookUrl`/`webhook`/`url`), but **unknown keys passed silently** — two foot-guns:

1. A **typo'd knob** (`botname` vs `botName`) is silently ignored — the operator gets default behavior with no hint why.
2. A **test-injection seam** (`resolveWebhookUrl`/`sleepImpl`/`now`) reaches the sink via the `{ ...config.notifications.discord }` spread (server-cli.js + supervisor.js). A JSON value there isn't callable, so `_configuredUrl()` throws internally and the sink **fails closed to "unconfigured"** — Discord notifications silently stop. Fail-closed (no secret exposure), but a silent foot-gun.

## How

- Module-level `DISCORD_SUPPORTED_KEYS` (the recognised knobs) + `DISCORD_SECRET_KEYS` (reused by the existing secret-warn loop, so the secret list has one source).
- After the per-key validation, warn on any key not in either set, naming the key and the supported set, using the existing non-fatal **"Invalid value for 'notifications.discord.X': unknown key (supported: …)"** wording — a cosmetic typo never aborts startup.
- Secret keys keep their specific "it's a secret" warning and are **not** double-reported as unknown.

## Tests (`config-discord-validation.test.js`)

- Typo'd knob warns (names key + supported set); test-seam keys (`resolveWebhookUrl`/`sleepImpl`/`now`) warn.
- Recognised knobs do **not** warn-as-unknown; secret keys are **not** double-warned (but still get the secret warning).
- `validateConfig` never throws on a cosmetic typo.

Server suite green for config + supervisor-push-config + discord-webhook-sink (261); eslint clean.