### PR TITLE
feat(app): group slash commands by source on mobile (chat redesign Phase 1 — mobile track)

### DIFF
--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -115,6 +115,16 @@ const HAIRLINE_COLOR: Record<ActivityState, string> = {
   error: COLORS.textError,
 };
 
+// Chat redesign #6391 (slice 8 parity, mobile): slash commands group by source
+// into Built-in / Project / User sections (mirrors the dashboard
+// SlashCommandPicker). Unknown/future sources sort last and fall under "Other".
+const SLASH_GROUP_LABEL: Record<string, string> = {
+  builtin: 'Built-in',
+  project: 'Project',
+  user: 'User',
+};
+const SLASH_SOURCE_RANK: Record<string, number> = { builtin: 0, project: 1, user: 2 };
+
 // -- Component --
 
 export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(function InputBar({
@@ -220,9 +230,16 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
   const filteredCommands = useMemo(() => {
     if (viewMode !== 'chat' || !value.startsWith('/') || slashCommands.length === 0) return [];
     const query = value.slice(1).toLowerCase();
-    // Show all commands if user just typed `/`
-    if (!query) return slashCommands;
-    return slashCommands.filter((cmd) => cmd.name.toLowerCase().includes(query));
+    const matched = query
+      ? slashCommands.filter((cmd) => cmd.name.toLowerCase().includes(query))
+      : slashCommands;
+    // #6391: stable-sort by source so the dropdown renders clean Built-in /
+    // Project / User sections (Array.sort is stable → order within a source is
+    // preserved; unknown sources rank last → "Other"). Copy first so we never
+    // mutate the store's slashCommands array.
+    return [...matched].sort(
+      (a, b) => (SLASH_SOURCE_RANK[a.source] ?? 99) - (SLASH_SOURCE_RANK[b.source] ?? 99),
+    );
   }, [value, slashCommands, viewMode]);
 
   const showDropdown = filteredCommands.length > 0;
@@ -235,25 +252,40 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
           keyboardShouldPersistTaps="handled"
           bounces={false}
         >
-          {filteredCommands.map((cmd) => (
-            <TouchableOpacity
-              key={cmd.name}
-              style={styles.dropdownItem}
-              onPress={() => handleChangeText(`/${cmd.name} `)}
-              accessibilityRole="button"
-              accessibilityLabel={`Slash command ${cmd.name}`}
-            >
-              <View style={styles.dropdownItemHeader}>
-                <Text style={styles.dropdownItemName}>/{cmd.name}</Text>
-                {cmd.source === 'project' && (
-                  <Text style={styles.dropdownItemBadge}>project</Text>
+          {filteredCommands.map((cmd, i) => {
+            // #6391: section header whenever the (sorted) source changes → clean
+            // Built-in / Project / User groups. project rows stay badgeless (the
+            // implicit default, per #3856); builtin/user get a chip.
+            const showHeader = i === 0 || filteredCommands[i - 1].source !== cmd.source;
+            return (
+              <React.Fragment key={cmd.name}>
+                {showHeader && (
+                  <Text style={styles.dropdownGroupHeader} accessibilityRole="header">
+                    {SLASH_GROUP_LABEL[cmd.source] ?? 'Other'}
+                  </Text>
                 )}
-              </View>
-              {cmd.description ? (
-                <Text style={styles.dropdownItemDesc} numberOfLines={1}>{cmd.description}</Text>
-              ) : null}
-            </TouchableOpacity>
-          ))}
+                <TouchableOpacity
+                  style={styles.dropdownItem}
+                  onPress={() => handleChangeText(`/${cmd.name} `)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Slash command ${cmd.name}`}
+                >
+                  <View style={styles.dropdownItemHeader}>
+                    <Text style={styles.dropdownItemName}>/{cmd.name}</Text>
+                    {cmd.source === 'builtin' && (
+                      <Text style={[styles.dropdownItemBadge, styles.dropdownItemBadgeBuiltin]}>built-in</Text>
+                    )}
+                    {cmd.source === 'user' && (
+                      <Text style={styles.dropdownItemBadge}>user</Text>
+                    )}
+                  </View>
+                  {cmd.description ? (
+                    <Text style={styles.dropdownItemDesc} numberOfLines={1}>{cmd.description}</Text>
+                  ) : null}
+                </TouchableOpacity>
+              </React.Fragment>
+            );
+          })}
         </ScrollView>
       )}
       {viewMode === 'terminal' && hasTerminal && (
@@ -479,6 +511,16 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: COLORS.borderPrimary,
   },
+  dropdownGroupHeader: {
+    color: COLORS.textMuted,
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
   dropdownItem: {
     paddingHorizontal: 16,
     paddingVertical: 10,
@@ -505,6 +547,16 @@ const styles = StyleSheet.create({
     paddingVertical: 1,
     borderRadius: 4,
     overflow: 'hidden',
+  },
+  // #3856 parity: built-in commands get a distinct OUTLINED accent chip
+  // (transparent bg + accent border/text) so the eye reads "locked provider
+  // built-in, not your editable file" — mirrors the dashboard's
+  // .slash-picker-badge-builtin. User/project use the flat chip above.
+  dropdownItemBadgeBuiltin: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: COLORS.accentBlue,
+    color: COLORS.accentBlue,
   },
   dropdownItemDesc: {
     color: COLORS.textMuted,

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -17,7 +17,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { TextInput, StyleSheet } from 'react-native';
+import { TextInput, StyleSheet, Text } from 'react-native';
 import { InputBar, type InputBarHandle } from '../InputBar';
 import { COLORS } from '../../constants/colors';
 
@@ -305,5 +305,67 @@ describe('InputBar activity hairline (chat redesign #6391)', () => {
 
     act(() => { tree.update(<InputBar {...baseProps} onChangeText={noop} activityState="error" />); });
     expect(hairlineColor(tree)).toBe(COLORS.textError);
+  });
+});
+
+describe('InputBar slash-command grouping (chat redesign #6391)', () => {
+  // Intentionally out of source order to prove the picker sorts/groups them.
+  const slashCommands = [
+    { name: 'zeta-user', description: 'u', source: 'user' as const },
+    { name: 'alpha-builtin', description: 'b', source: 'builtin' as const },
+    { name: 'mid-project', description: 'p', source: 'project' as const },
+  ];
+
+  // All visible Text content in tree (render) order — headers, names, badges.
+  function textsInOrder(tree: renderer.ReactTestRenderer): string[] {
+    return tree.root
+      .findAllByType(Text)
+      .map((t) => (Array.isArray(t.props.children) ? t.props.children.join('') : t.props.children))
+      .filter((c): c is string => typeof c === 'string');
+  }
+
+  // `inputText="/"` seeds the internal draft to '/', which opens the picker
+  // with the full (sorted) command list.
+  function openPicker(): renderer.ReactTestRenderer {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} onChangeText={noop} inputText="/" slashCommands={slashCommands} />,
+      );
+    });
+    return tree;
+  }
+
+  it('renders source section headers in Built-in → Project → User order', () => {
+    const texts = textsInOrder(openPicker());
+    const iBuiltin = texts.indexOf('Built-in');
+    const iProject = texts.indexOf('Project');
+    const iUser = texts.indexOf('User');
+    expect(iBuiltin).toBeGreaterThanOrEqual(0);
+    expect(iProject).toBeGreaterThan(iBuiltin);
+    expect(iUser).toBeGreaterThan(iProject);
+    // The builtin command sorts under its header, ahead of the user command.
+    expect(texts.indexOf('/alpha-builtin')).toBeGreaterThan(iBuiltin);
+    expect(texts.indexOf('/alpha-builtin')).toBeLessThan(texts.indexOf('/zeta-user'));
+  });
+
+  it('badges builtin and user but leaves project badgeless (dashboard parity)', () => {
+    const tree = openPicker();
+    const texts = textsInOrder(tree);
+    expect(texts).toContain('built-in');
+    expect(texts).toContain('user');
+    // No lowercase 'project' badge — the "Project" header conveys the group.
+    expect(texts).not.toContain('project');
+    // #3856 parity: built-in is the distinct OUTLINED accent chip (transparent
+    // bg); user is the flat chip. Pin the visual distinction against regression.
+    const badgeStyle = (label: string) => {
+      const t = tree.root.findAllByType(Text).find((n) => {
+        const c = Array.isArray(n.props.children) ? n.props.children.join('') : n.props.children;
+        return c === label;
+      })!;
+      return StyleSheet.flatten(t.props.style);
+    };
+    expect(badgeStyle('built-in').backgroundColor).toBe('transparent');
+    expect(badgeStyle('user').backgroundColor).not.toBe('transparent');
   });
 });


### PR DESCRIPTION
Fifth shippable slice of the **mobile track** for the chat redesign (#6389), Phase 1 (#6391) — **grouped slash commands**.

Ports the dashboard's grouped `SlashCommandPicker` (slice 8) to the mobile inline picker (it lives inside `InputBar.tsx`, not a separate component). The command objects already carry `source`, so this is presentation-only:

- **Stable-sort by source** (builtin < project < user; unknown last) in the `filteredCommands` `useMemo` — copies the array first so the store is never mutated.
- **Section headers** (`Built-in` / `Project` / `User`, `Other` fallback) render on source-change in the sorted list, with `accessibilityRole="header"`.
- **Badges aligned to the dashboard**: `builtin` gets a distinct **outlined accent chip** (#3856 — signals a locked provider built-in you can't shadow), `user` gets the flat chip, and `project` is **badgeless** (the `Project` header now conveys it — replacing the old lone project badge).

**No protocol/store/wire change** — the same typed `SlashCommand` (with `source`) already reaches the mobile picker.

**2-lens adversarial review** (sort/grouping correctness + dashboard parity) ran pre-commit. Both PASS; the parity lens flagged that mobile had flattened the builtin/user badges into one style, losing the dashboard's #3856 distinction — **fixed** (distinct outlined builtin chip) and the a11y nit (`accessibilityRole`) adopted. The correctness lens confirmed the sort is non-mutating + stable, no duplicate headers, and no key collision (the server dedupes command names globally).

Verified: app `tsc` clean; InputBar jest (19, +2 grouping tests incl. the badge-distinction pin) green; ratchet green. **Visual confirmation needs the device/Maestro.**

Part of #6391 · epic #6389.