### PR TITLE
fix(protocol): cross-platform harden @chroxy/protocol/project (#5886)

### DIFF
--- a/packages/protocol/dist/project.d.ts
+++ b/packages/protocol/dist/project.d.ts
@@ -22,6 +22,16 @@
  * `CHROXY_HOOKS_CHROXY_WORKTREES_ROOT`, and `CHROXY_HOOKS_TMP_PREFIXES`).
  */
 type ProjectEnv = Record<string, string | undefined>;
+/** Index of the agent-worktree marker in `dir`, or -1. Exported for cross-platform tests. */
+export declare function _worktreeMarkerIndex(dir: string): number;
+/**
+ * True if `dir` equals `prefix` or is nested directly under it. Separator-
+ * agnostic (normalizes `\`→`/` for the boundary check) and trailing-separator
+ * tolerant, so a Windows path matches a Windows prefix. On POSIX forward-slash
+ * paths this is a no-op normalization → identical to the old
+ * `dir === prefix || dir.startsWith(prefix + '/')`. Exported for cross-platform tests.
+ */
+export declare function _pathWithinPrefix(prefix: string, dir: string): boolean;
 /**
  * #5439 GAP B: a cwd inside a worktree checkout belongs to the PARENT project —
  * the segment before /.claude/worktrees/ — not the agent-* checkout. #5464

--- a/packages/protocol/dist/project.js
+++ b/packages/protocol/dist/project.js
@@ -22,17 +22,51 @@
  * `CHROXY_HOOKS_CHROXY_WORKTREES_ROOT`, and `CHROXY_HOOKS_TMP_PREFIXES`).
  */
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { homedir, platform, tmpdir } from 'node:os';
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 /** Default to process.env without depending on the `process` global type (tsconfig `types: []`). */
 function defaultEnv() {
     const g = globalThis;
     return g.process?.env ?? {};
 }
-/** Agent worktree checkouts live under <parent>/.claude/worktrees/<name>. */
-const WORKTREE_MARKER = '/.claude/worktrees/';
-/** Temp roots (plus their macOS /private realpaths) — never project sessions. */
-const TMP_PREFIXES = ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp'];
+/**
+ * Agent worktree checkouts live under <parent>/.claude/worktrees/<name>. The
+ * marker is matched separator-agnostically (`/` or `\`) so a Windows path
+ * (realpathSync returns backslashes) still folds into the parent project rather
+ * than mis-attributing to the `agent-*` basename (#5886). On POSIX paths the
+ * regex matches at the exact same index as the old `/.claude/worktrees/` literal.
+ */
+const WORKTREE_MARKER_RE = /[/\\]\.claude[/\\]worktrees[/\\]/;
+/** Index of the agent-worktree marker in `dir`, or -1. Exported for cross-platform tests. */
+export function _worktreeMarkerIndex(dir) {
+    return dir.search(WORKTREE_MARKER_RE);
+}
+/** POSIX temp roots (plus their macOS /private realpaths) — never project sessions. */
+const POSIX_TMP_PREFIXES = ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp'];
+/**
+ * Built-in temp roots for the RUNNING platform. The POSIX literals never match
+ * a Windows path, so on win32 use the real temp dir (`os.tmpdir()`),
+ * realpath-resolved. Platform-conditional so POSIX behavior is unchanged (#5886).
+ */
+function defaultTmpPrefixes() {
+    if (platform() === 'win32') {
+        const t = realResolve(tmpdir());
+        return t ? [t] : [];
+    }
+    return POSIX_TMP_PREFIXES;
+}
+/**
+ * True if `dir` equals `prefix` or is nested directly under it. Separator-
+ * agnostic (normalizes `\`→`/` for the boundary check) and trailing-separator
+ * tolerant, so a Windows path matches a Windows prefix. On POSIX forward-slash
+ * paths this is a no-op normalization → identical to the old
+ * `dir === prefix || dir.startsWith(prefix + '/')`. Exported for cross-platform tests.
+ */
+export function _pathWithinPrefix(prefix, dir) {
+    const np = prefix.replace(/[/\\]+$/, '').replace(/\\/g, '/');
+    const nd = dir.replace(/\\/g, '/');
+    return nd === np || nd.startsWith(np + '/');
+}
 /** resolve() then realpath (macOS: /tmp → /private/tmp); best-effort, never throws. */
 function realResolve(p) {
     let dir;
@@ -50,22 +84,25 @@ function realResolve(p) {
     }
 }
 /**
- * Test-surface override (colon-separated) for the tmp classification. On Linux
- * os.tmpdir() IS /tmp, so test fixtures built under the OS temp dir would
- * classify as 'tmp' and legit-repo tests fail on CI but pass on macOS. Tests
- * point this at a path that doesn't exist so their fixtures classify by the real
- * rules. Never set in production. An unusable override (no absolute prefixes)
- * falls back to the built-in list rather than silently disabling suppression.
+ * Test-surface override (split on `path.delimiter`) for the tmp classification.
+ * On Linux os.tmpdir() IS /tmp, so test fixtures built under the OS temp dir
+ * would classify as 'tmp' and legit-repo tests fail on CI but pass on macOS.
+ * Tests point this at a path that doesn't exist so their fixtures classify by
+ * the real rules. Never set in production. An unusable override (no absolute
+ * prefixes) falls back to the built-in list rather than silently disabling
+ * suppression.
  */
 function tmpPrefixes(env) {
     const raw = env?.CHROXY_HOOKS_TMP_PREFIXES;
     if (typeof raw !== 'string' || raw.length === 0)
-        return TMP_PREFIXES;
+        return defaultTmpPrefixes();
     const prefixes = raw
-        .split(':')
-        .map((p) => p.trim().replace(/\/+$/, ''))
-        .filter((p) => p.startsWith('/'));
-    return prefixes.length > 0 ? prefixes : TMP_PREFIXES;
+        // `path.delimiter` is `:` on POSIX (unchanged) and `;` on Windows, so a
+        // drive-letter override like `C:\Temp;D:\Tmp` splits correctly (#5886).
+        .split(delimiter)
+        .map((p) => p.trim().replace(/[/\\]+$/, ''))
+        .filter((p) => isAbsolute(p));
+    return prefixes.length > 0 ? prefixes : defaultTmpPrefixes();
 }
 /**
  * chroxy's SECOND worktree source — session worktrees the daemon creates at
@@ -165,7 +202,7 @@ export function worktreeParent(cwd, env = defaultEnv()) {
     const chroxyTop = chroxyWorktreeTopDir(dir, env);
     if (chroxyTop)
         return chroxyWorktreeParentProject(chroxyTop);
-    const idx = dir.indexOf(WORKTREE_MARKER);
+    const idx = _worktreeMarkerIndex(dir);
     if (idx <= 0)
         return null;
     const name = basename(dir.slice(0, idx));
@@ -189,13 +226,13 @@ export function classifyNonProjectCwd(cwd, env = defaultEnv()) {
     if (!dir)
         return null;
     for (const prefix of tmpPrefixes(env)) {
-        if (dir === prefix || dir.startsWith(prefix + '/'))
+        if (_pathWithinPrefix(prefix, dir))
             return 'tmp';
     }
     // Path-shape only — never gated on the .git gitdir parse succeeding: a session
     // in a chroxy worktree must stay suppressed even when the parent can't be
     // recovered (it would otherwise mint an opaque-id embed).
-    if (dir.includes(WORKTREE_MARKER) || chroxyWorktreeTopDir(dir, env))
+    if (WORKTREE_MARKER_RE.test(dir) || chroxyWorktreeTopDir(dir, env))
         return 'worktree';
     const homeRaw = typeof env.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir();
     if (homeRaw) {

--- a/packages/protocol/src/project.ts
+++ b/packages/protocol/src/project.ts
@@ -23,8 +23,8 @@
  */
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { homedir, platform, tmpdir } from 'node:os'
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 type ProjectEnv = Record<string, string | undefined>
 
@@ -34,11 +34,48 @@ function defaultEnv(): ProjectEnv {
   return g.process?.env ?? {}
 }
 
-/** Agent worktree checkouts live under <parent>/.claude/worktrees/<name>. */
-const WORKTREE_MARKER = '/.claude/worktrees/'
+/**
+ * Agent worktree checkouts live under <parent>/.claude/worktrees/<name>. The
+ * marker is matched separator-agnostically (`/` or `\`) so a Windows path
+ * (realpathSync returns backslashes) still folds into the parent project rather
+ * than mis-attributing to the `agent-*` basename (#5886). On POSIX paths the
+ * regex matches at the exact same index as the old `/.claude/worktrees/` literal.
+ */
+const WORKTREE_MARKER_RE = /[/\\]\.claude[/\\]worktrees[/\\]/
 
-/** Temp roots (plus their macOS /private realpaths) — never project sessions. */
-const TMP_PREFIXES = ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp']
+/** Index of the agent-worktree marker in `dir`, or -1. Exported for cross-platform tests. */
+export function _worktreeMarkerIndex(dir: string): number {
+  return dir.search(WORKTREE_MARKER_RE)
+}
+
+/** POSIX temp roots (plus their macOS /private realpaths) — never project sessions. */
+const POSIX_TMP_PREFIXES = ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp']
+
+/**
+ * Built-in temp roots for the RUNNING platform. The POSIX literals never match
+ * a Windows path, so on win32 use the real temp dir (`os.tmpdir()`),
+ * realpath-resolved. Platform-conditional so POSIX behavior is unchanged (#5886).
+ */
+function defaultTmpPrefixes(): string[] {
+  if (platform() === 'win32') {
+    const t = realResolve(tmpdir())
+    return t ? [t] : []
+  }
+  return POSIX_TMP_PREFIXES
+}
+
+/**
+ * True if `dir` equals `prefix` or is nested directly under it. Separator-
+ * agnostic (normalizes `\`→`/` for the boundary check) and trailing-separator
+ * tolerant, so a Windows path matches a Windows prefix. On POSIX forward-slash
+ * paths this is a no-op normalization → identical to the old
+ * `dir === prefix || dir.startsWith(prefix + '/')`. Exported for cross-platform tests.
+ */
+export function _pathWithinPrefix(prefix: string, dir: string): boolean {
+  const np = prefix.replace(/[/\\]+$/, '').replace(/\\/g, '/')
+  const nd = dir.replace(/\\/g, '/')
+  return nd === np || nd.startsWith(np + '/')
+}
 
 /** resolve() then realpath (macOS: /tmp → /private/tmp); best-effort, never throws. */
 function realResolve(p: string): string | null {
@@ -56,21 +93,24 @@ function realResolve(p: string): string | null {
 }
 
 /**
- * Test-surface override (colon-separated) for the tmp classification. On Linux
- * os.tmpdir() IS /tmp, so test fixtures built under the OS temp dir would
- * classify as 'tmp' and legit-repo tests fail on CI but pass on macOS. Tests
- * point this at a path that doesn't exist so their fixtures classify by the real
- * rules. Never set in production. An unusable override (no absolute prefixes)
- * falls back to the built-in list rather than silently disabling suppression.
+ * Test-surface override (split on `path.delimiter`) for the tmp classification.
+ * On Linux os.tmpdir() IS /tmp, so test fixtures built under the OS temp dir
+ * would classify as 'tmp' and legit-repo tests fail on CI but pass on macOS.
+ * Tests point this at a path that doesn't exist so their fixtures classify by
+ * the real rules. Never set in production. An unusable override (no absolute
+ * prefixes) falls back to the built-in list rather than silently disabling
+ * suppression.
  */
 function tmpPrefixes(env: ProjectEnv): string[] {
   const raw = env?.CHROXY_HOOKS_TMP_PREFIXES
-  if (typeof raw !== 'string' || raw.length === 0) return TMP_PREFIXES
+  if (typeof raw !== 'string' || raw.length === 0) return defaultTmpPrefixes()
   const prefixes = raw
-    .split(':')
-    .map((p) => p.trim().replace(/\/+$/, ''))
-    .filter((p) => p.startsWith('/'))
-  return prefixes.length > 0 ? prefixes : TMP_PREFIXES
+    // `path.delimiter` is `:` on POSIX (unchanged) and `;` on Windows, so a
+    // drive-letter override like `C:\Temp;D:\Tmp` splits correctly (#5886).
+    .split(delimiter)
+    .map((p) => p.trim().replace(/[/\\]+$/, ''))
+    .filter((p) => isAbsolute(p))
+  return prefixes.length > 0 ? prefixes : defaultTmpPrefixes()
 }
 
 /**
@@ -163,7 +203,7 @@ export function worktreeParent(cwd: string, env: ProjectEnv = defaultEnv()): str
   if (!dir) return null
   const chroxyTop = chroxyWorktreeTopDir(dir, env)
   if (chroxyTop) return chroxyWorktreeParentProject(chroxyTop)
-  const idx = dir.indexOf(WORKTREE_MARKER)
+  const idx = _worktreeMarkerIndex(dir)
   if (idx <= 0) return null
   const name = basename(dir.slice(0, idx))
   return name.length > 0 ? name : null
@@ -185,12 +225,12 @@ export function classifyNonProjectCwd(cwd: string, env: ProjectEnv = defaultEnv(
   const dir = realResolve(cwd)
   if (!dir) return null
   for (const prefix of tmpPrefixes(env)) {
-    if (dir === prefix || dir.startsWith(prefix + '/')) return 'tmp'
+    if (_pathWithinPrefix(prefix, dir)) return 'tmp'
   }
   // Path-shape only — never gated on the .git gitdir parse succeeding: a session
   // in a chroxy worktree must stay suppressed even when the parent can't be
   // recovered (it would otherwise mint an opaque-id embed).
-  if (dir.includes(WORKTREE_MARKER) || chroxyWorktreeTopDir(dir, env)) return 'worktree'
+  if (WORKTREE_MARKER_RE.test(dir) || chroxyWorktreeTopDir(dir, env)) return 'worktree'
   const homeRaw = typeof env.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
   if (homeRaw) {
     let homeResolved: string | null

--- a/packages/protocol/tests/project.test.js
+++ b/packages/protocol/tests/project.test.js
@@ -8,6 +8,8 @@ import {
   deriveProjectFromCwd,
   classifyNonProjectCwd,
   worktreeParent,
+  _worktreeMarkerIndex,
+  _pathWithinPrefix,
 } from '../src/project.ts'
 
 /**
@@ -143,5 +145,61 @@ describe('classifyNonProjectCwd', () => {
   it('returns null for unusable input', () => {
     assert.equal(classifyNonProjectCwd(''), null)
     assert.equal(classifyNonProjectCwd(null), null)
+  })
+})
+
+/**
+ * Cross-platform (#5886) — the public functions can't be driven with Windows
+ * paths on a POSIX runner (resolve()/realpathSync are platform-coupled), so the
+ * separator-agnostic STRING helpers are unit-tested directly with both `/` and
+ * `\` forms. POSIX behavior is pinned to be identical to the old `/`-literal logic.
+ */
+describe('_worktreeMarkerIndex (separator-agnostic worktree marker)', () => {
+  it('finds the marker in a POSIX path at the same index as the old literal', () => {
+    const dir = '/home/proj/.claude/worktrees/agent-1/src'
+    const idx = _worktreeMarkerIndex(dir)
+    assert.equal(idx, dir.indexOf('/.claude/worktrees/'))
+    assert.equal(basename(dir.slice(0, idx)), 'proj')
+  })
+
+  it('finds the marker in a Windows (backslash) path', () => {
+    const dir = 'C:\\Users\\me\\proj\\.claude\\worktrees\\agent-1\\src'
+    const idx = _worktreeMarkerIndex(dir)
+    assert.ok(idx > 0)
+    assert.equal(dir.slice(0, idx), 'C:\\Users\\me\\proj')
+  })
+
+  it('returns -1 when no marker is present (either separator)', () => {
+    assert.equal(_worktreeMarkerIndex('/home/proj/src'), -1)
+    assert.equal(_worktreeMarkerIndex('C:\\Users\\me\\proj\\src'), -1)
+  })
+
+  it('returns 0 for a marker at the very start (guarded by idx <= 0 in callers)', () => {
+    assert.equal(_worktreeMarkerIndex('/.claude/worktrees/x'), 0)
+  })
+})
+
+describe('_pathWithinPrefix (separator-agnostic tmp-prefix containment)', () => {
+  it('matches a nested path and the prefix itself (POSIX)', () => {
+    assert.equal(_pathWithinPrefix('/tmp', '/tmp/sess'), true)
+    assert.equal(_pathWithinPrefix('/tmp', '/tmp'), true)
+  })
+
+  it('does not match a sibling that merely shares the prefix string (POSIX)', () => {
+    assert.equal(_pathWithinPrefix('/tmp', '/tmpfoo'), false)
+  })
+
+  it('matches a nested path and the prefix itself (Windows backslash)', () => {
+    assert.equal(_pathWithinPrefix('C:\\Users\\me\\Temp', 'C:\\Users\\me\\Temp\\sess'), true)
+    assert.equal(_pathWithinPrefix('C:\\Users\\me\\Temp', 'C:\\Users\\me\\Temp'), true)
+  })
+
+  it('does not match a Windows sibling sharing the prefix string', () => {
+    assert.equal(_pathWithinPrefix('C:\\Temp', 'C:\\Tempfoo'), false)
+  })
+
+  it('tolerates a trailing separator on the prefix (both platforms)', () => {
+    assert.equal(_pathWithinPrefix('/tmp/', '/tmp/x'), true)
+    assert.equal(_pathWithinPrefix('C:\\Temp\\', 'C:\\Temp\\x'), true)
   })
 })


### PR DESCRIPTION
Closes **#5886** (follow-up from the P2-2 Copilot review). The shared project-derivation module had POSIX-only path handling — moved verbatim from the hook in #5885. On Windows, `realpathSync` returns backslash paths, so agent worktree checkouts were mis-attributed to their `agent-*` basename (→ per-agent Discord embed spam) and tmp suppression silently failed.

**POSIX behavior is byte-identical** (the separator-agnostic logic matches forward-slash paths exactly as before — verified by the existing hook/server/protocol suites, all green).

## Changes (`packages/protocol/src/project.ts`)
| Finding | Fix |
|---|---|
| Worktree marker `'/.claude/worktrees/'` hard-codes `/` | Separator-agnostic regex `/[/\\]\.claude[/\\]worktrees[/\\]/` via `_worktreeMarkerIndex` / `WORKTREE_MARKER_RE`, used by `worktreeParent` + `classifyNonProjectCwd`. Matches at the same index as the old literal on POSIX. |
| tmp override split on `':'` breaks `C:\Temp` | Split on `path.delimiter` (`:` POSIX / `;` Windows); filter with `isAbsolute` (was `startsWith('/')`). |
| tmp containment `dir.startsWith(prefix + '/')` | `_pathWithinPrefix` normalizes `\`→`/` for the boundary check. |
| Built-in `TMP_PREFIXES` is POSIX-only | Platform-conditional: POSIX keeps the `/tmp` list unchanged; **win32** uses `os.tmpdir()` (the POSIX literals never match a Windows path). |

## Testing strategy
Windows paths can't be driven through the public functions on a POSIX runner (`resolve()`/`realpathSync` are platform-coupled and would mangle backslash input). So the separator-agnostic **string** helpers (`_worktreeMarkerIndex`, `_pathWithinPrefix`) are exported and unit-tested **directly with both `/` and `\` forms** — that's where the cross-platform contract actually lives. The platform-conditional `defaultTmpPrefixes()` win32 branch is best-effort (untestable on POSIX); the POSIX branch is unchanged.

- protocol **313/313** (+9 new cross-platform helper tests), hook **97/97**, server event-ingest **52/52** — all green.
- `tsc` strict build clean; `dist/project.{js,d.ts}` regenerated + committed (repo's committed-dist pattern).

Closes #5886.