### PR TITLE
refactor(store-core): extract checkpoint handlers into handlers/checkpoint.ts (audit P2-3)

### DIFF
--- a/packages/store-core/src/handlers/checkpoint.ts
+++ b/packages/store-core/src/handlers/checkpoint.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared stateless handlers for checkpoint messages (checkpoint_created /
+ * checkpoint_list / checkpoint_restored).
+ *
+ * Extracted from the handlers barrel (audit P2-3) — pure move, no logic
+ * change. Re-exported from ./index so the public surface is unchanged. See
+ * ./index.ts for the stateless-handler contract.
+ */
+
+import type { Checkpoint } from '../types'
+import { resolveSessionId } from './_shared'
+
+// ---------------------------------------------------------------------------
+// checkpoint_created
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a newly created checkpoint to the active-session checkpoint list.
+ *
+ * Both clients gate on `msg.sessionId === activeSessionId` (with the usual
+ * "fall back to active when sessionId is absent" rule) and ignore malformed
+ * payloads. This handler encodes that gate: returns the new list when the
+ * append should happen, or null when the message should be ignored.
+ *
+ * Per-element shape is NOT validated — the cast to `Checkpoint` matches the
+ * inline behaviour in both clients prior to this migration. Tightening would
+ * be a behaviour change beyond the scope of #2661.
+ */
+export function handleCheckpointCreated(
+  msg: Record<string, unknown>,
+  currentCheckpoints: Checkpoint[],
+  activeSessionId: string | null,
+): Checkpoint[] | null {
+  const targetId = resolveSessionId(msg, activeSessionId)
+  if (!targetId || targetId !== activeSessionId) return null
+  const cp = msg.checkpoint
+  if (!cp || typeof cp !== 'object') return null
+  return [...currentCheckpoints, cp as Checkpoint]
+}
+
+// ---------------------------------------------------------------------------
+// checkpoint_list
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace the active-session checkpoint list with the server-provided array.
+ *
+ * Same active-session gate as `handleCheckpointCreated`. Returns the new array
+ * (which may be empty) when the replace should happen, or null when the
+ * message should be ignored (different session, missing/non-array payload,
+ * or no active session to fall back to).
+ */
+export function handleCheckpointList(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): Checkpoint[] | null {
+  const targetId = resolveSessionId(msg, activeSessionId)
+  if (!targetId || targetId !== activeSessionId) return null
+  if (!Array.isArray(msg.checkpoints)) return null
+  return msg.checkpoints as Checkpoint[]
+}
+
+// ---------------------------------------------------------------------------
+// checkpoint_restored
+// ---------------------------------------------------------------------------
+
+/** Parsed payload from a `checkpoint_restored` message. */
+export interface CheckpointRestoredPayload {
+  newSessionId: string
+}
+
+/**
+ * Extract and trim the new session ID from a `checkpoint_restored` message.
+ *
+ * App-only handler today (the dashboard's `checkpoint_restored` is a no-op);
+ * extracted here so dashboard can adopt the same handler later if/when it
+ * grows that surface. Returns null when the payload is missing, malformed,
+ * or empty after trimming — matching the inline guard `if (restoredNewSid.length > 0)`.
+ *
+ * Restore-flow side effects (e.g. `switchSession`) stay platform-specific and
+ * are gated by the caller on a non-null return.
+ */
+export function handleCheckpointRestored(
+  msg: Record<string, unknown>,
+): CheckpointRestoredPayload | null {
+  const raw = msg.newSessionId
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return { newSessionId: trimmed }
+}

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -13,7 +13,6 @@ import type {
   ActiveTool,
   AgentInfo,
   ChatMessage,
-  Checkpoint,
   ConnectedClient,
   ContextUsage,
   ConversationSummary,
@@ -767,84 +766,11 @@ export function handleServerMode(msg: Record<string, unknown>): { mode: ServerMo
 }
 
 // ---------------------------------------------------------------------------
-// checkpoint_created
+// Checkpoint handlers (checkpoint_created / checkpoint_list /
+// checkpoint_restored) live in ./checkpoint.ts (audit P2-3 split). Re-exported
+// here so the barrel's public surface is unchanged.
 // ---------------------------------------------------------------------------
-
-/**
- * Append a newly created checkpoint to the active-session checkpoint list.
- *
- * Both clients gate on `msg.sessionId === activeSessionId` (with the usual
- * "fall back to active when sessionId is absent" rule) and ignore malformed
- * payloads. This handler encodes that gate: returns the new list when the
- * append should happen, or null when the message should be ignored.
- *
- * Per-element shape is NOT validated — the cast to `Checkpoint` matches the
- * inline behaviour in both clients prior to this migration. Tightening would
- * be a behaviour change beyond the scope of #2661.
- */
-export function handleCheckpointCreated(
-  msg: Record<string, unknown>,
-  currentCheckpoints: Checkpoint[],
-  activeSessionId: string | null,
-): Checkpoint[] | null {
-  const targetId = resolveSessionId(msg, activeSessionId)
-  if (!targetId || targetId !== activeSessionId) return null
-  const cp = msg.checkpoint
-  if (!cp || typeof cp !== 'object') return null
-  return [...currentCheckpoints, cp as Checkpoint]
-}
-
-// ---------------------------------------------------------------------------
-// checkpoint_list
-// ---------------------------------------------------------------------------
-
-/**
- * Replace the active-session checkpoint list with the server-provided array.
- *
- * Same active-session gate as `handleCheckpointCreated`. Returns the new array
- * (which may be empty) when the replace should happen, or null when the
- * message should be ignored (different session, missing/non-array payload,
- * or no active session to fall back to).
- */
-export function handleCheckpointList(
-  msg: Record<string, unknown>,
-  activeSessionId: string | null,
-): Checkpoint[] | null {
-  const targetId = resolveSessionId(msg, activeSessionId)
-  if (!targetId || targetId !== activeSessionId) return null
-  if (!Array.isArray(msg.checkpoints)) return null
-  return msg.checkpoints as Checkpoint[]
-}
-
-// ---------------------------------------------------------------------------
-// checkpoint_restored
-// ---------------------------------------------------------------------------
-
-/** Parsed payload from a `checkpoint_restored` message. */
-export interface CheckpointRestoredPayload {
-  newSessionId: string
-}
-
-/**
- * Extract and trim the new session ID from a `checkpoint_restored` message.
- *
- * App-only handler today (the dashboard's `checkpoint_restored` is a no-op);
- * extracted here so dashboard can adopt the same handler later if/when it
- * grows that surface. Returns null when the payload is missing, malformed,
- * or empty after trimming — matching the inline guard `if (restoredNewSid.length > 0)`.
- *
- * Restore-flow side effects (e.g. `switchSession`) stay platform-specific and
- * are gated by the caller on a non-null return.
- */
-export function handleCheckpointRestored(
-  msg: Record<string, unknown>,
-): CheckpointRestoredPayload | null {
-  const raw = msg.newSessionId
-  if (typeof raw !== 'string') return null
-  const trimmed = raw.trim()
-  if (trimmed.length === 0) return null
-  return { newSessionId: trimmed }
-}
+export * from './checkpoint'
 
 // ---------------------------------------------------------------------------
 // error


### PR DESCRIPTION
## Summary

Seventh slice of **audit P2-3** — splitting `store-core/handlers/index.ts` by family. Follows #5892 git, #5893 file, #5894 environment, #5895 `_shared.ts`, #5896 budget, #5897 plan.

Moves the **checkpoint** family into a new `handlers/checkpoint.ts`:

- 3 handlers: `handleCheckpointCreated`, `handleCheckpointList`, `handleCheckpointRestored`
- the `CheckpointRestoredPayload` interface

## Dependencies

`checkpoint.ts` imports `Checkpoint` (`../types`) and `resolveSessionId` (`./_shared`). The `Checkpoint` type was used **only** by this family, so it is dropped from the barrel's `../types` import block (now unused there).

## Behavior preservation

- **Pure move, byte-identical**: `tail -n +13 checkpoint.ts` `diff`s clean against the lines removed from `index.ts`.
- Barrel re-exports via `export * from './checkpoint'`; public surface unchanged. No dangling references in `index.ts` (grep = 0).
- `handlers/index.ts`: 4942 → 4869 lines.

## Verification

- `npm run typecheck` (store-core) ✅
- `npx vitest run` (store-core): **1574 passed** ✅
- `npm run typecheck` (dashboard) ✅
- `npx tsc --noEmit` (app) ✅

Part of audit P2-3 (slice 7).