### PR TITLE
fix(dashboard): surface a voice error when the restart budget is exhausted

### DIFF
--- a/packages/dashboard/src/hooks/useVoiceInput.test.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.test.ts
@@ -550,6 +550,31 @@ describe('useVoiceInput', () => {
         expect(result.current.isRecording).toBe(false)
       })
 
+      // #6290: exhausting the restart budget previously flipped the mic off
+      // silently — the user kept "dictating" into a dead recogniser. The cap
+      // path must now surface a visible error so the InputBar banner shows it.
+      it('surfaces a voice error when the restart budget is exhausted (#6290)', async () => {
+        const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+        await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+        act(() => {
+          result.current.start()
+        })
+        const recognition = lastRecognition!
+
+        // No error before the budget runs out.
+        expect(result.current.error).toBeNull()
+
+        // Fire onend until the restart counter passes MAX_CONTINUOUS_RESTARTS.
+        for (let i = 0; i < 10; i++) {
+          act(() => { recognition.onend?.() })
+        }
+
+        expect(result.current.isRecording).toBe(false)
+        expect(result.current.error).toMatch(/stopped unexpectedly|tap the mic/i)
+      })
+
       it('successful onresult resets the restart counter (long sessions stay healthy)', async () => {
         const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
 

--- a/packages/dashboard/src/hooks/useVoiceInput.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.ts
@@ -428,6 +428,13 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
             // the tail of the previous session; fall through to stop.
           }
         }
+        // #6290: in continuous mode, if we land here without the user pressing
+        // stop, the restart budget is exhausted (or a restart threw) — the mic
+        // is reverting to off mid-dictation. Surface a hard error so the
+        // InputBar banner tells the user instead of silently going quiet.
+        if (modeRef.current === 'continuous' && !userStoppedRef.current) {
+          setError('Voice recognition stopped unexpectedly — tap the mic to retry.')
+        }
         setIsRecording(false)
       }
 


### PR DESCRIPTION
Closes #6290
Part of #6278

## What
When the dashboard Web Speech backend exhausts the continuous restart budget (`MAX_CONTINUOUS_RESTARTS` = 5), `recognition.onend` now surfaces a hard error — `Voice recognition stopped unexpectedly — tap the mic to retry.` — before clearing `isRecording`, so the existing InputBar error banner (#5756) shows it.

## Why
Previously, once the restart cap was hit the `onend` handler fell straight through to `setIsRecording(false)` with no `setError(...)`. The mic reverted to off mid-dictation while the user believed they were still dictating — the same silent-give-up family as the desktop-mic bug (#5668/#6280).

The new error is gated on `modeRef.current === 'continuous' && !userStoppedRef.current`, so an explicit user stop (or auto-pause mode) does not raise a spurious banner.

## Testing
- Extended `useVoiceInput.test.ts` with a `#6290` case that drives `onend` past the cap and asserts a visible error appears (and `isRecording` is cleared). The existing cap/user-stop/auto-pause tests still pin the no-spurious-error paths.
- CI runs typecheck + vitest (no node_modules in the worktree, so not run locally).
