### PR TITLE
feat(store-core): canonical tool-presentation registry (chat redesign Phase 0)

### DIFF
--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -371,6 +371,16 @@ export {
   shouldSuppressRawToolInput,
 } from './tool-summary'
 
+// Chat redesign #6389 (Phase 0 #6390): canonical tool-presentation registry
+// — verb (label) → kind → icon glyph → color token, defined once so the
+// dashboard and mobile op-card renderers can't drift.
+export {
+  TOOL_KIND_META,
+  getToolKind,
+  getToolPresentation,
+} from './tool-presentation'
+export type { ToolKind, ToolPresentation } from './tool-presentation'
+
 export {
   PASTE_COLLAPSE_CHAR_THRESHOLD,
   PASTE_COLLAPSE_LINE_THRESHOLD,

--- a/packages/store-core/src/tool-presentation.test.ts
+++ b/packages/store-core/src/tool-presentation.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getToolKind,
+  getToolPresentation,
+  TOOL_KIND_META,
+  type ToolKind,
+} from './tool-presentation'
+import { formatToolName } from './group-messages'
+
+describe('getToolKind', () => {
+  const cases: Array<[string, ToolKind]> = [
+    ['Read', 'read'],
+    ['read_file', 'read'],
+    ['NotebookRead', 'read'],
+    ['LS', 'read'],
+    ['Edit', 'edit'],
+    ['MultiEdit', 'edit'],
+    ['NotebookEdit', 'edit'],
+    ['Write', 'write'],
+    ['write_file', 'write'],
+    ['Bash', 'exec'],
+    ['BashOutput', 'exec'],
+    ['Grep', 'search'],
+    ['Glob', 'search'],
+    ['WebFetch', 'web'],
+    ['WebSearch', 'web'],
+    ['Task', 'task'],
+    ['TodoWrite', 'todo'],
+    ['AskUserQuestion', 'question'],
+  ]
+  it.each(cases)('classifies %s as %s', (name, kind) => {
+    expect(getToolKind(name)).toBe(kind)
+  })
+
+  it('is case- and separator-insensitive', () => {
+    expect(getToolKind('read-file')).toBe('read')
+    expect(getToolKind('BASH')).toBe('exec')
+    expect(getToolKind('todo_write')).toBe('todo')
+  })
+
+  it('classifies MCP tools as other (intent is not inferable)', () => {
+    expect(getToolKind('mcp__github__list_repos')).toBe('other')
+    expect(getToolKind('mcp__repo-memory__search_by_purpose')).toBe('other')
+  })
+
+  it('falls back to other for unknown / empty names', () => {
+    expect(getToolKind('SomeFutureTool')).toBe('other')
+    expect(getToolKind('')).toBe('other')
+    expect(getToolKind(undefined)).toBe('other')
+    expect(getToolKind(null)).toBe('other')
+  })
+})
+
+describe('getToolPresentation', () => {
+  it('returns kind + icon + colorToken + label for a core tool', () => {
+    expect(getToolPresentation('Read')).toEqual({
+      kind: 'read',
+      icon: TOOL_KIND_META.read.icon,
+      colorToken: TOOL_KIND_META.read.colorToken,
+      label: 'Read',
+    })
+  })
+
+  it('label matches formatToolName (single source of truth)', () => {
+    expect(getToolPresentation('read_file').label).toBe(formatToolName('read_file'))
+    expect(getToolPresentation('mcp__github__list_repos').label).toBe(
+      formatToolName('mcp__github__list_repos'),
+    )
+  })
+
+  it('forwards serverName to the label', () => {
+    expect(getToolPresentation('Read', 'gh').label).toBe(formatToolName('Read', 'gh'))
+  })
+
+  it('uses the other-kind meta for unknown tools', () => {
+    const p = getToolPresentation('SomeFutureTool')
+    expect(p.kind).toBe('other')
+    expect(p.icon).toBe(TOOL_KIND_META.other.icon)
+    expect(p.colorToken).toBe(TOOL_KIND_META.other.colorToken)
+  })
+
+  it('never throws on empty / nullish names', () => {
+    expect(() => getToolPresentation('')).not.toThrow()
+    expect(getToolPresentation(undefined).kind).toBe('other')
+  })
+})
+
+describe('TOOL_KIND_META', () => {
+  it('has an entry for every ToolKind the classifier can return', () => {
+    const kinds: ToolKind[] = [
+      'read', 'edit', 'write', 'exec', 'search', 'web', 'task', 'todo', 'question', 'other',
+    ]
+    for (const kind of kinds) {
+      expect(TOOL_KIND_META[kind]).toBeDefined()
+      expect(TOOL_KIND_META[kind].icon).toBeTruthy()
+      expect(TOOL_KIND_META[kind].colorToken).toBeTruthy()
+    }
+  })
+})

--- a/packages/store-core/src/tool-presentation.ts
+++ b/packages/store-core/src/tool-presentation.ts
@@ -1,0 +1,134 @@
+/**
+ * Canonical tool-presentation registry (chat redesign epic #6389, Phase 0 #6390).
+ *
+ * Both the dashboard and the mobile op-card renderers need to agree on
+ * how a tool is presented: which *kind* it is (read / edit / exec / …),
+ * which icon glyph stands for it, which color token tints it, and the
+ * human verb label. Today each client re-derives icon + color inline, so
+ * "Read = blue book" can drift between web and React Native. This module
+ * defines that mapping ONCE — pure data, no DOM / React Native deps —
+ * the same way {@link ./tool-summary} centralised the collapsed-preview
+ * extraction.
+ *
+ * The `label` reuses {@link formatToolName} so per-row labels keep
+ * matching the grouped-header breakdown (no second naming scheme).
+ *
+ * Consumers (Phase 2 op-card grammar) map the platform-neutral fields to
+ * their own primitives:
+ *   - `icon`       → a Tabler icon name (web) / an icon component (mobile)
+ *   - `colorToken` → `var(--<colorToken>)` (web) / the matching `COLORS`
+ *                    entry (mobile). These are the existing dashboard
+ *                    accent token names; Phase 0's `@chroxy/design-tokens`
+ *                    package (#6390) keeps them as the canonical
+ *                    cross-surface keys.
+ */
+
+import { formatToolName } from './group-messages'
+
+/** Coarse classification of a tool by what it does. `other` is the
+ *  catch-all for MCP tools, ToolSearch, custom/unknown tools, etc. */
+export type ToolKind =
+  | 'read'
+  | 'edit'
+  | 'write'
+  | 'exec'
+  | 'search'
+  | 'web'
+  | 'task'
+  | 'todo'
+  | 'question'
+  | 'other'
+
+export interface ToolPresentation {
+  kind: ToolKind
+  /** Semantic icon key — each client maps it to its own icon set. */
+  icon: string
+  /** Theme color token name (no `--` prefix) the client resolves. */
+  colorToken: string
+  /** Human-facing label — `formatToolName(name, serverName)`. */
+  label: string
+}
+
+/** Per-kind icon + color. Color tokens are the existing dashboard accent
+ *  tokens (see theme.css); the icon keys are semantic and platform-neutral. */
+export const TOOL_KIND_META: Readonly<Record<ToolKind, { icon: string; colorToken: string }>> = {
+  read: { icon: 'file-text', colorToken: 'accent-blue' },
+  edit: { icon: 'pencil', colorToken: 'accent-orange' },
+  write: { icon: 'file-plus', colorToken: 'accent-green' },
+  exec: { icon: 'terminal', colorToken: 'accent-purple' },
+  search: { icon: 'search', colorToken: 'accent-blue' },
+  web: { icon: 'world', colorToken: 'accent-blue' },
+  task: { icon: 'subtask', colorToken: 'accent-purple' },
+  todo: { icon: 'checklist', colorToken: 'accent-green' },
+  question: { icon: 'help', colorToken: 'accent-orange' },
+  other: { icon: 'tool', colorToken: 'text-muted' },
+}
+
+// Canonical name → kind. Keys are the tool name lower-cased with `_`/`-`
+// stripped, so `Read`, `read_file`, and `read-file` all resolve to the
+// same entry. Covers the Claude Code core tools plus common synonyms from
+// other providers (Codex/Gemini/MCP-shaped names).
+const KIND_BY_NORMALIZED_NAME: Readonly<Record<string, ToolKind>> = {
+  read: 'read',
+  readfile: 'read',
+  notebookread: 'read',
+  ls: 'read',
+  cat: 'read',
+  edit: 'edit',
+  multiedit: 'edit',
+  notebookedit: 'edit',
+  applypatch: 'edit',
+  update: 'edit',
+  write: 'write',
+  writefile: 'write',
+  createfile: 'write',
+  bash: 'exec',
+  bashoutput: 'exec',
+  shell: 'exec',
+  execute: 'exec',
+  killbash: 'exec',
+  killshell: 'exec',
+  grep: 'search',
+  glob: 'search',
+  search: 'search',
+  find: 'search',
+  websearch: 'web',
+  webfetch: 'web',
+  fetch: 'web',
+  task: 'task',
+  agent: 'task',
+  todowrite: 'todo',
+  todoread: 'todo',
+  askuserquestion: 'question',
+}
+
+const MCP_PREFIX = 'mcp__'
+
+/** Classify a tool name into a {@link ToolKind}. MCP tools (`mcp__…`) and
+ *  anything unrecognised fall back to `other` — never throws. */
+export function getToolKind(name: string | undefined | null): ToolKind {
+  if (!name) return 'other'
+  // MCP tools carry a server-qualified shape (`mcp__github__list_repos`)
+  // whose intent we can't reliably infer — classify as `other` rather
+  // than guessing off the trailing verb.
+  if (name.startsWith(MCP_PREFIX)) return 'other'
+  const normalized = name.toLowerCase().replace(/[_-]/g, '')
+  return KIND_BY_NORMALIZED_NAME[normalized] ?? 'other'
+}
+
+/** Full presentation descriptor for a tool: kind + icon + color token +
+ *  display label. `serverName` is forwarded to {@link formatToolName} so
+ *  MCP/server-prefixed labels match the rest of the chat surface. */
+export function getToolPresentation(
+  name: string | undefined | null,
+  serverName?: string,
+): ToolPresentation {
+  const kind = getToolKind(name)
+  const meta = TOOL_KIND_META[kind]
+  return {
+    kind,
+    icon: meta.icon,
+    colorToken: meta.colorToken,
+    label: formatToolName(name ?? '', serverName),
+  }
+}


### PR DESCRIPTION
First slice of **Phase 0** (#6390) for the chat redesign (#6389).

Adds `packages/store-core/src/tool-presentation.ts` — a pure-data registry that classifies a tool name into a kind (read/edit/write/exec/search/web/task/todo/question/other) and attaches a semantic icon key, a color token, and a display label (reusing `formatToolName`, so labels stay consistent with the grouped-header breakdown).

**Additive — no renderers changed.** The Phase 2 op-card grammar will consume `getToolPresentation()` so the dashboard and mobile op-cards can't drift on how a tool is shown.

- 27 unit tests (classification incl. MCP / unknown / empty, label parity with `formatToolName`, kind-meta completeness).
- Full store-core suite green (1881 tests); typecheck clean.

Part of #6390 · epic #6389.