### PR TITLE
fix(dashboard): drop never-sent queued bubbles on Stop/Cancel

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2825,6 +2825,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const sid = sessionId ?? activeSessionId;
     const payload: Record<string, unknown> = { type: 'interrupt' };
     if (sid) payload.sessionId = sid;
+    // #5938 — Stop clears the outgoing queue too (server policy #5936: a
+    // deliberate interrupt cancels pending follow-ups rather than auto-firing
+    // them). Drop the queued bubbles + entries optimistically so they don't
+    // linger as phantom "sent" messages (the bubble id IS the clientMessageId);
+    // the server's per-item message_dequeued{interrupted} then no-ops against
+    // the cleared queue.
+    if (sid && get().sessionStates[sid]) {
+      const queued = get().sessionStates[sid].queuedMessages ?? [];
+      if (queued.length > 0) {
+        const queuedIds = new Set(
+          queued.map((q) => q.clientMessageId).filter((id): id is string => !!id),
+        );
+        updateSession(sid, (ss) => ({
+          queuedMessages: EMPTY_QUEUED_MESSAGES,
+          messages: ss.messages.filter((m) => !queuedIds.has(m.id)),
+        }));
+      }
+    }
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);
       return 'sent';
@@ -2881,6 +2899,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (sid && get().sessionStates[sid]) {
       updateSession(sid, (ss) => ({
         queuedMessages: removeQueuedMessage(ss.queuedMessages, clientMessageId),
+        // #5938 — also drop the optimistic bubble (its id IS the clientMessageId);
+        // a cancelled message was never sent, so it must not linger as a phantom
+        // "sent" bubble once the queued badge clears.
+        messages: ss.messages.filter((m) => m.id !== clientMessageId),
       }));
     }
     wsSend(socket, payload);

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2831,8 +2831,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // linger as phantom "sent" messages (the bubble id IS the clientMessageId);
     // the server's per-item message_dequeued{interrupted} then no-ops against
     // the cleared queue.
-    if (sid && get().sessionStates[sid]) {
-      const queued = get().sessionStates[sid].queuedMessages ?? [];
+    const interruptState = sid ? get().sessionStates[sid] : undefined;
+    if (sid && interruptState) {
+      const queued = interruptState.queuedMessages ?? [];
       if (queued.length > 0) {
         const queuedIds = new Set(
           queued.map((q) => q.clientMessageId).filter((id): id is string => !!id),

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -557,6 +557,104 @@ describe('useConnectionStore', () => {
       // Local entry untouched — no optimistic removal without a real send.
       expect(useConnectionStore.getState().sessionStates.s1!.queuedMessages).toHaveLength(1);
     });
+
+    it('#5938: sendCancelQueued also drops the never-sent optimistic bubble (not just the badge)', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            // The bubble id IS the clientMessageId for a queued send.
+            messages: [
+              { id: 'uin-1', type: 'user_input', content: 'a', timestamp: 1 },
+              { id: 'uin-2', type: 'user_input', content: 'b', timestamp: 2 },
+            ],
+            queuedMessages: [
+              { clientMessageId: 'uin-1', text: 'a', queuedAt: 1, status: 'confirmed' },
+              { clientMessageId: 'uin-2', text: 'b', queuedAt: 2, status: 'confirmed' },
+            ],
+          },
+        },
+      });
+
+      useConnectionStore.getState().sendCancelQueued('uin-1');
+
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      // Badge cleared AND the phantom bubble removed — only uin-2 lingers.
+      expect(ss.queuedMessages.map(m => m.clientMessageId)).toEqual(['uin-2']);
+      expect(ss.messages.map(m => m.id)).toEqual(['uin-2']);
+    });
+
+    it('#5938: sendInterrupt clears the queue and drops every never-sent queued bubble', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            streamingMessageId: 'm-live',
+            messages: [
+              // A bubble belonging to the live (already-sent) turn must survive.
+              { id: 'uin-live', type: 'user_input', content: 'live', timestamp: 1 },
+              { id: 'uin-q1', type: 'user_input', content: 'q1', timestamp: 2 },
+              { id: 'uin-q2', type: 'user_input', content: 'q2', timestamp: 3 },
+            ],
+            queuedMessages: [
+              { clientMessageId: 'uin-q1', text: 'q1', queuedAt: 2, status: 'confirmed' },
+              { clientMessageId: 'uin-q2', text: 'q2', queuedAt: 3, status: 'confirmed' },
+            ],
+          },
+        },
+      });
+
+      const result = useConnectionStore.getState().sendInterrupt();
+
+      expect(result).toBe('sent');
+      const payload = JSON.parse(send.mock.calls[0]![0] as string);
+      expect(payload.type).toBe('interrupt');
+      const ss = useConnectionStore.getState().sessionStates.s1!;
+      // Queue emptied; both queued bubbles dropped; the live-turn bubble stays.
+      expect(ss.queuedMessages).toHaveLength(0);
+      expect(ss.messages.map(m => m.id)).toEqual(['uin-live']);
+    });
+
+    it('#5938: sendInterrupt with an explicit sessionId clears THAT session queue + bubbles', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's-active',
+        sessionStates: {
+          's-active': {
+            ...createEmptySessionState(),
+            messages: [{ id: 'uin-a', type: 'user_input', content: 'a', timestamp: 1 }],
+            queuedMessages: [{ clientMessageId: 'uin-a', text: 'a', queuedAt: 1, status: 'confirmed' }],
+          },
+          's-other': {
+            ...createEmptySessionState(),
+            messages: [{ id: 'uin-b', type: 'user_input', content: 'b', timestamp: 1 }],
+            queuedMessages: [{ clientMessageId: 'uin-b', text: 'b', queuedAt: 1, status: 'confirmed' }],
+          },
+        },
+      });
+
+      useConnectionStore.getState().sendInterrupt('s-other');
+
+      const states = useConnectionStore.getState().sessionStates;
+      // The target session is cleared; the ACTIVE session is untouched.
+      expect(states['s-other']!.queuedMessages).toHaveLength(0);
+      expect(states['s-other']!.messages).toHaveLength(0);
+      expect(states['s-active']!.queuedMessages.map(m => m.clientMessageId)).toEqual(['uin-a']);
+      expect(states['s-active']!.messages.map(m => m.id)).toEqual(['uin-a']);
+    });
   });
 
   it('#5710: destroySession sends force:true only when forced', async () => {


### PR DESCRIPTION
Closes #6284
Part of #6278

## What
When a user queues a follow-up while the turn is busy then hits **Stop** (or **Cancel** on a single queued item), the dashboard cleared the "Queued" badge but left the never-sent message in the transcript as an ordinary user bubble.

- `sendInterrupt` only sent `{type:'interrupt'}` and never touched `messages`.
- `sendCancelQueued` only removed the `queuedMessages` entry, not the optimistic bubble.

This ports the mobile app fix (#5938) to the dashboard store:

- **`sendInterrupt`** — snapshot the active/target session's queued `clientMessageId`s into a Set and clear `queuedMessages` while filtering those bubbles out of `messages`. Bubbles belonging to the already-sent live turn are kept.
- **`sendCancelQueued`** — also drop the single optimistic bubble (its `id` IS the `clientMessageId`).

The server's per-item `message_dequeued{interrupted|cancelled}` then no-ops idempotently against the already-cleared queue (the dispatch table only patches `queuedMessages`).

## Why
Per server policy #5936, a deliberate interrupt cancels pending follow-ups rather than auto-firing them — so a message the user never actually sent must not linger as a phantom "sent" bubble. The mobile app already does this; the dashboard never adopted it.

## Testing
Added dashboard store tests (`store.test.ts`, in the `#5939 queued send-while-busy` block) covering: cancel drops the single bubble; interrupt clears the queue and drops every queued bubble while preserving the live-turn bubble; and explicit-sessionId interrupt targets the right session. CI runs typecheck + tests — this worktree has no node_modules, so I could not run them locally.