### PR TITLE
refactor(server): consolidate the chroxy-worktree .git parser into @chroxy/protocol

### DIFF
--- a/packages/protocol/dist/project.d.ts
+++ b/packages/protocol/dist/project.d.ts
@@ -33,6 +33,18 @@ export declare function _worktreeMarkerIndex(dir: string): number;
  */
 export declare function _pathWithinPrefix(prefix: string, dir: string): boolean;
 /**
+ * Recover the owning repo PATH of a chroxy session worktree from its `.git` FILE:
+ * `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the repo root
+ * is three segments up. Returns null on any read/shape surprise — a tampered
+ * `.git` file then can't point a caller (project attribution here, or the server's
+ * `git worktree remove` GC) at an arbitrary path.
+ *
+ * Single source of truth for the chroxy-worktree `.git` parser (#5850 / #5869):
+ * the server's worktree GC (`worktree-gc.js`) imports this instead of keeping its
+ * own copy; `chroxyWorktreeParentProject` derives the project name from it.
+ */
+export declare function chroxyWorktreeRepoPath(worktreeDir: string): string | null;
+/**
  * #5439 GAP B: a cwd inside a worktree checkout belongs to the PARENT project —
  * the segment before /.claude/worktrees/ — not the agent-* checkout. #5464
  * extends this to chroxy session worktrees (~/.chroxy/worktrees/<id>): their

--- a/packages/protocol/dist/project.js
+++ b/packages/protocol/dist/project.js
@@ -148,12 +148,17 @@ function chroxyWorktreeTopDir(dir, env = defaultEnv()) {
     return id.length > 0 ? join(root, id) : null;
 }
 /**
- * Recover the parent project for a chroxy session worktree from its `.git` FILE:
- * `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the repo
- * root (the parent project) is three segments up. Returns null on any read/shape
- * surprise — a tampered `.git` file then can't misattribute the project.
+ * Recover the owning repo PATH of a chroxy session worktree from its `.git` FILE:
+ * `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the repo root
+ * is three segments up. Returns null on any read/shape surprise — a tampered
+ * `.git` file then can't point a caller (project attribution here, or the server's
+ * `git worktree remove` GC) at an arbitrary path.
+ *
+ * Single source of truth for the chroxy-worktree `.git` parser (#5850 / #5869):
+ * the server's worktree GC (`worktree-gc.js`) imports this instead of keeping its
+ * own copy; `chroxyWorktreeParentProject` derives the project name from it.
  */
-function chroxyWorktreeParentProject(worktreeDir) {
+export function chroxyWorktreeRepoPath(worktreeDir) {
     let raw;
     try {
         raw = readFileSync(join(worktreeDir, '.git'), 'utf8');
@@ -179,10 +184,21 @@ function chroxyWorktreeParentProject(worktreeDir) {
     // Strict shape: the linked gitdir must be <repo>/.git/worktrees/<id> — the
     // only shape `git worktree add` writes for the daemon's checkouts. Anything
     // else is a shape surprise → null, so a tampered .git file can't misattribute
-    // the project; classification still suppresses.
+    // the project (or target an arbitrary removal path).
     if (basename(gitDir) !== '.git')
         return null;
-    const name = basename(dirname(gitDir));
+    const repo = dirname(gitDir);
+    return repo.length > 0 ? repo : null;
+}
+/**
+ * Parent project NAME for a chroxy session worktree: the basename of its owning
+ * repo path (see chroxyWorktreeRepoPath). Returns null on any read/shape surprise.
+ */
+function chroxyWorktreeParentProject(worktreeDir) {
+    const repo = chroxyWorktreeRepoPath(worktreeDir);
+    if (repo === null)
+        return null;
+    const name = basename(repo);
     return name.length > 0 ? name : null;
 }
 /**

--- a/packages/protocol/src/project.ts
+++ b/packages/protocol/src/project.ts
@@ -156,12 +156,17 @@ function chroxyWorktreeTopDir(dir: string, env: ProjectEnv = defaultEnv()): stri
 }
 
 /**
- * Recover the parent project for a chroxy session worktree from its `.git` FILE:
- * `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the repo
- * root (the parent project) is three segments up. Returns null on any read/shape
- * surprise — a tampered `.git` file then can't misattribute the project.
+ * Recover the owning repo PATH of a chroxy session worktree from its `.git` FILE:
+ * `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the repo root
+ * is three segments up. Returns null on any read/shape surprise — a tampered
+ * `.git` file then can't point a caller (project attribution here, or the server's
+ * `git worktree remove` GC) at an arbitrary path.
+ *
+ * Single source of truth for the chroxy-worktree `.git` parser (#5850 / #5869):
+ * the server's worktree GC (`worktree-gc.js`) imports this instead of keeping its
+ * own copy; `chroxyWorktreeParentProject` derives the project name from it.
  */
-function chroxyWorktreeParentProject(worktreeDir: string): string | null {
+export function chroxyWorktreeRepoPath(worktreeDir: string): string | null {
   let raw: string
   try {
     raw = readFileSync(join(worktreeDir, '.git'), 'utf8')
@@ -183,9 +188,20 @@ function chroxyWorktreeParentProject(worktreeDir: string): string | null {
   // Strict shape: the linked gitdir must be <repo>/.git/worktrees/<id> — the
   // only shape `git worktree add` writes for the daemon's checkouts. Anything
   // else is a shape surprise → null, so a tampered .git file can't misattribute
-  // the project; classification still suppresses.
+  // the project (or target an arbitrary removal path).
   if (basename(gitDir) !== '.git') return null
-  const name = basename(dirname(gitDir))
+  const repo = dirname(gitDir)
+  return repo.length > 0 ? repo : null
+}
+
+/**
+ * Parent project NAME for a chroxy session worktree: the basename of its owning
+ * repo path (see chroxyWorktreeRepoPath). Returns null on any read/shape surprise.
+ */
+function chroxyWorktreeParentProject(worktreeDir: string): string | null {
+  const repo = chroxyWorktreeRepoPath(worktreeDir)
+  if (repo === null) return null
+  const name = basename(repo)
   return name.length > 0 ? name : null
 }
 

--- a/packages/protocol/tests/project.test.js
+++ b/packages/protocol/tests/project.test.js
@@ -8,6 +8,7 @@ import {
   deriveProjectFromCwd,
   classifyNonProjectCwd,
   worktreeParent,
+  chroxyWorktreeRepoPath,
   _worktreeMarkerIndex,
   _pathWithinPrefix,
 } from '../src/project.ts'
@@ -41,6 +42,34 @@ function chroxyWorktreeFixture(repoName = 'coolproj') {
   writeFileSync(join(wt, '.git'), `gitdir: ${join(repoRoot, '.git', 'worktrees', id)}\n`)
   return { home, root, id, wt, repoName }
 }
+
+describe('chroxyWorktreeRepoPath (shared .git parser, #5869)', () => {
+  it('recovers the owning repo PATH from a worktree .git file', () => {
+    const { home, wt, repoName } = chroxyWorktreeFixture()
+    assert.equal(chroxyWorktreeRepoPath(wt), join(home, 'projects', repoName))
+  })
+
+  it('returns null when the .git file is absent', () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'norepo-')))
+    assert.equal(chroxyWorktreeRepoPath(dir), null)
+  })
+
+  it('returns null when the gitdir pointer is the wrong shape (tamper guard)', () => {
+    const home = realpathSync(mkdtempSync(join(tmpdir(), 'bad-')))
+    const wt = join(home, '.chroxy', 'worktrees', 'cafebabecafebabecafebabecafebabe')
+    mkdirSync(wt, { recursive: true })
+    // Not `<repo>/.git/worktrees/<id>` — points straight at an arbitrary dir.
+    writeFileSync(join(wt, '.git'), `gitdir: ${join(home, 'evil')}\n`)
+    assert.equal(chroxyWorktreeRepoPath(wt), null)
+  })
+
+  it('the parent-project name is the basename of the recovered repo path', () => {
+    const { wt, repoName } = chroxyWorktreeFixture()
+    // chroxyWorktreeParentProject (used by deriveProjectFromCwd) derives the
+    // project name as basename(chroxyWorktreeRepoPath(...)).
+    assert.equal(basename(chroxyWorktreeRepoPath(wt)), repoName)
+  })
+})
 
 describe('deriveProjectFromCwd (server surface)', () => {
   it('walks up to the nearest .git and returns its basename', () => {

--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -26,7 +26,8 @@
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { isAbsolute, join as joinPath, resolve as resolvePath, dirname, sep } from 'node:path'
+import { isAbsolute, join as joinPath, resolve as resolvePath } from 'node:path'
+import { chroxyWorktreeRepoPath } from '@chroxy/protocol/project'
 import { GIT } from './git.js'
 
 // #5706: absolute-age fallback for the PID-liveness check. A dead agent's pid
@@ -250,27 +251,6 @@ function isClean(git, worktreePath) {
   }
 }
 
-/**
- * Recover the owning repo path of a chroxy session worktree from its `.git`
- * FILE: `git worktree add` writes `gitdir: <repo>/.git/worktrees/<id>`, so the
- * repo root is three segments up. Returns null on any read/shape surprise.
- */
-function chroxyWorktreeRepoPath(worktreePath, readFile = readFileSync) {
-  let raw
-  try { raw = readFile(joinPath(worktreePath, '.git'), 'utf8') } catch { return null }
-  const match = /^gitdir:\s*(.+?)\s*$/m.exec(raw)
-  if (!match) return null
-  let linkedGitDir
-  try { linkedGitDir = resolvePath(worktreePath, match[1]) } catch { return null }
-  const worktreesDir = dirname(linkedGitDir) // <repo>/.git/worktrees
-  const gitDir = dirname(worktreesDir)       // <repo>/.git
-  // Strict shape: the gitdir must be `<repo>/.git/worktrees/<id>` (the only
-  // form `git worktree add` writes), so a tampered .git file can't point the
-  // removal at an arbitrary path.
-  if (!worktreesDir.endsWith(`${sep}worktrees`) || !gitDir.endsWith(`${sep}.git`)) return null
-  const repo = dirname(gitDir)
-  return repo.length > 0 ? repo : null
-}
 
 /**
  * #5859 (audit P1-7): boot-time sweep of ORPHANED chroxy session worktrees.
@@ -295,7 +275,7 @@ function chroxyWorktreeRepoPath(worktreePath, readFile = readFileSync) {
  * @param {object} args
  * @param {string} args.worktreeBase - e.g. ~/.chroxy/worktrees
  * @param {Set<string>} args.liveSessionIds - currently-live session ids (off-limits)
- * @param {object} [args.deps] - { git, readdir, exists, readFile }
+ * @param {object} [args.deps] - { git, readdir, exists }
  * @returns {{ removed: string[], skippedDirty: object[], skippedError: object[], scanned: number }}
  */
 export function sweepOrphanChroxyWorktrees({ worktreeBase, liveSessionIds, deps = {} } = {}) {
@@ -303,7 +283,6 @@ export function sweepOrphanChroxyWorktrees({ worktreeBase, liveSessionIds, deps 
     git = (cwd, args) => execFileSync(GIT, ['-C', cwd, ...args], { encoding: 'utf8' }),
     readdir = (p) => readdirSync(p, { withFileTypes: true }),
     exists = existsSync,
-    readFile = readFileSync,
   } = deps
   const report = { removed: [], skippedDirty: [], skippedError: [], scanned: 0 }
   if (!worktreeBase || !exists(worktreeBase)) return report
@@ -326,7 +305,7 @@ export function sweepOrphanChroxyWorktrees({ worktreeBase, liveSessionIds, deps 
       report.skippedDirty.push({ path: wtPath, reason: clean === null ? 'status-unknown' : 'dirty' })
       continue
     }
-    const repo = chroxyWorktreeRepoPath(wtPath, readFile)
+    const repo = chroxyWorktreeRepoPath(wtPath)
     if (!repo) { report.skippedError.push({ path: wtPath, error: 'repo-unrecoverable' }); continue }
     try {
       git(repo, ['worktree', 'remove', wtPath]) // NO --force; clean-checked above


### PR DESCRIPTION
## Summary

Removes the last duplicate of the chroxy session-worktree `.git`-file parser (`gitdir: <repo>/.git/worktrees/<id>`). PR #5866 added two near-identical server copies; the `event-ingest.js` and `claude-hooks` copies already moved to `@chroxy/protocol/project` (#5850), leaving only `worktree-gc.js`'s `chroxyWorktreeRepoPath`. This folds that one in too.

## Changes

- **`packages/protocol/src/project.ts`**: export `chroxyWorktreeRepoPath` (the repo-PATH core — what the daemon's worktree GC needs). The existing internal `chroxyWorktreeParentProject` now derives the project name as `basename(chroxyWorktreeRepoPath(...))`. Behavior unchanged.
- **`packages/server/src/worktree-gc.js`**: import `chroxyWorktreeRepoPath` from `@chroxy/protocol/project`; delete the local copy (and the now-unused `dirname`/`sep` imports + the unused `readFile` DI seam — the sweep tests read real `.git` files). The protocol parser's `basename(...) === 'worktrees'/'.git'` shape guard replaces the equivalent `endsWith` guard, ending the byte-divergence the #5866 review flagged.
- **Tests**: direct protocol tests for `chroxyWorktreeRepoPath` (valid path, missing `.git`, wrong-shape tamper guard, basename == project name). Rebuilt the committed protocol `dist/`.

## Verification
- protocol `project.test.js`: 28/28 · server `worktree-gc.test.js`: 37/37 · `event-ingest*.test.js`: 67/67 · eslint clean on the changed server file · protocol `tsc` build clean (dist regenerated).

Closes #5869