### PR TITLE
fix(app): reset the encryption context as a unit on each connection (#6446)

### DIFF
--- a/packages/app/src/store/__tests__/message-handler.encryption-reset.test.ts
+++ b/packages/app/src/store/__tests__/message-handler.encryption-reset.test.ts
@@ -1,0 +1,31 @@
+import {
+  resetEncryptionContext,
+  getEncryptionState,
+  getPendingKeyPair,
+  setEncryptionState,
+  prepareEagerKeyExchange,
+} from '../message-handler';
+
+/**
+ * #6446 — the encryption context must reset as a UNIT on every new connection
+ * (forward secrecy). The audit's "HIGH: encryption leaks on server-switch" was a
+ * false positive (encryptionState + pendingKeyPair were already reset per
+ * connection); this pins the real grain of truth — that pendingSalt + any future
+ * field are cleared too, so nothing survives a reconnect / server switch.
+ */
+describe('resetEncryptionContext (#6446)', () => {
+  it('clears the encryption context as a unit', () => {
+    // Populate every encryption field, as a live connection would mid-handshake.
+    setEncryptionState({ sharedKey: new Uint8Array(32), sendNonce: 7, recvNonce: 9 } as never);
+    prepareEagerKeyExchange(); // sets pendingKeyPair + pendingSalt
+    expect(getEncryptionState()).not.toBeNull();
+    expect(getPendingKeyPair()).not.toBeNull();
+
+    resetEncryptionContext();
+
+    expect(getEncryptionState()).toBeNull();
+    expect(getPendingKeyPair()).toBeNull();
+    // pendingSalt is cleared by the same INITIAL_ENCRYPTION_CONTEXT unit-reset
+    // (no getter to assert directly; covered by construction — that was the gap).
+  });
+});

--- a/packages/app/src/store/__tests__/message-handler.encryption-reset.test.ts
+++ b/packages/app/src/store/__tests__/message-handler.encryption-reset.test.ts
@@ -2,6 +2,7 @@ import {
   resetEncryptionContext,
   getEncryptionState,
   getPendingKeyPair,
+  getPendingSalt,
   setEncryptionState,
   prepareEagerKeyExchange,
 } from '../message-handler';
@@ -20,12 +21,12 @@ describe('resetEncryptionContext (#6446)', () => {
     prepareEagerKeyExchange(); // sets pendingKeyPair + pendingSalt
     expect(getEncryptionState()).not.toBeNull();
     expect(getPendingKeyPair()).not.toBeNull();
+    expect(getPendingSalt()).not.toBeNull();
 
     resetEncryptionContext();
 
     expect(getEncryptionState()).toBeNull();
     expect(getPendingKeyPair()).toBeNull();
-    // pendingSalt is cleared by the same INITIAL_ENCRYPTION_CONTEXT unit-reset
-    // (no getter to assert directly; covered by construction — that was the gap).
+    expect(getPendingSalt()).toBeNull(); // the field the old field-by-field reset missed (#6446)
   });
 });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -96,7 +96,7 @@ import {
   handleMessage,
   setConnectionContext,
   setEncryptionState,
-  setPendingKeyPair,
+  resetEncryptionContext,
   prepareEagerKeyExchange,
   getEncryptionState,
   getPendingKeyPair,
@@ -1154,9 +1154,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
 
     function _connectWebSocket() {
-    // Reset encryption state for each new connection (forward secrecy)
-    setEncryptionState(null);
-    setPendingKeyPair(null);
+    // Reset the encryption context as a unit for each new connection (forward
+    // secrecy). #6446: doing this through resetEncryptionContext (not
+    // field-by-field) also clears pendingSalt + any future field, so nothing
+    // leaks across a reconnect or a server switch.
+    resetEncryptionContext();
     // #5962 (#5721 parity) — clear any leftover handshake timer from a prior
     // attempt before opening a new socket, so a stale timer can't fire against
     // this fresh attempt.
@@ -1500,9 +1502,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     clearPermissionSplits();
     // Clear terminal write batching
     clearTerminalWriteBatching();
-    // Clear encryption state (new connection = new keys = forward secrecy)
-    setEncryptionState(null);
-    setPendingKeyPair(null);
+    // Clear the encryption context as a unit (new connection = new keys =
+    // forward secrecy). #6446: also clears pendingSalt + any future field.
+    resetEncryptionContext();
     // Clear message queue on explicit disconnect
     clearMessageQueue();
     useMultiClientStore.getState().resetPresence();

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -642,6 +642,11 @@ export function setPendingKeyPair(kp: KeyPair | null): void {
   _ctx.pendingKeyPair = kp;
 }
 
+/** #6446 — read the in-flight handshake salt, so a reset can be asserted directly. */
+export function getPendingSalt(): string | null {
+  return _ctx.pendingSalt;
+}
+
 /**
  * #5555 (eager key exchange) — generate this connection's ephemeral X25519
  * keypair + per-connection salt and stash them on the handler context so they

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -661,6 +661,23 @@ export function prepareEagerKeyExchange(): { publicKey: string; salt: string } {
   return { publicKey: _ctx.pendingKeyPair.publicKey, salt: _ctx.pendingSalt };
 }
 
+/**
+ * Reset the E2E encryption context (post-handshake `encryptionState` AND the
+ * in-flight handshake material `pendingKeyPair` + `pendingSalt`) to its initial
+ * state, as a UNIT — for forward secrecy on every new connection.
+ *
+ * #6446: callers previously reset `encryptionState` + `pendingKeyPair`
+ * field-by-field and MISSED `pendingSalt`. Resetting through the grouped
+ * `INITIAL_ENCRYPTION_CONTEXT` (the same object `createDefaultContext` spreads)
+ * clears every field — and any field a future handshake adds to
+ * `EncryptionContext` — so nothing can silently survive a reconnect or a server
+ * switch. This is deliberately narrow: it does NOT tear down timers / heartbeat
+ * / connection-attempt counters (that is the heavier `resetAllHandlerState`).
+ */
+export function resetEncryptionContext(): void {
+  Object.assign(_ctx, INITIAL_ENCRYPTION_CONTEXT);
+}
+
 // ---------------------------------------------------------------------------
 // Connection attempt tracking
 // These are kept as export let (not in _ctx) to preserve ES module live-binding


### PR DESCRIPTION
Closes #6446.

## TL;DR — the HIGH-severity claim was a false positive
#6446 (from the convergence audit) claimed encryption handler state is **not reset on server-switch** → forward-secrecy / nonce-reuse risk. On investigation that is **incorrect**: `_connectWebSocket()` (connection.ts) already resets `encryptionState` **and** `pendingKeyPair` on **every** new connection ("forward secrecy"), and the server-switch path runs through it (called at the two connect sites). The audit + verify agents both missed that reset. There is **no HIGH leak**.

## The real (minor) grain of truth
That per-connection reset was done **field-by-field** and **missed `pendingSalt`** — the third `EncryptionContext` field. It's **cosmetic today**: `pendingKeyPair` IS reset, so the next handshake regenerates the salt and a lingering value is never read. But it's a latent leak the moment someone adds a new field to `EncryptionContext` and forgets to reset it too.

## Fix
Add `resetEncryptionContext()` — a **unit-reset** via the grouped `INITIAL_ENCRYPTION_CONTEXT` (the same object `createDefaultContext` spreads) — and use it at both reset sites (new-connection + disconnect). Every encryption field, and any field a future handshake adds, is now cleared as a unit. `setPendingKeyPair` import dropped (unused after the swap).

**Behaviour-preserving** (identical `encryptionState` + `pendingKeyPair` resets, plus `pendingSalt`). Severity is **LOW** (hygiene / future-proofing), not the HIGH originally filed.

## Verified
+1 test (first coverage for this reset — `resetEncryptionContext` clears the context as a unit); connection/handshake/encryption suites (318) green; tsc clean on the changed files.

From the convergence-audit backlog (#6446) — surfaced as a false positive + fixed the real residual.