### PR TITLE
feat(server): surface keychain health + storage backend in doctor (#6236)

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -371,7 +371,7 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // sections group together in the output report.
   checks.push(configCheck)
 
-  // 5.5 Credential storage (#6236). Surface WHERE the API token + credentials
+  // Credential storage (#6236). Surface WHERE the API token + credentials
   // actually live and whether the OS keychain is healthy — the #6235 fallback to
   // the 0600 file on a broken/missing login keychain is otherwise silent. A
   // broken keychain is a WARN (secrets work but aren't in the keychain + the

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -11,6 +11,7 @@ import { registerAnthropicCompatibleProviders } from './anthropic-compatible-ses
 import { parseTunnelArg } from './tunnel/index.js'
 import { TESTED_CLAUDE_TUI_CLI_VERSION } from './claude-tui/tested-cli-version.js'
 import { detectSilentMeteredDefault } from './doctor-billing.js'
+import { keychainHealth } from './keychain.js'
 import {
   billingClassForProvider,
   billingDetailForClass,
@@ -369,6 +370,24 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // 5. Config check — appended after provider checks so per-provider
   // sections group together in the output report.
   checks.push(configCheck)
+
+  // 5.5 Credential storage (#6236). Surface WHERE the API token + credentials
+  // actually live and whether the OS keychain is healthy — the #6235 fallback to
+  // the 0600 file on a broken/missing login keychain is otherwise silent. A
+  // broken keychain is a WARN (secrets work but aren't in the keychain + the
+  // operator gets a repair hint); disabled/unsupported/usable are informational
+  // PASS. keychainHealth() is non-prompting, so this never pops the macOS modal.
+  const kh = keychainHealth()
+  checks.push({
+    name: 'Credential storage',
+    status: kh.status === 'broken' ? 'warn' : 'pass',
+    message:
+      kh.status === 'usable'
+        ? 'OS keychain'
+        : kh.repairHint
+          ? `file fallback — ${kh.detail} — fix: ${kh.repairHint}`
+          : `file fallback — ${kh.detail}`,
+  })
 
   // 5.6 Tunnel routability (#5328 WP-5.6). For a configured NAMED tunnel, probe
   // the hostname end-to-end so a broken DNS route / down tunnel is visible here

--- a/packages/server/src/keychain.js
+++ b/packages/server/src/keychain.js
@@ -148,7 +148,7 @@ export function isKeychainBroken() {
  * non-prompting source of truth (no `find-/add-generic-password`, so no macOS
  * modal) that classifies the keychain and reports which backend credentials land
  * in. Mirrors the runtime gating in {@link isKeychainAvailable}:
- *   - `disabled`    — `CHROXY_*_DISABLE_KEYCHAIN` set → file/env owns secrets.
+ *   - `disabled`    — `CHROXY_DISABLE_KEYCHAIN=1` set → file/env owns secrets.
  *   - `unsupported` — no OS keychain on this platform (Windows/other) → file.
  *   - `broken`      — mac/linux keychain present but unreadable/missing → file
  *                     (this is the silent #6235 fallback the operator should see).
@@ -173,7 +173,9 @@ export function keychainHealth() {
     return {
       status: 'broken',
       backend: 'file',
-      detail: 'OS login keychain is missing or unreadable — credentials fell back to the 0600 file',
+      detail: isMac
+        ? 'macOS login keychain is missing or unreadable — credentials fell back to the 0600 file'
+        : 'Linux secret service (secret-tool/libsecret) is unavailable — credentials fell back to the 0600 file',
       repairHint: isMac
         ? 'recreate the login keychain in Keychain Access (File ▸ New Keychain, or reset via "security" / a relogin), then re-store with `chroxy init`'
         : 'ensure libsecret/`secret-tool` and a running secret service (e.g. gnome-keyring) are available, then re-store with `chroxy init`',

--- a/packages/server/src/keychain.js
+++ b/packages/server/src/keychain.js
@@ -135,6 +135,58 @@ export function isKeychainBroken() {
 }
 
 /**
+ * @typedef {object} KeychainHealth
+ * @property {'usable'|'broken'|'disabled'|'unsupported'} status — keychain state.
+ * @property {'keychain'|'file'} backend — where credentials are ACTUALLY stored
+ *   right now (the file/env fallback whenever the keychain isn't usable).
+ * @property {string} detail — one-line human explanation of the status.
+ * @property {string} [repairHint] — present only for `broken`: how to fix it.
+ */
+
+/**
+ * Operator-facing keychain diagnosis for `chroxy doctor` (#6236) — a single
+ * non-prompting source of truth (no `find-/add-generic-password`, so no macOS
+ * modal) that classifies the keychain and reports which backend credentials land
+ * in. Mirrors the runtime gating in {@link isKeychainAvailable}:
+ *   - `disabled`    — `CHROXY_*_DISABLE_KEYCHAIN` set → file/env owns secrets.
+ *   - `unsupported` — no OS keychain on this platform (Windows/other) → file.
+ *   - `broken`      — mac/linux keychain present but unreadable/missing → file
+ *                     (this is the silent #6235 fallback the operator should see).
+ *   - `usable`      — secrets are in the OS keychain.
+ */
+export function keychainHealth() {
+  if (keychainDisabled()) {
+    return {
+      status: 'disabled',
+      backend: 'file',
+      detail: 'OS keychain disabled via CHROXY_DISABLE_KEYCHAIN — using the 0600 file/env fallback',
+    }
+  }
+  if (!isMac && !isLinux) {
+    return {
+      status: 'unsupported',
+      backend: 'file',
+      detail: 'no OS keychain on this platform — using the 0600 file/env fallback',
+    }
+  }
+  if (!keychainUsable()) {
+    return {
+      status: 'broken',
+      backend: 'file',
+      detail: 'OS login keychain is missing or unreadable — credentials fell back to the 0600 file',
+      repairHint: isMac
+        ? 'recreate the login keychain in Keychain Access (File ▸ New Keychain, or reset via "security" / a relogin), then re-store with `chroxy init`'
+        : 'ensure libsecret/`secret-tool` and a running secret service (e.g. gnome-keyring) are available, then re-store with `chroxy init`',
+    }
+  }
+  return {
+    status: 'usable',
+    backend: 'keychain',
+    detail: 'credentials are stored in the OS keychain',
+  }
+}
+
+/**
  * Get token from OS keychain.
  * @param {string} [service] - Keychain service name (default: 'chroxy')
  * @param {string} [account] - Keychain account (default: 'api-token'). Other

--- a/packages/server/tests/keychain-mock.test.js
+++ b/packages/server/tests/keychain-mock.test.js
@@ -214,6 +214,43 @@ if (typeof mock.module !== 'function') {
         assert.equal(r.status, 'error', 'a broken keychain must NOT read as absent (would re-mint identity)')
         assert.equal(promptingCalls().length, 0)
       })
+
+      it('keychainHealth() reports broken + file backend + a repair hint (#6236)', () => {
+        brokenMock()
+        const h = keychain.keychainHealth()
+        assert.equal(h.status, 'broken')
+        assert.equal(h.backend, 'file')
+        assert.ok(h.detail && h.detail.length > 0, 'detail present')
+        assert.ok(h.repairHint && h.repairHint.length > 0, 'broken status carries a repair hint')
+        assert.equal(promptingCalls().length, 0, 'keychainHealth must not prompt')
+      })
+    })
+
+    // #6236 — keychainHealth() is the non-prompting source of truth chroxy doctor
+    // uses to surface where credentials live.
+    describe('keychainHealth (#6236)', () => {
+      it('reports usable + keychain backend when the default keychain exists', () => {
+        // Default mock: `security default-keychain` returns '' (inconclusive →
+        // usable per the probe), so health is usable.
+        cpMock.execFileSync.mock.mockImplementation((cmd, args) =>
+          args && args[0] === 'default-keychain' ? '' : '',
+        )
+        const h = keychain.keychainHealth()
+        assert.equal(h.status, 'usable')
+        assert.equal(h.backend, 'keychain')
+        assert.equal(h.repairHint, undefined)
+      })
+
+      it('reports disabled + file backend when CHROXY_DISABLE_KEYCHAIN is set', () => {
+        process.env.CHROXY_DISABLE_KEYCHAIN = '1'
+        try {
+          const h = keychain.keychainHealth()
+          assert.equal(h.status, 'disabled')
+          assert.equal(h.backend, 'file')
+        } finally {
+          delete process.env.CHROXY_DISABLE_KEYCHAIN
+        }
+      })
     })
   })
 }


### PR DESCRIPTION
## Summary

After #6235, a broken/missing macOS login keychain silently falls back to the 0600 file/env credential store — the operator gets **no signal** that the keychain is broken, that secrets moved to a file, or how to repair it. Surface it in `chroxy doctor`. Closes #6236.

## Changes

- **`keychain.js` — `keychainHealth()`** (new, **non-prompting** single source of truth): reuses `keychainDisabled` / `keychainUsable` / platform flags and never shells out to a prompting `security` call (so no macOS modal). Returns `{ status, backend, detail, repairHint? }`:
  - `usable` → backend `keychain`
  - `disabled` (`CHROXY_DISABLE_KEYCHAIN`) / `unsupported` (no OS keychain) → backend `file`
  - `broken` (mac/linux keychain present but unreadable) → backend `file` + a `repairHint`
- **`doctor.js`** — a **`Credential storage`** check: **WARN** (with the repair hint) when the keychain is broken — secrets work but aren't in the keychain; **PASS** (informational, naming the backend) for usable/disabled/unsupported.

## Out of scope
Runtime behaviour (already handled by #6235). Operator-facing diagnostics only.

## Tests
`keychainHealth()` broken (status + backend + repairHint, **zero prompting calls**), usable, and disabled cases. `keychain-mock`/`keychain` (28) + `doctor` (66) suites green; eslint clean.