### PR TITLE
refactor(server): move the Claude model catalog onto its own module (#6201 OCP)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -22,13 +22,11 @@ import { PermissionManager, wirePermissionManager } from './permission-manager.j
 import { createLogger } from './logger.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import {
-  FALLBACK_MODELS,
   ALLOWED_MODEL_IDS,
-  claudeDeriveId,
-  resolveClaudeContextWindow,
   getModelPricing,
   computePromptCostUsd,
 } from './models.js'
+import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { resolveAnthropicApiKey, maskApiKey } from './byok-credentials.js'
 import { BILLING_CLASSES } from './billing-class.js'
 import { translateSdkEvent } from './byok-event-translator.js'
@@ -201,7 +199,7 @@ export class ClaudeByokSession extends BaseSession {
   }
 
   static getFallbackModels() {
-    return FALLBACK_MODELS
+    return CLAUDE_FALLBACK_MODELS
   }
 
   static getAllowedModels() {
@@ -211,18 +209,10 @@ export class ClaudeByokSession extends BaseSession {
   /**
    * Model registry hook. BYOK accepts any Anthropic model id the API
    * accepts; reuse claude-* metadata since the ids are the same shape.
+   * Delegates to the shared claudeModelMetadata() helper (#6201 OCP).
    */
   static getModelMetadata(modelId) {
-    if (typeof modelId !== 'string' || modelId.length === 0) return null
-    const fullId = modelId
-    const id = claudeDeriveId(fullId)
-    return {
-      id,
-      label: id,
-      fullId,
-      contextWindow: resolveClaudeContextWindow(fullId),
-      description: '',
-    }
+    return claudeModelMetadata(modelId)
   }
 
   /**

--- a/packages/server/src/claude-channel-session.js
+++ b/packages/server/src/claude-channel-session.js
@@ -1,7 +1,8 @@
 import { homedir } from 'os'
 import { join } from 'path'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
+import { ALLOWED_MODEL_IDS } from './models.js'
+import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { BILLING_CLASSES } from './billing-class.js'
 
 // Minimum `claude` CLI version that ships the `--channels` MCP transport.
@@ -129,7 +130,7 @@ export class ClaudeChannelSession extends BaseSession {
   }
 
   static getFallbackModels() {
-    return FALLBACK_MODELS
+    return CLAUDE_FALLBACK_MODELS
   }
 
   static getAllowedModels() {
@@ -137,10 +138,7 @@ export class ClaudeChannelSession extends BaseSession {
   }
 
   static getModelMetadata(modelId) {
-    if (typeof modelId !== 'string' || modelId.length === 0) return null
-    const fullId = modelId
-    const id = claudeDeriveId(fullId)
-    return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
+    return claudeModelMetadata(modelId)
   }
 
   constructor(opts = {}) {

--- a/packages/server/src/claude-model-catalog.js
+++ b/packages/server/src/claude-model-catalog.js
@@ -1,0 +1,266 @@
+// Claude provider family's model catalog (#6201 OCP).
+//
+// Extracted VERBATIM from models.js so the generic models registry / overlay /
+// cost engine in models.js no longer OWNS the Claude model roster — it merely
+// consumes it. This is the inversion the #6201 audit wanted: adding a new
+// Claude-family model is now a single-row edit HERE (MODEL_METADATA), not an
+// edit to models.js's central tables. DeepSeek (#6365) was the first slice of
+// the same move; this is the Claude slice.
+//
+// This module is a PURE LEAF: it imports nothing from models.js or any session
+// class, so models.js can import it without a circular dependency, and all five
+// Claude session classes (SdkSession / CliSession / ClaudeTuiSession /
+// ClaudeChannelSession / ClaudeByokSession) can share one source of truth for
+// their `getFallbackModels()` / `getModelMetadata()` statics — which were
+// byte-identical copies before this consolidation.
+//
+// models.js re-exports DEFAULT_CONTEXT_WINDOW, ONE_M_SUFFIX, FALLBACK_MODELS,
+// resolveClaudeContextWindow and claudeDeriveId under their original names, so
+// every existing importer (and the test suites) is unaffected.
+
+/** Default context window for unknown models. Also the floor of the Claude
+ *  context-window heuristic below, and the generic registry fallback in
+ *  models.js for providers that report no window. */
+export const DEFAULT_CONTEXT_WINDOW = 200_000
+
+/** Suffix the Claude CLI uses to mark the explicit 1M-context variant */
+export const ONE_M_SUFFIX = '[1m]'
+
+// Opus gained a 1M context window at 4.6. `[major, minor]` of the first opus
+// release with a 1M window — opus at or above this (and any future opus major)
+// is treated as 1M; earlier opus and every other family default to 200k. The
+// SDK's authoritative modelUsage.contextWindow overrides this after turn 1, so a
+// wrong cold-start guess only ever surfaces for the first turn.
+const OPUS_ONE_M_MIN_VERSION = Object.freeze([4, 6])
+// Matches an opus version token: `opus-<major>` with an OPTIONAL `-<minor>` /
+// `.<minor>`, e.g. `claude-opus-4-8`, `claude-opus-4.8`, `claude-opus-5` (major
+// only), or `claude-opus-4-7-20251201` (versioned + dated). Both major and minor
+// are 1–2 digits NOT followed by another digit, so:
+//   - a DATED base id like `claude-opus-4-20250514` (opus 4.0, dated — 200k) does
+//     NOT read the date as a minor (the optional group fails → major-only 4.0);
+//   - a `claude-3-opus-20240229` id does NOT read the 8-digit date as a major
+//     (the major is capped at 2 digits + lookahead → no match → default).
+const OPUS_VERSION_RE = /opus-(\d{1,2})(?!\d)(?:[-.](\d{1,2})(?!\d))?/
+
+/**
+ * Static context-window heuristic used at cold start before the SDK reports.
+ * Opus 4.6+ has 1M (matched by family + version, so new minors/majors inherit it
+ * without a code change); most other Claude models have 200k. Any id carrying the
+ * explicit `[1m]` CLI suffix is a 1M-context variant regardless of the base
+ * model. The SDK sends authoritative values in
+ * `SDKResultSuccess.modelUsage[*].contextWindow` after each turn — registries
+ * opportunistically correct themselves via `updateContextWindow()` so wrong
+ * guesses only surface for the first turn.
+ *
+ * Exported so Claude providers (SdkSession/CliSession) can reuse it in
+ * their `getModelMetadata()` implementations.
+ */
+export function resolveClaudeContextWindow(fullId) {
+  if (typeof fullId !== 'string') return DEFAULT_CONTEXT_WINDOW
+  if (fullId.endsWith(ONE_M_SUFFIX)) return 1_000_000
+  const m = OPUS_VERSION_RE.exec(fullId)
+  if (m) {
+    const major = Number(m[1])
+    const minor = m[2] === undefined ? null : Number(m[2])
+    const [minMajor, minMinor] = OPUS_ONE_M_MIN_VERSION
+    // A future major (opus 5+) is 1M with or without a minor; opus 4 needs an
+    // explicit minor >= 6 (bare `opus-4` is 4.0 → 200k, not assumed 4.6).
+    if (major > minMajor) return 1_000_000
+    if (major === minMajor && minor !== null && minor >= minMinor) return 1_000_000
+  }
+  return DEFAULT_CONTEXT_WINDOW
+}
+
+
+/**
+ * Default Claude ID converter: strips the `claude-` prefix to produce the
+ * short id while keeping the full id as-is. Exported so provider classes
+ * can compose it in their own `getModelMetadata()`.
+ */
+export function claudeDeriveId(fullId) {
+  return typeof fullId === 'string' && fullId.startsWith('claude-') ? fullId.slice(7) : fullId
+}
+
+// Single source of truth for Claude model metadata (#5930 / #5631 DRY core).
+// Each row describes one known Claude model family head; the two scattered
+// data tables below — CLAUDE_FALLBACK_MODELS (cold-start / SDK-merge seed) and
+// CLAUDE_PRICING_USD_PER_MTOK (per-fullId billing rates) — are DERIVED from
+// this array, so adding a model is a single-row edit instead of edits in
+// several hand-synced places. The regex/string heuristics
+// (resolveClaudeContextWindow, humanizeModelId) intentionally stay separate:
+// they are the graceful-degradation path for models NOT in this table.
+//
+// Per-row fields:
+//   shortId, label, fullId — the CLAUDE_FALLBACK_MODELS triple. The fullIds are
+//     versioned family heads WITHOUT a date suffix (e.g. `claude-opus-4-7`, not
+//     `claude-opus-4-7-20251201`): the short aliases (sonnet/opus/haiku) resolve
+//     to the latest version in the claude CLI, and the SDK's supportedModels()
+//     is the source of truth for concrete date-pinned identifiers. These rows
+//     also seed the merge step in updateModels() so a stale/minimal SDK response
+//     still surfaces the newer chip in the picker (#3075).
+//   contextWindow — OPTIONAL. When set it overrides the cold-start heuristic
+//     for that known model (symmetric with the on-disk overlay in
+//     computeFallbackModels); when absent (the case for every row today) it is
+//     derived via resolveClaudeContextWindow(fullId), so the derivation is
+//     byte-identical to the prior CLAUDE_FALLBACK_MODELS literals.
+//   pricing — base Anthropic rates in USD per million tokens
+//     {input, output, cacheRead, cacheWrite}. ABSENT (e.g. fable, shipped
+//     without verified pricing) emits NO pricing key, so resolveModelPricing
+//     returns null — never $0 — for it.
+//   oneM — the `[1m]` long-context variant's rates, including the `longContext`
+//     premium block (#4087). ABSENT emits no `<fullId>[1m]` pricing key. Kept a
+//     sibling of `pricing` so a [1m] form can carry distinct base rates.
+//
+// Cache-write rates are the 5-minute ephemeral tier (the default; chroxy
+// doesn't opt into the pricier 1-hour tier). Source: Anthropic public pricing
+// page — keep rates in sync on every model change; wrong numbers mislead
+// cumulative-cost displays (#4054). The models.test.js snapshot pins the
+// derived tables to literals, so any rate drift OR derivation regression fails
+// loudly.
+const MODEL_METADATA = Object.freeze([
+  Object.freeze({
+    shortId: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6',
+    pricing: { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
+  }),
+  Object.freeze({
+    shortId: 'opus', label: 'Opus', fullId: 'claude-opus-4-8',
+    pricing: { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+    // #4087 — long-context (>200K input) premium tier. Below the 200K
+    // threshold the rates match the base entry; above it the published premium
+    // is a uniform 2× across all four rates. Today only Opus 4.x has a 1M
+    // variant in chroxy's set (resolveClaudeContextWindow). Verify against the
+    // Anthropic pricing page on the next periodic check.
+    oneM: {
+      input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
+      longContext: {
+        thresholdInputTokens: 200_000,
+        input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
+      },
+    },
+  }),
+  // #6219 — Fable (claude-fable-5) is disallowed for chroxy and removed from the
+  // roster. It is also filtered out of any SDK-returned list (DISALLOWED_MODEL_IDS
+  // in models.js) so it can't reappear in SDK/TUI modes, not just the CLI fallback.
+  Object.freeze({
+    shortId: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5',
+    pricing: { input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 },
+  }),
+])
+
+// Freeze a pricing block (incl. the nested longContext premium) IN PLACE so the
+// derived CLAUDE_PRICING_USD_PER_MTOK keeps the deep-frozen contract callers
+// relied on when the rates were hand-authored as Object.freeze literals. The
+// derived table deliberately shares object identity with its MODEL_METADATA
+// source row (both are frozen + read-only) — do NOT defensively deep-clone here,
+// that would just reintroduce the two-copies-can-drift problem this consolidation
+// removes.
+function deepFreezePricing(rates) {
+  if (rates && typeof rates === 'object') {
+    for (const v of Object.values(rates)) {
+      if (v && typeof v === 'object') Object.freeze(v)
+    }
+    Object.freeze(rates)
+  }
+  return rates
+}
+
+// Minimal fallback used only when the SDK has never responded and no disk cache
+// exists. Derived from MODEL_METADATA (source order preserved). Deep-frozen so
+// callers of getModels() can't mutate the module-level constant via the
+// returned array reference.
+//
+// Re-exported by models.js under the original name `FALLBACK_MODELS`.
+export const CLAUDE_FALLBACK_MODELS = Object.freeze(
+  MODEL_METADATA.map((m) => Object.freeze({
+    id: m.shortId,
+    label: m.label,
+    fullId: m.fullId,
+    contextWindow: m.contextWindow ?? resolveClaudeContextWindow(m.fullId),
+  })),
+)
+
+// Public Anthropic pricing in USD per million tokens, derived from
+// MODEL_METADATA: each row's `pricing` becomes the base `<fullId>` entry and
+// each `oneM` becomes the `<fullId>[1m]` long-context entry (#4087).
+// `computePromptCostUsd` selects between base and longContext rates based on
+// the turn's total input tokens.
+export const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze(
+  MODEL_METADATA.reduce((table, m) => {
+    if (m.pricing) table[m.fullId] = deepFreezePricing(m.pricing)
+    if (m.oneM) table[`${m.fullId}${ONE_M_SUFFIX}`] = deepFreezePricing(m.oneM)
+    return table
+  }, {}),
+)
+
+// Short-id → fullId so callers can pass either form. The fallback set is
+// the canonical mapping; new short aliases get picked up automatically.
+//
+// `[1m]` long-context variant (#4087): try the model id verbatim FIRST
+// so an explicit `claude-opus-4-7[1m]` entry — with its longContext
+// premium block — wins over the suffix-stripped fallback.
+//
+// Also normalises dated full IDs back to the family head: the Anthropic
+// SDK's `Model` enum returns forms like `claude-opus-4-7-20251201`, which
+// users may pin for reproducibility (#4084). The pricing table is keyed
+// on family heads (`claude-opus-4-7`), so a regex strip of the trailing
+// 8+-digit date suffix lets the lookup succeed for either form.
+//
+// [1m] re-attach after fallback (#4105 + #4107): when the input ended
+// with `[1m]` and a non-verbatim match resolves to a family head, try
+// `${head}[1m]` first so the explicit premium entry wins over the base.
+// Otherwise short-form `opus[1m]` and dated-form `*-YYYYMMDD[1m]` would
+// silently route to base rates and undercount >200K turns.
+export function resolvePricingKey(modelId) {
+  if (typeof modelId !== 'string' || modelId.length === 0) return null
+  if (CLAUDE_PRICING_USD_PER_MTOK[modelId]) return modelId
+  const had1m = modelId.endsWith(ONE_M_SUFFIX)
+  const stripped = had1m ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
+  // When the input carried [1m] AND a non-verbatim resolution lands on a
+  // family head with an explicit [1m] entry, prefer the [1m] entry so the
+  // longContext premium block is reachable.
+  const preferOneM = (key) => {
+    if (had1m) {
+      const oneMKey = `${key}${ONE_M_SUFFIX}`
+      if (CLAUDE_PRICING_USD_PER_MTOK[oneMKey]) return oneMKey
+    }
+    return key
+  }
+  if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return preferOneM(stripped)
+  // Dated full id? Strip the 8-digit date suffix and retry against the
+  // pricing table. The strip applies unconditionally; safety comes from
+  // the table itself — only `claude-*` keys exist, so a short-form like
+  // `opus-4-7-20251201` strips to `opus-4-7`, misses the table, and
+  // falls through to the CLAUDE_FALLBACK_MODELS short-id lookup (which expects
+  // the un-stripped id).
+  const dateStripped = stripped.replace(/-\d{8,}$/, '')
+  if (CLAUDE_PRICING_USD_PER_MTOK[dateStripped]) return preferOneM(dateStripped)
+  const fallback = CLAUDE_FALLBACK_MODELS.find((m) => m.id === stripped)
+  return fallback ? preferOneM(fallback.fullId) : null
+}
+
+/**
+ * Claude-style model metadata: strip the `claude-` prefix for the short id,
+ * reuse the shared context-window heuristic. The single source of truth for
+ * every Claude provider class's `static getModelMetadata()` — these were
+ * byte-identical copies across SdkSession / CliSession / ClaudeTuiSession /
+ * ClaudeChannelSession / ClaudeByokSession before #6201 consolidated them here.
+ *
+ * Called with the full model id as returned by the SDK (e.g. 'claude-sonnet-4-6').
+ * Short alias resolution is intentionally left to the caller — the registry
+ * always has the fullId available.
+ *
+ * @param {string} modelId - Full model id (e.g. 'claude-sonnet-4-6').
+ * @returns {{id:string,label:string,fullId:string,contextWindow:number,description:string}|null}
+ */
+export function claudeModelMetadata(modelId) {
+  if (typeof modelId !== 'string' || modelId.length === 0) return null
+  const fullId = modelId
+  const id = claudeDeriveId(fullId)
+  return {
+    id,
+    label: id,
+    fullId,
+    contextWindow: resolveClaudeContextWindow(fullId),
+    description: '',
+  }
+}

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -14,7 +14,8 @@ import { CLAUDE_TUI_PTY_SIZE } from '@chroxy/protocol'
 // (RESUME_UNKNOWN_STDERR_PATTERNS, #4929/#4950) via this matcher: the PTY
 // merges stdout+stderr, so claude's resume rejection lands in _outputTail.
 import { stderrIndicatesUnknownResume } from './cli-session.js'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
+import { ALLOWED_MODEL_IDS } from './models.js'
+import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 import { createLogger, loggerForSession, redactSensitive, redactSensitivePreservingEscapes } from './logger.js'
@@ -250,7 +251,7 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   static getFallbackModels() {
-    return FALLBACK_MODELS
+    return CLAUDE_FALLBACK_MODELS
   }
 
   static getAllowedModels() {
@@ -258,10 +259,7 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   static getModelMetadata(modelId) {
-    if (typeof modelId !== 'string' || modelId.length === 0) return null
-    const fullId = modelId
-    const id = claudeDeriveId(fullId)
-    return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
+    return claudeModelMetadata(modelId)
   }
 
   /**

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -7,7 +7,8 @@ import { createPermissionHookManager } from './permission-hook.js'
 import { guardChildStreams } from './child-stream-guard.js'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
-import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
+import { ALLOWED_MODEL_IDS } from './models.js'
+import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { forceKill } from './platform.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
@@ -319,8 +320,9 @@ export class CliSession extends BaseSession {
   }
 
   /**
-   * Per-provider fallback model list (#2956). Shared with SdkSession via
-   * the module-level `FALLBACK_MODELS`. The default Claude registry is
+   * Per-provider fallback model list (#2956). Shared with every Claude
+   * provider via `CLAUDE_FALLBACK_MODELS` in claude-model-catalog.js
+   * (#6201 OCP). The default Claude registry is
    * what this provider uses at runtime — this static exists so
    * `getRegistryForProvider('claude-cli')` and the per-provider tests
    * can discover the Claude defaults through the same hook shape used
@@ -329,7 +331,7 @@ export class CliSession extends BaseSession {
    * @returns {ReadonlyArray<{id:string,label:string,fullId:string,contextWindow:number}>}
    */
   static getFallbackModels() {
-    return FALLBACK_MODELS
+    return CLAUDE_FALLBACK_MODELS
   }
 
   static getAllowedModels() {
@@ -337,23 +339,14 @@ export class CliSession extends BaseSession {
   }
 
   /**
-   * Claude-style metadata: strip the `claude-` prefix for the short id,
-   * reuse the shared context-window heuristic. Mirrors SdkSession (#2956).
+   * Claude-style metadata via the shared claudeModelMetadata() helper
+   * (#6201 OCP). Mirrors SdkSession (#2956).
    *
    * @param {string} modelId
    * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}|null}
    */
   static getModelMetadata(modelId) {
-    if (typeof modelId !== 'string' || modelId.length === 0) return null
-    const fullId = modelId
-    const id = claudeDeriveId(fullId)
-    return {
-      id,
-      label: id,
-      fullId,
-      contextWindow: resolveClaudeContextWindow(fullId),
-      description: '',
-    }
+    return claudeModelMetadata(modelId)
   }
 
   constructor(opts = {}) {

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -3,135 +3,25 @@ import { homedir } from 'os'
 import { basename, dirname, join } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
+import {
+  DEFAULT_CONTEXT_WINDOW,
+  ONE_M_SUFFIX,
+  resolveClaudeContextWindow,
+  claudeDeriveId,
+  CLAUDE_FALLBACK_MODELS as FALLBACK_MODELS,
+  CLAUDE_PRICING_USD_PER_MTOK,
+  resolvePricingKey,
+} from './claude-model-catalog.js'
 
 const log = createLogger('models')
 
-/** Default context window for unknown models */
-export const DEFAULT_CONTEXT_WINDOW = 200_000
-
-/** Suffix the Claude CLI uses to mark the explicit 1M-context variant */
-export const ONE_M_SUFFIX = '[1m]'
-
-// Opus gained a 1M context window at 4.6. `[major, minor]` of the first opus
-// release with a 1M window — opus at or above this (and any future opus major)
-// is treated as 1M; earlier opus and every other family default to 200k. The
-// SDK's authoritative modelUsage.contextWindow overrides this after turn 1, so a
-// wrong cold-start guess only ever surfaces for the first turn.
-const OPUS_ONE_M_MIN_VERSION = Object.freeze([4, 6])
-// Matches an opus version token: `opus-<major>` with an OPTIONAL `-<minor>` /
-// `.<minor>`, e.g. `claude-opus-4-8`, `claude-opus-4.8`, `claude-opus-5` (major
-// only), or `claude-opus-4-7-20251201` (versioned + dated). Both major and minor
-// are 1–2 digits NOT followed by another digit, so:
-//   - a DATED base id like `claude-opus-4-20250514` (opus 4.0, dated — 200k) does
-//     NOT read the date as a minor (the optional group fails → major-only 4.0);
-//   - a `claude-3-opus-20240229` id does NOT read the 8-digit date as a major
-//     (the major is capped at 2 digits + lookahead → no match → default).
-const OPUS_VERSION_RE = /opus-(\d{1,2})(?!\d)(?:[-.](\d{1,2})(?!\d))?/
-
-/**
- * Static context-window heuristic used at cold start before the SDK reports.
- * Opus 4.6+ has 1M (matched by family + version, so new minors/majors inherit it
- * without a code change); most other Claude models have 200k. Any id carrying the
- * explicit `[1m]` CLI suffix is a 1M-context variant regardless of the base
- * model. The SDK sends authoritative values in
- * `SDKResultSuccess.modelUsage[*].contextWindow` after each turn — registries
- * opportunistically correct themselves via `updateContextWindow()` so wrong
- * guesses only surface for the first turn.
- *
- * Exported so Claude providers (SdkSession/CliSession) can reuse it in
- * their `getModelMetadata()` implementations.
- */
-export function resolveClaudeContextWindow(fullId) {
-  if (typeof fullId !== 'string') return DEFAULT_CONTEXT_WINDOW
-  if (fullId.endsWith(ONE_M_SUFFIX)) return 1_000_000
-  const m = OPUS_VERSION_RE.exec(fullId)
-  if (m) {
-    const major = Number(m[1])
-    const minor = m[2] === undefined ? null : Number(m[2])
-    const [minMajor, minMinor] = OPUS_ONE_M_MIN_VERSION
-    // A future major (opus 5+) is 1M with or without a minor; opus 4 needs an
-    // explicit minor >= 6 (bare `opus-4` is 4.0 → 200k, not assumed 4.6).
-    if (major > minMajor) return 1_000_000
-    if (major === minMajor && minor !== null && minor >= minMinor) return 1_000_000
-  }
-  return DEFAULT_CONTEXT_WINDOW
-}
-
-
-/**
- * Default Claude ID converter: strips the `claude-` prefix to produce the
- * short id while keeping the full id as-is. Exported so provider classes
- * can compose it in their own `getModelMetadata()`.
- */
-export function claudeDeriveId(fullId) {
-  return typeof fullId === 'string' && fullId.startsWith('claude-') ? fullId.slice(7) : fullId
-}
-
-// Single source of truth for Claude model metadata (#5930 / #5631 DRY core).
-// Each row describes one known Claude model family head; the two scattered
-// data tables below — FALLBACK_MODELS (cold-start / SDK-merge seed) and
-// CLAUDE_PRICING_USD_PER_MTOK (per-fullId billing rates) — are DERIVED from
-// this array, so adding a model is a single-row edit instead of edits in
-// several hand-synced places. The regex/string heuristics
-// (resolveClaudeContextWindow, humanizeModelId) intentionally stay separate:
-// they are the graceful-degradation path for models NOT in this table.
-//
-// Per-row fields:
-//   shortId, label, fullId — the FALLBACK_MODELS triple. The fullIds are
-//     versioned family heads WITHOUT a date suffix (e.g. `claude-opus-4-7`, not
-//     `claude-opus-4-7-20251201`): the short aliases (sonnet/opus/haiku) resolve
-//     to the latest version in the claude CLI, and the SDK's supportedModels()
-//     is the source of truth for concrete date-pinned identifiers. These rows
-//     also seed the merge step in updateModels() so a stale/minimal SDK response
-//     still surfaces the newer chip in the picker (#3075).
-//   contextWindow — OPTIONAL. When set it overrides the cold-start heuristic
-//     for that known model (symmetric with the on-disk overlay in
-//     computeFallbackModels); when absent (the case for every row today) it is
-//     derived via resolveClaudeContextWindow(fullId), so the derivation is
-//     byte-identical to the prior FALLBACK_MODELS literals.
-//   pricing — base Anthropic rates in USD per million tokens
-//     {input, output, cacheRead, cacheWrite}. ABSENT (e.g. fable, shipped
-//     without verified pricing) emits NO pricing key, so resolveModelPricing
-//     returns null — never $0 — for it.
-//   oneM — the `[1m]` long-context variant's rates, including the `longContext`
-//     premium block (#4087). ABSENT emits no `<fullId>[1m]` pricing key. Kept a
-//     sibling of `pricing` so a [1m] form can carry distinct base rates.
-//
-// Cache-write rates are the 5-minute ephemeral tier (the default; chroxy
-// doesn't opt into the pricier 1-hour tier). Source: Anthropic public pricing
-// page — keep rates in sync on every model change; wrong numbers mislead
-// cumulative-cost displays (#4054). The models.test.js snapshot pins the
-// derived tables to literals, so any rate drift OR derivation regression fails
-// loudly.
-const MODEL_METADATA = Object.freeze([
-  Object.freeze({
-    shortId: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6',
-    pricing: { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
-  }),
-  Object.freeze({
-    shortId: 'opus', label: 'Opus', fullId: 'claude-opus-4-8',
-    pricing: { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
-    // #4087 — long-context (>200K input) premium tier. Below the 200K
-    // threshold the rates match the base entry; above it the published premium
-    // is a uniform 2× across all four rates. Today only Opus 4.x has a 1M
-    // variant in chroxy's set (resolveClaudeContextWindow). Verify against the
-    // Anthropic pricing page on the next periodic check.
-    oneM: {
-      input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
-      longContext: {
-        thresholdInputTokens: 200_000,
-        input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
-      },
-    },
-  }),
-  // #6219 — Fable (claude-fable-5) is disallowed for chroxy and removed from the
-  // roster. It is also filtered out of any SDK-returned list (DISALLOWED_MODEL_IDS
-  // below) so it can't reappear in SDK/TUI modes, not just the CLI fallback.
-  Object.freeze({
-    shortId: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5',
-    pricing: { input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25 },
-  }),
-])
+// Claude model catalog (roster, pricing, context-window heuristic) moved to
+// claude-model-catalog.js (#6201 OCP) so this generic registry/overlay/cost
+// module no longer OWNS the Claude data — it consumes it. Re-exported under the
+// original names so every existing importer + test is unaffected. The
+// module-level pricing path (resolveModelPricing) and the createModelsRegistry
+// drift-guard read the imported CLAUDE_PRICING_USD_PER_MTOK / resolvePricingKey.
+export { DEFAULT_CONTEXT_WINDOW, ONE_M_SUFFIX, resolveClaudeContextWindow, claudeDeriveId, FALLBACK_MODELS }
 
 // #6219 — fullIds chroxy disallows regardless of source: the CLI fallback (gone
 // already, removed from MODEL_METADATA), the Agent SDK's supportedModels() push,
@@ -157,94 +47,10 @@ export function isDisallowedModelId(id) {
   return DISALLOWED_MODEL_IDS.has(base)
 }
 
-// Freeze a pricing block (incl. the nested longContext premium) IN PLACE so the
-// derived CLAUDE_PRICING_USD_PER_MTOK keeps the deep-frozen contract callers
-// relied on when the rates were hand-authored as Object.freeze literals. The
-// derived table deliberately shares object identity with its MODEL_METADATA
-// source row (both are frozen + read-only) — do NOT defensively deep-clone here,
-// that would just reintroduce the two-copies-can-drift problem this consolidation
-// removes.
-function deepFreezePricing(rates) {
-  if (rates && typeof rates === 'object') {
-    for (const v of Object.values(rates)) {
-      if (v && typeof v === 'object') Object.freeze(v)
-    }
-    Object.freeze(rates)
-  }
-  return rates
-}
-
-// Minimal fallback used only when the SDK has never responded and no disk cache
-// exists. Derived from MODEL_METADATA (source order preserved). Deep-frozen so
-// callers of getModels() can't mutate the module-level constant via the
-// returned array reference.
-export const FALLBACK_MODELS = Object.freeze(
-  MODEL_METADATA.map((m) => Object.freeze({
-    id: m.shortId,
-    label: m.label,
-    fullId: m.fullId,
-    contextWindow: m.contextWindow ?? resolveClaudeContextWindow(m.fullId),
-  })),
-)
-
-// Public Anthropic pricing in USD per million tokens, derived from
-// MODEL_METADATA: each row's `pricing` becomes the base `<fullId>` entry and
-// each `oneM` becomes the `<fullId>[1m]` long-context entry (#4087).
-// `computePromptCostUsd` selects between base and longContext rates based on
-// the turn's total input tokens.
-const CLAUDE_PRICING_USD_PER_MTOK = Object.freeze(
-  MODEL_METADATA.reduce((table, m) => {
-    if (m.pricing) table[m.fullId] = deepFreezePricing(m.pricing)
-    if (m.oneM) table[`${m.fullId}${ONE_M_SUFFIX}`] = deepFreezePricing(m.oneM)
-    return table
-  }, {}),
-)
-
-// Short-id → fullId so callers can pass either form. The fallback set is
-// the canonical mapping; new short aliases get picked up automatically.
-//
-// `[1m]` long-context variant (#4087): try the model id verbatim FIRST
-// so an explicit `claude-opus-4-7[1m]` entry — with its longContext
-// premium block — wins over the suffix-stripped fallback.
-//
-// Also normalises dated full IDs back to the family head: the Anthropic
-// SDK's `Model` enum returns forms like `claude-opus-4-7-20251201`, which
-// users may pin for reproducibility (#4084). The pricing table is keyed
-// on family heads (`claude-opus-4-7`), so a regex strip of the trailing
-// 8+-digit date suffix lets the lookup succeed for either form.
-//
-// [1m] re-attach after fallback (#4105 + #4107): when the input ended
-// with `[1m]` and a non-verbatim match resolves to a family head, try
-// `${head}[1m]` first so the explicit premium entry wins over the base.
-// Otherwise short-form `opus[1m]` and dated-form `*-YYYYMMDD[1m]` would
-// silently route to base rates and undercount >200K turns.
-function resolvePricingKey(modelId) {
-  if (typeof modelId !== 'string' || modelId.length === 0) return null
-  if (CLAUDE_PRICING_USD_PER_MTOK[modelId]) return modelId
-  const had1m = modelId.endsWith(ONE_M_SUFFIX)
-  const stripped = had1m ? modelId.slice(0, -ONE_M_SUFFIX.length) : modelId
-  // When the input carried [1m] AND a non-verbatim resolution lands on a
-  // family head with an explicit [1m] entry, prefer the [1m] entry so the
-  // longContext premium block is reachable.
-  const preferOneM = (key) => {
-    if (had1m) {
-      const oneMKey = `${key}${ONE_M_SUFFIX}`
-      if (CLAUDE_PRICING_USD_PER_MTOK[oneMKey]) return oneMKey
-    }
-    return key
-  }
-  if (CLAUDE_PRICING_USD_PER_MTOK[stripped]) return preferOneM(stripped)
-  // Dated full id? Strip the 8-digit date suffix and retry against the
-  // pricing table. The strip applies unconditionally; safety comes from
-  // the table itself — only `claude-*` keys exist, so a short-form like
-  // `opus-4-7-20251201` strips to `opus-4-7`, misses the table, and
-  // falls through to the FALLBACK_MODELS short-id lookup (which expects
-  // the un-stripped id).
-  const dateStripped = stripped.replace(/-\d{8,}$/, '')
-  if (CLAUDE_PRICING_USD_PER_MTOK[dateStripped]) return preferOneM(dateStripped)
-  const fallback = FALLBACK_MODELS.find((m) => m.id === stripped)
-  return fallback ? preferOneM(fallback.fullId) : null
-}
+// deepFreezePricing, FALLBACK_MODELS, CLAUDE_PRICING_USD_PER_MTOK and
+// resolvePricingKey now live in claude-model-catalog.js (#6201 OCP) — imported
+// above. resolveModelPricing() below layers the operator overlay + registry
+// resolution on top of the catalog's static base lookup.
 
 /**
  * Returns the pricing rates for a model (USD per million tokens), or null
@@ -999,7 +805,7 @@ export function createModelsRegistry(hooks = {}) {
             const reason = entry
               ? `no longContext premium block; >200K turns will bill at base rates`
               : `no entry in CLAUDE_PRICING_USD_PER_MTOK; cost may be 0 or fall back to base`
-            log.warn(`pricing-table drift: synthesized 1M variant ${variantFullId} ${reason}. Add an explicit entry (with longContext) in packages/server/src/models.js.`)
+            log.warn(`pricing-table drift: synthesized 1M variant ${variantFullId} ${reason}. Add an explicit entry (with longContext) in packages/server/src/claude-model-catalog.js.`)
             pricingDriftWarned.add(variantFullId)
           }
         }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1,7 +1,8 @@
 import { query } from '@anthropic-ai/claude-agent-sdk'
 import { join } from 'path'
 import { homedir } from 'os'
-import { updateModels, saveModelsCache, updateContextWindow, getModels, FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
+import { updateModels, saveModelsCache, updateContextWindow, getModels, ALLOWED_MODEL_IDS } from './models.js'
+import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
@@ -283,7 +284,7 @@ export class SdkSession extends BaseSession {
    * before the first SDK response arrives.
    */
   static getFallbackModels() {
-    return FALLBACK_MODELS
+    return CLAUDE_FALLBACK_MODELS
   }
 
   static getAllowedModels() {
@@ -293,26 +294,14 @@ export class SdkSession extends BaseSession {
   /**
    * Claude-style metadata: strip the `claude-` prefix for the short id,
    * reuse the shared context-window heuristic. Used by the per-provider
-   * registry for both lookup and validation (#2956).
-   *
-   * The registry calls this with the full model id as returned by the SDK
-   * (e.g. 'claude-sonnet-4-6'). Short alias resolution is intentionally
-   * left to the caller — the registry always has the fullId available.
+   * registry for both lookup and validation (#2956). Delegates to the shared
+   * claudeModelMetadata() so all Claude providers stay in lockstep (#6201 OCP).
    *
    * @param {string} modelId - Full model id (e.g. 'claude-sonnet-4-6').
    * @returns {{id:string,label:string,fullId:string,contextWindow:number,description?:string}|null}
    */
   static getModelMetadata(modelId) {
-    if (typeof modelId !== 'string' || modelId.length === 0) return null
-    const fullId = modelId
-    const id = claudeDeriveId(fullId)
-    return {
-      id,
-      label: id,
-      fullId,
-      contextWindow: resolveClaudeContextWindow(fullId),
-      description: '',
-    }
+    return claudeModelMetadata(modelId)
   }
 
   /** Token budgets for thinking levels. null = adaptive (SDK default). */

--- a/packages/server/tests/claude-model-catalog.test.js
+++ b/packages/server/tests/claude-model-catalog.test.js
@@ -1,0 +1,166 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CLAUDE_FALLBACK_MODELS,
+  CLAUDE_PRICING_USD_PER_MTOK,
+  resolvePricingKey,
+  claudeModelMetadata,
+  resolveClaudeContextWindow,
+  claudeDeriveId,
+  DEFAULT_CONTEXT_WINDOW,
+  ONE_M_SUFFIX,
+} from '../src/claude-model-catalog.js'
+import { computePromptCostUsd } from '../src/models.js'
+
+/**
+ * #6201 (OCP) — the Claude model catalog (MODEL_METADATA roster + its derived
+ * pricing/fallback tables + the resolvePricingKey/claudeModelMetadata accessors)
+ * was relocated VERBATIM out of models.js's central tables into this provider-
+ * family module, inverting ownership so models.js consumes the catalog rather
+ * than owning it.
+ *
+ * models.test.js + models-metadata-derivation.test.js already pin the derived
+ * tables THROUGH models.js's re-exports + getModelPricing(). This suite pins the
+ * SOURCE-OF-TRUTH module directly, covering the accessors that were either
+ * internal (resolvePricingKey, CLAUDE_PRICING_USD_PER_MTOK) or brand-new
+ * (claudeModelMetadata — the helper the five Claude session classes now delegate
+ * to). Same intent as the DeepSeek slice (#6365): make the relocation provably
+ * pure by value, not just by shape.
+ */
+describe('claude-model-catalog (#6201 OCP characterization)', () => {
+  it('CLAUDE_PRICING_USD_PER_MTOK matches the exact published rates (USD/Mtok)', () => {
+    assert.deepEqual(CLAUDE_PRICING_USD_PER_MTOK['claude-sonnet-4-6'], {
+      input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 3.75,
+    })
+    assert.deepEqual(CLAUDE_PRICING_USD_PER_MTOK['claude-opus-4-8'], {
+      input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
+    })
+    assert.deepEqual(CLAUDE_PRICING_USD_PER_MTOK['claude-opus-4-8[1m]'], {
+      input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75,
+      longContext: {
+        thresholdInputTokens: 200_000,
+        input: 30.00, output: 150.00, cacheRead: 3.00, cacheWrite: 37.50,
+      },
+    })
+    assert.deepEqual(CLAUDE_PRICING_USD_PER_MTOK['claude-haiku-4-5'], {
+      input: 1.00, output: 5.00, cacheRead: 0.10, cacheWrite: 1.25,
+    })
+  })
+
+  it('prices exactly the intended keys — fable absent, no unverified-pricing $0 (#6219)', () => {
+    assert.deepEqual(Object.keys(CLAUDE_PRICING_USD_PER_MTOK).sort(), [
+      'claude-haiku-4-5',
+      'claude-opus-4-8',
+      'claude-opus-4-8[1m]',
+      'claude-sonnet-4-6',
+    ])
+    assert.ok(!('claude-fable-5' in CLAUDE_PRICING_USD_PER_MTOK))
+  })
+
+  it('keeps pricing entries (incl. the nested longContext premium) deep-frozen', () => {
+    assert.ok(Object.isFrozen(CLAUDE_PRICING_USD_PER_MTOK))
+    assert.ok(Object.isFrozen(CLAUDE_PRICING_USD_PER_MTOK['claude-opus-4-8']))
+    const oneM = CLAUDE_PRICING_USD_PER_MTOK['claude-opus-4-8[1m]']
+    assert.ok(Object.isFrozen(oneM))
+    assert.ok(Object.isFrozen(oneM.longContext))
+  })
+
+  it('CLAUDE_FALLBACK_MODELS preserves the exact roster, order, and windows', () => {
+    assert.deepStrictEqual([...CLAUDE_FALLBACK_MODELS], [
+      { id: 'sonnet', label: 'Sonnet', fullId: 'claude-sonnet-4-6', contextWindow: 200_000 },
+      { id: 'opus', label: 'Opus', fullId: 'claude-opus-4-8', contextWindow: 1_000_000 },
+      { id: 'haiku', label: 'Haiku', fullId: 'claude-haiku-4-5', contextWindow: 200_000 },
+    ])
+    assert.ok(Object.isFrozen(CLAUDE_FALLBACK_MODELS))
+    for (const m of CLAUDE_FALLBACK_MODELS) assert.ok(Object.isFrozen(m), `${m.id} frozen`)
+  })
+
+  describe('resolvePricingKey — every resolution branch', () => {
+    it('resolves a verbatim full id', () => {
+      assert.equal(resolvePricingKey('claude-opus-4-8'), 'claude-opus-4-8')
+      assert.equal(resolvePricingKey('claude-sonnet-4-6'), 'claude-sonnet-4-6')
+    })
+
+    it('resolves a short alias via the fallback set', () => {
+      assert.equal(resolvePricingKey('opus'), 'claude-opus-4-8')
+      assert.equal(resolvePricingKey('haiku'), 'claude-haiku-4-5')
+    })
+
+    it('strips a dated full id back to the family head', () => {
+      assert.equal(resolvePricingKey('claude-opus-4-8-20251201'), 'claude-opus-4-8')
+    })
+
+    it('re-attaches [1m] so the longContext premium entry wins (#4105/#4107)', () => {
+      // short-form + [1m], dated + [1m], and verbatim + [1m] all reach the premium key.
+      assert.equal(resolvePricingKey('opus[1m]'), 'claude-opus-4-8[1m]')
+      assert.equal(resolvePricingKey('claude-opus-4-8-20251201[1m]'), 'claude-opus-4-8[1m]')
+      assert.equal(resolvePricingKey('claude-opus-4-8[1m]'), 'claude-opus-4-8[1m]')
+    })
+
+    it('returns null for unknown / empty / non-string ids', () => {
+      assert.equal(resolvePricingKey('gpt-5'), null)
+      assert.equal(resolvePricingKey(''), null)
+      assert.equal(resolvePricingKey(null), null)
+      assert.equal(resolvePricingKey(undefined), null)
+    })
+  })
+
+  describe('claudeModelMetadata — the shared getModelMetadata() helper', () => {
+    it('strips the claude- prefix and derives the window heuristically', () => {
+      assert.deepEqual(claudeModelMetadata('claude-sonnet-4-6'), {
+        id: 'sonnet-4-6', label: 'sonnet-4-6', fullId: 'claude-sonnet-4-6',
+        contextWindow: 200_000, description: '',
+      })
+      assert.deepEqual(claudeModelMetadata('claude-opus-4-8'), {
+        id: 'opus-4-8', label: 'opus-4-8', fullId: 'claude-opus-4-8',
+        contextWindow: 1_000_000, description: '',
+      })
+    })
+
+    it('honours the [1m] long-context suffix', () => {
+      assert.equal(claudeModelMetadata('claude-opus-4-8[1m]').contextWindow, 1_000_000)
+      assert.equal(claudeModelMetadata('claude-opus-4-8[1m]').id, 'opus-4-8[1m]')
+    })
+
+    it('passes a non-claude id through (BYOK reuses claude-shaped metadata)', () => {
+      assert.deepEqual(claudeModelMetadata('gpt-5'), {
+        id: 'gpt-5', label: 'gpt-5', fullId: 'gpt-5',
+        contextWindow: DEFAULT_CONTEXT_WINDOW, description: '',
+      })
+    })
+
+    it('returns null for empty / non-string ids', () => {
+      assert.equal(claudeModelMetadata(''), null)
+      assert.equal(claudeModelMetadata(null), null)
+      assert.equal(claudeModelMetadata(42), null)
+    })
+  })
+
+  describe('end-to-end cost through computePromptCostUsd (relocation is pure)', () => {
+    it('bills a sub-threshold opus turn at base rates', () => {
+      // 1M input + 1M output at base opus → 1*15.00 + 1*75.00 = 90.00.
+      const cost = computePromptCostUsd(
+        { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        CLAUDE_PRICING_USD_PER_MTOK['claude-opus-4-8'],
+      )
+      assert.ok(Math.abs(cost - 90.00) < 1e-6, `got ${cost}`)
+    })
+
+    it('bills an over-threshold opus[1m] turn at the 2× longContext premium (#4087)', () => {
+      // 300K input (>200K threshold) + 100K output at the premium tier →
+      // 0.3*30.00 + 0.1*150.00 = 9.00 + 15.00 = 24.00.
+      const cost = computePromptCostUsd(
+        { input_tokens: 300_000, output_tokens: 100_000 },
+        CLAUDE_PRICING_USD_PER_MTOK['claude-opus-4-8[1m]'],
+      )
+      assert.ok(Math.abs(cost - 24.00) < 1e-6, `got ${cost}`)
+    })
+  })
+
+  it('exports the shared constants under their canonical names', () => {
+    assert.equal(DEFAULT_CONTEXT_WINDOW, 200_000)
+    assert.equal(ONE_M_SUFFIX, '[1m]')
+    assert.equal(resolveClaudeContextWindow('claude-opus-4-8'), 1_000_000)
+    assert.equal(claudeDeriveId('claude-opus-4-8'), 'opus-4-8')
+  })
+})


### PR DESCRIPTION
## What & why

Second slice of the **#6201** `models.js` OCP refactor (DeepSeek pricing was the first, [#6365](https://github.com/blamechris/chroxy/pull/6365)). The Claude model roster (`MODEL_METADATA`) plus its derived tables — `CLAUDE_PRICING_USD_PER_MTOK`, the fallback list, `resolvePricingKey`, the context-window heuristic and the `claude-` id strip — move **verbatim** out of `models.js` into a new pure-leaf module `claude-model-catalog.js`.

`models.js` now **consumes** the Claude catalog instead of **owning** it. Adding a Claude-family model is a single-row edit in the catalog, never an edit to the generic registry / overlay / cost engine — the OCP smell the audit named, gone for Claude (it was already gone for every other provider).

## Design note — catalog module, not `SdkSession`

The design comment proposed putting the roster "on `SdkSession`". On inspection the five Claude provider classes (`SdkSession` / `CliSession` / `ClaudeTuiSession` / `ClaudeChannelSession` / `ClaudeByokSession`) are **siblings with no shared base**, and each carried a **byte-identical** `getModelMetadata()` triple. Bolting the roster onto one sibling would force the other four to import from it. A dedicated catalog module is the clean inversion — and it dedupes the five identical triples into one shared `claudeModelMetadata()` helper.

## How it stays behaviour-preserving

- `claude-model-catalog.js` is a **pure leaf** (imports nothing from `models.js` or any session class) → `models.js` importing it is acyclic.
- `models.js` re-exports `DEFAULT_CONTEXT_WINDOW`, `ONE_M_SUFFIX`, `resolveClaudeContextWindow`, `claudeDeriveId` and `FALLBACK_MODELS` under their **original names**, so every existing importer + test is unaffected. The module-level pricing path (`resolveModelPricing`) and the `createModelsRegistry` `#4106` drift-guard read the imported `CLAUDE_PRICING_USD_PER_MTOK` / `resolvePricingKey`.
- The five Claude classes drop their inline `getModelMetadata` bodies → `claudeModelMetadata()`; `getFallbackModels()` returns `CLAUDE_FALLBACK_MODELS`.
- `#4106` drift-warning now points operators at `claude-model-catalog.js`.

Byte-identical frozen rate objects · same `null`-not-`0` cost contract · same `[1m]` longContext premium · no `BaseSession` opt change.

## Tests

- **New** `tests/claude-model-catalog.test.js` — value-pins the relocated accessors (pricing rates + frozen contract, `resolvePricingKey`'s verbatim/short/dated/`[1m]` branches, `claudeModelMetadata`, end-to-end longContext-premium cost). Same blind-spot-C characterization the DeepSeek slice added.
- **453 pass / 0 fail** across `claude-model-catalog` + all 5 `models-*` + `byok-session` + `deepseek-session` + `providers` suites (baseline-identical; the `byok` `0.000375` opus anchor + the metadata-derivation snapshot stay green).
- eslint clean · all 5 custom server lints pass.
- A 4-dimension adversarial behaviour-preservation review (pricing purity / drift-guard / import-graph / delegation-equivalence) found one issue — the stale drift-warning file path — fixed here.

## Out of scope (noted, untouched)

The dashboard keeps its own `model-pricing.ts` Claude table with a "keep in sync with the server" comment — a pre-existing client-side copy, independent of this server move. A cross-package pricing-consistency test is a reasonable follow-up.

Part of #6201.