### PR TITLE
test: add expect.flat assertion to contract-switch harness + drain 9 types (#6325)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -75,17 +75,23 @@ jest.mock('../src/store/notifications', () => ({
       dismissSessionNotification: jest.fn(),
       setTimeoutWarning: jest.fn(),
       addServerError: jest.fn(),
+      setShutdown: jest.fn(),
     })),
     setState: jest.fn(),
   },
 }));
 
 jest.mock('../src/store/conversations', () => ({
-  useConversationStore: { getState: jest.fn(() => ({})), setState: jest.fn() },
+  // #6325: conversations_list/search_results mirror into the conversation store.
+  useConversationStore: {
+    getState: jest.fn(() => ({ setConversationHistory: jest.fn(), setSearchResults: jest.fn() })),
+    setState: jest.fn(),
+  },
 }));
 
 jest.mock('../src/store/connection-lifecycle', () => ({
-  useConnectionLifecycleStore: { getState: jest.fn(() => ({})), setState: jest.fn() },
+  // #6325: server_mode routes serverInfo into the connection-lifecycle store.
+  useConnectionLifecycleStore: { getState: jest.fn(() => ({ setServerInfo: jest.fn() })), setState: jest.fn() },
 }));
 
 jest.mock('expo-secure-store', () => ({
@@ -166,7 +172,7 @@ function seedStore(fx: ContractFixture) {
   for (const [id, seed] of Object.entries(fx.init?.sessions ?? {})) {
     sessionStates[id] = { ...createEmptySessionState(), ...(seed as Partial<SessionState>) };
   }
-  return createMockStore({
+  const store = createMockStore({
     activeSessionId: fx.init?.activeSessionId ?? null,
     sessions: [],
     availableProviders: [],
@@ -185,7 +191,19 @@ function seedStore(fx: ContractFixture) {
     activity: { bySession: {} },
     serverErrors: [],
     sessionNotifications: [],
+    // #6325: store methods the session-lifecycle handlers call at their tail —
+    // no-op stubs so session_switched/checkpoint_restored don't throw on an
+    // undefined method. switchSession is wired below (it must write activeSessionId).
+    fetchSlashCommands: jest.fn(),
+    fetchCustomAgents: jest.fn(),
   } as unknown as ConnectionState);
+  // #6325: checkpoint_restored calls get().switchSession(newId) — stub it to
+  // write the flat activeSessionId (the both-clients converged effect the fixture
+  // asserts). setState spreads prior state, so the method survives later writes.
+  (store.getState() as unknown as { switchSession: unknown }).switchSession = jest.fn((sessionId: string) =>
+    store.setState({ activeSessionId: sessionId }),
+  );
+  return store;
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +262,13 @@ describe('contract switch fixtures — app real handleMessage (#5556.5)', () => 
         if (Object.keys(scalarFields).length > 0) {
           expect(ss).toMatchObject(scalarFields);
         }
+      }
+      // #6325: assert any flat (top-level connection-state) fields a fixture
+      // specifies — server_mode, serverStatus, connectedClients, conversations,
+      // searchResults, … — via toMatchObject on the whole store. Omitted slice =
+      // "don't care", so existing fixtures are unaffected.
+      if (exp!.flat) {
+        expect(store.getState()).toMatchObject(exp!.flat);
       }
     });
   }

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -109,7 +109,7 @@ function seedStore(fx: ContractFixture) {
     sessionStates[id] = { ...createEmptySessionState(), ...(seed as Partial<SessionState>) }
   }
   const terminalWrites: string[] = []
-  return createMockStore({
+  const store = createMockStore({
     connectionPhase: 'connected',
     socket: null,
     sessions: [],
@@ -128,6 +128,11 @@ function seedStore(fx: ContractFixture) {
     connectedClients: [],
     activity: { bySession: {} },
     serverErrors: [],
+    // #6325: no-op stubs for the session-lifecycle handler tails
+    // (session_switched calls fetchSlashCommands/fetchCustomAgents; switchSession
+    // is wired below to write the flat activeSessionId for checkpoint_restored).
+    fetchSlashCommands: () => {},
+    fetchCustomAgents: () => {},
     // Store methods the real stream/tool handlers reach for (terminal preview
     // writes, flat addMessage). No-op-ish so the session-state assertions stand
     // alone — the terminal-preview side-channel is covered by its own tests.
@@ -140,6 +145,11 @@ function seedStore(fx: ContractFixture) {
     addServerError: () => {},
     _terminalWrites: terminalWrites,
   } as unknown as ConnectionState)
+  // #6325: checkpoint_restored calls get().switchSession(newId) — stub it to write
+  // the flat activeSessionId (setState spreads prior state, so it survives writes).
+  ;(store.getState() as unknown as { switchSession: unknown }).switchSession = (sessionId: string) =>
+    store.setState({ activeSessionId: sessionId })
+  return store
 }
 
 // ---------------------------------------------------------------------------
@@ -199,6 +209,13 @@ describe('contract switch fixtures — dashboard real handleMessage (#5556.5)', 
         if (Object.keys(scalarFields).length > 0) {
           expect(ss, `${fx.name}: ${id} scalar fields`).toMatchObject(scalarFields)
         }
+      }
+      // #6325: assert any flat (top-level connection-state) fields a fixture
+      // specifies — serverMode, serverStatus, connectedClients, conversations,
+      // searchResults, … — via toMatchObject on the whole store. Omitted slice =
+      // "don't care", so existing fixtures are unaffected.
+      if (exp!.flat) {
+        expect(store.getState(), `${fx.name}: flat fields`).toMatchObject(exp!.flat)
       }
     })
   }

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -72,7 +72,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // They are NOT on the shared dispatch table (the reducer write is platform-local
   // — each client owns its `activity` store field), so they stay PENDING rather
   // than carrying a DISPATCH_FIXTURES entry.
-  'activity_snapshot',
+  // activity_snapshot — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // activity_delta — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   // agent_list — migrated to the shared dispatch table (#5618 Batch 2); now has
   // a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
@@ -85,12 +85,12 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // both-clients-switch universe. checkpoint_restored is NOT migrated in this
   // batch (both clients still handle it platform-locally — the app via a switch
   // case, the dashboard via its HANDLERS map), so it remains pending.
-  'checkpoint_restored',
+  // checkpoint_restored — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // claude_ready — now has a SWITCH_FIXTURES entry (#6325, session-scalar assert).
   // client_focus_changed — migrated to the shared dispatch table (#5618 Batch 4).
   // client_joined — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
-  'client_left',
-  'conversations_list',
+  // client_left — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
+  // conversations_list — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // cost_update — migrated to the shared dispatch table (#5618 Batch 5a).
   'history_replay_end',
   'key_exchange_ok',
@@ -108,10 +108,10 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // app/dashboard element-handling divergence locked by a divergent fixture.
   'raw',
   'raw_background',
-  'search_results',
+  // search_results — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // server_error — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
-  'server_mode',
-  'server_shutdown',
+  // server_mode — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
+  // server_shutdown — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // server_status — now has a SWITCH_FIXTURES entry (#6325 batch A).
   // session_error — now has a SWITCH_FIXTURES entry (#6325 batch A).
   // session_list — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
@@ -119,8 +119,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // to the shared dispatch table (#5618 Batch 3); now have DISPATCH_FIXTURES
   // entries, so they leave the both-clients-switch universe.
   // session_role — migrated to the shared dispatch table (#5618 Batch 4).
-  'session_switched',
-  'session_timeout',
+  // session_switched — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
+  // session_timeout — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // session_warning — now has a SWITCH_FIXTURES entry (#6325; harness flat-seed/mock harden).
   // slash_commands — migrated to the shared dispatch table (#5618 Batch 2); now
   // has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2007,4 +2007,212 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       dashboard: { sessions: { s1: { messages: [{ type: 'system', content: 'Session will time out in 2 minutes' }] } } },
     },
   },
+  {
+    // #6325 (bucket-B flat-assert): an activity_snapshot REPLACES the target
+    // session's flat `activity` tree ({byId, order} per session) — both clients run
+    // the same applyActivitySnapshot + set({ activity }). A snapshot is a full-state
+    // resync, so (unlike activity_delta) it does NOT touch any session scalar. The
+    // harness seeds activity:{bySession:{}}, so populate-from-empty is non-vacuous.
+    name: "activity_snapshot replaces the target session's flat activity tree",
+    type: 'activity_snapshot',
+    message: {
+      type: 'activity_snapshot',
+      sessionId: 's1',
+      schemaVersion: 1,
+      entries: [
+        { id: 'a1', kind: 'shell', label: 'npm test', status: 'running', startedAt: 1000 },
+        { id: 'a2', kind: 'agent', label: 'review', status: 'done', startedAt: 1000, endedAt: 2000 },
+      ],
+    },
+    expect: {
+      flat: {
+        activity: {
+          bySession: {
+            s1: {
+              byId: {
+                a1: { id: 'a1', kind: 'shell', label: 'npm test', status: 'running', startedAt: 1000 },
+                a2: { id: 'a2', kind: 'agent', label: 'review', status: 'done', startedAt: 1000, endedAt: 2000 },
+              },
+              order: ['a1', 'a2'],
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    // #6325 (bucket-B): server re-homed this client onto a NEW session at the
+    // checkpoint. Both clients parse via shared handleCheckpointRestored then call
+    // get().switchSession(newSessionId); the converged both-clients flat effect is
+    // activeSessionId = newSessionId (the harness stubs switchSession to write it).
+    // Seeds activeSessionId 'old-sid' (≠ new) so the flip is non-vacuous and
+    // switchSession doesn't early-return.
+    name: 'checkpoint_restored re-homes the active session to the new checkpoint session (both clients)',
+    type: 'checkpoint_restored',
+    init: { activeSessionId: 'old-sid', sessions: { 'old-sid': {} } },
+    message: { type: 'checkpoint_restored', checkpointId: 'cp-1', newSessionId: 'cp-new-sid', name: 'Rewind: cp-1' },
+    expect: { flat: { activeSessionId: 'cp-new-sid' } },
+  },
+  {
+    // #6325 (bucket-B): another client disconnected. With ONE seeded (active)
+    // session the app's active-only append and the dashboard's all-sessions append
+    // converge → a plain expect (mirrors client_joined). The bubble label is
+    // 'A device' (not the wire id): handleClientLeft looks the departing client up
+    // in connectedClients, which the harness seeds to [] → fallback 'A device'. The
+    // roster flat effect ([]→[]) is vacuous, so we assert the bubble, not the roster.
+    name: 'client_left appends a disconnected-device system bubble to the active session',
+    type: 'client_left',
+    init: {
+      activeSessionId: 's1',
+      sessions: { s1: { messages: [{ id: 'seed-1', type: 'response', content: 'prior' } as unknown as ChatMessage] } },
+    },
+    message: { type: 'client_left', clientId: 'c2' },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            { id: 'seed-1', type: 'response', content: 'prior' },
+            { type: 'system', content: 'A device disconnected' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    // #6325 (bucket-B): both clients write the flat `conversationHistory` from the
+    // parsed `conversations` array (shared handleConversationsList). The app also
+    // mirrors to the mocked useConversationStore; the shared, non-mocked flat field
+    // both set identically is conversationHistory. Unseeded default → non-vacuous.
+    name: 'conversations_list replaces the flat conversationHistory list (both clients)',
+    type: 'conversations_list',
+    message: {
+      type: 'conversations_list',
+      conversations: [
+        {
+          conversationId: 'conv-1',
+          project: '/proj',
+          projectName: 'proj',
+          modifiedAt: '2026-06-24T00:00:00Z',
+          modifiedAtMs: 1750000000000,
+          sizeBytes: 1024,
+          preview: 'first turn',
+          cwd: '/proj',
+        },
+        {
+          conversationId: 'conv-2',
+          project: null,
+          projectName: 'other',
+          modifiedAt: '2026-06-23T00:00:00Z',
+          modifiedAtMs: 1749900000000,
+          sizeBytes: 2048,
+          preview: null,
+          cwd: null,
+        },
+      ],
+    },
+    expect: {
+      flat: {
+        conversationHistory: [
+          { conversationId: 'conv-1', projectName: 'proj', preview: 'first turn' },
+          { conversationId: 'conv-2', projectName: 'other', preview: null },
+        ],
+      },
+    },
+  },
+  {
+    // #6325 (bucket-B): both clients call sharedSearchResults then set({
+    // searchResults, searchLoading:false }). searchQuery is left unseeded so the
+    // staleness gate short-circuits → apply. Unseeded searchResults/searchLoading
+    // → non-vacuous. searchError is app-only (not asserted).
+    name: 'search_results replaces the flat searchResults list (both clients)',
+    type: 'search_results',
+    message: {
+      type: 'search_results',
+      query: 'auth',
+      results: [
+        {
+          conversationId: 'conv-1',
+          projectName: 'chroxy',
+          project: 'chroxy',
+          cwd: '/Users/me/chroxy',
+          preview: 'auth handler',
+          snippet: 'ws-auth.js validates the bearer token',
+          matchCount: 3,
+        },
+      ],
+    },
+    expect: {
+      flat: {
+        searchResults: [
+          {
+            conversationId: 'conv-1',
+            projectName: 'chroxy',
+            preview: 'auth handler',
+            matchCount: 3,
+          },
+        ],
+        searchLoading: false,
+      },
+    },
+  },
+  {
+    // #6325 (bucket-B): server_mode legitimately DIVERGES. The dashboard sets the
+    // flat main-store `serverMode`; the app routes it into the mocked
+    // useConnectionLifecycleStore (setServerInfo) and only conditionally sets
+    // viewMode (guarded on viewMode==='terminal', never seeded) — so the app makes
+    // no observable main-store mutation. Dashboard asserts flat serverMode; app no-op.
+    name: 'server_mode sets the flat serverMode on the dashboard; the app routes it to the mocked lifecycle store (divergent)',
+    type: 'server_mode',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'server_mode', mode: 'cli' },
+    divergent: {
+      reason:
+        "the dashboard writes the flat main-store field serverMode (set({serverMode:'cli'})); the app routes serverMode into the " +
+        'secondary useConnectionLifecycleStore (mocked here) and only conditionally sets viewMode (guarded on a terminal viewMode the ' +
+        'harness never seeds), so the app makes no observable main-store mutation.',
+      app: {},
+      dashboard: { flat: { serverMode: 'cli' } },
+    },
+  },
+  {
+    // #6325 (bucket-B): the server announced a restart. Both clients run the shared
+    // handleServerShutdown and set its patch onto the flat store: shutdownReason +
+    // restartEtaMs (restartingSince is Date.now() → not asserted). Both flat fields
+    // unseeded → non-vacuous. The app's setShutdown notification is off-slice.
+    name: 'server_shutdown writes shutdownReason + restartEtaMs to the flat store (both clients)',
+    type: 'server_shutdown',
+    message: { type: 'server_shutdown', reason: 'restart', restartEtaMs: 30000 },
+    expect: {
+      flat: { shutdownReason: 'restart', restartEtaMs: 30000 },
+    },
+  },
+  {
+    // #6325 (bucket-B): the active session switched. Both clients (shared
+    // handleSessionSwitched) set the flat activeSessionId to the new id and lazily
+    // init sessionStates[newId], stamping conversationId. Seeds a different starting
+    // activeSessionId so the flip is non-vacuous; the switched-to session is created
+    // by the handler. fetchSlashCommands/fetchCustomAgents at the tail are stubbed.
+    name: 'session_switched flips activeSessionId and initialises the switched-to session with its conversationId (both clients)',
+    type: 'session_switched',
+    init: { activeSessionId: 's-old', sessions: { 's-old': {} } },
+    message: { type: 'session_switched', sessionId: 's-new', conversationId: 'conv-7' },
+    expect: {
+      flat: { activeSessionId: 's-new' },
+      sessions: { 's-new': { conversationId: 'conv-7' } },
+    },
+  },
+  {
+    // #6325 (bucket-B): session_timeout deletes the timed-out session and, when it
+    // was active, reassigns the flat activeSessionId to the first remaining session.
+    // s1 (active) times out, s2 survives → both set activeSessionId 's2'. The deleted
+    // session is NOT listed under expect.sessions (the harness does toBeDefined()
+    // per id); only the flat activeSessionId effect is asserted (both agree).
+    name: 'session_timeout removes the active session and switches activeSessionId to the next remaining session',
+    type: 'session_timeout',
+    init: { activeSessionId: 's1', sessions: { s1: {}, s2: {} } },
+    message: { type: 'session_timeout', sessionId: 's1', name: 'Old Session' },
+    expect: {
+      flat: { activeSessionId: 's2' },
+    },
+  },
 ]


### PR DESCRIPTION
Part of #6325 (epic #6314 fixture drain). Wires the `expect.flat` slice into the switch harness, then drains the 9 bucket-B (flat connection-state) types. PENDING: 19 → 10.

## Harness: expect.flat
`FixtureExpectation.flat` already existed (the dispatch harness uses it); this extends **both** contract-switch harnesses to assert it via `toMatchObject(store.getState(), exp.flat)` after the sessions checks. Additive (omitted slice = don't-care) — **proven load-bearing by a negative probe** (a wrong flat value fails the suite).

Plus additive harness stubs for the handlers' secondary-store/method tails: app mocks gain `setConversationHistory`/`setSearchResults`/`setServerInfo`/`setShutdown`; both seedStores gain a `switchSession` stub (writes flat `activeSessionId`) + `fetchSlashCommands`/`fetchCustomAgents` no-ops.

## Drained (9, verified both-clients)
| type | asserted effect |
|---|---|
| `activity_snapshot` | flat `activity` tree (replace) |
| `checkpoint_restored` | flat `activeSessionId` (via `switchSession`) |
| `conversations_list` | flat `conversationHistory` |
| `search_results` | flat `searchResults` + `searchLoading` |
| `server_shutdown` | flat `shutdownReason` + `restartEtaMs` |
| `session_switched` | flat `activeSessionId` + new session `conversationId` |
| `session_timeout` | flat `activeSessionId` after deleting the active session |
| `client_left` | system bubble (roster flat effect vacuous with empty seeded roster) |
| `server_mode` | **divergent** — dashboard sets flat `serverMode`; app routes to the mocked lifecycle store (no main-store change) |

All seeded with a different/unseeded starting value (non-vacuous).

## Deferred
`auth_ok`/`auth_fail` (deepest connection-teardown surface — many lifecycle setters, encryption gate, heartbeat) to a focused slice; bucket C (`raw`/`terminal_output`, terminal mirror) + the 5 F-type reviews remain (10 PENDING).

## Verification
Full store-core (1838) + contract-fixtures (106) + app contract-switch (41) + dashboard contract-switch (41) + app/dashboard tsc green; negative probe confirmed `expect.flat` fails on a wrong value.

Part of #6325