### PR TITLE
test: harden contract-switch harness + drain 7 types (#6325)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -37,6 +37,8 @@ jest.mock('../src/utils/haptics', () => ({
 
 jest.mock('../src/store/persistence', () => ({
   clearPersistedSession: jest.fn(),
+  // #6325: session_list persists the active conversation id as a side effect.
+  persistLastConversationId: jest.fn(),
 }));
 
 jest.mock('../src/store/imperative-callbacks', () => ({
@@ -44,7 +46,8 @@ jest.mock('../src/store/imperative-callbacks', () => ({
 }));
 
 jest.mock('../src/store/multi-client', () => ({
-  useMultiClientStore: { getState: jest.fn(() => ({ setClients: jest.fn() })), setState: jest.fn() },
+  // #6325: client_joined calls addClient on the roster store.
+  useMultiClientStore: { getState: jest.fn(() => ({ setClients: jest.fn(), addClient: jest.fn(), removeClient: jest.fn() })), setState: jest.fn() },
 }));
 
 jest.mock('../src/store/web', () => ({
@@ -60,7 +63,21 @@ jest.mock('../src/store/terminal', () => ({
 }));
 
 jest.mock('../src/store/notifications', () => ({
-  useNotificationStore: { getState: jest.fn(() => ({ addNotification: jest.fn(), dismissNotification: jest.fn() })), setState: jest.fn() },
+  // #6325: permission_timeout/server_error/session_warning reach for more of the
+  // notification store than addNotification — seed the full surface so they
+  // exercise their real switch path instead of throwing on an undefined method.
+  useNotificationStore: {
+    getState: jest.fn(() => ({
+      addNotification: jest.fn(),
+      dismissNotification: jest.fn(),
+      sessionNotifications: [],
+      addSessionNotification: jest.fn(),
+      dismissSessionNotification: jest.fn(),
+      setTimeoutWarning: jest.fn(),
+      addServerError: jest.fn(),
+    })),
+    setState: jest.fn(),
+  },
 }));
 
 jest.mock('../src/store/conversations', () => ({
@@ -92,6 +109,7 @@ import {
   setConnectionContext,
   clearDeltaBuffers,
   updateSession,
+  resetReplayFlags,
 } from '../src/store/message-handler';
 import { createEmptySessionState } from '../src/store/utils';
 import type { ConnectionState, SessionState } from '../src/store/types';
@@ -157,6 +175,16 @@ function seedStore(fx: ContractFixture) {
     addMessage: jest.fn(),
     // The app's stream/tool handlers reach for the store's appendTerminalData.
     appendTerminalData: jest.fn(),
+    // #6325: flat connection-state fields the real store always initialises;
+    // seed them so handlers that read them (client_joined → connectedClients,
+    // activity_delta/_snapshot → activity, server_error → serverErrors,
+    // plan_ready/permission_timeout → sessionNotifications) exercise their real
+    // path instead of throwing on undefined. Off the asserted sessions[id] slice,
+    // so existing fixtures are unaffected.
+    connectedClients: [],
+    activity: { bySession: {} },
+    serverErrors: [],
+    sessionNotifications: [],
   } as unknown as ConnectionState);
 }
 
@@ -168,6 +196,11 @@ describe('contract switch fixtures — app real handleMessage (#5556.5)', () => 
   beforeEach(() => {
     jest.useFakeTimers();
     clearDeltaBuffers();
+    // #6325: reset the per-context replay flags between fixtures (the dashboard
+    // twin already does). Without this a prior history-replay fixture leaves a
+    // session in `_ctx.replayingSessions`, which gates off activity_delta's
+    // inactivity-warning clear (test-order contamination).
+    resetReplayFlags();
   });
 
   afterEach(() => {

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -120,6 +120,14 @@ function seedStore(fx: ContractFixture) {
     // permission_resolved's unconditional banner-drain (s.sessionNotifications.map)
     // runs against a realistic store instead of throwing on undefined.
     sessionNotifications: [],
+    // #6325: flat connection-state fields the real store always initialises;
+    // seed them so handlers that read them (client_joined → connectedClients,
+    // activity_delta/_snapshot → activity, server_error → serverErrors) exercise
+    // their real path instead of throwing on undefined. Off the asserted
+    // sessions[id] slice, so existing fixtures are unaffected.
+    connectedClients: [],
+    activity: { bySession: {} },
+    serverErrors: [],
     // Store methods the real stream/tool handlers reach for (terminal preview
     // writes, flat addMessage). No-op-ish so the session-state assertions stand
     // alone — the terminal-preview side-channel is covered by its own tests.

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -73,7 +73,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // — each client owns its `activity` store field), so they stay PENDING rather
   // than carrying a DISPATCH_FIXTURES entry.
   'activity_snapshot',
-  'activity_delta',
+  // activity_delta — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   // agent_list — migrated to the shared dispatch table (#5618 Batch 2); now has
   // a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   // auth_bootstrap — migrated to the shared dispatch table (#5618 Batch 5b).
@@ -88,7 +88,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'checkpoint_restored',
   // claude_ready — now has a SWITCH_FIXTURES entry (#6325, session-scalar assert).
   // client_focus_changed — migrated to the shared dispatch table (#5618 Batch 4).
-  'client_joined',
+  // client_joined — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   'client_left',
   'conversations_list',
   // cost_update — migrated to the shared dispatch table (#5618 Batch 5a).
@@ -100,8 +100,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // permission_expired — now has a SWITCH_FIXTURES entry (#6325).
   // permission_mode_changed — now has a SWITCH_FIXTURES entry (#6325, scalar assert).
   // permission_resolved now has a both-clients SWITCH_FIXTURES entry (#6058).
-  'permission_timeout',
-  'plan_ready',
+  // permission_timeout — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
+  // plan_ready — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   'pong',
   // primary_changed — migrated to the shared dispatch table (#5618 Batch 4).
   // provider_list — migrated to the shared dispatch table (#5618 Batch 2);
@@ -109,19 +109,19 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'raw',
   'raw_background',
   'search_results',
-  'server_error',
+  // server_error — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   'server_mode',
   'server_shutdown',
   // server_status — now has a SWITCH_FIXTURES entry (#6325 batch A).
   // session_error — now has a SWITCH_FIXTURES entry (#6325 batch A).
-  'session_list',
+  // session_list — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   // session_persist_failed / session_restore_failed / session_stopped — migrated
   // to the shared dispatch table (#5618 Batch 3); now have DISPATCH_FIXTURES
   // entries, so they leave the both-clients-switch universe.
   // session_role — migrated to the shared dispatch table (#5618 Batch 4).
   'session_switched',
   'session_timeout',
-  'session_warning',
+  // session_warning — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   // slash_commands — migrated to the shared dispatch table (#5618 Batch 2); now
   // has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   // stream_delta — now has a SWITCH_FIXTURES entry (#6325 batch A).

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1824,4 +1824,187 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       sessions: { s1: { messages: [{ id: 'resp-1', type: 'response', content: 'Hello, world' }] } },
     },
   },
+  {
+    // #6325 (drain #6314): a live-activity delta. Its PRIMARY effect (the flat
+    // `activity` tree) isn't switch-harness-assertable, but it has a deterministic
+    // both-clients session-scalar side effect: clearing the target session's
+    // inactivityWarning to null (live activity = the user is back). lastClientActivityAt
+    // is also written but is Date.now() (non-deterministic) → deliberately not asserted.
+    name: 'activity_delta clears any inactivityWarning on its target session (live-activity bump)',
+    type: 'activity_delta',
+    init: { sessions: { s1: { inactivityWarning: { idleMs: 60000, prefab: 'Still there?', receivedAt: 1000 } } } },
+    message: {
+      type: 'activity_delta',
+      sessionId: 's1',
+      schemaVersion: 1,
+      op: 'started',
+      entry: { id: 'a1', kind: 'shell', label: 'npm test', status: 'running', startedAt: 1000 },
+    },
+    expect: { sessions: { s1: { inactivityWarning: null } } },
+  },
+  {
+    // #6325 (drain #6314): another client connected. With ONE seeded (active)
+    // session the app's active-only append and the dashboard's all-sessions append
+    // converge → a plain expect (the divergence is only observable with 2+ seeded
+    // sessions). Seeds a prior bubble so the 2-entry expect is non-vacuous.
+    name: 'client_joined appends a connected-device system bubble to the active session',
+    type: 'client_joined',
+    init: {
+      activeSessionId: 's1',
+      sessions: { s1: { messages: [{ id: 'seed-1', type: 'response', content: 'prior' } as unknown as ChatMessage] } },
+    },
+    message: {
+      type: 'client_joined',
+      client: { clientId: 'c2', deviceName: 'iPhone 16 Pro', deviceType: 'phone', platform: 'ios' },
+    },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            { id: 'seed-1', type: 'response', content: 'prior' },
+            { type: 'system', content: 'iPhone 16 Pro connected' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    // #6325 (drain #6314): a pending permission auto-denied after the server
+    // timeout. Both clients (shared handlePermissionTimeout) scan sessionStates for
+    // the matching `prompt` (requestId + type==='prompt') and append a fixed
+    // '(Auto-denied — permission timed out)' suffix in place (options cleared, not
+    // asserted). Targeting is by requestId alone, so the fixture seeds the prompt.
+    name: 'permission_timeout appends the auto-denied suffix to the matching prompt in place (both clients)',
+    type: 'permission_timeout',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [
+            {
+              id: 'prompt-req-1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/x',
+              tool: 'Bash',
+              requestId: 'req-1',
+              options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+            } as unknown as ChatMessage,
+          ],
+        },
+      },
+    },
+    message: { type: 'permission_timeout', requestId: 'req-1', tool: 'Bash' },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            { id: 'prompt-req-1', type: 'prompt', content: 'Bash: rm -rf /tmp/x\n(Auto-denied — permission timed out)', tool: 'Bash' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    // #6325 (drain #6314): the plan is ready. Both clients flip the session to
+    // plan-pending and store the allowed prompts (session-scalar fields).
+    name: 'plan_ready flips plan state to ready and stores the allowed prompts (both clients)',
+    type: 'plan_ready',
+    init: { sessions: { s1: { isPlanPending: false, planAllowedPrompts: [] } } },
+    message: {
+      type: 'plan_ready',
+      sessionId: 's1',
+      allowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'Proceed with the plan' }],
+    },
+    expect: {
+      sessions: {
+        s1: {
+          isPlanPending: true,
+          planAllowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'Proceed with the plan' }],
+        },
+      },
+    },
+  },
+  {
+    // #6325 (drain #6314): a server-side error tagged to a session. Both clients
+    // (shared handleServerError) append an `error` bubble to the tagged session and
+    // clear streamingMessageId + pendingClientMessageId. The serverErrors ring +
+    // notification toast are off the sessions[id] slice.
+    name: 'server_error appends an error bubble to the tagged session and clears the live stream (both clients)',
+    type: 'server_error',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [{ id: 'resp-1', type: 'response', content: 'working' } as unknown as ChatMessage],
+          streamingMessageId: 'live-1',
+          pendingClientMessageId: 'uin-1',
+        },
+      },
+    },
+    message: { type: 'server_error', sessionId: 's1', category: 'session', message: 'Disk write failed', recoverable: true },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            { id: 'resp-1', type: 'response', content: 'working' },
+            { type: 'error', content: 'Disk write failed' },
+          ],
+          streamingMessageId: null,
+          pendingClientMessageId: null,
+        },
+      },
+    },
+  },
+  {
+    // #6325 (drain #6314): a session_list refresh patches conversationId onto a
+    // pre-existing session (the patch loop skips ids not already in sessionStates).
+    // Seeds a different starting conversationId so the patch is non-vacuous.
+    name: 'session_list patches conversationId onto a pre-existing session (both clients)',
+    type: 'session_list',
+    init: { activeSessionId: 's1', sessions: { s1: { conversationId: 'conv-OLD' } } },
+    message: {
+      type: 'session_list',
+      sessions: [
+        {
+          sessionId: 's1',
+          name: 'Session 1',
+          cwd: '/tmp',
+          type: 'cli',
+          hasTerminal: false,
+          model: null,
+          permissionMode: null,
+          isBusy: false,
+          createdAt: 0,
+          conversationId: 'conv-NEW',
+        },
+      ],
+    },
+    expect: { sessions: { s1: { conversationId: 'conv-NEW' } } },
+  },
+  {
+    // #6325 (drain #6314): a session_warning legitimately DIVERGES. The dashboard
+    // pushes a `system` warning bubble into the target session's messages; the app
+    // instead writes the warning to its flat `timeoutWarning` banner slot and leaves
+    // messages untouched. Target = the active session so the dashboard's
+    // non-active-session Alert side effect doesn't fire.
+    name: 'session_warning diverges: dashboard appends a warning bubble; the app keeps messages untouched',
+    type: 'session_warning',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: {
+      type: 'session_warning',
+      sessionId: 's1',
+      name: 'My Session',
+      reason: 'idle_timeout',
+      message: 'Session will time out in 2 minutes',
+      remainingMs: 120000,
+    },
+    divergent: {
+      reason:
+        'the dashboard pushes the shared system ChatMessage into the target session’s messages; the app writes the parsed ' +
+        'warning into the flat timeoutWarning slot (banner UI) + useNotificationStore and leaves sessions[id].messages untouched. ' +
+        'Target = the active session so the dashboard’s non-active-session Alert side effect does not fire.',
+      app: { sessions: { s1: { messages: [] } } },
+      dashboard: { sessions: { s1: { messages: [{ type: 'system', content: 'Session will time out in 2 minutes' }] } } },
+    },
+  },
 ]


### PR DESCRIPTION
Part of #6325 (epic #6314 fixture drain). Hardens both contract-switch harnesses, then drains 7 types that were blocked only by harness gaps. PENDING: 26 → 19.

## Harness hardening (additive — existing fixtures unaffected)
The 29-type classification + an empirical run found 7 types whose **asserted** effect is on `sessions[id]`, but whose handlers **throw** on flat connection-state the harness left unseeded (or on incomplete mocks). Fixed in both harnesses:
- **seedStore flat fields** (app + dashboard): `connectedClients`, `activity` (`{bySession:{}}`), `serverErrors` (+ app: `sessionNotifications`) — the flat fields the real store always initialises. Off the asserted `sessions[id]` slice.
- **app mocks**: `useNotificationStore` gains `sessionNotifications`/`addSessionNotification`/`dismissSessionNotification`/`setTimeoutWarning`/`addServerError`; multi-client gains `addClient`; persistence gains `persistLastConversationId`.
- **app `beforeEach` now calls `resetReplayFlags()`** — the dashboard twin already did. Without it a prior history-replay fixture leaves a session in `_ctx.replayingSessions`, which gates off `activity_delta`'s inactivity-warning clear (a real test-order contamination bug in the app harness, surfaced by this drain).

## Drained (7, verified both-clients via both real switches)
`activity_delta` (clears inactivityWarning), `client_joined` (connected-device bubble), `permission_timeout` (auto-denied suffix in place), `plan_ready` (plan-pending + allowed prompts), `server_error` (error bubble + clears live stream), `session_list` (conversationId patch). Plus **`session_warning` as a documented `divergent` fixture** — the dashboard appends a warning bubble; the app keeps `messages` untouched and routes it to its flat `timeoutWarning` banner.

All seed a *different* starting value than the expect (non-vacuous). `history_replay_end` is deferred — it needs a replay baseline (multi-message) the single-message harness can't seed yet.

## Verification
Full store-core (1838) + contract-fixtures (106) + app contract-switch (32) + dashboard contract-switch (32) + app/dashboard tsc all green.

Part of #6325