### PR TITLE
fix(app): keep attach/camera available during an active turn (#6118)

### DIFF
--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -181,9 +181,14 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
     pulseAnim.setValue(1);
   }, [isRecognizing, pulseAnim]);
 
+  // #6118 — attach/camera stay available during an active turn (streaming or
+  // busy). Since #5938 a mid-turn send QUEUES rather than being blocked, and the
+  // queued-send path carries attachments — so a user must be able to compose a
+  // full follow-up (text + files) while Claude is working. The old `!isStreaming`
+  // hide only existed because sending was disabled mid-turn; that reason is gone.
   const showMicButton = viewMode === 'chat' && !disabled && (onMicPress || speechUnavailable);
-  const showAttachButton = viewMode === 'chat' && !hasTerminal && !isStreaming && !disabled && onAttach;
-  const showCameraButton = viewMode === 'chat' && !hasTerminal && !isStreaming && !disabled && onCamera;
+  const showAttachButton = viewMode === 'chat' && !hasTerminal && !disabled && onAttach;
+  const showCameraButton = viewMode === 'chat' && !hasTerminal && !disabled && onCamera;
 
   // Filter slash commands based on current input (only when typing `/` at the start)
   const filteredCommands = useMemo(() => {

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -234,4 +234,20 @@ describe('InputBar send-while-streaming un-gate (#5938)', () => {
     expect(present(tree, 'chat-stop-button')).toBe(false);
     expect(tree.root.findByProps({ testID: 'chat-send-button' }).props.accessibilityLabel).toBe('Send message');
   });
+
+  // #6118 — attach/camera stay available during an active turn so a queued
+  // follow-up can carry attachments.
+  it('keeps Attach + Camera available while streaming (queue a follow-up with files)', () => {
+    const hasLabel = (tree: renderer.ReactTestRenderer, label: string) => {
+      try { tree.root.findByProps({ accessibilityLabel: label }); return true; } catch { return false; }
+    };
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} isStreaming={true} onAttach={noop} onCamera={noop} onChangeText={noop} />,
+      );
+    });
+    expect(hasLabel(tree, 'Attach file')).toBe(true);
+    expect(hasLabel(tree, 'Take photo')).toBe(true);
+  });
 });

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -237,17 +237,32 @@ describe('InputBar send-while-streaming un-gate (#5938)', () => {
 
   // #6118 — attach/camera stay available during an active turn so a queued
   // follow-up can carry attachments.
-  it('keeps Attach + Camera available while streaming (queue a follow-up with files)', () => {
-    const hasLabel = (tree: renderer.ReactTestRenderer, label: string) => {
-      try { tree.root.findByProps({ accessibilityLabel: label }); return true; } catch { return false; }
-    };
+  const hasLabel = (tree: renderer.ReactTestRenderer, label: string) => {
+    try { tree.root.findByProps({ accessibilityLabel: label }); return true; } catch { return false; }
+  };
+
+  it.each([
+    ['streaming', { isStreaming: true, isBusy: false }],
+    ['busy pre-stream', { isStreaming: false, isBusy: true }],
+  ])('keeps Attach + Camera available while %s (queue a follow-up with files)', (_label, turn) => {
     let tree!: renderer.ReactTestRenderer;
     act(() => {
       tree = renderer.create(
-        <InputBar {...baseProps} isStreaming={true} onAttach={noop} onCamera={noop} onChangeText={noop} />,
+        <InputBar {...baseProps} {...turn} onAttach={noop} onCamera={noop} onChangeText={noop} />,
       );
     });
     expect(hasLabel(tree, 'Attach file')).toBe(true);
     expect(hasLabel(tree, 'Take photo')).toBe(true);
+  });
+
+  it('still hides Attach + Camera while disconnected (disabled), even mid-turn', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} isStreaming={true} disabled onAttach={noop} onCamera={noop} onChangeText={noop} />,
+      );
+    });
+    expect(hasLabel(tree, 'Attach file')).toBe(false);
+    expect(hasLabel(tree, 'Take photo')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #6118 (follow-up from #6117 review). **Decision: SHOW** attach/camera during an active turn (rather than #6118's originally-suggested "hide for consistency").

Since #5938 a mid-turn send **queues** instead of being blocked, and the queued-send path already carries attachments — so a user should be able to compose a full follow-up (text **+ files**) while Claude is working. The previous `!isStreaming` hide on attach/camera only existed *because* sending was disabled mid-turn; that constraint is gone. Hiding them would arbitrarily block attachment-bearing queued follow-ups, contradicting the feature's intent.

## Change

`InputBar.tsx` — drop `!isStreaming` from `showAttachButton` / `showCameraButton`. They now render whenever `viewMode==='chat' && !hasTerminal && !disabled` and a handler is provided, regardless of turn state. (`disabled` still hides them while disconnected.)

## Test

`InputBar.imperative.test.tsx` — attach + camera remain present while streaming.
Full app suite green: **2026 passed**. Typecheck clean.