### PR TITLE
fix(app): refuse permission/question answers on a disconnected session (#5699)

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -388,14 +388,30 @@ describe('message queue', () => {
     expect(result).toBe('queued');
   });
 
-  it('queues permission_response when socket is not connected', () => {
+  it('REFUSES permission_response when socket is not connected (#5699 — never queued)', () => {
+    // The server expires the pending request on disconnect, so a queued
+    // response would drain into the void on reconnect while the prompt could
+    // look answered. Refuse with `false` instead of queuing.
     const result = useConnectionStore.getState().sendPermissionResponse('req-1', 'allow');
-    expect(result).toBe('queued');
+    expect(result).toBe(false);
   });
 
-  it('queues user_question_response when socket is not connected', () => {
+  it('REFUSES user_question_response when socket is not connected (#5699 — never queued)', () => {
     const result = useConnectionStore.getState().sendUserQuestionResponse('yes');
-    expect(result).toBe('queued');
+    expect(result).toBe(false);
+  });
+
+  it('a refused permission/question response consumes no queue capacity (#5699)', () => {
+    const store = useConnectionStore.getState();
+    // Refused responses must not occupy a queue slot — fill exactly to 10 with
+    // inputs after attempting to "answer" while disconnected.
+    expect(store.sendPermissionResponse('req-x', 'allow')).toBe(false);
+    expect(store.sendUserQuestionResponse('nope')).toBe(false);
+    for (let i = 0; i < 10; i++) {
+      expect(store.sendInput(`msg-${i}`)).toBe('queued');
+    }
+    // 11th input overflows — proving the two refused responses took no slots.
+    expect(store.sendInput('overflow')).toBe(false);
   });
 
   it('returns false when queue is full (max 10)', () => {
@@ -614,12 +630,15 @@ describe('sendUserQuestionResponse wire payload (#4761)', () => {
     expect(payload.answer).not.toContain('["App"');
   });
 
-  it('queues the multi-question payload when socket is not connected', () => {
+  it('REFUSES the multi-question payload when socket is not connected (#5699 — never queued)', () => {
+    // A multi-question answer is still a user_question_response: the server
+    // expires the pending request on disconnect, so it must be refused (false),
+    // not queued, to avoid a silent drain-into-the-void on reconnect.
     useConnectionStore.setState({ socket: null });
     const result = useConnectionStore
       .getState()
       .sendUserQuestionResponse({ 'Q?': ['A', 'B'] }, 'toolu_q');
-    expect(result).toBe('queued');
+    expect(result).toBe(false);
   });
 });
 

--- a/packages/app/src/__tests__/store/message-queue.test.ts
+++ b/packages/app/src/__tests__/store/message-queue.test.ts
@@ -146,7 +146,13 @@ describe('offline message queue (#5635)', () => {
   describe('flush on reconnect', () => {
     it('sends all valid queued messages in FIFO order and empties the queue', () => {
       _testQueueInternals.enqueue('input', { type: 'input', data: 'first' });
-      _testQueueInternals.enqueue('permission_response', { type: 'permission_response', allow: true });
+      // #5699 — permission_response / user_question_response are no longer
+      // queueable (the server expires them on disconnect); enqueue refuses them.
+      expect(
+        _testQueueInternals.enqueue('permission_response', { type: 'permission_response', allow: true }),
+      ).toBe(false);
+      // `interrupt` IS still queueable — use it to exercise mixed-type FIFO.
+      _testQueueInternals.enqueue('interrupt', { type: 'interrupt' });
       _testQueueInternals.enqueue('input', { type: 'input', data: 'second' });
 
       // Within all TTLs.
@@ -157,7 +163,7 @@ describe('offline message queue (#5635)', () => {
 
       expect(sent).toEqual([
         { type: 'input', data: 'first' },
-        { type: 'permission_response', allow: true },
+        { type: 'interrupt' },
         { type: 'input', data: 'second' },
       ]);
       expect(_testQueueInternals.getQueue()).toHaveLength(0);

--- a/packages/app/src/components/SessionNotificationBanner.tsx
+++ b/packages/app/src/components/SessionNotificationBanner.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
 } from 'react-native';
 import { useConnectionStore } from '../store/connection';
+import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import type { SessionNotification } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
@@ -26,6 +27,10 @@ function NotificationRow({ notification }: { notification: SessionNotification }
   const dismiss = useConnectionStore((s) => s.dismissSessionNotification);
   const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse);
   const sendPlanResponse = useConnectionStore((s) => s.sendPlanResponse);
+  // #5699/#6078 — gate the banner's permission Approve/Deny on a live
+  // connection, like the in-bubble buttons. The server expires the pending
+  // request on disconnect, so answering from a cached banner can't land.
+  const connected = useConnectionLifecycleStore((s) => s.connectionPhase === 'connected');
 
   const dotColor =
     notification.eventType === 'error' ? COLORS.accentRed :
@@ -36,15 +41,16 @@ function NotificationRow({ notification }: { notification: SessionNotification }
   const isPlan = notification.eventType === 'plan';
 
   const handleApprove = () => {
-    if (notification.requestId) {
-      sendPermissionResponse(notification.requestId, 'allow');
+    // #6078 — only dismiss the banner row when the answer actually went over
+    // the wire ('sent'). A disconnected tap now returns false, so the row stays
+    // visible and actionable for retry after reconnect instead of vanishing.
+    if (notification.requestId && sendPermissionResponse(notification.requestId, 'allow') === 'sent') {
       dismiss(notification.id);
     }
   };
 
   const handleDeny = () => {
-    if (notification.requestId) {
-      sendPermissionResponse(notification.requestId, 'deny');
+    if (notification.requestId && sendPermissionResponse(notification.requestId, 'deny') === 'sent') {
       dismiss(notification.id);
     }
   };
@@ -64,18 +70,22 @@ function NotificationRow({ notification }: { notification: SessionNotification }
       return (
         <View style={styles.actionButtons}>
           <TouchableOpacity
-            style={styles.approveButton}
+            style={[styles.approveButton, !connected && styles.actionButtonDisabled]}
             onPress={handleApprove}
+            disabled={!connected}
             accessibilityRole="button"
             accessibilityLabel="Approve permission"
+            accessibilityState={{ disabled: !connected }}
           >
             <Text style={styles.approveText}>Approve</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.denyButton}
+            style={[styles.denyButton, !connected && styles.actionButtonDisabled]}
             onPress={handleDeny}
+            disabled={!connected}
             accessibilityRole="button"
             accessibilityLabel="Deny permission"
+            accessibilityState={{ disabled: !connected }}
           >
             <Text style={styles.denyText}>Deny</Text>
           </TouchableOpacity>
@@ -207,6 +217,10 @@ const styles = StyleSheet.create({
   actionButtons: {
     flexDirection: 'row',
     gap: 6,
+  },
+  // #6078 — dim Approve/Deny while disconnected (the answer can't land).
+  actionButtonDisabled: {
+    opacity: 0.4,
   },
   approveButton: {
     backgroundColor: COLORS.accentGreen,

--- a/packages/app/src/components/__tests__/MessageBubble.a11y.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.a11y.test.tsx
@@ -21,6 +21,14 @@ import renderer, { act } from 'react-test-renderer';
 import { OTHER_OPTION_VALUE } from '@chroxy/store-core';
 import { MessageBubble } from '../chat/MessageBubble';
 import type { ChatMessage } from '../../store/types';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+// #5699 — answer controls now gate on a live connection. These tests exercise
+// the normal (connected) behaviour, so establish that precondition; the
+// disconnected gate has its own dedicated test below.
+beforeEach(() => {
+  useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+});
 
 function makePrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
@@ -115,5 +123,25 @@ describe('MessageBubble accessibility (#5634)', () => {
     });
     const sendAfter = tree.root.findByProps({ testID: 'approval-freetext-send' });
     expect(sendAfter.props.accessibilityState).toEqual({ disabled: false });
+  });
+
+  it('disables answer buttons and shows a reconnect hint while disconnected (#5699)', () => {
+    useConnectionLifecycleStore.setState({ connectionPhase: 'disconnected' });
+    const onSelectOption = jest.fn();
+    const tree = render(makePrompt(), onSelectOption);
+
+    // The option buttons are present but disabled (the answer can't reach the
+    // server's expired pending request) — not a tappable no-op.
+    const approve = tree.root.findByProps({ testID: 'approval-button-approve' });
+    expect(approve.props.accessibilityState).toEqual({ disabled: true, selected: false });
+    expect(approve.props.disabled).toBe(true);
+
+    // A clear "reconnect to respond" hint replaces the silent dead tap.
+    // (>=1: react-test-renderer matches both the element node and its host.)
+    expect(tree.root.findAllByProps({ testID: 'prompt-disconnected-hint' }).length).toBeGreaterThanOrEqual(1);
+
+    // Even a forced press routes nowhere — the store would refuse it anyway, but
+    // the disabled control means the handler isn't invoked.
+    expect(onSelectOption).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
@@ -18,6 +18,13 @@ import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { MessageBubble } from '../chat/MessageBubble';
 import type { ChatMessage } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+// #5699 — the multi-question Submit gates on a live connection. These tests
+// exercise the connected submit path, so set that precondition.
+beforeEach(() => {
+  useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+});
 
 function multiQuestionPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {

--- a/packages/app/src/components/__tests__/MessageBubble.otherFreeform.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.otherFreeform.test.tsx
@@ -22,6 +22,13 @@ import renderer, { act } from 'react-test-renderer';
 import { OTHER_OPTION_VALUE } from '@chroxy/store-core';
 import { MessageBubble } from '../chat/MessageBubble';
 import type { ChatMessage } from '../../store/types';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+// #5699 — the freeform Send + Enter (onSubmitEditing) paths gate on a live
+// connection. These tests exercise the connected submit, so set that.
+beforeEach(() => {
+  useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+});
 
 function makePromptWithOther(): ChatMessage {
   return {

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -17,6 +17,7 @@ import { OTHER_OPTION_VALUE, bumpRenderCount, isRetryableAskUserQuestionError, i
 import type { OtherFreeformAnswer } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage, SessionInfo } from '../../store/connection';
 import { useConnectionStore } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { FormattedResponse } from '../MarkdownRenderer';
@@ -165,6 +166,14 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
   const isThinking = message.type === 'thinking';
   const isPrompt = message.type === 'prompt';
   const isError = message.type === 'error';
+
+  // #5699 — answer buttons must be gated on a live connection, not just the
+  // text input. The server expires a pending permission/question request when
+  // the socket drops, so answering a cached prompt while disconnected can't
+  // land (sendPermissionResponse/sendUserQuestionResponse now refuse it). Gate
+  // the buttons here so the user sees a disabled, explained control instead of
+  // tapping into a silent no-op. Global selector (not session-keyed) — safe.
+  const connected = useConnectionLifecycleStore((s) => s.connectionPhase === 'connected');
   const isSystem = message.type === 'system';
 
   // #5674 — resolve the owning-session label for permission prompts so a user
@@ -258,6 +267,11 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
     !showMultiQuestionForm && !showMultiQuestionSummary &&
     (message.answered != null || !otherActive);
   const showFreetextInput = isPrompt && otherActive && !message.answered && !isExpired;
+  // #5699 — when an unanswered, non-expired prompt is showing but we're offline,
+  // explain why the (disabled) answer controls can't be used.
+  const showDisconnectedAnswerHint =
+    isPrompt && !connected && message.answered == null && !isExpired &&
+    (hasOptions || useMultiForm || otherActive);
 
   // Answered permission prompts (with requestId) collapse to a compact pill.
   // user_question prompts (no requestId) are NOT collapsed.
@@ -438,9 +452,15 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
           ))}
         </View>
       )}
+      {showDisconnectedAnswerHint && (
+        <Text testID="prompt-disconnected-hint" style={styles.promptDisconnectedHint}>
+          Disconnected — reconnect to respond
+        </Text>
+      )}
       {showMultiQuestionForm && (
         <MultiQuestionForm
           questions={message.questions!}
+          disabled={!connected}
           onSubmit={(answersMap) => {
             if (submittedRef.current) return;
             submittedRef.current = true;
@@ -480,7 +500,10 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
         <View style={styles.promptOptions}>
           {message.options!.map((opt, i) => {
             const isAnswered = message.answered != null;
-            const isDisabled = isAnswered || isExpired;
+            // #5699 — also disable while disconnected: the answer can't reach
+            // the (now-expired) pending request, so the control must not look
+            // tappable.
+            const isDisabled = isAnswered || isExpired || !connected;
             const isChosen = message.answered === opt.value;
             return (
               <TouchableOpacity
@@ -572,12 +595,13 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
             returnKeyType="send"
           />
           <TouchableOpacity
-            style={[styles.promptFreetextSend, !otherText.trim() && styles.promptOptionDisabled]}
-            disabled={!otherText.trim()}
+            style={[styles.promptFreetextSend, (!otherText.trim() || !connected) && styles.promptOptionDisabled]}
+            // #5699 — also block the freeform Send while disconnected.
+            disabled={!otherText.trim() || !connected}
             accessibilityRole="button"
             // #5634 — name the freeform response in the tool context.
             accessibilityLabel={message.tool ? `Send response, ${message.tool}` : 'Send response'}
-            accessibilityState={{ disabled: !otherText.trim() }}
+            accessibilityState={{ disabled: !otherText.trim() || !connected }}
             // #4755 — see input testID comment above.
             testID="approval-freetext-send"
             onPress={() => {
@@ -749,6 +773,13 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: 8,
     marginTop: 10,
+  },
+  // #5699 — muted caption shown above the disabled answer controls when offline.
+  promptDisconnectedHint: {
+    color: COLORS.textSecondary,
+    fontSize: 12,
+    fontStyle: 'italic',
+    marginTop: 8,
   },
   promptOptionButton: {
     backgroundColor: COLORS.accentOrangeMedium,

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -577,7 +577,13 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
             autoFocus
             onSubmitEditing={() => {
               const trimmed = otherText.trim();
-              if (!trimmed || submittedRef.current) return;
+              // #5699/#6079 — gate the Enter-key path on a live connection too
+              // (the Send button is already disabled). Critically, bail BEFORE
+              // latching submittedRef: a disconnected submit can't land, and
+              // setting the one-shot guard here would block the legitimate retry
+              // after reconnect (the guard only resets when message.answered
+              // changes, which never happens for a refused answer).
+              if (!trimmed || !connected || submittedRef.current) return;
               submittedRef.current = true;
               // #4755 — when the user reached this input by clicking the
               // synthesized "Other" option (otherActive true), emit the

--- a/packages/app/src/components/chat/MultiQuestionForm.tsx
+++ b/packages/app/src/components/chat/MultiQuestionForm.tsx
@@ -54,9 +54,15 @@ export type MultiQuestionAnswersMap = SharedMultiQuestionAnswersMap;
 export interface MultiQuestionFormProps {
   questions: ChatMessageQuestion[];
   onSubmit: (answersMap: MultiQuestionAnswersMap) => void;
+  /**
+   * #5699 — when false (disconnected), the Submit button is disabled. The answer
+   * can't reach the server's already-expired pending request, so the control
+   * must not look actionable.
+   */
+  disabled?: boolean;
 }
 
-export function MultiQuestionForm({ questions, onSubmit }: MultiQuestionFormProps) {
+export function MultiQuestionForm({ questions, onSubmit, disabled = false }: MultiQuestionFormProps) {
   // Local selection state is indexed by question POSITION so that while
   // the form is open, two questions with identical text track their
   // choices independently (single-select holds the chosen value string,
@@ -91,7 +97,7 @@ export function MultiQuestionForm({ questions, onSubmit }: MultiQuestionFormProp
   const canSubmit = computeCanSubmit(questions, { singleSelectByIdx, multiSelectByIdx });
 
   const handleSubmit = () => {
-    if (submittedRef.current || !canSubmit) return;
+    if (submittedRef.current || !canSubmit || disabled) return;
     submittedRef.current = true;
     onSubmit(buildAnswersMap(questions, { singleSelectByIdx, multiSelectByIdx }));
   };
@@ -151,9 +157,9 @@ export function MultiQuestionForm({ questions, onSubmit }: MultiQuestionFormProp
         testID="question-multi-submit"
         accessibilityRole="button"
         accessibilityLabel="Submit answers"
-        accessibilityState={{ disabled: !canSubmit }}
-        disabled={!canSubmit}
-        style={[styles.submitButton, !canSubmit && styles.submitButtonDisabled]}
+        accessibilityState={{ disabled: !canSubmit || disabled }}
+        disabled={!canSubmit || disabled}
+        style={[styles.submitButton, (!canSubmit || disabled) && styles.submitButtonDisabled]}
         onPress={handleSubmit}
       >
         <Text style={styles.submitButtonText}>Submit</Text>

--- a/packages/app/src/components/chat/MultiQuestionForm.tsx
+++ b/packages/app/src/components/chat/MultiQuestionForm.tsx
@@ -55,9 +55,9 @@ export interface MultiQuestionFormProps {
   questions: ChatMessageQuestion[];
   onSubmit: (answersMap: MultiQuestionAnswersMap) => void;
   /**
-   * #5699 — when false (disconnected), the Submit button is disabled. The answer
-   * can't reach the server's already-expired pending request, so the control
-   * must not look actionable.
+   * #5699 — when true (the caller passes `disabled={!connected}`), the Submit
+   * button is disabled: a disconnected answer can't reach the server's
+   * already-expired pending request, so the control must not look actionable.
    */
   disabled?: boolean;
 }

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1705,17 +1705,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   sendPermissionResponse: (requestId: string, decision: string) => {
     const { socket } = get();
+    // #5699 — refuse to answer a permission prompt while disconnected, rather
+    // than queuing it. The server EXPIRES the pending request the moment the
+    // socket drops, so a queued response just drains into the void on reconnect
+    // (the request no longer exists) — the user taps Allow and nothing lands.
+    // Return false so the prompt stays actionable and the caller can surface
+    // clear "not connected" feedback; the answer buttons also gate on
+    // connectionPhase in MessageBubble. Mirrors the dashboard #5699 fix.
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
     // allowSession: send immediate 'allow' unblock + register a session rule for auto-approval
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
     const payload = { type: 'permission_response', requestId, decision: wireDecision };
-    let result: 'sent' | 'queued' | false;
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      if (wireDecision === 'deny') hapticWarning(); else hapticMedium();
-      wsSend(socket, payload);
-      result = 'sent';
-    } else {
-      result = enqueueMessage('permission_response', payload);
-    }
+    if (wireDecision === 'deny') hapticWarning(); else hapticMedium();
+    wsSend(socket, payload);
+    const result: 'sent' | 'queued' | false = 'sent';
     // Auto-switch to the session that owns this prompt (if different from active).
     // Prefer sessionNotifications lookup (covers prompts stored before sessionStates[sid] existed),
     // fall back to scanning sessionStates messages.
@@ -1791,11 +1794,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       payload.answers = answer;
     }
     if (toolUseId) payload.toolUseId = toolUseId;
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, payload);
-      return 'sent';
-    }
-    return enqueueMessage('user_question_response', payload);
+    // #5699 — like permission responses, an AskUserQuestion answer is tied to a
+    // live pending request the server expires on disconnect; queuing it would
+    // drain into the void on reconnect. Refuse while disconnected so the form
+    // stays actionable and the caller gives clear feedback (the form also gates
+    // on connectionPhase in the UI).
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    wsSend(socket, payload);
+    return 'sent';
   },
 
   markPromptAnswered: (messageId: string, answer: string) => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -944,11 +944,23 @@ export function clearDeltaBuffers(): void {
 const QUEUE_TTLS: Record<string, number> = {
   input: 60_000,
   interrupt: 5_000,
-  permission_response: 300_000,
-  user_question_response: 60_000,
 };
 const QUEUE_MAX_SIZE = 10;
-const QUEUE_EXCLUDED = new Set(['set_model', 'set_permission_mode', 'mode', 'resize']);
+// #5699: permission_response / user_question_response are NOT queueable — the
+// server expires the pending request the moment the socket drops, so a queued
+// answer would drain into the void on reconnect while the UI could appear to
+// have answered. They are refused at the call sites (sendPermissionResponse /
+// sendUserQuestionResponse return false when disconnected); excluding them here
+// is the defense-in-depth backstop so no future enqueue path can re-introduce
+// the silent-loss bug.
+const QUEUE_EXCLUDED = new Set([
+  'set_model',
+  'set_permission_mode',
+  'mode',
+  'resize',
+  'permission_response',
+  'user_question_response',
+]);
 
 /**
  * #5633: surface a queue failure to the user as a system message in the


### PR DESCRIPTION
## Summary
Fixes the worst optimistic-action-loss failure mode on mobile (#5699): the server **expires** a pending permission/question request the moment the socket drops, so the old behavior — queuing the response with a 5-min TTL — drained it into the void on reconnect (the request no longer exists), while the answer buttons stayed tappable, producing a **silent dead tap**.

## Change

**Store (the safety net — mirrors the dashboard's #5699 fix):**
- `sendPermissionResponse` / `sendUserQuestionResponse` now return `false` when the socket isn't `OPEN` instead of enqueuing. The optimistic mark-answered is already gated on `sent === 'sent'`, so the prompt stays actionable (never falsely "answered").
- `permission_response` / `user_question_response` moved from `QUEUE_TTLS` to `QUEUE_EXCLUDED` — defense-in-depth so no future enqueue path can re-introduce the silent loss.

**UI (clear feedback instead of a dead tap):**
- `MessageBubble` option buttons + the "Other" freeform Send disable while disconnected; a **"Disconnected — reconnect to respond"** hint replaces the silent no-op.
- `MultiQuestionForm` gains a `disabled` prop; its Submit gates on connection.

## Tests
- Store: refusal returns `false` + consumes **no queue capacity** (connection + message-queue suites).
- Component: a disconnected-gating test (buttons disabled + hint shown + handler not invoked); connected precondition added to the existing answer-flow component tests.
- **Full app suite green (1975 tests) + `tsc` clean.**

## Scope / remaining (#5699 stays open)
This PR lands the **safety-critical core** (failure mode #2 + the headline "buttons gated on connected" criterion). The remaining #5699 acceptance items are additive UX for the *input* queue (failure mode #1) and switch (#3):
- reconnect banner surfacing the queued-message count,
- prompt-before-discard on manual disconnect with a non-empty queue,
- session-switch gating,
- a Maestro flow.

These need reactive queue-count plumbing + on-device verification, tracked as the continuation.

## Device verification
Store + component behavior is covered by jest. The visible disabled-state + hint should get a final check on a real device / simulator (Maestro flow is part of the remaining items).
