### PR TITLE
feat(app,dashboard): surface a rate_limited throttle notice (#6334)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -101,6 +101,7 @@ import {
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
+  handleRateLimited as sharedRateLimited,
   // web_task_created / web_task_updated — migrated to the shared dispatch table
   // (#5556 slice 4); the app no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
@@ -3132,6 +3133,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
       } else {
         get().addMessage(statusMsg);
+      }
+      break;
+    }
+
+    case 'rate_limited': {
+      // #6334 — surface the server-side throttle as a brief system notice so the
+      // user gets feedback (the rate limit itself is enforced server-side).
+      const { chatMessage: rateLimitMsg } = sharedRateLimited(msg);
+      const activeRateLimitId = get().activeSessionId;
+      if (activeRateLimitId && get().sessionStates[activeRateLimitId]) {
+        updateActiveSession((ss) => ({
+          messages: [...ss.messages, rateLimitMsg],
+        }));
+      } else {
+        get().addMessage(rateLimitMsg);
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -96,6 +96,7 @@ import {
   handleServerError as sharedServerError,
   handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
+  handleRateLimited as sharedRateLimited,
   // web_task_created / web_task_updated — migrated to the shared dispatch table
   // (#5556 slice 4); the dashboard no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
@@ -4522,6 +4523,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
       } else {
         get().addMessage(statusMsg);
+      }
+      break;
+    }
+
+    case 'rate_limited': {
+      // #6334 — surface the server-side throttle as a brief system notice so the
+      // user gets feedback (the rate limit itself is enforced server-side).
+      const { chatMessage: rateLimitMsg } = sharedRateLimited(msg);
+      const activeRateLimitId = get().activeSessionId;
+      if (activeRateLimitId && get().sessionStates[activeRateLimitId]) {
+        updateActiveSession((ss) => ({
+          messages: [...ss.messages, rateLimitMsg],
+        }));
+      } else {
+        get().addMessage(rateLimitMsg);
       }
       break;
     }

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -67,7 +67,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'session_created',    // ack handled via session_list refresh, no dedicated case needed
   'session_destroyed',  // ack handled via session_list refresh, no dedicated case needed
   'discovered_sessions', // multi-server discovery, handled at connection layer
-  'rate_limited',       // rate limit signals, handled at connection layer
+  // rate_limited — now handled in both clients' switch (#6334): a system throttle notice.
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
   'pair_request_pending', // #5510 pairing-approval primitive — consumed by the dedicated requester panel (dashboard utils/request-pairing.ts, its own short-lived WS onmessage), NOT the main message-handler dispatch the extractor scans. Mobile requester side is an explicit out-of-scope fast-follow per epic #5509.

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2427,4 +2427,18 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     message: { type: 'terminal_output', sessionId: 's1', data: 'term-line file.txt' },
     expect: { terminalWrites: ['term-line file.txt'] },
   },
+  {
+    // #6334: a server-side throttle. Both clients run the shared handleRateLimited,
+    // which builds a `system` bubble from `message` + a "Retry in Ns" hint
+    // (ceil(retryAfterMs/1000)), and append it to the active session.
+    name: 'rate_limited appends a system throttle notice with a retry hint (both clients)',
+    type: 'rate_limited',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'rate_limited', retryAfterMs: 2000, message: 'Too many messages. Please slow down.' },
+    expect: {
+      sessions: {
+        s1: { messages: [{ type: 'system', content: 'Too many messages. Please slow down. Retry in 2s.' }] },
+      },
+    },
+  },
 ]

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -220,11 +220,9 @@ const APP_ONLY = new Set<string>([
 // short-lived socket), so neither client's main switch covers them. Mirrors
 // handler-coverage's INTENTIONALLY_UNHANDLED.
 const UNHANDLED_BY_DESIGN = new Set<string>([
-  // #6332 (batch 2b of #6314): a server throttle notice sent on rate-limit, but
-  // NEITHER client has a handler today — it falls through to the default (no
-  // user-facing "slow down" surface yet). Schemaing it documented the wire
-  // contract; surfacing it in a client is a separate UX follow-up (#6334).
-  'rate_limited',
+  // rate_limited — now handled in both clients' switch (#6334): a system throttle
+  // notice (handleRateLimited), with a both-clients SWITCH_FIXTURES entry. Removed
+  // from this set (it has a real handler + contract fixture now).
   'extension_message',                    // routed to the extension framework, not the main switch
   'pair_request_pending',                 // pairing-approval primitive (#5510) — consumed by the requester's
                                           //   dedicated request-pairing socket, not the main dispatch

--- a/packages/store-core/src/handlers/error.ts
+++ b/packages/store-core/src/handlers/error.ts
@@ -276,3 +276,40 @@ export function handleServerStatusLegacy(
   }
   return { chatMessage }
 }
+
+/** Result of {@link handleRateLimited}. */
+export interface RateLimitedPayload {
+  /** A `system`-typed ChatMessage describing the throttle for the active session. */
+  chatMessage: ChatMessage
+}
+
+/**
+ * Build the system-typed ChatMessage for a `rate_limited` throttle notice (#6334).
+ *
+ * The server emits `{ retryAfterMs, message }` when a client trips the
+ * permission/question or general message rate limiter. Both clients surface it as
+ * a brief `system` bubble so the user gets feedback (the throttle itself is
+ * enforced server-side). The `retryAfterMs` is appended as a human "retry in Ns"
+ * hint (ceil to whole seconds, min 1) when positive; a missing/blank `message`
+ * falls back to a generic notice.
+ */
+export function handleRateLimited(
+  msg: Record<string, unknown>,
+): RateLimitedPayload {
+  const baseMessage: string =
+    typeof msg.message === 'string' && (msg.message as string).trim().length > 0
+      ? (msg.message as string)
+      : 'Rate limited. Please slow down.'
+  const retryAfterMs = typeof msg.retryAfterMs === 'number' ? msg.retryAfterMs : 0
+  const content =
+    retryAfterMs > 0
+      ? `${baseMessage} Retry in ${Math.max(1, Math.ceil(retryAfterMs / 1000))}s.`
+      : baseMessage
+  const chatMessage: ChatMessage = {
+    id: nextMessageId('rate-limit'),
+    type: 'system',
+    content,
+    timestamp: Date.now(),
+  }
+  return { chatMessage }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -580,6 +580,7 @@ export {
   handleServerError,
   handleServerShutdown,
   handleServerStatusLegacy,
+  handleRateLimited,
   handleWebTaskUpsert,
   // #5556 slice 4 — shared filter-and-append upsert for web_task_created/updated.
   applyWebTaskUpsert,


### PR DESCRIPTION
Closes #6334. The server emits `rate_limited` (`{retryAfterMs, message}`) on a throttle, but neither client handled it — the user saw nothing.

## What
Both clients now run a shared `handleRateLimited` that builds a `system` bubble from `message` + a `Retry in Ns` hint (`ceil(retryAfterMs/1000)`, min 1; omitted when `retryAfterMs<=0`; generic fallback on a blank message) and appends it to the active session — mirroring `server_status`.

e.g. `{ retryAfterMs: 2000, message: 'Too many messages. Please slow down.' }` → a system bubble: **"Too many messages. Please slow down. Retry in 2s."**

## Coverage (the 3-guard dance)
`rate_limited` was exempt in two guards as "handled at connection layer" — it now has a real handler, so:
- removed from protocol `handler-coverage` `INTENTIONALLY_UNHANDLED`,
- removed from store-core `protocol-type-coverage` `UNHANDLED_BY_DESIGN`,
- added a both-clients `SWITCH_FIXTURES` entry that pins the notice + retry hint through both clients' real switches.

## Verification
Full store-core (1839) + protocol (340) + app contract-switch (52) + dashboard contract-switch (52) + all three tsc green. The fixture proves the both-clients behavior deterministically.

Closes #6334