### PR TITLE
fix(dashboard): surface swallowed Tauri listener errors instead of dropping them

### DIFF
--- a/packages/dashboard/src/hooks/useTauriEvents.test.ts
+++ b/packages/dashboard/src/hooks/useTauriEvents.test.ts
@@ -233,4 +233,20 @@ describe('useTauriEvents', () => {
     await new Promise(r => setTimeout(r, 10))
     expect(unlisten).toHaveBeenCalled()
   })
+
+  it('surfaces (warns) a rejected listen() registration on cleanup, not silently (#6452)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Every listen() rejects (registration failed) instead of resolving an unlisten fn.
+    Object.defineProperty(window, '__TAURI__', {
+      value: { event: { listen: vi.fn(() => Promise.reject(new Error('registration failed'))) } },
+      writable: true,
+      configurable: true,
+    })
+    const { unmount } = renderHook(() => useTauriEvents())
+    unmount()
+    await new Promise(r => setTimeout(r, 10))
+    expect(warnSpy).toHaveBeenCalled()
+    expect(warnSpy.mock.calls.some(c => String(c[0]).includes('useTauriEvents'))).toBe(true)
+    warnSpy.mockRestore()
+  })
 })

--- a/packages/dashboard/src/hooks/useTauriEvents.ts
+++ b/packages/dashboard/src/hooks/useTauriEvents.ts
@@ -117,7 +117,15 @@ export function useTauriEvents() {
     )
 
     return () => {
-      unlisteners.forEach(p => p.then(fn => fn()).catch(() => {}))
+      // #6452 — surface (don't swallow) a failure here: a rejected listen()
+      // promise (the event was never registered) or an unlisten throw. Each is
+      // caught independently so cleanup never throws, but it's now observable
+      // instead of silently disappearing.
+      unlisteners.forEach(p =>
+        p.then(fn => fn()).catch((err) => {
+          console.warn('[useTauriEvents] listener registration/cleanup failed:', err)
+        }),
+      )
     }
   }, [])
 }


### PR DESCRIPTION
Closes #6452.

`useTauriEvents` cleanup did `unlisteners.forEach(p => p.then(fn => fn()).catch(() => {}))` — the `.catch(() => {})` silently swallowed both a **rejected `listen()`** (the event was never registered) and an **unlisten throw**, leaving no trace of a broken Tauri event wiring. Replace it with a `console.warn`; each promise is still caught independently so cleanup never throws — the failure is just observable now. +1 test (a rejecting `listen()` → warned on cleanup). tsc clean.

From the convergence-audit backlog (#6452).