### PR TITLE
refactor(server): version-aware opus context-window heuristic (#5931)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -18,13 +18,15 @@ export const ONE_M_SUFFIX = '[1m]'
 // SDK's authoritative modelUsage.contextWindow overrides this after turn 1, so a
 // wrong cold-start guess only ever surfaces for the first turn.
 const OPUS_ONE_M_MIN_VERSION = Object.freeze([4, 6])
-// Matches an `opus-<major>-<minor>` / `opus-<major>.<minor>` version token, e.g.
-// `claude-opus-4-8`, `claude-opus-4.8`, or `claude-opus-4-7-20251201` (versioned
-// + dated). The minor is 1–2 digits NOT followed by another digit, so a DATED
-// base id like `claude-opus-4-20250514` (opus 4.0, dated — a 200k model) does not
-// have its date misread as a huge minor version. A `claude-3-opus-2024…` id has
-// no `opus-<n>-<n>` token at all and falls through to the default.
-const OPUS_VERSION_RE = /opus-(\d+)[-.](\d{1,2})(?!\d)/
+// Matches an opus version token: `opus-<major>` with an OPTIONAL `-<minor>` /
+// `.<minor>`, e.g. `claude-opus-4-8`, `claude-opus-4.8`, `claude-opus-5` (major
+// only), or `claude-opus-4-7-20251201` (versioned + dated). Both major and minor
+// are 1–2 digits NOT followed by another digit, so:
+//   - a DATED base id like `claude-opus-4-20250514` (opus 4.0, dated — 200k) does
+//     NOT read the date as a minor (the optional group fails → major-only 4.0);
+//   - a `claude-3-opus-20240229` id does NOT read the 8-digit date as a major
+//     (the major is capped at 2 digits + lookahead → no match → default).
+const OPUS_VERSION_RE = /opus-(\d{1,2})(?!\d)(?:[-.](\d{1,2})(?!\d))?/
 
 /**
  * Static context-window heuristic used at cold start before the SDK reports.
@@ -45,9 +47,12 @@ export function resolveClaudeContextWindow(fullId) {
   const m = OPUS_VERSION_RE.exec(fullId)
   if (m) {
     const major = Number(m[1])
-    const minor = Number(m[2])
+    const minor = m[2] === undefined ? null : Number(m[2])
     const [minMajor, minMinor] = OPUS_ONE_M_MIN_VERSION
-    if (major > minMajor || (major === minMajor && minor >= minMinor)) return 1_000_000
+    // A future major (opus 5+) is 1M with or without a minor; opus 4 needs an
+    // explicit minor >= 6 (bare `opus-4` is 4.0 → 200k, not assumed 4.6).
+    if (major > minMajor) return 1_000_000
+    if (major === minMajor && minor !== null && minor >= minMinor) return 1_000_000
   }
   return DEFAULT_CONTEXT_WINDOW
 }

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -19,9 +19,12 @@ export const ONE_M_SUFFIX = '[1m]'
 // wrong cold-start guess only ever surfaces for the first turn.
 const OPUS_ONE_M_MIN_VERSION = Object.freeze([4, 6])
 // Matches an `opus-<major>-<minor>` / `opus-<major>.<minor>` version token, e.g.
-// `claude-opus-4-8` or `claude-opus-4.8`. A dated id like `claude-3-opus-2024…`
-// has no `opus-<n>-<n>` token, so it correctly falls through to the default.
-const OPUS_VERSION_RE = /opus-(\d+)[-.](\d+)/
+// `claude-opus-4-8`, `claude-opus-4.8`, or `claude-opus-4-7-20251201` (versioned
+// + dated). The minor is 1–2 digits NOT followed by another digit, so a DATED
+// base id like `claude-opus-4-20250514` (opus 4.0, dated — a 200k model) does not
+// have its date misread as a huge minor version. A `claude-3-opus-2024…` id has
+// no `opus-<n>-<n>` token at all and falls through to the default.
+const OPUS_VERSION_RE = /opus-(\d+)[-.](\d{1,2})(?!\d)/
 
 /**
  * Static context-window heuristic used at cold start before the SDK reports.

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -12,9 +12,21 @@ export const DEFAULT_CONTEXT_WINDOW = 200_000
 /** Suffix the Claude CLI uses to mark the explicit 1M-context variant */
 export const ONE_M_SUFFIX = '[1m]'
 
+// Opus gained a 1M context window at 4.6. `[major, minor]` of the first opus
+// release with a 1M window — opus at or above this (and any future opus major)
+// is treated as 1M; earlier opus and every other family default to 200k. The
+// SDK's authoritative modelUsage.contextWindow overrides this after turn 1, so a
+// wrong cold-start guess only ever surfaces for the first turn.
+const OPUS_ONE_M_MIN_VERSION = Object.freeze([4, 6])
+// Matches an `opus-<major>-<minor>` / `opus-<major>.<minor>` version token, e.g.
+// `claude-opus-4-8` or `claude-opus-4.8`. A dated id like `claude-3-opus-2024…`
+// has no `opus-<n>-<n>` token, so it correctly falls through to the default.
+const OPUS_VERSION_RE = /opus-(\d+)[-.](\d+)/
+
 /**
  * Static context-window heuristic used at cold start before the SDK reports.
- * Opus 4.6+ has 1M; most other Claude models have 200k. Any id carrying the
+ * Opus 4.6+ has 1M (matched by family + version, so new minors/majors inherit it
+ * without a code change); most other Claude models have 200k. Any id carrying the
  * explicit `[1m]` CLI suffix is a 1M-context variant regardless of the base
  * model. The SDK sends authoritative values in
  * `SDKResultSuccess.modelUsage[*].contextWindow` after each turn — registries
@@ -27,13 +39,13 @@ export const ONE_M_SUFFIX = '[1m]'
 export function resolveClaudeContextWindow(fullId) {
   if (typeof fullId !== 'string') return DEFAULT_CONTEXT_WINDOW
   if (fullId.endsWith(ONE_M_SUFFIX)) return 1_000_000
-  if (fullId.includes('opus-4-6') || fullId.includes('opus-4.6')) return 1_000_000
-  if (fullId.includes('opus-4-7') || fullId.includes('opus-4.7')) return 1_000_000
-  // opus-4-8 is treated as 1M for consistency with the rest of the opus 4.x
-  // family the heuristic already maps to 1M — this is a family-consistency
-  // default, not a verified spec. The SDK's authoritative
-  // modelUsage.contextWindow overrides it after the first turn if wrong.
-  if (fullId.includes('opus-4-8') || fullId.includes('opus-4.8')) return 1_000_000
+  const m = OPUS_VERSION_RE.exec(fullId)
+  if (m) {
+    const major = Number(m[1])
+    const minor = Number(m[2])
+    const [minMajor, minMinor] = OPUS_ONE_M_MIN_VERSION
+    if (major > minMajor || (major === minMajor && minor >= minMinor)) return 1_000_000
+  }
   return DEFAULT_CONTEXT_WINDOW
 }
 

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -64,6 +64,14 @@ describe('resolveClaudeContextWindow (#5931 — version-aware opus heuristic)', 
     assert.equal(resolveClaudeContextWindow('claude-3-opus-20240229'), DEFAULT_CONTEXT_WINDOW)
   })
 
+  it('does not misread a DATED base-opus-4 id as a 1M minor version', () => {
+    // claude-opus-4-20250514 is opus 4.0 (dated) — a 200k model. The date must
+    // not be parsed as minor=20250514 (which would wrongly map it to 1M).
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-20250514'), DEFAULT_CONTEXT_WINDOW)
+    // But a VERSIONED + dated id keeps its real minor → opus 4.7 dated is 1M.
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-7-20251201'), 1_000_000)
+  })
+
   it('defaults non-opus families to 200k', () => {
     assert.equal(resolveClaudeContextWindow('claude-sonnet-4-6'), DEFAULT_CONTEXT_WINDOW)
     assert.equal(resolveClaudeContextWindow('claude-haiku-4-5'), DEFAULT_CONTEXT_WINDOW)

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -55,6 +55,13 @@ describe('resolveClaudeContextWindow (#5931 — version-aware opus heuristic)', 
     assert.equal(resolveClaudeContextWindow('claude-opus-4-9'), 1_000_000)
     assert.equal(resolveClaudeContextWindow('claude-opus-4-12'), 1_000_000)
     assert.equal(resolveClaudeContextWindow('claude-opus-5-0'), 1_000_000)
+    // Major-only future id (no minor) — opus 5+ is 1M.
+    assert.equal(resolveClaudeContextWindow('claude-opus-5'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-6'), 1_000_000)
+  })
+
+  it('treats a bare major-only opus-4 (no minor) as 4.0 → 200k, not 4.6', () => {
+    assert.equal(resolveClaudeContextWindow('claude-opus-4'), DEFAULT_CONTEXT_WINDOW)
   })
 
   it('does NOT mis-map opus releases older than 4.6 to 1M', () => {

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider, registerProviderRegistry } from '../src/models.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider, registerProviderRegistry, resolveClaudeContextWindow, DEFAULT_CONTEXT_WINDOW } from '../src/models.js'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 // #5858: membership is now derived from `static claudeFamily` on the registered
 // provider classes (no hand-authored name literal). Importing providers.js
@@ -40,6 +40,45 @@ describe('FALLBACK_MODELS (default registry)', () => {
     for (const m of FALLBACK_MODELS) {
       assert.doesNotMatch(m.fullId, /-\d{8,}$/, `${m.id} fallback should not be a dated ID`)
     }
+  })
+})
+
+describe('resolveClaudeContextWindow (#5931 — version-aware opus heuristic)', () => {
+  it('maps the existing opus 4.6/4.7/4.8 minors to 1M (no behavior change)', () => {
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-6'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-7'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-8'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4.8'), 1_000_000)
+  })
+
+  it('generalizes to FUTURE opus minors and majors without a code change', () => {
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-9'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-12'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-5-0'), 1_000_000)
+  })
+
+  it('does NOT mis-map opus releases older than 4.6 to 1M', () => {
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-5'), DEFAULT_CONTEXT_WINDOW)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-0'), DEFAULT_CONTEXT_WINDOW)
+    // Dated opus-3 id carries no opus-<n>-<n> version token → default.
+    assert.equal(resolveClaudeContextWindow('claude-3-opus-20240229'), DEFAULT_CONTEXT_WINDOW)
+  })
+
+  it('defaults non-opus families to 200k', () => {
+    assert.equal(resolveClaudeContextWindow('claude-sonnet-4-6'), DEFAULT_CONTEXT_WINDOW)
+    assert.equal(resolveClaudeContextWindow('claude-haiku-4-5'), DEFAULT_CONTEXT_WINDOW)
+    assert.equal(resolveClaudeContextWindow('claude-fable-5'), DEFAULT_CONTEXT_WINDOW)
+  })
+
+  it('honors the explicit [1m] CLI suffix regardless of family', () => {
+    assert.equal(resolveClaudeContextWindow('claude-sonnet-4-6[1m]'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('some-model[1m]'), 1_000_000)
+  })
+
+  it('returns the default for non-string input', () => {
+    assert.equal(resolveClaudeContextWindow(null), DEFAULT_CONTEXT_WINDOW)
+    assert.equal(resolveClaudeContextWindow(undefined), DEFAULT_CONTEXT_WINDOW)
+    assert.equal(resolveClaudeContextWindow(42), DEFAULT_CONTEXT_WINDOW)
   })
 })
 


### PR DESCRIPTION
## Summary

`resolveClaudeContextWindow` (cold-start context-window guess) hardcoded `opus-4-6`/`4-7`/`4-8` → 1M. Each new opus minor needs a code edit, and a new opus *major* would be missed, until the SDK's authoritative `modelUsage.contextWindow` ratchets it after turn 1.

## Change

Replace the enumerated `.includes('opus-4-6')` checks with a **version-aware family match**: parse the `opus-<major>-<minor>` token and map opus **≥ 4.6** (and any future major) to 1M; earlier opus and all other families default to 200k.

- Current ids: **unchanged** (4-6/4-7/4-8 → 1M; sonnet/haiku/fable → 200k; `[1m]` suffix → 1M).
- New opus minors/majors (4-9, 4-12, 5-0) now inherit 1M with no code change.
- Older opus (4-5, dated opus-3) and non-opus families correctly stay 200k.

Part of the #5631 decomposition (folds into the #5930 metadata registry if that lands first).

## Tests

New direct unit test for `resolveClaudeContextWindow`: existing minors, future minors/majors, the pre-4.6 non-mapping, non-opus families, the `[1m]` suffix, and non-string input. `models.test.js` + `models-factory.test.js` + `models-per-provider.test.js`: 164/164 · eslint clean.

Closes #5931