### PR TITLE
fix(desktop): surface actionable message when auto-start is on but no token

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1385,7 +1385,16 @@ pub fn run() {
                             }
                         });
                     }
-                    StartupAction::Skip => {}
+                    // #6124 — auto-start is on but no token yet. The pairing /
+                    // first-run flow normally mints one, but if it never
+                    // completes (wizard dismissed, token expected-but-absent)
+                    // the splash would hang forever — the same failure class
+                    // #6015 fixes on the client branch. Surface an actionable
+                    // message instead of a silent spinner.
+                    StartupAction::Skip => window::emit_server_error(
+                        app.handle(),
+                        "Auto-start is on but no access token was found. Complete pairing, or paste a token in Settings.",
+                    ),
                 }
             }
 
@@ -1755,8 +1764,10 @@ enum StartupAction {
     /// external server (e.g. an always-on launchd daemon) and navigate to its
     /// dashboard, instead of hanging on the "Still starting…" splash forever.
     AdoptExternal,
-    /// Auto-start is on but no token yet — nothing to do here (the pairing /
-    /// first-run flow mints one); avoids launching a tokenless server.
+    /// Auto-start is on but no token yet — do NOT launch a tokenless server
+    /// (the pairing / first-run flow mints one). #6124: the caller surfaces an
+    /// actionable "complete pairing" message rather than hanging on the splash
+    /// if that flow never completes.
     Skip,
 }
 


### PR DESCRIPTION
## Summary

Fixes the indefinite "Still starting…" splash hang when **auto-start is ON but no access token exists yet** — the parity gap surfaced (and deliberately left out of scope) by PR #6123 / #6015.

`StartupAction::Skip` (auto-start on, no token) did nothing at launch, relying on the pairing / first-run wizard to mint a token and trigger a start. If that flow never completes (wizard dismissed, or a token expected-but-absent), the app hangs on the splash forever — the **same failure class** #6015 fixes on the client (`AdoptExternal`) branch, just on the auto-start branch.

## Change

The `Skip` arm now calls `window::emit_server_error` with an actionable message:

> Auto-start is on but no access token was found. Complete pairing, or paste a token in Settings.

This matches the actionable errors the new `AdoptExternal` path emits. The **pure `startup_action` decision is unchanged** — `(true, false)` still returns `Skip`; only the call-site side effect changes. `StartOwn` / `AdoptExternal` parity is otherwise untouched.

## Testing

- `cargo build` — green (only pre-existing objc/cocoa deprecation warnings).
- `cargo test --lib` — 157 passed, 0 failed (the `startup_action_maps_each_mode` pure test is unchanged and still green).

## Acceptance

- [x] `autoStartServer:true` + no token → actionable message, not an indefinite spinner.
- [x] Existing `(true,true)`/`AdoptExternal`/`Skip` parity otherwise unchanged.

Closes #6124