### PR TITLE
test: drain auth_ok + auth_fail + pair_fail from PENDING_CONTRACT (#6325)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -47,7 +47,7 @@ jest.mock('../src/store/imperative-callbacks', () => ({
 
 jest.mock('../src/store/multi-client', () => ({
   // #6325: client_joined calls addClient on the roster store.
-  useMultiClientStore: { getState: jest.fn(() => ({ setClients: jest.fn(), addClient: jest.fn(), removeClient: jest.fn() })), setState: jest.fn() },
+  useMultiClientStore: { getState: jest.fn(() => ({ setClients: jest.fn(), addClient: jest.fn(), removeClient: jest.fn(), setMyClientId: jest.fn(), setConnectedClients: jest.fn() })), setState: jest.fn() },
 }));
 
 jest.mock('../src/store/web', () => ({
@@ -90,8 +90,21 @@ jest.mock('../src/store/conversations', () => ({
 }));
 
 jest.mock('../src/store/connection-lifecycle', () => ({
-  // #6325: server_mode routes serverInfo into the connection-lifecycle store.
-  useConnectionLifecycleStore: { getState: jest.fn(() => ({ setServerInfo: jest.fn() })), setState: jest.fn() },
+  // #6325: server_mode/auth_ok/auth_fail/pair_fail route connection state into
+  // the lifecycle store — provide the full setter surface they reach for.
+  useConnectionLifecycleStore: {
+    getState: jest.fn(() => ({
+      setServerInfo: jest.fn(),
+      setConnectionPhase: jest.fn(),
+      setConnectionDetails: jest.fn(),
+      setActivePath: jest.fn(),
+      setConnectionError: jest.fn(),
+      setUserDisconnected: jest.fn(),
+      setSavedConnection: jest.fn(),
+      savedConnection: null,
+    })),
+    setState: jest.fn(),
+  },
 }));
 
 jest.mock('expo-secure-store', () => ({
@@ -146,7 +159,8 @@ function createMockStore(initial: Partial<ConnectionState>) {
 const mockCtx = {
   url: 'wss://test.example.com',
   token: 'test-token',
-  socket: {} as WebSocket,
+  // #6325: auth_fail/pair_fail call ctx.socket.close() before tearing down.
+  socket: { close: jest.fn() } as unknown as WebSocket,
   isReconnect: false,
   silent: false,
 };

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -77,8 +77,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // agent_list — migrated to the shared dispatch table (#5618 Batch 2); now has
   // a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   // auth_bootstrap — migrated to the shared dispatch table (#5618 Batch 5b).
-  'auth_fail',
-  'auth_ok',
+  // auth_fail — now has a SWITCH_FIXTURES entry (#6325 close-out).
+  // auth_ok — now has a SWITCH_FIXTURES entry (#6325 close-out).
   // available_models — migrated to the shared dispatch table (#5618 Batch 5a).
   // checkpoint_created / checkpoint_list — migrated to the shared dispatch table
   // (#5618 Batch 6); both now have DISPATCH_FIXTURES entries, so they leave the
@@ -96,7 +96,7 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   'key_exchange_ok',
   // multi_question_intervention — migrated to the shared dispatch table (#5618);
   // now has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
-  'pair_fail',
+  // pair_fail — now has a SWITCH_FIXTURES entry (#6325 close-out).
   // permission_expired — now has a SWITCH_FIXTURES entry (#6325).
   // permission_mode_changed — now has a SWITCH_FIXTURES entry (#6325, scalar assert).
   // permission_resolved now has a both-clients SWITCH_FIXTURES entry (#6058).

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2215,4 +2215,69 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       flat: { activeSessionId: 's2' },
     },
   },
+  {
+    // #6325 (auth_ok close-out): the handshake-complete frame. Both clients run the
+    // shared handleAuthOk parser, then write a SHARED slice onto the flat main store
+    // via set(connectedState): the boolean-coerced webFeatures map AND the
+    // shutdown-state clear (shutdownReason/restartEtaMs/restartingSince → null, "clear
+    // shutdown on a successful connect"). The dashboard ALSO writes serverMode/version/
+    // etc. flat; the app routes those into the mocked lifecycle/multi-client stores —
+    // so those DIVERGE and are not asserted. webFeatures (unseeded; the wire carries
+    // mixed-truthy values the parser coerces to strict booleans) + the shutdown trio
+    // (unseeded → the null clear) are the non-vacuous both-clients flat slice.
+    name: 'auth_ok writes the shared webFeatures map and clears shutdown state on the flat main store (both clients)',
+    type: 'auth_ok',
+    message: {
+      type: 'auth_ok',
+      webFeatures: { available: 1, remote: true, teleport: 0 },
+    },
+    expect: {
+      flat: {
+        webFeatures: { available: true, remote: true, teleport: false },
+        shutdownReason: null,
+        restartEtaMs: null,
+        restartingSince: null,
+      },
+    },
+  },
+  {
+    // #6325 (auth_fail close-out): the server rejected the bearer token. Both clients
+    // close the socket and tear down, but record the phase in DIFFERENT stores: the
+    // dashboard writes the flat main-store connectionPhase (set({ connectionPhase:
+    // 'disconnected', socket: null }), seeded 'connected' → non-vacuous); the app keeps
+    // connectionPhase in the secondary useConnectionLifecycleStore (mocked) and only
+    // writes socket: null (a WebSocket ref, not a meaningful assert) — so no observable
+    // main-store mutation. Same divergence shape as server_mode.
+    name: 'auth_fail flips the dashboard flat connectionPhase to disconnected; the app routes the phase to the mocked lifecycle store (divergent)',
+    type: 'auth_fail',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'auth_fail', reason: 'expired token' },
+    divergent: {
+      reason:
+        "the dashboard writes the flat main-store field connectionPhase via set({ connectionPhase: 'disconnected', socket: null }) " +
+        '(seeded connected → non-vacuous); the app keeps connectionPhase in the secondary useConnectionLifecycleStore (mocked here) and ' +
+        'writes only socket: null to the main store, so the app makes no observable main-store mutation.',
+      app: {},
+      dashboard: { flat: { connectionPhase: 'disconnected' } },
+    },
+  },
+  {
+    // #6325 (pair_fail close-out): pairing rejected — same divergence as auth_fail.
+    // The dashboard flips the flat connectionPhase to disconnected; the app routes the
+    // phase into the mocked lifecycle store and only does the vacuous set({socket:null}).
+    // Default reason 'unknown' (no reason field) skips the dashboard's requires_approval
+    // branch; activeServerId is unseeded so removeServer is never called.
+    name: 'pair_fail flips the dashboard flat connectionPhase to disconnected; the app routes the phase to the mocked lifecycle store (divergent)',
+    type: 'pair_fail',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'pair_fail' },
+    divergent: {
+      reason:
+        "the dashboard writes the flat main-store field connectionPhase via set({ connectionPhase: 'disconnected', socket: null }) " +
+        '(seeded connected → non-vacuous); the app routes the phase into the secondary useConnectionLifecycleStore (mocked here) and ' +
+        'only does the vacuous set({ socket: null }), so the app makes no observable main-store mutation.',
+      app: {},
+      dashboard: { flat: { connectionPhase: 'disconnected' } },
+    },
+  },
 ]


### PR DESCRIPTION
Part of #6325 (epic #6314 fixture drain). Three connection-handshake fixtures. PENDING: 10 → 7.

## Drained (verified both-clients)
- **`auth_ok`** (flat) — both clients write the shared boolean-coerced `webFeatures` map and clear shutdown state (`shutdownReason`/`restartEtaMs`/`restartingSince` → null) onto the flat main store. The server-info fields that diverge (app → mocked lifecycle/multi-client stores; dashboard → flat) are deliberately not asserted.
- **`auth_fail`** / **`pair_fail`** (divergent) — the dashboard flips the flat main-store `connectionPhase` to `'disconnected'`; the app keeps phase in the secondary `useConnectionLifecycleStore` (mocked) and makes no observable main-store change (same shape as the `server_mode` divergent fixture). The app side of the app `ConnectionState` has no `connectionPhase` field — phase genuinely lives in the lifecycle store.

All non-vacuous (`webFeatures`/shutdown trio unseeded; `connectionPhase` seeded `'connected'`).

## Harness (additive)
Extends the app mocks the auth path reaches: `mockCtx.socket.close()`, `useConnectionLifecycleStore` (full setter surface + `savedConnection:null`), `useMultiClientStore` (`setMyClientId`/`setConnectedClients`).

## Remaining (7)
- `raw`/`raw_background`/`terminal_output`/`pong`/`token_rotated` — no main-store-assertable both-clients contract (effect is the mocked terminal buffer, a pure heartbeat ack, or a URL/SecureStore write). A documented-exempt close-out follows.
- `key_exchange_ok`/`history_replay_end` — need a multi-message baseline the single-message harness can't seed.

## Verification
Full store-core (1838) + contract-fixtures (106) + app contract-switch (44) + dashboard contract-switch (44) + tsc green.

Part of #6325