### PR TITLE
refactor(server): extract getErrorMessage helper (#6201)

### DIFF
--- a/packages/server/src/channels/chroxy-channel-server.js
+++ b/packages/server/src/channels/chroxy-channel-server.js
@@ -35,6 +35,7 @@ import { pathToFileURL } from 'url'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 export const SERVER_NAME = 'chroxy-channel'
 export const SERVER_VERSION = '0.0.1'
@@ -185,7 +186,7 @@ export function startHttpControlSurface({ mcp, port = DEFAULT_PORT, log = (...a)
     // Body is read fully into memory: fine for a localhost debug prototype, not
     // for the real bridge. No size cap by design — the surface is trusted-local.
     req.on('error', err => {
-      log('request error:', err && err.message ? err.message : err)
+      log('request error:', getErrorMessage(err, err))
     })
     req.on('data', chunk => chunks.push(chunk))
     req.on('end', async () => {
@@ -206,7 +207,7 @@ export function startHttpControlSurface({ mcp, port = DEFAULT_PORT, log = (...a)
         res.writeHead(200, { 'Content-Type': 'text/plain' })
         res.end('ok')
       } catch (err) {
-        log('notification failed:', err && err.message ? err.message : err)
+        log('notification failed:', getErrorMessage(err, err))
         res.writeHead(502, { 'Content-Type': 'text/plain' })
         res.end('channel notification failed')
       }

--- a/packages/server/src/control-room/containers.js
+++ b/packages/server/src/control-room/containers.js
@@ -32,6 +32,7 @@
 
 import { execFile } from 'child_process'
 import { promisify } from 'util'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -250,7 +251,7 @@ export async function surveyContainers(opts = {}) {
       statsById = await collectDockerStats(_execFile, runningIds)
     } catch (err) {
       // The inventory still returns; just no live resource numbers.
-      dockerStatsNote = `docker stats unavailable: ${err && err.message ? err.message : 'probe failed'}`
+      dockerStatsNote = `docker stats unavailable: ${getErrorMessage(err, 'probe failed')}`
     }
   }
 

--- a/packages/server/src/control-room/emulators.js
+++ b/packages/server/src/control-room/emulators.js
@@ -23,6 +23,7 @@
 import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 import net from 'net'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -154,7 +155,7 @@ export async function surveyEmulators(opts = {}) {
     // No `emulator` binary (Android SDK absent) — first-class "absent".
     return {
       ...base,
-      note: `Android emulators are not available on this host (${err && err.message ? err.message : 'emulator -list-avds failed'}).`,
+      note: `Android emulators are not available on this host (${getErrorMessage(err, 'emulator -list-avds failed')}).`,
     }
   }
 

--- a/packages/server/src/control-room/handler-factory.js
+++ b/packages/server/src/control-room/handler-factory.js
@@ -19,6 +19,7 @@
  * refactor is behaviour-preserving.
  */
 import { createLogger } from '../logger.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const log = createLogger('ws')
 
@@ -76,7 +77,7 @@ export function makeSurveyHandler({ inFlight, logName, prepare, forbidden, inPro
     try {
       ctx.transport.send(ws, await run(args))
     } catch (err) {
-      log.warn(`${logName} failed: ${err && err.message ? err.message : 'unknown error'}`)
+      log.warn(`${logName} failed: ${getErrorMessage(err, 'unknown error')}`)
       ctx.transport.send(ws, failed({ ...args, err }))
     } finally {
       inFlight.delete(client)

--- a/packages/server/src/control-room/host-prune.js
+++ b/packages/server/src/control-room/host-prune.js
@@ -36,6 +36,7 @@ import { promisify } from 'util'
 import { parseByteSize } from './containers.js'
 import { listSnapshots } from '../snapshots-store.js'
 import { CHROXY_MANAGED_LABEL } from '../environments/backends/docker.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -242,7 +243,7 @@ export async function surveyHostPrune(opts = {}) {
     return {
       ...base,
       dockerAvailable: false,
-      note: `docker is unavailable — host prune survey skipped (${err && err.message ? err.message : 'exec failed'}).`,
+      note: `docker is unavailable — host prune survey skipped (${getErrorMessage(err, 'exec failed')}).`,
     }
   }
   let byLabelLines = []
@@ -252,7 +253,7 @@ export async function surveyHostPrune(opts = {}) {
     ], EXEC_OPTS)
     byLabelLines = parseContainerLines(byLabel.stdout, { trusted: true })
   } catch (err) {
-    containerNote = `the labeled chroxy container set could not be listed (${err && err.message ? err.message : 'exec failed'}).`
+    containerNote = `the labeled chroxy container set could not be listed (${getErrorMessage(err, 'exec failed')}).`
   }
   {
     const seen = new Set()
@@ -291,14 +292,14 @@ export async function surveyHostPrune(opts = {}) {
       ], EXEC_OPTS)
       for (const img of parseImageLines(stdout, { trusted: true })) consider(img)
     } catch (err) {
-      imageNote = `the labeled chroxy image set could not be listed (${err && err.message ? err.message : 'exec failed'}).`
+      imageNote = `the labeled chroxy image set could not be listed (${getErrorMessage(err, 'exec failed')}).`
     }
     for (const repo of CHROXY_IMAGE_REPOS) {
       try {
         const { stdout } = await _execFile('docker', ['images', repo, '--format', imgFmt], EXEC_OPTS)
         for (const img of parseImageLines(stdout)) consider(img)
       } catch (err) {
-        imageNote = `some chroxy image repositories could not be listed (${err && err.message ? err.message : 'exec failed'}).`
+        imageNote = `some chroxy image repositories could not be listed (${getErrorMessage(err, 'exec failed')}).`
       }
     }
   }
@@ -368,7 +369,7 @@ export async function runHostPrune(opts = {}) {
         result.removedContainers += 1
         result.reclaimedBytes += Number.isFinite(c.sizeBytes) ? c.sizeBytes : 0
       } catch (err) {
-        result.failures.push({ ref: c.name || c.id, error: err && err.message ? err.message : 'docker rm failed' })
+        result.failures.push({ ref: c.name || c.id, error: getErrorMessage(err, 'docker rm failed') })
       }
     }
   }
@@ -379,7 +380,7 @@ export async function runHostPrune(opts = {}) {
         result.removedImages += 1
         result.reclaimedBytes += Number.isFinite(img.sizeBytes) ? img.sizeBytes : 0
       } catch (err) {
-        result.failures.push({ ref: img.ref || img.id, error: err && err.message ? err.message : 'docker rmi failed' })
+        result.failures.push({ ref: img.ref || img.id, error: getErrorMessage(err, 'docker rmi failed') })
       }
     }
   }

--- a/packages/server/src/control-room/repo-runtime-config.js
+++ b/packages/server/src/control-room/repo-runtime-config.js
@@ -31,6 +31,7 @@ import { join } from 'path'
 import { parseDevContainer as realParseDevContainer } from '../devcontainer-config.js'
 import { DEFAULT_ALLOWED_DOCKER_IMAGES, imageMatchesAllowlist } from '../docker-image-allowlist.js'
 import { resolveEnvironmentBackend } from '../config.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 /** Isolation order is intrinsic to SessionManager (worktree created, then the
  *  worktree cwd is mounted into Docker) — there is no config knob for it. */
@@ -143,7 +144,7 @@ export function inspectRepo(repo, opts = {}) {
       error: null,
     }
   } catch (err) {
-    return { ...blank, error: err && err.message ? err.message : 'repo inspection failed' }
+    return { ...blank, error: getErrorMessage(err, 'repo inspection failed') }
   }
 }
 

--- a/packages/server/src/control-room/simulators.js
+++ b/packages/server/src/control-room/simulators.js
@@ -20,6 +20,7 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import net from 'net'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -191,7 +192,7 @@ export async function surveySimulators(opts = {}) {
     // No xcrun (not macOS / no Xcode) or simctl failed — first-class "absent".
     return {
       ...base,
-      note: `iOS simulators are not available on this host (${err && err.message ? err.message : 'xcrun simctl failed'}).`,
+      note: `iOS simulators are not available on this host (${getErrorMessage(err, 'xcrun simctl failed')}).`,
     }
   }
 

--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -32,6 +32,7 @@ import { promisify } from 'util'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { resolveRepoSet } from './repo-set.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -577,7 +578,7 @@ function degradedRepo(repo, now, err) {
     attribution: null,
     onboarding: 'skipped — survey failed',
     lastTouched: now.toISOString(),
-    note: `Survey failed: ${err && err.message ? err.message : 'unknown error'}`,
+    note: `Survey failed: ${getErrorMessage(err, 'unknown error')}`,
   }
 }
 

--- a/packages/server/src/control-room/wsl.js
+++ b/packages/server/src/control-room/wsl.js
@@ -21,6 +21,7 @@
 
 import { execFile } from 'child_process'
 import { promisify } from 'util'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -136,7 +137,7 @@ export async function surveyWsl(opts = {}) {
     // No wsl.exe / WSL not installed — first-class "absent".
     return {
       ...base,
-      note: `WSL is not available on this host (${err && err.message ? err.message : 'wsl.exe -l -v failed'}).`,
+      note: `WSL is not available on this host (${getErrorMessage(err, 'wsl.exe -l -v failed')}).`,
     }
   }
 

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -145,6 +145,7 @@ import {
   sanitizeContainerEnv,
 } from './devcontainer-config.js'
 import { isOperatorTimeoutInRange } from './duration.js'
+import { getErrorMessage } from './utils/error-message.js'
 
 const log = createLogger('docker-byok')
 
@@ -1763,7 +1764,7 @@ export class DockerByokSession extends ClaudeByokSession {
         timeout: 10_000,
       })
     } catch (err) {
-      const wrapped = new Error(err && err.message ? err.message : String(err))
+      const wrapped = new Error(getErrorMessage(err, String(err)))
       wrapped.code = 'post_create_marker_write_failed'
       wrapped.cause = err
       throw wrapped

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -45,6 +45,7 @@ import { surveyWsl, runWslAction, WSL_ACTIONS } from '../control-room/wsl.js'
 import { surveyIntegrations, runRepoMemoryIndex, runRepoRelayRerun } from '../control-room/integrations.js'
 import { surveySkillsInventory } from '../control-room/skills-inventory.js'
 import { makeSurveyHandler, makeSyncHostSurvey, makeActionError } from '../control-room/handler-factory.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const log = createLogger('ws')
 
@@ -160,7 +161,7 @@ const handleHostStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, prep, err }) => errorSnapshot(prep.root, requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'host status survey failed',
+    message: getErrorMessage(err, 'host status survey failed'),
   }),
   run: async ({ ctx, requestId, prep }) => {
     // Tests can inject `ctx.surveyRepos` / `ctx.resolveRepoSet` to stub the
@@ -219,7 +220,7 @@ const handleRunnerStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, prep, err }) => runnerErrorSnapshot(prep.root, requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'runner status survey failed',
+    message: getErrorMessage(err, 'runner status survey failed'),
   }),
   run: async ({ ctx, requestId, prep }) => {
     // Tests inject `ctx.surveyRunners` to stub the fs/exec calls.
@@ -278,7 +279,7 @@ const handleContainersStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, err }) => containersErrorSnapshot(requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'containers status survey failed',
+    message: getErrorMessage(err, 'containers status survey failed'),
   }),
   run: async ({ ctx, requestId }) => {
     // Tests inject `ctx.surveyContainers` to stub the docker/exec calls.
@@ -368,7 +369,7 @@ const handleRepoRuntimeConfigRequest = makeSurveyHandler({
   }, hostRuntimeDefaults(ctx?.services?.config || {})),
   failed: ({ ctx, requestId, err }) => repoRuntimeConfigErrorSnapshot(requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'repo runtime config survey failed',
+    message: getErrorMessage(err, 'repo runtime config survey failed'),
   }, hostRuntimeDefaults(ctx?.services?.config || {})),
   run: async ({ ctx, requestId }) => {
     const config = ctx?.services?.config || {}
@@ -436,7 +437,7 @@ const handleByokPoolStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, err }) => byokPoolErrorSnapshot(requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'BYOK pool status survey failed',
+    message: getErrorMessage(err, 'BYOK pool status survey failed'),
   }),
   run: async ({ ctx, requestId }) => {
     // Tests inject `ctx.surveyByokPool` to stub the pool/stats singletons.
@@ -491,7 +492,7 @@ const handleIntegrationStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, prep, err }) => integrationErrorSnapshot(prep.root, requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'integration status survey failed',
+    message: getErrorMessage(err, 'integration status survey failed'),
   }),
   run: async ({ ctx, requestId, prep }) => {
     // Tests inject `ctx.resolveRepoSet` / `ctx.surveyIntegrations` to stub the
@@ -578,7 +579,7 @@ const handleSkillsInventoryRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, prep, err }) => skillsInventoryErrorSnapshot(prep.root, requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'skills inventory survey failed',
+    message: getErrorMessage(err, 'skills inventory survey failed'),
   }),
   run: async ({ ctx, requestId, prep }) => {
     // Tests inject `ctx.resolveRepoSet` / `ctx.surveySkillsInventory` to stub the
@@ -817,7 +818,7 @@ async function handleIntegrationAction(ws, client, msg, ctx) {
     }
   } catch (err) {
     integrationActionError(ws, ctx, msg, 'repo-set-failed',
-      `Could not resolve the surveyed repo set: ${err && err.message ? err.message : 'unknown error'}`)
+      `Could not resolve the surveyed repo set: ${getErrorMessage(err, 'unknown error')}`)
     return
   }
   if (!isMember) {
@@ -854,7 +855,7 @@ async function handleIntegrationAction(ws, client, msg, ctx) {
       ...ackFields,
     })
   } catch (err) {
-    const message = err && err.message ? err.message : `${action} failed`
+    const message = getErrorMessage(err, `${action} failed`)
     log.warn(`integration_action ${action} failed for ${targetKey}: ${message}`)
     const reason = err && typeof err.reason === 'string' && err.reason.length > 0
       ? err.reason
@@ -984,7 +985,7 @@ async function handleContainersAction(ws, client, msg, ctx) {
       status: typeof status === 'string' ? status : null,
     })
   } catch (err) {
-    const message = err && err.message ? err.message : `${action} failed`
+    const message = getErrorMessage(err, `${action} failed`)
     log.warn(`containers_action ${action} failed for ${environmentId}: ${message}`)
     containerActionError(ws, ctx, msg, CONTAINER_ACTION_FAILURE_REASON[action], message)
   } finally {
@@ -1142,7 +1143,7 @@ async function handleByokPoolAction(ws, client, msg, ctx) {
     log.info(`byok_pool_action ${action} completed (client=${client?.id})`)
     ctx.transport.send(ws, ack)
   } catch (err) {
-    const message = err && err.message ? err.message : `${action} failed`
+    const message = getErrorMessage(err, `${action} failed`)
     log.warn(`byok_pool_action ${action} failed: ${message}`)
     byokPoolActionError(ws, ctx, msg, `${action}-failed`, message)
   } finally {
@@ -1188,7 +1189,7 @@ const handleHostPruneStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, err }) => hostPruneErrorSnapshot(requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'host prune survey failed',
+    message: getErrorMessage(err, 'host prune survey failed'),
   }),
   run: async ({ ctx, requestId }) => {
     const surveyFn = typeof ctx?.surveyHostPrune === 'function' ? ctx.surveyHostPrune : surveyHostPrune
@@ -1267,7 +1268,7 @@ async function handleHostPruneAction(ws, client, msg, ctx) {
       failures: result.failures,
     })
   } catch (err) {
-    const message = err && err.message ? err.message : 'host prune failed'
+    const message = getErrorMessage(err, 'host prune failed')
     log.warn(`host_prune_action ${kind} failed: ${message}`)
     hostPruneActionError(ws, ctx, msg, 'prune-failed', message)
   } finally {
@@ -1311,7 +1312,7 @@ const handleSimulatorStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, err }) => simulatorErrorSnapshot(requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'simulator survey failed',
+    message: getErrorMessage(err, 'simulator survey failed'),
   }),
   run: async ({ ctx, requestId }) => {
     const surveyFn = typeof ctx?.surveySimulators === 'function' ? ctx.surveySimulators : surveySimulators
@@ -1419,7 +1420,7 @@ async function handleSimulatorAction(ws, client, msg, ctx) {
       snapshot = await surveyFn({})
     } catch (err) {
       simulatorActionError(ws, ctx, msg, 'survey-failed',
-        err && err.message ? err.message : 'simulator survey failed')
+        getErrorMessage(err, 'simulator survey failed'))
       return
     }
     if (!snapshot?.available) {
@@ -1458,7 +1459,7 @@ async function handleSimulatorAction(ws, client, msg, ctx) {
       status: typeof status === 'string' ? status : null,
     })
   } catch (err) {
-    const message = err && err.message ? err.message : `${action} failed`
+    const message = getErrorMessage(err, `${action} failed`)
     log.warn(`simulator_action ${action} failed for ${udid}: ${message}`)
     simulatorActionError(ws, ctx, msg, SIMULATOR_ACTION_FAILURE_REASON[action], message)
   } finally {
@@ -1503,7 +1504,7 @@ const handleEmulatorStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, err }) => emulatorErrorSnapshot(requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'emulator survey failed',
+    message: getErrorMessage(err, 'emulator survey failed'),
   }),
   run: async ({ ctx, requestId }) => {
     const surveyFn = typeof ctx?.surveyEmulators === 'function' ? ctx.surveyEmulators : surveyEmulators
@@ -1606,7 +1607,7 @@ async function handleEmulatorAction(ws, client, msg, ctx) {
       snapshot = await surveyFn({})
     } catch (err) {
       emulatorActionError(ws, ctx, msg, 'survey-failed',
-        err && err.message ? err.message : 'emulator survey failed')
+        getErrorMessage(err, 'emulator survey failed'))
       return
     }
     if (!snapshot?.available) {
@@ -1657,7 +1658,7 @@ async function handleEmulatorAction(ws, client, msg, ctx) {
       status: typeof status === 'string' ? status : null,
     })
   } catch (err) {
-    const message = err && err.message ? err.message : `${action} failed`
+    const message = getErrorMessage(err, `${action} failed`)
     log.warn(`emulator_action ${action} failed for ${targetId}: ${message}`)
     emulatorActionError(ws, ctx, msg, EMULATOR_ACTION_FAILURE_REASON[action], message)
   } finally {
@@ -1703,7 +1704,7 @@ const handleWslStatusRequest = makeSurveyHandler({
   }),
   failed: ({ requestId, err }) => wslErrorSnapshot(requestId, {
     code: 'SURVEY_FAILED',
-    message: err && err.message ? err.message : 'WSL survey failed',
+    message: getErrorMessage(err, 'WSL survey failed'),
   }),
   run: async ({ ctx, requestId }) => {
     const surveyFn = typeof ctx?.surveyWsl === 'function' ? ctx.surveyWsl : surveyWsl
@@ -1797,7 +1798,7 @@ async function handleWslAction(ws, client, msg, ctx) {
     try {
       snapshot = await surveyFn({})
     } catch (err) {
-      wslActionError(ws, ctx, msg, 'survey-failed', err && err.message ? err.message : 'WSL survey failed')
+      wslActionError(ws, ctx, msg, 'survey-failed', getErrorMessage(err, 'WSL survey failed'))
       return
     }
     if (!snapshot?.available) {
@@ -1832,7 +1833,7 @@ async function handleWslAction(ws, client, msg, ctx) {
       status: typeof status === 'string' ? status : null,
     })
   } catch (err) {
-    const message = err && err.message ? err.message : `${action} failed`
+    const message = getErrorMessage(err, `${action} failed`)
     log.warn(`wsl_action ${action} failed for ${distro}: ${message}`)
     wslActionError(ws, ctx, msg, WSL_ACTION_FAILURE_REASON[action], message)
   } finally {

--- a/packages/server/src/handlers/repo-handlers.js
+++ b/packages/server/src/handlers/repo-handlers.js
@@ -22,6 +22,7 @@ import {
 } from '../config.js'
 import { validatePreset } from '../session-preset.js'
 import { validateCwdAllowed, sendSessionError } from '../handler-utils.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 /**
  * Reject a non-host (session-bound) client from a host-authority preset
@@ -229,7 +230,7 @@ function handleSessionPresetSet(ws, client, msg, ctx) {
     writeOverride(resolvedPath, toWrite, ctx.services.config?.configPath)
   } catch (err) {
     // Leak guard: never echo preset contents in the failure path.
-    sendSessionError(ws, ctx, `Failed to write session preset override: ${err && err.message ? err.message : 'error'}`)
+    sendSessionError(ws, ctx, `Failed to write session preset override: ${getErrorMessage(err, 'error')}`)
     return
   }
 

--- a/packages/server/src/handlers/summarize-handlers.js
+++ b/packages/server/src/handlers/summarize-handlers.js
@@ -26,6 +26,7 @@
  */
 import { createLogger } from '../logger.js'
 import { summarizeSession as defaultSummarizeSession } from '../summarize-session.js'
+import { getErrorMessage } from '../utils/error-message.js'
 
 const log = createLogger('ws')
 
@@ -99,7 +100,7 @@ async function handleSummarizeSession(ws, client, msg, ctx) {
     // text is logged server-side only (a thrown history-read error could carry
     // internal paths or unexpected text; keep the SUMMARIZE_FAILED surface
     // leak-safe, matching the model-call failure path below).
-    log.warn(`summarize_session history read failed for ${sessionId}: ${err && err.message ? err.message : 'unknown error'}`)
+    log.warn(`summarize_session history read failed for ${sessionId}: ${getErrorMessage(err, 'unknown error')}`)
     summarizeError(ws, ctx, sessionId, requestId, 'history-failed',
       'Could not read this session\'s history')
     return
@@ -143,7 +144,7 @@ async function handleSummarizeSession(ws, client, msg, ctx) {
     // thrown reason for the discriminator and a fixed message per reason.
     const reason = err && typeof err.reason === 'string' && err.reason.length > 0 ? err.reason : 'summarize-failed'
     const message = messageForReason(reason)
-    log.warn(`summarize_session failed for ${sessionId}: reason=${reason} (${err && err.message ? err.message : 'unknown error'})`)
+    log.warn(`summarize_session failed for ${sessionId}: reason=${reason} (${getErrorMessage(err, 'unknown error')})`)
     summarizeError(ws, ctx, sessionId, requestId, reason, message)
   } finally {
     summarizeInFlight.delete(sessionId)

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -3,6 +3,7 @@ import { createInterface } from 'readline'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { createLogger } from './logger.js'
 import { guardChildStreams } from './child-stream-guard.js'
+import { getErrorMessage } from './utils/error-message.js'
 
 const log = createLogger('jsonl-subprocess-session')
 
@@ -290,7 +291,7 @@ export class JsonlSubprocessSession extends BaseSession {
       // skills text. Reset busy state and surface the error to the caller.
       this._isBusy = false
       this.emit('error', {
-        message: err && err.message ? err.message : `Failed to spawn ${Klass.providerName}`,
+        message: getErrorMessage(err, `Failed to spawn ${Klass.providerName}`),
       })
       return
     }

--- a/packages/server/src/path-hash-trust-ledger.js
+++ b/packages/server/src/path-hash-trust-ledger.js
@@ -47,6 +47,7 @@
 import { readFileSync } from 'fs'
 import { randomBytes } from 'crypto'
 import { saveJsonState } from './json-state-file.js'
+import { getErrorMessage } from './utils/error-message.js'
 
 /**
  * @typedef {Object} TrustRecord
@@ -117,7 +118,7 @@ export class PathHashTrustLedger {
     try {
       parsed = JSON.parse(raw)
     } catch (err) {
-      this._log.warn(`Trust file is malformed JSON (${err && err.message ? err.message : err}); starting fresh`)
+      this._log.warn(`Trust file is malformed JSON (${getErrorMessage(err, err)}); starting fresh`)
       return empty
     }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -26,6 +26,7 @@ import { createLogger } from './logger.js'
 import { ExternalSessionRegistry } from './external-session-registry.js'
 import { metrics } from './metrics.js'
 import { auditShellDestroy } from './shell-audit.js'
+import { getErrorMessage } from './utils/error-message.js'
 import {
   forwardPerSessionSettingsToProviderOpts,
   serializePerSessionSettings,
@@ -994,7 +995,7 @@ export class SessionManager extends EventEmitter {
         }
       } catch (err) {
         // Leak guard: never echo preset contents in the failure path.
-        log.warn(`Session preset resolution failed for session ${sessionId} (non-fatal): ${err && err.message ? err.message : 'error'}`)
+        log.warn(`Session preset resolution failed for session ${sessionId} (non-fatal): ${getErrorMessage(err, 'error')}`)
         presetDescriptor = null
         effectiveSessionPreamble = sessionPreamble
       }
@@ -1345,7 +1346,7 @@ export class SessionManager extends EventEmitter {
           this.skillsUsageRecorder?.record({ sessionId, repo: resolvedCwd, skills: activeSkills })
         }
       } catch (err) {
-        log.debug(`skills-usage: failed to record activation for ${sessionId} (non-fatal): ${err && err.message ? err.message : err}`)
+        log.debug(`skills-usage: failed to record activation for ${sessionId} (non-fatal): ${getErrorMessage(err, err)}`)
       }
     }
     // Flush synchronously — a new session must survive an abrupt shutdown,
@@ -1542,7 +1543,7 @@ export class SessionManager extends EventEmitter {
         configPath: this.presetConfigPath || undefined,
       })
     } catch (err) {
-      log.warn(`resolveSessionPresetForCwd failed (non-fatal): ${err && err.message ? err.message : 'error'}`)
+      log.warn(`resolveSessionPresetForCwd failed (non-fatal): ${getErrorMessage(err, 'error')}`)
       return null
     }
   }

--- a/packages/server/src/skills-frontmatter.js
+++ b/packages/server/src/skills-frontmatter.js
@@ -21,6 +21,7 @@
  */
 import { readSync } from 'node:fs'
 import { createLogger } from './logger.js'
+import { getErrorMessage } from './utils/error-message.js'
 
 const log = createLogger('skills-loader')
 
@@ -96,7 +97,7 @@ export function parseFrontmatter(text) {
   try {
     frontmatter = _parseFrontmatterBody(yamlRaw)
   } catch (err) {
-    log.debug(`parseFrontmatter: malformed frontmatter — ${err && err.message ? err.message : err}`)
+    log.debug(`parseFrontmatter: malformed frontmatter — ${getErrorMessage(err, err)}`)
     return { frontmatter: null, body: text }
   }
 

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -66,6 +66,7 @@ import {
 import { dirname, join, relative, resolve, sep } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger.js'
+import { getErrorMessage } from './utils/error-message.js'
 
 const log = createLogger('skills-loader')
 
@@ -528,7 +529,7 @@ export function loadActiveSkills(dir, opts = {}) {
               try {
                 onCommunityTrustPending({ name, author: communityAuthorC, source: source || null, description, path: realPath })
               } catch (err) {
-                log.warn(`onCommunityTrustPending callback threw for ${label}: ${err && err.message ? err.message : err}`)
+                log.warn(`onCommunityTrustPending callback threw for ${label}: ${getErrorMessage(err, err)}`)
               }
             }
             if (!includeInactive) continue
@@ -550,7 +551,7 @@ export function loadActiveSkills(dir, opts = {}) {
           try {
             inspectResult = trustStore.inspect(realPath, finalBody)
           } catch (err) {
-            log.warn(`Skill ${label}: trust inspect threw (${err && err.message ? err.message : err}); allowing skill`)
+            log.warn(`Skill ${label}: trust inspect threw (${getErrorMessage(err, err)}); allowing skill`)
             inspectResult = null
           }
           if (inspectResult && inspectResult.status === 'mismatch') {
@@ -562,7 +563,7 @@ export function loadActiveSkills(dir, opts = {}) {
                   blocked: !!inspectResult.blocked, mode: trustStore.mode,
                 })
               } catch (err) {
-                log.warn(`onTrustMismatch callback threw for ${label}: ${err && err.message ? err.message : err}`)
+                log.warn(`onTrustMismatch callback threw for ${label}: ${getErrorMessage(err, err)}`)
               }
             }
             if (inspectResult.blocked) {
@@ -739,7 +740,7 @@ export function loadActiveSkills(dir, opts = {}) {
               try {
                 onCommunityTrustPending({ name, author: communityAuthorM, source: source || null, description, path: realPath2 })
               } catch (err) {
-                log.warn(`onCommunityTrustPending callback threw for ${label}: ${err && err.message ? err.message : err}`)
+                log.warn(`onCommunityTrustPending callback threw for ${label}: ${getErrorMessage(err, err)}`)
               }
             }
             if (!includeInactive) continue
@@ -761,7 +762,7 @@ export function loadActiveSkills(dir, opts = {}) {
           try {
             inspectResult = trustStore.inspect(realPath2, finalBody)
           } catch (err) {
-            log.warn(`Skill ${label}: trust inspect threw (${err && err.message ? err.message : err}); allowing skill`)
+            log.warn(`Skill ${label}: trust inspect threw (${getErrorMessage(err, err)}); allowing skill`)
             inspectResult = null
           }
           if (inspectResult && inspectResult.status === 'mismatch') {
@@ -773,7 +774,7 @@ export function loadActiveSkills(dir, opts = {}) {
                   blocked: !!inspectResult.blocked, mode: trustStore.mode,
                 })
               } catch (err) {
-                log.warn(`onTrustMismatch callback threw for ${label}: ${err && err.message ? err.message : err}`)
+                log.warn(`onTrustMismatch callback threw for ${label}: ${getErrorMessage(err, err)}`)
               }
             }
             if (inspectResult.blocked) {
@@ -1086,7 +1087,7 @@ export function loadActiveSkills(dir, opts = {}) {
             try {
               onCommunityTrustPending({ name, author: communityAuthor, source: source || null, description, path: realPath })
             } catch (err) {
-              log.warn(`onCommunityTrustPending callback threw for ${label}: ${err && err.message ? err.message : err}`)
+              log.warn(`onCommunityTrustPending callback threw for ${label}: ${getErrorMessage(err, err)}`)
             }
           }
           if (!includeInactive) continue
@@ -1130,7 +1131,7 @@ export function loadActiveSkills(dir, opts = {}) {
           // and fall through. The `inspect` implementation owns logging
           // for normal cases; this branch only fires if the implementor
           // throws unexpectedly.
-          log.warn(`Skill ${label}: trust inspect threw (${err && err.message ? err.message : err}); allowing skill`)
+          log.warn(`Skill ${label}: trust inspect threw (${getErrorMessage(err, err)}); allowing skill`)
           inspectResult = null
         }
         if (inspectResult && inspectResult.status === 'mismatch') {
@@ -1154,7 +1155,7 @@ export function loadActiveSkills(dir, opts = {}) {
             } catch (err) {
               // Callback errors are swallowed — they shouldn't change the
               // load outcome. Pure observer concern.
-              log.warn(`onTrustMismatch callback threw for ${label}: ${err && err.message ? err.message : err}`)
+              log.warn(`onTrustMismatch callback threw for ${label}: ${getErrorMessage(err, err)}`)
             }
           }
           if (inspectResult.blocked) {

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -45,6 +45,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { createLogger } from './logger.js'
 import { loadJsonState, saveJsonState } from './json-state-file.js'
+import { getErrorMessage } from './utils/error-message.js'
 
 const log = createLogger('skills-usage')
 
@@ -278,7 +279,7 @@ export class SkillsUsageRecorder {
       }
       if (changed) this._scheduleSave()
     } catch (err) {
-      log.debug(`skills-usage: record failed (non-fatal): ${err && err.message ? err.message : err}`)
+      log.debug(`skills-usage: record failed (non-fatal): ${getErrorMessage(err, err)}`)
     }
   }
 
@@ -328,7 +329,7 @@ export class SkillsUsageRecorder {
       this._save(this._store, this._filePath)
       this._dirty = false
     } catch (err) {
-      log.warn(`skills-usage: save failed: ${err && err.message ? err.message : err}`)
+      log.warn(`skills-usage: save failed: ${getErrorMessage(err, err)}`)
     }
   }
 }

--- a/packages/server/src/utils/error-message.js
+++ b/packages/server/src/utils/error-message.js
@@ -7,9 +7,18 @@
  * `.message` yields the message; anything else (null/undefined `err`, a thrown
  * non-Error, or an empty-string `.message`) yields the fallback.
  *
+ * The fallback is returned **as-is, by reference** — it is NOT coerced to a
+ * string. Most callers pass a string, but some pass a non-string (e.g.
+ * `getErrorMessage(err, err)` to forward the raw value into a template), exactly
+ * as the original idiom did. So with a non-string fallback the return type is
+ * that fallback's type, not `string`. Do not "fix" this by stringifying — it
+ * would silently change those call sites.
+ *
  * @param {unknown} err - the caught value (Error, string, anything).
- * @param {string} [fallback='unknown error'] - returned when no usable message.
- * @returns {string}
+ * @param {T} [fallback='unknown error'] - returned by reference when there is no
+ *   usable message; any type, defaulting to the string 'unknown error'.
+ * @returns {string|T} the message string, or the fallback unchanged.
+ * @template T
  */
 export function getErrorMessage(err, fallback = 'unknown error') {
   return err && err.message ? err.message : fallback

--- a/packages/server/src/utils/error-message.js
+++ b/packages/server/src/utils/error-message.js
@@ -1,0 +1,16 @@
+/**
+ * Extract a human-readable message from an unknown thrown value.
+ *
+ * Replaces the `err && err.message ? err.message : 'fallback'` idiom that was
+ * copy-pasted ~60× across the server (catch blocks, log lines, degraded survey
+ * replies). Behaviour is identical to that idiom: a truthy `err` with a truthy
+ * `.message` yields the message; anything else (null/undefined `err`, a thrown
+ * non-Error, or an empty-string `.message`) yields the fallback.
+ *
+ * @param {unknown} err - the caught value (Error, string, anything).
+ * @param {string} [fallback='unknown error'] - returned when no usable message.
+ * @returns {string}
+ */
+export function getErrorMessage(err, fallback = 'unknown error') {
+  return err && err.message ? err.message : fallback
+}

--- a/packages/server/tests/error-message.test.js
+++ b/packages/server/tests/error-message.test.js
@@ -1,0 +1,49 @@
+/**
+ * getErrorMessage(err, fallback) — the shared replacement for the
+ * `err && err.message ? err.message : 'fallback'` idiom (#6201 Tier-1).
+ *
+ * The behaviour must match that idiom EXACTLY so the ~60 conversion sites stay
+ * byte-for-byte equivalent.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { getErrorMessage } from '../src/utils/error-message.js'
+
+describe('getErrorMessage', () => {
+  it('returns the message of a real Error', () => {
+    assert.equal(getErrorMessage(new Error('boom'), 'fallback'), 'boom')
+  })
+
+  it('returns the message of a plain object carrying one', () => {
+    assert.equal(getErrorMessage({ message: 'shaped' }, 'fallback'), 'shaped')
+  })
+
+  it('falls back when err is null/undefined', () => {
+    assert.equal(getErrorMessage(null, 'fallback'), 'fallback')
+    assert.equal(getErrorMessage(undefined, 'fallback'), 'fallback')
+  })
+
+  it('falls back when err has no message', () => {
+    assert.equal(getErrorMessage({}, 'fallback'), 'fallback')
+    assert.equal(getErrorMessage('a thrown string', 'fallback'), 'fallback')
+  })
+
+  it('falls back on an empty-string message (matches the idiom — empty is falsy)', () => {
+    assert.equal(getErrorMessage(new Error(''), 'fallback'), 'fallback')
+    assert.equal(getErrorMessage({ message: '' }, 'fallback'), 'fallback')
+  })
+
+  it("defaults the fallback to 'unknown error'", () => {
+    assert.equal(getErrorMessage(null), 'unknown error')
+    assert.equal(getErrorMessage({}), 'unknown error')
+  })
+
+  it('matches the original idiom across a value matrix', () => {
+    const fallback = 'fb'
+    const idiom = (err) => (err && err.message ? err.message : fallback)
+    const cases = [null, undefined, 0, '', 'str', {}, { message: '' }, { message: 'm' }, new Error('e'), new Error('')]
+    for (const c of cases) {
+      assert.equal(getErrorMessage(c, fallback), idiom(c), `mismatch for ${JSON.stringify(c)}`)
+    }
+  })
+})

--- a/packages/server/tests/error-message.test.js
+++ b/packages/server/tests/error-message.test.js
@@ -38,6 +38,16 @@ describe('getErrorMessage', () => {
     assert.equal(getErrorMessage({}), 'unknown error')
   })
 
+  it('returns a non-string fallback BY REFERENCE (not stringified)', () => {
+    // Several call sites pass a non-string fallback, e.g. getErrorMessage(err, err)
+    // to forward the raw value into a template. The helper must pass it through
+    // untouched — a future "stringify the fallback" refactor would break them.
+    const raw = { code: 'E', toString() { return 'stringified' } }
+    assert.strictEqual(getErrorMessage(null, raw), raw) // same reference, not 'stringified'
+    const errLike = { name: 'X' } // truthy, no .message → fallback returned as-is
+    assert.strictEqual(getErrorMessage(errLike, errLike), errLike)
+  })
+
   it('matches the original idiom across a value matrix', () => {
     const fallback = 'fb'
     const idiom = (err) => (err && err.message ? err.message : fallback)


### PR DESCRIPTION
## Summary

Tier-1 cleanup from the SOLID/DRY swarm-audit epic (#6201). The `err && err.message ? err.message : 'fallback'` idiom was copy-pasted **~58×** across catch blocks, log lines, and degraded survey replies. This hoists it into `src/utils/error-message.js` as `getErrorMessage(err, fallback = 'unknown error')` and applies it across **19 tested modules**.

## Behaviour-identical

`getErrorMessage` returns `err.message` when `err` is truthy with a truthy message, else the fallback — exactly matching the idiom (an empty-string `.message` is falsy → fallback, as before). Every fallback at the call sites is pure (string/template literals, `String(err)`, bare `err`), so passing it as an eager 2nd arg is side-effect-free.

## Proven a pure swap by reversal

Per the project's "prove a pure-swap refactor by reversal" discipline: a reverse codemod (`getErrorMessage(err, X)` → the original ternary, minus the added import line) reproduced **every one of the 19 files byte-for-byte** against the pre-change `HEAD`. So the only logic change is the extraction itself.

## Scope guard

Per #6201 ("apply in TESTED files only"), the untested `skills-handlers.js` (2 sites) was deliberately left for a tests-first pass. The 19 touched modules all have coverage.

## Verification

- New `tests/error-message.test.js` asserts `getErrorMessage` matches the original idiom across a null / undefined / 0 / empty-string / string / object / `{message:''}` / `Error('')` / `Error('e')` value matrix.
- All touched-module suites green (control-room 511, skills/jsonl/docker-byok/channels/summarize/repo-handlers, + the new helper test); `eslint` + custom server lints clean.

Part of #6201.