### PR TITLE
test(store-core): drain user_input from PENDING_CONTRACT (first slice of #6325)

### DIFF
--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -128,7 +128,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'token_rotated',
   'tool_input_delta',
   // tunnel_url_changed — migrated to the shared dispatch table (#5618 Batch 5b).
-  'user_input',
+  // user_input — now has a SWITCH_FIXTURES entry (#6325), so it leaves the
+  // pending backlog (both clients build it via the shared sharedUserInput path).
   // user_question — migrated to the shared dispatch table (#5618); now has a
   // DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   // web_task_error — now has a SWITCH_FIXTURES entry (#5619), so it leaves the

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1610,4 +1610,30 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       },
     },
   },
+  {
+    // #6325 (drain #6314): the server broadcasts `user_input` to all OTHER
+    // clients when one client sends a message — a multi-client live echo. Both
+    // clients route it through the shared `sharedUserInput`/parseUserInputMessage
+    // path: it builds a `user_input`-typed bubble (content from `text`, id from
+    // the server's stable `messageId`) and appends it. The gate skips a message
+    // from THIS client (clientId === myClientId), so the fixture uses a different
+    // sender. The dashboard additionally writes the prompt to its terminal buffer
+    // (a mocked side effect outside the asserted `messages` slice).
+    name: 'user_input echoes another client’s message as a user_input bubble',
+    type: 'user_input',
+    init: { activeSessionId: 's1', myClientId: 'me', sessions: { s1: {} } },
+    message: {
+      type: 'user_input',
+      sessionId: 's1',
+      clientId: 'other-device',
+      messageId: 'ui-1',
+      text: 'hello from another device',
+      timestamp: 1000,
+    },
+    expect: {
+      sessions: {
+        s1: { messages: [{ id: 'ui-1', type: 'user_input', content: 'hello from another device' }] },
+      },
+    },
+  },
 ]


### PR DESCRIPTION
First slice of #6325 (closes epic #6314's fixture-drain). Drains **`user_input`** from `PENDING_CONTRACT_TYPES` by adding a behavioural `SWITCH_FIXTURES` entry.

## What & why
`user_input` is the server's multi-client live-echo (broadcast to OTHER clients when one sends a message). Both clients route it through the shared `sharedUserInput` → `parseUserInputMessage` path: it builds a `user_input`-typed bubble (content from `text`, id from the server's stable `messageId`) and appends it; the gate skips a message from this client (`clientId === myClientId`). The dashboard additionally writes the prompt to its terminal buffer — a mocked side effect outside the asserted `messages` slice, so both clients agree → a single `expect`.

## Correct-by-construction
The fixture is **behaviourally executed against both clients' real switches** by `packages/app/__tests__/contract-switch.test.ts` and `packages/dashboard/src/store/contract-switch.test.ts` — a wrong `expect` fails those suites. Verified green; the app suite shows `✓ user_input echoes another client's message`.

## Scope note
This is the **first** of the #6325 drain. The full harness map + per-type batching plan (each type needs dual-switch verification — `grep` false-negatives on the 220KB handlers, so node-scan both) is documented on the issue. Remaining types continue in follow-up slices.

## Verification
Full store-core (1838) + store-core contract-fixtures (106) + app contract-switch (17) + dashboard contract-switch (17) green.

Part of #6325 / #6314