### PR TITLE
fix(app): suppress AskUserQuestion raw tool_input in mobile ToolBubble (#6018)

### DIFF
--- a/packages/app/src/components/__tests__/AskUserQuestionRawInputLeak.test.tsx
+++ b/packages/app/src/components/__tests__/AskUserQuestionRawInputLeak.test.tsx
@@ -18,7 +18,6 @@
  */
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { Text } from 'react-native';
 import {
   handleToolStart,
   handleToolInputDelta,
@@ -93,14 +92,24 @@ function tapToExpand(root: renderer.ReactTestRenderer) {
   });
 }
 
+/**
+ * Collect every rendered string in the host tree. Walks the `toJSON()` output
+ * (fragments already flattened) so nested `<Text>Tool: {displayTool}</Text>`
+ * fragment children are captured — a one-level `findAllByType(Text)` flatten
+ * misses them.
+ */
+function collectStrings(node: unknown): string[] {
+  if (node == null) return [];
+  if (typeof node === 'string') return [node];
+  if (Array.isArray(node)) return node.flatMap(collectStrings);
+  if (typeof node === 'object' && 'children' in (node as Record<string, unknown>)) {
+    return collectStrings((node as { children: unknown }).children);
+  }
+  return [];
+}
+
 function getAllTextContent(root: renderer.ReactTestRenderer): string {
-  return root.root
-    .findAllByType(Text)
-    .flatMap((t) =>
-      Array.isArray(t.props.children) ? t.props.children : [t.props.children],
-    )
-    .filter((c): c is string => typeof c === 'string')
-    .join(' ');
+  return collectStrings(root.toJSON()).join(' ');
 }
 
 describe('#6018 AskUserQuestion raw tool_input must not leak on mobile', () => {
@@ -192,13 +201,16 @@ describe('#6018 AskUserQuestion raw tool_input must not leak on mobile', () => {
     expect(previewStr).toMatch(/rm -rf node_modules/);
   });
 
-  it('buildChatViewMessages round-trips — the ask message is present and suppressable', () => {
-    // Verify the store pipeline produces the expected structure.
+  it('buildChatViewMessages round-trips — the ask survives as a tool_use bubble, raw partial held in the store', () => {
+    // The AskUserQuestion survives the view pipeline as a tool_use bubble (so the
+    // ToolBubble still renders) rather than being dropped — suppression happens at
+    // RENDER time, not by discarding the message.
     const messages = buildAskUserQuestionMessages();
     const { chatMessages } = buildChatViewMessages(messages, null);
-    const askInView = chatMessages.find((m) => m.type === 'tool_use' && m.toolUseId === 'tu-ask');
-    expect(askInView).toBeDefined();
-    // The raw input partial must be in the message (wire path populated it).
-    expect(askInView!.toolInputPartial).toContain('"questions"');
+    expect(chatMessages.some((m) => m.type === 'tool_use')).toBe(true);
+    // The store message still holds the raw partial (the data isn't scrubbed —
+    // the ToolBubble just refuses to render it for suppressed tools).
+    const ask = messages.find((m) => m.toolUseId === 'tu-ask')!;
+    expect(ask.toolInputPartial).toContain('"questions"');
   });
 });

--- a/packages/app/src/components/__tests__/AskUserQuestionRawInputLeak.test.tsx
+++ b/packages/app/src/components/__tests__/AskUserQuestionRawInputLeak.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * #6018 — AskUserQuestion raw tool_input must never leak into the mobile chat.
+ *
+ * The dashboard surface gained this suppression in #5770 (#4667 original fix).
+ * The mobile `ToolBubble` was a parallel leak surface: it rendered
+ * `toolInputPartial` raw via `formatPartialPreview` (expanded body) and
+ * `getPartialSummary` (collapsed preview) with no AskUserQuestion suppression.
+ * On the claude-tui provider, AskUserQuestion streams its input as
+ * `tool_input_delta` chunks, so the raw `{"questions":[...` JSON could appear
+ * next to the structured QuestionPrompt / MultiQuestionForm card — two bubbles
+ * for the same prompt.
+ *
+ * These tests drive the PRODUCTION wire path:
+ *   handleToolStart + handleToolInputDelta → buildChatViewMessages → ToolBubble
+ *
+ * mirroring the dashboard's `AskUserQuestionRawInputLeak.test.tsx` (#5770)
+ * for the React Native surface.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+import {
+  handleToolStart,
+  handleToolInputDelta,
+  buildChatViewMessages,
+} from '@chroxy/store-core';
+import type { ChatMessage } from '@chroxy/store-core';
+import { ToolBubble } from '../chat/ToolBubble';
+
+const SESSION = 'sess-mobile-1';
+
+// Raw AskUserQuestion input JSON that must NEVER reach the mobile UI.
+const ASK_QUESTION_CHUNKS = [
+  '{"questions":[{"question":"Pick a deploy target",',
+  '"header":"Deploy","options":[{"label":"staging"},',
+  '{"label":"production"}]}]}',
+];
+
+/**
+ * Build a store message list exactly as the mobile app would after receiving
+ * the wire sequence for an AskUserQuestion tool_start + tool_input_delta
+ * stream, mirroring the claude-tui provider's streaming behaviour.
+ */
+function buildAskUserQuestionMessages(): ChatMessage[] {
+  const start = handleToolStart(
+    {
+      sessionId: SESSION,
+      tool: 'AskUserQuestion',
+      toolUseId: 'tu-ask',
+      messageId: 'm-ask',
+      // No `input` field — claude-tui streams input via tool_input_delta.
+    },
+    SESSION,
+    false,
+    [],
+  );
+
+  let messages: ChatMessage[] = [];
+  if (start.chatMessage) messages.push(start.chatMessage);
+
+  // Stream the raw JSON in chunks, exactly like the wire deltas.
+  for (const partialJson of ASK_QUESTION_CHUNKS) {
+    const delta = handleToolInputDelta(
+      { sessionId: SESSION, toolUseId: 'tu-ask', partialJson },
+      SESSION,
+    );
+    if (delta) messages = delta.applyTo(messages);
+  }
+  return messages;
+}
+
+function renderToolBubble(message: ChatMessage): renderer.ReactTestRenderer {
+  let root!: renderer.ReactTestRenderer;
+  act(() => {
+    root = renderer.create(
+      <ToolBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onToggleSelection={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    );
+  });
+  return root;
+}
+
+function tapToExpand(root: renderer.ReactTestRenderer) {
+  const touchables = root.root.findAllByProps({ activeOpacity: 0.7 });
+  expect(touchables.length).toBeGreaterThan(0);
+  act(() => {
+    touchables[0]!.props.onPress();
+  });
+}
+
+function getAllTextContent(root: renderer.ReactTestRenderer): string {
+  return root.root
+    .findAllByType(Text)
+    .flatMap((t) =>
+      Array.isArray(t.props.children) ? t.props.children : [t.props.children],
+    )
+    .filter((c): c is string => typeof c === 'string')
+    .join(' ');
+}
+
+describe('#6018 AskUserQuestion raw tool_input must not leak on mobile', () => {
+  it('wire path accumulates the raw JSON into toolInputPartial (sanity)', () => {
+    const messages = buildAskUserQuestionMessages();
+    const ask = messages.find((m) => m.toolUseId === 'tu-ask')!;
+    expect(ask.tool).toBe('AskUserQuestion');
+    // Confirm the accumulator holds the raw JSON — this is what must NOT render.
+    expect(ask.toolInputPartial).toContain('"questions"');
+    expect(ask.toolInputPartial).toContain('Pick a deploy target');
+  });
+
+  it('does NOT render the raw AskUserQuestion tool_input JSON in the collapsed preview', () => {
+    const messages = buildAskUserQuestionMessages();
+    const ask = messages.find((m) => m.toolUseId === 'tu-ask')!;
+    const root = renderToolBubble(ask);
+
+    // The collapsed preview (`testID="tool-collapsed-preview"`) must contain
+    // neither the raw JSON brace nor the question text.
+    const collapsed = root.root.findAllByProps({ testID: 'tool-collapsed-preview' });
+    // The preview Text is rendered (bubble is visible as a quiet placeholder).
+    expect(collapsed.length).toBeGreaterThan(0);
+    const previewText = collapsed[0]!.props.children ?? '';
+    const previewStr = Array.isArray(previewText)
+      ? previewText.filter((c: unknown): c is string => typeof c === 'string').join('')
+      : String(previewText);
+    expect(previewStr).not.toMatch(/"questions"/);
+    expect(previewStr).not.toMatch(/Pick a deploy target/);
+    expect(previewStr).not.toMatch(/\{"questions"/);
+  });
+
+  it('does NOT render the raw AskUserQuestion tool_input JSON in the expanded body', () => {
+    const messages = buildAskUserQuestionMessages();
+    const ask = messages.find((m) => m.toolUseId === 'tu-ask')!;
+    const root = renderToolBubble(ask);
+
+    tapToExpand(root);
+
+    const allText = getAllTextContent(root);
+    expect(allText).not.toMatch(/"questions"/);
+    expect(allText).not.toMatch(/Pick a deploy target/);
+    expect(allText).not.toMatch(/\{"questions"/);
+  });
+
+  it('still renders the ToolBubble as a visible placeholder (tool name in header)', () => {
+    const messages = buildAskUserQuestionMessages();
+    const ask = messages.find((m) => m.toolUseId === 'tu-ask')!;
+    const root = renderToolBubble(ask);
+
+    // The bubble must not return null — it renders as a quiet placeholder
+    // with the tool name in the header so the user knows a question is coming.
+    const allText = getAllTextContent(root);
+    // "AskUserQuestion" appears as the tool name in the header.
+    expect(allText).toMatch(/AskUserQuestion/);
+  });
+
+  it('does NOT suppress non-AskUserQuestion tool input (Bash early-abort UX must be unaffected)', () => {
+    // A Bash tool whose command streams in via tool_input_delta must still
+    // be visible in the collapsed preview (Bash early-abort #4063).
+    const start = handleToolStart(
+      {
+        sessionId: SESSION,
+        tool: 'Bash',
+        toolUseId: 'tu-bash',
+        messageId: 'm-bash',
+      },
+      SESSION,
+      false,
+      [],
+    );
+    let messages: ChatMessage[] = [];
+    if (start.chatMessage) messages.push(start.chatMessage);
+
+    const delta = handleToolInputDelta(
+      { sessionId: SESSION, toolUseId: 'tu-bash', partialJson: '{"command":"rm -rf node_modules"}' },
+      SESSION,
+    );
+    if (delta) messages = delta.applyTo(messages);
+
+    const bash = messages.find((m) => m.toolUseId === 'tu-bash')!;
+    const root = renderToolBubble(bash);
+
+    const collapsed = root.root.findByProps({ testID: 'tool-collapsed-preview' });
+    const previewText = collapsed.props.children ?? '';
+    const previewStr = Array.isArray(previewText)
+      ? previewText.filter((c: unknown): c is string => typeof c === 'string').join('')
+      : String(previewText);
+    // The command must be visible in the collapsed preview (field-priority extraction).
+    expect(previewStr).toMatch(/rm -rf node_modules/);
+  });
+
+  it('buildChatViewMessages round-trips — the ask message is present and suppressable', () => {
+    // Verify the store pipeline produces the expected structure.
+    const messages = buildAskUserQuestionMessages();
+    const { chatMessages } = buildChatViewMessages(messages, null);
+    const askInView = chatMessages.find((m) => m.type === 'tool_use' && m.toolUseId === 'tu-ask');
+    expect(askInView).toBeDefined();
+    // The raw input partial must be in the message (wire path populated it).
+    expect(askInView!.toolInputPartial).toContain('"questions"');
+  });
+});

--- a/packages/app/src/components/__tests__/AskUserQuestionRawInputLeak.test.tsx
+++ b/packages/app/src/components/__tests__/AskUserQuestionRawInputLeak.test.tsx
@@ -154,6 +154,42 @@ describe('#6018 AskUserQuestion raw tool_input must not leak on mobile', () => {
     expect(allText).not.toMatch(/\{"questions"/);
   });
 
+  it('does NOT render the raw tool_input JSON when input arrives whole on tool_start (non-streaming path)', () => {
+    // Providers that send the full input on tool_start (not as tool_input_delta
+    // chunks) land it in message.content: store-core does
+    // `content: msg.input ? JSON.stringify(msg.input) : tool`. The expanded body
+    // renders `content`, so without gating it leaks the raw JSON.
+    const start = handleToolStart(
+      {
+        sessionId: SESSION,
+        tool: 'AskUserQuestion',
+        toolUseId: 'tu-ask-whole',
+        messageId: 'm-ask-whole',
+        input: { questions: [{ question: 'Pick a deploy target', header: 'Deploy', options: [{ label: 'staging' }, { label: 'production' }] }] },
+      },
+      SESSION,
+      false,
+      [],
+    );
+    const ask = start.chatMessage!;
+    // Sanity: the raw JSON is in content (this is what must NOT render).
+    expect(ask.content).toContain('"questions"');
+
+    const root = renderToolBubble(ask);
+    // Collapsed: no leak.
+    let allText = getAllTextContent(root);
+    expect(allText).not.toMatch(/"questions"/);
+    expect(allText).not.toMatch(/Pick a deploy target/);
+    // Expanded: still no leak (content gated to the tool-name placeholder).
+    tapToExpand(root);
+    allText = getAllTextContent(root);
+    expect(allText).not.toMatch(/"questions"/);
+    expect(allText).not.toMatch(/Pick a deploy target/);
+    expect(allText).not.toMatch(/\{"questions"/);
+    // The bubble still renders as a placeholder (tool name visible).
+    expect(allText).toMatch(/AskUserQuestion/);
+  });
+
   it('still renders the ToolBubble as a visible placeholder (tool name in header)', () => {
     const messages = buildAskUserQuestionMessages();
     const ask = messages.find((m) => m.toolUseId === 'tu-ask')!;

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -79,13 +79,21 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
     : '';
   const rawContent = message.content?.trim() || '';
   const isPlaceholderContent = !rawContent || rawContent === message.tool;
-  const content = partialPreview && isPlaceholderContent
-    ? partialPreview
-    : (rawContent || partialPreview);
+  // #6018 — the NON-streaming path also leaks: when `tool_start` carries `input`,
+  // store-core serializes it into `message.content` (`content: msg.input ?
+  // JSON.stringify(msg.input) : tool`), so `rawContent` is the raw `{"questions":
+  // [...` JSON. For suppressed tools, never let that become the bubble body —
+  // collapse to the tool-name placeholder so the expanded body shows only the
+  // tool name (the structured QuestionPrompt card is the canonical render path).
+  const content = suppressRawInput
+    ? (message.tool || '')
+    : partialPreview && isPlaceholderContent
+      ? partialPreview
+      : (rawContent || partialPreview);
 
-  // Hide empty tool messages (for suppressed tools, content = rawContent = tool
-  // name placeholder, which is always non-empty after handleToolStart — so the
-  // bubble renders as a quiet placeholder with just the tool name + pulse marker).
+  // Hide empty tool messages. For suppressed tools `content` is the tool-name
+  // placeholder (non-empty, since the tool was matched by name) so the bubble
+  // still renders as a quiet placeholder with just the tool name + pulse marker.
   if (!content) return null;
 
   const displayTool = formatToolName(message.tool);

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -7,7 +7,7 @@ import {
   Platform,
   LayoutAnimation,
 } from 'react-native';
-import { getPartialSummary, tryParseCompleteJson } from '@chroxy/store-core';
+import { getPartialSummary, tryParseCompleteJson, shouldSuppressRawToolInput } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
@@ -57,11 +57,24 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
     onExpandedChange?.(message.id, next);
   };
   const longPressedRef = useRef(false);
+  // #6018 / #5770 — AskUserQuestion's tool_input shape is internal: the mobile
+  // surface already renders the structured question via the QuestionPrompt /
+  // MultiQuestionForm card (driven by the parallel `user_question` event).
+  // Surfacing the raw `{"questions":[...` JSON in the collapsed summary or the
+  // expanded partial-preview next to that card produces the two-bubbles-for-one-
+  // prompt symptom (#4667). Gate computed once so both branches stay in sync.
+  // Mirrors `shouldSuppressRawToolInput` usage in the dashboard ToolBubble (#5770).
+  // Must be computed before `partialPreview` and `partialSummary` so both gating
+  // sites can reference it without a temporal dead zone.
+  const suppressRawInput = shouldSuppressRawToolInput(message.tool);
   // #4081: streaming inputs land in `toolInputPartial` before `content`
   // is populated. Use it as the bubble body when `content` is empty or
   // identical to the tool name (the placeholder handleToolStart sets
   // when `msg.input` is missing). The result-arrival path is unchanged.
-  const partialPreview = !message.toolResult && message.toolInputPartial
+  // #6018 — gate on suppressRawInput: AskUserQuestion's raw tool_input
+  // must never surface in the expanded body (the structured QuestionPrompt
+  // card is the canonical render path for that tool).
+  const partialPreview = !message.toolResult && message.toolInputPartial && !suppressRawInput
     ? formatPartialPreview(message.toolInputPartial)
     : '';
   const rawContent = message.content?.trim() || '';
@@ -70,7 +83,9 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
     ? partialPreview
     : (rawContent || partialPreview);
 
-  // Hide empty tool messages
+  // Hide empty tool messages (for suppressed tools, content = rawContent = tool
+  // name placeholder, which is always non-empty after handleToolStart — so the
+  // bubble renders as a quiet placeholder with just the tool name + pulse marker).
   if (!content) return null;
 
   const displayTool = formatToolName(message.tool);
@@ -133,15 +148,19 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
   //
   // The Bash early-abort UX (#4063) hinges on `command` being
   // legible at a glance without expanding the bubble.
-  const partialSummary = message.toolInputPartial
+  // #6018 — suppress raw tool_input in the collapsed preview for tools whose
+  // input is handled by a dedicated structured card. When suppressed, the
+  // collapsed bubble shows only the tool name (header). Matches the dashboard
+  // ToolBubble's `suppressRawInput` gate on the `summary` computation.
+  const partialSummary = message.toolInputPartial && !suppressRawInput
     ? getPartialSummary(message.toolInputPartial)
     : null;
-  const contentSummary = !isPlaceholderContent
+  const contentSummary = !isPlaceholderContent && !suppressRawInput
     ? getPartialSummary(content)
     : null;
   const previewSource = partialSummary && isPlaceholderContent
     ? partialSummary
-    : (contentSummary || content);
+    : (contentSummary || (suppressRawInput ? '' : content));
   const preview = previewSource.length > 60 ? previewSource.slice(0, 60) + '...' : previewSource;
 
   // #4180: TodoWrite tool_result is rendered as a structured checklist


### PR DESCRIPTION
## Summary

Parallel-surface gap from #5770/#6017 (which fixed the dashboard). The mobile `ToolBubble` (`packages/app/src/components/chat/ToolBubble.tsx`) had **no** AskUserQuestion suppression — it rendered `toolInputPartial` raw via `formatPartialPreview` (expanded) and `getPartialSummary` (collapsed). On claude-tui, AskUserQuestion streams its input as `tool_input_delta` chunks, so the raw `{"questions":[...` JSON could surface next to the structured QuestionPrompt/MultiQuestionForm card — the two-bubbles-for-one-prompt symptom #4667/#5770 prevents.

Fix: import `shouldSuppressRawToolInput` from `@chroxy/store-core` (the single source of truth hoisted in #6017) and gate the expanded `partialPreview`, the collapsed `partialSummary`, and the `contentSummary`/`previewSource` fallbacks on it — mirroring the dashboard `ToolBubble`. The bubble still renders as a quiet placeholder (tool name in header); only the raw input body/preview is suppressed. Non-suppressed tools (e.g. Bash early-abort #4063) are unaffected.

This makes the store-core comment's "ToolBubble (web + mobile) … import this" claim accurate.

## Test plan

- New `AskUserQuestionRawInputLeak.test.tsx` drives the production wire path (`handleToolStart` + `handleToolInputDelta` → render) — raw question JSON never renders in collapsed or expanded body; bubble still renders as a placeholder; Bash input still shows; `buildChatViewMessages` keeps it as a `tool_use` bubble (suppression at render, not by dropping data). 6 passed.
- Existing `ToolBubble.test.tsx` / `ToolBubblePartialSummary.test.tsx` → 26 passed. tsc clean.

Closes #6018
Related to #5770, #6017