### PR TITLE
refactor(store-core): migrate available_models/cost_update onto the shared dispatch table (#5618 Batch 5a)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -97,8 +97,6 @@ import {
   // agent_spawned / agent_completed / agent_event / background_work_changed /
   // mcp_servers / session_usage / web_task_list / web_feature_status migrated
   // to the shared dispatch table (#5556 slice 2)
-  handleAvailableModels as sharedAvailableModels,
-  handleCostUpdate as sharedCostUpdate,
   handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
@@ -1229,6 +1227,14 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   getFollowMode: () => useMultiClientStore.getState().followMode,
   switchSession: (sessionId) => getStore().getState().switchSession(sessionId),
   setPrimaryClientId: (clientId) => useMultiClientStore.getState().setPrimaryClientId(clientId),
+  // #5618 Batch 5a — cost_update's app-only mirror: flat totalCost/costBudget +
+  // the useCostStore dual-write. (The shared per-session sessionCost patch is
+  // applied by the dispatch handler.) The app omits extendModelsPatch — it does
+  // not track availableModelsProvider (dashboard-only).
+  setCostUpdate: (totalCost, budget) => {
+    getStore().setState({ totalCost, costBudget: budget } as Partial<ConnectionState>);
+    useCostStore.getState().setCostUpdate(totalCost, budget);
+  },
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -2688,13 +2694,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // #5618 — model_changed migrated to the shared store-core dispatch table
     // (runDispatch handles it before this switch). Removed from here.
 
-    case 'available_models': {
-      if (Array.isArray(msg.models)) {
-        const { models, defaultModelId } = sharedAvailableModels(msg);
-        set({ availableModels: models, defaultModelId });
-      }
-      break;
-    }
+    // available_models — migrated to the shared dispatch table (#5618 Batch 5a;
+    // handled by runDispatch before this switch). Non-array payloads are a no-op
+    // that preserves the existing list. The app omits the dashboard-only
+    // availableModelsProvider extension.
+
 
     case 'permission_mode_changed': {
       const { mode } = sharedPermissionModeChanged(msg);
@@ -3226,18 +3230,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // mcp_servers — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'cost_update': {
-      const result = sharedCostUpdate(msg, get().activeSessionId);
-      const totalCost = typeof msg.totalCost === 'number' ? msg.totalCost : null;
-      const budget = typeof msg.budget === 'number' ? msg.budget : null;
-      if (result.sessionId && get().sessionStates[result.sessionId]) {
-        updateSession(result.sessionId, () => result.patch);
-      }
-      set({ totalCost, costBudget: budget });
-      // dual-write: remove after consumers migrate to CostStore
-      useCostStore.getState().setCostUpdate(totalCost, budget);
-      break;
-    }
+    // cost_update — migrated to the shared dispatch table (#5618 Batch 5a;
+    // handled by runDispatch before this switch). The shared per-session
+    // sessionCost patch runs in the table; the app's flat totalCost/costBudget +
+    // useCostStore dual-write ride on the `setCostUpdate` adapter hook.
 
     // session_usage / session_cost_threshold_crossed — migrated to the shared
     // dispatch table (#5556 slice 2)

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -91,9 +91,7 @@ import {
   // migrated to the shared dispatch table (#5556 slice 2)
   handleEnvironmentList as sharedEnvironmentList,
   handleEnvironmentError as sharedEnvironmentError,
-  handleAvailableModels as sharedAvailableModels,
   // mcp_servers / session_usage migrated to the shared dispatch table (#5556 slice 2)
-  handleCostUpdate as sharedCostUpdate,
   handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
@@ -1046,6 +1044,13 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   getMyClientId: () => getStore().getState().myClientId,
   getFollowMode: () => getStore().getState().followMode,
   switchSession: (sessionId) => getStore().getState().switchSession(sessionId),
+  // #5618 Batch 5a — the dashboard tracks which provider the available_models
+  // list is for; contribute it to the single available_models patch. The app
+  // omits this hook (no availableModelsProvider field). The dashboard omits
+  // setCostUpdate (cost_update's flat/cost-store mirror is app-only).
+  extendModelsPatch: (msg) => ({
+    availableModelsProvider: typeof msg.provider === 'string' ? msg.provider : null,
+  }),
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -4291,14 +4296,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'available_models': {
-      if (Array.isArray(msg.models)) {
-        const { models, defaultModelId } = sharedAvailableModels(msg);
-        const availableModelsProvider = typeof msg.provider === 'string' ? msg.provider : null;
-        set({ availableModels: models, availableModelsProvider, defaultModelId });
-      }
-      break;
-    }
+    // available_models — migrated to the shared dispatch table (#5618 Batch 5a;
+    // handled by runDispatch before this switch). Non-array payloads are a no-op
+    // that preserves the existing list. The dashboard's availableModelsProvider
+    // rides on the `extendModelsPatch` adapter hook (single set).
 
     // confirm_permission_mode — migrated to the shared dispatch table (#5556)
 
@@ -4771,13 +4772,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // mcp_servers — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'cost_update': {
-      const result = sharedCostUpdate(msg, get().activeSessionId);
-      if (result.sessionId && get().sessionStates[result.sessionId]) {
-        updateSession(result.sessionId, () => result.patch);
-      }
-      break;
-    }
+    // cost_update — migrated to the shared dispatch table (#5618 Batch 5a;
+    // handled by runDispatch before this switch). The dashboard applies only the
+    // shared per-session sessionCost patch (it omits the app's setCostUpdate
+    // flat/cost-store mirror).
 
     // session_usage / session_cost_threshold_crossed / dev_preview /
     // dev_preview_stopped — migrated to the shared dispatch table (#5556 slice 2)

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -221,14 +221,27 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
           // session/flat primaryClientId write IS asserted; the dispatch-table
           // unit tests cover the hook invocation). The dashboard omits it.
           setPrimaryClientId: () => {},
+          // #5618 Batch 5a — cost_update's app-only flat/cost-store mirror. Out
+          // of the shared contract (the shared sessionCost patch IS asserted);
+          // modelled as a no-op, with the hook invocation covered by the
+          // dispatch-table unit tests. The dashboard omits it.
+          setCostUpdate: () => {},
         }
       : {}),
     // #5618 Batch 3 — only the DASHBOARD shows the session_stopped info toast
     // (#4878); the app OMITS `addInfoNotification` (#4879). Record it on the
     // dashboard side so a unit/contract assertion can observe the divergence;
     // the app's empty array IS the contract for that case.
+    // #5618 Batch 5a — only the DASHBOARD contributes availableModelsProvider to
+    // the available_models patch (the app omits the hook). Locked by a divergent
+    // fixture (dashboard flat carries the extra field; app's does not).
     ...(kind === 'dashboard'
-      ? { addInfoNotification: (message: string) => infoNotifications.push(message) }
+      ? {
+          addInfoNotification: (message: string) => infoNotifications.push(message),
+          extendModelsPatch: (msg: Record<string, unknown>) => ({
+            availableModelsProvider: typeof msg.provider === 'string' ? msg.provider : null,
+          }),
+        }
       : {}),
   }
 

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -70,7 +70,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'auth_bootstrap',
   'auth_fail',
   'auth_ok',
-  'available_models',
+  // available_models — migrated to the shared dispatch table (#5618 Batch 5a).
   'checkpoint_created',
   'checkpoint_list',
   'checkpoint_restored',
@@ -79,7 +79,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'client_joined',
   'client_left',
   'conversations_list',
-  'cost_update',
+  // cost_update — migrated to the shared dispatch table (#5618 Batch 5a).
   'history_replay_end',
   'key_exchange_ok',
   // multi_question_intervention — migrated to the shared dispatch table (#5618);

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -534,6 +534,58 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { noop: true },
   },
 
+  // 4h. models / cost cases (#5618 Batch 5a). available_models shares the flat
+  // {availableModels, defaultModelId} write; the dashboard adds
+  // availableModelsProvider via extendModelsPatch (divergent). cost_update shares
+  // the per-session sessionCost patch; the app's flat/cost-store mirror is
+  // out-of-contract (covered by dispatch-table.test.ts units).
+  {
+    name: 'available_models replaces the flat list (app vs dashboard provider divergence)',
+    type: 'available_models',
+    message: {
+      type: 'available_models',
+      models: [{ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8' }],
+      defaultModel: 'opus',
+      provider: 'claude-tui',
+    },
+    divergent: {
+      app: {
+        flat: {
+          availableModels: [{ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8' }],
+          defaultModelId: 'opus',
+        },
+      },
+      dashboard: {
+        flat: {
+          availableModels: [{ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8' }],
+          defaultModelId: 'opus',
+          availableModelsProvider: 'claude-tui',
+        },
+      },
+      reason: 'dashboard tracks availableModelsProvider via extendModelsPatch; the app omits it',
+    },
+  },
+  {
+    name: 'available_models is a no-op for a non-array payload (preserves the existing list)',
+    type: 'available_models',
+    message: { type: 'available_models' },
+    expect: { noop: true },
+  },
+  {
+    name: 'cost_update applies the per-session sessionCost patch (explicit target)',
+    type: 'cost_update',
+    init: { sessions: { s1: {} } },
+    message: { type: 'cost_update', sessionId: 's1', sessionCost: 1.23 },
+    expect: { sessions: { s1: { sessionCost: 1.23 } } },
+  },
+  {
+    name: 'cost_update falls back to the active session when sessionId is omitted',
+    type: 'cost_update',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'cost_update', sessionCost: 0.5 },
+    expect: { sessions: { s1: { sessionCost: 0.5 } } },
+  },
+
   // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the
   // session was not paused; no-op when it was (budget_resumed already noted it)
   {

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -81,6 +81,18 @@ function makeAdapter(init?: {
   myClientId?: string | null
   /** Seed for `getFollowMode` (only when `multiClient`). */
   followMode?: boolean
+  /**
+   * When true, the adapter wires `extendModelsPatch` (the dashboard's
+   * availableModelsProvider contribution, #5618 Batch 5a). When omitted, the
+   * available_models patch carries only the shared fields (the app's behaviour).
+   */
+  extendModels?: boolean
+  /**
+   * When true, the adapter wires `setCostUpdate` (records into `costUpdates`) —
+   * cost_update's app-only flat/cost-store mirror (#5618 Batch 5a). When omitted,
+   * cost_update applies only the shared sessionCost patch (the dashboard).
+   */
+  costMirror?: boolean
 }) {
   const sessions: Record<string, FakeSession> = init?.sessions ?? {}
   let activeSessionId = init?.activeSessionId ?? null
@@ -95,6 +107,7 @@ function makeAdapter(init?: {
   const infoNotifications: string[] = []
   const switchedSessions: string[] = []
   const primaryClientIds: Array<string | null> = []
+  const costUpdates: Array<{ totalCost: number | null; budget: number | null }> = []
 
   const adapter: ClientStoreAdapter<FakeSession> = {
     getActiveSessionId: () => activeSessionId,
@@ -139,6 +152,19 @@ function makeAdapter(init?: {
           setPrimaryClientId: (clientId: string | null) => primaryClientIds.push(clientId),
         }
       : {}),
+    ...(init?.extendModels
+      ? {
+          extendModelsPatch: (msg: Record<string, unknown>) => ({
+            availableModelsProvider: typeof msg.provider === 'string' ? msg.provider : null,
+          }),
+        }
+      : {}),
+    ...(init?.costMirror
+      ? {
+          setCostUpdate: (totalCost: number | null, budget: number | null) =>
+            costUpdates.push({ totalCost, budget }),
+        }
+      : {}),
   }
 
   return {
@@ -152,6 +178,7 @@ function makeAdapter(init?: {
     infoNotifications,
     switchedSessions,
     primaryClientIds,
+    costUpdates,
     setActive: (id: string | null) => {
       activeSessionId = id
     },
@@ -640,6 +667,60 @@ describe('shared dispatch table', () => {
       const env = makeAdapter({ sessions: { other: { sessionId: 'other', messages: [] } } })
       expect(dispatch(env, { type: 'client_focus_changed', clientId: 'them', sessionId: 'other' })).toBe(false)
       expect(env.switchedSessions).toEqual([])
+    })
+  })
+
+  describe('available_models / cost_update (#5618 Batch 5a)', () => {
+    const modelsMsg = {
+      type: 'available_models',
+      models: [{ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8' }],
+      defaultModel: 'opus',
+      provider: 'claude-tui',
+    }
+
+    it('available_models replaces the flat list + default (app: no provider field)', () => {
+      const env = makeAdapter()
+      const handled = dispatch(env, modelsMsg)
+      expect(handled).toBe(true)
+      expect(env.flat.availableModels).toEqual([{ id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8' }])
+      expect(env.flat.defaultModelId).toBe('opus')
+      expect(env.flat.availableModelsProvider).toBeUndefined()
+    })
+
+    it('available_models adds availableModelsProvider when extendModelsPatch is wired (dashboard)', () => {
+      const env = makeAdapter({ extendModels: true })
+      dispatch(env, modelsMsg)
+      expect(env.flat.availableModelsProvider).toBe('claude-tui')
+    })
+
+    it('available_models is owned-but-no-op for a non-array payload (preserves the list)', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'available_models' })).toBe(true)
+      expect(env.flat.availableModels).toBeUndefined()
+      expect(env.flat.defaultModelId).toBeUndefined()
+    })
+
+    it('cost_update applies the per-session sessionCost patch + app mirror when wired', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } }, costMirror: true })
+      const handled = dispatch(env, { type: 'cost_update', sessionId: 's1', sessionCost: 1.23, totalCost: 9.9, budget: 20 })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.sessionCost).toBe(1.23)
+      expect(env.costUpdates).toEqual([{ totalCost: 9.9, budget: 20 }])
+    })
+
+    it('cost_update applies the session patch with NO mirror when setCostUpdate is absent (dashboard)', () => {
+      const env = makeAdapter({ sessions: { s1: { sessionId: 's1', messages: [] } } })
+      const handled = dispatch(env, { type: 'cost_update', sessionId: 's1', sessionCost: 1.23, totalCost: 9.9 })
+      expect(handled).toBe(true)
+      expect(env.sessions.s1.sessionCost).toBe(1.23)
+      expect(env.costUpdates).toEqual([])
+    })
+
+    it('cost_update falls back to the active session and coerces non-number mirror fields to null', () => {
+      const env = makeAdapter({ activeSessionId: 's1', sessions: { s1: { sessionId: 's1', messages: [] } }, costMirror: true })
+      dispatch(env, { type: 'cost_update', sessionCost: 0.5 })
+      expect(env.sessions.s1.sessionCost).toBe(0.5)
+      expect(env.costUpdates).toEqual([{ totalCost: null, budget: null }])
     })
   })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -89,6 +89,9 @@ import {
   handlePrimaryChanged,
   handleSessionRole,
   handleClientFocusChanged,
+  // --- models / cost cases (#5618 Batch 5a) ---
+  handleAvailableModels,
+  handleCostUpdate,
   handleSessionUsage,
   handleSessionContext,
   handleModelChangedPatch,
@@ -187,6 +190,10 @@ export interface DispatchSessionBase {
   // Both clients' real `SessionState` carry these (multi-client presence, #5281).
   primaryClientId?: string | null
   sessionRole?: SessionRole | null
+  // --- cost_update (#5618 Batch 5a) ---
+  // `sessionCost` — written by cost_update (the per-session running cost).
+  // Both clients' real `SessionState` carry it (BaseSessionState).
+  sessionCost?: number | null
 }
 
 /**
@@ -370,6 +377,28 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * regardless).
    */
   setPrimaryClientId?(clientId: string | null): void
+  /**
+   * Contribute extra flat fields to the `available_models` patch (#5618 Batch 5a).
+   * The dashboard tracks which provider the model list is for
+   * (`availableModelsProvider`, parsed from `msg.provider`) and writes it in the
+   * SAME `set` as the models; the app store has no such field. The dispatcher
+   * spreads the returned object into the single `setState` patch, preserving the
+   * single-write behaviour.
+   *
+   * OPTIONAL: when omitted (the app), no extra fields are added. Returns the
+   * patch fragment (e.g. `{ availableModelsProvider }`); receives the raw wire
+   * message so the client parses only the fields it needs.
+   */
+  extendModelsPatch?(msg: Record<string, unknown>): Record<string, unknown>
+  /**
+   * Mirror a cost update into the client's flat state + cost store (#5618 Batch 5a).
+   * `cost_update`'s shared effect is the per-session `sessionCost` patch; the app
+   * ADDITIONALLY writes flat `totalCost`/`costBudget` and dual-writes the
+   * `useCostStore`. The dashboard does neither. A platform-specific side-effect
+   * OUTSIDE the shared store-state contract; cost_update always OWNS the message
+   * (the session patch applies regardless), so it never declines.
+   */
+  setCostUpdate?(totalCost: number | null, budget: number | null): void
 }
 
 /**
@@ -548,6 +577,22 @@ export interface DispatchMessageMap {
     type: 'client_focus_changed'
     clientId?: string
     sessionId?: string
+  }
+  // --- models / cost cases (#5618 Batch 5a) ---
+  available_models: {
+    type: 'available_models'
+    models?: unknown[]
+    defaultModel?: string
+    // dashboard-only: which provider the list is for (parsed at the call site).
+    provider?: string
+  }
+  cost_update: {
+    type: 'cost_update'
+    sessionId?: string
+    sessionCost?: number
+    // app-only flat/cost-store mirror fields (parsed at the call site).
+    totalCost?: number
+    budget?: number
   }
   session_usage: {
     type: 'session_usage'
@@ -1209,6 +1254,44 @@ function dispatchClientFocusChanged<S extends DispatchSessionBase>(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Models / cost cases (#5618 Batch 5a)
+//
+// available_models replaces the flat model list (+ the dashboard's extra
+// `availableModelsProvider` via `extendModelsPatch`). cost_update applies the
+// shared per-session `sessionCost` patch (+ the app's flat/cost-store mirror via
+// `setCostUpdate`). Both ALWAYS own the message — the optional hooks only carry
+// the platform-specific extra, never gate ownership.
+// ---------------------------------------------------------------------------
+
+/** `available_models` — replace the flat model list (skip entirely if not an array). */
+function dispatchAvailableModels<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['available_models'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  // Both clients guard on Array.isArray BEFORE writing — a non-array payload is a
+  // no-op that PRESERVES the existing list (NOT a clobber to []).
+  if (!Array.isArray(msg.models)) return
+  const { models, defaultModelId } = handleAvailableModels(msg as Record<string, unknown>)
+  const extra = adapter.extendModelsPatch ? adapter.extendModelsPatch(msg as Record<string, unknown>) : {}
+  adapter.setState({ availableModels: models, defaultModelId, ...extra } as Record<string, unknown>)
+}
+
+/** `cost_update` — per-session sessionCost patch (+ app flat/cost-store mirror). */
+function dispatchCostUpdate<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['cost_update'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const result = handleCostUpdate(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (result.sessionId && adapter.hasSession(result.sessionId)) {
+    adapter.updateSession(result.sessionId, () => result.patch as Partial<S>)
+  }
+  // App-only: flat totalCost/costBudget + the useCostStore dual-write.
+  const totalCost = typeof msg.totalCost === 'number' ? msg.totalCost : null
+  const budget = typeof msg.budget === 'number' ? msg.budget : null
+  adapter.setCostUpdate?.(totalCost, budget)
+}
+
 /**
  * `notification_prefs` — validate + store the notification-prefs snapshot.
  * Slice-2 RECONCILE: both clients now share `handleNotificationPrefs`. A failed
@@ -1427,6 +1510,9 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     primary_changed: dispatchPrimaryChanged,
     session_role: dispatchSessionRole,
     client_focus_changed: dispatchClientFocusChanged,
+    // --- models / cost cases (#5618 Batch 5a) ---
+    available_models: dispatchAvailableModels,
+    cost_update: dispatchCostUpdate,
     session_usage: sessionPatchDispatcher<S>(handleSessionUsage),
     session_context: sessionPatchDispatcher<S>(handleSessionContext),
     model_changed: sessionPatchDispatcher<S>(handleModelChangedPatch),
@@ -1505,6 +1591,9 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'primary_changed',
   'session_role',
   'client_focus_changed',
+  // --- models / cost cases (#5618 Batch 5a) ---
+  'available_models',
+  'cost_update',
   'session_usage',
   'session_context',
   'session_cost_threshold_crossed',

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -1274,7 +1274,9 @@ function dispatchAvailableModels<S extends DispatchSessionBase>(
   if (!Array.isArray(msg.models)) return
   const { models, defaultModelId } = handleAvailableModels(msg as Record<string, unknown>)
   const extra = adapter.extendModelsPatch ? adapter.extendModelsPatch(msg as Record<string, unknown>) : {}
-  adapter.setState({ availableModels: models, defaultModelId, ...extra } as Record<string, unknown>)
+  // Spread `extra` FIRST so the shared fields always win — the hook is for EXTRA
+  // flat fields only and must never override availableModels/defaultModelId.
+  adapter.setState({ ...extra, availableModels: models, defaultModelId } as Record<string, unknown>)
 }
 
 /** `cost_update` — per-session sessionCost patch (+ app flat/cost-store mirror). */


### PR DESCRIPTION
## Summary

First slice of **Batch 5** of the dispatch-table migration (epic #5618; Batches 1–4 = #6207 / #6209 / #6210 / #6211). Batch 5 is heterogeneous, so it's decomposed — this PR takes the **two contained models/cost cases** (`available_models`, `cost_update`), which involve only flat/session writes (no socket/alert/tunnel risk). The heavier tail is sequenced separately.

Both share their core write; the per-client extra rides on a new optional hook:

| Case | Shared write | Per-client extra |
|------|--------------|------------------|
| `available_models` | flat `{ availableModels, defaultModelId }` | dashboard's `availableModelsProvider` via new `extendModelsPatch(msg)` (contributed to the **same** `set`; app omits) |
| `cost_update` | per-session `sessionCost` patch | app's flat `totalCost`/`costBudget` + `useCostStore` dual-write via new `setCostUpdate(totalCost, budget)` (dashboard omits) |

Both **always own** the message — the optional hooks only carry the platform-specific extra, never gate ownership.

**Behaviour-preserving detail:** a non-array `available_models` payload is a **no-op that preserves the existing list** — both clients guarded on `Array.isArray` before writing, so the dispatcher early-returns rather than clobbering to `[]`.

## Verification
- store-core: `npm run typecheck` + full vitest **1773 ✓** — 4 new `DISPATCH_FIXTURES` (available_models app-vs-dashboard provider **divergent** + non-array no-op; cost_update explicit-target + active-fallback) and 6 new `dispatch-table.test.ts` units. Removed the two from `PENDING_CONTRACT_TYPES` (extraction band still valid — universe 52→50).
- dashboard: vitest **4032 ✓** + typecheck
- protocol: **340 ✓** (handler-coverage credits the migrated types via `DISPATCH_TABLE_TYPES`)
- app: typecheck ✓ (no functional tests drive these types; full app jest runs in CI)

## Deferred (heavier Batch 5 tail — on #5618)
`auth_fail` / `server_mode` / `tunnel_url_changed` / `auth_bootstrap` need socket-I/O / platform-alert / tunnel-rotation primitives; `session_timeout` folds into that work. Each warrants its own careful PR.

Closes part of #5618.