### PR TITLE
fix(server): isolate per-permission throws in reconnect resend loops (#6054)

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -505,14 +505,23 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
               } else {
                 permissionSessionMap.set(requestId, sessionId)
               }
-              sendFn(ws, buildPermissionRequestMessage({
-                requestId: permData.requestId ?? requestId,
-                tool: permData.tool,
-                description: permData.description,
-                input: permData.input,
-                remainingMs,
-                sessionId,
-              }))
+              // #6054: buildPermissionRequestMessage throws on field drift (the
+              // intended #6031 fail-loud guard). Isolate it per-permission so one
+              // malformed pending entry can't abort the loop and strand the
+              // remaining valid prompts for this reconnecting client.
+              try {
+                sendFn(ws, buildPermissionRequestMessage({
+                  requestId: permData.requestId ?? requestId,
+                  tool: permData.tool,
+                  description: permData.description,
+                  input: permData.input,
+                  remainingMs,
+                  sessionId,
+                }))
+              } catch (err) {
+                log.warn(`Skipping malformed pending permission ${requestId} on resend: ${err?.message ?? err}`)
+                continue
+              }
             }
           }
         }
@@ -536,13 +545,20 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         } else {
           log.debug(`[session-binding-resend] legacy permission ${requestId} resent (client=unknown)`)
         }
-        sendFn(ws, buildPermissionRequestMessage({
-          requestId: pending.data.requestId ?? requestId,
-          tool: pending.data.tool,
-          description: pending.data.description,
-          input: pending.data.input,
-          remainingMs,
-        }))
+        // #6054: isolate the per-permission build+send so a single drifted
+        // legacy entry can't abort the loop (see SDK path above).
+        try {
+          sendFn(ws, buildPermissionRequestMessage({
+            requestId: pending.data.requestId ?? requestId,
+            tool: pending.data.tool,
+            description: pending.data.description,
+            input: pending.data.input,
+            remainingMs,
+          }))
+        } catch (err) {
+          log.warn(`Skipping malformed pending legacy permission ${requestId} on resend: ${err?.message ?? err}`)
+          continue
+        }
       }
     }
   }

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -288,6 +288,74 @@ describe('createPermissionHandler', () => {
       assert.equal(permissionSessionMap.get('sdk-req-map'), 'sess-map')
     })
 
+    it('skips a malformed legacy permission but still resends the valid ones (#6054)', () => {
+      const opts = makeHandlerOpts()
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+      // Malformed: `tool` is non-string → buildPermissionRequestMessage throws.
+      opts.pendingPermissions.set('req-bad', {
+        resolve: () => {},
+        timer: null,
+        data: {
+          requestId: 'req-bad',
+          tool: 12345,
+          description: '/tmp/bad',
+          input: {},
+          remainingMs: 300_000,
+          createdAt: Date.now(),
+        },
+      })
+      opts.pendingPermissions.set('req-good', {
+        resolve: () => {},
+        timer: null,
+        data: {
+          requestId: 'req-good',
+          tool: 'Write',
+          description: '/tmp/good',
+          input: {},
+          remainingMs: 300_000,
+          createdAt: Date.now(),
+        },
+      })
+      const ws = {}
+      assert.doesNotThrow(() => resendPendingPermissions(ws))
+      // Only the valid one is sent; the malformed one is logged-and-skipped.
+      assert.equal(opts.sendFn.mock.calls.length, 1)
+      const [, msg] = opts.sendFn.mock.calls[0].arguments
+      assert.equal(msg.type, 'permission_request')
+      assert.equal(msg.requestId, 'req-good')
+    })
+
+    it('skips a malformed SDK-mode permission but still resends the valid ones (#6054)', () => {
+      const session = {
+        _pendingPermissions: new Map([['sdk-bad', {}], ['sdk-good', {}]]),
+        _lastPermissionData: new Map([
+          ['sdk-bad', {
+            requestId: 'sdk-bad',
+            tool: 999, // non-string → builder throws
+            description: '/tmp/bad',
+            input: {},
+            remainingMs: 300_000,
+            createdAt: Date.now(),
+          }],
+          ['sdk-good', {
+            requestId: 'sdk-good',
+            tool: 'Write',
+            description: '/tmp/good',
+            input: {},
+            remainingMs: 300_000,
+            createdAt: Date.now(),
+          }],
+        ]),
+      }
+      const sm = { _sessions: new Map([['sess-mixed', { session }]]) }
+      const opts = makeHandlerOpts({ getSessionManager: mock.fn(() => sm) })
+      const { resendPendingPermissions } = createPermissionHandler(opts)
+      assert.doesNotThrow(() => resendPendingPermissions({}))
+      assert.equal(opts.sendFn.mock.calls.length, 1)
+      const [, msg] = opts.sendFn.mock.calls[0].arguments
+      assert.equal(msg.requestId, 'sdk-good')
+    })
+
     it('skips expired SDK-mode permissions', () => {
       const session = {
         _pendingPermissions: new Map([['sdk-req-exp', {}]]),

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -316,13 +316,29 @@ describe('createPermissionHandler', () => {
           createdAt: Date.now(),
         },
       })
+      // Capture warn-level logs so we can assert the skip is logged WITH the
+      // offending requestId (#6054 acceptance + Copilot review on #6067) — a
+      // regression that removed the log or dropped the requestId would slip past
+      // a send-only assertion.
+      const warnLines = []
+      const logSpy = (entry) => {
+        if (entry.level === 'warn' && entry.component === 'ws') warnLines.push(entry.message)
+      }
+      addLogListener(logSpy)
       const ws = {}
-      assert.doesNotThrow(() => resendPendingPermissions(ws))
+      try {
+        assert.doesNotThrow(() => resendPendingPermissions(ws))
+      } finally {
+        removeLogListener(logSpy)
+      }
       // Only the valid one is sent; the malformed one is logged-and-skipped.
       assert.equal(opts.sendFn.mock.calls.length, 1)
       const [, msg] = opts.sendFn.mock.calls[0].arguments
       assert.equal(msg.type, 'permission_request')
       assert.equal(msg.requestId, 'req-good')
+      const skipWarn = warnLines.find((m) => m.includes('req-bad'))
+      assert.ok(skipWarn, `expected a warn log naming the skipped requestId, got: ${JSON.stringify(warnLines)}`)
+      assert.match(skipWarn, /Skipping malformed/, 'warn explains the skip')
     })
 
     it('skips a malformed SDK-mode permission but still resends the valid ones (#6054)', () => {
@@ -350,10 +366,22 @@ describe('createPermissionHandler', () => {
       const sm = { _sessions: new Map([['sess-mixed', { session }]]) }
       const opts = makeHandlerOpts({ getSessionManager: mock.fn(() => sm) })
       const { resendPendingPermissions } = createPermissionHandler(opts)
-      assert.doesNotThrow(() => resendPendingPermissions({}))
+      const warnLines = []
+      const logSpy = (entry) => {
+        if (entry.level === 'warn' && entry.component === 'ws') warnLines.push(entry.message)
+      }
+      addLogListener(logSpy)
+      try {
+        assert.doesNotThrow(() => resendPendingPermissions({}))
+      } finally {
+        removeLogListener(logSpy)
+      }
       assert.equal(opts.sendFn.mock.calls.length, 1)
       const [, msg] = opts.sendFn.mock.calls[0].arguments
       assert.equal(msg.requestId, 'sdk-good')
+      const skipWarn = warnLines.find((m) => m.includes('sdk-bad'))
+      assert.ok(skipWarn, `expected a warn log naming the skipped requestId, got: ${JSON.stringify(warnLines)}`)
+      assert.match(skipWarn, /Skipping malformed/, 'warn explains the skip')
     })
 
     it('skips expired SDK-mode permissions', () => {


### PR DESCRIPTION
## Summary
`buildPermissionRequestMessage(...)` throws on schema-validation failure (the intended #6031 fail-loud drift guard). `resendPendingPermissions` calls it inside a `for...of` over pending permissions in **both** the SDK-mode path and the legacy path. An uncaught throw on one drifted entry aborted the entire resend loop, stranding every later **valid** pending prompt for the reconnecting client — and the resend path is exactly where reconnect resilience matters most.

## Change
- Wrap each per-permission `buildPermissionRequestMessage(...) → sendFn(...)` in the two resend loops with try/catch that `log.warn`s the offending `requestId` + error, then `continue`.
- HTTP-fallback site (single emit, not a loop) left to throw as before.

## Tests
- New: malformed legacy entry skipped, valid one still sent (asserts `requestId`).
- New: malformed SDK-mode entry skipped, valid one still sent.
- Full `ws-permissions.test.js` green (65 tests).

Closes #6054. Related to #6031.