### PR TITLE
feat(dashboard): degraded-survey error banner parity — host + runners (#6144)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -175,6 +175,18 @@ describe('ControlRoomSection (#5175)', () => {
     expect(screen.getByTestId('cr-callout')).toHaveTextContent('How to read the verdict')
   })
 
+  // #6144: a degraded survey (forbidden / failed / in-progress) carries an
+  // additive `error` annotation — render it as an alert banner, not as an
+  // empty survey.
+  it('renders a degraded-survey error banner (role=alert)', () => {
+    const snap = makeSnapshot({ repos: [], summary: { live: 0, onboarded: 0, abandoned: 0, investigate: 0, recent: 0 }, error: { code: 'SURVEY_FAILED', message: 'git ls-remote timed out' } })
+    render(<ControlRoomSection snapshot={snap} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    const banner = screen.getByTestId('cr-error')
+    expect(banner.getAttribute('role')).toBe('alert')
+    expect(banner.textContent).toContain('SURVEY_FAILED')
+    expect(banner.textContent).toContain('git ls-remote timed out')
+  })
+
   it('renders one row per repo with a colour-coded verdict tag', () => {
     render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
     expect(screen.getByTestId('cr-row-chroxy')).toBeTruthy()

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -1001,6 +1001,11 @@ export function ControlRoomSection({
             {loading ? 'Refreshing…' : 'Refresh'}
           </button>
         </div>
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="cr-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
         {snapshot && (
           <p className="cr-sub" data-testid="cr-sub">
             All {snapshot.repos.length} managed repo{snapshot.repos.length === 1 ? '' : 's'} under{' '}

--- a/packages/dashboard/src/components/RunnerStatusSection.test.tsx
+++ b/packages/dashboard/src/components/RunnerStatusSection.test.tsx
@@ -188,6 +188,18 @@ describe('RunnerStatusSection — populated', () => {
     render(<RunnerStatusSection snapshot={snapshot({ repos: [], summary: { total: 0, busy: 0, idle: 0, offline: 0, stopped: 0, unregistered: 0 } })} loading={false} connected={true} onRefresh={() => {}} />)
     expect(screen.getByTestId('runner-no-repos')).toBeTruthy()
   })
+
+  // #6144: a degraded survey (forbidden / failed / in-progress) carries an
+  // additive `error` annotation — render it as an alert banner, not as an
+  // empty survey.
+  it('renders a degraded-survey error banner (role=alert)', () => {
+    const snap = snapshot({ repos: [], summary: { total: 0, busy: 0, idle: 0, offline: 0, stopped: 0, unregistered: 0 }, error: { code: 'FORBIDDEN', message: 'host-level authority required' } })
+    render(<RunnerStatusSection snapshot={snap} loading={false} connected={true} onRefresh={() => {}} />)
+    const banner = screen.getByTestId('runner-error')
+    expect(banner.getAttribute('role')).toBe('alert')
+    expect(banner.textContent).toContain('FORBIDDEN')
+    expect(banner.textContent).toContain('host-level authority required')
+  })
 })
 
 describe('RunnerStatusSection — refresh', () => {

--- a/packages/dashboard/src/components/RunnerStatusSection.tsx
+++ b/packages/dashboard/src/components/RunnerStatusSection.tsx
@@ -225,6 +225,11 @@ export function RunnerStatusSection({
             {loading ? 'Refreshing…' : 'Refresh'}
           </button>
         </div>
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="runner-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
         {snapshot && (
           <p className="cr-sub" data-testid="runner-sub">
             {runnerCount} runner{runnerCount === 1 ? '' : 's'} across {snapshot.repos.length} project

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -899,6 +899,10 @@ export declare const ServerHostStatusSnapshotSchema: z.ZodObject<{
         lastTouched: z.ZodString;
         note: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>;
+    error: z.ZodOptional<z.ZodObject<{
+        code: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
 }, z.core.$strip>;
 /** One live agentCommId → session registration row. */
 export declare const MailboxRegistrationSchema: z.ZodObject<{

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -1036,6 +1036,17 @@ export const ServerHostStatusSnapshotSchema = z.object({
     root: z.string(),
     summary: HostStatusSummarySchema,
     repos: z.array(RepoStatusSchema),
+    // #6144: additive degraded-snapshot annotation — on a forbidden/in-progress/
+    // failed survey the handler returns an otherwise-valid (empty repos, zeroed
+    // summary) snapshot plus this `error`, so the Control Room section can surface
+    // the failure typed rather than mistaking it for an empty survey. Mirrors the
+    // runner/containers/integrations snapshots.
+    error: z
+        .object({
+        code: z.string(),
+        message: z.string(),
+    })
+        .optional(),
 });
 // ---------------------------------------------------------------------------
 // Mailbox (#5914 follow-up) — Control Room "Mailbox" tab snapshot.

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -1106,6 +1106,17 @@ export const ServerHostStatusSnapshotSchema = z.object({
   root: z.string(),
   summary: HostStatusSummarySchema,
   repos: z.array(RepoStatusSchema),
+  // #6144: additive degraded-snapshot annotation — on a forbidden/in-progress/
+  // failed survey the handler returns an otherwise-valid (empty repos, zeroed
+  // summary) snapshot plus this `error`, so the Control Room section can surface
+  // the failure typed rather than mistaking it for an empty survey. Mirrors the
+  // runner/containers/integrations snapshots.
+  error: z
+    .object({
+      code: z.string(),
+      message: z.string(),
+    })
+    .optional(),
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #6144. Retrofits the degraded-survey `error` banner into the two Control Room sections that still ignored it, for parity with the rest.

The Containers / Integrations / Skills / Mailbox / BYOK-pool / host-prune / device-runtime sections already render the snapshot's additive `error` ({code, message}) as an `role="alert"` callout — so a FORBIDDEN / SURVEY_FAILED / SURVEY_IN_PROGRESS reply isn't mistaken for a legitimate empty survey. The stragglers were **Project status** (`ControlRoomSection`/host) and **Self-hosted runners** (`RunnerStatusSection`).

## What changed

- **`RunnerStatusSection.tsx`** + **`ControlRoomSection.tsx`** — render `snapshot.error` (when present) as the same `cr-callout cr-callout-bad` `role="alert"` banner the Containers tab uses (`runner-error` / `cr-error` testIDs), placed in the header above the sub/summary.
- **protocol** — the `runner_status_snapshot` schema already declared the optional `error`; the `host_status_snapshot` schema did **not** — added it (the server already emits it via `buildSurveyErrorSnapshot` + the schema's runtime passthrough; this makes the dashboard consume it type-safely). Dist rebuilt.

## Tests

- A degraded-survey banner test (asserting `role="alert"` + the error code/message) added to both `RunnerStatusSection.test.tsx` and `ControlRoomSection.test.tsx`.

## Verification

- Full **dashboard** suite: **3974 pass**; **store-core** src: **1679 pass**; **protocol**: **340 pass**
- Both coverage guards green; dashboard + store-core typecheck clean
