### PR TITLE
fix(scripts): grapheme-aware deriveDescription cap (not UTF-16 units)

### DIFF
--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -42,6 +42,11 @@ const assert = (cond, msg) => {
   if (!cond) throw new Error(msg || 'assertion failed')
 }
 
+// Count visible glyphs (grapheme clusters), not UTF-16 code units — the unit the
+// cap is measured in since #6261.
+const countGraphemes = (s) =>
+  [...new Intl.Segmenter('en', { granularity: 'grapheme' }).segment(s)].length
+
 // A long single sentence with no early period and clearly numbered words, so a
 // mid-word cut is detectable: "word001 word002 … word040" (8-char stride).
 const numberedWords = (n) =>
@@ -111,6 +116,38 @@ await test('passes a 160-char string through but truncates at 161 on a word boun
   assert(truncated.endsWith('...'), 'a 161-char string should be truncated')
   assert(truncated.length <= 160, `truncated string should respect the cap, got length ${truncated.length}`)
   assert(truncated === 'a'.repeat(80) + '...', `should cut at the word boundary, got: ${JSON.stringify(truncated)}`)
+})
+
+// --- Test 7: grapheme-aware cap — a ZWJ sequence counts as ONE glyph (#6261) -
+// A "family" emoji is a single grapheme cluster but 7 code points / 11 UTF-16
+// code units. 30 of them is 30 graphemes (well under the 160 cap) yet 330 code
+// units (well over it). A code-unit cap would wrongly truncate — and slice a
+// family mid-ZWJ-sequence; a grapheme cap leaves the string untouched.
+await test('counts a ZWJ emoji sequence as one glyph and does not truncate under the cap', async () => {
+  const family = '👨‍👩‍👧‍👦' // 1 grapheme, 7 code points, 11 UTF-16 code units
+  const body = family.repeat(30) // 30 graphemes / 330 code units
+  assert(countGraphemes(body) === 30 && body.length === 330, 'fixture sanity: 30 graphemes, 330 code units')
+  const desc = deriveDescription(body, 'demo')
+  assert(desc === body, `a 30-grapheme string must pass through untouched (a UTF-16 cap would truncate it), got length ${desc.length}`)
+  assert(!desc.endsWith('...'), 'must not truncate a 30-grapheme description')
+})
+
+// --- Test 8: grapheme-aware cut — a space-less emoji run never splits a pair --
+// 200 emoji with no spaces to break on must hard-cut on a cluster boundary. A
+// UTF-16 slice at 157 units would bisect emoji #79's surrogate pair and leak a
+// lone high surrogate; a grapheme cut keeps every emoji whole.
+await test('hard-cuts a space-less emoji run on a cluster boundary, never a lone surrogate', async () => {
+  const emoji = '😀' // 1 grapheme, 2 UTF-16 code units
+  const body = emoji.repeat(200)
+  const desc = deriveDescription(body, 'demo')
+  assert(desc.endsWith('...'), `should truncate a 200-emoji run, got: ${JSON.stringify(desc.slice(0, 12))}…`)
+  const visible = desc.slice(0, -3) // strip the ASCII ellipsis
+  // Strip valid surrogate PAIRS; any surviving surrogate code unit is a lone
+  // (split) surrogate — the signature of a mid-cluster cut.
+  const stripped = visible.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '')
+  assert(!/[\uD800-\uDFFF]/.test(stripped), 'a lone surrogate leaked — the cut sliced mid-cluster')
+  assert([...visible].every((ch) => ch === emoji), 'every visible glyph must be a whole emoji')
+  assert(countGraphemes(visible) <= 160, `visible text must respect the 160-grapheme cap, got ${countGraphemes(visible)}`)
 })
 
 // --- summary --------------------------------------------------------------

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -68,6 +68,15 @@ function stripStamp(body) {
   return body.replace(/^<!--\s*skill-templates:.*?-->\s*$/gm, '').replace(/\n{3,}$/g, '\n').trimEnd() + '\n'
 }
 
+// Measure and cut descriptions on grapheme-cluster boundaries (not UTF-16 code
+// units) so a description dense in astral-plane characters (emoji, ZWJ sequences,
+// combining marks) caps by visible-glyph count and never slices mid-cluster
+// (#6261). Intl.Segmenter is built into Node — no dependency. For ASCII text every
+// grapheme is exactly one code unit, so the cap and cut points are byte-identical
+// to the old String.length / slice path.
+const GRAPHEME_SEG = new Intl.Segmenter('en', { granularity: 'grapheme' })
+const toGraphemes = (s) => Array.from(GRAPHEME_SEG.segment(s), (g) => g.segment)
+
 // First sentence of the first non-heading prose PARAGRAPH -> a clean one-line
 // description for menus. Accumulate the whole paragraph first (the source's first
 // sentence often wraps across several physical lines) so we don't return a dangling
@@ -85,16 +94,24 @@ export function deriveDescription(body, name) {
   if (!para) return `Project skill: /${name}`
   let desc = para.replace(/\s+/g, ' ').trim()
   const dot = desc.search(/\.(\s|$)/)
-  if (dot !== -1 && dot < 160) desc = desc.slice(0, dot + 1)
-  if (desc.length > 160) {
-    // Back off to the last word boundary at or before the 157-char cut so the
-    // visible text + ellipsis stays within 160 without slicing mid-word (#6259).
-    // A single pathological word longer than the cap has no space to break on —
-    // fall back to a hard cut so it still truncates.
+  // Keep just the first sentence when its terminating '.' falls within the cap.
+  // Measure the dot's position in graphemes — faithful to the old `dot < 160`
+  // UTF-16 check for ASCII, correct for astral text. '.' is its own grapheme, so
+  // the slice lands on a cluster boundary.
+  if (dot !== -1 && toGraphemes(desc.slice(0, dot)).length < 160) desc = desc.slice(0, dot + 1)
+  const graphemes = toGraphemes(desc)
+  if (graphemes.length > 160) {
+    // Back off to the last word boundary at or before the 157-grapheme cut so the
+    // visible text + ellipsis stays within 160 graphemes without slicing mid-word
+    // (#6259) or mid-cluster (#6261). A single pathological word longer than the
+    // cap has no space to break on — fall back to a hard 157-grapheme cut.
     let cut = 157
-    const lastSpace = desc.lastIndexOf(' ', cut)
+    let lastSpace = -1
+    for (let i = Math.min(cut, graphemes.length - 1); i >= 0; i--) {
+      if (graphemes[i] === ' ') { lastSpace = i; break }
+    }
     if (lastSpace > 0) cut = lastSpace
-    desc = desc.slice(0, cut).trimEnd() + '...'
+    desc = graphemes.slice(0, cut).join('').trimEnd() + '...'
   }
   return desc
 }


### PR DESCRIPTION
## Summary

`deriveDescription()` in `scripts/compile-skill-targets.mjs` measured its 160-char one-line cap in JavaScript `String.length` — UTF-16 code units, not grapheme clusters (#6261). A description dense in astral-plane characters (emoji, ZWJ sequences, combining marks) therefore under-counted visible glyphs and could slice a surrogate pair or grapheme cluster mid-character, leaving a lone surrogate or a shredded ZWJ sequence.

- Measure and cut on **grapheme-cluster boundaries** via `Intl.Segmenter` (built into Node — **no dependency**).
- The sentence cut, 160-cap check, and 157-char word-boundary backoff (#6259) now all count/slice in graphemes.
- **Byte-identical for ASCII:** every grapheme is one code unit, so the cap and cut points are unchanged for all existing inputs.

## Decision (per #6261 acceptance criteria)

The issue offered "implement grapheme-aware measurement *or* close wontfix." Implemented, because `Intl.Segmenter` is a zero-dependency Node built-in — the durable/correct option costs nothing.

## Test plan

- [x] 6 existing ASCII `deriveDescription` tests pass unchanged (confirms identical behavior for all real inputs).
- [x] New test: a ZWJ "family" emoji `👨‍👩‍👧‍👦` (1 grapheme / 11 UTF-16 units) — 30 of them pass through under the cap where a UTF-16 cap (330 units) would wrongly truncate and shred a family.
- [x] New test: a space-less 200-emoji run hard-cuts on a cluster boundary — no lone surrogate leaks (a UTF-16 slice at 157 would bisect emoji #79's surrogate pair).
- [x] Recompiling all 28 installed skills produces **no artifact diff** (`.claude/skills/`, `.gemini/commands/` unchanged).
- [x] `node scripts/__tests__/compile-skill-targets.test.mjs` → 8 passed, 0 failed.

Closes #6261