### PR TITLE
feat(dashboard): ChatErrorFrame — fold the 3 error chips onto one shell + registry (#6392)

### DIFF
--- a/packages/dashboard/src/components/AskUserQuestionStallChip.tsx
+++ b/packages/dashboard/src/components/AskUserQuestionStallChip.tsx
@@ -21,6 +21,8 @@
  * duplicate the theme tokens for no UX benefit).
  */
 import { useCallback } from 'react'
+import { getErrorPresentation } from '@chroxy/store-core'
+import { ChatErrorFrame } from './ChatErrorFrame'
 
 export interface AskUserQuestionStallChipProps {
   /** The raw error text from the server (action-oriented copy, currently
@@ -42,14 +44,17 @@ export function AskUserQuestionStallChip({ errorText, onRetry }: AskUserQuestion
     onRetry?.()
   }, [onRetry])
 
+  // #6392 — the six retryable AskUserQuestion codes all share one presentation;
+  // ASK_USER_QUESTION_STALL is the canonical (first, #4614) family code.
+  const presentation = getErrorPresentation('ASK_USER_QUESTION_STALL')
+
   return (
-    <div
-      className="stream-stall-chip"
-      data-testid="ask-user-question-stall-chip"
-      role="status"
+    <ChatErrorFrame
+      testId="ask-user-question-stall-chip"
+      role={presentation.role}
       title={errorText}
+      headline={presentation.headline}
     >
-      <span className="stream-stall-chip-text">Question delivery failed — retry?</span>
       {onRetry && (
         <button
           type="button"
@@ -60,6 +65,6 @@ export function AskUserQuestionStallChip({ errorText, onRetry }: AskUserQuestion
           Retry
         </button>
       )}
-    </div>
+    </ChatErrorFrame>
   )
 }

--- a/packages/dashboard/src/components/ChatErrorFrame.test.tsx
+++ b/packages/dashboard/src/components/ChatErrorFrame.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChatErrorFrame } from './ChatErrorFrame'
+
+describe('ChatErrorFrame', () => {
+  it('renders the shared stream-stall-chip shell with headline, testId, role + title', () => {
+    render(<ChatErrorFrame testId="x-chip" role="status" title="raw server error" headline="Stream stalled — retry?" />)
+    const el = screen.getByTestId('x-chip')
+    expect(el).toHaveClass('stream-stall-chip')
+    expect(el).toHaveAttribute('role', 'status')
+    expect(el).toHaveAttribute('title', 'raw server error')
+    expect(screen.getByText('Stream stalled — retry?')).toHaveClass('stream-stall-chip-text')
+  })
+
+  it('omits data-variant when undefined and sets it (with an assertive role) when given', () => {
+    const { rerender } = render(<ChatErrorFrame testId="x" role="status" title="" headline="h" />)
+    expect(screen.getByTestId('x')).not.toHaveAttribute('data-variant')
+    rerender(<ChatErrorFrame testId="x" role="alert" title="" headline="h" variant="exhausted" />)
+    expect(screen.getByTestId('x')).toHaveAttribute('data-variant', 'exhausted')
+    expect(screen.getByTestId('x')).toHaveAttribute('role', 'alert')
+  })
+
+  it('renders subtext and action children after the headline', () => {
+    render(
+      <ChatErrorFrame
+        testId="x"
+        role="status"
+        title=""
+        headline="h"
+        subtext={<span data-testid="sub">Attempted id: abc</span>}
+      >
+        <button data-testid="act" type="button">Retry</button>
+      </ChatErrorFrame>,
+    )
+    expect(screen.getByTestId('sub')).toBeInTheDocument()
+    expect(screen.getByTestId('act')).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/ChatErrorFrame.tsx
+++ b/packages/dashboard/src/components/ChatErrorFrame.tsx
@@ -1,0 +1,62 @@
+/**
+ * ChatErrorFrame — the single inline error-chip shell (chat redesign, Phase 2).
+ *
+ * StreamStallChip / AskUserQuestionStallChip / ResumeUnknownChip all delegate
+ * to this frame so the `stream-stall-chip` DOM + ARIA structure live in ONE
+ * place instead of being copy-pasted three times. The per-error wrappers stay
+ * thin: they source `role` + the default `headline` from store-core's
+ * {@link getErrorPresentation} registry, and keep their own dynamic bits — the
+ * stall chip's timeout/provider headline, the resume chip's "Attempted id:"
+ * subtext — plus their action buttons.
+ *
+ * Each wrapper passes its own `testId` (and the resume chip its `variant`), so
+ * existing unit + E2E selectors (`stream-stall-chip`, `resume-unknown-chip`,
+ * the `*-retry` buttons, `data-variant`) are unchanged — this is a pure DOM
+ * extraction, not a visual change.
+ */
+import type { ReactNode } from 'react'
+
+export interface ChatErrorFrameProps {
+  /** data-testid for the frame root — each wrapper keeps its own anchor
+   *  (`stream-stall-chip` / `ask-user-question-stall-chip` / `resume-unknown-chip`). */
+  testId: string
+  /** ARIA live politeness — `status` (polite, recoverable) or `alert`
+   *  (assertive, terminal). Sourced from `getErrorPresentation` by the wrapper. */
+  role: 'status' | 'alert'
+  /** Headline copy. Wrappers pass the registry default or a dynamic override
+   *  (e.g. the stall chip's "No response for 5 minutes — retry?"). */
+  headline: string
+  /** Raw server error text → `title` tooltip, so diagnostics aren't lost. */
+  title?: string
+  /** Optional `data-variant` attribute (the resume chip's recoverable/exhausted).
+   *  Omitted from the DOM when undefined. */
+  variant?: string
+  /** Optional sub-line under the headline (the resume chip's "Attempted id: …"). */
+  subtext?: ReactNode
+  /** Action affordances rendered after the headline (Retry / View logs …). */
+  children?: ReactNode
+}
+
+export function ChatErrorFrame({
+  testId,
+  role,
+  headline,
+  title,
+  variant,
+  subtext,
+  children,
+}: ChatErrorFrameProps) {
+  return (
+    <div
+      className="stream-stall-chip"
+      data-testid={testId}
+      data-variant={variant}
+      role={role}
+      title={title}
+    >
+      <span className="stream-stall-chip-text">{headline}</span>
+      {subtext}
+      {children}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ResumeUnknownChip.tsx
+++ b/packages/dashboard/src/components/ResumeUnknownChip.tsx
@@ -33,6 +33,8 @@
  * `data-testid` makes the chip targetable from integration / E2E tests.
  */
 import type { CSSProperties } from 'react'
+import { getErrorPresentation } from '@chroxy/store-core'
+import { ChatErrorFrame } from './ChatErrorFrame'
 
 export interface ResumeUnknownChipProps {
   /**
@@ -91,35 +93,30 @@ export function ResumeUnknownChip({
   // "Attempted id: " slot.
   const hasId = typeof attemptedResumeId === 'string' && attemptedResumeId.trim().length > 0
 
-  // #5006: switch headline + a11y role on the variant. The recoverable
-  // variant uses `role="status"` (polite live region — chroxy already
-  // recovered) whereas the exhausted variant uses `role="alert"` (assertive
-  // — the user must take action). Keep the same `stream-stall-chip` palette
-  // so the visual language stays shared; the AT role + copy carry the
-  // urgency difference.
+  // #5006 / #6392: the variant maps to a resume error code, and the shared
+  // error-presentation registry supplies the headline + a11y role for it —
+  // recoverable → polite `status` (chroxy already recovered), exhausted →
+  // assertive `alert` (the user must act). Same `stream-stall-chip` palette via
+  // ChatErrorFrame; the AT role + copy carry the urgency difference.
   const isExhausted = variant === 'exhausted'
-  const headline = isExhausted
-    ? 'Auto-recovery exhausted — start a new session manually to continue'
-    : 'Previous conversation could not be resumed — starting fresh'
-  const role = isExhausted ? 'alert' : 'status'
+  const presentation = getErrorPresentation(
+    isExhausted ? 'resume_unknown_exhausted' : 'resume_unknown',
+  )
 
   return (
-    <div
-      className="stream-stall-chip"
-      data-testid="resume-unknown-chip"
-      data-variant={variant}
-      role={role}
+    <ChatErrorFrame
+      testId="resume-unknown-chip"
+      variant={variant}
+      role={presentation.role}
       title={errorText}
-    >
-      <span className="stream-stall-chip-text">{headline}</span>
-      {hasId && (
-        <span
-          data-testid="resume-unknown-chip-id"
-          style={ID_SUBTEXT_STYLE}
-        >
-          Attempted id: {attemptedResumeId}
-        </span>
-      )}
-    </div>
+      headline={presentation.headline}
+      subtext={
+        hasId && (
+          <span data-testid="resume-unknown-chip-id" style={ID_SUBTEXT_STYLE}>
+            Attempted id: {attemptedResumeId}
+          </span>
+        )
+      }
+    />
   )
 }

--- a/packages/dashboard/src/components/StreamStallChip.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.tsx
@@ -17,7 +17,8 @@
  * wires it to `setViewMode('system')`).
  */
 import { useCallback } from 'react'
-import { formatDurationVerbose, getProviderInfo } from '@chroxy/store-core'
+import { formatDurationVerbose, getProviderInfo, getErrorPresentation } from '@chroxy/store-core'
+import { ChatErrorFrame } from './ChatErrorFrame'
 
 export interface StreamStallChipProps {
   /** The raw error text from the server (e.g. "Stream stalled — no response for 5 minutes"). */
@@ -97,10 +98,14 @@ export function StreamStallChip({
   // #4497: humanise only when the server actually advertised a usable
   // window. Guard against 0 (explicitly disabled, per protocol) and
   // non-finite values so a malformed auth_ok can't degrade the UI.
+  // #6392 — role + the static default headline come from the shared
+  // error-presentation registry; the timeout/provider headline below is the
+  // dynamic override the registry intentionally doesn't encode.
+  const presentation = getErrorPresentation('stream_stall')
   const body =
     typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
       ? `No response for ${formatDurationVerbose(timeoutMs)} — retry?`
-      : 'Stream stalled — retry?'
+      : presentation.headline
 
   // #4603: prefix the body with the provider short label (e.g. "SDK · ")
   // only when the prop is a non-empty, non-whitespace string. An empty
@@ -113,13 +118,12 @@ export function StreamStallChip({
   const headline = providerShort ? `${providerShort} · ${body}` : body
 
   return (
-    <div
-      className="stream-stall-chip"
-      data-testid="stream-stall-chip"
-      role="status"
+    <ChatErrorFrame
+      testId="stream-stall-chip"
+      role={presentation.role}
       title={errorText}
+      headline={headline}
     >
-      <span className="stream-stall-chip-text">{headline}</span>
       {onRetry && (
         <button
           type="button"
@@ -140,6 +144,6 @@ export function StreamStallChip({
           View logs
         </button>
       )}
-    </div>
+    </ChatErrorFrame>
   )
 }


### PR DESCRIPTION
Second half of the **error-frame** Phase 2 slice — the consumer of the #6422 registry.

## What
`StreamStallChip` / `AskUserQuestionStallChip` / `ResumeUnknownChip` each hand-rolled the same `stream-stall-chip` DOM and hard-coded their own headline + ARIA role. This extracts **one `ChatErrorFrame`** they all delegate to, sourcing `role` + the default headline from store-core's `getErrorPresentation` registry (#6422).

## Behavior-preserving
Each wrapper passes its own `testId` (and the resume chip its `variant`), and keeps its **dynamic** bits — StreamStall's timeout/provider headline (`No response for 5 minutes — retry?`, `SDK · …`), Resume's recoverable/exhausted variant + `Attempted id:` subtext. The rendered DOM (testids, classes, roles, `data-variant`, buttons) is identical, so **all existing chip tests stay green** — a pure DOM extraction, no visual change.

## Verified
42 tests (the 3 chip suites unchanged + the new `ChatErrorFrame` suite) · `tsc` · build · ratchet — all green.

Note: the ratchet false-positived on a `#NNNN` issue ref in the new file (4-digit refs look like 4-digit hex); dropped the `#` in one comment, tracked as #6423.

Part of the chat-redesign epic (#6389), Phase 2 (#6392).