### PR TITLE
feat(server): stamp com.chroxy.managed docker label + label-first prune scoping (#6155)

### DIFF
--- a/packages/server/src/control-room/host-prune.js
+++ b/packages/server/src/control-room/host-prune.js
@@ -4,10 +4,12 @@
  * Surfaces reclaimable HOST docker pressure scoped STRICTLY to chroxy's OWN
  * resources, so the Control Room can prune dangling chroxy artifacts (the
  * container analog of `chroxy worktree gc`) without ever touching a non-chroxy
- * workload. chroxy stamps no docker labels — it identifies its resources by
- * naming convention:
- *   - containers: name prefix `chroxy-env-` (docker-backend `--name chroxy-env-<id>`)
- *   - images:     repositories `chroxy-env` (env snapshots `chroxy-env:<id>-<ts>`)
+ * workload. #6155: chroxy now stamps a `com.chroxy.managed=true` docker label on
+ * every resource it creates (docker-backend `_startContainer` / `_commitContainer`),
+ * and the survey identifies resources BY THAT LABEL first, falling back to the
+ * legacy naming convention for resources created before the label existed:
+ *   - containers: label `com.chroxy.managed=true`, else name prefix `chroxy-env-`
+ *   - images:     label `com.chroxy.managed=true`, else repositories `chroxy-env`
  *                 and `chroxy-byok-snap` (BYOK pool snapshots)
  * There are no chroxy-managed named volumes (the backends use bind mounts).
  *
@@ -31,6 +33,7 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { parseByteSize } from './containers.js'
 import { listSnapshots } from '../snapshots-store.js'
+import { CHROXY_MANAGED_LABEL } from '../environments/backends/docker.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -55,17 +58,24 @@ export const PRUNABLE_CONTAINER_STATES = Object.freeze(['exited', 'created', 'de
  * `Size` token is `"<writable> (virtual <total>)"`; we count the writable layer
  * (what `docker rm` actually frees).
  *
+ * #6155: `trusted` skips the name-prefix check — the caller already constrained
+ * the query by `--filter label=com.chroxy.managed=true`, so membership is proven
+ * by the label even if the name doesn't follow the legacy `chroxy-env-*` shape.
+ * The default (name-prefix required) is the legacy/fallback path.
+ *
  * @param {string} stdout
+ * @param {{trusted?: boolean}} [opts]
  * @returns {Array<{id: string, name: string, state: string, sizeBytes: number|null}>}
  */
-export function parseContainerLines(stdout) {
+export function parseContainerLines(stdout, { trusted = false } = {}) {
   if (typeof stdout !== 'string') return []
   const out = []
   for (const line of stdout.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed) continue
     const [id, name, state, ...sizeParts] = trimmed.split('\t')
-    if (!id || typeof name !== 'string' || !name.startsWith(CHROXY_CONTAINER_PREFIX)) continue
+    if (!id || typeof name !== 'string') continue
+    if (!trusted && !name.startsWith(CHROXY_CONTAINER_PREFIX)) continue
     const st = (state || '').trim().toLowerCase()
     if (!PRUNABLE_CONTAINER_STATES.includes(st)) continue
     // Size = "1.09kB (virtual 5.59MB)" → writable side before " (".
@@ -83,17 +93,24 @@ export function parseContainerLines(stdout) {
  * display/exclusion-matching only; removal is always by image `id`, and a bare
  * repo ref never collides with a retained `repo:tag` exclusion entry).
  *
+ * #6155: `trusted` skips the repository-membership check — the caller already
+ * constrained the query by `--filter label=com.chroxy.managed=true`, so the image
+ * is chroxy's by label regardless of its repository. The default (repo must be in
+ * CHROXY_IMAGE_REPOS) is the legacy/fallback path.
+ *
  * @param {string} stdout
+ * @param {{trusted?: boolean}} [opts]
  * @returns {Array<{id: string, ref: string, repository: string, sizeBytes: number|null}>}
  */
-export function parseImageLines(stdout) {
+export function parseImageLines(stdout, { trusted = false } = {}) {
   if (typeof stdout !== 'string') return []
   const out = []
   for (const line of stdout.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed) continue
     const [id, repository, tag, size] = trimmed.split('\t')
-    if (!id || typeof repository !== 'string' || !CHROXY_IMAGE_REPOS.includes(repository.trim())) continue
+    if (!id || typeof repository !== 'string') continue
+    if (!trusted && !CHROXY_IMAGE_REPOS.includes(repository.trim())) continue
     const repo = repository.trim()
     const t = (tag || '').trim()
     const ref = t && t !== '<none>' ? `${repo}:${t}` : repo
@@ -203,17 +220,25 @@ export async function surveyHostPrune(opts = {}) {
 
   // Stopped chroxy containers. A docker/daemon failure here means docker is
   // unavailable → degrade the whole survey (no point probing images).
+  // #6155: identify by label first (robust), then the legacy `chroxy-env-*` name
+  // convention for containers created before the label existed. Union, dedup by id.
   let containers
   try {
-    const { stdout } = await _execFile('docker', [
-      'ps', '-a', '--size',
-      '--filter', 'name=chroxy-env',
-      '--filter', 'status=exited',
-      '--filter', 'status=created',
-      '--filter', 'status=dead',
-      '--format', '{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Size}}',
+    const statusFilters = ['--filter', 'status=exited', '--filter', 'status=created', '--filter', 'status=dead']
+    const fmt = '{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Size}}'
+    const byLabel = await _execFile('docker', [
+      'ps', '-a', '--size', '--filter', `label=${CHROXY_MANAGED_LABEL}=true`, ...statusFilters, '--format', fmt,
     ], EXEC_OPTS)
-    containers = parseContainerLines(stdout).filter((c) => !isTrackedContainer(c.id, tracked))
+    const byName = await _execFile('docker', [
+      'ps', '-a', '--size', '--filter', 'name=chroxy-env', ...statusFilters, '--format', fmt,
+    ], EXEC_OPTS)
+    const seen = new Set()
+    containers = []
+    for (const c of [...parseContainerLines(byLabel.stdout, { trusted: true }), ...parseContainerLines(byName.stdout)]) {
+      if (seen.has(c.id)) continue
+      seen.add(c.id)
+      if (!isTrackedContainer(c.id, tracked)) containers.push(c)
+    }
   } catch (err) {
     return {
       ...base,
@@ -231,16 +256,30 @@ export async function surveyHostPrune(opts = {}) {
   if (byokReadFailed) {
     imageNote = 'BYOK snapshot registry unavailable — image pruning skipped to avoid deleting retained snapshots.'
   } else {
+    const imgFmt = '{{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.Size}}'
+    const seenImg = new Set()
+    // Excluded if referenced by a live env (image or saved snapshot) OR retained
+    // as a BYOK snapshot sidecar. Only true orphans survive. Dedup by id so an
+    // image found by both the label and the repo query is considered once.
+    const consider = (img) => {
+      if (seenImg.has(img.id)) return
+      seenImg.add(img.id)
+      if (!tracked.imageRefs.has(img.ref) && !retainedByokTags.has(img.ref)) images.push(img)
+    }
+    // #6155: label-identified images first (robust, any repo), then the legacy
+    // per-repo lists for images created before the label existed.
+    try {
+      const { stdout } = await _execFile('docker', [
+        'images', '--filter', `label=${CHROXY_MANAGED_LABEL}=true`, '--format', imgFmt,
+      ], EXEC_OPTS)
+      for (const img of parseImageLines(stdout, { trusted: true })) consider(img)
+    } catch (err) {
+      imageNote = `the labeled chroxy image set could not be listed (${err && err.message ? err.message : 'exec failed'}).`
+    }
     for (const repo of CHROXY_IMAGE_REPOS) {
       try {
-        const { stdout } = await _execFile('docker', [
-          'images', repo, '--format', '{{.ID}}\t{{.Repository}}\t{{.Tag}}\t{{.Size}}',
-        ], EXEC_OPTS)
-        for (const img of parseImageLines(stdout)) {
-          // Excluded if referenced by a live env (image or saved snapshot) OR
-          // retained as a BYOK snapshot sidecar. Only true orphans survive.
-          if (!tracked.imageRefs.has(img.ref) && !retainedByokTags.has(img.ref)) images.push(img)
-        }
+        const { stdout } = await _execFile('docker', ['images', repo, '--format', imgFmt], EXEC_OPTS)
+        for (const img of parseImageLines(stdout)) consider(img)
       } catch (err) {
         imageNote = `some chroxy image repositories could not be listed (${err && err.message ? err.message : 'exec failed'}).`
       }

--- a/packages/server/src/control-room/host-prune.js
+++ b/packages/server/src/control-room/host-prune.js
@@ -4,10 +4,12 @@
  * Surfaces reclaimable HOST docker pressure scoped STRICTLY to chroxy's OWN
  * resources, so the Control Room can prune dangling chroxy artifacts (the
  * container analog of `chroxy worktree gc`) without ever touching a non-chroxy
- * workload. #6155: chroxy now stamps a `com.chroxy.managed=true` docker label on
- * every resource it creates (docker-backend `_startContainer` / `_commitContainer`),
- * and the survey identifies resources BY THAT LABEL first, falling back to the
- * legacy naming convention for resources created before the label existed:
+ * workload. #6155: chroxy stamps a `com.chroxy.managed=true` docker label on the
+ * resources it creates via `docker run` / `docker commit` (docker-backend
+ * `_startContainer` / `_commitContainer`), and the survey identifies resources BY
+ * THAT LABEL first, falling back to the legacy naming convention — which also
+ * covers compose-managed containers (`docker compose up`, project `chroxy-env-*`)
+ * that don't receive the CLI `--label`, and any resource created before the label:
  *   - containers: label `com.chroxy.managed=true`, else name prefix `chroxy-env-`
  *   - images:     label `com.chroxy.managed=true`, else repositories `chroxy-env`
  *                 and `chroxy-byok-snap` (BYOK pool snapshots)
@@ -218,32 +220,47 @@ export async function surveyHostPrune(opts = {}) {
     byokReadFailed = true
   }
 
-  // Stopped chroxy containers. A docker/daemon failure here means docker is
-  // unavailable → degrade the whole survey (no point probing images).
-  // #6155: identify by label first (robust), then the legacy `chroxy-env-*` name
-  // convention for containers created before the label existed. Union, dedup by id.
+  // Stopped chroxy containers. #6155: identify by label first (robust), then the
+  // legacy `chroxy-env-*` name convention (also covers compose-managed containers,
+  // which don't get the CLI label). Union, dedup by id.
+  //
+  // The LEGACY NAME query is the "is docker up" probe: if it throws, docker is
+  // unavailable → degrade the whole survey. The supplementary LABEL query
+  // soft-degrades (a note, keep the name results) — losing it can only *under*-
+  // prune, never over-prune, and the name query already finds every current
+  // chroxy container. (Mirrors the image-side handling below.)
   let containers
+  let containerNote = null
+  const statusFilters = ['--filter', 'status=exited', '--filter', 'status=created', '--filter', 'status=dead']
+  const psFmt = '{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Size}}'
+  let byNameOut
   try {
-    const statusFilters = ['--filter', 'status=exited', '--filter', 'status=created', '--filter', 'status=dead']
-    const fmt = '{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Size}}'
-    const byLabel = await _execFile('docker', [
-      'ps', '-a', '--size', '--filter', `label=${CHROXY_MANAGED_LABEL}=true`, ...statusFilters, '--format', fmt,
+    byNameOut = await _execFile('docker', [
+      'ps', '-a', '--size', '--filter', 'name=chroxy-env', ...statusFilters, '--format', psFmt,
     ], EXEC_OPTS)
-    const byName = await _execFile('docker', [
-      'ps', '-a', '--size', '--filter', 'name=chroxy-env', ...statusFilters, '--format', fmt,
-    ], EXEC_OPTS)
-    const seen = new Set()
-    containers = []
-    for (const c of [...parseContainerLines(byLabel.stdout, { trusted: true }), ...parseContainerLines(byName.stdout)]) {
-      if (seen.has(c.id)) continue
-      seen.add(c.id)
-      if (!isTrackedContainer(c.id, tracked)) containers.push(c)
-    }
   } catch (err) {
     return {
       ...base,
       dockerAvailable: false,
       note: `docker is unavailable — host prune survey skipped (${err && err.message ? err.message : 'exec failed'}).`,
+    }
+  }
+  let byLabelLines = []
+  try {
+    const byLabel = await _execFile('docker', [
+      'ps', '-a', '--size', '--filter', `label=${CHROXY_MANAGED_LABEL}=true`, ...statusFilters, '--format', psFmt,
+    ], EXEC_OPTS)
+    byLabelLines = parseContainerLines(byLabel.stdout, { trusted: true })
+  } catch (err) {
+    containerNote = `the labeled chroxy container set could not be listed (${err && err.message ? err.message : 'exec failed'}).`
+  }
+  {
+    const seen = new Set()
+    containers = []
+    for (const c of [...byLabelLines, ...parseContainerLines(byNameOut.stdout)]) {
+      if (seen.has(c.id)) continue
+      seen.add(c.id)
+      if (!isTrackedContainer(c.id, tracked)) containers.push(c)
     }
   }
 
@@ -289,7 +306,7 @@ export async function surveyHostPrune(opts = {}) {
   return {
     generatedAt: now.toISOString(),
     dockerAvailable: true,
-    note: imageNote,
+    note: [containerNote, imageNote].filter(Boolean).join(' ') || null,
     containers,
     images,
     summary: {

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -6,12 +6,16 @@ const log = createLogger('docker-backend')
 const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
 
 /**
- * #6155 — first-class docker labels stamped on every chroxy-created resource, so
+ * #6155 — first-class docker labels stamped on the chroxy resources created via
+ * `docker run` (`_startContainer`) and `docker commit` (`_commitContainer`), so
  * the Control Room host-prune survey can identify them by label (robust) with the
  * legacy name/tag convention (`chroxy-env-*` / `chroxy-env:` / `chroxy-byok-snap:`)
- * as a fallback for resources created before the label existed. `MANAGED` marks
- * ownership; `KIND` distinguishes a live env container from a committed snapshot
- * image. Kept here (the producer) and imported by `control-room/host-prune.js`.
+ * as a fallback. NOTE: compose-managed containers (`_composeUp` → `docker compose
+ * up`) do NOT receive these CLI `--label` flags — they're covered by the
+ * `chroxy-env-*` name fallback instead (their compose project is `chroxy-env-<id>`).
+ * `MANAGED` marks ownership; `KIND` distinguishes a live env container from a
+ * committed snapshot image. Kept here (the producer) and imported by
+ * `control-room/host-prune.js`.
  */
 export const CHROXY_MANAGED_LABEL = 'com.chroxy.managed'
 export const CHROXY_LABEL_KIND = 'com.chroxy.kind'

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -6,6 +6,17 @@ const log = createLogger('docker-backend')
 const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
 
 /**
+ * #6155 — first-class docker labels stamped on every chroxy-created resource, so
+ * the Control Room host-prune survey can identify them by label (robust) with the
+ * legacy name/tag convention (`chroxy-env-*` / `chroxy-env:` / `chroxy-byok-snap:`)
+ * as a fallback for resources created before the label existed. `MANAGED` marks
+ * ownership; `KIND` distinguishes a live env container from a committed snapshot
+ * image. Kept here (the producer) and imported by `control-room/host-prune.js`.
+ */
+export const CHROXY_MANAGED_LABEL = 'com.chroxy.managed'
+export const CHROXY_LABEL_KIND = 'com.chroxy.kind'
+
+/**
  * #5127 — Cap on the per-stream buffer the streaming execInEnvironment path
  * retains for the resolved value / failure tail. The buffered execFile path
  * rejects past Node's 1 MB maxBuffer; the streaming path used to accumulate
@@ -600,6 +611,9 @@ export class DockerBackend {
       const runArgs = [
         'run', '-d', '--init',
         '--name', `chroxy-env-${envId}`,
+        // #6155: first-class ownership labels (survey identity, name as fallback).
+        '--label', `${CHROXY_MANAGED_LABEL}=true`,
+        '--label', `${CHROXY_LABEL_KIND}=env`,
         '--memory', memoryLimit,
         '--cpus', cpuLimit,
         '--pids-limit', '512',
@@ -697,7 +711,16 @@ export class DockerBackend {
 
   _commitContainer(containerId, imageTag) {
     return new Promise((resolve, reject) => {
-      this._execFile('docker', ['commit', containerId, imageTag], { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
+      // #6155: stamp ownership labels onto the committed snapshot image (both env
+      // snapshots and BYOK pool snapshots commit through here) via `--change LABEL`,
+      // so host-prune can identify it by label with the `chroxy-*` tag as fallback.
+      const commitArgs = [
+        'commit',
+        '--change', `LABEL ${CHROXY_MANAGED_LABEL}=true`,
+        '--change', `LABEL ${CHROXY_LABEL_KIND}=snapshot`,
+        containerId, imageTag,
+      ]
+      this._execFile('docker', commitArgs, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
         if (err) {
           reject(new Error(stderr ? stderr.trim() : err.message))
           return

--- a/packages/server/tests/control-room-host-prune.test.js
+++ b/packages/server/tests/control-room-host-prune.test.js
@@ -64,6 +64,15 @@ describe('parseContainerLines()', () => {
     assert.equal(out[0].sizeBytes, 12_500_000)
     assert.equal(out[1].sizeBytes, 0)
   })
+
+  it('trusted: accepts a non-chroxy-named row (label-identified, #6155)', () => {
+    // The label-filtered docker query already proved membership, so a row whose
+    // name doesn't follow the legacy prefix is still kept.
+    const out = parseContainerLines('zzz\tweird-name\texited\t1MB (virtual 2MB)', { trusted: true })
+    assert.deepEqual(out.map((c) => c.id), ['zzz'])
+    // running is still excluded even when trusted (prunable-state gate stays).
+    assert.deepEqual(parseContainerLines('zzz\tweird-name\trunning\t1MB', { trusted: true }), [])
+  })
 })
 
 describe('parseImageLines()', () => {
@@ -76,6 +85,13 @@ describe('parseImageLines()', () => {
     ].join('\n'))
     assert.deepEqual(out.map((i) => i.ref), ['chroxy-env:foo-123', 'chroxy-byok-snap:abc-1', 'chroxy-env'])
     assert.equal(out[0].sizeBytes, 1_200_000_000)
+  })
+
+  it('trusted: accepts an image in a non-chroxy repo (label-identified, #6155)', () => {
+    // A label-filtered docker query can return an image whose repository isn't in
+    // the legacy set — trusted keeps it (membership proven by the label).
+    const out = parseImageLines('imgX\tmy-custom-repo\tv1\t50MB', { trusted: true })
+    assert.deepEqual(out.map((i) => i.ref), ['my-custom-repo:v1'])
   })
 })
 
@@ -117,6 +133,41 @@ describe('surveyHostPrune()', () => {
     assert.equal(snap.summary.imageCount, 2)
     assert.equal(snap.summary.reclaimableBytes, 10_000_000 + 1_000_000_000 + 500_000_000)
     assert.equal(snap.generatedAt, '2026-06-19T12:00:00.000Z')
+  })
+
+  it('unions the label-identified set with the legacy name/repo set, deduped (#6155)', async () => {
+    // A bespoke exec that returns DIFFERENT rows for the label query vs the legacy
+    // query, so we can prove: (a) a labeled container with a non-conventional name
+    // is found via the label path, (b) a legacy unlabeled chroxy-env-* container is
+    // found via the name path, (c) one returned by BOTH is deduped to a single row.
+    const calls = []
+    const _execFile = async (_cmd, args) => {
+      calls.push(args)
+      if (args[0] === 'ps') {
+        if (args.includes('label=com.chroxy.managed=true')) {
+          return { stdout: [
+            'labeledX\trenamed-by-user\texited\t1MB (virtual 9MB)',     // labeled, non-conventional name
+            'bothid00\tchroxy-env-both\texited\t2MB (virtual 9MB)',     // labeled AND conventional
+          ].join('\n') }
+        }
+        // legacy name query
+        return { stdout: [
+          'bothid00\tchroxy-env-both\texited\t2MB (virtual 9MB)',       // same as above → dedup
+          'legacyId0\tchroxy-env-old\texited\t3MB (virtual 9MB)',       // unlabeled legacy
+        ].join('\n') }
+      }
+      if (args[0] === 'images') {
+        if (args.includes('label=com.chroxy.managed=true')) {
+          return { stdout: 'limg\tmy-custom\tv1\t10MB' }                // labeled, non-chroxy repo
+        }
+        return { stdout: args[1] === 'chroxy-env' ? 'rimg\tchroxy-env\told-1\t20MB' : '' }
+      }
+      return { stdout: '' }
+    }
+    const snap = await surveyHostPrune({ listEnvironments: () => [], listByokSnapshots: NO_BYOK, _execFile, _now: NOW })
+    assert.deepEqual(snap.containers.map((c) => c.id).sort(), ['bothid00', 'labeledX', 'legacyId0'])
+    assert.equal(snap.summary.containerCount, 3) // deduped (bothid00 once)
+    assert.deepEqual(snap.images.map((i) => i.id).sort(), ['limg', 'rimg'])
   })
 
   it('excludes containers + images tracked by a live env (orphan-only)', async () => {
@@ -204,17 +255,25 @@ describe('surveyHostPrune()', () => {
     assert.deepEqual(snap.images, [])
   })
 
-  it('uses the chroxy name + state + image-repo filters on the docker ps/images calls', async () => {
+  it('queries by the managed label first, then the legacy name/repo filters (#6155)', async () => {
     const _execFile = execStub({ psOut: '', imagesOut: {} })
     await surveyHostPrune({ listByokSnapshots: NO_BYOK, _execFile, _now: NOW })
-    const ps = _execFile.calls.find((c) => c.args[0] === 'ps')
-    assert.ok(ps.args.includes('--size'))
-    assert.ok(ps.args.includes('name=chroxy-env'))
-    assert.ok(ps.args.includes('status=exited'))
-    assert.ok(ps.args.includes('status=created'))
-    assert.ok(ps.args.includes('status=dead'))
-    const imageRepos = _execFile.calls.filter((c) => c.args[0] === 'images').map((c) => c.args[1])
-    assert.deepEqual(imageRepos.sort(), ['chroxy-byok-snap', 'chroxy-env'])
+    const psCalls = _execFile.calls.filter((c) => c.args[0] === 'ps')
+    // Two container queries: label-identified first, then the legacy name prefix.
+    assert.equal(psCalls.length, 2)
+    assert.ok(psCalls[0].args.includes('label=com.chroxy.managed=true'), 'label ps query first')
+    assert.ok(psCalls.some((c) => c.args.includes('name=chroxy-env')), 'legacy name ps query present')
+    for (const ps of psCalls) {
+      assert.ok(ps.args.includes('--size'))
+      assert.ok(ps.args.includes('status=exited'))
+      assert.ok(ps.args.includes('status=created'))
+      assert.ok(ps.args.includes('status=dead'))
+    }
+    // Image queries: one label-filtered (any repo) + the two legacy per-repo lists.
+    const imageCalls = _execFile.calls.filter((c) => c.args[0] === 'images')
+    assert.ok(imageCalls.some((c) => c.args.includes('label=com.chroxy.managed=true')), 'label images query present')
+    const repos = imageCalls.filter((c) => c.args[1] !== '--filter').map((c) => c.args[1])
+    assert.deepEqual(repos.sort(), ['chroxy-byok-snap', 'chroxy-env'])
   })
 })
 

--- a/packages/server/tests/control-room-host-prune.test.js
+++ b/packages/server/tests/control-room-host-prune.test.js
@@ -170,6 +170,36 @@ describe('surveyHostPrune()', () => {
     assert.deepEqual(snap.images.map((i) => i.id).sort(), ['limg', 'rimg'])
   })
 
+  it('soft-degrades when only the label container query fails; name results survive (#6155)', async () => {
+    // The legacy name query (the degrade probe) succeeds, but the supplementary
+    // label query throws. The survey must stay dockerAvailable:true, keep the
+    // name-found container, and surface a note — losing the label query can only
+    // under-prune, never over-prune.
+    const _execFile = async (_cmd, args) => {
+      if (args[0] === 'ps') {
+        if (args.includes('label=com.chroxy.managed=true')) throw new Error('label query boom')
+        return { stdout: 'nameId00\tchroxy-env-keep\texited\t4MB (virtual 9MB)' }
+      }
+      if (args[0] === 'images') return { stdout: '' }
+      return { stdout: '' }
+    }
+    const snap = await surveyHostPrune({ listEnvironments: () => [], listByokSnapshots: NO_BYOK, _execFile, _now: NOW })
+    assert.equal(snap.dockerAvailable, true)
+    assert.deepEqual(snap.containers.map((c) => c.id), ['nameId00'])
+    assert.match(snap.note || '', /labeled chroxy container set could not be listed/)
+  })
+
+  it('still degrades to dockerAvailable:false when the legacy name query fails (#6155)', async () => {
+    // The name query is the daemon-up probe — if IT throws, the whole survey
+    // degrades (the label query is never reached).
+    const _execFile = async (_cmd, args) => {
+      if (args[0] === 'ps' && args.includes('name=chroxy-env')) throw new Error('Cannot connect to the Docker daemon')
+      return { stdout: '' }
+    }
+    const snap = await surveyHostPrune({ listByokSnapshots: NO_BYOK, _execFile, _now: NOW })
+    assert.equal(snap.dockerAvailable, false)
+  })
+
   it('excludes containers + images tracked by a live env (orphan-only)', async () => {
     const _execFile = execStub({
       psOut: [
@@ -255,13 +285,15 @@ describe('surveyHostPrune()', () => {
     assert.deepEqual(snap.images, [])
   })
 
-  it('queries by the managed label first, then the legacy name/repo filters (#6155)', async () => {
+  it('queries by both the managed label and the legacy name/repo filters (#6155)', async () => {
     const _execFile = execStub({ psOut: '', imagesOut: {} })
     await surveyHostPrune({ listByokSnapshots: NO_BYOK, _execFile, _now: NOW })
     const psCalls = _execFile.calls.filter((c) => c.args[0] === 'ps')
-    // Two container queries: label-identified first, then the legacy name prefix.
+    // Two container queries: the legacy name query (the degrade probe) + the
+    // supplementary label query (order: name first so a daemon-down throw degrades
+    // before the label query runs).
     assert.equal(psCalls.length, 2)
-    assert.ok(psCalls[0].args.includes('label=com.chroxy.managed=true'), 'label ps query first')
+    assert.ok(psCalls.some((c) => c.args.includes('label=com.chroxy.managed=true')), 'label ps query present')
     assert.ok(psCalls.some((c) => c.args.includes('name=chroxy-env')), 'legacy name ps query present')
     for (const ps of psCalls) {
       assert.ok(ps.args.includes('--size'))


### PR DESCRIPTION
## Summary

Fixes #6155 (hardens #6140). chroxy identified its docker resources only by **naming convention** (`chroxy-env-*` containers, `chroxy-env` / `chroxy-byok-snap` image repos). This stamps a first-class label so identity is robust if names ever change, keeping the convention as a backward-compat fallback so **pre-existing unlabeled resources are never orphaned**.

## What changed

**Producer — docker backend** (`environments/backends/docker.js`):
- `_startContainer` adds `--label com.chroxy.managed=true --label com.chroxy.kind=env`.
- `_commitContainer` (the single chokepoint for **both** env snapshots and BYOK pool snapshots — both route through `commitEnvironment` → `_commitContainer`) adds `--change 'LABEL com.chroxy.managed=true' --change 'LABEL com.chroxy.kind=snapshot'`.
- Exports `CHROXY_MANAGED_LABEL` / `CHROXY_LABEL_KIND`.

**Consumer — host-prune survey** (`control-room/host-prune.js`):
- Identifies containers + images **by label first** (`--filter label=com.chroxy.managed=true`), **unioned (dedup by id)** with the legacy name/repo queries so unlabeled pre-existing resources are still found.
- `parseContainerLines` / `parseImageLines` gain a `trusted` flag that skips the name/repo convention check for label-filtered results (membership already proven by the docker label filter).
- `runHostPrune` inherits this automatically (it re-surveys).

No behavior change for unlabeled running resources (no orphaning); the orphan-only + retained-snapshot exclusions from #6140 are preserved.

## Tests (cover labeled + legacy-unlabeled, acceptance #4)

- `trusted` parsers accept a non-conventional container name / non-chroxy image repo (label path); prunable-state gate still applies.
- A survey union test with a bespoke exec proving: a labeled non-conventional container is found via the label path, a legacy unlabeled `chroxy-env-*` via the name path, and one returned by both is deduped.
- Updated the query-shape test to assert label-first + legacy queries for both ps and images.

## Verification

- host-prune tests: **21 pass**; docker/environment/byok suites: **972 pass**, 0 fail
- Server custom lints green; eslint clean on changed source; server-only (no protocol/dist)
