### PR TITLE
fix(server): scope boot-cache warm + legacy available_models to the active provider (#6368)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -40,7 +40,7 @@ import { registerAnthropicCompatibleProviders } from './anthropic-compatible-ses
 import { registerOpenAiCompatibleProviders } from './openai-compatible-session.js'
 import { getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
-import { loadModelsCache, getModels, watchModelsOverlay } from './models.js'
+import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 // Imported from a dedicated constants module rather than environment-manager.js
 // so we don't eagerly pull in DockerBackend when environments are disabled —
 // environment-manager.js itself remains behind the dynamic import below
@@ -514,12 +514,6 @@ export async function startCliServer(config) {
     process.exit(1)
   }
 
-  // Warm the models registry from disk cache so the picker is populated
-  // before any SDK session fires supportedModels(). Silent miss on first boot.
-  if (loadModelsCache()) {
-    log.info(`Warmed models from cache: ${getModels().map(m => m.id).join(', ')}`)
-  }
-
   // Register optional providers (e.g. docker) based on config
   await registerDockerProvider(config)
 
@@ -538,6 +532,19 @@ export async function startCliServer(config) {
   registerOpenAiCompatibleProviders(config)
 
   const providerType = config.provider || DEFAULT_PROVIDER
+
+  // Warm the models registry from disk cache so the picker is populated before
+  // any SDK session fires supportedModels(). Routed through the ACTIVE provider's
+  // registry (#6368) so a non-Claude DEFAULT_PROVIDER warms its OWN cache
+  // (~/.chroxy/models-cache.<provider>.json) instead of the Claude default. For
+  // Claude providers getRegistryForProvider returns the shared default registry,
+  // so behaviour is byte-identical to the prior module-level loadModelsCache().
+  // Placed after the provider-registration block above so getRegistryForProvider
+  // can resolve docker/config-driven/non-Claude providers. Silent miss on first boot.
+  const bootRegistry = getRegistryForProvider(providerType)
+  if (bootRegistry.loadCache()) {
+    log.info(`Warmed models from cache: ${bootRegistry.getModels().map(m => m.id).join(', ')}`)
+  }
 
   // #4209 / #4246: resolve the effective skip-permissions setting from the
   // merged config (CLI flag > canonical `dangerouslySkipPermissions` >

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -4,7 +4,7 @@
  * Extracted from ws-server.js to separate the post-authentication
  * handshake and history replay concerns from core server orchestration.
  */
-import { toShortModelId, getModels, getDefaultModelId, getRegistryForProvider } from './models.js'
+import { toShortModelId, getRegistryForProvider } from './models.js'
 import { PERMISSION_MODES } from './handler-utils.js'
 import { listProviders, getProvider } from './providers.js'
 import { createLogger } from './logger.js'
@@ -671,7 +671,15 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
         ? toShortModelId(cliSession.model || cliSession.bootedModel)
         : null,
     })
-    send(ws, { type: 'available_models', models: getModels(), defaultModel: getDefaultModelId() })
+    // #6368: scope the legacy single-session model list to the ACTIVE provider's
+    // registry (the cliSession is the default-provider session) instead of the
+    // Claude-only module-level getModels(). billingCanary.defaultProvider is the
+    // resolved `config.provider || DEFAULT_PROVIDER`; for Claude (or a null/absent
+    // canary on old ctx) getRegistryForProvider falls back to the default Claude
+    // registry, so behaviour is unchanged today.
+    const legacyProvider = billingCanary?.defaultProvider || null
+    const legacyRegistry = getRegistryForProvider(legacyProvider)
+    send(ws, { type: 'available_models', models: legacyRegistry.getModels(), defaultModel: legacyRegistry.getDefaultModelId(), provider: legacyProvider })
     send(ws, {
       type: 'permission_mode_changed',
       mode: cliSession.permissionMode || 'approve',

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -184,6 +184,69 @@ describe('_reserveEagerDerivationSlot — per-iteration budget (#5622)', () => {
   })
 })
 
+// #6368: in legacy single-session mode the `available_models` snapshot must
+// reflect the ACTIVE provider's registry (the cliSession is the default-provider
+// session), not the Claude-only module-level getModels(). Pre-fix, a non-Claude
+// DEFAULT_PROVIDER broadcast Claude's roster to the picker. The provider is read
+// from billingCanary.defaultProvider (= resolved `config.provider || DEFAULT_PROVIDER`).
+describe('sendPostAuthInfo — legacy available_models provider scoping (#6368)', () => {
+  // Distinctive non-Claude provider so a Claude-vs-provider mix-up is obvious.
+  class Stub6368Session {
+    static claudeFamily = false
+    static getFallbackModels() {
+      return [{ id: 'stub-7b', label: 'Stub 7B', fullId: 'stub-7b', contextWindow: 8000 }]
+    }
+    static getModelMetadata(id) {
+      return { id, label: id, fullId: id, contextWindow: 8000 }
+    }
+    sendMessage() {}
+    interrupt() {}
+    setModel() {}
+    setPermissionMode() {}
+    start() {}
+    destroy() {}
+  }
+
+  function legacyCtx(overrides = {}) {
+    return makeCtx({
+      sessionManager: null,
+      cliSession: { isReady: false, model: null, bootedModel: null, permissionMode: 'approve', cwd: '/tmp' },
+      ...overrides,
+    })
+  }
+
+  it('scopes the legacy model list to a non-Claude default provider', () => {
+    registerProvider('stub-6368', Stub6368Session)
+    const ctx = legacyCtx({ billingCanary: { defaultProvider: 'stub-6368' } })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const avail = ctx._sends.find((m) => m.type === 'available_models')
+    assert.ok(avail, 'legacy mode must push an available_models snapshot')
+    const ids = avail.models.map((m) => m.id)
+    assert.ok(ids.includes('stub-7b'), `expected the provider's models, got ${JSON.stringify(ids)}`)
+    assert.ok(!ids.some((id) => ['sonnet', 'opus', 'haiku'].includes(id)), `must NOT broadcast Claude models, got ${JSON.stringify(ids)}`)
+    assert.equal(avail.provider, 'stub-6368')
+  })
+
+  it('falls back to the Claude default registry when no billing canary (old ctx / Claude default)', () => {
+    const ctx = legacyCtx() // no billingCanary
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+
+    const avail = ctx._sends.find((m) => m.type === 'available_models')
+    assert.ok(avail, 'legacy mode must push an available_models snapshot')
+    const ids = avail.models.map((m) => m.id)
+    // Default Claude registry roster (FALLBACK_MODELS) — unchanged behaviour.
+    assert.ok(ids.includes('sonnet') && ids.includes('opus') && ids.includes('haiku'), `expected the Claude default roster, got ${JSON.stringify(ids)}`)
+    assert.equal(avail.provider, null)
+  })
+})
+
 // #5622: under a reconnect storm, the eager X25519 fold is capped per event-loop
 // iteration so the synchronous scalar-mults don't starve the keepalive sweep.
 // Connects beyond the cap fall back to the (already-tested) discrete handshake.


### PR DESCRIPTION
## What & why

The module-level model proxies (`loadModelsCache`/`getModels`) in `models.js` delegate to the Claude-only `defaultRegistry`. Two paths used them without provider dispatch, so a non-Claude `DEFAULT_PROVIDER` would boot + broadcast the **Claude** roster instead of its own (surfaced during the #6201 PR4 scoping).

## Fix

- **Boot-cache warm (`server-cli.js`)** — was calling `loadModelsCache()` (Claude default cache) *unconditionally, before providers were even registered*. Moved it after the provider-registration block and routed through `getRegistryForProvider(providerType).loadCache()`, so the active provider warms its own `~/.chroxy/models-cache.<provider>.json`. For Claude providers `getRegistryForProvider` returns the shared default registry → **byte-identical** behaviour. (Bonus: it now can warm config-driven/docker providers, which the pre-registration call never could.)
- **Legacy `available_models` (`ws-history.js`)** — the single-session path used module-level `getModels()` (Claude). Now routes through `getRegistryForProvider(billingCanary?.defaultProvider)` (the resolved `config.provider || DEFAULT_PROVIDER`); a null/absent canary falls back to the Claude default registry, so behaviour is unchanged today. The multi-session path already did this correctly.

## Tests

New `legacy available_models provider scoping (#6368)` cases in `ws-history.test.js`:
- a registered non-Claude default provider → legacy `available_models` carries that provider's models (`stub-7b`), **not** `sonnet`/`opus`/`haiku`, with `provider` tagged;
- a no-billing-canary ctx → still serves the Claude default roster (`provider: null`).

eslint + custom server lints clean; 308 pass across ws-history/providers/models-per-provider/models-factory.

## Scope

**No current production impact** — `DEFAULT_PROVIDER=claude-tui`, so both paths resolve to the (correct) Claude registry today. This is latent-on-config-change. The boot-warm half is a direct `getRegistryForProvider` routing whose per-provider cache loading is already covered by the models-factory/per-provider suites; the testable behaviour-carrying half (legacy broadcast) is pinned here.

Closes #6368.