### PR TITLE
fix(dashboard): bump Opus pricing head to opus-4-8 (#6233)

### DIFF
--- a/packages/dashboard/src/lib/model-pricing.test.ts
+++ b/packages/dashboard/src/lib/model-pricing.test.ts
@@ -194,15 +194,16 @@ describe('MODEL_PRICING table integrity', () => {
   // on a live Claude cost path today — CLIENT_ESTIMATED_COST_PROVIDERS is
   // {codex, gemini} — so this guards table correctness, not a rendered cost.)
   it('prices the current-generation Claude models (#5631)', () => {
-    for (const id of ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5']) {
+    for (const id of ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5']) {
       expect(MODEL_PRICING[id], `${id} missing`).toBeDefined()
       const cost = calculateCost(id, 1000, 1000)
       expect(cost, `${id} cost`).not.toBeNull()
       expect(cost, `${id} cost`).toBeGreaterThan(0)
     }
     // Rates mirror the server's authoritative table (USD/Mtok → USD/1k).
-    expect(MODEL_PRICING['claude-opus-4-7']!.inputPer1k).toBe(0.015)
-    expect(MODEL_PRICING['claude-opus-4-7']!.outputPer1k).toBe(0.075)
+    // #6233: Opus head is opus-4-8 since the registry bump (#6219).
+    expect(MODEL_PRICING['claude-opus-4-8']!.inputPer1k).toBe(0.015)
+    expect(MODEL_PRICING['claude-opus-4-8']!.outputPer1k).toBe(0.075)
     expect(MODEL_PRICING['claude-sonnet-4-6']!.inputPer1k).toBe(0.003)
     expect(MODEL_PRICING['claude-sonnet-4-6']!.outputPer1k).toBe(0.015)
     expect(MODEL_PRICING['claude-haiku-4-5']!.inputPer1k).toBe(0.001)

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -34,10 +34,14 @@ const CLAUDE_PRICING: Record<string, ModelPricing> = {
   // Claude rows are not currently on any live cost path (Claude cost is
   // server-authoritative). They exist to remove the stale 3.x-era data and
   // keep the table right for any future consumer / if Claude is ever added to
-  // that set. (opus-4-8 + fable-5 are intentionally absent — the server
-  // doesn't price them yet either; tracked under #5631. The drift-warn in
-  // calculateCost surfaces any offered-but-unpriced model.)
-  'claude-opus-4-7': { inputPer1k: 0.015, outputPer1k: 0.075, label: 'Claude Opus 4.7' },
+  // that set. (#6233: the Opus head is claude-opus-4-8, matching the server
+  // registry since #6219. fable-5 is intentionally absent — the server ships it
+  // without verified pricing, so it has no pricing key either; tracked under
+  // #5631. The `[1m]` long-context variants are also absent: this flat
+  // USD/1k table can't represent the >200K premium tier the server models in
+  // its `oneM.longContext` block (#4087), and no model carries a [1m] row here.
+  // The drift-warn in calculateCost surfaces any offered-but-unpriced model.)
+  'claude-opus-4-8': { inputPer1k: 0.015, outputPer1k: 0.075, label: 'Claude Opus 4.8' },
   'claude-sonnet-4-6': { inputPer1k: 0.003, outputPer1k: 0.015, label: 'Claude Sonnet 4.6' },
   'claude-haiku-4-5': { inputPer1k: 0.001, outputPer1k: 0.005, label: 'Claude Haiku 4.5' },
   // Claude Sonnet 4.5 — previously mislabeled "Claude 3.7 Sonnet" (the rate

--- a/packages/dashboard/src/lib/model-pricing.ts
+++ b/packages/dashboard/src/lib/model-pricing.ts
@@ -35,9 +35,10 @@ const CLAUDE_PRICING: Record<string, ModelPricing> = {
   // server-authoritative). They exist to remove the stale 3.x-era data and
   // keep the table right for any future consumer / if Claude is ever added to
   // that set. (#6233: the Opus head is claude-opus-4-8, matching the server
-  // registry since #6219. fable-5 is intentionally absent — the server ships it
-  // without verified pricing, so it has no pricing key either; tracked under
-  // #5631. The `[1m]` long-context variants are also absent: this flat
+  // registry since #6219. fable-5 is intentionally absent — the server now
+  // disallows it and filters it out of the registry entirely (#6219), so no
+  // client ever sees it; broader single-source tracked under #5631. The `[1m]`
+  // long-context variants are also absent: this flat
   // USD/1k table can't represent the >200K premium tier the server models in
   // its `oneM.longContext` block (#4087), and no model carries a [1m] row here.
   // The drift-warn in calculateCost surfaces any offered-but-unpriced model.)


### PR DESCRIPTION
## Summary

The dashboard `model-pricing.ts` table still carried the Opus head as `claude-opus-4-7` after #6219 bumped the server registry to `claude-opus-4-8` and removed Fable. This is the follow-up #6231's own scope note flagged.

Closes #6233.

## Changes

- Rename `claude-opus-4-7` → `claude-opus-4-8` (label `Claude Opus 4.8`). **Same base rates** — server prices both at 15/75 USD/Mtok → 0.015/0.075 per 1k — so this is a key+label rename, not a rate change.
- Fix the self-contradictory header comment (it both kept the table "right" and listed `opus-4-8` as "intentionally absent"). Now: `opus-4-8` is the head; `fable-5` stays absent (server ships it without verified pricing → no pricing key); `[1m]` variants stay absent (this flat USD/1k table can't represent the server's >200K `oneM.longContext` premium — #4087 — and no model carries a `[1m]` row here).
- Update `model-pricing.test.ts` to assert the `opus-4-8` key.

## Not a live billing fix

This table only feeds `calculateCost` behind `CLIENT_ESTIMATED_COST_PROVIDERS = {codex, gemini}`; **Claude is not in that set** (Claude cost is server-authoritative). These rows guard table correctness / future-proofing. Broader single-source-of-truth for model metadata is tracked under #5631.

## Scope note

`claude-opus-4-7` still appears in several unrelated **test fixtures** (sample model ids for tooltip/dropdown rendering — `App.test.tsx`, `ChatSettingsDropdown.test.tsx`, etc.). Those aren't pricing data and don't break; updating them is out of scope for this pricing fix (belongs with the #5631 single-source sweep).

## Tests

`model-pricing.test.ts` green (26 passed); typecheck clean.