### PR TITLE
feat(server): cancel_queued wire message for per-item queue cancel (#5943)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -92,6 +92,11 @@ export declare const CancelActivitySchema: z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
+export declare const CancelQueuedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"cancel_queued">;
+    clientMessageId: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const SetModelSchema: z.ZodObject<{
     type: z.ZodLiteral<"set_model">;
     model: z.ZodString;
@@ -701,6 +706,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"cancel_queued">;
+    clientMessageId: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"set_model">;
     model: z.ZodString;
 }, z.core.$loose>, z.ZodObject<{
@@ -1106,6 +1115,7 @@ export type PairDenyMessage = z.infer<typeof PairDenySchema>;
 export type InputMessage = z.infer<typeof InputSchema>;
 export type InterruptMessage = z.infer<typeof InterruptSchema>;
 export type CancelActivityMessage = z.infer<typeof CancelActivitySchema>;
+export type CancelQueuedMessage = z.infer<typeof CancelQueuedSchema>;
 export type SetModelMessage = z.infer<typeof SetModelSchema>;
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>;
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -129,6 +129,22 @@ export const CancelActivitySchema = z.object({
     // to its outcome without inferring it from the terminal activity_delta.
     requestId: z.string().max(128).optional(),
 }).passthrough();
+// #5943 (epic #5935): cancel a SINGLE queued send-while-busy follow-up by its
+// `clientMessageId`, removing it from the server's per-session outgoing queue
+// (`base-session.js` `_outgoingQueue`) before it flushes. The server emits
+// `message_dequeued { reason: 'cancelled' }` so every client removes the queued
+// bubble. Authority mirrors `interrupt` — acting on your OWN bound/active
+// session, not a privilege escalation — so the server resolves the target from
+// `sessionId` or the caller's binding. Whole-queue cancellation stays on
+// `interrupt`; this is the per-item control action (the queue analogue of
+// `cancel_activity`).
+export const CancelQueuedSchema = z.object({
+    type: z.literal('cancel_queued'),
+    // Identifies the queued entry to drop. Same shape/cap as the `input`
+    // clientMessageId the entry was enqueued under.
+    clientMessageId: z.string().min(1).max(128),
+    sessionId: z.string().max(256).optional(),
+}).passthrough();
 export const SetModelSchema = z.object({
     type: z.literal('set_model'),
     model: z.string().max(256),
@@ -978,6 +994,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     InputSchema,
     InterruptSchema,
     CancelActivitySchema,
+    CancelQueuedSchema,
     SetModelSchema,
     SetPermissionModeSchema,
     SetThinkingLevelSchema,

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -140,8 +140,10 @@ export const CancelActivitySchema = z.object({
 // `cancel_activity`).
 export const CancelQueuedSchema = z.object({
     type: z.literal('cancel_queued'),
-    // Identifies the queued entry to drop. Same shape/cap as the `input`
-    // clientMessageId the entry was enqueued under.
+    // Identifies the queued entry to drop: the client-generated message id the
+    // entry was enqueued under (the server's resolved `messageId`, echoed as
+    // `clientMessageId` on `message_queued` / `message_dequeued`). Same 128-char
+    // cap the server applies to that id.
     clientMessageId: z.string().min(1).max(128),
     sessionId: z.string().max(256).optional(),
 }).passthrough();

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -652,10 +652,12 @@ export declare const ServerMessageQueuedSchema: z.ZodObject<{
 }, z.core.$loose>;
 /**
  * `message_dequeued` — a queued message left the queue. `reason` distinguishes
- * the two exit paths: `'flush'` (auto-sent on turn-complete — the client should
- * transition the bubble from queued → sent) vs `'interrupted'` (the queue was
- * cancelled by an interrupt — the client should remove the queued bubble). The
- * `queueLength` is the count remaining AFTER this item left.
+ * the exit paths: `'flush'` (auto-sent on turn-complete — the client should
+ * transition the bubble from queued → sent), `'interrupted'` (the whole queue
+ * was cancelled by an interrupt — the client should remove the queued bubble),
+ * and `'cancelled'` (#5943 — the owner cancelled this ONE entry via
+ * `cancel_queued` — the client removes just this bubble, leaving the rest of the
+ * queue intact). The `queueLength` is the count remaining AFTER this item left.
  */
 export declare const ServerMessageDequeuedSchema: z.ZodObject<{
     type: z.ZodLiteral<"message_dequeued">;
@@ -665,6 +667,7 @@ export declare const ServerMessageDequeuedSchema: z.ZodObject<{
     reason: z.ZodEnum<{
         flush: "flush";
         interrupted: "interrupted";
+        cancelled: "cancelled";
     }>;
 }, z.core.$loose>;
 /**

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -794,17 +794,19 @@ export const ServerMessageQueuedSchema = z.object({
 }).passthrough();
 /**
  * `message_dequeued` — a queued message left the queue. `reason` distinguishes
- * the two exit paths: `'flush'` (auto-sent on turn-complete — the client should
- * transition the bubble from queued → sent) vs `'interrupted'` (the queue was
- * cancelled by an interrupt — the client should remove the queued bubble). The
- * `queueLength` is the count remaining AFTER this item left.
+ * the exit paths: `'flush'` (auto-sent on turn-complete — the client should
+ * transition the bubble from queued → sent), `'interrupted'` (the whole queue
+ * was cancelled by an interrupt — the client should remove the queued bubble),
+ * and `'cancelled'` (#5943 — the owner cancelled this ONE entry via
+ * `cancel_queued` — the client removes just this bubble, leaving the rest of the
+ * queue intact). The `queueLength` is the count remaining AFTER this item left.
  */
 export const ServerMessageDequeuedSchema = z.object({
     type: z.literal('message_dequeued'),
     sessionId: z.string(),
     clientMessageId: z.string().optional(),
     queueLength: z.number().int().nonnegative(),
-    reason: z.enum(['flush', 'interrupted']),
+    reason: z.enum(['flush', 'interrupted', 'cancelled']),
 }).passthrough();
 // ───────────────────────────────────────────────────────────────────────────
 // Host/Repo Status Control Room (#5170 epic, #5171 protocol contract)

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -143,6 +143,23 @@ export const CancelActivitySchema = z.object({
   requestId: z.string().max(128).optional(),
 }).passthrough()
 
+// #5943 (epic #5935): cancel a SINGLE queued send-while-busy follow-up by its
+// `clientMessageId`, removing it from the server's per-session outgoing queue
+// (`base-session.js` `_outgoingQueue`) before it flushes. The server emits
+// `message_dequeued { reason: 'cancelled' }` so every client removes the queued
+// bubble. Authority mirrors `interrupt` — acting on your OWN bound/active
+// session, not a privilege escalation — so the server resolves the target from
+// `sessionId` or the caller's binding. Whole-queue cancellation stays on
+// `interrupt`; this is the per-item control action (the queue analogue of
+// `cancel_activity`).
+export const CancelQueuedSchema = z.object({
+  type: z.literal('cancel_queued'),
+  // Identifies the queued entry to drop. Same shape/cap as the `input`
+  // clientMessageId the entry was enqueued under.
+  clientMessageId: z.string().min(1).max(128),
+  sessionId: z.string().max(256).optional(),
+}).passthrough()
+
 export const SetModelSchema = z.object({
   type: z.literal('set_model'),
   model: z.string().max(256),
@@ -1109,6 +1126,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   InputSchema,
   InterruptSchema,
   CancelActivitySchema,
+  CancelQueuedSchema,
   SetModelSchema,
   SetPermissionModeSchema,
   SetThinkingLevelSchema,
@@ -1211,6 +1229,7 @@ export type PairDenyMessage = z.infer<typeof PairDenySchema>
 export type InputMessage = z.infer<typeof InputSchema>
 export type InterruptMessage = z.infer<typeof InterruptSchema>
 export type CancelActivityMessage = z.infer<typeof CancelActivitySchema>
+export type CancelQueuedMessage = z.infer<typeof CancelQueuedSchema>
 export type SetModelMessage = z.infer<typeof SetModelSchema>
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -154,8 +154,10 @@ export const CancelActivitySchema = z.object({
 // `cancel_activity`).
 export const CancelQueuedSchema = z.object({
   type: z.literal('cancel_queued'),
-  // Identifies the queued entry to drop. Same shape/cap as the `input`
-  // clientMessageId the entry was enqueued under.
+  // Identifies the queued entry to drop: the client-generated message id the
+  // entry was enqueued under (the server's resolved `messageId`, echoed as
+  // `clientMessageId` on `message_queued` / `message_dequeued`). Same 128-char
+  // cap the server applies to that id.
   clientMessageId: z.string().min(1).max(128),
   sessionId: z.string().max(256).optional(),
 }).passthrough()

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -846,17 +846,19 @@ export const ServerMessageQueuedSchema = z.object({
 
 /**
  * `message_dequeued` — a queued message left the queue. `reason` distinguishes
- * the two exit paths: `'flush'` (auto-sent on turn-complete — the client should
- * transition the bubble from queued → sent) vs `'interrupted'` (the queue was
- * cancelled by an interrupt — the client should remove the queued bubble). The
- * `queueLength` is the count remaining AFTER this item left.
+ * the exit paths: `'flush'` (auto-sent on turn-complete — the client should
+ * transition the bubble from queued → sent), `'interrupted'` (the whole queue
+ * was cancelled by an interrupt — the client should remove the queued bubble),
+ * and `'cancelled'` (#5943 — the owner cancelled this ONE entry via
+ * `cancel_queued` — the client removes just this bubble, leaving the rest of the
+ * queue intact). The `queueLength` is the count remaining AFTER this item left.
  */
 export const ServerMessageDequeuedSchema = z.object({
   type: z.literal('message_dequeued'),
   sessionId: z.string(),
   clientMessageId: z.string().optional(),
   queueLength: z.number().int().nonnegative(),
-  reason: z.enum(['flush', 'interrupted']),
+  reason: z.enum(['flush', 'interrupted', 'cancelled']),
 }).passthrough()
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -60,6 +60,40 @@ describe('@chroxy/protocol schemas', () => {
     assert.equal(result.data.type, 'cancel_activity')
   })
 
+  // #5943 (epic #5935): cancel_queued client→server message.
+  it('validates cancel_queued with a clientMessageId (sessionId optional)', async () => {
+    const { CancelQueuedSchema } = await import('../src/schemas/client.ts')
+    const minimal = CancelQueuedSchema.safeParse({ type: 'cancel_queued', clientMessageId: 'uin-2' })
+    assert.ok(minimal.success, 'Should validate with just clientMessageId')
+    const withSession = CancelQueuedSchema.safeParse({ type: 'cancel_queued', clientMessageId: 'uin-2', sessionId: 'sess-1' })
+    assert.ok(withSession.success, 'Should validate with sessionId too')
+  })
+
+  it('rejects cancel_queued missing or with an empty/over-long clientMessageId', async () => {
+    const { CancelQueuedSchema } = await import('../src/schemas/client.ts')
+    assert.ok(!CancelQueuedSchema.safeParse({ type: 'cancel_queued' }).success, 'missing clientMessageId rejected')
+    assert.ok(!CancelQueuedSchema.safeParse({ type: 'cancel_queued', clientMessageId: '' }).success, 'empty clientMessageId rejected')
+    assert.ok(!CancelQueuedSchema.safeParse({ type: 'cancel_queued', clientMessageId: 'x'.repeat(129) }).success, 'over-long clientMessageId rejected')
+  })
+
+  it('resolves cancel_queued through the ClientMessageSchema union by discriminator', async () => {
+    const { ClientMessageSchema } = await import('../src/schemas/client.ts')
+    const result = ClientMessageSchema.safeParse({ type: 'cancel_queued', clientMessageId: 'uin-2' })
+    assert.ok(result.success, 'union should route cancel_queued to CancelQueuedSchema')
+    assert.equal(result.data.type, 'cancel_queued')
+  })
+
+  // #5943: message_dequeued gains the 'cancelled' reason alongside flush/interrupted.
+  it('validates message_dequeued reason enum incl. cancelled (#5943)', async () => {
+    const { ServerMessageDequeuedSchema } = await import('../src/schemas/server.ts')
+    for (const reason of ['flush', 'interrupted', 'cancelled']) {
+      const r = ServerMessageDequeuedSchema.safeParse({ type: 'message_dequeued', sessionId: 's1', queueLength: 0, reason })
+      assert.ok(r.success, `reason '${reason}' should validate`)
+    }
+    const bad = ServerMessageDequeuedSchema.safeParse({ type: 'message_dequeued', sessionId: 's1', queueLength: 0, reason: 'bogus' })
+    assert.ok(!bad.success, 'unknown reason rejected')
+  })
+
   it('validates server auth_ok message', async () => {
     const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
     const result = ServerAuthOkSchema.safeParse({

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -719,6 +719,39 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
+   * #5943: cancel ONE queued outgoing message by its `clientMessageId`, leaving
+   * the rest of the queue intact. Called by the `cancel_queued` handler so the
+   * owner can drop a single send-while-busy follow-up they no longer want,
+   * WITHOUT the whole-queue cancellation an `interrupt` performs. Emits
+   * `message_dequeued` with `reason: 'cancelled'` (the per-item analogue of
+   * `clearOutgoingQueue`'s `'interrupted'`) so every client removes just that
+   * queued bubble. `queueLength` carries the count remaining AFTER removal,
+   * matching the documented meaning on the other dequeue paths.
+   *
+   * A no-op (returns false, no event) when the id is missing, empty, or matches
+   * nothing — an entry queued without a `clientMessageId` cannot be targeted
+   * (only the owner's optimistic copy carries one), and a stale/duplicate cancel
+   * for an already-flushed item must not emit a spurious dequeue.
+   *
+   * @param {string} clientMessageId
+   * @returns {boolean} true if an entry was found and removed.
+   */
+  cancelQueuedMessage(clientMessageId) {
+    if (this._destroying || typeof clientMessageId !== 'string' || clientMessageId.length === 0) {
+      return false
+    }
+    const idx = this._outgoingQueue.findIndex(
+      (item) => item.sendOptions?.clientMessageId === clientMessageId,
+    )
+    if (idx === -1) return false
+    this._outgoingQueue.splice(idx, 1)
+    const remaining = this._outgoingQueue.length
+    this.emit('message_dequeued', { clientMessageId, queueLength: remaining, reason: 'cancelled' })
+    ;(this._log || log).info(`Cancelled queued follow-up message ${clientMessageId} (${remaining} remaining)`)
+    return true
+  }
+
+  /**
    * #5160: wire the activity registry to this session's own lifecycle
    * events. The registry is a pure consumer — it only maps already-emitted
    * signals into `ActivityEntry` records, so listening here keeps it a thin

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -733,6 +733,12 @@ export class BaseSession extends EventEmitter {
    * (only the owner's optimistic copy carries one), and a stale/duplicate cancel
    * for an already-flushed item must not emit a spurious dequeue.
    *
+   * Authority is enforced upstream, NOT here: the `cancel_queued` handler
+   * resolves the caller to THIS session via the standard binding gate before
+   * calling in, and the queue is per-session, so reaching this method already
+   * means the caller owns the session. Keep that the ownership boundary if the
+   * queue is ever refactored to a cross-session structure.
+   *
    * @param {string} clientMessageId
    * @returns {boolean} true if an entry was found and removed.
    */

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -353,7 +353,10 @@ Object.assign(EVENT_MAP, {
         sessionId: ctx.sessionId,
         ...(typeof data?.clientMessageId === 'string' ? { clientMessageId: data.clientMessageId } : {}),
         queueLength: typeof data?.queueLength === 'number' ? data.queueLength : 0,
-        reason: data?.reason === 'interrupted' ? 'interrupted' : 'flush',
+        // #5943: pass the per-item cancel reason through alongside the two
+        // slice-① reasons; anything unrecognised collapses to 'flush' (the
+        // benign default — the client transitions the bubble to sent).
+        reason: data?.reason === 'interrupted' || data?.reason === 'cancelled' ? data.reason : 'flush',
       },
     }],
   }),

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -572,6 +572,51 @@ function handleInterrupt(ws, client, msg, ctx) {
 }
 
 /**
+ * #5943 (epic #5935): cancel ONE queued send-while-busy follow-up by its
+ * `clientMessageId`. Authority mirrors `interrupt` — acting on your OWN bound
+ * session, not a privilege escalation — so resolveSession's binding check is the
+ * only gate (a pairing-bound client may cancel a queued message in its own
+ * session but not another's). Whole-queue cancellation stays on `interrupt`.
+ *
+ * The session removes the matching `_outgoingQueue` entry and emits
+ * `message_dequeued { reason: 'cancelled' }`, which mirrors to every client via
+ * the EventNormalizer — so there is no extra reply on success here. A
+ * stale/duplicate cancel (id already flushed) is a silent no-op, like an
+ * `interrupt` to an idle session. Binding/stale-id failures surface the same
+ * session_error envelopes as handleInterrupt.
+ */
+function handleCancelQueued(ws, client, msg, ctx) {
+  const entry = resolveSession(ctx, msg, client)
+  if (entry) {
+    const cancelled = entry.session.cancelQueuedMessage(msg.clientMessageId)
+    log.info(`cancel_queued ${msg.clientMessageId} from ${client.id} → ${cancelled ? 'removed' : 'no-op (not queued)'}`)
+    return
+  }
+  // Disambiguate a binding mismatch from a truly-missing session, exactly as
+  // handleInterrupt does (Copilot review #4979).
+  if (msg.sessionId && client.boundSessionId && client.boundSessionId !== msg.sessionId) {
+    log.info(`cancel_queued rejected: session-token mismatch sessionId=${msg.sessionId} boundSessionId=${client.boundSessionId} client=${client.id}`)
+    ctx.transport.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessions.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
+    return
+  }
+  if (msg.sessionId) {
+    log.info(`cancel_queued dropped: session not found sessionId=${msg.sessionId} client=${client.id}`)
+    ctx.transport.send(ws, {
+      type: 'session_error',
+      code: 'SESSION_NOT_FOUND',
+      message: `Session not found: ${msg.sessionId}`,
+      attemptedSessionId: msg.sessionId,
+    })
+  }
+}
+
+/**
  * #5271 (Control Room Phase 2a): cancel a single in-flight activity node
  * (currently a Task subagent) in a session. Authority mirrors `interrupt` —
  * acting on your own session, NOT a privilege escalation — so resolveSession's
@@ -987,6 +1032,7 @@ function handleTerminalInput(ws, client, msg, ctx) {
 export const inputHandlers = {
   input: handleInput,
   interrupt: handleInterrupt,
+  cancel_queued: handleCancelQueued,
   terminal_input: handleTerminalInput,
   cancel_activity: handleCancelActivity,
   resume_budget: handleResumeBudget,

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -247,7 +247,8 @@ function _isSecureRequest(req) {
  * Client -> Server:
  *   { type: 'auth',      token: '...', deviceInfo? }   — authenticate (deviceInfo: { deviceId, deviceName, deviceType, platform })
  *   { type: 'input',     data: '...' }               — send text to active session
- *   { type: 'interrupt' }                             — interrupt active session
+ *   { type: 'interrupt' }                             — interrupt active session (also cancels the WHOLE outgoing queue)
+ *   { type: 'cancel_queued', clientMessageId, sessionId? } — cancel ONE queued send-while-busy follow-up (#5943); server emits message_dequeued(reason: 'cancelled')
  *   { type: 'set_model', model: '...' }              — change model on active session
  *   { type: 'set_permission_mode', mode: '...', confirmed? } — change permission mode (confirmed: true required for 'auto')
  *   { type: 'permission_response', requestId, decision } — respond to permission prompt
@@ -425,7 +426,7 @@ function _isSecureRequest(req) {
  *   { type: 'activity_snapshot', sessionId, schemaVersion, entries } — Control Room full activity tree for a session, on subscribe/resync (#5161 schema; emitter #5160; `entries: [{ id, kind, label, status, startedAt, endedAt?, parentId?, outputRef? }, …]`)
  *   { type: 'activity_delta', sessionId, schemaVersion, op, entry } — Control Room incremental activity-entry change (#5161 schema; emitter #5160; `op` is one of `started` / `updated` / `ended`; `entry` is the full node)
  *   { type: 'message_queued', sessionId, clientMessageId?, text, queueLength } — a send-while-busy follow-up entered the server's outgoing-message queue (#5936/#5937, transient; mirrors `_outgoingQueue`)
- *   { type: 'message_dequeued', sessionId, clientMessageId?, queueLength, reason } — a queued follow-up left the queue (#5936/#5937, transient; `reason` is `flush` (auto-sent on turn-complete) or `interrupted` (cancelled by a Stop))
+ *   { type: 'message_dequeued', sessionId, clientMessageId?, queueLength, reason } — a queued follow-up left the queue (#5936/#5937/#5943, transient; `reason` is `flush` (auto-sent on turn-complete), `interrupted` (whole queue cancelled by a Stop), or `cancelled` (one item cancelled via `cancel_queued`))
  *   { type: 'host_status_snapshot', requestId?, generatedAt, root, summary, repos, error? } — Control Room Host/Repo Status survey reply (#5171 schema; emitter #5174); reply to a `host_status_request`. Always carries the full snapshot shape (so it is protocol-schema-valid); on failure `repos` is empty, `summary` is zeroed, and an additive `error: { code, message }` annotation is present for the consumer to branch on. `requestId` echoes the request when provided.
  *   { type: 'runner_status_snapshot', requestId?, generatedAt, root, summary, repos, error? } — Control Room self-hosted runner survey reply (#5253 schema + emitter); reply to a `runner_status_request`. Same degraded-snapshot-with-`error` posture as `host_status_snapshot`: always the full shape; on failure `repos` is empty, `summary` is zeroed, and an additive `error: { code, message }` is present. `requestId` echoes the request when provided.
  *   { type: 'integration_status_snapshot', requestId?, generatedAt, root, summary, repos, repoMemoryCli?, error? } — Control Room Integrations survey reply (#5499 schema + emitter, epic #5498); reply to an `integration_status_request`. Per-repo repo-memory status (config, cache stats, telemetry report); `repoMemoryCli` notes the once-per-snapshot binary probe. Same degraded-snapshot-with-`error` posture as the host/runner surveys. `requestId` echoes the request when provided.

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -1994,4 +1994,66 @@ describe('input-handlers', () => {
       assert.equal(ctx.transport.getPrimary('s1'), 'me')
     })
   })
+
+  // #5943: per-item cancel of a queued send-while-busy follow-up.
+  describe('cancel_queued', () => {
+    function sessionWithCancel(removed = true) {
+      const session = createMockSession()
+      session.cancelQueuedMessage = createSpy(() => removed)
+      return session
+    }
+
+    it('calls session.cancelQueuedMessage with the clientMessageId on the bound session', () => {
+      const sessions = new Map()
+      const session = sessionWithCancel(true)
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      inputHandlers.cancel_queued(makeWs(), client, { clientMessageId: 'uin-2' }, ctx)
+
+      assert.equal(session.cancelQueuedMessage.callCount, 1)
+      assert.equal(session.cancelQueuedMessage.lastCall[0], 'uin-2')
+      assert.equal(ctx._sent.length, 0, 'success sends no extra reply (dequeue mirrors via the normalizer)')
+    })
+
+    it('is a silent no-op (no error) when the id is not queued', () => {
+      const sessions = new Map()
+      const session = sessionWithCancel(false) // nothing matched
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      inputHandlers.cancel_queued(makeWs(), client, { clientMessageId: 'uin-gone' }, ctx)
+
+      assert.equal(session.cancelQueuedMessage.callCount, 1)
+      assert.equal(ctx._sent.length, 0, 'a stale cancel must not surface an error')
+    })
+
+    it('sends SESSION_TOKEN_MISMATCH when bound to a different session', () => {
+      const sessions = new Map()
+      sessions.set('bound-id', { session: sessionWithCancel(), name: 'BoundSession', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ boundSessionId: 'bound-id' })
+
+      inputHandlers.cancel_queued(makeWs(), client, { clientMessageId: 'uin-1', sessionId: 'other-id' }, ctx)
+
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx._sent[0].attemptedSessionId, undefined)
+    })
+
+    it('sends SESSION_NOT_FOUND for an unknown sessionId', () => {
+      const ctx = makeCtx(new Map())
+      const client = makeClient({})
+
+      inputHandlers.cancel_queued(makeWs(), client, { clientMessageId: 'uin-1', sessionId: 'ghost' }, ctx)
+
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_NOT_FOUND')
+      assert.equal(ctx._sent[0].attemptedSessionId, 'ghost')
+    })
+  })
 })

--- a/packages/server/tests/outgoing-queue.test.js
+++ b/packages/server/tests/outgoing-queue.test.js
@@ -230,6 +230,80 @@ describe('outgoing-message queue (#5936)', () => {
     })
   })
 
+  // #5943: cancel ONE queued follow-up by clientMessageId, leaving the rest —
+  // the per-item analogue of clearOutgoingQueue (which cancels the whole queue).
+  describe('cancel single queued message (#5943)', () => {
+    it('removes the matching entry, leaves the rest, and emits message_dequeued(cancelled)', () => {
+      const s = new FakeSession()
+      s.sendMessage('turn')                                   // busy
+      s.sendMessage('q1', undefined, { clientMessageId: 'uin-1' })
+      s.sendMessage('q2', undefined, { clientMessageId: 'uin-2' })
+      s.sendMessage('q3', undefined, { clientMessageId: 'uin-3' })
+      assert.equal(s.outgoingQueueLength, 3)
+
+      const dequeued = []
+      s.on('message_dequeued', (e) => dequeued.push(e))
+      const ok = s.cancelQueuedMessage('uin-2')
+
+      assert.equal(ok, true)
+      assert.equal(s.outgoingQueueLength, 2, 'only the cancelled item left')
+      assert.deepEqual(dequeued, [{ clientMessageId: 'uin-2', queueLength: 2, reason: 'cancelled' }])
+    })
+
+    it('still flushes the surviving entries FIFO after a mid-queue cancel', async () => {
+      const s = new FakeSession()
+      s.sendMessage('turn')
+      s.sendMessage('q1', undefined, { clientMessageId: 'uin-1' })
+      s.sendMessage('q2', undefined, { clientMessageId: 'uin-2' })
+      s.sendMessage('q3', undefined, { clientMessageId: 'uin-3' })
+
+      s.cancelQueuedMessage('uin-2')
+      // Drain: each completeTurn flushes one head, going busy again.
+      s.completeTurn(); await tick()
+      s.completeTurn(); await tick()
+      assert.deepEqual(s.sent.map((m) => m.prompt), ['turn', 'q1', 'q3'], 'q2 dropped, q1/q3 sent in order')
+    })
+
+    it('is a no-op (returns false, no event) for an unknown or missing id', () => {
+      const s = new FakeSession()
+      s.sendMessage('turn')
+      s.sendMessage('q1', undefined, { clientMessageId: 'uin-1' })
+      const dequeued = []
+      s.on('message_dequeued', (e) => dequeued.push(e))
+
+      assert.equal(s.cancelQueuedMessage('uin-does-not-exist'), false)
+      assert.equal(s.cancelQueuedMessage(''), false)
+      assert.equal(s.cancelQueuedMessage(undefined), false)
+      assert.equal(s.outgoingQueueLength, 1, 'queue untouched')
+      assert.equal(dequeued.length, 0, 'no spurious dequeue')
+    })
+
+    it('cannot target an entry queued without a clientMessageId', () => {
+      const s = new FakeSession()
+      s.sendMessage('turn')
+      s.sendMessage('q1') // no clientMessageId
+      assert.equal(s.cancelQueuedMessage('uin-1'), false)
+      assert.equal(s.outgoingQueueLength, 1)
+    })
+
+    it('interrupt still clears the WHOLE queue after a single cancel', () => {
+      const s = new FakeSession()
+      s.sendMessage('turn')
+      s.sendMessage('q1', undefined, { clientMessageId: 'uin-1' })
+      s.sendMessage('q2', undefined, { clientMessageId: 'uin-2' })
+
+      assert.equal(s.cancelQueuedMessage('uin-1'), true)
+      assert.equal(s.outgoingQueueLength, 1)
+
+      const dequeued = []
+      s.on('message_dequeued', (e) => dequeued.push(e))
+      const cleared = s.clearOutgoingQueue()
+      assert.equal(cleared, 1)
+      assert.equal(s.outgoingQueueLength, 0)
+      assert.ok(dequeued.every((e) => e.reason === 'interrupted'))
+    })
+  })
+
   describe('normalizer → wire mapping injects sessionId', () => {
     const norm = new EventNormalizer()
 
@@ -270,6 +344,16 @@ describe('outgoing-message queue (#5936)', () => {
       )
       assert.equal(out.messages[0].msg.reason, 'interrupted')
       assert.equal(out.messages[0].msg.clientMessageId, 'uin-1')
+    })
+
+    it('passes through reason: cancelled (#5943)', () => {
+      const out = norm.normalize(
+        'message_dequeued',
+        { clientMessageId: 'uin-2', queueLength: 0, reason: 'cancelled' },
+        { sessionId: 'sess-3' },
+      )
+      assert.equal(out.messages[0].msg.reason, 'cancelled')
+      assert.equal(out.messages[0].msg.clientMessageId, 'uin-2')
     })
   })
 })

--- a/packages/server/tests/outgoing-queue.test.js
+++ b/packages/server/tests/outgoing-queue.test.js
@@ -246,7 +246,7 @@ describe('outgoing-message queue (#5936)', () => {
       const ok = s.cancelQueuedMessage('uin-2')
 
       assert.equal(ok, true)
-      assert.equal(s.outgoingQueueLength, 2, 'only the cancelled item left')
+      assert.equal(s.outgoingQueueLength, 2, 'cancelled item removed; the other two remain')
       assert.deepEqual(dequeued, [{ clientMessageId: 'uin-2', queueLength: 2, reason: 'cancelled' }])
     })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -412,7 +412,9 @@ export interface DispatchMessageMap {
     sessionId: string
     clientMessageId?: string
     queueLength: number
-    reason: 'flush' | 'interrupted'
+    // #5943 adds 'cancelled' (per-item cancel via cancel_queued) alongside the
+    // slice-① 'flush'/'interrupted'. Mirrors ServerMessageDequeuedSchema.reason.
+    reason: 'flush' | 'interrupted' | 'cancelled'
   }
 }
 

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -128,6 +128,12 @@ describe('handleMessageDequeued', () => {
     expect(builder.applyTo(current)).toEqual({ queuedMessages: [] })
   })
 
+  it('removes only the cancelled entry (#5943), leaving the rest of the queue', () => {
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b'), confirmed('uin-3', 'c')]
+    const builder = handleMessageDequeued({ sessionId: 's1', clientMessageId: 'uin-2', reason: 'cancelled' }, null)
+    expect(builder.applyTo(current)).toEqual({ queuedMessages: [confirmed('uin-1', 'a'), confirmed('uin-3', 'c')] })
+  })
+
   it('is a no-op (referential) for an unknown id', () => {
     const current = [confirmed('uin-1', 'a')]
     const builder = handleMessageDequeued({ sessionId: 's1', clientMessageId: 'uin-9', reason: 'flush' }, null)

--- a/packages/store-core/src/handlers/outgoing-queue.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.ts
@@ -160,12 +160,13 @@ export function handleMessageQueued(
 
 /**
  * Parse a `message_dequeued` event (wire shape
- * `{ sessionId, clientMessageId?, queueLength, reason: 'flush' | 'interrupted' }`)
- * into a builder that REMOVES the dequeued entry. Both exit reasons remove the
- * entry from the queue model: `'flush'` (the message is now being sent — the
- * normal user_input / stream path takes over rendering it) and `'interrupted'`
- * (the queue was cancelled by a Stop). Removal is by `clientMessageId`, or FIFO
- * head when the server echoed no id.
+ * `{ sessionId, clientMessageId?, queueLength, reason: 'flush' | 'interrupted' | 'cancelled' }`)
+ * into a builder that REMOVES the dequeued entry. ALL exit reasons remove the
+ * entry from the queue model — the handler is reason-agnostic: `'flush'` (the
+ * message is now being sent — the normal user_input / stream path takes over
+ * rendering it), `'interrupted'` (the whole queue was cancelled by a Stop), and
+ * `'cancelled'` (#5943 — the owner cancelled this one entry via `cancel_queued`).
+ * Removal is by `clientMessageId`, or FIFO head when the server echoed no id.
  *
  * Always returns a builder (no malformed-payload null) — a `message_dequeued`
  * with no id is the legitimate FIFO-head case, and an unknown id is a safe


### PR DESCRIPTION
## What

Adds a per-item cancel control action for the send-while-busy outgoing queue (epic #5935). Slice ① (#5936) gave the queue two exit paths — **flush** (auto-send on turn-complete) and **interrupt** (whole-queue clear). The UI slices ③ (#5938) / ④ (#5939) both have an AC "queued items are cancellable", which needs a way to drop **one** queued message without halting the rest. This is the queue analogue of `cancel_activity`.

## Changes

- **protocol:** `CancelQueuedSchema { type, clientMessageId, sessionId? }` added to the `ClientMessage` union; `ServerMessageDequeuedSchema.reason` enum gains `'cancelled'`. Dist rebuilt.
- **base-session:** `cancelQueuedMessage(clientMessageId)` removes the matching `_outgoingQueue` entry and emits `message_dequeued(reason: 'cancelled')` with the post-removal `queueLength`. No-op (returns `false`, no event) for a missing/empty/unknown id, or an entry queued without a `clientMessageId` — a stale/duplicate cancel can't emit a spurious dequeue.
- **event-normalizer:** passes `'cancelled'` through alongside `'interrupted'` (unknown reasons still collapse to `'flush'`).
- **input-handlers:** `handleCancelQueued` mirrors `handleInterrupt`'s authority — own bound/active session only (the `input_conflict` gate already sits above the queue, so cancel is owner-only by construction). Binding/stale-id failures surface the same `SESSION_TOKEN_MISMATCH` / `SESSION_NOT_FOUND` envelopes. Success replies nothing — the dequeue mirrors to every client via the normalizer. Registered as `cancel_queued`.
- **store-core:** `dispatch-table` reason union widened to include `'cancelled'`; `handleMessageDequeued` is already reason-agnostic (removes the entry by id), so the cancelled bubble is removed with **no logic change**.
- ws-server header doc updated (client `cancel_queued` + the third dequeue reason).

## Tests (AC: "cancel one of N leaving the rest; interrupt still clears all")

- **server outgoing-queue:** cancel one of N leaves the rest; survivors still flush FIFO; no-op for unknown/empty/undefined id and for an entry without a `clientMessageId`; interrupt still clears the whole queue after a single cancel; normalizer passes `cancelled` through.
- **input-handlers:** calls `cancelQueuedMessage` with the id; silent no-op when not queued; `SESSION_TOKEN_MISMATCH` on binding mismatch; `SESSION_NOT_FOUND` for an unknown id.
- **protocol:** `cancel_queued` validation (+ union routing) and the `message_dequeued` reason enum incl. `cancelled`.
- **store-core:** reason-agnostic removal of the cancelled entry.

Full protocol (323) + store-core (1599) suites green; broad server surface (572) green; dashboard/app/store-core typecheck clean; server custom lints pass.

Unblocks AC2 of ③ #5938 / ④ #5939.

Closes #5943