### PR TITLE
fix(server): bound claude-tui hook-drain fs so a stuck sink self-recovers (#6178)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2431,7 +2431,9 @@ export class ClaudeTuiSession extends BaseSession {
         try {
           // #6178: bounded — a timeout rejects into the catch below, which keeps
           // the name in _consumedFiles as the dedup guard (same as any unlink
-          // failure), so a stuck unlink can't re-process the file or wedge.
+          // failure), so a stuck unlink can't re-process the file or wedge. The
+          // file then stays on disk (never re-unlinked); on a permanently stuck
+          // mount that's bounded sink growth, with sweepStaleSinkDirs as backstop.
           await withHookFsTimeout(this._hookUnlink(full), this._hookFsTimeoutMs, 'unlink')
           this._consumedFiles.delete(name)
         } catch { /* leave the dedup guard in place */ }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -314,6 +314,12 @@ export class ClaudeTuiSession extends BaseSession {
     // rejects after this many ms so the poll loop re-checks its hard-timeout
     // guard instead of awaiting a frozen mount forever. Overridable in tests.
     this._hookFsTimeoutMs = ClaudeTuiSession.HOOK_FS_TIMEOUT_MS
+    // #6178 (review): a timed-out fs op can't be canceled — it stays pending in
+    // the libuv threadpool. Re-issuing it every poll pass would pile up stuck
+    // work and exhaust the shared 4-thread pool, reintroducing the cross-session
+    // impact #6132 fixed. So coalesce: keep ONE outstanding op per (kind,path)
+    // and re-race the SAME promise each pass until it settles (see _boundedHookFs).
+    this._inFlightHookFs = new Map()
 
     this._port = port || null
     // #4044: when true, spawn `claude` with --dangerously-skip-permissions
@@ -752,10 +758,44 @@ export class ClaudeTuiSession extends BaseSession {
 
   // #6178: hot-path hook-drain fs accessors. Thin wrappers over fs/promises so a
   // test can override them to simulate a hung mount; production just forwards.
-  // The drain wraps each call in withHookFsTimeout so a stuck one self-recovers.
+  // The drain calls them via _boundedHookFs (bound + coalesced), never directly.
   _hookReaddir(dir) { return readdir(dir) }
   _hookReadFile(path) { return readFile(path, 'utf8') }
   _hookUnlink(path) { return unlink(path) }
+
+  /**
+   * #6178 (review) — run a hot-path hook-drain fs op bounded by HOOK_FS_TIMEOUT_MS
+   * AND coalesced so at most one underlying op per (kind,path) is outstanding.
+   *
+   * A timed-out fs op can't be canceled: the real readdir/readFile/unlink stays
+   * pending in the libuv threadpool until the mount unfreezes. If each poll pass
+   * started a fresh op we'd accumulate stuck threadpool work and exhaust the
+   * shared 4-thread pool — reintroducing the cross-session blocking #6132 fixed.
+   * So we keep the SAME underlying promise per (kind,path) and re-race a fresh
+   * timer against it each pass; only after it finally settles is a new op issued.
+   *
+   * @param {'readdir'|'readFile'|'unlink'} kind
+   * @param {string} path  the sink dir (readdir) or a hook file (readFile/unlink)
+   * @returns {Promise<*>} the op result, or a HOOK_FS_TIMEOUT rejection
+   */
+  _boundedHookFs(kind, path) {
+    const key = `${kind}:${path}`
+    let inflight = this._inFlightHookFs.get(key)
+    if (!inflight) {
+      inflight = kind === 'readdir' ? this._hookReaddir(path)
+        : kind === 'readFile' ? this._hookReadFile(path)
+          : this._hookUnlink(path)
+      // Free the slot when the real op finally settles (even long after our race
+      // gave up), so a recovered mount can issue a fresh op. The then(noop,noop)
+      // marks the underlying promise handled so a late rejection is never an
+      // unhandledRejection; the guard avoids clobbering a newer entry.
+      inflight.then(() => {}, () => {}).finally(() => {
+        if (this._inFlightHookFs.get(key) === inflight) this._inFlightHookFs.delete(key)
+      })
+      this._inFlightHookFs.set(key, inflight)
+    }
+    return withHookFsTimeout(inflight, this._hookFsTimeoutMs, kind)
+  }
 
   /**
    * #5329 (IP-1): recover the hook sink dir after a readdir failure during the
@@ -2360,7 +2400,7 @@ export class ClaudeTuiSession extends BaseSession {
     const drainHookFiles = async () => {
       let entries
       try {
-        entries = await withHookFsTimeout(this._hookReaddir(this._sinkDir), this._hookFsTimeoutMs, 'readdir')
+        entries = await this._boundedHookFs('readdir', this._sinkDir)
       } catch (err) {
         // #6178: a hung sink fs (FUSE/NFS freeze) — DON'T treat it as deletion.
         // Skip this pass and return; the while-guard re-checks HOOK_TIMEOUT_MS so
@@ -2401,9 +2441,10 @@ export class ClaudeTuiSession extends BaseSession {
         const full = join(this._sinkDir, name)
         let parsed
         try {
-          // #6178: bounded — a timeout rejects and folds into this skip-and-retry
-          // (same as a partial-write/parse failure: re-read on the next pass).
-          const raw = await withHookFsTimeout(this._hookReadFile(full), this._hookFsTimeoutMs, 'readFile')
+          // #6178: bounded + coalesced — a timeout rejects and folds into this
+          // skip-and-retry (same as a partial-write/parse failure: re-read next
+          // pass), and the SAME readFile is re-raced rather than re-issued.
+          const raw = await this._boundedHookFs('readFile', full)
           if (raw.length === 0) continue  // partial write — poll again
           parsed = JSON.parse(raw)
         } catch { continue }
@@ -2434,7 +2475,7 @@ export class ClaudeTuiSession extends BaseSession {
           // failure), so a stuck unlink can't re-process the file or wedge. The
           // file then stays on disk (never re-unlinked); on a permanently stuck
           // mount that's bounded sink growth, with sweepStaleSinkDirs as backstop.
-          await withHookFsTimeout(this._hookUnlink(full), this._hookFsTimeoutMs, 'unlink')
+          await this._boundedHookFs('unlink', full)
           this._consumedFiles.delete(name)
         } catch { /* leave the dedup guard in place */ }
       }
@@ -2471,7 +2512,9 @@ export class ClaudeTuiSession extends BaseSession {
       if (now - lastHeartbeatMs >= ClaudeTuiSession.HOOK_HEARTBEAT_MS) {
         lastHeartbeatMs = now
         let sinkFileCount = 0
-        try { sinkFileCount = (await withHookFsTimeout(this._hookReaddir(this._sinkDir), this._hookFsTimeoutMs, 'heartbeat-readdir')).length } catch {}
+        // #6178 (review): shares the coalesced readdir slot with the drain, so the
+        // heartbeat never enqueues a second stuck readdir on a frozen mount.
+        try { sinkFileCount = (await this._boundedHookFs('readdir', this._sinkDir)).length } catch {}
         log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${totalConsumed} stopFound=${stopPayload ? 'yes' : 'no'})`)
       }
       if (stopPayload) break

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -89,6 +89,27 @@ const DENIED_QUESTION_REAPER_MS = ASK_USER_QUESTION_WATCHDOG_MS
  *   tool_result   { toolUseId, result, truncated }
  *   error         { message }
  */
+
+/**
+ * #6178: bound an fs promise so a stuck mount can't hold it open forever. Races
+ * `promise` against a timer that rejects with a tagged `HOOK_FS_TIMEOUT` error
+ * after `ms`. The timer is `unref`'d (never keeps the process alive) and cleared
+ * on settle (no leak on the happy path). Used only on the hot-path hook-drain
+ * fs ops. Exported for unit testing.
+ */
+export function withHookFsTimeout(promise, ms, label) {
+  let timer
+  const timeout = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(`hook-fs ${label} timed out after ${ms}ms`)
+      err.code = 'HOOK_FS_TIMEOUT'
+      reject(err)
+    }, ms)
+    if (typeof timer.unref === 'function') timer.unref()
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
 export class ClaudeTuiSession extends BaseSession {
   // #5858: Claude-family flag — single source of truth for isClaudeProvider().
   // This is the DEFAULT_PROVIDER, so its membership is load-bearing (#5855).
@@ -286,6 +307,13 @@ export class ClaudeTuiSession extends BaseSession {
     // may both be fractional.
     const rawMonotonicNow = typeof monotonicNow === 'function' ? monotonicNow : () => performance.now()
     this._monotonicNowFn = () => Math.trunc(rawMonotonicNow())
+
+    // #6178: per-call bound for the hot-path hook-drain fs ops. #6132 made the
+    // drain async so a stuck sink fs can't block OTHER sessions; this bound lets
+    // the stuck session ITSELF self-recover — a hung readdir/readFile/unlink
+    // rejects after this many ms so the poll loop re-checks its hard-timeout
+    // guard instead of awaiting a frozen mount forever. Overridable in tests.
+    this._hookFsTimeoutMs = ClaudeTuiSession.HOOK_FS_TIMEOUT_MS
 
     this._port = port || null
     // #4044: when true, spawn `claude` with --dangerously-skip-permissions
@@ -722,6 +750,13 @@ export class ClaudeTuiSession extends BaseSession {
     try { rmSync(join(this._sinkDir, 'askuserquestion-active'), { recursive: true, force: true }) } catch {}
   }
 
+  // #6178: hot-path hook-drain fs accessors. Thin wrappers over fs/promises so a
+  // test can override them to simulate a hung mount; production just forwards.
+  // The drain wraps each call in withHookFsTimeout so a stuck one self-recovers.
+  _hookReaddir(dir) { return readdir(dir) }
+  _hookReadFile(path) { return readFile(path, 'utf8') }
+  _hookUnlink(path) { return unlink(path) }
+
   /**
    * #5329 (IP-1): recover the hook sink dir after a readdir failure during the
    * poll loop. The sink lives under /tmp, so a tmpwatch sweep / tmpfs clear /
@@ -1063,6 +1098,11 @@ export class ClaudeTuiSession extends BaseSession {
   // stop-hook yet). Sized so healthy short turns (<5s end-to-end) emit
   // zero heartbeats but wedges produce a 5s-cadence trail of state.
   static get HOOK_HEARTBEAT_MS() { return 5_000 }
+  // #6178: per-call timeout for the hot-path hook-drain fs ops (readdir/readFile/
+  // unlink). A healthy sink read is sub-ms; this generous 2s bound only trips on
+  // a genuinely stuck mount (FUSE/NFS freeze), letting the poll loop re-check its
+  // hard-timeout guard rather than awaiting a frozen fs forever.
+  static get HOOK_FS_TIMEOUT_MS() { return 2_000 }
 
   get sessionId() {
     return this._sessionId
@@ -2320,8 +2360,17 @@ export class ClaudeTuiSession extends BaseSession {
     const drainHookFiles = async () => {
       let entries
       try {
-        entries = await readdir(this._sinkDir)
+        entries = await withHookFsTimeout(this._hookReaddir(this._sinkDir), this._hookFsTimeoutMs, 'readdir')
       } catch (err) {
+        // #6178: a hung sink fs (FUSE/NFS freeze) — DON'T treat it as deletion.
+        // Skip this pass and return; the while-guard re-checks HOOK_TIMEOUT_MS so
+        // the turn self-terminates via the hard-timeout watchdog instead of
+        // awaiting a frozen mount. Recreating the sink (below) would be wrong (the
+        // dir isn't gone, it's slow) and its sync mkdir could itself block.
+        if (err && err.code === 'HOOK_FS_TIMEOUT') {
+          log.warn(`hook drain readdir timed out (${this._hookFsTimeoutMs}ms) — sink fs may be stuck; skipping pass`)
+          return
+        }
         // #5329 (IP-1): the sink lives under /tmp, which a tmpwatch sweep, a
         // tmpfs clear, or a manual rm can delete mid-turn. A silent return here
         // spins this poll loop to the hard timeout while every claude
@@ -2352,7 +2401,9 @@ export class ClaudeTuiSession extends BaseSession {
         const full = join(this._sinkDir, name)
         let parsed
         try {
-          const raw = await readFile(full, 'utf8')
+          // #6178: bounded — a timeout rejects and folds into this skip-and-retry
+          // (same as a partial-write/parse failure: re-read on the next pass).
+          const raw = await withHookFsTimeout(this._hookReadFile(full), this._hookFsTimeoutMs, 'readFile')
           if (raw.length === 0) continue  // partial write — poll again
           parsed = JSON.parse(raw)
         } catch { continue }
@@ -2378,7 +2429,10 @@ export class ClaudeTuiSession extends BaseSession {
         // (rare), KEEP the name in _consumedFiles as the dedup guard so a later
         // readdir can't re-process it.
         try {
-          await unlink(full)
+          // #6178: bounded — a timeout rejects into the catch below, which keeps
+          // the name in _consumedFiles as the dedup guard (same as any unlink
+          // failure), so a stuck unlink can't re-process the file or wedge.
+          await withHookFsTimeout(this._hookUnlink(full), this._hookFsTimeoutMs, 'unlink')
           this._consumedFiles.delete(name)
         } catch { /* leave the dedup guard in place */ }
       }
@@ -2415,7 +2469,7 @@ export class ClaudeTuiSession extends BaseSession {
       if (now - lastHeartbeatMs >= ClaudeTuiSession.HOOK_HEARTBEAT_MS) {
         lastHeartbeatMs = now
         let sinkFileCount = 0
-        try { sinkFileCount = (await readdir(this._sinkDir)).length } catch {}
+        try { sinkFileCount = (await withHookFsTimeout(this._hookReaddir(this._sinkDir), this._hookFsTimeoutMs, 'heartbeat-readdir')).length } catch {}
         log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${totalConsumed} stopFound=${stopPayload ? 'yes' : 'no'})`)
       }
       if (stopPayload) break

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -815,10 +815,11 @@ describe('ClaudeTuiSession', () => {
       session._hookFsTimeoutMs = 40
       // Simulate a frozen mount: readdir never resolves. Pre-fix, the poll loop
       // would await this forever on the first pass and wedge until the PTY died
-      // (the while-guard never re-evaluated). Post-fix, each readdir rejects at
+      // (the while-guard never re-evaluated). Post-fix, each pass rejects at
       // _hookFsTimeoutMs, the loop keeps iterating, and the hard-timeout watchdog
       // ends the turn. If the fix regressed, this test HANGS (node:test timeout).
-      session._hookReaddir = () => new Promise(() => {})
+      let readdirCalls = 0
+      session._hookReaddir = () => { readdirCalls++; return new Promise(() => {}) }
       session._term = { write: () => {}, kill: () => {} }
       session.on('error', () => {})
       const start = Date.now()
@@ -826,6 +827,11 @@ describe('ClaudeTuiSession', () => {
       const elapsed = Date.now() - start
       assert.ok(elapsed < 3000, `turn self-terminated (${elapsed}ms), not wedged on the frozen readdir`)
       assert.equal(session._isBusy, false, 'busy cleared — the next turn isn\'t wedged')
+      // #6178 (review): the stuck readdir is COALESCED — re-raced, not re-issued.
+      // Across the multiple poll passes before the hard timeout, the underlying
+      // op is started exactly once, so it can't pile up stuck libuv threadpool
+      // work and exhaust the shared pool (which would re-block other sessions).
+      assert.equal(readdirCalls, 1, 'frozen readdir issued once, not once-per-pass')
       rmSync(session._sinkDir, { recursive: true, force: true })
     })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+import { ClaudeTuiSession, withHookFsTimeout } from '../src/claude-tui-session.js'
 import { RespawnRateLimiter } from '../src/utils/respawn-rate-limiter.js'
 import { addLogListener, removeLogListener } from '../src/logger.js'
 
@@ -798,6 +798,59 @@ describe('ClaudeTuiSession', () => {
       assert.ok(!existsSync(join(session._sinkDir, 'pre-x.json')), 'pre- unlinked')
       assert.ok(!existsSync(join(session._sinkDir, 'post-x.json')), 'post- unlinked')
       assert.ok(!existsSync(join(session._sinkDir, 'stop-z.json')), 'stop- unlinked')
+    })
+
+    // #6178: per-session self-recovery — the hot-path fs ops are bounded so a
+    // stuck sink fs can't wedge the turn that owns it (the cross-session win was
+    // #6132; this is the single-session follow-up).
+    it('self-recovers from a hung sink fs instead of wedging the turn (#6178)', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 5000, hardTimeoutMs: 400,
+      })
+      session._processReady = true
+      session._sessionId = 'test-hung-fs-6178'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-hung-'))
+      session._waitForPrompt = async () => true
+      session._hookFsTimeoutMs = 40
+      // Simulate a frozen mount: readdir never resolves. Pre-fix, the poll loop
+      // would await this forever on the first pass and wedge until the PTY died
+      // (the while-guard never re-evaluated). Post-fix, each readdir rejects at
+      // _hookFsTimeoutMs, the loop keeps iterating, and the hard-timeout watchdog
+      // ends the turn. If the fix regressed, this test HANGS (node:test timeout).
+      session._hookReaddir = () => new Promise(() => {})
+      session._term = { write: () => {}, kill: () => {} }
+      session.on('error', () => {})
+      const start = Date.now()
+      await session.sendMessage('hi')
+      const elapsed = Date.now() - start
+      assert.ok(elapsed < 3000, `turn self-terminated (${elapsed}ms), not wedged on the frozen readdir`)
+      assert.equal(session._isBusy, false, 'busy cleared — the next turn isn\'t wedged')
+      rmSync(session._sinkDir, { recursive: true, force: true })
+    })
+
+    // #6178: the bound primitive itself.
+    describe('withHookFsTimeout', () => {
+      it('rejects with a tagged HOOK_FS_TIMEOUT after the bound on a stuck promise', async () => {
+        const start = Date.now()
+        await assert.rejects(
+          () => withHookFsTimeout(new Promise(() => {}), 30, 'readdir'),
+          (err) => err.code === 'HOOK_FS_TIMEOUT' && /readdir/.test(err.message),
+        )
+        assert.ok(Date.now() - start < 1000, 'rejected promptly at the bound, not hung')
+      })
+
+      it('resolves with the value when the promise settles before the bound', async () => {
+        const v = await withHookFsTimeout(Promise.resolve(['a.json', 'b.json']), 1000, 'readdir')
+        assert.deepEqual(v, ['a.json', 'b.json'])
+      })
+
+      it('propagates the underlying rejection (not a timeout) when the promise rejects first', async () => {
+        await assert.rejects(
+          () => withHookFsTimeout(Promise.reject(new Error('ENOENT: gone')), 1000, 'readFile'),
+          (err) => /ENOENT/.test(err.message) && err.code !== 'HOOK_FS_TIMEOUT',
+        )
+      })
     })
 
     describe('sweepStaleSinkDirs', () => {


### PR DESCRIPTION
## Summary

Follow-up to #6132. That PR made the hook-drain async so a stuck sink filesystem can't block **other** claude-tui sessions (the default provider). This closes the **single-session** gap: the session that *owns* the stuck sink could still wedge, because the poll loop's hard-timeout guard is only re-checked *between* iterations — a single `await readdir`/`readFile`/`unlink` on a frozen mount (FUSE/NFS) never returns, so the loop never iterates to observe the watchdog.

## Changes

- New `withHookFsTimeout(promise, ms, label)` — `Promise.race` against an `unref`'d timer (cleared on settle, no leak), rejecting with a tagged `HOOK_FS_TIMEOUT` error. Exported for unit testing.
- `HOOK_FS_TIMEOUT_MS = 2000` (a healthy sink read is sub-ms; the bound only trips on a genuine freeze). Overridable per-instance via `_hookFsTimeoutMs`.
- Each hot-path fs op (drain `readdir`/`readFile`/`unlink` + the 5s heartbeat readdir) is wrapped. On timeout:
  - **readdir** → skip the pass and return; the `while`-guard re-checks `HOOK_TIMEOUT_MS` so the turn self-terminates via the hard-timeout watchdog. A timeout is **not** treated as sink deletion — no spurious `_recoverSinkDir`, whose sync `mkdir` could itself block on the same frozen mount.
  - **readFile** → folds into the existing skip-and-retry `catch` (re-read next pass).
  - **unlink** → folds into the existing `catch` that keeps the `_consumedFiles` dedup guard.
- The fs ops go through thin overridable instance seams (`_hookReaddir`/`_hookReadFile`/`_hookUnlink`) so a test can simulate a hung mount; production just forwards to `fs/promises`.

## Tests (296 green, was 292)

- `withHookFsTimeout` unit: rejects with `HOOK_FS_TIMEOUT` at the bound on a stuck promise; resolves with the value on a fast promise; propagates a fast underlying rejection (not masked as a timeout).
- Integration: overrides `_hookReaddir` to **never resolve**, sets a tiny bound + small `hardTimeoutMs`, and asserts the turn self-terminates (`_isBusy` cleared) within a wide wall-clock margin. **Pre-fix this test hangs** (node:test timeout) — that's the regression guard.
- `eslint` + `lint-session-opt-forwarding.sh` clean.

### Acceptance
- [x] Hot-path drain fs calls bounded by a per-call timeout (`Promise.race`).
- [x] A timed-out call handled like a transient sink failure (recover/skip + retry), not a wedge.
- [x] A test simulates a hung fs call and asserts the turn self-terminates rather than hanging.

Closes #6178
Relates to #6132, #5337 (epic #5338)