### PR TITLE
fix(app,dashboard): notification-prefs setters honor wsSend false return

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -288,11 +288,14 @@ describe('connection.ts — quiet-hours actions (#4544)', () => {
 // Switch revert was the only signal and looked like a misfire. Both the
 // store action and the SettingsScreen banner are covered here.
 describe('connection.ts — notification-prefs WS-closed return values (#4559)', () => {
-  it('setNotificationPrefsCategory returns true after sending and false on the no-op path', () => {
-    // The action body must return `true` once `wsSend(...)` has shipped
-    // the patch and `false` from the fall-through (closed socket).
+  it('setNotificationPrefsCategory gates the optimistic mutation on wsSend and fails closed (#6310)', () => {
+    // #6310: the action must send FIRST and gate on wsSend — `if (!wsSend(...)) return false`
+    // on the closing-socket TOCTOU — THEN apply the optimistic patch and `return true`, with
+    // the outer `return false` for the closed-socket no-op. Pre-#6310 the optimistic `set`
+    // ran before an unchecked `wsSend`, so the toggle reported success on a frame the server
+    // never received (phantom "sent"); this regex now pins the send-gated ordering.
     expect(connectionSource).toMatch(
-      /setNotificationPrefsCategory[\s\S]{0,1400}wsSend\(socket,[\s\S]{0,200}notification_prefs_set[\s\S]{0,300}return true[\s\S]{0,80}return false/,
+      /setNotificationPrefsCategory[\s\S]{0,800}if \(!wsSend\(socket,[\s\S]{0,300}notification_prefs_set[\s\S]{0,300}return false[\s\S]{0,500}return true[\s\S]{0,150}return false/,
     );
   });
 

--- a/packages/app/src/__tests__/store/connection-send-fail-closed.test.ts
+++ b/packages/app/src/__tests__/store/connection-send-fail-closed.test.ts
@@ -192,3 +192,89 @@ describe('#6308 — sendUserQuestionResponse does not lie on a closing socket', 
     expect(socket.send).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('#6310 — notification-prefs setters do not lie on a closing socket', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => { warn = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warn.mockRestore(); });
+
+  function seedPrefs(socket: FakeSocket): void {
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: {},
+        devices: { 'dev-1': { categories: {} } },
+        quietHours: null,
+        bypassCategories: [],
+      },
+    } as never);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prefs = (): any => useConnectionStore.getState().notificationPrefs;
+
+  it('setNotificationPrefsCategory: returns false + no optimistic flip when the send throws', () => {
+    const socket = closingSocket();
+    seedPrefs(socket);
+    const result = useConnectionStore.getState().setNotificationPrefsCategory('push', false);
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    expect(prefs().categories.push).toBeUndefined();
+  });
+
+  it('setNotificationPrefsCategory: applies the optimistic flip on a healthy send', () => {
+    const socket = liveSocket();
+    seedPrefs(socket);
+    expect(useConnectionStore.getState().setNotificationPrefsCategory('push', false)).toBe(true);
+    expect(prefs().categories.push).toBe(false);
+  });
+
+  it('setNotificationPrefsDevice: returns false + no optimistic patch when the send throws', () => {
+    const socket = closingSocket();
+    seedPrefs(socket);
+    const result = useConnectionStore.getState().setNotificationPrefsDevice('dev-1', 'push', false);
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    expect(prefs().devices['dev-1'].categories.push).toBeUndefined();
+  });
+
+  it('deleteNotificationPrefsDevice: returns false + keeps the row when the send throws', () => {
+    const socket = closingSocket();
+    seedPrefs(socket);
+    const result = useConnectionStore.getState().deleteNotificationPrefsDevice('dev-1');
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    expect(prefs().devices['dev-1']).toBeDefined();
+  });
+
+  it('deleteNotificationPrefsDevice: drops the row on a healthy send', () => {
+    const socket = liveSocket();
+    seedPrefs(socket);
+    expect(useConnectionStore.getState().deleteNotificationPrefsDevice('dev-1')).toBe(true);
+    expect(prefs().devices['dev-1']).toBeUndefined();
+  });
+
+  it('setNotificationPrefsQuietHours: returns false + no optimistic set when the send throws', () => {
+    const socket = closingSocket();
+    seedPrefs(socket);
+    const result = useConnectionStore.getState().setNotificationPrefsQuietHours({ start: '22:00', end: '07:00', timezone: 'UTC' });
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    expect(prefs().quietHours).toBeNull();
+  });
+
+  it('setNotificationPrefsBypassCategories: returns false + no optimistic set when the send throws', () => {
+    const socket = closingSocket();
+    seedPrefs(socket);
+    const result = useConnectionStore.getState().setNotificationPrefsBypassCategories(['errors']);
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    expect(prefs().bypassCategories).toEqual([]);
+  });
+
+  it('setNotificationPrefsBypassCategories: applies the list on a healthy send', () => {
+    const socket = liveSocket();
+    seedPrefs(socket);
+    expect(useConnectionStore.getState().setNotificationPrefsBypassCategories(['errors'])).toBe(true);
+    expect(prefs().bypassCategories).toEqual(['errors']);
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -634,6 +634,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setNotificationPrefsCategory: (category: string, enabled: boolean): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: send first and gate the optimistic mutation on wsSend. On the
+      // OPEN→CLOSING TOCTOU window wsSend catches the InvalidStateError and
+      // returns false; mutating then returning true would leave a phantom
+      // "sent" toggle the server never received (fails closed, no local drift).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { categories: { [category]: enabled } },
+      })) return false;
       if (notificationPrefs) {
         set({
           notificationPrefs: {
@@ -642,10 +650,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { categories: { [category]: enabled } },
-      });
       return true;
     }
     return false;
@@ -668,6 +672,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!deviceKey) return false;
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic mutation on the send (closing-socket TOCTOU).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: {
+          devices: {
+            [deviceKey]: { categories: { [category]: enabled } },
+          },
+        },
+      })) return false;
       if (notificationPrefs) {
         const existingDevice = notificationPrefs.devices[deviceKey] ?? {};
         const existingCats = existingDevice.categories ?? {};
@@ -684,14 +697,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: {
-          devices: {
-            [deviceKey]: { categories: { [category]: enabled } },
-          },
-        },
-      });
       return true;
     }
     return false;
@@ -714,6 +719,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!deviceKey) return false;
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic delete on the send (closing-socket TOCTOU) —
+      // an optimistic row removal on a failed send would never reconcile.
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { devices: { [deviceKey]: null } },
+      })) return false;
       if (notificationPrefs) {
         const { [deviceKey]: _removed, ...rest } = notificationPrefs.devices;
         void _removed;
@@ -724,10 +735,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { devices: { [deviceKey]: null } },
-      });
       return true;
     }
     return false;
@@ -743,15 +750,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic mutation on the send (closing-socket TOCTOU).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { quietHours: window },
+      })) return false;
       if (notificationPrefs) {
         set({
           notificationPrefs: { ...notificationPrefs, quietHours: window },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { quietHours: window },
-      });
       return true;
     }
     return false;
@@ -766,15 +774,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setNotificationPrefsBypassCategories: (categories: string[]): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic mutation on the send (closing-socket TOCTOU).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { bypassCategories: categories },
+      })) return false;
       if (notificationPrefs) {
         set({
           notificationPrefs: { ...notificationPrefs, bypassCategories: categories },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { bypassCategories: categories },
-      });
       return true;
     }
     return false;

--- a/packages/dashboard/src/store/connection-send-fail-closed.test.ts
+++ b/packages/dashboard/src/store/connection-send-fail-closed.test.ts
@@ -240,3 +240,78 @@ describe('#6308 — dashboard sendInterrupt / sendUserQuestionResponse', () => {
     expect(ss.activeTools.find((t) => t.toolUseId === 'tool-1')).toBeUndefined()
   })
 })
+
+describe('#6310 — dashboard notification-prefs setters do not lie on a closing socket', () => {
+  const seedPrefs = (store: { setState: (s: never) => void }, socket: WebSocket): void => {
+    store.setState({
+      socket,
+      notificationPrefs: {
+        categories: {},
+        devices: { 'dev-1': { categories: {} } },
+        quietHours: null,
+        bypassCategories: [],
+      },
+    } as never)
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prefs = (store: { getState: () => { notificationPrefs: unknown } }): any => store.getState().notificationPrefs
+
+  it('setNotificationPrefsCategory: returns false + no optimistic flip when the send throws', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = closingSocket()
+    seedPrefs(useConnectionStore, socket)
+    const result = useConnectionStore.getState().setNotificationPrefsCategory('push', false)
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    expect(prefs(useConnectionStore).categories.push).toBeUndefined()
+  })
+
+  it('setNotificationPrefsCategory: applies the optimistic flip on a healthy send', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: unknown[] = []
+    const socket = liveSocket(sent)
+    seedPrefs(useConnectionStore, socket)
+    expect(useConnectionStore.getState().setNotificationPrefsCategory('push', false)).toBe(true)
+    expect(prefs(useConnectionStore).categories.push).toBe(false)
+  })
+
+  it('setNotificationPrefsDevice: returns false + no optimistic patch when the send throws', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = closingSocket()
+    seedPrefs(useConnectionStore, socket)
+    const result = useConnectionStore.getState().setNotificationPrefsDevice('dev-1', 'push', false)
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    expect(prefs(useConnectionStore).devices['dev-1'].categories.push).toBeUndefined()
+  })
+
+  it('deleteNotificationPrefsDevice: returns false + keeps the row when the send throws', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = closingSocket()
+    seedPrefs(useConnectionStore, socket)
+    const result = useConnectionStore.getState().deleteNotificationPrefsDevice('dev-1')
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    expect(prefs(useConnectionStore).devices['dev-1']).toBeDefined()
+  })
+
+  it('setNotificationPrefsQuietHours: returns false + no optimistic set when the send throws', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = closingSocket()
+    seedPrefs(useConnectionStore, socket)
+    const result = useConnectionStore.getState().setNotificationPrefsQuietHours({ start: '22:00', end: '07:00', timezone: 'UTC' })
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    expect(prefs(useConnectionStore).quietHours).toBeNull()
+  })
+
+  it('setNotificationPrefsBypassCategories: returns false + no optimistic set when the send throws', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = closingSocket()
+    seedPrefs(useConnectionStore, socket)
+    const result = useConnectionStore.getState().setNotificationPrefsBypassCategories(['errors'])
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(result).toBe(false)
+    expect(prefs(useConnectionStore).bypassCategories).toEqual([])
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1445,6 +1445,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setNotificationPrefsCategory: (category: string, enabled: boolean): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: send first and gate the optimistic mutation on wsSend. On the
+      // OPEN→CLOSING TOCTOU window wsSend catches the InvalidStateError and
+      // returns false; mutating then returning true would leave a phantom
+      // "sent" toggle the server never received (fails closed, no local drift).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { categories: { [category]: enabled } },
+      })) return false;
       if (notificationPrefs) {
         set({
           notificationPrefs: {
@@ -1453,10 +1461,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { categories: { [category]: enabled } },
-      });
       return true;
     }
     return false;
@@ -1484,6 +1488,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!deviceKey) return false;
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic mutation on the send (closing-socket TOCTOU).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: {
+          devices: {
+            [deviceKey]: { categories: { [category]: enabled } },
+          },
+        },
+      })) return false;
       if (notificationPrefs) {
         const existingDevice = notificationPrefs.devices[deviceKey] ?? {};
         const existingCats = existingDevice.categories ?? {};
@@ -1500,14 +1513,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: {
-          devices: {
-            [deviceKey]: { categories: { [category]: enabled } },
-          },
-        },
-      });
       return true;
     }
     return false;
@@ -1533,6 +1538,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!deviceKey) return false;
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic delete on the send (closing-socket TOCTOU) —
+      // an optimistic row removal on a failed send would never reconcile.
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { devices: { [deviceKey]: null } },
+      })) return false;
       if (notificationPrefs) {
         const { [deviceKey]: _removed, ...rest } = notificationPrefs.devices;
         void _removed;
@@ -1543,10 +1554,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { devices: { [deviceKey]: null } },
-      });
       return true;
     }
     return false;
@@ -1565,15 +1572,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic mutation on the send (closing-socket TOCTOU).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { quietHours: window },
+      })) return false;
       if (notificationPrefs) {
         set({
           notificationPrefs: { ...notificationPrefs, quietHours: window },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { quietHours: window },
-      });
       return true;
     }
     return false;
@@ -1592,15 +1600,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setNotificationPrefsBypassCategories: (categories: string[]): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // #6310: gate the optimistic mutation on the send (closing-socket TOCTOU).
+      if (!wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { bypassCategories: categories },
+      })) return false;
       if (notificationPrefs) {
         set({
           notificationPrefs: { ...notificationPrefs, bypassCategories: categories },
         });
       }
-      wsSend(socket, {
-        type: 'notification_prefs_set',
-        prefs: { bypassCategories: categories },
-      });
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

Closes #6310 — the deferred site from the #6308/#6309 "wsSend false return" sweep.

The notification-prefs setter family on **both** clients (`setNotificationPrefsCategory`, `setNotificationPrefsDevice`, `deleteNotificationPrefsDevice`, `setNotificationPrefsQuietHours`, `setNotificationPrefsBypassCategories`) applied an optimistic `set({ notificationPrefs… })` then called `wsSend(socket, …)` **without checking its boolean return**, then `return true`. On the `OPEN → CLOSING` TOCTOU window `wsSend` (hardened in #6293) catches the `InvalidStateError` and returns `false`, but the setter reported success — the Settings toggle stayed flipped, the "server disconnected" banner (`SettingsScreen.tsx` drives it off this boolean) cleared, and the server never received the change. Silent drift until the next reconnect snapshot. Fails-closed, no security exposure, but a lying UI.

## Fix

Mirror #6309: **send first and gate the optimistic mutation on `wsSend`** — `if (!wsSend(...)) return false` — so a failed send fails closed with no local mutation. Applied identically to the mobile app and the dashboard (the issue flagged the dashboard had the same setter family).

## Tests

- `connection-send-fail-closed.test.ts` (app jest + dashboard vitest): a `wsSend → false` branch per setter asserts `false` is returned and **no** optimistic mutation is applied; happy-path guards assert `true` + the mutation lands.
- Updated the #4559 static-source regex in `SettingsScreenNotificationPrefs.test.ts` to pin the new send-gated ordering (it had encoded the old `set`-before-`wsSend` layout).

## Verification

- Full app suite: 2076 passed. Full dashboard suite: 4052 passed. Both typechecks clean.

Closes #6310
