### PR TITLE
feat(app): mobile user-shell terminal scaffold — read-only mirror (#5987)

### DIFF
--- a/packages/app/src/__tests__/store/terminal-mirror.test.ts
+++ b/packages/app/src/__tests__/store/terminal-mirror.test.ts
@@ -1,0 +1,109 @@
+import {
+  useConnectionStore,
+  createEmptySessionState,
+  _testMessageHandler,
+} from '../../store/connection';
+
+// #5835 / #5987 — read-only PTY mirror channel on mobile (PR1). Covers the new
+// store actions (terminal_subscribe / terminal_unsubscribe / terminal_resize)
+// and the terminal_output receive path that feeds appendTerminalData.
+
+const mockOpenSocket = () => {
+  const sent: Record<string, unknown>[] = [];
+  const socket = {
+    readyState: 1, // OPEN
+    send: (data: string) => { sent.push(JSON.parse(data)); },
+    close: jest.fn(),
+  };
+  useConnectionStore.setState({ socket: socket as unknown as WebSocket });
+  return sent;
+};
+
+beforeEach(() => {
+  useConnectionStore.setState({
+    terminalBuffer: '',
+    terminalRawBuffer: '',
+    sessionStates: { default: createEmptySessionState() },
+    activeSessionId: 'default',
+    socket: null,
+  });
+});
+
+describe('subscribeTerminalMirror', () => {
+  it('sends terminal_subscribe for a non-empty sessionId on an open socket', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().subscribeTerminalMirror('sess-1');
+    expect(sent).toEqual([{ type: 'terminal_subscribe', sessionId: 'sess-1' }]);
+  });
+
+  it('does nothing for an empty sessionId', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().subscribeTerminalMirror('');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('no-ops (does not throw) when the socket is not open', () => {
+    useConnectionStore.setState({ socket: null });
+    expect(() => useConnectionStore.getState().subscribeTerminalMirror('sess-1')).not.toThrow();
+  });
+});
+
+describe('unsubscribeTerminalMirror', () => {
+  it('sends terminal_unsubscribe for a non-empty sessionId', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().unsubscribeTerminalMirror('sess-1');
+    expect(sent).toEqual([{ type: 'terminal_unsubscribe', sessionId: 'sess-1' }]);
+  });
+
+  it('does nothing for an empty sessionId', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().unsubscribeTerminalMirror('');
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe('sendTerminalResize', () => {
+  it('sends terminal_resize with cols/rows for a valid size', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().sendTerminalResize('sess-1', 120, 40);
+    expect(sent).toEqual([{ type: 'terminal_resize', sessionId: 'sess-1', cols: 120, rows: 40 }]);
+  });
+
+  it('does nothing when cols <= 0 or rows <= 0', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().sendTerminalResize('sess-1', 0, 40);
+    useConnectionStore.getState().sendTerminalResize('sess-1', 120, 0);
+    useConnectionStore.getState().sendTerminalResize('sess-1', -1, -1);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('does nothing for an empty sessionId', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().sendTerminalResize('', 120, 40);
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe('terminal_output receive', () => {
+  const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
+
+  beforeEach(() => {
+    _testMessageHandler.setContext({
+      url: 'wss://test', token: 'tok', isReconnect: false,
+      silent: false, socket: mockSocket,
+    });
+  });
+  afterEach(() => _testMessageHandler.clearContext());
+
+  it('appends the data string to the raw terminal buffer (same path as raw)', () => {
+    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'sess-1', data: 'hello shell\r\n' });
+    expect(useConnectionStore.getState().terminalRawBuffer).toContain('hello shell');
+  });
+
+  it('ignores a non-string data payload without throwing or appending', () => {
+    const before = useConnectionStore.getState().terminalRawBuffer;
+    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'sess-1', data: 12345 });
+    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'sess-1' });
+    expect(useConnectionStore.getState().terminalRawBuffer).toBe(before);
+  });
+});

--- a/packages/app/src/__tests__/store/terminal-mirror.test.ts
+++ b/packages/app/src/__tests__/store/terminal-mirror.test.ts
@@ -95,15 +95,30 @@ describe('terminal_output receive', () => {
   });
   afterEach(() => _testMessageHandler.clearContext());
 
-  it('appends the data string to the raw terminal buffer (same path as raw)', () => {
-    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'sess-1', data: 'hello shell\r\n' });
+  it('appends the data string for the ACTIVE session (same path as raw)', () => {
+    // activeSessionId is 'default' (see top-level beforeEach).
+    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'default', data: 'hello shell\r\n' });
     expect(useConnectionStore.getState().terminalRawBuffer).toContain('hello shell');
+  });
+
+  it('ignores a frame for a non-active session (no cross-session bleed)', () => {
+    // A stale frame for a just-left session must not paint the active terminal
+    // (mobile uses one global terminalRawBuffer). Active is 'default'.
+    const before = useConnectionStore.getState().terminalRawBuffer;
+    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'other-session', data: 'stale bytes' });
+    expect(useConnectionStore.getState().terminalRawBuffer).toBe(before);
+  });
+
+  it('ignores a frame with a missing sessionId', () => {
+    const before = useConnectionStore.getState().terminalRawBuffer;
+    _testMessageHandler.handle({ type: 'terminal_output', data: 'orphan' });
+    expect(useConnectionStore.getState().terminalRawBuffer).toBe(before);
   });
 
   it('ignores a non-string data payload without throwing or appending', () => {
     const before = useConnectionStore.getState().terminalRawBuffer;
-    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'sess-1', data: 12345 });
-    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'sess-1' });
+    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'default', data: 12345 });
+    _testMessageHandler.handle({ type: 'terminal_output', sessionId: 'default' });
     expect(useConnectionStore.getState().terminalRawBuffer).toBe(before);
   });
 });

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -1587,7 +1587,7 @@ export function SessionScreen() {
             />
           </ErrorBoundary>
         ) : (
-          // TODO(#5837): interactive keystroke input (xterm stdin + terminal_input) — PR2.
+          // TODO(#6003): interactive keystroke input (xterm stdin + terminal_input) — PR2.
           // PR1 is a read-only mirror: terminal_output renders here via the
           // write-callback path, but no keystrokes are forwarded yet.
           <ErrorBoundary fallbackTitle="Terminal error">

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -26,6 +26,7 @@ import type { SessionIntervention } from '@chroxy/store-core';
 // uses, so widening `SelectOptionValue` to a third object shape can't
 // silently misroute it as freeform.
 import { isFreeformAnswer, providerSupportsMultiQuestion, providerSupportsSingleMultiSelect } from '@chroxy/store-core';
+import { USER_SHELL_PROVIDER } from '@chroxy/protocol';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
@@ -378,6 +379,10 @@ export function SessionScreen() {
   const teleportWebTask = useConnectionStore((s) => s.teleportWebTask);
   const destroySession = useConnectionStore((s) => s.destroySession);
   const createSession = useConnectionStore((s) => s.createSession);
+  // #5987 — only surface the "New Shell" affordance when the server advertises
+  // the user-shell capability; when absent, render nothing (mirrors the
+  // notificationPrefs capability gate in SettingsScreen).
+  const userShellSupported = useConnectionLifecycleStore((s) => !!s.serverCapabilities?.userShell);
   const switchSession = useConnectionStore((s) => s.switchSession);
   const latencyMs = useConnectionLifecycleStore((s) => s.latencyMs);
   const connectionQuality = useConnectionLifecycleStore((s) => s.connectionQuality);
@@ -508,7 +513,16 @@ export function SessionScreen() {
 
   // Determine if the active session has a terminal (PTY sessions do, CLI sessions don't)
   const activeSession = sessions.find((s) => s.sessionId === activeSessionId);
-  const hasTerminal = !isCliMode || (activeSession?.hasTerminal ?? false);
+  // #5987 — a user-shell ($SHELL PTY) session is terminal-only and drives the
+  // #5835 mirror channel (terminal_subscribe / terminal_output / terminal_resize)
+  // instead of claude-tui's legacy 'raw' + `resize` path. isPtyMirror gates the
+  // mirror subscribe/resize so claude-tui behavior stays exactly as before.
+  // Reuses the reactive `activeSessionProvider` selector declared above.
+  const isUserShell = activeSessionProvider === USER_SHELL_PROVIDER;
+  const isPtyMirror = isUserShell;
+  // A user-shell session is terminal-only, so it always has a terminal even
+  // though it isn't a claude-tui PTY.
+  const hasTerminal = isUserShell || !isCliMode || (activeSession?.hasTerminal ?? false);
 
   // Wire up terminal write callback when terminal view is visible (including split view)
   const terminalVisible = (viewMode === 'terminal' || (layout.isSplitView && viewMode !== 'files' && viewMode !== 'system')) && hasTerminal;
@@ -525,6 +539,30 @@ export function SessionScreen() {
     };
   }, [terminalVisible, activeSessionId, setTerminalWriteCallback]);
 
+  // #5835 / #5987 — opt into the live PTY mirror for a user-shell session while
+  // its terminal is visible, and opt out on leave / session switch. Only
+  // user-shell sessions use this channel (isPtyMirror); claude-tui stays on the
+  // legacy 'raw' stream and is unaffected. Mirrors the dashboard's subscribe
+  // effect — best-effort, the store actions no-op when the socket isn't open.
+  useEffect(() => {
+    if (!terminalVisible || !isPtyMirror || !activeSessionId) return;
+    const sessionId = activeSessionId;
+    useConnectionStore.getState().subscribeTerminalMirror(sessionId);
+    return () => {
+      useConnectionStore.getState().unsubscribeTerminalMirror(sessionId);
+    };
+  }, [terminalVisible, isPtyMirror, activeSessionId]);
+
+  // #5987 — a user-shell session is terminal-only, so snap the view to the
+  // terminal when one becomes active while sitting on the chat default. Only
+  // flips away from 'chat' (the default) so it never fights a user who has
+  // intentionally opened Files/System for the shell session.
+  useEffect(() => {
+    if (isUserShell && viewMode === 'chat') {
+      setViewMode('terminal');
+    }
+  }, [isUserShell, viewMode, setViewMode]);
+
   // Replay raw buffer into xterm.js when it becomes ready (initial mount, view switch, or crash recovery)
   const handleTerminalReady = useCallback(() => {
     terminalRef.current?.clear();
@@ -534,9 +572,19 @@ export function SessionScreen() {
     }
   }, []);
 
-  // Forward terminal dimensions to server for PTY resize
+  // Forward terminal dimensions to server for PTY resize. A user-shell session
+  // drives the #5835 mirror resize (terminal_resize, per-sessionId); claude-tui
+  // keeps the legacy `resize` (active-session) path. Reads provider fresh from
+  // the store so the callback can stay stable (empty deps) without going stale.
   const handleTerminalResize = useCallback((cols: number, rows: number) => {
-    useConnectionStore.getState().resize(cols, rows);
+    const store = useConnectionStore.getState();
+    const { activeSessionId: sid, sessions: sess } = store;
+    const provider = sess.find((s) => s.sessionId === sid)?.provider;
+    if (sid && provider === USER_SHELL_PROVIDER) {
+      store.sendTerminalResize(sid, cols, rows);
+    } else {
+      store.resize(cols, rows);
+    }
   }, []);
 
   // #3595: dedicated restart handler for the StdinDisabledBanner. Creates a
@@ -941,6 +989,21 @@ export function SessionScreen() {
           <View style={styles.sessionPickerWrapper}>
             <SessionPicker onCreatePress={() => setShowCreateModal(true)} />
           </View>
+          {/* #5987 — "New Shell" spins up a user-shell ($SHELL PTY) session.
+              Gated on the server's userShell capability; renders nothing when
+              the server doesn't advertise it. */}
+          {userShellSupported && (
+            <TouchableOpacity
+              testID="new-shell-button"
+              style={styles.overviewButton}
+              onPress={() => createSession({ name: 'Shell', provider: USER_SHELL_PROVIDER })}
+              hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+              accessibilityRole="button"
+              accessibilityLabel="New shell session"
+            >
+              <Text style={styles.overviewButtonText}>{'>_'}</Text>
+            </TouchableOpacity>
+          )}
           <TouchableOpacity
             style={styles.overviewButton}
             onPress={() => setShowSessionOverview(!showSessionOverview)}
@@ -981,18 +1044,22 @@ export function SessionScreen() {
         </View>
       ) : (
         <View style={styles.modeToggle}>
-          <TouchableOpacity
-            style={[styles.modeButton, viewMode === 'chat' && styles.modeButtonActive]}
-            onPress={() => setViewMode('chat')}
-            accessibilityRole="button"
-            accessibilityLabel="Chat"
-            accessibilityState={{ selected: viewMode === 'chat' }}
-          >
-            <Text style={[styles.modeButtonText, viewMode === 'chat' && styles.modeButtonTextActive]}>
-              Chat
-            </Text>
-          </TouchableOpacity>
-          {viewMode === 'chat' && (
+          {/* #5987 — a user-shell session is terminal-only; hide the Chat toggle
+              so there's no empty chat view to switch into. */}
+          {!isUserShell && (
+            <TouchableOpacity
+              style={[styles.modeButton, viewMode === 'chat' && styles.modeButtonActive]}
+              onPress={() => setViewMode('chat')}
+              accessibilityRole="button"
+              accessibilityLabel="Chat"
+              accessibilityState={{ selected: viewMode === 'chat' }}
+            >
+              <Text style={[styles.modeButtonText, viewMode === 'chat' && styles.modeButtonTextActive]}>
+                Chat
+              </Text>
+            </TouchableOpacity>
+          )}
+          {!isUserShell && viewMode === 'chat' && (
             <TouchableOpacity
               style={[styles.modeButton, chatFilterCompact && styles.modeButtonActive]}
               onPress={() => { setChatFilterCompact((v) => !v); clearSelection(); }}
@@ -1520,6 +1587,9 @@ export function SessionScreen() {
             />
           </ErrorBoundary>
         ) : (
+          // TODO(#5837): interactive keystroke input (xterm stdin + terminal_input) — PR2.
+          // PR1 is a read-only mirror: terminal_output renders here via the
+          // write-callback path, but no keystrokes are forwarded yet.
           <ErrorBoundary fallbackTitle="Terminal error">
             <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} />
           </ErrorBoundary>

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1932,6 +1932,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     sendIfOpen(payload);
   },
 
+  // #5835 / #5987 — live PTY mirror (read-only on mobile in PR1). Opt in/out of
+  // a session's terminal_output stream; only opted-in clients receive the mirror
+  // (server-side filter), so this is sent when a user-shell terminal is visible
+  // and cleared on leave. Best-effort — a closed socket just means no mirror
+  // until reconnect (sendIfOpen no-ops when not OPEN). Mirrors the dashboard's
+  // subscribeTerminalMirror / requestTerminalResize.
+  subscribeTerminalMirror: (sessionId) => {
+    if (!sessionId) return;
+    sendIfOpen({ type: 'terminal_subscribe', sessionId });
+  },
+  unsubscribeTerminalMirror: (sessionId) => {
+    if (!sessionId) return;
+    sendIfOpen({ type: 'terminal_unsubscribe', sessionId });
+  },
+  sendTerminalResize: (sessionId, cols, rows) => {
+    if (!sessionId || cols <= 0 || rows <= 0) return;
+    sendIfOpen({ type: 'terminal_resize', sessionId, cols, rows });
+  },
+
   // Directory listing
 
   setDirectoryListingCallback: (cb) => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2664,13 +2664,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // user-shell ($SHELL) session subscribed via terminal_subscribe. Render it
     // through the exact same write-callback → xterm path as 'raw' so user-shell
     // output appears in TerminalView with no TerminalView changes. Read-only in
-    // PR1; interactive stdin (terminal_input) is deferred — see #5837.
+    // PR1; interactive stdin (terminal_input) is deferred — see #6003.
     case 'terminal_output': {
       const data = msg.data;
-      if (typeof data === 'string') {
-        get().appendTerminalData(data);
-        useTerminalStore.getState().appendTerminalData(data);
-      }
+      if (typeof data !== 'string') break;
+      // Guard on the active session id (mirrors the dashboard handler): between
+      // an unsubscribe(old) and subscribe(new) during a session switch, a stale
+      // frame for the old session can still arrive — without this guard it would
+      // bleed into the new session's terminal (mobile renders one global
+      // terminalRawBuffer, so a mis-targeted frame paints the wrong shell).
+      if (typeof msg.sessionId !== 'string' || msg.sessionId !== get().activeSessionId) break;
+      get().appendTerminalData(data);
+      useTerminalStore.getState().appendTerminalData(data);
       break;
     }
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2659,6 +2659,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    // #5835 / #5987 — live PTY mirror channel. Unlike legacy 'raw' (claude-tui's
+    // headless output), terminal_output is the opt-in mirror stream for a
+    // user-shell ($SHELL) session subscribed via terminal_subscribe. Render it
+    // through the exact same write-callback → xterm path as 'raw' so user-shell
+    // output appears in TerminalView with no TerminalView changes. Read-only in
+    // PR1; interactive stdin (terminal_input) is deferred — see #5837.
+    case 'terminal_output': {
+      const data = msg.data;
+      if (typeof data === 'string') {
+        get().appendTerminalData(data);
+        useTerminalStore.getState().appendTerminalData(data);
+      }
+      break;
+    }
+
     case 'claude_ready': {
       const patch = sharedClaudeReady();
       const targetId = resolveSessionId(msg, get().activeSessionId);

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -655,6 +655,13 @@ export interface UIViewActions {
   clearTerminalBuffer: () => void;
   setTerminalWriteCallback: (cb: ((data: string) => void) | null) => void;
   resize: (cols: number, rows: number) => void;
+  // #5835 / #5987 — live PTY mirror channel (read-only on mobile in PR1).
+  // Opt in/out of a session's terminal_output stream and report the viewer's
+  // grid size. Used by user-shell sessions; claude-tui keeps its legacy 'raw'
+  // + `resize` path. Interactive stdin (terminal_input) is deferred — see #5837.
+  subscribeTerminalMirror: (sessionId: string) => void;
+  unsubscribeTerminalMirror: (sessionId: string) => void;
+  sendTerminalResize: (sessionId: string, cols: number, rows: number) => void;
 }
 
 /**

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -658,7 +658,7 @@ export interface UIViewActions {
   // #5835 / #5987 — live PTY mirror channel (read-only on mobile in PR1).
   // Opt in/out of a session's terminal_output stream and report the viewer's
   // grid size. Used by user-shell sessions; claude-tui keeps its legacy 'raw'
-  // + `resize` path. Interactive stdin (terminal_input) is deferred — see #5837.
+  // + `resize` path. Interactive stdin (terminal_input) is deferred — see #6003.
   subscribeTerminalMirror: (sessionId: string) => void;
   unsubscribeTerminalMirror: (sessionId: string) => void;
   sendTerminalResize: (sessionId: string, cols: number, rows: number) => void;

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -136,8 +136,11 @@ const PLATFORM_SPECIFIC = {
   // and mobile app (#4764 / PR #4862); no PLATFORM_SPECIFIC entry needed.
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
-  'terminal_output': 'dashboard', // #5835 (PR2) live claude-tui PTY mirror — the dashboard renders the raw bytes in xterm; the mobile WebView terminal render is a deferred follow-up per the epic
-  'terminal_size': 'dashboard', // #5835 Phase 2 authoritative live-PTY grid size — the dashboard letterboxes the mirror to it (setTerminalSize); same mobile follow-up as terminal_output
+  // 'terminal_output' is now handled by both dashboard (#5835 PR2) and the
+  // mobile app (#5987 — the user-shell read-only mirror routes it through the
+  // same write-callback → xterm path as 'raw'); no PLATFORM_SPECIFIC entry
+  // needed. Coverage passes because each handler has a `case 'terminal_output':`.
+  'terminal_size': 'dashboard', // #5835 Phase 2 authoritative live-PTY grid size — the dashboard letterboxes the mirror to it (setTerminalSize); mobile applies resize from its own pane measurement (#5987) but does not yet consume the server's terminal_size echo, so still dashboard-only
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
   'activity_snapshot': 'dashboard', // Control Room live activity tree (#5161 schema / #5160 server / #5162 reducer / #5163 dashboard panel) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5159
   'activity_delta': 'dashboard',    // Control Room activity delta — see activity_snapshot above; dashboard-only for v1, mobile parity is Phase-2 per epic #5159


### PR DESCRIPTION
## Summary

Mobile parity for the embedded user-shell terminal (epic #5982), **PR1: read-only mirror + UI scaffold**. The interactive keyboard (xterm stdin + `terminal_input`) is a deliberate follow-up (PR2 / #5837).

### Why this is more than a UI change
The dashboard reused its fully-built #5835 interactive terminal. Mobile had **none** of that — the app only handled the legacy `'raw'` output stream, never the #5835 mirror channel (`terminal_subscribe`/`terminal_output`/`terminal_resize`), and that work was deferred as #5837. A user-shell streams on the `terminal_output` mirror (not `'raw'`), so on mobile today it would show **nothing**. This PR ports the read-only mirror client.

## Changes
- **Store** (`connection.ts`/`types.ts`): `subscribeTerminalMirror` / `unsubscribeTerminalMirror` / `sendTerminalResize` (send `terminal_subscribe` / `_unsubscribe` / `_resize`), mirroring the dashboard.
- **Receive** (`message-handler.ts`): a `terminal_output` case that routes `data` through the same write-callback → xterm path as `'raw'` (no `TerminalView` changes).
- **SessionScreen**: subscribe to the mirror while a user-shell terminal is visible; treat user-shell as terminal-only (always `hasTerminal`, snap the view to terminal, hide the Chat toggle); route resize via `terminal_resize` for user-shell. **claude-tui is untouched** — only `provider === 'user-shell'` uses the new mirror path.
- **"New Shell"** affordance gated on `serverCapabilities.userShell` → `createSession({ provider: 'user-shell' })`; `testID="new-shell-button"`; renders nothing when the capability is absent.

## Out of scope (PR2 / #5837)
Interactive keystroke input — xterm runs `disableStdin: true` and no keystroke bridge exists. The shell is **viewable but not yet drivable** on mobile. Marked with a `TODO(#5837)` at the `TerminalView` render. This is the part that needs on-device iteration (RN WebView soft-keyboard focus).

## Tests
- 10 unit tests (`terminal-mirror.test.ts`): the three store actions (wire shapes, guards, closed-socket no-op) + the `terminal_output` receive path (appends string data, ignores non-string).
- Full app suite green (1945 tests, 147 suites). `tsc --noEmit` clean.

## On-device verification needed (I cannot run a simulator here)
1. Enable `userShell.enabled` on a server; connect the mobile dev client as the **primary** device → the **"New Shell"** (`>_`) button appears in the session header (and is absent on a server without the capability / a paired device).
2. Tap it → a user-shell session is created, the view is terminal-only (no Chat toggle), and shell output **renders** in the xterm WebView.
3. Confirm resize: rotate / change pane size → the PTY reflows (terminal_resize round-trips).
4. (Expected gap) typing does nothing yet — that's PR2 (#5837).

A Maestro flow for the New Shell button is best added alongside step 1–2 (needs the mock-server to advertise `userShell`); left for the on-device pass.

Related to #5987, #5982