### PR TITLE
fix(server): skip gitignored dirs in lint-ws-index-mutations walker

### DIFF
--- a/packages/server/scripts/lint-ws-index-mutations.mjs
+++ b/packages/server/scripts/lint-ws-index-mutations.mjs
@@ -76,12 +76,22 @@ const SET_MUTATE_RE = /\.subscribedSessionIds\.(add|delete|clear)\s*\(/g
 // the activeSessionId field write. NOT `==` / `===` / `=>`.
 const SET_ASSIGN_RE = /\.subscribedSessionIds\s*=(?![=>])/g
 
+// Directories the walker must not descend into. `dashboard-next/` is the
+// Vite-built static bundle (gitignored, see .gitignore: it is never committed
+// and is rebuilt locally / by the Tauri bundler) — its minified output packs the
+// forbidden patterns onto dense lines and trips this lint with false positives
+// (#6255). `node_modules/` is vendored dependencies, equally out of scope. The
+// lint only governs hand-written source under src/.
+const SKIP_DIRS = new Set(['node_modules', 'dashboard-next'])
+
 function walk(dir, acc = []) {
   for (const ent of readdirSync(dir)) {
     const p = join(dir, ent)
     const st = statSync(p)
-    if (st.isDirectory()) walk(p, acc)
-    else if (st.isFile() && p.endsWith('.js')) acc.push(p)
+    if (st.isDirectory()) {
+      if (SKIP_DIRS.has(ent)) continue
+      walk(p, acc)
+    } else if (st.isFile() && p.endsWith('.js')) acc.push(p)
   }
   return acc
 }

--- a/packages/server/tests/lint-ws-index-mutations.test.js
+++ b/packages/server/tests/lint-ws-index-mutations.test.js
@@ -257,6 +257,17 @@ describe('lint-ws-index-mutations', () => {
     assert.match(stderr, /handlers[/\\]bad\.js:3/, 'should flag the nested offender with its path')
   })
 
+  test('skips skip-dirs nested below the src root', () => {
+    // The skip matches the directory's basename at every recursion level, not
+    // just a child of src/. A transitive `node_modules/` under a normal source
+    // dir must be skipped too — this pins the "skip at any depth" contract that a
+    // root-only skip would silently break (the offender sits two levels down).
+    const { dir, srcDir } = setupFixtureTree({ 'handlers/node_modules/dep/index.js': NODE_MODULE_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `a skip-dir nested below src/ must still be skipped\nstderr:\n${stderr}`)
+  })
+
   test('--dry-run reports offenders but exits 0', () => {
     const { dir, srcDir } = setupFixtureTree({ 'bad.js': BARE_ACTIVE_WRITE_SRC })
     cleanups.push(dir)

--- a/packages/server/tests/lint-ws-index-mutations.test.js
+++ b/packages/server/tests/lint-ws-index-mutations.test.js
@@ -116,12 +116,28 @@ export function note(client, s) {
 }
 `
 
+// A minified production bundle of the kind Vite emits into \`src/dashboard-next/\`
+// — gitignored build output, not hand-written source. It packs several forbidden
+// patterns onto one dense line, so if the walker descends into that directory it
+// trips ACTIVE_WRITE_RE and SET_MUTATE_RE and fails the lint with false positives
+// (#6255). The walker must skip the whole \`dashboard-next/\` directory.
+const MINIFIED_BUNDLE_SRC = `function r(e,t){e.activeSessionId=t;e.subscribedSessionIds.add(t);return e.subscribedSessionIds}\n`
+
+// A vendored third-party dependency under \`node_modules/\` — also full of bare
+// mutations the walker has no business linting. Same directory-skip requirement.
+const NODE_MODULE_SRC = `module.exports = function (c, s) { c.activeSessionId = s }\n`
+
+// `name` may contain a `/`-separated subpath (e.g. `dashboard-next/dist/x.js`);
+// the parent dirs are created so fixtures can exercise the walker's recursion
+// and directory-skip behavior, not just a flat tree.
 function setupFixtureTree(extraFiles = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'chroxy-lint-ws-idx-'))
   const srcDir = join(dir, 'src')
   mkdirSync(srcDir, { recursive: true })
   for (const [name, src] of Object.entries(extraFiles)) {
-    writeFileSync(join(srcDir, name), src, 'utf8')
+    const filePath = join(srcDir, name)
+    mkdirSync(dirname(filePath), { recursive: true })
+    writeFileSync(filePath, src, 'utf8')
   }
   return { dir, srcDir }
 }
@@ -217,6 +233,28 @@ describe('lint-ws-index-mutations', () => {
     cleanups.push(dir)
     const { code, stderr } = runLint(srcDir)
     assert.equal(code, 0, `inline-comment references must not be flagged\nstderr:\n${stderr}`)
+  })
+
+  test('skips gitignored dashboard-next build artifacts', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'dashboard-next/dist/bundle.js': MINIFIED_BUNDLE_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `gitignored dashboard-next/ must not be walked\nstderr:\n${stderr}`)
+  })
+
+  test('skips node_modules', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'node_modules/dep/index.js': NODE_MODULE_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `node_modules must not be walked\nstderr:\n${stderr}`)
+  })
+
+  test('still recurses into ordinary subdirectories', () => {
+    const { dir, srcDir } = setupFixtureTree({ 'handlers/bad.js': BARE_ACTIVE_WRITE_SRC })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'a real offender in a normal subdir must still fail')
+    assert.match(stderr, /handlers[/\\]bad\.js:3/, 'should flag the nested offender with its path')
   })
 
   test('--dry-run reports offenders but exits 0', () => {


### PR DESCRIPTION
## Summary

`lint-ws-index-mutations.mjs` (#5579) walked **every** `.js` file under `src/`, with no directory filtering. That included:

- `src/dashboard-next/` — the gitignored, Vite-built static bundle (rebuilt locally / by the Tauri bundler, never committed)
- any `node_modules/`

The minified dashboard bundle packs bare `.activeSessionId = x` assignments onto dense lines, so the lint flagged them as reverse-index mutation offenders and **failed locally with false positives** — even though that output is build artifact, not hand-written source. Real repro on this machine: the local `src/dashboard-next/dist/assets/index-*.js` carries 3 bare `.activeSessionId=` assignments that trip `ACTIVE_WRITE_RE`.

## Fix

Add a `SKIP_DIRS = new Set(['node_modules', 'dashboard-next'])` guard to the walker so it descends only into hand-written source. The lint's scope is unchanged for real source files.

## Tests

Three fixture-tree tests added to `lint-ws-index-mutations.test.js`:

- **skips gitignored dashboard-next build artifacts** — a minified bundle fixture under `dashboard-next/dist/` with packed forbidden patterns → exit 0
- **skips node_modules** — a vendored-dep fixture under `node_modules/` → exit 0
- **still recurses into ordinary subdirectories** — a real offender under `handlers/` still fails with its `:line` (guards against over-skipping)

`setupFixtureTree` was extended to create parent dirs so nested fixture paths exercise the walker's recursion and skip behavior. Both skip tests are RED before the fix, GREEN after; the recursion guard is GREEN throughout.

Closes #6255

## Test plan

- [x] `node --test packages/server/tests/lint-ws-index-mutations.test.js` — 13/13 pass
- [x] `packages/server/scripts/lint-ws-index-mutations.sh` — OK against real `src/` (no longer false-positives on the local `dashboard-next/` bundle)