### PR TITLE
fix(store-core): guard CLAUDE_BACKED against future non-claude docker-* providers (#5448)

### DIFF
--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -354,6 +354,17 @@ export function _resetCredsCacheForTest() {
  *
  * @param {object} config - Merged server config
  */
+// #5448: every docker provider id registered below. store-core's
+// CLAUDE_BACKED_DOCKER_IDS allowlist assumes ALL of these run Claude sessions
+// (so a missing model contextWindow resolves to the Claude 200k default). That
+// is true today — each maps to a Claude wrapper (DockerSession/DockerSdkSession
+// extend the Claude CLI/SDK sessions; DockerByokSession runs the Claude BYOK
+// loop). If you register a NON-Claude provider under a `docker-*` name, you MUST
+// add it here AND decide its context-window story in store-core — otherwise the
+// providers test (every DOCKER_PROVIDER_ID must be Claude-backed) trips, instead
+// of the session silently regressing to a fabricated "% of 200k" meter.
+export const DOCKER_PROVIDER_IDS = ['docker-cli', 'docker-sdk', 'docker-byok', 'docker']
+
 export async function registerDockerProvider(config) {
   if (!config?.environments?.enabled) return
 
@@ -386,5 +397,5 @@ export async function registerDockerProvider(config) {
   // Backward compatibility: 'docker' maps to 'docker-cli' (hidden from listProviders)
   registerProvider('docker', DockerSession, { alias: true })
 
-  log.info('Docker providers registered (docker-cli, docker-sdk, docker-byok)')
+  log.info(`Docker providers registered (${DOCKER_PROVIDER_IDS.filter((id) => id !== 'docker').join(', ')})`)
 }

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -350,6 +350,7 @@ export function _resetCredsCacheForTest() {
  * Registers:
  *   - 'docker-cli': DockerSession (CLI-based, extends CliSession)
  *   - 'docker-sdk': DockerSdkSession (SDK-based, extends SdkSession)
+ *   - 'docker-byok': DockerByokSession (#4053, Claude BYOK loop on the host)
  *   - 'docker': backward-compatible alias for 'docker-cli'
  *
  * @param {object} config - Merged server config

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -1526,4 +1526,21 @@ describe('validateProviderClass — inProcessPermissions guard (#5379)', () => {
     const Stub = makeProviderClass({ inProcessPermissions: false, respondToPermission: false, respondToQuestion: false })
     assert.doesNotThrow(() => validateProviderClass(Stub, 'stub-no-inproc'))
   })
+
+  // #5448: store-core's context-window resolver assumes every docker-* provider
+  // is Claude-backed (200k default) via the CLAUDE_BACKED_DOCKER_IDS allowlist.
+  // That coupling lives in a different package than this registry, and the server
+  // can't import store-core's TS main entry under node --test (only the built
+  // /crypto subpath), so the two lists are kept in sync by a literal assertion on
+  // EACH side: this pins DOCKER_PROVIDER_IDS, and store-core's context-window.test
+  // pins CLAUDE_BACKED_DOCKER_IDS to the same set + asserts the resolver fails
+  // closed for an unknown docker-*. Adding a docker provider trips this test,
+  // forcing a conscious "is it Claude-backed?" decision in BOTH places.
+  describe('docker provider id set is pinned (#5448)', () => {
+    it('DOCKER_PROVIDER_IDS matches the known Claude-backed docker wrappers', async () => {
+      const { DOCKER_PROVIDER_IDS } = await import('../src/providers.js')
+      assert.deepEqual([...DOCKER_PROVIDER_IDS].sort(), ['docker', 'docker-byok', 'docker-cli', 'docker-sdk'],
+        'a docker provider changed — keep DOCKER_PROVIDER_IDS in sync with store-core CLAUDE_BACKED_DOCKER_IDS; a NON-Claude docker-* must NOT be added to the store-core allowlist (it would get a fabricated 200k context-window meter)')
+    })
+  })
 })

--- a/packages/store-core/src/context-window.test.ts
+++ b/packages/store-core/src/context-window.test.ts
@@ -7,7 +7,7 @@
  * "unknown window" state instead of a misleading "% of 200k" meter.
  */
 import { describe, it, expect } from 'vitest'
-import { isClaudeBackedProvider, resolveContextWindow } from './context-window'
+import { isClaudeBackedProvider, resolveContextWindow, CLAUDE_BACKED_DOCKER_IDS } from './context-window'
 import { DEFAULT_CONTEXT_WINDOW } from './types'
 
 describe('isClaudeBackedProvider (#5424)', () => {
@@ -38,6 +38,23 @@ describe('isClaudeBackedProvider (#5424)', () => {
     // 'claudette' / 'dockerish' must not ride the claude/docker defaults.
     expect(isClaudeBackedProvider('claudette')).toBe(false)
     expect(isClaudeBackedProvider('dockerish')).toBe(false)
+  })
+
+  it('FAILS CLOSED for an unknown docker-* provider (#5448)', () => {
+    // The docker family is an explicit allowlist, not a `docker-*` prefix — a
+    // future non-Claude containerized provider must NOT inherit the Claude 200k
+    // default (the #5424 failure mode) just because its id starts with `docker-`.
+    for (const p of ['docker-ollama', 'docker-vllm', 'docker-llamacpp', 'docker-future']) {
+      expect(isClaudeBackedProvider(p)).toBe(false)
+    }
+    // resolveContextWindow consequently returns null (real "unknown window"),
+    // not a fabricated 200k meter.
+    expect(resolveContextWindow(null, 'docker-ollama')).toBe(null)
+    expect(resolveContextWindow({}, 'docker-ollama')).toBe(null)
+  })
+
+  it('the docker allowlist exactly matches the known Claude docker wrappers (#5448)', () => {
+    expect([...CLAUDE_BACKED_DOCKER_IDS].sort()).toEqual(['docker', 'docker-byok', 'docker-cli', 'docker-sdk'])
   })
 })
 

--- a/packages/store-core/src/context-window.ts
+++ b/packages/store-core/src/context-window.ts
@@ -18,16 +18,30 @@ import { DEFAULT_CONTEXT_WINDOW } from './types'
 import type { ModelInfo } from './types'
 
 /**
- * Providers whose sessions are backed by Claude models and therefore
- * genuinely have the 200k default: the claude-* family plus the docker-*
- * wrappers (docker-cli / docker-sdk / docker-byok / docker all run a Claude
- * session inside the container — see provider-labels.ts).
+ * Claude-backed docker provider ids — an EXPLICIT allowlist, not a `docker-*`
+ * prefix (#5448). Every id here runs a Claude session inside the container
+ * (docker-cli / docker-sdk / docker-byok, plus the `docker` alias for docker-cli
+ * — see provider-labels.ts and the server's registerDockerProvider). It is an
+ * allowlist so a FUTURE non-Claude containerized provider registered under a
+ * `docker-*` name (e.g. `docker-ollama`) FAILS CLOSED — it does NOT inherit the
+ * Claude 200k default and instead resolves to a real `null` meter (the failure
+ * mode #5424 fixed for ollama). The server side asserts every registered
+ * `docker-*` provider is listed here (DOCKER_PROVIDER_IDS in providers.js), so
+ * adding a non-Claude docker provider trips a test instead of silently
+ * regressing the context-window meter.
  */
-const CLAUDE_BACKED_PREFIXES = ['claude', 'docker'] as const
+export const CLAUDE_BACKED_DOCKER_IDS: ReadonlySet<string> = new Set([
+  'docker', 'docker-cli', 'docker-sdk', 'docker-byok',
+])
 
 /**
  * Whether `provider` runs Claude models (and so may assume the Claude
  * 200k default when a model's `contextWindow` is missing).
+ *
+ * The claude-* family is matched by prefix (open-ended — every claude-* is
+ * Claude). The docker family is matched by the EXPLICIT CLAUDE_BACKED_DOCKER_IDS
+ * allowlist (#5448), NOT a `docker-*` prefix, so an unknown `docker-*` fails
+ * closed rather than fabricating a 200k meter.
  *
  * `null`/`undefined` counts as Claude-backed: servers that predate
  * per-session provider reporting only ran claude, so the legacy fallback
@@ -35,9 +49,8 @@ const CLAUDE_BACKED_PREFIXES = ['claude', 'docker'] as const
  */
 export function isClaudeBackedProvider(provider: string | null | undefined): boolean {
   if (provider == null) return true
-  return CLAUDE_BACKED_PREFIXES.some(
-    (prefix) => provider === prefix || provider.startsWith(`${prefix}-`),
-  )
+  if (provider === 'claude' || provider.startsWith('claude-')) return true
+  return CLAUDE_BACKED_DOCKER_IDS.has(provider)
 }
 
 /**

--- a/packages/store-core/src/context-window.ts
+++ b/packages/store-core/src/context-window.ts
@@ -25,10 +25,12 @@ import type { ModelInfo } from './types'
  * allowlist so a FUTURE non-Claude containerized provider registered under a
  * `docker-*` name (e.g. `docker-ollama`) FAILS CLOSED — it does NOT inherit the
  * Claude 200k default and instead resolves to a real `null` meter (the failure
- * mode #5424 fixed for ollama). The server side asserts every registered
- * `docker-*` provider is listed here (DOCKER_PROVIDER_IDS in providers.js), so
- * adding a non-Claude docker provider trips a test instead of silently
- * regressing the context-window meter.
+ * mode #5424 fixed for ollama). The server pins its own DOCKER_PROVIDER_IDS to
+ * this same set (providers.js) — each side's test fails if its list drifts — so
+ * adding a docker provider trips a test and forces a conscious "is it
+ * Claude-backed?" decision in both packages, instead of silently regressing the
+ * context-window meter. (The two lists can't share an import: the server loads
+ * only @chroxy/store-core/crypto, not this TS main entry.)
  */
 export const CLAUDE_BACKED_DOCKER_IDS: ReadonlySet<string> = new Set([
   'docker', 'docker-cli', 'docker-sdk', 'docker-byok',

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -18,6 +18,7 @@ export { DEFAULT_CONTEXT_WINDOW } from './types'
 export {
   isClaudeBackedProvider,
   resolveContextWindow,
+  CLAUDE_BACKED_DOCKER_IDS,
 } from './context-window'
 
 // #4853: runtime type-guard for `VoiceInputMode` — keyed off an


### PR DESCRIPTION
## What

Closes #5448 (from PR #5444 review). `isClaudeBackedProvider` treated the entire `docker-*` namespace as Claude-backed via a prefix, so a missing `contextWindow` resolved to the 200k Claude default. Correct today (all docker wrappers are Claude), but the coupling was implicit and in a **different package** than the registry: a future containerized non-claude provider under a `docker-*` name (e.g. `docker-ollama`) would silently regress to a fabricated "% of 200k" meter — the exact failure mode #5424 fixed for ollama — with no test to catch it.

## How

- **store-core** (`context-window.ts`): replaced the `docker` prefix with an **explicit `CLAUDE_BACKED_DOCKER_IDS` allowlist** (`docker`, `docker-cli`, `docker-sdk`, `docker-byok`). An unknown `docker-*` now **fails closed** — `isClaudeBackedProvider` returns `false` → `resolveContextWindow` returns `null` (real "unknown window") instead of a 200k meter. The `claude-*` family stays an open prefix. Exported for cross-package pinning.
- **server** (`providers.js`): documented the coupling at `registerDockerProvider`, and added a `DOCKER_PROVIDER_IDS` constant (now used in the registration log) listing every registered docker id, with a comment that a non-claude `docker-*` must **not** join the store-core allowlist.

## Why a literal set on each side (not a shared import)

The server can't import store-core's TS **main** entry under `node --test` (only the built `/crypto` subpath resolves), so the registry and the resolver can't share one constant. Instead each side pins the same set in its own test; either drifting fails its own test, and the cross-referencing comments force a conscious decision when a docker provider is added.

## Tests

- `store-core/context-window.test.ts` — **fails closed** for `docker-ollama`/`docker-vllm`/`docker-llamacpp`/`docker-future` (`isClaudeBackedProvider` false, `resolveContextWindow` null); allowlist exactly equals the known wrappers. Existing known-docker + non-claude + null cases unchanged.
- `server/providers.test.js` — pins `DOCKER_PROVIDER_IDS` to the known set (drift tripwire).

store-core suite 1573 pass + typecheck clean; server providers 91 pass; dashboard tsc clean (consumer); eslint clean. Behavior unchanged for every provider registered today.