### PR TITLE
refactor(server): move DeepSeek pricing onto its provider class (#6201 OCP)

### DIFF
--- a/packages/server/src/deepseek-session.js
+++ b/packages/server/src/deepseek-session.js
@@ -23,13 +23,27 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from './byok-session.js'
 import { resolveDeepSeekApiKey } from './deepseek-credentials.js'
-import { getDeepSeekPricing } from './models.js'
 import { BILLING_CLASSES } from './billing-class.js'
 
 // Override point for self-hosted or pinned-version endpoints. Defaults
 // to DeepSeek's Anthropic-compatible endpoint, which they explicitly
 // publish so Claude Code clients can point at it without translation.
 const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/anthropic'
+
+// DeepSeek pricing in USD per million tokens (#6201 OCP — owned by this provider
+// class rather than bolted into models.js's central tables; relocated verbatim from
+// models.js getDeepSeekPricing). DeepSeek reports usage in the Anthropic shape and
+// maps its cache-hit metric onto `cache_read_input_tokens`; it never reports cache
+// writes, so the zero `cacheWrite` rate is correct, not a placeholder. Verbatim-only
+// lookup — DeepSeek doesn't ship date-suffixed model ids the way Anthropic does, so
+// the strip-and-retry dance from models.js's resolvePricingKey isn't warranted here
+// (if they ever do, extend along the same shape).
+const DEEPSEEK_PRICING_USD_PER_MTOK = Object.freeze({
+  // V3 chat — general-purpose model.
+  'deepseek-chat':     Object.freeze({ input: 0.27, output: 1.10, cacheRead: 0.07, cacheWrite: 0 }),
+  // R1 reasoning — emits a reasoning trace before the final answer.
+  'deepseek-reasoner': Object.freeze({ input: 0.55, output: 2.19, cacheRead: 0.14, cacheWrite: 0 }),
+})
 
 // DeepSeek's published context window for both `deepseek-chat` (V3) and
 // `deepseek-reasoner` (R1). If they ever ship a larger-context variant,
@@ -166,6 +180,7 @@ export class DeepSeekSession extends ClaudeByokSession {
   }
 
   _getPricing(model) {
-    return getDeepSeekPricing(model)
+    if (typeof model !== 'string' || model.length === 0) return null
+    return DEEPSEEK_PRICING_USD_PER_MTOK[model] || null
   }
 }

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -298,39 +298,8 @@ function resolveModelPricing(modelId, overlay) {
   return (key && CLAUDE_PRICING_USD_PER_MTOK[key]) || null
 }
 
-// Public DeepSeek pricing in USD per million tokens (#4656). Source:
-// https://api-docs.deepseek.com/quick_start/pricing — keep in sync.
-// DeepSeek bills cache hits separately from cache misses but does NOT
-// charge a separate cache-write fee, so `cacheWrite` is 0; the field is
-// kept so the same `computePromptCostUsd` helper consumes both tables
-// without a shape branch.
-//
-// DeepSeek hits chroxy through their Anthropic-compatible endpoint
-// (https://api.deepseek.com/anthropic), so usage objects arrive in the
-// Anthropic shape (`input_tokens` / `output_tokens` /
-// `cache_read_input_tokens` / `cache_creation_input_tokens`). DeepSeek's
-// own docs note that they map their internal cache-hit metric onto the
-// Anthropic `cache_read_input_tokens` slot, and they never report cache
-// writes — so the zero rate is correct, not a placeholder.
-const DEEPSEEK_PRICING_USD_PER_MTOK = Object.freeze({
-  // V3 chat — general-purpose model.
-  'deepseek-chat':     Object.freeze({ input: 0.27, output: 1.10, cacheRead: 0.07, cacheWrite: 0 }),
-  // R1 reasoning — emits a reasoning trace before the final answer.
-  'deepseek-reasoner': Object.freeze({ input: 0.55, output: 2.19, cacheRead: 0.14, cacheWrite: 0 }),
-})
-
-/**
- * Returns the DeepSeek pricing rates for a model (USD per million tokens),
- * or null if pricing is unknown (#4656).
- *
- * Verbatim-only lookup. DeepSeek doesn't ship date-suffixed model ids the
- * way Anthropic does, so the strip-and-retry dance from `resolvePricingKey`
- * isn't warranted here. If they ever do, extend along the same shape.
- */
-export function getDeepSeekPricing(modelId) {
-  if (typeof modelId !== 'string' || modelId.length === 0) return null
-  return DEEPSEEK_PRICING_USD_PER_MTOK[modelId] || null
-}
+// DeepSeek pricing now lives on its provider class (#6201 OCP) —
+// see DEEPSEEK_PRICING_USD_PER_MTOK + _getPricing in deepseek-session.js.
 
 /**
  * Compute USD cost for a single turn's usage object as returned by the

--- a/packages/server/tests/deepseek-session.test.js
+++ b/packages/server/tests/deepseek-session.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DeepSeekSession } from '../src/deepseek-session.js'
 import { ClaudeByokSession } from '../src/byok-session.js'
+import { computePromptCostUsd } from '../src/models.js'
 
 /**
  * Tests for DeepSeekSession (#4656).
@@ -265,5 +266,54 @@ describe('DeepSeekSession (#4656)', () => {
       assert.equal(events[0].kind, 'ready')
       assert.equal(session._apiKeySource, 'file')
     })
+  })
+})
+
+/**
+ * #6201 (OCP) — DeepSeek pricing was relocated verbatim from models.js's central
+ * tables onto this provider class (`_getPricing`). The pre-existing suite did not
+ * value-cover DeepSeek rates (only the `getFallbackModels`/metadata shape), so this
+ * characterization test pins the exact published rates + the end-to-end cost through
+ * the shared `computePromptCostUsd`, making the relocation provably pure. `_getPricing`
+ * is `this`-free, so it's exercised straight off the prototype.
+ */
+describe('DeepSeekSession pricing (#6201 OCP characterization)', () => {
+  const getPricing = (id) => DeepSeekSession.prototype._getPricing(id)
+
+  it('returns the exact published rates (USD per million tokens)', () => {
+    assert.deepEqual(getPricing('deepseek-chat'), {
+      input: 0.27,
+      output: 1.10,
+      cacheRead: 0.07,
+      cacheWrite: 0,
+    })
+    assert.deepEqual(getPricing('deepseek-reasoner'), {
+      input: 0.55,
+      output: 2.19,
+      cacheRead: 0.14,
+      cacheWrite: 0,
+    })
+  })
+
+  it('returns null for unknown / empty / non-string ids (verbatim-only lookup)', () => {
+    assert.equal(getPricing('deepseek-unknown'), null)
+    assert.equal(getPricing('deepseek-chat-20250101'), null) // no date-strip retry
+    assert.equal(getPricing(''), null)
+    assert.equal(getPricing(null), null)
+    assert.equal(getPricing(undefined), null)
+  })
+
+  it('feeds the shared computePromptCostUsd to the expected USD cost', () => {
+    // 2M input + 1M output at deepseek-chat rates → 2*0.27 + 1*1.10 = 1.64.
+    const cost = computePromptCostUsd(
+      {
+        input_tokens: 2_000_000,
+        output_tokens: 1_000_000,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      getPricing('deepseek-chat'),
+    )
+    assert.ok(typeof cost === 'number' && Math.abs(cost - 1.64) < 1e-6, `got ${cost}`)
   })
 })


### PR DESCRIPTION
First slice of the #6201 `models.js` OCP refactor (pricing/context → provider classes), designed via a multi-agent understand+design pass. DeepSeek is the precedent the audit names — a non-Claude provider whose bespoke pricing literal was bolted into models.js's central tables.

## What
- `DEEPSEEK_PRICING_USD_PER_MTOK` + the verbatim-only lookup **relocate from models.js into `deepseek-session.js`**, where the `_getPricing` override seam already lived. `_getPricing` reads the local table directly (no models.js import).
- models.js **drops** `DEEPSEEK_PRICING_USD_PER_MTOK` + `getDeepSeekPricing` — sole consumer was `deepseek-session.js` (confirmed: no other importer, no re-export). So models.js stops owning DeepSeek pricing entirely (the OCP win, not a shim); a future provider adds nothing here. The shared `computePromptCostUsd` stays in models.js.
- **New characterization test** (the audit's blind-spot C — the old suite never value-covered DeepSeek rates): pins the exact published rates + null cases + the end-to-end cost through `computePromptCostUsd`, proving the relocation byte-for-byte pure.

## Verification
- deepseek + all 5 `models-*.test.js` green (214 tests) — Claude pricing/context untouched.
- 5 server custom lints pass; eslint clean.
- Behaviour-preserving: byte-identical frozen rate objects, same null-not-zero cost contract, no `BaseSession` opt added.

PRs 2-4 (Claude pricing/context, default-registry de-Clauding) are higher-blast-radius and [documented on #6201](https://github.com/blamechris/chroxy/issues/6201) for fresh sessions.

Part of #6201.