### PR TITLE
refactor(server): extract built-in-tool pure transforms shared by host + container (#5882)

### DIFF
--- a/packages/server/src/built-in-tools/file-ops.js
+++ b/packages/server/src/built-in-tools/file-ops.js
@@ -19,9 +19,12 @@
 
 import { readFile, writeFile, stat, mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { applyEdit, formatNumberedLines } from './tool-transforms.js'
 
 export const DEFAULT_READ_MAX_BYTES = 256_000
-export const DEFAULT_READ_LINE_LIMIT = 2_000
+// Single-sourced in tool-transforms.js (shared with the container Read); kept
+// as a re-export for back-compat.
+export { DEFAULT_READ_LINE_LIMIT } from './tool-transforms.js'
 
 /**
  * Read a file, optionally with a line range. Lines are 1-indexed in
@@ -79,30 +82,12 @@ export async function readFileTool({
     return { ok: false, code: 'BINARY', message: `binary content in ${filePath}; Read is text-only` }
   }
 
+  // Slice + line-number via the shared transform (same shape the container
+  // produces via its in-container awk). Match Claude Code's tabular format:
+  // 5-space-padded 1-indexed line number, then arrow, then the line.
   const text = raw.toString('utf8')
-  const allLines = text.split('\n')
-  const totalLines = allLines.length
-
-  const start = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) - 1 : 0
-  const requestedCount = Number.isFinite(limit) && limit > 0
-    ? Math.min(Math.floor(limit), DEFAULT_READ_LINE_LIMIT)
-    : DEFAULT_READ_LINE_LIMIT
-  const slice = allLines.slice(start, start + requestedCount)
-
-  // Match Claude Code's tabular line-numbered format: 5-space-padded
-  // 1-indexed line number, then arrow, then the line. Final trailing
-  // newline preserved when the slice ends at a real EOL.
-  const numbered = slice
-    .map((line, i) => `${String(start + i + 1).padStart(5)}→${line}`)
-    .join('\n')
-
-  return {
-    ok: true,
-    content: numbered,
-    totalLines,
-    linesReturned: slice.length,
-    truncatedByLimit: slice.length < totalLines - start,
-  }
+  const { content, totalLines, linesReturned, truncatedByLimit } = formatNumberedLines(text, { offset, limit })
+  return { ok: true, content, totalLines, linesReturned, truncatedByLimit }
 }
 
 /**
@@ -189,27 +174,25 @@ export async function editFileTool({
     throw err
   }
 
-  // Count occurrences without allocating a full split for huge files —
-  // indexOf walk is O(n) and predictable.
-  let count = 0
-  let idx = -1
-  while ((idx = content.indexOf(oldString, idx + 1)) !== -1) count++
-
-  if (count === 0) {
-    return { ok: false, code: 'NOT_FOUND', message: `oldString not found in ${filePath}` }
-  }
-  if (count > 1 && !replaceAll) {
-    return {
-      ok: false,
-      code: 'NOT_UNIQUE',
-      message: `oldString matched ${count} sites in ${filePath}; pass replaceAll=true or add surrounding context to make it unique`,
+  // Count + strict-uniqueness + LITERAL replacement via the shared transform
+  // (also drives the docker-byok container Edit, so the semantics can't drift).
+  // Type + NO_CHANGE were already handled above; map the remaining codes to the
+  // path-ful messages this tool has always returned.
+  const result = applyEdit(content, { oldString, newString, replaceAll })
+  if (!result.ok) {
+    if (result.code === 'NOT_FOUND') {
+      return { ok: false, code: 'NOT_FOUND', message: `oldString not found in ${filePath}` }
     }
+    if (result.code === 'NOT_UNIQUE') {
+      return {
+        ok: false,
+        code: 'NOT_UNIQUE',
+        message: `oldString matched ${result.matchCount} sites in ${filePath}; pass replaceAll=true or add surrounding context to make it unique`,
+      }
+    }
+    return { ok: false, code: result.code, message: result.message }
   }
 
-  const next = replaceAll
-    ? content.split(oldString).join(newString)
-    : content.replace(oldString, newString)
-
-  await writeFile(filePath, next)
-  return { ok: true, replacements: count, bytesWritten: Buffer.byteLength(next, 'utf8') }
+  await writeFile(filePath, result.next)
+  return { ok: true, replacements: result.replacements, bytesWritten: Buffer.byteLength(result.next, 'utf8') }
 }

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -1,0 +1,172 @@
+/**
+ * FS-agnostic / shell-agnostic PURE transforms for the built-in tools, shared
+ * by the host implementations (file-ops.js, byok-tool-executor.js) and the
+ * container re-encodings (docker-byok-session.js) so the tool SEMANTICS have a
+ * single source of truth and can't drift (audit P2-9 / #5882).
+ *
+ * Byte I/O stays provider-specific: the host reads/writes via node:fs; the
+ * container shells out via `docker exec`. Only the pure string/command shaping
+ * lives here.
+ */
+
+/**
+ * Quote a string for inclusion in a `bash -c` command via single-quote shell
+ * escaping (no expansion at all inside); embedded single quotes become `'\''`.
+ * Identical output to the per-file copies for string inputs.
+ */
+function shellQuote(s) {
+  if (typeof s !== 'string') return "''"
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+// ---------------------------------------------------------------------------
+// Edit — strict-unique-match string replacement
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply Claude Code's Edit semantics to an in-memory string. PURE — the caller
+ * does the byte I/O (host fs read/write, or `cat`/`tee` via docker exec).
+ *
+ * Contract:
+ *   - non-string / empty oldString            → { ok:false, code:'EINVAL' }
+ *   - non-string newString                     → { ok:false, code:'EINVAL' }
+ *   - oldString === newString                  → { ok:false, code:'NO_CHANGE' }
+ *   - oldString not present                    → { ok:false, code:'NOT_FOUND' }
+ *   - >1 match without replaceAll              → { ok:false, code:'NOT_UNIQUE', matchCount }
+ *   - otherwise                                → { ok:true, next, replacements }
+ *
+ * Replacement is LITERAL in both the single and replaceAll paths (split/join
+ * and slice), so a newString containing `$&`/`$1`/`$\`` is inserted verbatim —
+ * unlike `String.prototype.replace`, whose `$`-pattern interpretation was a
+ * latent footgun in the old host single-edit path. Each `code` carries a default
+ * `message`, but callers may map the code to their own (path-ful) wording.
+ *
+ * @param {string} content
+ * @param {{ oldString?: string, newString?: string, replaceAll?: boolean }} opts
+ */
+export function applyEdit(content, { oldString, newString, replaceAll = false } = {}) {
+  if (typeof oldString !== 'string' || oldString.length === 0) {
+    return { ok: false, code: 'EINVAL', message: 'oldString is required and must be non-empty' }
+  }
+  if (typeof newString !== 'string') {
+    return { ok: false, code: 'EINVAL', message: 'newString must be a string' }
+  }
+  if (oldString === newString) {
+    return { ok: false, code: 'NO_CHANGE', message: 'oldString and newString are identical' }
+  }
+
+  // Count occurrences without allocating a full split for huge files — an
+  // indexOf walk is O(n) and predictable.
+  let matchCount = 0
+  let idx = -1
+  while ((idx = content.indexOf(oldString, idx + 1)) !== -1) matchCount++
+
+  if (matchCount === 0) {
+    return { ok: false, code: 'NOT_FOUND', message: 'oldString not found' }
+  }
+  if (matchCount > 1 && !replaceAll) {
+    return {
+      ok: false,
+      code: 'NOT_UNIQUE',
+      matchCount,
+      message: `oldString matched ${matchCount} sites; pass replaceAll=true or add surrounding context to make it unique`,
+    }
+  }
+
+  let next
+  if (replaceAll) {
+    next = content.split(oldString).join(newString)
+  } else {
+    const at = content.indexOf(oldString)
+    next = content.slice(0, at) + newString + content.slice(at + oldString.length)
+  }
+  return { ok: true, next, replacements: matchCount }
+}
+
+// ---------------------------------------------------------------------------
+// Read — line-numbered output shape
+// ---------------------------------------------------------------------------
+
+/** Width the 1-indexed line number is right-padded to (then `→` then the line). */
+export const READ_LINE_NUMBER_PAD = 5
+
+/** Default line cap applied when no positive `limit` is given. */
+export const DEFAULT_READ_LINE_LIMIT = 2_000
+
+/**
+ * Slice `text` by a 1-indexed line range and render Claude Code's line-numbered
+ * Read shape (`<pad>→<line>`). PURE. (The container produces the same shape via
+ * an in-container `awk 'printf "%5d→%s"'` after a `sed | head` slice, mirroring
+ * READ_LINE_NUMBER_PAD — it can't reuse this JS because the slice happens
+ * in-container to avoid transferring the whole file.)
+ *
+ * @param {string} text
+ * @param {{ offset?: number, limit?: number, maxLines?: number }} opts
+ * @returns {{ content: string, totalLines: number, linesReturned: number, truncatedByLimit: boolean }}
+ */
+export function formatNumberedLines(text, { offset, limit, maxLines = DEFAULT_READ_LINE_LIMIT } = {}) {
+  const allLines = text.split('\n')
+  const totalLines = allLines.length
+  const start = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) - 1 : 0
+  const requestedCount = Number.isFinite(limit) && limit > 0
+    ? Math.min(Math.floor(limit), maxLines)
+    : maxLines
+  const slice = allLines.slice(start, start + requestedCount)
+  const content = slice
+    .map((line, i) => `${String(start + i + 1).padStart(READ_LINE_NUMBER_PAD)}→${line}`)
+    .join('\n')
+  return {
+    content,
+    totalLines,
+    linesReturned: slice.length,
+    truncatedByLimit: slice.length < totalLines - start,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Glob / Grep — shell command builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Shell metacharacters a Glob pattern must never contain — the `for f in
+ * <pattern>` expansion would otherwise run an attacker payload (#4070). Glob
+ * patterns legitimately need only `* ? [] {} / .` alnum `_ -`.
+ */
+export const GLOB_PATTERN_SHELL_METACHARS = /[$`;|&><()\\\n\r]/
+
+/**
+ * Build the bash command that lists files matching `pattern` under `root`.
+ * `pattern` MUST already be validated against GLOB_PATTERN_SHELL_METACHARS by
+ * the caller (it is interpolated unquoted so the shell expands it).
+ */
+export function buildGlobCommand(pattern, root) {
+  return `shopt -s globstar nullglob; cd ${shellQuote(root)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
+}
+
+/**
+ * Derive the rg/grep flag fragments from a Grep tool input: case-insensitive
+ * (`-i`), line numbers (`-n`, default on), and an optional `--glob` filter.
+ */
+export function buildGrepArgs(input) {
+  const ci = input?.['-i'] === true ? '-i' : ''
+  const ln = input?.['-n'] !== false ? '-n' : ''
+  const globArg = typeof input?.glob === 'string' && input.glob.length > 0
+    ? ` --glob ${shellQuote(input.glob)}` : ''
+  return { ci, ln, globArg }
+}
+
+/**
+ * Build the bash command that greps `pattern` under `root`, preferring ripgrep
+ * and falling back to `grep -r` only when rg is truly absent (an `if/then/else`,
+ * NOT `rg || grep`, so a no-match rg exit-1 doesn't re-run the search). Both
+ * exit 1 on "no matches"; pass `maskExit:true` when the runner rejects on
+ * non-zero (the container's `execInEnvironment`) so that case isn't a failure.
+ *
+ * @param {{ pattern: string, root: string, ci: string, ln: string, globArg: string, maskExit?: boolean }} opts
+ */
+export function buildGrepCommand({ pattern, root, ci, ln, globArg, maskExit = false }) {
+  const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
+  const grepCmd = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(root)}`
+  const core = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi`
+  return maskExit ? `${core}; true` : core
+}

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -56,10 +56,17 @@ export function applyEdit(content, { oldString, newString, replaceAll = false } 
   }
 
   // Count occurrences without allocating a full split for huge files — an
-  // indexOf walk is O(n) and predictable.
+  // indexOf walk is O(n) and predictable. Advance by oldString.length so the
+  // count is NON-overlapping, matching what `split(oldString).join(...)`
+  // actually replaces (so `replacements` and the NOT_UNIQUE guard agree with
+  // the replaceAll path — e.g. 'aa' in 'aaaa' is 2, not the overlapping 3).
   let matchCount = 0
-  let idx = -1
-  while ((idx = content.indexOf(oldString, idx + 1)) !== -1) matchCount++
+  let from = 0
+  let at
+  while ((at = content.indexOf(oldString, from)) !== -1) {
+    matchCount++
+    from = at + oldString.length
+  }
 
   if (matchCount === 0) {
     return { ok: false, code: 'NOT_FOUND', message: 'oldString not found' }

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -22,6 +22,12 @@ import { lookup as dnsLookup } from 'node:dns/promises'
 import { validatePathWithinCwd } from './ws-file-ops/common.js'
 import { executeBash, DEFAULT_BASH_TIMEOUT_MS } from './built-in-tools/bash-exec.js'
 import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file-ops.js'
+import {
+  GLOB_PATTERN_SHELL_METACHARS,
+  buildGlobCommand,
+  buildGrepArgs,
+  buildGrepCommand,
+} from './built-in-tools/tool-transforms.js'
 import { TODO_STATUSES, BUILTIN_TOOL_NAMES } from './byok-tools.js'
 // #4186: SSRF block-list lives in its own module so the (ip, expected)
 // table can grow without bloating this file's WebFetch integration tests.
@@ -232,11 +238,9 @@ async function runBash({ input, cwd, signal }) {
 }
 
 // Characters in a glob pattern that allow shell-side command substitution
-// or piping. Glob patterns legitimately need *, ?, [], {}, /, ., alnum,
-// _, and -. They never need any of these. Refuse them to prevent the
-// "for f in <pattern>" interpolation from running an attacker payload
-// (caught by /agent-review on PR #4060 — see #4070).
-const GLOB_PATTERN_SHELL_METACHARS = /[$`;|&><()\\\n\r]/
+// or piping (GLOB_PATTERN_SHELL_METACHARS + the command builders live in the
+// shared tool-transforms.js, so the host and the docker-byok container reject
+// and shell out identically — #4070 / #5882).
 
 async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   const pattern = input?.pattern
@@ -257,7 +261,7 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   // Shell expansion of `for f in <pattern>` is what produces the file
   // paths. Pattern is now whitelist-validated above, so interpolation
   // is safe.
-  const cmd = `shopt -s globstar nullglob; cd ${shellQuote(realRoot)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
+  const cmd = buildGlobCommand(pattern, realRoot)
   const result = await executeBash({
     command: cmd,
     cwd: realRoot,
@@ -280,20 +284,13 @@ async function runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   }
   const realRoot = await safeResolveRoot(input?.path, cwd, cwdRealCache, cwdCacheTtl)
 
-  // Prefer ripgrep; fall back to grep. Both honor -i and -n.
-  const ci = input?.['-i'] === true ? '-i' : ''
-  const ln = input?.['-n'] !== false ? '-n' : ''
-  const globArg = typeof input?.glob === 'string' && input.glob.length > 0
-    ? ` --glob ${shellQuote(input.glob)}` : ''
-
-  // Pick rg if available, else grep -r. Pre-fix this was `rg || grep`
-  // which re-ran the search with grep on the COMMON no-match case
-  // (rg exits 1 on no matches → `||` triggers grep), doubling work
-  // (Copilot review on #4060). Use if/then/else so grep only runs
-  // when rg is truly unavailable.
-  const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
-  const grepCmd = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(realRoot)}`
-  const cmd = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi`
+  // Prefer ripgrep; fall back to grep. Both honor -i and -n. The if/then/else
+  // (NOT `rg || grep`) keeps a no-match rg exit-1 from re-running the search
+  // under grep (Copilot review on #4060). executeBash captures the exit code
+  // (doesn't reject), so no `; true` mask is needed here. Builders are shared
+  // with the docker-byok container Grep (#5882).
+  const { ci, ln, globArg } = buildGrepArgs(input)
+  const cmd = buildGrepCommand({ pattern, root: realRoot, ci, ln, globArg })
 
   const result = await executeBash({
     command: cmd,
@@ -340,16 +337,6 @@ async function safeResolveRoot(p, cwd, cwdRealCache, cwdCacheTtl) {
     )
   }
   return realPath
-}
-
-/**
- * Quote a string for inclusion in a `bash -c` command. Uses single-quote
- * shell escaping which is the safest form (no expansion at all inside).
- * Embedded single quotes are escaped as `'\''`.
- */
-function shellQuote(s) {
-  if (typeof s !== 'string') return "''"
-  return `'${s.replace(/'/g, `'\\''`)}'`
 }
 
 const WEBFETCH_DEFAULT_TIMEOUT_MS = 30_000

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -126,6 +126,13 @@ import { createHash, randomBytes } from 'crypto'
 import { homedir, tmpdir } from 'os'
 import { isAbsolute, join, posix, resolve, sep } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
+import {
+  applyEdit,
+  GLOB_PATTERN_SHELL_METACHARS,
+  buildGlobCommand,
+  buildGrepArgs,
+  buildGrepCommand,
+} from './built-in-tools/tool-transforms.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
 import { buildPoolKey, getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
@@ -1927,8 +1934,6 @@ export class DockerByokSession extends ClaudeByokSession {
   async _containerEdit(input) {
     const containerPath = remapToContainerPath(input?.file_path, this.cwd)
     const oldString = typeof input?.old_string === 'string' ? input.old_string : ''
-    const newString = typeof input?.new_string === 'string' ? input.new_string : ''
-    const replaceAll = input?.replace_all === true
     if (oldString.length === 0) {
       return { content: 'Edit refused: old_string is required', isError: true }
     }
@@ -1941,40 +1946,29 @@ export class DockerByokSession extends ClaudeByokSession {
     if (readErr && readErr.trim()) {
       return { content: `Edit failed: ${readErr.trim()}`, isError: true }
     }
-    let replacements = 0
-    let updated
-    if (replaceAll) {
-      const parts = existing.split(oldString)
-      replacements = parts.length - 1
-      updated = parts.join(newString)
-    } else {
-      const idx = existing.indexOf(oldString)
-      if (idx === -1) {
-        return {
-          content: `Edit failed: old_string not found in ${input.file_path}`,
-          isError: true,
-        }
-      }
-      const dup = existing.indexOf(oldString, idx + oldString.length)
-      if (dup !== -1) {
-        return {
-          content: `Edit failed: old_string matches multiple sites in ${input.file_path}; add context or pass replace_all`,
-          isError: true,
-        }
-      }
-      replacements = 1
-      updated = existing.slice(0, idx) + newString + existing.slice(idx + oldString.length)
+    // Strict-unique-match + NO_CHANGE guard + LITERAL replacement via the shared
+    // transform (same one the host file-ops Edit uses) — #5882 closes the drift
+    // where this path lacked the NO_CHANGE guard and used slice vs the host's
+    // replace. Map the codes to this provider's existing message wording.
+    const result = applyEdit(existing, {
+      oldString,
+      newString: typeof input?.new_string === 'string' ? input.new_string : '',
+      replaceAll: input?.replace_all === true,
+    })
+    if (!result.ok) {
+      const msg = result.code === 'NOT_FOUND'
+        ? `Edit failed: old_string not found in ${input.file_path}`
+        : result.code === 'NOT_UNIQUE'
+          ? `Edit failed: old_string matches multiple sites in ${input.file_path}; add context or pass replace_all`
+          : result.code === 'NO_CHANGE'
+            ? 'Edit refused: old_string and new_string are identical'
+            : 'Edit refused: old_string is required'
+      return { content: msg, isError: true }
     }
-    if (replacements === 0) {
-      return {
-        content: `Edit failed: old_string not found in ${input.file_path}`,
-        isError: true,
-      }
-    }
-    const writeResult = await this._containerWrite({ file_path: input.file_path, content: updated })
+    const writeResult = await this._containerWrite({ file_path: input.file_path, content: result.next })
     if (writeResult.isError) return writeResult
     return {
-      content: `Replaced ${replacements} occurrence(s) in ${input.file_path}.`,
+      content: `Replaced ${result.replacements} occurrence(s) in ${input.file_path}.`,
       isError: false,
     }
   }
@@ -2010,7 +2004,7 @@ export class DockerByokSession extends ClaudeByokSession {
     if (typeof pattern !== 'string' || pattern.length === 0) {
       return { content: 'EINVAL: pattern is required', isError: true }
     }
-    if (/[$`;|&><()\\\n\r]/.test(pattern)) {
+    if (GLOB_PATTERN_SHELL_METACHARS.test(pattern)) {
       return {
         content: 'EINVAL: glob pattern contains shell-dangerous characters',
         isError: true,
@@ -2022,7 +2016,7 @@ export class DockerByokSession extends ClaudeByokSession {
     const root = input?.path
       ? remapToContainerPath(input.path, this.cwd)
       : CONTAINER_WORKSPACE
-    const cmd = `shopt -s globstar nullglob; cd ${shellQuote(root)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
+    const cmd = buildGlobCommand(pattern, root)
     const { stdout, stderr } = await this._execAsContainerUser({ cmd, timeout: 30_000 })
     if (!stdout && stderr && stderr.trim()) {
       return { content: `Glob failed: ${stderr.trim()}`, isError: true }
@@ -2043,20 +2037,13 @@ export class DockerByokSession extends ClaudeByokSession {
     const root = input?.path
       ? remapToContainerPath(input.path, this.cwd)
       : CONTAINER_WORKSPACE
-    const ci = input?.['-i'] === true ? '-i' : ''
-    const ln = input?.['-n'] !== false ? '-n' : ''
-    const globArg = typeof input?.glob === 'string' && input.glob.length > 0
-      ? ` --glob ${shellQuote(input.glob)}` : ''
-    const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
-    const grepCmd = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(root)}`
-    // Fix for PR #5021 review (Copilot, comment id 3348029186): rg and
-    // grep -r both exit 1 on "no matches", and execInEnvironment rejects
-    // on any non-zero exit, so the "No matches for ${pattern}" branch
-    // was unreachable. Mask the exit code so we can distinguish
-    // legitimate "no matches" (empty stdout, empty stderr) from real
-    // failures (non-empty stderr). The host-side equivalent
-    // (byok-tool-executor.js) uses the same `|| true` pattern.
-    const cmd = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi; true`
+    // Shared builders (#5882) — identical rg/grep shaping as the host Grep.
+    // `maskExit:true` appends `; true` because execInEnvironment rejects on any
+    // non-zero exit, and both rg and grep -r exit 1 on "no matches" (PR #5021
+    // review, Copilot comment 3348029186) — without the mask the legitimate
+    // "No matches" branch below would be unreachable.
+    const { ci, ln, globArg } = buildGrepArgs(input)
+    const cmd = buildGrepCommand({ pattern, root, ci, ln, globArg, maskExit: true })
     const { stdout, stderr } = await this._execAsContainerUser({ cmd, timeout: 30_000 })
     if (!stdout && stderr && stderr.trim()) {
       return { content: `Grep failed: ${stderr.trim()}`, isError: true }

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -47,6 +47,17 @@ describe('applyEdit', () => {
     assert.equal(applyEdit('x', { oldString: 'x', newString: 42 }).code, 'EINVAL')
   })
 
+  it('counts overlapping patterns NON-overlapping, consistent with split/join (#5888 Copilot)', () => {
+    // 'aa' in 'aaaa' is 2 non-overlapping occurrences (positions 0 and 2), not
+    // the overlapping 3. replaceAll must replace exactly 2 and report 2.
+    const all = applyEdit('aaaa', { oldString: 'aa', newString: 'b', replaceAll: true })
+    assert.deepEqual(all, { ok: true, next: 'bb', replacements: 2 })
+    // Without replaceAll the same input is non-unique (2 > 1).
+    assert.equal(applyEdit('aaaa', { oldString: 'aa', newString: 'b' }).matchCount, 2)
+    // 'aa' in 'aaa' is a single non-overlapping occurrence → a unique edit.
+    assert.deepEqual(applyEdit('aaa', { oldString: 'aa', newString: 'X' }), { ok: true, next: 'Xa', replacements: 1 })
+  })
+
   it('inserts a newString containing $-patterns LITERALLY (not String.replace interpretation)', () => {
     // Single-match path used to be `content.replace(old, new)`, which would
     // expand `$&` to the match. Literal replacement inserts it verbatim.

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -1,0 +1,131 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  applyEdit,
+  formatNumberedLines,
+  GLOB_PATTERN_SHELL_METACHARS,
+  buildGlobCommand,
+  buildGrepArgs,
+  buildGrepCommand,
+} from '../../src/built-in-tools/tool-transforms.js'
+
+/**
+ * Pure-transform contract (audit P2-9 / #5882). These back BOTH the host
+ * built-in tools and the docker-byok container re-encodings, so the semantics
+ * are pinned here once.
+ */
+
+describe('applyEdit', () => {
+  it('replaces a unique occurrence (literal slice)', () => {
+    const r = applyEdit('foo bar baz', { oldString: 'bar', newString: 'QUX' })
+    assert.deepEqual(r, { ok: true, next: 'foo QUX baz', replacements: 1 })
+  })
+
+  it('refuses >1 match without replaceAll, reporting the count', () => {
+    const r = applyEdit('aa aa aa', { oldString: 'aa', newString: 'b' })
+    assert.equal(r.ok, false)
+    assert.equal(r.code, 'NOT_UNIQUE')
+    assert.equal(r.matchCount, 3)
+  })
+
+  it('replaces every occurrence with replaceAll', () => {
+    const r = applyEdit('aa aa aa', { oldString: 'aa', newString: 'b', replaceAll: true })
+    assert.deepEqual(r, { ok: true, next: 'b b b', replacements: 3 })
+  })
+
+  it('NOT_FOUND when the oldString is absent', () => {
+    assert.equal(applyEdit('hello', { oldString: 'xyz', newString: 'abc' }).code, 'NOT_FOUND')
+  })
+
+  it('NO_CHANGE when old and new are identical (the container-side drift this closes)', () => {
+    assert.equal(applyEdit('hi', { oldString: 'x', newString: 'x' }).code, 'NO_CHANGE')
+  })
+
+  it('EINVAL for a missing/empty oldString or non-string newString', () => {
+    assert.equal(applyEdit('x', { oldString: '', newString: 'a' }).code, 'EINVAL')
+    assert.equal(applyEdit('x', { oldString: undefined, newString: 'a' }).code, 'EINVAL')
+    assert.equal(applyEdit('x', { oldString: 'x', newString: 42 }).code, 'EINVAL')
+  })
+
+  it('inserts a newString containing $-patterns LITERALLY (not String.replace interpretation)', () => {
+    // Single-match path used to be `content.replace(old, new)`, which would
+    // expand `$&` to the match. Literal replacement inserts it verbatim.
+    const r = applyEdit('a TOKEN b', { oldString: 'TOKEN', newString: '$& and $1 and $`' })
+    assert.equal(r.ok, true)
+    assert.equal(r.next, 'a $& and $1 and $` b')
+  })
+})
+
+describe('formatNumberedLines', () => {
+  it('numbers lines 1-indexed with a 5-wide pad and arrow', () => {
+    const r = formatNumberedLines('alpha\nbeta\ngamma')
+    assert.equal(r.content, '    1→alpha\n    2→beta\n    3→gamma')
+    assert.equal(r.totalLines, 3)
+    assert.equal(r.linesReturned, 3)
+    assert.equal(r.truncatedByLimit, false)
+  })
+
+  it('slices by 1-indexed offset/limit and reports truncation', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `L${i + 1}`).join('\n')
+    const r = formatNumberedLines(text, { offset: 3, limit: 2 })
+    assert.equal(r.content, '    3→L3\n    4→L4')
+    assert.equal(r.linesReturned, 2)
+    assert.equal(r.truncatedByLimit, true)
+  })
+
+  it('caps at maxLines', () => {
+    const text = Array.from({ length: 5 }, (_, i) => `L${i + 1}`).join('\n')
+    const r = formatNumberedLines(text, { maxLines: 2 })
+    assert.equal(r.linesReturned, 2)
+    assert.equal(r.truncatedByLimit, true)
+  })
+})
+
+describe('GLOB_PATTERN_SHELL_METACHARS', () => {
+  it('flags shell-dangerous characters and passes legitimate glob chars', () => {
+    for (const bad of ['$', '`', ';', '|', '&', '>', '<', '(', ')', '\\', '\n', '\r']) {
+      assert.equal(GLOB_PATTERN_SHELL_METACHARS.test(`a${bad}b`), true, `should flag ${JSON.stringify(bad)}`)
+    }
+    assert.equal(GLOB_PATTERN_SHELL_METACHARS.test('src/**/*.{js,ts}'), false)
+  })
+})
+
+describe('buildGlobCommand', () => {
+  it('builds the globstar listing command, quoting the root but not the pattern', () => {
+    assert.equal(
+      buildGlobCommand('**/*.ts', '/work/repo'),
+      `shopt -s globstar nullglob; cd '/work/repo' && for f in **/*.ts; do printf '%s\\n' "$f"; done`,
+    )
+  })
+})
+
+describe('buildGrepArgs', () => {
+  it('defaults line numbers on, case-insensitive off, no glob', () => {
+    assert.deepEqual(buildGrepArgs({}), { ci: '', ln: '-n', globArg: '' })
+  })
+  it('honors -i, -n=false, and a glob filter', () => {
+    assert.deepEqual(
+      buildGrepArgs({ '-i': true, '-n': false, glob: '*.go' }),
+      { ci: '-i', ln: '', globArg: ` --glob '*.go'` },
+    )
+  })
+})
+
+describe('buildGrepCommand', () => {
+  const base = { pattern: 'TODO', root: '/work', ci: '-i', ln: '-n', globArg: '' }
+
+  it('prefers rg with an if/then/else grep fallback', () => {
+    assert.equal(
+      buildGrepCommand(base),
+      `if command -v rg >/dev/null 2>&1; then rg -i -n --no-heading 'TODO' '/work'; else grep -r -i -n 'TODO' '/work'; fi`,
+    )
+  })
+
+  it('appends `; true` when maskExit (runner rejects on non-zero exit)', () => {
+    assert.equal(buildGrepCommand({ ...base, maskExit: true }).endsWith('; fi; true'), true)
+  })
+
+  it('threads the glob arg into the rg command', () => {
+    assert.match(buildGrepCommand({ ...base, globArg: ` --glob '*.md'` }), /rg -i -n --no-heading --glob '\*\.md'/)
+  })
+})

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -528,6 +528,97 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     assert.equal(_dockerBackend.calls.length, 0)
   })
 
+  // #5882 — the container Edit path was previously untested and had drifted
+  // from host-side editFileTool (no NO_CHANGE guard, slice vs replace). It now
+  // delegates the semantics to the shared applyEdit transform.
+  describe('Edit (container, via shared applyEdit) #5882', () => {
+    function editBackend(fileContent) {
+      return backendStub({
+        execResponses: {
+          'cat ': { stdout: fileContent },
+          'wc -c': { stdout: '1\n' },
+        },
+      })
+    }
+    function decodeWrittenContent(calls) {
+      const writeCall = calls.find((c) => c.cmd.includes('base64 -d'))
+      if (!writeCall) return null
+      const m = writeCall.cmd.match(/echo '([^']+)' \| base64 -d/)
+      return m ? Buffer.from(m[1], 'base64').toString('utf8') : null
+    }
+
+    it('applies a unique edit and writes the updated content', async () => {
+      const backend = editBackend('foo bar baz')
+      const { session } = buildSession({ backend })
+      const result = await session._dispatchBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: 'foo.txt', old_string: 'bar', new_string: 'QUX' },
+      })
+      assert.equal(result.isError, false)
+      assert.match(result.content, /Replaced 1 occurrence\(s\) in foo\.txt/)
+      assert.equal(decodeWrittenContent(backend.calls), 'foo QUX baz')
+    })
+
+    it('refuses a no-op edit (old === new) — NO_CHANGE, the drift this closes', async () => {
+      const backend = editBackend('hello hello')
+      const { session } = buildSession({ backend })
+      const result = await session._dispatchBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: 'foo.txt', old_string: 'hello', new_string: 'hello' },
+      })
+      assert.equal(result.isError, true)
+      assert.match(result.content, /identical/)
+      // It read the file (cat) but must NOT have written it.
+      assert.equal(backend.calls.some((c) => c.cmd.includes('base64 -d')), false)
+    })
+
+    it('refuses a non-unique edit without replace_all', async () => {
+      const backend = editBackend('aa aa aa')
+      const { session } = buildSession({ backend })
+      const result = await session._dispatchBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: 'foo.txt', old_string: 'aa', new_string: 'b' },
+      })
+      assert.equal(result.isError, true)
+      assert.match(result.content, /matches multiple sites/)
+    })
+
+    it('replaces every occurrence with replace_all', async () => {
+      const backend = editBackend('aa aa aa')
+      const { session } = buildSession({ backend })
+      const result = await session._dispatchBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: 'foo.txt', old_string: 'aa', new_string: 'b', replace_all: true },
+      })
+      assert.equal(result.isError, false)
+      assert.match(result.content, /Replaced 3 occurrence\(s\)/)
+      assert.equal(decodeWrittenContent(backend.calls), 'b b b')
+    })
+
+    it('refuses when old_string is not found', async () => {
+      const backend = editBackend('hello world')
+      const { session } = buildSession({ backend })
+      const result = await session._dispatchBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: 'foo.txt', old_string: 'xyz', new_string: 'abc' },
+      })
+      assert.equal(result.isError, true)
+      assert.match(result.content, /not found/)
+    })
+
+    it('refuses an empty old_string before touching the container', async () => {
+      const backend = editBackend('whatever')
+      const { session } = buildSession({ backend })
+      const result = await session._dispatchBuiltinTool({
+        toolName: 'Edit',
+        input: { file_path: 'foo.txt', old_string: '', new_string: 'x' },
+      })
+      assert.equal(result.isError, true)
+      assert.match(result.content, /old_string is required/)
+      assert.equal(backend.calls.length, 0)
+    })
+  })
+
   it('Bash routes the raw command through docker exec', async () => {
     const _dockerBackend = backendStub({
       defaultResponse: { stdout: 'hello\n', stderr: '' },


### PR DESCRIPTION
Closes **#5882** — the deferred P2-9 sub-item (audit §3a). `docker-byok-session.js` re-encoded the same built-in-tool **semantics** as the host tools and had **drifted**: the container `_containerEdit` lacked the `NO_CHANGE` guard and used `slice` where the host used `replace`; the rg/grep + glob command shaping was hand-mirrored.

Extract the FS-/shell-agnostic **pure transforms** into `built-in-tools/tool-transforms.js` so host and container share one source of truth. **Byte I/O stays provider-specific** (host `node:fs`; container `docker exec`).

## Shared transforms
| Transform | Used by | Notes |
|---|---|---|
| `applyEdit(content, {oldString,newString,replaceAll})` | host `editFileTool` + container `_containerEdit` | strict-unique-match + **NO_CHANGE guard** + **literal** replacement (returns codes; callers keep their own path-ful messages). |
| `buildGlobCommand` + `GLOB_PATTERN_SHELL_METACHARS` | host `runGlob` + `_containerGlob` | byte-identical shell command. |
| `buildGrepArgs` + `buildGrepCommand({maskExit})` | host `runGrep` + `_containerGrep` | container passes `maskExit:true` (its `execInEnvironment` rejects on non-zero; both rg/grep exit 1 on no-match). |
| `formatNumberedLines` + `READ_LINE_NUMBER_PAD` | host `readFileTool` | the container produces the same shape via in-container `awk` mirroring the pad. |

## Drift / footgun fixes
- **Container `_containerEdit`** now gets the `NO_CHANGE` guard (old===new was previously reported as a successful "Replaced N" — wrong).
- **Host `editFileTool`** single-edit path was `content.replace(old, new)`, which interprets `$&`/`$1` in the replacement — a latent footgun. `applyEdit` is literal in both single and replaceAll paths (matching the container + the host's own replaceAll). No test locked the old `$`-interpretation.

## Testing
- New `tool-transforms.test.js` (17) pins the contract — incl. the `$`-literal and `NO_CHANGE` cases.
- New **container Edit suite** (6) covers the previously-**untested** `_containerEdit` path — the exact blind spot that let it drift (unique edit, NO_CHANGE refusal, NOT_UNIQUE, replace_all, NOT_FOUND, empty-old-before-exec).
- Host `file-ops` (14), `byok-tool-executor` (85), `docker-byok-session` (155 incl. the command-string-pinning tests that prove the builders emit byte-identical commands) — all green. Removed the now-dead local `shellQuote` in `byok-tool-executor.js`.
- Full server suite: only the known `:8765` live-daemon `service.test.js` artifact fails (unrelated). eslint + all four custom shell lints clean.

Closes #5882.

## Note: match counting is non-overlapping (Copilot-flagged)
`applyEdit` counts matches **non-overlapping** (advancing by `oldString.length`), consistent with the `split/join` replaceAll path. This fixes a latent inconsistency inherited from the host `editFileTool` (which counted overlapping via `indexOf(old, idx+1)` but replaced via split/join, so `replacements` could be wrong — e.g. `'aa'` in `'aaaa'` counted 3 but replaced 2). Net behavior change vs the old host single-edit: an adjacent overlapping pattern like `'aa'` in `'aaa'` is now a single unique edit (matching split/join's view) rather than a `NOT_UNIQUE` refusal. The container `_containerEdit` already counted non-overlapping, so it's unchanged on that axis. Existing `NOT_UNIQUE` coverage (`'aa aa aa'` → 3) is unaffected; a regression test pins the overlapping cases.
