### PR TITLE
fix(server): unref() the destroy/respawn/shutdown force-kill timers (#6043)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -1471,6 +1471,12 @@ export class CliSession extends BaseSession {
           respawn()
         }
       }, 10000)
+      // #6043: fire-and-forget respawn safety net — never gate process exit on
+      // it. Respawn runs either off the child's 'close' or this fallback; if the
+      // loop is otherwise dead the process is exiting and there is nothing to
+      // respawn into, so holding the loop open for 10s only leaks (notably in
+      // tests with a mock child that never emits 'close').
+      if (typeof forceKillTimer.unref === 'function') forceKillTimer.unref()
 
       oldChild.kill('SIGTERM')
     } else {
@@ -1735,6 +1741,10 @@ export class CliSession extends BaseSession {
         this._emitInterruptedTurnResult()
       }
     }, 5000)
+    // #6043: fire-and-forget busy-state safety net — never gate process exit on
+    // it. It only force-clears local state if the child ignored SIGINT; if the
+    // loop is otherwise idle the process is exiting and the state is moot.
+    if (typeof this._interruptTimer.unref === 'function') this._interruptTimer.unref()
   }
 
   /** Clean up resources */
@@ -1788,6 +1798,12 @@ export class CliSession extends BaseSession {
       const forceKillTimer = setTimeout(() => {
         try { forceKill(child) } catch {}
       }, 3000)
+      // #6043: fire-and-forget safety net — never gate process exit on it. If
+      // the loop is otherwise idle the process is shutting down anyway and the
+      // child is reaped on exit; the timer only matters while the loop is alive
+      // for other reasons. Without unref it pins the loop for the full 3s in
+      // tests whose mock child never emits 'close'.
+      if (typeof forceKillTimer.unref === 'function') forceKillTimer.unref()
 
       child.on('close', () => clearTimeout(forceKillTimer))
       this._child = null

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -657,6 +657,10 @@ export class Supervisor extends EventEmitter {
         try { this._child.kill('SIGTERM') } catch {}
       }
     }, DRAIN_TIMEOUT)
+    // #6043: fire-and-forget drain safety net — never gate process exit on it.
+    // The supervisor stays alive via its own listening handles during a drain;
+    // this timer is only the fallback SIGTERM if the child ignores drain.
+    if (typeof drainTimer.unref === 'function') drainTimer.unref()
 
     if (this._child) {
       this._child.once('exit', () => clearTimeout(drainTimer))
@@ -788,6 +792,12 @@ export class Supervisor extends EventEmitter {
         this._log.info('Force-killing child after 5s timeout')
         try { forceKill(childRef) } catch {}
       }, 5000)
+      // #6043: fire-and-forget shutdown safety net — never gate process exit on
+      // it. During shutdown the supervisor is held alive by the awaited
+      // tunnel.stop() and remaining handles; the goal of this path is exit, so
+      // if the loop is otherwise idle the process should exit, not be pinned for
+      // 5s. The child is in this process group and is reaped on full exit.
+      if (typeof forceKillTimer.unref === 'function') forceKillTimer.unref()
 
       childRef.once('exit', () => clearTimeout(forceKillTimer))
 

--- a/packages/server/tests/cli-session-unref-kill-timers.test.js
+++ b/packages/server/tests/cli-session-unref-kill-timers.test.js
@@ -1,0 +1,137 @@
+import { describe, it, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { Readable, Writable } from 'node:stream'
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { CliSession } from '../src/cli-session.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+/**
+ * #6043: the destroy()/respawn/interrupt force-kill fallback timers are
+ * fire-and-forget safety nets cleared only when the child emits 'close'. They
+ * must be .unref()'d so a pending one never gates process exit — in tests with a
+ * mock child that never emits 'close' they otherwise pin the event loop for the
+ * full timeout (3s/10s/5s), which is the leak behind the #6027/#6042 teardown.
+ *
+ * These tests assert the actual timer objects are unref'd at runtime
+ * (timer.hasRef() === false) by capturing them through a setTimeout spy, plus a
+ * source-level check that the unref guard is present at each site.
+ */
+
+function createMockChild() {
+  const child = new EventEmitter()
+  child.stdin = new Writable({ write(chunk, enc, cb) { cb() } })
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 12345
+  child.kill = mock.fn(() => true)
+  child.killed = false
+  return child
+}
+
+function createSession(tmpDir) {
+  const stateFilePath = join(tmpDir, `state-${Math.random().toString(36).slice(2)}.json`)
+  return new CliSession({ cwd: '/tmp', stateFilePath })
+}
+
+/**
+ * Run `fn` with `setTimeout` patched so every armed timer is captured. Returns
+ * the list of captured Timeout objects. Restores the real setTimeout after.
+ */
+function captureTimers(fn) {
+  const captured = []
+  const realSetTimeout = globalThis.setTimeout
+  globalThis.setTimeout = (cb, ms, ...args) => {
+    const t = realSetTimeout(cb, ms, ...args)
+    captured.push(t)
+    return t
+  }
+  try {
+    fn()
+  } finally {
+    globalThis.setTimeout = realSetTimeout
+  }
+  return captured
+}
+
+describe('#6043 cli-session force-kill timers are unref()-d', () => {
+  let tmpDir
+  const sessions = []
+
+  function newSession() {
+    if (!tmpDir) tmpDir = mkdtempSync(join(tmpdir(), 'cli-unref-'))
+    const s = createSession(tmpDir)
+    sessions.push(s)
+    return s
+  }
+
+  afterEach(() => {
+    for (const s of sessions.splice(0)) {
+      s._child = null
+      try { const r = s.destroy(); if (r && typeof r.catch === 'function') r.catch(() => {}) } catch {}
+    }
+    if (tmpDir) { rmSync(tmpDir, { recursive: true, force: true }); tmpDir = null }
+  })
+
+  it('destroy() arms a force-kill timer that does not hold the event loop open', () => {
+    const session = newSession()
+    // Live mock child that never emits 'close' — the exact teardown leak case.
+    session._child = createMockChild()
+
+    const timers = captureTimers(() => session.destroy())
+
+    // The force-kill timer is the (only) one armed inside the `if (this._child)`
+    // block of destroy(); it must be unref'd.
+    assert.ok(timers.length >= 1, 'destroy() should arm at least one timer')
+    for (const t of timers) {
+      if (typeof t.unref === 'function') {
+        assert.equal(t.hasRef(), false, 'destroy() force-kill timer must not ref the loop')
+      }
+    }
+  })
+
+  it('destroy() force-kill timer still fires force-kill if the loop is alive', async () => {
+    const session = newSession()
+    const child = createMockChild()
+    session._child = child
+
+    // Speed the test up: patch setTimeout used inside destroy to fire near-immediately
+    // while preserving unref(). We assert the kill path runs (process is "busy").
+    const realSetTimeout = globalThis.setTimeout
+    globalThis.setTimeout = (cb, _ms, ...args) => realSetTimeout(cb, 5, ...args)
+    try {
+      session.destroy()
+      await new Promise((resolve) => realSetTimeout(resolve, 40))
+    } finally {
+      globalThis.setTimeout = realSetTimeout
+    }
+
+    assert.ok(child.kill.mock.callCount() >= 1,
+      'force-kill should still fire while the loop is otherwise alive')
+  })
+
+  it('source unref()s the destroy, respawn, and interrupt timers', () => {
+    const src = readFileSync(join(__dirname, '../src/cli-session.js'), 'utf-8')
+    // Three distinct unref guards expected (destroy force-kill, respawn
+    // force-kill, interrupt safety) — count the issue-tagged unref pattern.
+    const unrefCount = (src.match(/if \(typeof \w[\w.]*\.unref === 'function'\) [\w.]*\.unref\(\)/g) || []).length
+    assert.ok(unrefCount >= 3,
+      `expected >=3 unref guards in cli-session.js for #6043, found ${unrefCount}`)
+    assert.ok(src.includes('#6043'), 'expected #6043 rationale comments in cli-session.js')
+  })
+})
+
+describe('#6043 supervisor force-kill timers are unref()-d', () => {
+  it('source unref()s the drain and shutdown force-kill timers', () => {
+    const src = readFileSync(join(__dirname, '../src/supervisor.js'), 'utf-8')
+    const unrefCount = (src.match(/if \(typeof \w[\w.]*\.unref === 'function'\) [\w.]*\.unref\(\)/g) || []).length
+    assert.ok(unrefCount >= 2,
+      `expected >=2 #6043 unref guards in supervisor.js, found ${unrefCount}`)
+    assert.ok(src.includes('#6043'), 'expected #6043 rationale comments in supervisor.js')
+  })
+})

--- a/packages/server/tests/cli-session-unref-kill-timers.test.js
+++ b/packages/server/tests/cli-session-unref-kill-timers.test.js
@@ -117,11 +117,15 @@ describe('#6043 cli-session force-kill timers are unref()-d', () => {
 
   it('source unref()s the destroy, respawn, and interrupt timers', () => {
     const src = readFileSync(join(__dirname, '../src/cli-session.js'), 'utf-8')
-    // Three distinct unref guards expected (destroy force-kill, respawn
-    // force-kill, interrupt safety) — count the issue-tagged unref pattern.
-    const unrefCount = (src.match(/if \(typeof \w[\w.]*\.unref === 'function'\) [\w.]*\.unref\(\)/g) || []).length
-    assert.ok(unrefCount >= 3,
-      `expected >=3 unref guards in cli-session.js for #6043, found ${unrefCount}`)
+    // Assert the SPECIFIC guards by timer name (not a generic unref count): a
+    // generic count can stay green if one #6043 site loses its guard while an
+    // unrelated unref exists. Both force-kill sites share the name
+    // `forceKillTimer` (destroy + respawn), plus the interrupt safety timer.
+    const forceKillGuards = (src.match(/if \(typeof forceKillTimer\.unref === 'function'\) forceKillTimer\.unref\(\)/g) || []).length
+    assert.ok(forceKillGuards >= 2,
+      `expected both cli-session forceKillTimer sites unref()-d for #6043, found ${forceKillGuards}`)
+    assert.ok(/if \(typeof this\._interruptTimer\.unref === 'function'\) this\._interruptTimer\.unref\(\)/.test(src),
+      'expected the interrupt timer to be unref()-d for #6043')
     assert.ok(src.includes('#6043'), 'expected #6043 rationale comments in cli-session.js')
   })
 })
@@ -129,9 +133,13 @@ describe('#6043 cli-session force-kill timers are unref()-d', () => {
 describe('#6043 supervisor force-kill timers are unref()-d', () => {
   it('source unref()s the drain and shutdown force-kill timers', () => {
     const src = readFileSync(join(__dirname, '../src/supervisor.js'), 'utf-8')
-    const unrefCount = (src.match(/if \(typeof \w[\w.]*\.unref === 'function'\) [\w.]*\.unref\(\)/g) || []).length
-    assert.ok(unrefCount >= 2,
-      `expected >=2 #6043 unref guards in supervisor.js, found ${unrefCount}`)
+    // Assert each specific timer by name. supervisor.js also has an unrelated
+    // `_heartbeatInterval.unref()`, so a generic unref count would false-pass
+    // even if a #6043 guard were dropped (Copilot review on #6051).
+    assert.ok(/if \(typeof drainTimer\.unref === 'function'\) drainTimer\.unref\(\)/.test(src),
+      'expected the graceful-restart drainTimer to be unref()-d for #6043')
+    assert.ok(/if \(typeof forceKillTimer\.unref === 'function'\) forceKillTimer\.unref\(\)/.test(src),
+      'expected the shutdown forceKillTimer to be unref()-d for #6043')
     assert.ok(src.includes('#6043'), 'expected #6043 rationale comments in supervisor.js')
   })
 })


### PR DESCRIPTION
## Summary

The fire-and-forget force-kill fallback timers in `CliSession` and `Supervisor` are cleared **only** when the child emits `close`. A pending one keeps the event loop alive for the full timeout (3s/10s/5s) — the root behind the #6027/#6042 test-teardown work, where a mock child never emits `close` so the timer leaks for the whole interval.

`.unref()` them so a pending fire-and-forget kill never gates process exit, while still firing if the loop is otherwise alive.

Closes #6043.

## Sites unref'd (file:line on this branch)

| File | Site | Timeout | Why unref is safe |
|------|------|---------|-------------------|
| `cli-session.js:1804` | `destroy()` force-kill | 3s | Pure safety net cleared on child `close`; nothing awaits it. On exit the child is reaped; the timer only matters while the loop is alive for other reasons. This is the exact teardown-leak site #6042 hits. |
| `cli-session.js:1474` | respawn force-kill | 10s | Respawn runs off the child's `close` **or** this fallback. If the loop is otherwise dead the process is exiting and there is nothing to respawn into — holding it open 10s only leaks. |
| `cli-session.js:1744` | `_interruptTimer` busy-state safety | 5s | Tracked on `this` and cleared in `destroy()`; force-clears local busy state only if the child ignored SIGINT. If the loop is otherwise idle the process is exiting and the state is moot. |
| `supervisor.js:660` | graceful-restart `drainTimer` | DRAIN_TIMEOUT | Fallback SIGTERM if the child ignores `drain`. The supervisor stays alive via its own listening handles during a drain, so unref can't drop it prematurely. |
| `supervisor.js:797` | shutdown force-kill | 5s | During shutdown the supervisor is held alive by the awaited `tunnel.stop()` and remaining handles; the goal of this path **is** exit. The child is in this process group and reaped on full exit. |

## Safety reasoning (shutdown semantics)

`unref()` means the timer won't keep the event loop alive **on its own**. None of these timers is awaited or relied on for timing by anything else:

- **Production:** the process stays alive via real handles (listening sockets, the awaited `tunnel.stop()`) until shutdown actually completes, so an unref'd safety-net timer still fires within its window. On full process exit the child is in the same process group and is reaped — unref cannot orphan a child.
- **Tests / idle loop:** if the loop is otherwise empty, the process is meant to exit; pinning it for 3–10s is the leak this issue targets. The timer's job (force-kill / respawn / clear-busy) is moot once nothing else is running.

No site was left un-unref'd — all five are genuine fire-and-forget safety nets. Each carries a `#6043` rationale comment inline.

## Tests

New `tests/cli-session-unref-kill-timers.test.js`:
- Runtime assertion that `destroy()`'s force-kill timer has `hasRef() === false` (captured via a `setTimeout` spy with a live mock child that never emits `close`).
- That the timer still **fires** the force-kill when the loop is alive (behavior unchanged when busy).
- Source-level checks that the unref guard + `#6043` rationale are present at all sites in both files.

Verified locally (Node 22): the new test file exits in ~0.25s **without** `--test-force-exit` (pre-fix the `destroy()` timer pinned it ~3s). Existing `cli-session`, `supervisor`, and force-kill-ref suites: 139 pass / 0 fail. eslint clean on both changed src files.