### PR TITLE
chore(app): add test:fast script (jest without coverage)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -10,6 +10,7 @@
     "web": "expo start --web",
     "test": "jest --coverage",
     "test:coverage": "jest --coverage --coverageReporters=text --coverageReporters=html",
+    "test:fast": "jest --coverage=false",
     "bundle-xterm": "node scripts/bundle-xterm.js",
     "postinstall": "node scripts/bundle-xterm.js"
   },


### PR DESCRIPTION
## Summary

The app's default `test` script is `jest --coverage`. With `collectCoverageFrom: ["src/**/*.{ts,tsx}"]`, Jest loads and Babel-instruments the **entire** `src/` tree to compute coverage — even when running a single test file — which makes local single-file runs take minutes on the `jest-expo` preset.

`test:fast` (`jest --coverage=false`) is the iterative dev-loop variant. Run `npm run test:fast -w packages/app -- <file>` for fast feedback.

## Non-breaking

- `test` and `test:coverage` are unchanged.
- **CI is unaffected**: the App Tests job runs `npm test` (with coverage) on the 24GB self-hosted runner.

A larger structural speedup (running the app's *pure-logic* tests under vitest like store-core/dashboard do) is noted as a follow-up; this is the zero-risk quick win.