### PR TITLE
test(store-core): assert session-scalar fields in contract-switch + drain 3 types (#6325)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -202,6 +202,15 @@ describe('contract switch fixtures — app real handleMessage (#5556.5)', () => 
             expect(actual[i]).toMatchObject(m);
           });
         }
+        // #6325: assert any session-SCALAR fields a fixture specifies beyond
+        // `messages` (isIdle, claudeReady, streamingMessageId, permissionMode, …).
+        // Additive — message-only fixtures have no scalar keys, so they're
+        // unaffected; this unlocks the session-field types in the drain backlog.
+        const { messages: _ignoredMessages, ...scalarFields } = fields as Record<string, unknown>;
+        void _ignoredMessages;
+        if (Object.keys(scalarFields).length > 0) {
+          expect(ss).toMatchObject(scalarFields);
+        }
       }
     });
   }

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -182,6 +182,15 @@ describe('contract switch fixtures — dashboard real handleMessage (#5556.5)', 
             expect(actual[i], `${fx.name}: ${id} messages[${i}]`).toMatchObject(m)
           })
         }
+        // #6325: assert any session-SCALAR fields a fixture specifies beyond
+        // `messages` (isIdle, claudeReady, streamingMessageId, permissionMode, …).
+        // Additive — message-only fixtures have no scalar keys, so they're
+        // unaffected; this unlocks the session-field types in the drain backlog.
+        const { messages: _ignoredMessages, ...scalarFields } = fields as Record<string, unknown>
+        void _ignoredMessages
+        if (Object.keys(scalarFields).length > 0) {
+          expect(ss, `${fx.name}: ${id} scalar fields`).toMatchObject(scalarFields)
+        }
       }
     })
   }

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -64,7 +64,8 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 // only legitimate when retro-fitting a pre-existing case, with a note.
 // ---------------------------------------------------------------------------
 const PENDING_CONTRACT_TYPES = new Set<string>([
-  'agent_idle',
+  // agent_idle — now has a SWITCH_FIXTURES entry (#6325); the contract-switch
+  // harness was extended to assert session-scalar fields (isIdle, …).
   // activity_snapshot / activity_delta — both clients now feed them through the
   // store-core ACTIVITY reducer (applyActivitySnapshot/applyActivityDelta) from
   // their own switch (#6246/#6247 added the mobile side; dashboard since #5163).
@@ -85,7 +86,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // batch (both clients still handle it platform-locally — the app via a switch
   // case, the dashboard via its HANDLERS map), so it remains pending.
   'checkpoint_restored',
-  'claude_ready',
+  // claude_ready — now has a SWITCH_FIXTURES entry (#6325, session-scalar assert).
   // client_focus_changed — migrated to the shared dispatch table (#5618 Batch 4).
   'client_joined',
   'client_left',
@@ -97,7 +98,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // now has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   'pair_fail',
   // permission_expired — now has a SWITCH_FIXTURES entry (#6325).
-  'permission_mode_changed',
+  // permission_mode_changed — now has a SWITCH_FIXTURES entry (#6325, scalar assert).
   // permission_resolved now has a both-clients SWITCH_FIXTURES entry (#6058).
   'permission_timeout',
   'plan_ready',

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1725,4 +1725,48 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       },
     },
   },
+  {
+    // #6325 (drain #6314): session ready. Both clients apply the shared
+    // handleClaudeReady patch ({ claudeReady: true, stoppedAt: null,
+    // stoppedCode: null }) onto the session — no message bubble. With no
+    // backgroundTasks on the wire, the app (calls it with no msg arg) and the
+    // dashboard (calls it with msg) produce the identical scalar patch → single
+    // expect. Asserts the session-scalar field via the #6325 harness extension.
+    name: 'claude_ready sets the session claudeReady flag (both clients)',
+    type: 'claude_ready',
+    init: { activeSessionId: 's1', sessions: { s1: { claudeReady: false } } },
+    message: { type: 'claude_ready', sessionId: 's1' },
+    expect: {
+      sessions: { s1: { claudeReady: true } },
+    },
+  },
+  {
+    // #6325 (drain #6314): the agent went idle. Both clients apply the shared
+    // sharedAgentIdle patch ({ isIdle: true, streamingMessageId: null,
+    // activeTools: [] }) to the seeded session (the dashboard's local
+    // handleAgentIdle delegates to sharedAgentIdle on the seeded-session path).
+    // Asserts the scalar fields via the harness extension; activeTools:[] is
+    // omitted from expect because toMatchObject treats an empty expected array as
+    // vacuous (it matches any array).
+    name: 'agent_idle flips the session to idle and clears the streaming id (both clients)',
+    type: 'agent_idle',
+    init: { activeSessionId: 's1', sessions: { s1: { isIdle: false, streamingMessageId: 'live-1' } } },
+    message: { type: 'agent_idle', sessionId: 's1' },
+    expect: {
+      sessions: { s1: { isIdle: true, streamingMessageId: null } },
+    },
+  },
+  {
+    // #6325 (drain #6314): the server confirmed a permission-mode change. Both
+    // clients extract `mode` (shared handlePermissionModeChanged) and set the
+    // session field permissionMode. Target = msg.sessionId || activeSessionId; no
+    // message bubble. Asserts the scalar field via the harness extension.
+    name: 'permission_mode_changed updates the session permissionMode (both clients)',
+    type: 'permission_mode_changed',
+    init: { activeSessionId: 's1', sessions: { s1: { permissionMode: 'default' } } },
+    message: { type: 'permission_mode_changed', sessionId: 's1', mode: 'plan' },
+    expect: {
+      sessions: { s1: { permissionMode: 'plan' } },
+    },
+  },
 ]


### PR DESCRIPTION
Part of #6325 (epic #6314 fixture drain). The bulk-unlock slice: extends the contract-switch harness to assert **session-scalar fields**, then drains 3 types. PENDING: 32 → 29.

## The unlock
The prior verification found most remaining PENDING types mutate session-scalar state (`isIdle`, `claudeReady`, `permissionMode`, …), but the contract-switch harness only asserted `sessions[id].messages`. This adds a `toMatchObject` on the non-`messages` scalar fields of each `expect.sessions[id]` in **both** harnesses (`app/__tests__/contract-switch.test.ts` + `dashboard/src/store/contract-switch.test.ts`). Additive — message-only fixtures have no scalar keys, so all existing fixtures are unaffected.

**Proven load-bearing:** a negative probe (assert a wrong scalar value) fails the suite — so the new assertion genuinely asserts, it isn't a vacuous no-op.

## Drained (3, all verified both-clients, run through both real switches)
- **`claude_ready`** → `{ claudeReady: true }` (shared `handleClaudeReady`; no-backgroundTasks msg → app & dashboard produce the identical scalar patch).
- **`agent_idle`** → `{ isIdle: true, streamingMessageId: null }` (shared `sharedAgentIdle`; the dashboard's local `handleAgentIdle` delegates to it on the seeded-session path). `activeTools: []` omitted — `toMatchObject` treats an empty expected array as vacuous.
- **`permission_mode_changed`** → `{ permissionMode: 'plan' }` (shared `handlePermissionModeChanged`).

All seeded with a *different* starting value (`claudeReady:false`, `isIdle:false`+`streamingMessageId:'live-1'`, `permissionMode:'default'`) so the assertions are non-vacuous.

## Correct-by-construction
The fixtures run through both clients' real switches by the contract-switch suites (both show `✓`). A wrong `expect` fails them.

## Verification
Full store-core (1838) + contract-fixtures (106) + app contract-switch (22) + dashboard contract-switch (22) green; negative probe confirmed the scalar assertion fails on a wrong value.

Part of #6325