### PR TITLE
feat(dashboard): drag-to-scroll + chevron press-and-hold for Control Room tabs (#6230)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -392,14 +392,17 @@ describe('ControlRoomView auto-fetch on activation (#5543)', () => {
         vi.advanceTimersByTime(120)
         expect(scrollBy.mock.calls.length).toBeGreaterThan(callsAfterFirstTick)
 
-        // Release stops the repeat…
+        // Release stops the repeat. The trailing click fires immediately (same
+        // task as pointerup, before the next-tick `didRepeatRef` reset) so it is
+        // swallowed — no extra single-jump.
         fireEvent.pointerUp(right)
         const callsAtRelease = scrollBy.mock.calls.length
-        vi.advanceTimersByTime(360)
+        fireEvent.click(right)
         expect(scrollBy.mock.calls.length).toBe(callsAtRelease)
 
-        // …and the click that trails the release is swallowed (no extra jump).
-        fireEvent.click(right)
+        // After the next tick the marker clears and the repeat stays stopped, so
+        // no further scrolls happen on idle time.
+        vi.advanceTimersByTime(360)
         expect(scrollBy.mock.calls.length).toBe(callsAtRelease)
       } finally {
         vi.useRealTimers()
@@ -410,7 +413,7 @@ describe('ControlRoomView auto-fetch on activation (#5543)', () => {
       render(<ControlRoomView />)
       const tablist = screen.getByTestId('cr-tabs')
       setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 200 })
-      fireEvent.pointerDown(tablist, { button: 0, clientX: 150, pointerId: 1 })
+      fireEvent.pointerDown(tablist, { button: 0, pointerType: 'mouse', clientX: 150, pointerId: 1 })
       // A tiny move (≤5px) is treated as a click, not a drag.
       fireEvent.pointerMove(tablist, { clientX: 153, pointerId: 1 })
       expect(tablist.scrollLeft).toBe(200)
@@ -418,6 +421,16 @@ describe('ControlRoomView auto-fetch on activation (#5543)', () => {
       fireEvent.pointerMove(tablist, { clientX: 110, pointerId: 1 })
       expect(tablist.scrollLeft).toBe(200 - (110 - 150)) // startScroll - dx = 240
       fireEvent.pointerUp(tablist, { pointerId: 1 })
+    })
+
+    it('ignores a touch pointer (native pan-x handles it — no double-scroll)', () => {
+      render(<ControlRoomView />)
+      const tablist = screen.getByTestId('cr-tabs')
+      setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 200 })
+      fireEvent.pointerDown(tablist, { button: 0, pointerType: 'touch', clientX: 200, pointerId: 1 })
+      fireEvent.pointerMove(tablist, { clientX: 100, pointerId: 1 })
+      // Manual drag never engaged — scrollLeft is left to native panning.
+      expect(tablist.scrollLeft).toBe(200)
     })
 
     it('a drag does not switch tabs (the trailing tab-click is suppressed)', () => {
@@ -428,14 +441,15 @@ describe('ControlRoomView auto-fetch on activation (#5543)', () => {
       const containers = screen.getByTestId('cr-tab-containers')
       expect(repos.getAttribute('aria-selected')).toBe('true') // default tab
       // Drag the strip, then the pointer-up lands a click on another tab.
-      fireEvent.pointerDown(tablist, { button: 0, clientX: 200, pointerId: 1 })
+      fireEvent.pointerDown(tablist, { button: 0, pointerType: 'mouse', clientX: 200, pointerId: 1 })
       fireEvent.pointerMove(tablist, { clientX: 120, pointerId: 1 })
       fireEvent.pointerUp(tablist, { pointerId: 1 })
       fireEvent.click(containers)
       // Suppressed: repos stays selected, containers did not activate.
       expect(repos.getAttribute('aria-selected')).toBe('true')
       expect(containers.getAttribute('aria-selected')).toBe('false')
-      // A subsequent plain click (no drag) selects normally.
+      // A subsequent plain click (no drag) selects normally (the suppressed click
+      // reset the drag marker synchronously).
       fireEvent.click(containers)
       expect(containers.getAttribute('aria-selected')).toBe('true')
     })

--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -359,4 +359,85 @@ describe('ControlRoomView auto-fetch on activation (#5543)', () => {
       expect(scrollBy.mock.calls[0]![0].left).toBeCloseTo(210, 0)
     })
   })
+
+  // #6230 — harden the chevron-only path for mouse-only users: press-and-hold a
+  // chevron for continuous scroll, and drag the strip itself to scroll.
+  describe('#6230 press-and-hold + drag-to-scroll', () => {
+    function setGeometry(el: HTMLElement, g: { clientWidth: number; scrollWidth: number; scrollLeft: number }) {
+      Object.defineProperty(el, 'clientWidth', { value: g.clientWidth, configurable: true })
+      Object.defineProperty(el, 'scrollWidth', { value: g.scrollWidth, configurable: true })
+      Object.defineProperty(el, 'scrollLeft', { value: g.scrollLeft, writable: true, configurable: true })
+    }
+
+    it('press-and-hold on a chevron scrolls repeatedly until released, then swallows the trailing click', () => {
+      vi.useFakeTimers()
+      try {
+        render(<ControlRoomView />)
+        const tablist = screen.getByTestId('cr-tabs')
+        const scrollBy = vi.fn()
+        ;(tablist as unknown as { scrollBy: typeof scrollBy }).scrollBy = scrollBy
+        setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 0 })
+        fireEvent.scroll(tablist)
+        const right = screen.getByTestId('cr-tabs-chevron-right')
+
+        fireEvent.pointerDown(right)
+        // Before the hold threshold (350ms) nothing repeats.
+        vi.advanceTimersByTime(300)
+        expect(scrollBy).not.toHaveBeenCalled()
+        // Past the threshold, the repeat interval (120ms) nudges by ~18% width.
+        vi.advanceTimersByTime(50 + 120)
+        const callsAfterFirstTick = scrollBy.mock.calls.length
+        expect(callsAfterFirstTick).toBeGreaterThanOrEqual(1)
+        expect(scrollBy.mock.calls[0]![0].left).toBeCloseTo(54, 0) // 0.18 * 300
+        vi.advanceTimersByTime(120)
+        expect(scrollBy.mock.calls.length).toBeGreaterThan(callsAfterFirstTick)
+
+        // Release stops the repeat…
+        fireEvent.pointerUp(right)
+        const callsAtRelease = scrollBy.mock.calls.length
+        vi.advanceTimersByTime(360)
+        expect(scrollBy.mock.calls.length).toBe(callsAtRelease)
+
+        // …and the click that trails the release is swallowed (no extra jump).
+        fireEvent.click(right)
+        expect(scrollBy.mock.calls.length).toBe(callsAtRelease)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('dragging the strip past the threshold scrolls it', () => {
+      render(<ControlRoomView />)
+      const tablist = screen.getByTestId('cr-tabs')
+      setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 200 })
+      fireEvent.pointerDown(tablist, { button: 0, clientX: 150, pointerId: 1 })
+      // A tiny move (≤5px) is treated as a click, not a drag.
+      fireEvent.pointerMove(tablist, { clientX: 153, pointerId: 1 })
+      expect(tablist.scrollLeft).toBe(200)
+      // A real drag left (pointer moves right→ content scrolls back) updates scrollLeft.
+      fireEvent.pointerMove(tablist, { clientX: 110, pointerId: 1 })
+      expect(tablist.scrollLeft).toBe(200 - (110 - 150)) // startScroll - dx = 240
+      fireEvent.pointerUp(tablist, { pointerId: 1 })
+    })
+
+    it('a drag does not switch tabs (the trailing tab-click is suppressed)', () => {
+      render(<ControlRoomView initialTab="repos" />)
+      const tablist = screen.getByTestId('cr-tabs')
+      setGeometry(tablist, { clientWidth: 300, scrollWidth: 900, scrollLeft: 0 })
+      const repos = screen.getByTestId('cr-tab-repos')
+      const containers = screen.getByTestId('cr-tab-containers')
+      expect(repos.getAttribute('aria-selected')).toBe('true') // default tab
+      // Drag the strip, then the pointer-up lands a click on another tab.
+      fireEvent.pointerDown(tablist, { button: 0, clientX: 200, pointerId: 1 })
+      fireEvent.pointerMove(tablist, { clientX: 120, pointerId: 1 })
+      fireEvent.pointerUp(tablist, { pointerId: 1 })
+      fireEvent.click(containers)
+      // Suppressed: repos stays selected, containers did not activate.
+      expect(repos.getAttribute('aria-selected')).toBe('true')
+      expect(containers.getAttribute('aria-selected')).toBe('false')
+      // A subsequent plain click (no drag) selects normally.
+      fireEvent.click(containers)
+      expect(containers.getAttribute('aria-selected')).toBe('true')
+    })
+  })
 })

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -483,6 +483,83 @@ export function ControlRoomView({
     // scrollBy, and a missing scroll method must not throw.
     el.scrollBy?.({ left: dir * el.clientWidth * 0.7, behavior: 'smooth' })
   }, [])
+
+  // #6230: harden the chevron-only path for mouse-only users (no wheel-tilt).
+  // (a) PRESS-AND-HOLD a chevron → continuous scroll. A hold timer (350ms)
+  //     distinguishes a tap (→ the single-jump onClick below) from a hold
+  //     (→ a repeat interval that nudges the strip every 120ms while held).
+  //     `didRepeatRef` suppresses the trailing click that fires when a long
+  //     hold is released, so a hold doesn't tack on an extra jump.
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const repeatRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const didRepeatRef = useRef(false)
+  const stopHold = useCallback(() => {
+    if (holdTimerRef.current !== null) {
+      clearTimeout(holdTimerRef.current)
+      holdTimerRef.current = null
+    }
+    if (repeatRef.current !== null) {
+      clearInterval(repeatRef.current)
+      repeatRef.current = null
+    }
+  }, [])
+  const startHold = useCallback((dir: -1 | 1) => {
+    stopHold()
+    didRepeatRef.current = false
+    holdTimerRef.current = setTimeout(() => {
+      didRepeatRef.current = true
+      repeatRef.current = setInterval(() => {
+        const el = tablistRef.current
+        // Smaller, snappy nudges (no smooth easing) for a continuous feel.
+        el?.scrollBy?.({ left: dir * el.clientWidth * 0.18 })
+      }, 120)
+    }, 350)
+  }, [stopHold])
+  const handleChevronClick = useCallback((dir: -1 | 1) => {
+    // Swallow the click that trails a press-and-hold release (the hold already
+    // scrolled); a plain tap never set didRepeat, so it jumps as before.
+    if (didRepeatRef.current) {
+      didRepeatRef.current = false
+      return
+    }
+    scrollTabs(dir)
+  }, [scrollTabs])
+
+  // (b) DRAG-TO-SCROLL the strip with a pressed pointer. A small movement
+  //     threshold keeps a click-on-tab a click (drag only engages past 5px),
+  //     and `dragMovedRef` suppresses the tab's select-on-click after a drag so
+  //     dragging the strip never accidentally switches tabs.
+  const dragRef = useRef<{ active: boolean; startX: number; startScroll: number }>({
+    active: false,
+    startX: 0,
+    startScroll: 0,
+  })
+  const dragMovedRef = useRef(false)
+  const onStripPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    const el = tablistRef.current
+    if (!el) return
+    dragRef.current = { active: true, startX: e.clientX, startScroll: el.scrollLeft }
+    dragMovedRef.current = false
+  }, [])
+  const onStripPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current
+    if (!drag.active) return
+    const el = tablistRef.current
+    if (!el) return
+    const dx = e.clientX - drag.startX
+    if (!dragMovedRef.current && Math.abs(dx) <= 5) return
+    dragMovedRef.current = true
+    el.setPointerCapture?.(e.pointerId)
+    el.scrollLeft = drag.startScroll - dx
+  }, [])
+  const endStripDrag = useCallback(() => {
+    dragRef.current.active = false
+  }, [])
+
+  // Clear any in-flight hold timer/interval on unmount so a press-and-hold that
+  // outlives the view never fires into a torn-down ref.
+  useEffect(() => stopHold, [stopHold])
   // Keep the active tab visible when it changes programmatically (deep-link,
   // forceTab, ArrowLeft/Right roving) — scroll it into view within the strip
   // only (inline:'nearest' won't scroll the page vertically).
@@ -506,7 +583,11 @@ export function ControlRoomView({
           aria-hidden={!scrollState.left}
           tabIndex={-1}
           data-testid="cr-tabs-chevron-left"
-          onClick={() => scrollTabs(-1)}
+          onClick={() => handleChevronClick(-1)}
+          onPointerDown={() => startHold(-1)}
+          onPointerUp={stopHold}
+          onPointerLeave={stopHold}
+          onPointerCancel={stopHold}
         >
           ‹
         </button>
@@ -517,6 +598,10 @@ export function ControlRoomView({
           data-testid="cr-tabs"
           ref={tablistRef}
           onScroll={updateScrollAffordance}
+          onPointerDown={onStripPointerDown}
+          onPointerMove={onStripPointerMove}
+          onPointerUp={endStripDrag}
+          onPointerCancel={endStripDrag}
         >
         {CONTROL_ROOM_TABS.map((t, i) => {
           const active = tab === t.key
@@ -532,7 +617,16 @@ export function ControlRoomView({
               tabIndex={active ? 0 : -1}
               className={`cr-tab${active ? ' cr-tab-active' : ''}`}
               data-testid={`cr-tab-${t.key}`}
-              onClick={() => selectTab(t.key)}
+              onClick={() => {
+                // #6230: a drag on the strip ends with a click on whatever tab
+                // was under the pointer — suppress that select so dragging never
+                // switches tabs. A plain click never set dragMoved.
+                if (dragMovedRef.current) {
+                  dragMovedRef.current = false
+                  return
+                }
+                selectTab(t.key)
+              }}
               onKeyDown={(e) => {
                 if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return
                 e.preventDefault()
@@ -560,7 +654,11 @@ export function ControlRoomView({
           aria-hidden={!scrollState.right}
           tabIndex={-1}
           data-testid="cr-tabs-chevron-right"
-          onClick={() => scrollTabs(1)}
+          onClick={() => handleChevronClick(1)}
+          onPointerDown={() => startHold(1)}
+          onPointerUp={stopHold}
+          onPointerLeave={stopHold}
+          onPointerCancel={stopHold}
         >
           ›
         </button>

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -502,6 +502,15 @@ export function ControlRoomView({
       clearInterval(repeatRef.current)
       repeatRef.current = null
     }
+    // #6241 review: clear the repeat marker on the NEXT tick, not now — the click
+    // that trails a hold-release fires after pointerup (same task) and must still
+    // be swallowed by `handleChevronClick`, but a hold that ends WITHOUT a click
+    // (pointerleave/cancel, or mouseup off the button) must not leave the flag set
+    // to swallow a later, unrelated click. (handleChevronClick also resets it
+    // synchronously on the swallow, so this only covers the no-trailing-click case.)
+    setTimeout(() => {
+      didRepeatRef.current = false
+    }, 0)
   }, [])
   const startHold = useCallback((dir: -1 | 1) => {
     stopHold()
@@ -536,7 +545,12 @@ export function ControlRoomView({
   })
   const dragMovedRef = useRef(false)
   const onStripPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (e.button !== 0) return
+    // #6241 review: drag-to-scroll is a MOUSE affordance only — touch/pen get
+    // native horizontal panning (CSS `touch-action: pan-x`), so running the
+    // manual drag for them would double-scroll. Also resets `dragMovedRef` for
+    // EVERY pointerdown (a tab click bubbles here first), so a genuine tab click
+    // after a prior drag is never wrongly suppressed.
+    if (e.button !== 0 || e.pointerType !== 'mouse') return
     const el = tablistRef.current
     if (!el) return
     dragRef.current = { active: true, startX: e.clientX, startScroll: el.scrollLeft }
@@ -555,6 +569,13 @@ export function ControlRoomView({
   }, [])
   const endStripDrag = useCallback(() => {
     dragRef.current.active = false
+    // #6241 review: clear the drag marker on the next tick (same rationale as the
+    // hold marker) so a drag that ends WITHOUT a trailing tab-click — including a
+    // later keyboard activation of a tab, which fires a click with no preceding
+    // pointerdown to reset the flag — isn't wrongly suppressed.
+    setTimeout(() => {
+      dragMovedRef.current = false
+    }, 0)
   }, [])
 
   // Clear any in-flight hold timer/interval on unmount so a press-and-hold that
@@ -602,6 +623,7 @@ export function ControlRoomView({
           onPointerMove={onStripPointerMove}
           onPointerUp={endStripDrag}
           onPointerCancel={endStripDrag}
+          onPointerLeave={endStripDrag}
         >
         {CONTROL_ROOM_TABS.map((t, i) => {
           const active = tab === t.key

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9553,6 +9553,15 @@ button.sidebar-token-view-session-row:hover {
   scroll-padding-inline: 40px;
   /* Hide the native scrollbar — the chevrons + trackpad are the affordance. */
   scrollbar-width: none; /* Firefox */
+  /* #6230: drag-to-scroll affordance. The grab cursor invites a press-drag;
+     `user-select: none` stops the drag from selecting tab-label text mid-scroll.
+     `touch-action: pan-x` keeps native horizontal panning on touch devices. */
+  cursor: grab;
+  user-select: none;
+  touch-action: pan-x;
+}
+.cr-tabs:active {
+  cursor: grabbing;
 }
 .cr-tabs::-webkit-scrollbar {
   display: none; /* WebKit/Chromium */


### PR DESCRIPTION
## Summary

Hardens the Control Room tab-strip scroll affordances for **mouse-only users** (no wheel-tilt), who previously had only single-jump chevron clicks. Follow-up from #6229 (#6218). Closes #6230.

Implements **both** suggestions in the issue:

- **Chevron press-and-hold → continuous scroll.** A 350ms hold timer separates a *tap* (the existing single-jump `onClick`) from a *hold* (a 120ms repeat interval that nudges the strip ~18% of the viewport while held). The click that trails a hold-release is swallowed so a hold doesn't tack on an extra jump. Timers are cleared on unmount.
- **Drag-to-scroll the strip.** Pointer-down + drag scrolls the strip directly. A 5px movement threshold keeps a *click-on-tab* a click, and a completed drag suppresses the trailing tab `select`-on-click so dragging never switches tabs. CSS adds `cursor: grab/grabbing`, `user-select: none`, and `touch-action: pan-x`.

## Scope
`packages/dashboard/src/components/ControlRoomView.tsx` + `components.css` (+ tests). UX-only; keyboard nav and trackpad/wheel paths are unchanged.

## Tests
`ControlRoomView.test.tsx` (#6230 block): press-and-hold repeats then stops on release + swallows the trailing click (fake timers); drag past threshold scrolls; a drag suppresses the tab switch and a subsequent plain click selects normally. Full ControlRoomView suite (33) + dashboard `tsc --noEmit` green.