### PR TITLE
feat(app): provider capability-limitation note in the session-create modal (#6352, #6312)

### DIFF
--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -15,6 +15,8 @@ import { useConnectionStore } from '../store/connection';
 import { FolderBrowser } from './FolderBrowser';
 import { COLORS } from '../constants/colors';
 import { getProviderLabel } from '../constants/providers';
+import { buildProviderLimitationNote } from '@chroxy/store-core';
+import { DEFAULT_PROVIDER } from '@chroxy/protocol';
 
 const PROVIDERS_TIMEOUT_MS = 5000;
 
@@ -112,6 +114,17 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   ];
 
   const selectedProviderDetail = providerChips.find((p) => p.id === provider)?.detail ?? '';
+
+  // #6312 / #6352 — mobile parity with the dashboard's session-creation limitation
+  // note. When the selected provider reports a capability as `false` (notably the
+  // default claude-tui: no plan mode / streaming / model switch), surface a concise
+  // non-blocking note rather than leaving the user to infer the gap from an absent
+  // control. The empty `provider` chip means "server default", so resolve it to
+  // DEFAULT_PROVIDER for the capability lookup.
+  const selectedProviderCaps = availableProviders.find(
+    (p) => p.name === (provider || DEFAULT_PROVIDER),
+  )?.capabilities;
+  const providerLimitationNote = buildProviderLimitationNote(selectedProviderCaps);
 
   const handleCreate = () => {
     const sessionName = name.trim() || `Session ${sessions.length + 1}`;
@@ -269,6 +282,15 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
                 accessibilityLabel={`Billing: ${selectedProviderDetail}`}
               >
                 {selectedProviderDetail}
+              </Text>
+            ) : null}
+
+            {/* #6312 / #6352 — non-blocking capability-limitation note for a
+                reduced-capability provider (notably claude-tui). Additive copy
+                explaining the absent affordances; behaviour is unchanged. */}
+            {providerLimitationNote ? (
+              <Text style={styles.providerLimitationNote} testID="provider-limitation-note">
+                {providerLimitationNote}
               </Text>
             ) : null}
 
@@ -446,6 +468,13 @@ const styles = StyleSheet.create({
     marginTop: -8,
     marginBottom: 16,
     fontStyle: 'italic',
+  },
+  // #6312 / #6352 — capability-limitation note; subtle, sits under the provider row.
+  providerLimitationNote: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+    marginTop: -8,
+    marginBottom: 16,
   },
   providersEmptyRow: {
     flexDirection: 'row',

--- a/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
+++ b/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
@@ -275,3 +275,34 @@ describe('CreateSessionModal provider loading state', () => {
     expect(defaultChip).toBeTruthy();
   });
 });
+
+describe('CreateSessionModal — #6312/#6352 provider capability-limitation note', () => {
+  it('surfaces a limitation note for the default reduced-capability provider (claude-tui)', () => {
+    // The empty Default chip resolves to DEFAULT_PROVIDER (claude-tui); seed it with
+    // the degraded caps the server reports for claude-tui.
+    setupStore([
+      { name: 'claude-tui', capabilities: { planMode: false, streaming: false, modelSwitch: false }, auth: { ready: true } },
+    ]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    const note = component!.root.findByProps({ testID: 'provider-limitation-note' });
+    expect(JSON.stringify(note.props.children)).toContain("doesn't support");
+  });
+
+  it('shows no limitation note for a fully-capable provider', () => {
+    setupStore([
+      { name: 'claude-tui', capabilities: { planMode: true, streaming: true, modelSwitch: true }, auth: { ready: true } },
+    ]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    expect(component!.root.findAllByProps({ testID: 'provider-limitation-note' })).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #6352 · completes #6312. Mobile parity with the dashboard's session-creation limitation note.

When the selected provider reports a capability as `false` (notably the default **claude-tui**: no plan mode / streaming / model switch), the app's `CreateSessionModal` now surfaces the shared `buildProviderLimitationNote` text instead of leaving the user to infer the gap from an absent control.

## What
- Resolves the empty **Default** chip to `DEFAULT_PROVIDER` (claude-tui) for the capability lookup — so the note shows for the zero-config default, not only explicit provider picks.
- Reuses the store-core `buildProviderLimitationNote` helper (already tested, 6 cases) + the `streaming` field already on `ProviderCapabilities` — **additive copy, no behaviour change**, existing gating untouched.
- Mirrors the dashboard's `provider-limitation-note` testid + placement (under the provider row).

## Verification
- App tests: the note renders for a reduced-capability provider, and is absent for a fully-capable one (`CreateSessionModal.test.tsx`).
- `app tsc` clean; app component suite green (312).
- The dashboard half (render + `CreateSessionModalCapabilityNote.test.tsx`) already shipped in a prior PR; this is the mobile parity that was #6312's last open box.
- **Self-verified per your "test it yourself":** the wiring + the resolve-default-provider logic are unit-tested + type-checked. The one un-automated bit is the note's on-screen appearance in the live modal — a subtle line under the provider row mirroring the shipped dashboard pattern (low risk).

Closes #6352
Closes #6312