### PR TITLE
fix(skills): truncate derived skill description on a word boundary

### DIFF
--- a/.claude/skills/autonomous-dev-flow/SKILL.md
+++ b/.claude/skills/autonomous-dev-flow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Orchestrate long-running autonomous dev sessions — work through GitHub issues sequentially with TDD, create PRs, run /full-review, and continue to the next i..."
+description: "Orchestrate long-running autonomous dev sessions — work through GitHub issues sequentially with TDD, create PRs, run /full-review, and continue to the next..."
 ---
 
 # /autonomous-dev-flow

--- a/.claude/skills/hallucination-check/SKILL.md
+++ b/.claude/skills/hallucination-check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Independently verify a claim — usually a message relayed from **another agent** — against this repo's ground truth, using a **context-isolated** subagent tha..."
+description: "Independently verify a claim — usually a message relayed from **another agent** — against this repo's ground truth, using a **context-isolated** subagent..."
 ---
 
 # /hallucination-check

--- a/.claude/skills/prime-directive/SKILL.md
+++ b/.claude/skills/prime-directive/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "A reload-resilient north star for an unattended, multi-wave backlog-clearing marathon — a compact, self-contained constitution you re-invoke after every cont..."
+description: "A reload-resilient north star for an unattended, multi-wave backlog-clearing marathon — a compact, self-contained constitution you re-invoke after every..."
 ---
 
 # /prime-directive

--- a/.claude/skills/skill/SKILL.md
+++ b/.claude/skills/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "The package manager for Claude Code skills — `npm`/`brew` for the skill registry at [`blamechris/skill-templates`](https://github.com/blamechris/skill-templa..."
+description: "The package manager for Claude Code skills — `npm`/`brew` for the skill registry at..."
 ---
 
 # /skill

--- a/.claude/skills/smoke-form/SKILL.md
+++ b/.claude/skills/smoke-form/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Generate an interactive, **self-contained HTML smoke-test form** that guides a human through a manual verification pass — the hand-driven sibling of `/smoke-..."
+description: "Generate an interactive, **self-contained HTML smoke-test form** that guides a human through a manual verification pass — the hand-driven sibling of..."
 ---
 
 # /smoke-form

--- a/.claude/skills/tackle-issues/SKILL.md
+++ b/.claude/skills/tackle-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Run an unattended marathon session that works through GitHub issues across multiple waves until convergence — all issues are resolved, or all remaining issue..."
+description: "Run an unattended marathon session that works through GitHub issues across multiple waves until convergence — all issues are resolved, or all remaining..."
 ---
 
 # /tackle-issues

--- a/.claude/skills/visual-brief/SKILL.md
+++ b/.claude/skills/visual-brief/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Generate a polished, **self-contained HTML brief** of a topic — session status, a plan, or a code walkthrough — saved to a durable folder and opened in the b..."
+description: "Generate a polished, **self-contained HTML brief** of a topic — session status, a plan, or a code walkthrough — saved to a durable folder and opened in the..."
 ---
 
 # /visual-brief

--- a/.gemini/commands/autonomous-dev-flow.toml
+++ b/.gemini/commands/autonomous-dev-flow.toml
@@ -1,4 +1,4 @@
-description = 'Orchestrate long-running autonomous dev sessions — work through GitHub issues sequentially with TDD, create PRs, run /full-review, and continue to the next i...'
+description = 'Orchestrate long-running autonomous dev sessions — work through GitHub issues sequentially with TDD, create PRs, run /full-review, and continue to the next...'
 prompt = '''
 # /autonomous-dev-flow
 

--- a/.gemini/commands/hallucination-check.toml
+++ b/.gemini/commands/hallucination-check.toml
@@ -1,4 +1,4 @@
-description = "Independently verify a claim — usually a message relayed from **another agent** — against this repo's ground truth, using a **context-isolated** subagent tha..."
+description = "Independently verify a claim — usually a message relayed from **another agent** — against this repo's ground truth, using a **context-isolated** subagent..."
 prompt = '''
 # /hallucination-check
 

--- a/.gemini/commands/prime-directive.toml
+++ b/.gemini/commands/prime-directive.toml
@@ -1,4 +1,4 @@
-description = 'A reload-resilient north star for an unattended, multi-wave backlog-clearing marathon — a compact, self-contained constitution you re-invoke after every cont...'
+description = 'A reload-resilient north star for an unattended, multi-wave backlog-clearing marathon — a compact, self-contained constitution you re-invoke after every...'
 prompt = '''
 # /prime-directive
 

--- a/.gemini/commands/smoke-form.toml
+++ b/.gemini/commands/smoke-form.toml
@@ -1,4 +1,4 @@
-description = 'Generate an interactive, **self-contained HTML smoke-test form** that guides a human through a manual verification pass — the hand-driven sibling of `/smoke-...'
+description = 'Generate an interactive, **self-contained HTML smoke-test form** that guides a human through a manual verification pass — the hand-driven sibling of...'
 prompt = '''
 # /smoke-form
 

--- a/.gemini/commands/tackle-issues.toml
+++ b/.gemini/commands/tackle-issues.toml
@@ -1,4 +1,4 @@
-description = 'Run an unattended marathon session that works through GitHub issues across multiple waves until convergence — all issues are resolved, or all remaining issue...'
+description = 'Run an unattended marathon session that works through GitHub issues across multiple waves until convergence — all issues are resolved, or all remaining...'
 prompt = '''
 # /tackle-issues
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -771,3 +771,6 @@ jobs:
 
       - name: Run flush-and-exit.mjs tests
         run: node scripts/__tests__/flush-and-exit.test.mjs
+
+      - name: Run compile-skill-targets.mjs tests
+        run: node scripts/__tests__/compile-skill-targets.test.mjs

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * compile-skill-targets.test.mjs — node test harness for deriveDescription()
+ * in scripts/compile-skill-targets.mjs.
+ *
+ * No external test framework. Each `test()` block runs in series and pushes
+ * pass/fail into a counter. Exit status is 0 if all pass, 1 otherwise.
+ *
+ * Run from repo root:
+ *   node scripts/__tests__/compile-skill-targets.test.mjs
+ *
+ * Importing the module must NOT run its CLI main() — the module guards the
+ * invocation behind an "invoked directly" check so it is safe to import here.
+ */
+
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const helperPath = resolve(__dirname, '..', 'compile-skill-targets.mjs')
+
+const { deriveDescription } = await import(helperPath)
+
+let pass = 0
+let fail = 0
+const failures = []
+
+const test = async (name, fn) => {
+  try {
+    await fn()
+    pass++
+    process.stdout.write(`  ok ${name}\n`)
+  } catch (err) {
+    fail++
+    failures.push({ name, err })
+    process.stdout.write(`  FAIL ${name}: ${err.message}\n`)
+  }
+}
+
+const assert = (cond, msg) => {
+  if (!cond) throw new Error(msg || 'assertion failed')
+}
+
+// A long single sentence with no early period and clearly numbered words, so a
+// mid-word cut is detectable: "word001 word002 … word040" (8-char stride).
+const numberedWords = (n) =>
+  Array.from({ length: n }, (_, i) => `word${String(i + 1).padStart(3, '0')}`).join(' ')
+
+// --- Test 1: long description truncates on a WORD boundary (the #6259 bug) ---
+await test('truncates a long single sentence on a word boundary, not mid-word', async () => {
+  const body = numberedWords(40) // 319 chars, no period
+  const desc = deriveDescription(body, 'demo')
+
+  assert(desc.endsWith('...'), `should end with ellipsis, got: ${JSON.stringify(desc)}`)
+  assert(desc.length <= 160, `should respect the 160-char cap, got length ${desc.length}`)
+
+  // The text before the ellipsis must end on a COMPLETE numbered word — a
+  // mid-word cut (e.g. "word0...") is the bug we are fixing.
+  const visible = desc.slice(0, -3).trimEnd()
+  const lastToken = visible.split(' ').pop()
+  assert(
+    /^word\d{3}$/.test(lastToken),
+    `last token before ellipsis must be a whole word, got: ${JSON.stringify(lastToken)}`,
+  )
+})
+
+// --- Test 2: pathological single over-long word still hard-cuts (no space) ---
+await test('hard-cuts a single over-long word with no space to break on', async () => {
+  const body = 'x'.repeat(200) // one 200-char "word", no boundary to back off to
+  const desc = deriveDescription(body, 'demo')
+
+  assert(desc.endsWith('...'), `should end with ellipsis, got length ${desc.length}`)
+  assert(desc.length === 160, `should hard-cut to the cap (157 + '...'), got length ${desc.length}`)
+})
+
+// --- Test 3: first sentence is extracted when a period is within the cap ----
+await test('extracts the first sentence when it ends within the cap', async () => {
+  const body = 'First sentence here. Second sentence that should be dropped.'
+  const desc = deriveDescription(body, 'demo')
+  assert(desc === 'First sentence here.', `got: ${JSON.stringify(desc)}`)
+})
+
+// --- Test 4: a short paragraph passes through unchanged (no ellipsis) -------
+await test('passes a short paragraph through without an ellipsis', async () => {
+  const body = 'A short skill description'
+  const desc = deriveDescription(body, 'demo')
+  assert(desc === 'A short skill description', `got: ${JSON.stringify(desc)}`)
+  assert(!desc.endsWith('...'), 'short descriptions must not be truncated')
+})
+
+// --- Test 5: heading-only / empty body falls back to the project label ------
+await test('falls back to a project label when there is no prose', async () => {
+  const body = '# Heading only\n\n---\n'
+  const desc = deriveDescription(body, 'my-skill')
+  assert(desc === 'Project skill: /my-skill', `got: ${JSON.stringify(desc)}`)
+})
+
+// --- summary --------------------------------------------------------------
+process.stdout.write(`\n${pass} passed, ${fail} failed\n`)
+if (fail > 0) {
+  for (const f of failures) {
+    process.stderr.write(`\n[FAIL] ${f.name}\n${f.err.stack || f.err.message}\n`)
+  }
+  process.exit(1)
+}
+process.exit(0)

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -96,6 +96,23 @@ await test('falls back to a project label when there is no prose', async () => {
   assert(desc === 'Project skill: /my-skill', `got: ${JSON.stringify(desc)}`)
 })
 
+// --- Test 6: the 160-char cap boundary (passthrough at 160, cut at 161) ----
+// Pins the off-by-one most likely to regress on a future refactor of the cap:
+// a no-period string of exactly 160 chars is returned untouched (no ellipsis),
+// while 161 truncates on the word boundary and stays within the cap.
+await test('passes a 160-char string through but truncates at 161 on a word boundary', async () => {
+  const at160 = 'a'.repeat(80) + ' ' + 'b'.repeat(79) // length 160, no period
+  const passthrough = deriveDescription(at160, 'demo')
+  assert(passthrough === at160, `160-char string should pass through untouched, got length ${passthrough.length}`)
+  assert(!passthrough.endsWith('...'), '160-char string must not get an ellipsis')
+
+  const at161 = 'a'.repeat(80) + ' ' + 'b'.repeat(80) // length 161, no period
+  const truncated = deriveDescription(at161, 'demo')
+  assert(truncated.endsWith('...'), 'a 161-char string should be truncated')
+  assert(truncated.length <= 160, `truncated string should respect the cap, got length ${truncated.length}`)
+  assert(truncated === 'a'.repeat(80) + '...', `should cut at the word boundary, got: ${JSON.stringify(truncated)}`)
+})
+
 // --- summary --------------------------------------------------------------
 process.stdout.write(`\n${pass} passed, ${fail} failed\n`)
 if (fail > 0) {

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -19,8 +19,9 @@
 //
 // Exit non-zero on emit failure so /skill and CI can gate on it.
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
-import { join, dirname } from 'node:path'
+import { join, dirname, resolve } from 'node:path'
 import { homedir } from 'node:os'
+import { fileURLToPath } from 'node:url'
 
 const ALL_TARGETS = ['claude', 'gemini', 'codex']
 
@@ -71,7 +72,7 @@ function stripStamp(body) {
 // description for menus. Accumulate the whole paragraph first (the source's first
 // sentence often wraps across several physical lines) so we don't return a dangling
 // half-sentence. Capped; ellipsis only when truncated.
-function deriveDescription(body, name) {
+export function deriveDescription(body, name) {
   let para = ''
   for (const raw of body.split('\n')) {
     const line = raw.trim()
@@ -85,7 +86,16 @@ function deriveDescription(body, name) {
   let desc = para.replace(/\s+/g, ' ').trim()
   const dot = desc.search(/\.(\s|$)/)
   if (dot !== -1 && dot < 160) desc = desc.slice(0, dot + 1)
-  if (desc.length > 160) desc = desc.slice(0, 157).trimEnd() + '...'
+  if (desc.length > 160) {
+    // Back off to the last word boundary at or before the 157-char cut so the
+    // visible text + ellipsis stays within 160 without slicing mid-word (#6259).
+    // A single pathological word longer than the cap has no space to break on —
+    // fall back to a hard cut so it still truncates.
+    let cut = 157
+    const lastSpace = desc.lastIndexOf(' ', cut)
+    if (lastSpace > 0) cut = lastSpace
+    desc = desc.slice(0, cut).trimEnd() + '...'
+  }
   return desc
 }
 
@@ -245,4 +255,8 @@ function main() {
   console.log(`\nDone.${skipped ? ` ${skipped} target(s) skipped (logged above — not emitted).` : ''}`)
 }
 
-main()
+// Run the CLI only when invoked directly (`node compile-skill-targets.mjs`), not
+// when a test imports this module for unit coverage of deriveDescription().
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main()
+}


### PR DESCRIPTION
## Summary

`deriveDescription()` in `scripts/compile-skill-targets.mjs` hard-cut the auto-derived skill `description` at char 157 when the first sentence had no sentence-ending period before the cap — slicing **mid-word**. The committed `prime-directive` artifacts showed it literally: `"…you re-invoke after every cont..."`. This affects every skill whose first paragraph is one long sentence.

This implements **Option 1** from #6259 (word-boundary truncation) — the durable fix.

## Changes

- **Fix:** in `deriveDescription`, back off to the last whitespace at or before the 157-char cut before appending the ellipsis, so the text ends on a whole word. A single pathological word longer than the cap (no space to break on) still hard-cuts so it always truncates.
- **Testability:** `export` `deriveDescription` and guard the CLI `main()` behind an invoked-directly check so importing the module for unit tests does not run the compiler.
- **Test:** new `scripts/__tests__/compile-skill-targets.test.mjs` (same no-framework harness as `flush-and-exit.test.mjs`) covering the long-single-sentence word-boundary case, the pathological no-space case, first-sentence extraction, short-paragraph passthrough, and the empty-body fallback.
- **CI:** wire the new test into the `scripts-tests` job.
- **Regenerated artifacts:** recompiled the 7 affected skills — the diff is **description-line-only** (no body changes). `prime-directive` now reads `"…you re-invoke after every..."`.

## Acceptance criteria (#6259)

- [x] `deriveDescription` no longer cuts mid-word (truncates on a word boundary, then appends the ellipsis)
- [x] Recompiling existing skills produces no mid-word `...` descriptions
- [x] A unit check covers the long-single-sentence case

## Test plan

- [x] `node scripts/__tests__/compile-skill-targets.test.mjs` — 5/5 pass (RED before the fix on the word-boundary case, GREEN after)
- [x] `bash scripts/__tests__/bump-version.test.sh` — 14/14 pass
- [x] `node scripts/__tests__/flush-and-exit.test.mjs` — 5/5 pass
- [x] Direct CLI invocation (`node scripts/compile-skill-targets.mjs`) still compiles via the new guard

Closes #6259