### PR TITLE
feat(dashboard): WSL2 distro panel in Device runtimes tab (#6138)

### DIFF
--- a/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.test.tsx
@@ -31,10 +31,17 @@ vi.mock('../store/connection', () => ({
       emulatorActioningIds: new Set<string>(),
       emulatorActionResults: {},
       sendEmulatorAction: () => false,
+      // #6138: the WSL panel reads these (rendered by DeviceRuntimesSection).
+      wslStatus: null,
+      wslStatusLoading: false,
+      requestWslStatus: () => false,
+      wslActioningIds: new Set<string>(),
+      wslActionResults: {},
+      sendWslAction: () => false,
     }),
 }))
-import { DeviceRuntimesSection, AndroidEmulatorPanel } from './DeviceRuntimesSection'
-import type { ServerEmulatorStatusSnapshotMessage } from '@chroxy/protocol'
+import { DeviceRuntimesSection, AndroidEmulatorPanel, WslPanel } from './DeviceRuntimesSection'
+import type { ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage } from '@chroxy/protocol'
 
 afterEach(cleanup)
 
@@ -267,5 +274,100 @@ describe('AndroidEmulatorPanel (#6137)', () => {
     render(<AndroidEmulatorPanel snapshot={emuSnapshot({ devices: [{ avd: 'Pixel_7_API_34', serial: null, state: 'starting' }], readyForMaestro: { ready: false, runningDevice: null, metroReachable: true, mockServerReachable: true, reasons: ['No running emulator'] } })} loading={false} connected={true} onRefresh={() => {}} />)
     expect(screen.getByTestId('emulator-row-Pixel_7_API_34')).toBeTruthy()
     expect((screen.getByTestId('emulator-kill-Pixel_7_API_34') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+function wslSnapshot(over: Partial<ServerWslStatusSnapshotMessage> = {}): ServerWslStatusSnapshotMessage {
+  return {
+    type: 'wsl_status_snapshot',
+    generatedAt: '2026-06-20T12:00:00.000Z',
+    available: true,
+    note: null,
+    defaultDistro: 'Ubuntu',
+    distros: [
+      { name: 'Ubuntu', state: 'Running', version: 2, isDefault: true },
+      { name: 'Debian', state: 'Stopped', version: 2, isDefault: false },
+    ],
+    ...over,
+  } as ServerWslStatusSnapshotMessage
+}
+
+describe('WslPanel (#6138)', () => {
+  it('renders the empty state with a Run-survey button when no snapshot', () => {
+    render(<WslPanel snapshot={null} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('wsl-empty')).toBeTruthy()
+    expect(screen.queryByTestId('wsl-table')).toBeNull()
+  })
+
+  it('renders the unavailable note (off Windows) and no table', () => {
+    render(
+      <WslPanel
+        snapshot={wslSnapshot({ available: false, note: 'WSL is only available on Windows hosts.', defaultDistro: null, distros: [] })}
+        loading={false} connected={true} onRefresh={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('wsl-unavailable').textContent).toContain('Windows')
+    expect(screen.queryByTestId('wsl-table')).toBeNull()
+  })
+
+  it('renders state-aware Terminate (Running) + Start (Stopped) buttons and the default marker', () => {
+    render(<WslPanel snapshot={wslSnapshot()} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('wsl-terminate-Ubuntu')).toBeTruthy()
+    expect(screen.getByTestId('wsl-start-Debian')).toBeTruthy()
+    expect(screen.getByTestId('wsl-default-Ubuntu')).toBeTruthy()
+    expect(screen.queryByTestId('wsl-default-Debian')).toBeNull()
+    expect(screen.getByTestId('wsl-version-Ubuntu').textContent).toContain('WSL 2')
+  })
+
+  it('start routes to onAction(start, name); terminate routes to onAction(terminate, name)', () => {
+    const onAction = vi.fn()
+    render(<WslPanel snapshot={wslSnapshot()} loading={false} connected={true} onRefresh={() => {}} onAction={onAction} />)
+    fireEvent.click(screen.getByTestId('wsl-start-Debian'))
+    expect(onAction).toHaveBeenCalledWith('start', 'Debian')
+    fireEvent.click(screen.getByTestId('wsl-terminate-Ubuntu'))
+    expect(onAction).toHaveBeenCalledWith('terminate', 'Ubuntu')
+  })
+
+  it('a transitional-state distro (Installing) shows a disabled Start (cannot start non-Stopped)', () => {
+    render(<WslPanel snapshot={wslSnapshot({ distros: [{ name: 'Ubuntu', state: 'Installing', version: 2, isDefault: true }] })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect((screen.getByTestId('wsl-start-Ubuntu') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('wsl-state-Ubuntu').textContent).toBe('Installing')
+  })
+
+  it('disables the actioning row per-target, leaving others enabled', () => {
+    render(<WslPanel snapshot={wslSnapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set(['Ubuntu'])} actionResults={{}} />)
+    expect((screen.getByTestId('wsl-terminate-Ubuntu') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('wsl-pending-Ubuntu')).toBeTruthy()
+    expect((screen.getByTestId('wsl-start-Debian') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('shows a settled note after an action resolves', () => {
+    render(<WslPanel snapshot={wslSnapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set<string>()} actionResults={{ Ubuntu: { action: 'terminate', note: 'Terminated', error: null, at: 1 } }} />)
+    expect(screen.getByTestId('wsl-ok-Ubuntu').textContent).toContain('Terminated')
+  })
+
+  it('shows an error note after a failed action', () => {
+    render(<WslPanel snapshot={wslSnapshot()} loading={false} connected={true} onRefresh={() => {}} actioningIds={new Set<string>()} actionResults={{ Debian: { action: 'start', note: null, error: 'wsl.exe ENOENT', at: 1 } }} />)
+    expect(screen.getByTestId('wsl-error-Debian').textContent).toContain('ENOENT')
+  })
+
+  it('Refresh dispatches and is disabled while loading', () => {
+    const onRefresh = vi.fn()
+    const { rerender } = render(<WslPanel snapshot={wslSnapshot()} loading={false} connected={true} onRefresh={onRefresh} />)
+    fireEvent.click(screen.getByTestId('wsl-refresh'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    rerender(<WslPanel snapshot={wslSnapshot()} loading={true} connected={true} onRefresh={onRefresh} />)
+    expect((screen.getByTestId('wsl-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('renders a no-distros note when none are installed', () => {
+    render(<WslPanel snapshot={wslSnapshot({ defaultDistro: null, distros: [] })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('wsl-no-distros')).toBeTruthy()
+    expect(screen.queryByTestId('wsl-table')).toBeNull()
+  })
+
+  it('renders a null version as an em dash', () => {
+    render(<WslPanel snapshot={wslSnapshot({ distros: [{ name: 'Ubuntu', state: 'Stopped', version: null, isDefault: true }] })} loading={false} connected={true} onRefresh={() => {}} />)
+    expect(screen.getByTestId('wsl-version-Ubuntu').textContent).toBe('—')
   })
 })

--- a/packages/dashboard/src/components/DeviceRuntimesSection.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.tsx
@@ -15,8 +15,8 @@
  */
 import { useEffect } from 'react'
 import { useConnectionStore } from '../store/connection'
-import type { ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage } from '@chroxy/protocol'
-import type { SimulatorActionResult, EmulatorActionResult } from '../store/types'
+import type { ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage } from '@chroxy/protocol'
+import type { SimulatorActionResult, EmulatorActionResult, WslActionResult } from '../store/types'
 import { formatGeneratedAgo } from './ControlRoomSection'
 
 type SimAction = 'boot' | 'shutdown'
@@ -236,7 +236,215 @@ export function DeviceRuntimesSection({
       )}
     </div>
     <AndroidEmulatorPanel now={now} />
+    <WslPanel now={now} />
     </>
+  )
+}
+
+function WslActionFeedback({ distro, pending, result }: { distro: string; pending: boolean; result: WslActionResult | undefined }) {
+  if (pending) return <span className="cr-dim" data-testid={`wsl-pending-${distro}`}>Working…</span>
+  if (!result) return null
+  if (result.error) return <span className="cr-bad" data-testid={`wsl-error-${distro}`} role="alert">{result.error}</span>
+  return <span className="cr-ok" data-testid={`wsl-ok-${distro}`}>{result.note ?? 'done'}</span>
+}
+
+export interface WslPanelProps {
+  snapshot?: ServerWslStatusSnapshotMessage | null
+  loading?: boolean
+  connected?: boolean
+  onRefresh?: () => void
+  actioningIds?: Set<string>
+  actionResults?: Record<string, WslActionResult>
+  onAction?: (action: 'start' | 'terminate', distro: string) => void
+  now?: () => number
+}
+
+/**
+ * #6138 — the WSL2 half of the Device runtimes tab. Windows-host-only: off
+ * Windows / no wsl.exe the survey returns `available:false` and the panel shows
+ * just a note. Mirrors the sibling panels' chrome (eyebrow + Refresh +
+ * generated-ago + empty state), but there's no "Ready for Maestro" verdict — WSL
+ * is a host runtime, not a Maestro target. Each distro row exposes a state-gated
+ * Start (a Stopped distro) / Terminate (a Running distro) button; the server
+ * re-surveys + re-validates the distro name (lookup key, never a trusted path)
+ * and state-gates the action. The tab's generic auto-fetch only covers the iOS
+ * survey, so this panel self-fetches the WSL survey once on connect.
+ */
+export function WslPanel({
+  snapshot: snapshotProp,
+  loading: loadingProp,
+  connected: connectedProp,
+  onRefresh: onRefreshProp,
+  actioningIds: actioningIdsProp,
+  actionResults: actionResultsProp,
+  onAction: onActionProp,
+  now = Date.now,
+}: WslPanelProps = {}) {
+  const storeSnapshot = useConnectionStore((s) => s.wslStatus)
+  const storeLoading = useConnectionStore((s) => s.wslStatusLoading)
+  const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestWslStatus = useConnectionStore((s) => s.requestWslStatus)
+  const storeActioningIds = useConnectionStore((s) => s.wslActioningIds)
+  const storeActionResults = useConnectionStore((s) => s.wslActionResults)
+  const sendWslAction = useConnectionStore((s) => s.sendWslAction)
+
+  const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
+  const loading = loadingProp !== undefined ? loadingProp : storeLoading
+  const connected = connectedProp !== undefined ? connectedProp : storeConnected
+  const onRefresh = onRefreshProp ?? requestWslStatus
+  const actioningIds = actioningIdsProp ?? storeActioningIds
+  const actionResults = actionResultsProp ?? storeActionResults
+  const onAction = onActionProp ?? sendWslAction
+
+  // The tab's generic auto-fetch only requests the iOS survey, so kick the WSL
+  // survey once when we first connect with no snapshot yet (same pattern as the
+  // Android panel). A no-op when driven by props in tests.
+  useEffect(() => {
+    if (snapshotProp === undefined && storeConnected && storeSnapshot === null && !storeLoading) {
+      requestWslStatus()
+    }
+  }, [snapshotProp, storeConnected, storeSnapshot, storeLoading, requestWslStatus])
+
+  const refreshDisabled = loading || !connected
+  const handleRefresh = () => {
+    if (refreshDisabled) return
+    onRefresh()
+  }
+
+  const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
+
+  return (
+    <div className="cr-section" data-testid="wsl-section">
+      <header className="cr-header">
+        <div className="cr-eyebrow" data-testid="wsl-eyebrow">
+          host · wsl2 distros{snapshot ? ` · ${isoDate(snapshot.generatedAt)}` : ''}
+        </div>
+        <div className="cr-titlerow">
+          <h2 className="cr-title">WSL2 distros</h2>
+          <button
+            type="button"
+            className="cr-refresh"
+            data-testid="wsl-refresh"
+            onClick={handleRefresh}
+            disabled={refreshDisabled}
+            aria-busy={loading}
+            title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {snapshot?.error && (
+          <p className="cr-callout cr-callout-bad" data-testid="wsl-error" role="alert">
+            <b>Survey failed ({snapshot.error.code}):</b> {snapshot.error.message}
+          </p>
+        )}
+        {snapshot && !snapshot.available && (
+          <p className="cr-callout" data-testid="wsl-unavailable">
+            {snapshot.note || 'WSL is not available on this host.'}
+          </p>
+        )}
+        {snapshot && !Number.isNaN(generatedAtMs) && (
+          <p className="cr-generated" data-testid="wsl-generated">
+            {formatGeneratedAgo(generatedAtMs, now())}
+          </p>
+        )}
+      </header>
+
+      {!snapshot && (
+        <div className="cr-empty" data-testid="wsl-empty">
+          {loading ? (
+            <span>Running the WSL survey…</span>
+          ) : (
+            <>
+              <p>No WSL survey yet.</p>
+              <button
+                type="button"
+                className="cr-refresh"
+                data-testid="wsl-empty-refresh"
+                onClick={handleRefresh}
+                disabled={!connected}
+                title={connected ? undefined : 'Not connected — reconnect to run the survey'}
+              >
+                Run survey
+              </button>
+              {!connected && (
+                <p className="cr-dim" data-testid="wsl-not-connected">Not connected to the server.</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {snapshot?.available && (
+        snapshot.distros.length === 0 ? (
+          <p className="cr-dim" data-testid="wsl-no-distros">
+            No WSL distros are installed on this host.
+          </p>
+        ) : (
+          <section className="cr-table-wrap">
+            <table className="cr-table" data-testid="wsl-table">
+              <thead>
+                <tr><th>Distro</th><th>Version</th><th>State</th><th>Action</th></tr>
+              </thead>
+              <tbody>
+                {snapshot.distros.map((d) => {
+                  const isRunning = d.state === 'Running'
+                  const isStopped = d.state === 'Stopped'
+                  const pending = actioningIds.has(d.name)
+                  return (
+                    <tr key={d.name} data-testid={`wsl-row-${d.name}`}>
+                      <td>
+                        <b data-testid={`wsl-name-${d.name}`}>{d.name}</b>{' '}
+                        {d.isDefault && (
+                          <span className="cr-tag cr-tag-ok" data-testid={`wsl-default-${d.name}`}>default</span>
+                        )}
+                      </td>
+                      <td className="cr-dim" data-testid={`wsl-version-${d.name}`}>
+                        {d.version === null ? '—' : `WSL ${d.version}`}
+                      </td>
+                      <td>
+                        <span
+                          className={`cr-tag ${isRunning ? 'cr-tag-ok' : 'cr-tag-dim'}`}
+                          data-testid={`wsl-state-${d.name}`}
+                        >
+                          {d.state}
+                        </span>
+                      </td>
+                      <td data-testid={`wsl-actions-${d.name}`}>
+                        {isRunning ? (
+                          <button
+                            type="button"
+                            className="cr-action"
+                            data-testid={`wsl-terminate-${d.name}`}
+                            disabled={pending || !connected}
+                            onClick={() => onAction('terminate', d.name)}
+                            title="Terminate this distro"
+                          >
+                            Terminate
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            className="cr-action"
+                            data-testid={`wsl-start-${d.name}`}
+                            disabled={pending || !connected || !isStopped}
+                            onClick={() => onAction('start', d.name)}
+                            title={isStopped ? 'Start this distro' : `Cannot start (state: ${d.state})`}
+                          >
+                            Start
+                          </button>
+                        )}{' '}
+                        <WslActionFeedback distro={d.name} pending={pending} result={actionResults[d.name]} />
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </section>
+        )
+      )}
+    </div>
   )
 }
 

--- a/packages/dashboard/src/components/DeviceRuntimesSection.tsx
+++ b/packages/dashboard/src/components/DeviceRuntimesSection.tsx
@@ -1,15 +1,18 @@
 /**
- * DeviceRuntimesSection (#6136 / #6137, epic #5530) — the "Device runtimes"
- * Control Room tab. Surfaces two device-runtime panels: iOS simulators (#6136)
- * and Android emulators (#6137). (WSL2 #6138 is a Windows-only follow-up.)
+ * DeviceRuntimesSection (#6136 / #6137 / #6138, epic #5530) — the "Device
+ * runtimes" Control Room tab. Surfaces three device-runtime panels: iOS
+ * simulators (#6136), Android emulators (#6137), and WSL2 distros (#6138,
+ * Windows-host-only).
  *
- * Each panel renders its `*_status_snapshot` (devices + the headline **"Ready
- * for Maestro" verdict** — a booted/running device AND Metro (:8081) AND the
- * mock server (:9876) reachable — turning the manual Maestro pre-flight
- * (CLAUDE.md "UI Verification with Maestro") into one glance) plus per-row
- * lifecycle actions (simulator boot/shutdown; emulator boot/kill). Each follows
- * the established per-row discipline: the server takes the device id, re-surveys
- * + re-validates it as a lookup key, and state-gates the action. Non-destructive
+ * The simulator/emulator panels render their `*_status_snapshot` with the
+ * headline **"Ready for Maestro" verdict** — a booted/running device AND Metro
+ * (:8081) AND the mock server (:9876) reachable — turning the manual Maestro
+ * pre-flight (CLAUDE.md "UI Verification with Maestro") into one glance, plus
+ * per-row lifecycle actions (simulator boot/shutdown; emulator boot/kill). The
+ * WSL panel has no Maestro verdict (it's a host runtime, not a test target),
+ * just the distro survey + per-row start/terminate. Each follows the established
+ * per-row discipline: the server takes the device/distro id, re-surveys +
+ * re-validates it as a lookup key, and state-gates the action. Non-destructive
  * (no data loss), so no ConfirmDialog. `available:false` (no SDK / off-platform)
  * is a first-class state — no tables, just a note.
  */

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -553,6 +553,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #6137: emulator action — in-flight targets (avd/serial) + last outcome.
   emulatorActioningIds: new Set<string>(),
   emulatorActionResults: {},
+  // #6138: Control Room WSL2 distro snapshot, fed by the wsl_status_snapshot
+  // handler. Null until the first survey lands.
+  wslStatus: null,
+  wslStatusLoading: false,
+  // #6138: WSL action — in-flight distro names + last outcome per distro.
+  wslActioningIds: new Set<string>(),
+  wslActionResults: {},
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -1112,6 +1119,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return false;
   },
 
+  // #6138 (epic #5530): request a WSL2 distro survey. Mirrors
+  // requestEmulatorStatus — flips wslStatusLoading and sends a
+  // wsl_status_request; the reply is a single wsl_status_snapshot handled into
+  // wslStatus. Returns false (and does NOT set loading) when the socket is
+  // closed.
+  requestWslStatus: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ wslStatusLoading: true });
+      wsSend(socket, { type: 'wsl_status_request' });
+      return true;
+    }
+    return false;
+  },
+
   // #5499 (epic #5498): request an Integrations survey. Mirrors
   // requestRunnerStatus — flips integrationStatusLoading and sends an
   // integration_status_request; the reply is a single
@@ -1317,6 +1339,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       msg.serial = opts.serial;
     }
     wsSend(socket, msg);
+    return true;
+  },
+
+  // #6138 (epic #5530): start / terminate a WSL2 distro. The pending/result
+  // state is keyed by the distro name. Same wire-or-nothing contract as the
+  // sibling actions. Non-destructive (no data loss) → no confirm. The server
+  // re-surveys + re-validates the distro and state-gates it (start requires
+  // Stopped, terminate requires Running).
+  sendWslAction: (action: 'start' | 'terminate', distro: string): boolean => {
+    const { socket } = get();
+    if (action !== 'start' && action !== 'terminate') return false;
+    if (!distro) return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const requestId = `wsl-action-${nextMessageId()}`;
+    const pending = new Set(get().wslActioningIds);
+    pending.add(distro);
+    const results = { ...get().wslActionResults };
+    delete results[distro];
+    set({ wslActioningIds: pending, wslActionResults: results });
+    wsSend(socket, { type: 'wsl_action', action, distro, requestId });
     return true;
   },
 
@@ -2122,6 +2164,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().emulatorActioningIds.size > 0) {
         set({ emulatorActioningIds: new Set<string>() });
       }
+      // #6138: ditto for in-flight WSL distro actions.
+      if (get().wslActioningIds.size > 0) {
+        set({ wslActioningIds: new Set<string>() });
+      }
       // #6153: reset every Control Room survey *Loading flag that's still true on
       // a socket drop. Each survey section computes refreshDisabled = loading ||
       // !connected, so a refresh in flight when the socket dies would leave
@@ -2133,7 +2179,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const surveyLoadingKeys = [
         'hostStatusLoading', 'runnerStatusLoading', 'containersStatusLoading',
         'repoRuntimeConfigLoading', 'byokPoolStatusLoading', 'hostPruneStatusLoading',
-        'simulatorStatusLoading', 'emulatorStatusLoading', 'integrationStatusLoading',
+        'simulatorStatusLoading', 'emulatorStatusLoading', 'wslStatusLoading', 'integrationStatusLoading',
         'skillsInventoryLoading', 'mailboxStatusLoading',
       ] as const;
       const loadingReset: Partial<Record<(typeof surveyLoadingKeys)[number], boolean>> = {};
@@ -2429,6 +2475,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6137: emulator action pending/result state goes with it.
       emulatorActioningIds: new Set<string>(),
       emulatorActionResults: {},
+      // #6138: WSL distro action pending/result state goes with it.
+      wslActioningIds: new Set<string>(),
+      wslActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -2481,6 +2530,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6137: emulator action pending/result state goes with it.
       emulatorActioningIds: new Set<string>(),
       emulatorActionResults: {},
+      // #6138: WSL distro action pending/result state goes with it.
+      wslActioningIds: new Set<string>(),
+      wslActionResults: {},
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-wsl-action.test.ts
+++ b/packages/dashboard/src/store/dispatch-wsl-action.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration test for the WSL2 distro action wiring (#6138, epic #5530).
+ * Guards: ack clears the distro's pending state + records a note; malformed
+ * dropped; WSL_ACTION_FAILED clears the echoed distro + records the error;
+ * other targets untouched. Mirrors dispatch-emulator-action.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {},
+    wslActioningIds: new Set(['Ubuntu', 'Debian']),
+    wslActionResults: {},
+    messages: [],
+  }
+}
+
+describe('wsl action dispatch (#6138)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('a start ack clears the distro target and records a Started note', () => {
+    handleMessage({ type: 'wsl_action_ack', action: 'start', distro: 'Ubuntu', requestId: 'r1', status: 'running' }, ctx() as never)
+    const s = store.getState()
+    expect(s.wslActioningIds.has('Ubuntu')).toBe(false)
+    expect(s.wslActioningIds.has('Debian')).toBe(true) // other target untouched
+    expect(s.wslActionResults['Ubuntu']!.error).toBeNull()
+    expect(s.wslActionResults['Ubuntu']!.note).toMatch(/Started/)
+  })
+
+  it('a terminate ack clears the distro target and records a Terminated note', () => {
+    handleMessage({ type: 'wsl_action_ack', action: 'terminate', distro: 'Debian', status: 'stopped' }, ctx() as never)
+    expect(store.getState().wslActionResults['Debian']!.note).toMatch(/Terminated/)
+  })
+
+  it('appends an unexpected status to the note', () => {
+    handleMessage({ type: 'wsl_action_ack', action: 'start', distro: 'Ubuntu', status: 'installing' }, ctx() as never)
+    expect(store.getState().wslActionResults['Ubuntu']!.note).toMatch(/installing/)
+  })
+
+  it('drops a malformed ack (missing distro) without touching pending state', () => {
+    handleMessage({ type: 'wsl_action_ack', action: 'start' }, ctx() as never)
+    expect(store.getState().wslActioningIds.has('Ubuntu')).toBe(true)
+  })
+
+  it('WSL_ACTION_FAILED (start) clears the echoed distro and records the error', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'WSL_ACTION_FAILED', message: 'wsl.exe ENOENT', reason: 'start-failed', action: 'start', distro: 'Ubuntu', requestId: 'r1' }, ctx() as never)
+    const s = store.getState()
+    expect(s.wslActioningIds.has('Ubuntu')).toBe(false)
+    expect(s.wslActioningIds.has('Debian')).toBe(true)
+    expect(s.wslActionResults['Ubuntu']!.error).toMatch(/ENOENT/)
+    expect(s.wslActionResults['Ubuntu']!.note).toBeNull()
+  })
+
+  it('WSL_ACTION_FAILED (terminate) clears the echoed distro', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'WSL_ACTION_FAILED', message: 'no distribution', reason: 'terminate-failed', action: 'terminate', distro: 'Debian' }, ctx() as never)
+    expect(store.getState().wslActioningIds.has('Debian')).toBe(false)
+    expect(store.getState().wslActionResults['Debian']!.error).toMatch(/no distribution/)
+  })
+
+  it('a FAILED without a distro leaves action state alone', () => {
+    store.setState({ addServerError: vi.fn() } as never)
+    handleMessage({ type: 'session_error', code: 'WSL_ACTION_FAILED', message: 'boom' }, ctx() as never)
+    expect(store.getState().wslActioningIds.has('Ubuntu')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/dispatch-wsl-status.test.ts
+++ b/packages/dashboard/src/store/dispatch-wsl-status.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration test for the WSL2 distro survey wiring (#6138, epic #5530).
+ * Guards: snapshot REPLACES wslStatus + clears loading; malformed dropped
+ * without clearing loading; available:false (off Windows / no wsl.exe) is a
+ * valid state. Mirrors dispatch-emulator-status.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerWslStatusSnapshotMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return { connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {}, wslStatus: null, wslStatusLoading: true, messages: [] }
+}
+function snapshot(over: Partial<ServerWslStatusSnapshotMessage> = {}): ServerWslStatusSnapshotMessage {
+  return {
+    type: 'wsl_status_snapshot',
+    generatedAt: '2026-06-20T12:00:00.000Z',
+    available: true,
+    note: null,
+    defaultDistro: 'Ubuntu',
+    distros: [
+      { name: 'Ubuntu', state: 'Running', version: 2, isDefault: true },
+      { name: 'Debian', state: 'Stopped', version: 2, isDefault: false },
+    ],
+    ...over,
+  } as ServerWslStatusSnapshotMessage
+}
+
+describe('wsl status dispatch (#6138)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('applies wsl_status_snapshot and clears loading', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.wslStatus!.distros.map((d) => d.name)).toEqual(['Ubuntu', 'Debian'])
+    expect(s.wslStatus!.defaultDistro).toBe('Ubuntu')
+    expect(s.wslStatusLoading).toBe(false)
+  })
+
+  it('relays an available:false (off Windows / no wsl.exe) snapshot as a valid state', () => {
+    handleMessage(snapshot({ available: false, note: 'WSL is only available on Windows hosts.', defaultDistro: null, distros: [] }), ctx() as never)
+    const s = store.getState()
+    expect(s.wslStatus!.available).toBe(false)
+    expect(s.wslStatus!.distros).toEqual([])
+    expect(s.wslStatusLoading).toBe(false)
+  })
+
+  it('drops a malformed snapshot without clearing loading', () => {
+    handleMessage({ type: 'wsl_status_snapshot', generatedAt: '2026-06-20T12:00:00.000Z' }, ctx() as never)
+    expect(store.getState().wslStatus).toBeNull()
+    expect(store.getState().wslStatusLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -152,7 +152,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2647,6 +2647,18 @@ function handleEmulatorStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet
 }
 
 /**
+ * #6138 (epic #5530) — WSL2 distro survey `wsl_status_snapshot`: REPLACE the
+ * stored snapshot and clear the loading flag. Same defensive, full-replace,
+ * clear-loading-only-on-valid-parse contract as the iOS/Android siblings.
+ * `available:false` (off Windows / no wsl.exe) is a valid snapshot, not an error.
+ */
+function handleWslStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerWslStatusSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ wslStatus: parsed.data, wslStatusLoading: false });
+}
+
+/**
  * #5499 (epic #5498) — Integrations survey `integration_status_snapshot`:
  * REPLACE the stored survey and clear the loading flag. Same defensive,
  * full-replace, clear-loading-only-on-valid-parse contract as the host and
@@ -2953,6 +2965,44 @@ function handleEmulatorActionAck(msg: Record<string, unknown>, get: MsgGet, set:
 }
 
 /**
+ * #6138 (epic #5530) — resolve one WSL distro action target's pending state: drop
+ * the distro name from `wslActioningIds` and record the outcome in
+ * `wslActionResults`. Shared by the ack and the WSL_ACTION_FAILED session_error.
+ */
+function resolveWslAction(
+  get: MsgGet,
+  set: MsgSet,
+  distro: string,
+  result: { action: string; note: string | null; error: string | null },
+): void {
+  const pending = new Set(get().wslActioningIds);
+  pending.delete(distro);
+  set({
+    wslActioningIds: pending,
+    wslActionResults: { ...get().wslActionResults, [distro]: { ...result, at: Date.now() } },
+  });
+}
+
+/**
+ * #6138 — WSL action success ack: builds a human note ("Started" after a start,
+ * "Terminated" after a terminate) and clears the distro's pending state. The
+ * target id is the echoed distro name. A malformed ack is dropped (Zod) so the
+ * row keeps its honest pending state.
+ */
+function handleWslActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerWslActionAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const { action, distro, status } = parsed.data;
+  if (!distro) return;
+  // Append the echoed status only when it adds information — the happy path
+  // (start → "running", terminate → "stopped") is implied by the action.
+  const implied = action === 'start' ? 'running' : 'stopped';
+  const base = action === 'start' ? 'Started' : 'Terminated';
+  const note = status && status !== implied ? `${base} (${status})` : base;
+  resolveWslAction(get, set, distro, { action, note, error: null });
+}
+
+/**
  * #5547: a `summarize_session_result` resolves the pending summarize promise
  * (keyed by the echoed requestId) so the awaiting create-session flow opens
  * with the brief seeded. The failure half (SUMMARIZE_FAILED) rejects the same
@@ -3075,6 +3125,8 @@ const HANDLERS: Record<string, Handler> = {
   simulator_status_snapshot: handleSimulatorStatusSnapshot,
   // #6137 (epic #5530): Control Room Android emulator survey snapshot.
   emulator_status_snapshot: handleEmulatorStatusSnapshot,
+  // #6138 (epic #5530): Control Room WSL2 distro survey snapshot.
+  wsl_status_snapshot: handleWslStatusSnapshot,
   // #5499 (epic #5498): Control Room Integrations survey snapshot.
   integration_status_snapshot: handleIntegrationStatusSnapshot,
   skills_inventory_snapshot: handleSkillsInventorySnapshot,
@@ -3095,6 +3147,9 @@ const HANDLERS: Record<string, Handler> = {
   // #6137 (epic #5530): positive ack correlating an emulator_action (boot /
   // kill) request to its outcome.
   emulator_action_ack: handleEmulatorActionAck,
+  // #6138 (epic #5530): positive ack correlating a wsl_action (start /
+  // terminate) request to its outcome.
+  wsl_action_ack: handleWslActionAck,
   // #5547: one-shot session-summary result; resolves the pending summarize
   // promise so the create-session flow can open with the brief seeded.
   summarize_session_result: handleSummarizeSessionResult,
@@ -3857,6 +3912,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             error: parsed.message || 'Emulator action failed.',
           });
         }
+      } else if (parsed.code === 'WSL_ACTION_FAILED' && typeof msg.distro === 'string') {
+        // #6138: a failed wsl_action echoes the exact distro (+ action) — clear
+        // that distro's pending state and surface the reason inline (the generic
+        // branch below still raises the toast, matching the precedents).
+        resolveWslAction(get, set, msg.distro, {
+          action: typeof msg.action === 'string' ? msg.action : '',
+          note: null,
+          error: parsed.message || 'WSL action failed.',
+        });
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {
         const crashedId = parsed.sessionPatch.sessionId;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -629,9 +629,10 @@ export interface EmulatorActionResult {
 /**
  * #6138 (epic #5530) — outcome of the last WSL2 distro action (start /
  * terminate), kept for inline display. The target id is the distro `name`. A
- * successful `wsl_action_ack` records a human `note` (the new state) with
- * `error: null`; a WSL_ACTION_FAILED session_error records the message with
- * `note: null`. `at` is the local receipt time (epoch ms).
+ * successful `wsl_action_ack` records an action-oriented human `note`
+ * ("Started" / "Terminated", with the echoed status appended only when it's
+ * unexpected) and `error: null`; a WSL_ACTION_FAILED session_error records the
+ * message with `note: null`. `at` is the local receipt time (epoch ms).
  */
 export interface WslActionResult {
   action: string;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -626,6 +626,20 @@ export interface EmulatorActionResult {
   at: number;
 }
 
+/**
+ * #6138 (epic #5530) — outcome of the last WSL2 distro action (start /
+ * terminate), kept for inline display. The target id is the distro `name`. A
+ * successful `wsl_action_ack` records a human `note` (the new state) with
+ * `error: null`; a WSL_ACTION_FAILED session_error records the message with
+ * `note: null`. `at` is the local receipt time (epoch ms).
+ */
+export interface WslActionResult {
+  action: string;
+  note: string | null;
+  error: string | null;
+  at: number;
+}
+
 export interface ConnectionState {
   // Connection
   connectionPhase: ConnectionPhase;
@@ -978,6 +992,31 @@ export interface ConnectionState {
    * Replaced when the same target is actioned again.
    */
   emulatorActionResults: Record<string, EmulatorActionResult>;
+  /**
+   * #6138 (epic #5530) — Control Room WSL2 distro survey: the latest
+   * `wsl_status_snapshot` (distros + default), or null before the first one
+   * lands. `available:false` (off Windows / no wsl.exe) is a valid state.
+   * Replaced wholesale on each snapshot.
+   */
+  wslStatus: ServerWslStatusSnapshotMessage | null;
+  /**
+   * #6138 — true between dispatching a `wsl_status_request` and the matching
+   * snapshot arriving (Refresh spinner). Cleared when a VALID snapshot lands (a
+   * malformed payload is dropped and leaves this true).
+   */
+  wslStatusLoading: boolean;
+  /**
+   * #6138 — WSL distro names with an in-flight `wsl_action`: set when
+   * sendWslAction is called, cleared on the `wsl_action_ack` /
+   * WSL_ACTION_FAILED session_error. Keyed by distro so each row's buttons
+   * disable independently.
+   */
+  wslActioningIds: Set<string>;
+  /**
+   * #6138 — last WSL action outcome per distro name, for inline display.
+   * Replaced when the same distro is actioned again.
+   */
+  wslActionResults: Record<string, WslActionResult>;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;
@@ -1571,6 +1610,12 @@ export interface ConnectionState {
   // `emulatorStatusLoading` while in flight.
   requestEmulatorStatus: () => boolean;
 
+  // #6138 (epic #5530): request a WSL2 distro survey. Dispatches a
+  // `wsl_status_request`; the server replies with a single `wsl_status_snapshot`
+  // handled into `wslStatus`. Returns whether the message went on the wire
+  // (false = socket closed). Sets `wslStatusLoading` while in flight.
+  requestWslStatus: () => boolean;
+
   // #6139 (epic #5530): request a per-repo runtime config survey. Dispatches a
   // `repo_runtime_config_request`; the server replies with a single
   // `repo_runtime_config_snapshot` handled into `repoRuntimeConfig`. Returns
@@ -1674,6 +1719,17 @@ export interface ConnectionState {
   // actually went on the wire; an offline send (or a missing target) returns
   // false without queuing. Non-destructive, so no confirm gate.
   sendEmulatorAction: (action: 'boot' | 'kill', opts: { avd?: string; serial?: string; headless?: boolean }) => boolean;
+
+  // #6138 (epic #5530): start / terminate a WSL2 distro. `distro` names a distro
+  // the survey enumerated — the server re-surveys `wsl.exe -l -v` and re-validates
+  // it (the name is a lookup key, never a trusted target) plus state-gates the
+  // action (start requires Stopped, terminate requires Running). Dispatches a
+  // `wsl_action` tagged with a requestId the server echoes on the
+  // `wsl_action_ack` / WSL_ACTION_FAILED session_error. Marks the `distro` in
+  // `wslActioningIds` (dropping its stale result) ONLY when the message actually
+  // went on the wire; an offline send (or an empty distro) returns false without
+  // queuing. Non-destructive (no data loss), so no confirm gate.
+  sendWslAction: (action: 'start' | 'terminate', distro: string) => boolean;
 
   // #5547: request a server-side one-shot summary of a session's persisted
   // history (the sidebar "Summarize & start new session" action). Dispatches a

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -75,8 +75,9 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'activity_snapshot' / 'activity_delta' removed — the dashboard now handles
   // them (Control Room panel #5163); they moved to PLATFORM_SPECIFIC as
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5159.
-  'wsl_status_snapshot', // #6138 (epic #5530) — Control Room WSL2 distro survey reply. Server contract landed first; the dashboard slice that consumes it (the Device runtimes WSL panel) moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only (the mobile app has no Control Room).
-  'wsl_action_ack', // #6138 (epic #5530) — Control Room WSL2 start/terminate action ack. Server contract landed first (same server-first split as the survey above); the dashboard slice that consumes it moves this to PLATFORM_SPECIFIC as 'dashboard'. Host-level surface, dashboard-only.
+  // 'wsl_status_snapshot' / 'wsl_action_ack' removed — the dashboard now handles
+  // them (Control Room WSL panel #6138); they moved to PLATFORM_SPECIFIC as
+  // 'dashboard'. Windows-host-only surface; the mobile app has no Control Room.
   // 'host_status_snapshot' removed — the dashboard now handles it (Control
   // Room Host/Repo Status section #5175); it moved to PLATFORM_SPECIFIC as
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
@@ -165,6 +166,8 @@ const PLATFORM_SPECIFIC = {
   'simulator_action_ack': 'dashboard', // Control Room iOS simulator boot/shutdown action ack (#6136, epic #5530) — the dashboard consumes it to clear pending device state; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'emulator_status_snapshot': 'dashboard', // Control Room Android emulator survey reply (#6137, epic #5530) — the Device runtimes Android panel consumes it (devices + Ready-for-Maestro verdict); host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'emulator_action_ack': 'dashboard', // Control Room Android emulator boot/kill action ack (#6137, epic #5530) — the dashboard consumes it to clear pending device state; host-level surface, dashboard-only; mobile parity would be a fast-follow
+  'wsl_status_snapshot': 'dashboard', // Control Room WSL2 distro survey reply (#6138, epic #5530) — the Device runtimes WSL panel consumes it (handleWslStatusSnapshot). Windows-host-only surface; the mobile app has no Control Room.
+  'wsl_action_ack': 'dashboard', // Control Room WSL2 start/terminate action ack (#6138, epic #5530) — the dashboard consumes it to clear pending + record the outcome (handleWslActionAck). Windows-host-only surface.
   'skills_inventory_snapshot': 'dashboard', // Control Room Skills inventory survey reply (#5554, epic #5159) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'mailbox_status_snapshot': 'dashboard', // Control Room "Mailbox" tab survey reply (#5914 follow-up) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -152,6 +152,8 @@ const DASHBOARD_ONLY = new Set<string>([
   'simulator_action_ack',       // Control Room iOS simulator boot/shutdown action ack (#6136, epic #5530) — dashboard-only
   'emulator_status_snapshot',   // Control Room Android emulator survey (#6137, epic #5530) — dashboard-only (Device runtimes Android panel)
   'emulator_action_ack',        // Control Room Android emulator boot/kill action ack (#6137, epic #5530) — dashboard-only
+  'wsl_status_snapshot',        // Control Room WSL2 distro survey (#6138, epic #5530) — dashboard-only (Device runtimes WSL panel)
+  'wsl_action_ack',             // Control Room WSL2 start/terminate action ack (#6138, epic #5530) — dashboard-only
   'chroxy_context_hint_changed',// per-session context-hint toggle (#3805) — dashboard-only for v1
   'credential_test_result',     // Provider Credentials "Test" result (#3855) — dashboard-only
   'credentials_status',         // Provider Credentials pane (#3855) — dashboard-only
@@ -200,14 +202,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'wsl_status_snapshot',                  // #6138 (epic #5530) Control Room WSL2 distro survey —
-                                          //   server contract landed first; the Device runtimes WSL-panel
-                                          //   dashboard slice that consumes it is the tracked follow-up, then
-                                          //   this → DASHBOARD_ONLY
-  'wsl_action_ack',                       // #6138 (epic #5530) Control Room WSL2 start/terminate action ack —
-                                          //   server contract landed first (same server-first split as the
-                                          //   survey above); the dashboard slice that consumes it is the
-                                          //   tracked follow-up, then this → DASHBOARD_ONLY
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes epic #5530 (Control Room environment & runtime control). The server contract for the WSL2 distro survey + start/terminate actions shipped in #6173 (server-first split); this PR adds the dashboard panel that consumes it, the final sub-issue of the epic (9/9).

## Changes

- **`WslPanel`** — third panel in the Device runtimes tab, sibling of the iOS simulator (#6136) and Android emulator (#6137) panels. Renders the distro survey (name / WSL version / state + default-distro marker) with per-row **state-gated Start (Stopped) / Terminate (Running)** buttons. Windows-host-only: `available:false` (off Windows / no `wsl.exe`) is a first-class note with no table. Self-fetches the survey once on connect (the tab's generic auto-fetch only covers iOS), same pattern as the Android panel. Non-destructive (no data loss) → no confirm gate.
- **Store wiring** (`connection.ts` / `types.ts`): `wslStatus` / `wslStatusLoading` / `wslActioningIds` / `wslActionResults`; `requestWslStatus` + `sendWslAction` (wire-or-nothing, distro-keyed pending, drops stale result); `handleWslStatusSnapshot` (full-replace, clear-loading-only-on-valid-parse) + `handleWslActionAck` + `resolveWslAction` + the `WSL_ACTION_FAILED` `session_error` branch; socket-close / disconnect / forget resets (action buckets reset, snapshot kept).
- **Coverage guards**: promote `wsl_status_snapshot` / `wsl_action_ack` to dashboard-handled (protocol handler-coverage `PLATFORM_SPECIFIC: 'dashboard'`; store-core type-coverage `DASHBOARD_ONLY`), out of the server-first unhandled allowlists.

## Tests

- `dispatch-wsl-status.test.ts`, `dispatch-wsl-action.test.ts` (ack/failure/malformed dispatch).
- `WslPanel` render + action coverage in `DeviceRuntimesSection.test.tsx`.
- Local: dashboard 3995 tests + typecheck clean; store-core 1679 tests + typecheck; protocol 340 tests.

## Follow-up

- #6175 — live `wsl.exe` validation on a real Windows host (host-gated, acknowledged deferral).

Closes #6138