### PR TITLE
refactor: migrate budget_warning/plan_ready/rate_limited/server_shutdown to dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -31,11 +31,9 @@ import {
   // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
   handleClaudeReady as sharedClaudeReady,
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
-  handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
   // plan_started / inactivity_warning / dev_preview / dev_preview_stopped
   // migrated to the shared dispatch table (#5556 slice 2)
-  handlePlanReady as sharedPlanReady,
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
   handleToolInputDelta as sharedToolInputDelta,
@@ -97,9 +95,7 @@ import {
   // to the shared dispatch table (#5556 slice 2)
   handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
-  handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
-  handleRateLimited as sharedRateLimited,
   // web_task_created / web_task_updated — migrated to the shared dispatch table
   // (#5556 slice 4); the app no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
@@ -1219,6 +1215,19 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // per-session tracker and omits this hook).
   clearPendingPermissionModeRequests: (sessionId) =>
     clearPendingPermissionModeRequestsForSession(sessionId),
+  // #5618 — budget_warning (and future notice types) surface a transient alert
+  // via the app's React-Native Alert.
+  alert: (title, message) => Alert.alert(title, message),
+  // #5618 — plan_ready raises the app's 'plan' background-session notification
+  // (the dashboard has no equivalent surface and omits this hook).
+  notifyPlanReady: (sessionId) =>
+    pushSessionNotification(sessionId, 'plan', 'Plan ready for approval'),
+  // #5618 — server_shutdown mirrors the shutdown patch into the app's mobile
+  // notification store (the dashboard omits this hook).
+  applyShutdownNotification: (payload) =>
+    useNotificationStore
+      .getState()
+      .setShutdown(payload.shutdownReason, payload.restartEtaMs, payload.restartingSince),
   // #5653 — file-ops / git wrapper cases route through the shared dispatch
   // table; the app supplies its module-level imperative-callback registry so
   // the parsed payload reaches the UI's registered callback exactly as the
@@ -2846,19 +2855,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // agent_spawned / agent_completed / agent_event / background_work_changed /
     // plan_started — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'plan_ready': {
-      const planReady = sharedPlanReady(msg, get().activeSessionId);
-      if (planReady.sessionId && get().sessionStates[planReady.sessionId]) {
-        updateSession(planReady.sessionId, () => planReady.patch);
-      }
-      // Platform-specific UX: app surfaces a session notification on
-      // plan-ready (the dashboard has no equivalent surface). Kept at the
-      // call site so the shared handler stays free of platform concerns.
-      if (planReady.sessionId) {
-        pushSessionNotification(planReady.sessionId, 'plan', 'Plan ready for approval');
-      }
-      break;
-    }
+    // plan_ready — migrated to the shared dispatch table (#5618; runDispatch). The
+    // app's plan session-notification rides the optional notifyPlanReady adapter hook.
 
     // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
 
@@ -3120,33 +3118,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'rate_limited': {
-      // #6334 — surface the server-side throttle as a brief system notice so the
-      // user gets feedback (the rate limit itself is enforced server-side).
-      const { chatMessage: rateLimitMsg } = sharedRateLimited(msg);
-      const activeRateLimitId = get().activeSessionId;
-      if (activeRateLimitId && get().sessionStates[activeRateLimitId]) {
-        updateActiveSession((ss) => ({
-          messages: [...ss.messages, rateLimitMsg],
-        }));
-      } else {
-        get().addMessage(rateLimitMsg);
-      }
-      break;
-    }
+    // rate_limited (#6334) — migrated to the shared dispatch table (#5618;
+    // runDispatch). Byte-identical active-session notice; no per-client hook.
 
-    case 'server_shutdown': {
-      const shutdownPatch = sharedServerShutdown(msg);
-      set(shutdownPatch);
-      useNotificationStore
-        .getState()
-        .setShutdown(
-          shutdownPatch.shutdownReason,
-          shutdownPatch.restartEtaMs,
-          shutdownPatch.restartingSince,
-        );
-      break;
-    }
+    // server_shutdown — migrated to the shared dispatch table (#5618; runDispatch).
+    // The app's setShutdown notification rides the optional applyShutdownNotification hook.
 
     // --- Multi-client awareness ---
 
@@ -3256,19 +3232,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // session_usage / session_cost_threshold_crossed — migrated to the shared
     // dispatch table (#5556 slice 2)
 
-    case 'budget_warning': {
-      const { warningMessage, systemMessage } = sharedBudgetWarning(msg);
-      Alert.alert('Budget Warning', warningMessage);
-      const targetId = resolveSessionId(msg, get().activeSessionId);
-      if (targetId && get().sessionStates[targetId]) {
-        updateSession(targetId, (ss) => ({
-          messages: [...ss.messages, systemMessage],
-        }));
-      } else {
-        get().addMessage(systemMessage);
-      }
-      break;
-    }
+    // budget_warning — migrated to the shared dispatch table (#5618; runDispatch).
+    // The alert rides the new adapter.alert primitive; routing is byte-identical.
 
     case 'budget_exceeded': {
       const { exceededMessage, systemMessage } = sharedBudgetExceeded(msg);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -21,11 +21,9 @@ import {
   // agent_busy / budget_resumed migrated to the shared dispatch table (#5556)
   handleClaudeReady as sharedClaudeReady,
   handleThinkingLevelChanged as sharedThinkingLevelChanged,
-  handleBudgetWarning as sharedBudgetWarning,
   handleBudgetExceeded as sharedBudgetExceeded,
   // plan_started / inactivity_warning / dev_preview / dev_preview_stopped
   // migrated to the shared dispatch table (#5556 slice 2)
-  handlePlanReady as sharedPlanReady,
   // #4653: chroxy-side multi-question deny intervention surfaced to the user
   handleToolStart as sharedToolStart,
   handleToolResult as sharedToolResult,
@@ -92,9 +90,7 @@ import {
   // mcp_servers / session_usage migrated to the shared dispatch table (#5556 slice 2)
   handleResultUsage as sharedResultUsage,
   handleServerError as sharedServerError,
-  handleServerShutdown as sharedServerShutdown,
   handleServerStatusLegacy as sharedServerStatusLegacy,
-  handleRateLimited as sharedRateLimited,
   // web_task_created / web_task_updated — migrated to the shared dispatch table
   // (#5556 slice 4); the dashboard no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
@@ -1050,6 +1046,9 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
       updater(state as unknown as Record<string, unknown>) as Partial<ConnectionState>,
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
+  // #5618 — budget_warning (and future notice types) surface a transient alert
+  // via the dashboard's alert adapter.
+  alert: (title, message) => _adapters.alert.alert(title, message),
   getSessions: () => getStore().getState().sessions,
   // #5618 Batch 6 — checkpoint_created reads the prior flat list to append.
   // The dashboard omits syncSecondaryCheckpoints (no secondary checkpoint store).
@@ -2364,18 +2363,8 @@ function handlePermissionResolved(msg: Record<string, unknown>, get: MsgGet, set
   }
 }
 
-function handleBudgetWarning(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  const { warningMessage, systemMessage } = sharedBudgetWarning(msg);
-  _adapters.alert.alert('Budget Warning', warningMessage);
-  const targetId = resolveSessionId(msg, get().activeSessionId);
-  if (targetId && get().sessionStates[targetId]) {
-    updateSession(targetId, (ss) => ({
-      messages: [...ss.messages, systemMessage],
-    }));
-  } else {
-    get().addMessage(systemMessage);
-  }
-}
+// budget_warning — migrated to the shared dispatch table (#5618; runDispatch).
+// The alert rides the new adapter.alert primitive; routing is byte-identical.
 
 function handleBudgetExceeded(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
   const { exceededMessage, systemMessage } = sharedBudgetExceeded(msg);
@@ -2437,9 +2426,8 @@ function handleServerError(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
   }
 }
 
-function handleServerShutdown(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  set(sharedServerShutdown(msg));
-}
+// server_shutdown — migrated to the shared dispatch table (#5618; runDispatch).
+// The dashboard has no shutdown notification, so it omits applyShutdownNotification.
 
 /**
  * #5163 (epic #5159) — Control Room `activity_snapshot`: REPLACE the target
@@ -3178,11 +3166,11 @@ const HANDLERS: Record<string, Handler> = {
   tool_result: handleToolResult,
   permission_request: handlePermissionRequest,
   permission_resolved: handlePermissionResolved,
-  budget_warning: handleBudgetWarning,
+  // budget_warning — migrated to the shared dispatch table (#5618; runDispatch).
   budget_exceeded: handleBudgetExceeded,
   // budget_resumed migrated to the shared store-core dispatch table (#5556)
   server_error: handleServerError,
-  server_shutdown: handleServerShutdown,
+  // server_shutdown — migrated to the shared dispatch table (#5618; runDispatch).
   // #5163 (epic #5159): Control Room live activity tree.
   activity_snapshot: handleActivitySnapshot,
   activity_delta: handleActivityDelta,
@@ -4350,13 +4338,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // agent_spawned / agent_completed / agent_event / background_work_changed /
     // plan_started — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'plan_ready': {
-      const planReady = sharedPlanReady(msg, get().activeSessionId);
-      if (planReady.sessionId && get().sessionStates[planReady.sessionId]) {
-        updateSession(planReady.sessionId, () => planReady.patch);
-      }
-      break;
-    }
+    // plan_ready — migrated to the shared dispatch table (#5618; runDispatch). The
+    // dashboard has no plan notification, so it omits the notifyPlanReady hook.
 
     // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
 
@@ -4520,20 +4503,8 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'rate_limited': {
-      // #6334 — surface the server-side throttle as a brief system notice so the
-      // user gets feedback (the rate limit itself is enforced server-side).
-      const { chatMessage: rateLimitMsg } = sharedRateLimited(msg);
-      const activeRateLimitId = get().activeSessionId;
-      if (activeRateLimitId && get().sessionStates[activeRateLimitId]) {
-        updateActiveSession((ss) => ({
-          messages: [...ss.messages, rateLimitMsg],
-        }));
-      } else {
-        get().addMessage(rateLimitMsg);
-      }
-      break;
-    }
+    // rate_limited (#6334) — migrated to the shared dispatch table (#5618;
+    // runDispatch). Byte-identical active-session notice; no per-client hook.
 
     // --- Multi-client awareness ---
 

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -166,6 +166,9 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     // live `flat` ref so the web-task upsert fixtures observe identical results.
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => added.push(m),
+    // #5618 — `alert` is a transient UI side-effect OUTSIDE the shared store-state
+    // contract (no fixture asserts it), modelled as a no-op for the contract surface.
+    alert: () => {},
     getSessions: () => sessionList,
     // #5618 Batch 6 — checkpoint_created reads the prior flat list to append.
     // Both clients back it with their flat `checkpoints`; modelled as a read of

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1323,6 +1323,64 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
       sessions: { s1: { permissionMode: 'plan' } },
     },
   },
+  {
+    // #5618 — budget_warning migrated SWITCH→DISPATCH. Both clients append the SAME
+    // system note to the target session (the alert rides the shared adapter.alert,
+    // not asserted here).
+    name: 'budget_warning appends the warning system bubble to the target session (both clients)',
+    type: 'budget_warning',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'budget_warning', sessionId: 's1', message: 'Approaching cost budget limit' },
+    expect: {
+      sessions: {
+        s1: { messages: [{ type: 'system', content: 'Approaching cost budget limit' }] },
+      },
+    },
+  },
+  {
+    // #5618 — plan_ready migrated SWITCH→DISPATCH. Both clients flip the session to
+    // plan-pending and store the allowed prompts (the app's plan notification rides
+    // the optional notifyPlanReady hook, not asserted here).
+    name: 'plan_ready flips plan state to ready and stores the allowed prompts (both clients)',
+    type: 'plan_ready',
+    init: { sessions: { s1: { isPlanPending: false, planAllowedPrompts: [] } } },
+    message: {
+      type: 'plan_ready',
+      sessionId: 's1',
+      allowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'Proceed with the plan' }],
+    },
+    expect: {
+      sessions: {
+        s1: {
+          isPlanPending: true,
+          planAllowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'Proceed with the plan' }],
+        },
+      },
+    },
+  },
+  {
+    // #5618 — server_shutdown migrated SWITCH→DISPATCH. Both clients write the shared
+    // patch to flat state (the app's setShutdown notification rides applyShutdownNotification).
+    name: 'server_shutdown writes shutdownReason + restartEtaMs to the flat store (both clients)',
+    type: 'server_shutdown',
+    message: { type: 'server_shutdown', reason: 'restart', restartEtaMs: 30000 },
+    expect: {
+      flat: { shutdownReason: 'restart', restartEtaMs: 30000 },
+    },
+  },
+  {
+    // #5618 — rate_limited (#6334) migrated SWITCH→DISPATCH. Both clients append a
+    // system throttle notice (with a retry hint) to the active session.
+    name: 'rate_limited appends a system throttle notice with a retry hint (both clients)',
+    type: 'rate_limited',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'rate_limited', retryAfterMs: 2000, message: 'Too many messages. Please slow down.' },
+    expect: {
+      sessions: {
+        s1: { messages: [{ type: 'system', content: 'Too many messages. Please slow down. Retry in 2s.' }] },
+      },
+    },
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -1433,20 +1491,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       // Both clients attach the result onto the same bubble; assert the bubble
       // is still a single tool_use entry carrying the result text.
       sessions: { s1: { messages: [{ type: 'tool_use', toolUseId: 'tu-1' }] } },
-    },
-  },
-  {
-    // budget_warning is a both-clients switch case (#5619): both clients append
-    // the SAME system note to the target session's messages when it exists.
-    // `msg.message` is echoed verbatim into the bubble content.
-    name: 'budget_warning appends the warning system bubble to the target session',
-    type: 'budget_warning',
-    init: { activeSessionId: 's1', sessions: { s1: {} } },
-    message: { type: 'budget_warning', sessionId: 's1', message: 'Approaching cost budget limit' },
-    expect: {
-      sessions: {
-        s1: { messages: [{ type: 'system', content: 'Approaching cost budget limit' }] },
-      },
     },
   },
   {
@@ -1925,26 +1969,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
-    // #6325 (drain #6314): the plan is ready. Both clients flip the session to
-    // plan-pending and store the allowed prompts (session-scalar fields).
-    name: 'plan_ready flips plan state to ready and stores the allowed prompts (both clients)',
-    type: 'plan_ready',
-    init: { sessions: { s1: { isPlanPending: false, planAllowedPrompts: [] } } },
-    message: {
-      type: 'plan_ready',
-      sessionId: 's1',
-      allowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'Proceed with the plan' }],
-    },
-    expect: {
-      sessions: {
-        s1: {
-          isPlanPending: true,
-          planAllowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'Proceed with the plan' }],
-        },
-      },
-    },
-  },
-  {
     // #6325 (drain #6314): a server-side error tagged to a session. Both clients
     // (shared handleServerError) append an `error` bubble to the tagged session and
     // clear streamingMessageId + pendingClientMessageId. The serverErrors ring +
@@ -2195,18 +2219,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
-    // #6325 (bucket-B): the server announced a restart. Both clients run the shared
-    // handleServerShutdown and set its patch onto the flat store: shutdownReason +
-    // restartEtaMs (restartingSince is Date.now() → not asserted). Both flat fields
-    // unseeded → non-vacuous. The app's setShutdown notification is off-slice.
-    name: 'server_shutdown writes shutdownReason + restartEtaMs to the flat store (both clients)',
-    type: 'server_shutdown',
-    message: { type: 'server_shutdown', reason: 'restart', restartEtaMs: 30000 },
-    expect: {
-      flat: { shutdownReason: 'restart', restartEtaMs: 30000 },
-    },
-  },
-  {
     // #6325 (bucket-B): the active session switched. Both clients (shared
     // handleSessionSwitched) set the flat activeSessionId to the new id and lazily
     // init sessionStates[newId], stamping conversationId. Seeds a different starting
@@ -2426,19 +2438,5 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     init: { activeSessionId: 's1' },
     message: { type: 'terminal_output', sessionId: 's1', data: 'term-line file.txt' },
     expect: { terminalWrites: ['term-line file.txt'] },
-  },
-  {
-    // #6334: a server-side throttle. Both clients run the shared handleRateLimited,
-    // which builds a `system` bubble from `message` + a "Retry in Ns" hint
-    // (ceil(retryAfterMs/1000)), and append it to the active session.
-    name: 'rate_limited appends a system throttle notice with a retry hint (both clients)',
-    type: 'rate_limited',
-    init: { activeSessionId: 's1', sessions: { s1: {} } },
-    message: { type: 'rate_limited', retryAfterMs: 2000, message: 'Too many messages. Please slow down.' },
-    expect: {
-      sessions: {
-        s1: { messages: [{ type: 'system', content: 'Too many messages. Please slow down. Retry in 2s.' }] },
-      },
-    },
   },
 ]

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -145,6 +145,7 @@ function makeAdapter(init?: {
     setState: (patch) => Object.assign(flat, patch),
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => addedMessages.push(m),
+    alert: () => {},
     getSessions: () => sessionList,
     getCheckpoints: () => (flat.checkpoints as Checkpoint[] | undefined) ?? [],
     pushSessionNotification: (sessionId, eventType, message) =>

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -68,6 +68,10 @@ import {
   handleAgentIdle,
   handlePermissionModeChanged,
   handleBudgetResumed,
+  handleBudgetWarning,
+  handlePlanReady,
+  handleRateLimited,
+  handleServerShutdown,
   handleBudgetResumeAck,
   handleConversationId,
   handlePermissionRulesUpdated,
@@ -260,6 +264,13 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
   updateState(updater: (flat: Flat) => Flat): void
   /** Append a chat message via the client's own add-message path. */
   addMessage(message: ChatMessage): void
+  /**
+   * Surface a transient alert/toast to the user (#5618). Both clients back this
+   * with their own alert primitive (the app's React-Native `Alert.alert`, the
+   * dashboard's `_adapters.alert.alert`). Used by `budget_warning` and other
+   * notice-bearing types whose body is otherwise byte-identical across clients.
+   */
+  alert(title: string, message: string): void
   /** Read the current session list (for `session_updated`). */
   getSessions(): SessionInfo[]
   /**
@@ -335,6 +346,18 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * A null sessionId is a no-op.
    */
   clearPendingPermissionModeRequests?(sessionId: string | null): void
+  /**
+   * Surface the APP's `plan_ready` session notification (#5618). On `plan_ready`
+   * the app pushes a 'plan' background-session notification ("Plan ready for
+   * approval"); the DASHBOARD has no equivalent surface and OMITS this hook.
+   */
+  notifyPlanReady?(sessionId: string): void
+  /**
+   * Apply the APP's `server_shutdown` notification side-effect (#5618). After the
+   * shared shutdown patch is written to flat state, the app mirrors it into its
+   * mobile notification store (`setShutdown`); the DASHBOARD omits this hook.
+   */
+  applyShutdownNotification?(payload: { shutdownReason: 'restart' | 'shutdown' | 'crash'; restartEtaMs: number; restartingSince: number }): void
   /**
    * Mirror checkpoint changes into a SECONDARY client store (#5618 Batch 6).
    * The mobile app keeps a separate `useConversationStore` whose checkpoint list
@@ -545,6 +568,26 @@ export interface DispatchMessageMap {
     type: 'permission_mode_changed'
     sessionId?: string
     mode?: string | null
+  }
+  budget_warning: {
+    type: 'budget_warning'
+    sessionId?: string
+    message?: string
+  }
+  plan_ready: {
+    type: 'plan_ready'
+    sessionId?: string
+    allowedPrompts?: unknown[]
+  }
+  rate_limited: {
+    type: 'rate_limited'
+    message?: string
+    retryAfterMs?: number
+  }
+  server_shutdown: {
+    type: 'server_shutdown'
+    reason?: string
+    restartEtaMs?: number
   }
   budget_resumed: {
     type: 'budget_resumed'
@@ -972,6 +1015,75 @@ function dispatchBudgetResumed<S extends DispatchSessionBase>(
   } else {
     adapter.addMessage(systemMessage)
   }
+}
+
+/**
+ * `budget_warning` (#5618) — alert the user and append a system message to the
+ * target session (or the flat add-message path when it isn't local). Byte-identical
+ * across clients except the alert primitive, which is the required `adapter.alert`.
+ */
+function dispatchBudgetWarning<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['budget_warning'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { warningMessage, systemMessage } = handleBudgetWarning(msg as Record<string, unknown>)
+  adapter.alert('Budget Warning', warningMessage)
+  const targetId = resolveSessionId(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (targetId && adapter.hasSession(targetId)) {
+    adapter.updateSession(targetId, (ss) => ({ messages: [...ss.messages, systemMessage] } as Partial<S>))
+  } else {
+    adapter.addMessage(systemMessage)
+  }
+}
+
+/**
+ * `rate_limited` (#6334, #5618) — surface the server-side throttle as a brief
+ * system notice on the ACTIVE session (or the flat add-message path). Byte-identical
+ * across both clients.
+ */
+function dispatchRateLimited<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['rate_limited'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { chatMessage } = handleRateLimited(msg as Record<string, unknown>)
+  const activeId = adapter.getActiveSessionId()
+  if (activeId && adapter.hasSession(activeId)) {
+    adapter.updateSession(activeId, (ss) => ({ messages: [...ss.messages, chatMessage] } as Partial<S>))
+  } else {
+    adapter.addMessage(chatMessage)
+  }
+}
+
+/**
+ * `plan_ready` (#5618) — flip the target session into plan-pending. The APP also
+ * raises a 'plan' background-session notification via the optional
+ * {@link ClientStoreAdapter.notifyPlanReady} hook (the dashboard omits it).
+ */
+function dispatchPlanReady<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['plan_ready'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const planReady = handlePlanReady(msg as Record<string, unknown>, adapter.getActiveSessionId())
+  if (planReady.sessionId && adapter.hasSession(planReady.sessionId)) {
+    adapter.updateSession(planReady.sessionId, () => planReady.patch as unknown as Partial<S>)
+  }
+  if (planReady.sessionId) {
+    adapter.notifyPlanReady?.(planReady.sessionId)
+  }
+}
+
+/**
+ * `server_shutdown` (#5618) — write the shared shutdown patch to flat state. The
+ * APP additionally mirrors it into its mobile notification store via the optional
+ * {@link ClientStoreAdapter.applyShutdownNotification} hook (the dashboard omits it).
+ */
+function dispatchServerShutdown<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['server_shutdown'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const payload = handleServerShutdown(msg as Record<string, unknown>)
+  adapter.setState(payload as unknown as Record<string, unknown>)
+  adapter.applyShutdownNotification?.(payload)
 }
 
 /**
@@ -1770,6 +1882,10 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     agent_busy: dispatchAgentBusy,
     agent_idle: dispatchAgentIdle,
     permission_mode_changed: dispatchPermissionModeChanged,
+    budget_warning: dispatchBudgetWarning,
+    plan_ready: dispatchPlanReady,
+    rate_limited: dispatchRateLimited,
+    server_shutdown: dispatchServerShutdown,
     budget_resumed: dispatchBudgetResumed,
     budget_resume_ack: dispatchBudgetResumeAck,
     conversation_id: dispatchConversationId,
@@ -1859,6 +1975,10 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'agent_busy',
   'agent_idle',
   'permission_mode_changed',
+  'budget_warning',
+  'plan_ready',
+  'rate_limited',
+  'server_shutdown',
   'budget_resumed',
   'budget_resume_ack',
   'conversation_id',


### PR DESCRIPTION
Part of #5618 — the **first family-batched slice** (the maintainer chose grouped-by-family PRs). Four notification/alert *simple* types move onto the shared dispatch table, all **zero / unreachable-edge behaviour change**, verified by zero test breakage across both full store suites.

## What migrates
| type | shared body | per-client difference → how preserved |
|---|---|---|
| `budget_warning` | byte-identical (target-session message append, else `addMessage`) | the **alert** primitive → new **required** `adapter.alert(title, message)` (app `Alert.alert`, dashboard `_adapters.alert.alert`) — reusable by future notice types |
| `rate_limited` (#6334) | byte-identical active-session system notice | none |
| `plan_ready` | shared plan-pending flip | app's `'plan'` background notification → new optional `notifyPlanReady` hook (dashboard omits) |
| `server_shutdown` | shared flat patch | app's `setShutdown` mobile notification → new optional `applyShutdownNotification` hook (dashboard omits) |

Four contract fixtures move **SWITCH→DISPATCH**; the two test adapters gain a no-op `alert`.

## Honest note on the triage map
This is the genuinely-clean subset of the [verified triage map](https://github.com/blamechris/chroxy/issues/5618). Reading the actual code, several map-"trivial" types turned out **thick-divergence** — `server_status` (big dashboard-only startup-phase branch), `server_mode` (app→lifecycle-store+viewMode vs dashboard→flat+alert, only the parser shared), `session_warning` (app banner-state vs dashboard message-append) — where migrating adds more hook plumbing than dedup it saves. Those are better left switch-local; I'm verifying each remaining type against current code rather than trusting the map's complexity rating.

## Verification
store-core typecheck + full (1851) · protocol handler-coverage (340) · app contract-switch + **full app store (733)** · dashboard **full store (911)** · all tsc clean. Existing `message-handler.test.ts` for these four types still pass through `runDispatch`.

Part of #5618