### PR TITLE
feat(dashboard): queued-message UI for send-while-busy (#5939)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -228,6 +228,9 @@ export function App() {
   const {
     messages: storeMessages,
     streamingMessageId,
+    // #5939 (epic #5935 ④): per-session send-while-busy queue, surfaced as a
+    // "Queued" badge on the matching optimistic bubble.
+    queuedMessages,
     activeModel,
     permissionMode,
     contextUsage,
@@ -253,6 +256,17 @@ export function App() {
   const mismatchedSet = useMemo(
     () => new Set(activeMismatched || []),
     [activeMismatched],
+  )
+
+  // #5939 (epic #5935 ④): the ids of currently-queued send-while-busy
+  // follow-ups, as a stable Set so ChatView can render a "Queued" badge on the
+  // matching optimistic bubble. Only entries carrying a clientMessageId can be
+  // matched to a bubble (and cancelled); a server-confirmed entry with no local
+  // id is rare (another device) and simply renders without a badge here.
+  // (`onCancelQueued` is derived below, once the store action is bound.)
+  const queuedIds = useMemo(
+    () => new Set((queuedMessages || []).map(m => m.clientMessageId).filter((id): id is string => !!id)),
+    [queuedMessages],
   )
 
   // #4735 / #4731: the multi-question AskUserQuestion form is gated per
@@ -415,6 +429,12 @@ export function App() {
   const retryConnection = useConnectionStore(s => s.retryConnection)
   const sendInput = useConnectionStore(s => s.sendInput)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
+  const sendCancelQueued = useConnectionStore(s => s.sendCancelQueued)
+  // #5939: stable cancel callback so the memoized message rows skip re-render.
+  const onCancelQueued = useCallback(
+    (id: string) => { sendCancelQueued(id) },
+    [sendCancelQueued],
+  )
   // #5780 — nonce bumped on the explicit "jump to latest" user action. Those
   // actions are: send (handleSend), approving a permission/plan, and answering
   // an AskUserQuestion (#5786). Passed to every ChatView so it snaps to the
@@ -2054,6 +2074,8 @@ export function App() {
                         isBusy={!isIdle}
                         renderMessage={renderMessage}
                         scrollToBottomSignal={scrollToBottomSignal}
+                        queuedIds={queuedIds}
+                        onCancelQueued={onCancelQueued}
                       />
                     }
                     second={
@@ -2096,6 +2118,8 @@ export function App() {
                         renderMessage={renderMessage}
                         hidden={viewMode !== 'chat'}
                         scrollToBottomSignal={scrollToBottomSignal}
+                        queuedIds={queuedIds}
+                        onCancelQueued={onCancelQueued}
                       />
                     </div>
                     <div

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -65,6 +65,37 @@ describe('ChatView', () => {
     expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
   })
 
+  // #5939 (epic #5935 ④): queued send-while-busy follow-ups render a "Queued"
+  // badge + cancel affordance on the matching user_input bubble.
+  describe('queued-message badge (#5939)', () => {
+    const userMsg: ChatViewMessage = { id: 'uin-1', type: 'user_input', content: 'follow-up', timestamp: Date.now() }
+
+    it('renders a Queued badge on a user bubble whose id is in queuedIds', () => {
+      render(<ChatView messages={[userMsg]} isStreaming queuedIds={new Set(['uin-1'])} />)
+      expect(screen.getByTestId('msg-queued-uin-1')).toBeInTheDocument()
+      expect(screen.getByText('Queued')).toBeInTheDocument()
+    })
+
+    it('does NOT render a badge when the id is not queued', () => {
+      render(<ChatView messages={[userMsg]} isStreaming={false} queuedIds={new Set()} />)
+      expect(screen.queryByTestId('msg-queued-uin-1')).not.toBeInTheDocument()
+    })
+
+    it('renders a cancel button that calls onCancelQueued with the message id', () => {
+      const onCancelQueued = vi.fn()
+      render(<ChatView messages={[userMsg]} isStreaming queuedIds={new Set(['uin-1'])} onCancelQueued={onCancelQueued} />)
+      fireEvent.click(screen.getByTestId('msg-queued-cancel-uin-1'))
+      expect(onCancelQueued).toHaveBeenCalledTimes(1)
+      expect(onCancelQueued).toHaveBeenCalledWith('uin-1')
+    })
+
+    it('omits the cancel button when no onCancelQueued is supplied', () => {
+      render(<ChatView messages={[userMsg]} isStreaming queuedIds={new Set(['uin-1'])} />)
+      expect(screen.getByTestId('msg-queued-uin-1')).toBeInTheDocument()
+      expect(screen.queryByTestId('msg-queued-cancel-uin-1')).not.toBeInTheDocument()
+    })
+  })
+
   it('hides scroll-to-bottom when at bottom', () => {
     const messages = makeMessages(3)
     render(<ChatView messages={messages} isStreaming={false} />)

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -148,6 +148,17 @@ export interface ChatViewProps {
    * the bottom); only changes trigger a scroll.
    */
   scrollToBottomSignal?: number
+  /**
+   * #5939 (epic #5935 ④): ids of `user_input` messages currently held in the
+   * server's outgoing queue (send-while-busy). A row whose id is in this set
+   * renders a "Queued" badge + a cancel affordance instead of a plain sent
+   * bubble; the badge clears when the id leaves the set (flush / cancel /
+   * interrupt). A `Set` of scalars keeps the per-row prop a stable boolean so
+   * the row memo still skips unaffected rows.
+   */
+  queuedIds?: ReadonlySet<string>
+  /** #5939: cancel a single queued follow-up by its message id (cancel_queued). */
+  onCancelQueued?: (id: string) => void
 }
 
 const TYPE_CLASS: Record<string, string> = {
@@ -230,12 +241,18 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   content,
   timestamp,
   isStreaming,
+  queued,
+  onCancelQueued,
 }: {
   id: string
   type: ChatViewMessage['type']
   content: string
   timestamp: number
   isStreaming?: boolean
+  /** #5939: this user_input is held in the server's outgoing queue. */
+  queued?: boolean
+  /** #5939: cancel this queued follow-up (stable callback from ChatView). */
+  onCancelQueued?: (id: string) => void
 }) {
   // Dev-only render tally — proves (in the memoization test + ad-hoc
   // profiling) non-tail rows don't re-render on a delta flush. Never read on
@@ -259,8 +276,25 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   return (
     <>
       {type !== 'user_input' && icon}
-      <div className={`msg ${TYPE_CLASS[type] || 'assistant'}${isStreaming ? ' streaming' : ''}`}>
+      <div className={`msg ${TYPE_CLASS[type] || 'assistant'}${isStreaming ? ' streaming' : ''}${queued ? ' queued' : ''}`}>
         {body}
+        {queued && (
+          <span className="msg-queued" data-testid={`msg-queued-${id}`}>
+            <span className="msg-queued-label">Queued</span>
+            {onCancelQueued && (
+              <button
+                type="button"
+                className="msg-queued-cancel"
+                aria-label="Cancel queued message"
+                title="Cancel queued message"
+                data-testid={`msg-queued-cancel-${id}`}
+                onClick={() => onCancelQueued(id)}
+              >
+                ✕
+              </button>
+            )}
+          </span>
+        )}
         {timestamp > 0 && <span className="msg-timestamp">{formatTime(timestamp)}</span>}
       </div>
       {type === 'user_input' && icon}
@@ -268,7 +302,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBottomSignal }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
@@ -626,6 +660,8 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
                   content={msg.content}
                   timestamp={msg.timestamp}
                   isStreaming={msg.isStreaming}
+                  queued={queuedIds?.has(msg.id) ?? false}
+                  onCancelQueued={onCancelQueued}
                 />
               </MessageRowShell>
             )

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2153,7 +2153,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const activeId = get().activeSessionId;
       if (activeId && get().sessionStates[activeId]) {
         updateActiveSession((ss) => ({
-          messages: [...filterThinking(ss.messages), userMsg],
+          // Do NOT filterThinking here: the in-progress turn may still be
+          // showing its thinking indicator (e.g. streamingMessageId === 'pending',
+          // sent but no stream_start yet). Stripping it would blank the current
+          // turn's indicator just because the user queued a follow-up. Append the
+          // queued bubble at the tail — after the existing thinking indicator,
+          // which stays attributed to the live turn — so it reads as "queued
+          // behind" rather than "now processing".
+          messages: [...ss.messages, userMsg],
           queuedMessages: enqueueOptimisticQueuedMessage(ss.queuedMessages, {
             clientMessageId: messageId,
             text,

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -161,6 +161,10 @@ import {
   CONNECT_RETRY_DELAYS,
   type ProbeResult,
   type ConnectEndpoint,
+  // #5939 (epic #5935 ④): optimistic queued-message helpers for the
+  // send-while-busy path + per-item cancel.
+  enqueueOptimisticQueuedMessage,
+  removeQueuedMessage,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
 // #5184: header cost-badge mode union, default, and runtime guard. Lives in
@@ -2128,13 +2132,38 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // so the same id is shared between the optimistic entry, the server's
     // history record, and any live-echo broadcast. Reconnect replay can
     // then dedup by id instead of by (content, timestamp) equality.
+    const messageId = opts?.clientMessageId || nextMessageId('user');
     const userMsg: ChatMessage = {
-      id: opts?.clientMessageId || nextMessageId('user'),
+      id: messageId,
       type: 'user_input',
       content: text,
       timestamp: Date.now(),
       ...(attachments?.length ? { attachments } : undefined),
     };
+
+    // #5939 (epic #5935 ④): send-while-busy QUEUES instead of starting a new
+    // turn. The server holds the message in its outgoing queue and flushes it
+    // on turn-complete (slice ①); here we add the optimistic user bubble but do
+    // NOT fake a new turn — no thinking indicator, no streamingMessageId reset
+    // (the live turn keeps its own) — and record the message id in the per-
+    // session `queuedMessages` model so the bubble renders a "Queued" badge
+    // (cleared by the server's message_dequeued on flush/cancel). The terminal
+    // echo above still fires so the Output view stays consistent.
+    if (opts?.queued) {
+      const activeId = get().activeSessionId;
+      if (activeId && get().sessionStates[activeId]) {
+        updateActiveSession((ss) => ({
+          messages: [...filterThinking(ss.messages), userMsg],
+          queuedMessages: enqueueOptimisticQueuedMessage(ss.queuedMessages, {
+            clientMessageId: messageId,
+            text,
+            queuedAt: Date.now(),
+          }),
+        }));
+      }
+      return;
+    }
+
     const thinkingMsg: ChatMessage = {
       id: 'thinking',
       type: 'thinking',
@@ -2249,9 +2278,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // instead of (content, timestamp) equality (issue #2902).
     const clientMessageId = nextMessageId('user');
 
-    // Show user message immediately (optimistic update + thinking indicator).
-    // Wire attachments use a different shape than MessageAttachment — pass text only for now.
-    get().addUserMessage(input, undefined, { clientMessageId });
+    // #5939: a send while the turn is in progress (streamingMessageId truthy)
+    // is QUEUED by the server, not concurrently force-sent. Reflect that
+    // optimistically — render the bubble with a "Queued" badge instead of
+    // faking a fresh turn. The server is authoritative (its message_queued /
+    // message_dequeued events reconcile the local model either way), so a
+    // mis-guess here only briefly misrenders before self-correcting.
+    const busy = get().getActiveSessionState().streamingMessageId !== null;
+
+    // Show user message immediately (optimistic update + thinking indicator, or
+    // a queued badge when busy). Wire attachments use a different shape than
+    // MessageAttachment — pass text only for now.
+    get().addUserMessage(input, undefined, { clientMessageId, queued: busy });
 
     const payload: Record<string, unknown> = { type: 'input', data: input, clientMessageId };
     if (activeSessionId) payload.sessionId = activeSessionId;
@@ -2335,6 +2373,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       return 'sent';
     }
     return enqueueMessage('cancel_activity', payload);
+  },
+
+  // #5943 (epic #5935 ④): cancel one QUEUED send-while-busy follow-up by its
+  // clientMessageId (the optimistic bubble id). Like cancel_activity, it is NOT
+  // queued offline — a cancel that drains after a reconnect races the flush — so
+  // it fires only on a live socket. Optimistically removes the local queued
+  // entry so the badge clears immediately; the server's authoritative
+  // message_dequeued(reason: 'cancelled') is idempotent with this removal.
+  sendCancelQueued: (clientMessageId: string, sessionId?: string) => {
+    const { socket, activeSessionId } = get();
+    const sid = sessionId ?? activeSessionId;
+    if (!(socket && socket.readyState === WebSocket.OPEN)) return false;
+    const payload: Record<string, unknown> = { type: 'cancel_queued', clientMessageId };
+    if (sid) payload.sessionId = sid;
+    if (sid && get().sessionStates[sid]) {
+      updateActiveSession((ss) => ({
+        queuedMessages: removeQueuedMessage(ss.queuedMessages, clientMessageId),
+      }));
+    }
+    wsSend(socket, payload);
+    return 'sent';
   },
 
   // #3068 — manual prompt evaluator. Returns a Promise that resolves with the

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2387,8 +2387,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!(socket && socket.readyState === WebSocket.OPEN)) return false;
     const payload: Record<string, unknown> = { type: 'cancel_queued', clientMessageId };
     if (sid) payload.sessionId = sid;
+    // Optimistically remove from the TARGET session's queue (updateSession, not
+    // updateActiveSession) so a future cross-session cancel — `sid` resolved
+    // from an explicit sessionId rather than the active one — clears the right
+    // queue, not whichever session happens to be active.
     if (sid && get().sessionStates[sid]) {
-      updateActiveSession((ss) => ({
+      updateSession(sid, (ss) => ({
         queuedMessages: removeQueuedMessage(ss.queuedMessages, clientMessageId),
       }));
     }

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -418,6 +418,38 @@ describe('useConnectionStore', () => {
       expect(payload.clientMessageId).toBe(bubble!.id);
     });
 
+    it('preserves the in-progress turn thinking indicator when queueing a follow-up', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      // streamingMessageId 'pending' = sent, awaiting stream_start; the thinking
+      // bubble for that live turn is present and must survive a queued follow-up.
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            streamingMessageId: 'pending',
+            messages: [
+              { id: 'uin-0', type: 'user_input', content: 'first', timestamp: 1 },
+              { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
+            ],
+            queuedMessages: [],
+          },
+        },
+      });
+
+      useConnectionStore.getState().sendInput('second');
+
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      // The live turn's thinking indicator is NOT stripped...
+      expect(ss.messages.some(m => m.id === 'thinking')).toBe(true);
+      // ...and the queued bubble lands at the tail (queued behind the live turn).
+      expect(ss.messages[ss.messages.length - 1]!.content).toBe('second');
+      expect(ss.queuedMessages).toHaveLength(1);
+    });
+
     it('does NOT queue when idle: normal optimistic turn (thinking + pending stream)', async () => {
       const { useConnectionStore, createEmptySessionState } = await import('./connection');
       const send = vi.fn();

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -464,6 +464,29 @@ describe('useConnectionStore', () => {
       expect(ss.queuedMessages.map(m => m.clientMessageId)).toEqual(['uin-2']);
     });
 
+    it('sendCancelQueued with an explicit sessionId clears THAT session, not the active one', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's-active',
+        sessionStates: {
+          's-active': { ...createEmptySessionState(), queuedMessages: [{ clientMessageId: 'uin-a', text: 'a', queuedAt: 1, status: 'confirmed' }] },
+          's-other': { ...createEmptySessionState(), queuedMessages: [{ clientMessageId: 'uin-b', text: 'b', queuedAt: 1, status: 'confirmed' }] },
+        },
+      });
+
+      useConnectionStore.getState().sendCancelQueued('uin-b', 's-other');
+
+      const states = useConnectionStore.getState().sessionStates;
+      // The target session's entry is removed; the ACTIVE session is untouched.
+      expect(states['s-other']!.queuedMessages).toHaveLength(0);
+      expect(states['s-active']!.queuedMessages.map(m => m.clientMessageId)).toEqual(['uin-a']);
+      const payload = JSON.parse(send.mock.calls[0]![0] as string);
+      expect(payload.sessionId).toBe('s-other');
+    });
+
     it('sendCancelQueued is a no-op offline (not queueable — races the flush)', async () => {
       const { useConnectionStore, createEmptySessionState } = await import('./connection');
       useConnectionStore.setState({

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -385,6 +385,101 @@ describe('useConnectionStore', () => {
     expect(useConnectionStore.getState().cancellingActivityIds.has('s1:act-1')).toBe(false);
   });
 
+  // #5939 (epic #5935 ④): send-while-busy queues (optimistic badge) instead of
+  // faking a new turn; per-item cancel sends cancel_queued + optimistically
+  // clears the local entry.
+  describe('#5939 queued send-while-busy', () => {
+    it('queues a send while the turn is in progress: optimistic bubble + pending queue entry, no new-turn fake', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), streamingMessageId: 'm-live', messages: [], queuedMessages: [] } },
+      });
+
+      useConnectionStore.getState().sendInput('follow-up');
+
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      // The live turn keeps its own streaming id — we did NOT reset it to 'pending'.
+      expect(ss.streamingMessageId).toBe('m-live');
+      // No optimistic thinking indicator for a queued follow-up.
+      expect(ss.messages.some(m => m.type === 'thinking')).toBe(false);
+      // The user bubble is shown, and its id is recorded in the queue model as pending.
+      const bubble = ss.messages.find(m => m.type === 'user_input');
+      expect(bubble?.content).toBe('follow-up');
+      expect(ss.queuedMessages).toHaveLength(1);
+      expect(ss.queuedMessages[0]!.status).toBe('pending');
+      expect(ss.queuedMessages[0]!.clientMessageId).toBe(bubble!.id);
+      // The input still goes over the wire (the server queues it authoritatively).
+      const payload = JSON.parse(send.mock.calls[0]![0] as string);
+      expect(payload.type).toBe('input');
+      expect(payload.clientMessageId).toBe(bubble!.id);
+    });
+
+    it('does NOT queue when idle: normal optimistic turn (thinking + pending stream)', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), streamingMessageId: null, messages: [], queuedMessages: [] } },
+      });
+
+      useConnectionStore.getState().sendInput('first');
+
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      expect(ss.streamingMessageId).toBe('pending');
+      expect(ss.messages.some(m => m.type === 'thinking')).toBe(true);
+      expect(ss.queuedMessages).toHaveLength(0);
+    });
+
+    it('sendCancelQueued sends cancel_queued and optimistically removes the local entry', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            queuedMessages: [
+              { clientMessageId: 'uin-1', text: 'a', queuedAt: 1, status: 'confirmed' },
+              { clientMessageId: 'uin-2', text: 'b', queuedAt: 2, status: 'confirmed' },
+            ],
+          },
+        },
+      });
+
+      const result = useConnectionStore.getState().sendCancelQueued('uin-1');
+
+      expect(result).toBe('sent');
+      const payload = JSON.parse(send.mock.calls[0]![0] as string);
+      expect(payload).toEqual({ type: 'cancel_queued', clientMessageId: 'uin-1', sessionId: 's1' });
+      // Optimistic local removal — only uin-2 remains.
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      expect(ss.queuedMessages.map(m => m.clientMessageId)).toEqual(['uin-2']);
+    });
+
+    it('sendCancelQueued is a no-op offline (not queueable — races the flush)', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      useConnectionStore.setState({
+        socket: null,
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), queuedMessages: [{ clientMessageId: 'uin-1', text: 'a', queuedAt: 1, status: 'confirmed' }] } },
+      });
+
+      const result = useConnectionStore.getState().sendCancelQueued('uin-1');
+
+      expect(result).toBe(false);
+      // Local entry untouched — no optimistic removal without a real send.
+      expect(useConnectionStore.getState().sessionStates.s1!.queuedMessages).toHaveLength(1);
+    });
+  });
+
   it('#5710: destroySession sends force:true only when forced', async () => {
     const { useConnectionStore } = await import('./connection');
     const send = vi.fn();

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -964,7 +964,7 @@ export interface ConnectionState {
   clearSavedConnection: () => void;
   setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool') => void;
   addMessage: (message: ChatMessage) => void;
-  addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string }) => void;
+  addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
   appendTerminalData: (data: string) => void;
   clearTerminalBuffer: () => void;
   setTerminalWriteCallback: (cb: ((data: string) => void) | null) => void;
@@ -996,6 +996,16 @@ export interface ConnectionState {
    * failure surfaces as the existing `session_error` toast.
    */
   sendCancelActivity: (activityId: string, sessionId?: string) => 'sent' | 'queued' | false;
+  /**
+   * #5943 (epic #5935 ④): cancel ONE queued send-while-busy follow-up by its
+   * `clientMessageId` (the optimistic bubble id). Sends `cancel_queued`; the
+   * server removes the queued entry and emits `message_dequeued(reason:
+   * 'cancelled')`, which clears the queued badge. Optimistically removes the
+   * local queued entry too so the badge clears immediately. NOT queued offline
+   * — a cancel that drains seconds later races the flush, so it only fires on a
+   * live socket. Targets `sessionId` if given, else the active session.
+   */
+  sendCancelQueued: (clientMessageId: string, sessionId?: string) => 'sent' | false;
   /** #3068 — Run the prompt evaluator on a draft. Resolves with the verdict
    * payload, or rejects on disconnect / 60s timeout. Errors from the server
    * arrive as the `error` field on the resolved value, not as a Promise reject. */

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2462,6 +2462,56 @@ button.sidebar-token-view-session-row:hover {
   line-height: 1;
 }
 
+/* #5939 (epic #5935 ④): a send-while-busy follow-up is held in the server's
+   outgoing queue and flushes on turn-complete. The bubble is dimmed and dashed
+   to read as "not sent yet", with a small "Queued" pill + cancel control. */
+.msg.queued {
+  opacity: 0.72;
+  border: 1px dashed var(--accent-blue);
+}
+
+.msg-queued {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.msg-queued-label {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-blue) 22%, transparent);
+  color: var(--accent-blue);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.msg-queued-cancel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.msg-queued-cancel:hover {
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-primary);
+}
+
 .scroll-to-bottom {
   position: absolute;
   bottom: 12px;


### PR DESCRIPTION
## What

Slice ④ of epic #5935. The dashboard currently **force-sends concurrently** during a turn and optimistically fakes a fresh turn (thinking indicator + `streamingMessageId` reset). Now that the server queues a mid-turn send (slice ① #5936) and store-core mirrors it (slice ② #5937), this reflects that: a **send-while-busy queues**, renders distinctly, and auto-sends on turn-complete (FIFO, server-driven).

## ⚠️ Visual review requested before merge

Per the queue-UI plan, UI is not self-merged unseen. A faithful preview (real `theme.css` + `components.css`, exact `DefaultMessageRow` markup) is rendered below — the artifacts are on the dev machine at:
`~/chroxy-visual-review/5939-dashboard-queued-ui/` (`queued-ui.png` + `preview.html`).

The queued bubble is **dimmed with a dashed blue border**, carries a blue **"QUEUED"** pill and a **✕ cancel** button, and is visually distinct from a solid sent bubble and the streaming assistant bubble.

## Design (per the issue's analysis)

A queued message is **already recorded in history + echoed to other clients as sent** at enqueue time (slice ①), so the cleanest model is a **"queued" decoration on the normal optimistic bubble** (keyed by `clientMessageId`, which already equals the optimistic bubble id), NOT a separate bubble. The badge clears on `message_dequeued` (flush / cancel / interrupt); the bubble persists — consistent with history, reconnect-replay, and every other client.

## Changes

- **connection.ts** — `sendInput` detects an in-progress turn (`streamingMessageId` truthy) and routes `addUserMessage` down a `queued` branch: adds the optimistic bubble but does NOT fake a new turn (no thinking msg, no streaming reset) and records the id in `queuedMessages` via `enqueueOptimisticQueuedMessage`. The input still goes on the wire — the server queues it authoritatively and its `message_queued`/`message_dequeued` events reconcile the local model.
- **`sendCancelQueued(clientMessageId)`** — sends `cancel_queued` (#5943) + optimistically removes the local entry; not queued offline (a late cancel races the flush).
- **ChatView / DefaultMessageRow** — a `user_input` row whose id is in `queuedIds` renders the badge + cancel. Props are a stable `Set` + stable callback so the row memo still skips unaffected rows; the hidden-tab memo gate is unchanged.
- **App.tsx** — derive `queuedIds` from the active session's `queuedMessages` + a stable `onCancelQueued`; pass to the two chat `ChatView` sites.
- **components.css** — `.msg.queued` + `.msg-queued` badge/cancel styles.

## Acceptance criteria

- ✅ AC1 — send-while-busy queues (distinct UI) and auto-sends on turn-complete (server FIFO flush); no concurrent force-send fake-turn.
- ✅ AC2 — queued items cancellable (`cancel_queued`, #5943); per-session; clears on switch (queue lives in per-session state).
- ✅ AC3 — Stop clears the WHOLE queue server-side (`clearOutgoingQueue` → `message_dequeued(interrupted)`), which store-core already removes — no extra dashboard wiring.
- ✅ AC4 — vitest: store enqueue-vs-send branch (busy→queued, idle→normal) + `sendCancelQueued` (send + optimistic remove, offline no-op); ChatView badge render + cancel click.

Full dashboard suite green (3778); dashboard tsc clean.

Closes #5939