### PR TITLE
fix(app): show Stop + queue affordance during the busy-pre-stream window (#6116)

### DIFF
--- a/packages/app/__tests__/ComponentRendering.test.ts
+++ b/packages/app/__tests__/ComponentRendering.test.ts
@@ -58,9 +58,9 @@ describe('InputBar component', () => {
 
   test('has send button with accessibilityRole and accessibilityLabel', () => {
     expect(inputBarSrc).toMatch(/accessibilityRole="button"/)
-    // #5938 — the Send label is now dynamic: 'Queue message' mid-turn (the
-    // send-while-streaming un-gate), 'Send message' when idle.
-    expect(inputBarSrc).toMatch(/accessibilityLabel=\{isStreaming \? 'Queue message' : 'Send message'\}/)
+    // #5938/#6116 — the Send label is dynamic: 'Queue message' during an active
+    // turn (streaming OR busy pre-stream, via turnActive), 'Send message' when idle.
+    expect(inputBarSrc).toMatch(/accessibilityLabel=\{turnActive \? 'Queue message' : 'Send message'\}/)
   })
 
   test('has interrupt button with accessibility label', () => {

--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -59,6 +59,15 @@ export interface InputBarProps {
   enterToSend: boolean;
   onToggleEnterMode: () => void;
   isStreaming: boolean;
+  /**
+   * #6116 — `isBusy` (= the active session's `isIdle === false`) covers the
+   * window after `agent_busy` but before `stream_start`, where the server is
+   * processing but no text is streaming yet. A send during this window queues
+   * (#6113), so the composer must show the same Stop + "Queue message"
+   * affordance it shows while streaming — `isStreaming || isBusy` is the
+   * "turn active" gate, matching the dashboard.
+   */
+  isBusy?: boolean;
   claudeReady: boolean;
   viewMode: 'chat' | 'terminal' | 'files' | 'system';
   hasTerminal: boolean;
@@ -93,6 +102,7 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
   enterToSend,
   onToggleEnterMode,
   isStreaming,
+  isBusy = false,
   claudeReady,
   viewMode,
   hasTerminal,
@@ -112,6 +122,10 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
   onRemovePastedText,
 }, ref) {
   const a11yDisabled = disabled ? { disabled: true as const } : undefined;
+  // #6116 — a turn is "active" while streaming OR while the server is busy
+  // pre-stream (isBusy). Both states queue a send (#6113), so both show the
+  // Stop button + "Queue message" affordance + follow-up placeholder.
+  const turnActive = isStreaming || isBusy;
 
   // #5556 — InputBar owns the composer draft internally so that streaming
   // re-renders in SessionScreen don't re-render the TextInput on every delta.
@@ -324,7 +338,7 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
         <TextInput
           ref={textInputRef}
           style={[styles.input, !enterToSend && styles.inputMultiline, disabled && styles.inputDisabled]}
-          placeholder={disabled ? (disabledPlaceholder || 'Reconnecting...') : !claudeReady ? 'Connecting to Claude...' : 'Message Claude...'}
+          placeholder={disabled ? (disabledPlaceholder || 'Reconnecting...') : !claudeReady ? 'Connecting to Claude...' : turnActive ? 'Type to send follow-up…' : 'Message Claude...'}
           placeholderTextColor={COLORS.textDim}
           value={value}
           onChangeText={handleChangeText}
@@ -389,10 +403,10 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
             </Animated.View>
           </TouchableOpacity>
         )}
-        {/* #5938 — during a turn, BOTH controls show: Stop interrupts the live
-            turn, Send queues a follow-up that flushes when the turn completes.
-            When idle, only Send renders. */}
-        {isStreaming && (
+        {/* #5938/#6116 — during an active turn (streaming OR busy pre-stream),
+            BOTH controls show: Stop interrupts the turn, Send queues a follow-up
+            that flushes when the turn completes. When idle, only Send renders. */}
+        {turnActive && (
           <TouchableOpacity
             style={[styles.interruptButton, disabled && styles.interruptButtonDisabled]}
             onPress={onInterrupt}
@@ -410,7 +424,7 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
           onPress={onSend}
           disabled={disabled}
           accessibilityRole="button"
-          accessibilityLabel={isStreaming ? 'Queue message' : 'Send message'}
+          accessibilityLabel={turnActive ? 'Queue message' : 'Send message'}
           accessibilityState={a11yDisabled}
           testID="chat-send-button"
         >

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -207,4 +207,31 @@ describe('InputBar send-while-streaming un-gate (#5938)', () => {
     act(() => { input.props.onSubmitEditing(); });
     expect(onSend).toHaveBeenCalledTimes(1);
   });
+
+  // #6116 — the agent_busy-but-not-streaming window (isBusy && !isStreaming):
+  // the send queues (#6113), so the busy affordance must show even though no
+  // text is streaming yet.
+  it('shows Stop + "Queue message" + follow-up placeholder when busy pre-stream', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} isStreaming={false} isBusy={true} onChangeText={noop} />,
+      );
+    });
+    expect(present(tree, 'chat-stop-button')).toBe(true);
+    const send = tree.root.findByProps({ testID: 'chat-send-button' });
+    expect(send.props.accessibilityLabel).toBe('Queue message');
+    expect(getTextInput(tree).props.placeholder).toBe('Type to send follow-up…');
+  });
+
+  it('idle (not streaming, not busy) shows neither Stop nor the queue label', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} isStreaming={false} isBusy={false} onChangeText={noop} />,
+      );
+    });
+    expect(present(tree, 'chat-stop-button')).toBe(false);
+    expect(tree.root.findByProps({ testID: 'chat-send-button' }).props.accessibilityLabel).toBe('Send message');
+  });
 });

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -1680,6 +1680,7 @@ export function SessionScreen() {
         enterToSend={enterToSend}
         onToggleEnterMode={handleToggleEnterMode}
         isStreaming={!!streamingMessageId}
+        isBusy={!isIdle}
         claudeReady={claudeReady}
         viewMode={viewMode}
         hasTerminal={hasTerminal}


### PR DESCRIPTION
## Summary

Closes #6116 (follow-up from #6115 / #6113). Completes the queued-send parity: #6113 fixed the send *logic* (a mid-turn send queues when `isIdle === false` even before `stream_start`); this brings the **InputBar UI** to match.

During the `isIdle === false && streamingMessageId === null` window (after `agent_busy`, before `stream_start`, or a tool-only turn), mobile previously showed **no Stop button** and a "Send message" label even though the send would queue. Now it shows the same affordance it shows while streaming.

## Change

- `InputBar.tsx` — new `isBusy?: boolean` prop; `turnActive = isStreaming || isBusy` gates the Stop button, the `'Queue message'` send label, and a `'Type to send follow-up…'` placeholder. (InputBar uses default shallow `React.memo`, so the new prop is compared automatically.)
- `SessionScreen.tsx` — passes `isBusy={!isIdle}`.

Idle is unchanged: only Send, `'Send message'`, `'Message Claude…'`.

## Tests

- `InputBar.imperative.test.tsx` — busy-pre-stream shows Stop + `'Queue message'` + follow-up placeholder; idle-negative shows neither.
- `ComponentRendering.test.ts` — source-parse updated to the `turnActive` label.
- Full app suite green: **2025 passed**. Typecheck clean.