### PR TITLE
fix(app,dashboard): gate optimistic permissionMode flip on a real send (#6321)

### DIFF
--- a/packages/app/src/__tests__/store/connection-send-fail-closed.test.ts
+++ b/packages/app/src/__tests__/store/connection-send-fail-closed.test.ts
@@ -278,3 +278,48 @@ describe('#6310 — notification-prefs setters do not lie on a closing socket', 
     expect(prefs().bypassCategories).toEqual(['errors']);
   });
 });
+
+describe('#6321 — permission-mode setters do not leave a phantom mode on a closing socket', () => {
+  // These return void (unlike the notification-prefs family) and self-heal on a
+  // server CAPABILITY_NOT_SUPPORTED *rejection* — but a failed send has no
+  // round-trip, so no rejection arrives. The observable contract is that the
+  // optimistic permissionMode flip + pending registration (both gated in the same
+  // `if (!wsSend) return` block) do NOT happen when the send throws.
+  it('setPermissionMode: no optimistic permissionMode flip when the send throws', () => {
+    seedSession({ permissionMode: 'default' } as Partial<SessionState>);
+    const socket = closingSocket();
+    useConnectionStore.setState({ socket } as never);
+    useConnectionStore.getState().setPermissionMode('plan');
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(activeState().permissionMode).toBe('default');
+  });
+
+  it('setPermissionMode: applies the optimistic flip on a healthy send', () => {
+    seedSession({ permissionMode: 'default' } as Partial<SessionState>);
+    const socket = liveSocket();
+    useConnectionStore.setState({ socket } as never);
+    useConnectionStore.getState().setPermissionMode('plan');
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(activeState().permissionMode).toBe('plan');
+  });
+
+  it('confirmPermissionMode: no optimistic flip but still clears the confirm dialog when the send throws', () => {
+    seedSession({ permissionMode: 'default' } as Partial<SessionState>);
+    const socket = closingSocket();
+    useConnectionStore.setState({ socket, pendingPermissionConfirm: { mode: 'auto' } } as never);
+    useConnectionStore.getState().confirmPermissionMode('auto');
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    expect(activeState().permissionMode).toBe('default');
+    // The dialog still closes — the user did confirm; only the optimistic flip is gated.
+    expect(useConnectionStore.getState().pendingPermissionConfirm).toBeNull();
+  });
+
+  it('confirmPermissionMode: applies the flip + clears the dialog on a healthy send', () => {
+    seedSession({ permissionMode: 'default' } as Partial<SessionState>);
+    const socket = liveSocket();
+    useConnectionStore.setState({ socket, pendingPermissionConfirm: { mode: 'auto' } } as never);
+    useConnectionStore.getState().confirmPermissionMode('auto');
+    expect(activeState().permissionMode).toBe('auto');
+    expect(useConnectionStore.getState().pendingPermissionConfirm).toBeNull();
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -2025,6 +2025,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const previousMode = targetSessionId
         ? sessionStates[targetSessionId]?.permissionMode ?? null
         : null;
+      const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, requestId };
+      if (activeSessionId) payload.sessionId = activeSessionId;
+      // Send first and gate on the result (#6321). On the OPEN→CLOSING TOCTOU
+      // window wsSend catches InvalidStateError and returns false — there's no
+      // server round-trip, so a CAPABILITY_NOT_SUPPORTED rejection never arrives
+      // to revert. Bailing before the optimistic flip + pending registration keeps
+      // a failed send from leaving a phantom permissionMode or an orphaned pending
+      // request (mirrors the #6309/#6310 send-fail-closed family).
+      if (!wsSend(socket, payload)) return;
       // Drop any superseded pending entries for this session — only the
       // latest tap should be allowed to revert state on rejection. This
       // prevents stale rejections from overwriting a newer optimistic mode
@@ -2041,9 +2050,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (targetSessionId && sessionStates[targetSessionId]) {
         updateSession(targetSessionId, () => ({ permissionMode: mode }));
       }
-      const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, requestId };
-      if (activeSessionId) payload.sessionId = activeSessionId;
-      wsSend(socket, payload);
     }
   },
 
@@ -2062,17 +2068,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const previousMode = targetSessionId
         ? sessionStates[targetSessionId]?.permissionMode ?? null
         : null;
-      // Drop any superseded pending entries (see setPermissionMode for
-      // rationale).
-      clearPendingPermissionModeRequestsForSession(targetSessionId);
-      registerPendingPermissionModeRequest(requestId, {
-        sessionId: targetSessionId,
-        previousMode,
-        requestedMode: mode,
-      });
-      if (targetSessionId && sessionStates[targetSessionId]) {
-        updateSession(targetSessionId, () => ({ permissionMode: mode }));
-      }
       const payload: Record<string, unknown> = {
         type: 'set_permission_mode',
         mode,
@@ -2080,7 +2075,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         requestId,
       };
       if (activeSessionId) payload.sessionId = activeSessionId;
-      wsSend(socket, payload);
+      // Send first and gate the optimistic flip + pending registration on it
+      // (#6321) — see setPermissionMode. On a failed (closing-socket) send there's
+      // no round-trip to reject, so don't leave a phantom permissionMode or an
+      // orphaned pending request. The pendingPermissionConfirm dialog is still
+      // cleared below regardless (the user did confirm).
+      if (wsSend(socket, payload)) {
+        // Drop any superseded pending entries (see setPermissionMode for
+        // rationale).
+        clearPendingPermissionModeRequestsForSession(targetSessionId);
+        registerPendingPermissionModeRequest(requestId, {
+          sessionId: targetSessionId,
+          previousMode,
+          requestedMode: mode,
+        });
+        if (targetSessionId && sessionStates[targetSessionId]) {
+          updateSession(targetSessionId, () => ({ permissionMode: mode }));
+        }
+      }
     }
     set({ pendingPermissionConfirm: null });
   },

--- a/packages/dashboard/src/store/connection-send-fail-closed.test.ts
+++ b/packages/dashboard/src/store/connection-send-fail-closed.test.ts
@@ -347,10 +347,11 @@ describe('#6321 — dashboard setPermissionMode does not leave a phantom mode on
   })
 
   it('applies the optimistic flip on a healthy send', async () => {
-    const sent: unknown[] = []
+    const sent: Array<Record<string, unknown>> = []
     const socket = liveSocket(sent)
     const store = await seed(socket)
     store.getState().setPermissionMode('plan')
+    expect(sent).toEqual([expect.objectContaining({ type: 'set_permission_mode', mode: 'plan' })])
     expect(store.getState().sessionStates['sess-1']!.permissionMode).toBe('plan')
   })
 })

--- a/packages/dashboard/src/store/connection-send-fail-closed.test.ts
+++ b/packages/dashboard/src/store/connection-send-fail-closed.test.ts
@@ -315,3 +315,42 @@ describe('#6310 — dashboard notification-prefs setters do not lie on a closing
     expect(prefs(useConnectionStore).bypassCategories).toEqual([])
   })
 })
+
+describe('#6321 — dashboard setPermissionMode does not leave a phantom mode on a closing socket', () => {
+  // setPermissionMode self-heals on a server PERMISSION_MODE_NOT_APPLIED rejection,
+  // but a failed send has no round-trip → no rejection. The optimistic flip +
+  // pending registration are gated on a real send. ('plan' skips the destructive
+  // 'auto' window.confirm.) confirmPermissionMode has no optimistic flip on the
+  // dashboard, so only setPermissionMode needs covering.
+  async function seed(socket: WebSocket) {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessions: [{ sessionId: 'sess-1', name: 'sess-1', provider: 'claude-sdk' }],
+      sessionStates: {
+        'sess-1': { ...createEmptySessionState(), permissionMode: 'default' } as unknown as SessionState,
+      },
+      permissionMode: 'default',
+      previousPermissionMode: null,
+      socket,
+    } as never)
+    return useConnectionStore
+  }
+
+  it('no optimistic permissionMode flip when the send throws', async () => {
+    const socket = closingSocket()
+    const store = await seed(socket)
+    store.getState().setPermissionMode('plan')
+    expect(sendCalls(socket)).toHaveLength(1)
+    expect(store.getState().sessionStates['sess-1']!.permissionMode).toBe('default')
+    expect(store.getState().previousPermissionMode).toBeNull()
+  })
+
+  it('applies the optimistic flip on a healthy send', async () => {
+    const sent: unknown[] = []
+    const socket = liveSocket(sent)
+    const store = await seed(socket)
+    store.getState().setPermissionMode('plan')
+    expect(store.getState().sessionStates['sess-1']!.permissionMode).toBe('plan')
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3317,10 +3317,6 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // this, a rejected switch leaves previousPermissionMode pointing at the
     // current mode and the toggle silently becomes a no-op.
     const priorPreviousMode = get().previousPermissionMode ?? null;
-    // Save current mode before switching (for Shift+Tab toggle)
-    if (permissionMode && permissionMode !== mode) {
-      set({ previousPermissionMode: permissionMode });
-    }
     // #5716: remember the mode we're switching FROM, keyed by a requestId the
     // server echoes on a PERMISSION_MODE_NOT_APPLIED rejection, so the error
     // handler can roll the optimistic update below back instead of leaving the
@@ -3330,22 +3326,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       ? (get().sessionStates[activeSessionId]!.permissionMode ?? null)
       : (get().permissionMode ?? null);
     const requestId = `set-perm-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    if (mode === 'auto') {
-      // Send with confirmed:true so the server skips its own confirmation
-      // round-trip and broadcasts `permission_mode_changed` directly.
-      if (socket && socket.readyState === WebSocket.OPEN) {
-        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode, priorPreviousMode });
-        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, confirmed: true, requestId };
-        if (activeSessionId) payload.sessionId = activeSessionId;
-        wsSend(socket, payload);
-      }
-    } else {
-      if (socket && socket.readyState === WebSocket.OPEN) {
-        registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode, priorPreviousMode });
-        const payload: Record<string, unknown> = { type: 'set_permission_mode', mode, requestId };
-        if (activeSessionId) payload.sessionId = activeSessionId;
-        wsSend(socket, payload);
-      }
+    // Send with confirmed:true for `auto` so the server skips its own confirmation
+    // round-trip and broadcasts `permission_mode_changed` directly.
+    const payload: Record<string, unknown> = mode === 'auto'
+      ? { type: 'set_permission_mode', mode, confirmed: true, requestId }
+      : { type: 'set_permission_mode', mode, requestId };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    // #6321: when the socket is OPEN we attempt the send and gate the pending
+    // registration on its result — if wsSend returns false (the OPEN→CLOSING TOCTOU
+    // #6293/#6308/#6310 harden against) there's no server round-trip, so a
+    // PERMISSION_MODE_NOT_APPLIED rejection never arrives to revert. Bailing keeps a
+    // failed send from leaving a phantom permissionMode (a phantom `auto`/bypass is
+    // the dangerous case) or an orphaned pending request. With NO open socket we
+    // keep the #3693 offline behavior: still flip locally so the controlled
+    // <select> reflects the choice (no round-trip is pending, so nothing to register).
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      if (!wsSend(socket, payload)) return;
+      registerPermissionModeChangeRequest(requestId, { sessionId: activeSessionId, previousMode, priorPreviousMode });
+    }
+    // Save current mode before switching (for Shift+Tab toggle).
+    if (permissionMode && permissionMode !== mode) {
+      set({ previousPermissionMode: permissionMode });
     }
     // Optimistically update local state so the controlled `<select>`
     // doesn't snap back to the prior value before the server's


### PR DESCRIPTION
Closes #6321. The `setPermissionMode`/`confirmPermissionMode` sibling of the #6310 `wsSend`-false sweep.

## Problem
Both setters optimistically flip `permissionMode` + register a pending request (reverted by the server on a `CAPABILITY_NOT_SUPPORTED` / `PERMISSION_MODE_NOT_APPLIED` rejection), then call `wsSend` **unchecked**. On the OPEN→CLOSING TOCTOU window (#6293/#6308/#6310), `wsSend` catches the `InvalidStateError` and returns `false` — no server round-trip, so no rejection arrives, and the optimistic mode persists locally until the next reconnect snapshot. A phantom `auto`/bypass is the dangerous case.

## Fix
- **app** — both setters `if (!wsSend(...)) return;` before the optimistic flip + pending registration (`confirmPermissionMode` wraps the gated block so the `pendingPermissionConfirm` dialog still closes — the user did confirm).
- **dashboard `setPermissionMode`** — gate the pending registration + bail on a failed send **only when the socket is OPEN**. This preserves the **#3693 offline behavior**: with no open socket it still flips locally so the controlled `<select>` reflects the choice (no round-trip is pending, so nothing to register). `confirmPermissionMode` has no optimistic flip on the dashboard, so it needs no change.

The dashboard's offline-optimism was the subtle part — an early version gated unconditionally and broke `permission-mode-optimistic.test.ts` (which seeds `socket: null` and expects the flip). The fix scopes the gate to the OPEN-socket send path only.

## Tests
Closing-socket false-branch cases added to both `connection-send-fail-closed.test.ts` suites: no phantom flip, no orphaned pending, the confirm dialog still clears; healthy-send + #3693 no-socket flip paths unchanged.

## Verification
Full app store suite (687) + full dashboard store suite (916) + both tsc green.

Closes #6321