### PR TITLE
fix(store-core): reconcile a faked-fresh turn to queued in one step on message_queued

### DIFF
--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -1178,6 +1178,54 @@ describe('shared dispatch table', () => {
       dispatch(env, { type: 'message_dequeued', sessionId: 's1', clientMessageId: 'uin-1', queueLength: 0, reason: 'flush' })
       expect(env.sessions.s1.queuedMessages).toEqual([])
     })
+
+    it('reconciles a faked-fresh turn → clears streamingMessageId + strips thinking bubble in one step (#6291)', () => {
+      // The client judged 'not busy', faked a fresh working turn (a 'thinking'
+      // bubble + streamingMessageId: 'pending') for uin-1; the server queues it
+      // instead. The message_queued must retire that optimistic turn in the SAME
+      // state update that confirms the queued entry — not 5s later.
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            streamingMessageId: 'pending',
+            messages: [
+              { id: 'uin-1', type: 'user_input', content: 'hi', timestamp: 0 },
+              { id: 'thinking', type: 'thinking', content: '', timestamp: 0 },
+            ],
+            queuedMessages: [],
+          },
+        },
+      })
+      dispatch(env, { type: 'message_queued', sessionId: 's1', clientMessageId: 'uin-1', text: 'hi', queueLength: 1 })
+      expect(env.sessions.s1.streamingMessageId).toBeNull()
+      expect(env.sessions.s1.messages).toEqual([
+        { id: 'uin-1', type: 'user_input', content: 'hi', timestamp: 0 },
+      ])
+      expect(env.sessions.s1.queuedMessages).toMatchObject([
+        { clientMessageId: 'uin-1', text: 'hi', status: 'confirmed' },
+      ])
+    })
+
+    it('leaves a genuinely live turn (real stream id) untouched on message_queued (#6291)', () => {
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            streamingMessageId: 'resp-7',
+            messages: [{ id: 'thinking', type: 'thinking', content: '', timestamp: 0 }],
+            queuedMessages: [],
+          },
+        },
+      })
+      dispatch(env, { type: 'message_queued', sessionId: 's1', clientMessageId: 'uin-2', text: 'follow-up', queueLength: 1 })
+      // A real live turn keeps its stream id and thinking bubble; only the queue grows.
+      expect(env.sessions.s1.streamingMessageId).toBe('resp-7')
+      expect(env.sessions.s1.messages).toEqual([
+        { id: 'thinking', type: 'thinking', content: '', timestamp: 0 },
+      ])
+      expect(env.sessions.s1.queuedMessages).toHaveLength(1)
+    })
   })
 
   describe('plan_started', () => {

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -122,6 +122,7 @@ import {
   // --- outgoing-message queue mirror (#5937, epic #5935 part ②) ---
   handleMessageQueued,
   handleMessageDequeued,
+  type QueuedMessagesBuilder,
   // --- user_question (#5618) — byte-identical parse + append + notify ---
   handleUserQuestion,
   // --- multi_question_intervention (#5618) — byte-identical builder + append ---
@@ -167,6 +168,10 @@ import {
  */
 export interface DispatchSessionBase {
   messages: ChatMessage[]
+  // `streamingMessageId` — read+cleared by message_queued's faked-fresh-turn
+  // reconcile (#6291). Both clients' real `SessionState` carry it
+  // (BaseSessionState).
+  streamingMessageId?: string | null
   conversationId?: string | null
   sessionRules?: PermissionRule[]
   isIdle?: boolean
@@ -1036,7 +1041,7 @@ function dispatchQueuedMessages<S extends DispatchSessionBase>(
   handle: (
     msg: Record<string, unknown>,
     activeSessionId: string | null,
-  ) => { sessionId: string | null; applyTo: (current: QueuedSessionMessage[]) => { queuedMessages: QueuedSessionMessage[] } } | null,
+  ) => QueuedMessagesBuilder | null,
 ): (msg: Record<string, unknown>, adapter: ClientStoreAdapter<S>) => void {
   return (msg, adapter) => {
     const builder = handle(msg, adapter.getActiveSessionId())
@@ -1047,9 +1052,27 @@ function dispatchQueuedMessages<S extends DispatchSessionBase>(
         // when the builder returned the same array AND the field already held it,
         // skip the write so React's referential check elides a re-render. When the
         // field was undefined, `next` is a fresh array (!== undefined) → write.
-        return next === ss.queuedMessages
-          ? ({} as Partial<S>)
-          : ({ queuedMessages: next } as Partial<S>)
+        const patch: Partial<S> =
+          next === ss.queuedMessages ? ({} as Partial<S>) : ({ queuedMessages: next } as Partial<S>)
+        // #6291 — in the SAME update, retire a client-faked optimistic "working"
+        // turn (streamingMessageId: 'pending' + 'thinking' bubble) when this
+        // message_queued confirms the send the server actually queued. This makes
+        // the spinner→badge swap happen in one step immediately instead of waiting
+        // for the client's 5s stream-stall safety net.
+        const turnPatch = builder.reconcileFakedFreshTurn?.({
+          streamingMessageId: ss.streamingMessageId ?? null,
+          messages: ss.messages,
+        })
+        if (turnPatch) {
+          if ('streamingMessageId' in turnPatch) {
+            ;(patch as { streamingMessageId?: string | null }).streamingMessageId =
+              turnPatch.streamingMessageId
+          }
+          if (turnPatch.messages) {
+            ;(patch as { messages?: ChatMessage[] }).messages = turnPatch.messages
+          }
+        }
+        return patch
       })
     }
   }

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -261,6 +261,19 @@ describe('handleMessageQueued — faked-fresh-turn reconcile (#6291)', () => {
     const builder = handleMessageQueued({ sessionId: 's1', text: 'hi' }, null)!
     expect(builder.reconcileFakedFreshTurn!({ streamingMessageId: null, messages: [] })).toBeNull()
   })
+
+  it('strips ONLY the singleton thinking placeholder, preserving real persisted thinking content', () => {
+    // Real thinking content carries a non-'thinking' id (e.g. 'th1') even though
+    // its type is 'thinking'; only the optimistic placeholder uses id 'thinking'.
+    // Filtering by id (not type) must keep the real content. (#6291 review)
+    const realThinking: ChatMessage = { id: 'th1', type: 'thinking', content: 'reasoning…', timestamp: 0 }
+    const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-1', text: 'hi' }, null)!
+    const patch = builder.reconcileFakedFreshTurn!({
+      streamingMessageId: 'pending',
+      messages: [realThinking, userMsg('uin-1'), thinkingMsg()],
+    })
+    expect(patch).toEqual({ streamingMessageId: null, messages: [realThinking, userMsg('uin-1')] })
+  })
 })
 
 describe('handleMessageDequeued', () => {

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -6,7 +6,7 @@ import {
   removeQueuedMessage,
   reconcileQueueLength,
 } from './outgoing-queue'
-import type { QueuedSessionMessage } from '../types'
+import type { ChatMessage, QueuedSessionMessage } from '../types'
 
 /**
  * #5937 (epic #5935 slice ②) — unit coverage for the shared store-core
@@ -219,6 +219,47 @@ describe('handleMessageQueued', () => {
     const next = builder.applyTo(current).queuedMessages
     expect(next).toHaveLength(2)
     expect(next[1]).toMatchObject({ text: 'b', status: 'confirmed', clientMessageId: undefined })
+  })
+})
+
+describe('handleMessageQueued — faked-fresh-turn reconcile (#6291)', () => {
+  const userMsg = (id: string): ChatMessage => ({ id, type: 'user_input', content: 'hi', timestamp: 0 })
+  const thinkingMsg = (): ChatMessage => ({ id: 'thinking', type: 'thinking', content: '', timestamp: 0 })
+
+  it('clears a pending streamingMessageId and strips the thinking bubble in one step', () => {
+    const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-1', text: 'hi' }, null)!
+    const patch = builder.reconcileFakedFreshTurn!({
+      streamingMessageId: 'pending',
+      messages: [userMsg('uin-1'), thinkingMsg()],
+    })
+    expect(patch).toEqual({ streamingMessageId: null, messages: [userMsg('uin-1')] })
+  })
+
+  it('does NOT strip a real (non-thinking) message when there is no thinking bubble', () => {
+    const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-1', text: 'hi' }, null)!
+    // streamingMessageId is still the 'pending' sentinel (no stream_start yet) but
+    // the thinking bubble was already removed — clear the id, leave messages alone.
+    const patch = builder.reconcileFakedFreshTurn!({
+      streamingMessageId: 'pending',
+      messages: [userMsg('uin-1')],
+    })
+    expect(patch).toEqual({ streamingMessageId: null })
+    expect(patch).not.toHaveProperty('messages')
+  })
+
+  it('is a no-op (null) when a genuinely live turn owns a real stream id', () => {
+    const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-2', text: 'hi' }, null)!
+    // A live turn carries a real stream id, not the 'pending' sentinel — leave it.
+    const patch = builder.reconcileFakedFreshTurn!({
+      streamingMessageId: 'resp-7',
+      messages: [userMsg('uin-1'), thinkingMsg()],
+    })
+    expect(patch).toBeNull()
+  })
+
+  it('is a no-op (null) when nothing is streaming', () => {
+    const builder = handleMessageQueued({ sessionId: 's1', text: 'hi' }, null)!
+    expect(builder.reconcileFakedFreshTurn!({ streamingMessageId: null, messages: [] })).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/outgoing-queue.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.ts
@@ -23,8 +23,27 @@
  * Re-exported from ./index (the barrel) so the public surface is unchanged.
  */
 
-import type { QueuedSessionMessage } from '../types'
+import type { ChatMessage, QueuedSessionMessage } from '../types'
 import { resolveSessionId } from './_shared'
+
+/**
+ * Subset of session-state the queue handlers read to reconcile a faked-fresh
+ * optimistic turn (#6291). The client may OPTIMISTICALLY show a live "working"
+ * turn (a `'thinking'` bubble + `streamingMessageId: 'pending'`) for a send it
+ * judged would start a turn; when the server instead QUEUES that send, the
+ * `message_queued` echo must atomically retire that optimistic turn as the entry
+ * flips to confirmed-queued. Both clients' `BaseSessionState` carry these fields.
+ */
+export interface FakedFreshTurnState {
+  streamingMessageId: string | null
+  messages: ChatMessage[]
+}
+
+/** The patch a faked-fresh-turn reconcile produces (omitted fields are unchanged). */
+export interface FakedFreshTurnPatch {
+  streamingMessageId?: string | null
+  messages?: ChatMessage[]
+}
 
 /**
  * Builder result for the queue handlers, mirroring `SessionInterventionBuilder`
@@ -37,6 +56,17 @@ export interface QueuedMessagesBuilder {
   sessionId: string | null
   /** Apply against the session's current queue; returns the next queue patch. */
   applyTo: (current: QueuedSessionMessage[]) => { queuedMessages: QueuedSessionMessage[] }
+  /**
+   * #6291 — reconcile a client-faked optimistic "working" turn in the SAME state
+   * update that confirms this queued entry. Only `handleMessageQueued` populates
+   * this. Given the session's current `{ streamingMessageId, messages }`, returns
+   * a patch that clears the `'pending'` streamingMessageId and strips the
+   * optimistic `'thinking'` bubble when this `message_queued` corresponds to that
+   * optimistic turn; returns `null` (no patch) otherwise so the spinner→badge
+   * swap happens in one step immediately rather than after the client's 5s
+   * stream-stall safety net.
+   */
+  reconcileFakedFreshTurn?: (state: FakedFreshTurnState) => FakedFreshTurnPatch | null
 }
 
 /**
@@ -193,6 +223,25 @@ export function handleMessageQueued(
 
   return {
     sessionId: resolveSessionId(msg, activeSessionId),
+    // #6291 — when the client optimistically faked a fresh "working" turn for
+    // this send (streamingMessageId === 'pending' + a 'thinking' bubble) but the
+    // server queued it instead, retire that optimistic turn atomically as the
+    // entry confirms. Without this the live turn evaporates and re-labels itself
+    // "Queued" ~5s later when the client's stream-stall safety net fires, with no
+    // user action. We key off the literal 'pending' sentinel the client writes
+    // (it never sets streamingMessageId to a real clientMessageId before
+    // stream_start), so this fires only for a faked-fresh turn — a genuinely live
+    // turn carries a real stream id and is left untouched.
+    reconcileFakedFreshTurn: ({ streamingMessageId, messages }) => {
+      if (streamingMessageId !== 'pending') return null
+      const patch: FakedFreshTurnPatch = { streamingMessageId: null }
+      // Strip the optimistic 'thinking' bubble (id 'thinking') if present; keep
+      // the array reference (and omit the field) when there's nothing to remove
+      // so the dispatcher can elide a needless re-render.
+      const stripped = messages.filter((m) => m.type !== 'thinking')
+      if (stripped.length !== messages.length) patch.messages = stripped
+      return patch
+    },
     applyTo: (current) => {
       // #5950 — reconcile the result against the server's authoritative
       // queueLength so a leftover CONFIRMED orphan (from a dropped earlier

--- a/packages/store-core/src/handlers/outgoing-queue.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.ts
@@ -235,10 +235,12 @@ export function handleMessageQueued(
     reconcileFakedFreshTurn: ({ streamingMessageId, messages }) => {
       if (streamingMessageId !== 'pending') return null
       const patch: FakedFreshTurnPatch = { streamingMessageId: null }
-      // Strip the optimistic 'thinking' bubble (id 'thinking') if present; keep
-      // the array reference (and omit the field) when there's nothing to remove
-      // so the dispatcher can elide a needless re-render.
-      const stripped = messages.filter((m) => m.type !== 'thinking')
+      // Strip the optimistic 'thinking' bubble by its singleton id (matching the
+      // canonical filterThinking in utils.ts) — NOT by type, which would also
+      // delete real persisted thinking content that carries a non-'thinking' id.
+      // Keep the array reference (and omit the field) when there's nothing to
+      // remove so the dispatcher can elide a needless re-render.
+      const stripped = messages.filter((m) => m.id !== 'thinking')
       if (stripped.length !== messages.length) patch.messages = stripped
       return patch
     },


### PR DESCRIPTION
Closes #6291
Part of #6278

## What
When the client judges 'not busy' but the server actually has a turn in progress, the client optimistically renders a live working turn (a `'thinking'` bubble + `streamingMessageId: 'pending'`). The server replies `message_queued`, but the shared dispatch handler only patched `queuedMessages` — it never cleared `streamingMessageId` or stripped the thinking bubble. A 5s stream-stall safety net eventually fixed it, so the UI showed a working turn that evaporated and re-labeled itself "Queued" ~5s later with no user action.

This adds a `reconcileFakedFreshTurn` step to `handleMessageQueued` and applies it in `dispatchQueuedMessages`, in the SAME `updateSession` call that confirms the queued entry:
- when `streamingMessageId` is the `'pending'` sentinel → clear it to `null` and strip the optimistic `'thinking'` bubble;
- a genuinely live turn (real stream id like `resp-7`) is left untouched.

The spinner→badge swap now happens in one step, immediately.

## Why
Removes a confusing 5s window where a queued send looks like a live working turn before silently re-labeling itself. The fix lives in `store-core` so both the mobile app and the web dashboard inherit it through the single shared dispatch table (neither client carries its own `message_queued` copy).

## Files
- `packages/store-core/src/handlers/outgoing-queue.ts` — new `reconcileFakedFreshTurn` on the queued builder (+ `FakedFreshTurnState`/`FakedFreshTurnPatch` types).
- `packages/store-core/src/dispatch-table.ts` — `dispatchQueuedMessages` applies the turn patch in the same state update; `streamingMessageId` added to `DispatchSessionBase`.

## Testing
Added store-core unit tests (CI runs typecheck + vitest — I could not run them locally; the worktree has no node_modules):
- `outgoing-queue.test.ts` — builder-level: pending sentinel clears + strips thinking; no-thinking case clears id only; live stream id is a no-op; nothing-streaming is a no-op.
- `dispatch-table.test.ts` — dispatch-level: a faked-fresh turn clears `streamingMessageId` + removes the thinking bubble while adding the confirmed queued entry, in one step; a real live turn is left untouched.
