### PR TITLE
test(store-core): drain server_status + session_error + stream_delta from PENDING_CONTRACT (#6325)

### DIFF
--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -112,8 +112,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'server_error',
   'server_mode',
   'server_shutdown',
-  'server_status',
-  'session_error',
+  // server_status — now has a SWITCH_FIXTURES entry (#6325 batch A).
+  // session_error — now has a SWITCH_FIXTURES entry (#6325 batch A).
   'session_list',
   // session_persist_failed / session_restore_failed / session_stopped — migrated
   // to the shared dispatch table (#5618 Batch 3); now have DISPATCH_FIXTURES
@@ -124,7 +124,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'session_warning',
   // slash_commands — migrated to the shared dispatch table (#5618 Batch 2); now
   // has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
-  'stream_delta',
+  // stream_delta — now has a SWITCH_FIXTURES entry (#6325 batch A).
   'terminal_output',
   'token_rotated',
   // tool_input_delta — now has a SWITCH_FIXTURES entry (#6325); the harness

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1769,4 +1769,59 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       sessions: { s1: { permissionMode: 'plan' } },
     },
   },
+  {
+    // #6325 (drain #6314): a session crashed. Both clients (shared handleSessionError,
+    // category 'crash') flip the target session's `health` to 'crashed'. crashedId
+    // resolves to the active session, so the pushSessionNotification side effect
+    // early-returns (sessionId === activeSessionId) and never hits the mocked store.
+    // Non-vacuous: seeds health:'ok' so the handler must flip it.
+    name: 'session_error (crash) flips the target session health to crashed (both clients)',
+    type: 'session_error',
+    init: { activeSessionId: 's1', sessions: { s1: { health: 'ok' } } },
+    message: { type: 'session_error', category: 'crash', sessionId: 's1' },
+    expect: { sessions: { s1: { health: 'crashed' } } },
+  },
+  {
+    // #6325 (drain #6314): a legacy server_status (no phase) — both clients append
+    // the ANSI-stripped status message as a `system` bubble to the active session.
+    name: 'server_status (legacy, no phase) appends the status message to the active session (both clients)',
+    type: 'server_status',
+    init: {
+      activeSessionId: 's1',
+      sessions: { s1: { messages: [{ id: 'seed-1', type: 'user', content: 'hello', timestamp: 1 } as unknown as ChatMessage] } },
+    },
+    message: { type: 'server_status', message: 'Tunnel reconnected' },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            { type: 'user', content: 'hello' },
+            { type: 'system', content: 'Tunnel reconnected' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    // #6325 (drain #6314): a stream_delta buffers behind the coalescing flush timer,
+    // then applyDeltaBatch appends the text onto the in-flight response bubble's
+    // content on flush. The contract harness drains the timer before asserting, so
+    // the concatenated content is observable. Seeds non-empty content so the append
+    // is non-vacuous.
+    name: 'stream_delta appends the delta text onto its in-flight response bubble (both clients)',
+    type: 'stream_delta',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [{ id: 'resp-1', type: 'response', content: 'Hello' } as unknown as ChatMessage],
+          streamingMessageId: 'resp-1',
+        },
+      },
+    },
+    message: { type: 'stream_delta', sessionId: 's1', messageId: 'resp-1', delta: ', world' },
+    expect: {
+      sessions: { s1: { messages: [{ id: 'resp-1', type: 'response', content: 'Hello, world' }] } },
+    },
+  },
 ]


### PR DESCRIPTION
Part of #6325 (epic #6314 fixture drain). Three more behavioural fixtures, no harness change. PENDING: 29 → 26.

## Drained (all verified both-clients, run through both real switches)
- **`server_status`** (legacy, no phase) — both clients append the ANSI-stripped status as a `system` bubble to the active session.
- **`session_error`** (crash) — both clients flip the target session `health` to `'crashed'` (session-scalar). `crashedId === activeSessionId`, so the `pushSessionNotification` side effect early-returns and never touches the mocked store.
- **`stream_delta`** — both clients buffer the delta behind the coalescing flush timer; `applyDeltaBatch` appends it onto the in-flight response bubble on the harness's timer drain.

All seeded with a *different* starting value than the expect (`health:'ok'`, `content:'Hello'`) so the assertions are non-vacuous.

## Method + what's deferred
A 29-type classification pass (one agent per remaining type, node-scanning both 220KB handlers) found 11 candidates fixtureable on the current harness. Running them empirically, these 3 pass cleanly on **both** clients. The other 8 throw on **flat store state the contract-switch harness doesn't seed** (`activity`, `connectedClients`, `serverErrors`, `sessionNotifications`) or **incomplete `useNotificationStore` mocks** (`sessionNotifications`/`dismissSessionNotification`/`setTimeoutWarning`/`addServerError`) — not wrong expects. That's a focused **harness-hardening** follow-up (seed the flat defaults + complete the mocks in both harnesses), which also sets up the 11 bucket-B flat-assert types. `history_replay_end` needs a replay-baseline (multi-message) and is deferred separately.

## Verification
Full store-core (1838) + contract-fixtures (106) + app contract-switch (25) + dashboard contract-switch (25) green.

Part of #6325