### PR TITLE
fix(app): make activity-group entries tappable + multi-question forms answerable under Maestro

### DIFF
--- a/packages/app/.maestro/ask-user-question-multi.yaml
+++ b/packages/app/.maestro/ask-user-question-multi.yaml
@@ -69,6 +69,20 @@ name: ChatView AskUserQuestion multi-question form (#4697, #4604 Chunk B)
 - assertVisible:
     text: ".*Q1 — deploy to production\\?.*"
 
+# Dismiss the keyboard and bring Q1 fully into view before tapping
+# (#6103). With the keyboard up and the sticky session/tab header, the
+# chat list sits scrolled to the form's bottom — the upper questions
+# (Q1/Q2) land under the header, so their taps miss, the form stays
+# partly unanswered and Submit never enables. hideKeyboard frees the
+# space; scrollUntilVisible (100% by default) guarantees Q1 is clear of
+# the header before the first tap.
+- hideKeyboard
+- waitForAnimationToEnd
+- scrollUntilVisible:
+    element:
+      id: "question-multi-option-0-approve"
+    direction: UP
+
 # Answer all four questions (each is single-select) and submit —
 # round-trips the per-question answers map on the wire.
 - tapOn:

--- a/packages/app/.maestro/chat-multi-question.yaml
+++ b/packages/app/.maestro/chat-multi-question.yaml
@@ -109,6 +109,20 @@ name: ChatView mixed multi-question AskUserQuestion form (#4762, #4973)
 - assertVisible:
     text: ".*Q3 — rollback strategy\\?.*"
 
+# Dismiss the keyboard and bring Q1 fully into view before tapping
+# (#6103). With the keyboard up and the sticky session/tab header, the
+# chat list sits scrolled to the form's bottom — the upper questions
+# land under the header, so their taps miss, the form stays partly
+# unanswered and Submit never enables. hideKeyboard frees the space;
+# scrollUntilVisible (100% by default) guarantees Q1 is clear of the
+# header before the first tap.
+- hideKeyboard
+- waitForAnimationToEnd
+- scrollUntilVisible:
+    element:
+      id: "question-multi-option-0-approve"
+    direction: UP
+
 # Answer every question: Q[0] approve (single-select radio), Q[1]
 # app + server (multi-select checkbox — two taps add to the array),
 # Q[2] auto-rollback (single-select radio).

--- a/packages/app/src/components/chat/ActivityGroup.tsx
+++ b/packages/app/src/components/chat/ActivityGroup.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
-  ScrollView,
   Platform,
   LayoutAnimation,
 } from 'react-native';
@@ -263,7 +262,13 @@ export function ActivityGroup({
       </TouchableOpacity>
       {isThinking && <ThinkingIndicator />}
       {expanded && (
-        <ScrollView style={styles.activityList} nestedScrollEnabled>
+        // #6103: a plain View, not a nested ScrollView. A vertical ScrollView
+        // nested inside the virtualized chat list (#5534) is a React Native
+        // anti-pattern — it intercepts the entries' touch responders (their
+        // onPress never fired, so an entry could not be expanded) and triggers
+        // the "VirtualizedLists should never be nested" path. The outer chat
+        // list already scrolls; the group grows with its entries.
+        <View style={styles.activityList}>
           {activityMessages.map((msg) => (
             <ActivityEntry
               key={msg.id}
@@ -275,7 +280,7 @@ export function ActivityGroup({
               onExpandedChange={onExpandedChange}
             />
           ))}
-        </ScrollView>
+        </View>
       )}
     </View>
   );
@@ -311,7 +316,6 @@ const styles = StyleSheet.create({
   },
   activityList: {
     marginTop: 8,
-    maxHeight: 200,
   },
   activityEntry: {
     minHeight: 44,


### PR DESCRIPTION
## Summary

Closes #6103.

Three chat E2E flows (`chat-todolist`, `ask-user-question-multi`, `chat-multi-question`) failed deterministically — they reproduce standalone (`maestro test <flow>`), so they were pre-existing on `main`, surfaced by the per-flow Maestro runner from #6091. Two distinct root causes:

### 1. `chat-todolist` — app fix (also a real-device bug)

Activity-group entries were rendered inside a **nested vertical `ScrollView`** (`maxHeight: 200`) within the **virtualized** chat list (#5534). Nesting a `ScrollView` inside a `VirtualizedList` is a React Native anti-pattern: it **intercepts the entries' touch responders**, so an entry's `onPress` never fired and it could not be expanded — the structured `<TodoList>` (with `todo-list-header`) never rendered. The group *header*, being outside the ScrollView, stayed tappable (which is why the group expanded but the entry didn't).

Fix: replace the nested `ScrollView` with a plain `View` and drop the 200px cap. The outer chat list already scrolls, so the group grows with its entries. This also resolves the "VirtualizedLists should never be nested inside plain ScrollViews" path and makes the entries reliably tappable for real users, not just Maestro.

**UX note:** a very long activity group now grows tall (outer list scrolls) instead of scrolling within a 200px inner box. For the common 1–3-tool group this is unchanged; the trade-off removes a nested-scroll region inside an already-scrolling chat.

### 2. `ask-user-question-multi` + `chat-multi-question` — flow fix (test-only)

With the keyboard up and the sticky session/tab header, the chat sits scrolled to the form's bottom, so the **upper questions land under the header** and their taps miss. The form stays partly unanswered (verified: Q1/Q2 `selected=false`, Submit `enabled=false`) and the summary never renders. Add `hideKeyboard` + `scrollUntilVisible` (100%) on the first option before tapping, so every question is clear of the header. No app change.

## Verification

iPhone 16 Pro (iOS 18.6): all three flows pass standalone (exit 0, zero assertion failures) — `todo-list-header`, both `question-multi-summary`, and the `Q2: app, server` multi-select summary all assert visible.

App type-check clean; `ActivityGroup` / `ToolBubble` / `TodoList` / `MessageBubble.multiQuestion` unit suites green (46 tests).