### PR TITLE
test(server): re-recurse on ENOTEMPTY in temp-git-repo teardown (#6114)

### DIFF
--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { CheckpointManager } from '../src/checkpoint-manager.js'
-import { GIT, disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { GIT, disableRepoAutoGc, rmDirRobust } from './test-helpers.js'
 
 // Create a temporary git repo for testing
 function createTempGitRepo() {
@@ -37,8 +37,8 @@ describe('CheckpointManager', () => {
   })
 
   afterEach(() => {
-    rmSync(gitDir, RM_RETRY)
-    try { rmSync(tmpCheckpointsDir, RM_RETRY) } catch {}
+    rmDirRobust(gitDir)
+    try { rmDirRobust(tmpCheckpointsDir) } catch {}
   })
 
   it('creates a checkpoint with metadata', async () => {

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -14,7 +14,7 @@ import { execFileSync } from 'child_process'
 import { EventEmitter } from 'events'
 import { SessionManager, WorktreeError } from '../src/session-manager.js'
 import { GIT } from '../src/git.js'
-import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { disableRepoAutoGc, rmDirRobust } from './test-helpers.js'
 
 // ---------------------------------------------------------------------------
 // Register a no-op stub provider (avoids importing real SDK/CLI sessions)
@@ -113,7 +113,7 @@ describe('SessionManager worktree isolation', () => {
   })
 
   afterEach(() => {
-    rmSync(gitRepo, RM_RETRY)
+    rmDirRobust(gitRepo)
   })
 
   it('creates a worktree directory when worktree:true is passed', () => {
@@ -404,7 +404,7 @@ describe('SessionManager _removeWorktree fallback (#2460)', () => {
   })
 
   afterEach(() => {
-    rmSync(gitRepo, RM_RETRY)
+    rmDirRobust(gitRepo)
     rmSync(externalWorktreeBase, { recursive: true, force: true })
   })
 
@@ -481,7 +481,7 @@ describe('SessionManager isolation derivation (#2475)', () => {
   })
 
   afterEach(() => {
-    rmSync(gitRepo, RM_RETRY)
+    rmDirRobust(gitRepo)
   })
 
   it('default session has isolation "none"', () => {

--- a/packages/server/tests/test-helpers-rmdir.test.js
+++ b/packages/server/tests/test-helpers-rmdir.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmDirRobust } from './test-helpers.js'
+
+/**
+ * #6114 — rmDirRobust re-recurses on the transient gc-race teardown codes so a
+ * loose object git background gc writes AFTER the recursive walk passed its
+ * subtree (the failure mode plain `rmSync(RM_RETRY)` can't recover, because its
+ * internal retry only re-attempts the failing rmdir, never re-walks) is cleared
+ * on the next pass.
+ *
+ * The race itself only reproduces under load on the self-hosted Linux runner, so
+ * the re-recurse LOGIC is covered deterministically here via the `_rm` / `_sleep`
+ * injection seams; a real-filesystem happy-path test proves it actually removes a
+ * populated tree.
+ */
+describe('rmDirRobust (#6114)', () => {
+  it('removes a populated directory tree on the real filesystem (happy path)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-rmdir-'))
+    mkdirSync(join(dir, 'a', 'b'), { recursive: true })
+    writeFileSync(join(dir, 'a', 'b', 'f.txt'), 'x')
+    writeFileSync(join(dir, 'top.txt'), 'y')
+    rmDirRobust(dir)
+    assert.equal(existsSync(dir), false)
+  })
+
+  it('re-recurses after a transient ENOTEMPTY, then succeeds (the gc-race fix)', () => {
+    let calls = 0
+    let slept = 0
+    // Fail the first two attempts with ENOTEMPTY (gc re-created an object), then
+    // succeed — exactly the dropped-flush-then-settled pattern.
+    const _rm = () => {
+      calls++
+      if (calls <= 2) {
+        const err = new Error("ENOTEMPTY: directory not empty, rmdir '/tmp/x/.git'")
+        err.code = 'ENOTEMPTY'
+        throw err
+      }
+    }
+    rmDirRobust('/tmp/x', { _rm, _sleep: () => { slept++ } })
+    assert.equal(calls, 3, 'should re-walk until the rm succeeds')
+    assert.equal(slept, 2, 'should back off once per failed attempt')
+  })
+
+  it('surfaces a non-transient error immediately (no re-recurse on EACCES)', () => {
+    let calls = 0
+    const _rm = () => {
+      calls++
+      const err = new Error("EACCES: permission denied, rmdir '/tmp/locked'")
+      err.code = 'EACCES'
+      throw err
+    }
+    assert.throws(() => rmDirRobust('/tmp/locked', { _rm, _sleep: () => {} }), /EACCES/)
+    assert.equal(calls, 1, 'a genuine error must not trigger the retry loop')
+  })
+
+  it('gives up (throws) after `attempts` persistent transient failures', () => {
+    let calls = 0
+    const _rm = () => {
+      calls++
+      const err = new Error('ENOTEMPTY: directory not empty')
+      err.code = 'ENOTEMPTY'
+      throw err
+    }
+    assert.throws(() => rmDirRobust('/tmp/busy', { attempts: 4, _rm, _sleep: () => {} }), /ENOTEMPTY/)
+    assert.equal(calls, 4, 'should attempt exactly `attempts` times, then surface the failure')
+  })
+})

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { execFileSync } from 'node:child_process'
+import { rmSync } from 'node:fs'
 import { WsClientManager } from '../src/ws-client-manager.js'
 import { CTX_NAMESPACES, CTX_NAMESPACE_NAMES, assertCtxShape } from '../src/ws-handler-context.js'
 import { GIT as _GIT } from '../src/git.js'
@@ -38,6 +39,46 @@ export function disableRepoAutoGc(dir) {
 // load peak. The common case still succeeds on the first try with zero added
 // delay (rmSync only sleeps when a retry is actually needed).
 export const RM_RETRY = Object.freeze({ recursive: true, force: true, maxRetries: 20, retryDelay: 50 })
+
+// Synchronous sleep (no busy-spin) for the re-recurse backoff below. Atomics.wait
+// on a throwaway SharedArrayBuffer blocks the thread for `ms` without burning CPU.
+function sleepSync(ms) {
+  if (!(ms > 0)) return
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+// #6114: robustly remove a temp dir that git background gc may still be writing
+// into during teardown. `rmSync(dir, RM_RETRY)` retries the FAILING operation —
+// but the gc-race failure mode is a NEW loose object written into an
+// already-emptied `.git/objects/…` subtree AFTER the recursive walk passed it.
+// The final `rmdir '.git'` then throws ENOTEMPTY, and rmSync's internal retry
+// only re-attempts that same rmdir (the new file is never re-walked), so the
+// 10.5s RM_RETRY budget can still be exceeded (seen on a required check, #6114).
+// Re-running the WHOLE recursive remove RE-WALKS and clears the recreated object.
+//
+// Each outer attempt carries RM_RETRY's own per-op backoff; between attempts we
+// pause briefly to let gc settle before re-walking. Only the transient teardown
+// codes trigger a re-recurse — a real error (e.g. EACCES on a chmod-locked path)
+// surfaces immediately. `force: true` means a missing dir is a no-op (no ENOENT).
+// The common case still succeeds on the first rmSync with zero added delay.
+const RM_TRANSIENT_CODES = new Set(['ENOTEMPTY', 'EBUSY', 'ENOTDIR', 'EPERM'])
+// `_rm` / `_sleep` are injection seams for the unit test (deterministic
+// re-recurse coverage without needing the actual gc race); production callers
+// pass neither and get the real fs/sleep.
+export function rmDirRobust(dir, { attempts = 5, backoffMs = 50, _rm = rmSync, _sleep = sleepSync } = {}) {
+  for (let i = 0; i < attempts - 1; i++) {
+    try {
+      _rm(dir, RM_RETRY)
+      return
+    } catch (err) {
+      if (!RM_TRANSIENT_CODES.has(err?.code)) throw err
+      _sleep(backoffMs * (i + 1))
+    }
+  }
+  // Final attempt: let a persistent failure throw so a genuine teardown bug
+  // (not a transient gc-race) still fails the test loudly.
+  _rm(dir, RM_RETRY)
+}
 
 // Re-export the ctx-shape assert so handler tests can guard their mocks.
 export { assertCtxShape } from '../src/ws-handler-context.js'

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -15,7 +15,7 @@ import { basename, join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { GIT } from '../src/git.js'
-import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { disableRepoAutoGc, rmDirRobust } from './test-helpers.js'
 import {
   isPidAlive,
   parsePid,
@@ -143,7 +143,7 @@ describe('worktree-gc integration (real git repo)', () => {
   })
 
   afterEach(() => {
-    rmSync(repo, RM_RETRY)
+    rmDirRobust(repo)
   })
 
   it('plans: reclaim clean+dead-pid, skip dirty/live/no-pid/unlocked, prune dir-gone', () => {
@@ -431,7 +431,7 @@ describe('worktree-gc CLI (runWorktreeGc against a real repo)', () => {
     git(repo, ['worktree', 'lock', '--reason', `claude agent a2 (pid ${DEAD_PID})`, dirtyDead])
   })
 
-  afterEach(() => rmSync(repo, RM_RETRY))
+  afterEach(() => rmDirRobust(repo))
 
   it('dry-run (default) reports reclaimable and deletes nothing', async () => {
     const { runWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
@@ -502,7 +502,7 @@ describe('worktree-gc CLI (config controlRoomRoot auto-discovery, #5221)', () =>
     git(repo, ['worktree', 'lock', '--reason', `claude agent a1 (pid ${DEAD_PID})`, cleanDead])
   })
 
-  afterEach(() => rmSync(root, RM_RETRY))
+  afterEach(() => rmDirRobust(root))
 
   it('discovers repos under config.controlRoomRoot when no --repo is given', async () => {
     const { collectWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
@@ -567,7 +567,7 @@ describe('sweepOrphanChroxyWorktrees (real git repo)', () => {
   })
 
   afterEach(() => {
-    rmSync(repo, RM_RETRY)
+    rmDirRobust(repo)
     rmSync(base, { recursive: true, force: true })
   })
 

--- a/packages/server/tests/worktree-reaper.test.js
+++ b/packages/server/tests/worktree-reaper.test.js
@@ -13,7 +13,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { GIT } from '../src/git.js'
-import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { disableRepoAutoGc, rmDirRobust } from './test-helpers.js'
 import { reapWorktrees, maybeAutoReapWorktrees, startPeriodicAutoReap } from '../src/worktree-reaper.js'
 
 const LIVE_PID = 4100002
@@ -60,7 +60,7 @@ describe('worktree-reaper', () => {
     git(repo, ['worktree', 'lock', '--reason', `claude agent a3 (pid ${LIVE_PID})`, live])
   })
 
-  afterEach(() => rmSync(root, RM_RETRY))
+  afterEach(() => rmDirRobust(root))
 
   it('reapWorktrees reclaims clean+dead, preserves dirty + live', async () => {
     const summary = await reapWorktrees({ repos: [{ name: 'proj', path: repo }], planDeps, yieldFn })

--- a/packages/server/tests/worktree-reaper.test.js
+++ b/packages/server/tests/worktree-reaper.test.js
@@ -8,7 +8,7 @@
  */
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from 'fs'
+import { mkdtempSync, existsSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'


### PR DESCRIPTION
## Summary

Closes #6114. Kills the recurring `ENOTEMPTY: rmdir '<dir>/.git'` teardown flake on the self-hosted Linux runner (hit a required check **twice** during this session's PRs, each needing a re-run).

## Root cause (newly pinned)

The flake recurs **even with** the existing hardening — `disableRepoAutoGc(dir)` + `rmSync(dir, RM_RETRY)` (20 retries / ~10.5s). `rmSync`'s internal retry re-attempts the **failing operation** (the `rmdir '.git'`). But the failure mode is git background gc writing a **new** loose object into an already-emptied `.git/objects/…` subtree **after** the recursive walk passed it. Re-attempting the `rmdir` alone never re-walks, so the new file is never removed — the retry budget is exhausted on a `rmdir` that can't succeed. The fix needs a full **re-walk**.

## Change

- `test-helpers.js` — new `rmDirRobust(dir)`: an outer loop that re-runs the whole recursive `rmSync(RM_RETRY)` on the transient teardown codes (`ENOTEMPTY`/`EBUSY`/`ENOTDIR`/`EPERM`), re-walking to clear any gc-recreated object, with a short synchronous backoff (`Atomics.wait`) between attempts. Non-transient errors (e.g. `EACCES`) surface immediately; a persistent failure still throws after the attempt budget. The common case succeeds on the first `rmSync` with zero added delay.
- Swapped the temp-git-repo teardowns to `rmDirRobust`: `checkpoint-manager`, `session-manager-worktree` (×3), `worktree-gc` (×4), `worktree-reaper`.

## Tests

- `test-helpers-rmdir.test.js` — deterministic re-recurse coverage via `_rm`/`_sleep` injection seams (the race only reproduces under load on the Linux runner): re-recurse-then-succeed, non-transient surfaces immediately, gives up after N, plus a **real-filesystem** happy-path remove of a populated tree.
- Targeted runs green locally: `test-helpers-rmdir` + the 4 swapped files (**97 tests**). Custom server lints pass (the one local `lint-ws-index-mutations` failure is a pre-existing, gitignored `dashboard-next/dist` false positive — fails on clean main too, CI never sees it).

## Verification note

The race is load-dependent on the self-hosted Linux runner, so it can't be reproduced locally on macOS. The re-recurse **logic** is proven deterministically (injection-seam tests); the actual flake elimination is validated by this PR's own **Server Tests** run on the Linux runner and subsequent green runs.