### PR TITLE
test: multi-message contract-switch prelude; drain the last 2 types — PENDING now empty (#6344)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -17,7 +17,10 @@
 // ---------------------------------------------------------------------------
 
 jest.mock('../src/utils/crypto', () => ({
-  createKeyPair: jest.fn(),
+  // #6344: key_exchange_ok's prelude (encryption auth_ok) stashes _pendingKeyPair =
+  // createKeyPair() and reads .publicKey — return a stub so it's non-falsy (mirrors
+  // the dashboard crypto mock).
+  createKeyPair: jest.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
   deriveSharedKey: jest.fn(),
   encrypt: jest.fn(),
   decrypt: jest.fn(),
@@ -159,8 +162,9 @@ function createMockStore(initial: Partial<ConnectionState>) {
 const mockCtx = {
   url: 'wss://test.example.com',
   token: 'test-token',
-  // #6325: auth_fail/pair_fail call ctx.socket.close() before tearing down.
-  socket: { close: jest.fn() } as unknown as WebSocket,
+  // #6325/#6344: auth_fail/pair_fail call ctx.socket.close(); the key_exchange_ok
+  // prelude (encryption auth_ok) sends a discrete key_exchange via ctx.socket.send.
+  socket: { close: jest.fn(), send: jest.fn() } as unknown as WebSocket,
   isReconnect: false,
   silent: false,
 };
@@ -248,6 +252,11 @@ describe('contract switch fixtures — app real handleMessage (#5556.5)', () => 
       setStore(store);
       setConnectionContext(mockCtx as never);
 
+      // #6344: dispatch any prelude messages through the real handler first to
+      // establish multi-message context (e.g. a history_replay_start baseline).
+      for (const pre of fx.prelude ?? []) {
+        handleMessage(pre);
+      }
       handleMessage(fx.message);
       // Stream cases buffer deltas behind a flush timer; drain it.
       jest.runAllTimers();

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -181,6 +181,11 @@ describe('contract switch fixtures — dashboard real handleMessage (#5556.5)', 
       const store = seedStore(fx)
       setStore(store)
 
+      // #6344: dispatch any prelude messages through the real handler first to
+      // establish multi-message context (e.g. a history_replay_start baseline).
+      for (const pre of fx.prelude ?? []) {
+        handleMessage(pre, ctx(mockSocket) as never)
+      }
       handleMessage(fx.message, ctx(mockSocket) as never)
       // Stream cases buffer deltas behind a flush timer; drain it.
       vi.runAllTimers()

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -64,15 +64,13 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 // only legitimate when retro-fitting a pre-existing case, with a note.
 // ---------------------------------------------------------------------------
 const PENDING_CONTRACT_TYPES = new Set<string>([
-  // Remaining backlog (#6325 drained the rest into SWITCH_FIXTURES): only the two
-  // below stay pending — they need a MULTI-MESSAGE baseline the single-message
-  // contract-switch harness can't seed yet (it dispatches one wire message per
-  // fixture), so they await a harness that can stage a prior message first:
-  //   - history_replay_end: its in-place prompt resolution + reconcile only has an
-  //     observable effect after a prior history_replay_start(fullHistory) seeds the
-  //     rebuild baseline; dispatched alone it resolves against an empty baseline.
-  //   - key_exchange_ok: its effect depends on a prior key-exchange handshake
-  //     context (encryption state) that a single seeded message can't establish.
+  // EMPTY — the both-clients SWITCH_FIXTURES backlog is fully drained. Every
+  // both-clients switch type now has a behaviour-verified fixture (incl. the last
+  // two via the #6344 multi-message prelude: history_replay_end resolves against a
+  // history_replay_start baseline; key_exchange_ok runs after an encryption auth_ok
+  // stashes the pending key pair) OR is a documented NO_SWITCH_CONTRACT_BY_DESIGN
+  // exemption. Re-add a type here ONLY when retro-fitting a pre-existing case that
+  // genuinely can't be fixtured yet, with a note — prefer a real fixture.
   // agent_idle — now has a SWITCH_FIXTURES entry (#6325); the contract-switch
   // harness was extended to assert session-scalar fields (isIdle, …).
   // activity_snapshot / activity_delta — both clients now feed them through the
@@ -101,8 +99,8 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
   // client_left — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // conversations_list — now has a SWITCH_FIXTURES entry (#6325 bucket-B flat-assert).
   // cost_update — migrated to the shared dispatch table (#5618 Batch 5a).
-  'history_replay_end',
-  'key_exchange_ok',
+  // history_replay_end — now has a multi-message SWITCH_FIXTURES entry (#6344).
+  // key_exchange_ok — now has a multi-message SWITCH_FIXTURES entry (#6344).
   // multi_question_intervention — migrated to the shared dispatch table (#5618);
   // now has a DISPATCH_FIXTURES entry, so it leaves the both-clients-switch universe.
   // pair_fail — now has a SWITCH_FIXTURES entry (#6325 close-out).

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -125,6 +125,13 @@ export interface ContractFixture {
   type: string
   /** Starting store snapshot. */
   init?: FixtureInitialState
+  /**
+   * Optional ordered wire messages dispatched through the SAME real handleMessage
+   * BEFORE `message`, to establish context a single message can't (#6344) — e.g. a
+   * `history_replay_start` that seeds the rebuild baseline `history_replay_end`
+   * resolves against. The harness asserts only the post-`message` state.
+   */
+  prelude?: Array<Record<string, unknown>>
   /** The raw wire message handed to the dispatch path. */
   message: Record<string, unknown>
   /**
@@ -2276,6 +2283,58 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
         "the dashboard writes the flat main-store field connectionPhase via set({ connectionPhase: 'disconnected', socket: null }) " +
         '(seeded connected → non-vacuous); the app routes the phase into the secondary useConnectionLifecycleStore (mocked here) and ' +
         'only does the vacuous set({ socket: null }), so the app makes no observable main-store mutation.',
+      app: {},
+      dashboard: { flat: { connectionPhase: 'disconnected' } },
+    },
+  },
+  {
+    // #6344 (multi-message): history_replay_end's observable effect is the deferred
+    // atomic swap that slices off the pre-baseline prefix. That's only non-vacuous
+    // when (a) a full-rebuild baseline exists AND (b) entries were appended after it,
+    // so this fixture uses a prelude: history_replay_start(fullHistory) records the
+    // baseline at the seeded prefix length (1, no wipe — the #5555.4 contract), then
+    // a replayed `message` envelope appends after it. history_replay_end then swaps
+    // to the post-baseline tail → the seeded 'stale' prefix is removed, leaving only
+    // the replayed turn (1 in → 1 DIFFERENT out; a no-op would leave both = 2).
+    name: 'history_replay_end swaps to the replayed tail, dropping the pre-baseline prefix (multi-message)',
+    type: 'history_replay_end',
+    init: {
+      activeSessionId: 's1',
+      sessions: { s1: { messages: [{ id: 'old-1', type: 'response', content: 'stale' } as unknown as ChatMessage] } },
+    },
+    prelude: [
+      { type: 'history_replay_start', sessionId: 's1', fullHistory: true },
+      { type: 'message', sessionId: 's1', messageType: 'response', messageId: 'replayed-1', content: 'authoritative replayed turn', timestamp: 2000 },
+    ],
+    message: { type: 'history_replay_end', sessionId: 's1', latestSeq: 1 },
+    expect: {
+      sessions: {
+        s1: { messages: [{ id: 'replayed-1', type: 'response', content: 'authoritative replayed turn' }] },
+      },
+    },
+  },
+  {
+    // #6344 (multi-message): key_exchange_ok's only store-writing branch is the
+    // invalid-publicKey error path, gated behind `if (_pendingKeyPair)` — so alone
+    // it's a total no-op. The prelude auth_ok (encryption:'required', no
+    // serverPublicKey, unpinned→TOFU) takes the discrete-handshake fallback and
+    // stashes _pendingKeyPair; the asserted key_exchange_ok (publicKey omitted →
+    // null) then enters the guard and runs the error teardown. The divergence is the
+    // same shape as auth_fail/pair_fail: the dashboard flips the flat main-store
+    // connectionPhase; the app routes phase to the mocked lifecycle store (no
+    // observable main-store change).
+    name: 'key_exchange_ok (invalid server key) flips the dashboard flat connectionPhase; the app routes it to the mocked lifecycle store (divergent, multi-message)',
+    type: 'key_exchange_ok',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    prelude: [{ type: 'auth_ok', encryption: 'required' }],
+    message: { type: 'key_exchange_ok' },
+    divergent: {
+      reason:
+        "key_exchange_ok's only store-writing branch is the invalid-publicKey error path, gated behind if (_pendingKeyPair) — so " +
+        'without the prelude the handler is a pure no-op. The prelude auth_ok (encryption required, no serverPublicKey, unpinned→TOFU) ' +
+        'stashes _pendingKeyPair via the discrete-handshake fallback; the asserted key_exchange_ok (publicKey null) then runs the error ' +
+        'teardown. The dashboard writes the flat connectionPhase (seeded connected → non-vacuous); the app keeps phase in the mocked ' +
+        'lifecycle store and writes only socket: null, so it makes no observable main-store mutation.',
       app: {},
       dashboard: { flat: { connectionPhase: 'disconnected' } },
     },


### PR DESCRIPTION
Closes #6344. Empties `PENDING_CONTRACT_TYPES` entirely — the both-clients contract-fixture backlog (35 at the start of #6325) is **fully drained**.

## Harness: multi-message prelude
Adds a `prelude?: Array<Record<string, unknown>>` to `ContractFixture` — ordered wire messages dispatched through the **same real `handleMessage`** before the asserted message — so a fixture can establish multi-message context the single-message harness couldn't seed. Wired into both harnesses (inert for all existing fixtures; verified still 44 before the new fixtures).

## Drained (the last 2, verified both-clients)
- **`history_replay_end`** (single expect) — prelude: `history_replay_start(fullHistory)` records the rebuild baseline at the seeded prefix length, then a replayed `message` appends after it. `history_replay_end`'s deferred swap slices off the pre-baseline prefix, leaving only the replayed tail (seeded `stale` prefix → replaced; 1 in → 1 **different** out, so a no-op would leave 2 — non-vacuous).
- **`key_exchange_ok`** (divergent) — prelude: an encryption `auth_ok` (`required`, no `serverPublicKey`, unpinned→TOFU) stashes `_pendingKeyPair` via the discrete-handshake fallback; the asserted `key_exchange_ok` (null `publicKey`) then runs the `if (_pendingKeyPair)` error teardown. Same divergence as `auth_fail`/`pair_fail`: dashboard flips flat `connectionPhase`, app routes phase to the mocked lifecycle store.

Harness adds (additive): app `createKeyPair` mock now returns a stub pair (mirrors the dashboard); `mockCtx.socket` gains `send` (the prelude's discrete `key_exchange`).

## Result
**`PENDING_CONTRACT_TYPES` is now empty.** Every both-clients switch type is a behaviour-verified fixture (run through both clients' real switches) or a documented `NO_SWITCH_CONTRACT_BY_DESIGN` exemption.

## Verification
Full store-core (1839) + contract-fixtures/coverage-lint (107) + app contract-switch (46) + dashboard contract-switch (46) + app/dashboard tsc green.

Closes #6344