### PR TITLE
test(store-core): assert permission_resolved in-place flip in both-clients contract (#6074)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -204,6 +204,79 @@ describe('contract switch fixtures — app real handleMessage (#5556.5)', () => 
 });
 
 // ---------------------------------------------------------------------------
+// Targeted in-place-flip assertion for permission_resolved (#6074)
+//
+// The SWITCH_FIXTURES shape contract above strips non-whitelist fields via
+// normalize(), so it cannot observe the in-place mutation of answered /
+// answeredAt / options. This separate test drives the same real handleMessage
+// path and asserts the fields that are invisible to normalize().
+// ---------------------------------------------------------------------------
+
+describe('permission_resolved flips answered + clears options (in-place)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    clearDeltaBuffers();
+  });
+
+  afterEach(() => {
+    clearDeltaBuffers();
+    jest.runAllTimers();
+    jest.useRealTimers();
+    setConnectionContext(null);
+  });
+
+  it('permission_resolved flips answered + clears options (in-place) (#6074)', () => {
+    const before = Date.now();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [],
+      availableProviders: [],
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              tool: 'Bash',
+              requestId: 'req-1',
+              options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+              answered: undefined,
+              answeredAt: undefined,
+            },
+          ],
+        },
+      } as unknown as ConnectionState['sessionStates'],
+      messages: [],
+      addMessage: jest.fn(),
+      appendTerminalData: jest.fn(),
+    } as unknown as ConnectionState);
+    setStore(store);
+    setConnectionContext(mockCtx as never);
+
+    handleMessage({ type: 'permission_resolved', requestId: 'req-1', decision: 'allow' });
+    const after = Date.now();
+
+    const ss = (store.getState() as unknown as { sessionStates: Record<string, SessionState> })
+      .sessionStates['s1'];
+    expect(ss.messages).toHaveLength(1);
+    const bubble = ss.messages[0] as Record<string, unknown>;
+    // Shape invariant: same id/type/content/tool (not duplicated or wiped)
+    expect(bubble.id).toBe('prompt-req-1');
+    expect(bubble.type).toBe('prompt');
+    expect(bubble.content).toBe('Bash: rm -rf /tmp/x');
+    expect(bubble.tool).toBe('Bash');
+    // In-place flip: answered set to the decision string, options cleared
+    expect(bubble.answered).toBe('allow');
+    expect(typeof bubble.answeredAt).toBe('number');
+    expect(bubble.answeredAt as number).toBeGreaterThanOrEqual(before);
+    expect(bubble.answeredAt as number).toBeLessThanOrEqual(after);
+    expect(bubble.options).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Encrypted-handshake replay INTO the app's real store (#5556.6)
 //
 // The shared fake-WS handshake driver (REAL store-core crypto) runs the full

--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -261,7 +261,7 @@ describe('permission_resolved flips answered + clears options (in-place)', () =>
     const ss = (store.getState() as unknown as { sessionStates: Record<string, SessionState> })
       .sessionStates['s1'];
     expect(ss.messages).toHaveLength(1);
-    const bubble = ss.messages[0] as Record<string, unknown>;
+    const bubble = ss.messages[0] as unknown as Record<string, unknown>;
     // Shape invariant: same id/type/content/tool (not duplicated or wiped)
     expect(bubble.id).toBe('prompt-req-1');
     expect(bubble.type).toBe('prompt');

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -252,7 +252,7 @@ describe('permission_resolved flips answered + clears options (in-place)', () =>
     const ss = (store.getState() as unknown as { sessionStates: Record<string, SessionState> })
       .sessionStates['s1']
     expect(ss!.messages).toHaveLength(1)
-    const bubble = ss!.messages[0] as Record<string, unknown>
+    const bubble = ss!.messages[0] as unknown as Record<string, unknown>
     // Shape invariant: same id/type/content/tool (not duplicated or wiped)
     expect(bubble.id).toBe('prompt-req-1')
     expect(bubble.type).toBe('prompt')

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -184,6 +184,90 @@ describe('contract switch fixtures — dashboard real handleMessage (#5556.5)', 
 })
 
 // ---------------------------------------------------------------------------
+// Targeted in-place-flip assertion for permission_resolved (#6074)
+//
+// The SWITCH_FIXTURES shape contract above strips non-whitelist fields via
+// normalize(), so it cannot observe the in-place mutation of answered /
+// answeredAt / options. This separate test drives the same real handleMessage
+// path and asserts the fields that are invisible to normalize().
+// ---------------------------------------------------------------------------
+
+describe('permission_resolved flips answered + clears options (in-place)', () => {
+  let mockSocket: WebSocket
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+    mockSocket = createMockSocket()
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    setConnectionContext(null)
+    vi.useRealTimers()
+  })
+
+  it('permission_resolved flips answered + clears options (in-place) (#6074)', () => {
+    const before = Date.now()
+    const store = createMockStore({
+      connectionPhase: 'connected',
+      socket: null,
+      sessions: [],
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              tool: 'Bash',
+              requestId: 'req-1',
+              options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+              answered: undefined,
+              answeredAt: undefined,
+            },
+          ],
+        },
+      } as unknown as ConnectionState['sessionStates'],
+      messages: [],
+      sessionNotifications: [],
+      appendTerminalData: () => {},
+      addMessage: () => {},
+      addServerError: () => {},
+    } as unknown as ConnectionState)
+    setStore(store)
+
+    handleMessage(
+      { type: 'permission_resolved', requestId: 'req-1', decision: 'allow' },
+      ctx(mockSocket) as never,
+    )
+    const after = Date.now()
+
+    const ss = (store.getState() as unknown as { sessionStates: Record<string, SessionState> })
+      .sessionStates['s1']
+    expect(ss!.messages).toHaveLength(1)
+    const bubble = ss!.messages[0] as Record<string, unknown>
+    // Shape invariant: same id/type/content/tool (not duplicated or wiped)
+    expect(bubble.id).toBe('prompt-req-1')
+    expect(bubble.type).toBe('prompt')
+    expect(bubble.content).toBe('Bash: rm -rf /tmp/x')
+    expect(bubble.tool).toBe('Bash')
+    // In-place flip: answered set to the decision string, options cleared
+    expect(bubble.answered).toBe('allow')
+    expect(bubble.answeredAt).toBeTypeOf('number')
+    expect(bubble.answeredAt as number).toBeGreaterThanOrEqual(before)
+    expect(bubble.answeredAt as number).toBeLessThanOrEqual(after)
+    expect(bubble.options).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Encrypted-handshake replay INTO the dashboard's real store (#5556.6)
 //
 // The shared fake-WS handshake driver (REAL store-core crypto — NOT the

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2297,7 +2297,7 @@ function handlePermissionResolved(msg: Record<string, unknown>, get: MsgGet, set
     // (`markAllSessionNotificationsRead`).
     const readStamp = Date.now();
     set((s) => ({
-      sessionNotifications: s.sessionNotifications.map((n) =>
+      sessionNotifications: (s.sessionNotifications ?? []).map((n) =>
         n.requestId === resolvedRequestId && n.readAt === undefined
           ? { ...n, readAt: readStamp }
           : n


### PR DESCRIPTION
## Summary

From review of #6071. The both-clients `SWITCH_FIXTURES` runners normalize each asserted message to a `{id, type, content, tool, toolUseId}` whitelist, so in-place mutations (`permission_resolved` setting `answered`/`answeredAt`/`options: undefined`) were never observed — a no-op handler would pass identically.

Per option 2 in the issue: adds a **targeted both-clients assertion** for the `permission_resolved` flip (answered set, options cleared) alongside the existing shape fixture, in both clients. Does NOT touch `normalize()` or the fixture framework.

- `packages/dashboard/src/store/contract-switch.test.ts` — new `permission_resolved flips answered + clears options (in-place)` block
- `packages/app/__tests__/contract-switch.test.ts` — mirror (fake timers, matching the app pattern)

Also hardens the adjacent null-safety gap the issue flagged: dashboard `handlePermissionResolved` now uses `(s.sessionNotifications ?? []).map(...)` for parity with the app.

## Test plan

- Dashboard: `vitest run src/store/contract-switch.test.ts` → 15 passed; full `src/store` suite 778 passed; tsc clean.
- App: `jest __tests__/contract-switch.test.ts` → 15 passed; tsc clean.

Closes #6074