### PR TITLE
feat(server): fail-closed gate for the embedded user-shell terminal (#5985 part a)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -158,6 +158,17 @@ const CONFIG_SCHEMA = {
   // config file on the dev machine (physical-access proxy for real
   // user confirmation). Added in the 2026-04-11 audit Adversary A5 fix.
   allowAutoPermissionMode: 'boolean',
+  // #5985 (epic #5982): gate for the embedded user-shell terminal — a
+  // `user-shell` session spawns the operator's `$SHELL` (arbitrary code
+  // execution on the dev machine, reachable through the tunnel). Nested object
+  // `{ enabled: boolean }`. Defaults to undefined/false so fresh installs are
+  // secure-by-default: creating a `user-shell` session is rejected with
+  // USER_SHELL_DISABLED unless `userShell.enabled === true`. Enabling is a
+  // deliberate edit on the dev machine (physical-access proxy for confirmation),
+  // matching `allowAutoPermissionMode`. The gate is enforced in
+  // SessionManager.createSession so it covers every spawn path (WS create,
+  // restore, internal callers) — see the swarm-audit C3 finding.
+  userShell: 'object',
   // Allowlist of Docker image patterns that create_environment may use.
   // Each entry is either an exact image name or a prefix pattern like
   // `mcr.microsoft.com/devcontainers/*`. When set, client-supplied
@@ -583,6 +594,32 @@ function validateBillingBlock(billing, warnings) {
   }
   // #5878: typo-catch for the billing knobs.
   warnUnknownKeys(billing, BILLING_SUPPORTED_KEYS, 'billing', warnings)
+}
+
+const USER_SHELL_SUPPORTED_KEYS = new Set(['enabled'])
+
+// #5985 (epic #5982): validate the `userShell` block. Only `enabled` (boolean)
+// today; the security primitives (primary-token gate, audit, isolation) land in
+// the #5985b slice. Warn-only "Invalid value" wording (never "Invalid type") so
+// a mis-typed knob doesn't abort startup via loadAndMergeConfig's fatal-prefix.
+function validateUserShellBlock(userShell, warnings) {
+  if (typeof userShell !== 'object' || userShell === null || Array.isArray(userShell)) {
+    warnings.push(`Invalid value for 'userShell': expected object, got ${Array.isArray(userShell) ? 'array' : typeof userShell}`)
+    return
+  }
+  if (Object.prototype.hasOwnProperty.call(userShell, 'enabled')) {
+    if (typeof userShell.enabled !== 'boolean') {
+      warnings.push(`Invalid value for 'userShell.enabled': expected a boolean, got ${JSON.stringify(userShell.enabled)}`)
+    }
+  }
+  warnUnknownKeys(userShell, USER_SHELL_SUPPORTED_KEYS, 'userShell', warnings)
+}
+
+// #5985: single source of truth for "may a user-shell session be created?".
+// Fail-closed — anything other than an explicit `userShell.enabled === true` is
+// disabled. Used by SessionManager.createSession (the authoritative gate).
+export function isUserShellEnabled(config) {
+  return config?.userShell?.enabled === true
 }
 
 function validateDiscordNotificationsBlock(discord, warnings) {
@@ -1029,6 +1066,11 @@ export function validateConfig(config, verbose = false) {
   // Per-field typos are warn-only "Invalid value"; see validateBillingBlock.
   if (config.billing !== undefined) {
     validateBillingBlock(config.billing, warnings)
+  }
+
+  // #5985 (epic #5982): validate the user-shell gate block.
+  if (config.userShell !== undefined) {
+    validateUserShellBlock(config.userShell, warnings)
   }
 
   if (config.notifications !== undefined) {

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -600,8 +600,14 @@ const USER_SHELL_SUPPORTED_KEYS = new Set(['enabled'])
 
 // #5985 (epic #5982): validate the `userShell` block. Only `enabled` (boolean)
 // today; the security primitives (primary-token gate, audit, isolation) land in
-// the #5985b slice. Warn-only "Invalid value" wording (never "Invalid type") so
-// a mis-typed knob doesn't abort startup via loadAndMergeConfig's fatal-prefix.
+// the #5985b slice. SUB-key checks here are warn-only "Invalid value" (never
+// "Invalid type") so a mis-typed knob doesn't abort startup via
+// loadAndMergeConfig's fatal-prefix — and isUserShellEnabled stays fail-closed
+// for a bad `enabled` value. NOTE: the TOP-LEVEL shape (userShell must be an
+// object) is enforced separately by the shared schema type-gate in
+// validateConfig, which IS fatal for a non-object — same as billing /
+// notifications / environments. That's the fail-safe choice for a security gate:
+// a malformed block stops boot rather than silently disabling.
 function validateUserShellBlock(userShell, warnings) {
   if (typeof userShell !== 'object' || userShell === null || Array.isArray(userShell)) {
     warnings.push(`Invalid value for 'userShell': expected object, got ${Array.isArray(userShell) ? 'array' : typeof userShell}`)

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -45,7 +45,7 @@ import { loadModelsCache, getModels, watchModelsOverlay } from './models.js'
 // environment-manager.js itself remains behind the dynamic import below
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
-import { resolveSkipPermissions, buildEnvironmentBackend } from './config.js'
+import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled } from './config.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -634,6 +634,10 @@ export async function startCliServer(config) {
     // alias are honoured (with a deprecation warning for the latter —
     // see the [security] log lines above).
     defaultSkipPermissions: skipPerms.enabled,
+    // #5985 (epic #5982): gate the embedded user-shell terminal. Off unless the
+    // operator set userShell.enabled:true in the config file. Enforced in
+    // SessionManager.createSession so it covers every spawn path.
+    userShellEnabled: isUserShellEnabled(config),
     providerType,
     maxToolInput: config.maxToolInput || null,
     transforms: config.transforms || [],

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -85,6 +85,22 @@ export class SessionDirectoryError extends SessionError {
 }
 
 /**
+ * #5985 (epic #5982): thrown when a `user-shell` session is requested but the
+ * server has not opted in (`userShell.enabled !== true`). Secure-by-default —
+ * a user shell is arbitrary code execution on the dev machine, so it is off
+ * until an explicit local config edit enables it.
+ */
+export class UserShellDisabledError extends SessionError {
+  constructor() {
+    super(
+      'User-shell sessions are disabled on this server. To enable, set userShell.enabled:true in the server config file (requires local filesystem access). Default is disabled for security.',
+      'USER_SHELL_DISABLED'
+    )
+    this.name = 'UserShellDisabledError'
+  }
+}
+
+/**
  * Thrown when worktree creation fails (e.g. non-git directory).
  */
 export class WorktreeError extends SessionError {
@@ -206,6 +222,13 @@ export class SessionManager extends EventEmitter {
     // TUI session boots already in unmediated mode without requiring the
     // dashboard checkbox round-trip.
     defaultSkipPermissions = false,
+    // #5985 (epic #5982): gate for the embedded user-shell terminal. When false
+    // (default — secure-by-default), createSession rejects a `user-shell`
+    // provider with UserShellDisabledError. Wired from `isUserShellEnabled(config)`
+    // in server-cli. Enforced HERE (not in the WS handler) so it covers every
+    // spawn path — WS create, restoreState, and any internal caller — per the
+    // #5985 swarm-audit C3 finding.
+    userShellEnabled = false,
     // Shadowed in production (server-cli.js always passes providerType
     // explicitly), but kept on the single source of truth so the fallback
     // can't silently diverge from the server's default (#5819).
@@ -316,6 +339,7 @@ export class SessionManager extends EventEmitter {
     // partially enable the flag. Forwarded to providerOpts.skipPermissions
     // for every createSession() call that omits the field.
     this._defaultSkipPermissions = !!defaultSkipPermissions
+    this._userShellEnabled = !!userShellEnabled
     this._sweepOrphanWorktrees = !!sweepOrphanWorktrees
     this._providerType = providerType
 
@@ -792,6 +816,15 @@ export class SessionManager extends EventEmitter {
     // appeared in the UI. Runs BEFORE worktree creation so a failed preflight
     // doesn't leave an orphan worktree behind. (#2962)
     const resolvedProviderType = provider || this._providerType
+    // #5985 (epic #5982): fail-closed gate for the embedded user-shell terminal.
+    // Enforced here (before getProvider / any spawn) so it covers EVERY create
+    // path — WS create_session, restoreState, and internal callers — not just
+    // the WS handler (swarm-audit C3: a handler-only gate is bypassed on restore).
+    // The provider itself ships later (#5983); until then this is a deny that
+    // fails closed during build-out.
+    if (resolvedProviderType === 'user-shell' && !this._userShellEnabled) {
+      throw new UserShellDisabledError()
+    }
     const PreflightProviderClass = getProvider(resolvedProviderType)
     if (!this._skipPreflight) {
       runProviderPreflight(PreflightProviderClass)

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -339,7 +339,11 @@ export class SessionManager extends EventEmitter {
     // partially enable the flag. Forwarded to providerOpts.skipPermissions
     // for every createSession() call that omits the field.
     this._defaultSkipPermissions = !!defaultSkipPermissions
-    this._userShellEnabled = !!userShellEnabled
+    // #5985: strict `=== true` (not `!!`) so the fail-closed / no-coercion
+    // contract holds at the SessionManager layer too — a direct caller passing
+    // a truthy non-boolean (`'true'`, `1`) must NOT open the shell gate. Matches
+    // isUserShellEnabled()'s strictness; production passes that helper's boolean.
+    this._userShellEnabled = userShellEnabled === true
     this._sweepOrphanWorktrees = !!sweepOrphanWorktrees
     this._providerType = providerType
 

--- a/packages/server/tests/config-user-shell.test.js
+++ b/packages/server/tests/config-user-shell.test.js
@@ -31,13 +31,32 @@ describe('config.userShell (#5985)', () => {
     )
   })
 
-  it('warns when userShell is an array (wrong shape)', () => {
-    const result = validateConfig({ userShell: [] })
+  it('rejects userShell with the wrong top-level shape (array/scalar)', () => {
+    // Top-level shape is enforced by the shared schema type-gate, exactly like
+    // every other 'object' block (billing, notifications, environments): a
+    // non-object value is a fatal "Invalid type" config error. For a security
+    // gate that's the fail-safe choice — a malformed block stops boot rather
+    // than silently leaving the gate in an ambiguous state.
+    for (const bad of [[], 'yes', 3]) {
+      const result = validateConfig({ userShell: bad })
+      assert.equal(result.valid, false, `userShell=${JSON.stringify(bad)} must be invalid`)
+      assert.ok(
+        result.warnings.some((w) => w.includes('userShell') && w.includes('object')),
+        `expected a shape warning for userShell=${JSON.stringify(bad)}, got: ${JSON.stringify(result.warnings)}`,
+      )
+    }
+  })
+
+  it('a bad userShell.enabled SUB-key is warn-only and leaves the gate closed', () => {
+    // Sub-key validation (validateUserShellBlock) is warn-only — NOT a fatal
+    // "Invalid type" — and isUserShellEnabled stays false (fail-closed).
+    const result = validateConfig({ userShell: { enabled: 'x' } })
     assert.equal(result.valid, false)
     assert.ok(
-      result.warnings.some((w) => w.includes('userShell') && w.includes('object')),
-      `expected a shape warning for userShell, got: ${JSON.stringify(result.warnings)}`,
+      !result.warnings.some((w) => w.includes('Invalid type') && w.includes('userShell')),
+      `a bad enabled value must be warn-only, got: ${JSON.stringify(result.warnings)}`,
     )
+    assert.equal(isUserShellEnabled({ userShell: { enabled: 'x' } }), false)
   })
 
   it('warns on an unknown sub-key', () => {

--- a/packages/server/tests/config-user-shell.test.js
+++ b/packages/server/tests/config-user-shell.test.js
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateConfig, isUserShellEnabled } from '../src/config.js'
+
+/**
+ * #5985 (epic #5982) — `userShell: { enabled: boolean }` gates the embedded
+ * user-shell terminal. Validate the schema accepts a well-formed block, warns on
+ * the wrong shapes/types, flags unknown sub-keys, and does NOT emit an "Unknown
+ * config key" for `userShell`. Also pin `isUserShellEnabled` as the fail-closed
+ * single source of truth.
+ */
+describe('config.userShell (#5985)', () => {
+  it('accepts a well-formed { enabled: true } block', () => {
+    const result = validateConfig({ userShell: { enabled: true } })
+    assert.equal(result.valid, true)
+    assert.equal(result.warnings.length, 0)
+  })
+
+  it('accepts an empty userShell block (gate off)', () => {
+    const result = validateConfig({ userShell: {} })
+    assert.equal(result.valid, true)
+    assert.equal(result.warnings.length, 0)
+  })
+
+  it('warns when enabled is not a boolean', () => {
+    const result = validateConfig({ userShell: { enabled: 'yes' } })
+    assert.equal(result.valid, false)
+    assert.ok(
+      result.warnings.some((w) => w.includes('userShell.enabled') && w.includes('boolean')),
+      `expected a type warning for userShell.enabled, got: ${JSON.stringify(result.warnings)}`,
+    )
+  })
+
+  it('warns when userShell is an array (wrong shape)', () => {
+    const result = validateConfig({ userShell: [] })
+    assert.equal(result.valid, false)
+    assert.ok(
+      result.warnings.some((w) => w.includes('userShell') && w.includes('object')),
+      `expected a shape warning for userShell, got: ${JSON.stringify(result.warnings)}`,
+    )
+  })
+
+  it('warns on an unknown sub-key', () => {
+    const result = validateConfig({ userShell: { enabled: true, sudo: true } })
+    assert.ok(
+      result.warnings.some((w) => w.includes('userShell') && w.toLowerCase().includes('unknown')),
+      `expected an unknown-key warning for userShell.sudo, got: ${JSON.stringify(result.warnings)}`,
+    )
+  })
+
+  it('does not flag userShell as an unknown config key', () => {
+    const result = validateConfig({ userShell: { enabled: false } })
+    const unknown = result.warnings.find((w) => w.includes('Unknown config key') && w.includes('userShell'))
+    assert.equal(unknown, undefined)
+  })
+})
+
+describe('isUserShellEnabled (#5985) — fail-closed', () => {
+  it('is true ONLY for an explicit enabled:true', () => {
+    assert.equal(isUserShellEnabled({ userShell: { enabled: true } }), true)
+  })
+
+  it('is false for enabled:false, missing block, or missing config', () => {
+    assert.equal(isUserShellEnabled({ userShell: { enabled: false } }), false)
+    assert.equal(isUserShellEnabled({ userShell: {} }), false)
+    assert.equal(isUserShellEnabled({}), false)
+    assert.equal(isUserShellEnabled(undefined), false)
+    assert.equal(isUserShellEnabled(null), false)
+  })
+
+  it('is false for truthy-but-not-true enabled values (no coercion)', () => {
+    assert.equal(isUserShellEnabled({ userShell: { enabled: 'true' } }), false)
+    assert.equal(isUserShellEnabled({ userShell: { enabled: 1 } }), false)
+  })
+})

--- a/packages/server/tests/session-manager-user-shell-gate.test.js
+++ b/packages/server/tests/session-manager-user-shell-gate.test.js
@@ -1,0 +1,125 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { EventEmitter } from 'events'
+import { SessionManager, UserShellDisabledError } from '../src/session-manager.js'
+
+/**
+ * #5985 (epic #5982) — the fail-closed gate for the embedded user-shell
+ * terminal. A `user-shell` session spawns the operator's `$SHELL` (arbitrary
+ * code execution on the dev machine), so it is OFF unless the server config sets
+ * `userShell.enabled:true` (threaded in as `userShellEnabled`).
+ *
+ * The gate lives in `SessionManager.createSession` (NOT the WS handler) so it
+ * covers EVERY spawn path — WS create, restoreState, internal callers — per the
+ * swarm-audit C3 finding. The `user-shell` provider itself ships later (#5983);
+ * until then the gate fails closed (deny during build-out) and, when enabled,
+ * flow falls through to `getProvider` which throws "Unknown provider" — which is
+ * exactly how this test distinguishes "gate opened" from "gate blocked".
+ */
+
+let registerProvider
+
+class CaptureProvider extends EventEmitter {
+  constructor(opts) {
+    super()
+    this.cwd = opts.cwd
+    this.model = opts.model || null
+    this.permissionMode = opts.permissionMode || 'approve'
+    this.isRunning = false
+    this.resumeSessionId = null
+  }
+  static get capabilities() { return {} }
+  start() {}
+  destroy() {}
+  sendMessage() {}
+  interrupt() {}
+  setModel() {}
+  setPermissionMode() {}
+}
+
+before(async () => {
+  ({ registerProvider } = await import('../src/providers.js'))
+  registerProvider('test-usershell-normal', CaptureProvider)
+})
+
+function makeMgr(extraOpts = {}) {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'sm-usershell-'))
+  const stateFile = join(tmpDir, 'state.json')
+  const mgr = new SessionManager({
+    skipPreflight: true,
+    maxSessions: 10,
+    defaultCwd: '/tmp',
+    stateFilePath: stateFile,
+    ...extraOpts,
+  })
+  mgr._tmpDir = tmpDir
+  return mgr
+}
+
+function cleanup(mgr) {
+  mgr.destroyAll()
+  rmSync(mgr._tmpDir, { recursive: true, force: true })
+}
+
+describe('SessionManager user-shell gate (#5985)', () => {
+  it('disabled by default: rejects provider:user-shell with USER_SHELL_DISABLED', () => {
+    const mgr = makeMgr()
+    try {
+      assert.throws(
+        () => mgr.createSession({ cwd: '/tmp', provider: 'user-shell' }),
+        (err) => {
+          assert.ok(err instanceof UserShellDisabledError, `expected UserShellDisabledError, got ${err?.name}`)
+          assert.equal(err.code, 'USER_SHELL_DISABLED')
+          return true
+        },
+      )
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('explicit userShellEnabled:false also rejects', () => {
+    const mgr = makeMgr({ userShellEnabled: false })
+    try {
+      assert.throws(
+        () => mgr.createSession({ cwd: '/tmp', provider: 'user-shell' }),
+        (err) => err.code === 'USER_SHELL_DISABLED',
+      )
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('userShellEnabled:true OPENS the gate (flow proceeds past it to getProvider)', () => {
+    const mgr = makeMgr({ userShellEnabled: true })
+    try {
+      // No `user-shell` provider is registered yet (#5983 ships it), so flow
+      // falls through the gate to getProvider, which throws "Unknown provider".
+      // The point: it is NOT the gate error — proving the gate opened.
+      assert.throws(
+        () => mgr.createSession({ cwd: '/tmp', provider: 'user-shell' }),
+        (err) => {
+          assert.ok(!(err instanceof UserShellDisabledError), 'gate must NOT block when enabled')
+          assert.notEqual(err.code, 'USER_SHELL_DISABLED')
+          assert.match(err.message, /Unknown provider/)
+          return true
+        },
+      )
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('does not affect a normal provider when the gate is disabled', () => {
+    const mgr = makeMgr({ userShellEnabled: false })
+    try {
+      const id = mgr.createSession({ cwd: '/tmp', provider: 'test-usershell-normal' })
+      assert.ok(typeof id === 'string' && id.length > 0, 'a non-shell provider creates normally')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+})

--- a/packages/server/tests/session-manager-user-shell-gate.test.js
+++ b/packages/server/tests/session-manager-user-shell-gate.test.js
@@ -99,6 +99,9 @@ describe('SessionManager user-shell gate (#5985)', () => {
       // No `user-shell` provider is registered yet (#5983 ships it), so flow
       // falls through the gate to getProvider, which throws "Unknown provider".
       // The point: it is NOT the gate error — proving the gate opened.
+      // TODO(#5983/#5989): once the `user-shell` provider is registered this
+      // "Unknown provider" assertion flips meaning — re-assert the gate-opens
+      // path against a successful create (or a stubbed provider) at that point.
       assert.throws(
         () => mgr.createSession({ cwd: '/tmp', provider: 'user-shell' }),
         (err) => {
@@ -110,6 +113,23 @@ describe('SessionManager user-shell gate (#5985)', () => {
       )
     } finally {
       cleanup(mgr)
+    }
+  })
+
+  it('fail-closed: a truthy non-boolean userShellEnabled does NOT open the gate', () => {
+    // The gate is strict `=== true` (no `!!` coercion), so a direct caller
+    // passing a truthy non-boolean must still be rejected.
+    for (const truthy of ['true', 1, {}]) {
+      const mgr = makeMgr({ userShellEnabled: truthy })
+      try {
+        assert.throws(
+          () => mgr.createSession({ cwd: '/tmp', provider: 'user-shell' }),
+          (err) => err.code === 'USER_SHELL_DISABLED',
+          `userShellEnabled=${JSON.stringify(truthy)} must NOT open the gate`,
+        )
+      } finally {
+        cleanup(mgr)
+      }
     }
   })
 


### PR DESCRIPTION
## What

First slice of the embedded user-shell terminal epic (#5982). Lands the **security gate before the provider exists**, so the daemon fails closed during the rest of the build-out. Part of #5985.

## Why this slice first

The #5985 `/swarm-audit` (6 agents) returned **~2.75/5 — revise before implementing**, with a strong consensus criticism (all 6 agents) and a clear safe-first slice. This PR is that slice: the config flag + a **default-DENY at `SessionManager.createSession`**. It's valuable *before* the provider exists (fail-closed) and depends on none of the unresolved primitive work.

Audit finding **C3** specifically: the gate must live in `SessionManager.createSession`, NOT the WS handler — a handler-only gate (like the `validateCwdAllowed` precedent) is bypassed by `restoreState`→`createSession` and every internal caller.

## Changes

- **config:** `userShell: { enabled: boolean }` schema block + `validateUserShellBlock` (warn-only wording, unknown-subkey + shape/type checks) + `isUserShellEnabled(config)` — fail-closed single source of truth (only an explicit `enabled === true` opens it; no coercion).
- **SessionManager:** `userShellEnabled` constructor opt + a gate in `createSession` throwing `UserShellDisabledError` (code `USER_SHELL_DISABLED`) for `provider: 'user-shell'` unless enabled. Covers every spawn path. The WS `create_session` handler already forwards `err.code`, so clients get a clean `USER_SHELL_DISABLED`.
- **server-cli:** wire `userShellEnabled: isUserShellEnabled(config)`.

Default **OFF** — a user shell is arbitrary code execution on the dev machine reachable through the tunnel (mirrors `allowAutoPermissionMode`).

## Not in this PR (tracked, per the audit's revised model)

The WS `client.isPrimaryToken` primitive, the `terminal_*` gates (incl. `terminal_subscribe`), the mailbox/PTY-injection fence, auto-respawn-disable, audit log, and the `bearer-token-authority.md` updates land in **#5985b / #5983 / #5984**. This PR is deliberately just the fail-closed flag.

## Tests

- Config schema/validator/helper incl. fail-closed + no-coercion.
- The `createSession` gate: disabled → `USER_SHELL_DISABLED`; enabled → gate opens and falls through to `getProvider` (proving the gate passed); non-shell providers unaffected.
- All temp `stateFilePath`. Server custom lints green. 322 config+session-manager regression tests pass.