### PR TITLE
fix(dashboard): terminal-only providers no longer trap tabs or split (#5997)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -487,10 +487,13 @@ export function App() {
   // PTY mirror (e.g. after switching to a chat provider), fall back to chat —
   // the tab is hidden there, so the user shouldn't be stranded on it.
   useEffect(() => {
-    // #5986 — user-shell is terminal-only (no Chat view). Force the operator
-    // onto the Output terminal whenever a user-shell session is active so they
-    // never land on the (hidden) Chat tab after a session switch.
-    if (isUserShell && viewMode !== 'terminal') {
+    // #5986/#5997 — user-shell has no Chat view (the tab is hidden). Redirect
+    // the operator to the Output terminal ONLY from the now-hidden Chat tab
+    // (e.g. a persisted 'chat' viewMode carried over from a prior session). We
+    // deliberately do NOT force away from other tabs (Files / System / Diff /
+    // Envs are useful for a shell's cwd) — snapping back from every non-terminal
+    // view trapped the operator on the terminal (#5997).
+    if (isUserShell && viewMode === 'chat') {
       setViewMode('terminal')
       return
     }
@@ -607,6 +610,17 @@ export function App() {
     openSettings,
     closeControlRoom,
   } = useControlRoomState()
+  // #5997 — split view is a chat|terminal pane pair; it makes no sense for a
+  // terminal-only user-shell session (the chat half renders empty). The Split
+  // button is hidden for user-shell in ViewSwitcher, but a split carried over
+  // from a prior chat session would persist — clear it when a user-shell
+  // session becomes active so the operator is never left with an empty pane.
+  useEffect(() => {
+    if (isUserShell && splitMode) {
+      setSplitMode(null)
+      persistSplitMode(null)
+    }
+  }, [isUserShell, splitMode, setSplitMode])
   // #5206 — the session id awaiting close-confirmation, or null when no
   // confirm is pending. Drives the ConfirmDialog rendered near the modals.
   const [closeConfirmSessionId, setCloseConfirmSessionId] = useState<string | null>(null)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -939,6 +939,9 @@ export function App() {
     viewMode,
     setViewMode,
     setSplitMode,
+    // #5997 — gate the chat/terminal toggle + split shortcuts off for a
+    // terminal-only user-shell session (no chat surface to toggle/split).
+    terminalOnly: isUserShell,
     setPaletteOpen,
     setSidebarOpen,
     setSettingsOpen,

--- a/packages/dashboard/src/components/ViewSwitcher.test.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.test.tsx
@@ -52,14 +52,21 @@ describe('ViewSwitcher tab gates', () => {
     expect(screen.getByRole('button', { name: 'Output' })).toBeInTheDocument()
   })
 
-  it('hides the Split button for terminal-only providers (#5997)', () => {
-    // Split is a chat|terminal pane pair — meaningless without a chat surface,
-    // so it tracks showChatTab. Present by default, gone when chat is hidden.
+  it('shows Split only when BOTH chat and terminal surfaces exist (#5997)', () => {
+    // Split renders a ChatView + a terminal pane, so it needs both — present
+    // only when showChatTab AND showTerminalTab (claude-tui today).
     renderSwitcher({ showChatTab: true, showTerminalTab: true })
     expect(screen.getByRole('button', { name: 'Split' })).toBeInTheDocument()
 
+    // Terminal-only provider (user-shell): no chat surface → hidden.
     cleanup()
     renderSwitcher({ showChatTab: false, showTerminalTab: true })
+    expect(screen.queryByRole('button', { name: 'Split' })).not.toBeInTheDocument()
+
+    // Chat-only provider (no PTY/Output): no terminal surface → hidden too,
+    // otherwise the terminal half would render empty (Copilot review).
+    cleanup()
+    renderSwitcher({ showChatTab: true, showTerminalTab: false })
     expect(screen.queryByRole('button', { name: 'Split' })).not.toBeInTheDocument()
   })
 })

--- a/packages/dashboard/src/components/ViewSwitcher.test.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.test.tsx
@@ -51,4 +51,15 @@ describe('ViewSwitcher tab gates', () => {
     // The Output terminal stays — that's the only surface a user-shell has.
     expect(screen.getByRole('button', { name: 'Output' })).toBeInTheDocument()
   })
+
+  it('hides the Split button for terminal-only providers (#5997)', () => {
+    // Split is a chat|terminal pane pair — meaningless without a chat surface,
+    // so it tracks showChatTab. Present by default, gone when chat is hidden.
+    renderSwitcher({ showChatTab: true, showTerminalTab: true })
+    expect(screen.getByRole('button', { name: 'Split' })).toBeInTheDocument()
+
+    cleanup()
+    renderSwitcher({ showChatTab: false, showTerminalTab: true })
+    expect(screen.queryByRole('button', { name: 'Split' })).not.toBeInTheDocument()
+  })
 })

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -114,11 +114,16 @@ export function ViewSwitcher({
             panel slot (its header "Control Room" button) and opens as its own
             session-independent top-level tab in the SessionBar strip — not a
             per-session view tab here. */}
-        <button
-          className={`view-tab${splitMode ? ' active' : ''}`}
-          onClick={() => { const next: SplitDirection | null = splitMode ? null : 'horizontal'; setSplitMode(next); persistSplitMode(next) }}
-          type="button" title={`Split view (${formatShortcutKeys('Cmd+\\')})`}
-        >Split</button>
+        {/* #5997 — Split is a chat|terminal pane pair, so it needs a chat
+            surface. Hidden for terminal-only providers (user-shell) where the
+            Chat tab is also hidden — otherwise the chat half renders empty. */}
+        {showChatTab && (
+          <button
+            className={`view-tab${splitMode ? ' active' : ''}`}
+            onClick={() => { const next: SplitDirection | null = splitMode ? null : 'horizontal'; setSplitMode(next); persistSplitMode(next) }}
+            type="button" title={`Split view (${formatShortcutKeys('Cmd+\\')})`}
+          >Split</button>
+        )}
         <button className={`view-tab${viewMode === 'files' ? ' active' : ''}`} onClick={() => setViewMode('files')} type="button">Files</button>
         <button className={`view-tab${viewMode === 'system' ? ' active' : ''}`} onClick={() => { setViewMode('system'); setSplitMode(null); persistSplitMode(null) }} type="button">
           System{unreadSystemCount > 0 && <span className="system-badge">{unreadSystemCount}</span>}

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -114,10 +114,12 @@ export function ViewSwitcher({
             panel slot (its header "Control Room" button) and opens as its own
             session-independent top-level tab in the SessionBar strip — not a
             per-session view tab here. */}
-        {/* #5997 — Split is a chat|terminal pane pair, so it needs a chat
-            surface. Hidden for terminal-only providers (user-shell) where the
-            Chat tab is also hidden — otherwise the chat half renders empty. */}
-        {showChatTab && (
+        {/* #5997 — Split renders BOTH a ChatView and a terminal pane, so it
+            needs both surfaces present. Hidden unless the provider has a Chat
+            tab AND an Output terminal — i.e. only claude-tui today. For a
+            terminal-only provider (user-shell, no chat) or a chat-only provider
+            (no PTY/Output) one half would render empty. */}
+        {showChatTab && showTerminalTab && (
           <button
             className={`view-tab${splitMode ? ' active' : ''}`}
             onClick={() => { const next: SplitDirection | null = splitMode ? null : 'horizontal'; setSplitMode(next); persistSplitMode(next) }}

--- a/packages/dashboard/src/hooks/useShortcutDispatch.test.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.test.ts
@@ -242,6 +242,20 @@ describe('useShortcutDispatch', () => {
     expect(props.setViewMode).toHaveBeenCalledWith('terminal')
   })
 
+  it('view.toggleChatTerminal is a no-op for a terminal-only provider (#5997)', () => {
+    const props = makeProps({ viewMode: 'terminal', terminalOnly: true })
+    renderHook(() => useShortcutDispatch(props))
+    fireKey({ key: 't', metaKey: true })
+    expect(props.setViewMode).not.toHaveBeenCalled()
+  })
+
+  it('view.cycleSplit is a no-op for a terminal-only provider (#5997)', () => {
+    const props = makeProps({ terminalOnly: true })
+    renderHook(() => useShortcutDispatch(props))
+    fireKey({ key: '\\', metaKey: true })
+    expect(props.setSplitMode).not.toHaveBeenCalled()
+  })
+
   it('session.copyTranscript calls handleCopyTranscript', () => {
     const props = makeProps()
     renderHook(() => useShortcutDispatch(props))

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -43,6 +43,14 @@ export interface ShortcutDispatchProps {
   viewMode: ViewMode | string
   setViewMode: (m: ViewMode) => void
   setSplitMode: (fn: (prev: SplitDirection | null) => SplitDirection | null) => void
+  /**
+   * #5997 — the active session is a terminal-only provider (user-shell): no
+   * Chat view, so the chat/terminal toggle and split shortcuts are no-ops.
+   * Gating them here (rather than relying on the App-level cleanup effects)
+   * avoids the one-frame empty-chat-pane flicker those keystrokes would
+   * otherwise cause before the effect snaps the view back.
+   */
+  terminalOnly?: boolean
   setPaletteOpen: (fn: (prev: boolean) => boolean) => void
   setSidebarOpen: (fn: (prev: boolean) => boolean) => void
   setSettingsOpen: (fn: (prev: boolean) => boolean) => void
@@ -71,6 +79,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     viewMode,
     setViewMode,
     setSplitMode,
+    terminalOnly,
     setPaletteOpen,
     setSidebarOpen,
     setSettingsOpen,
@@ -205,9 +214,16 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
             setShowCreateSession(true)
             break
           case 'view.toggleChatTerminal':
+            // #5997 — a terminal-only provider has no Chat view; the toggle
+            // would flash an empty chat pane before the redirect effect snaps
+            // it back. No-op it at the source instead.
+            if (terminalOnly) break
             setViewMode(viewMode === 'chat' ? 'terminal' : 'chat')
             break
           case 'view.cycleSplit':
+            // #5997 — split is a chat|terminal pane pair; no chat surface on a
+            // terminal-only provider, so skip it here too.
+            if (terminalOnly) break
             setSplitMode(prev => {
               const next = prev === null ? 'horizontal' : prev === 'horizontal' ? 'vertical' : null
               persistSplitMode(next)
@@ -264,6 +280,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     handleCloseSession,
     viewMode,
     setViewMode,
+    terminalOnly,
     sendInterrupt,
     handleCopyTranscript,
     shortcutRegistry,


### PR DESCRIPTION
## Summary

Follow-up to #5996 (embedded user-shell dashboard UI). Two rough edges flagged in that PR's review are fixed here.

### 1. Non-terminal tabs were inert on a shell session

A user-shell session forced `viewMode` back to the Output terminal from **every** non-terminal view, so clicking **Files / System / Diff / Envs / Snapshots / Pool** was clickable-but-inert (instant snap-back). Those panes are actually useful for a shell session (inspect the shell's cwd, view logs).

**Fix:** redirect to the Output terminal **only from the now-hidden Chat tab** (a persisted `'chat'` viewMode carried over from a prior session) — not from every view. All other tabs now work normally for a user-shell session.

### 2. Split left an empty chat half

Split view is a `chat | terminal` pane pair, meaningless for a terminal-only provider (the chat half renders empty).

**Fix:** hide the Split button for terminal-only providers (it now tracks `showChatTab` in `ViewSwitcher`), and clear any split carried over from a prior chat session when a user-shell session becomes active.

## Tests
- `ViewSwitcher.test.tsx` — Split button hidden when `showChatTab` is false.
- Full dashboard suite green (3799).

## Verification note
Visual/browser verification of the live behavior (open a shell → click Files/Diff, confirm they render and don't snap back; confirm no Split button) is recommended but the logic is covered by typecheck + tests.

Closes #5997