### PR TITLE
feat(design-tokens): invert token pipeline — @chroxy/design-tokens (chat redesign Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,11 +400,11 @@ jobs:
         run: npm run build
         working-directory: packages/protocol
 
-      - name: Check generated tokens are up-to-date
+      - name: Check generated theme tokens are up-to-date
         run: |
-          node scripts/generate-theme-tokens.mjs
-          git diff --exit-code src/theme/tokens.ts || {
-            echo "::error::tokens.ts is stale. Run 'npm run generate-tokens' from packages/dashboard and commit the result."
+          npm run generate-tokens
+          git diff --exit-code src/theme/theme.css src/theme/tokens.ts || {
+            echo "::error::theme.css / tokens.ts are stale. Edit packages/design-tokens/src/tokens-data.js, run 'npm run generate-tokens' from packages/dashboard, and commit the result."
             exit 1
           }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,6 +1708,10 @@
       "resolved": "packages/dashboard",
       "link": true
     },
+    "node_modules/@chroxy/design-tokens": {
+      "resolved": "packages/design-tokens",
+      "link": true
+    },
     "node_modules/@chroxy/desktop": {
       "resolved": "packages/desktop",
       "link": true
@@ -17012,6 +17016,7 @@
       "name": "@chroxy/dashboard",
       "version": "0.9.47",
       "dependencies": {
+        "@chroxy/design-tokens": "*",
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
         "dompurify": "^3.3.1",
@@ -17116,6 +17121,11 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "packages/design-tokens": {
+      "name": "@chroxy/design-tokens",
+      "version": "0.9.47",
       "license": "MIT"
     },
     "packages/desktop": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,6 +11,7 @@
     "generate-tokens": "node scripts/generate-theme-tokens.mjs"
   },
   "dependencies": {
+    "@chroxy/design-tokens": "*",
     "@chroxy/protocol": "*",
     "@chroxy/store-core": "*",
     "dompurify": "^3.3.1",

--- a/packages/dashboard/scripts/generate-theme-tokens.mjs
+++ b/packages/dashboard/scripts/generate-theme-tokens.mjs
@@ -1,165 +1,29 @@
 #!/usr/bin/env node
 
 /**
- * Generate TypeScript theme tokens from CSS custom properties.
+ * Generate the dashboard theme from the canonical token map.
  *
- * Source of truth: src/dashboard-next/src/theme/theme.css
- * Output:         src/dashboard-next/src/theme/tokens.ts
+ * Source of truth: @chroxy/design-tokens (packages/design-tokens/src/tokens-data.js)
+ * Outputs:         src/theme/theme.css  (CSS custom properties)
+ *                  src/theme/tokens.ts  (typed token objects)
  *
- * Usage: node scripts/generate-theme-tokens.mjs
+ * The pipeline is INVERTED from the old "parse theme.css → emit tokens.ts"
+ * direction (chat redesign #6389, Phase 0 #6390): edit tokens in the package,
+ * then run this. CI (`check-tokens-fresh.mjs`) fails the build if the committed
+ * outputs drift from what this would generate.
+ *
+ * Usage: npm run generate-tokens   (from packages/dashboard)
  */
 
-import { readFileSync, writeFileSync } from 'fs'
+import { writeFileSync } from 'fs'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
+import { generateThemeCss, generateTokensTs } from '@chroxy/design-tokens'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const cssPath = resolve(__dirname, '..', 'src', 'theme', 'theme.css')
-const outPath = resolve(__dirname, '..', 'src', 'theme', 'tokens.ts')
+const themeDir = resolve(__dirname, '..', 'src', 'theme')
 
-// Parse CSS custom properties from :root block
-const css = readFileSync(cssPath, 'utf-8')
-const rootMatch = css.match(/:root\s*\{([^}]+)\}/)
-if (!rootMatch) {
-  console.error('Could not find :root block in theme.css')
-  process.exit(1)
-}
+writeFileSync(resolve(themeDir, 'theme.css'), generateThemeCss())
+writeFileSync(resolve(themeDir, 'tokens.ts'), generateTokensTs())
 
-const props = []
-for (const line of rootMatch[1].split('\n')) {
-  const match = line.match(/^\s*--([\w-]+):\s*(.+?)\s*;/)
-  if (match) {
-    props.push({ name: match[1], value: match[2] })
-  }
-}
-
-// Category mapping: CSS prefix → TS group
-const categories = {
-  bg: { group: 'colors', sub: 'bg' },
-  text: { group: 'colors', sub: 'text' },
-  accent: { group: 'colors', sub: 'accent' },
-  border: { group: 'colors', sub: 'border' },
-  banner: { group: 'colors', sub: 'banner' },
-  warning: { group: 'colors', sub: 'warning' },
-  status: { group: 'colors', sub: 'status' },
-  syntax: { group: 'colors', sub: 'syntax' },
-  diff: { group: 'colors', sub: 'diff' },
-  scrollbar: { group: 'colors', sub: 'scrollbar' },
-  font: { group: 'fonts', sub: null },
-  space: { group: 'spacing', sub: null },
-}
-
-// Convert kebab-case to camelCase
-function toCamelCase(str) {
-  return str.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase())
-}
-
-// Classify and group each property
-const groups = { colors: {}, spacing: {}, typography: {}, fonts: {} }
-const unmapped = []
-
-for (const { name, value } of props) {
-  // Typography scale: --text-xs, --text-sm, etc. (px values, not color hex)
-  if (name.startsWith('text-') && value.endsWith('px')) {
-    const key = name.replace('text-', '')
-    groups.typography[key] = parseInt(value, 10)
-    continue
-  }
-
-  // Find matching category by prefix
-  let matched = false
-  for (const [prefix, { group, sub }] of Object.entries(categories)) {
-    if (name.startsWith(prefix + '-')) {
-      const key = toCamelCase(name.slice(prefix.length + 1))
-      if (group === 'colors') {
-        if (!groups.colors[sub]) groups.colors[sub] = {}
-        groups.colors[sub][key] = value
-      } else if (group === 'spacing') {
-        // --space-1 → spacing[1] = 4
-        groups.spacing[key] = parseInt(value, 10)
-      } else if (group === 'fonts') {
-        groups.fonts[key] = value
-      }
-      matched = true
-      break
-    }
-  }
-
-  if (!matched) {
-    unmapped.push(`--${name}: ${value}`)
-  }
-}
-
-if (unmapped.length > 0) {
-  console.error(`[error] ${unmapped.length} unmapped CSS properties:`)
-  for (const prop of unmapped) console.error(`  ${prop}`)
-  process.exit(1)
-}
-
-// Generate TypeScript output
-function renderObject(obj, indent = 2) {
-  const pad = ' '.repeat(indent)
-  const lines = []
-  for (const [key, val] of Object.entries(obj)) {
-    if (typeof val === 'object' && val !== null) {
-      lines.push(`${pad}${key}: {`)
-      lines.push(renderObject(val, indent + 2))
-      lines.push(`${pad}},`)
-    } else if (typeof val === 'number') {
-      lines.push(`${pad}${key}: ${val},`)
-    } else if (typeof val === 'string' && val.includes("'")) {
-      // Use double quotes for values containing single quotes (font stacks)
-      lines.push(`${pad}${key}: "${val}",`)
-    } else {
-      lines.push(`${pad}${key}: '${val}',`)
-    }
-  }
-  return lines.join('\n')
-}
-
-const output = `/**
- * DO NOT EDIT — generated from theme.css by scripts/generate-theme-tokens.mjs
- *
- * Design tokens for the Chroxy desktop dashboard.
- * Run: npm run dashboard:generate-tokens
- */
-
-// ---------------------------------------------------------------------------
-// Colors
-// ---------------------------------------------------------------------------
-
-export const colors = {
-${renderObject(groups.colors)}
-} as const
-
-// ---------------------------------------------------------------------------
-// Spacing — 4px base grid
-// ---------------------------------------------------------------------------
-
-export const spacing = {
-${renderObject(groups.spacing)}
-} as const
-
-// ---------------------------------------------------------------------------
-// Typography — font sizes in px
-// ---------------------------------------------------------------------------
-
-export const typography = {
-${renderObject(groups.typography)}
-} as const
-
-// ---------------------------------------------------------------------------
-// Font stacks
-// ---------------------------------------------------------------------------
-
-export const fonts = {
-${renderObject(groups.fonts)}
-} as const
-`
-
-writeFileSync(outPath, output)
-console.log(`Generated ${outPath} from ${cssPath}`)
-console.log(`  Colors: ${Object.values(groups.colors).reduce((n, g) => n + Object.keys(g).length, 0)} tokens`)
-console.log(`  Spacing: ${Object.keys(groups.spacing).length} tokens`)
-console.log(`  Typography: ${Object.keys(groups.typography).length} tokens`)
-console.log(`  Fonts: ${Object.keys(groups.fonts).length} tokens`)
+console.log('Generated theme.css + tokens.ts from @chroxy/design-tokens')

--- a/packages/dashboard/src/theme/index.ts
+++ b/packages/dashboard/src/theme/index.ts
@@ -1,1 +1,1 @@
-export { colors, spacing, typography, fonts } from './tokens'
+export { colors, spacing, typography, fonts, leading, radii, motion } from './tokens'

--- a/packages/dashboard/src/theme/theme-engine.test.ts
+++ b/packages/dashboard/src/theme/theme-engine.test.ts
@@ -117,8 +117,14 @@ function parseRootTokensFromCss(): string[] {
     if (m[1]) names.push(m[1])
   }
 
-  // Exclude non-themeable structural tokens
-  const excludePrefixes = ['font-', 'text-xs', 'text-sm', 'text-base', 'text-md', 'text-lg', 'space-']
+  // Exclude non-themeable structural tokens (constant across every theme — no
+  // theme override sets them, so they're deliberately absent from ALL_CSS_VARS).
+  // chat redesign #6390 added the chat reading size, line heights, radii, and
+  // motion tokens to this same structural-only tier.
+  const excludePrefixes = [
+    'font-', 'text-xs', 'text-sm', 'text-base', 'text-md', 'text-lg', 'space-',
+    'text-chat', 'leading-', 'radius-', 'dur-', 'ease-', 'rail-', 'caret-', 'waiting-',
+  ]
   return names.filter((n) => !excludePrefixes.some((p) => n === p || n.startsWith(p)))
 }
 

--- a/packages/dashboard/src/theme/theme.css
+++ b/packages/dashboard/src/theme/theme.css
@@ -1,12 +1,10 @@
-/**
- * Chroxy Desktop Dashboard — CSS Custom Properties
- *
- * Dark-only theme. Values sourced from mobile colors.ts + legacy dashboard.css.
- * TypeScript tokens in tokens.ts mirror these values.
- */
+/* DO NOT EDIT — generated from @chroxy/design-tokens by
+ * scripts/generate-theme-tokens.mjs. Edit tokens in
+ * packages/design-tokens/src/tokens-data.js, then run
+ * `npm run generate-tokens` in packages/dashboard. */
 
 :root {
-  /* ---- Backgrounds ---- */
+  /* Backgrounds */
   --bg-primary: #0f0f1a;
   --bg-secondary: #1a1a2e;
   --bg-tertiary: #16162a;
@@ -22,7 +20,7 @@
   --bg-plan-banner: #2a1a40;
   --bg-modal: #1a1a2e;
 
-  /* ---- Text ---- */
+  /* Text */
   --text-primary: #ffffff;
   --text-secondary: #cccccc;
   --text-muted: #888888;
@@ -35,7 +33,7 @@
   --text-heading: #f0f0f0;
   --text-blockquote: #999999;
 
-  /* ---- Accents ---- */
+  /* Accents */
   --accent-blue: #4a9eff;
   --accent-green: #22c55e;
   --accent-purple: #a78bfa;
@@ -47,37 +45,28 @@
   --accent-blue-subtle: #4a9eff33;
   --accent-blue-border: #4a9eff44;
   --accent-blue-border-strong: #4a9eff66;
-
   --accent-green-light: #22c55e22;
   --accent-green-border: #22c55e33;
   --accent-green-border-strong: #22c55e66;
-
   --accent-purple-light: #a78bfa22;
   --accent-purple-subtle: #a78bfa33;
   --accent-purple-border-strong: #a78bfa66;
   --accent-purple-code: #c4a5ff;
-
   --accent-orange-light: #f59e0b11;
   --accent-orange-subtle: #f59e0b22;
   --accent-orange-medium: #f59e0b33;
   --accent-orange-border: #f59e0b44;
   --accent-orange-border-strong: #f59e0b66;
-
   --accent-red-light: #ff4a4a11;
   --accent-red-subtle: #ff4a4a22;
   --accent-red-border: #ff4a4a44;
 
-  /* Tailwind-scale tokens (#3789). Distinct base hexes from the
-   * Tailwind palette; mirror the accentOrange500 / accentYellow500 /
-   * accentRed500 tokens in packages/app/src/constants/colors.ts. The legacy
-   * --accent-orange / --accent-red above are brand hexes with opacity
-   * variants; the *-500 tokens are different base hexes, not opacity
-   * variants of them. Used by the activity-indicator escalation. */
+  /* Tailwind-scale (distinct base hexes, not opacity variants of the brand hex) */
   --accent-orange-500: #f97316;
   --accent-yellow-500: #eab308;
   --accent-red-500: #ef4444;
 
-  /* ---- Borders ---- */
+  /* Borders */
   --border-primary: #2a2a4e;
   --border-secondary: #3a3a5e;
   --border-subtle: #4a4a6e;
@@ -85,27 +74,20 @@
   --border-permission: #4a3a7a;
   --border-question: #2a5a7a;
 
-  /* ---- Banner borders (subtle dividers for status/warning banners) ---- */
+  /* Banner borders */
   --banner-border-subtle: #252540;
 
-  /* ---- Warning (amber-yellow, distinct from --accent-orange) ----
-   *
-   * Canonical warning tokens. Use these for any warning-tinted UI
-   * (text, icons, status dots, banner backgrounds). Previously this
-   * codebase had three fragmented references — `--warning`,
-   * `--status-warning`, `--warning-fg` — with divergent fallbacks.
-   * They have all been migrated to `--warning-fg` / `--warning-bg-subtle`.
-   */
+  /* Warning (amber-yellow, distinct from --accent-orange) */
   --warning-fg: #fbbf24;
   --warning-bg-subtle: #fbbf2422;
 
-  /* ---- Status indicators ---- */
+  /* Status indicators */
   --status-connected: #22c55e;
   --status-disconnected: #ef4444;
   --status-connecting: #eab308;
   --status-restarting: #f59e0b;
 
-  /* ---- Syntax highlighting ---- */
+  /* Syntax highlighting */
   --syntax-keyword: #c4a5ff;
   --syntax-string: #4eca6a;
   --syntax-comment: #7a7a7a;
@@ -117,33 +99,64 @@
   --syntax-type: #4a9eff;
   --syntax-property: #4eca6a;
 
-  /* ---- Diff ---- */
+  /* Diff */
   --diff-add-bg: #1a2e1a;
   --diff-remove-bg: #2e1a1a;
   --diff-add-text: #4eca6a;
   --diff-remove-text: #ff5b5b;
 
-  /* ---- Scrollbar ---- */
+  /* Scrollbar */
   --scrollbar-track: transparent;
   --scrollbar-thumb: #333355;
   --scrollbar-thumb-hover: #444466;
 
-  /* ---- Fonts ---- */
+  /* Fonts */
   --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, Consolas, monospace;
   --font-ui: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 
-  /* ---- Typography scale ---- */
+  /* Typography scale */
   --text-xs: 10px;
   --text-sm: 12px;
   --text-base: 13px;
   --text-md: 14px;
   --text-lg: 16px;
 
-  /* ---- Spacing (4px base grid) ---- */
+  /* Spacing (4px base grid) */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
   --space-4: 16px;
   --space-6: 24px;
   --space-8: 32px;
+
+  /* Typography — chat reading size (chat redesign #6390) */
+  --text-chat: 15px;
+
+  /* Line heights (chat redesign #6390) */
+  --leading-tight: 1.35;
+  --leading-normal: 1.5;
+  --leading-chat: 1.6;
+  --leading-code: 1.5;
+
+  /* Radii (chat redesign #6390) */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-pill: 999px;
+
+  /* Motion — durations (chat redesign #6390) */
+  --dur-fast: 150ms;
+  --dur-base: 200ms;
+  --dur-slow: 280ms;
+
+  /* Motion — easings (chat redesign #6390) */
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Motion — loop timings (chat redesign #6390) */
+  --rail-heartbeat: 1200ms;
+  --rail-breathe: 2400ms;
+  --caret-blink: 1100ms;
+  --waiting-pulse: 1600ms;
 }

--- a/packages/dashboard/src/theme/tokens.ts
+++ b/packages/dashboard/src/theme/tokens.ts
@@ -1,13 +1,10 @@
 /**
- * DO NOT EDIT — generated from theme.css by scripts/generate-theme-tokens.mjs
+ * DO NOT EDIT — generated from @chroxy/design-tokens by
+ * scripts/generate-theme-tokens.mjs.
  *
- * Design tokens for the Chroxy desktop dashboard.
- * Run: npm run dashboard:generate-tokens
+ * Edit tokens in packages/design-tokens/src/tokens-data.js, then run
+ * `npm run generate-tokens` in packages/dashboard.
  */
-
-// ---------------------------------------------------------------------------
-// Colors
-// ---------------------------------------------------------------------------
 
 export const colors = {
   bg: {
@@ -114,10 +111,6 @@ export const colors = {
   },
 } as const
 
-// ---------------------------------------------------------------------------
-// Spacing — 4px base grid
-// ---------------------------------------------------------------------------
-
 export const spacing = {
   1: 4,
   2: 8,
@@ -127,23 +120,49 @@ export const spacing = {
   8: 32,
 } as const
 
-// ---------------------------------------------------------------------------
-// Typography — font sizes in px
-// ---------------------------------------------------------------------------
-
 export const typography = {
   xs: 10,
   sm: 12,
   base: 13,
   md: 14,
   lg: 16,
+  chat: 15,
 } as const
-
-// ---------------------------------------------------------------------------
-// Font stacks
-// ---------------------------------------------------------------------------
 
 export const fonts = {
   mono: "'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, Consolas, monospace",
   ui: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+} as const
+
+export const leading = {
+  tight: 1.35,
+  normal: 1.5,
+  chat: 1.6,
+  code: 1.5,
+} as const
+
+export const radii = {
+  xs: 4,
+  sm: 6,
+  md: 10,
+  lg: 14,
+  pill: 999,
+} as const
+
+export const motion = {
+  durations: {
+    fast: 150,
+    base: 200,
+    slow: 280,
+  },
+  easings: {
+    out: 'cubic-bezier(0.2, 0.8, 0.2, 1)',
+    standard: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  },
+  loops: {
+    railHeartbeat: 1200,
+    railBreathe: 2400,
+    caretBlink: 1100,
+    waitingPulse: 1600,
+  },
 } as const

--- a/packages/design-tokens/index.d.ts
+++ b/packages/design-tokens/index.d.ts
@@ -1,0 +1,17 @@
+/** A titled section of design tokens: a list of `[cssVarName, value]` pairs. */
+export interface TokenGroup {
+  readonly title: string
+  readonly vars: ReadonlyArray<readonly [name: string, value: string]>
+}
+
+/** The canonical token map, in emission order, grouped for `theme.css` sections. */
+export declare const TOKEN_GROUPS: ReadonlyArray<TokenGroup>
+
+/** Flat, ordered list of every `[cssVarName, value]` across all groups. */
+export declare const ALL_TOKENS: ReadonlyArray<readonly [string, string]>
+
+/** Render the dashboard `theme.css` (`:root` custom properties) from the map. */
+export declare function generateThemeCss(): string
+
+/** Render the dashboard `theme/tokens.ts` (typed token objects) from the map. */
+export declare function generateTokensTs(): string

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@chroxy/design-tokens",
+  "version": "0.9.47",
+  "description": "Canonical Chroxy design tokens — single source for the dashboard theme (and, later, mobile). The dashboard theme.css + tokens.ts are generated from here.",
+  "type": "module",
+  "main": "src/index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./src/index.js"
+    }
+  },
+  "files": [
+    "src",
+    "index.d.ts"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "MIT"
+}

--- a/packages/design-tokens/src/index.js
+++ b/packages/design-tokens/src/index.js
@@ -1,0 +1,163 @@
+/**
+ * @chroxy/design-tokens — canonical token map + generators
+ * (chat redesign epic #6389, Phase 0 #6390).
+ *
+ * The dashboard's `theme.css` and `theme/tokens.ts` are GENERATED from
+ * `tokens-data.js` here (pipeline inverted from the old theme.css → tokens.ts
+ * direction). `generateThemeCss()` / `generateTokensTs()` are pure string
+ * builders; the dashboard's `scripts/generate-theme-tokens.mjs` writes them to
+ * disk. The structural-token grouping below MUST keep `colors` / `spacing` /
+ * `typography` / `fonts` byte-shape-compatible with the existing generated
+ * tokens.ts (the only change there is appended new groups), since
+ * `packages/dashboard/src/theme/index.ts` re-exports those four.
+ */
+
+import { TOKEN_GROUPS, ALL_TOKENS } from './tokens-data.js'
+
+export { TOKEN_GROUPS, ALL_TOKENS }
+
+// Color CSS-var prefixes → the `colors` sub-object key in tokens.ts. Mirrors
+// the categorisation the old generate-theme-tokens.mjs applied when parsing CSS.
+const COLOR_SUBS = ['bg', 'text', 'accent', 'border', 'banner', 'warning', 'status', 'syntax', 'diff', 'scrollbar']
+
+function toCamelCase(str) {
+  return str.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase())
+}
+
+/** Bucket every token into the tokens.ts export shape. Throws on an
+ *  unrecognised token so a new prefix can't silently vanish. */
+function categorize() {
+  const g = {
+    colors: {},
+    spacing: {},
+    typography: {},
+    fonts: {},
+    leading: {},
+    radii: {},
+    motion: { durations: {}, easings: {}, loops: {} },
+  }
+  for (const [name, value] of ALL_TOKENS) {
+    // Typography px sizes: --text-xs … --text-lg, plus the new --text-chat.
+    if (name.startsWith('text-') && value.endsWith('px')) {
+      g.typography[toCamelCase(name.slice('text-'.length))] = parseInt(value, 10)
+      continue
+    }
+    if (name.startsWith('leading-')) {
+      g.leading[toCamelCase(name.slice('leading-'.length))] = parseFloat(value)
+      continue
+    }
+    if (name.startsWith('radius-')) {
+      g.radii[toCamelCase(name.slice('radius-'.length))] = parseInt(value, 10)
+      continue
+    }
+    if (name.startsWith('dur-')) {
+      g.motion.durations[toCamelCase(name.slice('dur-'.length))] = parseInt(value, 10)
+      continue
+    }
+    if (name.startsWith('ease-')) {
+      g.motion.easings[toCamelCase(name.slice('ease-'.length))] = value
+      continue
+    }
+    if (/^(rail|caret|waiting)-/.test(name)) {
+      g.motion.loops[toCamelCase(name)] = parseInt(value, 10)
+      continue
+    }
+    let matched = false
+    for (const sub of COLOR_SUBS) {
+      if (name.startsWith(sub + '-')) {
+        if (!g.colors[sub]) g.colors[sub] = {}
+        g.colors[sub][toCamelCase(name.slice(sub.length + 1))] = value
+        matched = true
+        break
+      }
+    }
+    if (matched) continue
+    if (name.startsWith('font-')) {
+      g.fonts[toCamelCase(name.slice('font-'.length))] = value
+      continue
+    }
+    if (name.startsWith('space-')) {
+      g.spacing[toCamelCase(name.slice('space-'.length))] = parseInt(value, 10)
+      continue
+    }
+    throw new Error(`[design-tokens] unmapped token --${name}`)
+  }
+  return g
+}
+
+// Identical rendering contract to the old generate-theme-tokens.mjs:
+// numbers bare, strings single-quoted unless they contain a single quote
+// (font stacks), nested objects recursed.
+function renderObject(obj, indent = 2) {
+  const pad = ' '.repeat(indent)
+  const lines = []
+  for (const [key, val] of Object.entries(obj)) {
+    if (typeof val === 'object' && val !== null) {
+      lines.push(`${pad}${key}: {`)
+      lines.push(renderObject(val, indent + 2))
+      lines.push(`${pad}},`)
+    } else if (typeof val === 'number') {
+      lines.push(`${pad}${key}: ${val},`)
+    } else if (typeof val === 'string' && val.includes("'")) {
+      lines.push(`${pad}${key}: "${val}",`)
+    } else {
+      lines.push(`${pad}${key}: '${val}',`)
+    }
+  }
+  return lines.join('\n')
+}
+
+const GENERATED_HEADER = `/**
+ * DO NOT EDIT — generated from @chroxy/design-tokens by
+ * scripts/generate-theme-tokens.mjs.
+ *
+ * Edit tokens in packages/design-tokens/src/tokens-data.js, then run
+ * \`npm run generate-tokens\` in packages/dashboard.
+ */`
+
+/** Build the dashboard's `theme.css` (`:root` custom properties) from the
+ *  canonical map, with one section comment per token group. */
+export function generateThemeCss() {
+  const lines = [
+    '/* DO NOT EDIT — generated from @chroxy/design-tokens by',
+    ' * scripts/generate-theme-tokens.mjs. Edit tokens in',
+    ' * packages/design-tokens/src/tokens-data.js, then run',
+    ' * `npm run generate-tokens` in packages/dashboard. */',
+    '',
+    ':root {',
+  ]
+  TOKEN_GROUPS.forEach((group, i) => {
+    if (i > 0) lines.push('')
+    lines.push(`  /* ${group.title} */`)
+    for (const [name, value] of group.vars) lines.push(`  --${name}: ${value};`)
+  })
+  lines.push('}')
+  lines.push('')
+  return lines.join('\n')
+}
+
+/** Build the dashboard's `theme/tokens.ts` from the canonical map. The
+ *  `colors`/`spacing`/`typography`/`fonts` exports keep their existing shape;
+ *  `leading`/`radii`/`motion` are the new structural additions. */
+export function generateTokensTs() {
+  const g = categorize()
+  const block = (name, obj) => `export const ${name} = {\n${renderObject(obj)}\n} as const`
+  return [
+    GENERATED_HEADER,
+    '',
+    block('colors', g.colors),
+    '',
+    block('spacing', g.spacing),
+    '',
+    block('typography', g.typography),
+    '',
+    block('fonts', g.fonts),
+    '',
+    block('leading', g.leading),
+    '',
+    block('radii', g.radii),
+    '',
+    block('motion', g.motion),
+    '',
+  ].join('\n')
+}

--- a/packages/design-tokens/src/tokens-data.js
+++ b/packages/design-tokens/src/tokens-data.js
@@ -1,0 +1,240 @@
+/**
+ * Canonical Chroxy design tokens (chat redesign epic #6389, Phase 0 #6390).
+ *
+ * SINGLE SOURCE OF TRUTH for the dashboard theme. `theme.css` and
+ * `tokens.ts` in packages/dashboard are GENERATED from this map by
+ * `generateThemeCss()` / `generateTokensTs()` (see ./index.js) — the
+ * pipeline is inverted from the old "theme.css -> tokens.ts" direction.
+ * Edit tokens HERE, then run `npm run generate-tokens` in packages/dashboard.
+ *
+ * The existing color/spacing/typography/font values are the navy "Default"
+ * theme verbatim (the redesign keeps navy); the new groups below add the
+ * structural tokens (chat reading size, line heights, radii, motion).
+ *
+ * Each group is { title, vars: [[cssVarName, value], ...] }.
+ */
+
+export const TOKEN_GROUPS = [
+  {
+    title: "Backgrounds",
+    vars: [
+      ["bg-primary", "#0f0f1a"],
+      ["bg-secondary", "#1a1a2e"],
+      ["bg-tertiary", "#16162a"],
+      ["bg-card", "#2a2a4e"],
+      ["bg-input", "#0f0f1a"],
+      ["bg-terminal", "#000000"],
+      ["bg-header", "#151528"],
+      ["bg-session-bar", "#12121f"],
+      ["bg-code-block", "#0a0a18"],
+      ["bg-tool-bubble", "#161625"],
+      ["bg-permission", "#1e1a30"],
+      ["bg-question", "#1a2530"],
+      ["bg-plan-banner", "#2a1a40"],
+      ["bg-modal", "#1a1a2e"],
+    ],
+  },
+  {
+    title: "Text",
+    vars: [
+      ["text-primary", "#ffffff"],
+      ["text-secondary", "#cccccc"],
+      ["text-muted", "#888888"],
+      ["text-dim", "#666666"],
+      ["text-disabled", "#555555"],
+      ["text-error", "#e8a0a0"],
+      ["text-system", "#b0b0b0"],
+      ["text-link", "#4a9eff"],
+      ["text-emphasis", "#b0b8d0"],
+      ["text-heading", "#f0f0f0"],
+      ["text-blockquote", "#999999"],
+    ],
+  },
+  {
+    title: "Accents",
+    vars: [
+      ["accent-blue", "#4a9eff"],
+      ["accent-green", "#22c55e"],
+      ["accent-purple", "#a78bfa"],
+      ["accent-orange", "#f59e0b"],
+      ["accent-red", "#ff4a4a"],
+    ],
+  },
+  {
+    title: "Accent opacity variants",
+    vars: [
+      ["accent-blue-light", "#4a9eff22"],
+      ["accent-blue-subtle", "#4a9eff33"],
+      ["accent-blue-border", "#4a9eff44"],
+      ["accent-blue-border-strong", "#4a9eff66"],
+      ["accent-green-light", "#22c55e22"],
+      ["accent-green-border", "#22c55e33"],
+      ["accent-green-border-strong", "#22c55e66"],
+      ["accent-purple-light", "#a78bfa22"],
+      ["accent-purple-subtle", "#a78bfa33"],
+      ["accent-purple-border-strong", "#a78bfa66"],
+      ["accent-purple-code", "#c4a5ff"],
+      ["accent-orange-light", "#f59e0b11"],
+      ["accent-orange-subtle", "#f59e0b22"],
+      ["accent-orange-medium", "#f59e0b33"],
+      ["accent-orange-border", "#f59e0b44"],
+      ["accent-orange-border-strong", "#f59e0b66"],
+      ["accent-red-light", "#ff4a4a11"],
+      ["accent-red-subtle", "#ff4a4a22"],
+      ["accent-red-border", "#ff4a4a44"],
+    ],
+  },
+  {
+    title: "Tailwind-scale (distinct base hexes, not opacity variants of the brand hex)",
+    vars: [
+      ["accent-orange-500", "#f97316"],
+      ["accent-yellow-500", "#eab308"],
+      ["accent-red-500", "#ef4444"],
+    ],
+  },
+  {
+    title: "Borders",
+    vars: [
+      ["border-primary", "#2a2a4e"],
+      ["border-secondary", "#3a3a5e"],
+      ["border-subtle", "#4a4a6e"],
+      ["border-focus", "#4a9eff"],
+      ["border-permission", "#4a3a7a"],
+      ["border-question", "#2a5a7a"],
+    ],
+  },
+  {
+    title: "Banner borders",
+    vars: [
+      ["banner-border-subtle", "#252540"],
+    ],
+  },
+  {
+    title: "Warning (amber-yellow, distinct from --accent-orange)",
+    vars: [
+      ["warning-fg", "#fbbf24"],
+      ["warning-bg-subtle", "#fbbf2422"],
+    ],
+  },
+  {
+    title: "Status indicators",
+    vars: [
+      ["status-connected", "#22c55e"],
+      ["status-disconnected", "#ef4444"],
+      ["status-connecting", "#eab308"],
+      ["status-restarting", "#f59e0b"],
+    ],
+  },
+  {
+    title: "Syntax highlighting",
+    vars: [
+      ["syntax-keyword", "#c4a5ff"],
+      ["syntax-string", "#4eca6a"],
+      ["syntax-comment", "#7a7a7a"],
+      ["syntax-number", "#ff9a52"],
+      ["syntax-function", "#4a9eff"],
+      ["syntax-operator", "#e0e0e0"],
+      ["syntax-punctuation", "#888888"],
+      ["syntax-plain", "#a0d0ff"],
+      ["syntax-type", "#4a9eff"],
+      ["syntax-property", "#4eca6a"],
+    ],
+  },
+  {
+    title: "Diff",
+    vars: [
+      ["diff-add-bg", "#1a2e1a"],
+      ["diff-remove-bg", "#2e1a1a"],
+      ["diff-add-text", "#4eca6a"],
+      ["diff-remove-text", "#ff5b5b"],
+    ],
+  },
+  {
+    title: "Scrollbar",
+    vars: [
+      ["scrollbar-track", "transparent"],
+      ["scrollbar-thumb", "#333355"],
+      ["scrollbar-thumb-hover", "#444466"],
+    ],
+  },
+  {
+    title: "Fonts",
+    vars: [
+      ["font-mono", "'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, Consolas, monospace"],
+      ["font-ui", "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"],
+    ],
+  },
+  {
+    title: "Typography scale",
+    vars: [
+      ["text-xs", "10px"],
+      ["text-sm", "12px"],
+      ["text-base", "13px"],
+      ["text-md", "14px"],
+      ["text-lg", "16px"],
+    ],
+  },
+  {
+    title: "Spacing (4px base grid)",
+    vars: [
+      ["space-1", "4px"],
+      ["space-2", "8px"],
+      ["space-3", "12px"],
+      ["space-4", "16px"],
+      ["space-6", "24px"],
+      ["space-8", "32px"],
+    ],
+  },
+  {
+    title: "Typography — chat reading size (chat redesign #6390)",
+    vars: [
+      ["text-chat", "15px"],
+    ],
+  },
+  {
+    title: "Line heights (chat redesign #6390)",
+    vars: [
+      ["leading-tight", "1.35"],
+      ["leading-normal", "1.5"],
+      ["leading-chat", "1.6"],
+      ["leading-code", "1.5"],
+    ],
+  },
+  {
+    title: "Radii (chat redesign #6390)",
+    vars: [
+      ["radius-xs", "4px"],
+      ["radius-sm", "6px"],
+      ["radius-md", "10px"],
+      ["radius-lg", "14px"],
+      ["radius-pill", "999px"],
+    ],
+  },
+  {
+    title: "Motion — durations (chat redesign #6390)",
+    vars: [
+      ["dur-fast", "150ms"],
+      ["dur-base", "200ms"],
+      ["dur-slow", "280ms"],
+    ],
+  },
+  {
+    title: "Motion — easings (chat redesign #6390)",
+    vars: [
+      ["ease-out", "cubic-bezier(0.2, 0.8, 0.2, 1)"],
+      ["ease-standard", "cubic-bezier(0.4, 0, 0.2, 1)"],
+    ],
+  },
+  {
+    title: "Motion — loop timings (chat redesign #6390)",
+    vars: [
+      ["rail-heartbeat", "1200ms"],
+      ["rail-breathe", "2400ms"],
+      ["caret-blink", "1100ms"],
+      ["waiting-pulse", "1600ms"],
+    ],
+  },
+]
+
+/** Flat, ordered list of every [cssVarName, value] across all groups. */
+export const ALL_TOKENS = TOKEN_GROUPS.flatMap((g) => g.vars)

--- a/packages/design-tokens/test/index.test.js
+++ b/packages/design-tokens/test/index.test.js
@@ -1,0 +1,53 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { TOKEN_GROUPS, ALL_TOKENS, generateThemeCss, generateTokensTs } from '../src/index.js'
+
+const parseCssVars = (css) => {
+  const root = css.match(/:root\s*\{([\s\S]+)\}/)[1]
+  const m = {}
+  for (const line of root.split('\n')) {
+    const mm = line.match(/^\s*--([\w-]+):\s*(.+?)\s*;/)
+    if (mm) m[mm[1]] = mm[2]
+  }
+  return m
+}
+
+test('token map has no duplicate CSS var names', () => {
+  const names = ALL_TOKENS.map(([n]) => n)
+  assert.equal(new Set(names).size, names.length)
+})
+
+test('generateThemeCss emits every token exactly once, parseably', () => {
+  const vars = parseCssVars(generateThemeCss())
+  assert.equal(Object.keys(vars).length, ALL_TOKENS.length)
+  for (const [name, value] of ALL_TOKENS) assert.equal(vars[name], value)
+})
+
+test('navy palette + structural tokens are present with expected values', () => {
+  const vars = parseCssVars(generateThemeCss())
+  assert.equal(vars['bg-primary'], '#0f0f1a') // navy preserved
+  assert.equal(vars['accent-blue'], '#4a9eff')
+  assert.equal(vars['text-chat'], '15px') // new chat reading size
+  assert.equal(vars['radius-md'], '10px')
+  assert.equal(vars['dur-base'], '200ms')
+  assert.match(vars['ease-out'], /^cubic-bezier/)
+})
+
+test('generateTokensTs exports the existing + new groups and compiles-shaped output', () => {
+  const ts = generateTokensTs()
+  for (const grp of ['colors', 'spacing', 'typography', 'fonts', 'leading', 'radii', 'motion']) {
+    assert.match(ts, new RegExp(`export const ${grp} = \\{`), `missing export ${grp}`)
+  }
+  assert.match(ts, /chat: 15,/) // text-chat folded into typography
+  assert.match(ts, /radii = \{[\s\S]*md: 10,/)
+  assert.match(ts, /motion = \{[\s\S]*durations: \{[\s\S]*base: 200,/)
+})
+
+test('generateTokensTs is deterministic (stable output)', () => {
+  assert.equal(generateTokensTs(), generateTokensTs())
+  assert.equal(generateThemeCss(), generateThemeCss())
+})
+
+test('every group is non-empty', () => {
+  for (const g of TOKEN_GROUPS) assert.ok(g.vars.length > 0, `empty group ${g.title}`)
+})


### PR DESCRIPTION
Third slice of **Phase 0** (#6390) for the chat redesign (#6389) — the spine.

Inverts the token pipeline: a new **`@chroxy/design-tokens`** package is now the single source of truth, and the dashboard's `theme.css` + `theme/tokens.ts` are **generated from it** (old direction was `theme.css` → `tokens.ts`). Adds the structural tokens the redesign needs over the **existing navy palette, which is preserved byte-exact**.

### What's in it
- **`packages/design-tokens`** — `tokens-data.js` (the 95 navy tokens, bootstrapped exactly from the current `theme.css`, + 19 new structural ones), `generateThemeCss()` / `generateTokensTs()`, types, and a `node:test` suite (6).
- **New structural tokens** (chat redesign §3): `--text-chat: 15px`, line heights (`--leading-*`), radii (`--radius-*`), motion (`--dur-*`, `--ease-*`, rail/caret loop timings).
- **Dashboard** — `generate-theme-tokens.mjs` rewritten to read the package; `theme.css` + `tokens.ts` regenerated; the `theme` barrel now also exposes `leading`/`radii`/`motion`; `theme-engine.test.ts` excludes the new structural tokens from the `ALL_CSS_VARS` cleanup list (they're theme-invariant, like the existing `font-`/`space-`/`text-size` exclusions).
- **CI** — the existing "generated tokens up-to-date" gate now also covers `theme.css`.

### Safety
- **Round-trip proof:** generating `theme.css` back from the package preserves **all 95 existing token values byte-exact** (19 added); the `tokens.ts` `colors`/`spacing`/`fonts` blocks are byte-identical, `typography` gains only `chat`. So the live navy theme is provably unchanged.
- Full dashboard suite green (**4087 tests**), production build succeeds, dashboard `tsc` clean, generator idempotent.

### Deferred (follow-up)
Feeding mobile's `packages/app/src/constants/colors.ts` from the package is **not** in this PR — mobile uses divergent key naming (`backgroundPrimary` vs `--bg-primary`) and has app-only keys, so force-generating it would risk the app's ~1900 literal references. The overlapping values already agree, so it's low-urgency; tracked for a follow-up.

> Note: `theme.css` is now generated, so its previous prose comments are replaced by per-group section comments (the load-bearing disambiguations — e.g. "Tailwind-scale (distinct base hexes…)", "Warning (amber-yellow, distinct from --accent-orange)" — are carried as group titles in `tokens-data.js`).

Part of #6390 · epic #6389.
