### PR TITLE
feat(dashboard): presence rail — left-edge activity spine (chat redesign Phase 2)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2241,6 +2241,7 @@ export function App() {
                         messages={chatMessages}
                         isStreaming={streamingMessageId !== null}
                         isBusy={!isIdle}
+                        chatActivityState={chatActivity.state}
                         renderMessage={renderMessage}
                         scrollToBottomSignal={scrollToBottomSignal}
                         queuedIds={queuedIds}
@@ -2285,6 +2286,7 @@ export function App() {
                         messages={chatMessages}
                         isStreaming={streamingMessageId !== null}
                         isBusy={!isIdle}
+                        chatActivityState={chatActivity.state}
                         renderMessage={renderMessage}
                         hidden={viewMode !== 'chat'}
                         scrollToBottomSignal={scrollToBottomSignal}

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -44,6 +44,19 @@ describe('ChatView', () => {
     expect(screen.getByTestId('chat-view')).toBeInTheDocument()
   })
 
+  it('renders the presence rail reflecting the chat-activity state (chat redesign #6392)', () => {
+    render(<ChatView messages={makeMessages(2)} isStreaming={false} chatActivityState="thinking" />)
+    const rail = screen.getByTestId('presence-rail')
+    expect(rail).toHaveAttribute('data-activity-state', 'thinking')
+    // ambient decoration — hidden from assistive tech
+    expect(rail).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('defaults the presence rail to idle when no activity state is given (chat redesign #6392)', () => {
+    render(<ChatView messages={makeMessages(1)} isStreaming={false} />)
+    expect(screen.getByTestId('presence-rail')).toHaveAttribute('data-activity-state', 'idle')
+  })
+
   it('shows thinking dots when streaming', () => {
     render(<ChatView messages={makeMessages(1)} isStreaming />)
     expect(screen.getByTestId('thinking-dots')).toBeInTheDocument()

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -17,7 +17,7 @@
  * survives a row scrolling out of and back into the window.
  */
 import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
-import { bumpRenderCount } from '@chroxy/store-core'
+import { bumpRenderCount, type ChatActivityState } from '@chroxy/store-core'
 import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
 import { MessageRowShell } from './MeasuredRow'
@@ -118,6 +118,14 @@ export interface ChatViewProps {
   isStreaming: boolean
   /** Show thinking indicator during pre-streaming busy state */
   isBusy?: boolean
+  /**
+   * Chat redesign #6392 (presence rail): the canonical chat-activity state
+   * ('idle'|'thinking'|'busy'|'waiting'|'error') from store-core's
+   * `deriveChatActivity`. Drives the colour + motion of the left-edge presence
+   * rail via a `data-activity-state` attribute — the same wiring the Phase 1
+   * composer hairline uses. Undefined → the rail stays idle (neutral).
+   */
+  chatActivityState?: ChatActivityState
   /** Optional custom renderer. Return a node to override default rendering, or null to fall back. */
   renderMessage?: (msg: ChatViewMessage) => ReactNode | null
   /**
@@ -340,7 +348,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
@@ -686,6 +694,17 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage, scrollToBo
 
   return (
     <div className="chat-view" data-testid="chat-view">
+      {/*
+        Chat redesign #6392 (presence rail): ONE left-edge spine per pane,
+        absolutely positioned against this non-scrolling .chat-view parent — NOT
+        inside the virtualized .chat-messages scroller — so it's continuous and
+        independent of the windowed row slice and the WKWebView scroll-anchor
+        math. Colour + motion come from data-activity-state (the same pattern as
+        the Phase 1 composer hairline). aria-hidden: ambient decoration, not
+        content. Motion choreography is intentionally restrained pending design
+        tuning (see the .presence-rail CSS).
+      */}
+      <div className="presence-rail" data-activity-state={chatActivityState ?? 'idle'} data-testid="presence-rail" aria-hidden="true" />
       <ChatExpandContext.Provider value={expandRegistry}>
         <div
           ref={containerRef}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2557,6 +2557,60 @@ button.sidebar-token-view-session-row:hover {
   overscroll-behavior: contain;
 }
 
+/*
+ * Chat redesign #6392 — presence rail. A continuous left-edge spine painted on
+ * the non-scrolling .chat-view parent (NOT inside the virtualized .chat-messages
+ * scroller), so it stays continuous and independent of the windowed row slice
+ * and the WKWebView scroll-anchor math. Colour reflects the canonical
+ * chat-activity state at a glance ("what is my machine doing"); idle is
+ * invisible at rest. Colour mapping mirrors the Phase 1 composer hairline.
+ *
+ * MOTION IS INTENTIONALLY RESTRAINED — a single gentle "breathe" opacity loop
+ * for the active states, NOT the differentiated breathe/heartbeat/ring-pulse the
+ * spec sketches (§3.1). That choreography is a deliberate design-tuning
+ * follow-up to do with eyes on the real motion; the timings already reference
+ * the --rail-* tokens so retuning is a one-line change. Reduced-motion → static.
+ */
+.presence-rail {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px; /* must stay <= .chat-messages left padding (16px) so it never overpaints content */
+  background: transparent;
+  pointer-events: none;
+  z-index: 2;
+  transition: background var(--dur-base) var(--ease-standard);
+}
+.presence-rail[data-activity-state="thinking"] {
+  background: var(--accent-blue);
+  animation: presence-rail-breathe var(--rail-breathe) var(--ease-standard) infinite;
+}
+.presence-rail[data-activity-state="busy"] {
+  background: var(--accent-purple);
+  animation: presence-rail-breathe var(--rail-heartbeat) var(--ease-standard) infinite;
+}
+.presence-rail[data-activity-state="waiting"] {
+  background: var(--accent-orange);
+  animation: presence-rail-breathe var(--rail-breathe) var(--ease-standard) infinite;
+}
+.presence-rail[data-activity-state="error"] {
+  background: var(--text-error);
+}
+/* idle: transparent (declared on the base rule) — the rail is invisible at rest. */
+
+@keyframes presence-rail-breathe {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Match the active-state selectors' specificity (0,2,0) so this actually WINS
+     the cascade — a bare .presence-rail (0,1,0) loses to them and the breathe
+     would keep running for users who opted out of motion. */
+  .presence-rail[data-activity-state] { animation: none; }
+}
+
 /* ---- Message rows with sender icons ---- */
 .msg-row {
   display: flex;


### PR DESCRIPTION
First slice of **Phase 2** (#6392) — the **presence rail**, the redesign's signature remote-native feature ('what is my machine doing right now', at a glance).

A single continuous left-edge spine. The recon dissolved the scary part — instead of a per-row rail (which would gap over the virtualized list's spacers), it's **one element painted on the non-scrolling `.chat-view` parent**, outside the `.chat-messages` scroller, so it's continuous and independent of the windowed row slice + the WKWebView scroll-anchor math.

- **State→color** via a `data-activity-state` attribute — the *exact* Phase 1 composer-hairline pattern (idle=invisible, thinking=blue, busy=purple, waiting=orange, error=text-error). Wired from the canonical `deriveChatActivity` into the two chat ChatView instances (the system tab stays idle).
- **3px spine** in the 16px left gutter; `pointer-events:none`; `aria-hidden`; z-index clear of the scroll-to-bottom button.
- **Motion is intentionally RESTRAINED** — a single gentle breathe for active states, **not** the differentiated breathe/heartbeat/ring the spec sketches. That choreography is the taste layer to **tune with eyes on the real motion** (timings already reference the `--rail-*` tokens, so retuning is one line). ⬅️ **this bit is for your eye.**
- Reduced-motion → static.

**Deferred follow-ups:** per-tool-kind rail color (needs `deriveChatActivity` to carry the in-flight tool kind), the mobile port (Reanimated), and the motion-choreography tuning.

**2-lens adversarial review** (layout/virtualization + wiring/a11y) ran pre-commit. Layout confirmed the rail survives virtualization + overlaps nothing. Wiring caught a **real a11y bug** — the `prefers-reduced-motion` override sat at lower CSS specificity than the active-state animations so it never took effect — **fixed** (matched specificity); also tightened the prop type to the `ChatActivityState` union.

Verified: dashboard `tsc` clean; 52 ChatView tests (+2 rail) green; build + ratchet green. **The motion needs your eye** — run the dashboard and watch it breathe.

Part of #6392 · epic #6389.