### PR TITLE
fix(server): reap a denied-shape AskUserQuestion's leaked pending entry (#5792)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -688,6 +688,9 @@ export class ClaudeTuiSession extends BaseSession {
     if (this._destroying) return
     if (!this._pendingUserAnswers.has(toolUseId)) return
     ;(this._log || log).warn(`AskUserQuestion denied-shape reaper (#5792): tool=${toolUseId} pending entry never cleared after deny→Stop→idle — dropping leaked entry so a later no-toolUseId answer can't misroute to it`)
+    // _clearPendingAnswerByToolUseId re-enters _clearDeniedQuestionReaper; that's
+    // an idempotent no-op here (this reaper already self-deleted from the Map
+    // before its callback ran).
     this._clearPendingAnswerByToolUseId(toolUseId)
     this._clearAskUserQuestionWatchdog(toolUseId)
   }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -56,6 +56,13 @@ const __dirname = dirname(__filename)
 
 const log = createLogger('claude-tui-session')
 
+// #5792: how long a DENIED-shape AskUserQuestion pending entry may linger past
+// turn-end before the reaper drops it. Mirrors the 30s stall-watchdog window
+// (ASK_USER_QUESTION_WATCHDOG_MS) — long enough for any in-flight teardown /
+// reinject to clear the entry on its own (making the reaper a no-op), short
+// enough that a leaked entry can't shadow the most-recent fallback for long.
+const DENIED_QUESTION_REAPER_MS = 30 * 1000
+
 /**
  * ClaudeTuiSession — drives the interactive `claude` TUI under a PTY so the
  * round-trip bills as a subscription instead of programmatic (`claude -p` and
@@ -434,6 +441,21 @@ export class ClaudeTuiSession extends BaseSession {
     // answering / stalling one no longer disarms the others. Cleared per-id on
     // PostToolUse and cleared wholesale on the turn-ending paths + destroy().
     this._askUserQuestionWatchdogs = new Map()
+    // #5792: denied-shape AskUserQuestion reapers, keyed by toolUseId. A
+    // multi-question (questions.length > 1) or multi-select (any question
+    // multiSelect:true) AskUserQuestion is DENIED at the permission hook, so
+    // claude blocks → Stops with no PostToolUse. The Stop success path
+    // (_clearTurnEndState) clears the sibling lock + stall watchdogs but
+    // deliberately NOT _pendingUserAnswers (a legit sibling answer may still be
+    // in flight — see _pendingUserAnswers_clearAll's doc). For a denied shape
+    // there is NO legit answer coming, so that pending entry leaks: a later
+    // no-toolUseId respondToQuestion would misroute to it via the most-recent
+    // back-compat fallback. This reaper, armed ONLY for denied shapes at
+    // pending-creation, drops the still-leaked entry after a short window. It is
+    // deliberately keyed/cleared per toolUseId and does NOT touch the global
+    // askuserquestion-active lock (already cleared at the denied turn's Stop; a
+    // later turn may own a fresh lock by the time the reaper fires).
+    this._deniedQuestionReapers = new Map()
     // #5798: observability-only marker for the multi-select reinject "stop and
     // wait" steer. When CHROXY_TUI_MULTISELECT_REINJECT is on and a multi-select
     // AskUserQuestion is denied, the deny reason steers the model to STOP its
@@ -550,12 +572,16 @@ export class ClaudeTuiSession extends BaseSession {
   _pendingUserAnswers_clearAll() {
     this._pendingUserAnswers.clear()
     this._lastPendingAnswerToolUseId = null
+    // #5792: pending entries are gone → their reapers have nothing to guard.
+    this._clearAllDeniedQuestionReapers()
   }
 
   /** Internal: drop a specific pending answer entry (PostToolUse cleanup). */
   _clearPendingAnswerByToolUseId(toolUseId) {
     if (!toolUseId) return
     this._pendingUserAnswers.delete(toolUseId)
+    // #5792: the entry is gone → cancel its denied-shape reaper (no-op if none).
+    this._clearDeniedQuestionReaper(toolUseId)
     if (this._lastPendingAnswerToolUseId === toolUseId) {
       // Advance the "most recent" pointer to whichever entry was set most
       // recently after the one we just removed (insertion-order via Map
@@ -607,6 +633,63 @@ export class ClaudeTuiSession extends BaseSession {
   _clearAllAskUserQuestionWatchdogs() {
     for (const t of this._askUserQuestionWatchdogs.values()) clearTimeout(t)
     this._askUserQuestionWatchdogs.clear()
+  }
+
+  /**
+   * #5792: arm (or re-arm) the denied-shape reaper for one toolUseId. Called
+   * from `_emitToolHookEvent` ONLY when the AskUserQuestion payload is a denied
+   * shape (multi-question or multi-select) — a legitimate single single-select
+   * arms its own stall watchdog in `respondToQuestion` instead and is left
+   * alone. On fire, `_reapDeniedQuestion` drops the pending entry if it still
+   * leaks. Unlike the stall watchdog (which assumes a live, busy turn), this
+   * reaper must OUTLIVE the turn: the denied turn Stops immediately, so the
+   * reaper is intentionally NOT cleared by `_clearTurnEndState` — only when the
+   * pending entry it guards is cleared (see `_clearPendingAnswerByToolUseId` /
+   * `_pendingUserAnswers_clearAll`).
+   */
+  _armDeniedQuestionReaper(toolUseId, ms = DENIED_QUESTION_REAPER_MS) {
+    if (!toolUseId) return
+    const existing = this._deniedQuestionReapers.get(toolUseId)
+    if (existing) clearTimeout(existing)
+    const t = setTimeout(() => {
+      this._deniedQuestionReapers.delete(toolUseId)
+      this._reapDeniedQuestion(toolUseId)
+    }, ms)
+    this._deniedQuestionReapers.set(toolUseId, t)
+  }
+
+  /** #5792: cancel + drop ONE toolUseId's denied-shape reaper. Idempotent. */
+  _clearDeniedQuestionReaper(toolUseId) {
+    const t = this._deniedQuestionReapers.get(toolUseId)
+    if (t) {
+      clearTimeout(t)
+      this._deniedQuestionReapers.delete(toolUseId)
+    }
+  }
+
+  /** #5792: cancel + drop ALL denied-shape reapers (turn-level wipe + destroy()). Idempotent. */
+  _clearAllDeniedQuestionReapers() {
+    for (const t of this._deniedQuestionReapers.values()) clearTimeout(t)
+    this._deniedQuestionReapers.clear()
+  }
+
+  /**
+   * #5792: drop a denied-shape AskUserQuestion's pending entry if it STILL
+   * leaks after the reaper window (deny → Stop → idle with no answer). A no-op
+   * when the entry is already gone (PostToolUse arrived, the user answered, or a
+   * turn-ending teardown cleared it). Clears only this toolUseId's state — the
+   * pending entry and its own (keyed) stall watchdog. It deliberately does NOT
+   * touch the global `askuserquestion-active` lock: that lock is already cleared
+   * at the denied turn's Stop (`_clearTurnEndState`), and clearing it here could
+   * drop a LATER turn's legitimate lock if a fresh AskUserQuestion is in flight
+   * when the reaper fires.
+   */
+  _reapDeniedQuestion(toolUseId) {
+    if (this._destroying) return
+    if (!this._pendingUserAnswers.has(toolUseId)) return
+    ;(this._log || log).warn(`AskUserQuestion denied-shape reaper (#5792): tool=${toolUseId} pending entry never cleared after deny→Stop→idle — dropping leaked entry so a later no-toolUseId answer can't misroute to it`)
+    this._clearPendingAnswerByToolUseId(toolUseId)
+    this._clearAskUserQuestionWatchdog(toolUseId)
   }
 
   /**
@@ -2579,6 +2662,17 @@ export class ClaudeTuiSession extends BaseSession {
         // across any subsequent re-arm until the answer's PostToolUse clears the
         // pending entry.
         this._suspendBackstopsForPendingQuestion()
+        // #5792: a DENIED shape (multi-question OR any multi-select question) is
+        // rejected at the permission hook, so claude Stops with no PostToolUse
+        // and no answer ever arrives — the pending entry above would leak past
+        // turn-end (the Stop success path keeps pending). Arm a reaper to drop
+        // it. A legitimate single single-select is NOT a denied shape: it gets a
+        // PostToolUse (or its own respondToQuestion stall watchdog) and is left
+        // untouched.
+        const isDeniedShape = questionCount > 1 || questions.some((q) => q && q.multiSelect === true)
+        if (isDeniedShape) {
+          this._armDeniedQuestionReaper(toolUseId)
+        }
       }
       return
     }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -57,11 +57,12 @@ const __dirname = dirname(__filename)
 const log = createLogger('claude-tui-session')
 
 // #5792: how long a DENIED-shape AskUserQuestion pending entry may linger past
-// turn-end before the reaper drops it. Mirrors the 30s stall-watchdog window
-// (ASK_USER_QUESTION_WATCHDOG_MS) — long enough for any in-flight teardown /
-// reinject to clear the entry on its own (making the reaper a no-op), short
-// enough that a leaked entry can't shadow the most-recent fallback for long.
-const DENIED_QUESTION_REAPER_MS = 30 * 1000
+// turn-end before the reaper drops it. Derived from (not a re-declared copy of)
+// the stall-watchdog window so the two can't drift: long enough for any
+// in-flight teardown / reinject to clear the entry on its own (making the reaper
+// a no-op), short enough that a leaked entry can't shadow the most-recent
+// fallback for long. Same recovery-window class as the answer stall.
+const DENIED_QUESTION_REAPER_MS = ASK_USER_QUESTION_WATCHDOG_MS
 
 /**
  * ClaudeTuiSession — drives the interactive `claude` TUI under a PTY so the

--- a/packages/server/tests/claude-tui-denied-question-reaper.test.js
+++ b/packages/server/tests/claude-tui-denied-question-reaper.test.js
@@ -170,4 +170,55 @@ describe('ClaudeTuiSession — denied-shape AskUserQuestion reaper (#5792)', () 
     assert.doesNotThrow(() => session._reapDeniedQuestion('toolu_absent'))
     assert.ok(session._pendingUserAnswers.has('toolu_keep'), 'unrelated pending entry untouched')
   })
+
+  // S1 (review #5975): reaping the denied entry must not disturb a CO-RESIDENT
+  // legit single-select sibling — the actual #4668-class hazard the per-toolUseId
+  // keying guards against (the absent-id test above only covers a missing id).
+  it('reaping a denied multi leaves a co-resident legit single-select sibling intact', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    // Denied multi (id A) → arms a reaper (30s).
+    session._emitToolHookEvent('PreToolUse', multiQuestionPayload('toolu_A'), 'msg-test')
+    // Legit single single-select (id B) → no reaper; seed its own stall watchdog
+    // as respondToQuestion would, with a longer window so A's 30s reaper fires
+    // first without B's watchdog also firing.
+    session._emitToolHookEvent('PreToolUse', singleSelectPayload('toolu_B'), 'msg-test')
+    session._armAskUserQuestionWatchdog('toolu_B', 120_000)
+    assert.ok(session._deniedQuestionReapers.has('toolu_A'), 'reaper armed for the denied multi')
+    assert.equal(session._deniedQuestionReapers.has('toolu_B'), false, 'no reaper for the legit single-select')
+    assert.ok(session._askUserQuestionWatchdogs.has('toolu_B'), 'sibling stall watchdog armed')
+
+    mock.timers.tick(60_000) // past A's 30s reaper, before B's 120s watchdog
+
+    assert.equal(session._pendingUserAnswers.has('toolu_A'), false, 'denied sibling reaped')
+    assert.ok(session._pendingUserAnswers.has('toolu_B'), 'legit single-select entry survives')
+    assert.ok(session._askUserQuestionWatchdogs.has('toolu_B'), 'legit single-select watchdog survives')
+    assert.equal(session._lastPendingAnswerToolUseId, 'toolu_B', 'most-recent pointer points at the survivor')
+  })
+
+  // S2 (review #5975): the multiSelect reinject path clears the pending entry
+  // synchronously (before its async send) on every outcome, so it cancels the
+  // reaper — pinning the no-race property documented on DENIED_QUESTION_REAPER_MS.
+  it('the multiSelect reinject path cancels the reaper (flag-on, no race)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const prev = process.env.CHROXY_TUI_MULTISELECT_REINJECT
+    process.env.CHROXY_TUI_MULTISELECT_REINJECT = '1'
+    try {
+      session._emitToolHookEvent('PreToolUse', multiSelectPayload('toolu_ms'), 'msg-test')
+      assert.ok(session._deniedQuestionReapers.has('toolu_ms'), 'reaper armed for the denied multi-select')
+
+      // The session has no PTY in this unit test, so the flag-on reinject path
+      // tears down via the 'unavailable' refusal — which clears the pending entry
+      // synchronously, cancelling the reaper before any async send could race it.
+      session.respondToQuestion('', { 'Pick any': ['A'] }, 'toolu_ms', {})
+
+      assert.equal(session._pendingUserAnswers.has('toolu_ms'), false, 'reinject teardown cleared the entry')
+      assert.equal(session._deniedQuestionReapers.has('toolu_ms'), false, 'reaper cancelled with the entry')
+
+      mock.timers.tick(60_000) // nothing armed — must be a no-op
+      assert.equal(session._pendingUserAnswers.size, 0)
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_TUI_MULTISELECT_REINJECT
+      else process.env.CHROXY_TUI_MULTISELECT_REINJECT = prev
+    }
+  })
 })

--- a/packages/server/tests/claude-tui-denied-question-reaper.test.js
+++ b/packages/server/tests/claude-tui-denied-question-reaper.test.js
@@ -1,0 +1,173 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+
+/**
+ * #5792 — denied-shape AskUserQuestion reaper.
+ *
+ * The permission hook DENIES a multi-question (questions.length > 1) or
+ * multi-select (any question multiSelect:true) AskUserQuestion, so claude blocks
+ * in the tool then Stops with no PostToolUse. The Stop success path
+ * (`_clearTurnEndState`) clears the sibling lock + stall watchdogs but
+ * deliberately keeps `_pendingUserAnswers` (a legit sibling answer may still be
+ * in flight). For a DENIED shape no answer ever arrives, so that pending entry
+ * leaks past turn-end and a later no-toolUseId `respondToQuestion` would
+ * misroute to it via the most-recent back-compat fallback.
+ *
+ * The reaper, armed ONLY for denied shapes at pending-creation, drops the
+ * still-leaked entry after a window. A legitimate single single-select is left
+ * untouched (it gets a PostToolUse / its own stall watchdog).
+ */
+describe('ClaudeTuiSession — denied-shape AskUserQuestion reaper (#5792)', () => {
+  let emptySkillsDir
+  let session
+
+  const multiQuestionPayload = (toolUseId = 'toolu_multi') => ({
+    tool_name: 'AskUserQuestion',
+    tool_use_id: toolUseId,
+    tool_input: {
+      questions: [
+        { question: 'Which provider?', header: 'Provider', options: [{ label: 'A', value: 'a' }] },
+        { question: 'Which transport?', header: 'Transport', options: [{ label: 'B', value: 'b' }] },
+      ],
+    },
+  })
+
+  const multiSelectPayload = (toolUseId = 'toolu_ms') => ({
+    tool_name: 'AskUserQuestion',
+    tool_use_id: toolUseId,
+    tool_input: {
+      questions: [
+        { question: 'Pick any', header: 'Pick', multiSelect: true, options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }] },
+      ],
+    },
+  })
+
+  const singleSelectPayload = (toolUseId = 'toolu_single') => ({
+    tool_name: 'AskUserQuestion',
+    tool_use_id: toolUseId,
+    tool_input: {
+      questions: [
+        { question: 'Pick one', header: 'Pick', options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }] },
+      ],
+    },
+  })
+
+  beforeEach(() => {
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-skills-'))
+    session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+    session.on('error', () => {})
+    // _emitToolHookEvent reads _activeTurn for the synth-id fallback path.
+    session._activeTurn = { messageId: 'msg-test', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+  })
+
+  afterEach(async () => {
+    mock.timers.reset()
+    if (session) {
+      try { await session.destroy() } catch { /* ignore */ }
+      session = null
+    }
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
+  })
+
+  it('arms a reaper for a multi-question AskUserQuestion', () => {
+    session._emitToolHookEvent('PreToolUse', multiQuestionPayload('toolu_multi'), 'msg-test')
+    assert.ok(session._pendingUserAnswers.has('toolu_multi'), 'pending entry created')
+    assert.ok(session._deniedQuestionReapers.has('toolu_multi'), 'reaper armed for the denied multi-question shape')
+  })
+
+  it('arms a reaper for a single multi-select AskUserQuestion', () => {
+    session._emitToolHookEvent('PreToolUse', multiSelectPayload('toolu_ms'), 'msg-test')
+    assert.ok(session._pendingUserAnswers.has('toolu_ms'), 'pending entry created')
+    assert.ok(session._deniedQuestionReapers.has('toolu_ms'), 'reaper armed for the denied multi-select shape')
+  })
+
+  it('does NOT arm a reaper for a legitimate single single-select', () => {
+    session._emitToolHookEvent('PreToolUse', singleSelectPayload('toolu_single'), 'msg-test')
+    assert.ok(session._pendingUserAnswers.has('toolu_single'), 'pending entry created')
+    assert.equal(session._deniedQuestionReapers.has('toolu_single'), false,
+      'no reaper for a legitimate single single-select (it gets a PostToolUse / its own stall watchdog)')
+  })
+
+  // Acceptance #1: after deny→Stop→idle with no answer, _pendingUserAnswers AND
+  // the sibling lock are empty.
+  it('after deny→Stop→reaper-fire, pending entry and sibling lock are both empty', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    // The permission hook leaves an askuserquestion-active lock under the sink.
+    session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-'))
+    const lockPath = join(session._sinkDir, 'askuserquestion-active')
+    writeFileSync(lockPath, '1')
+    session._isBusy = true
+    session._currentMessageId = 'msg-test'
+
+    session._emitToolHookEvent('PreToolUse', multiQuestionPayload('toolu_multi'), 'msg-test')
+    assert.ok(session._pendingUserAnswers.has('toolu_multi'))
+    assert.ok(session._deniedQuestionReapers.has('toolu_multi'))
+
+    // Stop success path runs the shared per-turn teardown: it clears the lock +
+    // watchdogs but deliberately keeps _pendingUserAnswers. The reaper survives.
+    session._clearTurnEndState()
+    assert.equal(existsSync(lockPath), false, 'sibling lock already cleared at Stop (#4604)')
+    assert.ok(session._pendingUserAnswers.has('toolu_multi'), 'pending still leaks past Stop')
+    assert.ok(session._deniedQuestionReapers.has('toolu_multi'), 'reaper survives turn-end')
+
+    mock.timers.tick(60_000) // past the reaper window
+
+    assert.equal(session._pendingUserAnswers.size, 0, 'reaper dropped the leaked pending entry')
+    assert.equal(session._deniedQuestionReapers.size, 0, 'reaper self-removed after firing')
+    assert.equal(existsSync(lockPath), false, 'sibling lock stays empty')
+
+    rmSync(session._sinkDir, { recursive: true, force: true })
+  })
+
+  // Acceptance #2: a late answer arriving after the reaper fires is dropped
+  // cleanly, not misrouted via the most-recent back-compat fallback.
+  it('drops a late no-toolUseId answer after the reaper has fired (no misroute)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    session._emitToolHookEvent('PreToolUse', multiQuestionPayload('toolu_multi'), 'msg-test')
+    session._clearTurnEndState()
+    mock.timers.tick(60_000)
+    assert.equal(session._pendingUserAnswers.size, 0)
+    assert.equal(session._lastPendingAnswerToolUseId, null,
+      'most-recent pointer cleared so a no-toolUseId answer finds nothing to misroute to')
+    // The back-compat getter (what respondToQuestion falls back to) returns null.
+    assert.equal(session._pendingUserAnswer, null, 'no stale entry for the most-recent fallback')
+  })
+
+  it('PostToolUse cancels the reaper (answered/resolved entry is not reaped)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    session._emitToolHookEvent('PreToolUse', multiQuestionPayload('toolu_multi'), 'msg-test')
+    assert.ok(session._deniedQuestionReapers.has('toolu_multi'))
+
+    // PostToolUse clears the pending entry via _clearPendingAnswerByToolUseId,
+    // which must also cancel the reaper.
+    session._emitToolHookEvent('PostToolUse', multiQuestionPayload('toolu_multi'), 'msg-test')
+    assert.equal(session._pendingUserAnswers.has('toolu_multi'), false, 'PostToolUse cleared the entry')
+    assert.equal(session._deniedQuestionReapers.has('toolu_multi'), false, 'reaper cancelled with the entry')
+
+    mock.timers.tick(60_000) // reaper must not fire — nothing armed
+    assert.equal(session._pendingUserAnswers.size, 0)
+  })
+
+  it('a turn-level wipe (_pendingUserAnswers_clearAll) clears all reapers', () => {
+    session._emitToolHookEvent('PreToolUse', multiQuestionPayload('toolu_multi_a'), 'msg-test')
+    session._emitToolHookEvent('PreToolUse', multiSelectPayload('toolu_ms_b'), 'msg-test')
+    assert.equal(session._deniedQuestionReapers.size, 2)
+
+    // interrupt()/destroy() issue Ctrl-C then wipe pending wholesale.
+    session._pendingUserAnswers_clearAll()
+    assert.equal(session._pendingUserAnswers.size, 0)
+    assert.equal(session._deniedQuestionReapers.size, 0, 'all reapers cleared with the wholesale pending wipe')
+  })
+
+  it('_reapDeniedQuestion is a no-op when the entry is already gone', () => {
+    // No pending entry for this id → reaping must not throw or clear siblings.
+    session._emitToolHookEvent('PreToolUse', singleSelectPayload('toolu_keep'), 'msg-test')
+    assert.doesNotThrow(() => session._reapDeniedQuestion('toolu_absent'))
+    assert.ok(session._pendingUserAnswers.has('toolu_keep'), 'unrelated pending entry untouched')
+  })
+})


### PR DESCRIPTION
## Summary
A multi-question (`questions.length > 1`) or multi-select AskUserQuestion is **denied at the permission hook**, so claude blocks in the tool then **Stops with no PostToolUse**. The Stop success path (`_clearTurnEndState`) clears the `askuserquestion-active` sibling lock + stall watchdogs but deliberately keeps `_pendingUserAnswers` (a legit sibling answer may still be in flight). For a **denied** shape no answer ever arrives, so that pending entry **leaks past turn-end** — and a later no-`toolUseId` `respondToQuestion` would then **misroute** to it via the most-recent back-compat fallback (`form-driver.js`).

## Re-verify note (audit was partially stale)
The original audit (#5792) said the sibling lock + watchdogs also leak. Verified against current main: `_clearTurnEndState` (the shared success+error per-turn teardown, the #4604/#5319 drift fix) **already clears the lock and all watchdogs** on the Stop success path. The **only** residual leak is `_pendingUserAnswers`. Consequently this fix:
- clears the leaked pending entry (+ its keyed stall watchdog), and
- **deliberately does NOT clear the global `askuserquestion-active` lock** — it's already cleared at the denied turn's Stop, and clearing it from the reaper could drop a *later* turn's legitimate lock if a fresh AskUserQuestion is in flight when the reaper fires.

## Approach (the issue's recommended option A, scoped)
Arm a reaper **only for denied shapes** (`questionCount > 1` OR any `question.multiSelect === true`) at pending-creation in `_emitToolHookEvent`. It must **outlive the turn** (the denied turn Stops immediately), so it lives in its own `_deniedQuestionReapers` map and is **not** cleared by `_clearTurnEndState` — only when the pending entry it guards is cleared (`_clearPendingAnswerByToolUseId` / `_pendingUserAnswers_clearAll`), which covers PostToolUse, interrupt and destroy. On fire (30s window, mirrors `ASK_USER_QUESTION_WATCHDOG_MS`) it drops the entry **iff it still leaks** — a no-op otherwise. A legitimate single single-select is not a denied shape and is left untouched (it gets a PostToolUse / its own stall watchdog).

## Tests (acceptance criteria)
New `claude-tui-denied-question-reaper.test.js` (8 tests):
- arms a reaper for multi-question and for single multi-select shapes
- does **NOT** arm for a legitimate single single-select
- after deny→Stop→reaper-fire: `_pendingUserAnswers` **and** the sibling lock are empty (AC #1)
- a late no-`toolUseId` answer after the reaper fires is **dropped, not misrouted** (AC #2)
- PostToolUse cancels the reaper (answered entry not reaped)
- a turn-level wipe clears all reapers
- `_reapDeniedQuestion` is a no-op when the entry is already gone

372/372 green across the TUI session/form-driver/multi-question/permission-hook/mirror/attachments suites. Server custom lints green.

Closes #5792