### PR TITLE
refactor(store-core): extract shared connection runtime (heartbeat/handshake) (#6035)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -128,12 +128,21 @@ import {
   formatPartialCostLine,
   // #5515 (epic #5514): latency instrumentation primitives.
   RollingPercentiles,
-  splitRtt,
   // #5556 (epic #5514): shared stateful EWMA RTT smoother.
   RttSmoother,
   // #5556 (epic #5514): shared delta-flusher wiring (accumulator + timer +
   // override) — the client supplies only its `applyDeltas` store mutation.
   createDeltaFlusher,
+  // #6035: shared connection runtime — the heartbeat ping loop, pong-timeout
+  // reaper, handshake-window timer, and pong RTT measurement (formerly the
+  // byte-identical copy shared with the dashboard). The app injects its wsSend /
+  // quality-write sink / owned RttSmoother / latency-log hook. Constants aliased
+  // so the local `HEARTBEAT_INTERVAL_MS` / `HANDSHAKE_TIMEOUT_MS` exports
+  // re-source them.
+  createHeartbeatController,
+  HEARTBEAT_INTERVAL_MS as SC_HEARTBEAT_INTERVAL_MS,
+  HANDSHAKE_TIMEOUT_MS as SC_HANDSHAKE_TIMEOUT_MS,
+  LATENCY_LOG_INTERVAL_MS as SC_LATENCY_LOG_INTERVAL_MS,
   // epic #5556, sub-item 3: shared client message dispatch table.
   // Pure-delegation cases that were byte-identical with the dashboard route
   // through this table; a miss falls through to the switch below unchanged.
@@ -142,6 +151,7 @@ import {
 } from '@chroxy/store-core';
 import type {
   DeltaFlusher,
+  HeartbeatController,
   ClientStoreAdapter,
   DispatchCallbackName,
   DispatchCallbackPayload,
@@ -264,15 +274,17 @@ interface MessageHandlerContext extends EncryptionContext {
   pendingTerminalWrites: string;
   terminalWriteTimer: ReturnType<typeof setTimeout> | null;
 
-  // Client-side heartbeat
-  heartbeatInterval: ReturnType<typeof setInterval> | null;
-  pongTimeout: ReturnType<typeof setTimeout> | null;
-  lastPingSentAt: number;
-  // #5962 (#5721 parity) — client-side handshake timeout. The heartbeat does NOT
-  // start until auth_ok, so the handshake window has no liveness coverage; this
-  // timer drops a wedged half-open socket and hands off to the reconnect ladder.
-  handshakeTimeout: ReturnType<typeof setTimeout> | null;
+  // Client-side heartbeat + handshake timeout (#6035): the ping loop, the
+  // pong-timeout reaper, the handshake-window timer, and the pong RTT
+  // measurement now live in the shared `createHeartbeatController`
+  // (store-core/connection-runtime), lifted from the byte-identical copy this
+  // file shared with the dashboard. Lives on the context (one per connection)
+  // so `resetAllHandlerState` tears it down by replacing the context, exactly
+  // like the heartbeat fields it replaces.
+  heartbeat: HeartbeatController<WebSocket>;
   // #5556: EWMA-smoothed RTT (replaces the inlined `ewmaRtt` accumulator).
+  // Declared here (not inside the controller) because the delta-flusher also
+  // reads `rttSmoother.value` for its adaptive interval.
   rttSmoother: RttSmoother;
 
   // Delta batching (#5556): the accumulator map + coalescing timer + adaptive
@@ -312,10 +324,11 @@ function createDefaultContext(): MessageHandlerContext {
     deltaIdRemaps: new Map<string, string>(),
     pendingTerminalWrites: '',
     terminalWriteTimer: null,
-    heartbeatInterval: null,
-    pongTimeout: null,
-    lastPingSentAt: 0,
-    handshakeTimeout: null,
+    // #6035: the shared heartbeat + handshake controller, injected with the
+    // app's platform-specific effects. Built below (after `ctx` exists) so its
+    // `onLatencyLog` can gate on THIS context's shared `lastLatencyLogAt`
+    // throttle cursor (the same cursor the delta-flush latency path uses).
+    heartbeat: null as unknown as HeartbeatController<WebSocket>,
     rttSmoother,
     // #5556: the flusher owns the accumulator + coalescing timer + adaptive
     // window, sizing it off this context's own RttSmoother. `applyDeltas` is
@@ -331,6 +344,21 @@ function createDefaultContext(): MessageHandlerContext {
     messageQueue: [],
     serverWillBootstrap: false,
   };
+  ctx.heartbeat = createHeartbeatController({
+    wsSend,
+    rttSmoother,
+    onPongQuality: (latencyMs, quality) => {
+      useConnectionLifecycleStore.getState().setConnectionQuality(latencyMs, quality);
+    },
+    onLatencyLog: (line, pongRecvAt) => {
+      // #5515: throttle the dev split log on the shared cursor (also used by
+      // recordLatencySamples), so a streaming turn can't spam the console.
+      if (pongRecvAt - ctx.lastLatencyLogAt >= LATENCY_LOG_INTERVAL_MS) {
+        ctx.lastLatencyLogAt = pongRecvAt;
+        console.log(line);
+      }
+    },
+  });
   return ctx;
 }
 
@@ -344,9 +372,11 @@ let _ctx: MessageHandlerContext = createDefaultContext();
 export function resetAllHandlerState(): void {
   // Clear pending timers before overwriting
   if (_ctx.terminalWriteTimer) clearTimeout(_ctx.terminalWriteTimer);
-  if (_ctx.heartbeatInterval) clearInterval(_ctx.heartbeatInterval);
-  if (_ctx.pongTimeout) clearTimeout(_ctx.pongTimeout);
-  if (_ctx.handshakeTimeout) clearTimeout(_ctx.handshakeTimeout);
+  // #6035: the controller owns the heartbeat/pong/handshake timers — tear them
+  // down through it (stopHeartbeat clears the interval + pong timeout; the
+  // handshake clear cancels the handshake-window timer) before replacing ctx.
+  _ctx.heartbeat.stopHeartbeat();
+  _ctx.heartbeat.clearHandshakeTimer();
   _ctx.deltaFlusher.dispose();
   _ctx = createDefaultContext();
   _pendingPermissionModeRequests.clear();
@@ -730,13 +760,14 @@ export const SUBSCRIBE_SESSIONS_CHUNK_SIZE = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE;
 // Exported (#5633) so the AppState resume handler can use the real heartbeat
 // cadence as its "was the app backgrounded long enough for the socket to have
 // silently died?" threshold, rather than hardcoding a separate magic number
-// that could drift from this one.
-export const HEARTBEAT_INTERVAL_MS = 15_000;
-const PONG_TIMEOUT_MS = 5_000;
+// that could drift from this one. #6035: re-sourced from store-core so the app
+// and dashboard can't drift.
+export const HEARTBEAT_INTERVAL_MS = SC_HEARTBEAT_INTERVAL_MS;
 // #5515 (epic #5514): throttle the dev latency readout so a streaming turn
 // can't spam the console — one line every few seconds is enough to watch the
-// numbers move when flush intervals are tuned.
-const LATENCY_LOG_INTERVAL_MS = 3_000;
+// numbers move when flush intervals are tuned. Shared with recordLatencySamples
+// (the delta-flush latency path) via the same throttle window (#6035).
+const LATENCY_LOG_INTERVAL_MS = SC_LATENCY_LOG_INTERVAL_MS;
 
 // #5516 (epic #5514): adaptive delta-flush interval. Production reads the
 // current EWMA RTT and adapts (16-33ms cheap → 100ms poor) via
@@ -747,78 +778,37 @@ export function setDeltaFlushIntervalOverride(ms: number | null): void {
   _ctx.deltaFlusher.setIntervalOverride(ms);
 }
 
+// #6035: the heartbeat ping loop, the pong-timeout reaper, the handshake-window
+// timer, and the pong RTT measurement live in the shared
+// `createHeartbeatController` on the context. These exported wrappers delegate
+// to it so connection.ts's call sites and the test suites keep the same
+// `startHeartbeat`/`stopHeartbeat`/`armHandshakeTimer`/`clearHandshakeTimer`
+// contract.
 export function stopHeartbeat(): void {
-  if (_ctx.heartbeatInterval) { clearInterval(_ctx.heartbeatInterval); _ctx.heartbeatInterval = null; }
-  if (_ctx.pongTimeout) { clearTimeout(_ctx.pongTimeout); _ctx.pongTimeout = null; }
-  _ctx.lastPingSentAt = 0;
-  _ctx.rttSmoother.reset(); // Reset smoothed RTT on disconnect
+  _ctx.heartbeat.stopHeartbeat();
 }
 
 export function startHeartbeat(socket: WebSocket): void {
-  stopHeartbeat();
-  _ctx.heartbeatInterval = setInterval(() => {
-    if (socket.readyState !== WebSocket.OPEN) { stopHeartbeat(); return; }
-    try {
-      _ctx.lastPingSentAt = Date.now();
-      wsSend(socket, { type: 'ping' });
-    } catch { stopHeartbeat(); return; }
-    _ctx.pongTimeout = setTimeout(() => {
-      console.warn('[ws] Heartbeat pong timeout — closing dead connection');
-      stopHeartbeat();
-      try { socket.close(); } catch {}
-    }, PONG_TIMEOUT_MS);
-  }, HEARTBEAT_INTERVAL_MS);
+  _ctx.heartbeat.startHeartbeat(socket);
 }
 
-// #5962 (#5721 parity) — client-side handshake timeout. Mirrors the dashboard
-// (packages/dashboard/src/store/message-handler.ts). The heartbeat above does
-// NOT start until auth_ok is processed, so the handshake window (socket OPEN +
-// auth/pair sent, awaiting auth_ok/key_exchange_ok) has zero liveness coverage:
-// a server that opens the socket but never completes the handshake leaves the
-// client wedged until the transport drops on its own. A ~10s timer — comfortably
-// below the ~20s worst-case heartbeat detection once connected — hands off to the
-// normal reconnect ladder ("Handshake failed — reconnecting") instead of a
-// silent stall. Exported so connection.ts arms/clears it around the socket
-// lifecycle and tests can read the budget.
-export const HANDSHAKE_TIMEOUT_MS = 10_000;
+// #5962 (#5721 parity) — client-side handshake timeout budget (re-exported from
+// store-core so connection.ts and the tests can read it). The heartbeat does
+// NOT start until auth_ok is processed, so the handshake window had no liveness
+// coverage before this timer; it hands off to the reconnect ladder ("Handshake
+// failed — reconnecting") instead of a silent stall.
+export const HANDSHAKE_TIMEOUT_MS = SC_HANDSHAKE_TIMEOUT_MS;
 
-// Arm the handshake timer with the caller's fire behaviour. The fire callback is
-// injected (not built here) because the reconnect machinery it needs lives in
-// connection.ts's per-socket closure. Clears any prior timer first
-// (single-instance, mirroring startHeartbeat) so a reconnect that re-enters
-// onopen can never leak a second pending timer.
 export function armHandshakeTimer(onTimeout: () => void): void {
-  clearHandshakeTimer();
-  _ctx.handshakeTimeout = setTimeout(onTimeout, HANDSHAKE_TIMEOUT_MS);
+  _ctx.heartbeat.armHandshakeTimer(onTimeout);
 }
 
 export function clearHandshakeTimer(): void {
-  if (_ctx.handshakeTimeout) { clearTimeout(_ctx.handshakeTimeout); _ctx.handshakeTimeout = null; }
+  _ctx.heartbeat.clearHandshakeTimer();
 }
 
 function _onPong(serverTs?: number): void {
-  if (_ctx.pongTimeout) { clearTimeout(_ctx.pongTimeout); _ctx.pongTimeout = null; }
-  // Measure RTT and update connection quality using EWMA for stability
-  if (_ctx.lastPingSentAt > 0) {
-    const pongRecvAt = Date.now();
-    const rttMs = pongRecvAt - _ctx.lastPingSentAt;
-    // EWMA: smoothed = alpha * new + (1 - alpha) * prev (first sample bootstraps)
-    const smoothed = Math.round(_ctx.rttSmoother.update(rttMs));
-    const quality: 'good' | 'fair' | 'poor' = smoothed < 200 ? 'good' : smoothed < 500 ? 'fair' : 'poor';
-    useConnectionLifecycleStore.getState().setConnectionQuality(smoothed, quality);
-
-    // #5515 (epic #5514): split this RTT into approximate uplink/downlink
-    // halves using the server-stamped serverTs. The split is positioned within
-    // the locally-measured [ping,pong] interval (skew-clamped), so it stays
-    // sane even with clock skew — see store-core/latency-stats. Dev-only log,
-    // throttled by the same window as token-to-render.
-    const split = splitRtt({ pingSentAt: _ctx.lastPingSentAt, pongRecvAt, serverTs });
-    if (split.uplinkMs !== null && pongRecvAt - _ctx.lastLatencyLogAt >= LATENCY_LOG_INTERVAL_MS) {
-      _ctx.lastLatencyLogAt = pongRecvAt;
-      console.log(`[latency] rtt=${split.rttMs}ms split≈ up ${split.uplinkMs}ms / down ${split.downlinkMs}ms (approx, clock-skew)`);
-    }
-    _ctx.lastPingSentAt = 0;
-  }
+  _ctx.heartbeat.handlePong(serverTs);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -129,9 +129,17 @@ import {
   formatPartialCostLine,
   // #5515 (epic #5514): latency instrumentation primitives.
   RollingPercentiles,
-  splitRtt,
   // #5556 (epic #5514): shared stateful EWMA RTT smoother.
   RttSmoother,
+  // #6035: shared connection runtime — the heartbeat ping loop, pong-timeout
+  // reaper, handshake-window timer, and pong RTT measurement. The dashboard
+  // injects its wsSend / quality-write sink / owned RttSmoother / latency-log
+  // hook; the timer mechanics are shared with the app. Constants aliased so the
+  // local `HEARTBEAT_INTERVAL_MS` / `HANDSHAKE_TIMEOUT_MS` exports re-source them.
+  createHeartbeatController,
+  HEARTBEAT_INTERVAL_MS as SC_HEARTBEAT_INTERVAL_MS,
+  HANDSHAKE_TIMEOUT_MS as SC_HANDSHAKE_TIMEOUT_MS,
+  LATENCY_LOG_INTERVAL_MS as SC_LATENCY_LOG_INTERVAL_MS,
   // #5556 (epic #5514): shared delta-flusher wiring (accumulator + timer +
   // override) — the dashboard supplies only its `applyDeltas` store mutation.
   createDeltaFlusher,
@@ -699,100 +707,77 @@ export function clearTerminalWriteBatching(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Client-side heartbeat
+// Client-side heartbeat + handshake timeout
 // ---------------------------------------------------------------------------
-let _heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-let _pongTimeout: ReturnType<typeof setTimeout> | null = null;
-let _lastPingSentAt = 0;
-// #5556: EWMA-smoothed RTT for stable quality display (shared smoother).
+// #6035: the heartbeat ping loop, the pong-timeout reaper, the handshake-window
+// timer, and the pong RTT measurement now live in the shared
+// `createHeartbeatController` (store-core/connection-runtime), lifted from the
+// byte-identical copy this file shared with the app's message-handler.ts. The
+// dashboard injects only the genuinely platform-specific effects: its `wsSend`
+// (E2E envelope), the quality-write sink (`getStore().setState`), the owned
+// `_rttSmoother` (also read by the delta-flusher), and the latency-log hook
+// that gates on the shared `_lastLatencyLogAt` throttle cursor.
+//
+// `_rttSmoother` stays declared here (not inside the controller) because the
+// delta-flusher reads `_rttSmoother.value` for its adaptive interval (#5556).
 const _rttSmoother = new RttSmoother();
-const HEARTBEAT_INTERVAL_MS = 15_000;
-const PONG_TIMEOUT_MS = 5_000;
-
-// #5721 (item 2) — client-side handshake timeout. The heartbeat above does NOT
-// start until `auth_ok` is processed (see startHeartbeat's caller), so the
-// handshake window (socket OPEN + `auth`/`pair` sent, awaiting
-// `auth_ok`/`key_exchange_ok`) has zero liveness coverage: a server that opens
-// the socket but never completes the handshake leaves the client wedged in
-// `connecting`/`reconnecting` until the transport drops on its own. A dedicated
-// ~10s timer — comfortably below the ~20s worst-case heartbeat detection once
-// connected — surfaces "Handshake failed — reconnecting" and hands off to the
-// normal reconnect ladder instead of a silent stall. Exported so connection.ts
-// arms/clears it around the socket lifecycle and tests can read the budget.
-export const HANDSHAKE_TIMEOUT_MS = 10_000;
-let _handshakeTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
-// Arm the handshake timer with the caller's fire behaviour. The fire callback
-// is injected (not built here) because the reconnect machinery it needs lives
-// in connection.ts's per-socket closure — the same inversion createReconnectScheduler
-// uses. Clears any prior timer first (single-instance, mirroring startHeartbeat)
-// so a reconnect that re-enters onopen can never leak a second pending timer.
-export function armHandshakeTimer(onTimeout: () => void): void {
-  clearHandshakeTimer();
-  _handshakeTimeoutId = setTimeout(onTimeout, HANDSHAKE_TIMEOUT_MS);
-}
-
-export function clearHandshakeTimer(): void {
-  if (_handshakeTimeoutId) { clearTimeout(_handshakeTimeoutId); _handshakeTimeoutId = null; }
-}
 
 // #5515 (epic #5514): latency instrumentation. `_deltaServerTs` records the
 // server-stamped serverTs (and local recv time) of the OLDEST un-rendered
 // delta per messageId; on flush we measure serverTs→render (token-to-render)
 // and recv→render (client render cost) into the rolling p50/p95 buffers. See
 // store-core/latency-stats for the clock discipline. Dev-only console readout,
-// throttled so a streaming turn can't spam the log.
-const LATENCY_LOG_INTERVAL_MS = 3_000;
+// throttled so a streaming turn can't spam the log. `_lastLatencyLogAt` is the
+// shared throttle cursor for BOTH the pong-split log (in the controller's
+// onLatencyLog hook below) and recordLatencySamples (the delta path).
 const _deltaServerTs = new Map<string, { serverTs: number; recvAt: number }>();
 const _tokenToRender = new RollingPercentiles(200);
 const _clientRender = new RollingPercentiles(200);
 let _lastLatencyLogAt = 0;
 
+const _heartbeat = createHeartbeatController({
+  wsSend,
+  rttSmoother: _rttSmoother,
+  onPongQuality: (latencyMs, quality) => {
+    getStore().setState({ latencyMs, connectionQuality: quality });
+  },
+  // The dashboard runs in the browser where WebSocket.OPEN === 1.
+  openReadyState: WebSocket.OPEN,
+  onLatencyLog: (line, pongRecvAt) => {
+    if (pongRecvAt - _lastLatencyLogAt >= LATENCY_LOG_INTERVAL_MS) {
+      _lastLatencyLogAt = pongRecvAt;
+      console.log(line);
+    }
+  },
+});
+
+export const HEARTBEAT_INTERVAL_MS = SC_HEARTBEAT_INTERVAL_MS;
+// #5721 (item 2) — client-side handshake timeout budget (re-exported from
+// store-core so connection.ts and the tests can read it). The heartbeat does
+// NOT start until `auth_ok` is processed, so the handshake window had no
+// liveness coverage before this timer; it hands off to the reconnect ladder
+// ("Handshake failed — reconnecting") instead of a silent stall.
+export const HANDSHAKE_TIMEOUT_MS = SC_HANDSHAKE_TIMEOUT_MS;
+const LATENCY_LOG_INTERVAL_MS = SC_LATENCY_LOG_INTERVAL_MS;
+
 export function stopHeartbeat(): void {
-  if (_heartbeatInterval) { clearInterval(_heartbeatInterval); _heartbeatInterval = null; }
-  if (_pongTimeout) { clearTimeout(_pongTimeout); _pongTimeout = null; }
-  _lastPingSentAt = 0;
-  _rttSmoother.reset(); // Reset smoothed RTT on disconnect
+  _heartbeat.stopHeartbeat();
 }
 
 export function startHeartbeat(socket: WebSocket): void {
-  stopHeartbeat();
-  _heartbeatInterval = setInterval(() => {
-    if (socket.readyState !== WebSocket.OPEN) { stopHeartbeat(); return; }
-    try {
-      _lastPingSentAt = Date.now();
-      wsSend(socket, { type: 'ping' });
-    } catch { stopHeartbeat(); return; }
-    _pongTimeout = setTimeout(() => {
-      console.warn('[ws] Heartbeat pong timeout — closing dead connection');
-      stopHeartbeat();
-      try { socket.close(); } catch {}
-    }, PONG_TIMEOUT_MS);
-  }, HEARTBEAT_INTERVAL_MS);
+  _heartbeat.startHeartbeat(socket);
+}
+
+export function armHandshakeTimer(onTimeout: () => void): void {
+  _heartbeat.armHandshakeTimer(onTimeout);
+}
+
+export function clearHandshakeTimer(): void {
+  _heartbeat.clearHandshakeTimer();
 }
 
 function _onPong(serverTs?: number): void {
-  if (_pongTimeout) { clearTimeout(_pongTimeout); _pongTimeout = null; }
-  // Measure RTT and update connection quality using EWMA for stability
-  if (_lastPingSentAt > 0) {
-    const pongRecvAt = Date.now();
-    const rttMs = pongRecvAt - _lastPingSentAt;
-    // EWMA: smoothed = alpha * new + (1 - alpha) * prev (first sample bootstraps)
-    const smoothed = Math.round(_rttSmoother.update(rttMs));
-    const quality: 'good' | 'fair' | 'poor' = smoothed < 200 ? 'good' : smoothed < 500 ? 'fair' : 'poor';
-    getStore().setState({ latencyMs: smoothed, connectionQuality: quality });
-
-    // #5515 (epic #5514): split this RTT into approximate uplink/downlink
-    // halves using the server-stamped serverTs, positioned within the locally-
-    // measured [ping,pong] interval (skew-clamped) — see store-core/latency-
-    // stats. Dev-only, throttled by the same window as token-to-render.
-    const split = splitRtt({ pingSentAt: _lastPingSentAt, pongRecvAt, serverTs });
-    if (split.uplinkMs !== null && pongRecvAt - _lastLatencyLogAt >= LATENCY_LOG_INTERVAL_MS) {
-      _lastLatencyLogAt = pongRecvAt;
-      console.log(`[latency] rtt=${split.rttMs}ms split≈ up ${split.uplinkMs}ms / down ${split.downlinkMs}ms (approx, clock-skew)`);
-    }
-    _lastPingSentAt = 0;
-  }
+  _heartbeat.handlePong(serverTs);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/connection-runtime.test.ts
+++ b/packages/store-core/src/connection-runtime.test.ts
@@ -1,0 +1,272 @@
+/**
+ * #6035 — unit tests for the shared connection runtime (heartbeat + handshake
+ * timeout + reconnect-backoff counter) lifted from the app/dashboard
+ * message-handlers. Uses vitest fake timers; the controller's default scheduler
+ * is the global timers, so fake timers drive it without any injection (matching
+ * how the client call sites run under jest/vitest fake timers).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  createHeartbeatController,
+  createReconnectCounter,
+  rttQuality,
+  HEARTBEAT_INTERVAL_MS,
+  PONG_TIMEOUT_MS,
+  HANDSHAKE_TIMEOUT_MS,
+  type HeartbeatSocket,
+} from './connection-runtime'
+import { RttSmoother } from './delta-flush'
+
+class FakeSocket implements HeartbeatSocket {
+  readyState = 1 // OPEN
+  sent: Array<Record<string, unknown>> = []
+  closed = 0
+  sendThrows = false
+  send(data: string): void {
+    if (this.sendThrows) throw new Error('send failed')
+    this.sent.push(JSON.parse(data))
+  }
+  close(): void {
+    this.closed += 1
+    this.readyState = 3 // CLOSED
+  }
+}
+
+function makeController(overrides: Partial<Parameters<typeof createHeartbeatController>[0]> = {}) {
+  const socket = new FakeSocket()
+  const smoother = new RttSmoother()
+  const quality: Array<{ latencyMs: number; quality: string }> = []
+  const wsSend = vi.fn((s: HeartbeatSocket, payload: Record<string, unknown>) => {
+    s.send(JSON.stringify(payload))
+  })
+  const controller = createHeartbeatController({
+    wsSend,
+    rttSmoother: smoother,
+    onPongQuality: (latencyMs, q) => quality.push({ latencyMs, quality: q }),
+    ...overrides,
+  })
+  return { controller, socket, smoother, quality, wsSend }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('createHeartbeatController — heartbeat', () => {
+  it('sends a ping every HEARTBEAT_INTERVAL_MS while the socket is OPEN', () => {
+    const { controller, socket, wsSend } = makeController()
+    controller.startHeartbeat(socket)
+    expect(controller.isHeartbeatRunning).toBe(true)
+
+    expect(wsSend).not.toHaveBeenCalled() // nothing before the first interval
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS)
+    expect(wsSend).toHaveBeenCalledTimes(1)
+    expect(socket.sent[0]).toEqual({ type: 'ping' })
+
+    // Answer the ping so the pong-timeout reaper doesn't close the socket before
+    // the next interval, then the second ping fires.
+    controller.handlePong()
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS)
+    expect(wsSend).toHaveBeenCalledTimes(2)
+  })
+
+  it('closes the socket if no pong clears the pong-timeout within PONG_TIMEOUT_MS', () => {
+    const { controller, socket } = makeController()
+    controller.startHeartbeat(socket)
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS) // ping sent, pong-timeout armed
+    expect(socket.closed).toBe(0)
+
+    vi.advanceTimersByTime(PONG_TIMEOUT_MS) // pong never arrived
+    expect(socket.closed).toBe(1)
+    expect(controller.isHeartbeatRunning).toBe(false) // stopped on reap
+  })
+
+  it('does NOT close the socket when a pong arrives before the timeout', () => {
+    const { controller, socket } = makeController()
+    controller.startHeartbeat(socket)
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS) // ping + pong-timeout armed
+    controller.handlePong() // pong clears the timeout
+    vi.advanceTimersByTime(PONG_TIMEOUT_MS + 1_000)
+    expect(socket.closed).toBe(0)
+    expect(controller.isHeartbeatRunning).toBe(true)
+  })
+
+  it('stops itself (no ping, no close) when the socket is no longer OPEN', () => {
+    const { controller, socket, wsSend } = makeController()
+    controller.startHeartbeat(socket)
+    socket.readyState = 3 // CLOSED out from under the heartbeat
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS)
+    expect(wsSend).not.toHaveBeenCalled()
+    expect(socket.closed).toBe(0)
+    expect(controller.isHeartbeatRunning).toBe(false)
+  })
+
+  it('stops itself if wsSend throws', () => {
+    const { controller, socket } = makeController()
+    socket.sendThrows = true
+    controller.startHeartbeat(socket)
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS)
+    expect(controller.isHeartbeatRunning).toBe(false)
+  })
+
+  it('startHeartbeat is idempotent — a second call replaces the first interval', () => {
+    const { controller, socket, wsSend } = makeController()
+    controller.startHeartbeat(socket)
+    controller.startHeartbeat(socket) // clears + re-arms
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS)
+    expect(wsSend).toHaveBeenCalledTimes(1) // exactly one interval, not two
+  })
+
+  it('stopHeartbeat clears the interval, the pong-timeout, and resets the smoother', () => {
+    const { controller, socket, smoother } = makeController()
+    controller.startHeartbeat(socket)
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS) // pong-timeout armed
+    controller.handlePong() // seed the smoother
+
+    controller.stopHeartbeat()
+    expect(controller.isHeartbeatRunning).toBe(false)
+    expect(smoother.value).toBeNull() // reset
+
+    // No ping or close after stop, even past both windows.
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS + PONG_TIMEOUT_MS)
+    expect(socket.closed).toBe(0)
+  })
+})
+
+describe('createHeartbeatController — handlePong / quality', () => {
+  it('measures RTT into the smoother and reports a quality bucket', () => {
+    let t = 0
+    const { controller, socket, quality, smoother } = makeController({ now: () => t })
+    controller.startHeartbeat(socket)
+    t = 1_000
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS) // ping sent at t=1000
+    t = 1_050 // pong 50ms later
+    controller.handlePong()
+    expect(smoother.value).toBe(50)
+    expect(quality).toEqual([{ latencyMs: 50, quality: 'good' }])
+  })
+
+  it('does nothing on a pong with no outstanding ping', () => {
+    const { controller, quality, smoother } = makeController()
+    controller.handlePong() // lastPingSentAt is 0
+    expect(quality).toEqual([])
+    expect(smoother.value).toBeNull()
+  })
+
+  it('emits a throttled latency-split line when serverTs is present', () => {
+    let t = 0
+    const lines: string[] = []
+    const { controller, socket } = makeController({
+      now: () => t,
+      onLatencyLog: (line) => lines.push(line),
+    })
+    controller.startHeartbeat(socket)
+    t = 1_000
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS) // ping at t=1000
+    t = 1_100
+    controller.handlePong(1_040) // serverTs mid-interval → split available
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('[latency] rtt=100ms')
+  })
+
+  it('omits the latency split when serverTs is absent', () => {
+    let t = 0
+    const lines: string[] = []
+    const { controller, socket } = makeController({
+      now: () => t,
+      onLatencyLog: (line) => lines.push(line),
+    })
+    controller.startHeartbeat(socket)
+    t = 1_000
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS)
+    t = 1_100
+    controller.handlePong() // no serverTs
+    expect(lines).toHaveLength(0)
+  })
+})
+
+describe('createHeartbeatController — handshake timer', () => {
+  it('fires onTimeout exactly once after HANDSHAKE_TIMEOUT_MS', () => {
+    const { controller } = makeController()
+    const onTimeout = vi.fn()
+    controller.armHandshakeTimer(onTimeout)
+    expect(controller.isHandshakeArmed).toBe(true)
+
+    vi.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS - 1)
+    expect(onTimeout).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+
+    // No second fire ever.
+    vi.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS * 2)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('clearHandshakeTimer cancels a pending timer — it never fires', () => {
+    const { controller } = makeController()
+    const onTimeout = vi.fn()
+    controller.armHandshakeTimer(onTimeout)
+    controller.clearHandshakeTimer()
+    expect(controller.isHandshakeArmed).toBe(false)
+    vi.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS * 2)
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+
+  it('re-arming clears the prior timer (no double fire from a reconnect re-entering onopen)', () => {
+    const { controller } = makeController()
+    const first = vi.fn()
+    const second = vi.fn()
+    controller.armHandshakeTimer(first)
+    vi.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS / 2)
+    controller.armHandshakeTimer(second) // replaces `first`
+    vi.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS)
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('clearHandshakeTimer is a no-op when nothing is armed', () => {
+    const { controller } = makeController()
+    expect(() => controller.clearHandshakeTimer()).not.toThrow()
+    expect(controller.isHandshakeArmed).toBe(false)
+  })
+})
+
+describe('rttQuality', () => {
+  it('buckets by smoothed RTT', () => {
+    expect(rttQuality(0)).toBe('good')
+    expect(rttQuality(199)).toBe('good')
+    expect(rttQuality(200)).toBe('fair')
+    expect(rttQuality(499)).toBe('fair')
+    expect(rttQuality(500)).toBe('poor')
+    expect(rttQuality(5_000)).toBe('poor')
+  })
+})
+
+describe('createReconnectCounter', () => {
+  it('advances the backoff ladder, returning the pre-increment index', () => {
+    const counter = createReconnectCounter()
+    expect(counter.attempt).toBe(0)
+    expect(counter.next()).toBe(0)
+    expect(counter.next()).toBe(1)
+    expect(counter.next()).toBe(2)
+    expect(counter.attempt).toBe(3)
+  })
+
+  it('reset returns the ladder to 0', () => {
+    const counter = createReconnectCounter()
+    counter.next()
+    counter.next()
+    expect(counter.attempt).toBe(2)
+    counter.reset()
+    expect(counter.attempt).toBe(0)
+    expect(counter.next()).toBe(0)
+  })
+})

--- a/packages/store-core/src/connection-runtime.test.ts
+++ b/packages/store-core/src/connection-runtime.test.ts
@@ -204,6 +204,9 @@ describe('createHeartbeatController — handshake timer', () => {
 
     vi.advanceTimersByTime(1)
     expect(onTimeout).toHaveBeenCalledTimes(1)
+    // After firing, the timer is no longer armed and holds no stale handle
+    // (#6065 review).
+    expect(controller.isHandshakeArmed).toBe(false)
 
     // No second fire ever.
     vi.advanceTimersByTime(HANDSHAKE_TIMEOUT_MS * 2)

--- a/packages/store-core/src/connection-runtime.ts
+++ b/packages/store-core/src/connection-runtime.ts
@@ -1,0 +1,360 @@
+/**
+ * Shared client connection RUNTIME — heartbeat, handshake timeout, and the
+ * reconnect-backoff counter (#6035, follow-on to the connect-flow extraction in
+ * #5556).
+ *
+ * The app (`packages/app/src/store/message-handler.ts`) and the dashboard
+ * (`packages/dashboard/src/store/message-handler.ts`) independently maintained
+ * two parallel copies of the transport-timing layer: the same
+ * `startHeartbeat`/`stopHeartbeat` ping loop, the same `armHandshakeTimer`/
+ * `clearHandshakeTimer` window timer, and the same `nextReconnectAttempt`/
+ * `resetReconnectAttempt` backoff counter, behind the same
+ * `HEARTBEAT_INTERVAL_MS`/`PONG_TIMEOUT_MS`/`HANDSHAKE_TIMEOUT_MS` constants.
+ * The dashboard file header literally said it was "Ported from" the app file,
+ * and #5962/#5979 (app) and #5963 (dashboard) implemented the SAME handshake
+ * timeout twice "for parity". This module owns that timing machinery once.
+ *
+ * Mirrors the `createDeltaFlusher` / `connect-flow` template: pure,
+ * dependency-free, with an injectable scheduler (defaulting to the global
+ * `setTimeout`/`clearTimeout`/`setInterval`/`clearInterval`) so jest/vitest fake
+ * timers work at the client call sites and store-core's own unit tests run on a
+ * deterministic fake.
+ *
+ * ## What is shared vs. what stays at the call site
+ *
+ * SHARED (this module): the timer mechanics — when to ping, when to give up on a
+ * pong, when the handshake window expires, and the backoff-rung counter. These
+ * are byte-identical between the two clients and have no UI surface.
+ *
+ * INJECTED (per client, via the options): the genuinely platform-specific
+ * effects —
+ *   - `wsSend(socket, payload)`: each client encrypts/sends differently
+ *     (the E2E envelope is per-client state).
+ *   - `onPongQuality(latencyMs, quality)`: the app writes to its
+ *     `useConnectionLifecycleStore`; the dashboard writes `getStore().setState`.
+ *   - `rttSmoother`: the EWMA smoother instance is OWNED by the call site
+ *     (the delta-flusher also reads `rttSmoother.value`), so it is passed in
+ *     rather than created here — the controller folds pong RTTs into it but
+ *     never owns it.
+ *
+ * Behavior is intentionally identical to the pre-extraction copies; this is a
+ * de-dup refactor, not a behavior change.
+ */
+
+import { RttSmoother } from './delta-flush'
+import { splitRtt } from './latency-stats'
+
+// ---------------------------------------------------------------------------
+// Constants (single-sourced; both clients re-export these)
+// ---------------------------------------------------------------------------
+
+/**
+ * Heartbeat cadence. Exported because the app's AppState resume handler uses the
+ * real heartbeat interval as its "was the app backgrounded long enough for the
+ * socket to have silently died?" threshold rather than a separate magic number
+ * (#5633).
+ */
+export const HEARTBEAT_INTERVAL_MS = 15_000
+
+/** How long to wait for a `pong` before declaring the socket dead. */
+export const PONG_TIMEOUT_MS = 5_000
+
+/**
+ * Client-side handshake timeout (#5721 / #5962 / #5963). The heartbeat does NOT
+ * start until `auth_ok` is processed, so the handshake window (socket OPEN +
+ * `auth`/`pair` sent, awaiting `auth_ok`/`key_exchange_ok`) has zero liveness
+ * coverage: a server that opens the socket but never completes the handshake
+ * leaves the client wedged until the transport drops on its own. A ~10s timer —
+ * comfortably below the ~20s worst-case heartbeat detection once connected —
+ * hands off to the normal reconnect ladder ("Handshake failed — reconnecting")
+ * instead of a silent stall.
+ */
+export const HANDSHAKE_TIMEOUT_MS = 10_000
+
+/**
+ * Throttle for the dev latency readout so a streaming turn can't spam the
+ * console (#5515, epic #5514). Re-exported so the delta-flush path's
+ * `recordLatencySamples` shares the same window (the two paths gate on one
+ * `lastLatencyLogAt` cursor at the call site).
+ */
+export const LATENCY_LOG_INTERVAL_MS = 3_000
+
+// ---------------------------------------------------------------------------
+// Scheduler surface (matches connect-flow's ConnectFlowScheduler, plus interval)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal timer surface the heartbeat schedules on. Defaults to the global
+ * timer functions, so jest/vitest fake timers (which patch the globals) work at
+ * the client call sites with no extra wiring; store-core's own unit tests inject
+ * a deterministic fake instead.
+ */
+export interface HeartbeatScheduler {
+  setInterval: (cb: () => void, ms: number) => ReturnType<typeof setInterval>
+  clearInterval: (handle: ReturnType<typeof setInterval>) => void
+  setTimeout: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimeout: (handle: ReturnType<typeof setTimeout>) => void
+}
+
+const DEFAULT_SCHEDULER: HeartbeatScheduler = {
+  setInterval: (cb, ms) => setInterval(cb, ms),
+  clearInterval: (handle) => clearInterval(handle),
+  setTimeout: (cb, ms) => setTimeout(cb, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+}
+
+/**
+ * The minimal WebSocket surface the heartbeat touches. Both `WebSocket` (DOM)
+ * and React Native's `WebSocket` satisfy this; declared structurally so the
+ * shared module pulls in neither lib.dom nor react-native types.
+ */
+export interface HeartbeatSocket {
+  readonly readyState: number
+  send(data: string): void
+  close(): void
+}
+
+/** Connection-quality bucket derived from smoothed RTT. */
+export type ConnectionQuality = 'good' | 'fair' | 'poor'
+
+/**
+ * Map a smoothed RTT (ms) to the quality bucket. Single-sourced so the two
+ * clients can't drift their thresholds.
+ */
+export function rttQuality(smoothedMs: number): ConnectionQuality {
+  return smoothedMs < 200 ? 'good' : smoothedMs < 500 ? 'fair' : 'poor'
+}
+
+export interface CreateHeartbeatControllerOptions<S extends HeartbeatSocket = HeartbeatSocket> {
+  /**
+   * Send a frame on the socket. Each client owns its encryption envelope, so
+   * the send is injected rather than performed here. Typed over the client's
+   * concrete socket `S` (the app/dashboard pass their real `WebSocket`), so
+   * their existing `wsSend(socket: WebSocket, …)` slots in without a cast.
+   */
+  wsSend: (socket: S, payload: Record<string, unknown>) => void
+  /**
+   * The EWMA RTT smoother instance OWNED by the call site (the delta-flusher
+   * also reads `rttSmoother.value`). The controller folds pong RTTs into it and
+   * resets it on `stopHeartbeat`, but does not own it.
+   */
+  rttSmoother: RttSmoother
+  /**
+   * Write the measured latency + quality to the client's store. The app writes
+   * `useConnectionLifecycleStore`; the dashboard writes `getStore().setState`.
+   */
+  onPongQuality: (latencyMs: number, quality: ConnectionQuality) => void
+  /**
+   * The OPEN ready-state constant for this client's WebSocket (`WebSocket.OPEN`
+   * — 1 on both DOM and RN, but injected so the module never references a global
+   * `WebSocket`). Defaults to 1.
+   */
+  openReadyState?: number
+  /** `Date.now`-compatible clock; defaults to `Date.now`. Injected for tests. */
+  now?: () => number
+  /** Timer surface; defaults to the global timers. */
+  scheduler?: HeartbeatScheduler
+  /**
+   * Optional dev hook called with a formatted latency-split line when a pong
+   * arrives and the throttle window has elapsed. The call site owns the
+   * `lastLatencyLogAt` cursor (shared with the delta-flush path) and the actual
+   * `console.log`. Omit to skip the split entirely.
+   */
+  onLatencyLog?: (line: string, pongRecvAt: number) => void
+}
+
+/**
+ * The heartbeat + handshake controller. Returned by
+ * {@link createHeartbeatController}. One per store module (module-level
+ * singleton at each call site, matching the pre-extraction shape).
+ */
+export interface HeartbeatController<S extends HeartbeatSocket = HeartbeatSocket> {
+  /**
+   * Start the heartbeat on `socket`: ping every {@link HEARTBEAT_INTERVAL_MS},
+   * and if no pong clears the pong-timeout within {@link PONG_TIMEOUT_MS}, close
+   * the dead socket. Idempotent — clears any prior heartbeat first.
+   */
+  startHeartbeat: (socket: S) => void
+  /** Stop the heartbeat, clear the pong-timeout, and reset the RTT smoother. */
+  stopHeartbeat: () => void
+  /**
+   * Arm the handshake-window timer; `onTimeout` fires once after
+   * {@link HANDSHAKE_TIMEOUT_MS}. Clears any prior timer first (single-instance,
+   * mirroring startHeartbeat) so a reconnect that re-enters onopen can never
+   * leak a second pending timer.
+   */
+  armHandshakeTimer: (onTimeout: () => void) => void
+  /** Cancel the handshake-window timer if armed. */
+  clearHandshakeTimer: () => void
+  /**
+   * Handle an incoming `pong`: clear the pong-timeout, measure RTT, fold it into
+   * the smoother, and report quality via `onPongQuality`. `serverTs` is the
+   * server's optional wall-clock stamp used for the dev latency split.
+   */
+  handlePong: (serverTs?: number) => void
+  /** Test/teardown hook: whether the heartbeat interval is currently armed. */
+  readonly isHeartbeatRunning: boolean
+  /** Test/teardown hook: whether the handshake timer is currently armed. */
+  readonly isHandshakeArmed: boolean
+}
+
+/**
+ * Build the per-store heartbeat + handshake controller. The logic is a verbatim
+ * lift of the two clients' identical `startHeartbeat`/`stopHeartbeat`/
+ * `armHandshakeTimer`/`clearHandshakeTimer`/`_onPong` copies, with the
+ * platform-specific effects (send, quality write, dev log) injected.
+ */
+export function createHeartbeatController<S extends HeartbeatSocket = HeartbeatSocket>(
+  options: CreateHeartbeatControllerOptions<S>,
+): HeartbeatController<S> {
+  const {
+    wsSend,
+    rttSmoother,
+    onPongQuality,
+    openReadyState = 1,
+    now = () => Date.now(),
+    scheduler = DEFAULT_SCHEDULER,
+    onLatencyLog,
+  } = options
+
+  let heartbeatInterval: ReturnType<typeof setInterval> | null = null
+  let pongTimeout: ReturnType<typeof setTimeout> | null = null
+  let handshakeTimeout: ReturnType<typeof setTimeout> | null = null
+  let lastPingSentAt = 0
+
+  function stopHeartbeat(): void {
+    if (heartbeatInterval) {
+      scheduler.clearInterval(heartbeatInterval)
+      heartbeatInterval = null
+    }
+    if (pongTimeout) {
+      scheduler.clearTimeout(pongTimeout)
+      pongTimeout = null
+    }
+    lastPingSentAt = 0
+    rttSmoother.reset() // Reset smoothed RTT on disconnect
+  }
+
+  function startHeartbeat(socket: S): void {
+    stopHeartbeat()
+    heartbeatInterval = scheduler.setInterval(() => {
+      if (socket.readyState !== openReadyState) {
+        stopHeartbeat()
+        return
+      }
+      try {
+        lastPingSentAt = now()
+        wsSend(socket, { type: 'ping' })
+      } catch {
+        stopHeartbeat()
+        return
+      }
+      pongTimeout = scheduler.setTimeout(() => {
+        console.warn('[ws] Heartbeat pong timeout — closing dead connection')
+        stopHeartbeat()
+        try {
+          socket.close()
+        } catch {
+          /* close() may throw on an already-dead socket — ignore */
+        }
+      }, PONG_TIMEOUT_MS)
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  function armHandshakeTimer(onTimeout: () => void): void {
+    clearHandshakeTimer()
+    handshakeTimeout = scheduler.setTimeout(onTimeout, HANDSHAKE_TIMEOUT_MS)
+  }
+
+  function clearHandshakeTimer(): void {
+    if (handshakeTimeout) {
+      scheduler.clearTimeout(handshakeTimeout)
+      handshakeTimeout = null
+    }
+  }
+
+  function handlePong(serverTs?: number): void {
+    if (pongTimeout) {
+      scheduler.clearTimeout(pongTimeout)
+      pongTimeout = null
+    }
+    // Measure RTT and update connection quality using EWMA for stability.
+    if (lastPingSentAt > 0) {
+      const pongRecvAt = now()
+      const rttMs = pongRecvAt - lastPingSentAt
+      // EWMA: smoothed = alpha * new + (1 - alpha) * prev (first sample bootstraps).
+      const smoothed = Math.round(rttSmoother.update(rttMs))
+      onPongQuality(smoothed, rttQuality(smoothed))
+
+      // #5515 (epic #5514): split this RTT into approximate uplink/downlink
+      // halves using the server-stamped serverTs, positioned within the
+      // locally-measured [ping,pong] interval (skew-clamped). Dev-only, throttled
+      // by the same window as token-to-render (the call site owns the cursor).
+      if (onLatencyLog) {
+        const split = splitRtt({ pingSentAt: lastPingSentAt, pongRecvAt, serverTs })
+        if (split.uplinkMs !== null) {
+          onLatencyLog(
+            `[latency] rtt=${split.rttMs}ms split≈ up ${split.uplinkMs}ms / down ${split.downlinkMs}ms (approx, clock-skew)`,
+            pongRecvAt,
+          )
+        }
+      }
+      lastPingSentAt = 0
+    }
+  }
+
+  return {
+    startHeartbeat,
+    stopHeartbeat,
+    armHandshakeTimer,
+    clearHandshakeTimer,
+    handlePong,
+    get isHeartbeatRunning() {
+      return heartbeatInterval !== null
+    },
+    get isHandshakeArmed() {
+      return handshakeTimeout !== null
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reconnect-backoff counter
+// ---------------------------------------------------------------------------
+
+/**
+ * The consecutive close/error-path reconnect counter, used to index the
+ * {@link CONNECT_RETRY_DELAYS} backoff ladder so a flapping tunnel escalates its
+ * retry spacing (1s → 2s → 3s → 5s → 8s) instead of hammering the handshake at a
+ * fixed delay (#5555.5 / #5594). Reset to 0 on `auth_ok` (a *successful*
+ * connect — proof the link is healthy), NOT on mere socket-open, so a socket
+ * that opens but never authenticates keeps climbing the ladder.
+ *
+ * Returned by {@link createReconnectCounter} — create ONE per store module. The
+ * `next` method is the `nextRung` the shared `createReconnectScheduler` (in
+ * connect-flow) consumes.
+ */
+export interface ReconnectCounter {
+  /** Advance the backoff ladder, returning the PRE-increment attempt index. */
+  next: () => number
+  /** Reset the ladder — called from the `auth_ok` handler on a clean connect. */
+  reset: () => void
+  /** Current attempt index (read-only; the next `next()` will return this). */
+  readonly attempt: number
+}
+
+/** Build a reconnect-backoff counter starting at attempt 0. */
+export function createReconnectCounter(): ReconnectCounter {
+  let attempt = 0
+  return {
+    next() {
+      return attempt++
+    },
+    reset() {
+      attempt = 0
+    },
+    get attempt() {
+      return attempt
+    },
+  }
+}

--- a/packages/store-core/src/connection-runtime.ts
+++ b/packages/store-core/src/connection-runtime.ts
@@ -263,7 +263,13 @@ export function createHeartbeatController<S extends HeartbeatSocket = HeartbeatS
 
   function armHandshakeTimer(onTimeout: () => void): void {
     clearHandshakeTimer()
-    handshakeTimeout = scheduler.setTimeout(onTimeout, HANDSHAKE_TIMEOUT_MS)
+    // Null the handle when the timer FIRES (not just on clear) so isHandshakeArmed
+    // reflects reality post-fire and no obsolete handle lingers (#6065 review).
+    // External behavior is unchanged: onTimeout still runs once at the same time.
+    handshakeTimeout = scheduler.setTimeout(() => {
+      handshakeTimeout = null
+      onTimeout()
+    }, HANDSHAKE_TIMEOUT_MS)
   }
 
   function clearHandshakeTimer(): void {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -688,6 +688,34 @@ export type {
   SelectReconnectEndpointInput,
 } from './connect-flow'
 
+// #6035 — shared client connection RUNTIME: the heartbeat ping loop and the
+// handshake-window timeout, lifted from the two clients' identical
+// `startHeartbeat`/`stopHeartbeat`/`armHandshakeTimer`/`clearHandshakeTimer`/
+// `_onPong` copies in their message-handler.ts files. The timer mechanics live
+// here once; each client injects its `wsSend` (encryption envelope), its
+// quality-write sink, and its owned `RttSmoother` (also read by the
+// delta-flusher). `createReconnectCounter` packages the backoff-ladder counter
+// whose `next` is the `nextRung` the `createReconnectScheduler` above consumes;
+// the clients keep their `reconnectAttempt` live binding for now (their suites
+// read it directly), so the counter is exported for future single-sourcing.
+export {
+  createHeartbeatController,
+  createReconnectCounter,
+  rttQuality,
+  HEARTBEAT_INTERVAL_MS,
+  PONG_TIMEOUT_MS,
+  HANDSHAKE_TIMEOUT_MS,
+  LATENCY_LOG_INTERVAL_MS,
+} from './connection-runtime'
+export type {
+  HeartbeatScheduler,
+  HeartbeatSocket,
+  HeartbeatController,
+  CreateHeartbeatControllerOptions,
+  ConnectionQuality,
+  ReconnectCounter,
+} from './connection-runtime'
+
 // epic #5556, sub-item 5: shared behavioral-contract fixtures. The
 // `(wire message in → expected store mutation out)` table is DATA, consumed by
 // BOTH clients' test suites (app jest, dashboard vitest) to drive the same rows


### PR DESCRIPTION
## Summary

Extracts the duplicated transport-timing layer from the app and dashboard message-handlers into a new `@chroxy/store-core` module, so the heartbeat / handshake-timeout runtime lives once instead of as two parallel copies. Related to #6035.

Both `packages/app/src/store/message-handler.ts` and `packages/dashboard/src/store/message-handler.ts` independently defined a byte-identical `startHeartbeat`/`stopHeartbeat` ping loop, `armHandshakeTimer`/`clearHandshakeTimer` window timer, and `_onPong` RTT measurement, behind the same `HEARTBEAT_INTERVAL_MS` / `PONG_TIMEOUT_MS` / `HANDSHAKE_TIMEOUT_MS` constants. The dashboard copy was literally "Ported from" the app; #5962/#5979 (app) and #5963 (dashboard) implemented the same handshake timeout twice "for parity"; #5980 (FSM paired-drop) bit this same surface. Every reconnect/backoff fix has been hand-ported and drifts.

## What was extracted

New `packages/store-core/src/connection-runtime.ts`:

- **`createHeartbeatController`** — owns the heartbeat interval, the pong-timeout reaper, the handshake-window timer, and the pong RTT measurement. Follows the existing `createDeltaFlusher` / `connect-flow` template: pure, with an injectable scheduler defaulting to the global timers (so jest/vitest fake timers work at the call sites). Generic over the concrete socket type so each client's `wsSend(socket: WebSocket, …)` slots in without a cast.
- **`createReconnectCounter`** — the backoff-ladder counter whose `next` is the `nextRung` the existing `createReconnectScheduler` (in `connect-flow.ts`) consumes.
- **`HEARTBEAT_INTERVAL_MS` / `PONG_TIMEOUT_MS` / `HANDSHAKE_TIMEOUT_MS` / `LATENCY_LOG_INTERVAL_MS`** — single-sourced; both clients re-export from store-core.

## How each client consumes it

- **App** holds the controller on its per-connection `_ctx` (built in `createDefaultContext`, torn down on `resetAllHandlerState` by replacing the context — exactly like the heartbeat fields it replaced). Injects its `wsSend`, `useConnectionLifecycleStore.getState().setConnectionQuality` as the quality sink, the `_ctx.rttSmoother` (also read by the delta-flusher), and a latency-log hook gating on `ctx.lastLatencyLogAt`.
- **Dashboard** holds a module-level `_heartbeat` controller. Injects its `wsSend`, `getStore().setState({ latencyMs, connectionQuality })` as the quality sink, the module `_rttSmoother`, and a latency-log hook gating on `_lastLatencyLogAt`.
- Both keep their exported `startHeartbeat` / `stopHeartbeat` / `armHandshakeTimer` / `clearHandshakeTimer` / `_onPong` / `HANDSHAKE_TIMEOUT_MS` contracts as thin delegations, so `connection.ts` call sites and the existing test suites are untouched.

## Why behavior is identical per client

The extracted logic is a verbatim lift of the (already-identical) copies. The only per-client effects are **injected**: the encryption envelope (`wsSend`), the quality-write sink, the `RttSmoother` instance, and the dev latency-log throttle cursor.

## Deliberately left platform-specific / per-client

- The `RttSmoother` instance stays owned by the call site (the delta-flusher reads `rttSmoother.value` for its adaptive interval).
- The `lastLatencyLogAt` dev-log throttle stays at the call site (shared with the delta-flush `recordLatencySamples` path), passed in via the `onLatencyLog` hook.
- The `reconnectAttempt` live binding stays in each client (both suites import it as a live binding and assert on it directly). `createReconnectCounter` is exported for future single-sourcing but not forced in here to avoid breaking the live-binding test contract.

## Tests

- New `connection-runtime.test.ts` (18 cases): heartbeat fires/stops, pong reaping closes the socket, idempotent start, stop resets the smoother, pong measurement + quality bucketing, latency-split throttle, handshake timer fires once + is cancellable + re-arm replaces, and the reconnect counter advance/reset.
- Full store-core suite green (1663 tests).
- Dashboard store-tier suites green against the edited store-core (handshake-timeout, reconnect-backoff/endpoint, message-handler, encryption-guard, contract-switch, auth-ok, store — 468+ tests; the only "failed" files in a full run are unrelated `@testing-library/react` resolution in the ad-hoc worktree harness, 0 assertion failures).
- App store-tier suites green (reconnect-backoff, server-down, AutoResume/ZombieSocket reconnect, message-handler — 197 focused, 1760 in the broader dir; the only "failed" files are the unrelated missing build-time `xterm-bundle.generated`).
- `tsc --noEmit` clean for store-core and for both clients' message-handlers (and `connection.ts`).

## Behavior-parity confidence

High. Pure mechanical lift behind unchanged exported contracts, proven by both clients' existing connection/reconnect/handshake suites passing against the shared module. One supervised check remains per the issue's acceptance criteria: **reconnect behavior on real sockets** (app + dashboard) — left to the maintainer's device/integration pass since the worktree harness can't drive real transports.