### PR TITLE
fix(ci): ratchet hex-lint no longer false-positives on #NNNN issue refs

### DIFF
--- a/scripts/lint-no-raw-color-literals.sh
+++ b/scripts/lint-no-raw-color-literals.sh
@@ -31,6 +31,15 @@ BASELINE="scripts/no-raw-color-literals-baseline.txt"
 # 3/4/6/8-digit hex color literals (#fff, #ffff, #4a9eff, #4a9eff22).
 PAT='#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})'
 
+# The recheck pass below strips comments with perl. Fail LOUD if perl is missing
+# rather than letting `set -e` + the `|| true` swallow turn a perl-less runner
+# into a silently-disabled guard (every candidate would be dropped → all files
+# pass). perl is present on both CI runner pools; this just keeps it honest.
+command -v perl >/dev/null 2>&1 || {
+  echo "::error::lint-no-raw-color-literals.sh requires perl (used to strip comments before the hex re-check)"
+  exit 1
+}
+
 # Styling files (components + screens) that contain at least one hex literal,
 # excluding tests, generated bundles, and the xterm color assets. The color
 # *sources* (dashboard src/theme, mobile src/constants/colors.ts) are out of

--- a/scripts/lint-no-raw-color-literals.sh
+++ b/scripts/lint-no-raw-color-literals.sh
@@ -36,12 +36,26 @@ PAT='#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})'
 # *sources* (dashboard src/theme, mobile src/constants/colors.ts) are out of
 # scope by construction — they live outside components/screens.
 collect() {
+  # First pass: candidate files matching the raw pattern (a superset — includes
+  # files whose only "match" is a #NNNN issue reference in a comment). Second
+  # pass: re-check each candidate with COMMENTS STRIPPED, and keep only those
+  # that still contain a hex literal. Real color literals live in code / CSS
+  # values; #NNNN issue refs (3-4 hex digits → they trip the {3,4} branch) live
+  # exclusively in // and /* */ comments — so stripping comments removes the
+  # false positives without weakening the guard on actual colors (#6423).
   grep -rlE "$PAT" \
     packages/dashboard/src/components \
     packages/app/src/components \
     packages/app/src/screens \
     --include='*.ts' --include='*.tsx' --include='*.css' 2>/dev/null \
     | grep -vE '\.test\.|/__tests__/|\.generated\.|xterm|\.stories\.' \
+    | while IFS= read -r f; do
+        # Strip // line comments and /* */ block comments (the latter across
+        # newlines, via the /s flag), then test for a remaining hex literal.
+        if perl -0777 -pe 's{//[^\n]*}{}g; s{/\*.*?\*/}{}gs' "$f" 2>/dev/null | grep -Eq "$PAT"; then
+          printf '%s\n' "$f"
+        fi
+      done \
     | LC_ALL=C sort
 }
 


### PR DESCRIPTION
Closes #6423.

## Problem
`scripts/lint-no-raw-color-literals.sh` grep-matched **raw** file contents with `#([0-9a-fA-F]{8}|{6}|{3,4})`. A 4-digit issue reference like `#6392` is four hex digits → it trips the `{3,4}` branch, so a brand-new component file gets flagged as containing a 'raw color literal' even with **zero** real colors. Since the ratchet only bites *new* files, and new files carry `#NNNN` refs in comments by convention, this hit constantly (I worked around it once by dropping a `#` — a smell).

## Fix
Keep the fast `grep -rlE` first pass (a superset of candidates), then **re-check each candidate with comments stripped** (`//` line + `/* */` block, the latter across newlines) and keep only files that *still* contain a hex literal. Real color literals live in code / CSS values; `#NNNN` issue refs live exclusively in comments — so this removes the false positives **without weakening** the guard on actual colors.

Chose comment-stripping over the issue's alternative ("exclude all-decimal `#NNNN`") because that would punch a hole for common all-decimal colors like `#222` / `#000` / `#999`.

## Verified
- New file with only `#NNNN` refs in a comment → **passes** (was flagged before).
- New file with a real `'#222222'` in code → **still fails** (guard intact).
- The 125-file grandfathered baseline → still green.

From the W1 review backlog (#6423).