### PR TITLE
fix(server): redact secret-shaped values on the tool-broadcast path (#6029)

### DIFF
--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -18,6 +18,7 @@
 import { appendFileSync, statSync, renameSync, mkdirSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import { SENSITIVE_PATTERNS, API_KEY_PATTERNS, redactValue } from './redaction.js'
 
 const DEFAULT_LOG_DIR = join(homedir(), '.chroxy', 'logs')
 const MAX_LOG_SIZE = 5 * 1024 * 1024  // 5MB
@@ -26,72 +27,21 @@ const ROTATION_CHECK_INTERVAL = 100  // check every N writes
 
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 }
 
-// Sensitive patterns to redact from log messages
-const SENSITIVE_PATTERNS = [
-  // Bearer tokens in headers
-  /Bearer\s+[A-Za-z0-9_\-./+=]{8,}/gi,
-  // API tokens (base64url, UUID, hex) after common key names
-  /(?:token|password|secret|apiKey|api_key|authorization|credential|private_key)\s*[:=]\s*["']?[A-Za-z0-9_\-./+=]{8,}["']?/gi,
-]
-
-// Provider API key patterns (#2961). These run separately so we can emit a
-// bare "[REDACTED]" regardless of any surrounding key/value syntax — the raw
-// key often appears mid-sentence in stderr (e.g., "invalid api key sk-...").
-// Length floors are tuned to avoid false positives on short identifiers like
-// product SKUs or the literal word "AIzawa".
-const API_KEY_PATTERNS = [
-  // Anthropic: sk-ant-api03-... (checked before generic sk- so the longer
-  // prefix wins). Real keys are well over 40 trailing chars.
-  /\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{40,}/g,
-  // OpenAI project-scoped keys: sk-proj-... (typically 40+ chars after prefix)
-  /\bsk-proj-[A-Za-z0-9_-]{40,}/g,
-  // OpenAI legacy secret keys: sk- followed by 40+ chars. Must not match
-  // sk-ant- / sk-proj- (already handled above) — negative lookahead keeps
-  // them from being partially redacted.
-  /\bsk-(?!ant-|proj-)[A-Za-z0-9]{40,}/g,
-  // Google API keys: AIza + exactly 35 chars of [A-Za-z0-9_-].
-  // Trailing \b prevents matching into longer alphanumerics (e.g., AIzawa…).
-  /\bAIza[A-Za-z0-9_-]{35}\b/g,
-  // #5358: JWTs (incl. claude/OAuth bearer JWTs printed without a "Bearer"/key
-  // marker). header.payload.signature, each base64url; the header always starts
-  // `eyJ` (base64 of `{"`), which makes this specific enough to avoid matching
-  // ordinary dotted tokens. Length floors keep it off short `a.b.c` strings.
-  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
-  // #5413: Discord webhook URLs. The token segment after the numeric webhook
-  // id grants post/edit/delete on the channel, so the URL is a credential.
-  // Covers discordapp.com (legacy), ptb/canary builds, and optional /vN/ API
-  // version segments; anything after the token (e.g. /messages/<id>) is left
-  // intact. Real webhook tokens are 60+ chars; the 20 floor keeps doc
-  // placeholders like .../webhooks/123/abc readable while catching any
-  // plausible real token.
-  /\bhttps:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/(?:v\d+\/)?webhooks\/\d+\/[A-Za-z0-9_-]{20,}/g,
-]
+// #6029: the value-SHAPE patterns (SENSITIVE_PATTERNS / API_KEY_PATTERNS) and
+// the contiguous redaction logic now live in redaction.js as the single source
+// of truth, shared with the tool-broadcast sanitizer (ws-permissions.js). The
+// constants are imported here for redactSensitivePreservingEscapes (the
+// escape-aware PTY-dump pass that still needs the raw pattern list).
 
 /**
- * Redact sensitive data from a log message.
+ * Redact sensitive data from a log message. Delegates to the shared
+ * `redactValue` (redaction.js) so the logger and the tool-broadcast path apply
+ * identical patterns and replacement rules.
  * @param {string} msg
  * @returns {string}
  */
 export function redactSensitive(msg) {
-  let result = msg
-  for (const pattern of SENSITIVE_PATTERNS) {
-    result = result.replace(pattern, (match) => {
-      // Keep the key name, redact the value
-      const colonIdx = match.indexOf(':')
-      const eqIdx = match.indexOf('=')
-      const sepIdx = colonIdx >= 0 ? (eqIdx >= 0 ? Math.min(colonIdx, eqIdx) : colonIdx) : eqIdx
-      if (sepIdx >= 0) {
-        return match.slice(0, sepIdx + 1) + ' [REDACTED]'
-      }
-      // For Bearer tokens
-      if (match.startsWith('Bearer')) return 'Bearer [REDACTED]'
-      return '[REDACTED]'
-    })
-  }
-  for (const pattern of API_KEY_PATTERNS) {
-    result = result.replace(pattern, '[REDACTED]')
-  }
-  return result
+  return redactValue(msg)
 }
 
 // #5358: escape/control sequences a TUI can interleave INTO a token while

--- a/packages/server/src/redaction.js
+++ b/packages/server/src/redaction.js
@@ -12,7 +12,7 @@
  * - `SENSITIVE_PATTERNS` / `API_KEY_PATTERNS` — the value-shape regexes.
  * - `redactValue(str)` — apply both pattern sets to a string (the logger's
  *   existing redaction behavior, hoisted verbatim).
- * - `SENSITIVE_KEYS` — the key-NAME set used by the broadcast sanitizer.
+ * - `SENSITIVE_KEY_NAMES` — the key-NAME set used by the broadcast sanitizer.
  */
 
 // Sensitive patterns to redact from strings.

--- a/packages/server/src/redaction.js
+++ b/packages/server/src/redaction.js
@@ -1,0 +1,102 @@
+/**
+ * Shared secret-redaction primitives.
+ *
+ * Single source of truth for the value-SHAPE patterns (#6029). Previously the
+ * tool-broadcast sanitizer (ws-permissions.js) redacted by KEY NAME only, so a
+ * secret embedded in a value under a benign key — e.g.
+ * `{ command: 'export TOKEN=sk-ant-api03-…' }` or
+ * `{ url: 'https://discord.com/api/webhooks/…' }` — was broadcast verbatim to
+ * every subscribed client. The value patterns lived only in logger.js; this
+ * module hoists them so the broadcast path and the logger share one definition.
+ *
+ * - `SENSITIVE_PATTERNS` / `API_KEY_PATTERNS` — the value-shape regexes.
+ * - `redactValue(str)` — apply both pattern sets to a string (the logger's
+ *   existing redaction behavior, hoisted verbatim).
+ * - `SENSITIVE_KEYS` — the key-NAME set used by the broadcast sanitizer.
+ */
+
+// Sensitive patterns to redact from strings.
+const SENSITIVE_PATTERNS = [
+  // Bearer tokens in headers
+  /Bearer\s+[A-Za-z0-9_\-./+=]{8,}/gi,
+  // API tokens (base64url, UUID, hex) after common key names
+  /(?:token|password|secret|apiKey|api_key|authorization|credential|private_key)\s*[:=]\s*["']?[A-Za-z0-9_\-./+=]{8,}["']?/gi,
+]
+
+// Provider API key patterns (#2961). These run separately so we can emit a
+// bare "[REDACTED]" regardless of any surrounding key/value syntax — the raw
+// key often appears mid-sentence in stderr (e.g., "invalid api key sk-...").
+// Length floors are tuned to avoid false positives on short identifiers like
+// product SKUs or the literal word "AIzawa".
+const API_KEY_PATTERNS = [
+  // Anthropic: sk-ant-api03-... (checked before generic sk- so the longer
+  // prefix wins). Real keys are well over 40 trailing chars.
+  /\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{40,}/g,
+  // OpenAI project-scoped keys: sk-proj-... (typically 40+ chars after prefix)
+  /\bsk-proj-[A-Za-z0-9_-]{40,}/g,
+  // OpenAI legacy secret keys: sk- followed by 40+ chars. Must not match
+  // sk-ant- / sk-proj- (already handled above) — negative lookahead keeps
+  // them from being partially redacted.
+  /\bsk-(?!ant-|proj-)[A-Za-z0-9]{40,}/g,
+  // Google API keys: AIza + exactly 35 chars of [A-Za-z0-9_-].
+  // Trailing \b prevents matching into longer alphanumerics (e.g., AIzawa…).
+  /\bAIza[A-Za-z0-9_-]{35}\b/g,
+  // #5358: JWTs (incl. claude/OAuth bearer JWTs printed without a "Bearer"/key
+  // marker). header.payload.signature, each base64url; the header always starts
+  // `eyJ` (base64 of `{"`), which makes this specific enough to avoid matching
+  // ordinary dotted tokens. Length floors keep it off short `a.b.c` strings.
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
+  // #5413: Discord webhook URLs. The token segment after the numeric webhook
+  // id grants post/edit/delete on the channel, so the URL is a credential.
+  // Covers discordapp.com (legacy), ptb/canary builds, and optional /vN/ API
+  // version segments; anything after the token (e.g. /messages/<id>) is left
+  // intact. Real webhook tokens are 60+ chars; the 20 floor keeps doc
+  // placeholders like .../webhooks/123/abc readable while catching any
+  // plausible real token.
+  /\bhttps:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/(?:v\d+\/)?webhooks\/\d+\/[A-Za-z0-9_-]{20,}/g,
+]
+
+/**
+ * Key NAMES whose VALUE is always a secret (the broadcast sanitizer redacts
+ * these wholesale regardless of value shape). Kept here so the broadcast path
+ * and any other consumer share one list.
+ */
+const SENSITIVE_KEY_NAMES = new Set([
+  'token', 'password', 'apikey', 'secret', 'authorization',
+  'credential', 'private_key', 'api_key',
+])
+
+/**
+ * Redact secret-shaped substrings from a string value. This is the logger's
+ * existing redaction behavior, hoisted so the tool-broadcast path reuses the
+ * exact same patterns and replacement rules.
+ *
+ * - `SENSITIVE_PATTERNS` keep the key name and redact only the value.
+ * - `API_KEY_PATTERNS` redact the whole match (bare `[REDACTED]`).
+ *
+ * @param {string} msg
+ * @returns {string}
+ */
+export function redactValue(msg) {
+  let result = msg
+  for (const pattern of SENSITIVE_PATTERNS) {
+    result = result.replace(pattern, (match) => {
+      // Keep the key name, redact the value
+      const colonIdx = match.indexOf(':')
+      const eqIdx = match.indexOf('=')
+      const sepIdx = colonIdx >= 0 ? (eqIdx >= 0 ? Math.min(colonIdx, eqIdx) : colonIdx) : eqIdx
+      if (sepIdx >= 0) {
+        return match.slice(0, sepIdx + 1) + ' [REDACTED]'
+      }
+      // For Bearer tokens
+      if (match.startsWith('Bearer')) return 'Bearer [REDACTED]'
+      return '[REDACTED]'
+    })
+  }
+  for (const pattern of API_KEY_PATTERNS) {
+    result = result.replace(pattern, '[REDACTED]')
+  }
+  return result
+}
+
+export { SENSITIVE_PATTERNS, API_KEY_PATTERNS, SENSITIVE_KEY_NAMES }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -15,31 +15,69 @@ const PERMISSION_TTL_MS = 300_000 // 5 minutes
 // -- Broadcast safety --
 const MAX_INPUT_BYTES = 10_240 // 10KB max for broadcast
 
+// Cap recursion so a pathologically deep or cyclic tool_input can't blow the
+// stack. Real tool inputs are shallow; anything past this is summarized away.
+const MAX_SANITIZE_DEPTH = 8
+
+/**
+ * Recursively redact a single tool_input value of any shape (#6029). Applies the
+ * KEY-NAME pass to object keys and the VALUE-SHAPE pass (`redactValue`) to every
+ * string at any depth, so a secret nested inside an object or array — e.g.
+ * `{ env: { TOKEN: 'sk-ant-…' } }`, `{ args: ['--token', 'sk-ant-…'] }`, or
+ * `{ headers: { Authorization: 'Bearer …' } }` — can't slip past the top-level
+ * scan. `seen` guards against cycles; `depth` caps pathological nesting.
+ *
+ * @param {*} value
+ * @param {number} depth
+ * @param {WeakSet} seen
+ * @returns {*}
+ */
+function redactDeep(value, depth, seen) {
+  if (typeof value === 'string') {
+    const redacted = redactValue(value)
+    return redacted.length > MAX_INPUT_BYTES
+      ? redacted.slice(0, MAX_INPUT_BYTES) + '... [truncated]'
+      : redacted
+  }
+  if (!value || typeof value !== 'object') return value
+  if (depth >= MAX_SANITIZE_DEPTH) return '[REDACTED:depth]'
+  if (seen.has(value)) return '[REDACTED:cycle]'
+  seen.add(value)
+  let out
+  if (Array.isArray(value)) {
+    out = value.map((item) => redactDeep(item, depth + 1, seen))
+  } else {
+    out = {}
+    for (const [key, child] of Object.entries(value)) {
+      out[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
+        ? '[REDACTED]'
+        : redactDeep(child, depth + 1, seen)
+    }
+  }
+  seen.delete(value)
+  return out
+}
+
 /**
  * Sanitize tool input for broadcast: redact sensitive fields and truncate large
  * values. Two passes (#6029): a KEY-NAME pass redacts values under sensitive
- * keys wholesale, and a VALUE-SHAPE pass runs every remaining string value
+ * keys wholesale, and a VALUE-SHAPE pass runs every string value (at ANY depth)
  * through `redactValue` so a secret embedded under a benign key — e.g.
- * `{ command: 'export TOKEN=sk-ant-…' }` or `{ url: 'https://discord.com/api/webhooks/…' }`
- * — is redacted before it reaches any client. Value patterns are shared with the
- * logger via redaction.js (single source of truth).
+ * `{ command: 'export TOKEN=sk-ant-…' }`, `{ url: 'https://discord.com/api/webhooks/…' }`,
+ * or nested in `{ env: { TOKEN: 'sk-ant-…' } }` / `{ args: ['--token', 'sk-ant-…'] }`
+ * — is redacted before it reaches any client. Both passes recurse through nested
+ * objects and arrays. Value patterns are shared with the logger via redaction.js
+ * (single source of truth).
  */
 function sanitizeToolInput(input) {
   if (!input || typeof input !== 'object') return input
 
+  const seen = new WeakSet()
   const result = {}
   for (const [key, value] of Object.entries(input)) {
-    if (SENSITIVE_KEY_NAMES.has(key.toLowerCase())) {
-      result[key] = '[REDACTED]'
-    } else if (typeof value === 'string') {
-      // Value-shape pass first so a redacted secret never survives truncation.
-      const redacted = redactValue(value)
-      result[key] = redacted.length > MAX_INPUT_BYTES
-        ? redacted.slice(0, MAX_INPUT_BYTES) + '... [truncated]'
-        : redacted
-    } else {
-      result[key] = value
-    }
+    result[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
+      ? '[REDACTED]'
+      : redactDeep(value, 1, seen)
   }
 
   // Final size check on the whole object
@@ -48,6 +86,26 @@ function sanitizeToolInput(input) {
     return { _truncated: true, summary: serialized.slice(0, MAX_INPUT_BYTES) + '... [truncated]' }
   }
   return result
+}
+
+/**
+ * Build the human-readable `description` broadcast alongside a permission
+ * request. #6029: the description is derived from RAW toolInput and broadcast
+ * next to the sanitized `input`, so a secret in command/url/etc. would leak here
+ * even though `input` is clean. The final string is run through `redactValue` so
+ * the broadcast description can never carry a secret-shaped value.
+ *
+ * @param {object} toolInput
+ * @returns {string}
+ */
+function buildPermissionDescription(toolInput) {
+  const raw = toolInput.description
+    || toolInput.command
+    || toolInput.file_path
+    || toolInput.pattern
+    || toolInput.query
+    || JSON.stringify(toolInput).slice(0, 200)
+  return redactValue(raw)
 }
 
 /**
@@ -202,12 +260,7 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       const tool = hookData.tool_name || 'Unknown tool'
       const toolInput = hookData.tool_input || {}
       const sanitizedInput = sanitizeToolInput(toolInput)
-      const description = toolInput.description
-        || toolInput.command
-        || toolInput.file_path
-        || toolInput.pattern
-        || toolInput.query
-        || JSON.stringify(toolInput).slice(0, 200)
+      const description = buildPermissionDescription(toolInput)
 
       // #2831: find the CliSession this hook permission belongs to (via
       // the per-session hook secret from the Authorization header) so we
@@ -640,4 +693,4 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
 }
 
 // Exported for testing
-export { sanitizeToolInput }
+export { sanitizeToolInput, buildPermissionDescription }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -5,6 +5,7 @@ import { buildSessionTokenMismatchPayload } from './handler-utils.js'
 import { settlePush } from './push.js'
 import { createPermissionResolver } from './permission-resolver.js'
 import { sendOversizeResponse } from './http-oversize.js'
+import { SENSITIVE_KEY_NAMES, redactValue } from './redaction.js'
 
 const log = createLogger('ws')
 
@@ -13,20 +14,29 @@ const PERMISSION_TTL_MS = 300_000 // 5 minutes
 
 // -- Broadcast safety --
 const MAX_INPUT_BYTES = 10_240 // 10KB max for broadcast
-const SENSITIVE_KEYS = new Set(['token', 'password', 'apikey', 'secret', 'authorization', 'credential', 'private_key', 'api_key'])
 
 /**
- * Sanitize tool input for broadcast: redact sensitive fields and truncate large values.
+ * Sanitize tool input for broadcast: redact sensitive fields and truncate large
+ * values. Two passes (#6029): a KEY-NAME pass redacts values under sensitive
+ * keys wholesale, and a VALUE-SHAPE pass runs every remaining string value
+ * through `redactValue` so a secret embedded under a benign key — e.g.
+ * `{ command: 'export TOKEN=sk-ant-…' }` or `{ url: 'https://discord.com/api/webhooks/…' }`
+ * — is redacted before it reaches any client. Value patterns are shared with the
+ * logger via redaction.js (single source of truth).
  */
 function sanitizeToolInput(input) {
   if (!input || typeof input !== 'object') return input
 
   const result = {}
   for (const [key, value] of Object.entries(input)) {
-    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+    if (SENSITIVE_KEY_NAMES.has(key.toLowerCase())) {
       result[key] = '[REDACTED]'
-    } else if (typeof value === 'string' && value.length > MAX_INPUT_BYTES) {
-      result[key] = value.slice(0, MAX_INPUT_BYTES) + '... [truncated]'
+    } else if (typeof value === 'string') {
+      // Value-shape pass first so a redacted secret never survives truncation.
+      const redacted = redactValue(value)
+      result[key] = redacted.length > MAX_INPUT_BYTES
+        ? redacted.slice(0, MAX_INPUT_BYTES) + '... [truncated]'
+        : redacted
     } else {
       result[key] = value
     }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -13,7 +13,7 @@ const log = createLogger('ws')
 const PERMISSION_TTL_MS = 300_000 // 5 minutes
 
 // -- Broadcast safety --
-const MAX_INPUT_BYTES = 10_240 // 10KB max for broadcast
+const MAX_INPUT_CHARS = 10_240 // ~10K chars max for broadcast (JS string length, not bytes)
 
 // Cap recursion so a pathologically deep or cyclic tool_input can't blow the
 // stack. Real tool inputs are shallow; anything past this is summarized away.
@@ -35,8 +35,8 @@ const MAX_SANITIZE_DEPTH = 8
 function redactDeep(value, depth, seen) {
   if (typeof value === 'string') {
     const redacted = redactValue(value)
-    return redacted.length > MAX_INPUT_BYTES
-      ? redacted.slice(0, MAX_INPUT_BYTES) + '... [truncated]'
+    return redacted.length > MAX_INPUT_CHARS
+      ? redacted.slice(0, MAX_INPUT_CHARS) + '... [truncated]'
       : redacted
   }
   if (!value || typeof value !== 'object') return value
@@ -82,8 +82,8 @@ function sanitizeToolInput(input) {
 
   // Final size check on the whole object
   const serialized = JSON.stringify(result)
-  if (serialized.length > MAX_INPUT_BYTES) {
-    return { _truncated: true, summary: serialized.slice(0, MAX_INPUT_BYTES) + '... [truncated]' }
+  if (serialized.length > MAX_INPUT_CHARS) {
+    return { _truncated: true, summary: serialized.slice(0, MAX_INPUT_CHARS) + '... [truncated]' }
   }
   return result
 }

--- a/packages/server/tests/tool-broadcast-value-redaction.test.js
+++ b/packages/server/tests/tool-broadcast-value-redaction.test.js
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { sanitizeToolInput } from '../src/ws-permissions.js'
+import { redactValue } from '../src/redaction.js'
+
+/**
+ * #6029 — the tool-broadcast sanitizer redacted by KEY NAME only, so a secret
+ * embedded in a VALUE under a benign key leaked verbatim to every subscribed
+ * client. These tests pin the additive value-shape pass and confirm the
+ * pre-existing key-name redaction + truncation behavior is unchanged.
+ *
+ * NOTE: the secret strings below are synthetic placeholders shaped to match the
+ * patterns; no real credentials are present.
+ */
+
+// A synthetic Anthropic-shaped key (50 trailing chars, well over the 40 floor).
+const FAKE_ANT_KEY = 'sk-ant-api03-' + 'A'.repeat(50)
+// A synthetic Discord webhook (token segment over the 20 floor).
+const FAKE_DISCORD = 'https://discord.com/api/webhooks/123456789012345678/' + 'b'.repeat(40)
+// A synthetic JWT (eyJ header + two base64url segments).
+const FAKE_JWT = 'eyJhbGciOiJ' + 'A'.repeat(12) + '.' + 'B'.repeat(12) + '.' + 'C'.repeat(12)
+
+describe('#6029 tool-broadcast value redaction', () => {
+  it('redacts a secret-shaped API key embedded in a benign-keyed value', () => {
+    const out = sanitizeToolInput({ command: `export TOKEN=${FAKE_ANT_KEY}` })
+    assert.ok(!out.command.includes(FAKE_ANT_KEY), 'API key must not leak in command value')
+    assert.ok(out.command.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a Discord webhook URL embedded in a benign-keyed value', () => {
+    const out = sanitizeToolInput({ url: FAKE_DISCORD })
+    assert.ok(!out.url.includes('b'.repeat(40)), 'webhook token must not leak')
+    assert.ok(out.url.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a JWT embedded in a benign-keyed value', () => {
+    const out = sanitizeToolInput({ description: `auth header eyJ token ${FAKE_JWT}` })
+    assert.ok(!out.description.includes(FAKE_JWT), 'JWT must not leak')
+    assert.ok(out.description.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a Bearer token embedded in a benign-keyed value', () => {
+    const out = sanitizeToolInput({ command: 'curl -H "Authorization: Bearer abc123def456ghi789"' })
+    assert.ok(!out.command.includes('abc123def456ghi789'), 'bearer value must not leak')
+    assert.ok(out.command.includes('[REDACTED]'))
+  })
+
+  it('redacts secrets nested in string values across multiple benign keys', () => {
+    const out = sanitizeToolInput({
+      file_path: '/tmp/safe.txt',
+      command: `echo ${FAKE_ANT_KEY}`,
+    })
+    assert.equal(out.file_path, '/tmp/safe.txt', 'benign path unchanged')
+    assert.ok(!out.command.includes(FAKE_ANT_KEY))
+  })
+
+  it('leaves benign values unchanged (no over-redaction)', () => {
+    const input = {
+      command: 'git commit -m "fix: stuff"',
+      file_path: '/Users/x/Projects/chroxy/README.md',
+      pattern: 'export const FOO = 1',
+      count: 42,
+      flag: true,
+    }
+    const out = sanitizeToolInput(input)
+    assert.equal(out.command, input.command)
+    assert.equal(out.file_path, input.file_path)
+    assert.equal(out.pattern, input.pattern)
+    assert.equal(out.count, 42)
+    assert.equal(out.flag, true)
+  })
+
+  it('still redacts wholesale by sensitive KEY NAME (pre-existing behavior)', () => {
+    const out = sanitizeToolInput({ token: 'whatever-value', api_key: 'plain', password: 'hunter2' })
+    assert.equal(out.token, '[REDACTED]')
+    assert.equal(out.api_key, '[REDACTED]')
+    assert.equal(out.password, '[REDACTED]')
+  })
+
+  it('preserves non-object input passthrough', () => {
+    assert.equal(sanitizeToolInput(null), null)
+    assert.equal(sanitizeToolInput('str'), 'str')
+    assert.equal(sanitizeToolInput(7), 7)
+  })
+
+  it('still truncates an oversize whole object (pre-existing summary path)', () => {
+    const big = 'x'.repeat(20_000)
+    const out = sanitizeToolInput({ blob: big })
+    assert.equal(out._truncated, true)
+    assert.ok(out.summary.endsWith('... [truncated]'))
+  })
+
+  it('redacts a secret in an oversize value before the summary truncation', () => {
+    const out = sanitizeToolInput({ blob: 'y'.repeat(11_000) + ' ' + FAKE_ANT_KEY })
+    const serialized = JSON.stringify(out)
+    assert.ok(!serialized.includes(FAKE_ANT_KEY), 'secret must not survive into the truncated summary')
+  })
+})
+
+describe('#6029 shared redactValue helper', () => {
+  it('redacts API keys, webhooks, JWTs, bearer; passes benign text', () => {
+    assert.ok(!redactValue(FAKE_ANT_KEY).includes('A'.repeat(50)))
+    assert.ok(!redactValue(FAKE_DISCORD).includes('b'.repeat(40)))
+    assert.ok(!redactValue(FAKE_JWT).includes(FAKE_JWT))
+    assert.equal(redactValue('hello world, nothing secret here'), 'hello world, nothing secret here')
+  })
+})

--- a/packages/server/tests/tool-broadcast-value-redaction.test.js
+++ b/packages/server/tests/tool-broadcast-value-redaction.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { sanitizeToolInput } from '../src/ws-permissions.js'
+import { sanitizeToolInput, buildPermissionDescription } from '../src/ws-permissions.js'
 import { redactValue } from '../src/redaction.js'
 
 /**
@@ -94,6 +94,73 @@ describe('#6029 tool-broadcast value redaction', () => {
     const out = sanitizeToolInput({ blob: 'y'.repeat(11_000) + ' ' + FAKE_ANT_KEY })
     const serialized = JSON.stringify(out)
     assert.ok(!serialized.includes(FAKE_ANT_KEY), 'secret must not survive into the truncated summary')
+  })
+
+  // #6029 bypass 2: nested objects/arrays must be traversed, not just top-level.
+  it('redacts a secret nested in an object value', () => {
+    const out = sanitizeToolInput({ env: { TOKEN: FAKE_ANT_KEY } })
+    const serialized = JSON.stringify(out)
+    assert.ok(!serialized.includes(FAKE_ANT_KEY), 'nested object secret must not leak')
+    assert.ok(serialized.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a secret nested in an array value', () => {
+    const out = sanitizeToolInput({ args: ['--token', FAKE_ANT_KEY] })
+    const serialized = JSON.stringify(out)
+    assert.ok(!serialized.includes(FAKE_ANT_KEY), 'array secret must not leak')
+    assert.ok(serialized.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a Bearer header nested in an object value', () => {
+    const out = sanitizeToolInput({ headers: { Authorization: 'Bearer abc.def.ghijklmnop' } })
+    const serialized = JSON.stringify(out)
+    assert.ok(!serialized.includes('abc.def.ghijklmnop'), 'nested bearer token must not leak')
+    assert.ok(serialized.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a sensitive KEY NAME nested deep in an object', () => {
+    const out = sanitizeToolInput({ config: { auth: { password: 'hunter2' } } })
+    assert.equal(out.config.auth.password, '[REDACTED]', 'nested sensitive key redacted wholesale')
+  })
+
+  it('leaves benign nested structures unchanged', () => {
+    const input = { env: { NODE_ENV: 'production' }, args: ['build', '--watch'] }
+    const out = sanitizeToolInput(input)
+    assert.deepEqual(out, input)
+  })
+
+  it('guards against pathological depth / cycles without throwing', () => {
+    const cyclic = { a: 1 }
+    cyclic.self = cyclic
+    assert.doesNotThrow(() => sanitizeToolInput(cyclic))
+    const out = sanitizeToolInput(cyclic)
+    // The back-reference is caught and replaced rather than recursing forever.
+    const serialized = JSON.stringify(out)
+    assert.ok(serialized.includes('[REDACTED:cycle]'), 'cycle marker present')
+  })
+})
+
+describe('#6029 broadcast description redaction', () => {
+  it('redacts a secret in a command-derived description', () => {
+    const desc = buildPermissionDescription({ command: `export TOKEN=${FAKE_ANT_KEY}` })
+    assert.ok(!desc.includes(FAKE_ANT_KEY), 'API key must not leak in broadcast description')
+    assert.ok(desc.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a Discord webhook in a url-derived description', () => {
+    const desc = buildPermissionDescription({ url: FAKE_DISCORD })
+    assert.ok(!desc.includes('b'.repeat(40)), 'webhook token must not leak in description')
+    assert.ok(desc.includes('[REDACTED]'), 'should mark the redaction')
+  })
+
+  it('redacts a secret in the JSON.stringify fallback description', () => {
+    // No description/command/file_path/pattern/query — falls back to JSON dump.
+    const desc = buildPermissionDescription({ payload: `key ${FAKE_ANT_KEY}` })
+    assert.ok(!desc.includes(FAKE_ANT_KEY), 'fallback JSON dump must not leak the secret')
+  })
+
+  it('passes a benign description through unchanged', () => {
+    assert.equal(buildPermissionDescription({ command: 'ls -la' }), 'ls -la')
   })
 })
 


### PR DESCRIPTION
## Security

**Class:** credential leak (secret-in-value broadcast to clients).

### The leak
`sanitizeToolInput` (`packages/server/src/ws-permissions.js`), the only sanitizer on the tool-broadcast path (called at the permission-request handler before broadcast), redacted by **key name only** (`SENSITIVE_KEYS`). It never ran string **values** through any value-shape pattern. A secret placed in a value under a benign key was broadcast verbatim to every subscribed client, e.g.:

- `{ "command": "export TOKEN=sk-ant-api03-…" }`
- `{ "url": "https://discord.com/api/webhooks/123/…" }`
- a JWT / `Bearer …` token inside any field

The value-shape patterns already existed — but only in `logger.js`. Three redaction lists drifted independently.

### The fix
1. New `packages/server/src/redaction.js` — single source of truth for the value-shape patterns (`SENSITIVE_PATTERNS` + `API_KEY_PATTERNS`: `sk-ant-`/`sk-proj-`/`sk-`, `AIza`, JWT `eyJ…`, Discord webhooks, `Bearer`/`key=value`), the sensitive **key-name** set, and a `redactValue()` helper hoisted verbatim from the logger.
2. `sanitizeToolInput` now adds a **value-shape pass**: every remaining string value runs through `redactValue` (regardless of key name) **before** the size truncation, so a redacted secret can never survive into the broadcast. The pre-existing key-name redaction and oversize-summary path are untouched (additive only — benign values pass through unchanged).
3. `logger.js` consumes the same module: `redactSensitive` delegates to `redactValue` (same body, hoisted) and `redactSensitivePreservingEscapes` imports the shared pattern constants. **Logger behavior is preserved exactly** — it was a clean, behavior-preserving swap (verified by the existing logger + error-sanitization suites passing unchanged).

`config.js`'s narrow `SENSITIVE_KEYS = ['apiToken']` is a separate config-masking concern and was intentionally left alone.

### Test evidence
New `tests/tool-broadcast-value-redaction.test.js` — written RED first:
- leak repros: API key / Discord webhook / JWT / Bearer token embedded under benign keys (`command`, `url`, `description`) → assert the secret is gone and `[REDACTED]` is present
- secret in an **oversize** value is redacted before the summary truncation (verifies redact-before-truncate order)
- benign values (commands, paths, code, numbers, booleans) pass through unchanged (no over-redaction)
- existing key-name redaction, non-object passthrough, and oversize-summary path still hold

RED → GREEN: 6 leak subtests failed before the fix, all 11 pass after. Broader suites green:
- `tool-broadcast-value-redaction` 11/11
- `logger` + `ws-error-sanitization` + `logger-json-mode` + `logger-usage` 222/222
- `ws-permissions` + binding-integration + `permission-hook-sanitization` 153/153
- `claude-tui-session` 291/291

### Files changed
- `packages/server/src/redaction.js` (new)
- `packages/server/src/ws-permissions.js`
- `packages/server/src/logger.js`
- `packages/server/tests/tool-broadcast-value-redaction.test.js` (new)

Closes #6029