### PR TITLE
fix(app): route all manual-disconnect paths through the unsent-queue discard guard (#6081)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -16,6 +16,7 @@ import ActivityScreen from './screens/ActivityScreen';
 import { LockScreen } from './components/LockScreen';
 import { ConnectionAnnouncer } from './components/ConnectionAnnouncer';
 import { useConnectionStore } from './store/connection';
+import { disconnectWithQueueGuard } from './store/disconnectWithQueueGuard';
 import { useConnectionLifecycleStore } from './store/connection-lifecycle';
 import { setupNotificationResponseListener } from './notifications';
 import { useBiometricLock } from './hooks/useBiometricLock';
@@ -152,7 +153,7 @@ export default function App() {
                 title: sessionTitle,
                 headerRight: () => (
                   <TouchableOpacity
-                    onPress={() => useConnectionStore.getState().disconnect()}
+                    onPress={disconnectWithQueueGuard}
                     style={{ paddingLeft: 12 }}
                     accessibilityRole="button"
                     accessibilityLabel="Disconnect and go back"

--- a/packages/app/src/__tests__/screens/DisconnectQueueGuardRouting.test.ts
+++ b/packages/app/src/__tests__/screens/DisconnectQueueGuardRouting.test.ts
@@ -1,0 +1,89 @@
+/**
+ * #6081 — All manual-disconnect entry points route through disconnectWithQueueGuard.
+ *
+ * Three UI affordances let the user give up the connection:
+ *   1. App.tsx header "Disconnect" button (primary gap closed by #6081)
+ *   2. ConnectScreen.tsx auto-connect "Cancel" button (#6081)
+ *   3. SessionScreen.tsx reconnect-banner "Disconnect" button (handled by #6080/
+ *      refactored in #6081 to delegate to the shared helper)
+ *
+ * This file verifies (via source-text parsing, following the pattern established
+ * in SessionScreenQueuedCountBanner.test.ts) that none of these sites call
+ * disconnect() directly — they all go through disconnectWithQueueGuard so the
+ * unsent-queue discard warning is consistently shown.
+ *
+ * SettingsScreen.tsx is intentionally excluded — its disconnect is a settings-
+ * reset action, not a "give up the connection" path, and is out of scope.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const AppSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../App.tsx'),
+  'utf-8',
+);
+
+const ConnectScreenSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/ConnectScreen.tsx'),
+  'utf-8',
+);
+
+const SessionScreenSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SessionScreen.tsx'),
+  'utf-8',
+);
+
+describe('App.tsx header Disconnect button (#6081)', () => {
+  it('imports disconnectWithQueueGuard', () => {
+    expect(AppSrc).toMatch(/import \{ disconnectWithQueueGuard \} from ['"]\.\/store\/disconnectWithQueueGuard['"]/);
+  });
+
+  it('uses disconnectWithQueueGuard as the onPress handler (not a raw disconnect() call)', () => {
+    expect(AppSrc).toMatch(/onPress=\{disconnectWithQueueGuard\}/);
+  });
+
+  it('does NOT call useConnectionStore.getState().disconnect() for the header button', () => {
+    // The old pattern was: onPress={() => useConnectionStore.getState().disconnect()}
+    // After the fix, the ONLY getState() calls should be the ones inside the store helper,
+    // not at the call sites. Verify this file no longer has the direct getState disconnect.
+    expect(AppSrc).not.toMatch(/onPress=\{\(\) => useConnectionStore\.getState\(\)\.disconnect\(\)\}/);
+  });
+});
+
+describe('ConnectScreen.tsx auto-connect Cancel button (#6081)', () => {
+  it('imports disconnectWithQueueGuard', () => {
+    expect(ConnectScreenSrc).toMatch(/import \{ disconnectWithQueueGuard \} from ['"]\.\.\/store\/disconnectWithQueueGuard['"]/);
+  });
+
+  it('calls disconnectWithQueueGuard() in the Cancel onPress handler', () => {
+    expect(ConnectScreenSrc).toMatch(/disconnectWithQueueGuard\(\)/);
+  });
+
+  it('does NOT call useConnectionStore.getState().disconnect() in the Cancel handler', () => {
+    // The old auto-connect cancel called useConnectionStore.getState().disconnect() inline.
+    // After the fix, it should go through the guard instead.
+    expect(ConnectScreenSrc).not.toMatch(/useConnectionStore\.getState\(\)\.disconnect\(\)/);
+  });
+});
+
+describe('SessionScreen.tsx reconnect banner Disconnect (#6081 — DRY refactor of #6080)', () => {
+  it('imports disconnectWithQueueGuard', () => {
+    expect(SessionScreenSrc).toMatch(/import \{ disconnectWithQueueGuard \} from ['"]\.\.\/store\/disconnectWithQueueGuard['"]/);
+  });
+
+  it('handleStopReconnecting is assigned to disconnectWithQueueGuard (no inline copy)', () => {
+    expect(SessionScreenSrc).toMatch(/const handleStopReconnecting = disconnectWithQueueGuard/);
+  });
+
+  it('reconnect banner still wires Disconnect affordance to handleStopReconnecting', () => {
+    // The JSX reference stays the same — only the implementation moved.
+    expect(SessionScreenSrc).toMatch(/onPress=\{handleStopReconnecting\}/);
+  });
+
+  it('does NOT contain a second inline Alert.alert("Discard unsent messages?" …) copy', () => {
+    // There must be exactly zero inline Discard-unsent-messages Alert calls in
+    // SessionScreen now that the logic lives in the shared helper.
+    const matches = SessionScreenSrc.match(/Alert\.alert\(\s*'Discard unsent messages\?'/g);
+    expect(matches).toBeNull();
+  });
+});

--- a/packages/app/src/__tests__/screens/SessionScreenQueuedCountBanner.test.ts
+++ b/packages/app/src/__tests__/screens/SessionScreenQueuedCountBanner.test.ts
@@ -1,5 +1,5 @@
 /**
- * #5699 (part 2) — SessionScreen reconnect-banner queued-count + discard warning.
+ * #5699 (part 2) / #6081 — SessionScreen reconnect-banner queued-count + discard warning.
  *
  * While disconnected, typed input is buffered (message-handler queue) and mirrored
  * into the store as `queuedMessageCount`. The reconnect banner must surface that
@@ -8,10 +8,17 @@
  * the queue, so silently discarding typed input on a tap is the exact silent-loss
  * bug #5699 fixes.
  *
+ * #6081 refactored the inline Alert logic into the shared `disconnectWithQueueGuard`
+ * helper so all give-up paths (header button, ConnectScreen cancel, this banner)
+ * behave identically. SessionScreen now delegates to that helper rather than
+ * re-implementing the same Alert.
+ *
  * No `@testing-library/react-native` in this repo (see SessionScreenStoppedBanner
  * .test.ts), so this verifies the wire-up via source-text parsing; the queue/count
  * runtime behaviour is exercised against the real store in
- * __tests__/store/message-queue.test.ts and connection.test.ts.
+ * __tests__/store/message-queue.test.ts and connection.test.ts. The shared guard's
+ * logic (Alert shown / Disconnect calls disconnect / Keep waiting noop) is exercised
+ * in __tests__/store/disconnectWithQueueGuard.test.ts.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -21,7 +28,7 @@ const SessionScreenSrc = fs.readFileSync(
   'utf-8',
 );
 
-describe('SessionScreen reconnect queued-count banner (#5699)', () => {
+describe('SessionScreen reconnect queued-count banner (#5699 / #6081)', () => {
   it('selects queuedMessageCount from the store', () => {
     expect(SessionScreenSrc).toMatch(
       /const queuedMessageCount = useConnectionStore\(\(s\) => s\.queuedMessageCount\)/,
@@ -38,19 +45,15 @@ describe('SessionScreen reconnect queued-count banner (#5699)', () => {
     expect(SessionScreenSrc).toMatch(/onPress=\{handleStopReconnecting\}/);
   });
 
-  it('warns with a discard Alert before disconnecting when input is queued', () => {
-    expect(SessionScreenSrc).toMatch(/const handleStopReconnecting = useCallback\(\(\) => \{/);
-    expect(SessionScreenSrc).toMatch(/if \(queuedMessageCount > 0\)/);
-    expect(SessionScreenSrc).toMatch(/Alert\.alert\(\s*'Discard unsent messages\?'/);
+  it('handleStopReconnecting delegates to disconnectWithQueueGuard (DRY — no inline Alert copy)', () => {
+    // #6081: the inline useCallback + Alert logic moved to the shared helper.
+    expect(SessionScreenSrc).toMatch(/import \{ disconnectWithQueueGuard \} from ['"]\.\.\/store\/disconnectWithQueueGuard['"]/);
+    expect(SessionScreenSrc).toMatch(/const handleStopReconnecting = disconnectWithQueueGuard/);
   });
 
-  it('offers Keep waiting / Disconnect choices, with Disconnect calling disconnect', () => {
-    expect(SessionScreenSrc).toMatch(/text: 'Keep waiting', style: 'cancel'/);
-    expect(SessionScreenSrc).toMatch(/text: 'Disconnect', style: 'destructive', onPress: disconnect/);
-  });
-
-  it('falls through to a plain disconnect() when nothing is queued', () => {
-    // After the queued-count guard returns, the no-queue path calls disconnect directly.
-    expect(SessionScreenSrc).toMatch(/return;\s*\}\s*disconnect\(\);\s*\}, \[queuedMessageCount, disconnect\]\)/);
+  it('does NOT contain an inline "Discard unsent messages?" Alert in SessionScreen itself', () => {
+    // The shared helper owns this; verifying the copy was removed from the screen.
+    const inlineAlerts = SessionScreenSrc.match(/Alert\.alert\(\s*'Discard unsent messages\?'/g);
+    expect(inlineAlerts).toBeNull();
   });
 });

--- a/packages/app/src/__tests__/store/disconnectWithQueueGuard.test.ts
+++ b/packages/app/src/__tests__/store/disconnectWithQueueGuard.test.ts
@@ -1,0 +1,117 @@
+/**
+ * disconnectWithQueueGuard logic tests (#6081).
+ *
+ * The helper reads queuedMessageCount from the store imperatively and either:
+ *   a) disconnects immediately when no messages are queued, or
+ *   b) shows a confirmation Alert when messages are queued, disconnecting only
+ *      if the user chooses the destructive "Disconnect" action.
+ *
+ * Tests run against the real helper with store + Alert.alert mocked so we can
+ * assert on call arguments without a native runtime.
+ */
+
+import { Alert } from 'react-native';
+
+// We need to mock the connection store before importing the helper,
+// so the helper's module-level getState() picks up the mock.
+jest.mock('react-native', () => {
+  const rn = jest.requireActual('react-native');
+  return { ...rn, Alert: { alert: jest.fn() } };
+});
+
+const mockDisconnect = jest.fn();
+let _queuedMessageCount = 0;
+
+jest.mock('../../store/connection', () => ({
+  useConnectionStore: {
+    getState: () => ({
+      disconnect: mockDisconnect,
+      queuedMessageCount: _queuedMessageCount,
+    }),
+  },
+}));
+
+// Import AFTER mocks are set up.
+import { disconnectWithQueueGuard } from '../../store/disconnectWithQueueGuard';
+
+// Cast for convenience — jest.mock replaces the real Alert.alert.
+const mockAlertAlert = Alert.alert as jest.Mock;
+
+describe('disconnectWithQueueGuard (#6081)', () => {
+  beforeEach(() => {
+    _queuedMessageCount = 0;
+    mockDisconnect.mockClear();
+    mockAlertAlert.mockClear();
+  });
+
+  describe('when the queue is empty (queuedMessageCount === 0)', () => {
+    it('calls disconnect() immediately without showing an Alert', () => {
+      _queuedMessageCount = 0;
+      disconnectWithQueueGuard();
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+      expect(mockAlertAlert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when messages are queued (queuedMessageCount > 0)', () => {
+    it('shows the "Discard unsent messages?" Alert and does NOT disconnect immediately', () => {
+      _queuedMessageCount = 2;
+      disconnectWithQueueGuard();
+      expect(mockAlertAlert).toHaveBeenCalledTimes(1);
+      expect(mockAlertAlert.mock.calls[0][0]).toBe('Discard unsent messages?');
+      expect(mockDisconnect).not.toHaveBeenCalled();
+    });
+
+    it('Alert title is "Discard unsent messages?" with correct body for plural count', () => {
+      _queuedMessageCount = 3;
+      disconnectWithQueueGuard();
+      const [title, body] = mockAlertAlert.mock.calls[0] as [string, string];
+      expect(title).toBe('Discard unsent messages?');
+      expect(body).toContain('3 unsent messages');
+      expect(body).toContain('them');
+    });
+
+    it('Alert body uses singular grammar for exactly 1 queued message', () => {
+      _queuedMessageCount = 1;
+      disconnectWithQueueGuard();
+      const [, body] = mockAlertAlert.mock.calls[0] as [string, string];
+      expect(body).toContain('1 unsent message');
+      expect(body).not.toContain('messages waiting');
+      expect(body).toContain('it');
+    });
+
+    it('Alert has a "Keep waiting" cancel button and a "Disconnect" destructive button', () => {
+      _queuedMessageCount = 1;
+      disconnectWithQueueGuard();
+      const buttons = mockAlertAlert.mock.calls[0][2] as Array<{ text: string; style: string; onPress?: () => void }>;
+      expect(buttons).toHaveLength(2);
+      const keep = buttons.find((b) => b.text === 'Keep waiting');
+      const disc = buttons.find((b) => b.text === 'Disconnect');
+      expect(keep).toBeDefined();
+      expect(keep!.style).toBe('cancel');
+      expect(disc).toBeDefined();
+      expect(disc!.style).toBe('destructive');
+    });
+
+    it('"Disconnect" button onPress calls disconnect()', () => {
+      _queuedMessageCount = 1;
+      disconnectWithQueueGuard();
+      const buttons = mockAlertAlert.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+      const disc = buttons.find((b) => b.text === 'Disconnect');
+      expect(disc!.onPress).toBeDefined();
+      disc!.onPress!();
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('"Keep waiting" does not call disconnect()', () => {
+      _queuedMessageCount = 1;
+      disconnectWithQueueGuard();
+      const buttons = mockAlertAlert.mock.calls[0][2] as Array<{ text: string; style: string; onPress?: () => void }>;
+      const keep = buttons.find((b) => b.text === 'Keep waiting');
+      // cancel-style buttons have no onPress (or it is undefined/void) — just
+      // confirm disconnect was NOT called after showing the alert.
+      keep?.onPress?.();
+      expect(mockDisconnect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/app/src/__tests__/store/disconnectWithQueueGuard.test.ts
+++ b/packages/app/src/__tests__/store/disconnectWithQueueGuard.test.ts
@@ -12,21 +12,16 @@
 
 import { Alert } from 'react-native';
 
-// We need to mock the connection store before importing the helper,
-// so the helper's module-level getState() picks up the mock.
-jest.mock('react-native', () => {
-  const rn = jest.requireActual('react-native');
-  return { ...rn, Alert: { alert: jest.fn() } };
-});
-
+// Mock the connection store before importing the helper, so the helper's
+// module-level getState() picks up the mock.
 const mockDisconnect = jest.fn();
-let _queuedMessageCount = 0;
+let mockQueuedMessageCount = 0;
 
 jest.mock('../../store/connection', () => ({
   useConnectionStore: {
     getState: () => ({
       disconnect: mockDisconnect,
-      queuedMessageCount: _queuedMessageCount,
+      queuedMessageCount: mockQueuedMessageCount,
     }),
   },
 }));
@@ -34,19 +29,20 @@ jest.mock('../../store/connection', () => ({
 // Import AFTER mocks are set up.
 import { disconnectWithQueueGuard } from '../../store/disconnectWithQueueGuard';
 
-// Cast for convenience — jest.mock replaces the real Alert.alert.
-const mockAlertAlert = Alert.alert as jest.Mock;
+// Spy on the jest-expo-provided Alert.alert rather than re-mocking all of
+// react-native (a full requireActual triggers the DevMenu TurboModule error).
+const mockAlertAlert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
 describe('disconnectWithQueueGuard (#6081)', () => {
   beforeEach(() => {
-    _queuedMessageCount = 0;
+    mockQueuedMessageCount = 0;
     mockDisconnect.mockClear();
     mockAlertAlert.mockClear();
   });
 
   describe('when the queue is empty (queuedMessageCount === 0)', () => {
     it('calls disconnect() immediately without showing an Alert', () => {
-      _queuedMessageCount = 0;
+      mockQueuedMessageCount = 0;
       disconnectWithQueueGuard();
       expect(mockDisconnect).toHaveBeenCalledTimes(1);
       expect(mockAlertAlert).not.toHaveBeenCalled();
@@ -55,7 +51,7 @@ describe('disconnectWithQueueGuard (#6081)', () => {
 
   describe('when messages are queued (queuedMessageCount > 0)', () => {
     it('shows the "Discard unsent messages?" Alert and does NOT disconnect immediately', () => {
-      _queuedMessageCount = 2;
+      mockQueuedMessageCount = 2;
       disconnectWithQueueGuard();
       expect(mockAlertAlert).toHaveBeenCalledTimes(1);
       expect(mockAlertAlert.mock.calls[0][0]).toBe('Discard unsent messages?');
@@ -63,7 +59,7 @@ describe('disconnectWithQueueGuard (#6081)', () => {
     });
 
     it('Alert title is "Discard unsent messages?" with correct body for plural count', () => {
-      _queuedMessageCount = 3;
+      mockQueuedMessageCount = 3;
       disconnectWithQueueGuard();
       const [title, body] = mockAlertAlert.mock.calls[0] as [string, string];
       expect(title).toBe('Discard unsent messages?');
@@ -72,7 +68,7 @@ describe('disconnectWithQueueGuard (#6081)', () => {
     });
 
     it('Alert body uses singular grammar for exactly 1 queued message', () => {
-      _queuedMessageCount = 1;
+      mockQueuedMessageCount = 1;
       disconnectWithQueueGuard();
       const [, body] = mockAlertAlert.mock.calls[0] as [string, string];
       expect(body).toContain('1 unsent message');
@@ -81,7 +77,7 @@ describe('disconnectWithQueueGuard (#6081)', () => {
     });
 
     it('Alert has a "Keep waiting" cancel button and a "Disconnect" destructive button', () => {
-      _queuedMessageCount = 1;
+      mockQueuedMessageCount = 1;
       disconnectWithQueueGuard();
       const buttons = mockAlertAlert.mock.calls[0][2] as Array<{ text: string; style: string; onPress?: () => void }>;
       expect(buttons).toHaveLength(2);
@@ -94,7 +90,7 @@ describe('disconnectWithQueueGuard (#6081)', () => {
     });
 
     it('"Disconnect" button onPress calls disconnect()', () => {
-      _queuedMessageCount = 1;
+      mockQueuedMessageCount = 1;
       disconnectWithQueueGuard();
       const buttons = mockAlertAlert.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
       const disc = buttons.find((b) => b.text === 'Disconnect');
@@ -104,7 +100,7 @@ describe('disconnectWithQueueGuard (#6081)', () => {
     });
 
     it('"Keep waiting" does not call disconnect()', () => {
-      _queuedMessageCount = 1;
+      mockQueuedMessageCount = 1;
       disconnectWithQueueGuard();
       const buttons = mockAlertAlert.mock.calls[0][2] as Array<{ text: string; style: string; onPress?: () => void }>;
       const keep = buttons.find((b) => b.text === 'Keep waiting');

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { CameraView, useCameraPermissions, BarcodeScanningResult } from 'expo-camera';
 import * as Network from 'expo-network';
 import { useConnectionStore } from '../store/connection';
+import { disconnectWithQueueGuard } from '../store/disconnectWithQueueGuard';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { setPendingPairingId, setPendingPairingIdentityKey } from '../store/message-handler';
 import { Icon } from '../components/Icon';
@@ -348,7 +349,7 @@ export function ConnectScreen() {
           style={styles.autoConnectCancel}
           onPress={() => {
             setAutoConnecting(false);
-            useConnectionStore.getState().disconnect();
+            disconnectWithQueueGuard();
           }}
           accessibilityRole="button"
           accessibilityLabel="Cancel connection attempt"

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -63,6 +63,7 @@ import { pickFromCamera, pickFromGallery, pickDocument, toWireAttachments, MAX_A
 import type { Attachment } from '../utils/attachments';
 import { formatPasteMarker, expandPasteMarkers } from '@chroxy/store-core';
 import { PastedTextModal } from '../components/PastedTextModal';
+import { disconnectWithQueueGuard } from '../store/disconnectWithQueueGuard';
 
 
 // Stable empty arrays to avoid new-reference-per-render in Zustand selectors
@@ -223,9 +224,8 @@ export function SessionScreen() {
   const setViewMode = useConnectionStore((s) => s.setViewMode);
   const sendInput = useConnectionStore((s) => s.sendInput);
   const sendInterrupt = useConnectionStore((s) => s.sendInterrupt);
-  const disconnect = useConnectionStore((s) => s.disconnect);
   // #5699 — reactive count of queued (unsent) messages, surfaced in the
-  // reconnect banner and used to warn before a manual disconnect discards them.
+  // reconnect banner so held input isn't invisible to the user.
   const queuedMessageCount = useConnectionStore((s) => s.queuedMessageCount);
   // #5725 (#5698) — manual retry from the terminal `server_down` banner.
   const retryConnection = useConnectionStore((s) => s.retryConnection);
@@ -926,24 +926,10 @@ export function SessionScreen() {
     inputRef.current?.focus();
   }, []);
 
-  // #5699 — manual disconnect during a reconnect discards the outgoing queue
-  // (disconnect() calls clearMessageQueue). Warn first when there are unsent
-  // messages so the user doesn't silently lose typed input by giving up.
-  const handleStopReconnecting = useCallback(() => {
-    if (queuedMessageCount > 0) {
-      const n = queuedMessageCount;
-      Alert.alert(
-        'Discard unsent messages?',
-        `You have ${n} unsent message${n === 1 ? '' : 's'} waiting to send. Disconnecting will discard ${n === 1 ? 'it' : 'them'}.`,
-        [
-          { text: 'Keep waiting', style: 'cancel' },
-          { text: 'Disconnect', style: 'destructive', onPress: disconnect },
-        ],
-      );
-      return;
-    }
-    disconnect();
-  }, [queuedMessageCount, disconnect]);
+  // #5699 / #6081 — manual disconnect during a reconnect discards the outgoing
+  // queue (disconnect() calls clearMessageQueue). Delegate to the shared guard
+  // so all give-up paths warn identically before silently losing typed input.
+  const handleStopReconnecting = disconnectWithQueueGuard;
 
   const handleInvokeAgent = useCallback((agentName: string) => {
     inputRef.current?.setValue(`@${agentName} `);

--- a/packages/app/src/store/disconnectWithQueueGuard.ts
+++ b/packages/app/src/store/disconnectWithQueueGuard.ts
@@ -1,0 +1,51 @@
+/**
+ * disconnectWithQueueGuard — shared helper for manual-disconnect entry points.
+ *
+ * Several UI affordances let the user give up the connection (header Disconnect
+ * button, ConnectScreen auto-connect Cancel, reconnect-banner Disconnect).  All
+ * of them eventually call disconnect(), which also calls clearMessageQueue() —
+ * so any typed-but-unsent messages are silently discarded.
+ *
+ * This helper centralises the "warn first if there are queued messages" gate so
+ * every give-up path behaves identically (#6081 parity with #5699/#6080).
+ *
+ * Usage (outside React components — reads store imperatively):
+ *
+ *   import { disconnectWithQueueGuard } from '../store/disconnectWithQueueGuard';
+ *   // ...
+ *   onPress={disconnectWithQueueGuard}
+ *
+ * Usage inside a React component that already has a `disconnect` ref:
+ *
+ *   const disconnect = useConnectionStore((s) => s.disconnect);
+ *   // Still call the module-level helper — it reads the same store.
+ *   onPress={disconnectWithQueueGuard}
+ */
+import { Alert } from 'react-native';
+import { useConnectionStore } from './connection';
+
+/**
+ * Call disconnect() — but when the outgoing queue is non-empty, show a
+ * confirmation Alert first so the user can choose to keep waiting instead
+ * of silently discarding unsent messages.
+ *
+ * This is a plain function (not a hook) so it can be used as an `onPress`
+ * handler in both component callbacks and static navigator option factories
+ * (e.g. `options={{ headerRight: () => … }}`).
+ */
+export function disconnectWithQueueGuard(): void {
+  const { disconnect, queuedMessageCount } = useConnectionStore.getState();
+  if (queuedMessageCount > 0) {
+    const n = queuedMessageCount;
+    Alert.alert(
+      'Discard unsent messages?',
+      `You have ${n} unsent message${n === 1 ? '' : 's'} waiting to send. Disconnecting will discard ${n === 1 ? 'it' : 'them'}.`,
+      [
+        { text: 'Keep waiting', style: 'cancel' },
+        { text: 'Disconnect', style: 'destructive', onPress: disconnect },
+      ],
+    );
+    return;
+  }
+  disconnect();
+}


### PR DESCRIPTION
## Summary

Follow-up from review of #6080 (#5699 part 2). That PR added the "Discard unsent messages?" warning only to the reconnect banner's Disconnect (`handleStopReconnecting`). Two other manual-disconnect entry points still called `disconnect()` directly — and `disconnect()` runs `clearMessageQueue()`, silently dropping queued input:

- `App.tsx` — the Session screen's persistent header **Disconnect** button (primary gap)
- `ConnectScreen.tsx` — the auto-connect **Cancel** button (lower risk, pre-session)

Extracts the count-check + Alert-confirm into a shared `disconnectWithQueueGuard()` helper (`packages/app/src/store/disconnectWithQueueGuard.ts`) and routes **all three** give-up paths through it (DRY — `handleStopReconnecting` now delegates too). Same Alert copy/buttons as #6080. `SettingsScreen`'s "Clear Session History" (already warns) is left as-is.

## Test plan

- `disconnectWithQueueGuard.test.ts` — helper logic: count 0 → immediate disconnect, count > 0 → Alert (singular/plural copy, Keep waiting / Disconnect buttons), Disconnect onPress calls `disconnect()`. 7 passed.
- `DisconnectQueueGuardRouting.test.ts` — source-parse: all three call sites import + use the guard, no raw `disconnect()`.
- `SessionScreenQueuedCountBanner.test.ts` — updated for the DRY delegation.
- Full app jest suite (1998) + tsc clean.

Closes #6081
Related to #5699, #6080