### PR TITLE
fix(dashboard): reset flat primaryClientId on session switch (#5731 T2)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3188,6 +3188,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         lastResultCost: cached.lastResultCost,
         lastResultDuration: cached.lastResultDuration,
         isIdle: cached.isIdle,
+        // #5731 T2: mirror the per-session primary-owner into the flat slot too.
+        // `primaryClientId` is a FLAT ConnectionState field (the presence/"who's
+        // driving" badge reads it flat), so omitting it here left the PREVIOUS
+        // session's owner bleeding into the newly-selected session's UI until a
+        // `primary_changed`/`session_role` re-synced it — cross-session bleed.
+        // (thinkingLevel / sessionRole are per-session-read from sessionStates,
+        // not flat, so they don't bleed through the flat slot.)
+        primaryClientId: cached.primaryClientId,
         sessionNotifications: filteredNotifications,
       });
     } else {
@@ -3215,6 +3223,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         lastResultCost: null,
         lastResultDuration: null,
         isIdle: seedIsIdle,
+        // #5731 T2: reset the flat primary-owner so the previous session's owner
+        // doesn't bleed through during the server round-trip (cross-session
+        // bleed). Re-syncs from primary_changed/session_role once the switch
+        // lands. (thinkingLevel / sessionRole are per-session-read, not flat.)
+        primaryClientId: null,
         sessionNotifications: filteredNotifications,
       });
     }

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -798,6 +798,41 @@ describe('useConnectionStore', () => {
     useConnectionStore.setState({ sessions: [], activeSessionId: null, sessionStates: {}, messages: [] });
   });
 
+  it('switchSession resets the flat primaryClientId so it does not bleed across sessions (#5731 T2)', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const makeSession = (id: string) => ({
+      sessionId: id, name: id, cwd: '/tmp', type: 'cli' as const,
+      hasTerminal: false, model: null, permissionMode: null, isBusy: false,
+      createdAt: 0, conversationId: null,
+    });
+
+    // Session A is owned by client-a; switching to a session with cached state
+    // must adopt that session's owner (not retain A's), and switching to an
+    // uncached session must reset the flat owner to null.
+    useConnectionStore.setState({
+      sessions: [makeSession('session-a'), makeSession('session-b'), makeSession('session-c')],
+      activeSessionId: 'session-a',
+      primaryClientId: 'client-a',
+      sessionStates: {
+        'session-b': { ...createEmptySessionState(), primaryClientId: 'client-b' },
+      },
+    });
+
+    // Cached target → adopt the cached session's owner, not the prior one.
+    useConnectionStore.getState().switchSession('session-b');
+    expect(useConnectionStore.getState().primaryClientId).toBe('client-b');
+
+    // Uncached target → reset to null (no bleed of session-b's owner).
+    useConnectionStore.getState().switchSession('session-c');
+    expect(useConnectionStore.getState().primaryClientId).toBeNull();
+
+    // Cleanup
+    useConnectionStore.setState({
+      sessions: [], activeSessionId: null, sessionStates: {}, messages: [], primaryClientId: null,
+    });
+  });
+
   it('addMessage appends to messages array', async () => {
     const { useConnectionStore } = await import('./connection');
     const msg: ChatMessage = {


### PR DESCRIPTION
## Summary

Resets the flat `primaryClientId` on `switchSession` so it cannot carry a stale owner across sessions (audit finding #5731 T2).

`switchSession` optimistically mirrors a session's state into the flat connection slot but omitted `primaryClientId` — a **flat** `ConnectionState` field (`types.ts:792`). So after a switch the flat slot retained the **previous** session's owner until a `primary_changed` / `session_role` re-synced it.

## Severity (accurate scope)

The active-session presence badge reads the **per-session** `primaryClientId` via `resolveActivePrimaryClientId(activeSessionId, …)` (`ViewersIndicator.tsx:75`), which **ignores the flat slot whenever a session is active** (the deliberate #5281 ①.3 fix). So the active badge is already shielded from this bleed. The flat slot is consulted only in the **pre-session / default view**, and by any future direct flat consumer. This fix keeps the flat slot internally consistent and correct for those paths — it is correctness/hardening, not an active-badge user-visible bug on current main.

## Fix

Both branches of `switchSession` now handle `primaryClientId`:
- **cached target** → adopt the cached session's `primaryClientId`
- **uncached target** → reset to `null` (re-syncs from the server once the switch lands)

### Scope clarification
The audit listed `thinkingLevel` / `sessionRole` alongside, but those are **per-session-read** from `sessionStates` (SessionState / BaseSessionState fields, not flat `ConnectionState`) — they cannot bleed through the flat slot. Only `primaryClientId` is a flat-slot field. Verified against the type definitions.

## Testing

- New test (`store.test.ts`): cached-target adopts the cached owner, uncached-target resets to null.
- `npm run typecheck` clean; full dashboard suite **204 files / 3833 tests green**.

Related to #5731