### PR TITLE
refactor(store-core): migrate checkpoint_created/checkpoint_list onto the shared dispatch table (#5618 Batch 6)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -50,7 +50,9 @@ import {
   handleKeyExchangeOk as sharedKeyExchangeOk,
   handleServerMode as sharedServerMode,
   // checkpoint_created / checkpoint_list migrated to the shared dispatch table
-  // (#5618 Batch 6); only checkpoint_restored stays app-local.
+  // (#5618 Batch 6); checkpoint_restored is not migrated in this batch — it
+  // stays platform-local (here as a switch case; the dashboard via its
+  // HANDLERS map), so this shared import remains.
   handleCheckpointRestored as sharedCheckpointRestored,
   handleError as sharedError,
   handleSessionError as sharedSessionError,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -49,8 +49,8 @@ import {
   handleAuthFail as sharedAuthFail,
   handleKeyExchangeOk as sharedKeyExchangeOk,
   handleServerMode as sharedServerMode,
-  handleCheckpointCreated as sharedCheckpointCreated,
-  handleCheckpointList as sharedCheckpointList,
+  // checkpoint_created / checkpoint_list migrated to the shared dispatch table
+  // (#5618 Batch 6); only checkpoint_restored stays app-local.
   handleCheckpointRestored as sharedCheckpointRestored,
   handleError as sharedError,
   handleSessionError as sharedSessionError,
@@ -143,7 +143,6 @@ import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { hapticSuccess } from '../utils/haptics';
 import type {
   ChatMessage,
-  Checkpoint,
   ConnectionContext,
   ConnectionState,
   CustomAgent,
@@ -1163,6 +1162,8 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
   getSessions: () => getStore().getState().sessions,
+  // #5618 Batch 6 — checkpoint_created reads the prior flat list to append.
+  getCheckpoints: () => getStore().getState().checkpoints,
   // #5618 — user_question raises a background-session notification via the
   // app's own helper (which also mirrors the row into the mobile push store).
   pushSessionNotification: (sessionId, eventType, message) =>
@@ -1187,6 +1188,17 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
       useConversationStore.getState().setSlashCommands(list as SlashCommand[]);
     } else {
       useConversationStore.getState().setCustomAgents(list as CustomAgent[]);
+    }
+  },
+  // #5618 Batch 6 — checkpoint_created / checkpoint_list also mirror into the
+  // app's secondary conversation store (its checkpoint timeline UI), exactly as
+  // the prior inline `useConversationStore.getState().addCheckpoint(...)` /
+  // `setCheckpoints(...)` did. The dashboard omits this hook (no secondary store).
+  syncSecondaryCheckpoints: (op) => {
+    if (op.kind === 'append') {
+      useConversationStore.getState().addCheckpoint(op.checkpoint);
+    } else {
+      useConversationStore.getState().setCheckpoints(op.checkpoints);
     }
   },
   // #5618 Batch 2 — the app tightens provider_list elements via mapProviderList
@@ -3159,26 +3171,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // app builds the structured ServerError + ring + notification-store mirror);
     // the shared handlers own the message construction + console.warn.
 
-    case 'checkpoint_created': {
-      const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);
-      if (next) {
-        set({ checkpoints: next });
-        // Side effect: dual-write into the conversation store. The shared
-        // handler validated the payload, so we can safely treat the appended
-        // entry as the message's `checkpoint` field.
-        useConversationStore.getState().addCheckpoint(msg.checkpoint as Checkpoint);
-      }
-      break;
-    }
-
-    case 'checkpoint_list': {
-      const next = sharedCheckpointList(msg, get().activeSessionId);
-      if (next) {
-        set({ checkpoints: next });
-        useConversationStore.getState().setCheckpoints(next);
-      }
-      break;
-    }
+    // checkpoint_created / checkpoint_list — migrated to the shared dispatch
+    // table (#5618 Batch 6; handled by runDispatch before this switch). The
+    // app's secondary conversation-store mirror (addCheckpoint / setCheckpoints)
+    // now rides on the `syncSecondaryCheckpoints` adapter hook below; the
+    // dashboard omits that hook (no secondary checkpoint store).
 
     case 'checkpoint_restored': {
       // Server created a new session at the checkpoint state.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -42,8 +42,8 @@ import {
   decideKeyPinWithPairingIdentity,
   decodeEncryptionGate,
   handleServerMode as sharedServerMode,
-  handleCheckpointCreated as sharedCheckpointCreated,
-  handleCheckpointList as sharedCheckpointList,
+  // checkpoint_created / checkpoint_list migrated to the shared dispatch table
+  // (#5618 Batch 6); the dashboard has no checkpoint_restored case.
   handleError as sharedError,
   handleSessionError as sharedSessionError,
   handleLogEntry as sharedLogEntry,
@@ -1021,6 +1021,9 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
   getSessions: () => getStore().getState().sessions,
+  // #5618 Batch 6 — checkpoint_created reads the prior flat list to append.
+  // The dashboard omits syncSecondaryCheckpoints (no secondary checkpoint store).
+  getCheckpoints: () => getStore().getState().checkpoints,
   // #5618 — user_question raises a background-session notification via the
   // dashboard's own helper (dedup by (sessionId, eventType); no push store).
   pushSessionNotification: (sessionId, eventType, message) =>
@@ -4719,17 +4722,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // notification_prefs — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'checkpoint_created': {
-      const next = sharedCheckpointCreated(msg, get().checkpoints, get().activeSessionId);
-      if (next) set({ checkpoints: next });
-      break;
-    }
-
-    case 'checkpoint_list': {
-      const next = sharedCheckpointList(msg, get().activeSessionId);
-      if (next) set({ checkpoints: next });
-      break;
-    }
+    // checkpoint_created / checkpoint_list — migrated to the shared dispatch
+    // table (#5618 Batch 6; handled by runDispatch before this switch). The
+    // dashboard has no secondary checkpoint store, so it omits the
+    // syncSecondaryCheckpoints adapter hook (the app implements it).
 
     // session_restore_failed / session_persist_failed — migrated to the shared
     // dispatch table (#5618 Batch 3; handled by runDispatch before this switch).

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -43,7 +43,9 @@ import {
   decodeEncryptionGate,
   handleServerMode as sharedServerMode,
   // checkpoint_created / checkpoint_list migrated to the shared dispatch table
-  // (#5618 Batch 6); the dashboard has no checkpoint_restored case.
+  // (#5618 Batch 6); checkpoint_restored is not migrated in this batch — the
+  // dashboard handles it via its HANDLERS map (handleCheckpointRestored), not
+  // this switch, so no shared import is needed here.
   handleError as sharedError,
   handleSessionError as sharedSessionError,
   handleLogEntry as sharedLogEntry,

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -33,7 +33,7 @@ import {
   runDispatch,
   type ClientStoreAdapter,
 } from '../dispatch-table'
-import type { ChatMessage, SessionInfo } from '../types'
+import type { ChatMessage, SessionInfo, Checkpoint } from '../types'
 import type { FixtureInitialState } from './fixtures'
 
 /** A loose session shape — superset of the table's `DispatchSessionBase`. */
@@ -167,6 +167,10 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => added.push(m),
     getSessions: () => sessionList,
+    // #5618 Batch 6 — checkpoint_created reads the prior flat list to append.
+    // Both clients back it with their flat `checkpoints`; modelled as a read of
+    // the live `flat` ref so the checkpoint fixtures observe identical results.
+    getCheckpoints: () => (flat.checkpoints as Checkpoint[] | undefined) ?? [],
     // #5618 — `pushSessionNotification` is a UI side-effect OUTSIDE the shared
     // store-state contract (the app additionally mirrors into its mobile push
     // store; the dashboard does not). Modelled as a no-op here, exactly like the
@@ -241,6 +245,12 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
           // modelled as a no-op, with the hook invocation covered by the
           // dispatch-table unit tests. The dashboard omits it.
           setCostUpdate: () => {},
+          // #5618 Batch 6 — checkpoint_created / checkpoint_list mirror into the
+          // app's secondary conversation store. Out of the shared contract (the
+          // shared flat `checkpoints` write IS asserted); modelled as a no-op,
+          // with the hook invocation covered by the dispatch-table unit tests.
+          // The dashboard omits it.
+          syncSecondaryCheckpoints: () => {},
         }
       : {}),
     // #5618 Batch 3 — only the DASHBOARD shows the session_stopped info toast

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -73,8 +73,9 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // available_models — migrated to the shared dispatch table (#5618 Batch 5a).
   // checkpoint_created / checkpoint_list — migrated to the shared dispatch table
   // (#5618 Batch 6); both now have DISPATCH_FIXTURES entries, so they leave the
-  // both-clients-switch universe. checkpoint_restored stays app-only (no
-  // dashboard case), so it remains pending.
+  // both-clients-switch universe. checkpoint_restored is NOT migrated in this
+  // batch (both clients still handle it platform-locally — the app via a switch
+  // case, the dashboard via its HANDLERS map), so it remains pending.
   'checkpoint_restored',
   'claude_ready',
   // client_focus_changed — migrated to the shared dispatch table (#5618 Batch 4).

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -71,8 +71,10 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'auth_fail',
   'auth_ok',
   // available_models — migrated to the shared dispatch table (#5618 Batch 5a).
-  'checkpoint_created',
-  'checkpoint_list',
+  // checkpoint_created / checkpoint_list — migrated to the shared dispatch table
+  // (#5618 Batch 6); both now have DISPATCH_FIXTURES entries, so they leave the
+  // both-clients-switch universe. checkpoint_restored stays app-only (no
+  // dashboard case), so it remains pending.
   'checkpoint_restored',
   'claude_ready',
   // client_focus_changed — migrated to the shared dispatch table (#5618 Batch 4).

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1228,6 +1228,52 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
       },
     },
   },
+
+  // 14. checkpoint_created / checkpoint_list (#5618 Batch 6) — flat checkpoint
+  // list write, broadcast-guarded on the active session. The app's extra mirror
+  // into its conversation store rides on `syncSecondaryCheckpoints` (OUTSIDE the
+  // shared contract, like syncSecondaryInventory) — covered by the dispatch-table
+  // unit tests, not asserted here. These pin the SHARED flat-state result.
+  {
+    name: 'checkpoint_created appends the checkpoint to the (empty) flat list',
+    type: 'checkpoint_created',
+    init: { activeSessionId: 's1' },
+    message: { type: 'checkpoint_created', sessionId: 's1', checkpoint: { id: 'cp1', label: 'first' } },
+    expect: { flat: { checkpoints: [{ id: 'cp1', label: 'first' }] } },
+  },
+  {
+    name: 'checkpoint_created is dropped when it targets a non-active session',
+    type: 'checkpoint_created',
+    init: { activeSessionId: 'active' },
+    message: { type: 'checkpoint_created', sessionId: 'other', checkpoint: { id: 'cp1' } },
+    expect: { noop: true },
+  },
+  {
+    name: 'checkpoint_created is a no-op when the checkpoint payload is missing/non-object',
+    type: 'checkpoint_created',
+    message: { type: 'checkpoint_created' },
+    expect: { noop: true },
+  },
+  {
+    name: 'checkpoint_list replaces the flat checkpoint list with the server array',
+    type: 'checkpoint_list',
+    init: { activeSessionId: 's1' },
+    message: { type: 'checkpoint_list', sessionId: 's1', checkpoints: [{ id: 'a' }, { id: 'b' }] },
+    expect: { flat: { checkpoints: [{ id: 'a' }, { id: 'b' }] } },
+  },
+  {
+    name: 'checkpoint_list is dropped when it targets a non-active session',
+    type: 'checkpoint_list',
+    init: { activeSessionId: 'active' },
+    message: { type: 'checkpoint_list', sessionId: 'other', checkpoints: [{ id: 'a' }] },
+    expect: { noop: true },
+  },
+  {
+    name: 'checkpoint_list is a no-op when checkpoints is not an array',
+    type: 'checkpoint_list',
+    message: { type: 'checkpoint_list' },
+    expect: { noop: true },
+  },
 ]
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -12,6 +12,7 @@ import type {
   DevPreview,
   PendingBackgroundShell,
   QueuedSessionMessage,
+  Checkpoint,
 } from './types'
 import type { PermissionRule } from './handlers'
 
@@ -100,6 +101,18 @@ function makeAdapter(init?: {
    * shared list writes (the optional-chained tunnel apply is skipped).
    */
   tunnel?: boolean
+  /**
+   * Seed the flat `checkpoints` list so `checkpoint_created`'s read-modify-write
+   * (append) can be observed against a non-empty prior list (#5618 Batch 6).
+   */
+  checkpoints?: Checkpoint[]
+  /**
+   * When true, the adapter wires `syncSecondaryCheckpoints` (records into
+   * `checkpointSyncs`) — the app's secondary conversation-store mirror for
+   * checkpoint_created / checkpoint_list (#5618 Batch 6). When omitted, the hook
+   * is absent (the dashboard's behaviour: flat write only, no mirror).
+   */
+  checkpointMirror?: boolean
 }) {
   const sessions: Record<string, FakeSession> = init?.sessions ?? {}
   let activeSessionId = init?.activeSessionId ?? null
@@ -107,6 +120,7 @@ function makeAdapter(init?: {
   const myClientId = init?.myClientId ?? null
   const followMode = init?.followMode ?? false
   const flat: Record<string, unknown> = {}
+  if (init?.checkpoints) flat.checkpoints = init.checkpoints
   const addedMessages: ChatMessage[] = []
   const notifications: Array<{ sessionId: string; eventType: string; message: string }> = []
   const inventorySyncs: Array<{ kind: string; list: unknown[] }> = []
@@ -116,6 +130,9 @@ function makeAdapter(init?: {
   const primaryClientIds: Array<string | null> = []
   const costUpdates: Array<{ totalCost: number | null; budget: number | null }> = []
   const rotatedTunnelUrls: Array<{ url: string; previousUrl: string | null }> = []
+  const checkpointSyncs: Array<
+    { kind: 'append'; checkpoint: Checkpoint } | { kind: 'replace'; checkpoints: Checkpoint[] }
+  > = []
 
   const adapter: ClientStoreAdapter<FakeSession> = {
     getActiveSessionId: () => activeSessionId,
@@ -129,6 +146,7 @@ function makeAdapter(init?: {
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => addedMessages.push(m),
     getSessions: () => sessionList,
+    getCheckpoints: () => (flat.checkpoints as Checkpoint[] | undefined) ?? [],
     pushSessionNotification: (sessionId, eventType, message) =>
       notifications.push({ sessionId, eventType, message }),
     ...(init?.callbacks
@@ -179,6 +197,13 @@ function makeAdapter(init?: {
             rotatedTunnelUrls.push({ url, previousUrl }),
         }
       : {}),
+    ...(init?.checkpointMirror
+      ? {
+          syncSecondaryCheckpoints: (
+            op: { kind: 'append'; checkpoint: Checkpoint } | { kind: 'replace'; checkpoints: Checkpoint[] },
+          ) => checkpointSyncs.push(op),
+        }
+      : {}),
   }
 
   return {
@@ -187,6 +212,7 @@ function makeAdapter(init?: {
     flat,
     addedMessages,
     notifications,
+    checkpointSyncs,
     inventorySyncs,
     serverErrors,
     infoNotifications,
@@ -1527,6 +1553,75 @@ describe('shared dispatch table', () => {
       const env = makeAdapter()
       dispatch(env, { type: 'web_task_updated' })
       expect(env.flat.webTasks).toBeUndefined()
+    })
+  })
+
+  describe('checkpoint_created / checkpoint_list (#5618 Batch 6)', () => {
+    it('owns the message (runDispatch true) for both create and list', () => {
+      const env = makeAdapter()
+      expect(dispatch(env, { type: 'checkpoint_created', checkpoint: { id: 'cp1' } })).toBe(true)
+      expect(dispatch(env, { type: 'checkpoint_list', checkpoints: [] })).toBe(true)
+    })
+
+    it('checkpoint_created appends to the (empty) flat list', () => {
+      const env = makeAdapter({ activeSessionId: 's1' })
+      dispatch(env, { type: 'checkpoint_created', sessionId: 's1', checkpoint: { id: 'cp1', label: 'first' } })
+      expect(env.flat.checkpoints).toEqual([{ id: 'cp1', label: 'first' }])
+    })
+
+    it('checkpoint_created appends to a NON-empty prior list (read-modify-write via getCheckpoints)', () => {
+      const env = makeAdapter({ activeSessionId: 's1', checkpoints: [{ id: 'cp0' } as Checkpoint] })
+      dispatch(env, { type: 'checkpoint_created', sessionId: 's1', checkpoint: { id: 'cp1' } })
+      expect(env.flat.checkpoints).toEqual([{ id: 'cp0' }, { id: 'cp1' }])
+    })
+
+    it('checkpoint_created is dropped for a non-active session (no flat write)', () => {
+      const env = makeAdapter({ activeSessionId: 'active' })
+      dispatch(env, { type: 'checkpoint_created', sessionId: 'other', checkpoint: { id: 'cp1' } })
+      expect(env.flat.checkpoints).toBeUndefined()
+    })
+
+    it('checkpoint_created is a no-op when the checkpoint payload is missing/non-object', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'checkpoint_created' })
+      expect(env.flat.checkpoints).toBeUndefined()
+    })
+
+    it('checkpoint_list replaces the flat list with the server array', () => {
+      const env = makeAdapter({ activeSessionId: 's1', checkpoints: [{ id: 'old' } as Checkpoint] })
+      dispatch(env, { type: 'checkpoint_list', sessionId: 's1', checkpoints: [{ id: 'a' }, { id: 'b' }] })
+      expect(env.flat.checkpoints).toEqual([{ id: 'a' }, { id: 'b' }])
+    })
+
+    it('checkpoint_list is dropped for a non-active session', () => {
+      const env = makeAdapter({ activeSessionId: 'active' })
+      dispatch(env, { type: 'checkpoint_list', sessionId: 'other', checkpoints: [{ id: 'a' }] })
+      expect(env.flat.checkpoints).toBeUndefined()
+    })
+
+    it('checkpoint_list is a no-op when checkpoints is not an array', () => {
+      const env = makeAdapter()
+      dispatch(env, { type: 'checkpoint_list' })
+      expect(env.flat.checkpoints).toBeUndefined()
+    })
+
+    // The app's secondary conversation-store mirror rides on the optional
+    // syncSecondaryCheckpoints hook; the dashboard omits it (flat write only).
+    it('app mirror: syncSecondaryCheckpoints append on create, replace on list', () => {
+      const env = makeAdapter({ activeSessionId: 's1', checkpointMirror: true })
+      dispatch(env, { type: 'checkpoint_created', sessionId: 's1', checkpoint: { id: 'cp1' } })
+      dispatch(env, { type: 'checkpoint_list', sessionId: 's1', checkpoints: [{ id: 'a' }] })
+      expect(env.checkpointSyncs).toEqual([
+        { kind: 'append', checkpoint: { id: 'cp1' } },
+        { kind: 'replace', checkpoints: [{ id: 'a' }] },
+      ])
+    })
+
+    it('dashboard (no mirror hook) still writes flat state and never mirrors', () => {
+      const env = makeAdapter({ activeSessionId: 's1' }) // no checkpointMirror → hook absent
+      dispatch(env, { type: 'checkpoint_created', sessionId: 's1', checkpoint: { id: 'cp1' } })
+      expect(env.flat.checkpoints).toEqual([{ id: 'cp1' }])
+      expect(env.checkpointSyncs).toEqual([])
     })
   })
 })

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -58,6 +58,7 @@ import type {
   ServerErrorCategory,
   SessionRole,
   WebTask,
+  Checkpoint,
 } from './types'
 import { nextMessageId } from './utils'
 import {
@@ -126,6 +127,9 @@ import {
   // --- multi_question_intervention (#5618) — byte-identical builder + append ---
   handleMultiQuestionIntervention,
   applyInterventionBuilder,
+  // --- checkpoint cases (#5618 Batch 6) ---
+  handleCheckpointCreated,
+  handleCheckpointList,
   resolveSessionId,
   type PermissionMode,
   type PermissionRule,
@@ -247,6 +251,14 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
   /** Read the current session list (for `session_updated`). */
   getSessions(): SessionInfo[]
   /**
+   * Read the current flat checkpoint list (#5618 Batch 6). `checkpoint_created`
+   * is a read-modify-write (append to the existing list), so the dispatch
+   * handler needs the prior array — mirrors the inline `get().checkpoints` both
+   * clients read before this migration. Both back it with their flat connection
+   * state's `checkpoints` field.
+   */
+  getCheckpoints(): Checkpoint[]
+  /**
    * Push a per-session notification for a BACKGROUND session event (#5618).
    * Used by the `user_question` case to surface a question raised in a session
    * that is not the active one. Each client backs this with its own
@@ -291,6 +303,23 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * {@link ClientStoreAdapter.pushSessionNotification}.
    */
   syncSecondaryInventory?(kind: 'slashCommands' | 'customAgents', list: unknown[]): void
+  /**
+   * Mirror checkpoint changes into a SECONDARY client store (#5618 Batch 6).
+   * The mobile app keeps a separate `useConversationStore` whose checkpoint list
+   * powers its timeline UI; after the `checkpoint_created` / `checkpoint_list`
+   * dispatch handlers write the flat connection-state list, they call this to
+   * keep that store in sync — exactly the app's prior inline
+   * `useConversationStore.getState().addCheckpoint(...)` (append) /
+   * `setCheckpoints(...)` (replace). The `kind` discriminates which call.
+   *
+   * OPTIONAL: a client without a secondary checkpoint store (the dashboard)
+   * omits it; the dispatch handler then performs only the flat-state write. A
+   * platform-specific side-effect OUTSIDE the shared store-state contract, in
+   * the same spirit as {@link ClientStoreAdapter.syncSecondaryInventory}.
+   */
+  syncSecondaryCheckpoints?(
+    op: { kind: 'append'; checkpoint: Checkpoint } | { kind: 'replace'; checkpoints: Checkpoint[] },
+  ): void
   /**
    * Map/validate the raw `provider_list` element array before it is written to
    * flat state (#5618 Batch 2). The mobile app tightens each entry (drops
@@ -738,6 +767,19 @@ export interface DispatchMessageMap {
     questionCount?: number
     reason?: string
     timestamp?: number
+  }
+  // --- checkpoint cases (#5618 Batch 6) ---
+  // Both carry the broadcast-guard `sessionId`; the active-session gate +
+  // payload validation live in handleCheckpointCreated / handleCheckpointList.
+  checkpoint_created: {
+    type: 'checkpoint_created'
+    sessionId?: string
+    checkpoint?: unknown
+  }
+  checkpoint_list: {
+    type: 'checkpoint_list'
+    sessionId?: string
+    checkpoints?: unknown[]
   }
 }
 
@@ -1474,6 +1516,43 @@ function dispatchWebTaskUpsert<S extends DispatchSessionBase>(
 }
 
 /**
+ * `checkpoint_created` (#5618 Batch 6) — append the new checkpoint to the
+ * active-session list. Byte-identical between the clients' switches modulo the
+ * app's extra mirror into its `useConversationStore` (abstracted behind
+ * `syncSecondaryCheckpoints`, which the dashboard omits). Reads the prior list
+ * via `getCheckpoints()` and only writes on a non-null handler result — matching
+ * each client's prior `if (next) { set(...) }` guard (no no-op state churn).
+ */
+function dispatchCheckpointCreated<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['checkpoint_created'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const next = handleCheckpointCreated(
+    msg as Record<string, unknown>,
+    adapter.getCheckpoints(),
+    adapter.getActiveSessionId(),
+  )
+  if (!next) return
+  adapter.setState({ checkpoints: next } as Record<string, Checkpoint[]>)
+  adapter.syncSecondaryCheckpoints?.({ kind: 'append', checkpoint: msg.checkpoint as Checkpoint })
+}
+
+/**
+ * `checkpoint_list` (#5618 Batch 6) — replace the active-session checkpoint list
+ * with the server array. Pure flat write (no prior state needed); the app also
+ * mirrors the replacement into its secondary store via `syncSecondaryCheckpoints`.
+ */
+function dispatchCheckpointList<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['checkpoint_list'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const next = handleCheckpointList(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (!next) return
+  adapter.setState({ checkpoints: next } as Record<string, Checkpoint[]>)
+  adapter.syncSecondaryCheckpoints?.({ kind: 'replace', checkpoints: next })
+}
+
+/**
  * `user_question` (#5618) — append the question prompt to its (resolved)
  * session, falling back to the global log, then raise a background-session
  * notification. Byte-identical between the two clients' switches: both parsed
@@ -1642,6 +1721,9 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     user_question: dispatchUserQuestion,
     // --- multi_question_intervention (#5618) — byte-identical builder + append ---
     multi_question_intervention: dispatchMultiQuestionIntervention,
+    // --- checkpoint cases (#5618 Batch 6) ---
+    checkpoint_created: dispatchCheckpointCreated,
+    checkpoint_list: dispatchCheckpointList,
   }
 }
 
@@ -1712,6 +1794,9 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'user_question',
   // --- multi_question_intervention (#5618) — byte-identical builder + append ---
   'multi_question_intervention',
+  // --- checkpoint cases (#5618 Batch 6) ---
+  'checkpoint_created',
+  'checkpoint_list',
 ]
 
 /**


### PR DESCRIPTION
## Summary

Continues the dispatch-table migration (epic #5618): moves **`checkpoint_created`** and **`checkpoint_list`** off the twin platform-local switches onto the shared table (`createDispatchTable` + `runDispatch`). Both were byte-identical between the app and dashboard except the app's secondary mirror into its conversation store.

Related to #5618 (epic stays open).

## Approach (the #5595 playbook)

- **`dispatch-table.ts`**: `dispatchCheckpointCreated` / `dispatchCheckpointList` + registration + `DISPATCH_TABLE_TYPES` + `DispatchMessageMap` shapes.
  - `checkpoint_list` is a pure flat write (like `slash_commands`).
  - `checkpoint_created` is a **read-modify-write** (append to the prior list), so the adapter gains a **`getCheckpoints()`** read accessor (mirrors the existing `getSessions()`). This preserves each client's prior `if (next) { set(...) }` guard exactly — **no no-op state churn** (the reason I didn't reuse `updateState`).
- **App's conversation-store mirror** (`addCheckpoint` / `setCheckpoints`) rides on a **new optional `syncSecondaryCheckpoints?(op)` adapter hook** (`{kind:'append'|'replace'}`) — the same OUTSIDE-the-shared-contract pattern as `syncSecondaryInventory`. The **dashboard omits it** (flat write only).
- **Client handlers**: both cases removed; app wires `getCheckpoints` + `syncSecondaryCheckpoints`, dashboard wires only `getCheckpoints`. `checkpoint_restored` stays app-local (no dashboard case → still in the PENDING allowlist).

## Drift protection
- **6 contract fixtures** (`fixtures.ts`): write + non-active-session drop + malformed no-op, for each type.
- **10 dispatch-table unit tests**: ownership, empty + non-empty append (read-modify-write), gate drops, no-ops, and the **app-mirror vs dashboard-no-mirror** divergence.
- Removed `checkpoint_created` / `checkpoint_list` from the coverage-lint `PENDING_CONTRACT_TYPES` allowlist (it only shrinks).

## Verification (local)
- store-core full suite **1827 pass**
- dispatch-table + contract + coverage-lint **224 pass**
- dashboard `tsc --noEmit` clean · app `tsc --noEmit` clean
- app `message-handler.test.ts` **188 pass** (run `--runInBand --forceExit`)