### PR TITLE
feat(server): always-on shell-audit trail, level-independent (#6001)

### DIFF
--- a/docs/security/bearer-token-authority.md
+++ b/docs/security/bearer-token-authority.md
@@ -121,7 +121,7 @@ User-shell sessions are additionally gated by the `userShell.enabled` config fla
 
 **Audit trail (#5985).** Every user-shell lifecycle event is recorded to the `shell-audit` log component (`packages/server/src/shell-audit.js`) as a single greppable `[shell-audit]` line: a `user_shell_create` entry (sessionId, authorizing `clientId` + `tokenClass`, cwd, resolved shell, device) emitted by the WS create handler — the only layer that knows the token class — and a matching `user_shell_destroy` entry (sessionId, the shell's natural exit code/reason when it ended before teardown, else a `null` code with `reason=destroyed` for a per-session destroy or `reason=shutdown` at process shutdown) emitted by `SessionManager` for both teardown paths. Per-keystroke command-input auditing is deliberately out of scope (volume + privacy); the create/destroy pair with the token class is the traceability anchor. Filter the server log on the `shell-audit` component to reconstruct who opened which shell, from where, and how it ended.
 
-> **Operational note:** the trail is emitted at `info` level, so it requires `LOG_LEVEL<=info` (the default) — running the daemon at `LOG_LEVEL=warn`/`error` suppresses it. A level-independent always-on audit sink (in-memory ring + optional file, like `PermissionAuditLog`) is tracked as a follow-up; until then, keep `info` logging on when `userShell.enabled` is set.
+> **Always-on (#6001):** the trail is emitted via the logger's level-independent `audit()` path (tagged `[AUDIT] [shell-audit]`), so it is recorded regardless of `LOG_LEVEL` — a quiet `LOG_LEVEL=warn`/`error` daemon still captures every shell create/destroy. The lines are redacted and written to the daemon log file like any other.
 
 ## 5. Per-Session Hook Secrets
 

--- a/packages/dashboard/src/components/LogPanel.tsx
+++ b/packages/dashboard/src/components/LogPanel.tsx
@@ -4,7 +4,7 @@ import type { LogEntry } from '../store/types'
 
 type LogLevel = LogEntry['level']
 
-const LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error']
+const LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error', 'audit']
 
 export function LogPanel() {
   const logEntries = useConnectionStore((state) => state.logEntries)
@@ -12,7 +12,7 @@ export function LogPanel() {
   const activeSessionId = useConnectionStore((state) => state.activeSessionId)
   const sessionCount = useConnectionStore((state) => state.sessions.length)
 
-  const [filter, setFilter] = useState<Set<LogLevel>>(new Set(['info', 'warn', 'error']))
+  const [filter, setFilter] = useState<Set<LogLevel>>(new Set(['info', 'warn', 'error', 'audit']))
   const [sessionFilter, setSessionFilter] = useState(true) // filter by active session when multi-session
   const [autoScroll, setAutoScroll] = useState(true)
   const [copied, setCopied] = useState(false)

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8371,6 +8371,8 @@ button.sidebar-token-view-session-row:hover {
 .log-filter-warn.active { color: #f0ad4e; border-color: #f0ad4e; }
 .log-filter-error.active { color: #e74c3c; border-color: #e74c3c; }
 .log-filter-debug.active { color: #7f8c8d; border-color: #7f8c8d; }
+/* #6001 — the always-on security-audit level (shell-audit), distinct from warn's orange */
+.log-filter-audit.active { color: #17a2b8; border-color: #17a2b8; }
 
 .log-actions {
   display: flex;
@@ -8439,6 +8441,7 @@ button.sidebar-token-view-session-row:hover {
 .log-level-tag-warn { color: #f0ad4e; }
 .log-level-tag-error { color: #e74c3c; }
 .log-level-tag-debug { color: #7f8c8d; }
+.log-level-tag-audit { color: #17a2b8; font-weight: 600; }
 
 .log-component {
   color: var(--accent, #6c63ff);

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -305,11 +305,14 @@ export function getLogLevel() {
  * Create a component logger. Backward-compatible with existing API.
  * @param {string} component - Component name for log prefix
  * @param {object} [context] - Optional context (e.g. { sessionId })
- * @returns {{ debug: Function, info: Function, warn: Function, error: Function, log: Function, withSession: Function }}
+ * @returns {{ debug: Function, info: Function, warn: Function, error: Function, audit: Function, log: Function, withSession: Function }}
  */
 export function createLogger(component, context = {}) {
-  const write = (level, msg) => {
-    if (LOG_LEVELS[level] < _logLevel) return
+  const write = (level, msg, { always = false } = {}) => {
+    // `always` bypasses the configured level gate (#6001) so an audit trail is
+    // never dropped by LOG_LEVEL. Everything else (redaction, console routing,
+    // listener broadcast, file write) is identical to a normal line.
+    if (!always && LOG_LEVELS[level] < _logLevel) return
 
     const safeMsg = redactSensitive(msg)
     const timestamp = new Date().toISOString()
@@ -355,6 +358,13 @@ export function createLogger(component, context = {}) {
     info(msg) { write('info', msg) },
     warn(msg) { write('warn', msg) },
     error(msg) { write('error', msg) },
+    /**
+     * Always-on audit line (#6001) — bypasses the configured LOG_LEVEL so a
+     * security audit trail (e.g. shell-audit) is never suppressed by a quiet
+     * production log level. Tagged `[AUDIT]`; still redacted, broadcast to log
+     * listeners, and written to the daemon log file like any other line.
+     */
+    audit(msg) { write('audit', msg, { always: true }) },
     // Backward compat alias
     log(msg) { write('info', msg) },
     /** Create a child logger tagged with a session ID. */

--- a/packages/server/src/shell-audit.js
+++ b/packages/server/src/shell-audit.js
@@ -12,6 +12,11 @@
  * ("create/destroy audited, with the token class"). Per-keystroke command-input
  * auditing is deliberately out of scope (volume + privacy); the create/destroy
  * pair with the token class is the traceability anchor.
+ *
+ * Entries are emitted via the logger's always-on `audit()` path (#6001), so the
+ * trail survives a quiet `LOG_LEVEL` (warn/error) — a security record for a
+ * host-RCE capability must not vanish just because the operator turned down
+ * ordinary logging. Lines are tagged `[AUDIT] [shell-audit]`.
  */
 import { createLogger } from './logger.js'
 
@@ -44,7 +49,7 @@ export function formatShellAuditLine(event, fields = {}) {
  * widening of the authz is captured in the trail).
  */
 export function auditShellCreate({ sessionId, clientId, tokenClass, cwd, shell, deviceName } = {}) {
-  log.info(formatShellAuditLine('user_shell_create', { sessionId, clientId, tokenClass, cwd, shell, deviceName }))
+  log.audit(formatShellAuditLine('user_shell_create', { sessionId, clientId, tokenClass, cwd, shell, deviceName }))
 }
 
 /**
@@ -54,5 +59,5 @@ export function auditShellCreate({ sessionId, clientId, tokenClass, cwd, shell, 
  * asynchronously). `reason` is the shell's own exit reason or 'destroyed'.
  */
 export function auditShellDestroy({ sessionId, exitCode, reason } = {}) {
-  log.info(formatShellAuditLine('user_shell_destroy', { sessionId, exitCode, reason }))
+  log.audit(formatShellAuditLine('user_shell_destroy', { sessionId, exitCode, reason }))
 }

--- a/packages/server/tests/logger.test.js
+++ b/packages/server/tests/logger.test.js
@@ -164,6 +164,23 @@ describe('log levels', () => {
     assert.ok(content.includes('warn-msg'))
     assert.ok(content.includes('error-msg'))
   })
+
+  // #6001 — audit() bypasses the level gate so a security trail survives a
+  // quiet LOG_LEVEL. At the strictest non-silent level (error), an audit line
+  // is still written and tagged [AUDIT], while a plain info line is suppressed.
+  it('at level error, audit() is still written (always-on) but info is not', () => {
+    initFileLogging({ logDir, level: 'error' })
+    const log = createLogger('shell-audit')
+    log.info('info-suppressed')
+    log.audit('audit-kept')
+    closeFileLogging()
+
+    const content = readFileSync(join(logDir, 'chroxy.log'), 'utf8')
+    assert.ok(!content.includes('info-suppressed'), 'info is suppressed at error level')
+    assert.ok(content.includes('audit-kept'), 'audit survives the level gate')
+    assert.ok(content.includes('[AUDIT]'), 'audit line is tagged [AUDIT]')
+    assert.ok(content.includes('[shell-audit]'), 'component tag preserved')
+  })
 })
 
 describe('log rotation', () => {

--- a/packages/server/tests/shell-audit.test.js
+++ b/packages/server/tests/shell-audit.test.js
@@ -1,6 +1,10 @@
-import { describe, it } from 'node:test'
+import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { formatShellAuditLine } from '../src/shell-audit.js'
+import { mkdtempSync, rmSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { formatShellAuditLine, auditShellCreate } from '../src/shell-audit.js'
+import { initFileLogging, closeFileLogging } from '../src/logger.js'
 
 /**
  * #5985 (epic #5982) — shell-audit line formatting. The create/destroy audit
@@ -52,5 +56,29 @@ describe('shell-audit — formatShellAuditLine (#5985)', () => {
     const line = formatShellAuditLine('user_shell_create', { cwd: '/tmp/with space', deviceName: 'My Phone' })
     assert.match(line, /cwd="\/tmp\/with space"/)
     assert.match(line, /deviceName="My Phone"/)
+  })
+})
+
+// #6001 — the trail must survive a quiet LOG_LEVEL. Drive the real
+// auditShellCreate through file logging at the strictest non-silent level
+// (error) and assert the line is still written — locks the log.audit() wiring
+// against a regression back to a level-gated log.info().
+describe('shell-audit — always-on under quiet LOG_LEVEL (#6001)', () => {
+  let logDir
+  afterEach(() => {
+    closeFileLogging()
+    if (logDir) rmSync(logDir, { recursive: true, force: true })
+  })
+
+  it('writes a create entry even at LOG_LEVEL=error', () => {
+    logDir = mkdtempSync(join(tmpdir(), 'chroxy-shell-audit-'))
+    initFileLogging({ logDir, level: 'error' })
+    auditShellCreate({ sessionId: 'sess-9', clientId: 'client-9', tokenClass: 'primary', shell: '/bin/zsh' })
+    closeFileLogging()
+
+    const content = readFileSync(join(logDir, 'chroxy.log'), 'utf8')
+    assert.match(content, /event=user_shell_create/)
+    assert.match(content, /sessionId="sess-9"/)
+    assert.match(content, /\[AUDIT\]/)
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1969,6 +1969,12 @@ describe('handleLogEntry', () => {
     expect(handleLogEntry({ level: 'error' }).entry.level).toBe('error')
   })
 
+  it('preserves the always-on audit level (#6001), not coercing it to info', () => {
+    // The server's shell-audit trail is emitted at level 'audit'; the dashboard
+    // must keep it first-class (filterable / distinctly badged), not flatten it.
+    expect(handleLogEntry({ level: 'audit' }).entry.level).toBe('audit')
+  })
+
   it('defaults missing message to empty string', () => {
     const result = handleLogEntry({ component: 'ws' })
     expect(result.entry.message).toBe('')

--- a/packages/store-core/src/handlers/session-lifecycle.ts
+++ b/packages/store-core/src/handlers/session-lifecycle.ts
@@ -191,9 +191,12 @@ export function handleSessionStopped(
 // log_entry
 // ---------------------------------------------------------------------------
 
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+// 'audit' (#6001) is the server's always-on security-trail level (shell-audit) —
+// emitted regardless of LOG_LEVEL and surfaced as a first-class, filterable
+// level on the dashboard rather than being coerced down to 'info'.
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'audit'
 
-const VALID_LOG_LEVELS = new Set<LogLevel>(['debug', 'info', 'warn', 'error'])
+const VALID_LOG_LEVELS = new Set<LogLevel>(['debug', 'info', 'warn', 'error', 'audit'])
 
 export interface LogEntry {
   id: string


### PR DESCRIPTION
## Summary

The shell-audit trail (user-shell create/destroy — #5985) logged at **info** level, so a daemon run at `LOG_LEVEL=warn`/`error` silently dropped a security record for a host-RCE capability. This makes the trail **level-independent**.

## Change
- **logger** (`logger.js`): a new always-on **`audit(msg)`** method on `createLogger` — bypasses the `LOG_LEVEL` gate, tagged `[AUDIT]`. Redaction, console routing, log-listener broadcast, and daemon-file write are otherwise identical to any line. The internal `write()` gains an opt-in `{ always }` flag (backward-compatible — all existing 2-arg calls unchanged).
- **shell-audit** (`shell-audit.js`): emit create/destroy via `log.audit()` instead of `log.info()`.
- **docs** (`bearer-token-authority.md` §12): replace the "requires `LOG_LEVEL<=info`" caveat with the always-on guarantee.

## Why this approach
Rather than an unexposed in-memory ring (no operator-visible output) or a dedicated audit file (sandbox/test-write complexity), the trail now rides the operator's **normal log stream** but cannot be suppressed by `LOG_LEVEL` — directly solving "I turned logging down and lost the security trail," with zero new infra.

## Tests
- `audit()` is written at `LOG_LEVEL=error` while a plain `info` line is suppressed, and the line is tagged `[AUDIT]` with the component preserved.
- End-to-end: `auditShellCreate` writes its line at `LOG_LEVEL=error` (locks the `log.audit` wiring against a regression back to `log.info`).
- logger + shell-audit + wiring suites green (110+ tests); eslint clean.

Closes #6001