### PR TITLE
feat(server): auto-remove a user-shell session when its PTY exits (#5982)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2456,6 +2456,11 @@ export class SessionManager extends EventEmitter {
           const entry = this._sessions.get(sessionId)
           if (entry && !entry._destroying) {
             log.info(`Auto-removing exited user-shell session ${sessionId}`)
+            // Calls destroySession directly, intentionally bypassing the
+            // handler-layer "cannot destroy the last session" guard: that guard
+            // stops a USER from emptying their list, not a dead shell from being
+            // reaped — a zombie shell shouldn't be force-kept just because it's
+            // the last session.
             this.destroySession(sessionId)
           }
         }, AUTO_REMOVE_ON_EXIT_DELAY_MS)

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -33,6 +33,9 @@ import {
 
 const log = createLogger('session-manager')
 const DEFAULT_STATE_FILE = join(homedir(), '.chroxy', 'session-state.json')
+// #5982 — grace before auto-removing an exited user-shell session, so a live
+// viewer sees the "[shell exited]" marker before the session vanishes.
+const AUTO_REMOVE_ON_EXIT_DELAY_MS = 1500
 
 /**
  * Zero-initialized cumulative usage record (#4072). Lives on the session
@@ -2437,6 +2440,28 @@ export class SessionManager extends EventEmitter {
     session.on('terminal_resize', (data) => {
       this.emit('session_event', { sessionId, event: 'terminal_resize', data })
     })
+
+    // #5982 — auto-remove a user-shell session when its PTY exits on its own
+    // (the user typed `exit`, or the shell died). A short grace lets a live
+    // viewer read the "[shell exited]" marker, then the session is destroyed so
+    // no dead zombie shells linger in the list. UserShellSession emits
+    // `shell_exited` ONLY from its natural-exit path; an explicit destroySession
+    // detaches this listener first (removeAllListeners), so a deliberate
+    // teardown never schedules a redundant auto-remove. The timer is unref'd so
+    // it can't keep the process alive, and re-checks the session still exists
+    // (and isn't already tearing down) before destroying.
+    if (session.constructor?.isUserShell === true) {
+      session.on('shell_exited', () => {
+        const timer = setTimeout(() => {
+          const entry = this._sessions.get(sessionId)
+          if (entry && !entry._destroying) {
+            log.info(`Auto-removing exited user-shell session ${sessionId}`)
+            this.destroySession(sessionId)
+          }
+        }, AUTO_REMOVE_ON_EXIT_DELAY_MS)
+        if (typeof timer.unref === 'function') timer.unref()
+      })
+    }
 
     for (const event of PROXIED_EVENTS) {
       session.on(event, (data) => {

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -197,6 +197,10 @@ export class UserShellSession extends BaseSession {
       this.emit('terminal_output', { data: marker })
     }
     this._clearKillTimer()
+    // #5982 — signal a NATURAL exit so SessionManager can auto-remove the dead
+    // session (no lingering zombie shells). Emitted only here, so an explicit
+    // destroy() — which detaches listeners first — never triggers auto-remove.
+    this.emit('shell_exited', { code })
   }
 
   /**

--- a/packages/server/tests/shell-audit-wiring.test.js
+++ b/packages/server/tests/shell-audit-wiring.test.js
@@ -215,7 +215,9 @@ if (typeof mock.module !== 'function') {
       const mgr = makeMgr()
       const sessionId = mgr.createSession({ name: 'sh', cwd: '/tmp', provider: 'test-audit-usershell' })
       const entry = mgr.getSession(sessionId)
-      entry.session._exitReason = 'exit' // mimic a natural exit (set by _onShellExit)
+      // Mimic a natural exit — _onShellExit sets BOTH _exitCode and _exitReason.
+      entry.session._exitCode = 0
+      entry.session._exitReason = 'exit'
 
       entry.session.emit('shell_exited', { code: 0 })
       assert.ok(mgr.getSession(sessionId), 'still present during the grace window')
@@ -224,6 +226,7 @@ if (typeof mock.module !== 'function') {
       assert.equal(mgr.getSession(sessionId), null, 'removed after the grace')
       assert.equal(destroyCalls.length, 1)
       assert.equal(destroyCalls[0].reason, 'exit', 'audits the natural exit reason')
+      assert.equal(destroyCalls[0].exitCode, 0, 'audits the natural exit code')
       rmSync(mgr._tmpDir, { recursive: true, force: true })
     })
 

--- a/packages/server/tests/shell-audit-wiring.test.js
+++ b/packages/server/tests/shell-audit-wiring.test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after, beforeEach, mock } from 'node:test'
+import { describe, it, before, after, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
@@ -201,6 +201,55 @@ if (typeof mock.module !== 'function') {
         ctx,
       )
       assert.equal(createCalls.length, 0)
+    })
+  })
+
+  // #5982 — auto-remove an exited user-shell session after the grace delay, and
+  // never double-destroy if it's torn down during the grace.
+  describe('user-shell auto-remove on exit (#5982)', () => {
+    beforeEach(() => { destroyCalls.length = 0 })
+    afterEach(() => { mock.timers.reset() })
+
+    it('auto-removes a user-shell after a natural PTY exit (after the grace)', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      const mgr = makeMgr()
+      const sessionId = mgr.createSession({ name: 'sh', cwd: '/tmp', provider: 'test-audit-usershell' })
+      const entry = mgr.getSession(sessionId)
+      entry.session._exitReason = 'exit' // mimic a natural exit (set by _onShellExit)
+
+      entry.session.emit('shell_exited', { code: 0 })
+      assert.ok(mgr.getSession(sessionId), 'still present during the grace window')
+
+      mock.timers.tick(1500)
+      assert.equal(mgr.getSession(sessionId), null, 'removed after the grace')
+      assert.equal(destroyCalls.length, 1)
+      assert.equal(destroyCalls[0].reason, 'exit', 'audits the natural exit reason')
+      rmSync(mgr._tmpDir, { recursive: true, force: true })
+    })
+
+    it('does not double-destroy if the session is torn down during the grace', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      const mgr = makeMgr()
+      const sessionId = mgr.createSession({ name: 'sh', cwd: '/tmp', provider: 'test-audit-usershell' })
+      mgr.getSession(sessionId).session.emit('shell_exited', { code: 0 })
+
+      mgr.destroySession(sessionId) // explicit teardown during the grace
+      const after = destroyCalls.length
+
+      mock.timers.tick(1500) // pending timer fires — must be a no-op (session gone)
+      assert.equal(destroyCalls.length, after, 'the grace timer did not destroy again')
+      rmSync(mgr._tmpDir, { recursive: true, force: true })
+    })
+
+    it('does not auto-remove a non-shell session', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      const mgr = makeMgr()
+      const sessionId = mgr.createSession({ name: 'chat', cwd: '/tmp', provider: 'test-audit-normal' })
+      // A normal session has no shell_exited wiring; emitting it is inert.
+      mgr.getSession(sessionId).session.emit('shell_exited', { code: 0 })
+      mock.timers.tick(1500)
+      assert.ok(mgr.getSession(sessionId), 'non-shell session is not auto-removed')
+      rmSync(mgr._tmpDir, { recursive: true, force: true })
     })
   })
 }


### PR DESCRIPTION
## Summary

A user-shell is a transient `$SHELL` session — when its PTY exits on its own (the operator typed `exit`, or the shell died), the session previously lingered as a dead zombie in the session list. This auto-removes it.

## Change
- **`UserShellSession`** emits a `shell_exited` event from its natural-exit path (`_onShellExit`) **only** — never from `destroy()`. Since `destroySession` detaches listeners first (`removeAllListeners`), a deliberate teardown can't trigger a redundant auto-remove.
- **`SessionManager._wireSessionEvents`** (gated on `isUserShell`) schedules `destroySession` after a short grace (1500ms) so a live viewer reads the `[shell exited]` marker before the session vanishes. The timer is `unref`'d and re-checks the session still exists (and isn't already `_destroying`) before acting — so it's a clean no-op if the session was torn down during the grace. The destroy audits the **preserved natural exit reason** (e.g. `exit`/`close`/`error`), not `destroyed`.

## Behavior
- Type `exit` in a mobile/dashboard shell → the `[shell exited (code 0)]` marker shows briefly → the session disappears from the list. No lingering dead shells.
- An explicit "close session" during the grace doesn't double-destroy.
- Non-shell sessions (claude-tui, chat) are completely unaffected.

## Tests
- Auto-removes after the grace (audits `reason='exit'`); no double-destroy when torn down during the grace; non-shell session untouched. Uses `mock.timers` to drive the grace deterministically.
- session-manager + user-shell + audit suites green (236 tests); server lints pass; eslint clean.

Related to #5982