### PR TITLE
ci: drop the last --test-force-exit usages (#5480)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,14 @@ jobs:
         # but scopes to the platform suite to keep the Windows job fast.
         # `c8` is intentionally omitted — we don't need coverage from the
         # Windows runner; the ubuntu job is the source of truth there.
-        run: node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit ./tests/platform.test.js ./tests/platform-windows.test.js
+        #
+        # No `--test-force-exit` (#5480): it can silently truncate a run (exit 0
+        # while trailing suites are still queued). These two files have no leaked
+        # async handles — platform.test.js already runs flag-free as part of the
+        # main `npm test` glob, and platform-windows.test.js only uses sync
+        # spawnSync/fs (its forceKill is a synchronous child.kill, no timer) — so
+        # the runner exits naturally and a truncated run can't masquerade as green.
+        run: node --import ./tests/_setup.mjs --experimental-test-module-mocks --test ./tests/platform.test.js ./tests/platform-windows.test.js
 
   server-lint:
     name: Server Lint

--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -7,7 +7,7 @@
     "chroxy-hooks": "bin/chroxy-hooks.js"
   },
   "scripts": {
-    "test": "node --import ./tests/_setup.mjs --test --test-force-exit './tests/**/*.test.js'"
+    "test": "node --import ./tests/_setup.mjs --test './tests/**/*.test.js'"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

Removes the **last two** `--test-force-exit` flags any CI job runs, fully closing #5480.

#5480's hazard: the flag `process.exit()`s the moment the runner *appears* idle, so on a file with many trailing suites it can fire mid-queue — the run exits 0 with tests silently skipped. The full server suite already removed it via #6027 (leak teardown) + #6028 (the `assert-test-count.mjs` truncation guard). Two residual usages remained:

| Where | Job | Safe to drop because |
|-------|-----|----------------------|
| `.github/workflows/ci.yml` | Server Platform Tests (Windows) | `platform.test.js` already runs flag-free in the main `npm test` glob; `platform-windows.test.js` uses only sync `spawnSync`/`fs` (its `forceKill` is a synchronous `child.kill`, no timer) |
| `packages/claude-hooks/package.json` | Claude Hooks Tests | its tests open HTTP servers but close them in teardown — the suite exits naturally without the flag |

Without the flag the runner runs every test and exits with the correct code, so a truncated run is structurally impossible — no count guard needed for these.

## Verification

- **Windows job ran on this PR** (the platform path-filter includes `ci.yml`) and **passed in 1m14s** without the flag — real-environment proof of no hang/truncation.
- claude-hooks suite verified locally: **97/97, exits naturally** (90s hang-watch) without the flag.
- Remaining `--test-force-exit` repo matches are build artifacts under `src-tauri/target/**` (never executed by CI) and a comment.

Closes #5480.