### PR TITLE
feat(server): UserShellSession PTY provider — activates the user-shell terminal (#5983)

### DIFF
--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -22,6 +22,7 @@ import { DeepSeekSession } from './deepseek-session.js'
 import { OllamaSession } from './ollama-session.js'
 import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
+import { UserShellSession } from './user-shell-session.js'
 import { registerProviderRegistry } from './models.js'
 import { BILLING_CLASSES } from './billing-class.js'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
@@ -51,6 +52,11 @@ const PROVIDERS = {
   'ollama': OllamaSession,
   'gemini': GeminiSession,
   'codex': CodexSession,
+  // #5983 (epic #5982) — general-purpose user shell ($SHELL via node-pty).
+  // Gated OFF by default (userShell.enabled, #5985a) and primary-token-only
+  // on create + every terminal_* op (#5985b); excluded from mailbox injection
+  // (#5984). PTY-only — no chat/turn semantics.
+  'user-shell': UserShellSession,
 }
 
 // The default provider lives in @chroxy/protocol so the server, dashboard,

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -68,7 +68,11 @@ const PROVIDERS = {
 export { DEFAULT_PROVIDER }
 
 // Names hidden from listProviders() (backward-compat aliases, etc.)
-const HIDDEN = new Set()
+// #5994: user-shell is NOT a chat provider — it's a terminal-only session
+// created via a dedicated shell affordance (#5986/#5987), never the chat
+// provider picker. Hiding it keeps it out of listProviders() so it can't be
+// selected as a (fake-ready) chat backend. getProvider/create still resolve it.
+const HIDDEN = new Set(['user-shell'])
 
 /** Required methods every provider class prototype must expose. */
 const REQUIRED_METHODS = ['sendMessage', 'interrupt', 'setModel', 'setPermissionMode', 'start', 'destroy']

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1804,6 +1804,11 @@ export class SessionManager extends EventEmitter {
     if (this._destroying) return null
     const state = { version: 1, timestamp: Date.now(), sessions: [] }
     for (const [id, entry] of this._sessions) {
+      // #5983 (epic #5982): never persist a user-shell session. Restoring one
+      // would re-spawn a $SHELL on boot — bypassing the userShell.enabled gate
+      // if it was since turned off (swarm-audit C3 / Skeptic finding 4) — and a
+      // shell has no resumable conversation state worth keeping anyway.
+      if (entry.session?.constructor?.isUserShell === true) continue
       state.sessions.push(this._serializeSessionEntry(id, entry))
     }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -824,16 +824,17 @@ export class SessionManager extends EventEmitter {
     // appeared in the UI. Runs BEFORE worktree creation so a failed preflight
     // doesn't leave an orphan worktree behind. (#2962)
     const resolvedProviderType = provider || this._providerType
+    const PreflightProviderClass = getProvider(resolvedProviderType)
     // #5985 (epic #5982): fail-closed gate for the embedded user-shell terminal.
-    // Enforced here (before getProvider / any spawn) so it covers EVERY create
-    // path — WS create_session, restoreState, and internal callers — not just
-    // the WS handler (swarm-audit C3: a handler-only gate is bypassed on restore).
-    // The provider itself ships later (#5983); until then this is a deny that
-    // fails closed during build-out.
-    if (resolvedProviderType === 'user-shell' && !this._userShellEnabled) {
+    // Enforced here (before any spawn) so it covers EVERY create path — WS
+    // create_session, restoreState, and internal callers — not just the WS
+    // handler (swarm-audit C3: a handler-only gate is bypassed on restore). Keyed
+    // on the resolved provider CLASS (`isUserShell`), not the provider-name
+    // string, so any user-shell provider is caught regardless of its registry id
+    // — consistent with the serialize-skip and terminal_* gates.
+    if (PreflightProviderClass?.isUserShell === true && !this._userShellEnabled) {
       throw new UserShellDisabledError()
     }
-    const PreflightProviderClass = getProvider(resolvedProviderType)
     if (!this._skipPreflight) {
       runProviderPreflight(PreflightProviderClass)
     }

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -1,0 +1,339 @@
+/**
+ * UserShellSession (#5983, epic #5982) — a PTY-only session that spawns the
+ * operator's `$SHELL` for a general-purpose terminal inside Chroxy, independent
+ * of any Claude session.
+ *
+ * This is the provider that ACTIVATES the security foundation built behind it:
+ *   - `userShell.enabled` config gate (default OFF) — SessionManager.createSession (#5985a)
+ *   - WS primary-token gate on create + every terminal_* op (#5985b)
+ *   - excluded from the mailbox / isTui PTY-injection path (#5984)
+ *
+ * It deliberately does NOT inherit ClaudeTuiSession's machinery (resume,
+ * auto-respawn, conversation recovery, permission hook). A user shell has no
+ * "turns" and MUST NOT auto-respawn — per the #5985 swarm-audit (Guardian),
+ * typing `exit` resurrecting a fresh root shell is a footgun. Exit means gone.
+ */
+
+import { realpathSync, existsSync } from 'fs'
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('user-shell-session')
+
+// Match the claude-tui mirror grid so the dashboard renders shells at the same
+// default size; a client resize overrides it via resizeTerminal.
+const DEFAULT_COLS = 120
+const DEFAULT_ROWS = 30
+// Coalesce PTY bytes into one terminal_output per tick (bounds broadcast churn).
+const MIRROR_FLUSH_MS = 50
+// SIGTERM → grace → SIGKILL the process group on destroy.
+const DESTROY_GRACE_MS = 3000
+
+/**
+ * Resolve the shell to spawn: `$SHELL` if it exists, then common fallbacks.
+ * Never returns a non-existent path so spawn fails cleanly only on a truly
+ * shell-less host.
+ */
+function resolveShell() {
+  const shell = process.env.SHELL
+  if (typeof shell === 'string' && shell && existsSync(shell)) return shell
+  for (const cand of ['/bin/zsh', '/bin/bash', '/bin/sh']) {
+    if (existsSync(cand)) return cand
+  }
+  return '/bin/sh'
+}
+
+export class UserShellSession extends BaseSession {
+  static get displayLabel() {
+    return 'Shell'
+  }
+
+  // #5985b: this IS the general-purpose user shell — activates the WS
+  // primary-token terminal_* gates (create / subscribe / resize / input).
+  static get isUserShell() {
+    return true
+  }
+
+  // #5984: NOT the claude-tui PTY mirror — stays false (inherited), so the
+  // mailbox wakeup / Control Room isTui path never targets a shell.
+
+  static get capabilities() {
+    return {
+      // No Claude semantics: no permission engine, model switch, plan mode,
+      // resume, thinking budget, streaming, or tool events. It is purely a PTY.
+      permissions: false,
+      inProcessPermissions: false,
+      modelSwitch: false,
+      permissionModeSwitch: false,
+      planMode: false,
+      resume: false,
+      terminal: true,
+      thinkingLevel: false,
+      streaming: false,
+      tools: false,
+    }
+  }
+
+  constructor(opts = {}) {
+    // Picker forwards every BaseSession opt; `provider` is fixed to user-shell.
+    super(buildBaseSessionOpts(opts, { provider: 'user-shell' }))
+    this._term = null
+    this._ptyExited = false
+    this._destroying = false
+    this._shellAlive = false
+    this._ptyCols = DEFAULT_COLS
+    this._ptyRows = DEFAULT_ROWS
+    this._mirrorBuffer = ''
+    this._mirrorTimer = null
+    this._terminalMirrorActive = false
+    this._killTimer = null
+  }
+
+  /**
+   * A shell with a live PTY is "running" — keeps SessionTimeoutManager from
+   * reaping an open shell as idle and lets the UI show the tab as live. Turn-
+   * based `_isBusy` never flips for a shell, so the base getter would always be
+   * false; this reflects PTY liveness instead.
+   */
+  get isRunning() {
+    return this._shellAlive
+  }
+
+  /**
+   * Spawn the shell under node-pty and wire its I/O. Async + rejects on failure
+   * so SessionManager's _handleAsyncStartFailure tears down the phantom session
+   * (same contract claude-tui relies on).
+   */
+  async start() {
+    let ptyMod
+    try {
+      ptyMod = await import('node-pty')
+    } catch (err) {
+      throw new Error(`node-pty unavailable: ${err.message}`)
+    }
+
+    const shell = resolveShell()
+    let cwdReal
+    try {
+      cwdReal = realpathSync(this.cwd)
+    } catch {
+      // Fall back to the raw cwd; the spawn below surfaces a clean error if it's
+      // truly unusable. Never default to '/' silently (Tauri/launchd cwd trap).
+      cwdReal = this.cwd
+    }
+    const env = { ...process.env, TERM: 'xterm-256color' }
+
+    try {
+      this._term = ptyMod.spawn(shell, [], {
+        name: 'xterm-256color',
+        cols: this._ptyCols,
+        rows: this._ptyRows,
+        cwd: cwdReal,
+        env,
+      })
+    } catch (err) {
+      throw new Error(`Failed to spawn user shell (${shell}): ${err.message}`)
+    }
+
+    // destroy() can race the spawn (it set _destroying while we awaited the
+    // import): kill the fresh PTY so it isn't orphaned, then bail.
+    if (this._destroying) {
+      try { this._term.kill('SIGTERM') } catch { /* already gone */ }
+      this._term = null
+      return
+    }
+
+    this._shellAlive = true
+    log.info(`user-shell spawned (${shell} pid=${this._term.pid} ${this._ptyCols}x${this._ptyRows} cwd=${cwdReal})`)
+
+    this._term.onData((data) => this._feedTerminalMirror(data))
+    this._term.onExit((info) => this._onShellExit(info, 'exit'))
+    // #5311 parity: keep a per-session PTY fault from crashing the whole daemon.
+    // node-pty rethrows a socket error unless the Terminal has >= 2 'error'
+    // listeners; drive teardown off 'close'/'error' and register a second no-op
+    // 'error' listener to clear the rethrow threshold. _onShellExit is
+    // idempotent (guards on _ptyExited) so any firing order tears down once.
+    this._term.on('error', (err) => this._onShellExit(null, `error: ${err?.message || 'unknown'}`))
+    this._term.on('error', () => {})
+    this._term.on('close', () => this._onShellExit(null, 'close'))
+  }
+
+  /**
+   * The shell process ended (clean `exit`, close, or socket error). Idempotent.
+   * Tears the PTY down WITHOUT respawning — exit means gone (#5985 Guardian) —
+   * surfaces a final frame so the viewer sees it ended, and flips isRunning off.
+   */
+  _onShellExit(info, reason) {
+    if (this._ptyExited) return
+    this._ptyExited = true
+    this._shellAlive = false
+    const code = info && typeof info.exitCode === 'number' ? info.exitCode : null
+    log.info(`user-shell exited (reason=${reason}${code != null ? ` code=${code}` : ''})`)
+    // Flush any buffered bytes, then a terminal marker so a live viewer sees the
+    // shell ended rather than a frozen prompt. Kept out of history (it's a
+    // terminal_output, transient by wiring).
+    this._flushTerminalMirror()
+    const marker = `\r\n[chroxy] shell exited${code != null ? ` (code ${code})` : ''}\r\n`
+    this.emit('terminal_output', { data: marker })
+    this._clearKillTimer()
+  }
+
+  /**
+   * Append a raw PTY chunk to the coalescing buffer and arm a single flush
+   * timer. Gated on an active mirror (a subscriber present) so an unwatched
+   * shell does no per-byte work. Bytes are NOT transformed — faithful render.
+   */
+  _feedTerminalMirror(data) {
+    if (!this._terminalMirrorActive) return
+    this._mirrorBuffer += String(data)
+    if (this._mirrorTimer) return
+    this._mirrorTimer = setTimeout(() => this._flushTerminalMirror(), MIRROR_FLUSH_MS)
+    if (typeof this._mirrorTimer.unref === 'function') this._mirrorTimer.unref()
+  }
+
+  /** Emit the coalesced buffer as one terminal_output and reset. No-op if empty. */
+  _flushTerminalMirror() {
+    if (this._mirrorTimer) {
+      clearTimeout(this._mirrorTimer)
+      this._mirrorTimer = null
+    }
+    const data = this._mirrorBuffer
+    if (!data) return
+    this._mirrorBuffer = ''
+    this.emit('terminal_output', { data })
+  }
+
+  /**
+   * WsServer toggles the coalescer when the terminal-subscriber count crosses
+   * 0↔1 (#5837). When turning OFF, drop the pending buffer/timer (nobody's
+   * watching, so a trailing flush is waste).
+   */
+  setTerminalMirrorActive(active) {
+    const next = !!active
+    if (next === this._terminalMirrorActive) return
+    this._terminalMirrorActive = next
+    if (!next) {
+      if (this._mirrorTimer) {
+        clearTimeout(this._mirrorTimer)
+        this._mirrorTimer = null
+      }
+      this._mirrorBuffer = ''
+    }
+  }
+
+  /** The live PTY's current grid, for a newly-subscribing viewer to letterbox to. */
+  getTerminalSize() {
+    return { cols: this._ptyCols, rows: this._ptyRows }
+  }
+
+  /**
+   * Resize the live PTY. Clamps to the protocol bounds (so a bad caller can't
+   * throw inside node-pty), records the size, applies it when a PTY is alive,
+   * and emits terminal_resize (broadcast back as terminal_size). Returns the
+   * applied size or null on a no-op.
+   */
+  resizeTerminal(cols, rows) {
+    const c = Math.max(1, Math.min(1000, Math.floor(Number(cols))))
+    const r = Math.max(1, Math.min(1000, Math.floor(Number(rows))))
+    if (!Number.isFinite(c) || !Number.isFinite(r)) return null
+    if (c === this._ptyCols && r === this._ptyRows) return null
+    this._ptyCols = c
+    this._ptyRows = r
+    if (this._term && !this._ptyExited) {
+      try {
+        this._term.resize(c, r)
+      } catch (err) {
+        log.warn(`user-shell resize failed (${c}x${r}): ${err?.message || err}`)
+      }
+    }
+    this.emit('terminal_resize', { cols: c, rows: r })
+    return { cols: c, rows: r }
+  }
+
+  /**
+   * Write raw client keystrokes to the live PTY. The WS handler enforces
+   * authority (PRIMARY token + viewer); this just writes. No-op (false) when
+   * there is no live PTY.
+   * @returns {boolean}
+   */
+  writeTerminalInput(data) {
+    if (typeof data !== 'string' || data.length === 0) return false
+    if (!this._term || this._ptyExited || this._destroying) return false
+    try {
+      this._term.write(data)
+      return true
+    } catch (err) {
+      log.warn(`user-shell terminal input write failed: ${err?.message || err}`)
+      return false
+    }
+  }
+
+  // ── ProviderSession contract stubs ────────────────────────────────────────
+  // A user shell has no chat/turn semantics. These exist only to satisfy the
+  // REQUIRED_METHODS interface check; setModel/setPermissionMode are inherited
+  // from BaseSession (harmless no-ops here).
+
+  /** No-op: a shell takes raw keystrokes via writeTerminalInput, not messages. */
+  sendMessage() {
+    return false
+  }
+
+  /** No-op: there is no turn to interrupt; Ctrl-C is a keystroke (terminal_input). */
+  interrupt() {
+    return false
+  }
+
+  /**
+   * Kill the PTY (no respawn) and clear all timers. SIGTERM, then after a grace
+   * window SIGKILL the whole process group so backgrounded jobs die too. The
+   * liveness probe + _ptyExited latch narrow escalation to a genuinely-hung
+   * shell (never a recycled pid).
+   */
+  destroy() {
+    this._destroying = true
+
+    if (this._mirrorTimer) {
+      clearTimeout(this._mirrorTimer)
+      this._mirrorTimer = null
+    }
+    this._mirrorBuffer = ''
+
+    const term = this._term
+    const pid = term?.pid
+    if (term && !this._ptyExited) {
+      try { term.kill('SIGTERM') } catch { /* already gone */ }
+      if (Number.isInteger(pid) && pid > 0) {
+        this._killTimer = setTimeout(() => {
+          this._killTimer = null
+          if (this._ptyExited) return
+          try { process.kill(pid, 0) } catch { return /* already exited */ }
+          log.warn(`user-shell PTY (pid=${pid}) did not exit ${DESTROY_GRACE_MS}ms after SIGTERM — escalating to SIGKILL`)
+          let killed = false
+          if (process.platform !== 'win32') {
+            try { process.kill(-pid, 'SIGKILL'); killed = true } catch { /* group gone */ }
+          }
+          if (!killed) {
+            try { term.kill('SIGKILL') } catch {
+              try { process.kill(pid, 'SIGKILL') } catch { /* already gone */ }
+            }
+          }
+        }, DESTROY_GRACE_MS)
+        if (typeof this._killTimer.unref === 'function') this._killTimer.unref()
+      }
+    }
+    this._term = null
+    this._shellAlive = false
+
+    // BaseSession teardown (background-shell tracker, activity registry, pending
+    // maps). Mirrors the other providers' destroy() tail.
+    this._destroyPendingBackgroundShells()
+    this.removeAllListeners()
+  }
+
+  _clearKillTimer() {
+    if (this._killTimer) {
+      clearTimeout(this._killTimer)
+      this._killTimer = null
+    }
+  }
+}

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -31,8 +31,9 @@ const DESTROY_GRACE_MS = 3000
 
 /**
  * Resolve the shell to spawn: `$SHELL` if it exists, then common fallbacks.
- * Never returns a non-existent path so spawn fails cleanly only on a truly
- * shell-less host.
+ * Returns the first path that exists; if none do (a truly unusual host), falls
+ * back to `/bin/sh` as a last resort — start() then surfaces a clean spawn error
+ * if that path is also missing.
  */
 function resolveShell() {
   const shell = process.env.SHELL
@@ -173,8 +174,12 @@ export class UserShellSession extends BaseSession {
     // shell ended rather than a frozen prompt. Kept out of history (it's a
     // terminal_output, transient by wiring).
     this._flushTerminalMirror()
-    const marker = `\r\n[chroxy] shell exited${code != null ? ` (code ${code})` : ''}\r\n`
-    this.emit('terminal_output', { data: marker })
+    // Only surface the marker when a viewer is actually subscribed — consistent
+    // with the coalescer's mirror-active gate (an unwatched shell does no work).
+    if (this._terminalMirrorActive) {
+      const marker = `\r\n[chroxy] shell exited${code != null ? ` (code ${code})` : ''}\r\n`
+      this.emit('terminal_output', { data: marker })
+    }
     this._clearKillTimer()
   }
 
@@ -290,6 +295,11 @@ export class UserShellSession extends BaseSession {
    * shell (never a recycled pid).
    */
   destroy() {
+    // Idempotent: a second destroy() (or a destroy racing the exit path) is a
+    // no-op — the first call already armed teardown (SIGTERM + the escalation
+    // timer), and re-running would do nothing useful and risks cancelling a
+    // still-pending SIGKILL escalation.
+    if (this._destroying) return
     this._destroying = true
 
     if (this._mirrorTimer) {

--- a/packages/server/tests/session-manager-user-shell-gate.test.js
+++ b/packages/server/tests/session-manager-user-shell-gate.test.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { EventEmitter } from 'events'
 import { SessionManager, UserShellDisabledError } from '../src/session-manager.js'
+import { UserShellSession } from '../src/user-shell-session.js'
 
 /**
  * #5985 (epic #5982) — the fail-closed gate for the embedded user-shell
@@ -93,25 +94,19 @@ describe('SessionManager user-shell gate (#5985)', () => {
     }
   })
 
-  it('userShellEnabled:true OPENS the gate (flow proceeds past it to getProvider)', () => {
+  it('userShellEnabled:true OPENS the gate (user-shell session is created)', () => {
+    // #5983 registered the provider, so the gate-opens path now ends in a real
+    // UserShellSession (re-asserts the #5989 follow-up). Stub the $SHELL spawn —
+    // this test covers the gate, not node-pty.
+    const origStart = UserShellSession.prototype.start
+    UserShellSession.prototype.start = async function () {}
     const mgr = makeMgr({ userShellEnabled: true })
     try {
-      // No `user-shell` provider is registered yet (#5983 ships it), so flow
-      // falls through the gate to getProvider, which throws "Unknown provider".
-      // The point: it is NOT the gate error — proving the gate opened.
-      // TODO(#5983/#5989): once the `user-shell` provider is registered this
-      // "Unknown provider" assertion flips meaning — re-assert the gate-opens
-      // path against a successful create (or a stubbed provider) at that point.
-      assert.throws(
-        () => mgr.createSession({ cwd: '/tmp', provider: 'user-shell' }),
-        (err) => {
-          assert.ok(!(err instanceof UserShellDisabledError), 'gate must NOT block when enabled')
-          assert.notEqual(err.code, 'USER_SHELL_DISABLED')
-          assert.match(err.message, /Unknown provider/)
-          return true
-        },
-      )
+      const id = mgr.createSession({ cwd: '/tmp', provider: 'user-shell' })
+      assert.ok(typeof id === 'string' && id.length > 0, 'gate opened → session created')
+      assert.equal(mgr.getSession(id).session.constructor.isUserShell, true)
     } finally {
+      UserShellSession.prototype.start = origStart
       cleanup(mgr)
     }
   })

--- a/packages/server/tests/user-shell-session.test.js
+++ b/packages/server/tests/user-shell-session.test.js
@@ -1,0 +1,162 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { UserShellSession } from '../src/user-shell-session.js'
+import { getProvider, validateProviderClass } from '../src/providers.js'
+
+/**
+ * #5983 (epic #5982) — UserShellSession: a PTY-only $SHELL session. These tests
+ * exercise the terminal surface + lifecycle WITHOUT spawning a real shell (a
+ * fake PTY is injected as `_term`). start()'s real node-pty spawn is covered by
+ * the provider-registration contract + manual/integration testing.
+ */
+
+function makeFakeTerm() {
+  const calls = { write: [], resize: [], kill: [] }
+  return {
+    pid: 4242,
+    write(data) { calls.write.push(data) },
+    resize(c, r) { calls.resize.push([c, r]) },
+    kill(sig) { calls.kill.push(sig) },
+    onData() {},
+    onExit() {},
+    on() {},
+    _calls: calls,
+  }
+}
+
+// Build a session with a live injected PTY, skipping the real spawn.
+function makeLiveShell() {
+  const s = new UserShellSession({ cwd: '/tmp' })
+  s._term = makeFakeTerm()
+  s._shellAlive = true
+  return s
+}
+
+describe('UserShellSession — class contract (#5983)', () => {
+  it('is registered as the user-shell provider and passes the interface check', () => {
+    assert.equal(getProvider('user-shell'), UserShellSession)
+    assert.doesNotThrow(() => validateProviderClass(UserShellSession, 'user-shell'))
+  })
+
+  it('declares isUserShell=true and isClaudeTui=false (gates + mailbox fence)', () => {
+    assert.equal(UserShellSession.isUserShell, true)
+    assert.equal(UserShellSession.isClaudeTui, false, 'must NOT be a mailbox-injection / isTui target')
+  })
+
+  it('has PTY-only capabilities (no Claude semantics)', () => {
+    const c = UserShellSession.capabilities
+    assert.equal(c.terminal, true)
+    assert.equal(c.tools, false)
+    assert.equal(c.permissions, false)
+    assert.equal(c.streaming, false)
+    assert.equal(c.resume, false)
+  })
+
+  it('fixes provider to user-shell via the opt picker', () => {
+    const s = new UserShellSession({ cwd: '/tmp', model: 'ignored' })
+    assert.equal(s._provider, 'user-shell')
+  })
+
+  it('sendMessage / interrupt are inert no-ops (no turns)', () => {
+    const s = new UserShellSession({ cwd: '/tmp' })
+    assert.equal(s.sendMessage('hi'), false)
+    assert.equal(s.interrupt(), false)
+  })
+})
+
+describe('UserShellSession — terminal surface (#5983)', () => {
+  it('writeTerminalInput writes to a live PTY and no-ops on a dead one', () => {
+    const s = makeLiveShell()
+    assert.equal(s.writeTerminalInput('ls\r'), true)
+    assert.deepEqual(s._term._calls.write, ['ls\r'])
+    assert.equal(s.writeTerminalInput(''), false, 'empty data is a no-op')
+
+    s._ptyExited = true
+    assert.equal(s.writeTerminalInput('x'), false, 'no write after exit')
+  })
+
+  it('resizeTerminal clamps, applies, and emits terminal_resize; no-op on unchanged', () => {
+    const s = makeLiveShell()
+    const events = []
+    s.on('terminal_resize', (d) => events.push(d))
+
+    const applied = s.resizeTerminal(100, 40)
+    assert.deepEqual(applied, { cols: 100, rows: 40 })
+    assert.deepEqual(s._term._calls.resize.at(-1), [100, 40])
+    assert.deepEqual(events.at(-1), { cols: 100, rows: 40 })
+    assert.deepEqual(s.getTerminalSize(), { cols: 100, rows: 40 })
+
+    assert.equal(s.resizeTerminal(100, 40), null, 'unchanged size is a no-op')
+    assert.equal(s.resizeTerminal('x', 'y'), null, 'NaN is rejected, never reaches _term.resize')
+  })
+
+  it('coalesces PTY bytes into one terminal_output, gated on an active mirror', () => {
+    const s = makeLiveShell()
+    const out = []
+    s.on('terminal_output', (d) => out.push(d.data))
+
+    // Mirror inactive → no coalescing work, nothing emitted.
+    s._feedTerminalMirror('ignored')
+    s._flushTerminalMirror()
+    assert.equal(out.length, 0)
+
+    s.setTerminalMirrorActive(true)
+    s._feedTerminalMirror('foo')
+    s._feedTerminalMirror('bar')
+    s._flushTerminalMirror()
+    assert.deepEqual(out, ['foobar'], 'bytes coalesced into one frame')
+
+    // Turning the mirror off drops any buffered bytes (nobody watching).
+    s._feedTerminalMirror('dropped')
+    s.setTerminalMirrorActive(false)
+    s._flushTerminalMirror()
+    assert.deepEqual(out, ['foobar'], 'buffer cleared on mirror-off, no trailing flush')
+  })
+})
+
+describe('UserShellSession — lifecycle (#5983)', () => {
+  it('isRunning reflects PTY liveness', () => {
+    const s = new UserShellSession({ cwd: '/tmp' })
+    assert.equal(s.isRunning, false, 'no PTY yet')
+    s._shellAlive = true
+    assert.equal(s.isRunning, true)
+  })
+
+  it('_onShellExit is idempotent, flips isRunning off, and emits a final marker — NO respawn', () => {
+    const s = makeLiveShell()
+    s.setTerminalMirrorActive(true)
+    const out = []
+    s.on('terminal_output', (d) => out.push(d.data))
+
+    s._onShellExit({ exitCode: 0 }, 'exit')
+    assert.equal(s.isRunning, false)
+    assert.equal(s._ptyExited, true)
+    assert.equal(out.length, 1)
+    assert.match(out[0], /shell exited/)
+
+    // Idempotent: a second exit signal (close/error firing after onExit) is a no-op.
+    s._onShellExit(null, 'close')
+    assert.equal(out.length, 1, 'no duplicate marker')
+    // No respawn machinery exists — _term is left for destroy() to reap.
+    assert.equal(typeof s.start, 'function')
+  })
+
+  it('destroy SIGTERMs the live PTY, clears timers, and stops being runnable', () => {
+    const s = makeLiveShell()
+    const term = s._term
+    s.destroy()
+    assert.deepEqual(term._calls.kill, ['SIGTERM'])
+    assert.equal(s._destroying, true)
+    assert.equal(s._shellAlive, false)
+    assert.equal(s._term, null)
+    assert.equal(s._mirrorTimer, null)
+  })
+
+  it('destroy after exit does not double-kill', () => {
+    const s = makeLiveShell()
+    const term = s._term
+    s._onShellExit({ exitCode: 0 }, 'exit')
+    s.destroy()
+    assert.equal(term._calls.kill.length, 0, 'no SIGTERM — PTY already exited')
+  })
+})


### PR DESCRIPTION
## What

Sub-issue **#5983** of epic #5982 — the provider that makes the embedded user-shell **real**: a PTY-only session that spawns the operator's `$SHELL` via node-pty, behind the security foundation already merged ahead of it:
- `userShell.enabled` config gate, default OFF (#5985a)
- WS primary-token gate on create + every `terminal_*` op (#5985b)
- mailbox/isTui PTY-injection fence (#5984)

## The provider

`user-shell-session.js` — lean, purpose-built (does **not** inherit ClaudeTuiSession's resume/respawn/permission machinery):
- Spawns `$SHELL` (→ `/bin/zsh`|`bash`|`sh` fallback) with explicit `cwd` (never the launchd `/` trap).
- PTY bytes coalesced → `terminal_output`, gated via `setTerminalMirrorActive` (#5837 parity).
- `writeTerminalInput` / `resizeTerminal` / `getTerminalSize`; #5311-parity socket-error guard (a per-session PTY fault can't crash the daemon).
- `static isUserShell = true` → **activates** the #5985b `terminal_*` gates; `isClaudeTui` stays false → mailbox fence holds.
- `isRunning` reflects PTY liveness (an open shell isn't reaped as idle).
- **No auto-respawn** — exit means gone (#5985 Guardian: `exit` resurrecting a root shell is a footgun). `_onShellExit` is idempotent, flips `isRunning` off, emits a final marker.
- `destroy()` SIGTERMs then SIGKILLs the **process group** after a grace window (liveness-probe + latch guarded). Contract stubs: `sendMessage`/`interrupt` no-op.

`providers.js`: registers `'user-shell'` (validates at module load). `session-manager.js`: **never persists** a user-shell session (`serializeState` skips `isUserShell`) so a disabled flag can't be defeated by a stale restore entry (audit C3).

## Now live

This flips the previously-inert gates on. With `userShell.enabled` true, a **primary-token** client can create a shell and drive it via `terminal_*`; everything else is rejected exactly as the merged gates specify.

## Tests

Class contract (registered + validates, `isUserShell`/`isClaudeTui`, capabilities, opt-picker, no-op stubs); terminal surface (write / resize / coalesce / mirror-gate); lifecycle (`isRunning`, idempotent exit + **no respawn**, destroy SIGTERM, no double-kill). Re-asserted the #5985a gate-opens test against the now-registered provider (**closes #5989**). 600+ server tests green; opt-forwarding + state-file lints green; eslint clean.

> The real-shell spawn path in `start()` is verified by the provider contract + manual/integration testing (unit tests inject a fake PTY — no real shell spawned in CI).

## Deferred (#5985 tail, tracked in `bearer-token-authority.md` §12)

Audit log, host-local per-session approval, revoke-kills-live-shells, boot-time orphan-shell reaper, auto-remove-session-on-exit. Plus the clients: dashboard tab (#5986), mobile tab (#5987).