### PR TITLE
fix(app): surface File/Git op failures on a closed socket instead of wedging

### DIFF
--- a/packages/app/src/__tests__/components/FileEditor.test.ts
+++ b/packages/app/src/__tests__/components/FileEditor.test.ts
@@ -54,6 +54,14 @@ describe('FileEditor', () => {
       expect(source).toContain('Request timed out');
     });
 
+    it('surfaces a not-connected error on a closed-socket save and skips the timer (#6288)', () => {
+      // requestFileWrite returns false when the socket is closed; the editor
+      // must Alert immediately and return before arming the 10s timeout so it
+      // never shows the misleading "Request timed out".
+      expect(source).toContain('if (!requestFileWrite(filePath, content))');
+      expect(source).toContain("Alert.alert('Save Failed', 'Not connected to server')");
+    });
+
     it('has Cancel editing and Save file accessibility labels', () => {
       expect(source).toContain('Cancel editing');
       expect(source).toContain('Save file');

--- a/packages/app/src/__tests__/components/GitView.test.ts
+++ b/packages/app/src/__tests__/components/GitView.test.ts
@@ -79,6 +79,29 @@ describe('GitView source scan', () => {
     expect(SRC).toContain('accessibilityState');
   });
 
+  // Closed-socket handling (#6288): a request that no-ops on a closed socket
+  // must tear down the in-progress spinner and surface a "not connected" error
+  // instead of arming a callback that never resolves.
+  it('checks the requestGitStage result and surfaces a not-connected error', () => {
+    expect(SRC).toContain('if (!requestGitStage(paths))');
+    expect(SRC).toMatch(/Alert\.alert\('Not connected', 'Stage not sent/);
+  });
+
+  it('checks the requestGitUnstage result and surfaces a not-connected error', () => {
+    expect(SRC).toContain('if (!requestGitUnstage(paths))');
+    expect(SRC).toMatch(/Alert\.alert\('Not connected', 'Unstage not sent/);
+  });
+
+  it('checks the requestGitCommit result and surfaces a not-connected error', () => {
+    expect(SRC).toContain('if (!requestGitCommit(msg))');
+    expect(SRC).toMatch(/Alert\.alert\('Not connected', 'Commit not sent/);
+  });
+
+  it('clears the staging/committing spinner on a closed-socket send', () => {
+    expect(SRC).toContain('setStagingInProgress(false)');
+    expect(SRC).toContain('setCommitting(false)');
+  });
+
   // Type safety
   it('imports git types from store/types', () => {
     expect(SRC).toContain('GitFileStatus');

--- a/packages/app/src/__tests__/store/file-operations-store.test.js
+++ b/packages/app/src/__tests__/store/file-operations-store.test.js
@@ -163,4 +163,48 @@ describe('FileOperationsStore', () => {
     useFileOperationsStore.getState().requestGitStatus()
     expect(wsSendCalls).toHaveLength(0)
   })
+
+  // --- Closed-socket boolean contract (#6288) ---
+  //
+  // The file/git request methods that surface a "not connected" error
+  // (requestFileWrite / requestGitStage / requestGitUnstage / requestGitCommit)
+  // must RETURN sendIfOpen's boolean so GitView/FileEditor can tear down the
+  // in-progress spinner instead of arming a never-resolving callback.
+
+  it('requestFileWrite returns true when the socket is open', () => {
+    expect(
+      useFileOperationsStore.getState().requestFileWrite('/tmp/a.txt', 'x'),
+    ).toBe(true)
+  })
+
+  it('requestFileWrite returns false (no send) when the socket is closed', () => {
+    mockSocket.readyState = 3 // WebSocket.CLOSED
+    const sent = useFileOperationsStore.getState().requestFileWrite('/tmp/a.txt', 'x')
+    expect(sent).toBe(false)
+    expect(wsSendCalls).toHaveLength(0)
+  })
+
+  it('requestGitStage returns true when open, false (no send) when closed', () => {
+    expect(useFileOperationsStore.getState().requestGitStage(['a.ts'])).toBe(true)
+    mockSocket.readyState = 3
+    wsSendCalls.length = 0
+    expect(useFileOperationsStore.getState().requestGitStage(['a.ts'])).toBe(false)
+    expect(wsSendCalls).toHaveLength(0)
+  })
+
+  it('requestGitUnstage returns true when open, false (no send) when closed', () => {
+    expect(useFileOperationsStore.getState().requestGitUnstage(['a.ts'])).toBe(true)
+    mockSocket.readyState = 3
+    wsSendCalls.length = 0
+    expect(useFileOperationsStore.getState().requestGitUnstage(['a.ts'])).toBe(false)
+    expect(wsSendCalls).toHaveLength(0)
+  })
+
+  it('requestGitCommit returns true when open, false (no send) when closed', () => {
+    expect(useFileOperationsStore.getState().requestGitCommit('msg')).toBe(true)
+    mockSocket.readyState = 3
+    wsSendCalls.length = 0
+    expect(useFileOperationsStore.getState().requestGitCommit('msg')).toBe(false)
+    expect(wsSendCalls).toHaveLength(0)
+  })
 })

--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -113,9 +113,21 @@ export function FileEditor({ visible, filePath, initialContent, onClose, onSave 
 
             writeCallbackRef.current = cb;
             setFileWriteCallback(cb);
-            requestFileWrite(filePath, content);
+            if (!requestFileWrite(filePath, content)) {
+              // Socket closed — the write_file frame never went out, so the
+              // response callback would never fire. Surface an accurate error
+              // immediately instead of arming a 10s timer that resolves with a
+              // misleading "Request timed out" (#6288). The form stays open and
+              // re-submittable.
+              setSaving(false);
+              setFileWriteCallback(null);
+              writeCallbackRef.current = null;
+              Alert.alert('Save Failed', 'Not connected to server');
+              return;
+            }
 
-            // Timeout after 10 seconds
+            // Timeout after 10 seconds — only for a genuinely in-flight save
+            // that the server never answers.
             saveTimeoutRef.current = setTimeout(() => {
               saveTimeoutRef.current = null;
               if (writeCallbackRef.current === cb) {

--- a/packages/app/src/components/GitView.tsx
+++ b/packages/app/src/components/GitView.tsx
@@ -225,7 +225,14 @@ export function GitView({ visible, onClose }: GitViewProps) {
 
     stageCallbackRef.current = cb;
     setGitStageCallback(cb);
-    requestGitStage(paths);
+    if (!requestGitStage(paths)) {
+      // Socket closed — the response callback would never fire, leaving the
+      // spinner stuck forever. Tear down and surface an accurate error (#6288).
+      setGitStageCallback(null);
+      stageCallbackRef.current = null;
+      setStagingInProgress(false);
+      Alert.alert('Not connected', 'Stage not sent — reconnect and try again');
+    }
   }, [selectedPaths, unstaged, untracked, setGitStageCallback, requestGitStage, setGitStatusCallback, requestGitStatus]);
 
   const handleUnstageSelected = useCallback(() => {
@@ -259,7 +266,14 @@ export function GitView({ visible, onClose }: GitViewProps) {
 
     stageCallbackRef.current = cb;
     setGitStageCallback(cb);
-    requestGitUnstage(paths);
+    if (!requestGitUnstage(paths)) {
+      // Socket closed — the response callback would never fire, leaving the
+      // spinner stuck forever. Tear down and surface an accurate error (#6288).
+      setGitStageCallback(null);
+      stageCallbackRef.current = null;
+      setStagingInProgress(false);
+      Alert.alert('Not connected', 'Unstage not sent — reconnect and try again');
+    }
   }, [selectedPaths, staged, setGitStageCallback, requestGitUnstage, setGitStatusCallback, requestGitStatus]);
 
   const handleCommit = useCallback(() => {
@@ -296,7 +310,16 @@ export function GitView({ visible, onClose }: GitViewProps) {
           };
           commitCallbackRef.current = cb;
           setGitCommitCallback(cb);
-          requestGitCommit(msg);
+          if (!requestGitCommit(msg)) {
+            // Socket closed — the response callback would never fire, so the
+            // commit box would never clear and the spinner would hang. Tear
+            // down and surface an accurate error; the form stays
+            // re-submittable (#6288).
+            setGitCommitCallback(null);
+            commitCallbackRef.current = null;
+            setCommitting(false);
+            Alert.alert('Not connected', 'Commit not sent — reconnect and try again');
+          }
         },
       },
     ]);

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -2148,7 +2148,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   requestFileWrite: (path: string, content: string) => {
-    sendIfOpen({ type: 'write_file', path, content });
+    return sendIfOpen({ type: 'write_file', path, content });
   },
 
   // Diff viewer
@@ -2179,15 +2179,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   requestGitStage: (paths: string[]) => {
-    sendIfOpen({ type: 'git_stage', files: paths });
+    return sendIfOpen({ type: 'git_stage', files: paths });
   },
 
   requestGitUnstage: (paths: string[]) => {
-    sendIfOpen({ type: 'git_unstage', files: paths });
+    return sendIfOpen({ type: 'git_unstage', files: paths });
   },
 
   requestGitCommit: (message: string) => {
-    sendIfOpen({ type: 'git_commit', message });
+    return sendIfOpen({ type: 'git_commit', message });
   },
 
   fetchProviders: () => {

--- a/packages/app/src/store/file-operations.ts
+++ b/packages/app/src/store/file-operations.ts
@@ -38,13 +38,19 @@ interface FileOperationsActions {
   requestDirectoryListing: (path?: string) => void;
   requestFileListing: (path?: string) => void;
   requestFileContent: (path: string) => void;
-  requestFileWrite: (path: string, content: string) => void;
+  // Returns false when the socket is closed (frame not sent) so callers can
+  // surface a "not connected" error instead of arming a never-resolving
+  // callback / timeout (#6288).
+  requestFileWrite: (path: string, content: string) => boolean;
   requestDiff: (base?: string) => void;
   requestGitStatus: () => void;
   requestGitBranches: () => void;
-  requestGitStage: (paths: string[]) => void;
-  requestGitUnstage: (paths: string[]) => void;
-  requestGitCommit: (message: string) => void;
+  // Return false when the socket is closed (frame not sent) so callers can
+  // surface a "not connected" error instead of arming a never-resolving
+  // callback (#6288).
+  requestGitStage: (paths: string[]) => boolean;
+  requestGitUnstage: (paths: string[]) => boolean;
+  requestGitCommit: (message: string) => boolean;
 }
 
 export const useFileOperationsStore = create<FileOperationsActions>(() => ({
@@ -77,7 +83,7 @@ export const useFileOperationsStore = create<FileOperationsActions>(() => ({
   },
 
   requestFileWrite: (path: string, content: string) => {
-    sendIfOpen({ type: 'write_file', path, content });
+    return sendIfOpen({ type: 'write_file', path, content });
   },
 
   requestDiff: (base?: string) => {
@@ -95,14 +101,14 @@ export const useFileOperationsStore = create<FileOperationsActions>(() => ({
   },
 
   requestGitStage: (paths: string[]) => {
-    sendIfOpen({ type: 'git_stage', files: paths });
+    return sendIfOpen({ type: 'git_stage', files: paths });
   },
 
   requestGitUnstage: (paths: string[]) => {
-    sendIfOpen({ type: 'git_unstage', files: paths });
+    return sendIfOpen({ type: 'git_unstage', files: paths });
   },
 
   requestGitCommit: (message: string) => {
-    sendIfOpen({ type: 'git_commit', message });
+    return sendIfOpen({ type: 'git_commit', message });
   },
 }));

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -478,8 +478,13 @@ export function sendIfOpen(payload: Record<string, unknown>): boolean {
   if (!_store) return false;
   const socket = getStore().getState().socket;
   if (socket && socket.readyState === WebSocket.OPEN) {
-    wsSend(socket, payload);
-    return true;
+    // #6288 — propagate wsSend's boolean rather than assuming OPEN ⇒ sent. The
+    // socket can flip to CLOSING between the readyState check and the synchronous
+    // send (the TOCTOU window wsSend guards), so wsSend may swallow an
+    // InvalidStateError and return false. Callers that gate on this result
+    // (Git/File ops) must see that false, or they arm a callback/spinner that
+    // never resolves.
+    return wsSend(socket, payload);
   }
   return false;
 }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -577,7 +577,10 @@ export interface FileGitDiffActions {
   requestFileListing: (path?: string) => void;
   requestFileContent: (path: string) => void;
   setFileWriteCallback: (cb: ((result: FileWriteResult) => void) | null) => void;
-  requestFileWrite: (path: string, content: string) => void;
+  // Returns false when the socket is closed (frame not sent) so callers can
+  // surface a "not connected" error instead of arming a never-resolving
+  // callback / timeout (#6288).
+  requestFileWrite: (path: string, content: string) => boolean;
   // Git operations
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;
   setGitBranchesCallback: (cb: ((result: GitBranchesResult) => void) | null) => void;
@@ -585,9 +588,12 @@ export interface FileGitDiffActions {
   setGitCommitCallback: (cb: ((result: GitCommitResult) => void) | null) => void;
   requestGitStatus: () => void;
   requestGitBranches: () => void;
-  requestGitStage: (paths: string[]) => void;
-  requestGitUnstage: (paths: string[]) => void;
-  requestGitCommit: (message: string) => void;
+  // Return false when the socket is closed (frame not sent) so callers can
+  // surface a "not connected" error instead of arming a never-resolving
+  // callback (#6288).
+  requestGitStage: (paths: string[]) => boolean;
+  requestGitUnstage: (paths: string[]) => boolean;
+  requestGitCommit: (message: string) => boolean;
   // Diff viewer
   setDiffCallback: (cb: ((result: DiffResult) => void) | null) => void;
   requestDiff: (base?: string) => void;


### PR DESCRIPTION
Closes #6288
Part of #6278

## What
File/Git request methods (`requestGitStage`, `requestGitUnstage`, `requestGitCommit`, `requestFileWrite`) now **return** `sendIfOpen`'s boolean, and the callers act on a `false` (closed-socket) result instead of arming a callback/timer that never resolves.

- `store/connection.ts`, `store/file-operations.ts`, `store/types.ts` — the four request methods return `boolean`.
- `components/GitView.tsx` — Stage / Unstage / Commit: if the send returns `false`, clear the in-progress spinner, drop the armed callback, and `Alert('Not connected', '<op> not sent — reconnect and try again')`.
- `components/FileEditor.tsx` — Save: if the send returns `false`, `Alert('Save Failed', 'Not connected to server')` immediately and **skip** the 10s timer (kept only for a genuinely in-flight slow save).

## Why
These methods previously ignored `sendIfOpen`'s boolean. On a closed socket `sendIfOpen` no-ops and returns `false`, so the response callback never fired:
- GitView's `stagingInProgress` stayed `true` forever and the commit box never cleared — no error, no retry, permanent spinner.
- FileEditor waited 10s then showed a misleading "Request timed out".

Now a Stage/Commit/Save on a closed socket shows an immediate, accurate "not connected" error; forms stay re-submittable; no permanent spinner. Pattern precedent: notification prefs #4559.

## Testing
- Added closed-socket boolean-contract tests to `__tests__/store/file-operations-store.test.js` (each request method returns `true` when the socket is open, `false` with no send when closed).
- Extended the `GitView` and `FileEditor` source-scan tests to assert the new not-connected handling.
- Could not run the suite locally (worktree has no `node_modules`); CI runs typecheck + jest.