### PR TITLE
feat(dashboard): collapse thinking into a quiet expandable disclosure (chat redesign Phase 1)

### DIFF
--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -26,6 +26,19 @@ describe('ChatView', () => {
     expect(screen.getByText('Message 2')).toBeInTheDocument()
   })
 
+  it('renders thinking as a collapsed disclosure (chat redesign #6391)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 't1', type: 'thinking', content: 'deep-secret-reasoning', timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    const toggle = screen.getByTestId('thinking-toggle')
+    expect(toggle).toHaveTextContent('Thought')
+    // collapsed by default — the full reasoning is hidden
+    expect(screen.queryByText('deep-secret-reasoning')).not.toBeInTheDocument()
+    fireEvent.click(toggle)
+    expect(screen.getByText('deep-secret-reasoning')).toBeInTheDocument()
+  })
+
   it('renders empty state when no messages', () => {
     render(<ChatView messages={[]} isStreaming={false} />)
     expect(screen.getByTestId('chat-view')).toBeInTheDocument()

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -242,6 +242,35 @@ function rowClassFor(type: string, hasIcon: boolean): string {
   return hasIcon ? 'msg-row' : ''
 }
 
+/**
+ * Chat redesign #6391 (slice 6): thinking renders as a quiet, collapsed
+ * disclosure instead of a standing wall of reasoning text — "▸ Thinking…" while
+ * it streams, "▸ Thought" once done; click reveals the full reasoning. (The
+ * "thought for Ns" duration/token stat is deferred — it needs a thinking
+ * start/end the client doesn't carry yet.) The row's MeasuredRow ResizeObserver
+ * re-measures on toggle, so the virtualized list stays correct.
+ */
+function ThinkingBody({ content, streaming }: { content: string; streaming: boolean }) {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <div className="thinking-body">
+      <button
+        type="button"
+        className="thinking-toggle"
+        data-testid="thinking-toggle"
+        aria-expanded={expanded}
+        onClick={(e) => {
+          e.stopPropagation()
+          setExpanded(v => !v)
+        }}
+      >
+        {expanded ? '▾' : '▸'} {streaming ? 'Thinking…' : 'Thought'}
+      </button>
+      {expanded && <div className="thinking-full">{content}</div>}
+    </div>
+  )
+}
+
 const DefaultMessageRow = memo(function DefaultMessageRow({
   id,
   type,
@@ -278,7 +307,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   const body =
     type === 'response' || type === 'tool_use'
       ? <div dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
-      : content
+      : type === 'thinking'
+        ? <ThinkingBody content={content} streaming={!!isStreaming} />
+        : content
 
   return (
     <>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2698,6 +2698,26 @@ button.sidebar-token-view-session-row:hover {
   font-style: italic;
 }
 
+/* Chat redesign #6391 (slice 6): collapsed thinking disclosure — quiet by
+   default, expands to the full reasoning. Token-only (ratchet-clean). */
+.thinking-toggle {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font: inherit;
+  font-style: italic;
+  cursor: pointer;
+  padding: 0;
+}
+.thinking-toggle:hover {
+  color: var(--text-secondary);
+}
+.thinking-full {
+  margin-top: 4px;
+  white-space: pre-wrap;
+  color: var(--text-muted);
+}
+
 .msg.tool {
   background: var(--bg-tool-bubble);
   align-self: flex-start;


### PR DESCRIPTION
Slice 6 of **Phase 1** (#6391) — calmer thinking. **Completes the dashboard track.**

Thinking no longer renders as a standing wall of reasoning text. It's a **quiet collapsed disclosure** — **Thinking…** while it streams, **Thought** once done — that **expands on click** to the full reasoning. Matches the calibration finding (the real app demotes thinking to a quiet, expandable line, not a block).

- Client-side only — a small `ThinkingBody` component in `ChatView.tsx` for `type === 'thinking'`; the row's `MeasuredRow` `ResizeObserver` re-measures on toggle (no windowing plumbing).
- Token-only styling (ratchet-clean).

**Deferred:** the *"thought for Ns" duration + token* stat. Thinking messages carry a single timestamp (not start→end), so the duration isn't computable client-side, and the token count needs a new optional `ChatMessage` field + a server wire bump — a cross-package follow-on. This ships the collapse (the structural core) now.

Verified: `tsc`, build, full dashboard suite (4092, +1 collapse test) green.

Part of #6391 · epic #6389.