### PR TITLE
feat(dashboard): client-side handshake timeout (#5721 item 2)

### DIFF
--- a/packages/dashboard/src/store/connection-handshake-timeout.test.ts
+++ b/packages/dashboard/src/store/connection-handshake-timeout.test.ts
@@ -1,0 +1,157 @@
+/**
+ * #5721 (item 2) — client-side handshake timeout (dashboard).
+ *
+ * The heartbeat does not start until `auth_ok` is processed, so the handshake
+ * window (socket OPEN + `auth` sent, awaiting `auth_ok`/`key_exchange_ok`) had
+ * no liveness coverage. A dedicated HANDSHAKE_TIMEOUT_MS timer now fires
+ * "Handshake failed — reconnecting" and hands off to the normal reconnect ladder
+ * instead of a silent stall. These tests drive the production onopen/onmessage/
+ * onerror/disconnect paths with a mock socket + fake timers (mirrors
+ * connection-encryption-guard.test.ts / connection-reconnect-backoff.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v },
+  removeItem: (k: string) => { delete store[k] },
+  clear: () => { for (const k of Object.keys(store)) delete store[k] },
+  get length() { return Object.keys(store).length },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+vi.mock('../utils/auth', () => ({ getAuthToken: () => null }))
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 1
+  sent: string[] = []
+  closed = 0
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this) }
+  send(d: string) { this.sent.push(d) }
+  close() { this.closed += 1; this.readyState = 3 }
+}
+;(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket
+;(globalThis as unknown as { fetch: unknown }).fetch = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ status: 'ok' }),
+}))
+
+const { useConnectionStore } = await import('./connection')
+const { HANDSHAKE_TIMEOUT_MS } = await import('./message-handler')
+
+/** Open a connection and walk it through health check + WS construction + onopen. */
+async function openConnected(): Promise<MockWebSocket> {
+  const before = MockWebSocket.instances.length
+  useConnectionStore.getState().connect('wss://tunnel.example.com/ws', 'tok')
+  await vi.advanceTimersByTimeAsync(0)
+  const ws = MockWebSocket.instances[before]!
+  ws.readyState = 1
+  ws.onopen?.()
+  await vi.advanceTimersByTimeAsync(0)
+  return ws
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  MockWebSocket.instances = []
+  for (const k of Object.keys(store)) delete store[k]
+  useConnectionStore.setState({
+    serverRegistry: [],
+    activeServerId: null,
+    connectionPhase: 'disconnected',
+    wsUrl: null,
+    userDisconnected: false,
+    serverErrors: [],
+    connectionError: null,
+  })
+})
+
+afterEach(() => {
+  // Make sure no timer (handshake or reconnect-ladder) survives into the next
+  // test — module-level timers persist across tests in the same file.
+  useConnectionStore.getState().disconnect()
+  vi.clearAllTimers()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('#5721 client-side handshake timeout (dashboard)', () => {
+  it('fires after HANDSHAKE_TIMEOUT_MS when no auth_ok arrives, then reconnects', async () => {
+    const ws = await openConnected()
+    // The auth handshake frame went out…
+    expect(ws.sent.some(s => s.includes('"type":"auth"'))).toBe(true)
+    expect(ws.closed).toBe(0)
+
+    // …but no auth_ok / key_exchange_ok ever completes it.
+    await vi.advanceTimersByTimeAsync(HANDSHAKE_TIMEOUT_MS)
+
+    // The wedged socket is dropped and the UX shows the reconnecting state.
+    expect(ws.closed).toBe(1)
+    expect(useConnectionStore.getState().connectionPhase).toBe('reconnecting')
+    expect(useConnectionStore.getState().connectionError).toMatch(/Handshake failed/i)
+
+    // It hands off to the normal reconnect ladder — a fresh socket is built.
+    const before = MockWebSocket.instances.length
+    await vi.advanceTimersByTimeAsync(10_000) // past the (jittered) first rung
+    expect(MockWebSocket.instances.length).toBeGreaterThan(before)
+  })
+
+  it('clears the timer on auth_ok — no spurious fire on a healthy connect', async () => {
+    const ws = await openConnected()
+    const socketsBefore = MockWebSocket.instances.length
+
+    // Drive a real auth_ok through the production onmessage path — a healthy
+    // handshake completion.
+    ws.onmessage?.({ data: JSON.stringify({ type: 'auth_ok', serverMode: 'cli' }) })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(useConnectionStore.getState().connectionPhase).toBe('connected')
+
+    // Past the handshake budget (but before the 15s+5s heartbeat reaper that
+    // auth_ok started — advancing into that would close the socket for an
+    // unrelated reason) — the handshake timer was cleared, so it must NOT fire:
+    // the socket stays open, no reconnect socket is built, and the
+    // handshake-timeout error never appears.
+    await vi.advanceTimersByTimeAsync(HANDSHAKE_TIMEOUT_MS + 2_000)
+    expect(ws.closed).toBe(0)
+    expect(MockWebSocket.instances.length).toBe(socketsBefore) // no reconnect socket
+    expect(useConnectionStore.getState().connectionError ?? '').not.toMatch(/Handshake failed/i)
+  })
+
+  it('does not fire after a user-initiated disconnect', async () => {
+    const ws = await openConnected()
+    const socketsBefore = MockWebSocket.instances.length
+
+    useConnectionStore.getState().disconnect()
+    await vi.advanceTimersByTimeAsync(HANDSHAKE_TIMEOUT_MS * 2)
+
+    // disconnect() cleared the timer; it must not close again or reconnect.
+    expect(ws.closed).toBeLessThanOrEqual(1) // disconnect itself may close once
+    expect(MockWebSocket.instances.length).toBe(socketsBefore)
+    expect(useConnectionStore.getState().connectionPhase).not.toBe('reconnecting')
+  })
+
+  it('does not schedule a second reconnect when the socket already errored', async () => {
+    const ws = await openConnected()
+    // A transport error arms the reconnect scheduler first…
+    ws.onerror?.()
+    await vi.advanceTimersByTimeAsync(0)
+    const afterError = MockWebSocket.instances.length
+
+    // …then the handshake timer fires. scheduleReconnect's per-socket dedupe
+    // (reconnectScheduler.scheduled) must make this a no-op — exactly one
+    // reconnect socket should appear, not two.
+    await vi.advanceTimersByTimeAsync(HANDSHAKE_TIMEOUT_MS)
+    await vi.advanceTimersByTimeAsync(10_000) // let the single scheduled rung fire
+    // One new socket from the single scheduled reconnect (not two).
+    expect(MockWebSocket.instances.length).toBe(afterError + 1)
+  })
+})

--- a/packages/dashboard/src/store/connection-handshake-timeout.test.ts
+++ b/packages/dashboard/src/store/connection-handshake-timeout.test.ts
@@ -141,17 +141,17 @@ describe('#5721 client-side handshake timeout (dashboard)', () => {
 
   it('does not schedule a second reconnect when the socket already errored', async () => {
     const ws = await openConnected()
-    // A transport error arms the reconnect scheduler first…
+    // A transport error schedules a reconnect AND clears the handshake timer
+    // (onerror's teardown clear), so the timeout window is now a no-op…
     ws.onerror?.()
     await vi.advanceTimersByTimeAsync(0)
     const afterError = MockWebSocket.instances.length
 
-    // …then the handshake timer fires. scheduleReconnect's per-socket dedupe
-    // (reconnectScheduler.scheduled) must make this a no-op — exactly one
-    // reconnect socket should appear, not two.
+    // …advancing past the handshake budget adds nothing (the timer was cleared;
+    // and even if it weren't, scheduleReconnect's per-socket `scheduled` dedupe
+    // would suppress a second reconnect). Exactly one reconnect socket appears.
     await vi.advanceTimersByTimeAsync(HANDSHAKE_TIMEOUT_MS)
     await vi.advanceTimersByTimeAsync(10_000) // let the single scheduled rung fire
-    // One new socket from the single scheduled reconnect (not two).
     expect(MockWebSocket.instances.length).toBe(afterError + 1)
   })
 })

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -102,6 +102,8 @@ import {
   clearTerminalWriteBatching,
   appendPendingTerminalWrite,
   stopHeartbeat,
+  armHandshakeTimer,
+  clearHandshakeTimer,
   clearDeltaBuffers,
   clearMessageQueue,
   enqueueMessage,
@@ -1575,6 +1577,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Reset encryption state for each new connection (forward secrecy)
     setEncryptionState(null);
     setPendingKeyPair(null);
+    // #5721 (item 2) — clear any handshake timer left armed by a prior socket
+    // BEFORE this attempt opens, so a reconnect that re-enters onopen can never
+    // leak a second pending timer (the key leak-prevention site).
+    clearHandshakeTimer();
     const socket = new WebSocket(url);
 
     // #3624: shared reconnect scheduler used by both onclose and onerror.
@@ -1701,6 +1707,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
             ...(Object.keys(historyCursors).length > 0 ? { historyCursors } : {}),
           }));
         }
+        // #5721 (item 2) — a handshake frame went out; arm the handshake timer.
+        // If auth_ok / key_exchange_ok never completes the handshake within
+        // HANDSHAKE_TIMEOUT_MS, fire: drop this half-open socket and hand off to
+        // the SAME reconnect ladder a transport error uses (scheduleReconnect),
+        // surfacing "Handshake failed — reconnecting" instead of a silent stall
+        // until the transport gives up. The success clears live in the auth_ok /
+        // key_exchange_ok handlers; teardown clears live in onclose/onerror/
+        // disconnect and at the top of the next connect.
+        armHandshakeTimer(() => {
+          // Superseded by a newer attempt — ignore (mirrors the onclose/onerror
+          // stale guard). The current attempt's timer is the only live one.
+          if (myAttemptId !== connectionAttemptId) return;
+          // Null the handlers before closing so this manual close doesn't also
+          // dispatch through onclose; scheduleReconnect owns the recovery.
+          socket.onclose = null;
+          socket.onerror = null;
+          try { socket.close(); } catch { /* already closing */ }
+          scheduleReconnect('Handshake timed out', 'Handshake failed — reconnecting');
+        });
       }
     };
 
@@ -1754,6 +1779,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // Stale socket from a previous connection attempt — ignore
       if (myAttemptId !== connectionAttemptId) return;
+
+      // #5721 (item 2) — this attempt's socket closed; no handshake left to time.
+      // Clear AFTER the stale guard so a late stale-socket close can't cancel the
+      // CURRENT attempt's timer. (Idempotent if the handshake already completed.)
+      clearHandshakeTimer();
 
       // #3068: any in-flight evaluator request is now a guaranteed no-op —
       // reject them so awaiters get a fast error instead of waiting 60s for
@@ -1885,6 +1915,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // Stale socket from a previous connection attempt — ignore
       if (myAttemptId !== connectionAttemptId) return;
 
+      // #5721 (item 2) — the socket errored mid-handshake or after; cancel the
+      // handshake timer so it can't also fire (scheduleReconnect's per-socket
+      // dedupe would no-op the second one, but clearing keeps it tidy).
+      clearHandshakeTimer();
+
       // #3605: an unexpected error means any in-flight skill_trust_grant
       // request will never be acked. Clear both the Map-based correlation
       // (#3587) and the per-session arrays (#3588) so the SkillsPanel
@@ -1917,6 +1952,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Clear saved connection so ConnectScreen doesn't auto-reconnect
     setLastConnectedUrl(null);
     stopHeartbeat();
+    // #5721 (item 2) — user-initiated disconnect: cancel any armed handshake
+    // timer so it can't fire (and schedule a reconnect) after an explicit close.
+    clearHandshakeTimer();
     // #3068: same as the onclose handler — fail any pending evaluator
     // requests fast instead of waiting on the 60s timeout. We do this both
     // here (user-initiated) and in onclose (transport drop) because we null

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1719,10 +1719,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           // Superseded by a newer attempt — ignore (mirrors the onclose/onerror
           // stale guard). The current attempt's timer is the only live one.
           if (myAttemptId !== connectionAttemptId) return;
-          // Null the handlers before closing so this manual close doesn't also
-          // dispatch through onclose; scheduleReconnect owns the recovery.
+          // Null ALL handlers before closing: onclose/onerror so this manual
+          // close doesn't double-dispatch (scheduleReconnect owns recovery), AND
+          // onmessage so a frame already queued/in-flight on this wedged socket
+          // (a late auth_ok / key_exchange_ok) can't be delivered and mutate
+          // store state after we've declared the handshake failed.
           socket.onclose = null;
           socket.onerror = null;
+          socket.onmessage = null;
           try { socket.close(); } catch { /* already closing */ }
           scheduleReconnect('Handshake timed out', 'Handshake failed — reconnecting');
         });

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -709,6 +709,33 @@ const _rttSmoother = new RttSmoother();
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 
+// #5721 (item 2) — client-side handshake timeout. The heartbeat above does NOT
+// start until `auth_ok` is processed (see startHeartbeat's caller), so the
+// handshake window (socket OPEN + `auth`/`pair` sent, awaiting
+// `auth_ok`/`key_exchange_ok`) has zero liveness coverage: a server that opens
+// the socket but never completes the handshake leaves the client wedged in
+// `connecting`/`reconnecting` until the transport drops on its own. A dedicated
+// ~10s timer — comfortably below the ~20s worst-case heartbeat detection once
+// connected — surfaces "Handshake failed — reconnecting" and hands off to the
+// normal reconnect ladder instead of a silent stall. Exported so connection.ts
+// arms/clears it around the socket lifecycle and tests can read the budget.
+export const HANDSHAKE_TIMEOUT_MS = 10_000;
+let _handshakeTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+// Arm the handshake timer with the caller's fire behaviour. The fire callback
+// is injected (not built here) because the reconnect machinery it needs lives
+// in connection.ts's per-socket closure — the same inversion createReconnectScheduler
+// uses. Clears any prior timer first (single-instance, mirroring startHeartbeat)
+// so a reconnect that re-enters onopen can never leak a second pending timer.
+export function armHandshakeTimer(onTimeout: () => void): void {
+  clearHandshakeTimer();
+  _handshakeTimeoutId = setTimeout(onTimeout, HANDSHAKE_TIMEOUT_MS);
+}
+
+export function clearHandshakeTimer(): void {
+  if (_handshakeTimeoutId) { clearTimeout(_handshakeTimeoutId); _handshakeTimeoutId = null; }
+}
+
 // #5515 (epic #5514): latency instrumentation. `_deltaServerTs` records the
 // server-stamped serverTs (and local recv time) of the OLDEST un-rendered
 // delta per messageId; on flush we measure serverTs→render (token-to-render)
@@ -2871,6 +2898,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // reset the close/error-path backoff ladder here (not on socket-open). A
       // socket that opens but never authenticates keeps climbing the ladder.
       resetReconnectAttempt();
+      // #5721 (item 2) — auth_ok is the authoritative handshake-completion frame
+      // (the issue calls it out by name); a discrete key_exchange round-trip, when
+      // it happens, only ever FOLLOWS a successful auth_ok. Clear the handshake
+      // timer here so the (healthy) encryption sub-handshake isn't counted against
+      // the budget. Eager-encryption and no-encryption connects never send
+      // key_exchange, so this is the single authoritative clear.
+      clearHandshakeTimer();
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
       // #4766: full wire-shape decode lives in the shared parser
@@ -3106,6 +3140,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         _encryptionState = { sharedKey: encryptionKey, sendNonce: 0, recvNonce: 0 };
         _pendingKeyPair = null;
         _pendingSalt = null;
+        // #5721 (item 2) — defensive: auth_ok already cleared the handshake timer
+        // (it always precedes this discrete round-trip), but clear again here so a
+        // future reordering that makes the encryption sub-handshake the real
+        // completion point can't leave a timer to fire spuriously. Idempotent.
+        clearHandshakeTimer();
         console.log('[crypto] E2E encryption established');
         // Now send the post-auth messages that were deferred. #5555: skip the
         // 3 list requests when the server advertised the auth_bootstrap


### PR DESCRIPTION
## Summary

Closes #5721 (item 2 — client-side handshake timeout; item 1 / eager-rollback landed in #5944). App parity tracked in #5962.

The client heartbeat doesn't start until `auth_ok` is processed, so the **handshake window** (socket OPEN + `auth`/`pair` sent, awaiting `auth_ok`/`key_exchange_ok`) had **zero liveness coverage** — a server that opens the socket but never completes the handshake left the dashboard wedged in `connecting`/`reconnecting` until the transport gave up on its own.

## Change
A dedicated **`HANDSHAKE_TIMEOUT_MS` (10s)** timer (below the ~20s worst-case heartbeat detection once connected):
- **Arm** — in `socket.onopen`, right after the handshake frame goes out (inside the `readyState === OPEN` guard).
- **Clear (success)** — at the top of the `auth_ok` handler (the authoritative completion frame; a discrete `key_exchange` round-trip only ever follows it), plus a defensive clear in the `key_exchange_ok` success branch.
- **Fire** — drop the half-open socket and hand off to the **same** reconnect ladder a transport error uses (`scheduleReconnect`), surfacing **"Handshake failed — reconnecting"**. Does not invent a parallel reconnect path.
- **Teardown** — clears at `_connectWebSocket` entry (the leak-prevention site so a reconnect re-arms cleanly), `onclose` (after the stale guard), `onerror`, and `disconnect`.

### Safety
- **No double reconnect** — the fire path stale-checks (`myAttemptId !== connectionAttemptId`) and routes through `scheduleReconnect`, whose per-socket `reconnectScheduler.scheduled` dedupe no-ops a concurrent onclose/onerror retry.
- **No timer leak across reconnects** — `armHandshakeTimer` clears-then-sets (single instance) and `_connectWebSocket` entry clears any leftover before the next socket opens.
- **Eager vs discrete** — cleared on `auth_ok` so the healthy encryption sub-handshake isn't counted against the budget; eager/no-encryption connects (which never send `key_exchange`) are covered by the same `auth_ok` clear.

## Tests
New `connection-handshake-timeout.test.ts` (mock socket + fake timers, mirrors `connection-encryption-guard.test.ts`):
1. fires after the budget with no `auth_ok` → socket closed, phase `reconnecting`, error "Handshake failed", then a fresh socket from the ladder.
2. clears on `auth_ok` → no spurious fire (advanced past the budget but before the heartbeat reaper).
3. no second reconnect when the socket already errored (dedupe).
4. no fire after a user-initiated `disconnect`.

Full dashboard suite green (201 files / 3792 tests) + `tsc --noEmit` clean.