### PR TITLE
feat(dashboard): color the presence rail by the in-flight tool's kind (#6392)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -14,6 +14,7 @@ import {
   resolveContextWindow,
   providerSupportsMultiQuestion,
   formatToolName,
+  getToolPresentation,
   deriveChatActivity,
   type SessionInfo,
 } from '@chroxy/store-core'
@@ -300,6 +301,18 @@ export function App() {
   const workingLabel = useMemo(() => {
     const inFlight = findInFlightToolUse(storeMessages)
     return inFlight ? `Running ${formatToolName(inFlight.tool, inFlight.serverName)}…` : undefined
+  }, [storeMessages])
+
+  // #6392 — color the presence rail by the in-flight tool's kind (Read=blue,
+  // Bash=purple, Edit=orange…) via the shared tool-presentation registry, rather
+  // than the generic 'busy' purple. A `var(--token)` string when a tool is
+  // mid-flight, undefined otherwise → the rail falls back to its activity-state
+  // colour. Same findInFlightToolUse walk as workingLabel, so it's stable across
+  // response tokens (only changes when the tool changes).
+  const inFlightToolColor = useMemo(() => {
+    const inFlight = findInFlightToolUse(storeMessages)
+    if (!inFlight) return undefined
+    return `var(--${getToolPresentation(inFlight.tool, inFlight.serverName).colorToken})`
   }, [storeMessages])
 
   // #4735 / #4731: the multi-question AskUserQuestion form is gated per
@@ -2249,6 +2262,7 @@ export function App() {
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
                         workingLabel={workingLabel}
+                        inFlightToolColor={inFlightToolColor}
                       />
                     }
                     second={
@@ -2295,6 +2309,7 @@ export function App() {
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
                         workingLabel={workingLabel}
+                        inFlightToolColor={inFlightToolColor}
                       />
                     </div>
                     <div

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -76,6 +76,8 @@ describe('ChatView', () => {
   it('the busy + thinking rail rules consume --rail-color (tool colour overrides); waiting/error stay fixed (chat redesign #6392)', () => {
     expect(componentsCss).toMatch(/presence-rail\[data-activity-state="busy"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-purple\)\)/)
     expect(componentsCss).toMatch(/presence-rail\[data-activity-state="thinking"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-blue\)\)/)
+    // waiting + error keep their fixed signal colours — they must NOT read --rail-color.
+    expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="waiting"\]\s*\{[^}]*--rail-color/)
     expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="error"\]\s*\{[^}]*--rail-color/)
   })
 

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -5,6 +5,10 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { ChatView, type ChatViewMessage } from './ChatView'
 import { ThinkingDots } from './ThinkingDots'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const componentsCss = fs.readFileSync(path.resolve(__dirname, '../theme/components.css'), 'utf-8')
 
 afterEach(cleanup)
 
@@ -55,6 +59,24 @@ describe('ChatView', () => {
   it('defaults the presence rail to idle when no activity state is given (chat redesign #6392)', () => {
     render(<ChatView messages={makeMessages(1)} isStreaming={false} />)
     expect(screen.getByTestId('presence-rail')).toHaveAttribute('data-activity-state', 'idle')
+  })
+
+  it('paints the presence rail with the in-flight tool colour via --rail-color (chat redesign #6392)', () => {
+    const { rerender } = render(
+      <ChatView messages={makeMessages(2)} isStreaming={false} chatActivityState="busy" inFlightToolColor="var(--accent-blue)" />,
+    )
+    const rail = screen.getByTestId('presence-rail')
+    // Inline --rail-color wins the cascade so the busy rule paints the tool colour.
+    expect(rail.style.getPropertyValue('--rail-color')).toBe('var(--accent-blue)')
+    // No tool in flight → no override; the rail keeps its activity-state colour.
+    rerender(<ChatView messages={makeMessages(2)} isStreaming={false} chatActivityState="busy" />)
+    expect(screen.getByTestId('presence-rail').style.getPropertyValue('--rail-color')).toBe('')
+  })
+
+  it('the busy + thinking rail rules consume --rail-color (tool colour overrides); waiting/error stay fixed (chat redesign #6392)', () => {
+    expect(componentsCss).toMatch(/presence-rail\[data-activity-state="busy"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-purple\)\)/)
+    expect(componentsCss).toMatch(/presence-rail\[data-activity-state="thinking"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-blue\)\)/)
+    expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="error"\]\s*\{[^}]*--rail-color/)
   })
 
   it('shows thinking dots when streaming', () => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -126,6 +126,10 @@ export interface ChatViewProps {
    * composer hairline uses. Undefined → the rail stays idle (neutral).
    */
   chatActivityState?: ChatActivityState
+  /** #6392 — a `var(--token)` colour (from the shared tool-presentation registry)
+   *  for the presence rail when a tool is mid-flight, so the rail reflects WHICH
+   *  tool is running. undefined → the rail keeps its activity-state colour. */
+  inFlightToolColor?: string
   /** Optional custom renderer. Return a node to override default rendering, or null to fall back. */
   renderMessage?: (msg: ChatViewMessage) => ReactNode | null
   /**
@@ -348,7 +352,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
@@ -704,7 +708,13 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, render
         content. Motion choreography is intentionally restrained pending design
         tuning (see the .presence-rail CSS).
       */}
-      <div className="presence-rail" data-activity-state={chatActivityState ?? 'idle'} data-testid="presence-rail" aria-hidden="true" />
+      <div
+        className="presence-rail"
+        data-activity-state={chatActivityState ?? 'idle'}
+        style={inFlightToolColor ? ({ '--rail-color': inFlightToolColor } as CSSProperties) : undefined}
+        data-testid="presence-rail"
+        aria-hidden="true"
+      />
       <ChatExpandContext.Provider value={expandRegistry}>
         <div
           ref={containerRef}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2612,12 +2612,16 @@ button.sidebar-token-view-session-row:hover {
   z-index: 2;
   transition: background var(--dur-base) var(--ease-standard);
 }
+/* #6392 — when a tool is mid-flight the rail takes the tool's colour (--rail-color,
+   set inline from the tool-presentation registry); otherwise it falls back to the
+   activity-state colour. Only the two states a tool can run in (thinking / busy)
+   read --rail-color — waiting / error keep their fixed signal colour. */
 .presence-rail[data-activity-state="thinking"] {
-  background: var(--accent-blue);
+  background: var(--rail-color, var(--accent-blue));
   animation: presence-rail-breathe var(--rail-breathe) var(--ease-standard) infinite;
 }
 .presence-rail[data-activity-state="busy"] {
-  background: var(--accent-purple);
+  background: var(--rail-color, var(--accent-purple));
   animation: presence-rail-breathe var(--rail-heartbeat) var(--ease-standard) infinite;
 }
 .presence-rail[data-activity-state="waiting"] {


### PR DESCRIPTION
Phase 2 polish for the presence rail (#6413): instead of a generic 'busy' purple during all tool work, the rail now reflects **which tool is running** — Read=blue, Edit=orange, Bash=purple, Search=blue, Write=green… — reusing the **already-decided** `tool-presentation` registry colorTokens (no new colour choices).

## How (lower-risk path)
- `deriveChatActivity` is **untouched** — it's cross-package (mobile reuses it) and intentionally collapses tool work into 'busy'. Instead the in-flight tool colour is threaded **separately**: App.tsx derives it via the same `findInFlightToolUse` walk already used for `workingLabel` → `getToolPresentation().colorToken` → a `var(--token)` string passed to ChatView.
- ChatView sets it as an inline `--rail-color` custom property on the rail.
- The **busy + thinking** rail rules read `var(--rail-color, <activity-color>)` so the tool colour wins the cascade (inline var, no specificity fight), falling back to the activity colour when no tool is in flight. **waiting/error keep their fixed signal colours.**

## No regressions
`presence-rail-breathe` is opacity-only, so the static tool colour coexists with the breathe; the reduced-motion override (kills animation on `[data-activity-state]`) is untouched.

## Verified
+2 ChatView tests (the inline `--rail-color` is set when a tool's in flight + cleared when not; the CSS contract that busy/thinking consume `--rail-color`) · 54 ChatView tests · `tsc` · build · ratchet — all green.

Part of the chat-redesign epic (#6389), Phase 2 (#6392).