### PR TITLE
fix(app): restrict ConnectionPhase force to whitelisted terminal exits

### DIFF
--- a/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
+++ b/packages/app/src/__tests__/store/connection-lifecycle-store.test.ts
@@ -179,31 +179,50 @@ describe('useConnectionLifecycleStore', () => {
       warnSpy.mockRestore();
     });
 
-    it('#6286 — { force: true } applies an otherwise-illegal transition (the one legitimate forced exit)', () => {
+    it('#6296 — { force: true } is REJECTED on a non-whitelisted illegal transition (phase unchanged)', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
       const store = useConnectionLifecycleStore.getState();
       store.transitionPhase('connecting');
       store.transitionPhase('server_down');
-      // server_down → reconnecting is illegal, but force pushes it through.
+      // server_down → reconnecting is illegal AND not whitelisted in
+      // FORCEABLE_TRANSITIONS. Pre-#6296 force pushed ANY illegal edge through
+      // (the latent footgun this issue removes); now it is rejected even forced,
+      // so terminal server_down stickiness cannot be bypassed.
       store.transitionPhase('reconnecting', { force: true });
-      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('reconnecting');
-      // A forced (intentional) exit logs informationally, NOT as a violation warning.
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Forced transition'));
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[ConnectionFSM] Illegal transition: server_down → reconnecting')
+      );
+      // A rejected force must NOT log the informational "Forced transition" line.
+      expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Forced transition'));
+      warnSpy.mockRestore();
+      logSpy.mockRestore();
+    });
+
+    it('#6296 — { force: true } applies a whitelisted forced exit (server_down → connecting)', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const store = useConnectionLifecycleStore.getState();
+      store.transitionPhase('connecting');
+      store.transitionPhase('server_down');
+      // server_down → connecting is the one whitelisted forceable terminal exit
+      // (the retryConnection intent). It applies with no violation warning.
+      store.transitionPhase('connecting', { force: true });
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connecting');
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
       logSpy.mockRestore();
     });
 
-    it('#6286 — { force: true } does not warn on an already-legal transition', () => {
+    it('#6296 — { force: true } is a clean no-op on an already-legal transition (no warn)', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const store = useConnectionLifecycleStore.getState();
       store.transitionPhase('connecting');
-      store.transitionPhase('server_down');
-      // server_down → connecting is legal (retryConnection's real exit); force is a
-      // no-op on the validation but must still apply cleanly with no warning.
-      store.transitionPhase('connecting', { force: true });
-      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connecting');
+      // connecting → connected is already legal; force must apply it cleanly with
+      // no warning (force never penalises a legal transition).
+      store.transitionPhase('connected', { force: true });
+      expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('connected');
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -164,6 +164,11 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     expect(reconnectAttempt).toBe(0);
     // …and a fresh dial was attempted (connectAuto → connect → WebSocket).
     expect(ws.instances.length).toBeGreaterThan(before);
+    // #6296 — and the terminal phase was actually left: retryConnection's
+    // `transitionPhase('connecting', { force: true })` exit is a whitelisted
+    // forceable edge (server_down → connecting), so the FSM applied it rather
+    // than rejecting it. (Tightening force to a whitelist must not wedge here.)
+    expect(useConnectionLifecycleStore.getState().connectionPhase).not.toBe('server_down');
 
     ws.restore();
   });

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -16,8 +16,13 @@ import type { ConnectionPhase, SavedConnection } from './types';
  * only via its two declared legal edges — `connecting` (a user-initiated
  * retry, see `retryConnection`) or `disconnected` (an explicit disconnect).
  * `transitionPhase(to, { force: true })` is a deliberately-flagged escape
- * hatch that applies an otherwise-illegal transition; it is currently used
- * only by `retryConnection` and must stay confined to audited call sites.
+ * hatch that applies an otherwise-illegal transition — but ONLY for the
+ * edges enumerated in `FORCEABLE_TRANSITIONS` (#6296). `force` is NOT a
+ * blanket override: an illegal transition that is not whitelisted is
+ * rejected even with `force`, so a future caller cannot accidentally
+ * bypass terminal-phase stickiness (the #5980 clobber protection #6286
+ * added). It is currently used only by `retryConnection` and must stay
+ * confined to audited call sites.
  *
  * Notes on non-obvious entries:
  *  - connecting → server_restarting: health check returns "restarting" during the
@@ -48,6 +53,24 @@ const VALID_TRANSITIONS: Record<ConnectionPhase, ConnectionPhase[]> = {
   // explicit disconnect leaves it.
   server_down: ['connecting', 'disconnected'],
 };
+
+/**
+ * #6296 — the allow-list of otherwise-illegal transitions that `{ force: true }`
+ * is permitted to apply. `force` only escapes the FSM for an edge listed here;
+ * any other illegal transition is rejected even when forced, so a future caller
+ * cannot weaponise `force` to clobber a terminal phase (the #5980 regression
+ * #6286 fixed).
+ *
+ * Today this documents exactly one legitimate intent: leaving the terminal
+ * `server_down` phase on a user-initiated retry (`retryConnection`). That edge
+ * also happens to be legal in `VALID_TRANSITIONS`, so the current call site
+ * never actually needs the escape hatch — the whitelist records the intent so
+ * the edge stays force-safe even if its `VALID_TRANSITIONS` membership ever
+ * changes. Encoded as `"from→to"` strings for cheap membership checks.
+ */
+const FORCEABLE_TRANSITIONS: ReadonlySet<string> = new Set<string>([
+  'server_down→connecting',
+]);
 
 interface ServerInfo {
   serverMode?: 'cli' | null;
@@ -183,15 +206,20 @@ export const useConnectionLifecycleStore = create<ConnectionLifecycleState>((set
       // Previously the FSM warned then mutated unconditionally ("fail open"),
       // so the paired error→close events of one transport drop could clobber
       // the terminal `server_down` phase back to the reconnect spinner (#5980).
-      // The ONE legitimate forced exit (user-initiated retry leaving
-      // server_down) passes `{ force: true }`; everything else stays put.
-      if (opts?.force) {
-        // Intentional, flagged escape — informational, not a violation.
+      // #6296 — `{ force: true }` is NOT a blanket override: it only applies an
+      // illegal transition that is whitelisted in FORCEABLE_TRANSITIONS. The
+      // ONE legitimate forced exit (user-initiated retry leaving server_down →
+      // connecting) is whitelisted; every other illegal transition stays put
+      // even when forced, so `force` can never be used to bypass terminal
+      // stickiness.
+      if (opts?.force && FORCEABLE_TRANSITIONS.has(`${from}→${to}`)) {
+        // Intentional, whitelisted escape — informational, not a violation.
         console.log(`[ConnectionFSM] Forced transition: ${from} → ${to}`);
       } else {
         console.warn(
           `[ConnectionFSM] Illegal transition: ${from} → ${to}. ` +
-            `Allowed from ${from}: [${allowed.join(', ')}] — rejected`
+            `Allowed from ${from}: [${allowed.join(', ')}]` +
+            `${opts?.force ? ' (force is not whitelisted for this edge)' : ''} — rejected`
         );
         return;
       }


### PR DESCRIPTION
Closes #6296
Part of #6278

## What
Narrows `transitionPhase(to, { force: true })` (`packages/app/src/store/connection-lifecycle.ts`) so `force` can only apply a transition listed in a new `FORCEABLE_TRANSITIONS` allow-list — currently just `server_down → connecting`. Any other otherwise-illegal transition is now rejected (warned) **even with `force`**. `force` remains a clean no-op on already-legal transitions.

## Why
Previously `force` applied **any** otherwise-illegal transition. That was a latent footgun: a future caller could pass `{ force: true }` and bypass terminal-phase stickiness — the `#5980` clobber protection that `#6286` added (terminal `server_down` no longer gets clobbered back to the reconnect spinner by the paired error→close of one transport drop). The only current `force` call site is `retryConnection` in `connection.ts` (`server_down → connecting`), and that edge is already legal in `VALID_TRANSITIONS`, so `force` was a redundant safety there. Whitelisting documents the one legitimate terminal-exit intent and makes `force` incapable of bypassing the FSM for anything else.

`retryConnection`'s `server_down → connecting` exit is both legal and whitelisted, so the reconnect/retry flow is unaffected.

## Testing
- `connection-lifecycle-store.test.ts`: `force` is rejected on a non-whitelisted illegal edge (`server_down → reconnecting`, phase unchanged, no "Forced transition" log); `force` applies the whitelisted exit (`server_down → connecting`); `force` is a clean no-op on an already-legal transition (`connecting → connected`, no warn). The old "force pushes an arbitrary illegal transition" assertion (which this issue removes) was replaced.
- `connection-server-down.test.ts`: strengthened the existing `retryConnection` test to assert the terminal phase is actually left (`server_down → connecting` whitelisted forced exit succeeds end-to-end).

(No npm/tsc run — worktree has no node_modules; CI verifies.)
