### PR TITLE
fix(server): roll back eager handshake when auth_ok delivery fails (#5721 part 1)

### DIFF
--- a/packages/server/src/ws-client-sender.js
+++ b/packages/server/src/ws-client-sender.js
@@ -29,7 +29,14 @@ const WARN_THROTTLE_MS = 30_000
  * @param {number} [opts.warnThreshold] - Bytes above which to log warning
  * @param {number} [opts.evictThreshold] - Bytes above which to close client
  * @param {number} [opts.warnThrottleMs] - Min ms between warnings per client
- * @returns {(ws: WebSocket, client: object|undefined, message: object) => void}
+ * @returns {(ws: WebSocket, client: object|undefined, message: object) => boolean}
+ *   Returns `true` when the message was handed to `ws.send` without throwing
+ *   (or accepted into the post-auth / flush-overflow queue for later delivery),
+ *   `false` when it could not be delivered — the client was already evicted, or
+ *   `ws.send` threw (a torn-down / half-open socket). #5721: callers that gate
+ *   crypto state on a frame actually reaching the wire (the eager handshake's
+ *   `auth_ok` carrying `serverPublicKey`) MUST check this — the catch below
+ *   swallows the throw, so there is no exception to observe otherwise.
  */
 export function createClientSender(log, opts = {}) {
   const warnThreshold = opts.warnThreshold ?? WARN_THRESHOLD
@@ -42,18 +49,18 @@ export function createClientSender(log, opts = {}) {
     // chain (e.g. replayHistory / flushPostAuthQueue) would otherwise keep
     // serializing + encrypting messages that will never leave the buffer.
     if (client?._evicted) {
-      return
+      return false
     }
     // Queue messages while key exchange is pending
     if (client?.encryptionPending && client.postAuthQueue) {
       client.postAuthQueue.push(message)
-      return
+      return true
     }
     // Buffer messages while post-auth queue is still flushing
     if (client?._flushing) {
       client._flushOverflow = client._flushOverflow || []
       client._flushOverflow.push(message)
-      return
+      return true
     }
     // Assign per-client monotonic sequence number
     if (client) {
@@ -96,8 +103,13 @@ export function createClientSender(log, opts = {}) {
           log.warn(`Backpressure: client ${client.id} bufferedAmount ${buffered} exceeds warning threshold (${warnThreshold} bytes) type=${message?.type || 'unknown'}`)
         }
       }
+      // #5721: the frame was handed to ws.send without throwing. A post-send
+      // backpressure eviction above (ws.close) affects FUTURE sends, not this
+      // one — this message already left for the socket buffer, so report success.
+      return true
     } catch (err) {
       log.error(`Send error: ${err.message}`)
+      return false
     }
   }
 }

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -374,7 +374,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
       ? streamStallTimeoutMs
       : DEFAULT_STREAM_STALL_TIMEOUT_MS
 
-  send(ws, {
+  const authOkDelivered = send(ws, {
     type: 'auth_ok',
     clientId: client.id,
     serverMode,
@@ -425,6 +425,20 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   // from auth_ok.serverPublicKey + its own secret, so both sides start at
   // nonce 0 in lockstep. This is the un-gated eager path — no postAuthQueue.
   if (eagerEncryptionState) {
+    // #5721: gate the crypto activation on the auth_ok ACTUALLY reaching the
+    // wire. `send` (_clientSend) swallows a send throw internally, so without
+    // this check a failed/half-open auth_ok would still flip encryptionState —
+    // the server would then encrypt the whole post-auth burst with a key the
+    // client never received (it never got serverPublicKey), wedging the session
+    // until the 15–30s heartbeat sweep reaps it. Mirror the discrete-path
+    // rollback (#5702 8b / ws-auth.js key_exchange_ok): on non-delivery, do NOT
+    // mark E2E established, and close so the client reconnects and retries.
+    if (!authOkDelivered) {
+      log.error(`Failed to deliver eager auth_ok to ${client.id} — aborting handshake (client never received serverPublicKey)`)
+      client.encryptionState = null
+      try { ws.close(1011, 'Handshake failed') } catch { /* socket already gone */ }
+      return
+    }
     client.encryptionState = eagerEncryptionState
     log.info(`E2E encryption established eagerly with ${client.id}`)
   }

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -170,6 +170,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     serverMode, serverVersion, latestVersion, gitInfo,
     encryptionEnabled, localhostBypass, keyExchangeTimeoutMs,
     protocolVersion, minProtocolVersion, webTaskManager,
+    // #5721: `send` MUST be `WsServer._send` (which returns the delivery
+    // boolean from the client-sender), NOT a wrapper that drops the return —
+    // the eager-handshake gate below reads `authOkDelivered` to decide whether
+    // to mark E2E established. A ctx-wiring refactor that swallows the return
+    // would silently re-open the swallowed-send wedge this fix closes.
     send, broadcast, getConnectedClientList, permissions,
     resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs,
     // #4835: per-device active-session memory. Consulted below before

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -2293,7 +2293,10 @@ export class WsServer {
   /** Send JSON to a single client (delegates to extracted ws-client-sender) */
   _send(ws, message) {
     const client = this.clients.get(ws)
-    this._clientSend(ws, client, message)
+    // #5721: propagate the delivery boolean so callers gating crypto state on a
+    // frame reaching the wire (the eager handshake's auth_ok) can observe a
+    // swallowed send failure. Other callers ignore the return, unchanged.
+    return this._clientSend(ws, client, message)
   }
 
   /**

--- a/packages/server/tests/ws-client-sender.test.js
+++ b/packages/server/tests/ws-client-sender.test.js
@@ -260,6 +260,41 @@ describe('createClientSender', () => {
     })
   })
 
+  // #5721 — the delivery boolean callers gate crypto state on (the eager
+  // handshake's auth_ok). The catch swallows the throw, so the return value is
+  // the only observable signal that a frame did NOT reach the wire.
+  describe('delivery return value (#5721)', () => {
+    it('returns true when ws.send succeeds', () => {
+      const ws = { send: () => {}, bufferedAmount: 0 }
+      assert.equal(send(ws, { _seq: 0 }, { type: 'test' }), true)
+    })
+
+    it('returns false when ws.send throws (swallowed internally)', () => {
+      log.error = () => {}
+      const ws = { send: () => { throw new Error('half-open') } }
+      assert.equal(send(ws, { _seq: 0 }, { type: 'test' }), false)
+    })
+
+    it('returns false when the client was already evicted', () => {
+      const ws = { send: () => {}, bufferedAmount: 0 }
+      assert.equal(send(ws, { _seq: 0, _evicted: true }, { type: 'test' }), false)
+    })
+
+    it('returns true when the message is queued (encryptionPending)', () => {
+      const ws = { send: () => {}, bufferedAmount: 0 }
+      const client = { _seq: 0, encryptionPending: true, postAuthQueue: [] }
+      assert.equal(send(ws, client, { type: 'test' }), true)
+      assert.equal(client.postAuthQueue.length, 1)
+    })
+
+    it('returns true when the message is buffered (_flushing)', () => {
+      const ws = { send: () => {}, bufferedAmount: 0 }
+      const client = { _seq: 0, _flushing: true }
+      assert.equal(send(ws, client, { type: 'test' }), true)
+      assert.equal(client._flushOverflow.length, 1)
+    })
+  })
+
   describe('backpressure eviction dedupe (#4834)', () => {
     /**
      * Build a fake ws whose bufferedAmount is set per-call (simulating a

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -732,7 +732,11 @@ function makeEncryptingCtx(overrides = {}) {
     send: (ws, msg) => {
       const client = ctx.clients.get(ws)
       sends.push(msg)
-      clientSend(ws, client, msg)
+      // #5721: mirror the real WsServer._send contract — return the delivery
+      // boolean from the underlying client-sender so the eager handshake's
+      // auth_ok-delivery gate sees a faithful true/false (a normal fake ws
+      // returns true; an injected throwing ws.send returns false).
+      return clientSend(ws, client, msg)
     },
     ...overrides,
   })
@@ -792,6 +796,37 @@ describe('sendPostAuthInfo — eager key exchange (#5555)', () => {
     // And the client can actually decrypt that first burst frame with the shared key.
     const decrypted = decrypt(firstBurst, clientKey, 0, DIRECTION_SERVER)
     assert.equal(typeof decrypted.type, 'string')
+  })
+
+  it('#5721 — rolls back + closes when the eager auth_ok send fails (never marks E2E established)', () => {
+    // Half-open socket: ws.send throws, which _clientSend swallows + reports as a
+    // non-delivery (returns false). Without the #5721 gate the server would still
+    // flip encryptionState and encrypt the whole burst with a key the client
+    // never received (it never got serverPublicKey) — a silent wedge.
+    const closeCalls = []
+    const ws = {
+      readyState: 1,
+      send: () => { throw new Error('half-open socket') },
+      close: (code, reason) => closeCalls.push({ code, reason }),
+      _rawSent: [],
+    }
+    const ctx = makeEncryptingCtx({ encryptionEnabled: true, keyExchangeTimeoutMs: 60000 })
+    const clientKp = createKeyPair()
+    const client = registerClient(ctx, ws, {
+      socketIp: '203.0.113.9', // not localhost → encryption required → eager path
+      eagerKeyExchange: { publicKey: clientKp.publicKey, salt: generateConnectionSalt() },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+
+    // Crypto NOT established — mirrors the discrete-path rollback (#5702 8b).
+    assert.equal(client.encryptionState, null, 'encryptionState must NOT be set when auth_ok did not reach the wire')
+    // Handshake aborted: socket closed (1011) so the client reconnects + retries.
+    assert.equal(closeCalls.length, 1, 'socket closed on non-delivery')
+    assert.equal(closeCalls[0].code, 1011)
+    // The post-auth burst was skipped — we returned right after the failed auth_ok.
+    const attemptedTypes = ctx._plainSends.map(m => m.type)
+    assert.deepEqual(attemptedTypes, ['auth_ok'], 'only auth_ok attempted; burst skipped after rollback')
   })
 
   it('#5536 — signs the eager serverPublicKey with the configured identity', async () => {


### PR DESCRIPTION
## Summary

Closes the eager-handshake half of the async-wedge class that the discrete `key_exchange_ok` path already handles (#5702 8b). **Part of #5721** — delivers server parts 1 + 3; part 2 (client-side handshake timeout) is client UI and stays tracked on #5721.

The eager handshake (`ws-history.js`) sent the plaintext `auth_ok` carrying `serverPublicKey` via `_clientSend` — which **swallows** send errors — then set `client.encryptionState` **unconditionally**. On a failed/half-open send the client never received `serverPublicKey`, yet the server believed E2E was established and encrypted the whole post-auth burst with a key the client couldn't derive — a silent wedge backstopped only by the 15–30s heartbeat sweep.

## What changed
- **`ws-client-sender.js`** — `createClientSender`'s `send` now **returns a delivery boolean**: `true` when the frame was handed to `ws.send` (or accepted into the post-auth / flush-overflow queue), `false` when the client was already evicted or `ws.send` threw. (The catch still swallows the throw — the return is now the only observable signal.)
- **`ws-server.js`** — `_send` propagates that boolean (other callers ignore it, unchanged).
- **`ws-history.js`** — the eager path **gates `client.encryptionState` on delivery**: on non-delivery it does NOT mark E2E established, clears `encryptionState`, closes the socket (`1011`) so the client reconnects + retries, and skips the post-auth burst — mirroring the discrete-path rollback.

## Testing
- `ws-client-sender.test.js`: return-value coverage (success / throw / evicted / queued / buffered).
- `ws-history.test.js`: eager-path rollback (half-open socket → `encryptionState` stays null, socket closed `1011`, burst skipped). The `makeEncryptingCtx` test ctx now mirrors the real `_send` return contract.
- Full ws-server / sender / history / backpressure / auth suites green (790+ tests).

## Follow-ups (remain on #5721)
- **Part 2:** a dedicated client-side handshake timeout (surface "handshake failed — reconnecting" instead of relying on the heartbeat pong-timeout) — client UI (app/dashboard).
- **Part 3 (extended):** tie a heartbeat-backstop test to the handshake-wedge scenario.