### PR TITLE
refactor(test): unify both-clients handler-coverage extractor (#6021)

### DIFF
--- a/packages/protocol/dist/handler-coverage-extract.d.ts
+++ b/packages/protocol/dist/handler-coverage-extract.d.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared static-parse extractor for the two clients' `message-handler.ts`
+ * handler universes (#6021).
+ *
+ * BACKGROUND
+ * ----------
+ * Two guards static-parse the app + dashboard `message-handler.ts` sources to
+ * derive "which message types does each client handle":
+ *   - `packages/protocol/tests/handler-coverage.test.js` — the exhaustiveness
+ *     guard (every ServerMessageType has *some* handler `case` or an explicit
+ *     exclusion).
+ *   - `packages/store-core/src/contract-fixtures/coverage-lint.test.ts` (#5619)
+ *     — the both-clients no-new-drift fixture lint.
+ *
+ * Each used to carry its OWN regex. They drifted: the store-core copy was
+ * STRICTER (its HANDLERS-map terminator was `\n}`, which a non-greedily matched
+ * map containing a nested object literal truncates early, and its key matcher
+ * was `[a-z_]+`). This module is the SINGLE source of truth both consume so
+ * they can never diverge again, and it uses the more-permissive / correct parse.
+ *
+ * This file is intentionally dependency-free static text analysis — it imports
+ * nothing from the protocol enum/schemas, so it stays cheap to import from both
+ * the protocol `node --test` runner and the store-core vitest runner.
+ */
+/**
+ * Extract `case '<type>':` clause labels from a handler source.
+ *
+ * The app handler dispatches purely through a `switch`, so this is its whole
+ * universe; the dashboard handler also uses `case` clauses (plus, historically,
+ * a `HANDLERS` map — see {@link extractHandlersMapKeys}).
+ */
+export declare function extractCaseTypes(src: string): Set<string>;
+/**
+ * Extract the keys of a `const HANDLERS: Record<string, Handler> = { ... }`
+ * map from a handler source, if present.
+ *
+ * Why a brace-balanced scan instead of a single regex: the previous two copies
+ * both terminated the map body with a non-greedy `[\s\S]*?` against either `}`
+ * (protocol — stops at the FIRST `}`, truncating at a nested object literal) or
+ * `\n}` (store-core — stops at the first newline-prefixed `}`, same failure
+ * mode plus brittle to the closing brace's column/trailing tokens such as
+ * `} as const` / `} satisfies …`). A balanced scan from the opening `{` to its
+ * matching `}` parses the real map regardless of nested object values or how
+ * the closing brace is decorated, then reads only TOP-LEVEL keys.
+ *
+ * Keys are read with the per-line matcher `^\s*(\w+):` (permissively `\w+` so a
+ * future key with a digit or capital isn't silently dropped). Per-line matching
+ * is robust to interleaved `//` comment lines between entries — which the
+ * char-by-char alternative is not — and these handler maps are flat object
+ * literals, so a line-based read of the brace-balanced body collects exactly
+ * the top-level keys.
+ */
+export declare function extractHandlersMapKeys(src: string): Set<string>;
+/**
+ * The app handler's full type universe: `case` clauses only.
+ */
+export declare function extractAppHandlerTypes(appSrc: string): Set<string>;
+/**
+ * The dashboard handler's full type universe: `case` clauses plus any
+ * `HANDLERS` map keys.
+ */
+export declare function extractDashboardHandlerTypes(dashSrc: string): Set<string>;

--- a/packages/protocol/dist/handler-coverage-extract.d.ts
+++ b/packages/protocol/dist/handler-coverage-extract.d.ts
@@ -44,11 +44,11 @@ export declare function extractCaseTypes(src: string): Set<string>;
  * the closing brace is decorated, then reads only TOP-LEVEL keys.
  *
  * Keys are read with the per-line matcher `^\s*(\w+):` (permissively `\w+` so a
- * future key with a digit or capital isn't silently dropped). Per-line matching
- * is robust to interleaved `//` comment lines between entries — which the
- * char-by-char alternative is not — and these handler maps are flat object
- * literals, so a line-based read of the brace-balanced body collects exactly
- * the top-level keys.
+ * future key with a digit or capital isn't silently dropped) applied only to
+ * lines at the map's TOP LEVEL — a running brace-depth counter skips any line
+ * inside a nested object value, so a `someType: { ... }` entry contributes only
+ * its top-level key `someType`, never the nested literal's inner keys. Per-line
+ * matching is also robust to interleaved `//` comment lines between entries.
  */
 export declare function extractHandlersMapKeys(src: string): Set<string>;
 /**

--- a/packages/protocol/dist/handler-coverage-extract.js
+++ b/packages/protocol/dist/handler-coverage-extract.js
@@ -46,11 +46,11 @@ export function extractCaseTypes(src) {
  * the closing brace is decorated, then reads only TOP-LEVEL keys.
  *
  * Keys are read with the per-line matcher `^\s*(\w+):` (permissively `\w+` so a
- * future key with a digit or capital isn't silently dropped). Per-line matching
- * is robust to interleaved `//` comment lines between entries — which the
- * char-by-char alternative is not — and these handler maps are flat object
- * literals, so a line-based read of the brace-balanced body collects exactly
- * the top-level keys.
+ * future key with a digit or capital isn't silently dropped) applied only to
+ * lines at the map's TOP LEVEL — a running brace-depth counter skips any line
+ * inside a nested object value, so a `someType: { ... }` entry contributes only
+ * its top-level key `someType`, never the nested literal's inner keys. Per-line
+ * matching is also robust to interleaved `//` comment lines between entries.
  */
 export function extractHandlersMapKeys(src) {
     const keys = new Set();
@@ -76,8 +76,24 @@ export function extractHandlersMapKeys(src) {
     if (endIdx === -1)
         return keys;
     const body = src.slice(openIdx + 1, endIdx);
-    for (const m of body.matchAll(/^\s*(\w+)\s*:/gm))
-        keys.add(m[1]);
+    // Walk line by line tracking brace depth; collect keys only at the map's top
+    // level (depth 0) so a nested object value's inner keys are not mistaken for
+    // message types. The key on a `someType: {` line is matched before that line
+    // raises the depth, so the real top-level key is still captured.
+    let lineDepth = 0;
+    for (const line of body.split('\n')) {
+        if (lineDepth === 0) {
+            const m = line.match(/^\s*(\w+)\s*:/);
+            if (m)
+                keys.add(m[1]);
+        }
+        for (const ch of line) {
+            if (ch === '{')
+                lineDepth++;
+            else if (ch === '}')
+                lineDepth--;
+        }
+    }
     return keys;
 }
 /**

--- a/packages/protocol/dist/handler-coverage-extract.js
+++ b/packages/protocol/dist/handler-coverage-extract.js
@@ -1,0 +1,98 @@
+/**
+ * Shared static-parse extractor for the two clients' `message-handler.ts`
+ * handler universes (#6021).
+ *
+ * BACKGROUND
+ * ----------
+ * Two guards static-parse the app + dashboard `message-handler.ts` sources to
+ * derive "which message types does each client handle":
+ *   - `packages/protocol/tests/handler-coverage.test.js` — the exhaustiveness
+ *     guard (every ServerMessageType has *some* handler `case` or an explicit
+ *     exclusion).
+ *   - `packages/store-core/src/contract-fixtures/coverage-lint.test.ts` (#5619)
+ *     — the both-clients no-new-drift fixture lint.
+ *
+ * Each used to carry its OWN regex. They drifted: the store-core copy was
+ * STRICTER (its HANDLERS-map terminator was `\n}`, which a non-greedily matched
+ * map containing a nested object literal truncates early, and its key matcher
+ * was `[a-z_]+`). This module is the SINGLE source of truth both consume so
+ * they can never diverge again, and it uses the more-permissive / correct parse.
+ *
+ * This file is intentionally dependency-free static text analysis — it imports
+ * nothing from the protocol enum/schemas, so it stays cheap to import from both
+ * the protocol `node --test` runner and the store-core vitest runner.
+ */
+/**
+ * Extract `case '<type>':` clause labels from a handler source.
+ *
+ * The app handler dispatches purely through a `switch`, so this is its whole
+ * universe; the dashboard handler also uses `case` clauses (plus, historically,
+ * a `HANDLERS` map — see {@link extractHandlersMapKeys}).
+ */
+export function extractCaseTypes(src) {
+    return new Set([...src.matchAll(/case\s+'([a-z_]+)'/g)].map((m) => m[1]));
+}
+/**
+ * Extract the keys of a `const HANDLERS: Record<string, Handler> = { ... }`
+ * map from a handler source, if present.
+ *
+ * Why a brace-balanced scan instead of a single regex: the previous two copies
+ * both terminated the map body with a non-greedy `[\s\S]*?` against either `}`
+ * (protocol — stops at the FIRST `}`, truncating at a nested object literal) or
+ * `\n}` (store-core — stops at the first newline-prefixed `}`, same failure
+ * mode plus brittle to the closing brace's column/trailing tokens such as
+ * `} as const` / `} satisfies …`). A balanced scan from the opening `{` to its
+ * matching `}` parses the real map regardless of nested object values or how
+ * the closing brace is decorated, then reads only TOP-LEVEL keys.
+ *
+ * Keys are read with the per-line matcher `^\s*(\w+):` (permissively `\w+` so a
+ * future key with a digit or capital isn't silently dropped). Per-line matching
+ * is robust to interleaved `//` comment lines between entries — which the
+ * char-by-char alternative is not — and these handler maps are flat object
+ * literals, so a line-based read of the brace-balanced body collects exactly
+ * the top-level keys.
+ */
+export function extractHandlersMapKeys(src) {
+    const keys = new Set();
+    const header = src.match(/const HANDLERS:\s*Record<string,\s*Handler>\s*=\s*\{/);
+    if (!header || header.index === undefined)
+        return keys;
+    // Find the matching close brace for the `{` that ends the header match.
+    const openIdx = header.index + header[0].length - 1; // index of the `{`
+    let depth = 0;
+    let endIdx = -1;
+    for (let i = openIdx; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{')
+            depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) {
+                endIdx = i;
+                break;
+            }
+        }
+    }
+    if (endIdx === -1)
+        return keys;
+    const body = src.slice(openIdx + 1, endIdx);
+    for (const m of body.matchAll(/^\s*(\w+)\s*:/gm))
+        keys.add(m[1]);
+    return keys;
+}
+/**
+ * The app handler's full type universe: `case` clauses only.
+ */
+export function extractAppHandlerTypes(appSrc) {
+    return extractCaseTypes(appSrc);
+}
+/**
+ * The dashboard handler's full type universe: `case` clauses plus any
+ * `HANDLERS` map keys.
+ */
+export function extractDashboardHandlerTypes(dashSrc) {
+    const types = extractCaseTypes(dashSrc);
+    for (const k of extractHandlersMapKeys(dashSrc))
+        types.add(k);
+    return types;
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,6 +18,10 @@
     "./project": {
       "import": "./dist/project.js",
       "types": "./dist/project.d.ts"
+    },
+    "./handler-coverage": {
+      "import": "./dist/handler-coverage-extract.js",
+      "types": "./dist/handler-coverage-extract.d.ts"
     }
   },
   "scripts": {

--- a/packages/protocol/src/handler-coverage-extract.ts
+++ b/packages/protocol/src/handler-coverage-extract.ts
@@ -48,11 +48,11 @@ export function extractCaseTypes(src: string): Set<string> {
  * the closing brace is decorated, then reads only TOP-LEVEL keys.
  *
  * Keys are read with the per-line matcher `^\s*(\w+):` (permissively `\w+` so a
- * future key with a digit or capital isn't silently dropped). Per-line matching
- * is robust to interleaved `//` comment lines between entries — which the
- * char-by-char alternative is not — and these handler maps are flat object
- * literals, so a line-based read of the brace-balanced body collects exactly
- * the top-level keys.
+ * future key with a digit or capital isn't silently dropped) applied only to
+ * lines at the map's TOP LEVEL — a running brace-depth counter skips any line
+ * inside a nested object value, so a `someType: { ... }` entry contributes only
+ * its top-level key `someType`, never the nested literal's inner keys. Per-line
+ * matching is also robust to interleaved `//` comment lines between entries.
  */
 export function extractHandlersMapKeys(src: string): Set<string> {
   const keys = new Set<string>()
@@ -77,7 +77,21 @@ export function extractHandlersMapKeys(src: string): Set<string> {
   if (endIdx === -1) return keys
   const body = src.slice(openIdx + 1, endIdx)
 
-  for (const m of body.matchAll(/^\s*(\w+)\s*:/gm)) keys.add(m[1])
+  // Walk line by line tracking brace depth; collect keys only at the map's top
+  // level (depth 0) so a nested object value's inner keys are not mistaken for
+  // message types. The key on a `someType: {` line is matched before that line
+  // raises the depth, so the real top-level key is still captured.
+  let lineDepth = 0
+  for (const line of body.split('\n')) {
+    if (lineDepth === 0) {
+      const m = line.match(/^\s*(\w+)\s*:/)
+      if (m) keys.add(m[1])
+    }
+    for (const ch of line) {
+      if (ch === '{') lineDepth++
+      else if (ch === '}') lineDepth--
+    }
+  }
   return keys
 }
 

--- a/packages/protocol/src/handler-coverage-extract.ts
+++ b/packages/protocol/src/handler-coverage-extract.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared static-parse extractor for the two clients' `message-handler.ts`
+ * handler universes (#6021).
+ *
+ * BACKGROUND
+ * ----------
+ * Two guards static-parse the app + dashboard `message-handler.ts` sources to
+ * derive "which message types does each client handle":
+ *   - `packages/protocol/tests/handler-coverage.test.js` — the exhaustiveness
+ *     guard (every ServerMessageType has *some* handler `case` or an explicit
+ *     exclusion).
+ *   - `packages/store-core/src/contract-fixtures/coverage-lint.test.ts` (#5619)
+ *     — the both-clients no-new-drift fixture lint.
+ *
+ * Each used to carry its OWN regex. They drifted: the store-core copy was
+ * STRICTER (its HANDLERS-map terminator was `\n}`, which a non-greedily matched
+ * map containing a nested object literal truncates early, and its key matcher
+ * was `[a-z_]+`). This module is the SINGLE source of truth both consume so
+ * they can never diverge again, and it uses the more-permissive / correct parse.
+ *
+ * This file is intentionally dependency-free static text analysis — it imports
+ * nothing from the protocol enum/schemas, so it stays cheap to import from both
+ * the protocol `node --test` runner and the store-core vitest runner.
+ */
+
+/**
+ * Extract `case '<type>':` clause labels from a handler source.
+ *
+ * The app handler dispatches purely through a `switch`, so this is its whole
+ * universe; the dashboard handler also uses `case` clauses (plus, historically,
+ * a `HANDLERS` map — see {@link extractHandlersMapKeys}).
+ */
+export function extractCaseTypes(src: string): Set<string> {
+  return new Set([...src.matchAll(/case\s+'([a-z_]+)'/g)].map((m) => m[1]))
+}
+
+/**
+ * Extract the keys of a `const HANDLERS: Record<string, Handler> = { ... }`
+ * map from a handler source, if present.
+ *
+ * Why a brace-balanced scan instead of a single regex: the previous two copies
+ * both terminated the map body with a non-greedy `[\s\S]*?` against either `}`
+ * (protocol — stops at the FIRST `}`, truncating at a nested object literal) or
+ * `\n}` (store-core — stops at the first newline-prefixed `}`, same failure
+ * mode plus brittle to the closing brace's column/trailing tokens such as
+ * `} as const` / `} satisfies …`). A balanced scan from the opening `{` to its
+ * matching `}` parses the real map regardless of nested object values or how
+ * the closing brace is decorated, then reads only TOP-LEVEL keys.
+ *
+ * Keys are read with the per-line matcher `^\s*(\w+):` (permissively `\w+` so a
+ * future key with a digit or capital isn't silently dropped). Per-line matching
+ * is robust to interleaved `//` comment lines between entries — which the
+ * char-by-char alternative is not — and these handler maps are flat object
+ * literals, so a line-based read of the brace-balanced body collects exactly
+ * the top-level keys.
+ */
+export function extractHandlersMapKeys(src: string): Set<string> {
+  const keys = new Set<string>()
+  const header = src.match(/const HANDLERS:\s*Record<string,\s*Handler>\s*=\s*\{/)
+  if (!header || header.index === undefined) return keys
+
+  // Find the matching close brace for the `{` that ends the header match.
+  const openIdx = header.index + header[0].length - 1 // index of the `{`
+  let depth = 0
+  let endIdx = -1
+  for (let i = openIdx; i < src.length; i++) {
+    const ch = src[i]
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) {
+        endIdx = i
+        break
+      }
+    }
+  }
+  if (endIdx === -1) return keys
+  const body = src.slice(openIdx + 1, endIdx)
+
+  for (const m of body.matchAll(/^\s*(\w+)\s*:/gm)) keys.add(m[1])
+  return keys
+}
+
+/**
+ * The app handler's full type universe: `case` clauses only.
+ */
+export function extractAppHandlerTypes(appSrc: string): Set<string> {
+  return extractCaseTypes(appSrc)
+}
+
+/**
+ * The dashboard handler's full type universe: `case` clauses plus any
+ * `HANDLERS` map keys.
+ */
+export function extractDashboardHandlerTypes(dashSrc: string): Set<string> {
+  const types = extractCaseTypes(dashSrc)
+  for (const k of extractHandlersMapKeys(dashSrc)) types.add(k)
+  return types
+}

--- a/packages/protocol/tests/handler-coverage-extract.test.js
+++ b/packages/protocol/tests/handler-coverage-extract.test.js
@@ -74,6 +74,10 @@ describe('handler-coverage shared extractor (#6021)', () => {
     assert.ok(keys.has('early_key'), 'early_key recovered')
     assert.ok(keys.has('late_key_a'), 'late_key_a recovered (old regex dropped it)')
     assert.ok(keys.has('late_key_b'), 'late_key_b recovered (old regex dropped it)')
+    // ...and it must NOT over-capture the nested object value's inner key
+    // (`opt:` sits inside `makeHandler({ ... })`, depth > 0). A whole-body key
+    // matcher would mistake it for a message type; the depth-aware scan skips it.
+    assert.ok(!keys.has('opt'), 'nested object-value key must NOT be captured as a message type')
   })
 
   it('tolerates a decorated closing brace (} as const / trailing tokens)', () => {

--- a/packages/protocol/tests/handler-coverage-extract.test.js
+++ b/packages/protocol/tests/handler-coverage-extract.test.js
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  extractCaseTypes,
+  extractHandlersMapKeys,
+  extractDashboardHandlerTypes,
+} from '@chroxy/protocol/handler-coverage'
+
+/**
+ * Unit tests for the shared handler-coverage extractor (#6021).
+ *
+ * The headline case is the FORMATTING VARIATION that the previous, stricter
+ * copies of this regex would have MISSED — proving the unified extractor is the
+ * hardened, correct parse that both the protocol guard and the store-core lint
+ * now share.
+ */
+
+describe('handler-coverage shared extractor (#6021)', () => {
+  it('extracts case clause types', () => {
+    const src = `
+      switch (msg.type) {
+        case 'auth_ok':
+          break
+        case 'session_list': {
+          break
+        }
+      }
+    `
+    assert.deepEqual(
+      [...extractCaseTypes(src)].sort(),
+      ['auth_ok', 'session_list'],
+    )
+  })
+
+  // ── The hardening proof ────────────────────────────────────────────────
+  // A HANDLERS map whose FIRST value is a nested object literal whose closing
+  // brace sits at column 0 (an `} as const`-style inline object, or a
+  // prettier-collapsed value). The old store-core block regex
+  // `const HANDLERS: Record<string, Handler> = {([\s\S]*?)\n}` is NON-GREEDY,
+  // so it stopped its capture at the FIRST newline-prefixed `}` — the close of
+  // the nested literal — truncating the map body to just `early_key: { ... }`
+  // and SILENTLY DROPPING every key after it. (The old protocol block regex
+  // `…([\s\S]*?)}` had the same failure mode against ANY first `}`, even the
+  // indented one.) The unified brace-balanced extractor reads to the map's
+  // MATCHING close brace, so it recovers every top-level key.
+  it('recovers keys after a nested object literal value (old stricter regex would drop them)', () => {
+    const src = [
+      'const HANDLERS: Record<string, Handler> = {',
+      '  early_key: makeHandler({',
+      '  opt: true,',
+      '}),',
+      '  late_key_a: handleA,',
+      '  late_key_b: handleB,',
+      '}',
+      '',
+    ].join('\n')
+
+    // Precondition: the OLD store-core stricter parse truncates at the first
+    // `\n}` (the nested literal's close) and loses the late keys.
+    const oldBlock = src.match(
+      /const HANDLERS:\s*Record<string,\s*Handler>\s*=\s*\{([\s\S]*?)\n\}/,
+    )
+    const oldKeys = new Set()
+    if (oldBlock) {
+      for (const m of oldBlock[1].matchAll(/^\s*([a-z_]+):/gm)) oldKeys.add(m[1])
+    }
+    assert.ok(
+      !oldKeys.has('late_key_a') && !oldKeys.has('late_key_b'),
+      'precondition: the OLD stricter regex must miss the late keys',
+    )
+
+    // The unified extractor recovers all three top-level keys.
+    const keys = extractHandlersMapKeys(src)
+    assert.ok(keys.has('early_key'), 'early_key recovered')
+    assert.ok(keys.has('late_key_a'), 'late_key_a recovered (old regex dropped it)')
+    assert.ok(keys.has('late_key_b'), 'late_key_b recovered (old regex dropped it)')
+  })
+
+  it('tolerates a decorated closing brace (} as const / trailing tokens)', () => {
+    const src = `
+const HANDLERS: Record<string, Handler> = {
+  alpha: handleAlpha,
+  beta: handleBeta,
+} as const
+`
+    assert.deepEqual([...extractHandlersMapKeys(src)].sort(), ['alpha', 'beta'])
+  })
+
+  it('returns no map keys when there is no HANDLERS map', () => {
+    assert.equal(extractHandlersMapKeys('const x = 1').size, 0)
+  })
+
+  it('dashboard extractor unions case clauses and HANDLERS map keys', () => {
+    const src = `
+const HANDLERS: Record<string, Handler> = {
+  pong: handlePong,
+}
+function handleMessage(msg) {
+  switch (msg.type) {
+    case 'auth_ok':
+      break
+  }
+}
+`
+    assert.deepEqual(
+      [...extractDashboardHandlerTypes(src)].sort(),
+      ['auth_ok', 'pong'],
+    )
+  })
+})

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -2,6 +2,10 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import {
+  extractAppHandlerTypes,
+  extractDashboardHandlerTypes,
+} from '@chroxy/protocol/handler-coverage'
 
 /**
  * Handler coverage contract test
@@ -199,32 +203,10 @@ function extractServerMessageTypes(wsServerSrc) {
   return result
 }
 
-function extractAppHandlerTypes(appSrc) {
-  // App uses only case statements
-  const cases = [...appSrc.matchAll(/case\s+'([a-z_]+)'/g)].map(m => m[1])
-  return new Set(cases)
-}
-
-function extractDashboardHandlerTypes(dashSrc) {
-  const types = new Set()
-
-  // 1. HANDLERS map keys (e.g. `pong: handlePong,`)
-  const handlersBlock = dashSrc.match(
-    /const HANDLERS:\s*Record<string,\s*Handler>\s*=\s*\{([\s\S]*?)\}/,
-  )
-  if (handlersBlock) {
-    for (const m of handlersBlock[1].matchAll(/^\s*(\w+):/gm)) {
-      types.add(m[1])
-    }
-  }
-
-  // 2. case statements
-  for (const m of dashSrc.matchAll(/case\s+'([a-z_]+)'/g)) {
-    types.add(m[1])
-  }
-
-  return types
-}
+// extractAppHandlerTypes / extractDashboardHandlerTypes are imported from the
+// shared @chroxy/protocol/handler-coverage module (#6021) so this guard and the
+// store-core coverage lint can never diverge on how they parse the two clients'
+// handler sources.
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -38,6 +38,10 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import {
+  extractAppHandlerTypes,
+  extractDashboardHandlerTypes,
+} from '@chroxy/protocol/handler-coverage'
 import { SWITCH_FIXTURES } from './fixtures'
 import { DISPATCH_TABLE_TYPES } from '../dispatch-table'
 
@@ -119,29 +123,18 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
 
 // ---------------------------------------------------------------------------
 // Static extraction — derive the both-clients-SWITCH universe from the two
-// clients' real handler sources. Mirrors the protocol handler-coverage guard.
+// clients' real handler sources. The extractors are the SHARED helper from
+// @chroxy/protocol/handler-coverage (#6021), the single source of truth this
+// lint and the protocol handler-coverage guard both consume so they can never
+// diverge on the parse (the previous local copy here was stricter and could
+// miss HANDLERS-map keys in some formatting cases).
 // ---------------------------------------------------------------------------
-
-/** App handler uses only `case '<type>':` clauses. */
-function extractAppSwitchTypes(src: string): Set<string> {
-  return new Set([...src.matchAll(/case\s+'([a-z_]+)'/g)].map((m) => m[1]))
-}
-
-/** Dashboard handler uses `case '<type>':` clauses AND a `HANDLERS` map. */
-function extractDashSwitchTypes(src: string): Set<string> {
-  const types = new Set<string>([...src.matchAll(/case\s+'([a-z_]+)'/g)].map((m) => m[1]))
-  const handlersBlock = src.match(/const HANDLERS:\s*Record<string,\s*Handler>\s*=\s*\{([\s\S]*?)\n\}/)
-  if (handlersBlock) {
-    for (const m of handlersBlock[1].matchAll(/^\s*([a-z_]+):/gm)) types.add(m[1])
-  }
-  return types
-}
 
 function bothClientsSwitchTypes(): string[] {
   const appSrc = readFileSync(appHandlerPath, 'utf-8')
   const dashSrc = readFileSync(dashHandlerPath, 'utf-8')
-  const appTypes = extractAppSwitchTypes(appSrc)
-  const dashTypes = extractDashSwitchTypes(dashSrc)
+  const appTypes = extractAppHandlerTypes(appSrc)
+  const dashTypes = extractDashboardHandlerTypes(dashSrc)
   const dispatchTableTypes = new Set<string>(DISPATCH_TABLE_TYPES)
   return [...appTypes]
     .filter((t) => dashTypes.has(t) && !dispatchTableTypes.has(t))


### PR DESCRIPTION
## Summary

Two guards static-parsed the app + dashboard `message-handler.ts` handler universes with their OWN regexes, and they had drifted:

- `packages/protocol/tests/handler-coverage.test.js` — the exhaustiveness guard (HANDLERS block stopped at the first `}`; key matcher `\w+`).
- `packages/store-core/src/contract-fixtures/coverage-lint.test.ts` (#5619) — the both-clients no-new-drift lint, which was **stricter** (HANDLERS block terminator `\n}`; key matcher `[a-z_]+`) and could miss keys in some formatting cases.

This factors the extraction into ONE shared helper that both consume, so the correct/permissive parse is the single source of truth and they can never diverge again.

## Where the shared helper lives

`packages/protocol/src/handler-coverage-extract.ts`, exported via a new package subpath **`@chroxy/protocol/handler-coverage`**. It is dependency-free static text analysis (imports nothing from the protocol enum/schemas), so it's cheap to import from both the protocol `node --test` runner and the store-core vitest runner. Exports: `extractCaseTypes`, `extractHandlersMapKeys`, `extractAppHandlerTypes`, `extractDashboardHandlerTypes`.

The unified `extractHandlersMapKeys` uses a **brace-balanced scan** to the map's matching close brace, then reads top-level keys with the permissive per-line `^\s*(\w+):` matcher — robust to interleaved `//` comment lines between entries and to decorated closing braces (`} as const`, etc.), which the old single-regex approaches were not.

## How both consume it

- `handler-coverage.test.js` imports `extractAppHandlerTypes` / `extractDashboardHandlerTypes` and deletes its inline copies.
- `coverage-lint.test.ts` imports the same two functions (replacing its local `extractAppSwitchTypes` / `extractDashSwitchTypes`) and feeds them into `bothClientsSwitchTypes()`.

## Universe count

**Unchanged at 64.** Verified the new extractor and the old store-core regex produce the identical both-clients set (zero delta). The #5619 lint semantics are intact: no-new-drift, shrink-only `PENDING_CONTRACT_TYPES` allowlist, `>20` extraction-sanity floor.

## Hardening test

New unit test file `packages/protocol/tests/handler-coverage-extract.test.js`. The headline case feeds a `HANDLERS` map whose value contains a nested object literal whose closing brace sits at column 0 — the old stricter `\n}` regex truncated its capture there and **silently dropped every key after it**; the test asserts the old regex misses those keys (precondition) and that the unified brace-balanced extractor recovers them all.

## Protocol dist

Rebuilt (`npm run build` in `packages/protocol`); `dist/handler-coverage-extract.{js,d.ts}` force-added (dist is gitignored but tracked, same as the existing dist files) so the subpath resolves for the store-core lint in CI.

## Tests

- `packages/protocol`: `npm test` + `npm run build` (= typecheck) — **328 pass / 0 fail**.
- `packages/store-core`: `npx vitest run` — **40 files, 1645 pass / 0 fail**; `npm run typecheck` (`tsc --noEmit`) clean.

Closes #6021