### PR TITLE
test(server): transitive opt-forwarding lint discovery (audit P2-1)

### DIFF
--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -286,43 +286,53 @@ function parseBaseSessionOptKeysArray(baseSessionPath) {
 // regex matched only the two roots, so those six were invisible to the lint.
 const ROOT_SESSION_BASES = ['BaseSession', 'JsonlSubprocessSession']
 
-// Parents whose subclasses must NOT forward via the buildBaseSessionOpts()
+// Ancestors whose descendants must NOT forward via the buildBaseSessionOpts()
 // picker: ClaudeByokSession reads provider-local opts (mcpConfigPath /
 // mcpToolCallTimeoutMs / mcpStartCapMs) off the RAW opts object, which the
 // picker — copying only the 20 BASE_SESSION_OPT_KEYS — would silently drop. A
 // spread/positional super forwards them. #5367 moved the middle-layer trap from
-// base opts onto these provider-local opts (audit P2-1, second finding).
-const PICKER_FORBIDDEN_PARENTS = new Set(['ClaudeByokSession'])
+// base opts onto these provider-local opts (audit P2-1, second finding). The ban
+// applies to EVERY transitive descendant (a grandchild via the picker drops the
+// opts one level deeper), not just direct children — ClaudeByokSession itself is
+// exempt: it IS the consumer and correctly uses the picker toward BaseSession.
+const PICKER_FORBIDDEN_ANCESTORS = ['ClaudeByokSession']
 
 // Matches `class X extends Y` (with or without `export`, any indentation — the
 // factory-defined AnthropicCompatibleSession is a plain `class`, not exported).
 const ANY_CLASS_RE = /(?:export\s+)?class\s+([A-Za-z_$][\w$]*)\s+extends\s+([A-Za-z_$][\w$]*)\b/g
 
-/**
- * Transitively discover every session subclass name by fixpoint: seed with the
- * roots, then repeatedly add any `class X extends Y` whose Y is already known
- * until closure. `allStrippedSources` is every session file's comment-stripped
- * source. Returns the full Set of base names (roots included).
- */
-function discoverSessionBases(allStrippedSources) {
+/** Collect every `class X extends Y` edge ({ child, parent }) across all sources. */
+function collectClassEdges(allStrippedSources) {
   const edges = []
   for (const stripped of allStrippedSources) {
     for (const m of stripped.matchAll(ANY_CLASS_RE)) {
       edges.push({ child: m[1], parent: m[2] })
     }
   }
-  const bases = new Set(ROOT_SESSION_BASES)
+  return edges
+}
+
+/**
+ * Transitive descendant closure by fixpoint: starting from `seeds`, repeatedly
+ * add any `class X extends Y` whose Y is a seed or already-collected descendant,
+ * until closure. `includeSeeds` controls whether the seeds themselves are in the
+ * result (true for session-base discovery — the roots ARE bases; false for the
+ * picker ban — the ancestor itself is exempt, only its descendants are banned).
+ */
+function descendantClosure(edges, seeds, { includeSeeds }) {
+  const seedSet = new Set(seeds)
+  const out = new Set(includeSeeds ? seeds : [])
   let changed = true
   while (changed) {
     changed = false
     for (const { child, parent } of edges) {
-      if (bases.has(parent) && !bases.has(child)) {
-        bases.add(child)
+      if ((seedSet.has(parent) || out.has(parent)) && !out.has(child)) {
+        out.add(child)
         changed = true
       }
     }
   }
-  return bases
+  return out
 }
 
 /** Build a `class X extends <one of baseNames>` global matcher (m[1]=class, m[2]=parent). */
@@ -527,10 +537,14 @@ function main() {
   }
 
   const allFiles = walk(SRC_DIR)
-  // Discover the transitive session-base closure across ALL files (incl.
-  // base-session.js) so the fixpoint sees every `class … extends …` edge, then
-  // build the matcher that picks up direct AND second-tier subclasses.
-  const sessionBases = discoverSessionBases(allFiles.map(f => stripComments(readFileSync(f, 'utf8'))))
+  // Collect every class→parent edge across ALL files (incl. base-session.js) so
+  // both fixpoints see the full graph, then derive: the session-base closure
+  // (roots + every transitive subclass → the scan matcher picks up direct AND
+  // second-tier subclasses) and the picker-ban set (every transitive descendant
+  // of a forbidden ancestor, ancestor itself exempt).
+  const classEdges = collectClassEdges(allFiles.map(f => stripComments(readFileSync(f, 'utf8'))))
+  const sessionBases = descendantClosure(classEdges, ROOT_SESSION_BASES, { includeSeeds: true })
+  const pickerForbidden = descendantClosure(classEdges, PICKER_FORBIDDEN_ANCESTORS, { includeSeeds: false })
   const classRe = buildSessionClassRegex(sessionBases)
 
   const files = allFiles.filter(f => !f.endsWith('/base-session.js'))
@@ -545,7 +559,6 @@ function main() {
     let m
     while ((m = classRe.exec(strippedSrc)) !== null) {
       const className = m[1]
-      const parentName = m[2]
       const classDeclIdx = m.index
       const declLine = lineOf(strippedSrc, classDeclIdx)
       const ignore = findIgnoreList(origSrc, declLine)
@@ -559,8 +572,11 @@ function main() {
       // parent reads provider-local opts off raw opts (audit P2-1), where the
       // picker drops them.
       if (analysis.compliant === 'picker') {
-        if (PICKER_FORBIDDEN_PARENTS.has(parentName)) {
-          offenders.push({ file, line: declLine, className, pickerForbidden: parentName })
+        // Banned for EVERY transitive descendant of a forbidden ancestor, not
+        // just direct children — a grandchild via the picker drops the
+        // provider-local opts one level deeper.
+        if (pickerForbidden.has(className)) {
+          offenders.push({ file, line: declLine, className, pickerForbidden: true })
         }
         continue
       }
@@ -612,10 +628,10 @@ function main() {
     for (const o of offenders) {
       console.error(`  ${o.file}:${o.line}  class ${o.className}`)
       if (o.pickerForbidden) {
-        console.error(`    Uses super(buildBaseSessionOpts(...)) but extends ${o.pickerForbidden}, which`)
-        console.error('    reads provider-local opts (mcpConfigPath / mcpToolCallTimeoutMs / mcpStartCapMs)')
-        console.error('    off raw opts — the picker copies only BASE_SESSION_OPT_KEYS and would silently')
-        console.error('    drop them. Forward with super({ ...opts, <overrides> }) instead.')
+        console.error('    Uses super(buildBaseSessionOpts(...)) but descends from ClaudeByokSession,')
+        console.error('    which reads provider-local opts (mcpConfigPath / mcpToolCallTimeoutMs /')
+        console.error('    mcpStartCapMs) off raw opts — the picker copies only BASE_SESSION_OPT_KEYS and')
+        console.error('    would silently drop them. Forward with super({ ...opts, <overrides> }) instead.')
         continue
       }
       if (o.unrecognizedSuper !== undefined) {

--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -277,7 +277,59 @@ function parseBaseSessionOptKeysArray(baseSessionPath) {
 // Subclass scanning
 // ----------------------------------------------------------------------
 
-const CLASS_RE = /export\s+class\s+([A-Za-z_$][\w$]*)\s+extends\s+(BaseSession|JsonlSubprocessSession)\b/g
+// Root session base classes. Every class whose `extends` chain reaches one of
+// these — transitively — is a session subclass the opt-forwarding rule applies
+// to. The full set is discovered by fixpoint (discoverSessionBases) so the
+// SECOND middle layer is analyzed too: DockerSdkSession extends SdkSession, the
+// four ClaudeByokSession variants (Anthropic-compatible/DeepSeek/Ollama/
+// docker-byok), and DockerSession extends CliSession (audit P2-1). The old fixed
+// regex matched only the two roots, so those six were invisible to the lint.
+const ROOT_SESSION_BASES = ['BaseSession', 'JsonlSubprocessSession']
+
+// Parents whose subclasses must NOT forward via the buildBaseSessionOpts()
+// picker: ClaudeByokSession reads provider-local opts (mcpConfigPath /
+// mcpToolCallTimeoutMs / mcpStartCapMs) off the RAW opts object, which the
+// picker — copying only the 20 BASE_SESSION_OPT_KEYS — would silently drop. A
+// spread/positional super forwards them. #5367 moved the middle-layer trap from
+// base opts onto these provider-local opts (audit P2-1, second finding).
+const PICKER_FORBIDDEN_PARENTS = new Set(['ClaudeByokSession'])
+
+// Matches `class X extends Y` (with or without `export`, any indentation — the
+// factory-defined AnthropicCompatibleSession is a plain `class`, not exported).
+const ANY_CLASS_RE = /(?:export\s+)?class\s+([A-Za-z_$][\w$]*)\s+extends\s+([A-Za-z_$][\w$]*)\b/g
+
+/**
+ * Transitively discover every session subclass name by fixpoint: seed with the
+ * roots, then repeatedly add any `class X extends Y` whose Y is already known
+ * until closure. `allStrippedSources` is every session file's comment-stripped
+ * source. Returns the full Set of base names (roots included).
+ */
+function discoverSessionBases(allStrippedSources) {
+  const edges = []
+  for (const stripped of allStrippedSources) {
+    for (const m of stripped.matchAll(ANY_CLASS_RE)) {
+      edges.push({ child: m[1], parent: m[2] })
+    }
+  }
+  const bases = new Set(ROOT_SESSION_BASES)
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const { child, parent } of edges) {
+      if (bases.has(parent) && !bases.has(child)) {
+        bases.add(child)
+        changed = true
+      }
+    }
+  }
+  return bases
+}
+
+/** Build a `class X extends <one of baseNames>` global matcher (m[1]=class, m[2]=parent). */
+function buildSessionClassRegex(baseNames) {
+  const alt = [...baseNames].map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  return new RegExp(`(?:export\\s+)?class\\s+([A-Za-z_$][\\w$]*)\\s+extends\\s+(${alt})\\b`, 'g')
+}
 
 function lineOf(src, idx) {
   return src.slice(0, idx).split('\n').length
@@ -474,18 +526,26 @@ function main() {
     }
   }
 
-  const files = walk(SRC_DIR).filter(f => !f.endsWith('/base-session.js'))
+  const allFiles = walk(SRC_DIR)
+  // Discover the transitive session-base closure across ALL files (incl.
+  // base-session.js) so the fixpoint sees every `class … extends …` edge, then
+  // build the matcher that picks up direct AND second-tier subclasses.
+  const sessionBases = discoverSessionBases(allFiles.map(f => stripComments(readFileSync(f, 'utf8'))))
+  const classRe = buildSessionClassRegex(sessionBases)
+
+  const files = allFiles.filter(f => !f.endsWith('/base-session.js'))
   const offenders = []
   let analyzedCount = 0
 
   for (const file of files) {
     const origSrc = readFileSync(file, 'utf8')
-    if (!CLASS_RE.test(origSrc)) continue
-    CLASS_RE.lastIndex = 0
+    if (!classRe.test(origSrc)) continue
+    classRe.lastIndex = 0
     const strippedSrc = stripComments(origSrc)
     let m
-    while ((m = CLASS_RE.exec(strippedSrc)) !== null) {
+    while ((m = classRe.exec(strippedSrc)) !== null) {
       const className = m[1]
+      const parentName = m[2]
       const classDeclIdx = m.index
       const declLine = lineOf(strippedSrc, classDeclIdx)
       const ignore = findIgnoreList(origSrc, declLine)
@@ -494,9 +554,16 @@ function main() {
       analyzedCount++
 
       // #5367: `super(buildBaseSessionOpts(...))` — compliant by construction
-      // (coverage guaranteed by the array-vs-ctor assertion above + the picker
-      // copying every key). Counts as analyzed-and-ok.
-      if (analysis.compliant === 'picker') continue
+      // for BASE opts (coverage guaranteed by the array-vs-ctor assertion above
+      // + the picker copying every key). Counts as analyzed-and-ok — UNLESS the
+      // parent reads provider-local opts off raw opts (audit P2-1), where the
+      // picker drops them.
+      if (analysis.compliant === 'picker') {
+        if (PICKER_FORBIDDEN_PARENTS.has(parentName)) {
+          offenders.push({ file, line: declLine, className, pickerForbidden: parentName })
+        }
+        continue
+      }
 
       // #5367: an unrecognized super() shape (not the picker, not a bare
       // identifier/spread, not an object literal) could silently drop keys.
@@ -536,7 +603,7 @@ function main() {
         })
       }
     }
-    CLASS_RE.lastIndex = 0
+    classRe.lastIndex = 0
   }
 
   if (offenders.length) {
@@ -544,6 +611,13 @@ function main() {
     console.error('')
     for (const o of offenders) {
       console.error(`  ${o.file}:${o.line}  class ${o.className}`)
+      if (o.pickerForbidden) {
+        console.error(`    Uses super(buildBaseSessionOpts(...)) but extends ${o.pickerForbidden}, which`)
+        console.error('    reads provider-local opts (mcpConfigPath / mcpToolCallTimeoutMs / mcpStartCapMs)')
+        console.error('    off raw opts — the picker copies only BASE_SESSION_OPT_KEYS and would silently')
+        console.error('    drop them. Forward with super({ ...opts, <overrides> }) instead.')
+        continue
+      }
       if (o.unrecognizedSuper !== undefined) {
         console.error(`    Unrecognized super() shape: super(${o.unrecognizedSuper}...)`)
         console.error('    Expected super(buildBaseSessionOpts(opts, { ...overrides })), super(opts),')

--- a/packages/server/tests/lint-session-opt-forwarding.test.js
+++ b/packages/server/tests/lint-session-opt-forwarding.test.js
@@ -383,6 +383,129 @@ describe('lint-session-opt-forwarding', () => {
     )
   })
 
+  // audit P2-1 — a SECOND-tier subclass (extends a middle layer, not a root)
+  // that drops an opt via an object-literal super. Pre-P2-1 the fixed
+  // `extends (BaseSession|JsonlSubprocessSession)` regex never saw it, so the
+  // trap re-armed silently one layer down. Transitive discovery must flag it.
+  test('flags a second-tier subclass (extends a middle layer) that drops an opt — P2-1', () => {
+    const MID_LAYER_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class MidProviderSession extends BaseSession {
+  constructor(opts = {}) {
+    super({ ...opts })
+  }
+}
+`
+    const SECOND_TIER_DROP_SRC = `
+import { MidProviderSession } from './mid-provider-session.js'
+
+export class LeafProviderSession extends MidProviderSession {
+  constructor({ cwd } = {}) {
+    super({ cwd })
+  }
+}
+`
+    const { dir, srcDir } = setupFixtureTree({
+      'mid-provider-session.js': MID_LAYER_SRC,
+      'leaf-provider-session.js': SECOND_TIER_DROP_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'second-tier object-literal drop must fail via transitive discovery')
+    assert.match(stderr, /LeafProviderSession/, 'error should name the second-tier class')
+    assert.match(stderr, /model|permissionMode|streamStallTimeoutMs/, 'error should name a dropped opt')
+  })
+
+  // audit P2-1 — discovery must match a PLAIN `class` (no `export`), the shape
+  // of the factory-defined AnthropicCompatibleSession. The old regex required
+  // `export class`, so a non-exported session subclass was invisible.
+  test('discovers a non-exported `class` and flags its dropped opt — P2-1', () => {
+    const PLAIN_CLASS_DROP_SRC = `
+import { BaseSession } from './base-session.js'
+
+// not exported — defined for use within this module / a factory
+class PlainLeafSession extends BaseSession {
+  constructor({ cwd } = {}) {
+    super({ cwd })
+  }
+}
+
+export function makePlainLeaf(opts) { return new PlainLeafSession(opts) }
+`
+    const { dir, srcDir } = setupFixtureTree({
+      'plain-leaf-session.js': PLAIN_CLASS_DROP_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'a non-exported session subclass must still be analyzed')
+    assert.match(stderr, /PlainLeafSession/, 'error should name the plain class')
+  })
+
+  // audit P2-1 (second finding) — a class extending ClaudeByokSession must NOT
+  // forward via the buildBaseSessionOpts() picker: ClaudeByokSession reads
+  // provider-local opts off raw opts, which the picker (base keys only) drops.
+  test('bans the picker on a subclass of ClaudeByokSession — P2-1', () => {
+    const BYOK_BASE_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class ClaudeByokSession extends BaseSession {
+  constructor(opts = {}) {
+    super({ ...opts, provider: opts.provider || 'claude-byok' })
+  }
+}
+`
+    const BYOK_PICKER_SUBCLASS_SRC = `
+import { buildBaseSessionOpts } from './base-session.js'
+import { ClaudeByokSession } from './byok-session.js'
+
+export class DeepSeekSession extends ClaudeByokSession {
+  constructor(opts = {}) {
+    super(buildBaseSessionOpts(opts, { provider: 'deepseek' }))
+  }
+}
+`
+    const { dir, srcDir } = setupFixtureTree({
+      'byok-session.js': BYOK_BASE_SRC,
+      'deepseek-session.js': BYOK_PICKER_SUBCLASS_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'picker on a ClaudeByokSession subclass must fail')
+    assert.match(stderr, /DeepSeekSession/, 'error should name the offending subclass')
+    assert.match(stderr, /provider-local|picker|buildBaseSessionOpts/, 'error should explain the picker ban')
+  })
+
+  // audit P2-1 — control: a ClaudeByokSession subclass using a SPREAD super
+  // (the real shape) is fine; the ban targets ONLY the picker.
+  test('allows a spread super on a subclass of ClaudeByokSession — P2-1', () => {
+    const BYOK_BASE_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class ClaudeByokSession extends BaseSession {
+  constructor(opts = {}) {
+    super({ ...opts, provider: opts.provider || 'claude-byok' })
+  }
+}
+`
+    const BYOK_SPREAD_SUBCLASS_SRC = `
+import { ClaudeByokSession } from './byok-session.js'
+
+export class OllamaSession extends ClaudeByokSession {
+  constructor(opts = {}) {
+    super({ ...opts, provider: 'ollama' })
+  }
+}
+`
+    const { dir, srcDir } = setupFixtureTree({
+      'byok-session.js': BYOK_BASE_SRC,
+      'ollama-session.js': BYOK_SPREAD_SUBCLASS_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stdout, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `spread super on a byok subclass is fine\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+  })
+
   test('per-key allowlist comment suppresses a specific drop', () => {
     // Class can opt-out a specific key via a marker comment placed
     // immediately above the class declaration. Use case: a future

--- a/packages/server/tests/lint-session-opt-forwarding.test.js
+++ b/packages/server/tests/lint-session-opt-forwarding.test.js
@@ -476,6 +476,51 @@ export class DeepSeekSession extends ClaudeByokSession {
     assert.match(stderr, /provider-local|picker|buildBaseSessionOpts/, 'error should explain the picker ban')
   })
 
+  // audit P2-1 — the picker ban must reach TRANSITIVE descendants, not just
+  // direct children: a grandchild (extends DeepSeekSession extends
+  // ClaudeByokSession) using the picker still drops the provider-local opts one
+  // level deeper. Must be flagged.
+  test('bans the picker on a GRANDCHILD of ClaudeByokSession — P2-1', () => {
+    const BYOK_BASE_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class ClaudeByokSession extends BaseSession {
+  constructor(opts = {}) {
+    super({ ...opts, provider: opts.provider || 'claude-byok' })
+  }
+}
+`
+    const MID_BYOK_SRC = `
+import { ClaudeByokSession } from './byok-session.js'
+
+export class DeepSeekSession extends ClaudeByokSession {
+  constructor(opts = {}) {
+    super({ ...opts, provider: 'deepseek' })
+  }
+}
+`
+    const GRANDCHILD_PICKER_SRC = `
+import { buildBaseSessionOpts } from './base-session.js'
+import { DeepSeekSession } from './deepseek-session.js'
+
+export class DeepSeekProSession extends DeepSeekSession {
+  constructor(opts = {}) {
+    super(buildBaseSessionOpts(opts, { provider: 'deepseek-pro' }))
+  }
+}
+`
+    const { dir, srcDir } = setupFixtureTree({
+      'byok-session.js': BYOK_BASE_SRC,
+      'deepseek-session.js': MID_BYOK_SRC,
+      'deepseek-pro-session.js': GRANDCHILD_PICKER_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'picker on a grandchild of ClaudeByokSession must fail')
+    assert.match(stderr, /DeepSeekProSession/, 'error should name the grandchild')
+    assert.match(stderr, /provider-local|ClaudeByokSession|buildBaseSessionOpts/, 'error should explain the picker ban')
+  })
+
   // audit P2-1 — control: a ClaudeByokSession subclass using a SPREAD super
   // (the real shape) is fine; the ban targets ONLY the picker.
   test('allows a spread super on a subclass of ClaudeByokSession — P2-1', () => {


### PR DESCRIPTION
## Summary

Addresses audit **P2-1** (`docs/audit/swarm-audit-2026-06-15.md` §3a) — the opt-forwarding lint (`scripts/lint-session-opt-forwarding.mjs`) only matched `class X extends (BaseSession | JsonlSubprocessSession)`, so **six second-tier provider sessions were never analyzed**:

- `DockerSdkSession` → `SdkSession`
- `AnthropicCompatibleSession` / `DeepSeekSession` / `OllamaSession` / `DockerByokSession` → `ClaudeByokSession`
- `DockerSession` → `CliSession`

All six are safe today (spread/positional supers), but a maintainer adding a key-dropping object-literal `super({...})` one layer down would silently re-arm the middle-layer trap (`feedback_jsonl_subprocess_middle_layer.md`; #3224/#3231/#4790) with **no lint flag**.

## Changes

1. **Transitive discovery** — `discoverSessionBases()` computes the session-base closure by fixpoint over `class X extends Y` edges (seeded from the two roots), and the scan matcher is built from that closure. Second-tier subclasses are now analyzed.
2. **Plain `class`** — discovery matches `class` with or without `export` (the factory-defined `AnthropicCompatibleSession` is not exported).
3. **Picker ban on `ClaudeByokSession` subclasses** — `super(buildBaseSessionOpts(...))` copies only `BASE_SESSION_OPT_KEYS`, but `ClaudeByokSession` reads provider-local opts (`mcpConfigPath` / `mcpToolCallTimeoutMs` / `mcpStartCapMs`) off raw `opts`. #5367 moved the trap onto those; the lint now fails the picker on a `ClaudeByokSession` subclass (spread/positional still required there).

## Safety

Coverage-only change — the real tree still passes (`OK: …`; all six second-tier classes use spread/positional supers). 14 lint tests pass (10 existing + 4 new): a second-tier object-literal drop is flagged, a non-exported class is discovered, the picker-ban fires on a `ClaudeByokSession` subclass, and a spread super on a byok subclass is allowed (no false positive). Runs in both Server Tests and Server Lint (`.sh` wrapper).

Part of the audit P2 backlog.