### PR TITLE
fix(server): scope cloudflared cold-start timeout to the attempt, not the adapter (P0-2)

### DIFF
--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -95,6 +95,13 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       this.process = proc
       let resolved = false
+      // Per-attempt cold-start timeout flag. Must NOT reuse the instance-wide
+      // `intentionalShutdown` kill switch: a 30s cold-start timeout is exactly
+      // the transient failure the `start()` retry loop exists to absorb, but
+      // setting `intentionalShutdown` makes that loop give up (base.js:95) AND
+      // suppresses every future recovery. Scope the suppression to this one
+      // process so the retry budget and post-success recovery both survive.
+      let timedOut = false
 
       const httpUrl = `https://${this.tunnelHostname}`
       const wsUrl = `wss://${this.tunnelHostname}`
@@ -137,7 +144,10 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
         if (!resolved) {
           const tail = redactSensitive(outputTailRaw).trim()
           reject(new Error(`cloudflared exited with code ${code} before establishing tunnel${tail ? `. Last output: ${tail}` : ''}`))
-        } else {
+        } else if (!timedOut) {
+          // A cold-start timeout already rejected and killed the process; the
+          // `start()` retry loop owns the retry decision, so don't treat that
+          // kill as a mid-session outage to recover from.
           void this._handleUnexpectedExit(code, signal).catch((err) => {
             log.error(`Error while handling unexpected cloudflared exit: ${err.stack || err.message || err}`)
           })
@@ -152,7 +162,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       const timeoutHandle = setTimeout(() => {
         if (!resolved) {
           resolved = true
-          this.intentionalShutdown = true
+          timedOut = true
           proc.kill()
           const tail = redactSensitive(outputTailRaw).trim()
           reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)${tail ? ` Last output: ${tail}` : ''}`))
@@ -178,6 +188,9 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       this.process = proc
       let resolved = false
+      // Per-attempt cold-start timeout flag — see _startNamedTunnel for why this
+      // must not reuse the instance-wide `intentionalShutdown` kill switch.
+      let timedOut = false
 
       const handleOutput = (data) => {
         const text = data.toString()
@@ -214,7 +227,10 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       proc.on('close', (code, signal) => {
         if (!resolved) {
           reject(new Error(`cloudflared exited with code ${code} before establishing tunnel`))
-        } else {
+        } else if (!timedOut) {
+          // A cold-start timeout already rejected and killed the process; the
+          // `start()` retry loop owns the retry decision, so don't treat that
+          // kill as a mid-session outage to recover from.
           void this._handleUnexpectedExit(code, signal).catch((err) => {
             log.error(`Error while handling unexpected cloudflared exit: ${err.stack || err.message || err}`)
           })
@@ -226,7 +242,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       const timeoutHandle = setTimeout(() => {
         if (!resolved) {
           resolved = true
-          this.intentionalShutdown = true
+          timedOut = true
           proc.kill()
           reject(new Error('Tunnel timed out after 30s. Is cloudflared installed? (brew install cloudflared)'))
         }

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -264,6 +264,37 @@ describe('CloudflareTunnelAdapter', () => {
     })
   })
 
+  describe('cold-start timeout', () => {
+    // Regression: the 30s cold-start timeout used to set the instance-wide
+    // `intentionalShutdown` kill switch. That (a) made start()'s retry loop give
+    // up on the very transient failure it exists to absorb, and (b) suppressed
+    // ALL future recovery for the adapter's lifetime. The timeout must scope its
+    // suppression to the timed-out process only.
+    it('does not set intentionalShutdown or trigger recovery (#5851)', async () => {
+      // A process that never emits a URL and never closes on its own, so only
+      // the 30s timeout can resolve the start promise.
+      const proc = createMockProcess({ skipDefaultUrl: true })
+      const tunnel = new TestCloudflareAdapter({ port: 3000, mode: 'quick', mockSpawn: () => proc })
+
+      let recoveryCalled = false
+      tunnel._handleUnexpectedExit = async () => { recoveryCalled = true }
+
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        const startP = tunnel._startQuickTunnel()
+        mock.timers.tick(30_000) // fire the cold-start timeout
+        await assert.rejects(startP, /timed out after 30s/)
+        // The timeout's proc.kill() emits 'close' on a setImmediate (real timer).
+        await new Promise((resolve) => setImmediate(resolve))
+      } finally {
+        mock.timers.reset()
+      }
+
+      assert.equal(tunnel.intentionalShutdown, false, 'cold-start timeout must not poison the instance-wide kill switch')
+      assert.equal(recoveryCalled, false, 'a timeout-killed process must not be treated as a mid-session outage')
+    })
+  })
+
   describe('stop', () => {
     it('sets intentionalShutdown and does NOT trigger recovery', async () => {
       const mockSpawn = () => createMockProcess()


### PR DESCRIPTION
## Problem (high — disables all future tunnel recovery)

Found by the 2026-06-15 swarm hardening audit (P0-2).

Both `_startNamedTunnel` and `_startQuickTunnel` arm a 30s cold-start timeout. On fire it set the **instance-wide** `intentionalShutdown` kill switch, then killed the cloudflared process. `intentionalShutdown` is the adapter's "we asked for this, don't recover" flag, and it has two consumers:

1. `BaseTunnelAdapter.start()`'s bounded retry loop checks `if (this.intentionalShutdown) throw` (base.js:95) — so a single cold-start timeout **aborts the remaining retry attempts**, even though a 30s timeout is exactly the transient upstream hiccup that retry loop exists to absorb.
2. `_handleUnexpectedExit` early-returns when `intentionalShutdown` is set — and since it stays set, **all future recovery is suppressed** for the adapter's lifetime.

The tunnel dropping is the single most common real-world failure for a phone client, so silently disabling recovery is a serious reliability regression.

## Fix

Replace the instance-wide flag write with a **per-attempt closure-local `timedOut`** flag. The `close` handler skips `_handleUnexpectedExit` when the process was killed by its own timeout (`else if (!timedOut)`), and `intentionalShutdown` is never touched by the timeout — so the retry budget and post-success recovery both survive. Applied symmetrically to named and quick tunnels.

## Test

`tunnel/cloudflare.test.js` — new test drives the cold-start timeout via `mock.timers`, asserts the start rejects with the timeout message, and asserts `intentionalShutdown === false` and that the timeout-killed process does **not** trigger `_handleUnexpectedExit`.

All 21 cloudflare adapter tests pass.