### PR TITLE
fix(server): guard the set_model Claude-allowlist fallthrough for non-Claude providers (#6201 OCP)

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -4,7 +4,7 @@
  * Handles: set_model, set_permission_mode, permission_response,
  *          query_permission_audit, list_providers, set_permission_rules
  */
-import { ALLOWED_MODEL_IDS, toShortModelId } from '../models.js'
+import { ALLOWED_MODEL_IDS, toShortModelId, isClaudeProvider } from '../models.js'
 import {
   ALLOWED_PERMISSION_MODE_IDS,
   resolveSession,
@@ -191,6 +191,39 @@ function handleSetModel(ws, client, msg, ctx) {
     }
     // Fall through to the legacy global allowlist when the provider hasn't
     // opted in (e.g. claude-sdk, claude-cli, docker-* inherit from it).
+  }
+
+  // #6201 (OCP) — the global ALLOWED_MODEL_IDS below is the Claude-only,
+  // SDK-fed allowlist. A KNOWN non-Claude provider reaches this fallthrough
+  // only when it declares no static getAllowedModels() (getProviderAllowedModels
+  // returned null above); letting it through would silently validate its model
+  // ids against Claude's allowlist — an open-for-extension gap a newly-added
+  // provider could trip purely by existing. Reject such a provider with a clear
+  // error instead. Claude-family providers (claudeFamily === true) and legacy
+  // single-session (entry === null) fall through unchanged; an UNKNOWN provider
+  // fails open, mirroring the modelSwitch capability guard above. No current
+  // provider hits this branch — every shipped non-Claude provider has
+  // getAllowedModels() (so it's handled above) and user-shell is modelSwitch:false
+  // (rejected earlier) — so this is a pure forward-compat guard.
+  if (entry && entry.provider) {
+    let ResolvedProviderClass = null
+    try {
+      ResolvedProviderClass = getProvider(entry.provider)
+    } catch {
+      // Unknown provider — can't classify; fail open to the legacy behaviour.
+    }
+    if (ResolvedProviderClass && !isClaudeProvider(entry.provider, ResolvedProviderClass)) {
+      ;sessionLogger(modelSessionId).warn(`Rejected set_model '${msg.model}' on ${entry.provider} session ${modelSessionId} from ${client.id}: provider declares no model allowlist and is not Claude-family`)
+      sendError(
+        ws,
+        msg?.requestId,
+        'MODEL_NOT_SUPPORTED_BY_PROVIDER',
+        `The active provider '${entry.provider}' does not declare a model allowlist; cannot validate model '${msg.model}'.`,
+        undefined,
+        ctx,
+      )
+      return
+    }
   }
 
   if (ALLOWED_MODEL_IDS.has(msg.model)) {

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
+import { registerProvider } from '../../src/providers.js'
 import { addLogListener, removeLogListener } from '../../src/logger.js'
 import { createSpy, createMockSession, nsCtx } from '../test-helpers.js'
 
@@ -223,6 +224,63 @@ describe('settings-handlers', () => {
         settingsHandlers.set_model(ws, client, { model: 'haiku' }, ctx)
 
         assert.equal(session.setModel.callCount, 1)
+      })
+    })
+
+    // #6201 (OCP) — the legacy global ALLOWED_MODEL_IDS fallthrough is the
+    // Claude-only, SDK-fed allowlist. A KNOWN non-Claude provider only reaches
+    // it when it declares no static getAllowedModels(); letting it through would
+    // silently validate its model ids against Claude's list. No shipped provider
+    // is in that bucket (each non-Claude one has getAllowedModels(); user-shell
+    // is modelSwitch:false), so this guards a FUTURE provider added without an
+    // allowlist.
+    describe('non-Claude fallthrough guard (#6201 OCP)', () => {
+      // Stand-in for a future provider: registered, non-Claude, model-switchable,
+      // and declaring NO static getAllowedModels().
+      class NoAllowlistNonClaudeSession {
+        static claudeFamily = false
+        sendMessage() {}
+        interrupt() {}
+        setModel() {}
+        setPermissionMode() {}
+        start() {}
+        destroy() {}
+      }
+
+      it('rejects a Claude model on a known non-Claude provider that declares no allowlist', () => {
+        registerProvider('test-no-allowlist-nonclaude', NoAllowlistNonClaudeSession)
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Stub', cwd: '/tmp', provider: 'test-no-allowlist-nonclaude' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        // 'sonnet' is a valid Claude id (in ALLOWED_MODEL_IDS); before this guard
+        // it would have been silently accepted on this non-Claude session.
+        settingsHandlers.set_model(ws, client, { model: 'sonnet', requestId: 'r-ocp' }, ctx)
+
+        assert.equal(session.setModel.callCount, 0, 'must not apply a Claude model to a non-Claude provider lacking an allowlist')
+        assert.equal(ws._messages.length, 1)
+        const err = ws._messages[0]
+        assert.equal(err.type, 'error')
+        assert.equal(err.code, 'MODEL_NOT_SUPPORTED_BY_PROVIDER')
+        assert.match(err.message, /test-no-allowlist-nonclaude/)
+        assert.match(err.message, /allowlist/i)
+      })
+
+      it('fails open for an UNKNOWN provider — still accepts a valid Claude id (unchanged forward-compat)', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'Future', cwd: '/tmp', provider: 'totally-unknown-provider-xyz' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+        const ws = makeWs()
+
+        settingsHandlers.set_model(ws, client, { model: 'haiku' }, ctx)
+
+        assert.equal(session.setModel.callCount, 1, 'unknown provider falls through to the global allowlist (fail-open preserved)')
+        assert.equal(session.setModel.lastCall[0], 'haiku')
       })
     })
   })


### PR DESCRIPTION
## What & why

Final slice of the **#6201** `models.js` OCP move (PR1 [#6365](https://github.com/blamechris/chroxy/pull/6365), PR2 [#6366](https://github.com/blamechris/chroxy/pull/6366)). A scoping investigation of the designed "PR4 — make the default registry not hard-wired Claude" found the headline goal — *adding a provider needs zero `models.js` edits* — is **already met** on main (`getRegistryForProvider` dispatches purely by reflection on provider-class statics). The big "rewire `defaultRegistry` to be provider-neutral" idea was **investigated and rejected**: the default registry is the intentional single Claude-wired sink for the live Agent-SDK `supportedModels()` feed; non-Claude providers already bypass it via `getRegistryForProvider()`, so neutralizing it is speculative churn on billing/feed code with no functional gain.

What *did* remain is **one genuine, extension-reachable OCP gap**: the `set_model` handler's fallthrough validates against the Claude-only global `ALLOWED_MODEL_IDS` with **no provider guard**. The fallthrough comment even documents the Claude assumption ("claude-sdk, claude-cli, docker-* inherit from it") but nothing enforces it. A future non-Claude provider that declares no `static getAllowedModels()` would silently inherit Claude's allowlist and accept Claude model ids it can't run.

## The fix

Add an `isClaudeProvider` guard before the global-allowlist check:
- A **known non-Claude** provider reaching the fallthrough → rejected with `MODEL_NOT_SUPPORTED_BY_PROVIDER`.
- **Claude-family** providers and **legacy single-session** (`entry === null`) → fall through unchanged.
- An **unknown** provider → still fails open (mirrors the `modelSwitch` capability guard above).

**Zero impact on shipped providers:** every non-Claude provider already has `getAllowedModels()` (so it's handled earlier) and `user-shell` is `modelSwitch:false` (rejected at the capability gate). The guard fires only for a future registered non-Claude provider added without an allowlist — exactly the OCP contract.

## Tests

New `non-Claude fallthrough guard (#6201 OCP)` cases in `settings-handlers.test.js`:
- a registered stub non-Claude provider lacking `getAllowedModels()` → rejected (`MODEL_NOT_SUPPORTED_BY_PROVIDER`), `setModel` not called;
- an unknown provider → still accepts a valid Claude id (fail-open preserved).

235 pass / 0 fail across settings-handlers + ws-message-handlers + providers + models-per-provider; eslint + custom server lints clean.

## Scope notes

- A separate **`DEFAULT_PROVIDER=non-Claude` boot-cache mismatch** (`server-cli.js` loads only the Claude cache; legacy single-session `ws-history.js` broadcasts Claude models) is real but reachable **only by editing the hardcoded `DEFAULT_PROVIDER` constant**, not by adding a provider — out of OCP scope, tracked as a follow-up issue.
- This completes the `models.js` pricing/context → provider-classes OCP thread of #6201. The epic's other threads (config-resolution cleanup, event-normalizer registry, Tier-3 seams) remain — using "Part of #6201", not "Closes".

Part of #6201.