### PR TITLE
feat(server): start-time identity gate for the user-shell orphan reaper

### DIFF
--- a/packages/server/src/user-shell-registry.js
+++ b/packages/server/src/user-shell-registry.js
@@ -29,7 +29,15 @@
  * start-time that can't be re-read at reap is skipped (we don't signal a pid we
  * can't positively identify).
  *
- * All I/O is best-effort and the seams (`isAlive`/`commOf`/`kill`) are injectable
+ * Note: `lstart` is wall-clock LOCAL time, so if the host timezone / `LC_TIME`
+ * changes between the daemon incarnation that recorded the shell and the one that
+ * reaps it, the same process can format two different `lstart` strings. That
+ * makes the equality check fail-SAFE: it skips (leaks) a real orphan rather than
+ * ever wrong-killing — the never-signal-an-innocent-pid invariant holds
+ * unconditionally; only reap completeness degrades in that rare case.
+ *
+ * All I/O is best-effort and the seams (`isAlive`/`commOf`/`kill`/`startTimeOf`)
+ * are injectable
  * so the kill path is unit-testable without spawning or signalling a real
  * process, and so tests point the sidecar at a temp path (never the real
  * ~/.chroxy — the test sandbox guard, #4633).
@@ -157,7 +165,7 @@ function defaultKill(pid) {
  * @returns {{ reaped: Array, skipped: Array }} reaped = signalled orphans (the
  *   caller emits a destroy-audit entry per item); skipped carries a `why` so the
  *   reason a record was left alone (dead / comm-mismatch / comm-unknown /
- *   kill-failed) is observable.
+ *   starttime-unknown / starttime-mismatch / kill-failed) is observable.
  */
 export function reapOrphanShells(path, { isAlive = defaultIsAlive, commOf = defaultCommOf, startTimeOf = defaultStartTimeOf, kill = defaultKill } = {}) {
   const records = readRegistry(path)

--- a/packages/server/src/user-shell-registry.js
+++ b/packages/server/src/user-shell-registry.js
@@ -17,11 +17,17 @@
  * and the boot reaper is a no-op. After an ungraceful death the file retains the
  * last-known shells, which the reaper then reconciles.
  *
- * PID-reuse safety: the reaper only signals a recorded pid that is BOTH still
- * alive AND whose process-command basename still matches the recorded shell
- * (`ps -p <pid> -o comm=`). A still-alive orphan holds its pid (it can't have
- * been reused); a reused pid is very unlikely to also be the same shell binary —
- * so we never SIGTERM an innocent reused pid.
+ * PID-reuse safety (#6276 + #6327): the reaper only signals a recorded pid that
+ * is still alive, whose process-command basename still matches the recorded
+ * shell (`ps -p <pid> -o comm=`), AND whose OS process start-time (`ps -o
+ * lstart=`, captured at record) is unchanged. comm proves "same program"; the
+ * start-time proves "same process incarnation" — a recycled pid (the orphan
+ * exited and the OS reused its pid onto a fresh same-binary shell) has a strictly
+ * later lstart, so the equality check closes that same-binary reuse window
+ * deterministically. A record with no captured start-time (ps unavailable at
+ * spawn, or a legacy record) falls back to the comm-only gate; a record WITH a
+ * start-time that can't be re-read at reap is skipped (we don't signal a pid we
+ * can't positively identify).
  *
  * All I/O is best-effort and the seams (`isAlive`/`commOf`/`kill`) are injectable
  * so the kill path is unit-testable without spawning or signalling a real
@@ -64,11 +70,19 @@ function writeRegistry(path, records) {
  * same sessionId (idempotent on respawn). Best-effort — a write failure is
  * logged, never thrown (it must not fail the shell spawn).
  */
-export function recordShell(path, { sessionId, pid, shell } = {}) {
+export function recordShell(path, { sessionId, pid, shell } = {}, { startTimeOf = defaultStartTimeOf } = {}) {
   if (typeof sessionId !== 'string' || !Number.isInteger(pid) || pid <= 0) return
   try {
+    // #6327: capture the OS process start-time so the boot reaper can prove
+    // "same process incarnation", not just "same shell binary" — a recycled pid
+    // reports a strictly later lstart, which closes the same-binary reuse window.
+    const startTime = startTimeOf(pid) || null
+    const record = { sessionId, pid, shell: shell ? basename(shell) : null }
+    // Only persist a start-time when we actually captured one — a null key would
+    // be noise, and its absence is the documented "fall back to comm-only" signal.
+    if (startTime) record.startTime = startTime
     const records = readRegistry(path).filter((r) => r.sessionId !== sessionId)
-    records.push({ sessionId, pid, shell: shell ? basename(shell) : null })
+    records.push(record)
     writeRegistry(path, records)
   } catch (err) {
     log.warn(`failed to record user-shell ${sessionId} (non-fatal): ${err?.message || err}`)
@@ -114,6 +128,17 @@ function defaultCommOf(pid) {
   }
 }
 
+// The process start wall-clock (`lstart`) is fixed for a process's lifetime and
+// differs for a recycled pid's new occupant — so a verbatim string match is a
+// sound "same incarnation" check. Available on both macOS and Linux `ps`.
+function defaultStartTimeOf(pid) {
+  try {
+    return execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], { encoding: 'utf8' }).trim() || null
+  } catch {
+    return null
+  }
+}
+
 function defaultKill(pid) {
   try {
     process.kill(pid, 'SIGTERM')
@@ -134,7 +159,7 @@ function defaultKill(pid) {
  *   reason a record was left alone (dead / comm-mismatch / comm-unknown /
  *   kill-failed) is observable.
  */
-export function reapOrphanShells(path, { isAlive = defaultIsAlive, commOf = defaultCommOf, kill = defaultKill } = {}) {
+export function reapOrphanShells(path, { isAlive = defaultIsAlive, commOf = defaultCommOf, startTimeOf = defaultStartTimeOf, kill = defaultKill } = {}) {
   const records = readRegistry(path)
   const reaped = []
   const skipped = []
@@ -154,6 +179,22 @@ export function reapOrphanShells(path, { isAlive = defaultIsAlive, commOf = defa
       }
       if (commBase !== r.shell) {
         skipped.push({ ...r, why: 'comm-mismatch', comm: commBase })
+        continue
+      }
+    }
+    // #6327: start-time identity gate — closes the same-binary pid-reuse window
+    // comm can't (orphan exits → pid recycled onto a fresh same-binary shell).
+    // When we captured an lstart, the live process must still report the SAME
+    // lstart; a recycled pid's occupant started later → different lstart → skip.
+    // A record with no captured start-time falls back to the comm-only gate.
+    if (r.startTime) {
+      const liveStart = startTimeOf(r.pid)
+      if (!liveStart) {
+        skipped.push({ ...r, why: 'starttime-unknown' })
+        continue
+      }
+      if (liveStart !== r.startTime) {
+        skipped.push({ ...r, why: 'starttime-mismatch' })
         continue
       }
     }

--- a/packages/server/tests/session-manager-user-shell-gate.test.js
+++ b/packages/server/tests/session-manager-user-shell-gate.test.js
@@ -187,6 +187,22 @@ describe('SessionManager user-shell orphan reaper (#6276)', () => {
     }
   })
 
+  it('boot reaper does NOT signal a same-binary pid whose start-time differs from the record (#6327)', () => {
+    const killed = []
+    const mgr = makeMgr({
+      userShellReapSeams: { isAlive: () => true, commOf: () => 'zsh', startTimeOf: () => 'recycled-later', kill: (pid) => { killed.push(pid); return true } },
+    })
+    try {
+      writeFileSync(sidecarOf(mgr), JSON.stringify([{ sessionId: 'recycled-2', pid: 4242, shell: 'zsh', startTime: 'original' }]))
+      const audit = captureAudit(() => mgr.restoreState())
+      assert.deepEqual(killed, [], 'a recycled pid (later start-time) running the same shell binary must NOT be signalled')
+      assert.ok(!audit.some((m) => m.includes('orphan_reaper')), 'no orphan_reaper audit for a start-time-mismatched record')
+      assert.equal(existsSync(sidecarOf(mgr)), false)
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
   it('boot reaper is a no-op when there is no sidecar (clean-shutdown case)', () => {
     const mgr = makeMgr()
     try {

--- a/packages/server/tests/user-shell-registry.test.js
+++ b/packages/server/tests/user-shell-registry.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { readRegistry, recordShell, forgetShell, reapOrphanShells } from '../src/user-shell-registry.js'
 
-describe('user-shell-registry (#6276)', () => {
+describe('user-shell-registry (#6276 / #6327)', () => {
   let dir
   let sidecar
   beforeEach(() => {
@@ -14,44 +14,58 @@ describe('user-shell-registry (#6276)', () => {
   })
   afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
 
+  // Deterministic record: never spawn real `ps` in tests. Default to no
+  // start-time (the comm-only-fallback path); start-time tests pass their own.
+  const rec = (fields, startTimeOf = () => null) => recordShell(sidecar, fields, { startTimeOf })
+
   describe('record / forget', () => {
     it('records a shell and reads it back (shell stored as basename only)', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 4242, shell: '/bin/zsh' })
+      rec({ sessionId: 's1', pid: 4242, shell: '/bin/zsh' })
       assert.deepEqual(readRegistry(sidecar), [{ sessionId: 's1', pid: 4242, shell: 'zsh' }])
     })
 
     it('replaces the record for the same sessionId (idempotent respawn)', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 1, shell: '/bin/zsh' })
-      recordShell(sidecar, { sessionId: 's1', pid: 2, shell: '/bin/zsh' })
+      rec({ sessionId: 's1', pid: 1, shell: '/bin/zsh' })
+      rec({ sessionId: 's1', pid: 2, shell: '/bin/zsh' })
       const recs = readRegistry(sidecar)
       assert.equal(recs.length, 1)
       assert.equal(recs[0].pid, 2)
     })
 
     it('ignores a record with a non-positive / non-integer pid', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 0, shell: 'zsh' })
-      recordShell(sidecar, { sessionId: 's2', pid: -5, shell: 'zsh' })
-      recordShell(sidecar, { sessionId: 's3', pid: 1.5, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 0, shell: 'zsh' })
+      rec({ sessionId: 's2', pid: -5, shell: 'zsh' })
+      rec({ sessionId: 's3', pid: 1.5, shell: 'zsh' })
       assert.deepEqual(readRegistry(sidecar), [])
     })
 
     it('forget removes one record, keeping the others', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 11, shell: 'zsh' })
-      recordShell(sidecar, { sessionId: 's2', pid: 22, shell: 'bash' })
+      rec({ sessionId: 's1', pid: 11, shell: 'zsh' })
+      rec({ sessionId: 's2', pid: 22, shell: 'bash' })
       forgetShell(sidecar, 's1')
       assert.deepEqual(readRegistry(sidecar).map((r) => r.sessionId), ['s2'])
     })
 
     it('forget deletes the file once empty (clean shutdown leaves no sidecar)', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 11, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 11, shell: 'zsh' })
       forgetShell(sidecar, 's1')
       assert.equal(existsSync(sidecar), false)
     })
 
     it('forget on an unknown sessionId is a no-op', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 11, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 11, shell: 'zsh' })
       forgetShell(sidecar, 'nope')
       assert.deepEqual(readRegistry(sidecar).map((r) => r.sessionId), ['s1'])
+    })
+
+    it('captures the start-time when one is available (#6327)', () => {
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' }, () => 'Wed Jun 25 01:30:00 2026')
+      assert.equal(readRegistry(sidecar)[0].startTime, 'Wed Jun 25 01:30:00 2026')
+    })
+
+    it('omits the start-time key when none is captured (comm-only fallback)', () => {
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' }, () => null)
+      assert.ok(!('startTime' in readRegistry(sidecar)[0]))
     })
   })
 
@@ -74,11 +88,11 @@ describe('user-shell-registry (#6276)', () => {
     })
   })
 
-  describe('reapOrphanShells', () => {
-    const seams = (over = {}) => ({ isAlive: () => true, commOf: () => 'zsh', kill: () => true, ...over })
+  describe('reapOrphanShells — comm gate (#6276)', () => {
+    const seams = (over = {}) => ({ isAlive: () => true, commOf: () => 'zsh', startTimeOf: () => null, kill: () => true, ...over })
 
     it('SIGTERMs a live shell whose comm matches, and reports it reaped', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: '/bin/zsh' })
+      rec({ sessionId: 's1', pid: 100, shell: '/bin/zsh' })
       const killed = []
       const { reaped, skipped } = reapOrphanShells(sidecar, seams({ kill: (pid) => { killed.push(pid); return true } }))
       assert.deepEqual(killed, [100])
@@ -88,13 +102,13 @@ describe('user-shell-registry (#6276)', () => {
     })
 
     it('clears the sidecar after running (this instance starts fresh)', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' })
       reapOrphanShells(sidecar, seams())
       assert.equal(existsSync(sidecar), false)
     })
 
     it('skips a dead pid without killing (never signal a gone process)', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' })
       const killed = []
       const { reaped, skipped } = reapOrphanShells(sidecar, seams({ isAlive: () => false, kill: (p) => { killed.push(p); return true } }))
       assert.deepEqual(killed, [])
@@ -103,7 +117,7 @@ describe('user-shell-registry (#6276)', () => {
     })
 
     it('PID-reuse safety: skips a live pid whose comm no longer matches the shell', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' })
       const killed = []
       const { reaped, skipped } = reapOrphanShells(sidecar, seams({ commOf: () => 'postgres', kill: (p) => { killed.push(p); return true } }))
       assert.deepEqual(killed, [], 'must NOT signal a reused pid running a different program')
@@ -113,7 +127,7 @@ describe('user-shell-registry (#6276)', () => {
     })
 
     it('skips when comm is unknown (cannot positively identify the process)', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' })
       const { reaped, skipped } = reapOrphanShells(sidecar, seams({
         commOf: () => null,
         kill: () => { throw new Error('must not attempt to kill an unidentifiable pid') },
@@ -123,14 +137,14 @@ describe('user-shell-registry (#6276)', () => {
     })
 
     it('records a failed kill as skipped, not reaped', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: 'zsh' })
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' })
       const { reaped, skipped } = reapOrphanShells(sidecar, seams({ kill: () => false }))
       assert.equal(reaped.length, 0)
       assert.equal(skipped[0].why, 'kill-failed')
     })
 
     it('matches comm by basename (ps may return a full path)', () => {
-      recordShell(sidecar, { sessionId: 's1', pid: 100, shell: '/opt/homebrew/bin/fish' })
+      rec({ sessionId: 's1', pid: 100, shell: '/opt/homebrew/bin/fish' })
       const killed = []
       reapOrphanShells(sidecar, seams({ commOf: () => '/opt/homebrew/bin/fish', kill: (p) => { killed.push(p); return true } }))
       assert.deepEqual(killed, [100])
@@ -148,6 +162,50 @@ describe('user-shell-registry (#6276)', () => {
       const { reaped, skipped } = reapOrphanShells(sidecar, seams())
       assert.deepEqual(reaped, [])
       assert.deepEqual(skipped, [])
+    })
+  })
+
+  describe('reapOrphanShells — start-time gate (#6327)', () => {
+    const seams = (over = {}) => ({ isAlive: () => true, commOf: () => 'zsh', startTimeOf: () => 'T1', kill: () => true, ...over })
+
+    it('reaps when the live start-time still matches the recorded one', () => {
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' }, () => 'T1')
+      const killed = []
+      const { reaped } = reapOrphanShells(sidecar, seams({ startTimeOf: () => 'T1', kill: (p) => { killed.push(p); return true } }))
+      assert.deepEqual(killed, [100])
+      assert.equal(reaped.length, 1)
+    })
+
+    it('PID-reuse safety: skips a same-binary pid whose start-time differs (recycled)', () => {
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' }, () => 'recorded-earlier')
+      const killed = []
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams({
+        startTimeOf: () => 'recycled-later',
+        kill: (p) => { killed.push(p); return true },
+      }))
+      assert.deepEqual(killed, [], 'a recycled pid running the same shell binary must NOT be signalled')
+      assert.equal(reaped.length, 0)
+      assert.equal(skipped[0].why, 'starttime-mismatch')
+    })
+
+    it('skips when the live start-time is unreadable (cannot confirm identity)', () => {
+      rec({ sessionId: 's1', pid: 100, shell: 'zsh' }, () => 'T1')
+      const { reaped, skipped } = reapOrphanShells(sidecar, seams({
+        startTimeOf: () => null,
+        kill: () => { throw new Error('must not kill an unverifiable pid') },
+      }))
+      assert.equal(reaped.length, 0)
+      assert.equal(skipped[0].why, 'starttime-unknown')
+    })
+
+    it('falls back to the comm-only gate for a legacy record with no start-time', () => {
+      writeFileSync(sidecar, JSON.stringify([{ sessionId: 's1', pid: 100, shell: 'zsh' }]))
+      const killed = []
+      reapOrphanShells(sidecar, seams({
+        startTimeOf: () => { throw new Error('start-time must not be consulted when none was recorded') },
+        kill: (p) => { killed.push(p); return true },
+      }))
+      assert.deepEqual(killed, [100])
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #6327 — the deterministic hardening deferred from #6326's review. Closes the one residual wrong-kill window in the user-shell orphan reaper (#6276).

### The gap (#6326 review)
The reaper's `comm` basename gate proves "same shell binary," not "same process." Residual window: an orphaned shell **exits**, the OS **recycles its pid** onto a fresh **same-binary** shell (e.g. the user opens a new `zsh` that lands on the freed pid), then the daemon reboots → the reaper would SIGTERM that innocent shell.

### The fix
Add an OS process **start-time** (`ps -p <pid> -o lstart=`) identity check:
- Captured at **record** (`recordShell`), stored alongside the pid.
- Required to still match at **reap** — a recycled pid's occupant started later, so it reports a strictly different `lstart` → skipped (`why: 'starttime-mismatch'`).

`lstart` is fixed for a process's lifetime and differs per pid-incarnation, so a **verbatim string match** is a sound "same process" proof — cross-platform (macOS + Linux), no date parsing. The header's PID-reuse-safety claim is updated accordingly.

Backward-compatible: a record with **no** captured start-time (ps unavailable at spawn, or a pre-#6327 record) falls back to the comm-only gate; a record **with** a start-time that can't be re-read at reap is **skipped** (we don't signal a pid we can't positively identify).

## Tests

- `user-shell-registry.test.js` — new start-time describe block: matches→reap, **differs→skip (the #6327 safety)**, unreadable→skip, legacy-no-start-time→comm-only fallback; plus record-captures / record-omits-when-null. Existing comm-gate tests made deterministic (inject `startTimeOf` so no real `ps` runs).
- `session-manager-user-shell-gate.test.js` — boot reaper through `restoreState` does NOT signal/audit a same-binary pid with a differing start-time.

## Verification

Registry + user-shell gate + user-shell-session (47) and core session-manager + persistence (249) green. eslint + custom server lints clean. No `session-manager.js` change needed — the #6276 reap-seam plumbing already accepts `startTimeOf`, and production picks up the new `lstart` default automatically.

⚠️ As with #6326, the real `process.kill` is exercised only via injected seams (can't signal a real process in CI).

Closes #6327