### PR TITLE
feat(dashboard): group the slash-command picker by source (chat redesign Phase 1)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -457,6 +457,17 @@ export function App() {
 
   const slashCommands = useConnectionStore(s => s.slashCommands)
 
+  // Chat redesign #6391 (slice 8): order slash commands by source so the picker
+  // renders clean Built-in / Project / User groups (and the "builtins pinned
+  // above" intent in the SlashCommand docstring is actually enforced). Stable
+  // within each group; the parent's keyboard nav (InputBar `filteredCommands`)
+  // reads this same ordering, so selection stays coherent across the grouped
+  // display.
+  const orderedSlashCommands = useMemo(() => {
+    const rank = (s: string) => (s === 'builtin' ? 0 : s === 'project' ? 1 : 2)
+    return [...slashCommands].sort((a, b) => rank(a.source) - rank(b.source))
+  }, [slashCommands])
+
   // Store actions (stable refs)
   const connect = useConnectionStore(s => s.connect)
   const retryConnection = useConnectionStore(s => s.retryConnection)
@@ -2404,7 +2415,7 @@ export function App() {
               onFileTrigger={fetchFileList}
               attachments={fileAttachments}
               onRemoveAttachment={handleRemoveAttachment}
-              slashCommands={slashCommands}
+              slashCommands={orderedSlashCommands}
               onSlashTrigger={fetchSlashCommands}
               onImagePaste={handleImagePaste}
               onImageDrop={handleImageDrop}

--- a/packages/dashboard/src/components/SlashCommandPicker.test.tsx
+++ b/packages/dashboard/src/components/SlashCommandPicker.test.tsx
@@ -30,6 +30,24 @@ describe('SlashCommandPicker', () => {
     expect(screen.getByText('/fix-ci')).toBeInTheDocument()
   })
 
+  it('renders source group headers (chat redesign #6391)', () => {
+    render(
+      <SlashCommandPicker
+        commands={[
+          { name: 'clear', description: 'Clear', source: 'builtin' as const },
+          { name: 'commit', description: 'Commit', source: 'project' as const },
+          { name: 'learn', description: 'Learn', source: 'user' as const },
+        ]}
+        filter=""
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Built-in')).toBeInTheDocument()
+    expect(screen.getByText('Project')).toBeInTheDocument()
+    expect(screen.getByText('User')).toBeInTheDocument()
+  })
+
   it('shows command descriptions', () => {
     render(
       <SlashCommandPicker

--- a/packages/dashboard/src/components/SlashCommandPicker.tsx
+++ b/packages/dashboard/src/components/SlashCommandPicker.tsx
@@ -4,8 +4,16 @@
  * Appears above the InputBar when user types "/" at the start of input.
  * Supports filtering, keyboard navigation, and selection.
  */
-import { useEffect, useRef, useMemo } from 'react'
+import { Fragment, useEffect, useRef, useMemo } from 'react'
 import type { SlashCommand } from '../store/types'
+
+// Chat redesign #6391 (slice 8): section headers for the source groups. Any
+// future/unknown source falls into "Other".
+const SLASH_GROUP_LABEL: Record<string, string> = {
+  builtin: 'Built-in',
+  project: 'Project',
+  user: 'User',
+}
 
 export interface SlashCommandPickerProps {
   commands: SlashCommand[]
@@ -56,31 +64,44 @@ export function SlashCommandPicker({
   return (
     <div className="slash-picker" data-testid="slash-picker" ref={ref}>
       <div role="listbox" aria-label="Slash commands">
-        {filtered.map((cmd, i) => (
-          <div
-            key={cmd.name}
-            role="option"
-            aria-selected={i === selectedIndex}
-            className={`slash-picker-item${i === selectedIndex ? ' selected' : ''}`}
-            onClick={() => onSelect(cmd.name)}
-          >
-            <div className="slash-picker-name">/{cmd.name}</div>
-            <div className="slash-picker-desc">{cmd.description}</div>
-            {/*
-              #3856 — surface a chip on each row so users can tell a
-              provider built-in (locked, can't be shadowed) apart from a
-              user/project markdown skill (their own file, safe to edit).
-              `project` is the implicit default and stays badgeless to keep
-              the row chrome quiet for the most common case.
-            */}
-            {cmd.source === 'builtin' && (
-              <span className="slash-picker-badge slash-picker-badge-builtin">built-in</span>
-            )}
-            {cmd.source === 'user' && (
-              <span className="slash-picker-badge">user</span>
-            )}
-          </div>
-        ))}
+        {filtered.map((cmd, i) => {
+          // #6391 (slice 8): insert a source group header whenever the source
+          // changes. The list is sorted by source upstream (App.tsx), so this
+          // produces clean Built-in / Project / User sections without reordering
+          // here — the flat index `i` stays the keyboard-nav index.
+          const showHeader = i === 0 || filtered[i - 1]!.source !== cmd.source
+          return (
+            <Fragment key={cmd.name}>
+              {showHeader && (
+                <div className="slash-picker-group" role="presentation">
+                  {SLASH_GROUP_LABEL[cmd.source] ?? 'Other'}
+                </div>
+              )}
+              <div
+                role="option"
+                aria-selected={i === selectedIndex}
+                className={`slash-picker-item${i === selectedIndex ? ' selected' : ''}`}
+                onClick={() => onSelect(cmd.name)}
+              >
+                <div className="slash-picker-name">/{cmd.name}</div>
+                <div className="slash-picker-desc">{cmd.description}</div>
+                {/*
+                  #3856 — surface a chip on each row so users can tell a
+                  provider built-in (locked, can't be shadowed) apart from a
+                  user/project markdown skill (their own file, safe to edit).
+                  `project` is the implicit default and stays badgeless to keep
+                  the row chrome quiet for the most common case.
+                */}
+                {cmd.source === 'builtin' && (
+                  <span className="slash-picker-badge slash-picker-badge-builtin">built-in</span>
+                )}
+                {cmd.source === 'user' && (
+                  <span className="slash-picker-badge">user</span>
+                )}
+              </div>
+            </Fragment>
+          )
+        })}
       </div>
     </div>
   )

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4385,6 +4385,17 @@ button.sidebar-token-view-session-row:hover {
   transition: background 0.1s;
 }
 
+/* Chat redesign #6391 (slice 8): source group header in the slash picker
+   (Built-in / Project / User). Quiet, uppercase, token-only. */
+.slash-picker-group {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  padding: 6px 12px 2px;
+  user-select: none;
+}
+
 .slash-picker-item:hover,
 .slash-picker-item.selected {
   background: var(--bg-card);


### PR DESCRIPTION
Slice 8 of **Phase 1** (#6391) — the categorized slash menu.

The slash-command picker now renders **source group headers** — **Built-in / Project / User** — instead of a flat list.

- **No new field:** reuses the existing `SlashCommand.source` (`builtin`/`project`/`user`) — no store-core/protocol change.
- **Nav-coherent:** App.tsx sorts the command list by source *once* (`useMemo`), so both the picker's grouped display AND InputBar's keyboard-nav (`filteredCommands`) read the same order — selection stays correct across groups (headers inserted on source-change without reordering, preserving the flat nav index). Also enforces the "builtins pinned above" intent already documented on the type.
- Token-only header styling (ratchet-clean).

Verified: `tsc`, build, full dashboard suite (4090, +1 grouping test) green; existing picker tests still pass.

Part of #6391 · epic #6389.