### PR TITLE
fix(app): ConnectionPhase FSM rejects illegal transitions instead of failing open

### DIFF
--- a/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
+++ b/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
@@ -139,7 +139,7 @@ describe('useConnectionLifecycleStore', () => {
       expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connecting');
     });
 
-    it('warns on illegal transition and still applies the phase', () => {
+    it('#6286 — warns on an illegal transition and REJECTS it (phase unchanged)', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const store = useConnectionLifecycleStore.getState();
       // disconnected → connected is not a valid transition
@@ -147,12 +147,12 @@ describe('useConnectionLifecycleStore', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('[ConnectionFSM] Illegal transition: disconnected → connected')
       );
-      // Phase is still applied so production never silently breaks
-      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connected');
+      // The FSM now fails CLOSED: the phase is left unchanged.
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('disconnected');
       warnSpy.mockRestore();
     });
 
-    it('warns on illegal transition: connected → connecting (must go via disconnected or reconnecting first)', () => {
+    it('#6286 — rejects illegal transition: connected → connecting (phase unchanged)', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const store = useConnectionLifecycleStore.getState();
       store.transitionPhase('connecting');
@@ -161,6 +161,46 @@ describe('useConnectionLifecycleStore', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('[ConnectionFSM] Illegal transition: connected → connecting')
       );
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connected');
+      warnSpy.mockRestore();
+    });
+
+    it('#6286 — terminal server_down stays put under an illegal transition (e.g. paired error→close)', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const store = useConnectionLifecycleStore.getState();
+      store.transitionPhase('connecting');
+      store.transitionPhase('server_down');
+      // server_down → reconnecting is illegal (the clobber #5980 cured) — reject it.
+      store.transitionPhase('reconnecting');
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[ConnectionFSM] Illegal transition: server_down → reconnecting')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('#6286 — { force: true } applies an otherwise-illegal transition (the one legitimate forced exit)', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const store = useConnectionLifecycleStore.getState();
+      store.transitionPhase('connecting');
+      store.transitionPhase('server_down');
+      // server_down → reconnecting is illegal, but force pushes it through.
+      store.transitionPhase('reconnecting', { force: true });
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('reconnecting');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('force'));
+      warnSpy.mockRestore();
+    });
+
+    it('#6286 — { force: true } does not warn on an already-legal transition', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const store = useConnectionLifecycleStore.getState();
+      store.transitionPhase('connecting');
+      store.transitionPhase('server_down');
+      // server_down → connecting is legal (retryConnection's real exit); force is a
+      // no-op on the validation but must still apply cleanly with no warning.
+      store.transitionPhase('connecting', { force: true });
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connecting');
+      expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });
 

--- a/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
+++ b/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
@@ -181,14 +181,18 @@ describe('useConnectionLifecycleStore', () => {
 
     it('#6286 — { force: true } applies an otherwise-illegal transition (the one legitimate forced exit)', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
       const store = useConnectionLifecycleStore.getState();
       store.transitionPhase('connecting');
       store.transitionPhase('server_down');
       // server_down → reconnecting is illegal, but force pushes it through.
       store.transitionPhase('reconnecting', { force: true });
       expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('reconnecting');
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('force'));
+      // A forced (intentional) exit logs informationally, NOT as a violation warning.
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Forced transition'));
+      expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
+      logSpy.mockRestore();
     });
 
     it('#6286 — { force: true } does not warn on an already-legal transition', () => {
@@ -202,6 +206,28 @@ describe('useConnectionLifecycleStore', () => {
       expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connecting');
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
+    });
+
+    it('#6286 — allows disconnected → reconnecting (app-resume / network-change re-dial)', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const store = useConnectionLifecycleStore.getState();
+      // connect() computes 'reconnecting' (not 'connecting') when re-dialing a
+      // previously-connected URL whose lastConnectedUrl survived a non-user
+      // drop. From a 'disconnected' ConnectScreen that edge MUST be legal, or a
+      // live authenticated socket wedges (the regression caught reviewing #6286).
+      store.transitionPhase('reconnecting');
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('reconnecting');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('#6286 — the resume re-dial sequence disconnected → reconnecting → connected does not wedge', () => {
+      const store = useConnectionLifecycleStore.getState();
+      // Reproduces the app-resume path end to end: a re-dial from the
+      // ConnectScreen enters the reconnect ladder and auth_ok completes it.
+      store.transitionPhase('reconnecting');
+      store.transitionPhase('connected');
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connected');
     });
 
     it('allows connecting → reconnecting (retry escalation)', () => {
@@ -278,11 +304,14 @@ describe('useConnectionLifecycleStore', () => {
 
     it('setConnectionPhase delegates to transitionPhase (validates)', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      // Illegal path via the public setConnectionPhase API
-      useConnectionLifecycleStore.getState().setConnectionPhase('reconnecting');
+      // Illegal path via the public setConnectionPhase API. From the initial
+      // 'disconnected', → 'connected' is illegal (the legal exits are
+      // 'connecting' and 'reconnecting'), so it must warn and be rejected.
+      useConnectionLifecycleStore.getState().setConnectionPhase('connected');
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[ConnectionFSM] Illegal transition: disconnected → reconnecting')
+        expect.stringContaining('[ConnectionFSM] Illegal transition: disconnected → connected')
       );
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('disconnected');
       warnSpy.mockRestore();
     });
   });

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -171,8 +171,9 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
   it('keeps server_down sticky against the paired onerror/onclose of the same drop', async () => {
     // Regression: RN fires error → close (or close → error) for ONE transport
     // drop. The give-up sets server_down on the first event; the paired second
-    // event must NOT clobber it back to reconnecting/disconnected (transitionPhase
-    // only warns on the illegal transition — it still applies it).
+    // event must NOT clobber it back to reconnecting/disconnected. Two layers
+    // hold the line: the handlers' early-return on server_down, and (since #6286)
+    // the FSM rejecting the illegal exit instead of applying it.
     const ws = installMockWebSocket();
     await openConnectedSocket(ws);
     const socket = ws.instances[ws.instances.length - 1];

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -983,6 +983,14 @@ describe('WS message handler (direct)', () => {
   afterEach(() => _testMessageHandler.clearContext());
 
   describe('auth_ok', () => {
+    // auth_ok only ever arrives over an open socket — i.e. after connect() has
+    // moved the FSM to 'connecting'/'reconnecting'. Seed that realistic phase so
+    // the legal 'connecting → connected' edge applies (the FSM now rejects the
+    // unrealistic 'disconnected → connected' shortcut). (#6286)
+    beforeEach(() => {
+      useConnectionLifecycleStore.setState({ connectionPhase: 'connecting' });
+    });
+
     it('parses connectedClients with isSelf detection via clientId', () => {
       _testMessageHandler.handle({
         type: 'auth_ok',

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -12,10 +12,12 @@ import type { ConnectionPhase, SavedConnection } from './types';
  * Finite state machine: maps each phase to the set of phases it may
  * legally transition into.  Any transition not listed here is invalid and
  * is REJECTED — `transitionPhase` warns and leaves `connectionPhase`
- * unchanged (#6286). The single legitimate forced exit (leaving the
- * terminal `server_down` on a user-initiated retry) opts in via
- * `transitionPhase(to, { force: true })`; nothing else may leave a
- * terminal phase.
+ * unchanged (#6286). `server_down` is the one terminal phase; it is left
+ * only via its two declared legal edges — `connecting` (a user-initiated
+ * retry, see `retryConnection`) or `disconnected` (an explicit disconnect).
+ * `transitionPhase(to, { force: true })` is a deliberately-flagged escape
+ * hatch that applies an otherwise-illegal transition; it is currently used
+ * only by `retryConnection` and must stay confined to audited call sites.
  *
  * Notes on non-obvious entries:
  *  - connecting → server_restarting: health check returns "restarting" during the

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -11,8 +11,11 @@ import type { ConnectionPhase, SavedConnection } from './types';
 /**
  * Finite state machine: maps each phase to the set of phases it may
  * legally transition into.  Any transition not listed here is invalid and
- * will be logged as a warning (but still applied so production never
- * silently breaks).
+ * is REJECTED — `transitionPhase` warns and leaves `connectionPhase`
+ * unchanged (#6286). The single legitimate forced exit (leaving the
+ * terminal `server_down` on a user-initiated retry) opts in via
+ * `transitionPhase(to, { force: true })`; nothing else may leave a
+ * terminal phase.
  *
  * Notes on non-obvious entries:
  *  - connecting → server_restarting: health check returns "restarting" during the
@@ -124,7 +127,7 @@ interface ConnectionLifecycleState {
 
   // Actions
   setConnectionPhase: (phase: ConnectionPhase) => void;
-  transitionPhase: (to: ConnectionPhase) => void;
+  transitionPhase: (to: ConnectionPhase, opts?: { force?: boolean }) => void;
   setConnectionDetails: (url: string, token: string) => void;
   setServerInfo: (info: ServerInfo) => void;
   setConnectionQuality: (latencyMs: number | null, quality: 'good' | 'fair' | 'poor' | null) => void;
@@ -164,14 +167,22 @@ const initialState = {
 export const useConnectionLifecycleStore = create<ConnectionLifecycleState>((set, get) => ({
   ...initialState,
 
-  transitionPhase: (to) => {
+  transitionPhase: (to, opts) => {
     const from = get().connectionPhase;
     const allowed = VALID_TRANSITIONS[from];
     if (!allowed.includes(to)) {
+      // #6286 — ENFORCE: an illegal transition is rejected, not applied.
+      // Previously the FSM warned then mutated unconditionally ("fail open"),
+      // so the paired error→close events of one transport drop could clobber
+      // the terminal `server_down` phase back to the reconnect spinner (#5980).
+      // The ONE legitimate forced exit (user-initiated retry leaving
+      // server_down) passes `{ force: true }`; everything else stays put.
       console.warn(
         `[ConnectionFSM] Illegal transition: ${from} → ${to}. ` +
-          `Allowed from ${from}: [${allowed.join(', ')}]`
+          `Allowed from ${from}: [${allowed.join(', ')}]` +
+          (opts?.force ? ' — applying anyway (force)' : ' — rejected')
       );
+      if (!opts?.force) return;
     }
     set({ connectionPhase: to });
   },

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -26,7 +26,13 @@ import type { ConnectionPhase, SavedConnection } from './types';
  *    allowed so that recursive retry calls do not generate spurious warnings.
  */
 const VALID_TRANSITIONS: Record<ConnectionPhase, ConnectionPhase[]> = {
-  disconnected: ['connecting'],
+  // #6286 — `connecting` is a fresh dial; `reconnecting` is an app-resume /
+  // network-change re-dial of a previously-connected URL (connect() computes
+  // 'reconnecting' when `isReconnect`/`lastConnectedUrl` survives a non-user
+  // drop). Both MUST be legal exits from `disconnected`, or the resume re-dial
+  // is rejected and a live authenticated socket wedges on the ConnectScreen
+  // (disconnected → reconnecting → connected never completes).
+  disconnected: ['connecting', 'reconnecting'],
   // #6023 — a first-attempt probe can read the supervisor terminal-down signal
   // and latch 'server_down' straight from 'connecting' (no reconnect ladder yet).
   connecting: ['connecting', 'connected', 'disconnected', 'reconnecting', 'server_restarting', 'server_down'],
@@ -177,12 +183,16 @@ export const useConnectionLifecycleStore = create<ConnectionLifecycleState>((set
       // the terminal `server_down` phase back to the reconnect spinner (#5980).
       // The ONE legitimate forced exit (user-initiated retry leaving
       // server_down) passes `{ force: true }`; everything else stays put.
-      console.warn(
-        `[ConnectionFSM] Illegal transition: ${from} → ${to}. ` +
-          `Allowed from ${from}: [${allowed.join(', ')}]` +
-          (opts?.force ? ' — applying anyway (force)' : ' — rejected')
-      );
-      if (!opts?.force) return;
+      if (opts?.force) {
+        // Intentional, flagged escape — informational, not a violation.
+        console.log(`[ConnectionFSM] Forced transition: ${from} → ${to}`);
+      } else {
+        console.warn(
+          `[ConnectionFSM] Illegal transition: ${from} → ${to}. ` +
+            `Allowed from ${from}: [${allowed.join(', ')}] — rejected`
+        );
+        return;
+      }
     }
     set({ connectionPhase: to });
   },

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -971,7 +971,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       existing.onmessage = null;
       existing.close();
     }
-    const phase = isReconnect || _retryCount > 0 ? 'reconnecting' : 'connecting';
+    // #6286 — re-dialing over a still-`connected` phase (the resume/network
+    // liveness paths, or switching servers while connected) is a RECONNECT, not
+    // a fresh connect: `connected → connecting` is an illegal FSM exit and the
+    // FSM now rejects it (leaving the phase stuck on the old `connected`). Treat
+    // an already-connected phase as a reconnect so the legal `connected →
+    // reconnecting` edge is taken. `isReconnect`/`_retryCount` keep their meaning.
+    const wasConnectedPhase =
+      useConnectionLifecycleStore.getState().connectionPhase === 'connected';
+    const phase =
+      isReconnect || _retryCount > 0 || wasConnectedPhase ? 'reconnecting' : 'connecting';
     set({ socket: null });
     useConnectionLifecycleStore.getState().setConnectionPhase(phase);
     useConnectionLifecycleStore.getState().setConnectionError(
@@ -1364,9 +1373,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5725 (#5698) — terminal: the reconnect ladder already gave up
       // (server_down). The PAIRED event of this same transport drop (RN fires
       // error → close, or close → error) must NOT clobber server_down back to
-      // reconnecting/disconnected — transitionPhase only WARNS on the illegal
-      // transition, it still applies it, which would revert the terminal banner
-      // to the infinite spinner this state exists to kill. Keep it sticky.
+      // reconnecting/disconnected. Since #6286 the FSM itself rejects those
+      // illegal exits, so this early-return is belt-and-suspenders — it also
+      // skips the scheduleReconnect()/error writes below that the bare phase
+      // guard wouldn't.
       if (useConnectionLifecycleStore.getState().connectionPhase === 'server_down') {
         return;
       }
@@ -1418,7 +1428,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // #5725 (#5698) — terminal server_down is sticky against the paired event
       // of this drop (mirrors the onclose guard above): once the ladder gave up,
-      // a close→error (or error after a give-up) must not clobber it back.
+      // a close→error (or error after a give-up) must not clobber it back. Since
+      // #6286 the FSM rejects the illegal exit too; this early-return remains as
+      // belt-and-suspenders (it also skips the scheduleReconnect()/error writes).
       if (useConnectionLifecycleStore.getState().connectionPhase === 'server_down') {
         return;
       }
@@ -1551,12 +1563,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const lifecycle = useConnectionLifecycleStore.getState();
     // #5725 — leave the terminal server_down phase explicitly BEFORE dialing.
     // connect() sets 'reconnecting' when re-dialing the same URL (isReconnect),
-    // and `server_down -> reconnecting` is an illegal FSM transition (warns +
-    // still applies + carries the stale "Server appears to be down" error
-    // forward). `server_down -> connecting` is the legal exit; clearing the error
-    // here keeps the banner from leaking into the fresh attempt.
+    // and `server_down -> reconnecting` is an illegal FSM transition. Move to
+    // 'connecting' first; clearing the error here keeps the stale "Server
+    // appears to be down" banner from leaking into the fresh attempt.
+    // #6286 — the FSM now REJECTS illegal transitions instead of applying them,
+    // so this user-initiated terminal exit opts in via { force: true }: it is
+    // the ONLY deliberately-flagged way to leave a terminal phase.
     if (lifecycle.connectionPhase === 'server_down') {
-      lifecycle.setConnectionPhase('connecting');
+      lifecycle.transitionPhase('connecting', { force: true });
       lifecycle.setConnectionError(null, 0);
     }
     const saved = lifecycle.savedConnection;


### PR DESCRIPTION
Closes #6286

Part of #6278

## What

Make the `ConnectionPhase` FSM in `connection-lifecycle.ts` **enforce** legal transitions instead of failing open:

- `transitionPhase` now warns AND returns without mutating `connectionPhase` on an illegal transition. Previously it warned then ran `set({ connectionPhase: to })` unconditionally.
- Added an opt-in `transitionPhase(to, { force: true })` escape, used **only** by `retryConnection`'s deliberate `server_down → connecting` exit, so a terminal phase can only be left via a flagged call.
- The two hand-rolled `server_down` sticky guards in `connection.ts` (`onclose`, `onerror`) stay as belt-and-suspenders — they also short-circuit the `scheduleReconnect()`/error writes that the bare phase guard wouldn't.
- Adjusted `connect()`'s phase selection so a re-dial over a still-`connected` phase (the resume zombie-socket / network-change liveness paths, and switching servers while connected) is treated as a reconnect — taking the legal `connected → reconnecting` edge instead of the now-rejected `connected → connecting`.

## Why

`transitionPhase` failing open meant the terminal `server_down` phase was sticky only via hand-rolled early-returns at two call sites. The next consumer that forgets a guard re-introduces the #5980 paired error→close clobber: the terminal banner silently reverts to the reconnect spinner. Enforcing in the FSM itself makes that class of bug structurally unreachable — the documented root of "connection jumps around".

## Testing

CI runs typecheck + Jest for `packages/app`; I could not run them locally (worktree has no `node_modules`). Test changes:

- `connection-lifecycle-store.test.ts` — replaced the two "warns but still applies" assertions with rejection assertions (phase unchanged), and added: terminal `server_down` stays put under an illegal `→ reconnecting`; `{ force: true }` pushes an otherwise-illegal transition through; `{ force: true }` is a clean no-op (no warn) on an already-legal transition.
- `connection-server-down.test.ts` — the existing "paired onerror/onclose keeps server_down sticky" regression still holds; refreshed its comment to reflect the two layers (handler early-return + FSM rejection).