### PR TITLE
fix(app): handle the rotate-pin key decision exhaustively (#5978)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1500,11 +1500,36 @@ function verifyServerIdentityOrRefuse(
     applyIdentityRefusal(ctx, decision.reason, decision.message);
     return { refused: true };
   }
-  // Connect — capture the pin to persist on first use; clear the pairing
-  // identity once it's been adopted (or wasn't needed).
-  const pinToPersist = decision.action === 'pin-and-connect' ? decision.identityKey : null;
+  // Proceed — clear the pairing identity once it's been adopted (or wasn't
+  // needed) and capture the pin to persist.
+  //
+  // NB: an if/else chain, NOT a switch — the protocol handler-coverage contract
+  // (packages/protocol/tests/handler-coverage.test.js) statically greps this
+  // file for `case '<x>':` and asserts every <x> is a ServerMessageType. A
+  // switch over `decision.action` would surface 'connect'/'rotate-pin'/... as
+  // bogus "uncovered message types". Same exhaustiveness, no false case hits.
   pendingPairingIdentityKey = null;
-  return { refused: false, pinToPersist };
+  if (decision.action === 'connect') {
+    // Verified against an existing pin, or an old/unpinned daemon — leave the
+    // stored record's pin untouched.
+    return { refused: false, pinToPersist: null };
+  }
+  if (decision.action === 'pin-and-connect' || decision.action === 'rotate-pin') {
+    // #5616 — TOFU first-use ('pin-and-connect') AND a forward-chained identity
+    // rotation ('rotate-pin', where the old pinned identity signed the new one)
+    // both persist the offered identity as the new pin. Without the explicit
+    // 'rotate-pin' arm a rotation would connect but drop the new pin
+    // (pinToPersist=null), silently failing to chain it forward (#5978).
+    return { refused: false, pinToPersist: decision.identityKey };
+  }
+  // Exhaustiveness guard (#5978): adding a KeyPinDecision variant without
+  // handling it above is a compile error here. At runtime (e.g. a version-skew
+  // discriminator that bypasses the compiler) fail CLOSED — refuse rather than
+  // return the raw object, which has no `refused` field and would make callers
+  // silently proceed without a pin.
+  const _exhaustive: never = decision;
+  void _exhaustive;
+  return { refused: true };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #5978 (from-review on #5977, part of the #5616 identity-rotation epic).

store-core's `KeyPinDecision` union gained a `rotate-pin` variant in #5977 (the #5616 handoff: the old pinned identity signs the new one, the new identity proves liveness → chain the pin forward instead of refusing). The app's sole consumer — `verifyServerIdentityOrRefuse` in `message-handler.ts` — narrowed it **non-exhaustively**:

```ts
const pinToPersist = decision.action === 'pin-and-connect' ? decision.identityKey : null;
```

So a `rotate-pin` decision fell through to `null`: the app would **connect but drop the new pin**, silently failing to chain it forward. Unreachable in phase 1 (the app never forwards the rotation-cert fields), but a live correctness bug the moment phase 2 (#5976) emits them.

## Change

- Replaced the ternary with a `switch` that persists `decision.identityKey` for **both** `pin-and-connect` (TOFU first-use) and `rotate-pin` (forward-chained rotation).
- Added a compile-time exhaustiveness guard (`const _exhaustive: never = decision`) so a future `KeyPinDecision` variant can't silently fall through again.

This single helper covers both the eager and discrete handshake paths (both route through it).

## Verification

- `tsc --noEmit` clean.
- **Exhaustiveness guard is load-bearing** — RED-verified: dropping the `rotate-pin` arm makes tsc fail with `Type '{ action: "rotate-pin"; … }' is not assignable to type 'never'`.
- Existing `message-handler.encryption-gate.test.ts` (the pin-decision suite) passes 12/12 — no regression.

## Dashboard scope

The dashboard has **no** `KeyPinDecision` consumer yet (it doesn't call `decideKeyPin*` — identity verification isn't wired there). So there's nothing to mirror until that's wired under #5976; this PR is the app-side fix.

Part of #5616. Closes #5978.