### PR TITLE
fix(dashboard): give cr-callout-bad / cr-callout-ok real CSS (#6169)

### DIFF
--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9612,6 +9612,36 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-blue);
 }
 
+/*
+ * #6169 — accent variants for the Control Room callout. `.cr-callout-bad` is the
+ * degraded-survey banner used by all 11 survey sections (it was referenced but
+ * had no rule, so every banner fell back to the neutral blue `.cr-callout`);
+ * `.cr-callout-ok` is the Device-runtimes "Ready for Maestro" verdict. Both are
+ * defined after `.cr-callout` so their longhand border/colour overrides win at
+ * equal specificity. Tokens mirror the existing danger/success usage.
+ */
+.cr-callout-bad {
+  background: var(--danger-bg, rgba(220, 38, 38, 0.12));
+  border-color: var(--danger, #dc2626);
+  border-left-color: var(--danger, #dc2626);
+  color: var(--danger-fg, #f87171);
+}
+
+.cr-callout-bad b {
+  color: var(--danger-fg, #f87171);
+}
+
+.cr-callout-ok {
+  background: var(--success-bg, rgba(52, 208, 88, 0.12));
+  border-color: var(--success, #34d058);
+  border-left-color: var(--success, #34d058);
+  color: var(--success, #34d058);
+}
+
+.cr-callout-ok b {
+  color: var(--success, #34d058);
+}
+
 /* #5216 — repo-table view controls (filter chips + sort + visible count) */
 .cr-controls {
   display: flex;


### PR DESCRIPTION
## Summary

Fixes #6169. `.cr-callout-bad` is referenced by all 11 Control Room degraded-survey banners but had **no CSS rule** — so every error banner fell back to the neutral **blue** `.cr-callout` styling, visually indistinguishable from an info note (a survey *failure* looked like a note). `.cr-callout-ok` (the Device-runtimes "Ready for Maestro" verdict) was likewise undefined.

## Fix

Add both accent variants to `theme/components.css` immediately after `.cr-callout` (so their longhand `border-color`/`border-left-color`/`color` overrides win at equal specificity over the shorthand blue `.cr-callout`):
- `.cr-callout-bad` → danger palette (red) via `var(--danger*, …)` with the same fallbacks the theme already uses elsewhere.
- `.cr-callout-ok` → success palette (green) via `var(--success*, …)`.

The `role="alert"` a11y announcement (from #6167/#6144) was already correct; this is the matching **visual** treatment that finishes the degraded-banner work.

## Verification

- `npm run build -w packages/dashboard` succeeds (CSS valid).
- CSS-only; the banner class is already asserted by the component tests (jsdom doesn't compute styles, so there's no unit test for rendered colour).
