### PR TITLE
feat(app): composer activity hairline on mobile (chat redesign Phase 1 — mobile track)

### DIFF
--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -6,6 +6,7 @@ import { COLORS } from '../constants/colors';
 import type { SlashCommand } from '../store/connection';
 import type { Attachment } from '../utils/attachments';
 import { formatFileSize } from '../utils/attachments';
+import type { ActivityState } from '../store/session-activity';
 
 
 // -- Props --
@@ -75,6 +76,13 @@ export interface InputBarProps {
   disabled?: boolean;
   disabledPlaceholder?: string;
   slashCommands?: SlashCommand[];
+  /**
+   * Chat redesign #6391 (mobile): current chat-activity state, used to tint the
+   * composer's top hairline (idle = neutral; thinking/busy/waiting/error light
+   * it up). Already derived + persisted in the store; SessionScreen passes the
+   * primitive `.state` down. Mirrors the dashboard InputBar's data-activity-state.
+   */
+  activityState?: ActivityState;
   isRecognizing?: boolean;
   onMicPress?: () => void;
   speechUnavailable?: boolean;
@@ -89,6 +97,23 @@ export interface InputBarProps {
   /** #3797 — tap × on a chip to remove the chip and its inline marker. */
   onRemovePastedText?: (id: number) => void;
 }
+
+// Chat redesign #6391 (mobile): composer activity hairline — the top edge tints
+// by chat-activity state, mirroring the dashboard InputBar's data-activity-state
+// inset edge. idle keeps today's neutral border (no visible change at rest);
+// only active states light up. Width stays 1px in every state → zero layout
+// shift on transition. (RN has no inset box-shadow; recoloring the existing 1px
+// top border is the faithful 1:1 port.)
+const HAIRLINE_COLOR: Record<ActivityState, string> = {
+  idle: COLORS.backgroundCard,
+  thinking: COLORS.accentBlue,
+  busy: COLORS.accentPurple,
+  waiting: COLORS.accentOrange,
+  // Dashboard parity: error uses the muted --text-error token, NOT a louder
+  // alarm red, so the two clients don't drift (COLORS.textError '#e8a0a0' ===
+  // the dashboard's --text-error).
+  error: COLORS.textError,
+};
 
 // -- Component --
 
@@ -110,6 +135,7 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
   disabled,
   disabledPlaceholder,
   slashCommands = [],
+  activityState = 'idle',
   isRecognizing,
   onMicPress,
   speechUnavailable,
@@ -202,7 +228,7 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
   const showDropdown = filteredCommands.length > 0;
 
   return (
-    <View style={[styles.inputContainer, { paddingBottom: bottomPadding }]}>
+    <View style={[styles.inputContainer, { paddingBottom: bottomPadding, borderTopColor: HAIRLINE_COLOR[activityState] }]}>
       {showDropdown && (
         <ScrollView
           style={styles.dropdown}

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -17,8 +17,9 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { TextInput } from 'react-native';
+import { TextInput, StyleSheet } from 'react-native';
 import { InputBar, type InputBarHandle } from '../InputBar';
+import { COLORS } from '../../constants/colors';
 
 const noop = () => {};
 
@@ -264,5 +265,45 @@ describe('InputBar send-while-streaming un-gate (#5938)', () => {
     });
     expect(hasLabel(tree, 'Attach file')).toBe(false);
     expect(hasLabel(tree, 'Take photo')).toBe(false);
+  });
+});
+
+describe('InputBar activity hairline (chat redesign #6391)', () => {
+  // The root composer View's style is [styles.inputContainer, { paddingBottom,
+  // borderTopColor }]. The base style ALSO sets borderTopColor, so target the
+  // inline override — uniquely identified by carrying BOTH paddingBottom and
+  // borderTopColor — to read the EFFECTIVE (later-wins) edge color.
+  function hairlineColor(tree: renderer.ReactTestRenderer): unknown {
+    const view = tree.root.findAll(
+      (node) =>
+        String(node.type) === 'View' &&
+        Array.isArray(node.props.style) &&
+        node.props.style.some(
+          (s: any) => s && typeof s === 'object' && 'paddingBottom' in s && 'borderTopColor' in s,
+        ),
+    )[0];
+    // Flatten to the EFFECTIVE (later-wins) edge color RN actually paints —
+    // robust even if a future style element re-overrides borderTopColor.
+    return StyleSheet.flatten(view.props.style).borderTopColor;
+  }
+
+  it('keeps the neutral edge at idle (default — no visible change at rest)', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => { tree = renderer.create(<InputBar {...baseProps} onChangeText={noop} />); });
+    expect(hairlineColor(tree)).toBe(COLORS.backgroundCard);
+  });
+
+  it('tints the composer edge by chat-activity state (no layout shift — color only)', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar {...baseProps} onChangeText={noop} activityState="thinking" />);
+    });
+    expect(hairlineColor(tree)).toBe(COLORS.accentBlue);
+
+    act(() => { tree.update(<InputBar {...baseProps} onChangeText={noop} activityState="waiting" />); });
+    expect(hairlineColor(tree)).toBe(COLORS.accentOrange);
+
+    act(() => { tree.update(<InputBar {...baseProps} onChangeText={noop} activityState="error" />); });
+    expect(hairlineColor(tree)).toBe(COLORS.textError);
   });
 });

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -308,6 +308,16 @@ export function SessionScreen() {
     const id = s.activeSessionId;
     return id && s.sessionStates[id] ? s.sessionStates[id].health : 'healthy';
   });
+  // Chat redesign #6391 (mobile): chat-activity state (already derived +
+  // persisted by message-handler) drives the composer's activity hairline.
+  // A primitive-string selector → Zustand default equality re-renders the
+  // composer only on a real state transition, not every store write.
+  const activityState = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id]?.activityState
+      ? s.sessionStates[id].activityState.state
+      : 'idle';
+  });
   // #4879: quiet user-initiated Stop marker. Set by the `session_stopped`
   // handler (sharedSessionStopped); cleared on next claude_ready. Drives
   // the subtle "Session stopped." status strip below — distinct from the
@@ -1697,6 +1707,7 @@ export function SessionScreen() {
         disabled={connectionPhase !== 'connected'}
         disabledPlaceholder={viewingCachedSession ? 'Offline — viewing cached history' : connectionPhase === 'server_restarting' ? 'Server restarting...' : 'Reconnecting...'}
         slashCommands={slashCommands}
+        activityState={activityState}
         isRecognizing={isRecognizing}
         onMicPress={speechAvailable ? handleMicPress : undefined}
         speechUnavailable={!speechAvailable}


### PR DESCRIPTION
Third slice of the **mobile track** for the chat redesign (#6389), Phase 1 (#6391) — the **presence-rail signature** on mobile.

Ports the dashboard InputBar's `data-activity-state` edge to React Native. The composer's existing 1px top border now **recolors by chat-activity state**:

| state | edge |
|---|---|
| idle | neutral (unchanged at rest) |
| thinking | accent blue |
| busy | accent purple |
| waiting | accent orange |
| error | muted text-error (dashboard parity) |

- **No new derivation** — the activity state is already computed + persisted in the mobile store (`message-handler.ts`). `SessionScreen` reads it via a **primitive-string selector** (memo-safe: re-renders the composer only on a real transition) and passes `activityState` down.
- **Zero layout shift** — only `borderTopColor` changes; `borderTopWidth` stays 1px in every state (the RN-faithful port of the dashboard's inset box-shadow).
- No raw color literals (`COLORS.*`) — ratchet-clean.

**Adversarial review** (3 lenses: re-render correctness, dashboard parity, RN layout) ran pre-commit. Two PASS; the parity lens caught that `error` was mapped to the louder `accentRed` while the dashboard uses the muted `--text-error` — **fixed to `COLORS.textError` (#e8a0a0)** for exact parity. Test hardened to assert the `StyleSheet.flatten` effective color.

Verified: app `tsc` clean; InputBar jest (17, +2 hairline tests) green; ratchet green. **Visual confirmation needs the device/Maestro.**

Part of #6391 · epic #6389.