### PR TITLE
feat(app): mobile mission-control view, read-only slice (#5968)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -13,6 +13,7 @@ import { SettingsScreen } from './screens/SettingsScreen';
 import { PermissionHistoryScreen } from './screens/PermissionHistoryScreen';
 import { HistoryScreen } from './screens/HistoryScreen';
 import ActivityScreen from './screens/ActivityScreen';
+import { MissionControlScreen } from './screens/MissionControlScreen';
 import { LockScreen } from './components/LockScreen';
 import { ConnectionAnnouncer } from './components/ConnectionAnnouncer';
 import { useConnectionStore } from './store/connection';
@@ -36,6 +37,7 @@ export type RootStackParamList = {
   PermissionHistory: undefined;
   History: undefined;
   Activity: undefined;
+  MissionControl: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -187,6 +189,11 @@ export default function App() {
           name="Activity"
           component={ActivityScreen}
           options={{ title: 'Activity' }}
+        />
+        <Stack.Screen
+          name="MissionControl"
+          component={MissionControlScreen}
+          options={{ title: 'Mission Control' }}
         />
       </Stack.Navigator>
       {isLocked && <LockScreen onUnlock={unlock} />}

--- a/packages/app/src/__tests__/screens/MissionControlScreen.test.tsx
+++ b/packages/app/src/__tests__/screens/MissionControlScreen.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Render tests for the mobile MissionControlScreen (#5968 PR1).
+ *
+ * Proves the read-only cross-session view's grouping + rollups by reusing
+ * store-core's `selectCrossSessionActivity` over SEEDED `ActivityState` (built
+ * with `createEmptyActivityState` + `applyActivitySnapshot`, mirroring the
+ * dashboard's CrossSessionMissionControl.test.tsx fixtures). No device, no live
+ * feeder, no store/navigator: the test drives the pure `MissionControlBody`
+ * directly with fixtures — same render-test harness as ObserverBanner.test.tsx.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import type { ActivityEntry, ActivityState, CrossSessionMeta } from '@chroxy/store-core';
+import { createEmptyActivityState, applyActivitySnapshot } from '@chroxy/store-core';
+import { MissionControlBody } from '../../screens/MissionControlScreen';
+
+const T0 = 1_800_000_000_000;
+
+function entry(over: Partial<ActivityEntry> & Pick<ActivityEntry, 'id'>): ActivityEntry {
+  const status = over.status ?? 'running';
+  const terminal = status === 'done' || status === 'failed';
+  return {
+    id: over.id,
+    kind: over.kind ?? 'tool',
+    label: over.label ?? `label-${over.id}`,
+    status,
+    startedAt: over.startedAt ?? T0,
+    endedAt: over.endedAt ?? (terminal ? T0 + 1000 : undefined),
+    parentId: over.parentId,
+    outputRef: over.outputRef,
+  };
+}
+
+function stateOf(map: Record<string, ActivityEntry[]>): ActivityState {
+  let s = createEmptyActivityState();
+  for (const [sid, entries] of Object.entries(map)) {
+    s = applyActivitySnapshot(s, { type: 'activity_snapshot', sessionId: sid, schemaVersion: 1, entries });
+  }
+  return s;
+}
+
+const SESSIONS: CrossSessionMeta[] = [
+  { sessionId: 's1', cwd: '/home/u/repo-a', name: 'A1' },
+  { sessionId: 's2', cwd: '/home/u/repo-a', name: 'A2' },
+  { sessionId: 's3', cwd: '/home/u/repo-b', name: 'B1' },
+];
+
+function findByTestId(root: ReactTestInstance, testID: string): ReactTestInstance | null {
+  const matches = root.findAll((n) => n.props?.testID === testID);
+  return matches.length > 0 ? matches[0] : null;
+}
+
+function findAllByTestId(root: ReactTestInstance, testID: string): ReactTestInstance[] {
+  return root.findAll((n) => n.props?.testID === testID);
+}
+
+function textOf(node: ReactTestInstance | null): string {
+  if (node === null) return '';
+  return node
+    .findAllByType(Text)
+    .map((n) => {
+      const c = n.props.children;
+      if (typeof c === 'string' || typeof c === 'number') return String(c);
+      if (Array.isArray(c)) return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+      return '';
+    })
+    .join(' ');
+}
+
+describe('MissionControlScreen (#5968 PR1)', () => {
+  let tree: renderer.ReactTestRenderer | null = null;
+  afterEach(() => {
+    if (tree) {
+      act(() => tree!.unmount());
+      tree = null;
+    }
+  });
+
+  function render(props: React.ComponentProps<typeof MissionControlBody>): renderer.ReactTestRenderer {
+    let t!: renderer.ReactTestRenderer;
+    act(() => {
+      t = renderer.create(<MissionControlBody {...props} />);
+    });
+    tree = t;
+    return t;
+  }
+
+  it('renders the empty state when there are no sessions', () => {
+    const t = render({ activity: createEmptyActivityState(), sessions: [] });
+    expect(findByTestId(t.root, 'mission-control-empty')).not.toBeNull();
+    expect(findByTestId(t.root, 'mission-control-group-label')).toBeNull();
+  });
+
+  it('groups sessions by repo+worktree with labels and the overall total', () => {
+    const activity = stateOf({
+      s1: [entry({ id: 'e1', status: 'running' })],
+      s2: [entry({ id: 'e2', status: 'blocked' })],
+      s3: [entry({ id: 'e3', status: 'failed' })],
+    });
+    const t = render({ activity, sessions: SESSIONS });
+
+    const labels = findAllByTestId(t.root, 'mission-control-group-label').map((n) => textOf(n));
+    expect(labels).toEqual(['repo-a', 'repo-b']);
+
+    // Overall total: 1 running + 1 blocked + 1 failed.
+    expect(textOf(findByTestId(t.root, 'mission-control-total-running'))).toContain('1');
+    expect(textOf(findByTestId(t.root, 'mission-control-total-blocked'))).toContain('1');
+    expect(textOf(findByTestId(t.root, 'mission-control-total-failed'))).toContain('1');
+  });
+
+  it('renders a per-session status badge derived from activity entries', () => {
+    const activity = stateOf({
+      s1: [entry({ id: 'e1', status: 'running' })],
+      s2: [entry({ id: 'e2', status: 'blocked' })],
+      // s3 has no activity → idle.
+    });
+    const t = render({ activity, sessions: SESSIONS });
+
+    expect(textOf(findByTestId(t.root, 'mission-control-session-status-s1'))).toBe('Running');
+    expect(textOf(findByTestId(t.root, 'mission-control-session-status-s2'))).toBe('Blocked');
+    expect(textOf(findByTestId(t.root, 'mission-control-session-status-s3'))).toBe('Idle');
+  });
+
+  it('shows a worktree badge only on a group flagged as a worktree', () => {
+    const activity = stateOf({ wt: [entry({ id: 'e', status: 'blocked' })] });
+    const t = render({
+      activity,
+      sessions: [
+        { sessionId: 'main', cwd: '/home/u/repo-a', name: 'main' },
+        { sessionId: 'wt', cwd: '/home/u/.chroxy/worktrees/repo-a-feat', name: 'feat', worktree: true },
+      ],
+    });
+    // Exactly one group carries the worktree badge.
+    expect(findAllByTestId(t.root, 'mission-control-group-worktree').length).toBe(1);
+  });
+});

--- a/packages/app/src/__tests__/screens/MissionControlScreen.test.tsx
+++ b/packages/app/src/__tests__/screens/MissionControlScreen.test.tsx
@@ -10,7 +10,6 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { Text } from 'react-native';
 import type { ActivityEntry, ActivityState, CrossSessionMeta } from '@chroxy/store-core';
 import { createEmptyActivityState, applyActivitySnapshot } from '@chroxy/store-core';
 import { MissionControlBody } from '../../screens/MissionControlScreen';
@@ -52,20 +51,32 @@ function findByTestId(root: ReactTestInstance, testID: string): ReactTestInstanc
 }
 
 function findAllByTestId(root: ReactTestInstance, testID: string): ReactTestInstance[] {
-  return root.findAll((n) => n.props?.testID === testID);
+  // Match HOST instances only (`type` is a string like 'Text'/'View'): an RN
+  // <Text testID> surfaces both a composite and a host instance carrying the
+  // same testID, so an unfiltered findAll double-counts each element.
+  return root.findAll((n) => n.props?.testID === testID && typeof n.type === 'string');
 }
 
 function textOf(node: ReactTestInstance | null): string {
   if (node === null) return '';
-  return node
-    .findAllByType(Text)
-    .map((n) => {
-      const c = n.props.children;
-      if (typeof c === 'string' || typeof c === 'number') return String(c);
-      if (Array.isArray(c)) return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
-      return '';
-    })
-    .join(' ');
+  // Collect every string descendant of the node. Works whether `node` is a
+  // composite Text instance OR a host instance (a host <Text>'s children are
+  // raw strings, which findAllByType(Text) wouldn't reach) — so this is robust
+  // for both findByTestId (composite-first) and findAllByTestId (host-only).
+  const out: string[] = [];
+  const walk = (n: ReactTestInstance | string): void => {
+    if (typeof n === 'string') {
+      out.push(n);
+      return;
+    }
+    if (typeof n === 'number') {
+      out.push(String(n));
+      return;
+    }
+    for (const child of n.children ?? []) walk(child as ReactTestInstance | string);
+  };
+  walk(node);
+  return out.join('');
 }
 
 describe('MissionControlScreen (#5968 PR1)', () => {

--- a/packages/app/src/screens/MissionControlScreen.tsx
+++ b/packages/app/src/screens/MissionControlScreen.tsx
@@ -1,0 +1,247 @@
+/**
+ * MissionControlScreen (#5968 PR1) — the mobile, READ-ONLY mission-control view.
+ *
+ * Parity port of the dashboard `CrossSessionMissionControl` (#6183): it reuses
+ * store-core's `selectCrossSessionActivity` (#6182) so the mobile aggregate can
+ * never drift from the dashboard / tray badge. Sessions are grouped by
+ * repo+worktree (cwd); the overall set and each group carry
+ * running/blocked/failed/idle SESSION counts. Each session renders as a row with
+ * a derived-status badge.
+ *
+ * Scope (PR1): read-only only — NO drill-down/expansion, NO cancel/jump, NO
+ * external-sessions section. The live data feeder (dispatching
+ * `activity_snapshot` / `activity_delta` into `state.activity`) is PR2; until it
+ * lands the view shows the empty state for a fresh store.
+ *
+ * Testability: the screen is a thin store-reader that delegates rendering to the
+ * exported pure {@link MissionControlBody}. The render test drives the Body
+ * directly with seeded fixtures (no store / navigation context needed).
+ */
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import type {
+  CrossSessionMeta,
+  CrossSessionRollup,
+  SessionDerivedStatus,
+} from '@chroxy/store-core';
+import { selectCrossSessionActivity } from '@chroxy/store-core';
+import { useConnectionStore } from '../store/connection';
+import { COLORS } from '../constants/colors';
+
+// The store-core cross-session reducer state. Imported inline to avoid colliding
+// with the app's own `ActivityState` enum (store/session-activity.ts), which is
+// re-exported through store/types.ts under the same name.
+type CrossSessionState = import('@chroxy/store-core').ActivityState;
+
+const STATUS_LABEL: Record<SessionDerivedStatus, string> = {
+  running: 'Running',
+  blocked: 'Blocked',
+  failed: 'Failed',
+  idle: 'Idle',
+};
+
+const STATUS_COLOR: Record<SessionDerivedStatus, string> = {
+  running: COLORS.accentGreen,
+  blocked: COLORS.accentOrange,
+  failed: COLORS.accentRed,
+  idle: COLORS.textSecondary,
+};
+
+/** running/blocked/failed chips for a rollup (idle implied; omitted to cut noise). */
+function RollupChips({
+  rollup,
+  testIdPrefix,
+}: {
+  rollup: CrossSessionRollup;
+  testIdPrefix: string;
+}): React.ReactElement {
+  return (
+    <View style={styles.rollupRow} testID={testIdPrefix}>
+      <Text style={[styles.chip, { color: STATUS_COLOR.running }]} testID={`${testIdPrefix}-running`}>
+        {rollup.running} running
+      </Text>
+      <Text style={[styles.chip, { color: STATUS_COLOR.blocked }]} testID={`${testIdPrefix}-blocked`}>
+        {rollup.blocked} blocked
+      </Text>
+      <Text style={[styles.chip, { color: STATUS_COLOR.failed }]} testID={`${testIdPrefix}-failed`}>
+        {rollup.failed} failed
+      </Text>
+    </View>
+  );
+}
+
+export interface MissionControlBodyProps {
+  /** Whole-store activity reducer state (one tree per session). */
+  activity: CrossSessionState;
+  /** The authoritative session list (drives membership + grouping). */
+  sessions: readonly CrossSessionMeta[];
+}
+
+/**
+ * Pure, prop-driven render of the cross-session aggregate. Exported so the
+ * render test can seed fixtures directly without a store or navigator.
+ */
+export function MissionControlBody({ activity, sessions }: MissionControlBodyProps): React.ReactElement {
+  const cross = selectCrossSessionActivity(activity, sessions);
+
+  if (cross.groups.length === 0) {
+    return (
+      <View style={styles.container} testID="mission-control">
+        <View style={styles.emptyWrap} testID="mission-control-empty">
+          <Text style={styles.emptyText}>No active sessions</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content} testID="mission-control">
+      <View style={styles.header}>
+        <Text style={styles.headerLabel}>All sessions</Text>
+        <RollupChips rollup={cross.total} testIdPrefix="mission-control-total" />
+      </View>
+
+      {cross.groups.map((group) => (
+        <View key={group.key} style={styles.group} testID={`mc-group-${group.key}`}>
+          <View style={styles.groupHead}>
+            <Text style={styles.groupLabel} testID="mission-control-group-label">
+              {group.label}
+            </Text>
+            {group.worktree && (
+              <Text style={styles.worktreeBadge} testID="mission-control-group-worktree">
+                worktree
+              </Text>
+            )}
+          </View>
+          <RollupChips rollup={group.rollup} testIdPrefix="mission-control-group-rollup" />
+
+          <View style={styles.sessionList}>
+            {group.sessions.map((s) => (
+              <View key={s.sessionId} style={styles.sessionRow} testID={`mc-session-${s.sessionId}`}>
+                <Text style={styles.sessionName} numberOfLines={1}>
+                  {s.name}
+                </Text>
+                <Text
+                  style={[styles.statusBadge, { color: STATUS_COLOR[s.status] }]}
+                  testID={`mission-control-session-status-${s.sessionId}`}
+                  accessibilityRole="text"
+                  accessibilityLabel={`Status: ${STATUS_LABEL[s.status]}`}
+                >
+                  {STATUS_LABEL[s.status]}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+/** Maps a SessionInfo (store shape) to the selector's minimal CrossSessionMeta. */
+function toMeta(s: { sessionId: string; cwd?: string | null; name?: string; worktree?: boolean }): CrossSessionMeta {
+  return { sessionId: s.sessionId, cwd: s.cwd, name: s.name, worktree: s.worktree };
+}
+
+/** The navigable screen: reads the store, delegates to the pure Body. */
+export function MissionControlScreen(): React.ReactElement {
+  const activity = useConnectionStore((s) => s.activity);
+  const sessions = useConnectionStore((s) => s.sessions);
+  const metas = React.useMemo(() => sessions.map(toMeta), [sessions]);
+  return <MissionControlBody activity={activity} sessions={metas} />;
+}
+
+export default MissionControlScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.backgroundPrimary,
+  },
+  content: {
+    padding: 12,
+  },
+  emptyWrap: {
+    flex: 1,
+    minHeight: 120,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    color: COLORS.textSecondary,
+    fontSize: 15,
+  },
+  header: {
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: COLORS.borderPrimary,
+    marginBottom: 8,
+  },
+  headerLabel: {
+    color: COLORS.textPrimary,
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  rollupRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  chip: {
+    fontSize: 13,
+    fontWeight: '600',
+    marginRight: 12,
+    marginBottom: 2,
+  },
+  group: {
+    backgroundColor: COLORS.backgroundSecondary,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: COLORS.borderPrimary,
+    padding: 12,
+    marginBottom: 12,
+  },
+  groupHead: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  groupLabel: {
+    color: COLORS.textPrimary,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  worktreeBadge: {
+    marginLeft: 8,
+    color: COLORS.accentPurple,
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  sessionList: {
+    marginTop: 8,
+  },
+  sessionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 44,
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: COLORS.borderPrimary,
+  },
+  sessionName: {
+    flex: 1,
+    color: COLORS.textPrimary,
+    fontSize: 14,
+    marginRight: 12,
+  },
+  statusBadge: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+});

--- a/packages/app/src/screens/MissionControlScreen.tsx
+++ b/packages/app/src/screens/MissionControlScreen.tsx
@@ -102,7 +102,7 @@ export function MissionControlBody({ activity, sessions }: MissionControlBodyPro
       </View>
 
       {cross.groups.map((group) => (
-        <View key={group.key} style={styles.group} testID={`mc-group-${group.key}`}>
+        <View key={group.key} style={styles.group} testID={`mc-group-${groupTestId(group.key)}`}>
           <View style={styles.groupHead}>
             <Text style={styles.groupLabel} testID="mission-control-group-label">
               {group.label}
@@ -141,6 +141,16 @@ export function MissionControlBody({ activity, sessions }: MissionControlBodyPro
 /** Maps a SessionInfo (store shape) to the selector's minimal CrossSessionMeta. */
 function toMeta(s: { sessionId: string; cwd?: string | null; name?: string; worktree?: boolean }): CrossSessionMeta {
   return { sessionId: s.sessionId, cwd: s.cwd, name: s.name, worktree: s.worktree };
+}
+
+/**
+ * Stable testID fragment for a group (#6245 review): the selector keys groups by
+ * raw cwd, which is '' for the Ungrouped bucket and can carry path separators /
+ * colons (Windows paths) — both make E2E selectors brittle. Map empty → 'ungrouped'
+ * and collapse any non-alphanumeric run to a single '-'.
+ */
+function groupTestId(key: string): string {
+  return key.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'ungrouped';
 }
 
 /** The navigable screen: reads the store, delegates to the pure Body. */

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -427,6 +427,17 @@ export function SettingsScreen() {
           <Text style={styles.rowLabel}>Activity History</Text>
           <Text style={styles.rowValue}>View all</Text>
         </TouchableOpacity>
+        <View style={styles.separator} />
+        <TouchableOpacity
+          style={styles.row}
+          onPress={() => navigation.navigate('MissionControl')}
+          accessibilityRole="button"
+          accessibilityLabel="View mission control"
+          testID="settings-mission-control-row"
+        >
+          <Text style={styles.rowLabel}>Mission Control</Text>
+          <Text style={styles.rowValue}>View all</Text>
+        </TouchableOpacity>
       </View>
 
       <NotificationPrefsSection

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -137,6 +137,9 @@ import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
 import {
   getWsCloseMessage,
   getHealthCheckErrorMessage,
+  // #5968 — seed the cross-session activity reducer state consumed by the mobile
+  // MissionControlScreen. PR1 only initializes/resets it; the live feeder is PR2.
+  createEmptyActivityState,
   // #4875: shared typed predicate for the AskUserQuestion freeform shape.
   // Replaces the inline 5-condition check that previously diverged from
   // the looser SessionScreen variant; both call sites now narrow off the
@@ -510,6 +513,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   sessions: [],
   activeSessionId: null,
   sessionStates: {},
+  activity: createEmptyActivityState(),
   availableModels: [],
   defaultModelId: null,
   availablePermissionModes: [],
@@ -1570,6 +1574,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       sessions: [],
       activeSessionId: null,
       sessionStates: {},
+      activity: createEmptyActivityState(),
       viewingCachedSession: false,
       conversationHistory: [],
       conversationHistoryLoading: false,

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -255,6 +255,13 @@ export interface MultiClientSessionData {
   sessions: SessionInfo[];
   activeSessionId: string | null;
   sessionStates: Record<string, SessionState>;
+  // #5968 — the store-core cross-session activity reducer state, consumed by the
+  // mobile MissionControlScreen via `selectCrossSessionActivity`. Imported inline
+  // to avoid colliding with the app's own `ActivityState` enum
+  // (store/session-activity.ts), re-exported above under the same name. The live
+  // feeder (dispatching activity_snapshot/activity_delta) is PR2; until it lands
+  // this stays at `createEmptyActivityState()` and the view shows its empty state.
+  activity: import('@chroxy/store-core').ActivityState;
   // Connected clients (multi-client awareness)
   myClientId: string | null;
   connectedClients: ConnectedClient[];


### PR DESCRIPTION
## What

A **read-only**, mobile React Native mission-control view (`MissionControlScreen`) — the parity port of the dashboard's `CrossSessionMissionControl` (#6183), built on the same store-core selector so the surfaces can't drift.

- Reuses store-core's `selectCrossSessionActivity` (#6182) **verbatim** — no re-derived grouping/rollup logic on mobile.
- Groups sessions by repo+worktree (cwd) with the overall set and each group carrying running/blocked/failed/idle **session** counts, plus a per-session derived-status badge (running → green, blocked → orange, failed → red, idle → muted) using the app's existing `COLORS`.
- Empty state ("No active sessions") for a fresh / empty store.
- `testID` anchors on the key elements (`mission-control`, `mission-control-empty`, `mc-group-<key>`, `mc-session-<id>`, `mission-control-total-*`, `mission-control-group-label`, `mission-control-group-worktree`, `mission-control-session-status-<id>`).

## Scope (PR1 only)

READ-ONLY subset of the dashboard view: **no** drill-down/expansion, **no** cancel/jump, **no** external-sessions section.

The live data feeder (dispatching `activity_snapshot` / `activity_delta` into `state.activity` in the app message-handler) is **deferred to PR2** — the message-handler is intentionally untouched here. Until the feeder lands the view shows its empty state for a fresh store; `activity` is initialized/reset via `createEmptyActivityState()`.

## Wiring

- `store/types.ts` — `activity: import('@chroxy/store-core').ActivityState` added to the session data group. Imported inline to avoid colliding with the app's own `ActivityState` enum (`store/session-activity.ts`), which is re-exported under the same name — same dodge the dashboard uses.
- `store/connection.ts` — `activity: createEmptyActivityState()` in the initial state and the `forgetSession` reset (the only two reset sites that wipe `sessions`/`sessionStates`).
- `App.tsx` — `MissionControl` route registered (mirrors the `Activity` screen).
- `SettingsScreen.tsx` — a "Mission Control" navigation row alongside "Activity History".

## Test (proves parity without a device or live feeder)

`__tests__/screens/MissionControlScreen.test.tsx` (react-test-renderer, the repo's existing harness — same as `ObserverBanner.test.tsx`) drives the exported pure `MissionControlBody` with **seeded** `ActivityState` built via `createEmptyActivityState()` + `applyActivitySnapshot(...)`, mirroring the dashboard `CrossSessionMissionControl.test.tsx` fixtures. Asserts: empty state, group labels + overall rollup, per-session status badges (running/blocked/idle), and the worktree badge appearing only on a flagged group.

Part of #5968.

**Immediate follow-up (PR2):** the live activity feeder — dispatch `activity_snapshot` / `activity_delta` into `state.activity` in the app message-handler so the view lights up from real session activity.
