### PR TITLE
feat: auto-collapse long tool output behind a Show-more pill (chat redesign Phase 1)

### DIFF
--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -32,6 +32,20 @@ describe('ToolBubble', () => {
     expect(toggle).toBeInTheDocument()
   })
 
+  it('collapses a long tool result behind a Show-more pill (chat redesign #6391)', () => {
+    const longResult = Array.from({ length: 20 }, (_, i) => `line${i + 1}`).join('\n')
+    render(<ToolBubble {...baseProps} result={longResult} isTail />)
+    const resultEl = () => document.getElementById('tool-result-tool-1')!
+    const expandBtn = screen.getByTestId('tool-result-expand-tool-1')
+    expect(expandBtn).toHaveTextContent('Show 8 more lines')
+    // collapsed: head (line1..line12) shown, tail (line13..line20) hidden
+    expect(resultEl().textContent).toContain('line12')
+    expect(resultEl().textContent).not.toContain('line13')
+    fireEvent.click(expandBtn)
+    expect(resultEl().textContent).toContain('line20')
+    expect(screen.getByTestId('tool-result-collapse-tool-1')).toBeInTheDocument()
+  })
+
   it('has aria-expanded reflecting collapsed state', () => {
     render(<ToolBubble {...baseProps} />)
     const toggle = screen.getByRole('button')

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -29,6 +29,8 @@ import {
   getPartialSummary,
   tryParseCompleteJson,
   shouldSuppressRawToolInput,
+  TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD,
+  TOOL_OUTPUT_COLLAPSE_HEAD_LINES,
 } from '@chroxy/store-core'
 import type { ChildAgentEvent, ToolResultImage } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
@@ -177,6 +179,13 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   const todoParsed = expanded && result && toolName === 'TodoWrite'
     ? parseTodoList(result)
     : null
+  // #6391 (slice 7): collapse a long tool result to its head behind a "Show N
+  // more lines" pill. Independent of the bubble's own expand/collapse; the
+  // per-row ResizeObserver (MeasuredRow, #5561) re-measures the row when this
+  // toggles, so the virtualized list stays correct with no extra plumbing.
+  const [resultExpanded, setResultExpanded] = useState(false)
+  const resultLineCount = useMemo(() => (result ? result.split('\n').length : 0), [result])
+  const isLongResult = !todoParsed && resultLineCount > TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD
   // #4081: streaming preview — render the accumulator as a code block
   // while the result hasn't arrived. Best-effort pretty-print: try
   // JSON.parse first (the final delta often completes the JSON), fall
@@ -262,14 +271,38 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
         // outer onClick that collapses the bubble — otherwise selecting
         // text or interacting with the checklist accidentally re-toggles.
         <div
-          className="tool-result"
+          className={`tool-result${isLongResult ? ' tool-result--unbounded' : ''}`}
           id={resultId}
           onClick={(e) => e.stopPropagation()}
         >
           {todoParsed ? (
             <TodoList parsed={todoParsed} />
+          ) : isLongResult && !resultExpanded ? (
+            <>
+              <pre>{result!.split('\n').slice(0, TOOL_OUTPUT_COLLAPSE_HEAD_LINES).join('\n')}</pre>
+              <button
+                type="button"
+                className="tool-result-expand"
+                data-testid={`tool-result-expand-${toolUseId}`}
+                onClick={() => setResultExpanded(true)}
+              >
+                Show {resultLineCount - TOOL_OUTPUT_COLLAPSE_HEAD_LINES} more lines
+              </button>
+            </>
           ) : (
-            <pre>{result}</pre>
+            <>
+              <pre>{result}</pre>
+              {isLongResult && (
+                <button
+                  type="button"
+                  className="tool-result-expand"
+                  data-testid={`tool-result-collapse-${toolUseId}`}
+                  onClick={() => setResultExpanded(false)}
+                >
+                  Show less
+                </button>
+              )}
+            </>
           )}
         </div>
       )}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2936,6 +2936,29 @@ button.sidebar-token-view-session-row:hover {
   color: var(--text-secondary);
 }
 
+/* Chat redesign #6391 (slice 7): a long tool result manages its own length via
+   the "Show N more lines" collapse pill, so drop the fixed 200px scroll cap
+   when collapsible (the cap stays for short results, and the toggle button must
+   not be trapped inside a scroll box). The toggle re-measures the row via the
+   per-row ResizeObserver, so the virtualized list stays correct. */
+.tool-result--unbounded {
+  max-height: none;
+  overflow-y: visible;
+}
+.tool-result-expand {
+  display: block;
+  margin-top: 6px;
+  padding: 2px 0;
+  background: none;
+  border: none;
+  color: var(--accent-blue);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+.tool-result-expand:hover {
+  text-decoration: underline;
+}
+
 .tool-bubble.expanded .tool-result {
   display: block;
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -389,6 +389,14 @@ export {
 } from './tool-presentation'
 export type { ToolKind, ToolPresentation } from './tool-presentation'
 
+// Chat redesign #6391 (Phase 1): shared tool-output auto-collapse thresholds —
+// the dashboard + mobile ToolBubble collapse a long result past the same line
+// boundary.
+export {
+  TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD,
+  TOOL_OUTPUT_COLLAPSE_HEAD_LINES,
+} from './tool-output'
+
 export {
   PASTE_COLLAPSE_CHAR_THRESHOLD,
   PASTE_COLLAPSE_LINE_THRESHOLD,

--- a/packages/store-core/src/tool-output.ts
+++ b/packages/store-core/src/tool-output.ts
@@ -1,0 +1,15 @@
+/**
+ * Tool-output auto-collapse thresholds (chat redesign #6389, Phase 1 #6391).
+ *
+ * A tool result longer than {@link TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD} lines is
+ * collapsed in the ToolBubble to its first {@link TOOL_OUTPUT_COLLAPSE_HEAD_LINES}
+ * lines, behind a "Show N more lines" pill. Shared so the dashboard and mobile
+ * ToolBubble use the identical boundary (the design spec's "auto-collapse long
+ * output past a shared named threshold").
+ */
+
+/** Collapse a tool result once it exceeds this many lines. */
+export const TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD = 16
+
+/** Lines kept visible (the head) when a long tool result is collapsed. */
+export const TOOL_OUTPUT_COLLAPSE_HEAD_LINES = 12


### PR DESCRIPTION
Slice 7 of **Phase 1** (#6391) — auto-collapse long tool output.

A long tool result (more than **16 lines**) now collapses to its first **12 lines** behind a **"Show N more lines"** pill in the ToolBubble; clicking expands to the full output (with a "Show less" to re-collapse). The threshold lives in **store-core** (`tool-output.ts`) so the dashboard and mobile ToolBubble share the identical boundary.

- **Virtualization-safe, no new plumbing:** rows are measured by a per-row `ResizeObserver` (`MeasuredRow`/`MessageRowShell`, #5561), so the collapse toggle's height change auto-re-measures the windowed list.
- **Drops the 200px scroll cap when collapsible** — the collapse manages length, so the toggle button isn't trapped inside a scrollbox (short results keep the cap).
- Token-only pill styling (ratchet-clean).

Verified: store-core typecheck + full suite (1892); dashboard `tsc` + build + full suite (4091, +1 collapse test).

Part of #6391 · epic #6389.