### PR TITLE
feat(app): expose the LockScreen unlock control to screen readers

### DIFF
--- a/packages/app/src/components/LockScreen.tsx
+++ b/packages/app/src/components/LockScreen.tsx
@@ -22,7 +22,15 @@ export function LockScreen({ onUnlock }: LockScreenProps) {
         <Text style={styles.icon}>{'🔒'}</Text>
         <Text style={styles.title}>Chroxy is Locked</Text>
         <Text style={styles.subtitle}>Authenticate to continue</Text>
-        <TouchableOpacity style={styles.button} onPress={onUnlock}>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={onUnlock}
+          // #6450 — the lock gate blocks all app interaction, so the unlock
+          // control must be identifiable + actionable by screen-reader users.
+          accessibilityRole="button"
+          accessibilityLabel="Unlock Chroxy"
+          accessibilityHint="Authenticate with biometrics to continue"
+        >
           <Text style={styles.buttonText}>Unlock</Text>
         </TouchableOpacity>
       </View>

--- a/packages/app/src/components/__tests__/LockScreen.test.tsx
+++ b/packages/app/src/components/__tests__/LockScreen.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { LockScreen } from '../LockScreen';
+
+/**
+ * #6450 — the lock gate blocks all app interaction, so the unlock control must be
+ * identifiable + actionable by screen-reader users (role + label + hint).
+ */
+describe('LockScreen a11y (#6450)', () => {
+  let tree: renderer.ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (tree) {
+      act(() => { tree!.unmount(); });
+      tree = null;
+    }
+  });
+
+  it('exposes the unlock control to screen readers (role + label + hint)', () => {
+    act(() => {
+      tree = renderer.create(<LockScreen onUnlock={async () => true} />);
+    });
+    const btn = tree!.root.findByProps({ accessibilityLabel: 'Unlock Chroxy' });
+    expect(btn.props.accessibilityRole).toBe('button');
+    expect(btn.props.accessibilityHint).toMatch(/authenticate|biometric/i);
+  });
+});


### PR DESCRIPTION
Closes #6450.

The biometric lock gate (`LockScreen`) blocks **all** app interaction, but the unlock `TouchableOpacity` had no accessibility props — a screen-reader user couldn't identify or activate it. Add `accessibilityRole="button"`, `accessibilityLabel="Unlock Chroxy"`, and an `accessibilityHint` (authenticate with biometrics). +1 test (asserts role + label + hint); tsc clean.

From the convergence-audit backlog (#6450).