### PR TITLE
fix(app,dashboard): check wsSend return at side-effecting call sites (#6308)

### DIFF
--- a/packages/app/src/__tests__/store/connection-send-fail-closed.test.ts
+++ b/packages/app/src/__tests__/store/connection-send-fail-closed.test.ts
@@ -1,0 +1,194 @@
+/**
+ * #6308 — closing-socket TOCTOU: wsSend's false return must not be ignored.
+ *
+ * #6293 hardened wsSend to catch the InvalidStateError socket.send() throws when
+ * the socket flips OPEN → CLOSING mid-send over a flaky tunnel, returning `false`
+ * instead of throwing. sendInput was taught to check that (fall back to enqueue),
+ * but four sibling call sites kept reporting success while mutating local state —
+ * a "sent it and nothing happened" silent failure (the durability north star).
+ *
+ * These tests pin the fixed behaviour: when the send throws (modelled by a socket
+ * whose readyState is OPEN but whose send() throws), each action must NOT report a
+ * plain 'sent' and must NOT leave the UI asserting something the server never saw.
+ */
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../utils/haptics', () => ({
+  hapticLight: jest.fn(),
+  hapticMedium: jest.fn(),
+  hapticWarning: jest.fn(),
+  hapticSuccess: jest.fn(),
+}));
+
+import { useConnectionStore } from '../../store/connection';
+import type { SessionState } from '../../store/types';
+
+interface FakeSocket {
+  readyState: number;
+  send: jest.Mock;
+}
+
+const OPEN = 1; // WebSocket.OPEN
+
+/** A socket that passes the readyState===OPEN check but throws on send() —
+ *  the exact TOCTOU #6293/#6308 guard against. The real wsSend catches the throw,
+ *  warns, and returns false. */
+function closingSocket(): FakeSocket {
+  return {
+    readyState: OPEN,
+    send: jest.fn(() => {
+      throw new Error('InvalidStateError: socket is closing');
+    }),
+  };
+}
+
+function liveSocket(): FakeSocket {
+  return { readyState: OPEN, send: jest.fn() };
+}
+
+function seedSession(overrides: Partial<SessionState> = {}): void {
+  const base = {
+    messages: [],
+    queuedMessages: [],
+    streamingMessageId: null,
+    claudeReady: true,
+  } as unknown as SessionState;
+  useConnectionStore.setState({
+    activeSessionId: 'sess-1',
+    sessions: [{ sessionId: 'sess-1', name: 'sess-1', provider: 'claude-sdk' }],
+    sessionStates: { 'sess-1': { ...base, ...overrides } },
+    sessionNotifications: [],
+    socket: null,
+  } as never);
+}
+
+function activeState(): SessionState {
+  return useConnectionStore.getState().sessionStates['sess-1'];
+}
+
+describe('#6308 — sendCancelQueued does not lie on a closing socket', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => { warn = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warn.mockRestore(); });
+
+  it('returns false and preserves the queued entry + bubble when the send throws', () => {
+    const socket = closingSocket();
+    seedSession({
+      messages: [{ id: 'cmid-1', type: 'user_input', content: 'a', timestamp: 1 }],
+      queuedMessages: [{ clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' }],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    const result = useConnectionStore.getState().sendCancelQueued('cmid-1');
+
+    // The send was attempted, but reported failure rather than a phantom 'sent'.
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    // Nothing was optimistically dropped — the server still holds the queued
+    // message, so the bubble + entry must stay so the cancel is retryable and the
+    // turn is not orphaned.
+    expect(activeState().queuedMessages.map((m) => m.clientMessageId)).toEqual(['cmid-1']);
+    expect(activeState().messages.map((m) => m.id)).toEqual(['cmid-1']);
+  });
+
+  it('still drops the entry on a healthy send (happy-path regression guard)', () => {
+    const socket = liveSocket();
+    seedSession({
+      messages: [{ id: 'cmid-1', type: 'user_input', content: 'a', timestamp: 1 }],
+      queuedMessages: [{ clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' }],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    expect(useConnectionStore.getState().sendCancelQueued('cmid-1')).toBe('sent');
+    expect(activeState().queuedMessages).toHaveLength(0);
+    expect(activeState().messages).toHaveLength(0);
+  });
+});
+
+describe('#6308 — sendInterrupt does not report a phantom send on a closing socket', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => { warn = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warn.mockRestore(); });
+
+  it('falls back to the offline queue (returns queued, not sent) when the send throws', () => {
+    const socket = closingSocket();
+    seedSession({
+      streamingMessageId: 'live-1',
+      messages: [{ id: 'live-1', type: 'response', content: '…', timestamp: 1 }],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    const result = useConnectionStore.getState().sendInterrupt();
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    // The interrupt is queueable (5s TTL) — a failed live send routes to the
+    // offline queue so it retries on reconnect, instead of the pre-fix 'sent' lie.
+    expect(result).toBe('queued');
+    expect(result).not.toBe('sent');
+  });
+});
+
+describe('#6308 — sendPermissionResponse does not mark answered on a closing socket', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => { warn = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warn.mockRestore(); });
+
+  it('returns false and leaves the prompt un-answered when the send throws', () => {
+    const socket = closingSocket();
+    seedSession({
+      messages: [{ id: 'p1', type: 'prompt', requestId: 'req-1', tool: 'Read', timestamp: 1 }],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    const result = useConnectionStore.getState().sendPermissionResponse('req-1', 'allow');
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    // The prompt must stay actionable — marking it 'Allowed' while the server never
+    // saw the frame (and auto-denies on timeout) is the #5699 silent-loss symptom.
+    const prompt = activeState().messages.find((m) => m.requestId === 'req-1');
+    expect(prompt?.answered).toBeUndefined();
+  });
+
+  it('marks the prompt answered on a healthy send (happy-path regression guard)', () => {
+    const socket = liveSocket();
+    seedSession({
+      messages: [{ id: 'p1', type: 'prompt', requestId: 'req-1', tool: 'Read', timestamp: 1 }],
+    } as unknown as Partial<SessionState>);
+    useConnectionStore.setState({ socket } as never);
+
+    expect(useConnectionStore.getState().sendPermissionResponse('req-1', 'allow')).toBe('sent');
+    const prompt = activeState().messages.find((m) => m.requestId === 'req-1');
+    expect(prompt?.answered).toBe('allow');
+  });
+});
+
+describe('#6308 — sendUserQuestionResponse does not lie on a closing socket', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => { warn = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warn.mockRestore(); });
+
+  it('returns false when the send throws (answer tied to a live request)', () => {
+    const socket = closingSocket();
+    seedSession();
+    useConnectionStore.setState({ socket } as never);
+
+    const result = useConnectionStore.getState().sendUserQuestionResponse('Option A', 'tool-1');
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+
+  it('returns sent on a healthy send (happy-path regression guard)', () => {
+    const socket = liveSocket();
+    seedSession();
+    useConnectionStore.setState({ socket } as never);
+
+    expect(useConnectionStore.getState().sendUserQuestionResponse('Option A', 'tool-1')).toBe('sent');
+    expect(socket.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1793,8 +1793,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     if (socket && socket.readyState === WebSocket.OPEN) {
       hapticMedium();
-      wsSend(socket, payload);
-      return 'sent';
+      // #6308: the socket can flip OPEN → CLOSING before this synchronous send, so
+      // wsSend can throw and return false. Fall through to the offline queue so the
+      // interrupt retries on reconnect instead of reporting a 'sent' that never
+      // reached the server (the optimistic queue-drop above already matches the
+      // offline path's behaviour).
+      if (wsSend(socket, payload)) return 'sent';
     }
     return enqueueMessage('interrupt', payload);
   },
@@ -1812,6 +1816,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!(socket && socket.readyState === WebSocket.OPEN)) return false;
     const payload: Record<string, unknown> = { type: 'cancel_queued', clientMessageId };
     if (sid) payload.sessionId = sid;
+    hapticLight();
+    // #6308: cancel_queued is NOT offline-queueable, so send BEFORE the optimistic
+    // drop and bail if the socket threw on a closing send (wsSend → false). Dropping
+    // first then failing would strand the server's queued message (it flushes on the
+    // next turn) while the local bubble is already gone — an orphaned turn with no
+    // recovery path. Leaving the bubble in place keeps the cancel retryable.
+    if (!wsSend(socket, payload)) return false;
     if (sid && get().sessionStates[sid]) {
       updateSession(sid, (ss) => ({
         queuedMessages: removeQueuedMessage(ss.queuedMessages ?? [], clientMessageId),
@@ -1821,8 +1832,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         messages: ss.messages.filter((m) => m.id !== clientMessageId),
       }));
     }
-    hapticLight();
-    wsSend(socket, payload);
     return 'sent';
   },
 
@@ -1840,7 +1849,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
     const payload = { type: 'permission_response', requestId, decision: wireDecision };
     if (wireDecision === 'deny') hapticWarning(); else hapticMedium();
-    wsSend(socket, payload);
+    // #6308: the socket can flip OPEN → CLOSING before this synchronous send, so
+    // wsSend can throw and return false. Bail BEFORE marking the prompt answered —
+    // otherwise the UI shows "Allowed"/"Denied" while the server (never having seen
+    // the frame) auto-denies on timeout. Returning false keeps the prompt actionable,
+    // identical to the disconnected guard above (the #5699 contract).
+    if (!wsSend(socket, payload)) return false;
     const result: 'sent' | 'queued' | false = 'sent';
     // #6222: mark the prompt ChatMessage `answered` so the shared pending-count
     // derivation (`isLivePermissionPrompt` keys on `m.answered`) clears. Without
@@ -1932,8 +1946,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // stays actionable and the caller gives clear feedback (the form also gates
     // on connectionPhase in the UI).
     if (!socket || socket.readyState !== WebSocket.OPEN) return false;
-    wsSend(socket, payload);
-    return 'sent';
+    // #6308: the answer is tied to a live pending AskUserQuestion the server expires
+    // on disconnect; like sendPermissionResponse, report failure (not 'sent') when
+    // wsSend throws on a closing socket so the caller leaves the form actionable
+    // rather than marking it answered against a request the server never received.
+    return wsSend(socket, payload) ? 'sent' : false;
   },
 
   markPromptAnswered: (messageId: string, answer: string) => {

--- a/packages/dashboard/src/store/connection-send-fail-closed.test.ts
+++ b/packages/dashboard/src/store/connection-send-fail-closed.test.ts
@@ -1,0 +1,226 @@
+/**
+ * #6308 — closing-socket TOCTOU: wsSend's false return must not be ignored.
+ *
+ * #6293 hardened wsSend to catch the InvalidStateError socket.send() throws when
+ * the socket flips OPEN → CLOSING mid-send over a flaky tunnel, returning `false`
+ * instead of throwing. sendInput was taught to check that (fall back to enqueue),
+ * but four sibling actions kept reporting success while mutating local state — a
+ * "sent it and nothing happened" silent failure (the #6278 durability north star).
+ *
+ * These tests pin the fixed behaviour with a socket whose readyState is OPEN but
+ * whose send() throws (the exact TOCTOU). The real wsSend catches the throw, warns,
+ * and returns false; each action must then NOT report a plain 'sent' nor leave the
+ * UI asserting something the server never received.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { SessionState } from './types'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+/** OPEN socket whose send() throws — models the OPEN→CLOSING TOCTOU window. */
+function closingSocket(): WebSocket {
+  return {
+    send: vi.fn(() => {
+      throw new Error('InvalidStateError: socket is closing')
+    }),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+/** Healthy OPEN socket that records sent frames. */
+function liveSocket(sent: unknown[]): WebSocket {
+  return {
+    send: vi.fn((raw: string) => { try { sent.push(JSON.parse(raw)) } catch { /* noop */ } }),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+const sendCalls = (socket: WebSocket): unknown[][] => (socket.send as unknown as ReturnType<typeof vi.fn>).mock.calls
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('#6308 — dashboard sendCancelQueued', () => {
+  it('returns false and preserves the queued entry + bubble when the send throws', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const socket = closingSocket()
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: {
+        'sess-1': {
+          ...createEmptySessionState(),
+          messages: [{ id: 'cmid-1', type: 'user_input', content: 'a', timestamp: 1 }],
+          queuedMessages: [{ clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' }],
+        } as unknown as SessionState,
+      },
+      socket,
+    } as never)
+
+    const result = useConnectionStore.getState().sendCancelQueued('cmid-1', 'sess-1')
+
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    const ss = useConnectionStore.getState().sessionStates['sess-1']!
+    expect(ss.queuedMessages.map((m) => m.clientMessageId)).toEqual(['cmid-1'])
+    expect(ss.messages.map((m) => m.id)).toEqual(['cmid-1'])
+  })
+
+  it('drops the entry on a healthy send (happy-path regression guard)', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    const socket = liveSocket(sent)
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: {
+        'sess-1': {
+          ...createEmptySessionState(),
+          messages: [{ id: 'cmid-1', type: 'user_input', content: 'a', timestamp: 1 }],
+          queuedMessages: [{ clientMessageId: 'cmid-1', text: 'a', queuedAt: 1, status: 'confirmed' }],
+        } as unknown as SessionState,
+      },
+      socket,
+    } as never)
+
+    expect(useConnectionStore.getState().sendCancelQueued('cmid-1', 'sess-1')).toBe('sent')
+    expect(sent).toHaveLength(1)
+    const ss = useConnectionStore.getState().sessionStates['sess-1']!
+    expect(ss.queuedMessages).toHaveLength(0)
+    expect(ss.messages).toHaveLength(0)
+  })
+})
+
+describe('#6308 — dashboard sendCancelActivity', () => {
+  it('returns false and does NOT mark the node cancelling when the send throws', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const socket = closingSocket()
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: { 'sess-1': createEmptySessionState() },
+      cancellingActivityIds: new Set<string>(),
+      socket,
+    } as never)
+
+    const result = useConnectionStore.getState().sendCancelActivity('act-1', 'sess-1')
+
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    // The node must stay actionable — marking "Cancelling…" with no ack/failure
+    // ever arriving would strand it forever.
+    expect(useConnectionStore.getState().cancellingActivityIds.size).toBe(0)
+  })
+
+  it('marks the node cancelling on a healthy send (happy-path regression guard)', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    const socket = liveSocket(sent)
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: { 'sess-1': createEmptySessionState() },
+      cancellingActivityIds: new Set<string>(),
+      socket,
+    } as never)
+
+    expect(useConnectionStore.getState().sendCancelActivity('act-1', 'sess-1')).toBe('sent')
+    expect(useConnectionStore.getState().cancellingActivityIds.has('sess-1:act-1')).toBe(true)
+  })
+})
+
+describe('#6308 — dashboard sendPermissionResponse', () => {
+  it('returns false and leaves the prompt un-answered when the send throws', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const socket = closingSocket()
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: {
+        'sess-1': {
+          ...createEmptySessionState(),
+          messages: [{ id: 'p1', type: 'prompt', requestId: 'req-1', tool: 'Read', timestamp: 1 }],
+        } as unknown as SessionState,
+      },
+      sessionNotifications: [],
+      socket,
+    } as never)
+
+    const result = useConnectionStore.getState().sendPermissionResponse('req-1', 'allow')
+
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    const ss = useConnectionStore.getState().sessionStates['sess-1']!
+    const prompt = ss.messages.find((m) => m.requestId === 'req-1')
+    expect(prompt?.answered).toBeUndefined()
+  })
+
+  it('marks the prompt answered on a healthy send (happy-path regression guard)', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    const socket = liveSocket(sent)
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: {
+        'sess-1': {
+          ...createEmptySessionState(),
+          messages: [{ id: 'p1', type: 'prompt', requestId: 'req-1', tool: 'Read', timestamp: 1 }],
+        } as unknown as SessionState,
+      },
+      sessionNotifications: [],
+      socket,
+    } as never)
+
+    expect(useConnectionStore.getState().sendPermissionResponse('req-1', 'allow')).toBe('sent')
+    const ss = useConnectionStore.getState().sessionStates['sess-1']!
+    const prompt = ss.messages.find((m) => m.requestId === 'req-1')
+    expect(prompt?.answered).toBe('allow')
+  })
+})
+
+describe('#6308 — dashboard sendInterrupt / sendUserQuestionResponse', () => {
+  it('sendInterrupt does NOT report a plain sent when the send throws', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const socket = closingSocket()
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: {
+        'sess-1': { ...createEmptySessionState(), streamingMessageId: 'live-1' } as unknown as SessionState,
+      },
+      socket,
+    } as never)
+
+    const result = useConnectionStore.getState().sendInterrupt('sess-1')
+
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).not.toBe('sent')
+  })
+
+  it('sendUserQuestionResponse does NOT report a plain sent when the send throws', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const socket = closingSocket()
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: { 'sess-1': createEmptySessionState() },
+      socket,
+    } as never)
+
+    const result = useConnectionStore.getState().sendUserQuestionResponse('Option A', 'tool-1')
+
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).not.toBe('sent')
+  })
+})

--- a/packages/dashboard/src/store/connection-send-fail-closed.test.ts
+++ b/packages/dashboard/src/store/connection-send-fail-closed.test.ts
@@ -206,21 +206,37 @@ describe('#6308 — dashboard sendInterrupt / sendUserQuestionResponse', () => {
     const result = useConnectionStore.getState().sendInterrupt('sess-1')
 
     expect(sendCalls(socket)).toHaveLength(1)
-    expect(result).not.toBe('sent')
+    // interrupt is offline-queueable (5s TTL) — a failed live send falls through
+    // to the queue (retries on reconnect), never the pre-fix phantom 'sent'.
+    expect(result).toBe('queued')
   })
 
-  it('sendUserQuestionResponse does NOT report a plain sent when the send throws', async () => {
+  it('sendUserQuestionResponse falls through to the queue (optimistic flips run) when the send throws', async () => {
     const { useConnectionStore, createEmptySessionState } = await import('./connection')
     const socket = closingSocket()
     useConnectionStore.setState({
       activeSessionId: 'sess-1',
-      sessionStates: { 'sess-1': createEmptySessionState() },
+      sessionStates: {
+        'sess-1': {
+          ...createEmptySessionState(),
+          isIdle: true,
+          activeTools: [{ toolUseId: 'tool-1' }],
+          messages: [{ id: 'tool-1', type: 'tool_use', tool: 'AskUserQuestion', timestamp: 1 }],
+        } as unknown as SessionState,
+      },
       socket,
     } as never)
 
     const result = useConnectionStore.getState().sendUserQuestionResponse('Option A', 'tool-1')
 
     expect(sendCalls(socket)).toHaveLength(1)
-    expect(result).not.toBe('sent')
+    // user_question_response IS offline-queueable in the dashboard, so a failed
+    // live send falls through to the queue rather than reporting a phantom 'sent'.
+    expect(result).toBe('queued')
+    // The optimistic isIdle/activeTools flips run before the send and are kept on
+    // the queue fallback (identical to the offline path; the server reconciles).
+    const ss = useConnectionStore.getState().sessionStates['sess-1']!
+    expect(ss.isIdle).toBe(false)
+    expect(ss.activeTools.find((t) => t.toolUseId === 'tool-1')).toBeUndefined()
   })
 })

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2859,8 +2859,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       }
     }
     if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, payload);
-      return 'sent';
+      // #6308: wsSend can return false on a closing socket (see app sendInterrupt);
+      // fall through to the offline queue so the interrupt retries on reconnect
+      // rather than reporting a 'sent' that never reached the server.
+      if (wsSend(socket, payload)) return 'sent';
     }
     return enqueueMessage('interrupt', payload);
   },
@@ -2880,16 +2882,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const payload: Record<string, unknown> = { type: 'cancel_activity', activityId, requestId };
     if (sid) payload.sessionId = sid;
     if (sid && socket && socket.readyState === WebSocket.OPEN) {
-      // Only mark "cancelling" once the request is genuinely sent — otherwise an
-      // offline send (cancel_activity isn't in QUEUE_TTLS, so enqueue drops it)
-      // would strand the node "Cancelling…" with no ack/failure ever arriving.
+      // #6308: send BEFORE marking the node "cancelling" — wsSend can throw and
+      // return false on a closing socket, and marking first would strand the node
+      // "Cancelling…" with no ack/failure ever arriving (the same hazard the offline
+      // branch below avoids for non-queueable cancel_activity). Only mark once the
+      // frame is genuinely on the wire.
+      if (!wsSend(socket, payload)) return false;
       // Key by `${sessionId}:${activityId}` — activity ids (toolUseIds) are only
       // unique within a session, so a global activityId-only set would let one
       // session's cancel disable/clear another's identically-ided node (#5277).
       const cancelling = new Set(get().cancellingActivityIds);
       cancelling.add(`${sid}:${activityId}`);
       set({ cancellingActivityIds: cancelling });
-      wsSend(socket, payload);
       return 'sent';
     }
     return enqueueMessage('cancel_activity', payload);
@@ -2907,6 +2911,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!(socket && socket.readyState === WebSocket.OPEN)) return false;
     const payload: Record<string, unknown> = { type: 'cancel_queued', clientMessageId };
     if (sid) payload.sessionId = sid;
+    // #6308: cancel_queued is NOT offline-queueable — send BEFORE the optimistic drop
+    // and bail on a closing-socket failure (wsSend → false). Dropping first then
+    // failing would strand the server's queued message (it flushes next turn) while
+    // the local bubble is gone — an orphaned turn. Leaving it keeps the cancel retryable.
+    if (!wsSend(socket, payload)) return false;
     // Optimistically remove from the TARGET session's queue (updateSession, not
     // updateActiveSession) so a future cross-session cancel — `sid` resolved
     // from an explicit sessionId rather than the active one — clears the right
@@ -2920,7 +2929,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         messages: ss.messages.filter((m) => m.id !== clientMessageId),
       }));
     }
-    wsSend(socket, payload);
     return 'sent';
   },
 
@@ -2973,7 +2981,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // (the schema only accepts 'allow' | 'allowAlways' | 'deny').
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
     const payload = { type: 'permission_response', requestId, decision: wireDecision };
-    wsSend(socket, payload);
+    // #6308: the socket can flip OPEN → CLOSING before this synchronous send (wsSend
+    // → false). Bail BEFORE markPermissionResolved/markPromptAnswered — otherwise the
+    // bubble flips to "answered" while the server never saw the frame and auto-denies
+    // on timeout, exactly the #5699 silent-loss symptom this function's disconnected
+    // guard above was written to prevent. Returning false keeps the prompt actionable.
+    if (!wsSend(socket, payload)) return false;
     const result: 'sent' | 'queued' | false = 'sent';
     // Persist the decision in the store so PermissionPrompt renders its
     // answered state across remounts (#2833 — tab switch regression).
@@ -3169,8 +3182,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       });
     }
     if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, payload);
-      return 'sent';
+      // #6308: wsSend can return false on a closing socket; fall through to the
+      // offline queue so the answer retries on reconnect rather than reporting a
+      // 'sent' that never reached the server while the optimistic isIdle/activeTools
+      // flips above already make the form look resolved.
+      if (wsSend(socket, payload)) return 'sent';
     }
     return enqueueMessage('user_question_response', payload);
   },


### PR DESCRIPTION
## What

Gate every **side-effecting** WebSocket send on `wsSend`'s boolean return, so a closing-socket send failure can no longer report success while the UI asserts something the server never received.

## Why

[#6293](https://github.com/blamechris/chroxy/pull/6293) hardened `wsSend` to catch the `InvalidStateError` that `socket.send()` throws when the socket flips `OPEN → CLOSING` mid-send over a flaky tunnel — returning `false` instead of throwing — and taught `sendInput` to fall back to the offline queue on `false`. But its **sibling actions kept ignoring the return**, mutating local state and reporting `'sent'` in the same TOCTOU window. Surfaced by the post-merge durability audit of the [#6278](https://github.com/blamechris/chroxy/issues/6278) merge train. Fails **closed** (no fail-open exposure) but produces silent failures / stuck UI — the durability north star.

## Sites fixed (both clients unless noted)

| Action | Before (on `wsSend === false`) | After |
|---|---|---|
| `sendPermissionResponse` | marked prompt **Allowed/Denied**; server auto-denies on timeout (reopens the #5699 silent-loss) | bail before marking → prompt stays actionable |
| `sendUserQuestionResponse` | caller marked the form answered against a request the server never saw | report failure / fall through to queue |
| `sendInterrupt` | optimistic queue+bubble drop, returned `'sent'` → **orphaned turns** | fall through to the offline queue (retries on reconnect) |
| `sendCancelQueued` | dropped the optimistic bubble, returned `'sent'` → orphan, no recovery | send **before** the drop; bail on failure → bubble stays retryable |
| `sendCancelActivity` *(dashboard)* | node stuck **"Cancelling…"** with no ack/failure | send **before** the `cancelling` mark; bail on failure |

`sendInput` was already correct (the #6293 reference pattern).

## Scope / non-goals

The other ~100 `wsSend` calls are **fire-and-forget requests** (terminal input, status/list/credential ops) where a dropped send produces no false confirmation or stuck state — intentionally left ignoring the boolean. A broader sweep for the same pattern outside the resilience cluster could be a follow-up.

## Tests

New `connection-send-fail-closed.test.ts` in **both** packages: a socket whose `readyState` is `OPEN` but whose `send()` throws drives the real `wsSend → false` path. Each action asserts no phantom `'sent'` and no orphaning mutation, plus a happy-path regression guard.

- app: 7 cases (jest) ✅ · dashboard: 8 cases (vitest) ✅
- full suites green: dashboard **4046/4046**, app **2068/2068**; both type-checks clean.

## Smoke-test impact

None — narrow race, not reproducible without deliberately killing the tunnel mid-action. Safe ahead of tomorrow's smoke pass.

Closes #6308
