### PR TITLE
refactor(server): single-source duplicated validation regexes

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -146,11 +146,9 @@ import {
 } from './devcontainer-config.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { getErrorMessage } from './utils/error-message.js'
+import { VALID_USERNAME_RE } from './utils/validation-patterns.js'
 
 const log = createLogger('docker-byok')
-
-/** POSIX username pattern — same shape as docker-sdk-session.js. */
-const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
 
 const DEFAULT_IMAGE = 'node:22-slim'
 const DEFAULT_MEMORY_LIMIT = '2g'

--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -4,14 +4,9 @@ import { createLogger } from './logger.js'
 import { classifyDockerError } from './docker-session.js'
 import { DockerBackend, FORWARDED_ENV_KEYS, DEFAULT_CONTAINER_CLI_PATH } from './environments/backends/docker.js'
 import { BILLING_CLASSES } from './billing-class.js'
+import { VALID_USERNAME_RE } from './utils/validation-patterns.js'
 
 const log = createLogger('docker-sdk')
-
-/**
- * Valid POSIX username: starts with lowercase letter or underscore,
- * followed by lowercase alphanumeric, underscore, or hyphen.
- */
-const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
 
 /**
  * DockerSdkSession runs Claude Code inside an isolated Docker container

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -6,6 +6,7 @@ import { dirname, join } from 'path'
 import { homedir } from 'os'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
+import { VALID_USERNAME_RE } from './utils/validation-patterns.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import {
   parseDevContainer,
@@ -20,8 +21,6 @@ const DEFAULT_IMAGE = 'node:22-slim'
 const DEFAULT_MEMORY_LIMIT = '2g'
 const DEFAULT_CPU_LIMIT = '2'
 const DEFAULT_CONTAINER_USER = 'chroxy'
-
-const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
 
 // Re-export `UNREACHABLE_STATUSES` from the dedicated constants module so
 // existing importers (tests, future consumers) continue to work. The

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -1,5 +1,6 @@
 import { execFile, spawn } from 'child_process'
 import { createLogger } from '../../logger.js'
+import { VALID_USERNAME_RE } from '../../utils/validation-patterns.js'
 
 const log = createLogger('docker-backend')
 
@@ -279,10 +280,9 @@ export class DockerBackend {
       const execArgs = ['exec']
 
       if (user) {
-        // POSIX username pattern — same regex as docker-sdk-session.js
-        // and docker-byok-session.js. Refuse anything weirder so a
-        // caller-supplied string can't smuggle a flag.
-        if (!/^[a-z_][a-z0-9_-]{0,31}$/.test(user)) {
+        // Refuse anything but a POSIX username so a caller-supplied string
+        // can't smuggle a `docker exec` flag (VALID_USERNAME_RE is shared).
+        if (!VALID_USERNAME_RE.test(user)) {
           reject(new Error(`Invalid user "${user}" — must match POSIX username rules`))
           return
         }

--- a/packages/server/src/path-hash-trust-ledger.js
+++ b/packages/server/src/path-hash-trust-ledger.js
@@ -48,6 +48,7 @@ import { readFileSync } from 'fs'
 import { randomBytes } from 'crypto'
 import { saveJsonState } from './json-state-file.js'
 import { getErrorMessage } from './utils/error-message.js'
+import { HEX64 } from './utils/validation-patterns.js'
 
 /**
  * @typedef {Object} TrustRecord
@@ -55,8 +56,6 @@ import { getErrorMessage } from './utils/error-message.js'
  * @property {string} firstSeen    ISO timestamp of first sight
  * @property {string} [approvalTs] The third timestamp (named per subclass)
  */
-
-const HEX64 = /^[0-9a-f]{64}$/
 
 export class PathHashTrustLedger {
   /**
@@ -310,5 +309,3 @@ export class PathHashTrustLedger {
     }
   }
 }
-
-export { HEX64 as _HEX64 }

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -105,6 +105,7 @@ import { join } from 'path'
 import { createHash } from 'crypto'
 import { createLogger } from './logger.js'
 import { PathHashTrustLedger } from './path-hash-trust-ledger.js'
+import { HEX64 } from './utils/validation-patterns.js'
 
 const log = createLogger('skills-trust')
 
@@ -282,7 +283,7 @@ export class SkillsTrustStore extends PathHashTrustLedger {
         && typeof v === 'object'
         && !Array.isArray(v)
         && typeof v.sha256 === 'string'
-        && /^[0-9a-f]{64}$/.test(v.sha256)
+        && HEX64.test(v.sha256)
         && typeof v.firstSeen === 'string'
     }
     if (Object.keys(parsed).some(looksLikeV1Entry)) {

--- a/packages/server/src/utils/validation-patterns.js
+++ b/packages/server/src/utils/validation-patterns.js
@@ -1,0 +1,23 @@
+/**
+ * Shared validation regexes (#6201 DRY consolidation).
+ *
+ * These patterns validate untrusted string inputs and were previously copied
+ * verbatim across several modules — the copies even cross-referenced each other
+ * in comments ("same regex as docker-sdk-session.js"), the textbook DRY smell.
+ * Single-sourcing them keeps every call site in lockstep, so a future tightening
+ * (or loosening) lands everywhere at once instead of drifting silently.
+ */
+
+/**
+ * Valid POSIX/container username: starts with a lowercase letter or underscore,
+ * then up to 31 more lowercase-alphanumeric, underscore, or hyphen characters
+ * (32 total — the traditional `useradd` limit). Refusing anything else stops a
+ * caller-supplied string from smuggling a `docker exec -u` flag.
+ */
+export const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
+
+/**
+ * Lower-case SHA-256 hex digest: exactly 64 hex characters. Used to validate
+ * trust-ledger hashes (path-hash-trust-ledger.js, skills-trust.js).
+ */
+export const HEX64 = /^[0-9a-f]{64}$/

--- a/packages/server/tests/validation-patterns.test.js
+++ b/packages/server/tests/validation-patterns.test.js
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { VALID_USERNAME_RE, HEX64 } from '../src/utils/validation-patterns.js'
+
+/**
+ * Contract for the shared validation regexes (#6201). These two patterns were
+ * previously copied verbatim across environment-manager.js, docker-sdk-session.js,
+ * docker-byok-session.js, environments/backends/docker.js (username) and
+ * path-hash-trust-ledger.js, skills-trust.js (hex64). Pinning the contract here
+ * guards the single source against a future drift that would silently loosen one
+ * call site's input validation.
+ */
+
+describe('VALID_USERNAME_RE', () => {
+  describe('accepts valid POSIX/container usernames', () => {
+    for (const name of ['chroxy', 'root', 'a', '_svc', 'node22', 'user-name', 'a_b-c']) {
+      it(`accepts ${JSON.stringify(name)}`, () => {
+        assert.equal(VALID_USERNAME_RE.test(name), true)
+      })
+    }
+
+    it('accepts a 32-char name (1 leading + 31 trailing — the useradd limit)', () => {
+      assert.equal(VALID_USERNAME_RE.test('a' + 'b'.repeat(31)), true)
+    })
+  })
+
+  describe('rejects invalid input', () => {
+    for (const bad of [
+      '', // empty
+      '1user', // leading digit
+      '-user', // leading hyphen
+      'User', // uppercase
+      'a'.repeat(33), // 33 chars — over the 32 limit
+      'user name', // space
+      'user;rm -rf', // shell metacharacter
+      'user\n', // trailing newline (anchors are not multiline)
+      '-u', // a smuggled `docker exec` flag
+    ]) {
+      it(`rejects ${JSON.stringify(bad)}`, () => {
+        assert.equal(VALID_USERNAME_RE.test(bad), false)
+      })
+    }
+  })
+})
+
+describe('HEX64', () => {
+  // 64 lowercase hex characters.
+  const SHA256 = 'abcdef0123456789'.repeat(4)
+
+  describe('accepts a 64-char lowercase hex digest', () => {
+    for (const hex of [SHA256, '0'.repeat(64), 'f'.repeat(64)]) {
+      it(`accepts a digest starting ${hex.slice(0, 8)}…`, () => {
+        assert.equal(HEX64.test(hex), true)
+      })
+    }
+  })
+
+  describe('rejects invalid input', () => {
+    for (const bad of [
+      '', // empty
+      SHA256.slice(0, 63), // 63 chars — too short
+      SHA256 + '0', // 65 chars — too long
+      'A'.repeat(64), // uppercase — must be lowercase
+      'g'.repeat(64), // non-hex character
+      SHA256.slice(0, 63) + ' ', // trailing space
+    ]) {
+      it(`rejects ${JSON.stringify(bad.length > 16 ? bad.slice(0, 16) + '…' : bad)}`, () => {
+        assert.equal(HEX64.test(bad), false)
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

DRY consolidation from the SOLID/DRY epic (#6201, Tier 1 — *SAFE to do now*). Two validation regexes were copied verbatim across several server modules — the copies even cross-referenced each other in comments (`// same regex as docker-sdk-session.js`), the textbook DRY smell. This moves both into a single shared module so a future tightening lands everywhere at once instead of drifting silently.

New module: `packages/server/src/utils/validation-patterns.js`

- **`VALID_USERNAME_RE`** (`/^[a-z_][a-z0-9_-]{0,31}$/`, POSIX/container username) — **4 copies** removed:
  - `environment-manager.js` (named const)
  - `docker-sdk-session.js` (named const)
  - `docker-byok-session.js` (named const)
  - `environments/backends/docker.js` (**inlined** at the `docker exec -u` guard)
- **`HEX64`** (`/^[0-9a-f]{64}$/`, lower-case sha256 digest) — **2 copies** removed:
  - `path-hash-trust-ledger.js` (named const)
  - `skills-trust.js` (**inlined** in legacy-v1 detection)

Also removes the dead `_HEX64` test-only export from `path-hash-trust-ledger.js` — an exhaustive grep confirms no consumer in `src/` or `tests/`.

## Why this is safe

- The shared patterns are **byte-identical** to every original literal (verified by grep: the raw patterns now appear *only* in the new module).
- Pure import swap — no control-flow or validation-semantics change.
- Adds `tests/validation-patterns.test.js` pinning both patterns' contract (leading-char rule, 32-char username boundary, 64-char lower-case hex), so the single source can't drift.

## Test plan

- [x] `validation-patterns.test.js` (new) — passes
- [x] `path-hash-trust-ledger.test.js`, `skills-trust.test.js` (hex64 consumers) — green
- [x] `docker-sdk-session.test.js`, `docker-byok-session.test.js` (250 tests) — green
- [x] `environment-manager.test.js` (94 tests) — green
- [x] All 5 mandatory server lints (`lint-session-opt-forwarding`, `lint-tests-state-file-path`, `lint-logger-session-scoping`, `lint-ws-index-mutations`, `lint-claude-family-explicit`) — pass
- [x] ESLint on all changed files — 0 errors

Related to #6201