### PR TITLE
refactor(store-core): hoist canonical chat-activity state machine (chat redesign Phase 0)

### DIFF
--- a/packages/app/src/store/session-activity.ts
+++ b/packages/app/src/store/session-activity.ts
@@ -1,38 +1,15 @@
-export type ActivityState = 'idle' | 'thinking' | 'busy' | 'waiting' | 'error';
-
-export interface SessionActivity {
-  state: ActivityState;
-  detail?: string;
-  startedAt: number;
-}
-
-interface DeriveInput {
-  isIdle: boolean;
-  streamingMessageId: string | null;
-  isPlanPending: boolean;
-  pendingPermission?: boolean;
-  hasError?: boolean;
-}
-
-export function deriveActivityState(
-  input: DeriveInput,
-  previous?: SessionActivity,
-): SessionActivity {
-  let state: ActivityState = 'idle';
-
-  if (input.hasError) {
-    state = 'error';
-  } else if (input.pendingPermission || input.isPlanPending) {
-    state = 'waiting';
-  } else if (input.streamingMessageId) {
-    state = 'thinking';
-  } else if (!input.isIdle) {
-    state = 'busy';
-  }
-
-  const startedAt = previous && previous.state === state
-    ? previous.startedAt
-    : Date.now();
-
-  return { state, startedAt };
-}
+/**
+ * Per-session chat activity state — re-export shim.
+ *
+ * The implementation now lives in @chroxy/store-core (`chat-activity.ts`)
+ * so the dashboard's presence rail + composer lozenge read the SAME state
+ * machine as mobile (chat redesign #6389, Phase 0 #6390). This module
+ * re-exports it under the original mobile names so every existing import
+ * site keeps working unchanged.
+ */
+export { deriveChatActivity as deriveActivityState } from '@chroxy/store-core';
+export type {
+  ChatActivityState as ActivityState,
+  SessionChatActivity as SessionActivity,
+  ChatActivityInput,
+} from '@chroxy/store-core';

--- a/packages/store-core/src/chat-activity.test.ts
+++ b/packages/store-core/src/chat-activity.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  deriveChatActivity,
+  type SessionChatActivity,
+  type ChatActivityState,
+} from './chat-activity'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('deriveChatActivity', () => {
+  it('returns idle for a default (idle) session', () => {
+    expect(
+      deriveChatActivity({ isIdle: true, streamingMessageId: null, isPlanPending: false }).state,
+    ).toBe('idle')
+  })
+
+  it('returns thinking when streaming is active', () => {
+    expect(
+      deriveChatActivity({ isIdle: false, streamingMessageId: 'msg-1', isPlanPending: false }).state,
+    ).toBe('thinking')
+  })
+
+  it('returns waiting when a plan is pending', () => {
+    expect(
+      deriveChatActivity({ isIdle: false, streamingMessageId: null, isPlanPending: true }).state,
+    ).toBe('waiting')
+  })
+
+  it('returns waiting when permission is pending', () => {
+    expect(
+      deriveChatActivity({
+        isIdle: false,
+        streamingMessageId: null,
+        isPlanPending: false,
+        pendingPermission: true,
+      }).state,
+    ).toBe('waiting')
+  })
+
+  it('returns busy when not idle and not streaming', () => {
+    expect(
+      deriveChatActivity({ isIdle: false, streamingMessageId: null, isPlanPending: false }).state,
+    ).toBe('busy')
+  })
+
+  it('returns error when hasError, overriding everything else', () => {
+    expect(
+      deriveChatActivity({
+        isIdle: false,
+        streamingMessageId: 'msg-1',
+        isPlanPending: true,
+        pendingPermission: true,
+        hasError: true,
+      }).state,
+    ).toBe('error')
+  })
+
+  it('prefers waiting over thinking when both plan-pending and streaming', () => {
+    expect(
+      deriveChatActivity({ isIdle: false, streamingMessageId: 'msg-1', isPlanPending: true }).state,
+    ).toBe('waiting')
+  })
+
+  it('stamps startedAt with the current time on a fresh derive', () => {
+    const mockNow = 1700000000000
+    vi.spyOn(Date, 'now').mockReturnValue(mockNow)
+    const a = deriveChatActivity({ isIdle: false, streamingMessageId: 'msg-1', isPlanPending: false })
+    expect(a.startedAt).toBe(mockNow)
+  })
+
+  it('preserves startedAt while the state is unchanged', () => {
+    const previous: SessionChatActivity = { state: 'thinking', startedAt: 1000 }
+    const a = deriveChatActivity(
+      { isIdle: false, streamingMessageId: 'msg-1', isPlanPending: false },
+      previous,
+    )
+    expect(a.state).toBe('thinking')
+    expect(a.startedAt).toBe(1000)
+  })
+
+  it('resets startedAt when the state changes', () => {
+    const mockNow = 1700000000000
+    vi.spyOn(Date, 'now').mockReturnValue(mockNow)
+    const previous: SessionChatActivity = { state: 'thinking', startedAt: 1000 }
+    const a = deriveChatActivity(
+      { isIdle: true, streamingMessageId: null, isPlanPending: false },
+      previous,
+    )
+    expect(a.state).toBe('idle')
+    expect(a.startedAt).toBe(mockNow)
+  })
+
+  it('covers the full ChatActivityState union', () => {
+    const states: ChatActivityState[] = ['idle', 'thinking', 'busy', 'waiting', 'error']
+    expect(states).toHaveLength(5)
+  })
+})

--- a/packages/store-core/src/chat-activity.ts
+++ b/packages/store-core/src/chat-activity.ts
@@ -1,0 +1,70 @@
+/**
+ * Canonical per-session chat activity state machine
+ * (chat redesign epic #6389, Phase 0 #6390).
+ *
+ * Answers "what is THIS session's chat doing right now?" — the input the
+ * presence rail and composer state-lozenge both read. Previously this
+ * lived only in the mobile app (`packages/app/src/store/session-activity.ts`);
+ * the dashboard had no equivalent and leaned on a binary `isBusy`. Moving
+ * it here makes it the single source both clients map the same way.
+ *
+ * NOT to be confused with `deriveSessionStatus` in `activity-selectors.ts`:
+ * that is the Control Room CROSS-session attention rollup
+ * (`running | blocked | failed | idle`) computed from `ActivityEntry[]` — a
+ * different abstraction with a different consumer (#5159 / #6182). The
+ * names `ActivityState` / `SessionActivityState` are already taken by that
+ * Control Room reducer, so the chat machine uses the `Chat*` prefix.
+ *
+ * Pure, no DOM / React Native deps. Behaviour is identical to the former
+ * mobile implementation (state precedence + `startedAt` continuity) so the
+ * mobile re-export shim is a drop-in.
+ */
+
+/** A session's chat activity at a glance. `busy` is non-streaming work
+ *  (e.g. a tool running between streamed text); the spec's finer
+ *  `streaming` vs `tool-running` split lands when the rail consumes it and
+ *  the extra in-flight-tool input is plumbed through. */
+export type ChatActivityState = 'idle' | 'thinking' | 'busy' | 'waiting' | 'error'
+
+export interface SessionChatActivity {
+  state: ChatActivityState
+  detail?: string
+  /** Epoch ms the session entered `state`; preserved across re-derives
+   *  while the state is unchanged so consumers can show "for 12s". */
+  startedAt: number
+}
+
+export interface ChatActivityInput {
+  isIdle: boolean
+  streamingMessageId: string | null
+  isPlanPending: boolean
+  pendingPermission?: boolean
+  hasError?: boolean
+}
+
+/**
+ * Derive the chat activity from a session's flags. Precedence (highest
+ * first): error → waiting (permission/plan) → thinking (streaming) → busy
+ * (not idle) → idle. `startedAt` carries over from `previous` while the
+ * state is unchanged, and resets to now on a transition.
+ */
+export function deriveChatActivity(
+  input: ChatActivityInput,
+  previous?: SessionChatActivity,
+): SessionChatActivity {
+  let state: ChatActivityState = 'idle'
+
+  if (input.hasError) {
+    state = 'error'
+  } else if (input.pendingPermission || input.isPlanPending) {
+    state = 'waiting'
+  } else if (input.streamingMessageId) {
+    state = 'thinking'
+  } else if (!input.isIdle) {
+    state = 'busy'
+  }
+
+  const startedAt = previous && previous.state === state ? previous.startedAt : Date.now()
+
+  return { state, startedAt }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -315,6 +315,14 @@ export {
   selectCrossSessionActivity,
 } from './activity-reducer'
 
+// Chat redesign #6389 (Phase 0 #6390): canonical per-session chat activity
+// state machine (idle/thinking/busy/waiting/error) — the input the presence
+// rail + composer lozenge read. Distinct from `deriveSessionStatus` above
+// (the Control Room cross-session rollup). Mobile re-exports this under its
+// original names; the dashboard adopts it in Phase 1.
+export { deriveChatActivity } from './chat-activity'
+export type { ChatActivityState, SessionChatActivity, ChatActivityInput } from './chat-activity'
+
 // #4242: cheap structural gate for `JSON.parse` on streaming
 // `tool_input_delta` accumulators. Amortises N-1 throws on long
 // streams (every Bash invocation, every Edit).


### PR DESCRIPTION
Second slice of **Phase 0** (#6390) for the chat redesign (#6389).

**Premise correction:** the issue framed this as "merge `deriveActivityState` with `deriveSessionStatus`" — but they're different concepts. `deriveActivityState` is the *per-session chat UI state* (idle/thinking/busy/waiting/error) the presence rail + composer lozenge need; `deriveSessionStatus` is the **Control Room** *cross-session* rollup (running/blocked/failed/idle from `ActivityEntry[]`, #5159/#6182). So this PR hoists the former into store-core as the canonical shared machine and leaves the latter untouched.

- New `packages/store-core/src/chat-activity.ts` — `deriveChatActivity` + types. Behavior identical to the former mobile implementation (state precedence + `startedAt` continuity).
- Renamed types `ChatActivityState`/`SessionChatActivity`/`ChatActivityInput` to avoid colliding with the Control Room `ActivityState`/`SessionActivityState` already exported from store-core.
- `packages/app/src/store/session-activity.ts` → thin re-export shim aliasing to the original names; all six mobile import sites unchanged.
- Dashboard adoption (its first real activity-state source, replacing the binary `isBusy`) lands in Phase 1.

### Verification
- 11 new store-core tests; full store-core suite green (1865).
- Mobile `session-activity` jest test green through the shim (9).
- App `tsc --noEmit` clean (0 errors).

Part of #6390 · epic #6389.