### PR TITLE
test(server): apply rmDirRobust to remaining temp-git-repo teardowns (#6120)

### DIFF
--- a/packages/server/tests/git-ops.test.js
+++ b/packages/server/tests/git-ops.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { createFileOps } from '../src/ws-file-ops/index.js'
 import { GIT } from '../src/git.js'
-import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { disableRepoAutoGc, rmDirRobustAsync } from './test-helpers.js'
 
 describe('git status handler', () => {
   let tmpDir
@@ -31,7 +31,7 @@ describe('git status handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, RM_RETRY)
+    await rmDirRobustAsync(tmpDir)
   })
 
   it('returns current branch and clean status', async () => {
@@ -127,7 +127,7 @@ describe('git branches handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, RM_RETRY)
+    await rmDirRobustAsync(tmpDir)
   })
 
   it('lists local branches with current branch marked', async () => {

--- a/packages/server/tests/git-stage-commit.test.js
+++ b/packages/server/tests/git-stage-commit.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { createFileOps } from '../src/ws-file-ops/index.js'
 import { GIT } from '../src/git.js'
-import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { disableRepoAutoGc, rmDirRobustAsync } from './test-helpers.js'
 
 describe('git stage handler', () => {
   let tmpDir
@@ -28,7 +28,7 @@ describe('git stage handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, RM_RETRY)
+    await rmDirRobustAsync(tmpDir)
   })
 
   it('stages specified files', async () => {
@@ -87,7 +87,7 @@ describe('git unstage handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, RM_RETRY)
+    await rmDirRobustAsync(tmpDir)
   })
 
   it('unstages specified files', async () => {
@@ -139,7 +139,7 @@ describe('git commit handler', () => {
   })
 
   after(async () => {
-    await rm(tmpDir, RM_RETRY)
+    await rmDirRobustAsync(tmpDir)
   })
 
   it('creates a commit with staged changes', async () => {

--- a/packages/server/tests/session-context.test.js
+++ b/packages/server/tests/session-context.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { execFileSync } from 'child_process'
 import { readSessionContext } from '../src/session-context.js'
-import { GIT, disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { GIT, disableRepoAutoGc, rmDirRobustAsync } from './test-helpers.js'
 
 describe('readSessionContext', () => {
   let gitDir   // temp dir with git init + commit
@@ -27,8 +27,8 @@ describe('readSessionContext', () => {
   })
 
   after(async () => {
-    await rm(gitDir, RM_RETRY)
-    await rm(plainDir, RM_RETRY)
+    await rmDirRobustAsync(gitDir)
+    await rmDirRobustAsync(plainDir)
   })
 
   it('returns git branch for a git repository', async () => {

--- a/packages/server/tests/supervisor-rollback-a9.test.js
+++ b/packages/server/tests/supervisor-rollback-a9.test.js
@@ -1,11 +1,11 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { Supervisor } from '../src/supervisor.js'
-import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { disableRepoAutoGc, rmDirRobust } from './test-helpers.js'
 
 /**
  * Adversary A9 (2026-04-11 audit) — known-good-ref poisoning via
@@ -81,7 +81,7 @@ describe('Supervisor._rollbackToKnownGood — Adversary A9', () => {
 
   after(() => {
     try { process.chdir(originalCwd) } catch {}
-    try { rmSync(tmpDir, RM_RETRY) } catch {}
+    try { rmDirRobust(tmpDir) } catch {}
   })
 
   it('accepts a ref that matches a known-good-* tag', () => {

--- a/packages/server/tests/test-helpers-rmdir.test.js
+++ b/packages/server/tests/test-helpers-rmdir.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { rmDirRobust } from './test-helpers.js'
+import { rmDirRobust, rmDirRobustAsync } from './test-helpers.js'
 
 /**
  * #6114 — rmDirRobust re-recurses on the transient gc-race teardown codes so a
@@ -67,5 +67,55 @@ describe('rmDirRobust (#6114)', () => {
     }
     assert.throws(() => rmDirRobust('/tmp/busy', { attempts: 4, _rm, _sleep: () => {} }), /ENOTEMPTY/)
     assert.equal(calls, 4, 'should attempt exactly `attempts` times, then surface the failure')
+  })
+})
+
+describe('rmDirRobustAsync (#6120)', () => {
+  it('removes a populated directory tree on the real filesystem (happy path)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-rmdir-async-'))
+    mkdirSync(join(dir, 'a', 'b'), { recursive: true })
+    writeFileSync(join(dir, 'a', 'b', 'f.txt'), 'x')
+    await rmDirRobustAsync(dir)
+    assert.equal(existsSync(dir), false)
+  })
+
+  it('re-recurses after a transient ENOTEMPTY, then succeeds', async () => {
+    let calls = 0
+    let slept = 0
+    const _rm = async () => {
+      calls++
+      if (calls <= 2) {
+        const err = new Error("ENOTEMPTY: directory not empty, rmdir '/tmp/x/.git'")
+        err.code = 'ENOTEMPTY'
+        throw err
+      }
+    }
+    await rmDirRobustAsync('/tmp/x', { _rm, _sleep: async () => { slept++ } })
+    assert.equal(calls, 3)
+    assert.equal(slept, 2)
+  })
+
+  it('surfaces a non-transient error immediately (no re-recurse)', async () => {
+    let calls = 0
+    const _rm = async () => {
+      calls++
+      const err = new Error('EACCES: permission denied')
+      err.code = 'EACCES'
+      throw err
+    }
+    await assert.rejects(() => rmDirRobustAsync('/tmp/locked', { _rm, _sleep: async () => {} }), /EACCES/)
+    assert.equal(calls, 1)
+  })
+
+  it('gives up (rejects) after `attempts` persistent transient failures', async () => {
+    let calls = 0
+    const _rm = async () => {
+      calls++
+      const err = new Error('EBUSY')
+      err.code = 'EBUSY'
+      throw err
+    }
+    await assert.rejects(() => rmDirRobustAsync('/tmp/busy', { attempts: 3, _rm, _sleep: async () => {} }), /EBUSY/)
+    assert.equal(calls, 3)
   })
 })

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { execFileSync } from 'node:child_process'
 import { rmSync } from 'node:fs'
+import { rm as rmAsync } from 'node:fs/promises'
 import { WsClientManager } from '../src/ws-client-manager.js'
 import { CTX_NAMESPACES, CTX_NAMESPACE_NAMES, assertCtxShape } from '../src/ws-handler-context.js'
 import { GIT as _GIT } from '../src/git.js'
@@ -78,6 +79,26 @@ export function rmDirRobust(dir, { attempts = 5, backoffMs = 50, _rm = rmSync, _
   // Final attempt: let a persistent failure throw so a genuine teardown bug
   // (not a transient gc-race) still fails the test loudly.
   _rm(dir, RM_RETRY)
+}
+
+// Async counterpart of rmDirRobust for teardowns that `await rm(dir, RM_RETRY)`
+// (node:fs/promises). Same re-recurse-on-transient-code semantics; the backoff
+// is a real awaited timer rather than a blocking Atomics.wait. `_rm` / `_sleep`
+// are injection seams for the unit test.
+export async function rmDirRobustAsync(
+  dir,
+  { attempts = 5, backoffMs = 50, _rm = rmAsync, _sleep = (ms) => new Promise((r) => setTimeout(r, ms)) } = {},
+) {
+  for (let i = 0; i < attempts - 1; i++) {
+    try {
+      await _rm(dir, RM_RETRY)
+      return
+    } catch (err) {
+      if (!RM_TRANSIENT_CODES.has(err?.code)) throw err
+      await _sleep(backoffMs * (i + 1))
+    }
+  }
+  await _rm(dir, RM_RETRY)
 }
 
 // Re-export the ctx-shape assert so handler tests can guard their mocks.

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'os'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 import { createFileOps } from '../src/ws-file-ops/index.js'
-import { RM_RETRY } from './test-helpers.js'
+import { rmDirRobustAsync } from './test-helpers.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -30,7 +30,7 @@ describe('gitStage/gitUnstage path validation (#1958)', () => {
   })
 
   after(async () => {
-    if (tmpDir) await rm(tmpDir, RM_RETRY)
+    if (tmpDir) await rmDirRobustAsync(tmpDir)
   })
 
   it('gitStage rejects path traversal (../../etc/passwd)', async () => {
@@ -117,8 +117,8 @@ describe('git ops workspace root validation (#2690)', () => {
   })
 
   after(async () => {
-    if (workspaceDir) await rm(workspaceDir, RM_RETRY)
-    if (outsideDir) await rm(outsideDir, RM_RETRY)
+    if (workspaceDir) await rmDirRobustAsync(workspaceDir)
+    if (outsideDir) await rmDirRobustAsync(outsideDir)
   })
 
   it('gitStatus rejects a path outside workspace root', async () => {

--- a/packages/server/tests/ws-server-file-ops.test.js
+++ b/packages/server/tests/ws-server-file-ops.test.js
@@ -7,7 +7,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir, homedir } from 'node:os'
 import { WsServer as _WsServer } from '../src/ws-server.js'
-import { createMockSession, createMockSessionManager, waitFor, GIT, disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+import { createMockSession, createMockSessionManager, waitFor, GIT, disableRepoAutoGc, rmDirRobust } from './test-helpers.js'
 import { setLogListener } from '../src/logger.js'
 
 // Wrapper that defaults noEncrypt: true for all tests (avoids 5s key exchange timeouts)
@@ -1088,7 +1088,7 @@ describe('get_diff handler', () => {
       server.close()
       server = null
     }
-    rmSync(tempDir, RM_RETRY)
+    rmDirRobust(tempDir)
   })
 
   async function createDiffTestServer() {


### PR DESCRIPTION
## Summary

Closes #6120. Follow-up to #6114 (which added `rmDirRobust`/`rmDirRobustAsync` and swapped the checkpoint/worktree teardowns). The #6119 review flagged **six** sibling test files that create temp git repos (`disableRepoAutoGc`) but still tear down with a bare `RM_RETRY` remove — latent versions of the same gc-race `ENOTEMPTY: rmdir '.git'` flake. This finishes the class.

## Change

Swapped every remaining `RM_RETRY` teardown to the re-recursing helper:

- **async** (`await rm(dir, RM_RETRY)` → `await rmDirRobustAsync(dir)`): `git-ops`, `git-stage-commit`, `session-context`, `ws-file-ops-git-paths`
- **sync** (`rmSync(dir, RM_RETRY)` → `rmDirRobust(dir)`): `supervisor-rollback-a9`, `ws-server-file-ops`

Added **`rmDirRobustAsync`** — the `node:fs/promises` mirror of `rmDirRobust` (same re-recurse-on-transient-code semantics, awaited-timer backoff) — since these teardowns are in `async afterEach`. Dropped the now-unused `rmSync` import in `supervisor-rollback-a9`; single-file `rm()`/`rmSync()` removes elsewhere keep their imports.

After this, **no `RM_RETRY` teardown call sites remain** outside the helper itself.

## Tests

- `test-helpers-rmdir.test.js` — added async unit coverage (re-recurse-then-succeed, non-transient surfaces immediately, gives-up after N, real-fs happy path) alongside the sync set.
- All six swapped files green locally (**103 tests** across the affected suites).