### PR TITLE
fix(server): treat all Claude-family providers (incl. default claude-tui) as Claude (P0-5)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1059,12 +1059,25 @@ const defaultRegistry = createModelsRegistry({ overlay: defaultOverlay })
  */
 const providerRegistryCache = new Map()
 
+// Every Claude-family provider id registered in providers.js. These all run the
+// real `claude` against the moving-target model allowlist that the Agent SDK
+// pushes live, so an unknown initial model must soft-fall-back to the provider
+// default rather than hard-reject (see isClaudeProvider). Keep in sync with the
+// claude-* / docker-* entries in the PROVIDERS literal — notably claude-tui,
+// the DEFAULT_PROVIDER (@chroxy/protocol): omitting it made the default
+// provider hard-reject a stale dashboard model id where every other Claude
+// provider recovers. (Longer-term this set should derive from a single
+// `static claudeFamily = true` on the provider classes — audit P2.)
 const CLAUDE_PROVIDER_NAMES = new Set([
   'claude-sdk',
   'claude-cli',
+  'claude-tui',
+  'claude-channel',
+  'claude-byok',
   'docker',
   'docker-sdk',
   'docker-cli',
+  'docker-byok',
 ])
 
 /**

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd } from '../src/models.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider } from '../src/models.js'
+import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 
 describe('FALLBACK_MODELS (default registry)', () => {
   it('is deep-frozen so getModels() callers cannot mutate the constant', () => {
@@ -811,5 +812,39 @@ describe('computePromptCostUsd()', () => {
       // 300K * 1/Mtok = 0.3 (Haiku base input rate, NOT a doubled 0.6)
       assert.ok(Math.abs(cost - 0.3) < 1e-6, `Haiku 300K must stay on base, got ${cost}`)
     })
+  })
+})
+
+describe('isClaudeProvider — Claude-family provider allowlist', () => {
+  // Every Claude-family provider runs the real `claude` against the moving model
+  // allowlist the Agent SDK pushes live, so createSession must soft-fall-back an
+  // unknown initial model (not hard-reject). The set must cover ALL of them.
+  const CLAUDE_FAMILY = [
+    'claude-sdk', 'claude-cli', 'claude-tui', 'claude-channel', 'claude-byok',
+    'docker', 'docker-sdk', 'docker-cli', 'docker-byok',
+  ]
+
+  for (const name of CLAUDE_FAMILY) {
+    it(`treats ${name} as a Claude-family provider`, () => {
+      assert.equal(isClaudeProvider(name), true)
+    })
+  }
+
+  it('treats the DEFAULT_PROVIDER as Claude-family (so the default never hard-rejects a stale model)', () => {
+    // Regression guard: claude-tui became the default but was missing from the
+    // set, so the default provider hard-rejected stale dashboard model ids.
+    // If the default ever flips again, this fails until the set is updated.
+    assert.equal(isClaudeProvider(DEFAULT_PROVIDER), true, `DEFAULT_PROVIDER ${DEFAULT_PROVIDER} must be in CLAUDE_PROVIDER_NAMES`)
+  })
+
+  it('does not treat non-Claude providers as Claude-family', () => {
+    for (const name of ['codex', 'gemini', 'deepseek', 'ollama', 'unknown-provider']) {
+      assert.equal(isClaudeProvider(name), false, `${name} must not be Claude-family`)
+    }
+  })
+
+  it('honours the static claudeFamily flag for external providers', () => {
+    assert.equal(isClaudeProvider('some-external', { claudeFamily: true }), true)
+    assert.equal(isClaudeProvider('some-external', { claudeFamily: false }), false)
   })
 })

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -844,7 +844,11 @@ describe('isClaudeProvider — Claude-family provider allowlist', () => {
   })
 
   it('honours the static claudeFamily flag for external providers', () => {
-    assert.equal(isClaudeProvider('some-external', { claudeFamily: true }), true)
-    assert.equal(isClaudeProvider('some-external', { claudeFamily: false }), false)
+    // Match the real call site: a ProviderClass with a static claudeFamily flag,
+    // not a plain object (createSession passes the provider class).
+    class ClaudeFamilyProvider { static claudeFamily = true }
+    class NonClaudeProvider { static claudeFamily = false }
+    assert.equal(isClaudeProvider('some-external', ClaudeFamilyProvider), true)
+    assert.equal(isClaudeProvider('some-external', NonClaudeProvider), false)
   })
 })


### PR DESCRIPTION
## Problem (high — default provider hard-rejects valid sessions)

Found by the 2026-06-15 swarm hardening audit (P0-5).

`isClaudeProvider()` (backed by `CLAUDE_PROVIDER_NAMES`) decides, in `SessionManager.createSession`, whether an unknown initial model is a **hard rejection** or a **soft fall-back** to the provider default. Claude's allowlist is a moving target pushed live by the Agent SDK, so a stale dashboard `defaultModel` (e.g. `opus-4-6` after `opus-4-7` ships) must soft-fall-back — a hard error breaks otherwise-valid session creation.

The set listed only `claude-sdk`/`claude-cli` and the docker SDK/CLI aliases. It **omitted `claude-tui`** — the `DEFAULT_PROVIDER` since the metered cutover (#5819/#5822) — plus `claude-channel`, `claude-byok`, and `docker-byok`. So the now-default provider hard-rejected stale model ids where every other Claude provider recovers gracefully.

## Fix

Add `claude-tui`, `claude-channel`, `claude-byok`, and `docker-byok` to `CLAUDE_PROVIDER_NAMES`, with a comment tying it to the `claude-*`/`docker-*` entries in the `PROVIDERS` literal and noting the longer-term `static claudeFamily` single-source-of-truth (audit P2-1).

## Test

`models.test.js` — new `isClaudeProvider` block covers every Claude-family id, asserts non-Claude providers (codex/gemini/deepseek/ollama) stay strict, honours the `static claudeFamily` flag, and — the regression guard — anchors on `DEFAULT_PROVIDER` so a future default flip fails the test until the set is updated.

All models + per-provider + preflight tests pass (165 total).