### PR TITLE
refactor: migrate search_results onto the shared dispatch table (#5618)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -97,7 +97,6 @@ import {
   // web_task_created / web_task_updated — migrated to the shared dispatch table
   // (#5556 slice 4); the app no longer imports the upsert helper directly.
   handleWebTaskError as sharedWebTaskError,
-  handleSearchResults as sharedSearchResults,
   applyOrphanDeltas,
   isActivityEvent,
   // #5163 (epic #5159) — Control Room cross-session activity reducer:
@@ -160,6 +159,7 @@ import type {
   SlashCommand,
   ProviderInfo,
   ConversationSummary,
+  SearchResult,
   PermissionRule,
 } from './types';
 import { createEmptySessionState } from './utils';
@@ -1235,6 +1235,16 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   applyConversationsListExtras: (conversations) => {
     getStore().setState({ conversationHistoryError: null });
     useConversationStore.getState().setConversationHistory(conversations as ConversationSummary[]);
+  },
+  // #5618 — search_results staleness gate reads the live flat searchQuery.
+  getSearchQuery: () => getStore().getState().searchQuery,
+  // #5618 — search_results clears the app-only searchError flag and mirrors the
+  // results (with the live query) into the secondary conversation store (dashboard omits).
+  applySearchResultsExtras: (results) => {
+    getStore().setState({ searchError: null });
+    useConversationStore
+      .getState()
+      .setSearchResults(results as SearchResult[], getStore().getState().searchQuery);
   },
   // #5653 — file-ops / git wrapper cases route through the shared dispatch
   // table; the app supplies its module-level imperative-callback registry so
@@ -3333,15 +3343,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // The app's error-clear + useConversationStore mirror ride the optional
     // applyConversationsListExtras adapter hook.
 
-    case 'search_results': {
-      const currentQuery = (get() as ConnectionState).searchQuery;
-      const { results, shouldApply } = sharedSearchResults(msg, currentQuery);
-      if (!shouldApply) break; // Stale response for an older query — ignore
-      // results is already typed as SearchResult[] from store-core (#3146).
-      set({ searchResults: results, searchLoading: false, searchError: null });
-      useConversationStore.getState().setSearchResults(results, currentQuery);
-      break;
-    }
+    // search_results — migrated to the shared dispatch table (#5618; runDispatch).
+    // The staleness gate reads searchQuery via getSearchQuery; the app's searchError
+    // clear + useConversationStore mirror ride the optional applySearchResultsExtras hook.
 
     // notification_prefs — migrated to the shared dispatch table (#5556 slice
     // 2). The app previously hand-maintained a byte-identical inline Zod parse

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -94,7 +94,6 @@ import {
   handleWebTaskError as sharedWebTaskError,
   // web_task_list / web_feature_status migrated to the shared dispatch table
   // (#5556 slice 2)
-  handleSearchResults as sharedSearchResults,
   applyOrphanDeltas,
   isActivityEvent,
   // #5163 (epic #5159): Control Room activity reducer — snapshot replace +
@@ -1054,6 +1053,8 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
   // #5618 — checkpoint_restored auto-switches (plain, no options — the dashboard has
   // no serverNotify/haptic concepts; the app passes those via its own impl).
   switchToRestoredSession: (sessionId) => getStore().getState().switchSession(sessionId),
+  // #5618 — search_results staleness gate reads the live flat searchQuery.
+  getSearchQuery: () => getStore().getState().searchQuery,
   // #5618 — user_question raises a background-session notification via the
   // dashboard's own helper (dedup by (sessionId, eventType); no push store).
   pushSessionNotification: (sessionId, eventType, message) =>
@@ -4794,13 +4795,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
-    case 'search_results': {
-      const currentQuery = (get() as ConnectionState).searchQuery;
-      const { results, shouldApply } = sharedSearchResults(msg, currentQuery);
-      if (!shouldApply) break; // Stale response for an older query — ignore
-      set({ searchResults: results, searchLoading: false });
-      break;
-    }
+    // search_results — migrated to the shared dispatch table (#5618; runDispatch).
+    // The staleness gate reads searchQuery via getSearchQuery; the dashboard has no
+    // searchError / conversation-store mirror, so it omits applySearchResultsExtras.
 
     case 'log_entry': {
       const { entry } = sharedLogEntry(msg);

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -174,6 +174,8 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     // Both clients back it with their flat `checkpoints`; modelled as a read of
     // the live `flat` ref so the checkpoint fixtures observe identical results.
     getCheckpoints: () => (flat.checkpoints as Checkpoint[] | undefined) ?? [],
+    // #5618 — search_results staleness gate reads the live flat searchQuery.
+    getSearchQuery: () => ((flat as Record<string, unknown>).searchQuery as string | null | undefined) ?? null,
     // #5618 — `pushSessionNotification` is a UI side-effect OUTSIDE the shared
     // store-state contract (the app additionally mirrors into its mobile push
     // store; the dashboard does not). Modelled as a no-op here, exactly like the

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1432,6 +1432,42 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
       },
     },
   },
+  {
+    // #5618 — search_results migrated SWITCH→DISPATCH. Both clients write the flat
+    // searchResults + searchLoading:false (the staleness gate reads searchQuery via
+    // getSearchQuery — unseeded here → apply). The app's searchError clear + secondary
+    // store mirror ride the optional applySearchResultsExtras hook (not asserted).
+    name: 'search_results replaces the flat searchResults list (both clients)',
+    type: 'search_results',
+    message: {
+      type: 'search_results',
+      query: 'auth',
+      results: [
+        {
+          conversationId: 'conv-1',
+          projectName: 'chroxy',
+          project: 'chroxy',
+          cwd: '/Users/me/chroxy',
+          preview: 'auth handler',
+          snippet: 'ws-auth.js validates the bearer token',
+          matchCount: 3,
+        },
+      ],
+    },
+    expect: {
+      flat: {
+        searchResults: [
+          {
+            conversationId: 'conv-1',
+            projectName: 'chroxy',
+            preview: 'auth handler',
+            matchCount: 3,
+          },
+        ],
+        searchLoading: false,
+      },
+    },
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -2157,42 +2193,6 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
             { type: 'system', content: 'A device disconnected' },
           ],
         },
-      },
-    },
-  },
-  {
-    // #6325 (bucket-B): both clients call sharedSearchResults then set({
-    // searchResults, searchLoading:false }). searchQuery is left unseeded so the
-    // staleness gate short-circuits → apply. Unseeded searchResults/searchLoading
-    // → non-vacuous. searchError is app-only (not asserted).
-    name: 'search_results replaces the flat searchResults list (both clients)',
-    type: 'search_results',
-    message: {
-      type: 'search_results',
-      query: 'auth',
-      results: [
-        {
-          conversationId: 'conv-1',
-          projectName: 'chroxy',
-          project: 'chroxy',
-          cwd: '/Users/me/chroxy',
-          preview: 'auth handler',
-          snippet: 'ws-auth.js validates the bearer token',
-          matchCount: 3,
-        },
-      ],
-    },
-    expect: {
-      flat: {
-        searchResults: [
-          {
-            conversationId: 'conv-1',
-            projectName: 'chroxy',
-            preview: 'auth handler',
-            matchCount: 3,
-          },
-        ],
-        searchLoading: false,
       },
     },
   },

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -148,6 +148,7 @@ function makeAdapter(init?: {
     alert: () => {},
     getSessions: () => sessionList,
     getCheckpoints: () => (flat.checkpoints as Checkpoint[] | undefined) ?? [],
+    getSearchQuery: () => (flat.searchQuery as string | null | undefined) ?? null,
     pushSessionNotification: (sessionId, eventType, message) =>
       notifications.push({ sessionId, eventType, message }),
     switchToRestoredSession: (sessionId: string) => switchedSessions.push(sessionId),

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -138,6 +138,7 @@ import {
   handleCheckpointCreated,
   handleCheckpointRestored,
   handleConversationsList,
+  handleSearchResults,
   handleCheckpointList,
   resolveSessionId,
   type PermissionMode,
@@ -376,6 +377,19 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
    */
   applyConversationsListExtras?(conversations: unknown[]): void
   /**
+   * Read the current flat `searchQuery` (#5618). `search_results` needs it for the
+   * staleness gate — a late response for an older query is dropped. Both clients
+   * back it with their flat connection state's `searchQuery`.
+   */
+  getSearchQuery(): string | null
+  /**
+   * Apply the APP's `search_results` extras (#5618): clear the app-only `searchError`
+   * flag and mirror the results into its secondary `useConversationStore`. The
+   * DASHBOARD has neither and OMITS this hook (the shared `searchResults` /
+   * `searchLoading` write is enough).
+   */
+  applySearchResultsExtras?(results: unknown[]): void
+  /**
    * Mirror checkpoint changes into a SECONDARY client store (#5618 Batch 6).
    * The mobile app keeps a separate `useConversationStore` whose checkpoint list
    * powers its timeline UI; after the `checkpoint_created` / `checkpoint_list`
@@ -613,6 +627,11 @@ export interface DispatchMessageMap {
   checkpoint_restored: {
     type: 'checkpoint_restored'
     newSessionId?: string
+  }
+  search_results: {
+    type: 'search_results'
+    query?: string
+    results?: unknown[]
   }
   budget_resumed: {
     type: 'budget_resumed'
@@ -1140,6 +1159,23 @@ function dispatchCheckpointRestored<S extends DispatchSessionBase>(
   if (restored) {
     adapter.switchToRestoredSession(restored.newSessionId)
   }
+}
+
+/**
+ * `search_results` (#5618) — apply conversation-search results, dropping a stale
+ * response for an older query (the staleness gate reads the live `searchQuery` via
+ * the adapter). Both clients write the flat `searchResults` + `searchLoading: false`
+ * identically; the APP's extra `searchError` clear + secondary-store mirror ride the
+ * optional {@link ClientStoreAdapter.applySearchResultsExtras} hook.
+ */
+function dispatchSearchResults<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['search_results'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const { results, shouldApply } = handleSearchResults(msg as Record<string, unknown>, adapter.getSearchQuery())
+  if (!shouldApply) return
+  adapter.setState({ searchResults: results, searchLoading: false })
+  adapter.applySearchResultsExtras?.(results)
 }
 
 /**
@@ -1944,6 +1980,7 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     server_shutdown: dispatchServerShutdown,
     conversations_list: dispatchConversationsList,
     checkpoint_restored: dispatchCheckpointRestored,
+    search_results: dispatchSearchResults,
     budget_resumed: dispatchBudgetResumed,
     budget_resume_ack: dispatchBudgetResumeAck,
     conversation_id: dispatchConversationId,
@@ -2039,6 +2076,7 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   'server_shutdown',
   'conversations_list',
   'checkpoint_restored',
+  'search_results',
   'budget_resumed',
   'budget_resume_ack',
   'conversation_id',


### PR DESCRIPTION
Part of #5618. `search_results` onto the shared dispatch table — **zero behaviour change**, verified by zero test breakage across both full store suites.

Both clients write the flat `searchResults` + `searchLoading: false` identically (shared `handleSearchResults`), under the same staleness check (a late response for an older query is dropped). Two new adapter members carry the divergences:

| member | kind | purpose |
|---|---|---|
| `getSearchQuery()` | **required** | the staleness gate needs the live flat `searchQuery`; both clients read their own |
| `applySearchResultsExtras(results)` | optional | app clears its app-only `searchError` flag + mirrors results (with the live query) into its secondary `useConversationStore`; dashboard omits |

The fixture moves SWITCH→DISPATCH; both test adapters gain `getSearchQuery` (reads the flat `searchQuery` ref so the staleness gate behaves). The both-clients-switch universe drops to **40** (still inside the 39–50 band, no band change).

## Verification
store-core typecheck + full (1854) · protocol handler-coverage (340) · app contract-switch + **full app store (730)** · dashboard **full store (908)** · all tsc clean.

This is **9 of 42** remaining candidates migrated. Note: I'm finding the remaining tier is mostly thick-divergence (e.g. `permission_resolved`/`permission_timeout` weave a dashboard flat-message fallback into the all-sessions scan + diverge on #5008 mark-read-vs-remove + an app-only `ServerError` banner) — `search_results` was the cleanest remaining. Part of #5618