### PR TITLE
fix(server): default Opus 4.8, remove + disallow Fable in model registry (#6219)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -228,7 +228,7 @@ export class ClaudeByokSession extends BaseSession {
   /**
    * @param {object} [opts]
    * @param {string} [opts.cwd]            Working directory for tool execution.
-   * @param {string} [opts.model]          Anthropic model id; falls back to `claude-opus-4-7`.
+   * @param {string} [opts.model]          Anthropic model id; falls back to `claude-opus-4-8`.
    * @param {string} [opts.mcpConfigPath]  Path to a Claude-style MCP config (default: `~/.claude.json` or `$CHROXY_CLAUDE_CONFIG`).
    *   Canonical name (#4449). Only the `mcpServers` block is read — the rest of the
    *   file is ignored. A previous `opts.claudeConfigPath` alias was removed because
@@ -405,7 +405,7 @@ export class ClaudeByokSession extends BaseSession {
   // table — no fork, no re-implementation of the streaming + tool +
   // permission + MCP machinery.
   get _defaultModel() {
-    return 'claude-opus-4-7'
+    return 'claude-opus-4-8'
   }
 
   _resolveCredentials() {

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -143,10 +143,17 @@ const MODEL_METADATA = Object.freeze([
 // The `[1m]` variant is also matched. Exported for tests + future enforcement.
 export const DISALLOWED_MODEL_IDS = Object.freeze(new Set(['claude-fable-5']))
 
-/** True when a model id (with or without a trailing `[1m]`) is a disallowed fullId. */
+/**
+ * True when a model id resolves to a disallowed fullId, normalising the same id
+ * shapes the rest of this module supports: a trailing `[1m]` long-context suffix
+ * and/or a trailing `-YYYYMMDD` date stamp (the SDK's `Model` enum surfaces dated
+ * forms like `claude-fable-5-20251201`). So `claude-fable-5`, `claude-fable-5[1m]`,
+ * `claude-fable-5-20251201`, and `claude-fable-5-20251201[1m]` all match.
+ */
 export function isDisallowedModelId(id) {
   if (typeof id !== 'string') return false
-  const base = id.endsWith('[1m]') ? id.slice(0, -'[1m]'.length) : id
+  let base = id.endsWith('[1m]') ? id.slice(0, -'[1m]'.length) : id
+  base = base.replace(/-\d{8}$/, '') // strip a trailing YYYYMMDD date stamp
   return DISALLOWED_MODEL_IDS.has(base)
 }
 
@@ -781,7 +788,22 @@ export function createModelsRegistry(hooks = {}) {
       ? models.filter((m) => !isDisallowedModelId(m.id) && !isDisallowedModelId(m.fullId))
       : models
     activeModels = filtered
-    defaultModelId = nextDefault
+    // #6219 review (#6232): never leave defaultModelId pointing at a model that
+    // isn't in the active list — e.g. the SDK marked the now-filtered disallowed
+    // model (fable) as "Default", so nextDefault is its short id which isn't in
+    // `filtered`. A dangling default can't be resolved by the picker. When
+    // nextDefault is absent from the filtered list, re-pick a stable family head
+    // (opus → sonnet) else the first model (mirrors updateModels' fallback). Only
+    // fires when filtering actually dropped the chosen default — a present
+    // nextDefault (the common case + loadCache's own discard result) is kept.
+    const defaultPresent =
+      nextDefault != null && filtered.some((m) => m.id === nextDefault || m.fullId === nextDefault)
+    if (nextDefault != null && !defaultPresent) {
+      const preferred = filtered.find((m) => m.id === 'opus' || m.id === 'sonnet')
+      defaultModelId = preferred?.id ?? filtered[0]?.id ?? null
+    } else {
+      defaultModelId = nextDefault
+    }
     rebuildLookups(filtered)
   }
 

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -109,7 +109,7 @@ const MODEL_METADATA = Object.freeze([
     pricing: { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
   }),
   Object.freeze({
-    shortId: 'opus', label: 'Opus', fullId: 'claude-opus-4-7',
+    shortId: 'opus', label: 'Opus', fullId: 'claude-opus-4-8',
     pricing: { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
     // #4087 — long-context (>200K input) premium tier. Below the 200K
     // threshold the rates match the base entry; above it the published premium
@@ -124,18 +124,31 @@ const MODEL_METADATA = Object.freeze([
       },
     },
   }),
-  // Fable falls through to the 200k DEFAULT_CONTEXT_WINDOW heuristic on purpose
-  // — the SDK's authoritative modelUsage.contextWindow ratchets it after the
-  // first turn; we don't invent a fable window here. No `pricing` block: chroxy
-  // doesn't ship unverified fable rates, so it costs "unknown" (null), not $0.
-  Object.freeze({
-    shortId: 'fable', label: 'Fable', fullId: 'claude-fable-5',
-  }),
+  // #6219 — Fable (claude-fable-5) is disallowed for chroxy and removed from the
+  // roster. It is also filtered out of any SDK-returned list (DISALLOWED_MODEL_IDS
+  // below) so it can't reappear in SDK/TUI modes, not just the CLI fallback.
   Object.freeze({
     shortId: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5',
     pricing: { input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 },
   }),
 ])
+
+// #6219 — fullIds chroxy disallows regardless of source: the CLI fallback (gone
+// already, removed from MODEL_METADATA), the Agent SDK's supportedModels() push,
+// the disk cache, AND a user models-overlay.json. Fable (claude-fable-5) is
+// currently the only one. Keyed on the FULL id (not the short `fable` alias) so
+// the precise disallowed model is dropped without false-positiving an unrelated
+// overlay/SDK entry that merely uses `fable` as a short label. The short alias
+// can't resurface anyway — it only ever resolved to claude-fable-5, now removed.
+// The `[1m]` variant is also matched. Exported for tests + future enforcement.
+export const DISALLOWED_MODEL_IDS = Object.freeze(new Set(['claude-fable-5']))
+
+/** True when a model id (with or without a trailing `[1m]`) is a disallowed fullId. */
+export function isDisallowedModelId(id) {
+  if (typeof id !== 'string') return false
+  const base = id.endsWith('[1m]') ? id.slice(0, -'[1m]'.length) : id
+  return DISALLOWED_MODEL_IDS.has(base)
+}
 
 // Freeze a pricing block (incl. the nested longContext premium) IN PLACE so the
 // derived CLAUDE_PRICING_USD_PER_MTOK keeps the deep-frozen contract callers
@@ -669,6 +682,8 @@ export function createModelsRegistry(hooks = {}) {
     const overriddenBase = []
     const baseByFullId = new Map(baseFallbackModels.map((m) => [m.fullId, m]))
     for (const entry of overlayMap.values()) {
+      // #6219 — an overlay must not reintroduce a disallowed model (e.g. fable).
+      if (isDisallowedModelId(entry.shortId) || isDisallowedModelId(entry.fullId)) continue
       const baseRow = baseByFullId.get(entry.fullId)
       if (baseRow) {
         // Override the base row's label/window from the overlay when supplied.
@@ -758,9 +773,16 @@ export function createModelsRegistry(hooks = {}) {
   }
 
   function applyModels(models, nextDefault) {
-    activeModels = models
+    // #6219 — strip disallowed models (fable) from ANY source funnelled through
+    // here (SDK updateModels(), disk loadCache()), so they can't appear in
+    // SDK/TUI modes. Skip the allocation when nothing is disallowed (the common
+    // case). The CLI fallback is already clean (removed from MODEL_METADATA).
+    const filtered = models.some((m) => isDisallowedModelId(m.id) || isDisallowedModelId(m.fullId))
+      ? models.filter((m) => !isDisallowedModelId(m.id) && !isDisallowedModelId(m.fullId))
+      : models
+    activeModels = filtered
     defaultModelId = nextDefault
-    rebuildLookups(models)
+    rebuildLookups(filtered)
   }
 
   function snapshotString() {

--- a/packages/server/src/prompt-evaluator.js
+++ b/packages/server/src/prompt-evaluator.js
@@ -26,8 +26,8 @@ const log = createLogger('prompt-evaluator')
 // opus because the evaluator's job is to catch things a cheaper session model
 // would miss — using a less capable evaluator defeats the point of the feature.
 // Kept in sync with the canonical Opus id used elsewhere in the server
-// (see packages/server/src/models.js — `claude-opus-4-7`).
-const DEFAULT_MODEL = 'claude-opus-4-7'
+// (see packages/server/src/models.js — `claude-opus-4-8`).
+const DEFAULT_MODEL = 'claude-opus-4-8'
 
 // Cap the response so a runaway evaluator can't burn the whole context window
 // on its 'reasoning' field.
@@ -163,7 +163,7 @@ export function _resetSkipPatternCache() {
  * @param {object} args
  * @param {string} args.draft - The user's draft message (required, non-empty)
  * @param {string} [args.cwd] - Session cwd, included in the user prompt for context
- * @param {string} [args.model] - Anthropic model id (default: claude-opus-4-7
+ * @param {string} [args.model] - Anthropic model id (default: claude-opus-4-8
  *   or value of CHROXY_EVALUATOR_MODEL)
  * @param {string} [args.apiKey] - Anthropic API key (default: ANTHROPIC_API_KEY env)
  * @param {object} [args.client] - Test seam: pre-built Anthropic client (skips

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -174,14 +174,14 @@ describe('ClaudeByokSession', () => {
 
   describe('start()', () => {
     it('emits ready with model + empty tools when credentials present', async () => {
-      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-8' })
       const captured = captureEvents(session)
       // Inject a stub client BEFORE start to skip the real Anthropic constructor.
       session._client = { messages: { stream: () => fakeStream([]) } }
       await session.start()
       const ready = captured.find((e) => e.name === 'ready')
       assert.ok(ready, 'ready event must fire')
-      assert.equal(ready.payload.model, 'claude-opus-4-7')
+      assert.equal(ready.payload.model, 'claude-opus-4-8')
       assert.deepEqual(ready.payload.tools, [])
       await session.destroy()
     })
@@ -224,7 +224,7 @@ describe('ClaudeByokSession', () => {
       }))
       const session = new ClaudeByokSession({
         cwd: '/tmp',
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
         mcpConfigPath: configPath,
       })
       const captured = captureEvents(session)
@@ -491,7 +491,7 @@ describe('ClaudeByokSession', () => {
         messages: {
           stream: () =>
             fakeStream([
-              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-7' } },
+              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-8' } },
               { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
               { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } },
               { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: ', world' } },
@@ -539,11 +539,11 @@ describe('ClaudeByokSession', () => {
       // typeof === 'number' gate. Omitting it silently disables BYOK cost
       // accounting (#4056, blocks #4054).
       assert.equal(typeof results[0].payload.cost, 'number')
-      // Opus 4.7 default: 5 input * $15/Mtok + 4 output * $75/Mtok
+      // Opus 4.8 default: 5 input * $15/Mtok + 4 output * $75/Mtok
       //   = 0.000075 + 0.000300 = 0.000375 USD
       assert.ok(
         Math.abs(results[0].payload.cost - 0.000375) < 1e-9,
-        `expected cost ~= 0.000375 for 5in/4out on opus-4-7, got ${results[0].payload.cost}`,
+        `expected cost ~= 0.000375 for 5in/4out on opus-4-8, got ${results[0].payload.cost}`,
       )
       await session.destroy()
     })
@@ -586,7 +586,7 @@ describe('ClaudeByokSession', () => {
       // Accumulated usage: 10+7 input, 20+3 output.
       assert.equal(results[0].payload.usage.input_tokens, 17)
       assert.equal(results[0].payload.usage.output_tokens, 23)
-      // Accumulated cost (Opus 4.7): (17 * 15 + 23 * 75) / 1e6 = 0.001980
+      // Accumulated cost (Opus 4.8): (17 * 15 + 23 * 75) / 1e6 = 0.001980
       assert.ok(
         Math.abs(results[0].payload.cost - 0.001980) < 1e-9,
         `expected cost ~= 0.001980, got ${results[0].payload.cost}`,
@@ -655,7 +655,7 @@ describe('ClaudeByokSession', () => {
     it('resolves dated full model ids to family pricing (#4084)', async () => {
       // A user pinning to a dated revision must still get a non-zero
       // cost, not the silent cost: 0 + warn that pre-fix produced.
-      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7-20251201' })
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-8-20251201' })
       session._client = {
         messages: {
           stream: () =>
@@ -671,7 +671,7 @@ describe('ClaudeByokSession', () => {
       await session.sendMessage('q')
       const result = captured.find((e) => e.name === 'result')
       assert.ok(result)
-      // Same math as the canonical happy-path test (5in/4out on opus-4-7
+      // Same math as the canonical happy-path test (5in/4out on opus-4-8
       // = 0.000375 USD). Same numeric expectation proves the family
       // resolution worked.
       assert.ok(Math.abs(result.payload.cost - 0.000375) < 1e-9,
@@ -717,7 +717,7 @@ describe('ClaudeByokSession', () => {
           stream: () =>
             fakeStream(
               [
-                { type: 'message_start', message: { id: 'msg', model: 'claude-opus-4-7' } },
+                { type: 'message_start', message: { id: 'msg', model: 'claude-opus-4-8' } },
                 { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'response' } },
                 { type: 'message_stop' },
               ],
@@ -1173,7 +1173,7 @@ describe('ClaudeByokSession', () => {
         messages: {
           stream: () =>
             fakeStream([
-              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-7' } },
+              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-8' } },
               { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_42', name: 'Read', input: {} } },
               { type: 'content_block_stop', index: 0 },
               { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 1, output_tokens: 1 } },
@@ -1262,7 +1262,7 @@ describe('ClaudeByokSession', () => {
             round += 1
             if (round === 1) {
               return fakeStream([
-                { type: 'message_start', message: { id: 'msg_turn_1', model: 'claude-opus-4-7' } },
+                { type: 'message_start', message: { id: 'msg_turn_1', model: 'claude-opus-4-8' } },
                 { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu_01aaa', name: 'Read', input: {} } },
                 { type: 'content_block_stop', index: 0 },
                 { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'toolu_02bbb', name: 'Bash', input: {} } },
@@ -1279,7 +1279,7 @@ describe('ClaudeByokSession', () => {
               })
             }
             return fakeStream([
-              { type: 'message_start', message: { id: 'msg_turn_2', model: 'claude-opus-4-7' } },
+              { type: 'message_start', message: { id: 'msg_turn_2', model: 'claude-opus-4-8' } },
               { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
               { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'done' } },
               { type: 'content_block_stop', index: 0 },
@@ -1335,7 +1335,7 @@ describe('ClaudeByokSession', () => {
         messages: {
           stream: () =>
             fakeStream([
-              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-7' } },
+              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-8' } },
               // No `id` on the content_block — translator emits toolUseId: undefined.
               { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', name: 'Read', input: {} } },
               { type: 'content_block_stop', index: 0 },
@@ -1540,7 +1540,7 @@ describe('ClaudeByokSession', () => {
         messages: {
           stream: () =>
             fakeStream([
-              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-7' } },
+              { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-8' } },
               { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_42', name: 'Read', input: {} } },
               { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"file_pa' } },
               { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: 'th":"/tm' } },
@@ -1776,7 +1776,7 @@ describe('ClaudeByokSession', () => {
             if (callCount === 1) {
               return fakeStream(
                 [
-                  { type: 'message_start', message: { id: 'msg', model: 'claude-opus-4-7' } },
+                  { type: 'message_start', message: { id: 'msg', model: 'claude-opus-4-8' } },
                   { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu_1', name: 'Read', input: {} } },
                   { type: 'message_delta', delta: { stop_reason: 'tool_use' } },
                   { type: 'message_stop' },
@@ -3291,7 +3291,7 @@ describe('ClaudeByokSession', () => {
     })
 
     it('attributes child usage + cost into the parent turn result', async () => {
-      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-8' })
       session.setPermissionMode('auto')
       const captured = captureEvents(session)
       setupParentEmittingTaskOnce(session, {
@@ -3310,7 +3310,7 @@ describe('ClaudeByokSession', () => {
       // Total: 1007in/507out
       assert.equal(result.payload.usage.input_tokens, 1007, 'child input tokens fold into parent total')
       assert.equal(result.payload.usage.output_tokens, 507, 'child output tokens fold into parent total')
-      // Cost (Opus 4.7): (1007 * 15 + 507 * 75) / 1e6
+      // Cost (Opus 4.8): (1007 * 15 + 507 * 75) / 1e6
       const expectedCost = (1007 * 15 + 507 * 75) / 1e6
       assert.ok(Math.abs(result.payload.cost - expectedCost) < 1e-9,
         `expected cost ~= ${expectedCost}, got ${result.payload.cost}`)
@@ -3325,7 +3325,7 @@ describe('ClaudeByokSession', () => {
       //
       // Pre-#5020: error event carried only { code, message } — child cost
       // was silently dropped at _finishTurn reset.
-      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-8' })
       session.setPermissionMode('auto')
       const captured = captureEvents(session)
       let parentRound = 0
@@ -3386,7 +3386,7 @@ describe('ClaudeByokSession', () => {
         'parent round-1 input + child input fold into error event')
       assert.equal(streamErr.payload.usage.output_tokens, 810,
         'parent round-1 output + child output fold into error event')
-      // Cost (Opus 4.7): (2010 * 15 + 810 * 75) / 1e6
+      // Cost (Opus 4.8): (2010 * 15 + 810 * 75) / 1e6
       const expectedCost = (2010 * 15 + 810 * 75) / 1e6
       assert.ok(typeof streamErr.payload.cost === 'number',
         'STREAM_ERROR must carry partial cost')
@@ -4445,7 +4445,7 @@ describe('ClaudeByokSession', () => {
     })
 
     it('setModel updates without restart (stateless SDK client)', async () => {
-      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-8' })
       session._client = { messages: { stream: () => fakeStream([]) } }
       await session.start()
       session.setModel('claude-sonnet-4-6')
@@ -4459,7 +4459,7 @@ describe('ClaudeByokSession', () => {
       // BUT MCP trust prompts MUST NOT persist via the bypass — they
       // get denied so ~/.chroxy/mcp-trust.json stays untouched.
       const { existsSync, readFileSync } = await import('node:fs')
-      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-8' })
       session._client = { messages: { stream: () => fakeStream([]) } }
       await session.start()
 

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -154,7 +154,7 @@ describe('EventNormalizer', () => {
           cwd: '/tmp',
         }),
       })
-      const result = normalizer.normalize('ready', { model: 'claude-opus-4-7' }, ctx)
+      const result = normalizer.normalize('ready', { model: 'claude-opus-4-8' }, ctx)
       assert.equal(result.messages[1].msg.type, 'model_changed')
       assert.equal(result.messages[1].msg.model, 'opus')
     })
@@ -167,14 +167,14 @@ describe('EventNormalizer', () => {
           cwd: '/tmp',
         }),
       })
-      const result = normalizer.normalize('ready', { model: 'claude-opus-4-7' }, ctx)
+      const result = normalizer.normalize('ready', { model: 'claude-opus-4-8' }, ctx)
       assert.equal(result.messages[1].msg.model, 'opus')
     })
 
     it('falls back to bootedModel when data.model is missing (early ready emit)', () => {
       const ctx = makeCtx({
         getSessionEntry: () => ({
-          session: { model: null, bootedModel: 'claude-opus-4-7', permissionMode: 'approve' },
+          session: { model: null, bootedModel: 'claude-opus-4-8', permissionMode: 'approve' },
           name: 'Test',
           cwd: '/tmp',
         }),
@@ -204,7 +204,7 @@ describe('EventNormalizer', () => {
     it('prefers session.model over bootedModel when both are set and data.model is missing', () => {
       const ctx = makeCtx({
         getSessionEntry: () => ({
-          session: { model: 'claude-opus-4-7', bootedModel: 'claude-sonnet-4-6', permissionMode: 'approve' },
+          session: { model: 'claude-opus-4-8', bootedModel: 'claude-sonnet-4-6', permissionMode: 'approve' },
           name: 'Test',
           cwd: '/tmp',
         }),

--- a/packages/server/tests/models-factory.test.js
+++ b/packages/server/tests/models-factory.test.js
@@ -77,7 +77,7 @@ describe('createModelsRegistry', () => {
       { value: 'claude-sonnet-4', displayName: 'Sonnet', description: '' },
     ])
     // opus is always merged from FALLBACK_MODELS, so it wins the preference.
-    assert.equal(registry.getDefaultModelId(), 'opus-4-7')
+    assert.equal(registry.getDefaultModelId(), 'opus-4-8') // #6219 — opus head 4-7 → 4-8
   })
 
   it('picks the first converted entry when no opus/sonnet family is present (#5631)', () => {
@@ -225,7 +225,7 @@ describe('disk cache (loadCache / saveCache)', () => {
     const r1 = createModelsRegistry()
     r1.updateModels([
       { value: 'claude-sonnet-4-6', displayName: 'Default (Sonnet 4.6)', description: '' },
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
     const r1Models = r1.getModels()
     assert.equal(r1.saveCache(cachePath), true)
@@ -266,7 +266,7 @@ describe('disk cache (loadCache / saveCache)', () => {
     writeFileSync(cachePath, JSON.stringify({
       models: [
         { id: 'sonnet' }, // missing fullId
-        { fullId: 'claude-opus-4-7' }, // missing id
+        { fullId: 'claude-opus-4-8' }, // missing id
         { id: 42, fullId: 'claude-x' }, // wrong type
       ],
     }))
@@ -277,12 +277,12 @@ describe('disk cache (loadCache / saveCache)', () => {
   it('loadCache re-hydrates missing label/contextWindow on valid entries', () => {
     writeFileSync(cachePath, JSON.stringify({
       models: [
-        { id: 'opus-4-7', fullId: 'claude-opus-4-7' }, // no label, no contextWindow
+        { id: 'opus-4-8', fullId: 'claude-opus-4-8' }, // no label, no contextWindow
       ],
     }))
     const r = createModelsRegistry()
     assert.equal(r.loadCache(cachePath), true)
-    assert.equal(r.getModels()[0].label, 'Opus 4.7')
+    assert.equal(r.getModels()[0].label, 'Opus 4.8')
     assert.equal(r.getModels()[0].contextWindow, 1_000_000)
   })
 
@@ -302,7 +302,7 @@ describe('disk cache (loadCache / saveCache)', () => {
     writeFileSync(cachePath, JSON.stringify({
       models: [
         { id: 'opus-4-6', fullId: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 1_000_000 }, // retired
-        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+        { id: 'opus-4-8', fullId: 'claude-opus-4-8', label: 'Opus 4.8', contextWindow: 1_000_000 },
         { id: 'sonnet-4-6', fullId: 'claude-sonnet-4-6', label: 'Sonnet 4.6', contextWindow: 200_000 },
       ],
       defaultModelId: 'sonnet-4-6',
@@ -311,7 +311,7 @@ describe('disk cache (loadCache / saveCache)', () => {
     assert.equal(r.loadCache(cachePath), true)
     const loaded = r.getModels().map(m => m.fullId)
     assert.ok(!loaded.includes('claude-opus-4-6'), `retired claude-opus-4-6 should be dropped, got ${loaded.join(',')}`)
-    assert.ok(loaded.includes('claude-opus-4-7'), 'current claude-opus-4-7 should be kept')
+    assert.ok(loaded.includes('claude-opus-4-8'), 'current claude-opus-4-8 should be kept')
     assert.ok(loaded.includes('claude-sonnet-4-6'), 'current claude-sonnet-4-6 should be kept')
     // FALLBACK_MODELS includes haiku-4-5 — it should be merged in even though
     // the cache didn't have it, so the picker always has the canonical aliases.
@@ -336,22 +336,22 @@ describe('disk cache (loadCache / saveCache)', () => {
   it('loadCache keeps dated and [1m] variants whose stem matches a FALLBACK family', () => {
     writeFileSync(cachePath, JSON.stringify({
       models: [
-        { id: 'opus-4-7-20251201', fullId: 'claude-opus-4-7-20251201', label: 'Opus 4.7 (2025-12-01)', contextWindow: 1_000_000 },
-        { id: 'opus-4-7[1m]', fullId: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)', contextWindow: 1_000_000 },
+        { id: 'opus-4-8-20251201', fullId: 'claude-opus-4-8-20251201', label: 'Opus 4.8 (2025-12-01)', contextWindow: 1_000_000 },
+        { id: 'opus-4-8[1m]', fullId: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M)', contextWindow: 1_000_000 },
       ],
     }))
     const r = createModelsRegistry()
     assert.equal(r.loadCache(cachePath), true)
     const loaded = r.getModels().map(m => m.fullId)
-    assert.ok(loaded.includes('claude-opus-4-7-20251201'), 'dated variant of current opus-4-7 should be kept')
-    assert.ok(loaded.includes('claude-opus-4-7[1m]'), '[1m] variant of current opus-4-7 should be kept')
+    assert.ok(loaded.includes('claude-opus-4-8-20251201'), 'dated variant of current opus-4-8 should be kept')
+    assert.ok(loaded.includes('claude-opus-4-8[1m]'), '[1m] variant of current opus-4-8 should be kept')
   })
 
   it('loadCache discards a defaultModelId that points to a stale entry', () => {
     writeFileSync(cachePath, JSON.stringify({
       models: [
         { id: 'opus-4-6', fullId: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 1_000_000 },
-        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+        { id: 'opus-4-8', fullId: 'claude-opus-4-8', label: 'Opus 4.8', contextWindow: 1_000_000 },
       ],
       defaultModelId: 'opus-4-6',
     }))
@@ -388,7 +388,7 @@ describe('disk cache (loadCache / saveCache)', () => {
     writeFileSync(cachePath, JSON.stringify({
       models: [
         { id: 'opus-4-6', fullId: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 1_000_000 },
-        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+        { id: 'opus-4-8', fullId: 'claude-opus-4-8', label: 'Opus 4.8', contextWindow: 1_000_000 },
       ],
     }))
     const beforeMtime = statSync(cachePath).mtimeMs
@@ -400,7 +400,7 @@ describe('disk cache (loadCache / saveCache)', () => {
     const afterRaw = JSON.parse(readFileSync(cachePath, 'utf-8'))
     const afterIds = afterRaw.models.map(m => m.fullId)
     assert.ok(!afterIds.includes('claude-opus-4-6'), 'disk file should no longer contain claude-opus-4-6')
-    assert.ok(afterIds.includes('claude-opus-4-7'), 'disk file should still contain claude-opus-4-7')
+    assert.ok(afterIds.includes('claude-opus-4-8'), 'disk file should still contain claude-opus-4-8')
     assert.ok(statSync(cachePath).mtimeMs >= beforeMtime, 'disk file should have been touched')
   })
 
@@ -412,9 +412,10 @@ describe('disk cache (loadCache / saveCache)', () => {
     // file and bump mtime.
     writeFileSync(cachePath, JSON.stringify({
       models: [
-        { id: 'opus-4-7', fullId: 'claude-opus-4-7', label: 'Opus 4.7', contextWindow: 1_000_000 },
+        // #6219 — exactly the current FALLBACK_MODELS set (no fable: removed +
+        // disallowed, so seeding it would make loadCache heal the file).
+        { id: 'opus-4-8', fullId: 'claude-opus-4-8', label: 'Opus 4.8', contextWindow: 1_000_000 },
         { id: 'sonnet-4-6', fullId: 'claude-sonnet-4-6', label: 'Sonnet 4.6', contextWindow: 200_000 },
-        { id: 'fable-5', fullId: 'claude-fable-5', label: 'Fable 5', contextWindow: 200_000 },
         { id: 'haiku-4-5', fullId: 'claude-haiku-4-5', label: 'Haiku 4.5', contextWindow: 200_000 },
       ],
     }))
@@ -537,7 +538,7 @@ describe('silent failure logging (#2830)', () => {
     // Shape drift — no `value` key
     r.updateModels([
       { id: 'claude-sonnet-4-6', name: 'Sonnet 4.6' },
-      { id: 'claude-opus-4-7', name: 'Opus 4.7' },
+      { id: 'claude-opus-4-8', name: 'Opus 4.8' },
     ])
     const drop = entries.find(e => e.level === 'warn' && e.message.includes('dropped'))
     const none = entries.find(e => e.level === 'warn' && e.message.includes('none matched'))
@@ -551,7 +552,7 @@ describe('silent failure logging (#2830)', () => {
     const r = createModelsRegistry()
     r.updateModels([
       { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
-      { id: 'claude-opus-4-7', name: 'Opus 4.7' }, // missing `value`
+      { id: 'claude-opus-4-8', name: 'Opus 4.8' }, // missing `value`
     ])
     const drop = entries.find(e => e.level === 'warn' && e.message.includes('dropped 1/2'))
     assert.ok(drop, `expected a warn about 1/2 dropped, got: ${JSON.stringify(entries.map(e => e.message))}`)

--- a/packages/server/tests/models-metadata-derivation.test.js
+++ b/packages/server/tests/models-metadata-derivation.test.js
@@ -23,19 +23,22 @@ import {
 // Verbatim pre-consolidation FALLBACK_MODELS (contextWindow values inlined to
 // what resolveClaudeContextWindow returned at authoring time, so a regression in
 // the heuristic ALSO trips this test, not just a far-away window test).
+// #6219 updated the intended roster: Opus head bumped 4-7 → 4-8, and Fable
+// (disallowed) removed. The snapshot tracks the CURRENT intended set — the proof
+// is still "the derived table deep-equals the declared literal", just against the
+// post-#6219 roster, not the original #5930 freeze.
 const FALLBACK_MODELS_SNAPSHOT = [
   { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200_000 },
-  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-7', contextWindow: 1_000_000 },
-  { id: 'fable', label: 'Fable', fullId: 'claude-fable-5', contextWindow: 200_000 },
+  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8', contextWindow: 1_000_000 },
   { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: 200_000 },
 ]
 
-// Verbatim pre-consolidation CLAUDE_PRICING_USD_PER_MTOK. Fable is intentionally
-// ABSENT (chroxy ships no verified fable rates → cost "unknown", never $0).
+// CLAUDE_PRICING_USD_PER_MTOK snapshot. Fable is ABSENT (removed in #6219;
+// chroxy never shipped verified fable rates anyway — cost "unknown", never $0).
 const CLAUDE_PRICING_SNAPSHOT = {
   'claude-sonnet-4-6': { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
-  'claude-opus-4-7': { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
-  'claude-opus-4-7[1m]': {
+  'claude-opus-4-8': { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+  'claude-opus-4-8[1m]': {
     input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
     longContext: {
       thresholdInputTokens: 200_000,
@@ -61,14 +64,14 @@ describe('#5930 model-metadata consolidation is a pure restructure', () => {
   it('FALLBACK_MODELS preserves the exact roster + order', () => {
     assert.deepStrictEqual(
       FALLBACK_MODELS.map((m) => m.id),
-      ['sonnet', 'opus', 'fable', 'haiku'],
+      ['sonnet', 'opus', 'haiku'],
     )
   })
 
   it('the opus row derives its 1M window via the heuristic path', () => {
     const opus = FALLBACK_MODELS.find((m) => m.id === 'opus')
     assert.equal(opus.contextWindow, 1_000_000)
-    assert.equal(opus.contextWindow, resolveClaudeContextWindow('claude-opus-4-7'))
+    assert.equal(opus.contextWindow, resolveClaudeContextWindow('claude-opus-4-8'))
   })
 
   it('FALLBACK_MODELS stays deep-frozen', () => {
@@ -82,14 +85,15 @@ describe('#5930 model-metadata consolidation is a pure restructure', () => {
     }
   })
 
-  it('preserves the intentional fable pricing gap (cost unknown, not $0)', () => {
+  it('fable is fully removed (#6219) — not in the roster, no pricing', () => {
+    assert.ok(!FALLBACK_MODELS.some((m) => m.id === 'fable' || m.fullId === 'claude-fable-5'))
     assert.equal(getModelPricing('claude-fable-5'), null)
   })
 
   it('keeps pricing entries (incl. the nested longContext premium) deep-frozen', () => {
-    const opus = getModelPricing('claude-opus-4-7')
+    const opus = getModelPricing('claude-opus-4-8')
     assert.ok(Object.isFrozen(opus), 'opus base frozen')
-    const opus1m = getModelPricing('claude-opus-4-7[1m]')
+    const opus1m = getModelPricing('claude-opus-4-8[1m]')
     assert.ok(Object.isFrozen(opus1m), 'opus[1m] frozen')
     assert.ok(Object.isFrozen(opus1m.longContext), 'opus[1m].longContext frozen')
   })

--- a/packages/server/tests/models-overlay-reload.test.js
+++ b/packages/server/tests/models-overlay-reload.test.js
@@ -52,6 +52,16 @@ describe('registry.applyOverlay (#5932)', () => {
     assert.ok(reg.getAllowedModelIds().has('fable-9'))
   })
 
+  it('#6219 — a disallowed fullId (claude-fable-5) cannot be re-added via overlay', () => {
+    const reg = makeRegistry()
+    reg.applyOverlay(overlayMap({ 'claude-fable-5': { shortId: 'fable', label: 'Fable' } }))
+    assert.ok(!reg.getModels().some((m) => m.fullId === 'claude-fable-5'), 'disallowed overlay row must be skipped')
+    assert.ok(!reg.getAllowedModelIds().has('claude-fable-5'))
+    // An unrelated overlay id that merely uses `fable` as a label is unaffected.
+    reg.applyOverlay(overlayMap({ 'fable-9': { shortId: 'fable', label: 'Fable' } }))
+    assert.ok(reg.getModels().some((m) => m.fullId === 'fable-9'), 'non-disallowed overlay row still lands')
+  })
+
   it('overrides a base row label/contextWindow from the overlay', () => {
     const reg = makeRegistry()
     reg.applyOverlay(overlayMap({ 'base-1': { label: 'Renamed', contextWindow: 99000 } }))

--- a/packages/server/tests/models-per-provider.test.js
+++ b/packages/server/tests/models-per-provider.test.js
@@ -81,9 +81,9 @@ describe('provider static metadata hooks', () => {
     assert.equal(typeof SdkSession.getAllowedModels, 'function')
     const allowed = new Set(SdkSession.getAllowedModels())
     assert.ok(allowed.has('opus'))
-    assert.ok(allowed.has('claude-opus-4-7'))
-    assert.ok(allowed.has('fable'))
-    assert.ok(allowed.has('claude-fable-5'))
+    assert.ok(allowed.has('claude-opus-4-8'))
+    // #6219 — opus head bumped 4-7 → 4-8; fable removed/disallowed.
+    assert.ok(!allowed.has('claude-fable-5'))
     assert.ok(!allowed.has('opus-4-6'))
     assert.ok(!allowed.has('claude-opus-4-6'))
   })
@@ -92,9 +92,9 @@ describe('provider static metadata hooks', () => {
     assert.equal(typeof CliSession.getAllowedModels, 'function')
     const allowed = new Set(CliSession.getAllowedModels())
     assert.ok(allowed.has('opus'))
-    assert.ok(allowed.has('claude-opus-4-7'))
-    assert.ok(allowed.has('fable'))
-    assert.ok(allowed.has('claude-fable-5'))
+    assert.ok(allowed.has('claude-opus-4-8'))
+    // #6219 — opus head bumped 4-7 → 4-8; fable removed/disallowed.
+    assert.ok(!allowed.has('claude-fable-5'))
     assert.ok(!allowed.has('opus-4-6'))
     assert.ok(!allowed.has('claude-opus-4-6'))
   })
@@ -176,7 +176,7 @@ describe('createModelsRegistry(providerHooks)', () => {
   it('backward compat: no args => Claude-style defaults (FALLBACK_MODELS, claude- stripping)', () => {
     const r = createModelsRegistry()
     const ids = r.getModels().map(m => m.id).sort()
-    assert.deepEqual(ids, ['fable', 'haiku', 'opus', 'sonnet'])
+    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet']) // #6219 — fable removed
     const converted = r.updateModels([
       { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
     ])

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider, registerProviderRegistry, resolveClaudeContextWindow, DEFAULT_CONTEXT_WINDOW, DISALLOWED_MODEL_IDS, isDisallowedModelId } from '../src/models.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider, registerProviderRegistry, resolveClaudeContextWindow, DEFAULT_CONTEXT_WINDOW, DISALLOWED_MODEL_IDS, isDisallowedModelId, getDefaultModelId } from '../src/models.js'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 // #5858: membership is now derived from `static claudeFamily` on the registered
 // provider classes (no hand-authored name literal). Importing providers.js
@@ -46,7 +46,7 @@ describe('FALLBACK_MODELS (default registry)', () => {
 describe('resolveClaudeContextWindow (#5931 — version-aware opus heuristic)', () => {
   it('maps the existing opus 4.6/4.7/4.8 minors to 1M (no behavior change)', () => {
     assert.equal(resolveClaudeContextWindow('claude-opus-4-6'), 1_000_000)
-    assert.equal(resolveClaudeContextWindow('claude-opus-4-8'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-7'), 1_000_000)
     assert.equal(resolveClaudeContextWindow('claude-opus-4-8'), 1_000_000)
     assert.equal(resolveClaudeContextWindow('claude-opus-4.8'), 1_000_000)
   })
@@ -277,7 +277,7 @@ describe('updateModels', () => {
     assert.deepEqual(models, result)
   })
 
-  it('opus 4.7 gets a 1M context window', () => {
+  it('opus 4.8 gets a 1M context window', () => {
     const result = updateModels([
       { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
@@ -965,7 +965,11 @@ describe('disallowed models (#6219)', () => {
     assert.ok(DISALLOWED_MODEL_IDS.has('claude-fable-5'))
     assert.equal(isDisallowedModelId('claude-fable-5'), true)
     assert.equal(isDisallowedModelId('claude-fable-5[1m]'), true)
+    // Dated SDK forms (claude-*-YYYYMMDD) and dated+[1m] also normalise + match.
+    assert.equal(isDisallowedModelId('claude-fable-5-20251201'), true)
+    assert.equal(isDisallowedModelId('claude-fable-5-20251201[1m]'), true)
     assert.equal(isDisallowedModelId('claude-opus-4-8'), false)
+    assert.equal(isDisallowedModelId('claude-opus-4-8-20251201'), false)
     assert.equal(isDisallowedModelId('claude-sonnet-4-6'), false)
     // The bare short alias is NOT keyed (avoids clobbering unrelated overlay
     // ids that merely use `fable` as a label) — only the real fullId is.
@@ -989,5 +993,21 @@ describe('disallowed models (#6219)', () => {
     assert.ok(!ALLOWED_MODEL_IDS.has('claude-fable-5'), 'fable must not enter the allowlist')
     // A legitimate SDK model alongside it still lands.
     assert.ok(fullIds.includes('claude-sonnet-4-6'))
+  })
+
+  it('does not leave defaultModelId pointing at a filtered-out disallowed model (#6232)', () => {
+    // SDK marks the disallowed model as "Default" — after filtering it out the
+    // default must re-resolve to a real model, never a dangling fable id.
+    updateModels([
+      { value: 'claude-fable-5', displayName: 'Default (Fable 5)', description: '' },
+      { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
+    ])
+    const def = getDefaultModelId()
+    const fullIds = getModels().map((m) => m.fullId)
+    assert.ok(!fullIds.includes('claude-fable-5'), 'fable filtered out')
+    assert.notEqual(def, 'fable', 'default must not be the filtered-out disallowed short id')
+    assert.notEqual(def, 'claude-fable-5', 'default must not be the filtered-out disallowed fullId')
+    // The re-picked default resolves to a model that is actually in the list.
+    assert.ok(def != null && getModels().some((m) => m.id === def || m.fullId === def), 'default resolves to a present model')
   })
 })

--- a/packages/server/tests/models.test.js
+++ b/packages/server/tests/models.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider, registerProviderRegistry, resolveClaudeContextWindow, DEFAULT_CONTEXT_WINDOW } from '../src/models.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, resolveModelId, toShortModelId, getModels, updateModels, updateContextWindow, resetModels, getModelPricing, computePromptCostUsd, isClaudeProvider, registerProviderRegistry, resolveClaudeContextWindow, DEFAULT_CONTEXT_WINDOW, DISALLOWED_MODEL_IDS, isDisallowedModelId } from '../src/models.js'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 // #5858: membership is now derived from `static claudeFamily` on the registered
 // provider classes (no hand-authored name literal). Importing providers.js
@@ -22,9 +22,9 @@ describe('FALLBACK_MODELS (default registry)', () => {
     }
   })
 
-  it('contains sonnet, opus, fable, and haiku aliases', () => {
+  it('contains sonnet, opus, and haiku aliases', () => {
     const ids = FALLBACK_MODELS.map(m => m.id).sort()
-    assert.deepEqual(ids, ['fable', 'haiku', 'opus', 'sonnet'])
+    assert.deepEqual(ids, ['haiku', 'opus', 'sonnet']) // #6219 — fable removed
   })
 
   it('each entry has id, label, fullId, and contextWindow', () => {
@@ -46,7 +46,7 @@ describe('FALLBACK_MODELS (default registry)', () => {
 describe('resolveClaudeContextWindow (#5931 — version-aware opus heuristic)', () => {
   it('maps the existing opus 4.6/4.7/4.8 minors to 1M (no behavior change)', () => {
     assert.equal(resolveClaudeContextWindow('claude-opus-4-6'), 1_000_000)
-    assert.equal(resolveClaudeContextWindow('claude-opus-4-7'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-8'), 1_000_000)
     assert.equal(resolveClaudeContextWindow('claude-opus-4-8'), 1_000_000)
     assert.equal(resolveClaudeContextWindow('claude-opus-4.8'), 1_000_000)
   })
@@ -76,7 +76,7 @@ describe('resolveClaudeContextWindow (#5931 — version-aware opus heuristic)', 
     // not be parsed as minor=20250514 (which would wrongly map it to 1M).
     assert.equal(resolveClaudeContextWindow('claude-opus-4-20250514'), DEFAULT_CONTEXT_WINDOW)
     // But a VERSIONED + dated id keeps its real minor → opus 4.7 dated is 1M.
-    assert.equal(resolveClaudeContextWindow('claude-opus-4-7-20251201'), 1_000_000)
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-8-20251201'), 1_000_000)
   })
 
   it('defaults non-opus families to 200k', () => {
@@ -181,7 +181,7 @@ describe('updateModels', () => {
     it('logs warn when a 1M variant is synthesized but no pricing entry exists', () => {
       // claude-opus-4-6 resolves to 1M context via the heuristic, but
       // CLAUDE_PRICING_USD_PER_MTOK doesn't carry a `claude-opus-4-6[1m]`
-      // entry (only opus-4-7[1m] exists today). The base `claude-opus-4-6`
+      // entry (only opus-4-8[1m] exists today). The base `claude-opus-4-6`
       // entry is also absent, so resolvePricingKey returns null and cost
       // would be 0 — the drift warn fires regardless of WHICH undercount
       // path applies, so operators notice before bills lie.
@@ -195,9 +195,9 @@ describe('updateModels', () => {
       )
     })
 
-    it('does not warn for the existing claude-opus-4-7[1m] (pricing entry exists)', () => {
+    it('does not warn for the existing claude-opus-4-8[1m] (pricing entry exists)', () => {
       updateModels([
-        { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+        { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
       ])
       const drift = warnings.filter(w => w.includes('pricing-table drift'))
       assert.equal(drift.length, 0, `unexpected drift warning: ${JSON.stringify(warnings)}`)
@@ -262,15 +262,16 @@ describe('updateModels', () => {
     assert.equal(result[1].fullId, 'claude-opus-4-6')
     assert.equal(result[1].contextWindow, 1_000_000)
 
-    // Fallback entries the SDK didn't list are appended (Opus 4.7, Fable, Haiku 4.5).
+    // Fallback entries the SDK didn't list are appended (Opus 4.8, Haiku 4.5).
+    // #6219 — fable removed from the roster, so it is no longer merged.
     const fullIds = result.map(m => m.fullId)
-    assert.ok(fullIds.includes('claude-opus-4-7'), 'opus 4.7 fallback should be merged in')
-    assert.ok(fullIds.includes('claude-fable-5'), 'fable fallback should be merged in')
+    assert.ok(fullIds.includes('claude-opus-4-8'), 'opus 4.8 fallback should be merged in')
+    assert.ok(!fullIds.includes('claude-fable-5'), 'fable must not be merged (disallowed)')
     assert.ok(fullIds.includes('claude-haiku-4-5'), 'haiku 4.5 fallback should be merged in')
 
     // 1M variants are synthesized for any 1M-context model that lacks one.
     assert.ok(fullIds.includes('claude-opus-4-6[1m]'), 'opus 4.6 [1m] variant should be synthesized')
-    assert.ok(fullIds.includes('claude-opus-4-7[1m]'), 'opus 4.7 [1m] variant should be synthesized')
+    assert.ok(fullIds.includes('claude-opus-4-8[1m]'), 'opus 4.8 [1m] variant should be synthesized')
 
     const models = getModels()
     assert.deepEqual(models, result)
@@ -278,7 +279,7 @@ describe('updateModels', () => {
 
   it('opus 4.7 gets a 1M context window', () => {
     const result = updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
     assert.equal(result[0].contextWindow, 1_000_000)
   })
@@ -372,16 +373,16 @@ describe('1M-context variants and fallback merge (regression for #3075)', () => 
 
   it('synthesizes [1m] chips for any model with a 1M context window', () => {
     const result = updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
     const fullIds = result.map(m => m.fullId)
-    assert.ok(fullIds.includes('claude-opus-4-7'), 'base model present')
-    assert.ok(fullIds.includes('claude-opus-4-7[1m]'), '1m variant synthesized')
+    assert.ok(fullIds.includes('claude-opus-4-8'), 'base model present')
+    assert.ok(fullIds.includes('claude-opus-4-8[1m]'), '1m variant synthesized')
 
-    const variant = result.find(m => m.fullId === 'claude-opus-4-7[1m]')
+    const variant = result.find(m => m.fullId === 'claude-opus-4-8[1m]')
     assert.equal(variant.contextWindow, 1_000_000)
-    assert.equal(variant.label, 'Opus 4.7 (1M)')
-    assert.equal(variant.id, 'opus-4-7[1m]')
+    assert.equal(variant.label, 'Opus 4.8 (1M)')
+    assert.equal(variant.id, 'opus-4-8[1m]')
   })
 
   it('does not duplicate a [1m] chip the SDK already reports', () => {
@@ -402,9 +403,9 @@ describe('1M-context variants and fallback merge (regression for #3075)', () => 
       'haiku has 200k context — must not get a 1m chip')
   })
 
-  it('merges fallback models the SDK omitted (Opus 4.7 missing → fallback merged)', () => {
+  it('merges fallback models the SDK omitted (Opus 4.8 missing → fallback merged)', () => {
     // Reproduces the exact bug from #3075: SDK only reports 4.6 family, but
-    // fallback knows about Opus 4.7 — the picker should show all of them.
+    // fallback knows about Opus 4.8 — the picker should show all of them.
     const result = updateModels([
       { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
       { value: 'claude-opus-4-6', displayName: 'Opus 4.6', description: '' },
@@ -412,21 +413,21 @@ describe('1M-context variants and fallback merge (regression for #3075)', () => 
     const fullIds = result.map(m => m.fullId)
     assert.ok(fullIds.includes('claude-sonnet-4-6'))
     assert.ok(fullIds.includes('claude-opus-4-6'))
-    assert.ok(fullIds.includes('claude-opus-4-7'), 'Opus 4.7 missing from SDK should be merged from fallback')
+    assert.ok(fullIds.includes('claude-opus-4-8'), 'Opus 4.8 missing from SDK should be merged from fallback')
     assert.ok(fullIds.includes('claude-haiku-4-5'))
     // And both 1M-context models get [1m] chips.
     assert.ok(fullIds.includes('claude-opus-4-6[1m]'))
-    assert.ok(fullIds.includes('claude-opus-4-7[1m]'))
+    assert.ok(fullIds.includes('claude-opus-4-8[1m]'))
   })
 
   it('1M variants are addressable via resolveModelId/toShortModelId', () => {
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
-    assert.equal(resolveModelId('opus-4-7[1m]'), 'claude-opus-4-7[1m]')
-    assert.equal(toShortModelId('claude-opus-4-7[1m]'), 'opus-4-7[1m]')
-    assert.ok(ALLOWED_MODEL_IDS.has('claude-opus-4-7[1m]'))
-    assert.ok(ALLOWED_MODEL_IDS.has('opus-4-7[1m]'))
+    assert.equal(resolveModelId('opus-4-8[1m]'), 'claude-opus-4-8[1m]')
+    assert.equal(toShortModelId('claude-opus-4-8[1m]'), 'opus-4-8[1m]')
+    assert.ok(ALLOWED_MODEL_IDS.has('claude-opus-4-8[1m]'))
+    assert.ok(ALLOWED_MODEL_IDS.has('opus-4-8[1m]'))
   })
 
   it('SDK-reported [1m] entries get the 1M context window via the heuristic', () => {
@@ -462,7 +463,7 @@ describe('short aliases survive updateModels', () => {
   it('keeps sonnet/opus/haiku in ALLOWED_MODEL_IDS after SDK list replaces getModels()', () => {
     updateModels([
       { value: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: '' },
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
       { value: 'claude-haiku-4-5', displayName: 'Haiku 4.5', description: '' },
     ])
 
@@ -471,7 +472,7 @@ describe('short aliases survive updateModels', () => {
     assert.ok(ALLOWED_MODEL_IDS.has('opus'))
     assert.ok(ALLOWED_MODEL_IDS.has('haiku'))
     assert.equal(resolveModelId('sonnet'), 'claude-sonnet-4-6')
-    assert.equal(resolveModelId('opus'), 'claude-opus-4-7')
+    assert.equal(resolveModelId('opus'), 'claude-opus-4-8')
     assert.equal(resolveModelId('haiku'), 'claude-haiku-4-5')
   })
 
@@ -505,19 +506,19 @@ describe('updateContextWindow (self-correcting from SDK usage)', () => {
 
   it('overwrites the static fallback guess when SDK reports a different value', () => {
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
-    // Static heuristic guesses 1M for opus-4-7; verify we can correct it.
+    // Static heuristic guesses 1M for opus-4-8; verify we can correct it.
     assert.equal(getModels()[0].contextWindow, 1_000_000)
-    assert.equal(updateContextWindow('claude-opus-4-7', 200_000), true)
+    assert.equal(updateContextWindow('claude-opus-4-8', 200_000), true)
     assert.equal(getModels()[0].contextWindow, 200_000)
   })
 
   it('returns false and no-ops when the value already matches', () => {
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
-    assert.equal(updateContextWindow('claude-opus-4-7', 1_000_000), false)
+    assert.equal(updateContextWindow('claude-opus-4-8', 1_000_000), false)
   })
 
   it('matches short id as well as full id', () => {
@@ -534,11 +535,11 @@ describe('updateContextWindow (self-correcting from SDK usage)', () => {
 
   it('rejects invalid context windows', () => {
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
-    assert.equal(updateContextWindow('claude-opus-4-7', 0), false)
-    assert.equal(updateContextWindow('claude-opus-4-7', -1), false)
-    assert.equal(updateContextWindow('claude-opus-4-7', 'big'), false)
+    assert.equal(updateContextWindow('claude-opus-4-8', 0), false)
+    assert.equal(updateContextWindow('claude-opus-4-8', -1), false)
+    assert.equal(updateContextWindow('claude-opus-4-8', 'big'), false)
   })
 
   it('override survives subsequent updateModels refreshes (regression for #2820)', () => {
@@ -546,27 +547,27 @@ describe('updateContextWindow (self-correcting from SDK usage)', () => {
     // updateModels() rebuild cannot clobber a value we already learned from
     // modelUsage — otherwise the self-correcting loop never converges.
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
     assert.equal(getModels()[0].contextWindow, 1_000_000) // static heuristic
-    updateContextWindow('claude-opus-4-7', 500_000)       // SDK-reported override
+    updateContextWindow('claude-opus-4-8', 500_000)       // SDK-reported override
     assert.equal(getModels()[0].contextWindow, 500_000)
 
     // Simulate the next supportedModels() refresh — same list.
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
     assert.equal(getModels()[0].contextWindow, 500_000, 'override must persist across refreshes')
   })
 
   it('resetModels clears overrides so next updateModels uses the heuristic again', () => {
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
-    updateContextWindow('claude-opus-4-7', 500_000)
+    updateContextWindow('claude-opus-4-8', 500_000)
     resetModels()
     updateModels([
-      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+      { value: 'claude-opus-4-8', displayName: 'Opus 4.8', description: '' },
     ])
     assert.equal(getModels()[0].contextWindow, 1_000_000)
   })
@@ -589,8 +590,8 @@ describe('getModelPricing()', () => {
   })
 
   it('returns base rates matching the default-window entry for the [1m] suffix below threshold (#4087)', () => {
-    const base = getModelPricing('claude-opus-4-7')
-    const long = getModelPricing('claude-opus-4-7[1m]')
+    const base = getModelPricing('claude-opus-4-8')
+    const long = getModelPricing('claude-opus-4-8[1m]')
     // The base rates on the [1m] entry match the default-window entry —
     // sub-200K turns on Opus 1M cost the same as default Opus.
     assert.equal(long.input, base.input)
@@ -600,7 +601,7 @@ describe('getModelPricing()', () => {
   })
 
   it('[1m] entry carries a longContext block with the >200K premium rates (#4087)', () => {
-    const long = getModelPricing('claude-opus-4-7[1m]')
+    const long = getModelPricing('claude-opus-4-8[1m]')
     assert.ok(long.longContext, '[1m] entry must declare premium rates')
     assert.equal(long.longContext.thresholdInputTokens, 200_000)
     // Anthropic's published 1M premium: 2× input, 2× output (verify on
@@ -616,17 +617,17 @@ describe('getModelPricing()', () => {
     // The default-window entry can't ever exceed 200K (the window itself
     // is 200K), so premium pricing is irrelevant and would be misleading
     // if present. Confirms the design: longContext lives on `[1m]` only.
-    const base = getModelPricing('claude-opus-4-7')
+    const base = getModelPricing('claude-opus-4-8')
     assert.equal(base.longContext, undefined)
   })
 
   it('returns family-head pricing for dated full ids (Anthropic SDK Model enum form, #4084)', () => {
-    // The SDK's Model enum surfaces forms like claude-opus-4-7-20251201
+    // The SDK's Model enum surfaces forms like claude-opus-4-8-20251201
     // that users may pin for reproducibility. Without this, a pinned user
     // silently emits cost: 0.
-    const base = getModelPricing('claude-opus-4-7')
+    const base = getModelPricing('claude-opus-4-8')
     assert.deepEqual(
-      getModelPricing('claude-opus-4-7-20251201'),
+      getModelPricing('claude-opus-4-8-20251201'),
       base,
       'dated full id must resolve to its family head pricing',
     )
@@ -638,11 +639,11 @@ describe('getModelPricing()', () => {
     // A user pinning to a dated long-context variant must still get the
     // longContext premium block — pre-#4107 this fell through to the base
     // family entry, silently undercounting >200K turns. The combined form
-    // walks: verbatim miss → strip [1m] → 'claude-opus-4-7-20251201' miss
-    // → strip date → 'claude-opus-4-7' HIT base. The [1m] re-attach then
-    // promotes 'claude-opus-4-7' → 'claude-opus-4-7[1m]'.
-    const longOpus = getModelPricing('claude-opus-4-7[1m]')
-    assert.deepEqual(getModelPricing('claude-opus-4-7-20251201[1m]'), longOpus)
+    // walks: verbatim miss → strip [1m] → 'claude-opus-4-8-20251201' miss
+    // → strip date → 'claude-opus-4-8' HIT base. The [1m] re-attach then
+    // promotes 'claude-opus-4-8' → 'claude-opus-4-8[1m]'.
+    const longOpus = getModelPricing('claude-opus-4-8[1m]')
+    assert.deepEqual(getModelPricing('claude-opus-4-8-20251201[1m]'), longOpus)
   })
 
   it('still returns null for genuinely unknown dated families (no false-positive resolution)', () => {
@@ -670,12 +671,12 @@ describe('getModelPricing()', () => {
     // family. Pin the negative cases so a "make the regex looser" refactor
     // fails loudly.
     assert.equal(
-      getModelPricing('claude-opus-4-7-2025'),
+      getModelPricing('claude-opus-4-8-2025'),
       null,
       '4-digit year fragment must not trigger date-strip',
     )
     assert.equal(
-      getModelPricing('claude-opus-4-7-1234567'),
+      getModelPricing('claude-opus-4-8-1234567'),
       null,
       '7-digit trailing number must not trigger date-strip',
     )
@@ -683,8 +684,8 @@ describe('getModelPricing()', () => {
     // bound is forgiving for future timestamp formats). Asserted here to
     // make the boundary explicit alongside the negative cases.
     assert.deepEqual(
-      getModelPricing('claude-opus-4-7-123456789'),
-      getModelPricing('claude-opus-4-7'),
+      getModelPricing('claude-opus-4-8-123456789'),
+      getModelPricing('claude-opus-4-8'),
       '9-digit trailing number must trigger date-strip (forgiving upper bound)',
     )
   })
@@ -704,9 +705,9 @@ describe('getModelPricing()', () => {
   describe('[1m] re-attach after fallback resolution (#4105 + #4107)', () => {
     it('short-form opus[1m] routes to the explicit [1m] entry (premium pricing preserved)', () => {
       // resolvePricingKey walks: verbatim miss → strip [1m] → 'opus' table
-      // miss → fallback m.id === 'opus' → fullId 'claude-opus-4-7'. Before
+      // miss → fallback m.id === 'opus' → fullId 'claude-opus-4-8'. Before
       // the fix, this returned the base entry (no longContext block);
-      // after, it re-attaches [1m] and returns 'claude-opus-4-7[1m]'
+      // after, it re-attaches [1m] and returns 'claude-opus-4-8[1m]'
       // with the longContext premium.
       const longOpus = getModelPricing('opus[1m]')
       assert.ok(longOpus, 'opus[1m] should resolve to a pricing entry')
@@ -715,11 +716,11 @@ describe('getModelPricing()', () => {
     })
 
     it('dated + [1m] combined form routes to the explicit [1m] entry', () => {
-      // claude-opus-4-7-20251201[1m] walks: verbatim miss → strip [1m] →
-      // 'claude-opus-4-7-20251201' miss → strip date → 'claude-opus-4-7'
+      // claude-opus-4-8-20251201[1m] walks: verbatim miss → strip [1m] →
+      // 'claude-opus-4-8-20251201' miss → strip date → 'claude-opus-4-8'
       // HIT (base entry). Before the fix, returned base. After, re-attaches
-      // [1m] → returns 'claude-opus-4-7[1m]'.
-      const pricing = getModelPricing('claude-opus-4-7-20251201[1m]')
+      // [1m] → returns 'claude-opus-4-8[1m]'.
+      const pricing = getModelPricing('claude-opus-4-8-20251201[1m]')
       assert.ok(pricing, 'dated [1m] form should resolve')
       assert.ok(pricing.longContext, 'dated + [1m] form must keep premium tier (was missed pre-#4107)')
     })
@@ -795,16 +796,16 @@ describe('computePromptCostUsd()', () => {
     assert.equal(cost, 0)
   })
 
-  it('matches Opus 4.7 rate for the canonical happy-path test in byok-session', () => {
-    const opus = getModelPricing('claude-opus-4-7')
-    // The byok-session test asserts cost = 0.000375 for 5in/4out on opus-4-7.
+  it('matches Opus 4.8 rate for the canonical happy-path test in byok-session', () => {
+    const opus = getModelPricing('claude-opus-4-8')
+    // The byok-session test asserts cost = 0.000375 for 5in/4out on opus-4-8.
     // If the rate ever changes, the byok-session test's literal must change too.
     const cost = computePromptCostUsd({ input_tokens: 5, output_tokens: 4 }, opus)
     assert.ok(Math.abs(cost - 0.000375) < 1e-9, `opus 5in/4out reference: expected 0.000375, got ${cost}`)
   })
 
   describe('long-context premium tier (#4087)', () => {
-    const longOpus = getModelPricing('claude-opus-4-7[1m]')
+    const longOpus = getModelPricing('claude-opus-4-8[1m]')
 
     it('uses BASE rates when total input is below 200K (Opus [1m])', () => {
       // 100K input, 50K output — both well below threshold.
@@ -845,7 +846,7 @@ describe('computePromptCostUsd()', () => {
       // A pathological usage report (claims 300K input on default-window
       // model) must still use base rates — there's no longContext block
       // to flip into.
-      const baseOpus = getModelPricing('claude-opus-4-7')
+      const baseOpus = getModelPricing('claude-opus-4-8')
       const cost = computePromptCostUsd({ input_tokens: 300_000, output_tokens: 0 }, baseOpus)
       // 300K * 15/Mtok = 4.5 (base)
       assert.ok(Math.abs(cost - 4.5) < 1e-6, `default-window must stay on base regardless, got ${cost}`)
@@ -952,5 +953,41 @@ describe('isClaudeProvider — Claude-family provider allowlist', () => {
     // A class with no flag falls through to the name resolution.
     class NoFlag {}
     assert.equal(isClaudeProvider('claude-tui', NoFlag), true)
+  })
+})
+
+// #6219 — Fable (claude-fable-5) is disallowed across ALL sources.
+describe('disallowed models (#6219)', () => {
+  beforeEach(() => resetModels())
+  afterEach(() => resetModels())
+
+  it('isDisallowedModelId matches claude-fable-5 (and its [1m] variant), not allowed models', () => {
+    assert.ok(DISALLOWED_MODEL_IDS.has('claude-fable-5'))
+    assert.equal(isDisallowedModelId('claude-fable-5'), true)
+    assert.equal(isDisallowedModelId('claude-fable-5[1m]'), true)
+    assert.equal(isDisallowedModelId('claude-opus-4-8'), false)
+    assert.equal(isDisallowedModelId('claude-sonnet-4-6'), false)
+    // The bare short alias is NOT keyed (avoids clobbering unrelated overlay
+    // ids that merely use `fable` as a label) — only the real fullId is.
+    assert.equal(isDisallowedModelId('fable'), false)
+    assert.equal(isDisallowedModelId(undefined), false)
+  })
+
+  it('fable is absent from FALLBACK_MODELS and the allowlist', () => {
+    assert.ok(!FALLBACK_MODELS.some((m) => m.fullId === 'claude-fable-5'))
+    assert.ok(!ALLOWED_MODEL_IDS.has('claude-fable-5'))
+    assert.ok(!ALLOWED_MODEL_IDS.has('fable'))
+  })
+
+  it('updateModels strips an SDK-returned claude-fable-5 (disallowed in SDK/TUI too)', () => {
+    updateModels([
+      { value: 'claude-sonnet-4-6', displayName: 'Default (Sonnet 4.6)', description: '' },
+      { value: 'claude-fable-5', displayName: 'Fable 5', description: '' },
+    ])
+    const fullIds = getModels().map((m) => m.fullId)
+    assert.ok(!fullIds.includes('claude-fable-5'), 'SDK-returned fable must be filtered out')
+    assert.ok(!ALLOWED_MODEL_IDS.has('claude-fable-5'), 'fable must not enter the allowlist')
+    // A legitimate SDK model alongside it still lands.
+    assert.ok(fullIds.includes('claude-sonnet-4-6'))
   })
 })

--- a/packages/server/tests/session-info-booted-model.test.js
+++ b/packages/server/tests/session-info-booted-model.test.js
@@ -58,7 +58,7 @@ describe('sendSessionInfo — bootedModel fallback (#3691)', () => {
     // originally booted on opus. Precedence: explicit override wins.
     const session = sessionsMap.get('sess-1').session
     session.model = 'claude-sonnet-4-6'
-    session.bootedModel = 'claude-opus-4-7'
+    session.bootedModel = 'claude-opus-4-8'
 
     const ws = makeFakeWs()
     const ctx = makeCtx({ sessionManager: manager })
@@ -80,7 +80,7 @@ describe('sendSessionInfo — bootedModel fallback (#3691)', () => {
     // so tab switches don't blank out the picker.
     const session = sessionsMap.get('sess-1').session
     session.model = null
-    session.bootedModel = 'claude-opus-4-7'
+    session.bootedModel = 'claude-opus-4-8'
 
     const ws = makeFakeWs()
     const ctx = makeCtx({ sessionManager: manager })
@@ -100,7 +100,7 @@ describe('sendSessionInfo — bootedModel fallback (#3691)', () => {
     ])
     const session = sessionsMap.get('sess-1').session
     session.model = ''
-    session.bootedModel = 'claude-opus-4-7'
+    session.bootedModel = 'claude-opus-4-8'
 
     const ws = makeFakeWs()
     const ctx = makeCtx({ sessionManager: manager })
@@ -198,7 +198,7 @@ describe('sendPostAuthInfo — legacy cliSession bootedModel fallback (#3691)', 
       cwd: '/tmp',
       isReady: true,
       model: 'claude-sonnet-4-6',
-      bootedModel: 'claude-opus-4-7',
+      bootedModel: 'claude-opus-4-8',
       permissionMode: 'approve',
     }
     const ctx = makeLegacyCtx(cliSession)
@@ -215,7 +215,7 @@ describe('sendPostAuthInfo — legacy cliSession bootedModel fallback (#3691)', 
       cwd: '/tmp',
       isReady: true,
       model: null,
-      bootedModel: 'claude-opus-4-7',
+      bootedModel: 'claude-opus-4-8',
       permissionMode: 'approve',
     }
     const ctx = makeLegacyCtx(cliSession)
@@ -283,7 +283,7 @@ describe('SessionManager.listSessions — bootedModel fallback (#3691)', () => {
 
   it('reports session.model when an explicit override is set', () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
-    attachSession(mgr, 's-override', { model: 'claude-sonnet-4-6', bootedModel: 'claude-opus-4-7' })
+    attachSession(mgr, 's-override', { model: 'claude-sonnet-4-6', bootedModel: 'claude-opus-4-8' })
 
     const [entry] = mgr.listSessions()
     assert.equal(entry.sessionId, 's-override')
@@ -293,10 +293,10 @@ describe('SessionManager.listSessions — bootedModel fallback (#3691)', () => {
 
   it('falls back to session.bootedModel when session.model is null (#3691 core case)', () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
-    attachSession(mgr, 's-fallback', { model: null, bootedModel: 'claude-opus-4-7' })
+    attachSession(mgr, 's-fallback', { model: null, bootedModel: 'claude-opus-4-8' })
 
     const [entry] = mgr.listSessions()
-    assert.equal(entry.model, 'claude-opus-4-7',
+    assert.equal(entry.model, 'claude-opus-4-8',
       'session_list payload must surface the running model when no override is set')
   })
 
@@ -311,10 +311,10 @@ describe('SessionManager.listSessions — bootedModel fallback (#3691)', () => {
 
   it('falls back when session.model is an empty string', () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
-    attachSession(mgr, 's-empty-str', { model: '', bootedModel: 'claude-opus-4-7' })
+    attachSession(mgr, 's-empty-str', { model: '', bootedModel: 'claude-opus-4-8' })
 
     const [entry] = mgr.listSessions()
-    assert.equal(entry.model, 'claude-opus-4-7',
+    assert.equal(entry.model, 'claude-opus-4-8',
       'empty string is treated as "no override" by the `||` chain')
   })
 
@@ -324,14 +324,14 @@ describe('SessionManager.listSessions — bootedModel fallback (#3691)', () => {
     // fallback into a shared field — every entry must keep its own
     // precedence result.
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
-    attachSession(mgr, 's-a', { model: 'claude-sonnet-4-6', bootedModel: 'claude-opus-4-7', name: 'A' })
-    attachSession(mgr, 's-b', { model: null, bootedModel: 'claude-opus-4-7', name: 'B' })
+    attachSession(mgr, 's-a', { model: 'claude-sonnet-4-6', bootedModel: 'claude-opus-4-8', name: 'A' })
+    attachSession(mgr, 's-b', { model: null, bootedModel: 'claude-opus-4-8', name: 'B' })
     attachSession(mgr, 's-c', { model: null, bootedModel: null, name: 'C' })
 
     const list = mgr.listSessions()
     const byId = Object.fromEntries(list.map(e => [e.sessionId, e]))
     assert.equal(byId['s-a'].model, 'claude-sonnet-4-6')
-    assert.equal(byId['s-b'].model, 'claude-opus-4-7')
+    assert.equal(byId['s-b'].model, 'claude-opus-4-8')
     assert.equal(byId['s-c'].model, null)
   })
 })


### PR DESCRIPTION
## Summary

The model registry's Opus head was `claude-opus-4-7` and still listed **Fable** (`claude-fable-5`), which is disallowed for chroxy. In CLI mode (no SDK feed) the selector shows the registry fallback, so the default resolved to the wrong Opus and Fable was selectable.

Closes #6219.

## Changes (`packages/server/src/models.js`)

- **Opus head `claude-opus-4-7` → `claude-opus-4-8`** in `MODEL_METADATA`. Pricing + the 1M long-context tier carry over unchanged (4.8 is opus ≥4.6 → 1M). This makes the default-model preference (`opus` → `sonnet`) resolve to **Opus 4.8**.
- **Fable removed** from `MODEL_METADATA` (gone from the CLI fallback roster).
- **`DISALLOWED_MODEL_IDS` (`claude-fable-5`) + `isDisallowedModelId`**, filtered in:
  - `applyModels()` — covers the SDK `updateModels()` push **and** the disk cache, so Fable can't appear in **SDK/TUI** modes either.
  - `computeFallbackModels()`'s overlay loop — a user `models-overlay.json` can't re-add it.
  - Keyed on the precise **fullId** (not the bare `fable` alias) so an unrelated overlay/SDK entry that merely uses `fable` as a label isn't false-positived.
- `prompt-evaluator.js` + `byok-session.js` default model → `claude-opus-4-8`.

Addresses the user's "check SDK/TUI/other modes too" — disallow holds across all sources, not just the reported CLI path.

## Tests

- Updated the #5930 derivation snapshot to the new roster (`sonnet`, `opus`@4.8, `haiku`) + pricing keys.
- Updated per-provider / factory / byok / event-normalizer / booted-model fixtures (`opus-4-7` → `opus-4-8`; `toShortModelId`-normalizing tests required the current head).
- **Added** coverage: `isDisallowedModelId`, SDK-returned fable stripped by `updateModels`, overlay can't re-add `claude-fable-5`.
- All targeted model/provider/session suites green (models 191, +byok/evaluator 400, +session-manager/normalizer/sdk/cli 591).

## Scope note

This fixes the **selector's source of truth** (server registry → `available_models`). The dashboard's separate client-side cost-estimate table (`packages/dashboard/src/lib/model-pricing.ts`) still keys opus on `4-7`; that's a cost-display concern, not the selector — a small follow-up.

Pairs with #6220 (dropdown → modal picker UI).