### PR TITLE
fix(server): collision-proof the compat credential-cache slot key (#5486)

### DIFF
--- a/packages/server/src/anthropic-compatible-session.js
+++ b/packages/server/src/anthropic-compatible-session.js
@@ -144,7 +144,17 @@ export function resolveAnthropicCompatibleApiKey(entry) {
     return resolveAnthropicCompatibleApiKeyUncached(entry)
   }
   return cachedResolveCredentialFile(
-    `compat:${apiKeyEnv || ''}:${credentialsKey}`,
+    // #5486: encode the (apiKeyEnv, credentialsKey) pair with JSON so the slot key
+    // is collision-proof for ANY input charset. The plain `compat:<env>:<key>`
+    // form is unambiguous only for config-validated entries (ENV_VAR_NAME_RE /
+    // CREDENTIALS_KEY_RE both exclude `:` — #5458). But createAnthropicCompatibleSessionClass
+    // is exported for embedders/tests and its defensive normalization only checks
+    // "non-empty string", so a `:`-bearing value (apiKeyEnv 'A:B' + key 'C' vs
+    // 'A' + 'B:C') would mint the same `compat:A:B:C` slot and cross-serve cached
+    // credentials between two different specs. JSON.stringify quotes/escapes the
+    // delimiter, so distinct specs get distinct slots; an identical spec still
+    // produces an identical key (the intentional sharing from #5461 is preserved).
+    `compat:${JSON.stringify([apiKeyEnv || '', credentialsKey])}`,
     apiKeyEnv ? process.env[apiKeyEnv] : undefined,
     () => resolveAnthropicCompatibleApiKeyUncached(entry),
     apiKeyEnv || null,

--- a/packages/server/src/auth-probes.js
+++ b/packages/server/src/auth-probes.js
@@ -180,7 +180,8 @@ let _credFileCache = {
   // must not re-stat/re-parse the file per probe.
   discord: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
   // #5461: config-driven Anthropic-compatible entries add dynamic
-  // `compat:<apiKeyEnv>:<credentialsKey>` slots lazily on first use —
+  // `compat:<JSON [apiKeyEnv, credentialsKey]>` slots lazily on first use
+  // (#5486: JSON-encoded so the key is collision-proof for any charset) —
   // bounded by the configured entries, dropped by resetCachesForTest().
 }
 
@@ -209,7 +210,7 @@ const _SLOT_ENV_VAR = {
  * for a file-only credential spec — the env clause is omitted); fixed slots
  * keep their `_SLOT_ENV_VAR` mapping and don't pass it.
  *
- * @param {string} slot - 'byok' | 'deepseek' | 'discord' | dynamic (e.g. 'compat:ZAI_API_KEY:zaiApiKey')
+ * @param {string} slot - 'byok' | 'deepseek' | 'discord' | dynamic (e.g. 'compat:["ZAI_API_KEY","zaiApiKey"]')
  * @param {string | undefined} envValue - current value of the relevant env var
  * @param {() => object} resolve - the underlying *-credentials resolver
  * @param {string | null} [envVarName] - env var to name in the ENOENT reason (dynamic slots only)

--- a/packages/server/tests/anthropic-compatible.test.js
+++ b/packages/server/tests/anthropic-compatible.test.js
@@ -754,6 +754,55 @@ describe('credential file read caching (#5461)', () => {
     assert.doesNotMatch(fileOnly.reason, /not set/, 'no env clause when no apiKeyEnv is configured')
     assert.match(fileOnly.reason, /credentials\.json does not exist/)
   })
+
+  // #5486: the cache slot key must be collision-proof for ANY input charset.
+  // createAnthropicCompatibleSessionClass is exported for embedders/tests and its
+  // defensive normalization only checks "non-empty string" — so a `:`-bearing
+  // apiKeyEnv/credentialsKey could bypass the #5458 config charset regexes. The
+  // plain `compat:<env>:<key>` form was ambiguous there; the JSON-encoded form
+  // is not.
+  it('delimiter-bearing specs never share a slot — no cross-serve (#5486)', () => {
+    // Two distinct specs that BOTH minted `compat:AA:BB:C` under the old plain
+    // delimiter: ('AA:BB','C') and ('AA','BB:C'). Their env vars are unset, so
+    // both take the file path and (file unchanged) the old shared slot would
+    // cross-serve the first's cached result to the second.
+    writeRawCredentialsFile(JSON.stringify({ C: 'value-of-C', 'BB:C': 'value-of-BC' }))
+    const a = resolveAnthropicCompatibleApiKey({ apiKeyEnv: 'AA:BB', credentialsKey: 'C' })
+    const b = resolveAnthropicCompatibleApiKey({ apiKeyEnv: 'AA', credentialsKey: 'BB:C' })
+    assert.equal(a.key, 'value-of-C')
+    assert.equal(b.key, 'value-of-BC', 'second spec must resolve its OWN key, not cross-serve the first (collision)')
+    // Order-independence: the reverse order must also stay independent.
+    resetCachesForTest()
+    const b2 = resolveAnthropicCompatibleApiKey({ apiKeyEnv: 'AA', credentialsKey: 'BB:C' })
+    const a2 = resolveAnthropicCompatibleApiKey({ apiKeyEnv: 'AA:BB', credentialsKey: 'C' })
+    assert.equal(b2.key, 'value-of-BC')
+    assert.equal(a2.key, 'value-of-C')
+  })
+
+  it('two entries with the identical spec DO share one slot (intentional #5461 sharing)', () => {
+    // The slot key is derived ONLY from (apiKeyEnv, credentialsKey) — never the
+    // entry id — so two config entries with the same credential spec reuse one
+    // cache slot. Proof: the second resolve returns the stale cached value after
+    // the file content changed but (mtime,size,mode) was restored.
+    const original = JSON.stringify({ compatApiKey: 'sk-shared-aaaa' })
+    const renamed = JSON.stringify({ compatXpiKey: 'sk-shared-aaaa' })
+    assert.equal(original.length, renamed.length, 'fixtures must be byte-equal for the cache key to hit')
+    const file = writeRawCredentialsFile(original)
+    const pinned = pinnedDate()
+    utimesSync(file, pinned, pinned)
+
+    const first = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(first.key, 'sk-shared-aaaa')
+
+    writeFileSync(file, renamed)
+    chmodSync(file, 0o600)
+    utimesSync(file, pinned, pinned)
+
+    // A SECOND entry with the identical (apiKeyEnv, credentialsKey) — a different
+    // config entry.id is irrelevant to the slot — hits the shared cached slot.
+    const second = resolveAnthropicCompatibleApiKey({ apiKeyEnv: null, credentialsKey: 'compatApiKey' })
+    assert.equal(second.key, 'sk-shared-aaaa', 'identical spec reused the shared slot (no re-read of the changed file)')
+  })
 })
 
 describe('registerAnthropicCompatibleProviders', () => {

--- a/packages/server/tests/anthropic-compatible.test.js
+++ b/packages/server/tests/anthropic-compatible.test.js
@@ -786,7 +786,10 @@ describe('credential file read caching (#5461)', () => {
     // the file content changed but (mtime,size,mode) was restored.
     const original = JSON.stringify({ compatApiKey: 'sk-shared-aaaa' })
     const renamed = JSON.stringify({ compatXpiKey: 'sk-shared-aaaa' })
-    assert.equal(original.length, renamed.length, 'fixtures must be byte-equal for the cache key to hit')
+    // The cache invalidation keys on the file stat (mtime/size/mode), not content,
+    // so the fixtures only need EQUAL SIZE (not identical bytes) — with mtime+mode
+    // restored below, a same-size content swap still reads as a cache hit.
+    assert.equal(original.length, renamed.length, 'fixtures must be equal-length so the restored (mtime,size,mode) reads as a cache hit')
     const file = writeRawCredentialsFile(original)
     const pinned = pinnedDate()
     utimesSync(file, pinned, pinned)


### PR DESCRIPTION
## What

Closes #5486 (from PR #5484 review). `resolveAnthropicCompatibleApiKey` keyed its dynamic credential-file cache slots as `compat:<apiKeyEnv>:<credentialsKey>`. Collision-proof for **config-validated** entries (`ENV_VAR_NAME_RE` / `CREDENTIALS_KEY_RE` both exclude `:`, #5458). But `createAnthropicCompatibleSessionClass` is exported for embedders/tests and its defensive normalization only checks "non-empty string", so a `:`-bearing value — `apiKeyEnv: 'A:B', credentialsKey: 'C'` vs `apiKeyEnv: 'A', credentialsKey: 'B:C'` — both minted `compat:A:B:C` and **cross-served cached credential results between two different specs**.

## How

Encode the pair with JSON: `` `compat:${JSON.stringify([apiKeyEnv || '', credentialsKey])}` ``. The delimiter is now quoted/escaped, so distinct specs get distinct slots (`["A:B","C"]` ≠ `["A","B:C"]`) while an identical spec still maps to one slot (the **intentional sharing** from #5461 is preserved). The slot string is an **opaque cache key** — nothing parses its format (`resetCachesForTest` replaces the whole `_credFileCache` object; the `compat:` references elsewhere are doc comments), so the encoding change is fully internal. Doc-comment examples updated to the JSON form.

Chose the encoding route (over enforcing the #5458 charsets in the factory) because it fixes the single slot-key site for **both** the validated-config and embedder paths without rejecting embedder input.

## Tests (`anthropic-compatible.test.js`, #5461 cache suite)

- **Delimiter-bearing specs never share a slot** — `('AA:BB','C')` and `('AA','BB:C')` resolve their own keys (`value-of-C` / `value-of-BC`), no cross-serve; order-independent. (Fails on the old `compat:A:B:C` key.)
- **Identical spec shares one slot** — stale-cache proof (mutate file content, restore mtime/size/mode → second resolve returns the cached value), pinning the #5461 sharing semantics.

Server credential/provider/auth-probes suites green (191); eslint clean.