### PR TITLE
fix(dashboard,app): clear pending-permission count when answering from chat/banner (#6222)

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -470,7 +470,9 @@ describe('message queue', () => {
     useConnectionStore.getState().sendPermissionResponse('req-a', 'allow');
 
     const after = useConnectionStore.getState().sessionStates;
-    expect(after.s1.messages.find((m) => m.requestId === 'req-a')?.answered).toBe('Allowed');
+    // Canonical decision TOKEN, not a display label — SettingsScreen /
+    // PermissionHistoryScreen tally `m.answered === 'allow' | 'deny' | ...`.
+    expect(after.s1.messages.find((m) => m.requestId === 'req-a')?.answered).toBe('allow');
     expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
 
     // beforeEach does not reset `socket`; clear it so the open mock doesn't bleed

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../store/connection';
 import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
 import { clearAllCallbacks, getCallback } from '../../store/imperative-callbacks';
+import { derivePendingPermissionCounts, totalPendingPermissions } from '@chroxy/store-core';
 import {
   prepareEagerKeyExchange,
   setPendingKeyPair,
@@ -441,6 +442,40 @@ describe('message queue', () => {
     }
     // 11th should fail
     expect(store.sendInput('overflow')).toBe(false);
+  });
+
+  // #6222: answering a permission must clear the shared pending-permission count
+  // (isLivePermissionPrompt keys on m.answered). The cross-session
+  // SessionNotificationBanner calls only sendPermissionResponse, so without the
+  // fix that path left the prompt counted as pending.
+  it('sendPermissionResponse marks the prompt answered so the pending count clears (#6222)', () => {
+    const mockSocket = { readyState: 1, send: () => {} } as unknown as WebSocket;
+    const livePrompt: ChatMessage = {
+      id: 'm1',
+      type: 'prompt',
+      content: 'Allow?',
+      timestamp: 1,
+      requestId: 'req-a',
+      expiresAt: Date.now() + 5 * 60_000,
+    };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [livePrompt] } },
+      socket: mockSocket,
+    });
+
+    const before = useConnectionStore.getState().sessionStates;
+    expect(totalPendingPermissions(derivePendingPermissionCounts(before, Date.now()))).toBe(1);
+
+    useConnectionStore.getState().sendPermissionResponse('req-a', 'allow');
+
+    const after = useConnectionStore.getState().sessionStates;
+    expect(after.s1.messages.find((m) => m.requestId === 'req-a')?.answered).toBe('Allowed');
+    expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
+
+    // beforeEach does not reset `socket`; clear it so the open mock doesn't bleed
+    // into later tests that assume a disconnected socket.
+    useConnectionStore.setState({ socket: null });
   });
 
   it('does not queue excluded message types (setModel)', () => {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1817,10 +1817,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // derivation (`isLivePermissionPrompt` keys on `m.answered`) clears. Without
     // this, answering from the cross-session SessionNotificationBanner (which
     // calls only sendPermissionResponse) left the prompt counted as pending. The
-    // SessionScreen path marks answered with a richer summary AFTER this call, so
-    // it still wins there; this makes sendPermissionResponse the single choke
-    // point that clears the count for every caller (idempotent on the others).
-    get().markPromptAnsweredByRequestId(requestId, decision === 'deny' ? 'Denied' : 'Allowed');
+    // SessionScreen path marks answered with the same decision AFTER this call.
+    // Store the canonical decision TOKEN ('allow' | 'deny' | 'allowSession'), not
+    // a display label — SettingsScreen/PermissionHistoryScreen tally
+    // `m.answered === 'allow' | 'allowAlways' | 'allowSession' | 'deny'`.
+    get().markPromptAnsweredByRequestId(requestId, decision);
     // Auto-switch to the session that owns this prompt (if different from active).
     // Prefer sessionNotifications lookup (covers prompts stored before sessionStates[sid] existed),
     // fall back to scanning sessionStates messages.

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1813,6 +1813,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (wireDecision === 'deny') hapticWarning(); else hapticMedium();
     wsSend(socket, payload);
     const result: 'sent' | 'queued' | false = 'sent';
+    // #6222: mark the prompt ChatMessage `answered` so the shared pending-count
+    // derivation (`isLivePermissionPrompt` keys on `m.answered`) clears. Without
+    // this, answering from the cross-session SessionNotificationBanner (which
+    // calls only sendPermissionResponse) left the prompt counted as pending. The
+    // SessionScreen path marks answered with a richer summary AFTER this call, so
+    // it still wins there; this makes sendPermissionResponse the single choke
+    // point that clears the count for every caller (idempotent on the others).
+    get().markPromptAnsweredByRequestId(requestId, decision === 'deny' ? 'Denied' : 'Allowed');
     // Auto-switch to the session that owns this prompt (if different from active).
     // Prefer sessionNotifications lookup (covers prompts stored before sessionStates[sid] existed),
     // fall back to scanning sessionStates messages.

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -559,7 +559,6 @@ export function App() {
   // re-render unrelated chrome.
   const markSessionNotificationRead = useConnectionStore(s => s.markSessionNotificationRead)
   const markAllSessionNotificationsRead = useConnectionStore(s => s.markAllSessionNotificationsRead)
-  const markPromptAnsweredByRequestId = useConnectionStore(s => s.markPromptAnsweredByRequestId)
   const conversationHistory = useConnectionStore(s => s.conversationHistory)
   const fetchConversationHistory = useConnectionStore(s => s.fetchConversationHistory)
   const resumeConversation = useConnectionStore(s => s.resumeConversation)
@@ -1674,17 +1673,23 @@ export function App() {
     return result
   }, [sendUserQuestionResponse])
 
+  // #6222/#6224: respondToPermission (sendPermissionResponse) now marks the
+  // prompt answered with the canonical decision token itself — only when the
+  // answer actually went over the wire (after the disconnected-socket guard).
+  // The previous explicit markPromptAnsweredByRequestId(requestId, 'Allowed')
+  // here was both wrong-format (a display label, not the 'allow'/'deny' token
+  // consumers expect) and unconditional (it ran even when the send was refused
+  // while disconnected, falsely clearing the prompt). Dropped in favour of the
+  // single choke point.
   const handleBannerApprove = useCallback((requestId: string, notificationId: string) => {
     respondToPermission(requestId, 'allow')
-    markPromptAnsweredByRequestId(requestId, 'Allowed')
     dismissSessionNotification(notificationId)
-  }, [respondToPermission, markPromptAnsweredByRequestId, dismissSessionNotification])
+  }, [respondToPermission, dismissSessionNotification])
 
   const handleBannerDeny = useCallback((requestId: string, notificationId: string) => {
     respondToPermission(requestId, 'deny')
-    markPromptAnsweredByRequestId(requestId, 'Denied')
     dismissSessionNotification(notificationId)
-  }, [respondToPermission, markPromptAnsweredByRequestId, dismissSessionNotification])
+  }, [respondToPermission, dismissSessionNotification])
 
   // Retry reconnects to the *active* server (remote registry entry or local),
   // not unconditionally to local — see retryConnection / #5284.

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2947,12 +2947,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // derivation (`isLivePermissionPrompt` keys on `m.answered`). Without this,
     // answering a permission FROM THE CHAT STREAM (the inline PermissionPrompt,
     // which calls only sendPermissionResponse) left the "N pending" header
-    // indicator (#5667) and the dock badge (#6184) stuck. The banner and
-    // AskUserQuestion paths already call markPromptAnswered*, so this makes
+    // indicator (#5667) and the dock badge (#6184) stuck. This makes
     // sendPermissionResponse the single choke point that clears the count for
-    // every caller (the banner's own call becomes idempotent). Additive to the
+    // every caller. Store the canonical decision TOKEN ('allow' | 'deny' |
+    // 'allowSession'), not a display label — consumers treat `m.answered` as a
+    // decision enum (App.tsx's hasPendingAskUserQuestionPermission gate checks
+    // `=== 'allow' | 'allowSession'`; PermissionPrompt/ChildAgentEventList map
+    // the token to an "Allowed"/"Denied" label for display). Additive to the
     // bubble — PermissionPrompt reads answered from resolvedPermissions, not this.
-    get().markPromptAnsweredByRequestId(requestId, decision === 'deny' ? 'Denied' : 'Allowed');
+    get().markPromptAnsweredByRequestId(requestId, decision);
     // Auto-switch to the session that owns this prompt (if different from active).
     // Prefer sessionNotifications lookup (covers prompts stored before sessionStates[sid] existed),
     // fall back to scanning sessionStates messages.

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2941,6 +2941,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // Persist the decision in the store so PermissionPrompt renders its
     // answered state across remounts (#2833 — tab switch regression).
     get().markPermissionResolved(requestId, decision);
+    // #6222: also mark the prompt ChatMessage `answered`. markPermissionResolved
+    // only records the decision in the `resolvedPermissions` map — which flips
+    // the bubble's answered UI but is NOT consulted by the shared pending-count
+    // derivation (`isLivePermissionPrompt` keys on `m.answered`). Without this,
+    // answering a permission FROM THE CHAT STREAM (the inline PermissionPrompt,
+    // which calls only sendPermissionResponse) left the "N pending" header
+    // indicator (#5667) and the dock badge (#6184) stuck. The banner and
+    // AskUserQuestion paths already call markPromptAnswered*, so this makes
+    // sendPermissionResponse the single choke point that clears the count for
+    // every caller (the banner's own call becomes idempotent). Additive to the
+    // bubble — PermissionPrompt reads answered from resolvedPermissions, not this.
+    get().markPromptAnsweredByRequestId(requestId, decision === 'deny' ? 'Denied' : 'Allowed');
     // Auto-switch to the session that owns this prompt (if different from active).
     // Prefer sessionNotifications lookup (covers prompts stored before sessionStates[sid] existed),
     // fall back to scanning sessionStates messages.

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1621,10 +1621,12 @@ describe('sendPermissionResponse clears pending-permission count (#6222)', () =>
     // separate markPromptAnswered call, exactly what PermissionPrompt does).
     useConnectionStore.getState().sendPermissionResponse('req-a', 'allow');
 
-    // After: the prompt is marked answered and the count clears.
+    // After: the prompt is marked answered with the canonical decision TOKEN
+    // (not a display label — consumers treat `answered` as a decision enum) and
+    // the count clears.
     const after = useConnectionStore.getState().sessionStates;
     const prompt = after.s1!.messages.find((m) => m.requestId === 'req-a');
-    expect(prompt?.answered).toBe('Allowed');
+    expect(prompt?.answered).toBe('allow');
     expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
   });
 
@@ -1644,7 +1646,7 @@ describe('sendPermissionResponse clears pending-permission count (#6222)', () =>
 
     const after = useConnectionStore.getState().sessionStates;
     const prompt = after.s1!.messages.find((m) => m.requestId === 'req-a');
-    expect(prompt?.answered).toBe('Denied');
+    expect(prompt?.answered).toBe('deny');
     expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
   });
 
@@ -1668,7 +1670,7 @@ describe('sendPermissionResponse clears pending-permission count (#6222)', () =>
     useConnectionStore.getState().sendPermissionResponse('req-b', 'allow');
 
     const after = useConnectionStore.getState().sessionStates;
-    expect(after.s2!.messages.find((m) => m.requestId === 'req-b')?.answered).toBe('Allowed');
+    expect(after.s2!.messages.find((m) => m.requestId === 'req-b')?.answered).toBe('allow');
     expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
   });
 });

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1580,6 +1580,100 @@ describe('permission response auto-switch', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #6222 — answering a permission clears the pending-permission count
+// ---------------------------------------------------------------------------
+describe('sendPermissionResponse clears pending-permission count (#6222)', () => {
+  const futureExpiry = () => Date.now() + 5 * 60_000;
+
+  const makeLivePrompt = (id: string, reqId: string) => ({
+    id,
+    type: 'prompt' as const,
+    content: 'Allow?',
+    timestamp: 1,
+    requestId: reqId,
+    // requestId + future expiresAt are what make isLivePermissionPrompt count it
+    // as a live *permission* prompt (vs an AskUserQuestion, which carries neither).
+    expiresAt: futureExpiry(),
+  });
+
+  afterEach(async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({ sessions: [], activeSessionId: null, sessionStates: {}, socket: null });
+  });
+
+  it('marks the prompt answered so derivePendingPermissionCounts drops to 0 (inline chat Allow path)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { derivePendingPermissionCounts, totalPendingPermissions } = await import('@chroxy/store-core');
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [makeLivePrompt('m1', 'req-a')] },
+      },
+      socket: { readyState: 1, send: () => {} } as unknown as WebSocket,
+    });
+
+    // Before: one live pending permission.
+    const before = useConnectionStore.getState().sessionStates;
+    expect(totalPendingPermissions(derivePendingPermissionCounts(before, Date.now()))).toBe(1);
+
+    // Answer it via the inline-chat path (sendPermissionResponse only — no
+    // separate markPromptAnswered call, exactly what PermissionPrompt does).
+    useConnectionStore.getState().sendPermissionResponse('req-a', 'allow');
+
+    // After: the prompt is marked answered and the count clears.
+    const after = useConnectionStore.getState().sessionStates;
+    const prompt = after.s1!.messages.find((m) => m.requestId === 'req-a');
+    expect(prompt?.answered).toBe('Allowed');
+    expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
+  });
+
+  it('records a denial as the answered decision (deny path)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { derivePendingPermissionCounts, totalPendingPermissions } = await import('@chroxy/store-core');
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [makeLivePrompt('m1', 'req-a')] },
+      },
+      socket: { readyState: 1, send: () => {} } as unknown as WebSocket,
+    });
+
+    useConnectionStore.getState().sendPermissionResponse('req-a', 'deny');
+
+    const after = useConnectionStore.getState().sessionStates;
+    const prompt = after.s1!.messages.find((m) => m.requestId === 'req-a');
+    expect(prompt?.answered).toBe('Denied');
+    expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
+  });
+
+  it('clears a prompt owned by a background (non-active) session', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { derivePendingPermissionCounts, totalPendingPermissions } = await import('@chroxy/store-core');
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [] },
+        s2: { ...createEmptySessionState(), messages: [makeLivePrompt('m2', 'req-b')] },
+      },
+      socket: { readyState: 1, send: () => {} } as unknown as WebSocket,
+    });
+
+    expect(
+      totalPendingPermissions(derivePendingPermissionCounts(useConnectionStore.getState().sessionStates, Date.now())),
+    ).toBe(1);
+
+    useConnectionStore.getState().sendPermissionResponse('req-b', 'allow');
+
+    const after = useConnectionStore.getState().sessionStates;
+    expect(after.s2!.messages.find((m) => m.requestId === 'req-b')?.answered).toBe('Allowed');
+    expect(totalPendingPermissions(derivePendingPermissionCounts(after, Date.now()))).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Resolved-permission persistence + Allow for Session (#2833, #2834)
 // ---------------------------------------------------------------------------
 describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {


### PR DESCRIPTION
## Summary

Answering a permission prompt **from the chat message stream** (the inline `PermissionPrompt`) or the **cross-session `SessionNotificationBanner`** did not clear the "⚠ N pending" header indicator (#5667) or the desktop dock badge (#6184). The action went through (e.g. the file was written) but the counter stayed stuck.

Fixes #6222.

## Root cause

The pending-permission count is single-sourced in `@chroxy/store-core` (`isLivePermissionPrompt`), which keys on `m.answered`. Three UI paths answer a permission, but only two set `m.answered`:

| Path | Marked answered? |
|------|------------------|
| Cross-session banner (dashboard `App.tsx` → `markPromptAnsweredByRequestId`) | ✅ |
| AskUserQuestion (`useMessageRenderer` → `markPromptAnswered`) | ✅ |
| **Inline chat `PermissionPrompt`** (→ `sendPermissionResponse` only) | ❌ |
| **Mobile `SessionNotificationBanner`** (→ `sendPermissionResponse` only) | ❌ |

`sendPermissionResponse` only recorded the decision in the dashboard's `resolvedPermissions` map, which flips the *bubble*'s answered UI but is **not** consulted by the count derivation. So inline/banner answers left `m.answered` undefined → the prompt stayed counted → header + dock badge stuck.

## Fix

Make `sendPermissionResponse` the single choke point that also marks the prompt `answered` (dashboard **and** app). Every caller now clears the count; the callers that already marked answered (banner, SessionScreen) become idempotent — and SessionScreen's richer summary still wins because it marks answered *after* this call.

Additive to the bubble: `PermissionPrompt` reads its answered state from `resolvedPermissions`, not `m.answered`, so rendering is unchanged.

## Tests

- **dashboard** (`store.test.ts`, +3): inline-Allow clears `derivePendingPermissionCounts`→0 and sets `answered:'Allowed'`; deny sets `'Denied'`; a background (non-active) session's prompt clears too.
- **app** (`connection.test.ts`, +1): `sendPermissionResponse` marks the prompt answered and the pending count drops to 0.
- Full suites green: dashboard `4019 passed`, app `2030 passed`.

## Verification

Reproduced live in CLI mode pre-fix (Write prompt → Allow → file created but header stuck at "1 pending" indefinitely). Post-fix verified via the running desktop app (screenshots) — see PR thread.