### PR TITLE
refactor(store-core): consolidate inline field guards into _shared helpers (#6201)

### DIFF
--- a/packages/store-core/src/handlers/_shared.ts
+++ b/packages/store-core/src/handlers/_shared.ts
@@ -34,6 +34,18 @@ export function parseRawStringField(msg: Record<string, unknown>, field: string)
   return typeof val === 'string' ? val : null
 }
 
+/** Parse an unknown[] field, returning the array or [] when missing/non-array. */
+export function parseUnknownArrayField(msg: Record<string, unknown>, field: string): unknown[] {
+  const val = msg[field]
+  return Array.isArray(val) ? (val as unknown[]) : []
+}
+
+/** Parse a finite-number field, returning the value or `fallback` (default 0) when missing/non-finite. */
+export function parseFiniteNumberField(msg: Record<string, unknown>, field: string, fallback = 0): number {
+  const val = msg[field]
+  return typeof val === 'number' && Number.isFinite(val) ? val : fallback
+}
+
 /**
  * Build a small union-checking helper that returns the value when it matches
  * one of the provided literals, else null. Used for enum fields like

--- a/packages/store-core/src/handlers/agent.ts
+++ b/packages/store-core/src/handlers/agent.ts
@@ -10,7 +10,7 @@
  */
 
 import type { AgentInfo, ChatMessage } from '../types'
-import { resolveSessionId } from './_shared'
+import { parseRawStringField, resolveSessionId } from './_shared'
 
 // ---------------------------------------------------------------------------
 // agent_spawned / agent_completed
@@ -61,7 +61,7 @@ export function handleAgentSpawned(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): AgentInfoBuilder {
-  const toolUseId = typeof msg.toolUseId === 'string' ? msg.toolUseId : null
+  const toolUseId = parseRawStringField(msg, 'toolUseId')
   const rawDescription = typeof msg.description === 'string' ? msg.description : ''
   const description = rawDescription || 'Background task'
   const rawStartedAt = typeof msg.startedAt === 'number' ? msg.startedAt : 0
@@ -92,7 +92,7 @@ export function handleAgentCompleted(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): AgentInfoBuilder {
-  const toolUseId = typeof msg.toolUseId === 'string' ? msg.toolUseId : null
+  const toolUseId = parseRawStringField(msg, 'toolUseId')
   return {
     sessionId: resolveSessionId(msg, activeSessionId),
     applyTo: (current) => {
@@ -162,9 +162,7 @@ export function handleAgentEvent(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): AgentEventBuilder {
-  const parentToolUseId = typeof msg.parentToolUseId === 'string'
-    ? msg.parentToolUseId
-    : null
+  const parentToolUseId = parseRawStringField(msg, 'parentToolUseId')
   const eventType = typeof msg.eventType === 'string' && msg.eventType
     ? msg.eventType
     : null

--- a/packages/store-core/src/handlers/alerts.ts
+++ b/packages/store-core/src/handlers/alerts.ts
@@ -12,6 +12,7 @@
 
 // Established Zod-handler pattern (#3138).
 import { ServerNotificationPrefsSchema } from '@chroxy/protocol'
+import { parseFiniteNumberField, parseRawStringField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // session_cost_threshold_crossed (#4075)
@@ -42,13 +43,9 @@ export interface SessionCostThresholdCrossedPayload {
 export function handleSessionCostThresholdCrossed(
   msg: Record<string, unknown>,
 ): SessionCostThresholdCrossedPayload {
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const costUsd =
-    typeof msg.costUsd === 'number' && Number.isFinite(msg.costUsd) ? msg.costUsd : 0
-  const thresholdUsd =
-    typeof msg.thresholdUsd === 'number' && Number.isFinite(msg.thresholdUsd)
-      ? msg.thresholdUsd
-      : 0
+  const sessionId = parseRawStringField(msg, 'sessionId')
+  const costUsd = parseFiniteNumberField(msg, 'costUsd', 0)
+  const thresholdUsd = parseFiniteNumberField(msg, 'thresholdUsd', 0)
   return {
     sessionId,
     patch: { costThresholdWarning: { costUsd, thresholdUsd, dismissedAt: null } },

--- a/packages/store-core/src/handlers/auth.ts
+++ b/packages/store-core/src/handlers/auth.ts
@@ -13,7 +13,7 @@
  * imports ./auth or ./index.
  */
 
-import { parseEnumField, parseRawStringField } from './_shared'
+import { parseEnumField, parseRawStringField, parseUnknownArrayField } from './_shared'
 import { handleAvailablePermissionModes } from './permission'
 import type { PermissionMode } from './permission'
 
@@ -327,9 +327,9 @@ export function handleAuthBootstrap(
   sessionId: string | null
   tunnelUrl: string | null
 } {
-  const providers: unknown[] = Array.isArray(msg.providers) ? (msg.providers as unknown[]) : []
-  const slashCommands: unknown[] = Array.isArray(msg.slashCommands) ? (msg.slashCommands as unknown[]) : []
-  const agents: unknown[] = Array.isArray(msg.agents) ? (msg.agents as unknown[]) : []
+  const providers = parseUnknownArrayField(msg, 'providers')
+  const slashCommands = parseUnknownArrayField(msg, 'slashCommands')
+  const agents = parseUnknownArrayField(msg, 'agents')
   const sessionId = typeof msg.sessionId === 'string' && msg.sessionId ? msg.sessionId : null
   // #5555 (sub-item 7): the server's live public tunnel URL, when a tunnel is
   // up. Lets a reconnecting client re-learn a URL that rotated while it was
@@ -394,7 +394,7 @@ export function handleTunnelUrlChanged(
  * browser URL.
  */
 export function handleTokenRotated(msg: Record<string, unknown>): { token: string | null } {
-  return { token: typeof msg.token === 'string' ? msg.token : null }
+  return { token: parseRawStringField(msg, 'token') }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/client.ts
+++ b/packages/store-core/src/handlers/client.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ConnectedClient, SessionRole } from '../types'
+import { parseRawStringField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // Multi-client coordination
@@ -117,8 +118,8 @@ export interface PrimaryChanged {
  */
 export function handlePrimaryChanged(msg: Record<string, unknown>): PrimaryChanged {
   return {
-    sessionId: typeof msg.sessionId === 'string' ? msg.sessionId : null,
-    primaryClientId: typeof msg.clientId === 'string' ? msg.clientId : null,
+    sessionId: parseRawStringField(msg, 'sessionId'),
+    primaryClientId: parseRawStringField(msg, 'clientId'),
   }
 }
 
@@ -166,9 +167,8 @@ export function handleSessionRole(
   msg: Record<string, unknown>,
   myClientId: string | null,
 ): SessionRoleInfo {
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const primaryClientId =
-    typeof msg.primaryClientId === 'string' ? msg.primaryClientId : null
+  const sessionId = parseRawStringField(msg, 'sessionId')
+  const primaryClientId = parseRawStringField(msg, 'primaryClientId')
   let role: SessionRole
   if (!primaryClientId) {
     role = 'unclaimed'

--- a/packages/store-core/src/handlers/conversation.ts
+++ b/packages/store-core/src/handlers/conversation.ts
@@ -11,6 +11,7 @@
  */
 
 import type { ConversationSummary } from '../types'
+import { parseRawStringField, parseUnknownArrayField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // conversation_id
@@ -45,9 +46,8 @@ export function handleConversationId(
   msg: Record<string, unknown>,
 ): ConversationIdPayload {
   return {
-    sessionId: typeof msg.sessionId === 'string' ? msg.sessionId : null,
-    conversationId:
-      typeof msg.conversationId === 'string' ? msg.conversationId : null,
+    sessionId: parseRawStringField(msg, 'sessionId'),
+    conversationId: parseRawStringField(msg, 'conversationId'),
   }
 }
 
@@ -72,9 +72,10 @@ export function handleConversationId(
 export function handleConversationsList(msg: Record<string, unknown>): {
   conversations: ConversationSummary[]
 } {
-  const conversations: ConversationSummary[] = Array.isArray(msg.conversations)
-    ? (msg.conversations as ConversationSummary[])
-    : []
+  const conversations = parseUnknownArrayField(
+    msg,
+    'conversations',
+  ) as ConversationSummary[]
   return { conversations }
 }
 
@@ -139,8 +140,7 @@ export function handleHistoryReplayStart(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): HistoryReplayStartPayload {
-  const rawSessionId =
-    typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const rawSessionId = parseRawStringField(msg, 'sessionId')
   return {
     receivingHistoryReplay: true,
     fullHistory: msg.fullHistory === true,

--- a/packages/store-core/src/handlers/environment.ts
+++ b/packages/store-core/src/handlers/environment.ts
@@ -9,6 +9,8 @@
  * downstream in the app/dashboard. See ./index.ts for the handler contract.
  */
 
+import { parseRawStringField, parseUnknownArrayField } from './_shared'
+
 // ---------------------------------------------------------------------------
 // environment_list / environment_error
 //
@@ -35,9 +37,7 @@
 export function handleEnvironmentList(
   msg: Record<string, unknown>,
 ): { environments: unknown[] } {
-  const environments: unknown[] = Array.isArray(msg.environments)
-    ? (msg.environments as unknown[])
-    : []
+  const environments = parseUnknownArrayField(msg, 'environments')
   return { environments }
 }
 
@@ -54,6 +54,6 @@ export function handleEnvironmentError(
   msg: Record<string, unknown>,
 ): { error: string | null } {
   return {
-    error: typeof msg.error === 'string' ? msg.error : null,
+    error: parseRawStringField(msg, 'error'),
   }
 }

--- a/packages/store-core/src/handlers/error.ts
+++ b/packages/store-core/src/handlers/error.ts
@@ -17,6 +17,7 @@ import type { ChatMessage, ServerError } from '../types'
 // PR #5037 partial-cost sub-line under the error toast.
 import type { ErrorPartialCost } from '../cost-format'
 import { nextMessageId, stripAnsi } from '../utils'
+import { parseRawStringField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // error
@@ -71,7 +72,7 @@ export function handleError(msg: Record<string, unknown>): {
   const rawMessage =
     typeof msg.message === 'string' ? stripAnsi(msg.message).trim() : ''
   const message = rawMessage.length > 0 ? rawMessage : DEFAULT_ERROR_MESSAGE
-  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  const requestId = parseRawStringField(msg, 'requestId')
   // Strict boolean check — a typo (e.g. fatal: 'false' string) must NOT
   // degrade to a warning toast. Treat anything non-boolean as undefined.
   const fatal = typeof msg.fatal === 'boolean' ? msg.fatal : undefined

--- a/packages/store-core/src/handlers/file.ts
+++ b/packages/store-core/src/handlers/file.ts
@@ -9,6 +9,8 @@
  * module-level doc in ./index.ts for the stateless-handler contract.
  */
 
+import { parseRawStringField, parseUnknownArrayField } from './_shared'
+
 // ---------------------------------------------------------------------------
 // File operations: directory_listing / file_listing / file_content /
 // write_file_result
@@ -38,10 +40,10 @@ function extractEntriesPayload(
   error: string | null
 } {
   return {
-    path: typeof msg.path === 'string' ? msg.path : null,
-    parentPath: typeof msg.parentPath === 'string' ? msg.parentPath : null,
-    entries: Array.isArray(msg.entries) ? (msg.entries as unknown[]) : [],
-    error: typeof msg.error === 'string' ? msg.error : null,
+    path: parseRawStringField(msg, 'path'),
+    parentPath: parseRawStringField(msg, 'parentPath'),
+    entries: parseUnknownArrayField(msg, 'entries'),
+    error: parseRawStringField(msg, 'error'),
   }
 }
 
@@ -126,12 +128,12 @@ export interface FileContentPayload {
  */
 export function handleFileContent(msg: Record<string, unknown>): FileContentPayload {
   return {
-    path: typeof msg.path === 'string' ? msg.path : null,
-    content: typeof msg.content === 'string' ? msg.content : null,
-    language: typeof msg.language === 'string' ? msg.language : null,
+    path: parseRawStringField(msg, 'path'),
+    content: parseRawStringField(msg, 'content'),
+    language: parseRawStringField(msg, 'language'),
     size: typeof msg.size === 'number' ? msg.size : null,
     truncated: msg.truncated === true,
-    error: typeof msg.error === 'string' ? msg.error : null,
+    error: parseRawStringField(msg, 'error'),
   }
 }
 
@@ -154,7 +156,7 @@ export function handleWriteFileResult(
   msg: Record<string, unknown>,
 ): WriteFileResultPayload {
   return {
-    path: typeof msg.path === 'string' ? msg.path : null,
-    error: typeof msg.error === 'string' ? msg.error : null,
+    path: parseRawStringField(msg, 'path'),
+    error: parseRawStringField(msg, 'error'),
   }
 }

--- a/packages/store-core/src/handlers/git.ts
+++ b/packages/store-core/src/handlers/git.ts
@@ -15,6 +15,7 @@ import type {
   GitBranch,
   GitFileStatus,
 } from '../types'
+import { parseRawStringField, parseUnknownArrayField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // Git operation results (diff_result / git_status_result / git_branches_result /
@@ -173,10 +174,10 @@ export interface DiffResultPayload {
  * message). The `error` string passes through verbatim when present.
  */
 export function handleDiffResult(msg: Record<string, unknown>): DiffResultPayload {
-  const rawFiles = Array.isArray(msg.files) ? (msg.files as unknown[]) : []
+  const rawFiles = parseUnknownArrayField(msg, 'files')
   return {
     files: validateGitElements(rawFiles, isDiffFile, 'handleDiffResult.files'),
-    error: typeof msg.error === 'string' ? msg.error : null,
+    error: parseRawStringField(msg, 'error'),
   }
 }
 
@@ -207,13 +208,11 @@ export interface GitStatusResultPayload {
 export function handleGitStatusResult(
   msg: Record<string, unknown>,
 ): GitStatusResultPayload {
-  const rawStaged = Array.isArray(msg.staged) ? (msg.staged as unknown[]) : []
-  const rawUnstaged = Array.isArray(msg.unstaged) ? (msg.unstaged as unknown[]) : []
-  const rawUntracked = Array.isArray(msg.untracked)
-    ? (msg.untracked as unknown[])
-    : []
+  const rawStaged = parseUnknownArrayField(msg, 'staged')
+  const rawUnstaged = parseUnknownArrayField(msg, 'unstaged')
+  const rawUntracked = parseUnknownArrayField(msg, 'untracked')
   return {
-    branch: typeof msg.branch === 'string' ? msg.branch : null,
+    branch: parseRawStringField(msg, 'branch'),
     staged: validateGitElements(rawStaged, isGitFileStatus, 'handleGitStatusResult.staged'),
     unstaged: validateGitElements(rawUnstaged, isGitFileStatus, 'handleGitStatusResult.unstaged'),
     untracked: validateGitElements(
@@ -221,7 +220,7 @@ export function handleGitStatusResult(
       (v): v is string => typeof v === 'string',
       'handleGitStatusResult.untracked',
     ),
-    error: typeof msg.error === 'string' ? msg.error : null,
+    error: parseRawStringField(msg, 'error'),
   }
 }
 
@@ -247,17 +246,15 @@ export interface GitBranchesResultPayload {
 export function handleGitBranchesResult(
   msg: Record<string, unknown>,
 ): GitBranchesResultPayload {
-  const rawBranches = Array.isArray(msg.branches)
-    ? (msg.branches as unknown[])
-    : []
+  const rawBranches = parseUnknownArrayField(msg, 'branches')
   return {
     branches: validateGitElements(
       rawBranches,
       isGitBranch,
       'handleGitBranchesResult.branches',
     ),
-    currentBranch: typeof msg.currentBranch === 'string' ? msg.currentBranch : null,
-    error: typeof msg.error === 'string' ? msg.error : null,
+    currentBranch: parseRawStringField(msg, 'currentBranch'),
+    error: parseRawStringField(msg, 'error'),
   }
 }
 
@@ -282,7 +279,7 @@ export function handleGitStageResult(
   msg: Record<string, unknown>,
 ): GitStageResultPayload {
   return {
-    error: typeof msg.error === 'string' ? msg.error : null,
+    error: parseRawStringField(msg, 'error'),
   }
 }
 
@@ -307,9 +304,9 @@ export function handleGitCommitResult(
   msg: Record<string, unknown>,
 ): GitCommitResultPayload {
   return {
-    hash: typeof msg.hash === 'string' ? msg.hash : null,
-    message: typeof msg.message === 'string' ? msg.message : null,
-    error: typeof msg.error === 'string' ? msg.error : null,
+    hash: parseRawStringField(msg, 'hash'),
+    message: parseRawStringField(msg, 'message'),
+    error: parseRawStringField(msg, 'error'),
   }
 }
 

--- a/packages/store-core/src/handlers/inventory.ts
+++ b/packages/store-core/src/handlers/inventory.ts
@@ -14,7 +14,7 @@
 import type { ModelInfo } from '../types'
 // Established Zod-handler pattern (#3138).
 import { ServerAvailableModelsEntrySchema } from '@chroxy/protocol'
-import { parseStringField } from './_shared'
+import { parseRawStringField, parseStringField, parseUnknownArrayField } from './_shared'
 import type { SessionPatch } from './_shared'
 
 // ---------------------------------------------------------------------------
@@ -123,7 +123,7 @@ export function handleProviderList(
  * non-array (matches the dashboard's prior inline `Array.isArray(...) ? ... : []`).
  */
 export function handleFileList(msg: Record<string, unknown>): { files: unknown[] } {
-  const files: unknown[] = Array.isArray(msg.files) ? (msg.files as unknown[]) : []
+  const files = parseUnknownArrayField(msg, 'files')
   return { files }
 }
 
@@ -228,11 +228,8 @@ export function handleMcpServers(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): SessionPatch {
-  const servers: unknown[] = Array.isArray(msg.servers)
-    ? (msg.servers as unknown[])
-    : []
-  const rawSessionId =
-    typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const servers = parseUnknownArrayField(msg, 'servers')
+  const rawSessionId = parseRawStringField(msg, 'sessionId')
   return {
     sessionId: rawSessionId || activeSessionId,
     patch: { mcpServers: servers },

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -20,7 +20,7 @@
 
 import type { ChatMessage } from '../types'
 import { nextMessageId } from '../utils'
-import { parseStringField } from './_shared'
+import { parseRawStringField, parseStringField, parseUnknownArrayField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // permission_request / permission_resolved / permission_expired /
@@ -78,14 +78,14 @@ export interface PermissionRequestPayload {
 export function handlePermissionRequest(
   msg: Record<string, unknown>,
 ): PermissionRequestPayload {
-  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
-  const tool = typeof msg.tool === 'string' ? msg.tool : null
-  const description = typeof msg.description === 'string' ? msg.description : null
+  const requestId = parseRawStringField(msg, 'requestId')
+  const tool = parseRawStringField(msg, 'tool')
+  const description = parseRawStringField(msg, 'description')
   const input =
     msg.input && typeof msg.input === 'object' && !Array.isArray(msg.input)
       ? (msg.input as Record<string, unknown>)
       : null
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const sessionId = parseRawStringField(msg, 'sessionId')
   const remainingMs = typeof msg.remainingMs === 'number' ? msg.remainingMs : null
   return { requestId, tool, description, input, sessionId, remainingMs }
 }
@@ -108,8 +108,8 @@ export function handlePermissionResolved(
   msg: Record<string, unknown>,
 ): PermissionResolvedPayload {
   return {
-    requestId: typeof msg.requestId === 'string' ? msg.requestId : null,
-    decision: typeof msg.decision === 'string' ? msg.decision : null,
+    requestId: parseRawStringField(msg, 'requestId'),
+    decision: parseRawStringField(msg, 'decision'),
   }
 }
 
@@ -128,7 +128,7 @@ export function handlePermissionExpired(msg: Record<string, unknown>): {
   requestId: string | null
   systemMessage: ChatMessage
 } {
-  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  const requestId = parseRawStringField(msg, 'requestId')
   return {
     requestId,
     systemMessage: {
@@ -159,7 +159,7 @@ export function handlePermissionTimeout(msg: Record<string, unknown>): {
   tool: string
   systemMessage: ChatMessage
 } {
-  const requestId = typeof msg.requestId === 'string' ? msg.requestId : null
+  const requestId = parseRawStringField(msg, 'requestId')
   const tool = typeof msg.tool === 'string' ? msg.tool : 'permission'
   return {
     requestId,
@@ -193,10 +193,8 @@ export interface PermissionRulesUpdatedPayload {
 export function handlePermissionRulesUpdated(
   msg: Record<string, unknown>,
 ): PermissionRulesUpdatedPayload {
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const rules: PermissionRule[] = Array.isArray(msg.rules)
-    ? (msg.rules as unknown as PermissionRule[])
-    : []
+  const sessionId = parseRawStringField(msg, 'sessionId')
+  const rules = parseUnknownArrayField(msg, 'rules') as PermissionRule[]
   return { sessionId, rules }
 }
 
@@ -268,7 +266,7 @@ export interface PendingPermissionConfirm {
 export function handleConfirmPermissionMode(
   msg: Record<string, unknown>,
 ): PendingPermissionConfirm | null {
-  const mode = typeof msg.mode === 'string' ? msg.mode : null
+  const mode = parseRawStringField(msg, 'mode')
   if (!mode) return null
   const warning = typeof msg.warning === 'string' ? msg.warning : 'Are you sure?'
   return { mode, warning }

--- a/packages/store-core/src/handlers/plan.ts
+++ b/packages/store-core/src/handlers/plan.ts
@@ -8,7 +8,7 @@
  * lifecycle. See ./index.ts for the stateless-handler contract.
  */
 
-import { resolveSessionId } from './_shared'
+import { parseUnknownArrayField, resolveSessionId } from './_shared'
 import type { SessionPatch } from './_shared'
 
 // ---------------------------------------------------------------------------
@@ -75,9 +75,10 @@ export function handlePlanReady(
 ): SessionPatch {
   // Behaviour-preserving unsafe cast (see docstring above). `as unknown as`
   // makes it clear at the call site that the element shape isn't checked.
-  const prompts: PlanAllowedPrompt[] = Array.isArray(msg.allowedPrompts)
-    ? (msg.allowedPrompts as unknown as PlanAllowedPrompt[])
-    : []
+  const prompts = parseUnknownArrayField(
+    msg,
+    'allowedPrompts',
+  ) as PlanAllowedPrompt[]
   return {
     sessionId: resolveSessionId(msg, activeSessionId),
     patch: {

--- a/packages/store-core/src/handlers/session-lifecycle.ts
+++ b/packages/store-core/src/handlers/session-lifecycle.ts
@@ -11,7 +11,7 @@
 
 import type { SessionInfo } from '../types'
 import { nextMessageId, stripAnsi } from '../utils'
-import { parseStringField, resolveSessionId } from './_shared'
+import { parseRawStringField, parseStringField, resolveSessionId } from './_shared'
 import type { SessionPatch } from './_shared'
 
 // ---------------------------------------------------------------------------
@@ -86,8 +86,8 @@ export function handleSessionError(
    */
   attemptedSessionId: string | null
 } {
-  const category = typeof msg.category === 'string' ? msg.category : null
-  const code = typeof msg.code === 'string' ? msg.code : null
+  const category = parseRawStringField(msg, 'category')
+  const code = parseRawStringField(msg, 'code')
   const boundSessionName =
     typeof msg.boundSessionName === 'string' && msg.boundSessionName.length > 0
       ? msg.boundSessionName
@@ -95,10 +95,7 @@ export function handleSessionError(
   // #4982 — only forward when present + a non-empty string. Defense in
   // depth against malformed wire payloads (matches the attemptedResumeId
   // trimming/guard branch in handleMessage).
-  const attemptedSessionId =
-    typeof msg.attemptedSessionId === 'string' && msg.attemptedSessionId.trim().length > 0
-      ? msg.attemptedSessionId.trim()
-      : null
+  const attemptedSessionId = parseStringField(msg, 'attemptedSessionId')
 
   if (category === 'crash') {
     return {

--- a/packages/store-core/src/handlers/session-list.ts
+++ b/packages/store-core/src/handlers/session-list.ts
@@ -19,7 +19,7 @@ import type {
   PendingBackgroundShell,
   SessionInfo,
 } from '../types'
-import { resolveSessionId } from './_shared'
+import { parseUnknownArrayField, resolveSessionId } from './_shared'
 
 // ---------------------------------------------------------------------------
 // session_list
@@ -347,7 +347,7 @@ export function handleBackgroundWorkChanged(
   msg: Record<string, unknown>,
   activeSessionId: string | null,
 ): PendingBackgroundShellsBuilder {
-  const rawPending = Array.isArray(msg.pending) ? msg.pending : []
+  const rawPending = parseUnknownArrayField(msg, 'pending')
   const next: PendingBackgroundShell[] = []
   for (const raw of rawPending) {
     if (!raw || typeof raw !== 'object') continue

--- a/packages/store-core/src/handlers/session-status.ts
+++ b/packages/store-core/src/handlers/session-status.ts
@@ -11,7 +11,7 @@
 
 import type { ChatMessage } from '../types'
 import { nextMessageId } from '../utils'
-import { parseStringField, resolveSessionId } from './_shared'
+import { parseRawStringField, parseStringField, resolveSessionId } from './_shared'
 import type { SessionPatch } from './_shared'
 
 // ---------------------------------------------------------------------------
@@ -34,10 +34,10 @@ export function handleSessionContext(
     sessionId: resolveSessionId(msg, activeSessionId),
     patch: {
       sessionContext: {
-        gitBranch: typeof msg.gitBranch === 'string' ? msg.gitBranch : null,
+        gitBranch: parseRawStringField(msg, 'gitBranch'),
         gitDirty: typeof msg.gitDirty === 'number' ? msg.gitDirty : 0,
         gitAhead: typeof msg.gitAhead === 'number' ? msg.gitAhead : 0,
-        projectName: typeof msg.projectName === 'string' ? msg.projectName : null,
+        projectName: parseRawStringField(msg, 'projectName'),
       },
     },
   }
@@ -113,14 +113,14 @@ export interface SessionRestoreFailedPayload {
 export function handleSessionRestoreFailed(
   msg: Record<string, unknown>,
 ): SessionRestoreFailedPayload {
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
-  const name = typeof msg.name === 'string' ? msg.name : null
-  const provider = typeof msg.provider === 'string' ? msg.provider : null
-  const cwd = typeof msg.cwd === 'string' ? msg.cwd : null
-  const model = typeof msg.model === 'string' ? msg.model : null
-  const permissionMode = typeof msg.permissionMode === 'string' ? msg.permissionMode : null
-  const errorCode = typeof msg.errorCode === 'string' ? msg.errorCode : null
-  const errorMessage = typeof msg.errorMessage === 'string' ? msg.errorMessage : null
+  const sessionId = parseRawStringField(msg, 'sessionId')
+  const name = parseRawStringField(msg, 'name')
+  const provider = parseRawStringField(msg, 'provider')
+  const cwd = parseRawStringField(msg, 'cwd')
+  const model = parseRawStringField(msg, 'model')
+  const permissionMode = parseRawStringField(msg, 'permissionMode')
+  const errorCode = parseRawStringField(msg, 'errorCode')
+  const errorMessage = parseRawStringField(msg, 'errorMessage')
   const historyLength = typeof msg.historyLength === 'number' ? msg.historyLength : null
   const label = name ?? sessionId ?? 'session'
   const reason = errorMessage ?? errorCode ?? 'unknown error'
@@ -249,8 +249,8 @@ export interface ClientFocusChanged {
 export function handleClientFocusChanged(
   msg: Record<string, unknown>,
 ): ClientFocusChanged | null {
-  const clientId = typeof msg.clientId === 'string' ? msg.clientId : null
-  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const clientId = parseRawStringField(msg, 'clientId')
+  const sessionId = parseRawStringField(msg, 'sessionId')
   if (!clientId || !sessionId) return null
   return { clientId, sessionId }
 }

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -15,6 +15,7 @@ import { nextMessageId } from '../utils'
 import { isReplayDuplicate } from '../replay-dedup'
 import { resolveStreamId } from '../stream-id'
 import { isRateLimitMessage } from '@chroxy/protocol'
+import { parseRawStringField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // message
@@ -273,11 +274,11 @@ export function handleToolStart(
   receivingHistoryReplay: boolean,
   cachedMessages: readonly ChatMessage[],
 ): ToolStartPayload {
-  const msgSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const msgSessionId = parseRawStringField(msg, 'sessionId')
   const sessionId = msgSessionId || activeSessionId
   const tool = typeof msg.tool === 'string' ? msg.tool : undefined
   const toolName = tool || 'tool'
-  const messageId = typeof msg.messageId === 'string' ? msg.messageId : null
+  const messageId = parseRawStringField(msg, 'messageId')
   const toolId = messageId || nextMessageId('tool')
   const toolUseId = typeof msg.toolUseId === 'string' ? msg.toolUseId : undefined
   const serverName = typeof msg.serverName === 'string' ? msg.serverName : undefined
@@ -427,7 +428,7 @@ export function handleToolResult(
 ): ToolResultPayload | null {
   if (typeof msg.toolUseId !== 'string' || !msg.toolUseId) return null
   const toolUseId = msg.toolUseId
-  const msgSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const msgSessionId = parseRawStringField(msg, 'sessionId')
   const sessionId = msgSessionId || activeSessionId
   const resultText = typeof msg.result === 'string' ? msg.result : ''
   const truncated = typeof msg.truncated === 'boolean' ? msg.truncated : false
@@ -556,7 +557,7 @@ export function handleToolInputDelta(
   if (typeof msg.partialJson !== 'string') return null
   const toolUseId = msg.toolUseId
   const partialJson = msg.partialJson
-  const msgSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const msgSessionId = parseRawStringField(msg, 'sessionId')
   const sessionId = msgSessionId || activeSessionId
 
   return {
@@ -959,8 +960,7 @@ export function sharedStreamDelta(
   // / `handleToolStart`: a non-string value falls back to the active session
   // rather than coercing onto a Map key. `|| ctx.activeSessionId` also folds an
   // empty string into the fallback, preserving the prior `(as string) ||` shape.
-  const capturedSessionId =
-    (typeof msg.sessionId === 'string' ? msg.sessionId : null) || ctx.activeSessionId
+  const capturedSessionId = parseRawStringField(msg, 'sessionId') || ctx.activeSessionId
 
   // Forward delta text to terminal view (dashboard-only; app no-op).
   if (msg.delta.length > 0) {
@@ -1263,7 +1263,7 @@ export function handleStreamEnd(
   activeSessionId: string | null,
 ): StreamEndPayload {
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
-  const messageId = typeof msg.messageId === 'string' ? msg.messageId : null
+  const messageId = parseRawStringField(msg, 'messageId')
   return { sessionId, messageId }
 }
 
@@ -1338,8 +1338,7 @@ export function handleResultUsage(
     typeof msg.cost === 'number' ? msg.cost : null
   const lastResultDuration =
     typeof msg.duration === 'number' ? msg.duration : null
-  const rawSessionId =
-    typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const rawSessionId = parseRawStringField(msg, 'sessionId')
   return {
     sessionId: rawSessionId || activeSessionId,
     contextUsage,

--- a/packages/store-core/src/handlers/usage.ts
+++ b/packages/store-core/src/handlers/usage.ts
@@ -9,6 +9,7 @@
  */
 
 import type { CumulativeUsage } from '../types'
+import { parseRawStringField } from './_shared'
 import type { SessionPatch } from './_shared'
 
 // ---------------------------------------------------------------------------
@@ -42,8 +43,7 @@ export function handleCostUpdate(
 ): SessionPatch {
   const sessionCost =
     typeof msg.sessionCost === 'number' ? msg.sessionCost : null
-  const rawSessionId =
-    typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const rawSessionId = parseRawStringField(msg, 'sessionId')
   return {
     sessionId: rawSessionId || activeSessionId,
     patch: { sessionCost },
@@ -90,8 +90,7 @@ export function handleSessionUsage(
     costUsd: toFiniteNumber(raw.costUsd),
     turnsBilled: toFiniteNumber(raw.turnsBilled),
   }
-  const rawSessionId =
-    typeof msg.sessionId === 'string' ? msg.sessionId : null
+  const rawSessionId = parseRawStringField(msg, 'sessionId')
   return {
     sessionId: rawSessionId || activeSessionId,
     patch: { cumulativeUsage },

--- a/packages/store-core/src/handlers/web-task.ts
+++ b/packages/store-core/src/handlers/web-task.ts
@@ -11,6 +11,7 @@
  */
 
 import type { SearchResult, WebTask } from '../types'
+import { parseRawStringField, parseUnknownArrayField } from './_shared'
 
 // ---------------------------------------------------------------------------
 // web_task_created / web_task_updated (shared upsert)
@@ -120,7 +121,7 @@ export function handleWebTaskError(
       ? (msg.message as string)
       : null
   const errorMessage = messageText ?? 'Unknown error'
-  const code = typeof msg.code === 'string' ? (msg.code as string) : null
+  const code = parseRawStringField(msg, 'code')
   const boundSessionName =
     typeof msg.boundSessionName === 'string' &&
     (msg.boundSessionName as string).length > 0
@@ -145,7 +146,7 @@ export interface WebTaskListPayload {
 export function handleWebTaskList(
   msg: Record<string, unknown>,
 ): WebTaskListPayload {
-  return { tasks: Array.isArray(msg.tasks) ? (msg.tasks as unknown[]) : [] }
+  return { tasks: parseUnknownArrayField(msg, 'tasks') }
 }
 
 // ---------------------------------------------------------------------------
@@ -224,11 +225,8 @@ export function handleSearchResults(
   msg: Record<string, unknown>,
   currentQuery: string | null,
 ): SearchResultsPayload {
-  const results: SearchResult[] = Array.isArray(msg.results)
-    ? (msg.results as SearchResult[])
-    : []
-  const msgQuery: string | null =
-    typeof msg.query === 'string' ? (msg.query as string) : null
+  const results = parseUnknownArrayField(msg, 'results') as SearchResult[]
+  const msgQuery = parseRawStringField(msg, 'query')
   if (msgQuery !== null && currentQuery && msgQuery !== currentQuery) {
     return { results, shouldApply: false }
   }


### PR DESCRIPTION
## Summary

Tier-1 DRY cleanup from the 8-agent SOLID/DRY swarm-audit (#6201). Collapses **~82 inline field-guard expressions** scattered across 18 store-core handler modules onto the shared `_shared.ts` parsers — **zero behavior change**.

`_shared.ts` already exported `parseStringField` (trimmed, empty→null), `parseRawStringField` (`typeof v==='string' ? v : null`, empty preserved), and `parseEnumField`. This PR adds the two that were missing and routes the inline guards through all five:

| Inline pattern | Helper |
|---|---|
| `typeof msg.X === 'string' ? msg.X : null` | `parseRawStringField` (existing) |
| trimmed / empty→null string guard | `parseStringField` (existing) |
| `Array.isArray(msg.X) ? msg.X : []` | `parseUnknownArrayField` (**new**) |
| `typeof msg.X === 'number' && Number.isFinite(msg.X) ? msg.X : f` | `parseFiniteNumberField` (**new**) |

## Semantics preserved — deliberate skips

Each site was mapped to the helper whose semantics match **exactly**. Sites that did *not* exactly match were left untouched (documented in the audit): number guards without a finite check, string guards with non-null fallbacks (`'UNKNOWN'`, `undefined`, budget messages), truthy-but-untrimmed checks, guards reading nested paths / local vars / optional-chaining, and early-return array guards. Better to skip than change behavior.

## Verification

- store-core `tsc --noEmit`: clean
- store-core full suite: **1714/1714 pass** (handlers.test.ts 791-family + the both-client contract fixtures gate the zero-drift)
- store-core's public handler API (function signatures + return values) is unchanged → app/dashboard consumers unaffected; CI runs their suites to confirm.

Part of #6201 (Tier 1). 19 files, net −4 LOC but the win is single-sourcing the guards (one place to fix a parsing bug, drift-proof).