### PR TITLE
test(server): harden all temp-git-repo teardowns against background-gc ENOTEMPTY race (#6075, #6096)

### DIFF
--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -5,12 +5,13 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { CheckpointManager } from '../src/checkpoint-manager.js'
-import { GIT } from './test-helpers.js'
+import { GIT, disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 
 // Create a temporary git repo for testing
 function createTempGitRepo() {
   const dir = mkdtempSync(join(tmpdir(), 'chroxy-cp-test-'))
   execFileSync(GIT, ['init'], { cwd: dir })
+  disableRepoAutoGc(dir) // #6075: stop background gc racing the teardown rmSync
   execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: dir })
   execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: dir })
   writeFileSync(join(dir, 'file.txt'), 'initial content')
@@ -36,8 +37,8 @@ describe('CheckpointManager', () => {
   })
 
   afterEach(() => {
-    rmSync(gitDir, { recursive: true, force: true })
-    try { rmSync(tmpCheckpointsDir, { recursive: true, force: true }) } catch {}
+    rmSync(gitDir, RM_RETRY)
+    try { rmSync(tmpCheckpointsDir, RM_RETRY) } catch {}
   })
 
   it('creates a checkpoint with metadata', async () => {

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -14,6 +14,7 @@ import { execFileSync } from 'child_process'
 import { EventEmitter } from 'events'
 import { SessionManager, WorktreeError } from '../src/session-manager.js'
 import { GIT } from '../src/git.js'
+import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 
 // ---------------------------------------------------------------------------
 // Register a no-op stub provider (avoids importing real SDK/CLI sessions)
@@ -74,6 +75,7 @@ before(async () => {
 function makeGitRepo() {
   const dir = mkdtempSync(join(tmpdir(), 'chroxy-wt-test-'))
   execFileSync(GIT, ['init', '--initial-branch=main', dir], { stdio: 'pipe' })
+  disableRepoAutoGc(dir) // #6075: stop background gc racing the teardown rmSync
   execFileSync(GIT, ['-C', dir, 'config', 'user.email', 'test@chroxy.test'], { stdio: 'pipe' })
   execFileSync(GIT, ['-C', dir, 'config', 'user.name', 'Test'], { stdio: 'pipe' })
   // worktree add requires at least one commit so HEAD is valid
@@ -111,7 +113,7 @@ describe('SessionManager worktree isolation', () => {
   })
 
   afterEach(() => {
-    rmSync(gitRepo, { recursive: true, force: true })
+    rmSync(gitRepo, RM_RETRY)
   })
 
   it('creates a worktree directory when worktree:true is passed', () => {
@@ -402,7 +404,7 @@ describe('SessionManager _removeWorktree fallback (#2460)', () => {
   })
 
   afterEach(() => {
-    rmSync(gitRepo, { recursive: true, force: true })
+    rmSync(gitRepo, RM_RETRY)
     rmSync(externalWorktreeBase, { recursive: true, force: true })
   })
 
@@ -479,7 +481,7 @@ describe('SessionManager isolation derivation (#2475)', () => {
   })
 
   afterEach(() => {
-    rmSync(gitRepo, { recursive: true, force: true })
+    rmSync(gitRepo, RM_RETRY)
   })
 
   it('default session has isolation "none"', () => {

--- a/packages/server/tests/supervisor-rollback-a9.test.js
+++ b/packages/server/tests/supervisor-rollback-a9.test.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { Supervisor } from '../src/supervisor.js'
+import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 
 /**
  * Adversary A9 (2026-04-11 audit) — known-good-ref poisoning via
@@ -49,6 +50,7 @@ describe('Supervisor._rollbackToKnownGood — Adversary A9', () => {
     mkdirSync(chroxyDir)
 
     git(['init', '-q', '-b', 'main'], repoDir)
+    disableRepoAutoGc(repoDir) // #6075: stop background gc racing the teardown rmSync
     writeFileSync(join(repoDir, 'a.txt'), 'one')
     git(['add', 'a.txt'], repoDir)
     git(['commit', '-q', '-m', 'first'], repoDir)
@@ -79,7 +81,7 @@ describe('Supervisor._rollbackToKnownGood — Adversary A9', () => {
 
   after(() => {
     try { process.chdir(originalCwd) } catch {}
-    try { rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+    try { rmSync(tmpDir, RM_RETRY) } catch {}
   })
 
   it('accepts a ref that matches a known-good-* tag', () => {

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -1,9 +1,31 @@
 import { EventEmitter } from 'node:events'
+import { execFileSync } from 'node:child_process'
 import { WsClientManager } from '../src/ws-client-manager.js'
 import { CTX_NAMESPACES, CTX_NAMESPACE_NAMES, assertCtxShape } from '../src/ws-handler-context.js'
+import { GIT as _GIT } from '../src/git.js'
 
 // Re-export GIT from the source module so test files can import it from here
 export { GIT } from '../src/git.js'
+
+// #6075: many server tests create a throwaway git repo and rm it in teardown.
+// git spawns a DETACHED background `gc --auto` / `maintenance run --auto` after
+// commits once loose-object thresholds are met; on a busy runner that process
+// keeps writing under .git AFTER our synchronous git commands return, racing
+// the recursive remove and surfacing as `ENOTEMPTY: rmdir '<dir>/.git'`. This
+// flaked Server Tests after they moved to the self-hosted Linux runner.
+//
+// Disable auto-gc/maintenance on the throwaway repo's OWN config (NOT process-
+// wide GIT_CONFIG_* env — that leaks into the code-under-test's git commands and
+// broke checkpoint tag ops). Call right after `git init`, before any commit.
+export function disableRepoAutoGc(dir) {
+  execFileSync(_GIT, ['-C', dir, 'config', 'gc.auto', '0'], { stdio: 'pipe' })
+  execFileSync(_GIT, ['-C', dir, 'config', 'maintenance.auto', 'false'], { stdio: 'pipe' })
+}
+
+// rmSync options that ride out the ENOTEMPTY/EBUSY teardown race window — Node's
+// rmSync retries on exactly those codes. Belt-and-suspenders alongside
+// disableRepoAutoGc(); also covers any non-gc holder (#6075).
+export const RM_RETRY = Object.freeze({ recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
 
 // Re-export the ctx-shape assert so handler tests can guard their mocks.
 export { assertCtxShape } from '../src/ws-handler-context.js'

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -15,6 +15,7 @@ import { basename, join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { GIT } from '../src/git.js'
+import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 import {
   isPidAlive,
   parsePid,
@@ -134,6 +135,7 @@ describe('worktree-gc integration (real git repo)', () => {
   beforeEach(() => {
     repo = mkdtempSync(join(tmpdir(), 'chroxy-wtgc-'))
     git(repo, ['init', '--initial-branch=main', '.'])
+    disableRepoAutoGc(repo) // #6075: stop background gc racing the teardown rmSync
     git(repo, ['config', 'user.email', 'test@test'])
     git(repo, ['config', 'user.name', 'Test'])
     git(repo, ['commit', '--allow-empty', '-m', 'init'])
@@ -141,7 +143,7 @@ describe('worktree-gc integration (real git repo)', () => {
   })
 
   afterEach(() => {
-    rmSync(repo, { recursive: true, force: true })
+    rmSync(repo, RM_RETRY)
   })
 
   it('plans: reclaim clean+dead-pid, skip dirty/live/no-pid/unlocked, prune dir-gone', () => {
@@ -416,6 +418,7 @@ describe('worktree-gc CLI (runWorktreeGc against a real repo)', () => {
   beforeEach(() => {
     repo = mkdtempSync(join(tmpdir(), 'chroxy-wtgc-cli-'))
     git(repo, ['init', '--initial-branch=main', '.'])
+    disableRepoAutoGc(repo) // #6075: stop background gc racing the teardown rmSync
     git(repo, ['config', 'user.email', 'test@test'])
     git(repo, ['config', 'user.name', 'Test'])
     git(repo, ['commit', '--allow-empty', '-m', 'init'])
@@ -428,7 +431,7 @@ describe('worktree-gc CLI (runWorktreeGc against a real repo)', () => {
     git(repo, ['worktree', 'lock', '--reason', `claude agent a2 (pid ${DEAD_PID})`, dirtyDead])
   })
 
-  afterEach(() => rmSync(repo, { recursive: true, force: true }))
+  afterEach(() => rmSync(repo, RM_RETRY))
 
   it('dry-run (default) reports reclaimable and deletes nothing', async () => {
     const { runWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
@@ -490,6 +493,7 @@ describe('worktree-gc CLI (config controlRoomRoot auto-discovery, #5221)', () =>
     repo = join(root, 'project-a')
     mkdirSync(repo, { recursive: true })
     git(repo, ['init', '--initial-branch=main', '.'])
+    disableRepoAutoGc(repo) // #6075: stop background gc racing the teardown rmSync
     git(repo, ['config', 'user.email', 'test@test'])
     git(repo, ['config', 'user.name', 'Test'])
     git(repo, ['commit', '--allow-empty', '-m', 'init'])
@@ -498,7 +502,7 @@ describe('worktree-gc CLI (config controlRoomRoot auto-discovery, #5221)', () =>
     git(repo, ['worktree', 'lock', '--reason', `claude agent a1 (pid ${DEAD_PID})`, cleanDead])
   })
 
-  afterEach(() => rmSync(root, { recursive: true, force: true }))
+  afterEach(() => rmSync(root, RM_RETRY))
 
   it('discovers repos under config.controlRoomRoot when no --repo is given', async () => {
     const { collectWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
@@ -555,6 +559,7 @@ describe('sweepOrphanChroxyWorktrees (real git repo)', () => {
   beforeEach(() => {
     repo = mkdtempSync(join(tmpdir(), 'chroxy-cwt-repo-'))
     git(repo, ['init', '--initial-branch=main', '.'])
+    disableRepoAutoGc(repo) // #6075: stop background gc racing the teardown rmSync
     git(repo, ['config', 'user.email', 'test@test'])
     git(repo, ['config', 'user.name', 'Test'])
     git(repo, ['commit', '--allow-empty', '-m', 'init'])
@@ -562,7 +567,7 @@ describe('sweepOrphanChroxyWorktrees (real git repo)', () => {
   })
 
   afterEach(() => {
-    rmSync(repo, { recursive: true, force: true })
+    rmSync(repo, RM_RETRY)
     rmSync(base, { recursive: true, force: true })
   })
 

--- a/packages/server/tests/worktree-reaper.test.js
+++ b/packages/server/tests/worktree-reaper.test.js
@@ -13,6 +13,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { GIT } from '../src/git.js'
+import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 import { reapWorktrees, maybeAutoReapWorktrees, startPeriodicAutoReap } from '../src/worktree-reaper.js'
 
 const LIVE_PID = 4100002
@@ -43,6 +44,7 @@ describe('worktree-reaper', () => {
     repo = join(root, 'proj')
     mkdirSync(repo, { recursive: true })
     git(repo, ['init', '--initial-branch=main', '.'])
+    disableRepoAutoGc(repo) // #6075: stop background gc racing the teardown rmSync
     git(repo, ['config', 'user.email', 'test@test'])
     git(repo, ['config', 'user.name', 'Test'])
     git(repo, ['commit', '--allow-empty', '-m', 'init'])
@@ -58,7 +60,7 @@ describe('worktree-reaper', () => {
     git(repo, ['worktree', 'lock', '--reason', `claude agent a3 (pid ${LIVE_PID})`, live])
   })
 
-  afterEach(() => rmSync(root, { recursive: true, force: true }))
+  afterEach(() => rmSync(root, RM_RETRY))
 
   it('reapWorktrees reclaims clean+dead, preserves dirty + live', async () => {
     const summary = await reapWorktrees({ repos: [{ name: 'proj', path: repo }], planDeps, yieldFn })

--- a/packages/server/tests/ws-server-file-ops.test.js
+++ b/packages/server/tests/ws-server-file-ops.test.js
@@ -7,7 +7,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir, homedir } from 'node:os'
 import { WsServer as _WsServer } from '../src/ws-server.js'
-import { createMockSession, createMockSessionManager, waitFor, GIT } from './test-helpers.js'
+import { createMockSession, createMockSessionManager, waitFor, GIT, disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 import { setLogListener } from '../src/logger.js'
 
 // Wrapper that defaults noEncrypt: true for all tests (avoids 5s key exchange timeouts)
@@ -1074,6 +1074,7 @@ describe('get_diff handler', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'chroxy-diff-test-'))
     // Initialize a git repo in the temp directory
     execFileSync(GIT, ['init'], { cwd: tempDir, stdio: 'pipe' })
+    disableRepoAutoGc(tempDir) // #6075: stop background gc racing the teardown rmSync
     execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: tempDir, stdio: 'pipe' })
     execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: tempDir, stdio: 'pipe' })
     // Create an initial commit
@@ -1087,7 +1088,7 @@ describe('get_diff handler', () => {
       server.close()
       server = null
     }
-    rmSync(tempDir, { recursive: true, force: true })
+    rmSync(tempDir, RM_RETRY)
   })
 
   async function createDiffTestServer() {


### PR DESCRIPTION
## Summary

Follow-up to #6093. Right after Server Tests moved to the self-hosted Linux pool, **`main` went red**:

```
ENOTEMPTY: directory not empty, rmdir '/tmp/chroxy-cp-test-XXX/.git'
  at checkpoint-manager.test.js (afterEach rmSync)
```

## Root cause

`git` spawns a **detached background `gc --auto`** after commits once its loose-object thresholds are met. On a busy runner that process is still writing under `.git` when a test's `afterEach` recursively `rmSync`s the temp repo → the rimraf `ENOTEMPTY` race. Low-frequency (it passed in my in-container repro ×2 and on PR #6093's own run) but the loaded self-hosted machine raised the odds.

Not caused by #6093 (none of its changes touched these files) — the migration **exposed** a latent flake.

## Fix — one shared helper, applied to every temp-git-repo test

`test-helpers.js` gains two exports:
- **`disableRepoAutoGc(dir)`** — writes `gc.auto=0` + `maintenance.auto=false` to the throwaway repo's **own** config right after `git init`, removing the background-gc trigger at the source.
- **`RM_RETRY`** — `rmSync` opts (`maxRetries:10, retryDelay:50`); Node retries `ENOTEMPTY`/`EBUSY`, covering any residual non-gc holder.

Applied to the **complete set** of temp-git-repo teardowns (the gap #6096 was filed for — closed here, not just the one file that flaked):
- `checkpoint-manager.test.js`
- `session-manager-worktree.test.js`
- `ws-server-file-ops.test.js` (diff-test repo)
- `worktree-reaper.test.js`
- `worktree-gc.test.js` (4 integration blocks)

### Why repo-local config, not a global `GIT_CONFIG_*` env

I first tried disabling gc process-wide via `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_*` in `_setup.mjs` (one switch, covers everything). **It broke the checkpoint manager's own git tag operations** (`fatal: ambiguous argument 'chroxy-checkpoint/<id>'`) — process-wide git config leaks into the code-under-test's git commands. Caught in container stress (75/75 failed) before it reached review. The repo-local approach only affects the throwaway repo, so the code under test is unaffected.

## Verification

- All 5 files pass locally on macOS.
- **Container stress: 0 failures / 0 ENOTEMPTY across 75 runs (15 iters × 5 files)** under parallel load on `node:22-bookworm` (root) — vs. the broken global attempt which failed 75/75.

Closes #6096. Relates to #6075.