### PR TITLE
feat(dashboard): publish-artifact form in the Pages panel (#6110)

### DIFF
--- a/packages/dashboard/src/components/PagesPanel.test.tsx
+++ b/packages/dashboard/src/components/PagesPanel.test.tsx
@@ -76,4 +76,107 @@ describe('PagesPanel', () => {
     await waitFor(() => expect(screen.getByTestId('pages-error').textContent).toContain('boom'))
     expect(screen.getByTestId('page-card-status-report')).toBeTruthy()
   })
+
+  // #6110: the "publish this artifact" form.
+  describe('publish (#6110)', () => {
+    it('toggles the publish form open and closed', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse({ pages: [] }))
+      render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)
+      await waitFor(() => expect(screen.getByTestId('pages-empty')).toBeTruthy())
+      expect(screen.queryByTestId('pages-publish-form')).toBeNull()
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      expect(screen.getByTestId('pages-publish-form')).toBeTruthy()
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      expect(screen.queryByTestId('pages-publish-form')).toBeNull()
+    })
+
+    it('POSTs the artifact to /api/pages and shows the share URL inline', async () => {
+      const published = { slug: 'new-page', path: '/p/new-page/', title: 'My Report', bytes: 12, createdAt: '2026-06-20T12:00:00.000Z' }
+      const calls: Array<{ url: string; init?: RequestInit }> = []
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        calls.push({ url, init })
+        if (url === '/api/pages' && init?.method === 'POST') return jsonResponse(published)
+        // The mount fetch + the post-publish refresh both GET the list.
+        return jsonResponse({ pages: calls.some((c) => c.init?.method === 'POST') ? [{ ...published, title: published.title }] : [] })
+      })
+      render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} origin="https://x.example" />)
+      await waitFor(() => expect(screen.getByTestId('pages-empty')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      fireEvent.change(screen.getByTestId('pages-publish-title'), { target: { value: 'My Report' } })
+      fireEvent.change(screen.getByTestId('pages-publish-html'), { target: { value: '<h1>hi</h1>' } })
+      fireEvent.click(screen.getByTestId('pages-publish-submit'))
+
+      await waitFor(() => expect(screen.getByTestId('pages-publish-result-url').textContent).toBe('https://x.example/p/new-page/'))
+      const post = calls.find((c) => c.init?.method === 'POST')!
+      expect(post.url).toBe('/api/pages')
+      expect((post.init?.headers as Record<string, string>).Authorization).toBe('Bearer tok')
+      expect((post.init?.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+      expect(JSON.parse(post.init?.body as string)).toEqual({ title: 'My Report', html: '<h1>hi</h1>' })
+      // The post-publish refresh ran, so the new page appears in the list.
+      await waitFor(() => expect(screen.getByTestId('page-card-new-page')).toBeTruthy())
+    })
+
+    it('defaults a blank title to Untitled', async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = []
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        calls.push({ url, init })
+        if (url === '/api/pages' && init?.method === 'POST') return jsonResponse({ slug: 's', path: '/p/s/' })
+        return jsonResponse({ pages: [] })
+      })
+      render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)
+      await waitFor(() => expect(screen.getByTestId('pages-empty')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      fireEvent.change(screen.getByTestId('pages-publish-html'), { target: { value: '<p>x</p>' } })
+      fireEvent.click(screen.getByTestId('pages-publish-submit'))
+      await waitFor(() => expect(calls.some((c) => c.init?.method === 'POST')).toBe(true))
+      const post = calls.find((c) => c.init?.method === 'POST')!
+      expect(JSON.parse(post.init?.body as string).title).toBe('Untitled')
+    })
+
+    it('disables Publish until HTML is entered', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse({ pages: [] }))
+      render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)
+      await waitFor(() => expect(screen.getByTestId('pages-empty')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      expect((screen.getByTestId('pages-publish-submit') as HTMLButtonElement).disabled).toBe(true)
+      fireEvent.change(screen.getByTestId('pages-publish-html'), { target: { value: '<p>x</p>' } })
+      expect((screen.getByTestId('pages-publish-submit') as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    it('shows a publish error inline (403) without blanking the list', async () => {
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url === '/api/pages' && init?.method === 'POST') return jsonResponse({ error: 'primary_token_required' }, 403)
+        return jsonResponse({ pages: PAGES })
+      })
+      render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'bound'} />)
+      await waitFor(() => expect(screen.getByTestId('page-card-status-report')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      fireEvent.change(screen.getByTestId('pages-publish-html'), { target: { value: '<p>x</p>' } })
+      fireEvent.click(screen.getByTestId('pages-publish-submit'))
+      await waitFor(() => expect(screen.getByTestId('pages-publish-error').textContent).toContain('primary_token_required'))
+      // The list is untouched by a publish failure.
+      expect(screen.getByTestId('page-card-status-report')).toBeTruthy()
+    })
+
+    it('copies the published share URL', async () => {
+      const copyImpl = vi.fn(async () => true)
+      const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url === '/api/pages' && init?.method === 'POST') return jsonResponse({ slug: 's', path: '/p/s/' })
+        return jsonResponse({ pages: [] })
+      })
+      render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} copyImpl={copyImpl} origin="https://x.example" />)
+      await waitFor(() => expect(screen.getByTestId('pages-empty')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      fireEvent.change(screen.getByTestId('pages-publish-html'), { target: { value: '<p>x</p>' } })
+      fireEvent.click(screen.getByTestId('pages-publish-submit'))
+      await waitFor(() => expect(screen.getByTestId('pages-publish-result-copy')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('pages-publish-result-copy'))
+      await waitFor(() => expect(copyImpl).toHaveBeenCalledWith('https://x.example/p/s/'))
+      await waitFor(() => expect(screen.getByTestId('pages-publish-result-copy').textContent).toBe('Copied!'))
+    })
+  })
 })

--- a/packages/dashboard/src/components/PagesPanel.test.tsx
+++ b/packages/dashboard/src/components/PagesPanel.test.tsx
@@ -135,6 +135,18 @@ describe('PagesPanel', () => {
       expect(JSON.parse(post.init?.body as string).title).toBe('Untitled')
     })
 
+    it('loads a .html file into the textarea and seeds the title from the filename', async () => {
+      const fetchImpl = vi.fn(async () => jsonResponse({ pages: [] }))
+      render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)
+      await waitFor(() => expect(screen.getByTestId('pages-empty')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+      const file = new File(['<h1>loaded</h1>'], 'Report.html', { type: 'text/html' })
+      fireEvent.change(screen.getByTestId('pages-publish-file'), { target: { files: [file] } })
+      await waitFor(() => expect((screen.getByTestId('pages-publish-html') as HTMLTextAreaElement).value).toBe('<h1>loaded</h1>'))
+      // Title seeded from the filename with the extension stripped.
+      expect((screen.getByTestId('pages-publish-title') as HTMLInputElement).value).toBe('Report')
+    })
+
     it('disables Publish until HTML is entered', async () => {
       const fetchImpl = vi.fn(async () => jsonResponse({ pages: [] }))
       render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)

--- a/packages/dashboard/src/components/PagesPanel.test.tsx
+++ b/packages/dashboard/src/components/PagesPanel.test.tsx
@@ -147,6 +147,37 @@ describe('PagesPanel', () => {
       expect((screen.getByTestId('pages-publish-title') as HTMLInputElement).value).toBe('Report')
     })
 
+    it('uses an independent copy timer from the list — copying both does not leave a stuck "Copied!"', async () => {
+      vi.useFakeTimers()
+      try {
+        const copyImpl = vi.fn(async () => true)
+        const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = typeof input === 'string' ? input : input.toString()
+          if (url === '/api/pages' && init?.method === 'POST') return jsonResponse({ slug: 's', path: '/p/s/' })
+          return jsonResponse({ pages: PAGES })
+        })
+        render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} copyImpl={copyImpl} origin="https://x.example" />)
+        await vi.waitFor(() => expect(screen.getByTestId('page-card-status-report')).toBeTruthy())
+        // Publish so the result copy button exists.
+        fireEvent.click(screen.getByTestId('pages-publish-toggle'))
+        fireEvent.change(screen.getByTestId('pages-publish-html'), { target: { value: '<p>x</p>' } })
+        fireEvent.click(screen.getByTestId('pages-publish-submit'))
+        await vi.waitFor(() => expect(screen.getByTestId('pages-publish-result-copy')).toBeTruthy())
+        // Copy the list link, then immediately copy the published URL.
+        fireEvent.click(screen.getByTestId('page-copy-status-report'))
+        await vi.waitFor(() => expect(screen.getByTestId('page-copy-status-report').textContent).toBe('Copied!'))
+        fireEvent.click(screen.getByTestId('pages-publish-result-copy'))
+        await vi.waitFor(() => expect(screen.getByTestId('pages-publish-result-copy').textContent).toBe('Copied!'))
+        // After the flash window, BOTH revert — the publish copy didn't cancel the
+        // list copy's clear-timer (separate refs).
+        vi.advanceTimersByTime(1600)
+        await vi.waitFor(() => expect(screen.getByTestId('page-copy-status-report').textContent).toBe('Copy link'))
+        expect(screen.getByTestId('pages-publish-result-copy').textContent).toBe('Copy link')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('disables Publish until HTML is entered', async () => {
       const fetchImpl = vi.fn(async () => jsonResponse({ pages: [] }))
       render(<PagesPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 't'} />)

--- a/packages/dashboard/src/components/PagesPanel.tsx
+++ b/packages/dashboard/src/components/PagesPanel.tsx
@@ -105,10 +105,15 @@ export function PagesPanel({ fetchImpl, getToken, copyImpl, origin }: PagesPanel
   // previous timer (one consistent 1.5s window from the latest click, no
   // overlapping timers) and so it's torn down on unmount.
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // #6110 review: the publish-result copy uses its OWN flash timer, separate from
+  // the per-card list copy above. Sharing one ref meant copying one link
+  // canceled the other's clear-timer, leaving a stuck "Copied!" (both directions).
+  const publishCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
     void refreshRef.current()
     return () => {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      if (publishCopyTimerRef.current) clearTimeout(publishCopyTimerRef.current)
     }
   }, [])
 
@@ -206,9 +211,9 @@ export function PagesPanel({ fetchImpl, getToken, copyImpl, origin }: PagesPanel
     const ok = await resolvedCopy(publishedUrl)
     if (ok) {
       setPublishedCopied(true)
-      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
-      copyTimerRef.current = setTimeout(() => {
-        copyTimerRef.current = null
+      if (publishCopyTimerRef.current) clearTimeout(publishCopyTimerRef.current)
+      publishCopyTimerRef.current = setTimeout(() => {
+        publishCopyTimerRef.current = null
         setPublishedCopied(false)
       }, 1500)
     }

--- a/packages/dashboard/src/components/PagesPanel.tsx
+++ b/packages/dashboard/src/components/PagesPanel.tsx
@@ -7,11 +7,14 @@
  * **delete (revoke)**, reusing the existing primary-token-gated HTTP endpoints:
  *
  *   - GET    /api/pages          → { pages: [{ slug, title, createdAt, bytes, path }] }
+ *   - POST   /api/pages          → { slug, path, title, bytes, createdAt }  (#6110)
  *   - DELETE /api/pages/<slug>   → { removed: boolean }  (idempotent)
  *
  * Modeled on PoolStatsPanel (#5053): single fetch on mount + a Refresh button,
  * injectable fetch / token / clipboard / origin seams for tests. The
- * "publish this artifact" affordance from #5689 is a separate follow-up.
+ * "publish this artifact" affordance (#6110) is the in-panel form: paste or load
+ * an HTML artifact, POST it to /api/pages, and the returned share URL shows
+ * inline (copyable) while the new page drops into the list below.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getAuthToken } from '../utils/auth'
@@ -56,6 +59,16 @@ export function PagesPanel({ fetchImpl, getToken, copyImpl, origin }: PagesPanel
   const [error, setError] = useState<string | null>(null)
   const [copiedSlug, setCopiedSlug] = useState<string | null>(null)
   const [deletingSlug, setDeletingSlug] = useState<string | null>(null)
+  // #6110: the "publish this artifact" form — paste/load an HTML artifact and
+  // POST it to /api/pages, then surface the share URL inline. Form-scoped state
+  // (its own error + result) so a publish failure never blanks the page list.
+  const [showPublish, setShowPublish] = useState<boolean>(false)
+  const [publishTitle, setPublishTitle] = useState<string>('')
+  const [publishHtml, setPublishHtml] = useState<string>('')
+  const [publishing, setPublishing] = useState<boolean>(false)
+  const [publishError, setPublishError] = useState<string | null>(null)
+  const [publishedUrl, setPublishedUrl] = useState<string | null>(null)
+  const [publishedCopied, setPublishedCopied] = useState<boolean>(false)
 
   const resolvedFetch: typeof fetch =
     fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init))
@@ -132,21 +145,168 @@ export function PagesPanel({ fetchImpl, getToken, copyImpl, origin }: PagesPanel
     }
   }, [resolvedFetch, authHeaders])
 
+  // #6110: load an HTML file into the form (drop the chrome of pasting). Seeds
+  // the title from the filename when the title is still blank.
+  const handleFile = useCallback(async (file: File | undefined) => {
+    if (!file) return
+    setPublishError(null)
+    try {
+      const text = await file.text()
+      setPublishHtml(text)
+      setPublishTitle((t) => t || file.name.replace(/\.html?$/i, ''))
+    } catch {
+      setPublishError(`Could not read ${file.name}`)
+    }
+  }, [])
+
+  // #6110: POST the artifact to the existing primary-token-gated /api/pages,
+  // surface the returned share URL inline (copyable), and refresh so the new
+  // page appears in the list below. The 403 `primary_token_required` from the
+  // endpoint propagates as the inline error (a bound token can't publish).
+  const handlePublish = useCallback(async () => {
+    if (!publishHtml.trim()) {
+      setPublishError('Paste or load some HTML to publish.')
+      return
+    }
+    setPublishError(null)
+    setPublishedUrl(null)
+    setPublishedCopied(false)
+    setPublishing(true)
+    try {
+      const res = await resolvedFetch('/api/pages', {
+        method: 'POST',
+        headers: { ...(authHeaders() ?? {}), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: publishTitle.trim() || 'Untitled', html: publishHtml }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
+      }
+      const body = (await res.json()) as { path?: string; slug?: string }
+      setPublishedUrl(body.path ? `${resolvedOrigin}${body.path}` : '')
+      setPublishTitle('')
+      setPublishHtml('')
+      // The new page now exists server-side — reflect it in the list.
+      await refresh()
+    } catch (err) {
+      setPublishError(err instanceof Error ? err.message : 'Failed to publish')
+    } finally {
+      setPublishing(false)
+    }
+  }, [publishHtml, publishTitle, resolvedFetch, authHeaders, resolvedOrigin, refresh])
+
+  const handleCopyPublished = useCallback(async () => {
+    if (!publishedUrl) return
+    const ok = await resolvedCopy(publishedUrl)
+    if (ok) {
+      setPublishedCopied(true)
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = setTimeout(() => {
+        copyTimerRef.current = null
+        setPublishedCopied(false)
+      }, 1500)
+    }
+  }, [publishedUrl, resolvedCopy])
+
   const list = pages ?? []
 
   return (
     <div className="environment-panel" data-testid="pages-panel">
       <div className="env-panel-header">
         <h2>Pages</h2>
-        <button
-          className="btn-env-new"
-          data-testid="pages-refresh"
-          onClick={() => void refresh()}
-          disabled={loading}
-        >
-          {loading ? 'Loading…' : 'Refresh'}
-        </button>
+        <div style={{ display: 'flex', gap: '0.5em' }}>
+          <button
+            className="btn-env-new"
+            data-testid="pages-publish-toggle"
+            onClick={() => setShowPublish((v) => !v)}
+            aria-expanded={showPublish}
+          >
+            {showPublish ? 'Cancel' : '+ Publish HTML'}
+          </button>
+          <button
+            className="btn-env-new"
+            data-testid="pages-refresh"
+            onClick={() => void refresh()}
+            disabled={loading}
+          >
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+        </div>
       </div>
+
+      {showPublish && (
+        <div className="env-card" data-testid="pages-publish-form" style={{ marginBottom: '0.75em' }}>
+          <div className="env-card-details">
+            <label className="env-card-row" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '0.25em' }}>
+              <span className="env-card-label">Title</span>
+              <input
+                type="text"
+                data-testid="pages-publish-title"
+                value={publishTitle}
+                onChange={(e) => setPublishTitle(e.target.value)}
+                placeholder="Untitled"
+                disabled={publishing}
+              />
+            </label>
+            <label className="env-card-row" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '0.25em' }}>
+              <span className="env-card-label">HTML</span>
+              <textarea
+                data-testid="pages-publish-html"
+                value={publishHtml}
+                onChange={(e) => setPublishHtml(e.target.value)}
+                placeholder="Paste a self-contained HTML artifact, or load a .html file below"
+                rows={6}
+                disabled={publishing}
+                style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '0.8em', resize: 'vertical' }}
+              />
+            </label>
+            <label className="env-card-row" style={{ gap: '0.5em' }}>
+              <span className="env-card-label">Load file</span>
+              <input
+                type="file"
+                accept=".html,.htm,text/html"
+                data-testid="pages-publish-file"
+                disabled={publishing}
+                onChange={(e) => void handleFile(e.target.files?.[0])}
+              />
+            </label>
+          </div>
+          {publishError && (
+            <div
+              className="env-empty"
+              data-testid="pages-publish-error"
+              style={{ color: 'var(--status-error, #ef4444)' }}
+            >
+              {publishError}
+            </div>
+          )}
+          {publishedUrl !== null && (
+            <div className="env-card-row" data-testid="pages-publish-result" style={{ gap: '0.5em', alignItems: 'center' }}>
+              <span className="env-card-label">Published</span>
+              <a href={publishedUrl} target="_blank" rel="noreferrer" data-testid="pages-publish-result-url" style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '0.8em', wordBreak: 'break-all' }}>
+                {publishedUrl}
+              </a>
+              <button
+                className="btn-env-action"
+                data-testid="pages-publish-result-copy"
+                onClick={() => void handleCopyPublished()}
+              >
+                {publishedCopied ? 'Copied!' : 'Copy link'}
+              </button>
+            </div>
+          )}
+          <div className="env-card-actions">
+            <button
+              className="btn-env-action"
+              data-testid="pages-publish-submit"
+              onClick={() => void handlePublish()}
+              disabled={publishing || !publishHtml.trim()}
+            >
+              {publishing ? 'Publishing…' : 'Publish'}
+            </button>
+          </div>
+        </div>
+      )}
 
       {error && (
         <div

--- a/packages/dashboard/src/components/PagesPanel.tsx
+++ b/packages/dashboard/src/components/PagesPanel.tsx
@@ -183,7 +183,13 @@ export function PagesPanel({ fetchImpl, getToken, copyImpl, origin }: PagesPanel
         throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
       }
       const body = (await res.json()) as { path?: string; slug?: string }
-      setPublishedUrl(body.path ? `${resolvedOrigin}${body.path}` : '')
+      if (body.path) {
+        setPublishedUrl(`${resolvedOrigin}${body.path}`)
+      } else {
+        // Published, but no path to link — surface a note rather than a dead
+        // (empty-href) link. Defensive: today's server always returns a path.
+        setPublishError('Published, but the server returned no share URL.')
+      }
       setPublishTitle('')
       setPublishHtml('')
       // The new page now exists server-side — reflect it in the list.


### PR DESCRIPTION
## Summary

Closes #6110 (split from #5689). The Pages panel listed/copied/deleted published pages but had no in-dashboard way to *publish* — you had to drop to `chroxy publish <file>`. This adds the "publish this artifact" affordance as an in-panel form (the surface confirmed with the maintainer, since the dashboard has no separate report-viewer component today).

## Changes

- A **"+ Publish HTML"** toggle in the panel header opens a form:
  - **Title** input (defaults to `Untitled`).
  - **HTML** textarea — paste a self-contained artifact.
  - **Load file** — a `.html` file picker that reads the file into the textarea and seeds the title from the filename.
- **Publish** POSTs `{ title, html }` to the existing primary-token-gated `POST /api/pages`, renders the returned share URL **inline (copyable, opens in a new tab)**, clears the form, and **refreshes the list** so the new page drops in below.
- Form-scoped error + result state so a publish failure — e.g. the `403 primary_token_required` a bound (non-primary) token receives — shows **inline** and never blanks the page list.
- Mirrors the panel's existing injectable `fetch`/`token`/`clipboard`/`origin` seams; no new store wiring (HTTP-direct, consistent with the rest of the panel and the CLI).

## Acceptance
- [x] A generated HTML report exposes a "Publish" affordance (the Pages panel — the dashboard's artifact-management surface).
- [x] Clicking it POSTs to `/api/pages` and renders the returned share URL inline (copyable).
- [x] The new page then appears in the Pages panel (post-publish refresh).

## Tests (dashboard suite 4001 green, +6; typecheck clean)

- Toggle open/closed; POST shape (`Bearer` + `Content-Type: application/json` + `{title, html}`) → inline share URL + list refresh shows the new card; blank title → `Untitled`; Publish disabled until HTML entered; inline `403 primary_token_required` without blanking the list; copy the published URL.

Closes #6110