### PR TITLE
feat(store-core): canonical error-presentation registry (#6392)

### DIFF
--- a/packages/store-core/src/error-presentation.test.ts
+++ b/packages/store-core/src/error-presentation.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { getErrorPresentation, type ErrorKind } from './error-presentation'
+import { RETRYABLE_ASK_USER_QUESTION_ERROR_CODES } from './ask-user-question-errors'
+
+describe('getErrorPresentation', () => {
+  const cases: Array<[string, ErrorKind, 'status' | 'alert']> = [
+    ['stream_stall', 'stall', 'status'],
+    ['resume_unknown', 'resume', 'status'],
+    ['resume_unknown_exhausted', 'resume', 'alert'],
+  ]
+  it.each(cases)('maps %s → kind %s / role %s with a headline', (code, kind, role) => {
+    const p = getErrorPresentation(code)
+    expect(p.kind).toBe(kind)
+    expect(p.role).toBe(role)
+    expect(p.headline.length).toBeGreaterThan(0)
+  })
+
+  it('maps every retryable AskUserQuestion code to the shared question presentation', () => {
+    // Drives off the single-source-of-truth set so a future code is covered for free.
+    for (const code of RETRYABLE_ASK_USER_QUESTION_ERROR_CODES) {
+      const p = getErrorPresentation(code)
+      expect(p.kind).toBe('question')
+      expect(p.role).toBe('status')
+      expect(p.headline).toBe('Question delivery failed — retry?')
+    }
+  })
+
+  it('makes the exhausted resume terminal (alert) but the recoverable one polite (status)', () => {
+    expect(getErrorPresentation('resume_unknown_exhausted').role).toBe('alert')
+    expect(getErrorPresentation('resume_unknown').role).toBe('status')
+  })
+
+  it('falls back to generic/alert for unknown, empty, null, undefined — never throws', () => {
+    const fallbacks: Array<string | null | undefined> = ['totally_unknown_code', '', null, undefined]
+    for (const code of fallbacks) {
+      const p = getErrorPresentation(code)
+      expect(p.kind).toBe('generic')
+      expect(p.role).toBe('alert')
+      expect(p.headline.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('returns a non-empty headline for every known code', () => {
+    const known = [
+      'stream_stall',
+      'resume_unknown',
+      'resume_unknown_exhausted',
+      ...RETRYABLE_ASK_USER_QUESTION_ERROR_CODES,
+    ]
+    for (const code of known) {
+      expect(getErrorPresentation(code).headline.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/store-core/src/error-presentation.ts
+++ b/packages/store-core/src/error-presentation.ts
@@ -25,13 +25,16 @@ import { isRetryableAskUserQuestionError } from './ask-user-question-errors'
 export type ErrorKind = 'stall' | 'question' | 'resume' | 'generic'
 
 export interface ErrorPresentation {
-  kind: ErrorKind
+  // Fields are `readonly`: getErrorPresentation returns shared module-level
+  // singletons, so a consumer that mutated one would corrupt the registry for
+  // every later caller. readonly blocks that at compile time for all (TS) consumers.
+  readonly kind: ErrorKind
   /** ARIA live politeness: `status` (polite) for recoverable / auto-handled
    *  errors, `alert` (assertive) for terminal ones the user must act on. */
-  role: 'status' | 'alert'
+  readonly role: 'status' | 'alert'
   /** Default human-facing headline. Consumers may override for the dynamic
    *  cases (e.g. the stall chip's "No response for 30s — retry?"). */
-  headline: string
+  readonly headline: string
 }
 
 /** Per-code presentation. The AskUserQuestion teardown family (six codes, #5793)

--- a/packages/store-core/src/error-presentation.ts
+++ b/packages/store-core/src/error-presentation.ts
@@ -1,0 +1,86 @@
+/**
+ * Canonical error-presentation registry (chat redesign epic #6389, Phase 2 #6392).
+ *
+ * The dashboard chat stream renders an inline "chip" for recoverable error
+ * messages — a stalled stream, an AskUserQuestion delivery that failed, a
+ * conversation that couldn't be resumed — instead of a bare red bubble. Today
+ * each chip hard-codes its own headline copy + ARIA role, so the error taxonomy
+ * is scattered across StreamStallChip / AskUserQuestionStallChip /
+ * ResumeUnknownChip. This module defines that mapping ONCE — pure data, no DOM /
+ * React Native deps — the same way {@link ./tool-presentation} centralised
+ * tool-card presentation. A forthcoming single `ChatErrorFrame` (and a mobile
+ * twin) consume it so the two surfaces can't drift, and a new recoverable error
+ * code becomes a one-line addition here.
+ *
+ * `code` is the optional free-form `ChatMessage.code`, mirroring the server's
+ * error wire message. The AskUserQuestion family is matched via the existing
+ * single-source-of-truth predicate ({@link isRetryableAskUserQuestionError})
+ * rather than re-listing its six codes here.
+ */
+
+import { isRetryableAskUserQuestionError } from './ask-user-question-errors'
+
+/** Coarse classification of a recoverable chat error by what it represents.
+ *  `generic` is the catch-all for an unrecognised / missing error code. */
+export type ErrorKind = 'stall' | 'question' | 'resume' | 'generic'
+
+export interface ErrorPresentation {
+  kind: ErrorKind
+  /** ARIA live politeness: `status` (polite) for recoverable / auto-handled
+   *  errors, `alert` (assertive) for terminal ones the user must act on. */
+  role: 'status' | 'alert'
+  /** Default human-facing headline. Consumers may override for the dynamic
+   *  cases (e.g. the stall chip's "No response for 30s — retry?"). */
+  headline: string
+}
+
+/** Per-code presentation. The AskUserQuestion teardown family (six codes, #5793)
+ *  is matched via {@link isRetryableAskUserQuestionError}, not listed here, so a
+ *  new code lights up in one place. */
+const PRESENTATION_BY_CODE: Readonly<Record<string, ErrorPresentation>> = {
+  // Server emits this after the configured stream-inactivity window (#4475).
+  stream_stall: {
+    kind: 'stall',
+    role: 'status',
+    headline: 'Stream stalled — retry?',
+  },
+  // CliSession already auto-fell-back to a fresh conversation (#4944) — polite.
+  resume_unknown: {
+    kind: 'resume',
+    role: 'status',
+    headline: 'Previous conversation could not be resumed — starting fresh',
+  },
+  // Auto-respawn gave up (#5004) — terminal, the user must act, so assertive.
+  resume_unknown_exhausted: {
+    kind: 'resume',
+    role: 'alert',
+    headline: 'Auto-recovery exhausted — start a new session manually to continue',
+  },
+}
+
+/** Shared presentation for the AskUserQuestion teardown family (#5793) — the
+ *  prompt is dead but the user can recover by resending their request. */
+const QUESTION_PRESENTATION: ErrorPresentation = {
+  kind: 'question',
+  role: 'status',
+  headline: 'Question delivery failed — retry?',
+}
+
+/** Catch-all for an unrecognised / missing code — an unexpected error the user
+ *  should notice. Consumers typically show the raw server text as well. */
+const GENERIC_PRESENTATION: ErrorPresentation = {
+  kind: 'generic',
+  role: 'alert',
+  headline: 'Something went wrong',
+}
+
+/** Presentation descriptor for a chat error `code`: kind + ARIA role + a default
+ *  headline. The AskUserQuestion family is matched via the shared predicate; any
+ *  unrecognised / missing code falls back to `generic` — never throws. */
+export function getErrorPresentation(
+  code: string | null | undefined,
+): ErrorPresentation {
+  if (!code) return GENERIC_PRESENTATION
+  if (isRetryableAskUserQuestionError(code)) return QUESTION_PRESENTATION
+  return PRESENTATION_BY_CODE[code] ?? GENERIC_PRESENTATION
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -389,6 +389,12 @@ export {
 } from './tool-presentation'
 export type { ToolKind, ToolPresentation } from './tool-presentation'
 
+// Chat redesign #6389 (Phase 2 #6392): canonical error-presentation registry
+// — error code → kind → ARIA role → default headline, defined once so the
+// dashboard + mobile ChatErrorFrame can't drift on error copy / a11y.
+export { getErrorPresentation } from './error-presentation'
+export type { ErrorKind, ErrorPresentation } from './error-presentation'
+
 // Chat redesign #6391 (Phase 1): shared tool-output auto-collapse thresholds —
 // the dashboard + mobile ToolBubble collapse a long result past the same line
 // boundary.


### PR DESCRIPTION
First half of the **error-frame** Phase 2 slice — the pure-data registry. Mirrors the Phase-0 `tool-presentation` registry (#6395, landed standalone the same way) so the dashboard + mobile error frames can't drift.

## What
`getErrorPresentation(code)` → `{ kind, role, headline }` for every recoverable chat-error code, in one place:
- `stream_stall` → stall / status / "Stream stalled — retry?"
- the six-code **AskUserQuestion** teardown family → question / status / "Question delivery failed — retry?" (matched via the existing `isRetryableAskUserQuestionError` predicate — **no second list of codes**)
- `resume_unknown` → resume / status (polite — auto-fell-back) · `resume_unknown_exhausted` → resume / **alert** (assertive — terminal)
- catch-all → generic / alert (never throws on unknown/empty/null/undefined)

Today `StreamStallChip` / `AskUserQuestionStallChip` / `ResumeUnknownChip` each hard-code their own headline + ARIA role; this centralises the taxonomy + copy, and a new recoverable code becomes a one-line addition.

## Why standalone
No consumer yet — the single `ChatErrorFrame` that folds the three chips onto this registry is the **immediate follow-up PR**. Phase 0 landed `tool-presentation` (#6395) as standalone scaffolding the same way.

## Verified
7 tests (it.each table + AskUserQuestion-family loop + fallback + exhaustiveness) · **full store-core suite green (1899)** · `tsc` clean · no dist artifact (consumed from TS source).

Part of the chat-redesign epic (#6389).