### PR TITLE
test(protocol): lint every server→client schema type reaches both clients (#6033)

### DIFF
--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Protocol server→client TYPE coverage lint — the dashboard-first drift guard
+ * (#6033, from the 2026-06-18 SOLID/DRY swarm-audit).
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * Two guards already exist and neither catches a server→client message type
+ * that lands DASHBOARD-FIRST (the mailbox / billing-canary / user-shell /
+ * PTY-mirror pattern — added to the dashboard switch + the protocol schema, but
+ * never wired into the app):
+ *
+ *   1. `coverage-lint.test.ts` (#5619) — the both-clients SWITCH_FIXTURES lint.
+ *      Its universe is the INTERSECTION of the two clients' handler switches, so
+ *      a type only ONE client handles is, by construction, never in scope. A
+ *      dashboard-only type is invisible to it.
+ *
+ *   2. `protocol/tests/handler-coverage.test.js` — the exhaustiveness guard.
+ *      It DOES assert "every server→client type is in app OR declared
+ *      dashboard-only", which is the right shape — but its source of truth is the
+ *      hand-maintained `Server -> Client:` DOC COMMENT in `ws-server.js`, not the
+ *      protocol schema. That comment is incomplete: three real `z.literal(...)`
+ *      server→client types in `schemas/server.ts` (`billing_canary`,
+ *      `budget_resume_ack`, `cancel_activity_ack`) are NOT in it, so they are
+ *      worked around in that test's `SYNTHETIC_TYPES` ("not the ws-server.js
+ *      broadcast surface the extractor scans") rather than coverage-checked. A
+ *      future schema-first type added the same way inherits the same blind spot.
+ *
+ * WHAT THIS LINT ENFORCES
+ * -----------------------
+ * It takes the PROTOCOL SCHEMA as the source of truth: every `type:
+ * z.literal('<type>')` discriminator declared in `packages/protocol/src/schemas/
+ * server.ts` is a server→client message type. For each one it asserts the type
+ * is HANDLED BY BOTH CLIENTS — present in the app handler switch AND the
+ * dashboard handler switch (a shared store-core dispatch-table entry counts as
+ * covering BOTH, since each client routes through `runDispatch` before its own
+ * switch) — OR is on an explicit asymmetry allowlist:
+ *
+ *   - `DASHBOARD_ONLY` — handled by the dashboard by design (the app has no
+ *     surface for it yet); mobile parity is a tracked follow-up.
+ *   - `APP_ONLY` — handled by the app by design (no dashboard surface).
+ *   - `UNHANDLED_BY_DESIGN` — handled at a different layer (connection /
+ *     transport / a dedicated short-lived socket), not the main dispatch.
+ *
+ * A new schema-declared server→client type added to one client (or to neither)
+ * without an allowlist entry FAILS this lint — that is the anti-drift guarantee:
+ * intentional asymmetry must be DECLARED, accidental asymmetry fails CI.
+ *
+ * The allowlists are also kept HONEST: a stale entry (a type that no longer
+ * exists in the schema, or that has since gained both-client coverage, or whose
+ * declared single platform no longer matches reality) fails too — so the
+ * allowlists can only describe real, current asymmetries.
+ *
+ * RELATIONSHIP TO THE OTHER GUARDS
+ * --------------------------------
+ *   - vs `coverage-lint.test.ts` (#5619): that lint checks FIXTURE coverage of
+ *     the both-clients switch INTERSECTION (behavioural-contract drift). THIS
+ *     lint checks HANDLER coverage of the protocol's full DECLARED type union
+ *     (existence + declared asymmetry). Different universe, different question.
+ *   - vs `handler-coverage.test.js`: same shape, but THIS lint's source of truth
+ *     is the protocol schema, not the ws-server.js doc comment — so it catches
+ *     the schema-first types that guard structurally misses.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import {
+  extractAppHandlerTypes,
+  extractDashboardHandlerTypes,
+} from '@chroxy/protocol/handler-coverage'
+import { DISPATCH_TABLE_TYPES } from '../dispatch-table'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const serverSchemaPath = resolve(here, '../../../protocol/src/schemas/server.ts')
+const appHandlerPath = resolve(here, '../../../app/src/store/message-handler.ts')
+const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-handler.ts')
+
+// ---------------------------------------------------------------------------
+// Source of truth — the protocol's server→client message-type union.
+//
+// The server schemas are individual `z.object({ type: z.literal('<type>'), … })`
+// shapes, not one discriminated union we can introspect (see the note in
+// dispatch-table.ts). The discriminator literal IS the per-type identity, so we
+// static-parse every `type: z.literal('<type>')` from schemas/server.ts. Static
+// text analysis (not a runtime import) keeps this cheap and matches how the
+// handler universes are extracted, so the comparison is apples-to-apples.
+// ---------------------------------------------------------------------------
+function serverSchemaTypes(): string[] {
+  const src = readFileSync(serverSchemaPath, 'utf-8')
+  const types = new Set(
+    [...src.matchAll(/type:\s*z\.literal\('([a-z_]+)'\)/g)].map((m) => m[1]),
+  )
+  return [...types].sort()
+}
+
+// ---------------------------------------------------------------------------
+// Per-client handler universes. A type is covered by a client when it has a
+// `case`/HANDLERS-map entry in that client's source (via the shared
+// @chroxy/protocol/handler-coverage extractors, #6021) OR is registered in the
+// shared store-core dispatch table — a dispatch-table case is routed through
+// `runDispatch` by BOTH clients before their own switch, so it counts as
+// covering both. (The file-ops/git decline nuance from #5653 does not apply to
+// the schema-literal universe: none of those decline-capable types are declared
+// as `z.literal` server→client schemas here.)
+// ---------------------------------------------------------------------------
+function clientCoverage(): { inApp: (t: string) => boolean; inDash: (t: string) => boolean } {
+  const appTypes = extractAppHandlerTypes(readFileSync(appHandlerPath, 'utf-8'))
+  const dashTypes = extractDashboardHandlerTypes(readFileSync(dashHandlerPath, 'utf-8'))
+  const dispatch = new Set<string>(DISPATCH_TABLE_TYPES)
+  return {
+    inApp: (t) => appTypes.has(t) || dispatch.has(t),
+    inDash: (t) => dashTypes.has(t) || dispatch.has(t),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Asymmetry allowlists — DECLARED, intentional single-platform / unhandled
+// coverage. Mirrors the rationale recorded in protocol/tests/handler-coverage's
+// PLATFORM_SPECIFIC + INTENTIONALLY_UNHANDLED sets (the existing source of those
+// decisions); this lint re-states them against the SCHEMA universe so a
+// schema-first type can no longer slip past unguarded.
+//
+// Adding a NEW entry to silence the lint for a freshly-introduced type is only
+// legitimate when the asymmetry is genuinely intended (the other client has no
+// surface for it yet) — pair it with a tracking note. The preferred fix for an
+// accidental gap is to WIRE THE MISSING CLIENT, not to allowlist it.
+// ---------------------------------------------------------------------------
+
+// Handled by the DASHBOARD only — the app has no surface for these yet. Each is
+// a host-level / desktop-only feature (Control Room, provider-credentials forms,
+// pairing-approval banners, the prompt evaluator, the skills panel, the monthly
+// budget meter); mobile parity is a tracked follow-up under the cited epic.
+const DASHBOARD_ONLY = new Set<string>([
+  'activity_snapshot',          // Control Room activity tree (#5159)
+  'activity_delta',             // Control Room activity tree (#5159)
+  'billing_canary',             // live billing-canary banner (#5821) — dashboard sidebar
+  'byok_credentials_status',    // BYOK paste-API-key form (#4052) — dashboard-only for v1
+  'cancel_activity_ack',        // Control Room cancel-click correlation ack (#5277)
+  'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
+  'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
+  'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
+  'evaluate_draft_result',      // manual prompt evaluator (#3068) — dashboard-only for v1
+  'evaluator_clarify',          // auto-evaluator clarify banner (#3188) — dashboard-only
+  'evaluator_rewrite',          // auto-evaluator rewrite banner (#3188) — dashboard-only
+  'host_status_snapshot',       // Control Room Host/Repo Status (#5170) — dashboard-only for v1
+  'integration_action_ack',     // Control Room Integrations action ack (#5500) — dashboard-only
+  'integration_status_snapshot',// Control Room Integrations survey (#5499) — dashboard-only
+  'mailbox_status_snapshot',    // Control Room Mailbox tab survey (#5914) — dashboard-only
+  'monthly_budget',             // monthly programmatic-credit meter (#5665) — dashboard sidebar
+  'pair_pending',               // pairing-approval banner fan-out (#5510) — dashboard-only for v1
+  'pair_resolved',              // pairing-approval banner retraction (#5510) — dashboard-only for v1
+  'prompt_evaluator_changed',   // per-session promptEvaluator toggle (#3185) — dashboard-only
+  'runner_status_snapshot',     // Control Room self-hosted runner survey (#5253) — dashboard-only
+  'session_preamble_changed',   // per-session preamble (#4660) — dashboard-only for v1
+  'session_preset_snapshot',    // Control Room per-repo session-preset survey (#5553) — dashboard-only
+  'skill_activated',            // manual-skill runtime toggle (#3209) — dashboard-only for v1
+  'skill_changed',              // skill content-hash mismatch (#3205) — dashboard-only for v1
+  'skill_deactivated',          // manual-skill runtime toggle (#3209) — dashboard-only for v1
+  'skill_trust_accepted',       // operator-confirmed re-trust (#3235) — dashboard-only for v1
+  'skill_trust_grant_ok',       // skill_trust_grant ack (#3297) — dashboard-only for v1
+  'skill_trust_granted',        // community trust granted broadcast (#3297) — dashboard-only for v1
+  'skill_trust_request',        // community skill awaiting first-activation grant (#3297) — dashboard-only
+  'skills_inventory_snapshot',  // Control Room Skills inventory survey (#5554) — dashboard-only
+  'skills_list',                // skills list response (#3209) — dashboard-only for v1
+  'summarize_session_result',   // sidebar "Summarize & start new session" reply (#5547) — dashboard-only
+])
+
+// Handled by the APP only — no dashboard surface by design.
+const APP_ONLY = new Set<string>([
+  'push_token_error',           // push notifications are mobile-only
+])
+
+// Declared server→client schema types handled at a layer OTHER than the main
+// client message-handler dispatch (connection/transport, or a dedicated
+// short-lived socket), so neither client's main switch covers them. Mirrors
+// handler-coverage's INTENTIONALLY_UNHANDLED.
+const UNHANDLED_BY_DESIGN = new Set<string>([
+  'extension_message',                    // routed to the extension framework, not the main switch
+  'pair_request_pending',                 // pairing-approval primitive (#5510) — consumed by the requester's
+                                          //   dedicated request-pairing socket, not the main dispatch
+  'pair_result',                          // pairing-approval primitive (#5510) — terminal result for the
+                                          //   requester, handled by request-pairing.ts, not the main dispatch
+  'prompt_evaluator_skip_pattern_changed',// #3639 broadcast — surface is the per-session field on session_list;
+                                          //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
+  'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
+                                          //   session_list, not a dedicated wire-event handler
+])
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('protocol server→client type coverage lint (#6033)', () => {
+  const types = serverSchemaTypes()
+  const { inApp, inDash } = clientCoverage()
+
+  it('derives a non-trivial server→client schema-type union (extraction sanity)', () => {
+    // Pin to a band around the real count (~92) so a parser regression (e.g. the
+    // schema being reformatted in a way the literal regex stops matching) fails
+    // LOUDLY rather than silently shrinking the universe to nothing and passing
+    // vacuously. A real new server→client schema type that pushes past the
+    // ceiling is a DELIBERATE bump — raise both bounds in the same PR that adds
+    // the type (and its both-client coverage or allowlist entry).
+    expect(types.length).toBeGreaterThanOrEqual(80)
+    expect(types.length).toBeLessThanOrEqual(120)
+  })
+
+  it('every server→client schema type is handled by BOTH clients or explicitly declared asymmetric', () => {
+    const undeclared = types
+      .filter(
+        (t) =>
+          !(inApp(t) && inDash(t)) &&
+          !DASHBOARD_ONLY.has(t) &&
+          !APP_ONLY.has(t) &&
+          !UNHANDLED_BY_DESIGN.has(t),
+      )
+      .map((t) => {
+        const where = inApp(t) ? 'app only' : inDash(t) ? 'dashboard only' : 'NEITHER client'
+        return `${t} (${where})`
+      })
+    expect(
+      undeclared,
+      'Server→client schema type(s) NOT handled by both clients and NOT on an ' +
+        'asymmetry allowlist — the dashboard-first drift this lint guards. Wire ' +
+        'the missing client (preferred), or — only if the asymmetry is intended ' +
+        '— add the type to DASHBOARD_ONLY / APP_ONLY / UNHANDLED_BY_DESIGN with a ' +
+        `tracking note:\n  ${undeclared.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('DASHBOARD_ONLY entries are real schema types actually handled by the dashboard only', () => {
+    const schemaSet = new Set(types)
+    const violations: string[] = []
+    for (const t of DASHBOARD_ONLY) {
+      if (!schemaSet.has(t)) violations.push(`${t}: not a server→client schema type (stale)`)
+      else if (!inDash(t)) violations.push(`${t}: declared dashboard-only but NOT handled by the dashboard`)
+      else if (inApp(t)) violations.push(`${t}: now handled by the app too — remove from DASHBOARD_ONLY`)
+    }
+    expect(
+      violations,
+      'DASHBOARD_ONLY allowlist drifted from reality:\n  ' + violations.join('\n  '),
+    ).toEqual([])
+  })
+
+  it('APP_ONLY entries are real schema types actually handled by the app only', () => {
+    const schemaSet = new Set(types)
+    const violations: string[] = []
+    for (const t of APP_ONLY) {
+      if (!schemaSet.has(t)) violations.push(`${t}: not a server→client schema type (stale)`)
+      else if (!inApp(t)) violations.push(`${t}: declared app-only but NOT handled by the app`)
+      else if (inDash(t)) violations.push(`${t}: now handled by the dashboard too — remove from APP_ONLY`)
+    }
+    expect(
+      violations,
+      'APP_ONLY allowlist drifted from reality:\n  ' + violations.join('\n  '),
+    ).toEqual([])
+  })
+
+  it('UNHANDLED_BY_DESIGN entries are real schema types handled by neither client', () => {
+    const schemaSet = new Set(types)
+    const violations: string[] = []
+    for (const t of UNHANDLED_BY_DESIGN) {
+      if (!schemaSet.has(t)) violations.push(`${t}: not a server→client schema type (stale)`)
+      else if (inApp(t) || inDash(t)) {
+        const where = [inApp(t) && 'app', inDash(t) && 'dashboard'].filter(Boolean).join(' and ')
+        violations.push(`${t}: declared unhandled but handled by ${where} — move to an ONLY allowlist or remove`)
+      }
+    }
+    expect(
+      violations,
+      'UNHANDLED_BY_DESIGN allowlist drifted from reality:\n  ' + violations.join('\n  '),
+    ).toEqual([])
+  })
+})

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -89,7 +89,11 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 function serverSchemaTypes(): string[] {
   const src = readFileSync(serverSchemaPath, 'utf-8')
   const types = new Set(
-    [...src.matchAll(/type:\s*z\.literal\('([a-z_]+)'\)/g)].map((m) => m[1]),
+    // Permissive on quote style, identifier chars (digits/caps), and whitespace
+    // so a reformat / double-quote / digit-bearing type can't silently slip the
+    // drift guard (#6033 review). The `type:` anchor still excludes non-message
+    // literals (e.g. serverMode: z.literal('cli'), reason: z.literal(...)).
+    [...src.matchAll(/type:\s*z\.literal\(\s*['"]([A-Za-z0-9_]+)['"]\s*\)/g)].map((m) => m[1]),
   )
   return [...types].sort()
 }


### PR DESCRIPTION
## What

Adds `packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts` — a **dashboard-first drift guard**. It takes the protocol schema as the source of truth for the server→client message-type union and asserts every type is handled by **both** clients (app + dashboard) or is on an explicit, documented asymmetry allowlist.

Closes #6033.

## The gap this closes

Two guards exist and neither catches a server→client type that lands **dashboard-first** (mailbox / billing-canary / user-shell / PTY-mirror — added to the dashboard switch + the protocol schema but never wired into the app):

1. **`coverage-lint.test.ts` (#5619)** — the both-clients `SWITCH_FIXTURES` lint. Its universe is the **intersection** of the two clients' switches, so a type only one client handles is, by construction, never in scope. A dashboard-only type is invisible to it.
2. **`protocol/tests/handler-coverage.test.js`** — the exhaustiveness guard. It has the right shape ("every server→client type is in app OR declared dashboard-only") but its source of truth is the hand-maintained `Server -> Client:` **doc comment in `ws-server.js`**, which is incomplete: three real `z.literal` server→client types (`billing_canary`, `budget_resume_ack`, `cancel_activity_ack`) are absent from it and worked around in that test's `SYNTHETIC_TYPES` ("not the ws-server.js broadcast surface the extractor scans") rather than coverage-checked. A future schema-first type added the same way inherits the same blind spot.

## What the lint checks

- Enumerates every `type: z.literal('<type>')` discriminator in `packages/protocol/src/schemas/server.ts` (the declared server→client union — there is no single discriminated union to introspect; the literal is the per-type identity).
- For each type, asserts it is handled by **both** clients — present in the app switch **and** the dashboard switch, where a shared store-core **dispatch-table** entry counts as covering both (each client routes through `runDispatch` before its own switch) — **or** is on an allowlist.
- Reuses the shared `@chroxy/protocol/handler-coverage` extractors (#6021) — no duplicated parser.
- Keeps the allowlists **honest**: a stale entry (not a schema type, now symmetric, or wrong platform) fails too.

## How it differs from the fixture-coverage lint

`coverage-lint.test.ts` checks **fixture** coverage of the both-clients switch **intersection** (behavioural-contract drift — do the handlers that exist *agree*?). This lint checks **handler** coverage of the protocol's full **declared** type union (existence + declared asymmetry — does a handler *exist in both clients*?). Different universe, different question. And vs `handler-coverage.test.js`: same shape, but the source of truth is the **protocol schema**, not the ws-server.js doc comment, so it catches the schema-first types that guard misses.

## Allowlists (intentional, declared asymmetries)

Each entry mirrors an existing `PLATFORM_SPECIFIC` / `INTENTIONALLY_UNHANDLED` declaration in `handler-coverage.test.js`, restated against the schema universe with a tracking note:

- **`DASHBOARD_ONLY`** (32) — host-level / desktop-only features the app has no surface for yet: Control Room (`activity_*`, `host_status_snapshot`, `runner_status_snapshot`, `integration_*`, `mailbox_status_snapshot`, `skills_inventory_snapshot`, `session_preset_snapshot`), Provider Credentials (`credentials_status`, `credential_test_result`, `byok_credentials_status`), the prompt evaluator (`evaluate_draft_result`, `evaluator_rewrite`, `evaluator_clarify`, `prompt_evaluator_changed`), the skills panel (`skills_list`, `skill_activated`/`_deactivated`/`_changed`, `skill_trust_*`), pairing-approval banners (`pair_pending`, `pair_resolved`), the billing/budget meters (`billing_canary`, `monthly_budget`), `cancel_activity_ack`, `chroxy_context_hint_changed`, `session_preamble_changed`, `summarize_session_result`. Mobile parity is a tracked follow-up under each cited epic.
- **`APP_ONLY`** (1) — `push_token_error` (push notifications are mobile-only).
- **`UNHANDLED_BY_DESIGN`** (5) — handled at a layer other than the main dispatch: `extension_message` (extension framework), `pair_request_pending` / `pair_result` (the requester's dedicated request-pairing socket, #5510), `prompt_evaluator_skip_pattern_changed` (#3639 — surface is the per-session field on `session_list`), `stdin_dropped_totals` (#3544 — surface is the SessionInfo flag on `session_list`).

## Validation

Ran the 5 tests under store-core vitest — all green on current `main`. The lint passes today: the schema union is 92 types, 54 are both-clients (incl. dispatch-table), and the remaining 38 are exactly the allowlisted asymmetries.

## Acceptance criteria

- [x] Lint enumerates server→client types and asserts both-client coverage or an explicit asymmetry-allowlist entry.
- [x] Current intentional asymmetries are allow-listed (declared), accidental ones surfaced.