### PR TITLE
feat(server): reclaim orphaned chroxy session worktrees at boot (audit P1-7, closes #5859)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -623,6 +623,9 @@ export async function startCliServer(config) {
     defaultCwd: config.cwd || (isWithinHome(process.cwd()) ? process.cwd() : homedir()),
     defaultModel: config.model || null,
     defaultPermissionMode: 'approve',
+    // #5859 (audit P1-7): reclaim orphaned chroxy session worktrees at boot when
+    // the operator opted into worktree auto-reaping. Clean-tree-guarded.
+    sweepOrphanWorktrees: config.worktreeGc?.autoReap === true,
     // #4209 / #4246: seed the auto-created Default session + any
     // subsequent createSession() that omits the field. Only honoured by
     // the claude-tui provider; other providers ignore it harmlessly.

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -10,6 +10,7 @@ import { billingClassForProvider, BILLING_CLASSES } from './billing-class.js'
 import { MonthlyProgrammaticBudgetManager } from './billing-budget.js'
 import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderCredentialMissingError } from './utils/preflight.js'
 import { GIT } from './git.js'
+import { sweepOrphanChroxyWorktrees } from './worktree-gc.js'
 import { resolveJsonlPath, readConversationHistoryAsync } from './jsonl-reader.js'
 import { readSessionContext } from './session-context.js'
 import { parseDuration, isOperatorTimeoutInRange } from './duration.js'
@@ -289,6 +290,12 @@ export class SessionManager extends EventEmitter {
     maxMessages,
     maxHistory,
 
+    // #5859 (audit P1-7): opt-in boot-time sweep of orphaned chroxy session
+    // worktrees (dirs under the worktree base whose session id is no longer
+    // live). Off by default — server-cli enables it from config.worktreeGc.autoReap,
+    // mirroring the agent-worktree reaper's opt-in. Always clean-tree-guarded.
+    sweepOrphanWorktrees = false,
+
     // Test-only: skip preflight checks (binary + credential). Production must
     // leave this false so missing providers surface cleanly at createSession.
     skipPreflight = false,
@@ -309,6 +316,7 @@ export class SessionManager extends EventEmitter {
     // partially enable the flag. Forwarded to providerOpts.skipPermissions
     // for every createSession() call that omits the field.
     this._defaultSkipPermissions = !!defaultSkipPermissions
+    this._sweepOrphanWorktrees = !!sweepOrphanWorktrees
     this._providerType = providerType
 
     // Session behavior
@@ -1922,6 +1930,34 @@ export class SessionManager extends EventEmitter {
     // failure — otherwise the next successful save would drop failed-restore
     // entries. (serializeState() re-includes them from _failedRestores.)
     if (firstId || anyFailure) this._flushPersist()
+
+    // #5859 (audit P1-7): now that the live session set is rebuilt, sweep
+    // orphaned chroxy session worktrees — dirs under the worktree base whose
+    // session id is no longer live (left by a SIGKILL / crash / dropped state
+    // file; P0-3 stopped deleting them on clean shutdown, so they accrue). Opt-in
+    // and clean-tree-guarded (never deletes uncommitted/untracked/ignored work);
+    // best-effort so a GC hiccup never affects boot.
+    if (this._sweepOrphanWorktrees) {
+      try {
+        // The live set MUST include FAILED-restore sessions: those are kept in
+        // _failedRestores keyed by their original id (= the worktree dir
+        // basename) with worktreePath preserved on disk for a later retry
+        // (#2954). Treating their clean worktree as an orphan would delete the
+        // very checkout #2954 preserves — and a --detach worktree's commits
+        // would become unreachable. Union both so neither live nor failed-but-
+        // retained sessions are ever swept.
+        const liveSessionIds = new Set([...this._sessions.keys(), ...this._failedRestores.keys()])
+        const report = sweepOrphanChroxyWorktrees({
+          worktreeBase: this._worktreeBase || DEFAULT_WORKTREE_BASE,
+          liveSessionIds,
+        })
+        if (report.removed.length || report.skippedDirty.length || report.skippedError.length) {
+          log.info(`worktree orphan sweep: removed=${report.removed.length} skippedDirty=${report.skippedDirty.length} skippedError=${report.skippedError.length} (scanned ${report.scanned})`)
+        }
+      } catch (err) {
+        log.warn(`worktree orphan sweep failed (non-fatal): ${err?.message || err}`)
+      }
+    }
 
     return firstId
   }

--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -25,8 +25,8 @@
 // is fully testable against real temp repos without poking the real home dir.
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, statSync } from 'node:fs'
-import { isAbsolute, resolve as resolvePath } from 'node:path'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { isAbsolute, join as joinPath, resolve as resolvePath, dirname, sep } from 'node:path'
 import { GIT } from './git.js'
 
 // #5706: absolute-age fallback for the PID-liveness check. A dead agent's pid
@@ -248,6 +248,89 @@ function isClean(git, worktreePath) {
   } catch {
     return null
   }
+}
+
+/**
+ * Recover the owning repo path of a chroxy session worktree from its `.git`
+ * FILE: `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the
+ * repo root is three segments up. Returns null on any read/shape surprise.
+ */
+function chroxyWorktreeRepoPath(worktreePath, readFile = readFileSync) {
+  let raw
+  try { raw = readFile(joinPath(worktreePath, '.git'), 'utf8') } catch { return null }
+  const match = /^gitdir:\s*(.+?)\s*$/m.exec(raw)
+  if (!match) return null
+  let linkedGitDir
+  try { linkedGitDir = resolvePath(worktreePath, match[1]) } catch { return null }
+  const worktreesDir = dirname(linkedGitDir) // <repo>/.git/worktrees
+  const gitDir = dirname(worktreesDir)       // <repo>/.git
+  // Strict shape: the gitdir must be `<repo>/.git/worktrees/<id>` (the only
+  // form `git worktree add` writes), so a tampered .git file can't point the
+  // removal at an arbitrary path.
+  if (!worktreesDir.endsWith(`${sep}worktrees`) || !gitDir.endsWith(`${sep}.git`)) return null
+  const repo = dirname(gitDir)
+  return repo.length > 0 ? repo : null
+}
+
+/**
+ * #5859 (audit P1-7): boot-time sweep of ORPHANED chroxy session worktrees.
+ *
+ * Unlike the agent worktrees this module's reaper handles, chroxy's OWN session
+ * worktrees (`~/.chroxy/worktrees/<sessionId>`, created `git worktree add
+ * --detach`, NO lock) are never reclaimed by the lock/dead-pid reaper. When a
+ * session vanishes without a clean destroy (SIGKILL, crash, or a dropped
+ * state file) its worktree dir leaks forever.
+ *
+ * Removes a worktree dir ONLY when BOTH hold:
+ *   - its basename (the sessionId) is NOT in `liveSessionIds` (the set
+ *     restoreState rebuilt) — so a live session's worktree is never touched, AND
+ *   - the tree is CLEAN including ignored files — the same hard guard as the
+ *     reaper (`git worktree remove` without --force still deletes gitignored
+ *     content, so any uncommitted/untracked/ignored work means SKIP).
+ * A dirty orphan, or one whose repo/clean-state can't be determined, is skipped
+ * and reported. Never throws; never uses --force.
+ *
+ * Pure + dependency-injected.
+ *
+ * @param {object} args
+ * @param {string} args.worktreeBase - e.g. ~/.chroxy/worktrees
+ * @param {Set<string>} args.liveSessionIds - currently-live session ids (off-limits)
+ * @param {object} [args.deps] - { git, readdir, exists, readFile }
+ * @returns {{ removed: string[], skippedDirty: object[], skippedError: object[], scanned: number }}
+ */
+export function sweepOrphanChroxyWorktrees({ worktreeBase, liveSessionIds, deps = {} } = {}) {
+  const {
+    git = (cwd, args) => execFileSync(GIT, ['-C', cwd, ...args], { encoding: 'utf8' }),
+    readdir = (p) => readdirSync(p, { withFileTypes: true }),
+    exists = existsSync,
+    readFile = readFileSync,
+  } = deps
+  const report = { removed: [], skippedDirty: [], skippedError: [], scanned: 0 }
+  if (!worktreeBase || !exists(worktreeBase)) return report
+  const live = liveSessionIds instanceof Set ? liveSessionIds : new Set(liveSessionIds || [])
+  let entries
+  try { entries = readdir(worktreeBase) } catch (err) { report.skippedError.push({ path: worktreeBase, error: (err && err.message) || String(err) }); return report }
+  for (const ent of entries) {
+    if (!ent || typeof ent.isDirectory !== 'function' || !ent.isDirectory()) continue
+    const id = ent.name
+    if (live.has(id)) continue // owned by a live session — never touch
+    report.scanned++
+    const wtPath = joinPath(worktreeBase, id)
+    const clean = isClean(git, wtPath)
+    if (clean !== true) {
+      report.skippedDirty.push({ path: wtPath, reason: clean === null ? 'status-unknown' : 'dirty' })
+      continue
+    }
+    const repo = chroxyWorktreeRepoPath(wtPath, readFile)
+    if (!repo) { report.skippedError.push({ path: wtPath, error: 'repo-unrecoverable' }); continue }
+    try {
+      git(repo, ['worktree', 'remove', wtPath]) // NO --force; clean-checked above
+      report.removed.push(wtPath)
+    } catch (err) {
+      report.skippedError.push({ path: wtPath, error: (err && err.message) || String(err) })
+    }
+  }
+  return report
 }
 
 /**

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -85,13 +85,14 @@ function makeGitRepo() {
  * Create a SessionManager backed by the stub provider.
  * Worktrees are created inside the given gitRepo to keep temp files local.
  */
-function makeManager(gitRepo) {
+function makeManager(gitRepo, opts = {}) {
   const stateFile = join(gitRepo, 'session-state.json')
   const mgr = new SessionManager({ skipPreflight: true,
     maxSessions: 5,
     stateFilePath: stateFile,
-    providerType: 'stub-worktree',
+    providerType: opts.providerType || 'stub-worktree',
     defaultCwd: gitRepo,
+    sweepOrphanWorktrees: opts.sweepOrphanWorktrees === true,
   })
   // Redirect worktrees into the temp dir rather than ~/.chroxy/worktrees
   mgr._worktreeBase = join(gitRepo, 'worktrees')
@@ -509,5 +510,54 @@ describe('SessionManager isolation derivation (#2475)', () => {
     assert.equal(plain.isolation, 'none')
     assert.equal(wt.isolation, 'worktree')
     mgr.destroyAll()
+  })
+
+  // audit P1-7 (#5859): the boot-time orphan sweep, exercised through restoreState.
+  describe('orphan worktree boot sweep (sweepOrphanWorktrees)', () => {
+    it('sweeps a genuinely-orphaned clean worktree dir but keeps live sessions', () => {
+      const mgr = makeManager(gitRepo)
+      const liveId = mgr.createSession({ cwd: gitRepo, worktree: true })
+      const liveWt = mgr.getSession(liveId).worktreePath
+      // Fabricate an orphan: a real worktree under the base whose id is in NO
+      // session state (as if its session vanished via SIGKILL).
+      const orphanId = '0000000000000000000000000000dead'
+      const orphanWt = join(mgr._worktreeBase, orphanId)
+      execFileSync(GIT, ['-C', gitRepo, 'worktree', 'add', '--detach', orphanWt, 'HEAD'], { stdio: 'pipe' })
+      mgr.serializeState()
+
+      // Restart with the sweep enabled.
+      const mgr2 = makeManager(gitRepo, { sweepOrphanWorktrees: true })
+      mgr2.restoreState()
+
+      assert.ok(existsSync(liveWt), 'live session worktree preserved')
+      assert.equal(existsSync(orphanWt), false, 'orphaned worktree swept')
+      mgr2.destroyAll()
+    })
+
+    it('does NOT sweep a failed-restore session worktree (#2954 retry preservation)', () => {
+      const mgr = makeManager(gitRepo)
+      const id = mgr.createSession({ cwd: gitRepo, worktree: true })
+      const wtPath = mgr.getSession(id).worktreePath
+      assert.ok(existsSync(wtPath), 'worktree created')
+      mgr.serializeState()
+
+      // Rewrite the persisted provider to the fail-start stub so THIS session's
+      // restore throws (mirrors the #5310 failed-restore test), then restart
+      // with the sweep enabled. The failed session lands in _failedRestores
+      // keyed by its original id (= worktree dir basename) — its clean worktree
+      // must be preserved for retry, not swept as an orphan (#2954).
+      const stateFile = join(gitRepo, 'session-state.json')
+      const persisted = JSON.parse(readFileSync(stateFile, 'utf-8'))
+      persisted.sessions[0].provider = 'stub-worktree-failstart'
+      writeFileSync(stateFile, JSON.stringify(persisted))
+
+      const mgr2 = makeManager(gitRepo, { sweepOrphanWorktrees: true })
+      mgr2.restoreState()
+
+      assert.ok(!mgr2.getSession(id), 'session did not restore (start threw)')
+      assert.ok(mgr2._failedRestores.has(id), 'recorded as a failed restore for retry')
+      assert.ok(existsSync(wtPath), 'failed-restore worktree preserved, not swept (#2954)')
+      mgr2.destroyAll()
+    })
   })
 })

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -22,6 +22,7 @@ import {
   readLockReasonFromAdmin,
   planRepoGc,
   applyPlan,
+  sweepOrphanChroxyWorktrees,
 } from '../src/worktree-gc.js'
 
 // A pid that the fake kill treats as alive; everything else is "dead".
@@ -529,5 +530,73 @@ describe('worktree-gc CLI (config controlRoomRoot auto-discovery, #5221)', () =>
     // Test seam (deps.planDeps) overrides config.
     collectWorktreeGc({}, { configPath, withSizes: false, plan: planSpy, planDeps: { maxLockAgeMs: 12345 } })
     assert.equal(captured.maxLockAgeMs, 12345)
+  })
+})
+
+// #5859 (audit P1-7): boot-time sweep of orphaned chroxy session worktrees
+// (~/.chroxy/worktrees/<id>, --detach, unlocked). Real git repo + a separate
+// worktree base, since these are NOT the .claude/worktrees/agent-* the reaper handles.
+describe('sweepOrphanChroxyWorktrees (real git repo)', () => {
+  let repo, base
+
+  function addChroxyWorktree(id, { dirty, ignoredOnly } = {}) {
+    const wtPath = join(base, id)
+    git(repo, ['worktree', 'add', '--detach', wtPath, 'HEAD'])
+    if (dirty) writeFileSync(join(wtPath, 'scratch.txt'), 'uncommitted work')
+    if (ignoredOnly) {
+      writeFileSync(join(wtPath, '.gitignore'), '.env.local\n')
+      git(wtPath, ['add', '.gitignore'])
+      git(wtPath, ['commit', '-m', 'add gitignore'])
+      writeFileSync(join(wtPath, '.env.local'), 'TOKEN=secret') // clean to porcelain, NOT to --ignored
+    }
+    return wtPath
+  }
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'chroxy-cwt-repo-'))
+    git(repo, ['init', '--initial-branch=main', '.'])
+    git(repo, ['config', 'user.email', 'test@test'])
+    git(repo, ['config', 'user.name', 'Test'])
+    git(repo, ['commit', '--allow-empty', '-m', 'init'])
+    base = mkdtempSync(join(tmpdir(), 'chroxy-cwt-base-'))
+  })
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true })
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('removes a clean orphan, keeps a live session, skips dirty + ignored-only', () => {
+    const orphan = addChroxyWorktree('0000000000000000000000000000aaaa')
+    const live = addChroxyWorktree('0000000000000000000000000000live')
+    const dirty = addChroxyWorktree('0000000000000000000000000000dirt', { dirty: true })
+    const ignored = addChroxyWorktree('0000000000000000000000000000ign0', { ignoredOnly: true })
+
+    const report = sweepOrphanChroxyWorktrees({
+      worktreeBase: base,
+      liveSessionIds: new Set(['0000000000000000000000000000live']),
+    })
+
+    assert.equal(report.removed.map((p) => basename(p)).includes('0000000000000000000000000000aaaa'), true, 'clean orphan removed')
+    assert.equal(existsSync(orphan), false, 'clean orphan dir gone')
+    assert.equal(existsSync(live), true, 'live session worktree untouched')
+    assert.equal(existsSync(dirty), true, 'dirty orphan preserved')
+    assert.equal(existsSync(ignored), true, 'ignored-only orphan preserved (--ignored guard)')
+    assert.equal(report.skippedDirty.length, 2, 'dirty + ignored-only both skipped as not-clean')
+  })
+
+  it('is a no-op when the base does not exist', () => {
+    const report = sweepOrphanChroxyWorktrees({ worktreeBase: join(base, 'nonexistent'), liveSessionIds: new Set() })
+    assert.deepEqual(report, { removed: [], skippedDirty: [], skippedError: [], scanned: 0 })
+  })
+
+  it('skips a dir whose .git cannot be resolved to a repo (no removal)', () => {
+    const bogus = join(base, '0000000000000000000000000000bog0')
+    mkdirSync(bogus, { recursive: true })
+    writeFileSync(join(bogus, '.git'), 'gitdir: /nowhere/bogus\n') // status will fail → status-unknown
+    const report = sweepOrphanChroxyWorktrees({ worktreeBase: base, liveSessionIds: new Set() })
+    assert.equal(existsSync(bogus), true, 'unresolvable orphan left in place')
+    assert.equal(report.removed.length, 0)
+    assert.equal(report.skippedDirty.length + report.skippedError.length, 1)
   })
 })


### PR DESCRIPTION
## Problem (audit P1-7 — the leak P0-3 deferred)

Chroxy's own session worktrees (`~/.chroxy/worktrees/<id>`, created `git worktree add --detach`, **unlocked**) are never reclaimed by the lock/dead-pid agent-worktree reaper (which only handles `.claude/worktrees/agent-*`). When a session vanishes without a clean destroy (SIGKILL, crash, dropped state file), its worktree dir leaks forever — and #5853 (P0-3) correctly stopped deleting worktrees on clean shutdown, so without a sweep they only accrue.

## Fix

`sweepOrphanChroxyWorktrees()` in `worktree-gc.js`: after `restoreState` rebuilds the live session set, remove a worktree dir **only when both** hold:
- its basename (the session id) is **not** in the live set (so an active session's worktree is never touched), and
- the tree is **clean including ignored files** — the same hard guard as the reaper: `git worktree remove` without `--force` still deletes gitignored content, so any uncommitted/untracked/ignored work means **skip**.

Dirty or unresolvable orphans are skipped and reported. The function is pure + dependency-injected and never throws.

**Opt-in** via `config.worktreeGc.autoReap` (mirrors the agent-worktree reaper's opt-in default-off stance toward destructive worktree ops), threaded through a `SessionManager` `sweepOrphanWorktrees` ctor flag and run **best-effort** at the end of `restoreState` so a GC hiccup never affects boot.

## Tests

Real-git-repo sweep tests: clean orphan removed; live session worktree untouched; dirty orphan and ignored-only orphan both preserved (the `--ignored` guard); no-op when the base is missing; unresolvable `.git` left in place. All worktree-gc + session-manager-worktree + reaper/config suites pass; eslint clean.

Closes #5859