### PR TITLE
fix(store-core): correlate queued-reconcile to the owning pending turn

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1673,6 +1673,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     updateActiveSession((ss) => ({
       messages: [...filterThinking(ss.messages), userMsg, thinkingMsg],
       streamingMessageId: 'pending',
+      // #6302 — record WHICH send owns this 'pending' optimistic turn so a later
+      // message_queued only retires it when its clientMessageId matches (the
+      // owner check that protects this turn from another client's broadcast
+      // queued send in a multi-client session).
+      pendingClientMessageId: userMsg.id,
     }));
 
     // Safety net: if no stream_start arrives, clear the pending state for THIS
@@ -1691,6 +1696,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       updateSession(armedSessionId, (s) => ({
         messages: filterThinking(s.messages),
         streamingMessageId: null,
+        pendingClientMessageId: null,
       }));
     }, safetyNetMs);
   },

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2321,6 +2321,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             messages: [...dropGhost(ss.messages), noticeMsg],
             streamingMessageId:
               ss.streamingMessageId === 'pending' ? null : ss.streamingMessageId,
+            // #6302 — clear the pending-turn owner alongside the sentinel so a
+            // stale owner can't mis-gate a later reconcile (parity with the
+            // dashboard's input_conflict teardown).
+            pendingClientMessageId:
+              ss.streamingMessageId === 'pending' ? null : ss.pendingClientMessageId,
           }));
         } else {
           get().addMessage(noticeMsg);

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2501,8 +2501,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             _ctx.deltaIdRemaps.set(out.remap.from, out.remap.to);
           }
           if (!out.isNewMessage) {
-            // Reuse existing response message (reconnect replay dedup)
-            return { streamingMessageId: out.streamingMessageId };
+            // Reuse existing response message (reconnect replay dedup). #6302 —
+            // the 'pending' sentinel has now been adopted by a real stream id, so
+            // null the faked-fresh-turn owner to keep the invariant (owner is
+            // non-null only while streamingMessageId === 'pending').
+            return { streamingMessageId: out.streamingMessageId, pendingClientMessageId: null };
           }
           // #5938 — insert the new assistant message BEFORE any trailing queued
           // follow-up bubbles. A message queued during the pending window (before
@@ -2520,6 +2523,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           while (insertAt > 0 && queuedIdSet.has(base[insertAt - 1].id)) insertAt--;
           return {
             streamingMessageId: out.streamingMessageId,
+            // #6302 — real id adopts the turn; clear the faked-fresh-turn owner.
+            pendingClientMessageId: null,
             messages: [...base.slice(0, insertAt), out.newMessage!, ...base.slice(insertAt)],
           };
         });
@@ -2673,6 +2678,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // no-ops; the next stream_start will overwrite with the response id.
           if (ss.streamingMessageId === 'pending') {
             patch.streamingMessageId = toolMsg.id;
+            // #6302 — a tool-led turn just adopted the 'pending' sentinel with a
+            // real id, so clear the faked-fresh-turn owner (it never queued).
+            patch.pendingClientMessageId = null;
           }
           return patch;
         });
@@ -3388,6 +3396,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         updateSession(errSessionId, (ss) => ({
           messages: filterThinking([...ss.messages, errorMsg]),
           streamingMessageId: null,
+          // #6302 — clearing the stream tears down any faked-fresh turn; drop its
+          // owner so a stale id can't linger past the 'pending' window.
+          pendingClientMessageId: null,
         }));
       } else {
         const activeErrId = get().activeSessionId;
@@ -3395,6 +3406,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           updateActiveSession((ss) => ({
             messages: filterThinking([...ss.messages, errorMsg]),
             streamingMessageId: null,
+            pendingClientMessageId: null,
           }));
         }
         // No session context on app — the error is already surfaced via

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2664,6 +2664,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       updateActiveSession((ss) => ({
         messages: [...filterThinking(ss.messages), userMsg, thinkingMsg],
         streamingMessageId: 'pending',
+        // #6302 — record WHICH send owns this 'pending' optimistic turn so a later
+        // message_queued only retires it when its clientMessageId matches (the
+        // owner check that protects this turn from another client's broadcast
+        // queued send in a multi-client session). Flat-state fallback below has no
+        // per-session owner (legacy PTY mode, single client) so it omits this.
+        pendingClientMessageId: messageId,
       }));
     } else {
       set((state) => ({
@@ -2680,6 +2686,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         updateActiveSession((ss) => ({
           messages: filterThinking(ss.messages),
           streamingMessageId: null,
+          pendingClientMessageId: null,
         }));
       } else {
         set((s) => ({

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1617,6 +1617,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return {
       messages: get().messages,
       streamingMessageId: get().streamingMessageId,
+      // #6302 — the flat-state fallback has no active session, so no optimistic
+      // pending turn owns it.
+      pendingClientMessageId: null,
       claudeReady: get().claudeReady,
       activeModel: get().activeModel,
       permissionMode: get().permissionMode,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2421,6 +2421,9 @@ function handleServerError(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
     updateSession(errSessionId, (ss) => ({
       messages: filterThinking([...ss.messages, errorMsg]),
       streamingMessageId: null,
+      // #6302 — clear the pending-turn owner with the sentinel (parity with the
+      // app's server_error clear) so a stale owner can't mis-gate a reconcile.
+      pendingClientMessageId: null,
     }));
   } else {
     const activeErrId = get().activeSessionId;
@@ -2428,6 +2431,7 @@ function handleServerError(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
       updateActiveSession((ss) => ({
         messages: filterThinking([...ss.messages, errorMsg]),
         streamingMessageId: null,
+        pendingClientMessageId: null,
       }));
     } else {
       set({ streamingMessageId: null });

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1879,11 +1879,15 @@ function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
         _deltaIdRemaps.set(out.remap.from, out.remap.to);
       }
       if (!out.isNewMessage) {
-        // Reuse existing response message (reconnect replay dedup)
-        return { streamingMessageId: out.streamingMessageId };
+        // Reuse existing response message (reconnect replay dedup). #6302 — the
+        // 'pending' sentinel is now adopted by a real stream id, so null the
+        // faked-fresh-turn owner (owner is non-null only while 'pending').
+        return { streamingMessageId: out.streamingMessageId, pendingClientMessageId: null };
       }
       return {
         streamingMessageId: out.streamingMessageId,
+        // #6302 — real id adopts the turn; clear the faked-fresh-turn owner.
+        pendingClientMessageId: null,
         messages: [...filterThinking(ss.messages), out.newMessage!],
       };
     });
@@ -2104,6 +2108,9 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
       // the next stream_start will overwrite with the response id.
       if (ss.streamingMessageId === 'pending') {
         patch.streamingMessageId = toolMsg.id;
+        // #6302 — a tool-led turn just adopted the 'pending' sentinel with a real
+        // id, so clear the faked-fresh-turn owner (it never queued).
+        patch.pendingClientMessageId = null;
       }
       // #4308 — track the in-flight tool in activeTools[]. Same-reference
       // no-op (dedup by toolUseId) is honoured so a duplicate broadcast
@@ -4060,6 +4067,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           updateSession(conflictSessionId, (ss) => ({
             messages: dropGhost(ss.messages),
             streamingMessageId: ss.streamingMessageId === 'pending' ? null : ss.streamingMessageId,
+            // #6302 — the optimistic turn is being torn down (server rejected the
+            // send); drop its owner alongside the 'pending' sentinel.
+            ...(ss.streamingMessageId === 'pending' ? { pendingClientMessageId: null } : {}),
           }));
         } else {
           // Root-level (CLI single-session) store mode: addUserMessage put the

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -1179,16 +1179,18 @@ describe('shared dispatch table', () => {
       expect(env.sessions.s1.queuedMessages).toEqual([])
     })
 
-    it('reconciles a faked-fresh turn → clears streamingMessageId + strips thinking bubble in one step (#6291)', () => {
+    it('reconciles a faked-fresh turn → clears streamingMessageId + owner + strips thinking bubble in one step (#6291 / #6302)', () => {
       // The client judged 'not busy', faked a fresh working turn (a 'thinking'
-      // bubble + streamingMessageId: 'pending') for uin-1; the server queues it
-      // instead. The message_queued must retire that optimistic turn in the SAME
-      // state update that confirms the queued entry — not 5s later.
+      // bubble + streamingMessageId: 'pending', pendingClientMessageId: uin-1) for
+      // uin-1; the server queues it instead. The message_queued must retire that
+      // optimistic turn in the SAME state update that confirms the queued entry —
+      // not 5s later.
       const env = makeAdapter({
         sessions: {
           s1: {
             sessionId: 's1',
             streamingMessageId: 'pending',
+            pendingClientMessageId: 'uin-1',
             messages: [
               { id: 'uin-1', type: 'user_input', content: 'hi', timestamp: 0 },
               { id: 'thinking', type: 'thinking', content: '', timestamp: 0 },
@@ -1199,11 +1201,43 @@ describe('shared dispatch table', () => {
       })
       dispatch(env, { type: 'message_queued', sessionId: 's1', clientMessageId: 'uin-1', text: 'hi', queueLength: 1 })
       expect(env.sessions.s1.streamingMessageId).toBeNull()
+      expect(env.sessions.s1.pendingClientMessageId).toBeNull()
       expect(env.sessions.s1.messages).toEqual([
         { id: 'uin-1', type: 'user_input', content: 'hi', timestamp: 0 },
       ])
       expect(env.sessions.s1.queuedMessages).toMatchObject([
         { clientMessageId: 'uin-1', text: 'hi', status: 'confirmed' },
+      ])
+    })
+
+    it('#6302 — another client\'s queued send leaves THIS client\'s pending turn intact (owner mismatch)', () => {
+      // Multi-client: this client owns the pending turn for uin-1. A DIFFERENT
+      // client's mid-turn send (uin-2) is broadcast as message_queued. Even though
+      // streamingMessageId is still 'pending', the owner ids differ — so this
+      // client's spinner + thinking bubble must survive; only the queue grows.
+      const env = makeAdapter({
+        sessions: {
+          s1: {
+            sessionId: 's1',
+            streamingMessageId: 'pending',
+            pendingClientMessageId: 'uin-1',
+            messages: [
+              { id: 'uin-1', type: 'user_input', content: 'hi', timestamp: 0 },
+              { id: 'thinking', type: 'thinking', content: '', timestamp: 0 },
+            ],
+            queuedMessages: [],
+          },
+        },
+      })
+      dispatch(env, { type: 'message_queued', sessionId: 's1', clientMessageId: 'uin-2', text: 'theirs', queueLength: 1 })
+      expect(env.sessions.s1.streamingMessageId).toBe('pending')
+      expect(env.sessions.s1.pendingClientMessageId).toBe('uin-1')
+      expect(env.sessions.s1.messages).toEqual([
+        { id: 'uin-1', type: 'user_input', content: 'hi', timestamp: 0 },
+        { id: 'thinking', type: 'thinking', content: '', timestamp: 0 },
+      ])
+      expect(env.sessions.s1.queuedMessages).toMatchObject([
+        { clientMessageId: 'uin-2', text: 'theirs', status: 'confirmed' },
       ])
     })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -172,6 +172,11 @@ export interface DispatchSessionBase {
   // reconcile (#6291). Both clients' real `SessionState` carry it
   // (BaseSessionState).
   streamingMessageId?: string | null
+  // `pendingClientMessageId` — read+cleared alongside streamingMessageId by the
+  // faked-fresh-turn reconcile (#6302): the queued echo only retires the
+  // optimistic turn when its clientMessageId matches this owner. Both clients'
+  // real `SessionState` carry it (BaseSessionState).
+  pendingClientMessageId?: string | null
   conversationId?: string | null
   sessionRules?: PermissionRule[]
   isIdle?: boolean
@@ -1059,14 +1064,22 @@ function dispatchQueuedMessages<S extends DispatchSessionBase>(
         // message_queued confirms the send the server actually queued. This makes
         // the spinner→badge swap happen in one step immediately instead of waiting
         // for the client's 5s stream-stall safety net.
+        // #6302 — thread the pending-turn OWNER so the reconcile fires only for
+        // this client's own optimistic send (queued echo's clientMessageId ===
+        // pendingClientMessageId), not another client's broadcast queued send.
         const turnPatch = builder.reconcileFakedFreshTurn?.({
           streamingMessageId: ss.streamingMessageId ?? null,
           messages: ss.messages,
+          pendingClientMessageId: ss.pendingClientMessageId ?? null,
         })
         if (turnPatch) {
           if ('streamingMessageId' in turnPatch) {
             ;(patch as { streamingMessageId?: string | null }).streamingMessageId =
               turnPatch.streamingMessageId
+          }
+          if ('pendingClientMessageId' in turnPatch) {
+            ;(patch as { pendingClientMessageId?: string | null }).pendingClientMessageId =
+              turnPatch.pendingClientMessageId
           }
           if (turnPatch.messages) {
             ;(patch as { messages?: ChatMessage[] }).messages = turnPatch.messages

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -222,28 +222,34 @@ describe('handleMessageQueued', () => {
   })
 })
 
-describe('handleMessageQueued — faked-fresh-turn reconcile (#6291)', () => {
+describe('handleMessageQueued — faked-fresh-turn reconcile (#6291 / #6302)', () => {
   const userMsg = (id: string): ChatMessage => ({ id, type: 'user_input', content: 'hi', timestamp: 0 })
   const thinkingMsg = (): ChatMessage => ({ id: 'thinking', type: 'thinking', content: '', timestamp: 0 })
 
-  it('clears a pending streamingMessageId and strips the thinking bubble in one step', () => {
+  it('clears a pending streamingMessageId and strips the thinking bubble in one step (owner matches)', () => {
     const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-1', text: 'hi' }, null)!
     const patch = builder.reconcileFakedFreshTurn!({
       streamingMessageId: 'pending',
       messages: [userMsg('uin-1'), thinkingMsg()],
+      pendingClientMessageId: 'uin-1',
     })
-    expect(patch).toEqual({ streamingMessageId: null, messages: [userMsg('uin-1')] })
+    expect(patch).toEqual({
+      streamingMessageId: null,
+      pendingClientMessageId: null,
+      messages: [userMsg('uin-1')],
+    })
   })
 
   it('does NOT strip a real (non-thinking) message when there is no thinking bubble', () => {
     const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-1', text: 'hi' }, null)!
     // streamingMessageId is still the 'pending' sentinel (no stream_start yet) but
-    // the thinking bubble was already removed — clear the id, leave messages alone.
+    // the thinking bubble was already removed — clear the id + owner, leave messages.
     const patch = builder.reconcileFakedFreshTurn!({
       streamingMessageId: 'pending',
       messages: [userMsg('uin-1')],
+      pendingClientMessageId: 'uin-1',
     })
-    expect(patch).toEqual({ streamingMessageId: null })
+    expect(patch).toEqual({ streamingMessageId: null, pendingClientMessageId: null })
     expect(patch).not.toHaveProperty('messages')
   })
 
@@ -253,13 +259,52 @@ describe('handleMessageQueued — faked-fresh-turn reconcile (#6291)', () => {
     const patch = builder.reconcileFakedFreshTurn!({
       streamingMessageId: 'resp-7',
       messages: [userMsg('uin-1'), thinkingMsg()],
+      pendingClientMessageId: 'uin-2',
     })
     expect(patch).toBeNull()
   })
 
   it('is a no-op (null) when nothing is streaming', () => {
     const builder = handleMessageQueued({ sessionId: 's1', text: 'hi' }, null)!
-    expect(builder.reconcileFakedFreshTurn!({ streamingMessageId: null, messages: [] })).toBeNull()
+    expect(
+      builder.reconcileFakedFreshTurn!({ streamingMessageId: null, messages: [], pendingClientMessageId: null }),
+    ).toBeNull()
+  })
+
+  it('#6302 — is a no-op (null) when ANOTHER client\'s queued send arrives (owner mismatch)', () => {
+    // Multi-client: this client faked a fresh turn for uin-1 (it owns the pending
+    // turn). A DIFFERENT client's mid-turn send (uin-2) is broadcast as a
+    // message_queued — even though streamingMessageId is still 'pending', the
+    // owner ids differ, so this client's optimistic turn must stay intact.
+    const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-2', text: 'theirs' }, null)!
+    const patch = builder.reconcileFakedFreshTurn!({
+      streamingMessageId: 'pending',
+      messages: [userMsg('uin-1'), thinkingMsg()],
+      pendingClientMessageId: 'uin-1',
+    })
+    expect(patch).toBeNull()
+  })
+
+  it('#6302 — is a no-op (null) when the queued send has no clientMessageId (uncorrelatable)', () => {
+    // An idless queued send can't be matched to any owner, so it never retires a
+    // faked-fresh turn — even with a 'pending' sentinel outstanding.
+    const builder = handleMessageQueued({ sessionId: 's1', text: 'idless' }, null)!
+    const patch = builder.reconcileFakedFreshTurn!({
+      streamingMessageId: 'pending',
+      messages: [userMsg('uin-1'), thinkingMsg()],
+      pendingClientMessageId: 'uin-1',
+    })
+    expect(patch).toBeNull()
+  })
+
+  it('#6302 — is a no-op (null) when no owner is recorded (pendingClientMessageId null)', () => {
+    const builder = handleMessageQueued({ sessionId: 's1', clientMessageId: 'uin-1', text: 'hi' }, null)!
+    const patch = builder.reconcileFakedFreshTurn!({
+      streamingMessageId: 'pending',
+      messages: [userMsg('uin-1'), thinkingMsg()],
+      pendingClientMessageId: null,
+    })
+    expect(patch).toBeNull()
   })
 
   it('strips ONLY the singleton thinking placeholder, preserving real persisted thinking content', () => {
@@ -271,8 +316,13 @@ describe('handleMessageQueued — faked-fresh-turn reconcile (#6291)', () => {
     const patch = builder.reconcileFakedFreshTurn!({
       streamingMessageId: 'pending',
       messages: [realThinking, userMsg('uin-1'), thinkingMsg()],
+      pendingClientMessageId: 'uin-1',
     })
-    expect(patch).toEqual({ streamingMessageId: null, messages: [realThinking, userMsg('uin-1')] })
+    expect(patch).toEqual({
+      streamingMessageId: null,
+      pendingClientMessageId: null,
+      messages: [realThinking, userMsg('uin-1')],
+    })
   })
 })
 

--- a/packages/store-core/src/handlers/outgoing-queue.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.ts
@@ -37,12 +37,22 @@ import { resolveSessionId } from './_shared'
 export interface FakedFreshTurnState {
   streamingMessageId: string | null
   messages: ChatMessage[]
+  /**
+   * #6302 — the `clientMessageId` that OWNS the current 'pending' optimistic
+   * turn (set by the client alongside `streamingMessageId: 'pending'`). The
+   * reconcile fires ONLY when the incoming `message_queued`'s `clientMessageId`
+   * matches this — so another client's broadcast queued send (an id this client
+   * doesn't own) can never retire this client's own optimistic turn.
+   */
+  pendingClientMessageId: string | null
 }
 
 /** The patch a faked-fresh-turn reconcile produces (omitted fields are unchanged). */
 export interface FakedFreshTurnPatch {
   streamingMessageId?: string | null
   messages?: ChatMessage[]
+  /** #6302 — null the pending-turn owner when the optimistic turn is retired. */
+  pendingClientMessageId?: string | null
 }
 
 /**
@@ -232,9 +242,21 @@ export function handleMessageQueued(
     // (it never sets streamingMessageId to a real clientMessageId before
     // stream_start), so this fires only for a faked-fresh turn — a genuinely live
     // turn carries a real stream id and is left untouched.
-    reconcileFakedFreshTurn: ({ streamingMessageId, messages }) => {
+    //
+    // #6302 — and ONLY for OUR OWN optimistic send: the reconcile fires only when
+    // this `message_queued`'s clientMessageId matches the session's
+    // `pendingClientMessageId` (the id that owns the 'pending' turn). In a
+    // multi-client session another client's mid-turn send is broadcast as a
+    // `message_queued` too; without this owner check that broadcast would clear
+    // THIS client's pending turn early. A 'a user bubble with this id exists'
+    // check is insufficient — mid-turn sends are echoed across clients, so this
+    // client also holds bubbles for other clients' ids. When the queued send has
+    // no clientMessageId at all (legacy/idless), it can't be correlated to any
+    // owner, so it never retires a faked-fresh turn.
+    reconcileFakedFreshTurn: ({ streamingMessageId, messages, pendingClientMessageId }) => {
       if (streamingMessageId !== 'pending') return null
-      const patch: FakedFreshTurnPatch = { streamingMessageId: null }
+      if (!clientMessageId || clientMessageId !== pendingClientMessageId) return null
+      const patch: FakedFreshTurnPatch = { streamingMessageId: null, pendingClientMessageId: null }
       // Strip the optimistic 'thinking' bubble by its singleton id (matching the
       // canonical filterThinking in utils.ts) — NOT by type, which would also
       // delete real persisted thinking content that carries a non-'thinking' id.

--- a/packages/store-core/src/types/session.ts
+++ b/packages/store-core/src/types/session.ts
@@ -310,6 +310,22 @@ export type SessionRole = 'primary' | 'observer' | 'unclaimed';
 export interface BaseSessionState {
   messages: ChatMessage[];
   streamingMessageId: string | null;
+  /**
+   * #6302 — the `clientMessageId` of the send that OWNS the current optimistic
+   * "working" turn (the faked-fresh path that sets `streamingMessageId:
+   * 'pending'` + a `'thinking'` bubble before any `stream_start` arrives). Set
+   * alongside that sentinel and cleared (to null) wherever `streamingMessageId`
+   * leaves `'pending'` — the 5s stream-stall safety net, the faked-fresh-turn
+   * reconcile, a real `stream_start`/`tool_start` adopting a real id.
+   *
+   * Load-bearing in a MULTI-CLIENT session: mid-turn sends are echoed across
+   * clients, so a client holds queued/user bubbles for OTHER clients' ids too.
+   * The faked-fresh-turn reconcile (`reconcileFakedFreshTurn`) must therefore
+   * fire only when an incoming `message_queued`'s `clientMessageId` matches THIS
+   * field — another client's broadcast queued send must not retire this client's
+   * own optimistic turn. Null whenever no faked-fresh turn is outstanding.
+   */
+  pendingClientMessageId: string | null;
   claudeReady: boolean;
   activeModel: string | null;
   permissionMode: string | null;

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -12,6 +12,7 @@ describe('createEmptyBaseSessionState', () => {
     expect(state).toEqual({
       messages: [],
       streamingMessageId: null,
+      pendingClientMessageId: null,
       claudeReady: false,
       activeModel: null,
       permissionMode: null,

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -67,6 +67,7 @@ export function createEmptyBaseSessionState(): BaseSessionState {
   return {
     messages: [],
     streamingMessageId: null,
+    pendingClientMessageId: null,
     claudeReady: false,
     activeModel: null,
     permissionMode: null,


### PR DESCRIPTION
Closes #6302

Part of #6278

## What

`reconcileFakedFreshTurn` (store-core `handlers/outgoing-queue.ts`) cleared this client's optimistic 'pending' turn whenever ANY `message_queued` arrived while `streamingMessageId === 'pending'` — without checking the queued event was THIS client's own optimistic send. In a multi-client session another client's broadcast queued send could retire this client's pending turn early. A "a user bubble with this clientMessageId exists" check is insufficient: mid-turn sends are echoed across clients, so a client holds bubbles for other clients' ids too.

This threads the owning `clientMessageId` onto the pending sentinel so the reconcile fires only for the send that actually owns the turn.

- **Shared type:** `pendingClientMessageId: string | null` added to `BaseSessionState` (and to `createEmptyBaseSessionState` defaults).
- **Both clients set it:** app + dashboard set `pendingClientMessageId` to the send's `clientMessageId` in the faked-fresh path (alongside `streamingMessageId: 'pending'`), and clear it to null wherever the sentinel leaves 'pending' — the 5s stream-stall safety net, the faked-fresh-turn reconcile, a real `stream_start`/`tool_start` adopting a real id, plus the dashboard `input_conflict` teardown and the app `server_error` clear.
- **store-core gate:** `FakedFreshTurnState` carries `pendingClientMessageId`; `reconcileFakedFreshTurn` fires only when the incoming `message_queued`'s `clientMessageId === pendingClientMessageId` (in addition to `streamingMessageId === 'pending'`), nulls the owner when it retires the turn, and keeps the existing strip-by-id 'thinking' singleton behaviour. The dispatch table threads the owner into the reconcile state and applies the owner clear from the patch.

## Why

A different client's queued send (broadcast) must not retire this client's optimistic turn. The owning send still reconciles spinner → "Queued" badge in one step (no 5s wait).

## Testing

- `outgoing-queue.test.ts`: reconcile fires on owner match (clears `streamingMessageId` + `pendingClientMessageId` + strips thinking); NO-OP (null) on owner mismatch / idless queued send / no owner recorded, even with `streamingMessageId === 'pending'`; existing live-stream-id and no-streaming no-ops still pass.
- `dispatch-table.test.ts`: end-to-end dispatch — owner-match retires the turn in one update; another client's queued send leaves this client's pending turn intact while the queue still grows.
- `utils.test.ts`: factory shape updated for the new field.

The new field is client-side optimistic state only (never on the wire), so no protocol/coverage-lint surface is added.