### PR TITLE
fix(app): allow connecting/server_restarting → server_down in the FSM table

### DIFF
--- a/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
+++ b/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
@@ -184,6 +184,27 @@ describe('useConnectionLifecycleStore', () => {
       warnSpy.mockRestore();
     });
 
+    it('allows connecting → server_down (#6023 — first-attempt terminal-down signal)', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const store = useConnectionLifecycleStore.getState();
+      store.transitionPhase('connecting');
+      store.transitionPhase('server_down');
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('allows server_restarting → server_down (#6023 — supervisor gives up mid-restart)', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const store = useConnectionLifecycleStore.getState();
+      store.transitionPhase('connecting');
+      store.transitionPhase('server_restarting');
+      store.transitionPhase('server_down');
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
     it('allows self-transitions for reconnecting (retry loop)', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const store = useConnectionLifecycleStore.getState();

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -24,11 +24,15 @@ import type { ConnectionPhase, SavedConnection } from './types';
  */
 const VALID_TRANSITIONS: Record<ConnectionPhase, ConnectionPhase[]> = {
   disconnected: ['connecting'],
-  connecting: ['connecting', 'connected', 'disconnected', 'reconnecting', 'server_restarting'],
+  // #6023 — a first-attempt probe can read the supervisor terminal-down signal
+  // and latch 'server_down' straight from 'connecting' (no reconnect ladder yet).
+  connecting: ['connecting', 'connected', 'disconnected', 'reconnecting', 'server_restarting', 'server_down'],
   connected: ['disconnected', 'reconnecting', 'server_restarting'],
   // #5698 — the reconnect ladder gives up → terminal 'server_down'.
   reconnecting: ['reconnecting', 'connected', 'disconnected', 'server_restarting', 'server_down'],
-  server_restarting: ['connecting', 'reconnecting', 'disconnected'],
+  // #6023 — a restarting host whose next probe reads terminal-down goes
+  // straight to 'server_down' (supervisor gave up mid-restart).
+  server_restarting: ['connecting', 'reconnecting', 'disconnected', 'server_down'],
   // #5698 — terminal; only a user-initiated reconnect (→ connecting) or an
   // explicit disconnect leaves it.
   server_down: ['connecting', 'disconnected'],


### PR DESCRIPTION
## What

Closes #6191 (from-review on #6190). #6023 made the client latch the terminal `server_down` phase directly from:
- `connecting` — a first-attempt health probe reading the supervisor terminal-down signal (no reconnect ladder yet), and
- `server_restarting` — the supervisor giving up *mid-restart*.

But the app's `VALID_TRANSITIONS` table only listed `server_down` under `reconnecting`, so those two paths logged a spurious warn-only `[ConnectionFSM] Illegal transition: connecting → server_down`. The phase was still applied (the FSM warns then sets unconditionally), so this is purely **cosmetic log noise** — but worth silencing + making the table honest.

## How

Add `'server_down'` to the `connecting` and `server_restarting` allow-lists in `VALID_TRANSITIONS` (`packages/app/src/store/connection-lifecycle.ts`). App-only — the dashboard has no FSM transition table (it sets the phase directly).

## Tests
- `connection-lifecycle-store.test.ts` (+2): `connecting → server_down` and `server_restarting → server_down` are now allowed with no warn. Suite 31/31; app typecheck clean.