### PR TITLE
refactor(store-core): extract shared handler helpers into handlers/_shared.ts (audit P2-3)

### DIFF
--- a/packages/store-core/src/handlers/_shared.ts
+++ b/packages/store-core/src/handlers/_shared.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared internal helpers for the stateless message handlers — the field
+ * parsers and the session-resolution primitive used across every handler
+ * family module.
+ *
+ * Extracted from the handlers barrel (audit P2-3) so family modules
+ * (./git, ./file, ./environment, and the stateful families to follow) can
+ * import these without a circular dependency back on ./index. Pure move, no
+ * logic change.
+ *
+ * Visibility note: `resolveSessionId` and the `SessionPatch` type are part of
+ * the barrel's public surface and are re-exported from ./index. The three
+ * field parsers (`parseStringField`, `parseRawStringField`, `parseEnumField`)
+ * were always module-private; they are exported here only so sibling family
+ * modules can import them, and are deliberately NOT re-exported from ./index.
+ */
+
+/** Parse a string field from a message, returning trimmed value or null. */
+export function parseStringField(msg: Record<string, unknown>, field: string): string | null {
+  const val = msg[field]
+  if (typeof val === 'string' && val.trim()) return val.trim()
+  return null
+}
+
+/**
+ * Parse a string field WITHOUT trimming or empty-string coercion.
+ *
+ * Some legacy inline checks used `typeof v === 'string' ? v : null` — that
+ * passes through empty strings and whitespace verbatim. `auth_ok.cwd` is one
+ * such field; preserve the prior behaviour so this migration is mechanical.
+ */
+export function parseRawStringField(msg: Record<string, unknown>, field: string): string | null {
+  const val = msg[field]
+  return typeof val === 'string' ? val : null
+}
+
+/**
+ * Build a small union-checking helper that returns the value when it matches
+ * one of the provided literals, else null. Used for enum fields like
+ * `serverMode` and `mode`.
+ */
+export function parseEnumField<T extends string>(
+  msg: Record<string, unknown>,
+  field: string,
+  allowed: readonly T[],
+): T | null {
+  const val = msg[field]
+  return typeof val === 'string' && (allowed as readonly string[]).includes(val)
+    ? (val as T)
+    : null
+}
+
+// ---------------------------------------------------------------------------
+// Session-scoped state patches
+//
+// Many handlers follow a common pattern: resolve a target session ID from
+// the message (falling back to the active session), then produce a patch
+// for that session's state. The `SessionPatch` type captures this.
+// ---------------------------------------------------------------------------
+
+/** A patch to apply to a specific session's state. */
+export interface SessionPatch {
+  /** Session ID the patch targets (may be null if no session context). */
+  sessionId: string | null
+  /** Partial session state to shallow-merge. */
+  patch: Record<string, unknown>
+}
+
+/**
+ * Resolve which session a per-message-event targets — **fallback semantics**.
+ *
+ * Most server messages include an optional `sessionId`; when absent, the
+ * active session ID is used as a fallback. The returned value is non-null
+ * unless BOTH `msg.sessionId` and `activeSessionId` are missing/empty.
+ *
+ * Intended for events that should always be applied somewhere (e.g.
+ * `message`, `tool_start`, `tool_result`, `permission_request`): if the
+ * server omits the explicit routing tag, route to the user's current session.
+ *
+ * Distinct from {@link shouldSkipForSessionMismatch}, which uses
+ * **broadcast guard** semantics (drop the event when the explicit tag does
+ * not match).
+ */
+export function resolveSessionId(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): string | null {
+  return parseStringField(msg, 'sessionId') || activeSessionId
+}

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -43,82 +43,23 @@ import { isRateLimitMessage } from '@chroxy/protocol'
 // Established Zod-handler pattern (#3138).
 import { ServerAvailableModelsEntrySchema, ServerNotificationPrefsSchema } from '@chroxy/protocol'
 
+// Shared field parsers + session resolution live in ./_shared (audit P2-3).
+import {
+  parseStringField,
+  parseRawStringField,
+  parseEnumField,
+  resolveSessionId,
+} from './_shared'
+import type { SessionPatch } from './_shared'
 // ---------------------------------------------------------------------------
-// Helpers
+// Shared helpers (parseStringField / parseRawStringField / parseEnumField /
+// resolveSessionId) and the SessionPatch type now live in ./_shared.ts
+// (audit P2-3, imported above). resolveSessionId + SessionPatch are part of
+// the barrel's public surface, so they are re-exported here; the three field
+// parsers were always private and are intentionally not re-exported.
 // ---------------------------------------------------------------------------
-
-/** Parse a string field from a message, returning trimmed value or null. */
-function parseStringField(msg: Record<string, unknown>, field: string): string | null {
-  const val = msg[field]
-  if (typeof val === 'string' && val.trim()) return val.trim()
-  return null
-}
-
-/**
- * Parse a string field WITHOUT trimming or empty-string coercion.
- *
- * Some legacy inline checks used `typeof v === 'string' ? v : null` — that
- * passes through empty strings and whitespace verbatim. `auth_ok.cwd` is one
- * such field; preserve the prior behaviour so this migration is mechanical.
- */
-function parseRawStringField(msg: Record<string, unknown>, field: string): string | null {
-  const val = msg[field]
-  return typeof val === 'string' ? val : null
-}
-
-/**
- * Build a small union-checking helper that returns the value when it matches
- * one of the provided literals, else null. Used for enum fields like
- * `serverMode` and `mode`.
- */
-function parseEnumField<T extends string>(
-  msg: Record<string, unknown>,
-  field: string,
-  allowed: readonly T[],
-): T | null {
-  const val = msg[field]
-  return typeof val === 'string' && (allowed as readonly string[]).includes(val)
-    ? (val as T)
-    : null
-}
-
-// ---------------------------------------------------------------------------
-// Session-scoped state patches
-//
-// Many handlers follow a common pattern: resolve a target session ID from
-// the message (falling back to the active session), then produce a patch
-// for that session's state. The `SessionPatch` type captures this.
-// ---------------------------------------------------------------------------
-
-/** A patch to apply to a specific session's state. */
-export interface SessionPatch {
-  /** Session ID the patch targets (may be null if no session context). */
-  sessionId: string | null
-  /** Partial session state to shallow-merge. */
-  patch: Record<string, unknown>
-}
-
-/**
- * Resolve which session a per-message-event targets — **fallback semantics**.
- *
- * Most server messages include an optional `sessionId`; when absent, the
- * active session ID is used as a fallback. The returned value is non-null
- * unless BOTH `msg.sessionId` and `activeSessionId` are missing/empty.
- *
- * Intended for events that should always be applied somewhere (e.g.
- * `message`, `tool_start`, `tool_result`, `permission_request`): if the
- * server omits the explicit routing tag, route to the user's current session.
- *
- * Distinct from {@link shouldSkipForSessionMismatch}, which uses
- * **broadcast guard** semantics (drop the event when the explicit tag does
- * not match).
- */
-export function resolveSessionId(
-  msg: Record<string, unknown>,
-  activeSessionId: string | null,
-): string | null {
-  return parseStringField(msg, 'sessionId') || activeSessionId
-}
+export { resolveSessionId }
+export type { SessionPatch }
 
 // ---------------------------------------------------------------------------
 // model_changed


### PR DESCRIPTION
## Summary

Enabling slice for **audit P2-3**. The three families merged so far (#5892 git, #5893 file, #5894 environment) were dependency-free parse-only handlers. The remaining stateful families (budget, plan, checkpoint, agent, stream/tool/message, auth, …) all depend on a small set of cross-cutting helpers that live in the barrel. This PR moves those helpers into a new `handlers/_shared.ts` so sibling family modules can import them **without a circular dependency back on `./index`**.

Moved:
- `parseStringField` / `parseRawStringField` / `parseEnumField` — the field parsers (16 / 9 / 3 uses)
- `resolveSessionId` — the session-resolution primitive (21 call sites)
- `SessionPatch` — the session-scoped patch type (13 uses)

## Visibility (the one subtlety)

`resolveSessionId` and `SessionPatch` were part of the barrel's **public** surface — `index.ts` re-exports them from `./_shared` (`export { resolveSessionId }` / `export type { SessionPatch }`), so external consumers are unchanged. The three field parsers were always **private**; they're `export`ed from `_shared.ts` only so sibling modules can import them, and are deliberately **not** re-exported from the barrel.

## Behavior preservation

- **Pure move, byte-identical**: the moved bodies `diff` clean against the removed lines, modulo the added `export` keyword on the three previously-private parsers.
- `index.ts` imports the five symbols from `./_shared` and re-exports the two public ones. `resolveSessionId` calls `parseStringField`; both moved together, so `_shared.ts` is self-consistent and has no dependency on `./index` (no cycle).
- `handlers/index.ts`: 5209 → 5150 lines.

## Verification

- `npm run typecheck` (store-core) ✅
- `npx vitest run` (store-core): **1574 passed** ✅
- `npm run typecheck` (dashboard) ✅
- `npx tsc --noEmit` (app) ✅

Part of audit P2-3 (enabling slice; unblocks the stateful families).