### PR TITLE
feat(dashboard): always-visible Enter-mode keyhint (chat redesign Phase 1)

### DIFF
--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -25,6 +25,17 @@ describe('InputBar', () => {
     expect(screen.getByTestId('input-bar')).toHaveAttribute('data-activity-state', 'waiting')
   })
 
+  it('shows an always-visible Enter-mode keyhint (chat redesign #6391)', () => {
+    const { rerender } = render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} sendOnEnter />)
+    const hint = screen.getByTestId('input-bar-keyhint')
+    expect(hint).toBeInTheDocument()
+    expect(hint.textContent).toContain('send')
+    expect(hint.textContent).toContain('newline')
+    rerender(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} sendOnEnter={false} />)
+    expect(screen.getByTestId('input-bar-keyhint').textContent).toContain('send')
+    expect(screen.getByTestId('input-bar-keyhint').textContent).not.toContain('newline')
+  })
+
   it('calls onSend with input text on send button click', () => {
     const onSend = vi.fn()
     render(<InputBar onSend={onSend} onInterrupt={vi.fn()} />)

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -1169,6 +1169,12 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, c
         />
       </div>
       <div className="input-bar-actions">
+        {/* Chat redesign #6391 (slice 5): always-visible Enter-mode keyhint so
+            the send key is never a guess. aria-hidden — the sr-only
+            #shortcutsId span above carries the full hint for screen readers. */}
+        <span className="input-bar-keyhint" aria-hidden="true" data-testid="input-bar-keyhint">
+          {sendOnEnter ? '⏎ send · ⇧⏎ newline' : '⌘⏎ send'}
+        </span>
         {voiceInput?.isAvailable && (
           <button
             data-testid="mic-button"

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4911,6 +4911,18 @@ button.sidebar-token-view-session-row:hover {
   flex-shrink: 0;
 }
 
+/* Chat redesign #6391 (slice 5): always-visible Enter-mode keyhint. Muted and
+   small, sits inline before the action buttons — no extra row, so the composer
+   height never churns. Tokens only (ratchet-clean). */
+.input-bar-keyhint {
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  opacity: 0.7;
+  white-space: nowrap;
+  user-select: none;
+  margin-right: 2px;
+}
+
 .btn-mic {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Slice 5 of **Phase 1** (#6391) — the always-visible Enter-mode keyhint.

The composer's send key is no longer a guess: a muted hint sits inline in the actions row — **send on Enter / Shift+Enter for a newline** (or **Cmd/Ctrl+Enter to send** when Enter inserts a newline), driven by the `sendOnEnter` setting. Placed before the buttons so there's **no extra row -> no composer height churn**; `aria-hidden` since the existing `sr-only` shortcuts span already carries it for screen readers. Tokens only (ratchet-clean).

**Scope note:** the *send/stop visual morph* (the other half of planned slice 5) is **deferred**. During streaming the composer deliberately renders **both** a follow-up Send **and** Stop (the queue-while-streaming affordance) — a literal single-button morph would break that, so it needs a careful restyle that keeps both buttons. Tracked for a follow-on.

Verified: `tsc`, build, full dashboard suite (4089, +1 keyhint test) green.

Part of #6391 · epic #6389.