### PR TITLE
feat(dashboard): provider capability-limitation note at session creation (#6312)

### DIFF
--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -178,6 +178,10 @@ export interface ProviderCapabilities {
   // warning copy from it.
   interruptsTurnOnAutoSwitch?: boolean;
   planMode?: boolean;
+  // #6312: true when the provider streams partial responses. claude-tui reports
+  // false; other providers omit it (treated as capable). Consumed by the
+  // session-creation limitation note so `streaming: false` isn't dropped client-side.
+  streaming?: boolean;
   resume?: boolean;
   terminal?: boolean;
   thinkingLevel?: boolean;

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -10,6 +10,7 @@ import { Modal } from './Modal'
 import { usePathAutocomplete } from '../hooks/usePathAutocomplete'
 import { DirectoryBrowser } from './DirectoryBrowser'
 import { useConnectionStore } from '../store/connection'
+import { buildProviderLimitationNote } from '@chroxy/store-core'
 import type { DirectoryListing, DirectoryEntry, ModelInfo } from '../store/types'
 import { PROVIDER_LABELS } from '../lib/provider-labels'
 
@@ -781,6 +782,20 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                   data-capability={key}
                 >{label}</span>
               ))}
+            </div>
+          )
+        })()}
+        {/* #6312: a non-blocking limitation note for a reduced-capability
+            provider (notably claude-tui — no plan mode / streaming / model
+            switch). Explains the absent affordances rather than leaving the
+            user to infer the gap from a missing control. */}
+        {availableProviders.length > 0 && (() => {
+          const selected = availableProviders.find(p => p.name === provider)
+          const note = buildProviderLimitationNote(selected?.capabilities)
+          if (!note) return null
+          return (
+            <div className="provider-limitation-note" data-testid="provider-limitation-note">
+              {note}
             </div>
           )
         })()}

--- a/packages/dashboard/src/components/CreateSessionModalCapabilityNote.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalCapabilityNote.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for the provider limitation note on the Create Session modal (#6312).
+ *
+ * A reduced-capability provider (notably claude-tui, the zero-config default —
+ * no plan mode / streaming / model switch) previously communicated those gaps
+ * only by the ABSENCE of a UI control. This note explains them at session
+ * creation. Pins:
+ *   1. the note renders for a provider with `false` capabilities
+ *   2. the note is absent for a fully-capable provider
+ *   3. switching to a reduced-capability provider surfaces the note
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, fireEvent, cleanup, screen } from '@testing-library/react'
+
+const mockStoreState: Record<string, unknown> = {}
+
+vi.mock('../hooks/usePathAutocomplete', () => ({
+  usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector(mockStoreState),
+}))
+
+import { CreateSessionModal, type CreateSessionModalProps } from './CreateSessionModal'
+
+const READY_AUTH = {
+  ready: true,
+  source: 'env',
+  envVar: 'ANTHROPIC_API_KEY',
+  envVars: ['ANTHROPIC_API_KEY'],
+  detail: 'API key',
+  hint: '',
+}
+const TUI_DEGRADED = {
+  name: 'claude-tui',
+  capabilities: { permissions: true, modelSwitch: false, planMode: false, streaming: false },
+  auth: READY_AUTH,
+}
+const SDK_CAPABLE = {
+  name: 'claude-sdk',
+  capabilities: { permissions: true, modelSwitch: true, planMode: true, streaming: true },
+  auth: READY_AUTH,
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(mockStoreState)) delete mockStoreState[k]
+  Object.assign(mockStoreState, {
+    defaultProvider: 'claude-sdk',
+    defaultModel: null,
+    availableModels: [],
+    availableModelsProvider: null,
+    availableProviders: [SDK_CAPABLE, TUI_DEGRADED],
+    availablePermissionModes: [],
+    environments: [],
+    requestDirectoryListing: () => {},
+    setDirectoryListingCallback: () => {},
+    defaultCwd: null,
+  })
+})
+
+afterEach(cleanup)
+
+function renderModal(props: Partial<CreateSessionModalProps> = {}) {
+  const onCreate = vi.fn()
+  const onClose = vi.fn()
+  const defaultProps: CreateSessionModalProps = {
+    open: true,
+    onClose,
+    onCreate,
+    initialCwd: '/Users/me/projects',
+    knownCwds: [],
+    existingNames: [],
+    ...props,
+  }
+  return { ...render(<CreateSessionModal {...defaultProps} />), onCreate }
+}
+
+describe('CreateSessionModal provider limitation note (#6312)', () => {
+  it('renders the limitation note for a reduced-capability provider (claude-tui)', () => {
+    mockStoreState.defaultProvider = 'claude-tui'
+    renderModal()
+    const note = screen.getByTestId('provider-limitation-note')
+    expect(note).toBeInTheDocument()
+    expect(note.textContent).toMatch(/plan mode/)
+    expect(note.textContent).toMatch(/streaming/)
+    expect(note.textContent).toMatch(/model switching/)
+  })
+
+  it('does NOT render the note for a fully-capable provider', () => {
+    mockStoreState.defaultProvider = 'claude-sdk'
+    renderModal()
+    expect(screen.queryByTestId('provider-limitation-note')).not.toBeInTheDocument()
+  })
+
+  it('surfaces the note when the user switches to a reduced-capability provider', () => {
+    mockStoreState.defaultProvider = 'claude-sdk'
+    renderModal()
+    expect(screen.queryByTestId('provider-limitation-note')).not.toBeInTheDocument()
+    const select = screen.getByLabelText('Select provider') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'claude-tui' } })
+    const note = screen.getByTestId('provider-limitation-note')
+    expect(note.textContent).toMatch(/doesn't support/)
+  })
+})

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -139,6 +139,11 @@ export interface ProviderCapabilities {
   // streaming state to word the auto-mode confirm dialog accurately.
   interruptsTurnOnAutoSwitch?: boolean;
   planMode: boolean;
+  // #6312: true when the provider streams partial responses. claude-tui reports
+  // false (it can only deliver complete turns); other providers omit it (treated
+  // as capable). Consumed by the session-creation limitation note so the
+  // `streaming: false` flag isn't silently dropped client-side.
+  streaming?: boolean;
   resume: boolean;
   terminal: boolean;
   thinkingLevel?: boolean;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5767,6 +5767,22 @@ button.sidebar-token-view-session-row:hover {
    inline `<option>` hint (which truncated on narrow viewports and
    couldn't render code formatting). Warning-toned so it stands apart
    from the neutral billing-hint above. */
+/* #6312: a subtle informational note explaining a reduced-capability provider's
+   missing affordances (claude-tui: no plan mode / streaming / model switch) at
+   session creation. Info-toned, NOT a warning — the provider works fine; this
+   only sets expectations so the absent controls aren't a silent mystery. */
+.provider-limitation-note {
+  display: block;
+  margin-top: 6px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--surface-subtle, #ffffff0a);
+  border-left: 3px solid var(--border, #3a3a3a);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+}
+
 .provider-fix-hint {
   display: block;
   margin-top: 6px;

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -32,6 +32,8 @@ export { isVoiceInputMode } from './types'
 // this single guard, so widening `SelectOptionValue` to a third object
 // shape can't silently misroute it as freeform on either client.
 export { isFreeformAnswer } from './freeform-answer'
+export { buildProviderLimitationNote } from './provider-capabilities'
+export type { DegradableCapabilities } from './provider-capabilities'
 export type { OtherFreeformAnswer } from './freeform-answer'
 
 // #5555.3 / #5555.4 — lastSeq cursor tracking + no-blank-flash replay reconcile.

--- a/packages/store-core/src/provider-capabilities.test.ts
+++ b/packages/store-core/src/provider-capabilities.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { buildProviderLimitationNote } from './provider-capabilities'
+
+describe('buildProviderLimitationNote (#6312)', () => {
+  it('lists all three degraded capabilities for claude-tui (modelSwitch/planMode/streaming false)', () => {
+    expect(buildProviderLimitationNote({ planMode: false, streaming: false, modelSwitch: false })).toBe(
+      "This provider doesn't support plan mode, streaming, and model switching.",
+    )
+  })
+
+  it('returns null for a fully-capable provider', () => {
+    expect(buildProviderLimitationNote({ planMode: true, streaming: true, modelSwitch: true })).toBeNull()
+  })
+
+  it('lists only the single disabled capability', () => {
+    expect(buildProviderLimitationNote({ planMode: false, streaming: true, modelSwitch: true })).toBe(
+      "This provider doesn't support plan mode.",
+    )
+  })
+
+  it('joins two disabled capabilities with "and", no Oxford comma', () => {
+    expect(buildProviderLimitationNote({ planMode: false, streaming: false, modelSwitch: true })).toBe(
+      "This provider doesn't support plan mode and streaming.",
+    )
+  })
+
+  it('ignores undefined/absent flags (only an explicit false counts)', () => {
+    // A provider that simply omits `streaming` should not be reported as lacking it.
+    expect(buildProviderLimitationNote({ planMode: true, modelSwitch: true })).toBeNull()
+    expect(buildProviderLimitationNote({ streaming: false })).toBe(
+      "This provider doesn't support streaming.",
+    )
+  })
+
+  it('returns null for missing capabilities object', () => {
+    expect(buildProviderLimitationNote(null)).toBeNull()
+    expect(buildProviderLimitationNote(undefined)).toBeNull()
+  })
+})

--- a/packages/store-core/src/provider-capabilities.ts
+++ b/packages/store-core/src/provider-capabilities.ts
@@ -1,0 +1,46 @@
+/**
+ * Provider-capability limitation note (#6312).
+ *
+ * Some providers — notably `claude-tui`, the zero-config default — report
+ * `modelSwitch` / `planMode` / `streaming` as `false`. The matching affordances
+ * are gated client-side, but the limitation is communicated only by the ABSENCE
+ * of a UI control, so a first-time user has no explanation for why plan mode,
+ * streaming, or model switching is missing. This builds a concise, human note for
+ * the session-creation UI so the absence is explained rather than silent.
+ */
+
+/** The capability flags whose `false` value is worth explaining at session creation. */
+export interface DegradableCapabilities {
+  modelSwitch?: boolean
+  planMode?: boolean
+  streaming?: boolean
+}
+
+// Order here is the order the limitations are listed in the note.
+const DEGRADE_LABELS: Array<[keyof DegradableCapabilities, string]> = [
+  ['planMode', 'plan mode'],
+  ['streaming', 'streaming'],
+  ['modelSwitch', 'model switching'],
+]
+
+/**
+ * Build a one-line "This provider doesn't support …" note from a provider's
+ * capability flags, listing only the degradable capabilities reported as
+ * `false`. Returns `null` when none are disabled (a fully-capable provider shows
+ * no note) or when `caps` is missing — callers render nothing in that case.
+ */
+export function buildProviderLimitationNote(
+  caps: DegradableCapabilities | null | undefined,
+): string | null {
+  if (!caps) return null
+  const missing = DEGRADE_LABELS.filter(([key]) => caps[key] === false).map(([, label]) => label)
+  if (missing.length === 0) return null
+  const list =
+    missing.length === 1
+      ? missing[0]
+      : missing.length === 2
+        ? `${missing[0]} and ${missing[1]}`
+        : // 3+ — Oxford comma before the final "and".
+          `${missing.slice(0, -1).join(', ')}, and ${missing[missing.length - 1]}`
+  return `This provider doesn't support ${list}.`
+}


### PR DESCRIPTION
Part of #6312 (mobile parity tracked in #6352). `claude-tui` — the zero-config default — reports `modelSwitch`/`planMode`/`streaming` as `false`; the affordances are gated client-side but the gaps were communicated only by an absent control. This adds a concise non-blocking note.

## What
- **store-core `buildProviderLimitationNote(caps)`** — a tested pure helper listing the degradable capabilities a provider reports `false` (plan mode / streaming / model switching), e.g. *"This provider doesn't support plan mode, streaming, and model switching."*; `null` for a fully-capable provider or absent caps.
- **`ProviderCapabilities` (dashboard + app)** — adds the missing **`streaming`** field so `claude-tui`'s `streaming: false` is actually consumable client-side (it was dropped before).
- **dashboard `CreateSessionModal`** — renders the note (`data-testid=provider-limitation-note`) below the positive capability badges, info-toned (not a warning — the provider works fine). Additive copy; the existing graceful gating (read-only model badge, hidden plan affordance) is unchanged.

## Tests
- store-core helper: 6 cases (1/2/3-item Oxford-comma joins, `undefined` vs `false`, fully-capable → `null`, missing caps).
- dashboard component: note renders for claude-tui, absent for a capable provider, surfaces on provider switch.

## Scope
Dashboard slice. Mobile parity is **#6352** (the app has no `CreateSessionModal` equivalent — capabilities gate mid-session in `SessionScreen`, a distinct surface). The shared helper + `streaming` field are already in place for it.

## Verification
Full store-core (1845) + dashboard component test + app/dashboard tsc green. The render is verified by the component test; the visual tone is a quick eyeball.

Part of #6312