### PR TITLE
fix(server): isClaudeTui discriminator replaces writeTerminalInput duck-typing (#5984)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -199,6 +199,26 @@ export class BaseSession extends EventEmitter {
     return []
   }
 
+  /**
+   * #5984 (epic #5982): is this session class the claude-tui PTY mirror — the
+   * ONLY session type that is a legitimate target for server-initiated
+   * PTY-write paths (the mailbox live-interrupt wakeup) and the Control Room's
+   * `isTui` flag? Defaults to false; ClaudeTuiSession overrides to true.
+   *
+   * This replaces the previous `typeof session.writeTerminalInput === 'function'`
+   * duck-typing at those sites. The user-shell session (#5983) will ALSO expose
+   * `writeTerminalInput` (to receive `terminal_input`), so duck-typing would
+   * mis-detect it as claude-tui and let the weaker ingest-secret holder inject
+   * an executed line into a root shell (swarm-audit finding C2). A positive
+   * class discriminator fails safe: anything not explicitly claude-tui — incl.
+   * a future user-shell — is excluded by construction.
+   *
+   * @returns {boolean}
+   */
+  static get isClaudeTui() {
+    return false
+  }
+
   constructor({
     cwd,
     model,

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -90,6 +90,14 @@ export class ClaudeTuiSession extends BaseSession {
   // This is the DEFAULT_PROVIDER, so its membership is load-bearing (#5855).
   static claudeFamily = true
 
+  // #5984 (epic #5982): this IS the claude-tui PTY mirror — the only legitimate
+  // target for server-initiated PTY writes (mailbox wakeup) and the Control
+  // Room isTui flag. See BaseSession.isClaudeTui for why this is a positive
+  // discriminator rather than `typeof writeTerminalInput` duck-typing.
+  static get isClaudeTui() {
+    return true
+  }
+
   static get displayLabel() {
     return 'Claude Code (TUI · subscription)'
   }

--- a/packages/server/src/mailbox-route.js
+++ b/packages/server/src/mailbox-route.js
@@ -229,6 +229,12 @@ export function handleMailboxPing(server, req, res) {
 function injectWakeup(server, to, unreadCount) {
   const session = server.sessionManager?.resolveSessionByAgentCommId?.(to) ?? null
   if (!session) return 'no-session'
+  // #5984 (epic #5982): gate on the positive claude-tui discriminator, NOT
+  // `typeof session.writeTerminalInput` — a user-shell session (#5983) will
+  // also expose writeTerminalInput, and duck-typing here would let the weaker
+  // ingest-secret holder inject an executed line into a root shell (swarm-audit
+  // finding C2). Only the claude-tui PTY mirror is a legitimate wakeup target.
+  if (!session.constructor?.isClaudeTui) return 'not-tui'
   if (typeof session.writeTerminalInput !== 'function') return 'not-tui'
   // `isRunning` is true mid-turn or with background shells — inject only at a
   // quiet prompt so we never corrupt an in-flight turn's input.

--- a/packages/server/src/mailbox-route.js
+++ b/packages/server/src/mailbox-route.js
@@ -234,7 +234,13 @@ function injectWakeup(server, to, unreadCount) {
   // also expose writeTerminalInput, and duck-typing here would let the weaker
   // ingest-secret holder inject an executed line into a root shell (swarm-audit
   // finding C2). Only the claude-tui PTY mirror is a legitimate wakeup target.
-  if (!session.constructor?.isClaudeTui) return 'not-tui'
+  // Strict `!== true` (not truthiness): this gate is security-load-bearing, so a
+  // buggy override returning a truthy non-boolean must NOT be treated as tui.
+  if (session.constructor?.isClaudeTui !== true) return 'not-tui'
+  // Defense-in-depth: isClaudeTui===true implies writeTerminalInput exists today
+  // (only ClaudeTuiSession sets the marker AND defines the method), so this is
+  // unreachable in practice — but it guards against a future class that sets the
+  // marker without the method rather than throwing on the write below.
   if (typeof session.writeTerminalInput !== 'function') return 'not-tui'
   // `isRunning` is true mid-turn or with background shells — inject only at a
   // quiet prompt so we never corrupt an in-flight turn's input.

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -698,8 +698,9 @@ export class SessionManager extends EventEmitter {
         isBusy: !!(session && session.isRunning),
         // #5984 (epic #5982): positive claude-tui discriminator, not
         // `typeof writeTerminalInput` duck-typing (a user-shell session will
-        // also expose it). Matches the mailbox wakeup gate's eligibility.
-        isTui: !!(session && session.constructor?.isClaudeTui),
+        // also expose it). Strict `=== true` (matches the mailbox gate) so a
+        // buggy override returning a truthy non-boolean isn't treated as tui.
+        isTui: session?.constructor?.isClaudeTui === true,
       })
     }
     return out

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -696,7 +696,10 @@ export class SessionManager extends EventEmitter {
         sessionId,
         sessionName: typeof entry.name === 'string' ? entry.name : null,
         isBusy: !!(session && session.isRunning),
-        isTui: !!(session && typeof session.writeTerminalInput === 'function'),
+        // #5984 (epic #5982): positive claude-tui discriminator, not
+        // `typeof writeTerminalInput` duck-typing (a user-shell session will
+        // also expose it). Matches the mailbox wakeup gate's eligibility.
+        isTui: !!(session && session.constructor?.isClaudeTui),
       })
     }
     return out

--- a/packages/server/tests/mailbox-route.test.js
+++ b/packages/server/tests/mailbox-route.test.js
@@ -74,6 +74,10 @@ function idleTuiSession() {
   return {
     isRunning: false,
     writes: [],
+    // #5984: injectWakeup gates on the positive claude-tui discriminator
+    // (session.constructor.isClaudeTui), not duck-typed writeTerminalInput.
+    // A claude-tui-shaped fake must carry the marker to be a wakeup target.
+    constructor: { isClaudeTui: true },
     writeTerminalInput(text) {
       this.writes.push(text)
       return true
@@ -141,7 +145,7 @@ describe('POST /api/mailbox — ping behavior', () => {
   })
 
   it('does NOT inject when the recipient is mid-turn (busy) but still notifies', async () => {
-    const session = { isRunning: true, writes: [], writeTerminalInput(t) { this.writes.push(t); return true } }
+    const session = { isRunning: true, writes: [], constructor: { isClaudeTui: true }, writeTerminalInput(t) { this.writes.push(t); return true } }
     const push = makePushManager()
     const server = makeServer({ coder: session }, { pushManager: push })
     const res = await invoke(handleMailboxPing, server, {
@@ -165,6 +169,27 @@ describe('POST /api/mailbox — ping behavior', () => {
     assert.equal(res.body.injected, false)
   })
 
+  // #5984 (epic #5982) — swarm-audit finding C2: a non-claude-tui session that
+  // ALSO exposes writeTerminalInput (the future user-shell, #5983) must NOT be a
+  // mailbox-injection target. The gate is the positive `isClaudeTui` class
+  // discriminator, so duck-typing writeTerminalInput can never inject an
+  // executed line into a root shell via the weaker ingest secret.
+  it('reports not-tui for a writeTerminalInput-bearing NON-claude-tui session (user-shell)', async () => {
+    const shellWrites = []
+    const session = {
+      isRunning: false,
+      constructor: { isClaudeTui: false },
+      writeTerminalInput(t) { shellWrites.push(t); return true },
+    }
+    const res = await invoke(handleMailboxPing, makeServer({ coder: session }), {
+      headers: bearer(SECRET),
+      body: JSON.stringify({ to: 'coder', unread_count: 2 }),
+    })
+    assert.equal(res.body.reason, 'not-tui')
+    assert.equal(res.body.injected, false)
+    assert.equal(shellWrites.length, 0, 'must NEVER write into a non-claude-tui PTY')
+  })
+
   it('reports no-session for an unregistered recipient', async () => {
     const res = await invoke(handleMailboxPing, makeServer(), {
       headers: bearer(SECRET),
@@ -174,7 +199,7 @@ describe('POST /api/mailbox — ping behavior', () => {
   })
 
   it('reports pty-dead when the PTY write fails', async () => {
-    const session = { isRunning: false, writeTerminalInput: () => false }
+    const session = { isRunning: false, constructor: { isClaudeTui: true }, writeTerminalInput: () => false }
     const res = await invoke(handleMailboxPing, makeServer({ coder: session }), {
       headers: bearer(SECRET),
       body: JSON.stringify({ to: 'coder' }),
@@ -484,7 +509,8 @@ describe('SessionManager mailbox observability (Control Room snapshot)', () => {
   it('lists live agentCommId registrations with busy/tui flags, skipping dead sessions', () => {
     makeMgr()
     const tui = idleTuiSession()
-    const busyTui = { isRunning: true, writeTerminalInput() { return true } }
+    const busyTui = { isRunning: true, constructor: { isClaudeTui: true }, writeTerminalInput() { return true } }
+    // #5984: a non-claude-tui session is isTui:false even if it had a PTY write.
     const nonTui = { isRunning: false }
     mgr._sessions.set('sid-1', { session: tui, name: 'Coder' })
     mgr._sessions.set('sid-2', { session: busyTui, name: 'Builder' })

--- a/packages/server/tests/session-kind-discriminator.test.js
+++ b/packages/server/tests/session-kind-discriminator.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { BaseSession } from '../src/base-session.js'
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+
+/**
+ * #5984 (epic #5982) — the `isClaudeTui` class discriminator. It replaces the
+ * `typeof session.writeTerminalInput === 'function'` duck-typing at the two
+ * server-initiated PTY-write / observability sites (mailbox wakeup +
+ * Control Room isTui), so a future user-shell session (#5983) — which will ALSO
+ * expose writeTerminalInput — is excluded by construction (swarm-audit C2).
+ *
+ * Fail-safe contract: the marker is FALSE on the base class, so any session that
+ * does not explicitly opt in is treated as not-claude-tui.
+ */
+describe('isClaudeTui discriminator (#5984)', () => {
+  it('is false on BaseSession (the fail-safe default)', () => {
+    assert.equal(BaseSession.isClaudeTui, false)
+  })
+
+  it('is true on ClaudeTuiSession (the legitimate PTY-mirror target)', () => {
+    assert.equal(ClaudeTuiSession.isClaudeTui, true)
+  })
+
+  it('is readable off an instance via .constructor (the access path the gates use)', () => {
+    // The gates read `session.constructor?.isClaudeTui`. A subclass that does
+    // NOT override the getter inherits the base false — proving a hypothetical
+    // PTY-bearing subclass is excluded unless it explicitly opts in.
+    class FakeShellSession extends BaseSession {}
+    assert.equal(FakeShellSession.isClaudeTui, false)
+  })
+})

--- a/packages/server/tests/session-kind-discriminator.test.js
+++ b/packages/server/tests/session-kind-discriminator.test.js
@@ -22,10 +22,12 @@ describe('isClaudeTui discriminator (#5984)', () => {
     assert.equal(ClaudeTuiSession.isClaudeTui, true)
   })
 
-  it('is readable off an instance via .constructor (the access path the gates use)', () => {
-    // The gates read `session.constructor?.isClaudeTui`. A subclass that does
-    // NOT override the getter inherits the base false — proving a hypothetical
-    // PTY-bearing subclass is excluded unless it explicitly opts in.
+  it('a BaseSession subclass inherits the false default unless it opts in', () => {
+    // The gates read `session.constructor?.isClaudeTui` (that live access path is
+    // exercised end-to-end by the mailbox-route regression test). Here we assert
+    // the inheritance contract directly: a subclass that does NOT override the
+    // getter inherits the base false — so a hypothetical PTY-bearing subclass
+    // (e.g. the future user-shell) is excluded unless it explicitly opts in.
     class FakeShellSession extends BaseSession {}
     assert.equal(FakeShellSession.isClaudeTui, false)
   })


### PR DESCRIPTION
## What

Sub-issue **#5984** of the user-shell terminal epic (#5982). Introduces the session-`kind` discriminator that the swarm-audit (#5985) flagged as **security-load-bearing** (finding **C2**).

## Problem (swarm-audit C2)

The mailbox live-interrupt wakeup (`mailbox-route.js` `injectWakeup`) and the Control Room `isTui` flag (`session-manager.js` `listAgentCommRegistrations`) both detect the claude-tui PTY mirror by **duck-typing** `typeof session.writeTerminalInput === 'function'`. The future user-shell session (#5983) will **also** expose `writeTerminalInput` (to receive `terminal_input`), so duck-typing would mis-detect it as claude-tui — letting the weaker **ingest-secret** holder inject an executed line into a **root shell**.

## Fix

A positive class discriminator, fail-safe by construction:
- `BaseSession.isClaudeTui` → `false` (documented default).
- `ClaudeTuiSession` overrides → `true`.
- Both sites gate on `session.constructor?.isClaudeTui`.

Anything not explicitly claude-tui — including a future user-shell — is excluded. **No behavior change for claude-tui today** (it's the only session with `writeTerminalInput`), but the day a non-tui PTY session exists it can never become a mailbox-injection target.

## Tests

- `session-kind-discriminator.test.js`: base `false` / tui `true` / a `BaseSession` subclass inherits `false`.
- `mailbox-route.test.js`: new regression — a `writeTerminalInput`-bearing **non-claude-tui** session is `not-tui` and is **never written to**; existing claude-tui fakes carry the marker; the `isTui` snapshot test updated.

291 claude-tui + 204 session-manager + 32 mailbox/discriminator tests pass. Server custom lints green.

## Unblocks

The C2 mailbox fence for #5985b. The remaining #5985b work (WS `client.isPrimaryToken` primitive + `terminal_*` gates) is **not** in this PR — it touches `ws-auth.js` and is staged for review.