### PR TITLE
fix(claude-hooks): never derive the opaque session id for an unrecoverable chroxy worktree (#5483)

### DIFF
--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -232,6 +232,22 @@ function gitRootName(cwd) {
 export function deriveProject(cwd, env = process.env) {
   const fromWorktree = worktreeParent(cwd, env)
   if (fromWorktree) return fromWorktree
+  // #5483: inside a chroxy worktree (~/.chroxy/worktrees/<id>), `gitRootName`
+  // can ONLY ever yield the opaque 32-hex session id — the worktree dir's own
+  // basename, via its (possibly malformed) `.git` FILE or the final basename
+  // fallback. We only reach here when `worktreeParent` already returned null,
+  // i.e. the parent `.git` parse failed (corrupt/missing) — the residual path
+  // that still minted the opaque-id embed #5464 set out to eliminate. Skip the
+  // git walk for these and defer to CLAUDE_PROJECT_DIR / server-side derivation.
+  const resolved = realResolve(cwd)
+  if (resolved && chroxyWorktreeTopDir(resolved, env)) {
+    const projectDir = env.CLAUDE_PROJECT_DIR
+    if (typeof projectDir === 'string' && projectDir.length > 0) {
+      const name = basename(resolve(projectDir))
+      if (name.length > 0) return name
+    }
+    return null
+  }
   const fromCwd = gitRootName(cwd)
   if (fromCwd) return fromCwd
   const projectDir = env.CLAUDE_PROJECT_DIR

--- a/packages/claude-hooks/src/project.js
+++ b/packages/claude-hooks/src/project.js
@@ -232,13 +232,15 @@ function gitRootName(cwd) {
 export function deriveProject(cwd, env = process.env) {
   const fromWorktree = worktreeParent(cwd, env)
   if (fromWorktree) return fromWorktree
-  // #5483: inside a chroxy worktree (~/.chroxy/worktrees/<id>), `gitRootName`
-  // can ONLY ever yield the opaque 32-hex session id — the worktree dir's own
-  // basename, via its (possibly malformed) `.git` FILE or the final basename
-  // fallback. We only reach here when `worktreeParent` already returned null,
-  // i.e. the parent `.git` parse failed (corrupt/missing) — the residual path
-  // that still minted the opaque-id embed #5464 set out to eliminate. Skip the
-  // git walk for these and defer to CLAUDE_PROJECT_DIR / server-side derivation.
+  // #5483: inside a chroxy worktree (~/.chroxy/worktrees/<id>) the git walk
+  // can't name the right project. We only reach here when `worktreeParent`
+  // already returned null — the parent `.git` parse failed (corrupt/missing) —
+  // so `gitRootName` falls back to the worktree dir's basename (the opaque 32-hex
+  // session id) via the worktree-root `.git` FILE or the final basename fallback.
+  // (A nested sub-repo could yield some other basename, but that's not the
+  // session's project either.) Either way the walk is wrong here — it's the
+  // residual path that still minted the opaque-id embed #5464 eliminated — so
+  // skip it and defer to CLAUDE_PROJECT_DIR / server-side derivation.
   const resolved = realResolve(cwd)
   if (resolved && chroxyWorktreeTopDir(resolved, env)) {
     const projectDir = env.CLAUDE_PROJECT_DIR

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -261,8 +261,8 @@ describe('deriveProject', () => {
 
   // #5483: when the chroxy worktree's .git parse FAILS (corrupt or missing),
   // worktreeParent returns null. deriveProject must NOT fall through to the git
-  // walk — inside a chroxy worktree it can only ever yield the opaque session id
-  // (the worktree dir's basename), the exact noise embed #5464 eliminated.
+  // walk — with the parent unrecoverable it falls back to the worktree dir's
+  // basename (the opaque session id), the exact noise embed #5464 eliminated.
   it('never derives the opaque id when a chroxy worktree .git file is MALFORMED (#5483)', () => {
     // A shape-surprise gitdir (not <repo>/.git/worktrees/<id>) → parse returns null.
     const { root, wt, id } = chroxyWorktreeFixture({ gitdir: '/somewhere/bogus/x' })

--- a/packages/claude-hooks/tests/emit.test.js
+++ b/packages/claude-hooks/tests/emit.test.js
@@ -259,6 +259,35 @@ describe('deriveProject', () => {
     assert.equal(deriveProject(join(wt, 'packages', 'server'), env), 'coolproj', 'nested chroxy worktree cwd remaps too')
   })
 
+  // #5483: when the chroxy worktree's .git parse FAILS (corrupt or missing),
+  // worktreeParent returns null. deriveProject must NOT fall through to the git
+  // walk — inside a chroxy worktree it can only ever yield the opaque session id
+  // (the worktree dir's basename), the exact noise embed #5464 eliminated.
+  it('never derives the opaque id when a chroxy worktree .git file is MALFORMED (#5483)', () => {
+    // A shape-surprise gitdir (not <repo>/.git/worktrees/<id>) → parse returns null.
+    const { root, wt, id } = chroxyWorktreeFixture({ gitdir: '/somewhere/bogus/x' })
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }
+    assert.equal(worktreeParent(wt, env), null, 'precondition: parent parse fails on the malformed .git')
+    assert.notEqual(deriveProject(wt, env), id, 'must not mint the opaque session id')
+    assert.equal(deriveProject(wt, env), null, 'no parent + no CLAUDE_PROJECT_DIR → null (server derives)')
+    assert.equal(deriveProject(join(wt, 'packages', 'server'), env), null, 'nested cwd is suppressed too')
+  })
+
+  it('never derives the opaque id when a chroxy worktree .git file is MISSING (#5483)', () => {
+    const { root, wt, id } = chroxyWorktreeFixture({ noGitFile: true })
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root }
+    assert.equal(worktreeParent(wt, env), null, 'precondition: no .git → no parent')
+    assert.notEqual(deriveProject(wt, env), id)
+    assert.equal(deriveProject(wt, env), null)
+  })
+
+  it('falls back to CLAUDE_PROJECT_DIR (not the opaque id) for an unrecoverable chroxy worktree (#5483)', () => {
+    const { root, wt, id } = chroxyWorktreeFixture({ noGitFile: true })
+    const env = { CHROXY_HOOKS_CHROXY_WORKTREES_ROOT: root, CLAUDE_PROJECT_DIR: '/home/user/realproj' }
+    assert.notEqual(deriveProject(wt, env), id)
+    assert.equal(deriveProject(wt, env), 'realproj', 'CLAUDE_PROJECT_DIR still wins over the opaque id')
+  })
+
   it('resolves the chroxy worktrees root from $HOME when no override is set (#5464)', () => {
     const home = mkdtempSync(join(tmpdir(), 'hooks-chroxyhome-'))
     const id = 'feedfacefeedfacefeedfacefeedface'


### PR DESCRIPTION
## What

Addresses the **claude-hooks (emitter) half** of #5483 (from PR #5481 review). `classifyNonProjectCwd` suppresses non-subagent events from a chroxy worktree by path shape, but a **subagent** event passed through and `deriveProject` fell to `gitRootName` when the worktree's `.git` parse failed → the opaque 32-hex session id (worktree dir basename via a malformed `.git` FILE, or the basename fallback when missing).

## How (issue option 2)

In `deriveProject`, when `worktreeParent` returns null **and** the cwd resolves inside a chroxy worktree (`chroxyWorktreeTopDir`), skip the `gitRootName` walk (it can only ever yield the opaque id there) and defer to `CLAUDE_PROJECT_DIR` / `null`. The `.claude/worktrees/agent-*` path is unaffected (parent recovered from path shape, never the `.git` parse).

## Scope — emitter half only

This fixes the hook so it no longer **emits** the opaque id (sends `project: null`). The **server's** parallel `deriveProjectFromCwd` (`event-ingest.js`) has the same residual bug and re-derives the opaque id from `data.cwd` when the envelope project is null — filed as a follow-up (linked below). So this PR is **Part of #5483**, not a full close; #5483 stays open until the server parity lands.

## Tests (`emit.test.js`)

- MALFORMED `.git` (shape-surprise gitdir) and MISSING `.git` → `deriveProject` returns `null`, never the opaque id (nested cwd too); `CLAUDE_PROJECT_DIR` still wins.

claude-hooks suite green (93); eslint clean.

Part of #5483.