### PR TITLE
chore: gitignore audit/review artifacts; track tray-badge capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,8 +82,12 @@ tests/screenshots/
 **/tests/screenshots/
 docs/audit-results/
 docs/audits/
+docs/project-audit/
 docs/qa-log.md
 docs/smoke-test.md
 
 # Stray autonomous-session scratch logs (never commit)
 autonomous-session-*.md
+
+# Generated visual-review / brief artifacts (never commit)
+.visual-review/

--- a/packages/desktop/src-tauri/permissions/autogenerated/update_tray_badge.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/update_tray_badge.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-update-tray-badge"
+description = "Enables the update_tray_badge command without any pre-configured scope."
+commands.allow = ["update_tray_badge"]
+
+[[permission]]
+identifier = "deny-update-tray-badge"
+description = "Denies the update_tray_badge command without any pre-configured scope."
+commands.deny = ["update_tray_badge"]


### PR DESCRIPTION
## Summary
Two small housekeeping changes flagged while reviewing leftover working-tree state:

- **Gitignore generated artifacts** — add `docs/project-audit/` (multi-agent audit output) and `.visual-review/` (generated brief / smoke-test HTML+PNG) to `.gitignore`, alongside the existing `docs/audits/` and `docs/audit-results/` launch-hygiene ignores. Keeps generated audit/review output off `main`.
- **Track the tray-badge capability** — commit `permissions/autogenerated/update_tray_badge.toml`. The `update_tray_badge` command is already wired in `src-tauri/src/lib.rs` (definition + registration), but its autogenerated Tauri capability file was never tracked, unlike every sibling in `permissions/autogenerated/`. Same pattern as the `reset_speech_permissions` precedent (#5112).

## Test plan
- [ ] `git check-ignore docs/project-audit/ .visual-review/` resolves (artifacts ignored)
- [ ] Desktop builds with the tray-badge capability present