### PR TITLE
refactor(store-core): extract permission-request handlers into handlers/permission.ts (audit P2-3)

### DIFF
--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -11,11 +11,9 @@
 
 import type {
   ActiveTool,
-  ChatMessage,
   ModelInfo,
   TranscriptBackgroundTask,
 } from '../types'
-import { nextMessageId } from '../utils'
 // Established Zod-handler pattern (#3138).
 import { ServerAvailableModelsEntrySchema, ServerNotificationPrefsSchema } from '@chroxy/protocol'
 
@@ -556,182 +554,13 @@ export * from './session-status'
 export * from './conversation'
 
 // ---------------------------------------------------------------------------
-// permission_request / permission_resolved / permission_expired /
-// permission_timeout / permission_rules_updated
+// Permission-request handlers (permission_request, permission_resolved,
+// permission_expired, permission_timeout, permission_rules_updated + the
+// PermissionRule type) live in ./permission.ts (audit P2-3 split). Re-exported
+// here so the barrel's public surface is unchanged. (The permission-mode
+// handlers stay below — handleClaudeReady consumes handleAvailablePermissionModes.)
 // ---------------------------------------------------------------------------
-
-/**
- * Permission rule shape advertised by the server in `permission_rules_updated`.
- *
- * The handler does NOT validate element shape — the cast matches the inline
- * `as PermissionRule[]` both clients used prior to the migration. Tightening
- * would be a behaviour change and is out of scope for #2661.
- */
-export interface PermissionRule {
-  tool: string
-  decision: 'allow' | 'deny'
-  pattern?: string
-}
-
-/**
- * Parsed payload from a `permission_request` message.
- *
- * App-only handler today (the dashboard parses inline against its own session
- * routing rules); extracted here so dashboard can adopt later. Returns the
- * verbatim wire fields with the same shallow validation the inline impls used.
- *
- * Per-field notes (behaviour-preserving):
- * - `requestId`: null when missing/non-string (caller skips the prompt).
- * - `tool` / `description`: null when missing/non-string. The app uses these
- *   to build the prompt content string `"${tool}: ${description}"` with a
- *   "Permission required" fallback at the call site.
- * - `input`: the raw message payload's `input` when it is a non-null
- *   non-array object; null otherwise (#3123). The declared
- *   `Record<string, unknown> | null` type now matches the runtime guard —
- *   arrays are rejected so the type is no longer a shallow lie.
- * - `sessionId`: explicit sessionId from the message (no active-session
- *   fallback here — pending-permission routing is platform-specific).
- * - `remainingMs`: numeric value forwarded verbatim, including 0; null for
- *   missing or non-number values. The call site converts to absolute
- *   `expiresAt = Date.now() + remainingMs` only when non-null.
- *
- * Side effects (split streaming response, "Allow for Session" provider gate,
- * push session notification) all stay at the call site — they touch
- * platform-specific state.
- */
-export interface PermissionRequestPayload {
-  requestId: string | null
-  tool: string | null
-  description: string | null
-  input: Record<string, unknown> | null
-  sessionId: string | null
-  remainingMs: number | null
-}
-
-export function handlePermissionRequest(
-  msg: Record<string, unknown>,
-): PermissionRequestPayload {
-  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
-  const tool = typeof msg.tool === 'string' ? msg.tool : null
-  const description = typeof msg.description === 'string' ? msg.description : null
-  const input =
-    msg.input && typeof msg.input === 'object' && !Array.isArray(msg.input)
-      ? (msg.input as Record<string, unknown>)
-      : null
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const remainingMs = typeof msg.remainingMs === 'number' ? msg.remainingMs : null
-  return { requestId, tool, description, input, sessionId, remainingMs }
-}
-
-/**
- * Parsed payload from a `permission_resolved` message.
- *
- * App-only handler today (dashboard parses inline). Returns the requestId and
- * decision string verbatim — the decision is NOT validated against an enum to
- * match the prior inline `msg.decision as string` cast. The call site searches
- * all session states for the matching prompt and applies its own UX side
- * effects (clearing pending state, dismissing notification banners).
- */
-export interface PermissionResolvedPayload {
-  requestId: string | null
-  decision: string | null
-}
-
-export function handlePermissionResolved(
-  msg: Record<string, unknown>,
-): PermissionResolvedPayload {
-  return {
-    requestId: typeof msg.requestId === 'string' ? msg.requestId : null,
-    decision: typeof msg.decision === 'string' ? msg.decision : null,
-  }
-}
-
-/**
- * Parse a `permission_expired` message into the requestId plus a system
- * ChatMessage (mirrors `handleBudgetExceeded`'s shape).
- *
- * The system message text is the same line both clients append to the
- * matching prompt today: `"(Expired — this permission was already handled or
- * timed out)"`. The handler does NOT decide whether to apply it — the call
- * site gates on `requestId` and on whether the prompt was already resolved
- * (the dashboard's "already handled" race-suppression path stays platform-
- * specific). Banner dismissal also stays at the call site.
- */
-export function handlePermissionExpired(msg: Record<string, unknown>): {
-  requestId: string | null
-  systemMessage: ChatMessage
-} {
-  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
-  return {
-    requestId,
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: '(Expired — this permission was already handled or timed out)',
-      timestamp: Date.now(),
-    },
-  }
-}
-
-/**
- * Parse a `permission_timeout` message (app-only today) into the requestId,
- * the tool name, and a system ChatMessage describing the auto-deny.
- *
- * `tool` defaults to `"permission"` when missing/non-string — matches the
- * inline `typeof msg.tool === 'string' ? msg.tool : 'permission'` guard. The
- * system message follows the inline pattern
- * `"Permission for \"${tool}\" was auto-denied (timed out)"`.
- *
- * The call site uses this to:
- *   - mark matching prompts in any session as auto-denied (UI-side),
- *   - dismiss matching notification banners,
- *   - push a `ServerError` toast with the same wording.
- */
-export function handlePermissionTimeout(msg: Record<string, unknown>): {
-  requestId: string | null
-  tool: string
-  systemMessage: ChatMessage
-} {
-  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
-  const tool = typeof msg.tool === 'string' ? msg.tool : 'permission'
-  return {
-    requestId,
-    tool,
-    systemMessage: {
-      id: nextMessageId('system'),
-      type: 'system',
-      content: `Permission for "${tool}" was auto-denied (timed out)`,
-      timestamp: Date.now(),
-    },
-  }
-}
-
-/**
- * Parsed payload from a `permission_rules_updated` message.
- *
- * `rules` is the array as-sent by the server when it is an array, else an
- * empty array. Per-element shape is NOT validated — matches the inline
- * `Array.isArray(msg.rules) ? (msg.rules as PermissionRule[]) : []` cast both
- * clients used. Tightening would be a behaviour change and is out of scope.
- *
- * `sessionId` is the message's explicit sessionId or null; the call site
- * applies its own active-session fallback (the app and dashboard both default
- * to `activeSessionId` when missing).
- */
-export interface PermissionRulesUpdatedPayload {
-  sessionId: string | null
-  rules: PermissionRule[]
-}
-
-export function handlePermissionRulesUpdated(
-  msg: Record<string, unknown>,
-): PermissionRulesUpdatedPayload {
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const rules: PermissionRule[] = Array.isArray(msg.rules)
-    ? (msg.rules as unknown as PermissionRule[])
-    : []
-  return { sessionId, rules }
-}
+export * from './permission'
 
 // ---------------------------------------------------------------------------
 // File-operation result handlers (directory_listing / file_listing /

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -1,0 +1,196 @@
+/**
+ * Permission-request handlers (audit P2-3 split).
+ *
+ * Parsers for the permission-prompt lifecycle: `permission_request`,
+ * `permission_resolved`, `permission_expired` (auto-handled system notice),
+ * `permission_timeout` (auto-deny system notice), and `permission_rules_updated`
+ * (the PermissionRule[] snapshot). All routing + UX side effects stay at the
+ * call site; these only normalise the wire payload.
+ *
+ * (The permission-MODE handlers — permission_mode_changed /
+ * available_permission_modes / confirm_permission_mode — remain in ./index for
+ * now because handleClaudeReady consumes handleAvailablePermissionModes.)
+ *
+ * Re-exported from ./index (the barrel) so the public surface is unchanged.
+ */
+
+import type { ChatMessage } from '../types'
+import { nextMessageId } from '../utils'
+
+// ---------------------------------------------------------------------------
+// permission_request / permission_resolved / permission_expired /
+// permission_timeout / permission_rules_updated
+// ---------------------------------------------------------------------------
+
+/**
+ * Permission rule shape advertised by the server in `permission_rules_updated`.
+ *
+ * The handler does NOT validate element shape — the cast matches the inline
+ * `as PermissionRule[]` both clients used prior to the migration. Tightening
+ * would be a behaviour change and is out of scope for #2661.
+ */
+export interface PermissionRule {
+  tool: string
+  decision: 'allow' | 'deny'
+  pattern?: string
+}
+
+/**
+ * Parsed payload from a `permission_request` message.
+ *
+ * App-only handler today (the dashboard parses inline against its own session
+ * routing rules); extracted here so dashboard can adopt later. Returns the
+ * verbatim wire fields with the same shallow validation the inline impls used.
+ *
+ * Per-field notes (behaviour-preserving):
+ * - `requestId`: null when missing/non-string (caller skips the prompt).
+ * - `tool` / `description`: null when missing/non-string. The app uses these
+ *   to build the prompt content string `"${tool}: ${description}"` with a
+ *   "Permission required" fallback at the call site.
+ * - `input`: the raw message payload's `input` when it is a non-null
+ *   non-array object; null otherwise (#3123). The declared
+ *   `Record<string, unknown> | null` type now matches the runtime guard —
+ *   arrays are rejected so the type is no longer a shallow lie.
+ * - `sessionId`: explicit sessionId from the message (no active-session
+ *   fallback here — pending-permission routing is platform-specific).
+ * - `remainingMs`: numeric value forwarded verbatim, including 0; null for
+ *   missing or non-number values. The call site converts to absolute
+ *   `expiresAt = Date.now() + remainingMs` only when non-null.
+ *
+ * Side effects (split streaming response, "Allow for Session" provider gate,
+ * push session notification) all stay at the call site — they touch
+ * platform-specific state.
+ */
+export interface PermissionRequestPayload {
+  requestId: string | null
+  tool: string | null
+  description: string | null
+  input: Record<string, unknown> | null
+  sessionId: string | null
+  remainingMs: number | null
+}
+
+export function handlePermissionRequest(
+  msg: Record<string, unknown>,
+): PermissionRequestPayload {
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  const tool = typeof msg.tool === 'string' ? msg.tool : null
+  const description = typeof msg.description === 'string' ? msg.description : null
+  const input =
+    msg.input && typeof msg.input === 'object' && !Array.isArray(msg.input)
+      ? (msg.input as Record<string, unknown>)
+      : null
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const remainingMs = typeof msg.remainingMs === 'number' ? msg.remainingMs : null
+  return { requestId, tool, description, input, sessionId, remainingMs }
+}
+
+/**
+ * Parsed payload from a `permission_resolved` message.
+ *
+ * App-only handler today (dashboard parses inline). Returns the requestId and
+ * decision string verbatim — the decision is NOT validated against an enum to
+ * match the prior inline `msg.decision as string` cast. The call site searches
+ * all session states for the matching prompt and applies its own UX side
+ * effects (clearing pending state, dismissing notification banners).
+ */
+export interface PermissionResolvedPayload {
+  requestId: string | null
+  decision: string | null
+}
+
+export function handlePermissionResolved(
+  msg: Record<string, unknown>,
+): PermissionResolvedPayload {
+  return {
+    requestId: typeof msg.requestId === 'string' ? msg.requestId : null,
+    decision: typeof msg.decision === 'string' ? msg.decision : null,
+  }
+}
+
+/**
+ * Parse a `permission_expired` message into the requestId plus a system
+ * ChatMessage (mirrors `handleBudgetExceeded`'s shape).
+ *
+ * The system message text is the same line both clients append to the
+ * matching prompt today: `"(Expired — this permission was already handled or
+ * timed out)"`. The handler does NOT decide whether to apply it — the call
+ * site gates on `requestId` and on whether the prompt was already resolved
+ * (the dashboard's "already handled" race-suppression path stays platform-
+ * specific). Banner dismissal also stays at the call site.
+ */
+export function handlePermissionExpired(msg: Record<string, unknown>): {
+  requestId: string | null
+  systemMessage: ChatMessage
+} {
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  return {
+    requestId,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: '(Expired — this permission was already handled or timed out)',
+      timestamp: Date.now(),
+    },
+  }
+}
+
+/**
+ * Parse a `permission_timeout` message (app-only today) into the requestId,
+ * the tool name, and a system ChatMessage describing the auto-deny.
+ *
+ * `tool` defaults to `"permission"` when missing/non-string — matches the
+ * inline `typeof msg.tool === 'string' ? msg.tool : 'permission'` guard. The
+ * system message follows the inline pattern
+ * `"Permission for \"${tool}\" was auto-denied (timed out)"`.
+ *
+ * The call site uses this to:
+ *   - mark matching prompts in any session as auto-denied (UI-side),
+ *   - dismiss matching notification banners,
+ *   - push a `ServerError` toast with the same wording.
+ */
+export function handlePermissionTimeout(msg: Record<string, unknown>): {
+  requestId: string | null
+  tool: string
+  systemMessage: ChatMessage
+} {
+  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  const tool = typeof msg.tool === 'string' ? msg.tool : 'permission'
+  return {
+    requestId,
+    tool,
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: `Permission for "${tool}" was auto-denied (timed out)`,
+      timestamp: Date.now(),
+    },
+  }
+}
+
+/**
+ * Parsed payload from a `permission_rules_updated` message.
+ *
+ * `rules` is the array as-sent by the server when it is an array, else an
+ * empty array. Per-element shape is NOT validated — matches the inline
+ * `Array.isArray(msg.rules) ? (msg.rules as PermissionRule[]) : []` cast both
+ * clients used. Tightening would be a behaviour change and is out of scope.
+ *
+ * `sessionId` is the message's explicit sessionId or null; the call site
+ * applies its own active-session fallback (the app and dashboard both default
+ * to `activeSessionId` when missing).
+ */
+export interface PermissionRulesUpdatedPayload {
+  sessionId: string | null
+  rules: PermissionRule[]
+}
+
+export function handlePermissionRulesUpdated(
+  msg: Record<string, unknown>,
+): PermissionRulesUpdatedPayload {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const rules: PermissionRule[] = Array.isArray(msg.rules)
+    ? (msg.rules as unknown as PermissionRule[])
+    : []
+  return { sessionId, rules }
+}


### PR DESCRIPTION
## Summary

Audit **P2-3** continuation: split the `packages/store-core/src/handlers/index.ts` god-module family-by-family. This slice extracts the **permission-request** family.

Moved into the new `handlers/permission.ts`, behind `export * from './permission'` so the public surface is unchanged:

- `handlePermissionRequest` + `PermissionRequestPayload`
- `handlePermissionResolved` + `PermissionResolvedPayload`
- `handlePermissionExpired` (auto-handled system notice)
- `handlePermissionTimeout` (auto-deny system notice)
- `handlePermissionRulesUpdated` + `PermissionRulesUpdatedPayload` + the `PermissionRule` type

### What stays behind (deliberately)

The permission-**mode** handlers (`permission_mode_changed` / `available_permission_modes` / `confirm_permission_mode`) remain in `index.ts` for now: `handleClaudeReady` consumes `handleAvailablePermissionModes` + the `PermissionMode` type, so they'll move in a later slice once `claude_ready` is addressed (avoids an import-back from a barrel-re-exported sibling). `shouldSkipForSessionMismatch` is **not** a permission helper — it belongs to the `slash_commands`/`agent_list` misc cluster and stays.

### Cleanup

Dropped the now-unused `ChatMessage` (`../types`) and `nextMessageId` (`../utils`) imports from `index.ts` — both were only used by the moved permission-expired/timeout auto-deny system messages.

## Verification

- **Pure move** — moved body diffed byte-identical against `origin/main`.
- store-core `npm run typecheck` ✅ + `npx vitest run` ✅ (1574 tests)
- dashboard `npm run typecheck` ✅ (strict `noUnusedLocals`)
- app `npx tsc --noEmit` ✅

`index.ts`: 1334 → 1163 lines.

Related to #5911 (prior slice). Part of audit P2-3.