### PR TITLE
refactor(server): declarative validateRange table for config numeric fields (audit P2-6)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -678,19 +678,26 @@ const NUMERIC_RANGE_CHECKS = [
   { key: 'port', min: 1, max: 65535, belowMessage: '(must be 1-65535)', aboveMessage: '(must be 1-65535)' },
   { key: 'maxSessions', min: 1, belowMessage: '(must be >= 1)' },
   { key: 'maxPayload', min: 1024, max: 100 * 1024 * 1024, belowMessage: '(minimum 1KB / 1024 bytes)', aboveMessage: '(maximum 100MB)' },
-  { key: 'resultTimeoutMs', min: 30_000, max: TWENTY_FOUR_HOURS_MS, belowMessage: '(minimum 30000 / 30s)', aboveMessage: '(maximum 86400000 / 24h)' },
-  { key: 'streamStallTimeoutMs', min: 5_000, max: TWENTY_FOUR_HOURS_MS, allowZero: true, belowMessage: '(minimum 5000 / 5s; set 0 to disable)', aboveMessage: '(maximum 86400000 / 24h)' },
-  { key: 'backgroundShellHardQuiesceMs', min: 60_000, max: TWENTY_FOUR_HOURS_MS, allowZero: true, belowMessage: '(minimum 60000 / 60s; set 0 to disable)', aboveMessage: '(maximum 86400000 / 24h)' },
+  { key: 'resultTimeoutMs', min: 30_000, max: TWENTY_FOUR_HOURS_MS, finiteOnly: true, belowMessage: '(minimum 30000 / 30s)', aboveMessage: '(maximum 86400000 / 24h)' },
+  { key: 'streamStallTimeoutMs', min: 5_000, max: TWENTY_FOUR_HOURS_MS, allowZero: true, finiteOnly: true, belowMessage: '(minimum 5000 / 5s; set 0 to disable)', aboveMessage: '(maximum 86400000 / 24h)' },
+  { key: 'backgroundShellHardQuiesceMs', min: 60_000, max: TWENTY_FOUR_HOURS_MS, allowZero: true, finiteOnly: true, belowMessage: '(minimum 60000 / 60s; set 0 to disable)', aboveMessage: '(maximum 86400000 / 24h)' },
 ]
 
 /**
- * Push an `Invalid value` warning when finite numeric `value` falls outside
- * [min, max]. No-ops on a non-finite value (the type-check loop already warned)
- * and on an explicit 0 when `allowZero` (the "disable" sentinel). `min`/`max`
- * are each optional (maxSessions has only a lower bound).
+ * Push an `Invalid value` warning when numeric `value` falls outside [min, max].
+ * Skips non-number / NaN (the type-check loop already warned). `allowZero` skips
+ * an explicit 0 (the "disable" sentinel). `min`/`max` are each optional
+ * (maxSessions has only a lower bound).
+ *
+ * `finiteOnly` selects the original per-field guard exactly: port/maxSessions/
+ * maxPayload historically used `typeof === 'number'`, so a parseFloat'd env like
+ * `PORT=Infinity` reaches the comparison and trips the bound — keep that. The
+ * timeout fields used `Number.isFinite`, which skips Infinity entirely — keep
+ * that too (finiteOnly: true).
  */
-function validateRange(warnings, key, value, { min, max, allowZero = false, belowMessage, aboveMessage }) {
-  if (!Number.isFinite(value)) return
+function validateRange(warnings, key, value, { min, max, allowZero = false, finiteOnly = false, belowMessage, aboveMessage }) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return
+  if (finiteOnly && !Number.isFinite(value)) return
   if (allowZero && value === 0) return
   if (min != null && value < min) {
     warnings.push(`Invalid value for '${key}': ${value} ${belowMessage}`)

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -659,6 +659,47 @@ export function isFatalConfigWarning(warning) {
 }
 
 /**
+ * Declarative range checks for the simple numeric config fields (audit P2-6).
+ * Each entry replaces a hand-rolled `if (Number.isFinite(value) ...)` block that
+ * was copy-pasted ~6 times — a shape where a forgotten `Number.isFinite` guard,
+ * a missed `allowZero`, or an inverted comparison silently flips validation.
+ *
+ * `belowMessage`/`aboveMessage` are the EXACT operator-facing suffixes (appended
+ * after `${value} `); wording is per-field by design (different unit labels).
+ * Only the `Invalid value` PREFIX is load-bearing — it must never become
+ * `Invalid type`, which the CLI treats as fatal (see FATAL_CONFIG_WARNING_PREFIX).
+ *
+ * Fields with extra logic stay bespoke in validateConfig: `sessionTimeout`
+ * (duration-string parse), `hardTimeoutMs` (cross-field vs resultTimeoutMs), and
+ * `providerStreamStallTimeoutMs` (per-entry map iteration).
+ */
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000
+const NUMERIC_RANGE_CHECKS = [
+  { key: 'port', min: 1, max: 65535, belowMessage: '(must be 1-65535)', aboveMessage: '(must be 1-65535)' },
+  { key: 'maxSessions', min: 1, belowMessage: '(must be >= 1)' },
+  { key: 'maxPayload', min: 1024, max: 100 * 1024 * 1024, belowMessage: '(minimum 1KB / 1024 bytes)', aboveMessage: '(maximum 100MB)' },
+  { key: 'resultTimeoutMs', min: 30_000, max: TWENTY_FOUR_HOURS_MS, belowMessage: '(minimum 30000 / 30s)', aboveMessage: '(maximum 86400000 / 24h)' },
+  { key: 'streamStallTimeoutMs', min: 5_000, max: TWENTY_FOUR_HOURS_MS, allowZero: true, belowMessage: '(minimum 5000 / 5s; set 0 to disable)', aboveMessage: '(maximum 86400000 / 24h)' },
+  { key: 'backgroundShellHardQuiesceMs', min: 60_000, max: TWENTY_FOUR_HOURS_MS, allowZero: true, belowMessage: '(minimum 60000 / 60s; set 0 to disable)', aboveMessage: '(maximum 86400000 / 24h)' },
+]
+
+/**
+ * Push an `Invalid value` warning when finite numeric `value` falls outside
+ * [min, max]. No-ops on a non-finite value (the type-check loop already warned)
+ * and on an explicit 0 when `allowZero` (the "disable" sentinel). `min`/`max`
+ * are each optional (maxSessions has only a lower bound).
+ */
+function validateRange(warnings, key, value, { min, max, allowZero = false, belowMessage, aboveMessage }) {
+  if (!Number.isFinite(value)) return
+  if (allowZero && value === 0) return
+  if (min != null && value < min) {
+    warnings.push(`Invalid value for '${key}': ${value} ${belowMessage}`)
+  } else if (max != null && value > max) {
+    warnings.push(`Invalid value for '${key}': ${value} ${aboveMessage}`)
+  }
+}
+
+/**
  * Validate config object against schema.
  * Logs warnings for unknown keys and type mismatches.
  *
@@ -691,13 +732,12 @@ export function validateConfig(config, verbose = false) {
     }
   }
 
-  // Range validation for numeric and duration fields (only when type is correct)
-  if (typeof config.port === 'number' && (config.port < 1 || config.port > 65535)) {
-    warnings.push(`Invalid value for 'port': ${config.port} (must be 1-65535)`)
-  }
-
-  if (typeof config.maxSessions === 'number' && config.maxSessions < 1) {
-    warnings.push(`Invalid value for 'maxSessions': ${config.maxSessions} (must be >= 1)`)
+  // Range validation for the simple numeric fields (audit P2-6) — declarative
+  // table + shared validateRange; the Number.isFinite guard skips fields whose
+  // type the loop above already flagged. Duration/cross-field/map cases below
+  // stay bespoke.
+  for (const check of NUMERIC_RANGE_CHECKS) {
+    validateRange(warnings, check.key, config[check.key], check)
   }
 
   if (typeof config.sessionTimeout === 'string' && config.sessionTimeout.length > 0) {
@@ -706,26 +746,6 @@ export function validateConfig(config, verbose = false) {
       warnings.push(`Invalid duration format for 'sessionTimeout': '${config.sessionTimeout}'`)
     } else if (ms < 30_000) {
       warnings.push(`Value for 'sessionTimeout' is too low: '${config.sessionTimeout}' (minimum 30s)`)
-    }
-  }
-
-  if (typeof config.maxPayload === 'number') {
-    if (config.maxPayload < 1024) {
-      warnings.push(`Invalid value for 'maxPayload': ${config.maxPayload} (minimum 1KB / 1024 bytes)`)
-    } else if (config.maxPayload > 100 * 1024 * 1024) {
-      warnings.push(`Invalid value for 'maxPayload': ${config.maxPayload} (maximum 100MB)`)
-    }
-  }
-
-  // #3749: result-timeout range. Below 30s a slow tool reliably tips into
-  // false positives; above 24h the safety net is effectively disabled.
-  // Number.isFinite rejects NaN/Infinity (typeof both === 'number') so a
-  // sentinel-like sentinel can't silently slip past the bounds check.
-  if (Number.isFinite(config.resultTimeoutMs)) {
-    if (config.resultTimeoutMs < 30_000) {
-      warnings.push(`Invalid value for 'resultTimeoutMs': ${config.resultTimeoutMs} (minimum 30000 / 30s)`)
-    } else if (config.resultTimeoutMs > 24 * 60 * 60 * 1000) {
-      warnings.push(`Invalid value for 'resultTimeoutMs': ${config.resultTimeoutMs} (maximum 86400000 / 24h)`)
     }
   }
 
@@ -742,26 +762,6 @@ export function validateConfig(config, verbose = false) {
       warnings.push(`Invalid value for 'hardTimeoutMs': ${config.hardTimeoutMs} (maximum 86400000 / 24h)`)
     } else if (Number.isFinite(config.resultTimeoutMs) && config.hardTimeoutMs < config.resultTimeoutMs) {
       warnings.push(`'hardTimeoutMs' (${config.hardTimeoutMs}) is less than 'resultTimeoutMs' (${config.resultTimeoutMs}) — the soft warning will never fire before the hard kill`)
-    }
-  }
-
-  // #4467: stream-stall range. 0 is valid (disable). Otherwise 5s-24h.
-  if (Number.isFinite(config.streamStallTimeoutMs) && config.streamStallTimeoutMs !== 0) {
-    if (config.streamStallTimeoutMs < 5_000) {
-      warnings.push(`Invalid value for 'streamStallTimeoutMs': ${config.streamStallTimeoutMs} (minimum 5000 / 5s; set 0 to disable)`)
-    } else if (config.streamStallTimeoutMs > 24 * 60 * 60 * 1000) {
-      warnings.push(`Invalid value for 'streamStallTimeoutMs': ${config.streamStallTimeoutMs} (maximum 86400000 / 24h)`)
-    }
-  }
-
-  // #5288: background-shell hard-quiesce range. 0 is valid (disable). Otherwise
-  // 60s-24h — below the 60s advisory quiesce window makes no sense, above 24h
-  // is the shared ceiling.
-  if (Number.isFinite(config.backgroundShellHardQuiesceMs) && config.backgroundShellHardQuiesceMs !== 0) {
-    if (config.backgroundShellHardQuiesceMs < 60_000) {
-      warnings.push(`Invalid value for 'backgroundShellHardQuiesceMs': ${config.backgroundShellHardQuiesceMs} (minimum 60000 / 60s; set 0 to disable)`)
-    } else if (config.backgroundShellHardQuiesceMs > 24 * 60 * 60 * 1000) {
-      warnings.push(`Invalid value for 'backgroundShellHardQuiesceMs': ${config.backgroundShellHardQuiesceMs} (maximum 86400000 / 24h)`)
     }
   }
 

--- a/packages/server/tests/config-range-validation.test.js
+++ b/packages/server/tests/config-range-validation.test.js
@@ -113,6 +113,38 @@ describe('validateConfig range validation', () => {
     assert.ok(result.warnings.some(w => w.includes('expected number')))
     assert.ok(!result.warnings.some(w => w.includes('1-65535')))
   })
+
+  // Infinity is a typeof 'number' that parseFloat can mint from an env var
+  // (PORT=Infinity). port/maxPayload historically used `typeof === 'number'`, so
+  // an out-of-range Infinity must still warn (regression guard for the P2-6
+  // validateRange table — the timeout fields below intentionally do NOT).
+  it('warns when port is Infinity (exceeds max via typeof-number guard)', () => {
+    const result = validateConfig({ port: Infinity })
+    assert.ok(result.warnings.some(w => w.includes('port') && w.includes('1-65535')))
+  })
+
+  it('warns when port is -Infinity (below min)', () => {
+    const result = validateConfig({ port: -Infinity })
+    assert.ok(result.warnings.some(w => w.includes('port') && w.includes('1-65535')))
+  })
+
+  it('warns when maxPayload is Infinity (exceeds 100MB)', () => {
+    const result = validateConfig({ maxPayload: Infinity })
+    assert.ok(result.warnings.some(w => w.includes('maxPayload') && w.includes('100MB')))
+  })
+
+  it('warns when maxSessions is -Infinity (below 1)', () => {
+    const result = validateConfig({ maxSessions: -Infinity })
+    assert.ok(result.warnings.some(w => w.includes('maxSessions') && w.includes('>= 1')))
+  })
+
+  // The timeout fields used Number.isFinite originally — Infinity is skipped
+  // (no range warning), preserved via finiteOnly. NaN never warns anywhere.
+  it('does NOT emit a range warning for an Infinity timeout field (finiteOnly)', () => {
+    const result = validateConfig({ resultTimeoutMs: Infinity, streamStallTimeoutMs: Infinity })
+    assert.ok(!result.warnings.some(w => w.includes('resultTimeoutMs')))
+    assert.ok(!result.warnings.some(w => w.includes('streamStallTimeoutMs')))
+  })
 })
 
 /**


### PR DESCRIPTION
## Summary

Addresses the `validateRange` half of audit **P2-6** (`docs/audit/swarm-audit-2026-06-15.md` §3e). `validateConfig` carried ~6 hand-rolled numeric range blocks (`port`, `maxSessions`, `maxPayload`, `resultTimeoutMs`, `streamStallTimeoutMs`, `backgroundShellHardQuiesceMs`) — a copy-paste shape where a forgotten `Number.isFinite` guard, a missed `allowZero`, or an inverted comparison silently flips validation.

Replaced them with a declarative `NUMERIC_RANGE_CHECKS` table + a shared `validateRange(warnings, key, value, {min, max, allowZero, belowMessage, aboveMessage})` helper.

### Kept bespoke (per the audit)
- `sessionTimeout` — duration-string parse
- `hardTimeoutMs` — cross-field check vs `resultTimeoutMs`
- `providerStreamStallTimeoutMs` — per-entry map iteration

### Wording preserved
`belowMessage`/`aboveMessage` are the exact operator-facing suffixes; the load-bearing `Invalid value` prefix is unchanged (never `Invalid type`, which the CLI treats as fatal — `FATAL_CONFIG_WARNING_PREFIX`).

## Scope note
The second half of P2-6 — `warnUnknownKeys` for the k8s/billing/worktreeGc/rancher typo-acceptance gap — is split into **#5878** (it needs careful per-block known-key enumeration; a wrong set means false warnings).

## Safety

Behavior-preserving. `config-range-validation.test.js` (54), `config.test.js` (95), and the adjacent config suites — discord/worktree-gc/backend-selection/skip-permissions (64) — all stay green; eslint clean. The range tests assert on message substrings (`1-65535`, `>= 1`, `1KB`, `100MB`, `30s`, `set 0 to disable`), all preserved.

Part of the audit P2 backlog.