### PR TITLE
refactor(server): single-source the answer-authorization predicate (#6030)

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -209,6 +209,15 @@ const FORBIDDEN_HOME_SUBDIRS = new Set([
 // this so a client that merely knows a session id — but isn't watching it — can't
 // drive or leak its terminal (#5840 review; extended to terminal_input in #5842).
 // Shared here so the session-handlers and input-handlers copies can't drift.
+//
+// #6030: this is ALSO the single source of truth for the answer-authorization
+// invariant "who may ANSWER a permission/question == who could have RECEIVED it".
+// The broadcaster's recipient predicate (_matchesSession), the unbound
+// AskUserQuestion answer guard (input-handlers.js, #4788), and the unbound
+// permission-response guard (settings-handlers.js, #4798) all route through this
+// SAME function — so if the receiver set is ever widened (a new viewer class, the
+// LAN shared-session epic), the answer guards follow automatically and cannot
+// drift back into the cross-session answer-hijack vector #4788/#4798 closed.
 export function isSessionViewer(client, sid) {
   return client.activeSessionId === sid ||
     Boolean(client.subscribedSessionIds && client.subscribedSessionIds.has(sid))

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -915,15 +915,14 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
   // to match the client's active or subscribed sessions before routing the
   // answer. Without this, an unbound dashboard tab could submit an answer
   // for any session by replaying a known toolUseId — paired with the log
-  // leak in #4787 this enables cross-session answer hijacking. Mirrors the
-  // default filter used by _broadcastToSession (ws-broadcaster.js:106) so
-  // the set of clients permitted to ANSWER a question is the same set that
-  // could legitimately have RECEIVED it. Leaves the mapping intact so the
-  // legitimate subscribed client can still respond.
+  // leak in #4787 this enables cross-session answer hijacking. Routes through
+  // isSessionViewer (#6030) — the SAME predicate _broadcastToSession uses to
+  // pick recipients (ws-broadcaster.js _matchesSession) — so the set of clients
+  // permitted to ANSWER a question is provably the same set that could
+  // legitimately have RECEIVED it, and the two can never drift. Leaves the
+  // mapping intact so the legitimate subscribed client can still respond.
   if (!client.boundSessionId) {
-    const subscribed = questionSessionId === client.activeSessionId
-      || (client.subscribedSessionIds && client.subscribedSessionIds.has(questionSessionId))
-    if (!subscribed) return
+    if (!isSessionViewer(client, questionSessionId)) return
   }
 
   if (msg.toolUseId) ctx.permissions.questionSessionMap.delete(msg.toolUseId)

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -13,6 +13,7 @@ import {
   sendError,
   sendSessionError,
   buildSessionTokenMismatchPayload,
+  isSessionViewer,
 } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
 import { createLogger, loggerForSession, sessionLogger } from '../logger.js'
@@ -24,7 +25,7 @@ import {
   PER_SESSION_SETTINGS,
   buildPerSessionSettingHandler,
 } from '../per-session-settings.js'
-import { createPermissionResolver } from '../permission-resolver.js'
+import { createPermissionResolver, resolveOriginSessionId } from '../permission-resolver.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
 // These are safe file-operation tools that don't execute code or make network requests.
@@ -378,23 +379,27 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   // legacy `client.activeSessionId` fallback. That fallback is passed to the
   // resolver as `dispatchFallbackSessionId` (used ONLY to pick the dispatch
   // session, NEVER for the binding check — invariant B / the #2806 residual).
+  // #6030: computed via resolveOriginSessionId (the SAME helper the resolver
+  // uses), so the session this handler authorizes against is byte-identical to
+  // the one the resolver dispatches to — closing the prior `||` (here) vs `??`
+  // (resolver) split that disagreed on empty-string / 0-ish mapped ids.
   const mappedSessionId = ctx.permissions.permissionSessionMap.get(requestId)
-  const originSessionId = mappedSessionId || client.activeSessionId
+  const originSessionId = resolveOriginSessionId(mappedSessionId, client.activeSessionId)
 
   // #4798 (audit P0 symmetry with #4788): for UNBOUND clients, require the
   // originSessionId to match the client's active or subscribed sessions before
   // routing the decision. Without this, an unbound dashboard tab could
   // approve/deny a permission for any session by replaying a known requestId —
   // arguably MORE dangerous than the question hijack vector (#4788) because
-  // permission decisions gate file writes / shell exec. Mirrors the default
-  // filter used by _broadcastToSession (ws-broadcaster.js:106). Leaves the
-  // mapping intact so the legitimate subscribed client can still respond. WS-ONLY
-  // by design: a primary HTTP caller has full session authority (§3), so the HTTP
-  // path has no analog and must not inherit this restriction.
+  // permission decisions gate file writes / shell exec. Routes through
+  // isSessionViewer (#6030) — the SAME predicate _broadcastToSession uses to pick
+  // recipients (ws-broadcaster.js _matchesSession) — so "who may answer == who
+  // could receive" can never drift. Leaves the mapping intact so the legitimate
+  // subscribed client can still respond. WS-ONLY by design: a primary HTTP caller
+  // has full session authority (§3), so the HTTP path has no analog and must not
+  // inherit this restriction.
   if (!client.boundSessionId && originSessionId) {
-    const subscribed = originSessionId === client.activeSessionId
-      || (client.subscribedSessionIds && client.subscribedSessionIds.has(originSessionId))
-    if (!subscribed) {
+    if (!isSessionViewer(client, originSessionId)) {
       sessionLogger(originSessionId).warn(`[permission-response-reject] unbound client ${client.id} attempted to respond to ${requestId} (originSessionId=${originSessionId}, activeSessionId=${client.activeSessionId ?? 'none'}, subscribed=false) — dropped`)
       return
     }

--- a/packages/server/src/permission-resolver.js
+++ b/packages/server/src/permission-resolver.js
@@ -23,6 +23,28 @@
 //   { kind: 'not_found' }                                   -> HTTP 404 / WS permission_expired
 
 /**
+ * #6030: the single source of truth for the permission "dispatch origin"
+ * session id — the mapped session if the request was registered, else the
+ * WS-only legacy `client.activeSessionId` fallback (HTTP passes nothing).
+ *
+ * Both the WS handler (settings-handlers.js — for its unbound-subscription
+ * guard, invariant G) and the resolver below MUST compute this the SAME way, or
+ * the handler could authorize against one session while the resolver dispatches
+ * to another (issue #6030: the handler previously used `||` here while the
+ * resolver used `??`, so they disagreed on an empty-string / 0-ish mapped id).
+ * `??` is correct: a mapping is "present" iff it was actually registered
+ * (null/undefined absent), so an explicitly-mapped empty-string session id must
+ * be honoured, not silently coalesced to the active-session fallback.
+ *
+ * @param {string|null|undefined} mappedSessionId  the raw permissionSessionMap entry
+ * @param {string|null|undefined} fallbackSessionId  WS-only legacy fallback (client.activeSessionId); HTTP passes null
+ * @returns {string|null|undefined}
+ */
+export function resolveOriginSessionId(mappedSessionId, fallbackSessionId) {
+  return mappedSessionId ?? fallbackSessionId
+}
+
+/**
  * @param {{
  *   permissionSessionMap: Map<string, string>,
  *   pendingPermissions: Map<string, any>,
@@ -83,8 +105,9 @@ export function createPermissionResolver({
     }
 
     // Dispatch origin: the mapped session, or the WS-only legacy fallback. NEVER
-    // used for the binding check above.
-    const originSessionId = mappedSessionId ?? dispatchFallbackSessionId
+    // used for the binding check above. #6030: shared with the WS handler's guard
+    // via resolveOriginSessionId so both agree on empty-string/0-ish ids.
+    const originSessionId = resolveOriginSessionId(mappedSessionId, dispatchFallbackSessionId)
 
     // Invariant F: SDK-mode (in-process) dispatch is attempted before the legacy
     // store. Uses respondToPermission's RETURN VALUE as the resolved-vs-expired

--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -1,5 +1,6 @@
 import { createLogger } from './logger.js'
 import { metrics } from './metrics.js'
+import { isSessionViewer } from './handler-utils.js'
 
 const log = createLogger('ws')
 
@@ -143,10 +144,15 @@ export class WsBroadcaster {
    * truth for the full-scan fallbacks of _broadcastToSession /
    * _countSessionSubscribers / _hasDeflateSubscriber so they can never drift
    * (deliver vs count vs deflate MUST agree).
+   *
+   * #6030: delegates to the shared isSessionViewer predicate (handler-utils.js)
+   * so the RECEIVER set defined here and the answer-authorization guards in
+   * input-handlers.js (#4788) / settings-handlers.js (#4798) are the SAME logic
+   * — "who may answer == who could receive" can never drift. The boolean is
+   * identical: `a === sid || Boolean(subscribed.has(sid))`.
    */
   _matchesSession(client, sessionId) {
-    if (client.activeSessionId === sessionId) return true
-    return !!(client.subscribedSessionIds && client.subscribedSessionIds.has(sessionId))
+    return isSessionViewer(client, sessionId)
   }
 
   /**

--- a/packages/server/tests/answer-authorization-ssot.test.js
+++ b/packages/server/tests/answer-authorization-ssot.test.js
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { WsBroadcaster } from '../src/ws-broadcaster.js'
+import { isSessionViewer } from '../src/handler-utils.js'
+import { resolveOriginSessionId } from '../src/permission-resolver.js'
+
+/**
+ * #6030 — single-source-of-truth for the answer-authorization invariant:
+ * "the set of clients permitted to ANSWER a permission/question == the set that
+ * could legitimately have RECEIVED it (the session's recipient/viewer set)."
+ *
+ * Three sites previously re-implemented this predicate inline:
+ *   - ws-broadcaster.js  _matchesSession  (the RECEIVER set for session broadcasts)
+ *   - input-handlers.js  AskUserQuestion answer guard (#4788)
+ *   - settings-handlers.js permission_response guard (#4798)
+ *
+ * They now all route through the shared isSessionViewer predicate. These tests
+ * pin that the broadcaster's recipient set and the shared predicate agree, and
+ * that the eligibility rule the answer guards enforce is the same boolean.
+ */
+
+function makeClient({ activeSessionId = null, subscribedSessionIds = new Set() } = {}) {
+  return { activeSessionId, subscribedSessionIds }
+}
+
+// The exact answer-guard logic both handler sites run for an UNBOUND client.
+// Mirrors `if (!client.boundSessionId) { if (!isSessionViewer(...)) return }`.
+function mayAnswer(client, sessionId) {
+  return isSessionViewer(client, sessionId)
+}
+
+describe('#6030 answer-authorization SSoT — guard set == broadcast recipient set', () => {
+  // A representative population covering the eligibility dimensions.
+  const cases = [
+    { name: 'active-session match', client: makeClient({ activeSessionId: 's1' }), sid: 's1' },
+    { name: 'subscribed match', client: makeClient({ subscribedSessionIds: new Set(['s1']) }), sid: 's1' },
+    { name: 'active+subscribed both match', client: makeClient({ activeSessionId: 's1', subscribedSessionIds: new Set(['s1', 's2']) }), sid: 's1' },
+    { name: 'non-recipient (different active)', client: makeClient({ activeSessionId: 's2' }), sid: 's1' },
+    { name: 'non-recipient (different subscription)', client: makeClient({ subscribedSessionIds: new Set(['s2', 's3']) }), sid: 's1' },
+    { name: 'non-recipient (nothing)', client: makeClient(), sid: 's1' },
+    { name: 'missing subscribedSessionIds, no active', client: { activeSessionId: null }, sid: 's1' },
+  ]
+
+  // The broadcaster's RECEIVER predicate (full-scan fallback) is _matchesSession.
+  const broadcaster = new WsBroadcaster({ clients: new Map(), sendFn: () => {} })
+
+  for (const { name, client, sid } of cases) {
+    it(`agrees for: ${name}`, () => {
+      const receiver = broadcaster._matchesSession(client, sid)
+      const guard = mayAnswer(client, sid)
+      // The load-bearing invariant: who may answer == who could receive.
+      assert.equal(guard, receiver, 'answer guard diverged from broadcast recipient set')
+    })
+  }
+
+  it('authorized client (subscriber) may answer; non-recipient may not', () => {
+    const authorized = makeClient({ subscribedSessionIds: new Set(['s1']) })
+    const outsider = makeClient({ activeSessionId: 's2', subscribedSessionIds: new Set(['s2']) })
+
+    assert.equal(mayAnswer(authorized, 's1'), true, 'a session subscriber must be allowed to answer')
+    assert.equal(mayAnswer(outsider, 's1'), false, 'a non-recipient must NOT be allowed to answer')
+    // And both match the broadcaster's view of who would have received it.
+    assert.equal(broadcaster._matchesSession(authorized, 's1'), true)
+    assert.equal(broadcaster._matchesSession(outsider, 's1'), false)
+  })
+
+  it('active-session client may answer its own session but not a foreign one', () => {
+    const client = makeClient({ activeSessionId: 's1' })
+    assert.equal(mayAnswer(client, 's1'), true)
+    assert.equal(mayAnswer(client, 's-other'), false)
+  })
+})
+
+describe('#6030 resolveOriginSessionId — single dispatch-origin computation (??, not ||)', () => {
+  it('returns the mapped session when present', () => {
+    assert.equal(resolveOriginSessionId('s1', 's-active'), 's1')
+  })
+
+  it('falls back to the active session only when the mapping is absent (null/undefined)', () => {
+    assert.equal(resolveOriginSessionId(undefined, 's-active'), 's-active')
+    assert.equal(resolveOriginSessionId(null, 's-active'), 's-active')
+  })
+
+  it('honours an explicitly-mapped empty-string session id (?? not ||) — the operator-divergence fix', () => {
+    // The crux of the #6030 split: `||` would coalesce '' to the fallback,
+    // authorizing against the active session while dispatching to ''. `??`
+    // keeps the explicit mapping so the guard session == the dispatch session.
+    assert.equal(resolveOriginSessionId('', 's-active'), '')
+  })
+
+  it('with no mapping and no fallback, yields a falsy origin (guard is skipped)', () => {
+    assert.equal(resolveOriginSessionId(undefined, undefined), undefined)
+    assert.equal(resolveOriginSessionId(null, null), null)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #6030.

The authorization invariant **"the set permitted to ANSWER a permission/question == the set that could have RECEIVED it"** was enforced by copy-pasted predicates rather than shared code. This routes every site through the single `isSessionViewer` predicate so the answer guards and the broadcast recipient set can never drift back into the cross-session answer-hijack vector #4788/#4798 closed.

This is a **DRY/SSoT refactor, not a policy change** — behavior is byte-identical at each site.

## The predicate

The receiver/viewer rule is already defined once in `handler-utils.js`:

```js
export function isSessionViewer(client, sid) {
  return client.activeSessionId === sid ||
    Boolean(client.subscribedSessionIds && client.subscribedSessionIds.has(sid))
}
```

Every duplicated copy was logically `a === sid || Boolean(subscribed.has(sid))` — i.e. exactly this.

## Sites converted

| Site | Was | Now |
|---|---|---|
| `ws-broadcaster.js` `_matchesSession` (the RECEIVER set) | inline `activeSessionId === sid \|\| subscribed.has(sid)` | `return isSessionViewer(client, sessionId)` |
| `input-handlers.js` AskUserQuestion answer guard (#4788) | inline `const subscribed = ...; if (!subscribed) return` | `if (!isSessionViewer(client, questionSessionId)) return` |
| `settings-handlers.js` permission_response guard (#4798) | inline `const subscribed = ...; if (!subscribed) { ...log...; return }` | `if (!isSessionViewer(client, originSessionId)) { ...log...; return }` |

## originSessionId computed once (`||` → `??`)

The issue also flagged that `originSessionId` was computed twice with a subtle operator divergence: `settings-handlers.js` used `||` (falsy-coalesce) while `permission-resolver.js` used `??` (nullish-coalesce) — disagreeing on an empty-string / 0-ish mapped id, which could authorize against session A while dispatching to session B.

Fix: `permission-resolver.js` now exports a pure `resolveOriginSessionId(mappedSessionId, fallbackSessionId)` (using `??`). Both the resolver's internal dispatch-origin computation and the WS handler's guard consume this **single** helper, so the session the handler authorizes against is byte-identical to the one the resolver dispatches to.

## Why behavior is identical per site

- **`isSessionViewer` vs the inline checks** — the inline form `x === client.activeSessionId || (client.subscribedSessionIds && client.subscribedSessionIds.has(x))` is used only in a boolean `if (!subscribed)` context, so the `Boolean(...)` wrapper inside `isSessionViewer` changes nothing. `===` is order-independent. Result: identical truth value.
- **`resolveOriginSessionId`** returns `mapped ?? fallback` — exactly what the resolver already computed. The only changed call site is `settings-handlers.js`, where `||`→`??` is the intended #6030 normalization (it now AGREES with the resolver, which already used `??`). The guard at that site is wrapped in `&& originSessionId`, so the falsy-skip behavior is unchanged.
- The HTTP path (`ws-permissions.js`) delegates fully to the resolver and has no unbound-subscription guard by design (a primary HTTP token has full session authority, §3) — it inherits the shared `resolveOriginSessionId` transparently and needs no source change.
- No change to `boundSessionId` binding logic, the resolver's invariant A/B binding check, audit, or any error/`permission_expired` payload.

## Tests

`tests/answer-authorization-ssot.test.js` (13 cases, all passing locally):
- the answer-guard set equals the broadcast recipient set (`_matchesSession`) across the eligibility dimensions (active match / subscribed match / non-recipient / missing subscription set);
- an authorized subscriber **may** answer, a non-recipient **may not**;
- `resolveOriginSessionId` honours an explicitly-mapped empty-string id (`??` not `||`) and falls back only on null/undefined.

## Validation notes

This worktree has no `node_modules`, so SDK-importing server suites can't load here (`@anthropic-ai/claude-agent-sdk` resolution) — CI and the maintainer's container validate those. The new test + `ws-broadcaster.test.js` (73) + `permission-resolver.test.js` + `handler-utils.test.js` (133) all pass locally, and both server lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) are green.