### PR TITLE
fix(server): async fs in the claude-tui hook-drain hot path (#6132)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,5 +1,9 @@
 import { randomBytes, randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'fs'
+// #6132 (HOL fix from #5337): the per-turn hook-drain hot path uses async fs so a
+// slow/stuck sink (FUSE/NFS, full disk, tmpwatch race) can't block the shared
+// event loop — which would freeze EVERY claude-tui session (the default provider).
+import { readdir, readFile, unlink } from 'fs/promises'
 import { homedir, tmpdir } from 'os'
 import { performance } from 'node:perf_hooks'
 import { dirname, join } from 'path'
@@ -2313,10 +2317,10 @@ export class ClaudeTuiSession extends BaseSession {
     // grow. This cumulative counter drives the heartbeat/exit diagnostics.
     let totalConsumed = 0
 
-    const drainHookFiles = () => {
+    const drainHookFiles = async () => {
       let entries
       try {
-        entries = readdirSync(this._sinkDir)
+        entries = await readdir(this._sinkDir)
       } catch (err) {
         // #5329 (IP-1): the sink lives under /tmp, which a tmpwatch sweep, a
         // tmpfs clear, or a manual rm can delete mid-turn. A silent return here
@@ -2348,7 +2352,7 @@ export class ClaudeTuiSession extends BaseSession {
         const full = join(this._sinkDir, name)
         let parsed
         try {
-          const raw = readFileSync(full, 'utf8')
+          const raw = await readFile(full, 'utf8')
           if (raw.length === 0) continue  // partial write — poll again
           parsed = JSON.parse(raw)
         } catch { continue }
@@ -2374,7 +2378,7 @@ export class ClaudeTuiSession extends BaseSession {
         // (rare), KEEP the name in _consumedFiles as the dedup guard so a later
         // readdir can't re-process it.
         try {
-          unlinkSync(full)
+          await unlink(full)
           this._consumedFiles.delete(name)
         } catch { /* leave the dedup guard in place */ }
       }
@@ -2400,7 +2404,7 @@ export class ClaudeTuiSession extends BaseSession {
       if (this._ptyExited) break
       // _handleHardTimeout clears _isBusy; bail out cleanly if it fired.
       if (!this._isBusy) break
-      drainHookFiles()
+      await drainHookFiles()
       pollIters++
       // Wedge instrumentation (#4678 follow-up): if the loop has been
       // running >= HOOK_HEARTBEAT_MS since the last heartbeat with no
@@ -2411,7 +2415,7 @@ export class ClaudeTuiSession extends BaseSession {
       if (now - lastHeartbeatMs >= ClaudeTuiSession.HOOK_HEARTBEAT_MS) {
         lastHeartbeatMs = now
         let sinkFileCount = 0
-        try { sinkFileCount = readdirSync(this._sinkDir).length } catch {}
+        try { sinkFileCount = (await readdir(this._sinkDir)).length } catch {}
         log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${totalConsumed} stopFound=${stopPayload ? 'yes' : 'no'})`)
       }
       if (stopPayload) break

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -754,6 +754,52 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._consumedFiles.size, 0, '_consumedFiles pruned after successful unlink')
     })
 
+    // #6132 (HOL fix from #5337): the drain hot path is now async fs, processing
+    // its file batch with `await` between each readFile/unlink. Lock in that the
+    // causal prefix ordering (pre- before post-, see #3902) survives the
+    // sequential-await rewrite — the regression the async migration most risks.
+    it('emits a multi-file drain pass in causal order (pre→post) under async fs (#6132)', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 5000, hardTimeoutMs: 5000,
+      })
+      session._processReady = true
+      session._sessionId = 'test-order-6132'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-order-'))
+      session._waitForPrompt = async () => true
+      const events = []
+      session.on('tool_start', (e) => events.push(`start:${e.toolUseId}`))
+      session.on('tool_result', (e) => events.push(`result:${e.toolUseId}`))
+      session._term = {
+        write: () => {
+          // Write post- BEFORE pre- on disk: a naive lex sort would order
+          // "post-" ahead of "pre-" ('o' < 'r'), which is exactly the #3902
+          // bug. The prefix-ordered drain must still emit tool_start (pre)
+          // before tool_result (post) even though both land in one async pass.
+          writeFileSync(join(session._sinkDir, 'post-x.json'), JSON.stringify({
+            tool_use_id: 'toolu_x', tool_name: 'Bash', tool_response: { stdout: 'ok' },
+          }))
+          writeFileSync(join(session._sinkDir, 'pre-x.json'), JSON.stringify({
+            tool_use_id: 'toolu_x', tool_name: 'Bash', tool_input: { command: 'ls' },
+          }))
+          writeFileSync(join(session._sinkDir, 'stop-z.json'), JSON.stringify({ last_assistant_message: 'done' }))
+        },
+        kill: () => {},
+      }
+      session.on('error', () => {})
+      await session.sendMessage('hi')
+
+      const startIdx = events.indexOf('start:toolu_x')
+      const resultIdx = events.indexOf('result:toolu_x')
+      assert.ok(startIdx >= 0, 'tool_start emitted')
+      assert.ok(resultIdx >= 0, 'tool_result emitted')
+      assert.ok(startIdx < resultIdx, 'tool_start precedes tool_result despite post- sorting first on disk')
+      // Every consumed hook in the pass is unlinked (async unlink path).
+      assert.ok(!existsSync(join(session._sinkDir, 'pre-x.json')), 'pre- unlinked')
+      assert.ok(!existsSync(join(session._sinkDir, 'post-x.json')), 'post- unlinked')
+      assert.ok(!existsSync(join(session._sinkDir, 'stop-z.json')), 'stop- unlinked')
+    })
+
     describe('sweepStaleSinkDirs', () => {
       const DEAD_PID = 4242424 // deterministically reported dead via the stub below
       let created


### PR DESCRIPTION
## Summary

The per-turn hook drain (`drainHookFiles`) is the dominant hot path for the **default provider** (claude-tui): it runs every 150ms while *any* session has an active turn, doing `readdirSync` / `readFileSync` / `unlinkSync` against per-session `/tmp` sinks. Node's event loop is single-threaded, so one slow/stuck filesystem (FUSE/NFS, full disk, tmpwatch race) on any session's sink **blocks every claude-tui session**. This is the head-of-line-blocking mechanism confirmed by the #5337 (IP-9) probe.

This migrates the hot path to `fs/promises`.

## Changes

- `drainHookFiles` is now `async` and `await`s `readdir` / `readFile` / `unlink`. The enclosing `hookPoll` loop already had `await` points (the 150ms inter-drain sleep), so the call site just becomes `await drainHookFiles()`.
- The in-loop heartbeat `readdirSync` (every 5s) moves to async `readdir` too — so the per-turn drain holds **no sync fs on the shared loop**.
- Dropped the now-unused `unlinkSync` import.

## Correctness (the migration's main risk)

`drainHookFiles` is the turn-completion detector for the default provider, so the drain stays a **sequential, prefix-ordered loop**. Preserved identically, now between `await` points instead of synchronously:
- Causal ordering — pre- (tool_start) before post- (tool_result), the #3902 bug.
- Empty-file "partial write — poll again" skip.
- Once-only `_consumedFiles` consumption + unlink-after-consume (drop-from-Set on success, keep-as-guard on unlink failure).

## Tests

- Full `claude-tui-session.test.js` suite green (**292 tests**, was 291) — the existing `sendMessage` suite drives the async drain end-to-end, validating turn detection is unchanged (acceptance #2).
- **New deterministic test**: writes `post-x.json` *before* `pre-x.json` on disk (lex order would put post- first — the #3902 trap) and asserts `tool_start` still precedes `tool_result` through the single async pass, plus all three files unlinked.
- `eslint` + `lint-session-opt-forwarding.sh` clean.

## Scope

Hot path only, per the issue's "migrate the hot path first" guidance. The MEDIUM (`readSessionStatus` `setInterval` poll) and LOW (sweep / sink-ensure) sites stay sync for now — they're lower-cadence and a separate, lower-risk follow-up.

### Acceptance
- [x] `drainHookFiles` hot path uses async fs; no sync fs on the shared loop in the per-turn drain.
- [x] Turn-completion detection unchanged (suite green + new ordering test).
- [~] Frozen-mount latency: structurally guaranteed by async fs (the loop yields on each await; a stuck sink can no longer block sibling sessions). A live frozen-mount repro is a manual/integration check, not a deterministic unit test.

Closes #6132
Relates to #5337 (epic #5338)