### PR TITLE
feat(dashboard): number queued follow-ups by send order (#6392)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -14,6 +14,7 @@ import {
   resolveContextWindow,
   providerSupportsMultiQuestion,
   formatToolName,
+  getToolPresentation,
   deriveChatActivity,
   type SessionInfo,
 } from '@chroxy/store-core'
@@ -300,6 +301,18 @@ export function App() {
   const workingLabel = useMemo(() => {
     const inFlight = findInFlightToolUse(storeMessages)
     return inFlight ? `Running ${formatToolName(inFlight.tool, inFlight.serverName)}…` : undefined
+  }, [storeMessages])
+
+  // #6392 — color the presence rail by the in-flight tool's kind (Read=blue,
+  // Bash=purple, Edit=orange…) via the shared tool-presentation registry, rather
+  // than the generic 'busy' purple. A `var(--token)` string when a tool is
+  // mid-flight, undefined otherwise → the rail falls back to its activity-state
+  // colour. Same findInFlightToolUse walk as workingLabel, so it's stable across
+  // response tokens (only changes when the tool changes).
+  const inFlightToolColor = useMemo(() => {
+    const inFlight = findInFlightToolUse(storeMessages)
+    if (!inFlight) return undefined
+    return `var(--${getToolPresentation(inFlight.tool, inFlight.serverName).colorToken})`
   }, [storeMessages])
 
   // #4735 / #4731: the multi-question AskUserQuestion form is gated per
@@ -2249,6 +2262,7 @@ export function App() {
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
                         workingLabel={workingLabel}
+                        inFlightToolColor={inFlightToolColor}
                       />
                     }
                     second={
@@ -2295,6 +2309,7 @@ export function App() {
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
                         workingLabel={workingLabel}
+                        inFlightToolColor={inFlightToolColor}
                       />
                     </div>
                     <div

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -76,6 +76,8 @@ describe('ChatView', () => {
   it('the busy + thinking rail rules consume --rail-color (tool colour overrides); waiting/error stay fixed (chat redesign #6392)', () => {
     expect(componentsCss).toMatch(/presence-rail\[data-activity-state="busy"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-purple\)\)/)
     expect(componentsCss).toMatch(/presence-rail\[data-activity-state="thinking"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-blue\)\)/)
+    // waiting + error keep their fixed signal colours — they must NOT read --rail-color.
+    expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="waiting"\]\s*\{[^}]*--rail-color/)
     expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="error"\]\s*\{[^}]*--rail-color/)
   })
 

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -5,6 +5,10 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
 import { ChatView, type ChatViewMessage } from './ChatView'
 import { ThinkingDots } from './ThinkingDots'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const componentsCss = fs.readFileSync(path.resolve(__dirname, '../theme/components.css'), 'utf-8')
 
 afterEach(cleanup)
 
@@ -55,6 +59,24 @@ describe('ChatView', () => {
   it('defaults the presence rail to idle when no activity state is given (chat redesign #6392)', () => {
     render(<ChatView messages={makeMessages(1)} isStreaming={false} />)
     expect(screen.getByTestId('presence-rail')).toHaveAttribute('data-activity-state', 'idle')
+  })
+
+  it('paints the presence rail with the in-flight tool colour via --rail-color (chat redesign #6392)', () => {
+    const { rerender } = render(
+      <ChatView messages={makeMessages(2)} isStreaming={false} chatActivityState="busy" inFlightToolColor="var(--accent-blue)" />,
+    )
+    const rail = screen.getByTestId('presence-rail')
+    // Inline --rail-color wins the cascade so the busy rule paints the tool colour.
+    expect(rail.style.getPropertyValue('--rail-color')).toBe('var(--accent-blue)')
+    // No tool in flight → no override; the rail keeps its activity-state colour.
+    rerender(<ChatView messages={makeMessages(2)} isStreaming={false} chatActivityState="busy" />)
+    expect(screen.getByTestId('presence-rail').style.getPropertyValue('--rail-color')).toBe('')
+  })
+
+  it('the busy + thinking rail rules consume --rail-color (tool colour overrides); waiting/error stay fixed (chat redesign #6392)', () => {
+    expect(componentsCss).toMatch(/presence-rail\[data-activity-state="busy"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-purple\)\)/)
+    expect(componentsCss).toMatch(/presence-rail\[data-activity-state="thinking"\]\s*\{[^}]*background:\s*var\(--rail-color,\s*var\(--accent-blue\)\)/)
+    expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="error"\]\s*\{[^}]*--rail-color/)
   })
 
   it('shows thinking dots when streaming', () => {

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -81,6 +81,33 @@ describe('ChatView', () => {
     expect(componentsCss).not.toMatch(/presence-rail\[data-activity-state="error"\]\s*\{[^}]*--rail-color/)
   })
 
+  it('numbers queued follow-ups by send order when more than one is queued (chat redesign #6392)', () => {
+    render(
+      <ChatView
+        messages={makeMessages(3)}
+        isStreaming={false}
+        queuedIds={new Set(['msg-1', 'msg-2'])}
+        onCancelQueued={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('msg-queued-position-msg-1')).toHaveTextContent('#1')
+    expect(screen.getByTestId('msg-queued-position-msg-2')).toHaveTextContent('#2')
+  })
+
+  it('omits the position for a single queued follow-up (chat redesign #6392)', () => {
+    render(
+      <ChatView
+        messages={makeMessages(2)}
+        isStreaming={false}
+        queuedIds={new Set(['msg-1'])}
+        onCancelQueued={() => {}}
+      />,
+    )
+    // Still flagged as queued, just no redundant "#1".
+    expect(screen.getByTestId('msg-queued-msg-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('msg-queued-position-msg-1')).not.toBeInTheDocument()
+  })
+
   it('shows thinking dots when streaming', () => {
     render(<ChatView messages={makeMessages(1)} isStreaming />)
     expect(screen.getByTestId('thinking-dots')).toBeInTheDocument()

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -291,6 +291,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   isStreaming,
   queued,
   onCancelQueued,
+  queuePosition,
 }: {
   id: string
   type: ChatViewMessage['type']
@@ -301,6 +302,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   queued?: boolean
   /** #5939: cancel this queued follow-up (stable callback from ChatView). */
   onCancelQueued?: (id: string) => void
+  /** #6392: 1-based send position among queued follow-ups, shown only when more
+   *  than one is queued (so a lone queued message stays a plain "Queued"). */
+  queuePosition?: number
 }) {
   // Dev-only render tally — proves (in the memoization test + ad-hoc
   // profiling) non-tail rows don't re-render on a delta flush. Never read on
@@ -331,6 +335,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
         {queued && (
           <span className="msg-queued" data-testid={`msg-queued-${id}`}>
             <span className="msg-queued-label">Queued</span>
+            {queuePosition != null && (
+              <span className="msg-queued-position" data-testid={`msg-queued-position-${id}`}>#{queuePosition}</span>
+            )}
             {onCancelQueued && (
               <button
                 type="button"
@@ -354,6 +361,20 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
 
 function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // #6392 — 1-based send position for each queued follow-up, derived from the
+  // ordered `messages` (queuedIds is an unordered Set). Only built when 2+ are
+  // queued, so a single queued message stays a plain "Queued" (no "#1").
+  const queuePositions = useMemo(() => {
+    if (!queuedIds || queuedIds.size < 2) return null
+    const positions = new Map<string, number>()
+    let n = 0
+    for (const m of messages) {
+      if (queuedIds.has(m.id)) positions.set(m.id, ++n)
+    }
+    return positions
+  }, [messages, queuedIds])
+
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
   // #5954 — a ref mirror of `userScrolledUp` so the ResizeObserver callback can
@@ -766,6 +787,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   timestamp={msg.timestamp}
                   isStreaming={msg.isStreaming}
                   queued={queuedIds?.has(msg.id) ?? false}
+                  queuePosition={queuePositions?.get(msg.id)}
                   onCancelQueued={onCancelQueued}
                 />
               </MessageRowShell>

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -126,6 +126,10 @@ export interface ChatViewProps {
    * composer hairline uses. Undefined → the rail stays idle (neutral).
    */
   chatActivityState?: ChatActivityState
+  /** #6392 — a `var(--token)` colour (from the shared tool-presentation registry)
+   *  for the presence rail when a tool is mid-flight, so the rail reflects WHICH
+   *  tool is running. undefined → the rail keeps its activity-state colour. */
+  inFlightToolColor?: string
   /** Optional custom renderer. Return a node to override default rendering, or null to fall back. */
   renderMessage?: (msg: ChatViewMessage) => ReactNode | null
   /**
@@ -348,7 +352,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
@@ -704,7 +708,13 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, render
         content. Motion choreography is intentionally restrained pending design
         tuning (see the .presence-rail CSS).
       */}
-      <div className="presence-rail" data-activity-state={chatActivityState ?? 'idle'} data-testid="presence-rail" aria-hidden="true" />
+      <div
+        className="presence-rail"
+        data-activity-state={chatActivityState ?? 'idle'}
+        style={inFlightToolColor ? ({ '--rail-color': inFlightToolColor } as CSSProperties) : undefined}
+        data-testid="presence-rail"
+        aria-hidden="true"
+      />
       <ChatExpandContext.Provider value={expandRegistry}>
         <div
           ref={containerRef}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2855,6 +2855,13 @@ button.sidebar-token-view-session-row:hover {
   text-transform: uppercase;
 }
 
+/* #6392 — subtle 1-based send position shown next to the Queued pill when more
+   than one follow-up is queued (the flex gap on .msg-queued spaces it). */
+.msg-queued-position {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
 .msg-queued-cancel {
   display: inline-flex;
   align-items: center;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2612,12 +2612,16 @@ button.sidebar-token-view-session-row:hover {
   z-index: 2;
   transition: background var(--dur-base) var(--ease-standard);
 }
+/* #6392 — when a tool is mid-flight the rail takes the tool's colour (--rail-color,
+   set inline from the tool-presentation registry); otherwise it falls back to the
+   activity-state colour. Only the two states a tool can run in (thinking / busy)
+   read --rail-color — waiting / error keep their fixed signal colour. */
 .presence-rail[data-activity-state="thinking"] {
-  background: var(--accent-blue);
+  background: var(--rail-color, var(--accent-blue));
   animation: presence-rail-breathe var(--rail-breathe) var(--ease-standard) infinite;
 }
 .presence-rail[data-activity-state="busy"] {
-  background: var(--accent-purple);
+  background: var(--rail-color, var(--accent-purple));
   animation: presence-rail-breathe var(--rail-heartbeat) var(--ease-standard) infinite;
 }
 .presence-rail[data-activity-state="waiting"] {


### PR DESCRIPTION
When you queue multiple messages mid-turn (#5939 dims + dashes the ghosts), each queued ghost now shows its **1-based send position** (`#1`, `#2`…) next to the 'Queued' pill, so the send order is visible.

## Details
- Only shown when **2+** are queued — a lone queued message stays a plain 'Queued' (no redundant `#1`).
- Position derived from the **ordered `messages`** (`queuedIds` is an unordered `Set`), computed once in a `useMemo` (returns null for <2).
- Subtle element (`opacity: 0.7`, tabular-nums), spaced by the existing `.msg-queued` flex gap — no new colour.

## Verified
+2 ChatView tests · 56 ChatView tests · tsc · build · ratchet — all green.

## Note
Supersedes **#6427**, which GitHub auto-closed when its stacked base branch (`feat/dashboard-rail-tool-color`) was deleted on #6425's merge. Already reviewed there — **✅ approve, 0 critical** (send-order correct, no identity-thrash since `queuedIds` is a stable memo, stale-id safe, ratchet-safe, O(messages) only when 2+ queued). This branch is now merged with main (the rail-color slice landed via #6425).

Part of the chat-redesign epic (#6389), Phase 2 (#6392).