### PR TITLE
feat(server): boot-time orphan reaper for user-shell PTYs

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -26,6 +26,7 @@ import { createLogger } from './logger.js'
 import { ExternalSessionRegistry } from './external-session-registry.js'
 import { metrics } from './metrics.js'
 import { auditShellDestroy } from './shell-audit.js'
+import { recordShell, forgetShell, reapOrphanShells } from './user-shell-registry.js'
 import { getErrorMessage } from './utils/error-message.js'
 import {
   forwardPerSessionSettingsToProviderOpts,
@@ -235,6 +236,11 @@ export class SessionManager extends EventEmitter {
     // spawn path — WS create, restoreState, and any internal caller — per the
     // #5985 swarm-audit C3 finding.
     userShellEnabled = false,
+    // #6276 test seam: inject {isAlive, commOf, kill} for the boot-time
+    // orphan-shell reaper so the reap+audit path is exercisable without
+    // signalling a real process. Undefined in production → the reaper uses its
+    // own defaults (process.kill / ps).
+    userShellReapSeams = undefined,
     // Shadowed in production (server-cli.js always passes providerType
     // explicitly), but kept on the single source of truth so the fallback
     // can't silently diverge from the server's default (#5819).
@@ -350,6 +356,7 @@ export class SessionManager extends EventEmitter {
     // a truthy non-boolean (`'true'`, `1`) must NOT open the shell gate. Matches
     // isUserShellEnabled()'s strictness; production passes that helper's boolean.
     this._userShellEnabled = userShellEnabled === true
+    this._userShellReapSeams = userShellReapSeams
     this._sweepOrphanWorktrees = !!sweepOrphanWorktrees
     this._providerType = providerType
 
@@ -462,6 +469,9 @@ export class SessionManager extends EventEmitter {
     })
     // Backward-compatible accessors for tests that reference internal state
     this._stateFilePath = this._persistence._stateFilePath
+    // #6276: orphan-shell reaper sidecar, colocated with the state file so a
+    // test's temp stateFilePath keeps it out of the real ~/.chroxy.
+    this._userShellSidecarPath = join(dirname(this._stateFilePath), 'user-shells.json')
     this._stateTtlMs = this._persistence._stateTtlMs
     this._persistDebounceMs = this._persistence._persistDebounceMs
 
@@ -1841,6 +1851,9 @@ export class SessionManager extends EventEmitter {
         exitCode: entry.session._exitCode ?? null,
         reason: entry.session._exitReason ?? 'destroyed',
       })
+      // #6276: a clean teardown SIGTERMs the shell, so drop its orphan-reaper
+      // record — otherwise the next boot would try to reap an already-dead pid.
+      forgetShell(this._userShellSidecarPath, sessionId)
     }
     this.emit('session_destroyed', { sessionId })
     // Flush synchronously so the deletion survives an abrupt shutdown. The
@@ -2115,6 +2128,27 @@ export class SessionManager extends EventEmitter {
    * @returns {string|null} The first restored session ID, or null
    */
   restoreState() {
+    // #6276: reap orphaned user-shell PTYs FIRST — before the no-prior-state
+    // early return below — so it runs on EVERY boot. A SIGKILL/crash skips
+    // destroySession's SIGTERM, leaving a `$SHELL` reparented to init with no
+    // destroy-audit entry; the daemon may have no session state to restore yet
+    // still have a live orphaned shell recorded in the sidecar, so this cannot
+    // hang off state restoration. Runs unconditionally (independent of the
+    // userShell.enabled gate, so a shell from when the feature was enabled is
+    // cleaned up after it's turned off). No-op when the sidecar is absent (the
+    // clean-shutdown case). Best-effort — a reaper hiccup never affects boot.
+    try {
+      const { reaped, skipped } = reapOrphanShells(this._userShellSidecarPath, this._userShellReapSeams)
+      for (const r of reaped) {
+        auditShellDestroy({ sessionId: r.sessionId, exitCode: null, reason: 'orphan_reaper' })
+      }
+      if (reaped.length || skipped.length) {
+        log.warn(`user-shell orphan reaper: reaped=${reaped.length} skipped=${skipped.length}`)
+      }
+    } catch (err) {
+      log.warn(`user-shell orphan reaper failed (non-fatal): ${err?.message || err}`)
+    }
+
     const state = this._persistence.restoreState()
     if (!state) return null
 
@@ -2605,6 +2639,13 @@ export class SessionManager extends EventEmitter {
     // it can't keep the process alive, and re-checks the session still exists
     // (and isn't already tearing down) before destroying.
     if (session.constructor?.isUserShell === true) {
+      // #6276: record the live PTY pid to the orphan-reaper sidecar so a shell
+      // left running by an ungraceful daemon death (SIGKILL/crash, which skips
+      // destroySession's SIGTERM) can be reaped + audited on the next boot. The
+      // matching record is dropped by destroySession on a clean teardown.
+      session.on('shell_spawned', ({ pid } = {}) => {
+        recordShell(this._userShellSidecarPath, { sessionId, pid, shell: session._shellPath })
+      })
       session.on('shell_exited', () => {
         const timer = setTimeout(() => {
           const entry = this._sessions.get(sessionId)

--- a/packages/server/src/user-shell-registry.js
+++ b/packages/server/src/user-shell-registry.js
@@ -1,0 +1,169 @@
+/**
+ * user-shell-registry.js (#6276, epic #5982) — a durable sidecar that records
+ * the OS pid of each live embedded user-shell so a boot-time reaper can clean up
+ * shells orphaned by an ungraceful daemon death.
+ *
+ * Why this exists: a user-shell is a raw `$SHELL` PTY (host RCE over the tunnel).
+ * UserShellSessions are deliberately NEVER persisted across a daemon restart
+ * (session-manager.js — restoring one would re-spawn a shell and bypass the
+ * `userShell.enabled` gate). So on a CLEAN shutdown the shells are SIGTERM'd by
+ * destroySession and nothing leaks. But on a SIGKILL / crash the daemon dies
+ * without running teardown, and its node-pty shell children are reparented to
+ * init — a leaked process with NO `user_shell_destroy` audit entry (the gap this
+ * closes, swarm-audit 2026-06-22 Guardian/Planner).
+ *
+ * The sidecar mirrors the live set: a record is added when a shell spawns and
+ * removed on clean destroy, so after a graceful shutdown the file is empty/absent
+ * and the boot reaper is a no-op. After an ungraceful death the file retains the
+ * last-known shells, which the reaper then reconciles.
+ *
+ * PID-reuse safety: the reaper only signals a recorded pid that is BOTH still
+ * alive AND whose process-command basename still matches the recorded shell
+ * (`ps -p <pid> -o comm=`). A still-alive orphan holds its pid (it can't have
+ * been reused); a reused pid is very unlikely to also be the same shell binary —
+ * so we never SIGTERM an innocent reused pid.
+ *
+ * All I/O is best-effort and the seams (`isAlive`/`commOf`/`kill`) are injectable
+ * so the kill path is unit-testable without spawning or signalling a real
+ * process, and so tests point the sidecar at a temp path (never the real
+ * ~/.chroxy — the test sandbox guard, #4633).
+ */
+import { readFileSync, writeFileSync, renameSync, existsSync, unlinkSync } from 'fs'
+import { execFileSync } from 'child_process'
+import { basename } from 'path'
+import { createLogger } from './logger.js'
+
+const log = createLogger('user-shell-registry')
+
+/**
+ * Read the sidecar. Tolerates a missing or corrupt file (returns `[]`) — a
+ * malformed sidecar must never crash boot or a shell spawn.
+ * @returns {Array<{sessionId: string, pid: number, shell: string|null}>}
+ */
+export function readRegistry(path) {
+  try {
+    if (!existsSync(path)) return []
+    const parsed = JSON.parse(readFileSync(path, 'utf8'))
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((r) => r && typeof r.sessionId === 'string' && Number.isInteger(r.pid) && r.pid > 0)
+  } catch {
+    return []
+  }
+}
+
+function writeRegistry(path, records) {
+  // Atomic replace (tmp + rename) at 0600 — the file names host pids tied to a
+  // privileged capability; match the session-state secrecy posture.
+  const tmp = `${path}.tmp`
+  writeFileSync(tmp, JSON.stringify(records), { mode: 0o600 })
+  renameSync(tmp, path)
+}
+
+/**
+ * Record a freshly-spawned user-shell's pid. Replaces any prior record for the
+ * same sessionId (idempotent on respawn). Best-effort — a write failure is
+ * logged, never thrown (it must not fail the shell spawn).
+ */
+export function recordShell(path, { sessionId, pid, shell } = {}) {
+  if (typeof sessionId !== 'string' || !Number.isInteger(pid) || pid <= 0) return
+  try {
+    const records = readRegistry(path).filter((r) => r.sessionId !== sessionId)
+    records.push({ sessionId, pid, shell: shell ? basename(shell) : null })
+    writeRegistry(path, records)
+  } catch (err) {
+    log.warn(`failed to record user-shell ${sessionId} (non-fatal): ${err?.message || err}`)
+  }
+}
+
+/**
+ * Drop a user-shell's record on clean destroy. Deletes the file once empty so a
+ * graceful shutdown leaves no sidecar for the next boot to scan.
+ */
+export function forgetShell(path, sessionId) {
+  try {
+    const records = readRegistry(path)
+    if (!records.some((r) => r.sessionId === sessionId)) return
+    const next = records.filter((r) => r.sessionId !== sessionId)
+    if (next.length === 0) {
+      if (existsSync(path)) unlinkSync(path)
+    } else {
+      writeRegistry(path, next)
+    }
+  } catch (err) {
+    log.warn(`failed to forget user-shell ${sessionId} (non-fatal): ${err?.message || err}`)
+  }
+}
+
+// Default seams — overridden in tests so the kill path is exercised without
+// signalling a real process.
+function defaultIsAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    // ESRCH = no such process (dead). EPERM = alive but not signallable by us.
+    return err?.code === 'EPERM'
+  }
+}
+
+function defaultCommOf(pid) {
+  try {
+    return execFileSync('ps', ['-p', String(pid), '-o', 'comm='], { encoding: 'utf8' }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+function defaultKill(pid) {
+  try {
+    process.kill(pid, 'SIGTERM')
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Boot-time reap: for each recorded shell, SIGTERM it iff it is still alive AND
+ * its process-command basename matches the recorded shell (the PID-reuse safety
+ * gate). The sidecar is cleared afterwards regardless — this daemon instance
+ * starts fresh and live shells re-record on spawn.
+ *
+ * @returns {{ reaped: Array, skipped: Array }} reaped = signalled orphans (the
+ *   caller emits a destroy-audit entry per item); skipped carries a `why` so the
+ *   reason a record was left alone (dead / comm-mismatch / comm-unknown /
+ *   kill-failed) is observable.
+ */
+export function reapOrphanShells(path, { isAlive = defaultIsAlive, commOf = defaultCommOf, kill = defaultKill } = {}) {
+  const records = readRegistry(path)
+  const reaped = []
+  const skipped = []
+  for (const r of records) {
+    if (!isAlive(r.pid)) {
+      skipped.push({ ...r, why: 'dead' })
+      continue
+    }
+    // PID-reuse safety: never signal a live pid we can't positively identify as
+    // the same shell binary we recorded.
+    if (r.shell) {
+      const comm = commOf(r.pid)
+      const commBase = comm ? basename(comm) : null
+      if (!commBase) {
+        skipped.push({ ...r, why: 'comm-unknown' })
+        continue
+      }
+      if (commBase !== r.shell) {
+        skipped.push({ ...r, why: 'comm-mismatch', comm: commBase })
+        continue
+      }
+    }
+    if (kill(r.pid)) reaped.push(r)
+    else skipped.push({ ...r, why: 'kill-failed' })
+  }
+  try {
+    if (existsSync(path)) unlinkSync(path)
+  } catch {
+    /* best-effort — a leftover sidecar is reconciled on the next boot */
+  }
+  return { reaped, skipped }
+}

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -177,6 +177,11 @@ export class UserShellSession extends BaseSession {
 
     this._shellAlive = true
     log.info(`user-shell spawned (${shell} pid=${this._term.pid} ${this._ptyCols}x${this._ptyRows} cwd=${cwdReal})`)
+    // #6276: announce the live PTY pid so SessionManager can record it to the
+    // orphan-reaper sidecar. Emitted synchronously here (the listener is wired in
+    // _wireSessionEvents before start()) so the pid is durably tracked the moment
+    // the shell exists — the only window where a SIGKILL could orphan it.
+    this.emit('shell_spawned', { pid: this._term.pid })
 
     this._term.onData((data) => this._feedTerminalMirror(data))
     this._term.onExit((info) => this._onShellExit(info, 'exit'))

--- a/packages/server/tests/session-manager-user-shell-gate.test.js
+++ b/packages/server/tests/session-manager-user-shell-gate.test.js
@@ -1,11 +1,13 @@
 import { describe, it, before } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { EventEmitter } from 'events'
 import { SessionManager, UserShellDisabledError } from '../src/session-manager.js'
 import { UserShellSession } from '../src/user-shell-session.js'
+import { readRegistry } from '../src/user-shell-registry.js'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 
 /**
  * #5985 (epic #5982) — the fail-closed gate for the embedded user-shell
@@ -134,6 +136,90 @@ describe('SessionManager user-shell gate (#5985)', () => {
       const id = mgr.createSession({ cwd: '/tmp', provider: 'test-usershell-normal' })
       assert.ok(typeof id === 'string' && id.length > 0, 'a non-shell provider creates normally')
     } finally {
+      cleanup(mgr)
+    }
+  })
+})
+
+describe('SessionManager user-shell orphan reaper (#6276)', () => {
+  const sidecarOf = (mgr) => join(mgr._tmpDir, 'user-shells.json')
+
+  function captureAudit(run) {
+    const lines = []
+    const listener = (e) => { if (e?.level === 'audit') lines.push(e.message) }
+    addLogListener(listener)
+    try { run() } finally { removeLogListener(listener) }
+    return lines
+  }
+
+  it('boot reaper SIGTERMs a matching live orphan and emits an orphan_reaper destroy audit', () => {
+    const killed = []
+    const mgr = makeMgr({
+      userShellReapSeams: { isAlive: () => true, commOf: () => 'zsh', kill: (pid) => { killed.push(pid); return true } },
+    })
+    try {
+      writeFileSync(sidecarOf(mgr), JSON.stringify([{ sessionId: 'orphan-1', pid: 4242, shell: 'zsh' }]))
+      const audit = captureAudit(() => mgr.restoreState())
+      assert.deepEqual(killed, [4242], 'the matching live orphan was SIGTERM-ed')
+      assert.ok(
+        audit.some((m) => m.includes('user_shell_destroy') && m.includes('orphan-1') && m.includes('orphan_reaper')),
+        `expected an orphan_reaper destroy audit, got: ${JSON.stringify(audit)}`,
+      )
+      assert.equal(existsSync(sidecarOf(mgr)), false, 'sidecar cleared after the reap')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('boot reaper does NOT signal (or audit) a reused pid whose comm no longer matches the shell', () => {
+    const killed = []
+    const mgr = makeMgr({
+      userShellReapSeams: { isAlive: () => true, commOf: () => 'postgres', kill: (pid) => { killed.push(pid); return true } },
+    })
+    try {
+      writeFileSync(sidecarOf(mgr), JSON.stringify([{ sessionId: 'reused-1', pid: 4242, shell: 'zsh' }]))
+      const audit = captureAudit(() => mgr.restoreState())
+      assert.deepEqual(killed, [], 'must not signal an innocent reused pid')
+      assert.ok(!audit.some((m) => m.includes('orphan_reaper')), 'no orphan_reaper audit for a skipped record')
+      assert.equal(existsSync(sidecarOf(mgr)), false, 'sidecar still cleared (this instance starts fresh)')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('boot reaper is a no-op when there is no sidecar (clean-shutdown case)', () => {
+    const mgr = makeMgr()
+    try {
+      assert.equal(existsSync(sidecarOf(mgr)), false)
+      const audit = captureAudit(() => mgr.restoreState())
+      assert.ok(!audit.some((m) => m.includes('orphan_reaper')), 'no reaper audit without a sidecar')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('records a shell on spawn and forgets it on clean destroy (record/forget wiring)', () => {
+    const origStart = UserShellSession.prototype.start
+    UserShellSession.prototype.start = async function () {
+      this._term = { pid: 54321, kill: () => {}, write: () => {}, onData: () => {}, onExit: () => {}, on: () => {} }
+      this._shellAlive = true
+      this.emit('shell_spawned', { pid: 54321 })
+    }
+    const mgr = makeMgr({ userShellEnabled: true })
+    try {
+      const id = mgr.createSession({ cwd: '/tmp', provider: 'user-shell' })
+      assert.deepEqual(
+        readRegistry(sidecarOf(mgr)).map((r) => ({ sessionId: r.sessionId, pid: r.pid })),
+        [{ sessionId: id, pid: 54321 }],
+        'spawn recorded the pid to the sidecar',
+      )
+      mgr.destroySession(id)
+      assert.equal(
+        readRegistry(sidecarOf(mgr)).some((r) => r.sessionId === id), false,
+        'clean destroy dropped the record',
+      )
+    } finally {
+      UserShellSession.prototype.start = origStart
       cleanup(mgr)
     }
   })

--- a/packages/server/tests/user-shell-registry.test.js
+++ b/packages/server/tests/user-shell-registry.test.js
@@ -1,0 +1,153 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { readRegistry, recordShell, forgetShell, reapOrphanShells } from '../src/user-shell-registry.js'
+
+describe('user-shell-registry (#6276)', () => {
+  let dir
+  let sidecar
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-ush-reg-'))
+    sidecar = join(dir, 'user-shells.json')
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  describe('record / forget', () => {
+    it('records a shell and reads it back (shell stored as basename only)', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 4242, shell: '/bin/zsh' })
+      assert.deepEqual(readRegistry(sidecar), [{ sessionId: 's1', pid: 4242, shell: 'zsh' }])
+    })
+
+    it('replaces the record for the same sessionId (idempotent respawn)', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 1, shell: '/bin/zsh' })
+      recordShell(sidecar, { sessionId: 's1', pid: 2, shell: '/bin/zsh' })
+      const recs = readRegistry(sidecar)
+      assert.equal(recs.length, 1)
+      assert.equal(recs[0].pid, 2)
+    })
+
+    it('ignores a record with a non-positive / non-integer pid', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 0, shell: 'zsh' })
+      recordShell(sidecar, { sessionId: 's2', pid: -5, shell: 'zsh' })
+      recordShell(sidecar, { sessionId: 's3', pid: 1.5, shell: 'zsh' })
+      assert.deepEqual(readRegistry(sidecar), [])
+    })
+
+    it('forget removes one record, keeping the others', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 11, shell: 'zsh' })
+      recordShell(sidecar, { sessionId: 's2', pid: 22, shell: 'bash' })
+      forgetShell(sidecar, 's1')
+      assert.deepEqual(readRegistry(sidecar).map((r) => r.sessionId), ['s2'])
+    })
+
+    it('forget deletes the file once empty (clean shutdown leaves no sidecar)', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 11, shell: 'zsh' })
+      forgetShell(sidecar, 's1')
+      assert.equal(existsSync(sidecar), false)
+    })
+
+    it('forget on an unknown sessionId is a no-op', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 11, shell: 'zsh' })
+      forgetShell(sidecar, 'nope')
+      assert.deepEqual(readRegistry(sidecar).map((r) => r.sessionId), ['s1'])
+    })
+  })
+
+  describe('readRegistry tolerates bad input', () => {
+    it('returns [] for a missing file', () => {
+      assert.deepEqual(readRegistry(sidecar), [])
+    })
+    it('returns [] for corrupt JSON', () => {
+      writeFileSync(sidecar, '{not json')
+      assert.deepEqual(readRegistry(sidecar), [])
+    })
+    it('filters out malformed entries', () => {
+      writeFileSync(sidecar, JSON.stringify([
+        { sessionId: 's1', pid: 5, shell: 'zsh' },
+        { pid: 'x' },
+        null,
+        { sessionId: 's2' },
+      ]))
+      assert.deepEqual(readRegistry(sidecar).map((r) => r.sessionId), ['s1'])
+    })
+  })
+
+  describe('reapOrphanShells', () => {
+    const seams = (over = {}) => ({ isAlive: () => true, commOf: () => 'zsh', kill: () => true, ...over })
+
+    it('SIGTERMs a live shell whose comm matches, and reports it reaped', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: '/bin/zsh' })
+      const killed = []
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams({ kill: (pid) => { killed.push(pid); return true } }))
+      assert.deepEqual(killed, [100])
+      assert.equal(reaped.length, 1)
+      assert.equal(reaped[0].sessionId, 's1')
+      assert.equal(skipped.length, 0)
+    })
+
+    it('clears the sidecar after running (this instance starts fresh)', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      reapOrphanShells(sidecar, seams())
+      assert.equal(existsSync(sidecar), false)
+    })
+
+    it('skips a dead pid without killing (never signal a gone process)', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      const killed = []
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams({ isAlive: () => false, kill: (p) => { killed.push(p); return true } }))
+      assert.deepEqual(killed, [])
+      assert.equal(reaped.length, 0)
+      assert.equal(skipped[0].why, 'dead')
+    })
+
+    it('PID-reuse safety: skips a live pid whose comm no longer matches the shell', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      const killed = []
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams({ commOf: () => 'postgres', kill: (p) => { killed.push(p); return true } }))
+      assert.deepEqual(killed, [], 'must NOT signal a reused pid running a different program')
+      assert.equal(reaped.length, 0)
+      assert.equal(skipped[0].why, 'comm-mismatch')
+      assert.equal(skipped[0].comm, 'postgres')
+    })
+
+    it('skips when comm is unknown (cannot positively identify the process)', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams({
+        commOf: () => null,
+        kill: () => { throw new Error('must not attempt to kill an unidentifiable pid') },
+      }))
+      assert.equal(reaped.length, 0)
+      assert.equal(skipped[0].why, 'comm-unknown')
+    })
+
+    it('records a failed kill as skipped, not reaped', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams({ kill: () => false }))
+      assert.equal(reaped.length, 0)
+      assert.equal(skipped[0].why, 'kill-failed')
+    })
+
+    it('matches comm by basename (ps may return a full path)', () => {
+      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: '/opt/homebrew/bin/fish' })
+      const killed = []
+      reapOrphanShells(sidecar, seams({ commOf: () => '/opt/homebrew/bin/fish', kill: (p) => { killed.push(p); return true } }))
+      assert.deepEqual(killed, [100])
+    })
+
+    it('reaps a record with no recorded shell (no comm gate possible) when alive', () => {
+      writeFileSync(sidecar, JSON.stringify([{ sessionId: 's1', pid: 100, shell: null }]))
+      const killed = []
+      const { reaped } = reapOrphanShells(sidecar, seams({ kill: (p) => { killed.push(p); return true } }))
+      assert.deepEqual(killed, [100])
+      assert.equal(reaped.length, 1)
+    })
+
+    it('no sidecar → empty result, no throw', () => {
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams())
+      assert.deepEqual(reaped, [])
+      assert.deepEqual(skipped, [])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #6276 (epic #5982) — the last security-hardening tail before the embedded user-shell feature is declared done.

A user-shell is a raw `$SHELL` PTY (host RCE over the tunnel). On a **clean** shutdown `destroySession` SIGTERMs the shell. But on an **ungraceful** death (SIGKILL/crash) the daemon skips teardown and its node-pty shell child is reparented to init — a **leaked process with no `user_shell_destroy` audit entry** (swarm-audit 2026-06-22 Guardian/Planner).

### Premise correction (verified vs main)
The issue's literal AC ("extend the #5859 state-sweep") doesn't fit: user-shell sessions are **never persisted** (`session-manager.js`, #5983), so there's no boot-state to sweep. The orphan is an **OS-level pid**, not a session entry — so the fix is a durable pid sidecar.

## Design

- **`user-shell-registry.js`** — a sidecar (`user-shells.json`, colocated with the state file so a temp `stateFilePath` keeps it out of real `~/.chroxy`) of `{sessionId, pid, shell}` per live shell. `record` on spawn, `forget` on clean destroy, `reap` on boot.
- **Record point:** `UserShellSession` emits `shell_spawned{pid}` the moment the PTY exists; `SessionManager._wireSessionEvents` records it (the listener is wired before `start()`, so no race).
- **Forget:** `destroySession` drops the record next to the existing destroy-audit, so a clean teardown leaves no sidecar.
- **Reap:** at the **top of `restoreState`** (before the no-prior-state early return) so it runs on **every** boot — a crashed daemon may have a live orphan but no session state. Emits `auditShellDestroy{reason:'orphan_reaper'}` per reap. Runs **unconditionally** (independent of `userShell.enabled`) so a shell from when the feature was on is cleaned up after it's off.

### PID-reuse safety
The reaper SIGTERMs a recorded pid **iff** it is still alive **AND** its `ps -p <pid> -o comm=` basename still matches the recorded shell. A still-alive orphan holds its pid (can't be reused); a reused pid is very unlikely to also be the same shell binary — so an innocent reused pid is **never** signalled. (`isAlive`/`commOf`/`kill` are injectable seams.)

## Tests

- `user-shell-registry.test.js` (18): record/forget/idempotent-respawn, corrupt-sidecar tolerance, and every reap branch — match→kill+reap, dead→skip, **comm-mismatch→skip (PID-reuse safety)**, comm-unknown→skip, kill-failed→skip, basename matching, sidecar-cleared.
- `session-manager-user-shell-gate.test.js` (+4): boot reaper reaps+audits a matching orphan via injected seams; does NOT signal/audit a comm-mismatched reused pid; no-op without a sidecar; record-on-spawn + forget-on-destroy wiring end-to-end.

## Verification

Targeted suites green: registry (18) + user-shell gate (9) + user-shell-session, plus core session-manager + persistence (275) — no regressions. eslint + all 5 custom server lints clean.

⚠️ The actual `process.kill` of a real orphaned shell is exercised only through injected seams (can't signal a real process in CI); the production kill path is a 1-line `process.kill(pid, 'SIGTERM')` gated by the tested identity check.

Closes #6276