### PR TITLE
fix(protocol): declare provider on ServerAvailableModelsSchema (#6370)

### DIFF
--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -111,6 +111,7 @@ export declare const ServerAvailableModelsSchema: z.ZodObject<{
     type: z.ZodLiteral<"available_models">;
     models: z.ZodOptional<z.ZodArray<z.ZodUnknown>>;
     defaultModel: z.ZodOptional<z.ZodString>;
+    provider: z.ZodOptional<z.ZodNullable<z.ZodString>>;
 }, z.core.$strip>;
 export declare const ServerPermissionModeChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"permission_mode_changed">;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -185,12 +185,13 @@ export const ServerAvailableModelsSchema = z.object({
     type: z.literal('available_models'),
     models: z.array(z.unknown()).optional(),
     defaultModel: z.string().optional(),
-    // #6370: four senders tag the roster with the provider it came from
-    // (ws-history multi + legacy single, server-cli overlay re-broadcast,
-    // ws-forwarding) and the wire contract documents it — declare it so the
-    // schema matches. Nullable: some senders pass an explicit `provider: null`
-    // for the default/unscoped roster. Non-breaking — the handler reads models/
-    // defaultModel off the envelope and ignored the undeclared key before.
+    // #6370: every `available_models` sender tags the roster with the provider it
+    // came from (ws-history multi/legacy/refresh/switch, server-cli overlay
+    // re-broadcast, ws-forwarding, session-handlers) and the wire contract
+    // documents it — declare it so the schema matches. Nullable: several senders
+    // pass an explicit `provider: null` for the default/unscoped roster.
+    // Non-breaking — the handler reads models/defaultModel off the envelope and
+    // ignored the undeclared key before.
     provider: z.string().nullable().optional(),
 });
 export const ServerPermissionModeChangedSchema = z.object({

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -185,6 +185,13 @@ export const ServerAvailableModelsSchema = z.object({
     type: z.literal('available_models'),
     models: z.array(z.unknown()).optional(),
     defaultModel: z.string().optional(),
+    // #6370: four senders tag the roster with the provider it came from
+    // (ws-history multi + legacy single, server-cli overlay re-broadcast,
+    // ws-forwarding) and the wire contract documents it — declare it so the
+    // schema matches. Nullable: some senders pass an explicit `provider: null`
+    // for the default/unscoped roster. Non-breaking — the handler reads models/
+    // defaultModel off the envelope and ignored the undeclared key before.
+    provider: z.string().nullable().optional(),
 });
 export const ServerPermissionModeChangedSchema = z.object({
     type: z.literal('permission_mode_changed'),

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -204,12 +204,13 @@ export const ServerAvailableModelsSchema = z.object({
   type: z.literal('available_models'),
   models: z.array(z.unknown()).optional(),
   defaultModel: z.string().optional(),
-  // #6370: four senders tag the roster with the provider it came from
-  // (ws-history multi + legacy single, server-cli overlay re-broadcast,
-  // ws-forwarding) and the wire contract documents it — declare it so the
-  // schema matches. Nullable: some senders pass an explicit `provider: null`
-  // for the default/unscoped roster. Non-breaking — the handler reads models/
-  // defaultModel off the envelope and ignored the undeclared key before.
+  // #6370: every `available_models` sender tags the roster with the provider it
+  // came from (ws-history multi/legacy/refresh/switch, server-cli overlay
+  // re-broadcast, ws-forwarding, session-handlers) and the wire contract
+  // documents it — declare it so the schema matches. Nullable: several senders
+  // pass an explicit `provider: null` for the default/unscoped roster.
+  // Non-breaking — the handler reads models/defaultModel off the envelope and
+  // ignored the undeclared key before.
   provider: z.string().nullable().optional(),
 })
 

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -204,6 +204,13 @@ export const ServerAvailableModelsSchema = z.object({
   type: z.literal('available_models'),
   models: z.array(z.unknown()).optional(),
   defaultModel: z.string().optional(),
+  // #6370: four senders tag the roster with the provider it came from
+  // (ws-history multi + legacy single, server-cli overlay re-broadcast,
+  // ws-forwarding) and the wire contract documents it — declare it so the
+  // schema matches. Nullable: some senders pass an explicit `provider: null`
+  // for the default/unscoped roster. Non-breaking — the handler reads models/
+  // defaultModel off the envelope and ignored the undeclared key before.
+  provider: z.string().nullable().optional(),
 })
 
 export const ServerPermissionModeChangedSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3049,4 +3049,37 @@ describe('@chroxy/protocol schemas', () => {
       })
     })
   })
+
+  describe('ServerAvailableModelsSchema provider tag (#6370)', () => {
+    it('accepts a roster tagged with a provider string', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerAvailableModelsSchema.safeParse({
+        type: 'available_models',
+        models: [{ id: 'sonnet' }],
+        defaultModel: 'sonnet',
+        provider: 'claude-sdk',
+      })
+      assert.ok(r.success)
+      assert.equal(r.data.provider, 'claude-sdk', 'provider is preserved on parse, not stripped')
+    })
+
+    it('accepts an explicit provider: null (the default/unscoped roster — ws-history.js:859)', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerAvailableModelsSchema.safeParse({ type: 'available_models', models: [], provider: null })
+      assert.ok(r.success)
+      assert.equal(r.data.provider, null)
+    })
+
+    it('accepts an omitted provider (backward compatible)', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerAvailableModelsSchema.safeParse({ type: 'available_models', models: [], defaultModel: 'opus' })
+      assert.ok(r.success)
+      assert.equal(r.data.provider, undefined)
+    })
+
+    it('rejects a non-string provider', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      assert.ok(!ServerAvailableModelsSchema.safeParse({ type: 'available_models', provider: 42 }).success)
+    })
+  })
 })


### PR DESCRIPTION
## What & why

A from-review follow-up (surfaced in [#6369](https://github.com/blamechris/chroxy/pull/6369)) and the natural completion of this session's provider-tagging work. The `available_models` server message carries a **`provider`** tag, emitted by **six** senders:

- `ws-history.js:641` (multi-session) · `:682` (legacy single) · `:815` (per-provider refresh re-push) · `:859` (session-switch re-tag, passes `entry.provider || null`)
- `server-cli.js:953` (overlay hot-reload re-broadcast)
- `ws-forwarding.js:150` / `:427`

and the wire contract documents it (`ws-server.js:345`). But `ServerAvailableModelsSchema` declared only `type` / `models` / `defaultModel` — the `provider` field was **undeclared**, so the declared contract didn't match what the senders emit.

## Change

```ts
export const ServerAvailableModelsSchema = z.object({
  type: z.literal('available_models'),
  models: z.array(z.unknown()).optional(),
  defaultModel: z.string().optional(),
  provider: z.string().nullable().optional(),   // #6370
})
```

`nullable()` because `ws-history.js:859` emits `provider: entry.provider || null` for the default/unscoped roster. Rebuilt the tracked `dist/` artifact (`tsc`).

## Why it's safe

Non-breaking. `store-core`'s `handleAvailableModels` reads `models` / `defaultModel` off the envelope and **ignored** the undeclared `provider` key before (Zod strips unknowns), so nothing changes for existing clients. This is a schema-completeness fix + the **prerequisite** for any client that later wants to surface which provider a roster came from (out of scope here, per the issue).

## Tests

4 new schema tests: `provider` string preserved on parse · explicit `null` accepted · omitted accepted (backward compat) · non-string rejected. **protocol 344 pass · store-core 1854 pass** (all three coverage guards — handler-coverage, protocol-type-coverage-lint, store-core coverage-lint — green).

Closes #6370.