### PR TITLE
feat(control-room): surface repo-memory failed searches (topMissedQueries)

### DIFF
--- a/packages/dashboard/src/components/IntegrationsSection.test.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.test.tsx
@@ -56,6 +56,7 @@ function repoMemory(over: Partial<RepoMemoryStatus> = {}): RepoMemoryStatus {
       cacheEntryCount: 1391,
       staleEntryCount: 2,
       lastActivity: null,
+      topMissedQueries: [],
     },
     reason: null,
     ...over,
@@ -198,6 +199,7 @@ describe('IntegrationsSection — populated', () => {
           report: {
             totalEvents: 0, cacheHits: 0, cacheMisses: 0, cacheHitRatio: 0,
             estimatedTokensSaved: 0, cacheEntryCount: 10, staleEntryCount: 0, lastActivity: null,
+            topMissedQueries: [],
           },
         }),
       },
@@ -205,6 +207,44 @@ describe('IntegrationsSection — populated', () => {
     cleanup()
     renderSection(quiet)
     expect(screen.getByTestId('integration-ratio-quiet').textContent).toBe('no events')
+  })
+
+  it('missed-searches cell (#5681) shows the total count + distinct-query count, with the queries on hover', () => {
+    const snap = oneRepoSnapshot([
+      {
+        name: 'misses',
+        path: '/p/misses',
+        repoMemory: repoMemory({
+          report: {
+            totalEvents: 50, cacheHits: 40, cacheMisses: 10, cacheHitRatio: 0.8,
+            estimatedTokensSaved: 100, cacheEntryCount: 5, staleEntryCount: 0, lastActivity: null,
+            topMissedQueries: [
+              { query: 'websocket reconnect', count: 3 },
+              { query: 'oauth refresh', count: 1 },
+            ],
+          },
+        }),
+      },
+    ])
+    renderSection(snap)
+    const cell = screen.getByTestId('integration-missed-misses')
+    // total = 3 + 1 = 4, distinct = 2
+    expect(cell.textContent).toContain('4')
+    expect(cell.textContent).toContain('(2)')
+    expect(cell.getAttribute('title')).toBe('websocket reconnect (3)\noauth refresh (1)')
+  })
+
+  it('missed-searches cell renders "—" with no misses or on an older repo-memory (#5681)', () => {
+    // Default fixture has topMissedQueries: [] → quiet dash.
+    renderSection(snapshot())
+    expect(screen.getByTestId('integration-missed-chroxy').textContent).toBe('—')
+    // Degraded (no report) also shows the dash, not an error.
+    const broken = oneRepoSnapshot([
+      { name: 'broken', path: '/p/broken', repoMemory: repoMemory({ report: null, reason: 'report failed' }) },
+    ])
+    cleanup()
+    renderSection(broken)
+    expect(screen.getByTestId('integration-missed-broken').textContent).toBe('—')
   })
 
   it('renders tokens saved and entry counts (with stale annotation)', () => {

--- a/packages/dashboard/src/components/IntegrationsSection.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.tsx
@@ -150,6 +150,29 @@ function HitRatioCell({ repo }: { repo: IntegrationRepo }) {
   )
 }
 
+/**
+ * Missed-searches cell (#5681): the total count of failed `search_by_purpose`
+ * queries (sum of per-query counts) with the distinct-query count alongside and
+ * the actual queries on hover. A repo with no report, an older repo-memory
+ * (field absent → defaulted to []), or zero misses renders the quiet "—" — the
+ * same "absence is signal, not an error" treatment as the sibling cells.
+ */
+function MissedSearchesCell({ repo }: { repo: IntegrationRepo }) {
+  const report = repo.repoMemory?.report ?? null
+  const missed = report?.topMissedQueries ?? []
+  if (!report || missed.length === 0) {
+    return <td className="cr-dim" data-testid={`integration-missed-${repo.name}`}>—</td>
+  }
+  const total = missed.reduce((sum, m) => sum + m.count, 0)
+  const tooltip = missed.map(m => `${m.query} (${m.count})`).join('\n')
+  return (
+    <td data-testid={`integration-missed-${repo.name}`} title={tooltip}>
+      <span className="cr-warn">{total}</span>
+      <span className="cr-dim cr-mono"> ({missed.length})</span>
+    </td>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // #5501 — repo-relay cells.
 // ---------------------------------------------------------------------------
@@ -465,6 +488,7 @@ function IntegrationRow({
       </td>
       <CacheCell repo={repo} />
       <HitRatioCell repo={repo} />
+      <MissedSearchesCell repo={repo} />
       <td className="cr-dim cr-mono" data-testid={`integration-tokens-${repo.name}`}>
         {report ? `~${report.estimatedTokensSaved.toLocaleString('en-US')}` : '—'}
       </td>
@@ -666,7 +690,7 @@ export function IntegrationsSection({
                     legible. */}
                 <tr>
                   <th rowSpan={2}>Repo</th>
-                  <th colSpan={8} className="cr-th-group" data-testid="integration-group-memory">repo-memory</th>
+                  <th colSpan={9} className="cr-th-group" data-testid="integration-group-memory">repo-memory</th>
                   <th colSpan={5} className="cr-th-group" data-testid="integration-group-relay">repo-relay</th>
                 </tr>
                 <tr>
@@ -674,6 +698,7 @@ export function IntegrationsSection({
                   <th>Summarizer / tools</th>
                   <th>Cache</th>
                   <th>Hit ratio</th>
+                  <th>Missed</th>
                   <th>Tokens saved</th>
                   <th>Entries</th>
                   <th>Last activity</th>
@@ -688,7 +713,7 @@ export function IntegrationsSection({
               <tbody>
                 {snapshot.repos.length === 0 ? (
                   <tr data-testid="integration-no-repos">
-                    <td colSpan={14} className="cr-dim">
+                    <td colSpan={15} className="cr-dim">
                       No repos found under {snapshot.root}.
                     </td>
                   </tr>

--- a/packages/dashboard/src/store/dispatch-integration-status.test.ts
+++ b/packages/dashboard/src/store/dispatch-integration-status.test.ts
@@ -99,6 +99,7 @@ function snapshot(over: Partial<ServerIntegrationStatusSnapshotMessage> = {}): S
             cacheEntryCount: 1391,
             staleEntryCount: 2,
             lastActivity: null,
+            topMissedQueries: [],
           },
           reason: null,
         },

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -1265,6 +1265,10 @@ export declare const RepoMemoryReportSchema: z.ZodObject<{
     cacheEntryCount: z.ZodNullable<z.ZodNumber>;
     staleEntryCount: z.ZodNullable<z.ZodNumber>;
     lastActivity: z.ZodNullable<z.ZodString>;
+    topMissedQueries: z.ZodDefault<z.ZodArray<z.ZodObject<{
+        query: z.ZodString;
+        count: z.ZodNumber;
+    }, z.core.$strip>>>;
 }, z.core.$strip>;
 /**
  * One repo's repo-memory status.
@@ -1296,6 +1300,10 @@ export declare const RepoMemoryStatusSchema: z.ZodObject<{
         cacheEntryCount: z.ZodNullable<z.ZodNumber>;
         staleEntryCount: z.ZodNullable<z.ZodNumber>;
         lastActivity: z.ZodNullable<z.ZodString>;
+        topMissedQueries: z.ZodDefault<z.ZodArray<z.ZodObject<{
+            query: z.ZodString;
+            count: z.ZodNumber;
+        }, z.core.$strip>>>;
     }, z.core.$strip>>;
     reason: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
@@ -1407,6 +1415,10 @@ export declare const IntegrationRepoSchema: z.ZodObject<{
             cacheEntryCount: z.ZodNullable<z.ZodNumber>;
             staleEntryCount: z.ZodNullable<z.ZodNumber>;
             lastActivity: z.ZodNullable<z.ZodString>;
+            topMissedQueries: z.ZodDefault<z.ZodArray<z.ZodObject<{
+                query: z.ZodString;
+                count: z.ZodNumber;
+            }, z.core.$strip>>>;
         }, z.core.$strip>>;
         reason: z.ZodNullable<z.ZodString>;
     }, z.core.$strip>>;
@@ -1503,6 +1515,10 @@ export declare const ServerIntegrationStatusSnapshotSchema: z.ZodObject<{
                 cacheEntryCount: z.ZodNullable<z.ZodNumber>;
                 staleEntryCount: z.ZodNullable<z.ZodNumber>;
                 lastActivity: z.ZodNullable<z.ZodString>;
+                topMissedQueries: z.ZodDefault<z.ZodArray<z.ZodObject<{
+                    query: z.ZodString;
+                    count: z.ZodNumber;
+                }, z.core.$strip>>>;
             }, z.core.$strip>>;
             reason: z.ZodNullable<z.ZodString>;
         }, z.core.$strip>>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -1326,6 +1326,14 @@ export const RepoMemoryReportSchema = z.object({
     cacheEntryCount: z.number().int().nonnegative().finite().nullable(),
     staleEntryCount: z.number().int().nonnegative().finite().nullable(),
     lastActivity: z.string().datetime().nullable(),
+    // #5681 — `search_by_purpose` queries that matched nothing against a
+    // non-empty corpus, aggregated by query and ranked by frequency. Added in
+    // repo-memory 0.17.0; `.default([])` keeps pre-0.17.0 snapshots (and the
+    // #5503-era fixtures) valid when the field is absent.
+    topMissedQueries: z.array(z.object({
+        query: z.string(),
+        count: z.number().int().nonnegative().finite(),
+    })).default([]),
 });
 /**
  * One repo's repo-memory status.

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -1417,6 +1417,14 @@ export const RepoMemoryReportSchema = z.object({
   cacheEntryCount: z.number().int().nonnegative().finite().nullable(),
   staleEntryCount: z.number().int().nonnegative().finite().nullable(),
   lastActivity: z.string().datetime().nullable(),
+  // #5681 — `search_by_purpose` queries that matched nothing against a
+  // non-empty corpus, aggregated by query and ranked by frequency. Added in
+  // repo-memory 0.17.0; `.default([])` keeps pre-0.17.0 snapshots (and the
+  // #5503-era fixtures) valid when the field is absent.
+  topMissedQueries: z.array(z.object({
+    query: z.string(),
+    count: z.number().int().nonnegative().finite(),
+  })).default([]),
 })
 
 /**

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -2774,6 +2774,24 @@ describe('@chroxy/protocol schemas', () => {
         assert.ok(!RepoMemoryReportSchema.safeParse({ ...report, totalEvents: -1 }).success)
       })
 
+      it('defaults topMissedQueries to [] when absent and validates entries (#5681)', async () => {
+        const { RepoMemoryReportSchema } = await import('../src/schemas/server.ts')
+        // Absent (pre-0.17.0 CLI) → defaults to [].
+        const absent = RepoMemoryReportSchema.safeParse({ ...report })
+        assert.ok(absent.success)
+        assert.deepEqual(absent.data.topMissedQueries, [])
+        // Well-formed entries pass through.
+        const present = RepoMemoryReportSchema.safeParse({
+          ...report,
+          topMissedQueries: [{ query: 'websocket reconnect', count: 3 }],
+        })
+        assert.ok(present.success)
+        assert.equal(present.data.topMissedQueries[0].query, 'websocket reconnect')
+        // Malformed entries are rejected by the schema (count must be a non-negative int, query a string).
+        assert.ok(!RepoMemoryReportSchema.safeParse({ ...report, topMissedQueries: [{ query: 'x', count: -1 }] }).success)
+        assert.ok(!RepoMemoryReportSchema.safeParse({ ...report, topMissedQueries: [{ count: 1 }] }).success)
+      })
+
       it('accepts an error snapshot without repoMemoryCli (shared error envelope)', async () => {
         const { ServerIntegrationStatusSnapshotSchema } = await import('../src/schemas/server.ts')
         assert.ok(ServerIntegrationStatusSnapshotSchema.safeParse({

--- a/packages/server/src/control-room/integrations.js
+++ b/packages/server/src/control-room/integrations.js
@@ -189,6 +189,14 @@ export function parseRepoMemoryReport(json) {
       ? Math.trunc(diag.staleEntryCount)
       : null,
     lastActivity: deriveLastActivity(parsed),
+    // #5681 — failed search_by_purpose queries (repo-memory 0.17.0+). Absent on
+    // older CLIs; malformed entries tolerated: default to [] and keep only
+    // well-formed {query:string, count:>=0} pairs (mirrors the diagnostics guard).
+    topMissedQueries: Array.isArray(parsed.topMissedQueries)
+      ? parsed.topMissedQueries
+          .filter(m => m && typeof m === 'object' && typeof m.query === 'string' && Number.isFinite(m.count) && m.count >= 0)
+          .map(m => ({ query: m.query, count: Math.trunc(m.count) }))
+      : [],
   }
 }
 

--- a/packages/server/tests/control-room-integrations.test.js
+++ b/packages/server/tests/control-room-integrations.test.js
@@ -82,7 +82,35 @@ describe('parseRepoMemoryReport', () => {
       cacheEntryCount: 1391,
       staleEntryCount: 2,
       lastActivity: null,
+      // #5681 — absent on the 0.15.0 sample (pre-0.17.0), defaults to [].
+      topMissedQueries: [],
     })
+  })
+
+  it('maps topMissedQueries (#5681) and drops malformed entries', () => {
+    const report = parseRepoMemoryReport(JSON.stringify({
+      totalEvents: 10, cacheHits: 3, cacheMisses: 7, cacheHitRatio: 0.3, estimatedTokensSaved: 0,
+      topMissedQueries: [
+        { query: 'websocket reconnect', count: 3 },
+        { query: 'oauth refresh', count: 1.9 },     // count truncated to 1
+        { query: 'no count' },                        // dropped (count missing)
+        { count: 2 },                                 // dropped (query missing)
+        { query: 5, count: 2 },                       // dropped (query not a string)
+        { query: 'negative', count: -1 },             // dropped (count negative)
+        'not an object',                              // dropped
+      ],
+    }))
+    assert.deepEqual(report.topMissedQueries, [
+      { query: 'websocket reconnect', count: 3 },
+      { query: 'oauth refresh', count: 1 },
+    ])
+  })
+
+  it('defaults topMissedQueries to [] when absent or not an array (#5681)', () => {
+    const absent = parseRepoMemoryReport(JSON.stringify({ totalEvents: 1, cacheHits: 1, cacheMisses: 0, cacheHitRatio: 1, estimatedTokensSaved: 5 }))
+    assert.deepEqual(absent.topMissedQueries, [])
+    const wrongType = parseRepoMemoryReport(JSON.stringify({ totalEvents: 1, cacheHits: 1, cacheMisses: 0, cacheHitRatio: 1, estimatedTokensSaved: 5, topMissedQueries: 'nope' }))
+    assert.deepEqual(wrongType.topMissedQueries, [])
   })
 
   it('tolerates a missing diagnostics block (entry counts null)', () => {


### PR DESCRIPTION
## Summary

Closes #5681.

repo-memory 0.17.0 added `topMissedQueries` to `report --json` — the `search_by_purpose` queries that matched nothing against a non-empty corpus, aggregated and ranked by frequency. It's the most actionable repo-memory signal the Integrations tab wasn't surfacing: *"here's what an agent searched for that the summary index couldn't answer"* — concrete candidates for files needing better summaries.

Additive + backward-compatible across the schema/producer/renderer trio (they land together):

- **protocol** (`RepoMemoryReportSchema`): `topMissedQueries: z.array({query, count}).default([])`. `.default([])` keeps pre-0.17.0 snapshots and the #5503-era fixtures valid when the field is absent. dist rebuilt.
- **server** (`parseRepoMemoryReport`): maps the field, defaulting to `[]` when absent or not-an-array, and dropping malformed entries (mirrors the existing `diagnostics` tolerance — guards each `query`/`count`).
- **dashboard** (`IntegrationsSection`): a "Missed" cell in the repo-memory column group — the total failed-search count + distinct-query count, with the queries on hover (`title`). A repo with no misses, an older CLI (field absent → `[]`), or a failed report renders the quiet "—" (the same "absence is signal, not an error" treatment as the sibling cells).

## Acceptance (all met)
- A repo whose report includes `topMissedQueries` shows the failed-search count (+ queries on hover). ✅
- An older repo-memory (no field) or zero misses renders the empty state, not an error. ✅
- Producer/schema tolerate the field's absence (back-compat). ✅

## Verification
protocol 340 · dashboard IntegrationsSection 49 + dispatch-integration-status 5 · server control-room-integrations 66 — all green. dashboard tsc clean.