### PR TITLE
fix(server): require primary token to DELETE a host snapshot (audit P1-6)

### DIFF
--- a/docs/security/bearer-token-authority.md
+++ b/docs/security/bearer-token-authority.md
@@ -98,7 +98,7 @@ The following HTTP routes ([`http-routes.js`](../../packages/server/src/http-rou
 | `POST /pair-discord` | Mints a fresh approval-gated pairing id and posts its `chroxy://` link to Discord (#5513) — gated from day one. |
 | `DELETE /api/snapshots/:slug` | Host-level mutation: removes a docker image + sidecar shared across all sessions, beyond one session's scope (#5074 / audit P1-6). The `GET /api/snapshots` list stays read-only on `_validateBearerAuth`. |
 
-All five are exercised only by the daemon's **own dashboard** (`getAuthToken()` → the host's primary token via `?token=`/cookie) or the local **CLI** (`chroxy pair-code` → `connection.json` apiToken). The desktop LAN client's "Have a code?" flow (#5512) does NOT fetch these over HTTP — it takes a code typed off the host's screen and drives the WebSocket `pair` handshake directly, so no legitimate caller relies on a pairing-bound token reaching these endpoints.
+All six are exercised only by the daemon's **own dashboard** (`getAuthToken()` → the host's primary token via `?token=`/cookie) or the local **CLI** (`chroxy pair-code` → `connection.json` apiToken). The desktop LAN client's "Have a code?" flow (#5512) does NOT fetch these over HTTP — it takes a code typed off the host's screen and drives the WebSocket `pair` handshake directly, so no legitimate caller relies on a pairing-bound token reaching these endpoints.
 
 The remaining bearer-gated HTTP routes (`/version`, `/metrics`, `/diagnostics`, `GET /api/snapshots`, `/api/pool/stats`) are read-only operational telemetry that exposes no pairing or credential material, so they stay on `_validateBearerAuth` (any valid token). Note the `DELETE /api/snapshots/:slug` mutation is the exception — it is primary-only (see the table above).
 

--- a/docs/security/bearer-token-authority.md
+++ b/docs/security/bearer-token-authority.md
@@ -87,7 +87,7 @@ All three gates branch on `client.boundSessionId` and reject via `sendError` (a 
 
 The WS path distinguishes a bound token via `client.boundSessionId`. HTTP requests are stateless, so the equivalent gate is **`_validatePrimaryBearerAuth(req, res)`** ([`ws-server.js`](../../packages/server/src/ws-server.js)): it accepts a token only if it validates **and** is NOT a `PairingManager`-issued session token, rejecting bound tokens with `403 { "error": "primary_token_required" }`. This is the HTTP analog of the WS host-authority gate — `403` (not `401`) because the token IS valid, just an insufficient class.
 
-The following HTTP routes ([`http-routes.js`](../../packages/server/src/http-routes.js)) are gated on the primary token class. Each one either **mints/exposes live pairing material** (a bound device could otherwise transitively onboard further peers — "pairing-bound tokens can transitively mint peers") or **discloses the primary token itself**:
+The following HTTP routes ([`http-routes.js`](../../packages/server/src/http-routes.js)) are gated on the primary token class. Each one either **mints/exposes live pairing material** (a bound device could otherwise transitively onboard further peers — "pairing-bound tokens can transitively mint peers"), **discloses the primary token itself**, or **performs a host-level mutation beyond a single session's scope**:
 
 | Route | Why primary-only |
 |---|---|
@@ -96,10 +96,11 @@ The following HTTP routes ([`http-routes.js`](../../packages/server/src/http-rou
 | `GET /pairing-code` | Returns the current typeable linking code (#5512) and extends its grace window. |
 | `GET /connect` | Returns `connection.json`, which carries the **raw primary `apiToken`** and a `connectionUrl` embedding it whenever auth is required. A bound token reaching this escalates straight to the primary token. The body's redaction branch only fires when auth is *disabled*, so it is NOT the boundary. |
 | `POST /pair-discord` | Mints a fresh approval-gated pairing id and posts its `chroxy://` link to Discord (#5513) — gated from day one. |
+| `DELETE /api/snapshots/:slug` | Host-level mutation: removes a docker image + sidecar shared across all sessions, beyond one session's scope (#5074 / audit P1-6). The `GET /api/snapshots` list stays read-only on `_validateBearerAuth`. |
 
 All five are exercised only by the daemon's **own dashboard** (`getAuthToken()` → the host's primary token via `?token=`/cookie) or the local **CLI** (`chroxy pair-code` → `connection.json` apiToken). The desktop LAN client's "Have a code?" flow (#5512) does NOT fetch these over HTTP — it takes a code typed off the host's screen and drives the WebSocket `pair` handshake directly, so no legitimate caller relies on a pairing-bound token reaching these endpoints.
 
-The remaining bearer-gated HTTP routes (`/version`, `/metrics`, `/diagnostics`, `/api/snapshots*`, `/api/pool/stats`) are read-only operational telemetry that exposes no pairing or credential material, so they stay on `_validateBearerAuth` (any valid token).
+The remaining bearer-gated HTTP routes (`/version`, `/metrics`, `/diagnostics`, `GET /api/snapshots`, `/api/pool/stats`) are read-only operational telemetry that exposes no pairing or credential material, so they stay on `_validateBearerAuth` (any valid token). Note the `DELETE /api/snapshots/:slug` mutation is the exception — it is primary-only (see the table above).
 
 ## 5. Per-Session Hook Secrets
 

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -455,8 +455,13 @@ export function createHttpHandler(server) {
     // /api/snapshots returns, so the server never has to re-derive it
     // from the tag. Defence-in-depth: snapshots-store re-validates the
     // slug against the filename-safe charset before joining it to a path.
+    //
+    // Host-level mutation (removes a docker image + sidecar shared across all
+    // sessions), so it requires PRIMARY authority — a bound (share-a-session)
+    // token must not delete host snapshots. Mirrors the /api/pages DELETE gate.
+    // The GET list above stays on _validateBearerAuth (reads are open). (#5074 / audit P1-6)
     if (req.method === 'DELETE' && snapPath.startsWith('/api/snapshots/')) {
-      if (!server._validateBearerAuth(req, res)) return
+      if (!server._validatePrimaryBearerAuth(req, res)) return
       const rawSlug = snapPath.slice('/api/snapshots/'.length)
       let slug
       try {

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -779,6 +779,28 @@ describe('http-routes', () => {
       assert.equal(existsSync(join(workDir, 'snapshots', 'snap-protected.json')), true)
     })
 
+    // Audit P1-6: deleting a snapshot removes a host docker image + sidecar
+    // shared across all sessions — a host-level mutation that requires PRIMARY
+    // authority. A bound (pairing / share-a-session) token must be rejected.
+    it('DELETE /api/snapshots/:slug rejects a bound (pairing) token with primary_token_required', async () => {
+      writeSidecar('snap-bound', { tag: 'chroxy-byok-snap:bound' })
+      const removed = []
+      const mock = createMockServer({
+        _snapshotRemoveImage: async (tag) => { removed.push(tag) },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/snapshots/snap-bound`, {
+        method: 'DELETE',
+        headers: { 'Authorization': 'Bearer pairing-bound' },
+      })
+      assert.equal(res.status, 403)
+      const body = await res.json()
+      assert.equal(body.error, 'primary_token_required')
+      // Rejected before any host mutation.
+      assert.deepEqual(removed, [])
+      assert.equal(existsSync(join(workDir, 'snapshots', 'snap-bound.json')), true)
+    })
+
     // #5101 — when env-management is disabled, resolveRemoveImage falls
     // through to lazily constructing a DockerBackend. Caching that init
     // avoids re-running the dynamic `import()` and re-allocating a


### PR DESCRIPTION
## Problem (security — host mutation reachable by a bound token)

Found by the 2026-06-15 swarm hardening audit (P1-6).

`DELETE /api/snapshots/:slug` runs `docker rmi` + unlinks the sidecar — a **host-level mutation** affecting a resource shared across all sessions. But it was gated on `_validateBearerAuth`, which accepts bound (pairing / share-a-session) tokens. A shared-session viewer could therefore delete the operator's host snapshots (a DoS on host state), even though every other host-level mutation (`/api/pages` DELETE, pairing routes, etc.) requires the primary token class.

## Fix

Switch the gate to `_validatePrimaryBearerAuth`, mirroring the `DELETE /api/pages/:slug` route. Bound tokens now get `403 { "error": "primary_token_required" }`. The `GET /api/snapshots` list stays on `_validateBearerAuth` — reads are open, only the mutation is gated.

## Docs + test

- `bearer-token-authority.md` — added `DELETE /api/snapshots/:slug` to the primary-only table (broadening the table's rationale to include "host-level mutation beyond a single session's scope"), and corrected the read-only-routes line so `/api/snapshots*` no longer implies the DELETE is open.
- Test: a bound token (`Bearer pairing-bound`) gets `403 primary_token_required`, and the host mutation does not run (no image removed, sidecar intact).

All 50 http-routes tests pass.