### PR TITLE
refactor(server): consolidate model metadata into one MODEL_METADATA registry (#5930)

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -67,63 +67,113 @@ export function claudeDeriveId(fullId) {
   return typeof fullId === 'string' && fullId.startsWith('claude-') ? fullId.slice(7) : fullId
 }
 
-// Minimal fallback used only when the SDK has never responded and no disk
-// cache exists. Short aliases (sonnet/opus/haiku) resolve to the latest
-// version in the claude CLI, so these entries stay valid across releases.
-// Dated full IDs are intentionally avoided here — the SDK's supportedModels()
-// is the source of truth for concrete version identifiers.
+// Single source of truth for Claude model metadata (#5930 / #5631 DRY core).
+// Each row describes one known Claude model family head; the two scattered
+// data tables below — FALLBACK_MODELS (cold-start / SDK-merge seed) and
+// CLAUDE_PRICING_USD_PER_MTOK (per-fullId billing rates) — are DERIVED from
+// this array, so adding a model is a single-row edit instead of edits in
+// several hand-synced places. The regex/string heuristics
+// (resolveClaudeContextWindow, humanizeModelId) intentionally stay separate:
+// they are the graceful-degradation path for models NOT in this table.
 //
-// These also seed the merge step in `updateModels()` so that a stale or
-// minimal SDK response (e.g. only reporting 4.6 models) still surfaces the
-// newer 4.7 chip in the picker (#3075).
+// Per-row fields:
+//   shortId, label, fullId — the FALLBACK_MODELS triple. Short aliases
+//     (sonnet/opus/haiku) resolve to the latest version in the claude CLI, so
+//     undated full IDs are used on purpose — the SDK's supportedModels() is the
+//     source of truth for concrete version identifiers, and these rows also
+//     seed the merge step in updateModels() so a stale/minimal SDK response
+//     still surfaces the newer chip in the picker (#3075).
+//   contextWindow — OPTIONAL. When set it overrides the cold-start heuristic
+//     for that known model (symmetric with the on-disk overlay in
+//     computeFallbackModels); when absent (the case for every row today) it is
+//     derived via resolveClaudeContextWindow(fullId), so the derivation is
+//     byte-identical to the prior FALLBACK_MODELS literals.
+//   pricing — base Anthropic rates in USD per million tokens
+//     {input, output, cacheRead, cacheWrite}. ABSENT (e.g. fable, shipped
+//     without verified pricing) emits NO pricing key, so resolveModelPricing
+//     returns null — never $0 — for it.
+//   oneM — the `[1m]` long-context variant's rates, including the `longContext`
+//     premium block (#4087). ABSENT emits no `<fullId>[1m]` pricing key. Kept a
+//     sibling of `pricing` so a [1m] form can carry distinct base rates.
 //
-// Deep-frozen so callers of getModels() can't mutate the module-level constant
-// via the returned array reference.
-export const FALLBACK_MODELS = Object.freeze([
-  Object.freeze({ id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: resolveClaudeContextWindow('claude-sonnet-4-6') }),
-  Object.freeze({ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: resolveClaudeContextWindow('claude-opus-4-7') }),
-  // Fable falls through to the 200k DEFAULT_CONTEXT_WINDOW heuristic on
-  // purpose — the SDK's authoritative modelUsage.contextWindow ratchets it
-  // after the first turn; we don't invent a fable window here.
-  Object.freeze({ id: 'fable', label: 'Fable', fullId: 'claude-fable-5', contextWindow: resolveClaudeContextWindow('claude-fable-5') }),
-  Object.freeze({ id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: resolveClaudeContextWindow('claude-haiku-4-5') }),
+// Cache-write rates are the 5-minute ephemeral tier (the default; chroxy
+// doesn't opt into the pricier 1-hour tier). Source: Anthropic public pricing
+// page — keep rates in sync on every model change; wrong numbers mislead
+// cumulative-cost displays (#4054). The models.test.js snapshot pins the
+// derived tables to literals, so any rate drift OR derivation regression fails
+// loudly.
+const MODEL_METADATA = Object.freeze([
+  Object.freeze({
+    shortId: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6',
+    pricing: { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
+  }),
+  Object.freeze({
+    shortId: 'opus', label: 'Opus', fullId: 'claude-opus-4-7',
+    pricing: { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+    // #4087 — long-context (>200K input) premium tier. Below the 200K
+    // threshold the rates match the base entry; above it the published premium
+    // is a uniform 2× across all four rates. Today only Opus 4.x has a 1M
+    // variant in chroxy's set (resolveClaudeContextWindow). Verify against the
+    // Anthropic pricing page on the next periodic check.
+    oneM: {
+      input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
+      longContext: {
+        thresholdInputTokens: 200_000,
+        input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
+      },
+    },
+  }),
+  // Fable falls through to the 200k DEFAULT_CONTEXT_WINDOW heuristic on purpose
+  // — the SDK's authoritative modelUsage.contextWindow ratchets it after the
+  // first turn; we don't invent a fable window here. No `pricing` block: chroxy
+  // doesn't ship unverified fable rates, so it costs "unknown" (null), not $0.
+  Object.freeze({
+    shortId: 'fable', label: 'Fable', fullId: 'claude-fable-5',
+  }),
+  Object.freeze({
+    shortId: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5',
+    pricing: { input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 },
+  }),
 ])
 
-// Public Anthropic pricing in USD per million tokens. Cache-write is the
-// 5-minute ephemeral tier (the default; the 1-hour tier costs more but
-// chroxy doesn't opt into it). Source: Anthropic public pricing page —
-// keep this table in sync when prices change. Numbers wrong here mean
-// cumulative-cost displays mislead users (#4054), so revisit on every
-// model addition.
-//
-// #4087 — long-context (>200K input) premium tier: Anthropic charges a
-// higher rate when the total input (input + cache reads + cache writes)
-// exceeds 200K tokens on the `[1m]` long-context variant. The
-// `longContext` block on the `[1m]` entry captures the premium rates;
-// `computePromptCostUsd` selects between base and longContext rates
-// based on the turn's total input tokens.
-//
-// Today, only Opus 4.x has a 1M-context variant in chroxy's model set
-// (resolveClaudeContextWindow above). Sonnet 4.6 and Haiku 4.5 don't
-// have `[1m]` forms, so their entries have no longContext block.
-const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze({
-  'claude-sonnet-4-6': Object.freeze({ input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 }),
-  'claude-opus-4-7':   Object.freeze({ input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 }),
-  'claude-opus-4-7[1m]': Object.freeze({
-    // Below the 200K threshold the rates match the default-window entry.
-    input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
-    // Above 200K input the published premium is a uniform 2× across all
-    // four rates (input, output, cacheRead, cacheWrite). Verify against
-    // the Anthropic pricing page on the next periodic check — the
-    // numbers are public but easy to drift. Test in `models.test.js`
-    // pins the exact literals so a drift fails loudly.
-    longContext: Object.freeze({
-      thresholdInputTokens: 200_000,
-      input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
-    }),
-  }),
-  'claude-haiku-4-5':  Object.freeze({ input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 }),
-})
+// Freeze a pricing block (incl. the nested longContext premium) in place so the
+// derived CLAUDE_PRICING_USD_PER_MTOK keeps the deep-frozen contract callers
+// relied on when the rates were hand-authored as Object.freeze literals.
+function deepFreezePricing(rates) {
+  if (rates && typeof rates === 'object') {
+    for (const v of Object.values(rates)) {
+      if (v && typeof v === 'object') Object.freeze(v)
+    }
+    Object.freeze(rates)
+  }
+  return rates
+}
+
+// Minimal fallback used only when the SDK has never responded and no disk cache
+// exists. Derived from MODEL_METADATA (source order preserved). Deep-frozen so
+// callers of getModels() can't mutate the module-level constant via the
+// returned array reference.
+export const FALLBACK_MODELS = Object.freeze(
+  MODEL_METADATA.map((m) => Object.freeze({
+    id: m.shortId,
+    label: m.label,
+    fullId: m.fullId,
+    contextWindow: m.contextWindow ?? resolveClaudeContextWindow(m.fullId),
+  })),
+)
+
+// Public Anthropic pricing in USD per million tokens, derived from
+// MODEL_METADATA: each row's `pricing` becomes the base `<fullId>` entry and
+// each `oneM` becomes the `<fullId>[1m]` long-context entry (#4087).
+// `computePromptCostUsd` selects between base and longContext rates based on
+// the turn's total input tokens.
+const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze(
+  MODEL_METADATA.reduce((table, m) => {
+    if (m.pricing) table[m.fullId] = deepFreezePricing(m.pricing)
+    if (m.oneM) table[`${m.fullId}${ONE_M_SUFFIX}`] = deepFreezePricing(m.oneM)
+    return table
+  }, {}),
+)
 
 // Short-id → fullId so callers can pass either form. The fallback set is
 // the canonical mapping; new short aliases get picked up automatically.

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -136,9 +136,13 @@ const MODEL_METADATA = Object.freeze([
   }),
 ])
 
-// Freeze a pricing block (incl. the nested longContext premium) in place so the
+// Freeze a pricing block (incl. the nested longContext premium) IN PLACE so the
 // derived CLAUDE_PRICING_USD_PER_MTOK keeps the deep-frozen contract callers
-// relied on when the rates were hand-authored as Object.freeze literals.
+// relied on when the rates were hand-authored as Object.freeze literals. The
+// derived table deliberately shares object identity with its MODEL_METADATA
+// source row (both are frozen + read-only) — do NOT defensively deep-clone here,
+// that would just reintroduce the two-copies-can-drift problem this consolidation
+// removes.
 function deepFreezePricing(rates) {
   if (rates && typeof rates === 'object') {
     for (const v of Object.values(rates)) {

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -77,11 +77,12 @@ export function claudeDeriveId(fullId) {
 // they are the graceful-degradation path for models NOT in this table.
 //
 // Per-row fields:
-//   shortId, label, fullId — the FALLBACK_MODELS triple. Short aliases
-//     (sonnet/opus/haiku) resolve to the latest version in the claude CLI, so
-//     undated full IDs are used on purpose — the SDK's supportedModels() is the
-//     source of truth for concrete version identifiers, and these rows also
-//     seed the merge step in updateModels() so a stale/minimal SDK response
+//   shortId, label, fullId — the FALLBACK_MODELS triple. The fullIds are
+//     versioned family heads WITHOUT a date suffix (e.g. `claude-opus-4-7`, not
+//     `claude-opus-4-7-20251201`): the short aliases (sonnet/opus/haiku) resolve
+//     to the latest version in the claude CLI, and the SDK's supportedModels()
+//     is the source of truth for concrete date-pinned identifiers. These rows
+//     also seed the merge step in updateModels() so a stale/minimal SDK response
 //     still surfaces the newer chip in the picker (#3075).
 //   contextWindow — OPTIONAL. When set it overrides the cold-start heuristic
 //     for that known model (symmetric with the on-disk overlay in

--- a/packages/server/tests/models-metadata-derivation.test.js
+++ b/packages/server/tests/models-metadata-derivation.test.js
@@ -1,0 +1,96 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  FALLBACK_MODELS,
+  getModelPricing,
+  resolveClaudeContextWindow,
+  _resetModelsOverlayForTests,
+} from '../src/models.js'
+
+// #5930 — LOAD-BEARING PROOF that consolidating the scattered model-metadata
+// tables into one MODEL_METADATA registry is a PURE RESTRUCTURE with no billing
+// behavior change. These snapshots are VERBATIM copies of the FALLBACK_MODELS /
+// CLAUDE_PRICING_USD_PER_MTOK literals as they existed BEFORE the consolidation
+// (the #5631 DRY core). If a derived table no longer deep-equals its snapshot,
+// the refactor changed what models exist or what a turn costs — fail loudly.
+//
+// Pricing is asserted through the public getModelPricing() accessor (which, for
+// an exact fullId, hits resolvePricingKey's verbatim branch first — a direct
+// read of the derived CLAUDE_PRICING_USD_PER_MTOK table) with the overlay reset
+// to empty, so an ambient ~/.chroxy/models.json on the dev's machine can't mask
+// a derivation regression.
+
+// Verbatim pre-consolidation FALLBACK_MODELS (contextWindow values inlined to
+// what resolveClaudeContextWindow returned at authoring time, so a regression in
+// the heuristic ALSO trips this test, not just a far-away window test).
+const FALLBACK_MODELS_SNAPSHOT = [
+  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200_000 },
+  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: 1_000_000 },
+  { id: 'fable', label: 'Fable', fullId: 'claude-fable-5', contextWindow: 200_000 },
+  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: 200_000 },
+]
+
+// Verbatim pre-consolidation CLAUDE_PRICING_USD_PER_MTOK. Fable is intentionally
+// ABSENT (chroxy ships no verified fable rates → cost "unknown", never $0).
+const CLAUDE_PRICING_SNAPSHOT = {
+  'claude-sonnet-4-6': { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
+  'claude-opus-4-7': { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+  'claude-opus-4-7[1m]': {
+    input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
+    longContext: {
+      thresholdInputTokens: 200_000,
+      input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
+    },
+  },
+  'claude-haiku-4-5': { input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 },
+}
+
+describe('#5930 model-metadata consolidation is a pure restructure', () => {
+  before(() => {
+    // Isolate the pricing proof from any ambient on-disk overlay.
+    _resetModelsOverlayForTests()
+  })
+  after(() => {
+    _resetModelsOverlayForTests()
+  })
+
+  it('derived FALLBACK_MODELS deep-equals the pre-consolidation literal (order included)', () => {
+    assert.deepStrictEqual([...FALLBACK_MODELS], FALLBACK_MODELS_SNAPSHOT)
+  })
+
+  it('FALLBACK_MODELS preserves the exact roster + order', () => {
+    assert.deepStrictEqual(
+      FALLBACK_MODELS.map((m) => m.id),
+      ['sonnet', 'opus', 'fable', 'haiku'],
+    )
+  })
+
+  it('the opus row derives its 1M window via the heuristic path', () => {
+    const opus = FALLBACK_MODELS.find((m) => m.id === 'opus')
+    assert.equal(opus.contextWindow, 1_000_000)
+    assert.equal(opus.contextWindow, resolveClaudeContextWindow('claude-opus-4-7'))
+  })
+
+  it('FALLBACK_MODELS stays deep-frozen', () => {
+    assert.ok(Object.isFrozen(FALLBACK_MODELS))
+    for (const m of FALLBACK_MODELS) assert.ok(Object.isFrozen(m), `${m.id} frozen`)
+  })
+
+  it('derived pricing deep-equals the pre-consolidation literal for every priced key', () => {
+    for (const [fullId, expected] of Object.entries(CLAUDE_PRICING_SNAPSHOT)) {
+      assert.deepStrictEqual(getModelPricing(fullId), expected, `pricing ${fullId}`)
+    }
+  })
+
+  it('preserves the intentional fable pricing gap (cost unknown, not $0)', () => {
+    assert.equal(getModelPricing('claude-fable-5'), null)
+  })
+
+  it('keeps pricing entries (incl. the nested longContext premium) deep-frozen', () => {
+    const opus = getModelPricing('claude-opus-4-7')
+    assert.ok(Object.isFrozen(opus), 'opus base frozen')
+    const opus1m = getModelPricing('claude-opus-4-7[1m]')
+    assert.ok(Object.isFrozen(opus1m), 'opus[1m] frozen')
+    assert.ok(Object.isFrozen(opus1m.longContext), 'opus[1m].longContext frozen')
+  })
+})


### PR DESCRIPTION
## What

Consolidates the two scattered, hand-synced model-metadata tables in `packages/server/src/models.js` into **one ordered `MODEL_METADATA` source array** (one row per Claude model) and derives both tables from it. This is the **#5631 DRY core**: today adding a model requires editing `FALLBACK_MODELS` and `CLAUDE_PRICING_USD_PER_MTOK` separately; after this it's a single-row edit.

## Design

Each `MODEL_METADATA` row:
- `shortId` / `label` / `fullId` — the FALLBACK triple.
- `contextWindow?` — **optional** override; absent → derived via `resolveClaudeContextWindow(fullId)`. No row sets it today, so the derivation is byte-identical to the prior literals (symmetric with the on-disk overlay override).
- `pricing?` — base rates; **absent** (fable) emits no pricing key → `resolveModelPricing` returns `null`, never `$0`.
- `oneM?` — the `[1m]` long-context variant incl. the #4087 `longContext` premium block; absent → no `<fullId>[1m]` key.

`FALLBACK_MODELS` derives via `map` (source order, deep-frozen). `CLAUDE_PRICING_USD_PER_MTOK` derives by emitting a base key per priced row + a `[1m]` key per `oneM` row, with `deepFreezePricing` keeping the nested `longContext` frozen.

The regex/string heuristics (`resolveClaudeContextWindow`, `humanizeModelId`) **intentionally stay separate** — they're the graceful-degradation path for models *not* in the table, not per-model data.

## Proof it's a pure restructure (the load-bearing check)

`tests/models-metadata-derivation.test.js` snapshots the **verbatim pre-consolidation literals** and asserts the derived tables `deepStrictEqual` them — roster + order, the opus `[1m]` `longContext` premium, the intentional **fable pricing gap**, and deep-frozen-ness — through the public `FALLBACK_MODELS` / `getModelPricing` surface with the overlay reset for isolation. If a derived table no longer matches the snapshot, billing behavior changed and the test fails loudly.

`getModelPricing` / `computePromptCostUsd` behavior is unchanged. The #5932 overlay-fold path (`computeFallbackModels`) is untouched — it keys off the derived `FALLBACK_MODELS`, which is byte-identical.

## Tests

- New `models-metadata-derivation.test.js` (7 assertions) — green.
- `models.test.js`, `models-factory.test.js`, `models-overlay-reload.test.js`, `models-per-provider.test.js`, `cost-budget*.test.js`, `session-info-booted-model.test.js` — all green (229 tests across the model/cost surface).

Closes #5930