### PR TITLE
fix(server): signal a client-visible error when an over-size stream delta is dropped

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2609,14 +2609,16 @@ export class SessionManager extends EventEmitter {
       // so its local copy now diverges from the persisted message. Surface a
       // client-visible error so the truncation is observable instead of a silent
       // desync. Emitted once per stream (the history layer dedupes).
+      // The event-normalizer's generic `error` builder forwards only `message`
+      // + `code` to clients, so the payload is kept to exactly what reaches them
+      // — no dead `messageId` / `recoverable` fields that would imply a
+      // correlation the wire never delivers (#6431 review).
       this.emit('session_event', {
         sessionId,
         event: 'error',
         data: {
           code: 'stream_truncated',
           message: 'A response exceeded the server buffer limit and was truncated server-side; the saved message may be incomplete.',
-          recoverable: true,
-          messageId: data?.messageId,
         },
       })
     }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2599,9 +2599,26 @@ export class SessionManager extends EventEmitter {
    * Delegates to SessionMessageHistory and triggers persist when needed.
    */
   _recordHistory(sessionId, event, data) {
-    const { persistNeeded } = this._history.recordHistory(sessionId, event, data)
+    const { persistNeeded, truncated } = this._history.recordHistory(sessionId, event, data)
     if (persistNeeded) {
       this._schedulePersist()
+    }
+    if (truncated) {
+      // #6431 — an over-size stream delta was dropped from history. The client
+      // still received it (forwarded independently via the stream_delta proxy),
+      // so its local copy now diverges from the persisted message. Surface a
+      // client-visible error so the truncation is observable instead of a silent
+      // desync. Emitted once per stream (the history layer dedupes).
+      this.emit('session_event', {
+        sessionId,
+        event: 'error',
+        data: {
+          code: 'stream_truncated',
+          message: 'A response exceeded the server buffer limit and was truncated server-side; the saved message may be incomplete.',
+          recoverable: true,
+          messageId: data?.messageId,
+        },
+      })
     }
   }
 

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -19,13 +19,20 @@ export class SessionMessageHistory extends EventEmitter {
    * @param {number} [opts.maxMessages=1000] - Max messages per session (FIFO eviction when exceeded)
    * @param {number} [opts.maxHistory]       - Alias for maxMessages (legacy option name)
    * @param {number} [opts.maxToolInput]     - Max characters for tool input (unused here, reserved)
+   * @param {number} [opts.maxPendingStreamSize] - Max accumulated chars for one pending stream before further deltas are dropped (default 100MB). Injectable for tests.
    */
-  constructor({ maxMessages, maxHistory, maxToolInput } = {}) {
+  constructor({ maxMessages, maxHistory, maxToolInput, maxPendingStreamSize } = {}) {
     super()
     this._maxHistory = maxMessages ?? maxHistory ?? 1000
     this._maxToolInput = maxToolInput || null
+    this._maxPendingStreamSize = maxPendingStreamSize || MAX_PENDING_STREAM_SIZE
     this._messageHistory = new Map()    // sessionId -> Array<{ type, _seq, ...data }>
     this._pendingStreams = new Map()     // sessionId:messageId -> accumulated delta text
+    // #6431 — messageIds whose pending stream has already been truncated, so the
+    // truncation is signalled to the client ONCE per stream (every subsequent
+    // over-size delta for the same message also exceeds the cap and would
+    // otherwise re-fire the error). Cleared on stream_end / session clear.
+    this._truncatedStreams = new Set()   // sessionId:messageId
     this._historyTruncated = new Map()  // sessionId -> boolean
     // #5555.3 (lastSeq delta replay) — per-session monotonic history sequence.
     // Every entry pushed into the ring buffer is stamped with a strictly
@@ -116,6 +123,7 @@ export class SessionMessageHistory extends EventEmitter {
         const messageId = key.slice(prefix.length)
         closedMessageIds.push(messageId)
         this._pendingStreams.delete(key)
+        this._truncatedStreams.delete(key) // #6431 — release the truncation guard
       }
     }
     return closedMessageIds
@@ -294,9 +302,18 @@ export class SessionMessageHistory extends EventEmitter {
         const key = `${sessionId}:${data.messageId}`
         const existing = this._pendingStreams.get(key)
         if (existing !== undefined) {
-          if (existing.length + data.delta.length > MAX_PENDING_STREAM_SIZE) {
-            log.warn(`Stream delta exceeded size limit for ${key}`)
-            return { persistNeeded: false }
+          if (existing.length + data.delta.length > this._maxPendingStreamSize) {
+            // #6431 — drop the over-size delta from history. The client still
+            // received it (forwarded independently), so its local copy now
+            // diverges from the persisted message. Signal truncation ONCE per
+            // stream so the caller can emit a client-visible error instead of a
+            // silent desync.
+            const firstDrop = !this._truncatedStreams.has(key)
+            if (firstDrop) {
+              this._truncatedStreams.add(key)
+              log.warn(`Stream delta exceeded size limit for ${key} — truncating; client will be notified`)
+            }
+            return { persistNeeded: false, truncated: firstDrop }
           }
           this._pendingStreams.set(key, existing + data.delta)
         }
@@ -307,6 +324,7 @@ export class SessionMessageHistory extends EventEmitter {
         const key = `${sessionId}:${data.messageId}`
         const content = this._pendingStreams.get(key) || ''
         this._pendingStreams.delete(key)
+        this._truncatedStreams.delete(key) // #6431 — release the once-per-stream guard
         if (content) {
           this._pushHistory(history, {
             type: 'message',
@@ -474,6 +492,10 @@ export class SessionMessageHistory extends EventEmitter {
       if (key.startsWith(prefix)) {
         this._pendingStreams.delete(key)
       }
+    }
+    // #6431 — and any lingering truncation guards for this session
+    for (const key of this._truncatedStreams) {
+      if (key.startsWith(prefix)) this._truncatedStreams.delete(key)
     }
   }
 

--- a/packages/server/tests/session-message-history.test.js
+++ b/packages/server/tests/session-message-history.test.js
@@ -31,6 +31,48 @@ describe('SessionMessageHistory', () => {
     })
   })
 
+  // #6431 — an over-size stream delta is dropped from history but still reached
+  // the client, so recordHistory signals the drop (once per stream) and the
+  // SessionManager turns that into a client-visible error instead of a silent
+  // desync. maxPendingStreamSize is injectable so the test needs no 100MB alloc.
+  describe('stream truncation signalling (#6431)', () => {
+    it('returns truncated:true once, then false, when deltas exceed the size cap', () => {
+      const h = new SessionMessageHistory({ maxPendingStreamSize: 50 })
+      h.recordHistory('s1', 'stream_start', { messageId: 'm1' })
+      const r1 = h.recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'x'.repeat(100) })
+      assert.equal(r1.persistNeeded, false)
+      assert.equal(r1.truncated, true, 'first over-size delta signals truncation')
+      const r2 = h.recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'x'.repeat(100) })
+      assert.equal(r2.truncated, false, 'subsequent over-size deltas dedupe (no re-signal)')
+    })
+
+    it('does not signal truncation for a normal-size stream', () => {
+      const h = new SessionMessageHistory({ maxPendingStreamSize: 50 })
+      h.recordHistory('s1', 'stream_start', { messageId: 'm1' })
+      const r = h.recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'small' })
+      assert.ok(!r.truncated)
+    })
+
+    it('releases the once-per-stream guard on stream_end (a fresh stream re-signals)', () => {
+      const h = new SessionMessageHistory({ maxPendingStreamSize: 50 })
+      h.recordHistory('s1', 'stream_start', { messageId: 'm1' })
+      h.recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'x'.repeat(100) })
+      h.recordHistory('s1', 'stream_end', { messageId: 'm1' })
+      h.recordHistory('s1', 'stream_start', { messageId: 'm1' })
+      const r = h.recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'x'.repeat(100) })
+      assert.equal(r.truncated, true, 'guard released on stream_end → re-signals')
+    })
+
+    it('cleanupSession releases lingering truncation guards (no leak)', () => {
+      const h = new SessionMessageHistory({ maxPendingStreamSize: 50 })
+      h.recordHistory('s1', 'stream_start', { messageId: 'm1' })
+      h.recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'x'.repeat(100) })
+      assert.equal(h._truncatedStreams.size, 1)
+      h.cleanupSession('s1')
+      assert.equal(h._truncatedStreams.size, 0, 'cleanupSession releases the guard')
+    })
+  })
+
   describe('getHistory / getHistoryCount', () => {
     it('returns empty array for unknown session', () => {
       assert.deepStrictEqual(history.getHistory('unknown'), [])

--- a/packages/server/tests/stream-truncation-signal.test.js
+++ b/packages/server/tests/stream-truncation-signal.test.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'fs'
+
+/**
+ * #6431 — when a stream delta exceeds MAX_PENDING_STREAM_SIZE the server drops it
+ * from history, but the client already received it (forwarded independently), so
+ * the persisted message silently diverges from what the client observed. The fix:
+ * SessionManager emits a client-visible `error` session_event (code
+ * `stream_truncated`) so the truncation is observable instead of a silent desync.
+ */
+describe('SessionManager — stream truncation client signal (#6431)', () => {
+  it('emits one client-visible error session_event when an over-size delta is dropped', async () => {
+    const { SessionManager } = await import('../src/session-manager.js')
+    const tmpState = `/tmp/chroxy-truncsig-${Date.now()}-${Math.random()}.json`
+    const sm = new SessionManager({ skipPreflight: true, stateFilePath: tmpState, persistenceDebounceMs: 0 })
+    // Shrink the pending-stream cap so a small delta trips it (no 100MB alloc).
+    sm._history._maxPendingStreamSize = 50
+
+    const errors = []
+    sm.on('session_event', (e) => { if (e.event === 'error') errors.push(e) })
+
+    sm._recordHistory('s1', 'stream_start', { messageId: 'm1' })
+    sm._recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'x'.repeat(100) }) // over-size → drop
+    sm._recordHistory('s1', 'stream_delta', { messageId: 'm1', delta: 'x'.repeat(100) }) // again → deduped
+
+    assert.equal(errors.length, 1, 'truncation surfaces exactly one client-visible error (deduped)')
+    assert.equal(errors[0].sessionId, 's1')
+    assert.equal(errors[0].data.code, 'stream_truncated')
+    assert.equal(errors[0].data.messageId, 'm1')
+    assert.equal(errors[0].data.recoverable, true)
+
+    sm.destroy?.()
+    try { rmSync(tmpState, { force: true }) } catch { /* never written (no persistNeeded) */ }
+  })
+
+  it('does not emit for a normal-size stream', async () => {
+    const { SessionManager } = await import('../src/session-manager.js')
+    const tmpState = `/tmp/chroxy-truncsig-ok-${Date.now()}-${Math.random()}.json`
+    const sm = new SessionManager({ skipPreflight: true, stateFilePath: tmpState, persistenceDebounceMs: 0 })
+    sm._history._maxPendingStreamSize = 50
+
+    const errors = []
+    sm.on('session_event', (e) => { if (e.event === 'error') errors.push(e) })
+
+    sm._recordHistory('s2', 'stream_start', { messageId: 'm9' })
+    sm._recordHistory('s2', 'stream_delta', { messageId: 'm9', delta: 'small' })
+
+    assert.equal(errors.length, 0, 'a normal stream emits no truncation error')
+
+    sm.destroy?.()
+    try { rmSync(tmpState, { force: true }) } catch { /* ignore */ }
+  })
+})

--- a/packages/server/tests/stream-truncation-signal.test.js
+++ b/packages/server/tests/stream-truncation-signal.test.js
@@ -27,8 +27,10 @@ describe('SessionManager — stream truncation client signal (#6431)', () => {
     assert.equal(errors.length, 1, 'truncation surfaces exactly one client-visible error (deduped)')
     assert.equal(errors[0].sessionId, 's1')
     assert.equal(errors[0].data.code, 'stream_truncated')
-    assert.equal(errors[0].data.messageId, 'm1')
-    assert.equal(errors[0].data.recoverable, true)
+    assert.ok(errors[0].data.message, 'carries a human-readable message')
+    // messageId/recoverable are intentionally absent — the normalizer's generic
+    // error builder forwards only code + message, so we don't emit dead fields.
+    assert.equal(errors[0].data.messageId, undefined)
 
     sm.destroy?.()
     try { rmSync(tmpState, { force: true }) } catch { /* never written (no persistNeeded) */ }


### PR DESCRIPTION
Closes #6431.

## Problem
`session-message-history.js`: when a stream delta would push the pending stream past `MAX_PENDING_STREAM_SIZE` (100MB), the delta was dropped server-side with only a `log.warn()` — but it was still forwarded to clients (independently). The client accumulates it locally while the server discards it, so the **persisted message silently diverges** from what the client observed at `stream_end`. Hitting 100MB in one stream is extremely rare, so this is defence-in-depth, not a live bug.

## Fix
- `recordHistory` returns a `truncated` signal when it drops an over-size delta — **once per stream** (subsequent over-size deltas for the same message dedupe via a `_truncatedStreams` guard, so the client isn't spammed).
- `SessionManager._recordHistory` turns that into a **client-visible `error` session_event** (`code: 'stream_truncated'`, `recoverable: true`, with the `messageId`) — the same broadcast path proxied session events use. No silent desync.
- The per-stream guard is released on `stream_end` and in both per-session cleanup paths (`closePendingStreams`, `cleanupSession`) so it can't leak.
- `maxPendingStreamSize` is now an injectable constructor opt (default 100MB) so the cap is testable without a 100MB allocation.

No protocol change: error `code` is a free-string field surfaced via the existing generic error path.

## Verified
+6 tests (history-layer truncation signal + dedup + guard release + cleanup; SessionManager emits one client-visible error, none for a normal stream). `session-message-history` (59) + `concurrent-send-truncation`/`pushhistory` (11) suites green; server custom lints pass.

From the swarm-audit / W1 review backlog (#6431).