### PR TITLE
feat(app): derive mobile error-chip accessibilityLiveRegion from the registry role

### DIFF
--- a/packages/app/src/components/ResumeUnknownChip.tsx
+++ b/packages/app/src/components/ResumeUnknownChip.tsx
@@ -81,15 +81,19 @@ export function ResumeUnknownChip({
   // is single-sourced cross-surface. accessibilityRole stays `'alert'` for both
   // variants — the mobile RN convention is the assertive role on recoverable
   // amber chips too (parity with StreamStallChip); the label carries the urgency.
-  const { headline } = getErrorPresentation(
+  const { headline, role } = getErrorPresentation(
     variant === 'exhausted' ? 'resume_unknown_exhausted' : 'resume_unknown',
   );
+  // #6429: derive live-region politeness from the registry role — the exhausted
+  // (alert) variant announces assertively, the recoverable (status) one politely.
+  // accessibilityRole stays 'alert' for both (the label still carries the urgency).
+  const liveRegion = role === 'alert' ? 'assertive' : 'polite';
 
   return (
     <View
       testID="resume-unknown-chip"
       accessibilityRole="alert"
-      accessibilityLiveRegion="polite"
+      accessibilityLiveRegion={liveRegion}
       accessibilityLabel={headline}
       accessibilityHint={errorText}
       style={styles.container}

--- a/packages/app/src/components/StreamStallChip.tsx
+++ b/packages/app/src/components/StreamStallChip.tsx
@@ -53,9 +53,10 @@ export function StreamStallChip({
 }: StreamStallChipProps) {
   const [detailVisible, setDetailVisible] = useState(false);
 
-  // #6429: derive live-region politeness from the registry role — terminal
-  // (alert) variants announce assertively, recoverable (status) ones politely.
-  // accessibilityRole stays 'alert' (the RN convention for amber error chips).
+  // #6429: politeness is derived from the registry role for parity with the
+  // other error chips. stream_stall is role 'status', so this chip always
+  // resolves to 'polite'; the derivation just guards against a future role
+  // change. accessibilityRole stays 'alert' (the RN convention for amber chips).
   const liveRegion = getErrorPresentation('stream_stall').role === 'alert' ? 'assertive' : 'polite';
 
   const handleRetry = useCallback(() => {

--- a/packages/app/src/components/StreamStallChip.tsx
+++ b/packages/app/src/components/StreamStallChip.tsx
@@ -53,6 +53,11 @@ export function StreamStallChip({
 }: StreamStallChipProps) {
   const [detailVisible, setDetailVisible] = useState(false);
 
+  // #6429: derive live-region politeness from the registry role — terminal
+  // (alert) variants announce assertively, recoverable (status) ones politely.
+  // accessibilityRole stays 'alert' (the RN convention for amber error chips).
+  const liveRegion = getErrorPresentation('stream_stall').role === 'alert' ? 'assertive' : 'polite';
+
   const handleRetry = useCallback(() => {
     onRetry?.();
   }, [onRetry]);
@@ -65,7 +70,7 @@ export function StreamStallChip({
     <Pressable
       testID="stream-stall-chip"
       accessibilityRole="alert"
-      accessibilityLiveRegion="polite"
+      accessibilityLiveRegion={liveRegion}
       accessibilityLabel={headline}
       accessibilityHint={errorText}
       // Long-press reveals the underlying server diagnostic text without

--- a/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
+++ b/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
@@ -170,6 +170,20 @@ describe('ResumeUnknownChip (#4971)', () => {
       expect(chip.props.accessibilityLabel).not.toContain('starting fresh');
     });
 
+    // #6429: live-region politeness is derived from the registry role —
+    // exhausted (terminal/alert) announces assertively, recoverable (status)
+    // politely. accessibilityRole stays 'alert' for both (label carries copy).
+    it('derives accessibilityLiveRegion from the role: exhausted→assertive, recoverable→polite (#6429)', () => {
+      const exhausted = render(<ResumeUnknownChip variant="exhausted" errorText="x" />)
+        .root.findByProps({ testID: 'resume-unknown-chip' });
+      const recoverable = render(<ResumeUnknownChip variant="recoverable" errorText="x" />)
+        .root.findByProps({ testID: 'resume-unknown-chip' });
+      expect(exhausted.props.accessibilityLiveRegion).toBe('assertive');
+      expect(recoverable.props.accessibilityLiveRegion).toBe('polite');
+      expect(exhausted.props.accessibilityRole).toBe('alert');
+      expect(recoverable.props.accessibilityRole).toBe('alert');
+    });
+
     it('defaults to the recoverable headline when variant is omitted (back-compat)', () => {
       // Existing call sites pass no variant — they must continue to render
       // the recoverable copy unchanged.


### PR DESCRIPTION
Closes #6429.

## Problem
`StreamStallChip` + `ResumeUnknownChip` source their headline from store-core's `getErrorPresentation(code)` (#6392), but hard-coded `accessibilityLiveRegion="polite"` for **every** variant — including the terminal `resume_unknown_exhausted` chip. The registry already carries a `role: 'status' | 'alert'` field; the faithful RN mapping of that to politeness was unused.

## Fix
Derive `accessibilityLiveRegion` from `getErrorPresentation(code).role`: **status → polite, alert → assertive**. So the terminal/unrecoverable chip (`resume_unknown_exhausted`, role `alert`) now announces **assertively** — an a11y improvement — while recoverable chips stay polite. `accessibilityRole` is left as-is (`'alert'` for both, the documented mobile RN convention; the label carries the copy).

## Verified
+1 test (exhausted→assertive, recoverable→polite, role unchanged). `StreamStallChip` + `ResumeUnknownChip` (21) + `MessageBubble` renderer (19) jest suites green; app tsc clean on the changed files. Pure prop-value derivation — unit-tested, no device check needed.

From the W1 review backlog (#6429).