### PR TITLE
test(server): sandbox the api-token keychain in the test suite

### DIFF
--- a/docs/security/credentials-at-rest.md
+++ b/docs/security/credentials-at-rest.md
@@ -69,6 +69,8 @@ It does **not** derive a key from machine identifiers and "encrypt" with that. S
 
 **Caution — it disables keychain access entirely, including on read.** If the file is *already encrypted* and you set this flag, the read path can no longer reach the data key, so the store fails closed (`encrypted but its decryption key is unavailable`) and the credentials read as missing until you either unset the flag or re-enter them as plaintext. Only set it on a host whose `credentials.json` is still plaintext, or accept that you must re-enter the credentials.
 
+> **Sibling flag — the api-token keychain.** `CHROXY_CRED_DISABLE_KEYCHAIN` only covers the credential-store **data key**. The daemon's primary api-token is stored by a separate consumer (`keychain.js`, service `chroxy` / account `api-token`). `CHROXY_DISABLE_KEYCHAIN=1` is its equivalent off-switch: when set, `keychain.js` reports the keychain as unavailable, so the token falls back to the `0600` config file / `API_TOKEN` env exactly as on a host with no keychain. The server **test suite sets this by default** (`tests/_setup.mjs`) so tests never shell out to the real `security`/`secret-tool`.
+
 ## 6. Failure modes
 
 - **Lost / different-machine keychain.** If the file is encrypted but the `chroxy-cred-key` entry is missing (restored to a new machine, wiped keychain), the read **fails closed**: it returns no value and surfaces a clear status error (`encrypted but its decryption key is unavailable`), rather than silently treating the repo as having no credentials. The operator re-enters the credentials, which generates a fresh key.

--- a/packages/server/src/keychain.js
+++ b/packages/server/src/keychain.js
@@ -13,6 +13,27 @@ const DEFAULT_SERVICE = 'chroxy'
 const ACCOUNT = 'api-token'
 
 /**
+ * Global off-switch for OS keychain access.
+ *
+ * When `CHROXY_DISABLE_KEYCHAIN=1`, every entry point below behaves as if no
+ * keychain exists: `isKeychainAvailable()` is false, reads return
+ * null/`absent`, and writes/deletes no-op. Callers then transparently fall back
+ * to their file/env paths.
+ *
+ * Read LAZILY (per call, not at import) so tests can toggle it per-process:
+ * `tests/_setup.mjs` sets it for the whole suite to stop server tests from
+ * shelling out to the real `security`/`secret-tool` — which on a developer's
+ * box pollutes (or, with a broken login keychain, pops modal prompts for) the
+ * real keychain. This mirrors `CHROXY_CRED_DISABLE_KEYCHAIN` for the credential
+ * data-key store; here it covers the api-token keychain. Tests that genuinely
+ * drive the keychain code path clear the flag (real integration: keychain.test.js
+ * under `CHROXY_TEST_REAL_KEYCHAIN=1`; mocked child_process: keychain-mock.test.js).
+ */
+function keychainDisabled() {
+  return process.env.CHROXY_DISABLE_KEYCHAIN === '1'
+}
+
+/**
  * macOS `security` exit code for errSecItemNotFound — the item genuinely is not
  * in the keychain (a clean "absent"). Any OTHER non-zero exit (locked keychain,
  * interaction-not-allowed, keychain not found, auth denied, …) is a READ FAILURE
@@ -24,6 +45,7 @@ const MAC_ERR_SEC_ITEM_NOT_FOUND = 44
  * Check if OS keychain is available on this system.
  */
 export function isKeychainAvailable() {
+  if (keychainDisabled()) return false
   if (isMac) {
     try {
       execFileSync('security', ['help'], { stdio: 'pipe' })
@@ -49,6 +71,7 @@ export function isKeychainAvailable() {
  * @returns {string|null} Token or null if not found
  */
 export function getToken(service = DEFAULT_SERVICE) {
+  if (keychainDisabled()) return null
   if (isMac) {
     return _macGetToken(service)
   }
@@ -92,6 +115,7 @@ export function getToken(service = DEFAULT_SERVICE) {
  * @returns {KeychainReadResult}
  */
 export function getTokenStatus(service = DEFAULT_SERVICE) {
+  if (keychainDisabled()) return { status: 'absent', value: null, error: null }
   if (isMac) {
     return _macGetTokenStatus(service)
   }
@@ -107,6 +131,7 @@ export function getTokenStatus(service = DEFAULT_SERVICE) {
  * @param {string} [service] - Keychain service name (default: 'chroxy')
  */
 export function setToken(token, service = DEFAULT_SERVICE) {
+  if (keychainDisabled()) return
   if (isMac) {
     _macSetToken(service, token)
   } else if (isLinux) {
@@ -119,6 +144,7 @@ export function setToken(token, service = DEFAULT_SERVICE) {
  * @param {string} [service] - Keychain service name (default: 'chroxy')
  */
 export function deleteToken(service = DEFAULT_SERVICE) {
+  if (keychainDisabled()) return
   if (isMac) {
     _macDeleteToken(service)
   } else if (isLinux) {

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -228,6 +228,22 @@ if (fs.promises) {
 // `_setCredentialKeychainForTests(...)`, which takes precedence over this flag.
 process.env.CHROXY_CRED_DISABLE_KEYCHAIN = '1'
 
+// --- Default the api-token keychain (keychain.js) to "no keychain" ------------
+// Sibling of the credential-store flag above, for the OTHER keychain consumer:
+// `keychain.js` stores the daemon api-token under service 'chroxy' / account
+// 'api-token' by shelling out to the real `security`/`secret-tool`. That path is
+// NOT covered by CHROXY_CRED_DISABLE_KEYCHAIN. Without this flag, any test that
+// exercises keychain.js (or boots server-cli, which migrates the token on
+// startup) shells out to the REAL OS keychain — polluting it, and on a developer
+// box with a broken login keychain popping a modal "a keychain cannot be found
+// to store 'api-token'" prompt for EVERY access (the user had to Cancel a dozen+
+// on 2026-06-16). keychain.js reads this flag lazily, so the two tests that
+// genuinely drive its code path opt back in: keychain.test.js (real round-trip,
+// only under CHROXY_TEST_REAL_KEYCHAIN=1) and keychain-mock.test.js (mocked
+// child_process — never touches the real keychain). See
+// `server_suite_real_keychain_prompts.md`.
+process.env.CHROXY_DISABLE_KEYCHAIN = '1'
+
 // --- Scrub Discord webhook env -------------------------------------------------
 // #5413: PushManager always registers a DiscordWebhookSink that activates the
 // moment a webhook URL resolves. A developer with the webhook exported in

--- a/packages/server/tests/keychain-mock.test.js
+++ b/packages/server/tests/keychain-mock.test.js
@@ -19,6 +19,12 @@ if (typeof mock.module !== 'function') {
   })
 } else {
   // Mock child_process before importing keychain
+  // These tests drive keychain.js's real code path with a MOCKED child_process,
+  // so they never touch the OS keychain. Clear the suite-wide disable flag
+  // (`tests/_setup.mjs` sets CHROXY_DISABLE_KEYCHAIN=1) so isKeychainAvailable()
+  // / getToken() reach the mocked execFileSync instead of short-circuiting.
+  delete process.env.CHROXY_DISABLE_KEYCHAIN
+
   const cpMock = {
     execFileSync: mock.fn(() => '')
   }

--- a/packages/server/tests/keychain.test.js
+++ b/packages/server/tests/keychain.test.js
@@ -7,6 +7,18 @@ import { fileURLToPath } from 'url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const srcDir = join(__dirname, '../src')
 
+// `tests/_setup.mjs` sets CHROXY_DISABLE_KEYCHAIN=1 suite-wide so server tests
+// never shell out to the real OS keychain (modal-prompt spam on a broken login
+// keychain — see server_suite_real_keychain_prompts.md). The integration tests
+// below are the ONLY ones that exercise a real round-trip; gate them behind an
+// explicit opt-in so a deliberate `CHROXY_TEST_REAL_KEYCHAIN=1` run (e.g. a
+// known-good CI host) still gets real coverage, while the default run cleanly
+// skips them (isKeychainAvailable() → false). The plain export/null/source
+// assertions pass either way.
+if (process.env.CHROXY_TEST_REAL_KEYCHAIN === '1') {
+  delete process.env.CHROXY_DISABLE_KEYCHAIN
+}
+
 // Top-level await import to avoid timing issues with before() hooks
 const keychain = await import(join(srcDir, 'keychain.js'))
 
@@ -266,5 +278,38 @@ describe('Keychain failure paths (#1887)', () => {
       source.includes('config.apiToken'),
       'init-cmd.js should fall back to storing token in config'
     )
+  })
+})
+
+describe('CHROXY_DISABLE_KEYCHAIN off-switch', () => {
+  // The default test run has the flag set (tests/_setup.mjs); under
+  // CHROXY_TEST_REAL_KEYCHAIN=1 the top-of-file opt-in clears it. Assert the
+  // contract directly against the env so this holds in both modes.
+  const disabled = process.env.CHROXY_DISABLE_KEYCHAIN === '1'
+
+  it('reflects the disable flag in isKeychainAvailable()', () => {
+    if (disabled) {
+      assert.equal(keychain.isKeychainAvailable(), false, 'disabled → no keychain, regardless of binary presence')
+    } else {
+      // real-keychain opt-in: availability is environment-dependent (binary
+      // present or not) — just assert it stays a boolean and never throws.
+      assert.equal(typeof keychain.isKeychainAvailable(), 'boolean')
+    }
+  })
+
+  it('read/write/delete are inert no-ops when disabled (no real keychain access)', () => {
+    if (!disabled) return // only meaningful with the flag on
+    const svc = 'chroxy-test-disabled-noop'
+    assert.equal(keychain.getToken(svc), null)
+    assert.deepEqual(keychain.getTokenStatus(svc), { status: 'absent', value: null, error: null })
+    // These must NOT throw and must NOT shell out to `security`/`secret-tool`.
+    assert.doesNotThrow(() => keychain.setToken('should-be-ignored', svc))
+    assert.doesNotThrow(() => keychain.deleteToken(svc))
+    // A write that was a real no-op leaves the read still absent.
+    assert.equal(keychain.getToken(svc), null)
+    // migrateToken short-circuits on isKeychainAvailable() → no migration.
+    const res = keychain.migrateToken({ apiToken: 'x' }, svc)
+    assert.equal(res.migrated, false)
+    assert.equal(res.config.apiToken, 'x')
   })
 })


### PR DESCRIPTION
## Problem

Running the `packages/server` test suite shells out to the **real** macOS/Linux OS keychain. `keychain.js` (service `chroxy` / account `api-token`) calls `security`/`secret-tool` directly from any test that exercises it — or that boots `server-cli` (which migrates the token on startup). On a developer box with a *broken* login keychain this pops a modal **"a keychain cannot be found to store 'api-token'"** prompt for every access (the user had to Cancel a dozen+ on 2026-06-16).

The existing `CHROXY_CRED_DISABLE_KEYCHAIN` flag (#5154) only sandboxes the credential-store **data key** — not this separate api-token consumer.

## Fix

A sibling off-switch for the api-token keychain, mirroring the credential-store one:

- **`keychain.js`** — lazily-read `CHROXY_DISABLE_KEYCHAIN`. When set: `isKeychainAvailable()` → false, reads → `null`/`absent`, writes/deletes → no-op (`migrateToken` already gates on availability). Read per-call so tests can toggle per-process. Also usable in production to force the file fallback.
- **`tests/_setup.mjs`** — set `CHROXY_DISABLE_KEYCHAIN=1` suite-wide (next to the existing credential flag). No test touches the real keychain by default.
- **`keychain-mock.test.js`** — clears the flag; it drives the real code path through a **mocked** `child_process`, never the OS keychain.
- **`keychain.test.js`** — the only real round-trip integration tests; gated behind an explicit `CHROXY_TEST_REAL_KEYCHAIN=1` opt-in (default run skips them cleanly via `isKeychainAvailable()` → false). Adds tests pinning the disable contract.

Higher-level callers (`cli-init-cmd`, `server-identity`) already inject keychain fakes; `service.test.js` only asserts generated-wrapper strings — so no other test is affected.

## Verification

`node --import ./tests/_setup.mjs --test --test-force-exit --experimental-test-module-mocks tests/keychain.test.js tests/keychain-mock.test.js` → 26 tests, 21 pass, 0 fail, 5 skipped (the real round-trips skip in disabled mode). The `CHROXY_TEST_REAL_KEYCHAIN=1` path is intentionally not run on the developer box (that's what re-triggers the prompt).

Follow-up to the hazard recorded in `server_suite_real_keychain_prompts.md`.