### PR TITLE
fix(dashboard): surface send-failed/queued state + cover create-spinner reset

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -100,6 +100,11 @@ vi.mock('./components/CreateSessionModal', () => ({
   CreateSessionModal: (props: {
     open: boolean
     onCreate?: (data: { name: string; cwd: string }) => void
+    // #6301 — surface the create spinner + retryable error so the
+    // #6285 App-layer branches (create-confirm effect / not-sent
+    // else-branch) are directly assertable from the modal's DOM.
+    isCreating?: boolean
+    serverError?: string
   }) =>
     props.open ? (
       <div data-testid="create-session-modal-mock">
@@ -108,6 +113,10 @@ vi.mock('./components/CreateSessionModal', () => ({
           data-testid="create-session-modal-confirm"
           onClick={() => props.onCreate?.({ name: 'New Session', cwd: '/tmp/new' })}
         />
+        {props.isCreating ? <div data-testid="create-session-modal-creating" /> : null}
+        {props.serverError ? (
+          <div data-testid="create-session-modal-error">{props.serverError}</div>
+        ) : null}
       </div>
     ) : null,
 }))
@@ -174,6 +183,9 @@ vi.mock('./store/connection', () => {
     }),
     connect: vi.fn(),
     sendInput: vi.fn(),
+    // #6295 — queued-send notice path. App.handleSend surfaces a transient
+    // info notification when sendInput falls through to the offline queue.
+    addInfoNotification: vi.fn(),
     sendInterrupt: vi.fn(),
     sendPermissionResponse: vi.fn(),
     sendUserQuestionResponse: vi.fn(),
@@ -2504,6 +2516,72 @@ describe('App', () => {
       confirmCreate()             // create — must NOT seed
       expect(viewSessionComposer().value).toBe('')
     })
+  })
+})
+
+// #6301 — App-layer coverage for the #6285 create-spinner reset. #6285 made
+// createSession return a boolean and added two App.tsx branches that the
+// store-level tests only cover transitively:
+//   (a) the create-confirm-window guard (#6285 effect): if the socket drops
+//       mid-create (connectionPhase leaves 'connected' while isCreatingSession),
+//       the stranded "Creating…" spinner is cleared and a retryable error is
+//       surfaced — otherwise no session_created/session_error reply ever clears
+//       it and the spinner wedges forever.
+//   (b) the not-sent else-branch in handleCreateSession: clicking Create while
+//       the socket is closed (createSession returns false) surfaces the
+//       'Connection lost' error WITHOUT latching the spinner.
+// The modal mock surfaces `isCreating` / `serverError` as testID nodes so both
+// branches are directly assertable.
+describe('#6301 create-session spinner reset (#6285 App-layer branches)', () => {
+  // Fresh-session create: connected, no sessions yet, no active session. The
+  // WelcomeScreen renders its New Session button, and crucially activeSessionId
+  // stays null so the create-confirm effect (which closes the modal once the
+  // server adopts a session) does NOT fire — leaving the spinner observable.
+  const freshConnectedState = (createSession: () => boolean) => ({
+    connectionPhase: 'connected' as const,
+    sessions: [],
+    activeSessionId: null,
+    createSession: vi.fn(createSession),
+  })
+
+  function openCreateViaWelcome() {
+    fireEvent.click(screen.getByTestId('welcome-new-session'))
+    expect(screen.getByTestId('create-session-modal-mock')).toBeInTheDocument()
+  }
+
+  it('(a) clears the spinner and surfaces a retryable error when the socket drops mid-create', () => {
+    stateOverrides = freshConnectedState(() => true)
+    const { rerender } = render(<App />)
+    openCreateViaWelcome()
+
+    // Confirm — createSession returned true, so the spinner latches and no
+    // error shows yet (the server reply is still pending).
+    fireEvent.click(screen.getByTestId('create-session-modal-confirm'))
+    expect(screen.getByTestId('create-session-modal-creating')).toBeInTheDocument()
+    expect(screen.queryByTestId('create-session-modal-error')).not.toBeInTheDocument()
+
+    // Socket drops before the server replies: connectionPhase leaves 'connected'
+    // while isCreatingSession is still true. The #6285 effect must clear the
+    // spinner and surface the retryable 'Connection lost' error.
+    stateOverrides = { ...freshConnectedState(() => true), connectionPhase: 'reconnecting' as const }
+    rerender(<App />)
+
+    expect(screen.queryByTestId('create-session-modal-creating')).not.toBeInTheDocument()
+    expect(screen.getByTestId('create-session-modal-error').textContent).toMatch(/Connection lost/i)
+  })
+
+  it('(b) shows the Connection lost error and does NOT latch the spinner when Create is clicked on a closed socket', () => {
+    // createSession returns false (closed-socket no-op). The modal is still
+    // open (it was opened while connected), but the confirm hits the not-sent
+    // else-branch: surface the error, never latch the spinner.
+    stateOverrides = freshConnectedState(() => false)
+    render(<App />)
+    openCreateViaWelcome()
+
+    fireEvent.click(screen.getByTestId('create-session-modal-confirm'))
+
+    expect(screen.queryByTestId('create-session-modal-creating')).not.toBeInTheDocument()
+    expect(screen.getByTestId('create-session-modal-error').textContent).toMatch(/Connection lost/i)
   })
 })
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -459,6 +459,7 @@ export function App() {
   const connect = useConnectionStore(s => s.connect)
   const retryConnection = useConnectionStore(s => s.retryConnection)
   const sendInput = useConnectionStore(s => s.sendInput)
+  const addInfoNotification = useConnectionStore(s => s.addInfoNotification)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
   const sendCancelQueued = useConnectionStore(s => s.sendCancelQueued)
   // #5939: stable cancel callback so the memoized message rows skip re-render.
@@ -1512,7 +1513,15 @@ export function App() {
     const blocks = sid ? pastedTextBlocksRef.current.get(sid) ?? [] : []
     const blockMap = new Map(blocks.map(b => [b.id, b.content]))
     const expanded = blockMap.size > 0 ? expandPasteMarkers(text, blockMap) : text
-    sendInput(expanded, wire.length > 0 ? wire : undefined)
+    const sendResult = sendInput(expanded, wire.length > 0 ? wire : undefined)
+    // #6295 — parity with the mobile app (SessionScreen handleSend): when the
+    // socket is closed the send falls through to the offline queue and returns
+    // 'queued'. Surface a transient info notice so the operator knows the
+    // message will go out on reconnect, rather than seeing a plain "sent"-
+    // looking bubble during the disconnected window.
+    if (sendResult === 'queued') {
+      addInfoNotification('Message queued — will send on reconnect.')
+    }
     // #5780 — sending is an explicit "show me the latest" action: snap the
     // chat to the bottom even if the user had scrolled up before typing.
     setScrollToBottomSignal(n => n + 1)
@@ -1528,7 +1537,7 @@ export function App() {
     setInputDraftValue('')
     setPastedTextBlocks([])
     setInspectedPastedTextId(null)
-  }, [sendInput, fileAttachments, imageAttachments, activeSessionId])
+  }, [sendInput, addInfoNotification, fileAttachments, imageAttachments, activeSessionId])
 
   const handleInterrupt = useCallback(() => {
     sendInterrupt()


### PR DESCRIPTION
Closes #6295
Closes #6301

Part of #6278

## What
- **#6295 — dashboard send-failed visual parity.** `handleSend` now captures `sendInput`'s return value. When it is `'queued'` — the send fell through to the offline queue because the socket was closed (see store `sendInput`, #6283) — the dashboard surfaces a transient info notification ("Message queued — will send on reconnect.") via the existing `addInfoNotification` / Toast path, instead of leaving a plain "sent"-looking bubble during the disconnected window.
- **#6301 — App-layer tests for #6285.** Added `App.test.tsx` cases for the two #6285 branches that previously had only transitive (store-level) coverage:
  - (a) the socket drops between Create and the server reply (connectionPhase leaves `'connected'` while `isCreatingSession`) → the stranded "Creating…" spinner clears and a retryable error surfaces.
  - (b) clicking Create while disconnected (`createSession` returns `false`) → the "Connection lost" error shows and the spinner does **not** latch.

## Why
On the mobile app, `SessionScreen.handleSend` branches on `result === 'queued'` and tells the user the message is queued. The dashboard caller ignored `sendInput`'s return, so a send during a disconnected window looked successful. This restores parity. The #6285 fix shipped with store-level tests only; these add direct App-layer coverage for both branches.

## Testing
- `addInfoNotification` is the dashboard's existing info-notice mechanism (rendered as a Toast); the queued path reuses it — no new UI.
- New `App.test.tsx` cases reuse the existing harness: `stateOverrides`, the WelcomeScreen New Session opener, and the `create-session-modal` mock (extended to surface `isCreating`/`serverError` as testID nodes).
