### PR TITLE
feat(protocol): Zod-schema the high-traffic server→client types (batch 1 of #6314)

### DIFF
--- a/packages/protocol/dist/schemas/server/connection.d.ts
+++ b/packages/protocol/dist/schemas/server/connection.d.ts
@@ -174,3 +174,21 @@ export declare const ServerClaudeReadySchema: z.ZodObject<{
         reason: z.ZodString;
     }, z.core.$strip>>;
 }, z.core.$strip>;
+export declare const ServerClientJoinedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"client_joined">;
+    client: z.ZodObject<{
+        clientId: z.ZodString;
+        deviceName: z.ZodNullable<z.ZodString>;
+        deviceType: z.ZodEnum<{
+            unknown: "unknown";
+            phone: "phone";
+            tablet: "tablet";
+            desktop: "desktop";
+        }>;
+        platform: z.ZodString;
+    }, z.core.$strip>;
+}, z.core.$strip>;
+export declare const ServerClientLeftSchema: z.ZodObject<{
+    type: z.ZodLiteral<"client_left">;
+    clientId: z.ZodString;
+}, z.core.$strip>;

--- a/packages/protocol/dist/schemas/server/connection.js
+++ b/packages/protocol/dist/schemas/server/connection.js
@@ -261,3 +261,19 @@ export const ServerClaudeReadySchema = z.object({
         reason: z.string(),
     }).optional(),
 });
+// #6323 (batch 1 of #6314): multi-client presence — broadcast to OTHER
+// authenticated clients when a client connects (`client_joined`, with its
+// device descriptor) or disconnects (`client_left`). Emitted by ws-broadcaster.
+export const ServerClientJoinedSchema = z.object({
+    type: z.literal('client_joined'),
+    client: z.object({
+        clientId: z.string(),
+        deviceName: z.string().nullable(),
+        deviceType: z.enum(['phone', 'tablet', 'desktop', 'unknown']),
+        platform: z.string(),
+    }),
+});
+export const ServerClientLeftSchema = z.object({
+    type: z.literal('client_left'),
+    clientId: z.string(),
+});

--- a/packages/protocol/dist/schemas/server/session.d.ts
+++ b/packages/protocol/dist/schemas/server/session.d.ts
@@ -374,3 +374,27 @@ export declare const ServerSkillTrustGrantInvalidAuthorSchema: z.ZodObject<{
     message: z.ZodString;
     actualAuthor: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerSessionActivitySchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_activity">;
+    sessionId: z.ZodString;
+    isBusy: z.ZodBoolean;
+    lastCost: z.ZodNullable<z.ZodNumber>;
+}, z.core.$strip>;
+export declare const ServerSessionErrorSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_error">;
+    message: z.ZodString;
+    code: z.ZodOptional<z.ZodString>;
+    category: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+    recoverable: z.ZodOptional<z.ZodBoolean>;
+    reason: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    boundSessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    boundSessionName: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    primaryClientId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+}, z.core.$loose>;
+export declare const ServerSessionUpdatedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_updated">;
+    sessionId: z.ZodString;
+    name: z.ZodString;
+}, z.core.$strip>;

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -476,3 +476,39 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
     message: z.string(),
     actualAuthor: z.string(),
 });
+// #6323 (batch 1 of #6314): schemas for the highest-traffic unschemaed
+// server→client session messages, so a field-shape change is drift-checked.
+// Per-session busy/idle activity ping (ws-forwarding.js): `isBusy` flips true
+// when a stream starts and false when a result arrives; `lastCost` carries the
+// result cost (null while busy / when no cost is known).
+export const ServerSessionActivitySchema = z.object({
+    type: z.literal('session_activity'),
+    sessionId: z.string(),
+    isBusy: z.boolean(),
+    lastCost: z.number().finite().nullable(),
+});
+// Session operation error envelope — the union of fields across its many emit
+// sites (session-start / checkpoint / dev-preview failures, capability gates,
+// token-mismatch via buildSessionTokenMismatchPayload, control-room action
+// errors). `.passthrough()` because the control-room path spreads open-ended
+// `correlate(msg)` correlation fields onto the envelope (mirrors auth_ok's
+// passthrough rationale) — the named fields document the stable contract.
+export const ServerSessionErrorSchema = z.object({
+    type: z.literal('session_error'),
+    message: z.string(),
+    code: z.string().optional(),
+    category: z.string().optional(),
+    sessionId: z.string().optional(),
+    recoverable: z.boolean().optional(),
+    reason: z.string().optional(),
+    requestId: z.string().nullable().optional(),
+    boundSessionId: z.string().nullable().optional(),
+    boundSessionName: z.string().nullable().optional(),
+    primaryClientId: z.string().nullable().optional(),
+}).passthrough();
+// A session's metadata changed (today: its display name — auto-label or rename).
+export const ServerSessionUpdatedSchema = z.object({
+    type: z.literal('session_updated'),
+    sessionId: z.string(),
+    name: z.string(),
+});

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -259,3 +259,14 @@ export declare const ServerBackgroundWorkChangedSchema: z.ZodObject<{
         startedAt: z.ZodNumber;
     }, z.core.$strip>>;
 }, z.core.$strip>;
+export declare const ServerTerminalOutputSchema: z.ZodObject<{
+    type: z.ZodLiteral<"terminal_output">;
+    sessionId: z.ZodString;
+    data: z.ZodString;
+}, z.core.$strip>;
+export declare const ServerTerminalSizeSchema: z.ZodObject<{
+    type: z.ZodLiteral<"terminal_size">;
+    sessionId: z.ZodString;
+    cols: z.ZodNumber;
+    rows: z.ZodNumber;
+}, z.core.$strip>;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -348,3 +348,17 @@ export const ServerBackgroundWorkChangedSchema = z.object({
     sessionId: z.string(),
     pending: z.array(ServerPendingBackgroundShellSchema),
 });
+// #6323 (batch 1 of #6314): the live PTY mirror channel (#5835). `terminal_output`
+// is raw coalesced ANSI bytes (transient — no history/replay); `terminal_size` is
+// the authoritative grid the server broadcasts so observers letterbox to it.
+export const ServerTerminalOutputSchema = z.object({
+    type: z.literal('terminal_output'),
+    sessionId: z.string(),
+    data: z.string(),
+});
+export const ServerTerminalSizeSchema = z.object({
+    type: z.literal('terminal_size'),
+    sessionId: z.string(),
+    cols: z.number().int(),
+    rows: z.number().int(),
+});

--- a/packages/protocol/src/schemas/server/connection.ts
+++ b/packages/protocol/src/schemas/server/connection.ts
@@ -276,3 +276,21 @@ export const ServerClaudeReadySchema = z.object({
     reason: z.string(),
   }).optional(),
 })
+
+// #6323 (batch 1 of #6314): multi-client presence — broadcast to OTHER
+// authenticated clients when a client connects (`client_joined`, with its
+// device descriptor) or disconnects (`client_left`). Emitted by ws-broadcaster.
+export const ServerClientJoinedSchema = z.object({
+  type: z.literal('client_joined'),
+  client: z.object({
+    clientId: z.string(),
+    deviceName: z.string().nullable(),
+    deviceType: z.enum(['phone', 'tablet', 'desktop', 'unknown']),
+    platform: z.string(),
+  }),
+})
+
+export const ServerClientLeftSchema = z.object({
+  type: z.literal('client_left'),
+  clientId: z.string(),
+})

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -503,3 +503,43 @@ export const ServerSkillTrustGrantInvalidAuthorSchema = z.object({
   message: z.string(),
   actualAuthor: z.string(),
 })
+
+// #6323 (batch 1 of #6314): schemas for the highest-traffic unschemaed
+// server→client session messages, so a field-shape change is drift-checked.
+
+// Per-session busy/idle activity ping (ws-forwarding.js): `isBusy` flips true
+// when a stream starts and false when a result arrives; `lastCost` carries the
+// result cost (null while busy / when no cost is known).
+export const ServerSessionActivitySchema = z.object({
+  type: z.literal('session_activity'),
+  sessionId: z.string(),
+  isBusy: z.boolean(),
+  lastCost: z.number().finite().nullable(),
+})
+
+// Session operation error envelope — the union of fields across its many emit
+// sites (session-start / checkpoint / dev-preview failures, capability gates,
+// token-mismatch via buildSessionTokenMismatchPayload, control-room action
+// errors). `.passthrough()` because the control-room path spreads open-ended
+// `correlate(msg)` correlation fields onto the envelope (mirrors auth_ok's
+// passthrough rationale) — the named fields document the stable contract.
+export const ServerSessionErrorSchema = z.object({
+  type: z.literal('session_error'),
+  message: z.string(),
+  code: z.string().optional(),
+  category: z.string().optional(),
+  sessionId: z.string().optional(),
+  recoverable: z.boolean().optional(),
+  reason: z.string().optional(),
+  requestId: z.string().nullable().optional(),
+  boundSessionId: z.string().nullable().optional(),
+  boundSessionName: z.string().nullable().optional(),
+  primaryClientId: z.string().nullable().optional(),
+}).passthrough()
+
+// A session's metadata changed (today: its display name — auto-label or rename).
+export const ServerSessionUpdatedSchema = z.object({
+  type: z.literal('session_updated'),
+  sessionId: z.string(),
+  name: z.string(),
+})

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -389,3 +389,19 @@ export const ServerBackgroundWorkChangedSchema = z.object({
   sessionId: z.string(),
   pending: z.array(ServerPendingBackgroundShellSchema),
 })
+
+// #6323 (batch 1 of #6314): the live PTY mirror channel (#5835). `terminal_output`
+// is raw coalesced ANSI bytes (transient — no history/replay); `terminal_size` is
+// the authoritative grid the server broadcasts so observers letterbox to it.
+export const ServerTerminalOutputSchema = z.object({
+  type: z.literal('terminal_output'),
+  sessionId: z.string(),
+  data: z.string(),
+})
+
+export const ServerTerminalSizeSchema = z.object({
+  type: z.literal('terminal_size'),
+  sessionId: z.string(),
+  cols: z.number().int(),
+  rows: z.number().int(),
+})

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -151,6 +151,11 @@ const DASHBOARD_ONLY = new Set<string>([
   // activity_snapshot / activity_delta removed — the mobile app now feeds them
   // too (#6246/#6247, the Phase-2 mobile-parity fast-follow per epic #5159), so
   // they are no longer dashboard-only.
+  // #6323 (batch 1 of #6314): schemaing these surfaced an existing asymmetry —
+  // both are handled by the dashboard only today (the app has no `case`). Not
+  // introduced here; the schema just made the lint see them.
+  'session_activity',           // per-session busy/idle + cost ping — dashboard activity tree only
+  'terminal_size',              // authoritative PTY grid for letterboxing — app terminal parity is still partial (#5987)
   'billing_canary',             // live billing-canary banner (#5821) — dashboard sidebar
   'byok_credentials_status',    // BYOK paste-API-key form (#4052) — dashboard-only for v1
   'cancel_activity_ack',        // Control Room cancel-click correlation ack (#5277)


### PR DESCRIPTION
Closes #6323 (sub-issue of #6314 — 54 server→client types had no Zod schema).

## Change
Adds Zod schemas for the 7 highest-traffic previously-unschemaed server→client types, so a field-shape change is drift-checked against a contract:

| Type | File | Notes |
|---|---|---|
| `session_activity` | `server/session.ts` | busy/idle + cost ping |
| `session_error` | `server/session.ts` | `.passthrough()` — the control-room path spreads open-ended `correlate(msg)` fields; named fields are the stable contract |
| `session_updated` | `server/session.ts` | name change |
| `client_joined` / `client_left` | `server/connection.ts` | presence (nested device descriptor) |
| `terminal_output` / `terminal_size` | `server/stream.ts` | live PTY mirror channel |

Field shapes were **verified against the actual emit sites** (ws-forwarding / ws-broadcaster / handler-utils / control-room), not guessed — e.g. `session_error`'s full cross-site field union (code/category/sessionId/recoverable/reason/requestId/boundSession*/primaryClientId) + passthrough for correlation fields.

## Coverage guards
Schemaing `session_activity` + `terminal_size` surfaced a **pre-existing** dashboard-only asymmetry (the app has no handler `case` for them) — not introduced here; the schema just made the lint see them. Declared in `protocol-type-coverage-lint`'s `DASHBOARD_ONLY` allowlist with a tracking note (`terminal_size` ties to the still-partial app terminal parity #5987). The other 5 are already both-clients-handled / accounted-for.

## Verification
Full store-core (1838) + protocol (340) + the coverage guards (9) green. Protocol `dist` rebuilt + committed.

Closes #6323