### PR TITLE
test(store-core): pin web_task_error both-clients switch contract

### DIFF
--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -131,7 +131,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'user_input',
   // user_question — migrated to the shared dispatch table (#5618); now has a
   // DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
-  'web_task_error',
+  // web_task_error — now has a SWITCH_FIXTURES entry (#5619), so it leaves the
+  // pending allowlist (both clients append one identical `system` error bubble).
 ])
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1589,9 +1589,11 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
   {
     // web_task_error (#5619): both clients parse via the shared
     // `handleWebTaskError` and, on the common path, append ONE identical
-    // `system` bubble (content = the error message) to the ACTIVE session — both
-    // route by `activeSessionId`, not the wire `sessionId`. The app additionally
-    // short-circuits to a native Alert (NO bubble) ONLY when
+    // `system` bubble (content = the error message) to the ACTIVE session
+    // (`activeSessionId`). The message carries no session key of its own
+    // (its fields are taskId / message / code / boundSession*), so there is no
+    // per-session routing for the two clients to diverge on. The app
+    // additionally short-circuits to a native Alert (NO bubble) ONLY when
     // `code === 'SESSION_TOKEN_MISMATCH' && boundSessionName` is set; a plain
     // error message (no `code`/`boundSessionName`) never trips that, so both
     // clients agree — a single `expect`, no `divergent` block. `taskId` is

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1586,4 +1586,26 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       sessions: { s1: { messages: [{ id: 'resp-1', type: 'response', content: 'before error' }] } },
     },
   },
+  {
+    // web_task_error (#5619): both clients parse via the shared
+    // `handleWebTaskError` and, on the common path, append ONE identical
+    // `system` bubble (content = the error message) to the ACTIVE session — both
+    // route by `activeSessionId`, not the wire `sessionId`. The app additionally
+    // short-circuits to a native Alert (NO bubble) ONLY when
+    // `code === 'SESSION_TOKEN_MISMATCH' && boundSessionName` is set; a plain
+    // error message (no `code`/`boundSessionName`) never trips that, so both
+    // clients agree — a single `expect`, no `divergent` block. `taskId` is
+    // omitted deliberately: its presence drives a `webTasks` status update the
+    // fixture harness can't seed (init has no `webTasks` slice), and that update
+    // is a flat-state side effect OUTSIDE the asserted `messages` slice anyway.
+    name: 'web_task_error appends a system error bubble to the active session',
+    type: 'web_task_error',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'web_task_error', message: 'Web task failed: network timeout' },
+    expect: {
+      sessions: {
+        s1: { messages: [{ type: 'system', content: 'Web task failed: network timeout' }] },
+      },
+    },
+  },
 ]


### PR DESCRIPTION
## Summary
- Adds a `SWITCH_FIXTURES` entry for `web_task_error` (#5619), driving the shared transcript behaviour through **both** clients' real `handleMessage`. Both parse via the shared `handleWebTaskError` and append one identical `system` error bubble to the active session.
- The plain-error path has no per-client divergence, so a single `expect` (no `divergent` block): the app's `SESSION_TOKEN_MISMATCH` native-Alert short-circuit is gated on `code === 'SESSION_TOKEN_MISMATCH' && boundSessionName`, which a code-less message never trips. `taskId` is omitted deliberately — its presence drives a `webTasks` status update the fixture harness can't seed, and that update is a flat-state side effect outside the asserted `messages` slice.
- Removes `web_task_error` from `PENDING_CONTRACT_TYPES` now that it has a fixture. The allowlist only shrinks, and the "no stale entries" lint enforces the removal.

## Test plan
- [x] store-core full `vitest run` — 46 files / 1827 tests green (coverage-lint 4, protocol-type-coverage-lint 5, contract-fixtures 106)
- [x] dashboard `vitest run src/store/contract-switch.test.ts` — 16 green (new `web_task_error` case drives the dashboard twin)
- [x] app `jest __tests__/contract-switch.test.ts` — 16 green (new `web_task_error` case drives the app twin)
- [x] protocol `npm test` — 340 green (handler-coverage guard unaffected; `web_task_error` was already both-clients)