### PR TITLE
feat(dashboard): converge EnvironmentPanel into the Control Room (#6141)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -79,7 +79,6 @@ import { AgentMonitorPanel } from './components/AgentMonitorPanel'
 import { SessionLoadingSkeleton } from './components/SessionLoadingSkeleton'
 import { StartupErrorScreen } from './components/StartupErrorScreen'
 import { ConsolePage } from './components/ConsolePage'
-import { EnvironmentPanel } from './components/EnvironmentPanel'
 import { SnapshotsPanel } from './components/SnapshotsPanel'
 import { PoolStatsPanel } from './components/PoolStatsPanel'
 import { PagesPanel } from './components/PagesPanel'
@@ -2253,9 +2252,6 @@ export function App() {
                 )}
                 {viewMode === 'console' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <ConsolePage />
-                )}
-                {viewMode === 'environments' && connectionPhase !== 'connecting' && !isSwitchingSession && (
-                  <EnvironmentPanel />
                 )}
                 {viewMode === 'snapshots' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <SnapshotsPanel />

--- a/packages/dashboard/src/components/ContainersStatusSection.test.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.test.tsx
@@ -26,6 +26,12 @@ vi.mock('../store/connection', () => ({
       sendContainersAction: () => false,
     }),
 }))
+// #6141: the converged deep-management view. Stub it (like ControlRoomView.test
+// stubs its child sections) so this unit test stays focused on the disclosure
+// wiring rather than EnvironmentPanel's own store coupling.
+vi.mock('./EnvironmentPanel', () => ({
+  EnvironmentPanel: () => <div data-testid="stub-env-panel">+ New Environment</div>,
+}))
 import { ContainersStatusSection } from './ContainersStatusSection'
 
 afterEach(cleanup)
@@ -285,5 +291,23 @@ describe('ContainersStatusSection — lifecycle actions (#6134)', () => {
     const err = screen.getByTestId('container-action-error-env-1')
     expect(err.textContent).toContain('docker stop failed')
     expect(err.getAttribute('role')).toBe('alert')
+  })
+})
+
+describe('ContainersStatusSection — environment management (#6141)', () => {
+  it('the manage-environments disclosure is collapsed by default', () => {
+    render(<ContainersStatusSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('containers-manage-toggle')).toBeTruthy()
+    expect(screen.queryByTestId('containers-manage-panel')).toBeNull()
+  })
+
+  it('clicking the toggle reveals the converged EnvironmentPanel (create/list/destroy)', () => {
+    render(<ContainersStatusSection snapshot={snapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    fireEvent.click(screen.getByTestId('containers-manage-toggle'))
+    const panel = screen.getByTestId('containers-manage-panel')
+    expect(panel).toBeTruthy()
+    // EnvironmentPanel (stubbed) renders inside the disclosure.
+    expect(screen.getByTestId('stub-env-panel')).toBeTruthy()
+    expect(panel.textContent).toContain('New Environment')
   })
 })

--- a/packages/dashboard/src/components/ContainersStatusSection.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.tsx
@@ -507,13 +507,14 @@ export function ContainersStatusSection({
           className="cr-action"
           data-testid="containers-manage-toggle"
           aria-expanded={showManage}
+          aria-controls="containers-manage-panel-region"
           onClick={() => setShowManage((v) => !v)}
           title="Create or destroy persistent environments"
         >
           {showManage ? 'Hide environment management' : 'Manage environments'}
         </button>
         {showManage && (
-          <div data-testid="containers-manage-panel">
+          <div id="containers-manage-panel-region" data-testid="containers-manage-panel">
             <EnvironmentPanel />
           </div>
         )}

--- a/packages/dashboard/src/components/ContainersStatusSection.tsx
+++ b/packages/dashboard/src/components/ContainersStatusSection.tsx
@@ -26,6 +26,7 @@ import type { ServerContainersStatusSnapshotMessage } from '@chroxy/protocol'
 import type { ContainerActionResult } from '../store/types'
 import { formatGeneratedAgo } from './ControlRoomSection'
 import { ConfirmDialog } from './ConfirmDialog'
+import { EnvironmentPanel } from './EnvironmentPanel'
 
 type Accent = 'ok' | 'warn' | 'bad' | 'neutral'
 
@@ -363,6 +364,10 @@ export function ContainersStatusSection({
   // never straight to onAction. Holds the container awaiting confirmation
   // (null = dialog closed). Stop/Restart dispatch immediately.
   const [confirmDestroy, setConfirmDestroy] = useState<ContainerEntry | null>(null)
+  // #6141 (epic #5530): the converged deep-management view. The standalone
+  // "Envs" view-tab is gone — environment create/list/destroy now lives here,
+  // behind a disclosure so the read-only survey above stays the overview.
+  const [showManage, setShowManage] = useState(false)
   const handleRowAction = (environmentId: string, action: ContainerAction) => {
     if (action === 'destroy') {
       const target = snapshot?.containers.find((c) => c.id === environmentId) ?? null
@@ -495,6 +500,24 @@ export function ContainersStatusSection({
           </section>
         </>
       )}
+
+      <section className="cr-manage-environments" data-testid="containers-manage">
+        <button
+          type="button"
+          className="cr-action"
+          data-testid="containers-manage-toggle"
+          aria-expanded={showManage}
+          onClick={() => setShowManage((v) => !v)}
+          title="Create or destroy persistent environments"
+        >
+          {showManage ? 'Hide environment management' : 'Manage environments'}
+        </button>
+        {showManage && (
+          <div data-testid="containers-manage-panel">
+            <EnvironmentPanel />
+          </div>
+        )}
+      </section>
 
       <ConfirmDialog
         open={confirmDestroy !== null}

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -5,7 +5,7 @@ import { formatShortcutKeys } from '../utils/platform'
 // #5204 — 'control-room' is no longer a per-session viewMode; the Control
 // Room is a dedicated session-independent top-level tab (see `controlRoomOpen`
 // / `controlRoomActive` in App).
-export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'pages'
+export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages'
 
 /** Scrollable tab bar with arrow buttons when overflowing */
 export function ViewSwitcher({
@@ -133,7 +133,6 @@ export function ViewSwitcher({
         {showConsoleTab && (
           <button className={`view-tab${viewMode === 'console' ? ' active' : ''}`} onClick={() => { setViewMode('console'); setSplitMode(null); persistSplitMode(null) }} type="button">Console</button>
         )}
-        <button className={`view-tab${viewMode === 'environments' ? ' active' : ''}`} onClick={() => { setViewMode('environments'); setSplitMode(null); persistSplitMode(null) }} type="button">Envs</button>
         <button className={`view-tab${viewMode === 'snapshots' ? ' active' : ''}`} onClick={() => { setViewMode('snapshots'); setSplitMode(null); persistSplitMode(null) }} type="button">Snapshots</button>
         <button className={`view-tab${viewMode === 'pool' ? ' active' : ''}`} onClick={() => { setViewMode('pool'); setSplitMode(null); persistSplitMode(null) }} type="button">Pool</button>
         <button className={`view-tab${viewMode === 'pages' ? ' active' : ''}`} onClick={() => { setViewMode('pages'); setSplitMode(null); persistSplitMode(null) }} type="button">Pages</button>

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -34,7 +34,7 @@ import { processBase64Image } from '../utils/image-utils'
 import { useConnectionStore } from '../store/connection'
 import { persistSplitMode } from '../store/persistence'
 
-type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots'
+type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'snapshots'
 
 export interface ShortcutDispatchProps {
   shortcutRegistry: ShortcutRegistry

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -96,7 +96,11 @@ const MAX_TERMINAL_SIZE = 50_000;
  * #5204 — 'control-room' removed: it's a top-level tab now, not a view mode.
  * Any stale persisted 'control-room' value fails validation and falls back to
  * the default, which is the desired behaviour. */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots', 'pool', 'pages'] as const;
+// #6141: 'environments' retired — its UI converged into the Control Room
+// Containers section. A persisted 'environments' viewMode no longer validates
+// and falls back to the default, so a carried-over value can't render a
+// now-removed surface.
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'snapshots', 'pool', 'pages'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1127,7 +1127,7 @@ export interface ConnectionState {
 
   // View mode. #5204 — 'control-room' removed: the Control Room is now a
   // session-independent top-level tab in App, not a per-session view mode.
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'pages';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages';
 
   // Input settings
   inputSettings: InputSettings;
@@ -1146,7 +1146,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'pages') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
   appendTerminalData: (data: string) => void;


### PR DESCRIPTION
## Summary

#6141 (epic #5530). **Decision: CONVERGE** (the option the epic recommends). Folds the standalone `EnvironmentPanel` out of the per-session view-switcher and into the Control Room **Containers** section as the deep-management view it links into — one operational surface, no duplicate environment UI.

Closes #6141.

## Decision & rationale

The Containers Control Room section already surveys chroxy-managed environments host-wide (read-only + lifecycle actions). The standalone "Envs" view-tab was a per-session slot rendering the same host-level data — a duplicate surface. Converging puts the read-only survey (overview) and the create/destroy management (deep view) in **one** place, reachable from the Containers section, and removes the orphaned standalone tab.

## What changed

- **`ContainersStatusSection.tsx`** — a **"Manage environments"** disclosure renders the (unchanged) `EnvironmentPanel` below the survey. Collapsed by default so the survey stays the overview; one click reveals create/list/destroy in the same tab.
- **Removed the standalone "Envs" view-tab**, end to end:
  - the button in `ViewSwitcher.tsx`
  - the `viewMode === 'environments'` render branch + import in `App.tsx`
  - `'environments'` from every `ViewMode` union (`ViewSwitcher`, `store/types.ts`, `hooks/useShortcutDispatch.ts`)
  - `'environments'` from `persistence.ts` `VALID_VIEW_MODES` — so a **persisted** `'environments'` viewMode now falls back to the default rather than rendering a removed surface (no blank view, no orphaned tab).
- **`EnvironmentPanel.tsx` is unchanged** → no regression in environment **create / list / destroy / get** (still the existing environment protocol).

## Tests

- `ContainersStatusSection.test.tsx` — the disclosure is collapsed by default; clicking the toggle reveals the (stubbed) EnvironmentPanel. EnvironmentPanel is stubbed in this unit test (matching the `ControlRoomView.test` precedent of stubbing child sections) to keep it focused on the disclosure wiring.

## Verification

- Full **dashboard** suite: **3951 pass** (218 files); dashboard typecheck clean.
- No protocol/server changes (dashboard-only) — no dist rebuild.