### PR TITLE
feat(dashboard): Device runtimes Control Room tab — iOS simulators (#6136 slice 3)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -44,6 +44,7 @@ import { ContainersStatusSection } from './ContainersStatusSection'
 import { RepoRuntimeConfigSection } from './RepoRuntimeConfigSection'
 import { ByokPoolSection } from './ByokPoolSection'
 import { HostPruneSection } from './HostPruneSection'
+import { DeviceRuntimesSection } from './DeviceRuntimesSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { SkillsInventorySection } from './SkillsInventorySection'
 import { MailboxPanel } from './MailboxPanel'
@@ -171,6 +172,19 @@ export const CONTROL_ROOM_TABS = [
     snapshotKey: 'hostPruneStatus',
     loadingKey: 'hostPruneStatusLoading',
     requestKey: 'requestHostPruneStatus',
+  },
+  // #6136 (epic #5530): the Device runtimes tab — iOS simulators (devices +
+  // "Ready for Maestro" verdict) with boot/shutdown actions. Android (#6137) and
+  // WSL2 (#6138) are separate sub-issues that will add their own panels here.
+  // Same survey:true request/snapshot flow as the others.
+  {
+    key: 'device-runtimes',
+    label: 'Device runtimes',
+    survey: true,
+    requestType: 'simulator_status_request',
+    snapshotKey: 'simulatorStatus',
+    loadingKey: 'simulatorStatusLoading',
+    requestKey: 'requestSimulatorStatus',
   },
   {
     key: 'integrations',
@@ -429,6 +443,8 @@ export function ControlRoomView({
         <ByokPoolSection />
       ) : tab === 'host-prune' ? (
         <HostPruneSection />
+      ) : tab === 'device-runtimes' ? (
+        <DeviceRuntimesSection />
       ) : tab === 'integrations' ? (
         <IntegrationsSection />
       ) : tab === 'skills' ? (

--- a/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * DeviceRuntimesSection (#6136, epic #5530) — renderer tests.
+ *
+ * Covers the surface against a mocked `simulator_status_snapshot`:
+ *   - empty / loading / not-connected states before the first snapshot
+ *   - off-macOS (available:false) note (no verdict/table)
+ *   - the "Ready for Maestro" verdict (ready + not-ready with reasons)
+ *   - device table with boot/shutdown buttons keyed to device state
+ *   - boot/shutdown route to onAction (non-destructive — no confirm)
+ *   - buttons disable while any action is in flight
+ *   - pending → settled note; Refresh dispatch + disabled-while-loading
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ServerSimulatorStatusSnapshotMessage } from '@chroxy/protocol'
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      simulatorStatus: null,
+      simulatorStatusLoading: false,
+      connectionPhase: 'connected',
+      requestSimulatorStatus: () => false,
+      simulatorActioningIds: new Set<string>(),
+      simulatorActionResults: {},
+      sendSimulatorAction: () => false,
+    }),
+}))
+import { DeviceRuntimesSection } from './DeviceRuntimesSection'
+
+afterEach(cleanup)
+
+function snapshot(over: Partial<ServerSimulatorStatusSnapshotMessage> = {}): ServerSimulatorStatusSnapshotMessage {
+  return {
+    type: 'simulator_status_snapshot',
+    generatedAt: '2026-06-20T12:00:00.000Z',
+    available: true,
+    note: null,
+    devices: [
+      { udid: 'U-BOOTED1', name: 'iPhone 16 Pro', state: 'Booted', runtime: 'iOS 26.1', deviceType: 'iPhone 16 Pro', isAvailable: true },
+      { udid: 'U-SHUT0001', name: 'iPhone 15', state: 'Shutdown', runtime: 'iOS 26.1', deviceType: 'iPhone 15', isAvailable: true },
+    ],
+    readyForMaestro: { ready: true, bootedSimulator: 'iPhone 16 Pro', metroReachable: true, mockServerReachable: true, reasons: [] },
+    ...over,
+  } as ServerSimulatorStatusSnapshotMessage
+}
+
+describe('DeviceRuntimesSection — empty / loading / not-connected', () => {
+  it('renders the empty state with a Run-survey button when no snapshot', () => {
+    render(<DeviceRuntimesSection snapshot={null} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('device-runtimes-empty')).toBeTruthy()
+    expect(screen.queryByTestId('device-runtimes-table')).toBeNull()
+  })
+
+  it('disables the run button when not connected', () => {
+    render(<DeviceRuntimesSection snapshot={null} loading={false} connected={false} onRefresh={() => {}} />)
+    expect((screen.getByTestId('device-runtimes-empty-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+describe('DeviceRuntimesSection — unavailable (off macOS)', () => {
+  it('renders the unavailable note and no verdict/table', () => {
+    render(
+      <DeviceRuntimesSection
+        snapshot={snapshot({ available: false, note: 'not available on this host', devices: [], readyForMaestro: { ready: false, bootedSimulator: null, metroReachable: false, mockServerReachable: false, reasons: [] } })}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('device-runtimes-unavailable').textContent).toContain('not available')
+    expect(screen.queryByTestId('device-runtimes-verdict')).toBeNull()
+    expect(screen.queryByTestId('device-runtimes-table')).toBeNull()
+  })
+})
+
+describe('DeviceRuntimesSection — Ready for Maestro verdict', () => {
+  it('renders the ready verdict when all conditions pass', () => {
+    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    const verdict = screen.getByTestId('device-runtimes-verdict')
+    expect(verdict.getAttribute('data-ready')).toBe('true')
+    expect(screen.getByTestId('device-runtimes-verdict-ready').textContent).toContain('Ready for Maestro')
+  })
+
+  it('renders the not-ready verdict with reasons', () => {
+    render(
+      <DeviceRuntimesSection
+        snapshot={snapshot({ readyForMaestro: { ready: false, bootedSimulator: null, metroReachable: false, mockServerReachable: true, reasons: ['No booted simulator', 'Metro not reachable on :8081'] } })}
+        loading={false}
+        connected={true}
+        onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('device-runtimes-verdict').getAttribute('data-ready')).toBe('false')
+    expect(screen.getByTestId('device-runtimes-verdict-reasons').textContent).toContain('No booted simulator')
+  })
+})
+
+describe('DeviceRuntimesSection — device table + actions', () => {
+  it('renders a Shut down button for booted and a Boot button for shutdown devices', () => {
+    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('simulator-shutdown-U-BOOTED1')).toBeTruthy()
+    expect(screen.getByTestId('simulator-boot-U-SHUT0001')).toBeTruthy()
+  })
+
+  it('boot routes to onAction with (boot, udid) — no confirm gate', () => {
+    const onAction = vi.fn()
+    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('simulator-boot-U-SHUT0001'))
+    expect(onAction).toHaveBeenCalledWith('boot', 'U-SHUT0001')
+  })
+
+  it('shutdown routes to onAction with (shutdown, udid)', () => {
+    const onAction = vi.fn()
+    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('simulator-shutdown-U-BOOTED1'))
+    expect(onAction).toHaveBeenCalledWith('shutdown', 'U-BOOTED1')
+  })
+
+  it('disables every action button while any action is in flight', () => {
+    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set(['U-BOOTED1'])} actionResults={{}} />)
+    expect((screen.getByTestId('simulator-boot-U-SHUT0001') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('simulator-pending-U-BOOTED1')).toBeTruthy()
+  })
+
+  it('shows a settled note after an action resolves', () => {
+    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set<string>()} actionResults={{ 'U-SHUT0001': { action: 'boot', note: 'Booted (Booted)', error: null, at: 1 } }} />)
+    expect(screen.getByTestId('simulator-ok-U-SHUT0001').textContent).toContain('Booted')
+  })
+
+  it('renders a no-devices note when the host has none installed', () => {
+    render(<DeviceRuntimesSection snapshot={snapshot({ devices: [], readyForMaestro: { ready: false, bootedSimulator: null, metroReachable: true, mockServerReachable: true, reasons: ['No booted simulator'] } })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('device-runtimes-no-devices')).toBeTruthy()
+    expect(screen.queryByTestId('device-runtimes-table')).toBeNull()
+  })
+})
+
+describe('DeviceRuntimesSection — refresh', () => {
+  it('Refresh dispatches and is disabled while loading', () => {
+    const onRefresh = vi.fn()
+    const { rerender } = render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByTestId('device-runtimes-refresh'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    rerender(<DeviceRuntimesSection snapshot={snapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
+    expect((screen.getByTestId('device-runtimes-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
@@ -117,14 +117,27 @@ describe('DeviceRuntimesSection — device table + actions', () => {
     expect(onAction).toHaveBeenCalledWith('shutdown', 'U-BOOTED1')
   })
 
-  it('disables every action button while any action is in flight', () => {
+  it('disables the actioning row per-udid, leaving other rows enabled', () => {
+    // The server allows concurrent actions on distinct udids (cap 2), so only
+    // the in-flight device's button disables — other rows stay actionable.
     render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set(['U-BOOTED1'])} actionResults={{}} />)
-    expect((screen.getByTestId('simulator-boot-U-SHUT0001') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('simulator-shutdown-U-BOOTED1') as HTMLButtonElement).disabled).toBe(true)
     expect(screen.getByTestId('simulator-pending-U-BOOTED1')).toBeTruthy()
+    expect((screen.getByTestId('simulator-boot-U-SHUT0001') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('surfaces deviceType when it differs from the device name', () => {
+    render(
+      <DeviceRuntimesSection
+        snapshot={snapshot({ devices: [{ udid: 'U-RENAMED1', name: 'My Test Phone', state: 'Shutdown', runtime: 'iOS 26.1', deviceType: 'iPhone 15', isAvailable: true }] })}
+        loading={false} connected={true} onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('simulator-devicetype-U-RENAMED1').textContent).toBe('iPhone 15')
   })
 
   it('shows a settled note after an action resolves', () => {
-    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set<string>()} actionResults={{ 'U-SHUT0001': { action: 'boot', note: 'Booted (Booted)', error: null, at: 1 } }} />)
+    render(<DeviceRuntimesSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set<string>()} actionResults={{ 'U-SHUT0001': { action: 'boot', note: 'Booted', error: null, at: 1 } }} />)
     expect(screen.getByTestId('simulator-ok-U-SHUT0001').textContent).toContain('Booted')
   })
 

--- a/packages/dashboard/src/components/DeviceRuntimesSection.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.tsx
@@ -79,7 +79,6 @@ export function DeviceRuntimesSection({
   }
 
   const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
-  const anyActioning = actioningIds.size > 0
   const verdict = snapshot?.readyForMaestro
 
   return (
@@ -187,6 +186,9 @@ export function DeviceRuntimesSection({
                         <td>
                           <b data-testid={`simulator-name-${d.udid}`}>{d.name}</b>{' '}
                           <span className="cr-dim cr-mono">{d.udid.slice(0, 8)}</span>
+                          {d.deviceType && d.deviceType !== d.name && (
+                            <div className="cr-dim" data-testid={`simulator-devicetype-${d.udid}`}>{d.deviceType}</div>
+                          )}
                         </td>
                         <td className="cr-dim" data-testid={`simulator-runtime-${d.udid}`}>{d.runtime}</td>
                         <td>
@@ -203,7 +205,7 @@ export function DeviceRuntimesSection({
                               type="button"
                               className="cr-action"
                               data-testid={`simulator-shutdown-${d.udid}`}
-                              disabled={anyActioning || !connected}
+                              disabled={pending || !connected}
                               onClick={() => onAction('shutdown', d.udid)}
                               title="Shut down this simulator"
                             >
@@ -214,7 +216,7 @@ export function DeviceRuntimesSection({
                               type="button"
                               className="cr-action"
                               data-testid={`simulator-boot-${d.udid}`}
-                              disabled={anyActioning || !connected}
+                              disabled={pending || !connected}
                               onClick={() => onAction('boot', d.udid)}
                               title="Boot this simulator"
                             >

--- a/packages/dashboard/src/components/DeviceRuntimesSection.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.tsx
@@ -1,0 +1,237 @@
+/**
+ * DeviceRuntimesSection (#6136, epic #5530) — the "Device runtimes" Control Room
+ * tab. For this slice it surfaces iOS simulators (Android #6137 / WSL2 #6138 are
+ * separate sub-issues that will add their own panels here later).
+ *
+ * Renders the `simulator_status_snapshot` the server returns: each simulator's
+ * name / udid / state / runtime / device type, plus the headline **"Ready for
+ * Maestro" verdict** — a booted simulator AND Metro (:8081) AND the mock server
+ * (:9876) reachable — turning the manual Maestro pre-flight (CLAUDE.md "UI
+ * Verification with Maestro") into one glance.
+ *
+ * Boot / shutdown actions follow the established per-row discipline (mirrors the
+ * Containers tab): the server takes a `udid`, re-surveys + re-validates it as a
+ * lookup key, and state-gates the action. Non-destructive (no data loss), so no
+ * ConfirmDialog. `available:false` (off macOS / no xcrun) is a first-class state
+ * — no tables, just a note. Same pull-on-Refresh flow as the sibling surveys.
+ */
+import { useConnectionStore } from '../store/connection'
+import type { ServerSimulatorStatusSnapshotMessage } from '@chroxy/protocol'
+import type { SimulatorActionResult } from '../store/types'
+import { formatGeneratedAgo } from './ControlRoomSection'
+
+type SimAction = 'boot' | 'shutdown'
+
+/** ISO date (no time) for the eyebrow. */
+function isoDate(iso: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
+  return m ? m[1]! : iso
+}
+
+function ActionFeedback({ udid, pending, result }: { udid: string; pending: boolean; result: SimulatorActionResult | undefined }) {
+  if (pending) return <span className="cr-dim" data-testid={`simulator-pending-${udid}`}>Working…</span>
+  if (!result) return null
+  if (result.error) return <span className="cr-bad" data-testid={`simulator-error-${udid}`} role="alert">{result.error}</span>
+  return <span className="cr-ok" data-testid={`simulator-ok-${udid}`}>{result.note ?? 'done'}</span>
+}
+
+export interface DeviceRuntimesSectionProps {
+  snapshot?: ServerSimulatorStatusSnapshotMessage | null
+  loading?: boolean
+  connected?: boolean
+  onRefresh?: () => void
+  actioningIds?: Set<string>
+  actionResults?: Record<string, SimulatorActionResult>
+  onAction?: (action: SimAction, udid: string) => void
+  now?: () => number
+}
+
+export function DeviceRuntimesSection({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  actioningIds: actioningIdsProp,
+  actionResults: actionResultsProp,
+  onAction: onActionProp,
+  now = Date.now,
+}: DeviceRuntimesSectionProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.simulatorStatus)
+  const storeLoading = useConnectionStore((s) => s.simulatorStatusLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestSimulatorStatus = useConnectionStore((s) => s.requestSimulatorStatus)
+  const storeActioningIds = useConnectionStore((s) => s.simulatorActioningIds)
+  const storeActionResults = useConnectionStore((s) => s.simulatorActionResults)
+  const sendSimulatorAction = useConnectionStore((s) => s.sendSimulatorAction)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestSimulatorStatus
+  const actioningIds = actioningIdsProp ?? storeActioningIds
+  const actionResults = actionResultsProp ?? storeActionResults
+  const onAction = onActionProp ?? sendSimulatorAction
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+  const anyActioning = actioningIds.size > 0
+  const verdict = snapshot?.readyForMaestro
+
+  return (
+    <div className="cr-section" data-testid="device-runtimes-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="device-runtimes-eyebrow">
+          host · ios simulators{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h1 className="cr-title">Device runtimes</h1>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="device-runtimes-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="device-runtimes-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
+        {snapshot && !snapshot.available && (
+          <p className="cr-callout" data-testid="device-runtimes-unavailable">
+            {snapshot.note || 'iOS simulators are not available on this host.'}
+          </p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="device-runtimes-generated">
+            {formatGeneratedAgo(generatedAtMs, now())}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="device-runtimes-empty">
+          {loading ? (
+            <span>Running the simulator survey…</span>
+          ) : (
+            <>
+              <p>No simulator survey yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="device-runtimes-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="device-runtimes-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot?.available && verdict && (
+        <>
+          <section
+            className={`cr-callout ${verdict.ready ? 'cr-callout-ok' : 'cr-callout-bad'}`}
+            data-testid="device-runtimes-verdict"
+            data-ready={verdict.ready ? 'true' : 'false'}
+          >
+            {verdict.ready ? (
+              <p data-testid="device-runtimes-verdict-ready">
+                <b>✓ Ready for Maestro</b>
+                {verdict.bootedSimulator ? ` — ${verdict.bootedSimulator} booted, Metro + mock server reachable.` : ''}
+              </p>
+            ) : (
+              <>
+                <p data-testid="device-runtimes-verdict-not-ready"><b>✗ Not ready for Maestro</b></p>
+                <ul className="cr-reasons" data-testid="device-runtimes-verdict-reasons">
+                  {verdict.reasons.map((r, i) => (
+                    <li key={i}>{r}</li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </section>
+
+          {snapshot.devices.length === 0 ? (
+            <p className="cr-dim" data-testid="device-runtimes-no-devices">
+              No iOS simulators are installed on this host.
+            </p>
+          ) : (
+            <section className="cr-table-wrap">
+              <table className="cr-table" data-testid="device-runtimes-table">
+                <thead>
+                  <tr><th>Simulator</th><th>Runtime</th><th>State</th><th>Action</th></tr>
+                </thead>
+                <tbody>
+                  {snapshot.devices.map((d) => {
+                    const isBooted = d.state === 'Booted'
+                    const pending = actioningIds.has(d.udid)
+                    return (
+                      <tr key={d.udid} data-testid={`simulator-row-${d.udid}`}>
+                        <td>
+                          <b data-testid={`simulator-name-${d.udid}`}>{d.name}</b>{' '}
+                          <span className="cr-dim cr-mono">{d.udid.slice(0, 8)}</span>
+                        </td>
+                        <td className="cr-dim" data-testid={`simulator-runtime-${d.udid}`}>{d.runtime}</td>
+                        <td>
+                          <span
+                            className={`cr-tag ${isBooted ? 'cr-tag-ok' : 'cr-tag-dim'}`}
+                            data-testid={`simulator-state-${d.udid}`}
+                          >
+                            {d.state}
+                          </span>
+                        </td>
+                        <td data-testid={`simulator-actions-${d.udid}`}>
+                          {isBooted ? (
+                            <button
+                              type="button"
+                              className="cr-action"
+                              data-testid={`simulator-shutdown-${d.udid}`}
+                              disabled={anyActioning || !connected}
+                              onClick={() => onAction('shutdown', d.udid)}
+                              title="Shut down this simulator"
+                            >
+                              Shut down
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="cr-action"
+                              data-testid={`simulator-boot-${d.udid}`}
+                              disabled={anyActioning || !connected}
+                              onClick={() => onAction('boot', d.udid)}
+                              title="Boot this simulator"
+                            >
+                              Boot
+                            </button>
+                          )}{' '}
+                          <ActionFeedback udid={d.udid} pending={pending} result={actionResults[d.udid]} />
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -539,6 +539,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #6140 slice 2: host prune action — in-flight kinds + last outcome per kind.
   hostPruneActioningIds: new Set<string>(),
   hostPruneActionResults: {},
+  // #6136 (epic #5530): Control Room iOS simulator snapshot, fed by the
+  // simulator_status_snapshot handler. Null until the first survey lands.
+  simulatorStatus: null,
+  simulatorStatusLoading: false,
+  // #6136 slice 3: simulator action — in-flight udids + last outcome per udid.
+  simulatorActioningIds: new Set<string>(),
+  simulatorActionResults: {},
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -1068,6 +1075,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return false;
   },
 
+  // #6136 (epic #5530): request an iOS simulator survey. Mirrors
+  // requestHostPruneStatus — flips simulatorStatusLoading and sends a
+  // simulator_status_request; the reply is a single simulator_status_snapshot
+  // handled into simulatorStatus. Returns false (no loading) when the socket is
+  // closed.
+  requestSimulatorStatus: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ simulatorStatusLoading: true });
+      wsSend(socket, { type: 'simulator_status_request' });
+      return true;
+    }
+    return false;
+  },
+
   // #5499 (epic #5498): request an Integrations survey. Mirrors
   // requestRunnerStatus — flips integrationStatusLoading and sends an
   // integration_status_request; the reply is a single
@@ -1223,6 +1245,29 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     delete results[kind];
     set({ hostPruneActioningIds: pending, hostPruneActionResults: results });
     wsSend(socket, { type: 'host_prune_action', kind, requestId });
+    return true;
+  },
+
+  // #6136 slice 3 (epic #5530): boot / shut down an iOS simulator. The
+  // pending/result state is keyed by the device `udid`. Same wire-or-nothing
+  // contract as the sibling actions: tag with a requestId the server echoes on
+  // the simulator_action_ack / SIMULATOR_ACTION_FAILED session_error, and mark
+  // the udid pending ONLY when the message is genuinely on the wire. The server
+  // re-surveys + re-validates the udid (lookup key, never a trusted target) and
+  // state-gates the action. The udid's previous result is dropped so a stale
+  // outcome can't sit beside the pending state. Non-destructive → no confirm.
+  sendSimulatorAction: (action: 'boot' | 'shutdown', udid: string): boolean => {
+    const { socket } = get();
+    if (action !== 'boot' && action !== 'shutdown') return false;
+    if (!udid) return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const requestId = `simulator-action-${nextMessageId()}`;
+    const pending = new Set(get().simulatorActioningIds);
+    pending.add(udid);
+    const results = { ...get().simulatorActionResults };
+    delete results[udid];
+    set({ simulatorActioningIds: pending, simulatorActionResults: results });
+    wsSend(socket, { type: 'simulator_action', action, udid, requestId });
     return true;
   },
 
@@ -2020,6 +2065,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().hostPruneActioningIds.size > 0) {
         set({ hostPruneActioningIds: new Set<string>() });
       }
+      // #6136: ditto for in-flight simulator actions.
+      if (get().simulatorActioningIds.size > 0) {
+        set({ simulatorActioningIds: new Set<string>() });
+      }
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
@@ -2300,6 +2349,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6140: host prune action pending/result state goes with it.
       hostPruneActioningIds: new Set<string>(),
       hostPruneActionResults: {},
+      // #6136: simulator action pending/result state goes with it.
+      simulatorActioningIds: new Set<string>(),
+      simulatorActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -2346,6 +2398,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6140: host prune action pending/result state goes with it.
       hostPruneActioningIds: new Set<string>(),
       hostPruneActionResults: {},
+      // #6136: simulator action pending/result state goes with it.
+      simulatorActioningIds: new Set<string>(),
+      simulatorActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-simulator-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-simulator-action.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration test for the simulator action wiring (#6136 slice 3, epic #5530).
+ * Guards: ack clears the udid's pending state + records a note; malformed dropped;
+ * SIMULATOR_ACTION_FAILED clears the echoed udid + records the error; other udids
+ * untouched. Mirrors dispatch-host-prune-action.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {},
+    simulatorActioningIds: new Set(['U-A', 'U-B']),
+    simulatorActionResults: {},
+    messages: [],
+  }
+}
+
+describe('simulator action dispatch (#6136 slice 3)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('a boot ack clears the udid and records a state note', () => {
+    handleMessage({ type: 'simulator_action_ack', action: 'boot', udid: 'U-A', requestId: 'r1', status: 'Booted' }, ctx() as never)
+    const s = store.getState()
+    expect(s.simulatorActioningIds.has('U-A')).toBe(false)
+    expect(s.simulatorActioningIds.has('U-B')).toBe(true) // other udid untouched
+    expect(s.simulatorActionResults['U-A']!.error).toBeNull()
+    expect(s.simulatorActionResults['U-A']!.note).toMatch(/Booted/)
+  })
+
+  it('a shutdown ack records a shut-down note', () => {
+    handleMessage({ type: 'simulator_action_ack', action: 'shutdown', udid: 'U-A', status: 'Shutdown' }, ctx() as never)
+    expect(store.getState().simulatorActionResults['U-A']!.note).toMatch(/Shut down/)
+  })
+
+  it('drops a malformed ack (missing udid) without touching pending state', () => {
+    handleMessage({ type: 'simulator_action_ack', action: 'boot' }, ctx() as never)
+    expect(store.getState().simulatorActioningIds.has('U-A')).toBe(true)
+  })
+
+  it('SIMULATOR_ACTION_FAILED clears the echoed udid and records the error', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'SIMULATOR_ACTION_FAILED', message: 'Unable to boot device', reason: 'boot-failed', action: 'boot', udid: 'U-A', requestId: 'r1' }, ctx() as never)
+    const s = store.getState()
+    expect(s.simulatorActioningIds.has('U-A')).toBe(false)
+    expect(s.simulatorActioningIds.has('U-B')).toBe(true)
+    expect(s.simulatorActionResults['U-A']!.error).toMatch(/Unable to boot device/)
+    expect(s.simulatorActionResults['U-A']!.note).toBeNull()
+  })
+
+  it('a FAILED without a udid leaves action state alone', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'SIMULATOR_ACTION_FAILED', message: 'boom' }, ctx() as never)
+    expect(store.getState().simulatorActioningIds.has('U-A')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/dispatch-simulator-status.test.ts
+++ b/packages/dashboard/src/store/dispatch-simulator-status.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration test for the iOS simulator survey wiring (#6136, epic #5530).
+ * Guards: snapshot REPLACES simulatorStatus + clears loading; malformed dropped
+ * without clearing loading; available:false (off macOS) is a valid state.
+ * Mirrors dispatch-host-prune-status.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerSimulatorStatusSnapshotMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return { connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {}, simulatorStatus: null, simulatorStatusLoading: true, messages: [] }
+}
+function snapshot(over: Partial<ServerSimulatorStatusSnapshotMessage> = {}): ServerSimulatorStatusSnapshotMessage {
+  return {
+    type: 'simulator_status_snapshot',
+    generatedAt: '2026-06-20T12:00:00.000Z',
+    available: true,
+    note: null,
+    devices: [{ udid: 'U-BOOTED', name: 'iPhone 16 Pro', state: 'Booted', runtime: 'iOS 26.1', deviceType: 'iPhone 16 Pro', isAvailable: true }],
+    readyForMaestro: { ready: true, bootedSimulator: 'iPhone 16 Pro', metroReachable: true, mockServerReachable: true, reasons: [] },
+    ...over,
+  } as ServerSimulatorStatusSnapshotMessage
+}
+
+describe('simulator status dispatch (#6136)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('applies simulator_status_snapshot and clears loading', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.simulatorStatus!.devices.map((d) => d.udid)).toEqual(['U-BOOTED'])
+    expect(s.simulatorStatus!.readyForMaestro.ready).toBe(true)
+    expect(s.simulatorStatusLoading).toBe(false)
+  })
+
+  it('relays an available:false (off-macOS) snapshot as a valid state', () => {
+    handleMessage(snapshot({ available: false, note: 'not available on this host', devices: [], readyForMaestro: { ready: false, bootedSimulator: null, metroReachable: false, mockServerReachable: false, reasons: [] } }), ctx() as never)
+    const s = store.getState()
+    expect(s.simulatorStatus!.available).toBe(false)
+    expect(s.simulatorStatusLoading).toBe(false)
+  })
+
+  it('drops a malformed snapshot without clearing loading', () => {
+    handleMessage({ type: 'simulator_status_snapshot', generatedAt: '2026-06-20T12:00:00.000Z' }, ctx() as never)
+    expect(store.getState().simulatorStatus).toBeNull()
+    expect(store.getState().simulatorStatusLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2895,9 +2895,12 @@ function handleSimulatorActionAck(msg: Record<string, unknown>, get: MsgGet, set
   const parsed = ServerSimulatorActionAckSchema.safeParse(msg);
   if (!parsed.success) return;
   const { action, udid, status } = parsed.data;
-  const note = action === 'boot'
-    ? `Booted${status ? ` (${status})` : ''}`
-    : `Shut down${status ? ` (${status})` : ''}`;
+  // Append the echoed status only when it adds information — the happy path
+  // (boot → "Booted", shutdown → "Shutdown") is implied by the action, so a
+  // bare "Booted (Booted)" would be noise.
+  const implied = action === 'boot' ? 'Booted' : 'Shutdown';
+  const base = action === 'boot' ? 'Booted' : 'Shut down';
+  const note = status && status !== implied ? `${base} (${status})` : base;
   resolveSimulatorAction(get, set, udid, { action, note, error: null });
 }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2623,6 +2623,18 @@ function handleHostPruneStatusSnapshot(msg: Record<string, unknown>, _get: MsgGe
 }
 
 /**
+ * #6136 (epic #5530) — iOS simulator survey `simulator_status_snapshot`: REPLACE
+ * the stored snapshot and clear the loading flag. Same defensive, full-replace,
+ * clear-loading-only-on-valid-parse contract as the sibling survey handlers.
+ * `available:false` (off macOS / no xcrun) is a valid snapshot, not an error.
+ */
+function handleSimulatorStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerSimulatorStatusSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ simulatorStatus: parsed.data, simulatorStatusLoading: false });
+}
+
+/**
  * #5499 (epic #5498) — Integrations survey `integration_status_snapshot`:
  * REPLACE the stored survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host and
@@ -2855,6 +2867,41 @@ function handleHostPruneActionAck(msg: Record<string, unknown>, get: MsgGet, set
 }
 
 /**
+ * #6136 slice 3 (epic #5530) — resolve one simulator action target's pending
+ * state: drop the `udid` from `simulatorActioningIds` and record the outcome in
+ * `simulatorActionResults`. Shared by the success ack and the
+ * SIMULATOR_ACTION_FAILED session_error.
+ */
+function resolveSimulatorAction(
+  get: MsgGet,
+  set: MsgSet,
+  udid: string,
+  result: { action: string; note: string | null; error: string | null },
+): void {
+  const pending = new Set(get().simulatorActioningIds);
+  pending.delete(udid);
+  set({
+    simulatorActioningIds: pending,
+    simulatorActionResults: { ...get().simulatorActionResults, [udid]: { ...result, at: Date.now() } },
+  });
+}
+
+/**
+ * #6136 slice 3 — simulator action success ack: builds a human note from the
+ * echoed new state and clears the udid's pending state. A malformed ack is
+ * dropped (Zod safeParse) so the row keeps its honest pending state.
+ */
+function handleSimulatorActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerSimulatorActionAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const { action, udid, status } = parsed.data;
+  const note = action === 'boot'
+    ? `Booted${status ? ` (${status})` : ''}`
+    : `Shut down${status ? ` (${status})` : ''}`;
+  resolveSimulatorAction(get, set, udid, { action, note, error: null });
+}
+
+/**
  * #5547: a `summarize_session_result` resolves the pending summarize promise
  * (keyed by the echoed requestId) so the awaiting create-session flow opens
  * with the brief seeded. The failure half (SUMMARIZE_FAILED) rejects the same
@@ -2973,6 +3020,8 @@ const HANDLERS: Record<string, Handler> = {
   byok_pool_status_snapshot: handleByokPoolStatusSnapshot,
   // #6140 (epic #5530): Control Room host prune survey snapshot.
   host_prune_status_snapshot: handleHostPruneStatusSnapshot,
+  // #6136 (epic #5530): Control Room iOS simulator survey snapshot.
+  simulator_status_snapshot: handleSimulatorStatusSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
   skills_inventory_snapshot: handleSkillsInventorySnapshot,
@@ -2987,6 +3036,9 @@ const HANDLERS: Record<string, Handler> = {
   byok_pool_action_ack: handleByokPoolActionAck,
   // #6140 (epic #5530): positive ack correlating a host_prune_action to its outcome.
   host_prune_action_ack: handleHostPruneActionAck,
+  // #6136 (epic #5530): positive ack correlating a simulator_action (boot /
+  // shutdown) request to its outcome.
+  simulator_action_ack: handleSimulatorActionAck,
   // #5547: one-shot session-summary result; resolves the pending summarize
   // promise so the create-session flow can open with the brief seeded.
   summarize_session_result: handleSummarizeSessionResult,
@@ -3724,6 +3776,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         resolveHostPruneAction(get, set, msg.kind, {
           note: null,
           error: parsed.message || 'Host prune failed.',
+        });
+      } else if (parsed.code === 'SIMULATOR_ACTION_FAILED' && typeof msg.udid === 'string') {
+        // #6136: a failed simulator_action echoes the exact udid (+ action) —
+        // clear that device's pending state and surface the reason inline (the
+        // generic branch below still raises the toast, matching the precedents).
+        resolveSimulatorAction(get, set, msg.udid, {
+          action: typeof msg.action === 'string' ? msg.action : '',
+          note: null,
+          error: parsed.message || 'Simulator action failed.',
         });
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -598,6 +598,20 @@ export interface HostPruneActionResult {
   at: number;
 }
 
+/**
+ * #6136 slice 3 (epic #5530) — outcome of the last simulator action (boot /
+ * shutdown), kept for inline display. The target id is the device `udid`. A
+ * successful `simulator_action_ack` records a human `note` (the new state) with
+ * `error: null`; a SIMULATOR_ACTION_FAILED session_error records the message
+ * with `note: null`. `at` is the local receipt time (epoch ms).
+ */
+export interface SimulatorActionResult {
+  action: string;
+  note: string | null;
+  error: string | null;
+  at: number;
+}
+
 export interface ConnectionState {
   // Connection
   connectionPhase: ConnectionPhase;
@@ -898,6 +912,33 @@ export interface ConnectionState {
   hostPruneActioningIds: Set<string>;
   /** #6140 slice 2 — last host prune outcome per kind, for inline display. */
   hostPruneActionResults: Record<string, HostPruneActionResult>;
+  /**
+   * #6136 (epic #5530) — Control Room iOS simulator survey: the latest
+   * `simulator_status_snapshot` (devices + "Ready for Maestro" verdict), or null
+   * before the first one lands. Replaced wholesale on each snapshot (full
+   * picture, no delta stream). `available:false` off macOS is a valid state.
+   */
+  simulatorStatus: ServerSimulatorStatusSnapshotMessage | null;
+  /**
+   * #6136 — true between dispatching a `simulator_status_request` and the
+   * matching snapshot arriving, so the tab's Refresh button can spin. Cleared
+   * when a VALID snapshot lands (a malformed payload is dropped and leaves this
+   * true, matching the sibling surveys).
+   */
+  simulatorStatusLoading: boolean;
+  /**
+   * #6136 slice 3 (epic #5530) — device udids with an in-flight
+   * `simulator_action` (boot / shutdown): set when sendSimulatorAction is
+   * called, cleared on the `simulator_action_ack` / SIMULATOR_ACTION_FAILED
+   * session_error. Keyed by udid so each device row's buttons disable
+   * independently while their action is on the wire.
+   */
+  simulatorActioningIds: Set<string>;
+  /**
+   * #6136 slice 3 — last simulator action outcome per udid, for inline display
+   * in the device row. Replaced when the same device is actioned again.
+   */
+  simulatorActionResults: Record<string, SimulatorActionResult>;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;
@@ -1477,6 +1518,13 @@ export interface ConnectionState {
   // `hostPruneStatusLoading` while in flight.
   requestHostPruneStatus: () => boolean;
 
+  // #6136 (epic #5530): request an iOS simulator survey. Dispatches a
+  // `simulator_status_request`; the server replies with a single
+  // `simulator_status_snapshot` handled into `simulatorStatus`. Returns whether
+  // the message went on the wire (false = socket closed). Sets
+  // `simulatorStatusLoading` while in flight.
+  requestSimulatorStatus: () => boolean;
+
   // #6139 (epic #5530): request a per-repo runtime config survey. Dispatches a
   // `repo_runtime_config_request`; the server replies with a single
   // `repo_runtime_config_snapshot` handled into `repoRuntimeConfig`. Returns
@@ -1558,6 +1606,16 @@ export interface ConnectionState {
   // send returns false. Confirmation is the caller's responsibility (the UI
   // gates it behind a ConfirmDialog — it's destructive).
   sendHostPruneAction: (kind: 'containers' | 'images' | 'all') => boolean;
+
+  // #6136 slice 3 (epic #5530): boot / shut down an iOS simulator. `udid` names a
+  // device the survey enumerated — the server re-surveys and re-validates it (the
+  // udid is a lookup key, never a trusted target) plus state-gates the action.
+  // Dispatches a `simulator_action` tagged with a requestId the server echoes on
+  // the `simulator_action_ack` / SIMULATOR_ACTION_FAILED session_error. Marks the
+  // `udid` in `simulatorActioningIds` (dropping its stale result) ONLY when the
+  // message actually went on the wire; an offline send (or an empty udid)
+  // returns false without queuing. Non-destructive, so no confirm gate.
+  sendSimulatorAction: (action: 'boot' | 'shutdown', udid: string) => boolean;
 
   // #5547: request a server-side one-shot summary of a session's persisted
   // history (the sidebar "Summarize & start new session" action). Dispatches a

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -80,8 +80,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'simulator_status_snapshot', // #6136 (epic #5530) — Control Room iOS simulator survey reply. Server contract landed first; the dashboard slice that consumes it moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
-  'simulator_action_ack', // #6136 slice 2 (epic #5530) — Control Room iOS simulator boot/shutdown action ack. Server contract landed first (same server-first split as the survey above); the dashboard "Device runtimes" slice that consumes it moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -161,6 +159,8 @@ const PLATFORM_SPECIFIC = {
   'byok_pool_action_ack': 'dashboard', // Control Room BYOK pool mutating-action (drain/recycle/resize) ack (#6135, epic #5530) — the dashboard consumes it to clear pending target state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'host_prune_status_snapshot': 'dashboard', // Control Room host prune guardrails survey reply (#6140, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'host_prune_action_ack': 'dashboard', // Control Room host prune action ack (#6140, epic #5530) — the dashboard consumes it to clear pending kind state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'simulator_status_snapshot': 'dashboard', // Control Room iOS simulator survey reply (#6136, epic #5530) — the Device runtimes tab consumes it (devices + Ready-for-Maestro verdict); host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'simulator_action_ack': 'dashboard', // Control Room iOS simulator boot/shutdown action ack (#6136, epic #5530) — the dashboard consumes it to clear pending device state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'mailbox_status_snapshot': 'dashboard', // Control Room "Mailbox" tab survey reply (#5914 follow-up) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -148,6 +148,8 @@ const DASHBOARD_ONLY = new Set<string>([
   'byok_pool_action_ack',       // Control Room BYOK pool action ack (#6135, epic #5530) — dashboard-only
   'host_prune_status_snapshot', // Control Room host prune guardrails survey (#6140, epic #5530) — dashboard-only
   'host_prune_action_ack',      // Control Room host prune action ack (#6140, epic #5530) — dashboard-only
+  'simulator_status_snapshot',  // Control Room iOS simulator survey (#6136, epic #5530) — dashboard-only (Device runtimes tab)
+  'simulator_action_ack',       // Control Room iOS simulator boot/shutdown action ack (#6136, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -196,13 +198,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'simulator_status_snapshot',            // #6136 (epic #5530) Control Room iOS simulator survey —
-                                          //   server contract landed first; the dashboard slice that consumes
-                                          //   it is the tracked follow-up, then this → DASHBOARD_ONLY
-  'simulator_action_ack',                 // #6136 slice 2 (epic #5530) Control Room iOS simulator boot/shutdown
-                                          //   action ack — server contract landed first (same server-first split
-                                          //   as the survey above); the "Device runtimes" dashboard slice that
-                                          //   consumes it is the tracked follow-up, then this → DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#6136 slice 3 (epic #5530) — the dashboard half. Adds the **"Device runtimes"** Control Room tab that consumes the iOS simulator survey (slice 1) + boot/shutdown actions (slice 2, PR #6158). This **completes #6136**.

Closes #6136.

## What changed

- **`DeviceRuntimesSection.tsx`** (new) — renders the `simulator_status_snapshot`:
  - The headline **"Ready for Maestro" verdict** — booted simulator AND Metro (:8081) AND mock server (:9876) reachable — turning the manual Maestro pre-flight (CLAUDE.md "UI Verification with Maestro") into one glance. Ready → green; not-ready → the server's `reasons[]`.
  - A per-device table with **state-aware** action buttons (Boot for shutdown devices, Shut down for booted ones).
  - `available:false` (off macOS / no xcrun) is a first-class note — no verdict/table. Non-destructive actions → **no ConfirmDialog** (unlike host-prune).
- **store wiring** — `simulatorStatus`/`simulatorStatusLoading` + `requestSimulatorStatus`; `simulatorActioningIds`/`simulatorActionResults` (keyed by udid) + `sendSimulatorAction`; `handleSimulatorStatusSnapshot`/`handleSimulatorActionAck` + `resolveSimulatorAction` + the `SIMULATOR_ACTION_FAILED` `session_error` branch; socket-close/disconnect/forget resets for the action buckets — mirrors the host-prune/byok-pool slices exactly.
- **`ControlRoomView`** — `device-runtimes` `survey:true` tab descriptor (auto-fetch on activation via the generic effect) + render branch.
- **Coverage guards** — promotes `simulator_status_snapshot` + `simulator_action_ack` **out of** the unhandled allowlists **into** dashboard-handled (protocol `handler-coverage` → `PLATFORM_SPECIFIC: 'dashboard'`; store-core `protocol-type-coverage-lint` → `DASHBOARD_ONLY`). This is the dashboard half of the server-first split.

## Tests

- `dispatch-simulator-status.test.ts` + `dispatch-simulator-action.test.ts` — the store dispatch path (snapshot replace + loading clear, malformed-drop, ack clears the udid + records a note, `SIMULATOR_ACTION_FAILED` clears the echoed udid, other udids untouched).
- `DeviceRuntimesSection.test.tsx` — renderer (empty/loading/not-connected, off-macOS note, ready & not-ready verdicts with reasons, state-aware boot/shutdown buttons → onAction, disable-while-actioning, pending→settled, no-devices, refresh).

## Verification

- Full **dashboard** suite: **3948 pass** (218 files); **store-core** src: **1679 pass**
- Both coverage guards green; dashboard + store-core typecheck clean