### PR TITLE
feat(dashboard): embedded user-shell terminal UI (#5986)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -71,7 +71,7 @@ import { useControlRoomState } from './hooks/useControlRoomState'
 import { useMessageRenderer } from './hooks/useMessageRenderer'
 import { SplitPane } from './components/SplitPane'
 import { ViewSwitcher } from './components/ViewSwitcher'
-import { DEFAULT_PROVIDER } from '@chroxy/protocol'
+import { DEFAULT_PROVIDER, USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, persistInterventionPing, loadPersistedInterventionPing, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
 import { applyOrderById } from './utils/reorderById'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
@@ -148,6 +148,19 @@ export function App() {
   const activeSessionProvider = useConnectionStore(s =>
     s.sessions.find(sess => sess.sessionId === s.activeSessionId)?.provider ?? null,
   )
+  // #5986 (epic #5982): the embedded user-shell terminal. The server advertises
+  // `userShell` in auth_ok.capabilities only when config.userShell.enabled is on
+  // AND the connecting client holds the primary token class, so gating the "New
+  // shell" affordance on it means paired devices / disabled hosts never see a
+  // dead button.
+  const userShellSupported = useConnectionStore(s => s.serverCapabilities?.userShell === true)
+  // Providers backed by a real PTY get the live Output terminal. claude-tui
+  // mirrors its TUI PTY alongside the parsed Chat view; user-shell is
+  // terminal-ONLY — a raw $SHELL with no Claude chat/tools/permissions
+  // semantics, so its session renders the terminal and hides the Chat tab.
+  const isTui = activeSessionProvider === DEFAULT_PROVIDER
+  const isUserShell = activeSessionProvider === USER_SHELL_PROVIDER
+  const isPtyProvider = isTui || isUserShell
   const defaultCwd = useConnectionStore(s => s.defaultCwd)
   const sessions = useConnectionStore(s => s.sessions)
   // #5665 — machine-wide monthly programmatic-credit meter (sidebar token view).
@@ -473,24 +486,31 @@ export function App() {
   // non-tui session (e.g. after switching), fall back to chat — the tab is
   // hidden there, so the user shouldn't be stranded on it.
   useEffect(() => {
-    // Only force away from the Output tab once we KNOW the active session is
-    // non-tui. During the initial-load / reconnect window the provider is still
-    // null/unknown — force-switching then would kick the operator out of a
+    // #5986 — user-shell is terminal-only (no Chat view). Force the operator
+    // onto the Output terminal whenever a user-shell session is active so they
+    // never land on the (hidden) Chat tab after a session switch.
+    if (isUserShell && viewMode !== 'terminal') {
+      setViewMode('terminal')
+      return
+    }
+    // Only force away from the Output tab once we KNOW the active session has no
+    // PTY mirror. During the initial-load / reconnect window the provider is
+    // still null/unknown — force-switching then would kick the operator out of a
     // persisted Output view for a claude-tui session (Copilot #5838).
-    if (viewMode === 'terminal' && activeSessionProvider != null && activeSessionProvider !== DEFAULT_PROVIDER) {
+    if (viewMode === 'terminal' && activeSessionProvider != null && !isPtyProvider) {
       setViewMode('chat')
       return
     }
     // Gate the opt-in on a live socket and depend on connectionPhase, so a
     // reconnect (which clears the server-side terminalSessionIds set) re-runs
     // this effect and re-subscribes — otherwise the mirror silently stops
-    // updating until the user toggles tabs (Copilot #5838).
-    const isTui = activeSessionProvider === DEFAULT_PROVIDER
-    if (viewMode === 'terminal' && isTui && activeSessionId && connectionPhase === 'connected') {
+    // updating until the user toggles tabs (Copilot #5838). Both claude-tui and
+    // user-shell expose a live PTY mirror, so subscribe for either (#5986).
+    if (viewMode === 'terminal' && isPtyProvider && activeSessionId && connectionPhase === 'connected') {
       subscribeTerminalMirror(activeSessionId)
       return () => unsubscribeTerminalMirror(activeSessionId)
     }
-  }, [viewMode, activeSessionId, activeSessionProvider, connectionPhase, subscribeTerminalMirror, unsubscribeTerminalMirror, setViewMode])
+  }, [viewMode, activeSessionId, activeSessionProvider, isUserShell, isPtyProvider, connectionPhase, subscribeTerminalMirror, unsubscribeTerminalMirror, setViewMode])
   const setModel = useConnectionStore(s => s.setModel)
   const setPermissionMode = useConnectionStore(s => s.setPermissionMode)
   const setThinkingLevel = useConnectionStore(s => s.setThinkingLevel)
@@ -1477,6 +1497,16 @@ export function App() {
     openCreateSession()
   }, [openCreateSession])
 
+  // #5986 (epic #5982) — create an embedded user-shell directly. Unlike a chat
+  // session this skips the provider-picker modal: user-shell is HIDDEN from the
+  // chat provider list and server-gated on the primary token + the userShell
+  // capability, so there are no per-session options to pick. The session lands
+  // terminal-only (see the isUserShell branch — forces the Output view, hides
+  // Chat). cwd falls back to the host default when no repo is selected.
+  const handleNewShell = useCallback(() => {
+    createSession({ name: 'Shell', cwd: defaultCwd ?? undefined, provider: USER_SHELL_PROVIDER })
+  }, [createSession, defaultCwd])
+
   // #5202 — open the create-session picker pre-filled for an Investigate
   // action: cwd = the repo path, and the reason note seeded into the new
   // session's composer once it's created. The user still picks
@@ -1830,6 +1860,7 @@ export function App() {
         onMarkAllNotificationsRead={markAllSessionNotificationsRead}
         onDismissNotification={dismissSessionNotification}
         onNewSession={handleNewSession}
+        onNewShell={userShellSupported ? handleNewShell : undefined}
         onToggleSkillsPanel={() => {
           setSkillsPanelOpen(prev => {
             const next = !prev
@@ -2049,7 +2080,8 @@ export function App() {
               splitMode={splitMode}
               setSplitMode={setSplitMode}
               persistSplitMode={persistSplitMode}
-              showTerminalTab={activeSessionProvider === DEFAULT_PROVIDER}
+              showChatTab={!isUserShell}
+              showTerminalTab={isPtyProvider}
               showConsoleTab={showConsoleTab}
               unreadSystemCount={unreadSystemCount}
               checkpointsOpen={checkpointsOpen}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -480,11 +480,12 @@ export function App() {
   const createSession = useConnectionStore(s => s.createSession)
   const confirmSessionClose = useConnectionStore(s => s.confirmSessionClose)
   const setViewMode = useConnectionStore(s => s.setViewMode)
-  // #5835 (PR2): drive the live PTY mirror's opt-in. While the Output tab is
-  // shown for a claude-tui session, opt into terminal_output; opt out on leave /
-  // session switch / provider change. If the Output tab is somehow active on a
-  // non-tui session (e.g. after switching), fall back to chat — the tab is
-  // hidden there, so the user shouldn't be stranded on it.
+  // #5835 (PR2) / #5986: drive the live PTY mirror's opt-in. While the Output
+  // tab is shown for a PTY-backed session (claude-tui OR user-shell — see
+  // isPtyProvider), opt into terminal_output; opt out on leave / session switch
+  // / provider change. If the Output tab is somehow active on a session with no
+  // PTY mirror (e.g. after switching to a chat provider), fall back to chat —
+  // the tab is hidden there, so the user shouldn't be stranded on it.
   useEffect(() => {
     // #5986 — user-shell is terminal-only (no Chat view). Force the operator
     // onto the Output terminal whenever a user-shell session is active so they

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -46,6 +46,10 @@ export interface AppHeaderProps {
   onDismissNotification: ComponentProps<typeof NotificationsWidget>['onDismiss']
   // Overflow menu
   onNewSession: () => void
+  // #5986 — create an embedded user-shell. Undefined when the server doesn't
+  // advertise the `userShell` capability (flag off, or this client isn't the
+  // primary token), which filters the "New Shell" row out of the menu entirely.
+  onNewShell?: () => void
   onToggleSkillsPanel: () => void
   showCopyTranscript: boolean
   transcriptCopied: boolean
@@ -191,6 +195,16 @@ export function AppHeader(props: AppHeaderProps) {
               icon: '+',
               title: `New session (${formatShortcutKeys('Cmd+N')})`,
               onClick: props.onNewSession,
+            },
+            // #5986 — embedded user-shell. `onNewShell` is undefined unless the
+            // server advertises the userShell capability, so the menu filters
+            // this row out (falsy onClick) on hosts where it isn't available.
+            {
+              id: 'new-shell',
+              label: 'New Shell',
+              icon: '\u{1F5A5}',
+              title: 'Open an embedded terminal shell',
+              onClick: props.onNewShell,
             },
             {
               id: 'skills',

--- a/packages/dashboard/src/components/ViewSwitcher.test.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * ViewSwitcher tab-visibility tests.
+ *
+ * Pins the provider-aware tab gates:
+ *   - #5835: the "Output" tab appears only for providers with a real PTY
+ *     (claude-tui, and user-shell since #5986) via `showTerminalTab`.
+ *   - #5986: the "Chat" tab is hidden for terminal-only providers
+ *     (user-shell — a raw $SHELL has no parsed chat surface) via
+ *     `showChatTab`. Both default to shown so the common chat-provider
+ *     path is unaffected.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ViewSwitcher } from './ViewSwitcher'
+
+afterEach(cleanup)
+
+function renderSwitcher(overrides: Partial<Parameters<typeof ViewSwitcher>[0]> = {}) {
+  return render(
+    <ViewSwitcher
+      viewMode="terminal"
+      setViewMode={vi.fn()}
+      splitMode={null}
+      setSplitMode={vi.fn()}
+      persistSplitMode={vi.fn()}
+      showConsoleTab={false}
+      unreadSystemCount={0}
+      checkpointsOpen={false}
+      setCheckpointsOpen={vi.fn()}
+      {...overrides}
+    />,
+  )
+}
+
+describe('ViewSwitcher tab gates', () => {
+  it('shows both Chat and Output by default (chat provider path unaffected)', () => {
+    renderSwitcher({ showTerminalTab: true })
+    expect(screen.getByRole('button', { name: 'Chat' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Output' })).toBeInTheDocument()
+  })
+
+  it('hides the Output tab for providers without a PTY (showTerminalTab=false)', () => {
+    renderSwitcher({ showTerminalTab: false })
+    expect(screen.getByRole('button', { name: 'Chat' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Output' })).not.toBeInTheDocument()
+  })
+
+  it('hides the Chat tab for terminal-only providers (#5986 user-shell)', () => {
+    renderSwitcher({ showChatTab: false, showTerminalTab: true })
+    expect(screen.queryByRole('button', { name: 'Chat' })).not.toBeInTheDocument()
+    // The Output terminal stays — that's the only surface a user-shell has.
+    expect(screen.getByRole('button', { name: 'Output' })).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -10,15 +10,18 @@ export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'cons
 /** Scrollable tab bar with arrow buttons when overflowing */
 export function ViewSwitcher({
   viewMode, setViewMode, splitMode, setSplitMode, persistSplitMode,
-  showTerminalTab = true, showConsoleTab, unreadSystemCount, checkpointsOpen, setCheckpointsOpen,
+  showChatTab = true, showTerminalTab = true, showConsoleTab, unreadSystemCount, checkpointsOpen, setCheckpointsOpen,
 }: {
   viewMode: string
   setViewMode: (m: ViewMode) => void
   splitMode: SplitDirection | null
   setSplitMode: (m: SplitDirection | null) => void
   persistSplitMode: (m: SplitDirection | null) => void
-  // #5835 (PR2): the "Output" tab is the live claude-tui PTY mirror — shown only
-  // for claude-tui sessions (the only provider with a real PTY to mirror).
+  // #5986: the Chat tab is hidden for terminal-only providers (user-shell) —
+  // a raw $SHELL has no parsed chat surface, only the Output terminal.
+  showChatTab?: boolean
+  // #5835 (PR2): the "Output" tab is the live claude-tui PTY mirror — shown for
+  // providers with a real PTY (claude-tui, and user-shell since #5986).
   showTerminalTab?: boolean
   showConsoleTab: boolean
   unreadSystemCount: number
@@ -101,7 +104,9 @@ export function ViewSwitcher({
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
       >
-        <button className={`view-tab${viewMode === 'chat' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('chat'); setSplitMode(null); persistSplitMode(null) }} type="button">Chat</button>
+        {showChatTab && (
+          <button className={`view-tab${viewMode === 'chat' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('chat'); setSplitMode(null); persistSplitMode(null) }} type="button">Chat</button>
+        )}
         {showTerminalTab && (
           <button className={`view-tab${viewMode === 'terminal' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('terminal'); setSplitMode(null); persistSplitMode(null) }} type="button">Output</button>
         )}

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -47,6 +47,16 @@ export declare const MIN_PROTOCOL_VERSION = 1;
  */
 export declare const DEFAULT_PROVIDER = "claude-tui";
 /**
+ * #5986 (epic #5982): the embedded user-shell provider id. A user-shell session
+ * is a raw `$SHELL` PTY with NO Claude semantics — terminal-only, no chat, no
+ * tools/permissions/streaming. Single-sourced here so the server registry
+ * (`providers.js`), the WS create gate, and the clients (which render it
+ * terminal-only and gate the "New shell" button on the `userShell` capability)
+ * all agree on exactly one string. Server-gated behind `config.userShell.enabled`
+ * + a WS primary-token check — see `docs/security/bearer-token-authority.md`.
+ */
+export declare const USER_SHELL_PROVIDER = "user-shell";
+/**
  * #5835 / #5839: the fixed grid size of the claude-tui PTY. The server spawns
  * the TUI at this size and the dashboard renders the live mirror at exactly this
  * size (letterboxed), so the mirror stays 1:1 faithful. Single-sourced here so

--- a/packages/protocol/dist/index.js
+++ b/packages/protocol/dist/index.js
@@ -47,6 +47,16 @@ export const MIN_PROTOCOL_VERSION = 1;
  */
 export const DEFAULT_PROVIDER = 'claude-tui';
 /**
+ * #5986 (epic #5982): the embedded user-shell provider id. A user-shell session
+ * is a raw `$SHELL` PTY with NO Claude semantics — terminal-only, no chat, no
+ * tools/permissions/streaming. Single-sourced here so the server registry
+ * (`providers.js`), the WS create gate, and the clients (which render it
+ * terminal-only and gate the "New shell" button on the `userShell` capability)
+ * all agree on exactly one string. Server-gated behind `config.userShell.enabled`
+ * + a WS primary-token check — see `docs/security/bearer-token-authority.md`.
+ */
+export const USER_SHELL_PROVIDER = 'user-shell';
+/**
  * #5835 / #5839: the fixed grid size of the claude-tui PTY. The server spawns
  * the TUI at this size and the dashboard renders the live mirror at exactly this
  * size (letterboxed), so the mirror stays 1:1 faithful. Single-sourced here so

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -52,6 +52,17 @@ export const MIN_PROTOCOL_VERSION = 1
 export const DEFAULT_PROVIDER = 'claude-tui'
 
 /**
+ * #5986 (epic #5982): the embedded user-shell provider id. A user-shell session
+ * is a raw `$SHELL` PTY with NO Claude semantics — terminal-only, no chat, no
+ * tools/permissions/streaming. Single-sourced here so the server registry
+ * (`providers.js`), the WS create gate, and the clients (which render it
+ * terminal-only and gate the "New shell" button on the `userShell` capability)
+ * all agree on exactly one string. Server-gated behind `config.userShell.enabled`
+ * + a WS primary-token check — see `docs/security/bearer-token-authority.md`.
+ */
+export const USER_SHELL_PROVIDER = 'user-shell'
+
+/**
  * #5835 / #5839: the fixed grid size of the claude-tui PTY. The server spawns
  * the TUI at this size and the dashboard renders the live mirror at exactly this
  * size (letterboxed), so the mirror stays 1:1 faithful. Single-sourced here so

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -4,6 +4,7 @@
  * Handles: list_sessions, switch_session, create_session, destroy_session,
  *          rename_session, subscribe_sessions, unsubscribe_sessions
  */
+import { USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError, isSessionViewer, isUserShellSession } from '../handler-utils.js'
 import { getRegistryForProvider } from '../models.js'
 import { createLogger, loggerForSession } from '../logger.js'
@@ -148,7 +149,7 @@ function handleCreateSession(ws, client, msg, ctx) {
   // finding C1). The `userShell.enabled` flag is separately enforced as the
   // authoritative gate in SessionManager.createSession (covers every spawn
   // path); this is the token-class half, surfaced early with a clean code.
-  if (provider === 'user-shell' && client.isPrimaryToken !== true) {
+  if (provider === USER_SHELL_PROVIDER && client.isPrimaryToken !== true) {
     ctx.transport.send(ws, {
       type: 'session_error',
       code: 'PRIMARY_TOKEN_REQUIRED',

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -25,7 +25,7 @@ import { CodexSession } from './codex-session.js'
 import { UserShellSession } from './user-shell-session.js'
 import { registerProviderRegistry } from './models.js'
 import { BILLING_CLASSES } from './billing-class.js'
-import { DEFAULT_PROVIDER } from '@chroxy/protocol'
+import { DEFAULT_PROVIDER, USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import {
   hasClaudeOAuthCreds,
   hasCodexOAuthCreds,
@@ -55,8 +55,9 @@ const PROVIDERS = {
   // #5983 (epic #5982) — general-purpose user shell ($SHELL via node-pty).
   // Gated OFF by default (userShell.enabled, #5985a) and primary-token-only
   // on create + every terminal_* op (#5985b); excluded from mailbox injection
-  // (#5984). PTY-only — no chat/turn semantics.
-  'user-shell': UserShellSession,
+  // (#5984). PTY-only — no chat/turn semantics. Provider id single-sourced
+  // from @chroxy/protocol (#5986) so server + clients can't drift.
+  [USER_SHELL_PROVIDER]: UserShellSession,
 }
 
 // The default provider lives in @chroxy/protocol so the server, dashboard,
@@ -65,14 +66,14 @@ const PROVIDERS = {
 // (server-cli.js, doctor.js, session-manager.js) keep importing it from the
 // provider registry. Flipped to claude-tui ahead of the 2026-06-15 cutover
 // (#5819) — see the protocol constant's doc for the billing rationale.
-export { DEFAULT_PROVIDER }
+export { DEFAULT_PROVIDER, USER_SHELL_PROVIDER }
 
 // Names hidden from listProviders() (backward-compat aliases, etc.)
 // #5994: user-shell is NOT a chat provider — it's a terminal-only session
 // created via a dedicated shell affordance (#5986/#5987), never the chat
 // provider picker. Hiding it keeps it out of listProviders() so it can't be
 // selected as a (fake-ready) chat backend. getProvider/create still resolve it.
-const HIDDEN = new Set(['user-shell'])
+const HIDDEN = new Set([USER_SHELL_PROVIDER])
 
 /** Required methods every provider class prototype must expose. */
 const REQUIRED_METHODS = ['sendMessage', 'interrupt', 'setModel', 'setPermissionMode', 'start', 'destroy']

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -15,6 +15,7 @@
  */
 
 import { realpathSync, existsSync } from 'fs'
+import { USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { createLogger } from './logger.js'
 
@@ -77,7 +78,7 @@ export class UserShellSession extends BaseSession {
 
   constructor(opts = {}) {
     // Picker forwards every BaseSession opt; `provider` is fixed to user-shell.
-    super(buildBaseSessionOpts(opts, { provider: 'user-shell' }))
+    super(buildBaseSessionOpts(opts, { provider: USER_SHELL_PROVIDER }))
     this._term = null
     this._ptyExited = false
     this._destroying = false

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -338,12 +338,17 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // (older server) fall back to requesting the three lists as before. The
     // request handlers stay live either way for post-connect refreshes.
     authBootstrap: true,
-    // #5986 (epic #5982) — the embedded user-shell terminal is enabled on this
-    // server (userShell.enabled). The dashboard gates its "New shell" affordance
-    // on this; the provider is hidden from listProviders(), so this flag is the
-    // only signal that creating a `user-shell` session will succeed. Absent /
-    // false on servers without it → the affordance stays hidden (fail-closed).
-    userShell: userShellEnabled === true,
+    // #5986 (epic #5982) — the embedded user-shell terminal is available to THIS
+    // client: the server has it enabled (userShell.enabled) AND this connection
+    // holds the primary token. Both conditions of the create gate are reflected
+    // here (config gate #5985a + primary-token gate #5985b) so a paired
+    // (non-primary) device never sees a "New shell" affordance it would only get
+    // a PRIMARY_TOKEN_REQUIRED rejection from. The provider is hidden from
+    // listProviders(), so this flag is the only signal that creating a
+    // `user-shell` session will succeed. Absent / false on servers without it, on
+    // hosts with it disabled, or for paired clients → the affordance stays hidden
+    // (fail-closed). The server gates remain the authority regardless.
+    userShell: userShellEnabled === true && client?.isPrimaryToken === true,
   }
 
   // #3760, #3905: surface the effective inactivity timeouts so clients

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -226,22 +226,35 @@ describe('sendPostAuthInfo — eager-derivation storm fallback (#5622)', () => {
 })
 
 // #5986 (epic #5982): the userShell capability gates the dashboard's "New shell"
-// affordance. The provider is hidden from listProviders(), so this flag is the
-// only signal that creating a user-shell session will succeed — fail-closed.
+// affordance. It mirrors BOTH halves of the server create gate — the config flag
+// (userShell.enabled, #5985a) AND the primary-token class (#5985b) — so a paired
+// (non-primary) client never sees a button it would only get a
+// PRIMARY_TOKEN_REQUIRED rejection from. The provider is hidden from
+// listProviders(), so this flag is the only signal a user-shell create succeeds.
 describe('sendPostAuthInfo — userShell capability (#5986)', () => {
-  it('advertises userShell:true when the server enabled it', () => {
+  it('advertises userShell:true only when enabled AND the client is primary', () => {
     const ctx = makeCtx({ userShellEnabled: true })
     const ws = makeFakeWs()
-    registerClient(ctx, ws)
+    registerClient(ctx, ws, { isPrimaryToken: true })
     sendPostAuthInfo(ctx, ws)
     assert.equal(ctx._sends[0].capabilities.userShell, true)
   })
 
-  it('advertises userShell:false when disabled or absent (fail-closed)', () => {
+  it('advertises userShell:false to a paired (non-primary) client even when enabled', () => {
+    for (const primary of [false, undefined]) {
+      const ctx = makeCtx({ userShellEnabled: true })
+      const ws = makeFakeWs()
+      registerClient(ctx, ws, primary === undefined ? {} : { isPrimaryToken: primary })
+      sendPostAuthInfo(ctx, ws)
+      assert.equal(ctx._sends[0].capabilities.userShell, false)
+    }
+  })
+
+  it('advertises userShell:false when disabled or absent (fail-closed), even for a primary client', () => {
     for (const v of [false, undefined]) {
       const ctx = makeCtx(v === undefined ? {} : { userShellEnabled: v })
       const ws = makeFakeWs()
-      registerClient(ctx, ws)
+      registerClient(ctx, ws, { isPrimaryToken: true })
       sendPostAuthInfo(ctx, ws)
       assert.equal(ctx._sends[0].capabilities.userShell, false)
     }


### PR DESCRIPTION
## Summary

Wires the **dashboard client side** of the embedded user-shell terminal (epic #5982). The operator can now open a real `$SHELL` inside Chroxy from the dashboard and drive it interactively — the CLI-access-in-Chroxy ask.

The server foundation already landed:
- #5983 — PTY-only `UserShellSession` (raw `$SHELL` via node-pty, no Claude semantics)
- #5985a — `config.userShell.enabled` gate (off by default)
- #5985b — WS primary-token gate on create + every `terminal_*` op (paired devices can't reach a shell)
- #5984 — kind discriminator + mailbox fence
- #5986 server side (#5995) — advertises `userShell` in `auth_ok.capabilities`

## Client changes

- **"New Shell"** action in the header overflow (`⋯`) menu, gated on `serverCapabilities.userShell`. Creates a `provider: 'user-shell'` session directly — no provider-picker modal (the provider is hidden from the chat list and has no per-session options).
- **Terminal-only render** for a user-shell session: the view is forced to the Output terminal and the **Chat tab is hidden** (a raw shell has no parsed chat surface).
- Reuses the **#5835** live PTY mirror + interactive `MultiTerminalView` (keystrokes → PTY, resize sync), generalizing the TUI-only check to "provider backed by a PTY" (`isPtyProvider = isTui || isUserShell`).

## Single-sourcing

`USER_SHELL_PROVIDER = 'user-shell'` now lives in `@chroxy/protocol` (mirroring `DEFAULT_PROVIDER`), consumed by the server registry, the WS create gate, and the dashboard so the id can't drift. Protocol `dist/` rebuilt.

## Gating chain (defence in depth)

`serverCapabilities.userShell` is true only when `config.userShell.enabled` **and** the client holds the primary token — so paired devices / disabled hosts never see a dead "New Shell" button, and even if the button were forced, the server's create gate (#5985b) + config gate (#5985a) reject it.

## Tests

- `ViewSwitcher.test.tsx` — tab-visibility gates (`showChatTab` / `showTerminalTab`).
- Existing `HeaderOverflowMenu` falsy-`onClick` filter tests structurally cover the capability gate that hides "New Shell".
- Full dashboard suite green (3795). Affected server test files green (single-sourcing is behavior-preserving).

## Verification note

Dashboard typecheck + full vitest suite pass. On-device/browser visual verification of the live shell session (open "New Shell" → type commands → resize) is recommended before relying on it day-to-day — the wire path is the same one #5835 already exercises.

## Known minor (follow-up candidate)

If an operator explicitly enables **Split** view while a user-shell session is active, the chat half renders empty (split state is independent of the forced terminal view). Low-impact power-user edge; can be a small follow-up (clear/disable split for terminal-only providers).

Related to #5986, #5982