### PR TITLE
refactor(server): single-source control-room exec tunables

### DIFF
--- a/packages/server/src/control-room/constants.js
+++ b/packages/server/src/control-room/constants.js
@@ -1,0 +1,26 @@
+/**
+ * Shared Control Room survey/exec tunables (epic #5530).
+ *
+ * `EXEC_TIMEOUT_MS` and `DEFAULT_CONCURRENCY` were copy-defined with identical
+ * values across the control-room survey + action modules (simulators / wsl /
+ * containers / emulators / integrations / survey / runners / host-prune /
+ * skills-inventory). Every copy carried a "Kept consistent with the sibling
+ * surveys" comment — i.e. they were hand-synced, which is exactly the drift
+ * hazard a single source removes. Centralised here so one edit moves them all.
+ *
+ * NOT here: `EXEC_MAX_BUFFER`. It legitimately varies per command (8 MB where a
+ * probe emits a few JSON lines, 16 MB where a survey can emit a large `git
+ * status --porcelain` / device list), so it stays a per-module constant.
+ */
+
+/**
+ * Bound every control-room probe subprocess so a stuck daemon / wedged service
+ * manager / network blip rejects in finite time instead of hanging the survey
+ * forever — which would also pin the handler's per-client in-flight guard. Each
+ * survey already degrades a rejected probe to a null / "not available" state, so
+ * the timeout just guarantees the rejection (#5259).
+ */
+export const EXEC_TIMEOUT_MS = 20000
+
+/** Default per-target / per-repo concurrency cap for control-room surveys. */
+export const DEFAULT_CONCURRENCY = 5

--- a/packages/server/src/control-room/containers.js
+++ b/packages/server/src/control-room/containers.js
@@ -33,17 +33,10 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { getErrorMessage } from '../utils/error-message.js'
+import { EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
-/**
- * #6133: bound the `docker stats` probe so a stuck docker daemon rejects in
- * finite time instead of hanging the survey forever (which would also pin the
- * handler's per-client in-flight guard). The survey tolerates a rejected probe
- * (degrades to null stats + a note), so a timeout just guarantees it rejects.
- * Kept consistent with the sibling surveys (runners.js EXEC_TIMEOUT_MS).
- */
-export const EXEC_TIMEOUT_MS = 20000
 /** Modest output cap — one stats line per container, all small. */
 const EXEC_MAX_BUFFER = 8 * 1024 * 1024
 const EXEC_OPTS = { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }

--- a/packages/server/src/control-room/emulators.js
+++ b/packages/server/src/control-room/emulators.js
@@ -24,11 +24,10 @@ import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 import net from 'net'
 import { getErrorMessage } from '../utils/error-message.js'
+import { EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
-/** Bound each adb/emulator probe so a stuck daemon rejects in finite time. */
-export const EXEC_TIMEOUT_MS = 20000
 const EXEC_MAX_BUFFER = 16 * 1024 * 1024
 const EXEC_OPTS = { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }
 

--- a/packages/server/src/control-room/host-prune.js
+++ b/packages/server/src/control-room/host-prune.js
@@ -37,11 +37,10 @@ import { parseByteSize } from './containers.js'
 import { listSnapshots } from '../snapshots-store.js'
 import { CHROXY_MANAGED_LABEL } from '../environments/backends/docker.js'
 import { getErrorMessage } from '../utils/error-message.js'
+import { EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
-/** Bound the docker probes so a stuck daemon rejects in finite time. */
-export const EXEC_TIMEOUT_MS = 20000
 const EXEC_MAX_BUFFER = 8 * 1024 * 1024
 const EXEC_OPTS = { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }
 

--- a/packages/server/src/control-room/integrations.js
+++ b/packages/server/src/control-room/integrations.js
@@ -53,19 +53,10 @@ import { promisify } from 'util'
 import { readFile, stat } from 'fs/promises'
 import { join } from 'path'
 import { parseGithubOwnerRepo } from './survey.js'
+import { DEFAULT_CONCURRENCY, EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
-/** Per-repo concurrency cap for the survey (matches the sibling surveys). */
-export const DEFAULT_CONCURRENCY = 5
-
-/**
- * Bound every subprocess so a stuck `which`/`repo-memory` rejects in finite
- * time instead of hanging the survey forever — which would also pin the
- * handler's per-client in-flight guard. Kept consistent with survey.js /
- * runners.js EXEC_TIMEOUT_MS.
- */
-export const EXEC_TIMEOUT_MS = 20000
 /** Output cap for the report subprocess (report JSON is small). */
 const EXEC_MAX_BUFFER = 8 * 1024 * 1024
 /** Shared exec options for every probe. */

--- a/packages/server/src/control-room/runners.js
+++ b/packages/server/src/control-room/runners.js
@@ -37,24 +37,13 @@ import { promisify } from 'util'
 import { readFile, readdir } from 'fs/promises'
 import { join, basename } from 'path'
 import { homedir } from 'os'
+import { DEFAULT_CONCURRENCY, EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
 /** Default runner-install root scanned for `.runner` installs. */
 export const DEFAULT_RUNNER_ROOT = join(homedir(), 'github-runners')
 
-/** Default per-target concurrency cap for the survey. */
-export const DEFAULT_CONCURRENCY = 5
-
-/**
- * #5259: bound every probe subprocess so a stuck `gh`/`launchctl`/`systemctl`
- * (network blip, wedged service manager) rejects in finite time instead of
- * hanging the survey forever — which would also pin the handler's per-client
- * in-flight guard. The survey already tolerates a rejected probe (degrades to
- * not-running / null GitHub view), so a timeout just guarantees it rejects.
- * Kept consistent with the host survey (survey.js EXEC_TIMEOUT_MS).
- */
-export const EXEC_TIMEOUT_MS = 20000
 /** Modest output cap for probe subprocesses (runner JSON is small). */
 const EXEC_MAX_BUFFER = 8 * 1024 * 1024
 /** Shared exec options for every probe. */

--- a/packages/server/src/control-room/simulators.js
+++ b/packages/server/src/control-room/simulators.js
@@ -21,11 +21,10 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import net from 'net'
 import { getErrorMessage } from '../utils/error-message.js'
+import { EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
-/** Bound the simctl probe so a stuck Simulator service rejects in finite time. */
-export const EXEC_TIMEOUT_MS = 20000
 const EXEC_MAX_BUFFER = 16 * 1024 * 1024
 const EXEC_OPTS = { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }
 

--- a/packages/server/src/control-room/skills-inventory.js
+++ b/packages/server/src/control-room/skills-inventory.js
@@ -46,9 +46,7 @@
 import { readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { loadActiveSkills, findRepoSkillsDir, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
-
-/** Per-repo concurrency cap (matches the sibling surveys). */
-export const DEFAULT_CONCURRENCY = 5
+import { DEFAULT_CONCURRENCY } from './constants.js'
 
 /**
  * Parse a `skills.lock` file into a name → { hash, installed } map. The lock

--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -33,6 +33,7 @@ import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { resolveRepoSet } from './repo-set.js'
 import { getErrorMessage } from '../utils/error-message.js'
+import { DEFAULT_CONCURRENCY, EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -45,23 +46,11 @@ const execFileAsync = promisify(execFile)
 const EXEC_MAX_BUFFER = 16 * 1024 * 1024
 
 /**
- * #5259: bound every git/gh probe so a stuck subprocess (network blip on `gh`,
- * a wedged git) rejects in finite time instead of hanging the survey forever
- * (which would also pin the handler's per-client in-flight guard). tryExec
- * already degrades a rejected probe to null, so the timeout just guarantees the
- * rejection. Kept consistent with the runner survey (runners.js EXEC_TIMEOUT_MS).
- */
-const EXEC_TIMEOUT_MS = 20000
-
-/**
  * Cap for `gh pr list` (#5240). `gh pr list` defaults to 30, silently capping
  * the open-PR count AND the CI/review rollup. 200 covers even bot-heavy repos;
  * a repo past it is undercounted, but far less often than at the 30 default.
  */
 const GH_PR_LIST_LIMIT = 200
-
-/** Default concurrency cap for per-repo surveys. */
-export const DEFAULT_CONCURRENCY = 5
 
 /**
  * Default verdict thresholds. All durations are in milliseconds.

--- a/packages/server/src/control-room/wsl.js
+++ b/packages/server/src/control-room/wsl.js
@@ -22,11 +22,10 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { getErrorMessage } from '../utils/error-message.js'
+import { EXEC_TIMEOUT_MS } from './constants.js'
 
 const execFileAsync = promisify(execFile)
 
-/** Bound each wsl.exe probe so a stuck distro/service rejects in finite time. */
-export const EXEC_TIMEOUT_MS = 20000
 const EXEC_MAX_BUFFER = 16 * 1024 * 1024
 const EXEC_OPTS = { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }
 // The survey reads `wsl.exe -l -v`, which emits UTF-16LE. execFile's default

--- a/packages/server/tests/control-room-runners.test.js
+++ b/packages/server/tests/control-room-runners.test.js
@@ -33,8 +33,8 @@ import {
   ghRunnersApiPath,
   parseGhRunners,
   classifyRunner,
-  EXEC_TIMEOUT_MS,
 } from '../src/control-room/runners.js'
+import { EXEC_TIMEOUT_MS } from '../src/control-room/constants.js'
 
 // A Dirent-like for the injected readdir seam.
 const dirent = (name, isDir = true) => ({ name, isDirectory: () => isDir })


### PR DESCRIPTION
## Summary

`EXEC_TIMEOUT_MS` (20s probe bound) and `DEFAULT_CONCURRENCY` (5) were copy-defined with identical values across **nine** control-room survey/action modules — `simulators`, `wsl`, `containers`, `emulators`, `integrations`, `survey`, `runners`, `host-prune`, `skills-inventory`. Every copy carried a "kept consistent with the sibling surveys" comment, i.e. they were **hand-synced** — exactly the drift hazard a single source removes.

- New `packages/server/src/control-room/constants.js` exports both, with the rationale comments consolidated.
- All nine modules now `import` from it; the duplicated local `const`/`export const` defs are gone.
- The one test that asserted on `EXEC_TIMEOUT_MS` (`control-room-runners.test.js`) is repointed to `constants.js`.

## Not in scope (deliberate)

`EXEC_MAX_BUFFER` stays a **per-module** constant: it legitimately varies (8 MB for small JSON probes, 16 MB for large `git status --porcelain` / device-list surveys). Collapsing it would be a behavior change, so it's left alone.

## Test plan

- [x] `node --test` control-room suites green (runners/survey/integrations: 163 pass; simulators/wsl/containers/emulators/host-prune/handlers: 242 pass)
- [x] `skills-inventory.js` smoke-loads (no duplicate-declaration crash)
- [x] Server Lint: `lint-tests-state-file-path.sh` + `lint-session-opt-forwarding.sh` both exit 0
- [x] ESLint clean on all changed files (0 errors)

Related to epic #5530 (control room) / #6201 (DRY sweep).