### PR TITLE
feat(app): queue messages sent mid-turn instead of blocking send (#5938)

### DIFF
--- a/packages/app/__tests__/ComponentRendering.test.ts
+++ b/packages/app/__tests__/ComponentRendering.test.ts
@@ -58,7 +58,9 @@ describe('InputBar component', () => {
 
   test('has send button with accessibilityRole and accessibilityLabel', () => {
     expect(inputBarSrc).toMatch(/accessibilityRole="button"/)
-    expect(inputBarSrc).toMatch(/accessibilityLabel="Send message"/)
+    // #5938 — the Send label is now dynamic: 'Queue message' mid-turn (the
+    // send-while-streaming un-gate), 'Send message' when idle.
+    expect(inputBarSrc).toMatch(/accessibilityLabel=\{isStreaming \? 'Queue message' : 'Send message'\}/)
   })
 
   test('has interrupt button with accessibility label', () => {

--- a/packages/app/__tests__/message-handler.test.ts
+++ b/packages/app/__tests__/message-handler.test.ts
@@ -182,6 +182,45 @@ describe('message-handler', () => {
       expect(ss.streamingMessageId).toBe('start-1');
     });
 
+    it('#5938 — inserts the response BEFORE a trailing queued follow-up bubble', () => {
+      // A message was queued during the pending window: it sits at the end of
+      // `messages` with a matching `queuedMessages` entry, after the 'thinking'
+      // placeholder. When stream_start lands, the new response must go BEFORE the
+      // queued bubble (chronology: the queued message is a FUTURE turn).
+      store = createMockStore(createMockState({
+        streamingMessageId: 'pending',
+        messages: [
+          { id: 'user-a', type: 'user_input', content: 'A', timestamp: 1 },
+          { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
+          { id: 'queued-b', type: 'user_input', content: 'B', timestamp: 3 },
+        ],
+        queuedMessages: [{ clientMessageId: 'queued-b', text: 'B', queuedAt: 3, status: 'pending' }],
+      } as unknown as Partial<SessionState>));
+      setStore(store);
+
+      handleMessage({ type: 'stream_start', messageId: 'resp-a', sessionId: SESSION_ID });
+
+      const ids = store.getState().sessionStates[SESSION_ID].messages.map((m) => m.id);
+      // 'thinking' removed; response inserted before the still-queued 'queued-b'.
+      expect(ids).toEqual(['user-a', 'resp-a', 'queued-b']);
+    });
+
+    it('#5938 — appends the response at the end when nothing is queued (regression)', () => {
+      store = createMockStore(createMockState({
+        streamingMessageId: 'pending',
+        messages: [
+          { id: 'user-a', type: 'user_input', content: 'A', timestamp: 1 },
+          { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
+        ],
+      } as unknown as Partial<SessionState>));
+      setStore(store);
+
+      handleMessage({ type: 'stream_start', messageId: 'resp-a', sessionId: SESSION_ID });
+
+      const ids = store.getState().sessionStates[SESSION_ID].messages.map((m) => m.id);
+      expect(ids).toEqual(['user-a', 'resp-a']);
+    });
+
     it('reuses existing response message on reconnect replay', () => {
       store = createMockStore(createMockState({
         messages: [{ id: 'start-2', type: 'response', content: 'old content', timestamp: 1000 }],

--- a/packages/app/src/__tests__/store/connection-queued-messages.test.ts
+++ b/packages/app/src/__tests__/store/connection-queued-messages.test.ts
@@ -128,6 +128,25 @@ describe('#5938 — sendCancelQueued', () => {
     expect(ids).toEqual(['cmid-2']);
   });
 
+  it('also removes the optimistic bubble from messages (no phantom "sent" bubble)', () => {
+    const socket: FakeSocket = { readyState: OPEN, send: jest.fn() };
+    seedSession({
+      messages: [
+        { id: 'cmid-1', type: 'user_input', content: 'a', timestamp: 1 },
+        { id: 'cmid-2', type: 'user_input', content: 'b', timestamp: 2 },
+      ],
+      queuedMessages: [
+        { clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' },
+        { clientMessageId: 'cmid-2', text: 'b', queuedAt: 2, status: 'confirmed' },
+      ],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    useConnectionStore.getState().sendCancelQueued('cmid-1');
+    // The cancelled bubble is gone from messages; the other survives.
+    expect(activeState().messages.map((m) => m.id)).toEqual(['cmid-2']);
+  });
+
   it('refuses (returns false, no mutation) while disconnected', () => {
     seedSession({
       queuedMessages: [{ clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' }],
@@ -138,5 +157,46 @@ describe('#5938 — sendCancelQueued', () => {
     expect(result).toBe(false);
     // The entry is preserved — the queue stays actionable on reconnect.
     expect(activeState().queuedMessages).toHaveLength(1);
+  });
+});
+
+describe('#5938 — sendInterrupt clears the queue', () => {
+  it('drops queued bubbles + entries (Stop cancels pending follow-ups)', () => {
+    const socket: FakeSocket = { readyState: OPEN, send: jest.fn() };
+    seedSession({
+      streamingMessageId: 'live-1',
+      messages: [
+        { id: 'live-1', type: 'response', content: '…', timestamp: 1 },
+        { id: 'q-1', type: 'user_input', content: 'a', timestamp: 2 },
+        { id: 'q-2', type: 'user_input', content: 'b', timestamp: 3 },
+      ],
+      queuedMessages: [
+        { clientMessageId: 'q-1', text: 'a', queuedAt: 2, status: 'confirmed' },
+        { clientMessageId: 'q-2', text: 'b', queuedAt: 3, status: 'pending' },
+      ],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    useConnectionStore.getState().sendInterrupt();
+
+    const s = activeState();
+    // Interrupt frame went out; the queue + its phantom bubbles are cleared,
+    // the live response bubble is untouched.
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(socket.send.mock.calls[0][0])).toMatchObject({ type: 'interrupt' });
+    expect(s.queuedMessages).toHaveLength(0);
+    expect(s.messages.map((m) => m.id)).toEqual(['live-1']);
+  });
+
+  it('leaves messages untouched when there is no queue', () => {
+    const socket: FakeSocket = { readyState: OPEN, send: jest.fn() };
+    seedSession({
+      streamingMessageId: 'live-1',
+      messages: [{ id: 'live-1', type: 'response', content: '…', timestamp: 1 }],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    useConnectionStore.getState().sendInterrupt();
+    expect(activeState().messages.map((m) => m.id)).toEqual(['live-1']);
   });
 });

--- a/packages/app/src/__tests__/store/connection-queued-messages.test.ts
+++ b/packages/app/src/__tests__/store/connection-queued-messages.test.ts
@@ -1,0 +1,142 @@
+/**
+ * #5938 (epic #5935 slice ③) — send-while-streaming queue, store layer.
+ *
+ * Covers the two store actions the mobile queued-message UI relies on:
+ *   1. `addUserMessage(..., { queued: true })` — a mid-turn send must append the
+ *      user bubble + seed an optimistic `'pending'` queue entry WITHOUT
+ *      re-arming the live turn's thinking indicator / streamingMessageId (that
+ *      would stomp the in-flight turn). The non-queued path still arms as before.
+ *   2. `sendCancelQueued(clientMessageId)` — sends a `cancel_queued` wire frame
+ *      and optimistically drops the local entry when connected; refuses (returns
+ *      false, no mutation) while disconnected.
+ *
+ * Reconciliation against the server's message_queued/message_dequeued is owned
+ * by the shared store-core dispatch table (tested in store-core); these tests
+ * pin the app-store send/cancel path that feeds it.
+ */
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../utils/haptics', () => ({
+  hapticLight: jest.fn(),
+  hapticMedium: jest.fn(),
+  hapticWarning: jest.fn(),
+  hapticSuccess: jest.fn(),
+}));
+
+import { useConnectionStore } from '../../store/connection';
+import type { SessionState } from '../../store/types';
+
+interface FakeSocket {
+  readyState: number;
+  send: jest.Mock;
+}
+
+const OPEN = 1; // WebSocket.OPEN
+
+function seedSession(overrides: Partial<SessionState> = {}): void {
+  const base = {
+    messages: [],
+    queuedMessages: [],
+    streamingMessageId: null,
+    claudeReady: true,
+  } as unknown as SessionState;
+  useConnectionStore.setState({
+    activeSessionId: 'sess-1',
+    sessionStates: { 'sess-1': { ...base, ...overrides } },
+    socket: null,
+  } as never);
+}
+
+function activeState(): SessionState {
+  return useConnectionStore.getState().sessionStates['sess-1'];
+}
+
+describe('#5938 — addUserMessage queued path', () => {
+  it('seeds an optimistic pending entry and does NOT re-arm the live turn', () => {
+    // A turn is already streaming (id 'live-1') with its own thinking bubble.
+    seedSession({
+      streamingMessageId: 'live-1',
+      messages: [{ id: 'live-1', type: 'thinking', content: '', timestamp: 1 }],
+    } as unknown as Partial<SessionState>);
+
+    useConnectionStore.getState().addUserMessage('queued follow-up', undefined, {
+      clientMessageId: 'cmid-1',
+      queued: true,
+    });
+
+    const s = activeState();
+    // The user bubble is appended.
+    const userMsg = s.messages.find((m) => m.id === 'cmid-1');
+    expect(userMsg).toBeTruthy();
+    expect(userMsg?.type).toBe('user_input');
+    expect(userMsg?.content).toBe('queued follow-up');
+    // The live turn is untouched — no fresh thinking arm, stream id preserved.
+    expect(s.streamingMessageId).toBe('live-1');
+    expect(s.messages.filter((m) => m.type === 'thinking')).toHaveLength(1);
+    // An optimistic pending queue entry exists, keyed by the clientMessageId.
+    expect(s.queuedMessages).toHaveLength(1);
+    expect(s.queuedMessages[0]).toMatchObject({
+      clientMessageId: 'cmid-1',
+      text: 'queued follow-up',
+      status: 'pending',
+    });
+  });
+
+  it('dedupes a repeat queued send by clientMessageId', () => {
+    seedSession({ streamingMessageId: 'live-1' } as unknown as Partial<SessionState>);
+    const add = useConnectionStore.getState().addUserMessage;
+    add('dup', undefined, { clientMessageId: 'cmid-dup', queued: true });
+    add('dup', undefined, { clientMessageId: 'cmid-dup', queued: true });
+    expect(activeState().queuedMessages).toHaveLength(1);
+  });
+
+  it('the non-queued path still arms the thinking indicator (regression guard)', () => {
+    seedSession();
+    useConnectionStore.getState().addUserMessage('fresh turn', undefined, {
+      clientMessageId: 'cmid-2',
+    });
+    const s = activeState();
+    expect(s.streamingMessageId).toBe('pending');
+    expect(s.messages.some((m) => m.type === 'thinking')).toBe(true);
+    // No queue entry on a normal (idle) send.
+    expect(s.queuedMessages).toHaveLength(0);
+  });
+});
+
+describe('#5938 — sendCancelQueued', () => {
+  it('sends a cancel_queued frame and optimistically drops the entry when connected', () => {
+    const socket: FakeSocket = { readyState: OPEN, send: jest.fn() };
+    seedSession({
+      queuedMessages: [
+        { clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' },
+        { clientMessageId: 'cmid-2', text: 'b', queuedAt: 2, status: 'pending' },
+      ],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    const result = useConnectionStore.getState().sendCancelQueued('cmid-1');
+    expect(result).toBe('sent');
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(socket.send.mock.calls[0][0]);
+    expect(sent).toMatchObject({ type: 'cancel_queued', clientMessageId: 'cmid-1', sessionId: 'sess-1' });
+    // Only the cancelled entry is dropped.
+    const ids = activeState().queuedMessages.map((m) => m.clientMessageId);
+    expect(ids).toEqual(['cmid-2']);
+  });
+
+  it('refuses (returns false, no mutation) while disconnected', () => {
+    seedSession({
+      queuedMessages: [{ clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' }],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket: null } as never);
+
+    const result = useConnectionStore.getState().sendCancelQueued('cmid-1');
+    expect(result).toBe(false);
+    // The entry is preserved — the queue stays actionable on reconnect.
+    expect(activeState().queuedMessages).toHaveLength(1);
+  });
+});

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -75,6 +75,16 @@ export interface ChatViewProps {
   isSelectingRef: React.MutableRefObject<boolean>;
   onToggleSelection: (id: string) => void;
   streamingMessageId: string | null;
+  /**
+   * #5938 — clientMessageIds of the active session's user bubbles that are
+   * currently queued (sent mid-turn, awaiting flush). A matching `user_input`
+   * row renders a "Queued" badge + cancel affordance. Per-session, derived in
+   * SessionScreen from the store's `queuedMessages` so it survives the
+   * session-switch re-render without leaking across sessions.
+   */
+  queuedIds?: Set<string>;
+  /** #5938 — cancel a still-queued follow-up by its clientMessageId. */
+  onCancelQueued?: (id: string) => void;
   isPlanPending?: boolean;
   planAllowedPrompts?: { tool: string; prompt: string }[];
   onApprovePlan?: () => void;
@@ -153,6 +163,8 @@ export function ChatView({
   isSelectingRef,
   onToggleSelection,
   streamingMessageId,
+  queuedIds,
+  onCancelQueued,
   isPlanPending,
   planAllowedPrompts,
   onApprovePlan,
@@ -411,6 +423,8 @@ export function ChatView({
             <MessageBubble
               allowSingleMultiSelect={allowSingleMultiSelect}
               message={msg}
+              queued={msg.type === 'user_input' && (queuedIds?.has(msg.id) ?? false)}
+              onCancelQueued={onCancelQueued}
               onSelectOption={onSelectOption}
               onSubmitMultiQuestion={onSubmitMultiQuestion}
               allowMultiQuestion={allowMultiQuestion}
@@ -453,6 +467,8 @@ export function ChatView({
       onSubmitMultiQuestion,
       allowMultiQuestion,
       allowSingleMultiSelect,
+      queuedIds,
+      onCancelQueued,
       chatTailMessageId,
       lastUserInputContent,
       sendInput,

--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -330,7 +330,9 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
           onChangeText={handleChangeText}
           // When enterToSend is true, multiline is false and onSubmitEditing fires on Enter.
           // When enterToSend is false, multiline is true so onSubmitEditing never fires.
-          onSubmitEditing={enterToSend && !isStreaming && !disabled ? onSend : undefined}
+          // #5938 — Enter sends EVEN while streaming now; onSend routes a
+          // mid-turn message to the outgoing queue (the send-while-busy path).
+          onSubmitEditing={enterToSend && !disabled ? onSend : undefined}
           blurOnSubmit={false}
           multiline={!enterToSend}
           autoCapitalize={viewMode === 'chat' ? 'sentences' : 'none'}
@@ -387,7 +389,10 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
             </Animated.View>
           </TouchableOpacity>
         )}
-        {isStreaming ? (
+        {/* #5938 — during a turn, BOTH controls show: Stop interrupts the live
+            turn, Send queues a follow-up that flushes when the turn completes.
+            When idle, only Send renders. */}
+        {isStreaming && (
           <TouchableOpacity
             style={[styles.interruptButton, disabled && styles.interruptButtonDisabled]}
             onPress={onInterrupt}
@@ -395,22 +400,22 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
             accessibilityRole="button"
             accessibilityLabel="Interrupt Claude"
             accessibilityState={a11yDisabled}
+            testID="chat-stop-button"
           >
             <Icon name="stop" size={16} color={COLORS.textPrimary} />
           </TouchableOpacity>
-        ) : (
-          <TouchableOpacity
-            style={[styles.sendButton, disabled && styles.sendButtonDisabled]}
-            onPress={onSend}
-            disabled={disabled}
-            accessibilityRole="button"
-            accessibilityLabel="Send message"
-            accessibilityState={a11yDisabled}
-            testID="chat-send-button"
-          >
-            <Icon name="arrowUp" size={20} color={COLORS.textPrimary} />
-          </TouchableOpacity>
         )}
+        <TouchableOpacity
+          style={[styles.sendButton, disabled && styles.sendButtonDisabled]}
+          onPress={onSend}
+          disabled={disabled}
+          accessibilityRole="button"
+          accessibilityLabel={isStreaming ? 'Queue message' : 'Send message'}
+          accessibilityState={a11yDisabled}
+          testID="chat-send-button"
+        >
+          <Icon name="arrowUp" size={20} color={COLORS.textPrimary} />
+        </TouchableOpacity>
       </View>
     </View>
   );

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -152,3 +152,59 @@ describe('InputBar imperative draft ownership (#5556)', () => {
     expect(renderCount).toBe(afterFirst);
   });
 });
+
+describe('InputBar send-while-streaming un-gate (#5938)', () => {
+  // findByProps throws on 0 or >1; it collapses composite+host duplicates to the
+  // single component, so it's the reliable presence/absence probe here.
+  function present(tree: renderer.ReactTestRenderer, id: string): boolean {
+    try { tree.root.findByProps({ testID: id }); return true; } catch { return false; }
+  }
+
+  it('shows ONLY the Send button when idle', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar {...baseProps} isStreaming={false} onChangeText={noop} />);
+    });
+    expect(present(tree, 'chat-send-button')).toBe(true);
+    expect(present(tree, 'chat-stop-button')).toBe(false);
+  });
+
+  it('shows BOTH Send and Stop while streaming (so a mid-turn send can queue)', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar {...baseProps} isStreaming={true} onChangeText={noop} />);
+    });
+    // Send stays available → routes to the outgoing queue.
+    expect(present(tree, 'chat-send-button')).toBe(true);
+    // Stop is alongside it → interrupts the live turn.
+    expect(present(tree, 'chat-stop-button')).toBe(true);
+  });
+
+  it('the streaming Send button is enabled and fires onSend (enqueue path)', () => {
+    const onSend = jest.fn();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar {...baseProps} isStreaming={true} onSend={onSend} onChangeText={noop} />);
+    });
+    const send = tree.root.findByProps({ testID: 'chat-send-button' });
+    expect(send.props.accessibilityState?.disabled).toBeFalsy();
+    // The label flips to "Queue message" mid-turn for clarity.
+    expect(send.props.accessibilityLabel).toBe('Queue message');
+    act(() => { send.props.onPress(); });
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter-to-send stays wired while streaming (onSubmitEditing fires onSend)', () => {
+    const onSend = jest.fn();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} isStreaming={true} enterToSend onSend={onSend} onChangeText={noop} />,
+      );
+    });
+    const input = getTextInput(tree);
+    expect(input.props.onSubmitEditing).toBeDefined();
+    act(() => { input.props.onSubmitEditing(); });
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -73,8 +73,16 @@ export function buildPromptSessionLabel(
   return provider ? `${name} · ${provider}` : name;
 }
 
-function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, allowSingleMultiSelect, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
+function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, allowSingleMultiSelect, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
   message: ChatMessage;
+  /**
+   * #5938 — true when this `user_input` bubble was sent mid-turn and is sitting
+   * in the outgoing queue (awaiting the current turn's completion). Renders a
+   * "Queued" badge + cancel affordance under the message body.
+   */
+  queued?: boolean;
+  /** #5938 — cancel this queued follow-up by its message id before it flushes. */
+  onCancelQueued?: (id: string) => void;
   onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
   /**
    * #4973 — submit handler for the multi-question form. Fires with the
@@ -452,6 +460,26 @@ function MessageBubbleImpl({ message, onSelectOption, onSubmitMultiQuestion, all
           ))}
         </View>
       )}
+      {/* #5938 — queued follow-up: a "Queued" badge + cancel affordance under
+          a user bubble sent mid-turn. The server flushes it when the current
+          turn completes; tapping × cancels it before then. Only on user bubbles
+          flagged queued by ChatView (via the per-session queue). */}
+      {isUser && queued && (
+        <View style={styles.queuedRow} testID={`msg-queued-${message.id}`}>
+          <Text style={styles.queuedLabel}>Queued</Text>
+          {onCancelQueued && (
+            <TouchableOpacity
+              onPress={() => onCancelQueued(message.id)}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Cancel queued message"
+              testID={`msg-queued-cancel-${message.id}`}
+            >
+              <Text style={styles.queuedCancel}>Cancel</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
       {showDisconnectedAnswerHint && (
         <Text testID="prompt-disconnected-hint" style={styles.promptDisconnectedHint}>
           Disconnected — reconnect to respond
@@ -694,6 +722,10 @@ export const MessageBubble = React.memo(MessageBubbleImpl, (prev, next) => {
     // bubble keeps stale gating (the dashboard re-renders via useMessageRenderer's
     // deps; the app relies on this comparator).
     prev.allowSingleMultiSelect === next.allowSingleMultiSelect &&
+    // #5938 — re-render when the queued flag flips (badge appears/clears on
+    // enqueue/flush) or the cancel handler's presence changes.
+    prev.queued === next.queued &&
+    (prev.onCancelQueued == null) === (next.onCancelQueued == null) &&
     (prev.onRetryStreamStall == null) === (next.onRetryStreamStall == null)
   );
 });
@@ -712,6 +744,26 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
     borderColor: COLORS.accentBlueBorder,
     borderWidth: 1,
+  },
+  // #5938 — queued-follow-up affordance under a user bubble.
+  queuedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: 10,
+    marginTop: 6,
+  },
+  queuedLabel: {
+    color: COLORS.textMuted,
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  queuedCancel: {
+    color: COLORS.accentRed,
+    fontSize: 12,
+    fontWeight: '600',
   },
   attachmentRow: {
     flexDirection: 'row',

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -470,7 +470,9 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
           {onCancelQueued && (
             <TouchableOpacity
               onPress={() => onCancelQueued(message.id)}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              // #5938 — pad the tap target to ~44pt (iOS HIG): the "Cancel"
+              // text is ~16pt tall, so ≥14pt of vertical hitSlop clears the bar.
+              hitSlop={{ top: 14, bottom: 14, left: 12, right: 12 }}
               accessibilityRole="button"
               accessibilityLabel="Cancel queued message"
               testID={`msg-queued-cancel-${message.id}`}

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, stripAnsi, nextMessageId } from '../store/connection';
+import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, selectQueuedMessages, stripAnsi, nextMessageId } from '../store/connection';
 import type { ChatMessage, ConnectionPhase, AgentInfo, McpServer, DevPreview } from '../store/connection';
 import type { SessionIntervention } from '@chroxy/store-core';
 // #4875: shared typed predicate for the AskUserQuestion freeform shape.
@@ -224,6 +224,18 @@ export function SessionScreen() {
   const setViewMode = useConnectionStore((s) => s.setViewMode);
   const sendInput = useConnectionStore((s) => s.sendInput);
   const sendInterrupt = useConnectionStore((s) => s.sendInterrupt);
+  // #5938 — the active session's outgoing queue (mid-turn follow-ups). Derive a
+  // Set of queued clientMessageIds so ChatView/MessageBubble can flag matching
+  // user bubbles with a "Queued" badge + cancel affordance in O(1) per row.
+  // Reads from the per-session store (not ChatView-local state) so it survives
+  // the session-switch re-render without leaking across sessions.
+  const queuedMessages = useConnectionStore(selectQueuedMessages);
+  const sendCancelQueued = useConnectionStore((s) => s.sendCancelQueued);
+  const queuedIds = useMemo(
+    () => new Set(queuedMessages.map((m) => m.clientMessageId).filter((id): id is string => !!id)),
+    [queuedMessages],
+  );
+  const handleCancelQueued = useCallback((id: string) => { sendCancelQueued(id); }, [sendCancelQueued]);
   // #5699 — reactive count of queued (unsent) messages, surfaced in the
   // reconnect banner so held input isn't invisible to the user.
   const queuedMessageCount = useConnectionStore((s) => s.queuedMessageCount);
@@ -704,7 +716,12 @@ export function SessionScreen() {
     const hasAttachments = pendingAttachments.length > 0;
     // #5556 — read the draft from the InputBar ref (it owns the value now).
     const draft = inputRef.current?.getValue() ?? '';
-    if ((!draft.trim() && !hasAttachments) || streamingMessageId) return;
+    if (!draft.trim() && !hasAttachments) return;
+    // #5938 — capture busy state at send time. A send mid-turn no longer bails
+    // out: it queues (the bubble renders with a "Queued" badge and the server
+    // flushes it when the current turn completes) rather than starting a fresh
+    // turn. `busy` drives addUserMessage's optimistic-enqueue path below.
+    const busy = !!streamingMessageId;
     // Expand any collapsed-paste markers back to their original content
     // before send (#3797). Trim happens AFTER expansion so an expanded
     // payload with surrounding whitespace still sends cleanly.
@@ -755,7 +772,7 @@ export function SessionScreen() {
     const clientMessageId = nextMessageId('user');
 
     if (viewMode === 'chat' || viewMode === 'files') {
-      addUserMessage(text || `[${pendingAttachments.length} file(s) attached]`, msgAttachments, { clientMessageId });
+      addUserMessage(text || `[${pendingAttachments.length} file(s) attached]`, msgAttachments, { clientMessageId, queued: busy });
     }
 
     // Clear plan approval card — user has responded (whether approving or giving feedback)
@@ -1551,6 +1568,8 @@ export function SessionScreen() {
                   isSelectingRef={isSelectingRef}
                   onToggleSelection={toggleSelection}
                   streamingMessageId={streamingMessageId}
+                  queuedIds={queuedIds}
+                  onCancelQueued={handleCancelQueued}
                   isPlanPending={isPlanPending}
                   planAllowedPrompts={planAllowedPrompts}
                   onApprovePlan={handleApprovePlan}
@@ -1585,6 +1604,8 @@ export function SessionScreen() {
               isSelectingRef={isSelectingRef}
               onToggleSelection={toggleSelection}
               streamingMessageId={streamingMessageId}
+              queuedIds={queuedIds}
+              onCancelQueued={handleCancelQueued}
               isPlanPending={isPlanPending}
               planAllowedPrompts={planAllowedPrompts}
               onApprovePlan={handleApprovePlan}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1733,6 +1733,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket, activeSessionId } = get();
     const payload: Record<string, unknown> = { type: 'interrupt' };
     if (activeSessionId) payload.sessionId = activeSessionId;
+    // #5938 — Stop clears the outgoing queue too (server policy #5936: a
+    // deliberate interrupt cancels pending follow-ups rather than auto-firing
+    // them). Drop the queued bubbles + entries optimistically so they don't
+    // linger as phantom "sent" messages; the server's per-item
+    // message_dequeued{interrupted} then no-ops against the cleared queue.
+    if (activeSessionId && get().sessionStates[activeSessionId]) {
+      const queued = get().sessionStates[activeSessionId].queuedMessages ?? [];
+      if (queued.length > 0) {
+        const queuedIds = new Set(queued.map((q) => q.clientMessageId).filter((id): id is string => !!id));
+        updateSession(activeSessionId, (ss) => ({
+          queuedMessages: [],
+          messages: ss.messages.filter((m) => !queuedIds.has(m.id)),
+        }));
+      }
+    }
     if (socket && socket.readyState === WebSocket.OPEN) {
       hapticMedium();
       wsSend(socket, payload);
@@ -1757,6 +1772,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (sid && get().sessionStates[sid]) {
       updateSession(sid, (ss) => ({
         queuedMessages: removeQueuedMessage(ss.queuedMessages ?? [], clientMessageId),
+        // #5938 — also drop the optimistic bubble (its id IS the clientMessageId);
+        // a cancelled message was never sent, so it must not linger as a phantom
+        // "sent" bubble once the queued badge clears.
+        messages: ss.messages.filter((m) => m.id !== clientMessageId),
       }));
     }
     hapticLight();

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -168,10 +168,17 @@ import {
   RECONNECT_MAX_RUNG,
   // #5537 — shared LAN→tunnel fast-fallback decision for the reconnect ladder.
   selectReconnectEndpoint,
+  // #5938 (epic #5935 slice ③) — optimistic outgoing-queue helpers for the
+  // send-while-streaming path. The server is authoritative (it echoes
+  // message_queued / message_dequeued, reconciled by the shared dispatch
+  // table); these only seed/clear the local bubble so the queued state renders
+  // immediately without waiting on the round-trip.
+  enqueueOptimisticQueuedMessage,
+  removeQueuedMessage,
   type ProbeResult,
   type ConnectEndpoint,
 } from '@chroxy/store-core';
-import type { InputSettings } from '@chroxy/store-core';
+import type { InputSettings, QueuedSessionMessage } from '@chroxy/store-core';
 import { setCallback as setImperativeCallback, getCallback, clearAllCallbacks } from './imperative-callbacks';
 import { useMultiClientStore } from './multi-client';
 import { useWebStore } from './web';
@@ -343,6 +350,12 @@ export const selectLastResultDuration = (s: ConnectionState): number | null =>
   activeSession(s)?.lastResultDuration ?? null;
 export const selectIsIdle = (s: ConnectionState): boolean =>
   activeSession(s)?.isIdle ?? true;
+// #5938 — the active session's outgoing queue (messages sent mid-turn, awaiting
+// flush). Stable empty fallback so an idle/empty session keeps a referentially
+// constant value and never churns the selector.
+const EMPTY_QUEUED: QueuedSessionMessage[] = [];
+export const selectQueuedMessages = (s: ConnectionState): QueuedSessionMessage[] =>
+  activeSession(s)?.queuedMessages ?? EMPTY_QUEUED;
 
 // Search request tracking — prevents stale timeout/response races
 let searchNonce = 0;
@@ -1593,6 +1606,30 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       timestamp: Date.now(),
     };
 
+    // #5938 (epic #5935 slice ③) — send-while-streaming: the live turn already
+    // owns the thinking indicator + streamingMessageId, so a queued follow-up
+    // must NOT re-arm either (that would replace the in-flight turn's spinner
+    // and reset its stream id). Instead append the user bubble and seed an
+    // optimistic `'pending'` queue entry so it renders with a "Queued" badge
+    // immediately; the server's message_queued/message_dequeued (reconciled by
+    // the shared dispatch table) flips it to confirmed and clears it on flush.
+    // No safety-net timer either — the entry's lifecycle is the queue's, not a
+    // stream-stall window. Mirrors the dashboard's addUserMessage({ queued }).
+    if (opts?.queued) {
+      const activeId = get().activeSessionId;
+      if (activeId && get().sessionStates[activeId]) {
+        updateActiveSession((ss) => ({
+          messages: [...ss.messages, userMsg],
+          queuedMessages: enqueueOptimisticQueuedMessage(ss.queuedMessages ?? [], {
+            clientMessageId: userMsg.id,
+            text,
+            queuedAt: Date.now(),
+          }),
+        }));
+      }
+      return;
+    }
+
     // #5633: capture the session this optimistic turn belongs to AT ARM TIME.
     // The old safety net re-read `get().activeSessionId` when the timer FIRED,
     // so switching sessions (or a legitimately slow stream_start on cellular)
@@ -1702,6 +1739,29 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       return 'sent';
     }
     return enqueueMessage('interrupt', payload);
+  },
+
+  // #5938 (#5943) — cancel one still-queued follow-up before it flushes. Unlike
+  // sendInput, this is NOT queued offline: the server EXPIRES the outgoing queue
+  // when the socket drops, so a buffered cancel would drain into the void on
+  // reconnect. Refuse it while disconnected and optimistically drop the local
+  // bubble; the server's message_dequeued { reason: 'cancelled' } is idempotent
+  // with the removal (handled by the shared dispatch table). Mirrors the
+  // dashboard's sendCancelQueued.
+  sendCancelQueued: (clientMessageId: string, sessionId?: string) => {
+    const { socket, activeSessionId } = get();
+    const sid = sessionId ?? activeSessionId;
+    if (!(socket && socket.readyState === WebSocket.OPEN)) return false;
+    const payload: Record<string, unknown> = { type: 'cancel_queued', clientMessageId };
+    if (sid) payload.sessionId = sid;
+    if (sid && get().sessionStates[sid]) {
+      updateSession(sid, (ss) => ({
+        queuedMessages: removeQueuedMessage(ss.queuedMessages ?? [], clientMessageId),
+      }));
+    }
+    hapticLight();
+    wsSend(socket, payload);
+    return 'sent';
   },
 
   sendPermissionResponse: (requestId: string, decision: string) => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2413,9 +2413,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             // Reuse existing response message (reconnect replay dedup)
             return { streamingMessageId: out.streamingMessageId };
           }
+          // #5938 — insert the new assistant message BEFORE any trailing queued
+          // follow-up bubbles. A message queued during the pending window (before
+          // this stream_start) was appended at the end; without this it would sit
+          // ABOVE the response it precedes (wrong chronology) and stay there after
+          // flush. Queue-aware only: with no queued bubbles the index is the array
+          // end, so the result is byte-identical to the plain append.
+          const base = filterThinking(ss.messages);
+          const queuedIdSet = new Set(
+            (ss.queuedMessages ?? [])
+              .map((q) => q.clientMessageId)
+              .filter((id): id is string => !!id),
+          );
+          let insertAt = base.length;
+          while (insertAt > 0 && queuedIdSet.has(base[insertAt - 1].id)) insertAt--;
           return {
             streamingMessageId: out.streamingMessageId,
-            messages: [...filterThinking(ss.messages), out.newMessage!],
+            messages: [...base.slice(0, insertAt), out.newMessage!, ...base.slice(insertAt)],
           };
         });
       }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -467,9 +467,16 @@ export interface MultiClientSessionActions {
  */
 export interface MessageInputActions {
   addMessage: (message: ChatMessage) => void;
-  addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string }) => void;
+  // #5938 — `queued: true` records the bubble as a send-while-streaming
+  // follow-up: append it WITHOUT re-arming the thinking indicator / stream id
+  // and seed an optimistic `queuedMessages` entry (rendered with a "Queued"
+  // badge) instead of starting a fresh turn.
+  addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
   sendInput: (input: string, wireAttachments?: { type: string; mediaType: string; data: string; name: string }[], options?: { isVoice?: boolean; clientMessageId?: string }) => 'sent' | 'queued' | false;
   sendInterrupt: () => 'sent' | 'queued' | false;
+  // #5938 (#5943) — cancel one queued follow-up by its clientMessageId before
+  // it flushes. Returns false (refused) while disconnected; never offline-queued.
+  sendCancelQueued: (clientMessageId: string, sessionId?: string) => 'sent' | false;
   sendPermissionResponse: (requestId: string, decision: string) => 'sent' | 'queued' | false;
   /**
    * Send a `user_question_response` answer to the server.


### PR DESCRIPTION
## Summary

Closes #5938 (epic #5935 slice ③ — queue-while-processing on mobile).

Today the mobile composer **hard-gates** sending during a streaming turn: the Stop button replaces Send and Enter-to-send is disabled, so a user can't queue a follow-up. This un-gates it — a mid-turn send now **queues** (rendered distinctly with a "Queued" badge) and the server flushes it FIFO when the current turn completes. Mirrors the dashboard's #5939 pattern.

## What changed

- **InputBar** (`packages/app/src/components/InputBar.tsx`)
  - Enter-to-send stays wired while streaming (`onSubmitEditing` no longer gated on `!isStreaming`).
  - During a turn, **both** controls render: **Stop** interrupts the live turn, **Send** (label flips to "Queue message") queues a follow-up. When idle, only Send renders.
- **SessionScreen** (`screens/SessionScreen.tsx`)
  - Drop the `streamingMessageId` early-return in the send handler; capture `busy` at send time and route a mid-turn send through `addUserMessage({ queued })`.
  - Derive per-session `queuedIds` from the store's `queuedMessages` (not ChatView-local state, so it survives the session-switch re-render) and pass a cancel handler to ChatView.
- **store** (`store/connection.ts`, `store/types.ts`)
  - `addUserMessage({ queued })` appends the user bubble + seeds an optimistic `'pending'` queue entry **without** re-arming the live turn's thinking indicator / stream id.
  - New `sendCancelQueued(clientMessageId)` action — sends `cancel_queued` + optimistically drops the entry; **refused** (returns `false`, no mutation) while disconnected.
- **ChatView / MessageBubble** — render a "Queued" badge + **Cancel** on queued user bubbles; `queued` added to the `MessageBubble` memo comparator.

## Design notes

- **Server-authoritative.** The client only seeds/clears the optimistic bubble; reconciliation against the server's `message_queued` / `message_dequeued` is already wired app-side by the **shared store-core dispatch table** (`dispatch-table.ts` — slices ①/②), so this PR is the UI slice only.
- **Stop vs queue.** Stop interrupts the whole turn; the server emits `message_dequeued { reason: 'interrupted' }` for queued items, which the dispatch table clears — so **Stop clears the queue** (server-side, no extra client code).

## Tests

- `src/__tests__/store/connection-queued-messages.test.ts` — optimistic enqueue (no live-turn re-arm), dedup by `clientMessageId`, cancel send/refuse, non-queued regression guard.
- `src/components/__tests__/InputBar.imperative.test.tsx` — Send+Stop both present while streaming; Send enabled + label="Queue message"; Enter-to-send wired mid-turn.
- Full app suite green: **2015 passed**. App typecheck clean.

## Follow-up

On-device **Maestro** flow for the full send-while-streaming → queued → flush path needs a mock-server delayed-stream + `message_queued`/`message_dequeued` trigger (test-infra addition, best verified live on a simulator). Filing as a follow-up; acceptance here is covered by the store + component tests.