### PR TITLE
fix(server): dedup terminal-mirror gate + re-sync on active-session switch (audit P1-2)

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -214,6 +214,19 @@ export function isSessionViewer(client, sid) {
     Boolean(client.subscribedSessionIds && client.subscribedSessionIds.has(sid))
 }
 
+// #5835 / audit P1-2: the single predicate for who RECEIVES a session's live
+// terminal mirror — opted into the terminal (`terminalSessionIds`) AND a viewer
+// of the session (`isSessionViewer`). The delivery filter
+// (ws-forwarding's terminalSubscriberFilter) and the coalescer gate
+// (ws-server's _syncTerminalMirror) MUST use the SAME predicate: gate-true /
+// filter-false wastes the coalescer on nobody, and gate-false / filter-true is
+// a black terminal for a real viewer. Both inlined it before and could drift;
+// shared here so they can't.
+export function terminalMirrorRecipient(client, sid) {
+  return Boolean(client.terminalSessionIds && client.terminalSessionIds.has(sid)) &&
+    isSessionViewer(client, sid)
+}
+
 export function isPathWithin(absPath, baseDir) {
   if (absPath === baseDir) return true
   // Normalize: strip a trailing separator so filesystem root and

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events'
+import { createLogger } from './logger.js'
+
+const log = createLogger('ws-client-manager')
 
 // #5563: shared immutable empty Set returned by getSessionSubscribers when a
 // session has no indexed clients — avoids allocating per call on the hot path.
@@ -263,8 +266,11 @@ export class WsClientManager extends EventEmitter {
     // observes the new viewer state. Defensive try/catch: a listener failure
     // (e.g. mirror re-sync) must never corrupt the index. (audit P1-2)
     if (this._onActiveSessionChanged) {
+      // Best-effort: index integrity comes first, but log so a failing listener
+      // (e.g. a future _syncTerminalMirror edge case leaving the gate unsynced)
+      // is triageable instead of silently swallowed.
       try { this._onActiveSessionChanged(client, prev, sessionId) }
-      catch { /* listener is best-effort; index integrity comes first */ }
+      catch (err) { log.warn(`onActiveSessionChanged listener threw (index left intact): ${err?.message || err}`) }
     }
   }
 

--- a/packages/server/src/ws-client-manager.js
+++ b/packages/server/src/ws-client-manager.js
@@ -28,10 +28,21 @@ const EMPTY_SET = (() => {
  *   - 'client_departed'  ({ client })
  */
 export class WsClientManager extends EventEmitter {
-  constructor() {
+  /**
+   * @param {object} [opts]
+   * @param {(client: object, prev: string|null, next: string|null) => void} [opts.onActiveSessionChanged]
+   *   Invoked AFTER a client's active session actually changes (prev !== next),
+   *   with the index already updated. Lets the owner react to viewer-set changes
+   *   — e.g. re-sync the live terminal mirror gate for the old + new session
+   *   (audit P1-2) — from the single sanctioned mutation point, so every
+   *   setActiveSession caller (switch_session, checkpoint restore, conversation
+   *   switch, destroy re-home) inherits it instead of patching each call site.
+   */
+  constructor({ onActiveSessionChanged } = {}) {
     super()
     /** @type {Map<WebSocket, object>} */
     this.clients = new Map()
+    this._onActiveSessionChanged = typeof onActiveSessionChanged === 'function' ? onActiveSessionChanged : null
     // #5563: reverse index sessionId → Set<client> for O(subscribers) session
     // broadcasts and O(1) subscriber counts, instead of an O(clients) scan per
     // session-scoped message + a SECOND scan per buffered delta. A client is a
@@ -248,6 +259,13 @@ export class WsClientManager extends EventEmitter {
     if (prev) this._indexRemoveIfUnreferenced(client, prev)
     // The new active session always belongs in the index.
     if (sessionId) this._indexAdd(client, sessionId)
+    // Notify after the index + activeSessionId are settled so the listener
+    // observes the new viewer state. Defensive try/catch: a listener failure
+    // (e.g. mirror re-sync) must never corrupt the index. (audit P1-2)
+    if (this._onActiveSessionChanged) {
+      try { this._onActiveSessionChanged(client, prev, sessionId) }
+      catch { /* listener is best-effort; index integrity comes first */ }
+    }
   }
 
   /**

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -1,6 +1,7 @@
 import { createLogger } from './logger.js'
 import { getDefaultModelId, getRegistryForProvider } from './models.js'
 import { settlePush } from './push.js'
+import { terminalMirrorRecipient } from './handler-utils.js'
 
 const log = createLogger('ws-forwarding')
 
@@ -115,11 +116,7 @@ export function setupForwarding(ctx) {
  * broadcast can never reach a different audience than the bytes (#5840 review S2).
  */
 function terminalSubscriberFilter(sessionId) {
-  return (client) => Boolean(
-    client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
-    (client.activeSessionId === sessionId ||
-      (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))),
-  )
+  return (client) => terminalMirrorRecipient(client, sessionId)
 }
 
 /** Multi-session forwarding via normalizer */

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -29,6 +29,7 @@ import { createLogger, addLogListener, removeLogListener } from './logger.js'
 import { PermissionAuditLog } from './permission-audit.js'
 import { WsBroadcaster } from './ws-broadcaster.js'
 import { WsClientManager } from './ws-client-manager.js'
+import { terminalMirrorRecipient } from './handler-utils.js'
 import { getProviderDataDirs } from './providers.js'
 import { assertCtxShape } from './ws-handler-context.js'
 import { isLoopbackHost } from './bind-host.js'
@@ -570,7 +571,18 @@ export class WsServer {
       pagesDir: join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'pages'),
     })
     this._clientSend = createClientSender(log)
-    this._clientManager = new WsClientManager()
+    // audit P1-2: when a client's active session changes, re-sync the live
+    // terminal mirror gate for BOTH the session it left and the one it joined.
+    // Without this a client opted into session A's terminal that switches to B
+    // would fall out of A's delivery filter while A's coalescer kept running to
+    // nobody (the waste #5837/#5844 set out to kill). _syncTerminalMirror
+    // no-ops on a null id, so passing prev=null is safe.
+    this._clientManager = new WsClientManager({
+      onActiveSessionChanged: (client, prev, next) => {
+        this._syncTerminalMirror(prev)
+        this._syncTerminalMirror(next)
+      },
+    })
     this.clients = this._clientManager.clients // back-compat: expose the raw Map for context objects
     // #4835: per-device active-session memory. Caller can inject a custom
     // store (tests do this with a tmp file path); otherwise we construct
@@ -2192,16 +2204,11 @@ export class WsServer {
     if (typeof entry?.session?.setTerminalMirrorActive !== 'function') return
     let active = false
     for (const client of this.clients.values()) {
-      // Count a client only if it would actually RECEIVE terminal_output — i.e. it
-      // matches ws-forwarding's terminalSubscriberFilter: opted into the terminal
-      // (terminalSessionIds) AND a viewer of the session (active or subscribed).
-      // An opted-in-but-not-viewing client gets nothing, so it must not keep the
-      // coalescer running (#5844 review — align the gate with the delivery audience).
-      if (
-        client.terminalSessionIds && client.terminalSessionIds.has(sessionId) &&
-        (client.activeSessionId === sessionId ||
-          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId)))
-      ) {
+      // Count a client only if it would actually RECEIVE terminal_output — the
+      // SAME predicate ws-forwarding's terminalSubscriberFilter delivers on, so
+      // the coalescer gate and the delivery audience can never diverge (#5844
+      // review). Shared via terminalMirrorRecipient (audit P1-2).
+      if (terminalMirrorRecipient(client, sessionId)) {
         active = true
         break
       }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -578,7 +578,7 @@ export class WsServer {
     // nobody (the waste #5837/#5844 set out to kill). _syncTerminalMirror
     // no-ops on a null id, so passing prev=null is safe.
     this._clientManager = new WsClientManager({
-      onActiveSessionChanged: (client, prev, next) => {
+      onActiveSessionChanged: (_client, prev, next) => {
         this._syncTerminalMirror(prev)
         this._syncTerminalMirror(next)
       },

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -36,7 +36,35 @@ import {
   sendError,
   buildSessionTokenMismatchPayload,
   SESSION_TOKEN_MISMATCH_DEFAULT_MESSAGE,
+  isSessionViewer,
+  terminalMirrorRecipient,
 } from '../src/handler-utils.js'
+
+// audit P1-2: the live-terminal mirror recipient predicate. The delivery filter
+// (ws-forwarding) and the coalescer gate (ws-server) must use this same function
+// so the gate can never diverge from who actually receives terminal_output.
+describe('terminalMirrorRecipient', () => {
+  const viewerOpted = { activeSessionId: 's1', subscribedSessionIds: new Set(), terminalSessionIds: new Set(['s1']) }
+  const subscribedOpted = { activeSessionId: null, subscribedSessionIds: new Set(['s1']), terminalSessionIds: new Set(['s1']) }
+  const viewerNotOpted = { activeSessionId: 's1', subscribedSessionIds: new Set(), terminalSessionIds: new Set() }
+  const optedNotViewing = { activeSessionId: 's2', subscribedSessionIds: new Set(), terminalSessionIds: new Set(['s1']) }
+  const noTerminalSet = { activeSessionId: 's1', subscribedSessionIds: new Set() }
+
+  it('is true only when opted into the terminal AND viewing the session', () => {
+    assert.equal(terminalMirrorRecipient(viewerOpted, 's1'), true)
+    assert.equal(terminalMirrorRecipient(subscribedOpted, 's1'), true)
+    assert.equal(terminalMirrorRecipient(viewerNotOpted, 's1'), false, 'viewing but not opted in')
+    assert.equal(terminalMirrorRecipient(optedNotViewing, 's1'), false, 'opted in but viewing a different session')
+    assert.equal(terminalMirrorRecipient(noTerminalSet, 's1'), false, 'no terminalSessionIds set at all')
+  })
+
+  it('equals (opted-in AND isSessionViewer) — the contract the gate and filter share', () => {
+    for (const client of [viewerOpted, subscribedOpted, viewerNotOpted, optedNotViewing]) {
+      const expected = Boolean(client.terminalSessionIds && client.terminalSessionIds.has('s1')) && isSessionViewer(client, 's1')
+      assert.equal(terminalMirrorRecipient(client, 's1'), expected)
+    }
+  })
+})
 
 // -- Temp directory setup --
 let testDir

--- a/packages/server/tests/ws-client-manager.test.js
+++ b/packages/server/tests/ws-client-manager.test.js
@@ -635,4 +635,48 @@ describe('WsClientManager', () => {
       assert.strictEqual(manager.getPrimary('s1'), 'observer')
     })
   })
+
+  // audit P1-2: the active-session change hook is the single choke point ws-server
+  // uses to re-sync the live terminal mirror gate for the old + new session, so
+  // every setActiveSession caller (switch_session, checkpoint, conversation,
+  // re-home) inherits the invariant rather than patching each call site.
+  describe('onActiveSessionChanged hook', () => {
+    function createClientInfo(overrides = {}) {
+      return { id: 'c1', authenticated: true, activeSessionId: null, subscribedSessionIds: new Set(), _ws: createMockWs(1), ...overrides }
+    }
+
+    it('fires with (client, prev, next) after a real change, index already settled', () => {
+      const calls = []
+      const mgr = new WsClientManager({ onActiveSessionChanged: (c, prev, next) => calls.push({ id: c.id, prev, next, indexed: [...mgr.getSessionSubscribers(next || '')].length }) })
+      const client = createClientInfo()
+      mgr.addClient(client._ws, client)
+
+      mgr.setActiveSession(client, 's1')
+      mgr.setActiveSession(client, 's2')
+
+      assert.deepStrictEqual(calls, [
+        { id: 'c1', prev: null, next: 's1', indexed: 1 },
+        { id: 'c1', prev: 's1', next: 's2', indexed: 1 },
+      ])
+    })
+
+    it('does NOT fire when the active session is unchanged', () => {
+      let count = 0
+      const mgr = new WsClientManager({ onActiveSessionChanged: () => { count++ } })
+      const client = createClientInfo()
+      mgr.addClient(client._ws, client)
+      mgr.setActiveSession(client, 's1')
+      mgr.setActiveSession(client, 's1') // no-op (prev === next)
+      assert.strictEqual(count, 1)
+    })
+
+    it('a throwing listener does not corrupt the index', () => {
+      const mgr = new WsClientManager({ onActiveSessionChanged: () => { throw new Error('boom') } })
+      const client = createClientInfo()
+      mgr.addClient(client._ws, client)
+      assert.doesNotThrow(() => mgr.setActiveSession(client, 's1'))
+      assert.deepStrictEqual([...mgr.getSessionSubscribers('s1')].map(c => c.id), ['c1'])
+      mgr.verifyIndexIntegrity()
+    })
+  })
 })


### PR DESCRIPTION
## Problem (TUI reliability — audit P1-2, Theme B)

Two related defects in the live-terminal mirror (#5835):

**1. The recipient predicate was hand-duplicated and could drift.** "Opted into the terminal (`terminalSessionIds`) AND a viewer of the session" was inlined in both `ws-forwarding`'s `terminalSubscriberFilter` (the delivery filter) and `ws-server`'s `_syncTerminalMirror` (the coalescer gate), neither using the shared `isSessionViewer`. The gate and filter **must** be identical: gate-true/filter-false runs the coalescer for nobody (the waste #5844 fixed); gate-false/filter-true is a **black terminal for a real viewer**.

**2. Switching active session never re-synced the gate.** `setActiveSession` mutates `client.activeSessionId` — read by both the gate and the filter — but never called `_syncTerminalMirror`. A client opted into session A's terminal that switches to B falls out of A's delivery filter, yet **A's coalescer keeps running forever to nobody**. Masked today only because the dashboard happens to send a paired `terminal_unsubscribe`; breaks for mobile, reconnect races, or any future client.

## Fix

1. Extract `terminalMirrorRecipient(client, sid)` in `handler-utils.js` (`= opted-in AND isSessionViewer`) and call it from **both** `terminalSubscriberFilter` and `_syncTerminalMirror`. The gate is now provably the delivery audience.
2. Add an `onActiveSessionChanged(client, prev, next)` hook to `WsClientManager` — the single sanctioned active-session mutation point — and wire `ws-server` to `_syncTerminalMirror(prev)` + `_syncTerminalMirror(next)`. Every caller (switch_session, checkpoint restore, conversation switch, destroy re-home) inherits the re-sync instead of each call site having to remember it. The hook is defensive: a listener throw can't corrupt the index.

Note: the mirror **snapshot/resync** on backpressure-drop (Theme B finding 3) is a separate Device-validated item (audit P1-11), not in this PR.

## Tests

- `terminalMirrorRecipient` contract: true only when opted-in AND viewing; equals `opted-in && isSessionViewer` across all client shapes.
- `onActiveSessionChanged`: fires with `(client, prev, next)` after a real change (index already settled), does NOT fire on a no-op switch, and a throwing listener leaves the index intact.

All affected suites pass (ws-forwarding, ws-server*, ws-client-manager, handler-utils, claude-tui-mirror, session-handlers); eslint clean.