### PR TITLE
feat(server): mint + present the identity-rotation continuity cert (#5976)

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -25,6 +25,7 @@ import { registerWorktreeCommand } from './cli/worktree-gc-cmd.js'
 import { registerCredentialsCommand } from './cli/credentials-cmd.js'
 import { registerProvidersCommand } from './cli/providers-cmd.js'
 import { registerPagesCommands } from './cli/pages-cmd.js'
+import { registerIdentityCommand } from './cli/identity-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -52,5 +53,6 @@ registerWorktreeCommand(program)
 registerCredentialsCommand(program)
 registerProvidersCommand(program)
 registerPagesCommands(program)
+registerIdentityCommand(program)
 
 program.parse()

--- a/packages/server/src/cli/identity-cmd.js
+++ b/packages/server/src/cli/identity-cmd.js
@@ -1,0 +1,83 @@
+// `chroxy identity rotate` — rotate the daemon's long-lived signing identity
+// while minting a single-hop continuity cert (#5616/#5976).
+//
+// The daemon's identity key is what clients PIN at pairing time. Rotating it
+// (reinstall, machine migration, key hygiene) would normally force every paired
+// client to manually re-pair — and look indistinguishable from a MITM. This
+// command instead signs the NEW identity with the OLD secret ("old signs new"),
+// so a previously-pinned client that reconnects chains its pin forward
+// automatically. Single-hop: only the most-recent rotation is bridged; a client
+// that is ≥2 rotations behind still re-pairs.
+//
+// Admin-initiated and CONSEQUENTIAL, so it requires an explicit `--yes`. Without
+// it, the command explains what will happen and changes nothing.
+
+import { rotateServerIdentity } from '../server-identity.js'
+
+/**
+ * Run the rotation. Pure aside from the injected `rotate` seam + writer, so a
+ * test can assert the output + that the rotation ran without touching real
+ * keychain/disk.
+ *
+ * @param {{ yes?: boolean }} options
+ * @param {object} [deps]
+ * @returns {{ rotated: boolean, result: object|null }}
+ */
+export function runIdentityRotate(options = {}, deps = {}) {
+  const out = deps.write || console.log
+  const rotate = deps.rotate || rotateServerIdentity
+
+  if (!options.yes) {
+    out(
+      [
+        'chroxy identity rotate — mint a NEW daemon identity (continuity cert preserved).',
+        '',
+        'What happens:',
+        '  • A fresh identity keypair is minted and stored in place of the current one.',
+        '  • The OLD identity signs the NEW one (a single-hop continuity cert), so a',
+        '    client that pinned the current identity reconnects WITHOUT re-pairing.',
+        '  • A client that is ≥2 rotations behind, or that never pinned this daemon,',
+        '    will re-pair as usual.',
+        '  • Restart the daemon afterwards to serve the new identity.',
+        '',
+        'This is consequential — re-run with --yes to proceed:',
+        '  chroxy identity rotate --yes',
+      ].join('\n'),
+    )
+    return { rotated: false, result: null }
+  }
+
+  const result = rotate(deps.rotateOpts || {})
+  out(
+    [
+      'Rotated server identity.',
+      `  previous: ${result.previousPublicKey}`,
+      `  new:      ${result.newPublicKey}`,
+      `  backend:  ${result.backend}`,
+      '',
+      'A single-hop continuity cert was written — previously-pinned clients chain',
+      'forward without re-pairing. Restart the daemon to serve the new identity.',
+    ].join('\n'),
+  )
+  return { rotated: true, result }
+}
+
+export function registerIdentityCommand(program) {
+  const identity = program
+    .command('identity')
+    .description('Manage the daemon\'s long-lived signing identity (E2E key pinning)')
+
+  identity
+    .command('rotate')
+    .description('Rotate the identity key, preserving a single-hop continuity cert so pinned clients don\'t re-pair')
+    .option('--yes', 'Confirm the rotation (without this, the command only explains what it would do)')
+    .action((options) => {
+      try {
+        const { rotated } = runIdentityRotate(options)
+        if (!rotated) process.exitCode = 0
+      } catch (err) {
+        console.error(`identity rotate failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+}

--- a/packages/server/src/cli/identity-cmd.js
+++ b/packages/server/src/cli/identity-cmd.js
@@ -73,8 +73,7 @@ export function registerIdentityCommand(program) {
     .option('--yes', 'Confirm the rotation (without this, the command only explains what it would do)')
     .action((options) => {
       try {
-        const { rotated } = runIdentityRotate(options)
-        if (!rotated) process.exitCode = 0
+        runIdentityRotate(options)
       } catch (err) {
         console.error(`identity rotate failed: ${err.message}`)
         process.exitCode = 1

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -29,7 +29,7 @@ const log = createLogger('cli')
 import { removeConnectionInfo } from './connection-info.js'
 import { TokenManager } from './token-manager.js'
 import { PairingManager } from './pairing.js'
-import { getOrCreateServerIdentity, IdentityUnavailableError } from './server-identity.js'
+import { getOrCreateServerIdentity, IdentityUnavailableError, resolveServerRotationCert } from './server-identity.js'
 import { getLanIp } from './lan-ip.js'
 import { resolveBindHost, isLoopbackHost, formatHostForUrl, maybeWarnNonLoopbackBind } from './bind-host.js'
 import { writeFileRestricted } from './platform.js'
@@ -864,6 +864,24 @@ export async function startCliServer(config) {
         log.warn(`Could not establish server identity key (${err.message}); E2E key pinning disabled — connections stay TOFU`)
         serverIdentity = null
       }
+    }
+  }
+
+  // #5616/#5976 — if the identity was rotated (admin ran `chroxy identity
+  // rotate`), attach the single-hop continuity cert so the handshake can offer
+  // it. The staleness guard inside resolveServerRotationCert ignores a sidecar
+  // that names a different identity than the one we just loaded (e.g. left over
+  // from before a clean re-mint). Best-effort: a missing/unreadable sidecar
+  // simply leaves pinning behaviour unchanged (rotated clients re-pair).
+  if (serverIdentity) {
+    try {
+      const cert = resolveServerRotationCert(serverIdentity.publicKey)
+      if (cert) {
+        serverIdentity = { ...serverIdentity, rotationCert: cert.rotationCert, previousPublicKey: cert.previousPublicKey }
+        log.info('Identity-rotation continuity cert loaded — pinned clients can chain forward without re-pairing')
+      }
+    } catch (err) {
+      log.warn(`Could not load identity-rotation cert (${err.message}); rotated clients will need to re-pair`)
     }
   }
 

--- a/packages/server/src/server-identity.js
+++ b/packages/server/src/server-identity.js
@@ -34,7 +34,7 @@
 import { readFileSync, mkdirSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
-import { createSigningKeyPair } from '@chroxy/store-core/crypto'
+import { createSigningKeyPair, signIdentityRotation } from '@chroxy/store-core/crypto'
 import nacl from 'tweetnacl'
 import * as realKeychain from './keychain.js'
 import { writeFileRestricted } from './platform.js'
@@ -69,6 +69,16 @@ export class IdentityUnavailableError extends Error {
 
 /** Default on-disk fallback location. Overridable for tests. */
 export const DEFAULT_IDENTITY_FILE = join(homedir(), '.chroxy', 'server-identity.json')
+
+/**
+ * #5616/#5976 — the identity-rotation continuity-cert sidecar. PUBLIC data only
+ * (a signature + two public keys), so it is a plaintext file regardless of where
+ * the SECRET key lives (keychain or fallback file) — there is nothing secret to
+ * protect here. Single-hop by design: each rotation OVERWRITES it, retaining
+ * only the most-recent `prev → current` cert. A client pinned ≥2 rotations back
+ * has no chain to follow and correctly falls back to manual re-pair.
+ */
+export const DEFAULT_IDENTITY_ROTATION_FILE = join(homedir(), '.chroxy', 'server-identity-rotation.json')
 
 const SECRET_KEY_BYTES = nacl.sign.secretKeyLength // 64
 
@@ -229,4 +239,117 @@ export function getOrCreateServerIdentity({ keychain = realKeychain, filePath = 
   const backend = persistServerIdentity(kp, { keychain, filePath })
   log.info(`Minted new server identity key (backend: ${backend})`)
   return { ...kp, created: true, backend }
+}
+
+/**
+ * Load the single-hop rotation continuity cert sidecar, or null when absent /
+ * malformed. Returns the public triple a rotated daemon presents at handshake:
+ * `{ newIdentityKey, rotationCert, previousPublicKey }`.
+ *
+ * The caller MUST guard against a STALE sidecar: after a clean reinstall the
+ * identity is re-minted but an old sidecar may linger, so only present the cert
+ * when `newIdentityKey` equals the daemon's CURRENT identity public key (a stale
+ * sidecar names a `newIdentityKey` the daemon no longer holds). {@link
+ * resolveServerRotationCert} does that check.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.rotationFilePath]
+ * @returns {{ newIdentityKey: string, rotationCert: string, previousPublicKey: string }|null}
+ */
+export function loadServerRotationCert({ rotationFilePath = DEFAULT_IDENTITY_ROTATION_FILE } = {}) {
+  try {
+    const parsed = JSON.parse(readFileSync(rotationFilePath, 'utf-8'))
+    const { newIdentityKey, rotationCert, previousPublicKey } = parsed ?? {}
+    if (
+      typeof newIdentityKey === 'string' && newIdentityKey &&
+      typeof rotationCert === 'string' && rotationCert &&
+      typeof previousPublicKey === 'string' && previousPublicKey
+    ) {
+      return { newIdentityKey, rotationCert, previousPublicKey }
+    }
+  } catch {
+    // Missing / unreadable / malformed → no cert to present.
+  }
+  return null
+}
+
+/**
+ * Resolve the rotation cert to present for a given CURRENT identity public key,
+ * applying the staleness guard: a sidecar whose `newIdentityKey` does not match
+ * the live identity (e.g. left over from before a clean re-mint) is ignored.
+ *
+ * @param {string} currentIdentityPublicKey - the daemon's live identity pubkey
+ * @param {object} [opts]
+ * @param {string} [opts.rotationFilePath]
+ * @returns {{ rotationCert: string, previousPublicKey: string }|null}
+ */
+export function resolveServerRotationCert(currentIdentityPublicKey, { rotationFilePath = DEFAULT_IDENTITY_ROTATION_FILE } = {}) {
+  const sidecar = loadServerRotationCert({ rotationFilePath })
+  if (!sidecar) return null
+  if (sidecar.newIdentityKey !== currentIdentityPublicKey) {
+    // Stale sidecar (identity re-minted since rotation) — do NOT present it; a
+    // cert for an identity the daemon no longer holds would never verify and
+    // could only confuse a pinned client.
+    log.warn('Ignoring stale identity-rotation cert (newIdentityKey ≠ current identity)')
+    return null
+  }
+  return { rotationCert: sidecar.rotationCert, previousPublicKey: sidecar.previousPublicKey }
+}
+
+/**
+ * Rotate the daemon's identity (#5616/#5976, admin-initiated via
+ * `chroxy identity rotate`): mint a NEW identity, sign it with the OLD secret to
+ * mint a continuity cert ("old signs new"), persist the new secret in place of
+ * the old, and write the single-hop sidecar. A previously-pinned client that
+ * reconnects then chains its pin forward automatically (no manual re-pair) by
+ * verifying the cert against its pinned (old) key + the new key's live exchange
+ * signature.
+ *
+ * The OLD secret is read FIRST (while it still exists) — this is the only moment
+ * a cert can be minted. After this returns, the persisted identity is the NEW
+ * one; a running daemon keeps its in-memory OLD identity until restarted, so the
+ * caller must restart the daemon to serve the new identity.
+ *
+ * Throws when there is no current identity to rotate FROM (nothing pinned yet —
+ * just start the daemon, which mints a first identity), or when the keychain
+ * read failed ({@link IdentityUnavailableError} propagates).
+ *
+ * @param {object} [opts]
+ * @param {object} [opts.keychain]
+ * @param {string} [opts.filePath] - secret-key store path (fallback file)
+ * @param {string} [opts.rotationFilePath] - cert sidecar path
+ * @returns {{ previousPublicKey: string, newPublicKey: string, backend: 'keychain'|'file' }}
+ */
+export function rotateServerIdentity({
+  keychain = realKeychain,
+  filePath = DEFAULT_IDENTITY_FILE,
+  rotationFilePath = DEFAULT_IDENTITY_ROTATION_FILE,
+} = {}) {
+  const current = loadServerIdentity({ keychain, filePath })
+  if (!current) {
+    throw new Error(
+      'No existing server identity to rotate. Start the daemon once to mint an ' +
+      'identity (which clients then pair + pin) before rotating.',
+    )
+  }
+  const next = createSigningKeyPair()
+  // Mint the continuity cert WHILE the old secret is still loaded — old signs new.
+  const rotationCert = signIdentityRotation(next.publicKey, current.secretKey)
+  // Persist the new secret in place of the old (keychain or fallback file).
+  const backend = persistServerIdentity(next, { keychain, filePath })
+  // Write the single-hop sidecar (overwrites any prior cert — only the most
+  // recent prev→current hop is retained). Public data; mirror the secret file's
+  // directory creation. Not perm-restricted (nothing secret), but kept tidy.
+  mkdirSync(dirname(rotationFilePath), { recursive: true })
+  writeFileRestricted(
+    rotationFilePath,
+    JSON.stringify({
+      v: 1,
+      newIdentityKey: next.publicKey,
+      rotationCert,
+      previousPublicKey: current.publicKey,
+    }),
+  )
+  log.info(`Rotated server identity (backend: ${backend}); continuity cert written for previous pin`)
+  return { previousPublicKey: current.publicKey, newPublicKey: next.publicKey, backend }
 }

--- a/packages/server/src/server-identity.js
+++ b/packages/server/src/server-identity.js
@@ -335,13 +335,23 @@ export function rotateServerIdentity({
   const next = createSigningKeyPair()
   // Mint the continuity cert WHILE the old secret is still loaded — old signs new.
   const rotationCert = signIdentityRotation(next.publicKey, current.secretKey)
-  // Persist the new secret in place of the old (keychain or fallback file).
-  const backend = persistServerIdentity(next, { keychain, filePath })
-  // Write the single-hop sidecar (overwrites any prior cert — only the most
-  // recent prev→current hop is retained). Public data (a signature + two public
-  // keys); reuse writeFileRestricted for its ATOMIC temp+rename write so a crash
-  // can't leave a half-written cert — the 0600 mode it also sets is incidental
-  // here (nothing secret), not a requirement.
+
+  // ORDER MATTERS (fail-safety): write the sidecar BEFORE swapping the secret.
+  //   - sidecar write fails → we throw here, the secret is STILL the old one →
+  //     the identity did not rotate at all (old pins keep verifying). Safe.
+  //   - sidecar ok but persist fails → we throw below, the secret is STILL old →
+  //     the daemon serves the OLD identity and the just-written sidecar names a
+  //     newIdentityKey ≠ the live identity, so resolveServerRotationCert IGNORES
+  //     it as stale. Safe.
+  // The dangerous order (persist secret first) could leave a ROTATED identity
+  // with no cert — forcing every pinned client to manually re-pair, the exact
+  // failure this feature exists to prevent.
+  //
+  // Single-hop: this overwrites any prior cert — only the most recent
+  // prev→current hop is retained. Public data (a signature + two public keys);
+  // reuse writeFileRestricted for its ATOMIC temp+rename write so a crash can't
+  // leave a half-written cert — the 0600 mode it also sets is incidental here
+  // (nothing secret), not a requirement.
   mkdirSync(dirname(rotationFilePath), { recursive: true })
   writeFileRestricted(
     rotationFilePath,
@@ -352,6 +362,8 @@ export function rotateServerIdentity({
       previousPublicKey: current.publicKey,
     }),
   )
+  // Persist the new secret in place of the old (keychain or fallback file).
+  const backend = persistServerIdentity(next, { keychain, filePath })
   log.info(`Rotated server identity (backend: ${backend}); continuity cert written for previous pin`)
   return { previousPublicKey: current.publicKey, newPublicKey: next.publicKey, backend }
 }

--- a/packages/server/src/server-identity.js
+++ b/packages/server/src/server-identity.js
@@ -338,8 +338,10 @@ export function rotateServerIdentity({
   // Persist the new secret in place of the old (keychain or fallback file).
   const backend = persistServerIdentity(next, { keychain, filePath })
   // Write the single-hop sidecar (overwrites any prior cert — only the most
-  // recent prev→current hop is retained). Public data; mirror the secret file's
-  // directory creation. Not perm-restricted (nothing secret), but kept tidy.
+  // recent prev→current hop is retained). Public data (a signature + two public
+  // keys); reuse writeFileRestricted for its ATOMIC temp+rename write so a crash
+  // can't leave a half-written cert — the 0600 mode it also sets is incidental
+  // here (nothing secret), not a requirement.
   mkdirSync(dirname(rotationFilePath), { recursive: true })
   writeFileRestricted(
     rotationFilePath,

--- a/packages/server/src/ws-auth.js
+++ b/packages/server/src/ws-auth.js
@@ -603,6 +603,13 @@ export function handleKeyExchange(ctx, ws, msg) {
         type: 'key_exchange_ok',
         publicKey: serverKp.publicKey,
         ...(serverKeySig ? { serverKeySig } : {}),
+        // #5616/#5976 — identity-rotation continuity cert (discrete path). Same
+        // contract as the eager auth_ok path: present only alongside a live
+        // exchange signature and only when the daemon was rotated. Absent for
+        // un-rotated daemons; old clients ignore it.
+        ...(serverKeySig && serverIdentity?.rotationCert
+          ? { newIdentityKey: serverIdentity.publicKey, rotationCert: serverIdentity.rotationCert }
+          : {}),
       }))
     } catch (err) {
       // #5702 (8b): the client never received the exchange key, so we must NOT

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -448,6 +448,14 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // can verify it before keying off serverPublicKey. Absent when pinning is
     // unavailable; old clients ignore it.
     ...(eagerServerKeySig ? { serverKeySig: eagerServerKeySig } : {}),
+    // #5616/#5976 — identity-rotation continuity cert. Present only alongside a
+    // live exchange signature (the consume side needs BOTH the cert AND the new
+    // identity's live serverKeySig to chain forward), and only when the daemon
+    // was rotated (cert loaded at startup). Absent for un-rotated daemons / old
+    // clients ignore it; a pin-mismatched client with no cert still refuses.
+    ...(eagerServerKeySig && serverIdentity?.rotationCert
+      ? { newIdentityKey: serverIdentity.publicKey, rotationCert: serverIdentity.rotationCert }
+      : {}),
     ...extra,
   })
 

--- a/packages/server/tests/identity-cmd.test.js
+++ b/packages/server/tests/identity-cmd.test.js
@@ -1,0 +1,44 @@
+/**
+ * `chroxy identity rotate` CLI (#5616/#5976).
+ *
+ * Rotates the daemon's signing identity, minting a single-hop continuity cert so
+ * previously-pinned clients chain forward without re-pairing. Consequential, so
+ * it requires `--yes`; without it the command only explains what it would do.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { runIdentityRotate } from '../src/cli/identity-cmd.js'
+
+function capture() {
+  const lines = []
+  return { write: (s) => lines.push(String(s)), text: () => lines.join('\n') }
+}
+
+describe('identity rotate CLI (#5616)', () => {
+  it('explains and does NOT rotate without --yes', () => {
+    const out = capture()
+    let rotateCalled = false
+    const res = runIdentityRotate({}, { write: out.write, rotate: () => { rotateCalled = true; return {} } })
+    assert.equal(res.rotated, false)
+    assert.equal(rotateCalled, false)
+    assert.match(out.text(), /re-run with --yes/)
+    assert.match(out.text(), /continuity cert/i)
+  })
+
+  it('rotates with --yes and prints the previous/new keys + backend', () => {
+    const out = capture()
+    const fakeResult = { previousPublicKey: 'OLDPUB==', newPublicKey: 'NEWPUB==', backend: 'file' }
+    let passedOpts = null
+    const res = runIdentityRotate(
+      { yes: true },
+      { write: out.write, rotate: (opts) => { passedOpts = opts; return fakeResult }, rotateOpts: { filePath: '/tmp/x' } },
+    )
+    assert.equal(res.rotated, true)
+    assert.deepEqual(res.result, fakeResult)
+    assert.deepEqual(passedOpts, { filePath: '/tmp/x' })
+    assert.match(out.text(), /OLDPUB==/)
+    assert.match(out.text(), /NEWPUB==/)
+    assert.match(out.text(), /backend:\s+file/)
+    assert.match(out.text(), /Restart the daemon/)
+  })
+})

--- a/packages/server/tests/server-identity.test.js
+++ b/packages/server/tests/server-identity.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from 'node:fs'
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import {
@@ -289,6 +289,26 @@ describe('server identity rotation (#5616/#5976)', () => {
     withTempDir((filePath) => {
       const rotationFilePath = rotPath(filePath)
       assert.equal(loadServerRotationCert({ rotationFilePath }), null)
+    })
+  })
+
+  it('is fail-safe: a sidecar-write failure leaves the OLD identity un-rotated', () => {
+    withTempDir((filePath) => {
+      const kc = fakeKeychain({ available: false })
+      const before = getOrCreateServerIdentity({ keychain: kc, filePath })
+      // Point the sidecar at a path UNDER an existing file → mkdirSync(dirname)
+      // throws ENOTDIR, simulating a sidecar-write failure. Because the sidecar
+      // is written BEFORE the secret is swapped, the rotation must abort with the
+      // OLD identity still persisted (not a rotated identity with no cert).
+      const blocker = join(dirname(filePath), 'blocker')
+      writeFileSync(blocker, 'x')
+      const badRotationPath = join(blocker, 'rotation.json')
+
+      assert.throws(() => rotateServerIdentity({ keychain: kc, filePath, rotationFilePath: badRotationPath }))
+
+      // The persisted secret is UNCHANGED — pinned clients still verify.
+      const after = loadServerIdentity({ keychain: kc, filePath })
+      assert.equal(after.publicKey, before.publicKey)
     })
   })
 })

--- a/packages/server/tests/server-identity.test.js
+++ b/packages/server/tests/server-identity.test.js
@@ -2,8 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { dirname } from 'node:path'
+import { join, dirname } from 'node:path'
 import {
   IDENTITY_KEY_SERVICE,
   IdentityUnavailableError,

--- a/packages/server/tests/server-identity.test.js
+++ b/packages/server/tests/server-identity.test.js
@@ -3,17 +3,22 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { dirname } from 'node:path'
 import {
   IDENTITY_KEY_SERVICE,
   IdentityUnavailableError,
   getOrCreateServerIdentity,
   loadServerIdentity,
   persistServerIdentity,
+  rotateServerIdentity,
+  loadServerRotationCert,
+  resolveServerRotationCert,
 } from '../src/server-identity.js'
 import {
   createKeyPair,
   signExchangeKey,
   verifyExchangeKeySignature,
+  verifyIdentityRotation,
 } from '@chroxy/store-core/crypto'
 
 /**
@@ -196,6 +201,95 @@ describe('server identity (#5536)', () => {
       assert.equal(persistServerIdentity(kpFromFresh, { keychain: fakeKeychain({ available: true }), filePath }), 'keychain')
       // file fallback path
       assert.equal(persistServerIdentity(kpFromFresh, { keychain: fakeKeychain({ available: false }), filePath }), 'file')
+    })
+  })
+})
+
+describe('server identity rotation (#5616/#5976)', () => {
+  const rotPath = (filePath) => join(dirname(filePath), 'server-identity-rotation.json')
+
+  it('mints a NEW identity, replaces the secret, and writes a verifiable continuity cert', () => {
+    withTempDir((filePath) => {
+      const kc = fakeKeychain({ available: false }) // file backend → assert on disk
+      const rotationFilePath = rotPath(filePath)
+      const before = getOrCreateServerIdentity({ keychain: kc, filePath })
+
+      const res = rotateServerIdentity({ keychain: kc, filePath, rotationFilePath })
+      assert.equal(res.previousPublicKey, before.publicKey)
+      assert.notEqual(res.newPublicKey, before.publicKey)
+
+      // The persisted secret is now the NEW identity.
+      const after = loadServerIdentity({ keychain: kc, filePath })
+      assert.equal(after.publicKey, res.newPublicKey)
+
+      // The sidecar cert is "old signs new" and verifies against the OLD pin.
+      const sidecar = loadServerRotationCert({ rotationFilePath })
+      assert.equal(sidecar.newIdentityKey, res.newPublicKey)
+      assert.equal(sidecar.previousPublicKey, before.publicKey)
+      assert.equal(
+        verifyIdentityRotation(sidecar.newIdentityKey, sidecar.rotationCert, sidecar.previousPublicKey),
+        true,
+      )
+      // A cert does NOT verify against an unrelated key (sanity).
+      assert.equal(
+        verifyIdentityRotation(sidecar.newIdentityKey, sidecar.rotationCert, createKeyPair().publicKey),
+        false,
+      )
+    })
+  })
+
+  it('resolveServerRotationCert returns the cert for the current identity, null when stale', () => {
+    withTempDir((filePath) => {
+      const kc = fakeKeychain({ available: false })
+      const rotationFilePath = rotPath(filePath)
+      getOrCreateServerIdentity({ keychain: kc, filePath })
+      const res = rotateServerIdentity({ keychain: kc, filePath, rotationFilePath })
+
+      // Current identity matches the sidecar's newIdentityKey → cert resolves.
+      const resolved = resolveServerRotationCert(res.newPublicKey, { rotationFilePath })
+      assert.equal(resolved.previousPublicKey, res.previousPublicKey)
+      assert.ok(resolved.rotationCert)
+
+      // A different "current" identity (e.g. clean re-mint) → stale, ignored.
+      assert.equal(resolveServerRotationCert(createKeyPair().publicKey, { rotationFilePath }), null)
+    })
+  })
+
+  it('is single-hop — a second rotation overwrites the sidecar (only the latest hop)', () => {
+    withTempDir((filePath) => {
+      const kc = fakeKeychain({ available: false })
+      const rotationFilePath = rotPath(filePath)
+      const gen1 = getOrCreateServerIdentity({ keychain: kc, filePath })
+      const r1 = rotateServerIdentity({ keychain: kc, filePath, rotationFilePath })
+      const r2 = rotateServerIdentity({ keychain: kc, filePath, rotationFilePath })
+
+      const sidecar = loadServerRotationCert({ rotationFilePath })
+      // Bridges gen2 → gen3, NOT gen1 → gen3.
+      assert.equal(sidecar.previousPublicKey, r1.newPublicKey)
+      assert.equal(sidecar.newIdentityKey, r2.newPublicKey)
+      assert.notEqual(sidecar.previousPublicKey, gen1.publicKey)
+      // So a client pinned to gen1 cannot verify (the cert was signed by gen2).
+      assert.equal(
+        verifyIdentityRotation(sidecar.newIdentityKey, sidecar.rotationCert, gen1.publicKey),
+        false,
+      )
+    })
+  })
+
+  it('throws when there is no existing identity to rotate from', () => {
+    withTempDir((filePath) => {
+      const kc = fakeKeychain({ available: false })
+      assert.throws(
+        () => rotateServerIdentity({ keychain: kc, filePath, rotationFilePath: rotPath(filePath) }),
+        /No existing server identity/,
+      )
+    })
+  })
+
+  it('loadServerRotationCert returns null when the sidecar is absent or malformed', () => {
+    withTempDir((filePath) => {
+      const rotationFilePath = rotPath(filePath)
+      assert.equal(loadServerRotationCert({ rotationFilePath }), null)
     })
   })
 })


### PR DESCRIPTION
## Summary

The **server produce half** of the identity-key rotation handoff (#5616 phase 2 / #5976 items 1-2). The consume half (#6199) wired clients to chain their pin forward when given a valid continuity cert; this PR makes the daemon mint + present that cert, completing the feature end-to-end.

**Maintainer-decided design** (asked + recorded on #5976): **explicit CLI trigger** + **single-hop** cert.

## How it works

The cert is `OLD_identity_secret.sign(NEW_identity_pub)` — mintable only at the moment of rotation, while the old secret still exists. So rotation is a deliberate admin operation:

1. `chroxy identity rotate --yes` → `rotateServerIdentity()` loads the current (old) identity, mints a new keypair, signs the new pubkey with the **old** secret, persists the new secret **in place of** the old, and writes a single-hop sidecar.
2. On next daemon start, `server-cli.js` loads the sidecar (with a staleness guard) and attaches it to `serverIdentity`.
3. The handshake (`ws-history.js` eager `auth_ok` + `ws-auth.js` discrete `key_exchange_ok`) presents `newIdentityKey` + `rotationCert` — **only** alongside a live exchange signature and **only** when rotated.
4. A previously-pinned client verifies the cert against its pin + the new identity's live signature and re-pins (consume half, #6199).

## Design choices

- **Explicit CLI trigger** — admin-initiated, no surprise rotations; least-surprising and easiest to reason about for a security-critical key change.
- **Single-hop** — the sidecar stores only the most-recent `prev → current` cert (each rotation overwrites it). A client ≥2 rotations behind falls back to manual re-pair. Simple; covers the common "reconnect after one rotation" case.
- **Storage** — the **secret-key** store (keychain / 0600 file) format is **untouched** (zero migration risk). The cert + previous public key are **public**, so they live in a separate plaintext sidecar (`~/.chroxy/server-identity-rotation.json`).
- **Staleness guard** — `resolveServerRotationCert` ignores a sidecar whose `newIdentityKey` ≠ the live identity (e.g. left over from a clean re-mint), so a stale cert is never offered.
- **Fail closed** — the cert is presented only with a live `serverKeySig`; un-rotated daemons present nothing; a pin-mismatched client with no cert still refuses → manual re-pair.

## Tests

- **server-identity rotation suite**: rotation mints a *verifiable* cert (`verifyIdentityRotation(new, cert, old) === true`, and false against an unrelated key) and swaps the persisted secret; `resolveServerRotationCert` resolves for the current identity and returns null when stale; single-hop overwrite (a 2nd rotation bridges gen2→gen3, not gen1→gen3); throws with no identity to rotate; absent sidecar → null.
- **identity-cmd**: `--yes` gating (explains + no-op without it; rotates + prints prev/new/backend with it).

18 targeted tests pass. All server custom lints clean for tracked code. (The discrete `key_exchange_ok` has no Zod schema; `auth_ok`'s fields came from #6199. No protocol change here.)

Closes #5976. Completes #5616 end-to-end (with #6199). Single-hop + CLI-trigger limitations documented above.