### PR TITLE
refactor(server): single-source Claude-family membership via static claudeFamily (#5858)

### DIFF
--- a/packages/server/src/anthropic-compatible-session.js
+++ b/packages/server/src/anthropic-compatible-session.js
@@ -270,6 +270,12 @@ export function createAnthropicCompatibleSessionClass(rawEntry) {
   )
 
   class AnthropicCompatibleSession extends ClaudeByokSession {
+    // #5858: NOT Claude-family — config-driven Anthropic-compatible endpoints
+    // ride ClaudeByokSession's agent loop but have their own model allowlists,
+    // so override the inherited flag to false (validate strictly, never
+    // soft-fall-back to claude).
+    static claudeFamily = false
+
     /** The validated config entry this class was built from (introspection/tests). */
     static get compatEntry() {
       return entry

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -64,6 +64,13 @@ const MAX_TOOL_ROUNDS = 25
 const CWD_CACHE_TTL_MS = 30_000
 
 export class ClaudeByokSession extends BaseSession {
+  // #5858: Claude-family flag — single source of truth for isClaudeProvider().
+  // DockerByokSession (docker-byok) extends this and correctly inherits it.
+  // NOTE: non-Claude providers that ALSO extend this for the agent loop
+  // (DeepSeekSession, OllamaSession, AnthropicCompatibleSession) MUST override
+  // `static claudeFamily = false` — their model ids validate strictly.
+  static claudeFamily = true
+
   static get displayLabel() {
     return 'Claude (API key — BYOK)'
   }

--- a/packages/server/src/claude-channel-session.js
+++ b/packages/server/src/claude-channel-session.js
@@ -34,6 +34,9 @@ export const CLAUDE_CHANNEL_MIN_VERSION = '2.1.80'
  * permission-mode switch — those stay `false`, same gap `claude-tui` has.
  */
 export class ClaudeChannelSession extends BaseSession {
+  // #5858: Claude-family flag — single source of truth for isClaudeProvider().
+  static claudeFamily = true
+
   // Single source of truth for the scaffold's "not yet implemented" error
   // so start()/sendMessage()/interrupt() stay in lockstep and tests can
   // assert on the same string.

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -78,6 +78,10 @@ const log = createLogger('claude-tui-session')
  *   error         { message }
  */
 export class ClaudeTuiSession extends BaseSession {
+  // #5858: Claude-family flag — single source of truth for isClaudeProvider().
+  // This is the DEFAULT_PROVIDER, so its membership is load-bearing (#5855).
+  static claudeFamily = true
+
   static get displayLabel() {
     return 'Claude Code (TUI · subscription)'
   }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -189,6 +189,10 @@ export function buildClaudeCliArgs({ model, permissionMode, allowedTools, skills
  */
 
 export class CliSession extends BaseSession {
+  // #5858: Claude-family flag — single source of truth for isClaudeProvider().
+  // DockerSession (docker-cli / docker) extends this and inherits it.
+  static claudeFamily = true
+
   /**
    * Human-readable label shown in the startup banner and anywhere else the
    * server needs to name this provider (#2953). Each provider owns its own

--- a/packages/server/src/deepseek-session.js
+++ b/packages/server/src/deepseek-session.js
@@ -58,6 +58,11 @@ const DEEPSEEK_MODELS = Object.freeze([
 const DEEPSEEK_MODEL_IDS = Object.freeze(DEEPSEEK_MODELS.map((m) => m.id))
 
 export class DeepSeekSession extends ClaudeByokSession {
+  // #5858: NOT Claude-family — DeepSeek rides ClaudeByokSession's agent loop but
+  // has its own static model allowlist, so override the inherited flag to false
+  // (its model ids must validate strictly, never soft-fall-back to claude).
+  static claudeFamily = false
+
   static get displayLabel() {
     return 'DeepSeek (API key)'
   }

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1085,9 +1085,14 @@ const providerRegistryCache = new Map()
  * @returns {boolean}
  */
 export function isClaudeProvider(providerName, ProviderClass = null) {
-  if (ProviderClass && ProviderClass.claudeFamily === true) {
-    return true
+  // A passed class is AUTHORITATIVE: trust its boolean flag, so an explicit
+  // `static claudeFamily = false` opts out even when the name would otherwise
+  // resolve to a Claude class (name/class can only disagree on a caller bug,
+  // but the class the caller handed us is the ground truth).
+  if (ProviderClass && typeof ProviderClass.claudeFamily === 'boolean') {
+    return ProviderClass.claudeFamily
   }
+  // No class (or no flag on it) — resolve the class by name via the registry.
   if (typeof providerName === 'string') {
     const resolved = nameToProviderClass.get(providerName)
     if (resolved && resolved.claudeFamily === true) {

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1059,53 +1059,40 @@ const defaultRegistry = createModelsRegistry({ overlay: defaultOverlay })
  */
 const providerRegistryCache = new Map()
 
-// Every Claude-family provider id registered in providers.js. These all run the
-// real `claude` against the moving-target model allowlist that the Agent SDK
-// pushes live, so an unknown initial model must soft-fall-back to the provider
-// default rather than hard-reject (see isClaudeProvider). Keep in sync with the
-// claude-* / docker-* entries in the PROVIDERS literal — notably claude-tui,
-// the DEFAULT_PROVIDER (@chroxy/protocol): omitting it made the default
-// provider hard-reject a stale dashboard model id where every other Claude
-// provider recovers. (Longer-term this set should derive from a single
-// `static claudeFamily = true` on the provider classes — audit P2.)
-const CLAUDE_PROVIDER_NAMES = new Set([
-  'claude-sdk',
-  'claude-cli',
-  'claude-tui',
-  'claude-channel',
-  'claude-byok',
-  'docker',
-  'docker-sdk',
-  'docker-cli',
-  'docker-byok',
-])
-
 /**
- * True when the given provider name is a Claude-family provider (and so
- * shares the default models registry, which is fed by the Agent SDK's live
- * `supportedModels()` push). Non-Claude providers (Codex, Gemini, custom)
- * have their own static allowlists and should be validated strictly.
+ * True when the given provider is a Claude-family provider (and so shares the
+ * default models registry, which is fed by the Agent SDK's live
+ * `supportedModels()` push). Non-Claude providers (Codex, Gemini, custom) have
+ * their own static allowlists and should be validated strictly.
  *
- * Used by `SessionManager.createSession` (#3403) to decide whether an
- * unknown initial model should be a hard rejection or a soft fall-back to
- * the provider default — Claude's allowlist is a moving target driven by
- * a stale dashboard `defaultModel` (e.g. `opus-4-6` after `opus-4-7` ships)
- * so a hard error breaks otherwise-valid session creation.
+ * Used by `SessionManager.createSession` (#3403) to decide whether an unknown
+ * initial model should be a hard rejection or a soft fall-back to the provider
+ * default — Claude's allowlist is a moving target driven by a stale dashboard
+ * `defaultModel` (e.g. `opus-4-6` after `opus-4-7` ships) so a hard error breaks
+ * otherwise-valid session creation.
  *
- * Also honours an opt-in static flag on the provider class
- * (`static claudeFamily = true`) so external/test providers can mark
- * themselves as Claude-style without extending the hard-coded name set.
+ * #5858: membership is the SINGLE `static claudeFamily = true` flag on the
+ * provider class (inherited by docker-* subclasses), not a hand-maintained name
+ * literal that drifted from the registry (#5855). When the class isn't passed,
+ * it is resolved via the `nameToProviderClass` map (populated for every provider
+ * at registration). Docker-* resolve once `registerDockerProvider()` has run —
+ * which is always before a docker session is created; `getRegistryForProvider`
+ * is unaffected pre-registration because its unknown-name branch also returns
+ * the default registry.
  *
  * @param {string|undefined|null} providerName
  * @param {Function} [ProviderClass] - optional provider class for the name
  * @returns {boolean}
  */
 export function isClaudeProvider(providerName, ProviderClass = null) {
-  if (typeof providerName === 'string' && CLAUDE_PROVIDER_NAMES.has(providerName)) {
-    return true
-  }
   if (ProviderClass && ProviderClass.claudeFamily === true) {
     return true
+  }
+  if (typeof providerName === 'string') {
+    const resolved = nameToProviderClass.get(providerName)
+    if (resolved && resolved.claudeFamily === true) {
+      return true
+    }
   }
   return false
 }
@@ -1168,7 +1155,7 @@ export function _resetProviderRegistryCacheForTests(providerName) {
  * @returns {ReturnType<typeof createModelsRegistry>}
  */
 export function getRegistryForProvider(providerName) {
-  if (!providerName || CLAUDE_PROVIDER_NAMES.has(providerName)) {
+  if (!providerName || isClaudeProvider(providerName)) {
     return defaultRegistry
   }
 

--- a/packages/server/src/ollama-session.js
+++ b/packages/server/src/ollama-session.js
@@ -71,6 +71,11 @@ const OLLAMA_FALLBACK_MODELS = Object.freeze([
 const OLLAMA_ZERO_PRICING = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 })
 
 export class OllamaSession extends ClaudeByokSession {
+  // #5858: NOT Claude-family — Ollama rides ClaudeByokSession's agent loop but
+  // serves locally-pulled models (getAllowedModels() returns null, #5418), so
+  // override the inherited flag to false (never soft-fall-back to claude).
+  static claudeFamily = false
+
   static get displayLabel() {
     return 'Ollama (local)'
   }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -92,6 +92,11 @@ export const STDIN_DROPPED_ESCALATION_EVERY_N = 10
 export const REFUSED_SENDMESSAGE_WARN_INTERVAL_MS = 30 * 1000
 
 export class SdkSession extends BaseSession {
+  // #5858: marks this as a Claude-family provider — the single source of truth
+  // for `isClaudeProvider()` (drives the createSession soft-fallback for stale
+  // model ids + the shared models registry). Docker subclasses inherit it.
+  static claudeFamily = true
+
   /**
    * Human-readable label shown in the startup banner and anywhere else the
    * server needs to name this provider (#2953). Each provider owns its own

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -11,6 +11,8 @@ import '../src/providers.js'
 import { DockerSession } from '../src/docker-session.js'
 import { DockerSdkSession } from '../src/docker-sdk-session.js'
 import { DockerByokSession } from '../src/docker-byok-session.js'
+import { DeepSeekSession } from '../src/deepseek-session.js'
+import { OllamaSession } from '../src/ollama-session.js'
 
 describe('FALLBACK_MODELS (default registry)', () => {
   it('is deep-frozen so getModels() callers cannot mutate the constant', () => {
@@ -872,11 +874,29 @@ describe('isClaudeProvider — Claude-family provider allowlist', () => {
     }
   })
 
+  it('the non-Claude ClaudeByokSession subclasses keep the explicit false override', () => {
+    // Drift guard: these extend ClaudeByokSession (claudeFamily=true) for the
+    // agent loop and MUST override to false. If an override is dropped, this
+    // fails directly (not only via the name-based check above).
+    assert.equal(DeepSeekSession.claudeFamily, false)
+    assert.equal(OllamaSession.claudeFamily, false)
+  })
+
   it('honours the static claudeFamily flag passed directly (external providers)', () => {
     // Match the real call site: createSession passes the provider class.
     class ClaudeFamilyProvider { static claudeFamily = true }
     class NonClaudeProvider { static claudeFamily = false }
     assert.equal(isClaudeProvider('some-external', ClaudeFamilyProvider), true)
     assert.equal(isClaudeProvider('some-external', NonClaudeProvider), false)
+  })
+
+  it('a passed class is authoritative — explicit false opts out even for a Claude name', () => {
+    // #5890 (Copilot): when name and class disagree (a caller bug), the class
+    // the caller handed us wins, including an explicit opt-out.
+    class OptedOut { static claudeFamily = false }
+    assert.equal(isClaudeProvider('claude-tui', OptedOut), false)
+    // A class with no flag falls through to the name resolution.
+    class NoFlag {}
+    assert.equal(isClaudeProvider('claude-tui', NoFlag), true)
   })
 })

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,7 +1,16 @@
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it, before, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider } from '../src/models.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider, registerProviderRegistry } from '../src/models.js'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
+// #5858: membership is now derived from `static claudeFamily` on the registered
+// provider classes (no hand-authored name literal). Importing providers.js
+// registers claude-* + non-claude into the name→class map; docker-* register
+// lazily in prod, so the test registers their real classes (which extend the
+// claude sessions and inherit the flag) to exercise the same path.
+import '../src/providers.js'
+import { DockerSession } from '../src/docker-session.js'
+import { DockerSdkSession } from '../src/docker-sdk-session.js'
+import { DockerByokSession } from '../src/docker-byok-session.js'
 
 describe('FALLBACK_MODELS (default registry)', () => {
   it('is deep-frozen so getModels() callers cannot mutate the constant', () => {
@@ -818,7 +827,17 @@ describe('computePromptCostUsd()', () => {
 describe('isClaudeProvider — Claude-family provider allowlist', () => {
   // Every Claude-family provider runs the real `claude` against the moving model
   // allowlist the Agent SDK pushes live, so createSession must soft-fall-back an
-  // unknown initial model (not hard-reject). The set must cover ALL of them.
+  // unknown initial model (not hard-reject). Membership is the `static
+  // claudeFamily = true` flag on the provider class (#5858), resolved via the
+  // name→class registry. The non-docker entries are registered by importing
+  // providers.js above; docker-* register lazily in prod, so register them here.
+  before(() => {
+    registerProviderRegistry('docker', DockerSession)
+    registerProviderRegistry('docker-cli', DockerSession)
+    registerProviderRegistry('docker-sdk', DockerSdkSession)
+    registerProviderRegistry('docker-byok', DockerByokSession)
+  })
+
   const CLAUDE_FAMILY = [
     'claude-sdk', 'claude-cli', 'claude-tui', 'claude-channel', 'claude-byok',
     'docker', 'docker-sdk', 'docker-cli', 'docker-byok',
@@ -830,22 +849,31 @@ describe('isClaudeProvider — Claude-family provider allowlist', () => {
     })
   }
 
+  it('docker subclasses inherit the static claudeFamily flag (no per-id edit)', () => {
+    // The single-source mechanism: docker classes extend the claude sessions, so
+    // the flag is inherited without touching models.js.
+    assert.equal(DockerSession.claudeFamily, true)
+    assert.equal(DockerSdkSession.claudeFamily, true)
+    assert.equal(DockerByokSession.claudeFamily, true)
+  })
+
   it('treats the DEFAULT_PROVIDER as Claude-family (so the default never hard-rejects a stale model)', () => {
-    // Regression guard: claude-tui became the default but was missing from the
-    // set, so the default provider hard-rejected stale dashboard model ids.
-    // If the default ever flips again, this fails until the set is updated.
-    assert.equal(isClaudeProvider(DEFAULT_PROVIDER), true, `DEFAULT_PROVIDER ${DEFAULT_PROVIDER} must be in CLAUDE_PROVIDER_NAMES`)
+    // Regression guard (#5855): claude-tui became the default but was missing
+    // from the old hand-maintained set, so the default provider hard-rejected
+    // stale dashboard model ids. Now derived from the class flag.
+    assert.equal(isClaudeProvider(DEFAULT_PROVIDER), true, `DEFAULT_PROVIDER ${DEFAULT_PROVIDER} must be Claude-family`)
   })
 
   it('does not treat non-Claude providers as Claude-family', () => {
+    // deepseek/ollama extend ClaudeByokSession for the agent loop but override
+    // `static claudeFamily = false` — their model ids must validate strictly.
     for (const name of ['codex', 'gemini', 'deepseek', 'ollama', 'unknown-provider']) {
       assert.equal(isClaudeProvider(name), false, `${name} must not be Claude-family`)
     }
   })
 
-  it('honours the static claudeFamily flag for external providers', () => {
-    // Match the real call site: a ProviderClass with a static claudeFamily flag,
-    // not a plain object (createSession passes the provider class).
+  it('honours the static claudeFamily flag passed directly (external providers)', () => {
+    // Match the real call site: createSession passes the provider class.
     class ClaudeFamilyProvider { static claudeFamily = true }
     class NonClaudeProvider { static claudeFamily = false }
     assert.equal(isClaudeProvider('some-external', ClaudeFamilyProvider), true)


### PR DESCRIPTION
Closes **#5858** (audit P2-1). `isClaudeProvider()` — which decides whether an unknown initial model id soft-falls-back to the provider default or hard-rejects — used a **hand-maintained `CLAUDE_PROVIDER_NAMES` literal** in `models.js` that had to stay in sync with the `claude-*`/`docker-*` entries in `providers.js`. That's the exact drift that made `claude-tui` (the `DEFAULT_PROVIDER`) hard-reject stale model ids in **#5855**.

## Make `static claudeFamily` the single source of truth
- Add `static claudeFamily = true` to `SdkSession`, `CliSession`, `ClaudeTuiSession`, `ClaudeChannelSession`, `ClaudeByokSession`. The docker subclasses (`DockerSession`, `DockerSdkSession`, `DockerByokSession`) **inherit** it via `extends` — no per-id edit.
- **Override `static claudeFamily = false`** on the non-Claude providers that reuse `ClaudeByokSession` for the agent loop — `DeepSeekSession`, `OllamaSession`, `AnthropicCompatibleSession` (their model ids must validate strictly, never soft-fall-back to Claude). This is the one subtlety the issue's class list didn't surface: `ClaudeByokSession` is the shared base for both Claude BYOK *and* the Anthropic-compatible non-Claude providers.
- `isClaudeProvider(name, ProviderClass)` trusts a passed class's flag, else resolves the class via the existing `nameToProviderClass` map (populated for every provider at registration). **`CLAUDE_PROVIDER_NAMES` is deleted.**
- `getRegistryForProvider` uses the same predicate.

## Behavior preserved
- `session-manager.createSession` (#3403) already passes the `ProviderClass` to `isClaudeProvider`, so its soft-fallback resolves directly off the flag.
- `getRegistryForProvider(name)` (name only): for an unregistered name (incl. docker pre-registration), the unknown-name branch already returns the default registry — same result as before. A docker session is only created after `registerDockerProvider()` has run, so its membership resolves then.

## Acceptance (all met)
- [x] No hand-maintained name literal — membership is derived from the class flag
- [x] Existing `isClaudeProvider` tests + the #5855 `DEFAULT_PROVIDER` regression guard pass
- [x] A new built-in Claude provider is Claude-family with **no edit to `models.js`** (just the class flag) — proven by the docker-inheritance test

## Testing
- `models.test.js` now imports `providers.js` (registers claude-*/non-claude into the name→class map) and registers the real docker classes; asserts the `DEFAULT_PROVIDER` + all docker-* are Claude-family, the docker classes inherit the flag, and `deepseek`/`ollama`/codex/gemini are **not**.
- Full server suite green except the known `:8765` live-daemon `service.test.js` artifact (unrelated). eslint + all four custom shell lints clean.

Closes #5858.