### PR TITLE
fix(app,dashboard): guard wsSend against socket.send throwing on a closing socket

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -389,6 +389,29 @@ describe('message queue', () => {
     expect(result).toBe('queued');
   });
 
+  // #6283: the socket can flip OPEN → CLOSING between the readyState check and
+  // the synchronous send over a flaky tunnel, so socket.send throws
+  // InvalidStateError. wsSend swallows the throw and returns false; sendInput
+  // must fall through to the offline queue so the frame retries on reconnect
+  // instead of leaving a permanently 'sent'-looking bubble.
+  it('re-queues input when an OPEN socket.send throws mid-turn (#6283)', () => {
+    const throwingSocket = {
+      readyState: 1,
+      send: () => {
+        // Mirrors the browser's InvalidStateError on a CLOSING socket.
+        throw new Error('InvalidStateError: socket is not open');
+      },
+    } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: throwingSocket });
+
+    const result = useConnectionStore.getState().sendInput('hello');
+    expect(result).toBe('queued');
+
+    // beforeEach does not reset `socket`; clear it so the throwing mock doesn't
+    // bleed into later tests that assume a disconnected socket.
+    useConnectionStore.setState({ socket: null });
+  });
+
   it('REFUSES permission_response when socket is not connected (#5699 — never queued)', () => {
     // The server expires the pending request on disconnect, so a queued
     // response would drain into the void on reconnect while the prompt could

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -401,15 +401,14 @@ describe('message queue', () => {
         // Mirrors the browser's InvalidStateError on a CLOSING socket.
         throw new Error('InvalidStateError: socket is not open');
       },
+      // No-op close so the suite's beforeEach disconnect() can safely tear this
+      // mock down without throwing — no manual socket cleanup needed.
+      close: () => {},
     } as unknown as WebSocket;
     useConnectionStore.setState({ socket: throwingSocket });
 
     const result = useConnectionStore.getState().sendInput('hello');
     expect(result).toBe('queued');
-
-    // beforeEach does not reset `socket`; clear it so the throwing mock doesn't
-    // bleed into later tests that assume a disconnected socket.
-    useConnectionStore.setState({ socket: null });
   });
 
   it('REFUSES permission_response when socket is not connected (#5699 — never queued)', () => {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1729,8 +1729,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     let result: 'sent' | 'queued' | false;
     if (socket && socket.readyState === WebSocket.OPEN) {
       hapticLight();
-      wsSend(socket, payload);
-      result = 'sent';
+      // #6283: socket.readyState can flip OPEN → CLOSING before this synchronous
+      // send over a flaky tunnel, so wsSend can throw and return false. Fall
+      // through to the offline queue so the frame retries on reconnect instead
+      // of leaving a permanently 'sent'-looking bubble that never reached the
+      // server.
+      result = wsSend(socket, payload) ? 'sent' : enqueueMessage('input', payload);
     } else {
       result = enqueueMessage('input', payload);
     }

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -417,14 +417,30 @@ function mapProviderList(rawProviders: unknown[]): ProviderInfo[] {
 /**
  * Send a JSON message over WebSocket, encrypting if E2E encryption is active.
  * Use this instead of raw `socket.send(JSON.stringify(...))`.
+ *
+ * Returns `true` when the frame was handed to `socket.send` without throwing,
+ * `false` when the send threw. #6283: the caller checks `readyState === OPEN`,
+ * but the socket can flip to CLOSING before this synchronous send and throw
+ * `InvalidStateError` — a flaky-tunnel TOCTOU window. Swallowing the throw and
+ * signalling failure lets delivery-critical callers (`sendInput`) fall back to
+ * the offline queue instead of leaving a permanently 'sent'-looking bubble that
+ * never reached the server. Mirrors the server-side sender (#5721, see
+ * `packages/server/src/ws-client-sender.js`: catch → log → return false).
+ * Most callers ignore the result (a closed socket was already a silent no-op).
  */
-export function wsSend(socket: WebSocket, payload: Record<string, unknown>): void {
-  if (_ctx.encryptionState) {
-    const envelope = encrypt(JSON.stringify(payload), _ctx.encryptionState.sharedKey, _ctx.encryptionState.sendNonce, DIRECTION_CLIENT);
-    _ctx.encryptionState.sendNonce++;
-    socket.send(JSON.stringify(envelope));
-  } else {
-    socket.send(JSON.stringify(payload));
+export function wsSend(socket: WebSocket, payload: Record<string, unknown>): boolean {
+  try {
+    if (_ctx.encryptionState) {
+      const envelope = encrypt(JSON.stringify(payload), _ctx.encryptionState.sharedKey, _ctx.encryptionState.sendNonce, DIRECTION_CLIENT);
+      _ctx.encryptionState.sendNonce++;
+      socket.send(JSON.stringify(envelope));
+    } else {
+      socket.send(JSON.stringify(payload));
+    }
+    return true;
+  } catch (err) {
+    console.warn('[wsSend] socket.send threw — frame not delivered:', err);
+    return false;
   }
 }
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -429,19 +429,32 @@ function mapProviderList(rawProviders: unknown[]): ProviderInfo[] {
  * Most callers ignore the result (a closed socket was already a silent no-op).
  */
 export function wsSend(socket: WebSocket, payload: Record<string, unknown>): boolean {
+  // Serialize/encrypt OUTSIDE the try so a JSON/crypto bug still throws loudly
+  // (it's a real defect, not a transient send failure) rather than being
+  // swallowed, logged as a "send threw", and re-queued forever. The nonce is
+  // consumed for THIS frame here but only advanced after a successful send. (#6283)
+  const data = _ctx.encryptionState
+    ? JSON.stringify(
+        encrypt(
+          JSON.stringify(payload),
+          _ctx.encryptionState.sharedKey,
+          _ctx.encryptionState.sendNonce,
+          DIRECTION_CLIENT,
+        ),
+      )
+    : JSON.stringify(payload);
   try {
-    if (_ctx.encryptionState) {
-      const envelope = encrypt(JSON.stringify(payload), _ctx.encryptionState.sharedKey, _ctx.encryptionState.sendNonce, DIRECTION_CLIENT);
-      _ctx.encryptionState.sendNonce++;
-      socket.send(JSON.stringify(envelope));
-    } else {
-      socket.send(JSON.stringify(payload));
-    }
-    return true;
+    socket.send(data);
   } catch (err) {
+    // #6283 — the socket flipped to CLOSING after the readyState check (flaky
+    // tunnel TOCTOU). Don't advance sendNonce: the frame never went out, so the
+    // next send must reuse this nonce (reconnect forces a fresh key exchange,
+    // but a same-socket retry must not desync).
     console.warn('[wsSend] socket.send threw — frame not delivered:', err);
     return false;
   }
+  if (_ctx.encryptionState) _ctx.encryptionState.sendNonce++;
+  return true;
 }
 
 /**

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2788,8 +2788,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     let result: 'sent' | 'queued' | false;
     if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, payload);
-      result = 'sent';
+      // #6283: socket.readyState can flip OPEN → CLOSING before this synchronous
+      // send over a flaky tunnel, so wsSend can throw and return false. Fall
+      // through to the offline queue so the frame retries on reconnect instead
+      // of leaving a permanently 'sent'-looking bubble that never reached the
+      // server.
+      result = wsSend(socket, payload) ? 'sent' : enqueueMessage('input', payload);
     } else {
       result = enqueueMessage('input', payload);
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -461,14 +461,30 @@ let _serverWillBootstrap = false;
 /**
  * Send a JSON message over WebSocket, encrypting if E2E encryption is active.
  * Use this instead of raw `socket.send(JSON.stringify(...))`.
+ *
+ * Returns `true` when the frame was handed to `socket.send` without throwing,
+ * `false` when the send threw. #6283: the caller checks `readyState === OPEN`,
+ * but the socket can flip to CLOSING before this synchronous send and throw
+ * `InvalidStateError` — a flaky-tunnel TOCTOU window. Swallowing the throw and
+ * signalling failure lets delivery-critical callers (`sendInput`) fall back to
+ * the offline queue instead of leaving a permanently 'sent'-looking bubble that
+ * never reached the server. Mirrors the server-side sender (#5721, see
+ * `packages/server/src/ws-client-sender.js`: catch → log → return false).
+ * Most callers ignore the result (a closed socket was already a silent no-op).
  */
-export function wsSend(socket: WebSocket, payload: Record<string, unknown>): void {
-  if (_encryptionState) {
-    const envelope = encrypt(JSON.stringify(payload), _encryptionState.sharedKey, _encryptionState.sendNonce, DIRECTION_CLIENT);
-    _encryptionState.sendNonce++;
-    socket.send(JSON.stringify(envelope));
-  } else {
-    socket.send(JSON.stringify(payload));
+export function wsSend(socket: WebSocket, payload: Record<string, unknown>): boolean {
+  try {
+    if (_encryptionState) {
+      const envelope = encrypt(JSON.stringify(payload), _encryptionState.sharedKey, _encryptionState.sendNonce, DIRECTION_CLIENT);
+      _encryptionState.sendNonce++;
+      socket.send(JSON.stringify(envelope));
+    } else {
+      socket.send(JSON.stringify(payload));
+    }
+    return true;
+  } catch (err) {
+    console.warn('[wsSend] socket.send threw — frame not delivered:', err);
+    return false;
   }
 }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -473,19 +473,32 @@ let _serverWillBootstrap = false;
  * Most callers ignore the result (a closed socket was already a silent no-op).
  */
 export function wsSend(socket: WebSocket, payload: Record<string, unknown>): boolean {
+  // Serialize/encrypt OUTSIDE the try so a JSON/crypto bug still throws loudly
+  // (it's a real defect, not a transient send failure) rather than being
+  // swallowed, logged as a "send threw", and re-queued forever. The nonce is
+  // consumed for THIS frame here but only advanced after a successful send. (#6283)
+  const data = _encryptionState
+    ? JSON.stringify(
+        encrypt(
+          JSON.stringify(payload),
+          _encryptionState.sharedKey,
+          _encryptionState.sendNonce,
+          DIRECTION_CLIENT,
+        ),
+      )
+    : JSON.stringify(payload);
   try {
-    if (_encryptionState) {
-      const envelope = encrypt(JSON.stringify(payload), _encryptionState.sharedKey, _encryptionState.sendNonce, DIRECTION_CLIENT);
-      _encryptionState.sendNonce++;
-      socket.send(JSON.stringify(envelope));
-    } else {
-      socket.send(JSON.stringify(payload));
-    }
-    return true;
+    socket.send(data);
   } catch (err) {
+    // #6283 — the socket flipped to CLOSING after the readyState check (flaky
+    // tunnel TOCTOU). Don't advance sendNonce: the frame never went out, so the
+    // next send must reuse this nonce (reconnect forces a fresh key exchange,
+    // but a same-socket retry must not desync).
     console.warn('[wsSend] socket.send threw — frame not delivered:', err);
     return false;
   }
+  if (_encryptionState) _encryptionState.sendNonce++;
+  return true;
 }
 
 // #3671: edge-trigger memo for the dashboard's client_visible send. Initialised


### PR DESCRIPTION
Closes #6283
Part of #6278

## What
`wsSend` (in both `packages/app/src/store/message-handler.ts` and `packages/dashboard/src/store/message-handler.ts`) called `socket.send()` unguarded. Now both copies wrap the send in try/catch — on throw they log a warning and return `false` (return type widened `void` → `boolean`). The delivery-critical caller `sendInput` (app + dashboard `connection.ts`) treats a `false` send by falling through to the existing `enqueueMessage('input', payload)` offline-queue path.

## Why
There is a TOCTOU window: the caller checks `socket.readyState === WebSocket.OPEN`, but over a flaky Cloudflare tunnel the socket can flip to `CLOSING` before the synchronous `socket.send()`, throwing `InvalidStateError`. That threw uncaught — the optimistic user bubble stayed looking 'sent' while nothing reached the server and no error surfaced. Re-queuing on a failed send means the frame retries on reconnect instead of vanishing.

This mirrors the established server-side pattern in `packages/server/src/ws-client-sender.js` (#5721: catch → log → return false; callers gate on the boolean).

The widened return type is backward-compatible: every other `wsSend` caller ignores the result (a closed socket was already a silent no-op), so only `sendInput` changes behavior.

## Testing
Added an app store unit test (`packages/app/src/__tests__/store/connection.test.ts`): an OPEN socket whose `send` throws mid-turn causes `sendInput` to return `'queued'` (the frame retries on reconnect) rather than a phantom 'sent'. CI runs typecheck + the full app/dashboard test suites — I could not run them locally (worktree has no `node_modules`).