### PR TITLE
fix(server): use randomBytes (not Math.random) for the credential-store temp file

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -44,6 +44,7 @@
 import { readFileSync, statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
+import { randomBytes } from 'crypto'
 import { maskApiKey } from './byok-credentials.js'
 import * as realKeychain from './keychain.js'
 import { createLogger } from './logger.js'
@@ -374,7 +375,10 @@ function writeStoreAtomically(target, nextObj) {
   const key = getOrCreateMasterKey(activeKeychain())
   const payload = key ? encryptJson(nextObj, key) : nextObj
 
-  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`
+  // randomBytes (not Math.random) for the atomic-write temp suffix — a predictable
+  // temp name is a (minor) symlink/pre-creation foothold; cryptographic randomness
+  // costs nothing here and matches the pattern in path-hash-trust-ledger.js.
+  const tmp = `${target}.tmp.${process.pid}.${randomBytes(4).toString('hex')}`
   let renamed = false
   try {
     writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 })


### PR DESCRIPTION
W2 hardening (crypto hygiene). `writeStoreAtomically` (credential-store.js) named its atomic-write temp file with `Math.random()` — a **predictable** temp name is a minor symlink / pre-creation race foothold.

## Fix
Swap to `randomBytes(4).toString('hex')`, matching the pattern already used in `path-hash-trust-ledger.js`.

## Why minor (defence-in-depth, not critical)
The temp file is created `0o600` (owner-only, verified post-rename), and credentials are encrypted at rest by default — so a predicted name doesn't grant a local non-root attacker anything. This is hygiene, not a live vulnerability.

## Verified
Behaviour-neutral (the suffix's only job is per-PID collision avoidance). Credential suites green; no test change needed.

From the W2 deeper hardening audit.