### PR TITLE
feat: config.providers.allowAnyModel — serve new gemini/codex/deepseek models without a release (#6378)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -633,7 +633,7 @@ Notes:
 
 - **Default OFF.** Omitting the key keeps the strict, misconfiguration-catching behaviour. Opt in only for providers whose API you track.
 - **A restart is required** — the opt-in is read at startup (it seeds `SessionManager`).
-- **Pricing/context** for an unlisted model is `null` until you add it to the model table or the [`~/.chroxy/models.json` overlay](#) — serving still works; cost just reads `0`.
+- **Pricing/context** for an unlisted model is `null` until you add it to the model table or the `~/.chroxy/models.json` overlay (documentation tracked in [#6376](https://github.com/blamechris/chroxy/issues/6376)) — serving still works; cost just reads `0`.
 - This is the runtime escape hatch for the three release-bound providers; per-provider live discovery (so the list maintains itself) is tracked separately.
 
 ## Selecting a provider

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -609,6 +609,33 @@ npx chroxy start --provider lm-studio-oai
 - Tool-use quality depends entirely on the model behind the endpoint (same caveat as Ollama and the Anthropic-compatible block).
 - Capabilities are identical to `claude-byok` by construction — see the [capability matrix](#capability-matrix) note.
 
+## Serving a new model without a release (`providers.allowAnyModel`)
+
+Most of Chroxy's stack already lets a new model flow through with **no Chroxy release** the moment the provider's API exposes it:
+
+- **Claude** (`claude-sdk`/`-cli`/`-tui`/docker) — the Agent SDK's live `supportedModels()` push refreshes the registry at runtime; a new `claude-*` id is servable immediately (a release is only needed for accurate *pricing*, which otherwise degrades to `cost=null`).
+- **`anthropicCompatible` / `openaiCompatible`** endpoints — add a model via the config `models` array or live [model discovery](#model-discovery).
+- **`ollama`** — any `ollama pull`ed id passes through; the local daemon validates.
+
+The exception is the **static-allowlist subprocess providers — `gemini`, `codex`, `deepseek`** — whose accepted models are a fixed list compiled into the provider class. By default an unlisted id is hard-rejected (so a Claude id sent to a Gemini session can't silently respawn the CLI with a bad `-m` arg). To call a model the provider's API supports but Chroxy's list doesn't carry yet, opt the provider into **unrestricted** validation:
+
+```json
+{
+  "providers": {
+    "allowAnyModel": ["gemini", "codex", "deepseek"]
+  }
+}
+```
+
+Listed providers then behave like `ollama`: an unlisted-but-API-valid model id passes through **verbatim** at both session creation and live `set_model`, and the **upstream API becomes the validator** (an id it doesn't recognize surfaces as the provider's own error on the next turn). The list is **per-provider** — opting in `gemini` does not loosen `codex`.
+
+Notes:
+
+- **Default OFF.** Omitting the key keeps the strict, misconfiguration-catching behaviour. Opt in only for providers whose API you track.
+- **A restart is required** — the opt-in is read at startup (it seeds `SessionManager`).
+- **Pricing/context** for an unlisted model is `null` until you add it to the model table or the [`~/.chroxy/models.json` overlay](#) — serving still works; cost just reads `0`.
+- This is the runtime escape hatch for the three release-bound providers; per-provider live discovery (so the list maintains itself) is tracked separately.
+
 ## Selecting a provider
 
 Precedence (highest first): CLI flag > environment variable > config file > default (`claude-tui`; see #5819).

--- a/packages/server/src/anthropic-compatible-config.js
+++ b/packages/server/src/anthropic-compatible-config.js
@@ -500,10 +500,27 @@ function validateCompatibleProviders(configKey, value, opts = {}) {
  * @param {string[]} warnings - Accumulator the caller logs/returns
  */
 export function validateProvidersConfigBlock(providers, warnings) {
-  const KNOWN_PROVIDER_BLOCK_KEYS = new Set(['anthropicCompatible', 'openaiCompatible'])
+  const KNOWN_PROVIDER_BLOCK_KEYS = new Set(['anthropicCompatible', 'openaiCompatible', 'allowAnyModel'])
   for (const key of Object.keys(providers)) {
     if (!KNOWN_PROVIDER_BLOCK_KEYS.has(key)) {
       warnings.push(`Unknown key 'providers.${key}' (will be ignored)`)
+    }
+  }
+  // #6378: `providers.allowAnyModel` — an array of provider-name strings that
+  // opt out of static model-allowlist validation (serve any API-valid id with
+  // no release). Validate shape here so a malformed value warns rather than
+  // silently disabling the opt-in; bad entries are dropped by
+  // getAllowAnyModelProviders (config.js).
+  if (Object.prototype.hasOwnProperty.call(providers, 'allowAnyModel')) {
+    const value = providers.allowAnyModel
+    if (!Array.isArray(value)) {
+      warnings.push(`Invalid value for 'providers.allowAnyModel': expected an array of provider-name strings, got ${value === null ? 'null' : typeof value}`)
+    } else {
+      for (const name of value) {
+        if (typeof name !== 'string' || name.length === 0) {
+          warnings.push(`Invalid value in 'providers.allowAnyModel': expected non-empty provider-name strings, got ${JSON.stringify(name)}`)
+        }
+      }
     }
   }
   if (Object.prototype.hasOwnProperty.call(providers, 'anthropicCompatible')) {

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -652,6 +652,29 @@ export function isUserShellApprovalRequired(config) {
   return config?.userShell?.requireApproval === true
 }
 
+// #6378: which providers may serve a model id that is NOT in their static
+// allowlist. The static-allowlist subprocess providers (gemini/codex/deepseek)
+// otherwise hard-reject an unlisted-but-API-valid model, forcing a code release
+// just to add one the upstream API already exposes. Opting a provider in here
+// makes it behave like ollama (#5418 PROVIDER_MODELS_UNRESTRICTED): the id
+// passes through verbatim and the upstream API becomes the validator. Returns a
+// Set of provider-name strings; a missing/non-array value → empty Set (the
+// default — OFF, so the misconfig-catching strictness is preserved unless an
+// operator explicitly opts in). Only well-formed string entries are kept.
+export function getAllowAnyModelProviders(config) {
+  const raw = config?.providers?.allowAnyModel
+  if (!Array.isArray(raw)) return new Set()
+  return new Set(raw.filter((name) => typeof name === 'string' && name.length > 0))
+}
+
+// #6378: does `providerName` opt out of static model-allowlist validation?
+// Fail-closed: anything other than an explicit entry in
+// `config.providers.allowAnyModel` returns false.
+export function isProviderModelUnrestricted(config, providerName) {
+  if (!providerName) return false
+  return getAllowAnyModelProviders(config).has(providerName)
+}
+
 function validateDiscordNotificationsBlock(discord, warnings) {
   if (typeof discord !== 'object' || discord === null || Array.isArray(discord)) {
     warnings.push(`Invalid value for 'notifications.discord': expected object, got ${Array.isArray(discord) ? 'array' : typeof discord}`)

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -16,6 +16,7 @@ import {
   isSessionViewer,
 } from '../handler-utils.js'
 import { listProviders, getProvider } from '../providers.js'
+import { isProviderModelUnrestricted } from '../config.js'
 import { createLogger, loggerForSession, sessionLogger } from '../logger.js'
 // Credential + skills handlers were split into sibling modules (audit P2-4);
 // their maps are composed into settingsHandlers below.
@@ -67,8 +68,14 @@ const PROVIDER_MODELS_UNRESTRICTED = Symbol('provider-models-unrestricted')
  * @param {string|undefined} providerName - Session's registered provider name
  * @returns {string[]|typeof PROVIDER_MODELS_UNRESTRICTED|null}
  */
-function getProviderAllowedModels(providerName) {
+function getProviderAllowedModels(providerName, config) {
   if (!providerName) return null
+  // #6378: an operator can opt a static-allowlist provider into unrestricted
+  // model validation via `config.providers.allowAnyModel` — treat it exactly
+  // like ollama (#5418) so an unlisted-but-API-valid id passes through and the
+  // upstream API validates, with no release. Checked before the class lookup so
+  // it applies regardless of what getAllowedModels() returns.
+  if (isProviderModelUnrestricted(config, providerName)) return PROVIDER_MODELS_UNRESTRICTED
   let ProviderClass
   try {
     ProviderClass = getProvider(providerName)
@@ -128,7 +135,7 @@ function handleSetModel(ws, client, msg, ctx) {
   // it to setModel() would respawn the CLI with an unknown `-m` arg and
   // crash opaquely (see issue #2946). Consult the session's provider first.
   if (entry) {
-    const providerAllowed = getProviderAllowedModels(entry.provider)
+    const providerAllowed = getProviderAllowedModels(entry.provider, ctx.services?.config)
     if (providerAllowed === PROVIDER_MODELS_UNRESTRICTED) {
       // #5418: the provider validates nothing statically (ollama — any
       // locally pulled model id is valid; an unknown id surfaces as the

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -46,7 +46,7 @@ import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 // environment-manager.js itself remains behind the dynamic import below
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
-import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled } from './config.js'
+import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders } from './config.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -652,6 +652,10 @@ export async function startCliServer(config) {
     // operator set userShell.enabled:true in the config file. Enforced in
     // SessionManager.createSession so it covers every spawn path.
     userShellEnabled: isUserShellEnabled(config),
+    // #6378: providers opted into unrestricted model validation (serve any
+    // API-valid model id without a release). Empty Set unless the operator set
+    // config.providers.allowAnyModel.
+    allowAnyModelProviders: getAllowAnyModelProviders(config),
     providerType,
     maxToolInput: config.maxToolInput || null,
     transforms: config.transforms || [],

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -236,6 +236,13 @@ export class SessionManager extends EventEmitter {
     // spawn path — WS create, restoreState, and any internal caller — per the
     // #5985 swarm-audit C3 finding.
     userShellEnabled = false,
+    // #6378: provider names that opt OUT of static model-allowlist validation
+    // at create time (config.providers.allowAnyModel) — an unlisted-but-API-
+    // valid model id passes through verbatim instead of throwing
+    // ProviderModelNotSupportedError, so a new model needs no release. A Set of
+    // strings; wired from `getAllowAnyModelProviders(config)` in server-cli.
+    // Default empty → OFF (strict validation, the secure default).
+    allowAnyModelProviders = new Set(),
     // #6276 test seam: inject {isAlive, commOf, kill} for the boot-time
     // orphan-shell reaper so the reap+audit path is exercisable without
     // signalling a real process. Undefined in production → the reaper uses its
@@ -356,6 +363,11 @@ export class SessionManager extends EventEmitter {
     // a truthy non-boolean (`'true'`, `1`) must NOT open the shell gate. Matches
     // isUserShellEnabled()'s strictness; production passes that helper's boolean.
     this._userShellEnabled = userShellEnabled === true
+    // #6378: normalize to a Set so `.has()` is always safe even if a caller
+    // passes undefined/null/array. Default = empty Set (strict validation).
+    this._allowAnyModelProviders = allowAnyModelProviders instanceof Set
+      ? allowAnyModelProviders
+      : new Set(Array.isArray(allowAnyModelProviders) ? allowAnyModelProviders : [])
     this._userShellReapSeams = userShellReapSeams
     this._sweepOrphanWorktrees = !!sweepOrphanWorktrees
     this._providerType = providerType
@@ -854,7 +866,12 @@ export class SessionManager extends EventEmitter {
     if (!this._skipPreflight) {
       runProviderPreflight(PreflightProviderClass)
     }
-    if (resolvedModel && typeof PreflightProviderClass.getAllowedModels === 'function') {
+    // #6378: a provider opted into `config.providers.allowAnyModel` skips static
+    // allowlist validation entirely — the model id passes through verbatim and
+    // the upstream API validates it (mirrors ollama's null-allowlist behaviour),
+    // so a new model the provider's API already exposes needs no release.
+    const modelUnrestricted = this._allowAnyModelProviders.has(resolvedProviderType)
+    if (resolvedModel && !modelUnrestricted && typeof PreflightProviderClass.getAllowedModels === 'function') {
       let providerAllowedModels = null
       try {
         const list = PreflightProviderClass.getAllowedModels()

--- a/packages/server/tests/allow-any-model-optin.test.js
+++ b/packages/server/tests/allow-any-model-optin.test.js
@@ -1,0 +1,212 @@
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { EventEmitter } from 'events'
+import { getAllowAnyModelProviders, isProviderModelUnrestricted } from '../src/config.js'
+import { validateProvidersConfigBlock } from '../src/anthropic-compatible-config.js'
+import { SessionManager, ProviderModelNotSupportedError } from '../src/session-manager.js'
+import { registerProvider } from '../src/providers.js'
+import { settingsHandlers } from '../src/handlers/settings-handlers.js'
+import { createSpy, createMockSession, nsCtx } from './test-helpers.js'
+
+/**
+ * #6378 — `config.providers.allowAnyModel` opt-in. A static-allowlist provider
+ * (gemini/codex/deepseek) listed here serves an unlisted-but-API-valid model id
+ * verbatim (like ollama, #5418) instead of hard-rejecting it — so a new model
+ * the upstream API already exposes needs no chroxy release. Covers the config
+ * helpers, the providers-block validation, and BOTH validation seams
+ * (create-time preflight + set_model).
+ */
+
+// --- A. config helpers --------------------------------------------------------
+
+describe('#6378 config helpers', () => {
+  it('getAllowAnyModelProviders defaults to an empty Set (OFF) for missing/non-array', () => {
+    assert.equal(getAllowAnyModelProviders(undefined).size, 0)
+    assert.equal(getAllowAnyModelProviders({}).size, 0)
+    assert.equal(getAllowAnyModelProviders({ providers: {} }).size, 0)
+    assert.equal(getAllowAnyModelProviders({ providers: { allowAnyModel: 'gemini' } }).size, 0)
+    assert.equal(getAllowAnyModelProviders({ providers: { allowAnyModel: true } }).size, 0)
+  })
+
+  it('getAllowAnyModelProviders parses an array and drops non-string / empty entries', () => {
+    const set = getAllowAnyModelProviders({ providers: { allowAnyModel: ['gemini', 'codex', '', 7, null, 'deepseek'] } })
+    assert.deepEqual([...set].sort(), ['codex', 'deepseek', 'gemini'])
+  })
+
+  it('isProviderModelUnrestricted is fail-closed and matches membership', () => {
+    const config = { providers: { allowAnyModel: ['gemini'] } }
+    assert.equal(isProviderModelUnrestricted(config, 'gemini'), true)
+    assert.equal(isProviderModelUnrestricted(config, 'codex'), false)
+    assert.equal(isProviderModelUnrestricted(config, ''), false)
+    assert.equal(isProviderModelUnrestricted(config, undefined), false)
+    assert.equal(isProviderModelUnrestricted(undefined, 'gemini'), false)
+  })
+})
+
+// --- B. providers-block validation -------------------------------------------
+
+describe('#6378 providers.allowAnyModel validation', () => {
+  it('accepts a well-formed string array with no warnings', () => {
+    const warnings = []
+    validateProvidersConfigBlock({ allowAnyModel: ['gemini', 'codex'] }, warnings)
+    assert.deepEqual(warnings, [])
+  })
+
+  it('warns on a non-array value (and never as a fatal "Invalid type")', () => {
+    const warnings = []
+    validateProvidersConfigBlock({ allowAnyModel: 'gemini' }, warnings)
+    assert.equal(warnings.length, 1)
+    assert.match(warnings[0], /providers\.allowAnyModel/)
+    assert.match(warnings[0], /^Invalid value/)
+  })
+
+  it('warns on a non-string / empty array entry', () => {
+    const warnings = []
+    validateProvidersConfigBlock({ allowAnyModel: ['gemini', 42, ''] }, warnings)
+    assert.equal(warnings.length, 2)
+    assert.ok(warnings.every((w) => /providers\.allowAnyModel/.test(w)))
+  })
+
+  it('does not flag allowAnyModel as an unknown provider-block key', () => {
+    const warnings = []
+    validateProvidersConfigBlock({ allowAnyModel: ['gemini'] }, warnings)
+    assert.ok(!warnings.some((w) => /unknown key/i.test(w)))
+  })
+})
+
+// --- C. create-time seam (SessionManager.createSession preflight) -------------
+
+class Limited6378Session extends EventEmitter {
+  constructor(opts = {}) {
+    super()
+    this.cwd = opts.cwd
+    this.model = opts.model
+    this.isRunning = false
+    this.resumeSessionId = null
+  }
+  static get capabilities() {
+    return { permissions: false, inProcessPermissions: false, modelSwitch: true, permissionModeSwitch: true, planMode: false, resume: false, terminal: false }
+  }
+  static getAllowedModels() { return ['allowed-x'] }
+  start() { this.isRunning = true }
+  destroy() { this.isRunning = false }
+  sendMessage() {}
+  interrupt() {}
+  setModel() { return false }
+  setPermissionMode() { return false }
+}
+registerProvider('test-6378-limited', Limited6378Session)
+
+let _tmp
+function tmpStateFile() {
+  if (!_tmp) _tmp = mkdtempSync(join(tmpdir(), 'sm-6378-'))
+  return join(_tmp, `state-${process.hrtime.bigint()}.json`)
+}
+after(() => { if (_tmp) rmSync(_tmp, { recursive: true, force: true }) })
+
+describe('#6378 create-time seam', () => {
+  it('opted-in provider serves an unlisted model verbatim (no ProviderModelNotSupportedError)', () => {
+    const mgr = new SessionManager({
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      defaultCwd: tmpdir(),
+      allowAnyModelProviders: new Set(['test-6378-limited']),
+    })
+    const id = mgr.createSession({ provider: 'test-6378-limited', model: 'brand-new-2099', skipPersist: true })
+    assert.ok(id)
+    // Passed through verbatim — NOT softened to null, NOT rejected.
+    assert.equal(mgr.getSession(id).session.model, 'brand-new-2099')
+  })
+
+  it('without the opt-in, an unlisted model still hard-rejects (strict default preserved)', () => {
+    const mgr = new SessionManager({
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      defaultCwd: tmpdir(),
+      allowAnyModelProviders: new Set(),
+    })
+    assert.throws(
+      () => mgr.createSession({ provider: 'test-6378-limited', model: 'brand-new-2099', skipPersist: true }),
+      (err) => err instanceof ProviderModelNotSupportedError,
+    )
+    assert.equal(mgr.listSessions().length, 0)
+  })
+
+  it('a listed model is accepted regardless of the opt-in', () => {
+    const mgr = new SessionManager({
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      defaultCwd: tmpdir(),
+      allowAnyModelProviders: new Set(),
+    })
+    const id = mgr.createSession({ provider: 'test-6378-limited', model: 'allowed-x', skipPersist: true })
+    assert.equal(mgr.getSession(id).session.model, 'allowed-x')
+  })
+})
+
+// --- D. set_model seam (handleSetModel) --------------------------------------
+
+function setModelCtx(sessions, config) {
+  const sent = []
+  return nsCtx({
+    send: createSpy((ws, msg) => { sent.push(msg); if (ws?.send && ws.readyState === 1) ws.send(JSON.stringify(msg)) }),
+    broadcastToSession: createSpy(),
+    sessionManager: { getSession: createSpy((id) => sessions.get(id)) },
+    config,
+    _sent: sent,
+  })
+}
+function makeWs() {
+  const messages = []
+  return { readyState: 1, send: createSpy((raw) => messages.push(JSON.parse(raw))), _messages: messages }
+}
+
+describe('#6378 set_model seam', () => {
+  it('rejects an unlisted Gemini model when NOT opted in', () => {
+    const sessions = new Map()
+    const session = createMockSession()
+    sessions.set('s1', { session, name: 'Gem', cwd: '/tmp', provider: 'gemini' })
+    const ctx = setModelCtx(sessions, {})
+    const ws = makeWs()
+    settingsHandlers.set_model(ws, { id: 'c1', activeSessionId: 's1' }, { model: 'gemini-9.9-ultra', requestId: 'r1' }, ctx)
+    assert.equal(session.setModel.callCount, 0)
+    assert.equal(ws._messages[0].code, 'MODEL_NOT_SUPPORTED_BY_PROVIDER')
+  })
+
+  it('passes an unlisted Gemini model through when the provider is opted in', () => {
+    const sessions = new Map()
+    const session = createMockSession()
+    sessions.set('s1', { session, name: 'Gem', cwd: '/tmp', provider: 'gemini' })
+    const ctx = setModelCtx(sessions, { providers: { allowAnyModel: ['gemini'] } })
+    const ws = makeWs()
+    settingsHandlers.set_model(ws, { id: 'c1', activeSessionId: 's1' }, { model: 'gemini-9.9-ultra' }, ctx)
+    assert.equal(session.setModel.callCount, 1)
+    assert.equal(session.setModel.lastCall[0], 'gemini-9.9-ultra')
+    assert.equal(ctx.transport.broadcastToSession.callCount, 1)
+  })
+
+  it('the opt-in is per-provider: opting in gemini does not loosen codex', () => {
+    const sessions = new Map()
+    const session = createMockSession()
+    sessions.set('s1', { session, name: 'Cx', cwd: '/tmp', provider: 'codex' })
+    const ctx = setModelCtx(sessions, { providers: { allowAnyModel: ['gemini'] } })
+    const ws = makeWs()
+    settingsHandlers.set_model(ws, { id: 'c1', activeSessionId: 's1' }, { model: 'gpt-9.9-codex', requestId: 'r2' }, ctx)
+    assert.equal(session.setModel.callCount, 0)
+    assert.equal(ws._messages[0].code, 'MODEL_NOT_SUPPORTED_BY_PROVIDER')
+  })
+
+  it('still rejects an empty model id even when opted in', () => {
+    const sessions = new Map()
+    const session = createMockSession()
+    sessions.set('s1', { session, name: 'Gem', cwd: '/tmp', provider: 'gemini' })
+    const ctx = setModelCtx(sessions, { providers: { allowAnyModel: ['gemini'] } })
+    const ws = makeWs()
+    settingsHandlers.set_model(ws, { id: 'c1', activeSessionId: 's1' }, { model: '   ', requestId: 'r3' }, ctx)
+    assert.equal(session.setModel.callCount, 0)
+    assert.equal(ws._messages[0].code, 'INVALID_MODEL')
+  })
+})


### PR DESCRIPTION
## What & why

The first gap-closer from the **model-serving freshness audit** (2026-06-26). Most of Chroxy's stack already serves a new model with no release the moment the provider API exposes it (Claude via the SDK live push; `anthropic`/`openaiCompatible` via config/discovery; Ollama via pass-through). The exception is the **static-allowlist subprocess providers — `gemini`, `codex`, `deepseek`** — whose accepted models are a fixed list compiled into the provider class, so a new model needs a code release.

This adds a **per-provider opt-in** that makes those providers behave like Ollama (#5418): an unlisted-but-API-valid model id passes through **verbatim** and the **upstream API becomes the validator**.

```json
{ "providers": { "allowAnyModel": ["gemini", "codex", "deepseek"] } }
```

## How — both validation seams, one config source

The audit found exactly two seams that reject an unlisted model; both now consult the same config:

1. **`set_model`** (`settings-handlers.js`) — `getProviderAllowedModels(provider, config)` short-circuits to the existing `PROVIDER_MODELS_UNRESTRICTED` sentinel (the Ollama pass-through branch) when opted in.
2. **Create-time preflight** (`session-manager.js`) — a new `allowAnyModelProviders` Set ctor opt (wired from `getAllowAnyModelProviders(config)` in `server-cli.js`, exactly like `userShellEnabled`) skips the strict allowlist check, so the model passes through instead of throwing `ProviderModelNotSupportedError`.

Config helpers + providers-block validation live in `config.js` / `anthropic-compatible-config.js`.

## Safety / scope

- **Default OFF** (empty Set) — the strict, misconfiguration-catching behaviour (e.g. a Claude id sent to a Gemini session) is preserved unless an operator explicitly opts a provider in.
- **Per-provider** — opting in `gemini` does not loosen `codex` (asserted).
- Restart required (read at startup). Pricing/context for an unlisted model is `null` (serving works, cost reads `0`) — full pricing without a release is tracked in [#6381](https://github.com/blamechris/chroxy/issues/6381).

## Tests

14 new (`tests/allow-any-model-optin.test.js`): config helpers (default-OFF, parse/filter, fail-closed) · providers-block validation (non-array/non-string warn; not an unknown-key) · create-time seam (opted-in serves verbatim / strict default still rejects / listed model unaffected) · set_model seam (reject when off, pass-through when on, per-provider isolation, empty-id still rejected). eslint + 4 custom server lints clean; **282 pass** across affected suites (settings-handlers, session-manager-preflight/create-plan, config, ws-message-handlers, models).

Closes #6378.