### PR TITLE
fix(server): typed sendMessage failure returns + accurate tool-result-text comment (#5813 items 2+3)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2131,7 +2131,10 @@ export class ClaudeTuiSession extends BaseSession {
       const completed = await this._writePtyTextThrottled(promptToSend, {
         onAbort: () => this._finishTurnError('Turn aborted during prompt write', messageId),
       })
-      if (!completed) return { ok: false, reason: 'aborted' } // #5813: typed failure (write aborted)
+      // #5813: typed failure. _writePtyTextThrottled returns false for BOTH an
+      // aborted turn AND a mid-write PTY exit, so report the actual cause (#5848
+      // review) rather than always labelling it 'aborted'.
+      if (!completed) return { ok: false, reason: this._ptyExited ? 'pty_exited' : 'aborted' }
     } catch (err) {
       this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`, messageId)
       return { ok: false, reason: 'write_failed' } // #5813: typed failure

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2093,7 +2093,11 @@ export class ClaudeTuiSession extends BaseSession {
       const code = this._ptyExitInfo?.exitCode
       const signal = this._ptyExitInfo?.signal
       this._finishTurnError(`Claude PTY exited before prompt write (code=${code}${signal ? ` signal=${signal}` : ''})`, messageId)
-      return
+      // #5813: return the typed failure (like the up-front busy/not_runnable
+      // guards) so callers that key off `result.ok === false` — e.g. the reinject
+      // stop-and-wait watch-close in form-driver.js — don't have to rely on
+      // _finishTurnError's side-effect to know the turn never started.
+      return { ok: false, reason: 'pty_exited' }
     }
     // If the user clicked Stop during the probe wait, interrupt() has
     // already written Ctrl-C to the PTY and marked the turn aborted.
@@ -2103,7 +2107,7 @@ export class ClaudeTuiSession extends BaseSession {
     // still process the bytes once it returns to prompt). Bail cleanly.
     if (this._activeTurn?.aborted) {
       this._finishTurnError('Turn aborted before prompt write', messageId)
-      return
+      return { ok: false, reason: 'aborted' } // #5813: typed failure
     }
 
     // #4732: reset the per-turn pre-first-output watchdog latch so the
@@ -2127,10 +2131,10 @@ export class ClaudeTuiSession extends BaseSession {
       const completed = await this._writePtyTextThrottled(promptToSend, {
         onAbort: () => this._finishTurnError('Turn aborted during prompt write', messageId),
       })
-      if (!completed) return
+      if (!completed) return { ok: false, reason: 'aborted' } // #5813: typed failure (write aborted)
     } catch (err) {
       this._finishTurnError(`Failed to write prompt to PTY: ${err.message}`, messageId)
-      return
+      return { ok: false, reason: 'write_failed' } // #5813: typed failure
     }
 
     // Arm soft + hard inactivity timers (#3920). Each new hook file the

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1785,11 +1785,15 @@ describe('ClaudeTuiSession', () => {
         session._ptyExitInfo = { exitCode: 1, signal: null }
       }, 40)
 
-      await session.sendMessage('hello')
+      const result = await session.sendMessage('hello')
 
       assert.ok(errors.find((e) => /exited before prompt write/.test(e.message)),
         `expected "exited before prompt write" error, got: ${errors.map((e) => e.message).join(' | ')}`)
       assert.equal(session._isBusy, false, 'busy cleared after probe-time PTY death')
+      // #5813: the late-failure path returns the typed { ok:false } (like the
+      // up-front guards) so callers keying off result.ok — e.g. the reinject
+      // stop-and-wait watch-close — don't depend on _finishTurnError's side-effect.
+      assert.deepEqual(result, { ok: false, reason: 'pty_exited' })
     })
 
     it('sendMessage bails out via _finishTurnError when interrupt() fires during the probe wait', async () => {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -729,8 +729,10 @@ export type {
 } from './multi-question-form'
 
 // #5800 — shared tool-result-envelope unwrap, hoisted from the dashboard's
-// `lib/tool-result-text.ts` so the app gains the same `{stdout,stderr}` →
-// terminal-text normalisation. Zero behavior change for the dashboard.
+// `lib/tool-result-text.ts` so the `{stdout,stderr}` → terminal-text
+// normalisation is AVAILABLE for future app use (#5813: the app has no
+// tool-result-envelope Output surface today and doesn't call it — no current
+// parity gap). Zero behavior change for the dashboard.
 export {
   unwrapToolResultText,
 } from './tool-result-text'

--- a/packages/store-core/src/tool-result-text.ts
+++ b/packages/store-core/src/tool-result-text.ts
@@ -9,8 +9,9 @@
  *
  * #5800: hoisted from `packages/dashboard/src/lib/tool-result-text.ts` into
  * store-core (next to the other shared parsers like `partial-json.ts`) so the
- * app gains the same tool-result-envelope unwrap as the dashboard. Zero
- * behavior change for the dashboard.
+ * unwrap is AVAILABLE for future app use — the app has no tool-result-envelope
+ * Output surface today and does not call this yet, so there is no current parity
+ * gap to close (#5813). Zero behavior change for the dashboard.
  *
  * `unwrapToolResultText` normalises any of those shapes back to the text a
  * terminal should show:


### PR DESCRIPTION
## What

Two LOW follow-ups from the 2026-06-14 convergence accuracy-audit (#5813). **Does not close #5813** — item 1 (the reinject stop-wait telemetry false-positive) needs trace-validated work (see the [issue analysis](https://github.com/blamechris/chroxy/issues/5813) — both audit options are defeated by the post-reinject `_activeTurn` timing), and item 4 is latent.

### Item 2 — `sendMessage` late-failure paths return typed `{ ok:false, reason }`
The up-front guards already return `{ ok:false, reason }` (#5799), but the later paths (PTY exited / turn aborted / prompt-write abort / prompt-write throw) called `_finishTurnError` then **bare-returned**. The reinject stop-and-wait watch-close (`form-driver.js` ~692) keys off `result.ok === false`, so for those paths it relied on `_finishTurnError → _clearFirstOutputWatchdog` nulling the watch as a side-effect. Now they return `{ ok:false, reason: 'pty_exited' | 'aborted' | 'write_failed' }`, making the explicit guard load-bearing and refactor-safe.

### Item 3 — `tool-result-text.ts` header accuracy
#5800 hoisted `unwrapToolResultText` to store-core; the header claimed "the app gains the same unwrap." The app has no tool-result-envelope Output surface and never calls it (no parity gap). Reworded to "available for future app use."

## Tests
- `claude-tui-session.test.js` — the probe-time PTY-death path now asserts `sendMessage` returns `{ ok:false, reason:'pty_exited' }` (the late path the change adds typing to).
- Existing up-front `{ok:false}` guard coverage unchanged; store-core `tool-result-text` suite unaffected (comment-only).

Server claude-tui + form-driver suites green (310); store-core tool-result-text 11; eslint clean.

Part of #5813.