### PR TITLE
test(server): cover the untested pure helper modules

### DIFF
--- a/packages/server/tests/child-stream-guard.test.js
+++ b/packages/server/tests/child-stream-guard.test.js
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'events'
+import { guardChildStreams } from '../src/child-stream-guard.js'
+
+/**
+ * Unit coverage for the shared child stdout/stderr EPIPE guard (#5324/#5361).
+ * A stream 'error' with no listener crashes the whole daemon; this guard must
+ * attach a swallowing handler to both streams, respect the `destroying` getter,
+ * and never throw inside its own error path.
+ */
+
+function makeChild() {
+  const child = {}
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+function makeLog() {
+  const warnings = []
+  return { warnings, warn: (m) => warnings.push(m) }
+}
+
+describe('guardChildStreams', () => {
+  it('swallows + logs a stream error on both stdout and stderr (no throw)', () => {
+    const child = makeChild()
+    const log = makeLog()
+    guardChildStreams(child, { destroying: () => false, log, label: 'sess-1' })
+    assert.doesNotThrow(() => child.stdout.emit('error', new Error('EPIPE')))
+    assert.doesNotThrow(() => child.stderr.emit('error', new Error('read fault')))
+    assert.equal(log.warnings.length, 2)
+    assert.match(log.warnings[0], /\[sess-1\] stdout stream error \(ignored\): EPIPE/)
+    assert.match(log.warnings[1], /\[sess-1\] stderr stream error \(ignored\): read fault/)
+  })
+
+  it('stays silent while the session is destroying (expected teardown)', () => {
+    const child = makeChild()
+    const log = makeLog()
+    let destroying = false
+    guardChildStreams(child, { destroying: () => destroying, log })
+    destroying = true
+    child.stdout.emit('error', new Error('EPIPE'))
+    assert.equal(log.warnings.length, 0)
+  })
+
+  it('reads the destroying getter lazily on each error (not captured at attach time)', () => {
+    const child = makeChild()
+    const log = makeLog()
+    let destroying = false
+    guardChildStreams(child, { destroying: () => destroying, log })
+    child.stdout.emit('error', new Error('first'))   // logged
+    destroying = true
+    child.stdout.emit('error', new Error('second'))  // suppressed
+    assert.equal(log.warnings.length, 1)
+    assert.match(log.warnings[0], /first/)
+  })
+
+  it('tolerates a child with a missing stream', () => {
+    const child = { stdout: new EventEmitter(), stderr: null }
+    const log = makeLog()
+    assert.doesNotThrow(() => guardChildStreams(child, { destroying: () => false, log }))
+    assert.doesNotThrow(() => child.stdout.emit('error', new Error('EPIPE')))
+    assert.equal(log.warnings.length, 1)
+  })
+
+  it('falls back to a default logger when none is passed (never TypeErrors in its own handler)', () => {
+    const child = makeChild()
+    assert.doesNotThrow(() => guardChildStreams(child, { destroying: () => false }))
+    assert.doesNotThrow(() => child.stdout.emit('error', new Error('EPIPE')))
+  })
+
+  it('omitting opts entirely does not throw (defensive default arg)', () => {
+    const child = makeChild()
+    assert.doesNotThrow(() => guardChildStreams(child))
+  })
+})

--- a/packages/server/tests/credentials-file.test.js
+++ b/packages/server/tests/credentials-file.test.js
@@ -1,0 +1,71 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { readCredentialJsonField } from '../src/credentials-file.js'
+
+/**
+ * Unit coverage for the shared 0600-gated credentials reader (#4144 security
+ * boundary). Temp files live under tmpdir(), never the real ~/.chroxy (the
+ * tests/_setup.mjs sandbox guard would block that). The mode check reads the
+ * file's permission BITS (stat.mode & 0o777), not an access attempt, so it
+ * behaves identically as root — no POSIX_PERM_SKIP needed.
+ */
+
+describe('readCredentialJsonField', () => {
+  let dir
+  let path
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-cred-test-'))
+    path = join(dir, 'credentials.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns code:enoent when the file does not exist', () => {
+    const res = readCredentialJsonField(join(dir, 'nope.json'), 'anthropicApiKey')
+    assert.equal(res.key, null)
+    assert.equal(res.code, 'enoent')
+    assert.match(res.reason, /does not exist/)
+  })
+
+  it('refuses a file more permissive than 0600 (code:mode) with a chmod hint', () => {
+    writeFileSync(path, JSON.stringify({ anthropicApiKey: 'sk-secret' }))
+    chmodSync(path, 0o644)
+    const res = readCredentialJsonField(path, 'anthropicApiKey')
+    assert.equal(res.key, null)
+    assert.equal(res.code, 'mode')
+    assert.match(res.reason, /mode 644/)
+    assert.match(res.reason, /chmod 600/)
+  })
+
+  it('returns code:parse for non-JSON at 0600', () => {
+    writeFileSync(path, 'not json {{{')
+    chmodSync(path, 0o600)
+    const res = readCredentialJsonField(path, 'anthropicApiKey')
+    assert.equal(res.key, null)
+    assert.equal(res.code, 'parse')
+    assert.match(res.reason, /not valid JSON/)
+  })
+
+  it('returns code:missing when the field is absent or empty at 0600', () => {
+    writeFileSync(path, JSON.stringify({ other: 'x', anthropicApiKey: '' }))
+    chmodSync(path, 0o600)
+    const absent = readCredentialJsonField(path, 'deepseekApiKey')
+    assert.equal(absent.code, 'missing')
+    const empty = readCredentialJsonField(path, 'anthropicApiKey')
+    assert.equal(empty.code, 'missing')
+    assert.match(empty.reason, /missing or empty "anthropicApiKey"/)
+  })
+
+  it('returns the key on a well-formed 0600 file', () => {
+    writeFileSync(path, JSON.stringify({ anthropicApiKey: 'sk-ant-123', noise: 1 }))
+    chmodSync(path, 0o600)
+    const res = readCredentialJsonField(path, 'anthropicApiKey')
+    assert.deepEqual(res, { key: 'sk-ant-123' })
+  })
+})

--- a/packages/server/tests/http-oversize.test.js
+++ b/packages/server/tests/http-oversize.test.js
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'events'
+import { sendOversizeResponse } from '../src/http-oversize.js'
+
+/**
+ * Unit coverage for the shared oversize-body 413 responder (#5433). Locks the
+ * contract the three capped HTTP readers depend on: stop consuming + pause the
+ * request, write a 413 with `Connection: close`, and destroySoon the socket on
+ * 'finish' as a belt-and-braces teardown — without ever throwing.
+ */
+
+function makeReq() {
+  const req = new EventEmitter()
+  req.removeAllListenersCalledWith = []
+  const origRemoveAll = req.removeAllListeners.bind(req)
+  req.removeAllListeners = (name) => { req.removeAllListenersCalledWith.push(name); return origRemoveAll(name) }
+  req.paused = false
+  req.pause = () => { req.paused = true }
+  return req
+}
+
+function makeRes({ writeHeadThrows = false } = {}) {
+  const res = new EventEmitter()
+  const socket = { destroyed: false, destroySoonCalled: 0, destroySoon() { this.destroySoonCalled++ } }
+  res.socket = socket
+  res.writeHeadArgs = null
+  res.endArg = null
+  res.writeHead = (status, headers) => {
+    if (writeHeadThrows) throw new Error('socket gone')
+    res.writeHeadArgs = [status, headers]
+  }
+  res.end = (body) => { res.endArg = body; res.emit('finish') }
+  return res
+}
+
+describe('sendOversizeResponse', () => {
+  it('stops consuming the request and writes a 413 with Connection: close', () => {
+    const req = makeReq()
+    const res = makeRes()
+    sendOversizeResponse(req, res)
+    assert.ok(req.removeAllListenersCalledWith.includes('data'), 'drops the data listeners')
+    assert.equal(req.paused, true, 'pauses the request (TCP backpressure)')
+    assert.equal(res.writeHeadArgs[0], 413)
+    assert.equal(res.writeHeadArgs[1]['Connection'], 'close')
+    assert.equal(res.writeHeadArgs[1]['Content-Type'], 'application/json')
+  })
+
+  it('sends the default JSON payload, overridable by the caller', () => {
+    const res1 = makeRes()
+    sendOversizeResponse(makeReq(), res1)
+    assert.deepEqual(JSON.parse(res1.endArg), { error: 'body too large' })
+
+    const res2 = makeRes()
+    sendOversizeResponse(makeReq(), res2, { error: 'too big', max: 1024 })
+    assert.deepEqual(JSON.parse(res2.endArg), { error: 'too big', max: 1024 })
+  })
+
+  it('destroySoons the socket on response finish', () => {
+    const res = makeRes()
+    sendOversizeResponse(makeReq(), res)
+    // res.end() emits 'finish' synchronously in the mock.
+    assert.equal(res.socket.destroySoonCalled, 1)
+  })
+
+  it('does not destroySoon an already-destroyed socket', () => {
+    const res = makeRes()
+    res.socket.destroyed = true
+    sendOversizeResponse(makeReq(), res)
+    assert.equal(res.socket.destroySoonCalled, 0)
+  })
+
+  it('never throws if writeHead fails (socket already torn down)', () => {
+    const req = makeReq()
+    const res = makeRes({ writeHeadThrows: true })
+    assert.doesNotThrow(() => sendOversizeResponse(req, res))
+    // The request was still paused / drained before the write attempt.
+    assert.equal(req.paused, true)
+  })
+})

--- a/packages/server/tests/skills-content-validator.test.js
+++ b/packages/server/tests/skills-content-validator.test.js
@@ -1,0 +1,102 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHash } from 'crypto'
+import {
+  DEFAULT_ALLOWED_EXTENSIONS,
+  SKIP_DIRECTORY_NAMES,
+  _normalizeExtension,
+  _bufferLooksLikeText,
+  _pathLabel,
+} from '../src/skills-content-validator.js'
+
+/**
+ * Unit coverage for the pure skills content/path validation helpers (#3223).
+ * These gate which files load as skills and how skill paths are logged, so
+ * their edge behavior is security-adjacent — pin it.
+ */
+
+describe('skills-content-validator constants', () => {
+  it('DEFAULT_ALLOWED_EXTENSIONS is the dotless md/markdown pair', () => {
+    assert.deepEqual(DEFAULT_ALLOWED_EXTENSIONS, ['md', 'markdown'])
+  })
+
+  it('SKIP_DIRECTORY_NAMES covers the common vendored/build trees', () => {
+    for (const d of ['.git', 'node_modules', '__pycache__', 'dist', 'build']) {
+      assert.ok(SKIP_DIRECTORY_NAMES.has(d), `expected to skip ${d}`)
+    }
+    assert.ok(!SKIP_DIRECTORY_NAMES.has('src'))
+  })
+})
+
+describe('_normalizeExtension', () => {
+  it('lowercases, trims, and strips leading dots', () => {
+    assert.equal(_normalizeExtension('MD'), 'md')
+    assert.equal(_normalizeExtension('.md'), 'md')
+    assert.equal(_normalizeExtension('  .Markdown '), 'markdown')
+    assert.equal(_normalizeExtension('...txt'), 'txt')
+  })
+
+  it('accepts alphanumeric suffixes', () => {
+    assert.equal(_normalizeExtension('mdx'), 'mdx')
+    assert.equal(_normalizeExtension('h1'), 'h1')
+  })
+
+  it('rejects non-strings, empties, and non-[a-z0-9] content', () => {
+    assert.equal(_normalizeExtension(null), null)
+    assert.equal(_normalizeExtension(123), null)
+    assert.equal(_normalizeExtension(''), null)
+    assert.equal(_normalizeExtension('   '), null)
+    assert.equal(_normalizeExtension('.'), null)
+    assert.equal(_normalizeExtension('md.bak'), null) // dot in the middle
+    assert.equal(_normalizeExtension('m d'), null)    // space
+    assert.equal(_normalizeExtension('md!'), null)    // punctuation
+  })
+})
+
+describe('_bufferLooksLikeText', () => {
+  it('accepts plain ASCII and the standard whitespace control chars', () => {
+    assert.equal(_bufferLooksLikeText(Buffer.from('# Title\n\tindented\r\n\v\f end')), true)
+    assert.equal(_bufferLooksLikeText(Buffer.from('')), true) // empty is vacuously text
+  })
+
+  it('accepts multi-byte UTF-8 (bytes >= 0x80 pass)', () => {
+    assert.equal(_bufferLooksLikeText(Buffer.from('héllo — 日本語 😀', 'utf8')), true)
+  })
+
+  it('rejects a NUL byte anywhere, including a binary tail after a valid head', () => {
+    assert.equal(_bufferLooksLikeText(Buffer.from([0x00])), false)
+    const headThenNul = Buffer.concat([Buffer.from('# valid markdown head\n'), Buffer.from([0x00, 0x01])])
+    assert.equal(_bufferLooksLikeText(headThenNul), false)
+  })
+
+  it('rejects non-whitespace control chars (0x00–0x1F except tab/nl/vt/ff/cr, and 0x7F)', () => {
+    assert.equal(_bufferLooksLikeText(Buffer.from([0x01])), false) // SOH
+    assert.equal(_bufferLooksLikeText(Buffer.from([0x1f])), false) // US
+    assert.equal(_bufferLooksLikeText(Buffer.from([0x7f])), false) // DEL
+    assert.equal(_bufferLooksLikeText(Buffer.from([0x08])), false) // backspace
+  })
+})
+
+describe('_pathLabel', () => {
+  it('returns basename + 8-char sha256 prefix of the absolute path', () => {
+    const abs = '/Users/me/.chroxy/skills/evil.md'
+    const expectedPrefix = createHash('sha256').update(abs).digest('hex').slice(0, 8)
+    assert.equal(_pathLabel(abs), `evil.md#${expectedPrefix}`)
+  })
+
+  it('is stable for the same path and differs across paths (no layout leak via the hash)', () => {
+    const a = _pathLabel('/a/b/note.md')
+    const b = _pathLabel('/x/y/note.md')
+    assert.equal(_pathLabel('/a/b/note.md'), a)        // stable
+    assert.equal(a.split('#')[0], 'note.md')           // same basename
+    assert.equal(b.split('#')[0], 'note.md')
+    assert.notEqual(a, b)                              // different hash → different label
+  })
+
+  it('falls back to <unknown> basename for a non-string path', () => {
+    const label = _pathLabel(null)
+    assert.equal(label.split('#')[0], '<unknown>')
+    // The hash is still computed over String(null) deterministically.
+    assert.equal(label, `<unknown>#${createHash('sha256').update('null').digest('hex').slice(0, 8)}`)
+  })
+})


### PR DESCRIPTION
## Summary

Adds unit coverage for five previously-untested pure/near-pure server modules surfaced by a code-health audit. All are security-adjacent or contract-locking, and all are testable without real state (temp files under `tmpdir()`, injected mocks) — no keychain, no network, no SessionManager.

| Module | Coverage |
|--------|----------|
| `skills-content-validator.js` (#3223) | `_normalizeExtension`, `_bufferLooksLikeText` (incl. valid-head/binary-tail rejection), `_pathLabel` (basename + sha prefix, no FS-layout leak), the two exported constants |
| `credentials-file.js` (#4144) | `readCredentialJsonField` — `enoent` / `mode` (0644 refusal + chmod hint) / `parse` / `missing` / success. The mode check reads permission **bits** (`stat.mode & 0o777`), not an access attempt, so it's portable as root |
| `http-oversize.js` (#5433) | `sendOversizeResponse` — 413 + `Connection: close`, request pause/drain, `destroySoon`-on-finish, already-destroyed-socket guard, never-throws-on-writeHead-failure |
| `child-stream-guard.js` (#5324/#5361) | `guardChildStreams` — swallow+log, **lazy** `destroying` getter, missing-stream tolerance, fallback logger, no-opts default |

**28 new tests, all green.**

`byok-compose-state-shared.js` is intentionally left untested: `getSharedComposeStateStore()` constructs a `ByokComposeStateStore` at the default `~/.chroxy` path with no injection seam, which the `tests/_setup.mjs` sandbox guard blocks.

## Verification
`node --test` on the four new files: 28/28 pass. Pure additions (no source changes), so the test-count guard floor is unaffected (count only rises).