### PR TITLE
perf(dashboard): dedupe cross-session pending-permission derivation (#6225)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -235,10 +235,6 @@ export function App() {
   // Listen for Tauri desktop events (no-op in browser context)
   useTauriEvents()
 
-  // #6184: mirror the cross-session blocked+failed count on the desktop dock
-  // badge (no-op in a plain browser tab).
-  useTrayBadgeSync()
-
   // Voice input mode is persisted on inputSettings (#4785). Default is
   // 'continuous' — click to start, click to stop, mic stays lit across
   // silence gaps. Pre-#4785 behaviour ('auto-pause' on silence) available
@@ -1197,6 +1193,11 @@ export function App() {
   // the total and one click to reach the next waiting session (cyclically, in
   // visual tab order).
   const pendingPermissionTotal = totalPendingPermissions(pendingPermissionCounts)
+  // #6184/#6225: mirror the cross-session "needs me" count on the desktop dock
+  // badge (no-op in a plain browser tab). Reuses the pending total derived above
+  // for the header indicator so we don't scan every session's messages twice;
+  // the badge adds crashed-session count on top (failed slice, inside the hook).
+  useTrayBadgeSync(pendingPermissionTotal)
   const handleJumpToPending = useCallback(() => {
     const orderedIds = sessionTabs.map(t => t.sessionId)
     const next = selectNextPendingSession(orderedIds, pendingPermissionCounts, activeSessionId)

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
@@ -15,14 +15,16 @@ vi.mock('../utils/tauri-bridge', () => ({
 
 import { useTrayBadgeSync } from './useTrayBadgeSync'
 
-function Harness() {
-  useTrayBadgeSync()
+// BLOCKED is passed in by the caller (#6225 — App reuses its header pending
+// derivation); FAILED is read from the store's activity rollup inside the hook.
+function Harness({ blocked }: { blocked: number }) {
+  useTrayBadgeSync(blocked)
   return null
 }
 
 // Build an ActivityState where each sessionId maps to a single entry of the
 // given status (enough for deriveSessionStatus → the rollup). FAILED sessions
-// here drive the badge's `failed` slice (best-effort activity rollup).
+// here drive the badge's `failed` slice.
 function activityOf(map: Record<string, 'running' | 'blocked' | 'failed'>) {
   const bySession: Record<string, { byId: Record<string, unknown>; order: string[] }> = {}
   for (const [sid, status] of Object.entries(map)) {
@@ -35,36 +37,11 @@ function activityOf(map: Record<string, 'running' | 'blocked' | 'failed'>) {
   return { bySession }
 }
 
-// Build sessionStates carrying N live (unanswered, future-expiry) permission
-// prompts per session. This is what now drives the badge's `blocked` slice —
-// the SAME pending-permission derivation that powers the header "N pending"
-// indicator (#6184 fix), not the activity-tree `blocked` status.
-function sessionStatesWith(map: Record<string, number>) {
-  const out: Record<string, { messages: unknown[] }> = {}
-  for (const [sid, n] of Object.entries(map)) {
-    const messages: unknown[] = []
-    for (let i = 0; i < n; i++) {
-      messages.push({
-        id: `${sid}-p${i}`,
-        type: 'prompt',
-        content: 'Allow?',
-        timestamp: 1,
-        requestId: `${sid}-r${i}`,
-        expiresAt: Date.now() + 5 * 60_000,
-      })
-    }
-    out[sid] = { messages }
-  }
-  return out
-}
-
 function setStore(opts: {
-  pending?: Record<string, number>
   activity?: ReturnType<typeof activityOf>
   sessions?: Array<{ sessionId: string; cwd?: string | null; name?: string }>
 }) {
   storeState = {
-    sessionStates: sessionStatesWith(opts.pending ?? {}),
     activity: opts.activity ?? { bySession: {} },
     sessions: opts.sessions ?? [],
   }
@@ -77,53 +54,49 @@ describe('useTrayBadgeSync (#6184)', () => {
   })
   afterEach(() => cleanup())
 
-  it('invokes update_tray_badge with blocked (pending permissions) + failed counts', () => {
+  it('invokes update_tray_badge with the passed-in blocked + derived failed counts', () => {
     setStore({
-      pending: { s1: 1 },
       activity: activityOf({ s2: 'failed', s3: 'running' }),
       sessions: [{ sessionId: 's2', cwd: '/r' }, { sessionId: 's3', cwd: '/r' }],
     })
-    render(<Harness />)
+    render(<Harness blocked={1} />)
     expect(invokeSpy).toHaveBeenCalledTimes(1)
     expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 1, failed: 1 })
   })
 
-  it('counts every pending permission across sessions for blocked', () => {
-    setStore({ pending: { s1: 2, s2: 1 } })
-    render(<Harness />)
+  it('passes the blocked count through verbatim', () => {
+    setStore({})
+    render(<Harness blocked={3} />)
     expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 3, failed: 0 })
   })
 
   it('is a no-op outside Tauri (getTauriInvoke null)', () => {
     invokeImpl = null
-    setStore({ pending: { s1: 1 } })
-    render(<Harness />)
+    setStore({})
+    render(<Harness blocked={1} />)
     expect(invokeSpy).not.toHaveBeenCalled()
   })
 
   it('reports zero counts when nothing is pending/failed', () => {
     setStore({ activity: activityOf({ s1: 'running' }), sessions: [{ sessionId: 's1', cwd: '/r' }] })
-    render(<Harness />)
+    render(<Harness blocked={0} />)
     expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
   })
 
   it('does not re-invoke when the count is unchanged across re-renders (deduped)', () => {
-    setStore({ pending: { s1: 1 } })
-    const { rerender } = render(<Harness />)
+    setStore({})
+    const { rerender } = render(<Harness blocked={1} />)
     expect(invokeSpy).toHaveBeenCalledTimes(1)
-    // Re-render with NEW object refs but the SAME blocked/failed totals.
-    setStore({ pending: { s1: 1 } })
-    rerender(<Harness />)
+    setStore({})
+    rerender(<Harness blocked={1} />)
     expect(invokeSpy).toHaveBeenCalledTimes(1) // deduped — count didn't change
   })
 
-  it('re-invokes when the count changes (e.g. a permission is answered)', () => {
-    setStore({ pending: { s1: 1 } })
-    const { rerender } = render(<Harness />)
+  it('re-invokes when the blocked count changes (e.g. a permission is answered)', () => {
+    setStore({})
+    const { rerender } = render(<Harness blocked={1} />)
     expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 1, failed: 0 })
-    // The prompt is answered → no live pending permission remains → badge clears.
-    setStore({ pending: {} })
-    rerender(<Harness />)
+    rerender(<Harness blocked={0} />)
     expect(invokeSpy).toHaveBeenCalledTimes(2)
     expect(invokeSpy).toHaveBeenLastCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
   })

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.test.tsx
@@ -83,13 +83,16 @@ describe('useTrayBadgeSync (#6184)', () => {
     expect(invokeSpy).toHaveBeenCalledWith('update_tray_badge', { blocked: 0, failed: 0 })
   })
 
-  it('does not re-invoke when the count is unchanged across re-renders (deduped)', () => {
+  it('does not re-invoke when blocked + failed are unchanged across re-renders', () => {
     setStore({})
     const { rerender } = render(<Harness blocked={1} />)
     expect(invokeSpy).toHaveBeenCalledTimes(1)
     setStore({})
     rerender(<Harness blocked={1} />)
-    expect(invokeSpy).toHaveBeenCalledTimes(1) // deduped — count didn't change
+    // No second invoke: the effect's [blocked, failed] deps are unchanged so the
+    // effect doesn't re-run (and the lastSentRef key-guard would suppress a
+    // duplicate anyway if it did, e.g. under StrictMode's double-invoke).
+    expect(invokeSpy).toHaveBeenCalledTimes(1)
   })
 
   it('re-invokes when the blocked count changes (e.g. a permission is answered)', () => {

--- a/packages/dashboard/src/hooks/useTrayBadgeSync.ts
+++ b/packages/dashboard/src/hooks/useTrayBadgeSync.ts
@@ -2,16 +2,14 @@
  * useTrayBadgeSync (#6184, Control Room v2 phase 2 / #5964) — reflect the
  * cross-session "needs me" count on the desktop dock badge.
  *
- * Data source (#6184 fix, 2026-06-21): the BLOCKED count is the cross-session
- * pending-permission total — the SAME signal that drives the header "N pending"
- * indicator (`derivePendingPermissionCounts` → `totalPendingPermissions` over
- * `sessionStates`). The original implementation read the Control Room
- * activity-tree `blocked` status (`selectCrossSessionActivity().total.blocked`),
- * but that slice does not reliably carry a `blocked` entry for a live permission
- * prompt, so the dock badge never lit up even with prompts pending. The
- * pending-permission derivation is proven to fire (it powers the visible
- * "N pending" header), so the badge now keys off it. FAILED/crashed sessions
- * still come from the activity rollup (best-effort).
+ * BLOCKED is passed in by the caller (#6225). App already derives the
+ * cross-session pending-permission total for the header "N pending" indicator
+ * (`derivePendingPermissionCounts` → `totalPendingPermissions`), so the badge
+ * reuses that single derivation rather than scanning every session's message
+ * array a second time. The badge is `blocked + failed`, where FAILED is the
+ * activity-rollup crashed-session count (best-effort, still derived here). The
+ * header indicator is blocked-only, so the two match exactly only when nothing
+ * is failed.
  *
  * Pushes `blocked + failed` to the Tauri `update_tray_badge` command, which sets
  * the macOS dock-tile badge (Tauri v2's tray icon has no badge API; the dock
@@ -19,36 +17,16 @@
  * no-op. Deduped: the command is invoked only when the count actually changes.
  */
 import { useEffect, useRef } from 'react'
-import {
-  selectCrossSessionActivity,
-  derivePendingPermissionCounts,
-  totalPendingPermissions,
-} from '@chroxy/store-core'
+import { selectCrossSessionActivity } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
 import { getTauriInvoke } from '../utils/tauri-bridge'
 
-export function useTrayBadgeSync(): void {
-  // Compute the counts as REACTIVE selectors (recomputed on every store change,
-  // like the header "N pending" indicator) rather than inside an effect keyed on
-  // a store-slice reference. The permission-resolution update does not reliably
-  // change the `sessionStates` reference, so an effect dep'd on it never re-fired
-  // to push `blocked:0` — leaving the dock badge stuck (#6184). Selecting the
-  // derived numbers fixes the clear path: the effect below fires whenever the
-  // numbers change, including back to zero.
-  // BLOCKED = cross-session pending permissions (the signal that drives "N pending").
-  // The dock badge is `blocked + failed`, whereas the header "N pending"
-  // indicator (App.tsx) is blocked-only — they read the SAME blocked expression
-  // (so the pending portion never drifts) but the badge additionally surfaces
-  // crashed sessions, so the two match exactly only when nothing is failed.
-  // These run at RENDER time (not in the effect), so they must be total over a
-  // partially-populated store — an undefined `sessionStates`/`activity`/`sessions`
-  // during an early/transient render must not throw and white-screen the
-  // dashboard. `for..in` over undefined is a safe no-op, but the activity
-  // selector dereferences `state.bySession`, so default it explicitly.
-  const blocked = useConnectionStore((s) =>
-    totalPendingPermissions(derivePendingPermissionCounts(s.sessionStates ?? {}, Date.now())),
-  )
-  // FAILED = activity-rollup failed sessions (best-effort).
+export function useTrayBadgeSync(blocked: number): void {
+  // FAILED = activity-rollup failed sessions (best-effort). This runs at RENDER
+  // time, so it must be total over a partially-populated store — an undefined
+  // `activity`/`sessions` on an early/transient render must not throw and
+  // white-screen the dashboard (selectCrossSessionActivity dereferences
+  // `state.bySession`), so default them at the call site.
   const failed = useConnectionStore(
     (s) =>
       selectCrossSessionActivity(


### PR DESCRIPTION
## Summary

`useTrayBadgeSync` re-derived `derivePendingPermissionCounts` over every session's message array even though `App.tsx` already computes the same cross-session total for the header "N pending" indicator — two full scans per relevant store update (flagged in #6187 review).

Fixes #6225.

## Change

- `useTrayBadgeSync(blocked: number)` now takes the blocked total as a param instead of re-deriving it. The badge still derives its `failed` slice from the activity rollup inside the hook.
- `App.tsx` passes the `pendingPermissionTotal` it already computes (line ~1199) into the hook; the hook call moves below that computation.
- Net: the cross-session pending scan runs **once** per store update, shared by the header indicator and the dock badge.

## Behavior

Zero behavior change — `App` derives the total exactly as before (same `derivePendingPermissionCounts` + `useShallow`), the badge just reuses it. The render-time `failed` selector keeps its defensive defaults.

## Tests

- `useTrayBadgeSync.test.tsx` updated for the `blocked` param signature (set/clear, passthrough, dedup, no-op-outside-Tauri, failed-from-store).
- Full dashboard suite green (4025), typecheck clean.