### PR TITLE
feat(server): Anthropic↔OpenAI translation core for the OpenAI-compatible provider (#5420)

### DIFF
--- a/packages/server/src/anthropic-openai-translate.js
+++ b/packages/server/src/anthropic-openai-translate.js
@@ -47,22 +47,30 @@ function anthropicMessageToOpenAi(msg) {
     return [{ role, content: '' }]
   }
 
+  const textParts = content
+    .filter((b) => b?.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+
   // Tool RESULT blocks (carried on a 'user' message in Anthropic) become
-  // standalone OpenAI 'tool' messages keyed by tool_call_id.
+  // standalone OpenAI 'tool' messages keyed by tool_call_id. A user turn may
+  // ALSO carry sibling text blocks alongside the results — byok-session's
+  // MAX_TOOL_ROUNDS path builds exactly such a `[tool_result…, text]` turn (the
+  // "summarise, do not call tools" instruction). OpenAI has no text channel on a
+  // `tool` message, so append the text as a following `user` message rather than
+  // dropping it (#6128).
   const toolResults = content.filter((b) => b?.type === 'tool_result')
   if (toolResults.length > 0) {
-    return toolResults.map((b) => ({
+    const msgs = toolResults.map((b) => ({
       role: 'tool',
       tool_call_id: b.tool_use_id,
       content: toolResultContentToString(b.content),
     }))
+    if (textParts.length > 0) msgs.push({ role: 'user', content: textParts.join('') })
+    return msgs
   }
 
   // Assistant tool_use blocks → OpenAI assistant message with tool_calls.
   const toolUses = content.filter((b) => b?.type === 'tool_use')
-  const textParts = content
-    .filter((b) => b?.type === 'text' && typeof b.text === 'string')
-    .map((b) => b.text)
   if (toolUses.length > 0) {
     return [
       {

--- a/packages/server/src/anthropic-openai-translate.js
+++ b/packages/server/src/anthropic-openai-translate.js
@@ -1,0 +1,337 @@
+/**
+ * Pure translation between the Anthropic Messages API shapes and the OpenAI
+ * Chat Completions API shapes (#5420, option 1 — the AnthropicShimClient core).
+ *
+ * `ClaudeByokSession` drives `@anthropic-ai/sdk`'s `client.messages.stream(...)`:
+ * it sends an Anthropic request and consumes an async iterable of raw SDK events
+ * (message_start / content_block_start / content_block_delta / content_block_stop
+ * / message_delta / message_stop), then reads `stream.finalMessage()`. To reach
+ * OpenAI-compatible servers (LM Studio, vLLM, llama.cpp, OpenRouter, …) without
+ * forking that loop, a shim reproduces the SDK surface but speaks chat-completions
+ * underneath. THIS module is the pure, side-effect-free heart of that shim:
+ *
+ *   - `anthropicRequestToOpenAi(params)` — request shape translation.
+ *   - `createStreamTranslator()`        — fold OpenAI streaming chunks into the
+ *                                         Anthropic SDK event sequence + a final
+ *                                         Message (`{stop_reason, content, usage}`).
+ *
+ * Keeping it pure means the whole translation is fixture-testable against recorded
+ * OpenAI chunk sequences with no `openai` dependency and no live endpoint — the
+ * network glue (importing `openai`, awaiting the SSE iterator) is a thin separate
+ * layer. Live-endpoint fidelity (the #5420 spike: tool streaming, parallel tool
+ * calls, usage accounting against real servers) is verified separately.
+ *
+ * The emitted event objects match the RAW Anthropic SDK shapes that
+ * `byok-event-translator.js` switches on — that file is the contract this
+ * module's output must satisfy.
+ */
+
+// ---------------------------------------------------------------------------
+// Request: Anthropic Messages params → OpenAI Chat Completions params
+// ---------------------------------------------------------------------------
+
+/**
+ * Map Anthropic content (string | block[]) to an OpenAI message `content` /
+ * `tool_calls`. Anthropic packs tool results and tool calls INTO the message
+ * content array; OpenAI splits them across roles, so a single Anthropic message
+ * can fan out into several OpenAI messages. This returns the pieces for one
+ * Anthropic message so the caller can flatten.
+ */
+function anthropicMessageToOpenAi(msg) {
+  const { role, content } = msg
+  // Plain string content → a single same-role message.
+  if (typeof content === 'string') {
+    return [{ role, content }]
+  }
+  if (!Array.isArray(content)) {
+    return [{ role, content: '' }]
+  }
+
+  // Tool RESULT blocks (carried on a 'user' message in Anthropic) become
+  // standalone OpenAI 'tool' messages keyed by tool_call_id.
+  const toolResults = content.filter((b) => b?.type === 'tool_result')
+  if (toolResults.length > 0) {
+    return toolResults.map((b) => ({
+      role: 'tool',
+      tool_call_id: b.tool_use_id,
+      content: toolResultContentToString(b.content),
+    }))
+  }
+
+  // Assistant tool_use blocks → OpenAI assistant message with tool_calls.
+  const toolUses = content.filter((b) => b?.type === 'tool_use')
+  const textParts = content
+    .filter((b) => b?.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+  if (toolUses.length > 0) {
+    return [
+      {
+        role: 'assistant',
+        content: textParts.length > 0 ? textParts.join('') : null,
+        tool_calls: toolUses.map((b) => ({
+          id: b.id,
+          type: 'function',
+          function: { name: b.name, arguments: JSON.stringify(b.input ?? {}) },
+        })),
+      },
+    ]
+  }
+
+  // Otherwise: concatenate text blocks into a single same-role message.
+  return [{ role, content: textParts.join('') }]
+}
+
+/** Anthropic tool_result `content` is string | block[]; OpenAI wants a string. */
+function toolResultContentToString(content) {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => (typeof b === 'string' ? b : typeof b?.text === 'string' ? b.text : ''))
+      .join('')
+  }
+  return ''
+}
+
+/**
+ * Translate an Anthropic `messages.create/stream` params object to an OpenAI
+ * `chat.completions.create` params object. `stream`/`stream_options` are set by
+ * the caller (the shim always streams); everything else is shape translation.
+ */
+export function anthropicRequestToOpenAi(params = {}) {
+  const out = {
+    model: params.model,
+    // OpenAI uses max_tokens (deprecated) / max_completion_tokens; max_tokens is
+    // the broadly-compatible field across LM Studio / vLLM / llama.cpp / OpenRouter.
+    max_tokens: params.max_tokens,
+    messages: [],
+  }
+
+  // Anthropic carries the system prompt as a top-level string; OpenAI wants a
+  // leading system-role message.
+  if (typeof params.system === 'string' && params.system.length > 0) {
+    out.messages.push({ role: 'system', content: params.system })
+  }
+
+  for (const msg of params.messages || []) {
+    for (const m of anthropicMessageToOpenAi(msg)) out.messages.push(m)
+  }
+
+  if (Array.isArray(params.tools) && params.tools.length > 0) {
+    out.tools = params.tools.map((t) => ({
+      type: 'function',
+      function: {
+        name: t.name,
+        description: t.description,
+        // Anthropic calls it input_schema; OpenAI calls it parameters.
+        parameters: t.input_schema ?? { type: 'object', properties: {} },
+      },
+    }))
+  }
+
+  if (params.tool_choice) out.tool_choice = mapToolChoice(params.tool_choice)
+  if (typeof params.temperature === 'number') out.temperature = params.temperature
+  return out
+}
+
+/** Anthropic tool_choice → OpenAI tool_choice. */
+function mapToolChoice(tc) {
+  if (!tc || typeof tc !== 'object') return undefined
+  if (tc.type === 'auto') return 'auto'
+  if (tc.type === 'any') return 'required'
+  if (tc.type === 'tool' && typeof tc.name === 'string') {
+    return { type: 'function', function: { name: tc.name } }
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Response: OpenAI streaming chunks → Anthropic SDK event sequence
+// ---------------------------------------------------------------------------
+
+/** OpenAI finish_reason → Anthropic stop_reason. */
+export function mapFinishReason(reason) {
+  switch (reason) {
+    case 'stop':
+      return 'end_turn'
+    case 'tool_calls':
+    case 'function_call':
+      return 'tool_use'
+    case 'length':
+      return 'max_tokens'
+    case 'content_filter':
+      return 'stop_sequence'
+    default:
+      return reason ? 'end_turn' : null
+  }
+}
+
+/** OpenAI usage → Anthropic usage (no cache tokens in OpenAI; default 0). */
+export function mapUsage(usage) {
+  if (!usage || typeof usage !== 'object') {
+    return { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+  }
+  return {
+    input_tokens: Number(usage.prompt_tokens) || 0,
+    output_tokens: Number(usage.completion_tokens) || 0,
+    cache_read_input_tokens: Number(usage.prompt_tokens_details?.cached_tokens) || 0,
+    cache_creation_input_tokens: 0,
+  }
+}
+
+/**
+ * Stateful (but I/O-free) fold of an OpenAI chat-completions STREAM into the
+ * Anthropic SDK event sequence the byok loop consumes, plus the final Message.
+ *
+ * OpenAI streams one `choices[0].delta` per chunk: `delta.content` (text) and/or
+ * `delta.tool_calls[]` (each with a stable `index`, an `id`+`function.name` on
+ * first appearance, and `function.arguments` fragments thereafter). Anthropic
+ * instead opens a content BLOCK (content_block_start) per text run / tool_use,
+ * streams deltas into it, and closes it (content_block_stop) — so this translator
+ * assigns Anthropic block indices and tracks which OpenAI tool_call index maps to
+ * which block.
+ *
+ * Usage:
+ *   const tr = createStreamTranslator()
+ *   for (const chunk of openaiChunks) emit(...tr.push(chunk))   // Anthropic events
+ *   const { events, finalMessage } = tr.finish()                // trailing events + final
+ *
+ * `push` returns the events to emit for that chunk (possibly empty); `finish`
+ * returns any trailing close events plus the assembled final Message.
+ */
+export function createStreamTranslator() {
+  let started = false
+  let nextBlockIndex = 0
+  // Text block: opened lazily on the first text delta, closed when a tool call
+  // starts or the stream ends.
+  let textBlock = null // { index, text }
+  // OpenAI tool_call index -> { blockIndex, id, name, args }
+  const toolCalls = new Map()
+  // Anthropic content-block order, for finalMessage.content assembly.
+  const order = [] // { type: 'text'|'tool_use', ref }
+  let stopReason = null
+  let usage = null
+  let model = null
+  let messageId = null
+
+  function ensureStarted(chunk) {
+    if (started) return []
+    started = true
+    model = chunk?.model ?? null
+    messageId = chunk?.id ?? null
+    return [{ type: 'message_start', message: { id: messageId, model, role: 'assistant', content: [], usage: mapUsage(null) } }]
+  }
+
+  function closeTextBlock() {
+    if (!textBlock) return []
+    const ev = [{ type: 'content_block_stop', index: textBlock.index }]
+    textBlock = null
+    return ev
+  }
+
+  function push(chunk) {
+    const events = []
+    if (!chunk || typeof chunk !== 'object') return events
+    events.push(...ensureStarted(chunk))
+
+    // Usage can ride on any chunk (final chunk when stream_options.include_usage),
+    // and some servers send a usage-only trailing chunk with empty choices.
+    if (chunk.usage) usage = chunk.usage
+
+    const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined
+    if (!choice) return events
+    const delta = choice.delta || {}
+
+    // Text delta → open a text block if needed, then stream into it.
+    if (typeof delta.content === 'string' && delta.content.length > 0) {
+      if (!textBlock) {
+        textBlock = { index: nextBlockIndex++, text: '' }
+        order.push({ type: 'text', ref: textBlock })
+        events.push({ type: 'content_block_start', index: textBlock.index, content_block: { type: 'text', text: '' } })
+      }
+      textBlock.text += delta.content
+      events.push({ type: 'content_block_delta', index: textBlock.index, delta: { type: 'text_delta', text: delta.content } })
+    }
+
+    // Tool-call deltas.
+    if (Array.isArray(delta.tool_calls)) {
+      for (const tc of delta.tool_calls) {
+        const oaIndex = typeof tc.index === 'number' ? tc.index : 0
+        let entry = toolCalls.get(oaIndex)
+        if (!entry) {
+          // A tool block begins — close any open text block first (Anthropic
+          // blocks don't overlap).
+          events.push(...closeTextBlock())
+          entry = { blockIndex: nextBlockIndex++, id: tc.id || '', name: tc.function?.name || '', args: '' }
+          toolCalls.set(oaIndex, entry)
+          order.push({ type: 'tool_use', ref: entry })
+          events.push({
+            type: 'content_block_start',
+            index: entry.blockIndex,
+            content_block: { type: 'tool_use', id: entry.id, name: entry.name, input: {} },
+          })
+        } else {
+          // Late id/name (some servers send them split across chunks).
+          if (!entry.id && tc.id) entry.id = tc.id
+          if (!entry.name && tc.function?.name) entry.name = tc.function.name
+        }
+        const argFragment = tc.function?.arguments
+        if (typeof argFragment === 'string' && argFragment.length > 0) {
+          entry.args += argFragment
+          events.push({
+            type: 'content_block_delta',
+            index: entry.blockIndex,
+            delta: { type: 'input_json_delta', partial_json: argFragment },
+          })
+        }
+      }
+    }
+
+    if (choice.finish_reason) stopReason = mapFinishReason(choice.finish_reason)
+    return events
+  }
+
+  function finish() {
+    const events = []
+    // Close any still-open blocks (text, then each tool block in order).
+    events.push(...closeTextBlock())
+    for (const entry of toolCalls.values()) {
+      events.push({ type: 'content_block_stop', index: entry.blockIndex })
+    }
+    const finalUsage = mapUsage(usage)
+    // message_delta carries the final stop_reason + usage; message_stop ends it.
+    events.push({ type: 'message_delta', delta: { stop_reason: stopReason }, usage: finalUsage })
+    events.push({ type: 'message_stop' })
+
+    const content = order.map((o) =>
+      o.type === 'text'
+        ? { type: 'text', text: o.ref.text }
+        : { type: 'tool_use', id: o.ref.id, name: o.ref.name, input: safeParseJson(o.ref.args) },
+    )
+    const finalMessage = {
+      id: messageId,
+      type: 'message',
+      role: 'assistant',
+      model,
+      content,
+      // If the model emitted tool calls but the server omitted a finish_reason,
+      // infer tool_use so the byok loop runs the tools.
+      stop_reason: stopReason ?? (toolCalls.size > 0 ? 'tool_use' : 'end_turn'),
+      stop_sequence: null,
+      usage: finalUsage,
+    }
+    return { events, finalMessage }
+  }
+
+  return { push, finish }
+}
+
+/** Parse accumulated tool-arguments JSON; empty/invalid → {} (never throw). */
+function safeParseJson(s) {
+  if (typeof s !== 'string' || s.trim() === '') return {}
+  try {
+    const v = JSON.parse(s)
+    return v && typeof v === 'object' ? v : {}
+  } catch {
+    return {}
+  }
+}

--- a/packages/server/src/anthropic-openai-translate.js
+++ b/packages/server/src/anthropic-openai-translate.js
@@ -260,37 +260,28 @@ export function createStreamTranslator() {
       events.push({ type: 'content_block_delta', index: textBlock.index, delta: { type: 'text_delta', text: delta.content } })
     }
 
-    // Tool-call deltas.
+    // Tool-call deltas. The block is NOT opened until BOTH id and name are
+    // known: a conformant OpenAI server sends them in the first tool_call delta,
+    // but a non-standard one (this module's whole point) may split them across
+    // chunks — emitting content_block_start eagerly would bake wrong/empty
+    // id/name into the streamed tool_start (dashboard label + any id-keyed
+    // correlation). So buffer args until we can start, then flush them. #6128.
     if (Array.isArray(delta.tool_calls)) {
       for (const tc of delta.tool_calls) {
         const oaIndex = typeof tc.index === 'number' ? tc.index : 0
         let entry = toolCalls.get(oaIndex)
         if (!entry) {
-          // A tool block begins — close any open text block first (Anthropic
-          // blocks don't overlap).
-          events.push(...closeTextBlock())
-          entry = { blockIndex: nextBlockIndex++, id: tc.id || '', name: tc.function?.name || '', args: '' }
+          entry = { blockIndex: null, id: tc.id || '', name: tc.function?.name || '', args: '', started: false, emittedLen: 0 }
           toolCalls.set(oaIndex, entry)
           order.push({ type: 'tool_use', ref: entry })
-          events.push({
-            type: 'content_block_start',
-            index: entry.blockIndex,
-            content_block: { type: 'tool_use', id: entry.id, name: entry.name, input: {} },
-          })
         } else {
-          // Late id/name (some servers send them split across chunks).
           if (!entry.id && tc.id) entry.id = tc.id
           if (!entry.name && tc.function?.name) entry.name = tc.function.name
         }
         const argFragment = tc.function?.arguments
-        if (typeof argFragment === 'string' && argFragment.length > 0) {
-          entry.args += argFragment
-          events.push({
-            type: 'content_block_delta',
-            index: entry.blockIndex,
-            delta: { type: 'input_json_delta', partial_json: argFragment },
-          })
-        }
+        if (typeof argFragment === 'string') entry.args += argFragment
+        events.push(...maybeStartToolBlock(entry))
+        events.push(...flushToolArgs(entry))
       }
     }
 
@@ -298,16 +289,59 @@ export function createStreamTranslator() {
     return events
   }
 
+  /**
+   * Open the tool_use block once id+name are known (close any open text block
+   * first — Anthropic blocks don't overlap). No-op until then, or once started.
+   */
+  function maybeStartToolBlock(entry) {
+    if (entry.started || !entry.id || !entry.name) return []
+    const events = closeTextBlock()
+    entry.blockIndex = nextBlockIndex++
+    entry.started = true
+    events.push({
+      type: 'content_block_start',
+      index: entry.blockIndex,
+      content_block: { type: 'tool_use', id: entry.id, name: entry.name, input: {} },
+    })
+    return events
+  }
+
+  /** Emit any buffered tool-arg JSON not yet streamed (only once started). */
+  function flushToolArgs(entry) {
+    if (!entry.started || entry.args.length <= entry.emittedLen) return []
+    const pending = entry.args.slice(entry.emittedLen)
+    entry.emittedLen = entry.args.length
+    return [{ type: 'content_block_delta', index: entry.blockIndex, delta: { type: 'input_json_delta', partial_json: pending } }]
+  }
+
   function finish() {
     const events = []
+    // A tool_call that never received both id+name (non-conformant server) is
+    // force-started now so its block + accumulated args still surface.
+    for (const entry of toolCalls.values()) {
+      if (!entry.started) {
+        events.push(...closeTextBlock())
+        entry.blockIndex = nextBlockIndex++
+        entry.started = true
+        events.push({
+          type: 'content_block_start',
+          index: entry.blockIndex,
+          content_block: { type: 'tool_use', id: entry.id, name: entry.name, input: {} },
+        })
+        events.push(...flushToolArgs(entry))
+      }
+    }
     // Close any still-open blocks (text, then each tool block in order).
     events.push(...closeTextBlock())
     for (const entry of toolCalls.values()) {
       events.push({ type: 'content_block_stop', index: entry.blockIndex })
     }
     const finalUsage = mapUsage(usage)
-    // message_delta carries the final stop_reason + usage; message_stop ends it.
-    events.push({ type: 'message_delta', delta: { stop_reason: stopReason }, usage: finalUsage })
+    // Resolve the stop_reason ONCE: if the server omitted finish_reason but the
+    // model emitted tool calls, infer tool_use so the byok loop runs the tools.
+    // Both message_delta and finalMessage carry this same value (no drift).
+    const effectiveStopReason = stopReason ?? (toolCalls.size > 0 ? 'tool_use' : 'end_turn')
+    events.push({ type: 'message_delta', delta: { stop_reason: effectiveStopReason }, usage: finalUsage })
     events.push({ type: 'message_stop' })
 
     const content = order.map((o) =>
@@ -321,9 +355,7 @@ export function createStreamTranslator() {
       role: 'assistant',
       model,
       content,
-      // If the model emitted tool calls but the server omitted a finish_reason,
-      // infer tool_use so the byok loop runs the tools.
-      stop_reason: stopReason ?? (toolCalls.size > 0 ? 'tool_use' : 'end_turn'),
+      stop_reason: effectiveStopReason,
       stop_sequence: null,
       usage: finalUsage,
     }

--- a/packages/server/tests/anthropic-openai-translate.test.js
+++ b/packages/server/tests/anthropic-openai-translate.test.js
@@ -46,6 +46,24 @@ describe('#5420 anthropicRequestToOpenAi', () => {
     assert.deepEqual(out.messages, [{ role: 'tool', tool_call_id: 'call_1', content: 'result text' }])
   })
 
+  it('keeps sibling text alongside tool_result as a following user message (#6128)', () => {
+    const out = anthropicRequestToOpenAi({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'call_1', content: 'done' },
+            { type: 'text', text: 'Now summarise. Do not call tools.' },
+          ],
+        },
+      ],
+    })
+    assert.deepEqual(out.messages, [
+      { role: 'tool', tool_call_id: 'call_1', content: 'done' },
+      { role: 'user', content: 'Now summarise. Do not call tools.' },
+    ])
+  })
+
   it('translates an assistant tool_use block to OpenAI tool_calls', () => {
     const out = anthropicRequestToOpenAi({
       messages: [{ role: 'assistant', content: [{ type: 'tool_use', id: 'call_1', name: 'grep', input: { q: 'x' } }] }],

--- a/packages/server/tests/anthropic-openai-translate.test.js
+++ b/packages/server/tests/anthropic-openai-translate.test.js
@@ -1,0 +1,189 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  anthropicRequestToOpenAi,
+  createStreamTranslator,
+  mapFinishReason,
+  mapUsage,
+} from '../src/anthropic-openai-translate.js'
+import { translateSdkEvent } from '../src/byok-event-translator.js'
+
+// Drive a chunk sequence through the translator; return ALL emitted Anthropic
+// SDK events (push events + finish events) and the final Message.
+function run(chunks) {
+  const tr = createStreamTranslator()
+  const events = []
+  for (const c of chunks) events.push(...tr.push(c))
+  const { events: tail, finalMessage } = tr.finish()
+  events.push(...tail)
+  return { events, finalMessage }
+}
+
+// Map emitted events through the REAL byok translator → the kinds the session
+// consumes. This proves the shim's output satisfies byok-event-translator's
+// contract end-to-end.
+function kinds(events) {
+  return events.map(translateSdkEvent).filter(Boolean).map((e) => e.kind)
+}
+
+describe('#5420 anthropicRequestToOpenAi', () => {
+  it('lifts the system prompt to a leading system message', () => {
+    const out = anthropicRequestToOpenAi({ model: 'gpt-x', max_tokens: 100, system: 'be terse', messages: [] })
+    assert.deepEqual(out.messages[0], { role: 'system', content: 'be terse' })
+    assert.equal(out.model, 'gpt-x')
+    assert.equal(out.max_tokens, 100)
+  })
+
+  it('passes through a plain string user message', () => {
+    const out = anthropicRequestToOpenAi({ messages: [{ role: 'user', content: 'hi' }] })
+    assert.deepEqual(out.messages, [{ role: 'user', content: 'hi' }])
+  })
+
+  it('translates a tool_result block to an OpenAI tool message', () => {
+    const out = anthropicRequestToOpenAi({
+      messages: [{ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'result text' }] }],
+    })
+    assert.deepEqual(out.messages, [{ role: 'tool', tool_call_id: 'call_1', content: 'result text' }])
+  })
+
+  it('translates an assistant tool_use block to OpenAI tool_calls', () => {
+    const out = anthropicRequestToOpenAi({
+      messages: [{ role: 'assistant', content: [{ type: 'tool_use', id: 'call_1', name: 'grep', input: { q: 'x' } }] }],
+    })
+    assert.equal(out.messages[0].role, 'assistant')
+    assert.deepEqual(out.messages[0].tool_calls, [
+      { id: 'call_1', type: 'function', function: { name: 'grep', arguments: '{"q":"x"}' } },
+    ])
+  })
+
+  it('maps tools (input_schema → parameters) and tool_choice', () => {
+    const out = anthropicRequestToOpenAi({
+      messages: [],
+      tools: [{ name: 'grep', description: 'search', input_schema: { type: 'object', properties: { q: {} } } }],
+      tool_choice: { type: 'any' },
+    })
+    assert.deepEqual(out.tools[0], {
+      type: 'function',
+      function: { name: 'grep', description: 'search', parameters: { type: 'object', properties: { q: {} } } },
+    })
+    assert.equal(out.tool_choice, 'required')
+  })
+
+  it('maps tool_choice {type:tool,name} to a function choice', () => {
+    const out = anthropicRequestToOpenAi({ messages: [], tool_choice: { type: 'tool', name: 'grep' } })
+    assert.deepEqual(out.tool_choice, { type: 'function', function: { name: 'grep' } })
+  })
+})
+
+describe('#5420 createStreamTranslator — text stream', () => {
+  it('emits the Anthropic event sequence + final message for a text turn', () => {
+    const { events, finalMessage } = run([
+      { id: 'm1', model: 'gpt-x', choices: [{ delta: { role: 'assistant', content: '' } }] },
+      { choices: [{ delta: { content: 'Hello' } }] },
+      { choices: [{ delta: { content: ' world' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+      { choices: [], usage: { prompt_tokens: 12, completion_tokens: 3 } },
+    ])
+    const types = events.map((e) => e.type)
+    assert.deepEqual(types, [
+      'message_start',
+      'content_block_start',
+      'content_block_delta',
+      'content_block_delta',
+      'content_block_stop',
+      'message_delta',
+      'message_stop',
+    ])
+    // Through the real byok translator:
+    assert.deepEqual(kinds(events), ['stream_start', 'stream_delta', 'stream_delta', 'content_block_stop', 'message_delta', 'result'])
+    assert.deepEqual(finalMessage.content, [{ type: 'text', text: 'Hello world' }])
+    assert.equal(finalMessage.stop_reason, 'end_turn')
+    assert.deepEqual(finalMessage.usage, {
+      input_tokens: 12,
+      output_tokens: 3,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+})
+
+describe('#5420 createStreamTranslator — tool call stream', () => {
+  it('accumulates a tool_call into a tool_use block with parsed input', () => {
+    const { events, finalMessage } = run([
+      { id: 'm2', model: 'gpt-x', choices: [{ delta: { role: 'assistant' } }] },
+      { choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_9', function: { name: 'grep', arguments: '' } }] } }] },
+      { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":' } }] } }] },
+      { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '"auth"}' } }] } }] },
+      { choices: [{ delta: {}, finish_reason: 'tool_calls' }], usage: { prompt_tokens: 20, completion_tokens: 8 } },
+    ])
+    // The tool block opens, streams JSON fragments, closes.
+    assert.deepEqual(kinds(events), [
+      'stream_start',
+      'tool_start',
+      'tool_input_delta',
+      'tool_input_delta',
+      'content_block_stop',
+      'message_delta',
+      'result',
+    ])
+    const toolStart = events.map(translateSdkEvent).find((e) => e?.kind === 'tool_start')
+    assert.equal(toolStart.toolName, 'grep')
+    assert.equal(toolStart.toolUseId, 'call_9')
+    // Final message carries the parsed tool_use block + tool_use stop reason.
+    assert.deepEqual(finalMessage.content, [{ type: 'tool_use', id: 'call_9', name: 'grep', input: { q: 'auth' } }])
+    assert.equal(finalMessage.stop_reason, 'tool_use')
+  })
+
+  it('handles two parallel tool calls as two tool_use blocks', () => {
+    const { finalMessage } = run([
+      { id: 'm3', choices: [{ delta: { role: 'assistant' } }] },
+      { choices: [{ delta: { tool_calls: [{ index: 0, id: 'a', function: { name: 'f1', arguments: '{}' } }] } }] },
+      { choices: [{ delta: { tool_calls: [{ index: 1, id: 'b', function: { name: 'f2', arguments: '{}' } }] } }] },
+      { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+    ])
+    assert.equal(finalMessage.content.length, 2)
+    assert.deepEqual(finalMessage.content.map((b) => b.name), ['f1', 'f2'])
+  })
+})
+
+describe('#5420 createStreamTranslator — mixed text then tool', () => {
+  it('closes the text block before opening the tool block', () => {
+    const { events, finalMessage } = run([
+      { id: 'm4', choices: [{ delta: { content: 'let me check' } }] },
+      { choices: [{ delta: { tool_calls: [{ index: 0, id: 'c', function: { name: 'grep', arguments: '{}' } }] } }] },
+      { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+    ])
+    const types = events.map((e) => e.type)
+    // text block_start+delta, then its block_stop BEFORE the tool block_start.
+    const textStop = types.indexOf('content_block_stop')
+    const toolStart = types.findIndex(
+      (t, i) => t === 'content_block_start' && events[i].content_block?.type === 'tool_use',
+    )
+    assert.ok(textStop > -1 && toolStart > -1 && textStop < toolStart, 'text block closes before tool opens')
+    assert.deepEqual(finalMessage.content.map((b) => b.type), ['text', 'tool_use'])
+  })
+})
+
+describe('#5420 mapFinishReason / mapUsage', () => {
+  it('maps finish reasons', () => {
+    assert.equal(mapFinishReason('stop'), 'end_turn')
+    assert.equal(mapFinishReason('tool_calls'), 'tool_use')
+    assert.equal(mapFinishReason('length'), 'max_tokens')
+    assert.equal(mapFinishReason(null), null)
+  })
+
+  it('maps usage incl. cached prompt tokens, defaulting missing fields', () => {
+    assert.deepEqual(mapUsage({ prompt_tokens: 5, completion_tokens: 2, prompt_tokens_details: { cached_tokens: 4 } }), {
+      input_tokens: 5,
+      output_tokens: 2,
+      cache_read_input_tokens: 4,
+      cache_creation_input_tokens: 0,
+    })
+    assert.deepEqual(mapUsage(undefined), {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    })
+  })
+})

--- a/packages/server/tests/anthropic-openai-translate.test.js
+++ b/packages/server/tests/anthropic-openai-translate.test.js
@@ -152,6 +152,41 @@ describe('#5420 createStreamTranslator — tool call stream', () => {
     assert.equal(finalMessage.stop_reason, 'tool_use')
   })
 
+  it('buffers args until id+name are known when a server splits them across chunks', () => {
+    const { events, finalMessage } = run([
+      { id: 'm5', choices: [{ delta: { role: 'assistant' } }] },
+      // First tool_call delta: index + args fragment, but NO id/name yet.
+      { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":' } }] } }] },
+      // id arrives.
+      { choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_x' }] } }] },
+      // name arrives — only now may the block open.
+      { choices: [{ delta: { tool_calls: [{ index: 0, function: { name: 'grep', arguments: '"x"}' } }] } }] },
+      { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+    ])
+    // content_block_start must NOT precede knowing id+name, and must carry the
+    // CORRECT id/name (not the empty values from the first fragment).
+    const start = events.find((e) => e.type === 'content_block_start' && e.content_block?.type === 'tool_use')
+    assert.equal(start.content_block.id, 'call_x')
+    assert.equal(start.content_block.name, 'grep')
+    // The buffered '{"q":' fragment is flushed once started; full input parses.
+    assert.deepEqual(finalMessage.content, [{ type: 'tool_use', id: 'call_x', name: 'grep', input: { q: 'x' } }])
+    // No content_block_delta appears before the content_block_start.
+    const startIdx = events.indexOf(start)
+    const earlyDelta = events.findIndex((e) => e.type === 'content_block_delta')
+    assert.ok(earlyDelta > startIdx, 'args deltas only after the block opens')
+  })
+
+  it('emits a consistent stop_reason in message_delta AND finalMessage when finish_reason is omitted', () => {
+    const { events, finalMessage } = run([
+      { id: 'm6', choices: [{ delta: { tool_calls: [{ index: 0, id: 'c', function: { name: 'f', arguments: '{}' } }] } }] },
+      // Server ends the stream with NO finish_reason (non-conformant).
+      { choices: [{ delta: {} }] },
+    ])
+    const md = events.find((e) => e.type === 'message_delta')
+    assert.equal(md.delta.stop_reason, 'tool_use', 'message_delta carries the inferred reason')
+    assert.equal(finalMessage.stop_reason, 'tool_use', 'finalMessage matches message_delta')
+  })
+
   it('handles two parallel tool calls as two tool_use blocks', () => {
     const { finalMessage } = run([
       { id: 'm3', choices: [{ delta: { role: 'assistant' } }] },


### PR DESCRIPTION
## Summary

**First slice of #5420** (option 1 — the `AnthropicShimClient`). Delivers the pure, I/O-free translation core that lets `ClaudeByokSession`'s agent loop reach **OpenAI-compatible** servers (LM Studio, vLLM, llama.cpp, OpenRouter, Groq, Together…) without forking the ~2000-line byok loop. The byok loop drives `@anthropic-ai/sdk`'s `messages.stream()`; this module is what a shim folds OpenAI chat-completions into underneath.

## What's here (`anthropic-openai-translate.js`)

- **`anthropicRequestToOpenAi(params)`** — request translation: `system` → leading system message; Anthropic content blocks (string / `tool_result` / assistant `tool_use`) fanned into OpenAI roles + `tool_calls`; `tools` (`input_schema`→`parameters`) + `tool_choice`.
- **`createStreamTranslator()`** — folds an OpenAI streaming response into the **raw Anthropic SDK event sequence** that `byok-event-translator.js` consumes (`message_start` / `content_block_start|delta|stop` / `message_delta` / `message_stop`) plus a `finalMessage()` (`{stop_reason, content incl. parsed tool_use, usage}`). Handles lazy text blocks, **parallel tool calls** (per-index accumulation of fragmented `arguments` JSON), text→tool block ordering, and usage mapping.
- **`mapFinishReason` / `mapUsage`** helpers.

## Why pure / how it's verified

Keeping the translation pure means it's fully fixture-testable with **no `openai` dependency and no live endpoint**. The 12 tests drive recorded OpenAI chunk sequences and — critically — **pipe the emitted events through the real `byok-event-translator`** to prove the output satisfies the consumer contract end-to-end:

- text turn → `stream_start / stream_delta×2 / content_block_stop / message_delta / result`
- tool call → `tool_start / tool_input_delta×2 / …`, final `tool_use` block with **parsed input**
- two parallel tool calls → two `tool_use` blocks
- mixed text→tool → text block closes before the tool block opens
- usage + finish-reason mapping (incl. cached prompt tokens)

## Scope / what's next (deliberately separate)

The thin **`openai`-client glue** (the `messages.stream` network wrapper) and **provider/config registration** (reusing #5419's config-driven entry shape) land in follow-up slices — both need a **real endpoint** for the #5420 fidelity spike (tool streaming / parallel calls / usage against actual servers), which can't be verified in CI. This PR is the verifiable foundation.

Part of #5420.