### PR TITLE
feat(app): wire the server_down terminal reconnect state on mobile (#5725)

### DIFF
--- a/packages/app/src/__tests__/screens/SessionScreenServerDownBanner.test.ts
+++ b/packages/app/src/__tests__/screens/SessionScreenServerDownBanner.test.ts
@@ -1,0 +1,49 @@
+/**
+ * #5725 (#5698) — SessionScreen terminal `server_down` banner.
+ *
+ * When the reconnect ladder gives up, the app enters the terminal `server_down`
+ * phase. The banner must render distinctly from the live `reconnecting` spinner:
+ * "Server appears to be down", NO indefinite spinner, and a Reconnect button
+ * (wired to `retryConnection`, which resets the ladder + re-dials) instead of the
+ * Disconnect affordance.
+ *
+ * No `@testing-library/react-native` in this repo (see SessionScreenStoppedBanner
+ * .test.ts), so this verifies the wire-up via source-text parsing; the runtime
+ * behaviour (onGaveUp → server_down; retryConnection resets + re-dials) is
+ * exercised against the real store in __tests__/store/connection-server-down.test.ts.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SessionScreenSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SessionScreen.tsx'),
+  'utf-8',
+);
+
+describe('SessionScreen server_down banner (#5725)', () => {
+  it('selects retryConnection from the store', () => {
+    expect(SessionScreenSrc).toMatch(/const retryConnection = useConnectionStore\(\(s\) => s\.retryConnection\)/);
+  });
+
+  it('renders the reconnect banner for server_down (alongside reconnecting / server_restarting)', () => {
+    expect(SessionScreenSrc).toMatch(
+      /connectionPhase === 'reconnecting' \|\| connectionPhase === 'server_restarting' \|\| connectionPhase === 'server_down'/,
+    );
+  });
+
+  it('suppresses the indefinite spinner in the terminal server_down state', () => {
+    // The spinner is gated behind a non-server_down guard so the terminal banner
+    // does not show a forever-spinning ActivityIndicator.
+    expect(SessionScreenSrc).toMatch(/connectionPhase !== 'server_down' && \(\s*<RNActivityIndicator/);
+  });
+
+  it("shows the 'Server appears to be down' copy for server_down", () => {
+    expect(SessionScreenSrc).toMatch(/connectionPhase === 'server_down'\s*\?\s*'Server appears to be down'/);
+  });
+
+  it('offers a Reconnect button wired to retryConnection (not Disconnect) when server_down', () => {
+    expect(SessionScreenSrc).toMatch(/testID="server-down-reconnect"/);
+    expect(SessionScreenSrc).toMatch(/onPress=\{retryConnection\}/);
+    expect(SessionScreenSrc).toMatch(/<Text style=\{styles\.reconnectDisconnectText\}>Reconnect<\/Text>/);
+  });
+});

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -162,6 +162,40 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     ws.restore();
   });
 
+  it('keeps server_down sticky against the paired onerror/onclose of the same drop', async () => {
+    // Regression: RN fires error → close (or close → error) for ONE transport
+    // drop. The give-up sets server_down on the first event; the paired second
+    // event must NOT clobber it back to reconnecting/disconnected (transitionPhase
+    // only warns on the illegal transition — it still applies it).
+    const ws = installMockWebSocket();
+    await openConnectedSocket(ws);
+    const socket = ws.instances[ws.instances.length - 1];
+    // Simulate the ladder having given up (terminal phase set by onGaveUp).
+    useConnectionLifecycleStore.setState({
+      connectionPhase: 'server_down',
+      connectionError: 'Server appears to be down',
+    });
+
+    // error → close
+    socket.onerror?.({});
+    socket.onclose?.({ code: 1006 });
+    await flushPromises();
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+
+    // and the reverse close → error ordering on the same terminal state
+    socket.onclose?.({ code: 1006 });
+    socket.onerror?.({});
+    await flushPromises();
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+
+    // No spurious reconnect socket was built either.
+    jest.advanceTimersByTime(60_000);
+    await flushPromises();
+    expect(ws.instances.length).toBe(1);
+
+    ws.restore();
+  });
+
   it('retryConnection no-ops without a saved connection', async () => {
     const ws = installMockWebSocket();
     useConnectionLifecycleStore.setState({ connectionPhase: 'server_down', savedConnection: null });

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -16,7 +16,7 @@ jest.mock('expo-secure-store', () => ({
 import * as SecureStore from 'expo-secure-store';
 import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
 import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
-import { resetReconnectAttempt, reconnectAttempt } from '../../store/message-handler';
+import { resetReconnectAttempt, reconnectAttempt, nextReconnectAttempt } from '../../store/message-handler';
 import { clearAllCallbacks } from '../../store/imperative-callbacks';
 
 function flushPromises(): Promise<void> {
@@ -145,8 +145,14 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
       connectionError: 'Server appears to be down',
       savedConnection: { url: 'wss://tunnel.example.com', token: 'tok' },
     });
-    // Climb the ladder so we can prove retryConnection rewinds it.
+    // ACTUALLY climb the ladder first so the reset assertion is load-bearing —
+    // otherwise reconnectAttempt is already 0 and the test would pass even if
+    // retryConnection stopped resetting it.
     resetReconnectAttempt();
+    nextReconnectAttempt();
+    nextReconnectAttempt();
+    nextReconnectAttempt();
+    expect(reconnectAttempt).toBeGreaterThan(0);
     const before = ws.instances.length;
 
     useConnectionStore.getState().retryConnection();
@@ -154,7 +160,7 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     jest.advanceTimersByTime(0);
     await flushPromises();
 
-    // The ladder was reset to the bottom rung…
+    // The ladder was rewound to the bottom rung…
     expect(reconnectAttempt).toBe(0);
     // …and a fresh dial was attempted (connectAuto → connect → WebSocket).
     expect(ws.instances.length).toBeGreaterThan(before);

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #5725 (#5698) — terminal `server_down` reconnect state on mobile.
+ *
+ * PR #5724 capped the reconnect ladder + added the `server_down` ConnectionPhase
+ * on the DASHBOARD. The app previously passed no `maxRung`/`onGaveUp` to
+ * `createReconnectScheduler`, so it reconnect-looped forever. This wires the cap
+ * (→ `server_down` via `onGaveUp`) plus a `retryConnection` action that resets
+ * the ladder and re-dials. Mirrors the fake-WebSocket / fake-timer harness in
+ * connection-reconnect-backoff.test.ts.
+ */
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve('dev-id-123')),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { useConnectionStore, __resetDeviceIdCacheForTests } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { resetReconnectAttempt, reconnectAttempt } from '../../store/message-handler';
+import { clearAllCallbacks } from '../../store/imperative-callbacks';
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) =>
+    jest.requireActual<typeof globalThis>('timers').setImmediate(resolve),
+  );
+}
+
+function mockResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body ?? {}),
+    text: () => Promise.resolve(JSON.stringify(body ?? {})),
+  } as unknown as Response;
+}
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onclose: ((event?: unknown) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onmessage: ((event: unknown) => void) | null;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+function installMockWebSocket(): { instances: FakeSocket[]; restore: () => void } {
+  const instances: FakeSocket[] = [];
+  const Original = global.WebSocket;
+  // @ts-expect-error — mock WebSocket constructor
+  global.WebSocket = class MockWebSocket {
+    static OPEN = 1;
+    url: string;
+    readyState = 0;
+    onopen: (() => void) | null = null;
+    onclose: ((event?: unknown) => void) | null = null;
+    onerror: ((event?: unknown) => void) | null = null;
+    onmessage: ((event: unknown) => void) | null = null;
+    send = jest.fn();
+    close = jest.fn();
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this as unknown as FakeSocket);
+    }
+  };
+  return { instances, restore: () => { global.WebSocket = Original; } };
+}
+
+const originalFetch = global.fetch;
+let randomSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  clearAllCallbacks();
+  __resetDeviceIdCacheForTests();
+  resetReconnectAttempt();
+  randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0); // pin jitter to identity
+  (SecureStore.getItemAsync as jest.Mock).mockReset();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('dev-id-123');
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+  global.fetch = jest.fn().mockResolvedValue(mockResponse(200, { status: 'ok' })) as unknown as typeof fetch;
+  useConnectionStore.setState({ socket: null, sessionStates: {}, activeSessionId: null });
+  useConnectionLifecycleStore.setState({
+    connectionPhase: 'disconnected',
+    connectionError: null,
+    connectionRetryCount: 0,
+    wsUrl: null,
+    userDisconnected: false,
+    savedConnection: null,
+  });
+});
+
+afterEach(() => {
+  useConnectionStore.getState().disconnect();
+  randomSpy.mockRestore();
+  global.fetch = originalFetch;
+  jest.useRealTimers();
+});
+
+async function openConnectedSocket(ws: { instances: FakeSocket[] }) {
+  useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+  await flushPromises();
+  useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+}
+
+describe('#5725 terminal server_down after the reconnect ladder is exhausted', () => {
+  it('transitions to server_down once the ladder hits RECONNECT_MAX_RUNG (no infinite loop)', async () => {
+    const ws = installMockWebSocket();
+    await openConnectedSocket(ws);
+
+    // Drive consecutive drops. Each onclose schedules the next rung; advancing
+    // the (jitter-pinned) max delay fires it → connect() → fetch → new socket.
+    // After RECONNECT_MAX_RUNG rungs the scheduler gives up and onGaveUp sets
+    // the terminal phase instead of arming another retry.
+    for (let i = 0; i < 15; i++) {
+      if (useConnectionLifecycleStore.getState().connectionPhase === 'server_down') break;
+      const socket = ws.instances[ws.instances.length - 1];
+      socket.onclose?.({ code: 1006 });
+      jest.advanceTimersByTime(8000); // top rung is 8000ms (jitter 0)
+      await flushPromises();
+      // Mark a freshly-built socket connected so the next drop keeps climbing.
+      if (useConnectionLifecycleStore.getState().connectionPhase !== 'server_down') {
+        useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+      }
+    }
+
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+    expect(useConnectionLifecycleStore.getState().connectionError ?? '').toMatch(/Server appears to be down/i);
+
+    // Terminal: no further socket is built on its own.
+    const settled = ws.instances.length;
+    jest.advanceTimersByTime(60_000);
+    await flushPromises();
+    expect(ws.instances.length).toBe(settled);
+
+    ws.restore();
+  });
+
+  it('retryConnection resets the ladder and re-dials from server_down', async () => {
+    const ws = installMockWebSocket();
+    // Arrive in the terminal state with a maxed ladder + a saved connection.
+    useConnectionLifecycleStore.setState({
+      connectionPhase: 'server_down',
+      connectionError: 'Server appears to be down',
+      savedConnection: { url: 'wss://tunnel.example.com', token: 'tok' },
+    });
+    // Climb the ladder so we can prove retryConnection rewinds it.
+    resetReconnectAttempt();
+    const before = ws.instances.length;
+
+    useConnectionStore.getState().retryConnection();
+    await flushPromises();
+    jest.advanceTimersByTime(0);
+    await flushPromises();
+
+    // The ladder was reset to the bottom rung…
+    expect(reconnectAttempt).toBe(0);
+    // …and a fresh dial was attempted (connectAuto → connect → WebSocket).
+    expect(ws.instances.length).toBeGreaterThan(before);
+
+    ws.restore();
+  });
+
+  it('retryConnection no-ops without a saved connection', async () => {
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.setState({ connectionPhase: 'server_down', savedConnection: null });
+    const before = ws.instances.length;
+
+    useConnectionStore.getState().retryConnection();
+    await flushPromises();
+
+    expect(ws.instances.length).toBe(before); // nothing to dial
+    ws.restore();
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -223,6 +223,8 @@ export function SessionScreen() {
   const sendInput = useConnectionStore((s) => s.sendInput);
   const sendInterrupt = useConnectionStore((s) => s.sendInterrupt);
   const disconnect = useConnectionStore((s) => s.disconnect);
+  // #5725 (#5698) — manual retry from the terminal `server_down` banner.
+  const retryConnection = useConnectionStore((s) => s.retryConnection);
   const clearTerminalBuffer = useConnectionStore((s) => s.clearTerminalBuffer);
   const addUserMessage = useConnectionStore((s) => s.addUserMessage);
   const updateInputSettings = useConnectionStore((s) => s.updateInputSettings);
@@ -1197,29 +1199,42 @@ export function SessionScreen() {
       )}
 
       {/* Reconnecting / restarting banner */}
-      {(connectionPhase === 'reconnecting' || connectionPhase === 'server_restarting') && (
+      {(connectionPhase === 'reconnecting' || connectionPhase === 'server_restarting' || connectionPhase === 'server_down') && (
         <View testID="reconnect-banner" style={styles.reconnectingBanner}>
           <View style={styles.reconnectingRow}>
-            <RNActivityIndicator
-              testID="reconnect-spinner"
-              size="small"
-              color={COLORS.accentBlue}
-              style={styles.reconnectingSpinner}
-            />
+            {/* #5725 (#5698) — server_down is terminal: no indefinite spinner. */}
+            {connectionPhase !== 'server_down' && (
+              <RNActivityIndicator
+                testID="reconnect-spinner"
+                size="small"
+                color={COLORS.accentBlue}
+                style={styles.reconnectingSpinner}
+              />
+            )}
             <Text style={[styles.reconnectingText, { flex: 1 }]}>
-              {connectionPhase === 'server_restarting'
-                ? shutdownReason === 'shutdown'
-                  ? 'Server shut down'
-                  : restartCountdown != null && restartCountdown > 0
-                    ? `Server restarting... ~${Math.floor(restartCountdown / 60)}:${String(restartCountdown % 60).padStart(2, '0')}`
-                    : 'Server restarting...'
-                : connectionRetryCount > 0
-                  ? `Reconnecting (attempt ${connectionRetryCount + 1})...`
-                  : 'Reconnecting...'}
+              {connectionPhase === 'server_down'
+                ? 'Server appears to be down'
+                : connectionPhase === 'server_restarting'
+                  ? shutdownReason === 'shutdown'
+                    ? 'Server shut down'
+                    : restartCountdown != null && restartCountdown > 0
+                      ? `Server restarting... ~${Math.floor(restartCountdown / 60)}:${String(restartCountdown % 60).padStart(2, '0')}`
+                      : 'Server restarting...'
+                  : connectionRetryCount > 0
+                    ? `Reconnecting (attempt ${connectionRetryCount + 1})...`
+                    : 'Reconnecting...'}
             </Text>
-            <TouchableOpacity onPress={disconnect} style={styles.reconnectDisconnect} accessibilityRole="button" accessibilityLabel="Stop reconnecting">
-              <Text style={styles.reconnectDisconnectText}>Disconnect</Text>
-            </TouchableOpacity>
+            {/* #5725 (#5698) — server_down offers a manual Reconnect (resets the
+                ladder + re-dials); the live states keep the Disconnect affordance. */}
+            {connectionPhase === 'server_down' ? (
+              <TouchableOpacity testID="server-down-reconnect" onPress={retryConnection} style={styles.reconnectDisconnect} accessibilityRole="button" accessibilityLabel="Reconnect">
+                <Text style={styles.reconnectDisconnectText}>Reconnect</Text>
+              </TouchableOpacity>
+            ) : (
+              <TouchableOpacity onPress={disconnect} style={styles.reconnectDisconnect} accessibilityRole="button" accessibilityLabel="Stop reconnecting">
+                <Text style={styles.reconnectDisconnectText}>Disconnect</Text>
+              </TouchableOpacity>
+            )}
           </View>
           {connectionPhase === 'server_restarting' && shutdownReason === 'restart' && (
             <Text style={styles.reconnectingDetail}>Graceful restart</Text>

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1329,6 +1329,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // "Observing"/driver badge doesn't survive the reconnect gap.
       clearSessionRolesAcrossSessions(set, get);
 
+      // #5725 (#5698) — terminal: the reconnect ladder already gave up
+      // (server_down). The PAIRED event of this same transport drop (RN fires
+      // error → close, or close → error) must NOT clobber server_down back to
+      // reconnecting/disconnected — transitionPhase only WARNS on the illegal
+      // transition, it still applies it, which would revert the terminal banner
+      // to the infinite spinner this state exists to kill. Keep it sticky.
+      if (useConnectionLifecycleStore.getState().connectionPhase === 'server_down') {
+        return;
+      }
       // Auto-reconnect if the connection dropped unexpectedly (not user-initiated)
       if (wasConnected && disconnectedAttemptId !== myAttemptId) {
         const closeMsg = getWsCloseMessage(event.code);
@@ -1375,6 +1384,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         ? `Connection error: ${detail}`
         : 'Connection error — server may be unreachable';
 
+      // #5725 (#5698) — terminal server_down is sticky against the paired event
+      // of this drop (mirrors the onclose guard above): once the ladder gave up,
+      // a close→error (or error after a give-up) must not clobber it back.
+      if (useConnectionLifecycleStore.getState().connectionPhase === 'server_down') {
+        return;
+      }
       // Auto-reconnect on unexpected WS error
       if (disconnectedAttemptId !== myAttemptId) {
         // #3624 — if onclose already armed the retry for this same transport

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -117,6 +117,7 @@ import {
   stopHeartbeat,
   armHandshakeTimer,
   clearHandshakeTimer,
+  resetReconnectAttempt,
   clearDeltaBuffers,
   clearMessageQueue,
   enqueueMessage,
@@ -162,6 +163,9 @@ import {
   // #5621 — the shared retry-ladder defaults (was duplicated verbatim here).
   CONNECT_MAX_RETRIES,
   CONNECT_RETRY_DELAYS,
+  // #5725 (#5698) — cap the reconnect ladder so it goes terminal (server_down)
+  // instead of spinning forever.
+  RECONNECT_MAX_RUNG,
   // #5537 — shared LAN→tunnel fast-fallback decision for the reconnect ladder.
   selectReconnectEndpoint,
   type ProbeResult,
@@ -1143,6 +1147,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       reconnect: () => get().connect(resolveCurrentEndpointUrl(url, token), token),
       isStale: () => myAttemptId !== connectionAttemptId,
       retryDelays: CONNECT_RETRY_DELAYS,
+      // #5725 (#5698) — stop the reconnect ladder after RECONNECT_MAX_RUNG rungs
+      // and go terminal (server_down) instead of looping forever. A user-initiated
+      // retryConnection() (or an app resume / network-change recovery) resets the
+      // counter, so this is not permanent. Mirrors the dashboard (#5724).
+      maxRung: RECONNECT_MAX_RUNG,
+      onGaveUp: () => {
+        // Superseded by a newer attempt — don't clobber it.
+        if (myAttemptId !== connectionAttemptId) return;
+        console.log('[ws] reconnect ladder exhausted — server appears down');
+        useConnectionLifecycleStore.getState().setConnectionPhase('server_down');
+        useConnectionLifecycleStore.getState().setConnectionError('Server appears to be down', 0);
+      },
     });
     const scheduleReconnect = (): void => { reconnectScheduler.schedule(); };
 
@@ -1474,6 +1490,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // means "close the session for now" — the saved server should
     // persist so ConnectScreen shows "Reconnect". Only forgetSession()
     // (called from "Forget Server" in the alert and Settings) clears it.
+  },
+
+  // #5725 (#5698) — user-initiated retry from the terminal `server_down` state
+  // (the Reconnect button, app resume, and network-change recovery all route
+  // here). Reset the backoff ladder FIRST so the fresh attempt starts at rung 0;
+  // otherwise it would immediately re-exhaust the still-maxed counter and give
+  // up again on the first failure. Then reconnect to the saved connection
+  // (connectAuto re-resolves the freshest LAN/tunnel endpoint). Mirrors the
+  // dashboard's retryConnection (#5724).
+  retryConnection: () => {
+    resetReconnectAttempt();
+    const saved = useConnectionLifecycleStore.getState().savedConnection;
+    if (saved?.url && saved?.token) {
+      void get().connectAuto(saved, { silent: true });
+    }
   },
 
   forgetSession: () => {
@@ -2270,6 +2301,18 @@ export const _appStateSub = AppState.addEventListener('change', (nextState) => {
 
     const { connectionPhase, wsUrl, apiToken, userDisconnected, savedConnection } = useConnectionLifecycleStore.getState();
 
+    // #5725 (#5698) — the reconnect ladder gave up (terminal `server_down`)
+    // while the app was backgrounded; the server is very likely fine now, so a
+    // resume is the natural moment to retry (mirrors the dashboard tab-wake
+    // recovery, but mobile auto-clears where the laptop stays manual). Reset the
+    // ladder + reconnect via retryConnection; skip the zombie-socket logic below.
+    if (connectionPhase === 'server_down' && !userDisconnected && savedConnection?.url && savedConnection?.token) {
+      console.log('[ws] App resumed while server_down — retrying');
+      _lastResumeReconnectAt = now;
+      useConnectionStore.getState().retryConnection();
+      return;
+    }
+
     // #5633 Case 0 (zombie socket): we believe we're connected, the socket
     // even still claims OPEN, but we were away at least one heartbeat cycle —
     // long enough for iOS to have suspended JS and the connection to have
@@ -2367,6 +2410,18 @@ export const _networkSub = Network.addNetworkStateListener((state) => {
   if (userDisconnected || !savedConnection?.url || !savedConnection?.token) return;
   // Don't interrupt an in-flight connect/reconnect attempt.
   if (connectionPhase === 'connecting' || connectionPhase === 'reconnecting') return;
+
+  // #5725 (#5698) — the reconnect ladder gave up (terminal `server_down`) before
+  // the network dropped/changed; now that connectivity is back, retry with a
+  // fresh ladder (mirrors the app-resume recovery). Unlike the LAN-candidate
+  // fast-path below, this fires for ANY saved record — a server_down phone that
+  // roamed networks must not sit on a stale terminal banner.
+  if (connectionPhase === 'server_down') {
+    console.log('[ws] Network changed while server_down — retrying');
+    _lastNetworkReconnectAt = now;
+    void useConnectionStore.getState().retryConnection();
+    return;
+  }
 
   // Only bother re-selecting when a faster local path could exist for this
   // record — i.e. it carries a verified LAN candidate. Without one, the tunnel

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1516,7 +1516,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // dashboard's retryConnection (#5724).
   retryConnection: () => {
     resetReconnectAttempt();
-    const saved = useConnectionLifecycleStore.getState().savedConnection;
+    const lifecycle = useConnectionLifecycleStore.getState();
+    // #5725 — leave the terminal server_down phase explicitly BEFORE dialing.
+    // connect() sets 'reconnecting' when re-dialing the same URL (isReconnect),
+    // and `server_down -> reconnecting` is an illegal FSM transition (warns +
+    // still applies + carries the stale "Server appears to be down" error
+    // forward). `server_down -> connecting` is the legal exit; clearing the error
+    // here keeps the banner from leaking into the fresh attempt.
+    if (lifecycle.connectionPhase === 'server_down') {
+      lifecycle.setConnectionPhase('connecting');
+      lifecycle.setConnectionError(null, 0);
+    }
+    const saved = lifecycle.savedConnection;
     if (saved?.url && saved?.token) {
       void get().connectAuto(saved, { silent: true });
     }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -403,6 +403,9 @@ export interface ConnectionActions {
     options?: { silent?: boolean; preferTunnel?: boolean; force?: boolean },
   ) => Promise<void>;
   disconnect: () => void;
+  // #5725 (#5698) — user-initiated retry from the terminal `server_down` state:
+  // resets the reconnect ladder, then reconnects to the saved connection.
+  retryConnection: () => void;
   loadSavedConnection: () => Promise<void>;
   clearSavedConnection: () => Promise<void>;
 }


### PR DESCRIPTION
## Summary
The mobile app's `createReconnectScheduler` call passed no `maxRung`/`onGaveUp`, so it **reconnect-looped forever** — it carried the `server_down` ConnectionPhase + announcer labels as type-compat only and never actually entered the state. This wires the cap + terminal state, mirroring the dashboard (#5724 / #5698 FIX-2). Part of durability epic #5703.

## Changes
**`connection.ts`**
- Pass `maxRung: RECONNECT_MAX_RUNG` + `onGaveUp` (→ `setConnectionPhase('server_down')` + `'Server appears to be down'`, guarded against a superseded attempt) to `createReconnectScheduler`.
- New `retryConnection` action: `resetReconnectAttempt()` then `connectAuto` the saved connection (re-resolves the freshest LAN/tunnel endpoint). Without the reset, a retry from `server_down` would immediately re-exhaust the maxed counter and give up on the first failure.
- **Resume/network auto-clear:** the AppState resume handler and the network-change listener detect a stale `server_down` and route through `retryConnection`, so a phone coming back from sleep / roaming networks doesn't sit on a stale terminal banner. (The dashboard intentionally stays manual — a laptop surface; mobile needs the auto-clear.)

**`SessionScreen.tsx`** — render `server_down` in the reconnect banner distinctly: "Server appears to be down", **no indefinite spinner**, and a **Reconnect** button wired to `retryConnection` instead of Disconnect.

**`types.ts`** — add `retryConnection` to the store actions.

The `server_down` transition-table entry + announcer label already landed as type-compat in #5724 — unchanged here.

## Tests
- `connection-server-down.test.ts` (3): ladder-exhaustion → `server_down` (no infinite loop), `retryConnection` resets the ladder + re-dials, no-op without a saved connection — driven against the real store with a fake socket + fake timers (mirrors `connection-reconnect-backoff.test.ts`).
- `SessionScreenServerDownBanner.test.ts` (5): banner condition, copy, spinner suppression, Reconnect→`retryConnection` wiring (source-text, the repo's SessionScreen convention).

Full app store+screens suites (619) green + `tsc` clean.

## Note
Coordinates with #5699 (optimistic-on-disconnected gating) — both touch `connection.ts` reconnect, but this PR only adds the scheduler options + `retryConnection` + the resume/network branches (no conflict with the gating work).

Closes #5725