### PR TITLE
fix(tunnel): quick-tunnel error tail + unref timer + recovery generation guard (audit P2-11)

### DIFF
--- a/packages/server/src/server-cli/tunnel-lifecycle-handler.js
+++ b/packages/server/src/server-cli/tunnel-lifecycle-handler.js
@@ -115,12 +115,20 @@ export class TunnelLifecycleHandler {
     // 5. Wire up tunnel lifecycle events (before waitForTunnel to catch early failures)
     this._wireTunnelEvents(tunnel, wsServer)
 
+    // Newest-recovery-wins guard (audit P2-11): waitForTunnel can take ~90s, so
+    // a second tunnel_recovered firing during a prior re-verify would overlap —
+    // two loops racing on `currentWsUrl` and double-broadcasting the rotated URL.
+    // Each handler claims a generation; after its (long) await it bails if a
+    // newer recovery has since superseded it.
+    let recoveryGeneration = 0
+
     tunnel.on('tunnel_recovered', async ({ httpUrl: newHttpUrl, wsUrl: newWsUrl, attempt }) => {
       // #5314 (WP-1.4) — async event listener: waitForTunnel THROWS on a routine
       // DNS-settle failure, and an unhandled rejection here would hit server-cli's
       // unhandledRejection handler → process.exit(1), crashing the whole server on
       // a recoverable tunnel hiccup. Contain it: log and wait for the next
       // tunnel_recovered retry.
+      const myGeneration = ++recoveryGeneration
       try {
         log.info(`Tunnel recovered after ${attempt} attempt(s)`)
 
@@ -128,6 +136,13 @@ export class TunnelLifecycleHandler {
         await this._waitForTunnel(newHttpUrl, {
           initialDelay: tunnelArg.mode === 'quick' ? QUICK_TUNNEL_DNS_SETTLE_MS : 0,
         })
+
+        // A newer tunnel_recovered started while we were re-verifying — let it
+        // own the URL/QR update so the two don't race or double-broadcast.
+        if (myGeneration !== recoveryGeneration) {
+          log.info(`Stale tunnel_recovered (generation ${myGeneration}, newest ${recoveryGeneration}) — superseded, skipping`)
+          return
+        }
 
         // Only display new QR code if URL actually changed
         if (newWsUrl !== startupDisplay.currentWsUrl) {

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -9,6 +9,17 @@ const log = createLogger('tunnel')
 const CLOUDFLARED_OUTPUT_TAIL_CAP = 2000
 
 /**
+ * Redact + trim a raw cloudflared output tail for inclusion in a start-failure
+ * rejection. Centralized so the named AND quick paths redact identically — a
+ * token split across two `data` chunks survives a per-chunk redact, so the
+ * whole accumulated tail is redacted once here (#5366 review). Returns '' when
+ * the tail is empty.
+ */
+function redactedTail(rawTail) {
+  return redactSensitive(rawTail || '').trim()
+}
+
+/**
  * Cloudflare tunnel adapter.
  *
  * Quick mode: spawns `cloudflared tunnel --url` — random URL, no account needed.
@@ -142,7 +153,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       proc.on('close', (code, signal) => {
         if (!resolved) {
-          const tail = redactSensitive(outputTailRaw).trim()
+          const tail = redactedTail(outputTailRaw)
           reject(new Error(`cloudflared exited with code ${code} before establishing tunnel${tail ? `. Last output: ${tail}` : ''}`))
         } else if (!timedOut) {
           // A cold-start timeout already rejected and killed the process; the
@@ -164,10 +175,13 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           resolved = true
           timedOut = true
           proc.kill()
-          const tail = redactSensitive(outputTailRaw).trim()
+          const tail = redactedTail(outputTailRaw)
           reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)${tail ? ` Last output: ${tail}` : ''}`))
         }
       }, 30_000)
+      // Don't let the 30s start-timeout timer pin the event loop on success —
+      // it's only cleared on `proc.close`, but a healthy tunnel never closes.
+      timeoutHandle.unref?.()
 
       proc.once('close', () => {
         clearTimeout(timeoutHandle)
@@ -191,9 +205,16 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       // Per-attempt cold-start timeout flag — see _startNamedTunnel for why this
       // must not reuse the instance-wide `intentionalShutdown` kill switch.
       let timedOut = false
+      // Retain a redacted output tail so a start failure surfaces WHY (the most
+      // common failure mode), matching the named path (#5328/#5366). Accumulate
+      // raw + redact the whole tail once at emit time; stop after `resolved`.
+      let outputTailRaw = ''
 
       const handleOutput = (data) => {
         const text = data.toString()
+        if (!resolved) {
+          outputTailRaw = (outputTailRaw + text).slice(-CLOUDFLARED_OUTPUT_TAIL_CAP)
+        }
         const match = text.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/)
         if (match && !resolved) {
           resolved = true
@@ -226,7 +247,8 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       proc.on('close', (code, signal) => {
         if (!resolved) {
-          reject(new Error(`cloudflared exited with code ${code} before establishing tunnel`))
+          const tail = redactedTail(outputTailRaw)
+          reject(new Error(`cloudflared exited with code ${code} before establishing tunnel${tail ? `. Last output: ${tail}` : ''}`))
         } else if (!timedOut) {
           // A cold-start timeout already rejected and killed the process; the
           // `start()` retry loop owns the retry decision, so don't treat that
@@ -244,9 +266,12 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           resolved = true
           timedOut = true
           proc.kill()
-          reject(new Error('Tunnel timed out after 30s. Is cloudflared installed? (brew install cloudflared)'))
+          const tail = redactedTail(outputTailRaw)
+          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed? (brew install cloudflared)${tail ? ` Last output: ${tail}` : ''}`))
         }
       }, 30_000)
+      // Don't let the 30s start-timeout timer pin the event loop on success.
+      timeoutHandle.unref?.()
 
       proc.once('close', () => {
         clearTimeout(timeoutHandle)

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -176,7 +176,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           timedOut = true
           proc.kill()
           const tail = redactedTail(outputTailRaw)
-          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)${tail ? ` Last output: ${tail}` : ''}`))
+          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)${tail ? `. Last output: ${tail}` : ''}`))
         }
       }, 30_000)
       // Don't let the 30s start-timeout timer pin the event loop on success —
@@ -267,7 +267,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           timedOut = true
           proc.kill()
           const tail = redactedTail(outputTailRaw)
-          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed? (brew install cloudflared)${tail ? ` Last output: ${tail}` : ''}`))
+          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed? (brew install cloudflared)${tail ? `. Last output: ${tail}` : ''}`))
         }
       }, 30_000)
       // Don't let the 30s start-timeout timer pin the event loop on success.

--- a/packages/server/tests/tunnel-lifecycle-handler.test.js
+++ b/packages/server/tests/tunnel-lifecycle-handler.test.js
@@ -191,6 +191,30 @@ describe('TunnelLifecycleHandler — tunnel_recovered', () => {
     )
   })
 
+  it('newest-recovery-wins: a stale recovered handler bails after its re-verify (audit P2-11)', async () => {
+    // Two tunnel_recovered events fire back-to-back (a flap during a prior
+    // re-verify). Both suspend at their waitForTunnel await with generations
+    // 1 and 2; when the stale (gen-1) handler resumes it must bail so it can't
+    // race the newest on currentWsUrl or double-broadcast the rotated URL.
+    const { handler, tunnel, wsServer, startupDisplay } = build()
+    await handler.createAndStart()
+    startupDisplay.calls.length = 0
+    wsServer.urlChangedPushes.length = 0
+
+    tunnel.emit('tunnel_recovered', { httpUrl: 'https://a.example', wsUrl: 'wss://a.example', attempt: 1 })
+    tunnel.emit('tunnel_recovered', { httpUrl: 'https://b.example', wsUrl: 'wss://b.example', attempt: 2 })
+    // Let both handlers resume past their awaits.
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+
+    // Only the newest (b) updated the URL + rendered its QR; the stale (a) bailed.
+    assert.deepEqual(startupDisplay.calls, [['wss://b.example', 'https://b.example', 'cloudflare:quick']])
+    assert.equal(startupDisplay.currentWsUrl, 'wss://b.example')
+    assert.deepEqual(wsServer.urlChangedPushes, [
+      { url: 'wss://b.example', previousUrl: 'wss://t.example' },
+    ], 'only the newest recovery pushed a url-changed (no stale double-broadcast)')
+  })
+
   it('contains a waitForTunnel throw in the recovered handler (no crash)', async () => {
     let calls = 0
     const { handler, tunnel } = build({

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -155,6 +155,53 @@ describe('CloudflareTunnelAdapter', () => {
         },
       )
     })
+
+    it('includes the captured cloudflared output in a QUICK-tunnel failure (audit P2-11)', async () => {
+      // The default quick path previously rejected with only "exited with code N",
+      // dropping the real reason — now it retains the same redacted tail the
+      // named path does.
+      const mockSpawn = () => {
+        const proc = new EventEmitter()
+        proc.stdout = new EventEmitter()
+        proc.stderr = new EventEmitter()
+        proc.kill = function () { this.killed = true }
+        setImmediate(() => {
+          proc.stderr.emit('data', Buffer.from('ERR failed to connect to the Cloudflare edge'))
+          proc.emit('close', 1, null)
+        })
+        return proc
+      }
+      const tunnel = new TestCloudflareAdapter({ port: 3000, mockSpawn })
+
+      await assert.rejects(
+        () => tunnel._startQuickTunnel(),
+        /cloudflared exited with code 1 before establishing tunnel\. Last output: .*failed to connect to the Cloudflare edge/,
+      )
+    })
+
+    it('redacts token-shaped runs in the QUICK-tunnel captured output (audit P2-11)', async () => {
+      const secret = 'sk-ant-api03-' + 'A'.repeat(48)
+      const mockSpawn = () => {
+        const proc = new EventEmitter()
+        proc.stdout = new EventEmitter()
+        proc.stderr = new EventEmitter()
+        proc.kill = function () { this.killed = true }
+        setImmediate(() => {
+          proc.stderr.emit('data', Buffer.from(`ERR auth failed with token ${secret}`))
+          proc.emit('close', 1, null)
+        })
+        return proc
+      }
+      const tunnel = new TestCloudflareAdapter({ port: 3000, mockSpawn })
+
+      await tunnel._startQuickTunnel().then(
+        () => assert.fail('expected _startQuickTunnel() to reject'),
+        (err) => {
+          assert.match(err.message, /Last output:/)
+          assert.ok(!err.message.includes(secret), `token must be redacted, got: ${err.message}`)
+        },
+      )
+    })
   })
 
   describe('auto-recovery on unexpected exit', () => {


### PR DESCRIPTION
## Summary

Three tunnel-reliability findings from the 2026-06-15 swarm audit (`docs/audit/swarm-audit-2026-06-15.md` §3h), bundled as **P2-11**:

1. **Quick-tunnel start-failure dropped cloudflared's real output.** The named path retains a redacted output tail in its rejection (#5328/#5366); the **default** quick path rejected with only `exited with code N` — the most common failure, least diagnostic info. `_startQuickTunnel` now accumulates the same raw tail and emits a redacted `Last output:` suffix on both the close and timeout rejections. Extracted a shared `redactedTail()` helper so named + quick redact identically (a token split across two `data` chunks is redacted once over the whole tail).

2. **Cold-start timeout timer leaked on success.** The 30s timer is cleared only on `proc.close`, but a healthy long-lived tunnel never closes — so the non-`unref()`'d timer pinned the event loop for up to 30s (and re-armed per recovery attempt). Added `timeoutHandle.unref?.()` in both `_startNamedTunnel` and `_startQuickTunnel`.

3. **`tunnel_recovered` re-verification could run overlapping loops.** `waitForTunnel` can take ~90s; a flap during a prior re-verify overlapped, racing on `currentWsUrl` and double-broadcasting the rotated URL. Added a newest-recovery-wins generation guard — a stale handler bails after its await.

## Safety / behavior

Reliability hardening, no happy-path behavior change. Named-path output-tail behavior is unchanged (just routed through the shared helper). The `unref()` is guarded with `?.` for any non-Node timer. Existing tunnel suites stay green; new tests cover the quick-tunnel tail + redaction and the generation guard.

## Tests
- `tunnel/cloudflare.test.js` 23 pass, `tunnel-lifecycle-handler.test.js` 9 pass, full `tunnel/` dir green; eslint clean on `src/`.

Part of the audit P2 backlog.