### PR TITLE
feat(desktop): dock-badge the cross-session blocked+failed count (#6184)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -57,6 +57,7 @@ import { useShortcutRegistry } from './shortcuts/useShortcutRegistry'
 import { buildShortcutEntries } from './shortcuts/buildShortcutEntries'
 import { writeText as clipboardWriteText } from './utils/clipboard'
 import { useTauriEvents } from './hooks/useTauriEvents'
+import { useTrayBadgeSync } from './hooks/useTrayBadgeSync'
 import { useTauriMenuWiring } from './hooks/useTauriMenuWiring'
 import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
@@ -233,6 +234,10 @@ export function App() {
 
   // Listen for Tauri desktop events (no-op in browser context)
   useTauriEvents()
+
+  // #6184: mirror the cross-session blocked+failed count on the desktop dock
+  // badge (no-op in a plain browser tab).
+  useTrayBadgeSync()
 
   // Voice input mode is persisted on inputSettings (#4785). Default is
   // 'continuous' — click to start, click to stop, mic stays lit across

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
@@ -21,7 +21,8 @@ function Harness() {
 }
 
 // Build an ActivityState where each sessionId maps to a single entry of the
-// given status (enough for deriveSessionStatus → the rollup).
+// given status (enough for deriveSessionStatus → the rollup). FAILED sessions
+// here drive the badge's `failed` slice (best-effort activity rollup).
 function activityOf(map: Record<string, 'running' | 'blocked' | 'failed'>) {
   const bySession: Record<string, { byId: Record<string, unknown>; order: string[] }> = {}
   for (const [sid, status] of Object.entries(map)) {
@@ -34,8 +35,39 @@ function activityOf(map: Record<string, 'running' | 'blocked' | 'failed'>) {
   return { bySession }
 }
 
-function setStore(activity: unknown, sessions: Array<{ sessionId: string; cwd?: string | null; name?: string }>) {
-  storeState = { activity, sessions }
+// Build sessionStates carrying N live (unanswered, future-expiry) permission
+// prompts per session. This is what now drives the badge's `blocked` slice —
+// the SAME pending-permission derivation that powers the header "N pending"
+// indicator (#6184 fix), not the activity-tree `blocked` status.
+function sessionStatesWith(map: Record<string, number>) {
+  const out: Record<string, { messages: unknown[] }> = {}
+  for (const [sid, n] of Object.entries(map)) {
+    const messages: unknown[] = []
+    for (let i = 0; i < n; i++) {
+      messages.push({
+        id: `${sid}-p${i}`,
+        type: 'prompt',
+        content: 'Allow?',
+        timestamp: 1,
+        requestId: `${sid}-r${i}`,
+        expiresAt: Date.now() + 5 * 60_000,
+      })
+    }
+    out[sid] = { messages }
+  }
+  return out
+}
+
+function setStore(opts: {
+  pending?: Record<string, number>
+  activity?: ReturnType<typeof activityOf>
+  sessions?: Array<{ sessionId: string; cwd?: string | null; name?: string }>
+}) {
+  storeState = {
+    sessionStates: sessionStatesWith(opts.pending ?? {}),
+    activity: opts.activity ?? { bySession: {} },
+    sessions: opts.sessions ?? [],
+  }
 }
 
 describe('useTrayBadgeSync (#6184)', () => {
@@ -45,46 +77,54 @@ describe('useTrayBadgeSync (#6184)', () => {
   })
   afterEach(() => cleanup())
 
-  it('invokes update_tray_badge with blocked + failed counts', () => {
-    setStore(
-      activityOf({ s1: 'blocked', s2: 'failed', s3: 'running' }),
-      [{ sessionId: 's1', cwd: '/r' }, { sessionId: 's2', cwd: '/r' }, { sessionId: 's3', cwd: '/r' }],
-    )
+  it('invokes update_tray_badge with blocked (pending permissions) + failed counts', () => {
+    setStore({
+      pending: { s1: 1 },
+      activity: activityOf({ s2: 'failed', s3: 'running' }),
+      sessions: [{ sessionId: 's2', cwd: '/r' }, { sessionId: 's3', cwd: '/r' }],
+    })
     render(<Harness />)
     expect(invokeSpy).toHaveBeenCalledTimes(1)
     expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 1, failed: 1 })
   })
 
+  it('counts every pending permission across sessions for blocked', () => {
+    setStore({ pending: { s1: 2, s2: 1 } })
+    render(<Harness />)
+    expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 3, failed: 0 })
+  })
+
   it('is a no-op outside Tauri (getTauriInvoke null)', () => {
     invokeImpl = null
-    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    setStore({ pending: { s1: 1 } })
     render(<Harness />)
     expect(invokeSpy).not.toHaveBeenCalled()
   })
 
-  it('reports zero counts when nothing is blocked/failed', () => {
-    setStore(activityOf({ s1: 'running' }), [{ sessionId: 's1', cwd: '/r' }])
+  it('reports zero counts when nothing is pending/failed', () => {
+    setStore({ activity: activityOf({ s1: 'running' }), sessions: [{ sessionId: 's1', cwd: '/r' }] })
     render(<Harness />)
     expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
   })
 
   it('does not re-invoke when the count is unchanged across re-renders (deduped)', () => {
-    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    setStore({ pending: { s1: 1 } })
     const { rerender } = render(<Harness />)
     expect(invokeSpy).toHaveBeenCalledTimes(1)
-    // Re-render with a NEW activity object ref but the SAME blocked/failed totals.
-    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    // Re-render with NEW object refs but the SAME blocked/failed totals.
+    setStore({ pending: { s1: 1 } })
     rerender(<Harness />)
     expect(invokeSpy).toHaveBeenCalledTimes(1) // deduped — count didn't change
   })
 
-  it('re-invokes when the count changes', () => {
-    setStore(activityOf({ s1: 'running' }), [{ sessionId: 's1', cwd: '/r' }])
+  it('re-invokes when the count changes (e.g. a permission is answered)', () => {
+    setStore({ pending: { s1: 1 } })
     const { rerender } = render(<Harness />)
-    expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
-    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 1, failed: 0 })
+    // The prompt is answered → no live pending permission remains → badge clears.
+    setStore({ pending: {} })
     rerender(<Harness />)
     expect(invokeSpy).toHaveBeenCalledTimes(2)
-    expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 1, failed: 0 })
+    expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
   })
 })

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+// Controlled store state + a spy invoke, both swappable per test.
+let storeState: Record<string, unknown> = {}
+const invokeSpy = vi.fn(async () => undefined)
+let invokeImpl: typeof invokeSpy | null = invokeSpy
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+}))
+vi.mock('../utils/tauri-bridge', () => ({
+  getTauriInvoke: () => invokeImpl,
+}))
+
+import { useTrayBadgeSync } from './useTrayBadgeSync'
+
+function Harness() {
+  useTrayBadgeSync()
+  return null
+}
+
+// Build an ActivityState where each sessionId maps to a single entry of the
+// given status (enough for deriveSessionStatus → the rollup).
+function activityOf(map: Record<string, 'running' | 'blocked' | 'failed'>) {
+  const bySession: Record<string, { byId: Record<string, unknown>; order: string[] }> = {}
+  for (const [sid, status] of Object.entries(map)) {
+    const id = `e-${sid}`
+    bySession[sid] = {
+      byId: { [id]: { id, kind: 'tool', label: id, status, startedAt: 1, endedAt: status === 'failed' ? 2 : undefined } },
+      order: [id],
+    }
+  }
+  return { bySession }
+}
+
+function setStore(activity: unknown, sessions: Array<{ sessionId: string; cwd?: string | null; name?: string }>) {
+  storeState = { activity, sessions }
+}
+
+describe('useTrayBadgeSync (#6184)', () => {
+  beforeEach(() => {
+    invokeSpy.mockClear()
+    invokeImpl = invokeSpy
+  })
+  afterEach(() => cleanup())
+
+  it('invokes update_tray_badge with blocked + failed counts', () => {
+    setStore(
+      activityOf({ s1: 'blocked', s2: 'failed', s3: 'running' }),
+      [{ sessionId: 's1', cwd: '/r' }, { sessionId: 's2', cwd: '/r' }, { sessionId: 's3', cwd: '/r' }],
+    )
+    render(<Harness />)
+    expect(invokeSpy).toHaveBeenCalledTimes(1)
+    expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 1, failed: 1 })
+  })
+
+  it('is a no-op outside Tauri (getTauriInvoke null)', () => {
+    invokeImpl = null
+    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    render(<Harness />)
+    expect(invokeSpy).not.toHaveBeenCalled()
+  })
+
+  it('reports zero counts when nothing is blocked/failed', () => {
+    setStore(activityOf({ s1: 'running' }), [{ sessionId: 's1', cwd: '/r' }])
+    render(<Harness />)
+    expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
+  })
+
+  it('does not re-invoke when the count is unchanged across re-renders (deduped)', () => {
+    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    const { rerender } = render(<Harness />)
+    expect(invokeSpy).toHaveBeenCalledTimes(1)
+    // Re-render with a NEW activity object ref but the SAME blocked/failed totals.
+    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    rerender(<Harness />)
+    expect(invokeSpy).toHaveBeenCalledTimes(1) // deduped — count didn't change
+  })
+
+  it('re-invokes when the count changes', () => {
+    setStore(activityOf({ s1: 'running' }), [{ sessionId: 's1', cwd: '/r' }])
+    const { rerender } = render(<Harness />)
+    expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
+    setStore(activityOf({ s1: 'blocked' }), [{ sessionId: 's1', cwd: '/r' }])
+    rerender(<Harness />)
+    expect(invokeSpy).toHaveBeenCalledTimes(2)
+    expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 1, failed: 0 })
+  })
+})

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.ts
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.ts
@@ -2,26 +2,51 @@
  * useTrayBadgeSync (#6184, Control Room v2 phase 2 / #5964) — reflect the
  * cross-session "needs me" count on the desktop dock badge.
  *
- * Data-source decision (settled in #6184): dashboard-derived. The dashboard
- * already owns the session list + activity reducer state and computes the
- * cross-session rollup via `selectCrossSessionActivity` (#6182); rather than add
- * a parallel server-side aggregation, this hook reads that same rollup and pushes
- * `blocked + failed` to the Tauri `update_tray_badge` command, which sets the
- * macOS dock-tile badge (Tauri v2's tray icon has no badge API; the dock tile is
- * the native count surface). Outside Tauri (a plain browser tab) it's a no-op.
+ * Data source (#6184 fix, 2026-06-21): the BLOCKED count is the cross-session
+ * pending-permission total — the SAME signal that drives the header "N pending"
+ * indicator (`derivePendingPermissionCounts` → `totalPendingPermissions` over
+ * `sessionStates`). The original implementation read the Control Room
+ * activity-tree `blocked` status (`selectCrossSessionActivity().total.blocked`),
+ * but that slice does not reliably carry a `blocked` entry for a live permission
+ * prompt, so the dock badge never lit up even with prompts pending. The
+ * pending-permission derivation is proven to fire (it powers the visible
+ * "N pending" header), so the badge now keys off it. FAILED/crashed sessions
+ * still come from the activity rollup (best-effort).
  *
- * Deduped: the command is invoked only when the count actually changes, so a busy
- * stream of activity deltas that doesn't move the blocked/failed totals doesn't
- * spam the bridge.
+ * Pushes `blocked + failed` to the Tauri `update_tray_badge` command, which sets
+ * the macOS dock-tile badge (Tauri v2's tray icon has no badge API; the dock
+ * tile is the native count surface). Outside Tauri (a plain browser tab) it's a
+ * no-op. Deduped: the command is invoked only when the count actually changes.
  */
 import { useEffect, useRef } from 'react'
-import { selectCrossSessionActivity } from '@chroxy/store-core'
+import {
+  selectCrossSessionActivity,
+  derivePendingPermissionCounts,
+  totalPendingPermissions,
+} from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
 import { getTauriInvoke } from '../utils/tauri-bridge'
 
 export function useTrayBadgeSync(): void {
-  const activity = useConnectionStore((s) => s.activity)
-  const sessions = useConnectionStore((s) => s.sessions)
+  // Compute the counts as REACTIVE selectors (recomputed on every store change,
+  // like the header "N pending" indicator) rather than inside an effect keyed on
+  // a store-slice reference. The permission-resolution update does not reliably
+  // change the `sessionStates` reference, so an effect dep'd on it never re-fired
+  // to push `blocked:0` — leaving the dock badge stuck (#6184). Selecting the
+  // derived numbers fixes the clear path: the effect below fires whenever the
+  // numbers change, including back to zero.
+  // BLOCKED = cross-session pending permissions (the signal that drives "N pending").
+  const blocked = useConnectionStore((s) =>
+    totalPendingPermissions(derivePendingPermissionCounts(s.sessionStates, Date.now())),
+  )
+  // FAILED = activity-rollup failed sessions (best-effort).
+  const failed = useConnectionStore(
+    (s) =>
+      selectCrossSessionActivity(
+        s.activity,
+        s.sessions.map((x) => ({ sessionId: x.sessionId, cwd: x.cwd, name: x.name, worktree: x.worktree })),
+      ).total.failed,
+  )
   // Last count pushed to the bridge ("blocked:failed"), so we only invoke on a
   // real change. Held in a ref (survives re-renders, no extra render on update).
   const lastSentRef = useRef<string | null>(null)
@@ -30,15 +55,11 @@ export function useTrayBadgeSync(): void {
     const invoke = getTauriInvoke()
     if (!invoke) return // plain browser tab — no dock/tray to badge.
 
-    const { total } = selectCrossSessionActivity(
-      activity,
-      sessions.map((s) => ({ sessionId: s.sessionId, cwd: s.cwd, name: s.name, worktree: s.worktree })),
-    )
-    const key = `${total.blocked}:${total.failed}`
+    const key = `${blocked}:${failed}`
     if (key === lastSentRef.current) return // unchanged — don't spam the bridge.
     lastSentRef.current = key
     // Swallow IPC rejection (backend not ready / command unregistered) so a
     // best-effort cosmetic badge update can't surface an unhandled rejection.
-    void Promise.resolve(invoke('update_tray_badge', { blocked: total.blocked, failed: total.failed })).catch(() => {})
-  }, [activity, sessions])
+    void Promise.resolve(invoke('update_tray_badge', { blocked, failed })).catch(() => {})
+  }, [blocked, failed])
 }

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.ts
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.ts
@@ -37,6 +37,8 @@ export function useTrayBadgeSync(): void {
     const key = `${total.blocked}:${total.failed}`
     if (key === lastSentRef.current) return // unchanged — don't spam the bridge.
     lastSentRef.current = key
-    void invoke('update_tray_badge', { blocked: total.blocked, failed: total.failed })
+    // Swallow IPC rejection (backend not ready / command unregistered) so a
+    // best-effort cosmetic badge update can't surface an unhandled rejection.
+    void Promise.resolve(invoke('update_tray_badge', { blocked: total.blocked, failed: total.failed })).catch(() => {})
   }, [activity, sessions])
 }

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.ts
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.ts
@@ -36,6 +36,10 @@ export function useTrayBadgeSync(): void {
   // derived numbers fixes the clear path: the effect below fires whenever the
   // numbers change, including back to zero.
   // BLOCKED = cross-session pending permissions (the signal that drives "N pending").
+  // The dock badge is `blocked + failed`, whereas the header "N pending"
+  // indicator (App.tsx) is blocked-only — they read the SAME blocked expression
+  // (so the pending portion never drifts) but the badge additionally surfaces
+  // crashed sessions, so the two match exactly only when nothing is failed.
   // These run at RENDER time (not in the effect), so they must be total over a
   // partially-populated store — an undefined `sessionStates`/`activity`/`sessions`
   // during an early/transient render must not throw and white-screen the

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.ts
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.ts
@@ -1,0 +1,42 @@
+/**
+ * useTrayBadgeSync (#6184, Control Room v2 phase 2 / #5964) — reflect the
+ * cross-session "needs me" count on the desktop dock badge.
+ *
+ * Data-source decision (settled in #6184): dashboard-derived. The dashboard
+ * already owns the session list + activity reducer state and computes the
+ * cross-session rollup via `selectCrossSessionActivity` (#6182); rather than add
+ * a parallel server-side aggregation, this hook reads that same rollup and pushes
+ * `blocked + failed` to the Tauri `update_tray_badge` command, which sets the
+ * macOS dock-tile badge (Tauri v2's tray icon has no badge API; the dock tile is
+ * the native count surface). Outside Tauri (a plain browser tab) it's a no-op.
+ *
+ * Deduped: the command is invoked only when the count actually changes, so a busy
+ * stream of activity deltas that doesn't move the blocked/failed totals doesn't
+ * spam the bridge.
+ */
+import { useEffect, useRef } from 'react'
+import { selectCrossSessionActivity } from '@chroxy/store-core'
+import { useConnectionStore } from '../store/connection'
+import { getTauriInvoke } from '../utils/tauri-bridge'
+
+export function useTrayBadgeSync(): void {
+  const activity = useConnectionStore((s) => s.activity)
+  const sessions = useConnectionStore((s) => s.sessions)
+  // Last count pushed to the bridge ("blocked:failed"), so we only invoke on a
+  // real change. Held in a ref (survives re-renders, no extra render on update).
+  const lastSentRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const invoke = getTauriInvoke()
+    if (!invoke) return // plain browser tab — no dock/tray to badge.
+
+    const { total } = selectCrossSessionActivity(
+      activity,
+      sessions.map((s) => ({ sessionId: s.sessionId, cwd: s.cwd, name: s.name, worktree: s.worktree })),
+    )
+    const key = `${total.blocked}:${total.failed}`
+    if (key === lastSentRef.current) return // unchanged — don't spam the bridge.
+    lastSentRef.current = key
+    void invoke('update_tray_badge', { blocked: total.blocked, failed: total.failed })
+  }, [activity, sessions])
+}

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.ts
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.ts
@@ -36,15 +36,20 @@ export function useTrayBadgeSync(): void {
   // derived numbers fixes the clear path: the effect below fires whenever the
   // numbers change, including back to zero.
   // BLOCKED = cross-session pending permissions (the signal that drives "N pending").
+  // These run at RENDER time (not in the effect), so they must be total over a
+  // partially-populated store — an undefined `sessionStates`/`activity`/`sessions`
+  // during an early/transient render must not throw and white-screen the
+  // dashboard. `for..in` over undefined is a safe no-op, but the activity
+  // selector dereferences `state.bySession`, so default it explicitly.
   const blocked = useConnectionStore((s) =>
-    totalPendingPermissions(derivePendingPermissionCounts(s.sessionStates, Date.now())),
+    totalPendingPermissions(derivePendingPermissionCounts(s.sessionStates ?? {}, Date.now())),
   )
   // FAILED = activity-rollup failed sessions (best-effort).
   const failed = useConnectionStore(
     (s) =>
       selectCrossSessionActivity(
-        s.activity,
-        s.sessions.map((x) => ({ sessionId: x.sessionId, cwd: x.cwd, name: x.name, worktree: x.worktree })),
+        s.activity ?? { bySession: {} },
+        (s.sessions ?? []).map((x) => ({ sessionId: x.sessionId, cwd: x.cwd, name: x.name, worktree: x.worktree })),
       ).total.failed,
   )
   // Last count pushed to the bridge ("blocked:failed"), so we only invoke on a

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -30,6 +30,7 @@ const APP_COMMANDS: &[&str] = &[
     "set_summon_hotkey",
     "get_allow_auto_permission_mode",
     "set_allow_auto_permission_mode",
+    "update_tray_badge",
     "voice_available",
     "start_voice_input",
     "stop_voice_input",

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -38,6 +38,7 @@
     "allow-set-summon-hotkey",
     "allow-get-allow-auto-permission-mode",
     "allow-set-allow-auto-permission-mode",
+    "allow-update-tray-badge",
     "allow-voice-available",
     "allow-start-voice-input",
     "allow-stop-voice-input",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -342,8 +342,12 @@ fn set_dock_badge(label: Option<String>) {
         let dock_tile: id = msg_send![ns_app, dockTile];
         match label {
             Some(text) => {
+                // alloc/init returns a +1-retained NSString (NOT autoreleased).
+                // setBadgeLabel: keeps its own copy, so release our reference
+                // afterwards or it leaks one NSString per badge update.
                 let ns_str: id = NSString::alloc(nil).init_str(&text);
                 let _: () = msg_send![dock_tile, setBadgeLabel: ns_str];
+                let _: () = msg_send![ns_str, release];
             }
             None => {
                 let _: () = msg_send![dock_tile, setBadgeLabel: nil];

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -327,6 +327,55 @@ fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
     Ok(())
 }
 
+/// #6184 (Control Room v2 phase 2 / #5964) — set the macOS dock-tile badge label.
+/// `None` clears it. Must run on the main thread (the command below dispatches via
+/// `run_on_main_thread`) — AppKit UI calls off the main thread are undefined
+/// behaviour. Mirrors the existing cocoa/objc usage (the NSApp window-menu setup).
+#[cfg(target_os = "macos")]
+fn set_dock_badge(label: Option<String>) {
+    use cocoa::appkit::NSApp;
+    use cocoa::base::{id, nil};
+    use cocoa::foundation::NSString;
+    use objc::{msg_send, sel, sel_impl};
+    unsafe {
+        let ns_app: id = NSApp();
+        let dock_tile: id = msg_send![ns_app, dockTile];
+        match label {
+            Some(text) => {
+                let ns_str: id = NSString::alloc(nil).init_str(&text);
+                let _: () = msg_send![dock_tile, setBadgeLabel: ns_str];
+            }
+            None => {
+                let _: () = msg_send![dock_tile, setBadgeLabel: nil];
+            }
+        }
+    }
+}
+
+/// #6184 — reflect the cross-session "needs me" count on the dock icon: a red
+/// badge with `blocked + failed` (cleared at zero). The dashboard computes the
+/// count from the shared `selectCrossSessionActivity` rollup (#6182) and invokes
+/// this whenever it changes. macOS only for now (Tauri v2's tray icon exposes no
+/// badge API; the dock tile is the native "count" surface); a no-op elsewhere.
+#[tauri::command]
+fn update_tray_badge(app: tauri::AppHandle, blocked: u32, failed: u32) -> Result<(), String> {
+    let count = blocked.saturating_add(failed);
+    #[cfg(target_os = "macos")]
+    {
+        let label = if count == 0 { None } else { Some(count.to_string()) };
+        // AppKit must be touched on the main thread.
+        app.run_on_main_thread(move || set_dock_badge(label))
+            .map_err(|e| format!("Failed to update dock badge: {}", e))?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // No dock/tray badge surface on this platform yet — accept + ignore so the
+        // dashboard caller stays platform-agnostic.
+        let _ = (&app, count);
+    }
+    Ok(())
+}
+
 /// #5356 — current "expose on LAN" setting. False (loopback-only) is the
 /// default and the safe posture for the control socket.
 #[tauri::command]
@@ -860,6 +909,7 @@ pub fn run() {
             set_summon_hotkey,
             get_allow_auto_permission_mode,
             set_allow_auto_permission_mode,
+            update_tray_badge,
             #[cfg(target_os = "macos")]
             voice_available,
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

Final slice of Control Room v2 phase 2 (#5964, epic #5422) — surfaces the mission-control "needs me" count on the **macOS dock icon**, consuming the #6182 aggregation rollup. Data source is dashboard-derived (settled in #6184): no server changes, reuses the shared selector.

## Changes

- **Rust `update_tray_badge(blocked, failed)`** (`src-tauri/src/lib.rs`): sets the macOS **dock-tile badge** to `blocked + failed` (cleared at zero) via `cocoa` `NSApp().dockTile().setBadgeLabel:`, dispatched with `run_on_main_thread` (AppKit is main-thread-only). Tauri v2's tray icon exposes no badge API, so the dock tile is the native count surface. No-op off macOS. Mirrors the existing cocoa/objc `NSApp` usage already in the file.
- **`useTrayBadgeSync`** dashboard hook: computes `blocked + failed` from `selectCrossSessionActivity` (#6182) and invokes the command **when the count changes** (deduped via a ref); no-op outside Tauri (`getTauriInvoke()` null). Wired once at the `App` top level next to `useTauriEvents()`.

## Tests (dashboard suite 4021 green; `cargo check` clean; typecheck clean)
Hook: invokes with correct `{blocked, failed}`, no-op outside Tauri, zero counts, dedupe on unchanged re-render, re-invoke on change.

## ⚠️ Device-gated — needs your verification before merge
The Rust plumbing compiles (CI "Desktop Rust Tests") and the dashboard side is unit-tested, but the **dock-badge rendering can't be verified without a macOS build + run** (per the #6184 scoping: Tauri v2 has no testable tray-badge surface). **Please verify the badge appears/clears on your Mac before merging** — I've left this PR un-merged for that reason (not self-merging a visual I can't see).

Closes #6184. Completes Control Room v2 phase 2 (#5964): A #6182 ✓, B #6183 ✓, C #6184 (this).