### PR TITLE
test(app): Maestro flow — permission tap while disconnected is a no-op (#5699)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ When you modify app components (screens, UI elements, styling), verify with Maes
 | `manual-connect.yaml` | Manual entry form, URL input, Connect → optimistic SessionScreen + reconnect banner on unreachable server, header Disconnect back to ConnectScreen |
 | `lan-scan.yaml` | LAN scan trigger, in-progress or results state (scan can finish near-instantly) |
 | `chat-todolist.yaml` | TodoList renderer end-to-end (mock-server emits TodoWrite tool_use+tool_result, entry expands, structured TodoList renders with testIDs) |
-| `run-all.yaml` | Runs all 20 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, …) |
+| `run-all.yaml` | Runs all 22 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, …) |
 
 ### Fixture Seeding for Structured Renderers
 

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -43,6 +43,21 @@ let connectionCounter = 0
 // the flag stays consumed/unset, and reconnect.yaml fails at the assertion.
 let sawSimulateDisconnect = false
 
+// #5699: timed reconnect-hold. `simulate-disconnect-hold` drops the socket AND
+// makes the HTTP health endpoint return 503 for RECONNECT_HOLD_MS, so the app's
+// pre-WS health check keeps failing and the reconnect ladder stays in the
+// `reconnecting` phase — a STABLE disconnected window the
+// permission-disconnected-noop flow can assert against. The plain
+// `simulate-disconnect` window is ~1s (the mock health stays 200, so the app
+// re-dials almost immediately — see reconnect.yaml's "~1-in-3 catch rate"
+// note), too racy to tap a button inside. The hold self-releases (health 200
+// again) well before the ladder's 10-rung give-up (~59s → terminal
+// server_down), so the app auto-reconnects and the flow leaves the app usable
+// for the next run-all flow. reconnectHoldUntil is an absolute epoch-ms
+// deadline; 0 means "no hold active".
+const RECONNECT_HOLD_MS = 10000
+let reconnectHoldUntil = 0
+
 // #5469: per-connection counter for `show-stream-stall` hits.
 // On the SECOND trigger (within the same connection) the mock emits the
 // stall error with a distinguishable detail ("stall re-emission #2") and
@@ -134,6 +149,14 @@ function send(ws, msg) {
 
 const httpServer = createServer((req, res) => {
   if (req.method === 'GET' && (req.url === '/' || req.url === '/health')) {
+    // #5699: while a reconnect-hold is active, fail health so the app's pre-WS
+    // health check keeps the reconnect ladder in `reconnecting` (stable
+    // disconnected window for permission-disconnected-noop.yaml).
+    if (Date.now() < reconnectHoldUntil) {
+      res.writeHead(503, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ status: 'down', reason: 'reconnect-hold' }))
+      return
+    }
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ status: 'ok', mode: 'cli', hostname: 'mock-server', version: '0.1.0-test' }))
     return
@@ -515,6 +538,22 @@ wss.on('connection', (ws) => {
           sawSimulateDisconnect = true
           setTimeout(() => {
             console.log('[mock] simulate-disconnect — terminating WS')
+            try { ws.terminate() } catch {}
+          }, 1000)
+          break
+        }
+
+        // #5699: like simulate-disconnect, but ALSO holds the HTTP health
+        // endpoint down (503) for RECONNECT_HOLD_MS so the reconnect ladder
+        // can't re-dial immediately — a stable disconnected window the
+        // permission-disconnected-noop flow taps a permission button inside.
+        // The hold self-releases so the app auto-reconnects afterwards.
+        if (text.trim() === 'simulate-disconnect-hold') {
+          reconnectHoldUntil = Date.now() + RECONNECT_HOLD_MS
+          setTimeout(() => {
+            console.log(
+              `[mock] simulate-disconnect-hold — terminating WS; health 503 for ${RECONNECT_HOLD_MS}ms`,
+            )
             try { ws.terminate() } catch {}
           }, 1000)
           break

--- a/packages/app/.maestro/permission-disconnected-noop.yaml
+++ b/packages/app/.maestro/permission-disconnected-noop.yaml
@@ -119,4 +119,10 @@ name: Permission tap while disconnected is a no-op (#5699)
       id: "prompt-disconnected-hint"
     timeout: 10000
 
+# The prompt bubble survived the reconnect (it lives in cached history) and is
+# answerable again now that the gate cleared — assert the option button is still
+# present so "recovery" means a usable prompt, not a wiped one.
+- assertVisible:
+    id: "approval-button-approve"
+
 - takeScreenshot: permission-disconnected-recovered

--- a/packages/app/.maestro/permission-disconnected-noop.yaml
+++ b/packages/app/.maestro/permission-disconnected-noop.yaml
@@ -1,0 +1,122 @@
+appId: com.blamechris.chroxy
+name: Permission tap while disconnected is a no-op (#5699)
+---
+
+# #5699 — End-to-end coverage for the LAST acceptance criterion of the
+# optimistic-action-loss fix: tapping a permission / AskUserQuestion option
+# while the session is DISCONNECTED must be a no-op with clear feedback, NOT a
+# silent loss (the bubble flips to "answered" but the answer never reaches the
+# now-expired pending request on the server).
+#
+# The fix is two layers, both pinned here:
+#   (a) UI gate — MessageBubble disables the option buttons when
+#       `connectionPhase !== 'connected'` (isDisabled = ... || !connected) and
+#       renders the `prompt-disconnected-hint` caption
+#       ("Disconnected — reconnect to respond").
+#   (b) Store gate — SessionScreen.handleSelectOption only calls
+#       markPromptAnswered `if (sent === 'sent')`, and sendUserQuestionResponse
+#       returns false while the socket isn't OPEN. So even a tap that slipped
+#       past the UI gate produces NO optimistic "answered" state.
+#
+# Non-vacuity: the load-bearing assertion is that AFTER tapping Approve while
+# disconnected, the prompt is STILL unanswered — `prompt-disconnected-hint`
+# stays visible (it renders only while `!connected && answered == null`). If a
+# regression let the tap optimistically answer the bubble (the original #5699
+# bug), `answered` becomes non-null, the hint disappears, and this flow fails.
+#
+# Stable disconnected window: the plain `simulate-disconnect` trigger drops the
+# socket but leaves mock health at 200, so the app re-dials in ~1s — too racy
+# to tap a button inside (see reconnect.yaml). This flow uses
+# `simulate-disconnect-hold`, which additionally fails the mock's HTTP health
+# endpoint (503) for ~10s so the reconnect ladder stays in `reconnecting`. The
+# hold self-releases well before the ladder's 10-rung give-up (~59s →
+# server_down), so the app auto-reconnects at the end and the flow leaves it
+# usable for the next run-all flow.
+#
+# Deliberately RED run (for on-device verification): comment out the
+# `!connected` term in MessageBubble's `isDisabled` AND the `sent === 'sent'`
+# guard in SessionScreen.handleSelectOption — the tap then optimistically
+# answers the bubble, the hint disappears, and the post-tap
+# `assertVisible: prompt-disconnected-hint` times out.
+#
+# Tested devices: portrait iPhone (iOS 17+). Mirrors ask-user-question /
+# reconnect flows.
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+
+- runFlow: setup/ensure-session-screen.yaml
+
+# Ensure Chat tab.
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+# Seed an AskUserQuestion prompt (Approve / Deny options) while connected.
+- tapOn:
+    id: "chat-message-input"
+- inputText: "show-ask-user-question"
+
+- tapOn:
+    id: "chat-send-button"
+
+# Prompt bubble renders with both option buttons (connected baseline).
+- extendedWaitUntil:
+    visible:
+      id: "approval-button-approve"
+    timeout: 10000
+- assertVisible:
+    id: "approval-button-deny"
+
+# Now drop the connection AND hold it down so we have a stable disconnected
+# window. Mock terminates the WS ~1s later and returns 503 from /health for
+# ~10s, keeping the app in `reconnecting`.
+- tapOn:
+    id: "chat-message-input"
+- inputText: "simulate-disconnect-hold"
+
+- tapOn:
+    id: "chat-send-button"
+
+# Clear feedback appears: the prompt bubble shows the disconnected hint. This
+# proves we reached a non-connected phase AND the prompt is still unanswered
+# (the hint renders only while `!connected && answered == null`).
+- extendedWaitUntil:
+    visible:
+      id: "prompt-disconnected-hint"
+    timeout: 20000
+
+- takeScreenshot: permission-disconnected-hint
+
+# Attempt to answer while disconnected. The button is disabled (UI gate), so
+# onPress should not fire; even if it did, the store gate refuses the send and
+# never marks answered. Either way this must be a no-op.
+- tapOn:
+    id: "approval-button-approve"
+- waitForAnimationToEnd
+
+# Load-bearing no-op assertion: the prompt is STILL unanswered. The hint stays
+# visible (it requires `answered == null`); if the tap had optimistically
+# answered the bubble, the hint would be gone and this assertion would fail.
+- assertVisible:
+    id: "prompt-disconnected-hint"
+- assertVisible:
+    id: "approval-button-approve"
+
+- takeScreenshot: permission-disconnected-after-tap-noop
+
+# Recovery: the hold self-releases (health → 200) and the app auto-reconnects.
+# Wait for the connected happy-path layout (the input placeholder flips back to
+# "Message Claude...") so the flow leaves the app usable for the next flow and
+# proves the disconnect was transient, not a crash.
+- extendedWaitUntil:
+    visible:
+      text: "Message Claude..."
+    timeout: 30000
+
+# Once reconnected, the disconnected hint is gone (connected → the gate clears).
+- extendedWaitUntil:
+    notVisible:
+      id: "prompt-disconnected-hint"
+    timeout: 10000
+
+- takeScreenshot: permission-disconnected-recovered

--- a/packages/app/.maestro/run-all.yaml
+++ b/packages/app/.maestro/run-all.yaml
@@ -122,3 +122,13 @@ name: All E2E flows
 # encrypted assistant message round-trip. See key-exchange.yaml header
 # for on-device verification notes and assumptions.
 - runFlow: key-exchange.yaml
+
+# Flow 22: Permission tap while disconnected is a no-op (#5699) — pins
+# the last acceptance criterion of the optimistic-action-loss fix:
+# seeds an AskUserQuestion prompt, drops + holds the connection down
+# (mock 'simulate-disconnect-hold' fails /health for ~10s), asserts the
+# `prompt-disconnected-hint` feedback, taps Approve, and asserts the
+# bubble is STILL unanswered (hint persists). The non-vacuity hinge —
+# a regression that optimistically answered the tap would clear the
+# hint and fail the flow. Recovers via the self-releasing hold.
+- runFlow: permission-disconnected-noop.yaml


### PR DESCRIPTION
## Summary

Adds the final piece of **#5699** (optimistic actions on a disconnected/cached session can be silently lost): the device-gated Maestro E2E flow for the last acceptance criterion —

> Tests/Maestro flow cover: tap permission while disconnected → no-op + clear feedback

Parts 1 and 2 of #5699 (the `!connected` button gate + the `prompt-disconnected-hint` feedback, the queued-count banner, and the disconnect-discard prompt) already merged. This PR is the E2E coverage that pins the user-facing guarantee.

## What it verifies

The #5699 fix is two layers, both pinned:
- **UI gate** — `MessageBubble` disables the option buttons when `connectionPhase !== 'connected'` and renders the `prompt-disconnected-hint` caption ("Disconnected — reconnect to respond").
- **Store gate** — `SessionScreen.handleSelectOption` only calls `markPromptAnswered` `if (sent === 'sent')`, and `sendUserQuestionResponse` returns `false` while the socket isn't OPEN — so a tap produces **no** optimistic "answered" state.

**Flow** (`permission-disconnected-noop.yaml`): seed an AskUserQuestion prompt → drop + hold the connection down → assert the `prompt-disconnected-hint` feedback → tap Approve → assert the bubble is **still unanswered** (hint persists) → recover.

## Non-vacuity (RED-verified on-device)

The load-bearing assertion is the post-tap `prompt-disconnected-hint` still being visible — it renders only while `!connected && answered == null`. Verified on iPhone 16 Pro (iOS 18.6):
- **GREEN** on real code (all steps COMPLETED).
- **RED** with the `!connected` gate and the `sent === 'sent'` guard removed — the tap optimistically answers, the hint disappears, and the flow fails exactly at that assertion.

## Stable disconnected window

The plain `simulate-disconnect` trigger leaves mock `/health` at 200, so the app re-dials in ~1s — too racy to tap a button inside (see reconnect.yaml's "~1-in-3 catch rate" note). New `simulate-disconnect-hold` trigger drops the WS **and** returns 503 from `/health` for ~10s so the reconnect ladder stays in `reconnecting`. The hold self-releases well before the ladder's 10-rung give-up (~59s → terminal `server_down`), so the app auto-reconnects and the flow leaves the app usable for the next run-all flow.

## Changes

- `packages/app/.maestro/permission-disconnected-noop.yaml` — new flow.
- `packages/app/.maestro/mock-server.mjs` — `simulate-disconnect-hold` trigger + timed health-503 hold.
- `packages/app/.maestro/run-all.yaml` — register as Flow 22.

No production source changes.

Closes #5699