### PR TITLE
test(server): drift-guard the claude-tui --no-chrome spawn arg against the real method

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1653,11 +1653,19 @@ export class ClaudeTuiSession extends BaseSession {
    */
   async _spawnPty(permissionsEnabled) {
     let ptyMod
-    try {
-      ptyMod = await import('node-pty')
-    } catch (err) {
-      this.emit('error', { message: `node-pty unavailable: ${err.message}` })
-      return
+    // Test seam (#6417): a test may inject a capturing node-pty stand-in so the
+    // REAL arg-builder below runs against it — catching drift on the actual spawn
+    // argv (e.g. a dropped --no-chrome), which a wholesale _spawnPty mock cannot.
+    // Undefined in production → the genuine dynamic import runs unchanged.
+    if (this._ptyModOverride) {
+      ptyMod = this._ptyModOverride
+    } else {
+      try {
+        ptyMod = await import('node-pty')
+      } catch (err) {
+        this.emit('error', { message: `node-pty unavailable: ${err.message}` })
+        return
+      }
     }
 
     const cwdReal = realpathSync(this.cwd)

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -137,8 +137,9 @@ describe('ClaudeTuiSession', () => {
       ClaudeTuiSession.prototype._spawnPty = origSpawnPty // run the genuine method
       let realArgs = null
       let realCmd = null
+      let errored = false
       session = new ClaudeTuiSession({ cwd: '/tmp', port: 12346, skillsDir: emptySkillsDir, repoSkillsDir: null })
-      session.on('error', () => {}) // _spawnPty emits 'error' when our spawn throws; swallow it
+      session.on('error', () => { errored = true }) // _spawnPty emits 'error' when our spawn throws
       session._sessionId = 'drift-guard-uuid'
       session._settingsPath = join(fakeHome, 'settings.json')
       session._ptyModOverride = {
@@ -150,6 +151,10 @@ describe('ClaudeTuiSession', () => {
       assert.equal(realArgs.includes('--no-chrome'), true,
         'the REAL _spawnPty argv carries --no-chrome — drift on the real method is now caught')
       assert.equal(realArgs.includes('--settings'), true, 'the real argv also carries --settings')
+      // Clean-bail contract: the thrown spawn surfaces as an 'error' event and
+      // leaves no live PTY behind (the catch returns before _term is assigned).
+      assert.ok(errored, 'the spawn throw surfaces as an error event')
+      assert.ok(!session._term, 'clean bail: no live PTY left behind after the throw')
     })
 
     it('restored session: seeds _sessionId from resumeSessionId, keeps it through start, spawns with --resume', async () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -127,6 +127,31 @@ describe('ClaudeTuiSession', () => {
       assert.equal(capturedArgs.includes('--no-chrome'), true, 'TUI spawn passes --no-chrome')
     })
 
+    // #6417 — the assertions above pin the *wholesale _spawnPty mock* (it
+    // reconstructs the arg list), so dropping --no-chrome from the REAL method
+    // would not fail them. This test runs the real _spawnPty against a capturing
+    // node-pty stand-in (the _ptyModOverride seam), so drift on the real argv is
+    // caught directly. The stub throws after capturing, which _spawnPty's own
+    // spawn try-catch turns into an early return (no warmup, no live PTY).
+    it('drift guard: the REAL _spawnPty argv carries --no-chrome (stubs only node-pty spawn)', async () => {
+      ClaudeTuiSession.prototype._spawnPty = origSpawnPty // run the genuine method
+      let realArgs = null
+      let realCmd = null
+      session = new ClaudeTuiSession({ cwd: '/tmp', port: 12346, skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session.on('error', () => {}) // _spawnPty emits 'error' when our spawn throws; swallow it
+      session._sessionId = 'drift-guard-uuid'
+      session._settingsPath = join(fakeHome, 'settings.json')
+      session._ptyModOverride = {
+        spawn: (cmd, args) => { realCmd = cmd; realArgs = args; throw new Error('captured-and-bail') },
+      }
+      await session._spawnPty(true)
+      assert.ok(realArgs, 'the real _spawnPty invoked node-pty spawn (not a wholesale mock)')
+      assert.ok(realCmd, 'spawn received a claude binary path')
+      assert.equal(realArgs.includes('--no-chrome'), true,
+        'the REAL _spawnPty argv carries --no-chrome — drift on the real method is now caught')
+      assert.equal(realArgs.includes('--settings'), true, 'the real argv also carries --settings')
+    })
+
     it('restored session: seeds _sessionId from resumeSessionId, keeps it through start, spawns with --resume', async () => {
       const persisted = '11111111-2222-3333-4444-555555555555'
       session = new ClaudeTuiSession({


### PR DESCRIPTION
Closes #6417.

## Problem
The claude-tui resume suite mocks `_spawnPty` **wholesale** and reconstructs the arg list inside the mock, so the `--no-chrome` contract assertion pins the *mock*, not the real method. Dropping `--no-chrome` from the real `_spawnPty` (a PTY-wedge regression — Claude Code's 'Claude in Chrome detected' prompt blocks the headless TUI) would **not** fail any test.

## Fix
Add a `_ptyModOverride` test seam to `_spawnPty` (undefined in production → the genuine `await import('node-pty')` runs unchanged). A new test injects a *capturing* node-pty stand-in and runs the **real** `_spawnPty`, so its real arg-builder is exercised. The stub throws right after capturing the argv, which `_spawnPty`'s own spawn try-catch turns into a clean early return — no warmup, no live PTY to tear down.

## Verified
The new test asserts the **real** argv carries `--no-chrome` (and `--settings`). Drift on the real method is now caught directly. `claude-tui-session` suite: 301 green. Production behaviour unchanged (the seam is inert when unset).

From the W1 review backlog (#6417).