### PR TITLE
feat(dashboard): cross-session mission-control view in Control Room (#6183)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -37,6 +37,9 @@ function resetStore(over: Record<string, unknown> = {}) {
     requestHostStatus: requestHostStatusMock,
     requestRunnerStatus: requestRunnerStatusMock,
     requestIntegrationStatus: requestIntegrationStatusMock,
+    // #6183: the mission-control tab's wrapper reads these from the store.
+    sessions: [],
+    activity: { bySession: {} },
     ...over,
   }
 }
@@ -73,8 +76,13 @@ vi.mock('./SettingsPanel', () => ({
     </div>
   ),
 }))
+// #6183: stub the (store-backed) mission-control view so the tab-shell test stays
+// focused on routing (the descriptor↔render-branch wiring), not the aggregate.
+vi.mock('./CrossSessionMissionControl', () => ({
+  CrossSessionMissionControl: () => <div data-testid="stub-mission-control">mission-control</div>,
+}))
 
-import { ControlRoomView, CONTROL_ROOM_STALENESS_MS } from './ControlRoomView'
+import { ControlRoomView, CONTROL_ROOM_STALENESS_MS, CONTROL_ROOM_TABS } from './ControlRoomView'
 
 const KEY = 'chroxy_cr_tab'
 
@@ -111,6 +119,28 @@ describe('ControlRoomView', () => {
     expect(screen.queryByTestId('stub-repos')).toBeNull()
     expect(screen.getByTestId('cr-tab-runners').getAttribute('aria-selected')).toBe('true')
     expect(localStorage.getItem(KEY)).toBe('runners')
+  })
+
+  it('switches to the mission-control section when its tab is clicked, and persists it (#6183)', () => {
+    render(<ControlRoomView />)
+    fireEvent.click(screen.getByTestId('cr-tab-mission-control'))
+    expect(screen.getByTestId('stub-mission-control')).toBeTruthy()
+    expect(screen.queryByTestId('stub-repos')).toBeNull()
+    expect(screen.getByTestId('cr-tab-mission-control').getAttribute('aria-selected')).toBe('true')
+    expect(localStorage.getItem(KEY)).toBe('mission-control')
+  })
+
+  it('exposes a tab for every CONTROL_ROOM_TABS descriptor (no deep-linkable-but-missing tab)', () => {
+    // #6183 review: lightweight guard against descriptor drift — every descriptor
+    // must surface a clickable tab button. (A full render-each-panel loop isn't
+    // feasible here: the unmocked survey sections need store fields the minimal
+    // mock omits; the per-tab routing is covered by the targeted tab tests above
+    // + the mission-control test, and ControlRoomView.registry.test.ts covers the
+    // derived-set consistency.)
+    render(<ControlRoomView />)
+    for (const t of CONTROL_ROOM_TABS) {
+      expect(screen.getByTestId(`cr-tab-${t.key}`)).toBeTruthy()
+    }
   })
 
   it('switches to the integrations section when its tab is clicked, and persists it', () => {

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -48,6 +48,7 @@ import { DeviceRuntimesSection } from './DeviceRuntimesSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { SkillsInventorySection } from './SkillsInventorySection'
 import { MailboxPanel } from './MailboxPanel'
+import { CrossSessionMissionControl } from './CrossSessionMissionControl'
 import { SettingsContent } from './SettingsPanel'
 import { useConnectionStore } from '../store/connection'
 import type { ConnectionState } from '../store/types'
@@ -222,6 +223,16 @@ export const CONTROL_ROOM_TABS = [
     loadingKey: 'mailboxStatusLoading',
     requestKey: 'requestMailboxStatus',
   },
+  // #6183 (Control Room v2 phase 2 / #5964): cross-session mission control — the
+  // aggregate, read-only view over EVERY session's activity tree, grouped by
+  // repo+worktree with running/blocked/failed rollups. `survey: false`: it reads
+  // the live activity reducer state already in the store (fed by the
+  // activity_snapshot/delta handlers), so there's no per-tab snapshot to fetch.
+  {
+    key: 'mission-control',
+    label: 'Mission control',
+    survey: false,
+  },
   // #5544: the Settings tab converges the scattered preference surfaces
   // (notification categories, appearance, session defaults, BYOK, Tauri desktop
   // options) into the Control Room. It embeds `SettingsContent` — the same body
@@ -296,6 +307,26 @@ function isStale(generatedAt: string | undefined): boolean {
   const ms = Date.parse(generatedAt)
   if (Number.isNaN(ms)) return true
   return Date.now() - ms >= CONTROL_ROOM_STALENESS_MS
+}
+
+/**
+ * #6183: thin store-connected wrapper for the cross-session mission-control view.
+ * Reads the live activity reducer state + the session list from the store and
+ * maps each SessionInfo to the selector's minimal `CrossSessionMeta`. Re-renders
+ * (recomputing the aggregate) whenever activity or the session list changes, so
+ * the rollups stay live. The pure `CrossSessionMissionControl` holds all the
+ * rendering/grouping logic and is tested in isolation.
+ */
+function MissionControlTab() {
+  const activity = useConnectionStore((s) => s.activity)
+  const sessions = useConnectionStore((s) => s.sessions)
+  const metas = sessions.map((s) => ({
+    sessionId: s.sessionId,
+    cwd: s.cwd,
+    name: s.name,
+    worktree: s.worktree,
+  }))
+  return <CrossSessionMissionControl activity={activity} sessions={metas} />
 }
 
 export interface ControlRoomViewProps {
@@ -451,6 +482,8 @@ export function ControlRoomView({
         <SkillsInventorySection />
       ) : tab === 'mailbox' ? (
         <MailboxPanel />
+      ) : tab === 'mission-control' ? (
+        <MissionControlTab />
       ) : (
         // #5544: scrollable wrapper so the (often long) settings body scrolls
         // inside the tab panel rather than the whole Control Room view. The

--- a/packages/dashboard/src/components/CrossSessionMissionControl.test.tsx
+++ b/packages/dashboard/src/components/CrossSessionMissionControl.test.tsx
@@ -67,7 +67,10 @@ describe('CrossSessionMissionControl', () => {
       { sessionId: 'wt', cwd: '/home/u/.chroxy/worktrees/repo-a-feat', name: 'feat', worktree: true },
     ]} now={NOW} />)
     const groups = screen.getAllByTestId('mission-control-group')
-    // repo-a (named) sorts before the worktrees path; worktree badge only on the wt group.
+    // Two distinct cwds → two groups; the worktree badge appears on exactly the
+    // wt group (asserted by data-group-key below, not by order — the selector
+    // sorts by full cwd path so the `.chroxy/worktrees/...` path actually sorts
+    // before `/home/u/repo-a`, which is irrelevant to this assertion).
     const worktreeBadges = screen.getAllByTestId('mission-control-group-worktree')
     expect(worktreeBadges.length).toBe(1)
     // The flagged group is the one containing the wt session.

--- a/packages/dashboard/src/components/CrossSessionMissionControl.test.tsx
+++ b/packages/dashboard/src/components/CrossSessionMissionControl.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ActivityEntry, ActivityState, CrossSessionMeta } from '@chroxy/store-core'
+import { createEmptyActivityState, applyActivitySnapshot } from '@chroxy/store-core'
+import { CrossSessionMissionControl } from './CrossSessionMissionControl'
+
+const T0 = 1_800_000_000_000
+const NOW = () => T0 + 5000
+
+function entry(over: Partial<ActivityEntry> & Pick<ActivityEntry, 'id'>): ActivityEntry {
+  const status = over.status ?? 'running'
+  const terminal = status === 'done' || status === 'failed'
+  return {
+    id: over.id,
+    kind: over.kind ?? 'tool',
+    label: over.label ?? `label-${over.id}`,
+    status,
+    startedAt: over.startedAt ?? T0,
+    endedAt: over.endedAt ?? (terminal ? T0 + 1000 : undefined),
+    parentId: over.parentId,
+    outputRef: over.outputRef,
+  }
+}
+
+function stateOf(map: Record<string, ActivityEntry[]>): ActivityState {
+  let s = createEmptyActivityState()
+  for (const [sid, entries] of Object.entries(map)) {
+    s = applyActivitySnapshot(s, { type: 'activity_snapshot', sessionId: sid, schemaVersion: 1, entries })
+  }
+  return s
+}
+
+const SESSIONS: CrossSessionMeta[] = [
+  { sessionId: 's1', cwd: '/home/u/repo-a', name: 'A1' },
+  { sessionId: 's2', cwd: '/home/u/repo-a', name: 'A2' },
+  { sessionId: 's3', cwd: '/home/u/repo-b', name: 'B1' },
+]
+
+describe('CrossSessionMissionControl', () => {
+  afterEach(() => cleanup())
+
+  it('renders the empty state when there are no sessions', () => {
+    render(<CrossSessionMissionControl activity={createEmptyActivityState()} sessions={[]} now={NOW} />)
+    expect(screen.getByTestId('mission-control-empty')).toBeTruthy()
+    expect(screen.queryByTestId('mission-control-group')).toBeNull()
+  })
+
+  it('groups sessions by repo+worktree with labels and the overall total', () => {
+    const state = stateOf({
+      s1: [entry({ id: 'e1', status: 'running' })],
+      s2: [entry({ id: 'e2', status: 'blocked' })],
+      s3: [entry({ id: 'e3', status: 'failed' })],
+    })
+    render(<CrossSessionMissionControl activity={state} sessions={SESSIONS} now={NOW} />)
+    const labels = screen.getAllByTestId('mission-control-group-label').map((n) => n.textContent)
+    expect(labels).toEqual(['repo-a', 'repo-b'])
+    // Overall total: 1 running + 1 blocked + 1 failed.
+    expect(screen.getByTestId('mission-control-total-running').textContent).toContain('1')
+    expect(screen.getByTestId('mission-control-total-blocked').textContent).toContain('1')
+    expect(screen.getByTestId('mission-control-total-failed').textContent).toContain('1')
+  })
+
+  it('renders per-group rollups and a worktree badge only where flagged', () => {
+    const state = stateOf({ wt: [entry({ id: 'e', status: 'blocked' })] })
+    render(<CrossSessionMissionControl activity={state} sessions={[
+      { sessionId: 'main', cwd: '/home/u/repo-a', name: 'main' },
+      { sessionId: 'wt', cwd: '/home/u/.chroxy/worktrees/repo-a-feat', name: 'feat', worktree: true },
+    ]} now={NOW} />)
+    const groups = screen.getAllByTestId('mission-control-group')
+    // repo-a (named) sorts before the worktrees path; worktree badge only on the wt group.
+    const worktreeBadges = screen.getAllByTestId('mission-control-group-worktree')
+    expect(worktreeBadges.length).toBe(1)
+    // The flagged group is the one containing the wt session.
+    const wtGroup = groups.find((g) => g.getAttribute('data-group-key') === '/home/u/.chroxy/worktrees/repo-a-feat')!
+    expect(wtGroup.querySelector('[data-testid="mission-control-group-worktree"]')).toBeTruthy()
+  })
+
+  it('shows a derived status badge per session', () => {
+    const state = stateOf({
+      s1: [entry({ id: 'e1', status: 'running' })],
+      s2: [entry({ id: 'e2', status: 'blocked' })],
+    })
+    render(<CrossSessionMissionControl activity={state} sessions={SESSIONS} now={NOW} />)
+    expect(screen.getByTestId('mission-control-session-status-s1').textContent).toBe('Running')
+    expect(screen.getByTestId('mission-control-session-status-s2').textContent).toBe('Blocked')
+    expect(screen.getByTestId('mission-control-session-status-s3').textContent).toBe('Idle') // no activity
+  })
+
+  it('expands a session into its v1 ActivityTree (no regression — reuses the tree)', () => {
+    const state = stateOf({ s1: [entry({ id: 'tool-1', status: 'running', label: 'grep src' })] })
+    render(<CrossSessionMissionControl activity={state} sessions={SESSIONS} now={NOW} />)
+    // Collapsed: no tree yet.
+    expect(screen.queryByTestId('mission-control-session-tree-s1')).toBeNull()
+    fireEvent.click(screen.getByTestId('mission-control-session-toggle-s1'))
+    // Expanded: the per-session ActivityTree renders the entry from the v1 path.
+    expect(screen.getByTestId('mission-control-session-tree-s1')).toBeTruthy()
+    expect(screen.getByTestId('control-room-entry-label-tool-1').textContent).toBe('grep src')
+    // Collapse again.
+    fireEvent.click(screen.getByTestId('mission-control-session-toggle-s1'))
+    expect(screen.queryByTestId('mission-control-session-tree-s1')).toBeNull()
+  })
+
+  it('orders named groups ascending with the Ungrouped bucket last', () => {
+    render(<CrossSessionMissionControl activity={createEmptyActivityState()} sessions={[
+      { sessionId: 'z', cwd: '/home/u/repo-z', name: 'Z' },
+      { sessionId: 'a', cwd: '/home/u/repo-a', name: 'A' },
+      { sessionId: 'u', cwd: null, name: 'U' },
+    ]} now={NOW} />)
+    const labels = screen.getAllByTestId('mission-control-group-label').map((n) => n.textContent)
+    expect(labels).toEqual(['repo-a', 'repo-z', 'Ungrouped'])
+  })
+
+  it('reflects updated activity on re-render (live rollups)', () => {
+    const before = stateOf({ s1: [entry({ id: 'e1', status: 'running' })] })
+    const { rerender } = render(<CrossSessionMissionControl activity={before} sessions={[SESSIONS[0]!]} now={NOW} />)
+    expect(screen.getByTestId('mission-control-total-blocked').textContent).toContain('0')
+    const after = stateOf({ s1: [entry({ id: 'e1', status: 'blocked' })] })
+    rerender(<CrossSessionMissionControl activity={after} sessions={[SESSIONS[0]!]} now={NOW} />)
+    expect(screen.getByTestId('mission-control-total-blocked').textContent).toContain('1')
+    expect(screen.getByTestId('mission-control-total-running').textContent).toContain('0')
+  })
+})

--- a/packages/dashboard/src/components/CrossSessionMissionControl.tsx
+++ b/packages/dashboard/src/components/CrossSessionMissionControl.tsx
@@ -1,0 +1,138 @@
+/**
+ * CrossSessionMissionControl (#6183, Control Room v2 phase 2 / #5964) — the
+ * aggregate, read-only mission-control view spanning ALL sessions, the promotion
+ * of the v1 per-session ActivityTree (#5176) to "every session chroxy can see".
+ *
+ * Pure + prop-driven (same shape as ActivityTree): the parent passes the whole
+ * `activity` reducer state + the session list; this component derives the
+ * cross-session rollup via store-core's `selectCrossSessionActivity` (#6182) —
+ * sessions grouped by repo+worktree (cwd), each group + the overall set carrying
+ * running/blocked/failed/idle SESSION counts. Each session row drills down into
+ * its v1 `ActivityTree`, so the per-session tree stays the single source of
+ * truth (no regression) and this view is purely the aggregation layer on top.
+ *
+ * Read-only: no cancel affordance here (whole-turn / per-node control lives in
+ * the per-session surfaces). The overall rollup is what the tray badge (#6184)
+ * will consume off the same selector.
+ */
+import { useCallback, useState } from 'react'
+import type { ActivityState, CrossSessionMeta, SessionDerivedStatus } from '@chroxy/store-core'
+import { selectCrossSessionActivity } from '@chroxy/store-core'
+import { ActivityTree } from './ActivityTree'
+
+export interface CrossSessionMissionControlProps {
+  /** Whole-store activity state (one tree per session). */
+  activity: ActivityState
+  /** The authoritative session list (drives membership + grouping). */
+  sessions: readonly CrossSessionMeta[]
+  /** Injectable clock for the per-session trees' elapsed timers (tests). */
+  now?: () => number
+}
+
+const STATUS_LABEL: Record<SessionDerivedStatus, string> = {
+  running: 'Running',
+  blocked: 'Blocked',
+  failed: 'Failed',
+  idle: 'Idle',
+}
+
+/** running/blocked/failed chips for a rollup (idle implied; omitted to cut noise). */
+function RollupChips({ rollup, testidPrefix }: {
+  rollup: { running: number; blocked: number; failed: number; idle: number }
+  testidPrefix: string
+}) {
+  return (
+    <span className="mc-rollup" data-testid={testidPrefix}>
+      <span className="mc-chip mc-chip-running" data-testid={`${testidPrefix}-running`}>{rollup.running} running</span>
+      <span className="mc-chip mc-chip-blocked" data-testid={`${testidPrefix}-blocked`}>{rollup.blocked} blocked</span>
+      <span className="mc-chip mc-chip-failed" data-testid={`${testidPrefix}-failed`}>{rollup.failed} failed</span>
+    </span>
+  )
+}
+
+export function CrossSessionMissionControl({ activity, sessions, now = Date.now }: CrossSessionMissionControlProps) {
+  const agg = selectCrossSessionActivity(activity, sessions)
+
+  // Per-session drill-down expansion, keyed by sessionId (globally unique, so —
+  // unlike ActivityTree's per-session entry ids — no cross-session collision).
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set())
+  const toggle = useCallback((sessionId: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(sessionId)) next.delete(sessionId)
+      else next.add(sessionId)
+      return next
+    })
+  }, [])
+
+  if (agg.groups.length === 0) {
+    return (
+      <div className="mission-control" data-testid="mission-control">
+        <div className="mission-control-empty" data-testid="mission-control-empty">
+          No active sessions
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mission-control" data-testid="mission-control">
+      <header className="mission-control-header">
+        <span className="mc-total-label">All sessions</span>
+        <RollupChips rollup={agg.total} testidPrefix="mission-control-total" />
+      </header>
+
+      {agg.groups.map((group) => (
+        <section
+          key={group.key}
+          className="mission-control-group"
+          data-testid="mission-control-group"
+          data-group-key={group.key}
+        >
+          <h3 className="mission-control-group-head">
+            <span className="mission-control-group-label" data-testid="mission-control-group-label">
+              {group.label}
+            </span>
+            {group.worktree && (
+              <span className="mc-worktree-badge" data-testid="mission-control-group-worktree">worktree</span>
+            )}
+            <RollupChips rollup={group.rollup} testidPrefix="mission-control-group-rollup" />
+          </h3>
+
+          <ul className="mission-control-session-list">
+            {group.sessions.map((s) => {
+              const isOpen = expanded.has(s.sessionId)
+              return (
+                <li key={s.sessionId} className="mission-control-session" data-testid={`mission-control-session-${s.sessionId}`}>
+                  <button
+                    type="button"
+                    className={`mission-control-session-row status-${s.status}`}
+                    data-status={s.status}
+                    data-testid={`mission-control-session-toggle-${s.sessionId}`}
+                    aria-expanded={isOpen}
+                    onClick={() => toggle(s.sessionId)}
+                  >
+                    <span className="mission-control-session-name">{s.name}</span>
+                    <span
+                      className={`mc-status-badge status-${s.status}`}
+                      data-testid={`mission-control-session-status-${s.sessionId}`}
+                      role="status"
+                      aria-label={`Status: ${STATUS_LABEL[s.status]}`}
+                    >
+                      {STATUS_LABEL[s.status]}
+                    </span>
+                  </button>
+                  {isOpen && (
+                    <div className="mission-control-session-tree" data-testid={`mission-control-session-tree-${s.sessionId}`}>
+                      <ActivityTree activity={activity} sessionId={s.sessionId} now={now} />
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/CrossSessionMissionControl.tsx
+++ b/packages/dashboard/src/components/CrossSessionMissionControl.tsx
@@ -99,22 +99,28 @@ export function CrossSessionMissionControl({ activity, sessions, now = Date.now 
             <RollupChips rollup={group.rollup} testidPrefix="mission-control-group-rollup" />
           </h3>
 
-          <ul className="mission-control-session-list">
+          {/* Reuse the v1 ActivityTree list reset (control-room-entry-list) so the
+              session rows share the tree's spacing/markers-off styling. */}
+          <ul className="mission-control-session-list control-room-entry-list">
             {group.sessions.map((s) => {
               const isOpen = expanded.has(s.sessionId)
+              // aria-controls must reference the expanded region's id (set below).
+              const treeId = `mission-control-session-tree-${s.sessionId}`
               return (
                 <li key={s.sessionId} className="mission-control-session" data-testid={`mission-control-session-${s.sessionId}`}>
+                  {/* Reuse control-room-entry so the row matches the v1 tree rows. */}
                   <button
                     type="button"
-                    className={`mission-control-session-row status-${s.status}`}
+                    className={`control-room-entry mission-control-session-row status-${s.status}`}
                     data-status={s.status}
                     data-testid={`mission-control-session-toggle-${s.sessionId}`}
                     aria-expanded={isOpen}
+                    aria-controls={isOpen ? treeId : undefined}
                     onClick={() => toggle(s.sessionId)}
                   >
-                    <span className="mission-control-session-name">{s.name}</span>
+                    <span className="control-room-entry-label mission-control-session-name">{s.name}</span>
                     <span
-                      className={`mc-status-badge status-${s.status}`}
+                      className={`control-room-status-badge status-${s.status}`}
                       data-testid={`mission-control-session-status-${s.sessionId}`}
                       role="status"
                       aria-label={`Status: ${STATUS_LABEL[s.status]}`}
@@ -123,7 +129,7 @@ export function CrossSessionMissionControl({ activity, sessions, now = Date.now 
                     </span>
                   </button>
                   {isOpen && (
-                    <div className="mission-control-session-tree" data-testid={`mission-control-session-tree-${s.sessionId}`}>
+                    <div className="mission-control-session-tree" id={treeId} data-testid={treeId}>
                       <ActivityTree activity={activity} sessionId={s.sessionId} now={now} />
                     </div>
                   )}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1384,6 +1384,100 @@ button.sidebar-token-view-session-row:hover {
   border-color: var(--accent-orange-border-strong);
 }
 
+/* #6183: the cross-session aggregate can derive an `idle` session status (no
+   in-flight work) that the per-entry v1 statuses never produce — give it a muted
+   neutral treatment so the reused control-room status badge isn't unstyled. */
+.control-room-status-badge.status-idle {
+  color: var(--text-muted);
+  background: var(--surface-raised, rgba(127, 127, 127, 0.12));
+  border-color: var(--border-subtle, rgba(127, 127, 127, 0.25));
+}
+
+/* #6183 (Control Room v2 phase 2 / #5964): cross-session mission-control view.
+   The session list/rows/status-badge reuse the v1 control-room-* styles above;
+   these rules cover the NEW aggregate chrome (wrapper, group headers, the
+   per-group + overall rollup chips, the worktree tag). */
+.mission-control {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  height: 100%;
+  padding: 4px 2px;
+}
+.mission-control-empty {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+  padding: 8px 2px;
+}
+.mission-control-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.2));
+}
+.mc-total-label,
+.mission-control-group-label {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text-primary, inherit);
+}
+.mission-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.mission-control-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0;
+  font-size: 12px;
+}
+.mc-worktree-badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-purple, var(--text-muted));
+  background: var(--accent-purple-light, rgba(127, 127, 127, 0.12));
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.25));
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.mc-rollup {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-left: auto;
+}
+.mc-chip {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  border-radius: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.25));
+  color: var(--text-muted);
+}
+.mc-chip-running {
+  color: var(--accent-green, #4ade80);
+  border-color: var(--accent-green-border, rgba(74, 222, 128, 0.4));
+}
+.mc-chip-blocked {
+  color: var(--accent-orange);
+  border-color: var(--accent-orange-border-strong);
+}
+.mc-chip-failed {
+  color: var(--accent-red, #f87171);
+  border-color: var(--accent-red-border, rgba(248, 113, 113, 0.4));
+}
+.mission-control-session-tree {
+  padding-left: 12px;
+}
+
 /* Blocked-on-input entries are visually prominent and tie into the
    intervention surface (#4891): a steady amber accent + left rule so the
    operator's eye lands on "this needs you". A subtle pulse draws attention


### PR DESCRIPTION
## Summary

Slice B of Control Room v2 phase 2 (#5964, epic #5422), consuming the #6182 store-core aggregation selector (merged). Promotes the v1 per-session `ActivityTree` to an aggregate view over **every** session chroxy can see.

## Changes

- **`CrossSessionMissionControl`** (pure, prop-driven — same shape as `ActivityTree`): renders `selectCrossSessionActivity(activity, sessions)`:
  - Sessions **grouped by repo+worktree** (cwd), each group + the overall set showing a **running/blocked/failed rollup**.
  - Each session row drills down into its **v1 `ActivityTree`** — reused as-is, so the per-session tree stays the single source of truth (**no regression**).
  - Read-only; the overall rollup is the same one the tray badge (#6184) will consume.
- Wired into `ControlRoomView` as a new **static "Mission control" tab** (descriptor + render branch + a thin store-connected `MissionControlTab` wrapper mapping `SessionInfo → CrossSessionMeta`, re-rendering live on activity/session change). `survey: false` — it reads the live activity reducer state already in the store, no per-tab fetch.

## Acceptance
- [x] Dashboard shows one view of all sessions' trees grouped by repo+worktree.
- [x] Per-group rollups render and update live (re-render on activity/session change).
- [x] No regression to the per-session v1 tree (the same `ActivityTree` is reused for drill-down).
- [x] Component tests: grouping, rollups, status badges, expand, ordering, live update.

## Tests (dashboard suite 4014 green, +7; typecheck clean)
Empty state; grouping + labels + overall total; per-group rollups + worktree badge (realistic distinct-cwd worktree); per-session status badges (incl. idle for no-activity); expand-to-`ActivityTree` (reuse proof); group ordering (named asc, Ungrouped last); live rollup update on re-render. Existing `ControlRoomView` registry/view tests still pass with the new tab.

Part of #5964. Closes #6183. Next: #6184 (tray badge) consumes `agg.total` off the same selector.