### PR TITLE
refactor: migrate conversations_list + checkpoint_restored to dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -49,13 +49,11 @@ import {
   // (#5618 Batch 6); checkpoint_restored is not migrated in this batch — it
   // stays platform-local (here as a switch case; the dashboard via its
   // HANDLERS map), so this shared import remains.
-  handleCheckpointRestored as sharedCheckpointRestored,
   handleError as sharedError,
   handleSessionError as sharedSessionError,
   handleClientJoined as sharedClientJoined,
   handleClientLeft as sharedClientLeft,
   // conversation_id migrated to the shared dispatch table (#5556)
-  handleConversationsList as sharedConversationsList,
   handleHistoryReplayStart as sharedHistoryReplayStart,
   handleHistoryReplayEnd as sharedHistoryReplayEnd,
   // #5555.3 / #5555.4 — lastSeq cursor + no-blank-flash reconcile.
@@ -1228,6 +1226,16 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
     useNotificationStore
       .getState()
       .setShutdown(payload.shutdownReason, payload.restartEtaMs, payload.restartingSince),
+  // #5618 — checkpoint_restored auto-switches with the app's no-notify/no-haptic
+  // options (the server already re-homed this client; an auto-switch shouldn't buzz).
+  switchToRestoredSession: (sessionId) =>
+    getStore().getState().switchSession(sessionId, { serverNotify: false, haptic: false }),
+  // #5618 — conversations_list clears the app-only conversationHistoryError flag and
+  // mirrors the list into the secondary conversation store (the dashboard omits this).
+  applyConversationsListExtras: (conversations) => {
+    getStore().setState({ conversationHistoryError: null });
+    useConversationStore.getState().setConversationHistory(conversations as ConversationSummary[]);
+  },
   // #5653 — file-ops / git wrapper cases route through the shared dispatch
   // table; the app supplies its module-level imperative-callback registry so
   // the parsed payload reaches the UI's registered callback exactly as the
@@ -3212,15 +3220,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // now rides on the `syncSecondaryCheckpoints` adapter hook below; the
     // dashboard omits that hook (no secondary checkpoint store).
 
-    case 'checkpoint_restored': {
-      // Server created a new session at the checkpoint state.
-      // Auto-switch to it; session_list update follows from server.
-      const restored = sharedCheckpointRestored(msg);
-      if (restored) {
-        get().switchSession(restored.newSessionId, { serverNotify: false, haptic: false });
-      }
-      break;
-    }
+    // checkpoint_restored — migrated to the shared dispatch table (#5618; runDispatch).
+    // The auto-switch (with the app's no-notify/no-haptic opts) rides the required
+    // switchToRestoredSession adapter hook.
 
     // mcp_servers — migrated to the shared dispatch table (#5556 slice 2)
 
@@ -3327,14 +3329,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // web_task_list — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'conversations_list': {
-      // Parser shared via store-core; app-only state mirroring (loading/error
-      // flags + useConversationStore) stays here.
-      const { conversations } = sharedConversationsList(msg);
-      set({ conversationHistory: conversations, conversationHistoryLoading: false, conversationHistoryError: null });
-      useConversationStore.getState().setConversationHistory(conversations);
-      break;
-    }
+    // conversations_list — migrated to the shared dispatch table (#5618; runDispatch).
+    // The app's error-clear + useConversationStore mirror ride the optional
+    // applyConversationsListExtras adapter hook.
 
     case 'search_results': {
       const currentQuery = (get() as ConnectionState).searchQuery;

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -63,8 +63,6 @@ import {
   handlePermissionRequest as sharedPermissionRequest,
   handlePermissionResolved as sharedPermissionResolved,
   handlePermissionTimeout as sharedPermissionTimeout,
-  handleCheckpointRestored as sharedCheckpointRestored,
-  handleConversationsList as sharedConversationsList,
   handleRawOutput as sharedRawOutput,
   handleTokenRotated as sharedTokenRotated,
   handlePairFail as sharedPairFail,
@@ -1053,6 +1051,9 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // #5618 Batch 6 — checkpoint_created reads the prior flat list to append.
   // The dashboard omits syncSecondaryCheckpoints (no secondary checkpoint store).
   getCheckpoints: () => getStore().getState().checkpoints,
+  // #5618 — checkpoint_restored auto-switches (plain, no options — the dashboard has
+  // no serverNotify/haptic concepts; the app passes those via its own impl).
+  switchToRestoredSession: (sessionId) => getStore().getState().switchSession(sessionId),
   // #5618 — user_question raises a background-session notification via the
   // dashboard's own helper (dedup by (sessionId, eventType); no push store).
   pushSessionNotification: (sessionId, eventType, message) =>
@@ -1386,19 +1387,9 @@ function applyRotatedTunnelUrlDashboard(
   }
 }
 
-function handleCheckpointRestored(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  // Server has created a new session from the checkpoint and already moved
-  // this client's server-side activeSessionId onto it (the message is sent
-  // only to the requesting client — see checkpoint-handlers.js). #5454:
-  // adopt the shared parser and auto-switch to the restored session, matching
-  // the app. Previously the dashboard left the operator on the old tab until
-  // they clicked the new "Rewind: …" entry; the session_list broadcast that
-  // follows still populates the tab strip.
-  const restored = sharedCheckpointRestored(msg);
-  if (restored) {
-    get().switchSession(restored.newSessionId);
-  }
-}
+// checkpoint_restored — migrated to the shared dispatch table (#5618; runDispatch).
+// The auto-switch rides the required switchToRestoredSession adapter hook (the
+// dashboard's impl is the plain switchSession, no options).
 
 /**
  * Server emits pairing_refreshed whenever the pairing ID changes: after a
@@ -1413,12 +1404,9 @@ function handlePairingRefreshed(_msg: Record<string, unknown>, _get: MsgGet, set
 // web_feature_status + web_task_list migrated to the shared dispatch table
 // (#5556 slice 2)
 
-function handleConversationsList(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  // Parser shared via store-core (#5454); the dashboard intentionally has no
-  // `conversationHistoryError` / conversation-store mirror (those are app-only).
-  const { conversations } = sharedConversationsList(msg);
-  set({ conversationHistory: conversations, conversationHistoryLoading: false });
-}
+// conversations_list — migrated to the shared dispatch table (#5618; runDispatch).
+// The dashboard has no conversationHistoryError / conversation-store mirror, so it
+// omits the optional applyConversationsListExtras hook.
 
 // #5618 — model_changed migrated to the shared store-core dispatch table
 // (runDispatch handles it before the HANDLERS map / switch). Removed from here.
@@ -3133,10 +3121,10 @@ const HANDLERS: Record<string, Handler> = {
   terminal_size: handleTerminalSize,
   token_rotated: handleTokenRotated,
   pairing_refreshed: handlePairingRefreshed,
-  checkpoint_restored: handleCheckpointRestored,
+  // checkpoint_restored — migrated to the shared dispatch table (#5618; runDispatch).
   // web_feature_status / web_task_list migrated to the shared dispatch table
   // (#5556 slice 2)
-  conversations_list: handleConversationsList,
+  // conversations_list — migrated to the shared dispatch table (#5618; runDispatch).
   thinking_level_changed: handleThinkingLevelChanged,
   prompt_evaluator_changed: handlePromptEvaluatorChanged,
   chroxy_context_hint_changed: handleChroxyContextHintChanged,

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -201,6 +201,13 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     getMyClientId: () => myClientId,
     getFollowMode: () => followMode,
     switchSession: (sessionId) => switchedSessions.push(sessionId),
+    // #5618 — checkpoint_restored auto-switches via switchToRestoredSession. The
+    // contract asserts the flat activeSessionId flip (both real stores' switchSession
+    // re-homes activeSessionId), so model it as writing activeSessionId.
+    switchToRestoredSession: (sessionId) => {
+      ;(flat as Record<string, unknown>).activeSessionId = sessionId
+      switchedSessions.push(sessionId)
+    },
     // #5653 — only the APP opts its imperative-callback registry into the table.
     // Model it as "a callback IS registered for every channel" so the contract
     // can observe the invocation + payload. The DASHBOARD omits `getCallback`

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -214,10 +214,11 @@ describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
     // migrating types OUT to the shared dispatch table (universe shrinks below
     // the floor) lowers it — adjust both bounds in the same PR. Keep the band
     // TIGHT around the real count so the "fail loudly" intent stays sharp. Band
-    // last set for #5618 Batch 5b (available_models / cost_update / auth_bootstrap
-    // / tunnel_url_changed migrated out across Batch 5; universe down to ~48).
-    expect(both.length).toBeGreaterThanOrEqual(42)
-    expect(both.length).toBeLessThanOrEqual(54)
+    // last lowered for #5618 (agent_idle / permission_mode_changed / budget_warning /
+    // plan_ready / rate_limited / server_shutdown / conversations_list /
+    // checkpoint_restored migrated out; universe down to 41).
+    expect(both.length).toBeGreaterThanOrEqual(39)
+    expect(both.length).toBeLessThanOrEqual(50)
   })
 
   it('every both-clients switch type has a fixture, a PENDING entry, or a by-design exemption', () => {

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1381,6 +1381,57 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
       },
     },
   },
+  {
+    // #5618 — checkpoint_restored migrated SWITCH→DISPATCH. Both clients auto-switch
+    // to the new checkpoint session via the required switchToRestoredSession hook;
+    // the converged flat effect is activeSessionId = newSessionId (the DISPATCH test
+    // adapter models the switch as writing activeSessionId, like the real stores).
+    name: 'checkpoint_restored re-homes the active session to the new checkpoint session (both clients)',
+    type: 'checkpoint_restored',
+    init: { activeSessionId: 'old-sid', sessions: { 'old-sid': {} } },
+    message: { type: 'checkpoint_restored', checkpointId: 'cp-1', newSessionId: 'cp-new-sid', name: 'Rewind: cp-1' },
+    expect: { flat: { activeSessionId: 'cp-new-sid' } },
+  },
+  {
+    // #5618 — conversations_list migrated SWITCH→DISPATCH. Both clients write the flat
+    // conversationHistory from the parsed array (the app's error-clear + secondary-store
+    // mirror ride the optional applyConversationsListExtras hook, not asserted here).
+    name: 'conversations_list replaces the flat conversationHistory list (both clients)',
+    type: 'conversations_list',
+    message: {
+      type: 'conversations_list',
+      conversations: [
+        {
+          conversationId: 'conv-1',
+          project: '/proj',
+          projectName: 'proj',
+          modifiedAt: '2026-06-24T00:00:00Z',
+          modifiedAtMs: 1750000000000,
+          sizeBytes: 1024,
+          preview: 'first turn',
+          cwd: '/proj',
+        },
+        {
+          conversationId: 'conv-2',
+          project: null,
+          projectName: 'other',
+          modifiedAt: '2026-06-23T00:00:00Z',
+          modifiedAtMs: 1749900000000,
+          sizeBytes: 2048,
+          preview: null,
+          cwd: null,
+        },
+      ],
+    },
+    expect: {
+      flat: {
+        conversationHistory: [
+          { conversationId: 'conv-1', projectName: 'proj', preview: 'first turn' },
+          { conversationId: 'conv-2', projectName: 'other', preview: null },
+        ],
+      },
+    },
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -2085,19 +2136,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
-    // #6325 (bucket-B): server re-homed this client onto a NEW session at the
-    // checkpoint. Both clients parse via shared handleCheckpointRestored then call
-    // get().switchSession(newSessionId); the converged both-clients flat effect is
-    // activeSessionId = newSessionId (the harness stubs switchSession to write it).
-    // Seeds activeSessionId 'old-sid' (≠ new) so the flip is non-vacuous and
-    // switchSession doesn't early-return.
-    name: 'checkpoint_restored re-homes the active session to the new checkpoint session (both clients)',
-    type: 'checkpoint_restored',
-    init: { activeSessionId: 'old-sid', sessions: { 'old-sid': {} } },
-    message: { type: 'checkpoint_restored', checkpointId: 'cp-1', newSessionId: 'cp-new-sid', name: 'Rewind: cp-1' },
-    expect: { flat: { activeSessionId: 'cp-new-sid' } },
-  },
-  {
     // #6325 (bucket-B): another client disconnected. With ONE seeded (active)
     // session the app's active-only append and the dashboard's all-sessions append
     // converge → a plain expect (mirrors client_joined). The bubble label is
@@ -2119,47 +2157,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
             { type: 'system', content: 'A device disconnected' },
           ],
         },
-      },
-    },
-  },
-  {
-    // #6325 (bucket-B): both clients write the flat `conversationHistory` from the
-    // parsed `conversations` array (shared handleConversationsList). The app also
-    // mirrors to the mocked useConversationStore; the shared, non-mocked flat field
-    // both set identically is conversationHistory. Unseeded default → non-vacuous.
-    name: 'conversations_list replaces the flat conversationHistory list (both clients)',
-    type: 'conversations_list',
-    message: {
-      type: 'conversations_list',
-      conversations: [
-        {
-          conversationId: 'conv-1',
-          project: '/proj',
-          projectName: 'proj',
-          modifiedAt: '2026-06-24T00:00:00Z',
-          modifiedAtMs: 1750000000000,
-          sizeBytes: 1024,
-          preview: 'first turn',
-          cwd: '/proj',
-        },
-        {
-          conversationId: 'conv-2',
-          project: null,
-          projectName: 'other',
-          modifiedAt: '2026-06-23T00:00:00Z',
-          modifiedAtMs: 1749900000000,
-          sizeBytes: 2048,
-          preview: null,
-          cwd: null,
-        },
-      ],
-    },
-    expect: {
-      flat: {
-        conversationHistory: [
-          { conversationId: 'conv-1', projectName: 'proj', preview: 'first turn' },
-          { conversationId: 'conv-2', projectName: 'other', preview: null },
-        ],
       },
     },
   },

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -150,6 +150,7 @@ function makeAdapter(init?: {
     getCheckpoints: () => (flat.checkpoints as Checkpoint[] | undefined) ?? [],
     pushSessionNotification: (sessionId, eventType, message) =>
       notifications.push({ sessionId, eventType, message }),
+    switchToRestoredSession: (sessionId: string) => switchedSessions.push(sessionId),
     ...(init?.callbacks
       ? {
           getCallback: ((name: string) =>

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -136,6 +136,8 @@ import {
   applyInterventionBuilder,
   // --- checkpoint cases (#5618 Batch 6) ---
   handleCheckpointCreated,
+  handleCheckpointRestored,
+  handleConversationsList,
   handleCheckpointList,
   resolveSessionId,
   type PermissionMode,
@@ -358,6 +360,21 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    * mobile notification store (`setShutdown`); the DASHBOARD omits this hook.
    */
   applyShutdownNotification?(payload: { shutdownReason: 'restart' | 'shutdown' | 'crash'; restartEtaMs: number; restartingSince: number }): void
+  /**
+   * Auto-switch to the session a checkpoint restore created (#5618). BOTH clients
+   * switch, so this is required (not optional) — the only divergence is the options:
+   * the APP passes `{ serverNotify: false, haptic: false }` (the server already
+   * re-homed this client, and an auto-switch shouldn't buzz), the DASHBOARD passes
+   * none. Each client backs it with its store's `switchSession`.
+   */
+  switchToRestoredSession(sessionId: string): void
+  /**
+   * Apply the APP's `conversations_list` extras (#5618): clear the app-only
+   * `conversationHistoryError` flag and mirror the list into its secondary
+   * `useConversationStore`. The DASHBOARD has neither and OMITS this hook (the
+   * shared `conversationHistory` / `conversationHistoryLoading` write is enough).
+   */
+  applyConversationsListExtras?(conversations: unknown[]): void
   /**
    * Mirror checkpoint changes into a SECONDARY client store (#5618 Batch 6).
    * The mobile app keeps a separate `useConversationStore` whose checkpoint list
@@ -588,6 +605,14 @@ export interface DispatchMessageMap {
     type: 'server_shutdown'
     reason?: string
     restartEtaMs?: number
+  }
+  conversations_list: {
+    type: 'conversations_list'
+    conversations?: unknown[]
+  }
+  checkpoint_restored: {
+    type: 'checkpoint_restored'
+    newSessionId?: string
   }
   budget_resumed: {
     type: 'budget_resumed'
@@ -1084,6 +1109,37 @@ function dispatchServerShutdown<S extends DispatchSessionBase>(
   const payload = handleServerShutdown(msg as Record<string, unknown>)
   adapter.setState(payload as unknown as Record<string, unknown>)
   adapter.applyShutdownNotification?.(payload)
+}
+
+/**
+ * `conversations_list` (#5618) — replace the flat conversation-history list. Both
+ * clients write `conversationHistory` + `conversationHistoryLoading: false`
+ * identically; the APP's extra error-clear + secondary-store mirror ride the
+ * optional {@link ClientStoreAdapter.applyConversationsListExtras} hook.
+ */
+function dispatchConversationsList<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['conversations_list'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { conversations } = handleConversationsList(msg as Record<string, unknown>)
+  adapter.setState({ conversationHistory: conversations, conversationHistoryLoading: false })
+  adapter.applyConversationsListExtras?.(conversations)
+}
+
+/**
+ * `checkpoint_restored` (#5618) — the server created a new session at the restored
+ * checkpoint and re-homed this client onto it; auto-switch to it. Both clients
+ * switch via the required {@link ClientStoreAdapter.switchToRestoredSession} hook
+ * (the app passes its no-notify/no-haptic options, the dashboard plain).
+ */
+function dispatchCheckpointRestored<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['checkpoint_restored'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const restored = handleCheckpointRestored(msg as Record<string, unknown>)
+  if (restored) {
+    adapter.switchToRestoredSession(restored.newSessionId)
+  }
 }
 
 /**
@@ -1886,6 +1942,8 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     plan_ready: dispatchPlanReady,
     rate_limited: dispatchRateLimited,
     server_shutdown: dispatchServerShutdown,
+    conversations_list: dispatchConversationsList,
+    checkpoint_restored: dispatchCheckpointRestored,
     budget_resumed: dispatchBudgetResumed,
     budget_resume_ack: dispatchBudgetResumeAck,
     conversation_id: dispatchConversationId,
@@ -1979,6 +2037,8 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'plan_ready',
   'rate_limited',
   'server_shutdown',
+  'conversations_list',
+  'checkpoint_restored',
   'budget_resumed',
   'budget_resume_ack',
   'conversation_id',


### PR DESCRIPTION
Part of #5618 — second family-batched slice. Two types onto the shared dispatch table, both **zero behaviour change**, verified by zero test breakage across both full store suites.

| type | shared body | per-client difference → how preserved |
|---|---|---|
| `conversations_list` | both write `conversationHistory` + `conversationHistoryLoading: false` (shared `handleConversationsList`) | app's extra `conversationHistoryError` clear + `useConversationStore` mirror → new optional `applyConversationsListExtras` hook (dashboard omits — has neither) |
| `checkpoint_restored` | both auto-switch to the server-created session | the switch **options** — app passes `{ serverNotify: false, haptic: false }` (server already re-homed this client; an auto-switch shouldn't re-notify or buzz), dashboard passes none → new **required** `switchToRestoredSession` hook |

`switchToRestoredSession` is **required** (not optional) on purpose: both clients always switch, so making it required means a future client can't silently drop the auto-switch. Both test adapters implement it — the DISPATCH adapter models it as writing flat `activeSessionId` (matching the real stores' `switchSession`), so the moved fixture's `flat.activeSessionId` assertion stays non-vacuous.

Two fixtures move **SWITCH→DISPATCH**; the both-clients-switch coverage band drops 42–54 → 39–50 (universe now 41 after this slice).

## Verification
store-core typecheck + full (1853) · protocol handler-coverage (340) · app contract-switch + **full app store (731)** · dashboard **full store (909)** · all tsc clean.

This brings #5618 to **8 of 42** remaining candidates migrated (after agent_idle, permission_mode_changed, and the 4-type notification batch). Part of #5618