### PR TITLE
feat(dashboard): BYOK Pool Control Room tab (#6135 slice 3)

### DIFF
--- a/packages/dashboard/src/components/ByokPoolSection.test.tsx
+++ b/packages/dashboard/src/components/ByokPoolSection.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * ByokPoolSection (#6135, epic #5530) — renderer tests.
+ *
+ * Covers the surface against a mocked `byok_pool_status_snapshot`:
+ *   - empty / loading / not-connected states before the first snapshot
+ *   - a disabled-pool snapshot renders the note, no table/actions
+ *   - enabled: stats + limits chips, per-shape bucket rows
+ *   - Drain routes through the ConfirmDialog before calling onAction
+ *   - Recycle (per-row) routes through the ConfirmDialog with the bucket key
+ *   - Resize submits the typed caps; empty inputs submit nothing
+ *   - pending shows "Working…"; a settled result shows the note / error
+ *   - Refresh dispatches the request (and is disabled while loading)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ServerByokPoolStatusSnapshotMessage } from '@chroxy/protocol'
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      byokPoolStatus: null,
+      byokPoolStatusLoading: false,
+      connectionPhase: 'connected',
+      requestByokPoolStatus: () => false,
+      byokPoolActioningIds: new Set<string>(),
+      byokPoolActionResults: {},
+      sendByokPoolAction: () => false,
+    }),
+}))
+import { ByokPoolSection } from './ByokPoolSection'
+
+afterEach(cleanup)
+
+const BUCKET = 'node:22|/p|2g|2|chroxy'
+
+function snapshot(over: Partial<ServerByokPoolStatusSnapshotMessage> = {}): ServerByokPoolStatusSnapshotMessage {
+  return {
+    type: 'byok_pool_status_snapshot',
+    generatedAt: '2026-06-19T11:50:00.000Z',
+    enabled: true,
+    note: null,
+    limits: { idleTimeoutMs: 300000, maxPerKey: 2, maxTotal: 8, maxAgeMs: 1800000 },
+    stats: {
+      hits: 7, misses: 3, releases: 5, shutdowns: 0, hitRate: 0.7, totalSize: 2,
+      buckets: [{ key: BUCKET, size: 2, oldestIdleMs: 12000 }],
+      evictionsByReason: { idle: 4, over_cap: 1 },
+      recentEvictions: [],
+    },
+    ...over,
+  } as ServerByokPoolStatusSnapshotMessage
+}
+
+describe('ByokPoolSection — empty / loading / not-connected', () => {
+  it('renders the empty state with a Run-survey button when no snapshot', () => {
+    render(<ByokPoolSection snapshot={null} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('byok-pool-empty')).toBeTruthy()
+    expect(screen.getByTestId('byok-pool-empty-refresh')).toBeTruthy()
+    expect(screen.queryByTestId('byok-pool-table')).toBeNull()
+  })
+
+  it('shows a loading message while the first survey is in flight', () => {
+    render(<ByokPoolSection snapshot={null} loading={true} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('byok-pool-empty').textContent).toContain('Running the BYOK pool survey')
+  })
+
+  it('disables the run button and notes the disconnect when not connected', () => {
+    render(<ByokPoolSection snapshot={null} loading={false} connected={false} onRefresh={() => {}} />)
+    expect(screen.getByTestId('byok-pool-not-connected')).toBeTruthy()
+    expect((screen.getByTestId('byok-pool-empty-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+describe('ByokPoolSection — disabled pool', () => {
+  it('renders the disabled note and no table/actions', () => {
+    render(
+      <ByokPoolSection
+        snapshot={snapshot({ enabled: false, note: 'BYOK container pool is disabled.', limits: null, stats: null })}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('byok-pool-disabled').textContent).toContain('disabled')
+    expect(screen.queryByTestId('byok-pool-table')).toBeNull()
+    expect(screen.queryByTestId('byok-pool-actions')).toBeNull()
+  })
+})
+
+describe('ByokPoolSection — enabled', () => {
+  it('renders stats + limits chips', () => {
+    render(<ByokPoolSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('byok-pool-chip-warm-count').textContent).toBe('2')
+    expect(screen.getByTestId('byok-pool-chip-hits').textContent).toContain('7')
+    expect(screen.getByTestId('byok-pool-chip-perkey').textContent).toContain('2')
+    expect(screen.getByTestId('byok-pool-chip-total').textContent).toContain('8')
+    expect(screen.getByTestId('byok-pool-evictions').textContent).toContain('idle 4')
+  })
+
+  it('renders one row per warm bucket', () => {
+    render(<ByokPoolSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId(`byok-bucket-row-${BUCKET}`)).toBeTruthy()
+    expect(screen.getByTestId(`byok-bucket-size-${BUCKET}`).textContent).toBe('2')
+  })
+
+  it('Drain routes through the ConfirmDialog before calling onAction', () => {
+    const onAction = vi.fn()
+    render(<ByokPoolSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('byok-pool-drain'))
+    expect(onAction).not.toHaveBeenCalled() // dialog gates it
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+    expect(onAction).toHaveBeenCalledWith('drain')
+  })
+
+  it('Recycle routes through the ConfirmDialog with the bucket key', () => {
+    const onAction = vi.fn()
+    render(<ByokPoolSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId(`byok-recycle-${BUCKET}`))
+    expect(onAction).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+    expect(onAction).toHaveBeenCalledWith('recycle', { key: BUCKET })
+  })
+
+  it('Resize submits the typed caps; nothing when both inputs are empty', () => {
+    const onAction = vi.fn()
+    render(<ByokPoolSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    // Empty inputs → no-op.
+    fireEvent.click(screen.getByTestId('byok-pool-resize-apply'))
+    expect(onAction).not.toHaveBeenCalled()
+    // Type a per-key cap and apply.
+    fireEvent.change(screen.getByTestId('byok-pool-resize-perkey'), { target: { value: '1' } })
+    fireEvent.click(screen.getByTestId('byok-pool-resize-apply'))
+    expect(onAction).toHaveBeenCalledWith('resize', { maxPerKey: 1 })
+  })
+
+  it('shows Working… while a target is pending and a note when settled', () => {
+    const { rerender } = render(
+      <ByokPoolSection
+        snapshot={snapshot()}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+        actioningIds={new Set(['drain'])}
+        actionResults={{}}
+      />,
+    )
+    expect(screen.getByTestId('byok-action-pending-drain')).toBeTruthy()
+    rerender(
+      <ByokPoolSection
+        snapshot={snapshot()}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+        actioningIds={new Set<string>()}
+        actionResults={{ drain: { action: 'drain', note: 'Drained — evicted 3', error: null, at: 1 } }}
+      />,
+    )
+    expect(screen.getByTestId('byok-action-ok-drain').textContent).toContain('evicted 3')
+  })
+
+  it('Refresh dispatches the request and is disabled while loading', () => {
+    const onRefresh = vi.fn()
+    const { rerender } = render(
+      <ByokPoolSection snapshot={snapshot()} loading={false} connected={true} onRefresh={onRefresh} />,
+    )
+    fireEvent.click(screen.getByTestId('byok-pool-refresh'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    rerender(<ByokPoolSection snapshot={snapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
+    expect((screen.getByTestId('byok-pool-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/packages/dashboard/src/components/ByokPoolSection.tsx
+++ b/packages/dashboard/src/components/ByokPoolSection.tsx
@@ -163,7 +163,9 @@ export function ByokPoolSection({
   // 'recycle', key }); null = dialog closed.
   const [confirm, setConfirm] = useState<{ action: 'drain' | 'recycle'; key?: string } | null>(null)
 
-  // Resize inputs are local until Apply; seeded from the current effective caps.
+  // Resize inputs are local until Apply. They start EMPTY (the current effective
+  // caps show as the input placeholders); an empty field is left unchanged on
+  // submit, so the operator only sends the caps they actually typed.
   const [maxPerKeyInput, setMaxPerKeyInput] = useState<string>('')
   const [maxTotalInput, setMaxTotalInput] = useState<string>('')
 

--- a/packages/dashboard/src/components/ByokPoolSection.tsx
+++ b/packages/dashboard/src/components/ByokPoolSection.tsx
@@ -1,0 +1,416 @@
+/**
+ * ByokPoolSection (#6135, epic #5530) — the "BYOK Pool" Control Room tab.
+ *
+ * Renders the host-wide BYOK warm-container pool the server returns in a
+ * `byok_pool_status_snapshot`: whether the pool is enabled (off by default — a
+ * first-class state, not an error), its configured limits (idle TTL, per-key /
+ * total caps, max lifetime), live rolling stats (hits / misses / hit-rate /
+ * evictions-by-reason), and a table of the per-resource-shape warm buckets.
+ *
+ * Mutating actions (#6135 slice 2) follow the Containers tab's discipline:
+ *   - Drain   — evict ALL idle warm containers (pool-wide; behind a confirm).
+ *   - Recycle — evict ONE resource-shape bucket (per-row; behind a confirm).
+ *   - Resize  — tighten the runtime per-key / total caps (the server clamps to
+ *               the operator-configured ceiling; no confirm — it only frees).
+ *
+ * Same pull-on-Refresh data flow as the sibling surveys: Refresh dispatches
+ * `byok_pool_status_request` via the store's `requestByokPoolStatus`; the server
+ * replies with one `byok_pool_status_snapshot` handled into `byokPoolStatus`. No
+ * delta stream — each refresh replaces the whole survey. Actions reply with a
+ * `byok_pool_action_ack` (or BYOK_POOL_ACTION_FAILED) handled into the
+ * per-target pending/result state.
+ */
+import { useMemo, useState } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { ServerByokPoolStatusSnapshotMessage } from '@chroxy/protocol'
+import type { ByokPoolActionResult } from '../store/types'
+import { formatGeneratedAgo } from './ControlRoomSection'
+import { ConfirmDialog } from './ConfirmDialog'
+
+/** The pool actions the BYOK Pool tab can dispatch. */
+type ByokPoolAction = 'drain' | 'recycle' | 'resize'
+
+type ByokBucket = NonNullable<ServerByokPoolStatusSnapshotMessage['stats']>['buckets'][number]
+
+/** Pending/result target id, matching the store's sendByokPoolAction keys. */
+function targetId(action: ByokPoolAction, key?: string): string {
+  return action === 'recycle' && key ? `recycle:${key}` : action
+}
+
+/** ISO date (no time) for the eyebrow, e.g. "2026-06-19". */
+function isoDate(iso: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
+  return m ? m[1]! : iso
+}
+
+/** Compact human duration from ms: "2h 14m", "5m", "12s", "∞", or "—". */
+function formatDurationMs(ms: number | null): string {
+  if (ms === null) return '∞'
+  if (!Number.isFinite(ms) || ms < 0) return '—'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  const remM = m % 60
+  if (h < 24) return remM > 0 ? `${h}h ${remM}m` : `${h}h`
+  const d = Math.floor(h / 24)
+  const remH = h % 24
+  return remH > 0 ? `${d}d ${remH}h` : `${d}d`
+}
+
+/** Inline pending/result note for a settled (or in-flight) action target. */
+function ActionFeedback({ id, pending, result }: { id: string; pending: boolean; result: ByokPoolActionResult | undefined }) {
+  if (pending) {
+    return <span className="cr-dim" data-testid={`byok-action-pending-${id}`}>Working…</span>
+  }
+  if (!result) return null
+  if (result.error) {
+    return <span className="cr-bad" data-testid={`byok-action-error-${id}`} role="alert">{result.error}</span>
+  }
+  return <span className="cr-ok" data-testid={`byok-action-ok-${id}`}>{result.note ?? 'done'}</span>
+}
+
+function BucketRow({
+  bucket,
+  pending,
+  result,
+  connected,
+  onRecycle,
+}: {
+  bucket: ByokBucket
+  pending: boolean
+  result: ByokPoolActionResult | undefined
+  connected: boolean
+  onRecycle: (key: string) => void
+}) {
+  return (
+    <tr data-testid={`byok-bucket-row-${bucket.key}`}>
+      <td>
+        <b className="cr-mono" data-testid={`byok-bucket-key-${bucket.key}`}>{bucket.key}</b>
+      </td>
+      <td className="cr-dim" data-testid={`byok-bucket-size-${bucket.key}`}>{bucket.size}</td>
+      <td className="cr-dim" data-testid={`byok-bucket-idle-${bucket.key}`}>{formatDurationMs(bucket.oldestIdleMs)}</td>
+      <td data-testid={`byok-bucket-actions-${bucket.key}`}>
+        <div className="cr-actions">
+          <button
+            type="button"
+            className="cr-action cr-action-danger"
+            data-testid={`byok-recycle-${bucket.key}`}
+            disabled={pending || !connected}
+            onClick={() => onRecycle(bucket.key)}
+            title="Evict all warm containers for this resource shape"
+          >
+            Recycle
+          </button>
+        </div>
+        <ActionFeedback id={`recycle:${bucket.key}`} pending={pending} result={result} />
+      </td>
+    </tr>
+  )
+}
+
+export interface ByokPoolSectionProps {
+  /** Latest snapshot, or null before the first one lands. Defaults to the store. */
+  snapshot?: ServerByokPoolStatusSnapshotMessage | null
+  /** True while a refresh is in flight. Defaults to the store flag. */
+  loading?: boolean
+  /** Whether the WS connection is up. Defaults to the store's connected phase. */
+  connected?: boolean
+  /** Refresh action. Defaults to the store's requestByokPoolStatus. */
+  onRefresh?: () => void
+  /** Action target ids with an in-flight action. Defaults to the store set. */
+  actioningIds?: Set<string>
+  /** Per-target last action outcome. Defaults to the store map. */
+  actionResults?: Record<string, ByokPoolActionResult>
+  /**
+   * Dispatch a BYOK pool action. Defaults to the store's sendByokPoolAction.
+   * Drain/recycle are always routed through the confirmation dialog first.
+   */
+  onAction?: (action: ByokPoolAction, opts?: { key?: string; maxPerKey?: number; maxTotal?: number }) => void
+  /** Injectable clock (epoch ms) for the "generated Nm ago" string. */
+  now?: () => number
+}
+
+export function ByokPoolSection({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  actioningIds: actioningIdsProp,
+  actionResults: actionResultsProp,
+  onAction: onActionProp,
+  now = Date.now,
+}: ByokPoolSectionProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.byokPoolStatus)
+  const storeLoading = useConnectionStore((s) => s.byokPoolStatusLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestByokPoolStatus = useConnectionStore((s) => s.requestByokPoolStatus)
+  const storeActioningIds = useConnectionStore((s) => s.byokPoolActioningIds)
+  const storeActionResults = useConnectionStore((s) => s.byokPoolActionResults)
+  const sendByokPoolAction = useConnectionStore((s) => s.sendByokPoolAction)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestByokPoolStatus
+  const actioningIds = actioningIdsProp ?? storeActioningIds
+  const actionResults = actionResultsProp ?? storeActionResults
+  const onAction = onActionProp ?? sendByokPoolAction
+
+  // Drain + recycle are destructive — route through a confirmation dialog.
+  // `confirm` holds the pending action ({ action: 'drain' } or { action:
+  // 'recycle', key }); null = dialog closed.
+  const [confirm, setConfirm] = useState<{ action: 'drain' | 'recycle'; key?: string } | null>(null)
+
+  // Resize inputs are local until Apply; seeded from the current effective caps.
+  const [maxPerKeyInput, setMaxPerKeyInput] = useState<string>('')
+  const [maxTotalInput, setMaxTotalInput] = useState<string>('')
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+  const stats = snapshot?.stats ?? null
+  const limits = snapshot?.limits ?? null
+  const buckets = useMemo(() => stats?.buckets ?? [], [stats])
+  const evictionEntries = useMemo(
+    () => (stats ? Object.entries(stats.evictionsByReason).filter(([, n]) => n > 0) : []),
+    [stats],
+  )
+
+  const drainPending = actioningIds.has('drain')
+  const resizePending = actioningIds.has('resize')
+
+  const handleResize = () => {
+    if (resizePending || !connected) return
+    const perKey = maxPerKeyInput.trim() === '' ? undefined : Number(maxPerKeyInput)
+    const total = maxTotalInput.trim() === '' ? undefined : Number(maxTotalInput)
+    const opts: { maxPerKey?: number; maxTotal?: number } = {}
+    if (Number.isInteger(perKey) && (perKey as number) >= 1) opts.maxPerKey = perKey
+    if (Number.isInteger(total) && (total as number) >= 1) opts.maxTotal = total
+    if (opts.maxPerKey === undefined && opts.maxTotal === undefined) return
+    onAction('resize', opts)
+  }
+
+  return (
+    <div className="cr-section" data-testid="byok-pool-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="byok-pool-eyebrow">
+          host · BYOK warm-container pool{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h1 className="cr-title">BYOK Pool</h1>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="byok-pool-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="byok-pool-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
+        {snapshot && !snapshot.enabled && snapshot.note && (
+          <p className="cr-callout" data-testid="byok-pool-disabled">{snapshot.note}</p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="byok-pool-generated">
+            {formatGeneratedAgo(generatedAtMs, now())}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="byok-pool-empty">
+          {loading ? (
+            <span>Running the BYOK pool survey…</span>
+          ) : (
+            <>
+              <p>No BYOK pool survey yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="byok-pool-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="byok-pool-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot && snapshot.enabled && (
+        <>
+          <div className="cr-chips" data-testid="byok-pool-chips">
+            <span className="cr-chip" data-testid="byok-pool-chip-warm">
+              Warm: <b data-testid="byok-pool-chip-warm-count">{stats?.totalSize ?? 0}</b>
+            </span>
+            <span className="cr-chip" data-testid="byok-pool-chip-hitrate">
+              Hit rate: <b>{stats ? `${(stats.hitRate * 100).toFixed(0)}%` : '—'}</b>
+            </span>
+            <span className="cr-chip" data-testid="byok-pool-chip-hits">
+              Hits: <b>{stats?.hits ?? 0}</b>
+            </span>
+            <span className="cr-chip" data-testid="byok-pool-chip-misses">
+              Misses: <b>{stats?.misses ?? 0}</b>
+            </span>
+            <span className="cr-chip" data-testid="byok-pool-chip-releases">
+              Releases: <b>{stats?.releases ?? 0}</b>
+            </span>
+          </div>
+
+          {limits && (
+            <div className="cr-chips" data-testid="byok-pool-limit-chips">
+              <span className="cr-chip" data-testid="byok-pool-chip-idle">
+                Idle TTL: <b>{formatDurationMs(limits.idleTimeoutMs)}</b>
+              </span>
+              <span className="cr-chip" data-testid="byok-pool-chip-perkey">
+                Per-shape cap: <b>{limits.maxPerKey}</b>
+              </span>
+              <span className="cr-chip" data-testid="byok-pool-chip-total">
+                Total cap: <b>{limits.maxTotal}</b>
+              </span>
+              <span className="cr-chip" data-testid="byok-pool-chip-maxage">
+                Max age: <b>{formatDurationMs(limits.maxAgeMs)}</b>
+              </span>
+            </div>
+          )}
+
+          {evictionEntries.length > 0 && (
+            <p className="cr-dim" data-testid="byok-pool-evictions">
+              Evictions:{' '}
+              {evictionEntries.map(([reason, n], i) => (
+                <span key={reason} className="cr-mono">
+                  {i > 0 ? ' · ' : ''}{reason} {n}
+                </span>
+              ))}
+            </p>
+          )}
+
+          {/* Pool-wide actions: drain + resize. */}
+          <section className="cr-actions-bar" data-testid="byok-pool-actions">
+            <div className="cr-actions">
+              <button
+                type="button"
+                className="cr-action cr-action-danger"
+                data-testid="byok-pool-drain"
+                disabled={drainPending || !connected}
+                onClick={() => setConfirm({ action: 'drain' })}
+                title="Evict every idle warm container across all shapes"
+              >
+                Drain all
+              </button>
+            </div>
+            <ActionFeedback id="drain" pending={drainPending} result={actionResults['drain']} />
+
+            <div className="cr-resize" data-testid="byok-pool-resize">
+              <label>
+                Per-shape cap
+                <input
+                  type="number"
+                  min={1}
+                  data-testid="byok-pool-resize-perkey"
+                  value={maxPerKeyInput}
+                  placeholder={limits ? String(limits.maxPerKey) : ''}
+                  onChange={(e) => setMaxPerKeyInput(e.target.value)}
+                  disabled={resizePending || !connected}
+                />
+              </label>
+              <label>
+                Total cap
+                <input
+                  type="number"
+                  min={1}
+                  data-testid="byok-pool-resize-total"
+                  value={maxTotalInput}
+                  placeholder={limits ? String(limits.maxTotal) : ''}
+                  onChange={(e) => setMaxTotalInput(e.target.value)}
+                  disabled={resizePending || !connected}
+                />
+              </label>
+              <button
+                type="button"
+                className="cr-action"
+                data-testid="byok-pool-resize-apply"
+                disabled={resizePending || !connected}
+                onClick={handleResize}
+                title="Tighten the runtime caps (the server clamps to the host-configured ceiling)"
+              >
+                Resize
+              </button>
+              <ActionFeedback id="resize" pending={resizePending} result={actionResults['resize']} />
+            </div>
+          </section>
+
+          <section className="cr-table-wrap">
+            <table className="cr-table" data-testid="byok-pool-table">
+              <thead>
+                <tr>
+                  <th>Resource shape (key)</th>
+                  <th>Warm</th>
+                  <th>Oldest idle</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {buckets.length === 0 ? (
+                  <tr data-testid="byok-pool-no-buckets">
+                    <td colSpan={4} className="cr-dim">No warm containers parked right now.</td>
+                  </tr>
+                ) : (
+                  buckets.map((b) => (
+                    <BucketRow
+                      key={b.key}
+                      bucket={b}
+                      pending={actioningIds.has(targetId('recycle', b.key))}
+                      result={actionResults[targetId('recycle', b.key)]}
+                      connected={connected}
+                      onRecycle={(key) => setConfirm({ action: 'recycle', key })}
+                    />
+                  ))
+                )}
+              </tbody>
+            </table>
+          </section>
+        </>
+      )}
+
+      <ConfirmDialog
+        open={confirm !== null}
+        title={confirm?.action === 'drain' ? 'Drain the BYOK pool?' : 'Recycle this shape?'}
+        danger
+        confirmLabel={confirm?.action === 'drain' ? 'Drain all' : 'Recycle'}
+        message={
+          confirm?.action === 'drain' ? (
+            <>This evicts <b>every</b> idle warm container across all resource shapes. In-flight sessions keep their containers; the next acquire creates fresh ones.</>
+          ) : confirm?.action === 'recycle' ? (
+            <>This evicts every idle warm container for <b className="cr-mono">{confirm.key}</b>. The next acquire for that shape creates a fresh container.</>
+          ) : null
+        }
+        onConfirm={() => {
+          if (confirm?.action === 'drain') onAction('drain')
+          else if (confirm?.action === 'recycle' && confirm.key) onAction('recycle', { key: confirm.key })
+          setConfirm(null)
+        }}
+        onCancel={() => setConfirm(null)}
+      />
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -42,6 +42,7 @@ import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRe
 import { RunnerStatusSection } from './RunnerStatusSection'
 import { ContainersStatusSection } from './ContainersStatusSection'
 import { RepoRuntimeConfigSection } from './RepoRuntimeConfigSection'
+import { ByokPoolSection } from './ByokPoolSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { SkillsInventorySection } from './SkillsInventorySection'
 import { MailboxPanel } from './MailboxPanel'
@@ -143,6 +144,19 @@ export const CONTROL_ROOM_TABS = [
     snapshotKey: 'repoRuntimeConfig',
     loadingKey: 'repoRuntimeConfigLoading',
     requestKey: 'requestRepoRuntimeConfig',
+  },
+  // #6135 (epic #5530): the BYOK Pool tab — host-wide survey of the BYOK warm-
+  // container pool (enabled flag, configured limits, live stats + per-shape warm
+  // buckets) with drain / recycle / resize mutating actions. Same survey:true
+  // request/snapshot flow as the others; the #5546 staleness guard comes free.
+  {
+    key: 'byok-pool',
+    label: 'BYOK pool',
+    survey: true,
+    requestType: 'byok_pool_status_request',
+    snapshotKey: 'byokPoolStatus',
+    loadingKey: 'byokPoolStatusLoading',
+    requestKey: 'requestByokPoolStatus',
   },
   {
     key: 'integrations',
@@ -397,6 +411,8 @@ export function ControlRoomView({
         <ContainersStatusSection />
       ) : tab === 'repo-config' ? (
         <RepoRuntimeConfigSection />
+      ) : tab === 'byok-pool' ? (
+        <ByokPoolSection />
       ) : tab === 'integrations' ? (
         <IntegrationsSection />
       ) : tab === 'skills' ? (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -505,6 +505,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // the repo_runtime_config_snapshot handler. Null until the first survey lands.
   repoRuntimeConfig: null,
   repoRuntimeConfigLoading: false,
+  // #6135 (epic #5530): Control Room BYOK pool snapshot, fed by the
+  // byok_pool_status_snapshot handler. Null until the first survey lands.
+  byokPoolStatus: null,
+  byokPoolStatusLoading: false,
   // #5499 (epic #5498): Control Room Integrations snapshot, fed by the
   // integration_status_snapshot handler. Null until the first survey lands.
   integrationStatus: null,
@@ -524,6 +528,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // outcome per environment for inline display (same lifecycle as reindex).
   containerActioningIds: new Set<string>(),
   containerActionResults: {},
+  // #6135 slice 3: BYOK pool action — in-flight target ids + last outcome per
+  // target for inline display (same lifecycle as containerActioningIds).
+  byokPoolActioningIds: new Set<string>(),
+  byokPoolActionResults: {},
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -1023,6 +1031,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return false;
   },
 
+  // #6135 (epic #5530): request a BYOK pool survey. Mirrors
+  // requestContainersStatus — flips byokPoolStatusLoading and sends a
+  // byok_pool_status_request; the reply is a single byok_pool_status_snapshot
+  // handled into byokPoolStatus. Returns false (and does NOT set loading) when
+  // the socket is closed.
+  requestByokPoolStatus: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ byokPoolStatusLoading: true });
+      wsSend(socket, { type: 'byok_pool_status_request' });
+      return true;
+    }
+    return false;
+  },
+
   // #5499 (epic #5498): request an Integrations survey. Mirrors
   // requestRunnerStatus — flips integrationStatusLoading and sends an
   // integration_status_request; the reply is a single
@@ -1118,6 +1141,43 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     delete results[environmentId];
     set({ containerActioningIds: pending, containerActionResults: results });
     wsSend(socket, { type: 'containers_action', action, environmentId, requestId });
+    return true;
+  },
+
+  // #6135 slice 3 (epic #5530): run a BYOK pool mutating action. The pool is a
+  // single process-wide singleton, so the target id keys the pending/result
+  // state: 'drain' (pool-wide), 'recycle:<key>' (one bucket), 'resize'
+  // (pool-wide). Same wire-or-nothing contract as sendContainersAction — tag the
+  // request with a requestId the server echoes on the byok_pool_action_ack /
+  // BYOK_POOL_ACTION_FAILED session_error, and mark the target pending ONLY when
+  // the message is genuinely on the wire (never queued offline). For recycle the
+  // bucket key is required and is the survey's own key — the server re-validates
+  // it against the live pool's inspect() before any exec. For resize the caps are
+  // passed through and the server clamps them to the configured ceiling. The
+  // target's previous inline result is dropped so a stale outcome can't sit next
+  // to the pending state. Drain/recycle confirmation lives in the UI.
+  sendByokPoolAction: (
+    action: 'drain' | 'recycle' | 'resize',
+    opts?: { key?: string; maxPerKey?: number; maxTotal?: number },
+  ): boolean => {
+    const { socket } = get();
+    if (action !== 'drain' && action !== 'recycle' && action !== 'resize') return false;
+    if (action === 'recycle' && !opts?.key) return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const targetId = action === 'recycle' ? `recycle:${opts!.key}` : action;
+    const requestId = `byok-pool-action-${nextMessageId()}`;
+    const pending = new Set(get().byokPoolActioningIds);
+    pending.add(targetId);
+    const results = { ...get().byokPoolActionResults };
+    delete results[targetId];
+    set({ byokPoolActioningIds: pending, byokPoolActionResults: results });
+    const msg: Record<string, unknown> = { type: 'byok_pool_action', action, requestId };
+    if (action === 'recycle') msg.key = opts!.key;
+    if (action === 'resize') {
+      if (typeof opts?.maxPerKey === 'number') msg.maxPerKey = opts.maxPerKey;
+      if (typeof opts?.maxTotal === 'number') msg.maxTotal = opts.maxTotal;
+    }
+    wsSend(socket, msg);
     return true;
   },
 
@@ -1905,6 +1965,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().containerActioningIds.size > 0) {
         set({ containerActioningIds: new Set<string>() });
       }
+      // #6135: ditto for in-flight BYOK pool actions — the ack/failure is
+      // socket-scoped, so clear pending targets on a drop. (The server-side
+      // action keeps running; the next survey refresh shows its effect.)
+      if (get().byokPoolActioningIds.size > 0) {
+        set({ byokPoolActioningIds: new Set<string>() });
+      }
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
@@ -2179,6 +2245,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6134: container lifecycle action pending/result state goes with it.
       containerActioningIds: new Set<string>(),
       containerActionResults: {},
+      // #6135: BYOK pool action pending/result state goes with it.
+      byokPoolActioningIds: new Set<string>(),
+      byokPoolActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -2219,6 +2288,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6134: container lifecycle action pending/result state goes with it.
       containerActioningIds: new Set<string>(),
       containerActionResults: {},
+      // #6135: BYOK pool action pending/result state goes with it.
+      byokPoolActioningIds: new Set<string>(),
+      byokPoolActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-byok-pool-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-byok-pool-action.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Integration test for the BYOK pool action wiring (#6135 slice 3, epic #5530).
+ *
+ * Guards the wire path between the dashboard message handler and the store:
+ *   - `byok_pool_action_ack` clears the action TARGET's pending state and records
+ *     a human note for inline display. The target id is 'drain' / 'recycle:<key>'
+ *     / 'resize', matching sendByokPoolAction's keys.
+ *   - a malformed ack is dropped (Zod safeParse) without mutating state.
+ *   - a BYOK_POOL_ACTION_FAILED session_error clears the echoed target's pending
+ *     state and records the message as an inline error.
+ *   - other targets' pending state is never touched by an ack/error for one.
+ *
+ * Mirrors dispatch-containers-action.test.ts (the container action's test).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+
+const BUCKET = 'node:22|/p|2g|2|chroxy'
+const RECYCLE_TARGET = `recycle:${BUCKET}`
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    byokPoolActioningIds: new Set(['drain', RECYCLE_TARGET, 'resize']),
+    byokPoolActionResults: {},
+    messages: [],
+  }
+}
+
+describe('byok pool action dispatch (#6135 slice 3)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('a drain ack clears the drain target and records an evicted-count note', () => {
+    handleMessage({ type: 'byok_pool_action_ack', action: 'drain', requestId: 'a', drained: 3 }, ctx() as never)
+    const s = store.getState()
+    expect(s.byokPoolActioningIds.has('drain')).toBe(false)
+    expect(s.byokPoolActioningIds.has(RECYCLE_TARGET)).toBe(true) // others untouched
+    expect(s.byokPoolActioningIds.has('resize')).toBe(true)
+    expect(s.byokPoolActionResults['drain']!.error).toBeNull()
+    expect(s.byokPoolActionResults['drain']!.note).toMatch(/Drained — evicted 3/)
+  })
+
+  it('a recycle ack clears the recycle:<key> target keyed by the echoed key', () => {
+    handleMessage({ type: 'byok_pool_action_ack', action: 'recycle', key: BUCKET, drained: 2 }, ctx() as never)
+    const s = store.getState()
+    expect(s.byokPoolActioningIds.has(RECYCLE_TARGET)).toBe(false)
+    expect(s.byokPoolActioningIds.has('drain')).toBe(true)
+    expect(s.byokPoolActionResults[RECYCLE_TARGET]!.note).toMatch(/Recycled — evicted 2/)
+  })
+
+  it('a resize ack clears the resize target and notes evicted + new caps', () => {
+    handleMessage(
+      {
+        type: 'byok_pool_action_ack',
+        action: 'resize',
+        evicted: 4,
+        limits: { idleTimeoutMs: 300000, maxPerKey: 1, maxTotal: 2, maxAgeMs: null },
+        configured: { maxPerKey: 2, maxTotal: 8 },
+      },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.byokPoolActioningIds.has('resize')).toBe(false)
+    expect(s.byokPoolActionResults['resize']!.note).toMatch(/Resized — evicted 4 \(caps now 1\/key, 2 total\)/)
+  })
+
+  it('drops a malformed ack (missing action) without touching pending state', () => {
+    handleMessage({ type: 'byok_pool_action_ack', drained: 1 }, ctx() as never)
+    const s = store.getState()
+    expect(s.byokPoolActioningIds.has('drain')).toBe(true)
+    expect(s.byokPoolActionResults['drain']).toBeUndefined()
+  })
+
+  it('BYOK_POOL_ACTION_FAILED clears the echoed target and records the inline error', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage(
+      {
+        type: 'session_error',
+        code: 'BYOK_POOL_ACTION_FAILED',
+        message: 'docker rm -f failed',
+        reason: 'drain-failed',
+        action: 'drain',
+        requestId: 'a',
+      },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.byokPoolActioningIds.has('drain')).toBe(false)
+    expect(s.byokPoolActioningIds.has(RECYCLE_TARGET)).toBe(true)
+    expect(s.byokPoolActionResults['drain']!.error).toMatch(/docker rm -f failed/)
+    expect(s.byokPoolActionResults['drain']!.note).toBeNull()
+  })
+
+  it('a recycle failure clears the recycle:<key> target keyed by the echoed key', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage(
+      {
+        type: 'session_error',
+        code: 'BYOK_POOL_ACTION_FAILED',
+        message: 'unknown key',
+        reason: 'unknown-key',
+        action: 'recycle',
+        key: BUCKET,
+      },
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.byokPoolActioningIds.has(RECYCLE_TARGET)).toBe(false)
+    expect(s.byokPoolActioningIds.has('drain')).toBe(true)
+    expect(s.byokPoolActionResults[RECYCLE_TARGET]!.error).toMatch(/unknown key/)
+  })
+
+  it('a BYOK_POOL_ACTION_FAILED without an action leaves action state alone', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'BYOK_POOL_ACTION_FAILED', message: 'boom' }, ctx() as never)
+    const s = store.getState()
+    expect(s.byokPoolActioningIds.has('drain')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/dispatch-byok-pool-status.test.ts
+++ b/packages/dashboard/src/store/dispatch-byok-pool-status.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration test for the BYOK pool survey Control Room wiring (#6135, epic
+ * #5530).
+ *
+ * Guards the wire path between the dashboard message handler and the store:
+ *   - `byok_pool_status_snapshot` REPLACES `byokPoolStatus` and clears
+ *     `byokPoolStatusLoading`.
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state and
+ *     WITHOUT clearing the loading flag.
+ *   - a disabled-pool snapshot is a valid, first-class state.
+ *
+ * Mirrors dispatch-containers-status.test.ts (the containers survey's sibling).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerByokPoolStatusSnapshotMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    byokPoolStatus: null,
+    byokPoolStatusLoading: true,
+    messages: [],
+  }
+}
+
+function snapshot(over: Partial<ServerByokPoolStatusSnapshotMessage> = {}): ServerByokPoolStatusSnapshotMessage {
+  return {
+    type: 'byok_pool_status_snapshot',
+    generatedAt: '2026-06-19T11:50:00.000Z',
+    enabled: true,
+    note: null,
+    limits: { idleTimeoutMs: 300000, maxPerKey: 2, maxTotal: 8, maxAgeMs: 1800000 },
+    stats: {
+      hits: 5, misses: 2, releases: 4, shutdowns: 1, hitRate: 0.71, totalSize: 3,
+      buckets: [{ key: 'node:22|/p|2g|2|chroxy', size: 2, oldestIdleMs: 12000 }],
+      evictionsByReason: { idle: 3 },
+      recentEvictions: [{ key: 'node:22|/p|2g|2|chroxy', containerId: 'abc123', reason: 'idle', timestamp: 1000 }],
+    },
+    ...over,
+  } as ServerByokPoolStatusSnapshotMessage
+}
+
+describe('byok pool status dispatch (#6135)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('applies byok_pool_status_snapshot and clears the loading flag', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.byokPoolStatus).not.toBeNull()
+    expect(s.byokPoolStatus!.enabled).toBe(true)
+    expect(s.byokPoolStatus!.stats!.hits).toBe(5)
+    expect(s.byokPoolStatus!.stats!.buckets.map((b) => b.key)).toEqual(['node:22|/p|2g|2|chroxy'])
+    expect(s.byokPoolStatusLoading).toBe(false)
+  })
+
+  it('relays a disabled-pool snapshot as a first-class enabled:false state', () => {
+    handleMessage(
+      snapshot({ enabled: false, note: 'BYOK container pool is disabled.', limits: null, stats: null }),
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.byokPoolStatus!.enabled).toBe(false)
+    expect(s.byokPoolStatus!.limits).toBeNull()
+    expect(s.byokPoolStatus!.stats).toBeNull()
+    expect(s.byokPoolStatusLoading).toBe(false)
+  })
+
+  it('replaces a prior snapshot wholesale (no merge)', () => {
+    handleMessage(snapshot(), ctx() as never)
+    handleMessage(snapshot({ stats: { ...snapshot().stats!, hits: 99, buckets: [] } }), ctx() as never)
+    const s = store.getState()
+    expect(s.byokPoolStatus!.stats!.hits).toBe(99)
+    expect(s.byokPoolStatus!.stats!.buckets).toEqual([])
+  })
+
+  it('drops a malformed snapshot without mutating state or clearing loading', () => {
+    const before = store.getState().byokPoolStatus
+    // Missing required `enabled`.
+    handleMessage({ type: 'byok_pool_status_snapshot', generatedAt: '2026-06-19T11:50:00.000Z' }, ctx() as never)
+    expect(store.getState().byokPoolStatus).toBe(before)
+    expect(store.getState().byokPoolStatusLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2601,6 +2601,17 @@ function handleRepoRuntimeConfigSnapshot(msg: Record<string, unknown>, _get: Msg
 }
 
 /**
+ * #6135 (epic #5530) — BYOK pool survey `byok_pool_status_snapshot`: REPLACE the
+ * stored snapshot and clear the loading flag. Same defensive, full-replace,
+ * clear-loading-only-on-valid-parse contract as the sibling survey handlers.
+ */
+function handleByokPoolStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerByokPoolStatusSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ byokPoolStatus: parsed.data, byokPoolStatusLoading: false });
+}
+
+/**
  * #5499 (epic #5498) — Integrations survey `integration_status_snapshot`:
  * REPLACE the stored survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host and
@@ -2729,6 +2740,60 @@ function handleContainersActionAck(msg: Record<string, unknown>, get: MsgGet, se
 }
 
 /**
+ * #6135 slice 3 (epic #5530) — derive the pending/result TARGET id for a BYOK
+ * pool action from its echoed `action` (+ `key` for recycle). Must match the id
+ * `sendByokPoolAction` registers: 'drain' / 'recycle:<key>' / 'resize'. A
+ * recycle with no key can't have a live pending entry, so it maps to the bare
+ * action (a harmless no-op delete).
+ */
+function byokPoolActionTargetId(action: string, key: string | null | undefined): string {
+  return action === 'recycle' && typeof key === 'string' && key.length > 0 ? `recycle:${key}` : action;
+}
+
+/**
+ * #6135 slice 3 — resolve one BYOK pool action target's pending state: drop the
+ * target id from `byokPoolActioningIds` and record the outcome (a human `note`,
+ * or a failure message) in `byokPoolActionResults` for inline display. Shared by
+ * the success ack and the BYOK_POOL_ACTION_FAILED session_error — the same
+ * clear-pending-on-either-outcome contract as the container/reindex pairs.
+ */
+function resolveByokPoolAction(
+  get: MsgGet,
+  set: MsgSet,
+  targetId: string,
+  result: { action: string; note: string | null; error: string | null },
+): void {
+  const pending = new Set(get().byokPoolActioningIds);
+  pending.delete(targetId);
+  set({
+    byokPoolActioningIds: pending,
+    byokPoolActionResults: { ...get().byokPoolActionResults, [targetId]: { ...result, at: Date.now() } },
+  });
+}
+
+/**
+ * #6135 slice 3 — BYOK pool action success ack: positive confirmation that the
+ * `byok_pool_action` drain / recycle / resize completed. Builds a human note
+ * from the echoed result (drained/evicted counts, new limits) and clears the
+ * matching target's pending state. A malformed ack is dropped (Zod safeParse) so
+ * the row keeps its honest pending state rather than clearing on a half-true
+ * message.
+ */
+function handleByokPoolActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerByokPoolActionAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const { action, key, drained, evicted, limits } = parsed.data;
+  let note: string;
+  if (action === 'resize') {
+    const caps = limits ? ` (caps now ${limits.maxPerKey}/key, ${limits.maxTotal} total)` : '';
+    note = `Resized — evicted ${evicted ?? 0}${caps}`;
+  } else {
+    note = `${action === 'recycle' ? 'Recycled' : 'Drained'} — evicted ${drained ?? 0}`;
+  }
+  resolveByokPoolAction(get, set, byokPoolActionTargetId(action, key), { action, note, error: null });
+}
+
+/**
  * #5547: a `summarize_session_result` resolves the pending summarize promise
  * (keyed by the echoed requestId) so the awaiting create-session flow opens
  * with the brief seeded. The failure half (SUMMARIZE_FAILED) rejects the same
@@ -2843,6 +2908,8 @@ const HANDLERS: Record<string, Handler> = {
   containers_status_snapshot: handleContainersStatusSnapshot,
   // #6139 (epic #5530): Control Room per-repo runtime config survey snapshot.
   repo_runtime_config_snapshot: handleRepoRuntimeConfigSnapshot,
+  // #6135 (epic #5530): Control Room BYOK pool survey snapshot.
+  byok_pool_status_snapshot: handleByokPoolStatusSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
   skills_inventory_snapshot: handleSkillsInventorySnapshot,
@@ -2852,6 +2919,9 @@ const HANDLERS: Record<string, Handler> = {
   // #6134 (epic #5530): positive ack correlating a containers_action (stop /
   // restart / destroy) request to its outcome.
   containers_action_ack: handleContainersActionAck,
+  // #6135 (epic #5530): positive ack correlating a byok_pool_action (drain /
+  // recycle / resize) request to its outcome.
+  byok_pool_action_ack: handleByokPoolActionAck,
   // #5547: one-shot session-summary result; resolves the pending summarize
   // promise so the create-session flow can open with the brief seeded.
   summarize_session_result: handleSummarizeSessionResult,
@@ -3571,6 +3641,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           action: typeof msg.action === 'string' ? msg.action : '',
           status: null,
           error: parsed.message || 'Container action failed.',
+        });
+      } else if (parsed.code === 'BYOK_POOL_ACTION_FAILED' && typeof msg.action === 'string') {
+        // #6135: a failed byok_pool_action echoes the exact action (+ key for
+        // recycle) — clear that target's pending state and surface the reason
+        // inline (the generic branch below still raises the toast, matching the
+        // CONTAINER_ACTION_FAILED precedent).
+        resolveByokPoolAction(get, set, byokPoolActionTargetId(msg.action, typeof msg.key === 'string' ? msg.key : null), {
+          action: msg.action,
+          note: null,
+          error: parsed.message || 'BYOK pool action failed.',
         });
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -566,6 +566,23 @@ export interface ContainerActionResult {
   at: number;
 }
 
+/**
+ * #6135 slice 3 (epic #5530) — outcome of the last BYOK pool mutating action
+ * (drain / recycle / resize) for one action target, kept for inline display.
+ * The target id is `'drain'`, `'recycle:<bucket key>'`, or `'resize'` (the pool
+ * is a single process-wide singleton — drain/resize are pool-wide, recycle is
+ * per-resource-shape bucket). A successful `byok_pool_action_ack` records the
+ * echoed `action` + a human `note` (drained/evicted counts) with `error: null`;
+ * a BYOK_POOL_ACTION_FAILED session_error records the message with `note: null`.
+ * `at` is the local receipt time (epoch ms).
+ */
+export interface ByokPoolActionResult {
+  action: string;
+  note: string | null;
+  error: string | null;
+  at: number;
+}
+
 export interface ConnectionState {
   // Connection
   connectionPhase: ConnectionPhase;
@@ -745,6 +762,22 @@ export interface ConnectionState {
   repoRuntimeConfigLoading: boolean;
 
   /**
+   * #6135 (epic #5530) — Control Room BYOK pool survey: the latest
+   * `byok_pool_status_snapshot` (enabled flag, configured limits, live stats +
+   * per-shape warm buckets), or null before the first one lands (the BYOK Pool
+   * section renders an empty/loading state). Replaced wholesale on each snapshot
+   * (full picture, no delta stream).
+   */
+  byokPoolStatus: ServerByokPoolStatusSnapshotMessage | null;
+  /**
+   * #6135 — true between dispatching a `byok_pool_status_request` and the
+   * matching `byok_pool_status_snapshot` arriving, so the tab's Refresh button
+   * can spin. Cleared when a VALID snapshot lands (a malformed payload is
+   * dropped and leaves this true, matching the sibling surveys).
+   */
+  byokPoolStatusLoading: boolean;
+
+  /**
    * #5499 (epic #5498) — Control Room Integrations survey: the latest
    * `integration_status_snapshot` from the server (per-repo repo-memory
    * status). `null` until the first snapshot lands (the Integrations section
@@ -814,6 +847,19 @@ export interface ConnectionState {
    * again.
    */
   containerActionResults: Record<string, ContainerActionResult>;
+  /**
+   * #6135 slice 3 (epic #5530) — action target ids with an in-flight
+   * `byok_pool_action`: set when sendByokPoolAction is called, cleared on the
+   * `byok_pool_action_ack` / BYOK_POOL_ACTION_FAILED session_error. Keyed by the
+   * action target (`'drain'`, `'recycle:<bucket key>'`, `'resize'`) so each
+   * control disables independently while its action is on the wire.
+   */
+  byokPoolActioningIds: Set<string>;
+  /**
+   * #6135 slice 3 — last BYOK pool action outcome per target id, for inline
+   * display. Replaced when the same target is actioned again.
+   */
+  byokPoolActionResults: Record<string, ByokPoolActionResult>;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;
@@ -1379,6 +1425,13 @@ export interface ConnectionState {
   // `containersStatusLoading` while in flight.
   requestContainersStatus: () => boolean;
 
+  // #6135 (epic #5530): request a BYOK pool survey. Dispatches a
+  // `byok_pool_status_request`; the server replies with a single
+  // `byok_pool_status_snapshot` handled into `byokPoolStatus`. Returns whether
+  // the message went on the wire (false = socket closed). Sets
+  // `byokPoolStatusLoading` while in flight.
+  requestByokPoolStatus: () => boolean;
+
   // #6139 (epic #5530): request a per-repo runtime config survey. Dispatches a
   // `repo_runtime_config_request`; the server replies with a single
   // `repo_runtime_config_snapshot` handled into `repoRuntimeConfig`. Returns
@@ -1429,6 +1482,26 @@ export interface ConnectionState {
   // queuing, so the row can't strand mid-action. Destroy confirmation is the
   // caller's responsibility (the UI gates it behind a ConfirmDialog).
   sendContainersAction: (environmentId: string, action: 'stop' | 'restart' | 'destroy') => boolean;
+
+  // #6135 slice 3 (epic #5530): run a BYOK pool mutating action. The pool is a
+  // single process-wide singleton, so the actions differ by shape:
+  //   - 'drain'   — evict all idle warm containers (no target).
+  //   - 'recycle' — evict one resource-shape bucket; pass `opts.key` (the
+  //     bucket key the survey enumerated; the server re-validates it against the
+  //     live pool before any exec).
+  //   - 'resize'  — set runtime caps; pass `opts.maxPerKey` / `opts.maxTotal`
+  //     (the server clamps each to the operator-configured ceiling).
+  // Dispatches a `byok_pool_action` tagged with a requestId the server echoes on
+  // the `byok_pool_action_ack` / BYOK_POOL_ACTION_FAILED session_error. Marks
+  // the action target (`'drain'` / `'recycle:<key>'` / `'resize'`) in
+  // `byokPoolActioningIds` (and drops its stale result) ONLY when the message
+  // actually went on the wire; an offline send (or a recycle with no key) returns
+  // false without queuing. Drain/recycle confirmation is the caller's
+  // responsibility (the UI gates them behind a ConfirmDialog).
+  sendByokPoolAction: (
+    action: 'drain' | 'recycle' | 'resize',
+    opts?: { key?: string; maxPerKey?: number; maxTotal?: number },
+  ) => boolean;
 
   // #5547: request a server-side one-shot summary of a session's persisted
   // history (the sidebar "Summarize & start new session" action). Dispatches a

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -80,8 +80,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'byok_pool_status_snapshot', // #6135 (epic #5530) — Control Room BYOK container-pool stats survey reply. Server contract (survey + handler + protocol) landed first; the dashboard surface that consumes the snapshot is the tracked follow-up slice, at which point this moves to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
-  'byok_pool_action_ack', // #6135 slice 2 (epic #5530) — Control Room BYOK pool mutating-action (drain/recycle/resize) ack. Server contract (pool methods + handler + protocol) landed first; the dashboard slice that consumes the ack to clear pending row state is the tracked follow-up (slice 3), at which point this moves to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -157,6 +155,8 @@ const PLATFORM_SPECIFIC = {
   'integration_status_snapshot': 'dashboard', // Control Room Integrations survey reply (#5499, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'integration_action_ack': 'dashboard', // Control Room Integrations Reindex action ack (#5500, epic #5498) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'containers_action_ack': 'dashboard', // Control Room container lifecycle action ack (#6134, epic #5530) — the dashboard consumes it to clear pending row state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'byok_pool_status_snapshot': 'dashboard', // Control Room BYOK pool stats survey reply (#6135, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'byok_pool_action_ack': 'dashboard', // Control Room BYOK pool mutating-action (drain/recycle/resize) ack (#6135, epic #5530) — the dashboard consumes it to clear pending target state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'mailbox_status_snapshot': 'dashboard', // Control Room "Mailbox" tab survey reply (#5914 follow-up) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -144,6 +144,8 @@ const DASHBOARD_ONLY = new Set<string>([
   'containers_status_snapshot', // Control Room containers & environments survey (#6133, epic #5530) — dashboard-only
   'containers_action_ack',      // Control Room container lifecycle action ack (#6134, epic #5530) — dashboard-only
   'repo_runtime_config_snapshot', // Control Room per-repo runtime config survey (#6139, epic #5530) — dashboard-only
+  'byok_pool_status_snapshot',  // Control Room BYOK pool survey (#6135, epic #5530) — dashboard-only
+  'byok_pool_action_ack',       // Control Room BYOK pool action ack (#6135, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -192,13 +194,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'byok_pool_status_snapshot',            // #6135 (epic #5530) Control Room BYOK pool stats survey —
-                                          //   server contract landed first; the dashboard surface that consumes
-                                          //   the snapshot is the tracked follow-up, then this → DASHBOARD_ONLY
-  'byok_pool_action_ack',                 // #6135 slice 2 (epic #5530) Control Room BYOK pool mutating-action
-                                          //   (drain/recycle/resize) ack — server contract landed first; the
-                                          //   dashboard slice that consumes the ack is the tracked follow-up
-                                          //   (slice 3), then this → DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The dashboard surface for the Control Room **BYOK Pool** tab — slice 3 of #6135, completing the epic sub-issue. Consumes the slice-1 survey (#6150) and the slice-2 actions (#6151). Mirrors the Containers tab's survey + action discipline (#6133/#6134).

### Tab (`ByokPoolSection.tsx`)
- **Disabled is first-class** — pool off (the default) renders the `note`, no table/actions.
- **Enabled:** stats chips (warm / hit-rate / hits / misses / releases) + configured-limits chips (idle TTL / per-shape cap / total cap / max-age) + evictions-by-reason line.
- **Per-resource-shape bucket table** (key, warm count, oldest idle) with a per-row **Recycle** button.
- **Pool-wide actions:** **Drain all** + a **Resize** form (per-shape / total caps).
- Drain + recycle gate behind a `ConfirmDialog`; resize submits directly (the server clamps to the operator-configured ceiling).

### Store (`connection.ts` / `types.ts` / `message-handler.ts`)
- `byokPoolStatus` + `byokPoolStatusLoading` + `requestByokPoolStatus` (mirrors the sibling surveys).
- `byokPoolActioningIds` / `byokPoolActionResults` keyed by **action target** (`'drain'` / `'recycle:<bucket key>'` / `'resize'` — the pool is a single process-wide singleton, so there's no per-pool id) + `sendByokPoolAction(action, opts)` (wire-or-nothing, no offline queue), cleared on disconnect/forget.
- `byok_pool_status_snapshot` handler (full replace) + `byok_pool_action_ack` handler (builds a drained/evicted note) + `BYOK_POOL_ACTION_FAILED` `session_error` branch — both routed by the echoed action (+ key for recycle).

### Coverage
Both guards promoted `byok_pool_status_snapshot` + `byok_pool_action_ack` from unhandled → `dashboard` / `DASHBOARD_ONLY` (protocol handler-coverage + store-core protocol-type-coverage-lint).

## Tests
- `ByokPoolSection.test.tsx` — empty / loading / not-connected / disabled / enabled; stats+limits chips; bucket rows; Drain + Recycle confirm-dialog flow; Resize submit (and empty-input no-op); pending → settled note; Refresh dispatch + disabled-while-loading.
- `dispatch-byok-pool-status.test.ts` — snapshot apply / wholesale-replace / malformed-drop / disabled state.
- `dispatch-byok-pool-action.test.ts` — drain/recycle/resize ack target-id keying + note text; malformed-drop; BYOK_POOL_ACTION_FAILED clears the echoed target; no-action leaves state alone.
- Dashboard `tsc` + full suite **3912 green**; protocol 340; store-core 1679.

Closes #6135. Part of epic #5530.