### PR TITLE
refactor(store-core): extract cost/usage handlers into handlers/usage.ts (audit P2-3)

### DIFF
--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2520,89 +2520,11 @@ export function handleMcpServers(
 }
 
 // ---------------------------------------------------------------------------
-// cost_update
-//
-// Session-scoped scalar patch: writes `sessionCost` (number | null) into the
-// target session's state. Both clients also handle `totalCost` and `budget`
-// fields on this message, but those are global — not session-scoped — so they
-// are left to call sites and not part of this shared helper.
+// Cost/usage handlers (cost_update / session_usage) live in ./usage.ts
+// (audit P2-3 split). Re-exported here so the barrel's public surface is
+// unchanged.
 // ---------------------------------------------------------------------------
-
-/**
- * Resolve target session and produce a session patch that sets `sessionCost`.
- *
- * Behaviour-preserving: passes a numeric `sessionCost` through verbatim
- * (including `0`); any non-number — missing, null, string, etc. — becomes
- * null. Matches `typeof msg.sessionCost === 'number' ? msg.sessionCost : null`.
- *
- * Session resolution matches the prior inline behaviour exactly:
- * `(msg.sessionId as string) || activeSessionId` (raw string passthrough; no
- * trim, no whitespace coercion). A whitespace-only `sessionId` is preserved
- * verbatim so the downstream `sessionStates[id]` lookup misses, rather than
- * silently falling back to the active session and applying cost updates to
- * the wrong session. Mirrors the pattern used by `handleHistoryReplayStart`.
- */
-export function handleCostUpdate(
-  msg: Record<string, unknown>,
-  activeSessionId: string | null,
-): SessionPatch {
-  const sessionCost =
-    typeof msg.sessionCost === 'number' ? msg.sessionCost : null
-  const rawSessionId =
-    typeof msg.sessionId === 'string' ? msg.sessionId : null
-  return {
-    sessionId: rawSessionId || activeSessionId,
-    patch: { sessionCost },
-  }
-}
-
-// ---------------------------------------------------------------------------
-// session_usage (#4072 / #4073)
-//
-// Broadcast by SessionManager._trackUsage after every result event. Carries
-// the per-session running totals (tokens + cost). The shape on the wire is:
-//   { sessionId, msg: { type: 'session_usage', cumulativeUsage: {...} } }
-// after the EventNormalizer pass — handlers receive the inner msg.
-//
-// Each numeric field is coerced via `Number.isFinite` so a corrupted payload
-// (NaN, Infinity, missing, non-number) yields 0 rather than poisoning the
-// store with a non-numeric value the renderer would format as `$NaN`.
-//
-// `sessionId` resolution mirrors handleCostUpdate: raw string passthrough or
-// activeSessionId fallback. A whitespace-only id is preserved verbatim so the
-// downstream lookup misses rather than silently mis-routing.
-// ---------------------------------------------------------------------------
-
-function toFiniteNumber(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : 0
-}
-
-/**
- * Normalize a `session_usage` message into a SessionPatch carrying a fresh
- * `cumulativeUsage` block. Always emits a complete block (no partial patch
- * shapes) so a missing field on the wire reads as `0` for that category
- * rather than leaving stale tokens lingering on the renderer.
- */
-export function handleSessionUsage(
-  msg: Record<string, unknown>,
-  activeSessionId: string | null,
-): SessionPatch {
-  const raw = (msg.cumulativeUsage as Record<string, unknown> | undefined) ?? {}
-  const cumulativeUsage: CumulativeUsage = {
-    inputTokens: toFiniteNumber(raw.inputTokens),
-    outputTokens: toFiniteNumber(raw.outputTokens),
-    cacheReadTokens: toFiniteNumber(raw.cacheReadTokens),
-    cacheCreationTokens: toFiniteNumber(raw.cacheCreationTokens),
-    costUsd: toFiniteNumber(raw.costUsd),
-    turnsBilled: toFiniteNumber(raw.turnsBilled),
-  }
-  const rawSessionId =
-    typeof msg.sessionId === 'string' ? msg.sessionId : null
-  return {
-    sessionId: rawSessionId || activeSessionId,
-    patch: { cumulativeUsage },
-  }
-}
+export * from './usage'
 
 // ---------------------------------------------------------------------------
 // server_error

--- a/packages/store-core/src/handlers/usage.ts
+++ b/packages/store-core/src/handlers/usage.ts
@@ -27,12 +27,14 @@ import type { SessionPatch } from './_shared'
  * (including `0`); any non-number — missing, null, string, etc. — becomes
  * null. Matches `typeof msg.sessionCost === 'number' ? msg.sessionCost : null`.
  *
- * Session resolution matches the prior inline behaviour exactly:
- * `(msg.sessionId as string) || activeSessionId` (raw string passthrough; no
- * trim, no whitespace coercion). A whitespace-only `sessionId` is preserved
- * verbatim so the downstream `sessionStates[id]` lookup misses, rather than
- * silently falling back to the active session and applying cost updates to
- * the wrong session. Mirrors the pattern used by `handleHistoryReplayStart`.
+ * Session resolution: `msg.sessionId` is taken when it is a string (raw
+ * passthrough — no trim, no whitespace coercion), otherwise null; the result
+ * then falls back to `activeSessionId` via `||`. So a non-string or
+ * empty-string `sessionId` routes to the active session, while a
+ * whitespace-only `sessionId` is preserved verbatim so the downstream
+ * `sessionStates[id]` lookup misses, rather than silently falling back to the
+ * active session and applying cost updates to the wrong session. Mirrors the
+ * pattern used by `handleHistoryReplayStart`.
  */
 export function handleCostUpdate(
   msg: Record<string, unknown>,

--- a/packages/store-core/src/handlers/usage.ts
+++ b/packages/store-core/src/handlers/usage.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared stateless handlers for cost/usage messages (cost_update /
+ * session_usage).
+ *
+ * Extracted from the handlers barrel (audit P2-3) — pure move, no logic
+ * change. Re-exported from ./index so the public surface is unchanged. These
+ * produce SessionPatch updates carrying cost/cumulative-usage state. See
+ * ./index.ts for the stateless-handler contract.
+ */
+
+import type { CumulativeUsage } from '../types'
+import type { SessionPatch } from './_shared'
+
+// ---------------------------------------------------------------------------
+// cost_update
+//
+// Session-scoped scalar patch: writes `sessionCost` (number | null) into the
+// target session's state. Both clients also handle `totalCost` and `budget`
+// fields on this message, but those are global — not session-scoped — so they
+// are left to call sites and not part of this shared helper.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve target session and produce a session patch that sets `sessionCost`.
+ *
+ * Behaviour-preserving: passes a numeric `sessionCost` through verbatim
+ * (including `0`); any non-number — missing, null, string, etc. — becomes
+ * null. Matches `typeof msg.sessionCost === 'number' ? msg.sessionCost : null`.
+ *
+ * Session resolution matches the prior inline behaviour exactly:
+ * `(msg.sessionId as string) || activeSessionId` (raw string passthrough; no
+ * trim, no whitespace coercion). A whitespace-only `sessionId` is preserved
+ * verbatim so the downstream `sessionStates[id]` lookup misses, rather than
+ * silently falling back to the active session and applying cost updates to
+ * the wrong session. Mirrors the pattern used by `handleHistoryReplayStart`.
+ */
+export function handleCostUpdate(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch {
+  const sessionCost =
+    typeof msg.sessionCost === 'number' ? msg.sessionCost : null
+  const rawSessionId =
+    typeof msg.sessionId === 'string' ? msg.sessionId : null
+  return {
+    sessionId: rawSessionId || activeSessionId,
+    patch: { sessionCost },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_usage (#4072 / #4073)
+//
+// Broadcast by SessionManager._trackUsage after every result event. Carries
+// the per-session running totals (tokens + cost). The shape on the wire is:
+//   { sessionId, msg: { type: 'session_usage', cumulativeUsage: {...} } }
+// after the EventNormalizer pass — handlers receive the inner msg.
+//
+// Each numeric field is coerced via `Number.isFinite` so a corrupted payload
+// (NaN, Infinity, missing, non-number) yields 0 rather than poisoning the
+// store with a non-numeric value the renderer would format as `$NaN`.
+//
+// `sessionId` resolution mirrors handleCostUpdate: raw string passthrough or
+// activeSessionId fallback. A whitespace-only id is preserved verbatim so the
+// downstream lookup misses rather than silently mis-routing.
+// ---------------------------------------------------------------------------
+
+function toFiniteNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+/**
+ * Normalize a `session_usage` message into a SessionPatch carrying a fresh
+ * `cumulativeUsage` block. Always emits a complete block (no partial patch
+ * shapes) so a missing field on the wire reads as `0` for that category
+ * rather than leaving stale tokens lingering on the renderer.
+ */
+export function handleSessionUsage(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch {
+  const raw = (msg.cumulativeUsage as Record<string, unknown> | undefined) ?? {}
+  const cumulativeUsage: CumulativeUsage = {
+    inputTokens: toFiniteNumber(raw.inputTokens),
+    outputTokens: toFiniteNumber(raw.outputTokens),
+    cacheReadTokens: toFiniteNumber(raw.cacheReadTokens),
+    cacheCreationTokens: toFiniteNumber(raw.cacheCreationTokens),
+    costUsd: toFiniteNumber(raw.costUsd),
+    turnsBilled: toFiniteNumber(raw.turnsBilled),
+  }
+  const rawSessionId =
+    typeof msg.sessionId === 'string' ? msg.sessionId : null
+  return {
+    sessionId: rawSessionId || activeSessionId,
+    patch: { cumulativeUsage },
+  }
+}


### PR DESCRIPTION
## Summary

Ninth slice of **audit P2-3** — splitting `store-core/handlers/index.ts` by family. Follows #5892, #5893, #5894, #5895, #5896, #5897, #5898, #5899.

Moves the contiguous **cost/usage** family into a new `handlers/usage.ts`:

- 2 handlers: `handleCostUpdate`, `handleSessionUsage` — both produce `SessionPatch` updates carrying cost/cumulative-usage state.

## Scope note

`handleResultUsage` and `handleSessionCostThresholdCrossed` are conceptually related but sit non-contiguously in the result/stream area of the file; they stay in `index.ts` for now (will move with the stream family or a later usage pass).

## Dependencies

`usage.ts` imports `CumulativeUsage` (`../types`) and `SessionPatch` (`./_shared`). Both remain used elsewhere in `index.ts` (no import cleanup).

## Behavior preservation

- **Pure move, byte-identical**: `usage.ts` from its `cost_update` section header onward `diff`s clean against the `origin/main` block (lines 2522–2605).
- Barrel re-exports via `export * from './usage'`; public surface unchanged. The only remaining `handleCostUpdate` mention in `index.ts` is a JSDoc cross-reference.
- `handlers/index.ts`: 4695 → 4616 lines.

## Verification

- `npm run typecheck` (store-core) ✅
- `npx vitest run` (store-core): **1574 passed** ✅
- `npm run typecheck` (dashboard) ✅
- `npx tsc --noEmit` (app) ✅

Part of audit P2-3 (slice 9).