### PR TITLE
fix(server): name the openaiCompatible block in config errors

### DIFF
--- a/packages/server/src/anthropic-compatible-session.js
+++ b/packages/server/src/anthropic-compatible-session.js
@@ -187,17 +187,31 @@ function credentialHint(entry) {
  * embedders can pass a minimal raw entry.
  *
  * @param {object} rawEntry - Normalized config entry
+ * @param {object} [options] - Factory options
+ * @param {string} [options.blockLabel='anthropicCompatible'] - The config block
+ *   name that construction-error messages should reference. The OpenAI-compatible
+ *   factory delegates here and passes 'openaiCompatible' so a malformed
+ *   `providers.openaiCompatible` entry names its own block rather than this one
+ *   (#6253). Defaults to 'anthropicCompatible' so the Anthropic path's wording is
+ *   byte-for-byte unchanged.
  * @returns {typeof ClaudeByokSession} Provider session class for the registry
  */
-export function createAnthropicCompatibleSessionClass(rawEntry) {
+export function createAnthropicCompatibleSessionClass(rawEntry, { blockLabel = 'anthropicCompatible' } = {}) {
   if (typeof rawEntry !== 'object' || rawEntry === null || typeof rawEntry.id !== 'string' || rawEntry.id.length === 0) {
-    throw new Error('createAnthropicCompatibleSessionClass requires an entry with a non-empty id')
+    // The Anthropic block keeps its original (function-named) wording so its
+    // tests are unchanged; a delegated block (e.g. openaiCompatible) names
+    // itself, since there is no id to embed in the message here (#6253).
+    throw new Error(
+      blockLabel === 'anthropicCompatible'
+        ? 'createAnthropicCompatibleSessionClass requires an entry with a non-empty id'
+        : `${blockLabel} entry requires a non-empty id`,
+    )
   }
   if (typeof rawEntry.baseUrl !== 'string' || rawEntry.baseUrl.length === 0) {
-    throw new Error(`anthropicCompatible entry '${rawEntry.id}' requires a baseUrl`)
+    throw new Error(`${blockLabel} entry '${rawEntry.id}' requires a baseUrl`)
   }
   if (typeof rawEntry.defaultModel !== 'string' || rawEntry.defaultModel.length === 0) {
-    throw new Error(`anthropicCompatible entry '${rawEntry.id}' requires a defaultModel`)
+    throw new Error(`${blockLabel} entry '${rawEntry.id}' requires a defaultModel`)
   }
 
   // Defensive normalization (no-op for validator output).

--- a/packages/server/src/openai-compatible-session.js
+++ b/packages/server/src/openai-compatible-session.js
@@ -57,7 +57,9 @@ const log = createLogger('openai-compatible')
 export function createOpenAiCompatibleSessionClass(rawEntry) {
   // Reuse the Anthropic-compatible factory wholesale: it validates id/baseUrl/
   // defaultModel, freezes the entry, and wires every seam except the client.
-  const AnthropicCompatibleSession = createAnthropicCompatibleSessionClass(rawEntry)
+  // Pass our own block label so a malformed entry's construction error names
+  // `openaiCompatible`, not the delegated `anthropicCompatible` factory (#6253).
+  const AnthropicCompatibleSession = createAnthropicCompatibleSessionClass(rawEntry, { blockLabel: 'openaiCompatible' })
   // The frozen, normalized entry the base factory built — single source of the
   // baseUrl the shim needs.
   const entry = AnthropicCompatibleSession.compatEntry

--- a/packages/server/tests/anthropic-compatible.test.js
+++ b/packages/server/tests/anthropic-compatible.test.js
@@ -371,6 +371,23 @@ describe('AnthropicCompatibleSession factory', () => {
     assert.throws(() => createAnthropicCompatibleSessionClass({ id: 'x', baseUrl: 'https://e' }), /defaultModel/)
   })
 
+  it('field errors name the anthropicCompatible block, wording unchanged (#6253)', () => {
+    // The shared factory now threads a block label (openaiCompatible delegates
+    // here), but the default Anthropic path must keep its exact wording. Lock it.
+    assert.throws(
+      () => createAnthropicCompatibleSessionClass({ id: 'x' }),
+      /anthropicCompatible entry 'x' requires a baseUrl/,
+    )
+    assert.throws(
+      () => createAnthropicCompatibleSessionClass({ id: 'x', baseUrl: 'https://e' }),
+      /anthropicCompatible entry 'x' requires a defaultModel/,
+    )
+    assert.throws(
+      () => createAnthropicCompatibleSessionClass({}),
+      /createAnthropicCompatibleSessionClass requires an entry with a non-empty id/,
+    )
+  })
+
   describe('static metadata', () => {
     it('displayLabel uses the label, falling back to the id', () => {
       assert.equal(createAnthropicCompatibleSessionClass(makeEntry({ label: 'Z.ai GLM' })).displayLabel, 'Z.ai GLM')

--- a/packages/server/tests/openai-compatible-session.test.js
+++ b/packages/server/tests/openai-compatible-session.test.js
@@ -98,6 +98,32 @@ describe('createOpenAiCompatibleSessionClass', () => {
     assert.throws(() => createOpenAiCompatibleSessionClass(makeEntry({ defaultModel: '' })))
   })
 
+  it('construction errors name the openaiCompatible block, not anthropicCompatible (#6253)', () => {
+    // The factory delegates validation to createAnthropicCompatibleSessionClass.
+    // Without a threaded block label, a malformed openaiCompatible entry would
+    // throw "anthropicCompatible entry ... requires a baseUrl" and misdirect the
+    // operator to the wrong config key.
+    assert.throws(
+      () => createOpenAiCompatibleSessionClass(makeEntry({ baseUrl: '' })),
+      (err) => /openaiCompatible entry .* requires a baseUrl/.test(err.message)
+        && !/anthropicCompatible/.test(err.message),
+      'a missing baseUrl must name openaiCompatible and never anthropicCompatible',
+    )
+    assert.throws(
+      () => createOpenAiCompatibleSessionClass(makeEntry({ defaultModel: '' })),
+      (err) => /openaiCompatible entry .* requires a defaultModel/.test(err.message)
+        && !/anthropicCompatible/.test(err.message),
+      'a missing defaultModel must name openaiCompatible and never anthropicCompatible',
+    )
+    assert.throws(
+      () => createOpenAiCompatibleSessionClass(makeEntry({ id: '' })),
+      (err) => /openaiCompatible/.test(err.message)
+        && !/anthropicCompatible/.test(err.message)
+        && !/createAnthropicCompatibleSessionClass/.test(err.message),
+      'a missing id must name openaiCompatible, not the delegated factory',
+    )
+  })
+
   describe('seam overrides', () => {
     it('_defaultModel comes from the entry', () => {
       const Cls = createOpenAiCompatibleSessionClass(makeEntry())

--- a/packages/server/tests/openai-compatible-session.test.js
+++ b/packages/server/tests/openai-compatible-session.test.js
@@ -117,7 +117,11 @@ describe('createOpenAiCompatibleSessionClass', () => {
     )
     assert.throws(
       () => createOpenAiCompatibleSessionClass(makeEntry({ id: '' })),
-      (err) => /openaiCompatible/.test(err.message)
+      // Pin the exact wording of the delegated-block id message — it is the one
+      // string this fix introduces (the `${blockLabel} entry requires a non-empty
+      // id` branch), so lock it the way the baseUrl/defaultModel messages are and
+      // assert it never leaks the anthropic block or the function-named fallback.
+      (err) => /openaiCompatible entry requires a non-empty id/.test(err.message)
         && !/anthropicCompatible/.test(err.message)
         && !/createAnthropicCompatibleSessionClass/.test(err.message),
       'a missing id must name openaiCompatible, not the delegated factory',


### PR DESCRIPTION
## Summary

`createOpenAiCompatibleSessionClass` reuses `createAnthropicCompatibleSessionClass` wholesale for construction-time validation. That shared factory hard-coded the `anthropicCompatible` label in its error messages, so a malformed `providers.openaiCompatible` entry threw e.g. **`anthropicCompatible entry '<id>' requires a baseUrl`** — pointing the operator at the wrong config key.

## Fix

Thread a `blockLabel` option through `createAnthropicCompatibleSessionClass`:

- Defaults to `'anthropicCompatible'`, so the Anthropic path's error wording is **byte-for-byte unchanged**.
- The OpenAI factory passes `'openaiCompatible'`, so a bad `providers.openaiCompatible` entry now names its own block — for the `baseUrl`, `defaultModel`, **and** the id guard (the id guard keeps the original function-named message only for the default Anthropic path).

The config-time validator (`validateOpenAiCompatibleProviders`) was already block-aware; the only mislabeling was in the factory's construction guards.

## Tests

- **OpenAI side (new, #6253 regression):** construction errors for a missing `baseUrl` / `defaultModel` / `id` must match `openaiCompatible` and must **not** contain `anthropicCompatible` (or the delegated factory name). RED on the old source, GREEN after the fix (verified by reversal).
- **Anthropic side (new guard):** locks the original wording (`anthropicCompatible entry '<id>' requires a baseUrl` / `… requires a defaultModel` / `createAnthropicCompatibleSessionClass requires an entry with a non-empty id`) so a future refactor can't silently regress it.
- Existing `throws`-tests in both files are untouched.

## Acceptance (from #6253)

- [x] A bad `providers.openaiCompatible` entry throws an error naming `openaiCompatible`.
- [x] The Anthropic-compatible error wording + tests are unchanged.

Closes #6253

## Test plan

- [x] `node --test packages/server/tests/{anthropic-compatible,openai-compatible-session,openrouter-ergonomics}.test.js` — 130/130 pass
- [x] New OpenAI regression test verified RED on old source (TDD-by-reversal)
- [x] `lint-session-opt-forwarding.sh` + `lint-tests-state-file-path.sh` — OK