### PR TITLE
feat(dashboard): Host prune Control Room tab (#6140 slice 2)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -43,6 +43,7 @@ import { RunnerStatusSection } from './RunnerStatusSection'
 import { ContainersStatusSection } from './ContainersStatusSection'
 import { RepoRuntimeConfigSection } from './RepoRuntimeConfigSection'
 import { ByokPoolSection } from './ByokPoolSection'
+import { HostPruneSection } from './HostPruneSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { SkillsInventorySection } from './SkillsInventorySection'
 import { MailboxPanel } from './MailboxPanel'
@@ -157,6 +158,19 @@ export const CONTROL_ROOM_TABS = [
     snapshotKey: 'byokPoolStatus',
     loadingKey: 'byokPoolStatusLoading',
     requestKey: 'requestByokPoolStatus',
+  },
+  // #6140 (epic #5530): the Host prune tab — reclaimable, chroxy-scoped,
+  // orphan-only docker pressure (stopped chroxy containers + chroxy snapshot
+  // images not tracked by a live env) with drain/recycle-style prune actions.
+  // Same survey:true request/snapshot flow as the others.
+  {
+    key: 'host-prune',
+    label: 'Host prune',
+    survey: true,
+    requestType: 'host_prune_status_request',
+    snapshotKey: 'hostPruneStatus',
+    loadingKey: 'hostPruneStatusLoading',
+    requestKey: 'requestHostPruneStatus',
   },
   {
     key: 'integrations',
@@ -413,6 +427,8 @@ export function ControlRoomView({
         <RepoRuntimeConfigSection />
       ) : tab === 'byok-pool' ? (
         <ByokPoolSection />
+      ) : tab === 'host-prune' ? (
+        <HostPruneSection />
       ) : tab === 'integrations' ? (
         <IntegrationsSection />
       ) : tab === 'skills' ? (

--- a/packages/dashboard/src/components/HostPruneSection.test.tsx
+++ b/packages/dashboard/src/components/HostPruneSection.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * HostPruneSection (#6140, epic #5530) — renderer tests.
+ *
+ * Covers the surface against a mocked `host_prune_status_snapshot`:
+ *   - empty / loading / not-connected states before the first snapshot
+ *   - docker-unavailable note (no tables/actions)
+ *   - summary chips + container/image tables
+ *   - each prune button routes through the ConfirmDialog before onAction
+ *   - buttons disable when their resource class is empty / while actioning
+ *   - pending → settled note; Refresh dispatch + disabled-while-loading
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ServerHostPruneStatusSnapshotMessage } from '@chroxy/protocol'
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      hostPruneStatus: null,
+      hostPruneStatusLoading: false,
+      connectionPhase: 'connected',
+      requestHostPruneStatus: () => false,
+      hostPruneActioningIds: new Set<string>(),
+      hostPruneActionResults: {},
+      sendHostPruneAction: () => false,
+    }),
+}))
+import { HostPruneSection } from './HostPruneSection'
+
+afterEach(cleanup)
+
+function snapshot(over: Partial<ServerHostPruneStatusSnapshotMessage> = {}): ServerHostPruneStatusSnapshotMessage {
+  return {
+    type: 'host_prune_status_snapshot',
+    generatedAt: '2026-06-19T12:00:00.000Z',
+    dockerAvailable: true,
+    note: null,
+    containers: [{ id: 'aaa111222333', name: 'chroxy-env-foo', state: 'exited', sizeBytes: 12_000_000 }],
+    images: [{ id: 'img111222333', ref: 'chroxy-env:foo-1', repository: 'chroxy-env', sizeBytes: 1_000_000_000 }],
+    summary: { containerCount: 1, imageCount: 1, reclaimableBytes: 1_012_000_000 },
+    ...over,
+  } as ServerHostPruneStatusSnapshotMessage
+}
+
+describe('HostPruneSection — empty / loading / not-connected', () => {
+  it('renders the empty state with a Run-survey button when no snapshot', () => {
+    render(<HostPruneSection snapshot={null} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('host-prune-empty')).toBeTruthy()
+    expect(screen.queryByTestId('host-prune-containers-table')).toBeNull()
+  })
+
+  it('disables the run button when not connected', () => {
+    render(<HostPruneSection snapshot={null} loading={false} connected={false} onRefresh={() => {}} />)
+    expect((screen.getByTestId('host-prune-empty-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+describe('HostPruneSection — docker unavailable', () => {
+  it('renders the no-docker note and no tables/actions', () => {
+    render(
+      <HostPruneSection
+        snapshot={snapshot({ dockerAvailable: false, note: 'docker is unavailable', containers: [], images: [], summary: { containerCount: 0, imageCount: 0, reclaimableBytes: 0 } })}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('host-prune-no-docker').textContent).toContain('unavailable')
+    expect(screen.queryByTestId('host-prune-actions')).toBeNull()
+  })
+})
+
+describe('HostPruneSection — populated', () => {
+  it('renders summary chips + both tables', () => {
+    render(<HostPruneSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('host-prune-chip-containers-count').textContent).toBe('1')
+    expect(screen.getByTestId('host-prune-chip-images-count').textContent).toBe('1')
+    expect(screen.getByTestId('host-prune-container-aaa111222333')).toBeTruthy()
+    expect(screen.getByTestId('host-prune-image-img111222333')).toBeTruthy()
+  })
+
+  it('each prune kind routes through the ConfirmDialog before onAction', () => {
+    const onAction = vi.fn()
+    render(<HostPruneSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('host-prune-all'))
+    expect(onAction).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+    expect(onAction).toHaveBeenCalledWith('all')
+  })
+
+  it('Prune containers is disabled when there are no containers', () => {
+    render(
+      <HostPruneSection
+        snapshot={snapshot({ containers: [], summary: { containerCount: 0, imageCount: 1, reclaimableBytes: 1_000_000_000 } })}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+      />,
+    )
+    expect((screen.getByTestId('host-prune-containers') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('host-prune-images') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('shows Pruning… while a kind is pending and a note when settled', () => {
+    const { rerender } = render(
+      <HostPruneSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set(['all'])} actionResults={{}} />,
+    )
+    expect(screen.getByTestId('host-prune-pending-all')).toBeTruthy()
+    rerender(
+      <HostPruneSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set<string>()} actionResults={{ all: { kind: 'all', note: 'Removed 1 container, 1 image (~965 MiB)', error: null, at: 1 } }} />,
+    )
+    expect(screen.getByTestId('host-prune-ok-all').textContent).toContain('Removed 1 container')
+  })
+
+  it('Refresh dispatches and is disabled while loading', () => {
+    const onRefresh = vi.fn()
+    const { rerender } = render(<HostPruneSection snapshot={snapshot()} loading={false} connected={true} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByTestId('host-prune-refresh'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    rerender(<HostPruneSection snapshot={snapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
+    expect((screen.getByTestId('host-prune-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/packages/dashboard/src/components/HostPruneSection.tsx
+++ b/packages/dashboard/src/components/HostPruneSection.tsx
@@ -1,0 +1,297 @@
+/**
+ * HostPruneSection (#6140, epic #5530) — the "Host prune" Control Room tab.
+ *
+ * Renders reclaimable, chroxy-scoped, ORPHAN-ONLY host docker pressure the server
+ * returns in a `host_prune_status_snapshot`: stopped `chroxy-env-*` containers and
+ * chroxy snapshot images (`chroxy-env`/`chroxy-byok-snap`) NOT tracked by a live
+ * env, with per-resource sizes + a summary (counts + estimated reclaimable bytes).
+ * The container analog of `chroxy worktree gc`.
+ *
+ * Prune actions (drain/recycle-style) follow the established discipline: each is
+ * destructive and gated behind a ConfirmDialog; the server takes only a `kind`
+ * (containers/images/all) and re-surveys the chroxy-scoped orphan set itself, so
+ * the dashboard can never widen the blast radius. `dockerAvailable:false` is a
+ * first-class state (the host has no docker) — no tables, just a note.
+ *
+ * Same pull-on-Refresh flow as the sibling surveys.
+ */
+import { useState } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { ServerHostPruneStatusSnapshotMessage } from '@chroxy/protocol'
+import type { HostPruneActionResult } from '../store/types'
+import { formatGeneratedAgo } from './ControlRoomSection'
+import { ConfirmDialog } from './ConfirmDialog'
+
+type PruneKind = 'containers' | 'images' | 'all'
+
+/** Compact bytes ("45.2 MiB", "1.95 GiB", "512 B", or "—"). */
+function formatBytes(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes) || bytes < 0) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KiB', 'MiB', 'GiB', 'TiB']
+  let v = bytes / 1024
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v.toFixed(v < 10 ? 2 : 1)} ${units[i]}`
+}
+
+/** ISO date (no time) for the eyebrow. */
+function isoDate(iso: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
+  return m ? m[1]! : iso
+}
+
+function ActionFeedback({ id, pending, result }: { id: string; pending: boolean; result: HostPruneActionResult | undefined }) {
+  if (pending) return <span className="cr-dim" data-testid={`host-prune-pending-${id}`}>Pruning…</span>
+  if (!result) return null
+  if (result.error) return <span className="cr-bad" data-testid={`host-prune-error-${id}`} role="alert">{result.error}</span>
+  return <span className="cr-ok" data-testid={`host-prune-ok-${id}`}>{result.note ?? 'done'}</span>
+}
+
+export interface HostPruneSectionProps {
+  snapshot?: ServerHostPruneStatusSnapshotMessage | null
+  loading?: boolean
+  connected?: boolean
+  onRefresh?: () => void
+  actioningIds?: Set<string>
+  actionResults?: Record<string, HostPruneActionResult>
+  onAction?: (kind: PruneKind) => void
+  now?: () => number
+}
+
+export function HostPruneSection({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  actioningIds: actioningIdsProp,
+  actionResults: actionResultsProp,
+  onAction: onActionProp,
+  now = Date.now,
+}: HostPruneSectionProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.hostPruneStatus)
+  const storeLoading = useConnectionStore((s) => s.hostPruneStatusLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestHostPruneStatus = useConnectionStore((s) => s.requestHostPruneStatus)
+  const storeActioningIds = useConnectionStore((s) => s.hostPruneActioningIds)
+  const storeActionResults = useConnectionStore((s) => s.hostPruneActionResults)
+  const sendHostPruneAction = useConnectionStore((s) => s.sendHostPruneAction)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestHostPruneStatus
+  const actioningIds = actioningIdsProp ?? storeActioningIds
+  const actionResults = actionResultsProp ?? storeActionResults
+  const onAction = onActionProp ?? sendHostPruneAction
+
+  // Every prune is destructive → route through a confirmation. Holds the pending
+  // kind (null = dialog closed).
+  const [confirmKind, setConfirmKind] = useState<PruneKind | null>(null)
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+  const anyActioning = actioningIds.size > 0
+  const hasContainers = (snapshot?.summary.containerCount ?? 0) > 0
+  const hasImages = (snapshot?.summary.imageCount ?? 0) > 0
+  const nothingToPrune = snapshot != null && snapshot.dockerAvailable && !hasContainers && !hasImages
+
+  const PRUNE_LABEL: Record<PruneKind, string> = {
+    containers: 'Prune containers',
+    images: 'Prune images',
+    all: 'Prune all',
+  }
+
+  return (
+    <div className="cr-section" data-testid="host-prune-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="host-prune-eyebrow">
+          host · reclaimable docker pressure{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h1 className="cr-title">Host prune</h1>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="host-prune-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="host-prune-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
+        {snapshot && !snapshot.dockerAvailable && (
+          <p className="cr-callout" data-testid="host-prune-no-docker">
+            {snapshot.note || 'docker is unavailable on this host.'}
+          </p>
+        )}
+        {snapshot?.dockerAvailable && snapshot.note && (
+          <p className="cr-dim" data-testid="host-prune-note">{snapshot.note}</p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="host-prune-generated">
+            {formatGeneratedAgo(generatedAtMs, now())}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="host-prune-empty">
+          {loading ? (
+            <span>Running the host prune survey…</span>
+          ) : (
+            <>
+              <p>No host prune survey yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="host-prune-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="host-prune-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot?.dockerAvailable && (
+        <>
+          <div className="cr-chips" data-testid="host-prune-chips">
+            <span className="cr-chip" data-testid="host-prune-chip-containers">
+              Stopped containers: <b data-testid="host-prune-chip-containers-count">{snapshot.summary.containerCount}</b>
+            </span>
+            <span className="cr-chip" data-testid="host-prune-chip-images">
+              Orphan images: <b data-testid="host-prune-chip-images-count">{snapshot.summary.imageCount}</b>
+            </span>
+            <span className="cr-chip" data-testid="host-prune-chip-reclaimable">
+              Reclaimable: <b>~{formatBytes(snapshot.summary.reclaimableBytes)}</b>
+            </span>
+          </div>
+
+          <section className="cr-actions-bar" data-testid="host-prune-actions">
+            <div className="cr-actions">
+              <button
+                type="button"
+                className="cr-action cr-action-danger"
+                data-testid="host-prune-containers"
+                disabled={anyActioning || !connected || !hasContainers}
+                onClick={() => setConfirmKind('containers')}
+                title="Remove all stopped chroxy containers"
+              >
+                {PRUNE_LABEL.containers}
+              </button>
+              <button
+                type="button"
+                className="cr-action cr-action-danger"
+                data-testid="host-prune-images"
+                disabled={anyActioning || !connected || !hasImages}
+                onClick={() => setConfirmKind('images')}
+                title="Remove all orphan chroxy snapshot images"
+              >
+                {PRUNE_LABEL.images}
+              </button>
+              <button
+                type="button"
+                className="cr-action cr-action-danger"
+                data-testid="host-prune-all"
+                disabled={anyActioning || !connected || (!hasContainers && !hasImages)}
+                onClick={() => setConfirmKind('all')}
+                title="Remove all reclaimable chroxy containers + images"
+              >
+                {PRUNE_LABEL.all}
+              </button>
+            </div>
+            <ActionFeedback id="containers" pending={actioningIds.has('containers')} result={actionResults['containers']} />
+            <ActionFeedback id="images" pending={actioningIds.has('images')} result={actionResults['images']} />
+            <ActionFeedback id="all" pending={actioningIds.has('all')} result={actionResults['all']} />
+          </section>
+
+          {nothingToPrune && (
+            <p className="cr-dim" data-testid="host-prune-clean">Nothing reclaimable — no stopped chroxy containers or orphan snapshot images.</p>
+          )}
+
+          {hasContainers && (
+            <section className="cr-table-wrap">
+              <table className="cr-table" data-testid="host-prune-containers-table">
+                <thead>
+                  <tr><th>Stopped container</th><th>State</th><th>Size</th></tr>
+                </thead>
+                <tbody>
+                  {snapshot.containers.map((c) => (
+                    <tr key={c.id} data-testid={`host-prune-container-${c.id}`}>
+                      <td><b className="cr-mono">{c.name}</b> <span className="cr-dim cr-mono">{c.id.slice(0, 12)}</span></td>
+                      <td className="cr-dim">{c.state}</td>
+                      <td className="cr-dim">{formatBytes(c.sizeBytes)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          )}
+
+          {hasImages && (
+            <section className="cr-table-wrap">
+              <table className="cr-table" data-testid="host-prune-images-table">
+                <thead>
+                  <tr><th>Orphan image</th><th>Size</th></tr>
+                </thead>
+                <tbody>
+                  {snapshot.images.map((img) => (
+                    <tr key={img.id} data-testid={`host-prune-image-${img.id}`}>
+                      <td><b className="cr-mono">{img.ref}</b> <span className="cr-dim cr-mono">{img.id.slice(0, 12)}</span></td>
+                      <td className="cr-dim">{formatBytes(img.sizeBytes)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          )}
+        </>
+      )}
+
+      <ConfirmDialog
+        open={confirmKind !== null}
+        title="Prune chroxy docker resources?"
+        danger
+        confirmLabel={confirmKind ? PRUNE_LABEL[confirmKind] : 'Prune'}
+        message={
+          confirmKind ? (
+            <>
+              This permanently removes{' '}
+              {confirmKind === 'containers' ? 'all stopped chroxy containers'
+                : confirmKind === 'images' ? 'all orphan chroxy snapshot images'
+                : 'all reclaimable chroxy containers and orphan snapshot images'}
+              . Retained snapshots and live environments are never touched. This cannot be undone.
+            </>
+          ) : null
+        }
+        onConfirm={() => {
+          if (confirmKind) onAction(confirmKind)
+          setConfirmKind(null)
+        }}
+        onCancel={() => setConfirmKind(null)}
+      />
+    </div>
+  )
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -509,6 +509,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // byok_pool_status_snapshot handler. Null until the first survey lands.
   byokPoolStatus: null,
   byokPoolStatusLoading: false,
+  // #6140 (epic #5530): Control Room host prune snapshot, fed by the
+  // host_prune_status_snapshot handler. Null until the first survey lands.
+  hostPruneStatus: null,
+  hostPruneStatusLoading: false,
   // #5499 (epic #5498): Control Room Integrations snapshot, fed by the
   // integration_status_snapshot handler. Null until the first survey lands.
   integrationStatus: null,
@@ -532,6 +536,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // target for inline display (same lifecycle as containerActioningIds).
   byokPoolActioningIds: new Set<string>(),
   byokPoolActionResults: {},
+  // #6140 slice 2: host prune action — in-flight kinds + last outcome per kind.
+  hostPruneActioningIds: new Set<string>(),
+  hostPruneActionResults: {},
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -1046,6 +1053,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return false;
   },
 
+  // #6140 (epic #5530): request a host prune survey. Mirrors
+  // requestByokPoolStatus — flips hostPruneStatusLoading and sends a
+  // host_prune_status_request; the reply is a single host_prune_status_snapshot
+  // handled into hostPruneStatus. Returns false (no loading) when the socket is
+  // closed.
+  requestHostPruneStatus: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ hostPruneStatusLoading: true });
+      wsSend(socket, { type: 'host_prune_status_request' });
+      return true;
+    }
+    return false;
+  },
+
   // #5499 (epic #5498): request an Integrations survey. Mirrors
   // requestRunnerStatus — flips integrationStatusLoading and sends an
   // integration_status_request; the reply is a single
@@ -1178,6 +1200,29 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (typeof opts?.maxTotal === 'number') msg.maxTotal = opts.maxTotal;
     }
     wsSend(socket, msg);
+    return true;
+  },
+
+  // #6140 slice 2 (epic #5530): run a host prune for one `kind`
+  // (containers/images/all). The pending/result state is keyed by the kind. Same
+  // wire-or-nothing contract as the sibling actions: tag with a requestId the
+  // server echoes on the host_prune_action_ack / HOST_PRUNE_ACTION_FAILED
+  // session_error, and mark the kind pending ONLY when the message is genuinely
+  // on the wire. The server takes no target list — it re-surveys the chroxy-scoped
+  // orphan set and removes only those ids. The kind's previous result is dropped
+  // so a stale outcome can't sit beside the pending state. Confirmation lives in
+  // the UI.
+  sendHostPruneAction: (kind: 'containers' | 'images' | 'all'): boolean => {
+    const { socket } = get();
+    if (kind !== 'containers' && kind !== 'images' && kind !== 'all') return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const requestId = `host-prune-action-${nextMessageId()}`;
+    const pending = new Set(get().hostPruneActioningIds);
+    pending.add(kind);
+    const results = { ...get().hostPruneActionResults };
+    delete results[kind];
+    set({ hostPruneActioningIds: pending, hostPruneActionResults: results });
+    wsSend(socket, { type: 'host_prune_action', kind, requestId });
     return true;
   },
 
@@ -1971,6 +2016,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().byokPoolActioningIds.size > 0) {
         set({ byokPoolActioningIds: new Set<string>() });
       }
+      // #6140: ditto for in-flight host prune actions.
+      if (get().hostPruneActioningIds.size > 0) {
+        set({ hostPruneActioningIds: new Set<string>() });
+      }
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
@@ -2248,6 +2297,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6135: BYOK pool action pending/result state goes with it.
       byokPoolActioningIds: new Set<string>(),
       byokPoolActionResults: {},
+      // #6140: host prune action pending/result state goes with it.
+      hostPruneActioningIds: new Set<string>(),
+      hostPruneActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -2291,6 +2343,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6135: BYOK pool action pending/result state goes with it.
       byokPoolActioningIds: new Set<string>(),
       byokPoolActionResults: {},
+      // #6140: host prune action pending/result state goes with it.
+      hostPruneActioningIds: new Set<string>(),
+      hostPruneActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-host-prune-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-host-prune-action.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration test for the host prune action wiring (#6140 slice 2, epic #5530).
+ * Guards: ack clears the kind's pending state + records a note; malformed dropped;
+ * HOST_PRUNE_ACTION_FAILED clears the echoed kind + records the error; other kinds
+ * untouched. Mirrors dispatch-byok-pool-action.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {},
+    hostPruneActioningIds: new Set(['all', 'containers']),
+    hostPruneActionResults: {},
+    messages: [],
+  }
+}
+
+describe('host prune action dispatch (#6140 slice 2)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('an ack clears the kind and records a removed-count note', () => {
+    handleMessage({ type: 'host_prune_action_ack', kind: 'all', requestId: 'r1', dockerAvailable: true, removedContainers: 2, removedImages: 3, reclaimedBytes: 1_048_576, failures: [] }, ctx() as never)
+    const s = store.getState()
+    expect(s.hostPruneActioningIds.has('all')).toBe(false)
+    expect(s.hostPruneActioningIds.has('containers')).toBe(true) // other kind untouched
+    expect(s.hostPruneActionResults['all']!.error).toBeNull()
+    expect(s.hostPruneActionResults['all']!.note).toMatch(/Removed 2 containers, 3 images/)
+  })
+
+  it('a note flags partial failures', () => {
+    handleMessage({ type: 'host_prune_action_ack', kind: 'images', dockerAvailable: true, removedContainers: 0, removedImages: 1, reclaimedBytes: 0, failures: [{ ref: 'chroxy-env:x', error: 'in use' }] }, ctx() as never)
+    expect(store.getState().hostPruneActionResults['images']!.note).toMatch(/1 failed/)
+  })
+
+  it('drops a malformed ack (missing kind) without touching pending state', () => {
+    handleMessage({ type: 'host_prune_action_ack', removedContainers: 1 }, ctx() as never)
+    expect(store.getState().hostPruneActioningIds.has('all')).toBe(true)
+  })
+
+  it('HOST_PRUNE_ACTION_FAILED clears the echoed kind and records the error', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'HOST_PRUNE_ACTION_FAILED', message: 'docker rmi failed', reason: 'prune-failed', kind: 'all', requestId: 'r1' }, ctx() as never)
+    const s = store.getState()
+    expect(s.hostPruneActioningIds.has('all')).toBe(false)
+    expect(s.hostPruneActioningIds.has('containers')).toBe(true)
+    expect(s.hostPruneActionResults['all']!.error).toMatch(/docker rmi failed/)
+    expect(s.hostPruneActionResults['all']!.note).toBeNull()
+  })
+
+  it('a FAILED without a kind leaves action state alone', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'HOST_PRUNE_ACTION_FAILED', message: 'boom' }, ctx() as never)
+    expect(store.getState().hostPruneActioningIds.has('all')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/dispatch-host-prune-status.test.ts
+++ b/packages/dashboard/src/store/dispatch-host-prune-status.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Integration test for the host prune survey wiring (#6140, epic #5530).
+ * Guards: snapshot REPLACES hostPruneStatus + clears loading; malformed dropped
+ * without clearing loading; docker-unavailable is a valid state.
+ * Mirrors dispatch-byok-pool-status.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerHostPruneStatusSnapshotMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return { connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {}, hostPruneStatus: null, hostPruneStatusLoading: true, messages: [] }
+}
+function snapshot(over: Partial<ServerHostPruneStatusSnapshotMessage> = {}): ServerHostPruneStatusSnapshotMessage {
+  return {
+    type: 'host_prune_status_snapshot',
+    generatedAt: '2026-06-19T12:00:00.000Z',
+    dockerAvailable: true,
+    note: null,
+    containers: [{ id: 'aaa', name: 'chroxy-env-foo', state: 'exited', sizeBytes: 10_000_000 }],
+    images: [{ id: 'img1', ref: 'chroxy-env:foo-1', repository: 'chroxy-env', sizeBytes: 1_000_000_000 }],
+    summary: { containerCount: 1, imageCount: 1, reclaimableBytes: 1_010_000_000 },
+    ...over,
+  } as ServerHostPruneStatusSnapshotMessage
+}
+
+describe('host prune status dispatch (#6140)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('applies host_prune_status_snapshot and clears loading', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.hostPruneStatus!.summary.containerCount).toBe(1)
+    expect(s.hostPruneStatus!.images.map((i) => i.ref)).toEqual(['chroxy-env:foo-1'])
+    expect(s.hostPruneStatusLoading).toBe(false)
+  })
+
+  it('relays a docker-unavailable snapshot as a valid state', () => {
+    handleMessage(snapshot({ dockerAvailable: false, note: 'docker unavailable', containers: [], images: [], summary: { containerCount: 0, imageCount: 0, reclaimableBytes: 0 } }), ctx() as never)
+    const s = store.getState()
+    expect(s.hostPruneStatus!.dockerAvailable).toBe(false)
+    expect(s.hostPruneStatusLoading).toBe(false)
+  })
+
+  it('drops a malformed snapshot without clearing loading', () => {
+    handleMessage({ type: 'host_prune_status_snapshot', generatedAt: '2026-06-19T12:00:00.000Z' }, ctx() as never)
+    expect(store.getState().hostPruneStatus).toBeNull()
+    expect(store.getState().hostPruneStatusLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2825,6 +2825,21 @@ function resolveHostPruneAction(
 }
 
 /**
+ * #6140 slice 2 — compact auto-unit byte format for the prune note, so it reads
+ * consistently with the section's chips/tables (which use the same KiB/MiB/GiB
+ * scaling) rather than always-MiB.
+ */
+function formatReclaimedBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let v = bytes / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v.toFixed(v < 10 ? 2 : 1)} ${units[i]}`;
+}
+
+/**
  * #6140 slice 2 — host prune success ack: builds a human note from removed counts
  * + reclaimed bytes (+ any per-resource failures) and clears the kind's pending
  * state. A malformed ack is dropped (Zod safeParse) so the row keeps its honest
@@ -2834,8 +2849,7 @@ function handleHostPruneActionAck(msg: Record<string, unknown>, get: MsgGet, set
   const parsed = ServerHostPruneActionAckSchema.safeParse(msg);
   if (!parsed.success) return;
   const { kind, removedContainers, removedImages, reclaimedBytes, failures } = parsed.data;
-  const mib = (reclaimedBytes / (1024 * 1024)).toFixed(reclaimedBytes < 1024 * 1024 ? 2 : 0);
-  let note = `Removed ${removedContainers} container${removedContainers === 1 ? '' : 's'}, ${removedImages} image${removedImages === 1 ? '' : 's'} (~${mib} MiB)`;
+  let note = `Removed ${removedContainers} container${removedContainers === 1 ? '' : 's'}, ${removedImages} image${removedImages === 1 ? '' : 's'} (~${formatReclaimedBytes(reclaimedBytes)})`;
   if (failures.length > 0) note += ` — ${failures.length} failed`;
   resolveHostPruneAction(get, set, kind, { note, error: null });
 }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2612,6 +2612,17 @@ function handleByokPoolStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet
 }
 
 /**
+ * #6140 (epic #5530) — host prune survey `host_prune_status_snapshot`: REPLACE
+ * the stored snapshot and clear the loading flag. Same defensive, full-replace,
+ * clear-loading-only-on-valid-parse contract as the sibling survey handlers.
+ */
+function handleHostPruneStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerHostPruneStatusSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ hostPruneStatus: parsed.data, hostPruneStatusLoading: false });
+}
+
+/**
  * #5499 (epic #5498) — Integrations survey `integration_status_snapshot`:
  * REPLACE the stored survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host and
@@ -2794,6 +2805,42 @@ function handleByokPoolActionAck(msg: Record<string, unknown>, get: MsgGet, set:
 }
 
 /**
+ * #6140 slice 2 (epic #5530) — resolve one host prune `kind`'s pending state:
+ * drop it from `hostPruneActioningIds` and record the outcome in
+ * `hostPruneActionResults`. Shared by the ack and the HOST_PRUNE_ACTION_FAILED
+ * session_error.
+ */
+function resolveHostPruneAction(
+  get: MsgGet,
+  set: MsgSet,
+  kind: string,
+  result: { note: string | null; error: string | null },
+): void {
+  const pending = new Set(get().hostPruneActioningIds);
+  pending.delete(kind);
+  set({
+    hostPruneActioningIds: pending,
+    hostPruneActionResults: { ...get().hostPruneActionResults, [kind]: { kind, ...result, at: Date.now() } },
+  });
+}
+
+/**
+ * #6140 slice 2 — host prune success ack: builds a human note from removed counts
+ * + reclaimed bytes (+ any per-resource failures) and clears the kind's pending
+ * state. A malformed ack is dropped (Zod safeParse) so the row keeps its honest
+ * pending state.
+ */
+function handleHostPruneActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerHostPruneActionAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const { kind, removedContainers, removedImages, reclaimedBytes, failures } = parsed.data;
+  const mib = (reclaimedBytes / (1024 * 1024)).toFixed(reclaimedBytes < 1024 * 1024 ? 2 : 0);
+  let note = `Removed ${removedContainers} container${removedContainers === 1 ? '' : 's'}, ${removedImages} image${removedImages === 1 ? '' : 's'} (~${mib} MiB)`;
+  if (failures.length > 0) note += ` — ${failures.length} failed`;
+  resolveHostPruneAction(get, set, kind, { note, error: null });
+}
+
+/**
  * #5547: a `summarize_session_result` resolves the pending summarize promise
  * (keyed by the echoed requestId) so the awaiting create-session flow opens
  * with the brief seeded. The failure half (SUMMARIZE_FAILED) rejects the same
@@ -2910,6 +2957,8 @@ const HANDLERS: Record<string, Handler> = {
   repo_runtime_config_snapshot: handleRepoRuntimeConfigSnapshot,
   // #6135 (epic #5530): Control Room BYOK pool survey snapshot.
   byok_pool_status_snapshot: handleByokPoolStatusSnapshot,
+  // #6140 (epic #5530): Control Room host prune survey snapshot.
+  host_prune_status_snapshot: handleHostPruneStatusSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
   skills_inventory_snapshot: handleSkillsInventorySnapshot,
@@ -2922,6 +2971,8 @@ const HANDLERS: Record<string, Handler> = {
   // #6135 (epic #5530): positive ack correlating a byok_pool_action (drain /
   // recycle / resize) request to its outcome.
   byok_pool_action_ack: handleByokPoolActionAck,
+  // #6140 (epic #5530): positive ack correlating a host_prune_action to its outcome.
+  host_prune_action_ack: handleHostPruneActionAck,
   // #5547: one-shot session-summary result; resolves the pending summarize
   // promise so the create-session flow can open with the brief seeded.
   summarize_session_result: handleSummarizeSessionResult,
@@ -3651,6 +3702,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           action: msg.action,
           note: null,
           error: parsed.message || 'BYOK pool action failed.',
+        });
+      } else if (parsed.code === 'HOST_PRUNE_ACTION_FAILED' && typeof msg.kind === 'string') {
+        // #6140: a failed host_prune_action echoes the exact kind — clear that
+        // kind's pending state and surface the reason inline (the generic branch
+        // below still raises the toast, matching the precedents).
+        resolveHostPruneAction(get, set, msg.kind, {
+          note: null,
+          error: parsed.message || 'Host prune failed.',
         });
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -583,6 +583,21 @@ export interface ByokPoolActionResult {
   at: number;
 }
 
+/**
+ * #6140 slice 2 (epic #5530) — outcome of the last host prune action (kind
+ * containers/images/all), kept for inline display. The target id is the `kind`.
+ * A successful `host_prune_action_ack` records a human `note` (removed counts +
+ * reclaimed bytes, and any per-resource failures) with `error: null`; a
+ * HOST_PRUNE_ACTION_FAILED session_error records the message with `note: null`.
+ * `at` is the local receipt time (epoch ms).
+ */
+export interface HostPruneActionResult {
+  kind: string;
+  note: string | null;
+  error: string | null;
+  at: number;
+}
+
 export interface ConnectionState {
   // Connection
   connectionPhase: ConnectionPhase;
@@ -770,6 +785,20 @@ export interface ConnectionState {
    */
   byokPoolStatus: ServerByokPoolStatusSnapshotMessage | null;
   /**
+   * #6140 (epic #5530) — Control Room host prune survey: the latest
+   * `host_prune_status_snapshot` (reclaimable chroxy-scoped orphan docker
+   * pressure), or null before the first one lands. Replaced wholesale on each
+   * snapshot (full picture, no delta stream).
+   */
+  hostPruneStatus: ServerHostPruneStatusSnapshotMessage | null;
+  /**
+   * #6140 — true between dispatching a `host_prune_status_request` and the
+   * matching snapshot arriving, so the tab's Refresh button can spin. Cleared
+   * when a VALID snapshot lands (a malformed payload is dropped and leaves this
+   * true, matching the sibling surveys).
+   */
+  hostPruneStatusLoading: boolean;
+  /**
    * #6135 — true between dispatching a `byok_pool_status_request` and the
    * matching `byok_pool_status_snapshot` arriving, so the tab's Refresh button
    * can spin. Cleared when a VALID snapshot lands (a malformed payload is
@@ -860,6 +889,15 @@ export interface ConnectionState {
    * display. Replaced when the same target is actioned again.
    */
   byokPoolActionResults: Record<string, ByokPoolActionResult>;
+  /**
+   * #6140 slice 2 (epic #5530) — host prune action kinds with an in-flight
+   * `host_prune_action` (keyed by `kind`): set when sendHostPruneAction is
+   * called, cleared on the `host_prune_action_ack` / HOST_PRUNE_ACTION_FAILED
+   * session_error.
+   */
+  hostPruneActioningIds: Set<string>;
+  /** #6140 slice 2 — last host prune outcome per kind, for inline display. */
+  hostPruneActionResults: Record<string, HostPruneActionResult>;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;
@@ -1432,6 +1470,13 @@ export interface ConnectionState {
   // `byokPoolStatusLoading` while in flight.
   requestByokPoolStatus: () => boolean;
 
+  // #6140 (epic #5530): request a host prune survey. Dispatches a
+  // `host_prune_status_request`; the server replies with a single
+  // `host_prune_status_snapshot` handled into `hostPruneStatus`. Returns whether
+  // the message went on the wire (false = socket closed). Sets
+  // `hostPruneStatusLoading` while in flight.
+  requestHostPruneStatus: () => boolean;
+
   // #6139 (epic #5530): request a per-repo runtime config survey. Dispatches a
   // `repo_runtime_config_request`; the server replies with a single
   // `repo_runtime_config_snapshot` handled into `repoRuntimeConfig`. Returns
@@ -1502,6 +1547,17 @@ export interface ConnectionState {
     action: 'drain' | 'recycle' | 'resize',
     opts?: { key?: string; maxPerKey?: number; maxTotal?: number },
   ) => boolean;
+
+  // #6140 slice 2 (epic #5530): run a host prune. `kind` selects what to remove
+  // (stopped chroxy containers / chroxy snapshot images / both). The server
+  // takes no target list — it re-surveys the chroxy-scoped orphan set and removes
+  // only those ids. Dispatches a `host_prune_action` tagged with a requestId the
+  // server echoes on the `host_prune_action_ack` / HOST_PRUNE_ACTION_FAILED
+  // session_error. Marks the `kind` in `hostPruneActioningIds` (dropping its
+  // stale result) ONLY when the message actually went on the wire; an offline
+  // send returns false. Confirmation is the caller's responsibility (the UI
+  // gates it behind a ConfirmDialog — it's destructive).
+  sendHostPruneAction: (kind: 'containers' | 'images' | 'all') => boolean;
 
   // #5547: request a server-side one-shot summary of a session's persisted
   // history (the sidebar "Summarize & start new session" action). Dispatches a

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -80,8 +80,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'host_prune_status_snapshot', // #6140 (epic #5530) — Control Room host prune guardrails survey reply. Server contract (survey + handler + protocol) landed first; the dashboard slice that consumes it moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
-  'host_prune_action_ack', // #6140 (epic #5530) — Control Room host prune action ack. Server contract landed first; the dashboard slice that consumes the ack moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -159,6 +157,8 @@ const PLATFORM_SPECIFIC = {
   'containers_action_ack': 'dashboard', // Control Room container lifecycle action ack (#6134, epic #5530) — the dashboard consumes it to clear pending row state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'byok_pool_status_snapshot': 'dashboard', // Control Room BYOK pool stats survey reply (#6135, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'byok_pool_action_ack': 'dashboard', // Control Room BYOK pool mutating-action (drain/recycle/resize) ack (#6135, epic #5530) — the dashboard consumes it to clear pending target state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'host_prune_status_snapshot': 'dashboard', // Control Room host prune guardrails survey reply (#6140, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'host_prune_action_ack': 'dashboard', // Control Room host prune action ack (#6140, epic #5530) — the dashboard consumes it to clear pending kind state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'mailbox_status_snapshot': 'dashboard', // Control Room "Mailbox" tab survey reply (#5914 follow-up) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -146,6 +146,8 @@ const DASHBOARD_ONLY = new Set<string>([
   'repo_runtime_config_snapshot', // Control Room per-repo runtime config survey (#6139, epic #5530) — dashboard-only
   'byok_pool_status_snapshot',  // Control Room BYOK pool survey (#6135, epic #5530) — dashboard-only
   'byok_pool_action_ack',       // Control Room BYOK pool action ack (#6135, epic #5530) — dashboard-only
+  'host_prune_status_snapshot', // Control Room host prune guardrails survey (#6140, epic #5530) — dashboard-only
+  'host_prune_action_ack',      // Control Room host prune action ack (#6140, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -194,12 +196,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'host_prune_status_snapshot',           // #6140 (epic #5530) Control Room host prune guardrails survey —
-                                          //   server contract landed first; the dashboard slice that consumes
-                                          //   it is the tracked follow-up, then this → DASHBOARD_ONLY
-  'host_prune_action_ack',                // #6140 (epic #5530) Control Room host prune action ack —
-                                          //   server contract landed first; the dashboard slice that consumes
-                                          //   the ack is the tracked follow-up, then this → DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The dashboard surface for the Control Room **Host prune** tab — slice 2 of #6140, completing the sub-issue. Consumes the slice-1 server survey + prune action (#6154). Mirrors the BYOK Pool tab's survey+action discipline.

### Tab (`HostPruneSection.tsx`)
- **docker-unavailable is first-class** — renders the note, no tables/actions.
- **Available:** summary chips (stopped containers / orphan images / estimated reclaimable bytes), a stopped-containers table, an orphan-images table.
- **Three destructive prune actions** — Prune containers / Prune images / Prune all — each gated behind a `ConfirmDialog`. Buttons disable when their resource class is empty or while any prune is in flight. The confirm copy notes that retained snapshots + live environments are never touched (the server enforces this).

### Store
- `hostPruneStatus` + `hostPruneStatusLoading` + `requestHostPruneStatus`.
- `hostPruneActioningIds` / `hostPruneActionResults` keyed by **kind** + `sendHostPruneAction(kind)` (wire-or-nothing, no offline queue), cleared on disconnect/forget.
- `host_prune_status_snapshot` handler (full replace) + `host_prune_action_ack` handler (builds a removed-counts + reclaimed-bytes note, flags partial failures) + `HOST_PRUNE_ACTION_FAILED` `session_error` branch (keyed by echoed kind).

### Coverage
Both guards promoted `host_prune_status_snapshot` + `host_prune_action_ack` from unhandled → `dashboard` / `DASHBOARD_ONLY`.

## Tests
- `HostPruneSection.test.tsx` — empty/loading/not-connected, docker-unavailable, populated chips+tables, per-kind confirm-dialog flow, disabled-when-empty, pending→settled note, refresh dispatch/disabled.
- `dispatch-host-prune-status.test.ts` + `dispatch-host-prune-action.test.ts` — snapshot apply/unavailable/malformed; ack note + partial-failure flag + kind-keyed clearing; HOST_PRUNE_ACTION_FAILED.
- Dashboard `tsc` + full suite **3928 green**; store-core 1679; both coverage guards.

Closes #6140. Part of epic #5530.