### PR TITLE
feat(dashboard): Control Room Repo Runtime Config tab (#6139 slice 2)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -41,6 +41,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
 import { RunnerStatusSection } from './RunnerStatusSection'
 import { ContainersStatusSection } from './ContainersStatusSection'
+import { RepoRuntimeConfigSection } from './RepoRuntimeConfigSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { SkillsInventorySection } from './SkillsInventorySection'
 import { MailboxPanel } from './MailboxPanel'
@@ -128,6 +129,20 @@ export const CONTROL_ROOM_TABS = [
     snapshotKey: 'containersStatus',
     loadingKey: 'containersStatusLoading',
     requestKey: 'requestContainersStatus',
+  },
+  // #6139 (epic #5530): the Repo Runtime Config tab — read-only, per-repo view
+  // of what governs container runtimes (devcontainer/compose presence, the image
+  // a repo would run + the allowlist verdict) plus host-level defaults (effective
+  // backend, isolation order, image allowlist). Same survey:true request/snapshot
+  // flow as the others; the #5546 staleness guard comes free.
+  {
+    key: 'repo-config',
+    label: 'Repo runtime config',
+    survey: true,
+    requestType: 'repo_runtime_config_request',
+    snapshotKey: 'repoRuntimeConfig',
+    loadingKey: 'repoRuntimeConfigLoading',
+    requestKey: 'requestRepoRuntimeConfig',
   },
   {
     key: 'integrations',
@@ -380,6 +395,8 @@ export function ControlRoomView({
         <RunnerStatusSection />
       ) : tab === 'containers' ? (
         <ContainersStatusSection />
+      ) : tab === 'repo-config' ? (
+        <RepoRuntimeConfigSection />
       ) : tab === 'integrations' ? (
         <IntegrationsSection />
       ) : tab === 'skills' ? (

--- a/packages/dashboard/src/components/RepoRuntimeConfigSection.test.tsx
+++ b/packages/dashboard/src/components/RepoRuntimeConfigSection.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * RepoRuntimeConfigSection (#6139, epic #5530) — renderer tests.
+ *
+ * Covers the read-only surface against a mocked `repo_runtime_config_snapshot`:
+ *   - empty / loading / not-connected states before the first snapshot
+ *   - host-level defaults (backend + source, isolation, allowlist) render
+ *   - summary chips render the per-bucket counts
+ *   - one row per repo with devcontainer/compose presence, image + source
+ *   - the allowlist verdict: allowed / denied / n-a (default image)
+ *   - a per-repo error row, and the degraded-survey error banner
+ *   - Refresh dispatches the request (and is disabled while loading)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ServerRepoRuntimeConfigSnapshotMessage } from '@chroxy/protocol'
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      repoRuntimeConfig: null,
+      repoRuntimeConfigLoading: false,
+      connectionPhase: 'connected',
+      requestRepoRuntimeConfig: () => false,
+    }),
+}))
+import { RepoRuntimeConfigSection } from './RepoRuntimeConfigSection'
+
+afterEach(cleanup)
+
+type RepoEntry = ServerRepoRuntimeConfigSnapshotMessage['repos'][number]
+
+function repo(over: Partial<RepoEntry> = {}): RepoEntry {
+  return {
+    name: 'app',
+    path: '/Users/me/Projects/app',
+    devcontainer: { present: true, path: '/Users/me/Projects/app/.devcontainer/devcontainer.json' },
+    compose: { present: false, files: [] },
+    image: 'node:22',
+    imageSource: 'devcontainer',
+    imageAllowed: true,
+    error: null,
+    ...over,
+  }
+}
+
+function snapshot(over: Partial<ServerRepoRuntimeConfigSnapshotMessage> = {}): ServerRepoRuntimeConfigSnapshotMessage {
+  return {
+    type: 'repo_runtime_config_snapshot',
+    generatedAt: '2026-06-19T12:00:00.000Z',
+    backend: 'docker',
+    backendSource: 'default',
+    isolation: 'worktree-before-docker',
+    allowlist: { source: 'default', patterns: ['node:*', 'python:*'] },
+    repos: [
+      repo({ name: 'app', path: '/Users/me/Projects/app' }),
+      repo({
+        name: 'lib',
+        path: '/Users/me/Projects/lib',
+        devcontainer: { present: false, path: null },
+        compose: { present: true, files: ['docker-compose.yml'] },
+        image: 'node:22-slim',
+        imageSource: 'default',
+        imageAllowed: null,
+      }),
+    ],
+    summary: { total: 2, withDevcontainer: 1, withCompose: 1, imagesDenied: 0, errored: 0 },
+    ...over,
+  }
+}
+
+describe('RepoRuntimeConfigSection — empty / loading / not-connected', () => {
+  it('renders the empty state with a Run survey button before the first snapshot', () => {
+    render(<RepoRuntimeConfigSection snapshot={null} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-empty')).toBeTruthy()
+    expect(screen.getByTestId('repo-config-empty-refresh')).toBeTruthy()
+    expect(screen.queryByTestId('repo-config-table')).toBeNull()
+  })
+
+  it('renders a loading state', () => {
+    render(<RepoRuntimeConfigSection snapshot={null} loading={true} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-empty').textContent).toContain('Running the repo runtime config survey')
+  })
+
+  it('shows a not-connected hint and disables Run survey when disconnected', () => {
+    render(<RepoRuntimeConfigSection snapshot={null} loading={false} connected={false} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-not-connected')).toBeTruthy()
+    expect((screen.getByTestId('repo-config-empty-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+describe('RepoRuntimeConfigSection — populated', () => {
+  it('renders host-level defaults (backend + source, isolation, allowlist)', () => {
+    render(<RepoRuntimeConfigSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-backend').textContent).toContain('docker')
+    expect(screen.getByTestId('repo-config-backend').textContent).toContain('default')
+    expect(screen.getByTestId('repo-config-isolation').textContent).toContain('worktree-before-docker')
+    expect(screen.getByTestId('repo-config-allowlist').textContent).toContain('2')
+  })
+
+  it('renders summary chips with the per-bucket counts', () => {
+    render(<RepoRuntimeConfigSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-chip-total').textContent).toContain('2')
+    expect(screen.getByTestId('repo-config-chip-devcontainer').textContent).toContain('1')
+    expect(screen.getByTestId('repo-config-chip-compose').textContent).toContain('1')
+  })
+
+  it('renders a row per repo with image + source', () => {
+    render(<RepoRuntimeConfigSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-row-/Users/me/Projects/app')).toBeTruthy()
+    expect(screen.getByTestId('repo-config-row-/Users/me/Projects/lib')).toBeTruthy()
+    const appImage = screen.getByTestId('repo-config-image-/Users/me/Projects/app')
+    expect(appImage.textContent).toContain('node:22')
+    expect(appImage.textContent).toContain('devcontainer')
+  })
+
+  it('shows compose files when present and "—" when absent', () => {
+    render(<RepoRuntimeConfigSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-compose-/Users/me/Projects/app').textContent).toBe('—')
+    expect(screen.getByTestId('repo-config-compose-/Users/me/Projects/lib').textContent).toContain('docker-compose.yml')
+  })
+
+  it('renders the allowlist verdict: allowed, denied, and n/a for the default image', () => {
+    const snap = snapshot({
+      summary: { total: 3, withDevcontainer: 2, withCompose: 0, imagesDenied: 1, errored: 0 },
+      repos: [
+        repo({ path: '/a', imageAllowed: true }),
+        repo({ path: '/b', imageAllowed: false }),
+        repo({ path: '/c', imageSource: 'default', imageAllowed: null }),
+      ],
+    })
+    render(<RepoRuntimeConfigSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-verdict-/a').textContent).toContain('allowed')
+    expect(screen.getByTestId('repo-config-verdict-/b').textContent).toContain('denied')
+    expect(screen.getByTestId('repo-config-verdict-/c').textContent).toContain('n/a')
+  })
+
+  it('renders the images-denied chip only when there are denials', () => {
+    render(<RepoRuntimeConfigSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.queryByTestId('repo-config-chip-denied')).toBeNull()
+    const snap = snapshot({ summary: { total: 1, withDevcontainer: 0, withCompose: 0, imagesDenied: 1, errored: 0 } })
+    cleanup()
+    render(<RepoRuntimeConfigSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-chip-denied').textContent).toContain('1')
+  })
+
+  it('renders a per-repo error row', () => {
+    const snap = snapshot({
+      summary: { total: 1, withDevcontainer: 0, withCompose: 0, imagesDenied: 0, errored: 1 },
+      repos: [repo({ path: '/x', error: 'cwd unreadable', image: null, imageSource: null, imageAllowed: null })],
+    })
+    render(<RepoRuntimeConfigSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    const err = screen.getByTestId('repo-config-error-/x')
+    expect(err.textContent).toContain('cwd unreadable')
+    expect(err.getAttribute('role')).toBe('alert')
+  })
+
+  it('surfaces a degraded-survey error banner', () => {
+    const snap = snapshot({
+      repos: [],
+      summary: { total: 0, withDevcontainer: 0, withCompose: 0, imagesDenied: 0, errored: 0 },
+      error: { code: 'SURVEY_FAILED', message: 'fs unreachable' },
+    })
+    render(<RepoRuntimeConfigSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    const banner = screen.getByTestId('repo-config-error')
+    expect(banner.textContent).toContain('SURVEY_FAILED')
+    expect(banner.textContent).toContain('fs unreachable')
+  })
+
+  it('renders the no-repos row when the survey found nothing', () => {
+    render(<RepoRuntimeConfigSection snapshot={snapshot({ repos: [], summary: { total: 0, withDevcontainer: 0, withCompose: 0, imagesDenied: 0, errored: 0 } })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('repo-config-none')).toBeTruthy()
+  })
+})
+
+describe('RepoRuntimeConfigSection — refresh', () => {
+  it('dispatches onRefresh when Refresh is clicked', () => {
+    const onRefresh = vi.fn()
+    render(<RepoRuntimeConfigSection snapshot={snapshot()} loading={false} connected={true} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByTestId('repo-config-refresh'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables Refresh while loading and does not dispatch', () => {
+    const onRefresh = vi.fn()
+    render(<RepoRuntimeConfigSection snapshot={snapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
+    const btn = screen.getByTestId('repo-config-refresh') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    fireEvent.click(btn)
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/RepoRuntimeConfigSection.tsx
+++ b/packages/dashboard/src/components/RepoRuntimeConfigSection.tsx
@@ -41,11 +41,12 @@ function PresenceCell({ present, detail, testid }: { present: boolean; detail?: 
   )
 }
 
-/** The allowlist verdict for a repo's image: allowed / denied / N/A (default). */
+/**
+ * The allowlist verdict for a repo's image: allowed / denied / N/A (default).
+ * Only rendered for non-errored entries — RepoRow short-circuits an errored
+ * entry to a dedicated error row before this is reached.
+ */
 function VerdictCell({ entry }: { entry: RepoEntry }) {
-  if (entry.error) {
-    return <td className="cr-dim" data-testid={`repo-config-verdict-${entry.path}`}>—</td>
-  }
   // imageAllowed is null for the built-in default image (never allowlist-checked)
   // — show N/A, not a (misleading) verdict.
   if (entry.imageAllowed === null) {
@@ -148,7 +149,7 @@ export function RepoRuntimeConfigSection({
           host · repo runtime config{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
         </div>
         <div className="cr-titlerow">
-          <h1 className="cr-title">Repo Runtime Config</h1>
+          <h1 className="cr-title">Repo runtime config</h1>
           <button
             type="button"
             className="cr-refresh"

--- a/packages/dashboard/src/components/RepoRuntimeConfigSection.tsx
+++ b/packages/dashboard/src/components/RepoRuntimeConfigSection.tsx
@@ -1,0 +1,278 @@
+/**
+ * RepoRuntimeConfigSection (#6139, epic #5530) — the "Repo Runtime Config"
+ * Control Room tab. READ-ONLY.
+ *
+ * Renders the host-wide, per-repo survey of what governs container runtimes that
+ * the server returns in a `repo_runtime_config_snapshot`: an eyebrow + title +
+ * host-level defaults (effective backend + its source, isolation order, the
+ * effective docker-image allowlist), a row of summary chips, and a table of every
+ * managed repo showing devcontainer/compose config presence, the image the repo
+ * would run (+ its source), and the docker-image allowlist verdict.
+ *
+ * Lives next to the Containers tab inside the Control Room (see ControlRoomView).
+ * Same pull-on-Refresh data flow as the sibling surveys: the Refresh button
+ * dispatches `repo_runtime_config_request` via the store's
+ * `requestRepoRuntimeConfig`; the server replies with one
+ * `repo_runtime_config_snapshot` handled into `repoRuntimeConfig`. No delta
+ * stream — each refresh replaces the whole survey.
+ */
+import { useConnectionStore } from '../store/connection'
+import type { ServerRepoRuntimeConfigSnapshotMessage } from '@chroxy/protocol'
+import { formatGeneratedAgo } from './ControlRoomSection'
+
+type RepoEntry = ServerRepoRuntimeConfigSnapshotMessage['repos'][number]
+
+/** ISO date (no time) for the eyebrow, e.g. "2026-06-19". */
+function isoDate(iso: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
+  return m ? m[1]! : iso
+}
+
+/** A present/absent config cell: "✓ <detail>" (ok) or "—" (dim). */
+function PresenceCell({ present, detail, testid }: { present: boolean; detail?: string; testid: string }) {
+  if (!present) {
+    return <td className="cr-dim" data-testid={testid}>—</td>
+  }
+  return (
+    <td data-testid={testid}>
+      <span className="cr-ok">✓</span>
+      {detail ? <span className="cr-dim cr-mono"> {detail}</span> : null}
+    </td>
+  )
+}
+
+/** The allowlist verdict for a repo's image: allowed / denied / N/A (default). */
+function VerdictCell({ entry }: { entry: RepoEntry }) {
+  if (entry.error) {
+    return <td className="cr-dim" data-testid={`repo-config-verdict-${entry.path}`}>—</td>
+  }
+  // imageAllowed is null for the built-in default image (never allowlist-checked)
+  // — show N/A, not a (misleading) verdict.
+  if (entry.imageAllowed === null) {
+    return (
+      <td className="cr-dim" data-testid={`repo-config-verdict-${entry.path}`} title="The built-in default image is not subject to the allowlist">
+        n/a
+      </td>
+    )
+  }
+  const accent = entry.imageAllowed ? 'ok' : 'bad'
+  return (
+    <td data-testid={`repo-config-verdict-${entry.path}`}>
+      <span className={`cr-tag cr-tag-${accent}`} data-accent={accent}>
+        {entry.imageAllowed ? 'allowed' : 'denied'}
+      </span>
+    </td>
+  )
+}
+
+function RepoRow({ entry }: { entry: RepoEntry }) {
+  if (entry.error) {
+    return (
+      <tr data-testid={`repo-config-row-${entry.path}`}>
+        <td>
+          <b data-testid={`repo-config-name-${entry.path}`}>{entry.name || entry.path}</b>
+          <div className="cr-dim cr-mono cr-branch">{entry.path}</div>
+        </td>
+        <td className="cr-bad" colSpan={4} data-testid={`repo-config-error-${entry.path}`} role="alert">
+          {entry.error}
+        </td>
+      </tr>
+    )
+  }
+  return (
+    <tr data-testid={`repo-config-row-${entry.path}`}>
+      <td>
+        <b data-testid={`repo-config-name-${entry.path}`}>{entry.name || entry.path}</b>
+        <div className="cr-dim cr-mono cr-branch">{entry.path}</div>
+      </td>
+      <PresenceCell
+        present={entry.devcontainer.present}
+        testid={`repo-config-devcontainer-${entry.path}`}
+      />
+      <PresenceCell
+        present={entry.compose.present}
+        detail={entry.compose.files.length > 0 ? entry.compose.files.join(', ') : undefined}
+        testid={`repo-config-compose-${entry.path}`}
+      />
+      <td data-testid={`repo-config-image-${entry.path}`}>
+        <span className="cr-mono">{entry.image ?? '—'}</span>
+        {entry.imageSource ? <span className="cr-dim"> · {entry.imageSource}</span> : null}
+      </td>
+      <VerdictCell entry={entry} />
+    </tr>
+  )
+}
+
+export interface RepoRuntimeConfigSectionProps {
+  /** Latest snapshot, or null before the first one lands. Defaults to the store. */
+  snapshot?: ServerRepoRuntimeConfigSnapshotMessage | null
+  /** True while a refresh is in flight. Defaults to the store flag. */
+  loading?: boolean
+  /** Whether the WS connection is up. Defaults to the store's connected phase. */
+  connected?: boolean
+  /** Refresh action. Defaults to the store's requestRepoRuntimeConfig. */
+  onRefresh?: () => void
+  /** Injectable clock (epoch ms) for the "generated Nm ago" string. */
+  now?: () => number
+}
+
+export function RepoRuntimeConfigSection({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  now = Date.now,
+}: RepoRuntimeConfigSectionProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.repoRuntimeConfig)
+  const storeLoading = useConnectionStore((s) => s.repoRuntimeConfigLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestRepoRuntimeConfig = useConnectionStore((s) => s.requestRepoRuntimeConfig)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestRepoRuntimeConfig
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+
+  return (
+    <div className="cr-section" data-testid="repo-config-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="repo-config-eyebrow">
+          host · repo runtime config{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h1 className="cr-title">Repo Runtime Config</h1>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="repo-config-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot && (
+          <p className="cr-sub" data-testid="repo-config-sub">
+            {snapshot.summary.total} repo{snapshot.summary.total === 1 ? '' : 's'} — read-only view of what
+            governs each repo&apos;s container runtimes.
+          </p>
+        )}
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="repo-config-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="repo-config-generated">
+            {formatGeneratedAgo(generatedAtMs, now())}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="repo-config-empty">
+          {loading ? (
+            <span>Running the repo runtime config survey…</span>
+          ) : (
+            <>
+              <p>No repo runtime config survey yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="repo-config-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="repo-config-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot && (
+        <>
+          {/* Host-level defaults that apply across all repos. */}
+          <div className="cr-chips" data-testid="repo-config-defaults">
+            <span className="cr-chip" data-testid="repo-config-backend">
+              Backend: <b>{snapshot.backend}</b>
+              <span className="cr-dim"> ({snapshot.backendSource})</span>
+            </span>
+            <span className="cr-chip" data-testid="repo-config-isolation">
+              Isolation: <b>{snapshot.isolation}</b>
+            </span>
+            <span className="cr-chip" data-testid="repo-config-allowlist">
+              Image allowlist: <b>{snapshot.allowlist.patterns.length}</b>
+              <span className="cr-dim"> pattern{snapshot.allowlist.patterns.length === 1 ? '' : 's'} ({snapshot.allowlist.source})</span>
+            </span>
+          </div>
+
+          <div className="cr-chips" data-testid="repo-config-summary">
+            <span className="cr-chip" data-testid="repo-config-chip-total">
+              Repos: <b>{snapshot.summary.total}</b>
+            </span>
+            <span className="cr-chip" data-testid="repo-config-chip-devcontainer">
+              <span className="cr-dot cr-dot-ok" aria-hidden="true" />
+              Devcontainer: <b>{snapshot.summary.withDevcontainer}</b>
+            </span>
+            <span className="cr-chip" data-testid="repo-config-chip-compose">
+              <span className="cr-dot cr-dot-ok" aria-hidden="true" />
+              Compose: <b>{snapshot.summary.withCompose}</b>
+            </span>
+            {snapshot.summary.imagesDenied > 0 && (
+              <span className="cr-chip" data-testid="repo-config-chip-denied">
+                <span className="cr-dot cr-dot-bad" aria-hidden="true" />
+                Images denied: <b>{snapshot.summary.imagesDenied}</b>
+              </span>
+            )}
+            {snapshot.summary.errored > 0 && (
+              <span className="cr-chip" data-testid="repo-config-chip-errored">
+                <span className="cr-dot cr-dot-bad" aria-hidden="true" />
+                Errored: <b>{snapshot.summary.errored}</b>
+              </span>
+            )}
+          </div>
+
+          <section className="cr-table-wrap">
+            <table className="cr-table" data-testid="repo-config-table">
+              <thead>
+                <tr>
+                  <th>Repo</th>
+                  <th>Devcontainer</th>
+                  <th>Compose</th>
+                  <th>Image</th>
+                  <th>Allowlist</th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshot.repos.length === 0 ? (
+                  <tr data-testid="repo-config-none">
+                    <td colSpan={5} className="cr-dim">
+                      No managed repos found.
+                    </td>
+                  </tr>
+                ) : (
+                  snapshot.repos.map((entry) => <RepoRow key={entry.path} entry={entry} />)
+                )}
+              </tbody>
+            </table>
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -501,6 +501,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // the containers_status_snapshot handler. Null until the first survey lands.
   containersStatus: null,
   containersStatusLoading: false,
+  // #6139 (epic #5530): Control Room per-repo runtime config snapshot, fed by
+  // the repo_runtime_config_snapshot handler. Null until the first survey lands.
+  repoRuntimeConfig: null,
+  repoRuntimeConfigLoading: false,
   // #5499 (epic #5498): Control Room Integrations snapshot, fed by the
   // integration_status_snapshot handler. Null until the first survey lands.
   integrationStatus: null,
@@ -999,6 +1003,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       set({ containersStatusLoading: true });
       wsSend(socket, { type: 'containers_status_request' });
+      return true;
+    }
+    return false;
+  },
+
+  // #6139 (epic #5530): request a per-repo runtime config survey. Mirrors
+  // requestContainersStatus — flips repoRuntimeConfigLoading and sends a
+  // repo_runtime_config_request; the reply is a single
+  // repo_runtime_config_snapshot handled into repoRuntimeConfig. Returns false
+  // (and does NOT set loading) when the socket is closed.
+  requestRepoRuntimeConfig: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ repoRuntimeConfigLoading: true });
+      wsSend(socket, { type: 'repo_runtime_config_request' });
       return true;
     }
     return false;

--- a/packages/dashboard/src/store/dispatch-repo-runtime-config.test.ts
+++ b/packages/dashboard/src/store/dispatch-repo-runtime-config.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Integration test for the per-repo runtime config Control Room wiring
+ * (#6139, epic #5530).
+ *
+ * Guards the wire path between the dashboard message handler and the store:
+ *   - `repo_runtime_config_snapshot` REPLACES `repoRuntimeConfig` and clears
+ *     `repoRuntimeConfigLoading`.
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state and
+ *     WITHOUT clearing the loading flag.
+ *   - a second snapshot wholesale-replaces the first (full picture, no merge).
+ *   - an empty-repos survey is a valid snapshot.
+ *
+ * Mirrors dispatch-containers-status.test.ts (the containers survey's sibling test).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerRepoRuntimeConfigSnapshotMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    repoRuntimeConfig: null,
+    repoRuntimeConfigLoading: true,
+    messages: [],
+  }
+}
+
+function snapshot(over: Partial<ServerRepoRuntimeConfigSnapshotMessage> = {}): ServerRepoRuntimeConfigSnapshotMessage {
+  return {
+    type: 'repo_runtime_config_snapshot',
+    generatedAt: '2026-06-19T11:50:00.000Z',
+    backend: 'docker',
+    backendSource: 'default',
+    isolation: 'worktree-before-docker',
+    allowlist: { source: 'default', patterns: ['node:*'] },
+    repos: [
+      {
+        name: 'app',
+        path: '/Users/me/Projects/app',
+        devcontainer: { present: true, path: '/Users/me/Projects/app/.devcontainer/devcontainer.json' },
+        compose: { present: false, files: [] },
+        image: 'node:22',
+        imageSource: 'devcontainer',
+        imageAllowed: true,
+        error: null,
+      },
+    ],
+    summary: { total: 1, withDevcontainer: 1, withCompose: 0, imagesDenied: 0, errored: 0 },
+    ...over,
+  }
+}
+
+describe('repo runtime config dispatch (#6139)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('applies repo_runtime_config_snapshot and clears the loading flag', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.repoRuntimeConfig).not.toBeNull()
+    expect(s.repoRuntimeConfig!.repos.map((r) => r.path)).toEqual(['/Users/me/Projects/app'])
+    expect(s.repoRuntimeConfig!.backend).toBe('docker')
+    expect(s.repoRuntimeConfig!.summary.withDevcontainer).toBe(1)
+    expect(s.repoRuntimeConfigLoading).toBe(false)
+  })
+
+  it('replaces a prior snapshot wholesale (no merge)', () => {
+    handleMessage(snapshot(), ctx() as never)
+    handleMessage(
+      snapshot({
+        backend: 'k8s',
+        backendSource: 'config',
+        repos: [
+          {
+            name: 'lib',
+            path: '/Users/me/Projects/lib',
+            devcontainer: { present: false, path: null },
+            compose: { present: false, files: [] },
+            image: 'node:22-slim',
+            imageSource: 'default',
+            imageAllowed: null,
+            error: null,
+          },
+        ],
+        summary: { total: 1, withDevcontainer: 0, withCompose: 0, imagesDenied: 0, errored: 0 },
+      }),
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.repoRuntimeConfig!.repos.map((r) => r.path)).toEqual(['/Users/me/Projects/lib'])
+    expect(s.repoRuntimeConfig!.backend).toBe('k8s')
+  })
+
+  it('drops a malformed snapshot without mutating state or clearing loading', () => {
+    const before = store.getState().repoRuntimeConfig
+    // Missing required `summary` / `backend`.
+    handleMessage(
+      { type: 'repo_runtime_config_snapshot', generatedAt: '2026-06-19T11:50:00.000Z', repos: [] },
+      ctx() as never,
+    )
+    expect(store.getState().repoRuntimeConfig).toBe(before)
+    expect(store.getState().repoRuntimeConfigLoading).toBe(true)
+  })
+
+  it('accepts an empty-repos survey as a valid snapshot', () => {
+    handleMessage(
+      snapshot({ repos: [], summary: { total: 0, withDevcontainer: 0, withCompose: 0, imagesDenied: 0, errored: 0 } }),
+      ctx() as never,
+    )
+    expect(store.getState().repoRuntimeConfig!.repos).toEqual([])
+    expect(store.getState().repoRuntimeConfigLoading).toBe(false)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2589,6 +2589,18 @@ function handleContainersStatusSnapshot(msg: Record<string, unknown>, _get: MsgG
 }
 
 /**
+ * #6139 (epic #5530) — per-repo runtime config survey
+ * `repo_runtime_config_snapshot`: REPLACE the stored survey and clear the
+ * loading flag. Same defensive, full-replace, clear-loading-only-on-valid-parse
+ * contract as the host/runner/containers survey handlers above.
+ */
+function handleRepoRuntimeConfigSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerRepoRuntimeConfigSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ repoRuntimeConfig: parsed.data, repoRuntimeConfigLoading: false });
+}
+
+/**
  * #5499 (epic #5498) — Integrations survey `integration_status_snapshot`:
  * REPLACE the stored survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host and
@@ -2829,6 +2841,8 @@ const HANDLERS: Record<string, Handler> = {
   // #5253: self-hosted runner Control Room survey snapshot.
   runner_status_snapshot: handleRunnerStatusSnapshot,
   containers_status_snapshot: handleContainersStatusSnapshot,
+  // #6139 (epic #5530): Control Room per-repo runtime config survey snapshot.
+  repo_runtime_config_snapshot: handleRepoRuntimeConfigSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
   skills_inventory_snapshot: handleSkillsInventorySnapshot,

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -689,6 +689,22 @@ describe('useConnectionStore', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('#6139: requestRepoRuntimeConfig sets loading and sends on the wire; no-op + no loading offline', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const send = vi.fn();
+    const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: openSocket, repoRuntimeConfigLoading: false });
+    expect(useConnectionStore.getState().requestRepoRuntimeConfig()).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(send.mock.calls[0]![0] as string).type).toBe('repo_runtime_config_request');
+    expect(useConnectionStore.getState().repoRuntimeConfigLoading).toBe(true);
+
+    // Offline: no send, no loading flip.
+    useConnectionStore.setState({ socket: null, repoRuntimeConfigLoading: false });
+    expect(useConnectionStore.getState().requestRepoRuntimeConfig()).toBe(false);
+    expect(useConnectionStore.getState().repoRuntimeConfigLoading).toBe(false);
+  });
+
   it('exposes all required actions', async () => {
     const { useConnectionStore } = await import('./connection');
     const state = useConnectionStore.getState();

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -730,6 +730,21 @@ export interface ConnectionState {
   containersStatusLoading: boolean;
 
   /**
+   * #6139 (epic #5530) — Control Room per-repo runtime config survey: the
+   * latest `repo_runtime_config_snapshot`, or null before the first one lands
+   * (the Repo Runtime Config section renders an empty/loading state). Replaced
+   * wholesale on each snapshot (full picture, no delta stream).
+   */
+  repoRuntimeConfig: ServerRepoRuntimeConfigSnapshotMessage | null;
+  /**
+   * #6139 — true between dispatching a `repo_runtime_config_request` and the
+   * matching `repo_runtime_config_snapshot` arriving, so the tab's Refresh
+   * button can spin. Cleared when a VALID snapshot lands (a malformed payload
+   * is dropped and leaves this true, matching the sibling surveys).
+   */
+  repoRuntimeConfigLoading: boolean;
+
+  /**
    * #5499 (epic #5498) — Control Room Integrations survey: the latest
    * `integration_status_snapshot` from the server (per-repo repo-memory
    * status). `null` until the first snapshot lands (the Integrations section
@@ -1363,6 +1378,13 @@ export interface ConnectionState {
   // the message went on the wire (false = socket closed). Sets
   // `containersStatusLoading` while in flight.
   requestContainersStatus: () => boolean;
+
+  // #6139 (epic #5530): request a per-repo runtime config survey. Dispatches a
+  // `repo_runtime_config_request`; the server replies with a single
+  // `repo_runtime_config_snapshot` handled into `repoRuntimeConfig`. Returns
+  // whether the message went on the wire (false = socket closed). Sets
+  // `repoRuntimeConfigLoading` while in flight.
+  requestRepoRuntimeConfig: () => boolean;
 
   // #5499 (epic #5498): request an Integrations survey. Dispatches an
   // `integration_status_request`; the server replies with a single

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -80,7 +80,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'repo_runtime_config_snapshot', // #6139 (epic #5530) — Control Room per-repo runtime config survey reply. Server contract (survey + handler + protocol) landed first; the dashboard tab that consumes the snapshot is the tracked follow-up slice, at which point this moves to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -152,6 +151,7 @@ const PLATFORM_SPECIFIC = {
   'host_status_snapshot': 'dashboard', // Control Room Host/Repo Status survey reply (#5171 schema / #5174 server emitter / #5175 dashboard section) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5170
   'runner_status_snapshot': 'dashboard', // Control Room self-hosted runner survey reply (#5253) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'containers_status_snapshot': 'dashboard', // Control Room containers & environments survey reply (#6133, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'repo_runtime_config_snapshot': 'dashboard', // Control Room per-repo runtime config survey reply (#6139, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_status_snapshot': 'dashboard', // Control Room Integrations survey reply (#5499, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_action_ack': 'dashboard', // Control Room Integrations Reindex action ack (#5500, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'containers_action_ack': 'dashboard', // Control Room container lifecycle action ack (#6134, epic #5530) — the dashboard consumes it to clear pending row state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -143,6 +143,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'cancel_activity_ack',        // Control Room cancel-click correlation ack (#5277)
   'containers_status_snapshot', // Control Room containers & environments survey (#6133, epic #5530) — dashboard-only
   'containers_action_ack',      // Control Room container lifecycle action ack (#6134, epic #5530) — dashboard-only
+  'repo_runtime_config_snapshot', // Control Room per-repo runtime config survey (#6139, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -191,9 +192,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'repo_runtime_config_snapshot',         // #6139 (epic #5530) Control Room per-repo runtime config survey —
-                                          //   server contract landed first; the dashboard tab that consumes
-                                          //   the snapshot is the tracked follow-up, then this → DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 2 of **#6139** (epic #5530) — the dashboard tab consuming the read-only `repo_runtime_config_snapshot` whose server contract shipped in #6148 (`1fe021d93`). A new **"Repo runtime config"** Control Room tab.

## What changed

- **`RepoRuntimeConfigSection`** (new) — the tab body:
  - **Host-level defaults** as chips: effective **backend** + its source (`config`/`default`), **isolation** order, and the image **allowlist** (pattern count + source).
  - **Summary chips**: repos / with devcontainer / with compose / images-denied (only when >0) / errored (only when >0).
  - **Per-repo table**: devcontainer presence, compose presence (+ files), the **image** the repo would run (+ source), and the **allowlist verdict** — `allowed` / `denied` / `n/a`. The `n/a` reflects the server's correct semantics: the built-in default image is never allowlist-checked (only client-supplied images are), so a default-image repo isn't a misleading "denied".
  - Per-repo **error rows** (degradation) and a degraded-survey **error banner**. Empty / loading / not-connected states. Same pull-on-Refresh flow as the sibling tabs.
- **Store** — `repoRuntimeConfig` / `repoRuntimeConfigLoading` state + `requestRepoRuntimeConfig` action (mirrors `requestContainersStatus`).
- **`message-handler`** — `handleRepoRuntimeConfigSnapshot` (full-replace, clear-loading-only-on-valid-parse) registered for `repo_runtime_config_snapshot`.
- **`ControlRoomView`** — a `survey: true` `repo-config` tab descriptor (auto-fetch + #5546 staleness guard come free via the registry) + render branch.
- **Coverage guards** — `repo_runtime_config_snapshot` promoted from the unhandled allowlists → `dashboard` / `DASHBOARD_ONLY` in both the protocol `handler-coverage.test.js` and store-core `protocol-type-coverage-lint.test.ts`.

Dashboard-only — no protocol/server change, no dist rebuild.

## Tests

- `dispatch-repo-runtime-config.test.ts` (new) — wire path: snapshot replaces state + clears loading; malformed dropped (state + loading untouched); wholesale replace; empty-repos valid.
- `RepoRuntimeConfigSection.test.tsx` (new) — empty/loading/not-connected; host defaults; summary chips; per-repo rows + image/source; compose files vs "—"; verdict allowed/denied/n-a; denied chip only when >0; per-repo error row (role=alert); degraded banner; no-repos row; Refresh dispatch + disabled-while-loading.
- `store.test.ts` — `requestRepoRuntimeConfig` on-the-wire + offline no-op.
- The `ControlRoomView.registry.test.ts` structural invariants pass automatically for the new survey descriptor.
- Green: dashboard **3890** + typecheck · protocol **340** (handler-coverage incl.) · store-core **1679** (coverage guard incl.).

Closes #6139