### PR TITLE
feat(dashboard): breathe the connection dots while the agent is active (chat redesign Phase 2)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1962,6 +1962,7 @@ export function App() {
       <AppHeader
         serverVersion={serverVersion}
         connectionPhase={connectionPhase}
+        chatActivityState={chatActivity.state}
         serverPhase={serverPhase}
         isConnected={isConnected}
         tunnelReady={tunnelReady}
@@ -2447,6 +2448,7 @@ export function App() {
       {/* Footer bar */}
       <FooterBar
         connectionPhase={connectionPhase}
+        chatActivityState={chatActivity.state}
         tunnelReady={tunnelReady}
         serverPhase={serverPhase}
         tunnelProgress={tunnelProgress}

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -21,6 +21,12 @@ declare const __APP_VERSION__: string
 export interface AppHeaderProps {
   serverVersion: string | null
   connectionPhase: string
+  /**
+   * Chat redesign #6392: the canonical chat-activity state. When the dot is
+   * genuinely connected, an active state (thinking/busy/waiting) makes it
+   * breathe — the chrome shows life without overriding the connection colour.
+   */
+  chatActivityState?: string
   serverPhase: string | null
   isConnected: boolean
   tunnelReady: boolean
@@ -132,6 +138,7 @@ export function AppHeader(props: AppHeaderProps) {
           return (
             <span
               className={`status-dot ${phase}`}
+              data-activity={phase === 'connected' ? props.chatActivityState : undefined}
               title={label}
               aria-label={label}
             />

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -4,6 +4,7 @@ import { NotificationsWidget } from './NotificationsWidget'
 import { HeaderOverflowMenu, type HeaderOverflowItem } from './HeaderOverflowMenu'
 import { StatusBar } from './StatusBar'
 import { formatShortcutKeys } from '../utils/platform'
+import type { ChatActivityState } from '@chroxy/store-core'
 
 declare const __APP_VERSION__: string
 
@@ -26,7 +27,7 @@ export interface AppHeaderProps {
    * genuinely connected, an active state (thinking/busy/waiting) makes it
    * breathe — the chrome shows life without overriding the connection colour.
    */
-  chatActivityState?: string
+  chatActivityState?: ChatActivityState
   serverPhase: string | null
   isConnected: boolean
   tunnelReady: boolean

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -38,6 +38,18 @@ describe('FooterBar', () => {
     expect(screen.queryByText('server_down')).not.toBeInTheDocument()
   })
 
+  // Chat redesign #6392: the connection dot carries data-activity ONLY when
+  // genuinely connected, so CSS breathes it on activity without overriding the
+  // connection colour. Disconnected → no data-activity (connection signal wins).
+  it('sets data-activity on the connection dot only when connected', () => {
+    const { container, rerender } = render(<FooterBar {...baseProps} chatActivityState="busy" />)
+    expect(container.querySelector('.footer-status-dot')).toHaveAttribute('data-activity', 'busy')
+    rerender(<FooterBar {...baseProps} chatActivityState="idle" />)
+    expect(container.querySelector('.footer-status-dot')).toHaveAttribute('data-activity', 'idle')
+    rerender(<FooterBar connectionPhase="disconnected" chatActivityState="busy" />)
+    expect(container.querySelector('.footer-status-dot')).not.toHaveAttribute('data-activity')
+  })
+
   it('shows abbreviated cwd', () => {
     render(<FooterBar {...baseProps} cwd="/Users/me/Projects/chroxy" />)
     expect(screen.getByText('Projects/chroxy')).toBeInTheDocument()

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useEffect, useState } from 'react'
-import type { SessionIntervention } from '@chroxy/store-core'
+import type { SessionIntervention, ChatActivityState } from '@chroxy/store-core'
 import {
   costTooltip,
   contextTooltip,
@@ -21,7 +21,7 @@ declare const __APP_VERSION__: string
 export interface FooterBarProps {
   connectionPhase: string
   /** Chat redesign #6392: chat-activity state → breathe the dot when connected + active. */
-  chatActivityState?: string
+  chatActivityState?: ChatActivityState
   tunnelReady?: boolean
   serverPhase?: 'tunnel_warming' | 'tunnel_verifying' | 'ready' | null
   tunnelProgress?: { attempt: number; maxAttempts: number } | null

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -20,6 +20,8 @@ declare const __APP_VERSION__: string
 
 export interface FooterBarProps {
   connectionPhase: string
+  /** Chat redesign #6392: chat-activity state → breathe the dot when connected + active. */
+  chatActivityState?: string
   tunnelReady?: boolean
   serverPhase?: 'tunnel_warming' | 'tunnel_verifying' | 'ready' | null
   tunnelProgress?: { attempt: number; maxAttempts: number } | null
@@ -95,6 +97,7 @@ export const FOOTER_OVER_BUDGET_THRESHOLD = 100
 
 export function FooterBar({
   connectionPhase,
+  chatActivityState,
   tunnelReady = true,
   serverPhase,
   tunnelProgress,
@@ -185,6 +188,7 @@ export function FooterBar({
             announcements. */}
         <span
           className={`footer-status-dot ${dotClass}`}
+          data-activity={dotClass === 'connected' ? chatActivityState : undefined}
           title={statusFullLabel}
           aria-label={statusFullLabel}
         />

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -544,6 +544,22 @@
 .status-dot.server_restarting { background: var(--status-restarting); }
 .status-dot.server_down { background: var(--accent-red); } /* #5698 — terminal */
 
+/*
+ * Chat redesign #6392 — the connection dots (header + footer) also breathe while
+ * the agent is active, so the chrome shows life instead of a static green.
+ * COLOUR stays connection-driven (green=connected, orange/red=trouble); only the
+ * PULSE reflects activity, and only when genuinely connected — so a connected dot
+ * never reads as a connection problem. idle + error stay still. Reuses busyPulse.
+ */
+.status-dot.connected[data-activity="thinking"],
+.status-dot.connected[data-activity="busy"],
+.status-dot.connected[data-activity="waiting"],
+.footer-status-dot.connected[data-activity="thinking"],
+.footer-status-dot.connected[data-activity="busy"],
+.footer-status-dot.connected[data-activity="waiting"] {
+  animation: busyPulse 1.2s ease-in-out infinite;
+}
+
 /* ---- Sidebar ---- */
 .sidebar {
   display: flex;
@@ -7584,6 +7600,13 @@ button.sidebar-token-view-session-row:hover {
   .thinking-dot,
   .loading-spinner,
   .qr-spinner {
+    animation: none;
+  }
+
+  /* #6392: match the connection-dot pulse specificity (0,3,0) so this WINS the
+     cascade — a bare .status-dot (0,1,0) would lose to .status-dot.connected[…]. */
+  .status-dot.connected[data-activity],
+  .footer-status-dot.connected[data-activity] {
     animation: none;
   }
 


### PR DESCRIPTION
Part of Phase 2 (#6392) — making the chrome 'alive' like the presence rail.

The connection dots (header `v0.9.47 ●`, footer `● Connected`) were **static** — they change colour by connection phase but never pulse, so while Claude works they just sit there solid green. This wires the two **chrome** connection dots to the canonical `deriveChatActivity` state (already computed in `App.tsx`, already feeding the presence rail + hairline):

- When the dot is **genuinely connected**, an active state (`thinking`/`busy`/`waiting`) makes it **breathe** (`busyPulse`) via a `data-activity` attribute.
- **Colour stays connection-driven** (green=connected, orange/red=trouble) — only the *pulse* reflects activity, gated on `connected`, so a connected dot never reads as a connection problem. `idle`/`error` stay still.
- **Reduced-motion** drops to static — with **matched selector specificity** so the override wins the cascade (same trap the presence rail hit).

Verified: dashboard `tsc` + build green; ratchet green; +1 FooterBar wiring test.

**Follow-ups (noted):** the two *sidebar* connection dots deserve the same treatment, and the session dots still use the old 3-state machine + a keyframe quirk (working dot shrinks instead of breathing).

Part of #6392 · epic #6389.