### PR TITLE
fix(server): resource-limit caps on permission-manager + conversation-search (DoS)

### DIFF
--- a/packages/server/src/conversation-search.js
+++ b/packages/server/src/conversation-search.js
@@ -9,6 +9,10 @@ const MIN_FILE_SIZE = 100
 const CONCURRENCY = 10
 const MAX_FILE_READ = 512 * 1024 // read up to 512KB per file for search
 const DEFAULT_MAX_RESULTS = 50
+// #6448 — bound the query length: every candidate file is substring-scanned for
+// the query, so an absurdly long query is a CPU DoS. 500 chars is far beyond any
+// real search.
+const MAX_QUERY_LENGTH = 500
 
 /**
  * Extract searchable text from a JSONL entry.
@@ -152,6 +156,8 @@ async function searchFile(filePath, queryLower, conversationId, projectName, dec
 export async function searchConversations(query, opts = {}) {
   const trimmed = (query || '').trim()
   if (!trimmed) return []
+  // #6448 — reject an over-long query rather than substring-scan every file with it.
+  if (trimmed.length > MAX_QUERY_LENGTH) return []
 
   const queryLower = trimmed.toLowerCase()
   const projectsDir = opts.projectsDir || PROJECTS_DIR

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -20,6 +20,13 @@ export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch'
 // Default permission timeout (5 minutes)
 const DEFAULT_TIMEOUT_MS = 300_000
 
+// #6448 — resource-limit caps (DoS hardening). A normal session sits far below
+// all of these; they only bite under a flood of requests or a malicious tool
+// input, where the alternative is unbounded memory/CPU growth.
+const MAX_PENDING_PERMISSIONS = 1000  // concurrent pending requests (each holds map entries + a timer)
+const MAX_SESSION_RULES = 100         // session-scoped auto-allow rules
+const MAX_RAW_DESCRIPTION_LEN = 8192  // raw tool field length fed to redactValue (far above the 200-char shown window)
+
 /**
  * Manages in-process permission requests for SDK-style sessions.
  *
@@ -36,10 +43,13 @@ const DEFAULT_TIMEOUT_MS = 300_000
  *   user_question       { toolUseId, questions }
  */
 export class PermissionManager extends EventEmitter {
-  constructor({ timeoutMs, log } = {}) {
+  constructor({ timeoutMs, log, maxPendingPermissions } = {}) {
     super()
     this._timeoutMs = timeoutMs || DEFAULT_TIMEOUT_MS
     this._log = log || console
+    // #6448 — bound on concurrent pending permissions; injectable so the cap is
+    // testable without minting 1000 real requests.
+    this._maxPendingPermissions = maxPendingPermissions || MAX_PENDING_PERMISSIONS
 
     this._pendingPermissions = new Map() // requestId -> { resolve, input }
     this._permissionTimers = new Map()   // requestId -> timer
@@ -77,6 +87,10 @@ export class PermissionManager extends EventEmitter {
   setRules(rules) {
     if (!Array.isArray(rules)) {
       throw new Error('rules must be an array')
+    }
+    // #6448 — bound the session rules array (it is matched on every tool call).
+    if (rules.length > MAX_SESSION_RULES) {
+      throw new Error(`too many rules (max ${MAX_SESSION_RULES})`)
     }
     for (const rule of rules) {
       if (!rule || typeof rule.tool !== 'string') {
@@ -178,6 +192,17 @@ export class PermissionManager extends EventEmitter {
 
     return new Promise((resolve) => {
       const requestId = `perm-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
+      // #6448 — bound concurrent pending permissions (each holds entries in
+      // _pendingPermissions / _permissionTimers / _lastPermissionData plus a
+      // live timer). A normal session has 1-2 pending; this only trips under a
+      // flood, where the incoming request is auto-denied rather than letting
+      // those grow unbounded. The per-request timeout (below) sweeps stuck old
+      // entries, so the cap + timeout together bound memory.
+      if (this._pendingPermissions.size >= this._maxPendingPermissions) {
+        this._logInfo(`Pending-permission cap (${this._maxPendingPermissions}) reached — auto-denying ${requestId}`)
+        resolve({ behavior: 'deny', message: 'Too many pending permission requests' })
+        return
+      }
       this._pendingPermissions.set(requestId, {
         resolve,
         input: input || {},
@@ -199,7 +224,12 @@ export class PermissionManager extends EventEmitter {
       // leave a secret straddling the cap as a sub-floor partial prefix that the
       // pattern scan misses. String() coerces a non-string field so a malformed
       // tool input can't crash the emit path (.replace on a non-string throws).
-      const description = redactValue(String(rawDescription)).slice(0, 200)
+      // #6448 — cap the raw string BEFORE redaction so a malicious multi-MB tool
+      // field can't make redactValue scan the whole thing (CPU DoS). The 8KB cap
+      // is far above the 200-char shown window below, so it can never split a
+      // SHOWN secret — the #6038 redact-then-truncate guarantee holds for
+      // everything the client sees (anything past 8KB is sliced away regardless).
+      const description = redactValue(String(rawDescription).slice(0, MAX_RAW_DESCRIPTION_LEN)).slice(0, 200)
 
       this._logInfo(`Permission request ${requestId}: ${toolName}`)
 

--- a/packages/server/tests/conversation-search.test.js
+++ b/packages/server/tests/conversation-search.test.js
@@ -29,6 +29,12 @@ describe('conversation-search', () => {
     await rm(tmpDir, { recursive: true, force: true })
   })
 
+  // #6448 — bound the query length (every candidate file is substring-scanned).
+  it('returns [] for a query longer than the max length (DoS guard)', async () => {
+    const res = await searchConversations('x'.repeat(501))
+    assert.deepEqual(res, [])
+  })
+
   describe('extractSearchableText', () => {
     it('extracts text from user message with array content', () => {
       const entry = { type: 'user', message: { content: [{ type: 'text', text: 'hello world' }] } }

--- a/packages/server/tests/permission-manager-resource-caps.test.js
+++ b/packages/server/tests/permission-manager-resource-caps.test.js
@@ -52,4 +52,20 @@ describe('PermissionManager resource-limit caps (#6448)', () => {
     pm.destroy()
     await p
   })
+
+  it('a secret straddling the 8KB pre-cap boundary is never shown (review #6455 — pins the boundary)', async () => {
+    const pm = new PermissionManager({ timeoutMs: 60_000 })
+    let emitted = null
+    pm.on('permission_request', (p) => { emitted = p })
+    const secret = 'sk-ant-api03-' + 'A1b2C3d4e5'.repeat(5)
+    // Place the secret straddling the 8192-char pre-cap boundary. It is far past
+    // the 200-char shown window, so it is sliced away regardless of the cap — the
+    // pre-cap can only ever remove content that was already destined to be cut.
+    const huge = 'x'.repeat(8185) + secret + 'y'.repeat(1000)
+    const p = pm.handlePermission('Bash', { description: huge }, null, 'approve')
+    assert.ok(emitted.description.length <= 200, 'shown window stays bounded')
+    assert.ok(!emitted.description.includes('sk-ant-api03'), 'a secret past the shown window never appears')
+    pm.destroy()
+    await p
+  })
 })

--- a/packages/server/tests/permission-manager-resource-caps.test.js
+++ b/packages/server/tests/permission-manager-resource-caps.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PermissionManager } from '../src/permission-manager.js'
+
+/**
+ * #6448 — resource-limit caps (DoS hardening) on PermissionManager:
+ *   - concurrent pending permissions (bounds the maps + the per-request timers)
+ *   - session-rules array length
+ *   - raw tool-description length fed to redactValue (CPU)
+ */
+describe('PermissionManager resource-limit caps (#6448)', () => {
+  it('auto-denies a new permission request once the pending cap is reached', async () => {
+    const pm = new PermissionManager({ maxPendingPermissions: 2, timeoutMs: 60_000 })
+    // Two requests stay pending (never answered).
+    const p1 = pm.handlePermission('Bash', { command: 'a' }, null, 'approve')
+    const p2 = pm.handlePermission('Bash', { command: 'b' }, null, 'approve')
+    assert.equal(pm._pendingPermissions.size, 2, 'two requests are pending')
+
+    // The third trips the cap → auto-denied immediately, NOT added to the map.
+    const r3 = await pm.handlePermission('Bash', { command: 'c' }, null, 'approve')
+    assert.equal(r3.behavior, 'deny')
+    assert.match(r3.message, /too many pending/i)
+    assert.equal(pm._pendingPermissions.size, 2, 'the over-cap request is not added')
+
+    pm.destroy() // resolves p1/p2 (auto-deny) + clears their timers
+    await Promise.all([p1, p2])
+  })
+
+  it('rejects setRules with more than the max session rules', () => {
+    const pm = new PermissionManager()
+    const tooMany = Array.from({ length: 101 }, () => ({ tool: 'Read', decision: 'allow' }))
+    assert.throws(() => pm.setRules(tooMany), /too many rules/i)
+    const atCap = Array.from({ length: 100 }, () => ({ tool: 'Read', decision: 'allow' }))
+    assert.doesNotThrow(() => pm.setRules(atCap), 'exactly the cap is allowed')
+    pm.destroy()
+  })
+
+  it('caps a huge tool description before redaction (output bounded + secret still redacted)', async () => {
+    const pm = new PermissionManager({ timeoutMs: 60_000 })
+    let emitted = null
+    pm.on('permission_request', (p) => { emitted = p })
+    // A 5MB description with a real-shape Anthropic key near the start — redaction
+    // must run on the capped prefix, the shown window stays bounded, and the
+    // secret (within the shown window) must still be redacted.
+    const secret = 'sk-ant-api03-' + 'A1b2C3d4e5'.repeat(5) // >=40 chars after the prefix → matches the redact pattern
+    const huge = secret + ' ' + 'x'.repeat(5 * 1024 * 1024)
+    const p = pm.handlePermission('Bash', { description: huge }, null, 'approve')
+    assert.ok(emitted, 'permission_request emitted synchronously')
+    assert.ok(emitted.description.length <= 200, 'shown description stays bounded')
+    assert.ok(!emitted.description.includes('sk-ant-api03'), 'the secret is redacted in the shown window')
+
+    pm.destroy()
+    await p
+  })
+})


### PR DESCRIPTION
Closes #6448 (convergence-audit hardening cluster — 5 findings).

Bound four unbounded growth / unvalidated-length vectors. All are **defence-in-depth**: a normal session sits far below every cap, and each only trips under a flood of requests or a malicious tool input.

## Caps
| Cap | Where | Bound |
|-----|-------|-------|
| Concurrent **pending permissions** | `permission-manager.js` `handlePermission` | 1000 — covers the unbounded `_pendingPermissions`/`_permissionTimers`/`_lastPermissionData` maps **and** the per-request timer (they're 1:1). Over-cap → auto-deny; the per-request timeout sweeps stuck old entries. |
| **Session rules** array | `setRules()` | 100 (it's matched on every tool call) |
| Raw tool **description** length | before `redactValue` | 8 KB |
| Search **query** length | `conversation-search.js` | 500 chars |

## The description cap and #6038 (read this)
The description is `redactValue(raw).slice(0, 200)` — redact-then-truncate **on purpose** (#6038/#6048: truncating first could leave a secret straddling the cap un-redacted). A multi-MB `raw` makes `redactValue` scan the whole thing (CPU DoS). Fix: cap `raw` to **8 KB before** redaction. 8 KB is **40× the 200-char shown window**, so it can never split a *shown* secret — the #6038 guarantee holds for everything the client sees (anything past 8 KB is sliced away regardless). The existing #6048 straddle test still passes with the change.

## Verified
+5 tests (pending-cap auto-deny + map-not-grown; setRules >100 throws / 100 ok; 5 MB description → bounded + secret still redacted; over-long query → []). `permission-*` (240) + `conversation-search` + `permission-broadcast-redaction` suites green; server custom lints pass.

From the convergence-audit backlog (#6448).