### PR TITLE
feat(server): serve a terminal-down signal when the supervisor gives up

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -37,6 +37,11 @@ const CONFIG_SCHEMA = {
   allowedTools: 'array',
   noAuth: 'boolean',
   maxRestarts: 'number',
+  // #6022: ms the supervisor serves a terminal `status:'down'` health response
+  // (reason `supervisor_gave_up`) after exhausting its restart budget, before
+  // exiting — long enough for a polling client to latch the terminal state.
+  // 0 preserves the prior exit-immediately behaviour. Default 15000.
+  terminalDownGraceMs: 'number',
   tunnel: 'string',
   tunnelName: 'string',
   tunnelHostname: 'string',
@@ -1223,6 +1228,7 @@ function envKeyForConfig(key) {
     allowedTools: 'CHROXY_ALLOWED_TOOLS',
     noAuth: 'CHROXY_NO_AUTH',
     maxRestarts: 'CHROXY_MAX_RESTARTS',
+    terminalDownGraceMs: 'CHROXY_TERMINAL_DOWN_GRACE_MS',
     tunnel: 'CHROXY_TUNNEL',
     tunnelName: 'CHROXY_TUNNEL_NAME',
     tunnelHostname: 'CHROXY_TUNNEL_HOSTNAME',

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -593,7 +593,14 @@ export class Supervisor extends EventEmitter {
         // status so a polling client distinguishes "gave up" from the
         // recoverable "restarting" state (and from a silent port = asleep).
         if (this._terminalDown) {
-          res.writeHead(503, { 'Content-Type': 'application/json' })
+          // 200 (not 503) deliberately: the client health probe discards the
+          // body on a non-2xx response (`if (!res.ok) throw`) and keys off the
+          // `status` field — exactly as it does for the 200 `status:'restarting'`
+          // signal. A 503 would make this terminal-down body invisible to the
+          // reconnect ladder (#6023). The `status:'down'` field is the
+          // discriminator; selection still keys off `status:'ok'`, so a 'down'
+          // box is never mistaken for a healthy one.
+          res.writeHead(200, { 'Content-Type': 'application/json' })
           res.end(JSON.stringify({
             status: 'down',
             reason: 'supervisor_gave_up',

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -63,6 +63,18 @@ export class Supervisor extends EventEmitter {
     this._standbyServer = null
     this._standbyRetries = 0
     this._standbyRetryTimer = null
+    // #6022: terminal-down state. When the restart budget is exhausted the
+    // supervisor flips the standby server into a terminal `status:'down'`
+    // response (reason `supervisor_gave_up`) and serves it for a bounded grace
+    // window — long enough for a polling client to observe and latch the
+    // terminal state — before exiting. Configurable: 0 keeps the prior
+    // exit-immediately behaviour; a larger value extends the signal window.
+    this._terminalDown = false
+    this._terminalDownTimer = null
+    this._terminalDownGraceMs =
+      (typeof config.terminalDownGraceMs === 'number' && config.terminalDownGraceMs >= 0)
+        ? config.terminalDownGraceMs
+        : 15000
     this._shuttingDown = false
     this._draining = false
     this._childReady = false
@@ -528,7 +540,18 @@ export class Supervisor extends EventEmitter {
           } catch (pushErr) {
             this._log.error(`Failed to send push notification on supervisor exit: ${pushErr.message}`)
           }
-          this._exit(1)
+          // #6022: serve a terminal-down signal before exiting. The crash-looping
+          // child is dead, so there is no live WS path to broadcast a final
+          // shutdown through (the "dead-child problem"). Instead the supervisor —
+          // which still owns the port and the tunnel — flips the standby server
+          // into a terminal `status:'down'` response and serves it for a bounded
+          // grace window. A reconnecting client (local or remote, via the tunnel)
+          // polling /health during that window sees an explicit terminal-down
+          // status and can latch its "server appears down" state, instead of
+          // reconnect-looping forever once the port goes silent. After the grace
+          // window the supervisor exits(1) as before — freeing the port and
+          // preserving any outer launchd/KeepAlive recovery semantics.
+          this._serveTerminalDown()
           return
         }
 
@@ -565,6 +588,26 @@ export class Supervisor extends EventEmitter {
 
     this._standbyServer = createServer((req, res) => {
       if (req.method === 'GET' && (req.url === '/' || req.url === '/health')) {
+        // #6022: terminal-down — the restart budget is exhausted and the
+        // supervisor is about to exit. Report an explicit, non-transient down
+        // status so a polling client distinguishes "gave up" from the
+        // recoverable "restarting" state (and from a silent port = asleep).
+        if (this._terminalDown) {
+          res.writeHead(503, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({
+            status: 'down',
+            reason: 'supervisor_gave_up',
+            fatal: true,
+            metrics: {
+              supervisorUptimeS: Math.round((Date.now() - this._metrics.startedAt) / 1000),
+              totalRestarts: this._metrics.totalRestarts,
+              consecutiveRestarts: this._metrics.consecutiveRestarts,
+              lastExitReason: this._metrics.lastExitReason,
+              lastBackoffMs: this._metrics.lastBackoffMs,
+            },
+          }))
+          return
+        }
         // Calculate restart ETA: remaining backoff time + estimated child startup (~5s)
         // Uses actual scheduled time to account for elapsed wait since the restart was queued
         const STARTUP_ESTIMATE = 5000
@@ -629,6 +672,30 @@ export class Supervisor extends EventEmitter {
       this._standbyServer.close()
       this._standbyServer = null
     }
+  }
+
+  /**
+   * #6022 — the restart budget is exhausted. Bind the port (reusing the standby
+   * server, now in terminal-down mode) to serve an explicit
+   * `status:'down' reason:'supervisor_gave_up'` health response, hold it for the
+   * configured grace window so a polling client can observe and latch the
+   * terminal state, then exit(1). A grace of 0 preserves the prior
+   * exit-immediately behaviour (the terminal server is started and torn down on
+   * the next tick).
+   */
+  _serveTerminalDown() {
+    this._terminalDown = true
+    // Reuse the standby server machinery (incl. its EADDRINUSE retry) — the
+    // crash-looped child is dead, so the port is normally free. The handler
+    // serves the terminal-down body while `_terminalDown` is set.
+    this._startStandbyServer()
+    this._terminalDownTimer = setTimeout(() => {
+      this._terminalDownTimer = null
+      this._stopStandbyServer()
+      this._exit(1)
+    }, this._terminalDownGraceMs)
+    // Do NOT unref: this timer is the supervisor's last responsibility — the
+    // process must stay alive serving the terminal-down status until it fires.
   }
 
   /**
@@ -777,6 +844,9 @@ export class Supervisor extends EventEmitter {
     if (this._heartbeatInterval) clearInterval(this._heartbeatInterval)
     if (this._restartTimer) clearTimeout(this._restartTimer)
     if (this._deployResetTimer) { clearTimeout(this._deployResetTimer); this._deployResetTimer = null }
+    // #6022: a SIGINT/SIGTERM during the terminal-down grace window pre-empts it
+    // — drop the pending exit(1) timer; the shutdown path below exits(0) cleanly.
+    if (this._terminalDownTimer) { clearTimeout(this._terminalDownTimer); this._terminalDownTimer = null }
     this._log.info(`${signal} received, shutting down...`)
 
     // Remove PID file

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -684,6 +684,9 @@ export class Supervisor extends EventEmitter {
    * the next tick).
    */
   _serveTerminalDown() {
+    // Idempotent: the give-up branch is single-call by construction (the child
+    // is dead and not respawned), but guard defensively against a future caller.
+    if (this._terminalDown) return
     this._terminalDown = true
     // Reuse the standby server machinery (incl. its EADDRINUSE retry) — the
     // crash-looped child is dead, so the port is normally free. The handler

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -735,7 +735,9 @@ describe('Supervisor', () => {
       const body = await res.json()
 
       // Explicit, non-transient terminal-down signal — distinct from 'restarting'.
-      assert.equal(res.status, 503)
+      // 200 (not 503) so the client health probe (which discards non-2xx bodies)
+      // can read it; `status:'down'` is the discriminator (#6022 / #6023).
+      assert.equal(res.status, 200)
       assert.equal(body.status, 'down')
       assert.equal(body.reason, 'supervisor_gave_up')
       assert.equal(body.fatal, true)

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -144,6 +144,10 @@ function createTestSupervisor(overrides = {}) {
     pidFilePath: join(tmpDir, 'supervisor.pid'),
     knownGoodFile: join(tmpDir, 'known-good-ref'),
     maxRestarts: overrides.maxRestarts ?? 3, // low for fast tests
+    // #6022: default the terminal-down grace to 0 so give-up tests exit on the
+    // next tick (preserving the prior exit-immediately timing). Tests that
+    // assert the terminal-down signal set their own grace.
+    terminalDownGraceMs: overrides.terminalDownGraceMs ?? 0,
     ...overrides,
   }
 
@@ -708,6 +712,57 @@ describe('Supervisor', () => {
       assert.equal(body.status, 'restarting')
       assert.equal(body.metrics.totalRestarts, 3)
       assert.equal(body.metrics.lastBackoffMs, 5000)
+    })
+
+    it('serves a terminal down status after giving up (#6022)', async () => {
+      // Large grace so the timer does not fire mid-test; we probe then clean up.
+      const { supervisor } = setup({ terminalDownGraceMs: 60000 })
+      supervisor._port = 0
+      supervisor._metrics.totalRestarts = 7
+      supervisor._metrics.consecutiveRestarts = 4
+
+      supervisor._serveTerminalDown()
+      assert.equal(supervisor._terminalDown, true)
+      assert.ok(supervisor._standbyServer !== null)
+
+      await new Promise((resolve) => {
+        if (supervisor._standbyServer.listening) return resolve()
+        supervisor._standbyServer.on('listening', resolve)
+      })
+
+      const addr = supervisor._standbyServer.address()
+      const res = await fetch(`http://127.0.0.1:${addr.port}/health`)
+      const body = await res.json()
+
+      // Explicit, non-transient terminal-down signal — distinct from 'restarting'.
+      assert.equal(res.status, 503)
+      assert.equal(body.status, 'down')
+      assert.equal(body.reason, 'supervisor_gave_up')
+      assert.equal(body.fatal, true)
+      assert.equal(body.metrics.totalRestarts, 7)
+      assert.equal(body.metrics.consecutiveRestarts, 4)
+
+      // The grace timer is still pending — has not exited yet.
+      assert.equal(supervisor._exitCalled, null)
+
+      // Clean up the pending grace timer + socket.
+      clearTimeout(supervisor._terminalDownTimer)
+      supervisor._terminalDownTimer = null
+      supervisor._stopStandbyServer()
+    })
+
+    it('exits(1) after the terminal-down grace window elapses (#6022)', async () => {
+      const { supervisor } = setup({ terminalDownGraceMs: 0 })
+      supervisor._port = 0
+
+      await new Promise((resolve) => {
+        supervisor.once('test_exit', resolve)
+        supervisor._serveTerminalDown()
+      })
+
+      assert.equal(supervisor._exitCalled, 1)
+      // The standby socket is released as part of the exit sequence.
+      assert.equal(supervisor._standbyServer, null)
     })
 
     it('stops standby server when child becomes ready', () => {


### PR DESCRIPTION
## Summary

Fixes #6022 — when the supervisor exhausts its restart budget, live WS clients (local or remote, via the tunnel) get no terminal signal. Once the port goes silent they can't distinguish **"supervisor gave up"** from **"machine asleep / tunnel dead"**, so they reconnect-loop forever.

### The dead-child problem

The crash-looping child owns the `WsServer` and all WS connections. By the time the supervisor gives up, that child is — by definition of max-restarts — already dead, so there is **no live WS path** to broadcast a final `server_shutdown` through. #5698 deliberately did not try to reach into the dead child (racy/fragile).

### Mechanism (issue approach 1 + 2, non-fragile)

The supervisor still owns the **port** and the **tunnel**, and already binds the port to a standby health server (`status:"restarting"`) during restart windows. On give-up it now flips that standby into a **terminal** mode:

```
HTTP 503  { "status":"down", "reason":"supervisor_gave_up", "fatal":true, "metrics":{…} }
```

…and serves it for a **bounded grace window** (`terminalDownGraceMs`, default **15s** — ample for a polling client to observe and latch its terminal "server appears down" state), then `_exit(1)` as before.

### Why a bounded grace, not "never exit"

Keeping the supervisor alive forever would block any outer launchd/KeepAlive recovery (a fresh supervisor relaunch gets a fresh restart budget, the legitimate auto-recovery path). A bounded window gives clients a reliable terminal signal (15s ≫ any poll interval — long enough for the reconnect ladder to latch a sticky terminal phase) while preserving the existing eventual-exit/recovery semantics. Configurable: `0` keeps the prior exit-immediately behaviour; larger extends the window.

## Changes

- **`supervisor.js`** — `_serveTerminalDown()` + `_terminalDown` flag; the standby handler serves the terminal body while the flag is set; the grace timer is cleared in `shutdown()` so a SIGINT/SIGTERM during the window exits(0) cleanly.
- **`config.js`** — `terminalDownGraceMs` recognized (env `CHROXY_TERMINAL_DOWN_GRACE_MS`).
- **tests** — new: terminal-down body assertion (503/`down`/`supervisor_gave_up`/metrics) + exits(1)-after-grace; existing give-up tests default the grace to `0` (preserving prior exit-immediately timing).

The pure give-up decision (max-restarts threshold) is unchanged; only the side effect on exhaustion changes.

## Testing

- `supervisor.test.js` — 38 passed (2 new). All sibling supervisor test files green. `config.test.js` — 95 passed.
- Server custom lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) — green.

## Notes

- Pairs with the **client-side** reconnect-ladder terminal state (#6023), which consumes this `status:"down"` signal — that piece needs on-device (simulator) verification and is tracked separately.
- I did **not** add `supervisor_gave_up` to the `server_shutdown` WS reason enum (issue approach 3): this mechanism is HTTP-health-based, so there is still no non-fragile WS emit path to wire it to. Per the issue, the enum value should land *with* a real emit path — deferred until a WS consumer exists.

Closes #6022