### PR TITLE
feat(server): doctor probes named-tunnel routability (#5328 WP-5.6 item 4)

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -188,11 +188,11 @@ export function checkClaudeTuiCliVersion(deps = {}) {
 /**
  * #5328 (WP-5.6) — default end-to-end routability probe for a named tunnel:
  * a HEAD request to the tunnel hostname with a hard timeout. ANY HTTP response
- * (even 4xx/5xx/426-upgrade) proves the request reached the chroxy origin
- * through the Cloudflare edge — i.e. the hostname resolves and the route is
- * live. Only a network/DNS error or a timeout (caught here, returned as
- * `{ ok: false }`) means the path is broken. Uses the Node 22 global `fetch` +
- * `AbortController`; no new dependency.
+ * (even 4xx/5xx/426-upgrade, and whether it comes from the chroxy origin or a
+ * Cloudflare edge error page) means the hostname resolves and the edge answered
+ * — i.e. the route is live enough to reach. Only a network/DNS error or a
+ * timeout (caught here, returned as `{ ok: false }`) means the path is broken.
+ * Uses the Node 22 global `fetch` + `AbortController`; no new dependency.
  */
 async function defaultHttpsProbe(url, timeoutMs) {
   const controller = new AbortController()
@@ -227,11 +227,25 @@ async function defaultHttpsProbe(url, timeoutMs) {
  */
 export async function checkTunnelRoutability(deps = {}) {
   const { hostname = null, mode = null, timeoutMs = 5000, probe = defaultHttpsProbe } = deps
-  if (mode !== 'named' || typeof hostname !== 'string' || hostname.length === 0) return null
+  if (mode !== 'named' || typeof hostname !== 'string') return null
   const NAME = 'Tunnel routability'
+  // Trim and reject anything that isn't a bare host — a stray scheme, path,
+  // userinfo (`@`), or whitespace in the configured `tunnelHostname` would make
+  // `https://${hostname}/` probe a DIFFERENT host than intended (or build an
+  // invalid URL). Surface it as a warn rather than silently probing the wrong
+  // place. A bare `host` or `host:port` is fine.
+  const host = hostname.trim()
+  if (host.length === 0) return null
+  if (/[\s/@]/.test(host) || host.includes('://')) {
+    return {
+      name: NAME,
+      status: 'warn',
+      message: `Configured tunnelHostname '${hostname}' is not a bare host — expected e.g. 'tunnel.example.com', not a URL. Run 'chroxy tunnel setup' to (re)configure.`,
+    }
+  }
   let result
   try {
-    result = await probe(`https://${hostname}/`, timeoutMs)
+    result = await probe(`https://${host}/`, timeoutMs)
   } catch (err) {
     // A probe should resolve { ok: false }, never throw — but never let a
     // diagnostic crash the whole doctor run.
@@ -239,12 +253,12 @@ export async function checkTunnelRoutability(deps = {}) {
   }
   if (result && result.ok) {
     const code = typeof result.status === 'number' ? ` (HTTP ${result.status})` : ''
-    return { name: NAME, status: 'pass', message: `${hostname} is reachable${code}` }
+    return { name: NAME, status: 'pass', message: `${host} is reachable${code}` }
   }
   return {
     name: NAME,
     status: 'warn',
-    message: `${hostname} did not respond${result?.error ? ` (${result.error})` : ''} — the DNS route may be missing or the named tunnel is down. Run 'chroxy tunnel setup' to (re)configure.`,
+    message: `${host} did not respond${result?.error ? ` (${result.error})` : ''} — the DNS route may be missing or the named tunnel is down. Run 'chroxy tunnel setup' to (re)configure.`,
   }
 }
 

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -179,6 +179,69 @@ export function checkClaudeTuiCliVersion(deps = {}) {
 }
 
 /**
+ * #5328 (WP-5.6) — default end-to-end routability probe for a named tunnel:
+ * a HEAD request to the tunnel hostname with a hard timeout. ANY HTTP response
+ * (even 4xx/5xx/426-upgrade) proves the request reached the chroxy origin
+ * through the Cloudflare edge — i.e. the hostname resolves and the route is
+ * live. Only a network/DNS error or a timeout (caught here, returned as
+ * `{ ok: false }`) means the path is broken. Uses the Node 22 global `fetch` +
+ * `AbortController`; no new dependency.
+ */
+async function defaultHttpsProbe(url, timeoutMs) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { method: 'HEAD', signal: controller.signal, redirect: 'manual' })
+    return { ok: true, status: res.status }
+  } catch (err) {
+    const error = err?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : (err?.message || String(err))
+    return { ok: false, error }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * #5328 (WP-5.6) — probe whether a configured NAMED tunnel's hostname is
+ * actually routable end-to-end, so `chroxy doctor` distinguishes "cloudflared
+ * is installed" (the binary check) from "the edge → origin path resolves".
+ *
+ * Skipped (returns null) unless a named tunnel with a hostname is configured —
+ * a quick tunnel's URL is random and runtime-only, so doctor can't know it
+ * ahead of time. A reachable hostname is a `pass`; an unreachable one is a
+ * `warn` (a diagnostic, not a hard failure: the daemon still runs on localhost).
+ *
+ * @param {object} [deps]
+ * @param {string|null} [deps.hostname] - the configured named-tunnel hostname
+ * @param {string|null} [deps.mode] - the configured tunnel mode ('named'|'quick'|'none')
+ * @param {(url: string, timeoutMs: number) => Promise<{ ok: boolean, status?: number, error?: string }>} [deps.probe]
+ * @param {number} [deps.timeoutMs]
+ * @returns {Promise<{ name: string, status: 'pass'|'warn', message: string } | null>}
+ */
+export async function checkTunnelRoutability(deps = {}) {
+  const { hostname = null, mode = null, timeoutMs = 5000, probe = defaultHttpsProbe } = deps
+  if (mode !== 'named' || typeof hostname !== 'string' || hostname.length === 0) return null
+  const NAME = 'Tunnel routability'
+  let result
+  try {
+    result = await probe(`https://${hostname}/`, timeoutMs)
+  } catch (err) {
+    // A probe should resolve { ok: false }, never throw — but never let a
+    // diagnostic crash the whole doctor run.
+    result = { ok: false, error: err?.message || String(err) }
+  }
+  if (result && result.ok) {
+    const code = typeof result.status === 'number' ? ` (HTTP ${result.status})` : ''
+    return { name: NAME, status: 'pass', message: `${hostname} is reachable${code}` }
+  }
+  return {
+    name: NAME,
+    status: 'warn',
+    message: `${hostname} did not respond${result?.error ? ` (${result.error})` : ''} — the DNS route may be missing or the named tunnel is down. Run 'chroxy tunnel setup' to (re)configure.`,
+  }
+}
+
+/**
  * Run all preflight dependency checks and return results.
  *
  * Provider-aware: only runs the binary/credential checks for the
@@ -196,7 +259,7 @@ export function checkClaudeTuiCliVersion(deps = {}) {
  *   tests can point the check at a temp directory without mutating process.cwd().
  * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string, provider?: string }>, passed: boolean, providers: string[] }}
  */
-export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR, now = Date.now() } = {}) {
+export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR, now = Date.now(), tunnelProbe } = {}) {
   const checks = []
   const isMac = platform() === 'darwin'
   const isLinux = platform() === 'linux'
@@ -229,10 +292,15 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // 3. Load config (once) — used for both the Config check and provider resolution.
   let configProvider = null
   let configCheck = null
+  // #5328 (WP-5.6): named-tunnel coordinates for the routability probe (step 5.6).
+  let tunnelMode = null
+  let tunnelHostname = null
   if (existsSync(CONFIG_FILE)) {
     try {
       const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
       if (typeof config.provider === 'string') configProvider = config.provider
+      if (typeof config.tunnel === 'string') tunnelMode = config.tunnel
+      if (typeof config.tunnelHostname === 'string') tunnelHostname = config.tunnelHostname
       // #5419: register config-driven Anthropic-compatible endpoints before
       // provider resolution so a config.provider pointing at one preflights
       // its credential spec instead of failing as "Unknown provider".
@@ -269,6 +337,18 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // 5. Config check — appended after provider checks so per-provider
   // sections group together in the output report.
   checks.push(configCheck)
+
+  // 5.6 Tunnel routability (#5328 WP-5.6). For a configured NAMED tunnel, probe
+  // the hostname end-to-end so a broken DNS route / down tunnel is visible here
+  // rather than only as a failed remote connection later. Skipped for quick /
+  // no tunnel (no stable hostname to probe). `tunnelProbe` is injectable so the
+  // check is testable without a real network round-trip.
+  const tunnelCheck = await checkTunnelRoutability({
+    hostname: tunnelHostname,
+    mode: tunnelMode,
+    ...(tunnelProbe ? { probe: tunnelProbe } : {}),
+  })
+  if (tunnelCheck) checks.push(tunnelCheck)
 
   // 5.5 Billing canary (#5821, audit rec #4). Standalone-feasible half of the
   // canary: the silent-metered-default check needs only the resolved default

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -8,6 +8,7 @@ import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { getProvider, DEFAULT_PROVIDER } from './providers.js'
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
+import { parseTunnelArg } from './tunnel/index.js'
 import { TESTED_CLAUDE_TUI_CLI_VERSION } from './claude-tui/tested-cli-version.js'
 import { detectSilentMeteredDefault } from './doctor-billing.js'
 import {
@@ -26,7 +27,13 @@ import { checkDependencies } from './utils/check-dependencies.js'
 const __filename = fileURLToPath(import.meta.url)
 const SERVER_PKG_DIR = dirname(dirname(__filename))
 
-const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
+// Honor CHROXY_CONFIG_DIR (the repo-wide convention — connection-info.js,
+// models.js, etc.) so the config read resolves to the same dir as every other
+// reader. Without this, doctor read the REAL ~/.chroxy in tests despite
+// tests/_setup.mjs redirecting CHROXY_CONFIG_DIR to a tmp dir — which would let
+// the named-tunnel routability probe (#5328) fire a live network request from
+// a maintainer's real config during the suite.
+const CONFIG_FILE = join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'config.json')
 
 /**
  * Parse the leading `major.minor.patch` semver out of an arbitrary version
@@ -299,7 +306,18 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
     try {
       const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
       if (typeof config.provider === 'string') configProvider = config.provider
-      if (typeof config.tunnel === 'string') tunnelMode = config.tunnel
+      // Normalize the tunnel mode through parseTunnelArg so aliases resolve —
+      // e.g. `cloudflare:named` (a documented --tunnel form persisted verbatim)
+      // maps to mode 'named' and isn't silently skipped by the routability
+      // probe. parseTunnelArg throws on an unknown value; validateConfig already
+      // surfaces that, so treat it as "no probe" here rather than crashing doctor.
+      if (typeof config.tunnel === 'string') {
+        try {
+          tunnelMode = parseTunnelArg(config.tunnel)?.mode ?? null
+        } catch {
+          tunnelMode = null
+        }
+      }
       if (typeof config.tunnelHostname === 'string') tunnelHostname = config.tunnelHostname
       // #5419: register config-driven Anthropic-compatible endpoints before
       // provider resolution so a config.provider pointing at one preflights

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -742,9 +742,33 @@ describe('checkTunnelRoutability (#5328 WP-5.6)', () => {
       providers: ['claude-sdk'],
       tunnelProbe: async () => { probed = true; return { ok: true } },
     })
-    // The real home config under test has no named tunnel, so the probe must
-    // not fire and no routability check is added.
+    // CHROXY_CONFIG_DIR is redirected to a tmp dir by _setup.mjs and has no
+    // named tunnel, so the probe must not fire and no routability check is added.
     assert.equal(probed, false)
     assert.equal(checks.find(c => c.name === 'Tunnel routability'), undefined)
+  })
+
+  it('runDoctorChecks fires the probe for a configured named tunnel, incl. the cloudflare:named alias', async () => {
+    const { writeFileSync, rmSync } = await import('node:fs')
+    // _setup.mjs points CHROXY_CONFIG_DIR at a writable tmp dir and doctor's
+    // CONFIG_FILE now honors it (the hermeticity fix), so this lands in the
+    // sandbox, not the real ~/.chroxy.
+    const cfgPath = join(process.env.CHROXY_CONFIG_DIR, 'config.json')
+    writeFileSync(cfgPath, JSON.stringify({ tunnel: 'cloudflare:named', tunnelHostname: 'chroxy.example.com' }))
+    try {
+      let probedUrl = null
+      const { checks } = await runDoctorChecks({
+        providers: ['claude-sdk'],
+        tunnelProbe: async (url) => { probedUrl = url; return { ok: true, status: 200 } },
+      })
+      // The `cloudflare:named` alias must normalize to mode 'named' (not be
+      // skipped), and the probe must receive the configured hostname URL.
+      assert.equal(probedUrl, 'https://chroxy.example.com/')
+      const routability = checks.find(c => c.name === 'Tunnel routability')
+      assert.ok(routability)
+      assert.equal(routability.status, 'pass')
+    } finally {
+      rmSync(cfgPath, { force: true })
+    }
   })
 })

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -723,6 +723,35 @@ describe('checkTunnelRoutability (#5328 WP-5.6)', () => {
     assert.match(check.message, /did not respond \(boom\)/)
   })
 
+  it('trims surrounding whitespace from the hostname before probing', async () => {
+    let seenUrl = null
+    const check = await checkTunnelRoutability({
+      mode: 'named',
+      hostname: '  chroxy.example.com  ',
+      probe: async (url) => { seenUrl = url; return { ok: true, status: 200 } },
+    })
+    assert.equal(seenUrl, 'https://chroxy.example.com/')
+    assert.equal(check.status, 'pass')
+  })
+
+  it('warns (without probing) when the hostname is not a bare host', async () => {
+    for (const bad of ['https://chroxy.example.com', 'evil.com/@chroxy.example.com', 'a b.example.com', 'chroxy.example.com/path']) {
+      let probed = false
+      const check = await checkTunnelRoutability({
+        mode: 'named',
+        hostname: bad,
+        probe: async () => { probed = true; return { ok: true } },
+      })
+      assert.equal(probed, false, `should not probe a malformed host: ${bad}`)
+      assert.equal(check.status, 'warn')
+      assert.match(check.message, /is not a bare host/)
+    }
+  })
+
+  it('returns null for a whitespace-only hostname', async () => {
+    assert.equal(await checkTunnelRoutability({ mode: 'named', hostname: '   ' }), null)
+  })
+
   it('passes the hostname URL and a numeric timeout to the probe', async () => {
     let seenUrl = null
     let seenTimeout = null

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, parse as parsePath, relative } from 'node:path'
-import { runDoctorChecks, checkBinary, isBundledOrSupervisedContext, parseLeadingSemver, compareSemver, checkClaudeTuiCliVersion } from '../src/doctor.js'
+import { runDoctorChecks, checkBinary, isBundledOrSupervisedContext, parseLeadingSemver, compareSemver, checkClaudeTuiCliVersion, checkTunnelRoutability } from '../src/doctor.js'
 import { TESTED_CLAUDE_TUI_CLI_VERSION } from '../src/claude-tui/tested-cli-version.js'
 
 /**
@@ -680,5 +680,71 @@ describe('checkClaudeTuiCliVersion', () => {
 
   it('the shipped baseline constant is a parseable semver', () => {
     assert.notEqual(parseLeadingSemver(TESTED_CLAUDE_TUI_CLI_VERSION), null)
+  })
+})
+
+describe('checkTunnelRoutability (#5328 WP-5.6)', () => {
+  it('returns null when no named tunnel is configured (quick / none / no hostname)', async () => {
+    assert.equal(await checkTunnelRoutability({ mode: 'quick', hostname: 'x.example.com' }), null)
+    assert.equal(await checkTunnelRoutability({ mode: 'none', hostname: null }), null)
+    assert.equal(await checkTunnelRoutability({ mode: 'named', hostname: '' }), null)
+    assert.equal(await checkTunnelRoutability({}), null)
+  })
+
+  it('passes when the probe reaches the hostname (any HTTP response is routable)', async () => {
+    const check = await checkTunnelRoutability({
+      mode: 'named',
+      hostname: 'chroxy.example.com',
+      probe: async () => ({ ok: true, status: 426 }),
+    })
+    assert.equal(check.status, 'pass')
+    assert.match(check.message, /chroxy\.example\.com is reachable/)
+    assert.match(check.message, /HTTP 426/)
+  })
+
+  it('warns when the probe cannot reach the hostname (DNS/route down)', async () => {
+    const check = await checkTunnelRoutability({
+      mode: 'named',
+      hostname: 'chroxy.example.com',
+      probe: async () => ({ ok: false, error: 'getaddrinfo ENOTFOUND chroxy.example.com' }),
+    })
+    assert.equal(check.status, 'warn')
+    assert.match(check.message, /did not respond \(getaddrinfo ENOTFOUND/)
+    assert.match(check.message, /chroxy tunnel setup/)
+  })
+
+  it('warns (never throws) when the probe itself rejects', async () => {
+    const check = await checkTunnelRoutability({
+      mode: 'named',
+      hostname: 'chroxy.example.com',
+      probe: async () => { throw new Error('boom') },
+    })
+    assert.equal(check.status, 'warn')
+    assert.match(check.message, /did not respond \(boom\)/)
+  })
+
+  it('passes the hostname URL and a numeric timeout to the probe', async () => {
+    let seenUrl = null
+    let seenTimeout = null
+    await checkTunnelRoutability({
+      mode: 'named',
+      hostname: 'chroxy.example.com',
+      timeoutMs: 1234,
+      probe: async (url, timeoutMs) => { seenUrl = url; seenTimeout = timeoutMs; return { ok: true } },
+    })
+    assert.equal(seenUrl, 'https://chroxy.example.com/')
+    assert.equal(seenTimeout, 1234)
+  })
+
+  it('runDoctorChecks omits the routability check by default (no named tunnel) and never calls the real network', async () => {
+    let probed = false
+    const { checks } = await runDoctorChecks({
+      providers: ['claude-sdk'],
+      tunnelProbe: async () => { probed = true; return { ok: true } },
+    })
+    // The real home config under test has no named tunnel, so the probe must
+    // not fire and no routability check is added.
+    assert.equal(probed, false)
+    assert.equal(checks.find(c => c.name === 'Tunnel routability'), undefined)
   })
 })


### PR DESCRIPTION
## Summary

Closes #5328 — the last open item (item 4) of the WP-5.6 swallowed-errors grab-bag. The other six items were already resolved on main or resolved-by-design (full per-item audit posted on the issue).

`chroxy doctor` could confirm cloudflared was *installed* but not that a **named tunnel's hostname actually resolves end-to-end** — a missing DNS route or a down tunnel only surfaced later as a failed remote connection.

## Change
New **`checkTunnelRoutability`** (dependency-injected, testable):
- For a configured **named** tunnel, HEADs `https://<hostname>/` with a 5s timeout.
- **Any HTTP response** (even 4xx/5xx/426-upgrade) proves the edge→origin path is live → `pass`.
- A network/DNS error or timeout → `warn` (a diagnostic, not fatal — the daemon still runs on localhost; message points to `chroxy tunnel setup`).
- **Skipped** (returns null) for quick/no tunnel — a quick tunnel's URL is random + runtime-only, so there's no stable hostname to probe.

`runDoctorChecks` reads `tunnel`/`tunnelHostname` from the already-loaded config and uses the real `fetch` probe in production (Node 22 global — no new dependency); the probe is injectable so the check is unit-tested without a network round-trip.

## Tests (`doctor.test.js`, +6)
- null when no named tunnel (quick/none/empty hostname/no opts)
- pass on a reachable hostname (asserts any-HTTP-status is routable)
- warn on an unreachable hostname (DNS error) + `chroxy tunnel setup` hint
- warn (never throws) when the probe itself rejects
- asserts the exact URL + numeric timeout passed to the probe
- `runDoctorChecks` does NOT fire the probe by default (no named tunnel in the test home) and adds no routability check

doctor 62/62 + doctor-billing 14/14 green; all server custom lints pass.