### PR TITLE
fix(protocol): bound the client auth/pair collections against adversarial input (DoS)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -32,7 +32,7 @@ export declare const AuthSchema: z.ZodObject<{
     capabilities: z.ZodDefault<z.ZodCatch<z.ZodOptional<z.ZodArray<z.ZodString>>>>;
     eagerPublicKey: z.ZodOptional<z.ZodString>;
     eagerSalt: z.ZodOptional<z.ZodString>;
-    historyCursors: z.ZodCatch<z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>>;
+    historyCursors: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>;
 }, z.core.$loose>;
 export declare const PairSchema: z.ZodObject<{
     type: z.ZodLiteral<"pair">;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -32,7 +32,7 @@ export declare const AuthSchema: z.ZodObject<{
     capabilities: z.ZodDefault<z.ZodCatch<z.ZodOptional<z.ZodArray<z.ZodString>>>>;
     eagerPublicKey: z.ZodOptional<z.ZodString>;
     eagerSalt: z.ZodOptional<z.ZodString>;
-    historyCursors: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>;
+    historyCursors: z.ZodCatch<z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>>;
 }, z.core.$loose>;
 export declare const PairSchema: z.ZodObject<{
     type: z.ZodLiteral<"pair">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -66,12 +66,14 @@ export const AuthSchema = z.object({
     // ignores the field). The server falls back to a full replay (flagged with
     // `fullHistory: true` on `history_replay_start`) whenever it cannot honour a
     // cursor — history trimmed past it, unknown session, or a server restart
-    // reset the seqs. `seq` is a non-negative finite int; the server caps the
-    // number of honoured keys defensively so a fat map can't bloat the auth path.
-    // .catch(undefined): an oversized/malformed cursor map degrades to a full
-    // history replay (the documented fallback) rather than REJECTING the auth — so
-    // the cap can never lock a legitimate client out, only drop an abusive map.
-    historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).refine((m) => Object.keys(m).length <= 256, { message: 'too many history cursors (max 256)' }).optional().catch(undefined),
+    // reset the seqs. `seq` is a non-negative finite int; an INVALID value
+    // rejects the auth (#5555.3 — this contract predates the size cap and must
+    // hold). The `.refine` also rejects an absurdly large map (>256 keys): a
+    // legit client sends at most MAX_CLIENT_HISTORY_CURSORS (64), and the server
+    // independently caps the honoured keys, so a fat map can't bloat the replay
+    // path. No `.catch` here — unlike `capabilities` (graceful by design), this
+    // field rejects malformed input rather than silently degrading it.
+    historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).refine((m) => Object.keys(m).length <= 256, { message: 'too many history cursors (max 256)' }).optional(),
 }).passthrough();
 export const PairSchema = z.object({
     type: z.literal('pair'),

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -40,7 +40,11 @@ export const AuthSchema = z.object({
     token: z.string().max(512),
     protocolVersion: z.number().int().min(0).optional(),
     deviceInfo: DeviceInfoSchema.optional(),
-    capabilities: z.array(z.string()).optional().catch([]).default([]),
+    // Bounded to stop an adversarial auth/pair from sending a giant capabilities
+    // array (the server does `new Set(authData.capabilities)` with no count guard,
+    // so a huge array is a CPU/memory DoS at Set construction). Feature-flag list —
+    // 64 entries × 256 chars is far above any real client.
+    capabilities: z.array(z.string().max(256)).max(64).optional().catch([]).default([]),
     // #5555 (eager key exchange) — optional ephemeral X25519 public key + salt
     // sent WITH the auth message so the server can derive the shared key and
     // return its public key in auth_ok, collapsing the discrete `key_exchange`
@@ -64,14 +68,21 @@ export const AuthSchema = z.object({
     // cursor — history trimmed past it, unknown session, or a server restart
     // reset the seqs. `seq` is a non-negative finite int; the server caps the
     // number of honoured keys defensively so a fat map can't bloat the auth path.
-    historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).optional(),
+    // .catch(undefined): an oversized/malformed cursor map degrades to a full
+    // history replay (the documented fallback) rather than REJECTING the auth — so
+    // the cap can never lock a legitimate client out, only drop an abusive map.
+    historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).refine((m) => Object.keys(m).length <= 256, { message: 'too many history cursors (max 256)' }).optional().catch(undefined),
 }).passthrough();
 export const PairSchema = z.object({
     type: z.literal('pair'),
     pairingId: z.string().min(1).max(256),
     protocolVersion: z.number().int().min(0).optional(),
     deviceInfo: DeviceInfoSchema.optional(),
-    capabilities: z.array(z.string()).optional().catch([]).default([]),
+    // Bounded to stop an adversarial auth/pair from sending a giant capabilities
+    // array (the server does `new Set(authData.capabilities)` with no count guard,
+    // so a huge array is a CPU/memory DoS at Set construction). Feature-flag list —
+    // 64 entries × 256 chars is far above any real client.
+    capabilities: z.array(z.string().max(256)).max(64).optional().catch([]).default([]),
 }).passthrough();
 // -- Pairing-approval primitive (#5510, epic #5509) --
 //

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -46,7 +46,11 @@ export const AuthSchema = z.object({
   token: z.string().max(512),
   protocolVersion: z.number().int().min(0).optional(),
   deviceInfo: DeviceInfoSchema.optional(),
-  capabilities: z.array(z.string()).optional().catch([]).default([]),
+  // Bounded to stop an adversarial auth/pair from sending a giant capabilities
+  // array (the server does `new Set(authData.capabilities)` with no count guard,
+  // so a huge array is a CPU/memory DoS at Set construction). Feature-flag list —
+  // 64 entries × 256 chars is far above any real client.
+  capabilities: z.array(z.string().max(256)).max(64).optional().catch([]).default([]),
   // #5555 (eager key exchange) — optional ephemeral X25519 public key + salt
   // sent WITH the auth message so the server can derive the shared key and
   // return its public key in auth_ok, collapsing the discrete `key_exchange`
@@ -70,7 +74,10 @@ export const AuthSchema = z.object({
   // cursor — history trimmed past it, unknown session, or a server restart
   // reset the seqs. `seq` is a non-negative finite int; the server caps the
   // number of honoured keys defensively so a fat map can't bloat the auth path.
-  historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).optional(),
+  // .catch(undefined): an oversized/malformed cursor map degrades to a full
+  // history replay (the documented fallback) rather than REJECTING the auth — so
+  // the cap can never lock a legitimate client out, only drop an abusive map.
+  historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).refine((m) => Object.keys(m).length <= 256, { message: 'too many history cursors (max 256)' }).optional().catch(undefined),
 }).passthrough()
 
 export const PairSchema = z.object({
@@ -78,7 +85,11 @@ export const PairSchema = z.object({
   pairingId: z.string().min(1).max(256),
   protocolVersion: z.number().int().min(0).optional(),
   deviceInfo: DeviceInfoSchema.optional(),
-  capabilities: z.array(z.string()).optional().catch([]).default([]),
+  // Bounded to stop an adversarial auth/pair from sending a giant capabilities
+  // array (the server does `new Set(authData.capabilities)` with no count guard,
+  // so a huge array is a CPU/memory DoS at Set construction). Feature-flag list —
+  // 64 entries × 256 chars is far above any real client.
+  capabilities: z.array(z.string().max(256)).max(64).optional().catch([]).default([]),
 }).passthrough()
 
 // -- Pairing-approval primitive (#5510, epic #5509) --

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -72,12 +72,14 @@ export const AuthSchema = z.object({
   // ignores the field). The server falls back to a full replay (flagged with
   // `fullHistory: true` on `history_replay_start`) whenever it cannot honour a
   // cursor — history trimmed past it, unknown session, or a server restart
-  // reset the seqs. `seq` is a non-negative finite int; the server caps the
-  // number of honoured keys defensively so a fat map can't bloat the auth path.
-  // .catch(undefined): an oversized/malformed cursor map degrades to a full
-  // history replay (the documented fallback) rather than REJECTING the auth — so
-  // the cap can never lock a legitimate client out, only drop an abusive map.
-  historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).refine((m) => Object.keys(m).length <= 256, { message: 'too many history cursors (max 256)' }).optional().catch(undefined),
+  // reset the seqs. `seq` is a non-negative finite int; an INVALID value
+  // rejects the auth (#5555.3 — this contract predates the size cap and must
+  // hold). The `.refine` also rejects an absurdly large map (>256 keys): a
+  // legit client sends at most MAX_CLIENT_HISTORY_CURSORS (64), and the server
+  // independently caps the honoured keys, so a fat map can't bloat the replay
+  // path. No `.catch` here — unlike `capabilities` (graceful by design), this
+  // field rejects malformed input rather than silently degrading it.
+  historyCursors: z.record(z.string().max(256), z.number().int().nonnegative()).refine((m) => Object.keys(m).length <= 256, { message: 'too many history cursors (max 256)' }).optional(),
 }).passthrough()
 
 export const PairSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -58,6 +58,20 @@ describe('@chroxy/protocol schemas', () => {
     assert.deepEqual(ok.data.historyCursors, { s1: 5, s2: 10 }, 'a normal small cursor map passes through')
   })
 
+  // Pin the exact cap boundaries (review #6436) — these lines regress if someone
+  // tweaks the cap without updating the test.
+  it('bounds are exact: 64/256 at-cap pass, 65/257 one-over coerce', async () => {
+    const { AuthSchema } = await import('../src/schemas/client.ts')
+    const parse = (extra) => AuthSchema.safeParse({ type: 'auth', token: 't', ...extra }).data
+    assert.equal(parse({ capabilities: Array(64).fill('c') }).capabilities.length, 64, '64 capabilities pass')
+    assert.deepEqual(parse({ capabilities: Array(65).fill('c') }).capabilities, [], '65 coerce to []')
+    assert.equal(parse({ capabilities: ['x'.repeat(256)] }).capabilities.length, 1, '256-char capability passes')
+    assert.deepEqual(parse({ capabilities: ['x'.repeat(257)] }).capabilities, [], '257-char capability coerces to []')
+    const mk = (n) => Object.fromEntries(Array.from({ length: n }, (_, i) => [`s${i}`, i]))
+    assert.equal(Object.keys(parse({ historyCursors: mk(256) }).historyCursors).length, 256, '256 cursors pass')
+    assert.equal(parse({ historyCursors: mk(257) }).historyCursors, undefined, '257 cursors coerce to undefined')
+  })
+
   // #5270 (Control Room Phase 2a): cancel_activity client→server message.
   it('validates cancel_activity with an activityId (sessionId optional)', async () => {
     const { CancelActivitySchema } = await import('../src/schemas/client.ts')

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -48,19 +48,25 @@ describe('@chroxy/protocol schemas', () => {
     assert.deepEqual(ok.data.capabilities, ['voice', 'terminal'], 'a normal small list passes through')
   })
 
-  it('degrades an oversized historyCursors map to undefined (full replay, no reject)', async () => {
+  it('rejects an oversized historyCursors map (>256) and an invalid cursor value (#5555.3)', async () => {
     const { AuthSchema } = await import('../src/schemas/client.ts')
+    // Unlike capabilities (graceful .catch([])), historyCursors has NO .catch:
+    // its established contract is to REJECT malformed input (#5555.3), and the
+    // size cap rejects an abusive map rather than silently degrading it.
     const huge = Object.fromEntries(Array.from({ length: 5000 }, (_, i) => [`s${i}`, i]))
-    const res = AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: huge })
-    assert.ok(res.success, 'oversized historyCursors must not reject the auth')
-    assert.equal(res.data.historyCursors, undefined, 'oversized cursor map degrades to undefined (full replay)')
+    assert.equal(AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: huge }).success, false,
+      'an oversized cursor map (>256) rejects the auth')
+    for (const bad of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 'x']) {
+      assert.equal(AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: { s1: bad } }).success, false,
+        `an invalid cursor value (${String(bad)}) rejects the auth (#5555.3 preserved)`)
+    }
     const ok = AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: { s1: 5, s2: 10 } })
     assert.deepEqual(ok.data.historyCursors, { s1: 5, s2: 10 }, 'a normal small cursor map passes through')
   })
 
   // Pin the exact cap boundaries (review #6436) — these lines regress if someone
   // tweaks the cap without updating the test.
-  it('bounds are exact: 64/256 at-cap pass, 65/257 one-over coerce', async () => {
+  it('bounds are exact: at-cap pass; capabilities coerce, historyCursors reject one-over', async () => {
     const { AuthSchema } = await import('../src/schemas/client.ts')
     const parse = (extra) => AuthSchema.safeParse({ type: 'auth', token: 't', ...extra }).data
     assert.equal(parse({ capabilities: Array(64).fill('c') }).capabilities.length, 64, '64 capabilities pass')
@@ -68,8 +74,9 @@ describe('@chroxy/protocol schemas', () => {
     assert.equal(parse({ capabilities: ['x'.repeat(256)] }).capabilities.length, 1, '256-char capability passes')
     assert.deepEqual(parse({ capabilities: ['x'.repeat(257)] }).capabilities, [], '257-char capability coerces to []')
     const mk = (n) => Object.fromEntries(Array.from({ length: n }, (_, i) => [`s${i}`, i]))
-    assert.equal(Object.keys(parse({ historyCursors: mk(256) }).historyCursors).length, 256, '256 cursors pass')
-    assert.equal(parse({ historyCursors: mk(257) }).historyCursors, undefined, '257 cursors coerce to undefined')
+    // capabilities coerces (graceful .catch); historyCursors rejects (strict) — different by design.
+    assert.equal(AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: mk(256) }).success, true, '256 cursors pass')
+    assert.equal(AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: mk(257) }).success, false, '257 cursors reject')
   })
 
   // #5270 (Control Room Phase 2a): cancel_activity client→server message.

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -35,6 +35,29 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!result.success, 'Should reject data over 100k chars')
   })
 
+  // Swarm-audit (W2): bound the client auth collections so an adversarial auth
+  // can't DoS the server (capabilities is `new Set()`-iterated server-side).
+  it('degrades an oversized / over-long capabilities array to [] (no DoS, no reject)', async () => {
+    const { AuthSchema } = await import('../src/schemas/client.ts')
+    const big = AuthSchema.safeParse({ type: 'auth', token: 't', capabilities: Array(5000).fill('x') })
+    assert.ok(big.success, 'oversized capabilities must not reject the auth')
+    assert.deepEqual(big.data.capabilities, [], 'oversized array degrades to [] via .catch')
+    const longStr = AuthSchema.safeParse({ type: 'auth', token: 't', capabilities: ['x'.repeat(5000)] })
+    assert.deepEqual(longStr.data.capabilities, [], 'over-long capability string degrades to []')
+    const ok = AuthSchema.safeParse({ type: 'auth', token: 't', capabilities: ['voice', 'terminal'] })
+    assert.deepEqual(ok.data.capabilities, ['voice', 'terminal'], 'a normal small list passes through')
+  })
+
+  it('degrades an oversized historyCursors map to undefined (full replay, no reject)', async () => {
+    const { AuthSchema } = await import('../src/schemas/client.ts')
+    const huge = Object.fromEntries(Array.from({ length: 5000 }, (_, i) => [`s${i}`, i]))
+    const res = AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: huge })
+    assert.ok(res.success, 'oversized historyCursors must not reject the auth')
+    assert.equal(res.data.historyCursors, undefined, 'oversized cursor map degrades to undefined (full replay)')
+    const ok = AuthSchema.safeParse({ type: 'auth', token: 't', historyCursors: { s1: 5, s2: 10 } })
+    assert.deepEqual(ok.data.historyCursors, { s1: 5, s2: 10 }, 'a normal small cursor map passes through')
+  })
+
   // #5270 (Control Room Phase 2a): cancel_activity client→server message.
   it('validates cancel_activity with an activityId (sessionId optional)', async () => {
     const { CancelActivitySchema } = await import('../src/schemas/client.ts')


### PR DESCRIPTION
Swarm-audit W2. `AuthSchema`/`PairSchema` accepted an **unbounded `capabilities` array** (the server does `new Set(authData.capabilities)` with no count guard — a giant array is a CPU/memory DoS) and `AuthSchema` accepted an **unbounded `historyCursors` map**.

## Fix
- `capabilities` → `.max(64)` entries × `.max(256)` chars. Stays **graceful** (its pre-existing `.catch([])`): an over-limit value coerces to `[]`, never rejecting the auth.
- `historyCursors` → `.refine(≤256)` keys. **Strict** (no `.catch`): an oversized map OR an invalid cursor value rejects the auth — preserving the #5555.3 reject-on-invalid-value contract. A legitimate client sends at most `MAX_CLIENT_HISTORY_CURSORS` (64), far below 256, so the cap never locks out a real client.

The two fields differ by design: `capabilities` was already graceful; `historyCursors` had a strict reject contract (#5555.3). (An earlier revision used `.catch(undefined)` on historyCursors; CI's ws-auth `#5555.3` test caught that it swallowed the invalid-value rejection too, so it was dropped — see the correctness-fix comment.)

## Not changed
Attachment count is already capped server-side (`MAX_ATTACHMENT_COUNT=5`), so no schema change there.

## Verified
Protocol (347) + store-core (1899) + ws-auth (104) green; dist rebuilt + committed. Tests assert capabilities coerce, historyCursors reject (oversized + invalid value, #5555.3 locked).