### PR TITLE
test: pin web_task_error taskId + SESSION_TOKEN_MISMATCH facets (#6268)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -209,6 +209,9 @@ function seedStore(fx: ContractFixture) {
     activity: { bySession: {} },
     serverErrors: [],
     sessionNotifications: [],
+    // #6268: web_task_error maps over state.webTasks; seed it (default []) so the
+    // .map never throws, and let a fixture seed a task to flip to `failed`.
+    webTasks: fx.init?.webTasks ?? [],
     // #6325: store methods the session-lifecycle handlers call at their tail —
     // no-op stubs so session_switched/checkpoint_restored don't throw on an
     // undefined method. switchSession is wired below (it must write activeSessionId).

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -128,6 +128,9 @@ function seedStore(fx: ContractFixture) {
     connectedClients: [],
     activity: { bySession: {} },
     serverErrors: [],
+    // #6268: web_task_error maps over state.webTasks; seed it (default []) so the
+    // .map never throws, and let a fixture seed a task to flip to `failed`.
+    webTasks: fx.init?.webTasks ?? [],
     // #6325: no-op stubs for the session-lifecycle handler tails
     // (session_switched calls fetchSlashCommands/fetchCustomAgents; switchSession
     // is wired below to write the flat activeSessionId for checkpoint_restored).

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -63,6 +63,12 @@ export interface FixtureInitialState {
   myClientId?: string | null
   /** Follow-mode flag (#5618 Batch 4 — for client_focus_changed auto-switch). */
   followMode?: boolean
+  /**
+   * Flat `webTasks` slice (#6268) — both clients' `web_task_error` handler maps
+   * over `state.webTasks` to flip a matching task to `failed`, so a fixture that
+   * exercises the `taskId` path must seed the task it targets.
+   */
+  webTasks?: Array<Record<string, unknown>>
 }
 
 /**
@@ -2337,6 +2343,48 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
         'lifecycle store and writes only socket: null, so it makes no observable main-store mutation.',
       app: {},
       dashboard: { flat: { connectionPhase: 'disconnected' } },
+    },
+  },
+  {
+    // #6268: web_task_error carrying a taskId flips the matching flat webTask to
+    // `failed` with the error text — identical in both clients (the shared
+    // state.webTasks.map). Seeds a 'running' task so the transition is non-vacuous;
+    // updatedAt is Date.now() so it is deliberately not asserted. (The common
+    // taskId-less bubble path is pinned by the existing web_task_error fixture.)
+    name: 'web_task_error with a taskId flips the matching webTask to failed (both clients)',
+    type: 'web_task_error',
+    init: {
+      activeSessionId: 's1',
+      sessions: { s1: {} },
+      webTasks: [{ taskId: 't1', status: 'running', prompt: 'do the thing' }],
+    },
+    message: { type: 'web_task_error', taskId: 't1', message: 'task blew up' },
+    expect: {
+      flat: { webTasks: [{ taskId: 't1', status: 'failed', error: 'task blew up' }] },
+    },
+  },
+  {
+    // #6268: web_task_error with code SESSION_TOKEN_MISMATCH + boundSessionName
+    // legitimately DIVERGES (#2944). The app short-circuits to a native Alert and
+    // appends NO bubble (this device is paired to a different session); the
+    // dashboard has no such guard and always appends the system bubble. No taskId,
+    // so the webTasks slice is untouched. Target = the active session.
+    name: 'web_task_error SESSION_TOKEN_MISMATCH diverges: app shows an Alert with no bubble; the dashboard appends the bubble',
+    type: 'web_task_error',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: {
+      type: 'web_task_error',
+      code: 'SESSION_TOKEN_MISMATCH',
+      boundSessionName: 'My Session',
+      message: 'This action is bound to another session',
+    },
+    divergent: {
+      reason:
+        'on a SESSION_TOKEN_MISMATCH with a boundSessionName the app short-circuits to showBoundSessionMismatchAlert and appends NO ' +
+        'bubble (#2944), while the dashboard has no such guard and always appends the system error bubble. The Alert is a side effect ' +
+        'outside the asserted messages slice.',
+      app: { sessions: { s1: { messages: [] } } },
+      dashboard: { sessions: { s1: { messages: [{ type: 'system', content: 'This action is bound to another session' }] } } },
     },
   },
 ]


### PR DESCRIPTION
Closes #6268. Deepens `web_task_error` coverage on the two facets #6267 left open (it pinned only the common taskId-less bubble path), using the now-available `expect.flat` path + a seedable flat `webTasks` slice.

## Changes
- **Seedable flat `webTasks`** — adds optional `webTasks` to `FixtureInitialState`; both seedStores seed it (default `[]`) so the handler's `state.webTasks.map` never throws.
- **Both-clients fixture** — `web_task_error` with a `taskId` flips the matching webTask to `status:'failed'` + error text (the identical shared `state.webTasks.map` in both clients). Seeds `'running'` → non-vacuous; `updatedAt` is `Date.now()` so not asserted.
- **Divergent fixture** — `SESSION_TOKEN_MISMATCH` + `boundSessionName`: the app short-circuits to a native Alert and appends **no** bubble (#2944); the dashboard has no such guard and appends the system bubble.

Both verified through both clients' real switches. `web_task_error` already had a fixture, so this is pure coverage-deepening — no PENDING/coverage-lint change.

## Verification
Full store-core (1839) + contract-fixtures (107) + app contract-switch (48) + dashboard contract-switch (48) + tsc green.

Closes #6268