### PR TITLE
feat(server): warn on unknown keys in k8s/billing/worktreeGc/rancher config (#5878)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -287,6 +287,55 @@ const RANCHER_CLUSTER_ID_RE = /^c-[a-z0-9-]+$/
 const RANCHER_PROJECT_ID_RE = /^p-[a-z0-9-]+$/
 
 /**
+ * #5878 (audit P2-6 part 2): warn on unrecognised keys in a config sub-block so
+ * a typo (`billing.creditTeir`, `worktreeGc.autoRepa`, `k8s.imagePulPolicy`)
+ * surfaces a non-fatal warning instead of being silently dropped. Factored from
+ * the existing `notifications.discord` unknown-key loop (#5453).
+ *
+ * Iterates own enumerable keys; a key absent from `knownSet` pushes an
+ * "Invalid value … unknown key" warning (the NON-fatal wording — the CLI layer
+ * escalates only "Invalid type" prefixes, so a cosmetic typo can never fail
+ * startup). The "supported:" hint lists `supportedKeys` (defaults to `knownSet`)
+ * so a block whose known set includes allowed-but-not-advertised keys (e.g.
+ * discord's secret keys, which get their own pointed warning) doesn't surface
+ * them as suggestions.
+ *
+ * @param {object} obj - the sub-block (already known to be a plain object)
+ * @param {Set<string>} knownSet - recognised keys (no warning)
+ * @param {string} prefix - dotted path for the message (e.g. 'environments.k8s')
+ * @param {string[]} warnings - accumulator
+ * @param {Set<string>|string[]} [supportedKeys] - keys to list in the hint
+ */
+function warnUnknownKeys(obj, knownSet, prefix, warnings, supportedKeys = knownSet) {
+  const hint = [...supportedKeys].join(', ')
+  for (const key of Object.keys(obj)) {
+    if (knownSet.has(key)) continue
+    warnings.push(`Invalid value for '${prefix}.${key}': unknown key (supported: ${hint})`)
+  }
+}
+
+// #5878: recognised keys per advanced/enterprise config sub-block. Each set is
+// the UNION of what the validator checks AND what the wiring layer
+// (createEnvironmentBackend / server-cli / the reaper) forwards to the consumer
+// — a key the consumer reads but the validator omits would otherwise false-warn.
+// Verified against the consumers: K8sBackend wiring (config.js ~1385-1394) +
+// the `workspace` sub-block (#4556); billing-budget.js + billing-canary-monitor;
+// worktree-reaper.js; rancher.js + resolveRancherToken.
+const K8S_SUPPORTED_KEYS = new Set([
+  'namespace', 'inCluster', 'kubeconfigPath', 'sidecarImage', 'imagePullPolicy',
+  'connectMode', 'namespaceQuota', 'namespaceLimitRange', 'workspace',
+])
+const BILLING_SUPPORTED_KEYS = new Set([
+  'creditTier', 'monthlyCreditBudgetUsd', 'budgetWarningPercent', 'egressCheck', 'datacenterPrefixes',
+])
+const WORKTREE_GC_SUPPORTED_KEYS = new Set([
+  'autoReap', 'reapIntervalMs', 'maxLockAgeMs',
+])
+const RANCHER_SUPPORTED_KEYS = new Set([
+  'rancherUrl', 'clusterId', 'token', 'tokenEnv', 'tokenFile', 'caData', 'skipTLSVerify', 'defaultProjectId',
+])
+
+/**
  * #5144: validate the `environments.k8s` connection sub-block at config-load
  * time. The `workspace` sub-block has its own validation (#4556); this covers
  * the remaining fields the wiring layer forwards to `K8sBackend`. Every field
@@ -328,6 +377,9 @@ function validateK8sBlock(k8s, warnings) {
       )
     }
   }
+  // #5878: typo-catch. `workspace` IS recognised (validated separately at the
+  // call site, #4556), so it's in the known set — only genuine unknowns warn.
+  warnUnknownKeys(k8s, K8S_SUPPORTED_KEYS, 'environments.k8s', warnings)
 }
 
 /**
@@ -356,6 +408,10 @@ function validateRancherBlock(rancher, warnings) {
     )
     return
   }
+
+  // #5878: typo-catch — runs BEFORE the "configured" gate below so an unknown
+  // key warns even in a half-filled-in block.
+  warnUnknownKeys(rancher, RANCHER_SUPPORTED_KEYS, 'environments.rancher', warnings)
 
   const { rancherUrl, clusterId, token, tokenEnv, tokenFile, caData, skipTLSVerify, defaultProjectId } = rancher
 
@@ -523,6 +579,8 @@ function validateBillingBlock(billing, warnings) {
       warnings.push(`Invalid value for 'billing.datacenterPrefixes': expected an array of non-empty strings, got ${JSON.stringify(v)}`)
     }
   }
+  // #5878: typo-catch for the billing knobs.
+  warnUnknownKeys(billing, BILLING_SUPPORTED_KEYS, 'billing', warnings)
 }
 
 function validateDiscordNotificationsBlock(discord, warnings) {
@@ -616,12 +674,18 @@ function validateDiscordNotificationsBlock(discord, warnings) {
 
   // #5453: warn on any unrecognised key. A typo'd knob is silently ignored
   // (operator gets default behavior with no hint), and a test-seam key spread
-  // into the sink constructor fails it closed — both silent foot-guns. Skip the
-  // secret keys, which already got their specific "it's a secret" warning above.
-  for (const key of Object.keys(discord)) {
-    if (DISCORD_SUPPORTED_KEYS.has(key) || DISCORD_SECRET_KEYS.includes(key)) continue
-    warnings.push(`Invalid value for 'notifications.discord.${key}': unknown key (supported: ${[...DISCORD_SUPPORTED_KEYS].join(', ')})`)
-  }
+  // into the sink constructor fails it closed — both silent foot-guns. The
+  // secret keys are KNOWN (no unknown-key warning — they already got their
+  // specific "it's a secret" warning above) but are NOT advertised in the
+  // "supported:" hint, so warnUnknownKeys takes the union as the known set and
+  // DISCORD_SUPPORTED_KEYS as the hint. #5878: factored onto the shared helper.
+  warnUnknownKeys(
+    discord,
+    new Set([...DISCORD_SUPPORTED_KEYS, ...DISCORD_SECRET_KEYS]),
+    'notifications.discord',
+    warnings,
+    DISCORD_SUPPORTED_KEYS,
+  )
 }
 
 /**
@@ -949,6 +1013,8 @@ export function validateConfig(config, verbose = false) {
           warnings.push(`Invalid value for 'worktreeGc.maxLockAgeMs': expected a non-negative number (0 disables), got ${typeof v === 'number' ? v : typeof v}`)
         }
       }
+      // #5878: typo-catch for the worktree-GC knobs.
+      warnUnknownKeys(config.worktreeGc, WORKTREE_GC_SUPPORTED_KEYS, 'worktreeGc', warnings)
     }
   }
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -318,9 +318,11 @@ function warnUnknownKeys(obj, knownSet, prefix, warnings, supportedKeys = knownS
 // the UNION of what the validator checks AND what the wiring layer
 // (createEnvironmentBackend / server-cli / the reaper) forwards to the consumer
 // — a key the consumer reads but the validator omits would otherwise false-warn.
-// Verified against the consumers: K8sBackend wiring (config.js ~1385-1394) +
-// the `workspace` sub-block (#4556); billing-budget.js + billing-canary-monitor;
-// worktree-reaper.js; rancher.js + resolveRancherToken.
+// Verified against the consumers: the K8sBackend wiring in
+// createEnvironmentBackend (the `new K8sBackend({...})` field list) + the
+// `workspace` sub-block (#4556); billing-budget.js + billing-canary (egressCheck
+// / datacenterPrefixes via server-cli); worktree-reaper.js; rancher.js (the
+// RancherBackend ctor) + resolveRancherToken (tokenEnv / tokenFile).
 const K8S_SUPPORTED_KEYS = new Set([
   'namespace', 'inCluster', 'kubeconfigPath', 'sidecarImage', 'imagePullPolicy',
   'connectMode', 'namespaceQuota', 'namespaceLimitRange', 'workspace',

--- a/packages/server/tests/config-unknown-keys.test.js
+++ b/packages/server/tests/config-unknown-keys.test.js
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateConfig } from '../src/config.js'
+
+/**
+ * #5878 (audit P2-6 part 2): validateConfig now warns on unrecognised keys in
+ * the k8s / billing / worktreeGc / rancher blocks (mirroring the existing
+ * notifications.discord typo-catch), so `billing.creditTeir`,
+ * `worktreeGc.autoRepa`, `k8s.imagePulPolicy`, `rancher.clustreId` surface a
+ * NON-FATAL warning instead of being silently dropped.
+ *
+ * The known-key sets were verified against the consumers (K8sBackend wiring +
+ * the workspace sub-block, billing-budget/canary, worktree-reaper, rancher.js),
+ * so the "every real key accepted" assertions are the regression guard against a
+ * too-narrow set false-warning on a working config.
+ */
+
+function warningsFor(config, includes) {
+  return validateConfig(config).warnings.filter((w) => w.includes(includes))
+}
+
+describe('validateConfig — unknown-key typo-catch (#5878)', () => {
+  describe('environments.k8s', () => {
+    it('warns on a typo and uses non-fatal "Invalid value … unknown key" wording', () => {
+      const ws = warningsFor({ environments: { k8s: { imagePulPolicy: 'Always' } } }, 'environments.k8s.imagePulPolicy')
+      assert.equal(ws.length, 1)
+      assert.match(ws[0], /^Invalid value for 'environments\.k8s\.imagePulPolicy': unknown key/)
+      assert.doesNotMatch(ws[0], /Invalid type/)
+    })
+
+    it('accepts every real key without an unknown-key warning (incl. workspace + quota blocks)', () => {
+      const cfg = {
+        environments: {
+          k8s: {
+            namespace: 'ns', inCluster: true, kubeconfigPath: '/k', sidecarImage: 'img:1',
+            imagePullPolicy: 'IfNotPresent', connectMode: 'portforward',
+            namespaceQuota: { hard: {} }, namespaceLimitRange: { default: {} },
+            workspace: { claimName: 'pvc-1', mountPath: '/w', readOnly: true },
+          },
+        },
+      }
+      const unknown = validateConfig(cfg).warnings.filter((w) => w.includes('unknown key') && w.includes('environments.k8s'))
+      assert.deepEqual(unknown, [], 'no real k8s key should warn as unknown')
+    })
+  })
+
+  describe('billing', () => {
+    it('warns on a typo (creditTeir)', () => {
+      const ws = warningsFor({ billing: { creditTeir: 'pro' } }, 'billing.creditTeir')
+      assert.equal(ws.length, 1)
+      assert.match(ws[0], /unknown key/)
+    })
+
+    it('accepts every real key (incl. egressCheck / datacenterPrefixes)', () => {
+      const cfg = {
+        billing: {
+          creditTier: 'max5x', monthlyCreditBudgetUsd: 50, budgetWarningPercent: 75,
+          egressCheck: true, datacenterPrefixes: ['1.2.3.0/24'],
+        },
+      }
+      const unknown = validateConfig(cfg).warnings.filter((w) => w.includes('unknown key') && w.includes('billing.'))
+      assert.deepEqual(unknown, [])
+    })
+  })
+
+  describe('worktreeGc', () => {
+    it('warns on a typo (autoRepa)', () => {
+      const ws = warningsFor({ worktreeGc: { autoRepa: true } }, 'worktreeGc.autoRepa')
+      assert.equal(ws.length, 1)
+      assert.match(ws[0], /unknown key/)
+    })
+
+    it('accepts every real key (autoReap / reapIntervalMs / maxLockAgeMs)', () => {
+      const cfg = { worktreeGc: { autoReap: true, reapIntervalMs: 60000, maxLockAgeMs: 0 } }
+      const unknown = validateConfig(cfg).warnings.filter((w) => w.includes('unknown key') && w.includes('worktreeGc.'))
+      assert.deepEqual(unknown, [])
+    })
+  })
+
+  describe('environments.rancher', () => {
+    it('warns on a typo even in a half-filled (not-yet-configured) block', () => {
+      // No token source → "not configured" gate; the unknown-key check still runs.
+      const ws = warningsFor({ environments: { rancher: { clustreId: 'c-abc' } } }, 'environments.rancher.clustreId')
+      assert.equal(ws.length, 1)
+      assert.match(ws[0], /unknown key/)
+    })
+
+    it('accepts every real key (all 8 connection/token fields)', () => {
+      const cfg = {
+        environments: {
+          rancher: {
+            rancherUrl: 'https://rancher.example.com', clusterId: 'c-abc123',
+            token: 'tok', tokenEnv: 'RANCHER_TOKEN', tokenFile: '/run/tok',
+            caData: 'YWJj', skipTLSVerify: false, defaultProjectId: 'p-xyz789',
+          },
+        },
+      }
+      const unknown = validateConfig(cfg).warnings.filter((w) => w.includes('unknown key') && w.includes('environments.rancher'))
+      assert.deepEqual(unknown, [])
+    })
+  })
+
+  it('a cosmetic typo in any block never throws (non-fatal)', () => {
+    assert.doesNotThrow(() => validateConfig({
+      billing: { creditTeir: 'x' },
+      worktreeGc: { autoRepa: true },
+      environments: { k8s: { imagePulPolicy: 'x' }, rancher: { clustreId: 'c-1' } },
+    }))
+  })
+})


### PR DESCRIPTION
## Summary

Second half of audit **P2-6** (the `validateRange` half landed separately). Unknown-key ("typo") rejection was inconsistent: the top-level loop and `notifications.discord` warned on unrecognised keys, but `environments.k8s`, `billing`, `worktreeGc`, and `environments.rancher` **silently accepted typos** — `billing.creditTeir`, `worktreeGc.autoRepa`, `k8s.imagePulPolicy`, `rancher.clustreId` passed validation and were dropped. Closes #5878.

## What changed
- **`warnUnknownKeys(obj, knownSet, prefix, warnings, supportedKeys?)`** factored from the existing discord unknown-key loop; the discord block is refactored onto it. The optional `supportedKeys` keeps the discord **secret** keys out of the "supported:" hint while still treating them as known — preserving the exact existing discord message.
- Applied to the four blocks with **explicit known-key Sets verified against the CONSUMERS**, not just the validator (a key the consumer reads but the validator omits would false-warn on a working config):
  - **k8s** — `K8sBackend` wiring (`config.js` ~1385-1394) **+ the `workspace` sub-block** (#4556): `namespace, inCluster, kubeconfigPath, sidecarImage, imagePullPolicy, connectMode, namespaceQuota, namespaceLimitRange, workspace`
  - **billing** — `billing-budget.js` + `billing-canary-monitor.js`: `creditTier, monthlyCreditBudgetUsd, budgetWarningPercent, egressCheck, datacenterPrefixes`
  - **worktreeGc** — `worktree-reaper.js`: `autoReap, reapIntervalMs, maxLockAgeMs`
  - **rancher** — `rancher.js` + `resolveRancherToken`: `rancherUrl, clusterId, token, tokenEnv, tokenFile, caData, skipTLSVerify, defaultProjectId`
- Rancher's check runs **before** its "configured" gate so a typo warns even in a half-filled block. All warnings use the **non-fatal** `Invalid value … unknown key` wording (never `Invalid type`), so a cosmetic typo never aborts startup.

## Acceptance criteria
- [x] `warnUnknownKeys` helper; discord block refactored onto it.
- [x] Applied to k8s / billing / worktreeGc / rancher with explicit known-key sets.
- [x] Non-fatal `Invalid value … unknown key` wording (never `Invalid type`).
- [x] Tests: a typo in each block warns; every real key is accepted without warning.

## Testing
New `tests/config-unknown-keys.test.js` (9 tests) — per-block typo-warns + full-real-key-set accepted (the regression guard against a too-narrow set) + non-fatal-never-throws. Full config suite green (218 tests, discord refactor behavior-preserving). eslint + logger lint clean.

## Note on accuracy
The known-key sets are the load-bearing risk (a missing key = false warning on a real config). They were enumerated from the runtime consumers and double-checked at the exact wiring sites (e.g. confirmed `environments.k8s.workspace` is a real validated sub-block, and `billing.egressCheck`/`datacenterPrefixes` are read by the canary).