### PR TITLE
feat(server): hot-reload the models.json overlay without a restart (#5932)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -370,10 +370,16 @@ function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
   let raw
   try {
     raw = readFileSync(path, 'utf-8')
-  } catch {
-    // Missing file is the common case — empty overlay, no log. `ok` so a reload
-    // of a deleted file legitimately clears the overlay.
-    return { ok: true, overlay }
+  } catch (err) {
+    // A genuinely-absent file (ENOENT) is the common case AND a legitimate
+    // operator action — empty overlay, `ok: true` so a reload of a deleted file
+    // clears the overlay (no log; absence is normal). Any OTHER read error
+    // (EACCES, EBUSY, EISDIR, transient IO) is NOT an intentional clear — return
+    // `ok: false` + warn so a hot-reload keeps the LAST-GOOD set instead of
+    // silently wiping the operator's overlay on a transient fault (Copilot #5945).
+    if (err?.code === 'ENOENT') return { ok: true, overlay }
+    log.warn(`loadModelsOverlay: cannot read ${path}: ${err?.code || ''} ${err?.message || err} — keeping last-good overlay`.replace(/\s+/g, ' ').trim())
+    return { ok: false, overlay }
   }
   let parsed
   try {

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1,6 +1,6 @@
-import { readFileSync, mkdirSync } from 'fs'
+import { readFileSync, mkdirSync, watch as fsWatch } from 'fs'
 import { homedir } from 'os'
-import { dirname, join } from 'path'
+import { basename, dirname, join } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 
@@ -347,25 +347,44 @@ function getDefaultOverlayPath() {
  * @param {string} [path]
  * @returns {Map<string, {fullId:string, shortId?:string, label?:string, contextWindow?:number, pricing?:object}>}
  */
-function loadModelsOverlay(path = getDefaultOverlayPath()) {
+/**
+ * #5932 — load the overlay with an explicit MALFORMED-vs-EMPTY signal so a
+ * hot-reload can keep the last-good set when the file becomes malformed
+ * (rather than silently dropping every overlaid model). Returns
+ * `{ ok, overlay }`:
+ *   - absent file        → `{ ok: true,  overlay: <empty> }` (legit "no overrides";
+ *     a reload of an absent/deleted file CLEARS the overlay — an explicit
+ *     operator action, distinct from a parse failure)
+ *   - malformed JSON      → `{ ok: false, overlay: <empty> }`  (keep last-good on reload)
+ *   - non-object JSON root → `{ ok: false, overlay: <empty> }`
+ *   - valid object        → `{ ok: true,  overlay: <normalised> }`
+ *
+ * NEVER throws. The boot-time {@link loadModelsOverlay} wraps this and returns
+ * just the overlay (treating malformed as empty, exactly as before).
+ *
+ * @param {string} [path]
+ * @returns {{ ok: boolean, overlay: Map<string, object> }}
+ */
+function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
   const overlay = new Map()
   let raw
   try {
     raw = readFileSync(path, 'utf-8')
   } catch {
-    // Missing file is the common case — empty overlay, no log.
-    return overlay
+    // Missing file is the common case — empty overlay, no log. `ok` so a reload
+    // of a deleted file legitimately clears the overlay.
+    return { ok: true, overlay }
   }
   let parsed
   try {
     parsed = JSON.parse(raw)
   } catch (err) {
     log.warn(`loadModelsOverlay: malformed JSON in ${path}: ${err?.message || err} — ignoring overlay`)
-    return overlay
+    return { ok: false, overlay }
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     log.warn(`loadModelsOverlay: ${path} is not a JSON object keyed by model id — ignoring overlay`)
-    return overlay
+    return { ok: false, overlay }
   }
   for (const [key, value] of Object.entries(parsed)) {
     if (typeof key !== 'string' || key.length === 0) continue
@@ -380,13 +399,20 @@ function loadModelsOverlay(path = getDefaultOverlayPath()) {
     }
     overlay.set(fullId, entry)
   }
-  return overlay
+  return { ok: true, overlay }
 }
 
-// Module-level overlay, loaded once at boot. The default Claude registry and
-// the module-level getModelPricing() consult this. Per-provider registries
-// take their own overlay via the createModelsRegistry hook.
-const defaultOverlay = loadModelsOverlay()
+function loadModelsOverlay(path = getDefaultOverlayPath()) {
+  return loadModelsOverlayResult(path).overlay
+}
+
+// Module-level overlay, loaded at boot and HOT-RELOADABLE (#5932). The default
+// Claude registry and the module-level getModelPricing() consult this; both
+// read it dynamically (getModelPricing at call time; the registry via
+// applyOverlay), so reassigning it in reloadModelsOverlay() takes effect without
+// a restart. Per-provider registries take their own overlay via the
+// createModelsRegistry hook.
+let defaultOverlay = loadModelsOverlay()
 
 /**
  * Per-provider cache path resolver (#4413). Non-Claude providers
@@ -573,42 +599,56 @@ export function createModelsRegistry(hooks = {}) {
   // resolveModelPricing. SDK live values still win over both at
   // updateModels() time (the contextWindowOverrides / providerMeta lookups
   // are consulted ahead of the fallback row's contextWindow).
-  const overlayRows = []
-  const overriddenBase = []
-  const baseByFullId = new Map(baseFallbackModels.map((m) => [m.fullId, m]))
-  for (const entry of overlay.values()) {
-    const baseRow = baseByFullId.get(entry.fullId)
-    if (baseRow) {
-      // Override the base row's label/window from the overlay when supplied.
-      if (entry.label !== undefined || entry.contextWindow !== undefined || entry.shortId !== undefined) {
-        baseByFullId.set(entry.fullId, Object.freeze({
-          id: entry.shortId ?? baseRow.id,
-          label: entry.label ?? baseRow.label,
-          fullId: baseRow.fullId,
-          contextWindow: entry.contextWindow ?? baseRow.contextWindow,
-        }))
+  //
+  // #5932 — extracted so applyOverlay() can RE-fold a hot-reloaded overlay
+  // without rebuilding the whole registry (which would discard SDK-learned
+  // models + contextWindow overrides).
+  function computeFallbackModels(overlayMap) {
+    const overlayRows = []
+    const overriddenBase = []
+    const baseByFullId = new Map(baseFallbackModels.map((m) => [m.fullId, m]))
+    for (const entry of overlayMap.values()) {
+      const baseRow = baseByFullId.get(entry.fullId)
+      if (baseRow) {
+        // Override the base row's label/window from the overlay when supplied.
+        if (entry.label !== undefined || entry.contextWindow !== undefined || entry.shortId !== undefined) {
+          baseByFullId.set(entry.fullId, Object.freeze({
+            id: entry.shortId ?? baseRow.id,
+            label: entry.label ?? baseRow.label,
+            fullId: baseRow.fullId,
+            contextWindow: entry.contextWindow ?? baseRow.contextWindow,
+          }))
+        }
+        continue
       }
-      continue
+      const shortId = entry.shortId ?? deriveIdFn(entry.fullId)
+      overlayRows.push(Object.freeze({
+        id: shortId,
+        label: entry.label ?? humanizeModelId(shortId),
+        fullId: entry.fullId,
+        contextWindow: entry.contextWindow ?? resolveContextWindowFn(entry.fullId),
+      }))
     }
-    const shortId = entry.shortId ?? deriveIdFn(entry.fullId)
-    overlayRows.push(Object.freeze({
-      id: shortId,
-      label: entry.label ?? humanizeModelId(shortId),
-      fullId: entry.fullId,
-      contextWindow: entry.contextWindow ?? resolveContextWindowFn(entry.fullId),
-    }))
+    // Preserve base order, then append overlay-only rows.
+    for (const m of baseFallbackModels) overriddenBase.push(baseByFullId.get(m.fullId))
+    return overlayRows.length > 0 || overriddenBase.some((m, i) => m !== baseFallbackModels[i])
+      ? Object.freeze([...overriddenBase, ...overlayRows])
+      : baseFallbackModels
   }
-  // Preserve base order, then append overlay-only rows.
-  for (const m of baseFallbackModels) overriddenBase.push(baseByFullId.get(m.fullId))
-  const fallbackModels = overlayRows.length > 0 || overriddenBase.some((m, i) => m !== baseFallbackModels[i])
-    ? Object.freeze([...overriddenBase, ...overlayRows])
-    : baseFallbackModels
+
+  // #5932: `let` (was const) so applyOverlay() can swap in a re-folded set.
+  let fallbackModels = computeFallbackModels(overlay)
 
   let activeModels = fallbackModels
   let defaultModelId = null
   let allowedModelIds = new Set()
   let toFullIdMap = new Map()
   let toShortIdMap = new Map()
+  // #5932: the last SDK model list applied via updateModels(), retained so
+  // applyOverlay() can RE-merge a hot-reloaded overlay with the live SDK data
+  // (AC2) instead of reverting to the bare fallback view. Null until the first
+  // SDK refresh (CLI-only / pre-init).
+  let lastSdkModels = null
   // Snapshot of the last saved cache payload so saveCache() can skip
   // redundant writes. `null` forces the first save to always run.
   let lastSavedSnapshot = null
@@ -695,8 +735,34 @@ export function createModelsRegistry(hooks = {}) {
 
   rebuildLookups(fallbackModels)
 
-  return {
+  // #5932: captured in a const so applyOverlay() can re-run the full
+  // updateModels() pipeline against a re-folded fallback set. Methods reference
+  // `registry` only at call time (by which point it's assigned), so there is no
+  // temporal-dead-zone hazard.
+  const registry = {
     getModels() {
+      return activeModels
+    },
+
+    /**
+     * #5932 — apply a hot-reloaded overlay WITHOUT rebuilding the registry
+     * (which would discard SDK-learned models + contextWindow overrides). Re-fold
+     * the new overlay into the fallback set, then:
+     *   - if SDK data was applied (lastSdkModels) → re-run updateModels() so the
+     *     overlay (overlay-only rows + label/window overrides) re-merges with the
+     *     live SDK list exactly as it did originally (AC2);
+     *   - otherwise (CLI-only / pre-init) → the re-folded fallback IS the active
+     *     list; re-apply it and rebuild lookups, preserving the current default.
+     * Returns the new active model list.
+     */
+    applyOverlay(newOverlay) {
+      const map = newOverlay instanceof Map ? newOverlay : new Map()
+      fallbackModels = computeFallbackModels(map)
+      if (lastSdkModels) {
+        registry.updateModels(lastSdkModels)
+      } else {
+        applyModels(fallbackModels, defaultModelId)
+      }
       return activeModels
     },
 
@@ -869,6 +935,11 @@ export function createModelsRegistry(hooks = {}) {
         log.warn(`updateModels: no SDK entry matched the /^default\\b/i displayName regex — falling back to '${picked}' as the default model. The SDK's "Default (…)" marker may have changed shape.`)
       }
 
+      // #5932: remember the raw SDK list so a later overlay hot-reload can
+      // re-merge against it (AC2). Store the original input, not `converted`,
+      // so the re-merge re-derives ids/labels/windows from the new fallback
+      // exactly as the original call did.
+      lastSdkModels = sdkModels
       applyModels(converted, nextDefault)
       return converted
     },
@@ -900,6 +971,9 @@ export function createModelsRegistry(hooks = {}) {
     resetModels() {
       contextWindowOverrides.clear()
       pricingDriftWarned.clear()
+      // #5932: drop the retained SDK list too, so a reset truly returns to the
+      // bare fallback view (a later applyOverlay won't re-merge stale SDK data).
+      lastSdkModels = null
       applyModels(fallbackModels, null)
       lastSavedSnapshot = null
     },
@@ -1059,12 +1133,118 @@ export function createModelsRegistry(hooks = {}) {
       return saveCacheImpl(path)
     },
   }
+
+  return registry
 }
 
 // Default instance — preserves backward compatibility for all existing imports.
 // Seeded with the boot-loaded user overlay so an operator-supplied model id
 // appears in the picker / allowlist and survives the loadCache prune.
 const defaultRegistry = createModelsRegistry({ overlay: defaultOverlay })
+
+/**
+ * #5932 — hot-reload the user model overlay (`~/.chroxy/models.json`) into the
+ * DEFAULT (Claude) registry + the module-level pricing path, without a daemon
+ * restart. Re-reads the file, re-folds it into the registry (re-merging with
+ * any live SDK model list — AC2), and swaps the module-level `defaultOverlay`
+ * so `getModelPricing()` picks up new/changed pricing.
+ *
+ * Safety (AC3): a MALFORMED overlay is rejected — the registry + pricing keep
+ * the LAST GOOD set and the call returns `{ reloaded: false, reason }`. A
+ * deleted/absent file legitimately CLEARS the overlay (an explicit operator
+ * action). Never throws.
+ *
+ * @param {string} [path]
+ * @returns {{ reloaded: boolean, reason?: string, models?: object[], defaultModelId?: string|null }}
+ */
+export function reloadModelsOverlay(path = getDefaultOverlayPath()) {
+  const result = loadModelsOverlayResult(path)
+  if (!result.ok) {
+    // Malformed — keep the last-good registry + pricing untouched.
+    return { reloaded: false, reason: 'malformed' }
+  }
+  defaultOverlay = result.overlay
+  defaultRegistry.applyOverlay(result.overlay)
+  return {
+    reloaded: true,
+    models: defaultRegistry.getModels(),
+    defaultModelId: defaultRegistry.getDefaultModelId(),
+  }
+}
+
+/**
+ * #5932 — watch the overlay file for edits and hot-reload on change. Watches the
+ * containing DIRECTORY (not the file inode) so an editor's atomic
+ * write-temp-then-rename still fires, filters to the overlay filename, and
+ * debounces the burst of events a single save emits. On a successful reload the
+ * `onReload({ models, defaultModelId })` callback fires (the caller broadcasts
+ * `available_models`). A malformed save is ignored (last-good kept, no callback).
+ *
+ * Returns a `{ close() }` handle; call it on daemon shutdown. Never throws — a
+ * watch that can't be established (e.g. unsupported FS) logs a warn and returns
+ * an inert handle (boot-only behavior, unchanged).
+ *
+ * `watchFactory` is injectable for tests (defaults to `fs.watch`); it must
+ * return a watcher with `.close()` and accept `(dir, listener)`.
+ *
+ * @param {{ path?: string, onReload?: (r: object) => void, debounceMs?: number, watchFactory?: Function }} [opts]
+ * @returns {{ close: () => void }}
+ */
+export function watchModelsOverlay({ path = getDefaultOverlayPath(), onReload, debounceMs = 200, watchFactory } = {}) {
+  const dir = dirname(path)
+  const file = basename(path)
+  let timer = null
+  let closed = false
+
+  const fire = () => {
+    timer = null
+    if (closed) return
+    const result = reloadModelsOverlay(path)
+    if (result.reloaded && typeof onReload === 'function') {
+      try { onReload(result) } catch (err) { log.warn(`watchModelsOverlay: onReload threw: ${err?.message || err}`) }
+    }
+  }
+  const trigger = () => {
+    if (closed) return
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(fire, debounceMs)
+  }
+
+  let watcher
+  try {
+    const factory = typeof watchFactory === 'function' ? watchFactory : (d, listener) => fsWatch(d, listener)
+    watcher = factory(dir, (_eventType, changed) => {
+      // Directory watch fires for every entry; only react to our file. A null
+      // filename (some platforms) is treated as "maybe ours" → reload.
+      if (changed == null || basename(String(changed)) === file) trigger()
+    })
+    if (watcher && typeof watcher.on === 'function') {
+      watcher.on('error', (err) => log.warn(`watchModelsOverlay: watcher error: ${err?.message || err}`))
+    }
+  } catch (err) {
+    log.warn(`watchModelsOverlay: could not watch ${dir}: ${err?.message || err} — overlay edits need a restart`)
+    return { close() {} }
+  }
+
+  return {
+    close() {
+      closed = true
+      if (timer) { clearTimeout(timer); timer = null }
+      try { watcher?.close?.() } catch { /* already closed */ }
+    },
+  }
+}
+
+/**
+ * #5932 — test hook: restore the module-level default overlay + registry to a
+ * known state so a test that exercises reloadModelsOverlay() doesn't leak global
+ * mutations into sibling tests. Pass a Map to seed a specific overlay, or omit
+ * for an empty one.
+ */
+export function _resetModelsOverlayForTests(overlay = new Map()) {
+  defaultOverlay = overlay instanceof Map ? overlay : new Map()
+  defaultRegistry.applyOverlay(defaultOverlay)
+}
 
 /**
  * Per-provider registries. Providers that expose static

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -649,6 +649,12 @@ export function createModelsRegistry(hooks = {}) {
   // (AC2) instead of reverting to the bare fallback view. Null until the first
   // SDK refresh (CLI-only / pre-init).
   let lastSdkModels = null
+  // #5932 (PR #5945 review): the last list applied via loadCache(), retained so
+  // an overlay reload in the CLI-only window (cache warmed, no SDK refresh yet)
+  // preserves cache-warmed entries the new fallback doesn't cover (date-suffixed
+  // ids past the family filter) — WITHOUT resurrecting overlay-only rows the
+  // operator removed (those only ever live in fallbackModels, never here).
+  let lastCacheModels = null
   // Snapshot of the last saved cache payload so saveCache() can skip
   // redundant writes. `null` forces the first save to always run.
   let lastSavedSnapshot = null
@@ -760,6 +766,19 @@ export function createModelsRegistry(hooks = {}) {
       fallbackModels = computeFallbackModels(map)
       if (lastSdkModels) {
         registry.updateModels(lastSdkModels)
+      } else if (lastCacheModels) {
+        // Cache-warmed (loadCache) but no SDK refresh yet — apply the new
+        // fallback (base + overlay overrides + overlay-only rows) while
+        // PRESERVING the cache entries it doesn't cover (date-suffixed ids past
+        // the family filter, e.g. `claude-sonnet-4-20250514`). Preserve from the
+        // CACHE list, not `activeModels`, so an overlay-only row the operator
+        // REMOVED still drops (it lives in fallbackModels, never lastCacheModels)
+        // — matched on fullId so an overlay override of a cached/fallback row
+        // still wins (it's in fallbackModels → the cache copy is skipped).
+        const byFullId = new Set(fallbackModels.map((m) => m.fullId))
+        const preserved = lastCacheModels.filter((m) => !byFullId.has(m.fullId))
+        const next = preserved.length > 0 ? Object.freeze([...fallbackModels, ...preserved]) : fallbackModels
+        applyModels(next, defaultModelId)
       } else {
         applyModels(fallbackModels, defaultModelId)
       }
@@ -971,9 +990,11 @@ export function createModelsRegistry(hooks = {}) {
     resetModels() {
       contextWindowOverrides.clear()
       pricingDriftWarned.clear()
-      // #5932: drop the retained SDK list too, so a reset truly returns to the
-      // bare fallback view (a later applyOverlay won't re-merge stale SDK data).
+      // #5932: drop the retained SDK + cache lists too, so a reset truly returns
+      // to the bare fallback view (a later applyOverlay won't re-merge stale
+      // SDK/cache data).
       lastSdkModels = null
+      lastCacheModels = null
       applyModels(fallbackModels, null)
       lastSavedSnapshot = null
     },
@@ -1096,6 +1117,9 @@ export function createModelsRegistry(hooks = {}) {
         if (defaultDiscarded) nextDefault = null
 
         applyModels(models, nextDefault)
+        // #5932: remember the cache-applied list so an overlay reload in the
+        // CLI-only window (no SDK refresh yet) preserves these entries.
+        lastCacheModels = models
         // Treat the loaded state as the last-saved baseline so subsequent
         // saveCache() calls only hit disk when the registry actually drifts.
         lastSavedSnapshot = snapshotString()

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -39,7 +39,7 @@ import { registerDockerProvider, resolveProviderLabel, DEFAULT_PROVIDER } from '
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
 import { getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
-import { loadModelsCache, getModels } from './models.js'
+import { loadModelsCache, getModels, watchModelsOverlay } from './models.js'
 // Imported from a dedicated constants module rather than environment-manager.js
 // so we don't eagerly pull in DockerBackend when environments are disabled —
 // environment-manager.js itself remains behind the dynamic import below
@@ -902,6 +902,18 @@ export async function startCliServer(config) {
   maybeWarnNonLoopbackBind({ bindHost, log })
   wsServer.start(bindHost)
 
+  // #5932: hot-reload the ~/.chroxy/models.json overlay on edit — surfacing a
+  // new model id (or a label/contextWindow/pricing override) is "a config entry,
+  // not a code change", so it must not require a daemon restart. On a successful
+  // reload, re-broadcast `available_models` for the default (Claude) registry so
+  // connected pickers refresh live. A malformed save is ignored (last-good kept).
+  const modelsOverlayWatcher = watchModelsOverlay({
+    onReload: ({ models, defaultModelId }) => {
+      log.info(`Models overlay reloaded: ${models.map((m) => m.id).join(', ')}`)
+      wsServer.broadcast({ type: 'available_models', models, defaultModel: defaultModelId, provider: 'claude-sdk' })
+    },
+  })
+
   // #5821 (live wiring): the billing canary. Recomputes the daemon's billing
   // early-warnings (silent metered default; the dormant claude-tui
   // reclassification tripwire) and broadcasts a `billing_canary` message when
@@ -1135,6 +1147,7 @@ export async function startCliServer(config) {
     pairingManager,
     pushManager,
     billingCanaryMonitor,
+    modelsOverlayWatcher,
     getWorktreeReapTimer: () => worktreeReapTimer,
     emergencyCleanupSync,
     removeConnectionInfo,

--- a/packages/server/src/server-cli/server-orchestrator.js
+++ b/packages/server/src/server-cli/server-orchestrator.js
@@ -33,6 +33,7 @@ export class ServerOrchestrator {
     pairingManager,
     pushManager = null,
     billingCanaryMonitor = null,
+    modelsOverlayWatcher = null,
     getWorktreeReapTimer,
     emergencyCleanupSync,
     removeConnectionInfo = defaultRemoveConnectionInfo,
@@ -51,6 +52,10 @@ export class ServerOrchestrator {
     this._pairingManager = pairingManager
     this._pushManager = pushManager
     this._billingCanaryMonitor = billingCanaryMonitor
+    // #5932: the models.json overlay fs-watcher handle (or null when watching
+    // couldn't be established). Closed on shutdown so the watch doesn't outlive
+    // the daemon.
+    this._modelsOverlayWatcher = modelsOverlayWatcher || null
     this._getWorktreeReapTimer = typeof getWorktreeReapTimer === 'function' ? getWorktreeReapTimer : () => null
     this._emergencyCleanupSync = emergencyCleanupSync
     this._removeConnectionInfo = removeConnectionInfo
@@ -94,6 +99,11 @@ export class ServerOrchestrator {
     // wouldn't block exit, but clearing it avoids a sweep racing shutdown.
     const worktreeReapTimer = this._getWorktreeReapTimer()
     if (worktreeReapTimer) clearInterval(worktreeReapTimer)
+    // #5932: stop watching ~/.chroxy/models.json so the fs-watch doesn't outlive
+    // the daemon. Best-effort — close() never throws but guard anyway.
+    if (this._modelsOverlayWatcher) {
+      try { this._modelsOverlayWatcher.close?.() } catch {}
+    }
     // #5821: stop the billing-canary recompute timer. It's unref'd so it
     // wouldn't block exit, but clearing it avoids a recompute racing shutdown.
     if (this._billingCanaryMonitor) {

--- a/packages/server/tests/models-overlay-reload.test.js
+++ b/packages/server/tests/models-overlay-reload.test.js
@@ -1,0 +1,238 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+import {
+  createModelsRegistry,
+  reloadModelsOverlay,
+  watchModelsOverlay,
+  getModels,
+  _resetModelsOverlayForTests,
+} from '../src/models.js'
+
+/**
+ * #5932 — hot-reload the ~/.chroxy/models.json overlay without a daemon restart.
+ *
+ * Registry-level applyOverlay() is exercised on FRESH registries (no global
+ * mutation); the module-level reloadModelsOverlay() / watchModelsOverlay() touch
+ * the default singleton, so each test that uses them restores it via
+ * _resetModelsOverlayForTests() in afterEach.
+ */
+
+// A minimal non-Claude registry shape so overlay rows are deterministic.
+function makeRegistry() {
+  return createModelsRegistry({
+    fallbackModels: [{ id: 'base', label: 'Base', fullId: 'base-1', contextWindow: 1000 }],
+    deriveId: (id) => id,
+    resolveContextWindow: () => 4242,
+  })
+}
+
+function overlayMap(obj) {
+  const m = new Map()
+  for (const [fullId, v] of Object.entries(obj)) m.set(fullId, { fullId, ...v })
+  return m
+}
+
+describe('registry.applyOverlay (#5932)', () => {
+  it('adds an overlay-only model to the active list (no SDK data)', () => {
+    const reg = makeRegistry()
+    assert.equal(reg.getModels().some((m) => m.fullId === 'fable-9'), false)
+
+    reg.applyOverlay(overlayMap({ 'fable-9': { shortId: 'fable', label: 'Fable' } }))
+
+    const fable = reg.getModels().find((m) => m.fullId === 'fable-9')
+    assert.ok(fable, 'overlay-only model appears after applyOverlay')
+    assert.equal(fable.id, 'fable')
+    assert.equal(fable.label, 'Fable')
+    // resolves both ways + lands in the allowlist
+    assert.equal(reg.resolveModelId('fable'), 'fable-9')
+    assert.ok(reg.getAllowedModelIds().has('fable-9'))
+  })
+
+  it('overrides a base row label/contextWindow from the overlay', () => {
+    const reg = makeRegistry()
+    reg.applyOverlay(overlayMap({ 'base-1': { label: 'Renamed', contextWindow: 99000 } }))
+    const base = reg.getModels().find((m) => m.fullId === 'base-1')
+    assert.equal(base.label, 'Renamed')
+    assert.equal(base.contextWindow, 99000)
+  })
+
+  it('re-merges with the live SDK list (AC2) — SDK models survive, overlay-only appears', () => {
+    const reg = makeRegistry()
+    // SDK reports one model.
+    reg.updateModels([{ value: 'sdk-7', displayName: 'Default (SDK Seven)', description: '' }])
+    assert.ok(reg.getModels().some((m) => m.fullId === 'sdk-7'))
+
+    // Operator adds an overlay model and hot-reloads.
+    reg.applyOverlay(overlayMap({ 'fable-9': { shortId: 'fable', label: 'Fable' } }))
+
+    const ids = reg.getModels().map((m) => m.fullId)
+    assert.ok(ids.includes('sdk-7'), 'SDK model preserved across overlay reload')
+    assert.ok(ids.includes('fable-9'), 'overlay-only model merged in')
+    assert.equal(reg.getDefaultModelId(), 'sdk-7', 'SDK-derived default preserved')
+  })
+
+  it('removing an overlay entry on reload drops the overlay-only model', () => {
+    const reg = makeRegistry()
+    reg.applyOverlay(overlayMap({ 'fable-9': { shortId: 'fable' } }))
+    assert.ok(reg.getModels().some((m) => m.fullId === 'fable-9'))
+    // Reload with an empty overlay (operator deleted the entry).
+    reg.applyOverlay(new Map())
+    assert.equal(reg.getModels().some((m) => m.fullId === 'fable-9'), false)
+  })
+
+  it('treats a non-Map argument as an empty overlay (no throw)', () => {
+    const reg = makeRegistry()
+    assert.doesNotThrow(() => reg.applyOverlay(undefined))
+    assert.equal(reg.getModels().some((m) => m.fullId === 'fable-9'), false)
+  })
+})
+
+describe('reloadModelsOverlay (#5932)', () => {
+  let dir, path
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'overlay-reload-'))
+    path = join(dir, 'models.json')
+  })
+  afterEach(() => {
+    _resetModelsOverlayForTests() // restore the global singleton for sibling tests
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reloads a valid overlay into the default registry', () => {
+    writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9', label: 'Acme Nine' } }))
+    const res = reloadModelsOverlay(path)
+    assert.equal(res.reloaded, true)
+    assert.ok(res.models.some((m) => m.fullId === 'acme-overlay-test-9'), 'reloaded model is in the broadcast list')
+  })
+
+  it('keeps the last-good set when the overlay is malformed (AC3)', () => {
+    // Seed a good overlay first.
+    writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9', label: 'Acme Nine' } }))
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+
+    // Now corrupt the file and reload — must be rejected, last-good kept.
+    writeFileSync(path, '{ this is not valid json ')
+    const res = reloadModelsOverlay(path)
+    assert.equal(res.reloaded, false)
+    assert.equal(res.reason, 'malformed')
+    // The default registry still carries the previously-loaded model.
+    assert.ok(getModels().some((m) => m.fullId === 'acme-overlay-test-9'), 'last-good overlay kept on malformed reload')
+  })
+
+  it('rejects a non-object JSON root (array) as malformed', () => {
+    writeFileSync(path, JSON.stringify(['not', 'an', 'object']))
+    const res = reloadModelsOverlay(path)
+    assert.equal(res.reloaded, false)
+    assert.equal(res.reason, 'malformed')
+  })
+
+  it('clears the overlay when the file is absent/deleted (explicit operator action)', () => {
+    writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9' } }))
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+    unlinkSync(path)
+    const res = reloadModelsOverlay(path)
+    assert.equal(res.reloaded, true)
+    assert.equal(res.models.some((m) => m.fullId === 'acme-overlay-test-9'), false, 'deleted overlay clears the model')
+  })
+})
+
+describe('watchModelsOverlay (#5932)', () => {
+  let dir, path
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'overlay-watch-'))
+    path = join(dir, 'models.json')
+  })
+  afterEach(() => {
+    _resetModelsOverlayForTests()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // A fake fs.watch: an EventEmitter with a .close() that the listener is wired
+  // to, so the test can drive change events deterministically (no real fs.watch
+  // timing flakiness).
+  function fakeWatchFactory() {
+    const emitter = new EventEmitter()
+    let listener = null
+    const factory = (_dir, cb) => {
+      listener = cb
+      const watcher = new EventEmitter()
+      watcher.close = mock.fn()
+      emitter.on('change', (file) => listener('change', file))
+      watcher._emitter = emitter
+      return watcher
+    }
+    factory.emit = (file) => emitter.emit('change', file)
+    return factory
+  }
+
+  it('reloads + fires onReload on a debounced change to the overlay file', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    try {
+      writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9', label: 'Acme Nine' } }))
+      const calls = []
+      const factory = fakeWatchFactory()
+      const handle = watchModelsOverlay({
+        path,
+        debounceMs: 200,
+        watchFactory: factory,
+        onReload: (r) => calls.push(r),
+      })
+
+      // Two rapid change events for our file — should debounce to one reload.
+      factory.emit('models.json')
+      factory.emit('models.json')
+      assert.equal(calls.length, 0, 'no reload before the debounce window elapses')
+      mock.timers.tick(200)
+
+      assert.equal(calls.length, 1, 'exactly one reload after debounce')
+      assert.ok(calls[0].models.some((m) => m.fullId === 'acme-overlay-test-9'))
+      handle.close()
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('ignores change events for OTHER files in the directory', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    try {
+      writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9' } }))
+      const calls = []
+      const factory = fakeWatchFactory()
+      watchModelsOverlay({ path, debounceMs: 50, watchFactory: factory, onReload: (r) => calls.push(r) })
+      factory.emit('something-else.json')
+      mock.timers.tick(50)
+      assert.equal(calls.length, 0, 'a change to an unrelated file must not trigger a reload')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('does not fire onReload after close()', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    try {
+      writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9' } }))
+      const calls = []
+      const factory = fakeWatchFactory()
+      const handle = watchModelsOverlay({ path, debounceMs: 50, watchFactory: factory, onReload: (r) => calls.push(r) })
+      factory.emit('models.json')
+      handle.close()
+      mock.timers.tick(50)
+      assert.equal(calls.length, 0, 'a pending reload is cancelled by close()')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('returns an inert handle (no throw) when the watcher cannot be established', () => {
+    const throwingFactory = () => { throw new Error('ENOSYS: fs.watch unsupported') }
+    let handle
+    assert.doesNotThrow(() => {
+      handle = watchModelsOverlay({ path, watchFactory: throwingFactory })
+    })
+    assert.doesNotThrow(() => handle.close())
+  })
+})

--- a/packages/server/tests/models-overlay-reload.test.js
+++ b/packages/server/tests/models-overlay-reload.test.js
@@ -89,6 +89,34 @@ describe('registry.applyOverlay (#5932)', () => {
     assert.doesNotThrow(() => reg.applyOverlay(undefined))
     assert.equal(reg.getModels().some((m) => m.fullId === 'fable-9'), false)
   })
+
+  it('preserves cache-warmed (non-fallback) models on reload before any SDK refresh (#5945 review)', () => {
+    // A default-shaped Claude registry whose family filter recognises a
+    // date-suffixed sonnet id, then warm it from a disk cache (no updateModels
+    // → lastSdkModels stays null, the CLI-only window).
+    const reg = createModelsRegistry()
+    const dir = mkdtempSync(join(tmpdir(), 'overlay-cache-'))
+    const cachePath = join(dir, 'cache.json')
+    try {
+      writeFileSync(cachePath, JSON.stringify({
+        models: [
+          { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-20250514', contextWindow: 200000 },
+        ],
+        defaultModelId: 'sonnet',
+      }))
+      assert.equal(reg.loadCache(cachePath), true)
+      assert.ok(reg.getModels().some((m) => m.fullId === 'claude-sonnet-4-20250514'), 'cache-warmed model present')
+
+      // Operator edits the overlay (adds a custom model) — reload must NOT drop
+      // the cache-warmed date-suffixed entry.
+      reg.applyOverlay(overlayMap({ 'acme-9': { shortId: 'acme9', label: 'Acme' } }))
+      const ids = reg.getModels().map((m) => m.fullId)
+      assert.ok(ids.includes('claude-sonnet-4-20250514'), 'cache-warmed model survives overlay reload')
+      assert.ok(ids.includes('acme-9'), 'overlay-only model added')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('reloadModelsOverlay (#5932)', () => {

--- a/packages/server/tests/models-overlay-reload.test.js
+++ b/packages/server/tests/models-overlay-reload.test.js
@@ -158,6 +158,16 @@ describe('reloadModelsOverlay (#5932)', () => {
     assert.equal(res.reason, 'malformed')
   })
 
+  it('keeps last-good on a non-ENOENT read error (e.g. EISDIR) — does NOT clear (Copilot #5945)', () => {
+    // Seed a good overlay.
+    writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9' } }))
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+    // Reload pointing at the DIRECTORY → readFileSync throws EISDIR (not ENOENT).
+    const res = reloadModelsOverlay(dir)
+    assert.equal(res.reloaded, false, 'a transient/non-ENOENT read error must not clear the overlay')
+    assert.ok(getModels().some((m) => m.fullId === 'acme-overlay-test-9'), 'last-good overlay kept on read error')
+  })
+
   it('clears the overlay when the file is absent/deleted (explicit operator action)', () => {
     writeFileSync(path, JSON.stringify({ 'acme-overlay-test-9': { shortId: 'acme9' } }))
     assert.equal(reloadModelsOverlay(path).reloaded, true)


### PR DESCRIPTION
## Summary

The user model overlay (`~/.chroxy/models.json`) was loaded **once at boot**, so surfacing a new model id (or overriding a label/contextWindow/pricing) — "a config entry, not a code change" — required a daemon restart. This makes it hot-reload live. Part of #5631. Closes #5932.

## Design (testable core + thin glue)
- **`loadModelsOverlayResult`** — a loader variant returning `{ ok, overlay }` so a reload can distinguish **malformed** (keep last-good) from **absent** (legit clear). The boot-time `loadModelsOverlay` wraps it (malformed→empty, unchanged).
- **`registry.applyOverlay(newOverlay)`** — re-folds the overlay into the fallback set and **re-merges with the retained live SDK list** (`lastSdkModels`) so SDK-derived models + `contextWindow` overrides survive (**AC2**), *without* rebuilding the registry. The fold is extracted to `computeFallbackModels`; `fallbackModels` is now reassignable; `resetModels` drops the retained SDK list.
- **`reloadModelsOverlay(path)`** — swaps the module-level (now `let`) `defaultOverlay` so `getModelPricing()` picks up new pricing, applies to the default registry, and returns the new models/default for the caller to broadcast. Malformed → `{ reloaded: false }` (**AC3**); deleted → clears.
- **`watchModelsOverlay()`** — watches the config **directory** (robust to editors' atomic write-temp-then-rename), filters to the overlay filename, debounces, reloads, fires `onReload`. Injectable `watchFactory` for deterministic tests; inert handle on watch failure.
- **server-cli** starts the watcher → re-broadcasts `available_models` on reload; the **orchestrator** closes it on shutdown.

## Acceptance criteria
- [x] Editing `~/.chroxy/models.json` is reflected without restarting (fs-watch on the dir + debounce).
- [x] The reload re-merges with SDK-derived models and re-broadcasts the model list (`available_models`, provider `claude-sdk`).
- [x] Malformed overlay on reload keeps the last-good set + warns, never crashes (`loadModelsOverlayResult.ok === false`).
- [x] Tests for the reload + bad-file path.

## Testing
New `tests/models-overlay-reload.test.js` (13 tests): registry `applyOverlay` (overlay-only add / base override / **SDK re-merge** / removal / non-Map), `reloadModelsOverlay` (valid / **malformed-keeps-last-good** / array-root / deleted-clears), `watchModelsOverlay` (debounced reload, filename filter, close-cancels, inert-on-failure — all via an injected fake watcher + mocked timers). Full models + cost + orchestrator suites green (226 tests). eslint + logger lint clean.

## Risk note
Touches the cost-calc-adjacent model registry (memory flags this area fragile, #4054/#5631). Mitigations: the overlay fold is *extracted, not rewritten* (byte-identical logic, re-used at boot and reload); SDK data is **preserved** via `lastSdkModels` rather than discarded; malformed reloads are **rejected** (last-good kept); the singleton mutation is behind a tested `applyOverlay` + a `_resetModelsOverlayForTests` hook so tests don't leak global state.