### PR TITLE
feat(dashboard): wire canonical chat-activity state into the composer (chat redesign Phase 1)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -14,6 +14,7 @@ import {
   resolveContextWindow,
   providerSupportsMultiQuestion,
   formatToolName,
+  deriveChatActivity,
   type SessionInfo,
 } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
@@ -1213,6 +1214,22 @@ export function App() {
   // for the header indicator so we don't scan every session's messages twice;
   // the badge adds crashed-session count on top (failed slice, inside the hook).
   useTrayBadgeSync(pendingPermissionTotal)
+
+  // Chat redesign #6391 (slice 3): the dashboard's canonical per-session chat
+  // activity (idle/thinking/busy/waiting/error), replacing the ad-hoc binary
+  // isBusy. Feeds the store's raw signals into store-core's deriveChatActivity
+  // — the SAME machine the mobile app uses (#6396) — so the composer's live
+  // hairline + state-lozenge (slices 4-5) read one source instead of N
+  // independent isBusy/isStreaming derivations. Exposed to the composer as a
+  // data attribute; startedAt continuity is wired when slice 6 (footer-stat
+  // thinking) consumes it.
+  const chatActivity = deriveChatActivity({
+    isIdle: isIdle ?? true,
+    streamingMessageId: streamingMessageId ?? null,
+    isPlanPending: isPlanPending ?? false,
+    pendingPermission: (pendingPermissionCounts[activeSessionId ?? ''] ?? 0) > 0,
+  })
+
   const handleJumpToPending = useCallback(() => {
     const orderedIds = sessionTabs.map(t => t.sessionId)
     const next = selectNextPendingSession(orderedIds, pendingPermissionCounts, activeSessionId)
@@ -2379,6 +2396,7 @@ export function App() {
               disabled={!isConnected}
               isBusy={!isIdle}
               isStreaming={streamingMessageId !== null}
+              chatActivityState={chatActivity.state}
               placeholder={isConnected ? `Type a message... (${inputSettings.chatEnterToSend ? 'Enter' : formatShortcutKeys('Cmd+Enter')} to send)` : 'Connecting...'}
               controlledValue={inputDraftValue}
               onValueChange={handleDraftChange}

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -16,6 +16,15 @@ describe('InputBar', () => {
     expect(screen.getByTestId('send-button')).toBeInTheDocument()
   })
 
+  it('exposes the chat-activity state as a data attribute (chat redesign #6391)', () => {
+    const { rerender } = render(
+      <InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="streaming" />,
+    )
+    expect(screen.getByTestId('input-bar')).toHaveAttribute('data-activity-state', 'streaming')
+    rerender(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="waiting" />)
+    expect(screen.getByTestId('input-bar')).toHaveAttribute('data-activity-state', 'waiting')
+  })
+
   it('calls onSend with input text on send button click', () => {
     const onSend = vi.fn()
     render(<InputBar onSend={onSend} onInterrupt={vi.fn()} />)

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -64,6 +64,11 @@ export interface InputBarProps {
   disabled?: boolean
   isBusy?: boolean
   isStreaming?: boolean
+  /** Chat redesign #6391: the canonical chat-activity state
+   *  (idle/thinking/busy/waiting/error) from store-core's deriveChatActivity.
+   *  Surfaced as a `data-activity-state` attribute so the live hairline +
+   *  state-lozenge (slices 4-5) are pure CSS keyed off it. */
+  chatActivityState?: string
   placeholder?: string
   filePickerFiles?: FilePickerItem[] | null
   onFileTrigger?: () => void
@@ -182,7 +187,7 @@ const PTT_TYPING_GUARD_MS = 250
 //   - 'recording' : the timer fired while still held → voice capture is live
 type PttState = 'idle' | 'arming' | 'recording'
 
-export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory, highlightThinkingKeywords }: InputBarProps) {
+export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, chatActivityState, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory, highlightThinkingKeywords }: InputBarProps) {
   const [internalValue, setInternalValue] = useState('')
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
@@ -1017,6 +1022,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     <div
       className={`input-bar${dragging ? ' dragging' : ''}`}
       data-testid="input-bar"
+      data-activity-state={chatActivityState}
       onDragOver={handleDragOver}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}


### PR DESCRIPTION
Slice 3 of **Phase 1** (#6391) — the (invisible) foundation for the composer slices.

The dashboard has no canonical chat-activity state today: it derives a binary `isBusy = !isIdle` independently at 5+ sites. This wires in store-core's `deriveChatActivity` (the same machine the mobile app uses since #6396), fed from the store's raw signals:
- `isIdle` / `streamingMessageId` / `isPlanPending` from `getActiveSessionState()`,
- `pendingPermission` from `pendingPermissionCounts[activeSessionId]`,

and exposes the result to the composer as a **`data-activity-state`** attribute on `.input-bar` (idle/thinking/busy/waiting/error).

**No visible change** — it just makes the canonical state available. The live hairline + state-lozenge (slice 4) and send/stop morph (slice 5) become pure CSS/markup keyed off the attribute. `startedAt` continuity (a `useRef`) is deferred to slice 6, its first consumer.

Verified: `tsc`, build, full dashboard suite (4088, +1 new InputBar test asserting the attribute) green.

Part of #6391 · epic #6389.