### PR TITLE
refactor(server): extract createSession plan + stream delta target resolution (#6036)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -711,73 +711,42 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
-   * Create a new session.
-   * @param {object} [options]
-   * @param {string} [options.name]
-   * @param {string} [options.cwd]
-   * @param {string} [options.model]
-   * @param {string} [options.permissionMode]
-   * @param {string} [options.resumeSessionId]
-   * @param {string} [options.provider]
-   * @param {boolean} [options.worktree] - When true, creates a git worktree for isolation
-   * @param {object} [options.sandbox] - SDK sandbox settings for lightweight isolation
-   * @param {boolean} [options.promptEvaluator] - Per-session toggle for the auto-evaluator
-   *   chain (#3185). Default false — the manual `evaluate_draft` flow remains unaffected.
-   * @param {boolean} [options.chroxyContextHint] - Per-session opt-in toggle for
-   *   the Chroxy context-prefix in the system prompt (#3805). Default false —
-   *   when true, BaseSession._buildSystemPrompt prepends a short paragraph
-   *   telling the model it's running inside Chroxy so it can adjust output
-   *   for mobile clients. Persisted across reconnects.
-   * @param {string} [options.sessionPreamble] - Per-session user-authored
-   *   preamble prepended to the system prompt every turn (#4660). Default
-   *   empty string — when set, BaseSession._buildSystemPrompt puts the
-   *   preamble at the FRONT (before the optional chroxy hint and the
-   *   skills text). Trimmed + capped to SESSION_PREAMBLE_MAX_LENGTH by
-   *   BaseSession. Persisted across reconnects.
-   * @param {string} [options.promptEvaluatorSkipPattern] - Per-session regex source
-   *   string consulted by `shouldSkipEvaluator` BEFORE the server-wide
-   *   `config.promptEvaluatorSkipPattern` (the global knob landed in #3187;
-   *   this per-session override lands here in #3639). Pairs with the
-   *   per-session promptEvaluator toggle so different sessions can use
-   *   different skip heuristics (e.g. PR-review session skips 'lgtm',
-   *   triage session skips 'ack'). Default null — the global pattern from
-   *   #3187 still applies as the fallback.
-   * @param {boolean} [options.stdinForwardingDisabled] - Internal: hydrate the SidecarProcess
-   *   stdin_disabled latch (#3540) on a session being restored from disk. Only used by
-   *   `restoreState()`. Truthy = the prior process latched the flag; the new SdkSession
-   *   reports it via `listSessions` and `serializeState` round-trips it on the next write.
-   * @param {string} [options.bootedModel] - Internal/restore-only: pre-seed
-   *   `session.bootedModel` so the dashboard can show the actual model on a restored
-   *   session immediately, instead of falling back to the registry default until the
-   *   next CLI init event lands (#3700b). Empty / non-string ignored.
-   * @param {number} [options.messageCounter] - Internal/restore-only: pre-seed
-   *   `session._messageCounter` so a restored session's next sendMessage generates
-   *   `msg-{N+1}` instead of restarting from `msg-1` and colliding with messages
-   *   the dashboard cached from the previous process (#3700). Non-finite or
-   *   negative values ignored.
-   * @param {boolean} [options.skipPersist] - Internal: skip the sync persist flush. Used by
-   *   `restoreState()`, which must seed history and budget after createSession before the
-   *   state file is rewritten; otherwise each flush would overwrite the on-disk file with
-   *   empty history and destroy the very data we're restoring.
-   * @param {boolean} [options.skipPermissions] - #4208 / #4209: spawn the claude TUI with
-   *   `--dangerously-skip-permissions` (and elide chroxy's permission hook + sidecar
-   *   entirely). Forwarded to ClaudeTuiSession; other providers ignore it harmlessly via
-   *   destructuring. When omitted, falls back to the SessionManager-wide
-   *   `defaultSkipPermissions` (set from `chroxy start --dangerously-skip-permissions`).
-   * @param {string} [options.preserveId] - Optional 32-char lower-case hex session id to
-   *   reuse instead of generating a fresh `randomBytes(16).toString('hex')`. Invalid
-   *   format OR a collision with an already-live entry falls back to a fresh random id
-   *   so callers can safely pass any value. Primary use: `restoreState` reusing the
-   *   persisted id so dashboard's localStorage-cached `activeSessionId` still resolves
-   *   after a daemon restart (#4983).
-   * @param {boolean} [options.isRestore] - Internal (#5316): marks a session created by
-   *   `restoreState()`. When a provider's start() rejects ASYNCHRONOUSLY, the rejection
-   *   handler preserves the restored history + worktree (registers a failed-restore)
-   *   instead of fully destroying the session. Fresh sessions omit it and take the
-   *   full-destroy path on start failure.
-   * @returns {string} sessionId
+   * Resolve the validated "create plan" for a session (#6036 — the front-half
+   * SRP extraction out of {@link SessionManager#createSession}). Owns exactly
+   * the preflight + isolation + provider/preset resolution responsibilities:
+   *
+   *   1. session-limit guard + cwd existence check (throws on failure),
+   *   2. id generation (preserve-id validation #4983) + name,
+   *   3. provider resolution + the #2962 preflight (binary/credential) + the
+   *      user-shell fail-closed gate (#5985) + the #3403 model soft-fallback,
+   *   4. worktree isolation (fresh `git worktree add` OR the #5310 restore
+   *      rebind with the path-safety check),
+   *   5. per-repo session-preset resolution + preamble fold (#5553).
+   *
+   * Returns a plain plan object; {@link SessionManager#createSession} consumes
+   * it to build `providerOpts`, construct the session, register it, and start.
+   * Splitting the validation from the wiring keeps them close enough to read
+   * together — the "middle-layer trap" (#3224/#3231/#4790) recurs when they
+   * drift apart. Behaviour is identical to the previous inline front-half: the
+   * same checks run in the same order and throw the same errors.
+   *
+   * @param {object} args The (already-destructured) createSession options that
+   *   the plan depends on.
+   * @returns {{
+   *   sessionId: string,
+   *   sessionName: string,
+   *   resolvedCwd: string,
+   *   resolvedModel: (string|null),
+   *   resolvedPermissionMode: string,
+   *   resolvedProvider: string,
+   *   ProviderClass: Function,
+   *   worktreePath: (string|null),
+   *   worktreeRepoDir: (string|null),
+   *   presetDescriptor: (object|null),
+   *   effectiveSessionPreamble: (string|undefined),
+   * }} the validated create plan.
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, skipPersist = false, preserveId, isRestore = false } = {}) {
+  _resolveCreateSessionPlan({ name, cwd, model, permissionMode, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sessionPreamble, preserveId, isRestore = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -998,6 +967,124 @@ export class SessionManager extends EventEmitter {
         effectiveSessionPreamble = sessionPreamble
       }
     }
+
+    return {
+      sessionId,
+      sessionName,
+      resolvedCwd,
+      resolvedModel,
+      resolvedPermissionMode,
+      resolvedProvider,
+      ProviderClass,
+      worktreePath,
+      worktreeRepoDir,
+      presetDescriptor,
+      effectiveSessionPreamble,
+    }
+  }
+
+  /**
+   * Create a new session.
+   * @param {object} [options]
+   * @param {string} [options.name]
+   * @param {string} [options.cwd]
+   * @param {string} [options.model]
+   * @param {string} [options.permissionMode]
+   * @param {string} [options.resumeSessionId]
+   * @param {string} [options.provider]
+   * @param {boolean} [options.worktree] - When true, creates a git worktree for isolation
+   * @param {object} [options.sandbox] - SDK sandbox settings for lightweight isolation
+   * @param {boolean} [options.promptEvaluator] - Per-session toggle for the auto-evaluator
+   *   chain (#3185). Default false — the manual `evaluate_draft` flow remains unaffected.
+   * @param {boolean} [options.chroxyContextHint] - Per-session opt-in toggle for
+   *   the Chroxy context-prefix in the system prompt (#3805). Default false —
+   *   when true, BaseSession._buildSystemPrompt prepends a short paragraph
+   *   telling the model it's running inside Chroxy so it can adjust output
+   *   for mobile clients. Persisted across reconnects.
+   * @param {string} [options.sessionPreamble] - Per-session user-authored
+   *   preamble prepended to the system prompt every turn (#4660). Default
+   *   empty string — when set, BaseSession._buildSystemPrompt puts the
+   *   preamble at the FRONT (before the optional chroxy hint and the
+   *   skills text). Trimmed + capped to SESSION_PREAMBLE_MAX_LENGTH by
+   *   BaseSession. Persisted across reconnects.
+   * @param {string} [options.promptEvaluatorSkipPattern] - Per-session regex source
+   *   string consulted by `shouldSkipEvaluator` BEFORE the server-wide
+   *   `config.promptEvaluatorSkipPattern` (the global knob landed in #3187;
+   *   this per-session override lands here in #3639). Pairs with the
+   *   per-session promptEvaluator toggle so different sessions can use
+   *   different skip heuristics (e.g. PR-review session skips 'lgtm',
+   *   triage session skips 'ack'). Default null — the global pattern from
+   *   #3187 still applies as the fallback.
+   * @param {boolean} [options.stdinForwardingDisabled] - Internal: hydrate the SidecarProcess
+   *   stdin_disabled latch (#3540) on a session being restored from disk. Only used by
+   *   `restoreState()`. Truthy = the prior process latched the flag; the new SdkSession
+   *   reports it via `listSessions` and `serializeState` round-trips it on the next write.
+   * @param {string} [options.bootedModel] - Internal/restore-only: pre-seed
+   *   `session.bootedModel` so the dashboard can show the actual model on a restored
+   *   session immediately, instead of falling back to the registry default until the
+   *   next CLI init event lands (#3700b). Empty / non-string ignored.
+   * @param {number} [options.messageCounter] - Internal/restore-only: pre-seed
+   *   `session._messageCounter` so a restored session's next sendMessage generates
+   *   `msg-{N+1}` instead of restarting from `msg-1` and colliding with messages
+   *   the dashboard cached from the previous process (#3700). Non-finite or
+   *   negative values ignored.
+   * @param {boolean} [options.skipPersist] - Internal: skip the sync persist flush. Used by
+   *   `restoreState()`, which must seed history and budget after createSession before the
+   *   state file is rewritten; otherwise each flush would overwrite the on-disk file with
+   *   empty history and destroy the very data we're restoring.
+   * @param {boolean} [options.skipPermissions] - #4208 / #4209: spawn the claude TUI with
+   *   `--dangerously-skip-permissions` (and elide chroxy's permission hook + sidecar
+   *   entirely). Forwarded to ClaudeTuiSession; other providers ignore it harmlessly via
+   *   destructuring. When omitted, falls back to the SessionManager-wide
+   *   `defaultSkipPermissions` (set from `chroxy start --dangerously-skip-permissions`).
+   * @param {string} [options.preserveId] - Optional 32-char lower-case hex session id to
+   *   reuse instead of generating a fresh `randomBytes(16).toString('hex')`. Invalid
+   *   format OR a collision with an already-live entry falls back to a fresh random id
+   *   so callers can safely pass any value. Primary use: `restoreState` reusing the
+   *   persisted id so dashboard's localStorage-cached `activeSessionId` still resolves
+   *   after a daemon restart (#4983).
+   * @param {boolean} [options.isRestore] - Internal (#5316): marks a session created by
+   *   `restoreState()`. When a provider's start() rejects ASYNCHRONOUSLY, the rejection
+   *   handler preserves the restored history + worktree (registers a failed-restore)
+   *   instead of fully destroying the session. Fresh sessions omit it and take the
+   *   full-destroy path on start failure.
+   * @returns {string} sessionId
+   */
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, skipPersist = false, preserveId, isRestore = false } = {}) {
+    // #6036 — front-half SRP extraction: preflight + isolation + provider/preset
+    // resolution (incl. the limit guard, cwd check, id/name, #2962 preflight,
+    // #5985 user-shell gate, #3403 model fallback, worktree create/restore, and
+    // #5553 preset fold) all live in `_resolveCreateSessionPlan`. It throws the
+    // same errors in the same order the inline code did; this method then
+    // consumes the validated plan to build providerOpts, construct, register,
+    // and start. Both halves stay in the same file so the BaseSession opt
+    // forwarding stays readable next to the construction it feeds.
+    const plan = this._resolveCreateSessionPlan({
+      name,
+      cwd,
+      model,
+      permissionMode,
+      provider,
+      worktree,
+      restoreWorktreePath,
+      restoreWorktreeRepoDir,
+      sessionPreamble,
+      preserveId,
+      isRestore,
+    })
+    const {
+      sessionId,
+      sessionName,
+      resolvedCwd,
+      resolvedModel,
+      resolvedPermissionMode,
+      resolvedProvider,
+      ProviderClass,
+      worktreePath,
+      worktreeRepoDir,
+      presetDescriptor,
+      effectiveSessionPreamble,
+    } = plan
 
     const providerOpts = {
       cwd: resolvedCwd,

--- a/packages/server/tests/session-manager-create-plan.test.js
+++ b/packages/server/tests/session-manager-create-plan.test.js
@@ -1,0 +1,167 @@
+import { describe, it, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { EventEmitter } from 'events'
+import {
+  SessionManager,
+  SessionLimitError,
+  SessionDirectoryError,
+  ProviderModelNotSupportedError,
+} from '../src/session-manager.js'
+import { registerProvider } from '../src/providers.js'
+
+/**
+ * Unit tests for `_resolveCreateSessionPlan` (#6036) — the front-half SRP
+ * extraction from `createSession`. Each case asserts the plan the resolver
+ * returns equals exactly what the previous inline createSession front-half
+ * computed for the same inputs (id shape, name counter, cwd/model/permission/
+ * provider resolution, and the model soft-fallback / strict-reject fork).
+ *
+ * Every SessionManager MUST use a temp stateFilePath (see CLAUDE.md "Test
+ * state contamination").
+ */
+
+let _globalTmpDir
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'sm-create-plan-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
+
+class PlanFakeSession extends EventEmitter {
+  constructor(opts = {}) {
+    super()
+    this.cwd = opts.cwd
+  }
+  start() {}
+  destroy() {}
+  sendMessage() {}
+  interrupt() {}
+  setModel() { return false }
+  setPermissionMode() { return false }
+}
+
+// Non-Claude provider with a small static allowlist — exercises the strict
+// model rejection fork (no soft fallback).
+class PlanModelLimitedProvider extends PlanFakeSession {
+  static getAllowedModels() {
+    return ['allowed-model']
+  }
+}
+
+// Claude-family provider with a dynamic allowlist — exercises the #3403 soft
+// fallback (resolvedModel → null) instead of a hard reject.
+class PlanFakeClaudeProvider extends PlanFakeSession {
+  static claudeFamily = true
+  static getAllowedModels() {
+    return ['sonnet', 'opus']
+  }
+}
+
+registerProvider('test-plan-fake-6036', PlanFakeSession)
+registerProvider('test-plan-model-limited-6036', PlanModelLimitedProvider)
+registerProvider('test-plan-fake-claude-6036', PlanFakeClaudeProvider)
+
+describe('SessionManager._resolveCreateSessionPlan (#6036)', () => {
+  let mgr
+  beforeEach(() => {
+    mgr = new SessionManager({
+      maxSessions: 3,
+      stateFilePath: tmpStateFile(),
+      defaultCwd: tmpdir(),
+      defaultModel: 'default-model',
+      defaultPermissionMode: 'approve',
+      providerType: 'test-plan-fake-6036',
+      skipPreflight: true,
+    })
+  })
+
+  it('resolves a baseline plan: hex id, counter name, defaults applied', () => {
+    const plan = mgr._resolveCreateSessionPlan({})
+    assert.match(plan.sessionId, /^[a-f0-9]{32}$/)
+    assert.equal(plan.sessionName, 'Session 1')
+    assert.equal(plan.resolvedCwd, tmpdir())
+    assert.equal(plan.resolvedModel, 'default-model')
+    assert.equal(plan.resolvedPermissionMode, 'approve')
+    assert.equal(plan.resolvedProvider, 'test-plan-fake-6036')
+    assert.equal(typeof plan.ProviderClass, 'function')
+    assert.equal(plan.worktreePath, null)
+    assert.equal(plan.worktreeRepoDir, null)
+    // No .chroxy/session.json in tmpdir → no preset descriptor.
+    assert.equal(plan.presetDescriptor, null)
+  })
+
+  it('per-call name / cwd / model / permissionMode override the defaults', () => {
+    const plan = mgr._resolveCreateSessionPlan({
+      name: 'My Session',
+      cwd: tmpdir(),
+      model: 'allowed-model',
+      permissionMode: 'plan',
+      provider: 'test-plan-model-limited-6036',
+    })
+    assert.equal(plan.sessionName, 'My Session')
+    assert.equal(plan.resolvedModel, 'allowed-model')
+    assert.equal(plan.resolvedPermissionMode, 'plan')
+    assert.equal(plan.resolvedProvider, 'test-plan-model-limited-6036')
+  })
+
+  it('applies _defaultModel via nullish-coalesce for both undefined and null model', () => {
+    // `model ?? this._defaultModel` — preserved verbatim from the inline
+    // front-half. Both omitted (undefined) and explicit null fall back to the
+    // server default; an empty string is kept as-is (only null/undefined coalesce).
+    assert.equal(mgr._resolveCreateSessionPlan({}).resolvedModel, 'default-model')
+    assert.equal(mgr._resolveCreateSessionPlan({ model: null }).resolvedModel, 'default-model')
+    assert.equal(mgr._resolveCreateSessionPlan({ model: '' }).resolvedModel, '')
+  })
+
+  it('increments the session-name counter on each call', () => {
+    assert.equal(mgr._resolveCreateSessionPlan({}).sessionName, 'Session 1')
+    assert.equal(mgr._resolveCreateSessionPlan({}).sessionName, 'Session 2')
+  })
+
+  it('honors a valid preserveId (32 hex), else generates a fresh id', () => {
+    const id = 'a'.repeat(32)
+    assert.equal(mgr._resolveCreateSessionPlan({ preserveId: id }).sessionId, id)
+    // Invalid format → fresh random id, not the bad value.
+    const plan = mgr._resolveCreateSessionPlan({ preserveId: 'not-hex' })
+    assert.notEqual(plan.sessionId, 'not-hex')
+    assert.match(plan.sessionId, /^[a-f0-9]{32}$/)
+  })
+
+  it('throws SessionDirectoryError when the cwd does not exist', () => {
+    assert.throws(
+      () => mgr._resolveCreateSessionPlan({ cwd: join(tmpdir(), '__chroxy_missing_dir_6036__') }),
+      SessionDirectoryError,
+    )
+  })
+
+  it('throws SessionLimitError once the live session map is full', () => {
+    // Fill the map directly so the guard fires without spawning sessions.
+    for (let i = 0; i < 3; i++) mgr._sessions.set(`s${i}`, {})
+    assert.throws(() => mgr._resolveCreateSessionPlan({}), SessionLimitError)
+  })
+
+  it('strict-rejects an unsupported model on a non-Claude provider', () => {
+    assert.throws(
+      () =>
+        mgr._resolveCreateSessionPlan({
+          model: 'no-such-model',
+          provider: 'test-plan-model-limited-6036',
+        }),
+      ProviderModelNotSupportedError,
+    )
+  })
+
+  it('soft-falls-back to null for an unsupported model on a Claude provider (#3403)', () => {
+    const plan = mgr._resolveCreateSessionPlan({
+      model: 'retired-model',
+      provider: 'test-plan-fake-claude-6036',
+    })
+    assert.equal(plan.resolvedModel, null)
+  })
+})

--- a/packages/server/tests/session-manager-create-plan.test.js
+++ b/packages/server/tests/session-manager-create-plan.test.js
@@ -114,6 +114,9 @@ describe('SessionManager._resolveCreateSessionPlan (#6036)', () => {
     // `model ?? this._defaultModel` — preserved verbatim from the inline
     // front-half. Both omitted (undefined) and explicit null fall back to the
     // server default; an empty string is kept as-is (only null/undefined coalesce).
+    // NOTE: this pins CURRENT behavior, not a #3403 ruling — whether an explicit
+    // `model: null` should instead SURVIVE as a "use provider default" marker is
+    // tracked in #6064; this refactor only preserves what main did.
     assert.equal(mgr._resolveCreateSessionPlan({}).resolvedModel, 'default-model')
     assert.equal(mgr._resolveCreateSessionPlan({ model: null }).resolvedModel, 'default-model')
     assert.equal(mgr._resolveCreateSessionPlan({ model: '' }).resolvedModel, '')

--- a/packages/store-core/src/handlers/stream-delta-target.test.ts
+++ b/packages/store-core/src/handlers/stream-delta-target.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `resolveStreamDeltaTarget` (#6036) — the pure target/reuse decision
+ * extracted from `sharedStreamDelta`. Each case asserts the verdict equals
+ * exactly what the previous inline branch computed for the same inputs.
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveStreamDeltaTarget } from './stream'
+import type { ChatMessage } from '../types'
+
+const NOW = 1_700_000_000_000
+
+function resolverState(opts: {
+  postPermissionSplits?: string[]
+  deltaIdRemaps?: [string, string][]
+  resolvedMessages?: ChatMessage[]
+  targetForSuffix?: string | null
+}) {
+  return {
+    postPermissionSplits: new Set(opts.postPermissionSplits ?? []),
+    deltaIdRemaps: new Map(opts.deltaIdRemaps ?? []),
+    resolveMessages: () => ({
+      resolvedMessages: opts.resolvedMessages ?? [],
+      targetForSuffix: opts.targetForSuffix ?? null,
+    }),
+  }
+}
+
+function msg(id: string, type: ChatMessage['type']): ChatMessage {
+  return { id, type, content: '', timestamp: 0 }
+}
+
+describe('resolveStreamDeltaTarget', () => {
+  it('passes through when the id is unknown to every collection', () => {
+    const target = resolveStreamDeltaTarget('msg-1', resolverState({}), NOW)
+    expect(target).toEqual({ kind: 'passthrough', deltaId: 'msg-1' })
+  })
+
+  it('passes through when the id already points at a response slot', () => {
+    const target = resolveStreamDeltaTarget(
+      'msg-2',
+      resolverState({ resolvedMessages: [msg('msg-2', 'response')] }),
+      NOW,
+    )
+    expect(target).toEqual({ kind: 'passthrough', deltaId: 'msg-2' })
+  })
+
+  it('creates a post-permission split bubble (new id = <id>-post-<now>)', () => {
+    const target = resolveStreamDeltaTarget(
+      'msg-3',
+      resolverState({ postPermissionSplits: ['msg-3'] }),
+      NOW,
+    )
+    expect(target).toEqual({
+      kind: 'permission-split',
+      deltaId: 'msg-3',
+      newId: `msg-3-post-${NOW}`,
+    })
+  })
+
+  it('prefers the permission split over an existing remap for the same id', () => {
+    const target = resolveStreamDeltaTarget(
+      'msg-4',
+      resolverState({
+        postPermissionSplits: ['msg-4'],
+        deltaIdRemaps: [['msg-4', 'msg-4-other']],
+      }),
+      NOW,
+    )
+    expect(target).toEqual({
+      kind: 'permission-split',
+      deltaId: 'msg-4',
+      newId: `msg-4-post-${NOW}`,
+    })
+  })
+
+  it('follows a single-hop remap when one exists', () => {
+    const target = resolveStreamDeltaTarget(
+      'msg-5',
+      resolverState({ deltaIdRemaps: [['msg-5', 'msg-5-cont-999']] }),
+      NOW,
+    )
+    expect(target).toEqual({ kind: 'remap', deltaId: 'msg-5-cont-999' })
+  })
+
+  it('suffixes onto a fresh -response bubble when the id is a tool_use slot', () => {
+    const target = resolveStreamDeltaTarget(
+      'msg-6',
+      resolverState({
+        resolvedMessages: [msg('msg-6', 'tool_use')],
+        targetForSuffix: 'sess-1',
+      }),
+      NOW,
+    )
+    expect(target).toEqual({
+      kind: 'suffix',
+      deltaId: 'msg-6-response',
+      remapKey: 'msg-6',
+      suffixedId: 'msg-6-response',
+      targetForSuffix: 'sess-1',
+      needsAppend: true,
+    })
+  })
+
+  it('suffix verdict sets needsAppend=false when the -response bubble already exists', () => {
+    const target = resolveStreamDeltaTarget(
+      'msg-7',
+      resolverState({
+        resolvedMessages: [msg('msg-7', 'tool_use'), msg('msg-7-response', 'response')],
+        targetForSuffix: null,
+      }),
+      NOW,
+    )
+    expect(target).toEqual({
+      kind: 'suffix',
+      deltaId: 'msg-7-response',
+      remapKey: 'msg-7',
+      suffixedId: 'msg-7-response',
+      targetForSuffix: null,
+      needsAppend: false,
+    })
+  })
+
+  it('does NOT suffix a thinking/error slot away from response — only non-response slots route', () => {
+    // Mirrors the inline guard `existing && existing.type !== 'response'`: a
+    // tool_use is the reused-id case, but a non-response slot of any other type
+    // also suffixes. A response slot passes through (covered above); an absent
+    // slot passes through too.
+    const thinking = resolveStreamDeltaTarget(
+      'msg-8',
+      resolverState({ resolvedMessages: [msg('msg-8', 'thinking')] }),
+      NOW,
+    )
+    expect(thinking.kind).toBe('suffix')
+  })
+})

--- a/packages/store-core/src/handlers/stream-delta-target.test.ts
+++ b/packages/store-core/src/handlers/stream-delta-target.test.ts
@@ -8,6 +8,8 @@ import { resolveStreamDeltaTarget } from './stream'
 import type { ChatMessage } from '../types'
 
 const NOW = 1_700_000_000_000
+// resolveStreamDeltaTarget reads the clock lazily via a thunk (#6036 review).
+const nowFn = () => NOW
 
 function resolverState(opts: {
   postPermissionSplits?: string[]
@@ -31,7 +33,7 @@ function msg(id: string, type: ChatMessage['type']): ChatMessage {
 
 describe('resolveStreamDeltaTarget', () => {
   it('passes through when the id is unknown to every collection', () => {
-    const target = resolveStreamDeltaTarget('msg-1', resolverState({}), NOW)
+    const target = resolveStreamDeltaTarget('msg-1', resolverState({}), nowFn)
     expect(target).toEqual({ kind: 'passthrough', deltaId: 'msg-1' })
   })
 
@@ -39,7 +41,7 @@ describe('resolveStreamDeltaTarget', () => {
     const target = resolveStreamDeltaTarget(
       'msg-2',
       resolverState({ resolvedMessages: [msg('msg-2', 'response')] }),
-      NOW,
+      nowFn,
     )
     expect(target).toEqual({ kind: 'passthrough', deltaId: 'msg-2' })
   })
@@ -48,7 +50,7 @@ describe('resolveStreamDeltaTarget', () => {
     const target = resolveStreamDeltaTarget(
       'msg-3',
       resolverState({ postPermissionSplits: ['msg-3'] }),
-      NOW,
+      nowFn,
     )
     expect(target).toEqual({
       kind: 'permission-split',
@@ -64,7 +66,7 @@ describe('resolveStreamDeltaTarget', () => {
         postPermissionSplits: ['msg-4'],
         deltaIdRemaps: [['msg-4', 'msg-4-other']],
       }),
-      NOW,
+      nowFn,
     )
     expect(target).toEqual({
       kind: 'permission-split',
@@ -77,7 +79,7 @@ describe('resolveStreamDeltaTarget', () => {
     const target = resolveStreamDeltaTarget(
       'msg-5',
       resolverState({ deltaIdRemaps: [['msg-5', 'msg-5-cont-999']] }),
-      NOW,
+      nowFn,
     )
     expect(target).toEqual({ kind: 'remap', deltaId: 'msg-5-cont-999' })
   })
@@ -89,7 +91,7 @@ describe('resolveStreamDeltaTarget', () => {
         resolvedMessages: [msg('msg-6', 'tool_use')],
         targetForSuffix: 'sess-1',
       }),
-      NOW,
+      nowFn,
     )
     expect(target).toEqual({
       kind: 'suffix',
@@ -108,7 +110,7 @@ describe('resolveStreamDeltaTarget', () => {
         resolvedMessages: [msg('msg-7', 'tool_use'), msg('msg-7-response', 'response')],
         targetForSuffix: null,
       }),
-      NOW,
+      nowFn,
     )
     expect(target).toEqual({
       kind: 'suffix',
@@ -120,7 +122,7 @@ describe('resolveStreamDeltaTarget', () => {
     })
   })
 
-  it('does NOT suffix a thinking/error slot away from response — only non-response slots route', () => {
+  it('suffixes ANY non-response slot (e.g. thinking), mirroring the tool_use case', () => {
     // Mirrors the inline guard `existing && existing.type !== 'response'`: a
     // tool_use is the reused-id case, but a non-response slot of any other type
     // also suffixes. A response slot passes through (covered above); an absent
@@ -128,7 +130,7 @@ describe('resolveStreamDeltaTarget', () => {
     const thinking = resolveStreamDeltaTarget(
       'msg-8',
       resolverState({ resolvedMessages: [msg('msg-8', 'thinking')] }),
-      NOW,
+      nowFn,
     )
     expect(thinking.kind).toBe('suffix')
   })

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -824,6 +824,98 @@ export interface StreamDeltaContext {
 }
 
 /**
+ * The decision (`sharedStreamDelta`'s first responsibility, #6036) for which
+ * response slot an incoming delta belongs to, surfaced as data so the
+ * mutating caller stays separate from the routing logic. One of:
+ *
+ *   - `permission-split` — the id was flagged for a post-permission split, so a
+ *     fresh `<deltaId>-post-<now>` bubble is created and the old id remaps to it.
+ *   - `remap` — a single-hop remap already exists for the id; follow it.
+ *   - `suffix` — the id resolves to a NON-response bubble (a tool_use slot the
+ *     server reused), so route to a lazily-created `<deltaId>-response` bubble.
+ *   - `passthrough` — the id already targets the right response slot; no change.
+ */
+export type StreamDeltaTarget =
+  | { kind: 'permission-split'; deltaId: string; newId: string }
+  | { kind: 'remap'; deltaId: string }
+  | {
+      kind: 'suffix'
+      deltaId: string
+      /** The ORIGINAL (pre-suffix) id the caller must key the remap on. */
+      remapKey: string
+      suffixedId: string
+      targetForSuffix: string | null
+      needsAppend: boolean
+    }
+  | { kind: 'passthrough'; deltaId: string }
+
+/**
+ * Resolve which response slot an incoming `stream_delta` targets (#6036 — the
+ * first responsibility carved out of {@link sharedStreamDelta}). This is the
+ * pure decision half of the bubble-merge / stream_start-id reuse (#5697/#2546)
+ * logic: given the current id and the live state (the post-permission-split
+ * set, the remap map, and the resolved messages array), it returns the final
+ * `deltaId` plus a {@link StreamDeltaTarget} verdict describing the side
+ * effects the caller must apply. It performs NO mutation — the caller deletes
+ * from `postPermissionSplits`, writes `deltaIdRemaps`, and appends slots — so
+ * behaviour is byte-identical to the previous inline branch while being unit
+ * testable in isolation.
+ *
+ * @param incomingId The currently-resolved delta id (post original capture).
+ * @param state Membership + resolver snapshots from {@link StreamDeltaContext}.
+ * @param now Clock value for the post-permission split's `-post-<now>` id
+ *   (injected so the result is deterministic in tests; production passes
+ *   `Date.now()`).
+ */
+export function resolveStreamDeltaTarget(
+  incomingId: string,
+  state: {
+    postPermissionSplits: Set<string>
+    deltaIdRemaps: Map<string, string>
+    /**
+     * Resolve the effective messages array + session id the SAME way the
+     * defensive branch did: prefer the captured session's state, else the
+     * active session's, else the flat fallback (dashboard) — supplied as a
+     * thunk so the caller owns the platform-divergent resolution.
+     */
+    resolveMessages: () => {
+      resolvedMessages: readonly ChatMessage[]
+      targetForSuffix: string | null
+    }
+  },
+  now: number,
+): StreamDeltaTarget {
+  // Permission boundary split: first delta after a split creates a new message.
+  if (state.postPermissionSplits.has(incomingId)) {
+    const newId = `${incomingId}-post-${now}`
+    return { kind: 'permission-split', deltaId: incomingId, newId }
+  }
+  if (state.deltaIdRemaps.has(incomingId)) {
+    return { kind: 'remap', deltaId: state.deltaIdRemaps.get(incomingId)! }
+  }
+  // Defensive: server reuses messageId for tool_start and the post-tool
+  // stream_start. If stream_start was dropped or hasn't registered the remap
+  // yet, the delta would otherwise concatenate onto the tool_use bubble.
+  // Detect that here and route to a suffixed response id, lazy-creating the
+  // bubble.
+  const { resolvedMessages, targetForSuffix } = state.resolveMessages()
+  const existing = resolvedMessages.find((m) => m.id === incomingId)
+  if (existing && existing.type !== 'response') {
+    const suffixedId = `${incomingId}-response`
+    const needsAppend = !resolvedMessages.some((m) => m.id === suffixedId)
+    return {
+      kind: 'suffix',
+      deltaId: suffixedId,
+      remapKey: incomingId,
+      suffixedId,
+      targetForSuffix,
+      needsAppend,
+    }
+  }
+  return { kind: 'passthrough', deltaId: incomingId }
+}
+
+/**
  * Shared `stream_delta` handler (#4981). Owns the platform-neutral hot path:
  * the #4297 reorder dispatch, post-permission split, single-hop defensive
  * remap, post-tool continuation split (#4889) with the mid-sentence gate
@@ -903,13 +995,35 @@ export function sharedStreamDelta(
     return { sessionMessages, effectiveSessionId }
   }
 
-  // Permission boundary split: first delta after a split creates a new message.
-  if (ctx.postPermissionSplits.has(deltaId)) {
-    ctx.postPermissionSplits.delete(deltaId)
-    const newId = `${deltaId}-post-${Date.now()}`
-    ctx.deltaIdRemaps.set(deltaId, newId)
+  // #6036 — the target/reuse DECISION (permission split vs single-hop remap vs
+  // defensive `-response` suffix vs passthrough) lives in the pure
+  // `resolveStreamDeltaTarget`; this block only APPLIES the verdict's side
+  // effects, keeping the routing logic separately testable. The resolver re-
+  // reads `resolveSession()` itself (the defensive branch needs the captured→
+  // active→flat chain), so the `now` for the `-post-` id is captured up front
+  // exactly as the inline `${deltaId}-post-${Date.now()}` did. `newMsg`'s
+  // `timestamp` keeps its own `Date.now()` call, identical to before.
+  const target = resolveStreamDeltaTarget(
+    deltaId,
+    {
+      postPermissionSplits: ctx.postPermissionSplits,
+      deltaIdRemaps: ctx.deltaIdRemaps,
+      resolveMessages: () => {
+        const { sessionMessages, effectiveSessionId } = resolveSession()
+        return {
+          resolvedMessages: sessionMessages ?? ctx.getFlatMessages(),
+          targetForSuffix: sessionMessages ? effectiveSessionId : null,
+        }
+      },
+    },
+    Date.now(),
+  )
+  if (target.kind === 'permission-split') {
+    // Permission boundary split: first delta after a split creates a new message.
+    ctx.postPermissionSplits.delete(target.deltaId)
+    ctx.deltaIdRemaps.set(target.deltaId, target.newId)
     const newMsg: ChatMessage = {
-      id: newId,
+      id: target.newId,
       type: 'response',
       content: '',
       timestamp: Date.now(),
@@ -922,36 +1036,25 @@ export function sharedStreamDelta(
     //   - app: captured session when it has state, ELSE the active session;
     //     session-only (no flat fallback).
     ctx.appendResponseSlot(capturedSessionId, newMsg)
-    deltaId = newId
-  } else if (ctx.deltaIdRemaps.has(deltaId)) {
-    deltaId = ctx.deltaIdRemaps.get(deltaId)!
-  } else {
+    deltaId = target.newId
+  } else if (target.kind === 'remap') {
+    deltaId = target.deltaId
+  } else if (target.kind === 'suffix') {
     // Defensive: server reuses messageId for tool_start and the post-tool
     // stream_start. If stream_start was dropped or hasn't registered the
     // remap yet (e.g., session not in store at the time), the delta would
     // otherwise concatenate onto the tool_use bubble. Detect that here and
-    // route to a suffixed response id, lazy-creating the bubble.
-    //
-    // Resolve the effective target the same way both call sites did: prefer
-    // the captured session when it has state, else the active session; fall
-    // through to the flat messages when neither has session state (dashboard
-    // only — the app's `getSessionMessages`/`getFlatMessages` keep it inert).
-    const { sessionMessages, effectiveSessionId } = resolveSession()
-    const resolvedMessages = sessionMessages ?? ctx.getFlatMessages()
-    const targetForSuffix = sessionMessages ? effectiveSessionId : null
-    const existing = resolvedMessages.find((m) => m.id === deltaId)
-    if (existing && existing.type !== 'response') {
-      const suffixed = `${deltaId}-response`
-      ctx.deltaIdRemaps.set(deltaId, suffixed)
-      if (!resolvedMessages.some((m) => m.id === suffixed)) {
-        ctx.appendResponseSlot(
-          targetForSuffix,
-          { id: suffixed, type: 'response', content: '', timestamp: Date.now() },
-          { onlyIfAbsent: true },
-        )
-      }
-      deltaId = suffixed
+    // route to a suffixed response id, lazy-creating the bubble. The remap
+    // is keyed on the ORIGINAL (pre-suffix) id the resolver carried back.
+    ctx.deltaIdRemaps.set(target.remapKey, target.suffixedId)
+    if (target.needsAppend) {
+      ctx.appendResponseSlot(
+        target.targetForSuffix,
+        { id: target.suffixedId, type: 'response', content: '', timestamp: Date.now() },
+        { onlyIfAbsent: true },
+      )
     }
+    deltaId = target.deltaId
   }
 
   // #4889 — post-tool continuation split. The server reuses ONE messageId for

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -863,9 +863,10 @@ export type StreamDeltaTarget =
  *
  * @param incomingId The currently-resolved delta id (post original capture).
  * @param state Membership + resolver snapshots from {@link StreamDeltaContext}.
- * @param now Clock value for the post-permission split's `-post-<now>` id
- *   (injected so the result is deterministic in tests; production passes
- *   `Date.now()`).
+ * @param nowFn Clock thunk for the post-permission split's `-post-<now>` id,
+ *   read LAZILY (only on the split path) so a plain delta never pays a
+ *   `Date.now()` call. Injected for deterministic tests; production passes
+ *   `Date.now`.
  */
 export function resolveStreamDeltaTarget(
   incomingId: string,
@@ -883,11 +884,14 @@ export function resolveStreamDeltaTarget(
       targetForSuffix: string | null
     }
   },
-  now: number,
+  nowFn: () => number,
 ): StreamDeltaTarget {
   // Permission boundary split: first delta after a split creates a new message.
   if (state.postPermissionSplits.has(incomingId)) {
-    const newId = `${incomingId}-post-${now}`
+    // Read the clock lazily — only this (rare) split path needs it, so a plain
+    // delta on the hot path pays no Date.now() call (matches the pre-refactor
+    // inline behavior where the timestamp was only read inside this branch).
+    const newId = `${incomingId}-post-${nowFn()}`
     return { kind: 'permission-split', deltaId: incomingId, newId }
   }
   if (state.deltaIdRemaps.has(incomingId)) {
@@ -1016,7 +1020,7 @@ export function sharedStreamDelta(
         }
       },
     },
-    Date.now(),
+    Date.now,
   )
   if (target.kind === 'permission-split') {
     // Permission boundary split: first delta after a split creates a new message.


### PR DESCRIPTION
## Summary

SRP refactor flagged by the SOLID/DRY swarm-audit — carve two responsibilities out of the two god-functions, with **zero behaviour change**. Both are pure-function extractions covered by new focused unit tests plus the existing suites.

Closes #6036

## 1. `createSession` plan resolution (server)

`packages/server/src/session-manager.js` — extracted the `createSession` front-half into a new instance method:

```js
_resolveCreateSessionPlan({ name, cwd, model, permissionMode, provider, worktree,
  restoreWorktreePath, restoreWorktreeRepoDir, sessionPreamble, preserveId, isRestore })
  → { sessionId, sessionName, resolvedCwd, resolvedModel, resolvedPermissionMode,
      resolvedProvider, ProviderClass, worktreePath, worktreeRepoDir,
      presetDescriptor, effectiveSessionPreamble }
```

It owns exactly the preflight + isolation + provider/preset resolution concerns: the session-limit guard, cwd existence check, id generation (preserve-id #4983) + name, the #2962 provider preflight, the #5985 user-shell fail-closed gate, the #3403 model soft-fallback, worktree create / #5310 restore-rebind, and the #5553 preset fold. `createSession` now consumes the validated plan to build `providerOpts`, construct, register, and start.

**Why behaviour is identical:** the front-half logic was moved verbatim — the same checks run in the same order and throw the same errors (`SessionLimitError`, `SessionDirectoryError`, `WorktreeError`, `UserShellDisabledError`, `ProviderModelNotSupportedError`). The `++this._sessionCounter` name increment keeps its original position (before preflight). Both halves stay in the same file so opt forwarding still reads next to the construction it feeds (the #3224/#3231/#4790 "middle-layer trap" area).

## 2. `sharedStreamDelta` target resolution (store-core)

`packages/store-core/src/handlers/stream.ts` — extracted the target/reuse decision into a pure function:

```ts
resolveStreamDeltaTarget(incomingId, { postPermissionSplits, deltaIdRemaps, resolveMessages }, now)
  → StreamDeltaTarget  // 'permission-split' | 'remap' | 'suffix' | 'passthrough'
```

This is the pure decision half of the bubble-merge / stream_start-id reuse (#5697/#2546) logic. It returns the final `deltaId` plus a verdict describing the side effects; `sharedStreamDelta` applies them (deletes from `postPermissionSplits`, writes `deltaIdRemaps`, appends slots). The resolver performs **no** mutation.

**Why behaviour is identical:** the three-way `if/else-if/else` branch was translated 1:1 into the verdict + an apply block. The post-permission `-post-<now>` id is computed from an injected `now` (production passes `Date.now()`, exactly as the inline `${deltaId}-post-${Date.now()}` did); `newMsg.timestamp` keeps its own `Date.now()` call. The defensive `-response` suffix remap stays keyed on the original (pre-suffix) id.

## Tests

- `packages/server/tests/session-manager-create-plan.test.js` (9 cases) — id/name/cwd/model/permission/provider resolution, preserve-id handling, the `SessionLimitError` / `SessionDirectoryError` throws, and the model strict-reject (non-Claude) vs #3403 soft-fallback (Claude-family) fork.
- `packages/store-core/src/handlers/stream-delta-target.test.ts` (8 cases) — each verdict kind, branch precedence (permission-split over remap), and the suffix `needsAppend` flag.

## Validation

- store-core: full suite green (1653 tests / 41 files), `tsc --noEmit` clean.
- server: new test 9/9; existing `session-manager` + `preflight` + `worktree` + `naming-counter` + `skip-permissions` + `user-shell-gate` suites 252/252; `eslint` clean.
- `lint-session-opt-forwarding.sh` OK; `lint-tests-state-file-path.sh` OK.