### PR TITLE
fix(server): guard sweepOrphanChroxyWorktrees with a 32-hex session-id pre-filter

### DIFF
--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -313,6 +313,11 @@ export function sweepOrphanChroxyWorktrees({ worktreeBase, liveSessionIds, deps 
   for (const ent of entries) {
     if (!ent || typeof ent.isDirectory !== 'function' || !ent.isDirectory()) continue
     const id = ent.name
+    // Defense-in-depth: chroxy session ids are 32 lowercase hex (matching the
+    // /^[a-f0-9]{32}$/ constraint in session-manager.js). A dir under the base
+    // whose name isn't that shape was never created by chroxy (e.g. a user-placed
+    // directory) — never a removal candidate, even if it somehow looked clean.
+    if (!/^[a-f0-9]{32}$/.test(id)) continue
     if (live.has(id)) continue // owned by a live session — never touch
     report.scanned++
     const wtPath = joinPath(worktreeBase, id)

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -568,13 +568,13 @@ describe('sweepOrphanChroxyWorktrees (real git repo)', () => {
 
   it('removes a clean orphan, keeps a live session, skips dirty + ignored-only', () => {
     const orphan = addChroxyWorktree('0000000000000000000000000000aaaa')
-    const live = addChroxyWorktree('0000000000000000000000000000live')
-    const dirty = addChroxyWorktree('0000000000000000000000000000dirt', { dirty: true })
-    const ignored = addChroxyWorktree('0000000000000000000000000000ign0', { ignoredOnly: true })
+    const live = addChroxyWorktree('0000000000000000000000000000bbbb')
+    const dirty = addChroxyWorktree('0000000000000000000000000000cccc', { dirty: true })
+    const ignored = addChroxyWorktree('0000000000000000000000000000dddd', { ignoredOnly: true })
 
     const report = sweepOrphanChroxyWorktrees({
       worktreeBase: base,
-      liveSessionIds: new Set(['0000000000000000000000000000live']),
+      liveSessionIds: new Set(['0000000000000000000000000000bbbb']),
     })
 
     assert.equal(report.removed.map((p) => basename(p)).includes('0000000000000000000000000000aaaa'), true, 'clean orphan removed')
@@ -590,8 +590,21 @@ describe('sweepOrphanChroxyWorktrees (real git repo)', () => {
     assert.deepEqual(report, { removed: [], skippedDirty: [], skippedError: [], scanned: 0 })
   })
 
+  it('never sweeps a dir whose name is not a 32-hex session id (user-placed dir)', () => {
+    // A clean worktree that WOULD be a removal candidate but for its non-hex name.
+    const userDir = addChroxyWorktree('not-a-chroxy-session-id')
+    addChroxyWorktree('0000000000000000000000000000aaaa')
+
+    const report = sweepOrphanChroxyWorktrees({ worktreeBase: base, liveSessionIds: new Set() })
+
+    assert.equal(existsSync(userDir), true, 'non-hex-named dir never touched')
+    assert.equal(report.removed.map((p) => basename(p)).includes('not-a-chroxy-session-id'), false, 'non-hex dir not removed')
+    assert.equal(report.scanned, 1, 'only the hex-named orphan was scanned (non-hex dir filtered before scan)')
+    assert.equal(report.removed.map((p) => basename(p)).includes('0000000000000000000000000000aaaa'), true, 'hex orphan still removed')
+  })
+
   it('skips a dir whose .git cannot be resolved to a repo (no removal)', () => {
-    const bogus = join(base, '0000000000000000000000000000bog0')
+    const bogus = join(base, '0000000000000000000000000000beef')
     mkdirSync(bogus, { recursive: true })
     writeFileSync(join(bogus, '.git'), 'gitdir: /nowhere/bogus\n') // status will fail → status-unknown
     const report = sweepOrphanChroxyWorktrees({ worktreeBase: base, liveSessionIds: new Set() })


### PR DESCRIPTION
## Summary

`sweepOrphanChroxyWorktrees` iterates every directory under the worktree base and considers it for `git worktree remove` if it isn't a live session. It is already well-protected (`isClean()` → null for non-git dirs, and the `.git`-file parser requires a valid `gitdir: <repo>/.git/worktrees/<id>` pointer), so a user-placed directory was not a realistic removal candidate. As cheap defense-in-depth — and to match `session-manager.js`, which constrains ids with `/^[a-f0-9]{32}$/` — this adds the same shape guard as a fast pre-filter.

## Changes

- `worktree-gc.js`: skip any `base` entry whose basename is not 32 lowercase hex, before the clean-check.
- Tests: rewrite the sweep fixtures to hex-only ids (the old `...live/dirt/ign0/bog0` suffixes contain non-hex chars the new guard would now filter), and add a test that a clean, non-hex-named dir under the base is **never** swept (`scanned` stays at the single hex orphan).

## Acceptance criteria
- [x] `sweepOrphanChroxyWorktrees` skips any dir whose basename is not 32 lowercase hex
- [x] Existing real-git sweep tests updated to hex-only session ids
- [x] A test asserts a non-hex-named dir under the base is never swept

`worktree-gc.test.js`: 37/37 pass; adjacent worktree suites green; server lints pass (the local `dashboard-next/dist` artifact match is a gitignored build output, not in CI).

Closes #5872