### PR TITLE
feat(server): broadcast a terminal session-dead signal on respawn exhaustion (#5698)

### DIFF
--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -289,6 +289,14 @@ export const ServerMessageSchema = z.object({
     //     post-fallback retry ALSO matched the unknown-resume pattern, the
     //     server has stopped auto-respawning, and the user must start a
     //     fresh session manually.
+    //   - `'cli_respawn_exhausted'` (#5698) — terminal; CliSession's bounded
+    //     auto-respawn budget (rolling rate cap or the consecutive max of 5) is
+    //     spent, the server has stopped respawning, and the session is being
+    //     dropped. Distinct from a transient error toast so the client can
+    //     render a final "session ended (flapping)" state. Subprocess providers
+    //     extending CliSession (BYOK, Gemini, Codex, DeepSeek, Docker) inherit
+    //     it; the claude-tui PTY mirror emits the sibling `pty_respawn_exhausted`
+    //     / `resume_unknown_exhausted` codes for the same terminal condition.
     // Carries the conversation id chroxy passed to `claude --resume <id>`
     // before the CLI rejected it; dashboards surface it under the affordance
     // for operator correlation against the persisted state file

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -293,10 +293,11 @@ export const ServerMessageSchema = z.object({
     //     auto-respawn budget (rolling rate cap or the consecutive max of 5) is
     //     spent, the server has stopped respawning, and the session is being
     //     dropped. Distinct from a transient error toast so the client can
-    //     render a final "session ended (flapping)" state. Subprocess providers
-    //     extending CliSession (BYOK, Gemini, Codex, DeepSeek, Docker) inherit
-    //     it; the claude-tui PTY mirror emits the sibling `pty_respawn_exhausted`
-    //     / `resume_unknown_exhausted` codes for the same terminal condition.
+    //     render a final "session ended (flapping)" state. DockerSession (the
+    //     only CliSession subclass) inherits it; the other subprocess providers
+    //     have no auto-respawn loop, and the claude-tui PTY mirror emits the
+    //     sibling `pty_respawn_exhausted` / `resume_unknown_exhausted` codes for
+    //     the same terminal condition.
     // Carries the conversation id chroxy passed to `claude --resume <id>`
     // before the CLI rejected it; dashboards surface it under the affordance
     // for operator correlation against the persisted state file

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -308,6 +308,14 @@ export const ServerMessageSchema = z.object({
   //     post-fallback retry ALSO matched the unknown-resume pattern, the
   //     server has stopped auto-respawning, and the user must start a
   //     fresh session manually.
+  //   - `'cli_respawn_exhausted'` (#5698) — terminal; CliSession's bounded
+  //     auto-respawn budget (rolling rate cap or the consecutive max of 5) is
+  //     spent, the server has stopped respawning, and the session is being
+  //     dropped. Distinct from a transient error toast so the client can
+  //     render a final "session ended (flapping)" state. Subprocess providers
+  //     extending CliSession (BYOK, Gemini, Codex, DeepSeek, Docker) inherit
+  //     it; the claude-tui PTY mirror emits the sibling `pty_respawn_exhausted`
+  //     / `resume_unknown_exhausted` codes for the same terminal condition.
   // Carries the conversation id chroxy passed to `claude --resume <id>`
   // before the CLI rejected it; dashboards surface it under the affordance
   // for operator correlation against the persisted state file

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -312,10 +312,11 @@ export const ServerMessageSchema = z.object({
   //     auto-respawn budget (rolling rate cap or the consecutive max of 5) is
   //     spent, the server has stopped respawning, and the session is being
   //     dropped. Distinct from a transient error toast so the client can
-  //     render a final "session ended (flapping)" state. Subprocess providers
-  //     extending CliSession (BYOK, Gemini, Codex, DeepSeek, Docker) inherit
-  //     it; the claude-tui PTY mirror emits the sibling `pty_respawn_exhausted`
-  //     / `resume_unknown_exhausted` codes for the same terminal condition.
+  //     render a final "session ended (flapping)" state. DockerSession (the
+  //     only CliSession subclass) inherits it; the other subprocess providers
+  //     have no auto-respawn loop, and the claude-tui PTY mirror emits the
+  //     sibling `pty_respawn_exhausted` / `resume_unknown_exhausted` codes for
+  //     the same terminal condition.
   // Carries the conversation id chroxy passed to `claude --resume <id>`
   // before the CLI rejected it; dashboards surface it under the affordance
   // for operator correlation against the persisted state file

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -204,6 +204,20 @@ export class CliSession extends BaseSession {
   }
 
   /**
+   * #5698: `respawn_exhausted` is the terminal "session is dead (flapping)"
+   * signal — emitted by `_scheduleRespawn` once the bounded auto-respawn budget
+   * (the rolling rate cap or the consecutive max of 5) is spent. SessionManager
+   * listens for it and drops the session from its list (no input-rejecting
+   * zombie tab), mirroring ClaudeTuiSession's contract. Listing it here makes
+   * `_wireSessionEvents` bridge it onto the transient `session_event` channel
+   * as well (subprocess providers — BYOK, Gemini, Codex, DeepSeek, Docker —
+   * inherit this getter and so inherit the terminal signal).
+   */
+  static get customEvents() {
+    return ['respawn_exhausted']
+  }
+
+  /**
    * Root data directory for this provider (#2965).
    * Consumers (conversation-scanner, ws-file-ops) use this to locate
    * provider-specific subdirs (projects/, agents/, commands/) without
@@ -599,14 +613,21 @@ export class CliSession extends BaseSession {
     if (!this._respawnRateLimiter.record()) {
       const { maxPerWindow, windowMs } = this._respawnRateLimiter
       log.error(`Respawn rate cap reached (>${maxPerWindow} in ${Math.round(windowMs / 60000)}min), giving up — session is flapping`)
-      this.emit('error', { message: `Claude process is flapping — exceeded ${maxPerWindow} respawns in ${Math.round(windowMs / 60000)} minutes` })
+      // #5698: a CODED terminal error (so the client can render a distinct
+      // "session ended (flapping)" final state instead of a transient toast)
+      // PLUS `respawn_exhausted` so SessionManager drops the dead session.
+      this.emit('error', { code: 'cli_respawn_exhausted', message: `Claude process is flapping — exceeded ${maxPerWindow} respawns in ${Math.round(windowMs / 60000)} minutes` })
+      this.emit('respawn_exhausted', { reason: 'cli_respawn_rate_capped' })
       return
     }
 
     this._respawnCount++
     if (this._respawnCount > 5) {
       log.error('Max respawn attempts reached (5), giving up')
-      this.emit('error', { message: 'Claude process failed to stay alive after 5 attempts' })
+      // #5698: see the rate-cap branch above — coded terminal error + the
+      // session-dropping `respawn_exhausted` signal.
+      this.emit('error', { code: 'cli_respawn_exhausted', message: 'Claude process failed to stay alive after 5 attempts' })
+      this.emit('respawn_exhausted', { reason: 'cli_respawn_exhausted', attempts: this._respawnCount - 1 })
       return
     }
 

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -210,8 +210,11 @@ export class CliSession extends BaseSession {
    * listens for it and drops the session from its list (no input-rejecting
    * zombie tab), mirroring ClaudeTuiSession's contract. Listing it here makes
    * `_wireSessionEvents` bridge it onto the transient `session_event` channel
-   * as well (subprocess providers — BYOK, Gemini, Codex, DeepSeek, Docker —
-   * inherit this getter and so inherit the terminal signal).
+   * as well. DockerSession is the only subclass of CliSession, so it inherits
+   * this getter and the terminal signal; the other subprocess providers
+   * (BYOK/DeepSeek extend BaseSession, Gemini/Codex extend
+   * JsonlSubprocessSession) have no auto-respawn loop, so there is nothing to
+   * exhaust there.
    */
   static get customEvents() {
     return ['respawn_exhausted']

--- a/packages/server/tests/cli-session-respawn-exhausted.test.js
+++ b/packages/server/tests/cli-session-respawn-exhausted.test.js
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { CliSession } from '../src/cli-session.js'
+import { RespawnRateLimiter } from '../src/utils/respawn-rate-limiter.js'
+
+/**
+ * #5698 — per-session respawn-exhaustion terminal signal.
+ *
+ * When CliSession's bounded auto-respawn budget is spent (the rolling rate cap
+ * OR the consecutive max of 5) the session is dead. The fix makes that a
+ * DISTINCT terminal signal, not a generic transient error toast:
+ *   1. the `error` envelope carries `code: 'cli_respawn_exhausted'`, and
+ *   2. a single `respawn_exhausted` event fires so SessionManager drops the
+ *      dead session from its list (parity with ClaudeTuiSession).
+ *
+ * These tests drive the REAL CliSession (no spawn — `_scheduleRespawn` is pure
+ * timer/budget logic) so they can't drift from a copied harness.
+ */
+
+describe('CliSession respawn exhaustion — terminal signal (#5698)', () => {
+  it('declares respawn_exhausted in customEvents so it bridges to clients', () => {
+    assert.ok(
+      CliSession.customEvents.includes('respawn_exhausted'),
+      'respawn_exhausted must be a forwarded custom event',
+    )
+  })
+
+  it('consecutive max (>5) emits exactly one coded error AND one respawn_exhausted', () => {
+    const session = new CliSession({ cwd: '/tmp' })
+    const errors = []
+    const exhausted = []
+    session.on('error', (e) => errors.push(e))
+    session.on('respawn_exhausted', (e) => exhausted.push(e))
+
+    // Five respawns already consumed; the prior timer fired so the guard is
+    // clear — this call is the 6th attempt and trips the consecutive cap.
+    session._respawnCount = 5
+    session._respawnScheduled = false
+
+    session._scheduleRespawn()
+
+    assert.equal(errors.length, 1, 'exactly one terminal error')
+    assert.equal(errors[0].code, 'cli_respawn_exhausted', 'error carries the distinct terminal code')
+    assert.match(errors[0].message, /failed to stay alive after 5 attempts/)
+
+    assert.equal(exhausted.length, 1, 'exactly one respawn_exhausted signal')
+    assert.equal(exhausted[0].reason, 'cli_respawn_exhausted')
+    assert.equal(exhausted[0].attempts, 5)
+
+    assert.equal(session._respawnTimer, null, 'no respawn scheduled after exhaustion')
+    session.destroy()
+  })
+
+  it('rolling rate cap (flapping) emits one coded error AND one respawn_exhausted', () => {
+    // Small cap + fixed clock so the rolling window trips before the
+    // consecutive max, and a warmup reset of _respawnCount can't dodge it.
+    const session = new CliSession({ cwd: '/tmp' })
+    session._respawnRateLimiter = new RespawnRateLimiter({ maxPerWindow: 3, windowMs: 5 * 60_000, now: () => 1000 })
+    const errors = []
+    const exhausted = []
+    session.on('error', (e) => errors.push(e))
+    session.on('respawn_exhausted', (e) => exhausted.push(e))
+
+    for (let i = 0; i < 4; i++) {
+      session._respawnCount = 0 // system.init warmup reset
+      if (session._respawnTimer) { clearTimeout(session._respawnTimer); session._respawnTimer = null }
+      session._respawnScheduled = false
+      session._scheduleRespawn()
+    }
+
+    assert.equal(errors.length, 1, 'gives up exactly once despite warmup resets')
+    assert.equal(errors[0].code, 'cli_respawn_exhausted', 'rate-cap error carries the terminal code')
+    assert.match(errors[0].message, /flapping/)
+
+    assert.equal(exhausted.length, 1, 'exactly one respawn_exhausted signal')
+    assert.equal(exhausted[0].reason, 'cli_respawn_rate_capped')
+
+    assert.equal(session._respawnScheduled, false, 'no respawn scheduled after the rate cap')
+    session.destroy()
+  })
+
+  it('a transient error is distinct — it carries no terminal code', () => {
+    // A normal in-band error (e.g. a busy/queue-full reject) must NOT look
+    // like the terminal exhaustion signal, so a client can tell them apart.
+    const session = new CliSession({ cwd: '/tmp' })
+    const errors = []
+    session.on('error', (e) => errors.push(e))
+
+    session.emit('error', { message: 'Pending message queue full (max 3) — message discarded' })
+
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, undefined, 'transient errors have no cli_respawn_exhausted code')
+    session.destroy()
+  })
+
+  it('does not emit respawn_exhausted on a normal (within-budget) respawn', () => {
+    const session = new CliSession({ cwd: '/tmp' })
+    const exhausted = []
+    session.on('respawn_exhausted', (e) => exhausted.push(e))
+    session.start = () => {} // avoid a real spawn when the timer fires
+
+    session._scheduleRespawn() // first attempt — well within budget
+
+    assert.equal(exhausted.length, 0, 'no terminal signal for a healthy respawn')
+    assert.ok(session._respawnTimer, 'a respawn timer is scheduled')
+    session.destroy()
+  })
+})

--- a/packages/server/tests/cli-session-respawn-exhausted.test.js
+++ b/packages/server/tests/cli-session-respawn-exhausted.test.js
@@ -18,10 +18,10 @@ import { RespawnRateLimiter } from '../src/utils/respawn-rate-limiter.js'
  */
 
 describe('CliSession respawn exhaustion — terminal signal (#5698)', () => {
-  it('declares respawn_exhausted in customEvents so it bridges to clients', () => {
+  it('declares respawn_exhausted in customEvents so SessionManager forwards it', () => {
     assert.ok(
       CliSession.customEvents.includes('respawn_exhausted'),
-      'respawn_exhausted must be a forwarded custom event',
+      'respawn_exhausted must be a declared custom event so _wireSessionEvents forwards it',
     )
   })
 

--- a/packages/server/tests/cli-session-respawn-guard.test.js
+++ b/packages/server/tests/cli-session-respawn-guard.test.js
@@ -33,13 +33,17 @@ class RespawnTestHarness extends EventEmitter {
     // #5349: rolling-window cap, checked BEFORE _respawnCount.
     if (!this._respawnRateLimiter.record()) {
       const { maxPerWindow, windowMs } = this._respawnRateLimiter
-      this.emit('error', { message: `Claude process is flapping — exceeded ${maxPerWindow} respawns in ${Math.round(windowMs / 60000)} minutes` })
+      // #5698: coded terminal error + the session-dropping signal.
+      this.emit('error', { code: 'cli_respawn_exhausted', message: `Claude process is flapping — exceeded ${maxPerWindow} respawns in ${Math.round(windowMs / 60000)} minutes` })
+      this.emit('respawn_exhausted', { reason: 'cli_respawn_rate_capped' })
       return
     }
 
     this._respawnCount++
     if (this._respawnCount > 5) {
-      this.emit('error', { message: 'Claude process failed to stay alive after 5 attempts' })
+      // #5698: coded terminal error + the session-dropping signal.
+      this.emit('error', { code: 'cli_respawn_exhausted', message: 'Claude process failed to stay alive after 5 attempts' })
+      this.emit('respawn_exhausted', { reason: 'cli_respawn_exhausted', attempts: this._respawnCount - 1 })
       return
     }
 


### PR DESCRIPTION
## Summary

Part of #5698. Implements the tractable, CI-verifiable server-side piece — **AC3: per-session respawn-exhaustion terminal signal** — and decomposes the structural AC1/AC2/AC4 work into tracked follow-ups.

When a `CliSession`'s bounded auto-respawn budget is spent (the rolling rate cap **or** the consecutive max of 5), the session is dead — but until now it only emitted a generic, **uncoded** `error`, indistinguishable from a transient error toast, and never the `respawn_exhausted` signal. So the dead session lingered as an input-rejecting zombie tab and clients couldn't render a terminal state.

### What changed
- `CliSession._scheduleRespawn` exhaustion paths now:
  - tag the `error` envelope with `code: 'cli_respawn_exhausted'` so clients can render a distinct **"session ended (flapping)"** final state instead of a transient toast, and
  - emit `respawn_exhausted` (now declared in `CliSession.customEvents`) so `SessionManager` drops the session from its list — mirroring `ClaudeTuiSession`'s existing contract.
- Subprocess providers extending `CliSession` (BYOK, Gemini, Codex, DeepSeek, Docker) inherit the signal.
- Protocol: documented the new `'cli_respawn_exhausted'` terminal code in the `message.code` schema doc block (`code` stays free-form `z.string().max(64)`; no enum change needed). **Protocol dist rebuilt + committed.**

### Why this scope
The TUI provider already had a full `respawn_exhausted` terminal mechanism; `CliSession` (the base of all subprocess providers) was the gap. The `SessionManager` `respawn_exhausted` → `destroySession` wiring is already provider-agnostic (`#5315`), so `CliSession` inherits the zombie-drop behavior for free.

## Tests
New `tests/cli-session-respawn-exhausted.test.js` drives the **real** `CliSession` (no spawn — `_scheduleRespawn` is pure budget/timer logic) and proves:
- `respawn_exhausted` is in `customEvents`;
- consecutive-max exhaustion → exactly one coded error **and** one `respawn_exhausted`;
- rolling rate-cap (flapping) → exactly one coded error **and** one `respawn_exhausted`;
- a transient error carries **no** terminal code (distinct from exhaustion);
- a within-budget respawn emits **no** `respawn_exhausted`.

Existing `cli-session-respawn-guard.test.js` copied harness updated to stay in sync.

Results (Node 22):
- server (cli-session + event-normalizer + providers + session-manager suites): **all green** (349 + 204 pass, 0 fail)
- protocol: **323 pass, 0 fail**
- server custom lints (`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`): **OK**
- eslint on changed src: clean

## Deferred to follow-ups
- **#6022** — AC1 supervisor give-up terminal server-down mechanism. **Structurally infeasible as a child broadcast**: when the supervisor hits max-restarts the crash-looping child that owns the WsServer + connections is already dead, so there's no live child to broadcast `server_shutdown{reason:'supervisor_gave_up'}` through. The follow-up proposes a supervisor terminal-down HTTP endpoint / last-gasp signal (and adding the enum value *with* the real emit path). Intentionally not forced here to avoid a racy/fragile broadcast.
- **#6023** — AC2/AC4 app + dashboard reconnect-ladder terminal "server appears down" state. Confirmed AC4: the ladder retries indefinitely today. This is client UI needing on-device verification, out of scope for an autonomous server PR. Builds on the mobile `server_down` render groundwork from #5725 / #5980.

Related: #5725, #5980.

---
**Correction (post-review):** an earlier line above stated BYOK/Gemini/Codex/DeepSeek "extend CliSession" and inherit the signal — that is inaccurate. Only `DockerSession` extends `CliSession`. BYOK/DeepSeek extend `BaseSession`; Gemini/Codex extend `JsonlSubprocessSession`. None of those have an auto-respawn loop, so there is nothing to exhaust there and the coverage is correct as-is. Comments + test wording corrected in 1993b755f.