### PR TITLE
fix(server): track and clear the standby EADDRINUSE retry timer

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -62,6 +62,7 @@ export class Supervisor extends EventEmitter {
     this._restartCount = 0
     this._standbyServer = null
     this._standbyRetries = 0
+    this._standbyRetryTimer = null
     this._shuttingDown = false
     this._draining = false
     this._childReady = false
@@ -596,7 +597,8 @@ export class Supervisor extends EventEmitter {
     this._standbyServer.on('error', (err) => {
       if (err.code === 'EADDRINUSE') {
         this._standbyRetries++
-        setTimeout(() => {
+        this._standbyRetryTimer = setTimeout(() => {
+          this._standbyRetryTimer = null
           if (this._standbyServer) {
             this._standbyServer.close()
             this._standbyServer = null
@@ -615,6 +617,10 @@ export class Supervisor extends EventEmitter {
   }
 
   _stopStandbyServer() {
+    if (this._standbyRetryTimer) {
+      clearTimeout(this._standbyRetryTimer)
+      this._standbyRetryTimer = null
+    }
     if (this._standbyServer) {
       this._standbyServer.close()
       this._standbyServer = null

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -763,13 +763,14 @@ describe('Supervisor', () => {
       const { supervisor } = setup()
 
       // Occupy a port so the standby server's listen() fails with EADDRINUSE,
-      // exercising the retry-scheduling branch of the error handler.
-      const port = await findFreePort()
+      // exercising the retry-scheduling branch of the error handler. Bind the
+      // blocker to port 0 and read the assigned port (no findFreePort TOCTOU gap).
       const blocker = createNetServer()
       await new Promise((resolve, reject) => {
         blocker.on('error', reject)
-        blocker.listen(port, resolve)
+        blocker.listen(0, resolve)
       })
+      const port = blocker.address().port
 
       try {
         supervisor._port = port

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -758,6 +758,49 @@ describe('Supervisor', () => {
       assert.equal(supervisor._standbyRetries, 0,
         'Retry counter should reset on successful listen')
     })
+
+    it('tracks the EADDRINUSE retry timer and clears it on stop (no leaked timer)', async () => {
+      const { supervisor } = setup()
+
+      // Occupy a port so the standby server's listen() fails with EADDRINUSE,
+      // exercising the retry-scheduling branch of the error handler.
+      const port = await findFreePort()
+      const blocker = createNetServer()
+      await new Promise((resolve, reject) => {
+        blocker.on('error', reject)
+        blocker.listen(port, resolve)
+      })
+
+      try {
+        supervisor._port = port
+
+        // Capture the standby server handle before its listen() errors.
+        supervisor._startStandbyServer()
+        const standby = supervisor._standbyServer
+        assert.ok(standby !== null, 'standby server object created')
+
+        // Wait for the EADDRINUSE error handler to run.
+        await new Promise((resolve) => standby.once('error', () => setImmediate(resolve)))
+
+        assert.equal(supervisor._standbyRetries, 1, 'retry counter incremented on EADDRINUSE')
+        assert.ok(supervisor._standbyRetryTimer !== null,
+          'pending retry must be tracked on the instance so it can be cancelled')
+
+        // Stopping must cancel the pending retry timer (and null it) so it cannot
+        // fire across a stop/shutdown boundary.
+        supervisor._stopStandbyServer()
+        assert.equal(supervisor._standbyRetryTimer, null, 'retry timer cleared on stop')
+        assert.equal(supervisor._standbyServer, null, 'standby server cleared on stop')
+
+        // Prove the cancelled retry does not resurrect the standby after its delay
+        // (STANDBY_EADDRINUSE_RETRY_DELAY_MS is 500ms; wait past it).
+        await new Promise((resolve) => setTimeout(resolve, 600))
+        assert.equal(supervisor._standbyServer, null,
+          'cancelled retry must not restart the standby')
+      } finally {
+        await new Promise((resolve) => blocker.close(resolve))
+      }
+    })
   })
 
   describe('deploy crash detection', () => {


### PR DESCRIPTION
## Summary

`_startStandbyServer()`'s EADDRINUSE error handler scheduled a retry with a bare `setTimeout(...)` that was never stored on the instance and never cleared, so `_stopStandbyServer()` and `shutdown()` could not cancel a pending retry. The closure is guarded by `if (this._standbyServer)` so today it fires as a harmless no-op after a stop — but it is a latent timer leak that keeps the event loop alive briefly and is fragile to refactors (PR #5851 made the stop-with-pending-retry ordering more frequently reachable).

## Changes

- Add `this._standbyRetryTimer = null` to the constructor.
- Store the retry `setTimeout` handle on `this._standbyRetryTimer`; null it when the timer fires.
- `clearTimeout` + null it in `_stopStandbyServer()`. `shutdown()` already calls `_stopStandbyServer()`, so both the stop and shutdown paths are covered through that single chokepoint (kept DRY rather than duplicating the clear).

## Test

New regression test in the `standby server` describe block: occupies the port with a real `net` server to force the standby's `listen()` to emit `EADDRINUSE`, asserts the retry is tracked on `_standbyRetryTimer`, then asserts `_stopStandbyServer()` cancels it and the standby is not resurrected after the retry delay elapses.

`supervisor.test.js`: 36/36 pass. All four server lint scripts pass.

Closes #5856