### PR TITLE
chore: bump version to 0.9.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.47] - 2026-06-25
+
+A **model-serving freshness** release with **operator-security hardening**. The headline: you no longer need to release a new build to **call, add, or re-price a model** the provider's API already exposes — across the whole provider matrix. Alongside that: a **host-local user-shell approval** control, completion of the **#6201 Open/Closed catalog** refactor, an **OpenAI-compatible provider**, a **mobile mission-control** read-only slice, a deep **store-core/protocol contract-typing** wave, and broad reliability/UX polish.
+
+### Added
+
+- **Serve a new model without a release (model-serving freshness epic).**
+  - `providers.allowAnyModel` — a per-provider config opt-in (default OFF) that lets the static-allowlist providers (Gemini, Codex, DeepSeek) serve any API-valid model id verbatim, letting the upstream API be the validator — mirroring how Ollama already works (#6378).
+  - The hot-reloadable `~/.chroxy/models.json` **model overlay** now reaches **every provider's registry** via an optional per-entry `provider` field — add or relabel or re-window a Gemini/Codex/DeepSeek/Ollama model at runtime, not just Claude (#6377).
+  - **Per-provider overlay pricing** — a `provider`-tagged overlay entry can re-price a non-Claude model (e.g. DeepSeek) with no release (#6381).
+  - A user guide for the model overlay, previously undocumented (#6376).
+- **Host-local per-spawn user-shell approval (#6277).** Opt-in `userShell.requireApproval` holds a user-shell spawn pending the host operator's explicit OK, served over a **separate `127.0.0.1`-only listener** the Cloudflare tunnel never forwards (closing a tunnel-loopback bypass); driven by a new `chroxy shell approve|deny|list` CLI. Plus a boot-time orphan reaper for user-shell PTYs with a start-time identity gate (#6276).
+- **OpenAI-compatible provider** via the Anthropic shim — config-driven `/v1/chat/completions` endpoints (OpenAI, OpenRouter, LM Studio, vLLM, …) as first-class BYOK providers (#5420).
+- **Mobile mission-control** (read-only slice) — cross-session activity view on the app, with a live activity feeder and `lastClientActivityAt` tracking (#5968, #6246, #6248); desktop dock-badges the cross-session blocked+failed count (#6184).
+- **Dashboard model-picker** reworked to a button + modal picker with keyboard nav (#6220, #6238); the Control Room tab strip gains drag-to-scroll + edge chevrons (#6230, #6218).
+- **`doctor`** surfaces keychain health + the active storage backend (#6236).
+- **CI:** a Playwright dashboard smoke test (#6315) and a nightly Maestro app-E2E workflow (#6355) wired in.
+
+### Changed
+
+- **#6201 Open/Closed epic completed.** The Claude model catalog (roster, pricing, context-window heuristic) moved onto its own provider-owned module, inverting the dependency so the generic registry no longer reaches back into Claude specifics (#6366); DeepSeek pricing moved onto its provider class (#6365). `set_model` no longer falls through to the Claude allowlist for a non-Claude provider that declares none (#6367).
+- **Default model is now Opus 4.8**; Fable removed from and disallowed in the model registry (#6219, #6233).
+- **store-core dispatch-table migration (#5618)** — the remaining server→client handlers (`agent_idle`, `permission_mode_changed`, `budget_warning`/`plan_ready`/`rate_limited`/`server_shutdown`, `conversations_list`/`checkpoint_restored`, `search_results`) moved onto the shared dispatch table.
+- **Protocol contract-typing wave** — Zod-schemed the high-traffic, `environment_*`, and git/file/checkpoint-result server→client families (#6314, #6324), and drained the `PENDING_CONTRACT_TYPES` backlog with behavioural contract fixtures (#6325 close-out).
+- The release CI test gate broadened to match full CI coverage so a release re-tests the same suites (#6316).
+
+### Fixed
+
+- Declared the `provider` field on the `available_models` protocol schema to match the senders that emit it (#6370); boot-cache warm + legacy `available_models` are now scoped to the active provider when `DEFAULT_PROVIDER` is non-Claude (#6368).
+- **Connection resilience (mobile/dashboard):** the `ConnectionPhase` FSM rejects illegal transitions instead of failing open and restricts forced exits to whitelisted terminal phases; File/Git op failures on a closed socket surface instead of wedging; optimistic `set_model`/permission-mode/notification-pref/permission-answer flips now honor a false `wsSend` return (#6308, #6321, #6222, #6285, #6289).
+- **Desktop voice/speech helper:** single-owner reaping + decoupled stderr drain, with stderr surfaced on unexpected exit and a voice error when the restart budget is exhausted (#6281, #6282); deterministic concurrency regression tests added (#6362).
+- No macOS keychain modal on a broken login keychain — the daemon detects an unusable keychain without prompting (#6234).
+- `terminal_resync` recovers a desynced live PTY mirror, with a manual "refresh terminal" button on app + dashboard (#6329, #6330).
+- A `rate_limited` throttle notice is surfaced on app + dashboard (#6334); never-sent queued bubbles are dropped on Stop/Cancel and stranded in-flight flags reset on disconnect.
+
 ## [0.9.46] - 2026-06-20
 
 A large release on three fronts. **A security and identity-rotation wave** lands token revocation with scheduled rotation, revoke-kills-live-shells, identity-key rotation handoff, exchange-key domain separation, pairing-bound-token write gates, broadcast-path secret redaction, and a single-source answer-authorization predicate. **Two operator epics** open up: the **user-shell terminal** (#5982) puts a real `$SHELL` PTY behind a primary-token gate across server, dashboard, and mobile, and the **Control Room env/runtime control** epic (#5530) turns the dashboard into a live ops surface for containers, repo runtime config, the BYOK pool, host prune, device runtimes (iOS/Android/WSL2), and cross-session mission control. On top of that: **queue-while-processing** (server-authoritative send queue with per-item cancel and a live "Claude is working" indicator), an **OpenAI-compatible provider** translation core, an **agent-to-agent mailbox** with live interrupt, and a deep reliability/refactor wave — the store-core handler split, the swarm-hardening audit, claude-tui hardening, and CI moved onto self-hosted macOS + Linux runners with the last `--test-force-exit` retired. The original control-surface slice (Control Room Integrations/Settings tabs, pairing epic #5509, latency epic #5514, OpenRouter) ships in the same release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16942,7 +16942,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16996,7 +16996,7 @@
     },
     "packages/claude-hooks": {
       "name": "@chroxy/claude-hooks",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "license": "MIT",
       "dependencies": {
         "@chroxy/protocol": "*"
@@ -17010,7 +17010,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17120,11 +17120,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.46"
+      "version": "0.9.47"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17136,7 +17136,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17199,7 +17199,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.46",
+    "version": "0.9.47",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
@@ -27,19 +27,30 @@
         "NSPrivacyAccessedAPITypes": [
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
-            "NSPrivacyAccessedAPITypeReasons": ["C617.1", "0A2A.1", "3B52.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "C617.1",
+              "0A2A.1",
+              "3B52.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
-            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "CA92.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
-            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "35F9.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace",
-            "NSPrivacyAccessedAPITypeReasons": ["E174.1", "85F4.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "E174.1",
+              "85F4.1"
+            ]
           }
         ]
       }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/claude-hooks",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "Stateless Claude Code hook emitters for chroxy's POST /api/events ingest",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.46"
+version = "0.9.47"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Version 0.9.47

Marks this milestone as a version. **Model-serving freshness + operator-security** release.

**Headline:** you no longer need to release a new build to **call, add, or re-price a model** the provider's API already exposes — across the whole provider matrix (`allowAnyModel` + the all-provider `~/.chroxy/models.json` overlay + per-provider overlay pricing + the `available_models` schema match).

**Also in 0.9.47:** host-local user-shell approval (#6277, with the tunnel-loopback bypass closed), completion of the #6201 Open/Closed catalog refactor, an OpenAI-compatible provider (#5420), a mobile mission-control read-only slice, a deep store-core/protocol contract-typing wave (#5618/#6314/#6324/#6325), and broad reliability/UX polish.

Bumped via `scripts/bump-version.sh` (all 8 `package.json` + `app.json` + `tauri.conf.json` + `Cargo.toml`/locks → 0.9.47). Full notes in [`CHANGELOG.md`](CHANGELOG.md) `[0.9.47]`.

This is a version-marker bump — it does **not** trigger a release build (the `release.yml` workflow is dispatched separately on the tag when you're ready to cut one).