### PR TITLE
fix(app): add expo-local-authentication plugin for iOS Face ID

### DIFF
--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -83,7 +83,13 @@
       ],
       "expo-secure-store",
       "expo-localization",
-      "expo-live-activity"
+      "expo-live-activity",
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "Allow Chroxy to use Face ID to unlock the app."
+        }
+      ]
     ],
     "extra": {
       "eas": {


### PR DESCRIPTION
## Summary
- The mobile app's biometric lock calls `LocalAuthentication.authenticateAsync()`, but `app.json` registered no `expo-local-authentication` config plugin — so iOS builds shipped **without `NSFaceIDUsageDescription`**. On a Face ID device this crashes the app the moment biometric unlock is attempted.
- Registers the plugin with a `faceIDPermission` string so the usage description lands in `Info.plist`.

This was surfaced as **P0** by the project audit (Expo Expert lens) — an outright iOS crash with a one-line config fix.

## ⚠️ Requires a native rebuild
Config-plugin changes do **not** apply on hot reload. To take effect: `expo prebuild` / a new dev build (`npx expo run:ios` or an EAS dev build).

## Test plan
- [ ] Rebuild the iOS dev client
- [ ] Enable Biometric Lock in Settings
- [ ] Background + foreground the app → Face ID prompt appears (no crash)
- [ ] Confirm `NSFaceIDUsageDescription` is present in the generated `Info.plist`