### PR TITLE
test(server): harden remaining async-rm temp-git-repo teardowns (#6098)

### DIFF
--- a/packages/server/tests/git-ops.test.js
+++ b/packages/server/tests/git-ops.test.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { createFileOps } from '../src/ws-file-ops/index.js'
 import { GIT } from '../src/git.js'
+import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 
 describe('git status handler', () => {
   let tmpDir
@@ -20,6 +21,7 @@ describe('git status handler', () => {
     fileOps = createFileOps(mockSend, tmpDir)
     // Init a git repo in tmpDir
     execFileSync(GIT, ['init'], { cwd: tmpDir })
+    disableRepoAutoGc(tmpDir) // #6098: stop background gc racing the teardown rm
     execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: tmpDir })
     execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: tmpDir })
     // Create an initial commit
@@ -29,7 +31,7 @@ describe('git status handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+    await rm(tmpDir, RM_RETRY)
   })
 
   it('returns current branch and clean status', async () => {
@@ -114,6 +116,7 @@ describe('git branches handler', () => {
     // Pass tmpDir as workspaceRoot so git ops within it are allowed
     fileOps = createFileOps(mockSend, tmpDir)
     execFileSync(GIT, ['init'], { cwd: tmpDir })
+    disableRepoAutoGc(tmpDir) // #6098: stop background gc racing the teardown rm
     execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: tmpDir })
     execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: tmpDir })
     await writeFile(join(tmpDir, 'README.md'), '# Test')
@@ -124,7 +127,7 @@ describe('git branches handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+    await rm(tmpDir, RM_RETRY)
   })
 
   it('lists local branches with current branch marked', async () => {

--- a/packages/server/tests/git-stage-commit.test.js
+++ b/packages/server/tests/git-stage-commit.test.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { createFileOps } from '../src/ws-file-ops/index.js'
 import { GIT } from '../src/git.js'
+import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 
 describe('git stage handler', () => {
   let tmpDir
@@ -18,6 +19,7 @@ describe('git stage handler', () => {
     tmpDir = await mkdtemp(join(tmpdir(), 'chroxy-git-stage-'))
     fileOps = createFileOps(mockSend, tmpDir)
     execFileSync(GIT, ['init'], { cwd: tmpDir })
+    disableRepoAutoGc(tmpDir) // #6098: stop background gc racing the teardown rm
     execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: tmpDir })
     execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: tmpDir })
     await writeFile(join(tmpDir, 'README.md'), '# Test')
@@ -26,7 +28,7 @@ describe('git stage handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+    await rm(tmpDir, RM_RETRY)
   })
 
   it('stages specified files', async () => {
@@ -76,6 +78,7 @@ describe('git unstage handler', () => {
     tmpDir = await mkdtemp(join(tmpdir(), 'chroxy-git-unstage-'))
     fileOps = createFileOps(mockSend, tmpDir)
     execFileSync(GIT, ['init'], { cwd: tmpDir })
+    disableRepoAutoGc(tmpDir) // #6098: stop background gc racing the teardown rm
     execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: tmpDir })
     execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: tmpDir })
     await writeFile(join(tmpDir, 'README.md'), '# Test')
@@ -84,7 +87,7 @@ describe('git unstage handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+    await rm(tmpDir, RM_RETRY)
   })
 
   it('unstages specified files', async () => {
@@ -127,6 +130,7 @@ describe('git commit handler', () => {
     tmpDir = await mkdtemp(join(tmpdir(), 'chroxy-git-commit-'))
     fileOps = createFileOps(mockSend, tmpDir)
     execFileSync(GIT, ['init'], { cwd: tmpDir })
+    disableRepoAutoGc(tmpDir) // #6098: stop background gc racing the teardown rm
     execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: tmpDir })
     execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: tmpDir })
     await writeFile(join(tmpDir, 'README.md'), '# Test')
@@ -135,7 +139,7 @@ describe('git commit handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+    await rm(tmpDir, RM_RETRY)
   })
 
   it('creates a commit with staged changes', async () => {

--- a/packages/server/tests/session-context.test.js
+++ b/packages/server/tests/session-context.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { execFileSync } from 'child_process'
 import { readSessionContext } from '../src/session-context.js'
-import { GIT } from './test-helpers.js'
+import { GIT, disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 
 describe('readSessionContext', () => {
   let gitDir   // temp dir with git init + commit
@@ -15,6 +15,7 @@ describe('readSessionContext', () => {
     // Create a temp git repo fixture
     gitDir = await mkdtemp(join(tmpdir(), 'session-ctx-git-'))
     execFileSync(GIT, ['init', '-b', 'main'], { cwd: gitDir })
+    disableRepoAutoGc(gitDir) // #6098: stop background gc racing the teardown rm
     execFileSync(GIT, ['config', 'user.email', 'test@test.com'], { cwd: gitDir })
     execFileSync(GIT, ['config', 'user.name', 'Test'], { cwd: gitDir })
     await writeFile(join(gitDir, 'package.json'), JSON.stringify({ name: 'test-project' }))
@@ -26,8 +27,8 @@ describe('readSessionContext', () => {
   })
 
   after(async () => {
-    await rm(gitDir, { recursive: true, force: true })
-    await rm(plainDir, { recursive: true, force: true })
+    await rm(gitDir, RM_RETRY)
+    await rm(plainDir, RM_RETRY)
   })
 
   it('returns git branch for a git repository', async () => {

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'os'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 import { createFileOps } from '../src/ws-file-ops/index.js'
+import { RM_RETRY } from './test-helpers.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -29,7 +30,7 @@ describe('gitStage/gitUnstage path validation (#1958)', () => {
   })
 
   after(async () => {
-    if (tmpDir) await rm(tmpDir, { recursive: true, force: true })
+    if (tmpDir) await rm(tmpDir, RM_RETRY)
   })
 
   it('gitStage rejects path traversal (../../etc/passwd)', async () => {
@@ -116,8 +117,8 @@ describe('git ops workspace root validation (#2690)', () => {
   })
 
   after(async () => {
-    if (workspaceDir) await rm(workspaceDir, { recursive: true, force: true })
-    if (outsideDir) await rm(outsideDir, { recursive: true, force: true })
+    if (workspaceDir) await rm(workspaceDir, RM_RETRY)
+    if (outsideDir) await rm(outsideDir, RM_RETRY)
   })
 
   it('gitStatus rejects a path outside workspace root', async () => {


### PR DESCRIPTION
## Summary

Completes the temp-git-repo teardown hardening from #6095. That PR fixed the 6 files using synchronous `rmSync`; this one covers the four that tear down with `await rm` (fs/promises) — the same background-gc `ENOTEMPTY` race applies (git's detached `gc --auto` writing under `.git` while the recursive remove runs).

`fs.promises.rm` accepts the same `maxRetries`/`retryDelay` options as `rmSync`, so the shared `RM_RETRY` constant (from #6095, in `test-helpers.js`) applies directly.

## Changes

| File | Commits in setup? | Hardening |
|------|------|-----------|
| `git-ops.test.js` | yes | `disableRepoAutoGc()` + `RM_RETRY` |
| `git-stage-commit.test.js` | yes | `disableRepoAutoGc()` + `RM_RETRY` |
| `session-context.test.js` | yes | `disableRepoAutoGc()` + `RM_RETRY` |
| `ws-file-ops-git-paths.test.js` | **no** (init + config only) | `RM_RETRY` only — no commits means no background gc to disable |

The last one is deliberately `RM_RETRY`-only: adding `gc.auto=0` to a repo that never commits would be cargo-culting (nothing triggers gc). `RM_RETRY` still guards the teardown against any transient holder.

## Verification

- All 4 files pass locally on macOS.
- All 4 pass in `node:22-bookworm` (root) — the self-hosted runner's environment.
- No production source changes (test-only).

Closes #6098.