### PR TITLE
fix(server): emit domain-separated exchange-key signature (#5604 phase 2)

### DIFF
--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -593,7 +593,7 @@ export function handleKeyExchange(ctx, ws, msg) {
     let serverKeySig = null
     if (serverIdentity?.secretKey) {
       try {
-        serverKeySig = signExchangeKey(serverKp.publicKey, serverIdentity.secretKey)
+        serverKeySig = signExchangeKey(serverKp.publicKey, serverIdentity.secretKey, { domainSeparated: true })
       } catch (err) {
         log.warn(`Failed to sign exchange key for ${client.id}: ${err.message}`)
       }

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -291,7 +291,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
         // when pinning is unavailable — old clients ignore it, exchange stays TOFU.
         if (serverIdentity?.secretKey) {
           try {
-            eagerServerKeySig = signExchangeKey(serverKp.publicKey, serverIdentity.secretKey)
+            eagerServerKeySig = signExchangeKey(serverKp.publicKey, serverIdentity.secretKey, { domainSeparated: true })
           } catch (sigErr) {
             log.warn(`Failed to sign eager exchange key for ${client.id}: ${sigErr.message}`)
             eagerServerKeySig = null

--- a/packages/server/tests/ws-auth.test.js
+++ b/packages/server/tests/ws-auth.test.js
@@ -1773,6 +1773,48 @@ describe('handleKeyExchange', () => {
         false,
       )
     })
+
+    it('#5959 — serverKeySig is domain-separated (not bare): verifies with domain-separated payload, not with bare bytes', async () => {
+      // Proves the signer flip landed: the emitted signature covers
+      // `chroxy-exchange-key-v1:` ++ key, not the bare key bytes alone.
+      const { signExchangeKey, EXCHANGE_KEY_SIG_DOMAIN_V1 } = await import('@chroxy/store-core/crypto')
+      const identity = createSigningKeyPair()
+      const clientKp = nacl.box.keyPair()
+      const clientPubB64 = naclUtil.encodeBase64(clientKp.publicKey)
+      const salt = generateConnectionSalt()
+
+      const ws = makeMockWs()
+      const { ctx } = makeKeyExchangeCtx({ ws })
+      ctx.serverIdentity = identity
+
+      handleKeyExchange(ctx, ws, { type: 'key_exchange', publicKey: clientPubB64, salt })
+
+      const keOk = ws.sent().find(m => m.type === 'key_exchange_ok')
+      assert.ok(keOk.serverKeySig, 'serverKeySig present')
+
+      // The accept-both verifier still accepts the domain-separated form.
+      assert.equal(
+        verifyExchangeKeySignature(keOk.publicKey, keOk.serverKeySig, identity.publicKey),
+        true,
+        'verifyExchangeKeySignature accepts domain-separated sig',
+      )
+
+      // The emitted sig must NOT equal the bare-form sig produced by the old signer.
+      const bareSig = signExchangeKey(keOk.publicKey, identity.secretKey, { domainSeparated: false })
+      assert.notEqual(
+        keOk.serverKeySig,
+        bareSig,
+        'emitted sig differs from bare-form sig — signer is domain-separated',
+      )
+
+      // The emitted sig MUST equal the domain-separated sig (proves the flip).
+      const domainSig = signExchangeKey(keOk.publicKey, identity.secretKey, { domainSeparated: true })
+      assert.equal(
+        keOk.serverKeySig,
+        domainSig,
+        'emitted sig matches the domain-separated sig — ' + EXCHANGE_KEY_SIG_DOMAIN_V1 + ' prefix active',
+      )
+    })
   })
 
   describe('non-key_exchange message while encryption pending', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -928,6 +928,59 @@ describe('sendPostAuthInfo — eager key exchange (#5555)', () => {
     )
   })
 
+  it('#5959 — eager serverKeySig is domain-separated (not bare): verifies as domain-separated, not as bare bytes', async () => {
+    // Proves the signer flip landed on the eager path: the signature covers
+    // `chroxy-exchange-key-v1:` ++ key, not the bare key bytes alone.
+    const {
+      createSigningKeyPair,
+      verifyExchangeKeySignature,
+      signExchangeKey,
+      EXCHANGE_KEY_SIG_DOMAIN_V1,
+    } = await import('@chroxy/store-core/crypto')
+    const identity = createSigningKeyPair()
+    const ws = makeFakeWs()
+    const ctx = makeEncryptingCtx({
+      encryptionEnabled: true,
+      keyExchangeTimeoutMs: 60000,
+      serverIdentity: identity,
+    })
+    const clientKp = createKeyPair()
+    const salt = generateConnectionSalt()
+    registerClient(ctx, ws, {
+      socketIp: '203.0.113.11',
+      eagerKeyExchange: { publicKey: clientKp.publicKey, salt },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+
+    const authOk = ctx._plainSends.find(m => m.type === 'auth_ok')
+    assert.ok(authOk.serverPublicKey, 'eager serverPublicKey present')
+    assert.ok(authOk.serverKeySig, 'auth_ok carries serverKeySig')
+
+    // The accept-both verifier still accepts the domain-separated form.
+    assert.equal(
+      verifyExchangeKeySignature(authOk.serverPublicKey, authOk.serverKeySig, identity.publicKey),
+      true,
+      'verifyExchangeKeySignature accepts domain-separated sig',
+    )
+
+    // The emitted sig must NOT equal the bare-form sig produced by the old signer.
+    const bareSig = signExchangeKey(authOk.serverPublicKey, identity.secretKey, { domainSeparated: false })
+    assert.notEqual(
+      authOk.serverKeySig,
+      bareSig,
+      'emitted sig differs from bare-form sig — signer is domain-separated',
+    )
+
+    // The emitted sig MUST equal the domain-separated sig (proves the flip).
+    const domainSig = signExchangeKey(authOk.serverPublicKey, identity.secretKey, { domainSeparated: true })
+    assert.equal(
+      authOk.serverKeySig,
+      domainSig,
+      'emitted sig matches the domain-separated sig — ' + EXCHANGE_KEY_SIG_DOMAIN_V1 + ' prefix active',
+    )
+  })
+
   it('#5536 — omits serverKeySig on the eager path when no identity is configured', () => {
     const ws = makeFakeWs()
     const ctx = makeEncryptingCtx({ encryptionEnabled: true, keyExchangeTimeoutMs: 60000 })


### PR DESCRIPTION
## Summary

Phase 2 of #5604. Flips the two **server** exchange-key signer call sites to the domain-separated form (`chroxy-exchange-key-v1:` ++ key), now that phase 1 (#5604) made `verifyExchangeKeySignature` accept BOTH the bare and domain-separated forms.

- `packages/server/src/ws-auth.js` — `signExchangeKey(serverKp.publicKey, serverIdentity.secretKey, { domainSeparated: true })`
- `packages/server/src/ws-history.js` — same on the eager `serverKeySig` path

The verifier is **untouched** (still accepts both forms for one more release). No `dist/` rebuilt.

## Tests

- `tests/ws-auth.test.js` + `tests/ws-history.test.js` — assert the emitted `serverKeySig` (1) verifies, (2) differs from the bare form, (3) equals the domain-separated form.

## ⚠️ Release gate — do NOT merge until confirmed

Per #5959, phase 2 may only flip the signer **after** the phase-1 accept-both verifier has shipped to clients as the connecting-client floor. If a client running the old **bare-only** verifier (pre-#5604) connects to a server emitting domain-separated signatures, key-exchange verification fails → **forced manual re-pair**.

**Maintainer must confirm** the mobile app + dashboard releases carrying the #5604 accept-both verifier are the floor before merging this.

Closes #5959