### PR TITLE
refactor: migrate permission_mode_changed onto the shared dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2838,7 +2838,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // agent_idle — migrated to the shared dispatch table (#5618; handled by
     // runDispatch before this switch). The app has no flat idle fallback (it
     // derives isIdle from the active session), so it omits the
-    // applyAgentIdleFallback adapter hook — behaviour unchanged.
+    // applyNoSessionFallback adapter hook — behaviour unchanged.
 
     // agent_busy — migrated to the shared dispatch table (#5556)
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -27,7 +27,6 @@ import {
   resolveSessionId,
   handleUserInput as sharedUserInput,
   handleMessage as sharedMessageHandler,
-  handlePermissionModeChanged as sharedPermissionModeChanged,
   // available_permission_modes / session_updated / confirm_permission_mode /
   // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
   handleClaudeReady as sharedClaudeReady,
@@ -1215,6 +1214,11 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // app's own helper (which also mirrors the row into the mobile push store).
   pushSessionNotification: (sessionId, eventType, message) =>
     pushSessionNotification(sessionId, eventType, message),
+  // #5618 — permission_mode_changed clears the app's pending optimistic-revert
+  // tracker for the broadcast's target session (the dashboard has no equivalent
+  // per-session tracker and omits this hook).
+  clearPendingPermissionModeRequests: (sessionId) =>
+    clearPendingPermissionModeRequestsForSession(sessionId),
   // #5653 — file-ops / git wrapper cases route through the shared dispatch
   // table; the app supplies its module-level imperative-callback registry so
   // the parsed payload reaches the UI's registered callback exactly as the
@@ -2774,29 +2778,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // availableModelsProvider extension.
 
 
-    case 'permission_mode_changed': {
-      const { mode } = sharedPermissionModeChanged(msg);
-      const targetId = resolveSessionId(msg, get().activeSessionId);
-      {
-        const effectiveId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-        if (effectiveId && get().sessionStates[effectiveId]) {
-          updateSession(effectiveId, () => ({ permissionMode: mode }));
-        }
-        // Server doesn't echo back the originating requestId on
-        // permission_mode_changed broadcasts (multi-client safe), so clear any
-        // pending tracker entries for the message's resolved target. Use
-        // `targetId` (the session the broadcast is *for*) rather than
-        // `effectiveId`, which can fall back to `activeSessionId` and would
-        // wrongly clear pending entries on a different session if the broadcast
-        // arrived for a session that isn't currently in `sessionStates`.
-        if (targetId) {
-          clearPendingPermissionModeRequestsForSession(targetId);
-        }
-      }
-      // Clear pending confirm if mode change arrived (confirmation was accepted)
-      set({ pendingPermissionConfirm: null });
-      break;
-    }
+    // permission_mode_changed — migrated to the shared dispatch table (#5618;
+    // runDispatch). Now uses targetId-direct resolution (Decision A) instead of the
+    // app's prior effectiveId-retry; the app's clearPendingPermissionModeRequests is
+    // preserved via the _dispatchAdapter hook, and pendingPermissionConfirm is cleared
+    // via setState. Behaviour is unchanged in normal operation (sessionStates always
+    // holds the target session) — see dispatchPermissionModeChanged for the rationale.
 
     // confirm_permission_mode — migrated to the shared dispatch table (#5556)
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -17,11 +17,9 @@ import {
   resolveSessionId,
   handleUserInput as sharedUserInput,
   handleMessage as sharedMessageHandler,
-  handlePermissionModeChanged as sharedPermissionModeChanged,
   // available_permission_modes / session_updated / confirm_permission_mode /
   // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
   handleClaudeReady as sharedClaudeReady,
-  handleAgentIdle as sharedAgentIdle,
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
   handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
@@ -1060,9 +1058,10 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // dashboard's own helper (dedup by (sessionId, eventType); no push store).
   pushSessionNotification: (sessionId, eventType, message) =>
     pushSessionNotification(sessionId, eventType, message),
-  // #5618 — agent_idle no-session fallback: mirror the idle patch into FLAT state
-  // (the dashboard UI reads flat streamingMessageId/isIdle; the app omits this).
-  applyAgentIdleFallback: () => getStore().setState(sharedAgentIdle() as Partial<ConnectionState>),
+  // #5618 — generic no-session fallback: mirror a session-targeted patch into FLAT
+  // state (the dashboard UI reads flat streamingMessageId/isIdle/permissionMode; the
+  // app omits this hook). Used by agent_idle and permission_mode_changed.
+  applyNoSessionFallback: (patch) => getStore().setState(patch as Partial<ConnectionState>),
   // #5618 Batch 3 — error-sink for session_restore_failed / session_persist_failed.
   // The dashboard's connection-store addServerError builds its own envelope
   // (category 'general', id 'info', ring-capped serverErrors) from the message;
@@ -1776,17 +1775,13 @@ function clearPendingTrustGrantByRequestId(requestId: string, get: MsgGet): bool
   return cleared;
 }
 
-function handlePermissionModeChanged(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  const { mode } = sharedPermissionModeChanged(msg);
-  const targetId = resolveSessionId(msg, get().activeSessionId);
-  if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, () => ({ permissionMode: mode }));
-  } else {
-    set({ permissionMode: mode });
-  }
-  // Clear pending confirm if mode change arrived (confirmation was accepted)
-  set({ pendingPermissionConfirm: null });
-}
+// permission_mode_changed — migrated to the shared dispatch table (#5618;
+// runDispatch). The seeded-session path + the no-session FLAT fallback
+// (set({ permissionMode })) are the shared dispatchPermissionModeChanged; the flat
+// fallback is carried by the _dispatchAdapter.applyNoSessionFallback hook (the
+// dashboard's UI reads flat permissionMode), and pendingPermissionConfirm is cleared
+// via setState. The dashboard has no pending optimistic-revert tracker, so it omits
+// the clearPendingPermissionModeRequests hook.
 
 // available_permission_modes + session_updated migrated to the shared
 // store-core dispatch table (#5556)
@@ -3169,7 +3164,7 @@ const HANDLERS: Record<string, Handler> = {
   skill_trust_request: handleSkillTrustRequest,
   skill_trust_granted: handleSkillTrustGranted,
   skill_trust_grant_ok: handleSkillTrustGrantOk,
-  permission_mode_changed: handlePermissionModeChanged,
+  // permission_mode_changed — migrated to the shared dispatch table (#5618; runDispatch).
   // available_permission_modes / session_updated / agent_busy migrated to the
   // shared store-core dispatch table (#5556)
   session_switched: handleSessionSwitched,

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1299,7 +1299,7 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     // seeded-session path flips the session to idle ({ isIdle: true,
     // streamingMessageId: null, activeTools: [] }) via the shared dispatchAgentIdle
     // → updateSession. (The no-session FLAT fallback is preserved per-client by the
-    // optional applyAgentIdleFallback adapter hook — dashboard implements, app
+    // optional applyNoSessionFallback adapter hook — dashboard implements, app
     // omits — and is exercised by each client's own tests, not the shared contract.)
     name: 'agent_idle flips the seeded session to idle and clears the streaming id (both clients)',
     type: 'agent_idle',

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1309,6 +1309,20 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
       sessions: { s1: { isIdle: true, streamingMessageId: null } },
     },
   },
+  {
+    // #5618 — permission_mode_changed migrated from SWITCH to the shared dispatch
+    // table. The seeded-session path sets the session field permissionMode via the
+    // shared dispatchPermissionModeChanged (targetId-direct resolution, Decision A).
+    // The no-session flat fallback + the app-only clearPending tracker are per-client
+    // adapter hooks, exercised by each client's own tests, not this shared contract.
+    name: 'permission_mode_changed updates the seeded session permissionMode (both clients)',
+    type: 'permission_mode_changed',
+    init: { activeSessionId: 's1', sessions: { s1: { permissionMode: 'default' } } },
+    message: { type: 'permission_mode_changed', sessionId: 's1', mode: 'plan' },
+    expect: {
+      sessions: { s1: { permissionMode: 'plan' } },
+    },
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -1773,19 +1787,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     message: { type: 'claude_ready', sessionId: 's1' },
     expect: {
       sessions: { s1: { claudeReady: true } },
-    },
-  },
-  {
-    // #6325 (drain #6314): the server confirmed a permission-mode change. Both
-    // clients extract `mode` (shared handlePermissionModeChanged) and set the
-    // session field permissionMode. Target = msg.sessionId || activeSessionId; no
-    // message bubble. Asserts the scalar field via the harness extension.
-    name: 'permission_mode_changed updates the session permissionMode (both clients)',
-    type: 'permission_mode_changed',
-    init: { activeSessionId: 's1', sessions: { s1: { permissionMode: 'default' } } },
-    message: { type: 'permission_mode_changed', sessionId: 's1', mode: 'plan' },
-    expect: {
-      sessions: { s1: { permissionMode: 'plan' } },
     },
   },
   {

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -239,9 +239,10 @@ describe('shared dispatch table', () => {
   describe('runner mechanics', () => {
     it('returns false (table miss) for an unregistered type so the caller falls through', () => {
       const env = makeAdapter()
-      // permission_mode_changed stays platform-local (divergent dashboard
-      // flat-state fallback), so it is NOT in the shared table — a clean miss.
-      expect(dispatch(env, { type: 'permission_mode_changed', mode: 'plan' })).toBe(false)
+      // terminal_output is a terminal write, never a session-state update, so it is
+      // by-design NOT in the shared table (NO_SWITCH_CONTRACT_BY_DESIGN) — a clean
+      // miss → runDispatch returns false and the caller falls through to its switch.
+      expect(dispatch(env, { type: 'terminal_output', data: 'x' })).toBe(false)
     })
 
     it('returns false for a non-string type', () => {

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -66,6 +66,7 @@ import {
   handleSessionUpdated,
   handleAgentBusy,
   handleAgentIdle,
+  handlePermissionModeChanged,
   handleBudgetResumed,
   handleBudgetResumeAck,
   handleConversationId,
@@ -315,17 +316,25 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    */
   syncSecondaryInventory?(kind: 'slashCommands' | 'customAgents', list: unknown[]): void
   /**
-   * Apply the `agent_idle` no-session FALLBACK (#5618). When an `agent_idle`
-   * arrives for a session that isn't in `sessionStates`, the DASHBOARD writes the
-   * idle patch (`{ isIdle, streamingMessageId: null, activeTools: [] }`) into its
-   * FLAT connection state — its UI reads flat `streamingMessageId`/`isIdle`
-   * directly (App.tsx isStreaming) and its pre-bootstrap `sendInput` writes flat
-   * `pending`, so without this an abnormal `agent_idle` leaves the stop button
-   * stuck (#5760). The APP has no flat idle mirror (it derives `isIdle` from the
-   * active session) and OMITS this hook — a faithful per-client preservation of
-   * the prior switch behaviour, in the same spirit as {@link syncSecondaryInventory}.
+   * Apply a no-session FALLBACK patch to the FLAT connection state (#5618). When a
+   * session-targeted message (`agent_idle`, `permission_mode_changed`, …) arrives for
+   * a session that isn't in `sessionStates`, the DASHBOARD writes the patch into its
+   * flat state — its UI reads flat fields directly (`streamingMessageId`/`isIdle` for
+   * the stop button, App.tsx isStreaming; `permissionMode` for the mode pill) and its
+   * pre-bootstrap `sendInput` writes flat `pending`, so without this an abnormal
+   * broadcast leaves that flat UI stale (#5760). The APP has no flat mirror for these
+   * (it derives them from the active session) and OMITS this hook — a faithful
+   * per-client preservation of the prior switch behaviour, like {@link syncSecondaryInventory}.
    */
-  applyAgentIdleFallback?(): void
+  applyNoSessionFallback?(patch: Flat): void
+  /**
+   * Clear the APP's pending permission-mode optimistic-revert tracker for a session
+   * (#5618). On a `permission_mode_changed` broadcast the app drops any in-flight
+   * optimistic revert for `sessionId` so a late rejection can't undo the confirmed
+   * mode; the DASHBOARD has no equivalent per-session tracker and OMITS this hook.
+   * A null sessionId is a no-op.
+   */
+  clearPendingPermissionModeRequests?(sessionId: string | null): void
   /**
    * Mirror checkpoint changes into a SECONDARY client store (#5618 Batch 6).
    * The mobile app keeps a separate `useConversationStore` whose checkpoint list
@@ -531,6 +540,11 @@ export interface DispatchMessageMap {
   agent_idle: {
     type: 'agent_idle'
     sessionId?: string
+  }
+  permission_mode_changed: {
+    type: 'permission_mode_changed'
+    sessionId?: string
+    mode?: string | null
   }
   budget_resumed: {
     type: 'budget_resumed'
@@ -897,11 +911,42 @@ function dispatchAgentIdle<S extends DispatchSessionBase>(
   adapter: ClientStoreAdapter<S>,
 ): void {
   const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  const idlePatch = handleAgentIdle()
   if (targetId && adapter.hasSession(targetId)) {
-    adapter.updateSession(targetId, () => handleAgentIdle() as unknown as Partial<S>)
+    adapter.updateSession(targetId, () => idlePatch as unknown as Partial<S>)
   } else {
-    adapter.applyAgentIdleFallback?.()
+    adapter.applyNoSessionFallback?.(idlePatch as unknown as Record<string, unknown>)
   }
+}
+
+/**
+ * `permission_mode_changed` — apply the new permission mode to the target session
+ * (#5618). Reconciliation of the two prior switch cases:
+ *  - **Session resolution = targetId-direct** (Decision A): apply when the target is
+ *    local, else the dashboard's flat fallback via {@link ClientStoreAdapter.applyNoSessionFallback}.
+ *    This drops the APP's prior `effectiveId` retry-to-active-session, which only
+ *    diverged when the target wasn't in `sessionStates` — unreachable in normal use
+ *    (`session_list` seeds a shell for every session) and a latent multi-client bug
+ *    when it did fire (it applied another session's broadcast to the active one).
+ *  - **clearPending** (app-only optimistic-revert tracker) is preserved via
+ *    {@link ClientStoreAdapter.clearPendingPermissionModeRequests} — the app implements
+ *    it, the dashboard omits it. Keyed on `targetId` (the session the broadcast is
+ *    *for*), matching the app's prior multi-client-safe clear.
+ *  - **`pendingPermissionConfirm: null`** (both clients) via `setState`.
+ */
+function dispatchPermissionModeChanged<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['permission_mode_changed'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { mode } = handlePermissionModeChanged(msg as Record<string, unknown>)
+  const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (targetId && adapter.hasSession(targetId)) {
+    adapter.updateSession(targetId, () => ({ permissionMode: mode }) as unknown as Partial<S>)
+  } else {
+    adapter.applyNoSessionFallback?.({ permissionMode: mode })
+  }
+  adapter.clearPendingPermissionModeRequests?.(targetId)
+  adapter.setState({ pendingPermissionConfirm: null })
 }
 
 /** `budget_resumed` — append the "budget resumed" system message. */
@@ -1719,6 +1764,7 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     session_updated: dispatchSessionUpdated,
     agent_busy: dispatchAgentBusy,
     agent_idle: dispatchAgentIdle,
+    permission_mode_changed: dispatchPermissionModeChanged,
     budget_resumed: dispatchBudgetResumed,
     budget_resume_ack: dispatchBudgetResumeAck,
     conversation_id: dispatchConversationId,
@@ -1807,6 +1853,7 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'session_updated',
   'agent_busy',
   'agent_idle',
+  'permission_mode_changed',
   'budget_resumed',
   'budget_resume_ack',
   'conversation_id',

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -903,7 +903,7 @@ function dispatchAgentBusy<S extends DispatchSessionBase>(
  * prior switch case for a SEEDED session: `updateSession(target, () => handleAgentIdle())`
  * ({ isIdle, streamingMessageId: null, activeTools: [] }). The no-session FALLBACK
  * (the dashboard mirrors the patch into flat state; the app no-ops) is preserved
- * per-client via the optional {@link ClientStoreAdapter.applyAgentIdleFallback} hook
+ * per-client via the optional {@link ClientStoreAdapter.applyNoSessionFallback} hook
  * — no behaviour change on either client.
  */
 function dispatchAgentIdle<S extends DispatchSessionBase>(
@@ -945,7 +945,12 @@ function dispatchPermissionModeChanged<S extends DispatchSessionBase>(
   } else {
     adapter.applyNoSessionFallback?.({ permissionMode: mode })
   }
-  adapter.clearPendingPermissionModeRequests?.(targetId)
+  // Guard on targetId (matches the app's prior `if (targetId)`): never clear the
+  // tracker with a null key — clearing the app's pending entries is keyed on the
+  // session the broadcast is *for*.
+  if (targetId) {
+    adapter.clearPendingPermissionModeRequests?.(targetId)
+  }
   adapter.setState({ pendingPermissionConfirm: null })
 }
 


### PR DESCRIPTION
Part of #5618 — second dispatch-table slice. `permission_mode_changed` moves from a per-client switch case (app) / HANDLERS-map handler (dashboard) onto the shared dispatch table, and **generalizes the fallback hook** so the pattern scales to the rest.

## The one behaviour change — please spot-check (Decision A)
**Session resolution is now `targetId`-direct** (you picked this). The shared handler applies the mode to the target session when local, else the dashboard's flat fallback. This **drops the app's prior `effectiveId`-retry-to-active-session**.

Why it's safe: the retry only diverged when the broadcast's target wasn't in `sessionStates` — but `session_list` seeds a shell for *every* listed session ([app](packages/app/src/store/message-handler.ts), `createEmptySessionState` per `newSessionIds`), so the target is always present → `effectiveId === targetId` in all normal operation. The only case it fired was a stale/race broadcast for an absent session, where falling back to the *active* session is a latent multi-client bug (it flips session Y because session X's mode changed). **Zero test breakage across both full store suites** (687 app + 915 dashboard) confirms the edge is unreachable.

## The mechanical part (zero behaviour change)
| divergence | preserved how |
|---|---|
| dashboard no-session **flat fallback** (`set({ permissionMode })`); app no-op | generic `applyNoSessionFallback(patch)` adapter hook — dashboard implements, app omits. **`agent_idle` refactored onto the same hook** (was the agent_idle-specific `applyAgentIdleFallback`), so both flat-fallback types share one mechanism |
| app-only **`clearPendingPermissionModeRequests`** (optimistic-revert tracker, keyed on `targetId`) | per-client hook — app implements, dashboard omits |
| both clear **`pendingPermissionConfirm`** | `setState` |

The contract fixture moves **SWITCH → DISPATCH**; the table-miss unit test swaps its stale `permission_mode_changed` example for `terminal_output` (by-design never a dispatch type).

## Verification
store-core typecheck + full (1847) · protocol handler-coverage (340) · app contract-switch (50) + **full app store (687)** · dashboard contract-switch (50) + **full dashboard store (915)** · all tsc clean. Existing `message-handler.test.ts` (both clients, incl. the optimistic-revert / offline tests) still pass through `runDispatch`.

Part of #5618