### PR TITLE
refactor(store-core): move session-overview cost formatter into cost-format

### DIFF
--- a/packages/app/__tests__/ComponentRendering.test.ts
+++ b/packages/app/__tests__/ComponentRendering.test.ts
@@ -275,10 +275,6 @@ describe('SessionOverview component', () => {
     expect(sessionOverviewSrc).toMatch(/crashed.*permission.*attention.*agents.*busy.*idle/)
   })
 
-  test('exports formatCost helper', () => {
-    expect(sessionOverviewSrc).toMatch(/export\s+function\s+formatCost/)
-  })
-
   test('exports getStatusColor helper', () => {
     expect(sessionOverviewSrc).toMatch(/export\s+function\s+getStatusColor/)
   })
@@ -301,7 +297,7 @@ describe('SessionOverview component', () => {
   test('shows cost and budget in header', () => {
     expect(sessionOverviewSrc).toMatch(/totalCost/)
     expect(sessionOverviewSrc).toMatch(/costBudget/)
-    expect(sessionOverviewSrc).toMatch(/formatCost\(totalCost\)/)
+    expect(sessionOverviewSrc).toMatch(/formatCostOverview\(totalCost\)/)
   })
 
   test('displays git branch in session card footer', () => {

--- a/packages/app/src/__tests__/components/SessionOverview.test.ts
+++ b/packages/app/src/__tests__/components/SessionOverview.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { getSessionStatus, formatCost, getStatusColor } from '../../components/SessionOverview';
+import { getSessionStatus, getStatusColor } from '../../components/SessionOverview';
 
 describe('SessionOverview visible prop removal (#1072)', () => {
   const source = fs.readFileSync(
@@ -89,28 +89,6 @@ describe('SessionOverview helpers', () => {
         isPlanPending: false,
         hasNotification: false,
       })).toBe('idle');
-    });
-  });
-
-  describe('formatCost', () => {
-    it('returns "\u2014" for null', () => {
-      expect(formatCost(null)).toBe('\u2014');
-    });
-
-    it('returns "\u2014" for 0', () => {
-      expect(formatCost(0)).toBe('\u2014');
-    });
-
-    it('formats sub-cent amounts as <$0.01', () => {
-      expect(formatCost(0.0042)).toBe('<$0.01');
-    });
-
-    it('formats dollars with 2 decimals', () => {
-      expect(formatCost(1.234)).toBe('$1.23');
-    });
-
-    it('formats large amounts', () => {
-      expect(formatCost(12.5)).toBe('$12.50');
     });
   });
 

--- a/packages/app/src/components/SessionOverview.tsx
+++ b/packages/app/src/components/SessionOverview.tsx
@@ -12,6 +12,7 @@ import {
   Animated,
   type AlertButton,
 } from 'react-native';
+import { formatCostOverview } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 import type { SessionInfo, SessionHealth, SessionState, SessionNotification } from '../store/types';
 import { Icon, type IconName } from './Icon';
@@ -38,13 +39,6 @@ export function getSessionStatus(input: StatusInput): SessionStatus {
   if (input.activeAgentCount > 0) return 'agents';
   if (input.isBusy) return 'busy';
   return 'idle';
-}
-
-/** Format cost for display */
-export function formatCost(cost: number | null): string {
-  if (cost === null || cost === 0) return '\u2014';
-  if (cost > 0 && cost < 0.01) return '<$0.01';
-  return `$${cost.toFixed(2)}`;
 }
 
 /** Get color pair for a session status */
@@ -200,7 +194,7 @@ function SessionCard({ session, sessionState, isActive, hasNotification, notific
         )}
         {sessionState?.sessionCost != null && sessionState.sessionCost > 0 && (
           <Text style={styles.costText}>
-            {formatCost(sessionState.sessionCost)}
+            {formatCostOverview(sessionState.sessionCost)}
           </Text>
         )}
         {sessionState?.sessionContext?.gitBranch && (
@@ -301,7 +295,7 @@ export function SessionOverview({ onClose }: SessionOverviewProps) {
         <View style={styles.headerMeta}>
           {totalCost != null && totalCost > 0 && (
             <Text style={styles.headerCost}>
-              Total: {formatCost(totalCost)}
+              Total: {formatCostOverview(totalCost)}
               {costBudget != null ? ` / $${costBudget.toFixed(0)}` : ''}
             </Text>
           )}

--- a/packages/store-core/src/cost-format.test.ts
+++ b/packages/store-core/src/cost-format.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   formatCostBadge,
+  formatCostOverview,
   formatCostBreakdown,
   formatPartialCostLine,
   formatTokens,
@@ -39,6 +40,28 @@ describe('formatCostBadge (#4123)', () => {
     expect(formatCostBadge(-0.5)).toBe('$0')
     expect(formatCostBadge(NaN)).toBe('$0')
     expect(formatCostBadge(Infinity)).toBe('$0')
+  })
+})
+
+describe('formatCostOverview (#6201)', () => {
+  it('returns "—" (em-dash) for null', () => {
+    expect(formatCostOverview(null)).toBe('—')
+  })
+
+  it('returns "—" (em-dash) for 0', () => {
+    expect(formatCostOverview(0)).toBe('—')
+  })
+
+  it('formats sub-cent amounts as <$0.01', () => {
+    expect(formatCostOverview(0.0042)).toBe('<$0.01')
+  })
+
+  it('formats values with 2 decimals', () => {
+    expect(formatCostOverview(1.234)).toBe('$1.23')
+  })
+
+  it('formats large amounts', () => {
+    expect(formatCostOverview(12.5)).toBe('$12.50')
   })
 })
 

--- a/packages/store-core/src/cost-format.ts
+++ b/packages/store-core/src/cost-format.ts
@@ -35,6 +35,27 @@ export function formatCostBadge(costUsd: number): string {
 }
 
 /**
+ * Format a USD value for the session-overview rows (per-session + total) —
+ * a DETAIL register distinct from `formatCostBadge`. The overview favours a
+ * clean "no spend yet" affordance and a friendly sub-cent label over always
+ * rendering a precise number:
+ *
+ *   `null` / `0`    → '—' (em-dash) — "no cost recorded yet", visually
+ *                     distinct from a real `$0.00`
+ *   `0 < x < $0.01` → '<$0.01' — human-friendly "basically free" label
+ *   `>= $0.01`      → 2 decimals (`$1.23`, `$12.50`)
+ *
+ * Used by the mobile SessionOverview screen. Kept here (not inlined in the
+ * component) so every cost formatter shares one home and the app/dashboard
+ * can't drift on cost display — the reason this module exists (#4123 / #6201).
+ */
+export function formatCostOverview(cost: number | null): string {
+  if (cost === null || cost === 0) return '—'
+  if (cost > 0 && cost < 0.01) return '<$0.01'
+  return `$${cost.toFixed(2)}`
+}
+
+/**
  * #5039: error-path partial-cost snapshot folded onto a server `error`
  * event when the failed turn ran any parent rounds + Task subagent
  * calls before the error fired. Shape returned by `handleError` and

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -220,6 +220,10 @@ export {
 // implementation avoids drift between the two surfaces.
 export {
   formatCostBadge,
+  // #6201: session-overview detail register (em-dash empty-state + "<$0.01"
+  // friendly label), moved out of the app's SessionOverview so all cost
+  // formatters live in this one module.
+  formatCostOverview,
   formatCostBreakdown,
   // #5039: error-path partial-cost helper shared by dashboard toast
   // sub-line and mobile Alert.alert body.


### PR DESCRIPTION
## What

Relocates the app's inline `formatCost` (SessionOverview) into `@chroxy/store-core`'s `cost-format.ts` as `formatCostOverview`, per the **#6201 SOLID/DRY sweep**.

### Scoping note (why this isn't the "delete dup" the epic implied)

The epic listed `formatCost` → `formatCostBadge` as a dedup. Verification showed that's **not accurate**:

- The app **already uses** the canonical `formatCostBadge` for its cost **badge** (`SettingsBar.tsx`).
- `formatCost` is a **different display register** — the SessionOverview *rows* (per-session + total). It deliberately returns em-dash `—` for null/zero ("no cost yet") and `<$0.01`, vs `formatCostBadge`'s `$0` + 3-tier precision.
- It is **single-consumer** (SessionOverview only) and **not duplicated** anywhere.

So folding it into `formatCostBadge` would be a **UX regression** (`—`→`$0`, `<$0.01`→`$0.0042`, `$0.50`→`$0.500`), not a clean dedup. Instead this PR does the **safe, principled move**: `cost-format.ts` exists explicitly to be the single home for cost display "so app + dashboard can't drift" — this register belongs there too, as a sibling of `formatCostBadge` (mirrors the terse/verbose duration pattern from #6214).

## Changes

- **store-core** `cost-format.ts` — add `formatCostOverview` next to `formatCostBadge` (behaviour byte-identical to the app's original); exported from the barrel.
- **app** `SessionOverview.tsx` — import `formatCostOverview` from `@chroxy/store-core`; drop the local `formatCost`; both call sites updated.
- **Tests** — the 5 `formatCost` assertions move into `cost-format.test.ts` as `formatCostOverview`.

**No UX change**: the badge register (`formatCostBadge`) and the overview register (`formatCostOverview`) keep their distinct, intentional formats.

## Verification

- store-core: typecheck clean, **full suite 1804 ✓** (cost-format **29 ✓**, +5 moved tests)
- app: `tsc --noEmit` clean, SessionOverview suite **14 ✓**
- No orphaned `formatCost` references remain in the app.

Related to #6201.