### PR TITLE
feat(app): live activity feeder for mobile mission-control (#6246)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler-activity.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-activity.test.ts
@@ -16,6 +16,7 @@
  */
 import {
   _testMessageHandler,
+  _testResetStore,
   setStore,
 } from '../../store/message-handler';
 import { createEmptyActivityState } from '@chroxy/store-core';
@@ -89,6 +90,16 @@ function createMockContext() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+// #6247 review: the message-handler keeps module-level store + context refs.
+// Clear BOTH after each test so this suite can't leak state into other test
+// files (order-dependent failures). _testResetStore() drops the store; the
+// context is cleared so a later file that forgets to set it fails loudly
+// rather than reusing this suite's mock.
+afterEach(() => {
+  _testResetStore();
+  _testMessageHandler.setContext(null as never);
 });
 
 describe('activity feeder (#6246)', () => {

--- a/packages/app/src/__tests__/store/message-handler-activity.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-activity.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the mobile Control Room activity feeder (#6246).
+ *
+ * #6245 (PR1) added `activity: ActivityState` to the app ConnectionState and a
+ * read-only MissionControlScreen, but nothing dispatched `activity_snapshot` /
+ * `activity_delta` into the store, so the view always showed its empty state.
+ * #6246 wires those two message types into handleMessage's switch (mirroring the
+ * dashboard feeder): parse with the protocol Zod schema → reduce via store-core
+ * (`applyActivitySnapshot` REPLACE / `applyActivityDelta` upsert-by-id) → set,
+ * with a `next === prev` no-op short-circuit to skip needless re-renders.
+ *
+ * These tests exercise the production wire path: dispatch a message through
+ * `_testMessageHandler.handle` and assert on the resulting `state.activity` tree
+ * (keyed `bySession[sessionId].byId[entryId]`), exactly the shape the
+ * MissionControlScreen's `selectCrossSessionActivity` reads.
+ */
+import {
+  _testMessageHandler,
+  setStore,
+} from '../../store/message-handler';
+import { createEmptyActivityState } from '@chroxy/store-core';
+import type { ActivityEntry, ActivityState } from '@chroxy/store-core';
+import type { ConnectionState } from '../../store/types';
+
+// Mock persistence so the handler's imports resolve without touching disk.
+jest.mock('../../store/persistence', () => ({
+  clearPersistedSession: jest.fn(() => Promise.resolve()),
+  persistSessionMessages: jest.fn(),
+  persistViewMode: jest.fn(),
+  persistActiveSession: jest.fn(),
+  persistTerminalBuffer: jest.fn(),
+  loadPersistedState: jest.fn(),
+  loadSessionMessages: jest.fn(),
+  clearPersistedState: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+const T0 = 1_800_000_000_000;
+
+/** Build a wire-valid ActivityEntry, defaulting the schema-required fields. */
+function entry(over: Partial<ActivityEntry> & Pick<ActivityEntry, 'id'>): ActivityEntry {
+  const status = over.status ?? 'running';
+  const terminal = status === 'done' || status === 'failed';
+  return {
+    id: over.id,
+    kind: over.kind ?? 'tool',
+    label: over.label ?? `label-${over.id}`,
+    status,
+    startedAt: over.startedAt ?? T0,
+    endedAt: over.endedAt ?? (terminal ? T0 + 1000 : undefined),
+    parentId: over.parentId,
+    outputRef: over.outputRef,
+  };
+}
+
+/** Minimal mock Zustand store seeding `activity` with an empty reducer state. */
+function createMockStore(initialActivity: ActivityState) {
+  let state = { activity: initialActivity } as ConnectionState;
+  return {
+    store: {
+      getState: () => state,
+      setState: (
+        updater: Partial<ConnectionState> | ((s: ConnectionState) => Partial<ConnectionState>),
+      ) => {
+        state = typeof updater === 'function'
+          ? { ...state, ...updater(state) }
+          : { ...state, ...updater };
+      },
+      subscribe: () => () => {},
+      destroy: () => {},
+    },
+    current: () => state,
+  };
+}
+
+function createMockContext() {
+  return {
+    socket: { readyState: 1, send: jest.fn() } as any,
+    serverUrl: 'wss://test.example.com',
+    apiToken: 'test-token',
+    connectionId: 'test-conn-1',
+    reconnecting: false,
+    connectedAt: Date.now(),
+    isSessionSwitchReplay: false,
+    activeSessionIdAtConnect: null,
+    replayingSessions: new Set<string>(),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('activity feeder (#6246)', () => {
+  it('activity_snapshot populates state.activity for a session', () => {
+    const { store, current } = createMockStore(createEmptyActivityState());
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'activity_snapshot',
+      sessionId: 's1',
+      schemaVersion: 1,
+      entries: [entry({ id: 'e1', status: 'running' }), entry({ id: 'e2', status: 'blocked' })],
+    });
+
+    const tree = current().activity;
+    expect(tree.bySession.s1).toBeDefined();
+    expect(tree.bySession.s1!.byId.e1!.status).toBe('running');
+    expect(tree.bySession.s1!.byId.e2!.status).toBe('blocked');
+  });
+
+  it('activity_snapshot REPLACES the prior tree for that session', () => {
+    const { store, current } = createMockStore(createEmptyActivityState());
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'activity_snapshot',
+      sessionId: 's1',
+      schemaVersion: 1,
+      entries: [entry({ id: 'old', status: 'running' })],
+    });
+    _testMessageHandler.handle({
+      type: 'activity_snapshot',
+      sessionId: 's1',
+      schemaVersion: 1,
+      entries: [entry({ id: 'fresh', status: 'running' })],
+    });
+
+    const tree = current().activity;
+    expect(tree.bySession.s1!.byId.old).toBeUndefined();
+    expect(tree.bySession.s1!.byId.fresh!.status).toBe('running');
+  });
+
+  it('activity_delta upserts an entry into its session', () => {
+    const { store, current } = createMockStore(createEmptyActivityState());
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'activity_delta',
+      sessionId: 's2',
+      schemaVersion: 1,
+      op: 'started',
+      entry: entry({ id: 'd1', status: 'running' }),
+    });
+
+    let tree = current().activity;
+    expect(tree.bySession.s2!.byId.d1!.status).toBe('running');
+
+    // An `updated` delta carrying the full, current node upserts by id.
+    _testMessageHandler.handle({
+      type: 'activity_delta',
+      sessionId: 's2',
+      schemaVersion: 1,
+      op: 'updated',
+      entry: entry({ id: 'd1', status: 'blocked', label: 'now-blocked' }),
+    });
+
+    tree = current().activity;
+    expect(tree.bySession.s2!.byId.d1!.status).toBe('blocked');
+    expect(tree.bySession.s2!.byId.d1!.label).toBe('now-blocked');
+  });
+
+  it('drops a malformed activity_snapshot without throwing or mutating state', () => {
+    const seeded = createEmptyActivityState();
+    const { store, current } = createMockStore(seeded);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    expect(() =>
+      _testMessageHandler.handle({
+        type: 'activity_snapshot',
+        sessionId: 's1',
+        // schemaVersion missing → schema parse fails
+        entries: 'not-an-array',
+      }),
+    ).not.toThrow();
+
+    // No-op: the seeded reference is untouched (parse failed before any set).
+    expect(current().activity).toBe(seeded);
+    expect(current().activity.bySession).toEqual({});
+  });
+
+  it('drops a malformed activity_delta without throwing or mutating state', () => {
+    const seeded = createEmptyActivityState();
+    const { store, current } = createMockStore(seeded);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    expect(() =>
+      _testMessageHandler.handle({
+        type: 'activity_delta',
+        sessionId: 's1',
+        schemaVersion: 1,
+        op: 'started',
+        entry: { id: 'bad' }, // missing required fields (kind/label/status/startedAt)
+      }),
+    ).not.toThrow();
+
+    expect(current().activity).toBe(seeded);
+    expect(current().activity.bySession).toEqual({});
+  });
+});

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -107,6 +107,12 @@ import {
   handleSearchResults as sharedSearchResults,
   applyOrphanDeltas,
   isActivityEvent,
+  // #5163 (epic #5159) — Control Room cross-session activity reducer:
+  // snapshot replace + self-healing delta upsert + terminal-retention prune.
+  // The mobile MissionControlScreen (#5968 / #6245) and the dashboard panel
+  // both consume this one implementation; #6246 wires the feeder here.
+  applyActivitySnapshot,
+  applyActivityDelta,
   // #5039: shared partial-cost line helper — the same one the dashboard
   // toast uses, so the mobile Alert and the dashboard sub-line can't
   // drift apart on copy/format.
@@ -142,6 +148,11 @@ import type {
   DispatchCallbackPayload,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
+// #6246 — Control Room activity wire schemas. Validated defensively before the
+// store-core reducer so a malformed payload is dropped, not crashed on (same
+// pattern the dashboard feeder uses). Resolved via the jest moduleNameMapper
+// `^@chroxy/protocol/schemas$` and the protocol package's `./schemas` export.
+import { ServerActivitySnapshotSchema, ServerActivityDeltaSchema } from '@chroxy/protocol/schemas';
 import { hapticSuccess } from '../utils/haptics';
 import type {
   ChatMessage,
@@ -3496,6 +3507,45 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
       Alert.alert('Server Error', alertBody);
       break;
+    }
+
+    // #5163 (epic #5159) / #6246 — Control Room `activity_snapshot`: REPLACE the
+    // target session's activity tree with the snapshot's entries via the
+    // store-core reducer. Emitted on subscribe / resync so a late-joining or
+    // reconnecting client reaches canonical state in one message. The wire shape
+    // is validated with the protocol Zod schema (same defensive pattern as the
+    // dashboard feeder) so a malformed payload is dropped rather than crashing
+    // the reducer. `applyActivitySnapshot` returns the SAME state reference on a
+    // no-op, so the `next === prev` short-circuit skips a needless re-render.
+    // This makes #6245's read-only MissionControlScreen go live.
+    case 'activity_snapshot': {
+      const parsed = ServerActivitySnapshotSchema.safeParse(msg);
+      if (!parsed.success) return;
+      const prev = get().activity;
+      const next = applyActivitySnapshot(prev, parsed.data);
+      if (next === prev) return;
+      set({ activity: next });
+      return;
+    }
+
+    // #5163 (epic #5159) / #6246 — Control Room `activity_delta`: upsert the
+    // carried entry into its session by id. `op` is advisory — the full entry
+    // drives the result, so a dropped earlier delta is self-healed by the next
+    // one. Validated + `next === prev` no-op-short-circuited like the snapshot
+    // case above. NOTE: the dashboard ALSO bumps `lastClientActivityAt` / clears
+    // `inactivityWarning` for the delta's session here; that is DEFERRED for this
+    // slice — the dispatch-level activity bump at the top of handleMessage
+    // (`isActivityEvent`) does not yet include the activity_* types, so the
+    // "Working… last activity Ns ago" parity follow-up is intentionally out of
+    // scope for #6246.
+    case 'activity_delta': {
+      const parsed = ServerActivityDeltaSchema.safeParse(msg);
+      if (!parsed.success) return;
+      const prev = get().activity;
+      const next = applyActivityDelta(prev, parsed.data);
+      if (next === prev) return;
+      set({ activity: next });
+      return;
     }
 
     default: {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -3515,8 +3515,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // reconnecting client reaches canonical state in one message. The wire shape
     // is validated with the protocol Zod schema (same defensive pattern as the
     // dashboard feeder) so a malformed payload is dropped rather than crashing
-    // the reducer. `applyActivitySnapshot` returns the SAME state reference on a
-    // no-op, so the `next === prev` short-circuit skips a needless re-render.
+    // the reducer. `applyActivitySnapshot` always builds a fresh state, so the
+    // `next === prev` guard below is a harmless defensive no-op here (it's the
+    // live short-circuit for activity_delta, whose reducer returns the SAME ref
+    // on a no-op); kept for symmetry with the delta case + the dashboard feeder.
     // This makes #6245's read-only MissionControlScreen go live.
     case 'activity_snapshot': {
       const parsed = ServerActivitySnapshotSchema.safeParse(msg);

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -149,8 +149,10 @@ const PLATFORM_SPECIFIC = {
   // needed. Coverage passes because each handler has a `case 'terminal_output':`.
   'terminal_size': 'dashboard', // #5835 Phase 2 authoritative live-PTY grid size — the dashboard letterboxes the mirror to it (setTerminalSize); mobile applies resize from its own pane measurement (#5987) but does not yet consume the server's terminal_size echo, so still dashboard-only
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
-  'activity_snapshot': 'dashboard', // Control Room live activity tree (#5161 schema / #5160 server / #5162 reducer / #5163 dashboard panel) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5159
-  'activity_delta': 'dashboard',    // Control Room activity delta — see activity_snapshot above; dashboard-only for v1, mobile parity is Phase-2 per epic #5159
+  // 'activity_snapshot' / 'activity_delta' removed from PLATFORM_SPECIFIC — the
+  // mobile app now feeds them too (#6246/#6247, the Phase-2 mobile-parity
+  // fast-follow per epic #5159), so they are BOTH-CLIENTS and the coverage test
+  // passes because each handler has a `case 'activity_snapshot'/'activity_delta':`.
   'host_status_snapshot': 'dashboard', // Control Room Host/Repo Status survey reply (#5171 schema / #5174 server emitter / #5175 dashboard section) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5170
   'runner_status_snapshot': 'dashboard', // Control Room self-hosted runner survey reply (#5253) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'containers_status_snapshot': 'dashboard', // Control Room containers & environments survey reply (#6133, epic #5530) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -65,6 +65,14 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 // ---------------------------------------------------------------------------
 const PENDING_CONTRACT_TYPES = new Set<string>([
   'agent_idle',
+  // activity_snapshot / activity_delta — both clients now feed them through the
+  // store-core ACTIVITY reducer (applyActivitySnapshot/applyActivityDelta) from
+  // their own switch (#6246/#6247 added the mobile side; dashboard since #5163).
+  // They are NOT on the shared dispatch table (the reducer write is platform-local
+  // — each client owns its `activity` store field), so they stay PENDING rather
+  // than carrying a DISPATCH_FIXTURES entry.
+  'activity_snapshot',
+  'activity_delta',
   // agent_list — migrated to the shared dispatch table (#5618 Batch 2); now has
   // a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   // auth_bootstrap — migrated to the shared dispatch table (#5618 Batch 5b).

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -136,8 +136,9 @@ function clientCoverage(): { inApp: (t: string) => boolean; inDash: (t: string) 
 // pairing-approval banners, the prompt evaluator, the skills panel, the monthly
 // budget meter); mobile parity is a tracked follow-up under the cited epic.
 const DASHBOARD_ONLY = new Set<string>([
-  'activity_snapshot',          // Control Room activity tree (#5159)
-  'activity_delta',             // Control Room activity tree (#5159)
+  // activity_snapshot / activity_delta removed — the mobile app now feeds them
+  // too (#6246/#6247, the Phase-2 mobile-parity fast-follow per epic #5159), so
+  // they are no longer dashboard-only.
   'billing_canary',             // live billing-canary banner (#5821) — dashboard sidebar
   'byok_credentials_status',    // BYOK paste-API-key form (#4052) — dashboard-only for v1
   'cancel_activity_ack',        // Control Room cancel-click correlation ack (#5277)


### PR DESCRIPTION
## What this does

Wires the live Control Room activity feeder into the **mobile** app's WebSocket message handler, making #6245's read-only `MissionControlScreen` (PR1) actually go live.

PR1 (#6245) added `activity: ActivityState` to the app `ConnectionState` (seeded with `createEmptyActivityState()`) plus the read-only screen, but **nothing dispatched** `activity_snapshot` / `activity_delta` into it — so the view always showed its empty state. This PR adds the two `switch` cases that feed it.

## How

In `packages/app/src/store/message-handler.ts`, two new cases in `handleMessage`'s dispatch switch, **mirroring the dashboard feeder** (`packages/dashboard/src/store/message-handler.ts` `handleActivitySnapshot` / `handleActivityDelta`):

- `case 'activity_snapshot'` — parse with `ServerActivitySnapshotSchema` → `applyActivitySnapshot` (REPLACE the session's tree) → `set({ activity })`.
- `case 'activity_delta'` — parse with `ServerActivityDeltaSchema` → `applyActivityDelta` (upsert-by-id; `op` advisory, full entry is self-healing) → `set({ activity })`.

Both:
- validate the wire shape with the protocol Zod schema (defensive — a malformed payload is dropped, never crashes the reducer), and
- short-circuit on `next === prev` (the reducers return the same reference on a no-op) to skip needless re-renders.

Imports: `applyActivitySnapshot` / `applyActivityDelta` added to the existing `@chroxy/store-core` import; `ServerActivitySnapshotSchema` / `ServerActivityDeltaSchema` from `@chroxy/protocol/schemas` (jest resolves this via the existing `^@chroxy/protocol/schemas$` moduleNameMapper). The store-core `ActivityState` type is **not** imported by name in the handler — the app has its own local `ActivityState` enum; only the value reducers are imported.

## Deferred (parity follow-up, not in scope here)

The dashboard's `handleActivityDelta` also bumps `lastClientActivityAt` and clears `inactivityWarning` for the delta's session (so the "Working… last activity Ns ago" indicator and the inactivity chip stay fresh under Control-Room-only traffic). That is **deferred** for this slice — `activity_snapshot` / `activity_delta` are deliberately not in `ACTIVITY_EVENT_TYPES`, so the top-of-handler `isActivityEvent` bump doesn't cover them. This PR does only the activity reduce + set.

## Tests

New `packages/app/src/__tests__/store/message-handler-activity.test.ts` (mirrors the existing `message-handler.test.ts` harness — `createMockStore` + `setStore` + `_testMessageHandler.setContext/handle`), covering:
- `activity_snapshot` populates `state.activity.bySession[sid].byId[id]`;
- `activity_snapshot` REPLACES the prior tree for a session;
- `activity_delta` upserts (then `updated` re-upserts) an entry by id;
- malformed `activity_snapshot` / `activity_delta` are dropped without throwing and leave `state.activity` referentially unchanged.

Closes #6246
Completes the live-view acceptance criterion of #5968.