### PR TITLE
refactor(protocol): validated builder for permission_request emits (#6031)

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -291,6 +291,43 @@ export declare const ServerPermissionRequestSchema: z.ZodObject<{
     remainingMs: z.ZodOptional<z.ZodNumber>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+/**
+ * Single validated builder for the `permission_request` wire message (#6031).
+ *
+ * `permission_request` is the most security-relevant message on the wire — a
+ * dropped/misnamed binding field (e.g. `sessionId`) routes a prompt to the
+ * wrong session or strands it on the legacy resolver. It used to be hand-built
+ * as a raw object literal at 4+ emit sites (ws-permissions.js HTTP-fallback +
+ * two resend paths, event-normalizer.js), each free to drift its field set.
+ *
+ * This factory is the one place those sites construct the message, and it
+ * `safeParse`-validates against `ServerPermissionRequestSchema` so field drift
+ * (a missing required field, a wrong type) is caught instead of silently
+ * shipping a malformed prompt.
+ *
+ * Field hygiene:
+ *  - `type` is always set here — callers never pass it.
+ *  - Optional fields (`description`, `remainingMs`, `sessionId`) are omitted
+ *    entirely (absent, not `null`/`undefined`) when not provided, matching the
+ *    existing wire shape (clients fall back to the active session when
+ *    `sessionId` is absent).
+ *  - `input` is passed through as-is. Callers are responsible for redaction
+ *    (#6038: `description: redactValue(...)`, `input: sanitizeToolInput(...)`)
+ *    BEFORE handing values to this builder — it is a shape guard, not a
+ *    redaction layer, and must not re-process already-redacted values.
+ *
+ * Validation failures throw a descriptive `Error` (with the Zod issues) rather
+ * than returning a partial object, so a drift bug surfaces loudly at the emit
+ * site in dev/test/CI instead of corrupting the client prompt.
+ */
+export declare function buildPermissionRequestMessage(fields: {
+    requestId: string;
+    tool: string;
+    description?: string;
+    input?: unknown;
+    remainingMs?: number;
+    sessionId?: string;
+}): ServerPermissionRequestMessage;
 export declare const ServerUserQuestionSchema: z.ZodObject<{
     type: z.ZodLiteral<"user_question">;
     toolUseId: z.ZodString;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -323,8 +323,8 @@ export declare const ServerPermissionRequestSchema: z.ZodObject<{
 export declare function buildPermissionRequestMessage(fields: {
     requestId: string;
     tool: string;
+    input: unknown;
     description?: string;
-    input?: unknown;
     remainingMs?: number;
     sessionId?: string;
 }): ServerPermissionRequestMessage;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -444,6 +444,59 @@ export const ServerPermissionRequestSchema = z.object({
     // Emitted by ws-permissions.js (resendPendingPermissions + HTTP fallback).
     sessionId: z.string().optional(),
 });
+/**
+ * Single validated builder for the `permission_request` wire message (#6031).
+ *
+ * `permission_request` is the most security-relevant message on the wire — a
+ * dropped/misnamed binding field (e.g. `sessionId`) routes a prompt to the
+ * wrong session or strands it on the legacy resolver. It used to be hand-built
+ * as a raw object literal at 4+ emit sites (ws-permissions.js HTTP-fallback +
+ * two resend paths, event-normalizer.js), each free to drift its field set.
+ *
+ * This factory is the one place those sites construct the message, and it
+ * `safeParse`-validates against `ServerPermissionRequestSchema` so field drift
+ * (a missing required field, a wrong type) is caught instead of silently
+ * shipping a malformed prompt.
+ *
+ * Field hygiene:
+ *  - `type` is always set here — callers never pass it.
+ *  - Optional fields (`description`, `remainingMs`, `sessionId`) are omitted
+ *    entirely (absent, not `null`/`undefined`) when not provided, matching the
+ *    existing wire shape (clients fall back to the active session when
+ *    `sessionId` is absent).
+ *  - `input` is passed through as-is. Callers are responsible for redaction
+ *    (#6038: `description: redactValue(...)`, `input: sanitizeToolInput(...)`)
+ *    BEFORE handing values to this builder — it is a shape guard, not a
+ *    redaction layer, and must not re-process already-redacted values.
+ *
+ * Validation failures throw a descriptive `Error` (with the Zod issues) rather
+ * than returning a partial object, so a drift bug surfaces loudly at the emit
+ * site in dev/test/CI instead of corrupting the client prompt.
+ */
+export function buildPermissionRequestMessage(fields) {
+    const msg = {
+        type: 'permission_request',
+        requestId: fields.requestId,
+        tool: fields.tool,
+        input: fields.input,
+    };
+    // Omit optional fields when absent so the wire shape stays identical to the
+    // hand-built literals (clients fall back to the active session when
+    // `sessionId` is absent, not null).
+    if (fields.description !== undefined)
+        msg.description = fields.description;
+    if (fields.remainingMs !== undefined)
+        msg.remainingMs = fields.remainingMs;
+    if (fields.sessionId !== undefined)
+        msg.sessionId = fields.sessionId;
+    const result = ServerPermissionRequestSchema.safeParse(msg);
+    if (!result.success) {
+        throw new Error(`buildPermissionRequestMessage: invalid permission_request (${result.error.issues
+            .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+            .join('; ')})`);
+    }
+    return result.data;
+}
 export const ServerUserQuestionSchema = z.object({
     type: z.literal('user_question'),
     toolUseId: z.string(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -477,6 +477,67 @@ export const ServerPermissionRequestSchema = z.object({
   sessionId: z.string().optional(),
 })
 
+/**
+ * Single validated builder for the `permission_request` wire message (#6031).
+ *
+ * `permission_request` is the most security-relevant message on the wire — a
+ * dropped/misnamed binding field (e.g. `sessionId`) routes a prompt to the
+ * wrong session or strands it on the legacy resolver. It used to be hand-built
+ * as a raw object literal at 4+ emit sites (ws-permissions.js HTTP-fallback +
+ * two resend paths, event-normalizer.js), each free to drift its field set.
+ *
+ * This factory is the one place those sites construct the message, and it
+ * `safeParse`-validates against `ServerPermissionRequestSchema` so field drift
+ * (a missing required field, a wrong type) is caught instead of silently
+ * shipping a malformed prompt.
+ *
+ * Field hygiene:
+ *  - `type` is always set here — callers never pass it.
+ *  - Optional fields (`description`, `remainingMs`, `sessionId`) are omitted
+ *    entirely (absent, not `null`/`undefined`) when not provided, matching the
+ *    existing wire shape (clients fall back to the active session when
+ *    `sessionId` is absent).
+ *  - `input` is passed through as-is. Callers are responsible for redaction
+ *    (#6038: `description: redactValue(...)`, `input: sanitizeToolInput(...)`)
+ *    BEFORE handing values to this builder — it is a shape guard, not a
+ *    redaction layer, and must not re-process already-redacted values.
+ *
+ * Validation failures throw a descriptive `Error` (with the Zod issues) rather
+ * than returning a partial object, so a drift bug surfaces loudly at the emit
+ * site in dev/test/CI instead of corrupting the client prompt.
+ */
+export function buildPermissionRequestMessage(fields: {
+  requestId: string
+  tool: string
+  description?: string
+  input?: unknown
+  remainingMs?: number
+  sessionId?: string
+}): ServerPermissionRequestMessage {
+  const msg: Record<string, unknown> = {
+    type: 'permission_request',
+    requestId: fields.requestId,
+    tool: fields.tool,
+    input: fields.input,
+  }
+  // Omit optional fields when absent so the wire shape stays identical to the
+  // hand-built literals (clients fall back to the active session when
+  // `sessionId` is absent, not null).
+  if (fields.description !== undefined) msg.description = fields.description
+  if (fields.remainingMs !== undefined) msg.remainingMs = fields.remainingMs
+  if (fields.sessionId !== undefined) msg.sessionId = fields.sessionId
+
+  const result = ServerPermissionRequestSchema.safeParse(msg)
+  if (!result.success) {
+    throw new Error(
+      `buildPermissionRequestMessage: invalid permission_request (${result.error.issues
+        .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+        .join('; ')})`,
+    )
+  }
+  return result.data
+}
+
 export const ServerUserQuestionSchema = z.object({
   type: z.literal('user_question'),
   toolUseId: z.string(),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -509,8 +509,12 @@ export const ServerPermissionRequestSchema = z.object({
 export function buildPermissionRequestMessage(fields: {
   requestId: string
   tool: string
+  // `input` is REQUIRED (not `input?:`): the schema's `input: z.any()` accepts a
+  // missing key at runtime, so the type system is the only thing that catches an
+  // emitter dropping `input` — keeping it required is what makes this builder a
+  // real drift guard (Copilot review on #6052). All emit sites pass it.
+  input: unknown
   description?: string
-  input?: unknown
   remainingMs?: number
   sessionId?: string
 }): ServerPermissionRequestMessage {

--- a/packages/protocol/tests/permission-request-builder.test.js
+++ b/packages/protocol/tests/permission-request-builder.test.js
@@ -1,0 +1,147 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildPermissionRequestMessage,
+  ServerPermissionRequestSchema,
+} from '@chroxy/protocol'
+
+/**
+ * #6031: the `permission_request` wire message was hand-built as raw object
+ * literals at 4+ emit sites (ws-permissions.js HTTP-fallback + two resend
+ * paths, event-normalizer.js), each free to drift its field set. The single
+ * `buildPermissionRequestMessage` factory now constructs + safeParse-validates
+ * every emit so a dropped/misnamed/mis-typed field is caught loudly instead of
+ * shipping a malformed prompt that strands or mis-routes the permission.
+ *
+ * These tests pin both halves of the contract: a valid call produces a
+ * schema-valid message, and a malformed call (missing required field, wrong
+ * type) throws rather than returning a partial object.
+ */
+describe('buildPermissionRequestMessage (#6031)', () => {
+  describe('valid input', () => {
+    it('produces a schema-valid message with all fields', () => {
+      const msg = buildPermissionRequestMessage({
+        requestId: 'req-1',
+        tool: 'Bash',
+        description: 'ls -la',
+        input: { command: 'ls -la' },
+        remainingMs: 300_000,
+        sessionId: 'sess-abc',
+      })
+      assert.equal(msg.type, 'permission_request')
+      assert.equal(ServerPermissionRequestSchema.safeParse(msg).success, true)
+      assert.deepEqual(msg, {
+        type: 'permission_request',
+        requestId: 'req-1',
+        tool: 'Bash',
+        description: 'ls -la',
+        input: { command: 'ls -la' },
+        remainingMs: 300_000,
+        sessionId: 'sess-abc',
+      })
+    })
+
+    it('omits optional fields entirely when absent (absent, not null)', () => {
+      const msg = buildPermissionRequestMessage({
+        requestId: 'req-2',
+        tool: 'Read',
+        input: { file_path: '/etc/hosts' },
+      })
+      assert.equal(ServerPermissionRequestSchema.safeParse(msg).success, true)
+      assert.ok(!('description' in msg))
+      assert.ok(!('remainingMs' in msg))
+      // The binding field clients fall back on: absent, never null.
+      assert.ok(!('sessionId' in msg))
+    })
+
+    it('passes input through as-is without re-redacting (shape guard only)', () => {
+      // Callers redact BEFORE the builder (#6038); it must not touch values.
+      const redacted = { command: 'export TOKEN=[redacted]' }
+      const msg = buildPermissionRequestMessage({
+        requestId: 'req-3',
+        tool: 'Bash',
+        description: '[redacted]',
+        input: redacted,
+      })
+      assert.equal(msg.input, redacted)
+      assert.equal(msg.description, '[redacted]')
+    })
+
+    it('accepts remainingMs of 0 (expired-but-present)', () => {
+      const msg = buildPermissionRequestMessage({
+        requestId: 'req-4',
+        tool: 'Edit',
+        input: {},
+        remainingMs: 0,
+      })
+      assert.equal(msg.remainingMs, 0)
+      assert.equal(ServerPermissionRequestSchema.safeParse(msg).success, true)
+    })
+  })
+
+  describe('malformed input is rejected', () => {
+    it('throws when requestId is missing', () => {
+      assert.throws(
+        () => buildPermissionRequestMessage({ tool: 'Bash', input: {} }),
+        /invalid permission_request/,
+      )
+    })
+
+    it('throws when tool is missing', () => {
+      assert.throws(
+        () => buildPermissionRequestMessage({ requestId: 'req-5', input: {} }),
+        /invalid permission_request/,
+      )
+    })
+
+    it('throws when requestId is the wrong type', () => {
+      assert.throws(
+        () => buildPermissionRequestMessage({ requestId: 123, tool: 'Bash', input: {} }),
+        /invalid permission_request/,
+      )
+    })
+
+    it('throws when description is the wrong type', () => {
+      assert.throws(
+        () => buildPermissionRequestMessage({
+          requestId: 'req-6',
+          tool: 'Bash',
+          description: { not: 'a string' },
+          input: {},
+        }),
+        /invalid permission_request/,
+      )
+    })
+
+    it('throws when remainingMs is negative', () => {
+      assert.throws(
+        () => buildPermissionRequestMessage({
+          requestId: 'req-7',
+          tool: 'Bash',
+          input: {},
+          remainingMs: -1,
+        }),
+        /invalid permission_request/,
+      )
+    })
+
+    it('throws when sessionId is the wrong type', () => {
+      assert.throws(
+        () => buildPermissionRequestMessage({
+          requestId: 'req-8',
+          tool: 'Bash',
+          input: {},
+          sessionId: 42,
+        }),
+        /invalid permission_request/,
+      )
+    })
+
+    it('surfaces the offending field name in the error message', () => {
+      assert.throws(
+        () => buildPermissionRequestMessage({ tool: 'Bash', input: {} }),
+        /requestId/,
+      )
+    })
+  })
+})

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -1,6 +1,7 @@
 import { performance } from 'node:perf_hooks'
 import { toShortModelId } from './models.js'
 import { createLogger } from './logger.js'
+import { buildPermissionRequestMessage } from '@chroxy/protocol'
 
 const log = createLogger('event-normalizer')
 
@@ -507,14 +508,13 @@ Object.assign(EVENT_MAP, {
 
   permission_request: (data, ctx) => ({
     messages: [{
-      msg: {
-        type: 'permission_request',
+      msg: buildPermissionRequestMessage({
         requestId: data.requestId,
         tool: data.tool,
         description: data.description,
         input: data.input,
         remainingMs: data.remainingMs,
-      },
+      }),
     }],
     registrations: [{ map: 'permission', key: data.requestId, value: ctx.sessionId }],
     sideEffects: [{

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -6,6 +6,7 @@ import { settlePush } from './push.js'
 import { createPermissionResolver } from './permission-resolver.js'
 import { sendOversizeResponse } from './http-oversize.js'
 import { redactValue, sanitizeToolInput } from './redaction.js'
+import { buildPermissionRequestMessage } from '@chroxy/protocol'
 
 const log = createLogger('ws')
 
@@ -231,8 +232,7 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       // with `LOG_LEVEL=debug` when triangulating SESSION_TOKEN_MISMATCH.
       log.debug(`[session-binding-create] permission ${requestId} created via HTTP (sessionId=${ownerSessionId ?? 'none'}, sourceIp=${clientIp})`)
 
-      broadcastFn({
-        type: 'permission_request',
+      broadcastFn(buildPermissionRequestMessage({
         requestId,
         tool,
         description,
@@ -241,11 +241,11 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         // #5667: carry the owning session so clients route the prompt to the
         // session that actually asked, instead of falling back to whatever tab
         // is focused. Matches the resend-on-reconnect (line ~485) and SDK
-        // (line ~406) paths, which already include sessionId. The `sessionId`
-        // property is omitted entirely (absent, not null) when the request maps
-        // to no chroxy session — clients then fall back to the active session.
-        ...(ownerSessionId ? { sessionId: ownerSessionId } : {}),
-      })
+        // (line ~406) paths, which already include sessionId. The builder omits
+        // `sessionId` entirely (absent, not null) when undefined — the request
+        // maps to no chroxy session and clients fall back to the active one.
+        sessionId: ownerSessionId || undefined,
+      }))
 
       if (pushManager) {
         // #5702 (8d): settle the fire-and-forget send so a failed phone
@@ -505,8 +505,14 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
               } else {
                 permissionSessionMap.set(requestId, sessionId)
               }
-              const { createdAt: _ca, remainingMs: _origMs, ...clientPayload } = permData
-              sendFn(ws, { type: 'permission_request', ...clientPayload, remainingMs, sessionId })
+              sendFn(ws, buildPermissionRequestMessage({
+                requestId: permData.requestId ?? requestId,
+                tool: permData.tool,
+                description: permData.description,
+                input: permData.input,
+                remainingMs,
+                sessionId,
+              }))
             }
           }
         }
@@ -530,8 +536,13 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         } else {
           log.debug(`[session-binding-resend] legacy permission ${requestId} resent (client=unknown)`)
         }
-        const { createdAt: _ca, remainingMs: _origMs, ...clientPayload } = pending.data
-        sendFn(ws, { type: 'permission_request', ...clientPayload, remainingMs })
+        sendFn(ws, buildPermissionRequestMessage({
+          requestId: pending.data.requestId ?? requestId,
+          tool: pending.data.tool,
+          description: pending.data.description,
+          input: pending.data.input,
+          remainingMs,
+        }))
       }
     }
   }


### PR DESCRIPTION
## Summary

`permission_request` — the most security-relevant wire message — was hand-built as raw object literals at 4 emit sites, each free to drift its field set. A dropped/misnamed binding field (e.g. `sessionId`) routes a prompt to the wrong session or strands it on the legacy resolver. The only existing guard (`handler-coverage.test.js`) checks type-name completeness, not field shape.

This adds a single `buildPermissionRequestMessage(...)` factory in `@chroxy/protocol` that constructs **and** `safeParse`-validates the message against the existing `ServerPermissionRequestSchema`, and routes every emit site through it. Field drift (missing required field, wrong type) now throws loudly at the emit site instead of shipping a malformed prompt.

## Approach

**Builder** (over per-site validate): one typed factory is the single construction point, so the typed signature also prevents *extra* fields at the call site (which Zod's non-strict `.object()` would otherwise silently strip rather than reject). The builder:

- always sets `type` (callers never pass it),
- omits optional fields (`description`, `remainingMs`, `sessionId`) entirely when absent, preserving the existing wire shape (clients fall back to the active session when `sessionId` is absent, **not** null),
- passes `input`/`description` through as-is — callers still redact **before** the builder (#6038 `redactValue(...)` / `sanitizeToolInput(...)`); the builder is a shape guard, not a redaction layer, and must not re-process already-redacted values,
- throws a descriptive `Error` (offending field named) on a schema-parse failure.

No wire-shape change; this is a drift-guard.

## Emit sites converted

- `packages/server/src/ws-permissions.js` — HTTP-fallback broadcast (was the `...(ownerSessionId ? {sessionId} : {})` literal)
- `packages/server/src/ws-permissions.js` — resend-on-reconnect, SDK/session path (was `{...clientPayload, remainingMs, sessionId}`)
- `packages/server/src/ws-permissions.js` — resend-on-reconnect, legacy HTTP path (was `{...clientPayload, remainingMs}`)
- `packages/server/src/event-normalizer.js` — provider event normalizer (was the `permission_request:` literal)

## Schema / builder location

- `packages/protocol/src/schemas/server.ts` — `ServerPermissionRequestSchema` (existing) + new `buildPermissionRequestMessage(...)` (committed `dist/` regenerated).

## Tests

- `packages/protocol/tests/permission-request-builder.test.js` — accepts valid input (full + minimal, asserts optional fields omitted not null, input passed through un-redacted, `remainingMs: 0`); rejects malformed input (missing `requestId`/`tool`, mis-typed `requestId`/`description`/`sessionId`, negative `remainingMs`); asserts the error names the offending field.

### Verification

- Protocol suite green (`permission-request-builder.test.js` 11/11; `schemas.test.js` + `handler-coverage.test.js` 250/250).
- Server-side affected files green: `event-normalizer.test.js`, `ws-permissions.test.js`, `permission-broadcast-redaction.test.js` — 182/182. (SDK-importing tests can't run in the isolated worktree — no `node_modules`; CI covers them.)

Related to #6031.