### PR TITLE
refactor(store-core): migrate slash_commands/agent_list/provider_list onto the shared dispatch table (#5618 Batch 2)

### DIFF
--- a/packages/app/__tests__/CreateSessionModalProviders.test.ts
+++ b/packages/app/__tests__/CreateSessionModalProviders.test.ts
@@ -12,6 +12,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { DISPATCH_TABLE_TYPES } from '@chroxy/store-core';
 
 const modalSrc = fs.readFileSync(
   path.resolve(__dirname, '../src/components/CreateSessionModal.tsx'),
@@ -90,8 +91,13 @@ describe('ConnectionState — providers fields (#2948)', () => {
 });
 
 describe('message-handler — provider_list + auth_ok (#2948)', () => {
-  test('handles provider_list message and stores providers', () => {
-    expect(messageHandlerSrc).toMatch(/case\s+['"]provider_list['"]/);
+  test('handles provider_list via the shared dispatch table (#5618 Batch 2)', () => {
+    // provider_list migrated out of the app's local switch into the shared
+    // store-core dispatch table; the handler routes through `runDispatch` first,
+    // and the app's element-tightening rides on the `mapProviderList` adapter hook.
+    expect(messageHandlerSrc).toMatch(/runDispatch\(/);
+    expect(messageHandlerSrc).toMatch(/mapProviderList/);
+    expect(DISPATCH_TABLE_TYPES).toContain('provider_list');
   });
 
   test('sends list_providers as a post-auth message', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -95,9 +95,6 @@ import {
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
-  handleSlashCommands as sharedSlashCommands,
-  handleAgentList as sharedAgentList,
-  handleProviderList as sharedProviderList,
   handleAuthBootstrap as sharedAuthBootstrap,
   handleTunnelUrlChanged as sharedTunnelUrlChanged,
   // diff_result / git_status_result / git_branches_result / git_stage_result /
@@ -1191,6 +1188,21 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
     getCallback(name as CallbackName) as
       | ((payload: DispatchCallbackPayload) => void)
       | null,
+  // #5618 Batch 2 — slash_commands / agent_list also mirror into the app's
+  // secondary conversation store for the composer UI, exactly as the prior
+  // inline `useConversationStore.getState().setSlashCommands(...)` /
+  // `setCustomAgents(...)` did. The dashboard omits this hook (no secondary store).
+  syncSecondaryInventory: (kind, list) => {
+    if (kind === 'slashCommands') {
+      useConversationStore.getState().setSlashCommands(list as SlashCommand[]);
+    } else {
+      useConversationStore.getState().setCustomAgents(list as CustomAgent[]);
+    }
+  },
+  // #5618 Batch 2 — the app tightens provider_list elements via mapProviderList
+  // before the flat-state write (drops nameless/non-object entries). The
+  // dashboard omits this hook and writes the server payload verbatim.
+  mapProviderList: (providers) => mapProviderList(providers),
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -3157,30 +3169,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // shared*(msg) → cb(payload)` wrapper; the table now parses and invokes the
     // imperative callback via `_dispatchAdapter.getCallback`.
 
-    case 'slash_commands': {
-      const slashResult = sharedSlashCommands(msg, get().activeSessionId);
-      if (!slashResult) break;
-      const slashCommands = slashResult.commands as SlashCommand[];
-      set({ slashCommands });
-      useConversationStore.getState().setSlashCommands(slashCommands);
-      break;
-    }
-
-    case 'provider_list': {
-      const providerResult = sharedProviderList(msg);
-      if (!providerResult) break;
-      set({ availableProviders: mapProviderList(providerResult.providers) });
-      break;
-    }
-
-    case 'agent_list': {
-      const agentResult = sharedAgentList(msg, get().activeSessionId);
-      if (!agentResult) break;
-      const customAgents = agentResult.agents as CustomAgent[];
-      set({ customAgents });
-      useConversationStore.getState().setCustomAgents(customAgents);
-      break;
-    }
+    // slash_commands / agent_list / provider_list — migrated to the shared
+    // dispatch table (#5618 Batch 2; handled by runDispatch before this switch).
+    // The app's secondary-conversation-store mirror (slash/agents) and
+    // mapProviderList tightening now ride on the `syncSecondaryInventory` /
+    // `mapProviderList` adapter hooks. auth_bootstrap stays local — it folds all
+    // three lists into one connect-time frame with extra session-scope guarding.
 
     case 'auth_bootstrap': {
       // #5555 — connect-time bootstrap burst folds the provider / slash-command

--- a/packages/dashboard/src/components/ProviderPicker.test.tsx
+++ b/packages/dashboard/src/components/ProviderPicker.test.tsx
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest'
 import fs from 'fs'
 import path from 'path'
+import { DISPATCH_TABLE_TYPES } from '@chroxy/store-core'
 
 const modalSrc = fs.readFileSync(
   path.resolve(__dirname, './CreateSessionModal.tsx'),
@@ -83,8 +84,11 @@ describe('Provider picker in session creation (#1366)', () => {
     expect(typesSrc).toMatch(/fetchProviders\s*:\s*\(\)\s*=>/)
   })
 
-  test('message handler processes provider_list message', () => {
-    expect(messageHandlerSrc).toMatch(/case\s+['"]provider_list['"]/)
+  test('message handler processes provider_list message (via the shared dispatch table, #5618 Batch 2)', () => {
+    // provider_list migrated out of the dashboard's local switch into the shared
+    // store-core dispatch table; the handler routes through `runDispatch` first.
+    expect(messageHandlerSrc).toMatch(/runDispatch\(/)
+    expect(DISPATCH_TABLE_TYPES).toContain('provider_list')
   })
 
   test('list_providers is fetched on auth_ok', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -87,9 +87,6 @@ import {
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
-  handleSlashCommands as sharedSlashCommands,
-  handleAgentList as sharedAgentList,
-  handleProviderList as sharedProviderList,
   handleAuthBootstrap as sharedAuthBootstrap,
   handleTunnelUrlChanged as sharedTunnelUrlChanged,
   handleFileList as sharedFileList,
@@ -4667,30 +4664,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'slash_commands': {
-      const slashResult = sharedSlashCommands(msg, get().activeSessionId);
-      if (!slashResult) break;
-      set({ slashCommands: slashResult.commands as SlashCommand[] });
-      break;
-    }
+    // slash_commands / agent_list / provider_list — migrated to the shared
+    // dispatch table (#5618 Batch 2; handled by runDispatch before this switch).
+    // The dashboard has no secondary conversation store and trusts the server
+    // provider payload, so it supplies neither the `syncSecondaryInventory` nor
+    // the `mapProviderList` adapter hook — the dispatch handlers perform the
+    // plain flat-state write, exactly as these cases did. auth_bootstrap stays
+    // local. file_list remains dashboard-only.
 
     case 'file_list': {
       const fileResult = sharedFileList(msg);
       set({ filePickerFiles: fileResult.files as FilePickerItem[] });
-      break;
-    }
-
-    case 'agent_list': {
-      const agentResult = sharedAgentList(msg, get().activeSessionId);
-      if (!agentResult) break;
-      set({ customAgents: agentResult.agents as CustomAgent[] });
-      break;
-    }
-
-    case 'provider_list': {
-      const providerResult = sharedProviderList(msg);
-      if (!providerResult) break;
-      set({ availableProviders: providerResult.providers as ProviderInfo[] });
       break;
     }
 

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -146,6 +146,33 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
           getCallback: ((name: string) => (payload: unknown) => {
             callbacks.push({ name, payload })
           }) as ClientStoreAdapter<FixtureSession>['getCallback'],
+          // #5618 Batch 2 — model the app's `mapProviderList` element-tightening
+          // (packages/app/src/store/message-handler.ts) so `provider_list`
+          // fixtures observe the REAL app filtering: drop non-object / nameless
+          // entries; copy only `name` / `capabilities` / `auth` (each kept only
+          // when a non-array object). The DASHBOARD omits this hook → writes the
+          // server payload verbatim. The divergence is locked by a `divergent`
+          // provider_list fixture.
+          mapProviderList: ((providers: unknown[]) =>
+            providers
+              .filter(
+                (p): p is { name: string; [k: string]: unknown } =>
+                  !!p && typeof p === 'object' && typeof (p as { name?: unknown }).name === 'string',
+              )
+              .map((p) => {
+                const entry: Record<string, unknown> = { name: p.name }
+                const caps = (p as { capabilities?: unknown }).capabilities
+                if (caps && typeof caps === 'object' && !Array.isArray(caps)) entry.capabilities = caps
+                const auth = (p as { auth?: unknown }).auth
+                if (auth && typeof auth === 'object' && !Array.isArray(auth)) entry.auth = auth
+                return entry
+              })) as ClientStoreAdapter<FixtureSession>['mapProviderList'],
+          // #5618 Batch 2 — the app mirrors slash/agent inventory into its
+          // secondary conversation store. Like `pushSessionNotification`, this is
+          // a UI side-effect OUTSIDE the shared store-state contract; modelled as
+          // a no-op here (no fixture asserts on it — the dispatch-table unit tests
+          // cover the hook invocation directly).
+          syncSecondaryInventory: () => {},
         }
       : {}),
   }

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -65,7 +65,8 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 // ---------------------------------------------------------------------------
 const PENDING_CONTRACT_TYPES = new Set<string>([
   'agent_idle',
-  'agent_list',
+  // agent_list — migrated to the shared dispatch table (#5618 Batch 2); now has
+  // a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   'auth_bootstrap',
   'auth_fail',
   'auth_ok',
@@ -91,7 +92,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'plan_ready',
   'pong',
   'primary_changed',
-  'provider_list',
+  // provider_list — migrated to the shared dispatch table (#5618 Batch 2);
+  // app/dashboard element-handling divergence locked by a divergent fixture.
   'raw',
   'raw_background',
   'search_results',
@@ -108,7 +110,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'session_switched',
   'session_timeout',
   'session_warning',
-  'slash_commands',
+  // slash_commands — migrated to the shared dispatch table (#5618 Batch 2); now
+  // has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   'stream_delta',
   'terminal_output',
   'token_rotated',

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -305,6 +305,105 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { noop: true },
   },
 
+  // 4e. slash_commands / agent_list / provider_list (#5618 Batch 2) — flat
+  // list-replacement. slash_commands / agent_list carry the broadcast-guard
+  // sessionId (skip when it targets a non-active session). The app additionally
+  // mirrors slash/agent lists into its secondary conversation store (out of the
+  // shared contract — a no-op here) and tightens provider elements via
+  // mapProviderList (LOCKED by the divergent provider fixture below).
+  {
+    name: 'slash_commands replaces the flat slash-command list (server-wide)',
+    type: 'slash_commands',
+    message: { type: 'slash_commands', commands: [{ name: '/compact' }, { name: '/clear' }] },
+    expect: { flat: { slashCommands: [{ name: '/compact' }, { name: '/clear' }] } },
+  },
+  {
+    name: 'slash_commands is dropped when it targets a non-active session',
+    type: 'slash_commands',
+    init: { activeSessionId: 'active' },
+    message: { type: 'slash_commands', sessionId: 'other', commands: [{ name: '/x' }] },
+    expect: { noop: true },
+  },
+  {
+    name: 'slash_commands is a no-op when commands is not an array',
+    type: 'slash_commands',
+    message: { type: 'slash_commands' },
+    expect: { noop: true },
+  },
+  {
+    name: 'agent_list replaces the flat custom-agent list (server-wide)',
+    type: 'agent_list',
+    message: { type: 'agent_list', agents: [{ name: 'reviewer' }, { name: 'planner' }] },
+    expect: { flat: { customAgents: [{ name: 'reviewer' }, { name: 'planner' }] } },
+  },
+  {
+    name: 'agent_list is dropped when it targets a non-active session',
+    type: 'agent_list',
+    init: { activeSessionId: 'active' },
+    message: { type: 'agent_list', sessionId: 'other', agents: [{ name: 'x' }] },
+    expect: { noop: true },
+  },
+  {
+    name: 'agent_list is a no-op when agents is not an array',
+    type: 'agent_list',
+    message: { type: 'agent_list' },
+    expect: { noop: true },
+  },
+  {
+    name: 'provider_list replaces the flat provider list (well-formed: identical in both)',
+    type: 'provider_list',
+    message: {
+      type: 'provider_list',
+      providers: [
+        { name: 'claude', capabilities: { streaming: true }, auth: { type: 'oauth' } },
+        { name: 'gemini', capabilities: { streaming: false } },
+      ],
+    },
+    expect: {
+      flat: {
+        availableProviders: [
+          { name: 'claude', capabilities: { streaming: true }, auth: { type: 'oauth' } },
+          { name: 'gemini', capabilities: { streaming: false } },
+        ],
+      },
+    },
+  },
+  {
+    name: 'provider_list element handling (app mapProviderList tightens; dashboard writes verbatim)',
+    type: 'provider_list',
+    message: {
+      type: 'provider_list',
+      providers: [
+        { name: 'claude', capabilities: { streaming: true }, extra: 'drop-me' },
+        { noName: true },
+      ],
+    },
+    divergent: {
+      app: {
+        // mapProviderList drops the nameless entry and the non-allow-listed
+        // `extra` field, keeping only name + (object) capabilities.
+        flat: { availableProviders: [{ name: 'claude', capabilities: { streaming: true } }] },
+      },
+      dashboard: {
+        // verbatim passthrough — both elements kept, `extra` field retained.
+        flat: {
+          availableProviders: [
+            { name: 'claude', capabilities: { streaming: true }, extra: 'drop-me' },
+            { noName: true },
+          ],
+        },
+      },
+      reason:
+        'app mapProviderList drops nameless entries + strips non-name/capabilities/auth fields; dashboard writes the payload verbatim',
+    },
+  },
+  {
+    name: 'provider_list is a no-op when providers is not an array',
+    type: 'provider_list',
+    message: { type: 'provider_list' },
+    expect: { noop: true },
+  },
+
   // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the
   // session was not paused; no-op when it was (budget_resumed already noted it)
   {

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -47,6 +47,14 @@ function makeAdapter(init?: {
    * dashboard's behaviour — fall through to the local switch).
    */
   callbacks?: Partial<Record<string, ((payload: unknown) => void) | null>>
+  /**
+   * When true, the adapter wires the app-only inventory hooks (#5618 Batch 2):
+   * `syncSecondaryInventory` (records into `inventorySyncs`) and `mapProviderList`
+   * (a marker transform that proves the dispatcher writes the HOOK's output, not
+   * the raw payload). When omitted, both hooks are absent — the dashboard's
+   * verbatim behaviour (no secondary-store mirror; provider list written as-is).
+   */
+  inventoryHooks?: boolean
 }) {
   const sessions: Record<string, FakeSession> = init?.sessions ?? {}
   let activeSessionId = init?.activeSessionId ?? null
@@ -54,6 +62,7 @@ function makeAdapter(init?: {
   const flat: Record<string, unknown> = {}
   const addedMessages: ChatMessage[] = []
   const notifications: Array<{ sessionId: string; eventType: string; message: string }> = []
+  const inventorySyncs: Array<{ kind: string; list: unknown[] }> = []
 
   const adapter: ClientStoreAdapter<FakeSession> = {
     getActiveSessionId: () => activeSessionId,
@@ -75,6 +84,15 @@ function makeAdapter(init?: {
             (init.callbacks?.[name] ?? null)) as ClientStoreAdapter<FakeSession>['getCallback'],
         }
       : {}),
+    ...(init?.inventoryHooks
+      ? {
+          syncSecondaryInventory: (kind, list) => inventorySyncs.push({ kind, list }),
+          // Marker transform: prepend a sentinel so a test can prove the flat
+          // write used the hook's RETURN value, not the raw `providers`. (The
+          // contract test models the real app `mapProviderList` filtering.)
+          mapProviderList: (providers) => ['__mapped__', ...providers],
+        }
+      : {}),
   }
 
   return {
@@ -83,6 +101,7 @@ function makeAdapter(init?: {
     flat,
     addedMessages,
     notifications,
+    inventorySyncs,
     setActive: (id: string | null) => {
       activeSessionId = id
     },
@@ -339,6 +358,93 @@ describe('shared dispatch table', () => {
       expect(handled).toBe(true) // table OWNS the type; the parser rejects the payload
       expect(env.sessions.s1.interventions).toBeUndefined()
       expect(env.sessions.s1.messages).toHaveLength(0)
+    })
+  })
+
+  describe('slash_commands / agent_list / provider_list (#5618 Batch 2)', () => {
+    it('slash_commands replaces the flat list and mirrors into the secondary store (app)', () => {
+      const env = makeAdapter({ inventoryHooks: true })
+      const handled = dispatch(env, {
+        type: 'slash_commands',
+        commands: [{ name: '/compact' }, { name: '/clear' }],
+      })
+      expect(handled).toBe(true)
+      expect(env.flat.slashCommands).toEqual([{ name: '/compact' }, { name: '/clear' }])
+      expect(env.inventorySyncs).toEqual([
+        { kind: 'slashCommands', list: [{ name: '/compact' }, { name: '/clear' }] },
+      ])
+    })
+
+    it('slash_commands replaces the flat list with NO mirror when the hook is absent (dashboard)', () => {
+      const env = makeAdapter()
+      const handled = dispatch(env, { type: 'slash_commands', commands: [{ name: '/x' }] })
+      expect(handled).toBe(true)
+      expect(env.flat.slashCommands).toEqual([{ name: '/x' }])
+      expect(env.inventorySyncs).toEqual([])
+    })
+
+    it('slash_commands is owned-but-no-op when it targets a non-active session', () => {
+      const env = makeAdapter({ activeSessionId: 'active', inventoryHooks: true })
+      const handled = dispatch(env, {
+        type: 'slash_commands',
+        sessionId: 'other',
+        commands: [{ name: '/x' }],
+      })
+      expect(handled).toBe(true)
+      expect(env.flat.slashCommands).toBeUndefined()
+      expect(env.inventorySyncs).toEqual([])
+    })
+
+    it('slash_commands is owned-but-no-op when commands is not an array', () => {
+      const env = makeAdapter({ inventoryHooks: true })
+      expect(dispatch(env, { type: 'slash_commands' })).toBe(true)
+      expect(env.flat.slashCommands).toBeUndefined()
+      expect(env.inventorySyncs).toEqual([])
+    })
+
+    it('agent_list replaces the flat list and mirrors into the secondary store (app)', () => {
+      const env = makeAdapter({ inventoryHooks: true })
+      const handled = dispatch(env, {
+        type: 'agent_list',
+        agents: [{ name: 'reviewer' }],
+      })
+      expect(handled).toBe(true)
+      expect(env.flat.customAgents).toEqual([{ name: 'reviewer' }])
+      expect(env.inventorySyncs).toEqual([{ kind: 'customAgents', list: [{ name: 'reviewer' }] }])
+    })
+
+    it('agent_list is owned-but-no-op when agents is not an array', () => {
+      const env = makeAdapter({ inventoryHooks: true })
+      expect(dispatch(env, { type: 'agent_list' })).toBe(true)
+      expect(env.flat.customAgents).toBeUndefined()
+      expect(env.inventorySyncs).toEqual([])
+    })
+
+    it('provider_list writes the payload verbatim when no mapProviderList hook is set (dashboard)', () => {
+      const env = makeAdapter()
+      const handled = dispatch(env, {
+        type: 'provider_list',
+        providers: [{ name: 'claude' }, { name: 'gemini' }],
+      })
+      expect(handled).toBe(true)
+      expect(env.flat.availableProviders).toEqual([{ name: 'claude' }, { name: 'gemini' }])
+    })
+
+    it('provider_list writes the mapProviderList hook output when present (app)', () => {
+      const env = makeAdapter({ inventoryHooks: true })
+      const handled = dispatch(env, {
+        type: 'provider_list',
+        providers: [{ name: 'claude' }],
+      })
+      expect(handled).toBe(true)
+      // The marker proves the dispatcher wrote the HOOK's return value.
+      expect(env.flat.availableProviders).toEqual(['__mapped__', { name: 'claude' }])
+    })
+
+    it('provider_list is owned-but-no-op when providers is not an array', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'provider_list' })).toBe(true)
+      expect(env.flat.availableProviders).toBeUndefined()
     })
   })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -75,6 +75,10 @@ import {
   handlePlanStarted,
   handleInactivityWarning,
   handleMcpServers,
+  // --- inventory list-replacement cases (#5618 Batch 2) ---
+  handleSlashCommands,
+  handleAgentList,
+  handleProviderList,
   handleSessionUsage,
   handleSessionContext,
   handleModelChangedPatch,
@@ -245,6 +249,38 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * caller (which knows the concrete callback signature for `name`) narrows it.
    */
   getCallback?(name: DispatchCallbackName): ((payload: DispatchCallbackPayload) => void) | null | undefined
+  /**
+   * Mirror a server-wide inventory list into a SECONDARY client store (#5618
+   * Batch 2). The mobile app keeps a separate `useConversationStore` that also
+   * tracks the slash-command / custom-agent lists for its composer UI; after the
+   * `slash_commands` / `agent_list` dispatch handlers write the list into flat
+   * connection state, they call this to keep the secondary store in sync —
+   * exactly the app's prior inline
+   * `useConversationStore.getState().setSlashCommands(...)` / `setCustomAgents(...)`.
+   *
+   * OPTIONAL: a client without a secondary inventory store (the dashboard) omits
+   * it; the dispatch handler then performs only the flat-state write. This is a
+   * platform-specific side-effect OUTSIDE the shared store-state contract, in the
+   * same spirit as the app's extra push-store mirror in
+   * {@link ClientStoreAdapter.pushSessionNotification}.
+   */
+  syncSecondaryInventory?(kind: 'slashCommands' | 'customAgents', list: unknown[]): void
+  /**
+   * Map/validate the raw `provider_list` element array before it is written to
+   * flat state (#5618 Batch 2). The mobile app tightens each entry (drops
+   * non-object / nameless entries, copies only `name`/`capabilities`/`auth`) via
+   * its `mapProviderList`; the dashboard trusts the server payload and writes it
+   * verbatim.
+   *
+   * OPTIONAL: when omitted, the raw array is written unchanged (the dashboard's
+   * prior `set({ availableProviders: providers as ProviderInfo[] })`). When
+   * present, the returned array is written instead (the app's prior
+   * `set({ availableProviders: mapProviderList(providers) })`). For the
+   * well-formed payloads the server actually sends, the two are field-identical;
+   * the hook only diverges on malformed input, preserving each client's existing
+   * robustness behaviour.
+   */
+  mapProviderList?(providers: unknown[]): unknown[]
 }
 
 /**
@@ -368,6 +404,24 @@ export interface DispatchMessageMap {
     type: 'mcp_servers'
     sessionId?: string
     servers?: unknown[]
+  }
+  // --- inventory list-replacement cases (#5618 Batch 2) ---
+  // slash_commands / agent_list carry the broadcast-guard `sessionId`; the
+  // parser drops the message when it targets a non-active session. Element shape
+  // is validated downstream (the cast stays at the flat-state write).
+  slash_commands: {
+    type: 'slash_commands'
+    sessionId?: string
+    commands?: unknown[]
+  }
+  agent_list: {
+    type: 'agent_list'
+    sessionId?: string
+    agents?: unknown[]
+  }
+  provider_list: {
+    type: 'provider_list'
+    providers?: unknown[]
   }
   session_usage: {
     type: 'session_usage'
@@ -845,6 +899,53 @@ function dispatchWebTaskList<S extends DispatchSessionBase>(
   adapter.setState({ webTasks: tasks as WebTask[] } as Record<string, WebTask[]>)
 }
 
+// ---------------------------------------------------------------------------
+// Inventory list-replacement cases (#5618 Batch 2)
+//
+// slash_commands / agent_list / provider_list each replace a single flat
+// connection-state list. They share the base flat-state write across both
+// clients; the only divergences are platform-specific side-effects handled by
+// the OPTIONAL adapter hooks above (the app mirrors slash/agent lists into its
+// secondary `useConversationStore`, and tightens provider elements via
+// `mapProviderList`). With both hooks omitted, the dashboard's prior verbatim
+// behaviour is preserved exactly.
+// ---------------------------------------------------------------------------
+
+/** `slash_commands` — replace the flat slash-command list (broadcast-guarded). */
+function dispatchSlashCommands<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['slash_commands'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const result = handleSlashCommands(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (!result) return
+  adapter.setState({ slashCommands: result.commands } as Record<string, unknown[]>)
+  adapter.syncSecondaryInventory?.('slashCommands', result.commands)
+}
+
+/** `agent_list` — replace the flat custom-agent list (broadcast-guarded). */
+function dispatchAgentList<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['agent_list'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const result = handleAgentList(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (!result) return
+  adapter.setState({ customAgents: result.agents } as Record<string, unknown[]>)
+  adapter.syncSecondaryInventory?.('customAgents', result.agents)
+}
+
+/** `provider_list` — replace the flat provider list (server-wide; app tightens). */
+function dispatchProviderList<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['provider_list'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const result = handleProviderList(msg as Record<string, unknown>)
+  if (!result) return
+  const providers = adapter.mapProviderList
+    ? adapter.mapProviderList(result.providers)
+    : result.providers
+  adapter.setState({ availableProviders: providers } as Record<string, unknown[]>)
+}
+
 /**
  * `notification_prefs` — validate + store the notification-prefs snapshot.
  * Slice-2 RECONCILE: both clients now share `handleNotificationPrefs`. A failed
@@ -1051,6 +1152,10 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     plan_started: sessionPatchDispatcher<S>(handlePlanStarted),
     inactivity_warning: dispatchInactivityWarning,
     mcp_servers: sessionPatchDispatcher<S>(handleMcpServers),
+    // --- inventory list-replacement cases (#5618 Batch 2) ---
+    slash_commands: dispatchSlashCommands,
+    agent_list: dispatchAgentList,
+    provider_list: dispatchProviderList,
     session_usage: sessionPatchDispatcher<S>(handleSessionUsage),
     session_context: sessionPatchDispatcher<S>(handleSessionContext),
     model_changed: sessionPatchDispatcher<S>(handleModelChangedPatch),
@@ -1117,6 +1222,10 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'plan_started',
   'inactivity_warning',
   'mcp_servers',
+  // --- inventory list-replacement cases (#5618 Batch 2) ---
+  'slash_commands',
+  'agent_list',
+  'provider_list',
   'session_usage',
   'session_context',
   'session_cost_threshold_crossed',


### PR DESCRIPTION
## Summary

Batch 2 of the dispatch-table migration (epic #5618; Batch 1 = #6207). Migrates the three server-side **inventory list-replacement** messages — `slash_commands`, `agent_list`, `provider_list` — out of both clients' hand-copied switches into the shared store-core dispatch table.

All three share the same flat-state write across both clients; the only divergences are platform-specific side-effects, now expressed as **optional, no-op-defaulted adapter hooks** (so neither client can regress the other — the same pattern as `getCallback`/`pushSessionNotification`):

| Hook | App | Dashboard |
|------|-----|-----------|
| `syncSecondaryInventory(kind, list)` | mirrors slash/agent lists into the secondary `useConversationStore` (composer UI) | omitted (no secondary store) |
| `mapProviderList(providers)` | tightens elements (drops nameless/non-object entries; copies only `name`/`capabilities`/`auth`) | omitted → writes the server payload verbatim |

The provider element-handling divergence is **locked by a `divergent` contract fixture** (well-formed payloads are field-identical; the hook only diverges on malformed input, preserving each client's existing robustness).

`auth_bootstrap` stays local — it folds all three lists into one connect-time frame with extra session-scope guarding.

## Changes
- `dispatch-table.ts`: 3 new dispatch fns + map entries + 2 optional adapter hooks; registered in `createDispatchTable` **and** `DISPATCH_TABLE_TYPES` (drift test enforces equality).
- Both clients: dead `case` blocks + now-unused shared imports removed (app −24, dashboard −27).
- Tests: 8 new `DISPATCH_FIXTURES` (incl. the divergent provider fixture), removed the three from `PENDING_CONTRACT_TYPES`, 9 new `dispatch-table.test.ts` units, updated the two clients' provider source-grep tests to assert the shared-table route.

## Verification
- store-core: `npm run typecheck` + full vitest **1738 ✓** (contract 72 / dispatch-table 87 / coverage-lint 4 / protocol-type-coverage 5)
- dashboard: vitest **4032 ✓** + typecheck
- protocol: **340 ✓** (handler-coverage credits the migrated types via `DISPATCH_TABLE_TYPES`)
- app: typecheck ✓ + affected test files ✓ (full app jest suite runs in CI)

Closes part of #5618.