### PR TITLE
refactor(store-core): migrate session_restore_failed/persist_failed/stopped onto the shared dispatch table (#5618 Batch 3)

### DIFF
--- a/packages/app/src/__tests__/screens/SessionScreenStoppedBanner.test.ts
+++ b/packages/app/src/__tests__/screens/SessionScreenStoppedBanner.test.ts
@@ -17,6 +17,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { DISPATCH_TABLE_TYPES } from '@chroxy/store-core';
 
 const SessionScreenSrc = fs.readFileSync(
   path.resolve(__dirname, '../../screens/SessionScreen.tsx'),
@@ -85,20 +86,23 @@ describe('SessionScreen stopped status strip (#4879)', () => {
     expect(SessionScreenSrc).toMatch(/testID="session-stopped-banner-text"/);
   });
 
-  it('does NOT push a session notification or fire an Alert from the case branch', () => {
-    // The case branch in message-handler.ts must not show modal UI or
-    // push a notification — the inline strip carries the full signal.
+  it('shows no modal / notification / toast — migrated to the shared dispatch table (#5618 Batch 3)', () => {
+    // session_stopped moved out of the app's local switch into the shared
+    // store-core dispatch table; the app deliberately stays quiet (#4879 — the
+    // inline strip carries the full signal). It reproduces that by OMITTING the
+    // `addInfoNotification` adapter hook the dashboard supplies, so the
+    // dispatcher's `adapter.addInfoNotification?.(...)` is a no-op on mobile.
     const msgHandlerSrc = fs.readFileSync(
       path.resolve(__dirname, '../../store/message-handler.ts'),
       'utf-8',
     );
-    // Locate just the case body so we don't trip over unrelated Alert
-    // calls elsewhere in the dispatcher.
-    const caseBlock = msgHandlerSrc.match(/case 'session_stopped':\s*\{([\s\S]*?)\n {4}\}/);
-    expect(caseBlock).not.toBeNull();
-    const body = caseBlock![1];
-    expect(body).not.toMatch(/Alert\.alert/);
-    expect(body).not.toMatch(/pushSessionNotification/);
-    expect(body).not.toMatch(/addServerError/);
+    // No local case branch remains.
+    expect(msgHandlerSrc).not.toMatch(/case 'session_stopped':/);
+    // The app adapter does NOT wire the info-toast hook (the dashboard does) —
+    // i.e. no `addInfoNotification:` property in the adapter object (a comment
+    // mentioning the hook by name is fine; the property definition is not).
+    expect(msgHandlerSrc).not.toMatch(/addInfoNotification\s*:/);
+    // And the type is owned by the shared table.
+    expect(DISPATCH_TABLE_TYPES).toContain('session_stopped');
   });
 });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -54,8 +54,6 @@ import {
   handleCheckpointRestored as sharedCheckpointRestored,
   handleError as sharedError,
   handleSessionError as sharedSessionError,
-  // #4879: quiet user-initiated Stop confirmation handler
-  handleSessionStopped as sharedSessionStopped,
   handleClientJoined as sharedClientJoined,
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
@@ -92,7 +90,6 @@ import {
   chunkSubscribeSessionIds as sharedChunkSubscribeSessionIds,
   SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
   handleSessionTimeout as sharedSessionTimeout,
-  handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
   handleAuthBootstrap as sharedAuthBootstrap,
@@ -1203,6 +1200,28 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // before the flat-state write (drops nameless/non-object entries). The
   // dashboard omits this hook and writes the server payload verbatim.
   mapProviderList: (providers) => mapProviderList(providers),
+  // #5618 Batch 3 — error-sink for session_restore_failed / session_persist_failed.
+  // The app builds a structured ServerError, ring-caps the flat `serverErrors`
+  // list, and mirrors into the mobile notification store. (The id prefix is now a
+  // unified server-error prefix rather than the prior per-case restore/persist
+  // prefixes — ids stay unique; the prefix is cosmetic, not used for render/dedup.)
+  addServerError: (message, opts) => {
+    const serverError: ServerError = {
+      id: nextMessageId('server-error'),
+      category: (opts?.category ?? 'general') as ServerError['category'],
+      message,
+      recoverable: opts?.recoverable ?? true,
+      timestamp: Date.now(),
+      ...(opts?.sessionId ? { sessionId: opts.sessionId } : {}),
+    };
+    getStore().setState((state: ConnectionState) => ({
+      serverErrors: [...state.serverErrors, serverError].slice(-10),
+    }));
+    useNotificationStore.getState().addServerError(serverError);
+  },
+  // #5618 Batch 3 — the app deliberately shows NO info toast for session_stopped
+  // (#4879 — the inline session banner carries the signal), so `addInfoNotification`
+  // is OMITTED. The dashboard supplies it (its #4878 info toast).
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -2244,33 +2263,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_stopped': {
-      // #4879: quiet, informational confirmation when CliSession exits
-      // cleanly after a user-initiated Stop. The wire path was wired in
-      // #4868 (CliSession 'stopped' → SessionManager → ws-forwarding →
-      // ServerSessionStoppedSchema). Distinct from `session_error` (which
-      // flips `health: 'crashed'` and surfaces a loud red banner): the
-      // operator tapped Stop, the child process did indeed stop.
-      //
-      // Sets `stoppedAt` + `stoppedCode` on the target session — the
-      // SessionScreen reads those fields to render a subtle, info-styled
-      // status strip ("Session stopped." / "Session stopped. (exit N)").
-      // Both fields are cleared automatically by `handleClaudeReady`
-      // (which returns `stoppedAt: null, stoppedCode: null`) when the
-      // server restarts the child after the operator's next input.
-      //
-      // NO Alert / push notification — this is intentionally NOT an
-      // error UX. The active session's inline banner carries the full
-      // signal; for inactive sessions the absence of a session_error
-      // already conveys "no crash, clean stop" and adding a notification
-      // here would just be noise.
-      const stoppedPatch = sharedSessionStopped(msg, get().activeSessionId);
-      const stoppedTarget = stoppedPatch.sessionId;
-      if (stoppedTarget && get().sessionStates[stoppedTarget]) {
-        updateSession(stoppedTarget, () => stoppedPatch.patch);
-      }
-      break;
-    }
+    // session_stopped — migrated to the shared dispatch table (#5618 Batch 3;
+    // handled by runDispatch before this switch). Sets stoppedAt/stoppedCode on
+    // the target session; the app deliberately shows NO toast (#4879), so it
+    // omits the `addInfoNotification` adapter hook the dashboard supplies.
 
     // --- History replay ---
 
@@ -3222,62 +3218,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_restore_failed': {
-      // Server couldn't restart a persisted session (e.g. missing API key).
-      // History is preserved on disk; surface this visibly instead of making
-      // the saved session look like it silently disappeared after restart.
-      const restoreFailed = sharedSessionRestoreFailed(msg);
-      const serverError: ServerError = {
-        id: nextMessageId('restore'),
-        category: 'session',
-        message: restoreFailed.systemMessage.content,
-        recoverable: true,
-        timestamp: Date.now(),
-        ...(restoreFailed.sessionId ? { sessionId: restoreFailed.sessionId } : {}),
-      };
-      set((state: ConnectionState) => ({
-        serverErrors: [...state.serverErrors, serverError].slice(-10),
-      }));
-      useNotificationStore.getState().addServerError(serverError);
-      // eslint-disable-next-line no-console
-      console.warn('[session_restore_failed]', {
-        sessionId: restoreFailed.sessionId,
-        name: restoreFailed.name,
-        provider: restoreFailed.provider,
-        cwd: restoreFailed.cwd,
-        model: restoreFailed.model,
-        permissionMode: restoreFailed.permissionMode,
-        errorCode: restoreFailed.errorCode,
-        errorMessage: restoreFailed.errorMessage,
-        historyLength: restoreFailed.historyLength,
-      });
-      break;
-    }
-
-    case 'session_persist_failed': {
-      // #5714/#5701: a session-list mutation (create/rename/destroy) could not be
-      // flushed to disk and will be lost on restart. The write is atomic so
-      // on-disk state isn't corrupted — surface a recoverable error so the user
-      // isn't left silently believing the change persisted.
-      const persistSid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      const persistName = typeof msg.name === 'string' ? msg.name : null;
-      const label = persistName ? `"${persistName}"` : (persistSid ? `session ${persistSid}` : 'your session change');
-      const persistError: ServerError = {
-        id: nextMessageId('persist'),
-        category: 'session',
-        message: `Couldn't save ${label} — the change may be lost on restart. Check the daemon's disk space and write permissions.`,
-        recoverable: true,
-        timestamp: Date.now(),
-        ...(persistSid ? { sessionId: persistSid } : {}),
-      };
-      set((state: ConnectionState) => ({
-        serverErrors: [...state.serverErrors, persistError].slice(-10),
-      }));
-      useNotificationStore.getState().addServerError(persistError);
-      // eslint-disable-next-line no-console
-      console.warn('[session_persist_failed]', { sessionId: persistSid, name: persistName });
-      break;
-    }
+    // session_restore_failed / session_persist_failed — migrated to the shared
+    // dispatch table (#5618 Batch 3; handled by runDispatch before this switch).
+    // Both surface a recoverable error via the `addServerError` adapter hook (the
+    // app builds the structured ServerError + ring + notification-store mirror);
+    // the shared handlers own the message construction + console.warn.
 
     case 'checkpoint_created': {
       const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1208,7 +1208,9 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   addServerError: (message, opts) => {
     const serverError: ServerError = {
       id: nextMessageId('server-error'),
-      category: (opts?.category ?? 'general') as ServerError['category'],
+      // opts.category is the closed ServerErrorCategory union (typed at the hook),
+      // so no cast is needed — fall back to 'general' when the caller omits it.
+      category: opts?.category ?? 'general',
       message,
       recoverable: opts?.recoverable ?? true,
       timestamp: Date.now(),

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -68,7 +68,6 @@ import {
   handlePermissionRequest as sharedPermissionRequest,
   handlePermissionResolved as sharedPermissionResolved,
   handlePermissionTimeout as sharedPermissionTimeout,
-  handleSessionStopped as sharedSessionStopped,
   handleCheckpointRestored as sharedCheckpointRestored,
   handleConversationsList as sharedConversationsList,
   handleRawOutput as sharedRawOutput,
@@ -84,7 +83,6 @@ import {
   buildSessionListPatches as sharedBuildSessionListPatches,
   cumulativeUsageEquals as sharedCumulativeUsageEquals,
   handleSessionTimeout as sharedSessionTimeout,
-  handleSessionRestoreFailed as sharedSessionRestoreFailed,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
   handleAuthBootstrap as sharedAuthBootstrap,
@@ -1037,6 +1035,13 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // dashboard's own helper (dedup by (sessionId, eventType); no push store).
   pushSessionNotification: (sessionId, eventType, message) =>
     pushSessionNotification(sessionId, eventType, message),
+  // #5618 Batch 3 — error-sink for session_restore_failed / session_persist_failed.
+  // The dashboard's connection-store addServerError builds its own envelope
+  // (category 'general', id 'info', ring-capped serverErrors) from the message;
+  // it ignores the structured opts (its prior behaviour took only the string).
+  addServerError: (message) => getStore().getState().addServerError(message),
+  // #5618 Batch 3 — session_stopped's info toast (#4878). The app omits this hook.
+  addInfoNotification: (message) => getStore().getState().addInfoNotification(message),
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -4033,41 +4038,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_stopped': {
-      // #4878: quiet, informational confirmation when CliSession exits
-      // cleanly after a user-initiated Stop. The wire path was wired in
-      // #4868 (CliSession 'stopped' → SessionManager → ws-forwarding →
-      // ServerSessionStoppedSchema). Routed through `addInfoNotification`
-      // (info-level toast, not the red `addServerError` reserved for
-      // crashes / STREAM_ERROR / ABORT) so the operator gets a positive
-      // "you clicked Stop and the session did indeed stop" confirmation.
-      //
-      // A non-zero exit code is surfaced as a small diagnostic suffix
-      // (e.g. "Session stopped. (exit 143)" for SIGTERM). Code 0 is the
-      // common clean-exit case and gets no decoration — the bare
-      // "Session stopped." carries the full signal there. Missing code
-      // (future in-process providers per the #4756 follow-up) is also
-      // bare; surfacing "(exit undefined)" would be noisier than useful.
-      //
-      // #5454: parse + session patch shared via store-core (same handler the
-      // app uses; it also tightens the code guard with Number.isInteger so a
-      // fractional/NaN code renders bare instead of "(exit 1.5)"). The patch
-      // sets `stoppedAt`/`stoppedCode` on the target session — already part
-      // of the dashboard's BaseSessionState shape (#4879 parity) and cleared
-      // by `handleClaudeReady` exactly as on the app. The info toast stays
-      // dashboard-specific (#4878).
-      const stoppedPatch = sharedSessionStopped(msg, get().activeSessionId);
-      const stoppedTarget = stoppedPatch.sessionId;
-      if (stoppedTarget && get().sessionStates[stoppedTarget]) {
-        updateSession(stoppedTarget, () => stoppedPatch.patch);
-      }
-      const stoppedCode = stoppedPatch.patch.stoppedCode as number | null;
-      const stoppedMessage = stoppedCode != null && stoppedCode !== 0
-        ? `Session stopped. (exit ${stoppedCode})`
-        : 'Session stopped.';
-      get().addInfoNotification(stoppedMessage);
-      break;
-    }
+    // session_stopped — migrated to the shared dispatch table (#5618 Batch 3;
+    // handled by runDispatch before this switch). Sets stoppedAt/stoppedCode on
+    // the target session (shared with the app) and fires the dashboard-specific
+    // info toast (#4878) via the `addInfoNotification` adapter hook.
 
     // --- History replay ---
 
@@ -4821,43 +4795,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'session_restore_failed': {
-      // Server couldn't restart a persisted session (e.g. missing API key).
-      // History is preserved on disk; surface this visibly instead of making
-      // the saved session look like it silently disappeared after restart.
-      const restoreFailed = sharedSessionRestoreFailed(msg);
-      get().addServerError(restoreFailed.systemMessage.content);
-      // eslint-disable-next-line no-console
-      console.warn('[session_restore_failed]', {
-        sessionId: restoreFailed.sessionId,
-        name: restoreFailed.name,
-        provider: restoreFailed.provider,
-        cwd: restoreFailed.cwd,
-        model: restoreFailed.model,
-        permissionMode: restoreFailed.permissionMode,
-        errorCode: restoreFailed.errorCode,
-        errorMessage: restoreFailed.errorMessage,
-        historyLength: restoreFailed.historyLength,
-      });
-      break;
-    }
-
-    case 'session_persist_failed': {
-      // #5714/#5701: a session-list mutation (create/rename/destroy) could not be
-      // flushed to disk and will be lost on restart. The write is atomic so
-      // on-disk state isn't corrupted — this is purely the "your change wasn't
-      // saved" signal, surfaced as an error banner so the user isn't left
-      // silently believing it persisted.
-      const persistSid = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-      const persistName = typeof msg.name === 'string' ? msg.name : null;
-      const label = persistName ? `"${persistName}"` : (persistSid ? `session ${persistSid}` : 'your session change');
-      get().addServerError(
-        `Couldn't save ${label} — the change may be lost on restart. Check the daemon's disk space and write permissions.`,
-      );
-      // eslint-disable-next-line no-console
-      console.warn('[session_persist_failed]', { sessionId: persistSid, name: persistName });
-      break;
-    }
+    // session_restore_failed / session_persist_failed — migrated to the shared
+    // dispatch table (#5618 Batch 3; handled by runDispatch before this switch).
+    // Both surface the error via the `addServerError` adapter hook (the dashboard
+    // forwards the message to its connection-store addServerError banner); the
+    // shared handlers own the message construction + console.warn.
 
     // mcp_servers — migrated to the shared dispatch table (#5556 slice 2)
 

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -59,6 +59,21 @@ export interface AdapterResult {
    * array on the dashboard side IS the contract for those cases.
    */
   callbacks: Array<{ name: string; payload: unknown }>
+  /**
+   * Errors surfaced via the `addServerError` hook (#5618 Batch 3), in order.
+   * BOTH clients record these — the contract asserts they receive the SAME
+   * structured error for `session_restore_failed` / `session_persist_failed`
+   * (each client renders it differently below the hook, which is out of scope).
+   */
+  serverErrors: Array<{ message: string; category?: string; sessionId?: string; recoverable?: boolean }>
+  /**
+   * Info toasts surfaced via the `addInfoNotification` hook (#5618 Batch 3), in
+   * order. Only the DASHBOARD records these — the app omits the hook
+   * (`session_stopped` shows no toast on mobile, #4879). An empty array on the
+   * app side IS the contract for that case; the shared session patch is asserted
+   * separately.
+   */
+  infoNotifications: string[]
 }
 
 /** Which client an adapter models — drives the `updateSession` divergence. */
@@ -97,6 +112,8 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   const flat: Record<string, unknown> = {}
   const added: ChatMessage[] = []
   const callbacks: Array<{ name: string; payload: unknown }> = []
+  const serverErrors: AdapterResult['serverErrors'] = []
+  const infoNotifications: string[] = []
 
   // Reproduce each client's real `updateSession`. Both share the
   // "no-op on missing session / empty patch" guard; they diverge only in the
@@ -137,6 +154,14 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     // store; the dashboard does not). Modelled as a no-op here, exactly like the
     // app's `activityState` derivation above — no fixture asserts on it.
     pushSessionNotification: () => {},
+    // #5618 Batch 3 — BOTH clients surface recoverable errors via `addServerError`
+    // (the error-sink for session_restore_failed / session_persist_failed). Record
+    // the (message + structured opts) so the contract asserts both clients receive
+    // the SAME error. How each renders it (app structured ServerError + ring +
+    // notification store; dashboard string banner) is below the hook, out of scope.
+    addServerError: (message, opts) => {
+      serverErrors.push({ message, ...(opts ?? {}) })
+    },
     // #5653 — only the APP opts its imperative-callback registry into the table.
     // Model it as "a callback IS registered for every channel" so the contract
     // can observe the invocation + payload. The DASHBOARD omits `getCallback`
@@ -175,12 +200,19 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
           syncSecondaryInventory: () => {},
         }
       : {}),
+    // #5618 Batch 3 — only the DASHBOARD shows the session_stopped info toast
+    // (#4878); the app OMITS `addInfoNotification` (#4879). Record it on the
+    // dashboard side so a unit/contract assertion can observe the divergence;
+    // the app's empty array IS the contract for that case.
+    ...(kind === 'dashboard'
+      ? { addInfoNotification: (message: string) => infoNotifications.push(message) }
+      : {}),
   }
 
   return {
     adapter,
     get result(): AdapterResult {
-      return { sessions, flat, added, callbacks }
+      return { sessions, flat, added, callbacks, serverErrors, infoNotifications }
     },
     setActive: (id: string | null) => {
       activeSessionId = id

--- a/packages/store-core/src/contract-fixtures/contract.test.ts
+++ b/packages/store-core/src/contract-fixtures/contract.test.ts
@@ -64,9 +64,11 @@ function assertField(actual: unknown, expected: unknown, label: string) {
 
 function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: ContractFixture) {
   if (exp.noop) {
-    // No flat writes and no added messages…
+    // No flat writes, no added messages, and no surfaced error / info toast…
     expect(Object.keys(result.flat), `${fx.name}: expected no flat writes`).toHaveLength(0)
     expect(result.added, `${fx.name}: expected no addMessage`).toHaveLength(0)
+    expect(result.serverErrors, `${fx.name}: expected no addServerError`).toHaveLength(0)
+    expect(result.infoNotifications, `${fx.name}: expected no addInfoNotification`).toHaveLength(0)
     // …and every seeded session is untouched beyond its shell: it must carry
     // only the keys it was seeded with (the `{ sessionId, messages }` shell plus
     // the fixture's own `init.sessions[id]` keys). A handler that wrote a NEW
@@ -107,6 +109,15 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
         cb.payload,
       )
     })
+  }
+  if (exp.serverErrors) {
+    expect(result.serverErrors.length, `${fx.name}: serverError count`).toBe(exp.serverErrors.length)
+    exp.serverErrors.forEach((e, i) => {
+      expect(result.serverErrors[i], `${fx.name}: serverErrors[${i}]`).toMatchObject(e)
+    })
+  }
+  if (exp.infoNotifications) {
+    expect(result.infoNotifications, `${fx.name}: infoNotifications`).toEqual(exp.infoNotifications)
   }
 }
 

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -103,10 +103,10 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'server_status',
   'session_error',
   'session_list',
-  'session_persist_failed',
-  'session_restore_failed',
+  // session_persist_failed / session_restore_failed / session_stopped — migrated
+  // to the shared dispatch table (#5618 Batch 3); now have DISPATCH_FIXTURES
+  // entries, so they leave the both-clients-switch universe.
   'session_role',
-  'session_stopped',
   'session_switched',
   'session_timeout',
   'session_warning',

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -82,6 +82,18 @@ export interface FixtureExpectation {
    * file-ops / git case, which DECLINES). Omit the slice to "don't care".
    */
   callbacks?: Array<{ name: string; payload: Record<string, unknown> }>
+  /**
+   * Expected `addServerError` invocations (#5618 Batch 3), in order. Each entry
+   * is a partial deep-equal of the structured error. An empty array asserts NO
+   * error was surfaced. Omit the slice to "don't care".
+   */
+  serverErrors?: Array<{ message?: string; category?: string; sessionId?: string; recoverable?: boolean }>
+  /**
+   * Expected `addInfoNotification` invocations (#5618 Batch 3), in order. Only
+   * the dashboard records these; the app's array is always empty. Omit to "don't
+   * care".
+   */
+  infoNotifications?: string[]
   /** When true, assert NO mutation happened at all (state is untouched). */
   noop?: boolean
 }
@@ -402,6 +414,60 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     type: 'provider_list',
     message: { type: 'provider_list' },
     expect: { noop: true },
+  },
+
+  // 4f. error-sink / session-status cases (#5618 Batch 3). restore/persist
+  // surface a recoverable error via the shared `addServerError` hook — both
+  // clients receive the SAME structured error (each renders it differently below
+  // the hook). session_stopped sets a shared session patch + a dashboard-only
+  // info toast (the app shows none).
+  {
+    name: 'session_restore_failed surfaces a recoverable session error in both clients',
+    type: 'session_restore_failed',
+    message: {
+      type: 'session_restore_failed',
+      sessionId: 's1',
+      name: 'My Session',
+      errorMessage: 'missing API key',
+    },
+    expect: {
+      serverErrors: [
+        { message: 'Failed to restore My Session: missing API key', category: 'session', sessionId: 's1', recoverable: true },
+      ],
+    },
+  },
+  {
+    name: 'session_persist_failed surfaces a recoverable "not saved" error in both clients',
+    type: 'session_persist_failed',
+    message: { type: 'session_persist_failed', sessionId: 's1', name: 'My Session' },
+    expect: {
+      serverErrors: [
+        {
+          message: 'Couldn\'t save "My Session" — the change may be lost on restart. Check the daemon\'s disk space and write permissions.',
+          category: 'session',
+          sessionId: 's1',
+          recoverable: true,
+        },
+      ],
+    },
+  },
+  {
+    name: 'session_stopped sets stoppedCode on the target session (shared patch; toast is dashboard-only)',
+    type: 'session_stopped',
+    init: { sessions: { s1: {} } },
+    message: { type: 'session_stopped', sessionId: 's1', code: 143 },
+    // stoppedAt is Date.now() (differs per client run) so it is not asserted;
+    // stoppedCode is deterministic. The dashboard's info toast is out of the
+    // shared contract (covered by dispatch-table.test.ts units), so this asserts
+    // only the shared session patch — identical in both clients.
+    expect: { sessions: { s1: { stoppedCode: 143 } } },
+  },
+  {
+    name: 'session_stopped with a clean exit (code 0) sets stoppedCode 0',
+    type: 'session_stopped',
+    init: { sessions: { s1: {} } },
+    message: { type: 'session_stopped', sessionId: 's1', code: 0 },
+    expect: { sessions: { s1: { stoppedCode: 0 } } },
   },
 
   // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -55,6 +55,20 @@ function makeAdapter(init?: {
    * verbatim behaviour (no secondary-store mirror; provider list written as-is).
    */
   inventoryHooks?: boolean
+  /**
+   * When true, the adapter wires `addServerError` (records into `serverErrors`) —
+   * the error-sink for session_restore_failed / session_persist_failed (#5618
+   * Batch 3). When omitted, the hook is absent, so those cases DECLINE
+   * (`runDispatch` returns false), matching a client that hasn't opted in.
+   */
+  errorSink?: boolean
+  /**
+   * When true, the adapter wires `addInfoNotification` (records into
+   * `infoNotifications`) — the dashboard's session_stopped info toast. When
+   * omitted, the app's behaviour (no toast); session_stopped still OWNS the
+   * message and applies its session patch either way.
+   */
+  infoToast?: boolean
 }) {
   const sessions: Record<string, FakeSession> = init?.sessions ?? {}
   let activeSessionId = init?.activeSessionId ?? null
@@ -63,6 +77,8 @@ function makeAdapter(init?: {
   const addedMessages: ChatMessage[] = []
   const notifications: Array<{ sessionId: string; eventType: string; message: string }> = []
   const inventorySyncs: Array<{ kind: string; list: unknown[] }> = []
+  const serverErrors: Array<{ message: string; category?: string; sessionId?: string; recoverable?: boolean }> = []
+  const infoNotifications: string[] = []
 
   const adapter: ClientStoreAdapter<FakeSession> = {
     getActiveSessionId: () => activeSessionId,
@@ -93,6 +109,12 @@ function makeAdapter(init?: {
           mapProviderList: (providers) => ['__mapped__', ...providers],
         }
       : {}),
+    ...(init?.errorSink
+      ? { addServerError: (message, opts) => serverErrors.push({ message, ...(opts ?? {}) }) }
+      : {}),
+    ...(init?.infoToast
+      ? { addInfoNotification: (message: string) => infoNotifications.push(message) }
+      : {}),
   }
 
   return {
@@ -102,6 +124,8 @@ function makeAdapter(init?: {
     addedMessages,
     notifications,
     inventorySyncs,
+    serverErrors,
+    infoNotifications,
     setActive: (id: string | null) => {
       activeSessionId = id
     },
@@ -445,6 +469,76 @@ describe('shared dispatch table', () => {
       const env = makeAdapter()
       expect(dispatch(env, { type: 'provider_list' })).toBe(true)
       expect(env.flat.availableProviders).toBeUndefined()
+    })
+  })
+
+  describe('session_restore_failed / session_persist_failed / session_stopped (#5618 Batch 3)', () => {
+    it('session_restore_failed surfaces a structured error when addServerError is wired', () => {
+      const env = makeAdapter({ errorSink: true })
+      const handled = dispatch(env, {
+        type: 'session_restore_failed',
+        sessionId: 's1',
+        name: 'My Session',
+        errorMessage: 'missing API key',
+      })
+      expect(handled).toBe(true)
+      expect(env.serverErrors).toEqual([
+        {
+          message: 'Failed to restore My Session: missing API key',
+          category: 'session',
+          sessionId: 's1',
+          recoverable: true,
+        },
+      ])
+    })
+
+    it('session_restore_failed DECLINES (runDispatch false) when addServerError is absent', () => {
+      const env = makeAdapter() // no error-sink hook (a client that hasn't opted in)
+      expect(dispatch(env, { type: 'session_restore_failed', sessionId: 's1' })).toBe(false)
+      expect(env.serverErrors).toEqual([])
+    })
+
+    it('session_persist_failed surfaces the "not saved" error when addServerError is wired', () => {
+      const env = makeAdapter({ errorSink: true })
+      const handled = dispatch(env, { type: 'session_persist_failed', sessionId: 's1', name: 'My Session' })
+      expect(handled).toBe(true)
+      expect(env.serverErrors).toEqual([
+        {
+          message:
+            'Couldn\'t save "My Session" — the change may be lost on restart. Check the daemon\'s disk space and write permissions.',
+          category: 'session',
+          sessionId: 's1',
+          recoverable: true,
+        },
+      ])
+    })
+
+    it('session_persist_failed DECLINES when addServerError is absent', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'session_persist_failed', sessionId: 's1' })).toBe(false)
+      expect(env.serverErrors).toEqual([])
+    })
+
+    it('session_stopped sets stoppedCode and fires the info toast (dashboard)', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } }, infoToast: true })
+      const handled = dispatch(env, { type: 'session_stopped', sessionId: 's1', code: 143 })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.stoppedCode).toBe(143)
+      expect(env.infoNotifications).toEqual(['Session stopped. (exit 143)'])
+    })
+
+    it('session_stopped applies the patch with NO toast when addInfoNotification is absent (app)', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } } })
+      const handled = dispatch(env, { type: 'session_stopped', sessionId: 's1', code: 0 })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.stoppedCode).toBe(0)
+      expect(env.infoNotifications).toEqual([])
+    })
+
+    it('session_stopped uses a bare toast message for a clean (code 0) exit', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } }, infoToast: true })
+      dispatch(env, { type: 'session_stopped', sessionId: 's1', code: 0 })
+      expect(env.infoNotifications).toEqual(['Session stopped.'])
     })
   })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -79,6 +79,10 @@ import {
   handleSlashCommands,
   handleAgentList,
   handleProviderList,
+  // --- error-sink / session-status cases (#5618 Batch 3) ---
+  handleSessionStopped,
+  handleSessionRestoreFailed,
+  handleSessionPersistFailed,
   handleSessionUsage,
   handleSessionContext,
   handleModelChangedPatch,
@@ -281,6 +285,41 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * robustness behaviour.
    */
   mapProviderList?(providers: unknown[]): unknown[]
+  /**
+   * Surface a recoverable server-side error to the user (#5618 Batch 3). Used by
+   * the `session_restore_failed` / `session_persist_failed` cases, whose ONLY
+   * effect is to surface the error — there is no shared store mutation. Each
+   * client renders it its own way: the app builds a structured `ServerError`
+   * (ring-capped flat `serverErrors` list + mobile `useNotificationStore`); the
+   * dashboard calls its connection-store `addServerError(message)` (string
+   * banner, which builds its own envelope). The shared handler passes the
+   * already-constructed human-readable `message` plus structured metadata; a
+   * client uses whatever subset it needs (the dashboard ignores `opts`).
+   *
+   * OPTIONAL — and DECLINE-capable: when a client's adapter does NOT supply it,
+   * the restore/persist dispatch handlers return `false` so {@link runDispatch}
+   * falls through to that client's own switch (matching the
+   * imperative-callback / `getCallback` pattern — the error-sink IS the whole
+   * effect, so a client that hasn't wired it must keep handling the case
+   * locally). Both real clients supply it, so both OWN these cases.
+   */
+  addServerError?(
+    message: string,
+    opts?: { category?: string; sessionId?: string; recoverable?: boolean },
+  ): void
+  /**
+   * Surface a low-priority INFO notification (#5618 Batch 3). Used by
+   * `session_stopped` for the dashboard's "Session stopped." info toast
+   * (`addInfoNotification`). The app deliberately shows NO toast here (#4879 —
+   * the inline session banner carries the signal), so it OMITS this hook.
+   *
+   * OPTIONAL and out-of-contract: unlike `addServerError`, `session_stopped`
+   * ALSO performs a shared session patch (`stoppedAt`/`stoppedCode`), so its
+   * handler always OWNS the message and never declines — it just skips the toast
+   * when the hook is absent. This is a platform-specific side-effect like
+   * {@link ClientStoreAdapter.pushSessionNotification}.
+   */
+  addInfoNotification?(message: string): void
 }
 
 /**
@@ -422,6 +461,24 @@ export interface DispatchMessageMap {
   provider_list: {
     type: 'provider_list'
     providers?: unknown[]
+  }
+  // --- error-sink / session-status cases (#5618 Batch 3) ---
+  // The parsers read the raw fields; the map only needs `type` (+ the optional
+  // wire fields the handlers narrow themselves).
+  session_stopped: {
+    type: 'session_stopped'
+    sessionId?: string
+    code?: number
+  }
+  session_restore_failed: {
+    type: 'session_restore_failed'
+    sessionId?: string
+    name?: string
+  }
+  session_persist_failed: {
+    type: 'session_persist_failed'
+    sessionId?: string
+    name?: string
   }
   session_usage: {
     type: 'session_usage'
@@ -946,6 +1003,80 @@ function dispatchProviderList<S extends DispatchSessionBase>(
   adapter.setState({ availableProviders: providers } as Record<string, unknown[]>)
 }
 
+// ---------------------------------------------------------------------------
+// Error-sink / session-status cases (#5618 Batch 3)
+//
+// session_restore_failed / session_persist_failed surface a recoverable error
+// via the `addServerError` hook (their ONLY effect — no shared store mutation),
+// so they DECLINE when the adapter has no `addServerError` (matching the
+// file-ops / git `getCallback` pattern). session_stopped performs a shared
+// session patch (`stoppedAt`/`stoppedCode`) and ALSO fires the dashboard's
+// optional info toast, so it always OWNS the message.
+// ---------------------------------------------------------------------------
+
+/** `session_restore_failed` — surface the failure (app structured / dashboard banner). */
+function dispatchSessionRestoreFailed<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_restore_failed'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  if (!adapter.addServerError) return false
+  const r = handleSessionRestoreFailed(msg as Record<string, unknown>)
+  adapter.addServerError(r.systemMessage.content, {
+    category: 'session',
+    recoverable: true,
+    ...(r.sessionId ? { sessionId: r.sessionId } : {}),
+  })
+  // eslint-disable-next-line no-console
+  console.warn('[session_restore_failed]', {
+    sessionId: r.sessionId,
+    name: r.name,
+    provider: r.provider,
+    cwd: r.cwd,
+    model: r.model,
+    permissionMode: r.permissionMode,
+    errorCode: r.errorCode,
+    errorMessage: r.errorMessage,
+    historyLength: r.historyLength,
+  })
+}
+
+/** `session_persist_failed` — surface the "change not saved" error (#5714/#5701). */
+function dispatchSessionPersistFailed<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_persist_failed'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  if (!adapter.addServerError) return false
+  const r = handleSessionPersistFailed(msg as Record<string, unknown>)
+  adapter.addServerError(r.message, {
+    category: 'session',
+    recoverable: true,
+    ...(r.sessionId ? { sessionId: r.sessionId } : {}),
+  })
+  // eslint-disable-next-line no-console
+  console.warn('[session_persist_failed]', { sessionId: r.sessionId, name: r.name })
+}
+
+/** `session_stopped` — set stoppedAt/stoppedCode + optional dashboard info toast. */
+function dispatchSessionStopped<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_stopped'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId, patch } = handleSessionStopped(
+    msg as Record<string, unknown>,
+    adapter.getActiveSessionId(),
+  )
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => patch as Partial<S>)
+  }
+  // Dashboard-only info toast (#4878). The app omits the hook (#4879 — the
+  // inline session banner already carries the signal). Computed identically to
+  // the dashboard's prior inline message; fires regardless of session existence,
+  // matching the dashboard's prior unconditional `addInfoNotification`.
+  const code = (patch as { stoppedCode?: number | null }).stoppedCode
+  const message = code != null && code !== 0 ? `Session stopped. (exit ${code})` : 'Session stopped.'
+  adapter.addInfoNotification?.(message)
+}
+
 /**
  * `notification_prefs` — validate + store the notification-prefs snapshot.
  * Slice-2 RECONCILE: both clients now share `handleNotificationPrefs`. A failed
@@ -1156,6 +1287,10 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     slash_commands: dispatchSlashCommands,
     agent_list: dispatchAgentList,
     provider_list: dispatchProviderList,
+    // --- error-sink / session-status cases (#5618 Batch 3) ---
+    session_stopped: dispatchSessionStopped,
+    session_restore_failed: dispatchSessionRestoreFailed,
+    session_persist_failed: dispatchSessionPersistFailed,
     session_usage: sessionPatchDispatcher<S>(handleSessionUsage),
     session_context: sessionPatchDispatcher<S>(handleSessionContext),
     model_changed: sessionPatchDispatcher<S>(handleModelChangedPatch),
@@ -1226,6 +1361,10 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'slash_commands',
   'agent_list',
   'provider_list',
+  // --- error-sink / session-status cases (#5618 Batch 3) ---
+  'session_stopped',
+  'session_restore_failed',
+  'session_persist_failed',
   'session_usage',
   'session_context',
   'session_cost_threshold_crossed',

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -55,6 +55,7 @@ import type {
   PendingBackgroundShell,
   QueuedSessionMessage,
   SessionIntervention,
+  ServerErrorCategory,
   WebTask,
 } from './types'
 import { nextMessageId } from './utils'
@@ -305,7 +306,7 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    */
   addServerError?(
     message: string,
-    opts?: { category?: string; sessionId?: string; recoverable?: boolean },
+    opts?: { category?: ServerErrorCategory; sessionId?: string; recoverable?: boolean },
   ): void
   /**
    * Surface a low-priority INFO notification (#5618 Batch 3). Used by

--- a/packages/store-core/src/handlers/session-status.ts
+++ b/packages/store-core/src/handlers/session-status.ts
@@ -144,6 +144,39 @@ export function handleSessionRestoreFailed(
 }
 
 // ---------------------------------------------------------------------------
+// session_persist_failed
+// ---------------------------------------------------------------------------
+
+/** Parsed payload + user-facing message for a `session_persist_failed` message. */
+export interface SessionPersistFailedPayload {
+  sessionId: string | null
+  name: string | null
+  /** Human-readable, recoverable error message the caller surfaces to the user. */
+  message: string
+}
+
+/**
+ * Parse a `session_persist_failed` message (#5714/#5701).
+ *
+ * A session-list mutation (create/rename/destroy) could not be flushed to disk
+ * and will be lost on restart. The write is atomic so on-disk state isn't
+ * corrupted — this is purely the "your change wasn't saved" signal. Both clients
+ * built the identical `label` + message string inline; this centralises it.
+ */
+export function handleSessionPersistFailed(
+  msg: Record<string, unknown>,
+): SessionPersistFailedPayload {
+  const sessionId = parseRawStringField(msg, 'sessionId')
+  const name = parseRawStringField(msg, 'name')
+  const label = name ? `"${name}"` : sessionId ? `session ${sessionId}` : 'your session change'
+  return {
+    sessionId,
+    name,
+    message: `Couldn't save ${label} — the change may be lost on restart. Check the daemon's disk space and write permissions.`,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // session_warning
 // ---------------------------------------------------------------------------
 

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -583,9 +583,14 @@ export interface ServerErrorAction {
  * message. Callers slice an array of these into their `serverErrors` state
  * (typically capped at the most recent 10 entries).
  */
+/** Closed union of `ServerError` categories (#5618 Batch 3 — shared by the
+ * dispatch-table `addServerError` hook so callers can't pass an unsupported
+ * category that would break UI styling/filters). */
+export type ServerErrorCategory = 'tunnel' | 'session' | 'permission' | 'general';
+
 export interface ServerError {
   id: string;
-  category: 'tunnel' | 'session' | 'permission' | 'general';
+  category: ServerErrorCategory;
   message: string;
   recoverable: boolean;
   timestamp: number;


### PR DESCRIPTION
## Summary

Batch 3 of the dispatch-table migration (epic #5618; Batches 1–2 = #6207 / #6209). Migrates the three session-status error/notification cases — `session_restore_failed`, `session_persist_failed`, `session_stopped` — out of both clients' hand-copied switches into the shared store-core dispatch table.

Two new **optional, no-op-defaulted** adapter hooks express the per-client divergence:

| Hook | App | Dashboard |
|------|-----|-----------|
| `addServerError(message, opts)` | builds a structured `ServerError` → ring-capped flat `serverErrors` + mobile notification store | forwards the message to its connection-store `addServerError` banner |
| `addInfoNotification(message)` | **omitted** (#4879 — no toast; the inline strip carries the signal) | the `session_stopped` info toast (#4878) |

- **`session_restore_failed` / `session_persist_failed`** — the error-sink call is their *only* effect, so they are **DECLINE-capable**: a client whose adapter lacks `addServerError` falls through to its own switch (the established `getCallback` pattern). Both clients supply it, so both own these cases. The contract asserts **both clients receive the same structured error**; how each renders it is below the hook.
- **`session_stopped`** — performs a shared session patch (`stoppedAt`/`stoppedCode`) regardless, and fires the dashboard's optional info toast. Always owns the message.

Adds the shared `handleSessionPersistFailed` (the message both clients built inline); the shared handlers now also own the `console.warn`.

**`session_timeout` is deferred** — it needs platform `alert` + the active-session→flat-mirror sync + a `switchSession` accessor + `clearPersistedSession` GC, which overlap Batch 4's `switchSession` primitive. Tracked on #5618.

## Verification
- store-core: `npm run typecheck` + full vitest **1749 ✓** (contract / dispatch-table / coverage-lint / protocol-type-coverage)
- dashboard: vitest **4032 ✓** (incl. the migrated `session_stopped`/`restore`/`persist` dispatch functional tests) + typecheck
- protocol: **340 ✓** (handler-coverage credits the migrated types via `DISPATCH_TABLE_TYPES`)
- app: typecheck ✓ + affected test files ✓ (full app jest runs in CI)

4 new `DISPATCH_FIXTURES`, 7 new `dispatch-table.test.ts` units (incl. the decline-when-absent paths), the contract harness records `addServerError`/`addInfoNotification`, and the app's `session_stopped` source-grep test was updated for the migration.

Closes part of #5618.