### PR TITLE
feat(crypto): consume identity-rotation continuity cert at handshake (#5616)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1489,6 +1489,13 @@ function verifyServerIdentityOrRefuse(
   ctx: ConnectionContext,
   exchangePublicKey: string,
   serverKeySig: string | null,
+  // #5616 — identity-rotation continuity cert from the handshake (auth_ok /
+  // key_exchange_ok). When the daemon rotated its identity, `newIdentityKey` is
+  // its current key and `rotationCert` is the old-signed-new cert; a pinned
+  // client whose pin no longer verifies chains forward instead of refusing.
+  // Both null on un-rotated daemons / older servers (refusal path unchanged).
+  newIdentityKey: string | null = null,
+  rotationCert: string | null = null,
 ): { refused: false; pinToPersist: string | null } | { refused: true } {
   const saved = useConnectionLifecycleStore.getState().savedConnection;
   const pinnedIdentityKey = saved?.pinnedIdentityKey ?? null;
@@ -1497,6 +1504,8 @@ function verifyServerIdentityOrRefuse(
     pairingIdentityKey: pendingPairingIdentityKey,
     exchangePublicKey,
     serverKeySig,
+    newIdentityKey,
+    rotationCert,
   });
   if (decision.action === 'refuse') {
     applyIdentityRefusal(ctx, decision.reason, decision.message);
@@ -1807,7 +1816,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // (or pairing-time) identity BEFORE deriving the shared key. On a
           // mismatch this closes the socket and surfaces the refusal; we abort
           // the handshake entirely (no key derived, no post-auth burst).
-          const verdict = verifyServerIdentityOrRefuse(ctx, auth.serverPublicKey, auth.serverKeySig);
+          const verdict = verifyServerIdentityOrRefuse(ctx, auth.serverPublicKey, auth.serverKeySig, auth.newIdentityKey, auth.rotationCert);
           if (verdict.refused) {
             _ctx.pendingKeyPair = null;
             _ctx.pendingSalt = null;
@@ -1880,7 +1889,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // completion point can't leave a timer to fire spuriously. Idempotent.
       clearHandshakeTimer();
       if (_ctx.pendingKeyPair) {
-        const { publicKey: serverPublicKey, serverKeySig } = sharedKeyExchangeOk(msg);
+        const { publicKey: serverPublicKey, serverKeySig, newIdentityKey, rotationCert } = sharedKeyExchangeOk(msg);
         if (!serverPublicKey) {
           console.error('[crypto] Invalid publicKey in key_exchange_ok message', msg.publicKey);
           ctx.socket.close();
@@ -1893,7 +1902,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // #5536 — verify the server's signed exchange key against the pinned (or
         // pairing-time) identity BEFORE deriving the shared key. On a mismatch
         // this closes the socket + surfaces the refusal; abort the handshake.
-        const verdict = verifyServerIdentityOrRefuse(ctx, serverPublicKey, serverKeySig);
+        const verdict = verifyServerIdentityOrRefuse(ctx, serverPublicKey, serverKeySig, newIdentityKey, rotationCert);
         if (verdict.refused) {
           _ctx.pendingKeyPair = null;
           _ctx.pendingSalt = null;

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -36,6 +36,15 @@ import {
   setPendingKeyPair,
 } from './message-handler'
 import { createKeyPair, deriveSharedKey, deriveConnectionKey } from './crypto'
+// #5616 — REAL store-core crypto (NOT the mocked dashboard `./crypto` above) so
+// the rotation handoff runs through genuine signatures. `decideKeyPinWithPairingIdentity`
+// verifies against store-core's own crypto regardless of the `./crypto` mock.
+import {
+  createSigningKeyPair,
+  createKeyPair as realCreateKeyPair,
+  signExchangeKey,
+  signIdentityRotation,
+} from '@chroxy/store-core'
 import type { ConnectionState } from './types'
 
 // ---------------------------------------------------------------------------
@@ -687,6 +696,102 @@ describe('auth_ok handler', () => {
       const state = store.getState()
       expect(state.wsUrl).toBe('wss://my.server.com')
       expect(state.apiToken).toBe('my-tok')
+    })
+  })
+
+  // #5616 — the dashboard-specific consume half: a valid rotation cert must
+  // CHAIN THE PIN FORWARD in the server registry (not just connect this
+  // session). Regression guard for the missing `rotate-pin` persist arm — the
+  // handshake-e2e harness models the app's `pinToPersist` return shape, this
+  // exercises the dashboard's `updateServer` registry side effect end-to-end.
+  describe('identity-rotation pin handoff (#5616)', () => {
+    /** Seed a store whose active server is pinned to `pinnedKey`, tracking writes. */
+    function seedPinnedStore(pinnedKey: string) {
+      const s = createMockStore({
+        connectionPhase: 'connecting',
+        socket: null,
+        sessions: [],
+        activeSessionId: null,
+        sessionStates: {},
+        messages: [],
+        activeServerId: 'srv-1',
+        serverRegistry: [{ id: 'srv-1', name: 'Mac', wsUrl: 'wss://t', pinnedIdentityKey: pinnedKey }],
+      } as unknown as ConnectionState)
+      // Real registry semantics: updateServer patches the matching entry.
+      ;(s.getState() as unknown as { updateServer: unknown }).updateServer = (
+        id: string,
+        patch: Record<string, unknown>,
+      ) =>
+        s.setState((prev: ConnectionState) => ({
+          serverRegistry: (prev as unknown as { serverRegistry: Array<{ id: string }> }).serverRegistry.map(
+            (e) => (e.id === id ? { ...e, ...patch } : e),
+          ),
+        }) as Partial<ConnectionState>)
+      return s
+    }
+
+    function pinOf(s: ReturnType<typeof createMockStore>): string | undefined {
+      const reg = (s.getState() as unknown as { serverRegistry: Array<{ id: string; pinnedIdentityKey?: string }> })
+        .serverRegistry
+      return reg.find((e) => e.id === 'srv-1')?.pinnedIdentityKey
+    }
+
+    it('chains the registry pin forward to the new identity on a valid cert', () => {
+      const oldId = createSigningKeyPair()
+      const newId = createSigningKeyPair()
+      const exchange = realCreateKeyPair()
+      // The current (rotated) identity signs the LIVE exchange key; the OLD
+      // identity signs the new one (the continuity cert).
+      const serverKeySig = signExchangeKey(exchange.publicKey, newId.secretKey)
+      const rotationCert = signIdentityRotation(newId.publicKey, oldId.secretKey)
+
+      store = seedPinnedStore(oldId.publicKey)
+      setStore(store)
+      prepareEagerKeyExchange()
+
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(
+        createAuthOkMessage({
+          encryption: 'required',
+          serverPublicKey: exchange.publicKey,
+          serverKeySig,
+          newIdentityKey: newId.publicKey,
+          rotationCert,
+        }),
+        ctx as any,
+      )
+
+      // Pin chained forward — NOT left at the old key (the #5978 silent-drop bug).
+      expect(pinOf(store)).toBe(newId.publicKey)
+    })
+
+    it('REFUSES and leaves the pin unchanged when the continuity cert is forged', () => {
+      const oldId = createSigningKeyPair()
+      const newId = createSigningKeyPair()
+      const attacker = createSigningKeyPair()
+      const exchange = realCreateKeyPair()
+      const serverKeySig = signExchangeKey(exchange.publicKey, newId.secretKey)
+      // Forged: signed by an unrelated key, not the pinned old identity.
+      const rotationCert = signIdentityRotation(newId.publicKey, attacker.secretKey)
+
+      store = seedPinnedStore(oldId.publicKey)
+      setStore(store)
+      prepareEagerKeyExchange()
+
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(
+        createAuthOkMessage({
+          encryption: 'required',
+          serverPublicKey: exchange.publicKey,
+          serverKeySig,
+          newIdentityKey: newId.publicKey,
+          rotationCert,
+        }),
+        ctx as any,
+      )
+
+      // Fail closed: the old pin stays put, no silent forward-chain.
+      expect(pinOf(store)).toBe(oldId.publicKey)
     })
   })
 })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1149,8 +1149,17 @@ function verifyServerIdentityOrRefuse(
     applyIdentityRefusal(ctx, decision.reason, decision.message);
     return false;
   }
-  // Connect — pin on first use, then clear the pairing identity.
-  if (decision.action === 'pin-and-connect' && activeServerId) {
+  // Connect — persist the offered identity as the new pin, then clear the
+  // pairing identity. #5616 (#5978 parity with the app): BOTH TOFU first-use
+  // ('pin-and-connect') AND a forward-chained rotation ('rotate-pin', where the
+  // old pinned identity signed the new one) re-pin. Without the explicit
+  // 'rotate-pin' arm the dashboard would connect this session but DROP the new
+  // pin, so the next connect re-enters the handoff every time and the user is
+  // locked out once the cert stops being offered.
+  if (
+    (decision.action === 'pin-and-connect' || decision.action === 'rotate-pin') &&
+    activeServerId
+  ) {
     getStore().getState().updateServer(activeServerId, { pinnedIdentityKey: decision.identityKey });
   }
   setPendingPairingIdentityKey(null);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1123,6 +1123,13 @@ function verifyServerIdentityOrRefuse(
   ctx: { socket: WebSocket; silent: boolean },
   exchangePublicKey: string,
   serverKeySig: string | null,
+  // #5616 — identity-rotation continuity cert from the handshake (auth_ok /
+  // key_exchange_ok). When the daemon rotated its identity, `newIdentityKey` is
+  // its current key and `rotationCert` is the old-signed-new cert; a pinned
+  // client whose pin no longer verifies chains forward instead of refusing.
+  // Both null on un-rotated daemons / older servers (refusal path unchanged).
+  newIdentityKey: string | null = null,
+  rotationCert: string | null = null,
 ): boolean {
   const state = getStore().getState();
   const activeServerId = state.activeServerId;
@@ -1135,6 +1142,8 @@ function verifyServerIdentityOrRefuse(
     pairingIdentityKey: getPendingPairingIdentityKey(),
     exchangePublicKey,
     serverKeySig,
+    newIdentityKey,
+    rotationCert,
   });
   if (decision.action === 'refuse') {
     applyIdentityRefusal(ctx, decision.reason, decision.message);
@@ -3418,7 +3427,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // #5536 — verify the server's signed exchange key against the pinned
           // (or pairing-time) identity BEFORE deriving the shared key. On a
           // mismatch this closes the socket + surfaces the refusal; abort.
-          if (!verifyServerIdentityOrRefuse(ctx, auth.serverPublicKey, auth.serverKeySig)) {
+          if (!verifyServerIdentityOrRefuse(ctx, auth.serverPublicKey, auth.serverKeySig, auth.newIdentityKey, auth.rotationCert)) {
             _pendingKeyPair = null;
             _pendingSalt = null;
             break;
@@ -3478,7 +3487,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'key_exchange_ok': {
       if (_pendingKeyPair) {
-        const { publicKey: serverPublicKey, serverKeySig } = sharedKeyExchangeOk(msg);
+        const { publicKey: serverPublicKey, serverKeySig, newIdentityKey, rotationCert } = sharedKeyExchangeOk(msg);
         if (!serverPublicKey) {
           console.error('[crypto] Invalid publicKey in key_exchange_ok message', msg.publicKey);
           ctx.socket.close();
@@ -3490,7 +3499,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // #5536 — verify the server's signed exchange key against the pinned (or
         // pairing-time) identity BEFORE deriving the shared key. On a mismatch
         // this closes the socket + surfaces the refusal; abort the handshake.
-        if (!verifyServerIdentityOrRefuse(ctx, serverPublicKey, serverKeySig)) {
+        if (!verifyServerIdentityOrRefuse(ctx, serverPublicKey, serverKeySig, newIdentityKey, rotationCert)) {
           _pendingKeyPair = null;
           _pendingSalt = null;
           break;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -97,6 +97,8 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
     }, z.core.$strip>>;
     serverPublicKey: z.ZodOptional<z.ZodString>;
     serverKeySig: z.ZodOptional<z.ZodString>;
+    newIdentityKey: z.ZodOptional<z.ZodString>;
+    rotationCert: z.ZodOptional<z.ZodString>;
     availablePermissionModes: z.ZodOptional<z.ZodArray<z.ZodObject<{
         id: z.ZodString;
         label: z.ZodString;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -146,6 +146,19 @@ export const ServerAuthOkSchema = z.object({
     // time before keying off `serverPublicKey`. Absent for unpinned daemons /
     // older servers — old clients ignore it (TOFU unchanged).
     serverKeySig: z.string().max(512).optional(),
+    // #5616 (identity-key rotation handoff) — continuity-cert fields, present on
+    // the eager path only when the daemon's identity has been rotated and a
+    // continuity cert was minted at rotation time. `newIdentityKey` is the
+    // daemon's CURRENT (post-rotation) base64 Ed25519 identity public key;
+    // `rotationCert` is the base64 detached signature of `newIdentityKey` made by
+    // the PREVIOUS (pinned) identity's secret key. A pinned client whose stored
+    // pin no longer matches `serverKeySig` uses the pair to chain its pin forward
+    // (verify old-signed-new + new signed THIS exchange key) instead of refusing.
+    // Absent for un-rotated daemons / older servers — clients ignore them and the
+    // pin-mismatch path is unchanged (refuse → manual re-pair). Same shape as
+    // `serverKeySig` so the existing 512-char base64 bound applies.
+    newIdentityKey: z.string().max(512).optional(),
+    rotationCert: z.string().max(512).optional(),
     // #5555 (auth_bootstrap) — fold the static permission-mode enum into auth_ok
     // so a new client reads it here instead of waiting for the discrete
     // `available_permission_modes` burst frame (still sent for older clients).

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -151,6 +151,19 @@ export const ServerAuthOkSchema = z.object({
   // time before keying off `serverPublicKey`. Absent for unpinned daemons /
   // older servers — old clients ignore it (TOFU unchanged).
   serverKeySig: z.string().max(512).optional(),
+  // #5616 (identity-key rotation handoff) — continuity-cert fields, present on
+  // the eager path only when the daemon's identity has been rotated and a
+  // continuity cert was minted at rotation time. `newIdentityKey` is the
+  // daemon's CURRENT (post-rotation) base64 Ed25519 identity public key;
+  // `rotationCert` is the base64 detached signature of `newIdentityKey` made by
+  // the PREVIOUS (pinned) identity's secret key. A pinned client whose stored
+  // pin no longer matches `serverKeySig` uses the pair to chain its pin forward
+  // (verify old-signed-new + new signed THIS exchange key) instead of refusing.
+  // Absent for un-rotated daemons / older servers — clients ignore them and the
+  // pin-mismatch path is unchanged (refuse → manual re-pair). Same shape as
+  // `serverKeySig` so the existing 512-char base64 bound applies.
+  newIdentityKey: z.string().max(512).optional(),
+  rotationCert: z.string().max(512).optional(),
   // #5555 (auth_bootstrap) — fold the static permission-mode enum into auth_ok
   // so a new client reads it here instead of waiting for the discrete
   // `available_permission_modes` burst frame (still sent for older clients).

--- a/packages/store-core/src/handlers/auth.ts
+++ b/packages/store-core/src/handlers/auth.ts
@@ -130,6 +130,23 @@ export interface AuthOkPayload {
    */
   serverKeySig: string | null
   /**
+   * #5616 (identity-key rotation handoff) — the daemon's CURRENT (post-rotation)
+   * base64 Ed25519 identity public key, present only when the daemon rotated its
+   * identity and minted a continuity cert. Paired with {@link rotationCert}. A
+   * pinned client whose stored pin no longer verifies `serverKeySig` re-pins to
+   * THIS key once the cert chain checks out. Null when absent (un-rotated daemon
+   * / older server) — same `typeof === 'string' && truthy` validation as
+   * `serverKeySig`.
+   */
+  newIdentityKey: string | null
+  /**
+   * #5616 — base64 Ed25519 detached signature of {@link newIdentityKey} made by
+   * the PREVIOUS (pinned) identity's secret key (the "old signs new" continuity
+   * cert, minted at rotation time). The client verifies it against its stored
+   * pin before chaining forward. Null when absent.
+   */
+  rotationCert: string | null
+  /**
    * #5555 (auth_bootstrap) — the static permission-mode enum folded into
    * auth_ok so a new client doesn't have to wait for the discrete
    * `available_permission_modes` burst frame. Validated with the same shape
@@ -213,6 +230,13 @@ export function handleAuthOk(msg: Record<string, unknown>): AuthOkPayload {
     // missing/empty/non-string (unpinned daemon / discrete path).
     serverKeySig:
       typeof msg.serverKeySig === 'string' && msg.serverKeySig ? msg.serverKeySig : null,
+    // #5616 — identity-rotation continuity cert. Null for missing/empty/non-
+    // string (un-rotated daemon / older server), exactly the "no cert → can't
+    // chain forward → refuse" signal the pin-decision keys off.
+    newIdentityKey:
+      typeof msg.newIdentityKey === 'string' && msg.newIdentityKey ? msg.newIdentityKey : null,
+    rotationCert:
+      typeof msg.rotationCert === 'string' && msg.rotationCert ? msg.rotationCert : null,
     // #5555 — reuse the discrete-frame parser on the folded field. Absent /
     // non-array → null so the consumer falls back to the discrete frame.
     availablePermissionModes: Array.isArray(msg.availablePermissionModes)
@@ -242,7 +266,12 @@ export function handleAuthFail(msg: Record<string, unknown>): { reason: string }
  * setting `_encryptionState`, sending post-auth WS messages) stay at the call
  * site — they touch crypto state and the websocket directly.
  */
-export function handleKeyExchangeOk(msg: Record<string, unknown>): { publicKey: string | null; serverKeySig: string | null } {
+export function handleKeyExchangeOk(msg: Record<string, unknown>): {
+  publicKey: string | null
+  serverKeySig: string | null
+  newIdentityKey: string | null
+  rotationCert: string | null
+} {
   const raw = msg.publicKey
   const sig = msg.serverKeySig
   return {
@@ -250,6 +279,12 @@ export function handleKeyExchangeOk(msg: Record<string, unknown>): { publicKey: 
     // #5536 — Ed25519 signature (base64) over publicKey, present when the daemon
     // has a pinned identity. Null when absent (unpinned daemon / older server).
     serverKeySig: typeof sig === 'string' && sig ? sig : null,
+    // #5616 — identity-rotation continuity cert on the discrete path. Same
+    // validation + null semantics as the eager (auth_ok) path.
+    newIdentityKey:
+      typeof msg.newIdentityKey === 'string' && msg.newIdentityKey ? msg.newIdentityKey : null,
+    rotationCert:
+      typeof msg.rotationCert === 'string' && msg.rotationCert ? msg.rotationCert : null,
   }
 }
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1461,6 +1461,9 @@ describe('handleAuthOk', () => {
       capabilities: { notificationPrefs: true, somethingElse: false },
       serverPublicKey: 'srv-pub-key',
       serverKeySig: 'srv-key-sig',
+      // #5616 — identity-rotation continuity cert.
+      newIdentityKey: 'new-id-key',
+      rotationCert: 'rotation-cert-sig',
       // #5555 — folded static permission-mode enum.
       availablePermissionModes: [
         { id: 'approve', label: 'Approve' },
@@ -1484,6 +1487,8 @@ describe('handleAuthOk', () => {
       serverCapabilities: { notificationPrefs: true, somethingElse: false },
       serverPublicKey: 'srv-pub-key',
       serverKeySig: 'srv-key-sig',
+      newIdentityKey: 'new-id-key',
+      rotationCert: 'rotation-cert-sig',
       availablePermissionModes: [
         { id: 'approve', label: 'Approve' },
         { id: 'auto', label: 'Auto' },
@@ -1503,6 +1508,21 @@ describe('handleAuthOk', () => {
     expect(handleAuthOk({ serverPublicKey: '' }).serverPublicKey).toBeNull()
     expect(handleAuthOk({ serverPublicKey: 42 }).serverPublicKey).toBeNull()
     expect(handleAuthOk({ serverPublicKey: null }).serverPublicKey).toBeNull()
+  })
+
+  // #5616 — identity-rotation continuity-cert fields.
+  it('extracts the rotation continuity cert (newIdentityKey + rotationCert)', () => {
+    const result = handleAuthOk({ newIdentityKey: 'new-id', rotationCert: 'cert-sig' })
+    expect(result.newIdentityKey).toBe('new-id')
+    expect(result.rotationCert).toBe('cert-sig')
+  })
+
+  it('returns null cert fields when absent, empty, or non-string (un-rotated/old server)', () => {
+    expect(handleAuthOk({}).newIdentityKey).toBeNull()
+    expect(handleAuthOk({}).rotationCert).toBeNull()
+    expect(handleAuthOk({ newIdentityKey: '', rotationCert: '' }).newIdentityKey).toBeNull()
+    expect(handleAuthOk({ newIdentityKey: 42, rotationCert: {} }).newIdentityKey).toBeNull()
+    expect(handleAuthOk({ newIdentityKey: null, rotationCert: null }).rotationCert).toBeNull()
   })
 
   it('rejects unknown serverMode values', () => {
@@ -1724,6 +1744,8 @@ describe('handleAuthOk', () => {
       serverCapabilities: {},
       serverPublicKey: null,
       serverKeySig: null,
+      newIdentityKey: null,
+      rotationCert: null,
       availablePermissionModes: null,
     })
   })
@@ -1849,34 +1871,51 @@ describe('handleAuthFail', () => {
 // handleKeyExchangeOk
 // ---------------------------------------------------------------------------
 describe('handleKeyExchangeOk', () => {
+  // #5616 — the no-cert baseline shape (all four keys, cert fields null).
+  const NO_CERT = { newIdentityKey: null, rotationCert: null }
+
   it('extracts publicKey string', () => {
     expect(handleKeyExchangeOk({ publicKey: 'base64key==' })).toEqual({
       publicKey: 'base64key==',
       serverKeySig: null,
+      ...NO_CERT,
     })
   })
 
   it('returns null publicKey when missing', () => {
-    expect(handleKeyExchangeOk({})).toEqual({ publicKey: null, serverKeySig: null })
+    expect(handleKeyExchangeOk({})).toEqual({ publicKey: null, serverKeySig: null, ...NO_CERT })
   })
 
   it('returns null publicKey for non-string values', () => {
     // Matches inline guard: `if (!msg.publicKey || typeof msg.publicKey !== 'string')`
-    expect(handleKeyExchangeOk({ publicKey: 42 })).toEqual({ publicKey: null, serverKeySig: null })
-    expect(handleKeyExchangeOk({ publicKey: null })).toEqual({ publicKey: null, serverKeySig: null })
-    expect(handleKeyExchangeOk({ publicKey: '' })).toEqual({ publicKey: null, serverKeySig: null })
+    expect(handleKeyExchangeOk({ publicKey: 42 })).toEqual({ publicKey: null, serverKeySig: null, ...NO_CERT })
+    expect(handleKeyExchangeOk({ publicKey: null })).toEqual({ publicKey: null, serverKeySig: null, ...NO_CERT })
+    expect(handleKeyExchangeOk({ publicKey: '' })).toEqual({ publicKey: null, serverKeySig: null, ...NO_CERT })
   })
 
   it('#5536 — extracts the serverKeySig when present', () => {
     expect(handleKeyExchangeOk({ publicKey: 'pk==', serverKeySig: 'sig==' })).toEqual({
       publicKey: 'pk==',
       serverKeySig: 'sig==',
+      ...NO_CERT,
     })
   })
 
   it('#5536 — null serverKeySig for missing / empty / non-string', () => {
     expect(handleKeyExchangeOk({ publicKey: 'pk==', serverKeySig: '' }).serverKeySig).toBe(null)
     expect(handleKeyExchangeOk({ publicKey: 'pk==', serverKeySig: 42 }).serverKeySig).toBe(null)
+  })
+
+  it('#5616 — extracts the rotation cert on the discrete path', () => {
+    expect(
+      handleKeyExchangeOk({ publicKey: 'pk==', newIdentityKey: 'new-id', rotationCert: 'cert==' }),
+    ).toEqual({ publicKey: 'pk==', serverKeySig: null, newIdentityKey: 'new-id', rotationCert: 'cert==' })
+  })
+
+  it('#5616 — null cert fields for missing / empty / non-string', () => {
+    expect(handleKeyExchangeOk({ publicKey: 'pk==' }).newIdentityKey).toBe(null)
+    expect(handleKeyExchangeOk({ publicKey: 'pk==', newIdentityKey: '' }).newIdentityKey).toBe(null)
+    expect(handleKeyExchangeOk({ publicKey: 'pk==', rotationCert: 99 }).rotationCert).toBe(null)
   })
 })
 

--- a/packages/store-core/src/handshake-e2e/fake-ws.ts
+++ b/packages/store-core/src/handshake-e2e/fake-ws.ts
@@ -311,9 +311,14 @@ export class FakeHandshakeClient {
     const exchangePublicKey = authOk.serverPublicKey as string
     const serverKeySig = (authOk.serverKeySig as string | undefined) ?? null
     // #5616 — the rotation continuity cert, threaded into the pin decision
-    // exactly as the real clients do (app/dashboard message-handler.ts).
-    const newIdentityKey = (authOk.newIdentityKey as string | undefined) ?? null
-    const rotationCert = (authOk.rotationCert as string | undefined) ?? null
+    // exactly as the real clients do: the production parsers (handleAuthOk /
+    // handleKeyExchangeOk) normalise empty/non-string to null, so mirror that
+    // `typeof === 'string' && truthy ? v : null` guard here rather than a raw
+    // cast (which would treat '' / non-strings as present).
+    const newIdentityKey =
+      typeof authOk.newIdentityKey === 'string' && authOk.newIdentityKey ? authOk.newIdentityKey : null
+    const rotationCert =
+      typeof authOk.rotationCert === 'string' && authOk.rotationCert ? authOk.rotationCert : null
 
     // #5614 — the plaintext-downgrade gate runs FIRST, exactly as production does
     // (before the encryption branch / pin check). A pinned connection whose

--- a/packages/store-core/src/handshake-e2e/fake-ws.ts
+++ b/packages/store-core/src/handshake-e2e/fake-ws.ts
@@ -28,6 +28,7 @@ import {
   createKeyPair,
   createSigningKeyPair,
   signExchangeKey,
+  signIdentityRotation,
   deriveSharedKey,
   deriveConnectionKey,
   generateConnectionSalt,
@@ -158,6 +159,18 @@ export interface FakeServerOptions {
   omitSignature?: boolean
   /** Sign with a DIFFERENT identity key than the one the client pinned (MITM). */
   forgeSignature?: boolean
+  /**
+   * #5616 — simulate a ROTATED daemon identity. When set to the PREVIOUS
+   * (pinned) identity keypair, auth_ok carries a continuity cert: `serverKeySig`
+   * is signed by the CURRENT identity (`this.identity`), `newIdentityKey` is the
+   * current public key, and `rotationCert` is the current key signed by this
+   * previous secret ("old signs new"). A client pinned to the previous public
+   * key chains forward instead of refusing. With `forgeRotationCert`, the cert
+   * is signed by an UNRELATED key (attacker who never held the old secret).
+   */
+  rotatedFrom?: SigningKeyPair
+  /** Sign the rotation cert with an unrelated key (forged-continuity attack). */
+  forgeRotationCert?: boolean
 }
 
 export interface ReplayEntrySpec {
@@ -205,10 +218,23 @@ export class FakeHandshakeServer {
           this.exchange.publicKey,
           this.opts.forgeSignature ? this.forgedIdentity.secretKey : this.identity.secretKey,
         )
+    // #5616 — when simulating a rotated identity, present the continuity cert:
+    // newIdentityKey = current public key; rotationCert = current key signed by
+    // the PREVIOUS secret ("old signs new"). forgeRotationCert signs with an
+    // unrelated key (an attacker who never held the old secret).
+    let rotationFields: Record<string, unknown> = {}
+    if (this.opts.rotatedFrom) {
+      const signer = this.opts.forgeRotationCert ? this.forgedIdentity : this.opts.rotatedFrom
+      rotationFields = {
+        newIdentityKey: this.identity.publicKey,
+        rotationCert: signIdentityRotation(this.identity.publicKey, signer.secretKey),
+      }
+    }
     return {
       type: 'auth_ok',
       serverPublicKey: this.exchange.publicKey,
       ...(serverKeySig ? { serverKeySig } : {}),
+      ...rotationFields,
       salt: this.salt,
       encryption: 'required',
       capabilities: { authBootstrap: true },
@@ -284,6 +310,10 @@ export class FakeHandshakeClient {
     this.phases.push('auth_ok')
     const exchangePublicKey = authOk.serverPublicKey as string
     const serverKeySig = (authOk.serverKeySig as string | undefined) ?? null
+    // #5616 — the rotation continuity cert, threaded into the pin decision
+    // exactly as the real clients do (app/dashboard message-handler.ts).
+    const newIdentityKey = (authOk.newIdentityKey as string | undefined) ?? null
+    const rotationCert = (authOk.rotationCert as string | undefined) ?? null
 
     // #5614 — the plaintext-downgrade gate runs FIRST, exactly as production does
     // (before the encryption branch / pin check). A pinned connection whose
@@ -311,6 +341,8 @@ export class FakeHandshakeClient {
       pairingIdentityKey: this.opts.pairingIdentityKey ?? null,
       exchangePublicKey,
       serverKeySig,
+      newIdentityKey,
+      rotationCert,
     })
 
     if (decision.action === 'refuse') {
@@ -319,7 +351,9 @@ export class FakeHandshakeClient {
       return decision
     }
 
-    if (decision.action === 'pin-and-connect') {
+    // #5616 — TOFU first-use AND a forward-chained rotation both persist the
+    // offered identity as the new pin (mirrors app/dashboard message-handler.ts).
+    if (decision.action === 'pin-and-connect' || decision.action === 'rotate-pin') {
       this.store.pin(decision.identityKey)
     }
 

--- a/packages/store-core/src/handshake-e2e/handshake.test.ts
+++ b/packages/store-core/src/handshake-e2e/handshake.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { createSigningKeyPair, type SigningKeyPair } from '../crypto'
 import {
   FakeHandshakeServer,
   FakeHandshakeClient,
@@ -34,6 +35,10 @@ interface RunOpts {
   pairingIdentityKey?: string | null
   omitSignature?: boolean
   forgeSignature?: boolean
+  /** #5616 — simulate a rotated daemon identity (the PREVIOUS keypair). */
+  rotatedFrom?: SigningKeyPair
+  /** #5616 — sign the rotation cert with an unrelated key (forged continuity). */
+  forgeRotationCert?: boolean
   /** Replay entries to deliver (encrypted), in order. */
   replay?: ReplayEntrySpec[]
   /** fullHistory flag on the replay-start frame. */
@@ -54,6 +59,8 @@ function fullSequence(opts: RunOpts) {
   const server = new FakeHandshakeServer({
     omitSignature: opts.omitSignature,
     forgeSignature: opts.forgeSignature,
+    rotatedFrom: opts.rotatedFrom,
+    forgeRotationCert: opts.forgeRotationCert,
   })
   const store = makeMemoryStore()
   if (opts.preSeed) {
@@ -293,6 +300,100 @@ describe('encrypted handshake — pinned-key verification matrix (#5556.6)', () 
     expect(decision.action).toBe('connect')
     if (decision.action === 'connect') expect(decision.reason).toBe('unpinned-no-identity')
     expect(store.state.encryptionActive).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5616 — identity-rotation continuity-cert handoff matrix
+// ---------------------------------------------------------------------------
+
+describe('encrypted handshake — identity-rotation handoff (#5616)', () => {
+  it('a pinned client CHAINS its pin forward on a valid rotation cert (no re-pair)', () => {
+    const prev = createSigningKeyPair()
+    // Server rotated: current identity is fresh; auth_ok carries newIdentityKey +
+    // a cert signed by `prev` (the key the client pinned before rotation).
+    const server = new FakeHandshakeServer({ rotatedFrom: prev })
+    const store = makeMemoryStore()
+    const client = new FakeHandshakeClient(store, { pinnedIdentityKey: prev.publicKey })
+    const auth = client.sendAuth()
+    server.keyExchangeWithClient(auth.publicKey as string)
+
+    const decision = client.handleAuthOk(server.authOk())
+    expect(decision.action).toBe('rotate-pin')
+    if (decision.action === 'rotate-pin') {
+      expect(decision.reason).toBe('identity-rotated')
+      // Re-pins to the CURRENT (post-rotation) identity, not the old one.
+      expect(decision.identityKey).toBe(server.identityPublicKey)
+    }
+    // The new identity is persisted and the connection proceeds (no refusal).
+    expect(store.state.pinnedIdentity).toBe(server.identityPublicKey)
+    expect(store.state.refusal).toBeNull()
+    expect(store.state.encryptionActive).toBe(true)
+  })
+
+  it('REFUSES a forged continuity cert (attacker who never held the old secret)', () => {
+    const prev = createSigningKeyPair()
+    // Cert is signed by an UNRELATED key, not `prev` — the old identity never
+    // actually signed this new one.
+    const server = new FakeHandshakeServer({ rotatedFrom: prev, forgeRotationCert: true })
+    const store = makeMemoryStore()
+    const client = new FakeHandshakeClient(store, { pinnedIdentityKey: prev.publicKey })
+    const auth = client.sendAuth()
+    server.keyExchangeWithClient(auth.publicKey as string)
+
+    const decision = client.handleAuthOk(server.authOk())
+    expect(decision.action).toBe('refuse')
+    expect(store.state.refusal).not.toBeNull()
+    expect(store.state.pinnedIdentity).toBeNull()
+    expect(store.state.encryptionActive).toBe(false)
+  })
+
+  it('REFUSES a replayed cert whose new identity did NOT sign the live exchange key', () => {
+    const prev = createSigningKeyPair()
+    // Valid continuity cert (prev signed current) BUT the live serverKeySig is
+    // forged (signed by neither current nor prev) — a captured cert replayed
+    // without the new identity's live signature. Liveness check must fail closed.
+    const server = new FakeHandshakeServer({ rotatedFrom: prev, forgeSignature: true })
+    const store = makeMemoryStore()
+    const client = new FakeHandshakeClient(store, { pinnedIdentityKey: prev.publicKey })
+    const auth = client.sendAuth()
+    server.keyExchangeWithClient(auth.publicKey as string)
+
+    const decision = client.handleAuthOk(server.authOk())
+    expect(decision.action).toBe('refuse')
+    expect(store.state.pinnedIdentity).toBeNull()
+    expect(store.state.encryptionActive).toBe(false)
+  })
+
+  it('IGNORES the cert when the pin already matches the current identity (no rotation needed)', () => {
+    const prev = createSigningKeyPair()
+    const server = new FakeHandshakeServer({ rotatedFrom: prev })
+    const store = makeMemoryStore()
+    // Client is already pinned to the CURRENT identity — serverKeySig verifies
+    // directly, so the offered cert is irrelevant; a plain connect, no re-pin.
+    const client = new FakeHandshakeClient(store, { pinnedIdentityKey: server.identityPublicKey })
+    const auth = client.sendAuth()
+    server.keyExchangeWithClient(auth.publicKey as string)
+
+    const decision = client.handleAuthOk(server.authOk())
+    expect(decision.action).toBe('connect')
+    expect(store.state.refusal).toBeNull()
+    expect(store.state.encryptionActive).toBe(true)
+  })
+
+  it('an un-rotated daemon (no cert) still REFUSES a genuine pin mismatch', () => {
+    // No rotatedFrom → no cert offered; the daemon simply signs with a DIFFERENT
+    // identity than the client pinned (the classic MITM / lost-continuity case).
+    // Without a cert there is nothing to chain forward → refuse → manual re-pair.
+    const server = new FakeHandshakeServer({ forgeSignature: true })
+    const store = makeMemoryStore()
+    const client = new FakeHandshakeClient(store, { pinnedIdentityKey: createSigningKeyPair().publicKey })
+    const auth = client.sendAuth()
+    server.keyExchangeWithClient(auth.publicKey as string)
+
+    const decision = client.handleAuthOk(server.authOk())
+    expect(decision.action).toBe('refuse')
+    expect(store.state.encryptionActive).toBe(false)
   })
 })
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -177,6 +177,11 @@ export {
   createSigningKeyPair,
   signExchangeKey,
   verifyExchangeKeySignature,
+  // #5616 — identity-rotation continuity-cert primitives (produce + verify).
+  // Verify is used internally by key-pinning; both are part of the public
+  // rotation API the server (mint, #6198) and tests consume.
+  signIdentityRotation,
+  verifyIdentityRotation,
   deriveSharedKey,
   nonceFromCounter,
   encrypt,


### PR DESCRIPTION
## Summary

Phase 2 (client + protocol) of the identity-key rotation handoff (#5616). Today a legitimately-rotated daemon identity is indistinguishable from an attacker to a pinned client — both refuse + force a manual re-pair. Phase 1 (#5977) shipped the crypto (`signIdentityRotation`/`verifyIdentityRotation`) and the `tryRotationHandoff` decision tree, **but the clients never passed the cert into the decision**, so the handoff could never fire. This PR wires the transport → decision path so a pinned client can chain its pin forward when a valid continuity cert is presented.

The **server-side cert minting + presentation** (which carries genuine security-design decisions — rotation trigger, cert storage, single-hop vs chain) is split out to **#6198** for maintainer input.

## Changes

- **protocol** — add optional `newIdentityKey` + `rotationCert` to `ServerAuthOkSchema` (eager `auth_ok`; `key_exchange_ok` has no dedicated schema and is read raw). Dist rebuilt.
- **store-core** — surface both fields from `handleAuthOk` + `handleKeyExchangeOk` (same `typeof === 'string' && truthy → value, else null` validation as `serverKeySig`).
- **app + dashboard** — thread the two fields from the parsed handshake message through `verifyServerIdentityOrRefuse` → `decideKeyPinWithPairingIdentity`, on **both** the eager and discrete paths. The `rotate-pin` persistence already existed (#5978).

## Why this is safe

**Behaviour-preserving when no cert is present** (today, always): absent fields → `null` → `tryRotationHandoff` finds no cert → refuses, byte-identical to current behaviour. The change is purely additive and **fails closed** — it can only ever turn a refusal into a re-pin when a cryptographically valid cert + a live new-identity signature both verify (logic already audited + tested in #5977).

## Tests

Extended the store-core handshake-e2e harness (`fake-ws.ts` + `handshake.test.ts`) with a rotation matrix exercising the production decision path end-to-end:
- valid cert → **chains the pin forward** (re-pins to the new identity, no re-pair)
- **forged** continuity cert (attacker who never held the old secret) → refused
- **replayed** cert whose new identity did NOT sign the live exchange key → refused (liveness)
- pin already matches the current identity → cert ignored, plain connect
- un-rotated daemon with a genuine mismatch + no cert → still refused (manual re-pair)

Plus `handleAuthOk`/`handleKeyExchangeOk` parser unit tests for the new fields.

The harness's `handleAuthOk` + `rotate-pin` persistence were updated to mirror the real clients exactly, so the matrix runs the same decision + pin-write path production does.

## Verification

- store-core: **1714** pass (+ typecheck clean)
- protocol: **340** pass (+ typecheck clean)
- app: **2035** pass (+ typecheck clean)
- dashboard: **4030** pass (+ typecheck clean)

Related to #5616 (epic). Server-side produce half tracked in #6198.