### PR TITLE
refactor(store-core): migrate multi_question_intervention onto the shared dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -38,8 +38,6 @@ import {
   // plan_started / inactivity_warning / dev_preview / dev_preview_stopped
   // migrated to the shared dispatch table (#5556 slice 2)
   handlePlanReady as sharedPlanReady,
-  handleMultiQuestionIntervention as sharedMultiQuestionIntervention,
-  applyInterventionBuilder,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
   handleToolInputDelta as sharedToolInputDelta,
@@ -2786,51 +2784,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
-
-    case 'multi_question_intervention': {
-      // #4764 — chroxy's permission-hook (#4648) just denied a multi-question
-      // AskUserQuestion. Mirrors the dashboard's #4758 handler: append a
-      // SessionIntervention entry so the session-header counter ticks, and on
-      // the FIRST such intervention per session push a one-time system
-      // ChatMessage explaining what happened (without it the deny is invisible
-      // on the chat surface).
-      //
-      // applyInterventionBuilder dedups by toolUseId (a stuck model re-emitting
-      // the same payload won't double-count) and tells us whether this was the
-      // session's first intervention so the inline notice only fires once.
-      const builder = sharedMultiQuestionIntervention(msg, get().activeSessionId);
-      if (!builder) break;
-      const interventionTargetId = builder.sessionId;
-      if (!interventionTargetId) break;
-      const targetState = get().sessionStates[interventionTargetId];
-      if (!targetState) break;
-      const { interventions: nextInterventions, isFirst } = applyInterventionBuilder(
-        builder,
-        targetState.interventions,
-      );
-      // Skip the state mutation if nothing changed (dedup'd repeat) so React
-      // doesn't re-render the header counter on every stuck-model re-emit.
-      if (nextInterventions === targetState.interventions) break;
-      updateSession(interventionTargetId, (ss) => {
-        if (isFirst) {
-          return {
-            interventions: nextInterventions,
-            messages: [
-              ...ss.messages,
-              {
-                id: nextMessageId('system'),
-                type: 'system',
-                content:
-                  "chroxy intercepted a multi-question form and asked the agent to break it into single questions.",
-                timestamp: Date.now(),
-              },
-            ],
-          };
-        }
-        return { interventions: nextInterventions };
-      });
-      break;
-    }
 
     case 'raw_background': {
       const { data: rawBgData } = sharedRawOutput(msg);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -29,8 +29,6 @@ import {
   // migrated to the shared dispatch table (#5556 slice 2)
   handlePlanReady as sharedPlanReady,
   // #4653: chroxy-side multi-question deny intervention surfaced to the user
-  handleMultiQuestionIntervention as sharedMultiQuestionIntervention,
-  applyInterventionBuilder,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
   handleToolInputDelta as sharedToolInputDelta,
@@ -4342,52 +4340,6 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
-
-    case 'multi_question_intervention': {
-      // #4653 — chroxy's permission-hook (#4648) just denied a multi-question
-      // AskUserQuestion. Append a SessionIntervention entry so the
-      // FooterBar counter ticks, and on the FIRST such intervention per
-      // session push a one-time system ChatMessage explaining what
-      // happened (without it the deny is invisible — see v0.9.24
-      // dogfood feedback on #4653).
-      //
-      // applyInterventionBuilder dedups by toolUseId (a stuck model
-      // re-emitting the same payload won't double-count) and tells us
-      // whether this was the session's first intervention so the inline
-      // notice only fires once.
-      const builder = sharedMultiQuestionIntervention(msg, get().activeSessionId);
-      if (!builder) break;
-      const targetId = builder.sessionId;
-      if (!targetId) break;
-      const targetState = get().sessionStates[targetId];
-      if (!targetState) break;
-      const { interventions: nextInterventions, isFirst } = applyInterventionBuilder(
-        builder,
-        targetState.interventions,
-      );
-      // Skip the state mutation if nothing changed (dedup'd repeat) so React
-      // doesn't re-render the footer counter on every stuck-model re-emit.
-      if (nextInterventions === targetState.interventions) break;
-      updateSession(targetId, (ss) => {
-        if (isFirst) {
-          return {
-            interventions: nextInterventions,
-            messages: [
-              ...ss.messages,
-              {
-                id: nextMessageId('system'),
-                type: 'system',
-                content:
-                  "chroxy intercepted a multi-question form and asked the agent to break it into single questions.",
-                timestamp: Date.now(),
-              },
-            ],
-          };
-        }
-        return { interventions: nextInterventions };
-      });
-      break;
-    }
 
     case 'permission_expired': {
       const { requestId: expiredRequestId, systemMessage: expiredSystemMsg } =

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -81,7 +81,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'cost_update',
   'history_replay_end',
   'key_exchange_ok',
-  'multi_question_intervention',
+  // multi_question_intervention — migrated to the shared dispatch table (#5618);
+  // now has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   'pair_fail',
   'permission_expired',
   'permission_mode_changed',

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -270,6 +270,41 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { noop: true },
   },
 
+  // 4d. multi_question_intervention (#5618) — append a dedup'd, ring-capped
+  // SessionIntervention to the target session, and on the FIRST one push a
+  // one-time system ChatMessage. Builder dedups by toolUseId (a stuck-model
+  // re-emit is a no-op) — byte-identical on both clients.
+  {
+    name: 'multi_question_intervention appends the intervention + first-time system notice',
+    type: 'multi_question_intervention',
+    init: { sessions: { s1: {} } },
+    message: { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu1', questionCount: 3 },
+    expect: {
+      sessions: {
+        s1: {
+          interventions: [{ kind: 'multi_question', toolUseId: 'tu1', count: 3 }],
+          messages: [
+            sysMsg('chroxy intercepted a multi-question form and asked the agent to break it into single questions.'),
+          ],
+        },
+      },
+    },
+  },
+  {
+    name: 'multi_question_intervention dedups a repeat toolUseId (no-op, no re-render)',
+    type: 'multi_question_intervention',
+    init: { sessions: { s1: { interventions: [{ kind: 'multi_question', toolUseId: 'tu1', count: 3, timestamp: 1 }] } } },
+    message: { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu1', questionCount: 3 },
+    expect: { noop: true },
+  },
+  {
+    name: 'multi_question_intervention is a no-op on a malformed payload (questionCount < 2)',
+    type: 'multi_question_intervention',
+    init: { sessions: { s1: {} } },
+    message: { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu1', questionCount: 1 },
+    expect: { noop: true },
+  },
+
   // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the
   // session was not paused; no-op when it was (budget_resumed already noted it)
   {

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -289,6 +289,59 @@ describe('shared dispatch table', () => {
     })
   })
 
+  describe('multi_question_intervention (#5618)', () => {
+    it('appends the intervention and a first-time system notice', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } } })
+      const handled = dispatch(env, {
+        type: 'multi_question_intervention',
+        sessionId: 's1',
+        toolUseId: 'tu1',
+        questionCount: 3,
+      })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.interventions).toMatchObject([{ kind: 'multi_question', toolUseId: 'tu1', count: 3 }])
+      expect(env.sessions.s1.messages).toHaveLength(1)
+      expect(env.sessions.s1.messages[0]).toMatchObject({
+        type: 'system',
+        content: 'chroxy intercepted a multi-question form and asked the agent to break it into single questions.',
+      })
+    })
+
+    it('dedups a repeat toolUseId — no second intervention, no second notice', () => {
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            messages: [],
+            interventions: [{ kind: 'multi_question', toolUseId: 'tu1', count: 3, timestamp: 1 }],
+          } as unknown as FakeSession,
+        },
+      })
+      const handled = dispatch(env, {
+        type: 'multi_question_intervention',
+        sessionId: 's1',
+        toolUseId: 'tu1',
+        questionCount: 3,
+      })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.interventions).toHaveLength(1) // unchanged
+      expect(env.sessions.s1.messages).toHaveLength(0) // no repeat notice
+    })
+
+    it('is handled (no mutation) on a malformed payload (questionCount < 2)', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } } })
+      const handled = dispatch(env, {
+        type: 'multi_question_intervention',
+        sessionId: 's1',
+        toolUseId: 'tu1',
+        questionCount: 1,
+      })
+      expect(handled).toBe(true) // table OWNS the type; the parser rejects the payload
+      expect(env.sessions.s1.interventions).toBeUndefined()
+      expect(env.sessions.s1.messages).toHaveLength(0)
+    })
+  })
+
   describe('budget_resume_ack', () => {
     it('appends a "nothing to resume" note when the session was not paused', () => {
       const env = makeAdapter({

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -54,8 +54,10 @@ import type {
   DevPreview,
   PendingBackgroundShell,
   QueuedSessionMessage,
+  SessionIntervention,
   WebTask,
 } from './types'
+import { nextMessageId } from './utils'
 import {
   handleAvailablePermissionModes,
   handleSessionUpdated,
@@ -101,6 +103,9 @@ import {
   handleMessageDequeued,
   // --- user_question (#5618) — byte-identical parse + append + notify ---
   handleUserQuestion,
+  // --- multi_question_intervention (#5618) — byte-identical builder + append ---
+  handleMultiQuestionIntervention,
+  applyInterventionBuilder,
   resolveSessionId,
   type PermissionMode,
   type PermissionRule,
@@ -158,6 +163,10 @@ export interface DispatchSessionBase {
   // carry it (the dashboard also mirrors the active session's value to flat
   // top-level state via its adapter).
   activeModel?: string | null
+  // --- multi_question_intervention (#5618) ---
+  // `interventions` — read+rewritten by multi_question_intervention (dedup +
+  // ring-cap). Both clients' real `SessionState` carry it (BaseSessionState).
+  interventions?: SessionIntervention[]
 }
 
 /**
@@ -460,6 +469,15 @@ export interface DispatchMessageMap {
     // #4613 — `handleUserQuestion` honours a wire `timestamp` (when a finite
     // number) for history-replay ordering, falling back to append-time
     // Date.now(). Documented here so the message shape matches the parser.
+    timestamp?: number
+  }
+  // --- multi_question_intervention (#5618) — the deny-event the builder reads ---
+  multi_question_intervention: {
+    type: 'multi_question_intervention'
+    sessionId?: string
+    toolUseId?: string
+    questionCount?: number
+    reason?: string
     timestamp?: number
   }
 }
@@ -958,6 +976,52 @@ function dispatchUserQuestion<S extends DispatchSessionBase>(
   if (sessionId) adapter.pushSessionNotification(sessionId, 'question', questionText)
 }
 
+/**
+ * `multi_question_intervention` (#5618/#4653) — chroxy's permission-hook denied a
+ * multi-question AskUserQuestion; append a {@link SessionIntervention} so the
+ * session-header/footer counter ticks, and on the FIRST intervention per session
+ * push a one-time system ChatMessage explaining the interception. Byte-identical
+ * between the two clients' switches (only a local var name + comment wording
+ * differed): both built the dedup-by-toolUseId, ring-capped builder via the
+ * shared `handleMultiQuestionIntervention`, ran `applyInterventionBuilder`, and
+ * skipped the write on a reference-equal (dedup'd repeat) result. The
+ * reference-equality skip is expressed as a `{}` no-op patch inside the updater
+ * (the same idiom the agent_* handlers use) so a stuck-model re-emit doesn't
+ * re-render the counter.
+ */
+function dispatchMultiQuestionIntervention<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['multi_question_intervention'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const builder = handleMultiQuestionIntervention(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (!builder) return
+  const targetId = builder.sessionId
+  if (!targetId || !adapter.hasSession(targetId)) return
+  adapter.updateSession(targetId, (ss) => {
+    const current = ss.interventions ?? []
+    const { interventions: nextInterventions, isFirst } = applyInterventionBuilder(builder, current)
+    // Dedup'd repeat — nothing changed; return a no-op patch so React doesn't
+    // re-render the intervention counter on every stuck-model re-emit.
+    if (nextInterventions === current) return {} as Partial<S>
+    if (isFirst) {
+      return {
+        interventions: nextInterventions,
+        messages: [
+          ...ss.messages,
+          {
+            id: nextMessageId('system'),
+            type: 'system',
+            content:
+              'chroxy intercepted a multi-question form and asked the agent to break it into single questions.',
+            timestamp: Date.now(),
+          },
+        ],
+      } as Partial<S>
+    }
+    return { interventions: nextInterventions } as Partial<S>
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Table + runner
 // ---------------------------------------------------------------------------
@@ -1030,6 +1094,8 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     message_dequeued: dispatchQueuedMessages<S>(handleMessageDequeued),
     // --- user_question (#5618) — byte-identical append + notify ---
     user_question: dispatchUserQuestion,
+    // --- multi_question_intervention (#5618) — byte-identical builder + append ---
+    multi_question_intervention: dispatchMultiQuestionIntervention,
   }
 }
 
@@ -1080,6 +1146,8 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'model_changed',
   // --- user_question (#5618) — byte-identical append + notify ---
   'user_question',
+  // --- multi_question_intervention (#5618) — byte-identical builder + append ---
+  'multi_question_intervention',
 ]
 
 /**


### PR DESCRIPTION
## Summary

**Batch 1** of the dispatch-table migration ([scope on #5618](https://github.com/blamechris/chroxy/issues/5618)). `multi_question_intervention` was handled by a logically **byte-identical** local case in *both* clients (only a local var name + comment wording differed) — the cleanest drop-in candidate from the scoping pass.

## Changes

- **`dispatch-table.ts`**: add `dispatchMultiQuestionIntervention` — builds the dedup-by-toolUseId, ring-capped intervention via the shared `handleMultiQuestionIntervention`, runs `applyInterventionBuilder`, and on the **first** intervention per session appends the one-time system notice. The reference-equality skip (stuck-model re-emit) is expressed as a `{}` no-op patch inside the updater — the same idiom the `agent_*` handlers use. Registered in both `createDispatchTable` and `DISPATCH_TABLE_TYPES`; added the `DispatchMessageMap` entry + `interventions` to `DispatchSessionBase`.
- **`contract.test.ts`** (DISPATCH_FIXTURES): 3 fixtures — first-time append+notice, dedup no-op, malformed (`questionCount < 2`) no-op — each driven through **both** client adapters asserting identical mutation.
- **`coverage-lint.test.ts`**: removed from `PENDING_CONTRACT_TYPES` (now table-owned, like `user_question`).
- **`dispatch-table.test.ts`**: focused unit tests for the handler.
- **Both client message-handlers**: removed the now-dead local `case` + the unused `handleMultiQuestionIntervention`/`applyInterventionBuilder` imports (`runDispatch` owns it before the switch).

## Behaviour-preserving — verification

- store-core: typecheck + full suite (**1720**) + dispatch-table units (**78**) + contract/coverage-lint fixtures — green.
- dashboard: typecheck + message-handler (**253**) — green.
- app: typecheck — green.
- protocol: `handler-coverage` (**9**) — green (the migrated type stays counted as covered once its `case` is removed).

The authoritative cross-client guard is `contract.test.ts`, which runs the shared handler through both the app and dashboard adapters and asserts they produce identical store mutations. (The local app jest is the slow `jest-expo --coverage` path; the App Tests CI job runs the full app suite.)

Part of #5618. Next: Batch 2 (conversation-store side-effect hook → `slash_commands` / `agent_list` / `provider_list`).