### PR TITLE
fix(dashboard): suppress AskUserQuestion raw tool_input streaming bubble on claude-tui (#5770)

### DIFF
--- a/packages/dashboard/src/components/AskUserQuestionRawInputLeak.test.tsx
+++ b/packages/dashboard/src/components/AskUserQuestionRawInputLeak.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * #5770 — AskUserQuestion raw tool_input must never leak into the chat.
+ *
+ * Per #4667 the only render path for an AskUserQuestion is the structured
+ * QuestionPrompt card (driven by the parallel `user_question` event). The raw
+ * `tool_input` JSON — which on the claude-tui provider arrives as a stream of
+ * `tool_input_delta` chunks accumulating into `toolInputPartial` — must NOT be
+ * surfaced as a chat bubble.
+ *
+ * `ToolBubble` already suppresses this (its `SUPPRESS_RAW_INPUT_TOOLS` gate),
+ * but the SECOND render path — `ToolGroup`, used whenever a contiguous run of
+ * 2+ tools is collapsed — rendered the partial accumulator verbatim in its
+ * expanded detail panel with no suppression check. On claude-tui an
+ * AskUserQuestion call sitting alongside another tool in the same turn took the
+ * ToolGroup path, so the raw `{"questions":[...` JSON leaked next to the proper
+ * card.
+ *
+ * These tests drive the PRODUCTION wire path: `handleToolStart` +
+ * `handleToolInputDelta` build the store messages, `buildChatViewMessages`
+ * groups them, and the renderer is exercised exactly as the dashboard does.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ChatMessage } from '@chroxy/store-core'
+import {
+  handleToolStart,
+  handleToolInputDelta,
+  buildChatViewMessages,
+} from '@chroxy/store-core'
+import { ToolGroup } from './ToolGroup'
+
+afterEach(cleanup)
+
+const SESSION = 'sess-1'
+
+// Build the store messages exactly as the dashboard would after receiving a
+// claude-tui-style tool_start + a stream of tool_input_delta chunks for an
+// AskUserQuestion, plus a sibling tool so the run collapses into a ToolGroup.
+function buildLeakScenario(): ChatMessage[] {
+  // A preceding completed tool so the contiguous run is 2+ (forces ToolGroup,
+  // not the singleton ToolBubble path).
+  const sibling = handleToolStart(
+    { sessionId: SESSION, tool: 'Read', toolUseId: 'tu-read', messageId: 'm-read', input: { file_path: '/etc/hosts' } },
+    SESSION,
+    false,
+    [],
+  )
+  // The AskUserQuestion tool_start — claude-tui streams the input rather than
+  // delivering it inline, so there is no `input` field on the start frame.
+  const ask = handleToolStart(
+    { sessionId: SESSION, tool: 'AskUserQuestion', toolUseId: 'tu-ask', messageId: 'm-ask' },
+    SESSION,
+    false,
+    [],
+  )
+
+  let messages: ChatMessage[] = []
+  // handleToolStart carries the tool name on the ChatMessage but populates
+  // `toolInput` later (via tool_result / final input); attach the sibling's
+  // structured input so the regression test can assert it still renders.
+  if (sibling.chatMessage) messages.push({ ...sibling.chatMessage, toolInput: { file_path: '/etc/hosts' } })
+  if (ask.chatMessage) messages.push(ask.chatMessage)
+
+  // Stream the raw tool_input JSON in chunks, exactly like the wire deltas.
+  const chunks = [
+    '{"questions":[{"question":"Pick a deploy target",',
+    '"header":"Deploy","options":[{"label":"staging"},',
+    '{"label":"production"}]}]}',
+  ]
+  for (const partialJson of chunks) {
+    const delta = handleToolInputDelta(
+      { sessionId: SESSION, toolUseId: 'tu-ask', partialJson },
+      SESSION,
+    )
+    if (delta) messages = delta.applyTo(messages)
+  }
+  return messages
+}
+
+describe('#5770 AskUserQuestion raw tool_input leak', () => {
+  it('the wire path accumulates the raw JSON into toolInputPartial (sanity)', () => {
+    const messages = buildLeakScenario()
+    const ask = messages.find((m) => m.toolUseId === 'tu-ask')!
+    expect(ask.tool).toBe('AskUserQuestion')
+    // The accumulator holds the full raw JSON — this is what must NOT reach the UI.
+    expect(ask.toolInputPartial).toContain('"questions"')
+    expect(ask.toolInputPartial).toContain('Pick a deploy target')
+  })
+
+  it('groups the AskUserQuestion + sibling into a tool_group (the leaking path)', () => {
+    const messages = buildLeakScenario()
+    const { chatMessages, chatToolGroupPayloads } = buildChatViewMessages(messages, null)
+    const group = chatMessages.find((m) => m.type === 'tool_group')
+    expect(group).toBeDefined()
+    const payload = chatToolGroupPayloads.get(group!.id)!
+    expect(payload.messages.some((m) => m.tool === 'AskUserQuestion')).toBe(true)
+  })
+
+  it('does NOT render the raw AskUserQuestion tool_input JSON in the expanded ToolGroup', () => {
+    const messages = buildLeakScenario()
+    const { chatToolGroupPayloads, chatMessages } = buildChatViewMessages(messages, null)
+    const group = chatMessages.find((m) => m.type === 'tool_group')!
+    const payload = chatToolGroupPayloads.get(group.id)!
+
+    render(<ToolGroup messages={payload.messages} isActive={true} />)
+    // Active groups start expanded — the AskUserQuestion entry's detail panel
+    // is visible. Expand the entry too (its detail panel is per-entry).
+    fireEvent.click(screen.getByTestId('tool-group-entry-row-m-ask'))
+
+    // The raw question JSON must NOT appear anywhere in the rendered group.
+    expect(screen.queryByText(/Pick a deploy target/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/"questions"/)).not.toBeInTheDocument()
+    // The sibling tool's real input is unaffected.
+    expect(screen.getByTestId('tool-group-entry-m-read')).toHaveTextContent('/etc/hosts')
+  })
+})

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -28,6 +28,7 @@ import {
   getInputSummary,
   getPartialSummary,
   tryParseCompleteJson,
+  shouldSuppressRawToolInput,
 } from '@chroxy/store-core'
 import type { ChildAgentEvent, ToolResultImage } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
@@ -108,7 +109,12 @@ export interface ToolBubbleProps {
 // (b) the tool_input shape carries no user-meaningful text on its own.
 // "This shape looks ugly when rendered raw" is NOT sufficient — that's
 // what #4655's generic key:value fallback in `tool-summary.ts` is for.
-const SUPPRESS_RAW_INPUT_TOOLS = new Set(['AskUserQuestion'])
+//
+// #5770 — the suppress set now lives in @chroxy/store-core
+// (`SUPPRESS_RAW_INPUT_TOOLS` / `shouldSuppressRawToolInput`) as the single
+// source of truth so this path and the `ToolGroup` (2+ contiguous tools)
+// detail-panel path can't drift — the group path previously had no
+// suppression check and leaked the raw AskUserQuestion JSON on claude-tui.
 
 export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false, resultImages, childAgentEvents }: ToolBubbleProps) {
   // #4313 — tail bubbles mount expanded so the singleton trailing-tool
@@ -138,7 +144,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   // render path owns the display. Gate computed once so both the
   // collapsed summary and the expanded partial-preview branches stay
   // in sync.
-  const suppressRawInput = SUPPRESS_RAW_INPUT_TOOLS.has(toolName)
+  const suppressRawInput = shouldSuppressRawToolInput(toolName)
   // #4081: prefer the structured `input` summary when present (server
   // gave us the full final input, e.g. via legacy non-streaming
   // providers or after `tool_result` lands). Otherwise fall back to the

--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -312,11 +312,15 @@ describe('ToolGroup', () => {
       expect(screen.getByTestId('tool-group-entry-detail-2')).toHaveTextContent('root')
     })
 
-    it('renders the structured AskUserQuestion input verbatim so the user can see the question + options', () => {
-      // The bug surfaced via #4278: AskUserQuestion in a TUI session ends
-      // up in the tool group with no way to see what was asked. Until the
-      // server-side fix lands (#4278), at least the dashboard must let the
-      // user expand the entry to read the structured question.
+    it('suppresses the raw AskUserQuestion input — the QuestionPrompt card owns the display (#4667 / #5770)', () => {
+      // History: #4278 originally rendered AskUserQuestion's raw input in the
+      // group as a stopgap so the user could at least read the question. That
+      // is now obsolete — #4667 designated the structured QuestionPrompt card
+      // (driven by the parallel `user_question` event) as the ONLY render
+      // path, and #5770 found the group's detail panel was leaking the raw
+      // `{"questions":[...` JSON beside the card on the claude-tui provider
+      // (an AskUserQuestion sharing a turn with another tool takes the group
+      // path, not the singleton ToolBubble). Both surfaces must suppress.
       const messages = [
         tool('1', 'AskUserQuestion', {
           toolInput: {
@@ -332,9 +336,13 @@ describe('ToolGroup', () => {
       render(<ToolGroup messages={messages} isActive={true} />)
       fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
       const detail = screen.getByTestId('tool-group-entry-detail-1')
-      expect(detail).toHaveTextContent('Which release strategy?')
-      expect(detail).toHaveTextContent('Patch')
-      expect(detail).toHaveTextContent('Minor')
+      // The raw question text + options must NOT leak anywhere in the group.
+      expect(detail).not.toHaveTextContent('Which release strategy?')
+      expect(detail).not.toHaveTextContent('Patch')
+      expect(detail).not.toHaveTextContent('Minor')
+      // The entry collapses to a quiet placeholder: tool name only, "(no input)".
+      expect(screen.getByTestId('tool-group-entry-1')).toHaveTextContent('AskUserQuestion')
+      expect(detail).toHaveTextContent('(no input)')
     })
 
     it('Thinking entries are not expandable (no marker, no detail panel even on click)', () => {

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -16,6 +16,7 @@ import {
   formatToolName,
   tryParseCompleteJson,
   getInputSummary,
+  shouldSuppressRawToolInput,
 } from '@chroxy/store-core'
 import { ChildAgentEventList } from './ChildAgentEventList'
 import { ChatExpandContext, useInitialExpanded } from './chatExpandRegistry'
@@ -87,7 +88,18 @@ function ToolGroupEntry({
     )
   }
   const toolName = formatToolName(message.tool ?? 'Tool', message.serverName)
-  const summary = getInputSummary(message.toolInput)
+  // #4667 / #5770 — internal-shape tools (currently AskUserQuestion) must
+  // never surface raw `tool_input` in the chat surface; a dedicated
+  // structured card (QuestionPrompt, driven by the parallel `user_question`
+  // event) owns the display. ToolBubble already gates this; the grouped-entry
+  // path must too, or the raw `{"questions":[...` JSON streamed via
+  // `tool_input_delta` leaks into the expanded detail panel beside the card
+  // (the #5770 claude-tui leak — an AskUserQuestion sharing a turn with
+  // another tool takes the ToolGroup path, not the singleton ToolBubble).
+  // Shared suppress set lives in @chroxy/store-core so the two paths can't
+  // drift.
+  const suppressRawInput = shouldSuppressRawToolInput(message.tool)
+  const summary = suppressRawInput ? '' : getInputSummary(message.toolInput)
   // `toolResult` is set to the server's result string by handleToolResult,
   // including the empty string when the tool produced no output. A bare
   // truthiness check (`!!toolResult`) wrongly classifies an empty result
@@ -115,7 +127,11 @@ function ToolGroupEntry({
     }
   }
 
-  const structuredInputDetail = formatInputForDetail(message.toolInput)
+  // #4667 / #5770 — suppressed tools skip BOTH the structured and the
+  // streaming partial detail so the expanded panel shows "(no input)"
+  // instead of leaking the raw JSON. The QuestionPrompt card is the
+  // canonical render path.
+  const structuredInputDetail = suppressRawInput ? '' : formatInputForDetail(message.toolInput)
   // #4341: fall through to the streaming `toolInputPartial` accumulator
   // when the structured `toolInput` is empty. Pre-fix the expanded panel
   // showed "(no input)" for in-flight Agent/Task tools even though
@@ -124,7 +140,7 @@ function ToolGroupEntry({
   // (#4081), so the expanded view now mirrors the same fallback.
   // `isStreamingInput` flags the panel as still arriving so styling can
   // hint at the in-flight state (data-streaming="true").
-  const partialInputDetail = structuredInputDetail
+  const partialInputDetail = structuredInputDetail || suppressRawInput
     ? ''
     : formatPartialForDetail(message.toolInputPartial)
   const inputDetail = structuredInputDetail || partialInputDetail

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -140,7 +140,7 @@ function ToolGroupEntry({
   // (#4081), so the expanded view now mirrors the same fallback.
   // `isStreamingInput` flags the panel as still arriving so styling can
   // hint at the in-flight state (data-streaming="true").
-  const partialInputDetail = structuredInputDetail || suppressRawInput
+  const partialInputDetail = (structuredInputDetail || suppressRawInput)
     ? ''
     : formatPartialForDetail(message.toolInputPartial)
   const inputDetail = structuredInputDetail || partialInputDetail

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -333,6 +333,8 @@ export {
 export {
   getPartialSummary,
   getInputSummary,
+  SUPPRESS_RAW_INPUT_TOOLS,
+  shouldSuppressRawToolInput,
 } from './tool-summary'
 
 export {

--- a/packages/store-core/src/tool-summary.test.ts
+++ b/packages/store-core/src/tool-summary.test.ts
@@ -7,7 +7,12 @@
  * partial-JSON / final-input shapes.
  */
 import { describe, it, expect } from 'vitest'
-import { getInputSummary, getPartialSummary } from './tool-summary'
+import {
+  getInputSummary,
+  getPartialSummary,
+  SUPPRESS_RAW_INPUT_TOOLS,
+  shouldSuppressRawToolInput,
+} from './tool-summary'
 
 describe('getPartialSummary (#4243)', () => {
   it('prefers `command` over body when the partial JSON parses', () => {
@@ -300,5 +305,32 @@ describe('generic-fallback summary for unknown tool shapes (#4655)', () => {
     it('returns null for parseable but empty object (nothing to summarize)', () => {
       expect(getPartialSummary('{}')).toBeNull()
     })
+  })
+})
+
+// #4667 / #5770 — shared single source of truth for tools whose raw
+// tool_input must never reach any chat render path. Both ToolBubble (web +
+// mobile) and ToolGroup import this so the suppression can't drift.
+describe('shouldSuppressRawToolInput (#4667 / #5770)', () => {
+  it('suppresses AskUserQuestion — the claude-tui name shape on the wire', () => {
+    expect(shouldSuppressRawToolInput('AskUserQuestion')).toBe(true)
+    expect(SUPPRESS_RAW_INPUT_TOOLS.has('AskUserQuestion')).toBe(true)
+  })
+
+  it('does not suppress ordinary tools (their input is user-meaningful)', () => {
+    expect(shouldSuppressRawToolInput('Bash')).toBe(false)
+    expect(shouldSuppressRawToolInput('Read')).toBe(false)
+    expect(shouldSuppressRawToolInput('TodoWrite')).toBe(false)
+  })
+
+  it('is exact-match — no casing/prefix coercion (the wire name is canonical)', () => {
+    expect(shouldSuppressRawToolInput('askuserquestion')).toBe(false)
+    expect(shouldSuppressRawToolInput('mcp__x__AskUserQuestion')).toBe(false)
+  })
+
+  it('tolerates missing / null tool names', () => {
+    expect(shouldSuppressRawToolInput(undefined)).toBe(false)
+    expect(shouldSuppressRawToolInput(null)).toBe(false)
+    expect(shouldSuppressRawToolInput('')).toBe(false)
   })
 })

--- a/packages/store-core/src/tool-summary.ts
+++ b/packages/store-core/src/tool-summary.ts
@@ -217,3 +217,35 @@ export function getInputSummary(input: Record<string, unknown> | string | null |
   const generic = buildGenericSummary(inputObj)
   return generic ?? ''
 }
+
+// #4667 / #5770 — tools whose `tool_input` shape is internal and whose
+// canonical render path is a dedicated structured card driven by a parallel
+// event (AskUserQuestion → the `user_question` → QuestionPrompt card). For
+// these the raw input — including the `toolInputPartial` accumulator streamed
+// via `tool_input_delta` — must NEVER be surfaced in the chat: the collapsed
+// summary, the expanded partial-preview, AND the grouped-entry detail panel.
+// Otherwise the raw `{"questions":[...` JSON leaks as a bubble next to the
+// proper card (two bubbles for the same prompt).
+//
+// SINGLE SOURCE OF TRUTH (#5770): both the singleton `ToolBubble` and the
+// `ToolGroup` (2+ contiguous tools) render paths import this set so they can't
+// drift — previously `ToolGroup`'s detail panel had no suppression check and
+// leaked the raw JSON on the claude-tui provider whenever an AskUserQuestion
+// shared a turn with another tool.
+//
+// Add a tool here only when BOTH conditions hold: (a) a dedicated structured
+// renderer already exists for it (driven by a parallel event, the way
+// `user_question` drives QuestionPrompt) AND (b) the tool_input shape carries
+// no user-meaningful text on its own. "This shape looks ugly when rendered
+// raw" is NOT sufficient — that's what the #4655 generic key:value fallback
+// above is for.
+export const SUPPRESS_RAW_INPUT_TOOLS: ReadonlySet<string> = new Set(['AskUserQuestion'])
+
+/**
+ * Whether a tool's raw `tool_input` (final or the streaming
+ * `toolInputPartial` accumulator) must be suppressed from every chat render
+ * path. See {@link SUPPRESS_RAW_INPUT_TOOLS}.
+ */
+export function shouldSuppressRawToolInput(toolName: string | undefined | null): boolean {
+  return !!toolName && SUPPRESS_RAW_INPUT_TOOLS.has(toolName)
+}


### PR DESCRIPTION
## Problem

In the web dashboard, when the model calls `AskUserQuestion` via the **claude-tui** provider, the raw `tool_input` JSON leaked into the chat as an unformatted bubble rendered next to the structured QuestionPrompt card. Per #4667 the structured card is the only render path — the raw input must be suppressed entirely.

## Root cause

There are **two** tool-render paths, and only one was gated:

1. **Singleton `ToolBubble`** (1 trailing tool) — already suppressed raw input via a local `SUPPRESS_RAW_INPUT_TOOLS = new Set(['AskUserQuestion'])`.
2. **`ToolGroup`** (used whenever a contiguous run of 2+ tools collapses into a group) — had **no** suppression check. `ToolGroupEntry` rendered `formatPartialForDetail(message.toolInputPartial)` verbatim in its expanded detail panel.

On claude-tui the `tool_input` for AskUserQuestion is **streamed** as `tool_input_delta` chunks accumulating into `toolInputPartial`, and the call frequently shares a turn with another tool — so it takes the **ToolGroup** path, where the raw `{"questions":[...` JSON leaked beside the card. ToolBubble's gates were never the bug (as the issue noted); the group path was the unsuppressed source.

## Fix

- **Single source of truth**: moved the suppress set + a `shouldSuppressRawToolInput()` helper into `@chroxy/store-core` (`tool-summary.ts`, alongside the `getInputSummary`/`getPartialSummary` helpers whose output it gates), exported from the package index. ToolBubble and ToolGroup now both import it so they can't drift.
- **ToolGroup**: suppress the collapsed summary, the structured detail, and the streaming-partial detail for suppressed tools — the entry shows a quiet `(no input)` placeholder.
- **ToolBubble**: import the shared helper instead of its local literal set (behaviour unchanged).

## Regression tests

- New dashboard test (`AskUserQuestionRawInputLeak.test.tsx`) drives the **production wire path** — `handleToolStart` + `handleToolInputDelta` → `buildChatViewMessages` → `<ToolGroup>` — and asserts the raw question JSON never renders (RED before the fix, GREEN after).
- The obsolete #4278 ToolGroup test (which asserted the raw input *did* render, a pre-fix stopgap before the structured card existed) is updated to assert suppression.
- store-core unit tests pin the shared helper, including the claude-tui AskUserQuestion name shape and exact-match semantics (no casing/prefix coercion).

## Verification

- `packages/dashboard`: `npm test` → 3816 passed (203 files); `npm run typecheck` clean.
- `packages/store-core`: full `vitest run` → 1641 passed (39 files); `npm run typecheck` clean.

Closes #5770