### PR TITLE
docs(store-core): record the #5618 leave-local determination in coverage-lint

### DIFF
--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -63,6 +63,33 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 // both-clients case — add a real contract fixture instead. New entries are
 // only legitimate when retro-fitting a pre-existing case, with a note.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// #5618 dispatch-table migration — PHASE COMPLETE (closed 2026-06-25).
+//
+// The cleanly-beneficial migrations are done (~67 types now route through the
+// shared store-core dispatch table). The both-clients-switch types that REMAIN in
+// the universe below are INTENTIONALLY switch-local — do NOT re-attempt migrating
+// them onto the dispatch table without re-deciding (the triage map's "zero-change-
+// via-hooks" rating is misleading for them). Their `handleX` PARSER already lives in
+// store-core and both clients call it; what's left in each switch is genuinely
+// per-client ORCHESTRATION, not incidental duplication — so migrating it would wrap
+// that orchestration behind 2–4 new adapter hooks each, adding ~as much surface as
+// the dedup removes, with real regression risk. Representative cases:
+//   - permission_resolved / permission_timeout / permission_expired — thin shared
+//     prompt-mark updater; thick divergence (all-sessions scan, dashboard flat-message
+//     fallback, app `remove` vs dashboard #5008 `mark-read` notifications, app-only
+//     ServerError banner).
+//   - budget_exceeded — whole behaviour diverges by design (#5619): app manual Resume
+//     button vs dashboard auto-resume + modified message + toast.
+//   - server_status / server_mode / session_warning — thin shared core, thick divergence.
+//   - message / server_error / web_task_error / tool_* / stream_* / session_switched /
+//     session_timeout / client_joined / client_left / pair_fail, plus the hard four
+//     (error / session_list / auth_ok / key_exchange_ok).
+// These keep their SWITCH_FIXTURES (still behaviour-verified through each client's real
+// handler), so they are NOT NO_SWITCH_CONTRACT_BY_DESIGN exemptions. See the #5618
+// close comment for the full rationale.
+// ---------------------------------------------------------------------------
 const PENDING_CONTRACT_TYPES = new Set<string>([
   // EMPTY — the both-clients SWITCH_FIXTURES backlog is fully drained. Every
   // both-clients switch type now has a behaviour-verified fixture (incl. the last


### PR DESCRIPTION
Comment-only. Records the [#5618](https://github.com/blamechris/chroxy/issues/5618) close decision in code so a future pass doesn't re-attempt net-negative migrations.

The dispatch-table migration is complete (~67 types now route through the shared `runDispatch` table). The both-clients-switch types that remain in the coverage universe are **intentionally switch-local** — their `handleX` parsers are already shared in store-core; what's left in each switch is genuinely per-client *orchestration*, not incidental duplication (e.g. `permission_*`'s #5008 mark-read vs remove, `budget_exceeded`'s #5619 manual-vs-auto resume). Migrating them would add ~as much adapter surface as it removes, with regression risk.

A prominent comment block above `PENDING_CONTRACT_TYPES` now spells this out, with representative cases and a pointer to the #5618 close comment. These types keep their `SWITCH_FIXTURES` (still behaviour-verified), so they are **not** `NO_SWITCH_CONTRACT_BY_DESIGN` exemptions.

No behaviour, assertion, or universe change — coverage-lint stays green (5/5).