### PR TITLE
feat(app): bump lastClientActivityAt on activity_delta (#6248)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler-activity.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-activity.test.ts
@@ -55,8 +55,13 @@ function entry(over: Partial<ActivityEntry> & Pick<ActivityEntry, 'id'>): Activi
 }
 
 /** Minimal mock Zustand store seeding `activity` with an empty reducer state. */
-function createMockStore(initialActivity: ActivityState) {
-  let state = { activity: initialActivity } as ConnectionState;
+function createMockStore(
+  initialActivity: ActivityState,
+  sessionStates: Record<string, Partial<{ lastClientActivityAt: number; inactivityWarning: unknown }>> = {},
+) {
+  // sessionStates is present like the real store (the #6248 delta bump reads
+  // get().sessionStates[sid]); default empty so the bump is simply skipped.
+  let state = { activity: initialActivity, sessionStates } as unknown as ConnectionState;
   return {
     store: {
       getState: () => state,
@@ -212,5 +217,46 @@ describe('activity feeder (#6246)', () => {
 
     expect(current().activity).toBe(seeded);
     expect(current().activity.bySession).toEqual({});
+  });
+
+  // #6248 — a live activity_delta counts as activity: it bumps the session's
+  // lastClientActivityAt and clears a stale inactivityWarning (parity with the
+  // dashboard feeder + the app's isActivityEvent bump).
+  it('activity_delta bumps lastClientActivityAt and clears inactivityWarning for its session', () => {
+    const { store, current } = createMockStore(createEmptyActivityState(), {
+      s2: { lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'activity_delta',
+      sessionId: 's2',
+      schemaVersion: 1,
+      op: 'started',
+      entry: entry({ id: 'd1', status: 'running' }),
+    });
+
+    const ss = (current().sessionStates as Record<string, { lastClientActivityAt?: number; inactivityWarning?: unknown }>).s2;
+    expect(ss.lastClientActivityAt).toBeGreaterThan(1000);
+    expect(ss.inactivityWarning).toBeNull();
+  });
+
+  it('activity_delta does NOT bump a session absent from sessionStates (no throw)', () => {
+    const { store, current } = createMockStore(createEmptyActivityState()); // empty sessionStates
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    expect(() =>
+      _testMessageHandler.handle({
+        type: 'activity_delta',
+        sessionId: 'ghost',
+        schemaVersion: 1,
+        op: 'started',
+        entry: entry({ id: 'd1', status: 'running' }),
+      }),
+    ).not.toThrow();
+    // The activity tree still updates; only the (absent) session bump is skipped.
+    expect(current().activity.bySession.ghost!.byId.d1!.status).toBe('running');
   });
 });

--- a/packages/app/src/__tests__/store/message-handler-activity.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-activity.test.ts
@@ -57,7 +57,7 @@ function entry(over: Partial<ActivityEntry> & Pick<ActivityEntry, 'id'>): Activi
 /** Minimal mock Zustand store seeding `activity` with an empty reducer state. */
 function createMockStore(
   initialActivity: ActivityState,
-  sessionStates: Record<string, Partial<{ lastClientActivityAt: number; inactivityWarning: unknown }>> = {},
+  sessionStates: Record<string, Record<string, unknown>> = {},
 ) {
   // sessionStates is present like the real store (the #6248 delta bump reads
   // get().sessionStates[sid]); default empty so the bump is simply skipped.
@@ -258,5 +258,58 @@ describe('activity feeder (#6246)', () => {
     ).not.toThrow();
     // The activity tree still updates; only the (absent) session bump is skipped.
     expect(current().activity.bySession.ghost!.byId.d1!.status).toBe('running');
+  });
+
+  // #6248 guardrail 1: a delta arriving while the session is REPLAYING history
+  // must NOT bump (a session-switch replay would otherwise reset the timestamp).
+  // The replaying set lives on the module-level _ctx and is populated via a real
+  // `history_replay_start` (the canonical path the production gate reads).
+  it('activity_delta does NOT bump while the session is replaying history', () => {
+    const { store, current } = createMockStore(createEmptyActivityState(), {
+      // `messages: []` so history_replay_start (which reads messages.length) runs.
+      s2: { messages: [], lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Put s2 into _ctx.replayingSessions via the real replay-start path.
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
+    const before = (current().sessionStates as Record<string, { lastClientActivityAt?: number }>).s2.lastClientActivityAt;
+
+    _testMessageHandler.handle({
+      type: 'activity_delta',
+      sessionId: 's2',
+      schemaVersion: 1,
+      op: 'started',
+      entry: entry({ id: 'd1', status: 'running' }),
+    });
+
+    const ss = (current().sessionStates as Record<string, { lastClientActivityAt?: number }>).s2;
+    // Gated out: the delta did not bump the timestamp. The tree itself still upserts.
+    expect(ss.lastClientActivityAt).toBe(before);
+    expect(current().activity.bySession.s2!.byId.d1!.status).toBe('running');
+  });
+
+  // #6248 guardrail 2: activity_snapshot is a full-state RESYNC (on subscribe /
+  // reconnect), not fresh work — it must NOT bump lastClientActivityAt.
+  it('activity_snapshot does NOT bump lastClientActivityAt', () => {
+    const { store, current } = createMockStore(createEmptyActivityState(), {
+      s2: { lastClientActivityAt: 1000, inactivityWarning: { remainingMs: 5000 } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'activity_snapshot',
+      sessionId: 's2',
+      schemaVersion: 1,
+      entries: [entry({ id: 'e1', status: 'running' })],
+    });
+
+    const ss = (current().sessionStates as Record<string, { lastClientActivityAt?: number; inactivityWarning?: unknown }>).s2;
+    expect(ss.lastClientActivityAt).toBe(1000); // unchanged — snapshot doesn't bump
+    expect(ss.inactivityWarning).toEqual({ remainingMs: 5000 });
+    // …but the activity tree IS replaced by the snapshot.
+    expect(current().activity.bySession.s2!.byId.e1!.status).toBe('running');
   });
 });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -3534,12 +3534,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // carried entry into its session by id. `op` is advisory — the full entry
     // drives the result, so a dropped earlier delta is self-healed by the next
     // one. Validated + `next === prev` no-op-short-circuited like the snapshot
-    // case above. NOTE: the dashboard ALSO bumps `lastClientActivityAt` / clears
-    // `inactivityWarning` for the delta's session here; that is DEFERRED for this
-    // slice — the dispatch-level activity bump at the top of handleMessage
-    // (`isActivityEvent`) does not yet include the activity_* types, so the
-    // "Working… last activity Ns ago" parity follow-up is intentionally out of
-    // scope for #6246.
+    // case above.
     case 'activity_delta': {
       const parsed = ServerActivityDeltaSchema.safeParse(msg);
       if (!parsed.success) return;
@@ -3547,6 +3542,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const next = applyActivityDelta(prev, parsed.data);
       if (next === prev) return;
       set({ activity: next });
+      // #6248 — a delta is a genuine live state change (a background shell /
+      // subagent / tool started, progressed, or ended), so it counts as
+      // activity: bump `lastClientActivityAt` and clear any `inactivityWarning`
+      // for the delta's session, mirroring the dashboard feeder + the app's
+      // `isActivityEvent` bump (activity_delta isn't in ACTIVITY_EVENT_TYPES, so
+      // it's done here). Gated on `replayingSessions` exactly like that bump so a
+      // session-switch history replay doesn't reset the "Working… last activity
+      // Ns ago" timestamp (#4512). activity_snapshot deliberately does NOT bump —
+      // it's a full-state resync on subscribe/reconnect, not fresh work.
+      const deltaSid = parsed.data.sessionId;
+      if (get().sessionStates[deltaSid] && !_ctx.replayingSessions.has(deltaSid)) {
+        updateSession(deltaSid, (ss) => {
+          const patch: Partial<SessionState> = { lastClientActivityAt: Date.now() };
+          if (ss.inactivityWarning) patch.inactivityWarning = null;
+          return patch;
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
Closes #6248 (deferred parity from #6247). A live `activity_delta` is genuine work (a background shell / subagent / tool started, progressed, or ended), so it now bumps the session's `lastClientActivityAt` and clears a stale `inactivityWarning` — mirroring the dashboard feeder + the app's own `isActivityEvent` bump (`activity_delta` isn't in `ACTIVITY_EVENT_TYPES`, so it's done inline in the case). Gated on `replayingSessions` so a session-switch history replay doesn't reset the "Working… last activity Ns ago" timestamp. `activity_snapshot` deliberately does NOT bump (full-state resync).

App-only; no new message type → no coverage-guard changes. Tests: bump+clear for a known session, skip (no throw) for an absent session. app `tsc` 0-errors + jest 7/7.