### PR TITLE
refactor(store-core): extract dev-preview handlers into handlers/dev-preview.ts (audit P2-3)

### DIFF
--- a/packages/store-core/src/handlers/dev-preview.ts
+++ b/packages/store-core/src/handlers/dev-preview.ts
@@ -1,0 +1,83 @@
+/**
+ * Dev-preview handlers (audit P2-3 split).
+ *
+ * Parsers for `dev_preview` / `dev_preview_stopped`. Both return a
+ * `DevPreviewBuilder` (resolved sessionId + `applyTo(current)`) because the
+ * next devPreviews array depends on the existing one (dedup-by-port on add,
+ * filter on stop) — keeping a single sessionId-resolution path matching the
+ * plan handlers. State lookup + write stay at the call site.
+ *
+ * Re-exported from ./index (the barrel) so the public surface is unchanged.
+ */
+
+import type { DevPreview } from '../types'
+import { resolveSessionId } from './_shared'
+
+// ---------------------------------------------------------------------------
+// dev_preview / dev_preview_stopped
+//
+// These handlers are stateful in a way the others aren't: the new devPreviews
+// array depends on the existing array (dedup-by-port for `dev_preview`, filter
+// for `dev_preview_stopped`). To keep a single sessionId resolution path
+// (matching plan_started/plan_ready), the handlers return a builder shape:
+// `sessionId` resolved as usual, plus an `applyTo(current)` function the call
+// site invokes with the looked-up array. This avoids the double-resolution
+// pattern that would otherwise be needed if `currentPreviews` were a
+// pre-handler argument.
+// ---------------------------------------------------------------------------
+
+/** Builder result for handlers whose patch depends on existing state. */
+export interface DevPreviewBuilder {
+  /** Session ID the patch targets (may be null if no session context). */
+  sessionId: string | null
+  /** Apply the builder to the session's current devPreviews. */
+  applyTo: (current: DevPreview[]) => { devPreviews: DevPreview[] }
+}
+
+/**
+ * Resolve target session and produce a builder that appends (or replaces by
+ * port) a dev-preview entry. Both clients dedupe by port: a new preview for
+ * an already-tracked port replaces the existing entry, otherwise it is
+ * appended after the filtered remainder.
+ *
+ * Behaviour-preserving: `msg.port` and `msg.url` are forwarded verbatim with
+ * the same unsafe cast (`port as number, url as string`) the prior inline
+ * implementations used. Tightening to runtime validation would be a behaviour
+ * change and is out of scope for the #2661 mechanical migration.
+ */
+export function handleDevPreview(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): DevPreviewBuilder {
+  const preview: DevPreview = {
+    port: msg.port as number,
+    url: msg.url as string,
+  }
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    applyTo: (current) => ({
+      devPreviews: [...current.filter((p) => p.port !== preview.port), preview],
+    }),
+  }
+}
+
+/**
+ * Resolve target session and produce a builder that removes the dev-preview
+ * entry matching `msg.port`. If no entry matches the previews list is returned
+ * unchanged (matches both clients' prior `filter`-based inline implementation).
+ *
+ * Behaviour-preserving: `msg.port` is cast verbatim (`port as number`) without
+ * runtime validation, matching the prior inline behaviour.
+ */
+export function handleDevPreviewStopped(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): DevPreviewBuilder {
+  const stoppedPort = msg.port as number
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    applyTo: (current) => ({
+      devPreviews: current.filter((p) => p.port !== stoppedPort),
+    }),
+  }
+}

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -12,7 +12,6 @@
 import type {
   ActiveTool,
   ChatMessage,
-  DevPreview,
   ModelInfo,
   TranscriptBackgroundTask,
   ServerError,
@@ -373,73 +372,11 @@ export function applyInterventionBuilder(
 }
 
 // ---------------------------------------------------------------------------
-// dev_preview / dev_preview_stopped
-//
-// These handlers are stateful in a way the others aren't: the new devPreviews
-// array depends on the existing array (dedup-by-port for `dev_preview`, filter
-// for `dev_preview_stopped`). To keep a single sessionId resolution path
-// (matching plan_started/plan_ready), the handlers return a builder shape:
-// `sessionId` resolved as usual, plus an `applyTo(current)` function the call
-// site invokes with the looked-up array. This avoids the double-resolution
-// pattern that would otherwise be needed if `currentPreviews` were a
-// pre-handler argument.
+// Dev-preview handlers (dev_preview, dev_preview_stopped) live in
+// ./dev-preview.ts (audit P2-3 split). Re-exported here so the barrel's public
+// surface is unchanged.
 // ---------------------------------------------------------------------------
-
-/** Builder result for handlers whose patch depends on existing state. */
-export interface DevPreviewBuilder {
-  /** Session ID the patch targets (may be null if no session context). */
-  sessionId: string | null
-  /** Apply the builder to the session's current devPreviews. */
-  applyTo: (current: DevPreview[]) => { devPreviews: DevPreview[] }
-}
-
-/**
- * Resolve target session and produce a builder that appends (or replaces by
- * port) a dev-preview entry. Both clients dedupe by port: a new preview for
- * an already-tracked port replaces the existing entry, otherwise it is
- * appended after the filtered remainder.
- *
- * Behaviour-preserving: `msg.port` and `msg.url` are forwarded verbatim with
- * the same unsafe cast (`port as number, url as string`) the prior inline
- * implementations used. Tightening to runtime validation would be a behaviour
- * change and is out of scope for the #2661 mechanical migration.
- */
-export function handleDevPreview(
-  msg: Record<string, unknown>,
-  activeSessionId: string | null,
-): DevPreviewBuilder {
-  const preview: DevPreview = {
-    port: msg.port as number,
-    url: msg.url as string,
-  }
-  return {
-    sessionId: resolveSessionId(msg, activeSessionId),
-    applyTo: (current) => ({
-      devPreviews: [...current.filter((p) => p.port !== preview.port), preview],
-    }),
-  }
-}
-
-/**
- * Resolve target session and produce a builder that removes the dev-preview
- * entry matching `msg.port`. If no entry matches the previews list is returned
- * unchanged (matches both clients' prior `filter`-based inline implementation).
- *
- * Behaviour-preserving: `msg.port` is cast verbatim (`port as number`) without
- * runtime validation, matching the prior inline behaviour.
- */
-export function handleDevPreviewStopped(
-  msg: Record<string, unknown>,
-  activeSessionId: string | null,
-): DevPreviewBuilder {
-  const stoppedPort = msg.port as number
-  return {
-    sessionId: resolveSessionId(msg, activeSessionId),
-    applyTo: (current) => ({
-      devPreviews: current.filter((p) => p.port !== stoppedPort),
-    }),
-  }
-}
+export * from './dev-preview'
 
 // ---------------------------------------------------------------------------
 // auth_ok / auth_fail / key_exchange_ok / server_mode


### PR DESCRIPTION
## Summary

Audit **P2-3** continuation: split the `packages/store-core/src/handlers/index.ts` god-module family-by-family. This slice extracts the **dev-preview** family.

Moved into the new `handlers/dev-preview.ts`, behind `export * from './dev-preview'` so the public surface is unchanged:

- `handleDevPreview` + `DevPreviewBuilder`
- `handleDevPreviewStopped`

Self-contained family — dependencies are the `DevPreview` type and `resolveSessionId` (from `./_shared`). Both handlers return a builder (`sessionId` + `applyTo(current)`) because the next devPreviews array depends on the existing one (dedup-by-port on add, filter on stop).

### Cleanup

Dropped the now-unused `DevPreview` type import from `index.ts` — it was only referenced by the moved handlers.

## Verification

- **Pure move** — moved body diffed byte-identical against `origin/main`.
- store-core `npm run typecheck` ✅ + `npx vitest run` ✅ (1574 tests)
- dashboard `npm run typecheck` ✅ (strict `noUnusedLocals`)
- app `npx tsc --noEmit` ✅

`index.ts`: 1992 → 1931 lines.

Related to #5907 (prior slice). Part of audit P2-3.