### PR TITLE
feat(dashboard): Control Room container lifecycle action buttons (#6134 slice 2)

### DIFF
--- a/packages/dashboard/src/components/ContainersStatusSection.test.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.test.tsx
@@ -21,6 +21,9 @@ vi.mock('../store/connection', () => ({
       containersStatusLoading: false,
       connectionPhase: 'connected',
       requestContainersStatus: () => false,
+      containerActioningIds: new Set<string>(),
+      containerActionResults: {},
+      sendContainersAction: () => false,
     }),
 }))
 import { ContainersStatusSection } from './ContainersStatusSection'
@@ -184,5 +187,103 @@ describe('ContainersStatusSection — refresh', () => {
     expect(btn.disabled).toBe(true)
     fireEvent.click(btn)
     expect(onRefresh).not.toHaveBeenCalled()
+  })
+})
+
+describe('ContainersStatusSection — lifecycle actions (#6134)', () => {
+  function renderWith(over: Partial<Parameters<typeof ContainersStatusSection>[0]> = {}) {
+    const onAction = vi.fn()
+    render(
+      <ContainersStatusSection
+        snapshot={snapshot()}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+        actioningIds={new Set()}
+        actionResults={{}}
+        onAction={onAction}
+        {...over}
+      />,
+    )
+    return onAction
+  }
+
+  it('Stop/Restart/Destroy render for a single-container docker env', () => {
+    renderWith()
+    expect(screen.getByTestId('container-stop-env-1')).toBeTruthy()
+    expect(screen.getByTestId('container-restart-env-1')).toBeTruthy()
+    expect(screen.getByTestId('container-destroy-env-1')).toBeTruthy()
+  })
+
+  it('hides Stop/Restart for a compose env (only Destroy remains)', () => {
+    renderWith()
+    // env-3 is the compose env (containerId null, composeProject set).
+    expect(screen.queryByTestId('container-stop-env-3')).toBeNull()
+    expect(screen.queryByTestId('container-restart-env-3')).toBeNull()
+    expect(screen.getByTestId('container-destroy-env-3')).toBeTruthy()
+  })
+
+  it('Stop dispatches immediately (no confirmation); Restart too', () => {
+    const onAction = renderWith()
+    fireEvent.click(screen.getByTestId('container-stop-env-1'))
+    expect(onAction).toHaveBeenCalledWith('env-1', 'stop')
+    fireEvent.click(screen.getByTestId('container-restart-env-1'))
+    expect(onAction).toHaveBeenCalledWith('env-1', 'restart')
+  })
+
+  it('Destroy opens a confirmation dialog and only dispatches on confirm', () => {
+    const onAction = renderWith()
+    fireEvent.click(screen.getByTestId('container-destroy-env-1'))
+    // Dialog is shown; nothing dispatched yet.
+    expect(screen.getByTestId('confirm-dialog')).toBeTruthy()
+    expect(onAction).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+    expect(onAction).toHaveBeenCalledWith('env-1', 'destroy')
+  })
+
+  it('Destroy cancel closes the dialog without dispatching', () => {
+    const onAction = renderWith()
+    fireEvent.click(screen.getByTestId('container-destroy-env-1'))
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'))
+    expect(onAction).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('confirm-dialog')).toBeNull()
+  })
+
+  it('Stop is disabled for a non-running container', () => {
+    const snap = snapshot({
+      summary: { total: 1, running: 0, stopped: 1, other: 0 },
+      containers: [container({ id: 'env-x', status: 'stopped' })],
+    })
+    renderWith({ snapshot: snap })
+    expect((screen.getByTestId('container-stop-env-x') as HTMLButtonElement).disabled).toBe(true)
+    // Restart and Destroy stay enabled (restart a stopped container is valid).
+    expect((screen.getByTestId('container-restart-env-x') as HTMLButtonElement).disabled).toBe(false)
+    expect((screen.getByTestId('container-destroy-env-x') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('an in-flight env disables all its buttons and shows Working…', () => {
+    renderWith({ actioningIds: new Set(['env-1']) })
+    expect((screen.getByTestId('container-stop-env-1') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('container-restart-env-1') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('container-destroy-env-1') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('container-action-pending-env-1').textContent).toContain('Working')
+  })
+
+  it('disconnected disables every action button', () => {
+    renderWith({ connected: false })
+    expect((screen.getByTestId('container-stop-env-1') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('container-destroy-env-1') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('renders a settled success outcome inline', () => {
+    renderWith({ actionResults: { 'env-1': { action: 'stop', status: 'stopped', error: null, at: 1 } } })
+    expect(screen.getByTestId('container-action-ok-env-1').textContent).toContain('stopped')
+  })
+
+  it('renders a settled failure outcome inline (role=alert)', () => {
+    renderWith({ actionResults: { 'env-1': { action: 'stop', status: null, error: 'docker stop failed', at: 1 } } })
+    const err = screen.getByTestId('container-action-error-env-1')
+    expect(err.textContent).toContain('docker stop failed')
+    expect(err.getAttribute('role')).toBe('alert')
   })
 })

--- a/packages/dashboard/src/components/ContainersStatusSection.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.tsx
@@ -20,12 +20,25 @@
  *   - stopped/exited/error → warn/bad (amber/red)
  *   - anything else → neutral
  */
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { ServerContainersStatusSnapshotMessage } from '@chroxy/protocol'
+import type { ContainerActionResult } from '../store/types'
 import { formatGeneratedAgo } from './ControlRoomSection'
+import { ConfirmDialog } from './ConfirmDialog'
 
 type Accent = 'ok' | 'warn' | 'bad' | 'neutral'
+
+/** The lifecycle actions the Containers tab can dispatch. */
+type ContainerAction = 'stop' | 'restart' | 'destroy'
+
+/** Human label for a settled action result (success path). */
+function actionResultLabel(result: ContainerActionResult): string {
+  if (result.action === 'destroy') return 'destroyed'
+  if (result.action === 'stop') return result.status === 'stopped' ? 'stopped' : (result.status ?? 'stopped')
+  if (result.action === 'restart') return result.status === 'running' ? 'restarted' : (result.status ?? 'restarted')
+  return result.status ?? 'done'
+}
 
 type ContainerEntry = ServerContainersStatusSnapshotMessage['containers'][number]
 
@@ -120,7 +133,100 @@ function StatsCell({ container }: { container: ContainerEntry }) {
   )
 }
 
-function ContainerRow({ container }: { container: ContainerEntry }) {
+/**
+ * Per-row lifecycle actions (#6134). Stop / Restart are only meaningful for a
+ * single-container docker environment (the server rejects compose + backends
+ * that don't implement the lifecycle), so they're hidden for compose envs;
+ * Destroy is always offered (gated behind a confirmation in the section).
+ * Buttons disable while this row's action is on the wire or the socket is down;
+ * the settled outcome (or failure) renders inline.
+ */
+function ContainerActionsCell({
+  container,
+  pending,
+  result,
+  connected,
+  onAction,
+}: {
+  container: ContainerEntry
+  pending: boolean
+  result: ContainerActionResult | undefined
+  connected: boolean
+  onAction: (action: ContainerAction) => void
+}) {
+  const lifecycleSupported = Boolean(container.containerId) && !container.composeProject
+  const isRunning = container.status === 'running'
+  const baseDisabled = pending || !connected
+  return (
+    <td data-testid={`container-actions-${container.id}`}>
+      <div className="cr-actions">
+        {lifecycleSupported && (
+          <button
+            type="button"
+            className="cr-action"
+            data-testid={`container-stop-${container.id}`}
+            disabled={baseDisabled || !isRunning}
+            onClick={() => onAction('stop')}
+            title={isRunning ? 'Stop this container' : 'Container is not running'}
+          >
+            Stop
+          </button>
+        )}
+        {lifecycleSupported && (
+          <button
+            type="button"
+            className="cr-action"
+            data-testid={`container-restart-${container.id}`}
+            disabled={baseDisabled}
+            onClick={() => onAction('restart')}
+            title="Restart this container"
+          >
+            Restart
+          </button>
+        )}
+        <button
+          type="button"
+          className="cr-action cr-action-danger"
+          data-testid={`container-destroy-${container.id}`}
+          disabled={baseDisabled}
+          onClick={() => onAction('destroy')}
+          title="Destroy this environment"
+        >
+          Destroy
+        </button>
+      </div>
+      {pending ? (
+        <span className="cr-dim" data-testid={`container-action-pending-${container.id}`}>
+          Working…
+        </span>
+      ) : result ? (
+        result.error ? (
+          <span className="cr-bad" data-testid={`container-action-error-${container.id}`} role="alert">
+            {result.error}
+          </span>
+        ) : (
+          <span className="cr-ok" data-testid={`container-action-ok-${container.id}`}>
+            {actionResultLabel(result)}
+          </span>
+        )
+      ) : null}
+    </td>
+  )
+}
+
+function ContainerRow({
+  container,
+  pending,
+  result,
+  connected,
+  onAction,
+}: {
+  container: ContainerEntry
+  pending: boolean
+  result: ContainerActionResult | undefined
+  connected: boolean
+  onAction: (environmentId: string, action: ContainerAction) => void
+}) {
   return (
     <tr data-testid={`container-row-${container.id}`}>
       <td>
@@ -138,6 +244,13 @@ function ContainerRow({ container }: { container: ContainerEntry }) {
       </td>
       <td className="cr-dim">{formatUptime(container.uptimeMs)}</td>
       <StatsCell container={container} />
+      <ContainerActionsCell
+        container={container}
+        pending={pending}
+        result={result}
+        connected={connected}
+        onAction={(action) => onAction(container.id, action)}
+      />
     </tr>
   )
 }
@@ -162,17 +275,36 @@ function groupByCwd(containers: readonly ContainerEntry[]): CwdGroup[] {
   return order.map((cwd) => ({ cwd, containers: byCwd.get(cwd)! }))
 }
 
-function CwdGroupRows({ group }: { group: CwdGroup }) {
+function CwdGroupRows({
+  group,
+  actioningIds,
+  actionResults,
+  connected,
+  onAction,
+}: {
+  group: CwdGroup
+  actioningIds: Set<string>
+  actionResults: Record<string, ContainerActionResult>
+  connected: boolean
+  onAction: (environmentId: string, action: ContainerAction) => void
+}) {
   return (
     <>
       <tr className="runner-repo-row" data-testid={`container-cwd-${group.cwd}`}>
-        <td colSpan={6}>
+        <td colSpan={7}>
           <b className="runner-repo-name cr-mono">{group.cwd}</b>
           <span className="cr-dim"> · {group.containers.length} container{group.containers.length === 1 ? '' : 's'}</span>
         </td>
       </tr>
       {group.containers.map((c) => (
-        <ContainerRow key={c.id} container={c} />
+        <ContainerRow
+          key={c.id}
+          container={c}
+          pending={actioningIds.has(c.id)}
+          result={actionResults[c.id]}
+          connected={connected}
+          onAction={onAction}
+        />
       ))}
     </>
   )
@@ -187,6 +319,16 @@ export interface ContainersStatusSectionProps {
   connected?: boolean
   /** Refresh action. Defaults to the store's requestContainersStatus. */
   onRefresh?: () => void
+  /** Environment ids with an in-flight action. Defaults to the store set. */
+  actioningIds?: Set<string>
+  /** Per-environment last action outcome. Defaults to the store map. */
+  actionResults?: Record<string, ContainerActionResult>
+  /**
+   * Dispatch a container lifecycle action. Defaults to the store's
+   * sendContainersAction. Destroy is always routed through the confirmation
+   * dialog before this is called.
+   */
+  onAction?: (environmentId: string, action: ContainerAction) => void
   /** Injectable clock (epoch ms) for the "generated Nm ago" string. */
   now?: () => number
 }
@@ -196,17 +338,39 @@ export function ContainersStatusSection({
   loading: loadingProp,
   connected: connectedProp,
   onRefresh: onRefreshProp,
+  actioningIds: actioningIdsProp,
+  actionResults: actionResultsProp,
+  onAction: onActionProp,
   now = Date.now,
 }: ContainersStatusSectionProps = {}) {
   const storeSnapshot = useConnectionStore((s) => s.containersStatus)
   const storeLoading = useConnectionStore((s) => s.containersStatusLoading)
   const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
   const requestContainersStatus = useConnectionStore((s) => s.requestContainersStatus)
+  const storeActioningIds = useConnectionStore((s) => s.containerActioningIds)
+  const storeActionResults = useConnectionStore((s) => s.containerActionResults)
+  const sendContainersAction = useConnectionStore((s) => s.sendContainersAction)
 
   const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
   const loading = loadingProp !== undefined ? loadingProp : storeLoading
   const connected = connectedProp !== undefined ? connectedProp : storeConnected
   const onRefresh = onRefreshProp ?? requestContainersStatus
+  const actioningIds = actioningIdsProp ?? storeActioningIds
+  const actionResults = actionResultsProp ?? storeActionResults
+  const onAction = onActionProp ?? sendContainersAction
+
+  // #6134: destroy is destructive — route it through a confirmation dialog,
+  // never straight to onAction. Holds the container awaiting confirmation
+  // (null = dialog closed). Stop/Restart dispatch immediately.
+  const [confirmDestroy, setConfirmDestroy] = useState<ContainerEntry | null>(null)
+  const handleRowAction = (environmentId: string, action: ContainerAction) => {
+    if (action === 'destroy') {
+      const target = snapshot?.containers.find((c) => c.id === environmentId) ?? null
+      setConfirmDestroy(target)
+      return
+    }
+    onAction(environmentId, action)
+  }
 
   const refreshDisabled = loading || !connected
   const handleRefresh = () => {
@@ -304,23 +468,54 @@ export function ContainersStatusSection({
                   <th>Sessions</th>
                   <th>Uptime</th>
                   <th>Resources</th>
+                  <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {snapshot.containers.length === 0 ? (
                   <tr data-testid="containers-none">
-                    <td colSpan={6} className="cr-dim">
+                    <td colSpan={7} className="cr-dim">
                       No chroxy-managed containers or environments.
                     </td>
                   </tr>
                 ) : (
-                  groups.map((group) => <CwdGroupRows key={group.cwd} group={group} />)
+                  groups.map((group) => (
+                    <CwdGroupRows
+                      key={group.cwd}
+                      group={group}
+                      actioningIds={actioningIds}
+                      actionResults={actionResults}
+                      connected={connected}
+                      onAction={handleRowAction}
+                    />
+                  ))
                 )}
               </tbody>
             </table>
           </section>
         </>
       )}
+
+      <ConfirmDialog
+        open={confirmDestroy !== null}
+        title="Destroy environment?"
+        danger
+        confirmLabel="Destroy"
+        message={
+          confirmDestroy ? (
+            <>
+              This permanently removes the container for{' '}
+              <b>{confirmDestroy.name || confirmDestroy.id}</b>
+              {confirmDestroy.cwd ? <> ({confirmDestroy.cwd})</> : null}. Any unsaved work inside it is lost.
+            </>
+          ) : null
+        }
+        onConfirm={() => {
+          if (confirmDestroy) onAction(confirmDestroy.id, 'destroy')
+          setConfirmDestroy(null)
+        }}
+        onCancel={() => setConfirmDestroy(null)}
+      />
     </div>
   )
 }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -516,6 +516,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #5502: relay Re-run pending/result buckets (separate from reindex).
   relayRerunningRepoPaths: new Set<string>(),
   relayRerunResults: {},
+  // #6134: container lifecycle action — in-flight environment ids + last
+  // outcome per environment for inline display (same lifecycle as reindex).
+  containerActioningIds: new Set<string>(),
+  containerActionResults: {},
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -1069,6 +1073,32 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     delete results[repoPath];
     set({ relayRerunningRepoPaths: pending, relayRerunResults: results });
     wsSend(socket, { type: 'integration_action', action: 'repo_relay_rerun', repoPath, runId, requestId });
+    return true;
+  },
+
+  // #6134 (epic #5530): run a container lifecycle action (stop / restart /
+  // destroy) for one surveyed environment. Same wire-or-nothing contract as
+  // sendRepoMemoryReindex: tag the request with an opaque requestId the server
+  // echoes on the `containers_action_ack` / CONTAINER_ACTION_FAILED
+  // session_error, and mark the environment pending ONLY when the request is
+  // genuinely on the wire — never queued offline (an action that drains
+  // seconds later would strand the row mid-action with no ack arriving). The
+  // environmentId is the survey's own id; the server re-validates it against
+  // the live EnvironmentManager set before any exec. The row's previous inline
+  // result is dropped so a stale outcome can't sit next to the pending state.
+  // Destroy confirmation lives in the UI — this just sends.
+  sendContainersAction: (environmentId: string, action: 'stop' | 'restart' | 'destroy'): boolean => {
+    const { socket } = get();
+    if (!environmentId) return false;
+    if (action !== 'stop' && action !== 'restart' && action !== 'destroy') return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const requestId = `container-action-${nextMessageId()}`;
+    const pending = new Set(get().containerActioningIds);
+    pending.add(environmentId);
+    const results = { ...get().containerActionResults };
+    delete results[environmentId];
+    set({ containerActioningIds: pending, containerActionResults: results });
+    wsSend(socket, { type: 'containers_action', action, environmentId, requestId });
     return true;
   },
 
@@ -1850,6 +1880,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().relayRerunningRepoPaths.size > 0) {
         set({ relayRerunningRepoPaths: new Set<string>() });
       }
+      // #6134: ditto for in-flight container lifecycle actions — the ack/failure
+      // is socket-scoped, so clear pending rows on a drop. (The server-side
+      // action keeps running; the next survey refresh shows its effect.)
+      if (get().containerActioningIds.size > 0) {
+        set({ containerActioningIds: new Set<string>() });
+      }
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
@@ -2121,6 +2157,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5502: relay re-run pending/result state goes with it.
       relayRerunningRepoPaths: new Set<string>(),
       relayRerunResults: {},
+      // #6134: container lifecycle action pending/result state goes with it.
+      containerActioningIds: new Set<string>(),
+      containerActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -2158,6 +2197,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5502: relay re-run pending/result state goes with it.
       relayRerunningRepoPaths: new Set<string>(),
       relayRerunResults: {},
+      // #6134: container lifecycle action pending/result state goes with it.
+      containerActioningIds: new Set<string>(),
+      containerActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-containers-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-containers-action.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Integration test for the container lifecycle action wiring (#6134, epic #5530).
+ *
+ * Guards the wire path between the dashboard message handler and the store:
+ *   - `containers_action_ack` clears the environment's pending state and records
+ *     the carried action + status for inline display.
+ *   - a malformed ack is dropped (Zod safeParse) without mutating state.
+ *   - a CONTAINER_ACTION_FAILED session_error clears the pending state for the
+ *     echoed environmentId and records the message as an inline error.
+ *   - other environments' pending state is never touched by an ack/error for one.
+ *
+ * Mirrors dispatch-integration-action.test.ts (the Reindex action's test).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+
+const ENV = 'env-web'
+const OTHER_ENV = 'env-api'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    containerActioningIds: new Set([ENV, OTHER_ENV]),
+    containerActionResults: {},
+    messages: [],
+  }
+}
+
+function ack(over: Record<string, unknown> = {}) {
+  return {
+    type: 'containers_action_ack',
+    action: 'stop',
+    environmentId: ENV,
+    requestId: 'ca-1',
+    status: 'stopped',
+    ...over,
+  }
+}
+
+describe('container action dispatch (#6134)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('containers_action_ack clears the pending state and records the action + status', () => {
+    handleMessage(ack(), ctx() as never)
+    const s = store.getState()
+    expect(s.containerActioningIds.has(ENV)).toBe(false)
+    expect(s.containerActioningIds.has(OTHER_ENV)).toBe(true) // other env untouched
+    expect(s.containerActionResults[ENV]).toBeDefined()
+    expect(s.containerActionResults[ENV]!.action).toBe('stop')
+    expect(s.containerActionResults[ENV]!.status).toBe('stopped')
+    expect(s.containerActionResults[ENV]!.error).toBeNull()
+  })
+
+  it('a destroy ack (status "destroyed") clears pending and records the outcome', () => {
+    handleMessage(ack({ action: 'destroy', status: 'destroyed' }), ctx() as never)
+    const s = store.getState()
+    expect(s.containerActioningIds.has(ENV)).toBe(false)
+    expect(s.containerActionResults[ENV]!.action).toBe('destroy')
+    expect(s.containerActionResults[ENV]!.status).toBe('destroyed')
+    expect(s.containerActionResults[ENV]!.error).toBeNull()
+  })
+
+  it('a null-status ack still clears pending and records the run', () => {
+    handleMessage(ack({ status: null }), ctx() as never)
+    const s = store.getState()
+    expect(s.containerActioningIds.has(ENV)).toBe(false)
+    expect(s.containerActionResults[ENV]!.status).toBeNull()
+    expect(s.containerActionResults[ENV]!.error).toBeNull()
+  })
+
+  it('drops a malformed ack (missing environmentId) without touching pending state', () => {
+    // environmentId is required — omitting it fails the schema, so no row clears.
+    handleMessage({ type: 'containers_action_ack', action: 'stop', status: 'stopped' }, ctx() as never)
+    const s = store.getState()
+    expect(s.containerActioningIds.has(ENV)).toBe(true)
+    expect(s.containerActionResults[ENV]).toBeUndefined()
+  })
+
+  it('an ack for an unknown future action still clears its echoed env (forward-compat)', () => {
+    // action is a permissive string (matches integration_action_ack) — a future
+    // server action this client somehow has pending should still resolve.
+    handleMessage(ack({ action: 'pause' }), ctx() as never)
+    const s = store.getState()
+    expect(s.containerActioningIds.has(ENV)).toBe(false)
+    expect(s.containerActionResults[ENV]!.action).toBe('pause')
+  })
+
+  it('CONTAINER_ACTION_FAILED session_error clears pending and records the inline error', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage(
+      {
+        type: 'session_error',
+        code: 'CONTAINER_ACTION_FAILED',
+        message: 'docker stop failed: No such container',
+        reason: 'stop-failed',
+        action: 'stop',
+        environmentId: ENV,
+        requestId: 'ca-1',
+      },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.containerActioningIds.has(ENV)).toBe(false)
+    expect(s.containerActioningIds.has(OTHER_ENV)).toBe(true) // other env untouched
+    expect(s.containerActionResults[ENV]!.error).toMatch(/No such container/)
+    expect(s.containerActionResults[ENV]!.status).toBeNull()
+    expect(s.containerActionResults[ENV]!.action).toBe('stop')
+  })
+
+  it('a CONTAINER_ACTION_FAILED without an environmentId leaves action state alone', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage(
+      { type: 'session_error', code: 'CONTAINER_ACTION_FAILED', message: 'boom' },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.containerActioningIds.has(ENV)).toBe(true)
+    expect(s.containerActionResults[ENV]).toBeUndefined()
+  })
+
+  it('a fresh ack replaces a previous inline error for the same environment', () => {
+    store.setState({
+      containerActionResults: { [ENV]: { action: 'stop', status: null, error: 'old failure', at: 1 } },
+    } as never)
+    handleMessage(ack(), ctx() as never)
+    expect(store.getState().containerActionResults[ENV]!.error).toBeNull()
+    expect(store.getState().containerActionResults[ENV]!.status).toBe('stopped')
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2678,6 +2678,45 @@ function handleIntegrationActionAck(msg: Record<string, unknown>, get: MsgGet, s
 }
 
 /**
+ * #6134 (epic #5530) — resolve one environment's pending container action:
+ * drop the environmentId from `containerActioningIds` and record the outcome
+ * (resulting status, or a failure message) in `containerActionResults` for
+ * inline display. Shared by the success ack and the CONTAINER_ACTION_FAILED
+ * session_error — the same clear-pending-on-either-outcome contract as the
+ * reindex / relay-rerun pairs.
+ */
+function resolveContainerAction(
+  get: MsgGet,
+  set: MsgSet,
+  environmentId: string,
+  result: { action: string; status: string | null; error: string | null },
+): void {
+  const pending = new Set(get().containerActioningIds);
+  pending.delete(environmentId);
+  set({
+    containerActioningIds: pending,
+    containerActionResults: { ...get().containerActionResults, [environmentId]: { ...result, at: Date.now() } },
+  });
+}
+
+/**
+ * #6134 — container lifecycle action success ack: positive confirmation that
+ * the `containers_action` stop / restart / destroy completed, echoing the
+ * request's environmentId (+ action + resulting status). A malformed ack is
+ * dropped (Zod safeParse) so the row keeps its honest pending state rather
+ * than clearing on a half-true message.
+ */
+function handleContainersActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerContainersActionAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  resolveContainerAction(get, set, parsed.data.environmentId, {
+    action: parsed.data.action,
+    status: parsed.data.status ?? null,
+    error: null,
+  });
+}
+
+/**
  * #5547: a `summarize_session_result` resolves the pending summarize promise
  * (keyed by the echoed requestId) so the awaiting create-session flow opens
  * with the brief seeded. The failure half (SUMMARIZE_FAILED) rejects the same
@@ -2796,6 +2835,9 @@ const HANDLERS: Record<string, Handler> = {
   // #5500: positive ack correlating an integration_action (repo-memory
   // Reindex) request to its outcome.
   integration_action_ack: handleIntegrationActionAck,
+  // #6134 (epic #5530): positive ack correlating a containers_action (stop /
+  // restart / destroy) request to its outcome.
+  containers_action_ack: handleContainersActionAck,
   // #5547: one-shot session-summary result; resolves the pending summarize
   // promise so the create-session flow can open with the brief seeded.
   summarize_session_result: handleSummarizeSessionResult,
@@ -3506,6 +3548,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             error: parsed.message || 'Reindex failed.',
           });
         }
+      } else if (parsed.code === 'CONTAINER_ACTION_FAILED' && typeof msg.environmentId === 'string') {
+        // #6134: a failed containers_action echoes the exact environmentId
+        // (and action) — clear that row's pending state and surface the reason
+        // inline (the generic branch below still raises the toast, matching the
+        // INTEGRATION_ACTION_FAILED precedent). status is null on failure.
+        resolveContainerAction(get, set, msg.environmentId, {
+          action: typeof msg.action === 'string' ? msg.action : '',
+          status: null,
+          error: parsed.message || 'Container action failed.',
+        });
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {
         const crashedId = parsed.sessionPatch.sessionId;

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -650,6 +650,45 @@ describe('useConnectionStore', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('#6134: sendContainersAction marks the env pending, clears its stale result, and sends', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const send = vi.fn();
+    const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+    useConnectionStore.setState({
+      socket: openSocket,
+      containerActioningIds: new Set(),
+      containerActionResults: { 'env-web': { action: 'stop', status: null, error: 'old failure', at: 1 } },
+    });
+
+    const result = useConnectionStore.getState().sendContainersAction('env-web', 'restart');
+
+    expect(result).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse((send.mock.calls[0]![0]) as string);
+    expect(payload.type).toBe('containers_action');
+    expect(payload.action).toBe('restart');
+    expect(payload.environmentId).toBe('env-web');
+    expect(typeof payload.requestId).toBe('string');
+    expect(useConnectionStore.getState().containerActioningIds.has('env-web')).toBe(true);
+    // A fresh request invalidates the previous inline result for the env.
+    expect(useConnectionStore.getState().containerActionResults['env-web']).toBeUndefined();
+  });
+
+  it('#6134: sendContainersAction is a no-op offline, with an empty id, or an unknown action', async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({ socket: null, containerActioningIds: new Set(), containerActionResults: {} });
+    expect(useConnectionStore.getState().sendContainersAction('env-web', 'stop')).toBe(false);
+    expect(useConnectionStore.getState().containerActioningIds.has('env-web')).toBe(false);
+
+    const send = vi.fn();
+    const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: openSocket });
+    // empty id and an out-of-enum action both reject without sending.
+    expect(useConnectionStore.getState().sendContainersAction('', 'stop')).toBe(false);
+    expect(useConnectionStore.getState().sendContainersAction('env-web', 'frob' as never)).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it('exposes all required actions', async () => {
     const { useConnectionStore } = await import('./connection');
     const state = useConnectionStore.getState();

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -551,6 +551,21 @@ export interface RelayRerunResult {
   at: number;
 }
 
+/**
+ * #6134 (epic #5530) — outcome of the last container lifecycle action
+ * (stop / restart / destroy) for one environment, kept for inline display in
+ * its Containers row. A successful `containers_action_ack` records the echoed
+ * `action` + resulting `status` with `error: null`; a CONTAINER_ACTION_FAILED
+ * session_error records the message with `status: null`. `at` is the local
+ * receipt time (epoch ms).
+ */
+export interface ContainerActionResult {
+  action: string;
+  status: string | null;
+  error: string | null;
+  at: number;
+}
+
 export interface ConnectionState {
   // Connection
   connectionPhase: ConnectionPhase;
@@ -770,6 +785,20 @@ export interface ConnectionState {
    * the Integrations row. Replaced when the repo is re-run again.
    */
   relayRerunResults: Record<string, RelayRerunResult>;
+  /**
+   * #6134 (epic #5530) — environment ids with an in-flight `containers_action`
+   * (stop / restart / destroy): set when sendContainersAction is called,
+   * cleared on the `containers_action_ack` / CONTAINER_ACTION_FAILED
+   * session_error. Keyed by environmentId so each row's buttons disable
+   * independently while their action is on the wire.
+   */
+  containerActioningIds: Set<string>;
+  /**
+   * #6134 — last container lifecycle action outcome per environment id, for
+   * inline display in the Containers row. Replaced when the row is actioned
+   * again.
+   */
+  containerActionResults: Record<string, ContainerActionResult>;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;
@@ -1367,6 +1396,17 @@ export interface ConnectionState {
   // `relayRerunResults` entry) ONLY when the message actually went on the
   // wire; an offline send (or a non-integer runId) returns false.
   sendRepoRelayRerun: (repoPath: string, runId: number) => boolean;
+
+  // #6134 (epic #5530): run a container lifecycle action (stop / restart /
+  // destroy) for one surveyed environment. Dispatches a `containers_action`
+  // tagged with a requestId the server echoes on the `containers_action_ack`
+  // / CONTAINER_ACTION_FAILED session_error. Marks the environment in
+  // `containerActioningIds` (and drops its stale `containerActionResults`
+  // entry) ONLY when the message actually went on the wire — an offline send
+  // (or an empty environmentId / unknown action) returns false without
+  // queuing, so the row can't strand mid-action. Destroy confirmation is the
+  // caller's responsibility (the UI gates it behind a ConfirmDialog).
+  sendContainersAction: (environmentId: string, action: 'stop' | 'restart' | 'destroy') => boolean;
 
   // #5547: request a server-side one-shot summary of a session's persisted
   // history (the sidebar "Summarize & start new session" action). Dispatches a

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9986,6 +9986,25 @@ button.sidebar-token-view-session-row:hover {
   background: var(--accent-orange-subtle);
 }
 
+/* #6134 — the destructive "Destroy" row action (container lifecycle). Tinted
+ * red so the irreversible action reads at a glance, sharing .cr-action's
+ * geometry with Stop/Restart. */
+.cr-action-danger {
+  border-color: var(--accent-red-border);
+  color: var(--accent-red);
+}
+.cr-action-danger:hover:not(:disabled) {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+  background: var(--accent-red-subtle);
+}
+
+/* #6134 — disabled row actions (in-flight, socket down, or not applicable). */
+.cr-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 
 /* #5553 — per-repo session preset disclosure (create-session modal) + drawer. */
 .cr-action-gear {

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -80,7 +80,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'containers_action_ack', // #6134 (epic #5530) — Control Room container lifecycle action ack. Server contract (handler + action) landed first; the dashboard action buttons (which consume the ack to clear pending row state) are the tracked follow-up slice, at which point this moves to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -154,6 +153,7 @@ const PLATFORM_SPECIFIC = {
   'containers_status_snapshot': 'dashboard', // Control Room containers & environments survey reply (#6133, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_status_snapshot': 'dashboard', // Control Room Integrations survey reply (#5499, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_action_ack': 'dashboard', // Control Room Integrations Reindex action ack (#5500, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'containers_action_ack': 'dashboard', // Control Room container lifecycle action ack (#6134, epic #5530) — the dashboard consumes it to clear pending row state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'mailbox_status_snapshot': 'dashboard', // Control Room "Mailbox" tab survey reply (#5914 follow-up) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -142,6 +142,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'byok_credentials_status',    // BYOK paste-API-key form (#4052) — dashboard-only for v1
   'cancel_activity_ack',        // Control Room cancel-click correlation ack (#5277)
   'containers_status_snapshot', // Control Room containers & environments survey (#6133, epic #5530) — dashboard-only
+  'containers_action_ack',      // Control Room container lifecycle action ack (#6134, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -190,9 +191,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'containers_action_ack',                // #6134 (epic #5530) Control Room container lifecycle action ack —
-                                          //   server contract landed first; the dashboard action buttons that
-                                          //   consume the ack are the tracked follow-up, then this → DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 2 of **#6134** (epic #5530) — the dashboard surface for the container lifecycle actions whose server contract shipped in #6145 (`ae6934986`). Per-row **Stop / Restart / Destroy** buttons on the Control Room **Containers** tab.

## What changed

- **`ContainersStatusSection`** — a new **Actions** column. Stop/Restart render only for single-container docker envs (compose envs get **Destroy** only, mirroring the server's `EnvironmentManager.stop/restart` compose/backend guards). Stop disables when the container isn't running; every button disables while the row's action is in flight or the socket is down. **Destroy is destructive → routed through a `ConfirmDialog`** that names the target; it never dispatches straight to the action.
- **Store (`connection.ts`/`types.ts`)** — `sendContainersAction(environmentId, action)` clones the reindex/relay wire-or-nothing contract: tag with a `requestId` the server echoes, mark the env pending **only** when the message is genuinely on the wire (never queued offline — would strand the row mid-action), drop the stale inline result. New `containerActioningIds` / `containerActionResults` buckets, cleared on disconnect/forget.
- **`message-handler.ts`** — `containers_action_ack` resolves the pending row (echoed action + status); `CONTAINER_ACTION_FAILED` `session_error` clears it with the inline failure message. Both keyed by the echoed `environmentId` so one row's outcome can't clobber another's.
- **Coverage guards** — `containers_action_ack` promoted from the unhandled allowlists → `dashboard`/`DASHBOARD_ONLY` in both the protocol `handler-coverage.test.js` and the store-core `protocol-type-coverage-lint.test.ts`.
- **CSS** — `.cr-action-danger` (red Destroy) + `.cr-action:disabled`, reusing the existing `.cr-action` row-action geometry and `--accent-red*` tokens.

## Mutating-action discipline (server side, already merged in #6145)

Host-authority gate · survey-membership validation (env id must name a live `EnvironmentManager` env; client id is a lookup key, never a trusted target) · per-env in-flight guard + global cap · exactly-once ack/error correlation by `requestId`. The UI adds the destroy **confirmation affordance** required by the issue's acceptance criteria.

## Tests

- `dispatch-containers-action.test.ts` (new) — ack clears pending + records action/status; destroy ack; null-status; malformed-ack drop; forward-compat unknown action; `CONTAINER_ACTION_FAILED` clears + records inline error; missing-environmentId no-op; fresh ack replaces stale error; other envs untouched.
- `store.test.ts` — `sendContainersAction` pending+clear-stale+send; no-op offline / empty id / unknown action.
- `ContainersStatusSection.test.tsx` — buttons render (docker) / compose hides Stop+Restart; Stop/Restart dispatch immediately; Destroy confirm-gated (confirm dispatches, cancel doesn't); Stop disabled when not running; in-flight disables all + "Working…"; disconnected disables all; inline success/failure (role=alert) outcomes.
- Green: dashboard **3871** + typecheck, store-core **1679** (coverage guard incl.), protocol **340** (handler-coverage incl.).

Closes #6134