### PR TITLE
fix(server): guard ws.close() in the key-exchange timeout handler (swarm-audit)

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -500,7 +500,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
         try {
           ws.send(JSON.stringify({ type: 'server_error', message: 'Encryption required but key exchange timed out. Please reconnect.', recoverable: false }))
         } catch (_) {}
-        ws.close(1008, 'Key exchange timeout')
+        // Guard close() too: if the socket is already CLOSING/CLOSED when this
+        // timer fires (a race with a concurrent client disconnect), a bare
+        // ws.close() can throw — and the uncaught error would escape this setTimeout
+        // callback. Mirrors the guarded close() at the other timeout/error sites.
+        try {
+          ws.close(1008, 'Key exchange timeout')
+        } catch (_) {}
       }
     }, keyExchangeTimeoutMs)
   }

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -800,6 +800,25 @@ describe('sendPostAuthInfo — encryption', () => {
     if (client._keyExchangeTimeout) clearTimeout(client._keyExchangeTimeout)
   })
 
+  // Swarm-audit (W2): the key-exchange timeout handler must survive a throwing
+  // ws.close() (socket already CLOSING from a concurrent disconnect) — otherwise
+  // the uncaught error escapes the setTimeout callback.
+  it('does not crash when ws.close() throws as the key-exchange timeout fires', async () => {
+    const ws = makeFakeWs()
+    ws.close = () => { throw new Error('socket already closing') }
+    const ctx = makeCtx({ encryptionEnabled: true, keyExchangeTimeoutMs: 1 })
+    const client = registerClient(ctx, ws, { socketIp: '203.0.113.1' })
+
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(client.encryptionPending, true)
+
+    // Let the (1ms) timeout fire. If the close() throw escaped the timer callback
+    // the process would crash before the assertion below; the guard swallows it.
+    await new Promise((r) => setTimeout(r, 25))
+    assert.equal(client.encryptionPending, false, 'timeout handler completed despite the throwing close()')
+    if (client._keyExchangeTimeout) clearTimeout(client._keyExchangeTimeout)
+  })
+
   it('bypasses encryption requirement for 127.0.0.1 when localhostBypass enabled', () => {
     const ws = makeFakeWs()
     const ctx = makeCtx({ encryptionEnabled: true, localhostBypass: true })


### PR DESCRIPTION
W2 hardening (WS resilience). The key-exchange-timeout handler in `ws-history.js` guards its `ws.send()` in try-catch but the following `ws.close(1008, …)` is **bare**. If the socket is already CLOSING/CLOSED when the timer fires (a race with a concurrent client disconnect), `ws.close()` can throw — and the uncaught error escapes the `setTimeout` callback (no surrounding handler).

## Fix
Wrap `ws.close()` in try-catch, mirroring the guarded `close()` at the other timeout/error sites in the same file. Zero behaviour change on the happy path.

## Verified
+1 test (a throwing `close()` as the timeout fires → the handler completes, `encryptionPending=false`, no crash). Full ws-history suite green.

From the W2 deeper hardening audit.