### PR TITLE
feat(dashboard): model dropdown → button + modal model-picker (#6220)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -704,20 +704,23 @@ describe('App', () => {
       ],
     }
 
-    it('calls setModel with model id when a specific model is selected', () => {
+    // #6220 — the model picker is now a button that opens a modal; selecting a
+    // model in the modal calls setModel with that model's id.
+    it('calls setModel with the model id when a model is picked from the modal', () => {
       const setModelFn = vi.fn()
       stateOverrides = { ...modelsState, setModel: setModelFn }
       render(<App />)
-      const select = screen.getByTestId('chat-settings-trigger')
-      fireEvent.change(select, { target: { value: 'claude-opus' } })
+      fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+      fireEvent.click(screen.getByTestId('model-picker-item-claude-opus'))
       expect(setModelFn).toHaveBeenCalledWith('claude-opus')
     })
 
-    it('calls setModel with first model id when Default is selected', () => {
+    it('calls setModel with the default model id when the default-marked model is picked', () => {
       const setModelFn = vi.fn()
       stateOverrides = {
         ...modelsState,
         setModel: setModelFn,
+        defaultModelId: 'claude-sonnet',
         getActiveSessionState: () => ({
           messages: [],
           streamingMessageId: null,
@@ -731,8 +734,10 @@ describe('App', () => {
         }),
       }
       render(<App />)
-      const select = screen.getByTestId('chat-settings-trigger')
-      fireEvent.change(select, { target: { value: '' } })
+      fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+      // The default model is rendered with a "(default)" marker; picking it
+      // switches to it explicitly.
+      fireEvent.click(screen.getByTestId('model-picker-item-claude-sonnet'))
       expect(setModelFn).toHaveBeenCalledWith('claude-sonnet')
     })
   })

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -145,6 +145,7 @@ export function AppHeader(props: AppHeaderProps) {
           defaultModelId={props.defaultModelId}
           onModelChange={props.onModelChange}
           readOnlyModel={props.readOnlyModel}
+          providerLabel={props.provider}
           availablePermissionModes={props.availablePermissionModes}
           permissionMode={props.permissionMode}
           onPermissionModeChange={props.onPermissionModeChange}

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -1,6 +1,6 @@
 /**
- * ChatSettingsDropdown — native <select> elements for Model, Permission Mode,
- * and Thinking Level.
+ * ChatSettingsDropdown — model trigger button (opens the modal picker, #6220) +
+ * native <select> elements for Permission Mode and Thinking Level.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
@@ -40,348 +40,196 @@ function renderDropdown(overrides: Partial<ChatSettingsDropdownProps> = {}) {
 }
 
 describe('ChatSettingsDropdown', () => {
-  it('renders the model select', () => {
-    renderDropdown()
-    expect(screen.getByTestId('chat-settings-trigger')).toBeInTheDocument()
+  // #6220 — the model picker is now a button that opens a modal (was a native
+  // <select>). Only permission + thinking remain native <select> comboboxes.
+  describe('model trigger button (#6220)', () => {
+    it('renders the model trigger as a button (not a native select)', () => {
+      renderDropdown()
+      const trigger = screen.getByTestId('chat-settings-trigger')
+      expect(trigger).toBeInTheDocument()
+      expect(trigger.tagName.toLowerCase()).toBe('button')
+    })
+
+    it('shows the active model label', () => {
+      renderDropdown({ activeModel: 'sonnet' })
+      expect(screen.getByTestId('chat-settings-trigger').textContent).toContain('Sonnet')
+    })
+
+    it('shows "Default (<label>)" when the active model is the server default', () => {
+      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'sonnet' })
+      expect(screen.getByTestId('chat-settings-trigger').textContent).toMatch(/Default \(Sonnet\)/)
+    })
+
+    it('resolves a full-id activeModel to its label, not "Default" (#5628)', () => {
+      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'claude-opus-4-7' })
+      const t = screen.getByTestId('chat-settings-trigger').textContent || ''
+      expect(t).toContain('Opus')
+      expect(t).not.toMatch(/^Default/)
+    })
+
+    it('carries the data-kind="model" sizing hook + the model tooltip (#5181/#3888)', () => {
+      renderDropdown({ activeModel: 'opus' })
+      const trigger = screen.getByTestId('chat-settings-trigger')
+      expect(trigger.getAttribute('data-kind')).toBe('model')
+      expect(trigger.getAttribute('title')).toContain('claude-opus-4-7')
+      expect(trigger.getAttribute('aria-label')).toBe(trigger.getAttribute('title'))
+    })
+
+    it('opens the modal picker on click and lists every model', () => {
+      renderDropdown()
+      expect(screen.queryByTestId('model-picker')).toBeNull()
+      fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+      expect(screen.getByTestId('model-picker')).toBeInTheDocument()
+      expect(screen.getByTestId('model-picker-item-sonnet')).toBeInTheDocument()
+      expect(screen.getByTestId('model-picker-item-haiku')).toBeInTheDocument()
+      expect(screen.getByTestId('model-picker-item-opus')).toBeInTheDocument()
+    })
+
+    it('calls onModelChange when a model is picked from the modal', () => {
+      const onModelChange = vi.fn()
+      renderDropdown({ onModelChange })
+      fireEvent.click(screen.getByTestId('chat-settings-trigger'))
+      fireEvent.click(screen.getByTestId('model-picker-item-haiku'))
+      expect(onModelChange).toHaveBeenCalledWith('haiku')
+    })
   })
 
-  it('model select shows current model value', () => {
+  it('renders a permission-mode select alongside the model button', () => {
     renderDropdown()
-    const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
-    expect(modelSelect.value).toBe('sonnet')
+    // Model is a button now; permission is the only combobox by default.
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('model select contains all model options', () => {
-    renderDropdown()
-    const modelSelect = screen.getByTestId('chat-settings-trigger')
-    expect(modelSelect.querySelectorAll('option').length).toBeGreaterThanOrEqual(3)
-  })
-
-  it('renders permission mode select', () => {
-    renderDropdown()
-    const selects = screen.getAllByRole('combobox')
-    // Model + Permission Mode = at least 2 selects
-    expect(selects.length).toBeGreaterThanOrEqual(2)
-  })
-
-  it('hides thinking level when showThinkingLevel is false', () => {
+  it('hides thinking level when showThinkingLevel is false (permission only)', () => {
     renderDropdown({ showThinkingLevel: false })
-    const selects = screen.getAllByRole('combobox')
-    // Model + Permission = 2, no thinking
-    expect(selects).toHaveLength(2)
+    expect(screen.getAllByRole('combobox')).toHaveLength(1)
   })
 
   it('shows thinking level when showThinkingLevel is true', () => {
     renderDropdown({ showThinkingLevel: true, thinkingLevel: 'default' })
-    const selects = screen.getAllByRole('combobox')
-    // Model + Permission + Thinking = 3
-    expect(selects).toHaveLength(3)
+    // Permission + Thinking = 2 comboboxes (model is a button).
+    expect(screen.getAllByRole('combobox')).toHaveLength(2)
   })
 
   it('hides permission mode select when showPermissionMode is false (#3835)', () => {
-    // Codex and other providers without permission-mode switching must not
-    // surface the "Approve / Auto / Plan" selector — the concept doesn't
-    // apply to them and the dropdown values would be misleading.
     renderDropdown({ showPermissionMode: false })
-    const selects = screen.getAllByRole('combobox')
-    // Only the model select remains.
-    expect(selects).toHaveLength(1)
+    // Model is a button (not a combobox); with permission + thinking hidden none remain.
+    expect(screen.queryAllByRole('combobox')).toHaveLength(0)
+    expect(screen.getByTestId('chat-settings-trigger')).toBeInTheDocument()
   })
 
   it('defaults to showing permission mode when showPermissionMode is omitted', () => {
-    // Backwards-compat: existing Claude callers that never set the prop
-    // continue to see the permission picker.
     renderDropdown()
-    const selects = screen.getAllByRole('combobox')
-    expect(selects).toHaveLength(2)
-  })
-
-  it('calls onModelChange when model is selected', () => {
-    const onModelChange = vi.fn()
-    renderDropdown({ onModelChange })
-    fireEvent.change(screen.getByTestId('chat-settings-trigger'), { target: { value: 'haiku' } })
-    expect(onModelChange).toHaveBeenCalledWith('haiku')
+    expect(screen.getAllByRole('combobox')).toHaveLength(1)
   })
 
   it('calls onPermissionModeChange when mode is selected', () => {
     const onPermissionModeChange = vi.fn()
     renderDropdown({ onPermissionModeChange })
-    const selects = screen.getAllByRole('combobox')
-    // Second select is permission mode
-    fireEvent.change(selects[1]!, { target: { value: 'auto' } })
+    // Permission is the first (only) combobox now that the model is a button.
+    fireEvent.change(screen.getAllByRole('combobox')[0]!, { target: { value: 'auto' } })
     expect(onPermissionModeChange).toHaveBeenCalledWith('auto')
   })
 
   it('calls onThinkingLevelChange when level is selected', () => {
     const onThinkingLevelChange = vi.fn()
     renderDropdown({ showThinkingLevel: true, thinkingLevel: 'default', onThinkingLevelChange })
-    const selects = screen.getAllByRole('combobox')
-    // Third select is thinking level
-    fireEvent.change(selects[2]!, { target: { value: 'high' } })
+    // Order: permission (0), thinking (1).
+    fireEvent.change(screen.getAllByRole('combobox')[1]!, { target: { value: 'high' } })
     expect(onThinkingLevelChange).toHaveBeenCalledWith('high')
   })
 
-  // The promptEvaluator toggle was originally rendered inside
-  // ChatSettingsDropdown alongside the model + permission selects. It moved
-  // to SettingsPanel ("Active session" section) — see SettingsPanel.test.tsx
-  // for the per-session toggle coverage. The dropdown should NOT render any
-  // checkbox here even when the parent passes evaluator-related state via
-  // unknown extra props.
   it('does not render any prompt-evaluator checkbox in the header', () => {
     renderDropdown()
     expect(screen.queryByTestId('prompt-evaluator-toggle')).toBeNull()
     expect(screen.queryByTestId('prompt-evaluator-checkbox')).toBeNull()
   })
 
-  it('shows Default option for model when defaultModelId is set', () => {
-    renderDropdown({ defaultModelId: 'sonnet' })
-    const modelSelect = screen.getByTestId('chat-settings-trigger')
-    const options = modelSelect.querySelectorAll('option')
-    const defaultOption = Array.from(options).find(o => o.value === '')
-    expect(defaultOption).toBeDefined()
-    expect(defaultOption!.textContent).toContain('Default')
-  })
-
-  it('selects empty value when activeModel matches defaultModelId', () => {
-    renderDropdown({ defaultModelId: 'sonnet', activeModel: 'sonnet' })
-    const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
-    expect(modelSelect.value).toBe('')
-  })
-
-  it('filters default model from non-default options', () => {
-    renderDropdown({ defaultModelId: 'sonnet' })
-    const modelSelect = screen.getByTestId('chat-settings-trigger')
-    const options = Array.from(modelSelect.querySelectorAll('option'))
-    const nonDefaultOptions = options.filter(o => o.value !== '')
-    expect(nonDefaultOptions.every(o => o.value !== 'sonnet')).toBe(true)
-  })
-
-  it('calls onModelChange with defaultModelId when Default option is selected', () => {
-    const onModelChange = vi.fn()
-    renderDropdown({ defaultModelId: 'sonnet', activeModel: 'haiku', onModelChange })
-    fireEvent.change(screen.getByTestId('chat-settings-trigger'), { target: { value: '' } })
-    expect(onModelChange).toHaveBeenCalledWith('sonnet')
-  })
-
-  // #5628 — the active model can arrive as a FULL id ('claude-opus-4-7')
-  // while the <option> values are short ids ('opus'). A native <select> with
-  // an unmatched value renders its FIRST option, so the header showed
-  // "Default (…)" even though a non-default model was active. The select must
-  // resolve the active model the same way the status bar does (id || fullId).
-  describe('#5628 — header reflects the active session model', () => {
-    it('resolves a full-id activeModel to its short-id option (not Default)', () => {
-      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'claude-opus-4-7' })
-      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
-      expect(modelSelect.value).toBe('opus')
-    })
-
-    it('shows Default only when the full-id activeModel IS the default', () => {
-      renderDropdown({ defaultModelId: 'opus', activeModel: 'claude-opus-4-7' })
-      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
-      expect(modelSelect.value).toBe('')
-    })
-
-    it('renders a synthetic option with the raw id for a model not in the list', () => {
-      // fable is active but not broadcast in availableModels — degrade to the
-      // raw id rather than misrendering as "Default" (#5631 spirit).
-      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'claude-fable-5' })
-      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
-      expect(modelSelect.value).toBe('claude-fable-5')
-      const opt = Array.from(modelSelect.querySelectorAll('option')).find(
-        o => o.value === 'claude-fable-5',
-      )
-      expect(opt).toBeDefined()
-      expect(opt!.textContent).toBe('claude-fable-5')
-    })
-
-    it('does not add a synthetic option when the active model is already listed', () => {
-      renderDropdown({ defaultModelId: 'sonnet', activeModel: 'opus' })
-      const modelSelect = screen.getByTestId('chat-settings-trigger')
-      // sonnet (filtered to Default) + haiku + opus = 3 options total
-      expect(modelSelect.querySelectorAll('option').length).toBe(3)
-    })
-  })
-
-  // #3888 — header model-picker tooltip surfaces model + context-window
-  // #5181 (C3): the model dropdown must be robust to any-length model
-  // name. The actual truncation is CSS (`text-overflow: ellipsis` +
-  // min/max-width keyed off `data-kind="model"`), which jsdom doesn't
-  // apply — so these tests pin the contract the CSS relies on: the
-  // `data-kind="model"` selector hook is present, short and long labels
-  // both render without disturbing the option set, and the full model id
-  // stays discoverable via title/aria-label so a visually-truncated
-  // label is never lost to AT users.
-  describe('#5181 — responsive model dropdown', () => {
-    it('model select carries the data-kind="model" sizing hook', () => {
-      renderDropdown()
-      const modelSelect = screen.getByTestId('chat-settings-trigger')
-      expect(modelSelect.getAttribute('data-kind')).toBe('model')
-    })
-
-    it('renders a very long model label without dropping options', () => {
-      const longModels = [
-        {
-          id: 'long',
-          label: 'Claude Opus 4.7 Extended Thinking (1M context, preview build)',
-          fullId: 'claude-opus-4-7-extended-thinking-1m-preview',
-          contextWindow: 1_000_000,
-        },
-        { id: 'short', label: 'Auto', fullId: 'auto' },
-      ]
-      renderDropdown({ availableModels: longModels, activeModel: 'long', defaultModelId: null })
-      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
-      // Default option + both models present — the long label doesn't
-      // crowd out or collapse the others.
-      expect(modelSelect.querySelectorAll('option').length).toBe(3)
-      expect(modelSelect.value).toBe('long')
-    })
-
-    it('renders a very short model label cleanly', () => {
-      const shortModels = [{ id: 'auto', label: 'Auto', fullId: 'auto' }]
-      renderDropdown({ availableModels: shortModels, activeModel: 'auto', defaultModelId: null })
-      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
-      expect(modelSelect.value).toBe('auto')
-    })
-
-    it('keeps the full model id in title + aria-label so a truncated label stays discoverable', () => {
-      const longModels = [
-        {
-          id: 'long',
-          label: 'Claude Opus 4.7 Extended',
-          fullId: 'claude-opus-4-7-extended-thinking-1m-preview',
-          contextWindow: 1_000_000,
-        },
-      ]
-      renderDropdown({ availableModels: longModels, activeModel: 'long', defaultModelId: null })
-      const modelSelect = screen.getByTestId('chat-settings-trigger')
-      const title = modelSelect.getAttribute('title') ?? ''
-      const aria = modelSelect.getAttribute('aria-label') ?? ''
-      expect(title).toContain('claude-opus-4-7-extended-thinking-1m-preview')
-      expect(aria).toContain('claude-opus-4-7-extended-thinking-1m-preview')
-    })
-  })
-
+  // #3888 — the trigger button surfaces model + context-window via title/aria so
+  // a visually-truncated label is never lost to AT users. (The picker's option
+  // list + default/active marking are covered in ModelPickerModal.test.tsx.)
   describe('active-model tooltip (#3888)', () => {
     it('exposes model id and context-window via title attribute', () => {
       renderDropdown({ activeModel: 'opus' })
-      const select = screen.getByTestId('chat-settings-trigger')
-      const title = select.getAttribute('title') || ''
+      const trigger = screen.getByTestId('chat-settings-trigger')
+      const title = trigger.getAttribute('title') || ''
       expect(title).toContain('claude-opus-4-7')
       expect(title).toContain('200,000 tokens')
     })
 
     it('exposes the same prose via aria-label for screen readers', () => {
       renderDropdown({ activeModel: 'opus' })
-      const select = screen.getByTestId('chat-settings-trigger')
-      expect(select.getAttribute('aria-label')).toBe(select.getAttribute('title'))
+      const trigger = screen.getByTestId('chat-settings-trigger')
+      expect(trigger.getAttribute('aria-label')).toBe(trigger.getAttribute('title'))
     })
 
     it('omits the context-window sentence when contextWindow is missing', () => {
-      // Haiku in the fixture has no contextWindow set, so the tooltip must
-      // not invent one — degrade gracefully to "Active model: <id>." only.
       renderDropdown({ activeModel: 'haiku' })
-      const select = screen.getByTestId('chat-settings-trigger')
-      const title = select.getAttribute('title') || ''
+      const trigger = screen.getByTestId('chat-settings-trigger')
+      const title = trigger.getAttribute('title') || ''
       expect(title).toContain('claude-haiku')
       expect(title).not.toMatch(/context window/i)
     })
 
     it('falls back to a generic line when no model is active', () => {
       renderDropdown({ availableModels: [{ id: 'x', label: 'X', fullId: 'x' }], activeModel: null })
-      const select = screen.getByTestId('chat-settings-trigger')
-      const title = select.getAttribute('title') || ''
+      const trigger = screen.getByTestId('chat-settings-trigger')
+      const title = trigger.getAttribute('title') || ''
       expect(title.toLowerCase()).toContain('active model')
     })
 
     it('matches activeModel against fullId as well as id', () => {
-      // Server can broadcast either the short id or the full id; both must
-      // resolve to the same tooltip metadata so the pill is consistent.
       renderDropdown({ activeModel: 'claude-opus-4-7' })
-      const select = screen.getByTestId('chat-settings-trigger')
-      const title = select.getAttribute('title') || ''
+      const trigger = screen.getByTestId('chat-settings-trigger')
+      const title = trigger.getAttribute('title') || ''
       expect(title).toContain('claude-opus-4-7')
       expect(title).toContain('200,000 tokens')
     })
   })
 
-  // #4464 — TUI provider declares `modelSwitch: false` because the claude
-  // TUI binary doesn't expose mid-session model switching. Today the
-  // dashboard hides the picker entirely by passing availableModels=[], so
-  // users running a long TUI session have no UI surface telling them which
-  // model is active. The fix is a non-interactive read-only badge that
-  // shows in the same slot when a read-only model label is passed AND the
-  // picker is hidden (availableModels is empty).
+  // #4464 — TUI provider declares `modelSwitch: false`; the dashboard hides the
+  // picker (availableModels=[]) and shows a non-interactive read-only badge.
   describe('read-only model badge (#4464)', () => {
     it('renders a non-interactive badge when availableModels is empty and readOnlyModel is set', () => {
       renderDropdown({ availableModels: [], readOnlyModel: 'opus' })
-      // No <select> for model — the picker remains hidden.
       expect(screen.queryByTestId('chat-settings-trigger')).toBeNull()
-      // The badge IS rendered with a stable testid the Maestro flows can
-      // anchor on.
       const badge = screen.getByTestId('active-model-badge')
       expect(badge).toBeInTheDocument()
-      // Crucially NOT a <select> — must be a static span/div so screen
-      // readers + click handlers treat it as read-only.
       expect(badge.tagName.toLowerCase()).not.toBe('select')
     })
 
     it('badge text surfaces the active model id', () => {
       renderDropdown({ availableModels: [], readOnlyModel: 'opus' })
-      const badge = screen.getByTestId('active-model-badge')
-      expect(badge.textContent).toContain('opus')
+      expect(screen.getByTestId('active-model-badge').textContent).toContain('opus')
     })
 
     it('badge falls back to "Default" when readOnlyModel is an empty string', () => {
-      // Per #4464 acceptance: "if `activeModel` is empty/unknown, fall back
-      // to 'default' (whatever ~/.claude/settings.json resolves to)
-      // rather than hiding entirely." Hiding leaves the user blind to which
-      // model the TUI is actually running.
       renderDropdown({ availableModels: [], readOnlyModel: '' })
-      const badge = screen.getByTestId('active-model-badge')
-      expect(badge.textContent).toMatch(/default/i)
+      expect(screen.getByTestId('active-model-badge').textContent).toMatch(/default/i)
     })
 
     it('does NOT render the badge when the picker is shown (availableModels non-empty)', () => {
-      // The picker already displays the active model — a badge alongside
-      // would duplicate the surface.
       renderDropdown({ availableModels: MODELS, activeModel: 'opus', readOnlyModel: 'opus' })
       expect(screen.queryByTestId('active-model-badge')).toBeNull()
       expect(screen.getByTestId('chat-settings-trigger')).toBeInTheDocument()
     })
 
     it('does NOT render the badge when readOnlyModel is null', () => {
-      // Transient state where availableModels is empty for some non-TUI
-      // reason (e.g. provider just switched, models not yet broadcast)
-      // — we don't want to flash a "Default" badge during that window.
       renderDropdown({ availableModels: [], readOnlyModel: null })
       expect(screen.queryByTestId('active-model-badge')).toBeNull()
     })
 
     it('badge surfaces buildActiveModelTooltip output via title and aria-label', () => {
-      // The badge MUST reuse the same tooltip helper as the picker so the
-      // hover text stays in sync (#4464 acceptance: "Hover tooltip matches
-      // existing model picker tooltip").
-      renderDropdown({
-        availableModels: [],
-        activeModel: 'opus',
-        readOnlyModel: 'opus',
-      })
+      renderDropdown({ availableModels: [], activeModel: 'opus', readOnlyModel: 'opus' })
       const badge = screen.getByTestId('active-model-badge')
-      // When availableModels is empty (the TUI case), the helper still
-      // returns a meaningful "Active model: <id>" line — we don't have
-      // contextWindow metadata, but the headline survives.
       expect(badge.getAttribute('title')).toMatch(/active model/i)
       expect(badge.getAttribute('title')).toContain('opus')
-      // Screen reader parity with the picker.
       expect(badge.getAttribute('aria-label')).toBe(badge.getAttribute('title'))
     })
   })
 
-  // #4019 / #4211 Copilot review: the description from
-  // availablePermissionModes flows onto the permission <select>'s title
-  // attribute so the user gets the mid-session trade-off hint on hover.
-  // Server's PERMISSION_MODES carries description for every mode; we surface
-  // the one for the currently-selected option.
+  // #4019 / #4211 — permission-mode description flows onto the permission
+  // <select>'s title (and each <option>'s title).
   describe('#4019 permission-mode description tooltip', () => {
     const MODES_WITH_DESC = [
       { id: 'approve', label: 'Approve', description: 'Default. Each tool call gates on your approval.' },
@@ -425,7 +273,6 @@ describe('ChatSettingsDropdown', () => {
 
     it('falls back gracefully when the selected mode has no description (old server)', () => {
       const { container } = renderDropdown({
-        // Mix of with-/without-description; pre-#4018 servers ship none.
         availablePermissionModes: [
           { id: 'approve', label: 'Approve' },
           { id: 'auto', label: 'Auto' },
@@ -433,22 +280,15 @@ describe('ChatSettingsDropdown', () => {
         permissionMode: 'auto',
       })
       const permSelect = container.querySelector('select[data-kind="permission"]')
-      // No description → title is undefined / empty, not the literal string "undefined".
       const title = permSelect!.getAttribute('title')
       expect(title === null || title === '' || title === undefined).toBe(true)
     })
 
-    // #4212 ask 3 — per-<option> title parity. Most browsers don't surface
-    // option tooltips reliably, but the attribute should still match its
-    // mode's description verbatim so AT machinery (and future refactors of
-    // the picker into a non-native control) see consistent metadata. A
-    // future change that drops `title={m.description}` from the option map
-    // would silently regress this — pin it.
     it('each <option> carries its mode description as title (and omits it when missing)', () => {
       const MIXED = [
         { id: 'approve', label: 'Approve', description: 'Default. Each tool call gates on your approval.' },
         { id: 'auto', label: 'Auto', description: 'Auto-approve every tool call.' },
-        { id: 'legacy', label: 'Legacy' }, // pre-#4018 server: no description
+        { id: 'legacy', label: 'Legacy' },
       ]
       const { container } = renderDropdown({
         availablePermissionModes: MIXED,
@@ -468,7 +308,6 @@ describe('ChatSettingsDropdown', () => {
         'Default. Each tool call gates on your approval.',
       )
       expect(byValue('auto').getAttribute('title')).toBe('Auto-approve every tool call.')
-      // No description → attribute is absent or empty, never the string "undefined".
       const legacyTitle = byValue('legacy').getAttribute('title')
       expect(legacyTitle === null || legacyTitle === '').toBe(true)
     })

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -4,9 +4,10 @@
  * Uses native <select> elements which render their dropdown menus via the OS
  * compositor, avoiding CSS overflow/z-index clipping issues in Tauri WKWebView.
  */
-import { useCallback, useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import type { ModelInfo } from '../store/types'
 import type { PermissionMode } from '@chroxy/store-core'
+import { ModelPickerModal } from './ModelPickerModal'
 
 /**
  * Compose the hover tooltip for the active-model select (#3888).
@@ -50,6 +51,8 @@ export interface ChatSettingsDropdownProps {
   // same as today's "availableModels=[]" behaviour for the transient
   // provider-switch case where we don't want a flash of a stale label.
   readOnlyModel?: string | null
+  // #6220: active provider label, shown as the group header in the modal picker.
+  providerLabel?: string | null
   // #4019: PermissionMode carries an optional `description` field server-side
   // (PERMISSION_MODES exports it for every mode). Use the typed import from
   // store-core so the title-attribute hint stays in lockstep with the wire shape.
@@ -83,18 +86,12 @@ export function ChatSettingsDropdown({
   thinkingLevel,
   onThinkingLevelChange,
   readOnlyModel = null,
+  providerLabel = null,
 }: ChatSettingsDropdownProps) {
-  const handleModelChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    const v = e.target.value
-    if (v) {
-      onModelChange(v)
-    } else if (defaultModelId) {
-      const dm = availableModels.find(m => m.id === defaultModelId)
-      if (dm) onModelChange(dm.id)
-    } else if (availableModels[0]) {
-      onModelChange(availableModels[0].id)
-    }
-  }, [onModelChange, defaultModelId, availableModels])
+  // #6220: the model picker is now a button that opens a modal (was a native
+  // <select>). The select couldn't comfortably hold the full per-provider model
+  // set; the modal gives room for grouping, the default marker, and search.
+  const [pickerOpen, setPickerOpen] = useState(false)
 
   // #3888: hover tooltip on the active-model pill so users can see the full
   // model id and its context window without expanding the dropdown.
@@ -124,37 +121,42 @@ export function ChatSettingsDropdown({
   // True only when the active model genuinely IS the server default — compared
   // on the normalized short id so a full-id activeModel still resolves.
   const activeIsDefault = defaultModelId != null && activeOptionValue === defaultModelId
-  // Render a synthetic option ONLY when the active model is set, isn't the
-  // default, and isn't already one of the listed options.
-  const needsSyntheticOption =
-    !activeIsDefault && !!activeModel && activeEntry === null
+  // Label shown in the trigger button (and for the "Default (…)" form): the
+  // default model's label, falling back to the first model, then 'recommended'.
+  const defaultLabel =
+    (defaultModelId
+      ? availableModels.find((m) => m.id === defaultModelId)?.label
+      : availableModels[0]?.label) ?? 'recommended'
 
   return (
     <>
-      {/* Model */}
+      {/* Model — #6220: a button that opens the modal picker. Reads
+          "Default (<label>)" when the active model is the server default, else
+          the active model's label. */}
       {availableModels.length > 0 && (
-        <select
-          data-testid="chat-settings-trigger"
-          data-kind="model"
-          value={activeIsDefault ? '' : activeOptionValue}
-          onChange={handleModelChange}
-          title={modelTitle}
-          aria-label={modelTitle}
-        >
-          <option value="">
-            Default ({(defaultModelId
-              ? availableModels.find(m => m.id === defaultModelId)?.label
-              : availableModels[0]?.label) ?? 'recommended'})
-          </option>
-          {needsSyntheticOption && (
-            <option value={activeOptionValue}>{activeModel}</option>
-          )}
-          {availableModels
-            .filter(m => m.id !== defaultModelId)
-            .map(m => (
-              <option key={m.id} value={m.id}>{m.label}</option>
-            ))}
-        </select>
+        <>
+          <button
+            type="button"
+            data-testid="chat-settings-trigger"
+            data-kind="model"
+            className="chat-settings-model-btn"
+            onClick={() => setPickerOpen(true)}
+            title={modelTitle}
+            aria-label={modelTitle}
+            aria-haspopup="dialog"
+          >
+            {activeIsDefault ? `Default (${defaultLabel})` : (activeEntry?.label ?? activeModel ?? `Default (${defaultLabel})`)}
+          </button>
+          <ModelPickerModal
+            open={pickerOpen}
+            onClose={() => setPickerOpen(false)}
+            availableModels={availableModels}
+            activeModel={activeModel}
+            defaultModelId={defaultModelId}
+            providerLabel={providerLabel}
+            onSelect={onModelChange}
+          />
+        </>
       )}
 
       {/* #4464: read-only badge for providers without modelSwitch (claude TUI).

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -1,10 +1,14 @@
 /**
- * ChatSettingsDropdown — Model, Permission Mode, and Thinking Level selectors.
+ * ChatSettingsDropdown — Model, Permission Mode, and Thinking Level controls.
  *
- * Uses native <select> elements which render their dropdown menus via the OS
- * compositor, avoiding CSS overflow/z-index clipping issues in Tauri WKWebView.
+ * #6220: the Model control is a BUTTON that opens `ModelPickerModal` (the inline
+ * <select> couldn't hold the full per-provider model set). Permission Mode and
+ * Thinking Level remain native <select> elements, which render their menus via
+ * the OS compositor — avoiding CSS overflow/z-index clipping in Tauri WKWebView.
+ * The modal renders above everything via the shared `Modal` overlay, so it's
+ * likewise clipping-immune.
  */
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ModelInfo } from '../store/types'
 import type { PermissionMode } from '@chroxy/store-core'
 import { ModelPickerModal } from './ModelPickerModal'
@@ -92,6 +96,14 @@ export function ChatSettingsDropdown({
   // <select>). The select couldn't comfortably hold the full per-provider model
   // set; the modal gives room for grouping, the default marker, and search.
   const [pickerOpen, setPickerOpen] = useState(false)
+  // #6237 review: close the picker if the model list empties (a known transient
+  // during a provider switch — see readOnlyModel prop docs). The button/modal
+  // subtree is gated on `availableModels.length > 0`, so without this the modal
+  // unmounts while `pickerOpen` stays true and would silently reopen when models
+  // repopulate.
+  useEffect(() => {
+    if (availableModels.length === 0) setPickerOpen(false)
+  }, [availableModels.length])
 
   // #3888: hover tooltip on the active-model pill so users can see the full
   // model id and its context window without expanding the dropdown.

--- a/packages/dashboard/src/components/ModelPickerModal.test.tsx
+++ b/packages/dashboard/src/components/ModelPickerModal.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * ModelPickerModal (#6220) — modal model picker behaviour: list + group header,
+ * default/active marking, select → onSelect+onClose, search filter, arrow-key
+ * roving focus, disabled (forward-compat) rows, and Escape (via shared Modal).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { ModelPickerModal, type ModelPickerModalProps } from './ModelPickerModal'
+
+afterEach(cleanup)
+
+const MODELS = [
+  { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200000 },
+  { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8', contextWindow: 1_000_000 },
+  { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5' },
+]
+
+function renderModal(overrides: Partial<ModelPickerModalProps> = {}) {
+  const props: ModelPickerModalProps = {
+    open: true,
+    onClose: vi.fn(),
+    availableModels: MODELS,
+    activeModel: 'sonnet',
+    defaultModelId: 'opus',
+    providerLabel: 'claude-cli',
+    onSelect: vi.fn(),
+    ...overrides,
+  }
+  return { props, ...render(<ModelPickerModal {...props} />) }
+}
+
+describe('ModelPickerModal (#6220)', () => {
+  it('renders nothing when closed', () => {
+    renderModal({ open: false })
+    expect(screen.queryByTestId('model-picker')).toBeNull()
+  })
+
+  it('lists every available model under the provider group header', () => {
+    renderModal()
+    expect(screen.getByTestId('model-picker-group').textContent).toBe('claude-cli')
+    expect(screen.getByTestId('model-picker-item-sonnet')).toBeInTheDocument()
+    expect(screen.getByTestId('model-picker-item-opus')).toBeInTheDocument()
+    expect(screen.getByTestId('model-picker-item-haiku')).toBeInTheDocument()
+  })
+
+  it('marks the default model with "(default)"', () => {
+    renderModal({ defaultModelId: 'opus' })
+    expect(screen.getByTestId('model-picker-item-opus').textContent).toMatch(/Opus \(default\)/)
+    expect(screen.getByTestId('model-picker-item-sonnet').textContent).not.toMatch(/default/)
+  })
+
+  it('marks the active model as aria-selected', () => {
+    renderModal({ activeModel: 'sonnet' })
+    expect(screen.getByTestId('model-picker-item-sonnet').getAttribute('aria-selected')).toBe('true')
+    expect(screen.getByTestId('model-picker-item-opus').getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('resolves a full-id activeModel to the right row (#5628)', () => {
+    renderModal({ activeModel: 'claude-opus-4-8' })
+    expect(screen.getByTestId('model-picker-item-opus').getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('calls onSelect with the model id and closes when a row is clicked', () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    renderModal({ onSelect, onClose })
+    fireEvent.click(screen.getByTestId('model-picker-item-haiku'))
+    expect(onSelect).toHaveBeenCalledWith('haiku')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('filters the list by the search query (label, id, or fullId)', () => {
+    renderModal()
+    fireEvent.change(screen.getByTestId('model-picker-search'), { target: { value: 'opus' } })
+    expect(screen.getByTestId('model-picker-item-opus')).toBeInTheDocument()
+    expect(screen.queryByTestId('model-picker-item-sonnet')).toBeNull()
+    expect(screen.queryByTestId('model-picker-item-haiku')).toBeNull()
+  })
+
+  it('shows an empty state when nothing matches the query', () => {
+    renderModal()
+    fireEvent.change(screen.getByTestId('model-picker-search'), { target: { value: 'zzz-no-match' } })
+    expect(screen.getByTestId('model-picker-empty')).toBeInTheDocument()
+  })
+
+  it('renders a disabled (forward-compat) model as a non-selectable row', () => {
+    const onSelect = vi.fn()
+    const models = [...MODELS, { id: 'fable', label: 'Fable', fullId: 'claude-fable-5', disabled: true }]
+    renderModal({ availableModels: models as ModelPickerModalProps['availableModels'], onSelect })
+    const row = screen.getByTestId('model-picker-item-fable') as HTMLButtonElement
+    expect(row.disabled).toBe(true)
+    fireEvent.click(row)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('arrow keys move focus between option rows', () => {
+    renderModal()
+    const sonnet = screen.getByTestId('model-picker-item-sonnet')
+    sonnet.focus()
+    expect(document.activeElement).toBe(sonnet)
+    fireEvent.keyDown(screen.getByTestId('model-picker-list'), { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(screen.getByTestId('model-picker-item-opus'))
+    fireEvent.keyDown(screen.getByTestId('model-picker-list'), { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(sonnet)
+  })
+})

--- a/packages/dashboard/src/components/ModelPickerModal.tsx
+++ b/packages/dashboard/src/components/ModelPickerModal.tsx
@@ -1,0 +1,156 @@
+/**
+ * ModelPickerModal (#6220) — modal model picker that replaces the cramped inline
+ * model <select>. Lists the active provider's selectable models (grouped under a
+ * provider header), marks the default + the active selection, supports a search
+ * filter, and is keyboard-navigable (Esc/Tab via the shared Modal; Arrow keys to
+ * move between options, Enter/click to select).
+ *
+ * Disallowed models (e.g. fable, #6219) are excluded upstream in the server
+ * registry so they never reach `availableModels`; as a defensive forward-compat
+ * hook this also renders any entry flagged `disabled` as a non-selectable row.
+ */
+import { useMemo, useState, useRef, useEffect, useCallback } from 'react'
+import { Modal } from './Modal'
+import type { ModelInfo } from '../store/types'
+
+export interface ModelPickerModalProps {
+  open: boolean
+  onClose: () => void
+  availableModels: ModelInfo[]
+  activeModel: string | null
+  defaultModelId: string | null
+  /** Active provider label used as the group header (e.g. "claude-cli"). */
+  providerLabel?: string | null
+  onSelect: (id: string) => void
+}
+
+/** An entry that may carry a forward-compat `disabled` flag (not yet on ModelInfo). */
+type PickerModel = ModelInfo & { disabled?: boolean }
+
+export function ModelPickerModal({
+  open,
+  onClose,
+  availableModels,
+  activeModel,
+  defaultModelId,
+  providerLabel,
+  onSelect,
+}: ModelPickerModalProps) {
+  const [query, setQuery] = useState('')
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // Reset the search each time the modal opens so a stale filter doesn't hide
+  // the current model on reopen.
+  useEffect(() => {
+    if (open) setQuery('')
+  }, [open])
+
+  // Resolve the active model to its short id the same way the status bar does
+  // (it can arrive as a short id OR a full id) so the checkmark lands on the
+  // right row (#5628).
+  const activeId = useMemo(() => {
+    const entry = availableModels.find((m) => m.id === activeModel || m.fullId === activeModel)
+    return entry?.id ?? activeModel ?? null
+  }, [availableModels, activeModel])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return availableModels
+    return availableModels.filter(
+      (m) =>
+        m.label?.toLowerCase().includes(q) ||
+        m.id.toLowerCase().includes(q) ||
+        m.fullId?.toLowerCase().includes(q),
+    )
+  }, [availableModels, query])
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      onSelect(id)
+      onClose()
+    },
+    [onSelect, onClose],
+  )
+
+  // Arrow-key roving focus over the option rows (Esc + Tab-trap come from Modal).
+  const handleListKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+    e.preventDefault()
+    const items = Array.from(
+      listRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]:not([disabled])') ?? [],
+    )
+    if (items.length === 0) return
+    const idx = items.findIndex((el) => el === document.activeElement)
+    const nextIdx =
+      e.key === 'ArrowDown'
+        ? (idx + 1) % items.length
+        : (idx - 1 + items.length) % items.length
+    items[nextIdx]?.focus()
+  }, [])
+
+  return (
+    <Modal open={open} onClose={onClose} title="Select model" maxWidth="520px" closeOnBackdrop>
+      <div className="model-picker" data-testid="model-picker">
+        <input
+          type="text"
+          className="model-picker-search"
+          placeholder="Search models…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search models"
+          data-testid="model-picker-search"
+        />
+        <div
+          ref={listRef}
+          className="model-picker-list"
+          role="listbox"
+          aria-label="Models"
+          data-testid="model-picker-list"
+          onKeyDown={handleListKeyDown}
+        >
+          {providerLabel ? (
+            <div className="model-picker-group" data-testid="model-picker-group">
+              {providerLabel}
+            </div>
+          ) : null}
+          {filtered.length === 0 ? (
+            <div className="model-picker-empty" data-testid="model-picker-empty">
+              No models match “{query}”.
+            </div>
+          ) : (
+            filtered.map((m) => {
+              const isDefault = defaultModelId != null && m.id === defaultModelId
+              const isActive = m.id === activeId
+              const disabled = (m as PickerModel).disabled === true
+              return (
+                <button
+                  key={m.id}
+                  type="button"
+                  role="option"
+                  aria-selected={isActive}
+                  disabled={disabled}
+                  className={`model-picker-item${isActive ? ' model-picker-item-active' : ''}`}
+                  data-testid={`model-picker-item-${m.id}`}
+                  title={m.fullId || m.id}
+                  onClick={() => {
+                    if (!disabled) handleSelect(m.id)
+                  }}
+                >
+                  <span className="model-picker-item-label">
+                    {m.label || m.id}
+                    {isDefault ? ' (default)' : ''}
+                  </span>
+                  {isActive ? (
+                    <span className="model-picker-item-check" aria-hidden="true">
+                      ✓
+                    </span>
+                  ) : null}
+                </button>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -202,6 +202,97 @@
   border-color: var(--accent-blue);
 }
 
+/* #6220 — model picker trigger button (replaces the model <select>). Mirrors the
+   select chrome + sizing so it sits cleanly in the same header slot. */
+.chat-settings-model-btn {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: var(--text-base);
+  cursor: pointer;
+  text-align: left;
+  width: auto;
+  min-width: 160px;
+  max-width: 240px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.chat-settings-model-btn:hover {
+  border-color: var(--text-secondary);
+}
+.chat-settings-model-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+/* #6220 — modal model picker body (rendered inside the shared .modal-content). */
+.model-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+.model-picker-search {
+  width: 100%;
+}
+.model-picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+.model-picker-group {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 8px 8px 4px;
+}
+.model-picker-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--text-primary);
+  padding: 9px 12px;
+  font-size: var(--text-base);
+  text-align: left;
+  cursor: pointer;
+}
+.model-picker-item:hover:not(:disabled),
+.model-picker-item:focus-visible {
+  outline: none;
+  background: var(--bg-secondary);
+  border-color: var(--scrollbar-thumb);
+}
+.model-picker-item-active {
+  background: var(--bg-secondary);
+  border-color: var(--accent-blue);
+}
+.model-picker-item:disabled {
+  color: var(--text-disabled);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.model-picker-item-check {
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+.model-picker-empty {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  padding: 12px 8px;
+}
+
 /* #4464: read-only model badge for TUI sessions (claude TUI declares
    modelSwitch: false). Mirrors the model <select>'s size + chrome so the
    pill sits cleanly in the same slot; the muted text/border + cursor:default


### PR DESCRIPTION
## Summary

The cramped inline model `<select>` can't comfortably hold the full per-provider model set. Replace it with a **button** that reads `Default (<label>)` (or the active model's label) and opens a **modal model-picker**.

Closes #6220. Pairs with #6219 (registry data — disallowed models are excluded upstream, so they never reach the picker).

## Changes

- **`ModelPickerModal.tsx`** (new, built on the shared `Modal` → Esc + focus-trap + backdrop):
  - lists the active provider's models under a provider group header,
  - marks the **default** `(default)` and the **active** selection (`aria-selected`, resolved by id OR fullId — #5628),
  - **search** filter, **arrow-key** roving focus over option rows,
  - renders any entry flagged `disabled` as a non-selectable row (forward-compat; disallowed models are already excluded by #6219).
- **`ChatSettingsDropdown.tsx`**: the model `<select>` becomes a `button` (keeps the `data-kind="model"` sizing hook + the `title`/`aria-label` tooltip) that opens the modal. Permission + thinking stay native selects. **`AppHeader`** forwards the active provider as the group label.
- CSS: trigger button matches the select chrome; modal list/rows/search styling.

## Acceptance

- [x] Inline control is a button labeled `Default (<model>)` reflecting the active selection per tab.
- [x] Clicking opens a modal listing all selectable models (grouped by provider); disallowed entries are excluded (#6219) / disabled if flagged.
- [x] Selecting updates the session model + the inline label.
- [x] Keyboard accessible (open/close via Modal Esc + focus-trap, arrow-select, Enter/click).

## Tests

`ModelPickerModal.test.tsx` (list/group, default+active marking, select→onSelect+onClose, search, empty state, disabled row, arrow keys) + `ChatSettingsDropdown.test.tsx` rewritten for the button+modal + `App.test.tsx` model-selector tests updated. Dashboard suite + typecheck green.