### PR TITLE
feat(app): relaxed reading scale for mobile chat prose (chat redesign Phase 1 — mobile track)

### DIFF
--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -626,23 +626,26 @@ export const md = StyleSheet.create({
     paddingHorizontal: 3,
     borderRadius: 3,
   },
+  // Chat redesign #6391 (mobile relaxed scale): nudge heading leading up in step
+  // with the roomier 24px body so a heading never looks tighter than the prose
+  // beneath it. Headings stay slightly below 1.6 (they read fine denser).
   h1: {
     fontSize: 17,
     fontWeight: '700',
     color: COLORS.headerText1,
-    lineHeight: 24,
+    lineHeight: 26,
   },
   h2: {
     fontSize: 16,
     fontWeight: '700',
     color: COLORS.headerText2,
-    lineHeight: 22,
+    lineHeight: 24,
   },
   h3: {
     fontSize: 15,
     fontWeight: '600',
     color: COLORS.headerText3,
-    lineHeight: 22,
+    lineHeight: 24,
   },
   codeBlock: {
     backgroundColor: COLORS.backgroundCodeBlock,

--- a/packages/app/src/components/__tests__/MessageBubble.relaxedScale.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.relaxedScale.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Mobile relaxed reading scale (chat redesign #6391).
+ *
+ * The assistant prose body uses the dashboard's document leading ratio
+ * (lineHeight 24 over the 15px body = 1.60). This pins that the relaxed
+ * `messageText` leading actually REACHES the rendered prose — catching a future
+ * regression where `messageText` is detached from the body or the value drifts
+ * back to the old cramped 22. The reflow/scroll behaviour the looser leading
+ * produces is visual and verified on-device / via Maestro, not here.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text, StyleSheet } from 'react-native';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+beforeEach(() => {
+  useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+});
+
+function makeResponse(content: string): ChatMessage {
+  return { id: 'r-relaxed', type: 'response', content, timestamp: Date.now() };
+}
+
+function render(message: ChatMessage): renderer.ReactTestRenderer {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    );
+  });
+  return tree;
+}
+
+describe('MessageBubble relaxed reading scale (chat redesign #6391)', () => {
+  it('renders assistant prose at the relaxed 1.60 leading (24 over the 15px body)', () => {
+    const tree = render(makeResponse('Hello from the assistant'));
+    // Every 15px body text run must carry the relaxed 24px leading (= 1.60),
+    // not the old cramped 22. `messageText` is injected as messageTextStyle into
+    // FormattedResponse, so the rendered paragraph inherits fontSize 15 + the
+    // new lineHeight 24.
+    const bodyLeadings = tree.root
+      .findAllByType(Text)
+      .map((t) => StyleSheet.flatten(t.props.style))
+      .filter((s) => s && s.fontSize === 15)
+      .map((s) => s.lineHeight);
+    expect(bodyLeadings.length).toBeGreaterThan(0);
+    expect(bodyLeadings.every((lh) => lh === 24)).toBe(true);
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -947,7 +947,7 @@ const styles = StyleSheet.create({
     flex: 1,
     color: COLORS.textChatMessage,
     fontSize: 14,
-    lineHeight: 20,
+    lineHeight: 22, // #6391: relaxed leading reaches the prompt-answer summary (22/14 ≈ 1.57)
   },
   errorBubble: {
     backgroundColor: COLORS.accentRedLight,
@@ -979,6 +979,7 @@ const styles = StyleSheet.create({
   systemMessageText: {
     color: COLORS.textSystem,
     fontSize: 13,
+    lineHeight: 20, // #6391: was RN-default (cramped); relax secondary system notices too
   },
   selectedBubble: {
     borderColor: COLORS.accentBlue,
@@ -987,7 +988,11 @@ const styles = StyleSheet.create({
   messageText: {
     color: COLORS.textChatMessage,
     fontSize: 15,
-    lineHeight: 22,
+    // Chat redesign #6391 (mobile relaxed scale): 24/15 = 1.60 leading — the
+    // dashboard's document ratio. Body stays 15px (the correct phone size); the
+    // calmer reading rhythm comes from leading, not glyph size. Propagates to
+    // all assistant prose (FormattedResponse inherits this as messageTextStyle).
+    lineHeight: 24,
   },
   userMessageText: {
     color: COLORS.textPrimary,


### PR DESCRIPTION
Fourth slice of the **mobile track** for the chat redesign (#6389), Phase 1 (#6391) — the **relaxed reading scale**.

The mobile chat body was already **15px** (the dashboard's number — right for a phone at hold distance). The gap was **leading**: the body sat at lineHeight 22 (1.47), below the dashboard's document feel (1.6). This bumps the body **lineHeight 22 → 24 (= 1.60 exactly)** — and because `messageText` is injected as `messageTextStyle` into `FormattedResponse`, that **single change covers the whole reading surface** (paragraphs, lists, blockquotes, table cells).

Consistency follow-ups in the same slice:
- **system-notice** leading: added (was the cramped RN default).
- **multi-question summary** leading 20 → 22.
- **heading** leading nudged in step so a heading never reads tighter than the roomier prose under it: h1 24→26, h2 22→24, h3 22→24.

**Deliberately unchanged:** inline code, fenced code, and tool output stay dense (12–13px) — the document scale is for prose only; relaxing monospace wastes a phone's horizontal room and breaks code alignment.

A test pins that the relaxed leading actually **reaches the rendered prose** (not just sits in the StyleSheet). The reflow/scroll behaviour is visual — **eyeball on device / Maestro**.

Verified: app `tsc` clean; MessageBubble + MarkdownRenderer suites (48, +1) green; ratchet green.

Part of #6391 · epic #6389.