### PR TITLE
refactor(store-core): migrate primary_changed/session_role/client_focus_changed onto the shared dispatch table (#5618 Batch 4)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -56,9 +56,6 @@ import {
   handleSessionError as sharedSessionError,
   handleClientJoined as sharedClientJoined,
   handleClientLeft as sharedClientLeft,
-  handlePrimaryChanged as sharedPrimaryChanged,
-  handleSessionRole as sharedSessionRole,
-  handleClientFocusChanged as sharedClientFocusChanged,
   // conversation_id migrated to the shared dispatch table (#5556)
   handleConversationsList as sharedConversationsList,
   handleHistoryReplayStart as sharedHistoryReplayStart,
@@ -1224,6 +1221,14 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // #5618 Batch 3 — the app deliberately shows NO info toast for session_stopped
   // (#4879 — the inline session banner carries the signal), so `addInfoNotification`
   // is OMITTED. The dashboard supplies it (its #4878 info toast).
+  // #5618 Batch 4 — multi-client accessors for primary_changed / session_role /
+  // client_focus_changed. The app reads presence state from its dedicated
+  // useMultiClientStore (the dashboard reads flat state); these accessors hide
+  // that divergence so the three cases are fully shared.
+  getMyClientId: () => useMultiClientStore.getState().myClientId,
+  getFollowMode: () => useMultiClientStore.getState().followMode,
+  switchSession: (sessionId) => getStore().getState().switchSession(sessionId),
+  setPrimaryClientId: (clientId) => useMultiClientStore.getState().setPrimaryClientId(clientId),
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -3116,49 +3121,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'primary_changed': {
-      const { sessionId: primarySessionId, primaryClientId } = sharedPrimaryChanged(msg);
-      useMultiClientStore.getState().setPrimaryClientId(primaryClientId);
-      if (primarySessionId && get().sessionStates[primarySessionId]) {
-        updateSession(primarySessionId, () => ({
-          primaryClientId,
-        }));
-      } else if (!primarySessionId || primarySessionId === 'default') {
-        set({ primaryClientId });
-      }
-      break;
-    }
-
-    case 'session_role': {
-      // #5589 / #5281 — explicit primary-ownership. The server names the
-      // primary; we derive THIS client's role by comparing it to our own id
-      // (learned from auth_ok, canonical source: useMultiClientStore.myClientId).
-      // Stored per-session on `sessionRole` so the SessionScreen can surface an
-      // observer banner / claim affordance. We also mirror `primaryClientId`
-      // (the raw pointer) so the existing presence UI stays in sync without
-      // depending on a separate legacy `primary_changed` arriving.
-      const myClientId = useMultiClientStore.getState().myClientId;
-      const role = sharedSessionRole(msg, myClientId);
-      if (role.sessionId && get().sessionStates[role.sessionId]) {
-        updateSession(role.sessionId, () => ({
-          sessionRole: role.role,
-          primaryClientId: role.primaryClientId,
-        }));
-      }
-      break;
-    }
-
-    case 'client_focus_changed': {
-      const focus = sharedClientFocusChanged(msg);
-      if (!focus) break;
-      // Auto-switch if follow mode is on, event is from another client, target session exists locally, and not already on it
-      const mcState = useMultiClientStore.getState();
-      const { activeSessionId, sessionStates } = get();
-      if (mcState.followMode && focus.clientId !== mcState.myClientId && focus.sessionId !== activeSessionId && sessionStates[focus.sessionId]) {
-        get().switchSession(focus.sessionId);
-      }
-      break;
-    }
+    // primary_changed / session_role / client_focus_changed — migrated to the
+    // shared dispatch table (#5618 Batch 4; handled by runDispatch before this
+    // switch). The app's multi-client presence state (useMultiClientStore) is
+    // reached through the getMyClientId / getFollowMode / switchSession /
+    // setPrimaryClientId adapter hooks, so the three cases are now fully shared.
 
     // directory_listing / file_listing / file_content / write_file_result /
     // diff_result / git_status_result / git_branches_result / git_stage_result /

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -49,9 +49,6 @@ import {
   handleLogEntry as sharedLogEntry,
   handleClientJoined as sharedClientJoined,
   handleClientLeft as sharedClientLeft,
-  handlePrimaryChanged as sharedPrimaryChanged,
-  handleSessionRole as sharedSessionRole,
-  handleClientFocusChanged as sharedClientFocusChanged,
   // conversation_id migrated to the shared dispatch table (#5556)
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
@@ -1042,6 +1039,13 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   addServerError: (message) => getStore().getState().addServerError(message),
   // #5618 Batch 3 — session_stopped's info toast (#4878). The app omits this hook.
   addInfoNotification: (message) => getStore().getState().addInfoNotification(message),
+  // #5618 Batch 4 — multi-client accessors for primary_changed / session_role /
+  // client_focus_changed. The dashboard keeps presence state flat (the app uses
+  // a dedicated useMultiClientStore); these accessors hide that divergence. The
+  // dashboard has no secondary presence store, so it OMITS setPrimaryClientId.
+  getMyClientId: () => getStore().getState().myClientId,
+  getFollowMode: () => getStore().getState().followMode,
+  switchSession: (sessionId) => getStore().getState().switchSession(sessionId),
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -4540,48 +4544,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'primary_changed': {
-      const { sessionId: primarySessionId, primaryClientId } = sharedPrimaryChanged(msg);
-      if (primarySessionId && get().sessionStates[primarySessionId]) {
-        updateSession(primarySessionId, () => ({
-          primaryClientId,
-        }));
-      } else if (!primarySessionId || primarySessionId === 'default') {
-        set({ primaryClientId });
-      }
-      break;
-    }
-
-    case 'session_role': {
-      // #5589 / #5281 — explicit primary-ownership. Derive THIS client's role
-      // by comparing the server-named primary to our own id (from auth_ok,
-      // stored flat as `myClientId`). Stored per-session on `sessionRole` to
-      // drive the ViewersIndicator's observer state + claim affordance, and we
-      // mirror `primaryClientId` so presence stays in sync without depending on
-      // a separate legacy `primary_changed`. Kept platform-local (not in the
-      // shared dispatch table) for the same reason `primary_changed` is — the
-      // app's dedicated multi-client store vs the dashboard's flat+per-session
-      // slots diverge (see dispatch-table.ts divergent-cases note).
-      const role = sharedSessionRole(msg, get().myClientId);
-      if (role.sessionId && get().sessionStates[role.sessionId]) {
-        updateSession(role.sessionId, () => ({
-          sessionRole: role.role,
-          primaryClientId: role.primaryClientId,
-        }));
-      }
-      break;
-    }
-
-    case 'client_focus_changed': {
-      const focus = sharedClientFocusChanged(msg);
-      if (!focus) break;
-      // Auto-switch if follow mode is on, event is from another client, target session exists locally, and not already on it
-      const { followMode, myClientId, activeSessionId, sessionStates } = get();
-      if (followMode && focus.clientId !== myClientId && focus.sessionId !== activeSessionId && sessionStates[focus.sessionId]) {
-        get().switchSession(focus.sessionId);
-      }
-      break;
-    }
+    // primary_changed / session_role / client_focus_changed — migrated to the
+    // shared dispatch table (#5618 Batch 4; handled by runDispatch before this
+    // switch). The dashboard's flat presence state (myClientId / followMode /
+    // switchSession) is reached through the getMyClientId / getFollowMode /
+    // switchSession adapter hooks, so the three cases are now fully shared. The
+    // dashboard omits setPrimaryClientId (no secondary presence store).
 
     case 'directory_listing': {
       const cb = get()._directoryListingCallback;

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -74,6 +74,13 @@ export interface AdapterResult {
    * separately.
    */
   infoNotifications: string[]
+  /**
+   * Sessions switched to via `switchSession` (#5618 Batch 4), in order — the
+   * client_focus_changed follow-mode auto-switch. BOTH clients call it
+   * identically (the accessor hides where presence state lives), so the contract
+   * asserts they switch to the same session(s).
+   */
+  switchedSessions: string[]
 }
 
 /** Which client an adapter models — drives the `updateSession` divergence. */
@@ -109,11 +116,14 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   }
   let activeSessionId = init?.activeSessionId ?? null
   let sessionList: SessionInfo[] = init?.sessionList ?? []
+  const myClientId = init?.myClientId ?? null
+  const followMode = init?.followMode ?? false
   const flat: Record<string, unknown> = {}
   const added: ChatMessage[] = []
   const callbacks: Array<{ name: string; payload: unknown }> = []
   const serverErrors: AdapterResult['serverErrors'] = []
   const infoNotifications: string[] = []
+  const switchedSessions: string[] = []
 
   // Reproduce each client's real `updateSession`. Both share the
   // "no-op on missing session / empty patch" guard; they diverge only in the
@@ -162,6 +172,13 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     addServerError: (message, opts) => {
       serverErrors.push({ message, ...(opts ?? {}) })
     },
+    // #5618 Batch 4 — multi-client accessors. BOTH clients supply them (the
+    // accessor hides where presence state lives — app multi-client store vs
+    // dashboard flat). `switchSession` is recorded so the client_focus_changed
+    // contract asserts both clients auto-switch to the same session.
+    getMyClientId: () => myClientId,
+    getFollowMode: () => followMode,
+    switchSession: (sessionId) => switchedSessions.push(sessionId),
     // #5653 — only the APP opts its imperative-callback registry into the table.
     // Model it as "a callback IS registered for every channel" so the contract
     // can observe the invocation + payload. The DASHBOARD omits `getCallback`
@@ -198,6 +215,12 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
           // a no-op here (no fixture asserts on it — the dispatch-table unit tests
           // cover the hook invocation directly).
           syncSecondaryInventory: () => {},
+          // #5618 Batch 4 — the app mirrors the primary pointer into its
+          // secondary multi-client store. Out of the shared contract (like
+          // pushSessionNotification); modelled as a no-op (the shared
+          // session/flat primaryClientId write IS asserted; the dispatch-table
+          // unit tests cover the hook invocation). The dashboard omits it.
+          setPrimaryClientId: () => {},
         }
       : {}),
     // #5618 Batch 3 — only the DASHBOARD shows the session_stopped info toast
@@ -212,7 +235,7 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   return {
     adapter,
     get result(): AdapterResult {
-      return { sessions, flat, added, callbacks, serverErrors, infoNotifications }
+      return { sessions, flat, added, callbacks, serverErrors, infoNotifications, switchedSessions }
     },
     setActive: (id: string | null) => {
       activeSessionId = id

--- a/packages/store-core/src/contract-fixtures/contract.test.ts
+++ b/packages/store-core/src/contract-fixtures/contract.test.ts
@@ -69,6 +69,7 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
     expect(result.added, `${fx.name}: expected no addMessage`).toHaveLength(0)
     expect(result.serverErrors, `${fx.name}: expected no addServerError`).toHaveLength(0)
     expect(result.infoNotifications, `${fx.name}: expected no addInfoNotification`).toHaveLength(0)
+    expect(result.switchedSessions, `${fx.name}: expected no switchSession`).toHaveLength(0)
     // …and every seeded session is untouched beyond its shell: it must carry
     // only the keys it was seeded with (the `{ sessionId, messages }` shell plus
     // the fixture's own `init.sessions[id]` keys). A handler that wrote a NEW
@@ -118,6 +119,9 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
   }
   if (exp.infoNotifications) {
     expect(result.infoNotifications, `${fx.name}: infoNotifications`).toEqual(exp.infoNotifications)
+  }
+  if (exp.switchedSessions) {
+    expect(result.switchedSessions, `${fx.name}: switchedSessions`).toEqual(exp.switchedSessions)
   }
 }
 

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -159,11 +159,12 @@ describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
     // types that fell out. The band ratchets BOTH ways: a real new both-clients
     // switch type (universe grows past the ceiling) is a DELIBERATE bump, and
     // migrating types OUT to the shared dispatch table (universe shrinks below
-    // the floor) lowers it — adjust both bounds in the same PR. Floor last
-    // lowered 55→45 for #5618 Batch 4 (primary_changed / session_role /
+    // the floor) lowers it — adjust both bounds in the same PR. Keep the band
+    // TIGHT around the real count so the "fail loudly" intent stays sharp. Band
+    // last set for #5618 Batch 4 (primary_changed / session_role /
     // client_focus_changed migrated out; universe 55→52).
-    expect(both.length).toBeGreaterThanOrEqual(45)
-    expect(both.length).toBeLessThanOrEqual(70)
+    expect(both.length).toBeGreaterThanOrEqual(48)
+    expect(both.length).toBeLessThanOrEqual(58)
   })
 
   it('every both-clients switch type has a fixture or an explicit PENDING entry', () => {

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -75,7 +75,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'checkpoint_list',
   'checkpoint_restored',
   'claude_ready',
-  'client_focus_changed',
+  // client_focus_changed — migrated to the shared dispatch table (#5618 Batch 4).
   'client_joined',
   'client_left',
   'conversations_list',
@@ -91,7 +91,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'permission_timeout',
   'plan_ready',
   'pong',
-  'primary_changed',
+  // primary_changed — migrated to the shared dispatch table (#5618 Batch 4).
   // provider_list — migrated to the shared dispatch table (#5618 Batch 2);
   // app/dashboard element-handling divergence locked by a divergent fixture.
   'raw',
@@ -106,7 +106,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // session_persist_failed / session_restore_failed / session_stopped — migrated
   // to the shared dispatch table (#5618 Batch 3); now have DISPATCH_FIXTURES
   // entries, so they leave the both-clients-switch universe.
-  'session_role',
+  // session_role — migrated to the shared dispatch table (#5618 Batch 4).
   'session_switched',
   'session_timeout',
   'session_warning',
@@ -152,15 +152,18 @@ describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
   const covered = new Set(SWITCH_FIXTURES.map((f) => f.type))
 
   it('derives a non-trivial both-clients switch universe (extraction sanity)', () => {
-    // Pin the extraction to a band AROUND the real count (~64) so a parser
+    // Pin the extraction to a band AROUND the real count (~52) so a parser
     // regression fails LOUDLY (#6032). The old `> 20` floor was so far under the
     // real universe that a parse dropping to ~25 passed vacuously — silently
     // shrinking `both` so the anti-drift assertions below stopped protecting the
-    // types that fell out. The band ratchets: a real new both-clients switch type
-    // (the universe grows past the ceiling) is a DELIBERATE bump — raise both
-    // bounds in the same PR that adds its fixture / PENDING entry.
-    expect(both.length).toBeGreaterThanOrEqual(55)
-    expect(both.length).toBeLessThanOrEqual(80)
+    // types that fell out. The band ratchets BOTH ways: a real new both-clients
+    // switch type (universe grows past the ceiling) is a DELIBERATE bump, and
+    // migrating types OUT to the shared dispatch table (universe shrinks below
+    // the floor) lowers it — adjust both bounds in the same PR. Floor last
+    // lowered 55→45 for #5618 Batch 4 (primary_changed / session_role /
+    // client_focus_changed migrated out; universe 55→52).
+    expect(both.length).toBeGreaterThanOrEqual(45)
+    expect(both.length).toBeLessThanOrEqual(70)
   })
 
   it('every both-clients switch type has a fixture or an explicit PENDING entry', () => {

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -59,6 +59,10 @@ export interface FixtureInitialState {
   sessions?: Record<string, Record<string, unknown>>
   /** Session list (for `session_updated`). */
   sessionList?: SessionInfo[]
+  /** This client's own id (#5618 Batch 4 — for session_role / client_focus_changed). */
+  myClientId?: string | null
+  /** Follow-mode flag (#5618 Batch 4 — for client_focus_changed auto-switch). */
+  followMode?: boolean
 }
 
 /**
@@ -94,6 +98,12 @@ export interface FixtureExpectation {
    * care".
    */
   infoNotifications?: string[]
+  /**
+   * Expected `switchSession` invocations (#5618 Batch 4), in order — the
+   * client_focus_changed follow-mode auto-switch. Both clients call it
+   * identically; an empty array asserts NO switch fired. Omit to "don't care".
+   */
+  switchedSessions?: string[]
   /** When true, assert NO mutation happened at all (state is untouched). */
   noop?: boolean
 }
@@ -468,6 +478,60 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     init: { sessions: { s1: {} } },
     message: { type: 'session_stopped', sessionId: 's1', code: 0 },
     expect: { sessions: { s1: { stoppedCode: 0 } } },
+  },
+
+  // 4g. multi-client cases (#5618 Batch 4). The clients diverged only in where
+  // presence state lives (app multi-client store vs dashboard flat) — hidden
+  // behind the getMyClientId / getFollowMode / switchSession accessors — so the
+  // mutations are identical. The app's extra setPrimaryClientId mirror is
+  // out-of-contract (covered by dispatch-table.test.ts units).
+  {
+    name: 'primary_changed sets primaryClientId on the explicit target session',
+    type: 'primary_changed',
+    init: { sessions: { s1: {} } },
+    message: { type: 'primary_changed', sessionId: 's1', clientId: 'c1' },
+    expect: { sessions: { s1: { primaryClientId: 'c1' } } },
+  },
+  {
+    name: 'primary_changed writes flat primaryClientId for the server-wide default',
+    type: 'primary_changed',
+    message: { type: 'primary_changed', clientId: 'c1' },
+    expect: { flat: { primaryClientId: 'c1' } },
+  },
+  {
+    name: 'session_role derives primary when the server names this client',
+    type: 'session_role',
+    init: { myClientId: 'c1', sessions: { s1: {} } },
+    message: { type: 'session_role', sessionId: 's1', primaryClientId: 'c1' },
+    expect: { sessions: { s1: { sessionRole: 'primary', primaryClientId: 'c1' } } },
+  },
+  {
+    name: 'session_role derives observer when another client is primary',
+    type: 'session_role',
+    init: { myClientId: 'c1', sessions: { s1: {} } },
+    message: { type: 'session_role', sessionId: 's1', primaryClientId: 'c2' },
+    expect: { sessions: { s1: { sessionRole: 'observer', primaryClientId: 'c2' } } },
+  },
+  {
+    name: 'client_focus_changed auto-switches when follow mode is on (another client, local target)',
+    type: 'client_focus_changed',
+    init: { myClientId: 'me', followMode: true, activeSessionId: 'cur', sessions: { cur: {}, other: {} } },
+    message: { type: 'client_focus_changed', clientId: 'them', sessionId: 'other' },
+    expect: { switchedSessions: ['other'] },
+  },
+  {
+    name: 'client_focus_changed does NOT switch when follow mode is off',
+    type: 'client_focus_changed',
+    init: { myClientId: 'me', followMode: false, activeSessionId: 'cur', sessions: { cur: {}, other: {} } },
+    message: { type: 'client_focus_changed', clientId: 'them', sessionId: 'other' },
+    expect: { noop: true },
+  },
+  {
+    name: 'client_focus_changed ignores self-focus events even with follow mode on',
+    type: 'client_focus_changed',
+    init: { myClientId: 'me', followMode: true, activeSessionId: 'cur', sessions: { cur: {}, other: {} } },
+    message: { type: 'client_focus_changed', clientId: 'me', sessionId: 'other' },
+    expect: { noop: true },
   },
 
   // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -69,16 +69,32 @@ function makeAdapter(init?: {
    * message and applies its session patch either way.
    */
   infoToast?: boolean
+  /**
+   * When true, the adapter wires the multi-client accessors (#5618 Batch 4):
+   * `getMyClientId` / `getFollowMode` / `switchSession` (records into
+   * `switchedSessions`) and `setPrimaryClientId` (records into `primaryClientIds`).
+   * When omitted, the accessors are absent, so session_role / client_focus_changed
+   * DECLINE (`runDispatch` false). primary_changed never declines.
+   */
+  multiClient?: boolean
+  /** Seed for `getMyClientId` (only when `multiClient`). */
+  myClientId?: string | null
+  /** Seed for `getFollowMode` (only when `multiClient`). */
+  followMode?: boolean
 }) {
   const sessions: Record<string, FakeSession> = init?.sessions ?? {}
   let activeSessionId = init?.activeSessionId ?? null
   let sessionList: SessionInfo[] = init?.sessionList ?? []
+  const myClientId = init?.myClientId ?? null
+  const followMode = init?.followMode ?? false
   const flat: Record<string, unknown> = {}
   const addedMessages: ChatMessage[] = []
   const notifications: Array<{ sessionId: string; eventType: string; message: string }> = []
   const inventorySyncs: Array<{ kind: string; list: unknown[] }> = []
   const serverErrors: Array<{ message: string; category?: string; sessionId?: string; recoverable?: boolean }> = []
   const infoNotifications: string[] = []
+  const switchedSessions: string[] = []
+  const primaryClientIds: Array<string | null> = []
 
   const adapter: ClientStoreAdapter<FakeSession> = {
     getActiveSessionId: () => activeSessionId,
@@ -115,6 +131,14 @@ function makeAdapter(init?: {
     ...(init?.infoToast
       ? { addInfoNotification: (message: string) => infoNotifications.push(message) }
       : {}),
+    ...(init?.multiClient
+      ? {
+          getMyClientId: () => myClientId,
+          getFollowMode: () => followMode,
+          switchSession: (sessionId: string) => switchedSessions.push(sessionId),
+          setPrimaryClientId: (clientId: string | null) => primaryClientIds.push(clientId),
+        }
+      : {}),
   }
 
   return {
@@ -126,6 +150,8 @@ function makeAdapter(init?: {
     inventorySyncs,
     serverErrors,
     infoNotifications,
+    switchedSessions,
+    primaryClientIds,
     setActive: (id: string | null) => {
       activeSessionId = id
     },
@@ -539,6 +565,81 @@ describe('shared dispatch table', () => {
       const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } }, infoToast: true })
       dispatch(env, { type: 'session_stopped', sessionId: 's1', code: 0 })
       expect(env.infoNotifications).toEqual(['Session stopped.'])
+    })
+  })
+
+  describe('primary_changed / session_role / client_focus_changed (#5618 Batch 4)', () => {
+    it('primary_changed sets primaryClientId on the target session + mirrors into the app store', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } }, multiClient: true })
+      const handled = dispatch(env, { type: 'primary_changed', sessionId: 's1', clientId: 'c1' })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.primaryClientId).toBe('c1')
+      expect(env.primaryClientIds).toEqual(['c1']) // setPrimaryClientId mirror
+    })
+
+    it('primary_changed writes flat primaryClientId for the default scope, with NO mirror when the hook is absent', () => {
+      const env = makeAdapter() // no multiClient → no setPrimaryClientId hook
+      const handled = dispatch(env, { type: 'primary_changed', clientId: 'c1' })
+      expect(handled).toBe(true)
+      expect(env.flat.primaryClientId).toBe('c1')
+      expect(env.primaryClientIds).toEqual([])
+    })
+
+    it('session_role derives this client\'s role and stores it on the session', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } }, multiClient: true, myClientId: 'c1' })
+      const handled = dispatch(env, { type: 'session_role', sessionId: 's1', primaryClientId: 'c2' })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.sessionRole).toBe('observer')
+      expect(env.sessions.s1.primaryClientId).toBe('c2')
+    })
+
+    it('session_role DECLINES (runDispatch false) when getMyClientId is absent', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } } })
+      expect(dispatch(env, { type: 'session_role', sessionId: 's1', primaryClientId: 'c2' })).toBe(false)
+      expect(env.sessions.s1.sessionRole).toBeUndefined()
+    })
+
+    it('client_focus_changed auto-switches under follow mode (another client, local target, not active)', () => {
+      const env = makeAdapter({
+        sessions: { cur: { sessionId: 'cur', messages: [] }, other: { sessionId: 'other', messages: [] } },
+        activeSessionId: 'cur',
+        multiClient: true,
+        myClientId: 'me',
+        followMode: true,
+      })
+      const handled = dispatch(env, { type: 'client_focus_changed', clientId: 'them', sessionId: 'other' })
+      expect(handled).toBe(true)
+      expect(env.switchedSessions).toEqual(['other'])
+    })
+
+    it('client_focus_changed does NOT switch when follow mode is off / self / non-local / already active', () => {
+      const base = {
+        sessions: { cur: { sessionId: 'cur', messages: [] }, other: { sessionId: 'other', messages: [] } },
+        activeSessionId: 'cur',
+        multiClient: true,
+        myClientId: 'me',
+      }
+      const off = makeAdapter({ ...base, followMode: false })
+      dispatch(off, { type: 'client_focus_changed', clientId: 'them', sessionId: 'other' })
+      expect(off.switchedSessions).toEqual([])
+
+      const self = makeAdapter({ ...base, followMode: true })
+      dispatch(self, { type: 'client_focus_changed', clientId: 'me', sessionId: 'other' })
+      expect(self.switchedSessions).toEqual([])
+
+      const nonLocal = makeAdapter({ ...base, followMode: true })
+      dispatch(nonLocal, { type: 'client_focus_changed', clientId: 'them', sessionId: 'missing' })
+      expect(nonLocal.switchedSessions).toEqual([])
+
+      const alreadyActive = makeAdapter({ ...base, followMode: true })
+      dispatch(alreadyActive, { type: 'client_focus_changed', clientId: 'them', sessionId: 'cur' })
+      expect(alreadyActive.switchedSessions).toEqual([])
+    })
+
+    it('client_focus_changed DECLINES when the multi-client accessors are absent', () => {
+      const env = makeAdapter({ sessions: { other: { sessionId: 'other', messages: [] } } })
+      expect(dispatch(env, { type: 'client_focus_changed', clientId: 'them', sessionId: 'other' })).toBe(false)
+      expect(env.switchedSessions).toEqual([])
     })
   })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -534,12 +534,15 @@ export interface DispatchMessageMap {
   primary_changed: {
     type: 'primary_changed'
     sessionId?: string
-    clientId?: string
+    // null on the wire when the session is unclaimed (handlePrimaryChanged
+    // parses it via parseRawStringField → string | null).
+    clientId?: string | null
   }
   session_role: {
     type: 'session_role'
     sessionId?: string
-    primaryClientId?: string
+    // null when the session is unclaimed (handleSessionRole derives 'unclaimed').
+    primaryClientId?: string | null
   }
   client_focus_changed: {
     type: 'client_focus_changed'

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -56,6 +56,7 @@ import type {
   QueuedSessionMessage,
   SessionIntervention,
   ServerErrorCategory,
+  SessionRole,
   WebTask,
 } from './types'
 import { nextMessageId } from './utils'
@@ -84,6 +85,10 @@ import {
   handleSessionStopped,
   handleSessionRestoreFailed,
   handleSessionPersistFailed,
+  // --- multi-client cases (#5618 Batch 4) ---
+  handlePrimaryChanged,
+  handleSessionRole,
+  handleClientFocusChanged,
   handleSessionUsage,
   handleSessionContext,
   handleModelChangedPatch,
@@ -176,6 +181,12 @@ export interface DispatchSessionBase {
   // `interventions` — read+rewritten by multi_question_intervention (dedup +
   // ring-cap). Both clients' real `SessionState` carry it (BaseSessionState).
   interventions?: SessionIntervention[]
+  // --- multi-client cases (#5618 Batch 4) ---
+  // `primaryClientId` — written by primary_changed / session_role.
+  // `sessionRole` — written by session_role (this client's derived role).
+  // Both clients' real `SessionState` carry these (multi-client presence, #5281).
+  primaryClientId?: string | null
+  sessionRole?: SessionRole | null
 }
 
 /**
@@ -321,6 +332,44 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * {@link ClientStoreAdapter.pushSessionNotification}.
    */
   addInfoNotification?(message: string): void
+  /**
+   * Read THIS client's own client id (#5618 Batch 4) — learned from `auth_ok`.
+   * Used by session_role (to derive this client's role) and client_focus_changed
+   * (to ignore self-focus events). The app reads it from its dedicated
+   * `useMultiClientStore`; the dashboard from flat state — the SOLE divergence
+   * these cases had, now hidden behind this accessor.
+   *
+   * OPTIONAL and DECLINE-capable: the session_role / client_focus_changed
+   * handlers return `false` when it is absent so a client that hasn't wired the
+   * multi-client accessors falls through to its own switch. Both real clients
+   * supply it, so both own those cases.
+   */
+  getMyClientId?(): string | null
+  /**
+   * Read the "follow mode" flag (#5618 Batch 4) — when on, this client
+   * auto-switches to whatever session another client focuses. Used only by
+   * client_focus_changed. App: `useMultiClientStore`; dashboard: flat state.
+   * OPTIONAL/DECLINE-capable (see {@link ClientStoreAdapter.getMyClientId}).
+   */
+  getFollowMode?(): boolean
+  /**
+   * Switch the active session (#5618 Batch 4) — the client's own
+   * session-switch action, invoked by client_focus_changed's follow-mode
+   * auto-switch. Both clients back it with their store's `switchSession`.
+   * OPTIONAL/DECLINE-capable (see {@link ClientStoreAdapter.getMyClientId}).
+   */
+  switchSession?(sessionId: string): void
+  /**
+   * Mirror the primary client id into a SECONDARY client store (#5618 Batch 4).
+   * The app keeps a dedicated `useMultiClientStore` whose `primaryClientId` the
+   * presence UI reads; primary_changed updates it in addition to the shared
+   * session/flat write. The dashboard has no such store and OMITS this hook.
+   * A platform-specific side-effect OUTSIDE the shared store-state contract,
+   * like {@link ClientStoreAdapter.pushSessionNotification}; primary_changed
+   * always OWNS the message (it never declines — the shared write applies
+   * regardless).
+   */
+  setPrimaryClientId?(clientId: string | null): void
 }
 
 /**
@@ -480,6 +529,22 @@ export interface DispatchMessageMap {
     type: 'session_persist_failed'
     sessionId?: string
     name?: string
+  }
+  // --- multi-client cases (#5618 Batch 4) ---
+  primary_changed: {
+    type: 'primary_changed'
+    sessionId?: string
+    clientId?: string
+  }
+  session_role: {
+    type: 'session_role'
+    sessionId?: string
+    primaryClientId?: string
+  }
+  client_focus_changed: {
+    type: 'client_focus_changed'
+    clientId?: string
+    sessionId?: string
   }
   session_usage: {
     type: 'session_usage'
@@ -1078,6 +1143,69 @@ function dispatchSessionStopped<S extends DispatchSessionBase>(
   adapter.addInfoNotification?.(message)
 }
 
+// ---------------------------------------------------------------------------
+// Multi-client cases (#5618 Batch 4)
+//
+// primary_changed / session_role / client_focus_changed differed between the
+// clients ONLY in where the multi-client state lives (the app's dedicated
+// `useMultiClientStore` vs the dashboard's flat store) — the mutations were
+// identical. The `getMyClientId` / `getFollowMode` / `switchSession` accessors
+// hide that, so all three are now fully shared. primary_changed additionally
+// mirrors into the app's secondary store via the optional `setPrimaryClientId`
+// hook (out-of-contract). session_role / client_focus_changed DECLINE when the
+// multi-client accessors are absent (a client that hasn't opted in keeps its
+// local switch).
+// ---------------------------------------------------------------------------
+
+/** `primary_changed` — update the per-session / flat primary pointer (+ app mirror). */
+function dispatchPrimaryChanged<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['primary_changed'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { sessionId, primaryClientId } = handlePrimaryChanged(msg as Record<string, unknown>)
+  // App mirrors the raw pointer into its multi-client presence store first
+  // (matches the prior inline order); the dashboard omits this hook.
+  adapter.setPrimaryClientId?.(primaryClientId)
+  if (sessionId && adapter.hasSession(sessionId)) {
+    adapter.updateSession(sessionId, () => ({ primaryClientId } as Partial<S>))
+  } else if (!sessionId || sessionId === 'default') {
+    adapter.setState({ primaryClientId } as Record<string, unknown>)
+  }
+}
+
+/** `session_role` — store this client's derived role + primary on the session. */
+function dispatchSessionRole<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['session_role'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  if (!adapter.getMyClientId) return false
+  const role = handleSessionRole(msg as Record<string, unknown>, adapter.getMyClientId())
+  if (role.sessionId && adapter.hasSession(role.sessionId)) {
+    adapter.updateSession(
+      role.sessionId,
+      () => ({ sessionRole: role.role, primaryClientId: role.primaryClientId } as Partial<S>),
+    )
+  }
+}
+
+/** `client_focus_changed` — follow-mode auto-switch to another client's session. */
+function dispatchClientFocusChanged<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['client_focus_changed'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  if (!adapter.getFollowMode || !adapter.getMyClientId || !adapter.switchSession) return false
+  const focus = handleClientFocusChanged(msg as Record<string, unknown>)
+  if (!focus) return
+  if (
+    adapter.getFollowMode() &&
+    focus.clientId !== adapter.getMyClientId() &&
+    focus.sessionId !== adapter.getActiveSessionId() &&
+    adapter.hasSession(focus.sessionId)
+  ) {
+    adapter.switchSession(focus.sessionId)
+  }
+}
+
 /**
  * `notification_prefs` — validate + store the notification-prefs snapshot.
  * Slice-2 RECONCILE: both clients now share `handleNotificationPrefs`. A failed
@@ -1292,6 +1420,10 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     session_stopped: dispatchSessionStopped,
     session_restore_failed: dispatchSessionRestoreFailed,
     session_persist_failed: dispatchSessionPersistFailed,
+    // --- multi-client cases (#5618 Batch 4) ---
+    primary_changed: dispatchPrimaryChanged,
+    session_role: dispatchSessionRole,
+    client_focus_changed: dispatchClientFocusChanged,
     session_usage: sessionPatchDispatcher<S>(handleSessionUsage),
     session_context: sessionPatchDispatcher<S>(handleSessionContext),
     model_changed: sessionPatchDispatcher<S>(handleModelChangedPatch),
@@ -1366,6 +1498,10 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'session_stopped',
   'session_restore_failed',
   'session_persist_failed',
+  // --- multi-client cases (#5618 Batch 4) ---
+  'primary_changed',
+  'session_role',
+  'client_focus_changed',
   'session_usage',
   'session_context',
   'session_cost_threshold_crossed',


### PR DESCRIPTION
## Summary

Batch 4 of the dispatch-table migration (epic #5618; Batches 1–3 = #6207 / #6209 / #6210). Migrates the three **multi-client presence** cases — `primary_changed`, `session_role`, `client_focus_changed` — out of both clients' hand-copied switches.

Their *only* divergence was **where presence state lives** — the app's dedicated `useMultiClientStore` vs the dashboard's flat store — so four adapter methods hide it and the three cases become fully shared:

| Method | App | Dashboard |
|--------|-----|-----------|
| `getMyClientId()` | `useMultiClientStore.myClientId` | flat `myClientId` |
| `getFollowMode()` | `useMultiClientStore.followMode` | flat `followMode` |
| `switchSession(id)` | store `switchSession` | store `switchSession` |
| `setPrimaryClientId(id)` | mirrors into `useMultiClientStore` | **omitted** |

- `getMyClientId` / `getFollowMode` / `switchSession` are **optional + DECLINE-capable**: `session_role` / `client_focus_changed` fall through to the local switch when absent (the `getCallback` pattern). Both clients supply them, so both own the cases.
- `setPrimaryClientId` is an **optional app-only** mirror (out-of-contract, like `pushSessionNotification`). `primary_changed` never declines — the shared per-session / flat `primaryClientId` write applies regardless.

After this, `session_role` / `client_focus_changed` are byte-identical across clients (accessors resolve presence per platform); `primary_changed` shares the session/flat write.

## Verification
- store-core: `npm run typecheck` + full vitest **1763 ✓** — incl. 7 new `DISPATCH_FIXTURES` (primary→session/flat, session_role primary/observer, focus switch/off/self) and 8 new `dispatch-table.test.ts` units (decline-when-absent + the 4 no-switch branches). Lowered the extraction-sanity band 55→45 (the both-clients-switch universe shrank 55→52 as 3 types migrated out — the documented ratchet).
- dashboard: vitest **4032 ✓** (incl. the migrated functional dispatch tests) + typecheck
- protocol: **340 ✓** (handler-coverage credits the migrated types via `DISPATCH_TABLE_TYPES`)
- app: typecheck ✓ + functional tests **337 ✓** (full app jest runs in CI)

`session_timeout` remains deferred (heavier — overlaps a future `switchSession`-plus-flat-mirror effort). Closes part of #5618.