### PR TITLE
feat(app): source mobile error chips' headlines from the getErrorPresentation registry (#6392)

### DIFF
--- a/packages/app/src/components/ResumeUnknownChip.tsx
+++ b/packages/app/src/components/ResumeUnknownChip.tsx
@@ -36,6 +36,7 @@
  * affordance — the chip visual language is shared.
  */
 import { Platform, StyleSheet, Text, View } from 'react-native';
+import { getErrorPresentation } from '@chroxy/store-core';
 import { COLORS } from '../constants/colors';
 
 export interface ResumeUnknownChipProps {
@@ -65,9 +66,6 @@ export interface ResumeUnknownChipProps {
   variant?: 'recoverable' | 'exhausted';
 }
 
-const RECOVERABLE_HEADLINE = 'Previous conversation could not be resumed — starting fresh';
-const EXHAUSTED_HEADLINE = 'Auto-recovery exhausted — start a new session manually to continue';
-
 export function ResumeUnknownChip({
   errorText,
   attemptedResumeId,
@@ -78,11 +76,14 @@ export function ResumeUnknownChip({
   // a broken-looking "Attempted id: " slot with no value.
   const hasId = typeof attemptedResumeId === 'string' && attemptedResumeId.trim().length > 0;
 
-  // #5006: switch headline copy on the variant. accessibilityRole stays
-  // `'alert'` for both variants — the mobile RN convention is to use the
-  // assertive role on recoverable amber chips too (parity with
-  // StreamStallChip). The label difference carries the urgency signal.
-  const headline = variant === 'exhausted' ? EXHAUSTED_HEADLINE : RECOVERABLE_HEADLINE;
+  // #5006 / #6392: the variant maps to a resume error code; the shared
+  // error-presentation registry (store-core) supplies the headline so the copy
+  // is single-sourced cross-surface. accessibilityRole stays `'alert'` for both
+  // variants — the mobile RN convention is the assertive role on recoverable
+  // amber chips too (parity with StreamStallChip); the label carries the urgency.
+  const { headline } = getErrorPresentation(
+    variant === 'exhausted' ? 'resume_unknown_exhausted' : 'resume_unknown',
+  );
 
   return (
     <View

--- a/packages/app/src/components/StreamStallChip.tsx
+++ b/packages/app/src/components/StreamStallChip.tsx
@@ -19,6 +19,7 @@
  */
 import React, { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { getErrorPresentation } from '@chroxy/store-core';
 import { COLORS } from '../constants/colors';
 
 export interface StreamStallChipProps {
@@ -43,7 +44,13 @@ export interface StreamStallChipProps {
   headline?: string;
 }
 
-export function StreamStallChip({ errorText, onRetry, headline = 'Stream stalled — retry?' }: StreamStallChipProps) {
+export function StreamStallChip({
+  errorText,
+  onRetry,
+  // #6392: the default stream-stall copy is single-sourced from the shared
+  // error-presentation registry (callers override for the AskUserQuestion family).
+  headline = getErrorPresentation('stream_stall').headline,
+}: StreamStallChipProps) {
   const [detailVisible, setDetailVisible] = useState(false);
 
   const handleRetry = useCallback(() => {

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -8,7 +8,7 @@ import {
   Image,
   LayoutAnimation,
 } from 'react-native';
-import { OTHER_OPTION_VALUE, bumpRenderCount, isRetryableAskUserQuestionError, isSingleMultiSelectForm } from '@chroxy/store-core';
+import { OTHER_OPTION_VALUE, bumpRenderCount, getErrorPresentation, isRetryableAskUserQuestionError, isSingleMultiSelectForm } from '@chroxy/store-core';
 // #4875: `OtherFreeformAnswer` moved to @chroxy/store-core/freeform-answer
 // so the mobile store, the mobile screen, and (eventually) the dashboard
 // can converge on a single declaration paired with the shared
@@ -336,12 +336,13 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
       <StreamStallChip
         errorText={message.content?.trim() || ''}
         onRetry={onRetryStreamStall}
-        // #5793: the AskUserQuestion teardown codes are a question-delivery
-        // failure, not a stream stall — use copy that matches the dashboard's
-        // AskUserQuestionStallChip ("Question delivery failed — retry?").
+        // #5793 / #6392: the AskUserQuestion teardown codes are a question-
+        // delivery failure, not a stream stall — source the copy from the shared
+        // error-presentation registry (single source cross-surface). stream_stall
+        // falls through to the chip's registry-sourced default.
         headline={
           isRetryableAskUserQuestionError(message.code)
-            ? 'Question delivery failed — retry?'
+            ? getErrorPresentation(message.code).headline
             : undefined
         }
       />


### PR DESCRIPTION
**Cross-surface parity** for the error-frame work. The dashboard folded its three error chips onto store-core's `getErrorPresentation` registry (#6422/#6424); mobile already had the equivalent chips but **hand-rolled the same headline strings**. This wires mobile to the registry so the error copy is single-sourced and can't drift between surfaces.

## Changes
- **ResumeUnknownChip**: dropped the `RECOVERABLE_HEADLINE`/`EXHAUSTED_HEADLINE` constants; the variant maps to its resume code → `getErrorPresentation(code).headline`.
- **StreamStallChip**: the default `stream_stall` headline now comes from the registry (lazy destructuring default).
- **MessageBubble**: the AskUserQuestion headline now comes from the registry (`getErrorPresentation(message.code).headline`); `stream_stall` falls through to the chip's registry default.

## Deliberately unchanged
**a11y roles.** Mobile uses `accessibilityRole="alert"` for *both* recoverable + terminal variants (a documented RN convention). The registry's `status/alert` role maps to `accessibilityLiveRegion` politeness, not `accessibilityRole` — a separate a11y decision tracked as #6429.

## Verified
Behaviour-preserving — the registry returns the same strings, so the existing chip + MessageBubble jest tests (**68**, which assert the exact headlines) pass unchanged. App `tsc` + ratchet green. No visual change → no device/Maestro pass needed.

Part of the chat-redesign epic (#6389), Phase 2 (#6392).