### PR TITLE
feat(store-core): identity-key rotation handoff — crypto + pin chain-forward (#5616 phase 1)

### DIFF
--- a/packages/store-core/dist/crypto.d.ts
+++ b/packages/store-core/dist/crypto.d.ts
@@ -92,6 +92,53 @@ export declare function signExchangeKey(exchangePublicKeyBase64: string, identit
  */
 export declare function verifyExchangeKeySignature(exchangePublicKeyBase64: string, signatureBase64: string, identityPublicKeyBase64: string): boolean;
 /**
+ * #5616 — domain-separation label for an identity-key ROTATION statement: the
+ * OLD identity secret signs the NEW identity PUBLIC key so a pinned client can
+ * chain its pin forward (reinstall / machine migration / #5229 master-key
+ * rotation) instead of refusing + forcing a manual re-pair.
+ *
+ * This is a SECOND statement the identity key signs (the first being the
+ * exchange key, #5604), so domain separation is mandatory: without it a rotation
+ * cert (old signs new-identity-bytes) and an exchange-key signature (identity
+ * signs exchange-key-bytes) could be confused if their byte lengths ever
+ * coincided. Both labels are versioned ASCII; this scheme is domain-separated
+ * from the START (unlike the exchange-key ramp), since there is no legacy bare
+ * rotation-cert wire format to stay compatible with — it's a new message.
+ */
+export declare const IDENTITY_ROTATION_DOMAIN_V1 = "chroxy-identity-rotation-v1:";
+/**
+ * Sign an identity-rotation cert: the OLD identity secret signs the NEW identity
+ * public key (domain-separated). A pinned client presented this cert at handshake
+ * can verify the new identity was authorised by the identity it already trusts,
+ * and chain its pin forward without a manual re-pair (#5616).
+ *
+ * The cert alone is NOT sufficient to accept a rotation — the verifier must ALSO
+ * confirm the new identity signed the live exchange key (proving the server holds
+ * the new secret, not just a replayed cert). See `verifyIdentityRotation` +
+ * `decideKeyPin`'s rotation branch.
+ *
+ * @param newIdentityPublicKeyBase64 - the NEW identity Ed25519 public key (base64)
+ * @param oldIdentitySecretKey - the 64-byte OLD identity Ed25519 secret key
+ * @returns base64-encoded 64-byte detached rotation cert
+ */
+export declare function signIdentityRotation(newIdentityPublicKeyBase64: string, oldIdentitySecretKey: Uint8Array): string;
+/**
+ * Verify an identity-rotation cert: that `certBase64` is a valid signature over
+ * the NEW identity public key, produced by the holder of the OLD (pinned)
+ * identity secret. Returns true on a valid cert, false on any mismatch /
+ * malformed input. NEVER throws — an invalid cert is a verification FAILURE the
+ * caller must treat as "no valid rotation", not an exception to swallow.
+ *
+ * Only the domain-separated form is accepted (this statement type never had a
+ * bare wire form), so a context-free signature — or an exchange-key signature
+ * replayed as a rotation cert — cannot pass.
+ *
+ * @param newIdentityPublicKeyBase64 - the NEW identity Ed25519 public key offered
+ * @param certBase64 - the rotation cert offered by the server
+ * @param oldIdentityPublicKeyBase64 - the PINNED (old) identity public key to verify against
+ */
+export declare function verifyIdentityRotation(newIdentityPublicKeyBase64: string, certBase64: string, oldIdentityPublicKeyBase64: string): boolean;
+/**
  * Derive a shared symmetric key from the other side's public key and our secret key.
  */
 export declare function deriveSharedKey(theirPubBase64: string, mySecretKey: Uint8Array): Uint8Array;

--- a/packages/store-core/dist/crypto.js
+++ b/packages/store-core/dist/crypto.js
@@ -157,6 +157,103 @@ export function verifyExchangeKeySignature(exchangePublicKeyBase64, signatureBas
     }
 }
 /**
+ * #5616 — domain-separation label for an identity-key ROTATION statement: the
+ * OLD identity secret signs the NEW identity PUBLIC key so a pinned client can
+ * chain its pin forward (reinstall / machine migration / #5229 master-key
+ * rotation) instead of refusing + forcing a manual re-pair.
+ *
+ * This is a SECOND statement the identity key signs (the first being the
+ * exchange key, #5604), so domain separation is mandatory: without it a rotation
+ * cert (old signs new-identity-bytes) and an exchange-key signature (identity
+ * signs exchange-key-bytes) could be confused if their byte lengths ever
+ * coincided. Both labels are versioned ASCII; this scheme is domain-separated
+ * from the START (unlike the exchange-key ramp), since there is no legacy bare
+ * rotation-cert wire format to stay compatible with — it's a new message.
+ */
+export const IDENTITY_ROTATION_DOMAIN_V1 = 'chroxy-identity-rotation-v1:';
+/**
+ * Build the byte string the OLD identity key signs to bless a NEW identity:
+ * `IDENTITY_ROTATION_DOMAIN_V1` (ASCII) ++ the raw 32 bytes of the new identity
+ * Ed25519 public key.
+ */
+function identityRotationSigMessage(newIdentityPublicKeyBytes) {
+    const prefix = new TextEncoder().encode(IDENTITY_ROTATION_DOMAIN_V1);
+    const msg = new Uint8Array(prefix.length + newIdentityPublicKeyBytes.length);
+    msg.set(prefix, 0);
+    msg.set(newIdentityPublicKeyBytes, prefix.length);
+    return msg;
+}
+/**
+ * Sign an identity-rotation cert: the OLD identity secret signs the NEW identity
+ * public key (domain-separated). A pinned client presented this cert at handshake
+ * can verify the new identity was authorised by the identity it already trusts,
+ * and chain its pin forward without a manual re-pair (#5616).
+ *
+ * The cert alone is NOT sufficient to accept a rotation — the verifier must ALSO
+ * confirm the new identity signed the live exchange key (proving the server holds
+ * the new secret, not just a replayed cert). See `verifyIdentityRotation` +
+ * `decideKeyPin`'s rotation branch.
+ *
+ * @param newIdentityPublicKeyBase64 - the NEW identity Ed25519 public key (base64)
+ * @param oldIdentitySecretKey - the 64-byte OLD identity Ed25519 secret key
+ * @returns base64-encoded 64-byte detached rotation cert
+ */
+export function signIdentityRotation(newIdentityPublicKeyBase64, oldIdentitySecretKey) {
+    if (typeof newIdentityPublicKeyBase64 !== 'string' || newIdentityPublicKeyBase64.trim().length === 0) {
+        throw new Error('signIdentityRotation: new identity public key must be a non-empty base64 string');
+    }
+    if (!(oldIdentitySecretKey instanceof Uint8Array) || oldIdentitySecretKey.length !== nacl.sign.secretKeyLength) {
+        throw new Error(`signIdentityRotation: old identity secret key must be a ${nacl.sign.secretKeyLength}-byte Uint8Array`);
+    }
+    const newIdentityBytes = new Uint8Array(decodeBase64(newIdentityPublicKeyBase64));
+    if (newIdentityBytes.length !== nacl.sign.publicKeyLength) {
+        throw new Error(`signIdentityRotation: new identity public key must decode to ${nacl.sign.publicKeyLength} bytes`);
+    }
+    const sig = nacl.sign.detached(identityRotationSigMessage(newIdentityBytes), oldIdentitySecretKey);
+    return encodeBase64(sig);
+}
+/**
+ * Verify an identity-rotation cert: that `certBase64` is a valid signature over
+ * the NEW identity public key, produced by the holder of the OLD (pinned)
+ * identity secret. Returns true on a valid cert, false on any mismatch /
+ * malformed input. NEVER throws — an invalid cert is a verification FAILURE the
+ * caller must treat as "no valid rotation", not an exception to swallow.
+ *
+ * Only the domain-separated form is accepted (this statement type never had a
+ * bare wire form), so a context-free signature — or an exchange-key signature
+ * replayed as a rotation cert — cannot pass.
+ *
+ * @param newIdentityPublicKeyBase64 - the NEW identity Ed25519 public key offered
+ * @param certBase64 - the rotation cert offered by the server
+ * @param oldIdentityPublicKeyBase64 - the PINNED (old) identity public key to verify against
+ */
+export function verifyIdentityRotation(newIdentityPublicKeyBase64, certBase64, oldIdentityPublicKeyBase64) {
+    try {
+        if (typeof newIdentityPublicKeyBase64 !== 'string' || newIdentityPublicKeyBase64.length === 0)
+            return false;
+        if (typeof certBase64 !== 'string' || certBase64.length === 0)
+            return false;
+        if (typeof oldIdentityPublicKeyBase64 !== 'string' || oldIdentityPublicKeyBase64.length === 0)
+            return false;
+        const newIdentityBytes = new Uint8Array(decodeBase64(newIdentityPublicKeyBase64));
+        const cert = new Uint8Array(decodeBase64(certBase64));
+        const oldIdentityPub = new Uint8Array(decodeBase64(oldIdentityPublicKeyBase64));
+        // Both the new identity key and the verifying old identity key are Ed25519
+        // public keys; the cert is a detached Ed25519 signature. Reject wrong lengths
+        // as malformed input up front rather than as a genuine mismatch.
+        if (newIdentityBytes.length !== nacl.sign.publicKeyLength)
+            return false;
+        if (cert.length !== nacl.sign.signatureLength)
+            return false;
+        if (oldIdentityPub.length !== nacl.sign.publicKeyLength)
+            return false;
+        return nacl.sign.detached.verify(identityRotationSigMessage(newIdentityBytes), cert, oldIdentityPub);
+    }
+    catch {
+        return false;
+    }
+}
+/**
  * Derive a shared symmetric key from the other side's public key and our secret key.
  */
 export function deriveSharedKey(theirPubBase64, mySecretKey) {

--- a/packages/store-core/src/crypto.test.ts
+++ b/packages/store-core/src/crypto.test.ts
@@ -17,6 +17,9 @@ import {
   signExchangeKey,
   verifyExchangeKeySignature,
   EXCHANGE_KEY_SIG_DOMAIN_V1,
+  signIdentityRotation,
+  verifyIdentityRotation,
+  IDENTITY_ROTATION_DOMAIN_V1,
   DIRECTION_SERVER,
   DIRECTION_CLIENT,
 } from './crypto'
@@ -807,5 +810,85 @@ describe('exchange-key signature domain separation (#5604 compat ramp)', () => {
     // Pin the exact label — changing it would silently break verification across
     // a version skew, so a change must be deliberate (and bump the version).
     expect(EXCHANGE_KEY_SIG_DOMAIN_V1).toBe('chroxy-exchange-key-v1:')
+  })
+})
+
+describe('identity-key rotation cert (#5616)', () => {
+  it('signs with the old identity and verifies the new identity against the old public key', () => {
+    const oldIdentity = createSigningKeyPair()
+    const newIdentity = createSigningKeyPair()
+    const cert = signIdentityRotation(newIdentity.publicKey, oldIdentity.secretKey)
+    expect(verifyIdentityRotation(newIdentity.publicKey, cert, oldIdentity.publicKey)).toBe(true)
+  })
+
+  it('rejects a cert from a DIFFERENT old identity (forged rotation)', () => {
+    const realOld = createSigningKeyPair()
+    const attackerOld = createSigningKeyPair()
+    const newIdentity = createSigningKeyPair()
+    // The attacker signs the new identity with THEIR key, but the client pinned
+    // the real old identity — so the cert fails against the pinned key.
+    const forged = signIdentityRotation(newIdentity.publicKey, attackerOld.secretKey)
+    expect(verifyIdentityRotation(newIdentity.publicKey, forged, realOld.publicKey)).toBe(false)
+  })
+
+  it('rejects a valid cert verified against a SUBSTITUTED new identity', () => {
+    const oldIdentity = createSigningKeyPair()
+    const realNew = createSigningKeyPair()
+    const otherNew = createSigningKeyPair()
+    const cert = signIdentityRotation(realNew.publicKey, oldIdentity.secretKey)
+    // The cert is genuine but blesses realNew; verifying it for a different new
+    // identity must fail (an attacker can't redirect the cert to their key).
+    expect(verifyIdentityRotation(otherNew.publicKey, cert, oldIdentity.publicKey)).toBe(false)
+  })
+
+  it('an exchange-key signature is NOT accepted as a rotation cert (domain separation)', () => {
+    // Cross-protocol confusion guard: a signature the old identity produced over
+    // an exchange key must not verify as a rotation cert over those same bytes.
+    const oldIdentity = createSigningKeyPair()
+    const newIdentity = createSigningKeyPair()
+    // Sign the new-identity bytes AS AN EXCHANGE KEY (bare + domain-separated),
+    // then try to pass each off as a rotation cert.
+    const asExchangeBare = signExchangeKey(newIdentity.publicKey, oldIdentity.secretKey)
+    const asExchangeDomain = signExchangeKey(newIdentity.publicKey, oldIdentity.secretKey, { domainSeparated: true })
+    expect(verifyIdentityRotation(newIdentity.publicKey, asExchangeBare, oldIdentity.publicKey)).toBe(false)
+    expect(verifyIdentityRotation(newIdentity.publicKey, asExchangeDomain, oldIdentity.publicKey)).toBe(false)
+  })
+
+  it('a tampered cert byte fails verification', () => {
+    const oldIdentity = createSigningKeyPair()
+    const newIdentity = createSigningKeyPair()
+    const cert = signIdentityRotation(newIdentity.publicKey, oldIdentity.secretKey)
+    const bytes = decodeBase64(cert)
+    bytes[0] ^= 0xff
+    expect(verifyIdentityRotation(newIdentity.publicKey, encodeBase64(bytes), oldIdentity.publicKey)).toBe(false)
+  })
+
+  it('returns false (never throws) for malformed / empty / missing inputs', () => {
+    const oldIdentity = createSigningKeyPair()
+    const newIdentity = createSigningKeyPair()
+    const cert = signIdentityRotation(newIdentity.publicKey, oldIdentity.secretKey)
+    expect(verifyIdentityRotation(newIdentity.publicKey, '', oldIdentity.publicKey)).toBe(false)
+    expect(verifyIdentityRotation(newIdentity.publicKey, cert, '')).toBe(false)
+    expect(verifyIdentityRotation('', cert, oldIdentity.publicKey)).toBe(false)
+    expect(verifyIdentityRotation(newIdentity.publicKey, 'not-base64-@@@', oldIdentity.publicKey)).toBe(false)
+    expect(verifyIdentityRotation(newIdentity.publicKey, cert, 'tooShort')).toBe(false)
+    // @ts-expect-error — deliberately pass a non-string to assert no throw
+    expect(verifyIdentityRotation(undefined, cert, oldIdentity.publicKey)).toBe(false)
+  })
+
+  it('signIdentityRotation throws on a wrong-length old secret key', () => {
+    const newIdentity = createSigningKeyPair()
+    expect(() => signIdentityRotation(newIdentity.publicKey, new Uint8Array(32))).toThrow()
+  })
+
+  it('signIdentityRotation throws on a new identity key that is not 32 bytes', () => {
+    const oldIdentity = createSigningKeyPair()
+    const notAnIdentity = encodeBase64(nacl.randomBytes(16))
+    expect(() => signIdentityRotation(notAnIdentity, oldIdentity.secretKey)).toThrow()
+  })
+
+  it('exposes a stable, versioned domain label distinct from the exchange-key label', () => {
+    expect(IDENTITY_ROTATION_DOMAIN_V1).toBe('chroxy-identity-rotation-v1:')
+    expect(IDENTITY_ROTATION_DOMAIN_V1).not.toBe(EXCHANGE_KEY_SIG_DOMAIN_V1)
   })
 })

--- a/packages/store-core/src/crypto.ts
+++ b/packages/store-core/src/crypto.ts
@@ -207,6 +207,107 @@ export function verifyExchangeKeySignature(
 }
 
 /**
+ * #5616 — domain-separation label for an identity-key ROTATION statement: the
+ * OLD identity secret signs the NEW identity PUBLIC key so a pinned client can
+ * chain its pin forward (reinstall / machine migration / #5229 master-key
+ * rotation) instead of refusing + forcing a manual re-pair.
+ *
+ * This is a SECOND statement the identity key signs (the first being the
+ * exchange key, #5604), so domain separation is mandatory: without it a rotation
+ * cert (old signs new-identity-bytes) and an exchange-key signature (identity
+ * signs exchange-key-bytes) could be confused if their byte lengths ever
+ * coincided. Both labels are versioned ASCII; this scheme is domain-separated
+ * from the START (unlike the exchange-key ramp), since there is no legacy bare
+ * rotation-cert wire format to stay compatible with — it's a new message.
+ */
+export const IDENTITY_ROTATION_DOMAIN_V1 = 'chroxy-identity-rotation-v1:'
+
+/**
+ * Build the byte string the OLD identity key signs to bless a NEW identity:
+ * `IDENTITY_ROTATION_DOMAIN_V1` (ASCII) ++ the raw 32 bytes of the new identity
+ * Ed25519 public key.
+ */
+function identityRotationSigMessage(newIdentityPublicKeyBytes: Uint8Array): Uint8Array {
+  const prefix = new TextEncoder().encode(IDENTITY_ROTATION_DOMAIN_V1)
+  const msg = new Uint8Array(prefix.length + newIdentityPublicKeyBytes.length)
+  msg.set(prefix, 0)
+  msg.set(newIdentityPublicKeyBytes, prefix.length)
+  return msg
+}
+
+/**
+ * Sign an identity-rotation cert: the OLD identity secret signs the NEW identity
+ * public key (domain-separated). A pinned client presented this cert at handshake
+ * can verify the new identity was authorised by the identity it already trusts,
+ * and chain its pin forward without a manual re-pair (#5616).
+ *
+ * The cert alone is NOT sufficient to accept a rotation — the verifier must ALSO
+ * confirm the new identity signed the live exchange key (proving the server holds
+ * the new secret, not just a replayed cert). See `verifyIdentityRotation` +
+ * `decideKeyPin`'s rotation branch.
+ *
+ * @param newIdentityPublicKeyBase64 - the NEW identity Ed25519 public key (base64)
+ * @param oldIdentitySecretKey - the 64-byte OLD identity Ed25519 secret key
+ * @returns base64-encoded 64-byte detached rotation cert
+ */
+export function signIdentityRotation(
+  newIdentityPublicKeyBase64: string,
+  oldIdentitySecretKey: Uint8Array,
+): string {
+  if (typeof newIdentityPublicKeyBase64 !== 'string' || newIdentityPublicKeyBase64.trim().length === 0) {
+    throw new Error('signIdentityRotation: new identity public key must be a non-empty base64 string')
+  }
+  if (!(oldIdentitySecretKey instanceof Uint8Array) || oldIdentitySecretKey.length !== nacl.sign.secretKeyLength) {
+    throw new Error(`signIdentityRotation: old identity secret key must be a ${nacl.sign.secretKeyLength}-byte Uint8Array`)
+  }
+  const newIdentityBytes = new Uint8Array(decodeBase64(newIdentityPublicKeyBase64))
+  if (newIdentityBytes.length !== nacl.sign.publicKeyLength) {
+    throw new Error(`signIdentityRotation: new identity public key must decode to ${nacl.sign.publicKeyLength} bytes`)
+  }
+  const sig = nacl.sign.detached(identityRotationSigMessage(newIdentityBytes), oldIdentitySecretKey)
+  return encodeBase64(sig)
+}
+
+/**
+ * Verify an identity-rotation cert: that `certBase64` is a valid signature over
+ * the NEW identity public key, produced by the holder of the OLD (pinned)
+ * identity secret. Returns true on a valid cert, false on any mismatch /
+ * malformed input. NEVER throws — an invalid cert is a verification FAILURE the
+ * caller must treat as "no valid rotation", not an exception to swallow.
+ *
+ * Only the domain-separated form is accepted (this statement type never had a
+ * bare wire form), so a context-free signature — or an exchange-key signature
+ * replayed as a rotation cert — cannot pass.
+ *
+ * @param newIdentityPublicKeyBase64 - the NEW identity Ed25519 public key offered
+ * @param certBase64 - the rotation cert offered by the server
+ * @param oldIdentityPublicKeyBase64 - the PINNED (old) identity public key to verify against
+ */
+export function verifyIdentityRotation(
+  newIdentityPublicKeyBase64: string,
+  certBase64: string,
+  oldIdentityPublicKeyBase64: string,
+): boolean {
+  try {
+    if (typeof newIdentityPublicKeyBase64 !== 'string' || newIdentityPublicKeyBase64.length === 0) return false
+    if (typeof certBase64 !== 'string' || certBase64.length === 0) return false
+    if (typeof oldIdentityPublicKeyBase64 !== 'string' || oldIdentityPublicKeyBase64.length === 0) return false
+    const newIdentityBytes = new Uint8Array(decodeBase64(newIdentityPublicKeyBase64))
+    const cert = new Uint8Array(decodeBase64(certBase64))
+    const oldIdentityPub = new Uint8Array(decodeBase64(oldIdentityPublicKeyBase64))
+    // Both the new identity key and the verifying old identity key are Ed25519
+    // public keys; the cert is a detached Ed25519 signature. Reject wrong lengths
+    // as malformed input up front rather than as a genuine mismatch.
+    if (newIdentityBytes.length !== nacl.sign.publicKeyLength) return false
+    if (cert.length !== nacl.sign.signatureLength) return false
+    if (oldIdentityPub.length !== nacl.sign.publicKeyLength) return false
+    return nacl.sign.detached.verify(identityRotationSigMessage(newIdentityBytes), cert, oldIdentityPub)
+  } catch {
+    return false
+  }
+}
+
+/**
  * Derive a shared symmetric key from the other side's public key and our secret key.
  */
 export function deriveSharedKey(theirPubBase64: string, mySecretKey: Uint8Array): Uint8Array {

--- a/packages/store-core/src/key-pinning.test.ts
+++ b/packages/store-core/src/key-pinning.test.ts
@@ -2,7 +2,7 @@
  * Tests for the shared E2E key-pinning decision (#5536).
  */
 import { describe, it, expect } from 'vitest'
-import { createKeyPair, createSigningKeyPair, signExchangeKey } from './crypto'
+import { createKeyPair, createSigningKeyPair, signExchangeKey, signIdentityRotation } from './crypto'
 import {
   decideKeyPin,
   decideKeyPinWithPairingIdentity,
@@ -237,5 +237,126 @@ describe('decodeEncryptionGate — plaintext-auth_ok downgrade cell (#5614)', ()
       encryptionMode: null,
     })
     expect(g).toEqual({ action: 'connect', reason: 'verified' })
+  })
+})
+
+describe('decideKeyPin — identity-rotation handoff (#5616)', () => {
+  /**
+   * A legitimately-rotated daemon: the OLD (pinned) identity signs the NEW
+   * identity (rotation cert), and the NEW identity signs this handshake's
+   * exchange key (liveness). `oldIdentity` is what the client has pinned.
+   */
+  function makeRotation() {
+    const oldIdentity = createSigningKeyPair()
+    const newIdentity = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const serverKeySig = signExchangeKey(exchange.publicKey, newIdentity.secretKey)
+    const rotationCert = signIdentityRotation(newIdentity.publicKey, oldIdentity.secretKey)
+    return { oldIdentity, newIdentity, exchange, serverKeySig, rotationCert }
+  }
+
+  it('ROTATE-PINs to the new identity when the cert + liveness both verify', () => {
+    const { oldIdentity, newIdentity, exchange, serverKeySig, rotationCert } = makeRotation()
+    const d = decideKeyPin({
+      pinnedIdentityKey: oldIdentity.publicKey,
+      exchangePublicKey: exchange.publicKey,
+      serverKeySig,
+      newIdentityKey: newIdentity.publicKey,
+      rotationCert,
+    })
+    expect(d).toEqual({ action: 'rotate-pin', reason: 'identity-rotated', identityKey: newIdentity.publicKey })
+  })
+
+  it('REFUSEs when the rotation cert is signed by a non-pinned identity (forged rotation)', () => {
+    const { newIdentity, exchange, serverKeySig } = makeRotation()
+    const pinned = createSigningKeyPair()
+    const attacker = createSigningKeyPair()
+    // Attacker blesses the new identity with THEIR key, not the pinned one.
+    const forgedCert = signIdentityRotation(newIdentity.publicKey, attacker.secretKey)
+    const d = decideKeyPin({
+      pinnedIdentityKey: pinned.publicKey,
+      exchangePublicKey: exchange.publicKey,
+      serverKeySig,
+      newIdentityKey: newIdentity.publicKey,
+      rotationCert: forgedCert,
+    })
+    expect(d.action).toBe('refuse')
+    expect((d as { reason: string }).reason).toBe('signature-mismatch')
+  })
+
+  it('REFUSEs a replayed cert when the new identity did NOT sign the live exchange key', () => {
+    // Attacker captured a genuine old→new rotation cert but lacks the new secret,
+    // so they sign the exchange key with their OWN key. Liveness check fails.
+    const oldIdentity = createSigningKeyPair()
+    const newIdentity = createSigningKeyPair()
+    const attacker = createSigningKeyPair()
+    const exchange = createKeyPair()
+    const rotationCert = signIdentityRotation(newIdentity.publicKey, oldIdentity.secretKey)
+    const attackerSig = signExchangeKey(exchange.publicKey, attacker.secretKey)
+    const d = decideKeyPin({
+      pinnedIdentityKey: oldIdentity.publicKey,
+      exchangePublicKey: exchange.publicKey,
+      serverKeySig: attackerSig,
+      newIdentityKey: newIdentity.publicKey,
+      rotationCert,
+    })
+    expect(d.action).toBe('refuse')
+    expect((d as { reason: string }).reason).toBe('signature-mismatch')
+  })
+
+  it('REFUSEs when a cert is present but no new identity key is offered', () => {
+    const { oldIdentity, newIdentity, exchange, serverKeySig, rotationCert } = makeRotation()
+    void newIdentity
+    const d = decideKeyPin({
+      pinnedIdentityKey: oldIdentity.publicKey,
+      exchangePublicKey: exchange.publicKey,
+      serverKeySig,
+      newIdentityKey: null,
+      rotationCert,
+    })
+    expect(d.action).toBe('refuse')
+  })
+
+  it('still CONNECTs (no rotation) when the offered key verifies against the pin directly', () => {
+    // Rotation fields present but irrelevant: the direct pin check wins first, so
+    // a stale/irrelevant rotation cert never overrides a normal verified connect.
+    const { oldIdentity, newIdentity, rotationCert } = makeRotation()
+    const exchange = createKeyPair()
+    const directSig = signExchangeKey(exchange.publicKey, oldIdentity.secretKey)
+    const d = decideKeyPin({
+      pinnedIdentityKey: oldIdentity.publicKey,
+      exchangePublicKey: exchange.publicKey,
+      serverKeySig: directSig,
+      newIdentityKey: newIdentity.publicKey,
+      rotationCert,
+    })
+    expect(d).toEqual({ action: 'connect', reason: 'verified' })
+  })
+
+  it('REFUSEs (no rotation attempted) when the handshake is unsigned even with a cert', () => {
+    const { oldIdentity, newIdentity, rotationCert } = makeRotation()
+    const exchange = createKeyPair()
+    const d = decideKeyPin({
+      pinnedIdentityKey: oldIdentity.publicKey,
+      exchangePublicKey: exchange.publicKey,
+      serverKeySig: null,
+      newIdentityKey: newIdentity.publicKey,
+      rotationCert,
+    })
+    // No live signature → no liveness proof possible; fail closed as a downgrade.
+    expect(d).toEqual({ action: 'refuse', reason: 'pinned-but-unsigned', message: KEY_PIN_MISMATCH_MESSAGE })
+  })
+
+  it('forwards the rotation handoff through decideKeyPinWithPairingIdentity', () => {
+    const { oldIdentity, newIdentity, exchange, serverKeySig, rotationCert } = makeRotation()
+    const d = decideKeyPinWithPairingIdentity({
+      pinnedIdentityKey: oldIdentity.publicKey,
+      pairingIdentityKey: null,
+      exchangePublicKey: exchange.publicKey,
+      serverKeySig,
+      newIdentityKey: newIdentity.publicKey,
+      rotationCert,
+    })
+    expect(d).toEqual({ action: 'rotate-pin', reason: 'identity-rotated', identityKey: newIdentity.publicKey })
   })
 })

--- a/packages/store-core/src/key-pinning.ts
+++ b/packages/store-core/src/key-pinning.ts
@@ -21,7 +21,13 @@
  *     ├─ yes → server sent a signature?
  *     │         ├─ yes → verify(sig over exchangeKey, pinnedKey)
  *     │         │         ├─ ok    → CONNECT (identity confirmed)
- *     │         │         └─ fail  → REFUSE  (MITM / wrong daemon / rotated key)
+ *     │         │         └─ fail  → identity-rotation handoff? (#5616)
+ *     │         │                    ├─ valid cert (old pin signed new identity)
+ *     │         │                    │   AND new identity signed THIS exchange key
+ *     │         │                    │   → ROTATE-PIN (chain the pin forward; no
+ *     │         │                    │      forced re-pair for a legit rotation)
+ *     │         │                    └─ else → REFUSE (MITM / wrong daemon /
+ *     │         │                       rotated key with no valid continuity cert)
  *     │         └─ no  → REFUSE (pinned but unsigned — downgrade attempt: a MITM
  *     │                  cannot produce a valid sig, so it would strip the field
  *     │                  to force us back to TOFU; refusing closes that door)

--- a/packages/store-core/src/key-pinning.ts
+++ b/packages/store-core/src/key-pinning.ts
@@ -43,7 +43,7 @@
  * (the server already refuses to downgrade encryption to plaintext).
  */
 
-import { verifyExchangeKeySignature } from './crypto'
+import { verifyExchangeKeySignature, verifyIdentityRotation } from './crypto'
 
 /** What the caller should do with a handshake, given the pin state. */
 export type KeyPinDecision =
@@ -51,6 +51,14 @@ export type KeyPinDecision =
   | { action: 'connect'; reason: 'verified' | 'unpinned-no-identity' }
   /** Proceed AND store `identityKey` as the newly-pinned identity (TOFU first-use). */
   | { action: 'pin-and-connect'; reason: 'pin-on-first-use'; identityKey: string }
+  /**
+   * #5616 — the offered exchange key failed direct verification against the pin,
+   * but the server presented a valid rotation cert (old pinned identity signed
+   * the new identity) AND the new identity proved liveness by signing this
+   * handshake's exchange key. Chain the pin forward: proceed AND RE-PIN to
+   * `identityKey` (the new identity) instead of refusing + forcing a re-pair.
+   */
+  | { action: 'rotate-pin'; reason: 'identity-rotated'; identityKey: string }
   /** Abort the connection; the offered key failed verification against the pin. */
   | {
       action: 'refuse'
@@ -66,6 +74,16 @@ export interface KeyPinInput {
   exchangePublicKey: string
   /** The server's signature over `exchangePublicKey`, or null if it sent none. */
   serverKeySig: string | null
+  /**
+   * #5616 — the NEW identity public key the server rotated to, or null/absent if
+   * no rotation is being offered. Present alongside `rotationCert`.
+   */
+  newIdentityKey?: string | null
+  /**
+   * #5616 — a rotation cert: the OLD (currently-pinned) identity's signature over
+   * `newIdentityKey`. Null/absent when no rotation is offered.
+   */
+  rotationCert?: string | null
 }
 
 /**
@@ -189,11 +207,52 @@ export function decideKeyPin(input: KeyPinInput): KeyPinDecision {
   if (ok) {
     return { action: 'connect', reason: 'verified' }
   }
+  // #5616 — direct verification failed. Before refusing, try an identity-rotation
+  // handoff: a legitimately-rotated daemon (reinstall / migration / #5229) signs
+  // the new identity with the OLD one, so a pinned client can chain forward.
+  const rotated = tryRotationHandoff({ pinnedIdentityKey, exchangePublicKey, serverKeySig, input })
+  if (rotated) return rotated
   return {
     action: 'refuse',
     reason: 'signature-mismatch',
     message: KEY_PIN_MISMATCH_MESSAGE,
   }
+}
+
+/**
+ * #5616 — try to accept an identity-rotation handoff after a direct pin check
+ * failed. Returns a `rotate-pin` decision ONLY when BOTH hold:
+ *
+ *   1. The OLD (pinned) identity signed the NEW identity — a valid rotation cert.
+ *      Proves the rotation was authorised by the identity the client already
+ *      trusts (a MITM lacks the old secret, so cannot forge this).
+ *   2. The NEW identity signed THIS handshake's exchange key — liveness. Proves
+ *      the server actually holds the new secret right now; without this an
+ *      attacker who captured an old (legitimate) rotation cert but not the new
+ *      secret could replay the cert to pin THEIR key. Re-using the live
+ *      `serverKeySig` verification against the new identity closes that.
+ *
+ * Any missing input (no cert, no new identity, no live sig) → null (no rotation),
+ * and the caller refuses as before. Pure; never throws (the crypto verifiers
+ * swallow malformed input → false).
+ */
+function tryRotationHandoff(args: {
+  pinnedIdentityKey: string
+  exchangePublicKey: string
+  serverKeySig: string
+  input: KeyPinInput
+}): Extract<KeyPinDecision, { action: 'rotate-pin' }> | null {
+  const { pinnedIdentityKey, exchangePublicKey, serverKeySig, input } = args
+  const newIdentityKey = input.newIdentityKey
+  const rotationCert = input.rotationCert
+  if (!newIdentityKey || !rotationCert) return null
+  // (1) the pinned identity must have blessed the new identity.
+  if (!verifyIdentityRotation(newIdentityKey, rotationCert, pinnedIdentityKey)) return null
+  // (2) the new identity must have signed this live exchange key (liveness — no
+  // cert replay). The same exchange-key signature, now checked against the NEW
+  // identity it claims to come from.
+  if (!verifyExchangeKeySignature(exchangePublicKey, serverKeySig, newIdentityKey)) return null
+  return { action: 'rotate-pin', reason: 'identity-rotated', identityKey: newIdentityKey }
 }
 
 /**
@@ -220,9 +279,16 @@ export function decideKeyPinWithPairingIdentity(input: KeyPinInput & {
 }): KeyPinDecision {
   const { pinnedIdentityKey, pairingIdentityKey, exchangePublicKey, serverKeySig } = input
 
-  // Already pinned → the strict path.
+  // Already pinned → the strict path. Forward the #5616 rotation inputs so a
+  // pinned client can chain its pin forward through decideKeyPin.
   if (pinnedIdentityKey) {
-    return decideKeyPin({ pinnedIdentityKey, exchangePublicKey, serverKeySig })
+    return decideKeyPin({
+      pinnedIdentityKey,
+      exchangePublicKey,
+      serverKeySig,
+      newIdentityKey: input.newIdentityKey,
+      rotationCert: input.rotationCert,
+    })
   }
 
   // Not yet pinned, but we have a pairing-time identity to adopt. Verify the


### PR DESCRIPTION
## Summary
A legitimately-rotated daemon identity (reinstall, machine migration, #5229 master-key rotation) is today indistinguishable from an attacker to a pinned client — both resolve to `refuse + manually re-pair` (#5616). This lands the **verifiable cryptographic core** that lets a pinned client *chain its pin forward* instead, following the #5604 phasing model (crypto + decision first; live wiring + release-floor second).

## Phase 1 scope (this PR — store-core only, zero live-handshake risk)
**Crypto (`crypto.ts`)**
- `IDENTITY_ROTATION_DOMAIN_V1 = 'chroxy-identity-rotation-v1:'` — a *second* statement the identity key signs (after the #5604 exchange-key sig), so it is **domain-separated from the start** (no legacy bare form to ramp; #5604's own comment anticipated 'rotation statements').
- `signIdentityRotation(newIdentityPub, oldIdentitySecret)` — the OLD identity signs the NEW identity public key (the rotation cert).
- `verifyIdentityRotation(newIdentityPub, cert, oldIdentityPub)` — verifies the pinned (old) identity blessed the new one. Never throws; only the domain-separated form is accepted, so an exchange-key sig can't be replayed as a cert. `dist/crypto.js` rebuilt via `build:crypto` (ESM fixup preserved).

**Pin decision (`key-pinning.ts`)**
- New `rotate-pin` `KeyPinDecision` variant + optional `newIdentityKey`/`rotationCert` inputs. When a direct pin check fails, `tryRotationHandoff` accepts the new identity **only if BOTH** hold:
  1. the pinned identity signed the new identity (cert authorises the rotation — a MITM lacks the old secret), and
  2. the new identity signed **this handshake's** exchange key (**liveness** — closes cert-replay by an attacker who captured a cert but not the new secret).
  Forwarded through `decideKeyPinWithPairingIdentity`.

## Security properties (all unit-tested)
- MITM can't forge a cert (no old secret) → no rotation.
- Cert-replay attacker (has an old→new cert, not the new secret) → liveness check fails → refuse.
- Strip the cert / wrong identity → direct verify fails, no valid handoff → refuse (no downgrade).
- Direct pin check still wins first; an irrelevant/stale cert never overrides a normal verified connect.

## Tests
- `crypto.test.ts`: sign/verify round-trip, forged-old-identity, substituted-new-identity, **exchange-key-sig-not-accepted-as-cert** (domain separation), tampered cert, malformed-never-throws, wrong-length throws, stable+distinct label.
- `key-pinning.test.ts`: rotate-pin happy path, forged cert refuse, **replayed-cert-without-liveness refuse**, cert-without-new-identity refuse, direct-verify-wins, unsigned-with-cert refuse, forwarding through `decideKeyPinWithPairingIdentity`.
- Full store-core suite 1636 green; store-core + app tsc clean; server identity/pairing/ws-auth 116 green against the rebuilt dist.

## Not in this PR (phase 2 → 5976)
Server-side rotation-cert generation (retain prior identity), the protocol `rotationCert` field, client consume-and-re-pin wiring, and the client-release-floor decision — needs live multi-client verification.

Part of #5616