### PR TITLE
feat(app): no-bubble assistant on mobile (chat redesign Phase 1 — mobile track)

### DIFF
--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -170,6 +170,9 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
     if (message.answered == null) submittedRef.current = false;
   }, [message.answered]);
   const isUser = message.type === 'user_input';
+  // Chat redesign #6391 (mobile no-bubble): the assistant 'response' prose
+  // loses its card and sits on the bare canvas (parity with the dashboard).
+  const isAssistant = message.type === 'response';
   const isTool = message.type === 'tool_use';
   const isThinking = message.type === 'thinking';
   const isPrompt = message.type === 'prompt';
@@ -396,7 +399,7 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
       // Applied to every bubble (cheap, deterministic, and lets the test
       // assert on a stable per-message anchor instead of brittle text matching).
       testID={`approval-card-${message.id}`}
-      style={[styles.messageBubble, isUser && styles.userBubble, isPrompt && styles.promptBubble, isError && styles.errorBubble, isSystem && styles.systemBubble, isSelected && styles.selectedBubble]}
+      style={[styles.messageBubble, isAssistant && styles.assistantBubble, isUser && styles.userBubble, isPrompt && styles.promptBubble, isError && styles.errorBubble, isSystem && styles.systemBubble, isSelected && styles.selectedBubble]}
     >
       <View style={isPrompt && message.expiresAt && !message.answered ? styles.promptHeaderRow : undefined}>
         <Text
@@ -740,6 +743,16 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     marginBottom: 12,
     maxWidth: '85%',
+  },
+  // Chat redesign #6391 (mobile no-bubble): bare assistant response — no card,
+  // flush, so a long turn reads like a document. User/prompt/tool keep cards.
+  assistantBubble: {
+    backgroundColor: 'transparent',
+    paddingHorizontal: 0,
+    paddingVertical: 2,
+    borderRadius: 0,
+    marginBottom: 8,
+    maxWidth: '100%',
   },
   userBubble: {
     backgroundColor: COLORS.accentBlueLight,


### PR DESCRIPTION
First slice of the **mobile (React Native) track** for the chat redesign (#6389), Phase 1 (#6391).

Ports the dashboard's **no-bubble assistant** (#6401) to the app: the assistant `'response'` bubble gets an `assistantBubble` style override — **transparent background, flush padding, no radius, full width** — so the assistant prose sits on the bare canvas and a long turn reads like a document. **User, prompt, error, system, and tool bubbles keep their cards.**

- One `MessageBubble` StyleSheet addition + an `isAssistant` flag; mirrors the dashboard CSS change.
- No raw color literals added (`'transparent'` + numbers) — ratchet-clean.

Verified: app `tsc` clean; MessageBubble jest suite (47) green; ratchet lint green. **Visual confirmation needs the device/Maestro** (RN styling isn't unit-visually-testable) — worth an eyeball in the app.

Part of #6391 · epic #6389.