### PR TITLE
fix(server): let an explicit model:null survive create as the #3403 provider-default marker (#6064)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -753,11 +753,19 @@ export class SessionManager extends EventEmitter {
     }
 
     const baseCwd = cwd || this._defaultCwd
-    // Nullish-coalesce so an explicit `null` (the soft-fallback marker for a
-    // stale Claude model — see #3403) survives restore intact instead of
-    // re-applying `_defaultModel`. Only `undefined` (omitted/missing) falls
-    // back to the server-config default.
-    let resolvedModel = model ?? this._defaultModel
+    // #6064/#3403: only an OMITTED model (`undefined`) falls back to the
+    // server-config default. An explicit `null` is the #3403 "use the provider's
+    // own default" marker and must SURVIVE — it reaches this method ONLY via
+    // restoreState: the wire `create_session.model` is `z.string().optional()`,
+    // so clients send a string or omit the field (never null), and every other
+    // internal caller omits `model` entirely. A session that soft-fell-back to
+    // the provider default (`resolvedModel = null` below) persists `model: null`;
+    // coalescing that to `_defaultModel` on restore would re-pin it to a
+    // server-config id that may itself be stale — exactly the staleness #3403
+    // avoids — so restore must reproduce the null faithfully. (The prior `??`
+    // coalesced null too, contradicting this and the comment that claimed null
+    // survived; #6064.)
+    let resolvedModel = model === undefined ? this._defaultModel : model
     const resolvedPermissionMode = permissionMode || this._defaultPermissionMode
 
     // Validate cwd exists

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -755,16 +755,16 @@ export class SessionManager extends EventEmitter {
     const baseCwd = cwd || this._defaultCwd
     // #6064/#3403: only an OMITTED model (`undefined`) falls back to the
     // server-config default. An explicit `null` is the #3403 "use the provider's
-    // own default" marker and must SURVIVE — it reaches this method ONLY via
-    // restoreState: the wire `create_session.model` is `z.string().optional()`,
-    // so clients send a string or omit the field (never null), and every other
-    // internal caller omits `model` entirely. A session that soft-fell-back to
-    // the provider default (`resolvedModel = null` below) persists `model: null`;
-    // coalescing that to `_defaultModel` on restore would re-pin it to a
-    // server-config id that may itself be stale — exactly the staleness #3403
-    // avoids — so restore must reproduce the null faithfully. (The prior `??`
-    // coalesced null too, contradicting this and the comment that claimed null
-    // survived; #6064.)
+    // own default" marker and must SURVIVE. `null` is NOT a valid value on the WS
+    // wire (`create_session.model` is `z.string().optional()`, so a remote client
+    // sends a string or omits the field — never null); in practice it arrives via
+    // restoreState (the production path: a session that soft-fell-back to the
+    // provider default persists `model: null`) or an explicit internal/test
+    // caller passing it deliberately. Coalescing that `null` to `_defaultModel`
+    // would re-pin it to a server-config id that may itself be stale — exactly
+    // the staleness #3403 avoids — so the marker must be reproduced faithfully.
+    // (The prior `??` coalesced null too, contradicting this and the comment that
+    // claimed null survived; #6064.)
     let resolvedModel = model === undefined ? this._defaultModel : model
     const resolvedPermissionMode = permissionMode || this._defaultPermissionMode
 

--- a/packages/server/tests/session-manager-create-plan.test.js
+++ b/packages/server/tests/session-manager-create-plan.test.js
@@ -114,10 +114,12 @@ describe('SessionManager._resolveCreateSessionPlan (#6036)', () => {
     // #6064 ruling: `model === undefined ? this._defaultModel : model`.
     //  - omitted (undefined) → server-config default (the normal create path).
     //  - explicit `null` → SURVIVES as the #3403 "use the provider's own default"
-    //    marker. null reaches createSession only via restoreState (the wire
-    //    create_session.model is z.string().optional() — clients send a string or
-    //    omit it, never null), so re-pinning a persisted provider-default to
-    //    _defaultModel would re-introduce the staleness #3403 avoids.
+    //    marker. `null` is not valid on the WS wire (create_session.model is
+    //    z.string().optional() — a remote client sends a string or omits it,
+    //    never null); it arrives mainly via restoreState (a persisted soft-
+    //    fallback) or an explicit internal/test caller like this one. Re-pinning a
+    //    persisted provider-default to _defaultModel would re-introduce the
+    //    staleness #3403 avoids.
     //  - empty string → kept as-is (unchanged).
     assert.equal(mgr._resolveCreateSessionPlan({}).resolvedModel, 'default-model')
     assert.equal(mgr._resolveCreateSessionPlan({ model: null }).resolvedModel, null)

--- a/packages/server/tests/session-manager-create-plan.test.js
+++ b/packages/server/tests/session-manager-create-plan.test.js
@@ -110,16 +110,19 @@ describe('SessionManager._resolveCreateSessionPlan (#6036)', () => {
     assert.equal(plan.resolvedProvider, 'test-plan-model-limited-6036')
   })
 
-  it('applies _defaultModel via nullish-coalesce for both undefined and null model', () => {
-    // `model ?? this._defaultModel` — preserved verbatim from the inline
-    // front-half. Both omitted (undefined) and explicit null fall back to the
-    // server default; an empty string is kept as-is (only null/undefined coalesce).
-    // NOTE: this pins CURRENT behavior, not a #3403 ruling — whether an explicit
-    // `model: null` should instead SURVIVE as a "use provider default" marker is
-    // tracked in #6064; this refactor only preserves what main did.
+  it('falls back to _defaultModel ONLY for an omitted (undefined) model; null survives (#6064/#3403)', () => {
+    // #6064 ruling: `model === undefined ? this._defaultModel : model`.
+    //  - omitted (undefined) → server-config default (the normal create path).
+    //  - explicit `null` → SURVIVES as the #3403 "use the provider's own default"
+    //    marker. null reaches createSession only via restoreState (the wire
+    //    create_session.model is z.string().optional() — clients send a string or
+    //    omit it, never null), so re-pinning a persisted provider-default to
+    //    _defaultModel would re-introduce the staleness #3403 avoids.
+    //  - empty string → kept as-is (unchanged).
     assert.equal(mgr._resolveCreateSessionPlan({}).resolvedModel, 'default-model')
-    assert.equal(mgr._resolveCreateSessionPlan({ model: null }).resolvedModel, 'default-model')
+    assert.equal(mgr._resolveCreateSessionPlan({ model: null }).resolvedModel, null)
     assert.equal(mgr._resolveCreateSessionPlan({ model: '' }).resolvedModel, '')
+    assert.equal(mgr._resolveCreateSessionPlan({ model: 'allowed-model', provider: 'test-plan-model-limited-6036' }).resolvedModel, 'allowed-model')
   })
 
   it('increments the session-name counter on each call', () => {


### PR DESCRIPTION
## Investigation outcome
Raised during #6062 (#6036) review: `_resolveCreateSessionPlan` used `model ?? this._defaultModel`, so an explicit `model: null` coalesced to the server-config default. The question (#6064): is that correct, or should `null` survive as #3403's 'use provider default' marker?

**Finding — null should survive.** Evidence:
- The wire schema is `create_session.model: z.string().optional()` — clients send a **string or omit** the field; `null` is not a valid wire value. Both the dashboard and app build the message with a conditional-add (omit when unset).
- Every internal `createSession` caller either passes a string (`session-handlers`) or omits `model` (`server-cli`, `checkpoint-handlers`, `conversation-handlers`). 
- **`null` therefore reaches `createSession` only via `restoreState`** (`model: saved.model`), where a session that soft-fell-back to the provider default (#3403, `resolvedModel = null`) persisted `model: null`.
- Coalescing that persisted `null` to `_defaultModel` on restore re-pins the session to a server-config id that may itself be stale — **exactly the staleness #3403 was created to avoid**. The in-code comment already *claimed* null survived; `??` contradicted it.

## Change
`model ?? this._defaultModel` → `model === undefined ? this._defaultModel : model`:
- **create path**: unchanged — `null` never occurs; string/undefined behave identically.
- **restore path**: a persisted provider-default (`null`) is reproduced faithfully instead of re-pinned.
- old state files (no model field → `undefined`) still fall back to `_defaultModel` (unchanged).

## Tests
- `session-manager-create-plan.test.js`: `model: null` now asserts `resolvedModel === null` (was `'default-model'`); undefined→default and `''`→`''` unchanged; a real string still survives.
- Ran session-manager + create-plan + booted-model + preset + models suites: **330 tests green**.

Closes #6064. Related to #3403, #6036.