### PR TITLE
refactor(store-core): migrate user_question onto the shared dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -118,7 +118,6 @@ import {
   // (#5556 slice 4); the app no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
   handleSearchResults as sharedSearchResults,
-  handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
   isActivityEvent,
   // #5039: shared partial-cost line helper — the same one the dashboard
@@ -1179,6 +1178,10 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
   getSessions: () => getStore().getState().sessions,
+  // #5618 — user_question raises a background-session notification via the
+  // app's own helper (which also mirrors the row into the mobile push store).
+  pushSessionNotification: (sessionId, eventType, message) =>
+    pushSessionNotification(sessionId, eventType, message),
   // #5653 — file-ops / git wrapper cases route through the shared dispatch
   // table; the app supplies its module-level imperative-callback registry so
   // the parsed payload reaches the UI's registered callback exactly as the
@@ -3060,22 +3063,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // permission_rules_updated — migrated to the shared dispatch table (#5556)
 
 
-    case 'user_question': {
-      const parsed = sharedUserQuestion(msg, get().activeSessionId);
-      if (!parsed) break;
-      const { sessionId: questionTargetId, chatMessage: questionMsg, questionText } = parsed;
-      if (questionTargetId && get().sessionStates[questionTargetId]) {
-        updateSession(questionTargetId, (ss) => ({
-          messages: [...ss.messages, questionMsg],
-        }));
-      } else {
-        get().addMessage(questionMsg);
-      }
-      if (questionTargetId) {
-        pushSessionNotification(questionTargetId, 'question', questionText);
-      }
-      break;
-    }
+    // user_question — migrated to the shared dispatch table (#5618)
 
     case 'server_status': {
       // Ignore structured startup phase events (phase field) — only the dashboard uses these

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -114,7 +114,6 @@ import {
   // web_task_list / web_feature_status migrated to the shared dispatch table
   // (#5556 slice 2)
   handleSearchResults as sharedSearchResults,
-  handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
   isActivityEvent,
   // #5163 (epic #5159): Control Room activity reducer — snapshot replace +
@@ -1039,6 +1038,10 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
   getSessions: () => getStore().getState().sessions,
+  // #5618 — user_question raises a background-session notification via the
+  // dashboard's own helper (dedup by (sessionId, eventType); no push store).
+  pushSessionNotification: (sessionId, eventType, message) =>
+    pushSessionNotification(sessionId, eventType, message),
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -4480,22 +4483,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // permission_rules_updated — migrated to the shared dispatch table (#5556)
 
 
-    case 'user_question': {
-      const parsed = sharedUserQuestion(msg, get().activeSessionId);
-      if (!parsed) break;
-      const { sessionId: questionTargetId, chatMessage: questionMsg, questionText } = parsed;
-      if (questionTargetId && get().sessionStates[questionTargetId]) {
-        updateSession(questionTargetId, (ss) => ({
-          messages: [...ss.messages, questionMsg],
-        }));
-      } else {
-        get().addMessage(questionMsg);
-      }
-      if (questionTargetId) {
-        pushSessionNotification(questionTargetId, 'question', questionText);
-      }
-      break;
-    }
+    // user_question — migrated to the shared dispatch table (#5618)
 
     case 'server_status': {
       // Handle structured startup phase events (phase field present)

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -132,6 +132,11 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => added.push(m),
     getSessions: () => sessionList,
+    // #5618 — `pushSessionNotification` is a UI side-effect OUTSIDE the shared
+    // store-state contract (the app additionally mirrors into its mobile push
+    // store; the dashboard does not). Modelled as a no-op here, exactly like the
+    // app's `activityState` derivation above — no fixture asserts on it.
+    pushSessionNotification: () => {},
     // #5653 — only the APP opts its imperative-callback registry into the table.
     // Model it as "a callback IS registered for every channel" so the contract
     // can observe the invocation + payload. The DASHBOARD omits `getCallback`

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -114,7 +114,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'tool_input_delta',
   'tunnel_url_changed',
   'user_input',
-  'user_question',
+  // user_question — migrated to the shared dispatch table (#5618); now has a
+  // DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   'web_task_error',
 ])
 

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -243,6 +243,33 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { added: [sysMsg('Cost budget override — session resumed')] },
   },
 
+  // 4c. user_question (#5618) — append the question prompt to its (resolved)
+  // session, else the global log. The `pushSessionNotification` side-effect is a
+  // UI concern OUTSIDE this store-state contract (no-op in the harness adapter),
+  // so only the message append is asserted — byte-identical on both clients.
+  {
+    name: 'user_question appends the question prompt to the target session',
+    type: 'user_question',
+    init: { sessions: { s1: {} } },
+    message: { type: 'user_question', sessionId: 's1', questions: [{ question: 'Proceed?' }] },
+    expect: {
+      sessions: { s1: { messages: [{ type: 'prompt', content: 'Proceed?' }] } },
+    },
+  },
+  {
+    name: 'user_question falls back to addMessage when no session resolves',
+    type: 'user_question',
+    message: { type: 'user_question', questions: [{ question: 'Proceed?' }] },
+    expect: { added: [{ type: 'prompt', content: 'Proceed?' }] },
+  },
+  {
+    name: 'user_question is a no-op when the questions payload is malformed',
+    type: 'user_question',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'user_question', questions: [] },
+    expect: { noop: true },
+  },
+
   // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the
   // session was not paused; no-op when it was (budget_resumed already noted it)
   {

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -53,6 +53,7 @@ function makeAdapter(init?: {
   let sessionList: SessionInfo[] = init?.sessionList ?? []
   const flat: Record<string, unknown> = {}
   const addedMessages: ChatMessage[] = []
+  const notifications: Array<{ sessionId: string; eventType: string; message: string }> = []
 
   const adapter: ClientStoreAdapter<FakeSession> = {
     getActiveSessionId: () => activeSessionId,
@@ -66,6 +67,8 @@ function makeAdapter(init?: {
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => addedMessages.push(m),
     getSessions: () => sessionList,
+    pushSessionNotification: (sessionId, eventType, message) =>
+      notifications.push({ sessionId, eventType, message }),
     ...(init?.callbacks
       ? {
           getCallback: ((name: string) =>
@@ -79,6 +82,7 @@ function makeAdapter(init?: {
     sessions,
     flat,
     addedMessages,
+    notifications,
     setActive: (id: string | null) => {
       activeSessionId = id
     },
@@ -217,6 +221,53 @@ describe('shared dispatch table', () => {
         type: 'system',
         content: 'Cost budget override — session resumed',
       })
+    })
+  })
+
+  describe('user_question (#5618)', () => {
+    it('appends the question prompt to the target session and notifies', () => {
+      const env = makeAdapter({
+        activeSessionId: 'other',
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      const handled = dispatch(env, {
+        type: 'user_question',
+        sessionId: 's1',
+        questions: [{ question: 'Proceed with the deploy?' }],
+      })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.messages).toHaveLength(1)
+      expect(env.sessions.s1.messages[0]).toMatchObject({
+        type: 'prompt',
+        content: 'Proceed with the deploy?',
+      })
+      expect(env.addedMessages).toHaveLength(0)
+      expect(env.notifications).toEqual([
+        { sessionId: 's1', eventType: 'question', message: 'Proceed with the deploy?' },
+      ])
+    })
+
+    it('falls back to addMessage (global log) and skips notify when no session resolves', () => {
+      const env = makeAdapter() // no activeSessionId, no explicit sessionId
+      const handled = dispatch(env, {
+        type: 'user_question',
+        questions: [{ question: 'Anyone there?' }],
+      })
+      expect(handled).toBe(true)
+      expect(env.addedMessages).toHaveLength(1)
+      expect(env.addedMessages[0]).toMatchObject({ type: 'prompt', content: 'Anyone there?' })
+      // sessionId is null → no per-session notification.
+      expect(env.notifications).toHaveLength(0)
+    })
+
+    it('is handled (no mutation) when the questions payload is malformed', () => {
+      const env = makeAdapter({ activeSessionId: 's1', sessions: { s1: { sessionId: 's1', messages: [] } } })
+      const handled = dispatch(env, { type: 'user_question', questions: [] })
+      // The table OWNS the type (returns true) but the parser rejects it.
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.messages).toHaveLength(0)
+      expect(env.addedMessages).toHaveLength(0)
+      expect(env.notifications).toHaveLength(0)
     })
   })
 

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -247,6 +247,24 @@ describe('shared dispatch table', () => {
       ])
     })
 
+    it('honours a finite wire timestamp on the appended prompt (#4613)', () => {
+      const env = makeAdapter({
+        activeSessionId: 'other',
+        sessions: { s1: { sessionId: 's1', messages: [] } },
+      })
+      dispatch(env, {
+        type: 'user_question',
+        sessionId: 's1',
+        questions: [{ question: 'Deploy now?' }],
+        timestamp: 1_700_000_000_000,
+      })
+      expect(env.sessions.s1.messages[0]).toMatchObject({
+        type: 'prompt',
+        content: 'Deploy now?',
+        timestamp: 1_700_000_000_000,
+      })
+    })
+
     it('falls back to addMessage (global log) and skips notify when no session resolves', () => {
       const env = makeAdapter() // no activeSessionId, no explicit sessionId
       const handled = dispatch(env, {

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -457,6 +457,10 @@ export interface DispatchMessageMap {
     sessionId?: string
     toolUseId?: string
     questions?: unknown[]
+    // #4613 — `handleUserQuestion` honours a wire `timestamp` (when a finite
+    // number) for history-replay ordering, falling back to append-time
+    // Date.now(). Documented here so the message shape matches the parser.
+    timestamp?: number
   }
 }
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -99,6 +99,8 @@ import {
   // --- outgoing-message queue mirror (#5937, epic #5935 part ②) ---
   handleMessageQueued,
   handleMessageDequeued,
+  // --- user_question (#5618) — byte-identical parse + append + notify ---
+  handleUserQuestion,
   resolveSessionId,
   type PermissionMode,
   type PermissionRule,
@@ -159,6 +161,16 @@ export interface DispatchSessionBase {
 }
 
 /**
+ * The session-notification event kinds the dispatch handlers may raise (#5618).
+ * Deliberately the INTERSECTION both clients' `SessionNotification['eventType']`
+ * accept — the app's union also has `'plan'`, the dashboard's does not — so a
+ * value of this type is assignable to either client's real
+ * `pushSessionNotification` without a cast. `user_question` only ever passes
+ * `'question'`; widen this only to a kind BOTH clients accept.
+ */
+export type SessionNotificationEventType = 'permission' | 'question' | 'completed' | 'error'
+
+/**
  * The minimal store surface a dispatch-table handler needs. Each client
  * supplies an implementation backed by its own Zustand store. Generic over the
  * client's session-state type `S` so {@link ClientStoreAdapter.updateSession}'s
@@ -195,6 +207,18 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
   addMessage(message: ChatMessage): void
   /** Read the current session list (for `session_updated`). */
   getSessions(): SessionInfo[]
+  /**
+   * Push a per-session notification for a BACKGROUND session event (#5618).
+   * Used by the `user_question` case to surface a question raised in a session
+   * that is not the active one. Each client backs this with its own
+   * `pushSessionNotification` — both dedup by `(sessionId, eventType)` and
+   * early-return when the target IS the active session; the APP additionally
+   * mirrors the row into its mobile push-notification store. That extra
+   * side-effect is platform-specific and lives in the app's impl, exactly like
+   * the app's `activityState` derivation — it is OUTSIDE the shared store-state
+   * contract, so the dispatch handler stays platform-agnostic.
+   */
+  pushSessionNotification(sessionId: string, eventType: SessionNotificationEventType, message: string): void
   /**
    * Resolve a one-shot imperative callback by name (#5653). Used by the
    * file-ops / git wrapper cases, whose only effect is to invoke a callback the
@@ -426,6 +450,13 @@ export interface DispatchMessageMap {
     // #5943 adds 'cancelled' (per-item cancel via cancel_queued) alongside the
     // slice-① 'flush'/'interrupted'. Mirrors ServerMessageDequeuedSchema.reason.
     reason: 'flush' | 'interrupted' | 'cancelled'
+  }
+  // --- user_question (#5618) — the question payload the shared parser reads ---
+  user_question: {
+    type: 'user_question'
+    sessionId?: string
+    toolUseId?: string
+    questions?: unknown[]
   }
 }
 
@@ -892,6 +923,37 @@ function dispatchWebTaskUpsert<S extends DispatchSessionBase>(
   })
 }
 
+/**
+ * `user_question` (#5618) — append the question prompt to its (resolved)
+ * session, falling back to the global log, then raise a background-session
+ * notification. Byte-identical between the two clients' switches: both parsed
+ * via the shared `handleUserQuestion`, appended the prompt, and called
+ * `pushSessionNotification(sessionId, 'question', questionText)`. The only
+ * divergence was inside each client's own `pushSessionNotification` (the app
+ * also hits its mobile push-notification store) — abstracted behind the
+ * adapter method, so this handler stays platform-agnostic.
+ */
+function dispatchUserQuestion<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['user_question'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const parsed = handleUserQuestion(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (!parsed) return
+  const { sessionId, chatMessage, questionText } = parsed
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(
+      sessionId,
+      (ss) =>
+        ({
+          messages: [...ss.messages, chatMessage],
+        } as Partial<S>),
+    )
+  } else {
+    adapter.addMessage(chatMessage)
+  }
+  if (sessionId) adapter.pushSessionNotification(sessionId, 'question', questionText)
+}
+
 // ---------------------------------------------------------------------------
 // Table + runner
 // ---------------------------------------------------------------------------
@@ -962,6 +1024,8 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     // --- outgoing-message queue mirror (#5937, epic #5935 part ②) ---
     message_queued: dispatchQueuedMessages<S>(handleMessageQueued),
     message_dequeued: dispatchQueuedMessages<S>(handleMessageDequeued),
+    // --- user_question (#5618) — byte-identical append + notify ---
+    user_question: dispatchUserQuestion,
   }
 }
 
@@ -1010,6 +1074,8 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'message_dequeued',
   // --- reconciled divergent case (#5618) ---
   'model_changed',
+  // --- user_question (#5618) — byte-identical append + notify ---
+  'user_question',
 ]
 
 /**


### PR DESCRIPTION
## Summary

Continues the dispatch-table migration (#5618 / epic #5556) past the byte-identical surface.

A fresh diff of the two clients' message-handlers (40 common `case` types, normalized) found **`user_question` is the only remaining common case whose store mutation is byte-identical** between app and dashboard. The other ~39 common types carry *intentional* platform divergences — mobile notification-store/`Alert` vs dashboard flat-state/toast, plus race handling like #2833/#5008 — so they are **reconcile-or-document** work, not mechanical moves (see the re-scope comment on #5618).

This PR migrates that one safe type and adds the notification adapter capability that future notification-bearing migrations will reuse.

## Changes

- **`dispatchUserQuestion`** added to the shared table: parse via the existing store-core `handleUserQuestion`, append the prompt to the resolved session (or the global log), then raise the background-session notification.
- **`ClientStoreAdapter.pushSessionNotification`** — new adapter method; each client wires its own impl. The app's extra side-effect (mirroring the row into the mobile push-notification store) stays in the app's impl: it's outside the shared store-state contract, exactly like the app's `activityState` derivation.
- **`SessionNotificationEventType`** is the **intersection** both clients accept (the dashboard's union lacks `'plan'`) so wiring type-checks without a cast. `user_question` only ever passes `'question'`.
- Removed the now-duplicate `case 'user_question'` from both handlers + the now-unused `sharedUserQuestion` import.
- **Behavioral contract:** 3 new `DISPATCH_FIXTURES` rows (append / global-log fallback / malformed no-op); dropped `user_question` from `PENDING_CONTRACT_TYPES`; added dispatch-table unit tests.

## Why behaviour-preserving

`user_question`'s store mutation (append a `prompt` message to the target session or the global log) was already byte-identical; only each client's local `pushSessionNotification` differed (app also hits the mobile push store). The adapter abstracts exactly that difference, so the shared handler is platform-agnostic and each client keeps its own notification behaviour. The contract fixtures prove both clients produce identical store mutations through the shared path.

## Verification

- store-core: **1704** pass (+ typecheck clean) — dispatch-table unit tests, contract fixtures, coverage lint
- protocol: **340** pass — handler-coverage credits `user_question` via `DISPATCH_TABLE_TYPES`
- app: **2035** pass (+ typecheck clean)
- dashboard: **4030** pass (+ typecheck clean)

Related to #5618 (epic #5556) — this is one slice; the issue stays open for the reconcile-or-document remainder.