### PR TITLE
refactor(server): centralize the config fatal-vs-warn policy (audit P1-9)

### DIFF
--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -8,7 +8,7 @@ import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import readline from 'readline'
-import { validateConfig, mergeConfig } from '../config.js'
+import { validateConfig, mergeConfig, isFatalConfigWarning } from '../config.js'
 
 export const CONFIG_DIR = join(homedir(), '.chroxy')
 export const CONFIG_FILE = join(CONFIG_DIR, 'config.json')
@@ -174,7 +174,9 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
 
   const validation = validateConfig(config, options.verbose)
   if (!validation.valid) {
-    const typeErrors = validation.warnings.filter(w => w.startsWith('Invalid type'))
+    // Fatality comes from the single policy in config.js (isFatalConfigWarning),
+    // not an inlined string match here — see audit P1-9.
+    const typeErrors = validation.warnings.filter(isFatalConfigWarning)
     if (typeErrors.length > 0) {
       console.error('❌ Configuration has type errors:')
       for (const err of typeErrors) {

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -637,6 +637,28 @@ export function sanitizeConfig(config) {
 }
 
 /**
+ * The SINGLE source of the fatal-vs-warn config policy (audit P1-9). A config
+ * problem is FATAL (the CLI exits 1) iff its warning is a schema TYPE mismatch
+ * — wording prefix "Invalid type ..." — because a wrong-typed field is a real
+ * misconfiguration the operator must fix. Everything else ("Invalid value ...",
+ * "Unknown config key ...", range/format warnings) is non-fatal: the runtime
+ * clamps/ignores it, so a cosmetic typo never blocks startup.
+ *
+ * This used to be inlined as `w.startsWith('Invalid type')` in cli/shared.js,
+ * divorced from where the warnings are produced — so a new fatal/non-fatal
+ * decision had no single home and a mis-prefixed message could silently flip
+ * a field's severity. Centralizing it here (with the invariant test in
+ * config.test.js asserting no "Invalid value" warning is ever fatal) keeps the
+ * policy and the wording convention in lockstep.
+ */
+export const FATAL_CONFIG_WARNING_PREFIX = 'Invalid type'
+
+/** True iff this validateConfig warning should abort startup. See FATAL_CONFIG_WARNING_PREFIX. */
+export function isFatalConfigWarning(warning) {
+  return typeof warning === 'string' && warning.startsWith(FATAL_CONFIG_WARNING_PREFIX)
+}
+
+/**
  * Validate config object against schema.
  * Logs warnings for unknown keys and type mismatches.
  *

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -3,7 +3,38 @@ import assert from 'node:assert/strict'
 import { writeFileSync, mkdtempSync, rmSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { validateConfig, mergeConfig, readReposFromConfig, writeReposToConfig, sanitizeConfig } from '../src/config.js'
+import { validateConfig, mergeConfig, readReposFromConfig, writeReposToConfig, sanitizeConfig, isFatalConfigWarning } from '../src/config.js'
+
+// audit P1-9: fatality must come from the single isFatalConfigWarning policy,
+// and the wording convention (type=fatal, value=non-fatal) must hold — a typo
+// in a value should never abort startup.
+describe('isFatalConfigWarning (config fatal-vs-warn policy)', () => {
+  it('treats "Invalid type" warnings as fatal and "Invalid value" as non-fatal', () => {
+    assert.equal(isFatalConfigWarning("Invalid type for 'port': expected number, got string"), true)
+    assert.equal(isFatalConfigWarning("Invalid value for 'environments.k8s.connectMode': 'x'"), false)
+    assert.equal(isFatalConfigWarning('Unknown config key: foo'), false)
+    assert.equal(isFatalConfigWarning(''), false)
+    assert.equal(isFatalConfigWarning(undefined), false)
+  })
+
+  it('INVARIANT: no "Invalid value" warning validateConfig produces is ever fatal', () => {
+    // A config that trips many value-level checks at once (range + format +
+    // enum + unknown key). None must be classified fatal.
+    const bad = validateConfig({
+      port: 70000,                                   // out of range (Invalid value)
+      maxSessions: 0,                                // < 1 (Invalid value)
+      totallyUnknownKey: true,                       // Unknown config key
+      environments: { k8s: { imagePullPolicy: 'Sometimes', connectMode: 'telepathy' } }, // enum (Invalid value)
+    })
+    const fatalValueWarnings = bad.warnings.filter(
+      (w) => w.startsWith('Invalid value') && isFatalConfigWarning(w),
+    )
+    assert.deepEqual(fatalValueWarnings, [], `no "Invalid value" warning may be fatal; got: ${JSON.stringify(fatalValueWarnings)}`)
+    // And a genuine type error IS fatal.
+    const typed = validateConfig({ port: { nested: true } }) // wrong type for port
+    assert.ok(typed.warnings.some(isFatalConfigWarning), 'a type mismatch must be fatal')
+  })
+})
 
 describe('validateConfig', () => {
   it('accepts valid config with all known keys', () => {


### PR DESCRIPTION
## Problem (audit P1-9 — fragile fatality policy)

Whether a config problem aborts startup was encoded as an **inlined** `validation.warnings.filter(w => w.startsWith('Invalid type'))` in `cli/shared.js` — divorced from `config.js` where the warnings are actually produced. So the fatal/non-fatal decision had no single home, and a future warning with a mis-chosen prefix could silently flip a field's severity (a value typo becoming fatal, or a real type error becoming non-fatal).

## Fix

Centralize the policy as exported **`isFatalConfigWarning()`** (+ `FATAL_CONFIG_WARNING_PREFIX`) in `config.js` — the one place that owns "schema type mismatch = fatal; `Invalid value` / unknown-key / range/format = non-fatal (runtime clamps/ignores)". `cli/shared.js` now calls it instead of inlining the string match.

## Test

Invariant test in `config.test.js`: across a config that trips many value-level checks at once (range + enum + unknown-key), **no** `Invalid value` warning is ever classified fatal; and a genuine type mismatch **is** fatal.

## Scope note

Warnings stay `string[]` — the contract ~10 test files and `doctor.js` rely on (`w.includes(...)`, `w.startsWith(...)`). The audit floated a structured `{message, fatal}[]` shape; that's deliberately **out of scope** here — it would churn every warning assertion across those files for no added safety beyond the centralized predicate + invariant test.