### PR TITLE
test(server): widen temp-git-repo teardown retry budget to ride out runner load

### DIFF
--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -25,7 +25,16 @@ export function disableRepoAutoGc(dir) {
 // rmSync options that ride out the ENOTEMPTY/EBUSY teardown race window — Node's
 // rmSync retries on exactly those codes. Belt-and-suspenders alongside
 // disableRepoAutoGc(); also covers any non-gc holder (#6075).
-export const RM_RETRY = Object.freeze({ recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+//
+// maxRetries is 20 (not 10): Node uses LINEAR backoff (wait = retryDelay *
+// attempt), so 20×50ms ≈ a 10.5s cumulative window vs ~2.75s at 10. A git repo
+// that just ran `git add -A`/tag writes loose objects into .git, and on the busy
+// self-hosted runner the recursive delete can readdir→rmdir before the FS
+// settles → `ENOTEMPTY: rmdir '.../.git'`. The 10-retry budget was exceeded once
+// on a required check (checkpoint-manager teardown, main @c17d8009); the wider
+// window covers the load peak. The common case still succeeds on the first try
+// with zero added delay.
+export const RM_RETRY = Object.freeze({ recursive: true, force: true, maxRetries: 20, retryDelay: 50 })
 
 // Re-export the ctx-shape assert so handler tests can guard their mocks.
 export { assertCtxShape } from '../src/ws-handler-context.js'

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -26,14 +26,17 @@ export function disableRepoAutoGc(dir) {
 // rmSync retries on exactly those codes. Belt-and-suspenders alongside
 // disableRepoAutoGc(); also covers any non-gc holder (#6075).
 //
-// maxRetries is 20 (not 10): Node uses LINEAR backoff (wait = retryDelay *
-// attempt), so 20×50ms ≈ a 10.5s cumulative window vs ~2.75s at 10. A git repo
-// that just ran `git add -A`/tag writes loose objects into .git, and on the busy
-// self-hosted runner the recursive delete can readdir→rmdir before the FS
-// settles → `ENOTEMPTY: rmdir '.../.git'`. The 10-retry budget was exceeded once
-// on a required check (checkpoint-manager teardown, main @c17d8009); the wider
-// window covers the load peak. The common case still succeeds on the first try
-// with zero added delay.
+// maxRetries is 20 (not 10): Node uses LINEAR backoff — it waits
+// `retryDelay * attempt` before retry N, so the cumulative window is the
+// triangular sum retryDelay * N(N+1)/2. At retryDelay=50ms that's
+// 50*(20*21/2) = 10,500ms (~10.5s) for 20 retries vs 50*(10*11/2) = 2,750ms
+// (~2.75s) for 10. A git repo that just ran `git add -A` / `git tag` writes
+// loose objects into .git, and on the busy self-hosted runner the recursive
+// delete can readdir→rmdir before the FS settles → `ENOTEMPTY: rmdir
+// '.../.git'`. The 10-retry budget was exceeded once on a required check
+// (checkpoint-manager teardown, main @c17d8009); the wider window covers the
+// load peak. The common case still succeeds on the first try with zero added
+// delay (rmSync only sleeps when a retry is actually needed).
 export const RM_RETRY = Object.freeze({ recursive: true, force: true, maxRetries: 20, retryDelay: 50 })
 
 // Re-export the ctx-shape assert so handler tests can guard their mocks.


### PR DESCRIPTION
## Summary

The temp-git-repo teardown race (`ENOTEMPTY: rmdir '.../.git'`) is already hardened with the canonical fix — `disableRepoAutoGc()` (gc.auto=0 + maintenance.auto=false) on the repo plus `RM_RETRY` on the recursive delete. But the **required** `Server Tests` check flaked once on this exact race (checkpoint-manager teardown, main @`c17d8009`) and passed on re-run, so the existing retry budget is occasionally short on the busy self-hosted Linux runner.

Node's `rmSync` uses **linear** backoff (`wait = retryDelay × attempt`), so the old `maxRetries: 10, retryDelay: 50` gives a ~2.75s cumulative window. A git repo that just ran `git add -A`/`git tag` writes loose objects into `.git`, and under parallel load the recursive delete can `readdir`→`rmdir` before the filesystem settles. The peak exceeded 2.75s.

This bumps `maxRetries` 10→20 (~10.5s cumulative window). The common case (delete succeeds on the first attempt) is unchanged — **zero added delay** — and a genuinely stuck delete still fails, just later. The change is to the shared `RM_RETRY` constant, so all ten temp-git-repo teardowns benefit.

## Why not a structural fix
There isn't a cleaner one: the manager only runs awaited git commands (no detached gc), and the repo already has `gc.auto=0`. The remaining flake is FS-settle timing on a loaded runner — a sufficient retry budget is the fix.

## Verification
`checkpoint-manager.test.js` + `git-ops.test.js` green locally (29/29). No tests added/removed (count guard unaffected).