### PR TITLE
fix(server): preserve worktrees on shutdown so worktree sessions can restore (P0-3)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1565,9 +1565,15 @@ export class SessionManager extends EventEmitter {
       } catch (destroyErr) {
         log.error(`Error destroying session ${sessionId} "${entry.name}" during destroyAll(): ${destroyErr?.stack || destroyErr}`)
       }
-      if (entry.worktreePath) {
-        this._removeWorktree(entry.worktreePath, entry.worktreeRepoDir, sessionId)
-      }
+      // Do NOT remove the worktree here. destroyAll() is a process-shutdown
+      // teardown, not a user-initiated session destroy: the session was just
+      // serialized as live above, and on the next start restoreState() rebinds
+      // it to this exact worktree dir (#5310). Deleting it now orphaned the
+      // restore — the worktree session came back pointing at a directory that
+      // no longer existed, losing any uncommitted work in it. Worktree removal
+      // belongs only in destroySessionLocked() (the explicit per-session
+      // destroy). Orphan worktrees from sessions that DON'T come back are
+      // swept at boot — see worktree-gc (P1-7 follow-up).
       this.emit('session_destroyed', { sessionId })
     }
     this._sessions.clear()

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -155,7 +155,12 @@ describe('SessionManager worktree isolation', () => {
     mgr.destroyAll()
   })
 
-  it('destroyAll removes all worktrees', () => {
+  // destroyAll() is a process-shutdown teardown, NOT a user destroy. It must
+  // PRESERVE worktrees so restoreState() can rebind them on the next start.
+  // Pre-fix it deleted them, so on restart the serialized worktree sessions
+  // pointed at directories that no longer existed and could never restore
+  // (losing any uncommitted work in them).
+  it('destroyAll PRESERVES worktrees for restore (does not delete them)', () => {
     const mgr = makeManager(gitRepo)
 
     const id1 = mgr.createSession({ cwd: gitRepo, worktree: true })
@@ -169,8 +174,41 @@ describe('SessionManager worktree isolation', () => {
 
     mgr.destroyAll()
 
-    assert.ok(!existsSync(path1), 'worktree 1 should be removed after destroyAll')
-    assert.ok(!existsSync(path2), 'worktree 2 should be removed after destroyAll')
+    assert.ok(existsSync(path1), 'worktree 1 must survive a shutdown destroyAll')
+    assert.ok(existsSync(path2), 'worktree 2 must survive a shutdown destroyAll')
+  })
+
+  // End-to-end restart regression: a worktree session must survive a full
+  // shutdown (destroyAll) + restart (fresh manager restoreState) cycle. This is
+  // the realistic path destroyAll's worktree deletion broke.
+  it('worktree session survives a destroyAll + restore restart cycle', () => {
+    const mgr = makeManager(gitRepo)
+    const id = mgr.createSession({ cwd: gitRepo, worktree: true })
+    const wtPath = mgr.getSession(id).worktreePath
+    assert.ok(wtPath && existsSync(wtPath), 'worktree created')
+
+    // Drop an uncommitted file into the worktree to prove work is preserved.
+    const scratch = join(wtPath, 'uncommitted-work.txt')
+    writeFileSync(scratch, 'in-progress work that must not be deleted on shutdown')
+
+    // Full shutdown: serializes state, then tears sessions down.
+    mgr.destroyAll()
+    assert.ok(existsSync(wtPath), 'worktree dir survives shutdown')
+    assert.ok(existsSync(scratch), 'uncommitted work survives shutdown')
+
+    // Restart: a fresh manager over the same state file rebinds the session.
+    const mgr2 = makeManager(gitRepo)
+    mgr2.restoreState()
+
+    const r = mgr2.getSession(id)
+    assert.ok(r, 'worktree session restored after restart')
+    assert.equal(r.worktreePath, wtPath, 'rebound to the same worktree')
+    assert.equal(r.isolation, 'worktree', 'isolation preserved across restart')
+    assert.ok(existsSync(scratch), 'uncommitted work intact after restore')
+
+    mgr2.destroySession(id)
+    assert.ok(!existsSync(wtPath), 'explicit destroySession still GCs the worktree')
+    mgr2.destroyAll()
   })
 
   // #5310 (WP-0.4) — the worktree binding must survive a daemon restart.


### PR DESCRIPTION
## Problem (high — worktree sessions never restore; uncommitted work lost)

Found by the 2026-06-15 swarm hardening audit (P0-3).

`destroyAll()` is the process-**shutdown** teardown. It first `serializeState()`s every session as live — including worktree sessions, with their `worktreePath`/`worktreeRepoDir` — so that `restoreState()` can rebind them on the next start (#5310). But the same loop then called `_removeWorktree()` for every session, **deleting the worktrees it had just serialized as live**. On restart, the restored worktree sessions pointed at directories that no longer existed: the session could not restore, and any uncommitted work in the worktree was gone.

Per-session `destroySessionLocked()` deleting the worktree is correct — the user explicitly destroyed that session. Doing it on shutdown is not.

## Fix

Remove the worktree deletion from `destroyAll()`'s loop (keep `session.destroy()` to close the PTY/subprocess). Worktree removal now lives only in `destroySessionLocked()`. Orphan worktrees from sessions that genuinely don't come back are a separate concern handled by a boot-time GC sweep (audit P1-7 follow-up).

## Tests

- **Inverted** the test that codified the deletion (`destroyAll removes all worktrees` → `destroyAll PRESERVES worktrees for restore`).
- **New end-to-end regression**: create a worktree session, drop an uncommitted file in it, `destroyAll()` (shutdown), then restore with a fresh manager — asserts the session rebinds to the same worktree, isolation is preserved, and the uncommitted file is intact. Also confirms an explicit `destroySession` still GCs the worktree.

All 253 session-manager tests pass.