### PR TITLE
feat(dashboard): no-bubble assistant — responses on the bare canvas (chat redesign Phase 1)

### DIFF
--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2604,9 +2604,17 @@ button.sidebar-token-view-session-row:hover {
 }
 
 .msg.assistant {
-  background: var(--bg-secondary);
+  /* Chat redesign #6391 (no-bubble three-tier hierarchy): the assistant
+     response sits on the BARE chat canvas — no card, no tail — so a long agent
+     turn reads like a document, not a wall of grey bubbles. The user keeps its
+     card (.msg.user) and tool calls keep theirs (.msg.tool); only the
+     assistant prose loses its bubble. Markdown chrome (code blocks,
+     blockquotes, inline code) keeps its own surfaces since those rules hang off
+     `.msg` descendants, not the bubble background. */
+  background: transparent;
   align-self: flex-start;
-  border-bottom-left-radius: 4px;
+  padding: 2px 0;
+  border-radius: 0;
 }
 
 .msg.user {


### PR DESCRIPTION
Slice 2 of **Phase 1** (#6391) for the chat redesign (#6389) — the highest-value rendering decision.

Strips the bubble chrome from assistant responses: `.msg.assistant` goes **transparent** (no background, no tail radius, flush padding), so the assistant prose sits on the bare chat canvas. The **user keeps its card** (`.msg.user`) and **tool calls keep theirs** (`.msg.tool`) — the three-tier hierarchy from the spec. A long agent turn now reads like a document, not a wall of grey bubbles.

CSS-only, one rule in `components.css` — no JSX/row-shell change (the row logic already routes `response → .msg.assistant`, and markdown chrome like code blocks/blockquotes keeps its own surfaces since those rules hang off `.msg` descendants, not the bubble bg). Builds on slice 1 (#6400).

Verified: production build, `tsc`, full dashboard suite (4087) green; CI's Dashboard Smoke (Playwright) renders it. **Visible change** — worth a quick eyeball, trivially revertable (one CSS block) if spacing wants tuning.

Part of #6391 · epic #6389.