### PR TITLE
feat(app): client-side handshake timeout on mobile (#5962, #5721 parity)

### DIFF
--- a/packages/app/src/__tests__/store/connection-handshake-timeout.test.ts
+++ b/packages/app/src/__tests__/store/connection-handshake-timeout.test.ts
@@ -1,0 +1,198 @@
+/**
+ * #5962 (#5721 parity) — client-side handshake timeout (mobile app).
+ *
+ * The heartbeat does not start until `auth_ok` is processed, so the handshake
+ * window (socket OPEN + `auth`/`pair` sent, awaiting `auth_ok`/`key_exchange_ok`)
+ * had no liveness coverage. A dedicated HANDSHAKE_TIMEOUT_MS timer now fires
+ * "Handshake failed — reconnecting" and hands off to the normal reconnect ladder
+ * instead of a silent stall. These tests drive the production onopen / onmessage /
+ * onerror / disconnect paths with a fake socket + fake timers (mirrors the
+ * harness in connection-reconnect-backoff.test.ts; the dashboard analogue is
+ * connection-handshake-timeout.test.ts).
+ */
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve('dev-id-123')),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { resetReconnectAttempt, HANDSHAKE_TIMEOUT_MS } from '../../store/message-handler';
+import { clearAllCallbacks } from '../../store/imperative-callbacks';
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) =>
+    jest.requireActual<typeof globalThis>('timers').setImmediate(resolve),
+  );
+}
+
+function mockResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  } as unknown as Response;
+}
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: ((event?: unknown) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onmessage: ((event: unknown) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+function installMockWebSocket(): { instances: FakeSocket[]; restore: () => void } {
+  const instances: FakeSocket[] = [];
+  const Original = global.WebSocket;
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 0;
+    onopen: (() => void) | null = null;
+    onclose: ((event?: unknown) => void) | null = null;
+    onerror: ((event?: unknown) => void) | null = null;
+    onmessage: ((event: unknown) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn(function (this: FakeSocket) { this.readyState = 3; });
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this as unknown as FakeSocket);
+    }
+  };
+  return { instances, restore: () => { global.WebSocket = Original; } };
+}
+
+const originalFetch = global.fetch;
+let randomSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  clearAllCallbacks();
+  __resetDeviceIdCacheForTests();
+  resetReconnectAttempt();
+  randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0); // pin jitter to identity
+  (SecureStore.getItemAsync as jest.Mock).mockReset();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('dev-id-123');
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+  global.fetch = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' })) as unknown as typeof fetch;
+  useConnectionStore.setState({ socket: null, sessionStates: {}, activeSessionId: null });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+  });
+});
+
+afterEach(() => {
+  // Make sure no timer (handshake or reconnect-ladder) survives into the next
+  // test — module-level timers persist across tests in the same file.
+  useConnectionStore.getState().disconnect();
+  randomSpy.mockRestore();
+  global.fetch = originalFetch;
+  jest.useRealTimers();
+});
+
+/** Connect, walk through the health check + WS construction, and fire onopen. */
+async function openConnected(ws: { instances: FakeSocket[] }): Promise<FakeSocket> {
+  const before = ws.instances.length;
+  useConnectionStore.getState().connect('wss://tunnel.example.com/ws', 'tok', { silent: true });
+  await flushPromises();
+  const socket = ws.instances[before]!;
+  socket.readyState = 1;
+  socket.onopen?.();
+  await flushPromises(); // onopen awaits getDeviceId().then(...) → send + arm
+  return socket;
+}
+
+describe('#5962 client-side handshake timeout (mobile app)', () => {
+  it('fires after HANDSHAKE_TIMEOUT_MS when no auth_ok arrives, then reconnects', async () => {
+    const ws = installMockWebSocket();
+    const socket = await openConnected(ws);
+    // The auth handshake frame went out…
+    expect(socket.send.mock.calls.some(([d]) => String(d).includes('"type":"auth"'))).toBe(true);
+    expect(socket.close).not.toHaveBeenCalled();
+
+    // …but no auth_ok / key_exchange_ok ever completes it.
+    jest.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS);
+    await flushPromises();
+
+    // The wedged socket is dropped and the UX shows the reconnecting state.
+    expect(socket.close).toHaveBeenCalled();
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('reconnecting');
+    expect(useConnectionLifecycleStore.getState().connectionError ?? '').toMatch(/Handshake failed/i);
+
+    // It hands off to the normal reconnect ladder — a fresh socket is built.
+    const before = ws.instances.length;
+    jest.advanceTimersByTime(2_000); // past the (jitter-pinned) first rung
+    await flushPromises();
+    expect(ws.instances.length).toBeGreaterThan(before);
+
+    ws.restore();
+  });
+
+  it('clears the timer on auth_ok — no spurious fire on a healthy connect', async () => {
+    const ws = installMockWebSocket();
+    const socket = await openConnected(ws);
+    const socketsBefore = ws.instances.length;
+
+    // Drive a real auth_ok through the production onmessage path.
+    socket.onmessage?.({ data: JSON.stringify({ type: 'auth_ok', serverMode: 'cli' }) });
+    await flushPromises();
+
+    // Past the handshake budget — the timer was cleared, so it must NOT fire:
+    // the socket stays open, no reconnect socket is built, and the
+    // handshake-timeout error never appears. (Stop short of the 15s+5s heartbeat
+    // reaper that auth_ok started, which would close the socket for another reason.)
+    jest.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS + 2_000);
+    await flushPromises();
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(ws.instances.length).toBe(socketsBefore); // no reconnect socket
+    expect(useConnectionLifecycleStore.getState().connectionError ?? '').not.toMatch(/Handshake failed/i);
+
+    ws.restore();
+  });
+
+  it('does not fire after a user-initiated disconnect', async () => {
+    const ws = installMockWebSocket();
+    await openConnected(ws);
+    const socketsBefore = ws.instances.length;
+
+    useConnectionStore.getState().disconnect();
+    jest.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS * 2);
+    await flushPromises();
+
+    // disconnect() cleared the timer; it must not reconnect.
+    expect(ws.instances.length).toBe(socketsBefore);
+    expect(useConnectionLifecycleStore.getState().connectionPhase).not.toBe('reconnecting');
+
+    ws.restore();
+  });
+
+  it('does not schedule a second reconnect when the socket already errored', async () => {
+    const ws = installMockWebSocket();
+    const socket = await openConnected(ws);
+
+    // A transport error schedules a reconnect AND clears the handshake timer
+    // (onerror's teardown clear), so the timeout window is now a no-op.
+    socket.onerror?.({});
+    await flushPromises();
+
+    // Advancing past the handshake budget adds nothing extra (the timer was
+    // cleared; and even if it weren't, scheduleReconnect's per-socket dedupe
+    // would suppress a second reconnect). Exactly one reconnect socket appears.
+    jest.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS);
+    jest.advanceTimersByTime(2_000); // let the single scheduled rung fire
+    await flushPromises();
+    expect(ws.instances.length).toBe(2); // original + exactly one reconnect
+
+    ws.restore();
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -115,6 +115,8 @@ import {
   clearTerminalWriteBatching,
   appendPendingTerminalWrite,
   stopHeartbeat,
+  armHandshakeTimer,
+  clearHandshakeTimer,
   clearDeltaBuffers,
   clearMessageQueue,
   enqueueMessage,
@@ -1101,6 +1103,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Reset encryption state for each new connection (forward secrecy)
     setEncryptionState(null);
     setPendingKeyPair(null);
+    // #5962 (#5721 parity) — clear any leftover handshake timer from a prior
+    // attempt before opening a new socket, so a stale timer can't fire against
+    // this fresh attempt.
+    clearHandshakeTimer();
     const socket = new WebSocket(url);
 
     // #3624 (ported from dashboard) — per-socket reconnect scheduler for both
@@ -1183,6 +1189,38 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
               ...(Object.keys(historyCursors).length > 0 ? { historyCursors } : {}),
             }));
           }
+          // #5962 (#5721 parity) — a handshake frame (auth/pair) went out; arm the
+          // handshake timer. If auth_ok / key_exchange_ok never completes within
+          // HANDSHAKE_TIMEOUT_MS, drop this half-open socket and hand off to the
+          // SAME reconnect ladder a transport drop uses, surfacing "Handshake
+          // failed — reconnecting" instead of a silent stall. The success clears
+          // live in the auth_ok / key_exchange_ok handlers; teardown clears live in
+          // onclose/onerror/disconnect and at the top of the next connect.
+          armHandshakeTimer(() => {
+            // Superseded by a newer attempt — ignore (mirrors the onclose/onerror
+            // stale guard). The current attempt's timer is the only live one.
+            if (myAttemptId !== connectionAttemptId) return;
+            // User disconnected this attempt — don't auto-reconnect.
+            if (disconnectedAttemptId === myAttemptId) return;
+            // Null ALL handlers before closing: onclose/onerror so this manual
+            // close doesn't double-dispatch (scheduleReconnect owns recovery), AND
+            // onmessage so a late auth_ok / key_exchange_ok already in flight on
+            // this wedged socket can't mutate store state after we've declared the
+            // handshake failed.
+            socket.onclose = null;
+            socket.onerror = null;
+            socket.onmessage = null;
+            try { socket.close(); } catch { /* already closing */ }
+            set({ socket: null });
+            // Mirror the onerror first-write-wins guard so a paired drop can't
+            // double-write the phase/error; then hand off to the ladder.
+            if (!reconnectScheduler.scheduled) {
+              console.log('[ws] Handshake timed out, reconnecting...');
+              useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
+              useConnectionLifecycleStore.getState().setConnectionError('Handshake failed — reconnecting', 0);
+            }
+            scheduleReconnect();
+          });
         }
       });
     };
@@ -1237,6 +1275,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // Stale socket from a previous connection attempt — ignore
       if (myAttemptId !== connectionAttemptId) return;
+
+      // #5962 (#5721 parity) — this attempt's socket closed; no handshake left to
+      // time. Clear AFTER the stale guard so a late stale-socket close can't
+      // cancel the CURRENT attempt's timer. Idempotent if already cleared.
+      clearHandshakeTimer();
 
       const wasConnected = useConnectionLifecycleStore.getState().connectionPhase === 'connected';
       set({ socket: null });
@@ -1295,6 +1338,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // Stale socket from a previous connection attempt — ignore
       if (myAttemptId !== connectionAttemptId) return;
 
+      // #5962 (#5721 parity) — clear the handshake timer after the stale guard
+      // (this attempt errored; the reconnect ladder takes over).
+      clearHandshakeTimer();
+
       set({ socket: null });
 
       // UX landmine #8: extract whatever detail we can from the error
@@ -1331,6 +1378,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Clear saved connection so ConnectScreen doesn't auto-reconnect
     setLastConnectedUrl(null);
     stopHeartbeat();
+    // #5962 (#5721 parity) — user-initiated disconnect nulls socket.onclose
+    // below, so the onclose handshake-timer clear never runs; clear it here.
+    clearHandshakeTimer();
     const { socket } = get();
     if (socket) {
       socket.onclose = null;

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1196,6 +1196,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           // failed — reconnecting" instead of a silent stall. The success clears
           // live in the auth_ok / key_exchange_ok handlers; teardown clears live in
           // onclose/onerror/disconnect and at the top of the next connect.
+          //
+          // The timer is a SINGLE global (message-handler `_ctx`), so guard the
+          // ARM (not just the fire callback) against a stale/superseded attempt: a
+          // late onopen on an old socket must not clear+re-arm the CURRENT
+          // attempt's timer and strip its liveness coverage. (onopen also `await`s
+          // getDeviceId, widening the window for a late delivery.)
+          if (myAttemptId !== connectionAttemptId || disconnectedAttemptId === myAttemptId) return;
           armHandshakeTimer(() => {
             // Superseded by a newer attempt — ignore (mirrors the onclose/onerror
             // stale guard). The current attempt's timer is the only live one.

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -268,6 +268,10 @@ interface MessageHandlerContext extends EncryptionContext {
   heartbeatInterval: ReturnType<typeof setInterval> | null;
   pongTimeout: ReturnType<typeof setTimeout> | null;
   lastPingSentAt: number;
+  // #5962 (#5721 parity) — client-side handshake timeout. The heartbeat does NOT
+  // start until auth_ok, so the handshake window has no liveness coverage; this
+  // timer drops a wedged half-open socket and hands off to the reconnect ladder.
+  handshakeTimeout: ReturnType<typeof setTimeout> | null;
   // #5556: EWMA-smoothed RTT (replaces the inlined `ewmaRtt` accumulator).
   rttSmoother: RttSmoother;
 
@@ -311,6 +315,7 @@ function createDefaultContext(): MessageHandlerContext {
     heartbeatInterval: null,
     pongTimeout: null,
     lastPingSentAt: 0,
+    handshakeTimeout: null,
     rttSmoother,
     // #5556: the flusher owns the accumulator + coalescing timer + adaptive
     // window, sizing it off this context's own RttSmoother. `applyDeltas` is
@@ -341,6 +346,7 @@ export function resetAllHandlerState(): void {
   if (_ctx.terminalWriteTimer) clearTimeout(_ctx.terminalWriteTimer);
   if (_ctx.heartbeatInterval) clearInterval(_ctx.heartbeatInterval);
   if (_ctx.pongTimeout) clearTimeout(_ctx.pongTimeout);
+  if (_ctx.handshakeTimeout) clearTimeout(_ctx.handshakeTimeout);
   _ctx.deltaFlusher.dispose();
   _ctx = createDefaultContext();
   _pendingPermissionModeRequests.clear();
@@ -762,6 +768,32 @@ export function startHeartbeat(socket: WebSocket): void {
       try { socket.close(); } catch {}
     }, PONG_TIMEOUT_MS);
   }, HEARTBEAT_INTERVAL_MS);
+}
+
+// #5962 (#5721 parity) — client-side handshake timeout. Mirrors the dashboard
+// (packages/dashboard/src/store/message-handler.ts). The heartbeat above does
+// NOT start until auth_ok is processed, so the handshake window (socket OPEN +
+// auth/pair sent, awaiting auth_ok/key_exchange_ok) has zero liveness coverage:
+// a server that opens the socket but never completes the handshake leaves the
+// client wedged until the transport drops on its own. A ~10s timer — comfortably
+// below the ~20s worst-case heartbeat detection once connected — hands off to the
+// normal reconnect ladder ("Handshake failed — reconnecting") instead of a
+// silent stall. Exported so connection.ts arms/clears it around the socket
+// lifecycle and tests can read the budget.
+export const HANDSHAKE_TIMEOUT_MS = 10_000;
+
+// Arm the handshake timer with the caller's fire behaviour. The fire callback is
+// injected (not built here) because the reconnect machinery it needs lives in
+// connection.ts's per-socket closure. Clears any prior timer first
+// (single-instance, mirroring startHeartbeat) so a reconnect that re-enters
+// onopen can never leak a second pending timer.
+export function armHandshakeTimer(onTimeout: () => void): void {
+  clearHandshakeTimer();
+  _ctx.handshakeTimeout = setTimeout(onTimeout, HANDSHAKE_TIMEOUT_MS);
+}
+
+export function clearHandshakeTimer(): void {
+  if (_ctx.handshakeTimeout) { clearTimeout(_ctx.handshakeTimeout); _ctx.handshakeTimeout = null; }
 }
 
 function _onPong(serverTs?: number): void {
@@ -1574,6 +1606,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       return;
 
     case 'auth_ok': {
+      // #5962 (#5721 parity) — auth_ok is the authoritative handshake-complete
+      // signal; clear the handshake timer so a completed handshake can't fire it.
+      // Eager-encryption and no-encryption connects never send key_exchange, so
+      // this is the single authoritative clear (key_exchange_ok clears defensively).
+      clearHandshakeTimer();
       // Reset replay flags — fresh auth means clean slate (#4512: clear the
       // per-session replaying set so a reconnect doesn't leave stale ids
       // gating future activity bumps).
@@ -1790,6 +1827,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'key_exchange_ok': {
+      // #5962 (#5721 parity) — defensive: auth_ok already cleared the handshake
+      // timer (it precedes the discrete key-exchange round-trip), but clear again
+      // so a future reordering that makes the encryption sub-handshake the real
+      // completion point can't leave a timer to fire spuriously. Idempotent.
+      clearHandshakeTimer();
       if (_ctx.pendingKeyPair) {
         const { publicKey: serverPublicKey, serverKeySig } = sharedKeyExchangeOk(msg);
         if (!serverPublicKey) {


### PR DESCRIPTION
## Summary
Mirrors the dashboard's client-side handshake timeout (#5721 item 2 / #5963) onto the mobile app. The app's heartbeat does not start until `auth_ok`, so the handshake window (socket OPEN + `auth`/`pair` sent, awaiting `auth_ok`/`key_exchange_ok`) had **no liveness coverage**: a server that opens the socket but never completes the handshake left the client wedged until the transport dropped on its own. A dedicated ~10s timer now drops the half-open socket and hands off to the existing reconnect ladder ("Handshake failed — reconnecting") instead of a silent stall.

## Changes
**`message-handler.ts`**
- `HANDSHAKE_TIMEOUT_MS = 10_000` + `armHandshakeTimer`/`clearHandshakeTimer` on the `_ctx` timer state (next to the heartbeat helpers), cleared in `resetAllHandlerState`.
- Authoritative clear in the `auth_ok` handler; defensive clear in `key_exchange_ok`.

**`connection.ts`**
- Arm in `socket.onopen` after the auth/pair send. On fire (guarded by the same stale-attempt + user-disconnect checks the onclose/onerror paths use): null `onclose`/`onerror`/`onmessage`, close the socket, surface the reconnecting phase/error (first-write-wins via `reconnectScheduler.scheduled`), and `scheduleReconnect()`.
- Teardown clears: connect-entry (before opening the new socket), `onclose` (after the stale guard, so a late stale-socket close can't cancel the current attempt's timer), `onerror`, and user-initiated `disconnect()` (which nulls `onclose`, so the timer is cleared directly).

## Tests
New `connection-handshake-timeout.test.ts` (4 tests, mirroring the dashboard suite, driving the real onopen/onmessage/onerror/disconnect paths with a fake socket + fake timers):
- fires after `HANDSHAKE_TIMEOUT_MS` with no `auth_ok` → drops socket → reconnecting + error → reconnect socket built
- clears on `auth_ok` (no spurious fire on a healthy connect)
- no fire after a user-initiated disconnect
- no double reconnect when the socket already errored

Full app store suite (601) green + app `tsc` clean.

Closes #5962