### PR TITLE
refactor(store-core): single-source elapsed-time formatters

### DIFF
--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -25,24 +25,13 @@
  */
 import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { formatDurationTerse, formatToolName } from '@chroxy/store-core';
+import { formatDurationTerse, formatElapsedAgo, formatToolName } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { COLORS } from '../constants/colors';
 
 /** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754 / #3884) */
 const FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
-
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return 'just now';
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  const remS = s % 60;
-  if (m < 60) return remS === 0 ? `${m}m ago` : `${m}m ${remS}s ago`;
-  const h = Math.floor(m / 60);
-  return `${h}h ${m % 60}m ago`;
-}
 
 export function statusColor(elapsedMs: number, timeoutMs: number): string {
   if (elapsedMs >= timeoutMs - 60_000) return COLORS.accentRed500;
@@ -174,7 +163,7 @@ export function ActivityIndicator() {
   // in flight (e.g. waiting on assistant text between tool calls).
   const label = inFlight
     ? `Running ${formatToolName(inFlight.tool, inFlight.serverName)} · ${formatDurationTerse(now - inFlight.startedAt)}`
-    : `Working… last activity ${formatElapsed(elapsed)}`;
+    : `Working… last activity ${formatElapsedAgo(elapsed)}`;
 
   return (
     <View style={styles.container}>

--- a/packages/app/src/components/CheckInChip.tsx
+++ b/packages/app/src/components/CheckInChip.tsx
@@ -15,17 +15,7 @@ import { View, Text, Pressable, StyleSheet, AccessibilityInfo } from 'react-nati
 import { useConnectionStore } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { COLORS } from '../constants/colors';
-
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return 'just now';
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  const remS = s % 60;
-  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`;
-  const h = Math.floor(m / 60);
-  return `${h}h ${m % 60}m`;
-}
+import { formatElapsedSince } from '@chroxy/store-core';
 
 export function CheckInChip() {
   // Each `inactivity_warning` from the server replaces the slot with a
@@ -79,7 +69,7 @@ export function CheckInChip() {
     <View style={styles.container} testID="check-in-chip">
       <View style={styles.dot} />
       <Text style={styles.label} accessibilityElementsHidden importantForAccessibility="no">
-        Agent quiet for {formatElapsed(totalIdle)}
+        Agent quiet for {formatElapsedSince(totalIdle)}
       </Text>
       <Pressable
         accessibilityRole="button"

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -23,7 +23,7 @@
  */
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { formatDurationTerse, formatToolName } from '@chroxy/store-core'
+import { formatDurationTerse, formatElapsedAgo, formatToolName } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
 
 /**
@@ -91,17 +91,6 @@ export function findInFlightToolUse(
 
 /** Fallback default matching the server's BaseSession.DEFAULT_RESULT_TIMEOUT_MS (#3754 / #3884) */
 const FALLBACK_TIMEOUT_MS = 30 * 60 * 1000
-
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return 'just now'
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s ago`
-  const m = Math.floor(s / 60)
-  const remS = s % 60
-  if (m < 60) return remS === 0 ? `${m}m ago` : `${m}m ${remS}s ago`
-  const h = Math.floor(m / 60)
-  return `${h}h ${m % 60}m ago`
-}
 
 // #4308 — duration without the "ago" suffix, used for the "Running X · 12s"
 // label (the named tool is current, not past, so "ago" is wrong). #4510 / #6201
@@ -499,7 +488,7 @@ export function ActivityIndicator() {
   } else if (inFlightTool != null && inFlightStartedAt != null) {
     label = `Running ${formatToolName(inFlightTool, inFlightServerName ?? undefined)} · ${formatDurationTerse(now - inFlightStartedAt)}`
   } else {
-    label = `Working… last activity ${formatElapsed(elapsed)}`
+    label = `Working… last activity ${formatElapsedAgo(elapsed)}`
   }
 
   return (

--- a/packages/dashboard/src/components/CheckInChip.tsx
+++ b/packages/dashboard/src/components/CheckInChip.tsx
@@ -14,17 +14,7 @@
  */
 import { useEffect, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
-
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return 'just now'
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s`
-  const m = Math.floor(s / 60)
-  const remS = s % 60
-  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`
-  const h = Math.floor(m / 60)
-  return `${h}h ${m % 60}m`
-}
+import { formatElapsedSince } from '@chroxy/store-core'
 
 export function CheckInChip() {
   // Each `inactivity_warning` from the server replaces the slot with a
@@ -76,7 +66,7 @@ export function CheckInChip() {
       </span>
       <span className="check-in-chip__dot" aria-hidden="true" />
       <span className="check-in-chip__label" aria-hidden="true">
-        Agent quiet for {formatElapsed(totalIdle)}
+        Agent quiet for {formatElapsedSince(totalIdle)}
       </span>
       <button
         type="button"

--- a/packages/store-core/src/elapsed.test.ts
+++ b/packages/store-core/src/elapsed.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Elapsed / relative-time formatter tests — #6201.
+ *
+ * Pins the two registers consolidated from the app + dashboard copies of
+ * ActivityIndicator (`formatElapsedAgo`) and CheckInChip
+ * (`formatElapsedSince`).
+ */
+import { describe, it, expect } from 'vitest'
+import { formatElapsedSince, formatElapsedAgo } from './elapsed'
+
+describe('formatElapsedSince', () => {
+  it('returns "just now" for sub-second input', () => {
+    expect(formatElapsedSince(0)).toBe('just now')
+    expect(formatElapsedSince(999)).toBe('just now')
+  })
+
+  it('returns Ns for inputs under 60s', () => {
+    expect(formatElapsedSince(1000)).toBe('1s')
+    expect(formatElapsedSince(5000)).toBe('5s')
+    expect(formatElapsedSince(59_000)).toBe('59s')
+  })
+
+  it('returns Nm at exact minute boundaries', () => {
+    expect(formatElapsedSince(60_000)).toBe('1m')
+    expect(formatElapsedSince(120_000)).toBe('2m')
+  })
+
+  it('returns Nm Ns for non-exact minutes under 60m', () => {
+    expect(formatElapsedSince(150_000)).toBe('2m 30s')
+    expect(formatElapsedSince(65_000)).toBe('1m 5s')
+  })
+
+  it('returns Nh Nm at and above one hour', () => {
+    expect(formatElapsedSince(60 * 60_000)).toBe('1h 0m')
+    expect(formatElapsedSince(60 * 60_000 + 5 * 60_000)).toBe('1h 5m')
+  })
+})
+
+describe('formatElapsedAgo', () => {
+  it('returns "just now" (no suffix) for sub-second input', () => {
+    expect(formatElapsedAgo(0)).toBe('just now')
+    expect(formatElapsedAgo(999)).toBe('just now')
+  })
+
+  it('appends " ago" to every non-"just now" branch', () => {
+    expect(formatElapsedAgo(5000)).toBe('5s ago')
+    expect(formatElapsedAgo(60_000)).toBe('1m ago')
+    expect(formatElapsedAgo(150_000)).toBe('2m 30s ago')
+    expect(formatElapsedAgo(60 * 60_000 + 5 * 60_000)).toBe('1h 5m ago')
+  })
+})

--- a/packages/store-core/src/elapsed.ts
+++ b/packages/store-core/src/elapsed.ts
@@ -1,0 +1,43 @@
+/**
+ * Elapsed / relative-time formatters — #6201.
+ *
+ * Two registers for "how long since X", both taking a millisecond delta and
+ * flooring sub-second values to "just now":
+ *   - `formatElapsedSince` — "just now" / "5s" / "2m 30s" / "1h 5m" (terse,
+ *     no suffix) — used by the CheckInChip "Agent quiet for …" copy.
+ *   - `formatElapsedAgo`  — the same, with an " ago" suffix on every
+ *     non-"just now" branch ("5s ago", "2m 30s ago") — used by the
+ *     ActivityIndicator "last activity …" copy.
+ *
+ * Consolidated here (#6201 SOLID/DRY sweep): both forms were inlined
+ * byte-identically in the app AND dashboard copies of ActivityIndicator
+ * (relative) and CheckInChip (terse). Single-sourcing also de-dups the two
+ * registers against each other — `formatElapsedAgo` is `formatElapsedSince`
+ * plus the suffix, so the branch structure lives in exactly one place.
+ *
+ * Distinct from `formatDurationTerse` (./duration), which formats an arbitrary
+ * duration and returns "0s" (not "just now") for sub-second input.
+ */
+
+/**
+ * Terse elapsed form: "just now" under 1s, then "5s" / "2m 30s" / "1h 5m".
+ */
+export function formatElapsedSince(ms: number): string {
+  if (ms < 1000) return 'just now'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const remS = s % 60
+  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
+/**
+ * Relative form: `formatElapsedSince` with an " ago" suffix on every branch
+ * except "just now" ("5s ago", "2m 30s ago", "1h 5m ago").
+ */
+export function formatElapsedAgo(ms: number): string {
+  const since = formatElapsedSince(ms)
+  return since === 'just now' ? since : `${since} ago`
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -243,6 +243,13 @@ export type { ErrorPartialCost } from './cost-format'
 // re-inlining the same two registers.
 export { formatDurationTerse, formatDurationVerbose } from './duration'
 
+// #6201: shared elapsed-time formatters. `formatElapsedAgo` (the fine-grained
+// "Ns ago" form) was duplicated in the app + dashboard ActivityIndicator;
+// `formatElapsedSince` (the no-suffix terse form) in the app + dashboard
+// CheckInChip. Single-sourced here. (Distinct from device-format's coarse
+// `formatRelativeTime`, which does "1 min ago / 2 days ago" for last-seen.)
+export { formatElapsedSince, formatElapsedAgo } from './elapsed'
+
 export type {
   SessionVisualStatus,
   SessionVisualStatusInput,


### PR DESCRIPTION
## What

Consolidates two relative-elapsed formatters into `@chroxy/store-core`, per the **#6201 SOLID/DRY sweep** (shared UI helpers duplicated app+dashboard). Each was inlined **byte-for-byte in both the app and dashboard**:

- **`formatElapsedAgo`** (ms → `"just now"` / `"5s ago"` / `"2m 30s ago"` / `"1h 5m ago"`) — the ActivityIndicator "last activity …" form.
- **`formatElapsedSince`** (same shape, **no** `" ago"` suffix) — the CheckInChip "Agent quiet for …" form.

### Bonus de-dup

The two share structure — `formatElapsedAgo` is literally `formatElapsedSince` plus an `" ago"` suffix on the non-`"just now"` branches — so the new module collapses them onto **one core helper**, not two copies.

### Naming

`formatRelativeTime` was already taken by `device-format.ts` (#4591) — a *coarse* "1 min ago / 2 days ago / 1 yr ago" last-seen formatter. These fine-grained ones are named `formatElapsedAgo` / `formatElapsedSince` to pair cleanly and avoid the collision.

## Changes

- **New** `packages/store-core/src/elapsed.ts` + `elapsed.test.ts` (7 tests); exported from the barrel.
- **app + dashboard `ActivityIndicator`** → import `formatElapsedAgo`; drop local copies.
- **app + dashboard `CheckInChip`** → import `formatElapsedSince`; drop local copies.

### Scope note (why not "unify all formatElapsed")

There are 9 `formatElapsed` definitions, but only these two forms are genuine cross-package dups. The rest are **intentionally distinct** and left untouched: seconds-input (`android-session-notification`), padded two-arg timestamp (`SettingsBar`/`AgentMonitorPanel`), `h:mm:ss` clock (`ActivityTree`), and always-`Nm Ns` (`BackgroundSessionProgress`). A single parameterized helper for all would be flag-soup worse than the duplication.

## Verification (full suites)

- store-core: typecheck clean, **full suite 1811 ✓** (incl. 7 new elapsed tests)
- app: `tsc --noEmit` clean, **full jest 2029 ✓** (153 suites)
- dashboard: typecheck clean, **full suite 4016 ✓** (224 files)
- No bare `formatElapsed(` references remain in the 4 edited components; no source-grep test pins them.

Related to #6201.