### PR TITLE
security(crypto): domain-separate the exchange-key signature (accept-both ramp, #5604 phase 1)

### DIFF
--- a/packages/store-core/dist/crypto.d.ts
+++ b/packages/store-core/dist/crypto.d.ts
@@ -38,16 +38,39 @@ export interface SigningKeyPair {
  */
 export declare function createSigningKeyPair(): SigningKeyPair;
 /**
+ * #5604 — domain-separation label for the exchange-key signature. The identity
+ * key today signs ONLY the exchange key, so the bare 32 bytes are unambiguous;
+ * but if the key is ever reused to sign another payload (rotation statements,
+ * capability grants, …) a context-free signature invites cross-protocol
+ * confusion. Prefixing this versioned ASCII label binds a signature to "this is
+ * an exchange key" so it can never be replayed as another statement. `v1` marks
+ * the scheme so a future change can bump it.
+ *
+ * Rollout is a compat ramp (see `verifyExchangeKeySignature`): the verifier
+ * accepts BOTH the bare and domain-separated forms now, so the signer can flip
+ * to the domain-separated form in a later release without forcing already-pinned
+ * clients to re-pair.
+ */
+export declare const EXCHANGE_KEY_SIG_DOMAIN_V1 = "chroxy-exchange-key-v1:";
+/**
  * Sign an ephemeral exchange public key (base64) with the identity secret key.
  * Returns the detached signature as base64. The signed message is the RAW bytes
  * of the exchange public key (decoded from base64), so both sides sign/verify
  * over identical bytes regardless of base64 canonicalisation.
  *
+ * `opts.domainSeparated` (#5604) prepends `EXCHANGE_KEY_SIG_DOMAIN_V1` to the
+ * signed bytes. Defaults to `false` (bare form) so existing callers — and the
+ * live wire format — are unchanged until the compat ramp flips the signer; the
+ * accept-both verifier ships first.
+ *
  * @param exchangePublicKeyBase64 - the per-connection X25519 public key to bind
  * @param identitySecretKey - the 64-byte Ed25519 secret key
+ * @param opts.domainSeparated - sign the domain-separated payload (default false)
  * @returns base64-encoded 64-byte detached signature
  */
-export declare function signExchangeKey(exchangePublicKeyBase64: string, identitySecretKey: Uint8Array): string;
+export declare function signExchangeKey(exchangePublicKeyBase64: string, identitySecretKey: Uint8Array, opts?: {
+    domainSeparated?: boolean;
+}): string;
 /**
  * Verify that `signatureBase64` is a valid Ed25519 signature over
  * `exchangePublicKeyBase64`, produced by the holder of the secret key matching
@@ -55,6 +78,13 @@ export declare function signExchangeKey(exchangePublicKeyBase64: string, identit
  * signature, false on any mismatch / malformed input. NEVER throws — a bad or
  * absent signature is a verification FAILURE the caller must treat as a refusal,
  * not an exception to swallow.
+ *
+ * #5604 — accepts a signature over EITHER the bare exchange-key bytes (today's
+ * signer) OR the domain-separated payload (`EXCHANGE_KEY_SIG_DOMAIN_V1` ++ bytes,
+ * the form the signer flips to in a later release). Both require the identity
+ * secret to produce, so accepting both does not weaken pinning — it only lets
+ * the signer migrate without forcing already-pinned clients to re-pair. A future
+ * release can drop the bare branch once the signer no longer emits it.
  *
  * @param exchangePublicKeyBase64 - the per-connection X25519 public key offered
  * @param signatureBase64 - the detached signature offered by the server

--- a/packages/store-core/dist/crypto.js
+++ b/packages/store-core/dist/crypto.js
@@ -145,6 +145,10 @@ export function verifyExchangeKeySignature(exchangePublicKeyBase64, signatureBas
             return false;
         // Bare form first (the live wire format — the common path); fall back to the
         // domain-separated form so a future signer flip verifies without a re-pair.
+        // TODO(#5959 phase 3): once the signer has emitted ONLY the domain-separated
+        // form for a full release, DROP the bare branch below — leaving it forever
+        // would defeat the domain separation (a context-free signature stays
+        // accepted). This accept-both window is deliberately temporary.
         return (nacl.sign.detached.verify(exchangeKeyBytes, sig, identityPub) ||
             nacl.sign.detached.verify(exchangeKeySigMessage(exchangeKeyBytes, true), sig, identityPub));
     }

--- a/packages/store-core/dist/crypto.js
+++ b/packages/store-core/dist/crypto.js
@@ -47,23 +47,59 @@ export function createSigningKeyPair() {
     return { publicKey: encodeBase64(kp.publicKey), secretKey: kp.secretKey };
 }
 /**
+ * #5604 — domain-separation label for the exchange-key signature. The identity
+ * key today signs ONLY the exchange key, so the bare 32 bytes are unambiguous;
+ * but if the key is ever reused to sign another payload (rotation statements,
+ * capability grants, …) a context-free signature invites cross-protocol
+ * confusion. Prefixing this versioned ASCII label binds a signature to "this is
+ * an exchange key" so it can never be replayed as another statement. `v1` marks
+ * the scheme so a future change can bump it.
+ *
+ * Rollout is a compat ramp (see `verifyExchangeKeySignature`): the verifier
+ * accepts BOTH the bare and domain-separated forms now, so the signer can flip
+ * to the domain-separated form in a later release without forcing already-pinned
+ * clients to re-pair.
+ */
+export const EXCHANGE_KEY_SIG_DOMAIN_V1 = 'chroxy-exchange-key-v1:';
+/**
+ * Build the byte string the identity key signs/verifies for an exchange key.
+ * Bare form = the raw 32 exchange-key bytes (today's wire format).
+ * Domain-separated form = `EXCHANGE_KEY_SIG_DOMAIN_V1` (ASCII) ++ the 32 bytes.
+ */
+function exchangeKeySigMessage(exchangeKeyBytes, domainSeparated) {
+    if (!domainSeparated)
+        return exchangeKeyBytes;
+    const prefix = new TextEncoder().encode(EXCHANGE_KEY_SIG_DOMAIN_V1);
+    const msg = new Uint8Array(prefix.length + exchangeKeyBytes.length);
+    msg.set(prefix, 0);
+    msg.set(exchangeKeyBytes, prefix.length);
+    return msg;
+}
+/**
  * Sign an ephemeral exchange public key (base64) with the identity secret key.
  * Returns the detached signature as base64. The signed message is the RAW bytes
  * of the exchange public key (decoded from base64), so both sides sign/verify
  * over identical bytes regardless of base64 canonicalisation.
  *
+ * `opts.domainSeparated` (#5604) prepends `EXCHANGE_KEY_SIG_DOMAIN_V1` to the
+ * signed bytes. Defaults to `false` (bare form) so existing callers — and the
+ * live wire format — are unchanged until the compat ramp flips the signer; the
+ * accept-both verifier ships first.
+ *
  * @param exchangePublicKeyBase64 - the per-connection X25519 public key to bind
  * @param identitySecretKey - the 64-byte Ed25519 secret key
+ * @param opts.domainSeparated - sign the domain-separated payload (default false)
  * @returns base64-encoded 64-byte detached signature
  */
-export function signExchangeKey(exchangePublicKeyBase64, identitySecretKey) {
+export function signExchangeKey(exchangePublicKeyBase64, identitySecretKey, opts = {}) {
     if (typeof exchangePublicKeyBase64 !== 'string' || exchangePublicKeyBase64.trim().length === 0) {
         throw new Error('signExchangeKey: exchange public key must be a non-empty base64 string');
     }
     if (!(identitySecretKey instanceof Uint8Array) || identitySecretKey.length !== nacl.sign.secretKeyLength) {
         throw new Error(`signExchangeKey: identity secret key must be a ${nacl.sign.secretKeyLength}-byte Uint8Array`);
     }
-    const message = new Uint8Array(decodeBase64(exchangePublicKeyBase64));
+    const exchangeKeyBytes = new Uint8Array(decodeBase64(exchangePublicKeyBase64));
+    const message = exchangeKeySigMessage(exchangeKeyBytes, opts.domainSeparated === true);
     const sig = nacl.sign.detached(message, identitySecretKey);
     return encodeBase64(sig);
 }
@@ -74,6 +110,13 @@ export function signExchangeKey(exchangePublicKeyBase64, identitySecretKey) {
  * signature, false on any mismatch / malformed input. NEVER throws — a bad or
  * absent signature is a verification FAILURE the caller must treat as a refusal,
  * not an exception to swallow.
+ *
+ * #5604 — accepts a signature over EITHER the bare exchange-key bytes (today's
+ * signer) OR the domain-separated payload (`EXCHANGE_KEY_SIG_DOMAIN_V1` ++ bytes,
+ * the form the signer flips to in a later release). Both require the identity
+ * secret to produce, so accepting both does not weaken pinning — it only lets
+ * the signer migrate without forcing already-pinned clients to re-pair. A future
+ * release can drop the bare branch once the signer no longer emits it.
  *
  * @param exchangePublicKeyBase64 - the per-connection X25519 public key offered
  * @param signatureBase64 - the detached signature offered by the server
@@ -87,20 +130,23 @@ export function verifyExchangeKeySignature(exchangePublicKeyBase64, signatureBas
             return false;
         if (typeof identityPublicKeyBase64 !== 'string' || identityPublicKeyBase64.length === 0)
             return false;
-        const message = new Uint8Array(decodeBase64(exchangePublicKeyBase64));
+        const exchangeKeyBytes = new Uint8Array(decodeBase64(exchangePublicKeyBase64));
         const sig = new Uint8Array(decodeBase64(signatureBase64));
         const identityPub = new Uint8Array(decodeBase64(identityPublicKeyBase64));
         // This function only ever verifies an X25519 EXCHANGE public key, so reject
         // anything that isn't 32 bytes up front — a wrong-length key is malformed
         // input, not a genuine signature mismatch. deriveSharedKey enforces the same
         // length downstream, but checking here keeps the signature API honest.
-        if (message.length !== nacl.box.publicKeyLength)
+        if (exchangeKeyBytes.length !== nacl.box.publicKeyLength)
             return false;
         if (sig.length !== nacl.sign.signatureLength)
             return false;
         if (identityPub.length !== nacl.sign.publicKeyLength)
             return false;
-        return nacl.sign.detached.verify(message, sig, identityPub);
+        // Bare form first (the live wire format — the common path); fall back to the
+        // domain-separated form so a future signer flip verifies without a re-pair.
+        return (nacl.sign.detached.verify(exchangeKeyBytes, sig, identityPub) ||
+            nacl.sign.detached.verify(exchangeKeySigMessage(exchangeKeyBytes, true), sig, identityPub));
     }
     catch {
         return false;

--- a/packages/store-core/src/crypto.test.ts
+++ b/packages/store-core/src/crypto.test.ts
@@ -16,6 +16,7 @@ import {
   createSigningKeyPair,
   signExchangeKey,
   verifyExchangeKeySignature,
+  EXCHANGE_KEY_SIG_DOMAIN_V1,
   DIRECTION_SERVER,
   DIRECTION_CLIENT,
 } from './crypto'
@@ -738,5 +739,61 @@ describe('server identity signing (#5536 — E2E key pinning)', () => {
     const identity = createSigningKeyPair()
     expect(decodeBase64(identity.publicKey).length).toBe(nacl.sign.publicKeyLength)
     expect(identity.secretKey.length).toBe(nacl.sign.secretKeyLength)
+  })
+})
+
+describe('exchange-key signature domain separation (#5604 compat ramp)', () => {
+  it('defaults to the bare form (unchanged wire format) when no opts are given', () => {
+    const identity = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const bare = signExchangeKey(exchange.publicKey, identity.secretKey)
+    const explicitBare = signExchangeKey(exchange.publicKey, identity.secretKey, { domainSeparated: false })
+    // Deterministic Ed25519 detached signatures: the default and explicit-bare
+    // forms must be byte-identical, proving the default did not change.
+    expect(bare).toBe(explicitBare)
+  })
+
+  it('the domain-separated signature differs from the bare one over the same key', () => {
+    const identity = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const bare = signExchangeKey(exchange.publicKey, identity.secretKey)
+    const domain = signExchangeKey(exchange.publicKey, identity.secretKey, { domainSeparated: true })
+    expect(domain).not.toBe(bare)
+  })
+
+  it('verify accepts the bare-form signature (today\'s signer)', () => {
+    const identity = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const bare = signExchangeKey(exchange.publicKey, identity.secretKey, { domainSeparated: false })
+    expect(verifyExchangeKeySignature(exchange.publicKey, bare, identity.publicKey)).toBe(true)
+  })
+
+  it('verify accepts the domain-separated signature (future signer flip — no re-pair)', () => {
+    const identity = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const domain = signExchangeKey(exchange.publicKey, identity.secretKey, { domainSeparated: true })
+    expect(verifyExchangeKeySignature(exchange.publicKey, domain, identity.publicKey)).toBe(true)
+  })
+
+  it('a domain-separated signature still fails against a DIFFERENT identity (no security loss)', () => {
+    const realIdentity = createSigningKeyPair()
+    const attackerIdentity = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const domain = signExchangeKey(exchange.publicKey, attackerIdentity.secretKey, { domainSeparated: true })
+    expect(verifyExchangeKeySignature(exchange.publicKey, domain, realIdentity.publicKey)).toBe(false)
+  })
+
+  it('a domain-separated signature fails against a SUBSTITUTED exchange key', () => {
+    const identity = createSigningKeyPair()
+    const realExchange = createKeyPair()
+    const otherExchange = createKeyPair()
+    const domain = signExchangeKey(realExchange.publicKey, identity.secretKey, { domainSeparated: true })
+    expect(verifyExchangeKeySignature(otherExchange.publicKey, domain, identity.publicKey)).toBe(false)
+  })
+
+  it('exposes a stable, versioned domain label', () => {
+    // Pin the exact label — changing it would silently break verification across
+    // a version skew, so a change must be deliberate (and bump the version).
+    expect(EXCHANGE_KEY_SIG_DOMAIN_V1).toBe('chroxy-exchange-key-v1:')
   })
 })

--- a/packages/store-core/src/crypto.test.ts
+++ b/packages/store-core/src/crypto.test.ts
@@ -791,6 +791,18 @@ describe('exchange-key signature domain separation (#5604 compat ramp)', () => {
     expect(verifyExchangeKeySignature(otherExchange.publicKey, domain, identity.publicKey)).toBe(false)
   })
 
+  it('a tampered domain-separated signature fails verification', () => {
+    const identity = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const domain = signExchangeKey(exchange.publicKey, identity.secretKey, { domainSeparated: true })
+    const bytes = decodeBase64(domain)
+    bytes[0] ^= 0xff
+    const tampered = encodeBase64(bytes)
+    // The domain-separated branch must reject a corrupted signature just like
+    // the bare branch — accept-both widens the accepted MESSAGES, not forgeries.
+    expect(verifyExchangeKeySignature(exchange.publicKey, tampered, identity.publicKey)).toBe(false)
+  })
+
   it('exposes a stable, versioned domain label', () => {
     // Pin the exact label — changing it would silently break verification across
     // a version skew, so a change must be deliberate (and bump the version).

--- a/packages/store-core/src/crypto.ts
+++ b/packages/store-core/src/crypto.ts
@@ -193,6 +193,10 @@ export function verifyExchangeKeySignature(
     if (identityPub.length !== nacl.sign.publicKeyLength) return false
     // Bare form first (the live wire format — the common path); fall back to the
     // domain-separated form so a future signer flip verifies without a re-pair.
+    // TODO(#5959 phase 3): once the signer has emitted ONLY the domain-separated
+    // form for a full release, DROP the bare branch below — leaving it forever
+    // would defeat the domain separation (a context-free signature stays
+    // accepted). This accept-both window is deliberately temporary.
     return (
       nacl.sign.detached.verify(exchangeKeyBytes, sig, identityPub) ||
       nacl.sign.detached.verify(exchangeKeySigMessage(exchangeKeyBytes, true), sig, identityPub)

--- a/packages/store-core/src/crypto.ts
+++ b/packages/store-core/src/crypto.ts
@@ -91,23 +91,64 @@ export function createSigningKeyPair(): SigningKeyPair {
 }
 
 /**
+ * #5604 — domain-separation label for the exchange-key signature. The identity
+ * key today signs ONLY the exchange key, so the bare 32 bytes are unambiguous;
+ * but if the key is ever reused to sign another payload (rotation statements,
+ * capability grants, …) a context-free signature invites cross-protocol
+ * confusion. Prefixing this versioned ASCII label binds a signature to "this is
+ * an exchange key" so it can never be replayed as another statement. `v1` marks
+ * the scheme so a future change can bump it.
+ *
+ * Rollout is a compat ramp (see `verifyExchangeKeySignature`): the verifier
+ * accepts BOTH the bare and domain-separated forms now, so the signer can flip
+ * to the domain-separated form in a later release without forcing already-pinned
+ * clients to re-pair.
+ */
+export const EXCHANGE_KEY_SIG_DOMAIN_V1 = 'chroxy-exchange-key-v1:'
+
+/**
+ * Build the byte string the identity key signs/verifies for an exchange key.
+ * Bare form = the raw 32 exchange-key bytes (today's wire format).
+ * Domain-separated form = `EXCHANGE_KEY_SIG_DOMAIN_V1` (ASCII) ++ the 32 bytes.
+ */
+function exchangeKeySigMessage(exchangeKeyBytes: Uint8Array, domainSeparated: boolean): Uint8Array {
+  if (!domainSeparated) return exchangeKeyBytes
+  const prefix = new TextEncoder().encode(EXCHANGE_KEY_SIG_DOMAIN_V1)
+  const msg = new Uint8Array(prefix.length + exchangeKeyBytes.length)
+  msg.set(prefix, 0)
+  msg.set(exchangeKeyBytes, prefix.length)
+  return msg
+}
+
+/**
  * Sign an ephemeral exchange public key (base64) with the identity secret key.
  * Returns the detached signature as base64. The signed message is the RAW bytes
  * of the exchange public key (decoded from base64), so both sides sign/verify
  * over identical bytes regardless of base64 canonicalisation.
  *
+ * `opts.domainSeparated` (#5604) prepends `EXCHANGE_KEY_SIG_DOMAIN_V1` to the
+ * signed bytes. Defaults to `false` (bare form) so existing callers — and the
+ * live wire format — are unchanged until the compat ramp flips the signer; the
+ * accept-both verifier ships first.
+ *
  * @param exchangePublicKeyBase64 - the per-connection X25519 public key to bind
  * @param identitySecretKey - the 64-byte Ed25519 secret key
+ * @param opts.domainSeparated - sign the domain-separated payload (default false)
  * @returns base64-encoded 64-byte detached signature
  */
-export function signExchangeKey(exchangePublicKeyBase64: string, identitySecretKey: Uint8Array): string {
+export function signExchangeKey(
+  exchangePublicKeyBase64: string,
+  identitySecretKey: Uint8Array,
+  opts: { domainSeparated?: boolean } = {},
+): string {
   if (typeof exchangePublicKeyBase64 !== 'string' || exchangePublicKeyBase64.trim().length === 0) {
     throw new Error('signExchangeKey: exchange public key must be a non-empty base64 string')
   }
   if (!(identitySecretKey instanceof Uint8Array) || identitySecretKey.length !== nacl.sign.secretKeyLength) {
     throw new Error(`signExchangeKey: identity secret key must be a ${nacl.sign.secretKeyLength}-byte Uint8Array`)
   }
-  const message = new Uint8Array(decodeBase64(exchangePublicKeyBase64))
+  const exchangeKeyBytes = new Uint8Array(decodeBase64(exchangePublicKeyBase64))
+  const message = exchangeKeySigMessage(exchangeKeyBytes, opts.domainSeparated === true)
   const sig = nacl.sign.detached(message, identitySecretKey)
   return encodeBase64(sig)
 }
@@ -119,6 +160,13 @@ export function signExchangeKey(exchangePublicKeyBase64: string, identitySecretK
  * signature, false on any mismatch / malformed input. NEVER throws — a bad or
  * absent signature is a verification FAILURE the caller must treat as a refusal,
  * not an exception to swallow.
+ *
+ * #5604 — accepts a signature over EITHER the bare exchange-key bytes (today's
+ * signer) OR the domain-separated payload (`EXCHANGE_KEY_SIG_DOMAIN_V1` ++ bytes,
+ * the form the signer flips to in a later release). Both require the identity
+ * secret to produce, so accepting both does not weaken pinning — it only lets
+ * the signer migrate without forcing already-pinned clients to re-pair. A future
+ * release can drop the bare branch once the signer no longer emits it.
  *
  * @param exchangePublicKeyBase64 - the per-connection X25519 public key offered
  * @param signatureBase64 - the detached signature offered by the server
@@ -133,17 +181,22 @@ export function verifyExchangeKeySignature(
     if (typeof exchangePublicKeyBase64 !== 'string' || exchangePublicKeyBase64.length === 0) return false
     if (typeof signatureBase64 !== 'string' || signatureBase64.length === 0) return false
     if (typeof identityPublicKeyBase64 !== 'string' || identityPublicKeyBase64.length === 0) return false
-    const message = new Uint8Array(decodeBase64(exchangePublicKeyBase64))
+    const exchangeKeyBytes = new Uint8Array(decodeBase64(exchangePublicKeyBase64))
     const sig = new Uint8Array(decodeBase64(signatureBase64))
     const identityPub = new Uint8Array(decodeBase64(identityPublicKeyBase64))
     // This function only ever verifies an X25519 EXCHANGE public key, so reject
     // anything that isn't 32 bytes up front — a wrong-length key is malformed
     // input, not a genuine signature mismatch. deriveSharedKey enforces the same
     // length downstream, but checking here keeps the signature API honest.
-    if (message.length !== nacl.box.publicKeyLength) return false
+    if (exchangeKeyBytes.length !== nacl.box.publicKeyLength) return false
     if (sig.length !== nacl.sign.signatureLength) return false
     if (identityPub.length !== nacl.sign.publicKeyLength) return false
-    return nacl.sign.detached.verify(message, sig, identityPub)
+    // Bare form first (the live wire format — the common path); fall back to the
+    // domain-separated form so a future signer flip verifies without a re-pair.
+    return (
+      nacl.sign.detached.verify(exchangeKeyBytes, sig, identityPub) ||
+      nacl.sign.detached.verify(exchangeKeySigMessage(exchangeKeyBytes, true), sig, identityPub)
+    )
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary

Refs #5604. Phase 1 of the domain-separation compat ramp for the Ed25519 exchange-key signature. Follow-up for the signer flip: https://github.com/blamechris/chroxy/issues/5959.

The identity key currently signs the **bare** 32-byte X25519 exchange key with no context prefix. Safe today (its only signing use), but reusing the key to sign anything else later (rotation statements, capability grants) would invite **cross-protocol signature confusion**. This lands the groundwork now, while it's cheap — before wide pinning adoption.

## Changes (all in `packages/store-core/src/crypto.ts`)
- **`EXCHANGE_KEY_SIG_DOMAIN_V1 = 'chroxy-exchange-key-v1:'`** + `signExchangeKey(key, secret, { domainSeparated })` that prepends the label to the signed bytes. **Default stays bare** — the live wire format and every existing caller are unchanged.
- **`verifyExchangeKeySignature` accepts EITHER form.** Both require the identity secret to forge, so accepting both **does not weaken pinning** — it only lets a later release flip the signer without forcing already-pinned clients to re-pair.
- Rebuilt `dist/crypto.js` via `build:crypto` (preserves the tweetnacl-util ESM default-import fixup that bare `tsc` would clobber).

## Why phased (no signer flip here)
"Clients have begun pinning" (#5603). If the signer flipped to the domain-separated form now, an already-pinned client that only accepts the bare form would fail verification → forced re-pair. So phase 1 ships the **accept-both verifier first**; the signer flip is https://github.com/blamechris/chroxy/issues/5959; dropping the bare-accept branch is phase 3.

## Security reasoning
- Accept-both is not a downgrade: an attacker still needs the identity secret to produce a signature in either form over the offered exchange key. Tests assert a domain-separated signature still fails against a different identity and against a substituted exchange key.
- No confusion vector introduced: both accepted forms are bound to the same exchange key; domain separation guards against a *different* future payload type, which doesn't exist yet.

## Tests
- `crypto.test.ts`: new "#5604 compat ramp" block — default==explicit-bare (byte-identical, proves default unchanged), domain≠bare, verify accepts bare, verify accepts domain, domain-sig fails wrong-identity, domain-sig fails substituted-key, pinned label string.
- Full store-core suite green (1619). Server handshake suite green (ws-auth + server-identity + pairing-identity, 116 tests) against the rebuilt dist.