### PR TITLE
feat(dashboard): in-chat "Claude is working" indicator with live tool surfacing (#5953)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -13,6 +13,7 @@ import {
   expandPasteMarkers,
   resolveContextWindow,
   providerSupportsMultiQuestion,
+  formatToolName,
   type SessionInfo,
 } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
@@ -33,7 +34,7 @@ import { processImageFiles, filterImageFiles } from './utils/image-utils'
 import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
 import { formatTranscript } from './lib/transcript'
-import { ActivityIndicator } from './components/ActivityIndicator'
+import { ActivityIndicator, findInFlightToolUse } from './components/ActivityIndicator'
 import { CheckInChip } from './components/CheckInChip'
 import { EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
 import { SessionNotFoundChip } from './components/SessionNotFoundChip'
@@ -268,6 +269,17 @@ export function App() {
     () => new Set((queuedMessages || []).map(m => m.clientMessageId).filter((id): id is string => !!id)),
     [queuedMessages],
   )
+
+  // #5953 (epic #5951): label for the in-chat "Claude is working" indicator.
+  // Surfaces the current in-flight tool ("Running Bash…") using the same
+  // detection the ActivityIndicator uses; falls back to undefined so the
+  // indicator shows its generic default ("Claude is working…"). The walk is
+  // O(1) in practice (the unresolved tool is at the tail) and the label string
+  // is stable across response tokens (it only changes when the tool changes).
+  const workingLabel = useMemo(() => {
+    const inFlight = findInFlightToolUse(storeMessages)
+    return inFlight ? `Running ${formatToolName(inFlight.tool, inFlight.serverName)}…` : undefined
+  }, [storeMessages])
 
   // #4735 / #4731: the multi-question AskUserQuestion form is gated per
   // session type. TUI / CLI sessions (`claude-tui` / `claude-cli`) keep
@@ -2076,6 +2088,7 @@ export function App() {
                         scrollToBottomSignal={scrollToBottomSignal}
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
+                        workingLabel={workingLabel}
                       />
                     }
                     second={
@@ -2120,6 +2133,7 @@ export function App() {
                         scrollToBottomSignal={scrollToBottomSignal}
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
+                        workingLabel={workingLabel}
                       />
                     </div>
                     <div

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -51,6 +51,23 @@ describe('ChatView', () => {
     expect(screen.queryByTestId('thinking-dots')).not.toBeInTheDocument()
   })
 
+  // #5953 — the streaming tail shows the labelled WorkingIndicator.
+  it('shows the working indicator with the generic default label when streaming', () => {
+    render(<ChatView messages={makeMessages(1)} isStreaming />)
+    expect(screen.getByTestId('working-indicator')).toBeInTheDocument()
+    expect(screen.getByTestId('working-label')).toHaveTextContent('Claude is working…')
+  })
+
+  it('surfaces the in-flight activity via workingLabel', () => {
+    render(<ChatView messages={makeMessages(1)} isStreaming workingLabel="Running Bash…" />)
+    expect(screen.getByTestId('working-label')).toHaveTextContent('Running Bash…')
+  })
+
+  it('hides the working indicator when idle', () => {
+    render(<ChatView messages={makeMessages(1)} isStreaming={false} isBusy={false} workingLabel="Running Bash…" />)
+    expect(screen.queryByTestId('working-indicator')).not.toBeInTheDocument()
+  })
+
   it('shows scroll-to-bottom button when scrolled up', () => {
     const messages = makeMessages(3)
     render(<ChatView messages={messages} isStreaming={false} />)

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -18,7 +18,7 @@
  */
 import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
 import { bumpRenderCount } from '@chroxy/store-core'
-import { ThinkingDots } from './ThinkingDots'
+import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
 import { MessageRowShell } from './MeasuredRow'
 import { ChatExpandContext, type ChatExpandRegistry } from './chatExpandRegistry'
@@ -159,6 +159,13 @@ export interface ChatViewProps {
   queuedIds?: ReadonlySet<string>
   /** #5939: cancel a single queued follow-up by its message id (cancel_queued). */
   onCancelQueued?: (id: string) => void
+  /**
+   * #5953 (epic #5951): label for the in-chat "Claude is working" indicator
+   * shown at the streaming tail. The parent derives it from the active session's
+   * in-flight tool ("Running Bash…") or passes nothing for the generic default
+   * ("Claude is working…"). A stable string so it doesn't churn per token.
+   */
+  workingLabel?: string
 }
 
 const TYPE_CLASS: Record<string, string> = {
@@ -302,7 +309,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
@@ -674,7 +681,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
               style={{ flex: '0 0 auto', height: range.bottomSpacer }}
             />
           )}
-          {(isStreaming || isBusy) && <ThinkingDots />}
+          {(isStreaming || isBusy) && <WorkingIndicator label={workingLabel} />}
         </div>
       </ChatExpandContext.Provider>
 

--- a/packages/dashboard/src/components/WorkingIndicator.test.tsx
+++ b/packages/dashboard/src/components/WorkingIndicator.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * WorkingIndicator tests (#5953, epic #5951).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { WorkingIndicator, DEFAULT_WORKING_LABEL } from './WorkingIndicator'
+
+afterEach(cleanup)
+
+describe('WorkingIndicator', () => {
+  it('shows the generic default label when none is supplied', () => {
+    render(<WorkingIndicator />)
+    expect(screen.getByTestId('working-label')).toHaveTextContent(DEFAULT_WORKING_LABEL)
+  })
+
+  it('falls back to the default for an empty label', () => {
+    render(<WorkingIndicator label="" />)
+    expect(screen.getByTestId('working-label')).toHaveTextContent(DEFAULT_WORKING_LABEL)
+  })
+
+  it('surfaces a provided activity label (e.g. the in-flight tool)', () => {
+    render(<WorkingIndicator label="Running Bash…" />)
+    expect(screen.getByTestId('working-label')).toHaveTextContent('Running Bash…')
+  })
+
+  it('keeps the animated dots (thinking-dots) for existing callers/tests', () => {
+    render(<WorkingIndicator label="Running Read…" />)
+    expect(screen.getByTestId('working-indicator')).toBeInTheDocument()
+    expect(screen.getByTestId('thinking-dots')).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/WorkingIndicator.tsx
+++ b/packages/dashboard/src/components/WorkingIndicator.tsx
@@ -1,0 +1,29 @@
+/**
+ * WorkingIndicator (#5953, epic #5951) — the in-chat "Claude is working" signal
+ * shown at the streaming tail while a turn is in progress.
+ *
+ * Replaces the bare three-dot `ThinkingDots` with a labelled affordance so a
+ * live turn reads as "Claude is actively doing something" rather than a static
+ * view that could be mistaken for a hang. The label surfaces the current
+ * activity — the in-flight tool ("Running Bash…") when one is running, else a
+ * generic "Claude is working…". `ThinkingDots` is kept INSIDE so its animation +
+ * `thinking-dots` test id are preserved for existing callers/tests.
+ *
+ * Presentational: the label is computed by the parent (App derives it from the
+ * active session's in-flight tool via `findInFlightToolUse` + `formatToolName`)
+ * and passed in, keeping ChatView store-free and unit-testable.
+ */
+import { ThinkingDots } from './ThinkingDots'
+
+export const DEFAULT_WORKING_LABEL = 'Claude is working…'
+
+export function WorkingIndicator({ label }: { label?: string }) {
+  return (
+    <div className="working-indicator" data-testid="working-indicator">
+      <ThinkingDots />
+      <span className="working-label" data-testid="working-label">
+        {label && label.length > 0 ? label : DEFAULT_WORKING_LABEL}
+      </span>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/WorkingIndicator.tsx
+++ b/packages/dashboard/src/components/WorkingIndicator.tsx
@@ -18,8 +18,16 @@ import { ThinkingDots } from './ThinkingDots'
 export const DEFAULT_WORKING_LABEL = 'Claude is working…'
 
 export function WorkingIndicator({ label }: { label?: string }) {
+  // role="status" + aria-live="polite" so a screen reader announces the working
+  // state + current activity (the visual dots alone are invisible to AT). Polite
+  // (not assertive) so it doesn't interrupt the streamed response being read.
   return (
-    <div className="working-indicator" data-testid="working-indicator">
+    <div
+      className="working-indicator"
+      data-testid="working-indicator"
+      role="status"
+      aria-live="polite"
+    >
       <ThinkingDots />
       <span className="working-label" data-testid="working-label">
         {label && label.length > 0 ? label : DEFAULT_WORKING_LABEL}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5151,6 +5151,29 @@ button.sidebar-token-view-session-row:hover {
   align-self: flex-start;
 }
 
+/* #5953 (epic #5951): in-chat "Claude is working" indicator at the streaming
+   tail — the animated dots plus a label surfacing the current activity, so a
+   live turn reads as actively working rather than a static/hung view. The
+   nested `.thinking-dots` drops its own padding so the row aligns tightly. */
+.working-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 14px 8px;
+}
+
+.working-indicator .thinking-dots {
+  padding: 0;
+}
+
+.working-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-style: italic;
+  line-height: 1;
+}
+
 .thinking-dot {
   width: 8px;
   height: 8px;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5165,6 +5165,10 @@ button.sidebar-token-view-session-row:hover {
 
 .working-indicator .thinking-dots {
   padding: 0;
+  /* `.thinking-dots` sets `align-self: flex-start` for its standalone use; in
+     the indicator row that top-aligns the dots against the label, so override
+     it back to the parent's center alignment. */
+  align-self: center;
 }
 
 .working-label {


### PR DESCRIPTION
## What

Sub-issue of epic #5951 (live-turn chat UX). The in-chat streaming indicator was a bare three-dot `ThinkingDots` — it didn't read clearly as *"Claude is actively working"* and surfaced no activity (it could be mistaken for a hang). This replaces it with a labelled `WorkingIndicator` at the streaming tail.

## Visual

Real-CSS preview saved at `~/Projects/chroxy/.visual-review/5953-working-indicator/` (`working-ui.png` + `preview.html`). Three states: generic **"Claude is working…"**, **"Running Bash…"**, **"Running Read…"** — animated dots + an italic muted label below the streaming bubble.

## Changes

- **`WorkingIndicator`** (new, presentational): animated dots + a label. Keeps `ThinkingDots` nested so its animation and `thinking-dots` test id survive for existing callers/tests.
- **Label surfaces the current activity**: the in-flight tool (`Running Bash…`), derived in App via the existing `findInFlightToolUse` + `formatToolName` — the *same* detection the `ActivityIndicator` already uses — falling back to `Claude is working…` when no tool is running.
- **ChatView** gains a `workingLabel` prop (presentational, store-free); **App** passes it to the two chat ChatView sites. The label is memoized on `storeMessages` and is **stable across response tokens** (changes only when the tool changes), so it doesn't churn the render.
- **CSS**: `.working-indicator` / `.working-label`.

## Acceptance criteria

- ✅ While a turn streams, a clear persistent "Claude is working" affordance is visible and reads as active (not stalled).
- ✅ The current tool/action is surfaced live where applicable (`Running <Tool>…`).
- ✅ Clears cleanly on turn-complete (gated on `isStreaming || isBusy`); does not collide with the #5939 queued badge (separate component/markup).
- ✅ Render/unit coverage (`WorkingIndicator.test.tsx` + ChatView tests).

Full dashboard suite green (3788); tsc clean.

Closes #5953