### PR TITLE
docs(contributing): document the branch-protection & CI policy (#3816)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,39 @@ Thanks for your interest in contributing! This document covers how to get starte
 5. Commit with a clear message
 6. Push and open a PR
 
+## Branch protection & CI policy
+
+`main` is protected. Every PR must satisfy these gates before it can merge — they
+apply to maintainer and external PRs alike:
+
+- **All required status checks green.** The full CI matrix is required:
+  `Server Tests`, `Server Lint`, `Protocol Tests`, `Store Core Tests`,
+  `Store Core Type Check`, `Dashboard Tests`, `Dashboard Type Check`, `App Tests`,
+  `App Type Check`, `App Expo Doctor`, and `Desktop Rust Tests`. (The
+  `Desktop (macOS)` / `Desktop (Windows)` release builds run only on tag pushes
+  and gate the release pipeline, not PRs.)
+- **All review conversations resolved** (`required_conversation_resolution`). A PR
+  with an open review thread cannot merge — resolve it (or have it resolved) first.
+- **A Copilot review** is requested automatically on the default branch and must be
+  present.
+- **No force-pushes or branch deletions** to `main`.
+
+Deliberate policy choices (a solo-maintained project):
+
+- **No required approving review** (`required_approving_review_count: 0`). The
+  maintainer self-merges once the checks and conversation-resolution gates above
+  pass; the CI matrix + Copilot review are the quality bar, not a second human.
+  This keeps merge latency low and is what lets unattended/batch maintenance flows
+  merge their own green, reviewed PRs.
+- **Admins are not force-subjected to the rules** (`enforce_admins: false`) to keep
+  an emergency-fix path open; in practice every merge still goes through the gates
+  above.
+
+Repository Actions hardening: third-party actions are **SHA-pinned**
+(`sha_pinning_required`), the default `GITHUB_TOKEN` is **read-only** (jobs elevate
+per-workflow via `permissions:`), and **fork PRs from first-time contributors
+require maintainer approval** before workflows run.
+
 ## Code Style
 
 - **TypeScript** for the app, **JavaScript (ES modules)** for the server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,36 +57,38 @@ Thanks for your interest in contributing! This document covers how to get starte
 
 ## Branch protection & CI policy
 
-`main` is protected. Every PR must satisfy these gates before it can merge — they
-apply to maintainer and external PRs alike:
+`main` is protected. Every PR is expected to clear these gates before merging:
 
-- **All required status checks green.** The full CI matrix is required:
+- **Required status checks must be green.** These checks block the merge:
   `Server Tests`, `Server Lint`, `Protocol Tests`, `Store Core Tests`,
   `Store Core Type Check`, `Dashboard Tests`, `Dashboard Type Check`, `App Tests`,
-  `App Type Check`, `App Expo Doctor`, and `Desktop Rust Tests`. (The
-  `Desktop (macOS)` / `Desktop (Windows)` release builds run only on tag pushes
-  and gate the release pipeline, not PRs.)
-- **All review conversations resolved** (`required_conversation_resolution`). A PR
-  with an open review thread cannot merge — resolve it (or have it resolved) first.
-- **A Copilot review** is requested automatically on the default branch and must be
-  present.
+  `App Type Check`, `App Expo Doctor`, and `Desktop Rust Tests`. (Other CI jobs
+  run too — e.g. conditional Windows platform tests and scripts/hooks jobs — but
+  the list above is the set wired as required. The `Desktop (macOS)` /
+  `Desktop (Windows)` release builds run only on tag pushes and gate the release
+  pipeline, not PRs.)
+- **All review conversations must be resolved.** A PR with an open review thread
+  cannot merge — resolve it (or have it resolved) first.
+- **A Copilot review** is requested automatically on the default branch (via a
+  repository ruleset) and is expected before merge.
 - **No force-pushes or branch deletions** to `main`.
 
 Deliberate policy choices (a solo-maintained project):
 
-- **No required approving review** (`required_approving_review_count: 0`). The
-  maintainer self-merges once the checks and conversation-resolution gates above
-  pass; the CI matrix + Copilot review are the quality bar, not a second human.
-  This keeps merge latency low and is what lets unattended/batch maintenance flows
-  merge their own green, reviewed PRs.
-- **Admins are not force-subjected to the rules** (`enforce_admins: false`) to keep
-  an emergency-fix path open; in practice every merge still goes through the gates
-  above.
+- **No required approving review.** The maintainer self-merges once the checks and
+  conversation-resolution gates above pass; the required checks plus the Copilot
+  review are the quality bar, not a second human reviewer. This keeps merge latency
+  low and lets unattended/batch maintenance flows merge their own green, reviewed
+  PRs.
+- **Admins are not force-subjected to the protection rules**, which keeps an
+  emergency-fix path open. This is why the bar above is framed as the expected
+  policy rather than a rule enforced against every actor — in practice every merge
+  still goes through these gates.
 
-Repository Actions hardening: third-party actions are **SHA-pinned**
-(`sha_pinning_required`), the default `GITHUB_TOKEN` is **read-only** (jobs elevate
-per-workflow via `permissions:`), and **fork PRs from first-time contributors
-require maintainer approval** before workflows run.
+Repository Actions are hardened too: third-party actions are pinned to full commit
+SHAs, the default workflow token is read-only (jobs elevate their own permissions
+per-workflow as needed), and workflows on pull requests from first-time
+contributors require maintainer approval before they run.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Closes the pre-1.0 branch-protection hardening checklist (#3816). Most items were already satisfied since the issue was filed; this documents the final policy and resolves the two open decisions.

## Already in place (verified)
- **SHA-pinning required** for third-party actions (the issue's `sha_pinning_required: false` gap is closed).
- **All four previously-missing required checks added** — `App Tests`, `Store Core Tests`, `Desktop Rust Tests`, `App Expo Doctor` are now required (11 required checks total).
- **Fork PRs from first-time contributors require approval**; default `GITHUB_TOKEN` is **read-only** (per-job `permissions:` elevation).
- `required_conversation_resolution: true`, no force-pushes/deletions, Copilot review auto-requested.

## Decisions recorded (no settings changed)
- **`required_approving_review_count` stays 0** — the maintainer self-merges once CI + conversation-resolution + Copilot review pass; the CI matrix is the quality bar. Raising it would block self-merge with no second human available.
- **`enforce_admins` stays false** — solo-maintainer emergency path; every merge still goes through the gates in practice.

## Change
Adds a **"Branch protection & CI policy"** section to `CONTRIBUTING.md` capturing all of the above so contributors know what to expect. Docs-only — **no branch-protection settings are mutated.**

Closes #3816