### PR TITLE
feat(server): OpenAI-compatible provider via the Anthropic shim (#5420)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13056,6 +13056,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.44.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
+      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/openid-client": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
@@ -17134,6 +17152,7 @@
         "commander": "^12.0.0",
         "dotenv": "^16.3.0",
         "node-pty": "^1.1.0",
+        "openai": "^6.0.0",
         "qrcode": "^1.5.3",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
     "commander": "^12.0.0",
     "dotenv": "^16.3.0",
     "node-pty": "^1.1.0",
-    "openai": "^4.104.0",
+    "openai": "^6.0.0",
     "qrcode": "^1.5.3",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,6 +31,7 @@
     "commander": "^12.0.0",
     "dotenv": "^16.3.0",
     "node-pty": "^1.1.0",
+    "openai": "^4.104.0",
     "qrcode": "^1.5.3",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",

--- a/packages/server/src/anthropic-compatible-config.js
+++ b/packages/server/src/anthropic-compatible-config.js
@@ -433,11 +433,46 @@ function validateEntry(raw, path, seenIds, reservedIds, warnings) {
  *   defaultModel, models|null, pricing|null, contextWindow|null }`.
  */
 export function validateAnthropicCompatibleProviders(value, opts = {}) {
+  return validateCompatibleProviders('anthropicCompatible', value, opts)
+}
+
+/**
+ * Validate + normalize the `providers.openaiCompatible` array (#5420).
+ *
+ * The OpenAI-compatible sibling of the Anthropic-compatible block: the entry
+ * shape is identical (id/label/baseUrl/apiKeyEnv/credentialsKey/defaultModel/
+ * models/pricing/contextWindow/modelDiscovery) — only the wire dialect of the
+ * registered session differs (chat-completions via the shim vs Anthropic
+ * `/v1/messages`). It therefore reuses `validateEntry` 1:1; only the warning
+ * path prefix differs so operators see the right config key.
+ *
+ * Never throws. Invalid entries are dropped (with a warning each); valid
+ * siblings survive.
+ *
+ * @param {*} value - The raw `providers.openaiCompatible` value
+ * @param {{ reservedIds?: Iterable<string> }} [opts]
+ * @returns {{ entries: Array<object>, warnings: string[] }}
+ */
+export function validateOpenAiCompatibleProviders(value, opts = {}) {
+  return validateCompatibleProviders('openaiCompatible', value, opts)
+}
+
+/**
+ * Shared implementation behind both compatible-provider validators. Identical
+ * entry validation (`validateEntry`); only the `providers.<key>` path prefix in
+ * the warnings differs, so an operator's startup log names the block they wrote.
+ *
+ * @param {string} configKey - 'anthropicCompatible' | 'openaiCompatible'
+ * @param {*} value
+ * @param {{ reservedIds?: Iterable<string> }} opts
+ * @returns {{ entries: Array<object>, warnings: string[] }}
+ */
+function validateCompatibleProviders(configKey, value, opts = {}) {
   const warnings = []
   const entries = []
 
   if (!Array.isArray(value)) {
-    warnings.push(`Invalid value for 'providers.anthropicCompatible': expected an array of endpoint entries, got ${typeName(value)}`)
+    warnings.push(`Invalid value for 'providers.${configKey}': expected an array of endpoint entries, got ${typeName(value)}`)
     return { entries, warnings }
   }
 
@@ -448,7 +483,7 @@ export function validateAnthropicCompatibleProviders(value, opts = {}) {
 
   const seenIds = new Set()
   for (let i = 0; i < value.length; i++) {
-    const normalized = validateEntry(value[i], `providers.anthropicCompatible[${i}]`, seenIds, reservedIds, warnings)
+    const normalized = validateEntry(value[i], `providers.${configKey}[${i}]`, seenIds, reservedIds, warnings)
     if (normalized) entries.push(normalized)
   }
 
@@ -465,13 +500,18 @@ export function validateAnthropicCompatibleProviders(value, opts = {}) {
  * @param {string[]} warnings - Accumulator the caller logs/returns
  */
 export function validateProvidersConfigBlock(providers, warnings) {
+  const KNOWN_PROVIDER_BLOCK_KEYS = new Set(['anthropicCompatible', 'openaiCompatible'])
   for (const key of Object.keys(providers)) {
-    if (key !== 'anthropicCompatible') {
+    if (!KNOWN_PROVIDER_BLOCK_KEYS.has(key)) {
       warnings.push(`Unknown key 'providers.${key}' (will be ignored)`)
     }
   }
   if (Object.prototype.hasOwnProperty.call(providers, 'anthropicCompatible')) {
     const { warnings: entryWarnings } = validateAnthropicCompatibleProviders(providers.anthropicCompatible)
+    warnings.push(...entryWarnings)
+  }
+  if (Object.prototype.hasOwnProperty.call(providers, 'openaiCompatible')) {
+    const { warnings: entryWarnings } = validateOpenAiCompatibleProviders(providers.openaiCompatible)
     warnings.push(...entryWarnings)
   }
 }

--- a/packages/server/src/anthropic-openai-shim.js
+++ b/packages/server/src/anthropic-openai-shim.js
@@ -1,0 +1,109 @@
+/**
+ * Network glue for the OpenAI-compatible provider (#5420).
+ *
+ * `ClaudeByokSession` drives `@anthropic-ai/sdk`'s `client.messages.stream(...)`:
+ * it passes an Anthropic Messages request, consumes an async iterable of raw SDK
+ * events (message_start / content_block_* / message_delta / message_stop), then
+ * reads `stream.finalMessage()`. To reach OpenAI-compatible servers (LM Studio,
+ * vLLM, llama.cpp, OpenRouter, …) without forking that loop, this shim reproduces
+ * that surface but speaks OpenAI chat-completions underneath.
+ *
+ * The pure translation (request shape + the streaming-chunk fold into Anthropic
+ * SDK events + the final Message) lives in anthropic-openai-translate.js (#6127).
+ * This module is the thin I/O layer: it imports `openai`, awaits the SSE
+ * iterator, feeds each chunk through `createStreamTranslator()`, and exposes the
+ * async-iterable + `.finalMessage()` the byok loop expects. Keeping it this thin
+ * means the translation stays fixture-testable with no live endpoint, and this
+ * file is exercised with a MOCKED `openai` package (no network).
+ *
+ * The emitted event objects match the RAW Anthropic SDK shapes that
+ * byok-event-translator.js switches on — that file is the contract.
+ */
+
+import OpenAI from 'openai'
+import { anthropicRequestToOpenAi, createStreamTranslator } from './anthropic-openai-translate.js'
+
+/**
+ * Build a minimal Anthropic-SDK-shaped client backed by an OpenAI-compatible
+ * chat-completions endpoint.
+ *
+ * Returns `{ messages: { stream(params, opts) } }` where `stream` mirrors
+ * `@anthropic-ai/sdk`'s `messages.stream`: it returns an object that is
+ * async-iterable over the translated Anthropic SDK events AND exposes
+ * `finalMessage()` resolving to the assembled final Message
+ * (`{ id, type, role, model, content, stop_reason, stop_sequence, usage }`).
+ *
+ * @param {{ baseURL: string, apiKey: string }} cfg
+ * @returns {{ messages: { stream: (params: object, opts?: { signal?: AbortSignal }) => object } }}
+ */
+export function createAnthropicShimClient({ baseURL, apiKey }) {
+  const client = new OpenAI({ baseURL, apiKey })
+
+  return {
+    messages: {
+      stream(params = {}, opts = {}) {
+        return createShimStream(client, params, opts)
+      },
+    },
+  }
+}
+
+/**
+ * The async-iterable + finalMessage object returned by `messages.stream`.
+ *
+ * Iteration is single-pass: it opens the OpenAI stream lazily on the first
+ * iteration, folds each chunk through the translator (yielding Anthropic events),
+ * then flushes the translator's trailing events on stream end. The assembled
+ * final Message is captured during iteration so `finalMessage()` resolves once
+ * iteration completes (the byok loop always fully iterates before awaiting it).
+ *
+ * @param {object} client - the OpenAI client
+ * @param {object} params - Anthropic Messages params
+ * @param {{ signal?: AbortSignal }} opts
+ */
+function createShimStream(client, params, opts) {
+  const signal = opts?.signal
+  const translator = createStreamTranslator()
+  let finalMessage = null
+
+  async function* iterate() {
+    const request = {
+      ...anthropicRequestToOpenAi(params),
+      stream: true,
+      // Ask for usage on the final chunk where the server supports it
+      // (OpenAI / vLLM / many proxies); mapUsage defaults to zero otherwise.
+      stream_options: { include_usage: true },
+    }
+
+    const openaiStream = await client.chat.completions.create(request, { signal })
+
+    for await (const chunk of openaiStream) {
+      for (const event of translator.push(chunk)) yield event
+    }
+
+    const { events, finalMessage: assembled } = translator.finish()
+    finalMessage = assembled
+    for (const event of events) yield event
+  }
+
+  const iterable = iterate()
+
+  return {
+    [Symbol.asyncIterator]() {
+      return iterable
+    },
+    async finalMessage() {
+      // The byok loop fully drains the iterator before calling this, so the
+      // translator has already been finished and `finalMessage` is populated.
+      // Guard defensively: if a caller asks early, drain the remaining events
+      // (discarding them) so `finish()` runs and the message is assembled.
+      if (finalMessage === null) {
+        // Drain remaining events so the generator runs finish() and assembles
+        // the message (the events themselves are discarded on this path).
+        // eslint-disable-next-line no-unused-vars
+        for await (const _event of iterable) { /* drain */ }
+      }
+      return finalMessage
+    },
+  }
+}

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -8,6 +8,7 @@ import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { getProvider, DEFAULT_PROVIDER } from './providers.js'
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
+import { registerOpenAiCompatibleProviders } from './openai-compatible-session.js'
 import { parseTunnelArg } from './tunnel/index.js'
 import { TESTED_CLAUDE_TUI_CLI_VERSION } from './claude-tui/tested-cli-version.js'
 import { detectSilentMeteredDefault } from './doctor-billing.js'
@@ -340,6 +341,10 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
       // Invalid entries are warned about (and surface again through
       // validateConfig below) and skipped.
       registerAnthropicCompatibleProviders(config)
+      // #5420: register config-driven OpenAI-compatible endpoints too, same
+      // rationale as above — a config.provider pointing at one preflights its
+      // credential spec instead of failing as "Unknown provider".
+      registerOpenAiCompatibleProviders(config)
       const { valid, warnings } = validateConfig(config)
       if (valid) {
         configCheck = { name: 'Config', status: 'pass', message: CONFIG_FILE }

--- a/packages/server/src/openai-compatible-session.js
+++ b/packages/server/src/openai-compatible-session.js
@@ -21,8 +21,10 @@
  * (id/label/baseUrl/defaultModel/models?/apiKeyEnv?/credentialsKey?/pricing?/
  * contextWindow?/modelDiscovery?), validated by the same validator in
  * anthropic-compatible-config.js. The ONLY difference is the wire dialect of
- * `baseUrl`: it must point at an OpenAI chat-completions endpoint (the shim
- * appends `/chat/completions`) rather than an Anthropic `/v1/messages` one.
+ * `baseUrl`: it is the OpenAI API BASE URL — typically ending in `/v1` (e.g.
+ * `https://openrouter.ai/api/v1`, `http://localhost:1234/v1` for LM Studio) —
+ * which the `openai` SDK joins with `/chat/completions`, rather than an
+ * Anthropic `/v1/messages` base.
  *
  * Credentials never touch config.json: `apiKeyEnv` names an env var,
  * `credentialsKey` names a field in ~/.chroxy/credentials.json (mode 0600).

--- a/packages/server/src/openai-compatible-session.js
+++ b/packages/server/src/openai-compatible-session.js
@@ -1,0 +1,114 @@
+/**
+ * Config-driven OpenAI-compatible provider endpoints (#5420).
+ *
+ * The sibling of anthropic-compatible-session.js (#5419): anything that speaks
+ * the OpenAI Chat Completions API — OpenAI itself, OpenRouter, LM Studio, vLLM,
+ * llama.cpp server, Together, Groq, DeepInfra, any custom proxy — can be
+ * declared in config.json under `providers.openaiCompatible` and registered as
+ * a first-class provider at startup, without writing a per-service session class.
+ *
+ * The Anthropic↔OpenAI translation core (request shape + streaming-chunk fold
+ * into Anthropic SDK events + final Message) ships in anthropic-openai-translate.js
+ * (#6127); the network glue that exposes it as an `@anthropic-ai/sdk`-shaped
+ * client lives in anthropic-openai-shim.js. This module reuses the entire
+ * config-driven Anthropic-compatible factory (credential resolution, model
+ * allowlists / discovery, pricing, preflight, resolveAuth) and swaps exactly one
+ * seam: `_buildClient` returns the OpenAI shim client instead of a raw Anthropic
+ * client. Subclass, not fork — every byok-session fix and every
+ * anthropic-compatible improvement flows to every configured OpenAI endpoint.
+ *
+ * Entry shape is identical to `providers.anthropicCompatible`
+ * (id/label/baseUrl/defaultModel/models?/apiKeyEnv?/credentialsKey?/pricing?/
+ * contextWindow?/modelDiscovery?), validated by the same validator in
+ * anthropic-compatible-config.js. The ONLY difference is the wire dialect of
+ * `baseUrl`: it must point at an OpenAI chat-completions endpoint (the shim
+ * appends `/chat/completions`) rather than an Anthropic `/v1/messages` one.
+ *
+ * Credentials never touch config.json: `apiKeyEnv` names an env var,
+ * `credentialsKey` names a field in ~/.chroxy/credentials.json (mode 0600).
+ * Env wins over file. Keys are never logged.
+ */
+
+import { createAnthropicCompatibleSessionClass } from './anthropic-compatible-session.js'
+import { validateOpenAiCompatibleProviders } from './anthropic-compatible-config.js'
+import { createAnthropicShimClient } from './anthropic-openai-shim.js'
+import { registerProvider, getRegisteredProviderNames } from './providers.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('openai-compatible')
+
+/**
+ * Create a ClaudeByokSession subclass for one validated OpenAI-compatible config
+ * entry. Delegates the whole four-seam machinery to
+ * `createAnthropicCompatibleSessionClass` and overrides only `_buildClient` so
+ * the session talks chat-completions (via the shim) instead of Anthropic
+ * `/v1/messages`.
+ *
+ * The entry should be the NORMALIZED shape produced by
+ * `validateOpenAiCompatibleProviders`; the underlying Anthropic-compatible
+ * factory still applies the same defaults defensively so tests and embedders can
+ * pass a minimal raw entry.
+ *
+ * @param {object} rawEntry - Normalized config entry
+ * @returns {typeof import('./byok-session.js').ClaudeByokSession} Provider session class
+ */
+export function createOpenAiCompatibleSessionClass(rawEntry) {
+  // Reuse the Anthropic-compatible factory wholesale: it validates id/baseUrl/
+  // defaultModel, freezes the entry, and wires every seam except the client.
+  const AnthropicCompatibleSession = createAnthropicCompatibleSessionClass(rawEntry)
+  // The frozen, normalized entry the base factory built — single source of the
+  // baseUrl the shim needs.
+  const entry = AnthropicCompatibleSession.compatEntry
+
+  class OpenAiCompatibleSession extends AnthropicCompatibleSession {
+    /**
+     * The ONE swapped seam: build an OpenAI-shim client (chat-completions under
+     * an Anthropic-SDK-shaped surface) instead of a raw Anthropic client.
+     * Everything else — credential resolution, history rollback, parallel
+     * tools, MAX_TOOL_ROUNDS, pricing, model discovery — is inherited unchanged.
+     */
+    _buildClient(apiKey) {
+      return createAnthropicShimClient({ baseURL: entry.baseUrl, apiKey })
+    }
+  }
+
+  return OpenAiCompatibleSession
+}
+
+/**
+ * Register every valid `providers.openaiCompatible` entry from the merged config
+ * as a first-class provider (#5420). Called once at server startup
+ * (server-cli.js) right after `registerAnthropicCompatibleProviders`, before the
+ * default-provider resolution so `--provider <id>` can select an OpenAI endpoint.
+ *
+ * Invalid entries are logged and skipped; valid siblings still register.
+ * Collisions are checked against the static RESERVED_PROVIDER_IDS and the LIVE
+ * registry at call time (which already includes any anthropicCompatible ids
+ * registered moments earlier).
+ *
+ * @param {object | null | undefined} config - Merged server config
+ * @returns {string[]} The provider ids that were registered
+ */
+export function registerOpenAiCompatibleProviders(config) {
+  const block = config?.providers
+  // Legacy form: `providers` as an array of provider-id strings — nothing here.
+  if (typeof block !== 'object' || block === null || Array.isArray(block)) return []
+  if (!Object.prototype.hasOwnProperty.call(block, 'openaiCompatible')) return []
+
+  const { entries, warnings } = validateOpenAiCompatibleProviders(block.openaiCompatible, {
+    reservedIds: getRegisteredProviderNames(),
+  })
+  for (const warning of warnings) {
+    log.warn(warning)
+  }
+
+  const registered = []
+  for (const entry of entries) {
+    registerProvider(entry.id, createOpenAiCompatibleSessionClass(entry))
+    registered.push(entry.id)
+    log.info(
+      `OpenAI-compatible provider registered: ${entry.id} → ${entry.baseUrl} (default model: ${entry.defaultModel}, models: ${entry.models ? entry.models.join(', ') : 'unrestricted'}, key: ${entry.apiKeyEnv || entry.credentialsKey || 'none'})`,
+    )
+  }
+  return registered
+}

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -37,6 +37,7 @@ import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychai
 import { maybeEncryptCredentialsAtRest } from './credential-store.js'
 import { registerDockerProvider, resolveProviderLabel, DEFAULT_PROVIDER } from './providers.js'
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
+import { registerOpenAiCompatibleProviders } from './openai-compatible-session.js'
 import { getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
 import { loadModelsCache, getModels, watchModelsOverlay } from './models.js'
@@ -529,6 +530,12 @@ export async function startCliServer(config) {
   // `config.provider` can select one. Invalid entries are warned about
   // and skipped; valid siblings still register.
   registerAnthropicCompatibleProviders(config)
+  // #5420: register config-driven OpenAI-compatible endpoints from
+  // `providers.openaiCompatible` (OpenAI, OpenRouter, LM Studio, vLLM,
+  // llama.cpp, Together, Groq, custom). Same entry shape, but the session
+  // talks chat-completions via the Anthropic↔OpenAI shim. Registered right
+  // after the Anthropic-compatible block (collision-checked against it).
+  registerOpenAiCompatibleProviders(config)
 
   const providerType = config.provider || DEFAULT_PROVIDER
 

--- a/packages/server/tests/anthropic-compatible.test.js
+++ b/packages/server/tests/anthropic-compatible.test.js
@@ -349,8 +349,10 @@ describe('anthropic-compatible config validation', () => {
 
     it('warns on unknown sub-keys of the providers object', () => {
       const warnings = []
-      validateProvidersConfigBlock({ anthropicCompatible: [], openaiCompatible: [] }, warnings)
-      assert.ok(warnings.some((w) => w.includes("'providers.openaiCompatible'") && w.includes('ignored')))
+      // #5420: openaiCompatible is now a KNOWN key (not ignored); use a
+      // genuinely-unrecognized key to exercise the unknown-sub-key warning.
+      validateProvidersConfigBlock({ anthropicCompatible: [], openaiCompatible: [], bogusKey: [] }, warnings)
+      assert.ok(warnings.some((w) => w.includes("'providers.bogusKey'") && w.includes('ignored')))
     })
   })
 })

--- a/packages/server/tests/anthropic-openai-shim.test.js
+++ b/packages/server/tests/anthropic-openai-shim.test.js
@@ -1,0 +1,176 @@
+/**
+ * Tests for the OpenAI-compatible shim (#5420) — the network glue that exposes
+ * an OpenAI chat-completions endpoint behind an `@anthropic-ai/sdk`-shaped
+ * `messages.stream(...)` surface.
+ *
+ * The `openai` package is MOCKED via mock.module so NO live API is hit: a
+ * recorded array of OpenAI SSE chunks is fed back, and we assert the shim yields
+ * the Anthropic SDK event sequence + assembles finalMessage correctly. The pure
+ * translation is covered separately (anthropic-openai-translate.test.js); this
+ * proves the glue (request build, iteration, finish flush, finalMessage, abort).
+ *
+ * Requires: --experimental-test-module-mocks flag (set in package.json).
+ */
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Skip the whole suite if mock.module is unavailable (no flag / old Node).
+if (typeof mock.module !== 'function') {
+  describe('#5420 OpenAI-compatible shim', () => {
+    it('skipped: mock.module not available (needs --experimental-test-module-mocks)', (t) => {
+      t.skip('mock.module requires --experimental-test-module-mocks')
+    })
+  })
+} else {
+  // Capture the args the shim passes the OpenAI client + the chunks to replay.
+  let capturedCtorArgs = null
+  let capturedCreateArgs = null
+  let chunksToReplay = []
+  let throwOnCreate = null
+
+  // Minimal OpenAI client stub. `chat.completions.create(request, opts)` returns
+  // an async-iterable over the recorded chunks (mirrors the streaming client).
+  class FakeOpenAI {
+    constructor(args) {
+      capturedCtorArgs = args
+      this.chat = {
+        completions: {
+          create: async (request, opts) => {
+            capturedCreateArgs = { request, opts }
+            if (throwOnCreate) throw throwOnCreate
+            return (async function* () {
+              for (const c of chunksToReplay) {
+                if (opts?.signal?.aborted) {
+                  const err = new Error('aborted')
+                  err.name = 'AbortError'
+                  throw err
+                }
+                yield c
+              }
+            })()
+          },
+        },
+      }
+    }
+  }
+
+  // Mock the `openai` package BEFORE importing the shim. The shim does
+  // `import OpenAI from 'openai'`, so the mocked module must provide a default.
+  mock.module('openai', { defaultExport: FakeOpenAI })
+
+  const { createAnthropicShimClient } = await import('../src/anthropic-openai-shim.js')
+
+  // Drive a stream end-to-end: collect every yielded Anthropic event + the
+  // finalMessage. Resets the captured state for the case.
+  async function runShim(chunks, { params, signal } = {}) {
+    chunksToReplay = chunks
+    capturedCtorArgs = null
+    capturedCreateArgs = null
+    const client = createAnthropicShimClient({ baseURL: 'http://local/v1', apiKey: 'k' })
+    const stream = client.messages.stream(
+      params || { model: 'gpt-x', max_tokens: 100, messages: [{ role: 'user', content: 'hi' }] },
+      signal ? { signal } : {},
+    )
+    const events = []
+    for await (const ev of stream) events.push(ev)
+    const finalMessage = await stream.finalMessage()
+    return { events, finalMessage }
+  }
+
+  describe('#5420 OpenAI-compatible shim', () => {
+    it('constructs the OpenAI client with baseURL + apiKey', async () => {
+      await runShim([{ id: 'm1', model: 'gpt-x', choices: [{ delta: { content: 'hi' }, finish_reason: 'stop' }] }])
+      assert.deepEqual(capturedCtorArgs, { baseURL: 'http://local/v1', apiKey: 'k' })
+    })
+
+    it('translates Anthropic params to a streaming chat-completions request', async () => {
+      await runShim([{ id: 'm1', choices: [{ delta: { content: 'x' }, finish_reason: 'stop' }] }], {
+        params: { model: 'gpt-x', max_tokens: 50, system: 'be terse', messages: [{ role: 'user', content: 'hi' }] },
+      })
+      const { request } = capturedCreateArgs
+      assert.equal(request.model, 'gpt-x')
+      assert.equal(request.max_tokens, 50)
+      assert.equal(request.stream, true)
+      assert.deepEqual(request.stream_options, { include_usage: true })
+      // System prompt lifted to a leading system message by the translator.
+      assert.deepEqual(request.messages[0], { role: 'system', content: 'be terse' })
+      assert.deepEqual(request.messages[1], { role: 'user', content: 'hi' })
+    })
+
+    it('yields the Anthropic SDK event sequence for a text turn', async () => {
+      const { events, finalMessage } = await runShim([
+        { id: 'm1', model: 'gpt-x', choices: [{ delta: { role: 'assistant', content: '' } }] },
+        { choices: [{ delta: { content: 'Hello' } }] },
+        { choices: [{ delta: { content: ' world' } }] },
+        { choices: [{ delta: {}, finish_reason: 'stop' }] },
+        { choices: [], usage: { prompt_tokens: 12, completion_tokens: 3 } },
+      ])
+      const types = events.map((e) => e.type)
+      assert.deepEqual(types, [
+        'message_start',
+        'content_block_start',
+        'content_block_delta',
+        'content_block_delta',
+        'content_block_stop',
+        'message_delta',
+        'message_stop',
+      ])
+      assert.equal(finalMessage.content[0].type, 'text')
+      assert.equal(finalMessage.content[0].text, 'Hello world')
+      assert.equal(finalMessage.stop_reason, 'end_turn')
+      assert.deepEqual(finalMessage.usage, {
+        input_tokens: 12,
+        output_tokens: 3,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      })
+    })
+
+    it('assembles a tool_use finalMessage from streamed tool-call deltas', async () => {
+      const { events, finalMessage } = await runShim([
+        { id: 'm2', model: 'gpt-x', choices: [{ delta: { role: 'assistant' } }] },
+        { choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_9', function: { name: 'grep', arguments: '' } }] } }] },
+        { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":' } }] } }] },
+        { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '"auth"}' } }] } }] },
+        { choices: [{ delta: {}, finish_reason: 'tool_calls' }], usage: { prompt_tokens: 20, completion_tokens: 8 } },
+      ])
+      const types = events.map((e) => e.type)
+      assert.ok(types.includes('content_block_start'))
+      assert.ok(types.includes('content_block_delta'))
+      assert.ok(types.includes('message_stop'))
+      assert.equal(finalMessage.stop_reason, 'tool_use')
+      assert.equal(finalMessage.content[0].type, 'tool_use')
+      assert.equal(finalMessage.content[0].id, 'call_9')
+      assert.equal(finalMessage.content[0].name, 'grep')
+      assert.deepEqual(finalMessage.content[0].input, { q: 'auth' })
+    })
+
+    it('finalMessage() resolves even when iteration drains it first', async () => {
+      // The byok loop fully iterates, THEN awaits finalMessage — assert that
+      // ordering works (the assembled message is captured during finish()).
+      const { finalMessage } = await runShim([
+        { id: 'm3', choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] },
+      ])
+      assert.ok(finalMessage)
+      assert.equal(finalMessage.role, 'assistant')
+    })
+
+    it('propagates an aborted signal', async () => {
+      const ac = new AbortController()
+      ac.abort()
+      await assert.rejects(
+        () => runShim([{ id: 'm4', choices: [{ delta: { content: 'x' } }] }], { signal: ac.signal }),
+        (err) => err.name === 'AbortError',
+      )
+    })
+
+    it('propagates a create() failure (e.g. connection refused)', async () => {
+      throwOnCreate = new Error('ECONNREFUSED')
+      try {
+        await assert.rejects(() => runShim([]), /ECONNREFUSED/)
+      } finally {
+        throwOnCreate = null
+      }
+    })
+  })
+}

--- a/packages/server/tests/openai-compatible-session.test.js
+++ b/packages/server/tests/openai-compatible-session.test.js
@@ -1,0 +1,182 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  validateOpenAiCompatibleProviders,
+  validateProvidersConfigBlock,
+} from '../src/anthropic-compatible-config.js'
+import {
+  createOpenAiCompatibleSessionClass,
+  registerOpenAiCompatibleProviders,
+} from '../src/openai-compatible-session.js'
+import { ClaudeByokSession } from '../src/byok-session.js'
+import { getProvider, validateProviderClass } from '../src/providers.js'
+import { OllamaSession } from '../src/ollama-session.js'
+
+/**
+ * Tests for config-driven OpenAI-compatible provider endpoints (#5420) —
+ * `providers.openaiCompatible` in config.json.
+ *
+ * The entry shape and validation are shared with the Anthropic-compatible block
+ * (anthropic-compatible.test.js exhaustively covers entry validation), so this
+ * file pins only the OpenAI-specific surface:
+ *   - the validator reuses the same entry rules under the new config key
+ *   - the session-class factory produces a valid ClaudeByokSession subclass
+ *     (passes validateProviderClass) with the four seams resolved
+ *   - `_buildClient` returns the OpenAI shim surface (messages.stream), NOT a
+ *     raw Anthropic client — the one swapped seam
+ *   - startup registration into the live provider registry
+ *   - `providers.openaiCompatible` is an accepted config block (no "unknown key"
+ *     warning) and validates alongside `anthropicCompatible`
+ */
+
+function makeEntry(overrides = {}) {
+  return {
+    id: 'openrouter-oai',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    defaultModel: 'openai/gpt-4o-mini',
+    ...overrides,
+  }
+}
+
+describe('openai-compatible config validation', () => {
+  it('accepts a minimal entry under the openaiCompatible key', () => {
+    const { entries, warnings } = validateOpenAiCompatibleProviders([makeEntry()])
+    assert.deepEqual(warnings, [])
+    assert.equal(entries.length, 1)
+    const e = entries[0]
+    assert.equal(e.id, 'openrouter-oai')
+    assert.equal(e.baseUrl, 'https://openrouter.ai/api/v1')
+    assert.equal(e.defaultModel, 'openai/gpt-4o-mini')
+    assert.ok(Object.isFrozen(e))
+  })
+
+  it('warning paths name the openaiCompatible config key', () => {
+    const { entries, warnings } = validateOpenAiCompatibleProviders([makeEntry({ id: 'NOT VALID' })])
+    assert.equal(entries.length, 0)
+    assert.ok(warnings.some((w) => w.includes('providers.openaiCompatible[0].id')),
+      `expected an openaiCompatible-pathed warning, got: ${warnings}`)
+  })
+
+  it('validateProvidersConfigBlock accepts openaiCompatible (no unknown-key warning)', () => {
+    const warnings = []
+    validateProvidersConfigBlock({ openaiCompatible: [makeEntry()] }, warnings)
+    assert.ok(!warnings.some((w) => w.includes("Unknown key 'providers.openaiCompatible'")),
+      `openaiCompatible must be a known block, got: ${warnings}`)
+  })
+
+  it('validateProvidersConfigBlock validates both blocks together', () => {
+    const warnings = []
+    validateProvidersConfigBlock(
+      {
+        anthropicCompatible: [{ id: 'zai-glm', baseUrl: 'https://api.z.ai/api/anthropic', defaultModel: 'glm-4.7' }],
+        openaiCompatible: [makeEntry()],
+      },
+      warnings,
+    )
+    assert.deepEqual(warnings, [])
+  })
+})
+
+describe('createOpenAiCompatibleSessionClass', () => {
+  it('produces a ClaudeByokSession subclass that passes validateProviderClass', () => {
+    const Cls = createOpenAiCompatibleSessionClass(makeEntry())
+    assert.ok(Cls.prototype instanceof ClaudeByokSession)
+    // Must not throw — the registry contract every provider must satisfy.
+    validateProviderClass(Cls, 'openrouter-oai')
+  })
+
+  it('exposes the frozen entry via compatEntry', () => {
+    const Cls = createOpenAiCompatibleSessionClass(makeEntry())
+    assert.equal(Cls.compatEntry.id, 'openrouter-oai')
+    assert.equal(Cls.compatEntry.baseUrl, 'https://openrouter.ai/api/v1')
+    assert.ok(Object.isFrozen(Cls.compatEntry))
+  })
+
+  it('throws for an entry missing required fields', () => {
+    assert.throws(() => createOpenAiCompatibleSessionClass({ id: '', baseUrl: 'x', defaultModel: 'm' }))
+    assert.throws(() => createOpenAiCompatibleSessionClass(makeEntry({ baseUrl: '' })))
+    assert.throws(() => createOpenAiCompatibleSessionClass(makeEntry({ defaultModel: '' })))
+  })
+
+  describe('seam overrides', () => {
+    it('_defaultModel comes from the entry', () => {
+      const Cls = createOpenAiCompatibleSessionClass(makeEntry())
+      const session = new Cls({ cwd: '/tmp' })
+      assert.equal(session._defaultModel, 'openai/gpt-4o-mini')
+    })
+
+    it('_buildClient returns the OpenAI shim surface (messages.stream), not a raw Anthropic client', () => {
+      const Cls = createOpenAiCompatibleSessionClass(makeEntry())
+      const session = new Cls({ cwd: '/tmp' })
+      const client = session._buildClient('test-key')
+      assert.equal(typeof client.messages?.stream, 'function',
+        'shim client must expose messages.stream')
+      // A raw Anthropic client would expose a baseURL string; the shim does not.
+      assert.equal(typeof client.baseURL, 'undefined',
+        'the shim wraps the OpenAI client; it is not a raw Anthropic client')
+    })
+
+    it('_getPricing returns zero rates when pricing is absent (no missing-pricing warn)', () => {
+      const Cls = createOpenAiCompatibleSessionClass(makeEntry())
+      const pricing = new Cls({ cwd: '/tmp' })._getPricing('openai/gpt-4o-mini')
+      assert.ok(pricing)
+      assert.equal(pricing.input, 0)
+      assert.equal(pricing.output, 0)
+    })
+
+    it('_getPricing returns configured rates with missing rates defaulted to 0', () => {
+      const Cls = createOpenAiCompatibleSessionClass(makeEntry({ pricing: { input: 0.15, output: 0.6 } }))
+      const pricing = new Cls({ cwd: '/tmp' })._getPricing('openai/gpt-4o-mini')
+      assert.equal(pricing.input, 0.15)
+      assert.equal(pricing.output, 0.6)
+      assert.equal(pricing.cacheRead, 0)
+      assert.equal(pricing.cacheWrite, 0)
+    })
+
+    it('models tri-state: array → allowlist, absent → null (unrestricted)', () => {
+      const restricted = createOpenAiCompatibleSessionClass(makeEntry({ models: ['openai/gpt-4o', 'openai/gpt-4o-mini'] }))
+      assert.deepEqual(restricted.getAllowedModels(), ['openai/gpt-4o', 'openai/gpt-4o-mini'])
+      const open = createOpenAiCompatibleSessionClass(makeEntry())
+      assert.equal(open.getAllowedModels(), null)
+    })
+  })
+})
+
+describe('registerOpenAiCompatibleProviders', () => {
+  let registeredIds = []
+  beforeEach(() => {
+    registeredIds = []
+  })
+  afterEach(() => {
+    // Best-effort registry hygiene: nothing exported to unregister, but the ids
+    // used here are unique-suffixed so they don't collide with built-ins.
+  })
+
+  it('returns [] for non-object / legacy-array / missing block', () => {
+    assert.deepEqual(registerOpenAiCompatibleProviders(undefined), [])
+    assert.deepEqual(registerOpenAiCompatibleProviders({}), [])
+    assert.deepEqual(registerOpenAiCompatibleProviders({ providers: ['claude-sdk'] }), [])
+    assert.deepEqual(registerOpenAiCompatibleProviders({ providers: {} }), [])
+  })
+
+  it('registers a valid entry into the live registry', () => {
+    registeredIds = registerOpenAiCompatibleProviders({
+      providers: {
+        openaiCompatible: [makeEntry({ id: 'openrouter-oai-test' })],
+      },
+    })
+    assert.deepEqual(registeredIds, ['openrouter-oai-test'])
+    const Cls = getProvider('openrouter-oai-test')
+    assert.ok(Cls)
+    assert.ok(Cls.prototype instanceof ClaudeByokSession)
+    assert.equal(Cls.compatEntry.baseUrl, 'https://openrouter.ai/api/v1')
+  })
+
+  it('never clobbers a built-in provider on an id collision', () => {
+    const registered = registerOpenAiCompatibleProviders({
+      providers: { openaiCompatible: [makeEntry({ id: 'ollama' })] },
+    })
+    assert.deepEqual(registered, [], 'ollama is reserved — dropped')
+    assert.equal(getProvider('ollama'), OllamaSession, 'built-in class must not be clobbered')
+  })
+})

--- a/packages/server/tests/openai-compatible-session.test.js
+++ b/packages/server/tests/openai-compatible-session.test.js
@@ -162,11 +162,11 @@ describe('registerOpenAiCompatibleProviders', () => {
   it('registers a valid entry into the live registry', () => {
     registeredIds = registerOpenAiCompatibleProviders({
       providers: {
-        openaiCompatible: [makeEntry({ id: 'openrouter-oai-test' })],
+        openaiCompatible: [makeEntry({ id: 'test-openrouter-oai' })],
       },
     })
-    assert.deepEqual(registeredIds, ['openrouter-oai-test'])
-    const Cls = getProvider('openrouter-oai-test')
+    assert.deepEqual(registeredIds, ['test-openrouter-oai'])
+    const Cls = getProvider('test-openrouter-oai')
     assert.ok(Cls)
     assert.ok(Cls.prototype instanceof ClaudeByokSession)
     assert.equal(Cls.compatEntry.baseUrl, 'https://openrouter.ai/api/v1')


### PR DESCRIPTION
## What

Adds config-driven **OpenAI-compatible** provider endpoints under `providers.openaiCompatible` — the sibling of the #5419 Anthropic-compatible block. Anything speaking the OpenAI Chat Completions API (OpenAI, OpenRouter, LM Studio, vLLM, llama.cpp, Together, Groq, custom proxies) can be declared in `config.json` and registered as a first-class provider at startup, no per-service session class required.

Part of #5420.

## How it reuses the #6127 translation core

The hard part — the pure Anthropic↔OpenAI translation — already shipped in #6127 (`anthropic-openai-translate.js`). This PR adds only the thin layers around it:

- **`anthropic-openai-shim.js`** (new) — `createAnthropicShimClient({ baseURL, apiKey })` returns a minimal `@anthropic-ai/sdk`-shaped client: `{ messages: { stream(params, { signal }) } }`. Inside, it translates the Anthropic request via `anthropicRequestToOpenAi`, calls `new OpenAI({ baseURL, apiKey }).chat.completions.create({ ...translated, stream: true, stream_options: { include_usage: true } }, { signal })`, folds each SSE chunk through `createStreamTranslator()` (yielding the Anthropic SDK event sequence the byok loop consumes), and exposes `.finalMessage()` assembled from the translator's `finish()`. The abort signal is forwarded.

- **`openai-compatible-session.js`** (new) — `createOpenAiCompatibleSessionClass(entry)` **subclasses** the Anthropic-compatible factory's product and overrides exactly **one** seam, `_buildClient`, to return the shim. Every other seam (credential resolution, model allowlist / discovery, pricing, preflight, `resolveAuth`) and every `byok-session` fix is inherited unchanged. `registerOpenAiCompatibleProviders(config)` mirrors `registerAnthropicCompatibleProviders`.

- **`anthropic-compatible-config.js`** — `validateOpenAiCompatibleProviders` reuses the **identical** entry validator (extracted a shared `validateCompatibleProviders` helper so only the `providers.<key>` warning prefix differs — no duplicated validation logic). `validateProvidersConfigBlock` now accepts both `anthropicCompatible` and `openaiCompatible`.

- **`server-cli.js` + `doctor.js`** — register the OpenAI-compatible block right after the Anthropic-compatible one (collision-checked against the live registry, which already includes the just-registered anthropicCompatible ids).

- **`package.json`** — adds the `openai` dependency (`^4.104.0`).

## Entry shape

Identical to `providers.anthropicCompatible`: `id` / `label?` / `baseUrl` / `defaultModel` / `models?` / `apiKeyEnv?` / `credentialsKey?` / `pricing?` / `contextWindow?` / `modelDiscovery?`. The only operator-visible difference is that `baseUrl` points at an OpenAI chat-completions endpoint rather than an Anthropic `/v1/messages` one. Credentials never touch config.json (env var or `~/.chroxy/credentials.json`, mode 0600).

## Tests (no live API)

- `tests/anthropic-openai-shim.test.js` — **mocks the `openai` package** via `--experimental-test-module-mocks` `mock.module('openai', { defaultExport: FakeOpenAI })`, replays recorded OpenAI SSE chunks, and asserts the shim yields the Anthropic event sequence, assembles `finalMessage` (text + tool_use turns), translates the request (system lift, `stream`/`stream_options`), and propagates abort + create() errors.
- `tests/openai-compatible-session.test.js` — asserts `registerOpenAiCompatibleProviders` registers a class that passes `validateProviderClass`, the four seams resolve (`_defaultModel`, `_getPricing`, `_buildClient` returns the shim surface not a raw Anthropic client, models tri-state), config-key validation, and that built-ins aren't clobbered on a collision.

## Deferred (fast-follows)

- **Live-endpoint spike** — tool-streaming / parallel-tool-call / usage-accounting fidelity against real OpenAI-compatible servers can't run in CI; tracked under #5420's live-fidelity AC.
- **`docs/providers.md` polish** and a `chroxy providers add` CLI affordance for the new block (the Anthropic-compatible CLI in `cli/providers-cmd.js` could grow an `--openai`-style flag).

Using **Part of #5420** (not Closes) because the live-fidelity AC needs a real endpoint not verifiable in CI.