### PR TITLE
fix(server): redact tool input on the SDK permission broadcast path (#6038)

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -188,12 +188,18 @@ export class PermissionManager extends EventEmitter {
       })
 
       const toolInput = input || {}
-      const description = toolInput.description
+      const rawDescription = toolInput.description
         || toolInput.command
         || toolInput.file_path
         || toolInput.pattern
         || toolInput.query
-        || (Object.keys(toolInput).length > 0 ? JSON.stringify(toolInput).slice(0, 200) : toolName)
+        || (Object.keys(toolInput).length > 0 ? JSON.stringify(toolInput) : toolName)
+      // #6038/#6048/#6049: build the broadcast description by REDACTING the full
+      // string first, THEN truncating — truncating first (the old order) could
+      // leave a secret straddling the cap as a sub-floor partial prefix that the
+      // pattern scan misses. String() coerces a non-string field so a malformed
+      // tool input can't crash the emit path (.replace on a non-string throws).
+      const description = redactValue(String(rawDescription)).slice(0, 200)
 
       this._logInfo(`Permission request ${requestId}: ${toolName}`)
 
@@ -204,7 +210,7 @@ export class PermissionManager extends EventEmitter {
       const permPayload = {
         requestId,
         tool: toolName,
-        description: redactValue(description),
+        description,
         input: sanitizeToolInput(toolInput),
         remainingMs: this._timeoutMs,
         createdAt: Date.now(),
@@ -598,7 +604,7 @@ export class PermissionManager extends EventEmitter {
       const permPayload = {
         requestId,
         tool: 'mcp_spawn',
-        description: redactValue(description),
+        description: redactValue(String(description)).slice(0, 200),
         input: sanitizeToolInput(input),
         remainingMs: this._timeoutMs,
         createdAt: Date.now(),

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -1,6 +1,10 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
 import { createLogger } from './logger.js'
+// #6038: the SDK/TUI permission path broadcasts to clients too, so it must apply
+// the same redaction as the hook path. Shared sanitizer + value redactor live in
+// redaction.js (a leaf module — no import cycle / HTTP-handler weight).
+import { sanitizeToolInput, redactValue } from './redaction.js'
 
 const _fallbackLog = createLogger('permission-manager')
 
@@ -193,11 +197,15 @@ export class PermissionManager extends EventEmitter {
 
       this._logInfo(`Permission request ${requestId}: ${toolName}`)
 
+      // #6038: redact before broadcast. The raw input/description are kept for
+      // execution via the _pendingPermissions entry above; this payload is
+      // broadcast/display only, so a secret in a value (or the stringified
+      // fallback description) must not reach subscribed clients.
       const permPayload = {
         requestId,
         tool: toolName,
-        description,
-        input: toolInput,
+        description: redactValue(description),
+        input: sanitizeToolInput(toolInput),
         remainingMs: this._timeoutMs,
         createdAt: Date.now(),
       }
@@ -584,11 +592,14 @@ export class PermissionManager extends EventEmitter {
 
       this._logInfo(`MCP trust request ${requestId}: ${server.name}`)
 
+      // #6038: redact before broadcast (description embeds server.command/argv0;
+      // input carries args/envKeys). Raw values for execution live on the
+      // _pendingPermissions entry above.
       const permPayload = {
         requestId,
         tool: 'mcp_spawn',
-        description,
-        input,
+        description: redactValue(description),
+        input: sanitizeToolInput(input),
         remainingMs: this._timeoutMs,
         createdAt: Date.now(),
       }

--- a/packages/server/src/redaction.js
+++ b/packages/server/src/redaction.js
@@ -99,4 +99,87 @@ export function redactValue(msg) {
   return result
 }
 
-export { SENSITIVE_PATTERNS, API_KEY_PATTERNS, SENSITIVE_KEY_NAMES }
+// -- Broadcast safety (#6029) --
+// Relocated here (#6038) from ws-permissions.js so both broadcast paths — the
+// hook path (ws-permissions.js) AND the SDK/TUI provider path
+// (permission-manager.js) — share one sanitizer. This is a leaf module, so
+// permission-manager.js can import it without pulling in the HTTP-handler stack
+// or risking an import cycle.
+const MAX_INPUT_CHARS = 10_240 // ~10K chars max for broadcast (JS string length, not bytes)
+
+// Cap recursion so a pathologically deep or cyclic tool_input can't blow the
+// stack. Real tool inputs are shallow; anything past this is summarized away.
+const MAX_SANITIZE_DEPTH = 8
+
+/**
+ * Recursively redact a single tool_input value of any shape (#6029). Applies the
+ * KEY-NAME pass to object keys and the VALUE-SHAPE pass (`redactValue`) to every
+ * string at any depth, so a secret nested inside an object or array — e.g.
+ * `{ env: { TOKEN: 'sk-ant-…' } }`, `{ args: ['--token', 'sk-ant-…'] }`, or
+ * `{ headers: { Authorization: 'Bearer …' } }` — can't slip past the top-level
+ * scan. `seen` guards against cycles; `depth` caps pathological nesting.
+ *
+ * @param {*} value
+ * @param {number} depth
+ * @param {WeakSet} seen
+ * @returns {*}
+ */
+function redactDeep(value, depth, seen) {
+  if (typeof value === 'string') {
+    const redacted = redactValue(value)
+    return redacted.length > MAX_INPUT_CHARS
+      ? redacted.slice(0, MAX_INPUT_CHARS) + '... [truncated]'
+      : redacted
+  }
+  if (!value || typeof value !== 'object') return value
+  if (depth >= MAX_SANITIZE_DEPTH) return '[REDACTED:depth]'
+  if (seen.has(value)) return '[REDACTED:cycle]'
+  seen.add(value)
+  let out
+  if (Array.isArray(value)) {
+    out = value.map((item) => redactDeep(item, depth + 1, seen))
+  } else {
+    out = {}
+    for (const [key, child] of Object.entries(value)) {
+      out[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
+        ? '[REDACTED]'
+        : redactDeep(child, depth + 1, seen)
+    }
+  }
+  seen.delete(value)
+  return out
+}
+
+/**
+ * Sanitize tool input for broadcast: redact sensitive fields and truncate large
+ * values. Two passes (#6029): a KEY-NAME pass redacts values under sensitive
+ * keys wholesale, and a VALUE-SHAPE pass runs every string value (at ANY depth)
+ * through `redactValue` so a secret embedded under a benign key — e.g.
+ * `{ command: 'export TOKEN=sk-ant-…' }`, `{ url: 'https://discord.com/api/webhooks/…' }`,
+ * or nested in `{ env: { TOKEN: 'sk-ant-…' } }` / `{ args: ['--token', 'sk-ant-…'] }`
+ * — is redacted before it reaches any client. Both passes recurse through nested
+ * objects and arrays.
+ *
+ * @param {object} input
+ * @returns {object}
+ */
+function sanitizeToolInput(input) {
+  if (!input || typeof input !== 'object') return input
+
+  const seen = new WeakSet()
+  const result = {}
+  for (const [key, value] of Object.entries(input)) {
+    result[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
+      ? '[REDACTED]'
+      : redactDeep(value, 1, seen)
+  }
+
+  // Final size check on the whole object
+  const serialized = JSON.stringify(result)
+  if (serialized.length > MAX_INPUT_CHARS) {
+    return { _truncated: true, summary: serialized.slice(0, MAX_INPUT_CHARS) + '... [truncated]' }
+  }
+  return result
+}
+
+export { SENSITIVE_PATTERNS, API_KEY_PATTERNS, SENSITIVE_KEY_NAMES, sanitizeToolInput }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -5,7 +5,7 @@ import { buildSessionTokenMismatchPayload } from './handler-utils.js'
 import { settlePush } from './push.js'
 import { createPermissionResolver } from './permission-resolver.js'
 import { sendOversizeResponse } from './http-oversize.js'
-import { SENSITIVE_KEY_NAMES, redactValue } from './redaction.js'
+import { redactValue, sanitizeToolInput } from './redaction.js'
 
 const log = createLogger('ws')
 
@@ -13,80 +13,10 @@ const log = createLogger('ws')
 const PERMISSION_TTL_MS = 300_000 // 5 minutes
 
 // -- Broadcast safety --
-const MAX_INPUT_CHARS = 10_240 // ~10K chars max for broadcast (JS string length, not bytes)
-
-// Cap recursion so a pathologically deep or cyclic tool_input can't blow the
-// stack. Real tool inputs are shallow; anything past this is summarized away.
-const MAX_SANITIZE_DEPTH = 8
-
-/**
- * Recursively redact a single tool_input value of any shape (#6029). Applies the
- * KEY-NAME pass to object keys and the VALUE-SHAPE pass (`redactValue`) to every
- * string at any depth, so a secret nested inside an object or array — e.g.
- * `{ env: { TOKEN: 'sk-ant-…' } }`, `{ args: ['--token', 'sk-ant-…'] }`, or
- * `{ headers: { Authorization: 'Bearer …' } }` — can't slip past the top-level
- * scan. `seen` guards against cycles; `depth` caps pathological nesting.
- *
- * @param {*} value
- * @param {number} depth
- * @param {WeakSet} seen
- * @returns {*}
- */
-function redactDeep(value, depth, seen) {
-  if (typeof value === 'string') {
-    const redacted = redactValue(value)
-    return redacted.length > MAX_INPUT_CHARS
-      ? redacted.slice(0, MAX_INPUT_CHARS) + '... [truncated]'
-      : redacted
-  }
-  if (!value || typeof value !== 'object') return value
-  if (depth >= MAX_SANITIZE_DEPTH) return '[REDACTED:depth]'
-  if (seen.has(value)) return '[REDACTED:cycle]'
-  seen.add(value)
-  let out
-  if (Array.isArray(value)) {
-    out = value.map((item) => redactDeep(item, depth + 1, seen))
-  } else {
-    out = {}
-    for (const [key, child] of Object.entries(value)) {
-      out[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
-        ? '[REDACTED]'
-        : redactDeep(child, depth + 1, seen)
-    }
-  }
-  seen.delete(value)
-  return out
-}
-
-/**
- * Sanitize tool input for broadcast: redact sensitive fields and truncate large
- * values. Two passes (#6029): a KEY-NAME pass redacts values under sensitive
- * keys wholesale, and a VALUE-SHAPE pass runs every string value (at ANY depth)
- * through `redactValue` so a secret embedded under a benign key — e.g.
- * `{ command: 'export TOKEN=sk-ant-…' }`, `{ url: 'https://discord.com/api/webhooks/…' }`,
- * or nested in `{ env: { TOKEN: 'sk-ant-…' } }` / `{ args: ['--token', 'sk-ant-…'] }`
- * — is redacted before it reaches any client. Both passes recurse through nested
- * objects and arrays. Value patterns are shared with the logger via redaction.js
- * (single source of truth).
- */
-function sanitizeToolInput(input) {
-  if (!input || typeof input !== 'object') return input
-
-  const seen = new WeakSet()
-  const result = {}
-  for (const [key, value] of Object.entries(input)) {
-    result[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
-      ? '[REDACTED]'
-      : redactDeep(value, 1, seen)
-  }
-
-  // Final size check on the whole object
-  const serialized = JSON.stringify(result)
-  if (serialized.length > MAX_INPUT_CHARS) {
-    return { _truncated: true, summary: serialized.slice(0, MAX_INPUT_CHARS) + '... [truncated]' }
-  }
-  return result
-}
+// `sanitizeToolInput` (key-name + recursive value-shape redaction) lives in
+// redaction.js (#6038) so the SDK/TUI provider path (permission-manager.js)
+// shares the exact same sanitizer as this hook path. Imported above and
+// re-exported below for back-compat with existing importers/tests.
 
 /**
  * Build the human-readable `description` broadcast alongside a permission

--- a/packages/server/tests/permission-broadcast-redaction.test.js
+++ b/packages/server/tests/permission-broadcast-redaction.test.js
@@ -68,4 +68,34 @@ describe('#6038 SDK permission broadcast redaction', () => {
     pm.destroy()
     void requestId
   })
+
+  it('redacts a secret in the stringified fallback even when it straddles the truncation cap (#6048)', () => {
+    const pm = new PermissionManager({ log: silentLog })
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    // No description/command/etc. field → description falls back to
+    // JSON.stringify(toolInput). Pad so the secret value sits across the
+    // 200-char cap; redaction must run on the FULL string before truncation.
+    pm.handlePermission('Tool', { padding: 'p'.repeat(180), blob: FAKE_ANT_KEY }, null, 'approve')
+
+    const ev = events[0]
+    assert.ok(ev, 'permission_request should be emitted')
+    assert.ok(!ev.description.includes('sk-ant'), 'no partial secret prefix may survive in the description')
+
+    pm.destroy()
+  })
+
+  it('does not crash when a description-source field is non-string (#6049)', () => {
+    const pm = new PermissionManager({ log: silentLog })
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    assert.doesNotThrow(() => {
+      pm.handlePermission('Tool', { command: { nested: 'obj' } }, null, 'approve')
+    })
+    assert.ok(events[0], 'permission_request should still be emitted')
+
+    pm.destroy()
+  })
 })

--- a/packages/server/tests/permission-broadcast-redaction.test.js
+++ b/packages/server/tests/permission-broadcast-redaction.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PermissionManager } from '../src/permission-manager.js'
+
+/**
+ * #6038 — the SDK/TUI provider permission path (permission-manager.js) builds the
+ * broadcast `permission_request` payload with `input` and `description` derived
+ * from the RAW tool input, then emits it to every subscribed client. That is the
+ * same credential-leak class #6029/#6037 fixed on the hook path. These tests pin
+ * that the broadcast payload is redacted (key-name + value-shape, at any depth)
+ * before it is emitted, while the raw input is still available for execution.
+ *
+ * NOTE: the secret strings below are synthetic placeholders shaped to match the
+ * detection patterns; no real credentials are present.
+ */
+
+const silentLog = { info() {}, warn() {}, error() {}, debug() {} }
+const FAKE_ANT_KEY = 'sk-ant-api03-' + 'A'.repeat(50)
+
+describe('#6038 SDK permission broadcast redaction', () => {
+  it('redacts a secret-shaped value under a benign key before broadcast', () => {
+    const pm = new PermissionManager({ log: silentLog })
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    pm.handlePermission('Bash', { command: `export TOKEN=${FAKE_ANT_KEY}` }, null, 'approve')
+
+    const ev = events[0]
+    assert.ok(ev, 'permission_request should be emitted')
+    assert.ok(!JSON.stringify(ev.input).includes(FAKE_ANT_KEY), 'secret must not leak in broadcast input')
+    assert.ok(!ev.description.includes(FAKE_ANT_KEY), 'secret must not leak in the description fallback')
+    assert.ok(ev.input.command.includes('[REDACTED]'), 'redaction marker should be present')
+
+    pm.destroy()
+  })
+
+  it('redacts a secret nested inside an object value', () => {
+    const pm = new PermissionManager({ log: silentLog })
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    pm.handlePermission('mcp_tool', { env: { TOKEN: FAKE_ANT_KEY } }, null, 'approve')
+
+    const ev = events[0]
+    assert.ok(ev, 'permission_request should be emitted')
+    assert.ok(!JSON.stringify(ev.input).includes(FAKE_ANT_KEY), 'nested secret must not leak in broadcast input')
+
+    pm.destroy()
+  })
+
+  it('leaves the raw input intact for execution (only the broadcast copy is redacted)', () => {
+    const pm = new PermissionManager({ log: silentLog })
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const requestId = events.length
+    pm.handlePermission('Bash', { command: `export TOKEN=${FAKE_ANT_KEY}` }, null, 'approve')
+    const ev = events[0]
+
+    // The pending entry (used to resolve/execute) keeps the raw value.
+    const pending = pm._pendingPermissions.get(ev.requestId)
+    assert.ok(pending, 'pending entry should exist')
+    assert.ok(
+      JSON.stringify(pending.input).includes(FAKE_ANT_KEY),
+      'the execution-path input must remain raw (redaction is broadcast-only)',
+    )
+
+    pm.destroy()
+    void requestId
+  })
+})


### PR DESCRIPTION
## Summary

Closes #6038. The hook permission path was sanitized in #6029/#6037, but the **SDK/TUI provider path** (`permission-manager.js` — the **default** provider) broadcast `permission_request` with `input` verbatim and a `description` built from raw `JSON.stringify(toolInput)`. `session-manager` forwards `permission_request` to every subscribed client, so a secret in a tool-input value leaked on the most commonly-exercised path — the same class #6029 fixed.

## Changes

- **Relocate** `sanitizeToolInput` + `redactDeep` (+ depth/size constants) from `ws-permissions.js` → `redaction.js` (the leaf single-source-of-truth). This lets `permission-manager.js` import the sanitizer without pulling in the HTTP-handler stack or risking an import cycle. `ws-permissions.js` imports and **re-exports** `sanitizeToolInput` for back-compat (existing importers/tests unchanged).
- **`permission-manager.js`** — both `permPayload` sites (tool permission + MCP spawn) now broadcast `description: redactValue(...)` and `input: sanitizeToolInput(...)`. The **raw** input for execution stays on the `_pendingPermissions` entry, untouched — only the broadcast/display copy is redacted.
- **Test** `permission-broadcast-redaction.test.js`: secret-in-value redacted, secret-nested-in-object redacted, and raw execution input preserved.

## Validation (Linux container)
- New test 3/3, existing `tool-broadcast-value-redaction` 21/21 (re-export works), `permission-manager` 83/83.
- eslint + server custom lints clean.

## Related
- #6039 was already addressed by #6037 (closed) — `sanitizeToolInput` already recurses.