### PR TITLE
test(store-core): add both-clients permission_resolved contract fixture (#6058)

### DIFF
--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -112,6 +112,10 @@ function seedStore(fx: ContractFixture) {
     activeSessionId: fx.init?.activeSessionId ?? null,
     sessionStates,
     messages: [],
+    // #6058: the real store always initialises sessionNotifications; seed it so
+    // permission_resolved's unconditional banner-drain (s.sessionNotifications.map)
+    // runs against a realistic store instead of throwing on undefined.
+    sessionNotifications: [],
     // Store methods the real stream/tool handlers reach for (terminal preview
     // writes, flat addMessage). No-op-ish so the session-state assertions stand
     // alone — the terminal-preview side-channel is covered by its own tests.

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -86,9 +86,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'pair_fail',
   'permission_expired',
   'permission_mode_changed',
-  // permission_resolved: the dashboard call site maps over session messages in a
-  // way the simple contract fixture doesn't yet satisfy — tracked separately.
-  'permission_resolved',
+  // permission_resolved now has a both-clients SWITCH_FIXTURES entry (#6058).
   'permission_timeout',
   'plan_ready',
   'pong',

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1057,6 +1057,43 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
+    // permission_resolved (another client answered) flips the matching 'prompt'
+    // bubble to answered IN PLACE — both clients keep exactly ONE bubble and do
+    // NOT add/remove/retype it. Each client scans its session states for the
+    // requestId and rewrites that one bubble ({...m, answered, answeredAt,
+    // options: undefined}); the answered/answeredAt/options fields are STRIPPED by
+    // each runner's `normalize`, so the asserted slice is the unchanged prompt
+    // bubble (same id/type/content/tool). The contract this pins is the
+    // both-clients shape invariant: one in-place flip, never a duplicate prompt or
+    // a wiped transcript. (#6058; deferred from #6032.) The dashboard's extra
+    // sessionNotifications-drain + flat-messages-fallback and the app's banner
+    // filter are per-client side effects outside the messages slice.
+    name: 'permission_resolved flips the prompt to answered in place (one bubble, shape unchanged)',
+    type: 'permission_resolved',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              tool: 'Bash',
+              requestId: 'req-1',
+            } as unknown as ChatMessage,
+          ],
+        },
+      },
+    },
+    message: { type: 'permission_resolved', requestId: 'req-1', decision: 'allow' },
+    expect: {
+      sessions: {
+        s1: { messages: [{ id: 'prompt-req-1', type: 'prompt', content: 'Bash: rm -rf /tmp/x', tool: 'Bash' }] },
+      },
+    },
+  },
+  {
     // error is a GLOBAL surface (app → native Alert, dashboard → toast) — neither
     // client routes it into a session transcript. Seed a response bubble on the
     // active session and assert the error leaves the transcript completely


### PR DESCRIPTION
## Summary
Deferred from #6055 (#6032): `permission_resolved` passed the offline dispatch analysis but failed the dashboard contract-switch suite with `Cannot read properties of undefined (reading 'map')`.

## Root cause
The dashboard's `handlePermissionResolved` (message-handler.ts) **always** runs a `sessionNotifications.map(...)` banner-drain, and — when the prompt isn't found in `sessionStates` — a flat `get().messages.map(...)` fallback. The harness seeded neither robustly, so the always-run drain threw on `undefined`. The **app** handler already reads `(s.sessionNotifications ?? [])`, so it was null-safe.

## Change
- **Fixture**: seed the owning session **with** the prompt bubble (carrying `requestId`) so both clients take the found-in-place path and flip that one bubble to `answered`. `answered`/`answeredAt`/`options` are stripped by each runner's `normalize`, so the asserted `messages` slice is the **unchanged single prompt bubble** — pinning the both-clients shape invariant: one in-place flip, never a duplicate prompt or a wiped transcript.
- **Dashboard harness**: seed `sessionNotifications: []` (the real store always initialises it) so the production drain runs against a realistic store. App harness unchanged (already null-safe).
- Remove `permission_resolved` from `PENDING_CONTRACT_TYPES`.

## Verification
- store-core contract-fixtures: **63 tests** green (incl. coverage-lint).
- dashboard `contract-switch.test.ts`: **14** green (+1).
- app `contract-switch.test.ts`: **14** green (+1).

Closes #6058. Related to #6032.