### PR TITLE
fix(server): free the port before forking the replacement supervisor child (P0-1)

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -379,6 +379,18 @@ export class Supervisor extends EventEmitter {
       this._restartTimer = null
     }
 
+    // Free the port BEFORE forking the replacement child. After a crash the
+    // exit handler starts a standby health server bound to `this._port`; if it
+    // is still listening when the new child forks, the child's own `listen()`
+    // fails with EADDRINUSE and it exits before sending `ready` — so the
+    // `_stopStandbyServer()` on `ready` (below) never runs, the standby stays
+    // up, and every restart attempt hits the same EADDRINUSE until the restart
+    // cap, silently bricking the daemon on the first crash. Stopping standby
+    // here (idempotent when none is running, e.g. the first start) guarantees
+    // the port is available for the child to bind. `close()` releases the
+    // listening socket; the standby has no keep-alive clients to drain.
+    this._stopStandbyServer()
+
     const childScript = resolve(__dirname, 'server-cli-child.js')
     const childEnv = {
       ...process.env,

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -5,7 +5,33 @@ import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { Readable } from 'stream'
+import { createServer as createNetServer } from 'net'
 import { Supervisor } from '../src/supervisor.js'
+
+// Bind without a host arg so these probes match how the supervisor's standby
+// server binds (`listen(port)` → the unspecified address), otherwise an
+// IPv4-vs-IPv6/dual-stack mismatch makes the EADDRINUSE check flaky.
+
+/** Bind an ephemeral port, read it, release it — a free port for a test. */
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer()
+    srv.on('error', reject)
+    srv.listen(0, () => {
+      const { port } = srv.address()
+      srv.close(() => resolve(port))
+    })
+  })
+}
+
+/** Try to listen on a port; resolve with the error code (or null on success). */
+function tryListen(port) {
+  return new Promise((resolve) => {
+    const srv = createNetServer()
+    srv.on('error', (err) => resolve(err.code))
+    srv.listen(port, () => srv.close(() => resolve(null)))
+  })
+}
 
 /**
  * Create a mock child process (EventEmitter with send/kill/stdout/stderr).
@@ -274,6 +300,42 @@ describe('Supervisor', () => {
       // Child restart happens on setTimeout — verify state is correct
       assert.equal(supervisor._child, null)
       assert.equal(supervisor._childReady, false)
+    })
+
+    // Regression: the standby health server that runs while the child is down
+    // binds `this._port`. Before the fix, it kept listening when the next child
+    // forked, so the child hit EADDRINUSE, exited before `ready`, and the
+    // `_stopStandbyServer()` on `ready` never ran — every restart hit the same
+    // EADDRINUSE until the cap, bricking the daemon. startChild() must free the
+    // port BEFORE forking. Uses a REAL listening socket so a mocked fork can't
+    // hide the port conflict.
+    it('frees the standby port before forking the replacement child (no EADDRINUSE crash-loop)', async () => {
+      const port = await findFreePort()
+      const { supervisor } = setup({ port })
+
+      // Stand up a real standby health server, as the crash path does.
+      supervisor._startStandbyServer()
+      await new Promise((resolve) => supervisor._standbyServer.once('listening', resolve))
+
+      // Sanity: the standby genuinely holds the port (real-listener check) — a
+      // fresh listener on it must fail, mirroring what the forked child sees.
+      assert.equal(await tryListen(port), 'EADDRINUSE')
+
+      // Capture the standby state at the moment the child would fork.
+      let standbyAtForkTime = 'unset'
+      const realFork = supervisor._fork.bind(supervisor)
+      supervisor._fork = (script, args, opts) => {
+        standbyAtForkTime = supervisor._standbyServer
+        return realFork(script, args, opts)
+      }
+
+      supervisor.startChild()
+
+      // The port must have been released before the fork, so the child can bind.
+      assert.equal(standbyAtForkTime, null, 'standby server must be stopped before the replacement child forks')
+
+      // No pending restart timer to leak into other tests.
+      if (supervisor._restartTimer) { clearTimeout(supervisor._restartTimer); supervisor._restartTimer = null }
     })
 
     it('emits child_exit event on crash', async () => {

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -313,9 +313,12 @@ describe('Supervisor', () => {
       const port = await findFreePort()
       const { supervisor } = setup({ port })
 
-      // Stand up a real standby health server, as the crash path does.
+      // Stand up a real standby health server, as the crash path does. Keep a
+      // handle to the server object — _stopStandbyServer() nulls the field, but
+      // we still need to observe its 'close' to prove the port is released.
       supervisor._startStandbyServer()
-      await new Promise((resolve) => supervisor._standbyServer.once('listening', resolve))
+      const standby = supervisor._standbyServer
+      await new Promise((resolve) => standby.once('listening', resolve))
 
       // Sanity: the standby genuinely holds the port (real-listener check) — a
       // fresh listener on it must fail, mirroring what the forked child sees.
@@ -331,8 +334,17 @@ describe('Supervisor', () => {
 
       supervisor.startChild()
 
-      // The port must have been released before the fork, so the child can bind.
+      // startChild() must stop the standby before forking.
       assert.equal(standbyAtForkTime, null, 'standby server must be stopped before the replacement child forks')
+
+      // …and the stop must ACTUALLY release the port, not just null the field:
+      // once the standby socket finishes closing, the port is bindable again
+      // (server.close() releases the listening socket; the real child cannot
+      // call listen() before this tick — it is a separate forked process that
+      // must spawn + init Node + load modules first, far longer than one loop
+      // tick). This closes the "test passes while the port is still bound" gap.
+      await new Promise((resolve) => standby.once('close', resolve))
+      assert.equal(await tryListen(port), null, 'standby close must release the port for the child to bind')
 
       // No pending restart timer to leak into other tests.
       if (supervisor._restartTimer) { clearTimeout(supervisor._restartTimer); supervisor._restartTimer = null }


### PR DESCRIPTION
## Problem (critical — service-killing)

Found by the 2026-06-15 swarm hardening audit (P0-1, the only critical finding).

After a supervised child crashes, the exit handler calls `_startStandbyServer()` to serve `{"status":"restarting"}` on the daemon port while the child is down. The standby was only stopped on the child's `ready` IPC message (`_stopStandbyServer()` in the message handler). But the **replacement child cannot bind the port the standby is still holding** — it exits with `EADDRINUSE` *before* sending `ready`, so `_stopStandbyServer()` never runs. The standby stays up, every backoff-driven restart hits the same `EADDRINUSE`, and the supervisor burns through its restart budget to the cap — **silently bricking the daemon on the first crash**.

This was invisible to the existing tests because they mock `_fork`, so no child ever actually binds a port.

## Fix

Call `_stopStandbyServer()` at the top of `startChild()` (right after clearing the restart timer), freeing the port **before** the replacement child forks and listens. The call is idempotent (no-op when no standby is running, e.g. the first start). `close()` releases the listening socket; the standby has no keep-alive clients to drain. There is a sub-second window where the port serves neither standby nor child — far preferable to a guaranteed crash-loop, and the standby is re-armed by the next exit if the child fails again.

## Test

`supervisor.test.js` — new regression that stands up a **real** standby listening socket, asserts it genuinely holds the port (`EADDRINUSE` on a fresh `listen`), then asserts `_standbyServer === null` at the moment the replacement child forks. A mocked-fork-only test cannot catch this class of bug, so the test uses a real socket.

All 58 supervisor tests pass.