### PR TITLE
fix(server): thread _now clock seam through sendLiveActivityUpdate (#6165)

### DIFF
--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -548,14 +548,17 @@ export class PushManager {
   async sendLiveActivityUpdate(state, detail) {
     if (!this._expoSink.hasLiveActivityTokens) return
 
-    // Rate limit check (live_activity category: 5s)
+    // Rate limit check (live_activity category: 5s). #6165: use the injected
+    // clock seam (same as send()) — both share `_lastSent`, so reading the wall
+    // clock here while send() honoured `_now` would mix clocks through the map.
     const category = 'live_activity'
     const limit = RATE_LIMITS[category]
+    const nowMs = this._now()
     const lastSent = this._lastSent.get(category) || 0
-    if (Date.now() - lastSent < limit) {
+    if (nowMs - lastSent < limit) {
       return
     }
-    this._lastSent.set(category, Date.now())
+    this._lastSent.set(category, nowMs)
 
     await this._expoSink.sendLiveActivityUpdate(state, detail)
   }

--- a/packages/server/tests/push-live-activity.test.js
+++ b/packages/server/tests/push-live-activity.test.js
@@ -181,6 +181,25 @@ describe('PushManager Live Activity tokens (#2172)', () => {
       await manager.sendLiveActivityUpdate('writing', 'Step 2')
       assert.equal(fetchMock.mock.calls.length, 2)
     })
+
+    // #6165: the rate-limit honours the injected `_now` clock seam (not the wall
+    // clock), consistent with send(). Advancing only the injected clock past the
+    // 5s window must unblock the next update.
+    it('rate-limit reads the injected _now clock seam', async () => {
+      let nowMs = 1_000_000
+      const pm = new PushManager({ now: () => nowMs })
+      pm.registerLiveActivityToken(LA_TOKEN_1)
+      const fetchMock = mockFetchOk()
+      globalThis.fetch = fetchMock
+
+      await pm.sendLiveActivityUpdate('thinking', 'Step 1')
+      await pm.sendLiveActivityUpdate('thinking', 'Step 2') // same frozen instant — blocked
+      assert.equal(fetchMock.mock.calls.length, 1)
+
+      nowMs += 6_000 // advance only the injected clock past the 5s window
+      await pm.sendLiveActivityUpdate('writing', 'Step 3')
+      assert.equal(fetchMock.mock.calls.length, 2)
+    })
   })
 
   // -- backward compatibility --


### PR DESCRIPTION
## Summary

Fixes #6165 (follow-up to #6164). `sendLiveActivityUpdate()`'s rate-limit block still read raw `Date.now()`, while `send()` honours the injected `this._now` clock seam. Since both share the `_lastSent` map, a test (or future code) that pins `send()`'s clock while live-activity reads the wall clock could see mixed-clock interaction through the shared map.

## Fix

Replace the two `Date.now()` calls in `sendLiveActivityUpdate()` with a single `const nowMs = this._now()`, reused for the rate-limit check and stamp — mirroring `send()`. No raw `Date.now()` remains in either rate-limit path.

## Tests

Added a rate-limit test that advances **only** the injected clock past the 5s window and asserts the next update unblocks — proving the seam is honoured (not the wall clock).

## Verification

- `push-live-activity` + `notification-prefs-quiet-hours` suites: **84 pass**
- Server-only; no protocol/dist changes
