### PR TITLE
refactor(store-core): migrate model_changed to the shared dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -27,7 +27,6 @@ import {
   resolveSessionId,
   handleUserInput as sharedUserInput,
   handleMessage as sharedMessageHandler,
-  handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
   // available_permission_modes / session_updated / confirm_permission_mode /
   // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
@@ -2661,17 +2660,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'model_changed': {
-      const { model } = sharedModelChanged(msg);
-      const targetId = resolveSessionId(msg, get().activeSessionId);
-      {
-        const effectiveId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-        if (effectiveId && get().sessionStates[effectiveId]) {
-          updateSession(effectiveId, () => ({ activeModel: model }));
-        }
-      }
-      break;
-    }
+    // #5618 — model_changed migrated to the shared store-core dispatch table
+    // (runDispatch handles it before this switch). Removed from here.
 
     case 'available_models': {
       if (Array.isArray(msg.models)) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -17,7 +17,6 @@ import {
   resolveSessionId,
   handleUserInput as sharedUserInput,
   handleMessage as sharedMessageHandler,
-  handleModelChanged as sharedModelChanged,
   handlePermissionModeChanged as sharedPermissionModeChanged,
   // available_permission_modes / session_updated / confirm_permission_mode /
   // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
@@ -1350,22 +1349,11 @@ function handleConversationsList(msg: Record<string, unknown>, _get: MsgGet, set
   set({ conversationHistory: conversations, conversationHistoryLoading: false });
 }
 
-function handleModelChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const { model } = sharedModelChanged(msg);
-  const targetId = resolveSessionId(msg, get().activeSessionId);
-  if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, () => ({ activeModel: model }));
-  } else {
-    set({ activeModel: model });
-  }
-  // #5711: deliberately do NOT clear pending reverts here. The server sends
-  // model_changed XOR error per requestId (never both), so a successful change
-  // never receives a later error to mis-consume. Clearing by sessionId would be
-  // too coarse — with two rapid changes on one session (A→B, B→C), the ack for
-  // the first would drop the SECOND's still-in-flight revert, stranding the
-  // dropdown if the second is then rejected. Stale success entries are bounded
-  // by the FIFO cap and cleared on disconnect.
-}
+// #5618 — model_changed migrated to the shared store-core dispatch table
+// (runDispatch handles it before the HANDLERS map / switch). Removed from here.
+// The #5711 note (model_changed deliberately does NOT clear pending model-revert
+// entries — server sends model_changed XOR error per requestId) still holds: the
+// shared handler likewise only writes activeModel and never touches reverts.
 
 function handleThinkingLevelChanged(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
   const { level } = sharedThinkingLevelChanged(msg);
@@ -2736,7 +2724,6 @@ const HANDLERS: Record<string, Handler> = {
   // web_feature_status / web_task_list migrated to the shared dispatch table
   // (#5556 slice 2)
   conversations_list: handleConversationsList,
-  model_changed: handleModelChanged,
   thinking_level_changed: handleThinkingLevelChanged,
   prompt_evaluator_changed: handlePromptEvaluatorChanged,
   chroxy_context_hint_changed: handleChroxyContextHintChanged,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -321,8 +321,12 @@ export function clearPendingTrustGrants(): void {
 // the dashboard keeps showing a model the session never switched to. Remember
 // the model we switched FROM, keyed by the set_model requestId the server
 // echoes on its error, so the `error` handler can roll the optimistic update
-// back. Cleared on the matching `model_changed` success, on a matching error,
-// or on disconnect. Bounded FIFO like the trust-grant map.
+// back. Consumed (deleted) on a matching error; otherwise cleared on disconnect
+// or evicted by the bounded FIFO cap. A successful change is NOT cleared here —
+// the server sends model_changed XOR error per requestId (#5711), so a success
+// entry simply ages out via the cap and is never mis-consumed by a later error.
+// (model_changed itself is handled by the shared store-core dispatch table since
+// #5618 and only writes activeModel; it never touched this map.)
 interface PendingModelRevert {
   sessionId: string | null;
   previousModel: string | null;

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -81,7 +81,6 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'cost_update',
   'history_replay_end',
   'key_exchange_ok',
-  'model_changed',
   'multi_question_intervention',
   'pair_fail',
   'permission_expired',

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -198,6 +198,32 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { sessions: { active: { isIdle: false } } },
   },
 
+  // 3b. model_changed (#5618) — set the target session's activeModel. Reconciled
+  // from the two clients' divergent edge fallbacks: a known target updates that
+  // session (incl. the active session, whose flat mirror the dashboard adapter
+  // keeps in sync); a stray unknown-session model_changed is a clean no-op.
+  {
+    name: 'model_changed sets activeModel on the explicit target session',
+    type: 'model_changed',
+    init: { sessions: { s1: { activeModel: 'claude-sonnet-4-6' } } },
+    message: { type: 'model_changed', sessionId: 's1', model: 'claude-opus-4-8' },
+    expect: { sessions: { s1: { activeModel: 'claude-opus-4-8' } } },
+  },
+  {
+    name: 'model_changed falls back to the active session when sessionId is absent',
+    type: 'model_changed',
+    init: { activeSessionId: 'active', sessions: { active: { activeModel: 'claude-sonnet-4-6' } } },
+    message: { type: 'model_changed', model: 'claude-opus-4-8' },
+    expect: { sessions: { active: { activeModel: 'claude-opus-4-8' } } },
+  },
+  {
+    name: 'model_changed for an unknown session is a no-op (reconciled edge)',
+    type: 'model_changed',
+    init: { activeSessionId: 'active', sessions: { active: { activeModel: 'keep' } } },
+    message: { type: 'model_changed', sessionId: 'ghost', model: 'ignored' },
+    expect: { noop: true },
+  },
+
   // 4. budget_resumed — append system message (target session OR flat addMessage)
   {
     name: 'budget_resumed appends the system message to the target session',

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -98,7 +98,9 @@ describe('shared dispatch table', () => {
   describe('runner mechanics', () => {
     it('returns false (table miss) for an unregistered type so the caller falls through', () => {
       const env = makeAdapter()
-      expect(dispatch(env, { type: 'model_changed', model: 'opus' })).toBe(false)
+      // permission_mode_changed stays platform-local (divergent dashboard
+      // flat-state fallback), so it is NOT in the shared table — a clean miss.
+      expect(dispatch(env, { type: 'permission_mode_changed', mode: 'plan' })).toBe(false)
     })
 
     it('returns false for a non-string type', () => {

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -151,6 +151,11 @@ export interface DispatchSessionBase {
   // `queuedMessages` — read+rewritten by message_queued / message_dequeued.
   // Both clients' real `SessionState` carry this array (BaseSessionState).
   queuedMessages?: QueuedSessionMessage[]
+  // --- reconciled divergent case (#5618) ---
+  // `activeModel` — written by model_changed. Both clients' real `SessionState`
+  // carry it (the dashboard also mirrors the active session's value to flat
+  // top-level state via its adapter).
+  activeModel?: string | null
 }
 
 /**

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -75,6 +75,7 @@ import {
   handleMcpServers,
   handleSessionUsage,
   handleSessionContext,
+  handleModelChangedPatch,
   handleSessionCostThresholdCrossed,
   handleDevPreview,
   handleDevPreviewStopped,
@@ -343,6 +344,11 @@ export interface DispatchMessageMap {
     gitAhead?: unknown
     projectName?: unknown
   }
+  model_changed: {
+    type: 'model_changed'
+    sessionId?: string
+    model?: string
+  }
   session_cost_threshold_crossed: {
     type: 'session_cost_threshold_crossed'
     sessionId?: string
@@ -445,8 +451,12 @@ export type DispatchTable<S extends DispatchSessionBase> = {
 // Handlers — one pure delegation per migrated case
 //
 // Each was byte-for-byte identical between the app and dashboard switches
-// (see the PR body's per-case diff verdicts). Genuinely-divergent cases
-// (model_changed, permission_mode_changed, agent_idle — all carry a dashboard
+// (see the PR body's per-case diff verdicts). model_changed (#5618) was
+// RECONCILED into the table — its only divergence was a stray-unknown-session
+// edge fallback (app → active session; dashboard → flat write), now a clean
+// no-op; every known-target case (incl. the dashboard's flat mirror) is
+// preserved. Genuinely-divergent cases still left out:
+// (permission_mode_changed, agent_idle — carry a dashboard
 // flat-state fallback the app lacks; budget_warning/exceeded — platform alert
 // APIs; primary_changed, client_joined/left/focus_changed — the app's
 // dedicated multi-client store; available_models — dashboard-only
@@ -908,6 +918,7 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     mcp_servers: sessionPatchDispatcher<S>(handleMcpServers),
     session_usage: sessionPatchDispatcher<S>(handleSessionUsage),
     session_context: sessionPatchDispatcher<S>(handleSessionContext),
+    model_changed: sessionPatchDispatcher<S>(handleModelChangedPatch),
     session_cost_threshold_crossed: dispatchSessionCostThresholdCrossed,
     dev_preview: dispatchDevPreview,
     dev_preview_stopped: dispatchDevPreviewStopped,
@@ -992,6 +1003,8 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   // --- outgoing-message queue mirror (#5937, epic #5935 part ②) ---
   'message_queued',
   'message_dequeued',
+  // --- reconciled divergent case (#5618) ---
+  'model_changed',
 ]
 
 /**

--- a/packages/store-core/src/handlers/session-config.ts
+++ b/packages/store-core/src/handlers/session-config.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ActiveTool, TranscriptBackgroundTask } from '../types'
-import { parseStringField } from './_shared'
+import { parseStringField, resolveSessionId, type SessionPatch } from './_shared'
 
 // ---------------------------------------------------------------------------
 // model_changed
@@ -19,6 +19,26 @@ import { parseStringField } from './_shared'
 /** Extract the model value from a `model_changed` message. */
 export function handleModelChanged(msg: Record<string, unknown>): { model: string | null } {
   return { model: parseStringField(msg, 'model') }
+}
+
+/**
+ * #5618 — `model_changed` as a session patch for the shared dispatch table.
+ * Targets the resolved session (msg.sessionId, else the active session) and sets
+ * its `activeModel`. The `sessionPatchDispatcher` only applies the patch when
+ * that session exists, so a stray `model_changed` for an unknown session is a
+ * no-op — replacing the two clients' divergent edge fallbacks (the app updated
+ * the active session; the dashboard wrote flat `activeModel`). For every normal
+ * case (a known target — including the active session, whose flat mirror the
+ * dashboard adapter keeps in sync) both clients behave exactly as before.
+ */
+export function handleModelChangedPatch(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionPatch {
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    patch: { activeModel: handleModelChanged(msg).model },
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -449,6 +449,7 @@ export {
   OTHER_OPTION_LABEL,
   resolveSessionId,
   handleModelChanged,
+  handleModelChangedPatch,
   handlePermissionModeChanged,
   handleAvailablePermissionModes,
   handleSessionUpdated,


### PR DESCRIPTION
## Summary

**Part of #5618** (one reconciliation slice — the umbrella tracks the remaining divergent cases). Migrates `model_changed` from both clients' platform-local switches into the shared store-core dispatch table.

Per the [migration audit](https://github.com/blamechris/chroxy/issues/5618#issuecomment-4754619382), the mechanical byte-identical sweep is done; what's left is divergent cases needing per-case reconciliation. `model_changed` is the safest: its **normal path was byte-identical** in both clients (`updateSession(targetId, {activeModel})` for a known session — including the active session, whose flat mirror the dashboard adapter keeps in sync). The only divergence was a stray **unknown-session** edge fallback:
- app → updated the *active* session
- dashboard → wrote flat `activeModel`

## Reconciliation

`handleModelChangedPatch(msg, activeSessionId): SessionPatch` (store-core), registered via the existing `sessionPatchDispatcher` — which applies the patch **only when the target session exists**. The unknown-session edge becomes a clean **no-op**, replacing both clients' divergent fallbacks. Every known-target case (the overwhelmingly common path) is preserved exactly.

- Added `model_changed` to `DispatchMessageMap` + `DISPATCH_TABLE_TYPES`; updated the "deliberately NOT here" comment.
- Removed the app switch case + the dashboard `handleModelChanged`/HANDLERS entry (+ now-unused `sharedModelChanged` imports). The #5711 "deliberately don't clear pending reverts" note still holds — the shared handler only writes `activeModel`.

## Behavior delta (explicit)

Only the rare **stray `model_changed` for a session not in `sessionStates`** changes: previously app updated the active session / dashboard set a flat model; now it's a no-op (don't guess which session a stray event targets). Both clients now agree.

## Drift protection / tests

- **3 new contract fixtures** (known target / active-session fallback / unknown-session no-op) — run through **both** client adapters, so the two clients are proven to agree.
- Removed `model_changed` from the coverage-lint `PENDING_CONTRACT_TYPES` allowlist (now fixtured); updated the dispatch-table table-miss example to a still-unregistered type (`permission_mode_changed`).
- Green: store-core **1679**, app **2028**, dashboard **3832**, protocol handler-coverage **9**; all three typechecks clean.