### PR TITLE
fix(server): recover parent repo for chroxy-worktree cwds in event ingest (P1-10, closes #5483)

### DIFF
--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -278,9 +278,8 @@ export function deriveProjectFromCwd(cwd, env = process.env) {
   }
   // chroxy session worktree → parent repo (or null), never the opaque id.
   const resolved = realResolve(cwd)
-  if (resolved && chroxyWorktreeTopDir(resolved, env)) {
-    return chroxyWorktreeParentProject(chroxyWorktreeTopDir(resolved, env))
-  }
+  const chroxyTop = resolved ? chroxyWorktreeTopDir(resolved, env) : null
+  if (chroxyTop) return chroxyWorktreeParentProject(chroxyTop)
   let current = dir
   // Bounded walk — terminates at the fs root anyway; the cap is paranoia
   // against pathological/cyclic resolutions.

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -27,7 +27,7 @@
 
 import { randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
-import { basename, dirname, join, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
 import { safeTokenCompare } from './token-compare.js'
 import { sendOversizeResponse } from './http-oversize.js'
@@ -207,9 +207,10 @@ export function ensureIngestSecret(secretPath = defaultIngestSecretPath()) {
  * (os.tmpdir() classification differs across platforms). Never set in prod.
  */
 function chroxyWorktreesRoot(env = process.env) {
-  const override = env?.CHROXY_WORKTREES_ROOT
-  if (typeof override === 'string' && override.trim().startsWith('/')) {
-    return realResolve(override.trim().replace(/\/+$/, ''))
+  const override = typeof env?.CHROXY_WORKTREES_ROOT === 'string' ? env.CHROXY_WORKTREES_ROOT.trim() : ''
+  // isAbsolute()/replace cover both POSIX (`/…`) and Windows (`C:\…`, `\\…`) roots.
+  if (override.length > 0 && isAbsolute(override)) {
+    return realResolve(override.replace(/[/\\]+$/, ''))
   }
   const home = typeof env?.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
   if (!home) return null
@@ -229,8 +230,12 @@ function realResolve(p) {
  */
 function chroxyWorktreeTopDir(dir, env = process.env) {
   const root = chroxyWorktreesRoot(env)
-  if (!root || !dir.startsWith(root + '/')) return null
-  const id = dir.slice(root.length + 1).split('/')[0]
+  if (!root) return null
+  // relative()/sep are separator-agnostic (POSIX `/` and Windows `\`). `dir`
+  // must be strictly inside root — a '..'/absolute relative means it escaped.
+  const rel = relative(root, dir)
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) return null
+  const id = rel.split(sep)[0]
   return id.length > 0 ? join(root, id) : null
 }
 
@@ -277,8 +282,10 @@ export function deriveProjectFromCwd(cwd, env = process.env) {
     return null
   }
   // chroxy session worktree → parent repo (or null), never the opaque id.
-  const resolved = realResolve(cwd)
-  const chroxyTop = resolved ? chroxyWorktreeTopDir(resolved, env) : null
+  // Reuse the already-resolved `dir`; realpath best-effort (macOS /tmp → /private/tmp).
+  let resolved
+  try { resolved = realpathSync(dir) } catch { resolved = dir }
+  const chroxyTop = chroxyWorktreeTopDir(resolved, env)
   if (chroxyTop) return chroxyWorktreeParentProject(chroxyTop)
   let current = dir
   // Bounded walk — terminates at the fs root anyway; the cap is paranoia

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -26,7 +26,7 @@
  */
 
 import { randomBytes } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
 import { basename, dirname, join, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { safeTokenCompare } from './token-compare.js'
@@ -194,19 +194,92 @@ export function ensureIngestSecret(secretPath = defaultIngestSecretPath()) {
 }
 
 /**
+ * #5483/#5850: chroxy's SECOND worktree source — session worktrees the daemon
+ * creates at `~/.chroxy/worktrees/<sessionId>`. Their basename is an OPAQUE hex
+ * session id, so the plain git-root walk below would name the project after the
+ * id instead of the real repo. This mirrors the hook-side handling in
+ * packages/claude-hooks/src/project.js (which already shipped, #5483) so the
+ * server's fallback derivation can't re-mint the opaque id the hook now avoids
+ * sending. The two copies are slated to merge into one shared module (#5850 /
+ * audit P2-2); until then, keep them in sync.
+ *
+ * Test surface: CHROXY_WORKTREES_ROOT lets a test point the root at a temp dir
+ * (os.tmpdir() classification differs across platforms). Never set in prod.
+ */
+function chroxyWorktreesRoot(env = process.env) {
+  const override = env?.CHROXY_WORKTREES_ROOT
+  if (typeof override === 'string' && override.trim().startsWith('/')) {
+    return realResolve(override.trim().replace(/\/+$/, ''))
+  }
+  const home = typeof env?.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
+  if (!home) return null
+  return realResolve(join(home, '.chroxy', 'worktrees'))
+}
+
+/** resolve() then realpath (macOS: /tmp → /private/tmp); best-effort, never throws. */
+function realResolve(p) {
+  let dir
+  try { dir = resolve(p) } catch { return null }
+  try { return realpathSync(dir) } catch { return dir }
+}
+
+/**
+ * If `dir` (already real-resolved) is inside a chroxy session worktree, return
+ * that worktree's top dir (`<root>/<id>`); else null. The root itself is not one.
+ */
+function chroxyWorktreeTopDir(dir, env = process.env) {
+  const root = chroxyWorktreesRoot(env)
+  if (!root || !dir.startsWith(root + '/')) return null
+  const id = dir.slice(root.length + 1).split('/')[0]
+  return id.length > 0 ? join(root, id) : null
+}
+
+/**
+ * Recover the parent project for a chroxy session worktree from its `.git` FILE:
+ * `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the repo
+ * root (the parent project) is three segments up. Returns null on any read/shape
+ * surprise — a tampered `.git` file then can't misattribute the project.
+ */
+function chroxyWorktreeParentProject(worktreeDir) {
+  let raw
+  try { raw = readFileSync(join(worktreeDir, '.git'), 'utf8') } catch { return null }
+  const match = /^gitdir:\s*(.+?)\s*$/m.exec(raw)
+  if (!match) return null
+  let linkedGitDir
+  try { linkedGitDir = resolve(worktreeDir, match[1]) } catch { return null }
+  const worktreesDir = dirname(linkedGitDir) // <repo>/.git/worktrees
+  if (basename(worktreesDir) !== 'worktrees') return null
+  const gitDir = dirname(worktreesDir) // <repo>/.git
+  if (basename(gitDir) !== '.git') return null
+  const name = basename(dirname(gitDir))
+  return name.length > 0 ? name : null
+}
+
+/**
  * Derive a project name from a working directory by walking up to the
  * nearest `.git` (directory OR file — worktrees use a `.git` file) and
  * taking that directory's basename. Falls back to `basename(cwd)` when no
  * git root is found, and `null` for unusable input. Pure fs probing — never
  * shells out (this runs per ingested event).
+ *
+ * #5483/#5850: a cwd inside a chroxy session worktree (`~/.chroxy/worktrees/<id>`)
+ * is handled FIRST — the git walk there would name the project after the opaque
+ * session id (the worktree's `.git` is a file pointing back at the real repo), so
+ * recover the parent repo from that file, or return null (defer to the explicit
+ * `event.project` / nothing) rather than mint the id.
  */
-export function deriveProjectFromCwd(cwd) {
+export function deriveProjectFromCwd(cwd, env = process.env) {
   if (typeof cwd !== 'string' || cwd.length === 0) return null
   let dir
   try {
     dir = resolve(cwd)
   } catch {
     return null
+  }
+  // chroxy session worktree → parent repo (or null), never the opaque id.
+  const resolved = realResolve(cwd)
+  if (resolved && chroxyWorktreeTopDir(resolved, env)) {
+    return chroxyWorktreeParentProject(chroxyWorktreeTopDir(resolved, env))
   }
   let current = dir
   // Bounded walk — terminates at the fs root anyway; the cap is paranoia

--- a/packages/server/tests/event-ingest.test.js
+++ b/packages/server/tests/event-ingest.test.js
@@ -20,7 +20,7 @@ import { createServer } from 'node:http'
 import { once } from 'node:events'
 import { mkdtempSync, mkdirSync, writeFileSync, statSync, existsSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { createHttpHandler } from '../src/http-routes.js'
 import {
   loadOrCreateIngestSecret,
@@ -472,8 +472,8 @@ describe('event-ingest', () => {
       const res = await post(event)
       assert.equal(res.status, 200)
       const body = await res.json()
-      assert.equal(body.project, repo.split('/').pop())
-      assert.equal(mockServer.pushManager.calls[0].data.project, repo.split('/').pop())
+      assert.equal(body.project, basename(repo))
+      assert.equal(mockServer.pushManager.calls[0].data.project, basename(repo))
     })
 
     it('uses data.title / data.message as the notification text when provided', async () => {
@@ -606,7 +606,7 @@ describe('deriveProjectFromCwd', () => {
     mkdirSync(join(repo, '.git'))
     const nested = join(repo, 'a', 'b', 'c')
     mkdirSync(nested, { recursive: true })
-    assert.equal(deriveProjectFromCwd(nested), repo.split('/').pop())
+    assert.equal(deriveProjectFromCwd(nested), basename(repo))
   })
 
   it('treats a .git FILE as a git root (worktrees)', () => {
@@ -614,7 +614,7 @@ describe('deriveProjectFromCwd', () => {
     writeFileSync(join(wt, '.git'), 'gitdir: /somewhere/else\n')
     const nested = join(wt, 'src')
     mkdirSync(nested)
-    assert.equal(deriveProjectFromCwd(nested), wt.split('/').pop())
+    assert.equal(deriveProjectFromCwd(nested), basename(wt))
   })
 
   it('prefers the NEAREST .git when nested repos exist', () => {
@@ -664,7 +664,7 @@ describe('deriveProjectFromCwd', () => {
     it('recovers the parent repo basename, not the opaque session id', () => {
       const { repo, wt, env } = makeChroxyWorktree()
       const got = deriveProjectFromCwd(wt, env)
-      assert.equal(got, repo.split('/').pop())
+      assert.equal(got, basename(repo))
       assert.notEqual(got, ID, 'must not return the opaque session id')
     })
 
@@ -672,7 +672,7 @@ describe('deriveProjectFromCwd', () => {
       const { repo, wt, env } = makeChroxyWorktree()
       const nested = join(wt, 'packages', 'app')
       mkdirSync(nested, { recursive: true })
-      assert.equal(deriveProjectFromCwd(nested, env), repo.split('/').pop())
+      assert.equal(deriveProjectFromCwd(nested, env), basename(repo))
     })
 
     it('returns null (not the id) when the worktree .git file is corrupt', () => {

--- a/packages/server/tests/event-ingest.test.js
+++ b/packages/server/tests/event-ingest.test.js
@@ -641,4 +641,48 @@ describe('deriveProjectFromCwd', () => {
   it('does not throw on a nonexistent path (still walks the string)', () => {
     assert.equal(deriveProjectFromCwd('/nonexistent/zzz/abc'), 'abc')
   })
+
+  // #5483/#5850: a cwd inside a chroxy session worktree (~/.chroxy/worktrees/<id>)
+  // must resolve to the PARENT repo, never the opaque hex session id. This mirrors
+  // the hook-side fix (#5483) so the server fallback can't re-mint the id.
+  describe('chroxy session worktree (#5483/#5850)', () => {
+    const ID = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4'
+
+    // git: 'valid' writes a real `git worktree add` .git file pointing back at
+    // the repo; 'corrupt' writes garbage; 'missing' writes no file.
+    function makeChroxyWorktree({ git = 'valid' } = {}) {
+      const root = mkdtempSync(join(tmpdir(), 'cwt-root-'))
+      const repo = mkdtempSync(join(tmpdir(), 'cwt-repo-'))
+      const wt = join(root, ID)
+      mkdirSync(wt, { recursive: true })
+      if (git === 'valid') writeFileSync(join(wt, '.git'), `gitdir: ${join(repo, '.git', 'worktrees', ID)}\n`)
+      else if (git === 'corrupt') writeFileSync(join(wt, '.git'), 'not a gitdir line\n')
+      const env = { ...process.env, CHROXY_WORKTREES_ROOT: root }
+      return { root, repo, wt, env }
+    }
+
+    it('recovers the parent repo basename, not the opaque session id', () => {
+      const { repo, wt, env } = makeChroxyWorktree()
+      const got = deriveProjectFromCwd(wt, env)
+      assert.equal(got, repo.split('/').pop())
+      assert.notEqual(got, ID, 'must not return the opaque session id')
+    })
+
+    it('recovers from a nested cwd inside the worktree too', () => {
+      const { repo, wt, env } = makeChroxyWorktree()
+      const nested = join(wt, 'packages', 'app')
+      mkdirSync(nested, { recursive: true })
+      assert.equal(deriveProjectFromCwd(nested, env), repo.split('/').pop())
+    })
+
+    it('returns null (not the id) when the worktree .git file is corrupt', () => {
+      const { wt, env } = makeChroxyWorktree({ git: 'corrupt' })
+      assert.equal(deriveProjectFromCwd(wt, env), null)
+    })
+
+    it('returns null (not the id) when the worktree .git file is missing', () => {
+      const { wt, env } = makeChroxyWorktree({ git: 'missing' })
+      assert.equal(deriveProjectFromCwd(wt, env), null)
+    })
+  })
 })


### PR DESCRIPTION
## Problem (audit P1-10 — the #5483 fix wasn't end-to-end)

`deriveProjectFromCwd` walks up to the nearest `.git` and takes the basename. For a chroxy session worktree (`~/.chroxy/worktrees/<id>`), that `.git` is a **file** and the directory basename is the **opaque session id** — so the project name became the id. The hook-side fix (#5483, merged this session as #5849) eliminated this on the hook, and the hook now sends `project: null` for an unrecoverable chroxy worktree. But the server's `event.project || deriveProjectFromCwd(cwd)` fallback then **re-minted the opaque id**, so the end-to-end behavior was still wrong (a phantom `agent-<hex>` Discord status embed).

## Fix

Mirror the hook-side handling in `event-ingest.js`: detect a chroxy session worktree **first** and recover the parent repo from the worktree `.git` file's `gitdir:` line (`<repo>/.git/worktrees/<id>` → repo root), or return `null` — never the opaque id. Now `event.project (null) → deriveProjectFromCwd → parent repo or null`, end-to-end.

This is the audit's **interim** for P1-10: it deliberately duplicates `packages/claude-hooks/src/project.js`. The two copies are slated to merge into one shared module — tracked as **#5850 / audit P2-2** (a packaging decision, since claude-hooks is intentionally zero-dep and standalone). #5850 stays open for that.

## Tests

`deriveProjectFromCwd` chroxy-worktree describe: parent-repo recovery (asserts it is NOT the opaque id), nested cwd inside the worktree, and corrupt/missing `.git` → `null` (not the id). All 67 event-ingest tests pass; eslint clean.

Closes #5483