### PR TITLE
ci(release): broaden the release test gate to match CI coverage (#6316)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
   test:
     name: Test Suite
     needs: validate
+    # #6316: deliberately GitHub-hosted ubuntu-24.04 (x86_64), NOT the self-hosted
+    # ARM64 pool CI uses for same-repo merges — so a release never blocks on
+    # self-hosted-runner availability. CI already validated the merged commit on
+    # ARM64; this re-test is a defense-in-depth consistency gate, and the arch
+    # difference is an accepted tradeoff (release availability > arch parity).
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -64,6 +69,31 @@ jobs:
       - name: Test dashboard
         run: npm test
         working-directory: packages/dashboard
+
+      # #6316: broaden the release gate to match CI's unit-test coverage so a
+      # regression in an otherwise-release-untested package (store-core,
+      # claude-hooks, app units) can't ship. Mirrors ci.yml's store-core-tests /
+      # claude-hooks-tests / app-tests jobs, including the @chroxy/protocol build
+      # (claude-hooks + app depend on it) and the app's xterm bundle.
+      - name: Test store-core
+        run: npm test
+        working-directory: packages/store-core
+
+      - name: Build @chroxy/protocol
+        run: npm run build
+        working-directory: packages/protocol
+
+      - name: Test claude-hooks
+        run: npm test
+        working-directory: packages/claude-hooks
+
+      - name: Generate xterm bundle
+        run: npm run bundle-xterm
+        working-directory: packages/app
+
+      - name: Test app
+        run: npm test
+        working-directory: packages/app
 
   docker:
     name: Docker Image


### PR DESCRIPTION
## What & why

The release pipeline's `test` job (a hard `needs:` gate for `docker` / `desktop-macos` / `desktop-windows` / `github-release`) re-tested a **narrower** suite than CI — server + dashboard tests + app `tsc`, but it **omitted** the Store Core, Claude Hooks, and App unit suites CI gates on. A regression in one of those packages could ship in a release uncaught (#6316).

## Change

- **Broaden the suite** (the audit's confirmed sub-claim): add Store Core / Claude Hooks / App unit tests to the `test` job, mirroring `ci.yml`'s `store-core-tests` / `claude-hooks-tests` / `app-tests` recipes — including the `@chroxy/protocol` build (claude-hooks + app depend on it) and the app's `bundle-xterm`. Failure mode is **fail-safe**: a regression now *blocks* the release, never ships.
- **Document the runner choice** (the audit's second sub-claim): an inline comment records that the release `test` job deliberately stays on GitHub-hosted `ubuntu-24.04` rather than the self-hosted ARM64 pool CI uses — so a release never blocks on self-hosted-runner availability. The arch gap is an accepted defense-in-depth tradeoff (CI already validated the merged commit on ARM64).

## Verification — please read

⚠️ **`release.yml`'s `test` job runs only on a release tag, so this change cannot be exercised on a PR.** The added commands are **identical to `ci.yml`'s green unit-test jobs** (CI-proven), and the YAML parses cleanly, but the *modified release job itself* should be confirmed on the **next release (or a throwaway tag)** before relying on it. I'm leaving the merge decision to you for that reason — happy to merge once you're comfortable, or you can verify-then-merge.

Closes #6316.