### PR TITLE
feat: per-provider overlay pricing — re-price non-Claude models with no release (#6381)

### DIFF
--- a/docs/guides/model-overlay.md
+++ b/docs/guides/model-overlay.md
@@ -2,7 +2,7 @@
 
 Add, relabel, or re-price a model **at runtime, with no Chroxy release** — by dropping a small JSON file next to your config. The overlay is Chroxy's lightest "serve a model the build doesn't know about yet" lever: edit the file and the change is picked up live (hot-reload), no restart.
 
-> **Scope:** by default an entry applies to the **Claude registry** (`claude-sdk` / `claude-cli` / `claude-tui` / docker-wrapped Claude). Since [#6377](https://github.com/blamechris/chroxy/issues/6377) an entry can carry a **`provider` field** to target any other provider's registry instead (Gemini, Codex, DeepSeek, Ollama, config-driven endpoints) — see [Targeting a specific provider](#targeting-a-specific-provider-non-claude). One caveat: **`pricing` in a `provider`-tagged entry is not yet applied** — non-Claude cost flows through the provider class, not the registry, so overlay pricing currently only takes effect for Claude models (labels / context windows / new-model seeding work for every provider).
+> **Scope:** by default an entry applies to the **Claude registry** (`claude-sdk` / `claude-cli` / `claude-tui` / docker-wrapped Claude). Since [#6377](https://github.com/blamechris/chroxy/issues/6377) an entry can carry a **`provider` field** to target any other provider's registry instead (Gemini, Codex, DeepSeek, Ollama, config-driven endpoints) — see [Targeting a specific provider](#targeting-a-specific-provider-non-claude). **Labels, context windows, and new-model seeding work for every provider.** Overlay **`pricing`** is honored wherever the provider reports per-token cost — Claude (always) and **DeepSeek** ([#6381](https://github.com/blamechris/chroxy/issues/6381)); Ollama is intentionally `$0`, config-driven endpoints price via their own `pricing` / discovery, and Gemini/Codex don't report token cost so pricing is moot there.
 
 ## Location
 
@@ -38,7 +38,7 @@ A JSON **object keyed by the model's full id**. Every field except the key is op
 | `shortId` | Optional alias (e.g. `opus-5`) the picker and `set_model` accept. Defaults to a derived short id. |
 | `label` | Optional display name in the picker. Defaults to a humanized id. |
 | `contextWindow` | Optional token window (positive number) for the context meter. |
-| `pricing` | Optional USD-per-MTok rates: `{ input, output, cacheRead, cacheWrite }`. Absent → cost reads `null` (not `$0`). (Claude registry only — see the scope note.) |
+| `pricing` | Optional USD-per-MTok rates: `{ input, output, cacheRead, cacheWrite }`. Absent → cost reads `null` (not `$0`). Honored for Claude and DeepSeek — see the scope note. |
 | `provider` | Optional provider name (e.g. `"gemini"`, `"codex"`, `"deepseek"`) to target that provider's registry instead of Claude's. Omit for Claude models. |
 
 ### What an entry does
@@ -69,7 +69,7 @@ Add a `provider` field to route an entry to that provider's own registry instead
 - A tagged entry seeds/overrides **that** provider's picker + allowlist and is **isolated** — a `gemini` entry never bleeds into Codex or Claude.
 - Routing is by the field's **presence**, not by validating the name; a Claude provider name (or omitting the field) lands on the Claude registry, so just omit `provider` for Claude models.
 - Tagged entries hot-reload like Claude ones — already-running provider sessions pick up the change on the next models fetch.
-- **`pricing` is not yet applied for tagged entries** (non-Claude cost is owned by the provider class, not the registry). Labels, context windows, and new-model seeding work for every provider; per-provider overlay *pricing* is a follow-up.
+- **`pricing` applies wherever the provider reports per-token cost** — e.g. a `provider: "deepseek"` entry re-prices a DeepSeek model with no release ([#6381](https://github.com/blamechris/chroxy/issues/6381)), overriding the shipped static rate. Ollama is `$0` by design; Gemini/Codex don't report token cost; config-driven endpoints carry their own `pricing`.
 - To *serve* (not just list) a new model on a static-allowlist provider, you still want [`providers.allowAnyModel`](../providers.md#serving-a-new-model-without-a-release-providersallowanymodel) — the overlay makes it appear in the picker; `allowAnyModel` lets an unlisted id through validation.
 
 ## Hot-reload
@@ -84,7 +84,7 @@ The overlay is watched and re-folded into the registry on change ([#5932](https:
 
 - **Secrets never belong here** (same posture as `config.json`) — the overlay only carries model metadata.
 - `claude-fable-5` is disallowed and **cannot be reintroduced** via the overlay ([#6219](https://github.com/blamechris/chroxy/issues/6219)).
-- Untagged entries are Claude-registry-scoped; use a `provider` field for other providers (see [Targeting a specific provider](#targeting-a-specific-provider-non-claude)). `pricing` overrides apply to Claude models only for now.
+- Untagged entries are Claude-registry-scoped; use a `provider` field for other providers (see [Targeting a specific provider](#targeting-a-specific-provider-non-claude)). `pricing` overrides apply to Claude and DeepSeek (the providers that report per-token cost).
 - This complements, not replaces, the SDK's live `supportedModels()` push — a brand-new Claude model the SDK already knows about appears with no overlay at all; the overlay is for getting *ahead* of the build (or fixing a label/price) before the SDK or a release catches up.
 
 ## When to reach for which lever

--- a/packages/server/src/deepseek-session.js
+++ b/packages/server/src/deepseek-session.js
@@ -22,6 +22,7 @@
 
 import Anthropic from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from './byok-session.js'
+import { getRegistryForProvider } from './models.js'
 import { resolveDeepSeekApiKey } from './deepseek-credentials.js'
 import { BILLING_CLASSES } from './billing-class.js'
 
@@ -181,6 +182,11 @@ export class DeepSeekSession extends ClaudeByokSession {
 
   _getPricing(model) {
     if (typeof model !== 'string' || model.length === 0) return null
+    // #6381: a `provider: "deepseek"` entry in ~/.chroxy/models.json can re-price
+    // a model with no release (e.g. when DeepSeek changes published rates). The
+    // operator overlay wins over the shipped static table; absent → static.
+    const fromOverlay = getRegistryForProvider(this._provider).getOverlayPricing(model)
+    if (fromOverlay) return fromOverlay
     return DEEPSEEK_PRICING_USD_PER_MTOK[model] || null
   }
 }

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -83,19 +83,27 @@ export function getModelPricing(modelId) {
  * @param {Map} [overlay] - fullId → overlay entry map (see loadModelsOverlayResult)
  * @returns {object|null}
  */
-function resolveModelPricing(modelId, overlay) {
-  if (overlay && overlay.size > 0 && typeof modelId === 'string' && modelId.length > 0) {
-    // Try the id verbatim, then the registry-resolved full id, against the
-    // overlay's fullId-keyed map. Short ids ('opus') resolve via the default
-    // registry so an operator can key the overlay on either form.
-    const candidates = new Set([modelId])
-    const resolvedFull = defaultRegistry.resolveModelId(modelId)
-    if (typeof resolvedFull === 'string' && resolvedFull.length > 0) candidates.add(resolvedFull)
-    for (const candidate of candidates) {
-      const entry = overlay.get(candidate)
-      if (entry && entry.pricing) return entry.pricing
-    }
+// #6381 — pure overlay-pricing lookup against a fullId-keyed overlay map. Tries
+// the id verbatim, then the `resolveId`-resolved full id (so an operator can key
+// the overlay on a short alias OR a full id). Returns the matched entry's pricing
+// or null. Reused by resolveModelPricing (Claude path, with the static fallback)
+// and the per-provider registry's getOverlayPricing (overlay only) so non-Claude
+// providers can be re-priced via the overlay with no release.
+function lookupOverlayPricing(modelId, overlay, resolveId) {
+  if (!(overlay instanceof Map) || overlay.size === 0 || typeof modelId !== 'string' || modelId.length === 0) return null
+  const candidates = new Set([modelId])
+  const resolved = typeof resolveId === 'function' ? resolveId(modelId) : null
+  if (typeof resolved === 'string' && resolved.length > 0) candidates.add(resolved)
+  for (const candidate of candidates) {
+    const entry = overlay.get(candidate)
+    if (entry && entry.pricing) return entry.pricing
   }
+  return null
+}
+
+function resolveModelPricing(modelId, overlay) {
+  const fromOverlay = lookupOverlayPricing(modelId, overlay, (id) => defaultRegistry.resolveModelId(id))
+  if (fromOverlay) return fromOverlay
   const key = resolvePricingKey(modelId)
   // Coalesce a resolved-but-absent key (e.g. a short alias that resolves to a
   // full id with no pricing row because we don't ship unverified pricing) to null, not
@@ -222,7 +230,6 @@ function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
   // non-Claude provider's own registry: Map<providerName, Map<fullId, entry>>.
   const overlay = new Map()
   const byProvider = new Map()
-  const pricingIgnoredForTagged = []
   let raw
   try {
     raw = readFileSync(path, 'utf-8')
@@ -272,16 +279,9 @@ function loadModelsOverlayResult(path = getDefaultOverlayPath()) {
       let providerMap = byProvider.get(provider)
       if (!providerMap) { providerMap = new Map(); byProvider.set(provider, providerMap) }
       providerMap.set(fullId, entry)
-      // #6385: a tagged (non-Claude) entry's `pricing` is collected but inert —
-      // non-Claude cost flows through ProviderClass._getPricing, not the
-      // registry. Surface it once so the inertness is observable, not doc-tribal.
-      if (entry.pricing) pricingIgnoredForTagged.push(fullId)
     } else {
       overlay.set(fullId, entry)
     }
-  }
-  if (pricingIgnoredForTagged.length > 0) {
-    log.debug(`loadModelsOverlay: ignoring 'pricing' on ${pricingIgnoredForTagged.length} provider-tagged overlay entr${pricingIgnoredForTagged.length === 1 ? 'y' : 'ies'} (${pricingIgnoredForTagged.join(', ')}) — non-Claude pricing is owned by the provider class, not the overlay (#6385)`)
   }
   return { ok: true, overlay, byProvider }
 }
@@ -473,6 +473,10 @@ export function createModelsRegistry(hooks = {}) {
   const cachePathFn = typeof hooks.cachePath === 'function' ? hooks.cachePath : getDefaultCachePath
   const getModelMetadataFn = typeof hooks.getModelMetadata === 'function' ? hooks.getModelMetadata : null
   const overlay = hooks.overlay instanceof Map ? hooks.overlay : new Map()
+  // #6381: the CURRENT overlay (swapped by applyOverlay on hot-reload), retained
+  // so getOverlayPricing() reflects live edits. The fallback rows don't carry
+  // pricing, so pricing is read from this map directly.
+  let currentOverlay = overlay
 
   // Fold overlay entries into the fallback set. An overlay entry for a fullId
   // NOT already in the base fallbacks seeds the registry exactly like a
@@ -672,6 +676,7 @@ export function createModelsRegistry(hooks = {}) {
      */
     applyOverlay(newOverlay) {
       const map = newOverlay instanceof Map ? newOverlay : new Map()
+      currentOverlay = map // #6381: keep getOverlayPricing in sync with reloads
       fallbackModels = computeFallbackModels(map)
       if (lastSdkModels) {
         registry.updateModels(lastSdkModels)
@@ -914,6 +919,14 @@ export function createModelsRegistry(hooks = {}) {
 
     resolveModelId(model) {
       return toFullIdMap.get(model) || model
+    },
+
+    // #6381: this registry's overlay pricing for a model id (or null). Lets a
+    // non-Claude provider honor `pricing` from a `provider`-tagged ~/.chroxy/
+    // models.json entry — re-pricing a model with no release. Overlay only; the
+    // provider's own static table is the caller's fallback.
+    getOverlayPricing(model) {
+      return lookupOverlayPricing(model, currentOverlay, (id) => toFullIdMap.get(id) || id)
     },
 
     toShortModelId(model) {

--- a/packages/server/tests/deepseek-overlay-pricing.test.js
+++ b/packages/server/tests/deepseek-overlay-pricing.test.js
@@ -1,0 +1,79 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import '../src/providers.js'
+import {
+  reloadModelsOverlay,
+  getRegistryForProvider,
+  _resetModelsOverlayForTests,
+  _resetProviderRegistryCacheForTests,
+} from '../src/models.js'
+import { DeepSeekSession } from '../src/deepseek-session.js'
+
+/**
+ * #6381 — a `provider`-tagged ~/.chroxy/models.json entry can re-price a
+ * non-Claude model with no release. DeepSeek is the built-in beneficiary: its
+ * `_getPricing` consults the registry's overlay pricing (via getOverlayPricing)
+ * before the shipped static DEEPSEEK_PRICING table.
+ */
+
+let dir
+function writeOverlay(obj) {
+  if (!dir) dir = mkdtempSync(join(tmpdir(), 'ds-overlay-price-'))
+  const path = join(dir, 'models.json')
+  writeFileSync(path, JSON.stringify(obj))
+  return path
+}
+
+beforeEach(() => {
+  _resetProviderRegistryCacheForTests()
+  _resetModelsOverlayForTests()
+})
+afterEach(() => {
+  _resetProviderRegistryCacheForTests()
+  _resetModelsOverlayForTests()
+  if (dir) { rmSync(dir, { recursive: true, force: true }); dir = null }
+})
+
+const OVERLAY_PRICE = { input: 99, output: 199, cacheRead: 9, cacheWrite: 19 }
+
+describe('#6381 DeepSeek overlay pricing', () => {
+  it('registry.getOverlayPricing is null with no overlay, and the entry pricing once seeded', () => {
+    assert.equal(getRegistryForProvider('deepseek').getOverlayPricing('deepseek-chat'), null)
+
+    const path = writeOverlay({ 'deepseek-chat': { provider: 'deepseek', pricing: OVERLAY_PRICE } })
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+
+    assert.deepEqual(getRegistryForProvider('deepseek').getOverlayPricing('deepseek-chat'), OVERLAY_PRICE)
+  })
+
+  it('DeepSeekSession._getPricing returns the SHIPPED static rate with no overlay', () => {
+    const session = new DeepSeekSession({ cwd: '/tmp' })
+    const priced = session._getPricing('deepseek-chat')
+    assert.ok(priced && typeof priced === 'object', 'deepseek-chat has a shipped static price')
+    assert.notDeepEqual(priced, OVERLAY_PRICE)
+  })
+
+  it('an overlay entry OVERRIDES the static rate (re-price with no release)', () => {
+    const path = writeOverlay({ 'deepseek-chat': { provider: 'deepseek', pricing: OVERLAY_PRICE } })
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+
+    const session = new DeepSeekSession({ cwd: '/tmp' })
+    assert.deepEqual(session._getPricing('deepseek-chat'), OVERLAY_PRICE, 'overlay pricing wins over the static table')
+  })
+
+  it('a Claude-default (untagged) overlay entry does NOT affect DeepSeek pricing', () => {
+    const path = writeOverlay({ 'deepseek-chat': { pricing: OVERLAY_PRICE } }) // no provider → Claude registry
+    assert.equal(reloadModelsOverlay(path).reloaded, true)
+
+    const session = new DeepSeekSession({ cwd: '/tmp' })
+    assert.notDeepEqual(session._getPricing('deepseek-chat'), OVERLAY_PRICE, 'untagged entry must not reach DeepSeek')
+  })
+
+  it('a model with neither overlay nor static pricing returns null (no fabrication)', () => {
+    const session = new DeepSeekSession({ cwd: '/tmp' })
+    assert.equal(session._getPricing('deepseek-nonexistent-9'), null)
+  })
+})


### PR DESCRIPTION
## What & why

Completes the loose end from [#6377](https://github.com/blamechris/chroxy/pull/6384): a `provider`-tagged `~/.chroxy/models.json` entry's **`pricing`** block was collected but **inert** — non-Claude cost flows through `ProviderClass._getPricing`, not the registry. This wires overlay pricing for **DeepSeek**, the built-in provider with a static pricing table an operator may need to correct (e.g. when DeepSeek changes published rates) **without a release**. Addresses the overlay-pricing dimension of [#6381](https://github.com/blamechris/chroxy/issues/6381).

## How

- **`models.js`** — extracted a pure `lookupOverlayPricing(modelId, overlay, resolveId)` (the overlay-pricing lookup `resolveModelPricing` already did for Claude, now shared). Each registry **retains its current overlay** (swapped by `applyOverlay` on hot-reload) and exposes **`getOverlayPricing(model)`** — overlay-only pricing for *that* registry, no static fallback.
- **`deepseek-session.js`** — `_getPricing(model)` now consults `getRegistryForProvider(this._provider).getOverlayPricing(model)` first, then the shipped `DEEPSEEK_PRICING` table. (`this._provider === 'deepseek'`.)
- Removed the #6377 `pricing ignored` `log.debug` — pricing now **actually applies** for the provider that matters (supersedes the #6385 observability signal).

## Scope

DeepSeek is the deliberate target. The other non-Claude providers don't need it: **Ollama** is `$0` by design, **config-driven** anthropic/openai-compatible endpoints already price via their `pricing`/discovery, and **Gemini/Codex** drive CLIs that don't report per-token cost (no `_getPricing`). The `getOverlayPricing` mechanism is generic, so any future provider can opt in with a one-line `_getPricing` change.

## Tests

5 new (`tests/deepseek-overlay-pricing.test.js`): registry `getOverlayPricing` null→entry once seeded · DeepSeek `_getPricing` returns the **shipped static** rate with no overlay · an overlay entry **overrides** the static rate · an **untagged** (Claude) entry does NOT reach DeepSeek · unknown model → `null` (no fabrication). The shared `resolveModelPricing` refactor is covered by the existing pricing/models suites. eslint + custom lints clean; **136 pass** across pricing/models/deepseek/overlay suites (no regression).

Relates to #6381.