### PR TITLE
fix(dashboard): hoist permission keyboard shortcuts to a single listener (#6287)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -268,7 +268,15 @@ vi.mock('./store/connection', () => {
     return state
   }
   useConnectionStore.getState = () => ({ ...baseState, ...stateOverrides })
-  return { useConnectionStore }
+  // #6287 — useChatKeyboard (mounted by App) calls these rule-eligibility helpers
+  // at render to decide whether the permission shortcut offers allow-for-session.
+  // Stub them false in the smoke harness (real coverage lives in
+  // useChatKeyboard.test.tsx + PermissionPrompt.test.tsx).
+  return {
+    useConnectionStore,
+    isRuleEligibleTool: () => false,
+    isRuleEligibleProvider: () => false,
+  }
 })
 
 // Mock zustand/react/shallow — just pass through the selector

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -58,6 +58,7 @@ import { buildShortcutEntries } from './shortcuts/buildShortcutEntries'
 import { writeText as clipboardWriteText } from './utils/clipboard'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { useTrayBadgeSync } from './hooks/useTrayBadgeSync'
+import { useChatKeyboard } from './hooks/useChatKeyboard'
 import { useTauriMenuWiring } from './hooks/useTauriMenuWiring'
 import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
@@ -1703,6 +1704,21 @@ export function App() {
     if (result !== false) setScrollToBottomSignal(n => n + 1)
     return result
   }, [sendPermissionResponse])
+
+  // #6287 — a SINGLE document-level keyboard listener for the permission
+  // shortcuts, scoped to the FIRST unanswered prompt in the active session.
+  // Replaces the per-instance keydown effect that PermissionPrompt used to
+  // register: with multiple live prompts, Cmd+Y / Cmd+Shift+Y / Escape fired on
+  // EVERY mounted prompt at once, answering all pending requests from one
+  // keystroke (a security hazard). Answering the primary advances to the next.
+  useChatKeyboard({
+    storeMessages,
+    resolvedPermissions,
+    sendPermissionResponse: respondToPermission,
+    activeSessionProvider,
+    availableProviders,
+    connected: connectionPhase === 'connected',
+  })
 
   const respondToUserQuestion = useCallback<typeof sendUserQuestionResponse>((...args) => {
     const result = sendUserQuestionResponse(...args)

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -8,7 +8,6 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { PermissionPrompt } from './PermissionPrompt'
 import { PlanApproval } from './PlanApproval'
-import { Modal } from './Modal'
 import type { PermissionDecision } from '../store/types'
 
 // Mock the store so the component can read `resolvedPermissions[requestId]`
@@ -334,188 +333,6 @@ describe('PermissionPrompt', () => {
     expect(screen.getByText('Allowed')).toBeInTheDocument()
   })
 
-  it('allows with Cmd+Y keyboard shortcut (#1190)', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
-  })
-
-  it('allows with Ctrl+Y keyboard shortcut (#1190)', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', ctrlKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
-  })
-
-  it('denies with Escape keyboard shortcut (#1190)', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'deny')
-  })
-
-  it('allows with Cmd+Shift+Y (caps) keyboard shortcut (#1190)', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'Y', metaKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
-  })
-
-  it('ignores shortcuts when focus is in a textarea (#1190)', () => {
-    const onRespond = vi.fn()
-    render(
-      <div>
-        <textarea data-testid="input" />
-        <PermissionPrompt
-          requestId="req-1"
-          tool="Write"
-          description="test"
-          remainingMs={60000}
-          onRespond={onRespond}
-        />
-      </div>
-    )
-    const textarea = screen.getByTestId('input')
-    textarea.focus()
-    fireEvent.keyDown(textarea, { key: 'y', metaKey: true, bubbles: true })
-    expect(onRespond).not.toHaveBeenCalled()
-  })
-
-  it('ignores shortcuts when focus is in a select (#1190)', () => {
-    const onRespond = vi.fn()
-    render(
-      <div>
-        <select data-testid="model-select"><option>opus</option></select>
-        <PermissionPrompt
-          requestId="req-1"
-          tool="Write"
-          description="test"
-          remainingMs={60000}
-          onRespond={onRespond}
-        />
-      </div>
-    )
-    const sel = screen.getByTestId('model-select')
-    sel.focus()
-    fireEvent.keyDown(sel, { key: 'Escape', bubbles: true })
-    expect(onRespond).not.toHaveBeenCalled()
-  })
-
-  it('does not fire shortcut after already answered (#1190)', () => {
-    // The resolved state now lives in the store (#2833), so simulate the
-    // store update that the parent would normally perform.
-    const onRespond = vi.fn((reqId: string, decision: PermissionDecision) => {
-      mockStoreState.resolvedPermissions = { ...mockStoreState.resolvedPermissions, [reqId]: decision }
-    })
-    const { rerender } = render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.click(screen.getByText('Allow'))
-    rerender(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    onRespond.mockClear()
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onRespond).not.toHaveBeenCalled()
-  })
-
-  it('ignores Escape when a modal overlay is open (#1230)', () => {
-    const onRespond = vi.fn()
-    render(
-      <div>
-        <div data-modal-overlay data-testid="modal-overlay" />
-        <PermissionPrompt
-          requestId="req-1"
-          tool="Write"
-          description="test"
-          remainingMs={60000}
-          onRespond={onRespond}
-        />
-      </div>
-    )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onRespond).not.toHaveBeenCalled()
-  })
-
-  it('still allows Cmd+Y when a modal overlay is open (#1230)', () => {
-    const onRespond = vi.fn()
-    render(
-      <div>
-        <div data-modal-overlay data-testid="modal-overlay" />
-        <PermissionPrompt
-          requestId="req-1"
-          tool="Write"
-          description="test"
-          remainingMs={60000}
-          onRespond={onRespond}
-        />
-      </div>
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
-  })
-
-  it('cleans up keyboard listener on unmount (#1190)', () => {
-    const onRespond = vi.fn()
-    const { unmount } = render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    unmount()
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    expect(onRespond).not.toHaveBeenCalled()
-  })
-
   // #2852: double-click / key-repeat race
   it('ignores a second Allow click while first is in flight (#2852)', () => {
     const onRespond = vi.fn()
@@ -550,23 +367,6 @@ describe('PermissionPrompt', () => {
     fireEvent.click(screen.getByText('Deny'))
     expect(onRespond).toHaveBeenCalledTimes(1)
     expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
-  })
-
-  it('ignores repeated Cmd+Y shortcuts while respond is in flight (#2852)', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    expect(onRespond).toHaveBeenCalledTimes(1)
   })
 
   it('disables all action buttons after first click (#2852)', () => {
@@ -617,116 +417,11 @@ describe('PermissionPrompt', () => {
 
   // #5699 (review): the keyboard shortcuts must ALSO be gated. A disconnected
   // keypress that reached respond() would latch `submitting` and wedge the prompt
-  // permanently (submitting never resets), so it must be a complete no-op.
-  it('ignores keyboard shortcuts while disconnected and does not wedge the prompt (#5699)', () => {
-    mockStoreState.connectionPhase = 'reconnecting'
-    const onRespond = vi.fn()
-    const { rerender } = render(
-      <PermissionPrompt
-        requestId="req-kbd"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })   // Cmd+Y allow
-    fireEvent.keyDown(document, { key: 'Escape' })             // deny
-    expect(onRespond).not.toHaveBeenCalled()
-
-    // Reconnect: the prompt must still be actionable (not wedged on a latched
-    // `submitting`). A keypress now answers for real.
-    mockStoreState.connectionPhase = 'connected'
-    rerender(
-      <PermissionPrompt
-        requestId="req-kbd"
-        tool="Write"
-        description="test"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-kbd', 'allow')
-  })
 })
 
 // ---------------------------------------------------------------------------
 // Integration: Modal + PermissionPrompt Escape interaction (#1241)
 // ---------------------------------------------------------------------------
-describe('Modal + PermissionPrompt integration', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('Escape closes Modal without denying PermissionPrompt (#1241)', () => {
-    const onClose = vi.fn()
-    const onRespond = vi.fn()
-    render(
-      <div>
-        <Modal open={true} onClose={onClose} title="Settings">
-          <p>Modal content</p>
-        </Modal>
-        <PermissionPrompt
-          requestId="req-1"
-          tool="Write"
-          description="test"
-          remainingMs={60000}
-          onRespond={onRespond}
-        />
-      </div>
-    )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onClose).toHaveBeenCalled()
-    expect(onRespond).not.toHaveBeenCalled()
-  })
-
-  it('Escape denies PermissionPrompt when no Modal is open (#1241)', () => {
-    const onRespond = vi.fn()
-    render(
-      <div>
-        <Modal open={false} onClose={vi.fn()} title="Settings">
-          <p>Modal content</p>
-        </Modal>
-        <PermissionPrompt
-          requestId="req-1"
-          tool="Write"
-          description="test"
-          remainingMs={60000}
-          onRespond={onRespond}
-        />
-      </div>
-    )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'deny')
-  })
-
-  it('Cmd+Y allows PermissionPrompt even with Modal open (#1241)', () => {
-    const onClose = vi.fn()
-    const onRespond = vi.fn()
-    render(
-      <div>
-        <Modal open={true} onClose={onClose} title="Settings">
-          <p>Modal content</p>
-        </Modal>
-        <PermissionPrompt
-          requestId="req-1"
-          tool="Write"
-          description="test"
-          remainingMs={60000}
-          onRespond={onRespond}
-        />
-      </div>
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
-  })
-})
-
 describe('PlanApproval', () => {
   it('renders plan content', () => {
     render(
@@ -962,65 +657,6 @@ describe('PermissionPrompt — Allow for Session button (#2834)', () => {
     expect(screen.queryByTestId('btn-allow-session')).not.toBeInTheDocument()
   })
 
-  it('Cmd+Shift+Y triggers allowSession for rule-eligible tools', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Read"
-        description="t"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true, shiftKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowSession')
-  })
-
-  it('Ctrl+Shift+Y triggers allowSession for rule-eligible tools', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Write"
-        description="t"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', ctrlKey: true, shiftKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowSession')
-  })
-
-  it('Cmd+Shift+Y is a no-op for tools that are not rule-eligible', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Bash"
-        description="t"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true, shiftKey: true })
-    expect(onRespond).not.toHaveBeenCalled()
-  })
-
-  it('Cmd+Y (no shift) still triggers allow on rule-eligible tools', () => {
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Read"
-        description="t"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true })
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
-  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1064,23 +700,6 @@ describe('PermissionPrompt — provider capability gate (#3072)', () => {
       />
     )
     expect(screen.queryByTestId('btn-allow-session')).not.toBeInTheDocument()
-  })
-
-  it('Cmd+Shift+Y is a no-op when the provider does not support sessionRules', () => {
-    mockStoreState.sessions = [{ sessionId: 's1', provider: 'codex' }]
-    mockStoreState.availableProviders = [{ name: 'codex', capabilities: { sessionRules: false } }]
-    const onRespond = vi.fn()
-    render(
-      <PermissionPrompt
-        requestId="req-1"
-        tool="Read"
-        description="t"
-        remainingMs={60000}
-        onRespond={onRespond}
-      />
-    )
-    fireEvent.keyDown(document, { key: 'y', metaKey: true, shiftKey: true })
-    expect(onRespond).not.toHaveBeenCalled()
   })
 
   it('coerces a click on a stale allowSession decision to plain allow when provider lacks support', () => {

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -142,36 +142,13 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     onRespond(requestId, effective)
   }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules, connected])
 
-  // Keyboard shortcuts:
-  //   Cmd/Ctrl+Y         -> allow
-  //   Cmd/Ctrl+Shift+Y   -> allowSession (rule-eligible tools only, #2834)
-  //   Escape             -> deny (skipped when a Modal overlay is open, #1230)
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Skip when focus is in an input, textarea, or select
-      const tag = (e.target as HTMLElement)?.tagName
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
-
-      if (e.key.toLowerCase() === 'y' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault()
-        if (e.shiftKey) {
-          // Allow for Session — no-op when the tool is not rule-eligible (#2834)
-          // or the active provider doesn't support session rules (#3072).
-          if (isRuleEligibleTool(tool) && providerSupportsRules) {
-            respond('allowSession')
-          }
-        } else {
-          respond('allow')
-        }
-      } else if (e.key === 'Escape') {
-        // Skip if a modal overlay is open — let Modal handle Escape (#1230)
-        if (document.querySelector('[data-modal-overlay]')) return
-        respond('deny')
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [respond, tool, providerSupportsRules])
+  // #6287 — the Cmd/Ctrl+Y, Cmd/Ctrl+Shift+Y and Escape keyboard shortcuts moved
+  // to a SINGLE document-level listener (useChatKeyboard, wired in App.tsx) that
+  // targets only the FIRST unanswered prompt in the active session. Each
+  // PermissionPrompt previously registered its own keydown listener, so with
+  // multiple live prompts (parallel SDK tool calls) one keystroke answered EVERY
+  // mounted prompt at once — a security hazard. The buttons below still call
+  // `respond` directly.
 
   const isExpired = remaining <= 0
   const isUrgent = remaining > 0 && remaining <= 30000

--- a/packages/dashboard/src/hooks/useChatKeyboard.test.tsx
+++ b/packages/dashboard/src/hooks/useChatKeyboard.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * useChatKeyboard tests — #6287
+ *
+ * The permission keyboard shortcuts (Cmd/Ctrl+Y, Cmd/Ctrl+Shift+Y, Escape) used
+ * to be registered per-PermissionPrompt instance, so with multiple live prompts a
+ * single keystroke fired on EVERY mounted prompt at once — answering all pending
+ * requests (a security hazard). These tests assert the hoisted single listener
+ * targets only the FIRST unanswered prompt in the active session, advances to the
+ * next as prompts are answered, and preserves the input-focus / modal-overlay /
+ * disconnected guards.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { renderHook, cleanup } from '@testing-library/react'
+import type { ChatMessage } from '@chroxy/store-core'
+
+// Keep the heavy store module out of the test — the hook only needs these two
+// pure predicates from it.
+vi.mock('../store/connection', () => ({
+  isRuleEligibleTool: (tool: string) => tool === 'Read' || tool === 'Edit',
+  isRuleEligibleProvider: () => true,
+}))
+
+import { useChatKeyboard, type UseChatKeyboardArgs } from './useChatKeyboard'
+
+afterEach(cleanup)
+
+function promptMsg(id: string, requestId: string, tool: string, answered?: string): ChatMessage {
+  return {
+    id,
+    type: 'prompt',
+    content: `${tool} permission`,
+    timestamp: 0,
+    requestId,
+    tool,
+    expiresAt: Date.now() + 60_000,
+    answered,
+  } as ChatMessage
+}
+
+function baseArgs(over: Partial<UseChatKeyboardArgs> = {}): UseChatKeyboardArgs {
+  return {
+    storeMessages: [],
+    resolvedPermissions: {},
+    sendPermissionResponse: vi.fn(),
+    activeSessionProvider: 'claude-sdk',
+    availableProviders: [],
+    connected: true,
+    ...over,
+  }
+}
+
+function fireKey(init: KeyboardEventInit & { key: string }, target?: EventTarget) {
+  const ev = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+  if (target) Object.defineProperty(ev, 'target', { value: target })
+  document.dispatchEvent(ev)
+  return ev
+}
+
+describe('useChatKeyboard (#6287)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('Cmd+Y answers only the FIRST unanswered prompt, not all live prompts', () => {
+    const send = vi.fn()
+    renderHook(() =>
+      useChatKeyboard(
+        baseArgs({
+          sendPermissionResponse: send,
+          storeMessages: [
+            promptMsg('m1', 'req-1', 'Bash'),
+            promptMsg('m2', 'req-2', 'Bash'),
+          ],
+        }),
+      ),
+    )
+
+    fireKey({ key: 'y', metaKey: true })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('req-1', 'allow')
+  })
+
+  it('skips already-answered / cross-client-resolved prompts when picking the primary', () => {
+    const send = vi.fn()
+    renderHook(() =>
+      useChatKeyboard(
+        baseArgs({
+          sendPermissionResponse: send,
+          resolvedPermissions: { 'req-1': 'allow' },
+          storeMessages: [
+            promptMsg('m1', 'req-1', 'Bash'), // resolved cross-client
+            promptMsg('m2', 'req-2', 'Bash', 'deny'), // answered locally
+            promptMsg('m3', 'req-3', 'Bash'), // <- primary
+          ],
+        }),
+      ),
+    )
+
+    fireKey({ key: 'y', metaKey: true })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('req-3', 'allow')
+  })
+
+  it('Escape denies the primary prompt; Cmd+Shift+Y allows-for-session on rule-eligible tools', () => {
+    const send = vi.fn()
+    const { rerender } = renderHook((args: UseChatKeyboardArgs) => useChatKeyboard(args), {
+      initialProps: baseArgs({
+        sendPermissionResponse: send,
+        storeMessages: [promptMsg('m1', 'req-1', 'Read')],
+      }),
+    })
+
+    fireKey({ key: 'y', metaKey: true, shiftKey: true })
+    expect(send).toHaveBeenLastCalledWith('req-1', 'allowSession')
+
+    // Advance to a fresh primary and deny via Escape.
+    send.mockClear()
+    rerender(
+      baseArgs({
+        sendPermissionResponse: send,
+        storeMessages: [promptMsg('m2', 'req-2', 'Bash')],
+      }),
+    )
+    fireKey({ key: 'Escape' })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('req-2', 'deny')
+  })
+
+  it('coerces Cmd+Shift+Y to plain allow when the tool is not rule-eligible', () => {
+    const send = vi.fn()
+    renderHook(() =>
+      useChatKeyboard(
+        baseArgs({
+          sendPermissionResponse: send,
+          // Bash is not rule-eligible, so allowSession must not fire at all on
+          // the shift path (matching the button's gating).
+          storeMessages: [promptMsg('m1', 'req-1', 'Bash')],
+        }),
+      ),
+    )
+    fireKey({ key: 'y', metaKey: true, shiftKey: true })
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does nothing while disconnected', () => {
+    const send = vi.fn()
+    renderHook(() =>
+      useChatKeyboard(
+        baseArgs({
+          connected: false,
+          sendPermissionResponse: send,
+          storeMessages: [promptMsg('m1', 'req-1', 'Bash')],
+        }),
+      ),
+    )
+    fireKey({ key: 'y', metaKey: true })
+    fireKey({ key: 'Escape' })
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('skips when focus is in an input/textarea/select', () => {
+    const send = vi.fn()
+    renderHook(() =>
+      useChatKeyboard(
+        baseArgs({
+          sendPermissionResponse: send,
+          storeMessages: [promptMsg('m1', 'req-1', 'Bash')],
+        }),
+      ),
+    )
+    const input = document.createElement('input')
+    fireKey({ key: 'y', metaKey: true }, input)
+    fireKey({ key: 'Escape' }, document.createElement('textarea'))
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('Escape is a no-op when a modal overlay is open', () => {
+    const send = vi.fn()
+    const overlay = document.createElement('div')
+    overlay.setAttribute('data-modal-overlay', '')
+    document.body.appendChild(overlay)
+    try {
+      renderHook(() =>
+        useChatKeyboard(
+          baseArgs({
+            sendPermissionResponse: send,
+            storeMessages: [promptMsg('m1', 'req-1', 'Bash')],
+          }),
+        ),
+      )
+      fireKey({ key: 'Escape' })
+      expect(send).not.toHaveBeenCalled()
+    } finally {
+      overlay.remove()
+    }
+  })
+
+  it('does not double-fire on key auto-repeat for the same primary', () => {
+    const send = vi.fn()
+    renderHook(() =>
+      useChatKeyboard(
+        baseArgs({
+          sendPermissionResponse: send,
+          storeMessages: [promptMsg('m1', 'req-1', 'Bash')],
+        }),
+      ),
+    )
+    fireKey({ key: 'y', metaKey: true })
+    fireKey({ key: 'y', metaKey: true })
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows with Ctrl+Y (non-Mac modifier)', () => {
+    const send = vi.fn()
+    renderHook(() =>
+      useChatKeyboard(
+        baseArgs({
+          sendPermissionResponse: send,
+          storeMessages: [promptMsg('m1', 'req-1', 'Bash')],
+        }),
+      ),
+    )
+    fireKey({ key: 'y', ctrlKey: true })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('req-1', 'allow')
+  })
+
+  it('still allows Cmd+Y when a modal overlay is open (the overlay guard is Escape-only, #1230)', () => {
+    const send = vi.fn()
+    const overlay = document.createElement('div')
+    overlay.setAttribute('data-modal-overlay', '')
+    document.body.appendChild(overlay)
+    try {
+      renderHook(() =>
+        useChatKeyboard(
+          baseArgs({
+            sendPermissionResponse: send,
+            storeMessages: [promptMsg('m1', 'req-1', 'Bash')],
+          }),
+        ),
+      )
+      fireKey({ key: 'y', metaKey: true })
+      expect(send).toHaveBeenCalledWith('req-1', 'allow')
+    } finally {
+      overlay.remove()
+    }
+  })
+})

--- a/packages/dashboard/src/hooks/useChatKeyboard.ts
+++ b/packages/dashboard/src/hooks/useChatKeyboard.ts
@@ -1,0 +1,135 @@
+/**
+ * useChatKeyboard (#6287) — a SINGLE document-level keyboard listener for the
+ * permission shortcuts, scoped to the FIRST unanswered permission prompt in the
+ * active session.
+ *
+ * Before this, every mounted `<PermissionPrompt>` registered its own `keydown`
+ * listener (PermissionPrompt.tsx). With more than one live prompt at once
+ * (usePermissionAnnouncer can surface several), Cmd+Y / Cmd+Shift+Y / Escape
+ * fired on EVERY mounted prompt simultaneously — a single keystroke answered
+ * (allowed or denied) every pending request, a security hazard. Hoisting to one
+ * listener that targets only the visible primary prompt fixes the fan-out:
+ * answering the primary advances "first unanswered" to the next, so the operator
+ * walks the queue one keystroke at a time.
+ *
+ * The existing guards are preserved: skip when focus is in an INPUT/TEXTAREA/
+ * SELECT, skip Escape when a modal overlay (`[data-modal-overlay]`) is open, and
+ * only act while connected (sendPermissionResponse refuses to send while the
+ * socket is down, so we never optimistically resolve a prompt the server can't
+ * receive — #5699).
+ */
+import { useEffect, useMemo, useRef } from 'react'
+import type { ChatMessage } from '@chroxy/store-core'
+import { isRuleEligibleTool, isRuleEligibleProvider } from '../store/connection'
+import type { PermissionDecision, ProviderInfo } from '../store/types'
+
+export interface UseChatKeyboardArgs {
+  /** The active session's messages, in render order. */
+  storeMessages: ChatMessage[]
+  /** Cross-client permission decisions keyed by requestId. */
+  resolvedPermissions: Record<string, PermissionDecision> | undefined
+  /** The single choke point that sends the answer (App's respondToPermission). */
+  sendPermissionResponse: (requestId: string, decision: PermissionDecision) => unknown
+  /** Active session provider, used to gate 'allowSession' on rule support. */
+  activeSessionProvider: string | null
+  /** Registered providers, used to resolve `isRuleEligibleProvider`. */
+  availableProviders: ProviderInfo[]
+  /** Whether the socket is connected — shortcuts no-op while disconnected. */
+  connected: boolean
+}
+
+/**
+ * The first unanswered permission prompt in the active session — the SAME
+ * predicate the renderer uses to decide whether to mount an interactive
+ * `<PermissionPrompt>` (`requestId && expiresAt && !answered`), plus the
+ * cross-client `resolvedPermissions` check so a prompt another client already
+ * answered is skipped.
+ */
+function findPrimaryPermissionPrompt(
+  storeMessages: ChatMessage[],
+  resolvedPermissions: Record<string, PermissionDecision> | undefined,
+): { requestId: string; tool: string } | null {
+  for (const m of storeMessages) {
+    if (!m.requestId || !m.expiresAt || m.answered) continue
+    if (resolvedPermissions?.[m.requestId]) continue
+    return { requestId: m.requestId, tool: m.tool || 'Unknown' }
+  }
+  return null
+}
+
+export function useChatKeyboard(args: UseChatKeyboardArgs): void {
+  const {
+    storeMessages,
+    resolvedPermissions,
+    sendPermissionResponse,
+    activeSessionProvider,
+    availableProviders,
+    connected,
+  } = args
+
+  const primary = useMemo(
+    () => findPrimaryPermissionPrompt(storeMessages, resolvedPermissions),
+    [storeMessages, resolvedPermissions],
+  )
+  const providerSupportsRules = isRuleEligibleProvider(activeSessionProvider, availableProviders)
+
+  // Mirror the keys we depend on into refs so the listener reads fresh values
+  // without re-binding on every render (storeMessages re-references on each
+  // streaming delta). One stable listener for the component's lifetime.
+  const stateRef = useRef({ primary, providerSupportsRules, connected, sendPermissionResponse })
+  stateRef.current = { primary, providerSupportsRules, connected, sendPermissionResponse }
+
+  // #6287 — guard against double-fire from key auto-repeat before the store's
+  // answered state flips and `primary` advances. Latched per requestId; cleared
+  // whenever the primary prompt changes (a new one became first-unanswered).
+  const submittedRef = useRef<string | null>(null)
+  useEffect(() => {
+    submittedRef.current = null
+  }, [primary?.requestId])
+
+  useEffect(() => {
+    const respond = (decision: PermissionDecision) => {
+      const { primary: cur, providerSupportsRules: rules, connected: live, sendPermissionResponse: send } = stateRef.current
+      if (!cur || !live) return
+      if (submittedRef.current === cur.requestId) return
+      // Coerce 'allowSession' to plain 'allow' when the tool/provider can't take a
+      // session rule — mirrors PermissionPrompt.respond so keyboard users on an
+      // ineligible prompt still get an Allow-equivalent decision (#2834/#3072).
+      const allowSessionOk = isRuleEligibleTool(cur.tool) && rules
+      const effective: PermissionDecision =
+        decision === 'allowSession' && !allowSessionOk ? 'allow' : decision
+      submittedRef.current = cur.requestId
+      send(cur.requestId, effective)
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Skip when focus is in an input, textarea, or select.
+      const tag = (e.target as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+
+      if (e.key.toLowerCase() === 'y' && (e.metaKey || e.ctrlKey)) {
+        // Only act if there IS a primary prompt to answer.
+        if (!stateRef.current.primary) return
+        e.preventDefault()
+        if (e.shiftKey) {
+          // Allow for Session — no-op when the tool/provider doesn't support
+          // session rules (#2834/#3072), matching the button's gating.
+          const cur = stateRef.current.primary
+          if (cur && isRuleEligibleTool(cur.tool) && stateRef.current.providerSupportsRules) {
+            respond('allowSession')
+          }
+        } else {
+          respond('allow')
+        }
+      } else if (e.key === 'Escape') {
+        if (!stateRef.current.primary) return
+        // Skip if a modal overlay is open — let the Modal handle Escape (#1230).
+        if (document.querySelector('[data-modal-overlay]')) return
+        respond('deny')
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [])
+}


### PR DESCRIPTION
Closes #6287
Part of #6278

## Problem (security)
Each `<PermissionPrompt>` registered its own `document` keydown listener. With more than one live permission prompt at once (parallel SDK tool calls — `usePermissionAnnouncer` can surface several), a single **Cmd+Y / Cmd+Shift+Y / Escape** fired on EVERY mounted prompt simultaneously — one keystroke allowed (or denied) tool requests the user never read.

## Fix
- **`useChatKeyboard`** — one document-level listener (wired in App.tsx) that targets only the **first unanswered prompt** in the active session; answering it advances "first unanswered" to the next, so the operator walks the queue one keystroke at a time. All existing guards preserved: skip when focus is in INPUT/TEXTAREA/SELECT, skip Escape when a modal overlay is open, no-op while disconnected, in-flight/auto-repeat dedup, and `allowSession` rule-eligibility (coerced to plain allow when the tool/provider can't take a rule).
- **PermissionPrompt** — its per-instance keydown effect is removed; the buttons still call `respond` directly.

## Tests
- **`useChatKeyboard.test.tsx`** (10 cases) owns the keyboard semantics: primary-only fan-out, skip-answered/cross-client-resolved, Escape-deny, Cmd+Shift+Y allow-for-session + coerce, disconnected no-op, input-focus skip, modal-overlay Escape no-op, auto-repeat dedup, **Ctrl+Y** variant, and **Cmd+Y still works with a modal open** (the overlay guard is Escape-only).
- **PermissionPrompt.test.tsx** — the 18 obsolete tests that exercised the *removed* per-instance listener are deleted; button/render/shortcut-hint coverage is kept. The App smoke mock stubs the rule-eligibility helpers the hook reads at render.

Verified locally: dashboard `tsc --noEmit` clean; full dashboard vitest green (4038 tests).

## History note
A working implementation lived briefly in the #6300 bundle before being split out for this focused review; recovered from branch history + re-wired onto current main, with the test migration done properly this time.