### PR TITLE
ci(server): make Server Tests container-portable + move to self-hosted Linux (#6075)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,10 @@ permissions:
 # is not a `runner-target` consumer). The Windows job stays GitHub-hosted (no
 # self-hosted Windows box). After the Linux runner was bumped to 24GB (#6046),
 # Store Core Tests and App Tests moved to the self-hosted pool (their blocker was
-# npm-ci/transform OOM, not arch). Server Tests stays GitHub-hosted — RAM was
-# ruled out; 9 tests fail on the ARM64 container from genuine env differences
-# (keychain, Docker-in-Docker, fs perms) — tracked in #6075.
+# npm-ci/transform OOM, not arch). Server Tests moved too once #6075 made the
+# suite container-portable (the 9 ARM64-container failures were genuine env
+# differences — root-bypassed fs perms, $HOME assumptions, a uuidgen dependency —
+# not RAM); see the server-tests job comment.
 
 jobs:
   runner-target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,16 @@ jobs:
           fi
   server-tests:
     name: Server Tests
-    # Stays GitHub-hosted (#6046): RAM was ruled out — with the self-hosted
-    # runner at 24GB, 9 tests still fail on the ARM64 Linux container from
-    # genuine env differences (keychain rekey, create_environment /
-    # Docker-in-Docker, disk-cache paths, permission-hook pipeline,
-    # ws-file-ops + directory-listing fs perms). Making the server suite
-    # container-portable is tracked in #6075.
-    runs-on: ubuntu-24.04
+    # Moved to the self-hosted Linux pool (#6075). #6046 left this GitHub-hosted
+    # because 9 tests failed on the ARM64 Linux container from genuine env
+    # differences; #6075 made the suite container-portable (root bypasses POSIX
+    # perm bits → skip those asserts; tests that assumed the repo lives under
+    # $HOME now use $HOME-relative paths; the per-turn hook filenames fall back
+    # to /proc/sys/kernel/random/uuid when uuidgen is absent). Verified 0-fail
+    # on node:22-bookworm as root. Fork PRs still route to ubuntu-24.04 via
+    # runner-target (untrusted code never runs on the self-hosted machine).
+    needs: runner-target
+    runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}  # SELF_HOSTED_OR_HOSTED (see header)
     timeout-minutes: 10
     defaults:
       run:

--- a/packages/server/src/claude-tui/pty-driver.js
+++ b/packages/server/src/claude-tui/pty-driver.js
@@ -175,7 +175,14 @@ export function ensureCwdTrusted(cwd) {
 //   PreToolUse   → <sink>/pre-<uuid>.json    (one per tool call)
 //   PostToolUse  → <sink>/post-<uuid>.json   (one per tool call)
 //
-// `uuidgen` gives us atomic unique names cross-platform (macOS + Linux).
+// Unique filenames come from UUID_CMD below. `uuidgen` is the first choice
+// (always present on macOS, and on Linux when `uuid-runtime` is installed) but
+// it is NOT in a minimal Debian/Ubuntu container — a bare `$(uuidgen)` there
+// collapses to an empty string, so every event collides on `pre-.json` /
+// `post-.json` and the poller silently sees only the last one (#6075). We fall
+// back to the kernel UUID source (`/proc/sys/kernel/random/uuid`, present on
+// every Linux with no package) and finally to pid+nanoseconds. The expression
+// is POSIX-sh safe (no `$RANDOM`/bashisms) since claude may run hooks under sh.
 // IMPORTANT: do not use `mktemp <sink>/foo-XXXXXX.json` — macOS BSD mktemp
 // does NOT expand the X-template when there's a `.json` suffix after it,
 // so the file ends up named literally "foo-XXXXXX.json" and every turn
@@ -193,13 +200,15 @@ export function ensureCwdTrusted(cwd) {
 export function writeHookSettings(sinkDir, { permissionsEnabled }) {
   const settingsPath = join(sinkDir, 'settings.json')
   const sinkDirEsc = JSON.stringify(sinkDir)
+  // Portable unique-id source for hook filenames — see the UUID note above.
+  const UUID_CMD = '$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "$$-$(date +%s%N)")'
   // PreToolUse runs ALL registered hooks in order. We always capture the
   // event for our own observability; when permissions are enabled the
   // chroxy permission-hook.sh runs SECOND, gating the tool call via long-
   // poll to /permission. Claude waits for every hook to exit non-zero
   // before running the tool.
   const preToolUseHooks = [
-    { type: 'command', command: `cat > ${sinkDirEsc}/pre-$(uuidgen).json` },
+    { type: 'command', command: `cat > ${sinkDirEsc}/pre-${UUID_CMD}.json` },
   ]
   if (permissionsEnabled) {
     preToolUseHooks.push({
@@ -211,7 +220,7 @@ export function writeHookSettings(sinkDir, { permissionsEnabled }) {
   const settings = {
     hooks: {
       Stop: [
-        { hooks: [{ type: 'command', command: `cat > ${sinkDirEsc}/stop-$(uuidgen).json` }] },
+        { hooks: [{ type: 'command', command: `cat > ${sinkDirEsc}/stop-${UUID_CMD}.json` }] },
       ],
       PreToolUse: [
         { hooks: preToolUseHooks },
@@ -222,7 +231,7 @@ export function writeHookSettings(sinkDir, { permissionsEnabled }) {
         // because cat would consume stdin entirely, leaving the cleanup
         // hook with an empty payload.
         { hooks: [
-          { type: 'command', command: `tee ${sinkDirEsc}/post-$(uuidgen).json | grep -q '"tool_name":"AskUserQuestion"' && rm -rf ${sinkDirEsc}/askuserquestion-active || true` },
+          { type: 'command', command: `tee ${sinkDirEsc}/post-${UUID_CMD}.json | grep -q '"tool_name":"AskUserQuestion"' && rm -rf ${sinkDirEsc}/askuserquestion-active || true` },
         ] },
       ],
     },

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -292,7 +292,13 @@ describe('ClaudeTuiSession', () => {
       assert.ok(settings.hooks?.PreToolUse, 'PreToolUse hook present')
       assert.ok(settings.hooks?.PostToolUse, 'PostToolUse hook present')
       const stopCmd = settings.hooks.Stop[0].hooks[0].command
-      assert.match(stopCmd, /stop-\$\(uuidgen\)\.json/, 'Stop uses uuidgen for unique-per-turn names (mktemp + .json suffix breaks on BSD macOS)')
+      // Stop uses a $(...)-substituted unique name per turn (mktemp + .json
+      // suffix breaks on BSD macOS — see writeHookSettings note).
+      assert.match(stopCmd, /stop-\$\(uuidgen.*\)\.json/, 'Stop uses a $(...)-substituted unique-per-turn filename')
+      // #6075: uuidgen is absent on minimal Debian/Ubuntu containers, so the
+      // substitution MUST fall back to the kernel UUID source — otherwise every
+      // turn collides on `stop-.json` and the poller drops all but the last.
+      assert.match(stopCmd, /\/proc\/sys\/kernel\/random\/uuid/, 'uuid generation falls back to the kernel source when uuidgen is unavailable')
     })
 
     it('rejects + emits error if PTY exits during warmup (#5316)', async () => {

--- a/packages/server/tests/credential-rekey.test.js
+++ b/packages/server/tests/credential-rekey.test.js
@@ -18,6 +18,7 @@ import {
   setMasterKey,
 } from '../src/credential-cipher.js'
 import { runCredentialsRekey } from '../src/cli/credentials-cmd.js'
+import { POSIX_PERM_SKIP } from './test-helpers.js'
 
 /**
  * Credential data-key rotation / rekey (#5229). An in-memory keychain fake
@@ -167,8 +168,7 @@ describe('credential data-key rekey (#5229)', () => {
     assert.equal(keychain.getToken(CRED_KEY_SERVICE), keyBefore) // key never rotated
   })
 
-  it('rolls the keychain key back on a write failure so the existing store stays readable', (t) => {
-    if (process.platform === 'win32') return t.skip('dir-permission write failure not reproducible on win32')
+  it('rolls the keychain key back on a write failure so the existing store stays readable', { skip: POSIX_PERM_SKIP }, () => {
     setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-secret-value')
     const keyBefore = keychain.getToken(CRED_KEY_SERVICE)
     // Make the atomic temp-write fail: a read-only parent dir can't hold the tmp file.

--- a/packages/server/tests/environment-handlers.test.js
+++ b/packages/server/tests/environment-handlers.test.js
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { homedir } from 'node:os'
 import { featureHandlers as environmentHandlers } from '../src/handlers/feature-handlers.js'
 import { waitFor, nsCtx } from './test-helpers.js'
 
@@ -85,7 +86,12 @@ describe('create_environment handler', () => {
     const ctx = createMockCtx({ environmentManager: envManager })
 
     const handler = environmentHandlers.create_environment
-    handler(ws, client, { type: 'create_environment', name: 'test-env', cwd: process.cwd() }, ctx)
+    // Use the home directory as the cwd: validateCwdAllowed() requires the cwd
+    // to be within $HOME when no workspaceRoots are configured. process.cwd()
+    // is the repo, which is under $HOME on a dev machine but NOT in a CI
+    // container (repo at /work, home at /root) — that mismatch made the handler
+    // respond environment_error instead of environment_created (#6075).
+    handler(ws, client, { type: 'create_environment', name: 'test-env', cwd: homedir() }, ctx)
 
     // Handler is async (uses .then), wait for response
     await waitFor(() => ctx._sent.length >= 1, { label: 'environment_created response' })

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createModelsRegistry, canonicalStringify } from '../src/models.js'
 import { addLogListener, getLogLevel, removeLogListener, setLogLevel } from '../src/logger.js'
+import { POSIX_PERM_SKIP } from './test-helpers.js'
 
 describe('createModelsRegistry', () => {
   it('returns an object with all registry methods', () => {
@@ -427,10 +428,7 @@ describe('disk cache (loadCache / saveCache)', () => {
     assert.equal(statSync(cachePath).mtimeMs, beforeMtime, 'disk file should not be rewritten on clean load')
   })
 
-  it('saveCache swallows write errors (returns false) on read-only parent', () => {
-    // POSIX-only: chmod bits don't map cleanly to Windows ACLs, where the
-    // invoking user often retains write permission regardless. Skip there.
-    if (process.platform === 'win32') return
+  it('saveCache swallows write errors (returns false) on read-only parent', { skip: POSIX_PERM_SKIP }, () => {
     chmodSync(dir, 0o500)
     try {
       const r = createModelsRegistry()
@@ -512,8 +510,7 @@ describe('silent failure logging (#2830)', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('saveCache failure logs a warn with the path and error', () => {
-    if (process.platform === 'win32') return
+  it('saveCache failure logs a warn with the path and error', { skip: POSIX_PERM_SKIP }, () => {
     chmodSync(dir, 0o500)
     try {
       const r = createModelsRegistry()

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -8,6 +8,23 @@ export { GIT } from '../src/git.js'
 // Re-export the ctx-shape assert so handler tests can guard their mocks.
 export { assertCtxShape } from '../src/ws-handler-context.js'
 
+// Skip reason for tests that chmod a path to a restrictive mode (0o000 / 0o500)
+// and assert the resulting EACCES / write failure. Two environments can't
+// observe POSIX permission-bit denials:
+//   - root (e.g. a CI Linux container running as uid 0) bypasses mode bits
+//     entirely, so a "read-only" dir is still writable and a 0o000 dir is
+//     still readable — the expected denial never happens.
+//   - Windows ACLs don't map to chmod bits; the invoking user typically keeps
+//     access regardless.
+// Pass this straight to node:test's `{ skip }` option — it's a reason string
+// when skipping and `false` (i.e. run the test) otherwise. See #6075.
+export const POSIX_PERM_SKIP =
+  process.platform === 'win32'
+    ? 'Windows ACLs do not map to chmod permission bits'
+    : (typeof process.getuid === 'function' && process.getuid() === 0)
+      ? 'running as root (e.g. CI Linux container) bypasses Unix permission bits'
+      : false
+
 // Reverse index: flat field name -> namespace it belongs to. Derived from the
 // single source of truth (CTX_NAMESPACES) so the test mock builder can't drift.
 const FIELD_TO_NS = {}

--- a/packages/server/tests/ws-file-ops-error-paths.test.js
+++ b/packages/server/tests/ws-file-ops-error-paths.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, chmodSync, 
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { createFileOps } from '../src/ws-file-ops/index.js'
+import { POSIX_PERM_SKIP } from './test-helpers.js'
 
 describe('ws-file-ops error paths', () => {
   let tmp
@@ -24,7 +25,7 @@ describe('ws-file-ops error paths', () => {
     rmSync(tmp, { recursive: true, force: true })
   })
 
-  it('browseFiles returns Permission denied for EACCES', async () => {
+  it('browseFiles returns Permission denied for EACCES', { skip: POSIX_PERM_SKIP }, async () => {
     const noRead = join(tmp, 'noperm')
     mkdirSync(noRead)
     chmodSync(noRead, 0o000)

--- a/packages/server/tests/ws-server-file-ops.test.js
+++ b/packages/server/tests/ws-server-file-ops.test.js
@@ -200,16 +200,25 @@ describe('directory listing', () => {
     await waitForMessage(messages, 'auth_ok', 2000)
     messages.length = 0
 
-    // Use this test file itself as a file path
-    const filePath = new URL(import.meta.url).pathname
-    send(ws, { type: 'list_directory', path: filePath })
+    // list_directory restricts to $HOME, so the file under test must live there.
+    // Using this test file's own path only worked when the repo happened to be
+    // under $HOME (a dev machine); in a CI container the repo is at /work and
+    // the home-restriction fired first, masking the not-a-directory check
+    // (#6075). Create a real file inside $HOME instead.
+    const homeTmpDir = mkdtempSync(join(homedir(), '.chx-fileops-test-'))
+    const filePath = join(homeTmpDir, 'afile.txt')
+    writeFileSync(filePath, 'x')
+    try {
+      send(ws, { type: 'list_directory', path: filePath })
 
-    const listing = await waitForMessage(messages, 'directory_listing', 2000)
-    assert.ok(listing, 'Should receive directory_listing')
-    assert.equal(listing.error, 'Not a directory')
-    assert.deepEqual(listing.entries, [])
-
-    ws.close()
+      const listing = await waitForMessage(messages, 'directory_listing', 2000)
+      assert.ok(listing, 'Should receive directory_listing')
+      assert.equal(listing.error, 'Not a directory')
+      assert.deepEqual(listing.entries, [])
+    } finally {
+      rmSync(homeTmpDir, { recursive: true, force: true })
+      ws.close()
+    }
   })
 
   it('filters hidden directories', async () => {
@@ -277,7 +286,13 @@ describe('directory listing', () => {
     assert.ok(listing, 'Should receive directory_listing')
     assert.equal(listing.error, null)
     assert.ok(listing.path, 'Should have a resolved path')
-    assert.ok(listing.entries.length > 0, 'Home directory should have entries')
+    // The empty path must default to $HOME. Assert the resolved path IS the
+    // home directory rather than that home is non-empty — a fresh CI container
+    // home (/root) can be empty once hidden entries are filtered, which made
+    // the old entries>0 check fail there (#6075).
+    assert.equal(realpathSync(listing.path), realpathSync(homedir()),
+      'empty path should resolve to the home directory')
+    assert.ok(Array.isArray(listing.entries), 'entries should be an array')
 
     ws.close()
   })


### PR DESCRIPTION
## Summary

Closes **#6075**. #6046 left the Server Tests job GitHub-hosted because 9 tests failed on the ARM64 `node:22-bookworm` self-hosted container from genuine environment differences (RAM was ruled out). This PR makes the suite container-portable and routes the job to the self-hosted Linux pool.

**Verified 0-fail** on `node:22-bookworm` as root (full suite: 9938 pass, 18 skipped). This PR's own Server Tests run executes on the self-hosted Linux runner — real-world confirmation.

## Root causes & fixes

| Failure(s) | Root cause | Fix |
|---|---|---|
| `ws-file-ops EACCES`, `models-factory` read-only `saveCache` ×2, `credential-rekey` write-error | **root bypasses Unix permission bits** — `chmod 0o000/0o500` doesn't deny uid 0 | shared `POSIX_PERM_SKIP` guard (`test-helpers.js`) — skips only as root / on Windows, runs everywhere else |
| `create_environment`, directory-listing "file path" | tests assumed the **repo lives under `$HOME`** (container repo is `/work`, home is `/root`) | use `$HOME`-relative paths |
| directory-listing "home default" | container `/root` is empty after hidden-file filtering | assert the empty path **resolves to `$HOME`** (the actual behavior) instead of "home is non-empty" |
| permission-hook forensic files | **`uuidgen` is absent on minimal Debian/Ubuntu** (`uuid-runtime` not installed) → every event collides on one filename, poller drops all but the last | **production fix** in `pty-driver.js`: fall back to `/proc/sys/kernel/random/uuid` then pid+nanoseconds (POSIX-sh safe) |

## Why the hook change is production-relevant

The `$(uuidgen)` hook filenames weren't just a test artifact — chroxy running in **any** minimal Linux container (e.g. the Docker environment backend) would have had all `pre-`/`post-`/`stop-` hook files collide, silently breaking per-turn `tool_result` emission. The fallback hardens that path; `claude-tui-session.test.js` now asserts the fallback is present.

## CI routing

The `server-tests` job now `needs: runner-target` and routes via `fromJSON(...outputs.runner)` — self-hosted Linux for same-repo pushes/PRs, `ubuntu-24.04` for fork PRs (untrusted code never runs on the self-hosted machine), matching the #6046 pattern.

## Verification

- Reproduced the exact 9 failures in `node:22-bookworm` (ARM64, root).
- Applied fixes; re-ran in-container: all 6 target files pass (4 perm tests skip cleanly), full suite **0 fail**.
- Locally on macOS (non-root): all changed files pass with the perm tests **running** (no coverage lost on dev/hosted platforms).
- Custom server lints + eslint clean; ci.yml YAML validated.

Closes #6075