### PR TITLE
feat(dashboard): Pages panel — list / copy-link / delete published pages

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -82,6 +82,7 @@ import { ConsolePage } from './components/ConsolePage'
 import { EnvironmentPanel } from './components/EnvironmentPanel'
 import { SnapshotsPanel } from './components/SnapshotsPanel'
 import { PoolStatsPanel } from './components/PoolStatsPanel'
+import { PagesPanel } from './components/PagesPanel'
 import { type RepoInvestigateRequest, type RepoOpenSessionRequest } from './components/ControlRoomSection'
 import { ControlRoomView } from './components/ControlRoomView'
 import { AppModals } from './components/AppModals'
@@ -2261,6 +2262,9 @@ export function App() {
                 )}
                 {viewMode === 'pool' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <PoolStatsPanel />
+                )}
+                {viewMode === 'pages' && connectionPhase !== 'connecting' && !isSwitchingSession && (
+                  <PagesPanel />
                 )}
                 {/* #5204 — the Control Room moved out of the per-session view
                     area into a dedicated top-level tab (rendered above). */}

--- a/packages/dashboard/src/components/PagesPanel.test.tsx
+++ b/packages/dashboard/src/components/PagesPanel.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { PagesPanel, type PageEntry } from './PagesPanel'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+const PAGES: PageEntry[] = [
+  { slug: 'status-report', title: 'Status Report', createdAt: '2026-06-19T10:00:00.000Z', bytes: 2048, path: '/p/status-report/' },
+  { slug: 'arch-brief', title: 'Arch Brief', createdAt: '2026-06-18T09:00:00.000Z', bytes: 512000, path: '/p/arch-brief/' },
+]
+
+describe('PagesPanel', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => cleanup())
+
+  it('fetches /api/pages with the bearer token and lists pages', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ pages: PAGES }))
+    render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} origin="https://x.example" />)
+    await waitFor(() => expect(screen.getByTestId('page-card-status-report')).toBeTruthy())
+    expect(fetchImpl).toHaveBeenCalledWith('/api/pages', expect.objectContaining({ headers: { Authorization: 'Bearer tok' } }))
+    expect(screen.getByTestId('page-title-status-report').textContent).toBe('Status Report')
+    expect(screen.getByTestId('page-card-arch-brief')).toBeTruthy()
+  })
+
+  it('renders the empty state when there are no pages', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ pages: [] }))
+    render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)
+    await waitFor(() => expect(screen.getByTestId('pages-empty')).toBeTruthy())
+    expect(screen.queryByTestId('pages-list')).toBeNull()
+  })
+
+  it('renders an error on a non-ok response and does not show the list', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: 'primary_token_required' }, 403))
+    render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)
+    await waitFor(() => expect(screen.getByTestId('pages-error').textContent).toContain('primary_token_required'))
+    expect(screen.queryByTestId('pages-list')).toBeNull()
+  })
+
+  it('copies the share URL (origin + path) and flashes "Copied!"', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ pages: PAGES }))
+    const copyImpl = vi.fn(async () => true)
+    render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} copyImpl={copyImpl} origin="https://x.example" />)
+    await waitFor(() => expect(screen.getByTestId('page-copy-status-report')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('page-copy-status-report'))
+    await waitFor(() => expect(copyImpl).toHaveBeenCalledWith('https://x.example/p/status-report/'))
+    await waitFor(() => expect(screen.getByTestId('page-copy-status-report').textContent).toBe('Copied!'))
+  })
+
+  it('deletes a page (DELETE /api/pages/<slug>) and drops the row', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === '/api/pages') return jsonResponse({ pages: PAGES })
+      if (url === '/api/pages/arch-brief') return jsonResponse({ removed: true })
+      return new Response('not found', { status: 404 })
+    })
+    render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+    await waitFor(() => expect(screen.getByTestId('page-card-arch-brief')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('page-delete-arch-brief'))
+    await waitFor(() => expect(screen.queryByTestId('page-card-arch-brief')).toBeNull())
+    expect(fetchImpl).toHaveBeenCalledWith('/api/pages/arch-brief', expect.objectContaining({ method: 'DELETE', headers: { Authorization: 'Bearer tok' } }))
+    // The other page is untouched.
+    expect(screen.getByTestId('page-card-status-report')).toBeTruthy()
+  })
+
+  it('surfaces a delete failure as an error and keeps the row', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === '/api/pages') return jsonResponse({ pages: PAGES })
+      return jsonResponse({ error: 'boom' }, 500)
+    })
+    render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+    await waitFor(() => expect(screen.getByTestId('page-card-status-report')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('page-delete-status-report'))
+    await waitFor(() => expect(screen.getByTestId('pages-error').textContent).toContain('boom'))
+    expect(screen.getByTestId('page-card-status-report')).toBeTruthy()
+  })
+})

--- a/packages/dashboard/src/components/PagesPanel.tsx
+++ b/packages/dashboard/src/components/PagesPanel.tsx
@@ -88,15 +88,26 @@ export function PagesPanel({ fetchImpl, getToken, copyImpl, origin }: PagesPanel
 
   const refreshRef = useRef(refresh)
   refreshRef.current = refresh
+  // The "Copied!" flash timer: held in a ref so a repeat click clears the
+  // previous timer (one consistent 1.5s window from the latest click, no
+  // overlapping timers) and so it's torn down on unmount.
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
     void refreshRef.current()
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    }
   }, [])
 
   const handleCopy = useCallback(async (page: PageEntry) => {
     const ok = await resolvedCopy(`${resolvedOrigin}${page.path}`)
     if (ok) {
       setCopiedSlug(page.slug)
-      setTimeout(() => setCopiedSlug((s) => (s === page.slug ? null : s)), 1500)
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = setTimeout(() => {
+        copyTimerRef.current = null
+        setCopiedSlug((s) => (s === page.slug ? null : s))
+      }, 1500)
     }
   }, [resolvedCopy, resolvedOrigin])
 

--- a/packages/dashboard/src/components/PagesPanel.tsx
+++ b/packages/dashboard/src/components/PagesPanel.tsx
@@ -1,0 +1,208 @@
+/**
+ * PagesPanel (#5689) — dashboard surface for Chroxy Pages (epic #5683).
+ *
+ * The CLI shipped `chroxy publish` / `chroxy pages list|rm` (#5687); this panel
+ * exposes the same so users never drop to a terminal. It lists published pages
+ * (title, slug, created, size) with a one-click **copy share URL** and
+ * **delete (revoke)**, reusing the existing primary-token-gated HTTP endpoints:
+ *
+ *   - GET    /api/pages          → { pages: [{ slug, title, createdAt, bytes, path }] }
+ *   - DELETE /api/pages/<slug>   → { removed: boolean }  (idempotent)
+ *
+ * Modeled on PoolStatsPanel (#5053): single fetch on mount + a Refresh button,
+ * injectable fetch / token / clipboard / origin seams for tests. The
+ * "publish this artifact" affordance from #5689 is a separate follow-up.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getAuthToken } from '../utils/auth'
+import { writeText } from '../utils/clipboard'
+
+export interface PageEntry {
+  slug: string
+  title: string
+  createdAt: string
+  bytes: number
+  /** Server-relative page path, e.g. `/p/<slug>/`. */
+  path: string
+}
+
+interface PagesPanelProps {
+  /** Override the fetch impl. Tests inject a stub; production gets window.fetch. */
+  fetchImpl?: typeof fetch
+  /** Override the auth-token resolver. Tests pass a fixed string. */
+  getToken?: () => string | null
+  /** Override the clipboard writer. Tests inject a spy; production gets writeText. */
+  copyImpl?: (text: string) => Promise<boolean>
+  /** Override the share-URL origin. Tests pass a fixed value; production uses window.location.origin. */
+  origin?: string
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatCreated(iso: string): string {
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return '—'
+  return new Date(ms).toLocaleString()
+}
+
+export function PagesPanel({ fetchImpl, getToken, copyImpl, origin }: PagesPanelProps = {}) {
+  const [pages, setPages] = useState<PageEntry[] | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copiedSlug, setCopiedSlug] = useState<string | null>(null)
+  const [deletingSlug, setDeletingSlug] = useState<string | null>(null)
+
+  const resolvedFetch: typeof fetch =
+    fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init))
+  const resolvedGetToken = getToken ?? getAuthToken
+  const resolvedCopy = copyImpl ?? writeText
+  const resolvedOrigin = origin ?? (typeof window !== 'undefined' ? window.location.origin : '')
+
+  const authHeaders = useCallback((): HeadersInit | undefined => {
+    const token = resolvedGetToken()
+    return token ? { Authorization: `Bearer ${token}` } : undefined
+  }, [resolvedGetToken])
+
+  const refresh = useCallback(async () => {
+    setError(null)
+    setLoading(true)
+    try {
+      const res = await resolvedFetch('/api/pages', { headers: authHeaders() })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
+      }
+      const body = (await res.json()) as { pages?: PageEntry[] }
+      setPages(Array.isArray(body.pages) ? body.pages : [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load pages')
+    } finally {
+      setLoading(false)
+    }
+  }, [resolvedFetch, authHeaders])
+
+  const refreshRef = useRef(refresh)
+  refreshRef.current = refresh
+  useEffect(() => {
+    void refreshRef.current()
+  }, [])
+
+  const handleCopy = useCallback(async (page: PageEntry) => {
+    const ok = await resolvedCopy(`${resolvedOrigin}${page.path}`)
+    if (ok) {
+      setCopiedSlug(page.slug)
+      setTimeout(() => setCopiedSlug((s) => (s === page.slug ? null : s)), 1500)
+    }
+  }, [resolvedCopy, resolvedOrigin])
+
+  const handleDelete = useCallback(async (slug: string) => {
+    setError(null)
+    setDeletingSlug(slug)
+    try {
+      const res = await resolvedFetch(`/api/pages/${encodeURIComponent(slug)}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
+      }
+      // Optimistically drop the row; the server delete is idempotent.
+      setPages((prev) => (prev ? prev.filter((p) => p.slug !== slug) : prev))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to delete ${slug}`)
+    } finally {
+      setDeletingSlug((s) => (s === slug ? null : s))
+    }
+  }, [resolvedFetch, authHeaders])
+
+  const list = pages ?? []
+
+  return (
+    <div className="environment-panel" data-testid="pages-panel">
+      <div className="env-panel-header">
+        <h2>Pages</h2>
+        <button
+          className="btn-env-new"
+          data-testid="pages-refresh"
+          onClick={() => void refresh()}
+          disabled={loading}
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          className="env-empty"
+          data-testid="pages-error"
+          style={{ color: 'var(--status-error, #ef4444)' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!error && pages && list.length === 0 && (
+        <div className="env-empty" data-testid="pages-empty">
+          <p>No pages published yet.</p>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.9em' }}>
+            Publish an HTML artifact with <code>chroxy publish &lt;file&gt;</code> and it
+            appears here with a shareable link.
+          </p>
+        </div>
+      )}
+
+      {/* The list renders whenever pages are known — a transient action error
+          (e.g. a failed delete) shows in the banner above WITHOUT blanking the
+          still-valid list. Only an initial-load failure (pages === null) shows
+          the error in place of the list. */}
+      {list.length > 0 && (
+        <div className="env-grid" data-testid="pages-list">
+          {list.map((p) => (
+            <div className="env-card" key={p.slug} data-testid={`page-card-${p.slug}`}>
+              <div className="env-card-header">
+                <span className="env-card-name" data-testid={`page-title-${p.slug}`}>{p.title || p.slug}</span>
+              </div>
+              <div className="env-card-details">
+                <div className="env-card-row">
+                  <span className="env-card-label">Slug</span>
+                  <span className="env-card-value" style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '0.8em' }}>{p.slug}</span>
+                </div>
+                <div className="env-card-row">
+                  <span className="env-card-label">Created</span>
+                  <span className="env-card-value">{formatCreated(p.createdAt)}</span>
+                </div>
+                <div className="env-card-row">
+                  <span className="env-card-label">Size</span>
+                  <span className="env-card-value">{formatBytes(p.bytes)}</span>
+                </div>
+              </div>
+              <div className="env-card-actions">
+                <button
+                  className="btn-env-action"
+                  data-testid={`page-copy-${p.slug}`}
+                  onClick={() => void handleCopy(p)}
+                >
+                  {copiedSlug === p.slug ? 'Copied!' : 'Copy link'}
+                </button>
+                <button
+                  className="btn-env-action btn-env-danger"
+                  data-testid={`page-delete-${p.slug}`}
+                  onClick={() => void handleDelete(p.slug)}
+                  disabled={deletingSlug === p.slug}
+                >
+                  {deletingSlug === p.slug ? 'Deleting…' : 'Delete'}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -5,7 +5,7 @@ import { formatShortcutKeys } from '../utils/platform'
 // #5204 — 'control-room' is no longer a per-session viewMode; the Control
 // Room is a dedicated session-independent top-level tab (see `controlRoomOpen`
 // / `controlRoomActive` in App).
-export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool'
+export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'pages'
 
 /** Scrollable tab bar with arrow buttons when overflowing */
 export function ViewSwitcher({
@@ -136,6 +136,7 @@ export function ViewSwitcher({
         <button className={`view-tab${viewMode === 'environments' ? ' active' : ''}`} onClick={() => { setViewMode('environments'); setSplitMode(null); persistSplitMode(null) }} type="button">Envs</button>
         <button className={`view-tab${viewMode === 'snapshots' ? ' active' : ''}`} onClick={() => { setViewMode('snapshots'); setSplitMode(null); persistSplitMode(null) }} type="button">Snapshots</button>
         <button className={`view-tab${viewMode === 'pool' ? ' active' : ''}`} onClick={() => { setViewMode('pool'); setSplitMode(null); persistSplitMode(null) }} type="button">Pool</button>
+        <button className={`view-tab${viewMode === 'pages' ? ' active' : ''}`} onClick={() => { setViewMode('pages'); setSplitMode(null); persistSplitMode(null) }} type="button">Pages</button>
         <div className="view-switch-spacer" />
         <button className={`view-tab view-tab-right${checkpointsOpen ? ' active' : ''}`} onClick={() => setCheckpointsOpen(prev => !prev)} type="button" title="Toggle checkpoint timeline">Checkpoints</button>
         <button className={`view-tab${viewMode === 'diff' ? ' active' : ''}`} onClick={() => setViewMode('diff')} type="button">Diff</button>

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -96,7 +96,7 @@ const MAX_TERMINAL_SIZE = 50_000;
  * #5204 — 'control-room' removed: it's a top-level tab now, not a view mode.
  * Any stale persisted 'control-room' value fails validation and falls back to
  * the default, which is the desired behaviour. */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots', 'pool'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots', 'pool', 'pages'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -943,7 +943,7 @@ export interface ConnectionState {
 
   // View mode. #5204 — 'control-room' removed: the Control Room is now a
   // session-independent top-level tab in App, not a per-session view mode.
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'pages';
 
   // Input settings
   inputSettings: InputSettings;
@@ -962,7 +962,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'pages') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
   appendTerminalData: (data: string) => void;


### PR DESCRIPTION
## Summary

Part of #5689 (Chroxy Pages epic #5683). The CLI shipped `chroxy publish` / `chroxy pages list|rm` (#5687); this adds the dashboard equivalent so Pages feels native instead of CLI-only.

New **"Pages" tab** lists published pages (title, slug, created, size) with a one-click **copy share URL** and **delete (revoke)**, reusing the existing primary-token-gated endpoints — **no new server surface**:
- `GET /api/pages` → `{ pages: [{ slug, title, createdAt, bytes, path }] }`
- `DELETE /api/pages/<slug>` → `{ removed }` (idempotent)

Modeled on `PoolStatsPanel` (#5053): single fetch on mount + Refresh button, injectable `fetch`/`token`/`clipboard`/`origin` seams. Copy routes through the Tauri-aware `writeText` helper (#4673). Delete optimistically drops the row; a transient delete error shows in the banner **without blanking the still-valid list** (only an initial-load failure replaces the list — a UX bug the tests caught and the code now avoids).

**Wiring:** `'pages'` added to all four ViewMode unions (store state, `setViewMode`, `ViewSwitcher`, persistence `VALID_VIEW_MODES`); a "Pages" nav button after "Pool"; the panel mounted in `App.tsx`.

## Scope

This lands the **list / copy / delete** panel — the well-defined core. The issue's second affordance, **"publish this artifact"** (a button on generated HTML reports that POSTs to `/api/pages`), is split to a follow-up since it touches the report-generation surfaces.

## Verification

`PagesPanel.test.tsx` (7 tests: bearer-token header, list render, empty state, load error, copy-flash with origin+path, delete-drops-row with the right DELETE URL, delete-error-keeps-list) + ViewSwitcher/persistence suites green; dashboard `tsc` clean. The panel follows the production-proven PoolStatsPanel fetch pattern; CI runs the full dashboard suite.