### PR TITLE
feat(dashboard): sidebar dots — breathe connection dots + fix session-dot shrink

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2020,6 +2020,7 @@ export function App() {
           width={sidebarWidth}
           filter={sidebarFilter}
           serverStatus={isConnected ? 'connected' : isReconnecting ? 'reconnecting' : 'disconnected'}
+          chatActivityState={chatActivity.state}
           tunnelUrl={null}
           connectedClients={connectedClients}
           activePrimaryClientId={resolveActivePrimaryClientId(activeSessionId, sessionStates, globalPrimaryClientId)}

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -986,11 +986,15 @@ export function Sidebar({
 
           {/* Footer */}
           <div className="sidebar-footer" data-testid="sidebar-footer">
-            <span className={`sidebar-status-dot ${serverStatus}`} data-activity={serverStatus === 'connected' ? chatActivityState : undefined} title={
-              serverStatus === 'connected' ? 'Server connected'
-                : serverStatus === 'reconnecting' ? 'Reconnecting to server...'
-                : 'Server disconnected'
-            } />
+            <span
+              className={`sidebar-status-dot ${serverStatus}`}
+              data-activity={serverStatus === 'connected' ? chatActivityState : undefined}
+              title={
+                serverStatus === 'connected' ? 'Server connected'
+                  : serverStatus === 'reconnecting' ? 'Reconnecting to server...'
+                  : 'Server disconnected'
+              }
+            />
             <span className="sidebar-status-label">{statusLabel}</span>
             {tunnelUrl && (
               <span className="sidebar-tunnel" title={tunnelUrl}>

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@
  * Collapsible with Cmd+B toggle.
  */
 import { useState, useCallback, useRef, useMemo } from 'react'
-import type { CumulativeUsage, SessionInfo, SessionVisualStatus, SessionRole } from '@chroxy/store-core'
+import type { CumulativeUsage, SessionInfo, SessionVisualStatus, SessionRole, ChatActivityState } from '@chroxy/store-core'
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 import { ConversationSearch } from './ConversationSearch'
@@ -69,6 +69,10 @@ export interface SidebarProps {
   width: number
   filter: string
   serverStatus: 'connected' | 'disconnected' | 'reconnecting'
+  /** #6418 — active session's chat-activity state. The connection dots breathe
+      (busyPulse) while it's thinking/busy/waiting, mirroring the header+footer
+      dots (#6415). Connection colour stays serverStatus-driven. */
+  chatActivityState?: ChatActivityState
   tunnelUrl: string | null
   /** #5281 ①.3 — all clients attached to the daemon, for the shared-session
       presence indicator in the footer. */
@@ -130,6 +134,7 @@ export function Sidebar({
   width,
   filter,
   serverStatus,
+  chatActivityState,
   tunnelUrl,
   connectedClients,
   activePrimaryClientId,
@@ -689,6 +694,7 @@ export function Sidebar({
             <span className="sidebar-projects-title">Projects</span>
             <span
               className={`sidebar-status-dot ${serverStatus}`}
+              data-activity={serverStatus === 'connected' ? chatActivityState : undefined}
               data-testid="sidebar-projects-status-dot"
               // Decorative — the adjacent status label already announces the
               // state, so hide the dot from screen readers to avoid a
@@ -980,7 +986,7 @@ export function Sidebar({
 
           {/* Footer */}
           <div className="sidebar-footer" data-testid="sidebar-footer">
-            <span className={`sidebar-status-dot ${serverStatus}`} title={
+            <span className={`sidebar-status-dot ${serverStatus}`} data-activity={serverStatus === 'connected' ? chatActivityState : undefined} title={
               serverStatus === 'connected' ? 'Server connected'
                 : serverStatus === 'reconnecting' ? 'Reconnecting to server...'
                 : 'Server disconnected'

--- a/packages/dashboard/src/components/SidebarDotAnimation.test.ts
+++ b/packages/dashboard/src/components/SidebarDotAnimation.test.ts
@@ -21,8 +21,11 @@ describe('Sidebar dot animations (#1675)', () => {
     expect(componentsCss).not.toMatch(/sidebar-session-dot\.status-idle\s*\{[^}]*animation:/)
   })
 
-  test('working dot has dotPulse animation', () => {
-    expect(componentsCss).toMatch(/sidebar-session-dot\.status-working\s*\{[^}]*animation:\s*dotPulse/)
+  test('working dot breathes (dotBreathe, not the shrink keyframe dotPulse)', () => {
+    // #6419 — dotPulse animates scale(0)->scale(1) so the dot vanished ~80% of the
+    // cycle; dotBreathe (opacity + gentle scale) actually breathes.
+    expect(componentsCss).toMatch(/sidebar-session-dot\.status-working\s*\{[^}]*animation:\s*dotBreathe/)
+    expect(componentsCss).not.toMatch(/sidebar-session-dot\.status-working\s*\{[^}]*animation:\s*dotPulse/)
   })
 
   test('stale dot is static warning color', () => {
@@ -30,8 +33,8 @@ describe('Sidebar dot animations (#1675)', () => {
     expect(componentsCss).not.toMatch(/sidebar-session-dot\.status-stale\s*\{[^}]*animation:/)
   })
 
-  test('dotPulse keyframes exist in global.css', () => {
-    expect(globalCss).toMatch(/@keyframes dotPulse/)
+  test('dotBreathe keyframes exist in global.css', () => {
+    expect(globalCss).toMatch(/@keyframes dotBreathe/)
   })
 
   test('working dot animation respects prefers-reduced-motion', () => {

--- a/packages/dashboard/src/components/SidebarDotAnimation.test.ts
+++ b/packages/dashboard/src/components/SidebarDotAnimation.test.ts
@@ -40,4 +40,15 @@ describe('Sidebar dot animations (#1675)', () => {
   test('working dot animation respects prefers-reduced-motion', () => {
     expect(componentsCss).toMatch(/prefers-reduced-motion[\s\S]*?sidebar-session-dot/)
   })
+
+  // #6418 — the sidebar CONNECTION dots (Projects header + footer) breathe while
+  // the active session is active. Pin both the pulse and its reduced-motion
+  // override so a future refactor can't silently drop them (review suggestion, #6421).
+  test('sidebar connection dot breathes via busyPulse when active', () => {
+    expect(componentsCss).toMatch(/sidebar-status-dot\.connected\[data-activity="thinking"\][\s\S]*?animation:\s*busyPulse/)
+  })
+
+  test('sidebar connection dot pulse respects prefers-reduced-motion', () => {
+    expect(componentsCss).toMatch(/prefers-reduced-motion[\s\S]*?sidebar-status-dot\.connected\[data-activity\][\s\S]*?animation:\s*none/)
+  })
 })

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -947,7 +947,11 @@
 
 .sidebar-session-dot.status-working {
   background: var(--accent-green);
-  animation: dotPulse 1.5s ease-in-out infinite;
+  /* #6419 — dotBreathe (opacity + gentle scale), NOT dotPulse: dotPulse animates
+     scale(0)->scale(1), so the working dot vanished for 80% of each cycle instead
+     of breathing. dotPulse stays for the .thinking-dot loader, where the staggered
+     bounce is intended. */
+  animation: dotBreathe 1.5s ease-in-out infinite;
 }
 
 .sidebar-session-dot.status-stale {
@@ -1727,6 +1731,16 @@ button.sidebar-token-view-session-row:hover {
 
 .sidebar-status-dot.reconnecting {
   background: var(--status-restarting);
+}
+
+/* #6418 — the sidebar connection dots breathe while the active session is
+   thinking/busy/waiting, mirroring the header+footer dots (#6415). Gated on
+   .connected so a disconnected/reconnecting dot never animates; colour stays
+   serverStatus-driven. idle + error stay still. Reuses busyPulse. */
+.sidebar-status-dot.connected[data-activity="thinking"],
+.sidebar-status-dot.connected[data-activity="busy"],
+.sidebar-status-dot.connected[data-activity="waiting"] {
+  animation: busyPulse 1.2s ease-in-out infinite;
 }
 
 .sidebar-tunnel {
@@ -7606,7 +7620,8 @@ button.sidebar-token-view-session-row:hover {
   /* #6392: match the connection-dot pulse specificity (0,3,0) so this WINS the
      cascade — a bare .status-dot (0,1,0) would lose to .status-dot.connected[…]. */
   .status-dot.connected[data-activity],
-  .footer-status-dot.connected[data-activity] {
+  .footer-status-dot.connected[data-activity],
+  .sidebar-status-dot.connected[data-activity] {
     animation: none;
   }
 


### PR DESCRIPTION
Continues the chat-redesign "breathing dots" theme from the header+footer connection dots (#6415).

## What
1. **Sidebar connection dots breathe** (closes #6418). The two `.sidebar-status-dot`s (Projects header + footer) now pulse via `busyPulse` while the **active session** is thinking/busy/waiting, gated on `.connected` so a disconnected/reconnecting dot never animates. Colour stays `serverStatus`-driven; reduced-motion handled at matched specificity. Mirrors the header+footer pattern — same `data-activity` gate, same keyframe.
2. **Session working-dot shrink fix** (keyframe half of #6419). `.sidebar-session-dot.status-working` animated **`dotPulse`**, which scales `0→1` — so the working dot **vanished ~80% of each cycle** instead of breathing. Switched to **`dotBreathe`** (opacity + gentle scale; already defined, previously unused). `dotPulse` stays for the `.thinking-dot` loader, where the staggered bounce is intentional.

## Deliberately NOT done
The **5-state session-dot migration** (other half of #6419) is declined: `deriveSessionVisualStatus` (idle/working/**stale**) is an orthogonal axis to `deriveChatActivity` (live turn states); migrating drops `stale` (a regression). Rationale on #6419.

## Verified
`tsc` clean · 109 dashboard tests (SidebarDotAnimation asserts `dotBreathe`) · production build · ratchet hex-lint green.

Part of the chat-redesign epic (#6389).