### PR TITLE
fix(server): reject unbound pairing tokens on HTTP /permission-response (security)

### DIFF
--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -342,6 +342,29 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       ? pairingManager.getSessionIdForToken(presentedToken)
       : null
 
+    // SECURITY (swarm-audit): reject an UNBOUND PAIRING token — a pairing-ISSUED
+    // token with no bound session, e.g. one a device obtained from the auto-
+    // refreshing linking-mode QR, which is handed out PRE host-approval. Such a
+    // token resolves to callerBoundSessionId=null, which the resolver treats as
+    // unrestricted, so without this guard it could answer ANY session's permission
+    // over this HTTP fallback. This PRESERVES the #5373 "invariant G": the PRIMARY
+    // API token is NOT a pairing token (isSessionTokenValid=false) so it keeps full
+    // HTTP authority, and bound pairing tokens are binding-checked by the resolver
+    // below — only unbound *pairing* tokens are rejected. The typeof guard keeps
+    // single-token / partial-pairingManager modes working (no isSessionTokenValid →
+    // treated as the primary token, i.e. not rejected).
+    const tokenIsPairingToken = !!(
+      pairingManager &&
+      typeof pairingManager.isSessionTokenValid === 'function' &&
+      presentedToken &&
+      pairingManager.isSessionTokenValid(presentedToken)
+    )
+    if (tokenIsPairingToken && callerBoundSessionId === null) {
+      log.warn('Rejected HTTP /permission-response: an unbound pairing token cannot answer permission requests')
+      sendJson(res, 403, { error: 'unbound token cannot answer cross-session permissions' })
+      return
+    }
+
     const MAX_BODY = 4096
     // utf8 decoding + byte-accurate cap, checked BEFORE append — see
     // handlePermissionRequest above; the three capped readers stay in lockstep.

--- a/packages/server/tests/ws-permissions-unbound-token.test.js
+++ b/packages/server/tests/ws-permissions-unbound-token.test.js
@@ -103,4 +103,30 @@ describe('HTTP /permission-response rejects unbound pairing tokens (swarm-audit 
     const res = await respond('bound-token')
     assert.doesNotMatch(String(res.body ?? ''), /unbound token/)
   })
+
+  it('does NOT 403 when the pairingManager lacks isSessionTokenValid (single-token / partial mode)', async () => {
+    // The typeof guard must treat the token as the primary (not a pairing token):
+    // it neither throws nor rejects when isSessionTokenValid is absent.
+    const partial = createPermissionHandler({
+      sendFn: mock.fn(),
+      broadcastFn: mock.fn(),
+      validateBearerAuth: mock.fn(() => true),
+      pendingPermissions: new Map(),
+      permissionSessionMap: new Map(),
+      getSessionManager: () => ({ getSession: () => null }),
+      pairingManager: { getSessionIdForToken: () => null }, // NO isSessionTokenValid
+    })
+    try {
+      const req = makeReq(
+        JSON.stringify({ requestId: 'perm-1', decision: 'allow' }),
+        { authorization: 'Bearer any-token' },
+      )
+      const res = makeRes()
+      partial.handlePermissionResponseHttp(req, res)
+      await new Promise((r) => setImmediate(r))
+      assert.doesNotMatch(String(res.body ?? ''), /unbound token/)
+    } finally {
+      partial.destroy()
+    }
+  })
 })

--- a/packages/server/tests/ws-permissions-unbound-token.test.js
+++ b/packages/server/tests/ws-permissions-unbound-token.test.js
@@ -1,0 +1,106 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { createPermissionHandler } from '../src/ws-permissions.js'
+
+/**
+ * Security regression test (swarm-audit finding).
+ *
+ * The HTTP `POST /permission-response` fallback authenticates via the broad
+ * `_validateBearerAuth` (which accepts pairing-issued tokens), then looks up the
+ * token's bound session. A BOUND pairing token is binding-checked by the resolver
+ * (can only answer its own session). But an UNBOUND pairing token — e.g. one a
+ * device obtained by scanning the auto-refreshing linking-mode QR, which is issued
+ * PRE host-approval — resolved to `callerBoundSessionId=null`, which the resolver
+ * treats as unrestricted, letting it answer ANY session's permission.
+ *
+ * The fix rejects unbound pairing tokens at this endpoint with a 403. The primary
+ * API token (not a pairing token) and bound pairing tokens are unaffected.
+ */
+
+function makeReq(body, headers = {}) {
+  const emitter = new EventEmitter()
+  emitter.method = 'POST'
+  emitter.headers = headers
+  emitter.socket = { remoteAddress: '127.0.0.1' }
+  process.nextTick(() => {
+    emitter.emit('data', Buffer.from(body))
+    emitter.emit('end')
+  })
+  emitter.destroy = mock.fn()
+  emitter.setEncoding = mock.fn()
+  emitter.pause = mock.fn()
+  return emitter
+}
+
+function makeRes() {
+  const listeners = {}
+  return {
+    statusCode: null,
+    body: null,
+    writeHead(code) { this.statusCode = code },
+    end(b) { this.body = b },
+    on(event, cb) { listeners[event] = cb; return this },
+    emit(event, ...args) { if (listeners[event]) listeners[event](...args) },
+  }
+}
+
+describe('HTTP /permission-response rejects unbound pairing tokens (swarm-audit security fix)', () => {
+  let handler
+  let pairingTokens // token -> boundSessionId | null
+
+  beforeEach(() => {
+    pairingTokens = new Map()
+    const pairingManager = {
+      // True for any token this PairingManager issued (bound OR unbound); false
+      // for the primary API token — exactly how the real isSessionTokenValid behaves.
+      isSessionTokenValid: (t) => pairingTokens.has(t),
+      getSessionIdForToken: (t) => (pairingTokens.has(t) ? pairingTokens.get(t) : null),
+    }
+    handler = createPermissionHandler({
+      sendFn: mock.fn(),
+      broadcastFn: mock.fn(),
+      validateBearerAuth: mock.fn(() => true),
+      pendingPermissions: new Map(),
+      permissionSessionMap: new Map(),
+      getSessionManager: () => ({ getSession: () => null }),
+      pairingManager,
+    })
+  })
+
+  afterEach(() => {
+    handler?.destroy()
+  })
+
+  async function respond(token) {
+    const req = makeReq(
+      JSON.stringify({ requestId: 'perm-1', decision: 'allow' }),
+      { authorization: `Bearer ${token}` },
+    )
+    const res = makeRes()
+    handler.handlePermissionResponseHttp(req, res)
+    await new Promise((r) => setImmediate(r))
+    return res
+  }
+
+  it('rejects an UNBOUND pairing token with 403 (closes the linking-mode-QR cross-session gap)', async () => {
+    pairingTokens.set('unbound-linking-token', null) // valid pairing token, no bound session
+    const res = await respond('unbound-linking-token')
+    assert.equal(res.statusCode, 403)
+    assert.match(String(res.body), /unbound token/)
+  })
+
+  it('does NOT reject the primary API token (it is not a pairing token)', async () => {
+    // Not in pairingTokens → isSessionTokenValid=false → not a pairing token → the
+    // unbound guard is skipped; it proceeds (and 404s on the unknown requestId).
+    const res = await respond('primary-api-token')
+    assert.doesNotMatch(String(res.body ?? ''), /unbound token/)
+  })
+
+  it('does NOT reject a BOUND pairing token at the unbound guard (resolver binding-checks it)', async () => {
+    pairingTokens.set('bound-token', 'sess-X')
+    const res = await respond('bound-token')
+    assert.doesNotMatch(String(res.body ?? ''), /unbound token/)
+  })
+})


### PR DESCRIPTION
Swarm-audit **security** finding — deep-verified through a dedicated investigation that almost ruled it a false positive (unbound tokens are host-authority *by design* from the host-approval flow) before confirming the gap.

## The gap
The HTTP `POST /permission-response` fallback authenticates via the broad `_validateBearerAuth` (accepts pairing-issued tokens). A **bound** pairing token is binding-checked by the resolver. But an **unbound** pairing token — one a device obtains by scanning the auto-refreshing **linking-mode QR**, which is handed out **PRE host-approval** — resolves to `callerBoundSessionId=null`, which the resolver treats as unrestricted. So a device that merely scanned the public linking QR could answer *any* session's permission prompt over HTTP, with no binding.

## The fix
Reject unbound **pairing** tokens at this endpoint with a 403. Crucially, this **preserves the documented #5373 "invariant G"** (verified — its parity suite stays green): the **primary API token** is NOT a pairing token (`isSessionTokenValid=false`), so it keeps full HTTP authority; **bound** pairing tokens stay binding-checked by the resolver. Only unbound *pairing* tokens are newly rejected. A `typeof` guard keeps single-token / partial-`pairingManager` modes working (no `isSessionTokenValid` → treat as the primary token).

## Verified
+3 targeted tests (unbound→403; primary not rejected; bound not rejected by the guard). The existing **ws-permissions + binding-integration + #5373 cross-transport parity** suites (72 tests) stay green — so the primary-token and bound-token behaviour is provably unchanged. Custom server lints green.

From the swarm audit (the one confirmed *security* finding).