### PR TITLE
refactor(server): P2-9 provider DRY pack (permission wiring, stream guard, credential reader)

### DIFF
--- a/packages/server/src/anthropic-compatible-session.js
+++ b/packages/server/src/anthropic-compatible-session.js
@@ -36,7 +36,7 @@
  * site.
  */
 
-import { readFileSync, statSync } from 'fs'
+import { readCredentialJsonField } from './credentials-file.js'
 import { join } from 'path'
 import { homedir } from 'os'
 import Anthropic from '@anthropic-ai/sdk'
@@ -69,47 +69,17 @@ function credentialsFilePath() {
 }
 
 /**
- * Read one field out of ~/.chroxy/credentials.json with the same 0600
- * enforcement as byok-credentials.js / deepseek-credentials.js.
+ * Read one field out of ~/.chroxy/credentials.json with 0600 enforcement.
+ * Thin wrapper over the shared reader (P2-9); its reason strings match this
+ * caller's prior format 1:1 (no env-var ENOENT prefix here), so the `code` is
+ * not consulted.
  *
  * @param {string} field - Field name (e.g. 'zaiApiKey')
  * @returns {{ key: string } | { key: null, reason: string }}
  */
 function readCredentialsField(field) {
-  const CREDENTIALS_FILE = credentialsFilePath()
-  let stat
-  try {
-    stat = statSync(CREDENTIALS_FILE)
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      return { key: null, reason: `${CREDENTIALS_FILE} does not exist` }
-    }
-    return { key: null, reason: `unable to stat ${CREDENTIALS_FILE}: ${err.message}` }
-  }
-
-  // Refuse anything more permissive than 0600 — same security boundary
-  // as the BYOK/DeepSeek resolvers. A pasted-in credentials.json
-  // defaulting to 0644 would leak the key to every local user.
-  const perms = stat.mode & 0o777
-  if (perms !== 0o600) {
-    return {
-      key: null,
-      reason: `${CREDENTIALS_FILE} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${CREDENTIALS_FILE})`,
-    }
-  }
-
-  let parsed
-  try {
-    parsed = JSON.parse(readFileSync(CREDENTIALS_FILE, 'utf8'))
-  } catch (err) {
-    return { key: null, reason: `${CREDENTIALS_FILE} unreadable or not valid JSON: ${err.message}` }
-  }
-
-  if (typeof parsed?.[field] !== 'string' || parsed[field].length === 0) {
-    return { key: null, reason: `${CREDENTIALS_FILE} missing or empty "${field}" field` }
-  }
-
-  return { key: parsed[field] }
+  const { key, reason } = readCredentialJsonField(credentialsFilePath(), field)
+  return key !== null ? { key } : { key: null, reason }
 }
 
 /**

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -12,9 +12,10 @@
  * Never logged. The redactor at logger.js scrubs `sk-ant-` and `Bearer`
  * patterns before any log line lands on disk.
  */
-import { readFileSync, statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'fs'
+import { statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
+import { readCredentialJsonField } from './credentials-file.js'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home; if this were captured at module load, the
@@ -35,57 +36,15 @@ export function resolveAnthropicApiKey() {
   }
 
   const CREDENTIALS_FILE = credentialsFilePath()
-  let stat
-  try {
-    stat = statSync(CREDENTIALS_FILE)
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      return {
-        key: null,
-        source: 'none',
-        reason: `ANTHROPIC_API_KEY not set and ${CREDENTIALS_FILE} does not exist`,
-      }
-    }
-    return {
-      key: null,
-      source: 'none',
-      reason: `unable to stat ${CREDENTIALS_FILE}: ${err.message}`,
-    }
+  const result = readCredentialJsonField(CREDENTIALS_FILE, 'anthropicApiKey')
+  if (result.key !== null) {
+    return { key: result.key, source: 'file' }
   }
-
-  // Refuse anything more permissive than 0600. Permissions check uses the
-  // low 9 bits (mode & 0o777). On macOS a file pasted in from elsewhere
-  // commonly arrives as 0644; we want to fail with a clear hint rather
-  // than read the key from a world-readable file.
-  const perms = stat.mode & 0o777
-  if (perms !== 0o600) {
-    return {
-      key: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${CREDENTIALS_FILE})`,
-    }
-  }
-
-  let parsed
-  try {
-    parsed = JSON.parse(readFileSync(CREDENTIALS_FILE, 'utf8'))
-  } catch (err) {
-    return {
-      key: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} unreadable or not valid JSON: ${err.message}`,
-    }
-  }
-
-  if (typeof parsed?.anthropicApiKey !== 'string' || parsed.anthropicApiKey.length === 0) {
-    return {
-      key: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} missing or empty "anthropicApiKey" field`,
-    }
-  }
-
-  return { key: parsed.anthropicApiKey, source: 'file' }
+  // Preserve the env-var-prefixed ENOENT hint; every other reason is verbatim.
+  const reason = result.code === 'enoent'
+    ? `ANTHROPIC_API_KEY not set and ${CREDENTIALS_FILE} does not exist`
+    : result.reason
+  return { key: null, source: 'none', reason }
 }
 
 /**

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -18,7 +18,7 @@ import Anthropic, { APIUserAbortError } from '@anthropic-ai/sdk'
 import { join } from 'path'
 import { homedir } from 'os'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
-import { PermissionManager } from './permission-manager.js'
+import { PermissionManager, wirePermissionManager } from './permission-manager.js'
 import { createLogger } from './logger.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import {
@@ -244,20 +244,11 @@ export class ClaudeByokSession extends BaseSession {
     // AbortController for the active stream so interrupt() can cancel.
     this._abortController = null
 
-    // PermissionManager + event re-emission. Same wiring as
-    // sdk-session.js:254-275 so the dashboard / mobile permission UI
-    // and the audit log work uniformly across providers.
+    // PermissionManager + event re-emission via the shared wiring (P2-9) so the
+    // dashboard / mobile permission UI and the audit log work uniformly across
+    // providers. ByokSession passes no pause/resume hooks (no result-timeout).
     this._permissions = new PermissionManager({ log })
-    this._permissions.on('permission_request', (data) => this.emit('permission_request', data))
-    this._permissions.on('user_question', (data) => this.emit('user_question', data))
-    this._permissions.on('permission_resolved', (data) => {
-      if (data && (data.requestId || data.toolUseId)) {
-        this.emit('permission_resolved', data)
-      }
-    })
-    // Backward-compatible accessors used by ws-permissions.js + settings-handlers.js.
-    this._pendingPermissions = this._permissions._pendingPermissions
-    this._lastPermissionData = this._permissions._lastPermissionData
+    wirePermissionManager(this, this._permissions)
 
     // Realpath cache used by the tool executor's path-safety check. One
     // cache per session — fresh sessions don't reuse a stale cwd.

--- a/packages/server/src/child-stream-guard.js
+++ b/packages/server/src/child-stream-guard.js
@@ -1,0 +1,30 @@
+/**
+ * Shared EPIPE guard for a spawned child's stdout/stderr (#5324/#5361).
+ *
+ * A stream-level 'error' (EPIPE on a dying child, a read fault) emitted on
+ * child.stdout/child.stderr with NO listener throws and crashes the WHOLE
+ * daemon — readline does not attach an error handler to its input, so each
+ * stream needs its own. We log + swallow: the matching process death already
+ * surfaces via 'close' (exit code) or 'error' (spawn failure), which drive
+ * teardown/respawn; the stream error itself carries no extra recoverable
+ * signal beyond "the pipe broke".
+ *
+ * Extracted from the byte-divergent copies in cli-session.js and
+ * jsonl-subprocess-session.js (audit P2-9). `destroying` is a GETTER, not a
+ * boolean: both call sites attach this before the `_destroying` flag can flip,
+ * so the guard must read it lazily on each error.
+ *
+ * @param {import('child_process').ChildProcess} child
+ * @param {{ destroying: () => boolean, log: { warn: (m: string) => void }, label?: string }} opts
+ */
+export function guardChildStreams(child, { destroying, log, label } = {}) {
+  const prefix = label ? `[${label}] ` : ''
+  for (const name of ['stdout', 'stderr']) {
+    const stream = child?.[name]
+    if (!stream) continue
+    stream.on('error', (err) => {
+      if (destroying && destroying()) return
+      log.warn(`${prefix}${name} stream error (ignored): ${err?.message || err}`)
+    })
+  }
+}

--- a/packages/server/src/child-stream-guard.js
+++ b/packages/server/src/child-stream-guard.js
@@ -1,3 +1,11 @@
+import { createLogger } from './logger.js'
+
+// Defensive fallback so the guard can NEVER throw a TypeError inside its own
+// error handler if a future caller omits `log` — that would defeat the whole
+// point of a crash-prevention guard (Copilot review). Both current callers
+// pass their own session/provider logger.
+const _fallbackLog = createLogger('child-stream-guard')
+
 /**
  * Shared EPIPE guard for a spawned child's stdout/stderr (#5324/#5361).
  *
@@ -15,9 +23,9 @@
  * so the guard must read it lazily on each error.
  *
  * @param {import('child_process').ChildProcess} child
- * @param {{ destroying: () => boolean, log: { warn: (m: string) => void }, label?: string }} opts
+ * @param {{ destroying: () => boolean, log?: { warn: (m: string) => void }, label?: string }} opts
  */
-export function guardChildStreams(child, { destroying, log, label } = {}) {
+export function guardChildStreams(child, { destroying, log = _fallbackLog, label } = {}) {
   const prefix = label ? `[${label}] ` : ''
   for (const name of ['stdout', 'stderr']) {
     const stream = child?.[name]

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -4,6 +4,7 @@ import { randomBytes } from 'crypto'
 import { homedir } from 'os'
 import { join } from 'path'
 import { createPermissionHookManager } from './permission-hook.js'
+import { guardChildStreams } from './child-stream-guard.js'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
@@ -539,21 +540,9 @@ export class CliSession extends BaseSession {
     })
 
     // #5361 (follow-up to #5324) — guard the child's stdout/stderr streams
-    // against an unhandled 'error' event. A stream-level error (EPIPE on a
-    // dying child, a read fault) emitted on child.stdout/child.stderr with NO
-    // listener throws and crashes the WHOLE daemon. readline does not attach an
-    // error handler to its input, so each stream needs its own. Log + swallow —
-    // the matching process death surfaces via 'close' (exit code) or 'error'
-    // (spawn failure), which already drive teardown/respawn; the stream error
-    // itself carries no extra recoverable signal beyond "the pipe broke".
-    child.stdout.on('error', (err) => {
-      if (this._destroying) return
-      ;(this._log || log).warn(`stdout stream error (ignored): ${err?.message || err}`)
-    })
-    child.stderr.on('error', (err) => {
-      if (this._destroying) return
-      ;(this._log || log).warn(`stderr stream error (ignored): ${err?.message || err}`)
-    })
+    // against an unhandled 'error' event that would crash the daemon. Shared
+    // helper (P2-9); `_destroying` flips after attach so it is read lazily.
+    guardChildStreams(child, { destroying: () => this._destroying, log: this._log || log })
 
     // Absorb EPIPE and other low-level stdin errors so they don't become
     // unhandled exceptions. Writes are already wrapped in try/catch below.

--- a/packages/server/src/credentials-file.js
+++ b/packages/server/src/credentials-file.js
@@ -1,0 +1,58 @@
+/**
+ * Shared 0600-gated reader for a single field of a credentials JSON file
+ * (#4144 security boundary). Extracted from the three byte-divergent copies in
+ * byok-credentials.js, deepseek-credentials.js, and anthropic-compatible-session.js
+ * (audit P2-9).
+ *
+ * The 0600-mode refusal, the parse-error reason, and the missing-field reason
+ * are byte-identical across all three callers and live here. The ONLY caller
+ * divergence is the ENOENT reason (BYOK/DeepSeek prefix it with the env-var
+ * name, e.g. "ANTHROPIC_API_KEY not set and …"), so this returns a `code` the
+ * caller can branch on to substitute its own message — every other reason
+ * string is preserved verbatim.
+ *
+ * This is the NON-cached path; the `cachedResolveCredentialFile` cache layer
+ * (auth-probes.js, #5461) is unaffected and may wrap a call to this.
+ *
+ * @param {string} path  absolute path to credentials.json
+ * @param {string} field  field name to read (e.g. 'anthropicApiKey')
+ * @returns {{ key: string } | { key: null, reason: string, code: 'enoent'|'stat'|'mode'|'parse'|'missing' }}
+ */
+import { readFileSync, statSync } from 'fs'
+
+export function readCredentialJsonField(path, field) {
+  let stat
+  try {
+    stat = statSync(path)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { key: null, code: 'enoent', reason: `${path} does not exist` }
+    }
+    return { key: null, code: 'stat', reason: `unable to stat ${path}: ${err.message}` }
+  }
+
+  // Refuse anything more permissive than 0600. The check uses the low 9 bits
+  // (mode & 0o777). On macOS a file pasted in from elsewhere commonly arrives
+  // as 0644; we fail with a clear hint rather than read a world-readable key.
+  const perms = stat.mode & 0o777
+  if (perms !== 0o600) {
+    return {
+      key: null,
+      code: 'mode',
+      reason: `${path} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${path})`,
+    }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'))
+  } catch (err) {
+    return { key: null, code: 'parse', reason: `${path} unreadable or not valid JSON: ${err.message}` }
+  }
+
+  if (typeof parsed?.[field] !== 'string' || parsed[field].length === 0) {
+    return { key: null, code: 'missing', reason: `${path} missing or empty "${field}" field` }
+  }
+
+  return { key: parsed[field] }
+}

--- a/packages/server/src/deepseek-credentials.js
+++ b/packages/server/src/deepseek-credentials.js
@@ -19,10 +19,10 @@
  * DeepSeek `sk-` prefix overlaps with many other key formats so it isn't
  * special-cased there — masking at the use site is the defense.
  */
-import { readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { maskApiKey } from './byok-credentials.js'
+import { readCredentialJsonField } from './credentials-file.js'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home (same rationale as byok-credentials.js).
@@ -42,56 +42,15 @@ export function resolveDeepSeekApiKey() {
   }
 
   const CREDENTIALS_FILE = credentialsFilePath()
-  let stat
-  try {
-    stat = statSync(CREDENTIALS_FILE)
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      return {
-        key: null,
-        source: 'none',
-        reason: `DEEPSEEK_API_KEY not set and ${CREDENTIALS_FILE} does not exist`,
-      }
-    }
-    return {
-      key: null,
-      source: 'none',
-      reason: `unable to stat ${CREDENTIALS_FILE}: ${err.message}`,
-    }
+  const result = readCredentialJsonField(CREDENTIALS_FILE, 'deepseekApiKey')
+  if (result.key !== null) {
+    return { key: result.key, source: 'file' }
   }
-
-  // Refuse anything more permissive than 0600 — same security boundary
-  // as the BYOK resolver. A pasted-in credentials.json defaulting to 0644
-  // on macOS would otherwise leak the key to every local user.
-  const perms = stat.mode & 0o777
-  if (perms !== 0o600) {
-    return {
-      key: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${CREDENTIALS_FILE})`,
-    }
-  }
-
-  let parsed
-  try {
-    parsed = JSON.parse(readFileSync(CREDENTIALS_FILE, 'utf8'))
-  } catch (err) {
-    return {
-      key: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} unreadable or not valid JSON: ${err.message}`,
-    }
-  }
-
-  if (typeof parsed?.deepseekApiKey !== 'string' || parsed.deepseekApiKey.length === 0) {
-    return {
-      key: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} missing or empty "deepseekApiKey" field`,
-    }
-  }
-
-  return { key: parsed.deepseekApiKey, source: 'file' }
+  // Preserve the env-var-prefixed ENOENT hint; every other reason is verbatim.
+  const reason = result.code === 'enoent'
+    ? `DEEPSEEK_API_KEY not set and ${CREDENTIALS_FILE} does not exist`
+    : result.reason
+  return { key: null, source: 'none', reason }
 }
 
 // Re-export the masking helper so callers don't have to import from two

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -2,6 +2,7 @@ import { spawn } from 'child_process'
 import { createInterface } from 'readline'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { createLogger } from './logger.js'
+import { guardChildStreams } from './child-stream-guard.js'
 
 const log = createLogger('jsonl-subprocess-session')
 
@@ -345,22 +346,10 @@ export class JsonlSubprocessSession extends BaseSession {
       }
     })
 
-    // #5324 (WP-5.2) — guard the child's stdio streams against an unhandled
-    // 'error' event. A stream-level error (EPIPE on a dying child, a read fault)
-    // emitted on proc.stdout/proc.stderr with NO listener throws and crashes the
-    // WHOLE daemon. readline does not attach an error handler to its input, so
-    // proc.stdout needs its own. Log + swallow — the matching process death
-    // surfaces via 'close' (exit code) or 'error' (spawn failure), which already
-    // tear the turn down; the stream error itself carries no extra recoverable
-    // signal beyond "the pipe broke".
-    proc.stdout.on('error', (err) => {
-      if (this._destroying) return
-      log.warn(`[${Klass.providerName}] stdout stream error: ${err?.message || err}`)
-    })
-    proc.stderr.on('error', (err) => {
-      if (this._destroying) return
-      log.warn(`[${Klass.providerName}] stderr stream error: ${err?.message || err}`)
-    })
+    // #5324 (WP-5.2) — guard the child's stdout/stderr streams against an
+    // unhandled 'error' event that would crash the daemon. Shared helper (P2-9);
+    // `_destroying` flips after attach so it is read lazily.
+    guardChildStreams(proc, { destroying: () => this._destroying, log, label: Klass.providerName })
 
     proc.on('close', (code) => {
       this._process = null

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -674,3 +674,47 @@ function normalizeAnswerValue(value) {
   }
   return ''
 }
+
+/**
+ * Wire a PermissionManager's three events to a session's own EventEmitter and
+ * install the back-compat accessors (`_pendingPermissions` / `_lastPermissionData`,
+ * read by ws-permissions.js + settings-handlers.js). Extracted from the two
+ * in-process providers (SdkSession, ByokSession) that each hand-rolled the same
+ * wiring (audit P2-9); Docker variants inherit from these.
+ *
+ * The only real asymmetry is SdkSession's inactivity-timer pause/resume around a
+ * pending permission (#2831) — passed as optional `onRequest` (fired on both
+ * permission_request and user_question, before the re-emit) and `onResolved`
+ * (fired on every permission_resolved, before the requestId/toolUseId re-emit
+ * guard). ByokSession passes neither.
+ *
+ * @param {import('events').EventEmitter} session  the session to re-emit on
+ * @param {PermissionManager} permissions
+ * @param {{ onRequest?: () => void, onResolved?: () => void }} [hooks]
+ */
+export function wirePermissionManager(session, permissions, { onRequest, onResolved } = {}) {
+  permissions.on('permission_request', (data) => {
+    if (onRequest) onRequest()
+    session.emit('permission_request', data)
+  })
+  permissions.on('user_question', (data) => {
+    if (onRequest) onRequest()
+    session.emit('user_question', data)
+  })
+  permissions.on('permission_resolved', (data) => {
+    if (onResolved) onResolved()
+    // #3048: re-emit so the unified pipeline (SessionManager → ws-forwarding →
+    // EventNormalizer → broadcast) fans the resolution out to every client.
+    // #3736: AskUserQuestion resolutions carry `toolUseId` instead of
+    // `requestId` — re-emit both shapes so the EventNormalizer can prune the
+    // questionSessionMap entry (pre-fix this branch was dropped and the map
+    // leaked one entry per timeout/abort/clear). The permission-audit listener
+    // in ws-server.js gates on `data.requestId` and ignores the question variant.
+    if (data && (data.requestId || data.toolUseId)) {
+      session.emit('permission_resolved', data)
+    }
+  })
+  // Backward-compatible accessors used by ws-permissions.js + settings-handlers.js.
+  session._pendingPermissions = permissions._pendingPermissions
+  session._lastPermissionData = permissions._lastPermissionData
+}

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -14,7 +14,7 @@ import {
 } from './background-shells.js'
 import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
 import { createLogger, loggerForSession } from './logger.js'
-import { PermissionManager } from './permission-manager.js'
+import { PermissionManager, wirePermissionManager } from './permission-manager.js'
 import { formatBytes } from './utils/format-bytes.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { detectThinkingKeyword } from './detect-thinking-keyword.js'
@@ -371,42 +371,17 @@ export class SdkSession extends BaseSession {
     // destroy().
     this._taskIdByToolUseId = new Map()
 
-    // Permission handling — delegated to PermissionManager
+    // Permission handling — delegated to PermissionManager. The pause/resume
+    // hooks keep the inactivity timer suspended while a permission is pending:
+    // waiting on user input is NOT inactivity, and without this a session with
+    // a pending prompt silently goes unresponsive after 5 min (#2831). The
+    // pause uses a reference count so concurrent prompts keep the timer
+    // suspended until the last one resolves. (Shared wiring extracted in P2-9.)
     this._permissions = new PermissionManager({ log })
-    this._permissions.on('permission_request', (data) => {
-      // Pause the inactivity timer: waiting on user input is NOT inactivity.
-      // Without this, sessions with pending permissions silently go
-      // unresponsive after 5 min (#2831). Pause/resume uses a reference
-      // count so concurrent prompts correctly keep the timer suspended
-      // until the last one is resolved.
-      this._pauseResultTimeoutForPermission()
-      this.emit('permission_request', data)
+    wirePermissionManager(this, this._permissions, {
+      onRequest: () => this._pauseResultTimeoutForPermission(),
+      onResolved: () => this._resumeResultTimeoutForPermission(),
     })
-    this._permissions.on('user_question', (data) => {
-      this._pauseResultTimeoutForPermission()
-      this.emit('user_question', data)
-    })
-    this._permissions.on('permission_resolved', (data) => {
-      this._resumeResultTimeoutForPermission()
-      // #3048: re-emit so the unified pipeline (SessionManager → ws-forwarding
-      // → EventNormalizer → broadcast) can fan out the resolution to every
-      // connected client.
-      //
-      // #3736: also re-emit AskUserQuestion resolutions (which carry
-      // `toolUseId` instead of `requestId`) so the EventNormalizer can prune
-      // the questionSessionMap entry. Pre-fix this branch was silently
-      // dropped and the question map leaked one entry per timeout/abort/clear.
-      // The EventNormalizer + ws-forwarding handle both shapes; the
-      // permission-audit listener in ws-server.js gates on `data.requestId`
-      // and ignores the question variant.
-      if (data && (data.requestId || data.toolUseId)) {
-        this.emit('permission_resolved', data)
-      }
-    })
-
-    // Backward-compatible accessors (used by ws-permissions.js, settings-handlers.js)
-    this._pendingPermissions = this._permissions._pendingPermissions
-    this._lastPermissionData = this._permissions._lastPermissionData
 
     // Permission pause bookkeeping for _resultTimeout (#2831)
     this._permissionPauseCount = 0

--- a/packages/server/tests/cli-session-stdin-epipe.test.js
+++ b/packages/server/tests/cli-session-stdin-epipe.test.js
@@ -224,37 +224,51 @@ describe('stdout/stderr stream error listeners (#5361)', () => {
   // uses. A behavioural emit on a mock stream would only re-prove EventEmitter
   // semantics (the listener it attaches is the test's own, not the source's),
   // so it is deliberately omitted as false coverage.
-  it('source wires child.stdout/child.stderr error listeners, _destroying-guarded, in the spawn path', async () => {
+  // Since audit P2-9 the stdout/stderr error guard lives in the shared
+  // child-stream-guard.js (guardChildStreams), invoked from each provider's
+  // spawn path. The wiring is still source-introspected (mock children only
+  // re-prove EventEmitter semantics), split across the helper + the call site.
+  it('shared guardChildStreams wires both streams, _destroying-guarded', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { dirname, join } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const dir = dirname(fileURLToPath(import.meta.url))
+    const guard = readFileSync(join(dir, '../src/child-stream-guard.js'), 'utf-8')
+
+    // Covers BOTH streams — without the guard a stream 'error' is unhandled and
+    // crashes the whole daemon (the regression #5324/#5361 closed).
+    assert.ok(/\['stdout',\s*'stderr'\]/.test(guard),
+      'child-stream-guard.js must iterate both stdout and stderr')
+    assert.ok(guard.includes(".on('error'"),
+      'child-stream-guard.js must register an error listener')
+    // The listener must short-circuit while tearing down — the destroying()
+    // getter is read lazily because the flag flips after attach.
+    const m = guard.match(/\.on\('error',[\s\S]{0,200}?\}\)/)
+    assert.ok(m, "the .on('error', ...) block should be parseable")
+    assert.ok(m[0].includes('destroying'),
+      'the error listener must be guarded by the destroying() getter')
+  })
+
+  it('cli-session invokes guardChildStreams in the spawn path with the _destroying getter', async () => {
     const { readFileSync } = await import('node:fs')
     const { dirname, join } = await import('node:path')
     const { fileURLToPath } = await import('node:url')
     const dir = dirname(fileURLToPath(import.meta.url))
     const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
 
-    // Both listeners must exist — without them a stream 'error' is unhandled
-    // and crashes the whole daemon (the regression this PR closes).
-    assert.ok(source.includes("child.stdout.on('error'"),
-      'cli-session.js must register child.stdout.on(\'error\')')
-    assert.ok(source.includes("child.stderr.on('error'"),
-      'cli-session.js must register child.stderr.on(\'error\')')
+    // The call must pass a _destroying getter (lazy read), not a snapshot.
+    // Slice by index rather than a regex — the inner `() => this._destroying`
+    // arrow's parens would otherwise truncate a non-greedy `\)` match early.
+    const callIdx = source.indexOf('guardChildStreams(child,')
+    assert.ok(callIdx >= 0, 'cli-session.js must call guardChildStreams(child, ...)')
+    assert.ok(source.slice(callIdx, callIdx + 160).includes('this._destroying'),
+      'the guard must be wired to this._destroying')
 
-    // Each listener must short-circuit while tearing down (mirrors #5324) —
-    // assert the `this._destroying` guard appears within the listener body.
-    for (const stream of ['stdout', 'stderr']) {
-      const m = source.match(new RegExp(`child\\.${stream}\\.on\\('error',[\\s\\S]{0,200}?\\}\\)`))
-      assert.ok(m, `child.${stream}.on('error', ...) block should be parseable`)
-      assert.ok(m[0].includes('this._destroying'),
-        `child.${stream} error listener must be guarded by this._destroying`)
-    }
-
-    // The listeners must be attached to the spawned child (so EVERY (re)spawn
-    // gets them) — assert they appear after the `const child = spawn(...)` call.
-    // There is a single spawn site, so "after spawn" == "in the spawn path".
+    // Must run after the single `const child = spawn(...)` so EVERY (re)spawn
+    // gets the guard.
     const spawnIdx = source.indexOf('const child = spawn(')
     assert.ok(spawnIdx >= 0, 'cli-session.js should spawn the child via spawn()')
-    assert.ok(source.indexOf("child.stdout.on('error'") > spawnIdx,
-      'stdout error listener must be attached to the spawned child')
-    assert.ok(source.indexOf("child.stderr.on('error'") > spawnIdx,
-      'stderr error listener must be attached to the spawned child')
+    assert.ok(source.indexOf('guardChildStreams(child,') > spawnIdx,
+      'guardChildStreams must be invoked on the spawned child')
   })
 })


### PR DESCRIPTION
Extracts three byte-divergent provider helpers flagged in audit **P2-9** (`docs/audit/swarm-audit-2026-06-15.md` §3a). Behavior-preserving; each consolidation also kills a latent drift trap. Verified against current `main` before coding.

## Extractions

| Helper | New home | Consolidates | Notes |
|---|---|---|---|
| `wirePermissionManager(session, permissions, {onRequest, onResolved})` | `permission-manager.js` | `sdk-session.js` + `byok-session.js` permission event re-emission + `_pendingPermissions`/`_lastPermissionData` back-compat accessors | SdkSession's inactivity-timer pause/resume around a pending permission (#2831) is passed as the optional hooks; ByokSession passes none. Docker variants inherit. Fixes a stale cross-reference comment. |
| `guardChildStreams(child, {destroying, log, label})` | `child-stream-guard.js` (new) | `cli-session.js` + `jsonl-subprocess-session.js` stdout/stderr EPIPE guard | The daemon-crash-critical #5324/#5361 guard was implemented twice and had **already diverged** (session-scoped vs providerName-prefixed logger; one said "(ignored)", one didn't). `destroying` is a **getter** — both sites attach before `_destroying` flips. Unified on "(ignored)". |
| `readCredentialJsonField(path, field)` | `credentials-file.js` (new) | `byok-credentials.js` + `deepseek-credentials.js` + `anthropic-compatible-session.js` 0600-gated reader | Returns a `code` so the BYOK/DeepSeek callers keep their env-var-prefixed ENOENT hint (`ANTHROPIC_API_KEY not set and …`); **every other reason string is byte-identical**. The `cachedResolveCredentialFile` cache layer (#5461) is untouched. |

## Scope
The 5th P2-9 finding — the docker-byok built-in-tool **pure-transforms** (`_containerRead/Write/Edit/Glob/Grep` re-encoding `file-ops.js` semantics) — is larger/riskier and the audit recommended splitting it out. Filed as **#5882**.

## Testing
- Updated the `cli-session` source-introspection EPIPE test: now asserts the shared guard wires both streams `_destroying`-guarded **and** that `cli-session` invokes `guardChildStreams` in the spawn path with the `_destroying` getter (intent preserved; structure moved).
- Affected suites green locally: `sdk-session`, `byok-session`, `byok-credentials`, `deepseek-credentials`, `deepseek-session`, `anthropic-compatible`, `cli-session`, `cli-session-stdin-epipe`, `jsonl-subprocess-session`, `ollama-session`, `permission-manager`, `permission-resolved-broadcast`, `providers`. All four custom server shell lints pass; eslint clean.
- Full `packages/server` suite: the only non-passes are the known `:8765` live-daemon `service.test.js` artifact + a handful of load-induced timing flakes (MCP start-cap, TUI arrow-nav, rate-limiter sliding-window) that all pass when run in isolation.

Closes part of audit P2-9; remainder tracked in #5882.