### PR TITLE
fix(server): route BYOK credentials through the canonical encryption-aware store (#5867)

### DIFF
--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -3,19 +3,24 @@
  *
  * Priority order:
  *   1. process.env.ANTHROPIC_API_KEY
- *   2. ~/.chroxy/credentials.json — { anthropicApiKey: "sk-ant-..." }
- *      File MUST be mode 0600. We refuse to read it otherwise (security
- *      boundary: API keys are user-pasted secrets and should not be
- *      world-readable; if the user accidentally chmodded the file to 0644
- *      we'd rather fail loudly than silently expose the key).
+ *   2. the canonical credential store (`credential-store.js`,
+ *      ~/.chroxy/credentials.json, mode 0600) — decryption-aware (#5154) and
+ *      honoring the legacy `anthropicApiKey` alias for files written by the
+ *      pre-#5867 single-key BYOK path.
+ *
+ * #5867: writes/clears now go through `setStoredCredential` /
+ * `deleteStoredCredential` (merge + at-rest encryption), so a BYOK set/clear no
+ * longer clobbers sibling provider keys or downgrades an encrypted store to
+ * plaintext. This module is now read-only (resolve + status + mask); the WS
+ * handlers call the store directly.
  *
  * Never logged. The redactor at logger.js scrubs `sk-ant-` and `Bearer`
  * patterns before any log line lands on disk.
  */
-import { statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'fs'
-import { join, dirname } from 'path'
+import { existsSync } from 'fs'
+import { join } from 'path'
 import { homedir } from 'os'
-import { readCredentialJsonField } from './credentials-file.js'
+import { resolveStoredCredentialWithMeta } from './credential-store.js'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home; if this were captured at module load, the
@@ -25,7 +30,10 @@ function credentialsFilePath() {
 }
 
 /**
- * Resolve the Anthropic API key for a BYOK session.
+ * Resolve the Anthropic API key for a BYOK session. Env var wins; otherwise the
+ * cipher-aware credential store. The `reason` (when missing) preserves the
+ * store's read distinctions: bad mode, keychain-locked, corrupt envelope,
+ * file-absent, or present-but-no-Anthropic-credential.
  *
  * @returns {{ key: string, source: 'env' | 'file' } | { key: null, source: 'none', reason: string }}
  */
@@ -35,96 +43,20 @@ export function resolveAnthropicApiKey() {
     return { key: envKey, source: 'env' }
   }
 
+  const { value, fileExists, error } = resolveStoredCredentialWithMeta('ANTHROPIC_API_KEY')
+  if (value) {
+    return { key: value, source: 'file' }
+  }
   const CREDENTIALS_FILE = credentialsFilePath()
-  const result = readCredentialJsonField(CREDENTIALS_FILE, 'anthropicApiKey')
-  if (result.key !== null) {
-    return { key: result.key, source: 'file' }
+  let reason
+  if (error) {
+    reason = error
+  } else if (!fileExists) {
+    reason = `ANTHROPIC_API_KEY not set and ${CREDENTIALS_FILE} does not exist`
+  } else {
+    reason = `ANTHROPIC_API_KEY not set and no Anthropic credential is stored in ${CREDENTIALS_FILE}`
   }
-  // Preserve the env-var-prefixed ENOENT hint; every other reason is verbatim.
-  const reason = result.code === 'enoent'
-    ? `ANTHROPIC_API_KEY not set and ${CREDENTIALS_FILE} does not exist`
-    : result.reason
   return { key: null, source: 'none', reason }
-}
-
-/**
- * Persist the user's Anthropic API key to ~/.chroxy/credentials.json
- * atomically with mode 0600.
- *
- * Atomicity: write to `credentials.json.tmp.<pid>.<rand>`, chmod 0600,
- * fsync isn't strictly needed for this size, then rename over the
- * target. A crash between write and rename leaves the old file intact.
- *
- * Post-write the mode is re-stat'd and we throw if it didn't take. This
- * guards against an unexpected umask making the file world-readable even
- * after chmod (rare). The security boundary is: refuse a bad state, do
- * not log a warning and continue.
- *
- * Windows note: chmod / 0600 don't map cleanly to NTFS ACLs, so the mode
- * verification is POSIX-only. On win32 the rename and chmod still run
- * (best-effort) but the strict 0o600 assertion is skipped — see #4144.
- *
- * @param {string} key  the `sk-ant-...` API key
- * @throws if key is missing/non-string, or if the post-write mode != 0600 on POSIX
- */
-export function writeAnthropicApiKey(key) {
-  if (typeof key !== 'string' || key.length === 0) {
-    throw new Error('writeAnthropicApiKey: key is required (non-empty string)')
-  }
-  const target = credentialsFilePath()
-  const dir = dirname(target)
-  // 0o700 on the dir so creds aren't enumerable to other local users.
-  mkdirSync(dir, { recursive: true, mode: 0o700 })
-  // Existing dir may have a more-permissive mode from before this code
-  // existed — tighten it. POSIX-only (Windows ACLs handle differently).
-  if (process.platform !== 'win32') {
-    try { chmodSync(dir, 0o700) } catch { /* best-effort */ }
-  }
-
-  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`
-  let renamed = false
-  try {
-    // Open with mode 0600 directly so the brief window before chmod
-    // doesn't expose the key as 0644 (umask-dependent default).
-    writeFileSync(tmp, JSON.stringify({ anthropicApiKey: key }, null, 2), { mode: 0o600 })
-    if (process.platform !== 'win32') {
-      chmodSync(tmp, 0o600)
-    }
-    // win32 renameSync can't atomically replace an existing destination —
-    // unlink the target first so the move semantics match POSIX. The
-    // window between unlink and rename is tiny; an OS-level crash there
-    // can leave the file missing but never world-readable.
-    if (process.platform === 'win32' && existsSync(target)) {
-      try { unlinkSync(target) } catch { /* */ }
-    }
-    renameSync(tmp, target)
-    renamed = true
-    // Verify the mode survived the rename. POSIX-only: on win32 the mode
-    // bits don't reflect NTFS ACLs, so a strict 0o600 check would always
-    // fail and refuse to write valid credentials.
-    if (process.platform !== 'win32') {
-      const perms = statSync(target).mode & 0o777
-      if (perms !== 0o600) {
-        try { unlinkSync(target) } catch { /* */ }
-        throw new Error(`credentials file ended up with mode ${perms.toString(8)} after write; refused`)
-      }
-    }
-  } finally {
-    if (!renamed && existsSync(tmp)) {
-      try { unlinkSync(tmp) } catch { /* */ }
-    }
-  }
-}
-
-/**
- * Remove the stored credentials file. No-op when missing. Does not touch
- * the parent ~/.chroxy directory.
- */
-export function clearAnthropicApiKey() {
-  const target = credentialsFilePath()
-  try { unlinkSync(target) } catch (err) {
-    if (err.code !== 'ENOENT') throw err
-  }
 }
 
 /**

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -428,6 +428,43 @@ export function getStoredCredential(key) {
 }
 
 /**
+ * #5867 — resolve a KNOWN credential's value AND the read metadata in one
+ * cipher-aware, alias-aware read. Like `getStoredCredential` but also returns
+ * the `readStore` metadata (`fileExists`, `error`, `keychainUnavailable`) so a
+ * caller can build a status `reason` that preserves the bad-mode /
+ * keychain-locked / corrupt-envelope / file-absent distinctions WITHOUT this
+ * module logging or echoing the value. The raw `value` is returned only to the
+ * caller. Honors the legacy `anthropicApiKey` alias like `getStoredCredential`.
+ *
+ * Used by byok-credentials.resolveAnthropicApiKey so the BYOK paid-auth read
+ * path goes through the encryption-aware store instead of a plaintext re-read.
+ *
+ * @param {string} key
+ * @returns {{ value: string | null, fileExists: boolean, error: string | null, keychainUnavailable: boolean }}
+ */
+export function resolveStoredCredentialWithMeta(key) {
+  if (!isKnownCredentialKey(key)) {
+    return { value: null, fileExists: false, error: null, keychainUnavailable: false }
+  }
+  const { data, fileExists, error, keychainUnavailable } = readStore()
+  if (error) {
+    return { value: null, fileExists, error, keychainUnavailable: Boolean(keychainUnavailable) }
+  }
+  const canonical = data[key]
+  if (typeof canonical === 'string' && canonical.length > 0) {
+    return { value: canonical, fileExists, error: null, keychainUnavailable: false }
+  }
+  const legacyField = LEGACY_FIELD_BY_KEY[key]
+  if (legacyField) {
+    const legacy = data[legacyField]
+    if (typeof legacy === 'string' && legacy.length > 0) {
+      return { value: legacy, fileExists, error: null, keychainUnavailable: false }
+    }
+  }
+  return { value: null, fileExists, error: null, keychainUnavailable: false }
+}
+
+/**
  * #5490 — read a single string field out of the credentials store, going
  * through the SAME cipher-aware reader (`readStore`) the API-key resolvers use:
  * 0600 mode enforcement, encrypted-envelope decryption, and the

--- a/packages/server/src/handlers/credential-handlers.js
+++ b/packages/server/src/handlers/credential-handlers.js
@@ -5,11 +5,7 @@
  * token is rejected); status reads are open to any authenticated client.
  */
 import { sendError } from '../handler-utils.js'
-import {
-  getAnthropicApiKeyStatus,
-  writeAnthropicApiKey,
-  clearAnthropicApiKey,
-} from '../byok-credentials.js'
+import { getAnthropicApiKeyStatus } from '../byok-credentials.js'
 import {
   getCredentialsStatus,
   setStoredCredential,
@@ -68,6 +64,12 @@ function rejectCredentialWriteIfBound(ws, client, msg, ctx) {
  * Auth posture: status reads are open to any authenticated WS client. WRITES
  * (set/clear) require host-level authority — a pairing-bound session token is
  * rejected via `rejectCredentialWriteIfBound` (#5155).
+ *
+ * #5867: set/clear now go through the canonical `setStoredCredential` /
+ * `deleteStoredCredential` (merge + at-rest encryption) instead of the legacy
+ * whole-file overwrite/unlink, so a BYOK write no longer wipes sibling provider
+ * keys or downgrades an encrypted store to plaintext. The status surface stays
+ * the BYOK-specific `getAnthropicApiKeyStatus` for dashboard back-compat.
  */
 function handleByokGetCredentialsStatus(ws, client, msg, ctx) {
   const status = getAnthropicApiKeyStatus()
@@ -84,16 +86,18 @@ function handleByokSetCredentials(ws, client, msg, ctx) {
     sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'anthropicApiKey is required', undefined, ctx)
     return
   }
-  // Reject anything that doesn't even look like a key. The Anthropic key
-  // format starts with `sk-ant-`. We don't validate further — formats can
-  // evolve — but the prefix check catches obvious pastes-of-the-wrong-
-  // thing (e.g. OpenAI keys, OAuth tokens) before we persist them.
+  // Reject anything that doesn't even look like a key BEFORE persisting (the
+  // store validates too, but this gives the nicer BYOK-specific error). The
+  // Anthropic key format starts with `sk-ant-`; the prefix check catches
+  // obvious wrong-thing pastes (OpenAI keys, OAuth tokens).
   if (!key.startsWith('sk-ant-')) {
     sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'API key must start with sk-ant-', undefined, ctx)
     return
   }
   try {
-    writeAnthropicApiKey(key)
+    // Merge into the canonical store (encrypt-at-rest aware) — never the legacy
+    // whole-file overwrite that wiped sibling provider keys (#5867).
+    setStoredCredential('ANTHROPIC_API_KEY', key)
   } catch (err) {
     log.warn(`byok_set_credentials write failed: ${err?.message}`)
     sendError(ws, msg?.requestId, 'CREDENTIALS_WRITE_FAILED', err?.message || 'write failed', undefined, ctx)
@@ -113,7 +117,9 @@ function handleByokSetCredentials(ws, client, msg, ctx) {
 function handleByokClearCredentials(ws, client, msg, ctx) {
   if (rejectCredentialWriteIfBound(ws, client, msg, ctx)) return
   try {
-    clearAnthropicApiKey()
+    // Remove only the Anthropic key from the canonical store — siblings (and
+    // the encrypted envelope) survive; the file is unlinked only when empty.
+    deleteStoredCredential('ANTHROPIC_API_KEY')
   } catch (err) {
     sendError(ws, msg?.requestId, 'CREDENTIALS_CLEAR_FAILED', err?.message || 'clear failed', undefined, ctx)
     return

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -82,7 +82,10 @@ describe('byok-credentials', () => {
       assert.equal(result.source, 'file')
     })
 
-    it('refuses to read a 0644 credentials file (security boundary)', () => {
+    // POSIX-only: the canonical store's readStore() skips the mode check on
+    // win32 (NTFS ACLs don't map to POSIX bits, #4144), so a 0644 file IS read
+    // there — the same posture every other credential already has on Windows.
+    it('refuses to read a 0644 credentials file (security boundary)', { skip: process.platform === 'win32' }, () => {
       const chroxyDir = join(tmpHome, '.chroxy')
       mkdirSync(chroxyDir, { recursive: true })
       writeFileSync(credPath(), JSON.stringify({ anthropicApiKey: 'sk-ant-should-not-load' }))

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -1,29 +1,36 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, statSync, readFileSync, existsSync, readdirSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   resolveAnthropicApiKey,
   maskApiKey,
-  writeAnthropicApiKey,
-  clearAnthropicApiKey,
   getAnthropicApiKeyStatus,
   hasStoredCredentials,
 } from '../src/byok-credentials.js'
+import {
+  setStoredCredential,
+  deleteStoredCredential,
+  _setCredentialKeychainForTests,
+} from '../src/credential-store.js'
 
 /**
- * Tests for byok-credentials.js — env-var precedence, file-fallback,
- * permission enforcement (0600 required), key masking.
+ * Tests for byok-credentials.js — env-var precedence, store-backed file
+ * fallback (#5867: reads now go through the cipher-aware credential-store), the
+ * 0600 permission boundary, and key masking.
  *
  * Run with HOME pointed at a tmpdir so we never touch the real
- * ~/.chroxy/credentials.json on the dev machine.
+ * ~/.chroxy/credentials.json. The test bootstrap (_setup.mjs) sets
+ * CHROXY_CRED_DISABLE_KEYCHAIN=1, so the store writes 0600 plaintext by
+ * default; the encrypted round-trip test injects an in-memory keychain.
  */
 
 describe('byok-credentials', () => {
   let tmpHome
   let originalHome
   let originalApiKey
+  const credPath = () => join(tmpHome, '.chroxy', 'credentials.json')
 
   beforeEach(() => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-byok-cred-test-'))
@@ -34,6 +41,7 @@ describe('byok-credentials', () => {
   })
 
   afterEach(() => {
+    _setCredentialKeychainForTests(null)
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
     if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
@@ -57,23 +65,28 @@ describe('byok-credentials', () => {
       assert.match(result.reason, /does not exist/)
     })
 
-    it('reads file when env not set and file is mode 0600', () => {
-      const chroxyDir = join(tmpHome, '.chroxy')
-      const credPath = join(chroxyDir, 'credentials.json')
-      mkdirSync(chroxyDir, { recursive: true })
-      writeFileSync(credPath, JSON.stringify({ anthropicApiKey: 'sk-ant-from-file' }))
-      chmodSync(credPath, 0o600)
+    it('reads a key stored via the canonical store (mode 0600)', () => {
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-from-store')
       const result = resolveAnthropicApiKey()
-      assert.equal(result.key, 'sk-ant-from-file')
+      assert.equal(result.key, 'sk-ant-from-store')
+      assert.equal(result.source, 'file')
+    })
+
+    it('reads a legacy { anthropicApiKey } file written by the pre-#5867 path', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath(), JSON.stringify({ anthropicApiKey: 'sk-ant-legacy-alias' }))
+      chmodSync(credPath(), 0o600)
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, 'sk-ant-legacy-alias')
       assert.equal(result.source, 'file')
     })
 
     it('refuses to read a 0644 credentials file (security boundary)', () => {
       const chroxyDir = join(tmpHome, '.chroxy')
-      const credPath = join(chroxyDir, 'credentials.json')
       mkdirSync(chroxyDir, { recursive: true })
-      writeFileSync(credPath, JSON.stringify({ anthropicApiKey: 'sk-ant-should-not-load' }))
-      chmodSync(credPath, 0o644)
+      writeFileSync(credPath(), JSON.stringify({ anthropicApiKey: 'sk-ant-should-not-load' }))
+      chmodSync(credPath(), 0o644)
       const result = resolveAnthropicApiKey()
       assert.equal(result.key, null)
       assert.match(result.reason, /mode 644/)
@@ -82,38 +95,79 @@ describe('byok-credentials', () => {
 
     it('returns "none" when credentials.json is unparseable', () => {
       const chroxyDir = join(tmpHome, '.chroxy')
-      const credPath = join(chroxyDir, 'credentials.json')
       mkdirSync(chroxyDir, { recursive: true })
-      writeFileSync(credPath, 'not valid json {')
-      chmodSync(credPath, 0o600)
+      writeFileSync(credPath(), 'not valid json {')
+      chmodSync(credPath(), 0o600)
       const result = resolveAnthropicApiKey()
       assert.equal(result.key, null)
       assert.match(result.reason, /unreadable or not valid JSON/)
     })
 
-    it('returns "none" when credentials.json lacks anthropicApiKey field', () => {
-      const chroxyDir = join(tmpHome, '.chroxy')
-      const credPath = join(chroxyDir, 'credentials.json')
-      mkdirSync(chroxyDir, { recursive: true })
-      writeFileSync(credPath, JSON.stringify({ otherKey: 'sk-other' }))
-      chmodSync(credPath, 0o600)
+    it('returns "none" when the store has no Anthropic credential', () => {
+      // A valid, 0600 store with only a sibling key — the file exists and reads
+      // fine, but there is no ANTHROPIC_API_KEY / anthropicApiKey in it.
+      setStoredCredential('GEMINI_API_KEY', 'gem-sibling-value')
       const result = resolveAnthropicApiKey()
       assert.equal(result.key, null)
-      assert.match(result.reason, /missing or empty "anthropicApiKey"/)
+      assert.match(result.reason, /no Anthropic credential is stored/)
     })
 
-    it('prefers env var over file when both are present', () => {
-      // Demonstrates the priority order — env wins. Allows users to
-      // override a saved file by exporting the env var temporarily.
-      const chroxyDir = join(tmpHome, '.chroxy')
-      const credPath = join(chroxyDir, 'credentials.json')
-      mkdirSync(chroxyDir, { recursive: true })
-      writeFileSync(credPath, JSON.stringify({ anthropicApiKey: 'sk-ant-from-file' }))
-      chmodSync(credPath, 0o600)
+    it('prefers env var over store when both are present', () => {
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-from-store')
       process.env.ANTHROPIC_API_KEY = 'sk-ant-from-env'
       const result = resolveAnthropicApiKey()
       assert.equal(result.key, 'sk-ant-from-env')
       assert.equal(result.source, 'env')
+    })
+  })
+
+  // #5867 — the BYOK set/clear path now uses the canonical store. These tests
+  // pin the two acceptance criteria the legacy whole-file overwrite/unlink
+  // violated: sibling credentials survive, and a set→read round-trip works in
+  // BOTH plaintext and encrypted (keychain) modes.
+  describe('canonical-store integration (#5867)', () => {
+    it('setting the BYOK key preserves a sibling provider credential', () => {
+      setStoredCredential('GEMINI_API_KEY', 'gem-keep-me')
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-byok-set')
+      const parsed = JSON.parse(readFileSync(credPath(), 'utf8'))
+      assert.equal(parsed.GEMINI_API_KEY, 'gem-keep-me', 'sibling key must survive the BYOK write')
+      assert.equal(resolveAnthropicApiKey().key, 'sk-ant-byok-set')
+    })
+
+    it('clearing the BYOK key preserves a sibling and leaves the file intact', () => {
+      setStoredCredential('GEMINI_API_KEY', 'gem-keep-me')
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-byok-set')
+      deleteStoredCredential('ANTHROPIC_API_KEY')
+      assert.ok(existsSync(credPath()), 'file must remain while a sibling exists')
+      const parsed = JSON.parse(readFileSync(credPath(), 'utf8'))
+      assert.equal(parsed.GEMINI_API_KEY, 'gem-keep-me')
+      assert.equal(resolveAnthropicApiKey().key, null, 'Anthropic key is gone')
+    })
+
+    it('clearing the only credential removes the file', () => {
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-only')
+      deleteStoredCredential('ANTHROPIC_API_KEY')
+      assert.equal(existsSync(credPath()), false)
+    })
+
+    it('round-trips a set→read in ENCRYPTED mode and never writes plaintext', () => {
+      // Drive the encrypted-at-rest path with an in-memory keychain (the
+      // getToken/setToken interface credential-cipher.js uses).
+      const store = new Map()
+      _setCredentialKeychainForTests({
+        isKeychainAvailable: () => true,
+        getToken: (service) => store.get(service) ?? null,
+        setToken: (token, service) => { store.set(service, token) },
+        deleteToken: (service) => { store.delete(service) },
+      })
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-encrypted-roundtrip')
+      // On-disk bytes must be an envelope, NOT the plaintext key.
+      const raw = readFileSync(credPath(), 'utf8')
+      assert.equal(raw.includes('sk-ant-encrypted-roundtrip'), false, 'key must not be on disk in plaintext')
+      // Decryption-aware read resolves it.
+      const result = resolveAnthropicApiKey()
+      assert.equal(result.key, 'sk-ant-encrypted-roundtrip')
+      assert.equal(result.source, 'file')
     })
   })
 
@@ -122,7 +176,6 @@ describe('byok-credentials', () => {
       const masked = maskApiKey('sk-ant-api03-abcdefghijklmnopqrstuvwxyz')
       assert.match(masked, /^sk-ant-api03/)
       assert.match(masked, /\[\d+ chars redacted\]$/)
-      // Critical: the full key must not appear in the masked output.
       assert.equal(masked.includes('abcdefghijklmnopqrstuvwxyz'), false)
     })
 
@@ -134,14 +187,10 @@ describe('byok-credentials', () => {
     })
 
     it('never echoes the full key — even for unexpectedly short inputs', () => {
-      // Pre-fix, slice(0, 12) returned the entire string for any input
-      // shorter than 12 chars, leaking the whole secret into logs.
-      // Caught by Copilot review on PR #4055.
       const short = 'sk-ant-x'  // 8 chars
       const masked = maskApiKey(short)
       assert.equal(masked.includes(short), false, 'must not contain the full short key')
       assert.match(masked, /\[\d+ chars redacted\]$/)
-      // The visible prefix should be at most one-third of the input.
       const visibleSegment = masked.split('...')[0]
       assert.ok(visibleSegment.length <= Math.floor(short.length / 3),
         `visible prefix (${visibleSegment.length}) must be <= 1/3 of input (${Math.floor(short.length / 3)})`)
@@ -150,100 +199,13 @@ describe('byok-credentials', () => {
     it('still produces a useful prefix for normal-length keys', () => {
       const real = 'sk-ant-api03-' + 'a'.repeat(95)  // ~108 chars, claude length
       const masked = maskApiKey(real)
-      // Still 12 chars of useful prefix for grepping logs.
       assert.match(masked, /^sk-ant-api03/)
       assert.match(masked, /\[\d+ chars redacted\]$/)
       assert.equal(masked.includes(real.slice(15)), false)
     })
   })
 
-  // POSIX-only: chmod / 0o600 don't map cleanly to NTFS ACLs, so the file
-  // mode assertions are skipped on win32. The behavior under test still
-  // runs there (the rename + write); only the strict 0o600 check is POSIX.
-  const isPosix = process.platform !== 'win32'
-
-  describe('writeAnthropicApiKey (#4052)', () => {
-    it('writes the key to ~/.chroxy/credentials.json with mode 0600 (POSIX only)', { skip: !isPosix }, () => {
-      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
-      writeAnthropicApiKey('sk-ant-paste-test')
-      assert.ok(existsSync(credPath), 'file must exist after write')
-      const mode = statSync(credPath).mode & 0o777
-      assert.equal(mode, 0o600, `mode must be 0600, got ${mode.toString(8)}`)
-      const parsed = JSON.parse(readFileSync(credPath, 'utf8'))
-      assert.equal(parsed.anthropicApiKey, 'sk-ant-paste-test')
-    })
-
-    it('writes the key file regardless of platform (cross-platform)', () => {
-      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
-      writeAnthropicApiKey('sk-ant-cross-platform')
-      assert.ok(existsSync(credPath))
-      const parsed = JSON.parse(readFileSync(credPath, 'utf8'))
-      assert.equal(parsed.anthropicApiKey, 'sk-ant-cross-platform')
-    })
-
-    it('creates the ~/.chroxy directory if missing', () => {
-      assert.equal(existsSync(join(tmpHome, '.chroxy')), false)
-      writeAnthropicApiKey('sk-ant-mkdir-test')
-      assert.ok(existsSync(join(tmpHome, '.chroxy')))
-      if (isPosix) {
-        assert.equal(statSync(join(tmpHome, '.chroxy')).mode & 0o777, 0o700,
-          '.chroxy dir should be 0700 so creds aren\'t enumerable')
-      }
-    })
-
-    it('overwrites an existing credentials file atomically', () => {
-      writeAnthropicApiKey('sk-ant-first')
-      writeAnthropicApiKey('sk-ant-second')
-      const parsed = JSON.parse(readFileSync(join(tmpHome, '.chroxy', 'credentials.json'), 'utf8'))
-      assert.equal(parsed.anthropicApiKey, 'sk-ant-second')
-      if (isPosix) {
-        const mode = statSync(join(tmpHome, '.chroxy', 'credentials.json')).mode & 0o777
-        assert.equal(mode, 0o600, 'mode must remain 0600 on overwrite')
-      }
-    })
-
-    it('rejects empty / non-string keys', () => {
-      assert.throws(() => writeAnthropicApiKey(''), /required/i)
-      assert.throws(() => writeAnthropicApiKey(null), /required/i)
-      assert.throws(() => writeAnthropicApiKey(undefined), /required/i)
-      assert.throws(() => writeAnthropicApiKey(123), /required/i)
-    })
-
-    it('writes a key that resolveAnthropicApiKey can then read back', () => {
-      writeAnthropicApiKey('sk-ant-roundtrip')
-      const result = resolveAnthropicApiKey()
-      assert.equal(result.key, 'sk-ant-roundtrip')
-      assert.equal(result.source, 'file')
-    })
-
-    it('does not leave any .tmp.* files in ~/.chroxy after a successful write', () => {
-      // The atomic-rename path uses a temp file; after a normal success
-      // there should be no leftover *.tmp.* entries.
-      writeAnthropicApiKey('sk-ant-no-tmp-leftover')
-      const credDir = join(tmpHome, '.chroxy')
-      const entries = readDir(credDir)
-      const stale = entries.filter((e) => e.includes('.tmp.'))
-      assert.equal(stale.length, 0, `unexpected tmp files: ${stale.join(', ')}`)
-    })
-  })
-
-  describe('clearAnthropicApiKey (#4052)', () => {
-    it('removes the credentials file', () => {
-      writeAnthropicApiKey('sk-ant-to-be-cleared')
-      const credPath = join(tmpHome, '.chroxy', 'credentials.json')
-      assert.ok(existsSync(credPath))
-      clearAnthropicApiKey()
-      assert.equal(existsSync(credPath), false)
-    })
-
-    it('is a no-op if the file does not exist', () => {
-      // Should not throw.
-      clearAnthropicApiKey()
-      assert.equal(existsSync(join(tmpHome, '.chroxy', 'credentials.json')), false)
-    })
-  })
-
-  describe('getAnthropicApiKeyStatus (#4052)', () => {
+  describe('getAnthropicApiKeyStatus', () => {
     it('reports "missing" when neither env nor file present', () => {
       const s = getAnthropicApiKeyStatus()
       assert.equal(s.status, 'missing')
@@ -253,8 +215,6 @@ describe('byok-credentials', () => {
     })
 
     it('reports "set" with source=env when env var is set', () => {
-      // Use a realistic-length key so maskApiKey emits the full 12-char prefix
-      // (short keys cap visible at floor(len/3) by design).
       const longKey = 'sk-ant-api03-' + 'a'.repeat(95)
       process.env.ANTHROPIC_API_KEY = longKey
       const s = getAnthropicApiKeyStatus()
@@ -264,9 +224,8 @@ describe('byok-credentials', () => {
       assert.equal(s.masked.includes(longKey.slice(15)), false, 'must not echo full key')
     })
 
-    it('reports "set" with source=file when key is in credentials.json', () => {
-      const longKey = 'sk-ant-api03-' + 'b'.repeat(95)
-      writeAnthropicApiKey(longKey)
+    it('reports "set" with source=file when key is in the store', () => {
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-' + 'b'.repeat(95))
       const s = getAnthropicApiKeyStatus()
       assert.equal(s.status, 'set')
       assert.equal(s.source, 'file')
@@ -274,14 +233,11 @@ describe('byok-credentials', () => {
     })
 
     it('reports fileExists=false when no credentials file is on disk (#4144)', () => {
-      const s = getAnthropicApiKeyStatus()
-      assert.equal(s.fileExists, false)
+      assert.equal(getAnthropicApiKeyStatus().fileExists, false)
     })
 
     it('reports fileExists=true when env wins precedence but file is on disk (#4144 stale-file)', () => {
-      // Plant a file and an env var. Env wins; the dashboard still needs
-      // to know the shadowed file exists so it can offer Remove.
-      writeAnthropicApiKey('sk-ant-api03-' + 'c'.repeat(95))
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-' + 'c'.repeat(95))
       process.env.ANTHROPIC_API_KEY = 'sk-ant-env-' + 'd'.repeat(95)
       const s = getAnthropicApiKeyStatus()
       assert.equal(s.status, 'set')
@@ -290,7 +246,7 @@ describe('byok-credentials', () => {
     })
 
     it('reports fileExists=true when only the file is the key source (#4144 consistency)', () => {
-      writeAnthropicApiKey('sk-ant-api03-' + 'e'.repeat(95))
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-' + 'e'.repeat(95))
       const s = getAnthropicApiKeyStatus()
       assert.equal(s.source, 'file')
       assert.equal(s.fileExists, true)
@@ -302,24 +258,17 @@ describe('byok-credentials', () => {
       assert.equal(hasStoredCredentials(), false)
     })
 
-    it('returns true after writeAnthropicApiKey lands a file', () => {
-      writeAnthropicApiKey('sk-ant-api03-' + 'f'.repeat(95))
+    it('returns true after a store write lands a file', () => {
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-' + 'f'.repeat(95))
       assert.equal(hasStoredCredentials(), true)
     })
 
     it('returns true even when the file mode is wrong (resolve would refuse it)', () => {
-      // Plant a file with mode 0644 — resolveAnthropicApiKey will refuse
-      // to read it, but the user still has a file on disk to clear.
-      const credsPath = join(tmpHome, '.chroxy', 'credentials.json')
-      mkdirSync(join(tmpHome, '.chroxy'), { recursive: true })
-      writeFileSync(credsPath, '{"anthropicApiKey":"x"}', { mode: 0o644 })
-      chmodSync(credsPath, 0o644)
-      assert.equal(hasStoredCredentials(), true,
-        'presence is independent of resolution validity')
+      const chroxyDir = join(tmpHome, '.chroxy')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath(), '{"anthropicApiKey":"x"}', { mode: 0o644 })
+      chmodSync(credPath(), 0o644)
+      assert.equal(hasStoredCredentials(), true, 'presence is independent of resolution validity')
     })
   })
 })
-
-function readDir(p) {
-  try { return readdirSync(p) } catch { return [] }
-}

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -1269,7 +1269,9 @@ describe('listProviders credential-file caching (#4658)', () => {
         const afterBlank = listProviders().find(p => p.name === 'claude-byok').auth
         assert.equal(afterBlank.ready, false,
           'cache must refresh on mtime change — otherwise we would still report ready=true after blanking')
-        assert.match(afterBlank.detail, /missing or empty "anthropicApiKey" field/)
+        // #5867: reason wording updated when the BYOK read moved to the
+        // canonical store ("no Anthropic credential is stored").
+        assert.match(afterBlank.detail, /no Anthropic credential is stored/)
       } finally {
         teardown()
       }


### PR DESCRIPTION
Closes **#5867** (audit P1-8). The BYOK credential handlers used the legacy `byok-credentials.js` write path, which **clobbered sibling provider keys** and **downgraded an encrypted store to plaintext**:
- `writeAnthropicApiKey` did a **full-file overwrite** (wiping `GEMINI_API_KEY` etc. set via the generic store)
- `clearAnthropicApiKey` **unlinked the whole file**
- both wrote **plaintext**, silently downgrading an at-rest-encrypted store (#5154)

The read path was coupled — `byok-session`'s paid-API auth reads `resolveAnthropicApiKey` — so all three had to migrate together (this is the "not a thin shim" trap the issue calls out).

## Changes
| File | Change |
|---|---|
| `credential-store.js` | New `resolveStoredCredentialWithMeta(key)` — cipher-aware, legacy-`anthropicApiKey`-alias-aware read that **also** returns the `readStore` metadata (`fileExists` / `error` / `keychainUnavailable`) so callers build status reasons without echoing the value. |
| `byok-credentials.js` | `resolveAnthropicApiKey` reads via the store (env precedence preserved; reasons preserve the bad-mode / keychain-locked / corrupt-envelope / file-absent distinctions, plus a clearer present-but-no-Anthropic-key reason). `getAnthropicApiKeyStatus`/`hasStoredCredentials`/`maskApiKey` unchanged. **Dropped** `writeAnthropicApiKey` + `clearAnthropicApiKey` — the module is now read-only. |
| `handlers/credential-handlers.js` | `byok_set_credentials` → `setStoredCredential('ANTHROPIC_API_KEY', key)` (merge + encrypt; keeps the `sk-ant-` pre-check for the nicer error). `byok_clear_credentials` → `deleteStoredCredential('ANTHROPIC_API_KEY')` (single-key delete; file unlinked only when empty). |

## Backward compatibility
Existing plaintext `{ anthropicApiKey }` files written by the pre-#5867 path still resolve — `readStore` passes plaintext through and `getStoredCredential`/the new reader honor the legacy alias. `byok-session` auth and the `listProviders` credential-file cache are unaffected (the underlying file read is unchanged).

## Acceptance (all met)
- [x] Setting/clearing the BYOK key **preserves sibling credentials** (merge / single-key delete)
- [x] BYOK set→read round-trips in **both plaintext and encrypted (keychain)** modes — **no plaintext downgrade**
- [x] `byok-session` auth still resolves the key; env-var precedence preserved
- [x] `getAnthropicApiKeyStatus` reasons (missing / bad-mode / keychain-locked) preserved
- [x] `byok-credentials.test.js` rewritten around the store

## Testing
- `byok-credentials.test.js` rewritten (25): env precedence, store + legacy-alias reads, 0600 boundary, **sibling-preservation on set/clear**, plaintext + **encrypted set→read round-trip** (asserts the key is never on disk in plaintext).
- `byok-credentials-handlers` (16), `credential-store*` suites, `byok-session`, `providers` (91, updated the cache reason-string assertion) — all green.
- Full server suite: only the known `:8765` live-daemon `service.test.js` artifact fails (unrelated). eslint + all four custom shell lints clean.

Closes #5867.