### PR TITLE
fix(server): no macOS keychain modal on a broken login keychain (#6234)

### DIFF
--- a/packages/server/src/keychain.js
+++ b/packages/server/src/keychain.js
@@ -7,6 +7,7 @@
  * - Windows/fallback: returns null (caller falls back to chmod 600 file)
  */
 import { execFileSync } from 'child_process'
+import { existsSync } from 'node:fs'
 import { isMac, isLinux } from './platform.js'
 
 const DEFAULT_SERVICE = 'chroxy'
@@ -34,23 +35,54 @@ function keychainDisabled() {
 }
 
 /**
- * macOS `security` exit code for errSecItemNotFound — the item genuinely is not
- * in the keychain (a clean "absent"). Any OTHER non-zero exit (locked keychain,
- * interaction-not-allowed, keychain not found, auth denied, …) is a READ FAILURE
- * we must NOT confuse with absence — see getTokenStatus / #5615.
+ * Cached, NON-PROMPTING "is the OS keychain actually usable" probe.
+ *
+ * The previous `isKeychainAvailable()` only ran `security help`, which succeeds
+ * even on a box whose LOGIN keychain is missing/corrupt ("keychain cannot be
+ * found"). So the daemon then shelled out to `security find-/add-generic-password`
+ * — and macOS answers an inaccessible keychain with a BLOCKING MODAL before
+ * returning an error. This probe verifies, without opening the keychain (no
+ * modal), that the configured default keychain file actually exists (macOS) or
+ * that the backend CLI is present (Linux). When it can't prove the keychain is
+ * usable, callers fall back to file/env storage silently.
+ *
+ * `security default-keychain` only PRINTS the configured path (it does not open
+ * the keychain → no prompt); `existsSync` then confirms the file is there. An
+ * empty/unparseable path is treated as INCONCLUSIVE → usable, so prior behaviour
+ * and mocked tests (which stub execFileSync) are preserved — only a NON-EMPTY
+ * path that is missing is a definitive "broken keychain".
+ *
+ * Cached per-process: the result is stable for a daemon's lifetime (repair the
+ * keychain → restart to pick it up). Reset in tests via the export below.
  */
-const MAC_ERR_SEC_ITEM_NOT_FOUND = 44
+let _keychainUsableCache = null
 
-/**
- * Check if OS keychain is available on this system.
- */
-export function isKeychainAvailable() {
-  if (keychainDisabled()) return false
+/** Test-only: clear the cached usability probe so a test can re-toggle it. */
+export function _resetKeychainHealthForTests() {
+  _keychainUsableCache = null
+}
+
+function keychainUsable() {
+  if (_keychainUsableCache !== null) return _keychainUsableCache
+  _keychainUsableCache = _probeKeychainUsable()
+  return _keychainUsableCache
+}
+
+function _probeKeychainUsable() {
   if (isMac) {
     try {
-      execFileSync('security', ['help'], { stdio: 'pipe' })
-      return true
+      const out = execFileSync('security', ['default-keychain', '-d', 'user'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      // Output is the quoted path, e.g.  "/Users/x/Library/Keychains/login.keychain-db"
+      const path = out.trim().replace(/^"(.*)"$/, '$1')
+      // Inconclusive (no path / mocked execFileSync) → assume usable; only a
+      // real, missing path is a definitive broken-keychain signal.
+      if (!path) return true
+      return existsSync(path)
     } catch {
+      // `security` absent or errored → treat as not usable (file fallback).
       return false
     }
   }
@@ -66,6 +98,26 @@ export function isKeychainAvailable() {
 }
 
 /**
+ * macOS `security` exit code for errSecItemNotFound — the item genuinely is not
+ * in the keychain (a clean "absent"). Any OTHER non-zero exit (locked keychain,
+ * interaction-not-allowed, keychain not found, auth denied, …) is a READ FAILURE
+ * we must NOT confuse with absence — see getTokenStatus / #5615.
+ */
+const MAC_ERR_SEC_ITEM_NOT_FOUND = 44
+
+/**
+ * Check if OS keychain is available on this system.
+ */
+export function isKeychainAvailable() {
+  if (keychainDisabled()) return false
+  // Gate on the non-prompting usability probe (CLI present AND the default
+  // keychain file actually exists) so a broken/missing login keychain reports
+  // unavailable instead of letting callers trigger the macOS "keychain cannot
+  // be found" modal.
+  return keychainUsable()
+}
+
+/**
  * Get token from OS keychain.
  * @param {string} [service] - Keychain service name (default: 'chroxy')
  * @param {string} [account] - Keychain account (default: 'api-token'). Other
@@ -75,7 +127,9 @@ export function isKeychainAvailable() {
  * @returns {string|null} Token or null if not found
  */
 export function getToken(service = DEFAULT_SERVICE, account = ACCOUNT) {
-  if (keychainDisabled()) return null
+  // Gate on usability (disabled OR broken keychain) so a missing login keychain
+  // never reaches the prompting `security find-generic-password` call.
+  if (!isKeychainAvailable()) return null
   if (isMac) {
     return _macGetToken(service, account)
   }
@@ -119,7 +173,15 @@ export function getToken(service = DEFAULT_SERVICE, account = ACCOUNT) {
  * @returns {KeychainReadResult}
  */
 export function getTokenStatus(service = DEFAULT_SERVICE) {
+  // The explicit off-switch (tests) → 'absent': the file fallback owns identity.
   if (keychainDisabled()) return { status: 'absent', value: null, error: null }
+  // #5615 fail-safe: a BROKEN/missing keychain must read as 'error', NOT
+  // 'absent' — an identity caller that re-mints on 'absent' would false-MITM
+  // every already-pinned client. Reporting 'error' makes it fail safe (don't
+  // rotate) AND avoids the prompting find-generic-password call (no modal).
+  if (!keychainUsable()) {
+    return { status: 'error', value: null, error: 'keychain unavailable (missing or broken login keychain)' }
+  }
   if (isMac) {
     return _macGetTokenStatus(service)
   }
@@ -135,7 +197,9 @@ export function getTokenStatus(service = DEFAULT_SERVICE) {
  * @param {string} [service] - Keychain service name (default: 'chroxy')
  */
 export function setToken(token, service = DEFAULT_SERVICE) {
-  if (keychainDisabled()) return
+  // Gate on usability so a broken keychain never reaches the prompting
+  // `security add-generic-password` call (the "store API token" modal).
+  if (!isKeychainAvailable()) return
   if (isMac) {
     _macSetToken(service, token)
   } else if (isLinux) {
@@ -148,7 +212,7 @@ export function setToken(token, service = DEFAULT_SERVICE) {
  * @param {string} [service] - Keychain service name (default: 'chroxy')
  */
 export function deleteToken(service = DEFAULT_SERVICE) {
-  if (keychainDisabled()) return
+  if (!isKeychainAvailable()) return
   if (isMac) {
     _macDeleteToken(service)
   } else if (isLinux) {

--- a/packages/server/src/keychain.js
+++ b/packages/server/src/keychain.js
@@ -118,6 +118,20 @@ export function isKeychainAvailable() {
 }
 
 /**
+ * True when the keychain is present-but-UNUSABLE (broken/missing login keychain),
+ * as DISTINCT from explicitly disabled (`CHROXY_DISABLE_KEYCHAIN=1`).
+ *
+ * The server-identity loader (#5615) needs this distinction: a broken keychain
+ * must not silently rotate the identity. It uses `isKeychainBroken()` to fail
+ * safe — refuse to mint a replacement when it can't confirm there's no pinned
+ * identity in the (now unreadable) keychain AND no fallback file exists. The
+ * probe is non-prompting, so this never triggers the macOS modal.
+ */
+export function isKeychainBroken() {
+  return !keychainDisabled() && !keychainUsable()
+}
+
+/**
  * Get token from OS keychain.
  * @param {string} [service] - Keychain service name (default: 'chroxy')
  * @param {string} [account] - Keychain account (default: 'api-token'). Other

--- a/packages/server/src/keychain.js
+++ b/packages/server/src/keychain.js
@@ -77,9 +77,12 @@ function _probeKeychainUsable() {
       })
       // Output is the quoted path, e.g.  "/Users/x/Library/Keychains/login.keychain-db"
       const path = out.trim().replace(/^"(.*)"$/, '$1')
-      // Inconclusive (no path / mocked execFileSync) → assume usable; only a
-      // real, missing path is a definitive broken-keychain signal.
-      if (!path) return true
+      // INCONCLUSIVE → assume usable (preserve prior behaviour + keep mocked
+      // tests working): empty output, OR anything that isn't an absolute path
+      // (a mocked/stubbed value, an unexpected `security` format). Only an
+      // absolute path that is actually MISSING is a definitive broken-keychain
+      // signal — never run existsSync() on a non-path and mistake it for broken.
+      if (!path || !path.startsWith('/')) return true
       return existsSync(path)
     } catch {
       // `security` absent or errored → treat as not usable (file fallback).
@@ -189,20 +192,23 @@ export function getToken(service = DEFAULT_SERVICE, account = ACCOUNT) {
 export function getTokenStatus(service = DEFAULT_SERVICE) {
   // The explicit off-switch (tests) → 'absent': the file fallback owns identity.
   if (keychainDisabled()) return { status: 'absent', value: null, error: null }
-  // #5615 fail-safe: a BROKEN/missing keychain must read as 'error', NOT
-  // 'absent' — an identity caller that re-mints on 'absent' would false-MITM
-  // every already-pinned client. Reporting 'error' makes it fail safe (don't
-  // rotate) AND avoids the prompting find-generic-password call (no modal).
+  // Platforms with NO keychain backend (Windows/other) → 'absent': there is no
+  // keychain that could hold an identity, so the file legitimately owns it (the
+  // documented "other platforms" contract). This must come BEFORE the broken
+  // check — `keychainUsable()` is always false on those platforms, and reporting
+  // 'error' there would wrongly block identity loading.
+  if (!isMac && !isLinux) return { status: 'absent', value: null, error: null }
+  // #5615 fail-safe: on mac/linux a BROKEN/missing keychain reads as 'error',
+  // NOT 'absent' — an identity caller that re-mints on 'absent' would false-MITM
+  // every already-pinned client. 'error' fails safe (don't rotate) AND avoids
+  // the prompting find-generic-password call (no modal).
   if (!keychainUsable()) {
     return { status: 'error', value: null, error: 'keychain unavailable (missing or broken login keychain)' }
   }
   if (isMac) {
     return _macGetTokenStatus(service)
   }
-  if (isLinux) {
-    return _linuxGetTokenStatus(service)
-  }
-  return { status: 'absent', value: null, error: null }
+  return _linuxGetTokenStatus(service)
 }
 
 /**

--- a/packages/server/src/server-identity.js
+++ b/packages/server/src/server-identity.js
@@ -136,7 +136,8 @@ export function loadServerIdentity({ keychain = realKeychain, filePath = DEFAULT
     }
     // status === 'absent' (or malformed found) → continue to the file fallback.
   }
-  // Fallback file.
+  // Fallback file. Checked even when the keychain is unavailable (disabled OR
+  // broken): a valid file identity is authoritative and using it does NOT rotate.
   try {
     const raw = readFileSync(filePath, 'utf-8')
     const parsed = JSON.parse(raw)
@@ -144,6 +145,19 @@ export function loadServerIdentity({ keychain = realKeychain, filePath = DEFAULT
     if (kp) return kp
   } catch {
     // Missing / unreadable / malformed — treated as "no identity yet".
+  }
+  // #5615 (#6234 follow-up): no file identity, and the keychain is present but
+  // BROKEN/unreadable (not merely disabled). We cannot confirm there is no
+  // pinned identity sitting in the now-unreadable keychain, so minting a fresh
+  // one would false-MITM every already-pinned client. Fail safe — refuse to
+  // mint — exactly as the pre-#6234 keychain-read-error path did, but WITHOUT
+  // the macOS modal (the broken state is detected by the non-prompting probe).
+  // Disabled keychains (tests / CHROXY_DISABLE_KEYCHAIN) are NOT broken: they
+  // legitimately fall through to mint a first-run identity.
+  if (typeof keychain.isKeychainBroken === 'function' && keychain.isKeychainBroken()) {
+    throw new IdentityUnavailableError(
+      'server identity keychain is unavailable (broken/missing) and no fallback identity file exists; refusing to mint a replacement that would invalidate pinned clients',
+    )
   }
   return null
 }

--- a/packages/server/tests/keychain-mock.test.js
+++ b/packages/server/tests/keychain-mock.test.js
@@ -45,11 +45,17 @@ if (typeof mock.module !== 'function') {
       // Default: simulate macOS
       platformMock.isMac = true
       platformMock.isLinux = false
+      // The usability probe (`security default-keychain`) is cached per-process;
+      // clear it so each test re-probes against its own mock (and a throw-all
+      // test doesn't poison `usable=false` for the next one).
+      keychain._resetKeychainHealthForTests()
     })
 
     describe('getToken failure handling', () => {
       it('returns null when execFileSync throws (macOS)', () => {
-        cpMock.execFileSync.mock.mockImplementation(() => {
+        cpMock.execFileSync.mock.mockImplementation((cmd, args) => {
+          // Let the usability probe pass so the op-under-test still runs.
+          if (args && args[0] === 'default-keychain') return ''
           throw new Error('security: SecKeychainSearchCopyNext failed')
         })
 
@@ -62,7 +68,9 @@ if (typeof mock.module !== 'function') {
       // verifies the same null-return contract with a Linux-style error message.
       // True Linux-path coverage requires a Linux CI environment.
       it('returns null when execFileSync throws (Linux-style error)', () => {
-        cpMock.execFileSync.mock.mockImplementation(() => {
+        cpMock.execFileSync.mock.mockImplementation((cmd, args) => {
+          // Let the usability probe pass so the op-under-test still runs.
+          if (args && args[0] === 'default-keychain') return ''
           throw new Error('secret-tool: No matching items found')
         })
 
@@ -73,7 +81,9 @@ if (typeof mock.module !== 'function') {
 
     describe('setToken error propagation', () => {
       it('throws when execFileSync throws (macOS)', () => {
-        cpMock.execFileSync.mock.mockImplementation(() => {
+        cpMock.execFileSync.mock.mockImplementation((cmd, args) => {
+          // Let the usability probe pass so the op-under-test still runs.
+          if (args && args[0] === 'default-keychain') return ''
           throw new Error('security: permission denied')
         })
 
@@ -87,7 +97,9 @@ if (typeof mock.module !== 'function') {
 
     describe('deleteToken error tolerance', () => {
       it('does not throw when execFileSync throws (macOS)', () => {
-        cpMock.execFileSync.mock.mockImplementation(() => {
+        cpMock.execFileSync.mock.mockImplementation((cmd, args) => {
+          // Let the usability probe pass so the op-under-test still runs.
+          if (args && args[0] === 'default-keychain') return ''
           throw new Error('security: item not found')
         })
 
@@ -101,7 +113,9 @@ if (typeof mock.module !== 'function') {
       // Note: same binding limitation as getToken — this verifies the error-swallow
       // contract with a Linux-style error message on the macOS code path.
       it('does not throw when execFileSync throws (Linux-style error)', () => {
-        cpMock.execFileSync.mock.mockImplementation(() => {
+        cpMock.execFileSync.mock.mockImplementation((cmd, args) => {
+          // Let the usability probe pass so the op-under-test still runs.
+          if (args && args[0] === 'default-keychain') return ''
           throw new Error('secret-tool: item not found')
         })
 
@@ -154,6 +168,51 @@ if (typeof mock.module !== 'function') {
         assert.equal(result.migrated, true, 'should return migrated:true on success')
         assert.equal(result.config.apiToken, undefined, 'token removed from config')
         assert.equal(result.config.port, 8765, 'other config keys preserved')
+      })
+    })
+
+    // Broken / missing login keychain: the `security default-keychain` probe
+    // reports a path that doesn't exist, so every op must short-circuit to the
+    // file fallback WITHOUT shelling out to the prompting find-/add-/delete-
+    // generic-password calls (which pop the "keychain cannot be found" modal).
+    describe('broken keychain (missing login keychain file) — no prompting ops', () => {
+      const MISSING = '/definitely/not/a/real/path/login.keychain-db'
+      function brokenMock() {
+        cpMock.execFileSync.mock.mockImplementation((cmd, args) => {
+          if (args && args[0] === 'default-keychain') return `"${MISSING}"`
+          // Any OTHER security call would be a prompting op — fail loudly so the
+          // test catches a regression that lets one through.
+          throw new Error(`unexpected prompting keychain call: ${args && args[0]}`)
+        })
+      }
+      const promptingCalls = () =>
+        cpMock.execFileSync.mock.calls.filter(
+          (c) => Array.isArray(c.arguments?.[1]) &&
+            ['find-generic-password', 'add-generic-password', 'delete-generic-password'].includes(c.arguments[1][0]),
+        )
+
+      it('isKeychainAvailable() is false when the default keychain file is missing', () => {
+        brokenMock()
+        assert.equal(keychain.isKeychainAvailable(), false)
+      })
+
+      it('getToken() returns null without a prompting find call', () => {
+        brokenMock()
+        assert.equal(keychain.getToken('test-service'), null)
+        assert.equal(promptingCalls().length, 0, 'must not call find-generic-password on a broken keychain')
+      })
+
+      it('setToken() no-ops (no throw, no prompting add call)', () => {
+        brokenMock()
+        assert.doesNotThrow(() => keychain.setToken('tok', 'test-service'))
+        assert.equal(promptingCalls().length, 0, 'must not call add-generic-password on a broken keychain')
+      })
+
+      it('getTokenStatus() returns "error" (fail-safe), not "absent" (#5615)', () => {
+        brokenMock()
+        const r = keychain.getTokenStatus('test-service')
+        assert.equal(r.status, 'error', 'a broken keychain must NOT read as absent (would re-mint identity)')
+        assert.equal(promptingCalls().length, 0)
       })
     })
   })

--- a/packages/server/tests/server-identity.test.js
+++ b/packages/server/tests/server-identity.test.js
@@ -26,10 +26,14 @@ import {
  * dir so the real ~/.chroxy/ tree is never written (per the test-state rule).
  */
 
-function fakeKeychain({ available = true, readError = null } = {}) {
+function fakeKeychain({ available = true, readError = null, broken = false } = {}) {
   const store = new Map()
   return {
     isKeychainAvailable: () => available,
+    // #6234 — a BROKEN keychain is present-but-unusable (distinct from disabled).
+    // The identity loader fails safe (throws) on broken + no file rather than
+    // minting a replacement that would invalidate pinned clients.
+    isKeychainBroken: () => broken,
     getToken: (service) => store.get(service) ?? null,
     // #5615 — distinguishes absent from a read failure. When `readError` is set
     // the read FAILS (simulating a locked keychain) rather than reporting absence.
@@ -176,6 +180,38 @@ describe('server identity (#5536)', () => {
         const id = getOrCreateServerIdentity({ keychain: kc, filePath })
         assert.equal(id.created, true)
         assert.equal(id.secretKey.length, 64)
+      })
+    })
+
+    // #6234 — a BROKEN/missing keychain (distinct from disabled). The no-modal
+    // fix must NOT trade the modal for a silent rotation.
+    it('(d) broken keychain + a valid fallback FILE identity → loads the file (no rotation, no throw)', () => {
+      withTempDir((filePath) => {
+        // Mint to the FILE (keychain disabled at mint time → file fallback).
+        const minted = getOrCreateServerIdentity({ keychain: fakeKeychain({ available: false }), filePath })
+        assert.equal(existsSync(filePath), true)
+        // Keychain later goes BROKEN: the file is authoritative — load it unchanged.
+        const broken = fakeKeychain({ available: false, broken: true })
+        const loaded = loadServerIdentity({ keychain: broken, filePath })
+        assert.ok(loaded, 'must load the file identity rather than throw')
+        assert.equal(loaded.publicKey, minted.publicKey, 'same identity — no rotation')
+      })
+    })
+
+    it('(e) broken keychain + NO fallback file → throws IdentityUnavailableError (refuses to mint)', () => {
+      withTempDir((filePath) => {
+        const broken = fakeKeychain({ available: false, broken: true })
+        // Can't confirm there is no pinned identity in the unreadable keychain →
+        // fail safe rather than mint a replacement that false-MITMs pinned clients.
+        assert.throws(
+          () => loadServerIdentity({ keychain: broken, filePath }),
+          (err) => err instanceof IdentityUnavailableError,
+        )
+        assert.throws(
+          () => getOrCreateServerIdentity({ keychain: broken, filePath }),
+          IdentityUnavailableError,
+        )
+        assert.equal(existsSync(filePath), false, 'must not write a fresh file identity')
       })
     })
   })


### PR DESCRIPTION
## Summary

A missing/corrupt macOS **login keychain** made the running daemon pop a blocking *"keychain cannot be found to store API token"* modal. `isKeychainAvailable()` only ran `security help` (which still succeeds on a broken box), so `getToken()`/`setToken()` shelled out to `security find-/add-generic-password` — and macOS answers an inaccessible keychain with a modal before erroring.

Closes #6234. (The test suite was already protected via `tests/_setup.mjs` `CHROXY_DISABLE_KEYCHAIN=1` — this is the live daemon path.)

## Fix (`packages/server/src/keychain.js`)

- **Cached, non-prompting usability probe** `keychainUsable()`: `security default-keychain` only *prints* the configured path (no prompt); `existsSync` confirms the file exists. A non-empty path that's **missing** = definitive broken keychain → unusable. An empty/unparseable path is **inconclusive → usable** (preserves prior behaviour + mocked tests).
- `isKeychainAvailable()` now gates on the probe; `getToken`/`setToken`/`deleteToken` short-circuit to the file/env fallback when unusable → **no prompting call → no modal**.
- `getTokenStatus()` returns **`error`** (not `absent`) on a broken keychain so the server-identity caller still **fails safe (#5615)** instead of re-minting and false-MITMing pinned clients.
- Cached per-process (repair keychain → restart picks it up); `_resetKeychainHealthForTests()` for tests.

## Tests

- `keychain-mock.test.js`: reset the probe cache per-test; throw-all mocks let the `default-keychain` probe pass so the op-under-test still runs; **new broken-keychain suite** asserts no prompting find/add/delete calls + `getTokenStatus → error`.
- Green: keychain (25 pass / 5 real-integration skipped) + 202 credential/identity consumer tests.

## Follow-up

Surfacing the broken-keychain state in `chroxy doctor` (so the user knows creds are file-stored + how to repair) is a nice future addition — out of scope here.