### PR TITLE
fix(client): exit the reconnect ladder on the supervisor terminal-down signal

### DIFF
--- a/packages/app/src/__tests__/store/connection-connect.test.ts
+++ b/packages/app/src/__tests__/store/connection-connect.test.ts
@@ -122,6 +122,24 @@ describe('connect() health check', () => {
     expect(state.shutdownReason).toBe('restart');
     expect(state.restartEtaMs).toBe(5000);
   });
+
+  it('latches server_down immediately on a terminal-down response (#6023)', async () => {
+    // Supervisor gave up — HTTP 200 { status: 'down', reason: 'supervisor_gave_up' }
+    // (#6022/#6130). The probe must stop the ladder and latch server_down now,
+    // not climb to onProbeGaveUp / disconnected.
+    const fetchSpy = jest.fn().mockResolvedValue(
+      mockResponse(200, { status: 'down', reason: 'supervisor_gave_up' }),
+    );
+    global.fetch = fetchSpy;
+
+    useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
+    await flushPromises();
+
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+    expect(useConnectionLifecycleStore.getState().connectionError).toBe('Server appears to be down');
+    // Terminal — no re-probe (a retry would call fetch again).
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('connect() retry exhaustion', () => {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1048,6 +1048,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
               const restartEtaMs = typeof body.restartEtaMs === 'number' ? body.restartEtaMs : null;
               return { kind: 'restarting', restartEtaMs };
             }
+            // #6023: the supervisor exhausted its restart budget and is serving a
+            // terminal-down health body (#6022/#6130). Stop the ladder now.
+            if (body.status === 'down') {
+              return { kind: 'terminal_down', reason: typeof body.reason === 'string' ? body.reason : 'supervisor_gave_up' };
+            }
           } catch (err) {
             console.log('[ws] Health check body unreadable:', err instanceof Error ? err.message : String(err));
           }
@@ -1075,6 +1080,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       },
       onProbeFailed: (reason) => {
         useConnectionLifecycleStore.getState().setConnectionError(reason, _retryCount);
+      },
+      onTerminalDown: () => {
+        // #6023: supervisor gave up — latch the terminal server_down state now
+        // (same sticky FSM phase the ladder cap uses, #5725/#5980) instead of
+        // climbing the full retry budget. retryConnection() resets it.
+        if (myAttemptId !== connectionAttemptId) return;
+        console.log('[ws] server served terminal-down (supervisor gave up) — server_down');
+        useConnectionLifecycleStore.getState().setConnectionPhase('server_down');
+        useConnectionLifecycleStore.getState().setConnectionError('Server appears to be down', 0);
       },
       scheduleRetry: (nextAttempt, delayMs) => {
         console.log(`[ws] Retrying in ${delayMs}ms...`);

--- a/packages/dashboard/src/store/connection-server-down.test.ts
+++ b/packages/dashboard/src/store/connection-server-down.test.ts
@@ -1,0 +1,69 @@
+/**
+ * #6023 — the client consumes the supervisor terminal-down health signal
+ * (#6022/#6130: `GET /health` → 200 `{ status: 'down', reason: 'supervisor_gave_up' }`)
+ * and latches the terminal `server_down` phase IMMEDIATELY, instead of climbing
+ * the full reconnect ladder against a host that has explicitly given up.
+ *
+ * The decision tree itself is unit-tested in store-core (connect-flow.test.ts);
+ * this pins the dashboard wiring: probe parses status:'down' → terminal_down,
+ * and onTerminalDown writes server_down + does NOT open a socket or arm a retry.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+class MockWebSocket {
+  static OPEN = 1
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  readyState = 0
+  constructor(_url: string) { MockWebSocket.count++ }
+  send(): void { /* no-op */ }
+  close(): void { this.readyState = 3 }
+  static count = 0
+}
+
+describe('dashboard reconnect — terminal server-down signal (#6023)', () => {
+  beforeEach(() => {
+    MockWebSocket.count = 0
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+  afterEach(() => { vi.unstubAllGlobals(); vi.resetModules() })
+
+  async function flushMicrotasks() {
+    const real = globalThis.setTimeout
+    await new Promise((r) => real(r, 0))
+    await new Promise((r) => real(r, 0))
+  }
+
+  it('latches server_down on a status:down health body — no socket, no re-probe', async () => {
+    const { useConnectionStore } = await import('./connection')
+
+    // A retry would re-run the probe, so fetch-called-once proves the ladder
+    // stopped (a robust signal — unlike counting timers, which would also catch
+    // the probe's own 5000ms fetch-abort timeout).
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'down', reason: 'supervisor_gave_up' }),
+    }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    void useConnectionStore.getState().connect('wss://example.invalid', 'tok')
+    await flushMicrotasks()
+
+    expect(useConnectionStore.getState().connectionPhase).toBe('server_down')
+    expect(useConnectionStore.getState().connectionError).toBe('Server appears to be down')
+    expect(MockWebSocket.count).toBe(0)   // never opened a socket
+    expect(fetchSpy).toHaveBeenCalledTimes(1) // never re-probed (no retry ladder)
+  })
+
+  it('still connects normally on a healthy probe (no false-positive)', async () => {
+    const { useConnectionStore } = await import('./connection')
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ status: 'ok' }) })))
+    void useConnectionStore.getState().connect('wss://example.invalid', 'tok')
+    await flushMicrotasks()
+    expect(MockWebSocket.count).toBe(1)
+    expect(useConnectionStore.getState().connectionPhase).not.toBe('server_down')
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1852,6 +1852,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
               const restartEtaMs = typeof body.restartEtaMs === 'number' ? body.restartEtaMs : null;
               return { kind: 'restarting', restartEtaMs };
             }
+            // #6023: the supervisor exhausted its restart budget and is serving a
+            // terminal-down health body (#6022/#6130). Stop the ladder now.
+            if (body.status === 'down') {
+              return { kind: 'terminal_down', reason: typeof body.reason === 'string' ? body.reason : 'supervisor_gave_up' };
+            }
           } catch (err) {
             console.log('[ws] Health check body unreadable:', err instanceof Error ? err.message : String(err));
           }
@@ -1879,6 +1884,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       },
       onProbeFailed: (reason) => {
         set({ connectionError: reason });
+      },
+      onTerminalDown: () => {
+        // #6023: supervisor gave up — latch the terminal server_down state
+        // immediately instead of climbing the full retry ladder. The reconnect
+        // banner / footer already render this phase; retryConnection() resets it.
+        set({ connectionPhase: 'server_down', connectionError: 'Server appears to be down' });
+        console.warn('[chroxy] Server appears to be down (supervisor gave up). Reconnect manually when it is back.');
       },
       scheduleRetry: (nextAttempt, delayMs) => {
         console.log(`[ws] Retrying in ${delayMs}ms...`);

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1886,6 +1886,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         set({ connectionError: reason });
       },
       onTerminalDown: () => {
+        // Superseded by a newer attempt — don't clobber it (parity with
+        // scheduleRetry / onGaveUp + the app's onTerminalDown). Redundant with
+        // store-core's synchronous isStale() today, but guards against a future
+        // await sneaking in before this callback.
+        if (myAttemptId !== connectionAttemptId) return;
         // #6023: supervisor gave up — latch the terminal server_down state
         // immediately instead of climbing the full retry ladder. The reconnect
         // banner / footer already render this phase; retryConnection() resets it.

--- a/packages/store-core/src/connect-flow.test.ts
+++ b/packages/store-core/src/connect-flow.test.ts
@@ -147,6 +147,73 @@ describe('runConnectAttempt — success path', () => {
   })
 })
 
+describe('runConnectAttempt — terminal_down path (#6023)', () => {
+  it('latches server_down via onTerminalDown and stops — no retry, no socket', async () => {
+    const onTerminalDown = vi.fn()
+    const scheduleRetry = vi.fn()
+    const openSocket = vi.fn()
+    const onProbeFailed = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'terminal_down', reason: 'supervisor_gave_up' }),
+      isStale: () => false,
+      openSocket,
+      onRestarting: vi.fn(),
+      onProbeFailed,
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      onTerminalDown,
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(onTerminalDown).toHaveBeenCalledWith({ reason: 'supervisor_gave_up' })
+    expect(scheduleRetry).not.toHaveBeenCalled()
+    expect(openSocket).not.toHaveBeenCalled()
+    expect(onProbeFailed).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the attempt went stale during the probe', async () => {
+    const onTerminalDown = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'terminal_down', reason: 'supervisor_gave_up' }),
+      isStale: () => true,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed: vi.fn(),
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      onTerminalDown,
+      scheduleRetry: vi.fn(),
+      jitter: noJitter,
+    })
+    expect(onTerminalDown).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the failed-probe ladder when onTerminalDown is omitted (legacy)', async () => {
+    const scheduleRetry = vi.fn()
+    const onProbeFailed = vi.fn()
+    await runConnectAttempt({
+      attempt: 0,
+      resolveEndpoint: () => ENDPOINT,
+      probe: async () => ({ kind: 'terminal_down', reason: 'supervisor_gave_up' }),
+      isStale: () => false,
+      openSocket: vi.fn(),
+      onRestarting: vi.fn(),
+      onProbeFailed,
+      onRestartGaveUp: vi.fn(),
+      onProbeGaveUp: vi.fn(),
+      // onTerminalDown intentionally omitted
+      scheduleRetry,
+      jitter: noJitter,
+    })
+    expect(onProbeFailed).toHaveBeenCalledWith('supervisor_gave_up')
+    expect(scheduleRetry).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('runConnectAttempt — restarting path', () => {
   it('signals restarting and schedules the next retry on the ladder', async () => {
     const onRestarting = vi.fn()

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -118,6 +118,12 @@ export type ProbeResult =
   | { kind: 'ok' }
   | { kind: 'restarting'; restartEtaMs: number | null }
   | { kind: 'failed'; reason: string }
+  // #6023: the supervisor exhausted its restart budget and is serving a
+  // terminal `{ status: 'down', reason: 'supervisor_gave_up' }` health response
+  // (#6022/#6130). The daemon is NOT coming back on its own — stop the ladder
+  // immediately and latch the terminal `server_down` state, rather than spinning
+  // the full retry budget against a host that has explicitly given up.
+  | { kind: 'terminal_down'; reason: string }
 
 /**
  * The endpoint to connect to for a given attempt. Returned by
@@ -223,6 +229,15 @@ export interface RunConnectAttemptOptions {
   onProbeFailed: (reason: string) => void
 
   /**
+   * #6023: the host served a terminal-down health signal (supervisor gave up).
+   * Write the sticky `server_down` phase + the "server appears down" copy and
+   * STOP — no retry is scheduled, since the daemon has explicitly given up.
+   * Optional so a client that omits it falls back to the legacy never-terminal
+   * behavior (the time-based ladder cap still latches server_down after N).
+   */
+  onTerminalDown?: (info: { reason: string }) => void
+
+  /**
    * Retries are exhausted because the host is still restarting. Write the
    * terminal `disconnected` phase + the "restart timed out" copy/UX.
    */
@@ -274,6 +289,7 @@ export function runConnectAttempt(options: RunConnectAttemptOptions): Promise<vo
     onProbeFailed,
     onRestartGaveUp,
     onProbeGaveUp,
+    onTerminalDown,
     scheduleRetry,
     jitter = defaultJitter,
   } = options
@@ -292,6 +308,23 @@ export function runConnectAttempt(options: RunConnectAttemptOptions): Promise<vo
 
       if (result.kind === 'ok') {
         openSocket(endpoint)
+        return
+      }
+
+      // #6023: the supervisor gave up — terminal, no retry. Latch server_down.
+      // A client that didn't wire onTerminalDown falls through to treat it like a
+      // failed probe (climbs the ladder), preserving legacy behavior.
+      if (result.kind === 'terminal_down') {
+        if (onTerminalDown) {
+          onTerminalDown({ reason: result.reason })
+          return
+        }
+        onProbeFailed(result.reason)
+        if (attempt < maxRetries) {
+          scheduleRetry(attempt + 1, delayFor(attempt))
+        } else {
+          onProbeGaveUp()
+        }
         return
       }
 

--- a/packages/store-core/src/connect-flow.ts
+++ b/packages/store-core/src/connect-flow.ts
@@ -232,8 +232,10 @@ export interface RunConnectAttemptOptions {
    * #6023: the host served a terminal-down health signal (supervisor gave up).
    * Write the sticky `server_down` phase + the "server appears down" copy and
    * STOP — no retry is scheduled, since the daemon has explicitly given up.
-   * Optional so a client that omits it falls back to the legacy never-terminal
-   * behavior (the time-based ladder cap still latches server_down after N).
+   * Optional: a caller that omits it falls back to treating the signal as a
+   * failed probe — it climbs the connect-retry ladder and ends at
+   * `onProbeGaveUp` (terminal `disconnected`), i.e. pre-#6023 behavior. (Both
+   * shipping clients wire it; the fallback exists for tests / future callers.)
    */
   onTerminalDown?: (info: { reason: string }) => void
 


### PR DESCRIPTION
## What

Closes #6023. The client now **consumes the supervisor terminal-down signal** (#6022/#6130) and latches the terminal `server_down` state **immediately**, instead of spinning the full ~59s reconnect ladder against a daemon that has explicitly given up.

## Background

The supervisor already serves a terminal-down health response when it exhausts its restart budget — `GET /health` → **200** `{ status: 'down', reason: 'supervisor_gave_up' }` (`supervisor.js`, whose comment explicitly cites #6023). But the client probe only checked `status: 'restarting'`, so a permanently-down server was treated like a transient unreachable host and the ladder ran to exhaustion (`RECONNECT_MAX_RUNG`, ~59s) before latching `server_down`.

The *after-N-attempts* terminal state (#5698/#5725/#5724/#5980) already exists and is unchanged — this PR adds the faster, explicit **daemon-gone** path that #6023's notes called out ("Consumes the supervisor terminal-down signal once that lands").

## How

- **store-core `connect-flow.ts`** — new `terminal_down` `ProbeResult` variant + optional `onTerminalDown` callback. `runConnectAttempt` stops immediately on it (no retry). If a client omits `onTerminalDown`, it falls back to the failed-probe ladder (legacy behavior preserved).
- **dashboard + app probes** — parse `body.status === 'down'` → `{ kind: 'terminal_down', reason }`; both wire `onTerminalDown` → sticky `server_down` + "Server appears to be down". The existing renders + `retryConnection()` (resets the ladder) handle the rest.

## Why this is fully autonomous (no device needed)

The reconnect ladder is **shared store-core** (#6065), so one change covers both clients, and the `server_down` *render* already shipped + was verified for dashboard (#5724) and mobile (#5980). This PR only adds the *trigger*, covered by unit tests.

## Tests
- store-core `connect-flow.test.ts` (+3): `terminal_down` → `onTerminalDown` stops the ladder; stale-attempt no-op; legacy fallback when `onTerminalDown` omitted.
- dashboard `connection-server-down.test.ts` (new, 2): a `status:'down'` health body latches `server_down` with no socket + no re-probe; a healthy probe still connects (no false-positive).
- Full suites green locally: store-core 1698, dashboard 4025, app connection 275; all three typechecks clean.

## Acceptance (#6023)
- [x] After the server is gone, the client reaches a terminal `server_down` state (now *immediately* on the explicit signal; the time-based ladder cap remains the fallback for silent unreachability).
- [x] Distinct from the transient reconnect banner; manual retry affordance (`retryConnection`) resets the ladder.
- [x] Both surfaces (shared store-core runtime).
- [x] Consumes the supervisor terminal-down signal (#6130).
- [x] Terminal phase is sticky / FSM-guarded (reuses the #5980 server_down phase).