### PR TITLE
feat: extend the models.json overlay to non-Claude provider registries (#6377)

### DIFF
--- a/docs/guides/model-overlay.md
+++ b/docs/guides/model-overlay.md
@@ -2,7 +2,7 @@
 
 Add, relabel, or re-price a model **at runtime, with no Chroxy release** — by dropping a small JSON file next to your config. The overlay is Chroxy's lightest "serve a model the build doesn't know about yet" lever: edit the file and the change is picked up live (hot-reload), no restart.
 
-> **Scope today:** the overlay applies to the **default Claude registry** only (`claude-sdk` / `claude-cli` / `claude-tui` / docker-wrapped Claude). Extending it to the other providers' registries (Gemini, Codex, DeepSeek, Ollama, config-driven endpoints) is tracked in [#6377](https://github.com/blamechris/chroxy/issues/6377). For those providers today, see [`providers.allowAnyModel`](../providers.md#serving-a-new-model-without-a-release-providersallowanymodel) (serve any API-valid id) and the config-driven [`models` / `modelDiscovery`](../providers.md#anthropic-compatible-endpoints-config-driven) blocks.
+> **Scope:** by default an entry applies to the **Claude registry** (`claude-sdk` / `claude-cli` / `claude-tui` / docker-wrapped Claude). Since [#6377](https://github.com/blamechris/chroxy/issues/6377) an entry can carry a **`provider` field** to target any other provider's registry instead (Gemini, Codex, DeepSeek, Ollama, config-driven endpoints) — see [Targeting a specific provider](#targeting-a-specific-provider-non-claude). One caveat: **`pricing` in a `provider`-tagged entry is not yet applied** — non-Claude cost flows through the provider class, not the registry, so overlay pricing currently only takes effect for Claude models (labels / context windows / new-model seeding work for every provider).
 
 ## Location
 
@@ -38,7 +38,8 @@ A JSON **object keyed by the model's full id**. Every field except the key is op
 | `shortId` | Optional alias (e.g. `opus-5`) the picker and `set_model` accept. Defaults to a derived short id. |
 | `label` | Optional display name in the picker. Defaults to a humanized id. |
 | `contextWindow` | Optional token window (positive number) for the context meter. |
-| `pricing` | Optional USD-per-MTok rates: `{ input, output, cacheRead, cacheWrite }`. Absent → cost reads `null` (not `$0`). |
+| `pricing` | Optional USD-per-MTok rates: `{ input, output, cacheRead, cacheWrite }`. Absent → cost reads `null` (not `$0`). (Claude registry only — see the scope note.) |
+| `provider` | Optional provider name (e.g. `"gemini"`, `"codex"`, `"deepseek"`) to target that provider's registry instead of Claude's. Omit for Claude models. |
 
 ### What an entry does
 
@@ -46,6 +47,30 @@ A JSON **object keyed by the model's full id**. Every field except the key is op
 - **An existing id** has its `label` / `contextWindow` / `shortId` overridden (overlay wins over the static heuristic).
 - **Pricing precedence:** overlay `pricing` (matched on the resolved full id) > the built-in pricing table > `null`. A missing `pricing` block does *not* shadow the built-in table.
 - **Live SDK values still win** for the context window: when the Agent SDK reports a model, its values are consulted ahead of the overlay row, so the overlay never pins a stale window over fresh SDK data.
+
+### Targeting a specific provider (non-Claude)
+
+Add a `provider` field to route an entry to that provider's own registry instead of Claude's ([#6377](https://github.com/blamechris/chroxy/issues/6377)):
+
+```json
+{
+  "gemini-3.0-pro": {
+    "provider": "gemini",
+    "label": "Gemini 3.0 Pro",
+    "contextWindow": 2000000
+  },
+  "deepseek-v4": {
+    "provider": "deepseek",
+    "label": "DeepSeek V4"
+  }
+}
+```
+
+- A tagged entry seeds/overrides **that** provider's picker + allowlist and is **isolated** — a `gemini` entry never bleeds into Codex or Claude.
+- Routing is by the field's **presence**, not by validating the name; a Claude provider name (or omitting the field) lands on the Claude registry, so just omit `provider` for Claude models.
+- Tagged entries hot-reload like Claude ones — already-running provider sessions pick up the change on the next models fetch.
+- **`pricing` is not yet applied for tagged entries** (non-Claude cost is owned by the provider class, not the registry). Labels, context windows, and new-model seeding work for every provider; per-provider overlay *pricing* is a follow-up.
+- To *serve* (not just list) a new model on a static-allowlist provider, you still want [`providers.allowAnyModel`](../providers.md#serving-a-new-model-without-a-release-providersallowanymodel) — the overlay makes it appear in the picker; `allowAnyModel` lets an unlisted id through validation.
 
 ## Hot-reload
 
@@ -59,7 +84,7 @@ The overlay is watched and re-folded into the registry on change ([#5932](https:
 
 - **Secrets never belong here** (same posture as `config.json`) — the overlay only carries model metadata.
 - `claude-fable-5` is disallowed and **cannot be reintroduced** via the overlay ([#6219](https://github.com/blamechris/chroxy/issues/6219)).
-- Claude-registry-scoped (see the scope note above).
+- Untagged entries are Claude-registry-scoped; use a `provider` field for other providers (see [Targeting a specific provider](#targeting-a-specific-provider-non-claude)). `pricing` overrides apply to Claude models only for now.
 - This complements, not replaces, the SDK's live `supportedModels()` push — a brand-new Claude model the SDK already knows about appears with no overlay at all; the overlay is for getting *ahead* of the build (or fixing a label/price) before the SDK or a release catches up.
 
 ## When to reach for which lever

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -216,7 +216,12 @@ function getDefaultOverlayPath() {
  * @returns {{ ok: boolean, overlay: Map<string, object> }}
  */
 function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
+  // `overlay` is the DEFAULT (Claude) registry overlay — entries with no
+  // `provider` field (or a Claude provider name), for backward compatibility.
+  // `byProvider` (#6377) routes entries that carry `provider: "<name>"` to that
+  // non-Claude provider's own registry: Map<providerName, Map<fullId, entry>>.
   const overlay = new Map()
+  const byProvider = new Map()
   let raw
   try {
     raw = readFileSync(path, 'utf-8')
@@ -227,20 +232,20 @@ function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
     // (EACCES, EBUSY, EISDIR, transient IO) is NOT an intentional clear — return
     // `ok: false` + warn so a hot-reload keeps the LAST-GOOD set instead of
     // silently wiping the operator's overlay on a transient fault (Copilot #5945).
-    if (err?.code === 'ENOENT') return { ok: true, overlay }
+    if (err?.code === 'ENOENT') return { ok: true, overlay, byProvider }
     log.warn(`loadModelsOverlay: cannot read ${path}: ${err?.code || ''} ${err?.message || err} — keeping last-good overlay`.replace(/\s+/g, ' ').trim())
-    return { ok: false, overlay }
+    return { ok: false, overlay, byProvider }
   }
   let parsed
   try {
     parsed = JSON.parse(raw)
   } catch (err) {
     log.warn(`loadModelsOverlay: malformed JSON in ${path}: ${err?.message || err} — ignoring overlay`)
-    return { ok: false, overlay }
+    return { ok: false, overlay, byProvider }
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     log.warn(`loadModelsOverlay: ${path} is not a JSON object keyed by model id — ignoring overlay`)
-    return { ok: false, overlay }
+    return { ok: false, overlay, byProvider }
   }
   for (const [key, value] of Object.entries(parsed)) {
     if (typeof key !== 'string' || key.length === 0) continue
@@ -253,9 +258,24 @@ function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
     if (value.pricing && typeof value.pricing === 'object' && !Array.isArray(value.pricing)) {
       entry.pricing = value.pricing
     }
-    overlay.set(fullId, entry)
+    // #6377: route by an optional `provider` field. Routing is by PRESENCE, not
+    // by classifying the name — this runs at module-init (before providers may
+    // have registered), so a registry lookup here would be unreliable. Absent
+    // `provider` → the default Claude registry overlay (backward-compatible, the
+    // common case). A `provider` name → that provider's own registry overlay,
+    // applied by getRegistryForProvider (which returns the default registry for
+    // Claude names, so tagging a Claude model is a documented no-op — omit it).
+    // The routing field is NOT copied into the entry.
+    const provider = typeof value.provider === 'string' && value.provider.length > 0 ? value.provider : null
+    if (provider) {
+      let providerMap = byProvider.get(provider)
+      if (!providerMap) { providerMap = new Map(); byProvider.set(provider, providerMap) }
+      providerMap.set(fullId, entry)
+    } else {
+      overlay.set(fullId, entry)
+    }
   }
-  return { ok: true, overlay }
+  return { ok: true, overlay, byProvider }
 }
 
 function loadModelsOverlay(path = getDefaultOverlayPath()) {
@@ -268,7 +288,12 @@ function loadModelsOverlay(path = getDefaultOverlayPath()) {
 // applyOverlay), so reassigning it in reloadModelsOverlay() takes effect without
 // a restart. Per-provider registries take their own overlay via the
 // createModelsRegistry hook.
-let defaultOverlay = loadModelsOverlay()
+const _bootOverlayResult = loadModelsOverlayResult()
+let defaultOverlay = _bootOverlayResult.overlay
+// #6377: per-provider overlays — entries tagged `provider: "<name>"` keyed by
+// provider name. Threaded into each non-Claude registry by
+// getRegistryForProvider and re-folded across cached registries on hot-reload.
+let providerOverlays = _bootOverlayResult.byProvider
 
 /**
  * Per-provider cache path resolver (#4413). Non-Claude providers
@@ -1069,6 +1094,15 @@ export function reloadModelsOverlay(path = getDefaultOverlayPath()) {
   }
   defaultOverlay = result.overlay
   defaultRegistry.applyOverlay(result.overlay)
+  // #6377: re-fold the per-provider slices into every ALREADY-BUILT non-Claude
+  // registry. A provider whose registry hasn't been built yet picks up its slice
+  // lazily on first getRegistryForProvider() (which reads providerOverlays), so
+  // only the cached ones need an explicit re-fold here. A provider that lost all
+  // its overlay entries gets an empty Map → its overlay-only rows drop.
+  providerOverlays = result.byProvider
+  for (const [name, registry] of providerRegistryCache) {
+    registry.applyOverlay(providerOverlays.get(name) ?? new Map())
+  }
   return {
     reloaded: true,
     models: defaultRegistry.getModels(),
@@ -1145,9 +1179,15 @@ export function watchModelsOverlay({ path = getDefaultOverlayPath(), onReload, d
  * mutations into sibling tests. Pass a Map to seed a specific overlay, or omit
  * for an empty one.
  */
-export function _resetModelsOverlayForTests(overlay = new Map()) {
+export function _resetModelsOverlayForTests(overlay = new Map(), byProvider = new Map()) {
   defaultOverlay = overlay instanceof Map ? overlay : new Map()
   defaultRegistry.applyOverlay(defaultOverlay)
+  // #6377: reset the per-provider overlays + re-fold any cached provider
+  // registries so a test can't leak provider-overlay state into siblings.
+  providerOverlays = byProvider instanceof Map ? byProvider : new Map()
+  for (const [name, registry] of providerRegistryCache) {
+    registry.applyOverlay(providerOverlays.get(name) ?? new Map())
+  }
 }
 
 /**
@@ -1300,6 +1340,11 @@ export function getRegistryForProvider(providerName) {
     // #4413: provider-scoped cache path. Lazy resolver so tests that mutate
     // `CHROXY_CONFIG_DIR` after registry creation still hit the temp dir.
     cachePath: () => getProviderCachePath(providerName),
+    // #6377: this provider's slice of the user overlay (entries tagged
+    // `provider: "<name>"`) — seeds new models + overrides labels/windows just
+    // like the Claude registry's overlay. Empty Map when the operator supplied
+    // none. Re-folded on hot-reload (reloadModelsOverlay).
+    overlay: providerOverlays.get(providerName) ?? new Map(),
   })
   // #4413: hydrate the registry from its own cache file before serving the
   // first getModels() call. A miss (no file, malformed, all-stale) is a

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -80,7 +80,7 @@ export function getModelPricing(modelId) {
  * yields null — never 0.
  *
  * @param {string} modelId
- * @param {Map} [overlay] - fullId → overlay entry map (see loadModelsOverlay)
+ * @param {Map} [overlay] - fullId → overlay entry map (see loadModelsOverlayResult)
  * @returns {object|null}
  */
 function resolveModelPricing(modelId, overlay) {
@@ -209,11 +209,11 @@ function getDefaultOverlayPath() {
  *   - non-object JSON root → `{ ok: false, overlay: <empty> }`
  *   - valid object        → `{ ok: true,  overlay: <normalised> }`
  *
- * NEVER throws. The boot-time {@link loadModelsOverlay} wraps this and returns
- * just the overlay (treating malformed as empty, exactly as before).
+ * NEVER throws. Boot + reload call this directly to get both the default
+ * (Claude) overlay and the per-provider slices (#6377).
  *
  * @param {string} [path]
- * @returns {{ ok: boolean, overlay: Map<string, object> }}
+ * @returns {{ ok: boolean, overlay: Map<string, object>, byProvider: Map<string, Map<string, object>> }}
  */
 function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
   // `overlay` is the DEFAULT (Claude) registry overlay — entries with no
@@ -222,6 +222,7 @@ function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
   // non-Claude provider's own registry: Map<providerName, Map<fullId, entry>>.
   const overlay = new Map()
   const byProvider = new Map()
+  const pricingIgnoredForTagged = []
   let raw
   try {
     raw = readFileSync(path, 'utf-8')
@@ -271,15 +272,18 @@ function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
       let providerMap = byProvider.get(provider)
       if (!providerMap) { providerMap = new Map(); byProvider.set(provider, providerMap) }
       providerMap.set(fullId, entry)
+      // #6385: a tagged (non-Claude) entry's `pricing` is collected but inert —
+      // non-Claude cost flows through ProviderClass._getPricing, not the
+      // registry. Surface it once so the inertness is observable, not doc-tribal.
+      if (entry.pricing) pricingIgnoredForTagged.push(fullId)
     } else {
       overlay.set(fullId, entry)
     }
   }
+  if (pricingIgnoredForTagged.length > 0) {
+    log.debug(`loadModelsOverlay: ignoring 'pricing' on ${pricingIgnoredForTagged.length} provider-tagged overlay entr${pricingIgnoredForTagged.length === 1 ? 'y' : 'ies'} (${pricingIgnoredForTagged.join(', ')}) — non-Claude pricing is owned by the provider class, not the overlay (#6385)`)
+  }
   return { ok: true, overlay, byProvider }
-}
-
-function loadModelsOverlay(path = getDefaultOverlayPath()) {
-  return loadModelsOverlayResult(path).overlay
 }
 
 // Module-level overlay, loaded at boot and HOT-RELOADABLE (#5932). The default
@@ -455,7 +459,7 @@ function humanizeModelId(id) {
  *   provider-scoped path (e.g. `~/.chroxy/models-cache.codex.json`) so the
  *   default Claude cache stays untouched by per-provider learn-loops (#4413).
  * @param {Map} [hooks.overlay] - User-extensible overlay (fullId → entry; see
- *   loadModelsOverlay). Overlay entries SEED the registry like a
+ *   loadModelsOverlayResult). Overlay entries SEED the registry like a
  *   FALLBACK_MODELS row, so a brand-new model id appears with no code change
  *   and survives loadCache()'s family prune. The default Claude registry gets
  *   the module-level `defaultOverlay`; pass `new Map()` to opt out.

--- a/packages/server/tests/models-overlay-per-provider.test.js
+++ b/packages/server/tests/models-overlay-per-provider.test.js
@@ -1,0 +1,113 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+// Importing providers.js registers the real provider classes so
+// getRegistryForProvider('gemini'|'codex') resolves (mirrors models-per-provider.test.js).
+import '../src/providers.js'
+import {
+  reloadModelsOverlay,
+  getRegistryForProvider,
+  _resetModelsOverlayForTests,
+  _resetProviderRegistryCacheForTests,
+} from '../src/models.js'
+
+/**
+ * #6377 — the ~/.chroxy/models.json overlay now reaches NON-Claude provider
+ * registries via a per-entry `provider` field. An entry tagged
+ * `provider: "gemini"` seeds/overrides the Gemini registry (picker + allowlist),
+ * not the default Claude one; an untagged entry stays on the Claude registry
+ * (backward-compatible). Hot-reload re-folds already-built provider registries.
+ *
+ * Seeds via a temp overlay file + reloadModelsOverlay(path); restores the global
+ * singletons in afterEach so state never leaks into sibling suites.
+ */
+
+let dir
+function overlayPath() {
+  if (!dir) dir = mkdtempSync(join(tmpdir(), 'models-overlay-pp-'))
+  return join(dir, 'models.json')
+}
+function writeOverlay(obj) {
+  const path = overlayPath()
+  writeFileSync(path, JSON.stringify(obj))
+  return path
+}
+
+beforeEach(() => {
+  _resetProviderRegistryCacheForTests()
+  _resetModelsOverlayForTests()
+})
+afterEach(() => {
+  _resetProviderRegistryCacheForTests()
+  _resetModelsOverlayForTests()
+  if (dir) { rmSync(dir, { recursive: true, force: true }); dir = null }
+})
+
+const FAKE = 'gemini-test-9-ultra'
+
+describe('#6377 per-provider model overlay', () => {
+  it('a provider-tagged entry seeds that provider registry (picker + allowlist), not the Claude one', () => {
+    const path = writeOverlay({
+      [FAKE]: { provider: 'gemini', label: 'Gemini Test 9 Ultra', contextWindow: 1000000 },
+    })
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+
+    const gem = getRegistryForProvider('gemini')
+    const row = gem.getModels().find((m) => m.fullId === FAKE)
+    assert.ok(row, 'overlay model appears in the Gemini picker')
+    assert.equal(row.label, 'Gemini Test 9 Ultra')
+    assert.equal(row.contextWindow, 1000000)
+    assert.ok(gem.getAllowedModelIds().has(FAKE), 'overlay model lands in the Gemini allowlist')
+
+    // It must NOT leak into the default Claude registry.
+    const claude = getRegistryForProvider('claude-sdk')
+    assert.ok(!claude.getModels().some((m) => m.fullId === FAKE), 'tagged entry must not reach the Claude registry')
+    assert.ok(!claude.getAllowedModelIds().has(FAKE))
+  })
+
+  it('an UNtagged entry stays on the Claude default registry (backward compatible)', () => {
+    const path = writeOverlay({ 'claude-untagged-test-9': { shortId: 'ut9', label: 'Untagged Nine' } })
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+
+    const claude = getRegistryForProvider('claude-sdk')
+    assert.ok(claude.getModels().some((m) => m.fullId === 'claude-untagged-test-9'), 'untagged entry seeds the Claude registry')
+
+    const gem = getRegistryForProvider('gemini')
+    assert.ok(!gem.getModels().some((m) => m.fullId === 'claude-untagged-test-9'), 'untagged entry must not reach the Gemini registry')
+  })
+
+  it('hot-reload re-folds an ALREADY-BUILT provider registry', () => {
+    // Build the Gemini registry BEFORE the overlay exists (cached, empty slice).
+    const gem = getRegistryForProvider('gemini')
+    assert.ok(!gem.getModels().some((m) => m.fullId === FAKE))
+
+    const path = writeOverlay({ [FAKE]: { provider: 'gemini', label: 'Gemini Test 9 Ultra' } })
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+
+    // Same cached instance now carries the overlay row (re-folded in place).
+    assert.equal(getRegistryForProvider('gemini'), gem, 'same cached registry instance')
+    assert.ok(gem.getModels().some((m) => m.fullId === FAKE), 're-folded into the live registry without a rebuild')
+    assert.ok(gem.getAllowedModelIds().has(FAKE))
+  })
+
+  it('a reload that drops the entry removes the overlay-only row from the provider registry', () => {
+    const path = writeOverlay({ [FAKE]: { provider: 'gemini', label: 'X' } })
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+    const gem = getRegistryForProvider('gemini')
+    assert.ok(gem.getModels().some((m) => m.fullId === FAKE))
+
+    writeOverlay({}) // operator removed the entry
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+    assert.ok(!gem.getModels().some((m) => m.fullId === FAKE), 'overlay-only row drops when the entry is removed')
+    assert.ok(!gem.getAllowedModelIds().has(FAKE))
+  })
+
+  it('per-provider isolation: a gemini-tagged entry does not reach the codex registry', () => {
+    const path = writeOverlay({ [FAKE]: { provider: 'gemini', label: 'G' } })
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+    const codex = getRegistryForProvider('codex')
+    assert.ok(!codex.getModels().some((m) => m.fullId === FAKE), 'gemini overlay must not bleed into codex')
+  })
+})


### PR DESCRIPTION
## What & why

Third item from the **model-serving freshness audit**. The hot-reloadable `~/.chroxy/models.json` overlay — the lever for adding/relabeling a model at runtime with no release — previously reached **only the default Claude registry** (`getRegistryForProvider` built non-Claude registries with no overlay). So an operator couldn't surface or relabel a Gemini/Codex/DeepSeek/Ollama model without a code release.

This routes overlay entries to the right registry via an optional per-entry **`provider`** field.

## How

```json
{
  "gemini-3.0-pro": { "provider": "gemini", "label": "Gemini 3.0 Pro", "contextWindow": 2000000 }
}
```

- **`loadModelsOverlayResult`** now returns `{ ok, overlay, byProvider }`. An entry with a `provider` field routes to `byProvider[name]`; an untagged entry stays in the default (Claude) overlay — **fully backward-compatible** (existing flat files unchanged).
- **Routing is by field _presence_, not name classification.** The overlay loads at module-init, before providers may have registered, so an `isClaudeProvider()` lookup there would be unreliable — presence routing is deterministic and boot-safe. (A Claude provider name, or omitting the field, lands on the Claude registry.)
- **`getRegistryForProvider`** threads `providerOverlays.get(name)` into each non-Claude registry — the model seeds the picker, resolves both ways, and **lands in the allowlist**, exactly like the Claude registry already does.
- **Hot-reload** (`reloadModelsOverlay`) re-folds the per-provider slices into already-built cached registries; `_resetModelsOverlayForTests` resets the provider state too.

## Scope note (deliberate)

**`pricing` for a tagged entry is NOT applied here.** Non-Claude cost flows through `ProviderClass._getPricing`, a separate seam from the registry — wiring overlay pricing into every provider class is its own change. Labels, context windows, and new-model seeding work for **every** provider; per-provider overlay *pricing* is a documented follow-up. (This PR is faithful to the issue title — "extend the overlay to non-Claude provider **registries**.")

## Tests

5 new (`tests/models-overlay-per-provider.test.js`): tagged entry seeds the provider registry (picker + allowlist) and does NOT leak to Claude · untagged entry stays on Claude · **hot-reload re-folds an already-built registry in place** · a dropped entry removes the overlay-only row · gemini↔codex isolation. eslint + 4 custom lints clean; **198 pass** across all models suites (no regression — existing overlay/per-provider behaviour intact). Docs: `model-overlay.md` gains the `provider` field + a "Targeting a specific provider" section.

Closes #6377.