### PR TITLE
test(server): tear down leaked handles so the suite exits without --test-force-exit (#6027)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "start": "node src/cli.js start",
     "dev": "node --watch src/cli.js start",
-    "test": "node ./scripts/assert-test-count.mjs c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
-    "test:raw": "c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
-    "test:coverage": "c8 --reporter=text --reporter=html node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
+    "test": "node ./scripts/assert-test-count.mjs c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
+    "test:raw": "c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
+    "test:coverage": "c8 --reporter=text --reporter=html node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
     "test:integration": "node --import ./tests/_setup.mjs --test ./tests/*.integration.test.js",
     "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
     "lint": "eslint src/",

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -505,6 +505,13 @@ export class PermissionManager extends EventEmitter {
     this._pendingPermissions.clear()
     this._lastPermissionData.clear()
 
+    // #6027: belt-and-braces — the loop above only clears timers for entries
+    // still in _pendingPermissions. A permission timer whose requestId has
+    // already left that map would otherwise survive destroy() and keep the
+    // suite alive without --test-force-exit. Drop any stragglers.
+    for (const timer of this._permissionTimers.values()) clearTimeout(timer)
+    this._permissionTimers.clear()
+
     // Auto-deny pending user answer
     this._clearQuestionTimer()
     if (this._pendingUserAnswer) {

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -73,6 +73,10 @@ export class Supervisor extends EventEmitter {
     this._restartScheduledAt = null
     this._restartDelayMs = null
     this._restartTimer = null
+    // #6027: deploy-window reset timer. Instance-scoped (was a startChild-local
+    // closure var) so shutdown()/teardown can clear it — otherwise a child that
+    // goes ready but never exits leaves a ~DEPLOY_CRASH_WINDOW timer pending.
+    this._deployResetTimer = null
     this._log = createLogger('supervisor')
 
     // Deploy rollback tracking
@@ -426,7 +430,6 @@ export class Supervisor extends EventEmitter {
       })
     }
 
-    let deployResetTimer = null
     this._child.on('message', (msg) => {
       if (msg.type === 'ready') {
         this._log.info('Server child is ready')
@@ -442,7 +445,8 @@ export class Supervisor extends EventEmitter {
         if (this._lastDeployTimestamp > 0 && this._deployFailureCount > 0) {
           const remaining = DEPLOY_CRASH_WINDOW - (Date.now() - this._lastDeployTimestamp)
           if (remaining > 0) {
-            deployResetTimer = setTimeout(() => {
+            this._deployResetTimer = setTimeout(() => {
+              this._deployResetTimer = null
               this._deployFailureCount = 0
               this._log.info('Deploy crash window passed, resetting failure count')
             }, remaining)
@@ -466,7 +470,7 @@ export class Supervisor extends EventEmitter {
       void (async () => {
         stdoutRl?.close()
         stderrRl?.close()
-        if (deployResetTimer) { clearTimeout(deployResetTimer); deployResetTimer = null }
+        if (this._deployResetTimer) { clearTimeout(this._deployResetTimer); this._deployResetTimer = null }
         const childUptimeMs = this._metrics.childStartedAt ? Date.now() - this._metrics.childStartedAt : 0
         this._child = null
         this._childReady = false
@@ -768,6 +772,7 @@ export class Supervisor extends EventEmitter {
     this._shuttingDown = true
     if (this._heartbeatInterval) clearInterval(this._heartbeatInterval)
     if (this._restartTimer) clearTimeout(this._restartTimer)
+    if (this._deployResetTimer) { clearTimeout(this._deployResetTimer); this._deployResetTimer = null }
     this._log.info(`${signal} received, shutting down...`)
 
     // Remove PID file

--- a/packages/server/tests/cli-session-pending-queue.test.js
+++ b/packages/server/tests/cli-session-pending-queue.test.js
@@ -17,6 +17,9 @@ import { CliSession } from '../src/cli-session.js'
 const _createdSessions = []
 afterEach(() => {
   for (const s of _createdSessions) {
+    // Null the mock child first: destroy() otherwise arms a 3s forceKillTimer
+    // cleared only by a real child's 'close' event, which the mock never emits.
+    s._child = null
     try { const r = s.destroy(); if (r && typeof r.catch === 'function') r.catch(() => {}) } catch {}
   }
   _createdSessions.length = 0

--- a/packages/server/tests/cli-session-pending-queue.test.js
+++ b/packages/server/tests/cli-session-pending-queue.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test'
+import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { Writable, Readable } from 'node:stream'
@@ -11,8 +11,21 @@ import { CliSession } from '../src/cli-session.js'
  * the queue is drained in order when the process becomes ready.
  */
 
+// #6027: destroy() every constructed session after each test so the
+// sendMessage-armed _hardTimeout/_streamStallTimeout don't outlive the suite
+// (keeping it alive without --test-force-exit). destroy() is idempotent.
+const _createdSessions = []
+afterEach(() => {
+  for (const s of _createdSessions) {
+    try { const r = s.destroy(); if (r && typeof r.catch === 'function') r.catch(() => {}) } catch {}
+  }
+  _createdSessions.length = 0
+})
+
 function createSession(opts = {}) {
-  return new CliSession({ cwd: '/tmp', ...opts })
+  const session = new CliSession({ cwd: '/tmp', ...opts })
+  _createdSessions.push(session)
+  return session
 }
 
 function createMockChild() {

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -48,6 +48,10 @@ after(() => {
 const _createdSessions = []
 afterEach(() => {
   for (const s of _createdSessions) {
+    // Null the mock child first: destroy() otherwise arms a 3s forceKillTimer
+    // cleared only by a real child's 'close' event, which the mock never emits
+    // — a (self-clearing, non-hanging) timer we'd rather not add in a teardown.
+    s._child = null
     try { const r = s.destroy(); if (r && typeof r.catch === 'function') r.catch(() => {}) } catch {}
   }
   _createdSessions.length = 0

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -40,6 +40,19 @@ after(() => {
   if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
 })
 
+// #6027: sendMessage arms _resultTimeout/_hardTimeout/_streamStallTimeout, but
+// most tests clear only _resultTimeout (or none), leaking _hardTimeout/
+// _streamStallTimeout and keeping the suite alive without --test-force-exit.
+// Track every constructed session and destroy() it after each test — destroy()
+// clears all of them and is idempotent (tests already call it twice safely).
+const _createdSessions = []
+afterEach(() => {
+  for (const s of _createdSessions) {
+    try { const r = s.destroy(); if (r && typeof r.catch === 'function') r.catch(() => {}) } catch {}
+  }
+  _createdSessions.length = 0
+})
+
 function createSession(opts = {}) {
   const stateFilePath = opts.stateFilePath || tmpStateFile()
   // CliSession ignores unknown keys via destructuring today, so passing
@@ -50,6 +63,7 @@ function createSession(opts = {}) {
   // instance so individual tests can assert on it.
   const session = new CliSession({ cwd: '/tmp', stateFilePath, ...opts })
   session._testStateFilePath = stateFilePath
+  _createdSessions.push(session)
   return session
 }
 

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -172,6 +172,9 @@ describe('Supervisor', () => {
     for (const s of supervisors) {
       s._shuttingDown = true
       if (s._heartbeatInterval) clearInterval(s._heartbeatInterval)
+      // #6027: a child that went ready (deploy window) but never exited leaves
+      // _deployResetTimer pending; the exit handler that would clear it never ran.
+      if (s._deployResetTimer) { clearTimeout(s._deployResetTimer); s._deployResetTimer = null }
       s._stopStandbyServer()
     }
     supervisors = []

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -281,7 +281,7 @@ describe('CloudflareTunnelAdapter', () => {
       await tunnel.stop()
     })
 
-    it('stops after maxRecoveryAttempts failures', async () => {
+    it('stops after maxRecoveryAttempts failures', async (t) => {
       let spawnCount = 0
       const mockSpawn = () => {
         spawnCount++
@@ -297,6 +297,11 @@ describe('CloudflareTunnelAdapter', () => {
       }
 
       const tunnel = new TestCloudflareAdapter({ port: 3000, mockSpawn })
+      // #6027: recovery is an unbounded long-tail loop — after the first round
+      // emits tunnel_failed it keeps retrying in the background. stop() aborts
+      // it; register via t.after so it runs even if an assertion below throws
+      // (otherwise the leaked backoff would hang the suite w/o force-exit).
+      t.after(() => tunnel.stop())
       tunnel.recoveryBackoffs = [10, 20, 30]
 
       await tunnel.start()
@@ -308,10 +313,6 @@ describe('CloudflareTunnelAdapter', () => {
       const failedEvent = await failedPromise
       assert.ok(failedEvent.message.includes('3 attempts'))
       assert.equal(spawnCount, 4)
-      // #6027: recovery is an unbounded long-tail loop — after the first round
-      // emits tunnel_failed it keeps retrying in the background. Stop it so the
-      // backoff sleep doesn't outlive the test (hangs the suite w/o force-exit).
-      await tunnel.stop()
     })
   })
 
@@ -419,38 +420,39 @@ describe('CloudflareTunnelAdapter', () => {
       await tunnel.stop()
     })
 
-    it('rejects when tunnelName is missing', async () => {
+    it('rejects when tunnelName is missing', async (t) => {
       const tunnel = new TestCloudflareAdapter({
         port: 3000,
         mockSpawn: () => createNamedMockProcess(),
         mode: 'named',
         config: { tunnelHostname: 'chroxy.example.com' },
       })
+      // #6027: a failed named-tunnel start leaves the retry/recovery loop
+      // scheduling backoff sleeps in the background. stop() aborts it; via
+      // t.after so it runs even if the assertion below throws (otherwise the
+      // leaked timer keeps the suite alive without --test-force-exit).
+      t.after(() => tunnel.stop())
 
       await assert.rejects(
         async () => await tunnel.start(),
         /tunnelName/
       )
-      // #6027: a failed named-tunnel start leaves the retry/recovery loop
-      // scheduling backoff sleeps in the background. Stop it so the timer
-      // doesn't outlive the test (keeps the suite alive without force-exit).
-      await tunnel.stop()
     })
 
-    it('rejects when tunnelHostname is missing', async () => {
+    it('rejects when tunnelHostname is missing', async (t) => {
       const tunnel = new TestCloudflareAdapter({
         port: 3000,
         mockSpawn: () => createNamedMockProcess(),
         mode: 'named',
         config: { tunnelName: 'chroxy' },
       })
+      // #6027: stop the background retry/recovery loop (see tunnelName test).
+      t.after(() => tunnel.stop())
 
       await assert.rejects(
         async () => await tunnel.start(),
         /tunnelHostname/
       )
-      // #6027: stop the background retry/recovery loop (see tunnelName test).
-      await tunnel.stop()
     })
 
     it('hasStableUrl returns true for named mode', () => {

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -427,6 +427,10 @@ describe('CloudflareTunnelAdapter', () => {
         async () => await tunnel.start(),
         /tunnelName/
       )
+      // #6027: a failed named-tunnel start leaves the retry/recovery loop
+      // scheduling backoff sleeps in the background. Stop it so the timer
+      // doesn't outlive the test (keeps the suite alive without force-exit).
+      await tunnel.stop()
     })
 
     it('rejects when tunnelHostname is missing', async () => {
@@ -441,6 +445,8 @@ describe('CloudflareTunnelAdapter', () => {
         async () => await tunnel.start(),
         /tunnelHostname/
       )
+      // #6027: stop the background retry/recovery loop (see tunnelName test).
+      await tunnel.stop()
     })
 
     it('hasStableUrl returns true for named mode', () => {

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -308,6 +308,10 @@ describe('CloudflareTunnelAdapter', () => {
       const failedEvent = await failedPromise
       assert.ok(failedEvent.message.includes('3 attempts'))
       assert.equal(spawnCount, 4)
+      // #6027: recovery is an unbounded long-tail loop — after the first round
+      // emits tunnel_failed it keeps retrying in the background. Stop it so the
+      // backoff sleep doesn't outlive the test (hangs the suite w/o force-exit).
+      await tunnel.stop()
     })
   })
 

--- a/packages/server/tests/ws-server-error-handlers.test.js
+++ b/packages/server/tests/ws-server-error-handlers.test.js
@@ -1,15 +1,23 @@
-import { describe, it, after, mock } from 'node:test'
+import { describe, it, afterEach, after, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { createMockSessionManager } from './test-helpers.js'
 
 describe('WsServer error handlers (#2195)', { timeout: 10000 }, () => {
   let wsServer
 
-  after(async () => {
-    mock.restoreAll()
+  // #6027: each test creates and reassigns `wsServer`, so an `after` that
+  // closes only the last one leaks the earlier listening socket + its
+  // keepalive/auth-cleanup intervals — keeping the suite alive without
+  // --test-force-exit. Close after every test instead.
+  afterEach(() => {
     if (wsServer) {
       try { wsServer.close() } catch {}
+      wsServer = null
     }
+  })
+
+  after(() => {
+    mock.restoreAll()
   })
 
   it('attaches an error handler to the WebSocketServer instance', async () => {


### PR DESCRIPTION
## Summary

Root-cause fix for #6027 (the `--test-force-exit` truncation behind #5480). The server suite needed `--test-force-exit` because leaked timers/handles kept the event loop alive after tests finished — and the flag races the TAP summary flush, truncating the count non-deterministically. This tears down the actual leaks and **drops the flag**.

## How the leaks were found

Reproduced in a **Linux Docker container** (CI's non-TTY condition, and no macOS login keychain → no modal spam, the reason the suite can't be run on the dev Mac). Per-file timeout bisect → 8 candidate files; a `setTimeout`/`setInterval` monkeypatch hook printed the source creation site of every still-pending, ref-keeping timer.

**5 files had true leaks** (a constructed object whose timer was never torn down). The other 3 flagged files (`byok-mcp-client`, `claude-tui-session`, `byok-session`) turned out to be **slow, not leaking** — they exit cleanly on their own in 65–73s (real backoff/respawn/DEAD delays), they just exceeded the bisect timeout. They are unchanged.

## Fixes (teardown only — no production behavior change)

| File | Leak | Fix |
|---|---|---|
| `ws-server-error-handlers.test.js` | listening socket + keepalive/auth intervals | reassigns `wsServer` per test; `after()` closed only the last → close after **each** test |
| `supervisor.js` + test | deploy-window reset timer | was a `startChild`-local closure var → promoted to `this._deployResetTimer` so `shutdown()` and the test `afterEach` can clear it |
| `cli-session.test.js` / `cli-session-pending-queue.test.js` | `_hardTimeout` / `_streamStallTimeout` | `sendMessage` arms three timers but tests cleared only `_resultTimeout` → track every constructed session and `destroy()` it in `afterEach` (idempotent) |
| `permission-manager.js` (`clearAll`) | straggler `_permissionTimers` | the loop only cleared timers tied to a still-pending entry → also drop any straggler |
| `tunnel/cloudflare.test.js` | unbounded long-tail recovery + named-config start-retry | `sleep()` is abortable via `stop()` → call `stop()` after the recovery/rejection tests |

Then `package.json`: removed `--test-force-exit` from `test` / `test:raw` / `test:coverage`. The #5480 `assert-test-count` guard stays (defense-in-depth, acceptance criterion); the 10-min CI job timeout backstops any future leak as a loud failure.

## Validation (in the Linux container)

- Full suite **without** `--test-force-exit`: **4 runs, all exit in ~73s, 0 cancelled**, stable **10050**-test count (was: hangs past 9 min).
- The 2 failing tests in the container (`permission-hook-posttooluse-cleanup`) fail on **pristine `main` too** — container-env gaps, not caused by this change (real CI is green on those).
- All server custom lints pass; eslint clean.

Closes #6027.
Unblocks #6037 (its security fix was blocked only by this CI truncation).