### PR TITLE
fix(server): kill UTC-boundary flake in quiet-hours send tests (#6146)

### DIFF
--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -111,7 +111,12 @@ export class PushManager {
    *   file, kept separate from the status store) and `billingAlerts` (kill-switch,
    *   default on when a webhook resolves).
    */
-  constructor({ storagePath, prefsPath, discord = {} } = {}) {
+  constructor({ storagePath, prefsPath, discord = {}, now } = {}) {
+    // #6146: injectable clock. send()'s rate-limit AND the #4544 quiet-hours
+    // gate evaluate against "now"; tests pin it to a deterministic instant so
+    // the quiet-hours classification can't flip on a CI run near a window
+    // boundary (the flake this seam fixes). Defaults to the real wall clock.
+    this._now = typeof now === 'function' ? now : Date.now
     // #4541: notification-prefs path. Optional — when omitted PushManager
     // operates entirely in-memory (callers like one-off tests don't need
     // to write to disk). When set, getPrefs / setPrefs round-trip
@@ -509,16 +514,17 @@ export class PushManager {
     // gate so a single shared throttle still applies regardless of
     // per-device prefs. See RATE_LIMITS history comments above.
     const limit = RATE_LIMITS[category] ?? 30_000
+    const nowMs = this._now()
     const lastSent = this._lastSent.get(category) || 0
-    if (Date.now() - lastSent < limit) {
+    if (nowMs - lastSent < limit) {
       return true
     }
-    this._lastSent.set(category, Date.now())
+    this._lastSent.set(category, nowMs)
 
     return await this._sinks.fanOut(
       { category, title, body, data, categoryId },
       {
-        now: Date.now(),
+        now: nowMs,
         isCategoryEnabled: (cat, deviceId) => this.isCategoryEnabled(cat, deviceId),
         isInQuietHours: (now, deviceId) => this.isInQuietHours(now, deviceId),
         shouldBypassQuietHours: (cat, deviceId) => this.shouldBypassQuietHours(cat, deviceId),

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -110,13 +110,17 @@ export class PushManager {
    *   #5828: also feeds DiscordBillingSink — `billingStatePath` (its own state
    *   file, kept separate from the status store) and `billingAlerts` (kill-switch,
    *   default on when a webhook resolves).
+   * @param {() => number} [opts.now] - #6146 injectable clock (epoch ms),
+   *   defaults to `Date.now`. send()'s rate-limit AND the #4544 quiet-hours gate
+   *   evaluate against "now"; tests pin it to a deterministic instant so the
+   *   quiet-hours classification can't flip on a CI run near a window boundary.
    */
-  constructor({ storagePath, prefsPath, discord = {}, now } = {}) {
-    // #6146: injectable clock. send()'s rate-limit AND the #4544 quiet-hours
-    // gate evaluate against "now"; tests pin it to a deterministic instant so
-    // the quiet-hours classification can't flip on a CI run near a window
-    // boundary (the flake this seam fixes). Defaults to the real wall clock.
-    this._now = typeof now === 'function' ? now : Date.now
+  constructor({ storagePath, prefsPath, discord = {}, now = Date.now } = {}) {
+    // #6146: injectable clock (default Date.now). Assigned directly — an invalid
+    // value fails fast on use rather than silently reverting, matching the
+    // codebase's clock-seam convention (utils/respawn-rate-limiter.js,
+    // turn-tracker.js).
+    this._now = now
     // #4541: notification-prefs path. Optional — when omitted PushManager
     // operates entirely in-memory (callers like one-off tests don't need
     // to write to disk). When set, getPrefs / setPrefs round-trip

--- a/packages/server/tests/notification-prefs-quiet-hours.test.js
+++ b/packages/server/tests/notification-prefs-quiet-hours.test.js
@@ -805,9 +805,16 @@ describe('isInQuietHoursIn — Intl.DateTimeFormat memoization (#4568)', () => {
 })
 
 describe('PushManager.send — quiet-hours gate (#4544)', () => {
+  // #6146: pin "now" to a deterministic instant well inside the 00:00–23:59
+  // window so the quiet-hours classification can't flip when CI runs in the
+  // final 23:59:00–23:59:59 minute (which falls outside an end-exclusive
+  // window). Noon UTC on a fixed date is unambiguously inside.
+  const FIXED_NOW = Date.UTC(2026, 0, 15, 12, 0, 0)
+  const fixedNow = () => FIXED_NOW
+
   it('skips Expo POST when ALL tokens are in quiet hours and category does not bypass', async () => {
     const { PushManager } = await import('../src/push.js')
-    const pm = new PushManager({ prefsPath })
+    const pm = new PushManager({ prefsPath, now: fixedNow })
     pm.registerToken('ExponentPushToken[tok-a]')
     pm.registerToken('ExponentPushToken[tok-b]')
     // Set a global window that covers "now" — set start/end such that
@@ -861,7 +868,7 @@ describe('PushManager.send — quiet-hours gate (#4544)', () => {
 
   it('sends only to tokens NOT in quiet hours when per-device overrides differ', async () => {
     const { PushManager } = await import('../src/push.js')
-    const pm = new PushManager({ prefsPath })
+    const pm = new PushManager({ prefsPath, now: fixedNow })
     pm.registerToken('ExponentPushToken[tok-asleep]')
     pm.registerToken('ExponentPushToken[tok-awake]')
     // Global: always-on quiet hours.


### PR DESCRIPTION
## Summary

Fixes #6146 — `notification-prefs-quiet-hours.test.js` intermittently failed two `PushManager.send` subtests in CI (observed 2026-06-20T00:01 UTC; passed locally otherwise), a time-dependent flake.

## Cause

The two tests set a `00:00`–`23:59` quiet-hours window to "cover now". But the window is **end-exclusive**, so the final minute `23:59:00`–`23:59:59` falls **outside** it. When CI ran in that minute, "now" classified as out-of-window and the expectation (all tokens muted) flipped.

## Fix

Add an injectable clock seam to `PushManager` — a constructor `now` option used for **both** the rate-limit check and the quiet-hours `now` in `send()` — defaulting to the real wall clock (`Date.now`). The two affected tests pin it to **noon UTC on a fixed date** (unambiguously inside the window), so the classification is deterministic regardless of when/where CI runs.

This mirrors the codebase's existing clock-seam convention (`isInQuietHours(now = Date.now(), …)` already takes a `now`; this threads a controllable one through `send()`).

## Verification

- `notification-prefs-quiet-hours.test.js`: **62/62 pass**
- Full push/notification suite: **281 pass**, 0 fail
- Server-only; no protocol/dist changes
