### PR TITLE
fix(dashboard): normalize degraded-survey error banner a11y (#6167)

### DIFF
--- a/packages/dashboard/src/components/IntegrationsSection.test.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.test.tsx
@@ -276,7 +276,10 @@ describe('IntegrationsSection — populated', () => {
       summary: { total: 0, configured: 0, notConfigured: 0, degraded: 0 },
       error: { code: 'SURVEY_FAILED', message: 'stat exploded' },
     }))
-    expect(screen.getByTestId('integration-error').textContent).toContain('stat exploded')
+    const banner = screen.getByTestId('integration-error')
+    expect(banner.getAttribute('role')).toBe('alert') // #6167 a11y parity
+    expect(banner.textContent).toContain('SURVEY_FAILED')
+    expect(banner.textContent).toContain('stat exploded')
   })
 
   it('renders the no-repos row when the survey found nothing', () => {

--- a/packages/dashboard/src/components/IntegrationsSection.tsx
+++ b/packages/dashboard/src/components/IntegrationsSection.tsx
@@ -662,9 +662,9 @@ export function IntegrationsSection({
           </div>
 
           {snapshot.error && (
-            <div className="cr-callout" data-testid="integration-error">
-              <b>Survey degraded:</b> {snapshot.error.message} <span className="cr-dim cr-mono">({snapshot.error.code})</span>
-            </div>
+            <p className="cr-callout cr-callout-bad" data-testid="integration-error" role="alert">
+              <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+            </p>
           )}
 
           {snapshot.repoMemoryCli && !snapshot.repoMemoryCli.found && (

--- a/packages/dashboard/src/components/MailboxPanel.test.tsx
+++ b/packages/dashboard/src/components/MailboxPanel.test.tsx
@@ -109,7 +109,10 @@ describe('MailboxPanel', () => {
         now={NOW}
       />,
     )
-    expect(screen.getByTestId('mailbox-error').textContent).toContain('host-level authority')
+    const banner = screen.getByTestId('mailbox-error')
+    expect(banner.getAttribute('role')).toBe('alert') // #6167 a11y parity
+    expect(banner.textContent).toContain('FORBIDDEN')
+    expect(banner.textContent).toContain('host-level authority')
   })
 
   it('dispatches Refresh and disables it while loading', () => {

--- a/packages/dashboard/src/components/MailboxPanel.tsx
+++ b/packages/dashboard/src/components/MailboxPanel.tsx
@@ -170,7 +170,9 @@ export function MailboxPanel({
           </p>
         )}
         {snapshot && snapshot.error && (
-          <p className="cr-bad" data-testid="mailbox-error">{snapshot.error.message}</p>
+          <p className="cr-callout cr-callout-bad" data-testid="mailbox-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
         )}
         {snapshot && !Number.isNaN(generatedAtMs) && (
           <p className="cr-generated" data-testid="mailbox-generated">

--- a/packages/dashboard/src/components/SkillsInventorySection.test.tsx
+++ b/packages/dashboard/src/components/SkillsInventorySection.test.tsx
@@ -183,8 +183,10 @@ describe('SkillsInventorySection — degradation', () => {
   it('renders the top-level degraded-survey callout', () => {
     const snap = snapshot({ global: [], repos: [], error: { code: 'FORBIDDEN', message: 'no authority' } })
     render(<SkillsInventorySection {...baseProps} snapshot={snap} />)
-    expect(screen.getByTestId('skills-error').textContent).toContain('no authority')
-    expect(screen.getByTestId('skills-error').textContent).toContain('FORBIDDEN')
+    const banner = screen.getByTestId('skills-error')
+    expect(banner.getAttribute('role')).toBe('alert') // #6167 a11y parity
+    expect(banner.textContent).toContain('no authority')
+    expect(banner.textContent).toContain('FORBIDDEN')
   })
 })
 

--- a/packages/dashboard/src/components/SkillsInventorySection.tsx
+++ b/packages/dashboard/src/components/SkillsInventorySection.tsx
@@ -317,9 +317,9 @@ export function SkillsInventorySection({
           </div>
 
           {snapshot.error && (
-            <div className="cr-callout" data-testid="skills-error">
-              <b>Survey degraded:</b> {snapshot.error.message} <span className="cr-dim cr-mono">({snapshot.error.code})</span>
-            </div>
+            <p className="cr-callout cr-callout-bad" data-testid="skills-error" role="alert">
+              <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+            </p>
           )}
 
           <SkillCard


### PR DESCRIPTION
## Summary

Fixes #6167 (follow-up to #6144). Normalizes the three Control Room sections that rendered the degraded-survey `error` with a **divergent** treatment onto the canonical banner the other 8 sections use.

The material gap was **accessibility**: Integrations, Skills, and Mailbox lacked `role="alert"`, so a screen reader never announced the degraded-survey banner — defeating the point of distinguishing it from an empty survey. They also used a plain `cr-callout`/`cr-bad` (not `cr-callout-bad`), divergent wording ("Survey degraded:"), and Mailbox omitted the error code entirely.

## What changed

All three now render the canonical banner:
```tsx
<p className="cr-callout cr-callout-bad" data-testid="<x>-error" role="alert">
  <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
</p>
```
- `IntegrationsSection.tsx` (`integration-error`)
- `SkillsInventorySection.tsx` (`skills-error`)
- `MailboxPanel.tsx` (`mailbox-error` — now also shows the code)

Existing `data-testid`s preserved. Dashboard-only — no schema change (these snapshots already carry `error`).

## Tests

Extended each section's existing banner test to assert `role="alert"` + the error code.

## Verification

- Full **dashboard** suite: **3974 pass**; typecheck clean
