### PR TITLE
refactor(store-core): move permission-mode handlers into handlers/permission.ts (audit P2-3)

### DIFF
--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -25,6 +25,11 @@ import {
   resolveSessionId,
 } from './_shared'
 import type { SessionPatch } from './_shared'
+// handleAuthOk folds the available-permission-modes list into its payload, so
+// it imports these back from ./permission (where the permission-mode handlers
+// now live — audit P2-3). No cycle: ./permission never imports ./index.
+import { handleAvailablePermissionModes } from './permission'
+import type { PermissionMode } from './permission'
 // ---------------------------------------------------------------------------
 // Shared helpers (parseStringField / parseRawStringField / parseEnumField /
 // resolveSessionId) and the SessionPatch type now live in ./_shared.ts
@@ -45,52 +50,12 @@ export function handleModelChanged(msg: Record<string, unknown>): { model: strin
 }
 
 // ---------------------------------------------------------------------------
-// permission_mode_changed
+// Permission-mode handlers (permission_mode_changed, available_permission_modes
+// — handleAvailablePermissionModes + PermissionMode, confirm_permission_mode)
+// live in ./permission.ts (audit P2-3 split), alongside the permission-request
+// handlers. Re-exported via the ./permission barrel line below. handleAuthOk
+// imports handleAvailablePermissionModes + PermissionMode back from there.
 // ---------------------------------------------------------------------------
-
-/** Extract the permission mode from a `permission_mode_changed` message. */
-export function handlePermissionModeChanged(msg: Record<string, unknown>): { mode: string | null } {
-  return { mode: parseStringField(msg, 'mode') }
-}
-
-// ---------------------------------------------------------------------------
-// available_permission_modes
-// ---------------------------------------------------------------------------
-
-export interface PermissionMode {
-  id: string
-  label: string
-  /**
-   * #4019: optional human-readable explainer for the mode (e.g. "Auto-approve
-   * every tool call without prompting"). The server's PERMISSION_MODES table
-   * exports a description for every mode; we keep the field optional here so
-   * older servers that pre-date the description plumbing still parse cleanly.
-   */
-  description?: string
-}
-
-/** Validate and extract permission modes from an `available_permission_modes` message. */
-export function handleAvailablePermissionModes(
-  msg: Record<string, unknown>,
-): PermissionMode[] | null {
-  if (!Array.isArray(msg.modes)) return null
-  return (msg.modes as unknown[])
-    .filter(
-      (m): m is { id: string; label: string; description?: unknown } =>
-        typeof m === 'object' &&
-        m !== null &&
-        typeof (m as { id: unknown }).id === 'string' &&
-        typeof (m as { label: unknown }).label === 'string',
-    )
-    .map((m) => {
-      const out: PermissionMode = { id: m.id, label: m.label }
-      // #4019: pass through description when present + string-typed. Non-
-      // strings (number, object, etc.) get dropped at the type boundary
-      // rather than poisoning the typed shape downstream consumers see.
-      if (typeof m.description === 'string') out.description = m.description
-      return out
-    })
-}
 
 // ---------------------------------------------------------------------------
 // Session-lifecycle handlers (session_updated, session_error, session_stopped,
@@ -100,30 +65,10 @@ export function handleAvailablePermissionModes(
 export * from './session-lifecycle'
 
 // ---------------------------------------------------------------------------
-// confirm_permission_mode
+// confirm_permission_mode (handleConfirmPermissionMode + PendingPermissionConfirm)
+// moved to ./permission.ts (audit P2-3 split). Re-exported via the ./permission
+// barrel line below.
 // ---------------------------------------------------------------------------
-
-export interface PendingPermissionConfirm {
-  mode: string
-  warning: string
-}
-
-/**
- * Extract the mode + warning text from a `confirm_permission_mode` message.
- *
- * Returns the pending-confirmation payload when the server included a valid
- * `mode` string, or null when the message is malformed (caller should leave
- * existing pending state alone in that case — matches both clients' prior
- * inline behavior).
- */
-export function handleConfirmPermissionMode(
-  msg: Record<string, unknown>,
-): PendingPermissionConfirm | null {
-  const mode = typeof msg.mode === 'string' ? msg.mode : null
-  if (!mode) return null
-  const warning = typeof msg.warning === 'string' ? msg.warning : 'Are you sure?'
-  return { mode, warning }
-}
 
 // ---------------------------------------------------------------------------
 // claude_ready

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -499,11 +499,12 @@ export * from './session-status'
 export * from './conversation'
 
 // ---------------------------------------------------------------------------
-// Permission-request handlers (permission_request, permission_resolved,
-// permission_expired, permission_timeout, permission_rules_updated + the
-// PermissionRule type) live in ./permission.ts (audit P2-3 split). Re-exported
-// here so the barrel's public surface is unchanged. (The permission-mode
-// handlers stay below — handleClaudeReady consumes handleAvailablePermissionModes.)
+// Permission handlers — request lifecycle (permission_request / _resolved /
+// _expired / _timeout / _rules_updated + the PermissionRule type) AND the
+// permission-mode controls (permission_mode_changed / available_permission_modes
+// / confirm_permission_mode) — live in ./permission.ts (audit P2-3 split).
+// Re-exported here so the barrel's public surface is unchanged. handleAuthOk
+// imports handleAvailablePermissionModes + PermissionMode back from there.
 // ---------------------------------------------------------------------------
 export * from './permission'
 

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -1,21 +1,25 @@
 /**
- * Permission-request handlers (audit P2-3 split).
+ * Permission handlers (audit P2-3 split).
  *
- * Parsers for the permission-prompt lifecycle: `permission_request`,
- * `permission_resolved`, `permission_expired` (auto-handled system notice),
- * `permission_timeout` (auto-deny system notice), and `permission_rules_updated`
- * (the PermissionRule[] snapshot). All routing + UX side effects stay at the
- * call site; these only normalise the wire payload.
+ * Permission-request lifecycle: `permission_request`, `permission_resolved`,
+ * `permission_expired` (auto-handled system notice), `permission_timeout`
+ * (auto-deny system notice), and `permission_rules_updated` (the
+ * PermissionRule[] snapshot).
  *
- * (The permission-MODE handlers — permission_mode_changed /
- * available_permission_modes / confirm_permission_mode — remain in ./index for
- * now because handleClaudeReady consumes handleAvailablePermissionModes.)
+ * Permission-mode controls: `permission_mode_changed`,
+ * `available_permission_modes` (`handleAvailablePermissionModes` +
+ * `PermissionMode`), and `confirm_permission_mode`. `handleAvailablePermissionModes`
+ * + `PermissionMode` are also consumed by `handleAuthOk` in ./index, which
+ * imports them back from here (no cycle — this file never imports ./index).
  *
- * Re-exported from ./index (the barrel) so the public surface is unchanged.
+ * All routing + UX side effects stay at the call site; these only normalise the
+ * wire payload. Re-exported from ./index (the barrel) so the public surface is
+ * unchanged.
  */
 
 import type { ChatMessage } from '../types'
 import { nextMessageId } from '../utils'
+import { parseStringField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // permission_request / permission_resolved / permission_expired /
@@ -193,4 +197,78 @@ export function handlePermissionRulesUpdated(
     ? (msg.rules as unknown as PermissionRule[])
     : []
   return { sessionId, rules }
+}
+
+// ---------------------------------------------------------------------------
+// permission_mode_changed
+// ---------------------------------------------------------------------------
+
+/** Extract the permission mode from a `permission_mode_changed` message. */
+export function handlePermissionModeChanged(msg: Record<string, unknown>): { mode: string | null } {
+  return { mode: parseStringField(msg, 'mode') }
+}
+
+// ---------------------------------------------------------------------------
+// available_permission_modes
+// ---------------------------------------------------------------------------
+
+export interface PermissionMode {
+  id: string
+  label: string
+  /**
+   * #4019: optional human-readable explainer for the mode (e.g. "Auto-approve
+   * every tool call without prompting"). The server's PERMISSION_MODES table
+   * exports a description for every mode; we keep the field optional here so
+   * older servers that pre-date the description plumbing still parse cleanly.
+   */
+  description?: string
+}
+
+/** Validate and extract permission modes from an `available_permission_modes` message. */
+export function handleAvailablePermissionModes(
+  msg: Record<string, unknown>,
+): PermissionMode[] | null {
+  if (!Array.isArray(msg.modes)) return null
+  return (msg.modes as unknown[])
+    .filter(
+      (m): m is { id: string; label: string; description?: unknown } =>
+        typeof m === 'object' &&
+        m !== null &&
+        typeof (m as { id: unknown }).id === 'string' &&
+        typeof (m as { label: unknown }).label === 'string',
+    )
+    .map((m) => {
+      const out: PermissionMode = { id: m.id, label: m.label }
+      // #4019: pass through description when present + string-typed. Non-
+      // strings (number, object, etc.) get dropped at the type boundary
+      // rather than poisoning the typed shape downstream consumers see.
+      if (typeof m.description === 'string') out.description = m.description
+      return out
+    })
+}
+
+// ---------------------------------------------------------------------------
+// confirm_permission_mode
+// ---------------------------------------------------------------------------
+
+export interface PendingPermissionConfirm {
+  mode: string
+  warning: string
+}
+
+/**
+ * Extract the mode + warning text from a `confirm_permission_mode` message.
+ *
+ * Returns the pending-confirmation payload when the server included a valid
+ * `mode` string, or null when the message is malformed (caller should leave
+ * existing pending state alone in that case — matches both clients' prior
+ * inline behavior).
+ */
+export function handleConfirmPermissionMode(
+  msg: Record<string, unknown>,
+): PendingPermissionConfirm | null {
+  const mode = typeof msg.mode === 'string' ? msg.mode : null
+  if (!mode) return null
+  const warning = typeof msg.warning === 'string' ? msg.warning : 'Are you sure?'
+  return { mode, warning }
 }


### PR DESCRIPTION
## Summary

Audit **P2-3** continuation: split the `packages/store-core/src/handlers/index.ts` god-module family-by-family. This slice moves the **permission-mode** handlers into the existing `handlers/permission.ts` (joining the permission-request handlers from #5912), completing the permission family.

Moved (re-exported via the existing `export * from './permission'` barrel line, so the public surface is unchanged):

- `handlePermissionModeChanged`
- `handleAvailablePermissionModes` + the `PermissionMode` type
- `handleConfirmPermissionMode` + `PendingPermissionConfirm`

### The import-back (and why there's no cycle)

`handleAuthOk` (auth family, still in `index.ts`) folds the available-permission-modes list into its `AuthOkPayload` — it calls `handleAvailablePermissionModes` and its payload type references `PermissionMode`. So `index.ts` now **imports those two symbols back** from `./permission`:

```ts
import { handleAvailablePermissionModes } from './permission'
import type { PermissionMode } from './permission'
```

No cycle: `./permission` only imports from `../types`, `../utils`, and `./_shared` — it never imports `./index`. This is the documented "import it back" pattern for a handler consumed by a still-resident family.

This **unblocks the auth slice next**: `auth.ts` will import the same two symbols from `./permission` instead of needing them in `index.ts`.

`parseStringField` (used by `handlePermissionModeChanged`) was added to `permission.ts`'s `./_shared` import; it stays in `index.ts` too (still used by `handleModelChanged` / `handleThinkingLevelChanged` / `handleAvailableModels`).

## Verification

- **Pure move** — both moved sub-ranges (the `permission_mode_changed`/`available_permission_modes` block and the `confirm_permission_mode` block, split by the prior session-lifecycle re-export) diffed byte-identical against `origin/main`.
- store-core `npm run typecheck` ✅ + `npx vitest run` ✅ (1574 tests) — confirms no import cycle.
- dashboard `npm run typecheck` ✅ (strict `noUnusedLocals`)
- app `npx tsc --noEmit` ✅

`index.ts`: 1163 → 1107 lines.

Related to #5912 (prior slice). Part of audit P2-3.