### PR TITLE
test(app): cover App-level view-mode effect transitions (#5998)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -236,6 +236,14 @@ vi.mock('./store/connection', () => {
     requestHostStatus: vi.fn(),
     requestRunnerStatus: vi.fn(),
     requestIntegrationStatus: vi.fn(),
+    // #5998 — the App-level view-mode effect opts a PTY-backed session into the
+    // live terminal mirror and forces the view-mode for terminal-only / non-PTY
+    // providers. The base mock exposes the two mirror actions + the
+    // serverCapabilities slice the effect (and the "New Shell" gate) read, so the
+    // effect's selectors don't crash on a missing action when these tests run.
+    subscribeTerminalMirror: vi.fn(),
+    unsubscribeTerminalMirror: vi.fn(),
+    serverCapabilities: null,
   }
   const useConnectionStore = (
     selector?: (s: typeof baseState) => unknown,
@@ -2585,5 +2593,191 @@ describe('context meter with unknown context window (#5424)', () => {
     const label = screen.getByTestId('status-context-label')
     expect(label.textContent).toContain('12.5k')
     expect(label.textContent).toContain('32.0k')
+  })
+})
+
+// #5998 — App-level view-mode effect (App.tsx). The effect:
+//   1. forces a user-shell (terminal-only) session's view to 'terminal'
+//      when it's sitting on the now-hidden Chat tab;
+//   2. forces a non-PTY (chat) provider back to 'chat' if it's stranded on
+//      the Output tab — but ONLY once the provider is known (not null), the
+//      #5838 null-provider guard, so a persisted Output view for a claude-tui
+//      session isn't kicked away during the load/reconnect window;
+//   3. opts a PTY-backed session (BOTH claude-tui AND user-shell) into the
+//      live terminal mirror when on the Output tab + connected, re-subscribing
+//      after a reconnect (connectionPhase flips back to 'connected').
+describe('App-level view-mode effect (#5998)', () => {
+  function session(provider: string) {
+    return {
+      sessionId: 's1',
+      name: 'Test',
+      cwd: '/tmp',
+      type: 'cli' as const,
+      hasTerminal: true,
+      model: null,
+      permissionMode: null,
+      isBusy: false,
+      createdAt: Date.now(),
+      conversationId: null,
+      provider,
+    }
+  }
+
+  // AC1 — switching to a user-shell session forces viewMode to 'terminal'
+  // (the Chat tab is hidden for a terminal-only provider, so a session sitting
+  // on the persisted 'chat' default must snap to the Output terminal).
+  it('forces viewMode to terminal for a user-shell session sitting on chat (AC1)', () => {
+    const setViewMode = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('user-shell')],
+      activeSessionId: 's1',
+      viewMode: 'chat',
+      serverCapabilities: { userShell: true },
+      setViewMode,
+    }
+    render(<App />)
+    expect(setViewMode).toHaveBeenCalledWith('terminal')
+  })
+
+  it('does NOT force a user-shell session away from a non-chat tab (System stays put) (AC1)', () => {
+    // The effect only redirects from the now-hidden Chat tab — Files/System are
+    // useful for a shell's cwd and must not be snapped back (#5997).
+    const setViewMode = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('user-shell')],
+      activeSessionId: 's1',
+      viewMode: 'system',
+      serverCapabilities: { userShell: true },
+      setViewMode,
+    }
+    render(<App />)
+    expect(setViewMode).not.toHaveBeenCalled()
+  })
+
+  // AC2 — a non-PTY (chat) provider stranded on the Output tab is forced back
+  // to chat once the provider is known.
+  it('forces viewMode to chat when a non-PTY provider is stranded on the Output tab (AC2)', () => {
+    const setViewMode = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('claude-sdk')],
+      activeSessionId: 's1',
+      viewMode: 'terminal',
+      setViewMode,
+    }
+    render(<App />)
+    expect(setViewMode).toHaveBeenCalledWith('chat')
+  })
+
+  // AC2 — the #5838 null-provider guard: during the initial-load / reconnect
+  // window the active session's provider is still null/unknown. Force-switching
+  // then would kick the operator out of a persisted Output view for a
+  // claude-tui session, so the effect must NOT force away from 'terminal'.
+  it('does NOT force-switch from terminal while the provider is still null (#5838 guard) (AC2)', () => {
+    const setViewMode = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      // No matching session for activeSessionId → activeSessionProvider is null
+      // (the load/reconnect window before session_list resolves the provider).
+      sessions: [],
+      activeSessionId: 's1',
+      viewMode: 'terminal',
+      setViewMode,
+    }
+    render(<App />)
+    expect(setViewMode).not.toHaveBeenCalled()
+  })
+
+  // AC3 — a PTY provider on the Output tab + connected subscribes to the mirror.
+  // BOTH claude-tui and user-shell are PTY-backed (isPtyProvider = isTui ||
+  // isUserShell), so both subscribe.
+  it('subscribes to the terminal mirror for a claude-tui session on Output + connected (AC3)', () => {
+    const subscribeTerminalMirror = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('claude-tui')],
+      activeSessionId: 's1',
+      viewMode: 'terminal',
+      subscribeTerminalMirror,
+    }
+    render(<App />)
+    expect(subscribeTerminalMirror).toHaveBeenCalledWith('s1')
+  })
+
+  it('subscribes to the terminal mirror for a user-shell session on Output + connected (AC3)', () => {
+    const subscribeTerminalMirror = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('user-shell')],
+      activeSessionId: 's1',
+      viewMode: 'terminal',
+      serverCapabilities: { userShell: true },
+      subscribeTerminalMirror,
+    }
+    render(<App />)
+    expect(subscribeTerminalMirror).toHaveBeenCalledWith('s1')
+  })
+
+  it('does NOT subscribe for a non-PTY (chat) provider even on the Output tab (AC3)', () => {
+    // A claude-sdk session has no PTY mirror; it's force-switched to chat
+    // (AC2) and never subscribes.
+    const subscribeTerminalMirror = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('claude-sdk')],
+      activeSessionId: 's1',
+      viewMode: 'terminal',
+      subscribeTerminalMirror,
+    }
+    render(<App />)
+    expect(subscribeTerminalMirror).not.toHaveBeenCalled()
+  })
+
+  it('does NOT subscribe while disconnected, then subscribes when the socket connects (AC3)', () => {
+    // The opt-in is gated on a live socket (connectionPhase === 'connected').
+    const subscribeTerminalMirror = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connecting',
+      sessions: [session('claude-tui')],
+      activeSessionId: 's1',
+      viewMode: 'terminal',
+      subscribeTerminalMirror,
+    }
+    const { rerender } = render(<App />)
+    expect(subscribeTerminalMirror).not.toHaveBeenCalled()
+
+    stateOverrides = { ...stateOverrides, connectionPhase: 'connected' }
+    rerender(<App />)
+    expect(subscribeTerminalMirror).toHaveBeenCalledWith('s1')
+  })
+
+  it('re-subscribes to the terminal mirror after a reconnect (AC3)', () => {
+    // A reconnect clears the server-side terminalSessionIds set, so the effect
+    // must re-run on the connectionPhase change and re-subscribe — otherwise
+    // the mirror silently stops updating (#5838).
+    const subscribeTerminalMirror = vi.fn()
+    const unsubscribeTerminalMirror = vi.fn()
+    stateOverrides = {
+      connectionPhase: 'connected',
+      sessions: [session('claude-tui')],
+      activeSessionId: 's1',
+      viewMode: 'terminal',
+      subscribeTerminalMirror,
+      unsubscribeTerminalMirror,
+    }
+    const { rerender } = render(<App />)
+    expect(subscribeTerminalMirror).toHaveBeenCalledTimes(1)
+
+    // Drop the connection (cleanup runs → unsubscribe), then reconnect.
+    stateOverrides = { ...stateOverrides, connectionPhase: 'reconnecting' }
+    rerender(<App />)
+    expect(unsubscribeTerminalMirror).toHaveBeenCalledWith('s1')
+
+    stateOverrides = { ...stateOverrides, connectionPhase: 'connected' }
+    rerender(<App />)
+    expect(subscribeTerminalMirror).toHaveBeenCalledTimes(2)
+    expect(subscribeTerminalMirror).toHaveBeenLastCalledWith('s1')
   })
 })

--- a/packages/dashboard/src/components/ViewSwitcher.test.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.test.tsx
@@ -52,6 +52,17 @@ describe('ViewSwitcher tab gates', () => {
     expect(screen.getByRole('button', { name: 'Output' })).toBeInTheDocument()
   })
 
+  // #5998 — dedicated Split + showChatTab=false case: a terminal-only provider
+  // (user-shell) has no chat surface, so the Split tab — which renders a
+  // ChatView alongside a terminal pane — must be hidden even though the Output
+  // terminal is present.
+  it('hides the Split tab when showChatTab=false (terminal-only provider) (#5998)', () => {
+    renderSwitcher({ showChatTab: false, showTerminalTab: true })
+    expect(screen.queryByRole('button', { name: 'Split' })).not.toBeInTheDocument()
+    // The Output terminal stays — the only surface a user-shell has.
+    expect(screen.getByRole('button', { name: 'Output' })).toBeInTheDocument()
+  })
+
   it('shows Split only when BOTH chat and terminal surfaces exist (#5997)', () => {
     // Split renders a ChatView + a terminal pane, so it needs both — present
     // only when showChatTab AND showTerminalTab (claude-tui today).


### PR DESCRIPTION
## Summary

Adds test coverage for the App-level view-mode effect in `packages/dashboard/src/App.tsx` (the effect that drives view-mode + the live terminal mirror for PTY / terminal-only providers). The effect was previously untested.

The `ViewSwitcher.test.tsx` AC lives in the dashboard package — the only `ViewSwitcher` in the repo, and the same effect/component PR #5996 (#5986) shipped. The effect's #5838 null-provider guard and `isPtyProvider = isTui || isUserShell` logic match the ACs exactly.

## What's tested (per AC)

**AC1 — user-shell forces terminal**
- A user-shell session sitting on the (now-hidden) Chat tab snaps `viewMode` to `terminal`.
- A user-shell session on a non-chat tab (System) is NOT snapped back (#5997).

**AC2 — non-PTY forces chat + #5838 null-provider guard**
- A non-PTY (chat) provider stranded on the Output tab is forced back to `chat` once the provider is known.
- During the load/reconnect window the provider is still `null` → the effect does NOT force-switch away from `terminal` (the #5838 guard that protects a persisted Output view for a claude-tui session).

**AC3 — PTY providers (claude-tui AND user-shell) subscribe to the mirror**
- Both claude-tui and user-shell subscribe to `subscribeTerminalMirror` on Output + connected.
- A non-PTY provider does not subscribe.
- No subscribe while disconnected; subscribes once the socket connects.
- Re-subscribes after a reconnect (unsubscribe on drop, fresh subscribe on reconnect — #5838).

**AC4 — Split + showChatTab=false**
- Dedicated `ViewSwitcher.test.tsx` case asserting the Split tab is hidden for a terminal-only provider (showChatTab=false, showTerminalTab=true).

## Test-support tweak
Added `subscribeTerminalMirror`, `unsubscribeTerminalMirror`, and `serverCapabilities` to the existing App.test store mock so the effect's selectors resolve.

## Verification
- `npx vitest run src/App.test.tsx src/components/ViewSwitcher.test.tsx` — 114 passed.
- Full dashboard suite: `npm test` — 3813 passed (202 files).
- `npm run typecheck` — clean.

Closes #5998