### PR TITLE
fix(server): re-home other clients on checkpoint restore (#5700)

### DIFF
--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -145,6 +145,10 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
       newSessionId,
       name: newEntry?.name || `Rewind: ${checkpoint.name}`,
     })
+    // The initiator's active session moved to the rewound session above; announce
+    // it to presence/Control-Room observers (the loop below does the same for the
+    // other re-homed clients).
+    broadcastFocusChanged(client, newSessionId, ctx)
     // #5700: re-home OTHER clients that were actively viewing the original
     // session onto the rewound session — mirroring the destroy path's
     // client-iteration (session-handlers.js). Without this the initiator
@@ -155,6 +159,12 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
     for (const [otherWs, c] of ctx.transport.clients) {
       if (c === client) continue // initiator already re-homed above
       if (!c.authenticated || c.activeSessionId !== sid) continue
+      // A pairing-bound client is cryptographically scoped to its bound session.
+      // Unlike the destroy path (where the session is gone, so re-homing is
+      // forced), restore leaves the original session intact — so a bound client
+      // must stay on it, never be auto-switched to the rewound session (mirrors
+      // the switch_session boundSessionId enforcement). #5700 review.
+      if (c.boundSessionId) continue
       ctx.transport.setActiveSession(c, newSessionId)
       ctx.transport.send(otherWs, {
         type: 'session_switched',

--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -4,7 +4,7 @@
  * Handles: create_checkpoint, list_checkpoints, restore_checkpoint, delete_checkpoint
  */
 import { realpathSync } from 'fs'
-import { sendSessionError } from '../handler-utils.js'
+import { sendSessionError, broadcastFocusChanged } from '../handler-utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ws')
@@ -145,6 +145,29 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
       newSessionId,
       name: newEntry?.name || `Rewind: ${checkpoint.name}`,
     })
+    // #5700: re-home OTHER clients that were actively viewing the original
+    // session onto the rewound session — mirroring the destroy path's
+    // client-iteration (session-handlers.js). Without this the initiator
+    // switches to the rewound session while every other subscriber keeps showing
+    // the original session's pre-rewind history (two clients, two histories, no
+    // reconciliation until a manual re-subscribe). The original session is NOT
+    // destroyed; its active viewers simply follow the rewind.
+    for (const [otherWs, c] of ctx.transport.clients) {
+      if (c === client) continue // initiator already re-homed above
+      if (!c.authenticated || c.activeSessionId !== sid) continue
+      ctx.transport.setActiveSession(c, newSessionId)
+      ctx.transport.send(otherWs, {
+        type: 'session_switched',
+        sessionId: newSessionId,
+        name: newEntry?.name || `Rewind: ${checkpoint.name}`,
+        cwd: newEntry?.cwd,
+        conversationId: newEntry?.session?.resumeSessionId || null,
+      })
+      ctx.transport.sendSessionInfo(otherWs, newSessionId)
+      // #5555.3 — forced re-home after a rewind: authoritative full rebuild.
+      ctx.transport.replayHistory(otherWs, newSessionId, { forceFull: true })
+      broadcastFocusChanged(c, newSessionId, ctx)
+    }
     ctx.transport.broadcastSessionList()
   } catch (err) {
     sendSessionError(ws, ctx, `Failed to restore checkpoint: ${err.message}`)

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -11,6 +11,8 @@ function makeCtx(sessions = new Map(), overrides = {}) {
     send: createSpy((ws, msg) => { sent.push(msg) }),
     broadcast: createSpy((msg) => { broadcasts.push(msg) }),
     broadcastSessionList: createSpy(),
+    sendSessionInfo: createSpy(),
+    replayHistory: createSpy(),
     sessionManager: {
       getSession: createSpy((id) => sessions.get(id)),
       createSession: createSpy(async () => 'restored-session-id'),
@@ -171,6 +173,66 @@ describe('checkpoint-handlers', () => {
       const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
       assert.ok(restored, 'checkpoint_restored not sent')
       assert.equal(restored.newSessionId, 'restored-session-id')
+    })
+
+    it('re-homes OTHER clients viewing the original session onto the rewound session (#5700)', async () => {
+      const sessions = new Map()
+      const orig = createMockSession()
+      orig.isRunning = false
+      sessions.set('s1', { session: orig, name: 'S', cwd: '/tmp' })
+      const rewound = createMockSession()
+      rewound.resumeSessionId = 'conv-1'
+      sessions.set('restored-session-id', { session: rewound, name: 'Rewind: Checkpoint 1', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+
+      // Two clients both actively viewing the original session: the initiator and
+      // an observer (e.g. app restores, dashboard was watching the same session).
+      const initiatorWs = makeWs()
+      const observerWs = makeWs()
+      const initiator = makeClient({ id: 'c1', authenticated: true, activeSessionId: 's1' })
+      const observer = makeClient({ id: 'c2', authenticated: true, activeSessionId: 's1' })
+      ctx.clientManager.addClient(initiatorWs, initiator)
+      ctx.clientManager.addClient(observerWs, observer)
+      ctx.clientManager.setActiveSession(initiator, 's1')
+      ctx.clientManager.setActiveSession(observer, 's1')
+
+      await checkpointHandlers.restore_checkpoint(initiatorWs, initiator, { checkpointId: 'cp-1' }, ctx)
+
+      // The observer must follow the rewind, not keep showing the pre-rewind history.
+      assert.equal(observer.activeSessionId, 'restored-session-id', 'observer re-homed to the rewound session')
+      const switchedToObserver = ctx.transport.send.calls.find(
+        ([w, m]) => w === observerWs && m && m.type === 'session_switched' && m.sessionId === 'restored-session-id',
+      )
+      assert.ok(switchedToObserver, 'observer must receive session_switched to the rewound session')
+      const replayedForObserver = ctx.transport.replayHistory.calls.find(
+        ([w, sid, opts]) => w === observerWs && sid === 'restored-session-id' && opts && opts.forceFull === true,
+      )
+      assert.ok(replayedForObserver, 'observer must get a forced full history replay of the rewound session')
+    })
+
+    it('does not re-home a client viewing a DIFFERENT session during restore (#5700)', async () => {
+      const sessions = new Map()
+      const orig = createMockSession()
+      orig.isRunning = false
+      sessions.set('s1', { session: orig, name: 'S', cwd: '/tmp' })
+      sessions.set('other-session', { session: createMockSession(), name: 'Other', cwd: '/tmp' })
+      sessions.set('restored-session-id', { session: createMockSession(), name: 'Rewind: Checkpoint 1', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+
+      const initiatorWs = makeWs()
+      const bystanderWs = makeWs()
+      const initiator = makeClient({ id: 'c1', authenticated: true, activeSessionId: 's1' })
+      const bystander = makeClient({ id: 'c2', authenticated: true, activeSessionId: 'other-session' })
+      ctx.clientManager.addClient(initiatorWs, initiator)
+      ctx.clientManager.addClient(bystanderWs, bystander)
+      ctx.clientManager.setActiveSession(initiator, 's1')
+      ctx.clientManager.setActiveSession(bystander, 'other-session')
+
+      await checkpointHandlers.restore_checkpoint(initiatorWs, initiator, { checkpointId: 'cp-1' }, ctx)
+
+      assert.equal(bystander.activeSessionId, 'other-session', 'a client on a different session is untouched')
     })
 
     // #5731 T8 (confirms deferred #5700) — restoring hard-resets the working

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -211,6 +211,31 @@ describe('checkpoint-handlers', () => {
       assert.ok(replayedForObserver, 'observer must get a forced full history replay of the rewound session')
     })
 
+    it('does NOT re-home a pairing-bound client even if it views the original session (#5700)', async () => {
+      const sessions = new Map()
+      const orig = createMockSession()
+      orig.isRunning = false
+      sessions.set('s1', { session: orig, name: 'S', cwd: '/tmp' })
+      sessions.set('restored-session-id', { session: createMockSession(), name: 'Rewind: Checkpoint 1', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+
+      const initiatorWs = makeWs()
+      const boundWs = makeWs()
+      const initiator = makeClient({ id: 'c1', authenticated: true, activeSessionId: 's1' })
+      // A pairing-bound client scoped to s1 — must NOT be auto-switched off it
+      // (the original session is not destroyed by a restore).
+      const bound = makeClient({ id: 'c2', authenticated: true, activeSessionId: 's1', boundSessionId: 's1' })
+      ctx.clientManager.addClient(initiatorWs, initiator)
+      ctx.clientManager.addClient(boundWs, bound)
+      ctx.clientManager.setActiveSession(initiator, 's1')
+      ctx.clientManager.setActiveSession(bound, 's1')
+
+      await checkpointHandlers.restore_checkpoint(initiatorWs, initiator, { checkpointId: 'cp-1' }, ctx)
+
+      assert.equal(bound.activeSessionId, 's1', 'a pairing-bound client stays on its bound session')
+    })
+
     it('does not re-home a client viewing a DIFFERENT session during restore (#5700)', async () => {
       const sessions = new Map()
       const orig = createMockSession()


### PR DESCRIPTION
## Summary

Fixes a multi-client desync from the durability audit: `handleRestoreCheckpoint` created the rewound session and re-homed only the **initiating** client (`setActiveSession`), leaving every other client subscribed to the original session showing its **pre-rewind** history — two clients, two histories, no reconciliation until a manual re-subscribe.

## Verification of the audit claim
Confirmed by direct read: `checkpoint-handlers.js` re-homed only `client` via `setActiveSession(client, newSessionId)`; the **destroy** path (`session-handlers.js`) already iterates all clients and re-homes active viewers. (The `#5731 T8` busy-shared-cwd guard for restore landed earlier; this closes the remaining re-homing gap.)

## Fix
After creating the rewound session, iterate `ctx.transport.clients` and re-home any **other** authenticated viewer of the original session onto the rewound session, reusing the destroy path's pattern: `setActiveSession` + `session_switched` + `sendSessionInfo` + `replayHistory(forceFull:true)` + `broadcastFocusChanged`. The original session is **not** destroyed; its active viewers simply follow the rewind.

## Tests
- app+dashboard on the same session → restore on one re-homes the other (asserts `session_switched` to the rewound session + a forced full history replay for the observer).
- a client viewing a **different** session is left untouched.

`checkpoint-handlers.test.js`: 19/19 · `session-handlers.test.js` + `ws-handler-coverage`: 99/99 · eslint clean.

Closes #5700