### PR TITLE
test(server): fail CI on --test-force-exit truncation via a test-count guard (#5480)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "start": "node src/cli.js start",
     "dev": "node --watch src/cli.js start",
-    "test": "c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
+    "test": "node ./scripts/assert-test-count.mjs c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
+    "test:raw": "c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
     "test:coverage": "c8 --reporter=text --reporter=html node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
     "test:integration": "node --import ./tests/_setup.mjs --test ./tests/*.integration.test.js",
     "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test ./tests/integration/k8s-sidecar-roundtrip.test.js",

--- a/packages/server/scripts/assert-test-count.mjs
+++ b/packages/server/scripts/assert-test-count.mjs
@@ -40,7 +40,23 @@ import { spawn } from 'node:child_process'
 // AND shrinkage, while still catching a truncation that drops more than a couple
 // hundred tests. Override per-invocation with CHROXY_MIN_TEST_COUNT for targeted
 // runs of a subset (e.g. a single large file in local repro).
-const EXPECTED_MIN_TESTS = Number(process.env.CHROXY_MIN_TEST_COUNT ?? 9700)
+const DEFAULT_MIN_TESTS = 9700
+// Validate the override: an invalid value (typo, empty, non-numeric) must NOT
+// silently disable the floor. `Number('abc')` is NaN and `total < NaN` is always
+// false, which would quietly turn the guard off — so fall back to the default and
+// warn loudly instead.
+let EXPECTED_MIN_TESTS = DEFAULT_MIN_TESTS
+if (process.env.CHROXY_MIN_TEST_COUNT !== undefined) {
+  const parsed = Number(process.env.CHROXY_MIN_TEST_COUNT)
+  if (Number.isInteger(parsed) && parsed > 0) {
+    EXPECTED_MIN_TESTS = parsed
+  } else {
+    console.error(
+      `[assert-test-count] ignoring invalid CHROXY_MIN_TEST_COUNT='${process.env.CHROXY_MIN_TEST_COUNT}' ` +
+      `(must be a positive integer); using default floor ${DEFAULT_MIN_TESTS}.`,
+    )
+  }
+}
 
 // How far above the floor the live count must climb before we suggest bumping
 // the floor. Purely advisory — never fails the run.
@@ -59,8 +75,10 @@ if (!cmd) {
 let captured = ''
 const child = spawn(cmd, args, {
   stdio: ['inherit', 'pipe', 'inherit'],
-  // `c8`/`node` resolve from PATH; shell:false keeps argv quoting intact.
-  shell: false,
+  // `c8`/`node` resolve from PATH. On Windows, npm installs `c8` as a `c8.cmd`
+  // shim and CreateProcess can't execute a .cmd without a shell, so spawn via
+  // the shell there; on POSIX keep shell:false so argv quoting stays intact.
+  shell: process.platform === 'win32',
 })
 
 child.stdout.on('data', (chunk) => {

--- a/packages/server/scripts/assert-test-count.mjs
+++ b/packages/server/scripts/assert-test-count.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Truncation guard for `--test-force-exit` (#5480).
+ *
+ * The server test command runs the Node test runner with `--test-force-exit`,
+ * which `process.exit()`s the moment the runner *appears* idle. On a large
+ * file this can fire while trailing suites are still queued, so the file runs
+ * only a subset of its tests — yet exit code stays 0. A truncated run is then
+ * indistinguishable from a green one (confirmed reproducible on current main:
+ * `discord-webhook-sink.test.js` ran anywhere from 79 to 114 of its 114 tests
+ * across 20 runs, always exiting 0).
+ *
+ * `--test-force-exit` cannot simply be removed: WITHOUT it the full suite hangs
+ * past the 10-minute CI budget on leaked handles (tunnel-recovery timers and
+ * friends — see follow-up issue). So instead of trading one silent failure
+ * mode for a loud hang, this wrapper makes a *truncated* run go RED:
+ *
+ *   1. It runs the underlying test command (passed as argv), streaming all
+ *      output through unchanged so coverage + TAP land on the terminal/CI log.
+ *   2. From the aggregate TAP summary it reads `# tests N` and `# fail M`.
+ *   3. It exits non-zero if:
+ *        - the summary is missing (the runner died before reporting), OR
+ *        - `M > 0` (real test failures — mirrors the runner's own exit), OR
+ *        - `N < EXPECTED_MIN_TESTS` (a truncation dropped enough tests to fall
+ *          below the documented floor).
+ *
+ * EXPECTED_MIN_TESTS is a *lower bound*, not the exact count. The full suite
+ * reports ~10040 tests today; the floor sits below that with headroom so it
+ * does not break every time a test is added, but high enough that a meaningful
+ * truncation trips it. When the suite grows well past the floor, bump the floor
+ * (the script prints the live count + a nudge when headroom gets large). When
+ * tests are deliberately removed below the floor, lower it in the same PR.
+ */
+
+import { spawn } from 'node:child_process'
+
+// --- The documented floor -----------------------------------------------------
+// Set below the observed full-suite count (~10040 tests, three clean runs on
+// 2026-06-18: 10040 / 10044 / 10048) with deliberate headroom for honest growth
+// AND shrinkage, while still catching a truncation that drops more than a couple
+// hundred tests. Override per-invocation with CHROXY_MIN_TEST_COUNT for targeted
+// runs of a subset (e.g. a single large file in local repro).
+const EXPECTED_MIN_TESTS = Number(process.env.CHROXY_MIN_TEST_COUNT ?? 9700)
+
+// How far above the floor the live count must climb before we suggest bumping
+// the floor. Purely advisory — never fails the run.
+const HEADROOM_NUDGE = 600
+
+const cmd = process.argv[2]
+const args = process.argv.slice(3)
+
+if (!cmd) {
+  console.error('[assert-test-count] usage: assert-test-count.mjs <cmd> [...args]')
+  process.exit(2)
+}
+
+// Capture stdout while still echoing it. The TAP summary the Node test runner
+// emits goes to stdout; stderr is passed straight through (logs/warnings).
+let captured = ''
+const child = spawn(cmd, args, {
+  stdio: ['inherit', 'pipe', 'inherit'],
+  // `c8`/`node` resolve from PATH; shell:false keeps argv quoting intact.
+  shell: false,
+})
+
+child.stdout.on('data', (chunk) => {
+  captured += chunk
+  process.stdout.write(chunk)
+})
+
+child.on('error', (err) => {
+  console.error(`[assert-test-count] failed to spawn '${cmd}': ${err.message}`)
+  process.exit(2)
+})
+
+child.on('close', (code, signal) => {
+  const fail = () => process.exit(1)
+
+  // Parse the aggregate TAP summary. The Node test runner prints one summary
+  // block at the very end; we take the LAST occurrence of each line so a
+  // subtest's own `# fail 0` cannot shadow the aggregate.
+  const lastNumber = (label) => {
+    const re = new RegExp(`^# ${label} (\\d+)`, 'gm')
+    let m
+    let val = null
+    while ((m = re.exec(captured)) !== null) val = Number(m[1])
+    return val
+  }
+
+  const total = lastNumber('tests')
+  const failed = lastNumber('fail')
+
+  if (signal) {
+    console.error(`\n[assert-test-count] FAIL: test process was killed by signal ${signal}.`)
+    return fail()
+  }
+
+  if (total === null || failed === null) {
+    console.error(
+      '\n[assert-test-count] FAIL: no TAP summary (`# tests` / `# fail`) found in output. ' +
+      'The runner likely died before reporting — treat as a truncated/aborted run.',
+    )
+    return fail()
+  }
+
+  if (failed > 0) {
+    console.error(`\n[assert-test-count] FAIL: ${failed} test(s) failed (see TAP output above).`)
+    return fail()
+  }
+
+  if (total < EXPECTED_MIN_TESTS) {
+    console.error(
+      `\n[assert-test-count] FAIL: only ${total} tests ran, below the floor of ${EXPECTED_MIN_TESTS}.\n` +
+      '  This is the --test-force-exit truncation guard (#5480): a large test file very likely\n' +
+      '  had trailing suites skipped before the forced exit. Re-run; if it persists, a file\n' +
+      '  grew large enough to truncate reliably (split it, or move suites earlier). If you\n' +
+      '  intentionally removed tests below the floor, lower EXPECTED_MIN_TESTS in this script.',
+    )
+    return fail()
+  }
+
+  // Green. Nudge to raise the floor if it has drifted well below the live count.
+  if (total - EXPECTED_MIN_TESTS > HEADROOM_NUDGE) {
+    console.error(
+      `\n[assert-test-count] OK: ${total} tests ran (floor ${EXPECTED_MIN_TESTS}). ` +
+      `Consider raising EXPECTED_MIN_TESTS — the suite is now ${total - EXPECTED_MIN_TESTS} above the floor.`,
+    )
+  } else {
+    console.error(`\n[assert-test-count] OK: ${total} tests ran (floor ${EXPECTED_MIN_TESTS}).`)
+  }
+
+  // Preserve the underlying exit code for any non-test failure (e.g. c8 error)
+  // that still printed a clean summary.
+  process.exit(code ?? 0)
+})


### PR DESCRIPTION
## Problem

The server test command runs Node's test runner with `--test-force-exit`, which `process.exit()`s the moment the runner *appears* idle. On a large file that can fire while trailing suites are still queued, so the file runs only a subset of its tests — yet exit code stays 0. A truncated run is then indistinguishable from a green one.

## Reproduced on current main (Node 22.22.3)

`discord-webhook-sink.test.js` with the exact CI flags (`--import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit`), 20 runs:

- **WITH** `--test-force-exit`: test count ranged **79–114** of 114, **always exit 0**. Non-deterministic truncation confirmed.
- **WITHOUT** the flag: deterministically **114/114**, clean exit (this single file does not hang).
- Truncation is **worse when stdout is piped (non-TTY)** — which is exactly the CI condition (82 vs 114 in one comparison). My guard pipes stdout, so it sees what CI sees.

### Mechanism

`--test-force-exit` exits as soon as the runner's queue looks drained; between suites the event loop can momentarily have no pending work, so the forced exit beats the still-queued trailing suites. The aggregate TAP `# tests` / `# pass` / `# fail` summary is still emitted on a truncated run, just with a lower count — so the count is the signal.

## Why the flag can't just be removed (root cause, deferred)

Full suite **WITHOUT** `--test-force-exit` **hangs past 9 minutes** (a 560s alarm fired before the runner emitted a summary) — leaked handles keep the event loop alive after all tests finish. This is the original reason the flag exists, so removing it trades a silent truncation for a loud 10-min CI hang. Root-cause teardown of the leaked timers (tunnel-recovery `setTimeout`s, reapers/pollers/monitors) is tracked in **#6027**.

## The guard (cheap insurance)

New `packages/server/scripts/assert-test-count.mjs` wraps the test command: it streams all output through unchanged (coverage + TAP still land in the CI log), reads the aggregate TAP summary, and exits non-zero if:

- the summary is **missing** (runner died before reporting — aborted/killed run), or
- any test **failed** (mirrors the runner's own exit), or
- the test count is **below a documented floor** (truncation).

`npm test` now runs through the guard; the raw command is preserved as `npm run test:raw`. The floor (`EXPECTED_MIN_TESTS = 9700`, overridable via `CHROXY_MIN_TEST_COUNT`) is a conservative *lower bound* below the observed full-suite count (~10040, three clean runs: 10040 / 10044 / 10048) with headroom for honest growth/shrinkage, plus an advisory nudge to raise it when the suite climbs well above the floor. It is high enough to catch a truncation that drops more than a couple hundred tests.

### Proven RED on truncation, GREEN on a full run

- GREEN — single file, floor below count → `OK: 114 tests ran` (exit 0).
- RED — simulated truncation (floor above achievable count) → `FAIL: only 85 tests ran, below the floor` (exit 1).
- RED — real test failure → `FAIL: N test(s) failed` (exit 1).
- RED — missing summary (process produced no TAP) → `FAIL: no TAP summary found` (exit 1).
- Full `npm test` through the guard: 10058 tests, count assertion passes (well above floor). The only 2 failures were the known live-`:8765`-daemon `getFullServiceStatus` tests (environmental, documented; green in CI where no daemon runs).

## Files changed

- `packages/server/scripts/assert-test-count.mjs` (new) — the guard.
- `packages/server/package.json` — `test` runs through the guard; raw command preserved as `test:raw`.

## Deferred

Root-cause leaked-handle teardown → #6027. The flag and this guard stay in place until then.

Part of #5480