### PR TITLE
test(store-core): enforce both-clients SWITCH_FIXTURES coverage + grow fixtures (#5619)

### DIFF
--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Both-clients SWITCH_FIXTURES coverage lint (#5619, epic #5556).
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * `SWITCH_FIXTURES` is the only suite that drives BOTH clients' production
+ * `handleMessage` switches against one shared expectation (app jest +
+ * dashboard vitest). It is the behavioural-contract guard for the message
+ * types that still live in each client's own switch / HANDLERS map (i.e. the
+ * cases NOT yet migrated to the shared store-core dispatch table — those are
+ * covered+enforced separately by `contract.test.ts` against DISPATCH_FIXTURES).
+ *
+ * Before this lint, growing that coverage was unenforced: a contributor could
+ * add a NEW both-clients switch case (a type handled by both the app and the
+ * dashboard) and never add a contract fixture for it, silently widening the
+ * exact behavioural-drift surface epic #5556 set out to close.
+ *
+ * WHAT THIS LINT ENFORCES
+ * -----------------------
+ * It derives the authoritative both-clients-SWITCH universe by static-parsing
+ * the two clients' real `message-handler.ts` sources (the same technique the
+ * protocol `handler-coverage.test.js` guard uses), intersecting them, and
+ * subtracting the shared dispatch-table types (`DISPATCH_TABLE_TYPES`, which
+ * are covered by DISPATCH_FIXTURES). Every remaining type MUST be either:
+ *   - covered by a `SWITCH_FIXTURES` entry, OR
+ *   - listed in the explicit `PENDING_CONTRACT_TYPES` allowlist below.
+ *
+ * A NEW both-clients switch type added without a fixture or a pending entry
+ * FAILS this lint — that is the anti-drift guarantee. The allowlist absorbs the
+ * pre-existing ~57-type backlog so the lint does not force all of them at once;
+ * SHRINKING the allowlist (by adding genuine fixtures) is the tracked future
+ * work (#5618 / #5619). The lint also fails on a STALE allowlist entry (a type
+ * that is no longer a both-clients switch type, or that has since gained a
+ * fixture) — so the allowlist can only shrink, never silently rot.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { SWITCH_FIXTURES } from './fixtures'
+import { DISPATCH_TABLE_TYPES } from '../dispatch-table'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const appHandlerPath = resolve(here, '../../../app/src/store/message-handler.ts')
+const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-handler.ts')
+
+// ---------------------------------------------------------------------------
+// PENDING allowlist — both-clients switch types that do NOT yet have a
+// SWITCH_FIXTURES entry. This is the pre-existing backlog (epic #5556 sub-item
+// 5 covered only ~6 of these). The lint subtracts this set so it enforces
+// NO-NEW-DRIFT without forcing all ~57 fixtures at once. Each removal here must
+// be paired with a real, behaviour-verified fixture in fixtures.ts. SHRINKING
+// this set toward empty is tracked under #5618 / #5619.
+//
+// Do NOT add a new type here to silence the lint for a freshly-introduced
+// both-clients case — add a real contract fixture instead. New entries are
+// only legitimate when retro-fitting a pre-existing case, with a note.
+// ---------------------------------------------------------------------------
+const PENDING_CONTRACT_TYPES = new Set<string>([
+  'agent_idle',
+  'agent_list',
+  'auth_bootstrap',
+  'auth_fail',
+  'auth_ok',
+  'available_models',
+  'checkpoint_created',
+  'checkpoint_list',
+  'checkpoint_restored',
+  'claude_ready',
+  'client_focus_changed',
+  'client_joined',
+  'client_left',
+  'conversations_list',
+  'cost_update',
+  'error',
+  'history_replay_end',
+  'key_exchange_ok',
+  'model_changed',
+  'multi_question_intervention',
+  'pair_fail',
+  'permission_expired',
+  'permission_mode_changed',
+  'permission_request',
+  'permission_resolved',
+  'permission_timeout',
+  'plan_ready',
+  'pong',
+  'primary_changed',
+  'provider_list',
+  'raw',
+  'raw_background',
+  'result',
+  'search_results',
+  'server_error',
+  'server_mode',
+  'server_shutdown',
+  'server_status',
+  'session_error',
+  'session_list',
+  'session_persist_failed',
+  'session_restore_failed',
+  'session_role',
+  'session_stopped',
+  'session_switched',
+  'session_timeout',
+  'session_warning',
+  'slash_commands',
+  'stream_delta',
+  'stream_end',
+  'terminal_output',
+  'token_rotated',
+  'tool_input_delta',
+  'tunnel_url_changed',
+  'user_input',
+  'user_question',
+  'web_task_error',
+])
+
+// ---------------------------------------------------------------------------
+// Static extraction — derive the both-clients-SWITCH universe from the two
+// clients' real handler sources. Mirrors the protocol handler-coverage guard.
+// ---------------------------------------------------------------------------
+
+/** App handler uses only `case '<type>':` clauses. */
+function extractAppSwitchTypes(src: string): Set<string> {
+  return new Set([...src.matchAll(/case\s+'([a-z_]+)'/g)].map((m) => m[1]))
+}
+
+/** Dashboard handler uses `case '<type>':` clauses AND a `HANDLERS` map. */
+function extractDashSwitchTypes(src: string): Set<string> {
+  const types = new Set<string>([...src.matchAll(/case\s+'([a-z_]+)'/g)].map((m) => m[1]))
+  const handlersBlock = src.match(/const HANDLERS:\s*Record<string,\s*Handler>\s*=\s*\{([\s\S]*?)\n\}/)
+  if (handlersBlock) {
+    for (const m of handlersBlock[1].matchAll(/^\s*([a-z_]+):/gm)) types.add(m[1])
+  }
+  return types
+}
+
+function bothClientsSwitchTypes(): string[] {
+  const appSrc = readFileSync(appHandlerPath, 'utf-8')
+  const dashSrc = readFileSync(dashHandlerPath, 'utf-8')
+  const appTypes = extractAppSwitchTypes(appSrc)
+  const dashTypes = extractDashSwitchTypes(dashSrc)
+  const dispatchTableTypes = new Set<string>(DISPATCH_TABLE_TYPES)
+  return [...appTypes]
+    .filter((t) => dashTypes.has(t) && !dispatchTableTypes.has(t))
+    .sort()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
+  const both = bothClientsSwitchTypes()
+  const covered = new Set(SWITCH_FIXTURES.map((f) => f.type))
+
+  it('derives a non-trivial both-clients switch universe (extraction sanity)', () => {
+    // If this collapses to ~0 the regex/path drifted and the lint below would
+    // pass vacuously. Pin a floor well under the real count (~64).
+    expect(both.length).toBeGreaterThan(20)
+  })
+
+  it('every both-clients switch type has a fixture or an explicit PENDING entry', () => {
+    const undeclared = both.filter((t) => !covered.has(t) && !PENDING_CONTRACT_TYPES.has(t))
+    expect(
+      undeclared,
+      'New both-clients switch type(s) with NO SWITCH_FIXTURES entry and not in ' +
+        'PENDING_CONTRACT_TYPES. Add a behaviour-verified fixture to ' +
+        'contract-fixtures/fixtures.ts (preferred), or — only when retro-fitting a ' +
+        `pre-existing case — add it to the PENDING allowlist with a note:\n  ${undeclared.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('PENDING_CONTRACT_TYPES has no stale entries (allowlist only shrinks)', () => {
+    const bothSet = new Set(both)
+    const stale = [...PENDING_CONTRACT_TYPES].filter(
+      // Stale = no longer a both-clients switch type, OR now has a fixture
+      // (in which case it must be REMOVED from the allowlist, not left behind).
+      (t) => !bothSet.has(t) || covered.has(t),
+    )
+    expect(
+      stale,
+      'PENDING_CONTRACT_TYPES contains stale entries — remove them. A type is ' +
+        'stale once it gains a SWITCH_FIXTURES entry, or stops being a ' +
+        `both-clients switch type:\n  ${stale.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('SWITCH_FIXTURES only targets real both-clients switch types (no stale fixtures)', () => {
+    const bothSet = new Set(both)
+    const stale = SWITCH_FIXTURES.filter((f) => !bothSet.has(f.type)).map((f) => `${f.type} (${f.name})`)
+    expect(
+      stale,
+      'SWITCH_FIXTURES entries whose type is not a both-clients switch case ' +
+        '(migrated to the dispatch table, renamed, or single-platform). Move or ' +
+        `remove them:\n  ${stale.join('\n  ')}`,
+    ).toEqual([])
+  })
+})

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -914,6 +914,50 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
+    // budget_warning is a both-clients switch case (#5619): both clients append
+    // the SAME system note to the target session's messages when it exists.
+    // `msg.message` is echoed verbatim into the bubble content.
+    name: 'budget_warning appends the warning system bubble to the target session',
+    type: 'budget_warning',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'budget_warning', sessionId: 's1', message: 'Approaching cost budget limit' },
+    expect: {
+      sessions: {
+        s1: { messages: [{ type: 'system', content: 'Approaching cost budget limit' }] },
+      },
+    },
+  },
+  {
+    // budget_exceeded is a DOCUMENTED divergence (#5619): both append a
+    // "session paused" system note, but the dashboard auto-resumes and tacks
+    // ". Budget will auto-resume." onto the same bubble (the app does not — it
+    // shows a manual "Resume" Alert action instead). The `divergent` block pins
+    // each client's own content so the difference is locked, not hidden.
+    name: 'budget_exceeded appends a paused system bubble (dashboard notes auto-resume)',
+    type: 'budget_exceeded',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'budget_exceeded', sessionId: 's1', message: 'Cost budget exceeded' },
+    divergent: {
+      reason:
+        'dashboard auto-resumes and appends ". Budget will auto-resume." to the bubble; ' +
+        'the app surfaces a manual Resume Alert and leaves the bubble at "— session paused"',
+      app: {
+        sessions: {
+          s1: { messages: [{ type: 'system', content: 'Cost budget exceeded — session paused' }] },
+        },
+      },
+      dashboard: {
+        sessions: {
+          s1: {
+            messages: [
+              { type: 'system', content: 'Cost budget exceeded — session paused. Budget will auto-resume.' },
+            ],
+          },
+        },
+      },
+    },
+  },
+  {
     name: 'history_replay_start (full) keeps existing messages visible (no blank-flash wipe)',
     type: 'history_replay_start',
     init: {


### PR DESCRIPTION
## What

`SWITCH_FIXTURES` is the only suite that drives **both** clients' production `handleMessage` switches (app jest + dashboard vitest) against one shared expectation — the behavioural-contract guard for message types still living in each client's own switch / HANDLERS map (the dispatch-table-owned types are covered separately by `contract.test.ts` against `DISPATCH_FIXTURES`). Growing that coverage was previously **unenforced**: a new both-clients switch case could ship with no contract fixture, silently re-opening the drift surface epic #5556 set out to close.

## The lint (anti-drift guard)

New vitest `packages/store-core/src/contract-fixtures/coverage-lint.test.ts` — runs in the existing **Store Core Tests** CI job (no new workflow wiring). It:

1. Derives the authoritative **both-clients-SWITCH universe** by static-parsing the app + dashboard `message-handler.ts` sources (same technique as the protocol `handler-coverage.test.js` guard), intersecting them, and subtracting `DISPATCH_TABLE_TYPES`.
2. Asserts every remaining type is **either** covered by a `SWITCH_FIXTURES` entry **or** listed in an explicit, documented `PENDING_CONTRACT_TYPES` allowlist (the pre-existing backlog, pointing at #5618/#5619).
3. Fails on a **new** both-clients case with no fixture/pending entry (the no-new-drift guarantee), on **stale** allowlist entries (a type that gained a fixture or stopped being both-clients), and on stale `SWITCH_FIXTURES` whose type is no longer a both-clients switch case. So the allowlist can only **shrink**.

Universe at this PR: **64** both-clients switch types — **7 covered** by fixtures (5 pre-existing + 2 new), **57 allow-listed** as the tracked backlog. Shrinking the allowlist by adding genuine, behaviour-verified fixtures is the future work.

## Fixtures grown (real behaviour, both clients)

Per the issue, no fabricated bulk fixtures — only types I could verify against the real handlers:

- **`budget_warning`** — *identical* in both clients: both append the same system bubble (`msg.message` content) to the target session.
- **`budget_exceeded`** — *documented divergence* via a `divergent` block: the dashboard auto-resumes and appends `". Budget will auto-resume."` to the bubble; the app surfaces a manual Resume Alert and leaves it at `"— session paused"`. The fixture pins each client's own expected content, so the difference is locked, not hidden.

Both are driven through each client's **real** `handleMessage` (app jest + dashboard vitest) and converge on their asserted state.

## Deferred

The Maestro device-layer `key_exchange`/eager-handshake case was deferred (needs a simulator) — filed as #6019.

## Tests

- store-core: `vitest run` 1645 passed (40 files) + `typecheck` clean
- dashboard: `vitest run` 3818 passed (203 files) + `typecheck` clean
- app: `jest` 1968 passed (147 suites) + `tsc --noEmit` clean
- protocol `handler-coverage.test.js`: 9 passed (shares the static-parse approach)

Closes #5619