### PR TITLE
test: assert terminal-mirror writes; un-exempt raw/raw_background/terminal_output (#6345)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -190,6 +190,10 @@ function seedStore(fx: ContractFixture) {
   for (const [id, seed] of Object.entries(fx.init?.sessions ?? {})) {
     sessionStates[id] = { ...createEmptySessionState(), ...(seed as Partial<SessionState>) };
   }
+  // #6345: capture appendTerminalData args so a fixture can assert terminal-mirror
+  // writes (raw / raw_background / terminal_output) via expect.terminalWrites,
+  // mirroring the dashboard harness's _terminalWrites.
+  const terminalWrites: string[] = [];
   const store = createMockStore({
     activeSessionId: fx.init?.activeSessionId ?? null,
     sessions: [],
@@ -198,7 +202,10 @@ function seedStore(fx: ContractFixture) {
     messages: [],
     addMessage: jest.fn(),
     // The app's stream/tool handlers reach for the store's appendTerminalData.
-    appendTerminalData: jest.fn(),
+    appendTerminalData: (d: string) => {
+      terminalWrites.push(d);
+    },
+    _terminalWrites: terminalWrites,
     // #6325: flat connection-state fields the real store always initialises;
     // seed them so handlers that read them (client_joined → connectedClients,
     // activity_delta/_snapshot → activity, server_error → serverErrors,
@@ -295,6 +302,13 @@ describe('contract switch fixtures — app real handleMessage (#5556.5)', () => 
       // "don't care", so existing fixtures are unaffected.
       if (exp!.flat) {
         expect(store.getState()).toMatchObject(exp!.flat);
+      }
+      // #6345: assert the ordered terminal-mirror writes (appendTerminalData args)
+      // a fixture drives (raw / raw_background / terminal_output).
+      if (exp!.terminalWrites) {
+        expect((store.getState() as unknown as { _terminalWrites: string[] })._terminalWrites).toEqual(
+          exp!.terminalWrites,
+        );
       }
     });
   }

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -225,6 +225,14 @@ describe('contract switch fixtures — dashboard real handleMessage (#5556.5)', 
       if (exp!.flat) {
         expect(store.getState(), `${fx.name}: flat fields`).toMatchObject(exp!.flat)
       }
+      // #6345: assert the ordered terminal-mirror writes (appendTerminalData args)
+      // a fixture drives (raw / raw_background / terminal_output).
+      if (exp!.terminalWrites) {
+        expect(
+          (store.getState() as unknown as { _terminalWrites: string[] })._terminalWrites,
+          `${fx.name}: terminal writes`,
+        ).toEqual(exp!.terminalWrites)
+      }
     })
   }
 })

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -160,14 +160,11 @@ const PENDING_CONTRACT_TYPES = new Set<string>([
 // later gains a real main-store effect must move OUT of this set into a fixture.
 // ---------------------------------------------------------------------------
 const NO_SWITCH_CONTRACT_BY_DESIGN = new Set<string>([
-  // raw / raw_background / terminal_output — the only effect is
-  // get().appendTerminalData(...) (the PTY/terminal mirror buffer), which the
-  // contract-switch harness stubs to a no-op (app: jest.fn(); dashboard: pushes
-  // to a local _terminalWrites array). No sessions[id], no scalar, no flat write.
-  // The terminal mirror is covered by its own dashboard/app terminal tests.
-  'raw',
-  'raw_background',
-  'terminal_output',
+  // raw / raw_background / terminal_output — MOVED OUT (#6345): now real
+  // SWITCH_FIXTURES asserting their get().appendTerminalData write via the harness's
+  // captured `_terminalWrites` (expect.terminalWrites). They were exempt only
+  // because the harness stubbed appendTerminalData to a no-op; once captured, the
+  // terminal-mirror write IS an observable both-clients contract.
   // pong — pure heartbeat ack: both clients only clear the pong-timeout timer
   // (scheduler.clearTimeout); the RTT/quality path is gated on a running ping loop
   // (lastPingSentAt > 0) unreachable from a single seeded pong, and the app routes

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -116,6 +116,13 @@ export interface FixtureExpectation {
    * to "don't care".
    */
   rotatedTunnelUrls?: Array<{ url: string; previousUrl: string | null }>
+  /**
+   * Expected ordered `appendTerminalData` call args (#6345) — the terminal-mirror
+   * writes a fixture drives (raw / raw_background / terminal_output). Both harnesses
+   * capture the strings passed to the store's `appendTerminalData`; this asserts
+   * them in order. Omit the slice to "don't care".
+   */
+  terminalWrites?: string[]
   /** When true, assert NO mutation happened at all (state is untouched). */
   noop?: boolean
 }
@@ -2386,5 +2393,38 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       app: { sessions: { s1: { messages: [] } } },
       dashboard: { sessions: { s1: { messages: [{ type: 'system', content: 'This action is bound to another session' }] } } },
     },
+  },
+  {
+    // #6345: raw PTY output. Both clients pass the shared handleRawOutput data
+    // (msg.data verbatim, '' on non-string) to get().appendTerminalData —
+    // unconditionally (no sessionId/active gate). The app also mirrors into the
+    // mocked useTerminalStore, but only the main-store write is captured, so both
+    // see exactly one identical write → a single terminalWrites expect. (Plain
+    // ASCII data — the contract is "verbatim pass-through"; the byte content is
+    // irrelevant and ANSI escapes only invite source-mangling.)
+    name: 'raw writes the PTY chunk to the terminal mirror, unconditionally (both clients)',
+    type: 'raw',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'raw', sessionId: 's1', data: 'raw-pty-chunk' },
+    expect: { terminalWrites: ['raw-pty-chunk'] },
+  },
+  {
+    // #6345: background-agent PTY output. Same as raw — unconditional verbatim
+    // get().appendTerminalData write in both clients; no gate, no init needed.
+    name: 'raw_background writes the decoded PTY chunk to the terminal mirror (both clients)',
+    type: 'raw_background',
+    message: { type: 'raw_background', data: 'background-agent-output' },
+    expect: { terminalWrites: ['background-agent-output'] },
+  },
+  {
+    // #6345: the opt-in live-PTY mirror channel (#5835). Both clients gate on
+    // typeof msg.data === 'string' AND msg.sessionId === activeSessionId, then write
+    // msg.data verbatim to get().appendTerminalData. Seed activeSessionId === the
+    // message sessionId so the active-id guard passes.
+    name: 'terminal_output writes the PTY chunk to the mirror for the active session (both clients)',
+    type: 'terminal_output',
+    init: { activeSessionId: 's1' },
+    message: { type: 'terminal_output', sessionId: 's1', data: 'term-line file.txt' },
+    expect: { terminalWrites: ['term-line file.txt'] },
   },
 ]


### PR DESCRIPTION
Closes #6345. Makes the contract-fixture universe maximally covered — only 2 types remain by-design-exempt.

## Harness: expect.terminalWrites
Adds an `expect.terminalWrites` (string[]) slice to `FixtureExpectation` and captures `appendTerminalData` call args in **both** harnesses (the app stub now pushes to a `_terminalWrites` array, mirroring the dashboard's existing one). **Proven load-bearing by a negative probe** (a wrong value fails the suite).

## Un-exempted (3, verified both-clients)
- **`raw` / `raw_background`** — both clients pass the shared `handleRawOutput` data (`msg.data` verbatim, `''` on non-string) to `get().appendTerminalData` **unconditionally** — one identical captured write each.
- **`terminal_output`** — both gate on `typeof data==='string'` AND `sessionId===activeSessionId`, then write `msg.data` verbatim; the fixture seeds the matching active session.

The app's extra `useTerminalStore` mirror write targets a **mocked** store and isn't captured, so it's not a divergence — single both-clients `expect` each. Plain-ASCII data (the contract is verbatim pass-through; byte content is irrelevant and ANSI escapes only invite source-mangling).

## Result
`NO_SWITCH_CONTRACT_BY_DESIGN` is now just **`pong` + `token_rotated`** — the two with genuinely no main-store contract (pure heartbeat ack / URL+SecureStore writes). Every other both-clients switch type is a behaviour-verified fixture.

## Verification
Full store-core (1839) + contract-fixtures/coverage-lint (107) + app contract-switch (51) + dashboard contract-switch (51) + tsc green; negative probe confirmed terminalWrites fails on a wrong value.

Closes #6345