### PR TITLE
feat(dashboard): number queued follow-ups by send order (#6392)

### DIFF
--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -81,6 +81,33 @@ describe('ChatView', () => {
     expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="error"\]\s*\{[^}]*--rail-color/)
   })
 
+  it('numbers queued follow-ups by send order when more than one is queued (chat redesign #6392)', () => {
+    render(
+      <ChatView
+        messages={makeMessages(3)}
+        isStreaming={false}
+        queuedIds={new Set(['msg-1', 'msg-2'])}
+        onCancelQueued={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('msg-queued-position-msg-1')).toHaveTextContent('#1')
+    expect(screen.getByTestId('msg-queued-position-msg-2')).toHaveTextContent('#2')
+  })
+
+  it('omits the position for a single queued follow-up (chat redesign #6392)', () => {
+    render(
+      <ChatView
+        messages={makeMessages(2)}
+        isStreaming={false}
+        queuedIds={new Set(['msg-1'])}
+        onCancelQueued={() => {}}
+      />,
+    )
+    // Still flagged as queued, just no redundant "#1".
+    expect(screen.getByTestId('msg-queued-msg-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('msg-queued-position-msg-1')).not.toBeInTheDocument()
+  })
+
   it('shows thinking dots when streaming', () => {
     render(<ChatView messages={makeMessages(1)} isStreaming />)
     expect(screen.getByTestId('thinking-dots')).toBeInTheDocument()

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -291,6 +291,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   isStreaming,
   queued,
   onCancelQueued,
+  queuePosition,
 }: {
   id: string
   type: ChatViewMessage['type']
@@ -301,6 +302,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   queued?: boolean
   /** #5939: cancel this queued follow-up (stable callback from ChatView). */
   onCancelQueued?: (id: string) => void
+  /** #6392: 1-based send position among queued follow-ups, shown only when more
+   *  than one is queued (so a lone queued message stays a plain "Queued"). */
+  queuePosition?: number
 }) {
   // Dev-only render tally — proves (in the memoization test + ad-hoc
   // profiling) non-tail rows don't re-render on a delta flush. Never read on
@@ -331,6 +335,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
         {queued && (
           <span className="msg-queued" data-testid={`msg-queued-${id}`}>
             <span className="msg-queued-label">Queued</span>
+            {queuePosition != null && (
+              <span className="msg-queued-position" data-testid={`msg-queued-position-${id}`}>#{queuePosition}</span>
+            )}
             {onCancelQueued && (
               <button
                 type="button"
@@ -354,6 +361,20 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
 
 function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // #6392 — 1-based send position for each queued follow-up, derived from the
+  // ordered `messages` (queuedIds is an unordered Set). Only built when 2+ are
+  // queued, so a single queued message stays a plain "Queued" (no "#1").
+  const queuePositions = useMemo(() => {
+    if (!queuedIds || queuedIds.size < 2) return null
+    const positions = new Map<string, number>()
+    let n = 0
+    for (const m of messages) {
+      if (queuedIds.has(m.id)) positions.set(m.id, ++n)
+    }
+    return positions
+  }, [messages, queuedIds])
+
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
   // #5954 — a ref mirror of `userScrolledUp` so the ResizeObserver callback can
@@ -766,6 +787,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   timestamp={msg.timestamp}
                   isStreaming={msg.isStreaming}
                   queued={queuedIds?.has(msg.id) ?? false}
+                  queuePosition={queuePositions?.get(msg.id)}
                   onCancelQueued={onCancelQueued}
                 />
               </MessageRowShell>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2855,6 +2855,13 @@ button.sidebar-token-view-session-row:hover {
   text-transform: uppercase;
 }
 
+/* #6392 — subtle 1-based send position shown next to the Queued pill when more
+   than one follow-up is queued (the flex gap on .msg-queued spaces it). */
+.msg-queued-position {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
 .msg-queued-cancel {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Small Phase 2 polish. When you queue multiple messages mid-turn (#5939 dims + dashes the ghosts), each queued ghost now shows its **1-based send position** (`#1`, `#2`…) next to the 'Queued' pill, so the send order is visible at a glance.

## Details
- Only shown when **2+** are queued — a lone queued message stays a plain 'Queued' (no redundant `#1`).
- Position is derived from the **ordered `messages`** array (`queuedIds` is an unordered `Set`), computed once in a `useMemo`.
- The flex `gap` on `.msg-queued` spaces it; the position is a subtle (`opacity: 0.7`, tabular-nums) element, no new colour.

## Verified
+2 ChatView tests (2-queued shows `#1`/`#2` in send order; 1-queued shows no position) · 56 ChatView tests · tsc · build · ratchet — all green.

⚠️ **Stacked on #6425** (base is `feat/dashboard-rail-tool-color`) — both touch ChatView/components.css. Merge #6425 first; this will retarget to main automatically.

Part of the chat-redesign epic (#6389), Phase 2 (#6392).