### PR TITLE
feat(dashboard): Control Room Containers tab (consumes the containers survey)

### DIFF
--- a/packages/dashboard/src/components/ContainersStatusSection.test.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * ContainersStatusSection (#6133, epic #5530) — renderer tests.
+ *
+ * Covers the surface against a mocked `containers_status_snapshot`:
+ *   - empty / loading / not-connected states before the first snapshot
+ *   - summary chips render the per-bucket counts
+ *   - one group header per cwd + one row per container
+ *   - status tag accent maps running→ok, stopped→warn, error→bad, other→neutral
+ *   - stats cell renders cpu/mem or "—" when stats are null
+ *   - the docker-stats degradation note renders when present
+ *   - Refresh dispatches the request (and is disabled while loading)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ServerContainersStatusSnapshotMessage } from '@chroxy/protocol'
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      containersStatus: null,
+      containersStatusLoading: false,
+      connectionPhase: 'connected',
+      requestContainersStatus: () => false,
+    }),
+}))
+import { ContainersStatusSection } from './ContainersStatusSection'
+
+afterEach(cleanup)
+
+type ContainerEntry = ServerContainersStatusSnapshotMessage['containers'][number]
+
+function container(over: Partial<ContainerEntry> = {}): ContainerEntry {
+  return {
+    id: 'env-1',
+    name: 'web',
+    cwd: '/Users/me/Projects/app',
+    image: 'node:22-slim',
+    status: 'running',
+    backend: 'docker',
+    containerId: 'abcdef123456789',
+    composeProject: null,
+    sessionCount: 2,
+    createdAt: '2026-06-19T11:00:00.000Z',
+    uptimeMs: 3000000,
+    stats: { cpuPercent: 0.5, memBytes: 47400000, memPercent: 2.26 },
+    ...over,
+  }
+}
+
+function snapshot(over: Partial<ServerContainersStatusSnapshotMessage> = {}): ServerContainersStatusSnapshotMessage {
+  return {
+    type: 'containers_status_snapshot',
+    generatedAt: '2026-06-19T12:00:00.000Z',
+    summary: { total: 3, running: 2, stopped: 1, other: 0 },
+    containers: [
+      container({ id: 'env-1', name: 'web', cwd: '/Users/me/Projects/app', status: 'running' }),
+      container({ id: 'env-2', name: 'worker', cwd: '/Users/me/Projects/app', status: 'running' }),
+      container({
+        id: 'env-3',
+        name: 'api',
+        cwd: '/Users/me/Projects/other',
+        status: 'stopped',
+        backend: 'compose',
+        containerId: null,
+        composeProject: 'chroxy-env-3',
+        sessionCount: 0,
+        uptimeMs: null,
+        stats: null,
+      }),
+    ],
+    dockerStatsNote: null,
+    ...over,
+  }
+}
+
+describe('ContainersStatusSection — empty / loading / not-connected', () => {
+  it('renders the empty state with a Run survey button before the first snapshot', () => {
+    render(<ContainersStatusSection snapshot={null} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('containers-empty')).toBeTruthy()
+    expect(screen.getByTestId('containers-empty-refresh')).toBeTruthy()
+    expect(screen.queryByTestId('containers-table')).toBeNull()
+  })
+
+  it('renders a loading state', () => {
+    render(<ContainersStatusSection snapshot={null} loading={true} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('containers-empty').textContent).toContain('Running the containers survey')
+  })
+
+  it('shows a not-connected hint and disables Run survey when disconnected', () => {
+    render(<ContainersStatusSection snapshot={null} loading={false} connected={false} onRefresh={() => {}} />)
+    expect(screen.getByTestId('containers-not-connected')).toBeTruthy()
+    expect((screen.getByTestId('containers-empty-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+describe('ContainersStatusSection — populated', () => {
+  it('renders summary chips with the per-bucket counts', () => {
+    render(<ContainersStatusSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('containers-chip-count-total').textContent).toBe('3')
+    expect(screen.getByTestId('containers-chip-count-running').textContent).toBe('2')
+    expect(screen.getByTestId('containers-chip-count-stopped').textContent).toBe('1')
+  })
+
+  it('groups containers by cwd (one header per workdir) and a row per container', () => {
+    render(<ContainersStatusSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('container-cwd-/Users/me/Projects/app')).toBeTruthy()
+    expect(screen.getByTestId('container-cwd-/Users/me/Projects/other')).toBeTruthy()
+    expect(screen.getByTestId('container-row-env-1')).toBeTruthy()
+    expect(screen.getByTestId('container-row-env-2')).toBeTruthy()
+    expect(screen.getByTestId('container-row-env-3')).toBeTruthy()
+  })
+
+  it('maps status → tag accent', () => {
+    render(<ContainersStatusSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('container-status-env-1').getAttribute('data-accent')).toBe('ok') // running
+    expect(screen.getByTestId('container-status-env-3').getAttribute('data-accent')).toBe('warn') // stopped
+  })
+
+  it('error status renders the bad accent; an unknown status is neutral', () => {
+    const snap = snapshot({
+      summary: { total: 2, running: 0, stopped: 0, other: 2 },
+      containers: [
+        container({ id: 'e-err', status: 'error', cwd: '/c' }),
+        container({ id: 'e-weird', status: 'provisioning', cwd: '/c' }),
+      ],
+    })
+    render(<ContainersStatusSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('container-status-e-err').getAttribute('data-accent')).toBe('bad')
+    expect(screen.getByTestId('container-status-e-weird').getAttribute('data-accent')).toBe('neutral')
+  })
+
+  it('stats cell shows cpu/mem when present and "—" when null', () => {
+    render(<ContainersStatusSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    const running = screen.getByTestId('container-stats-env-1')
+    expect(running.textContent).toContain('0.5% cpu')
+    expect(running.textContent).toContain('MiB')
+    expect(screen.getByTestId('container-stats-env-3').textContent).toBe('—')
+  })
+
+  it('renders the docker-stats degradation note when present', () => {
+    render(<ContainersStatusSection snapshot={snapshot({ dockerStatsNote: 'docker stats unavailable: docker not found' })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('containers-stats-note').textContent).toContain('docker stats unavailable')
+  })
+
+  it('renders the no-containers row when the survey found nothing', () => {
+    render(<ContainersStatusSection snapshot={snapshot({ containers: [], summary: { total: 0, running: 0, stopped: 0, other: 0 } })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('containers-none')).toBeTruthy()
+  })
+})
+
+describe('ContainersStatusSection — refresh', () => {
+  it('dispatches onRefresh when Refresh is clicked', () => {
+    const onRefresh = vi.fn()
+    render(<ContainersStatusSection snapshot={snapshot()} loading={false} connected={true} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByTestId('containers-refresh'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables Refresh while loading and does not dispatch', () => {
+    const onRefresh = vi.fn()
+    render(<ContainersStatusSection snapshot={snapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
+    const btn = screen.getByTestId('containers-refresh') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    fireEvent.click(btn)
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/ContainersStatusSection.test.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.test.tsx
@@ -137,6 +137,27 @@ describe('ContainersStatusSection — populated', () => {
     expect(screen.getByTestId('container-stats-env-3').textContent).toBe('—')
   })
 
+  it('stats cell shows "—" when stats is present but every field is null', () => {
+    const snap = snapshot({
+      summary: { total: 1, running: 1, stopped: 0, other: 0 },
+      containers: [container({ id: 'e-null', stats: { cpuPercent: null, memBytes: null, memPercent: null } })],
+    })
+    render(<ContainersStatusSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('container-stats-e-null').textContent).toBe('—')
+  })
+
+  it('surfaces a degraded-survey error banner instead of looking like an empty survey', () => {
+    const snap = snapshot({
+      summary: { total: 0, running: 0, stopped: 0, other: 0 },
+      containers: [],
+      error: { code: 'SURVEY_FAILED', message: 'docker daemon unreachable' },
+    })
+    render(<ContainersStatusSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    const banner = screen.getByTestId('containers-error')
+    expect(banner.textContent).toContain('SURVEY_FAILED')
+    expect(banner.textContent).toContain('docker daemon unreachable')
+  })
+
   it('renders the docker-stats degradation note when present', () => {
     render(<ContainersStatusSection snapshot={snapshot({ dockerStatsNote: 'docker stats unavailable: docker not found' })} loading={false} connected={true} onRefresh={() => {}} />)
     expect(screen.getByTestId('containers-stats-note').textContent).toContain('docker stats unavailable')

--- a/packages/dashboard/src/components/ContainersStatusSection.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.tsx
@@ -101,7 +101,10 @@ function StatusTag({ container }: { container: ContainerEntry }) {
 /** Live resource cell: CPU% + memory, or "—" when stats are unavailable. */
 function StatsCell({ container }: { container: ContainerEntry }) {
   const { stats } = container
-  if (!stats) {
+  // null stats (not running / probe failed) OR a stats object whose individual
+  // fields are all null (the protocol allows each to be nullable) → "—", never a
+  // blank cell.
+  if (!stats || (stats.cpuPercent === null && stats.memBytes === null && stats.memPercent === null)) {
     return <td className="cr-dim" data-testid={`container-stats-${container.id}`}>—</td>
   }
   return (
@@ -238,6 +241,11 @@ export function ContainersStatusSection({
           <p className="cr-sub" data-testid="containers-sub">
             {snapshot.summary.total} container{snapshot.summary.total === 1 ? '' : 's'} across {groups.length} workdir
             {groups.length === 1 ? '' : 's'} — chroxy-managed environments only.
+          </p>
+        )}
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="containers-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
           </p>
         )}
         {snapshot?.dockerStatsNote && (

--- a/packages/dashboard/src/components/ContainersStatusSection.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.tsx
@@ -1,0 +1,318 @@
+/**
+ * ContainersStatusSection (#6133, epic #5530) — the "Containers" Control Room tab.
+ *
+ * Renders the host-wide survey of chroxy-managed containers & environments the
+ * server returns in a `containers_status_snapshot`: an eyebrow + title +
+ * subtitle, a row of summary chips (total / running / stopped / other), and a
+ * table of every environment grouped by its backing working directory (`cwd`),
+ * each row showing status, backend, image, attached-session count, uptime, and a
+ * best-effort `docker stats` snapshot (CPU% / memory).
+ *
+ * Lives next to the runner + integrations tables inside the Control Room (see
+ * ControlRoomView). Same pull-on-Refresh data flow as the sibling surveys: the
+ * Refresh button dispatches `containers_status_request` via the store's
+ * `requestContainersStatus`; the server replies with one
+ * `containers_status_snapshot` handled into `containersStatus`. No delta stream —
+ * each refresh replaces the whole survey.
+ *
+ * Status → accent:
+ *   - running → ok   (green)
+ *   - stopped/exited/error → warn/bad (amber/red)
+ *   - anything else → neutral
+ */
+import { useMemo } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { ServerContainersStatusSnapshotMessage } from '@chroxy/protocol'
+import { formatGeneratedAgo } from './ControlRoomSection'
+
+type Accent = 'ok' | 'warn' | 'bad' | 'neutral'
+
+type ContainerEntry = ServerContainersStatusSnapshotMessage['containers'][number]
+
+const STATUS_ACCENT: Record<string, Accent> = {
+  running: 'ok',
+  stopped: 'warn',
+  exited: 'warn',
+  error: 'bad',
+}
+
+function statusAccent(status: string): Accent {
+  return STATUS_ACCENT[status] ?? 'neutral'
+}
+
+interface SummaryChip {
+  key: keyof ServerContainersStatusSnapshotMessage['summary']
+  label: string
+  accent: Accent
+}
+
+// total first (neutral), then the buckets the operator scans (problems last).
+const SUMMARY_CHIPS: readonly SummaryChip[] = [
+  { key: 'total', label: 'Containers', accent: 'neutral' },
+  { key: 'running', label: 'Running', accent: 'ok' },
+  { key: 'stopped', label: 'Stopped', accent: 'warn' },
+  { key: 'other', label: 'Other', accent: 'bad' },
+]
+
+/** ISO date (no time) for the eyebrow, e.g. "2026-06-19". */
+function isoDate(iso: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
+  return m ? m[1]! : iso
+}
+
+/** Compact human uptime from ms: "2h 14m", "5m", "12s", or "—". */
+function formatUptime(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms) || ms < 0) return '—'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  const remM = m % 60
+  if (h < 24) return remM > 0 ? `${h}h ${remM}m` : `${h}h`
+  const d = Math.floor(h / 24)
+  const remH = h % 24
+  return remH > 0 ? `${d}d ${remH}h` : `${d}d`
+}
+
+/** Compact bytes ("45.2 MiB", "1.95 GiB", "512 B", or "—"). */
+function formatBytes(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes) || bytes < 0) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KiB', 'MiB', 'GiB', 'TiB']
+  let v = bytes / 1024
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v.toFixed(v < 10 ? 2 : 1)} ${units[i]}`
+}
+
+function StatusTag({ container }: { container: ContainerEntry }) {
+  const accent = statusAccent(container.status)
+  return (
+    <span className={`cr-tag cr-tag-${accent}`} data-testid={`container-status-${container.id}`} data-accent={accent}>
+      {container.status}
+    </span>
+  )
+}
+
+/** Live resource cell: CPU% + memory, or "—" when stats are unavailable. */
+function StatsCell({ container }: { container: ContainerEntry }) {
+  const { stats } = container
+  if (!stats) {
+    return <td className="cr-dim" data-testid={`container-stats-${container.id}`}>—</td>
+  }
+  return (
+    <td data-testid={`container-stats-${container.id}`}>
+      {stats.cpuPercent !== null && <span className="cr-mono">{stats.cpuPercent.toFixed(1)}% cpu</span>}
+      {stats.memBytes !== null && (
+        <span className="cr-dim cr-mono">
+          {stats.cpuPercent !== null ? ' · ' : ''}{formatBytes(stats.memBytes)}
+          {stats.memPercent !== null ? ` (${stats.memPercent.toFixed(1)}%)` : ''}
+        </span>
+      )}
+    </td>
+  )
+}
+
+function ContainerRow({ container }: { container: ContainerEntry }) {
+  return (
+    <tr data-testid={`container-row-${container.id}`}>
+      <td>
+        <b data-testid={`container-name-${container.id}`}>{container.name || container.id}</b>
+        <div className="cr-dim cr-mono cr-branch">
+          {container.backend}
+          {container.containerId ? ` · ${container.containerId.slice(0, 12)}` : ''}
+          {container.composeProject ? ` · ${container.composeProject}` : ''}
+        </div>
+      </td>
+      <td><StatusTag container={container} /></td>
+      <td className="cr-dim cr-mono">{container.image ?? '—'}</td>
+      <td className="cr-dim" data-testid={`container-sessions-${container.id}`}>
+        {container.sessionCount > 0 ? `${container.sessionCount}` : '—'}
+      </td>
+      <td className="cr-dim">{formatUptime(container.uptimeMs)}</td>
+      <StatsCell container={container} />
+    </tr>
+  )
+}
+
+interface CwdGroup {
+  cwd: string
+  containers: ContainerEntry[]
+}
+
+/** Group the flat container list by `cwd` (the backing repo), preserving order. */
+function groupByCwd(containers: readonly ContainerEntry[]): CwdGroup[] {
+  const order: string[] = []
+  const byCwd = new Map<string, ContainerEntry[]>()
+  for (const c of containers) {
+    const key = c.cwd || '(no workdir)'
+    if (!byCwd.has(key)) {
+      byCwd.set(key, [])
+      order.push(key)
+    }
+    byCwd.get(key)!.push(c)
+  }
+  return order.map((cwd) => ({ cwd, containers: byCwd.get(cwd)! }))
+}
+
+function CwdGroupRows({ group }: { group: CwdGroup }) {
+  return (
+    <>
+      <tr className="runner-repo-row" data-testid={`container-cwd-${group.cwd}`}>
+        <td colSpan={6}>
+          <b className="runner-repo-name cr-mono">{group.cwd}</b>
+          <span className="cr-dim"> · {group.containers.length} container{group.containers.length === 1 ? '' : 's'}</span>
+        </td>
+      </tr>
+      {group.containers.map((c) => (
+        <ContainerRow key={c.id} container={c} />
+      ))}
+    </>
+  )
+}
+
+export interface ContainersStatusSectionProps {
+  /** Latest snapshot, or null before the first one lands. Defaults to the store. */
+  snapshot?: ServerContainersStatusSnapshotMessage | null
+  /** True while a refresh is in flight. Defaults to the store flag. */
+  loading?: boolean
+  /** Whether the WS connection is up. Defaults to the store's connected phase. */
+  connected?: boolean
+  /** Refresh action. Defaults to the store's requestContainersStatus. */
+  onRefresh?: () => void
+  /** Injectable clock (epoch ms) for the "generated Nm ago" string. */
+  now?: () => number
+}
+
+export function ContainersStatusSection({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  now = Date.now,
+}: ContainersStatusSectionProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.containersStatus)
+  const storeLoading = useConnectionStore((s) => s.containersStatusLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestContainersStatus = useConnectionStore((s) => s.requestContainersStatus)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestContainersStatus
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const groups = useMemo(() => (snapshot ? groupByCwd(snapshot.containers) : []), [snapshot])
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+
+  return (
+    <div className="cr-section" data-testid="containers-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="containers-eyebrow">
+          host · containers &amp; environments{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h1 className="cr-title">Containers</h1>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="containers-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot && (
+          <p className="cr-sub" data-testid="containers-sub">
+            {snapshot.summary.total} container{snapshot.summary.total === 1 ? '' : 's'} across {groups.length} workdir
+            {groups.length === 1 ? '' : 's'} — chroxy-managed environments only.
+          </p>
+        )}
+        {snapshot?.dockerStatsNote && (
+          <p className="cr-dim" data-testid="containers-stats-note">{snapshot.dockerStatsNote}</p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="containers-generated">
+            {formatGeneratedAgo(generatedAtMs, now())}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="containers-empty">
+          {loading ? (
+            <span>Running the containers survey…</span>
+          ) : (
+            <>
+              <p>No containers survey yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="containers-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="containers-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot && (
+        <>
+          <div className="cr-chips" data-testid="containers-chips">
+            {SUMMARY_CHIPS.map((chip) => (
+              <span className="cr-chip" key={chip.key} data-testid={`containers-chip-${chip.key}`}>
+                {chip.accent !== 'neutral' && <span className={`cr-dot cr-dot-${chip.accent}`} aria-hidden="true" />}
+                {chip.label}: <b data-testid={`containers-chip-count-${chip.key}`}>{snapshot.summary[chip.key]}</b>
+              </span>
+            ))}
+          </div>
+
+          <section className="cr-table-wrap">
+            <table className="cr-table" data-testid="containers-table">
+              <thead>
+                <tr>
+                  <th>Container / backend</th>
+                  <th>Status</th>
+                  <th>Image</th>
+                  <th>Sessions</th>
+                  <th>Uptime</th>
+                  <th>Resources</th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshot.containers.length === 0 ? (
+                  <tr data-testid="containers-none">
+                    <td colSpan={6} className="cr-dim">
+                      No chroxy-managed containers or environments.
+                    </td>
+                  </tr>
+                ) : (
+                  groups.map((group) => <CwdGroupRows key={group.cwd} group={group} />)
+                )}
+              </tbody>
+            </table>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -40,6 +40,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
 import { RunnerStatusSection } from './RunnerStatusSection'
+import { ContainersStatusSection } from './ContainersStatusSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { SkillsInventorySection } from './SkillsInventorySection'
 import { MailboxPanel } from './MailboxPanel'
@@ -114,6 +115,19 @@ export const CONTROL_ROOM_TABS = [
     snapshotKey: 'runnerStatus',
     loadingKey: 'runnerStatusLoading',
     requestKey: 'requestRunnerStatus',
+  },
+  // #6133 (epic #5530): the Containers tab — host-wide survey of chroxy-managed
+  // containers & environments (Docker/Compose; k8s/rancher as validated) with
+  // state / image / uptime / session linkage / docker-stats. Same survey:true
+  // request/snapshot flow as the others; the #5546 staleness guard comes free.
+  {
+    key: 'containers',
+    label: 'Containers',
+    survey: true,
+    requestType: 'containers_status_request',
+    snapshotKey: 'containersStatus',
+    loadingKey: 'containersStatusLoading',
+    requestKey: 'requestContainersStatus',
   },
   {
     key: 'integrations',
@@ -364,6 +378,8 @@ export function ControlRoomView({
         <ControlRoomSection onInvestigate={onInvestigate} onOpenSession={onOpenSession} onConfigureRepo={onConfigureRepo} />
       ) : tab === 'runners' ? (
         <RunnerStatusSection />
+      ) : tab === 'containers' ? (
+        <ContainersStatusSection />
       ) : tab === 'integrations' ? (
         <IntegrationsSection />
       ) : tab === 'skills' ? (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -497,6 +497,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // runner_status_snapshot handler. Null until the first survey lands.
   runnerStatus: null,
   runnerStatusLoading: false,
+  // #6133 (epic #5530): Control Room containers & environments snapshot, fed by
+  // the containers_status_snapshot handler. Null until the first survey lands.
+  containersStatus: null,
+  containersStatusLoading: false,
   // #5499 (epic #5498): Control Room Integrations snapshot, fed by the
   // integration_status_snapshot handler. Null until the first survey lands.
   integrationStatus: null,
@@ -976,6 +980,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       set({ runnerStatusLoading: true });
       wsSend(socket, { type: 'runner_status_request' });
+      return true;
+    }
+    return false;
+  },
+
+  // #6133 (epic #5530): request a containers & environments survey. Mirrors
+  // requestRunnerStatus — flips containersStatusLoading and sends a
+  // containers_status_request; the reply is a single containers_status_snapshot
+  // handled into containersStatus. Returns false (and does NOT set loading) when
+  // the socket is closed.
+  requestContainersStatus: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ containersStatusLoading: true });
+      wsSend(socket, { type: 'containers_status_request' });
       return true;
     }
     return false;

--- a/packages/dashboard/src/store/dispatch-containers-status.test.ts
+++ b/packages/dashboard/src/store/dispatch-containers-status.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Integration test for the containers & environments Control Room wiring
+ * (#6133, epic #5530).
+ *
+ * Guards the wire path between the dashboard message handler and the store:
+ *   - `containers_status_snapshot` REPLACES `containersStatus` and clears
+ *     `containersStatusLoading`.
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state and
+ *     WITHOUT clearing the loading flag.
+ *   - a second snapshot wholesale-replaces the first (full picture, no merge).
+ *   - an empty-containers survey is a valid snapshot.
+ *
+ * Mirrors dispatch-runner-status.test.ts (the runner survey's sibling test).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerContainersStatusSnapshotMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    containersStatus: null,
+    containersStatusLoading: true,
+    messages: [],
+  }
+}
+
+function snapshot(over: Partial<ServerContainersStatusSnapshotMessage> = {}): ServerContainersStatusSnapshotMessage {
+  return {
+    type: 'containers_status_snapshot',
+    generatedAt: '2026-06-19T11:50:00.000Z',
+    summary: { total: 1, running: 1, stopped: 0, other: 0 },
+    containers: [
+      {
+        id: 'env-1',
+        name: 'web',
+        cwd: '/Users/me/Projects/app',
+        image: 'node:22-slim',
+        status: 'running',
+        backend: 'docker',
+        containerId: 'abcdef123456789',
+        composeProject: null,
+        sessionCount: 2,
+        createdAt: '2026-06-19T11:00:00.000Z',
+        uptimeMs: 3000000,
+        stats: { cpuPercent: 0.5, memBytes: 47400000, memPercent: 2.26 },
+      },
+    ],
+    dockerStatsNote: null,
+    ...over,
+  }
+}
+
+describe('containers status dispatch (#6133)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('applies containers_status_snapshot and clears the loading flag', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.containersStatus).not.toBeNull()
+    expect(s.containersStatus!.containers.map((c) => c.id)).toEqual(['env-1'])
+    expect(s.containersStatus!.summary.running).toBe(1)
+    expect(s.containersStatusLoading).toBe(false)
+  })
+
+  it('replaces a prior snapshot wholesale (no merge)', () => {
+    handleMessage(snapshot(), ctx() as never)
+    handleMessage(
+      snapshot({
+        summary: { total: 1, running: 0, stopped: 1, other: 0 },
+        containers: [
+          {
+            id: 'env-2',
+            name: 'api',
+            cwd: '/Users/me/Projects/other',
+            image: null,
+            status: 'stopped',
+            backend: 'compose',
+            containerId: null,
+            composeProject: 'chroxy-env-2',
+            sessionCount: 0,
+            createdAt: null,
+            uptimeMs: null,
+            stats: null,
+          },
+        ],
+      }),
+      ctx() as never,
+    )
+    expect(store.getState().containersStatus!.containers.map((c) => c.id)).toEqual(['env-2'])
+  })
+
+  it('drops a malformed snapshot without mutating state or clearing loading', () => {
+    const before = store.getState().containersStatus
+    // Missing required `summary`.
+    handleMessage(
+      { type: 'containers_status_snapshot', generatedAt: '2026-06-19T11:50:00.000Z', containers: [] },
+      ctx() as never,
+    )
+    expect(store.getState().containersStatus).toBe(before)
+    expect(store.getState().containersStatusLoading).toBe(true)
+  })
+
+  it('accepts an empty-containers survey as a valid snapshot', () => {
+    handleMessage(
+      snapshot({ containers: [], summary: { total: 0, running: 0, stopped: 0, other: 0 } }),
+      ctx() as never,
+    )
+    expect(store.getState().containersStatus!.containers).toEqual([])
+    expect(store.getState().containersStatusLoading).toBe(false)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2577,6 +2577,18 @@ function handleRunnerStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, 
 }
 
 /**
+ * #6133 (epic #5530) — containers & environments survey
+ * `containers_status_snapshot`: REPLACE the stored survey and clear the loading
+ * flag. Same defensive, full-replace, clear-loading-only-on-valid-parse contract
+ * as the host/runner survey handlers above.
+ */
+function handleContainersStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerContainersStatusSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ containersStatus: parsed.data, containersStatusLoading: false });
+}
+
+/**
  * #5499 (epic #5498) — Integrations survey `integration_status_snapshot`:
  * REPLACE the stored survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host and
@@ -2777,6 +2789,7 @@ const HANDLERS: Record<string, Handler> = {
   session_preset_snapshot: handleSessionPresetSnapshot,
   // #5253: self-hosted runner Control Room survey snapshot.
   runner_status_snapshot: handleRunnerStatusSnapshot,
+  containers_status_snapshot: handleContainersStatusSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
   skills_inventory_snapshot: handleSkillsInventorySnapshot,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -700,6 +700,20 @@ export interface ConnectionState {
   runnerStatusLoading: boolean;
 
   /**
+   * #6133 (epic #5530) — Control Room containers & environments survey: the
+   * latest `containers_status_snapshot` from the server. `null` until the first
+   * snapshot lands (the Containers section renders an empty/loading state).
+   * Replaced wholesale on each snapshot (full picture, no delta stream).
+   */
+  containersStatus: ServerContainersStatusSnapshotMessage | null;
+  /**
+   * #6133 — true between dispatching a `containers_status_request` and the
+   * matching `containers_status_snapshot` arriving, so the Containers-tab
+   * Refresh button can spin. Cleared when a snapshot lands.
+   */
+  containersStatusLoading: boolean;
+
+  /**
    * #5499 (epic #5498) — Control Room Integrations survey: the latest
    * `integration_status_snapshot` from the server (per-repo repo-memory
    * status). `null` until the first snapshot lands (the Integrations section
@@ -1312,6 +1326,13 @@ export interface ConnectionState {
   // message went on the wire (false = socket closed). Sets `runnerStatusLoading`
   // while in flight.
   requestRunnerStatus: () => boolean;
+
+  // #6133 (epic #5530): request a containers & environments survey. Dispatches a
+  // `containers_status_request`; the server replies with a single
+  // `containers_status_snapshot` handled into `containersStatus`. Returns whether
+  // the message went on the wire (false = socket closed). Sets
+  // `containersStatusLoading` while in flight.
+  requestContainersStatus: () => boolean;
 
   // #5499 (epic #5498): request an Integrations survey. Dispatches an
   // `integration_status_request`; the server replies with a single

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -709,7 +709,8 @@ export interface ConnectionState {
   /**
    * #6133 — true between dispatching a `containers_status_request` and the
    * matching `containers_status_snapshot` arriving, so the Containers-tab
-   * Refresh button can spin. Cleared when a snapshot lands.
+   * Refresh button can spin. Cleared when a VALID snapshot lands (a malformed
+   * payload is dropped and leaves this true, matching the sibling surveys).
    */
   containersStatusLoading: boolean;
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -80,7 +80,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'containers_status_snapshot', // #6133 (epic #5530) — Control Room containers & environments survey reply. Server contract (survey + handler) landed first; the dashboard Containers section (store + ControlRoomView tab + ContainersStatusSection) is the tracked follow-up slice, at which point this moves to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -151,6 +150,7 @@ const PLATFORM_SPECIFIC = {
   'activity_delta': 'dashboard',    // Control Room activity delta — see activity_snapshot above; dashboard-only for v1, mobile parity is Phase-2 per epic #5159
   'host_status_snapshot': 'dashboard', // Control Room Host/Repo Status survey reply (#5171 schema / #5174 server emitter / #5175 dashboard section) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5170
   'runner_status_snapshot': 'dashboard', // Control Room self-hosted runner survey reply (#5253) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'containers_status_snapshot': 'dashboard', // Control Room containers & environments survey reply (#6133, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_status_snapshot': 'dashboard', // Control Room Integrations survey reply (#5499, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_action_ack': 'dashboard', // Control Room Integrations Reindex action ack (#5500, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -141,6 +141,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'billing_canary',             // live billing-canary banner (#5821) — dashboard sidebar
   'byok_credentials_status',    // BYOK paste-API-key form (#4052) — dashboard-only for v1
   'cancel_activity_ack',        // Control Room cancel-click correlation ack (#5277)
+  'containers_status_snapshot', // Control Room containers & environments survey (#6133, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -189,9 +190,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'containers_status_snapshot',           // #6133 (epic #5530) Control Room containers survey — server contract
-                                          //   landed first; the dashboard Containers section is the tracked
-                                          //   follow-up slice, at which point this moves to DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second slice of **#6133** (epic #5530): the dashboard **Containers** Control Room tab that renders the containers & environments survey the server contract (slice 1, #6142) emits. Mirrors the runner/integration tab wiring exactly — this **closes #6133**.

## What's in this slice

- **store** — `containersStatus` + `containersStatusLoading` on `ConnectionState`, initial state, `requestContainersStatus()` action (sends `containers_status_request`, flips loading), and the `containers_status_snapshot` message-handler (Zod-validated full replace; clears loading only on a valid parse — same defensive contract as the host/runner handlers).
- **ControlRoomView** — a `CONTROL_ROOM_TABS` "Containers" descriptor (the #5546 auto-fetch + staleness guard come free from the registry) + the render branch.
- **`ContainersStatusSection.tsx`** — summary chips (total/running/stopped/other); containers **grouped by `cwd`**; each row shows status (accent-mapped: running→ok, stopped→warn, error→bad, other→neutral), backend, image, attached sessions, uptime, and the best-effort docker-stats CPU/mem; empty / loading / not-connected states + a docker-stats degradation note.
- **coverage** — `containers_status_snapshot` moved from the *unhandled* allowlists to the *dashboard* ones now that the dashboard handles it: `PLATFORM_SPECIFIC: 'dashboard'` (protocol handler-coverage) + `DASHBOARD_ONLY` (store-core protocol-type-coverage-lint). This is the planned promotion noted in #6142.

## Testing

- `dispatch-containers-status.test.ts` — wire path: apply/clear-loading, wholesale replace, drop-malformed (keeps loading), empty survey.
- `ContainersStatusSection.test.tsx` — empty/loading/not-connected, summary chips, cwd grouping, status→accent mapping (incl. error/unknown), stats cell (present + null), degradation note, refresh enable/disable.
- Full **dashboard (3849)** + **store-core (1679)** suites green; both typechecks clean; both coverage guards green.

Closes #6133