### PR TITLE
fix(dashboard): horizontally scroll Control Room tab strip with edge chevrons (#6218)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -347,10 +347,16 @@ describe('ControlRoomView auto-fetch on activation (#5543)', () => {
       const tablist = screen.getByTestId('cr-tabs')
       const scrollBy = vi.fn()
       ;(tablist as unknown as { scrollBy: typeof scrollBy }).scrollBy = scrollBy
-      Object.defineProperty(tablist, 'clientWidth', { value: 300, configurable: true })
-      fireEvent.click(screen.getByTestId('cr-tabs-chevron-right'))
+      // Put the strip into an overflowing state first so the right chevron is
+      // actually visible (not pointer-events:none) — a realistic click.
+      setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 0 })
+      fireEvent.scroll(tablist)
+      const right = screen.getByTestId('cr-tabs-chevron-right')
+      expect(right.className).not.toContain('cr-tab-chevron-hidden')
+      fireEvent.click(right)
       expect(scrollBy).toHaveBeenCalledWith(expect.objectContaining({ left: expect.any(Number), behavior: 'smooth' }))
-      expect(scrollBy.mock.calls[0]![0].left).toBeGreaterThan(0)
+      // ~70% of the 300px viewport, scrolling right (positive delta).
+      expect(scrollBy.mock.calls[0]![0].left).toBeCloseTo(210, 0)
     })
   })
 })

--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -308,4 +308,49 @@ describe('ControlRoomView auto-fetch on activation (#5543)', () => {
     expect(requestRunnerStatusMock).not.toHaveBeenCalled()
     expect(requestIntegrationStatusMock).not.toHaveBeenCalled()
   })
+
+  // #6218 — the tab strip scrolls horizontally with edge-chevron affordances.
+  // jsdom has no layout, so we simulate the scroll geometry on the tablist.
+  describe('#6218 overflow scroll + chevrons', () => {
+    function setGeometry(el: HTMLElement, g: { clientWidth: number; scrollWidth: number; scrollLeft: number }) {
+      Object.defineProperty(el, 'clientWidth', { value: g.clientWidth, configurable: true })
+      Object.defineProperty(el, 'scrollWidth', { value: g.scrollWidth, configurable: true })
+      Object.defineProperty(el, 'scrollLeft', { value: g.scrollLeft, writable: true, configurable: true })
+    }
+
+    it('renders both edge chevrons, hidden when the strip is not overflowing', () => {
+      render(<ControlRoomView />)
+      expect(screen.getByTestId('cr-tabs-chevron-left').className).toContain('cr-tab-chevron-hidden')
+      expect(screen.getByTestId('cr-tabs-chevron-right').className).toContain('cr-tab-chevron-hidden')
+    })
+
+    it('shows the right chevron when content is clipped to the right (at the start)', () => {
+      render(<ControlRoomView />)
+      const tablist = screen.getByTestId('cr-tabs')
+      setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 0 })
+      fireEvent.scroll(tablist)
+      expect(screen.getByTestId('cr-tabs-chevron-right').className).not.toContain('cr-tab-chevron-hidden')
+      expect(screen.getByTestId('cr-tabs-chevron-left').className).toContain('cr-tab-chevron-hidden')
+    })
+
+    it('shows the left chevron (and hides the right) once scrolled to the end', () => {
+      render(<ControlRoomView />)
+      const tablist = screen.getByTestId('cr-tabs')
+      setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 600 })
+      fireEvent.scroll(tablist)
+      expect(screen.getByTestId('cr-tabs-chevron-left').className).not.toContain('cr-tab-chevron-hidden')
+      expect(screen.getByTestId('cr-tabs-chevron-right').className).toContain('cr-tab-chevron-hidden')
+    })
+
+    it('clicking the right chevron scrolls the strip to the right', () => {
+      render(<ControlRoomView />)
+      const tablist = screen.getByTestId('cr-tabs')
+      const scrollBy = vi.fn()
+      ;(tablist as unknown as { scrollBy: typeof scrollBy }).scrollBy = scrollBy
+      Object.defineProperty(tablist, 'clientWidth', { value: 300, configurable: true })
+      fireEvent.click(screen.getByTestId('cr-tabs-chevron-right'))
+      expect(scrollBy).toHaveBeenCalledWith(expect.objectContaining({ left: expect.any(Number), behavior: 'smooth' }))
+      expect(scrollBy.mock.calls[0]![0].left).toBeGreaterThan(0)
+    })
+  })
 })

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -460,7 +460,11 @@ export function ControlRoomView({
     if (!el) return
     const { scrollLeft, scrollWidth, clientWidth } = el
     // 1px slack absorbs sub-pixel rounding so a fully-scrolled edge reads as 0.
-    setScrollState({ left: scrollLeft > 1, right: scrollLeft + clientWidth < scrollWidth - 1 })
+    const left = scrollLeft > 1
+    const right = scrollLeft + clientWidth < scrollWidth - 1
+    // Bail when nothing changed — scroll/ResizeObserver fire on every tick, so
+    // returning the previous object skips a re-render unless the booleans flip.
+    setScrollState((prev) => (prev.left === left && prev.right === right ? prev : { left, right }))
   }, [])
   useEffect(() => {
     const el = tablistRef.current

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -448,9 +448,72 @@ export function ControlRoomView({
     request()
   }, [connected, descriptor, request, loading, snapshot])
 
+  // #6218: the tab strip has more tabs than fit at common widths, so it scrolls
+  // horizontally with edge-chevron affordances. `scrollState` tracks whether
+  // there's clipped content on either side (so the chevrons only show when they
+  // do something); recomputed on scroll, on resize (ResizeObserver), and after
+  // the tab set changes.
+  const tablistRef = useRef<HTMLDivElement>(null)
+  const [scrollState, setScrollState] = useState<{ left: boolean; right: boolean }>({ left: false, right: false })
+  const updateScrollAffordance = useCallback(() => {
+    const el = tablistRef.current
+    if (!el) return
+    const { scrollLeft, scrollWidth, clientWidth } = el
+    // 1px slack absorbs sub-pixel rounding so a fully-scrolled edge reads as 0.
+    setScrollState({ left: scrollLeft > 1, right: scrollLeft + clientWidth < scrollWidth - 1 })
+  }, [])
+  useEffect(() => {
+    const el = tablistRef.current
+    if (!el) return
+    updateScrollAffordance()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(updateScrollAffordance)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [updateScrollAffordance])
+  const scrollTabs = useCallback((dir: -1 | 1) => {
+    const el = tablistRef.current
+    if (!el) return
+    // Scroll by ~70% of the visible width so a click reveals a fresh page of
+    // tabs while keeping one for context. Optional-call: jsdom doesn't implement
+    // scrollBy, and a missing scroll method must not throw.
+    el.scrollBy?.({ left: dir * el.clientWidth * 0.7, behavior: 'smooth' })
+  }, [])
+  // Keep the active tab visible when it changes programmatically (deep-link,
+  // forceTab, ArrowLeft/Right roving) — scroll it into view within the strip
+  // only (inline:'nearest' won't scroll the page vertically).
+  useEffect(() => {
+    const el = tablistRef.current
+    if (!el) return
+    const active = el.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]')
+    // Optional-call: jsdom doesn't implement scrollIntoView; a missing method
+    // must not throw during render.
+    active?.scrollIntoView?.({ inline: 'nearest', block: 'nearest' })
+    updateScrollAffordance()
+  }, [tab, updateScrollAffordance])
+
   return (
     <div className="cr-view" data-testid="control-room-view">
-      <div className="cr-tabs" role="tablist" aria-label="Control Room sections" data-testid="cr-tabs">
+      <div className="cr-tabs-wrap">
+        <button
+          type="button"
+          className={`cr-tab-chevron cr-tab-chevron-left${scrollState.left ? '' : ' cr-tab-chevron-hidden'}`}
+          aria-label="Scroll tabs left"
+          aria-hidden={!scrollState.left}
+          tabIndex={-1}
+          data-testid="cr-tabs-chevron-left"
+          onClick={() => scrollTabs(-1)}
+        >
+          ‹
+        </button>
+        <div
+          className="cr-tabs"
+          role="tablist"
+          aria-label="Control Room sections"
+          data-testid="cr-tabs"
+          ref={tablistRef}
+          onScroll={updateScrollAffordance}
+        >
         {CONTROL_ROOM_TABS.map((t, i) => {
           const active = tab === t.key
           return (
@@ -485,6 +548,18 @@ export function ControlRoomView({
             </button>
           )
         })}
+        </div>
+        <button
+          type="button"
+          className={`cr-tab-chevron cr-tab-chevron-right${scrollState.right ? '' : ' cr-tab-chevron-hidden'}`}
+          aria-label="Scroll tabs right"
+          aria-hidden={!scrollState.right}
+          tabIndex={-1}
+          data-testid="cr-tabs-chevron-right"
+          onClick={() => scrollTabs(1)}
+        >
+          ›
+        </button>
       </div>
       {tab === 'repos' ? (
         <ControlRoomSection onInvestigate={onInvestigate} onOpenSession={onOpenSession} onConfigureRepo={onConfigureRepo} />

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9453,9 +9453,13 @@ button.sidebar-token-view-session-row:hover {
   display: flex;
   flex-wrap: nowrap;
   gap: 4px;
-  padding: 10px 28px 0;
+  /* Horizontal padding (40px) must exceed the 36px chevron width so the
+     first/last tab never sits under a visible chevron (#6218 review). */
+  padding: 10px 40px 0;
   overflow-x: auto;
   scroll-behavior: smooth;
+  /* Keep a tab clear of the chevrons when scrolled into view. */
+  scroll-padding-inline: 40px;
   /* Hide the native scrollbar — the chevrons + trackpad are the affordance. */
   scrollbar-width: none; /* Firefox */
 }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9437,14 +9437,30 @@ button.sidebar-token-view-session-row:hover {
   min-height: 0;
 }
 
-.cr-tabs {
-  display: flex;
-  gap: 4px;
-  padding: 10px 28px 0;
+/* #6218 — the tab strip overflows at common widths (many Control Room tabs),
+   so it scrolls horizontally. The wrapper owns the centred max-width + the
+   full-width underline and positions the edge chevrons; the inner .cr-tabs is
+   the scroll viewport. */
+.cr-tabs-wrap {
+  position: relative;
   max-width: 1100px;
   width: 100%;
   margin: 0 auto;
   border-bottom: 1px solid var(--border-secondary);
+}
+
+.cr-tabs {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 4px;
+  padding: 10px 28px 0;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  /* Hide the native scrollbar — the chevrons + trackpad are the affordance. */
+  scrollbar-width: none; /* Firefox */
+}
+.cr-tabs::-webkit-scrollbar {
+  display: none; /* WebKit/Chromium */
 }
 
 .cr-tab {
@@ -9458,6 +9474,48 @@ button.sidebar-token-view-session-row:hover {
   font-weight: 600;
   cursor: pointer;
   margin-bottom: -1px;
+  /* Don't shrink/wrap — keep natural width so the row overflows (and scrolls)
+     instead of compressing labels (#6218). */
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+/* #6218 — edge chevrons. Absolutely positioned so showing/hiding them never
+   shifts the tab layout; a gradient fade keeps them legible over tabs. */
+.cr-tab-chevron {
+  position: absolute;
+  top: 0;
+  bottom: 1px;
+  width: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 20px;
+  line-height: 1;
+  z-index: 2;
+  transition: opacity 0.12s ease;
+}
+.cr-tab-chevron:hover {
+  color: var(--text-primary);
+}
+.cr-tab-chevron-left {
+  left: 0;
+  justify-content: flex-start;
+  padding-left: 6px;
+  background: linear-gradient(to right, var(--bg-secondary) 55%, transparent);
+}
+.cr-tab-chevron-right {
+  right: 0;
+  justify-content: flex-end;
+  padding-right: 6px;
+  background: linear-gradient(to left, var(--bg-secondary) 55%, transparent);
+}
+.cr-tab-chevron-hidden {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .cr-tab:hover {


### PR DESCRIPTION
## Summary

The Control Room top tab row (Status, Runners, Containers, BYOK Pool, Host prune, Device runtimes, Integrations, Skills, Mailbox, Mission control, Settings…) has more tabs than fit at common window widths, so several were rendered **offscreen with no way to reach them** — the row neither scrolled nor wrapped.

Closes #6218.

## Change

- `.cr-tabs` is now a horizontal scroll viewport (`overflow-x:auto`, `flex-wrap:nowrap`, native scrollbar hidden); tabs are `flex:0 0 auto` so the row overflows instead of compressing labels.
- A new `.cr-tabs-wrap` owns the centred max-width + full-width underline and positions **edge chevrons** (`‹` / `›`) that:
  - appear only when there's clipped content on that side (`scrollState` from `scrollLeft`/`scrollWidth`/`clientWidth`, recomputed on scroll + `ResizeObserver`),
  - scroll the row ~70% of the viewport on click,
  - are absolutely positioned with a gradient fade, so showing/hiding them causes **no layout shift**.
- The active tab is scrolled into view (`scrollIntoView({inline:'nearest'})`) whenever it changes programmatically (deep-link, `forceTab`, ArrowLeft/Right roving).
- `scrollIntoView`/`scrollBy` are optional-chained (jsdom doesn't implement them).

## Acceptance

- [x] Overflowing tab row scrolls horizontally (wheel/trackpad + drag).
- [x] Edge chevron(s) appear when content is clipped and scroll on click.
- [x] Active tab auto-scrolls into view when selected programmatically.
- [x] No layout shift (chevrons absolutely positioned); labels never clipped (no shrink/wrap).

## Tests

`ControlRoomView.test.tsx` +4: chevrons hidden when not overflowing; right chevron shows when clipped-right; left shows (right hides) at the end; clicking scrolls. Geometry simulated (jsdom has no layout). Full dashboard suite green (4029), typecheck clean.