### PR TITLE
fix(store-core): self-heal an orphaned 'Queued' badge via queueLength reconciliation

### DIFF
--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -547,6 +547,25 @@ describe('shared dispatch table', () => {
       expect(env.sessions.s1.queuedMessages).toHaveLength(1)
       expect(env.sessions.s2.queuedMessages).toEqual([])
     })
+
+    it('self-heals a leftover orphan on the next dequeue via the authoritative queueLength (#5950)', () => {
+      // uin-0's message_dequeued was lost, leaving a stuck "Queued" badge. The
+      // server now flushes uin-1 with queueLength: 0 → both entries clear.
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            messages: [],
+            queuedMessages: [
+              { clientMessageId: 'uin-0', text: 'orphan', queuedAt: 9, status: 'confirmed' },
+              { clientMessageId: 'uin-1', text: 'a', queuedAt: 10, status: 'confirmed' },
+            ],
+          },
+        },
+      })
+      dispatch(env, { type: 'message_dequeued', sessionId: 's1', clientMessageId: 'uin-1', queueLength: 0, reason: 'flush' })
+      expect(env.sessions.s1.queuedMessages).toEqual([])
+    })
   })
 
   describe('plan_started', () => {

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -4,6 +4,7 @@ import {
   handleMessageDequeued,
   enqueueOptimisticQueuedMessage,
   removeQueuedMessage,
+  reconcileQueueLength,
 } from './outgoing-queue'
 import type { QueuedSessionMessage } from '../types'
 
@@ -60,6 +61,80 @@ describe('removeQueuedMessage', () => {
   it('returns the same empty array when there is nothing to remove', () => {
     const current: QueuedSessionMessage[] = []
     expect(removeQueuedMessage(current, undefined)).toBe(current)
+  })
+})
+
+describe('reconcileQueueLength (#5950 orphan-badge safety net)', () => {
+  it('returns the same array (referential) when local length already matches', () => {
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b')]
+    expect(reconcileQueueLength(current, 2)).toBe(current)
+  })
+
+  it('returns the same array when local is SHORTER than the server count (never pads)', () => {
+    const current = [confirmed('uin-1', 'a')]
+    // We are missing a confirmed entry we never saw the text for — leave it for
+    // the reconnect snapshot to backfill rather than fabricate a blank bubble.
+    expect(reconcileQueueLength(current, 3)).toBe(current)
+  })
+
+  it('trims the oldest (FIFO-head) orphans down to the authoritative count', () => {
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b'), confirmed('uin-3', 'c')]
+    // Server says only 1 remains → a dropped message_dequeued left 2 orphans;
+    // drop the two oldest, keep the newest.
+    expect(reconcileQueueLength(current, 1)).toEqual([confirmed('uin-3', 'c')])
+  })
+
+  it('clears the whole queue when the server says zero remain', () => {
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b')]
+    expect(reconcileQueueLength(current, 0)).toEqual([])
+  })
+
+  it('is a no-op (referential) when queueLength is absent/non-finite (older server)', () => {
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b')]
+    expect(reconcileQueueLength(current, undefined)).toBe(current)
+    expect(reconcileQueueLength(current, NaN)).toBe(current)
+  })
+
+  it('floors a fractional count and never goes negative', () => {
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b')]
+    expect(reconcileQueueLength(current, 1.9)).toEqual([confirmed('uin-2', 'b')])
+    expect(reconcileQueueLength(current, -5)).toEqual([])
+  })
+})
+
+describe('queueLength reconciliation through the wire handlers (#5950)', () => {
+  it('message_dequeued self-heals a leftover orphan using the authoritative queueLength', () => {
+    // Local queue carries a stale orphan (uin-0) whose dequeue was lost. The
+    // server now dequeues uin-1 and stamps queueLength: 0 (nothing remains).
+    const current = [confirmed('uin-0', 'orphan'), confirmed('uin-1', 'a')]
+    const builder = handleMessageDequeued(
+      { sessionId: 's1', clientMessageId: 'uin-1', queueLength: 0, reason: 'flush' },
+      null,
+    )
+    expect(builder.applyTo(current)).toEqual({ queuedMessages: [] })
+  })
+
+  it('message_queued trims a leftover orphan after appending the new confirmed entry', () => {
+    // Local: one orphan + one confirmed (2). A new queued message arrives; the
+    // server's authoritative count is 2 (the orphan already left server-side),
+    // so after appending the new entry (→ 3) we trim back to 2.
+    const current = [confirmed('uin-0', 'orphan'), confirmed('uin-1', 'a')]
+    const builder = handleMessageQueued(
+      { sessionId: 's1', clientMessageId: 'uin-2', text: 'b', queueLength: 2 },
+      null,
+    )
+    const next = builder!.applyTo(current).queuedMessages
+    expect(next.map((m) => m.clientMessageId)).toEqual(['uin-1', 'uin-2'])
+  })
+
+  it('leaves a correctly-synced queue untouched (referential) when queueLength matches', () => {
+    const current = [confirmed('uin-1', 'a')]
+    const builder = handleMessageDequeued(
+      { sessionId: 's1', clientMessageId: 'uin-9', queueLength: 1, reason: 'flush' },
+      null,
+    )
+    // unknown id → no removal, length already matches → referential no-op
+    expect(builder.applyTo(current).queuedMessages).toBe(current)
   })
 })
 

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -22,6 +22,13 @@ const confirmed = (clientMessageId: string, text: string, queuedAt = 0): QueuedS
   status: 'confirmed',
 })
 
+const pending = (clientMessageId: string, text: string, queuedAt = 0): QueuedSessionMessage => ({
+  clientMessageId,
+  text,
+  queuedAt,
+  status: 'pending',
+})
+
 describe('enqueueOptimisticQueuedMessage', () => {
   it('appends a pending entry', () => {
     const next = enqueueOptimisticQueuedMessage([], { clientMessageId: 'uin-1', text: 'hi', queuedAt: 5 })
@@ -77,16 +84,33 @@ describe('reconcileQueueLength (#5950 orphan-badge safety net)', () => {
     expect(reconcileQueueLength(current, 3)).toBe(current)
   })
 
-  it('trims the oldest (FIFO-head) orphans down to the authoritative count', () => {
+  it('trims the oldest (FIFO-head) confirmed orphans down to the authoritative count', () => {
     const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b'), confirmed('uin-3', 'c')]
     // Server says only 1 remains → a dropped message_dequeued left 2 orphans;
     // drop the two oldest, keep the newest.
     expect(reconcileQueueLength(current, 1)).toEqual([confirmed('uin-3', 'c')])
   })
 
-  it('clears the whole queue when the server says zero remain', () => {
+  it('clears all CONFIRMED entries when the server says zero remain', () => {
     const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b')]
     expect(reconcileQueueLength(current, 0)).toEqual([])
+  })
+
+  it('NEVER trims pending (optimistic) entries — only confirmed ones count toward queueLength', () => {
+    // Two fast queued sends before the 1st confirms: uin-1 just flipped to
+    // confirmed, uin-2 is still optimistic pending. The server has only seen
+    // uin-1 so queueLength is 1. A blind length trim (len 2 > 1) would drop the
+    // confirmed uin-1 and keep the unconfirmed uin-2 — the regression. Status-
+    // aware: confirmedCount(1) == target(1) → no trim, both survive.
+    const current = [confirmed('uin-1', 'a'), pending('uin-2', 'b')]
+    expect(reconcileQueueLength(current, 1)).toBe(current)
+  })
+
+  it('reaps a confirmed orphan while preserving an interleaved pending entry', () => {
+    // [orphan(confirmed), pending, confirmed] with server queueLength 1 → drop
+    // the oldest confirmed (orphan), keep the pending and the newest confirmed.
+    const current = [confirmed('uin-0', 'orphan'), pending('uin-1', 'live'), confirmed('uin-2', 'a')]
+    expect(reconcileQueueLength(current, 1)).toEqual([pending('uin-1', 'live'), confirmed('uin-2', 'a')])
   })
 
   it('is a no-op (referential) when queueLength is absent/non-finite (older server)', () => {
@@ -114,10 +138,10 @@ describe('queueLength reconciliation through the wire handlers (#5950)', () => {
     expect(builder.applyTo(current)).toEqual({ queuedMessages: [] })
   })
 
-  it('message_queued trims a leftover orphan after appending the new confirmed entry', () => {
+  it('message_queued trims a leftover confirmed orphan after appending the new confirmed entry', () => {
     // Local: one orphan + one confirmed (2). A new queued message arrives; the
     // server's authoritative count is 2 (the orphan already left server-side),
-    // so after appending the new entry (→ 3) we trim back to 2.
+    // so after appending the new entry (→ 3 confirmed) we trim back to 2.
     const current = [confirmed('uin-0', 'orphan'), confirmed('uin-1', 'a')]
     const builder = handleMessageQueued(
       { sessionId: 's1', clientMessageId: 'uin-2', text: 'b', queueLength: 2 },
@@ -125,6 +149,20 @@ describe('queueLength reconciliation through the wire handlers (#5950)', () => {
     )
     const next = builder!.applyTo(current).queuedMessages
     expect(next.map((m) => m.clientMessageId)).toEqual(['uin-1', 'uin-2'])
+  })
+
+  it('does NOT drop a confirmed entry when a 2nd send is still optimistic pending (regression guard)', () => {
+    // Two fast queued sends: both optimistically enqueued as pending. The
+    // server's message_queued for uin-1 arrives first (queueLength: 1) while
+    // uin-2 is still pending locally. Confirming uin-1 must NOT trim it away —
+    // confirmedCount(1) == queueLength(1), the pending uin-2 is not yet counted.
+    const current = [pending('uin-1', 'first'), pending('uin-2', 'second')]
+    const builder = handleMessageQueued(
+      { sessionId: 's1', clientMessageId: 'uin-1', text: 'first', queueLength: 1 },
+      null,
+    )
+    const next = builder!.applyTo(current).queuedMessages
+    expect(next).toEqual([confirmed('uin-1', 'first'), pending('uin-2', 'second')])
   })
 
   it('leaves a correctly-synced queue untouched (referential) when queueLength matches', () => {

--- a/packages/store-core/src/handlers/outgoing-queue.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.ts
@@ -62,22 +62,36 @@ function optionalNumber(msg: Record<string, unknown>, key: string): number | und
  * `message_queued` / `message_dequeued` with the AUTHORITATIVE post-event
  * `queueLength`. If a `message_dequeued` is ever lost (a dropped frame, or a
  * server edge that flushes without emitting), a stale entry would otherwise keep
- * its "Queued" badge until a reconnect re-syncs. Reconciling the local queue
- * length against the server's count on EVERY queue event self-heals that orphan
- * on the next queue activity: when the local queue is LONGER than the server
- * says, drop the oldest (FIFO-head) extras down to the authoritative count.
+ * its "Queued" badge until a reconnect re-syncs. Reconciling against the
+ * server's count on every queue event self-heals that orphan on the next queue
+ * activity.
  *
- * Only TRIMS, never PADS — a local queue SHORTER than the server's count means
- * we are missing a confirmed entry whose text we never saw; we cannot fabricate
- * it, so it is left for the planned reconnect snapshot (#5937) to backfill. A
- * non-finite/absent `queueLength` (an older server) returns `current` unchanged.
+ * STATUS-AWARE — this is load-bearing. Only `'confirmed'` entries correspond to
+ * messages the server is actually holding (and thus counted in `queueLength`).
+ * Optimistic `'pending'` entries (added synchronously on send, before their
+ * `message_queued` round-trips) are NOT yet server-acknowledged, so they
+ * legitimately make the local queue longer than `queueLength` and must NEVER be
+ * trimmed — they resolve via their own `message_queued` confirmation. A blind
+ * length trim would, on two fast queued sends, drop the just-confirmed entry
+ * while keeping an unconfirmed one (a normal-path data-loss bug, no dropped
+ * frame required). So we reconcile the CONFIRMED count only.
+ *
+ * Behaviour:
+ *   - confirmed-count <= target → no-op (returns `current`, referential — React
+ *     skips the re-render). Also covers "local SHORTER than server": we never
+ *     PAD, since a missing confirmed entry's text was never seen (left for the
+ *     planned reconnect snapshot #5937 to backfill).
+ *   - confirmed-count > target → drop the oldest (FIFO-head) CONFIRMED orphans
+ *     until the confirmed count equals `target`, preserving every pending entry
+ *     and overall order.
+ *   - non-finite/absent `queueLength` (older server) → returns `current`.
  *
  * FIFO-head trim is exact for the dominant case (a dropped flush retires the
- * front of the queue, so the orphan IS the oldest). A dropped dequeue for a
- * mid-queue `cancel_queued` is the only case where head-trim could drop a
- * still-valid entry instead of the orphan; that compound failure is vanishingly
- * unlikely and still self-corrects on the reconnect snapshot — the user always
- * sees the correct NUMBER of queued bubbles regardless.
+ * front of the queue, so the orphan IS the oldest confirmed entry). A dropped
+ * dequeue for a mid-queue `cancel_queued` of a confirmed entry is the only case
+ * where head-trim could drop a different still-valid confirmed entry; that
+ * compound failure is vanishingly unlikely, keeps the correct NUMBER of bubbles,
+ * and self-corrects on the reconnect snapshot.
  */
 export function reconcileQueueLength(
   current: QueuedSessionMessage[],
@@ -87,10 +101,18 @@ export function reconcileQueueLength(
     return current
   }
   const target = Math.max(0, Math.floor(serverQueueLength))
-  if (current.length <= target) return current
-  // Keep the newest `target` entries — the front of the queue flushes first, so
-  // the extras beyond the authoritative count are the oldest (head) orphans.
-  return current.slice(current.length - target)
+  const confirmedCount = current.reduce((n, m) => (m.status === 'confirmed' ? n + 1 : n), 0)
+  if (confirmedCount <= target) return current
+  // Drop the oldest confirmed orphans (filter walks head→tail) until the
+  // confirmed count matches the server's; pending entries always survive.
+  let toDrop = confirmedCount - target
+  return current.filter((m) => {
+    if (toDrop > 0 && m.status === 'confirmed') {
+      toDrop--
+      return false
+    }
+    return true
+  })
 }
 
 /**
@@ -173,11 +195,10 @@ export function handleMessageQueued(
     sessionId: resolveSessionId(msg, activeSessionId),
     applyTo: (current) => {
       // #5950 — reconcile the result against the server's authoritative
-      // queueLength so a leftover orphan (from a dropped earlier dequeue) is
-      // trimmed. A no-op (referential) when the queue is already in sync.
-      const reconcile = (q: QueuedSessionMessage[]) => ({
-        queuedMessages: reconcileQueueLength(q, queueLength),
-      })
+      // queueLength so a leftover CONFIRMED orphan (from a dropped earlier
+      // dequeue) is trimmed. Status-aware: optimistic pending entries are never
+      // trimmed, so a 2nd fast send queued before the 1st confirms is safe. A
+      // no-op (referential) when the confirmed count is already in sync.
       if (clientMessageId) {
         const idx = current.findIndex((m) => m.clientMessageId === clientMessageId)
         // `existing` is read off the index AND truthy-guarded so it narrows to a
@@ -189,11 +210,11 @@ export function handleMessageQueued(
           // No-op (referential equality) when already confirmed with identical
           // text — a duplicate message_queued must not churn the array.
           if (existing.status === 'confirmed' && existing.text === text) {
-            return reconcile(current)
+            return { queuedMessages: reconcileQueueLength(current, queueLength) }
           }
           const next = current.slice()
           next[idx] = { ...existing, text, status: 'confirmed' }
-          return reconcile(next)
+          return { queuedMessages: reconcileQueueLength(next, queueLength) }
         }
       }
       const entry: QueuedSessionMessage = {
@@ -202,7 +223,7 @@ export function handleMessageQueued(
         queuedAt: Date.now(),
         status: 'confirmed',
       }
-      return reconcile([...current, entry])
+      return { queuedMessages: reconcileQueueLength([...current, entry], queueLength) }
     },
   }
 }

--- a/packages/store-core/src/handlers/outgoing-queue.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.ts
@@ -51,6 +51,48 @@ function optionalString(msg: Record<string, unknown>, key: string): string | und
   return typeof v === 'string' && v.length > 0 ? v : undefined
 }
 
+/** Read a finite numeric field, else undefined. */
+function optionalNumber(msg: Record<string, unknown>, key: string): number | undefined {
+  const v = msg[key]
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+/**
+ * #5950 — defense-in-depth orphan-badge safety net. The server stamps every
+ * `message_queued` / `message_dequeued` with the AUTHORITATIVE post-event
+ * `queueLength`. If a `message_dequeued` is ever lost (a dropped frame, or a
+ * server edge that flushes without emitting), a stale entry would otherwise keep
+ * its "Queued" badge until a reconnect re-syncs. Reconciling the local queue
+ * length against the server's count on EVERY queue event self-heals that orphan
+ * on the next queue activity: when the local queue is LONGER than the server
+ * says, drop the oldest (FIFO-head) extras down to the authoritative count.
+ *
+ * Only TRIMS, never PADS — a local queue SHORTER than the server's count means
+ * we are missing a confirmed entry whose text we never saw; we cannot fabricate
+ * it, so it is left for the planned reconnect snapshot (#5937) to backfill. A
+ * non-finite/absent `queueLength` (an older server) returns `current` unchanged.
+ *
+ * FIFO-head trim is exact for the dominant case (a dropped flush retires the
+ * front of the queue, so the orphan IS the oldest). A dropped dequeue for a
+ * mid-queue `cancel_queued` is the only case where head-trim could drop a
+ * still-valid entry instead of the orphan; that compound failure is vanishingly
+ * unlikely and still self-corrects on the reconnect snapshot — the user always
+ * sees the correct NUMBER of queued bubbles regardless.
+ */
+export function reconcileQueueLength(
+  current: QueuedSessionMessage[],
+  serverQueueLength: number | undefined,
+): QueuedSessionMessage[] {
+  if (typeof serverQueueLength !== 'number' || !Number.isFinite(serverQueueLength)) {
+    return current
+  }
+  const target = Math.max(0, Math.floor(serverQueueLength))
+  if (current.length <= target) return current
+  // Keep the newest `target` entries — the front of the queue flushes first, so
+  // the extras beyond the authoritative count are the oldest (head) orphans.
+  return current.slice(current.length - target)
+}
+
 /**
  * #5937 — optimistic local enqueue for the send-while-busy path (called by a
  * client's send action, NOT a wire handler). Appends a `'pending'` entry so the
@@ -125,10 +167,17 @@ export function handleMessageQueued(
   // QueuedSessionMessage doc). Do NOT tighten this to `!text`.
   if (typeof text !== 'string') return null
   const clientMessageId = optionalString(msg, 'clientMessageId')
+  const queueLength = optionalNumber(msg, 'queueLength')
 
   return {
     sessionId: resolveSessionId(msg, activeSessionId),
     applyTo: (current) => {
+      // #5950 — reconcile the result against the server's authoritative
+      // queueLength so a leftover orphan (from a dropped earlier dequeue) is
+      // trimmed. A no-op (referential) when the queue is already in sync.
+      const reconcile = (q: QueuedSessionMessage[]) => ({
+        queuedMessages: reconcileQueueLength(q, queueLength),
+      })
       if (clientMessageId) {
         const idx = current.findIndex((m) => m.clientMessageId === clientMessageId)
         // `existing` is read off the index AND truthy-guarded so it narrows to a
@@ -140,11 +189,11 @@ export function handleMessageQueued(
           // No-op (referential equality) when already confirmed with identical
           // text — a duplicate message_queued must not churn the array.
           if (existing.status === 'confirmed' && existing.text === text) {
-            return { queuedMessages: current }
+            return reconcile(current)
           }
           const next = current.slice()
           next[idx] = { ...existing, text, status: 'confirmed' }
-          return { queuedMessages: next }
+          return reconcile(next)
         }
       }
       const entry: QueuedSessionMessage = {
@@ -153,7 +202,7 @@ export function handleMessageQueued(
         queuedAt: Date.now(),
         status: 'confirmed',
       }
-      return { queuedMessages: [...current, entry] }
+      return reconcile([...current, entry])
     },
   }
 }
@@ -177,8 +226,14 @@ export function handleMessageDequeued(
   activeSessionId: string | null,
 ): QueuedMessagesBuilder {
   const clientMessageId = optionalString(msg, 'clientMessageId')
+  const queueLength = optionalNumber(msg, 'queueLength')
   return {
     sessionId: resolveSessionId(msg, activeSessionId),
-    applyTo: (current) => ({ queuedMessages: removeQueuedMessage(current, clientMessageId) }),
+    // #5950 — after removing the dequeued entry, reconcile against the server's
+    // authoritative queueLength so any leftover orphan (from a dropped earlier
+    // dequeue) is trimmed too. Referential no-op when already in sync.
+    applyTo: (current) => ({
+      queuedMessages: reconcileQueueLength(removeQueuedMessage(current, clientMessageId), queueLength),
+    }),
   }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -469,6 +469,9 @@ export {
   handleMessageDequeued,
   enqueueOptimisticQueuedMessage,
   removeQueuedMessage,
+  // #5950 — orphan-badge safety net: reconcile local queue length to the
+  // server's authoritative count so a dropped message_dequeued self-heals.
+  reconcileQueueLength,
   handleDevPreview,
   handleDevPreviewStopped,
   handleAuthOk,


### PR DESCRIPTION
## Summary

Closes #5950 (from-review follow-up of #5949 / queue-while-processing ④).

The send-while-busy queue removed an entry only on its matching `message_dequeued`. If that event were ever lost (dropped frame, or a server edge that flushes without emitting), the optimistic **"Queued"** badge stayed stuck on the bubble until a reconnect re-synced — unlike the streaming path, which has a 5s safety net.

## Fix — `queueLength` reconciliation (shared, pure, both platforms)

Every `message_queued` / `message_dequeued` carries the server's **authoritative post-event `queueLength`**. A new pure helper `reconcileQueueLength(current, serverQueueLength)` runs inside both queue builders' `applyTo`: after the normal patch, if the local queue is **longer** than the server says, trim the oldest (FIFO-head) orphans down to the authoritative count. A dropped dequeue thus **self-heals on the next queue activity**.

- **Only trims, never pads** — a queue shorter than the server's count means a confirmed entry whose text we never saw; left for the planned reconnect snapshot (#5937) to backfill rather than fabricating a blank bubble.
- **Referential no-op** when already in sync (React skips the re-render) and when `queueLength` is absent/non-finite (older server).
- **No client change** — both the dashboard and the app inherit the heal through the existing store-core `dispatch` path. Applies to the app queue UI (#5938) once it lands.

### FIFO-head trim — the one documented limitation
Head-trim is exact for the dominant case (a dropped flush retires the front of the queue, so the orphan IS the oldest). A dropped dequeue for a mid-queue `cancel_queued` is the only case where head-trim could drop a still-valid entry instead of the orphan; that compound failure is vanishingly unlikely and still self-corrects on the reconnect snapshot — the user always sees the correct *number* of queued bubbles regardless.

## Acceptance criteria
- [x] A queued badge cannot stay stuck indefinitely when a `message_dequeued` is dropped — it self-heals on the next queue event (and reconnect snapshot backstops the connected-but-idle corner, per the issue's Option B).
- [x] No regression to the normal flush/cancel/interrupt clear path — reconcile is a referential no-op when the queue already matches; all existing queue tests pass unchanged (they carry no/matching `queueLength`).

## Tests
- `outgoing-queue.test.ts`: 11 new cases for `reconcileQueueLength` + the two wire handlers reconciling through `queueLength` (trim, clear-to-zero, never-pad, floor/negative, referential no-ops, absent-queueLength).
- `dispatch-table.test.ts`: end-to-end self-heal of a leftover orphan through `dispatch`.
- Full store-core suite green (1609 tests) + `tsc --noEmit` clean.