### PR TITLE
feat(dashboard): relax chat reading scale onto Phase 0 tokens (chat redesign Phase 1)

### DIFF
--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2593,9 +2593,12 @@ button.sidebar-token-view-session-row:hover {
      wall — without min-width: 0 the bubble blew past it. */
   min-width: 0;
   padding: 10px 14px;
-  border-radius: 12px;
-  font-size: var(--text-md);
-  line-height: 1.55;
+  /* Chat redesign #6391: relaxed reading scale + soft-card radius, re-pointed
+     at the Phase 0 design tokens (theme.css). Body goes 14px/1.55 -> the
+     dedicated chat size 15px/1.6; radius 12px -> the canonical --radius-md. */
+  border-radius: var(--radius-md);
+  font-size: var(--text-chat);
+  line-height: var(--leading-chat);
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
@@ -2700,7 +2703,7 @@ button.sidebar-token-view-session-row:hover {
 .msg-timestamp {
   display: block;
   text-align: right;
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   opacity: 0.6;
   margin-top: 4px;


### PR DESCRIPTION
First slice of **Phase 1** (#6391) for the chat redesign (#6389).

Re-points the chat message chrome at the Phase 0 design tokens (already emitted into `theme.css` by `@chroxy/design-tokens`):
- body `var(--text-md)` 14px / 1.55 line-height -> the dedicated `var(--text-chat)` (15px) / `var(--leading-chat)` (1.6) — the relaxed reading scale.
- bubble radius 12px -> `var(--radius-md)` (10px).
- timestamp `0.7rem` -> `var(--text-xs)`.

Headers (`.msg h1/h2/h3`) stay `em`-relative so they scale with the body automatically. **Pure CSS, one seam** (`components.css`) — no JS/state/protocol change, no new files. It's the visible "change the token, the whole chat surface moves" proof that Phase 0's inverted pipeline pays off, and it sets the relaxed scale the no-bubble hierarchy (next slice) builds on.

Verified: production build, `tsc`, dashboard theme + ChatView tests green; CI's Dashboard Smoke (Playwright) exercises it. Conservative scale change — worth a quick eyeball when convenient.

Part of #6391 · epic #6389.