### PR TITLE
fix(server): launch claude-tui with --no-chrome (dodge Claude Code 2.1.186 Chrome prompt)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1681,6 +1681,13 @@ export class ClaudeTuiSession extends BaseSession {
     const args = [
       ...idArgs,
       '--settings', this._settingsPath,
+      // Claude Code 2.1.186 added a "Claude in Chrome extension detected"
+      // first-run prompt that interactively blocks the TUI (1/2/Enter/Esc) when
+      // the browser extension is installed. chroxy's PTY driver can't dismiss
+      // that prompt, so the session wedges and the claude PTY exits mid-turn
+      // (code=1). A headless chroxy TUI session never drives the browser
+      // integration, so disable it at spawn — no prompt, no wedge.
+      '--no-chrome',
     ]
     if (this.skipPermissions) {
       // #4044: bypass chroxy's hook + claude's per-tool prompt entirely.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -73,7 +73,7 @@ describe('ClaudeTuiSession', () => {
         const idArgs = this._resumedFromPersisted
           ? ['--resume', this._sessionId]
           : ['--session-id', this._sessionId]
-        capturedArgs = [...idArgs, '--settings', this._settingsPath]
+        capturedArgs = [...idArgs, '--settings', this._settingsPath, '--no-chrome']
         this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
       }
     })
@@ -122,6 +122,9 @@ describe('ClaudeTuiSession', () => {
       const i = capturedArgs.indexOf('--session-id')
       assert.ok(i >= 0 && capturedArgs[i + 1] === session._sessionId, 'fresh spawn uses --session-id <uuid>')
       assert.equal(capturedArgs.includes('--resume'), false, 'fresh spawn must NOT use --resume')
+      // Claude Code 2.1.186's "Claude in Chrome extension detected" prompt
+      // interactively wedges the PTY; the TUI spawn must pass --no-chrome.
+      assert.equal(capturedArgs.includes('--no-chrome'), true, 'TUI spawn passes --no-chrome')
     })
 
     it('restored session: seeds _sessionId from resumeSessionId, keeps it through start, spawns with --resume', async () => {


### PR DESCRIPTION
Hotfix for a session-breaking upstream change, found live while testing.

**Symptom:** every claude-tui session dies mid-turn — `Claude PTY exited mid-turn (code=1)` — the TUI tail showing a new **"Claude in Chrome extension detected"** prompt (`1. Yes, use my browser / 2. No, keep browser tools off`).

**Cause:** Claude Code **2.1.186** added a first-run prompt when it detects the Claude-in-Chrome browser extension. It's interactive (1/2/Enter/Esc); chroxy's PTY driver can't dismiss it, so the session wedges and the `claude` PTY exits.

**Fix:** pass `--no-chrome` when chroxy spawns the claude TUI (`claude-tui-session.js` base args). A headless chroxy TUI session never drives the browser integration, so disabling it at spawn is correct + side-effect-free.

**Test:** the suite mocks `_spawnPty`; kept the mock faithful (mirrors `--no-chrome`) + added a contract assertion. claude-tui-session suite green (300/300); server opt-forwarding + state-file lints green.