### PR TITLE
refactor(ws): harden + dedup ws-broadcaster (audit P2-8)

### DIFF
--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -14,6 +14,7 @@ const log = createLogger('ws')
  *   - broadcastStatus()     server_status broadcast
  *   - broadcastShutdown()   server_shutdown broadcast
  *   - _broadcastClientJoined()  client_joined to other clients
+ *   - _broadcastClientLeft()    client_left to other clients
  *
  * @param {object} opts
  * @param {Map} opts.clients             ws → client Map (shared reference with WsServer)
@@ -109,12 +110,60 @@ export class WsBroadcaster {
     return true
   }
 
-  /** Broadcast a message to all authenticated clients matching a filter */
+  /**
+   * Broadcast a message to all authenticated clients matching a filter.
+   *
+   * A throwing `filter` must NOT abort delivery to the remaining clients: the
+   * fast path (#5563) already isolates each member, but the legacy full-scan
+   * loops did not, so one bad client could silently drop the broadcast for
+   * every *later* client. We catch a filter throw, warn once per client, and
+   * continue. (No shipping filter throws today — the #4799 fix hardened the
+   * default — but this is the resilient invariant the fast path already has.)
+   */
   _broadcast(message, filter = () => true) {
     for (const [ws, client] of this._clients) {
-      if (client.authenticated && filter(client) && ws.readyState === 1) {
-        this._sendOneWithBackpressure(ws, client, message)
+      if (!client.authenticated || ws.readyState !== 1) continue
+      let matched
+      try {
+        matched = filter(client)
+      } catch (err) {
+        if (!client._broadcastFilterThrewWarned) {
+          log.warn(`Broadcast filter threw for client ${client.id} (${message?.type || 'unknown'}): ${err?.message || err} — skipping client, broadcast continues`)
+          client._broadcastFilterThrewWarned = true
+        }
+        continue
       }
+      if (matched) this._sendOneWithBackpressure(ws, client, message)
+    }
+  }
+
+  /**
+   * Pure recipient predicate for session-scoped broadcasts: does this client's
+   * active session match, or has it explicitly subscribed? Single source of
+   * truth for the full-scan fallbacks of _broadcastToSession /
+   * _countSessionSubscribers / _hasDeflateSubscriber so they can never drift
+   * (deliver vs count vs deflate MUST agree).
+   */
+  _matchesSession(client, sessionId) {
+    if (client.activeSessionId === sessionId) return true
+    return !!(client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))
+  }
+
+  /**
+   * Yield `{ client, sock }` for each authenticated, OPEN member of a session's
+   * reverse index (#5563). Single source of the per-member liveness guard the
+   * three index fast paths (_broadcastToSession / _countSessionSubscribers /
+   * _hasDeflateSubscriber) previously triplicated — they MUST agree, so the
+   * guard lives here once. Yields nothing when no index is wired; callers then
+   * take their full-scan fallback.
+   */
+  * _liveSessionMembers(sessionId) {
+    if (!this._clientManager) return
+    for (const client of this._clientManager.getSessionSubscribers(sessionId)) {
+      if (!client.authenticated) continue
+      const sock = client._ws
+      if (!sock || sock.readyState !== 1) continue
+      yield { client, sock }
     }
   }
 
@@ -158,30 +207,24 @@ export class WsBroadcaster {
       // backpressure. Each client carries a stable `_ws` back-reference set at
       // registration (ws-server.js addClient), so no per-send Map lookup is
       // needed. The index Set holds only this session's viewers.
-      for (const client of this._clientManager.getSessionSubscribers(sessionId)) {
-        if (!client.authenticated) continue
-        const sock = client._ws
-        if (!sock || sock.readyState !== 1) continue
+      for (const { client, sock } of this._liveSessionMembers(sessionId)) {
         this._sendOneWithBackpressure(sock, client, tagged)
       }
       return
     }
 
-    // Full-scan fallback: no index (test fixtures) or a custom filter.
+    // Full-scan fallback: no index (test fixtures) or a custom filter. Route
+    // through _broadcast so the throwing-filter guard + backpressure decision
+    // live in exactly one place.
     const effectiveFilter = filter || ((client) => {
-      if (client.activeSessionId === sessionId) return true
-      if (client.subscribedSessionIds) return client.subscribedSessionIds.has(sessionId)
-      if (client.authenticated && !client._missingSubscribedSessionIdsWarned) {
+      if (this._matchesSession(client, sessionId)) return true
+      if (!client.subscribedSessionIds && !client._missingSubscribedSessionIdsWarned) {
         log.warn(`Client ${client.id} is authenticated but has no subscribedSessionIds Set — falling back to activeSessionId match only (sessionId=${sessionId}, messageType=${message?.type || 'unknown'})`)
         client._missingSubscribedSessionIdsWarned = true
       }
       return false
     })
-    for (const [ws, client] of this._clients) {
-      if (client.authenticated && effectiveFilter(client) && ws.readyState === 1) {
-        this._sendOneWithBackpressure(ws, client, tagged)
-      }
-    }
+    this._broadcast(tagged, effectiveFilter)
   }
 
   /**
@@ -204,22 +247,14 @@ export class WsBroadcaster {
     // total clients).
     if (this._clientManager) {
       let count = 0
-      for (const client of this._clientManager.getSessionSubscribers(sessionId)) {
-        if (!client.authenticated) continue
-        const sock = client._ws
-        if (!sock || sock.readyState !== 1) continue
-        count++
-      }
+      for (const _member of this._liveSessionMembers(sessionId)) count++
       return count
     }
     // Full-scan fallback for fixtures constructed without a clientManager.
     let count = 0
     for (const [ws, client] of this._clients) {
       if (!client.authenticated || ws.readyState !== 1) continue
-      if (client.activeSessionId === sessionId ||
-          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))) {
-        count++
-      }
+      if (this._matchesSession(client, sessionId)) count++
     }
     return count
   }
@@ -247,10 +282,7 @@ export class WsBroadcaster {
    */
   _hasDeflateSubscriber(sessionId) {
     if (this._clientManager) {
-      for (const client of this._clientManager.getSessionSubscribers(sessionId)) {
-        if (!client.authenticated) continue
-        const sock = client._ws
-        if (!sock || sock.readyState !== 1) continue
+      for (const { client } of this._liveSessionMembers(sessionId)) {
         if (client.usesDeflate) return true
       }
       return false
@@ -259,10 +291,7 @@ export class WsBroadcaster {
     for (const [ws, client] of this._clients) {
       if (!client.authenticated || ws.readyState !== 1) continue
       if (!client.usesDeflate) continue
-      if (client.activeSessionId === sessionId ||
-          (client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))) {
-        return true
-      }
+      if (this._matchesSession(client, sessionId)) return true
     }
     return false
   }
@@ -281,6 +310,22 @@ export class WsBroadcaster {
     }
     for (const [ws, client] of this._clients) {
       if (ws !== excludeWs && client.authenticated && ws.readyState === 1) {
+        this._sendOneWithBackpressure(ws, client, message)
+      }
+    }
+  }
+
+  /**
+   * Broadcast client_left to all OTHER authenticated clients. Mirror of
+   * _broadcastClientJoined — excludes the departing client by id (it may still
+   * be in the map mid-teardown) and routes through _sendOneWithBackpressure so
+   * the fan-out shares the same backpressure + metrics path as every other
+   * broadcast (was an open-coded loop in ws-server.js).
+   */
+  _broadcastClientLeft(departingClient) {
+    const message = { type: 'client_left', clientId: departingClient.id }
+    for (const [ws, client] of this._clients) {
+      if (client.id !== departingClient.id && client.authenticated && ws.readyState === 1) {
         this._sendOneWithBackpressure(ws, client, message)
       }
     }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -2067,6 +2067,11 @@ export class WsServer {
     this._broadcaster._broadcastClientJoined(newClient, excludeWs)
   }
 
+  /** Broadcast client_left to all OTHER authenticated clients */
+  _broadcastClientLeft(departingClient) {
+    this._broadcaster._broadcastClientLeft(departingClient)
+  }
+
   /**
    * #5555.6 — one keepalive sweep over all authenticated clients.
    *
@@ -2142,12 +2147,7 @@ export class WsServer {
     }
 
     // Broadcast client_left to remaining authenticated clients
-    const message = { type: 'client_left', clientId: departingClient.id }
-    for (const [ws, client] of this.clients) {
-      if (client.id !== departingClient.id && client.authenticated && ws.readyState === 1) {
-        this._send(ws, message)
-      }
-    }
+    this._broadcastClientLeft(departingClient)
   }
 
   /**

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -148,6 +148,29 @@ describe('WsBroadcaster', () => {
       assert.equal(sent.length, 1)
       assert.equal(sent[0].ws, ws2)
     })
+
+    it('a throwing filter does not abort delivery to later clients (audit 3b)', () => {
+      // A filter that throws on one client must skip ONLY that client — the
+      // legacy loop unwound the whole iteration, silently dropping the
+      // broadcast for every later client.
+      const ws1 = createFakeWs()
+      const wsBad = createFakeWs()
+      const ws3 = createFakeWs()
+      clients.set(ws1, createFakeClient({ id: 'c1' }))
+      clients.set(wsBad, createFakeClient({ id: 'bad' }))
+      clients.set(ws3, createFakeClient({ id: 'c3' }))
+
+      assert.doesNotThrow(() => {
+        broadcaster._broadcast({ type: 'x' }, (client) => {
+          if (client.id === 'bad') throw new Error('boom')
+          return true
+        })
+      })
+
+      // c1 and c3 both received it; only the throwing client was skipped.
+      const ids = sent.map((e) => clients.get(e.ws).id).sort()
+      assert.deepEqual(ids, ['c1', 'c3'])
+    })
   })
 
   describe('_broadcastToSession()', () => {
@@ -354,6 +377,59 @@ describe('WsBroadcaster', () => {
       assert.equal(sent[0].message.client.deviceName, null)
       assert.equal(sent[0].message.client.deviceType, 'unknown')
       assert.equal(sent[0].message.client.platform, 'unknown')
+    })
+  })
+
+  describe('_broadcastClientLeft()', () => {
+    it('sends client_left to all except the departing client', () => {
+      const wsGone = createFakeWs()
+      const wsOther1 = createFakeWs()
+      const wsOther2 = createFakeWs()
+      const departing = createFakeClient({ id: 'gone' })
+      clients.set(wsGone, departing)
+      clients.set(wsOther1, createFakeClient({ id: 'c1' }))
+      clients.set(wsOther2, createFakeClient({ id: 'c2' }))
+
+      broadcaster._broadcastClientLeft(departing)
+
+      assert.equal(sent.length, 2)
+      for (const entry of sent) {
+        assert.notEqual(clients.get(entry.ws).id, 'gone')
+        assert.equal(entry.message.type, 'client_left')
+        assert.equal(entry.message.clientId, 'gone')
+      }
+    })
+
+    it('skips unauthenticated and non-OPEN peers', () => {
+      const wsGone = createFakeWs()
+      const wsUnauth = createFakeWs()
+      const wsClosed = createFakeWs({ readyState: 3 })
+      const wsOk = createFakeWs()
+      const departing = createFakeClient({ id: 'gone' })
+      clients.set(wsGone, departing)
+      clients.set(wsUnauth, createFakeClient({ id: 'u', authenticated: false }))
+      clients.set(wsClosed, createFakeClient({ id: 'closed' }))
+      clients.set(wsOk, createFakeClient({ id: 'ok' }))
+
+      broadcaster._broadcastClientLeft(departing)
+
+      assert.equal(sent.length, 1)
+      assert.equal(clients.get(sent[0].ws).id, 'ok')
+    })
+
+    it('routes through backpressure (drops + counter) like other broadcasts', () => {
+      broadcaster = new WsBroadcaster({ clients, sendFn, backpressureThreshold: 100 })
+      const wsGone = createFakeWs()
+      const wsBack = createFakeWs({ bufferedAmount: 200 })
+      const departing = createFakeClient({ id: 'gone' })
+      const backClient = createFakeClient({ id: 'back' })
+      clients.set(wsGone, departing)
+      clients.set(wsBack, backClient)
+
+      broadcaster._broadcastClientLeft(departing)
+
+      assert.equal(sent.length, 0)
+      assert.equal(backClient._backpressureDrops, 1)
     })
   })
 


### PR DESCRIPTION
## Summary

Addresses the three **P2-8** findings from the 2026-06-15 swarm audit (`docs/audit/swarm-audit-2026-06-15.md` §3b), all in the broadcast layer:

1. **A throwing recipient filter aborted delivery to all later clients.** `_broadcast` and the full-scan branch of `_broadcastToSession` called `filter(client)` unguarded — one throw unwound the loop and silently dropped the broadcast for every *later* client. `_broadcast` now wraps the filter in `try/catch` + `continue` with a warn-once per client; `_broadcastToSession`'s fallback routes through `_broadcast`, so the guard lives in exactly one place. (No shipping filter throws today — #4799 hardened the default — but this is the resilient invariant the #5563 fast path already has.)

2. **Index per-member guard was triplicated** across `_broadcastToSession` / `_countSessionSubscribers` / `_hasDeflateSubscriber` (the `!authenticated → skip / _ws / readyState !== 1 → skip` block). These MUST agree (deliver vs count vs deflate), so they now share a single `_liveSessionMembers(sessionId)` generator. The full-scan fallback predicate is single-sourced into `_matchesSession()`.

3. **`client_left` fan-out was a fourth open-coded `O(clients)` loop** in `ws-server.js` that bypassed the broadcaster's backpressure + metrics path. Added `_broadcastClientLeft()` mirroring `_broadcastClientJoined()`; `ws-server.js` now delegates.

## Safety / behavior

Pure DRY + resilience refactor — no happy-path behavior change. The existing broadcaster suite, the ws-server broadcast suite, and the randomized **index-parity oracle** test all stay green. New tests cover the throwing-filter resilience and `_broadcastClientLeft` (recipients, auth/readyState skip, backpressure routing).

## Tests
- `ws-broadcaster.test.js` 63 pass, `ws-server-broadcast.test.js` 36 pass, `ws-server.test.js` 122 pass, `lint-ws-index-mutations.test.js` 10 pass, client-manager + backpressure suites green; eslint clean.

Part of the audit P2 backlog.