### PR TITLE
feat(app): interactive keystroke input for the mobile user-shell terminal (#6003)

### DIFF
--- a/packages/app/src/__tests__/components/TerminalView.test.tsx
+++ b/packages/app/src/__tests__/components/TerminalView.test.tsx
@@ -245,6 +245,20 @@ describe('TerminalView interactive input (#6003)', () => {
     expect(findPosted('set-interactive')).toEqual({ type: 'set-interactive', enabled: true });
   });
 
+  it('re-applies interactive state on a crash-recovery reload (second ready)', () => {
+    act(() => {
+      create(<TerminalView interactive />);
+    });
+    markReady();
+    const wv = getWebView();
+    wv.postMessage.mockClear();
+    // Simulate the WebView content process being killed and the page reloading:
+    // it re-emits `ready`, and the handler must re-enable stdin (the reloaded
+    // page reset to disableStdin: true).
+    markReady();
+    expect(findPosted('set-interactive')).toEqual({ type: 'set-interactive', enabled: true });
+  });
+
   it('marks the WebView text-interaction-enabled only when interactive', () => {
     let roRenderer!: ReactTestRenderer;
     act(() => {

--- a/packages/app/src/__tests__/components/TerminalView.test.tsx
+++ b/packages/app/src/__tests__/components/TerminalView.test.tsx
@@ -216,6 +216,32 @@ describe('TerminalView interactive input (#6003)', () => {
     expect(onInput).toHaveBeenCalledWith('ls -la\r');
   });
 
+  it('IGNORES an input message when read-only (defense vs unexpected WebView messages)', () => {
+    const onInput = jest.fn();
+    act(() => {
+      create(<TerminalView onInput={onInput} />); // not interactive
+    });
+    markReady();
+    act(() => {
+      getWebView().emitMessage(JSON.stringify({ type: 'input', data: 'rm -rf /\r' }));
+    });
+    expect(onInput).not.toHaveBeenCalled();
+  });
+
+  it('focus() is a no-op when read-only (does not summon the keyboard)', () => {
+    const handleRef = React.createRef<TerminalHandle>();
+    act(() => {
+      create(<TerminalView ref={handleRef} />); // not interactive
+    });
+    markReady();
+    const wv = getWebView();
+    wv.postMessage.mockClear();
+    act(() => {
+      handleRef.current!.focus();
+    });
+    expect(wv.postMessage).not.toHaveBeenCalled();
+  });
+
   it('focus() posts a focus bridge message', () => {
     const handleRef = React.createRef<TerminalHandle>();
     act(() => {
@@ -259,18 +285,23 @@ describe('TerminalView interactive input (#6003)', () => {
     expect(findPosted('set-interactive')).toEqual({ type: 'set-interactive', enabled: true });
   });
 
-  it('marks the WebView text-interaction-enabled only when interactive', () => {
+  it('gates textInteractionEnabled + keyboardDisplayRequiresUserAction on interactive', () => {
     let roRenderer!: ReactTestRenderer;
     act(() => {
       roRenderer = create(<TerminalView />);
     });
-    expect(roRenderer.root.findByProps({ testID: 'webview' }).props.textInteractionEnabled).toBe(false);
+    const roWebView = roRenderer.root.findByProps({ testID: 'webview' });
+    expect(roWebView.props.textInteractionEnabled).toBe(false);
+    // Read-only keeps the pre-PR behavior (prop left undefined, not forced false).
+    expect(roWebView.props.keyboardDisplayRequiresUserAction).toBeUndefined();
 
     let intRenderer!: ReactTestRenderer;
     act(() => {
       intRenderer = create(<TerminalView interactive />);
     });
-    expect(intRenderer.root.findByProps({ testID: 'webview' }).props.textInteractionEnabled).toBe(true);
+    const intWebView = intRenderer.root.findByProps({ testID: 'webview' });
+    expect(intWebView.props.textInteractionEnabled).toBe(true);
+    expect(intWebView.props.keyboardDisplayRequiresUserAction).toBe(false);
   });
 });
 

--- a/packages/app/src/__tests__/components/TerminalView.test.tsx
+++ b/packages/app/src/__tests__/components/TerminalView.test.tsx
@@ -177,6 +177,89 @@ describe('TerminalView postMessage bridge (#5519)', () => {
   });
 });
 
+describe('TerminalView interactive input (#6003)', () => {
+  // Find a captured RN->WebView bridge message of a given type.
+  function findPosted(type: string): Record<string, unknown> | undefined {
+    return getWebView()
+      .postMessage.mock.calls.map((c) => JSON.parse(c[0] as string))
+      .find((m) => m.type === type);
+  }
+
+  it('enables stdin on ready when interactive (posts set-interactive:true)', () => {
+    act(() => {
+      create(<TerminalView interactive />);
+    });
+    markReady();
+    expect(findPosted('set-interactive')).toEqual({ type: 'set-interactive', enabled: true });
+  });
+
+  it('does NOT enable stdin on ready when read-only (default)', () => {
+    act(() => {
+      create(<TerminalView />);
+    });
+    markReady();
+    const setTrue = getWebView()
+      .postMessage.mock.calls.map((c) => JSON.parse(c[0] as string))
+      .find((m) => m.type === 'set-interactive' && m.enabled === true);
+    expect(setTrue).toBeUndefined();
+  });
+
+  it('forwards xterm input (onData → {type:\'input\'}) to onInput', () => {
+    const onInput = jest.fn();
+    act(() => {
+      create(<TerminalView interactive onInput={onInput} />);
+    });
+    markReady();
+    act(() => {
+      getWebView().emitMessage(JSON.stringify({ type: 'input', data: 'ls -la\r' }));
+    });
+    expect(onInput).toHaveBeenCalledWith('ls -la\r');
+  });
+
+  it('focus() posts a focus bridge message', () => {
+    const handleRef = React.createRef<TerminalHandle>();
+    act(() => {
+      create(<TerminalView ref={handleRef} interactive />);
+    });
+    markReady();
+    const wv = getWebView();
+    wv.postMessage.mockClear();
+    act(() => {
+      handleRef.current!.focus();
+    });
+    expect(JSON.parse(wv.postMessage.mock.calls[0][0] as string)).toEqual({ type: 'focus' });
+  });
+
+  it('pushes interactivity changes after ready (read-only → interactive toggle)', () => {
+    const handleRef = React.createRef<TerminalHandle>();
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<TerminalView ref={handleRef} interactive={false} />);
+    });
+    markReady();
+    const wv = getWebView();
+    wv.postMessage.mockClear();
+    act(() => {
+      renderer.update(<TerminalView ref={handleRef} interactive />);
+    });
+    expect(findPosted('set-interactive')).toEqual({ type: 'set-interactive', enabled: true });
+  });
+
+  it('marks the WebView text-interaction-enabled only when interactive', () => {
+    let roRenderer!: ReactTestRenderer;
+    act(() => {
+      roRenderer = create(<TerminalView />);
+    });
+    expect(roRenderer.root.findByProps({ testID: 'webview' }).props.textInteractionEnabled).toBe(false);
+
+    let intRenderer!: ReactTestRenderer;
+    act(() => {
+      intRenderer = create(<TerminalView interactive />);
+    });
+    expect(intRenderer.root.findByProps({ testID: 'webview' }).props.textInteractionEnabled).toBe(true);
+  });
+});
+
 describe('TerminalView navigation allow-list (#5645)', () => {
   // The xterm document loads from an inline `source={{ html }}` with no baseUrl,
   // so RN WebView reports the document URL as `about:blank` on iOS

--- a/packages/app/src/__tests__/components/xterm-html.test.ts
+++ b/packages/app/src/__tests__/components/xterm-html.test.ts
@@ -60,6 +60,10 @@ describe('buildXtermHtml', () => {
     expect(html).toContain("type: 'input'");
   });
 
+  it('guards onData against firing while read-only (disableStdin safety belt)', () => {
+    expect(html).toContain('if (term.options.disableStdin) return');
+  });
+
   it('handles the set-interactive bridge message (toggles disableStdin)', () => {
     expect(html).toContain("case 'set-interactive'");
     expect(html).toContain('term.options.disableStdin = !msg.enabled');

--- a/packages/app/src/__tests__/components/xterm-html.test.ts
+++ b/packages/app/src/__tests__/components/xterm-html.test.ts
@@ -50,6 +50,27 @@ describe('buildXtermHtml', () => {
     expect(html).toContain('ReactNativeWebView.postMessage');
   });
 
+  // #6003 — interactive user-shell input wiring.
+  it('starts stdin disabled (read-only by default)', () => {
+    expect(html).toContain('disableStdin: true');
+  });
+
+  it('streams keystrokes to RN via onData → {type:\'input\'}', () => {
+    expect(html).toContain('term.onData(');
+    expect(html).toContain("type: 'input'");
+  });
+
+  it('handles the set-interactive bridge message (toggles disableStdin)', () => {
+    expect(html).toContain("case 'set-interactive'");
+    expect(html).toContain('term.options.disableStdin = !msg.enabled');
+  });
+
+  it('handles the focus bridge message and focuses on tap when interactive', () => {
+    expect(html).toContain("case 'focus'");
+    expect(html).toContain("addEventListener('click'");
+    expect(html).toContain('term.focus()');
+  });
+
   it('has no external stylesheet links', () => {
     expect(html).not.toMatch(/<link[^>]*rel="stylesheet"[^>]*href="http/);
   });

--- a/packages/app/src/__tests__/store/terminal-mirror.test.ts
+++ b/packages/app/src/__tests__/store/terminal-mirror.test.ts
@@ -84,6 +84,54 @@ describe('sendTerminalResize', () => {
   });
 });
 
+describe('sendTerminalInput (#6003)', () => {
+  it('sends a single terminal_input frame for a small payload', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().sendTerminalInput('sess-1', 'ls -la\r');
+    expect(sent).toEqual([{ type: 'terminal_input', sessionId: 'sess-1', data: 'ls -la\r' }]);
+  });
+
+  it('does nothing for an empty sessionId or empty data', () => {
+    const sent = mockOpenSocket();
+    useConnectionStore.getState().sendTerminalInput('', 'x');
+    useConnectionStore.getState().sendTerminalInput('sess-1', '');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('no-ops (does not throw) when the socket is not open', () => {
+    useConnectionStore.setState({ socket: null });
+    expect(() => useConnectionStore.getState().sendTerminalInput('sess-1', 'x')).not.toThrow();
+  });
+
+  it('chunks a >64k paste into sub-cap frames that concatenate back to the original', () => {
+    const sent = mockOpenSocket();
+    const big = 'a'.repeat(70000); // > MAX (65536), < 100k cap
+    useConnectionStore.getState().sendTerminalInput('sess-1', big);
+    expect(sent.length).toBeGreaterThan(1);
+    for (const f of sent) {
+      expect(f.type).toBe('terminal_input');
+      expect(f.sessionId).toBe('sess-1');
+      expect((f.data as string).length).toBeLessThanOrEqual(65536);
+    }
+    expect(sent.map((f) => f.data).join('')).toBe(big);
+  });
+
+  it('never splits a UTF-16 surrogate pair across a chunk boundary', () => {
+    const sent = mockOpenSocket();
+    // Fill exactly to the boundary with single-code-unit chars, then an emoji
+    // (surrogate pair) straddling the 65536 seam.
+    const data = 'a'.repeat(65535) + '😀' + 'b'.repeat(1000);
+    useConnectionStore.getState().sendTerminalInput('sess-1', data);
+    // Reassembles losslessly and no chunk ends on a lone high surrogate.
+    expect(sent.map((f) => f.data).join('')).toBe(data);
+    for (const f of sent) {
+      const s = f.data as string;
+      const last = s.charCodeAt(s.length - 1);
+      expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+    }
+  });
+});
+
 describe('terminal_output receive', () => {
   const mockSocket = { readyState: 1, send: jest.fn(), close: jest.fn() } as unknown as WebSocket;
 

--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -53,21 +53,34 @@ export function shouldAllowTerminalNavigation(request: ShouldStartLoadRequest): 
 export interface TerminalHandle {
   write: (data: string) => void;
   clear: () => void;
+  /** #6003 — focus the terminal (summons the soft keyboard when interactive). */
+  focus: () => void;
 }
 
 export interface TerminalViewProps {
   onResize?: (cols: number, rows: number) => void;
   onReady?: () => void;
+  // #6003 — when true, xterm stdin is enabled (interactive user-shell PTY) and
+  // keystrokes/paste stream back via onInput. Defaults to read-only (chat /
+  // claude-tui mirror) so existing behavior is unchanged.
+  interactive?: boolean;
+  onInput?: (data: string) => void;
 }
 
 // -- Component --
 
-export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(function TerminalView({ onResize, onReady }, ref) {
+export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(function TerminalView({ onResize, onReady, interactive, onInput }, ref) {
   const webViewRef = useRef<WebView>(null);
   const readyRef = useRef(false);
   const pendingWritesRef = useRef<string[]>([]);
   const [recovering, setRecovering] = useState(false);
   const recoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // #6003 — keep onInput + interactive in refs so the (stable) message handler
+  // and the ready path read the latest without re-subscribing.
+  const onInputRef = useRef(onInput);
+  const interactiveRef = useRef(interactive);
+  useEffect(() => { onInputRef.current = onInput; }, [onInput]);
+  useEffect(() => { interactiveRef.current = interactive; }, [interactive]);
 
   const html = useMemo(() => buildXtermHtml(), []);
 
@@ -92,6 +105,14 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
     webViewRef.current?.postMessage(JSON.stringify({ type: 'clear' }));
   }, []);
 
+  // #6003 — toggle xterm stdin / focus the terminal via the bridge.
+  const postSetInteractive = useCallback((enabled: boolean) => {
+    webViewRef.current?.postMessage(JSON.stringify({ type: 'set-interactive', enabled }));
+  }, []);
+  const postFocus = useCallback(() => {
+    webViewRef.current?.postMessage(JSON.stringify({ type: 'focus' }));
+  }, []);
+
   useImperativeHandle(ref, () => ({
     write(data: string) {
       if (readyRef.current) {
@@ -106,7 +127,17 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
       }
       pendingWritesRef.current = [];
     },
-  }), [postWrite, postClear]);
+    focus() {
+      if (readyRef.current) postFocus();
+    },
+  }), [postWrite, postClear, postFocus]);
+
+  // #6003 — push interactivity changes once the page is ready. The ready handler
+  // (below) applies the initial state via interactiveRef, so this only fires for
+  // post-ready toggles (e.g. switching to/from a user-shell session).
+  useEffect(() => {
+    if (readyRef.current) postSetInteractive(!!interactive);
+  }, [interactive, postSetInteractive]);
 
   const handleMessage = useCallback((event: WebViewMessageEvent) => {
     try {
@@ -124,6 +155,9 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
         if (pending.length > 0) {
           postWrite(pending.join(''));
         }
+        // #6003 — apply the current interactivity state to the freshly-loaded
+        // page (initial mount and after a crash-recovery reload).
+        if (interactiveRef.current) postSetInteractive(true);
         onReady?.();
         // Forward initial dimensions so the PTY is sized correctly on mount/reload
         if (typeof msg.cols === 'number' && typeof msg.rows === 'number') {
@@ -131,11 +165,14 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
         }
       } else if (msg.type === 'resize') {
         onResize?.(msg.cols, msg.rows);
+      } else if (msg.type === 'input') {
+        // #6003 — a keystroke/paste from an interactive terminal.
+        if (typeof msg.data === 'string') onInputRef.current?.(msg.data);
       }
     } catch {
       // Ignore malformed messages
     }
-  }, [postWrite, onReady, onResize]);
+  }, [postWrite, postSetInteractive, onReady, onResize]);
 
   // Crash recovery: reload WebView when the OS kills the content process
   const handleWebViewCrash = useCallback(() => {
@@ -179,8 +216,14 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
         showsHorizontalScrollIndicator={false}
         allowsInlineMediaPlayback={true}
         mediaPlaybackRequiresUserAction={false}
-        // Prevent text selection in WebView (display-only terminal)
-        textInteractionEnabled={false}
+        // #6003 — allow text interaction (tap-to-focus → soft keyboard) only for
+        // an interactive user-shell terminal; a read-only chat/mirror terminal
+        // stays selection-free as before.
+        textInteractionEnabled={!!interactive}
+        // #6003 — let a tap inside the WebView summon the keyboard without an
+        // extra user gesture (the tap itself is the gesture). iOS-only prop;
+        // harmless elsewhere.
+        keyboardDisplayRequiresUserAction={false}
       />
     </View>
   );

--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -128,7 +128,8 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
       pendingWritesRef.current = [];
     },
     focus() {
-      if (readyRef.current) postFocus();
+      // Only an interactive terminal should summon the soft keyboard.
+      if (readyRef.current && interactiveRef.current) postFocus();
     },
   }), [postWrite, postClear, postFocus]);
 
@@ -166,8 +167,10 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
       } else if (msg.type === 'resize') {
         onResize?.(msg.cols, msg.rows);
       } else if (msg.type === 'input') {
-        // #6003 — a keystroke/paste from an interactive terminal.
-        if (typeof msg.data === 'string') onInputRef.current?.(msg.data);
+        // #6003 — a keystroke/paste from an interactive terminal. Guard on
+        // interactivity too (not just the WebView's disableStdin) so an
+        // unexpected/malicious 'input' message can't drive a read-only terminal.
+        if (interactiveRef.current && typeof msg.data === 'string') onInputRef.current?.(msg.data);
       }
     } catch {
       // Ignore malformed messages
@@ -220,10 +223,11 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
         // an interactive user-shell terminal; a read-only chat/mirror terminal
         // stays selection-free as before.
         textInteractionEnabled={!!interactive}
-        // #6003 — let a tap inside the WebView summon the keyboard without an
-        // extra user gesture (the tap itself is the gesture). iOS-only prop;
-        // harmless elsewhere.
-        keyboardDisplayRequiresUserAction={false}
+        // #6003 — for an interactive terminal, let a tap inside the WebView
+        // summon the keyboard without an extra user gesture (the tap itself is
+        // the gesture). Left undefined for a read-only terminal so its behavior
+        // is unchanged from before this PR. iOS-only prop.
+        keyboardDisplayRequiresUserAction={interactive ? false : undefined}
       />
     </View>
   );

--- a/packages/app/src/components/xterm-html.ts
+++ b/packages/app/src/components/xterm-html.ts
@@ -78,6 +78,10 @@ export function buildXtermHtml(): string {
   // terminals. Covers typed keys, pasted text (bracketed paste — one onData),
   // and xterm-synthesized control sequences.
   term.onData(function(data) {
+    // Read-only safety belt: onData should only fire while stdin is enabled, but
+    // enforce it here too so a future xterm version that emits onData for
+    // programmatic writes can never leak input from a read-only terminal.
+    if (term.options.disableStdin) return;
     window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'input', data: data }));
   });
 

--- a/packages/app/src/components/xterm-html.ts
+++ b/packages/app/src/components/xterm-html.ts
@@ -7,11 +7,17 @@ import { XTERM_CSS, XTERM_JS, FIT_ADDON_JS } from './xterm-bundle.generated';
  * xterm.js + FitAddon are bundled locally (inlined from node_modules via
  * scripts/bundle-xterm.js) so the terminal works offline without CDN access.
  *
- * The terminal is display-only (disableStdin: true) — input goes through InputBar.
+ * The terminal starts display-only (disableStdin: true). For a chat session,
+ * input goes through InputBar. For an interactive user-shell PTY (#6003), RN
+ * sends {type:'set-interactive', enabled:true} to enable stdin; xterm's onData
+ * then streams keystrokes back to RN as {type:'input', data} → terminal_input.
  *
  * Bridge protocol:
- *   RN → WebView (postMessage): {type:'write', data:string}, {type:'clear'}, {type:'reset'}
- *   WebView → RN (postMessage): {type:'ready', cols:number, rows:number}, {type:'resize', cols:number, rows:number}
+ *   RN → WebView (postMessage): {type:'write', data:string}, {type:'clear'}, {type:'reset'},
+ *                               {type:'set-interactive', enabled:boolean}, {type:'focus'}
+ *   WebView → RN (postMessage): {type:'ready', cols:number, rows:number},
+ *                               {type:'resize', cols:number, rows:number},
+ *                               {type:'input', data:string}  (interactive only)
  */
 export function buildXtermHtml(): string {
   return `<!DOCTYPE html>
@@ -67,6 +73,21 @@ export function buildXtermHtml(): string {
   term.loadAddon(fitAddon);
   term.open(document.getElementById('terminal'));
 
+  // #6003: stream keystrokes to RN. onData only fires while stdin is enabled
+  // (set-interactive below), so this is inert for read-only chat/mirror
+  // terminals. Covers typed keys, pasted text (bracketed paste — one onData),
+  // and xterm-synthesized control sequences.
+  term.onData(function(data) {
+    window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'input', data: data }));
+  });
+
+  // #6003: tapping an interactive terminal focuses xterm's hidden textarea,
+  // which summons the soft keyboard (the focus must happen inside the user
+  // gesture for iOS to show the keyboard). No-op while read-only.
+  document.getElementById('terminal').addEventListener('click', function() {
+    if (!term.options.disableStdin) { try { term.focus(); } catch(e) {} }
+  });
+
   // Debounced resize notification (250ms) — avoids flooding during animations/rotations
   var _resizeTimer = null;
   function notifyResize() {
@@ -120,6 +141,15 @@ export function buildXtermHtml(): string {
           break;
         case 'reset':
           term.reset();
+          break;
+        case 'set-interactive':
+          // #6003: toggle stdin for an interactive user-shell PTY. When enabling,
+          // focus so onData starts flowing (and the keyboard can appear).
+          term.options.disableStdin = !msg.enabled;
+          if (msg.enabled) { try { term.focus(); } catch(e) {} }
+          break;
+        case 'focus':
+          try { term.focus(); } catch(e) {}
           break;
       }
     } catch(err) {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -520,6 +520,11 @@ export function SessionScreen() {
   // Reuses the reactive `activeSessionProvider` selector declared above.
   const isUserShell = activeSessionProvider === USER_SHELL_PROVIDER;
   const isPtyMirror = isUserShell;
+  // #6003 — a user-shell terminal is interactive (drivable) only when this client
+  // may drive it: the server's userShell capability is gated on the primary token
+  // (+ userShell.enabled), matching the terminal_input authority gate. claude-tui
+  // mirrors stay read-only. Enables xterm stdin + keystroke forwarding below.
+  const terminalInteractive = isUserShell && userShellSupported;
   // A user-shell session is terminal-only, so it always has a terminal even
   // though it isn't a claude-tui PTY.
   const hasTerminal = isUserShell || !isCliMode || (activeSession?.hasTerminal ?? false);
@@ -584,6 +589,19 @@ export function SessionScreen() {
       store.sendTerminalResize(sid, cols, rows);
     } else {
       store.resize(cols, rows);
+    }
+  }, []);
+
+  // #6003 — forward keystrokes/paste from an interactive user-shell terminal to
+  // the PTY (terminal_input, chunked under the 100k cap). Reads the session
+  // fresh from the store so the callback stays stable; only sends for a
+  // user-shell (the read-only mirror's xterm never emits onData anyway).
+  const handleTerminalInput = useCallback((data: string) => {
+    const store = useConnectionStore.getState();
+    const { activeSessionId: sid, sessions: sess } = store;
+    const provider = sess.find((s) => s.sessionId === sid)?.provider;
+    if (sid && provider === USER_SHELL_PROVIDER) {
+      store.sendTerminalInput(sid, data);
     }
   }, []);
 
@@ -1532,7 +1550,7 @@ export function SessionScreen() {
             <View style={styles.splitDivider} />
             <View style={styles.splitPane}>
               <ErrorBoundary fallbackTitle="Terminal error">
-                <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} />
+                <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} interactive={terminalInteractive} onInput={handleTerminalInput} />
               </ErrorBoundary>
             </View>
           </View>
@@ -1587,11 +1605,11 @@ export function SessionScreen() {
             />
           </ErrorBoundary>
         ) : (
-          // TODO(#6003): interactive keystroke input (xterm stdin + terminal_input) — PR2.
-          // PR1 is a read-only mirror: terminal_output renders here via the
-          // write-callback path, but no keystrokes are forwarded yet.
+          // #6003 — interactive for a user-shell PTY (xterm stdin + terminal_input);
+          // read-only mirror for claude-tui (terminal_output renders via the
+          // write-callback path, onData stays disabled so no input is forwarded).
           <ErrorBoundary fallbackTitle="Terminal error">
-            <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} />
+            <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} interactive={terminalInteractive} onInput={handleTerminalInput} />
           </ErrorBoundary>
         )
       )}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1972,7 +1972,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         const code = data.charCodeAt(end - 1);
         if (code >= 0xd800 && code <= 0xdbff) end -= 1;
       }
-      sendIfOpen({ type: 'terminal_input', sessionId, data: data.slice(i, end) });
+      // sendIfOpen returns false when the socket isn't OPEN; bail rather than
+      // slicing the rest of a large paste into frames that can't be sent.
+      if (!sendIfOpen({ type: 'terminal_input', sessionId, data: data.slice(i, end) })) return;
       i = end;
     }
   },

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1951,6 +1951,32 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     sendIfOpen({ type: 'terminal_resize', sessionId, cols, rows });
   },
 
+  // #6003 — forward keystrokes from an interactive (user-shell) terminal to the
+  // PTY. A single keystroke is a few bytes, but a bracketed paste fires one
+  // onData with the whole clipboard, which can exceed TerminalInputSchema's 100k
+  // cap — the server would reject and drop that frame. Split into sub-cap frames
+  // (the PTY is an ordered byte stream, so splitting is transparent), and never
+  // split a UTF-16 surrogate pair across a boundary so an emoji at the seam can't
+  // corrupt into lone surrogates. Mirrors the dashboard's sendTerminalInput.
+  sendTerminalInput: (sessionId, data) => {
+    if (!sessionId || !data) return;
+    const MAX = 65536; // comfortably under TerminalInputSchema.data.max(100000)
+    if (data.length <= MAX) {
+      sendIfOpen({ type: 'terminal_input', sessionId, data });
+      return;
+    }
+    let i = 0;
+    while (i < data.length) {
+      let end = Math.min(i + MAX, data.length);
+      if (end < data.length) {
+        const code = data.charCodeAt(end - 1);
+        if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+      }
+      sendIfOpen({ type: 'terminal_input', sessionId, data: data.slice(i, end) });
+      i = end;
+    }
+  },
+
   // Directory listing
 
   setDirectoryListingCallback: (cb) => {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -662,6 +662,8 @@ export interface UIViewActions {
   subscribeTerminalMirror: (sessionId: string) => void;
   unsubscribeTerminalMirror: (sessionId: string) => void;
   sendTerminalResize: (sessionId: string, cols: number, rows: number) => void;
+  /** #6003 — forward keystrokes from an interactive (user-shell) terminal to the PTY (chunked under the 100k cap). */
+  sendTerminalInput: (sessionId: string, data: string) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary

PR2 of mobile user-shell: makes the user-shell PTY **drivable** from the phone (PR1 #6002 shipped the read-only mirror). claude-tui terminals stay read-only.

## What changed

- **`xterm-html.ts`** — wire `term.onData` → `{type:'input'}` postMessage (inert while stdin disabled); add `set-interactive` (toggles `disableStdin` + focuses) and `focus` bridge messages; tap-to-focus inside the user gesture so iOS summons the soft keyboard. Starts read-only (`disableStdin: true`).
- **`TerminalView.tsx`** — `interactive` + `onInput` props; `focus()` handle; applies interactivity on `ready` and on post-ready toggle; forwards `input` messages to `onInput`; `textInteractionEnabled` + `keyboardDisplayRequiresUserAction` gated on `interactive` (read-only terminal stays selection-free).
- **store** — `sendTerminalInput(sessionId, data)`: chunks >64k pastes under `TerminalInputSchema`'s 100k cap, UTF-16-surrogate-safe (mirrors the dashboard).
- **`SessionScreen.tsx`** — `terminalInteractive = isUserShell && userShellSupported` (the `userShell` capability is primary-gated, matching the server's `terminal_input` authority); wire `interactive` + `onInput` to both terminal render sites; remove the `TODO(#6003)`.

Server already routes `terminal_input` to the PTY (#5835) and the protocol cap exists — **no server/protocol change**.

## Gating
| Session | stdin | keystrokes forwarded? |
|---|---|---|
| user-shell (primary, userShell cap) | enabled | yes → `terminal_input` |
| claude-tui mirror | disabled | no (read-only) |
| user-shell w/o capability (non-primary) | disabled | no |

## Tests
- `xterm-html.test.ts` — onData→input wiring, set-interactive/focus handlers, starts read-only.
- `TerminalView.test.tsx` — enables stdin on ready when interactive (not when read-only), forwards input→onInput, `focus()` posts, post-ready toggle, `textInteractionEnabled` gating.
- `terminal-mirror.test.ts` — `sendTerminalInput` single frame, empty/closed-socket no-op, >64k chunking reassembles losslessly, surrogate-pair never split.
- Full app suite green: **1962 tests**, app `tsc` clean.

## ⚠️ Needs on-device verification (per the issue)
This lands the **best-effort** soft-keyboard wiring (tap-to-focus in-gesture, `keyboardDisplayRequiresUserAction={false}`, `textInteractionEnabled`). The issue explicitly calls out soft-keyboard summoning on RN WebView as the finicky part needing iOS + Android iteration. The remaining ACs to confirm on hardware:
- [ ] Typing reaches the PTY and echoes back
- [ ] Soft keyboard appears on focus (iOS + Android)
- [ ] Paste >100k chunked, not dropped (unit-tested; confirm on device)

A fresh dev/preview APK is needed to test (the earlier APK predates this).

Closes #6003. Related to #5987, #5982