### PR TITLE
feat(app): auto-collapse long tool output on mobile (chat redesign Phase 1 — mobile track)

### DIFF
--- a/packages/app/src/components/__tests__/ToolBubble.test.tsx
+++ b/packages/app/src/components/__tests__/ToolBubble.test.tsx
@@ -86,6 +86,26 @@ describe('ToolBubble — TodoWrite integration (#4180)', () => {
     expect(findByTestId(root, 'todo-list-item-t3')[0]).toBeTruthy();
   });
 
+  it('collapses a long tool result behind a Show-more pill (chat redesign #6391)', () => {
+    const longContent = Array.from({ length: 20 }, (_, i) => `line${i + 1}`).join('\n');
+    const root = renderBubble(makeToolMessage({ id: 'tool-long', tool: 'Bash', content: longContent, toolResult: undefined }));
+    tapToExpand(root);
+    const allText = () =>
+      root.root.findAllByType(Text)
+        .flatMap((t) => (Array.isArray(t.props.children) ? t.props.children : [t.props.children]))
+        .filter((c): c is string => typeof c === 'string')
+        .join(' ');
+    // Collapsed: the Show-more pill is present; head (line12) shown, tail (line13) hidden.
+    expect(findByTestId(root, 'tool-result-expand-tool-long')[0]).toBeTruthy();
+    expect(allText()).toContain('line12');
+    expect(allText()).not.toContain('line13');
+    // Expand → full result visible.
+    act(() => {
+      findByTestId(root, 'tool-result-expand-tool-long')[0]!.props.onPress();
+    });
+    expect(allText()).toContain('line20');
+  });
+
   it('parses message.toolResult — not message.content (pins #4194 regression)', () => {
     // `content` is plainly NOT a TodoWrite header here; if the parser were
     // pointed at it, the structured renderer would not appear and we'd see

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -7,7 +7,7 @@ import {
   Platform,
   LayoutAnimation,
 } from 'react-native';
-import { getPartialSummary, tryParseCompleteJson, shouldSuppressRawToolInput } from '@chroxy/store-core';
+import { getPartialSummary, tryParseCompleteJson, shouldSuppressRawToolInput, TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD, TOOL_OUTPUT_COLLAPSE_HEAD_LINES } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
@@ -52,6 +52,9 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
   onExpandedChange?: (id: string, expanded: boolean) => void;
 }) {
   const [expanded, setExpandedRaw] = useState(() => getInitialExpanded?.(message.id) ?? false);
+  // #6391 (mobile auto-collapse): inner collapse of a long expanded result,
+  // mirroring the dashboard ToolBubble. Independent of the bubble's own expand.
+  const [resultExpanded, setResultExpanded] = useState(false);
   const setExpanded = (next: boolean) => {
     setExpandedRaw(next);
     onExpandedChange?.(message.id, next);
@@ -185,6 +188,10 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
   const todoParsed = expanded && message.tool === 'TodoWrite' && message.toolResult
     ? parseTodoList(message.toolResult)
     : null;
+  // #6391 (mobile auto-collapse): collapse a long expanded result to its head
+  // behind a "Show N more lines" pill (shared store-core threshold).
+  const contentLineCount = content ? content.split('\n').length : 0;
+  const isLongContent = !todoParsed && contentLineCount > TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD;
 
   return (
     <TouchableOpacity
@@ -218,8 +225,22 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
         <>
           {todoParsed ? (
             <TodoList parsed={todoParsed} />
+          ) : isLongContent && !resultExpanded ? (
+            <>
+              <Text selectable style={styles.toolContentExpanded}>{content.split('\n').slice(0, TOOL_OUTPUT_COLLAPSE_HEAD_LINES).join('\n')}</Text>
+              <TouchableOpacity onPress={() => setResultExpanded(true)} testID={`tool-result-expand-${message.id}`}>
+                <Text style={styles.toolResultExpand}>Show {contentLineCount - TOOL_OUTPUT_COLLAPSE_HEAD_LINES} more lines</Text>
+              </TouchableOpacity>
+            </>
           ) : (
-            <Text selectable style={styles.toolContentExpanded}>{content}</Text>
+            <>
+              <Text selectable style={styles.toolContentExpanded}>{content}</Text>
+              {isLongContent && (
+                <TouchableOpacity onPress={() => setResultExpanded(false)} testID={`tool-result-collapse-${message.id}`}>
+                  <Text style={styles.toolResultExpand}>Show less</Text>
+                </TouchableOpacity>
+              )}
+            </>
           )}
           {/* #5060 — Task subagent nested progress. The child's
               intermediate tool_start/tool_result/tool_input_delta/
@@ -291,6 +312,12 @@ const styles = StyleSheet.create({
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     marginTop: 6,
     lineHeight: 18,
+  },
+  // #6391 (mobile auto-collapse): the "Show N more lines" / "Show less" pill.
+  toolResultExpand: {
+    color: COLORS.accentBlue,
+    fontSize: 12,
+    marginTop: 6,
   },
   selectedBubble: {
     borderColor: COLORS.accentBlue,


### PR DESCRIPTION
Second slice of the **mobile track** for the chat redesign (#6389), Phase 1 (#6391).

Ports the dashboard's **auto-collapse long output** (#6406) to the mobile chat `ToolBubble`. When a tool bubble is expanded and its result exceeds the **shared store-core threshold** (`TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD` = 16 lines), it collapses to the first `TOOL_OUTPUT_COLLAPSE_HEAD_LINES` (12) behind a **"Show N more lines"** pill; **"Show less"** re-collapses. Dashboard and mobile now consume the identical named threshold — they can't drift.

- One inner `resultExpanded` state + a derived `isLongContent`; the bubble's own expand/collapse is untouched.
- No raw color literals (`COLORS.accentBlue`) — ratchet-clean.

Verified: app `tsc` clean; mobile ToolBubble jest (27, +1 collapse test: head-shown / tail-hidden → expand → full) green; ratchet green.

Part of #6391 · epic #6389.