### PR TITLE
refactor(store-core): migrate tunnel_url_changed/auth_bootstrap onto the shared dispatch table (#5618 Batch 5b)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -89,8 +89,6 @@ import {
   handleSessionTimeout as sharedSessionTimeout,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
-  handleAuthBootstrap as sharedAuthBootstrap,
-  handleTunnelUrlChanged as sharedTunnelUrlChanged,
   // diff_result / git_status_result / git_branches_result / git_stage_result /
   // git_unstage_result / git_commit_result — migrated to the shared dispatch
   // table (#5556 slice 3 / #5653).
@@ -1235,6 +1233,10 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
     getStore().setState({ totalCost, costBudget: budget } as Partial<ConnectionState>);
     useCostStore.getState().setCostUpdate(totalCost, budget);
   },
+  // #5618 Batch 5b — repoint the persisted (SecureStore) tunnel endpoint after a
+  // quick-tunnel rotation (tunnel_url_changed / auth_bootstrap). The app's apply
+  // ignores previousUrl (the dashboard uses it to match the right registry entry).
+  applyRotatedTunnelUrl: (url) => { applyRotatedTunnelUrl(url); },
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -3145,51 +3147,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // `mapProviderList` adapter hooks. auth_bootstrap stays local — it folds all
     // three lists into one connect-time frame with extra session-scope guarding.
 
-    case 'auth_bootstrap': {
-      // #5555 — connect-time bootstrap burst folds the provider / slash-command
-      // / agent lists into one server-initiated frame so the client skips its
-      // 3-request connect-time round trip. Apply each list through the SAME
-      // store mutations + element validation the discrete responses use, so the
-      // bootstrap and refresh paths are behaviourally identical.
-      const boot = sharedAuthBootstrap(msg);
-      // #5555 (sub-item 7): re-learn the live tunnel URL on every connect. If a
-      // quick-tunnel rotation happened while the app was offline (so it missed
-      // the live `tunnel_url_changed` push), this repoints the persisted record
-      // to the working endpoint. Applied before the session-scope guard below
-      // so a stale-session burst still refreshes the URL.
-      if (boot.tunnelUrl) applyRotatedTunnelUrl(boot.tunnelUrl);
-      // Providers (server-wide, no session guard).
-      set({ availableProviders: mapProviderList(boot.providers) });
-      // Slash commands + agents are scoped to the connect-time active session.
-      // Guard against a stale burst: if a session switch already moved the
-      // active id off the burst's `sessionId`, skip the session-scoped lists
-      // (the post-switch session_switched flow re-requests them) but keep the
-      // server-wide provider list applied above.
-      const activeId = get().activeSessionId;
-      if (boot.sessionId && activeId && boot.sessionId !== activeId) break;
-      const slashCommands = boot.slashCommands as SlashCommand[];
-      set({ slashCommands });
-      useConversationStore.getState().setSlashCommands(slashCommands);
-      const customAgents = boot.agents as CustomAgent[];
-      set({ customAgents });
-      useConversationStore.getState().setCustomAgents(customAgents);
-      break;
-    }
-
-    case 'tunnel_url_changed': {
-      // #5555 (sub-item 7): a quick-tunnel recovery rotated the public URL.
-      // Repoint the persisted tunnel endpoint so the next reconnect dials the
-      // working URL instead of hammering the dead one (and survives an app
-      // restart — the record is SecureStore-backed).
-      //
-      // BEST-EFFORT for us: this client is connected THROUGH the tunnel, so the
-      // socket carrying this frame rode the now-dead old tunnel — we often will
-      // NOT receive it. The durable recovery is the `tunnelUrl` re-advertised in
-      // the `auth_bootstrap` burst on the next reconnect (handled above).
-      const rotated = sharedTunnelUrlChanged(msg);
-      if (rotated) applyRotatedTunnelUrl(rotated.url);
-      break;
-    }
+    // auth_bootstrap / tunnel_url_changed — migrated to the shared dispatch table
+    // (#5618 Batch 5b; handled by runDispatch before this switch). auth_bootstrap
+    // reuses the Batch 2 mapProviderList + syncSecondaryInventory hooks and the
+    // new applyRotatedTunnelUrl hook (session-scope guard preserved);
+    // tunnel_url_changed's apply rides on applyRotatedTunnelUrl alone.
 
     // session_restore_failed / session_persist_failed — migrated to the shared
     // dispatch table (#5618 Batch 3; handled by runDispatch before this switch).

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -3144,8 +3144,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // dispatch table (#5618 Batch 2; handled by runDispatch before this switch).
     // The app's secondary-conversation-store mirror (slash/agents) and
     // mapProviderList tightening now ride on the `syncSecondaryInventory` /
-    // `mapProviderList` adapter hooks. auth_bootstrap stays local — it folds all
-    // three lists into one connect-time frame with extra session-scope guarding.
+    // `mapProviderList` adapter hooks (auth_bootstrap, which folds the same lists
+    // into one connect-time frame, was migrated in #5618 Batch 5b — see below).
 
     // auth_bootstrap / tunnel_url_changed — migrated to the shared dispatch table
     // (#5618 Batch 5b; handled by runDispatch before this switch). auth_bootstrap

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -4613,8 +4613,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // The dashboard has no secondary conversation store and trusts the server
     // provider payload, so it supplies neither the `syncSecondaryInventory` nor
     // the `mapProviderList` adapter hook — the dispatch handlers perform the
-    // plain flat-state write, exactly as these cases did. auth_bootstrap stays
-    // local. file_list remains dashboard-only.
+    // plain flat-state write, exactly as these cases did. (auth_bootstrap, which
+    // folds the same lists into one connect-time frame, was migrated in #5618
+    // Batch 5b — see below.) file_list remains dashboard-only.
 
     case 'file_list': {
       const fileResult = sharedFileList(msg);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -82,8 +82,6 @@ import {
   handleSessionTimeout as sharedSessionTimeout,
   handleSessionWarning as sharedSessionWarning,
   handleSessionSwitched as sharedSessionSwitched,
-  handleAuthBootstrap as sharedAuthBootstrap,
-  handleTunnelUrlChanged as sharedTunnelUrlChanged,
   handleFileList as sharedFileList,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
@@ -158,7 +156,6 @@ import type {
   ChatMessage,
   ConnectionContext,
   ConnectionState,
-  CustomAgent,
   DirectoryEntry,
   EnvironmentInfo,
   EvaluatorRewriteMeta,
@@ -169,9 +166,7 @@ import type {
   SessionInfo,
   SessionNotification,
   SessionState,
-  SlashCommand,
   FilePickerItem,
-  ProviderInfo,
 } from './types';
 import { createEmptySessionState } from './utils';
 import { clearPersistedSession } from './persistence';
@@ -1051,6 +1046,12 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   extendModelsPatch: (msg) => ({
     availableModelsProvider: typeof msg.provider === 'string' ? msg.provider : null,
   }),
+  // #5618 Batch 5b — repoint the localStorage server-registry entry after a
+  // quick-tunnel rotation (tunnel_url_changed / auth_bootstrap). Consults
+  // previousUrl to match the right entry (the app ignores it).
+  applyRotatedTunnelUrl: (url, previousUrl) => {
+    applyRotatedTunnelUrlDashboard(getStore().getState, url, previousUrl);
+  },
 };
 
 const _dispatchTable = createDispatchTable<SessionState>();
@@ -4621,47 +4622,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'auth_bootstrap': {
-      // #5555 — connect-time bootstrap burst folds the provider / slash-command
-      // / agent lists into one server-initiated frame so the client skips its
-      // 3-request connect-time round trip. Apply each list through the SAME
-      // store mutations the discrete responses use.
-      const boot = sharedAuthBootstrap(msg);
-      // #5555 (sub-item 7): re-learn the live tunnel URL on every connect. If a
-      // quick-tunnel rotation happened while this dashboard was disconnected
-      // (so it missed the live `tunnel_url_changed` push), repoint the stored
-      // server entry to the working endpoint. No-op for the same-origin
-      // connection and for LAN entries.
-      if (boot.tunnelUrl) applyRotatedTunnelUrlDashboard(get, boot.tunnelUrl, null);
-      set({ availableProviders: boot.providers as ProviderInfo[] });
-      // Slash commands + agents are scoped to the connect-time active session.
-      // Guard against a stale burst: if a session switch already moved the
-      // active id off the burst's `sessionId`, skip the session-scoped lists
-      // (the post-switch flow re-requests them) but keep the server-wide
-      // provider list applied above.
-      const activeId = get().activeSessionId;
-      if (boot.sessionId && activeId && boot.sessionId !== activeId) break;
-      set({ slashCommands: boot.slashCommands as SlashCommand[] });
-      set({ customAgents: boot.agents as CustomAgent[] });
-      break;
-    }
-
-    case 'tunnel_url_changed': {
-      // #5555 (sub-item 7): a quick-tunnel recovery rotated the public URL.
-      // Repoint the active server-registry entry so the next reconnect dials
-      // the working URL (and survives a tab refresh — localStorage-backed).
-      //
-      // A localhost dashboard (served by the local daemon, activeServerId ===
-      // null) keeps its socket across the rotation and so RELIABLY receives
-      // this push — but it dials window.location, not the tunnel, so the
-      // helper is a no-op for it. A remote/LAN dashboard reaches the server
-      // THROUGH the tunnel, so it usually will NOT receive this frame (the old
-      // tunnel just died); its durable recovery is the `tunnelUrl` in the
-      // auth_bootstrap burst on the next reconnect (handled above).
-      const rotated = sharedTunnelUrlChanged(msg);
-      if (rotated) applyRotatedTunnelUrlDashboard(get, rotated.url, rotated.previousUrl);
-      break;
-    }
+    // auth_bootstrap / tunnel_url_changed — migrated to the shared dispatch table
+    // (#5618 Batch 5b; handled by runDispatch before this switch). auth_bootstrap
+    // applies the provider list (verbatim — dashboard omits mapProviderList) + the
+    // session-scope-guarded slash/agent lists + the tunnel URL via the
+    // applyRotatedTunnelUrl hook; tunnel_url_changed's apply rides on that hook
+    // alone (consulting previousUrl to match the registry entry).
 
     case 'byok_credentials_status': {
       // #4052: server replies after refresh / set / clear. The masked

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -81,6 +81,13 @@ export interface AdapterResult {
    * asserts they switch to the same session(s).
    */
   switchedSessions: string[]
+  /**
+   * Tunnel-URL rotations applied via `applyRotatedTunnelUrl` (#5618 Batch 5b), in
+   * order — from tunnel_url_changed and the auth_bootstrap burst. BOTH clients
+   * call it (the persistence is platform-local below the hook), so the contract
+   * asserts they apply the SAME (url, previousUrl).
+   */
+  rotatedTunnelUrls: Array<{ url: string; previousUrl: string | null }>
 }
 
 /** Which client an adapter models — drives the `updateSession` divergence. */
@@ -124,6 +131,7 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   const serverErrors: AdapterResult['serverErrors'] = []
   const infoNotifications: string[] = []
   const switchedSessions: string[] = []
+  const rotatedTunnelUrls: AdapterResult['rotatedTunnelUrls'] = []
 
   // Reproduce each client's real `updateSession`. Both share the
   // "no-op on missing session / empty patch" guard; they diverge only in the
@@ -171,6 +179,13 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     // notification store; dashboard string banner) is below the hook, out of scope.
     addServerError: (message, opts) => {
       serverErrors.push({ message, ...(opts ?? {}) })
+    },
+    // #5618 Batch 5b — BOTH clients repoint their persisted tunnel endpoint
+    // (storage is platform-local below the hook). Record (url, previousUrl) so the
+    // contract asserts both apply the same rotation for tunnel_url_changed /
+    // auth_bootstrap.
+    applyRotatedTunnelUrl: (url, previousUrl) => {
+      rotatedTunnelUrls.push({ url, previousUrl })
     },
     // #5618 Batch 4 — multi-client accessors. BOTH clients supply them (the
     // accessor hides where presence state lives — app multi-client store vs
@@ -248,7 +263,7 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   return {
     adapter,
     get result(): AdapterResult {
-      return { sessions, flat, added, callbacks, serverErrors, infoNotifications, switchedSessions }
+      return { sessions, flat, added, callbacks, serverErrors, infoNotifications, switchedSessions, rotatedTunnelUrls }
     },
     setActive: (id: string | null) => {
       activeSessionId = id

--- a/packages/store-core/src/contract-fixtures/contract.test.ts
+++ b/packages/store-core/src/contract-fixtures/contract.test.ts
@@ -70,6 +70,7 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
     expect(result.serverErrors, `${fx.name}: expected no addServerError`).toHaveLength(0)
     expect(result.infoNotifications, `${fx.name}: expected no addInfoNotification`).toHaveLength(0)
     expect(result.switchedSessions, `${fx.name}: expected no switchSession`).toHaveLength(0)
+    expect(result.rotatedTunnelUrls, `${fx.name}: expected no applyRotatedTunnelUrl`).toHaveLength(0)
     // …and every seeded session is untouched beyond its shell: it must carry
     // only the keys it was seeded with (the `{ sessionId, messages }` shell plus
     // the fixture's own `init.sessions[id]` keys). A handler that wrote a NEW
@@ -122,6 +123,9 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
   }
   if (exp.switchedSessions) {
     expect(result.switchedSessions, `${fx.name}: switchedSessions`).toEqual(exp.switchedSessions)
+  }
+  if (exp.rotatedTunnelUrls) {
+    expect(result.rotatedTunnelUrls, `${fx.name}: rotatedTunnelUrls`).toEqual(exp.rotatedTunnelUrls)
   }
 }
 

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -67,7 +67,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'agent_idle',
   // agent_list — migrated to the shared dispatch table (#5618 Batch 2); now has
   // a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
-  'auth_bootstrap',
+  // auth_bootstrap — migrated to the shared dispatch table (#5618 Batch 5b).
   'auth_fail',
   'auth_ok',
   // available_models — migrated to the shared dispatch table (#5618 Batch 5a).
@@ -116,7 +116,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'terminal_output',
   'token_rotated',
   'tool_input_delta',
-  'tunnel_url_changed',
+  // tunnel_url_changed — migrated to the shared dispatch table (#5618 Batch 5b).
   'user_input',
   // user_question — migrated to the shared dispatch table (#5618); now has a
   // DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
@@ -161,10 +161,10 @@ describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
     // migrating types OUT to the shared dispatch table (universe shrinks below
     // the floor) lowers it — adjust both bounds in the same PR. Keep the band
     // TIGHT around the real count so the "fail loudly" intent stays sharp. Band
-    // last set for #5618 Batch 4 (primary_changed / session_role /
-    // client_focus_changed migrated out; universe 55→52).
-    expect(both.length).toBeGreaterThanOrEqual(48)
-    expect(both.length).toBeLessThanOrEqual(58)
+    // last set for #5618 Batch 5b (available_models / cost_update / auth_bootstrap
+    // / tunnel_url_changed migrated out across Batch 5; universe down to ~48).
+    expect(both.length).toBeGreaterThanOrEqual(42)
+    expect(both.length).toBeLessThanOrEqual(54)
   })
 
   it('every both-clients switch type has a fixture or an explicit PENDING entry', () => {

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -104,6 +104,12 @@ export interface FixtureExpectation {
    * identically; an empty array asserts NO switch fired. Omit to "don't care".
    */
   switchedSessions?: string[]
+  /**
+   * Expected `applyRotatedTunnelUrl` invocations (#5618 Batch 5b), in order. Both
+   * clients call it identically; an empty array asserts NO rotation applied. Omit
+   * to "don't care".
+   */
+  rotatedTunnelUrls?: Array<{ url: string; previousUrl: string | null }>
   /** When true, assert NO mutation happened at all (state is untouched). */
   noop?: boolean
 }
@@ -584,6 +590,58 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     init: { activeSessionId: 's1', sessions: { s1: {} } },
     message: { type: 'cost_update', sessionCost: 0.5 },
     expect: { sessions: { s1: { sessionCost: 0.5 } } },
+  },
+
+  // 4i. connect-time burst / tunnel cases (#5618 Batch 5b). tunnel_url_changed's
+  // only effect is the platform-local apply via applyRotatedTunnelUrl (both
+  // clients call it identically). auth_bootstrap writes the shared flat lists
+  // (providers verbatim for well-formed input; the app's mapProviderList +
+  // syncSecondaryInventory extras are out-of-contract) + applies the tunnel URL.
+  {
+    name: 'tunnel_url_changed applies the rotated URL in both clients',
+    type: 'tunnel_url_changed',
+    message: { type: 'tunnel_url_changed', url: 'wss://new.example', previousUrl: 'wss://old.example' },
+    expect: { rotatedTunnelUrls: [{ url: 'wss://new.example', previousUrl: 'wss://old.example' }] },
+  },
+  {
+    name: 'tunnel_url_changed is a no-op when the url is missing/malformed',
+    type: 'tunnel_url_changed',
+    message: { type: 'tunnel_url_changed', url: 'http://not-wss' },
+    expect: { noop: true },
+  },
+  {
+    name: 'auth_bootstrap applies providers + slash/agent lists + the tunnel URL',
+    type: 'auth_bootstrap',
+    message: {
+      type: 'auth_bootstrap',
+      providers: [{ name: 'claude' }],
+      slashCommands: [{ name: '/compact' }],
+      agents: [{ name: 'reviewer' }],
+      tunnelUrl: 'wss://boot.example',
+    },
+    expect: {
+      flat: {
+        availableProviders: [{ name: 'claude' }],
+        slashCommands: [{ name: '/compact' }],
+        customAgents: [{ name: 'reviewer' }],
+      },
+      rotatedTunnelUrls: [{ url: 'wss://boot.example', previousUrl: null }],
+    },
+  },
+  {
+    name: 'auth_bootstrap applies providers but skips slash/agents for a stale session burst',
+    type: 'auth_bootstrap',
+    init: { activeSessionId: 'active' },
+    message: {
+      type: 'auth_bootstrap',
+      sessionId: 'stale',
+      providers: [{ name: 'claude' }],
+      slashCommands: [{ name: '/compact' }],
+      agents: [{ name: 'reviewer' }],
+    },
+    // Providers are server-wide (applied); the session-scoped slash/agent lists
+    // are skipped because the burst's sessionId no longer matches the active one.
+    expect: { flat: { availableProviders: [{ name: 'claude' }] } },
   },
 
   // 4b. budget_resume_ack (#5752) — quiet "nothing to resume" note when the

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -93,6 +93,13 @@ function makeAdapter(init?: {
    * cost_update applies only the shared sessionCost patch (the dashboard).
    */
   costMirror?: boolean
+  /**
+   * When true, the adapter wires `applyRotatedTunnelUrl` (records into
+   * `rotatedTunnelUrls`) — tunnel_url_changed / auth_bootstrap (#5618 Batch 5b).
+   * When omitted, tunnel_url_changed DECLINES; auth_bootstrap still owns via its
+   * shared list writes (the optional-chained tunnel apply is skipped).
+   */
+  tunnel?: boolean
 }) {
   const sessions: Record<string, FakeSession> = init?.sessions ?? {}
   let activeSessionId = init?.activeSessionId ?? null
@@ -108,6 +115,7 @@ function makeAdapter(init?: {
   const switchedSessions: string[] = []
   const primaryClientIds: Array<string | null> = []
   const costUpdates: Array<{ totalCost: number | null; budget: number | null }> = []
+  const rotatedTunnelUrls: Array<{ url: string; previousUrl: string | null }> = []
 
   const adapter: ClientStoreAdapter<FakeSession> = {
     getActiveSessionId: () => activeSessionId,
@@ -165,6 +173,12 @@ function makeAdapter(init?: {
             costUpdates.push({ totalCost, budget }),
         }
       : {}),
+    ...(init?.tunnel
+      ? {
+          applyRotatedTunnelUrl: (url: string, previousUrl: string | null) =>
+            rotatedTunnelUrls.push({ url, previousUrl }),
+        }
+      : {}),
   }
 
   return {
@@ -179,6 +193,7 @@ function makeAdapter(init?: {
     switchedSessions,
     primaryClientIds,
     costUpdates,
+    rotatedTunnelUrls,
     setActive: (id: string | null) => {
       activeSessionId = id
     },
@@ -721,6 +736,71 @@ describe('shared dispatch table', () => {
       dispatch(env, { type: 'cost_update', sessionCost: 0.5 })
       expect(env.sessions.s1.sessionCost).toBe(0.5)
       expect(env.costUpdates).toEqual([{ totalCost: null, budget: null }])
+    })
+  })
+
+  describe('tunnel_url_changed / auth_bootstrap (#5618 Batch 5b)', () => {
+    it('tunnel_url_changed applies the rotated URL when the hook is wired', () => {
+      const env = makeAdapter({ tunnel: true })
+      const handled = dispatch(env, { type: 'tunnel_url_changed', url: 'wss://new.x', previousUrl: 'wss://old.x' })
+      expect(handled).toBe(true)
+      expect(env.rotatedTunnelUrls).toEqual([{ url: 'wss://new.x', previousUrl: 'wss://old.x' }])
+    })
+
+    it('tunnel_url_changed DECLINES (runDispatch false) when applyRotatedTunnelUrl is absent', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'tunnel_url_changed', url: 'wss://new.x' })).toBe(false)
+      expect(env.rotatedTunnelUrls).toEqual([])
+    })
+
+    it('tunnel_url_changed is owned-but-no-op for a malformed (non-wss) url', () => {
+      const env = makeAdapter({ tunnel: true })
+      expect(dispatch(env, { type: 'tunnel_url_changed', url: 'http://nope' })).toBe(true)
+      expect(env.rotatedTunnelUrls).toEqual([])
+    })
+
+    it('auth_bootstrap applies providers + slash/agents + tunnel (app: mapped + mirrored)', () => {
+      const env = makeAdapter({ inventoryHooks: true, tunnel: true })
+      const handled = dispatch(env, {
+        type: 'auth_bootstrap',
+        providers: [{ name: 'claude' }],
+        slashCommands: [{ name: '/compact' }],
+        agents: [{ name: 'reviewer' }],
+        tunnelUrl: 'wss://boot.x',
+      })
+      expect(handled).toBe(true)
+      // app mapProviderList marker proves the hook ran on providers
+      expect(env.flat.availableProviders).toEqual(['__mapped__', { name: 'claude' }])
+      expect(env.flat.slashCommands).toEqual([{ name: '/compact' }])
+      expect(env.flat.customAgents).toEqual([{ name: 'reviewer' }])
+      expect(env.inventorySyncs).toEqual([
+        { kind: 'slashCommands', list: [{ name: '/compact' }] },
+        { kind: 'customAgents', list: [{ name: 'reviewer' }] },
+      ])
+      expect(env.rotatedTunnelUrls).toEqual([{ url: 'wss://boot.x', previousUrl: null }])
+    })
+
+    it('auth_bootstrap writes providers verbatim with no mirror when hooks are absent (dashboard)', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'auth_bootstrap', providers: [{ name: 'claude' }], slashCommands: [{ name: '/x' }], agents: [] })
+      expect(env.flat.availableProviders).toEqual([{ name: 'claude' }])
+      expect(env.flat.slashCommands).toEqual([{ name: '/x' }])
+      expect(env.inventorySyncs).toEqual([])
+      expect(env.rotatedTunnelUrls).toEqual([])
+    })
+
+    it('auth_bootstrap applies providers but SKIPS slash/agents for a stale session burst', () => {
+      const env = makeAdapter({ activeSessionId: 'active' })
+      dispatch(env, {
+        type: 'auth_bootstrap',
+        sessionId: 'stale',
+        providers: [{ name: 'claude' }],
+        slashCommands: [{ name: '/x' }],
+        agents: [{ name: 'a' }],
+      })
+      expect(env.flat.availableProviders).toEqual([{ name: 'claude' }])
+      expect(env.flat.slashCommands).toBeUndefined()
+      expect(env.flat.customAgents).toBeUndefined()
     })
   })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -92,6 +92,9 @@ import {
   // --- models / cost cases (#5618 Batch 5a) ---
   handleAvailableModels,
   handleCostUpdate,
+  // --- connect-time burst / tunnel cases (#5618 Batch 5b) ---
+  handleAuthBootstrap,
+  handleTunnelUrlChanged,
   handleSessionUsage,
   handleSessionContext,
   handleModelChangedPatch,
@@ -399,6 +402,21 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * (the session patch applies regardless), so it never declines.
    */
   setCostUpdate?(totalCost: number | null, budget: number | null): void
+  /**
+   * Repoint the client's persisted tunnel endpoint after a quick-tunnel URL
+   * rotation (#5618 Batch 5b). Used by `tunnel_url_changed` and the
+   * `auth_bootstrap` connect-time burst. The STORAGE is platform-local (mobile:
+   * the SecureStore-backed `SavedConnection.tunnelUrl`; dashboard: the
+   * localStorage server-registry entry's wsUrl), so each client wraps its own
+   * apply — the dashboard additionally consults `previousUrl` to match the right
+   * entry; the app ignores it.
+   *
+   * OPTIONAL: `tunnel_url_changed`'s ONLY effect is this apply, so that handler
+   * DECLINES when the hook is absent (the file-ops / getCallback pattern).
+   * `auth_bootstrap` calls it best-effort (optional-chained) and still OWNS the
+   * message via its shared list writes.
+   */
+  applyRotatedTunnelUrl?(url: string, previousUrl: string | null): void
 }
 
 /**
@@ -593,6 +611,22 @@ export interface DispatchMessageMap {
     // app-only flat/cost-store mirror fields (parsed at the call site).
     totalCost?: number
     budget?: number
+  }
+  // --- connect-time burst / tunnel cases (#5618 Batch 5b) ---
+  // The handlers parse the raw fields defensively; the map only needs `type`
+  // (+ the optional wire fields each parser reads).
+  tunnel_url_changed: {
+    type: 'tunnel_url_changed'
+    url?: string
+    previousUrl?: string
+  }
+  auth_bootstrap: {
+    type: 'auth_bootstrap'
+    sessionId?: string
+    providers?: unknown[]
+    slashCommands?: unknown[]
+    agents?: unknown[]
+    tunnelUrl?: string
   }
   session_usage: {
     type: 'session_usage'
@@ -1294,6 +1328,51 @@ function dispatchCostUpdate<S extends DispatchSessionBase>(
   adapter.setCostUpdate?.(totalCost, budget)
 }
 
+// ---------------------------------------------------------------------------
+// Connect-time burst / tunnel cases (#5618 Batch 5b)
+//
+// tunnel_url_changed's ONLY effect is repointing the persisted tunnel endpoint
+// (platform-local storage) — so it DECLINES without `applyRotatedTunnelUrl`.
+// auth_bootstrap folds the connect-time provider/slash/agent lists into one
+// frame; it reuses the Batch 2 `mapProviderList` / `syncSecondaryInventory` hooks
+// and applies the tunnel URL best-effort, so it always OWNS the message via its
+// shared flat writes.
+// ---------------------------------------------------------------------------
+
+/** `tunnel_url_changed` — repoint the persisted tunnel endpoint (platform-local apply). */
+function dispatchTunnelUrlChanged<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['tunnel_url_changed'],
+  adapter: ClientStoreAdapter<S>,
+): void | false {
+  if (!adapter.applyRotatedTunnelUrl) return false
+  const rotated = handleTunnelUrlChanged(msg as Record<string, unknown>)
+  if (rotated) adapter.applyRotatedTunnelUrl(rotated.url, rotated.previousUrl)
+}
+
+/** `auth_bootstrap` — connect-time burst: tunnel URL + provider/slash/agent lists. */
+function dispatchAuthBootstrap<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['auth_bootstrap'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const boot = handleAuthBootstrap(msg as Record<string, unknown>)
+  // Re-learn a tunnel URL that may have rotated while offline. Applied BEFORE the
+  // session-scope guard so a stale-session burst still refreshes the URL.
+  if (boot.tunnelUrl) adapter.applyRotatedTunnelUrl?.(boot.tunnelUrl, null)
+  // Providers — server-wide, no session guard. The app tightens elements via
+  // mapProviderList; the dashboard writes verbatim (the Batch 2 divergence).
+  const providers = adapter.mapProviderList ? adapter.mapProviderList(boot.providers) : boot.providers
+  adapter.setState({ availableProviders: providers } as Record<string, unknown>)
+  // Slash commands + agents are scoped to the connect-time active session: skip
+  // them (but keep providers) when a session switch already moved off the burst's
+  // sessionId — the post-switch flow re-requests them.
+  const activeId = adapter.getActiveSessionId()
+  if (boot.sessionId && activeId && boot.sessionId !== activeId) return
+  adapter.setState({ slashCommands: boot.slashCommands } as Record<string, unknown>)
+  adapter.syncSecondaryInventory?.('slashCommands', boot.slashCommands)
+  adapter.setState({ customAgents: boot.agents } as Record<string, unknown>)
+  adapter.syncSecondaryInventory?.('customAgents', boot.agents)
+}
+
 /**
  * `notification_prefs` — validate + store the notification-prefs snapshot.
  * Slice-2 RECONCILE: both clients now share `handleNotificationPrefs`. A failed
@@ -1515,6 +1594,9 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     // --- models / cost cases (#5618 Batch 5a) ---
     available_models: dispatchAvailableModels,
     cost_update: dispatchCostUpdate,
+    // --- connect-time burst / tunnel cases (#5618 Batch 5b) ---
+    tunnel_url_changed: dispatchTunnelUrlChanged,
+    auth_bootstrap: dispatchAuthBootstrap,
     session_usage: sessionPatchDispatcher<S>(handleSessionUsage),
     session_context: sessionPatchDispatcher<S>(handleSessionContext),
     model_changed: sessionPatchDispatcher<S>(handleModelChangedPatch),
@@ -1596,6 +1678,9 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   // --- models / cost cases (#5618 Batch 5a) ---
   'available_models',
   'cost_update',
+  // --- connect-time burst / tunnel cases (#5618 Batch 5b) ---
+  'tunnel_url_changed',
+  'auth_bootstrap',
   'session_usage',
   'session_context',
   'session_cost_threshold_crossed',


### PR DESCRIPTION
## Summary

Second slice of **Batch 5** (epic #5618; Batches 1–5a = #6207 / #6209 / #6210 / #6211 / #6212). Migrates `tunnel_url_changed` and the `auth_bootstrap` connect-time burst.

Both share a new optional **`applyRotatedTunnelUrl(url, previousUrl)`** hook — the persistence is platform-local below it (app → SecureStore `SavedConnection.tunnelUrl`; dashboard → the localStorage server-registry entry, consulting `previousUrl` to match). `auth_bootstrap` additionally **reuses the Batch 2 `mapProviderList` + `syncSecondaryInventory` hooks** — high dedup, no new surface for the list application.

| Case | Behaviour |
|------|-----------|
| `tunnel_url_changed` | only effect is the platform-local apply → **DECLINES** when the hook is absent (the `getCallback` pattern); both clients supply it |
| `auth_bootstrap` | tunnel URL (best-effort, before the session guard) → provider list (app tightens via `mapProviderList`, dashboard verbatim) → **session-scope-guarded** slash/agent lists (app mirrors into `useConversationStore`). Always owns via the shared flat writes |

## Scope boundary — `auth_fail` / `server_mode` / `session_timeout` stay KEEP-LOCAL
Re-verified against current main: these are connection-lifecycle coupled — `ctx.socket.close()` + `ctx.silent` + native `Alert` (auth_fail), lifecycle store + viewMode coercion vs flat + alert (server_mode), and `alert` + active→flat-mirror + `switchSession` + `clearPersistedSession` (session_timeout). Their divergence is *what lifecycle side-effects fire*, not *where state lives* — the category the adapter deliberately excludes. Forcing them through one-off `closeSocket`/`alert`/`clearPersistedSession` hooks would bloat the adapter for near-zero shared store mutation. Documented on #5618; this is the migration's natural boundary.

## Verification
- store-core: `npm run typecheck` + full vitest **1783 ✓** — 4 new `DISPATCH_FIXTURES` (tunnel apply + malformed no-op; auth_bootstrap full + stale-session-guard) and 6 new `dispatch-table.test.ts` units (incl. decline-when-absent + the session-scope skip). Lowered the extraction band 48–58 → 42–54 (universe ~48 after Batch 5 migrated 4 types out).
- dashboard: vitest **4032 ✓** — incl. the existing functional `tunnel-url-changed.test.ts` + `auth-ok-handler.test.ts` (auth_bootstrap) suites, which pass unchanged via the dispatch path.
- protocol: **340 ✓**
- app: typecheck ✓ + functional `message-handler.test.ts` (running)

Closes part of #5618.