### PR TITLE
test(server): de-flake the EventNormalizer adaptive-flush pull-in subtest

### DIFF
--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1101,6 +1101,16 @@ describe('EventNormalizer adaptive flush window (#5516)', () => {
     const counts = { 'sess-multi': 3, 'sess-solo': 1 }
     const n = new EventNormalizer({ getSubscriberCount: (s) => counts[s] ?? 0 })
     withSetTimeoutSpy((delays) => {
+      // Pin the clock the normalizer reads so the pull-in is deterministic.
+      // bufferDelta computes `wantDeadline = performance.now() + intervalMs` on
+      // each call and only reschedules when the new deadline is SOONER than the
+      // armed one. The solo call (now+8) must beat the multi deadline (now0+16),
+      // which holds only while < 8ms of wall-clock elapsed between the two
+      // synchronous calls. Under a >8ms GC/scheduling stall on a loaded CI runner
+      // that window closes and the reschedule is (correctly) skipped — a real
+      // flake (#5923). Freeze performance.now so the two reads are equal (0ms
+      // elapsed), exercising the pull-in path the assertions below describe.
+      mock.method(performance, 'now', () => 1000)
       // Multi-client session arms the 16ms timer first.
       n.bufferDelta('sess-multi', 'm', 'a')
       assert.equal(delays[0], 16)


### PR DESCRIPTION
## Summary

Fixes a real flake in a **required** check (`Server Tests`) that surfaces under CI load: the subtest "a single-client buffer pulls in an already-armed default-window deadline" fails intermittently (observed on an unrelated PR whose only change raised CI load).

## Root cause

`bufferDelta` (`event-normalizer.js` ~L902-911) computes `wantDeadline = performance.now() + intervalMs` per call and only reschedules (pulls the deadline IN) when the new target is **sooner** than the armed one:

```js
const now = performance.now()
const wantDeadline = now + intervalMs                 // solo: now + 8
} else if (wantDeadline < this._deltaFlushDeadline) {  // multi armed now0 + 16
```

The test makes two **synchronous** `bufferDelta` calls and asserts `delays.length === 2`. The pull-in holds only while `t_solo - t_multi < 8ms`. A >8ms GC/scheduling stall between the two synchronous statements (plausible under `c8` coverage + parallel files + `--test-force-exit` on a loaded runner) closes that window, the reschedule is correctly skipped, and the assertion fails. Passes 114/114 locally and reliably on main.

## Fix

Freeze `performance.now` to a constant inside the subtest's existing mock block (restored by the block's `mock.restoreAll()`), so the two reads are 0ms apart and the pull-in path is exercised deterministically. **No production change.** The converse subtest ('does NOT push the deadline out') is already elapsed-time-robust (16 > 8 regardless), so only this one needs the clock pinned.

`event-normalizer.test.js`: 114/114 pass.

Closes #5923