### PR TITLE
feat(store-core): cross-session activity aggregation selector (#6182)

### DIFF
--- a/packages/store-core/src/activity-reducer.ts
+++ b/packages/store-core/src/activity-reducer.ts
@@ -451,7 +451,9 @@ const emptyRollup = (): MutableRollup => ({ running: 0, blocked: 0, failed: 0, i
  * Build the cross-session mission-control aggregate from the activity reducer
  * state + the authoritative session list. The `sessions` list drives membership
  * (activity for a session not in the list is ignored); a session with no
- * activity is included as `idle`. Pure + deterministic for a stable input.
+ * activity is included as `idle`. A duplicate `sessionId` is counted ONCE
+ * (first occurrence wins) so the rollup that drives the "needs me" badge can't
+ * over-count on a malformed list. Pure + deterministic for a stable input.
  */
 export function selectCrossSessionActivity(
   state: ActivityState,
@@ -460,8 +462,11 @@ export function selectCrossSessionActivity(
   type MutableGroup = { worktree: boolean; sessions: CrossSessionGroupSession[]; rollup: MutableRollup }
   const byKey = new Map<string, MutableGroup>()
   const total = emptyRollup()
+  const seen = new Set<string>()
 
   for (const meta of sessions) {
+    if (seen.has(meta.sessionId)) continue // dedupe — first occurrence wins
+    seen.add(meta.sessionId)
     const status = deriveSessionStatus(selectSessionEntries(state, meta.sessionId))
     const key = typeof meta.cwd === 'string' && meta.cwd.trim() !== '' ? meta.cwd : ''
     let group = byKey.get(key)

--- a/packages/store-core/src/activity-reducer.ts
+++ b/packages/store-core/src/activity-reducer.ts
@@ -346,3 +346,153 @@ export function selectActivityTree(state: ActivityState, sessionId: string): rea
   }
   return result
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// Cross-session aggregation (#6182, Control Room v2 phase 2 / #5964)
+//
+// A selector layer ON TOP of the per-session reducer above: it turns the
+// all-sessions activity map into a mission-control rollup — sessions grouped by
+// repo+worktree, each group + the whole set carrying running/blocked/failed/idle
+// counts. The dashboard aggregate view (#6183) and the Tauri tray badge (#6184)
+// both consume THIS one selector so the surfaces can't drift.
+//
+// Design decisions (documented so consumers don't have to reverse-engineer):
+//   - GROUP KEY is the session's `cwd`. Chroxy has no separate repo-root field on
+//     SessionInfo, but a worktree always has a distinct cwd from its main
+//     checkout, so grouping by cwd is grouping by repo+worktree. A session with
+//     no cwd lands in the "" (Ungrouped) bucket, which sorts last.
+//   - PER-SESSION STATUS is derived from the session's activity entries with the
+//     priority blocked > running > failed > idle: "blocked-on-input" is the
+//     highest-attention signal (something needs you NOW), then actively running,
+//     then a terminal failure with nothing live, then idle (no/only-done work).
+//   - ROLLUPS count SESSIONS by derived status (not entries) — that's what
+//     "across sessions" / the tray "N need me" badge means.
+//   - ORDERING: groups by key ascending (Ungrouped last) so groups don't jump as
+//     sessions come and go; sessions within a group preserve the caller's input
+//     order (the tab order), which is deterministic for a stable input.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** A session's derived attention status, rolled up from its activity entries. */
+export type SessionDerivedStatus = 'running' | 'blocked' | 'failed' | 'idle'
+
+/** Counts of sessions in each derived status (per group, and overall). */
+export interface CrossSessionRollup {
+  readonly running: number
+  readonly blocked: number
+  readonly failed: number
+  readonly idle: number
+}
+
+/** Minimal per-session metadata the selector needs (a SessionInfo subset). */
+export interface CrossSessionMeta {
+  readonly sessionId: string
+  /** Working directory — the repo+worktree group key. Null/empty → Ungrouped. */
+  readonly cwd?: string | null
+  /** Display name; falls back to the sessionId. */
+  readonly name?: string
+  /** Whether this session runs in a git worktree (annotates the group). */
+  readonly worktree?: boolean
+}
+
+/** One session inside an aggregate group. */
+export interface CrossSessionGroupSession {
+  readonly sessionId: string
+  readonly name: string
+  readonly status: SessionDerivedStatus
+}
+
+/** Sessions sharing a repo+worktree (cwd), with their rollup. */
+export interface CrossSessionGroup {
+  /** The cwd, or '' for the Ungrouped bucket. */
+  readonly key: string
+  /** Human label: the last path segment of `key`, or 'Ungrouped'. */
+  readonly label: string
+  /** True if ANY session in the group is flagged as a worktree. */
+  readonly worktree: boolean
+  readonly sessions: readonly CrossSessionGroupSession[]
+  readonly rollup: CrossSessionRollup
+}
+
+/** The cross-session aggregate: ordered groups + the overall rollup. */
+export interface CrossSessionActivity {
+  readonly groups: readonly CrossSessionGroup[]
+  /** Sum across every session (drives the tray badge). */
+  readonly total: CrossSessionRollup
+}
+
+/**
+ * Derive a session's attention status from its activity entries.
+ * Priority: blocked > running > failed > idle (see the block comment above).
+ * A session with no entries (or only `done` entries) is `idle`.
+ */
+export function deriveSessionStatus(entries: readonly ActivityEntry[]): SessionDerivedStatus {
+  let hasRunning = false
+  let hasFailed = false
+  for (const e of entries) {
+    if (e.status === 'blocked') return 'blocked' // highest-attention; short-circuit
+    if (e.status === 'running') hasRunning = true
+    else if (e.status === 'failed') hasFailed = true
+  }
+  if (hasRunning) return 'running'
+  if (hasFailed) return 'failed'
+  return 'idle'
+}
+
+/** Last path segment of a cwd (handles POSIX and Windows separators). */
+function labelFromCwd(cwd: string): string {
+  const parts = cwd.split(/[/\\]/).filter(Boolean)
+  return parts.length > 0 ? parts[parts.length - 1]! : cwd
+}
+
+type MutableRollup = { running: number; blocked: number; failed: number; idle: number }
+const emptyRollup = (): MutableRollup => ({ running: 0, blocked: 0, failed: 0, idle: 0 })
+
+/**
+ * Build the cross-session mission-control aggregate from the activity reducer
+ * state + the authoritative session list. The `sessions` list drives membership
+ * (activity for a session not in the list is ignored); a session with no
+ * activity is included as `idle`. Pure + deterministic for a stable input.
+ */
+export function selectCrossSessionActivity(
+  state: ActivityState,
+  sessions: readonly CrossSessionMeta[],
+): CrossSessionActivity {
+  type MutableGroup = { worktree: boolean; sessions: CrossSessionGroupSession[]; rollup: MutableRollup }
+  const byKey = new Map<string, MutableGroup>()
+  const total = emptyRollup()
+
+  for (const meta of sessions) {
+    const status = deriveSessionStatus(selectSessionEntries(state, meta.sessionId))
+    const key = typeof meta.cwd === 'string' && meta.cwd.trim() !== '' ? meta.cwd : ''
+    let group = byKey.get(key)
+    if (group === undefined) {
+      group = { worktree: false, sessions: [], rollup: emptyRollup() }
+      byKey.set(key, group)
+    }
+    group.sessions.push({ sessionId: meta.sessionId, name: meta.name ?? meta.sessionId, status })
+    if (meta.worktree === true) group.worktree = true
+    group.rollup[status] += 1
+    total[status] += 1
+  }
+
+  // Named groups alpha-ascending; the Ungrouped ('') bucket always last.
+  const keys = [...byKey.keys()].sort((a, b) => {
+    if (a === b) return 0
+    if (a === '') return 1
+    if (b === '') return -1
+    return a < b ? -1 : 1
+  })
+
+  const groups: CrossSessionGroup[] = keys.map((key) => {
+    const g = byKey.get(key)!
+    return {
+      key,
+      label: key === '' ? 'Ungrouped' : labelFromCwd(key),
+      worktree: g.worktree,
+      sessions: g.sessions,
+      rollup: g.rollup,
+    }
+  })
+
+  return { groups, total }
+}

--- a/packages/store-core/src/cross-session-activity.test.ts
+++ b/packages/store-core/src/cross-session-activity.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import type { ActivityEntry, ServerActivitySnapshotMessage } from '@chroxy/protocol'
+import {
+  createEmptyActivityState,
+  applyActivitySnapshot,
+  deriveSessionStatus,
+  selectCrossSessionActivity,
+  type ActivityState,
+  type CrossSessionMeta,
+} from './activity-reducer'
+
+const T0 = 1_800_000_000_000
+
+function entry(over: Partial<ActivityEntry> & Pick<ActivityEntry, 'id'>): ActivityEntry {
+  const status = over.status ?? 'running'
+  const terminal = status === 'done' || status === 'failed'
+  return {
+    id: over.id,
+    kind: over.kind ?? 'tool',
+    label: over.label ?? `label-${over.id}`,
+    status,
+    startedAt: over.startedAt ?? T0,
+    endedAt: over.endedAt ?? (terminal ? T0 + 1000 : undefined),
+    parentId: over.parentId,
+    outputRef: over.outputRef,
+  }
+}
+
+function snapshot(sessionId: string, entries: ActivityEntry[]): ServerActivitySnapshotMessage {
+  return { type: 'activity_snapshot', sessionId, schemaVersion: 1, entries }
+}
+
+/** Build an ActivityState from { sessionId: entries[] }. */
+function stateOf(map: Record<string, ActivityEntry[]>): ActivityState {
+  let s = createEmptyActivityState()
+  for (const [sid, entries] of Object.entries(map)) {
+    s = applyActivitySnapshot(s, snapshot(sid, entries))
+  }
+  return s
+}
+
+describe('deriveSessionStatus', () => {
+  it('is idle with no entries or only done entries', () => {
+    expect(deriveSessionStatus([])).toBe('idle')
+    expect(deriveSessionStatus([entry({ id: 'a', status: 'done' })])).toBe('idle')
+  })
+  it('is running when any entry runs (and none blocked)', () => {
+    expect(deriveSessionStatus([entry({ id: 'a', status: 'done' }), entry({ id: 'b', status: 'running' })])).toBe('running')
+  })
+  it('is failed when a terminal failure exists and nothing is live', () => {
+    expect(deriveSessionStatus([entry({ id: 'a', status: 'failed' }), entry({ id: 'b', status: 'done' })])).toBe('failed')
+  })
+  it('blocked beats running and failed (highest attention)', () => {
+    expect(deriveSessionStatus([
+      entry({ id: 'a', status: 'running' }),
+      entry({ id: 'b', status: 'failed' }),
+      entry({ id: 'c', status: 'blocked' }),
+    ])).toBe('blocked')
+  })
+  it('running beats failed when both present', () => {
+    expect(deriveSessionStatus([entry({ id: 'a', status: 'failed' }), entry({ id: 'b', status: 'running' })])).toBe('running')
+  })
+})
+
+describe('selectCrossSessionActivity', () => {
+  const sessions: CrossSessionMeta[] = [
+    { sessionId: 's1', cwd: '/home/u/repo-a', name: 'A1' },
+    { sessionId: 's2', cwd: '/home/u/repo-a', name: 'A2', worktree: true },
+    { sessionId: 's3', cwd: '/home/u/repo-b', name: 'B1' },
+  ]
+
+  it('groups sessions by cwd and labels by last path segment', () => {
+    const state = stateOf({
+      s1: [entry({ id: 'e1', status: 'running' })],
+      s2: [entry({ id: 'e2', status: 'blocked' })],
+      s3: [entry({ id: 'e3', status: 'failed' })],
+    })
+    const agg = selectCrossSessionActivity(state, sessions)
+    expect(agg.groups.map((g) => g.key)).toEqual(['/home/u/repo-a', '/home/u/repo-b'])
+    expect(agg.groups.map((g) => g.label)).toEqual(['repo-a', 'repo-b'])
+    // repo-a has both s1 (running) + s2 (blocked); the group is flagged worktree (s2).
+    const a = agg.groups[0]!
+    expect(a.sessions.map((s) => s.sessionId)).toEqual(['s1', 's2'])
+    expect(a.worktree).toBe(true)
+    expect(a.rollup).toEqual({ running: 1, blocked: 1, failed: 0, idle: 0 })
+    const b = agg.groups[1]!
+    expect(b.worktree).toBe(false)
+    expect(b.rollup).toEqual({ running: 0, blocked: 0, failed: 1, idle: 0 })
+  })
+
+  it('computes the top-level total across all sessions', () => {
+    const state = stateOf({
+      s1: [entry({ id: 'e1', status: 'running' })],
+      s2: [entry({ id: 'e2', status: 'blocked' })],
+      s3: [entry({ id: 'e3', status: 'failed' })],
+    })
+    const agg = selectCrossSessionActivity(state, sessions)
+    expect(agg.total).toEqual({ running: 1, blocked: 1, failed: 1, idle: 0 })
+  })
+
+  it('a session with no activity is idle and still appears in its group', () => {
+    const state = stateOf({ s1: [entry({ id: 'e1', status: 'running' })] }) // s2/s3 have no activity
+    const agg = selectCrossSessionActivity(state, sessions)
+    expect(agg.total).toEqual({ running: 1, blocked: 0, failed: 0, idle: 2 })
+    const a = agg.groups.find((g) => g.key === '/home/u/repo-a')!
+    expect(a.sessions.find((s) => s.sessionId === 's2')!.status).toBe('idle')
+  })
+
+  it('puts sessions with no cwd into an Ungrouped bucket that sorts last', () => {
+    const state = stateOf({ x: [entry({ id: 'e', status: 'running' })] })
+    const agg = selectCrossSessionActivity(state, [
+      { sessionId: 'x', cwd: '/home/u/repo-z', name: 'Z' },
+      { sessionId: 'y', cwd: null, name: 'Y' },
+      { sessionId: 'w', name: 'W' }, // cwd omitted entirely
+      { sessionId: 'v', cwd: '   ', name: 'V' }, // whitespace-only → ungrouped
+    ])
+    const last = agg.groups[agg.groups.length - 1]!
+    expect(last.key).toBe('')
+    expect(last.label).toBe('Ungrouped')
+    expect(last.sessions.map((s) => s.sessionId)).toEqual(['y', 'w', 'v'])
+  })
+
+  it('falls back the session name to the sessionId when name is omitted', () => {
+    const agg = selectCrossSessionActivity(createEmptyActivityState(), [{ sessionId: 'sONLY', cwd: '/r' }])
+    expect(agg.groups[0]!.sessions[0]!.name).toBe('sONLY')
+  })
+
+  it('is empty (no groups, zero total) for an empty session list', () => {
+    const agg = selectCrossSessionActivity(stateOf({ s1: [entry({ id: 'e', status: 'running' })] }), [])
+    expect(agg.groups).toEqual([])
+    expect(agg.total).toEqual({ running: 0, blocked: 0, failed: 0, idle: 0 })
+  })
+
+  it('handles Windows-style cwd separators in the label', () => {
+    const agg = selectCrossSessionActivity(createEmptyActivityState(), [
+      { sessionId: 's', cwd: 'C:\\Users\\u\\repo-win', name: 'W' },
+    ])
+    expect(agg.groups[0]!.label).toBe('repo-win')
+  })
+
+  it('preserves caller (tab) order for sessions within a group', () => {
+    const metas: CrossSessionMeta[] = [
+      { sessionId: 'b', cwd: '/r', name: 'B' },
+      { sessionId: 'a', cwd: '/r', name: 'A' },
+      { sessionId: 'c', cwd: '/r', name: 'C' },
+    ]
+    const agg = selectCrossSessionActivity(createEmptyActivityState(), metas)
+    expect(agg.groups[0]!.sessions.map((s) => s.sessionId)).toEqual(['b', 'a', 'c'])
+  })
+})

--- a/packages/store-core/src/cross-session-activity.test.ts
+++ b/packages/store-core/src/cross-session-activity.test.ts
@@ -63,9 +63,12 @@ describe('deriveSessionStatus', () => {
 })
 
 describe('selectCrossSessionActivity', () => {
+  // Two tabs on the same repo (both the main checkout — realistic) + a third on
+  // another repo. The worktree flag is exercised separately with a realistically
+  // distinct-cwd worktree session (a worktree never shares its origin's cwd).
   const sessions: CrossSessionMeta[] = [
     { sessionId: 's1', cwd: '/home/u/repo-a', name: 'A1' },
-    { sessionId: 's2', cwd: '/home/u/repo-a', name: 'A2', worktree: true },
+    { sessionId: 's2', cwd: '/home/u/repo-a', name: 'A2' },
     { sessionId: 's3', cwd: '/home/u/repo-b', name: 'B1' },
   ]
 
@@ -78,14 +81,28 @@ describe('selectCrossSessionActivity', () => {
     const agg = selectCrossSessionActivity(state, sessions)
     expect(agg.groups.map((g) => g.key)).toEqual(['/home/u/repo-a', '/home/u/repo-b'])
     expect(agg.groups.map((g) => g.label)).toEqual(['repo-a', 'repo-b'])
-    // repo-a has both s1 (running) + s2 (blocked); the group is flagged worktree (s2).
+    // repo-a has both tabs s1 (running) + s2 (blocked).
     const a = agg.groups[0]!
     expect(a.sessions.map((s) => s.sessionId)).toEqual(['s1', 's2'])
-    expect(a.worktree).toBe(true)
+    expect(a.worktree).toBe(false)
     expect(a.rollup).toEqual({ running: 1, blocked: 1, failed: 0, idle: 0 })
     const b = agg.groups[1]!
     expect(b.worktree).toBe(false)
     expect(b.rollup).toEqual({ running: 0, blocked: 0, failed: 1, idle: 0 })
+  })
+
+  it('flags a group as worktree from a realistically distinct-cwd worktree session', () => {
+    // A worktree session has its OWN cwd (never the origin checkout's), so it
+    // forms its own group; that group is flagged worktree.
+    const agg = selectCrossSessionActivity(createEmptyActivityState(), [
+      { sessionId: 'main', cwd: '/home/u/repo-a', name: 'main' },
+      { sessionId: 'wt', cwd: '/home/u/.chroxy/worktrees/repo-a-feat', name: 'feat', worktree: true },
+    ])
+    const main = agg.groups.find((g) => g.key === '/home/u/repo-a')!
+    const wt = agg.groups.find((g) => g.key === '/home/u/.chroxy/worktrees/repo-a-feat')!
+    expect(main.worktree).toBe(false)
+    expect(wt.worktree).toBe(true)
+    expect(wt.label).toBe('repo-a-feat')
   })
 
   it('computes the top-level total across all sessions', () => {

--- a/packages/store-core/src/cross-session-activity.test.ts
+++ b/packages/store-core/src/cross-session-activity.test.ts
@@ -147,4 +147,21 @@ describe('selectCrossSessionActivity', () => {
     const agg = selectCrossSessionActivity(createEmptyActivityState(), metas)
     expect(agg.groups[0]!.sessions.map((s) => s.sessionId)).toEqual(['b', 'a', 'c'])
   })
+
+  it('counts a duplicate sessionId once (first occurrence wins)', () => {
+    const state = stateOf({ dup: [entry({ id: 'e', status: 'blocked' })] })
+    const agg = selectCrossSessionActivity(state, [
+      { sessionId: 'dup', cwd: '/r', name: 'first' },
+      { sessionId: 'dup', cwd: '/r', name: 'second' },
+    ])
+    expect(agg.groups[0]!.sessions.map((s) => s.name)).toEqual(['first'])
+    expect(agg.groups[0]!.rollup).toEqual({ running: 0, blocked: 1, failed: 0, idle: 0 })
+    expect(agg.total).toEqual({ running: 0, blocked: 1, failed: 0, idle: 0 })
+  })
+
+  it('labels a separators-only cwd as the raw cwd (a distinct real group, not Ungrouped)', () => {
+    const agg = selectCrossSessionActivity(createEmptyActivityState(), [{ sessionId: 's', cwd: '/', name: 'root' }])
+    expect(agg.groups[0]!.key).toBe('/')
+    expect(agg.groups[0]!.label).toBe('/')
+  })
 })

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -258,6 +258,13 @@ export type {
   SessionActivityState,
   ActivityState,
   ActivityTreeNode,
+  // #6182 (Control Room v2 phase 2 / #5964): cross-session aggregation selector.
+  SessionDerivedStatus,
+  CrossSessionRollup,
+  CrossSessionMeta,
+  CrossSessionGroupSession,
+  CrossSessionGroup,
+  CrossSessionActivity,
 } from './activity-reducer'
 
 // #5163: re-export the wire-level activity types from the protocol through the
@@ -279,6 +286,9 @@ export {
   clearSessionActivity,
   selectSessionEntries,
   selectActivityTree,
+  // #6182: cross-session aggregation (group by repo+worktree + rollups).
+  deriveSessionStatus,
+  selectCrossSessionActivity,
 } from './activity-reducer'
 
 // #4242: cheap structural gate for `JSON.parse` on streaming


### PR DESCRIPTION
## Summary

Foundation slice for Control Room v2 phase 2 (#5964, epic #5422), decomposed today. Adds a selector layer on top of the per-session activity reducer (#5162) that turns the all-sessions activity map into a mission-control rollup — so the dashboard aggregate view (#6183) and the Tauri tray badge (#6184) can consume one shared, tested source of truth instead of each re-deriving it.

Pure store-core; no UI or server changes; extends the existing reducer rather than a parallel path (per the issue's guidance).

## API

- **`selectCrossSessionActivity(state, sessions)`** → `{ groups, total }`:
  - Sessions grouped by **repo + worktree**, keyed by `cwd` (chroxy has no separate repo-root field on `SessionInfo`, but a worktree always has a distinct `cwd`, so cwd-grouping *is* repo+worktree grouping). A session with no cwd lands in an **Ungrouped** bucket that sorts last.
  - Each group + the overall `total` carry **session counts** by status: `running / blocked / failed / idle`.
  - **Ordering:** groups by key ascending (Ungrouped last) so groups don't jump as sessions come/go; sessions keep caller (tab) order — deterministic for a stable input.
- **`deriveSessionStatus(entries)`** → per-session attention status, priority **blocked > running > failed > idle** (blocked-on-input is the highest "needs me" signal; no/only-`done` work is idle).

## Design decisions (documented in code)
- Group key = `cwd`; rollups count **sessions** (not entries) — that's what "across sessions" / the tray "N need me" badge means.
- Membership is driven by the authoritative `sessions` list; activity for a session not in the list is ignored; a session with no activity is included as `idle`.

## Tests (store-core suite 1692 green, +13; typecheck clean)
`deriveSessionStatus` priority matrix; grouping + labels (incl. Windows `\` separators); per-group + total rollups; no-activity→idle; the Ungrouped bucket (null / omitted / whitespace cwd); name→sessionId fallback; empty list; tab-order preservation. The store-core contract-fixture / coverage lints pass within the full suite.

Part of #5964. Closes #6182.