### PR TITLE
feat(dashboard): unify the send-while-busy queue trigger with the input busy state (#5952)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2285,13 +2285,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // instead of (content, timestamp) equality (issue #2902).
     const clientMessageId = nextMessageId('user');
 
-    // #5939: a send while the turn is in progress (streamingMessageId truthy)
-    // is QUEUED by the server, not concurrently force-sent. Reflect that
-    // optimistically — render the bubble with a "Queued" badge instead of
-    // faking a fresh turn. The server is authoritative (its message_queued /
-    // message_dequeued events reconcile the local model either way), so a
-    // mis-guess here only briefly misrenders before self-correcting.
-    const busy = get().getActiveSessionState().streamingMessageId !== null;
+    // #5939 / #5952: a send while the turn is in progress is QUEUED by the
+    // server, not concurrently force-sent. Reflect that optimistically — render
+    // the bubble with a "Queued" badge instead of faking a fresh turn.
+    //
+    // #5952: the busy signal must match EXACTLY what the InputBar shows as busy
+    // (`isStreaming || isBusy` → `streamingMessageId !== null || isIdle === false`)
+    // so there is no window where the input UI says "busy" (Stop visible, "Type
+    // to send follow-up…") yet a send optimistically fakes a fresh turn. `isIdle`
+    // is the server-authoritative working flag (#4639); `streamingMessageId`
+    // additionally covers the optimistic pre-status window. Either ⇒ queue. The
+    // server is authoritative regardless (it queues any mid-turn input and
+    // reconciles via message_queued/message_dequeued), so this only keeps the
+    // optimistic render honest.
+    const active = get().getActiveSessionState();
+    const busy = active.streamingMessageId !== null || active.isIdle === false;
 
     // Show user message immediately (optimistic update + thinking indicator, or
     // a queued badge when busy). Wire attachments use a different shape than

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -450,6 +450,30 @@ describe('useConnectionStore', () => {
       expect(ss.queuedMessages).toHaveLength(1);
     });
 
+    it('#5952: queues when the server says busy (isIdle false) even if streamingMessageId is still null', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      // The pre-stream window: the server reported the turn busy (isIdle:false)
+      // but no stream_start has set streamingMessageId yet. The InputBar shows
+      // its busy UI here (isBusy = !isIdle), so a send must QUEUE — not fake a
+      // fresh turn — matching the input affordance.
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), isIdle: false, streamingMessageId: null, messages: [], queuedMessages: [] } },
+      });
+
+      useConnectionStore.getState().sendInput('follow-up');
+
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      expect(ss.queuedMessages).toHaveLength(1);
+      expect(ss.queuedMessages[0]!.status).toBe('pending');
+      // Did NOT fake a new turn.
+      expect(ss.messages.some(m => m.type === 'thinking')).toBe(false);
+      expect(ss.streamingMessageId).toBeNull();
+    });
+
     it('does NOT queue when idle: normal optimistic turn (thinking + pending stream)', async () => {
       const { useConnectionStore, createEmptySessionState } = await import('./connection');
       const send = vi.fn();


### PR DESCRIPTION
## What

Sub-issue of epic #5951; hardens the queue behavior from #5939/#5935.

`sendInput` decided whether to queue a send-while-busy message from `streamingMessageId !== null` **alone**, but the InputBar shows its busy UI (Stop button, "Type to send follow-up…") from `isStreaming || isBusy` = `streamingMessageId !== null || isIdle === false`.

In the **pre-stream window** — the server reported the turn busy (`isIdle: false`) but no `stream_start` has set `streamingMessageId` yet — those two signals diverged: the input UI said "busy" while a send optimistically **faked a fresh turn** instead of queuing. That's the "you can force an input mid-turn" gap.

## Fix

Unify the queue trigger to the **same** signal the InputBar uses:

```
busy = active.streamingMessageId !== null || active.isIdle === false
```

`isIdle` is the server-authoritative working flag (#4639); `streamingMessageId` covers the optimistic pre-status window. Either ⇒ queue. Now **whenever the InputBar shows busy, a send queues** — there's no force-send-fake-turn window.

The server already queues any mid-turn `input` authoritatively and reconciles via `message_queued`/`message_dequeued`, so this only keeps the optimistic render honest (no protocol-level force-send was ever possible).

## Acceptance criteria

- ✅ No input path force-sends a message that jumps a running turn — every path routes through `sendInput`, which now queues whenever busy (Enter/Send/voice/evaluator-clarify resend all go through it).
- ✅ Stop is always visible + clickable while streaming or busy — already implemented (#3850) and covered by `InputBar.test.tsx` (`shows interrupt button when isStreaming`/`isBusy`, both-Send-and-Stop with draft).
- ✅ Busy queue trigger unit-tested: a send with `isIdle:false` + `streamingMessageId:null` now queues (pending, no thinking bubble, no streaming reset).

Full dashboard suite green (3781); tsc clean.

Closes #5952