### PR TITLE
fix(dashboard): re-pin chat to the tail when the input area grows (#5954 part 2)

### DIFF
--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -250,6 +250,10 @@ describe('ChatView', () => {
   // fold. jsdom has no ResizeObserver, so install a controllable one (the same
   // pattern as the virtualization test) and fire the container's callback by
   // hand after shrinking `clientHeight`.
+  // NOTE: this positive case is tautological in isolation — `userScrolledUp`
+  // defaults to false, so it would pass even if the `userScrolledUpRef` gate were
+  // broken. The scrolled-up negative test directly below is the load-bearing one
+  // (it proves the ref gate actually suppresses the re-pin); keep both.
   it('re-pins to the bottom when the input area grows while following (#5954)', async () => {
     type Entry = { el: HTMLElement; cb: ResizeObserverCallback }
     const observers: Entry[] = []

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -242,6 +242,85 @@ describe('ChatView', () => {
     vi.useRealTimers()
   })
 
+  // #5954 (occlusion) — when the input area grows (multi-line textarea,
+  // attachments, the activity / check-in chips appearing) the `.chat-messages`
+  // viewport shrinks, which fires the container's ResizeObserver. While the user
+  // is following the tail, the observer must re-pin to the bottom so the newest
+  // lines stay ABOVE the input bar instead of sliding below the now-shorter
+  // fold. jsdom has no ResizeObserver, so install a controllable one (the same
+  // pattern as the virtualization test) and fire the container's callback by
+  // hand after shrinking `clientHeight`.
+  it('re-pins to the bottom when the input area grows while following (#5954)', async () => {
+    type Entry = { el: HTMLElement; cb: ResizeObserverCallback }
+    const observers: Entry[] = []
+    class MockRO {
+      cb: ResizeObserverCallback
+      constructor(cb: ResizeObserverCallback) { this.cb = cb }
+      observe(el: Element) { observers.push({ el: el as HTMLElement, cb: this.cb }) }
+      unobserve() {}
+      disconnect() {}
+    }
+    const origRO = globalThis.ResizeObserver
+    ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      MockRO as unknown as typeof ResizeObserver
+    try {
+      render(<ChatView messages={makeMessages(3)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+      // Following the tail: at bottom, user has not scrolled up.
+      Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+      Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
+      Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+
+      // The input area grows → the viewport shrinks and the browser leaves the
+      // tail below the new fold (scrollTop now short of the new bottom).
+      container.scrollTop = 600
+      Object.defineProperty(container, 'clientHeight', { value: 250, configurable: true })
+
+      // Fire the container's ResizeObserver (the real reflow path). The observer
+      // re-pins to the bottom because the user is still following.
+      const containerRO = observers.find(o => o.el === container)
+      expect(containerRO).toBeTruthy()
+      await act(async () => { containerRO!.cb([], containerRO as unknown as ResizeObserver) })
+      expect(container.scrollTop).toBe(1000)
+    } finally {
+      ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = origRO
+    }
+  })
+
+  it('does NOT re-pin on resize when the user has scrolled up (#5954 / #4652)', async () => {
+    type Entry = { el: HTMLElement; cb: ResizeObserverCallback }
+    const observers: Entry[] = []
+    class MockRO {
+      cb: ResizeObserverCallback
+      constructor(cb: ResizeObserverCallback) { this.cb = cb }
+      observe(el: Element) { observers.push({ el: el as HTMLElement, cb: this.cb }) }
+      unobserve() {}
+      disconnect() {}
+    }
+    const origRO = globalThis.ResizeObserver
+    ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      MockRO as unknown as typeof ResizeObserver
+    try {
+      render(<ChatView messages={makeMessages(3)} isStreaming={false} />)
+      const container = screen.getByTestId('chat-messages')
+      Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+      Object.defineProperty(container, 'scrollTop', { value: 100, writable: true, configurable: true })
+      Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+      // User deliberately scrolled up to read history.
+      await act(async () => { fireEvent.scroll(container) })
+      expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+      // The input area grows; the observer must leave the reading position alone.
+      Object.defineProperty(container, 'clientHeight', { value: 250, configurable: true })
+      const containerRO = observers.find(o => o.el === container)
+      expect(containerRO).toBeTruthy()
+      await act(async () => { containerRO!.cb([], containerRO as unknown as ResizeObserver) })
+      expect(container.scrollTop).toBe(100)
+    } finally {
+      ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = origRO
+    }
+  })
+
   it('snaps to bottom when scrollToBottomSignal bumps, even if scrolled up (#5780)', async () => {
     vi.useFakeTimers()
     const messages = makeMessages(3)

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -313,6 +313,10 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
+  // #5954 — a ref mirror of `userScrolledUp` so the ResizeObserver callback can
+  // read the live follow-state without re-subscribing the observer every time
+  // the user crosses the bottom threshold. Kept in sync by the effect below.
+  const userScrolledUpRef = useRef(false)
 
   // #5561 — scroll-anchor compensation state. WKWebView (the Tauri desktop's
   // engine, and the dashboard's PRIMARY consumer) does NOT implement default
@@ -466,15 +470,38 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
     syncGeometry()
   }, [syncGeometry, scrollToBottomNow])
 
+  // #5954 — mirror `userScrolledUp` into a ref so the ResizeObserver callback
+  // (which we don't want to re-subscribe on every threshold crossing) reads the
+  // current follow-state.
+  useEffect(() => {
+    userScrolledUpRef.current = userScrolledUp
+  }, [userScrolledUp])
+
   // #5561 — keep the windowed range correct when the container resizes (panel
   // split drag, window resize, sidebar toggle) without a scroll event firing.
+  //
+  // #5954 — also re-pin to the tail when the container SHRINKS because the input
+  // area grew (a multi-line textarea, attachments, or the activity / check-in
+  // chips appearing all push `.chat-messages` shorter). Content growth during
+  // streaming changes `scrollHeight`, not the container's `clientHeight`, so it
+  // never fires this observer — the streaming RAF owns that path. This observer
+  // fires only on viewport-height changes, which is exactly when a previously
+  // bottom-pinned tail would otherwise slide below the now-shorter fold and
+  // render *behind* the input bar. Gated on following (`!userScrolledUpRef`) so
+  // a user reading history is never yanked down (#4652 / AC3). `scrollToBottomNow`
+  // keeps the programmatic-scroll suppression contract (#5957) intact, and only
+  // ever runs when the #5561 anchor compensation is dormant (it bails unless
+  // `userScrolledUp`), so the two never fight.
   useEffect(() => {
     const el = containerRef.current
     if (!el || typeof ResizeObserver === 'undefined') return
-    const ro = new ResizeObserver(() => syncGeometry())
+    const ro = new ResizeObserver(() => {
+      syncGeometry()
+      if (!userScrolledUpRef.current) scrollToBottomNow()
+    })
     ro.observe(el)
     return () => ro.disconnect()
-  }, [syncGeometry])
+  }, [syncGeometry, scrollToBottomNow])
 
   // #5561 — engine-independent scroll-position compensation.
   //

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -480,14 +480,17 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
   // #5561 — keep the windowed range correct when the container resizes (panel
   // split drag, window resize, sidebar toggle) without a scroll event firing.
   //
-  // #5954 — also re-pin to the tail when the container SHRINKS because the input
-  // area grew (a multi-line textarea, attachments, or the activity / check-in
-  // chips appearing all push `.chat-messages` shorter). Content growth during
-  // streaming changes `scrollHeight`, not the container's `clientHeight`, so it
-  // never fires this observer — the streaming RAF owns that path. This observer
-  // fires only on viewport-height changes, which is exactly when a previously
-  // bottom-pinned tail would otherwise slide below the now-shorter fold and
-  // render *behind* the input bar. Gated on following (`!userScrolledUpRef`) so
+  // #5954 — also re-pin to the tail on a container resize. The motivating case
+  // is a SHRINK because the input area grew (a multi-line textarea, attachments,
+  // or the activity / check-in chips appearing all push `.chat-messages`
+  // shorter), which slides a previously bottom-pinned tail below the now-shorter
+  // fold so it renders *behind* the input bar. ResizeObserver also fires on
+  // width changes (split-pane drag, sidebar toggle) and on grow — re-pinning
+  // there while following is harmless-to-helpful (it keeps the tail in view on
+  // any geometry change), so we don't try to distinguish the trigger. What this
+  // observer does NOT see is streamed content growth: that changes `scrollHeight`,
+  // not the container's own box size, so it never fires here — the streaming RAF
+  // owns that path (no double-pin). Gated on following (`!userScrolledUpRef`) so
   // a user reading history is never yanked down (#4652 / AC3). `scrollToBottomNow`
   // keeps the programmatic-scroll suppression contract (#5957) intact, and only
   // ever runs when the #5561 anchor compensation is dormant (it bails unless


### PR DESCRIPTION
## What

Part of #5954 (sub-issue of #5951). Part 1 (#5957) fixed streaming auto-follow; this is **part 2 — the input-bar occlusion** (AC1).

## Problem

The newest streamed lines could render *behind* the input bar. The occlusion isn't static overlap — `.chat-view` (`flex:1`) and `.input-bar` (`flex-shrink:0`) are flex siblings, so flexbox already reserves space. It happens **dynamically**: when the input *area* grows (multi-line textarea, attachments, the `ActivityIndicator` / `CheckInChip` appearing), `.chat-messages` shrinks from the bottom, and a previously bottom-pinned tail slides below the new, shorter fold.

## Fix

The container already has a `ResizeObserver` (#5561) that only re-ran windowing geometry. It now also **re-pins to the tail** when the viewport shrinks — but only while the user is following:

- Content growth during streaming changes `scrollHeight`, *not* the container's `clientHeight`, so it never fires this observer — the streaming RAF (#5957) owns that path. The observer fires only on viewport-height changes, which is exactly the occlusion trigger.
- Gated on `!userScrolledUp` (mirrored into a ref so the observer isn't re-subscribed on every bottom-threshold crossing) — a user reading history is **not** yanked down (#4652 / AC3).
- Reuses `scrollToBottomNow` to preserve the #5957 programmatic-scroll suppression contract.
- Runs only while the #5561 anchor compensation is dormant (that effect bails unless `userScrolledUp`), so the two paths never fight.

## Tests

`ChatView.test.tsx` (controllable `ResizeObserver`, the house pattern from the virtualization test):
- re-pins to the bottom when the input area grows while following
- does **not** re-pin on resize when the user has scrolled up

Full dashboard suite green (3795 tests) + `tsc` clean.

## Acceptance criteria
- [x] Newest streamed content never hidden behind the input bar (re-pin on viewport shrink).
- [x] Stays pinned to the live tail while streaming (#5957).
- [x] A scrolled-up user is not snapped down (#4652 preserved).
- [x] Coverage for the occlusion + scrolled-up cases.

> Note: kept open (not auto-closed) so #5954 can be closed after the on-device visual confirmation it asks for — jsdom can't model the real reflow pixels.