### PR TITLE
fix(app): match dashboard busy-detection for queued sends (#6113)

### DIFF
--- a/packages/app/src/__tests__/screens/SessionScreenBusyParity.test.ts
+++ b/packages/app/src/__tests__/screens/SessionScreenBusyParity.test.ts
@@ -1,0 +1,39 @@
+/**
+ * #6113 — mobile send-while-busy detection must match the dashboard's #5952
+ * condition: a send queues when a turn is in flight, where "in flight" is
+ * `streamingMessageId !== null` OR `isIdle === false`. The `isIdle` half covers
+ * the window after `agent_busy` but before `stream_start` (or a tool-only turn
+ * that never streams text) — without it a send in that window force-sends on
+ * mobile while the dashboard queues.
+ *
+ * Following this repo's SessionScreen-testing convention (no
+ * @testing-library/react-native — see SessionScreenQueuedCountBanner.test.ts),
+ * the wire-up is verified by source-text parsing; the queued-path RUNTIME effect
+ * (addUserMessage({ queued }) → optimistic queue entry, no live-turn re-arm) is
+ * exercised against the real store in
+ * __tests__/store/connection-queued-messages.test.ts.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SessionScreenSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SessionScreen.tsx'),
+  'utf-8',
+);
+
+describe('SessionScreen send-while-busy parity (#6113 / #5952)', () => {
+  it('subscribes to isIdle from the store', () => {
+    expect(SessionScreenSrc).toMatch(/const isIdle = useConnectionStore\(selectIsIdle\)/);
+  });
+
+  it('computes busy as streamingMessageId OR not-idle (dashboard #5952 parity)', () => {
+    // Must include the !isIdle half — `const busy = !!streamingMessageId;` alone
+    // would regress to the narrower pre-#6113 condition.
+    expect(SessionScreenSrc).toMatch(/const busy = !!streamingMessageId \|\| !isIdle;/);
+  });
+
+  it('routes the send through addUserMessage with the queued flag', () => {
+    expect(SessionScreenSrc).toMatch(/addUserMessage\(/);
+    expect(SessionScreenSrc).toMatch(/\{ clientMessageId, queued: busy \}/);
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -721,7 +721,13 @@ export function SessionScreen() {
     // out: it queues (the bubble renders with a "Queued" badge and the server
     // flushes it when the current turn completes) rather than starting a fresh
     // turn. `busy` drives addUserMessage's optimistic-enqueue path below.
-    const busy = !!streamingMessageId;
+    // #6113 — match the dashboard's #5952 condition: `isIdle === false` covers
+    // the window after `agent_busy` but before `stream_start` (or a tool-only
+    // turn that never streams text), where the server is processing but
+    // streamingMessageId is still null. Without it a send in that window would
+    // force-send on mobile while the dashboard queues. isIdle defaults to true,
+    // so a genuinely idle send still starts a fresh turn (no false-queue).
+    const busy = !!streamingMessageId || !isIdle;
     // Expand any collapsed-paste markers back to their original content
     // before send (#3797). Trim happens AFTER expansion so an expanded
     // payload with surrounding whitespace still sends cleanly.


### PR DESCRIPTION
## Summary

Closes #6113 (follow-up from #6111 / #5938). Brings mobile's send-while-busy detection to parity with the dashboard's #5952.

Mobile computed `busy = !!streamingMessageId`. The dashboard's #5952 uses `streamingMessageId !== null || isIdle === false`. The `isIdle === false` half covers the window **after `agent_busy` but before `stream_start`** (or a tool-only turn that never streams text), where the server is processing but `streamingMessageId` is still null. Without it, a send in that window **force-sent on mobile while the dashboard queued** — a cross-client behavior gap.

## Change

`packages/app/src/screens/SessionScreen.tsx` — one line in the send handler:

```diff
-    const busy = !!streamingMessageId;
+    const busy = !!streamingMessageId || !isIdle;
```

`isIdle` is already subscribed via `selectIsIdle`. It defaults to `true` (`createEmptySessionState`), is set `false` by `agent_busy` and back to `true` by `result`/session-config — so a genuinely idle send still starts a fresh turn (no false-queue).

## Tests

- `src/__tests__/screens/SessionScreenBusyParity.test.ts` — source-parse regression guard for the parity condition (repo convention: SessionScreen has no RTL render harness — see `SessionScreenQueuedCountBanner.test.ts`; the queued-path **runtime** effect is exercised against the real store in `connection-queued-messages.test.ts`).
- Full app suite green: **2023 passed**. Typecheck clean.