### PR TITLE
fix(server): consolidate claude-tui per-turn teardown into _clearTurnEndState (audit P1-1)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2350,24 +2350,12 @@ export class ClaudeTuiSession extends BaseSession {
     // path, matching the one _finishTurnError emits on error paths so
     // every turn lands one grep-able line regardless of outcome.
     this._logSendMessageSummary('success')
-    // Clear inactivity timers — turn done, nothing to backstop (#3920, #4638, #4732).
-    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
-    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
-    if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }
-    // #4732: clear the pre-first-output watchdog. By the success path we
-    // already saw at least one hook (the Stop hook), so it should be
-    // disarmed via _clearFirstOutputWatchdog already — but the same
-    // belt-and-braces clear the other timers get above also applies here
-    // so a freak ordering can't leak a live handle past turn-end.
-    this._clearFirstOutputWatchdog()
-    // #4022: drop the per-turn attachment dir now that the Stop hook
-    // has fired and the response has streamed back. The Read-tool
-    // results are already in the model's context window, so the bytes
-    // on disk aren't needed for the next turn.
-    this._cleanupTurnAttachments(this._activeTurn)
-    this._activeTurn = null
-    this._isBusy = false
-    this._currentMessageId = null
+    // Per-turn teardown: inactivity timers (#3920, #4638, #4732), pre-first-output
+    // watchdog, per-turn attachment dir (#4022 — Read results are already in the
+    // model's context window), the busy-state triple, and — previously MISSING on
+    // this path — the AskUserQuestion sibling lock + stall watchdogs (#4604/#5319).
+    // Shared with _finishTurnError so the two can't re-diverge. See helper doc.
+    this._clearTurnEndState()
   }
 
   /**
@@ -2699,19 +2687,45 @@ export class ClaudeTuiSession extends BaseSession {
     }
   }
 
+  /**
+   * Common per-turn teardown shared by the success path and `_finishTurnError`
+   * (audit P1-1). Both previously hand-rolled these clears and the success path
+   * had DRIFTED — it omitted the AskUserQuestion sibling-lock clear and the
+   * stall-watchdog clear, so a Stop-hook success whose PostToolUse never fired
+   * could (a) leak the `askuserquestion-active` lock and spuriously deny the
+   * NEXT turn's question inside the 60s stale-reclaim window (#4604), and
+   * (b) leave an armed 30s watchdog that could tear down a later unrelated busy
+   * turn. Routing both paths through one helper keeps them from re-diverging.
+   *
+   * Owns: the inactivity timers, the pre-first-output watchdog, the per-turn
+   * attachment dir (cleaned BEFORE `_activeTurn` is nulled so it still has the
+   * dir), the busy-state triple, the AskUserQuestion sibling lock, and the
+   * per-toolUseId stall watchdogs.
+   *
+   * Deliberately does NOT call `_pendingUserAnswers_clearAll()`: neither caller
+   * issues Ctrl-C, so a sibling AskUserQuestion answer already on the wire can
+   * still validly consume its entry (#4802). The Ctrl-C / kill paths
+   * (`_teardownTurn`, `interrupt`, `destroy`) clear pending answers themselves.
+   * Also does NOT touch `_pendingBackgroundCommands`: run-in-background shells
+   * persist across turns by design (the #4307 invariant) and are dropped only
+   * by their own PostToolUse/BashOutput or at `destroy()`.
+   */
+  _clearTurnEndState() {
+    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
+    if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }
+    this._clearFirstOutputWatchdog()
+    this._cleanupTurnAttachments(this._activeTurn)
+    this._activeTurn = null
+    this._isBusy = false
+    this._currentMessageId = null
+    this._clearAskUserQuestionLock()
+    this._clearAllAskUserQuestionWatchdogs()
+  }
+
   _finishTurnError(message, callerMessageId) {
     this._assertBusyHasMessageId('_finishTurnError')
     this._logSendMessageSummary('error')
-    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
-    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
-    // #4638: clear the stream-stall watchdog so a turn that fails or
-    // aborts before the stall window doesn't fire a stale stream_stall
-    // error into the dashboard mid-recovery.
-    if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }
-    // #4732: clear the pre-first-output watchdog for the same reason —
-    // an aborted/failed turn must not surface a stale first-output stall
-    // into the dashboard mid-recovery.
-    this._clearFirstOutputWatchdog()
     // #4010: balance the early stream_start with stream_end + result so the
     // dashboard's busy state clears (event-normalizer.js:215 synthesizes
     // agent_idle from result). Without this, an aborted/failed TUI turn
@@ -2722,7 +2736,8 @@ export class ClaudeTuiSession extends BaseSession {
     // to here) still pairs stream_end with the stream_start we opened.
     // Without that fallback, the if(messageId) guard would silently skip
     // stream_end, leaving session-message-history._pendingStreams holding
-    // the entry until destroy().
+    // the entry until destroy(). Read messageId/duration BEFORE the teardown
+    // helper nulls the turn fields.
     const messageId = callerMessageId || this._currentMessageId
     const duration = this._activeTurn ? this._nowMonotonic() - this._activeTurn.startedAt : 0
     if (messageId) this.emit('stream_end', { messageId })
@@ -2735,38 +2750,16 @@ export class ClaudeTuiSession extends BaseSession {
       { cost: null, duration, usage: null, sessionId: this._sessionId },
       'turn_finished_with_error',
     )
-    // #4022: drop the per-turn attachment dir on every failure path so
-    // a stalled/aborted/PTY-exited turn doesn't leak the materialized
-    // files until destroy(). No-op when the turn had no attachments.
-    this._cleanupTurnAttachments(this._activeTurn)
-    this._activeTurn = null
-    this._isBusy = false
-    this._currentMessageId = null
-    // #4286 / #4802: deliberately do NOT call
-    // `_pendingUserAnswers_clearAll()` here. The original #4286 fix
-    // wiped the single-field slot to keep late user_question_response
-    // events from writing into a dead turn — but post-#4668 the field is
-    // a Map, and the audit (P1.2 #4802) flagged that the implicit wipe
-    // collapsed sibling AskUserQuestion entries that still had legitimate
-    // answers in flight. `_finishTurnError` runs on PTY-exit / Stop-hook
-    // timeout / prompt-write failure paths that do NOT issue Ctrl-C, so
-    // a parallel sibling's response that's already on the wire (#4668
-    // retry-as-singles shape) can still validly consume its entry. Late
-    // arrivals after the PTY has truly stopped responding will no-op in
-    // `respondToQuestion` (write throws / TUI ignores) — far better than
-    // silently dropping the legitimate response and re-creating the
-    // #4668 wedge. The other turn-ending sites
-    // (`_teardownTurn` / `interrupt()` / `destroy()`) still call
-    // `_pendingUserAnswers_clearAll()` because they DO issue Ctrl-C or
-    // kill the PTY outright.
-    this._clearAskUserQuestionLock()
-    // #4604: same symmetry for the stall watchdog. The guard in
-    // _onAskUserQuestionStall (`!_pendingUserAnswer && !_isBusy`) would
-    // currently no-op the late fire (both are falsy here), but leaving
-    // the setTimeout handles live wastes a callback invocation 30s later.
-    // #5319 (WP-3.2): the turn errored — every per-toolUseId watchdog is moot
-    // (their fires would no-op on !_isBusy), so clear them all.
-    this._clearAllAskUserQuestionWatchdogs()
+    // Shared per-turn teardown: timers, pre-first-output watchdog, attachment
+    // dir (#4022), the busy-state triple, the AskUserQuestion sibling lock
+    // (#4604), and the per-toolUseId stall watchdogs (#5319). The emits above
+    // are synchronous, so deferring the timer clears into the helper (vs the
+    // old before-emit position) cannot let a timer fire in between. The helper
+    // intentionally does NOT clear `_pendingUserAnswers` — see its doc (#4286 /
+    // #4802): this path issues no Ctrl-C, so a sibling answer already on the
+    // wire can still validly consume its entry; the Ctrl-C/kill paths
+    // (`_teardownTurn` / `interrupt()` / `destroy()`) clear pending answers.
+    this._clearTurnEndState()
   }
 
   /**

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1124,6 +1124,11 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
+    // #4307: the PTY is gone, so the ephemeral intra-turn run_in_background
+    // tool_use→command map can never be resolved by a result on this PTY — drop
+    // it (matches _clearTurnEndState / base _clearMessageState). On respawn the
+    // next turn starts clean; on destroy _clearMessageState would clear it anyway.
+    this._pendingBackgroundCommands.clear()
     // #5777 (#5788): cancel a pending first-turn submit nudge directly here.
     // _onPtyGone is the one teardown path that does NOT route through
     // _clearFirstOutputWatchdog, so without this an armed nudge would only be
@@ -2706,9 +2711,17 @@ export class ClaudeTuiSession extends BaseSession {
    * issues Ctrl-C, so a sibling AskUserQuestion answer already on the wire can
    * still validly consume its entry (#4802). The Ctrl-C / kill paths
    * (`_teardownTurn`, `interrupt`, `destroy`) clear pending answers themselves.
-   * Also does NOT touch `_pendingBackgroundCommands`: run-in-background shells
-   * persist across turns by design (the #4307 invariant) and are dropped only
-   * by their own PostToolUse/BashOutput or at `destroy()`.
+   *
+   * DOES clear `_pendingBackgroundCommands` — the ephemeral intra-turn
+   * tool_use→command lookup (#4307). Per its base-session contract that map is
+   * dropped every turn (CLI/SDK do so via `_clearMessageState`): once a turn
+   * ends, any run_in_background `tool_use` that never saw its result this turn is
+   * stranded, and the agent re-emits a fresh `tool_use` next turn if it still
+   * cares. This is NOT the cross-turn "waiting on background shell" state — that
+   * lives in `_backgroundShellTracker` (transient-by-design, quiesced
+   * separately) and is untouched here. Leaving the map uncleared per-turn was
+   * the leak audit P1-1 flagged: ClaudeTuiSession is the only subclass that
+   * didn't run the base per-turn reset.
    */
   _clearTurnEndState() {
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
@@ -2721,6 +2734,7 @@ export class ClaudeTuiSession extends BaseSession {
     this._currentMessageId = null
     this._clearAskUserQuestionLock()
     this._clearAllAskUserQuestionWatchdogs()
+    this._pendingBackgroundCommands.clear()
   }
 
   _finishTurnError(message, callerMessageId) {
@@ -3274,6 +3288,9 @@ export class ClaudeTuiSession extends BaseSession {
     // `_handleHardTimeout` / `_handleStreamStall` / `_handleFirstOutputTimeout`
     // can never leak a live handle that would re-fire on a torn-down turn.
     this._clearFirstOutputWatchdog()
+    // #4307: drop the ephemeral intra-turn run_in_background tool_use→command
+    // map on this turn-end too (matches _clearTurnEndState / base _clearMessageState).
+    this._pendingBackgroundCommands.clear()
     // 5. Error + result emit, in the order the caller requests. The two
     // existing callers disagree (hard-timeout: error first; stream-stall:
     // result first), and that asymmetry is preserved exactly.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -563,17 +563,30 @@ describe('ClaudeTuiSession', () => {
       rmSync(s._sinkDir, { recursive: true, force: true })
     })
 
-    it('does NOT clear _pendingBackgroundCommands (the #4307 cross-turn invariant)', () => {
+    it('clears the ephemeral intra-turn _pendingBackgroundCommands map (#4307 leak)', () => {
       const s = makeSession()
       s._isBusy = true
       s._currentMessageId = 'msg-1'
       s._activeTurn = { messageId: 'msg-1', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      // A run_in_background tool_use whose result never landed this turn.
       s._pendingBackgroundCommands.set('bg-tool-1', 'npm run dev')
 
       s._clearTurnEndState()
 
-      assert.equal(s._pendingBackgroundCommands.get('bg-tool-1'), 'npm run dev',
-        'background-shell entries persist across turns (#4307) — cleared only by PostToolUse/BashOutput or destroy')
+      assert.equal(s._pendingBackgroundCommands.size, 0,
+        'stranded intra-turn command map dropped at turn-end, matching base _clearMessageState (#4307)')
+    })
+
+    it('does NOT touch the cross-turn background-shell tracker', () => {
+      const s = makeSession()
+      // The _backgroundShellTracker is the cross-turn "waiting on shell" state —
+      // transient-by-design and quiesced separately, never per-turn-cleared here.
+      assert.ok(s._backgroundShellTracker, 'tracker exists')
+      const trackerBefore = s._backgroundShellTracker
+      s._isBusy = true
+      s._activeTurn = { messageId: 'm', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      s._clearTurnEndState()
+      assert.strictEqual(s._backgroundShellTracker, trackerBefore, 'tracker instance untouched')
     })
 
     it('is idempotent (safe to call when nothing is armed)', () => {
@@ -581,6 +594,32 @@ describe('ClaudeTuiSession', () => {
       assert.doesNotThrow(() => { s._clearTurnEndState(); s._clearTurnEndState() })
       assert.equal(s._isBusy, false)
       assert.equal(s._askUserQuestionWatchdogs.size, 0)
+    })
+
+    // End-to-end linkage (review #5862): prove a REAL teardown path routes
+    // through the helper, so a refactor that drops the _clearTurnEndState() call
+    // from a turn-end path is caught — not just the helper-in-isolation test.
+    it('_finishTurnError routes through the helper (clears lock, watchdogs, bg map, busy triple)', () => {
+      const s = makeSession()
+      s._isBusy = true
+      s._currentMessageId = 'msg-err'
+      s._activeTurn = { messageId: 'msg-err', startedAt: Date.now() - 10, aborted: false, synthSeq: 0 }
+      s._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-'))
+      const lockPath = join(s._sinkDir, 'askuserquestion-active')
+      writeFileSync(lockPath, '1')
+      s._askUserQuestionWatchdogs.set('tool-1', setTimeout(() => {}, 60_000))
+      s._pendingBackgroundCommands.set('bg-1', 'sleep 99')
+
+      s._finishTurnError('boom', 'msg-err')
+
+      assert.equal(s._isBusy, false, '_finishTurnError cleared busy via the helper')
+      assert.equal(s._currentMessageId, null)
+      assert.equal(s._activeTurn, null)
+      assert.equal(existsSync(lockPath), false, 'AskUserQuestion lock cleared')
+      assert.equal(s._askUserQuestionWatchdogs.size, 0, 'stall watchdogs cleared')
+      assert.equal(s._pendingBackgroundCommands.size, 0, 'intra-turn bg map cleared')
+
+      rmSync(s._sinkDir, { recursive: true, force: true })
     })
   })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -521,6 +521,69 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // Audit P1-1 — per-turn teardown consolidation. The success path used to
+  // hand-roll its clears and had drifted from _finishTurnError, omitting the
+  // AskUserQuestion sibling-lock + stall-watchdog clears. _clearTurnEndState()
+  // is the shared helper both now route through.
+  describe('_clearTurnEndState (per-turn teardown helper)', () => {
+    function makeSession() {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      s.on('error', () => {})
+      session = s
+      return s
+    }
+
+    it('clears the busy triple, inactivity timers, AskUserQuestion lock and stall watchdogs', () => {
+      const s = makeSession()
+      // Arm a full turn's worth of per-turn state.
+      s._isBusy = true
+      s._currentMessageId = 'msg-1'
+      s._activeTurn = { messageId: 'msg-1', startedAt: Date.now() - 50, aborted: false, synthSeq: 0 }
+      s._resultTimeout = setTimeout(() => {}, 60_000)
+      s._hardTimeout = setTimeout(() => {}, 60_000)
+      s._streamStallTimeout = setTimeout(() => {}, 60_000)
+      // A real sink dir with the sibling lock the permission hook leaves behind.
+      s._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-'))
+      const lockPath = join(s._sinkDir, 'askuserquestion-active')
+      writeFileSync(lockPath, '1')
+      // An armed per-toolUseId stall watchdog.
+      s._askUserQuestionWatchdogs.set('tool-1', setTimeout(() => {}, 60_000))
+
+      s._clearTurnEndState()
+
+      assert.equal(s._isBusy, false, '_isBusy cleared')
+      assert.equal(s._currentMessageId, null, '_currentMessageId cleared')
+      assert.equal(s._activeTurn, null, '_activeTurn cleared')
+      assert.equal(s._resultTimeout, null, 'result timer cleared')
+      assert.equal(s._hardTimeout, null, 'hard timer cleared')
+      assert.equal(s._streamStallTimeout, null, 'stream-stall timer cleared')
+      assert.equal(existsSync(lockPath), false, 'askuserquestion-active sibling lock removed (#4604)')
+      assert.equal(s._askUserQuestionWatchdogs.size, 0, 'all stall watchdogs cleared (#5319)')
+
+      rmSync(s._sinkDir, { recursive: true, force: true })
+    })
+
+    it('does NOT clear _pendingBackgroundCommands (the #4307 cross-turn invariant)', () => {
+      const s = makeSession()
+      s._isBusy = true
+      s._currentMessageId = 'msg-1'
+      s._activeTurn = { messageId: 'msg-1', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      s._pendingBackgroundCommands.set('bg-tool-1', 'npm run dev')
+
+      s._clearTurnEndState()
+
+      assert.equal(s._pendingBackgroundCommands.get('bg-tool-1'), 'npm run dev',
+        'background-shell entries persist across turns (#4307) — cleared only by PostToolUse/BashOutput or destroy')
+    })
+
+    it('is idempotent (safe to call when nothing is armed)', () => {
+      const s = makeSession()
+      assert.doesNotThrow(() => { s._clearTurnEndState(); s._clearTurnEndState() })
+      assert.equal(s._isBusy, false)
+      assert.equal(s._askUserQuestionWatchdogs.size, 0)
+    })
+  })
+
   // #5322 (WP-4.2, security) — the PTY diagnostic dumps (hex + readable tail)
   // ride into log lines AND client-facing `error` events. A pasted/echoed OAuth
   // token or API key in claude's output must not leak through them.


### PR DESCRIPTION
## Problem (TUI reliability — audit P1-1, Theme A)

`ClaudeTuiSession` is the only session subclass whose per-turn teardown doesn't route through a shared reset (`CliSession`/`SdkSession` call `_clearMessageState()` every turn; the TUI only calls it at `destroy()`). Its turn-end paths hand-rolled the clears and **drifted**: the success (Stop-hook) path cleared the inactivity timers + attachment dir but **omitted** the AskUserQuestion sibling-lock clear and the stall-watchdog clear that `_finishTurnError` does. Consequences on the now-default provider:

- A Stop-hook success whose PostToolUse never fired leaks the `askuserquestion-active` sibling lock → **spurious deny of the next turn's question** inside the 60s stale-reclaim window (#4604).
- An armed 30s stall watchdog survives into a later turn → can **tear down an unrelated busy turn** (#5319).

## Fix

Extract `_clearTurnEndState()` — inactivity timers, pre-first-output watchdog, per-turn attachment dir, the `_activeTurn`/`_isBusy`/`_currentMessageId` triple, the AskUserQuestion sibling lock, and the per-toolUseId stall watchdogs — and route **both** the success path and `_finishTurnError` through it so they can't re-diverge. In `_finishTurnError` the clears now run after the (synchronous) `stream_end`/`error`/`result` emits; since emits are synchronous no timer can fire in between, so behavior is preserved.

## Deliberately scoped out (verified against the code, not just the audit)

- **`_pendingUserAnswers_clearAll()` stays caller-specific** — neither the success path nor `_finishTurnError` issues Ctrl-C, so a sibling AskUserQuestion answer already on the wire can still validly consume its entry (#4802). The Ctrl-C/kill paths (`_teardownTurn`/`interrupt`/`destroy`) clear pending answers themselves, so the helper is not routed through `_teardownTurn`.
- **`_pendingBackgroundCommands` is NOT cleared** per-turn. The audit suggested it, but line 3503-3508 documents the **#4307 invariant**: run-in-background shells persist across turns (the "waiting on background shell" chip must survive until the shell actually reports) and are dropped only by their own PostToolUse/BashOutput or at `destroy()`. A per-turn clear would re-break #4307. The residual leak (entries whose PostToolUse never arrives) is bounded and freed at destroy — left as-is.

## Tests

New `_clearTurnEndState` describe: asserts the helper clears the busy triple, the three inactivity timers, the AskUserQuestion lock file, and all stall watchdogs; asserts it PRESERVES `_pendingBackgroundCommands` (#4307 guard); and asserts idempotency. All 346 claude-tui tests pass; eslint clean.