### PR TITLE
refactor(server): consolidate permission-mode list to one source

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -18,10 +18,9 @@ import { BackgroundShellTracker } from './background-shell-tracker.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { createLogger } from './logger.js'
 import { ActivityRegistry } from './activity-registry.js'
+import { ALLOWED_PERMISSION_MODE_IDS } from './handler-utils.js'
 
 const log = createLogger('base-session')
-
-const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
 
 // #3805: opt-in Chroxy context paragraph. Prepended to `_buildSystemPrompt()`
 // output when `chroxyContextHint` is true so the model knows it's running
@@ -1067,7 +1066,7 @@ export class BaseSession extends EventEmitter {
    * Returns true if the mode actually changed.
    */
   setPermissionMode(mode) {
-    if (!VALID_PERMISSION_MODES.includes(mode)) {
+    if (!ALLOWED_PERMISSION_MODE_IDS.has(mode)) {
       return false
     }
     // 'auto' is the panic-button: a user mid-turn (i.e. _isBusy=true)

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -6,7 +6,7 @@
  */
 import { USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { auditShellCreate } from '../shell-audit.js'
-import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError, isSessionViewer, isUserShellSession } from '../handler-utils.js'
+import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError, isSessionViewer, isUserShellSession, ALLOWED_PERMISSION_MODE_IDS } from '../handler-utils.js'
 import { getRegistryForProvider } from '../models.js'
 import { createLogger, loggerForSession } from '../logger.js'
 
@@ -107,9 +107,8 @@ function handleCreateSession(ws, client, msg, ctx) {
   const cwd = (typeof msg.cwd === 'string' && msg.cwd.trim()) ? msg.cwd.trim() : undefined
   const provider = (typeof msg.provider === 'string' && msg.provider.trim()) ? msg.provider.trim() : undefined
   const model = (typeof msg.model === 'string' && msg.model.trim()) ? msg.model.trim() : undefined
-  const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
   const rawPermMode = (typeof msg.permissionMode === 'string' && msg.permissionMode.trim()) ? msg.permissionMode.trim() : undefined
-  const permissionMode = rawPermMode && VALID_PERMISSION_MODES.includes(rawPermMode) ? rawPermMode : undefined
+  const permissionMode = rawPermMode && ALLOWED_PERMISSION_MODE_IDS.has(rawPermMode) ? rawPermMode : undefined
   const worktree = msg.worktree === true ? true : undefined
   const sandbox = (msg.sandbox && typeof msg.sandbox === 'object' && !Array.isArray(msg.sandbox)) ? msg.sandbox : undefined
   const environmentId = (typeof msg.environmentId === 'string' && msg.environmentId.trim()) ? msg.environmentId.trim() : undefined


### PR DESCRIPTION
## Summary

`VALID_PERMISSION_MODES` / `PERMISSION_MODES` was declared in **three** places in `packages/server/src` that could silently diverge:

- `base-session.js` — private `const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']`
- `handlers/session-handlers.js` — the same array inline inside `handleCreateSession`
- `handler-utils.js` — the canonical `PERMISSION_MODES` (objects with labels/descriptions) + `ALLOWED_PERMISSION_MODE_IDS` (the `Set` of ids)

This consolidates the two duplicates onto the canonical `ALLOWED_PERMISSION_MODE_IDS`, matching the pattern already used in `settings-handlers.js`.

- `session-handlers.js`: drop the inline array; validate via `ALLOWED_PERMISSION_MODE_IDS.has(rawPermMode)`.
- `base-session.js`: drop the private array; `setPermissionMode` validates via `ALLOWED_PERMISSION_MODE_IDS.has(mode)`.

**No behavior change** — the canonical set holds the same four ids (`approve`, `acceptEdits`, `auto`, `plan`); `Set.has` is membership-order-independent. No circular import (`handler-utils.js` depends only on `logger.js`).

## Test plan

- [x] `eslint` clean on both changed files
- [x] Server lints: `lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`, `lint-tests-state-file-path.sh`, `lint-claude-family-explicit.sh` all pass. `lint-ws-index-mutations.sh` only flags a gitignored local dashboard build artifact (`dashboard-next/dist/`, never committed/built in CI) — no tracked file is flagged.
- [x] Targeted tests green: 267 pass / 0 fail across `base-session.test.js`, `handlers/session-handlers.test.js`, `ws-message-handlers.test.js` (includes the suite asserting `ALLOWED_PERMISSION_MODE_IDS` matches `PERMISSION_MODES`).