### PR TITLE
feat(server): advertise userShell capability in auth_ok (#5986 server side)

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -177,6 +177,10 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // would silently re-open the swallowed-send wedge this fix closes.
     send, broadcast, getConnectedClientList, permissions,
     resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs,
+    // #5986 (epic #5982): whether the embedded user-shell terminal is enabled,
+    // surfaced as the `userShell` capability so the dashboard gates its "New
+    // shell" affordance. Optional — absent → false (fail-closed) for old servers.
+    userShellEnabled,
     // #4835: per-device active-session memory. Consulted below before
     // falling back to defaultSessionId / firstSessionId so a reconnect
     // restores whatever session the client was actually viewing instead
@@ -334,6 +338,12 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // (older server) fall back to requesting the three lists as before. The
     // request handlers stay live either way for post-connect refreshes.
     authBootstrap: true,
+    // #5986 (epic #5982) — the embedded user-shell terminal is enabled on this
+    // server (userShell.enabled). The dashboard gates its "New shell" affordance
+    // on this; the provider is hidden from listProviders(), so this flag is the
+    // only signal that creating a `user-shell` session will succeed. Absent /
+    // false on servers without it → the affordance stays hidden (fail-closed).
+    userShell: userShellEnabled === true,
   }
 
   // #3760, #3905: surface the effective inactivity timeouts so clients

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -859,6 +859,12 @@ export class WsServer {
       // the dashboard chip can hide instead of rendering against a
       // disabled timer).
       get streamStallTimeoutMs() { return self.config?.streamStallTimeoutMs ?? null },
+      // #5986 (epic #5982): whether the embedded user-shell terminal is enabled
+      // (userShell.enabled). Surfaced in auth_ok's capability map so the
+      // dashboard can show/hide the "New shell" affordance fail-closed (the
+      // user-shell provider is hidden from listProviders, so the picker can't
+      // advertise it). Late-bound getter so a test mutating self.config is seen.
+      get userShellEnabled() { return self.config?.userShell?.enabled === true },
       // #4835: per-device active-session memory consulted during reconnect.
       // sendPostAuthInfo treats this as optional, but production wiring
       // always supplies the default disk-backed store from the WsServer

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -20,6 +20,7 @@ import { handleAuthMessage, handlePairMessage, handlePairRequestMessage, handleK
 import { postPairLinkToDiscord } from './discord-pair-delivery.js'
 import { sendPostAuthInfo, replayHistory, flushPostAuthQueue, sendSessionInfo } from './ws-history.js'
 import { createDevicePreferences } from './device-preferences.js'
+import { isUserShellEnabled } from './config.js'
 import { createHttpHandler } from './http-routes.js'
 import { CheckpointManager } from './checkpoint-manager.js'
 import { DevPreviewManager } from './dev-preview.js'
@@ -864,7 +865,7 @@ export class WsServer {
       // dashboard can show/hide the "New shell" affordance fail-closed (the
       // user-shell provider is hidden from listProviders, so the picker can't
       // advertise it). Late-bound getter so a test mutating self.config is seen.
-      get userShellEnabled() { return self.config?.userShell?.enabled === true },
+      get userShellEnabled() { return isUserShellEnabled(self.config) },
       // #4835: per-device active-session memory consulted during reconnect.
       // sendPostAuthInfo treats this as optional, but production wiring
       // always supplies the default disk-backed store from the WsServer

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -225,6 +225,29 @@ describe('sendPostAuthInfo — eager-derivation storm fallback (#5622)', () => {
   })
 })
 
+// #5986 (epic #5982): the userShell capability gates the dashboard's "New shell"
+// affordance. The provider is hidden from listProviders(), so this flag is the
+// only signal that creating a user-shell session will succeed — fail-closed.
+describe('sendPostAuthInfo — userShell capability (#5986)', () => {
+  it('advertises userShell:true when the server enabled it', () => {
+    const ctx = makeCtx({ userShellEnabled: true })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(ctx._sends[0].capabilities.userShell, true)
+  })
+
+  it('advertises userShell:false when disabled or absent (fail-closed)', () => {
+    for (const v of [false, undefined]) {
+      const ctx = makeCtx(v === undefined ? {} : { userShellEnabled: v })
+      const ws = makeFakeWs()
+      registerClient(ctx, ws)
+      sendPostAuthInfo(ctx, ws)
+      assert.equal(ctx._sends[0].capabilities.userShell, false)
+    }
+  })
+})
+
 // #3760: surface the effective inactivity timeout in auth_ok so clients can
 // render their ActivityIndicator timeout warning against the real configured
 // value instead of a hardcoded reference.


### PR DESCRIPTION
## What

Server side of **#5986** (epic #5982) — surface whether the embedded user-shell is enabled so the dashboard can gate its "New shell" affordance.

## Why

The user-shell provider is intentionally **hidden from `listProviders()`** (#5994) — it's terminal-only, not a chat backend. So the provider picker can't tell the dashboard that creating a `user-shell` session will succeed. The existing #3272 `auth_ok.capabilities` map (a `record<string,boolean>` built exactly for "gate UI on server support") is the right channel.

## Changes

- `ws-server.js` `_historyCtx`: late-bound `userShellEnabled` getter → `config.userShell.enabled === true` (mirrors the existing `resultTimeoutMs`/`hardTimeoutMs`/`streamStallTimeoutMs` getters).
- `ws-history.js` `sendPostAuthInfo`: thread it through and add `userShell` to the capability map. Absent/false on older servers → the dashboard hides the affordance (**fail-closed**).
- No protocol schema change — `capabilities` is an open record and `.passthrough()`.

## Tests

`auth_ok` advertises `userShell: true` when enabled, `false` when disabled or absent. 143 ws-history + 153 ws-auth/server tests green; opt-forwarding + state-file lints green; eslint clean.

## Next (#5986 client side)

The dashboard consumes `capabilities.userShell` → shows a "New shell" button → `create_session{provider:'user-shell'}` → interactive `TerminalView` (reused from the #5835 remote viewer). That half is visual and best verified on-device, so it's a separate PR. This server change is independently complete and testable.