### PR TITLE
fix(server): strip primary API_TOKEN from all spawned child process env

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -23,6 +23,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { createLogger } from './logger.js'
+import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 
 // #4453: exponential restart backoff. The first restart still fires at ~1s
 // after the death (no regression on the existing acceptance test); the
@@ -164,12 +165,29 @@ export class MCPClient extends EventEmitter {
     }
   }
 
+  /**
+   * Build the env for the spawned MCP server child. Inherits the operator's
+   * full process env plus any user-configured `_config.env`, then strips the
+   * chroxy-owned daemon secrets (#6311) — the full-authority API_TOKEN must
+   * never reach an MCP server subprocess, which could read it and seize the
+   * daemon. Extracted so the strip is unit-testable without a real spawn.
+   *
+   * @returns {Record<string, string>}
+   */
+  _buildChildEnv() {
+    const env = { ...process.env, ...this._config.env }
+    for (const key of CHROXY_SECRET_DENYLIST) {
+      delete env[key]
+    }
+    return env
+  }
+
   _spawnAndHandshake() {
     this._setState(MCP_STATES.STARTING)
     let child
     try {
       child = spawn(this._config.command, this._config.args, {
-        env: { ...process.env, ...this._config.env },
+        env: this._buildChildEnv(),
         stdio: ['pipe', 'pipe', 'pipe'],
       })
     } catch (err) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -16,6 +16,7 @@ import { CLAUDE_TUI_PTY_SIZE } from '@chroxy/protocol'
 import { stderrIndicatesUnknownResume } from './cli-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
+import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 import { createLogger, loggerForSession, redactSensitive, redactSensitivePreservingEscapes } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
@@ -1587,28 +1588,35 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
-   * Spawn the persistent PTY under node-pty + wait for the TUI to render.
-   * Sets `this._term`, wires onData/onExit handlers, then sleeps for
-   * WARMUP_MS so the TUI's input prompt is ready before the first
-   * sendMessage() writes. Tests stub this method on the prototype to
-   * skip the real spawn.
+   * Build the env object for the spawned claude TUI PTY.
+   *
+   * Unlike the claude-cli path (which goes through buildSpawnEnv('claude')),
+   * the TUI inherits the operator's full shell env (denylist semantics) so
+   * Claude Code tools see the user's environment — but two classes of secret
+   * are stripped:
+   *   - ANTHROPIC_API_KEY: would pin auth to API billing and defeat the whole
+   *     point of this subscription/OAuth provider.
+   *   - CHROXY_SECRET_DENYLIST (API_TOKEN): the full-authority primary bearer
+   *     token must never reach a tool/MCP/subagent the TUI runs (#6311). The
+   *     scoped per-session CHROXY_HOOK_SECRET below is the only chroxy secret
+   *     the child legitimately needs.
+   *
+   * Extracted from _spawnPty so the secret-stripping invariant is unit-testable
+   * without spawning a real PTY.
    *
    * @param {boolean} permissionsEnabled
+   * @returns {Record<string, string>}
    */
-  async _spawnPty(permissionsEnabled) {
-    let ptyMod
-    try {
-      ptyMod = await import('node-pty')
-    } catch (err) {
-      this.emit('error', { message: `node-pty unavailable: ${err.message}` })
-      return
-    }
-
-    const cwdReal = realpathSync(this.cwd)
+  _buildPtyEnv(permissionsEnabled) {
     const env = { ...process.env }
     // The TUI path must route via OAuth subscription. ANTHROPIC_API_KEY would
     // pin auth to API and defeat the whole point of this provider.
     delete env.ANTHROPIC_API_KEY
+    // #6311: strip chroxy-owned daemon secrets (the primary API_TOKEN) so a
+    // tool/MCP/subagent/shell the TUI runs can't read them from process.env.
+    for (const key of CHROXY_SECRET_DENYLIST) {
+      delete env[key]
+    }
     env.TERM = 'xterm-256color'
 
     // permission-hook.sh reads these to phone home to /permission on the
@@ -1633,6 +1641,29 @@ export class ClaudeTuiSession extends BaseSession {
       // none of CHROXY_* env vars are read.
       env.CHROXY_SINK_DIR = this._sinkDir
     }
+    return env
+  }
+
+  /**
+   * Spawn the persistent PTY under node-pty + wait for the TUI to render.
+   * Sets `this._term`, wires onData/onExit handlers, then sleeps for
+   * WARMUP_MS so the TUI's input prompt is ready before the first
+   * sendMessage() writes. Tests stub this method on the prototype to
+   * skip the real spawn.
+   *
+   * @param {boolean} permissionsEnabled
+   */
+  async _spawnPty(permissionsEnabled) {
+    let ptyMod
+    try {
+      ptyMod = await import('node-pty')
+    } catch (err) {
+      this.emit('error', { message: `node-pty unavailable: ${err.message}` })
+      return
+    }
+
+    const cwdReal = realpathSync(this.cwd)
+    const env = this._buildPtyEnv(permissionsEnabled)
 
     // #5307 (WP-0.1) — on a fresh session, set the conversation uuid with
     // `--session-id <id>` (claude requires a brand-new uuid here). On restore,

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -18,6 +18,7 @@ import { realpathSync, existsSync } from 'fs'
 import { USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { createLogger } from './logger.js'
+import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 
 const log = createLogger('user-shell-session')
 
@@ -111,6 +112,24 @@ export class UserShellSession extends BaseSession {
   }
 
   /**
+   * Build the env for the spawned interactive shell PTY. Inherits the operator's
+   * full process env (it IS their shell) with TERM forced, then strips the
+   * chroxy-owned daemon secrets (#6311) — defence in depth so a command, script,
+   * or tool the user runs in the shell can't read the daemon's full-authority
+   * primary bearer token from the environment. Extracted so the strip is
+   * unit-testable without a real PTY spawn.
+   *
+   * @returns {Record<string, string>}
+   */
+  _buildShellEnv() {
+    const env = { ...process.env, TERM: 'xterm-256color' }
+    for (const key of CHROXY_SECRET_DENYLIST) {
+      delete env[key]
+    }
+    return env
+  }
+
+  /**
    * Spawn the shell under node-pty and wire its I/O. Async + rejects on failure
    * so SessionManager's _handleAsyncStartFailure tears down the phantom session
    * (same contract claude-tui relies on).
@@ -134,7 +153,7 @@ export class UserShellSession extends BaseSession {
       // truly unusable. Never default to '/' silently (Tauri/launchd cwd trap).
       cwdReal = this.cwd
     }
-    const env = { ...process.env, TERM: 'xterm-256color' }
+    const env = this._buildShellEnv()
 
     try {
       this._term = ptyMod.spawn(shell, [], {

--- a/packages/server/src/utils/spawn-env.js
+++ b/packages/server/src/utils/spawn-env.js
@@ -7,8 +7,9 @@
  *     (ANTHROPIC_API_KEY, CHROXY_HOOK_SECRET, arbitrary DB creds, etc.) never
  *     leak into their subprocess environment.
  *   - "denylist" mode: the full parent env is forwarded minus a small set of
- *     keys that would be harmful (ANTHROPIC_API_KEY). Used for the Claude CLI
- *     where the user's full environment is expected to be available.
+ *     keys that would be harmful (ANTHROPIC_API_KEY, plus the chroxy-owned
+ *     daemon secrets in CHROXY_SECRET_DENYLIST). Used for the Claude CLI where
+ *     the user's full environment is expected to be available.
  *
  * Centralising the pattern here means future providers get safe-by-default
  * env handling automatically.
@@ -66,6 +67,23 @@ const STANDARD_ALLOWLIST = [
   'https_proxy',
   'no_proxy',
   'all_proxy',
+]
+
+// Chroxy-owned daemon secrets that must NEVER reach any spawned child process,
+// regardless of provider or mode (#6311). API_TOKEN is the full-authority
+// primary bearer token (docs/security/bearer-token-authority.md §1/§3): a tool,
+// MCP server, subagent, or shell command the agent runs could read it from
+// process.env and gain full control of the daemon — every session's history,
+// input, model switching and settings — over the WebSocket/HTTP control surface.
+// The narrowly-scoped per-session CHROXY_HOOK_SECRET is passed explicitly via
+// `extras` instead; it only authorises POST /permission, so it is safe to hand
+// to the child.
+//
+// Allowlist-mode providers (codex, gemini) already exclude these by omission;
+// this set is the belt-and-braces guarantee for denylist-mode providers (claude)
+// and is re-used by the claude-tui PTY spawn path (claude-tui-session.js).
+export const CHROXY_SECRET_DENYLIST = [
+  'API_TOKEN',
 ]
 
 const PROVIDERS = {
@@ -148,9 +166,13 @@ export function buildSpawnEnv(provider, extras = {}) {
     return { ...env, ...extras }
   }
 
-  // denylist mode: start from full parent env, remove sensitive keys
+  // denylist mode: start from full parent env, remove sensitive keys.
+  // #6311: always strip the chroxy-owned daemon secrets in addition to the
+  // provider's own denylist, so the full-authority API_TOKEN never reaches a
+  // denylist-mode child (the parent env is otherwise forwarded wholesale).
+  const effectiveDenylist = [...config.denylist, ...CHROXY_SECRET_DENYLIST]
   const parentEnv = { ...process.env }
-  for (const key of config.denylist) {
+  for (const key of effectiveDenylist) {
     delete parentEnv[key]
   }
   // #3855: inject ONLY this provider's own credential-store keys that the
@@ -159,7 +181,7 @@ export function buildSpawnEnv(provider, extras = {}) {
   // secrets (OPENAI_API_KEY, GEMINI_API_KEY) never leak into this subprocess.
   // ANTHROPIC_API_KEY is excluded from storeInjectKeys AND denylisted, so the
   // CLI keeps using subscription/OAuth auth.
-  const denySet = new Set(config.denylist)
+  const denySet = new Set(effectiveDenylist)
   for (const key of config.storeInjectKeys || []) {
     if (denySet.has(key)) continue
     if (!isKnownCredentialKey(key)) continue

--- a/packages/server/tests/byok-mcp-client.test.js
+++ b/packages/server/tests/byok-mcp-client.test.js
@@ -516,4 +516,38 @@ describe('MCPClient', () => {
       assert.ok(elapsed >= 900 && elapsed <= 2000, `destroy took ${elapsed}ms, expected ~1000ms (SIGTERM grace before SIGKILL)`)
     })
   })
+
+  describe('_buildChildEnv secret stripping (#6311)', () => {
+    it('strips the primary API_TOKEN from the MCP server child env', () => {
+      const prev = process.env.API_TOKEN
+      process.env.API_TOKEN = 'primary-bearer-token'
+      try {
+        const client = new MCPClient(stubConfig({ env: { MY_MCP_OPT: 'keep-me' } }), { log: silentLog() })
+        const env = client._buildChildEnv()
+        assert.equal(env.API_TOKEN, undefined,
+          'the full-authority API_TOKEN must never reach an MCP server subprocess')
+        assert.equal(env.MY_MCP_OPT, 'keep-me',
+          'user-configured _config.env entries are still forwarded')
+        assert.equal(env.PATH, process.env.PATH,
+          'the operator process env still passes through (minus secrets)')
+      } finally {
+        if (prev === undefined) delete process.env.API_TOKEN
+        else process.env.API_TOKEN = prev
+      }
+    })
+
+    it('strips API_TOKEN even when _config.env tries to set it', () => {
+      const prev = process.env.API_TOKEN
+      delete process.env.API_TOKEN
+      try {
+        const client = new MCPClient(stubConfig({ env: { API_TOKEN: 'sneaky' } }), { log: silentLog() })
+        const env = client._buildChildEnv()
+        assert.equal(env.API_TOKEN, undefined,
+          'a reserved chroxy secret name in _config.env is stripped, not honoured')
+      } finally {
+        if (prev === undefined) delete process.env.API_TOKEN
+        else process.env.API_TOKEN = prev
+      }
+    })
+  })
 })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -6989,4 +6989,72 @@ describe('ClaudeTuiSession — monotonic watchdog clocks (#5332)', () => {
     ])
     assert.equal(ready, false, 'loop exits not-ready via the monotonic deadline (did not hang on the frozen wall clock)')
   })
+
+  describe('_buildPtyEnv secret stripping (#6311)', () => {
+    let envSkillsDir
+    let envSession
+
+    beforeEach(() => {
+      envSkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-env-'))
+    })
+
+    afterEach(async () => {
+      if (envSession) {
+        try { await envSession.destroy() } catch { /* ignore */ }
+        envSession = null
+      }
+      if (envSkillsDir) rmSync(envSkillsDir, { recursive: true, force: true })
+      envSkillsDir = null
+    })
+
+    it('strips the primary API_TOKEN from the spawned TUI env', () => {
+      const prev = process.env.API_TOKEN
+      process.env.API_TOKEN = 'primary-bearer-token'
+      try {
+        envSession = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: envSkillsDir, repoSkillsDir: null })
+        const env = envSession._buildPtyEnv(true)
+        assert.equal(env.API_TOKEN, undefined,
+          'the full-authority primary API_TOKEN must never reach a tool/MCP/subagent the TUI runs')
+      } finally {
+        if (prev === undefined) delete process.env.API_TOKEN
+        else process.env.API_TOKEN = prev
+      }
+    })
+
+    it('still strips ANTHROPIC_API_KEY (OAuth-only invariant preserved)', () => {
+      const prev = process.env.ANTHROPIC_API_KEY
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-leak'
+      try {
+        envSession = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: envSkillsDir, repoSkillsDir: null })
+        const env = envSession._buildPtyEnv(true)
+        assert.equal(env.ANTHROPIC_API_KEY, undefined,
+          'ANTHROPIC_API_KEY stays stripped so the TUI keeps using OAuth/subscription auth')
+      } finally {
+        if (prev === undefined) delete process.env.ANTHROPIC_API_KEY
+        else process.env.ANTHROPIC_API_KEY = prev
+      }
+    })
+
+    it('passes the scoped CHROXY_HOOK_SECRET when permissions are enabled', () => {
+      envSession = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: envSkillsDir, repoSkillsDir: null })
+      const env = envSession._buildPtyEnv(true)
+      assert.equal(env.CHROXY_HOOK_SECRET, envSession._hookSecret,
+        'the per-session hook secret is the only chroxy secret the child legitimately needs')
+      assert.equal(env.TERM, 'xterm-256color')
+    })
+
+    it('forwards non-secret operator env (denylist semantics preserved)', () => {
+      const prev = process.env.CHROXY_TUI_ENV_PASSTHROUGH
+      process.env.CHROXY_TUI_ENV_PASSTHROUGH = 'visible-to-tools'
+      try {
+        envSession = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: envSkillsDir, repoSkillsDir: null })
+        const env = envSession._buildPtyEnv(false)
+        assert.equal(env.CHROXY_TUI_ENV_PASSTHROUGH, 'visible-to-tools',
+          'the TUI still inherits the full operator shell env minus secrets')
+      } finally {
+        if (prev === undefined) delete process.env.CHROXY_TUI_ENV_PASSTHROUGH
+        else process.env.CHROXY_TUI_ENV_PASSTHROUGH = prev
+      }
+    })
+  })
 })

--- a/packages/server/tests/spawn-env.test.js
+++ b/packages/server/tests/spawn-env.test.js
@@ -29,6 +29,14 @@ describe('buildSpawnEnv', () => {
       })
     })
 
+    it('strips the primary API_TOKEN from child env (#6311)', () => {
+      withEnv({ API_TOKEN: 'primary-bearer-token', OPENAI_API_KEY: 'sk-openai' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.API_TOKEN, undefined,
+          'the daemon primary bearer token (API_TOKEN) must not leak to codex child')
+      })
+    })
+
     it('passes OPENAI_API_KEY to child env', () => {
       withEnv({ OPENAI_API_KEY: 'sk-openai-123' }, () => {
         const env = buildSpawnEnv('codex')
@@ -106,6 +114,14 @@ describe('buildSpawnEnv', () => {
       })
     })
 
+    it('strips the primary API_TOKEN from child env (#6311)', () => {
+      withEnv({ API_TOKEN: 'primary-bearer-token', GEMINI_API_KEY: 'g' }, () => {
+        const env = buildSpawnEnv('gemini')
+        assert.equal(env.API_TOKEN, undefined,
+          'the daemon primary bearer token (API_TOKEN) must not leak to gemini child')
+      })
+    })
+
     it('passes GEMINI_API_KEY to child env', () => {
       withEnv({ GEMINI_API_KEY: 'gemini-123' }, () => {
         const env = buildSpawnEnv('gemini')
@@ -168,6 +184,25 @@ describe('buildSpawnEnv', () => {
         const env = buildSpawnEnv('claude')
         assert.equal(env.PATH, '/usr/bin')
         assert.equal(env.HOME, '/home/x')
+      })
+    })
+
+    it('strips the primary API_TOKEN even though denylist mode forwards arbitrary keys (#6311)', () => {
+      withEnv({ API_TOKEN: 'primary-bearer-token', CHROXY_TEST_PASSTHROUGH: 'ok' }, () => {
+        const env = buildSpawnEnv('claude')
+        assert.equal(env.API_TOKEN, undefined,
+          'the full-authority primary API_TOKEN must never reach the claude child env')
+        assert.equal(env.CHROXY_TEST_PASSTHROUGH, 'ok',
+          'non-secret operator env still passes through (denylist mode preserved)')
+      })
+    })
+
+    it('keeps the scoped CHROXY_HOOK_SECRET (passed via extras) while stripping API_TOKEN (#6311)', () => {
+      withEnv({ API_TOKEN: 'primary-bearer-token' }, () => {
+        const env = buildSpawnEnv('claude', { CHROXY_HOOK_SECRET: 'scoped-secret' })
+        assert.equal(env.API_TOKEN, undefined, 'primary token stripped')
+        assert.equal(env.CHROXY_HOOK_SECRET, 'scoped-secret',
+          'the scoped per-session hook secret is the only chroxy secret the child should get')
       })
     })
   })

--- a/packages/server/tests/user-shell-session.test.js
+++ b/packages/server/tests/user-shell-session.test.js
@@ -159,4 +159,23 @@ describe('UserShellSession — lifecycle (#5983)', () => {
     s.destroy()
     assert.equal(term._calls.kill.length, 0, 'no SIGTERM — PTY already exited')
   })
+
+  describe('_buildShellEnv secret stripping (#6311)', () => {
+    it('strips the primary API_TOKEN from the shell PTY env', () => {
+      const prev = process.env.API_TOKEN
+      process.env.API_TOKEN = 'primary-bearer-token'
+      try {
+        const s = new UserShellSession({ cwd: '/tmp' })
+        const env = s._buildShellEnv()
+        assert.equal(env.API_TOKEN, undefined,
+          'the full-authority API_TOKEN must never reach the interactive shell env')
+        assert.equal(env.TERM, 'xterm-256color', 'TERM is forced for the PTY')
+        assert.equal(env.PATH, process.env.PATH,
+          'the operator process env still passes through (it is their shell), minus secrets')
+      } finally {
+        if (prev === undefined) delete process.env.API_TOKEN
+        else process.env.API_TOKEN = prev
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #6311 (HIGH): the full-authority primary bearer token (`API_TOKEN`) was forwarded into **every spawned child-process environment** that inherits the daemon's `process.env`, stripped only of `ANTHROPIC_API_KEY`. Any tool / MCP server / subagent / shell command the agent runs — routine on this daemon — could read `process.env.API_TOKEN` and gain full, unscoped control of the daemon (every session's history, input, model switching, settings) over the WebSocket/HTTP surface. Per [`docs/security/bearer-token-authority.md`](docs/security/bearer-token-authority.md) §1/§3 that token grants full session authority; the existing per-session `CHROXY_HOOK_SECRET` scoping was meant to withhold exactly this from the subprocess.

The initial fix covered the two Claude provider paths; review (#6317) found two more spawn sites with the same leak, now folded in. **All four spawn sites are fixed via one single-sourced `CHROXY_SECRET_DENYLIST`.**

## Changes

- **`utils/spawn-env.js`** — new exported `CHROXY_SECRET_DENYLIST` (`API_TOKEN`), always stripped in denylist mode in addition to the provider's own denylist.
- **`claude-tui-session.js`** — extracted `_buildPtyEnv()` (default provider; previously bypassed `buildSpawnEnv`), strips the denylist.
- **`byok-mcp-client.js`** — extracted `_buildChildEnv()` for spawned MCP servers (the exact MCP vector #6311 names); strips `API_TOKEN` even if `config.env` sets the reserved name. **Closes #6318.**
- **`user-shell-session.js`** — extracted `_buildShellEnv()` for the interactive `$SHELL` PTY; defence-in-depth strip. **Closes #6319.**

The scoped `CHROXY_HOOK_SECRET` is still passed through on the Claude paths (permission hook keeps working). Allowlist providers (codex/gemini) already excluded `API_TOKEN` by omission; explicit invariant tests added.

## Tests

Regression tests assert `API_TOKEN` is absent from each env builder while non-secret operator env / user config survive:
- `spawn-env.test.js` — claude denylist + codex/gemini allowlist + `CHROXY_HOOK_SECRET`-via-extras survives.
- `claude-tui-session.test.js` — `_buildPtyEnv` (4 tests).
- `byok-mcp-client.test.js` — `_buildChildEnv` (2 tests, incl. reserved-name override).
- `user-shell-session.test.js` — `_buildShellEnv` (1 test).

## Verification

- Targeted suites green: `spawn-env`+provider-env (66), `claude-tui-session` (300), `byok-mcp-client`+`user-shell-session` (46), related BYOK/user-shell (75). eslint clean on changed src; all 5 custom server lints pass.
- Verified against main @ `0cf5d1937`; each finding confirmed against main before filing.

Closes #6311
Closes #6318
Closes #6319
