### PR TITLE
lint(server): require ClaudeByokSession subclasses to declare claudeFamily explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,20 @@ jobs:
             exit 1
           fi
 
+      - name: Check ClaudeByokSession subclasses declare claudeFamily explicitly
+        run: |
+          # Issue #5891 — Claude-family membership (strict vs soft-fallback model
+          # id validation) is the single `static claudeFamily` flag. A new class
+          # that `extends ClaudeByokSession` and forgets `static claudeFamily =
+          # false` silently inherits `true` and is mis-classified. This lint
+          # requires every subclass to declare membership explicitly.
+          if scripts/lint-claude-family-explicit.sh; then
+            echo "OK — every ClaudeByokSession subclass declares static claudeFamily"
+          else
+            echo "::error::A class extending ClaudeByokSession is missing an explicit static claudeFamily. See packages/server/scripts/lint-claude-family-explicit.sh."
+            exit 1
+          fi
+
   dashboard-tests:
     name: Dashboard Tests
     runs-on: ubuntu-24.04

--- a/packages/server/scripts/lint-claude-family-explicit.mjs
+++ b/packages/server/scripts/lint-claude-family-explicit.mjs
@@ -29,7 +29,7 @@
  *   --dry-run          Print offenders without failing the exit code.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -80,6 +80,43 @@ function findMatchingBrace(src, openIdx) {
   return -1
 }
 
+// Blank out `//` line and `/* */` block comments, preserving every character
+// position and newline so downstream index/line math stays valid. Run the
+// subclass scan on the stripped text so a `class X extends ClaudeByokSession {`
+// written inside a comment is never matched as a real subclass (PR #5925
+// review). String literals are left intact — like the repo's other lints, we
+// don't strip strings (a class declaration inside a string is not a real case).
+function stripComments(src) {
+  let out = ''
+  let i = 0
+  const n = src.length
+  let inStr = null
+  while (i < n) {
+    const ch = src[i]
+    if (inStr) {
+      out += ch
+      if (ch === '\\' && i + 1 < n) { out += src[i + 1]; i += 2; continue }
+      if (ch === inStr) inStr = null
+      i++
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inStr = ch; out += ch; i++; continue }
+    if (ch === '/' && src[i + 1] === '/') {
+      while (i < n && src[i] !== '\n') { out += ' '; i++ }
+      continue
+    }
+    if (ch === '/' && src[i + 1] === '*') {
+      out += '  '; i += 2
+      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) { out += src[i] === '\n' ? '\n' : ' '; i++ }
+      if (i < n) { out += '  '; i += 2 }
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
+}
+
 function listJsFiles(dir) {
   const out = []
   for (const ent of readdirSync(dir, { withFileTypes: true })) {
@@ -114,8 +151,12 @@ function main() {
   const offenders = []
   let subclassCount = 0
   for (const file of files) {
-    const src = readFileSync(file, 'utf8')
-    if (!src.includes('ClaudeByokSession')) continue
+    const raw = readFileSync(file, 'utf8')
+    if (!raw.includes('ClaudeByokSession')) continue
+    // Scan comment-stripped text (indices preserved) so a subclass declaration
+    // inside a comment isn't matched. `static claudeFamily = …` is real code and
+    // survives stripping intact.
+    const src = stripComments(raw)
     SUBCLASS_RE.lastIndex = 0
     let m
     while ((m = SUBCLASS_RE.exec(src)) !== null) {

--- a/packages/server/scripts/lint-claude-family-explicit.mjs
+++ b/packages/server/scripts/lint-claude-family-explicit.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Lint: every class that `extends ClaudeByokSession` MUST declare its own
+ * `static claudeFamily = true|false`.
+ *
+ * Background (#5858 / #5890 / #5891): Claude-family membership — which decides
+ * whether a provider's model ids validate STRICTLY or soft-fall-back to a stale
+ * Claude default — is the single `static claudeFamily` flag (models.js reads
+ * `ProviderClass.claudeFamily`). `ClaudeByokSession` is the shared base for the
+ * agent-loop providers and sets `static claudeFamily = true`. The residual drift
+ * mode: a NEW non-Claude provider that `extends ClaudeByokSession` and forgets to
+ * override `static claudeFamily = false` silently INHERITS `true` and is
+ * mis-classified as Claude-family.
+ *
+ * This lint closes that gap at the source — mirroring the opt-forwarding lint
+ * discipline (#4797). It requires every subclass to state its membership
+ * explicitly (true or false), so inheritance is never the load-bearing answer.
+ * The test-authored truth (per-provider expectation) stays out of production; the
+ * production source keeps a literal-free single source of membership.
+ *
+ * Exit codes:
+ *   0 — every `extends ClaudeByokSession` subclass declares `static claudeFamily`
+ *   1 — at least one subclass omits it (printed with file:line + class name)
+ *   2 — parser failure
+ *
+ * Flags:
+ *   --src-dir <path>   Override the src directory (used by the test against a
+ *                      fixture tree). Defaults to `../src` relative to this file.
+ *   --dry-run          Print offenders without failing the exit code.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function parseFlags(argv) {
+  const flags = { srcDir: null, dryRun: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--src-dir') flags.srcDir = argv[++i]
+    else if (a === '--dry-run') flags.dryRun = true
+  }
+  return flags
+}
+
+const { srcDir: srcDirOverride, dryRun } = parseFlags(process.argv.slice(2))
+const SRC_DIR = resolve(srcDirOverride || join(__dirname, '..', 'src'))
+
+// Find the index of the `}` matching the `{` at openIdx, skipping strings,
+// template literals, and comments. Returns -1 if unbalanced.
+function findMatchingBrace(src, openIdx) {
+  let depth = 0
+  let i = openIdx
+  let inStr = null
+  while (i < src.length) {
+    const ch = src[i]
+    const prev = src[i - 1]
+    if (inStr) {
+      if (ch === inStr && prev !== '\\') inStr = null
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      inStr = ch
+    } else if (ch === '/' && src[i + 1] === '/') {
+      const nl = src.indexOf('\n', i)
+      i = nl === -1 ? src.length : nl
+      continue
+    } else if (ch === '/' && src[i + 1] === '*') {
+      const end = src.indexOf('*/', i + 2)
+      i = end === -1 ? src.length : end + 2
+      continue
+    } else if (ch === '{') {
+      depth++
+    } else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+    i++
+  }
+  return -1
+}
+
+function listJsFiles(dir) {
+  const out = []
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, ent.name)
+    if (ent.isDirectory()) {
+      if (ent.name === 'node_modules' || ent.name === 'dashboard-next') continue
+      out.push(...listJsFiles(p))
+    } else if (ent.isFile() && ent.name.endsWith('.js')) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+const lineOf = (src, idx) => src.slice(0, idx).split('\n').length
+
+// `class X extends ClaudeByokSession {` (named; covers the factory-created
+// AnthropicCompatibleSession too, regardless of the enclosing function).
+const SUBCLASS_RE = /\bclass\s+([A-Za-z0-9_$]+)\s+extends\s+ClaudeByokSession\s*\{/g
+// A direct `static claudeFamily = true|false` member.
+const DECLARES_RE = /\bstatic\s+claudeFamily\s*=\s*(?:true|false)\b/
+
+function main() {
+  let files
+  try {
+    files = listJsFiles(SRC_DIR)
+  } catch (err) {
+    console.error(`lint-claude-family-explicit: cannot read ${SRC_DIR}: ${err.message}`)
+    return 2
+  }
+
+  const offenders = []
+  let subclassCount = 0
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8')
+    if (!src.includes('ClaudeByokSession')) continue
+    SUBCLASS_RE.lastIndex = 0
+    let m
+    while ((m = SUBCLASS_RE.exec(src)) !== null) {
+      const name = m[1]
+      const braceIdx = src.indexOf('{', m.index + m[0].length - 1)
+      const end = findMatchingBrace(src, braceIdx)
+      if (end === -1) {
+        console.error(`lint-claude-family-explicit: unbalanced braces for class ${name} in ${file}`)
+        return 2
+      }
+      subclassCount++
+      const body = src.slice(braceIdx, end + 1)
+      if (!DECLARES_RE.test(body)) {
+        offenders.push({ file, line: lineOf(src, m.index), name })
+      }
+    }
+  }
+
+  if (offenders.length > 0) {
+    console.error('ERROR: class(es) extending ClaudeByokSession without an explicit `static claudeFamily`:')
+    console.error('')
+    for (const o of offenders) {
+      console.error(`  ${o.file}:${o.line}  class ${o.name}`)
+    }
+    console.error('')
+    console.error('Claude-family membership must be DECLARED, not inherited. Add')
+    console.error('`static claudeFamily = true` (a Claude/Anthropic-key provider) or')
+    console.error('`static claudeFamily = false` (a non-Claude provider whose model ids')
+    console.error('validate strictly) to each subclass body. See models.js + #5858/#5891.')
+    return dryRun ? 0 : 1
+  }
+
+  console.log(`OK: ${subclassCount} ClaudeByokSession subclass(es) declare static claudeFamily explicitly.`)
+  return 0
+}
+
+process.exit(main())

--- a/packages/server/scripts/lint-claude-family-explicit.sh
+++ b/packages/server/scripts/lint-claude-family-explicit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-claude-family-explicit.mjs`
+# for the actual implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-claude-family-explicit.sh` without worrying about the
+# Node interpreter path on the runner image.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-claude-family-explicit.mjs "$@"

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -338,6 +338,13 @@ export function normalizePostCreateCommand(value) {
 }
 
 export class DockerByokSession extends ClaudeByokSession {
+  // #5891: declare Claude-family membership explicitly rather than inheriting it
+  // from ClaudeByokSession. Docker-BYOK runs Claude/Anthropic-key models in a
+  // container, so its model ids validate strictly as Claude-family — same as the
+  // base. Made explicit so a future non-Claude subclass can't silently inherit
+  // `true` (enforced by scripts/lint-claude-family-explicit.sh).
+  static claudeFamily = true
+
   static get displayLabel() {
     return 'Claude (BYOK — Docker container)'
   }

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -340,9 +340,11 @@ export function normalizePostCreateCommand(value) {
 export class DockerByokSession extends ClaudeByokSession {
   // #5891: declare Claude-family membership explicitly rather than inheriting it
   // from ClaudeByokSession. Docker-BYOK runs Claude/Anthropic-key models in a
-  // container, so its model ids validate strictly as Claude-family — same as the
-  // base. Made explicit so a future non-Claude subclass can't silently inherit
-  // `true` (enforced by scripts/lint-claude-family-explicit.sh).
+  // container, so it IS Claude-family — its model ids take the soft-fallback path
+  // (an unknown id falls back to a Claude default) rather than the strict
+  // rejection non-Claude providers get; same as the base. Made explicit so a
+  // future non-Claude subclass can't silently inherit `true` (enforced by
+  // scripts/lint-claude-family-explicit.sh).
   static claudeFamily = true
 
   static get displayLabel() {

--- a/packages/server/tests/lint-claude-family-explicit.test.js
+++ b/packages/server/tests/lint-claude-family-explicit.test.js
@@ -27,7 +27,9 @@ const LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-claude-family-expl
 const REAL_SRC = resolve(__dirname, '..', 'src')
 
 function runLint(srcDir, extra = []) {
-  return spawnSync('node', [LINT_SCRIPT, '--src-dir', srcDir, ...extra], { encoding: 'utf8' })
+  // process.execPath (not a bare 'node' on PATH) — robust + consistent with the
+  // other lint tests in this repo.
+  return spawnSync(process.execPath, [LINT_SCRIPT, '--src-dir', srcDir, ...extra], { encoding: 'utf8' })
 }
 
 function withFixtureDir(files, fn) {
@@ -93,6 +95,24 @@ describe('lint-claude-family-explicit', () => {
       assert.equal(r.status, 0, r.stderr)
       // No `extends ClaudeByokSession` subclass present → 0 counted.
       assert.match(r.stdout, /0 ClaudeByokSession subclass/)
+    })
+  })
+
+  test('does not match a subclass declaration written inside a comment', () => {
+    const commented = `
+// Example from the docs: class DocExample extends ClaudeByokSession { ... }
+/* class BlockExample extends ClaudeByokSession {
+     static get x() { return 1 }
+   } */
+export class RealOne extends ClaudeByokSession {
+  static claudeFamily = false
+}
+`
+    withFixtureDir({ 'c.js': commented }, (dir) => {
+      const r = runLint(dir)
+      assert.equal(r.status, 0, r.stderr)
+      // Only RealOne is a real subclass; the commented ones are ignored.
+      assert.match(r.stdout, /1 ClaudeByokSession subclass/)
     })
   })
 

--- a/packages/server/tests/lint-claude-family-explicit.test.js
+++ b/packages/server/tests/lint-claude-family-explicit.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for scripts/lint-claude-family-explicit.mjs
+ *
+ * The lint guards the residual Claude-family drift mode (#5858/#5891): a new
+ * class that `extends ClaudeByokSession` and forgets `static claudeFamily =
+ * false` silently inherits `true` from the base and is mis-classified as
+ * Claude-family (soft-falling-back stale model ids instead of validating
+ * strictly).
+ *
+ * Strategy: run the lint as a child process against a temp directory of fixture
+ * files via `--src-dir`, asserting it flags an undeclared subclass and accepts
+ * explicitly-declared ones. A final case runs it against the REAL src to prove
+ * the tree is currently compliant.
+ *
+ * Issue: #5891 (follow-up from #5890/#5858).
+ */
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-claude-family-explicit.mjs')
+const REAL_SRC = resolve(__dirname, '..', 'src')
+
+function runLint(srcDir, extra = []) {
+  return spawnSync('node', [LINT_SCRIPT, '--src-dir', srcDir, ...extra], { encoding: 'utf8' })
+}
+
+function withFixtureDir(files, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-cf-lint-'))
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      writeFileSync(join(dir, name), contents)
+    }
+    return fn(dir)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const COMPLIANT_FALSE = `
+export class DeepSeekSession extends ClaudeByokSession {
+  static claudeFamily = false
+}
+`
+const COMPLIANT_TRUE = `
+export class DockerByokSession extends ClaudeByokSession {
+  static claudeFamily = true
+  static get displayLabel() { return 'x' }
+}
+`
+const OFFENDER = `
+export class ForgotToDeclareSession extends ClaudeByokSession {
+  static get displayLabel() { return 'oops' }
+}
+`
+
+describe('lint-claude-family-explicit', () => {
+  test('passes when every subclass declares static claudeFamily', () => {
+    withFixtureDir({ 'a.js': COMPLIANT_FALSE, 'b.js': COMPLIANT_TRUE }, (dir) => {
+      const r = runLint(dir)
+      assert.equal(r.status, 0, r.stderr)
+      assert.match(r.stdout, /2 ClaudeByokSession subclass\(es\) declare static claudeFamily/)
+    })
+  })
+
+  test('fails (exit 1) and names a subclass missing static claudeFamily', () => {
+    withFixtureDir({ 'a.js': COMPLIANT_TRUE, 'bad.js': OFFENDER }, (dir) => {
+      const r = runLint(dir)
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /ForgotToDeclareSession/)
+      assert.match(r.stderr, /without an explicit `static claudeFamily`/)
+    })
+  })
+
+  test('--dry-run reports the offender but exits 0', () => {
+    withFixtureDir({ 'bad.js': OFFENDER }, (dir) => {
+      const r = runLint(dir, ['--dry-run'])
+      assert.equal(r.status, 0)
+      assert.match(r.stderr, /ForgotToDeclareSession/)
+    })
+  })
+
+  test('does not flag the base ClaudeByokSession (it does not extend itself)', () => {
+    withFixtureDir({
+      'base.js': 'export class ClaudeByokSession extends JsonlSubprocessSession {\n  static claudeFamily = true\n}\n',
+    }, (dir) => {
+      const r = runLint(dir)
+      assert.equal(r.status, 0, r.stderr)
+      // No `extends ClaudeByokSession` subclass present → 0 counted.
+      assert.match(r.stdout, /0 ClaudeByokSession subclass/)
+    })
+  })
+
+  test('the real src tree is compliant', () => {
+    const r = runLint(REAL_SRC)
+    assert.equal(r.status, 0, r.stderr)
+  })
+})


### PR DESCRIPTION
## Summary

Closes the residual Claude-family drift mode flagged in #5858/#5890 review: a new class that `extends ClaudeByokSession` and forgets `static claudeFamily = false` silently inherits `true` from the base and is mis-classified as Claude-family — soft-falling-back stale model ids instead of validating strictly.

Implements **Option B** from the issue (CI lint), which matches the repo's lint-per-invariant culture and catches **any** new subclass at the source (a classification test only covers providers it imports).

## Changes

- **`scripts/lint-claude-family-explicit.{mjs,sh}`** (new): every `class … extends ClaudeByokSession` must declare its own `static claudeFamily = true|false`. Node implementation with a brace-matcher (string/comment-aware), `--src-dir` (testable) and `--dry-run` flags, mirroring `lint-session-opt-forwarding`.
- **CI**: wired into the `Server Lint` job.
- **`docker-byok-session.js`**: `DockerByokSession` was the one subclass relying on **inherited** `claudeFamily = true`. Declared it explicitly — it IS Claude-family (BYOK Claude models in a container), so the value is unchanged; the lint flagged exactly it before this commit.
- **Test**: `lint-claude-family-explicit.test.js` runs the lint against fixture trees (accepts declared true/false, fails + names an undeclared subclass, honors `--dry-run`, ignores the base class, asserts the real src tree is compliant).

## Verification
- Lint on real src: `OK: 4 ClaudeByokSession subclass(es) declare static claudeFamily explicitly.`
- `lint-claude-family-explicit.test.js`: 5/5 pass. `models.test.js`: 91/91 pass (no classification change).

Closes #5891