### PR TITLE
test(store-core): drain permission_expired + tool_input_delta from PENDING_CONTRACT (#6325 batch)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -135,6 +135,10 @@ function normalize(messages: unknown[]): Array<Record<string, unknown>> {
     content: m.content,
     tool: m.tool,
     toolUseId: m.toolUseId,
+    // #6325: the partial-JSON accumulator (tool_input_delta) — included so a
+    // fixture can assert streamed tool input. toMatchObject is partial, so
+    // existing fixtures that don't assert it are unaffected.
+    toolInputPartial: m.toolInputPartial,
   }));
 }
 

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -95,6 +95,10 @@ function normalize(messages: unknown[]): Array<Record<string, unknown>> {
     content: m.content,
     tool: m.tool,
     toolUseId: m.toolUseId,
+    // #6325: the partial-JSON accumulator (tool_input_delta) — included so a
+    // fixture can assert streamed tool input. toMatchObject is partial, so
+    // existing fixtures that don't assert it are unaffected.
+    toolInputPartial: m.toolInputPartial,
   }))
 }
 

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -96,7 +96,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // multi_question_intervention — migrated to the shared dispatch table (#5618);
   // now has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   'pair_fail',
-  'permission_expired',
+  // permission_expired — now has a SWITCH_FIXTURES entry (#6325).
   'permission_mode_changed',
   // permission_resolved now has a both-clients SWITCH_FIXTURES entry (#6058).
   'permission_timeout',
@@ -126,7 +126,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'stream_delta',
   'terminal_output',
   'token_rotated',
-  'tool_input_delta',
+  // tool_input_delta — now has a SWITCH_FIXTURES entry (#6325); the harness
+  // normalize() was extended to assert its toolInputPartial accumulator.
   // tunnel_url_changed — migrated to the shared dispatch table (#5618 Batch 5b).
   // user_input — now has a SWITCH_FIXTURES entry (#6325), so it leaves the
   // pending backlog (both clients build it via the shared sharedUserInput path).

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1636,4 +1636,93 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       },
     },
   },
+  {
+    // #6325 (drain #6314): a pending permission expired/could-not-route. Both
+    // clients call the shared handlePermissionExpired, which appends a fixed
+    // "(Expired — …)" suffix to the matching `prompt` bubble IN PLACE (matched by
+    // requestId + type==='prompt') and clears its options (options is dropped by
+    // the harness normalize, so not asserted). Target = msg.sessionId ||
+    // activeSessionId; no-op if requestId is null or the session/prompt is absent
+    // — so the fixture seeds a prompt carrying the requestId. The dashboard's
+    // #2833 already-resolved early-return is gated on `resolvedPermissions`, which
+    // FixtureInitialState can't seed, so both clients take the same path → single
+    // expect. The banner-drain is a sessionNotifications side effect outside the
+    // asserted messages slice.
+    name: 'permission_expired appends the expired suffix to the matching prompt in place (both clients)',
+    type: 'permission_expired',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              tool: 'Bash',
+              requestId: 'req-1',
+              options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+            } as unknown as ChatMessage,
+          ],
+        },
+      },
+    },
+    message: {
+      type: 'permission_expired',
+      requestId: 'req-1',
+      sessionId: 's1',
+      message: 'permission response could not be routed (expired/handled)',
+    },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x\n(Expired — this permission was already handled or timed out)',
+              tool: 'Bash',
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    // #6325 (drain #6314): streaming partial tool input. Both clients delegate to
+    // the shared handleToolInputDelta, which locates the in-flight tool_use bubble
+    // by toolUseId and appends `partialJson` onto its `toolInputPartial`
+    // accumulator (seeded undefined → ''), leaving a single tool_use entry. The
+    // assertion on `toolInputPartial` requires that field in the harness
+    // `normalize()` whitelist (added in this PR for both clients).
+    name: 'tool_input_delta accumulates the partial JSON onto its in-flight tool_use bubble',
+    type: 'tool_input_delta',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'tool-tu-1',
+              type: 'tool_use',
+              tool: 'Bash',
+              toolUseId: 'tu-1',
+              content: '',
+            } as unknown as ChatMessage,
+          ],
+        },
+      },
+    },
+    message: {
+      type: 'tool_input_delta',
+      sessionId: 's1',
+      toolUseId: 'tu-1',
+      partialJson: '{"command":"ls',
+    },
+    expect: {
+      sessions: {
+        s1: { messages: [{ type: 'tool_use', toolUseId: 'tu-1', toolInputPartial: '{"command":"ls' }] },
+      },
+    },
+  },
 ]


### PR DESCRIPTION
Part of #6325 (closes epic #6314's fixture drain). Two more behavioural fixtures + a small harness extension. PENDING: 34 → 32.

## Verified-both-clients fixtures
A 10-type parallel verification (node-scanning both 220KB handlers — `grep` lies) found only **2** of the candidates are cleanly fixtureable now; the other 8 mutate session-scalar/flat state the messages-slice harness can't assert (see finding below).

- **`permission_expired`** — both clients call the shared `handlePermissionExpired`, which appends a fixed `(Expired — …)` suffix to the matching `prompt` bubble **in place** (matched by `requestId` + `type==='prompt'`). Single `expect` (the dashboard's already-resolved early-return is gated on `resolvedPermissions`, which `FixtureInitialState` can't seed → both take the same path).
- **`tool_input_delta`** — both clients accumulate `partialJson` onto the in-flight `tool_use` bubble's `toolInputPartial`. Extended the contract-switch `normalize()` whitelist in **both** harnesses to include `toolInputPartial` (partial-match → existing fixtures unaffected); otherwise the accumulator is dropped and the assertion would be vacuous.

## Correct-by-construction
Both run through both clients' **real** switches by `app/__tests__/contract-switch.test.ts` + `dashboard/src/store/contract-switch.test.ts` (both show `✓`). A wrong `expect` fails those suites.

## Finding (the bulk unlock)
Most remaining PENDING types (`agent_idle`, `claude_ready`, `permission_mode_changed`, `plan_ready`, …) mutate **session-scalar** fields (`isIdle`, `claudeReady`, `mode`) — and `permission_timeout`/`server_error`/`session_error` hit unmocked secondary stores / unseeded flat slices. The messages-slice harness can't assert those today. The next, larger slice is a **session-field harness extension** (assert `sessions[id].{isIdle,claudeReady,…}` + fix the app's `useNotificationStore`/`serverErrors` seeding). Mapped on #6325.

## Verification
Full store-core (1838) + contract-fixtures (106) + app contract-switch (19) + dashboard contract-switch (19) green.

Part of #6325