### PR TITLE
test(dashboard): fix onUserConsoleLog teardown flake in server-registry-store (#6063)

### DIFF
--- a/packages/dashboard/src/store/server-registry-store.test.ts
+++ b/packages/dashboard/src/store/server-registry-store.test.ts
@@ -48,6 +48,16 @@ beforeEach(() => {
     activeServerId: null,
     connectionPhase: 'disconnected',
     ...realActions,
+    // #6063: stub the network-touching `connect` so the switchServer /
+    // connectToServer / connectLocal / pairServer tests — which only assert the
+    // synchronous registry/scope state those actions set BEFORE delegating to
+    // connect() — never open a real WebSocket. The real connect()'s async path
+    // logs via console.* AFTER the test body resolves, racing the vitest worker
+    // teardown ("Closing rpc while onUserConsoleLog was pending" →
+    // EnvironmentTeardownError → green suite, non-zero exit, red CI job). The
+    // retryConnection tests override `connect`/`connectToServer` with their own
+    // spies after this, so they are unaffected.
+    connect: vi.fn(),
   })
 })
 


### PR DESCRIPTION
## Summary
The **Dashboard Tests** job intermittently exits code 1 with **every test passing**:

```
Test Files  203 passed (203)
     Tests  3822 passed (3822)
    Errors  1 error
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "src/store/server-registry-store.test.ts"
```

A `console.*` fires while the worker RPC channel is closing → non-zero exit on a green suite → blocks merges and forces re-runs.

## Root cause
`switchServer` / `connectToServer` / `connectLocal` / `pairServer` set `activeServerId` + persistence scope **synchronously**, then delegate to the real `connect()`, which opens a WebSocket. Its async path logs via `console.*` **after** the test body resolves — racing the vitest worker teardown.

## Fix
These tests only assert the synchronous registry/scope state, so stub `connect()` in `beforeEach` (after restoring the real actions). No real socket is opened; no late log races teardown. The `retryConnection` tests override `connect`/`connectToServer` with their own spies and are unaffected.

## Verification
- `server-registry-store.test.ts` green (18 tests).
- Ran 5× consecutively — exit 0 every time (the teardown error was intermittent before).

Closes #6063.