### PR TITLE
refactor: migrate agent_idle onto the shared dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -31,7 +31,6 @@ import {
   // available_permission_modes / session_updated / confirm_permission_mode /
   // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
   handleClaudeReady as sharedClaudeReady,
-  handleAgentIdle as sharedAgentIdle,
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
@@ -2849,13 +2848,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'agent_idle': {
-      const targetId = resolveSessionId(msg, get().activeSessionId);
-      if (targetId && get().sessionStates[targetId]) {
-        updateSession(targetId, () => sharedAgentIdle());
-      }
-      break;
-    }
+    // agent_idle — migrated to the shared dispatch table (#5618; handled by
+    // runDispatch before this switch). The app has no flat idle fallback (it
+    // derives isIdle from the active session), so it omits the
+    // applyAgentIdleFallback adapter hook — behaviour unchanged.
 
     // agent_busy — migrated to the shared dispatch table (#5556)
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1060,6 +1060,9 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // dashboard's own helper (dedup by (sessionId, eventType); no push store).
   pushSessionNotification: (sessionId, eventType, message) =>
     pushSessionNotification(sessionId, eventType, message),
+  // #5618 — agent_idle no-session fallback: mirror the idle patch into FLAT state
+  // (the dashboard UI reads flat streamingMessageId/isIdle; the app omits this).
+  applyAgentIdleFallback: () => getStore().setState(sharedAgentIdle() as Partial<ConnectionState>),
   // #5618 Batch 3 — error-sink for session_restore_failed / session_persist_failed.
   // The dashboard's connection-store addServerError builds its own envelope
   // (category 'general', id 'info', ring-capped serverErrors) from the message;
@@ -1856,18 +1859,13 @@ function handleClaudeReady(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
   }
 }
 
-function handleAgentIdle(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const targetId = resolveSessionId(msg, get().activeSessionId);
-  if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, () => sharedAgentIdle());
-  } else {
-    // Legacy/pre-bootstrap path: no session-state yet. The dashboard UI reads
-    // the flat `streamingMessageId` directly (App.tsx isStreaming check), and
-    // sendInput writes flat 'pending' here too. Without this fallback, an
-    // abnormal agent_idle in this state would leave the stop button stuck.
-    set(sharedAgentIdle());
-  }
-}
+// agent_idle — migrated to the shared dispatch table (#5618; runDispatch handles
+// it before this HANDLERS map). The seeded-session path is the shared
+// dispatchAgentIdle; the dashboard's no-session FLAT fallback (its UI reads flat
+// streamingMessageId/isIdle directly — App.tsx isStreaming — and sendInput writes
+// flat 'pending', so without it an abnormal agent_idle leaves the stop button
+// stuck) is preserved per-client via the _dispatchAdapter.applyAgentIdleFallback
+// hook below.
 
 // agent_busy migrated to the shared store-core dispatch table (#5556)
 
@@ -3176,7 +3174,7 @@ const HANDLERS: Record<string, Handler> = {
   // shared store-core dispatch table (#5556)
   session_switched: handleSessionSwitched,
   claude_ready: handleClaudeReady,
-  agent_idle: handleAgentIdle,
+  // agent_idle — migrated to the shared dispatch table (#5618; runDispatch).
   stream_start: handleStreamStart,
   stream_delta: handleStreamDelta,
   stream_end: handleStreamEnd,

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1294,6 +1294,21 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     message: { type: 'checkpoint_list' },
     expect: { noop: true },
   },
+  {
+    // #5618 — agent_idle migrated from SWITCH to the shared dispatch table. The
+    // seeded-session path flips the session to idle ({ isIdle: true,
+    // streamingMessageId: null, activeTools: [] }) via the shared dispatchAgentIdle
+    // → updateSession. (The no-session FLAT fallback is preserved per-client by the
+    // optional applyAgentIdleFallback adapter hook — dashboard implements, app
+    // omits — and is exercised by each client's own tests, not the shared contract.)
+    name: 'agent_idle flips the seeded session to idle and clears the streaming id (both clients)',
+    type: 'agent_idle',
+    init: { activeSessionId: 's1', sessions: { s1: { isIdle: false, streamingMessageId: 'live-1' } } },
+    message: { type: 'agent_idle', sessionId: 's1' },
+    expect: {
+      sessions: { s1: { isIdle: true, streamingMessageId: null } },
+    },
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -1758,22 +1773,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     message: { type: 'claude_ready', sessionId: 's1' },
     expect: {
       sessions: { s1: { claudeReady: true } },
-    },
-  },
-  {
-    // #6325 (drain #6314): the agent went idle. Both clients apply the shared
-    // sharedAgentIdle patch ({ isIdle: true, streamingMessageId: null,
-    // activeTools: [] }) to the seeded session (the dashboard's local
-    // handleAgentIdle delegates to sharedAgentIdle on the seeded-session path).
-    // Asserts the scalar fields via the harness extension; activeTools:[] is
-    // omitted from expect because toMatchObject treats an empty expected array as
-    // vacuous (it matches any array).
-    name: 'agent_idle flips the session to idle and clears the streaming id (both clients)',
-    type: 'agent_idle',
-    init: { activeSessionId: 's1', sessions: { s1: { isIdle: false, streamingMessageId: 'live-1' } } },
-    message: { type: 'agent_idle', sessionId: 's1' },
-    expect: {
-      sessions: { s1: { isIdle: true, streamingMessageId: null } },
     },
   },
   {

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -65,6 +65,7 @@ import {
   handleAvailablePermissionModes,
   handleSessionUpdated,
   handleAgentBusy,
+  handleAgentIdle,
   handleBudgetResumed,
   handleBudgetResumeAck,
   handleConversationId,
@@ -314,6 +315,18 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    */
   syncSecondaryInventory?(kind: 'slashCommands' | 'customAgents', list: unknown[]): void
   /**
+   * Apply the `agent_idle` no-session FALLBACK (#5618). When an `agent_idle`
+   * arrives for a session that isn't in `sessionStates`, the DASHBOARD writes the
+   * idle patch (`{ isIdle, streamingMessageId: null, activeTools: [] }`) into its
+   * FLAT connection state — its UI reads flat `streamingMessageId`/`isIdle`
+   * directly (App.tsx isStreaming) and its pre-bootstrap `sendInput` writes flat
+   * `pending`, so without this an abnormal `agent_idle` leaves the stop button
+   * stuck (#5760). The APP has no flat idle mirror (it derives `isIdle` from the
+   * active session) and OMITS this hook — a faithful per-client preservation of
+   * the prior switch behaviour, in the same spirit as {@link syncSecondaryInventory}.
+   */
+  applyAgentIdleFallback?(): void
+  /**
    * Mirror checkpoint changes into a SECONDARY client store (#5618 Batch 6).
    * The mobile app keeps a separate `useConversationStore` whose checkpoint list
    * powers its timeline UI; after the `checkpoint_created` / `checkpoint_list`
@@ -513,6 +526,10 @@ export interface DispatchMessageMap {
   }
   agent_busy: {
     type: 'agent_busy'
+    sessionId?: string
+  }
+  agent_idle: {
+    type: 'agent_idle'
     sessionId?: string
   }
   budget_resumed: {
@@ -864,6 +881,26 @@ function dispatchAgentBusy<S extends DispatchSessionBase>(
   const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
   if (targetId && adapter.hasSession(targetId)) {
     adapter.updateSession(targetId, () => handleAgentBusy() as Partial<S>)
+  }
+}
+
+/**
+ * `agent_idle` — flip the target session to idle (#5618). Byte-identical to the
+ * prior switch case for a SEEDED session: `updateSession(target, () => handleAgentIdle())`
+ * ({ isIdle, streamingMessageId: null, activeTools: [] }). The no-session FALLBACK
+ * (the dashboard mirrors the patch into flat state; the app no-ops) is preserved
+ * per-client via the optional {@link ClientStoreAdapter.applyAgentIdleFallback} hook
+ * — no behaviour change on either client.
+ */
+function dispatchAgentIdle<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['agent_idle'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (targetId && adapter.hasSession(targetId)) {
+    adapter.updateSession(targetId, () => handleAgentIdle() as unknown as Partial<S>)
+  } else {
+    adapter.applyAgentIdleFallback?.()
   }
 }
 
@@ -1681,6 +1718,7 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     available_permission_modes: dispatchAvailablePermissionModes,
     session_updated: dispatchSessionUpdated,
     agent_busy: dispatchAgentBusy,
+    agent_idle: dispatchAgentIdle,
     budget_resumed: dispatchBudgetResumed,
     budget_resume_ack: dispatchBudgetResumeAck,
     conversation_id: dispatchConversationId,
@@ -1768,6 +1806,7 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'available_permission_modes',
   'session_updated',
   'agent_busy',
+  'agent_idle',
   'budget_resumed',
   'budget_resume_ack',
   'conversation_id',


### PR DESCRIPTION
Part of #5618 — the first slice of the resumed dispatch-table migration. `agent_idle` moves from a per-client switch case (app) / HANDLERS-map handler (dashboard) onto the shared store-core dispatch table, shrinking both ~220KB twin handlers by one duplicated case.

## Reconciliation (the load-bearing part — please spot-check)
**Zero behaviour change on either client.** The two clients diverged on the no-session path; I preserved both exactly rather than picking a winner:

| path | app | dashboard |
|---|---|---|
| seeded session | `updateSession(target, handleAgentIdle())` | identical → **shared `dispatchAgentIdle`** |
| **no session** | no-op (derives `isIdle` from the active session) | flat-fallback `set(sharedAgentIdle())` (its UI reads flat `streamingMessageId`/`isIdle` — App.tsx `isStreaming`; #5760) |

The no-session fallback is preserved **per-client via a new optional `ClientStoreAdapter.applyAgentIdleFallback` hook** — the dashboard implements it, the app omits it — exactly mirroring the existing `syncSecondaryInventory?` optional-hook pattern. So neither client's behaviour changes; the duplication is just removed.

This **optional-hook-for-divergent-fallback** is the reusable pattern for the other divergent-fallback types in the [#5618 triage map](https://github.com/blamechris/chroxy/issues/5618#issuecomment-4799220768) (agent_idle, claude_ready, permission_mode_changed all share the dashboard-flat-fallback shape).

## Mechanics
dispatch-table.ts: `DispatchMessageMap.agent_idle` + `dispatchAgentIdle` + register + `DISPATCH_TABLE_TYPES` + the adapter hook. Both clients: remove the case/handler+map-entry; the dashboard adds the hook impl. The `agent_idle` contract fixture moves **SWITCH → DISPATCH** (the shared contract test asserts the seeded-session scalar flip through `runDispatch`).

## Verification
store-core typecheck + full (1846) · protocol handler-coverage (340) · app contract-switch (51) + **full app store (687)** · dashboard contract-switch (51) + **full dashboard store (916)** · all tsc clean. The existing `message-handler.test.ts` (both clients) that exercise `agent_idle` still pass — behaviour confirmed preserved through `runDispatch`.

Part of #5618