### PR TITLE
feat(app): confirm before opening a markdown link (anti-phishing)

### DIFF
--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, Text, StyleSheet, Platform, Linking, StyleProp, TextStyle, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, Platform, Linking, Alert, StyleProp, TextStyle, ScrollView } from 'react-native';
 import { ICON_BULLET, ICON_CHECKBOX_CHECKED, ICON_CHECKBOX_UNCHECKED } from '../constants/icons';
 import { COLORS } from '../constants/colors';
 import { tokenize, SYNTAX_COLORS } from '../utils/syntax';
@@ -69,8 +69,15 @@ export function splitContentBlocks(rawContent: string): ContentBlock[] {
   return blocks;
 }
 
-/** Safe URL opener with scheme validation and error handling */
-function openURL(url: string) {
+/**
+ * Safe URL opener with scheme validation + a confirmation prompt.
+ *
+ * #6447 — links in rendered markdown come from the server (Claude responses and
+ * tool output), which a malicious server or MITM could inject. Confirm before
+ * opening and show the FULL destination URL so the user can spot a phishing link,
+ * rather than silently navigating away. Exported for unit testing.
+ */
+export function openURL(url: string) {
   // Strip trailing punctuation that shouldn't be part of the URL
   const cleanUrl = url.replace(/[.,;!?)\]]+$/, '');
 
@@ -80,9 +87,22 @@ function openURL(url: string) {
     return;
   }
 
-  void Linking.openURL(cleanUrl).catch((err) => {
-    console.error('Failed to open URL:', cleanUrl, err);
-  });
+  Alert.alert(
+    'Open link?',
+    cleanUrl,
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Open',
+        onPress: () => {
+          void Linking.openURL(cleanUrl).catch((err) => {
+            console.error('Failed to open URL:', cleanUrl, err);
+          });
+        },
+      },
+    ],
+    { cancelable: true },
+  );
 }
 
 /** Generate indentation whitespace based on nesting level.

--- a/packages/app/src/components/__tests__/MarkdownRenderer.openURL.test.ts
+++ b/packages/app/src/components/__tests__/MarkdownRenderer.openURL.test.ts
@@ -1,0 +1,46 @@
+import { Alert, Linking } from 'react-native';
+import { openURL } from '../MarkdownRenderer';
+
+/**
+ * #6447 — markdown links come from the server (Claude responses / tool output),
+ * which a malicious server or MITM could inject. openURL must confirm + show the
+ * full destination URL before navigating, not open silently.
+ */
+describe('MarkdownRenderer openURL link confirmation (#6447)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks(); // RN mocks Linking.openURL as a shared jest.fn — clear leaked calls
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('confirms with the full URL before opening; opens only on the Open action', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const openSpy = jest.spyOn(Linking, 'openURL').mockImplementation(() => Promise.resolve());
+
+    openURL('http://evil.example.com/phish');
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).not.toHaveBeenCalled(); // not opened until the user confirms
+    const call = alertSpy.mock.calls[0] as unknown as [string, string, Array<{ text: string; onPress?: () => void }>];
+    expect(call[0]).toMatch(/open link/i);
+    expect(call[1]).toBe('http://evil.example.com/phish'); // full URL shown for phishing-spotting
+
+    call[2].find((b) => b.text === 'Open')?.onPress?.();
+    expect(openSpy).toHaveBeenCalledWith('http://evil.example.com/phish');
+  });
+
+  it('strips trailing punctuation before confirming', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    openURL('https://example.com/page).');
+    expect((alertSpy.mock.calls[0] as unknown[])[1]).toBe('https://example.com/page');
+  });
+
+  it('rejects a non-http(s) scheme without prompting or opening', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const openSpy = jest.spyOn(Linking, 'openURL').mockImplementation(() => Promise.resolve());
+    openURL('javascript:alert(1)');
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #6447.

## Problem
Markdown links (rendered in chat from Claude responses + tool output) were opened **silently** via `Linking.openURL` after a scheme check. A malicious server or MITM could inject a phishing link the user taps without seeing where it goes.

## Fix
`openURL` now shows an `Alert` titled *Open link?* with the **full destination URL** as the body, and opens only when the user taps **Open** (Cancel by default / on backdrop). http/https scheme validation is unchanged and still runs first. `openURL` is exported for unit testing.

## UX note (your call confirmed)
This adds a confirm dialog on **every** in-chat link tap — the standard anti-phishing posture (show the URL before navigating). If you'd prefer a lighter touch later (e.g. only confirm for external/unfamiliar domains, or a long-press-to-preview), that's an easy follow-up; this ships the safe default.

## Verified
+3 tests (confirms with the full URL before opening; opens only on the Open action; strips trailing punctuation; rejects non-http(s) without prompting). tsc clean.

From the convergence-audit backlog (#6447).