### PR TITLE
refactor(store-core): extract cost-budget handlers into handlers/budget.ts (audit P2-3)

### DIFF
--- a/packages/store-core/src/handlers/budget.ts
+++ b/packages/store-core/src/handlers/budget.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared stateless handlers for cost-budget messages (budget_warning /
+ * budget_exceeded / budget_resumed / budget_resume_ack).
+ *
+ * Extracted from the handlers barrel (audit P2-3) — pure move, no logic
+ * change. Re-exported from ./index so the public surface is unchanged. Each
+ * handler builds a `system` ChatMessage note for the budget lifecycle. See
+ * ./index.ts for the stateless-handler contract.
+ */
+
+import type { ChatMessage } from '../types'
+import { nextMessageId } from '../utils'
+
+// ---------------------------------------------------------------------------
+// budget_warning
+// ---------------------------------------------------------------------------
+
+/** Extract warning text and build a system message for `budget_warning`. */
+export function handleBudgetWarning(msg: Record<string, unknown>): {
+  warningMessage: string
+  systemMessage: ChatMessage
+} {
+  const warningMessage =
+    typeof msg.message === 'string' ? msg.message : 'Approaching cost budget limit'
+  return {
+    warningMessage,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: warningMessage,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// budget_exceeded
+// ---------------------------------------------------------------------------
+
+/** Extract exceeded text and build a system message for `budget_exceeded`. */
+export function handleBudgetExceeded(msg: Record<string, unknown>): {
+  exceededMessage: string
+  systemMessage: ChatMessage
+} {
+  const exceededMessage =
+    typeof msg.message === 'string' ? msg.message : 'Cost budget exceeded'
+  return {
+    exceededMessage,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: `${exceededMessage} — session paused`,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// budget_resumed
+// ---------------------------------------------------------------------------
+
+/** Build a system message for `budget_resumed`. */
+export function handleBudgetResumed(): { systemMessage: ChatMessage } {
+  return {
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: 'Cost budget override — session resumed',
+      timestamp: Date.now(),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// budget_resume_ack (#5752)
+// ---------------------------------------------------------------------------
+
+/**
+ * Acknowledge an actioned `resume_budget` request.
+ *
+ * When the session was actually paused (`wasPaused === true`) the server also
+ * broadcast a `budget_resumed`, which already injected the "session resumed"
+ * note — so the ack adds nothing and returns `{ systemMessage: null }`. When the
+ * session was NOT paused the ack is the only feedback the clicking client gets,
+ * so it appends a quiet note rather than leaving the control silently dead
+ * (e.g. a second client in a shared session tapping Resume after the first
+ * already resumed).
+ */
+export function handleBudgetResumeAck(
+  msg: Record<string, unknown>,
+): { systemMessage: ChatMessage | null } {
+  if (msg.wasPaused === true) return { systemMessage: null }
+  return {
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: 'Budget was not paused — nothing to resume',
+      timestamp: Date.now(),
+    },
+  }
+}

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -259,93 +259,11 @@ export function handleThinkingLevelChanged(msg: Record<string, unknown>): { leve
 }
 
 // ---------------------------------------------------------------------------
-// budget_warning
+// Cost-budget handlers (budget_warning / budget_exceeded / budget_resumed /
+// budget_resume_ack) live in ./budget.ts (audit P2-3 split). Re-exported here
+// so the barrel's public surface is unchanged.
 // ---------------------------------------------------------------------------
-
-/** Extract warning text and build a system message for `budget_warning`. */
-export function handleBudgetWarning(msg: Record<string, unknown>): {
-  warningMessage: string
-  systemMessage: ChatMessage
-} {
-  const warningMessage =
-    typeof msg.message === 'string' ? msg.message : 'Approaching cost budget limit'
-  return {
-    warningMessage,
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: warningMessage,
-      timestamp: Date.now(),
-    },
-  }
-}
-
-// ---------------------------------------------------------------------------
-// budget_exceeded
-// ---------------------------------------------------------------------------
-
-/** Extract exceeded text and build a system message for `budget_exceeded`. */
-export function handleBudgetExceeded(msg: Record<string, unknown>): {
-  exceededMessage: string
-  systemMessage: ChatMessage
-} {
-  const exceededMessage =
-    typeof msg.message === 'string' ? msg.message : 'Cost budget exceeded'
-  return {
-    exceededMessage,
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: `${exceededMessage} — session paused`,
-      timestamp: Date.now(),
-    },
-  }
-}
-
-// ---------------------------------------------------------------------------
-// budget_resumed
-// ---------------------------------------------------------------------------
-
-/** Build a system message for `budget_resumed`. */
-export function handleBudgetResumed(): { systemMessage: ChatMessage } {
-  return {
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: 'Cost budget override — session resumed',
-      timestamp: Date.now(),
-    },
-  }
-}
-
-// ---------------------------------------------------------------------------
-// budget_resume_ack (#5752)
-// ---------------------------------------------------------------------------
-
-/**
- * Acknowledge an actioned `resume_budget` request.
- *
- * When the session was actually paused (`wasPaused === true`) the server also
- * broadcast a `budget_resumed`, which already injected the "session resumed"
- * note — so the ack adds nothing and returns `{ systemMessage: null }`. When the
- * session was NOT paused the ack is the only feedback the clicking client gets,
- * so it appends a quiet note rather than leaving the control silently dead
- * (e.g. a second client in a shared session tapping Resume after the first
- * already resumed).
- */
-export function handleBudgetResumeAck(
-  msg: Record<string, unknown>,
-): { systemMessage: ChatMessage | null } {
-  if (msg.wasPaused === true) return { systemMessage: null }
-  return {
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: 'Budget was not paused — nothing to resume',
-      timestamp: Date.now(),
-    },
-  }
-}
+export * from './budget'
 
 // ---------------------------------------------------------------------------
 // plan_started


### PR DESCRIPTION
## Summary

Fifth slice of **audit P2-3** — splitting `store-core/handlers/index.ts` by family. Follows #5892 (git), #5893 (file), #5894 (environment), #5895 (`_shared.ts`).

Moves the **cost-budget** family into a new `handlers/budget.ts`:

- 4 handlers: `handleBudgetWarning`, `handleBudgetExceeded`, `handleBudgetResumed`, `handleBudgetResumeAck` — each builds a `system` ChatMessage note for the budget lifecycle.

## Dependencies

`budget.ts` imports only `ChatMessage` (`../types`) and `nextMessageId` (`../utils`) — the handlers use bare `typeof` checks and need none of the shared barrel helpers. Both imports remain used in `index.ts` (no import cleanup).

## Behavior preservation

- **Pure move, byte-identical**: `tail -n +14 budget.ts` `diff`s clean against the lines removed from `index.ts`.
- Barrel re-exports via `export * from './budget'`; public surface unchanged. The only remaining `handleBudgetExceeded` mention in `index.ts` is a JSDoc cross-reference in `handleSessionCostThresholdCrossed` ("mirrors `handleBudgetExceeded`'s shape") — a comment, not a call.
- `handlers/index.ts`: 5150 → 5068 lines.

## Verification

- `npm run typecheck` (store-core) ✅
- `npx vitest run` (store-core): **1574 passed** ✅
- `npm run typecheck` (dashboard) ✅
- `npx tsc --noEmit` (app) ✅

Part of audit P2-3 (slice 5).