### PR TITLE
feat(server): pin the tested claude CLI version in chroxy doctor (audit P1-3)

### DIFF
--- a/packages/server/src/claude-tui/tested-cli-version.js
+++ b/packages/server/src/claude-tui/tested-cli-version.js
@@ -1,0 +1,22 @@
+// The claude CLI version chroxy's claude-tui form-driving was last validated
+// against (audit P1-3 / #5821 backstop).
+//
+// ClaudeTuiSession drives the real `claude` interactive TUI by screen-scraping
+// and emitting empirically-pinned keystroke sequences (see pty-driver.js /
+// form-driver.js) — there is NO programmatic answer channel. A claude CLI UI
+// change (hotkey scheme, prompt layout, bracketed-paste handling) can therefore
+// mis-drive AskUserQuestion forms SILENTLY: a wrong key lands, claude resolves
+// *some* option, and the user's choice is quietly mis-applied.
+//
+// This pin lets `chroxy doctor` turn that silent class into a MEASURED, surfaced
+// signal: it warns when the installed claude differs (by major.minor) from the
+// version the byte sequences were validated against. It is the only real
+// backstop against the silent-mis-drive class until a structured answer channel
+// exists.
+//
+// MAINTENANCE: when you re-validate the form-driving against a newer claude CLI
+// (running the AskUserQuestion flows and confirming the keystrokes still resolve
+// the intended option — e.g. via scripts/tui-form-recorder.mjs), bump this to
+// the version you tested. Keep it next to the driving code so the bump is an
+// obvious part of that re-validation.
+export const TESTED_CLAUDE_TUI_CLI_VERSION = '2.1.177'

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -8,6 +8,7 @@ import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { getProvider, DEFAULT_PROVIDER } from './providers.js'
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
+import { TESTED_CLAUDE_TUI_CLI_VERSION } from './claude-tui/tested-cli-version.js'
 import { detectSilentMeteredDefault } from './doctor-billing.js'
 import {
   billingClassForProvider,
@@ -110,6 +111,71 @@ function resolveProviders({ providers, configProvider }) {
   if (Array.isArray(providers) && providers.length > 0) return providers
   if (typeof configProvider === 'string' && configProvider.length > 0) return [configProvider]
   return [DEFAULT_PROVIDER]
+}
+
+/**
+ * The claude-tui provider's preflight binary candidate paths (homebrew, ~/.local,
+ * npm-global, etc.), so the version-pin check resolves `claude` the same way the
+ * provider preflight does. Best-effort: returns [] if the spec isn't shaped as
+ * expected (the check then falls back to PATH resolution). (#5871)
+ */
+function claudeTuiBinaryCandidates() {
+  try {
+    const Provider = getProvider('claude-tui')
+    const candidates = Provider?.preflight?.binary?.candidates
+    return Array.isArray(candidates) ? candidates : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * audit P1-3 / #5821: compare the installed claude CLI version against the
+ * version chroxy's claude-tui form-driving was validated against
+ * (TESTED_CLAUDE_TUI_CLI_VERSION). A major.minor drift is a `warn` — the
+ * keystroke driving may mis-resolve forms after a CLI UI change; an exact or
+ * patch-only difference is a `pass`. Returns null when claude can't be run (the
+ * provider binary check already reports a missing claude). Dependency-injected
+ * for tests.
+ *
+ * @param {object} [deps]
+ * @param {(bin: string, args: string[]) => string} [deps.exec]
+ * @param {string} [deps.tested]
+ * @param {string[]} [deps.candidates] - fallback absolute paths for resolveBinary
+ * @returns {{ name: string, status: 'pass'|'warn', message: string } | null}
+ */
+export function checkClaudeTuiCliVersion(deps = {}) {
+  const {
+    exec = (bin, args) => execFileSync(bin, args, { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] }),
+    tested = TESTED_CLAUDE_TUI_CLI_VERSION,
+    // #5871: resolve against the SAME candidate paths the claude-tui provider
+    // preflight uses, so this drift backstop isn't silently skipped in a
+    // minimal-PATH (Tauri/launchd) install where the provider check still finds
+    // claude via its candidate list — exactly the bundled context where a
+    // silent mis-drive would otherwise go unnoticed.
+    candidates = claudeTuiBinaryCandidates(),
+  } = deps
+  let output
+  try {
+    output = exec(resolveBinary('claude', candidates), ['--version'])
+  } catch {
+    return null // claude missing/hung — the provider binary check surfaces that
+  }
+  const NAME = 'claude-tui driving'
+  const found = parseLeadingSemver(output)
+  const testedSemver = parseLeadingSemver(tested)
+  if (found === null) {
+    return { name: NAME, status: 'warn', message: `Could not parse 'claude --version'; TUI form-driving is validated against ${tested}` }
+  }
+  const foundStr = `${found[0]}.${found[1]}.${found[2]}`
+  if (testedSemver && found[0] === testedSemver[0] && found[1] === testedSemver[1]) {
+    return { name: NAME, status: 'pass', message: `claude ${foundStr} matches the tested TUI-driving baseline (${tested})` }
+  }
+  return {
+    name: NAME,
+    status: 'warn',
+    message: `claude ${foundStr} differs from the tested TUI-driving baseline (${tested}) — chroxy drives the TUI by screen-scraping pinned keystrokes, so a CLI UI change can mis-drive AskUserQuestion forms silently. If question prompts misbehave, report it; re-validation will bump the baseline.`,
+  }
 }
 
 /**
@@ -241,6 +307,17 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
         message: `Default provider '${effectiveDefault}' — ${detail}. Programmatic-credit cutover: ${cutover}.`,
       })
     }
+  }
+
+  // 5.6 claude-tui CLI version pin (audit P1-3, #5821 backstop). The claude-tui
+  // provider drives the real `claude` TUI by screen-scraping pinned keystrokes
+  // (no structured answer channel), so a CLI UI change can mis-drive
+  // AskUserQuestion forms SILENTLY. Surface a major.minor drift from the tested
+  // version as a measured warning instead. Only meaningful when the default
+  // provider actually drives the TUI.
+  if (effectiveDefault === 'claude-tui') {
+    const tuiCheck = checkClaudeTuiCliVersion()
+    if (tuiCheck) checks.push(tuiCheck)
   }
 
   // 6. Dependencies

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, parse as parsePath, relative } from 'node:path'
-import { runDoctorChecks, checkBinary, isBundledOrSupervisedContext, parseLeadingSemver, compareSemver } from '../src/doctor.js'
+import { runDoctorChecks, checkBinary, isBundledOrSupervisedContext, parseLeadingSemver, compareSemver, checkClaudeTuiCliVersion } from '../src/doctor.js'
+import { TESTED_CLAUDE_TUI_CLI_VERSION } from '../src/claude-tui/tested-cli-version.js'
 
 /**
  * Integration tests for doctor.js.
@@ -641,5 +642,43 @@ describe('isBundledOrSupervisedContext (issue #3023)', () => {
     } finally {
       restoreEnv()
     }
+  })
+})
+
+// audit P1-3 / #5821: claude-tui CLI-version pin — the backstop against silent
+// AskUserQuestion mis-drive after a claude CLI UI change.
+describe('checkClaudeTuiCliVersion', () => {
+  it('passes when the installed claude matches the tested baseline (major.minor)', () => {
+    const tested = '2.1.177'
+    const check = checkClaudeTuiCliVersion({ tested, exec: () => '2.1.177 (Claude Code)' })
+    assert.equal(check.status, 'pass')
+    assert.match(check.message, /matches the tested TUI-driving baseline/)
+  })
+
+  it('passes on a patch-only difference (same major.minor)', () => {
+    const check = checkClaudeTuiCliVersion({ tested: '2.1.177', exec: () => '2.1.200 (Claude Code)' })
+    assert.equal(check.status, 'pass')
+  })
+
+  it('warns on a major.minor drift (a UI change may mis-drive forms)', () => {
+    const check = checkClaudeTuiCliVersion({ tested: '2.1.177', exec: () => '2.2.0 (Claude Code)' })
+    assert.equal(check.status, 'warn')
+    assert.match(check.message, /differs from the tested TUI-driving baseline/)
+    assert.match(check.message, /mis-drive AskUserQuestion forms silently/)
+  })
+
+  it('warns (does not throw) when claude --version is unparseable', () => {
+    const check = checkClaudeTuiCliVersion({ tested: '2.1.177', exec: () => 'some unexpected output' })
+    assert.equal(check.status, 'warn')
+    assert.match(check.message, /Could not parse/)
+  })
+
+  it('returns null when claude cannot be run (provider check covers a missing claude)', () => {
+    const check = checkClaudeTuiCliVersion({ exec: () => { throw new Error('ENOENT') } })
+    assert.equal(check, null)
+  })
+
+  it('the shipped baseline constant is a parseable semver', () => {
+    assert.notEqual(parseLeadingSemver(TESTED_CLAUDE_TUI_CLI_VERSION), null)
   })
 })


### PR DESCRIPTION
## Problem (audit P1-3 — the only backstop against silent TUI mis-drive)

`ClaudeTuiSession` (the default provider) drives the real `claude` interactive TUI by **screen-scraping + emitting empirically-pinned keystrokes** — there is no programmatic answer channel. A claude CLI UI change (hotkey scheme, prompt layout, bracketed-paste handling) can therefore mis-drive AskUserQuestion forms **silently**: a wrong key lands, claude resolves *some* option, PostToolUse fires, and the user's choice is quietly mis-applied.

## Fix

- `TESTED_CLAUDE_TUI_CLI_VERSION` (`claude-tui/tested-cli-version.js`) — the claude CLI version the form-driving was last validated against, co-located with the driving code so re-validation bumps it next to the byte sequences. Seeded at `2.1.177` (current).
- A `chroxy doctor` check (section 5.6, only when the default provider is `claude-tui`) that runs `claude --version` and **warns on a major.minor drift** from the baseline (an exact or patch-only difference passes). This turns the silent mis-drive class into a measured, surfaced signal — the cheapest, highest-value backstop until a structured answer channel exists (#5821).

The check returns `null` when claude can't be run (the existing provider binary check already reports a missing claude), so no duplicate failure.

## Tests

`checkClaudeTuiCliVersion`: pass on match, pass on patch-only diff, warn on major.minor drift (message names the silent-mis-drive risk), warn (no throw) on unparseable output, null when claude is missing, and the shipped baseline parses as semver. All 56 doctor tests pass; eslint clean.