### PR TITLE
feat(dashboard): Android emulator panel in Device runtimes (#6137)

### DIFF
--- a/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
@@ -259,4 +259,13 @@ describe('AndroidEmulatorPanel (#6137)', () => {
     expect(screen.getByTestId('emulator-no-devices')).toBeTruthy()
     expect(screen.queryByTestId('emulator-table')).toBeNull()
   })
+
+  it('a live device with no serial renders safely with a disabled Kill (nothing to kill)', () => {
+    // Schema-permitted edge: a just-starting emulator the survey hasn't assigned
+    // a serial to yet. The row keys off the avd fallback and the Kill button
+    // disables (no serial → no kill target) instead of breaking.
+    render(<AndroidEmulatorPanel snapshot={emuSnapshot({ devices: [{ avd: 'Pixel_7_API_34', serial: null, state: 'starting' }], readyForMaestro: { ready: false, runningDevice: null, metroReachable: true, mockServerReachable: true, reasons: ['No running emulator'] } })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('emulator-row-Pixel_7_API_34')).toBeTruthy()
+    expect((screen.getByTestId('emulator-kill-Pixel_7_API_34') as HTMLButtonElement).disabled).toBe(true)
+  })
 })

--- a/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
@@ -24,9 +24,17 @@ vi.mock('../store/connection', () => ({
       simulatorActioningIds: new Set<string>(),
       simulatorActionResults: {},
       sendSimulatorAction: () => false,
+      // #6137: the Android emulator panel reads these (rendered by DeviceRuntimesSection).
+      emulatorStatus: null,
+      emulatorStatusLoading: false,
+      requestEmulatorStatus: () => false,
+      emulatorActioningIds: new Set<string>(),
+      emulatorActionResults: {},
+      sendEmulatorAction: () => false,
     }),
 }))
-import { DeviceRuntimesSection } from './DeviceRuntimesSection'
+import { DeviceRuntimesSection, AndroidEmulatorPanel } from './DeviceRuntimesSection'
+import type { ServerEmulatorStatusSnapshotMessage } from '@chroxy/protocol'
 
 afterEach(cleanup)
 
@@ -156,5 +164,99 @@ describe('DeviceRuntimesSection — refresh', () => {
     expect(onRefresh).toHaveBeenCalledTimes(1)
     rerender(<DeviceRuntimesSection snapshot={snapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
     expect((screen.getByTestId('device-runtimes-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+function emuSnapshot(over: Partial<ServerEmulatorStatusSnapshotMessage> = {}): ServerEmulatorStatusSnapshotMessage {
+  return {
+    type: 'emulator_status_snapshot',
+    generatedAt: '2026-06-20T12:00:00.000Z',
+    available: true,
+    note: null,
+    devices: [
+      { avd: 'Pixel_7_API_34', serial: 'emulator-5554', state: 'running' },
+      { avd: 'Pixel_5_API_33', serial: null, state: 'stopped' },
+    ],
+    readyForMaestro: { ready: true, runningDevice: 'Pixel_7_API_34', metroReachable: true, mockServerReachable: true, reasons: [] },
+    ...over,
+  } as ServerEmulatorStatusSnapshotMessage
+}
+
+describe('AndroidEmulatorPanel (#6137)', () => {
+  it('renders the empty state with a Run-survey button when no snapshot', () => {
+    render(<AndroidEmulatorPanel snapshot={null} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('emulator-empty')).toBeTruthy()
+    expect(screen.queryByTestId('emulator-table')).toBeNull()
+  })
+
+  it('renders the unavailable note (no SDK) and no verdict/table', () => {
+    render(
+      <AndroidEmulatorPanel
+        snapshot={emuSnapshot({ available: false, note: 'not available on this host', devices: [], readyForMaestro: { ready: false, runningDevice: null, metroReachable: false, mockServerReachable: false, reasons: [] } })}
+        loading={false} connected={true} onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('emulator-unavailable').textContent).toContain('not available')
+    expect(screen.queryByTestId('emulator-verdict')).toBeNull()
+  })
+
+  it('renders the ready verdict and a state-aware Kill (running) + Boot (stopped) buttons', () => {
+    render(<AndroidEmulatorPanel snapshot={emuSnapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('emulator-verdict').getAttribute('data-ready')).toBe('true')
+    expect(screen.getByTestId('emulator-kill-emulator-5554')).toBeTruthy()
+    expect(screen.getByTestId('emulator-boot-Pixel_5_API_33')).toBeTruthy()
+  })
+
+  it('renders the not-ready verdict with reasons', () => {
+    render(
+      <AndroidEmulatorPanel
+        snapshot={emuSnapshot({ devices: [{ avd: 'Pixel_5_API_33', serial: null, state: 'stopped' }], readyForMaestro: { ready: false, runningDevice: null, metroReachable: false, mockServerReachable: true, reasons: ['No running emulator', 'Metro not reachable on :8081'] } })}
+        loading={false} connected={true} onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('emulator-verdict').getAttribute('data-ready')).toBe('false')
+    expect(screen.getByTestId('emulator-verdict-reasons').textContent).toContain('No running emulator')
+  })
+
+  it('boot routes to onAction(boot, {avd}); kill routes to onAction(kill, {serial})', () => {
+    const onAction = vi.fn()
+    render(<AndroidEmulatorPanel snapshot={emuSnapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('emulator-boot-Pixel_5_API_33'))
+    expect(onAction).toHaveBeenCalledWith('boot', { avd: 'Pixel_5_API_33' })
+    fireEvent.click(screen.getByTestId('emulator-kill-emulator-5554'))
+    expect(onAction).toHaveBeenCalledWith('kill', { serial: 'emulator-5554' })
+  })
+
+  it('a starting emulator shows a Kill button (live) with the warn state tag', () => {
+    render(<AndroidEmulatorPanel snapshot={emuSnapshot({ devices: [{ avd: 'Pixel_7_API_34', serial: 'emulator-5554', state: 'starting' }], readyForMaestro: { ready: false, runningDevice: null, metroReachable: true, mockServerReachable: true, reasons: ['No running emulator'] } })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('emulator-state-emulator-5554').textContent).toBe('starting')
+    expect(screen.getByTestId('emulator-kill-emulator-5554')).toBeTruthy()
+  })
+
+  it('disables the actioning row per-target, leaving others enabled', () => {
+    render(<AndroidEmulatorPanel snapshot={emuSnapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set(['emulator-5554'])} actionResults={{}} />)
+    expect((screen.getByTestId('emulator-kill-emulator-5554') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('emulator-pending-emulator-5554')).toBeTruthy()
+    expect((screen.getByTestId('emulator-boot-Pixel_5_API_33') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('shows a settled note after an action resolves', () => {
+    render(<AndroidEmulatorPanel snapshot={emuSnapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set<string>()} actionResults={{ 'Pixel_5_API_33': { action: 'boot', note: 'Starting…', error: null, at: 1 } }} />)
+    expect(screen.getByTestId('emulator-ok-Pixel_5_API_33').textContent).toContain('Starting')
+  })
+
+  it('Refresh dispatches and is disabled while loading', () => {
+    const onRefresh = vi.fn()
+    const { rerender } = render(<AndroidEmulatorPanel snapshot={emuSnapshot()} loading={false} connected={true} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByTestId('emulator-refresh'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    rerender(<AndroidEmulatorPanel snapshot={emuSnapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
+    expect((screen.getByTestId('emulator-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('renders a no-devices note when no AVDs are installed', () => {
+    render(<AndroidEmulatorPanel snapshot={emuSnapshot({ devices: [], readyForMaestro: { ready: false, runningDevice: null, metroReachable: true, mockServerReachable: true, reasons: ['No running emulator'] } })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('emulator-no-devices')).toBeTruthy()
+    expect(screen.queryByTestId('emulator-table')).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/DeviceRuntimesSection.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.tsx
@@ -1,23 +1,22 @@
 /**
- * DeviceRuntimesSection (#6136, epic #5530) — the "Device runtimes" Control Room
- * tab. For this slice it surfaces iOS simulators (Android #6137 / WSL2 #6138 are
- * separate sub-issues that will add their own panels here later).
+ * DeviceRuntimesSection (#6136 / #6137, epic #5530) — the "Device runtimes"
+ * Control Room tab. Surfaces two device-runtime panels: iOS simulators (#6136)
+ * and Android emulators (#6137). (WSL2 #6138 is a Windows-only follow-up.)
  *
- * Renders the `simulator_status_snapshot` the server returns: each simulator's
- * name / udid / state / runtime / device type, plus the headline **"Ready for
- * Maestro" verdict** — a booted simulator AND Metro (:8081) AND the mock server
- * (:9876) reachable — turning the manual Maestro pre-flight (CLAUDE.md "UI
- * Verification with Maestro") into one glance.
- *
- * Boot / shutdown actions follow the established per-row discipline (mirrors the
- * Containers tab): the server takes a `udid`, re-surveys + re-validates it as a
- * lookup key, and state-gates the action. Non-destructive (no data loss), so no
- * ConfirmDialog. `available:false` (off macOS / no xcrun) is a first-class state
- * — no tables, just a note. Same pull-on-Refresh flow as the sibling surveys.
+ * Each panel renders its `*_status_snapshot` (devices + the headline **"Ready
+ * for Maestro" verdict** — a booted/running device AND Metro (:8081) AND the
+ * mock server (:9876) reachable — turning the manual Maestro pre-flight
+ * (CLAUDE.md "UI Verification with Maestro") into one glance) plus per-row
+ * lifecycle actions (simulator boot/shutdown; emulator boot/kill). Each follows
+ * the established per-row discipline: the server takes the device id, re-surveys
+ * + re-validates it as a lookup key, and state-gates the action. Non-destructive
+ * (no data loss), so no ConfirmDialog. `available:false` (no SDK / off-platform)
+ * is a first-class state — no tables, just a note.
  */
+import { useEffect } from 'react'
 import { useConnectionStore } from '../store/connection'
-import type { ServerSimulatorStatusSnapshotMessage } from '@chroxy/protocol'
-import type { SimulatorActionResult } from '../store/types'
+import type { ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage } from '@chroxy/protocol'
+import type { SimulatorActionResult, EmulatorActionResult } from '../store/types'
 import { formatGeneratedAgo } from './ControlRoomSection'
 
 type SimAction = 'boot' | 'shutdown'
@@ -82,6 +81,7 @@ export function DeviceRuntimesSection({
   const verdict = snapshot?.readyForMaestro
 
   return (
+    <>
     <div className="cr-section" data-testid="device-runtimes-section">
       <header className="cr-header">
         <div className="cr-eyebrow" data-testid="device-runtimes-eyebrow">
@@ -224,6 +224,236 @@ export function DeviceRuntimesSection({
                             </button>
                           )}{' '}
                           <ActionFeedback udid={d.udid} pending={pending} result={actionResults[d.udid]} />
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+    <AndroidEmulatorPanel now={now} />
+    </>
+  )
+}
+
+function EmulatorActionFeedback({ id, pending, result }: { id: string; pending: boolean; result: EmulatorActionResult | undefined }) {
+  if (pending) return <span className="cr-dim" data-testid={`emulator-pending-${id}`}>Working…</span>
+  if (!result) return null
+  if (result.error) return <span className="cr-bad" data-testid={`emulator-error-${id}`} role="alert">{result.error}</span>
+  return <span className="cr-ok" data-testid={`emulator-ok-${id}`}>{result.note ?? 'done'}</span>
+}
+
+export interface AndroidEmulatorPanelProps {
+  snapshot?: ServerEmulatorStatusSnapshotMessage | null
+  loading?: boolean
+  connected?: boolean
+  onRefresh?: () => void
+  actioningIds?: Set<string>
+  actionResults?: Record<string, EmulatorActionResult>
+  onAction?: (action: 'boot' | 'kill', opts: { avd?: string; serial?: string }) => void
+  now?: () => number
+}
+
+/**
+ * #6137 — the Android emulator half of the Device runtimes tab. Mirrors the iOS
+ * panel above: the "Ready for Maestro" verdict + a per-device table with
+ * state-aware Boot (a stopped AVD) / Kill (a live serial) buttons. The tab's
+ * generic auto-fetch only covers the iOS survey, so this panel self-fetches the
+ * emulator survey once on connect (and the Refresh button re-runs it).
+ */
+export function AndroidEmulatorPanel({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  actioningIds: actioningIdsProp,
+  actionResults: actionResultsProp,
+  onAction: onActionProp,
+  now = Date.now,
+}: AndroidEmulatorPanelProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.emulatorStatus)
+  const storeLoading = useConnectionStore((s) => s.emulatorStatusLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestEmulatorStatus = useConnectionStore((s) => s.requestEmulatorStatus)
+  const storeActioningIds = useConnectionStore((s) => s.emulatorActioningIds)
+  const storeActionResults = useConnectionStore((s) => s.emulatorActionResults)
+  const sendEmulatorAction = useConnectionStore((s) => s.sendEmulatorAction)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestEmulatorStatus
+  const actioningIds = actioningIdsProp ?? storeActioningIds
+  const actionResults = actionResultsProp ?? storeActionResults
+  const onAction = onActionProp ?? ((action: 'boot' | 'kill', opts: { avd?: string; serial?: string }) => sendEmulatorAction(action, opts))
+
+  // The tab's generic auto-fetch only requests the iOS survey, so kick the
+  // emulator survey once when we first connect with no snapshot yet. (When
+  // driven by props in tests, the store selectors aren't used; this effect is a
+  // no-op there because onRefresh is the injected prop.)
+  useEffect(() => {
+    if (snapshotProp === undefined && storeConnected && storeSnapshot === null && !storeLoading) {
+      requestEmulatorStatus()
+    }
+  }, [snapshotProp, storeConnected, storeSnapshot, storeLoading, requestEmulatorStatus])
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+  const verdict = snapshot?.readyForMaestro
+
+  return (
+    <div className="cr-section" data-testid="emulator-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="emulator-eyebrow">
+          host · android emulators{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h2 className="cr-title">Android emulators</h2>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="emulator-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="emulator-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
+        {snapshot && !snapshot.available && (
+          <p className="cr-callout" data-testid="emulator-unavailable">
+            {snapshot.note || 'Android emulators are not available on this host.'}
+          </p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="emulator-generated">
+            {formatGeneratedAgo(generatedAtMs, now())}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="emulator-empty">
+          {loading ? (
+            <span>Running the emulator survey…</span>
+          ) : (
+            <>
+              <p>No emulator survey yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="emulator-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="emulator-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot?.available && verdict && (
+        <>
+          <section
+            className={`cr-callout ${verdict.ready ? 'cr-callout-ok' : 'cr-callout-bad'}`}
+            data-testid="emulator-verdict"
+            data-ready={verdict.ready ? 'true' : 'false'}
+          >
+            {verdict.ready ? (
+              <p data-testid="emulator-verdict-ready">
+                <b>✓ Ready for Maestro</b>
+                {verdict.runningDevice ? ` — ${verdict.runningDevice} running, Metro + mock server reachable.` : ''}
+              </p>
+            ) : (
+              <>
+                <p data-testid="emulator-verdict-not-ready"><b>✗ Not ready for Maestro</b></p>
+                <ul className="cr-reasons" data-testid="emulator-verdict-reasons">
+                  {verdict.reasons.map((r, i) => (
+                    <li key={i}>{r}</li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </section>
+
+          {snapshot.devices.length === 0 ? (
+            <p className="cr-dim" data-testid="emulator-no-devices">
+              No AVDs are installed on this host.
+            </p>
+          ) : (
+            <section className="cr-table-wrap">
+              <table className="cr-table" data-testid="emulator-table">
+                <thead>
+                  <tr><th>Emulator</th><th>State</th><th>Action</th></tr>
+                </thead>
+                <tbody>
+                  {snapshot.devices.map((d) => {
+                    const isLive = d.state !== 'stopped'
+                    // Target id: avd for a stopped AVD (boot), serial for a live one (kill).
+                    const targetId = isLive ? (d.serial ?? '') : (d.avd ?? '')
+                    const pending = targetId.length > 0 && actioningIds.has(targetId)
+                    const rowKey = d.serial || d.avd || 'unknown'
+                    return (
+                      <tr key={rowKey} data-testid={`emulator-row-${rowKey}`}>
+                        <td>
+                          <b data-testid={`emulator-name-${rowKey}`}>{d.avd || d.serial || 'unknown'}</b>{' '}
+                          {d.serial && <span className="cr-dim cr-mono">{d.serial}</span>}
+                        </td>
+                        <td>
+                          <span
+                            className={`cr-tag ${d.state === 'running' ? 'cr-tag-ok' : d.state === 'starting' ? 'cr-tag-warn' : 'cr-tag-dim'}`}
+                            data-testid={`emulator-state-${rowKey}`}
+                          >
+                            {d.state}
+                          </span>
+                        </td>
+                        <td data-testid={`emulator-actions-${rowKey}`}>
+                          {isLive ? (
+                            <button
+                              type="button"
+                              className="cr-action"
+                              data-testid={`emulator-kill-${rowKey}`}
+                              disabled={pending || !connected || !d.serial}
+                              onClick={() => d.serial && onAction('kill', { serial: d.serial })}
+                              title="Kill this emulator"
+                            >
+                              Kill
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="cr-action"
+                              data-testid={`emulator-boot-${rowKey}`}
+                              disabled={pending || !connected || !d.avd}
+                              onClick={() => d.avd && onAction('boot', { avd: d.avd })}
+                              title="Boot this emulator"
+                            >
+                              Boot
+                            </button>
+                          )}{' '}
+                          {targetId.length > 0 && (
+                            <EmulatorActionFeedback id={rowKey} pending={pending} result={actionResults[targetId]} />
+                          )}
                         </td>
                       </tr>
                     )

--- a/packages/dashboard/src/components/DeviceRuntimesSection.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.tsx
@@ -409,8 +409,13 @@ export function AndroidEmulatorPanel({
                 <tbody>
                   {snapshot.devices.map((d) => {
                     const isLive = d.state !== 'stopped'
-                    // Target id: avd for a stopped AVD (boot), serial for a live one (kill).
-                    const targetId = isLive ? (d.serial ?? '') : (d.avd ?? '')
+                    // Target id keys per-row pending/feedback. It matches the id
+                    // sendEmulatorAction marks pending: serial for a live (kill)
+                    // row, avd for a stopped (boot) row. A live row with no serial
+                    // (schema-permitted, e.g. a just-starting emulator) falls back
+                    // to its avd so pending/feedback still render under the row —
+                    // the Kill button stays disabled (no serial → nothing to kill).
+                    const targetId = isLive ? (d.serial ?? d.avd ?? '') : (d.avd ?? '')
                     const pending = targetId.length > 0 && actioningIds.has(targetId)
                     const rowKey = d.serial || d.avd || 'unknown'
                     return (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -546,6 +546,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #6136 slice 3: simulator action — in-flight udids + last outcome per udid.
   simulatorActioningIds: new Set<string>(),
   simulatorActionResults: {},
+  // #6137: Control Room Android emulator snapshot, fed by the
+  // emulator_status_snapshot handler. Null until the first survey lands.
+  emulatorStatus: null,
+  emulatorStatusLoading: false,
+  // #6137: emulator action — in-flight targets (avd/serial) + last outcome.
+  emulatorActioningIds: new Set<string>(),
+  emulatorActionResults: {},
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -1090,6 +1097,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return false;
   },
 
+  // #6137 (epic #5530): request an Android emulator survey. Mirrors
+  // requestSimulatorStatus — flips emulatorStatusLoading and sends an
+  // emulator_status_request; the reply is a single emulator_status_snapshot
+  // handled into emulatorStatus. Returns false (no loading) when the socket is
+  // closed.
+  requestEmulatorStatus: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ emulatorStatusLoading: true });
+      wsSend(socket, { type: 'emulator_status_request' });
+      return true;
+    }
+    return false;
+  },
+
   // #5499 (epic #5498): request an Integrations survey. Mirrors
   // requestRunnerStatus — flips integrationStatusLoading and sends an
   // integration_status_request; the reply is a single
@@ -1268,6 +1290,33 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     delete results[udid];
     set({ simulatorActioningIds: pending, simulatorActionResults: results });
     wsSend(socket, { type: 'simulator_action', action, udid, requestId });
+    return true;
+  },
+
+  // #6137 (epic #5530): boot an AVD / kill a running Android emulator. The
+  // pending/result state is keyed by the target (avd for boot, serial for kill).
+  // Same wire-or-nothing contract as the sibling actions. Non-destructive → no
+  // confirm. The server re-surveys + re-validates the target and state-gates it.
+  sendEmulatorAction: (action: 'boot' | 'kill', opts: { avd?: string; serial?: string; headless?: boolean }): boolean => {
+    const { socket } = get();
+    if (action !== 'boot' && action !== 'kill') return false;
+    const targetId = action === 'boot' ? opts?.avd : opts?.serial;
+    if (!targetId) return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const requestId = `emulator-action-${nextMessageId()}`;
+    const pending = new Set(get().emulatorActioningIds);
+    pending.add(targetId);
+    const results = { ...get().emulatorActionResults };
+    delete results[targetId];
+    set({ emulatorActioningIds: pending, emulatorActionResults: results });
+    const msg: Record<string, unknown> = { type: 'emulator_action', action, requestId };
+    if (action === 'boot') {
+      msg.avd = opts.avd;
+      if (opts.headless) msg.headless = true;
+    } else {
+      msg.serial = opts.serial;
+    }
+    wsSend(socket, msg);
     return true;
   },
 
@@ -2069,6 +2118,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().simulatorActioningIds.size > 0) {
         set({ simulatorActioningIds: new Set<string>() });
       }
+      // #6137: ditto for in-flight emulator actions.
+      if (get().emulatorActioningIds.size > 0) {
+        set({ emulatorActioningIds: new Set<string>() });
+      }
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
@@ -2352,6 +2405,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6136: simulator action pending/result state goes with it.
       simulatorActioningIds: new Set<string>(),
       simulatorActionResults: {},
+      // #6137: emulator action pending/result state goes with it.
+      emulatorActioningIds: new Set<string>(),
+      emulatorActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -2401,6 +2457,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6136: simulator action pending/result state goes with it.
       simulatorActioningIds: new Set<string>(),
       simulatorActionResults: {},
+      // #6137: emulator action pending/result state goes with it.
+      emulatorActioningIds: new Set<string>(),
+      emulatorActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-emulator-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-emulator-action.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Integration test for the Android emulator action wiring (#6137, epic #5530).
+ * Guards: ack clears the target's pending state + records a note; malformed
+ * dropped; EMULATOR_ACTION_FAILED clears the echoed target + records the error;
+ * other targets untouched. Mirrors dispatch-simulator-action.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {},
+    emulatorActioningIds: new Set(['Pixel_5_API_33', 'emulator-5554']),
+    emulatorActionResults: {},
+    messages: [],
+  }
+}
+
+describe('emulator action dispatch (#6137)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('a boot ack clears the avd target and records a Starting note', () => {
+    handleMessage({ type: 'emulator_action_ack', action: 'boot', avd: 'Pixel_5_API_33', serial: null, requestId: 'r1', status: 'starting' }, ctx() as never)
+    const s = store.getState()
+    expect(s.emulatorActioningIds.has('Pixel_5_API_33')).toBe(false)
+    expect(s.emulatorActioningIds.has('emulator-5554')).toBe(true) // other target untouched
+    expect(s.emulatorActionResults['Pixel_5_API_33']!.error).toBeNull()
+    expect(s.emulatorActionResults['Pixel_5_API_33']!.note).toMatch(/Starting/)
+  })
+
+  it('a kill ack clears the serial target and records a Killed note', () => {
+    handleMessage({ type: 'emulator_action_ack', action: 'kill', avd: null, serial: 'emulator-5554', status: 'killed' }, ctx() as never)
+    expect(store.getState().emulatorActionResults['emulator-5554']!.note).toMatch(/Killed/)
+  })
+
+  it('drops a malformed ack (missing target) without touching pending state', () => {
+    handleMessage({ type: 'emulator_action_ack', action: 'boot' }, ctx() as never)
+    expect(store.getState().emulatorActioningIds.has('Pixel_5_API_33')).toBe(true)
+  })
+
+  it('EMULATOR_ACTION_FAILED (boot) clears the echoed avd and records the error', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'EMULATOR_ACTION_FAILED', message: 'emulator ENOENT', reason: 'boot-failed', action: 'boot', avd: 'Pixel_5_API_33', requestId: 'r1' }, ctx() as never)
+    const s = store.getState()
+    expect(s.emulatorActioningIds.has('Pixel_5_API_33')).toBe(false)
+    expect(s.emulatorActioningIds.has('emulator-5554')).toBe(true)
+    expect(s.emulatorActionResults['Pixel_5_API_33']!.error).toMatch(/ENOENT/)
+    expect(s.emulatorActionResults['Pixel_5_API_33']!.note).toBeNull()
+  })
+
+  it('EMULATOR_ACTION_FAILED (kill) clears the echoed serial', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'EMULATOR_ACTION_FAILED', message: 'device not found', reason: 'kill-failed', action: 'kill', serial: 'emulator-5554' }, ctx() as never)
+    expect(store.getState().emulatorActioningIds.has('emulator-5554')).toBe(false)
+    expect(store.getState().emulatorActionResults['emulator-5554']!.error).toMatch(/device not found/)
+  })
+
+  it('a FAILED without a target leaves action state alone', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'EMULATOR_ACTION_FAILED', message: 'boom' }, ctx() as never)
+    expect(store.getState().emulatorActioningIds.has('Pixel_5_API_33')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/dispatch-emulator-status.test.ts
+++ b/packages/dashboard/src/store/dispatch-emulator-status.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration test for the Android emulator survey wiring (#6137, epic #5530).
+ * Guards: snapshot REPLACES emulatorStatus + clears loading; malformed dropped
+ * without clearing loading; available:false (no SDK) is a valid state.
+ * Mirrors dispatch-simulator-status.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerEmulatorStatusSnapshotMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return { connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {}, emulatorStatus: null, emulatorStatusLoading: true, messages: [] }
+}
+function snapshot(over: Partial<ServerEmulatorStatusSnapshotMessage> = {}): ServerEmulatorStatusSnapshotMessage {
+  return {
+    type: 'emulator_status_snapshot',
+    generatedAt: '2026-06-20T12:00:00.000Z',
+    available: true,
+    note: null,
+    devices: [{ avd: 'Pixel_7_API_34', serial: 'emulator-5554', state: 'running' }],
+    readyForMaestro: { ready: true, runningDevice: 'Pixel_7_API_34', metroReachable: true, mockServerReachable: true, reasons: [] },
+    ...over,
+  } as ServerEmulatorStatusSnapshotMessage
+}
+
+describe('emulator status dispatch (#6137)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('applies emulator_status_snapshot and clears loading', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.emulatorStatus!.devices.map((d) => d.serial)).toEqual(['emulator-5554'])
+    expect(s.emulatorStatus!.readyForMaestro.ready).toBe(true)
+    expect(s.emulatorStatusLoading).toBe(false)
+  })
+
+  it('relays an available:false (no SDK) snapshot as a valid state', () => {
+    handleMessage(snapshot({ available: false, note: 'no Android SDK', devices: [], readyForMaestro: { ready: false, runningDevice: null, metroReachable: false, mockServerReachable: false, reasons: [] } }), ctx() as never)
+    const s = store.getState()
+    expect(s.emulatorStatus!.available).toBe(false)
+    expect(s.emulatorStatusLoading).toBe(false)
+  })
+
+  it('drops a malformed snapshot without clearing loading', () => {
+    handleMessage({ type: 'emulator_status_snapshot', generatedAt: '2026-06-20T12:00:00.000Z' }, ctx() as never)
+    expect(store.getState().emulatorStatus).toBeNull()
+    expect(store.getState().emulatorStatusLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2635,6 +2635,18 @@ function handleSimulatorStatusSnapshot(msg: Record<string, unknown>, _get: MsgGe
 }
 
 /**
+ * #6137 (epic #5530) — Android emulator survey `emulator_status_snapshot`:
+ * REPLACE the stored snapshot and clear the loading flag. Same defensive,
+ * full-replace, clear-loading-only-on-valid-parse contract as the iOS sibling.
+ * `available:false` (no Android SDK) is a valid snapshot, not an error.
+ */
+function handleEmulatorStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerEmulatorStatusSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ emulatorStatus: parsed.data, emulatorStatusLoading: false });
+}
+
+/**
  * #5499 (epic #5498) — Integrations survey `integration_status_snapshot`:
  * REPLACE the stored survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host and
@@ -2905,6 +2917,42 @@ function handleSimulatorActionAck(msg: Record<string, unknown>, get: MsgGet, set
 }
 
 /**
+ * #6137 (epic #5530) — resolve one emulator action target's pending state: drop
+ * the target (avd or serial) from `emulatorActioningIds` and record the outcome
+ * in `emulatorActionResults`. Shared by the ack and the EMULATOR_ACTION_FAILED
+ * session_error.
+ */
+function resolveEmulatorAction(
+  get: MsgGet,
+  set: MsgSet,
+  targetId: string,
+  result: { action: string; note: string | null; error: string | null },
+): void {
+  const pending = new Set(get().emulatorActioningIds);
+  pending.delete(targetId);
+  set({
+    emulatorActioningIds: pending,
+    emulatorActionResults: { ...get().emulatorActionResults, [targetId]: { ...result, at: Date.now() } },
+  });
+}
+
+/**
+ * #6137 — emulator action success ack: builds a human note ("Starting…" after a
+ * boot, "Killed" after a kill) and clears the target's pending state. The target
+ * id is the echoed avd (boot) or serial (kill). A malformed ack is dropped (Zod)
+ * so the row keeps its honest pending state.
+ */
+function handleEmulatorActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerEmulatorActionAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const { action, avd, serial, status } = parsed.data;
+  const targetId = action === 'boot' ? avd : serial;
+  if (!targetId) return;
+  const note = action === 'boot' ? `Starting${status ? `… (${status})` : '…'}` : `Killed${status ? ` (${status})` : ''}`;
+  resolveEmulatorAction(get, set, targetId, { action, note, error: null });
+}
+
+/**
  * #5547: a `summarize_session_result` resolves the pending summarize promise
  * (keyed by the echoed requestId) so the awaiting create-session flow opens
  * with the brief seeded. The failure half (SUMMARIZE_FAILED) rejects the same
@@ -3025,6 +3073,8 @@ const HANDLERS: Record<string, Handler> = {
   host_prune_status_snapshot: handleHostPruneStatusSnapshot,
   // #6136 (epic #5530): Control Room iOS simulator survey snapshot.
   simulator_status_snapshot: handleSimulatorStatusSnapshot,
+  // #6137 (epic #5530): Control Room Android emulator survey snapshot.
+  emulator_status_snapshot: handleEmulatorStatusSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
   skills_inventory_snapshot: handleSkillsInventorySnapshot,
@@ -3042,6 +3092,9 @@ const HANDLERS: Record<string, Handler> = {
   // #6136 (epic #5530): positive ack correlating a simulator_action (boot /
   // shutdown) request to its outcome.
   simulator_action_ack: handleSimulatorActionAck,
+  // #6137 (epic #5530): positive ack correlating an emulator_action (boot /
+  // kill) request to its outcome.
+  emulator_action_ack: handleEmulatorActionAck,
   // #5547: one-shot session-summary result; resolves the pending summarize
   // promise so the create-session flow can open with the brief seeded.
   summarize_session_result: handleSummarizeSessionResult,
@@ -3789,6 +3842,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           note: null,
           error: parsed.message || 'Simulator action failed.',
         });
+      } else if (parsed.code === 'EMULATOR_ACTION_FAILED' && (typeof msg.avd === 'string' || typeof msg.serial === 'string')) {
+        // #6137: a failed emulator_action echoes the target (avd for boot,
+        // serial for kill) — clear that target's pending state and surface the
+        // reason inline (the generic branch below still raises the toast).
+        const action = typeof msg.action === 'string' ? msg.action : '';
+        const targetId = action === 'boot'
+          ? (typeof msg.avd === 'string' ? msg.avd : '')
+          : (typeof msg.serial === 'string' ? msg.serial : '');
+        if (targetId) {
+          resolveEmulatorAction(get, set, targetId, {
+            action,
+            note: null,
+            error: parsed.message || 'Emulator action failed.',
+          });
+        }
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {
         const crashedId = parsed.sessionPatch.sessionId;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -612,6 +612,20 @@ export interface SimulatorActionResult {
   at: number;
 }
 
+/**
+ * #6137 (epic #5530) — outcome of the last Android emulator action (boot /
+ * kill), kept for inline display. The target id is the avd (boot) or serial
+ * (kill). A successful `emulator_action_ack` records a human `note` with
+ * `error: null`; an EMULATOR_ACTION_FAILED session_error records the message
+ * with `note: null`. `at` is the local receipt time (epoch ms).
+ */
+export interface EmulatorActionResult {
+  action: string;
+  note: string | null;
+  error: string | null;
+  at: number;
+}
+
 export interface ConnectionState {
   // Connection
   connectionPhase: ConnectionPhase;
@@ -939,6 +953,31 @@ export interface ConnectionState {
    * in the device row. Replaced when the same device is actioned again.
    */
   simulatorActionResults: Record<string, SimulatorActionResult>;
+  /**
+   * #6137 (epic #5530) — Control Room Android emulator survey: the latest
+   * `emulator_status_snapshot` (devices + "Ready for Maestro" verdict), or null
+   * before the first one lands. `available:false` (no Android SDK) is a valid
+   * state. Replaced wholesale on each snapshot.
+   */
+  emulatorStatus: ServerEmulatorStatusSnapshotMessage | null;
+  /**
+   * #6137 — true between dispatching an `emulator_status_request` and the
+   * matching snapshot arriving (Refresh spinner). Cleared when a VALID snapshot
+   * lands (a malformed payload is dropped and leaves this true).
+   */
+  emulatorStatusLoading: boolean;
+  /**
+   * #6137 — emulator action targets (avd for boot / serial for kill) with an
+   * in-flight `emulator_action`: set when sendEmulatorAction is called, cleared
+   * on the `emulator_action_ack` / EMULATOR_ACTION_FAILED session_error. Keyed
+   * by target so each device row's buttons disable independently.
+   */
+  emulatorActioningIds: Set<string>;
+  /**
+   * #6137 — last emulator action outcome per target id, for inline display.
+   * Replaced when the same target is actioned again.
+   */
+  emulatorActionResults: Record<string, EmulatorActionResult>;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;
@@ -1525,6 +1564,13 @@ export interface ConnectionState {
   // `simulatorStatusLoading` while in flight.
   requestSimulatorStatus: () => boolean;
 
+  // #6137 (epic #5530): request an Android emulator survey. Dispatches an
+  // `emulator_status_request`; the server replies with a single
+  // `emulator_status_snapshot` handled into `emulatorStatus`. Returns whether
+  // the message went on the wire (false = socket closed). Sets
+  // `emulatorStatusLoading` while in flight.
+  requestEmulatorStatus: () => boolean;
+
   // #6139 (epic #5530): request a per-repo runtime config survey. Dispatches a
   // `repo_runtime_config_request`; the server replies with a single
   // `repo_runtime_config_snapshot` handled into `repoRuntimeConfig`. Returns
@@ -1616,6 +1662,18 @@ export interface ConnectionState {
   // message actually went on the wire; an offline send (or an empty udid)
   // returns false without queuing. Non-destructive, so no confirm gate.
   sendSimulatorAction: (action: 'boot' | 'shutdown', udid: string) => boolean;
+
+  // #6137 (epic #5530): boot an AVD / kill a running Android emulator. boot
+  // targets an `avd` (the survey enumerated, currently stopped) with an optional
+  // `headless` (`-no-window`); kill targets a running `serial`. The server
+  // re-surveys + re-validates the target (lookup key, never a trusted path) and
+  // state-gates the action. Dispatches an `emulator_action` tagged with a
+  // requestId the server echoes on the `emulator_action_ack` /
+  // EMULATOR_ACTION_FAILED session_error. Marks the target (avd or serial) in
+  // `emulatorActioningIds` (dropping its stale result) ONLY when the message
+  // actually went on the wire; an offline send (or a missing target) returns
+  // false without queuing. Non-destructive, so no confirm gate.
+  sendEmulatorAction: (action: 'boot' | 'kill', opts: { avd?: string; serial?: string; headless?: boolean }) => boolean;
 
   // #5547: request a server-side one-shot summary of a session's persisted
   // history (the sidebar "Summarize & start new session" action). Dispatches a

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -75,8 +75,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'activity_snapshot' / 'activity_delta' removed — the dashboard now handles
   // them (Control Room panel #5163); they moved to PLATFORM_SPECIFIC as
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5159.
-  'emulator_status_snapshot', // #6137 (epic #5530) — Control Room Android emulator survey reply. Server contract landed first; the dashboard slice that consumes it (the Device runtimes Android panel) moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
-  'emulator_action_ack', // #6137 (epic #5530) — Control Room Android emulator boot/kill action ack. Server contract landed first (same server-first split as the survey above); the dashboard slice that consumes it moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only.
   // 'host_status_snapshot' removed — the dashboard now handles it (Control
   // Room Host/Repo Status section #5175); it moved to PLATFORM_SPECIFIC as
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
@@ -163,6 +161,8 @@ const PLATFORM_SPECIFIC = {
   'host_prune_action_ack': 'dashboard', // Control Room host prune action ack (#6140, epic #5530) — the dashboard consumes it to clear pending kind state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'simulator_status_snapshot': 'dashboard', // Control Room iOS simulator survey reply (#6136, epic #5530) — the Device runtimes tab consumes it (devices + Ready-for-Maestro verdict); host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'simulator_action_ack': 'dashboard', // Control Room iOS simulator boot/shutdown action ack (#6136, epic #5530) — the dashboard consumes it to clear pending device state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'emulator_status_snapshot': 'dashboard', // Control Room Android emulator survey reply (#6137, epic #5530) — the Device runtimes Android panel consumes it (devices + Ready-for-Maestro verdict); host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
+  'emulator_action_ack': 'dashboard', // Control Room Android emulator boot/kill action ack (#6137, epic #5530) — the dashboard consumes it to clear pending device state; host-level surface, dashboard-only; mobile parity would be a fast-follow
   'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'mailbox_status_snapshot': 'dashboard', // Control Room "Mailbox" tab survey reply (#5914 follow-up) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -150,6 +150,8 @@ const DASHBOARD_ONLY = new Set<string>([
   'host_prune_action_ack',      // Control Room host prune action ack (#6140, epic #5530) — dashboard-only
   'simulator_status_snapshot',  // Control Room iOS simulator survey (#6136, epic #5530) — dashboard-only (Device runtimes tab)
   'simulator_action_ack',       // Control Room iOS simulator boot/shutdown action ack (#6136, epic #5530) — dashboard-only
+  'emulator_status_snapshot',   // Control Room Android emulator survey (#6137, epic #5530) — dashboard-only (Device runtimes Android panel)
+  'emulator_action_ack',        // Control Room Android emulator boot/kill action ack (#6137, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -198,14 +200,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'emulator_status_snapshot',             // #6137 (epic #5530) Control Room Android emulator survey —
-                                          //   server contract landed first; the Device runtimes Android-panel
-                                          //   dashboard slice that consumes it is the tracked follow-up, then
-                                          //   this → DASHBOARD_ONLY
-  'emulator_action_ack',                  // #6137 (epic #5530) Control Room Android emulator boot/kill action
-                                          //   ack — server contract landed first (same server-first split as
-                                          //   the survey above); the dashboard slice that consumes it is the
-                                          //   tracked follow-up, then this → DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#6137 (epic #5530), **dashboard half** — **completes #6137**. Adds the Android emulator panel alongside iOS in the Device runtimes Control Room tab, consuming the survey + boot/kill actions shipped server-side in #6161.

Closes #6137.

## What changed

- **`DeviceRuntimesSection.tsx`** now renders **two** panels: the existing **iOS simulators** panel (unchanged — all testIDs preserved) + a new **`AndroidEmulatorPanel`**. The Android panel mirrors the iOS one:
  - the **"Ready for Maestro" verdict** (running emulator + Metro :8081 + mock server :9876, with `reasons[]`)
  - a per-device table with **state-aware** actions: **Boot** a stopped AVD, **Kill** a live serial. A `starting` (booting) emulator shows a warn tag + Kill (so you can't boot a duplicate). Per-target pending/feedback; per-target disable (not global).
  - The tab's generic auto-fetch only covers the iOS survey, so the panel **self-fetches the emulator survey once on connect** (and Refresh re-runs it).
- **store wiring** — `emulatorStatus`/`emulatorStatusLoading` + `requestEmulatorStatus`; `emulatorActioningIds`/`emulatorActionResults` (keyed by `avd` for boot / `serial` for kill) + `sendEmulatorAction`; `handleEmulatorStatusSnapshot`/`handleEmulatorActionAck` + `resolveEmulatorAction` + the `EMULATOR_ACTION_FAILED` `session_error` branch; socket-close/disconnect/forget resets. Mirrors the simulator wiring exactly.
- **Coverage guards** — promotes `emulator_status_snapshot` + `emulator_action_ack` out of the unhandled allowlists into dashboard-handled (the server-first split's dashboard half).

## Tests

- `dispatch-emulator-status.test.ts` + `dispatch-emulator-action.test.ts` — the store dispatch path (snapshot replace + loading clear, malformed-drop, boot/kill ack clears the target + records a note, `EMULATOR_ACTION_FAILED` clears the echoed target, other targets untouched).
- `AndroidEmulatorPanel` renderer tests (empty/unavailable, ready & not-ready verdicts, state-aware boot/kill → onAction, starting-state tag, per-target disable, pending→settled, refresh, no-devices).

## Verification

- Full **dashboard** suite: **3970 pass** (220 files); **store-core** src: **1679 pass**
- Both coverage guards green; dashboard + store-core typecheck clean
- Dashboard-only (no protocol/server changes) — no dist rebuild