### PR TITLE
feat(app): manual 'refresh terminal' resync button (#6329)

### DIFF
--- a/packages/app/src/__tests__/components/TerminalView.test.tsx
+++ b/packages/app/src/__tests__/components/TerminalView.test.tsx
@@ -468,3 +468,33 @@ describe('TerminalView originWhitelist passes RN whitelist for both inline-load 
     expect(passesWhitelist(compiled, '')).toBe(false);
   });
 });
+
+/**
+ * #6329 — manual "refresh terminal" resync button. The button is presentation-only;
+ * SessionScreen passes `onRefresh` (= requestTerminalResync(activeSessionId)) only
+ * when the active session is a resync-eligible PTY mirror and not an observer. These
+ * pin the wiring: the button renders + fires onRefresh when the prop is supplied, and
+ * is absent (the gated-off case) when it isn't.
+ */
+describe('TerminalView — #6329 manual resync button', () => {
+  it('renders the ⟳ button and calls onRefresh on press when onRefresh is provided', () => {
+    const onRefresh = jest.fn();
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<TerminalView onRefresh={onRefresh} />);
+    });
+    const button = renderer.root.findByProps({ testID: 'terminal-resync-button' });
+    act(() => {
+      button.props.onPress();
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the resync button when onRefresh is omitted (gated-off case)', () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<TerminalView />);
+    });
+    expect(renderer.root.findAllByProps({ testID: 'terminal-resync-button' })).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState, useEffect } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import type { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes';
 import { buildXtermHtml } from './xterm-html';
@@ -65,11 +65,17 @@ export interface TerminalViewProps {
   // claude-tui mirror) so existing behavior is unchanged.
   interactive?: boolean;
   onInput?: (data: string) => void;
+  // #6329 — when provided, render a manual "refresh terminal" control that forces a
+  // resync repaint (the auto-resync on (re)subscribe is already wired in
+  // SessionScreen). Omitted (no button) when there's no resync-eligible session —
+  // e.g. a claude-tui mirror or an observer — so the affordance only appears where it
+  // works. The server still enforces resync authority, so this is a UX gate.
+  onRefresh?: () => void;
 }
 
 // -- Component --
 
-export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(function TerminalView({ onResize, onReady, interactive, onInput }, ref) {
+export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(function TerminalView({ onResize, onReady, interactive, onInput, onRefresh }, ref) {
   const webViewRef = useRef<WebView>(null);
   const readyRef = useRef(false);
   const pendingWritesRef = useRef<string[]>([]);
@@ -195,6 +201,20 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
           <Text style={styles.recoveryText}>Terminal recovering...</Text>
         </View>
       )}
+      {/* #6329 — manual resync: force a fresh repaint if the live mirror looks
+          out of sync (the auto-resync on resubscribe is the primary recovery). */}
+      {onRefresh && (
+        <TouchableOpacity
+          style={styles.refreshButton}
+          onPress={onRefresh}
+          testID="terminal-resync-button"
+          accessibilityRole="button"
+          accessibilityLabel="Refresh terminal"
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Text style={styles.refreshGlyph}>⟳</Text>
+        </TouchableOpacity>
+      )}
       <WebView
         ref={webViewRef}
         source={{ html }}
@@ -256,6 +276,25 @@ const styles = StyleSheet.create({
   recoveryText: {
     color: COLORS.accentOrange,
     fontSize: 13,
+    fontWeight: '600',
+  },
+  // #6329 — small top-right corner control, mirrors the dashboard's ⟳ resync button.
+  refreshButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    zIndex: 2,
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(26, 26, 46, 0.85)',
+  },
+  refreshGlyph: {
+    color: COLORS.textDim,
+    fontSize: 16,
+    lineHeight: 18,
     fontWeight: '600',
   },
 });

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -535,6 +535,15 @@ export function SessionScreen() {
   // Reuses the reactive `activeSessionProvider` selector declared above.
   const isUserShell = activeSessionProvider === USER_SHELL_PROVIDER;
   const isPtyMirror = isUserShell;
+  // #6329 — manual terminal resync affordance. The store action + the auto-resync
+  // on (re)subscribe ship in #6313; this wires the explicit "looks out of sync"
+  // button. Only meaningful for the live PTY mirror (user-shell) on an active,
+  // non-observer session — the server still enforces resync authority.
+  const requestTerminalResync = useConnectionStore((s) => s.requestTerminalResync);
+  const canResyncTerminal = isPtyMirror && !!activeSessionId && sessionRole !== 'observer';
+  const handleTerminalRefresh = useCallback(() => {
+    if (activeSessionId) requestTerminalResync(activeSessionId);
+  }, [activeSessionId, requestTerminalResync]);
   // #6003 — a user-shell terminal is interactive (drivable) only when this client
   // may drive it: the server's userShell capability is gated on the primary token
   // (+ userShell.enabled), matching the terminal_input authority gate. claude-tui
@@ -1590,7 +1599,7 @@ export function SessionScreen() {
             <View style={styles.splitDivider} />
             <View style={styles.splitPane}>
               <ErrorBoundary fallbackTitle="Terminal error">
-                <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} interactive={terminalInteractive} onInput={handleTerminalInput} />
+                <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} interactive={terminalInteractive} onInput={handleTerminalInput} onRefresh={canResyncTerminal ? handleTerminalRefresh : undefined} />
               </ErrorBoundary>
             </View>
           </View>
@@ -1651,7 +1660,7 @@ export function SessionScreen() {
           // read-only mirror for claude-tui (terminal_output renders via the
           // write-callback path, onData stays disabled so no input is forwarded).
           <ErrorBoundary fallbackTitle="Terminal error">
-            <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} interactive={terminalInteractive} onInput={handleTerminalInput} />
+            <TerminalView ref={terminalRef} onReady={handleTerminalReady} onResize={handleTerminalResize} interactive={terminalInteractive} onInput={handleTerminalInput} onRefresh={canResyncTerminal ? handleTerminalRefresh : undefined} />
           </ErrorBoundary>
         )
       )}


### PR DESCRIPTION
Closes #6329. Wires the ready-but-dormant `requestTerminalResync` action (shipped + tested in #6313/#6330) to a manual affordance in the app's terminal view, mirroring the dashboard's ⟳ `terminal-resync-button`.

## What
- **`TerminalView`** gains an optional `onRefresh` prop → a small top-right ⟳ `TouchableOpacity` (`testID="terminal-resync-button"`), rendered **only when `onRefresh` is supplied** so the button appears solely where resync applies.
- **`SessionScreen`** passes `onRefresh = requestTerminalResync(activeSessionId)`, gated on `canResyncTerminal = isPtyMirror && activeSessionId && sessionRole !== 'observer'` — the live PTY-mirror (user-shell), active, non-observer case (matches the dashboard's `!activeIsObserver` gate). The server still enforces resync authority, so the gate is UX-only.

The auto-resync on (re)subscribe (from #6313) remains the **primary** recovery; this is the explicit "looks out of sync" button.

## Verification
- New `TerminalView` tests: the ⟳ button renders + fires `onRefresh` on press; absent when `onRefresh` is omitted (the gated-off case). The store action itself is covered by `terminal-mirror.test.ts` (#6313).
- `app tsc` clean; component + store suites green (288).
- **Honest note (self-verified per the maintainer's "test it yourself"):** the *wiring* is fully unit-tested + type-checked; the one un-automated bit is the button's on-screen **appearance/tap** in a live user-shell terminal — a tiny corner control directly mirroring the dashboard's proven pattern (low risk). Happy to add a Maestro flow as a follow-up if you'd like the visual pinned too.

Closes #6329