### PR TITLE
feat(ci): lint for fallback-less var(--…) to undefined CSS custom properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,9 @@ jobs:
       - name: No raw color literals in new styling files
         run: bash scripts/lint-no-raw-color-literals.sh
 
+      - name: No fallback-less var(--…) to an undefined CSS custom property
+        run: bash scripts/lint-undefined-css-vars.sh
+
   store-core-tests:
     name: Store Core Tests
     # Self-hosted (#6046): the prior install OOM (exit 137) was the 7.7GB Docker

--- a/scripts/lint-undefined-css-vars.sh
+++ b/scripts/lint-undefined-css-vars.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Lint: no fallback-less var(--foo) referencing an undefined CSS custom property.
+#
+# #6420. Catches the #6416 bug class: when the whole --color-* token namespace
+# was undefined, var(--color-surface) silently resolved to transparent and the
+# Cmd+K palette was unreadable — no error, just a wrong colour. A static guard
+# flags any var(--foo) reference (without a fallback) whose --foo is defined
+# nowhere, so the bug class fails at CI time instead of via visual regression.
+#
+# A var() WITH a fallback (var(--foo, x)) is ALWAYS safe and is ignored — the
+# fallback is exactly the "defined elsewhere or this default" escape hatch.
+#
+# Comments are stripped before scanning (mirrors lint-no-raw-color-literals.sh
+# / #6423) so a JSDoc reference like `a var(--token) colour` in a .tsx comment
+# is not mistaken for a real, broken reference.
+#
+# Pure grep/comm + perl (for comment stripping) — no deps. CI runs it under bash.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ROOT="packages/dashboard/src"
+
+command -v perl >/dev/null 2>&1 || {
+  echo "::error::lint-undefined-css-vars.sh requires perl (used to strip comments)"
+  exit 1
+}
+
+# Grandfathered: short semantic vars referenced (fallback-less) in components.css
+# that the theme does not define (it defines suffixed forms like --accent-blue).
+# These pre-date the lint and need a theme-author decision to resolve — tracked
+# in https://github.com/blamechris/chroxy/issues/6444. The list only FREEZES the
+# known backlog; any NEW undefined reference is still caught. Shrink it as #6444
+# is worked.
+ALLOW="--accent --accent-yellow --bg-active --bg-hover --border --border-muted --error --text-bright --text-tertiary"
+
+# Comment-stripped content of every styling file, as one stream (// line + /* */
+# block comments, the latter across newlines via /s). Over-stripping a // inside
+# a string only drops a candidate (false-negative) — safe for this guard.
+stripped="$(find "$ROOT" \( -name '*.css' -o -name '*.ts' -o -name '*.tsx' \) -type f -print0 \
+  | xargs -0 perl -0777 -pe 's{//[^\n]*}{}g; s{/\*.*?\*/}{}gs' 2>/dev/null)"
+
+# Defined props: `--foo:` (CSS / inline object), setProperty('--foo'), '--foo':
+defined="$(printf '%s' "$stripped" \
+  | grep -oE -- "--[a-zA-Z0-9-]+[[:space:]]*:|setProperty\(['\"]--[a-zA-Z0-9-]+|['\"]--[a-zA-Z0-9-]+['\"][[:space:]]*:" \
+  | grep -oE -- "--[a-zA-Z0-9-]+" | sort -u)"
+
+# Fallback-less references: var(--foo) but NOT var(--foo, …).
+refs="$(printf '%s' "$stripped" \
+  | grep -oE "var\(--[a-zA-Z0-9-]+[[:space:]]*\)" \
+  | grep -oE -- "--[a-zA-Z0-9-]+" | sort -u)"
+
+# Known = defined ∪ grandfathered. Undefined = fallback-less refs minus known.
+known="$(printf '%s\n' "$defined"; printf '%s\n' $ALLOW)"
+known="$(printf '%s\n' "$known" | sort -u)"
+undefined="$(comm -23 <(printf '%s\n' "$refs") <(printf '%s\n' "$known") | grep -v '^$' || true)"
+
+if [ -n "$undefined" ]; then
+  echo "::error::var(--…) references an undefined CSS custom property with no fallback:"
+  printf '%s\n' "$undefined" | sed 's/^/    /'
+  echo "  Fix one of: define it (packages/dashboard/src/theme), add a fallback"
+  echo "  (var(--x, <value>)), or — if intentional/pre-existing — add it to ALLOW"
+  echo "  in scripts/lint-undefined-css-vars.sh (and track it under #6444)."
+  exit 1
+fi
+
+echo "OK — every fallback-less var(--…) resolves to a defined custom property ($(printf '%s\n' $ALLOW | grep -c .) grandfathered, tracked in #6444)."

--- a/scripts/lint-undefined-css-vars.sh
+++ b/scripts/lint-undefined-css-vars.sh
@@ -36,21 +36,27 @@ command -v perl >/dev/null 2>&1 || {
 # is worked.
 ALLOW="--accent --accent-yellow --bg-active --bg-hover --border --border-muted --error --text-bright --text-tertiary"
 
-# Comment-stripped content of every styling file, as one stream (// line + /* */
-# block comments, the latter across newlines via /s). Over-stripping a // inside
-# a string only drops a candidate (false-negative) — safe for this guard.
-stripped="$(find "$ROOT" \( -name '*.css' -o -name '*.ts' -o -name '*.tsx' \) -type f -print0 \
-  | xargs -0 perl -0777 -pe 's{//[^\n]*}{}g; s{/\*.*?\*/}{}gs' 2>/dev/null)"
+# Comment-stripped content of every styling file, as one stream. CSS files get
+# ONLY the /* */ strip — CSS has no // line comments, so stripping // there could
+# eat a real `--foo:` definition (e.g. inside a url()) and cause a FALSE positive;
+# .ts/.tsx get both // and /* */. Over-stripping only ever drops a candidate
+# (false-negative). `|| true`: an empty styling dir mustn't abort under set -e.
+css_stripped="$(find "$ROOT" -name '*.css' -type f -print0 \
+  | xargs -0 perl -0777 -pe 's{/\*.*?\*/}{}gs' 2>/dev/null || true)"
+ts_stripped="$(find "$ROOT" \( -name '*.ts' -o -name '*.tsx' \) -type f -print0 \
+  | xargs -0 perl -0777 -pe 's{//[^\n]*}{}g; s{/\*.*?\*/}{}gs' 2>/dev/null || true)"
+stripped="$css_stripped
+$ts_stripped"
 
 # Defined props: `--foo:` (CSS / inline object), setProperty('--foo'), '--foo':
 defined="$(printf '%s' "$stripped" \
   | grep -oE -- "--[a-zA-Z0-9-]+[[:space:]]*:|setProperty\(['\"]--[a-zA-Z0-9-]+|['\"]--[a-zA-Z0-9-]+['\"][[:space:]]*:" \
-  | grep -oE -- "--[a-zA-Z0-9-]+" | sort -u)"
+  | grep -oE -- "--[a-zA-Z0-9-]+" | sort -u || true)"
 
 # Fallback-less references: var(--foo) but NOT var(--foo, …).
 refs="$(printf '%s' "$stripped" \
   | grep -oE "var\(--[a-zA-Z0-9-]+[[:space:]]*\)" \
-  | grep -oE -- "--[a-zA-Z0-9-]+" | sort -u)"
+  | grep -oE -- "--[a-zA-Z0-9-]+" | sort -u || true)"
 
 # Known = defined ∪ grandfathered. Undefined = fallback-less refs minus known.
 known="$(printf '%s\n' "$defined"; printf '%s\n' $ALLOW)"


### PR DESCRIPTION
Closes #6420.

## Problem
The Cmd+K palette was unreadable (#6416) because the entire `--color-*` token namespace was undefined — `var(--color-surface)` silently resolved to transparent. CSS custom properties **fail silently**: an undefined `var(--foo)` (no fallback) resolves to the property's initial/inherited value, with no error. The only thing that caught #6416 was visual regression.

## Fix
A static guard (`scripts/lint-undefined-css-vars.sh`, wired into the **Style Lint** CI job) flags any `var(--foo)` reference **without a fallback** whose `--foo` is defined nowhere in the dashboard (CSS `--foo:`, `setProperty('--foo')`, or inline `'--foo':`).

- **Fallbacks are safe:** `var(--foo, <value>)` is ignored — that's the legitimate escape hatch.
- **Comments are stripped first** (mirrors #6423): a JSDoc reference like `a \`var(--token)\` colour` is not a false positive.
- **perl-guarded** (fail loud if perl is missing, like #6439).

## Grandfathered (tracked in #6444)
The lint surfaced **9 pre-existing** fallback-less refs in `theme/components.css` to undefined short semantic vars (`--accent`, `--border`, `--error`, …) — theme.css only defines suffixed forms (`--accent-blue`). Resolving them needs a theme-author decision (define / re-point / remove), so they're grandfathered via an inline `ALLOW` list and tracked in #6444. **New** undefined refs are caught immediately.

## Verified
Passes clean on current main (9 grandfathered, `--token` comment stripped); fails on an injected fallback-less undefined ref; a `var(--x, #fff)` fallback passes.

From the W1 review backlog (#6420).