### PR TITLE
feat(dashboard): ArrowDown/Enter from the model-picker search field (#6238)

### DIFF
--- a/packages/dashboard/src/components/ModelPickerModal.test.tsx
+++ b/packages/dashboard/src/components/ModelPickerModal.test.tsx
@@ -103,4 +103,46 @@ describe('ModelPickerModal (#6220)', () => {
     fireEvent.keyDown(screen.getByTestId('model-picker-list'), { key: 'ArrowUp' })
     expect(document.activeElement).toBe(sonnet)
   })
+
+  // #6238 — search-then-arrow: ArrowDown from the search field jumps into the
+  // first (enabled) result without an intermediate Tab.
+  it('ArrowDown from the search field focuses the first result row', () => {
+    renderModal()
+    const search = screen.getByTestId('model-picker-search')
+    search.focus()
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(screen.getByTestId('model-picker-item-sonnet'))
+  })
+
+  it('ArrowDown from search skips a disabled first row to the first enabled one', () => {
+    const models = [
+      { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', disabled: true },
+      { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8' },
+    ]
+    renderModal({ availableModels: models as ModelPickerModalProps['availableModels'] })
+    const search = screen.getByTestId('model-picker-search')
+    search.focus()
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(screen.getByTestId('model-picker-item-opus'))
+  })
+
+  it('Enter in the search field selects when the filter narrows to exactly one match', () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    renderModal({ onSelect, onClose })
+    const search = screen.getByTestId('model-picker-search')
+    fireEvent.change(search, { target: { value: 'opus' } })
+    fireEvent.keyDown(search, { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledWith('opus')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('Enter in the search field does NOT select when more than one match remains', () => {
+    const onSelect = vi.fn()
+    renderModal({ onSelect })
+    const search = screen.getByTestId('model-picker-search')
+    // Empty query → all three models match; Enter must not pick arbitrarily.
+    fireEvent.keyDown(search, { key: 'Enter' })
+    expect(onSelect).not.toHaveBeenCalled()
+  })
 })

--- a/packages/dashboard/src/components/ModelPickerModal.tsx
+++ b/packages/dashboard/src/components/ModelPickerModal.tsx
@@ -88,6 +88,30 @@ export function ModelPickerModal({
     items[nextIdx]?.focus()
   }, [])
 
+  // #6238: the search <input> is a sibling of the listbox, so its keydowns don't
+  // bubble into `handleListKeyDown`. Wire the search-then-arrow flow directly:
+  // ArrowDown jumps focus to the first enabled result; Enter selects when the
+  // filter has narrowed to exactly one enabled match (type-to-pick).
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        listRef.current
+          ?.querySelector<HTMLButtonElement>('[role="option"]:not([disabled])')
+          ?.focus()
+        return
+      }
+      if (e.key === 'Enter') {
+        const enabled = filtered.filter((m) => (m as PickerModel).disabled !== true)
+        if (enabled.length === 1) {
+          e.preventDefault()
+          handleSelect(enabled[0]!.id)
+        }
+      }
+    },
+    [filtered, handleSelect],
+  )
+
   return (
     <Modal open={open} onClose={onClose} title="Select model" maxWidth="520px" closeOnBackdrop>
       <div className="model-picker" data-testid="model-picker">
@@ -97,6 +121,7 @@ export function ModelPickerModal({
           placeholder="Search models…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleSearchKeyDown}
           aria-label="Search models"
           data-testid="model-picker-search"
         />


### PR DESCRIPTION
Closes #6238 (from the #6237 review). The picker opens focused on the search input, but arrow-roving was wired only on the sibling listbox, so ArrowDown in the search box didn't move into the results — the user had to Tab in first.

Adds an `onKeyDown` on the search input:
- **ArrowDown** → focuses the first **enabled** result row (skips a disabled first row).
- **Enter** → selects when the filter narrows to exactly **one** enabled match (type-to-pick); no-op on 0 or >1 so it never picks arbitrarily.

Existing inter-row arrow roving is unchanged. Tests: ArrowDown-into-list, disabled-row skip, Enter-single-match select, Enter-multi-match no-op (14 pass); `tsc --noEmit` clean. Dashboard-only.