### PR TITLE
feat(server): resolve the Discord webhook from the OS keychain as a third source (#5493)

### DIFF
--- a/packages/server/src/discord-credentials.js
+++ b/packages/server/src/discord-credentials.js
@@ -15,6 +15,10 @@
  *   2. ~/.chroxy/credentials.json — { discordWebhookUrl: "https://discord.com/api/webhooks/..." }
  *      File MUST be mode 0600. We refuse to read it otherwise (security
  *      boundary: secrets must not be world-readable).
+ *   3. OS keychain — service `chroxy-discord-webhook`, account `webhook-url`
+ *      (#5493). The launchd cutover stores it here; a Tauri-app-spawned server
+ *      has no wrapper to export the env var, so the server reads the keychain
+ *      directly (mirrors how the API token self-resolves).
  *
  * The URL is deliberately NOT a config.json key — config.json is not
  * permission-restricted and gets echoed in verbose/diagnostic output.
@@ -29,6 +33,15 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { cachedResolveCredentialFile } from './auth-probes.js'
 import { readStoredField } from './credential-store.js'
+import { getToken } from './keychain.js'
+
+// #5493: the launchd cutover (#5439) stores the webhook in the OS keychain under
+// this service/account and relies on ~/.chroxy/service-wrapper.sh to export it as
+// the env var. A Tauri-app-spawned server has no wrapper, so env+file both miss —
+// read the keychain directly as a third source (mirrors the API token, which the
+// server self-resolves from the keychain too).
+const DISCORD_WEBHOOK_KEYCHAIN_SERVICE = 'chroxy-discord-webhook'
+const DISCORD_WEBHOOK_KEYCHAIN_ACCOUNT = 'webhook-url'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home (same rationale as byok-credentials.js).
@@ -68,15 +81,23 @@ export function extractWebhookIdToken(url) {
 /**
  * Resolve the Discord webhook URL for the notification sink.
  *
- * @returns {{ url: string, source: 'env' | 'file' } | { url: null, source: 'none', reason: string }}
+ * @param {object} [opts]
+ * @param {(service: string, account: string) => string|null} [opts.keychainGet]
+ *   OS-keychain reader (source 3); injectable for tests. Defaults to
+ *   keychain.getToken, which itself returns null when no keychain is available.
+ * @returns {{ url: string, source: 'env' | 'file' | 'keychain' } | { url: null, source: 'none', reason: string }}
  */
-export function resolveDiscordWebhookUrl() {
+export function resolveDiscordWebhookUrl({ keychainGet = getToken } = {}) {
   const envUrl = process.env.CHROXY_DISCORD_WEBHOOK_URL
   if (typeof envUrl === 'string' && envUrl.length > 0) {
     return { url: envUrl, source: 'env' }
   }
 
   const CREDENTIALS_FILE = credentialsFilePath()
+  // The file source's failure reason is captured rather than returned eagerly so
+  // a missing/empty/unreadable file falls through to the keychain (#5493) before
+  // we report `source: 'none'` with the most informative reason.
+  let fileReason = null
 
   // #5490: route the file read through credential-store's cipher-aware reader.
   // The webhook URL lives in the SAME credentials.json the BYOK/API-key
@@ -93,43 +114,47 @@ export function resolveDiscordWebhookUrl() {
     read = readStoredField('discordWebhookUrl')
   } catch (err) {
     // Defensive: readStoredField is non-throwing by contract, but if it ever
-    // does, degrade to source:'none' rather than crash the sink's probe.
-    return {
-      url: null,
-      source: 'none',
-      reason: `unable to read ${CREDENTIALS_FILE}: ${err.message}`,
+    // does, record the reason and fall through to the keychain.
+    read = null
+    fileReason = `unable to read ${CREDENTIALS_FILE}: ${err.message}`
+  }
+
+  if (read) {
+    // A read error covers bad mode, malformed JSON, an encrypted envelope whose
+    // keychain data key is unavailable, a corrupt/undecryptable envelope, AND a
+    // non-ENOENT stat failure (EACCES/EPERM). readStore() reports those stat
+    // failures with `fileExists:false` but a populated `error`, so this MUST be
+    // checked before the `!fileExists` "does not exist" branch below — otherwise a
+    // permission error would be misreported as a missing file, hiding the real
+    // cause from an operator debugging a 0600/ownership problem. The reason is
+    // value-free (built by credential-store from the path/cause).
+    if (read.error) {
+      fileReason = read.error
+    } else if (!read.fileExists) {
+      fileReason = `CHROXY_DISCORD_WEBHOOK_URL not set and ${CREDENTIALS_FILE} does not exist`
+    } else if (read.value === null) {
+      fileReason = `${CREDENTIALS_FILE} missing or empty "discordWebhookUrl" field`
+    } else {
+      return { url: read.value, source: 'file' }
     }
   }
 
-  // A read error covers bad mode, malformed JSON, an encrypted envelope whose
-  // keychain data key is unavailable, a corrupt/undecryptable envelope, AND a
-  // non-ENOENT stat failure (EACCES/EPERM). readStore() reports those stat
-  // failures with `fileExists:false` but a populated `error`, so this MUST be
-  // checked before the `!fileExists` "does not exist" branch below — otherwise a
-  // permission error would be misreported as a missing file, hiding the real
-  // cause from an operator debugging a 0600/ownership problem. The reason is
-  // value-free (built by credential-store from the path/cause).
-  if (read.error) {
-    return { url: null, source: 'none', reason: read.error }
+  // Source 3 (#5493): the OS keychain. getToken short-circuits to null when the
+  // keychain is unavailable/disabled, so this is a no-op on platforms/tests
+  // without one. Returned raw (like env/file) — the sink applies the same
+  // isValidDiscordWebhookUrl + maskWebhookUrl rules to every source.
+  const keychainUrl = keychainGet(DISCORD_WEBHOOK_KEYCHAIN_SERVICE, DISCORD_WEBHOOK_KEYCHAIN_ACCOUNT)
+  if (typeof keychainUrl === 'string' && keychainUrl.length > 0) {
+    return { url: keychainUrl, source: 'keychain' }
   }
 
-  if (!read.fileExists) {
-    return {
-      url: null,
-      source: 'none',
-      reason: `CHROXY_DISCORD_WEBHOOK_URL not set and ${CREDENTIALS_FILE} does not exist`,
-    }
+  return {
+    url: null,
+    source: 'none',
+    reason: fileReason
+      ? `${fileReason}; no webhook in the keychain either`
+      : `CHROXY_DISCORD_WEBHOOK_URL not set and no webhook in ${CREDENTIALS_FILE} or the keychain`,
   }
-
-  if (read.value === null) {
-    return {
-      url: null,
-      source: 'none',
-      reason: `${CREDENTIALS_FILE} missing or empty "discordWebhookUrl" field`,
-    }
-  }
-
-  return { url: read.value, source: 'file' }
 }
 
 /**

--- a/packages/server/src/keychain.js
+++ b/packages/server/src/keychain.js
@@ -68,15 +68,19 @@ export function isKeychainAvailable() {
 /**
  * Get token from OS keychain.
  * @param {string} [service] - Keychain service name (default: 'chroxy')
+ * @param {string} [account] - Keychain account (default: 'api-token'). Other
+ *   credentials reuse the same OS keychain under a different account — e.g. the
+ *   Discord webhook URL at service `chroxy-discord-webhook` / account
+ *   `webhook-url` (#5493).
  * @returns {string|null} Token or null if not found
  */
-export function getToken(service = DEFAULT_SERVICE) {
+export function getToken(service = DEFAULT_SERVICE, account = ACCOUNT) {
   if (keychainDisabled()) return null
   if (isMac) {
-    return _macGetToken(service)
+    return _macGetToken(service, account)
   }
   if (isLinux) {
-    return _linuxGetToken(service)
+    return _linuxGetToken(service, account)
   }
   return null
 }
@@ -187,12 +191,12 @@ export function migrateToken(config, service = DEFAULT_SERVICE) {
 
 // -- macOS implementation (security command) --
 
-function _macGetToken(service) {
+function _macGetToken(service, account = ACCOUNT) {
   try {
     const output = execFileSync('security', [
       'find-generic-password',
       '-s', service,
-      '-a', ACCOUNT,
+      '-a', account,
       '-w',
     ], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
     return output.trim() || null
@@ -248,12 +252,12 @@ function _macDeleteToken(service) {
 
 // -- Linux implementation (secret-tool / libsecret) --
 
-function _linuxGetToken(service) {
+function _linuxGetToken(service, account = ACCOUNT) {
   try {
     const output = execFileSync('secret-tool', [
       'lookup',
       'service', service,
-      'account', ACCOUNT,
+      'account', account,
     ], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
     return output.trim() || null
   } catch {

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -179,6 +179,48 @@ describe('discord-credentials — webhook URL sourcing', () => {
     assert.equal(r.source, 'none')
   })
 
+  // #5493: a Tauri-app-spawned server has no service-wrapper to export the env
+  // var, and credentials.json is the encrypted BYOK envelope — so the webhook
+  // must be readable straight from the OS keychain as a third source.
+  it('falls back to the keychain when env and file are both absent (#5493)', () => {
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    const r = resolveDiscordWebhookUrl({
+      keychainGet: (service, account) =>
+        service === 'chroxy-discord-webhook' && account === 'webhook-url' ? WEBHOOK : null,
+    })
+    assert.equal(r.source, 'keychain')
+    assert.equal(r.url, WEBHOOK)
+  })
+
+  it('env var wins over the keychain (#5493)', () => {
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.CHROXY_DISCORD_WEBHOOK_URL = WEBHOOK
+    const r = resolveDiscordWebhookUrl({ keychainGet: () => 'https://discord.com/api/webhooks/9/keychain-token-zzzzzzzzzzzzzzzzzzzz' })
+    assert.equal(r.source, 'env')
+    assert.equal(r.url, WEBHOOK)
+  })
+
+  it('the credentials file wins over the keychain (#5493)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    const dir = join(home, '.chroxy')
+    mkdirSync(dir, { recursive: true })
+    const file = join(dir, 'credentials.json')
+    writeFileSync(file, JSON.stringify({ discordWebhookUrl: WEBHOOK }), { mode: 0o600 })
+    chmodSync(file, 0o600)
+    const r = resolveDiscordWebhookUrl({ keychainGet: () => 'https://discord.com/api/webhooks/9/keychain-token-zzzzzzzzzzzzzzzzzzzz' })
+    assert.equal(r.source, 'file')
+    assert.equal(r.url, WEBHOOK)
+  })
+
+  it('keychain miss leaves source none with a reason noting the keychain was checked (#5493)', () => {
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    const r = resolveDiscordWebhookUrl({ keychainGet: () => null })
+    assert.equal(r.url, null)
+    assert.equal(r.source, 'none')
+    assert.match(r.reason, /keychain/)
+  })
+
   // #5523 review: a non-ENOENT stat failure (EACCES/EPERM) must surface the
   // real error, NOT be misreported as "does not exist". readStore() returns such
   // failures as { fileExists:false, error:'unable to stat …' }, so the resolver


### PR DESCRIPTION
## Problem

A Tauri-app-spawned server gets no Discord notifications out of the box. The webhook resolution order was env → `~/.chroxy/credentials.json`, and **neither** works for the desktop app:
- The launchd cutover (#5439) stores the webhook in the macOS keychain (`chroxy-discord-webhook` / `webhook-url`) and relies on `service-wrapper.sh` to export the env var — the Tauri app spawns `cli.js start` with no wrapper, so the env source is empty.
- `credentials.json` is the encrypted BYOK envelope (`{v,alg,nonce,data}`), not plain JSON — so the file source reports `missing or empty "discordWebhookUrl" field`.

Net effect: switching from the service to the app silently drops all Discord notifications.

## Fix

Add a **third source** to `resolveDiscordWebhookUrl`: read the OS keychain directly (service `chroxy-discord-webhook`, account `webhook-url`), after env and file — mirroring how the API token already self-resolves from the keychain (removing the wrapper as a single point of delivery). Priority stays **env > file > keychain**; the file source's failure reason is now captured and falls through so the keychain is tried before reporting `source:'none'` (and that final reason notes the keychain was checked).

`keychain.getToken` gains an optional `account` param (default `'api-token'`, so every existing caller is unchanged), threaded through the mac/linux read helpers — the webhook lives under a different account in the same keychain. The keychain reader is injected into the resolver via a default-param seam for testing (mirrors the repo's other DI seams); it self-disables when no keychain is available.

## Tests
- keychain fallback when env+file both absent; env wins over keychain; file wins over keychain; keychain miss → `source:'none'` with a keychain-aware reason.
- `discord-webhook-sink.test.js`: 105/105 · `keychain*.test.js`: green (real-keychain cases skipped) · eslint 0 errors · server lints pass.

Closes #5493