### PR TITLE
fix(server): atomic exclusive-create for the ingest secret (no concurrent-write race)

### DIFF
--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -163,6 +163,18 @@ export function defaultIngestSecretPath() {
   return join(configDir, 'ingest-secret')
 }
 
+// Synchronous millisecond sleep (Atomics.wait on a throwaway SharedArrayBuffer) —
+// used only in the rare ingest-secret create race, to yield the CPU so a concurrent
+// winner's writeSync can land before we re-read its (briefly 0-byte) file.
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+  } catch {
+    // SharedArrayBuffer/Atomics unavailable — skip the backoff; the retry loop's
+    // own syscall overhead still spaces the reads.
+  }
+}
+
 /**
  * Read the ingest secret from disk, generating + persisting it (0600,
  * temp+rename via writeFileRestricted) when missing. Throws on I/O failure
@@ -186,10 +198,19 @@ export function loadOrCreateIngestSecret(secretPath = defaultIngestSecretPath())
     fd = openSync(secretPath, 'ax', 0o600)
   } catch (err) {
     if (err && err.code === 'EEXIST') {
-      const existing = readFileSync(secretPath, 'utf-8').trim()
-      if (existing.length > 0) return existing
-      // Exists but EMPTY — a corrupt / crashed-mid-write file, NOT the concurrent
-      // race. Fall back to the legacy temp+rename overwrite to recover.
+      // The file already exists — re-read the winner's secret. An EMPTY read means
+      // EITHER a corrupt / crashed-mid-write file OR a concurrent winner that just
+      // created the 0-byte file via its own 'ax' but hasn't flushed its writeSync
+      // yet. Retry briefly (yielding the CPU so the winner can be scheduled) so its
+      // write lands and BOTH processes converge on the winner's secret — overwriting
+      // here would clobber the winner's inode and re-open the very split-secret race.
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const existing = readFileSync(secretPath, 'utf-8').trim()
+        if (existing.length > 0) return existing
+        if (attempt < 9) sleepSync(5)
+      }
+      // Still empty after the retry window — genuinely corrupt (not a live winner);
+      // recover via the legacy temp+rename overwrite.
       writeFileRestricted(secretPath, secret + '\n')
       return secret
     }

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -26,7 +26,7 @@
  */
 
 import { randomBytes } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, openSync, writeSync, closeSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import { safeTokenCompare } from './token-compare.js'
@@ -176,7 +176,30 @@ export function loadOrCreateIngestSecret(secretPath = defaultIngestSecretPath())
   }
   const secret = randomBytes(32).toString('base64url')
   mkdirSync(dirname(secretPath), { recursive: true })
-  writeFileRestricted(secretPath, secret + '\n')
+  // Atomic exclusive-create ('ax' fails with EEXIST if the file already exists) so
+  // two concurrent first-starts can't each write a DIFFERENT secret: the old
+  // existsSync+write check-then-act let the LAST writer win, silently invalidating
+  // the first process's secret (and the emitters that already authenticated with
+  // it). With 'ax' the FIRST writer wins; a loser re-reads the winner's secret.
+  let fd
+  try {
+    fd = openSync(secretPath, 'ax', 0o600)
+  } catch (err) {
+    if (err && err.code === 'EEXIST') {
+      const existing = readFileSync(secretPath, 'utf-8').trim()
+      if (existing.length > 0) return existing
+      // Exists but EMPTY — a corrupt / crashed-mid-write file, NOT the concurrent
+      // race. Fall back to the legacy temp+rename overwrite to recover.
+      writeFileRestricted(secretPath, secret + '\n')
+      return secret
+    }
+    throw err
+  }
+  try {
+    writeSync(fd, secret + '\n')
+  } finally {
+    closeSync(fd)
+  }
   return secret
 }
 

--- a/packages/server/tests/ingest-secret-atomic.test.js
+++ b/packages/server/tests/ingest-secret-atomic.test.js
@@ -1,0 +1,55 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { loadOrCreateIngestSecret } from '../src/event-ingest.js'
+
+/**
+ * Swarm-audit hardening: loadOrCreateIngestSecret used a non-atomic
+ * existsSync+write check-then-act, so two concurrent first-starts could each
+ * generate a DIFFERENT secret (the last writer won, silently invalidating the
+ * first). The fix uses an atomic exclusive-create ('ax') so the first writer
+ * wins and losers re-read it, while still recovering an empty/corrupt file.
+ */
+describe('loadOrCreateIngestSecret — atomic create (swarm-audit race fix)', () => {
+  let dir
+  let secretPath
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-ingest-'))
+    secretPath = join(dir, 'ingest-secret')
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates + persists a secret when missing, owner-only (0600)', () => {
+    const s = loadOrCreateIngestSecret(secretPath)
+    assert.equal(typeof s, 'string')
+    assert.ok(s.length > 0)
+    assert.equal(readFileSync(secretPath, 'utf-8').trim(), s)
+    if (process.platform !== 'win32') {
+      // no group/other access
+      assert.equal(statSync(secretPath).mode & 0o077, 0)
+    }
+  })
+
+  it('is idempotent — a second call returns the same persisted secret', () => {
+    const a = loadOrCreateIngestSecret(secretPath)
+    const b = loadOrCreateIngestSecret(secretPath)
+    assert.equal(a, b)
+  })
+
+  it('returns a pre-existing secret verbatim (the loser re-read path)', () => {
+    writeFileSync(secretPath, 'preexisting-secret\n', { mode: 0o600 })
+    assert.equal(loadOrCreateIngestSecret(secretPath), 'preexisting-secret')
+  })
+
+  it('regenerates over an empty/corrupt file (recovery, not the concurrent race)', () => {
+    writeFileSync(secretPath, '', { mode: 0o600 })
+    const s = loadOrCreateIngestSecret(secretPath)
+    assert.ok(s.length > 0)
+    assert.equal(readFileSync(secretPath, 'utf-8').trim(), s)
+  })
+})


### PR DESCRIPTION
Swarm-audit hardening. `loadOrCreateIngestSecret` used a non-atomic `existsSync`+write **check-then-act**: two concurrent first-starts could both see the file missing, each generate a **different** secret, and the last writer would win — silently invalidating the first process's secret (and the hook emitters that already authenticated with it).

## Fix
Atomic **exclusive-create** (`openSync(path, 'ax', 0o600)` — fails with `EEXIST` if the file already exists), so the **first** writer wins and a loser re-reads the winner's secret. An empty/corrupt file (a crash mid-write — not the concurrent race) still recovers via the legacy temp+rename overwrite.

## Verified
+4 tests (creates 0600 when missing; idempotent; returns a pre-existing secret verbatim; regenerates over an empty file). Existing event-ingest suites stay green; server lint clean.

From the swarm audit.