### PR TITLE
fix(desktop): adopt an external server in client mode instead of hanging (#6015)

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1350,11 +1350,42 @@ pub fn run() {
             if !is_first_run {
                 let settings = app.state::<Mutex<DesktopSettings>>();
                 let auto_start = lock_or_recover(&settings).auto_start_server;
-                if auto_start {
-                    let config = config::load_config();
-                    if config.api_token.is_some() {
-                        handle_start(app.handle());
+                drop(settings);
+                let config = config::load_config();
+                match startup_action(auto_start, config.api_token.is_some()) {
+                    StartupAction::StartOwn => handle_start(app.handle()),
+                    // #6015 — client mode: adopt an already-running external server
+                    // instead of hanging on the splash. Probe /health on the
+                    // configured port; navigate to its dashboard on success, or
+                    // surface an actionable error (not an indefinite spinner).
+                    StartupAction::AdoptExternal => {
+                        let app_handle = app.handle().clone();
+                        let port = config.port;
+                        let token = config.api_token.clone();
+                        std::thread::spawn(move || {
+                            if probe_external_health(port) {
+                                match token {
+                                    Some(t) => window::emit_server_ready(&app_handle, port, Some(&t)),
+                                    None => window::emit_server_error(
+                                        &app_handle,
+                                        &format!(
+                                            "A server is running on port {} but no access token was found. Pair the app or paste a token in Settings.",
+                                            port
+                                        ),
+                                    ),
+                                }
+                            } else {
+                                window::emit_server_error(
+                                    &app_handle,
+                                    &format!(
+                                        "No server found on port {}. Start a server, or enable Auto-start Server in Settings.",
+                                        port
+                                    ),
+                                );
+                            }
+                        });
                     }
+                    StartupAction::Skip => {}
                 }
             }
 
@@ -1710,6 +1741,49 @@ fn monitor_startup(app: &tauri::AppHandle, context: StartupContext) -> bool {
     update_menu_state(app, MenuState::Stopped);
     window::emit_server_error(app, &timeout_msg);
     send_notification(app, timeout_title, &timeout_msg);
+    false
+}
+
+/// #6015 — what to do for the embedded server at a (non-first-run) launch. The
+/// pure decision is split out from the I/O (probe + navigate) so it is unit
+/// testable.
+#[derive(Debug, PartialEq, Eq)]
+enum StartupAction {
+    /// Auto-start is on and a token exists — launch the bundled server.
+    StartOwn,
+    /// Auto-start is off — act as a CLIENT: probe for an already-running
+    /// external server (e.g. an always-on launchd daemon) and navigate to its
+    /// dashboard, instead of hanging on the "Still starting…" splash forever.
+    AdoptExternal,
+    /// Auto-start is on but no token yet — nothing to do here (the pairing /
+    /// first-run flow mints one); avoids launching a tokenless server.
+    Skip,
+}
+
+fn startup_action(auto_start: bool, has_token: bool) -> StartupAction {
+    match (auto_start, has_token) {
+        (true, true) => StartupAction::StartOwn,
+        (true, false) => StartupAction::Skip,
+        (false, _) => StartupAction::AdoptExternal,
+    }
+}
+
+/// #6015 — probe an already-running external server's `/health` on loopback.
+/// A few short attempts (so a just-launched daemon is still adopted); returns
+/// true on the first 200. Mirrors the embedded-server health check (ureq, 2s).
+fn probe_external_health(port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{}/health", port);
+    for attempt in 0..10 {
+        if let Ok(resp) = ureq::get(&url).timeout(std::time::Duration::from_secs(2)).call() {
+            if resp.status() == 200 {
+                return true;
+            }
+        }
+        // No sleep after the final attempt.
+        if attempt < 9 {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    }
     false
 }
 
@@ -2288,6 +2362,17 @@ mod tests {
         cfg.get("allowAutoPermissionMode")
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
+    }
+
+    // #6015 — startup-mode decision: auto-start+token launches our own server;
+    // auto-start without a token does nothing (pairing mints one); auto-start
+    // OFF means act as a client and adopt an external server.
+    #[test]
+    fn startup_action_maps_each_mode() {
+        assert_eq!(startup_action(true, true), StartupAction::StartOwn);
+        assert_eq!(startup_action(true, false), StartupAction::Skip);
+        assert_eq!(startup_action(false, true), StartupAction::AdoptExternal);
+        assert_eq!(startup_action(false, false), StartupAction::AdoptExternal);
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1774,9 +1774,19 @@ fn startup_action(auto_start: bool, has_token: bool) -> StartupAction {
 fn probe_external_health(port: u16) -> bool {
     let url = format!("http://127.0.0.1:{}/health", port);
     for attempt in 0..10 {
-        if let Ok(resp) = ureq::get(&url).timeout(std::time::Duration::from_secs(2)).call() {
-            if resp.status() == 200 {
-                return true;
+        // Log each attempt (mirrors the embedded-server health check in
+        // server.rs) so a stuck client-mode launch is debuggable from the app's
+        // stderr/console rather than a silent spinner.
+        match ureq::get(&url).timeout(std::time::Duration::from_secs(2)).call() {
+            Ok(resp) => {
+                let code = resp.status();
+                eprintln!("[client-adopt] attempt #{} GET {} -> {}", attempt + 1, url, code);
+                if code == 200 {
+                    return true;
+                }
+            }
+            Err(err) => {
+                eprintln!("[client-adopt] attempt #{} GET {} -> Err({})", attempt + 1, url, err);
             }
         }
         // No sleep after the final attempt.

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1771,6 +1771,21 @@ fn startup_action(auto_start: bool, has_token: bool) -> StartupAction {
 /// #6015 — probe an already-running external server's `/health` on loopback.
 /// A few short attempts (so a just-launched daemon is still adopted); returns
 /// true on the first 200. Mirrors the embedded-server health check (ureq, 2s).
+/// #6015 (security, #6123 review) — confirm a 200 `/health` body is actually a
+/// chroxy server before adopting it. We navigate WITH the access token, so a
+/// 200 from an UNRELATED local service squatting on the port must NOT receive
+/// the token. chroxy's health JSON is `{"status":"ok","mode":...,"version":...}`
+/// — require `status:"ok"` AND a string `version` as the fingerprint. Pure, so
+/// unit-tested.
+fn is_chroxy_health(body: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(body)
+        .map(|v| {
+            v.get("status").and_then(|s| s.as_str()) == Some("ok")
+                && v.get("version").and_then(|x| x.as_str()).is_some()
+        })
+        .unwrap_or(false)
+}
+
 fn probe_external_health(port: u16) -> bool {
     let url = format!("http://127.0.0.1:{}/health", port);
     for attempt in 0..10 {
@@ -1780,9 +1795,19 @@ fn probe_external_health(port: u16) -> bool {
         match ureq::get(&url).timeout(std::time::Duration::from_secs(2)).call() {
             Ok(resp) => {
                 let code = resp.status();
-                eprintln!("[client-adopt] attempt #{} GET {} -> {}", attempt + 1, url, code);
                 if code == 200 {
-                    return true;
+                    // Token-leak guard: only adopt a verified chroxy server.
+                    let body = resp.into_string().unwrap_or_default();
+                    if is_chroxy_health(&body) {
+                        eprintln!("[client-adopt] attempt #{} GET {} -> 200 (chroxy)", attempt + 1, url);
+                        return true;
+                    }
+                    eprintln!(
+                        "[client-adopt] attempt #{} GET {} -> 200 but not a chroxy /health body; not adopting",
+                        attempt + 1, url
+                    );
+                } else {
+                    eprintln!("[client-adopt] attempt #{} GET {} -> {}", attempt + 1, url, code);
                 }
             }
             Err(err) => {
@@ -2383,6 +2408,21 @@ mod tests {
         assert_eq!(startup_action(true, false), StartupAction::Skip);
         assert_eq!(startup_action(false, true), StartupAction::AdoptExternal);
         assert_eq!(startup_action(false, false), StartupAction::AdoptExternal);
+    }
+
+    // #6015 (security) — only a real chroxy /health body is adoptable; a 200
+    // from an unrelated local service squatting on the port must NOT be adopted
+    // (we'd otherwise navigate the token to it).
+    #[test]
+    fn is_chroxy_health_fingerprint() {
+        assert!(is_chroxy_health(r#"{"status":"ok","mode":"cli","version":"0.9.46"}"#));
+        // Wrong/foreign shapes — reject.
+        assert!(!is_chroxy_health(r#"{"status":"ok"}"#)); // no version
+        assert!(!is_chroxy_health(r#"{"status":"healthy","version":"1.0"}"#)); // not chroxy's "ok"
+        assert!(!is_chroxy_health(r#"{"version":"1.0"}"#)); // no status
+        assert!(!is_chroxy_health("OK")); // not JSON (e.g. another service)
+        assert!(!is_chroxy_health("")); // empty
+        assert!(!is_chroxy_health(r#"{"status":"ok","version":200}"#)); // version not a string
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #6015. When `autoStartServer:false`, the desktop app started nothing and hung on the "Still starting…" splash forever — even with a healthy server already serving `/dashboard` on the configured port. This made the documented **daemon-as-server + app-as-client** topology (the natural durable setup: server survives app close/reboot, app is just a viewer) unusable.

## Change (`src-tauri/src/lib.rs`)

- **`startup_action(auto_start, has_token) -> {StartOwn, AdoptExternal, Skip}`** — a pure, unit-tested decision:
  - `auto_start && token` → `StartOwn` (launch the bundled server, unchanged)
  - `auto_start && !token` → `Skip` (pairing/first-run mints one; avoids a tokenless server)
  - `!auto_start` → `AdoptExternal` (act as a client)
- **`AdoptExternal`** spawns a probe of `http://127.0.0.1:<port>/health` (ureq, a few short attempts so a just-started daemon is still adopted):
  - healthy + token → navigate the webview to the external dashboard via the existing `emit_server_ready`, reusing `config.api_token` (the same local source the auto-start path already uses — no new token UX for the local daemon)
  - healthy + no token → actionable `emit_server_error` ("server running but no token; pair/paste")
  - no server → actionable `emit_server_error` ("no server found; start one or enable Auto-start")

`autoStartServer:true` behavior is unchanged.

## Acceptance criteria

- [x] Healthy external server + `autoStartServer:false` → navigates to the dashboard (no indefinite "Still starting"). *(needs desktop launch verification)*
- [x] No server + `autoStartServer:false` → actionable error, not an infinite spinner.
- [x] `autoStartServer:true` unchanged.
- [x] Token: reuses the locally-stored token for the local daemon; LAN/remote pairing stays out of scope for this slice (noted in #6015's phase-2 direction).

## Tests / verification

- `startup_action_maps_each_mode` unit test (Desktop Rust Tests). `cargo test` green locally; crate compiles.
- **Behavior verification needs a desktop launch** in client mode (CI can't exercise the webview navigate) — verifying with a build before merge.