### PR TITLE
fix(dashboard): reset Control Room survey loading flags on socket close (#6153)

### DIFF
--- a/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
+++ b/packages/dashboard/src/store/connection-reconnect-backoff.test.ts
@@ -351,3 +351,50 @@ describe('onclose clears transient state across all sessions (#5731 T4)', () => 
     expect(st.sessionStates.b!.primaryClientId).toBeNull()
   })
 })
+
+// ---------------------------------------------------------------------------
+// #6153 — onclose resets every Control Room survey *Loading flag. A refresh in
+// flight when the socket drops would otherwise leave loading=true forever, and
+// refreshDisabled = loading || !connected wedges the disabled Refresh button
+// (it can't issue the request that would clear it) until a full remount.
+// ---------------------------------------------------------------------------
+
+describe('onclose resets Control Room survey loading flags (#6153)', () => {
+  it('clears every *StatusLoading that was true; keeps the (stale) snapshots', async () => {
+    const ws = await openConnected()
+
+    useConnectionStore.setState({
+      hostStatusLoading: true,
+      runnerStatusLoading: true,
+      containersStatusLoading: true,
+      repoRuntimeConfigLoading: true,
+      byokPoolStatusLoading: true,
+      hostPruneStatusLoading: true,
+      simulatorStatusLoading: true,
+      emulatorStatusLoading: true,
+      integrationStatusLoading: true,
+      skillsInventoryLoading: true,
+      mailboxStatusLoading: true,
+      // a stale snapshot that must SURVIVE the drop (re-fetched on reconnect)
+      hostPruneStatus: { type: 'host_prune_status_snapshot', generatedAt: '2026-06-20T00:00:00.000Z', dockerAvailable: true, note: null, containers: [], images: [], summary: { containerCount: 0, imageCount: 0, reclaimableBytes: 0 } },
+    } as never)
+
+    ws.onclose?.({ code: 1006 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const st = useConnectionStore.getState()
+    expect(st.hostStatusLoading).toBe(false)
+    expect(st.runnerStatusLoading).toBe(false)
+    expect(st.containersStatusLoading).toBe(false)
+    expect(st.repoRuntimeConfigLoading).toBe(false)
+    expect(st.byokPoolStatusLoading).toBe(false)
+    expect(st.hostPruneStatusLoading).toBe(false)
+    expect(st.simulatorStatusLoading).toBe(false)
+    expect(st.emulatorStatusLoading).toBe(false)
+    expect(st.integrationStatusLoading).toBe(false)
+    expect(st.skillsInventoryLoading).toBe(false)
+    expect(st.mailboxStatusLoading).toBe(false)
+    // The snapshot is intentionally retained (staleness is signalled in the UI).
+    expect(st.hostPruneStatus).not.toBeNull()
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2122,6 +2122,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().emulatorActioningIds.size > 0) {
         set({ emulatorActioningIds: new Set<string>() });
       }
+      // #6153: reset every Control Room survey *Loading flag that's still true on
+      // a socket drop. Each survey section computes refreshDisabled = loading ||
+      // !connected, so a refresh in flight when the socket dies would leave
+      // loading=true forever — the disabled Refresh button can never clear it
+      // post-reconnect (it can't issue the request that would). One DRY sweep
+      // over the survey family avoids per-tab drift. (We intentionally KEEP the
+      // stale snapshots — the "generated Nm ago" line signals staleness, and a
+      // reconnect re-fetches on tab activation; clearing would flash empty.)
+      const surveyLoadingKeys = [
+        'hostStatusLoading', 'runnerStatusLoading', 'containersStatusLoading',
+        'repoRuntimeConfigLoading', 'byokPoolStatusLoading', 'hostPruneStatusLoading',
+        'simulatorStatusLoading', 'emulatorStatusLoading', 'integrationStatusLoading',
+        'skillsInventoryLoading', 'mailboxStatusLoading',
+      ] as const;
+      const loadingReset: Partial<Record<(typeof surveyLoadingKeys)[number], boolean>> = {};
+      for (const key of surveyLoadingKeys) {
+        if (get()[key]) loadingReset[key] = false;
+      }
+      if (Object.keys(loadingReset).length > 0) {
+        set(loadingReset);
+      }
 
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();


### PR DESCRIPTION
## Summary

Fixes #6153 — a pattern-wide latent bug across the Control Room survey family (surfaced during the #6152 review).

Every survey section computes `refreshDisabled = loading || !connected`. If the socket dropped **while a refresh was in flight** (request sent, snapshot not yet received), the `*StatusLoading` flag stayed `true`. After reconnect, the disabled Refresh button could never issue the request that would clear it — the tab wedged until a full remount.

## Fix

The `onclose` handler in `store/connection.ts` already clears the action-pending Sets (`containerActioningIds`, `byokPoolActioningIds`, …). This adds a **DRY sweep** that resets every survey `*Loading` flag back to `false`:

`hostStatusLoading`, `runnerStatusLoading`, `containersStatusLoading`, `repoRuntimeConfigLoading`, `byokPoolStatusLoading`, `hostPruneStatusLoading`, `simulatorStatusLoading`, `emulatorStatusLoading`, `integrationStatusLoading`, `skillsInventoryLoading`, `mailboxStatusLoading`.

**Decision on the optional snapshot-clearing** (the issue left it as a UX call): **keep the stale snapshots.** The "generated Nm ago" line already signals staleness and a reconnect re-fetches on tab activation, so clearing would just flash empty on every reconnect. The fix only resets the loading booleans.

## Tests

Added a store test (in `connection-reconnect-backoff.test.ts`, alongside the existing onclose-reset cases): set every `*StatusLoading: true` + a stale snapshot, fire `onclose`, assert all loading flags reset to `false` and the snapshot survives.

## Verification

- Full **dashboard** suite: **3972 pass**; typecheck clean
- Dashboard-only (no protocol/server) — no dist rebuild