### PR TITLE
ci: run Desktop Rust Tests on the self-hosted macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,7 +619,13 @@ jobs:
 
   desktop-tests:
     name: Desktop Rust Tests
-    runs-on: macos-latest
+    # Runs on the self-hosted macOS runner (Apple Silicon) to avoid GitHub-hosted
+    # macOS minutes (billed at 10x ubuntu). SECURITY: this repo is public, so the
+    # job is gated to same-repo events only — fork PRs must NOT execute on the
+    # self-hosted host. A fork PR touching desktop code simply skips this job
+    # (maintainer can validate it locally / on a hosted re-run if needed).
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 15
     defaults:
       run:


### PR DESCRIPTION
## Why
GitHub-hosted **macOS** minutes are billed at **10×** ubuntu — the single biggest per-minute CI cost. The "Desktop Rust Tests" job is a native Tauri/Rust build, so it's the natural fit for the newly-registered self-hosted Apple Silicon runner (`self-hosted,macOS,ARM64,chroxy-mac`).

## Change
- `desktop-tests` job: `runs-on: macos-latest` → `runs-on: [self-hosted, macOS, ARM64]`.
- **Security gate (`if:`)**: this repo is public, so the job runs only on `push` or **same-repo** PRs — fork PRs never execute on the self-hosted host. A fork PR touching desktop code skips this job (validate locally / hosted re-run if needed).

## Scope / not-in-this-PR
- ubuntu server jobs **stay hosted** — running them on the Mac would spam the real login keychain with modals and collide with the local `:8765` daemon. Full off-hosted migration needs a Linux self-hosted runner or Docker (separate decision).
- Windows platform job stays hosted (conditional/rare; can't run on macOS).
- Caveat: this job now only runs while the self-hosted Mac is awake/online.

This PR's own CI will run the job on the self-hosted runner (same-repo PR) — a live end-to-end validation.