### PR TITLE
fix(dashboard): keep the streaming auto-scroll pinned to the bottom (#5954 part 1)

### DIFF
--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -210,10 +210,14 @@ describe('ChatView', () => {
     vi.useRealTimers()
   })
 
-  // #5954 — the streaming RAF keeps re-pinning to the growing bottom, and its
-  // own (programmatic) scroll events must not be misread as a user scroll-up
-  // (which would kill the auto-follow). Mirrors the suppression contract that
-  // `scrollToBottomNow` owns (next-frame flag clear).
+  // #5954 — behavior guard: the streaming RAF keeps re-pinning to the growing
+  // bottom, and an at-bottom self-induced scroll does not surface the
+  // scroll-to-bottom button. NOTE: this is a happy-path guard, not a regression
+  // test for the deferred-flag-clear fix specifically — the exact
+  // synchronous-vs-next-frame `programmaticScrollRef` timing depends on the
+  // browser's async scroll-event dispatch ordering, which jsdom doesn't model,
+  // so it would also pass on the pre-fix code. The suppression fix is verified
+  // by reasoning + on-device confirmation (#5954 stays open for the live check).
   it('keeps following the bottom while streaming as content grows (#5954)', async () => {
     vi.useFakeTimers()
     render(<ChatView messages={makeMessages(3)} isStreaming />)

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -210,6 +210,34 @@ describe('ChatView', () => {
     vi.useRealTimers()
   })
 
+  // #5954 — the streaming RAF keeps re-pinning to the growing bottom, and its
+  // own (programmatic) scroll events must not be misread as a user scroll-up
+  // (which would kill the auto-follow). Mirrors the suppression contract that
+  // `scrollToBottomNow` owns (next-frame flag clear).
+  it('keeps following the bottom while streaming as content grows (#5954)', async () => {
+    vi.useFakeTimers()
+    render(<ChatView messages={makeMessages(3)} isStreaming />)
+    const container = screen.getByTestId('chat-messages')
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 0, writable: true, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+
+    // Streaming RAF pins to the current bottom.
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(1000)
+
+    // Content grows (a stream_delta) — the RAF re-pins to the NEW bottom.
+    Object.defineProperty(container, 'scrollHeight', { value: 1500, configurable: true })
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(1500)
+
+    // The self-induced scroll event (flag still held) must NOT surface the
+    // scroll-to-bottom button — i.e. it isn't misread as a user scroll-up.
+    await act(() => { fireEvent.scroll(container) })
+    expect(screen.queryByTestId('scroll-to-bottom')).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
   it('snaps to bottom when scrollToBottomSignal bumps, even if scrolled up (#5780)', async () => {
     vi.useFakeTimers()
     const messages = makeMessages(3)

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -591,22 +591,30 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
     requestAnimationFrame(() => { scrollToBottomNow() })
   }, [scrollToBottomSignal, scrollToBottomNow])
 
-  // During streaming, continuously scroll to bottom via RAF
+  // During streaming, continuously re-pin to the bottom via RAF so the growing
+  // tail stays in view. #5954: reuse `scrollToBottomNow()` rather than an inline
+  // `scrollTop = scrollHeight` with a SYNCHRONOUS `programmaticScrollRef` clear.
+  // The synchronous clear violated the suppression contract (the flag was
+  // already false by the time the write's async `scroll` event reached
+  // `handleScroll`), so a streaming scroll event landing in a transient
+  // not-quite-at-bottom window (windowing churn / content growth between the
+  // write and the event) was misread as a user scroll-up — which flipped
+  // `userScrolledUp` and KILLED the auto-follow effect, dropping the live tail
+  // below the fold ("doesn't consistently stay at the bottom"). `scrollToBottomNow`
+  // holds the flag until the next frame, so `handleScroll`'s
+  // `programmaticScrollRef.current && atBottom` guard reliably ignores the
+  // self-induced events while a genuine user scroll-up (atBottom false) is still
+  // honored.
   useEffect(() => {
     if (!isStreaming || userScrolledUp) return
     let rafId: number
     const tick = () => {
-      const el = containerRef.current
-      if (el) {
-        programmaticScrollRef.current = true
-        el.scrollTop = el.scrollHeight
-        programmaticScrollRef.current = false
-      }
+      scrollToBottomNow()
       rafId = requestAnimationFrame(tick)
     }
     rafId = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(rafId)
-  }, [isStreaming, userScrolledUp])
+  }, [isStreaming, userScrolledUp, scrollToBottomNow])
 
   // #5561 — the windowed slice. Only rows in [startIndex, endIndex) mount; the
   // top/bottom spacers reserve the height of the skipped rows so the scrollbar


### PR DESCRIPTION
## What

Partial fix for #5954 (epic #5951) — the **stick-to-bottom-during-streaming** half.

The streaming auto-follow RAF set `scrollTop = scrollHeight` and cleared `programmaticScrollRef` **synchronously**, violating the suppression contract `scrollToBottomNow` documents (clear on the *next* frame so the write's async `scroll` event isn't misread as a user scroll).

Because the flag was already `false` by the time the synthetic `scroll` reached `handleScroll`, a streaming scroll landing in a transient not-quite-at-bottom window (windowing churn, or content growth between the write and the event) was **misclassified as a user scroll-up** — which flipped `userScrolledUp`, **killed the auto-follow effect**, and dropped the live tail below the fold. That matches the reported "doesn't consistently stay at the bottom".

## Fix

Reuse the proven `scrollToBottomNow()` primitive inside the streaming RAF instead of the inline write. It holds the flag until the next frame, so `handleScroll`'s `programmaticScrollRef.current && atBottom` guard reliably ignores the self-induced events. A genuine user scroll-up (`atBottom` false) is still honored, so scroll-up-to-read-history during streaming is unaffected. This is a strict consistency fix — the streaming RAF now behaves like the mount / count-follow / signal effects that already use `scrollToBottomNow`.

## Verification & what's left

- Unit: streaming re-pins to the growing bottom; a self-induced scroll does not surface the scroll-to-bottom button. Full dashboard suite green (3789); tsc clean.
- ⚠️ **Scroll *feel* can't be screenshot/unit-verified** — needs on-device confirmation. **`Part of #5954`, not `Closes`** — the issue stays open for:
  1. your live confirmation that the tail now stays pinned during a long streaming turn, and
  2. the **input-bar-occlusion** half (the input bar is a flex sibling with 16px padding, so I couldn't reproduce a true occlusion from static analysis — likely needs a live repro to pin down, if it's distinct from this stick-to-bottom bug).

Part of #5954