### PR TITLE
fix(app): roll back the orphaned 'Queued' badge when a send fails outright

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -821,22 +821,13 @@ export function SessionScreen() {
         content: 'Message queued — waiting for reconnection...',
         timestamp: Date.now(),
       });
-    } else if (result === false) {
-      // #6451 — the send AND the offline-enqueue both failed (offline queue
-      // full), so the message never left. If we optimistically showed a 'Queued'
-      // badge (busy / send-while-streaming), no server message_queued/dequeued
-      // will ever reconcile it — roll it back so it doesn't linger forever, and
-      // tell the user the send failed.
-      const store = useConnectionStore.getState();
-      if (busy && (viewMode === 'chat' || viewMode === 'files')) {
-        store.clearOptimisticQueuedMessage(clientMessageId);
-      }
-      store.addMessage({
-        id: `send-failed-${Date.now()}`,
-        type: 'system',
-        content: "Couldn't send — the message queue is full. Reconnect and try again.",
-        timestamp: Date.now(),
-      });
+    } else if (result === false && busy && (viewMode === 'chat' || viewMode === 'files')) {
+      // #6451 — the send AND the offline-enqueue both failed (queue full), so no
+      // server message_queued/dequeued will reconcile the optimistic 'Queued'
+      // badge we added when busy — roll it back so it doesn't linger forever.
+      // (enqueueMessage already surfaced a 'couldn't queue' system message via
+      // notifyQueueFailure, so we don't add a duplicate notice here.)
+      useConnectionStore.getState().clearOptimisticQueuedMessage(clientMessageId);
     }
   };
   // Refresh the live implementation each render, then expose a stable wrapper.

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -821,6 +821,22 @@ export function SessionScreen() {
         content: 'Message queued — waiting for reconnection...',
         timestamp: Date.now(),
       });
+    } else if (result === false) {
+      // #6451 — the send AND the offline-enqueue both failed (offline queue
+      // full), so the message never left. If we optimistically showed a 'Queued'
+      // badge (busy / send-while-streaming), no server message_queued/dequeued
+      // will ever reconcile it — roll it back so it doesn't linger forever, and
+      // tell the user the send failed.
+      const store = useConnectionStore.getState();
+      if (busy && (viewMode === 'chat' || viewMode === 'files')) {
+        store.clearOptimisticQueuedMessage(clientMessageId);
+      }
+      store.addMessage({
+        id: `send-failed-${Date.now()}`,
+        type: 'system',
+        content: "Couldn't send — the message queue is full. Reconnect and try again.",
+        timestamp: Date.now(),
+      });
     }
   };
   // Refresh the live implementation each render, then expose a stable wrapper.

--- a/packages/app/src/store/__tests__/connection.clearOptimisticQueued.test.ts
+++ b/packages/app/src/store/__tests__/connection.clearOptimisticQueued.test.ts
@@ -1,0 +1,38 @@
+import { useConnectionStore } from '../connection';
+import { createEmptySessionState } from '../utils';
+
+/**
+ * #6451 — when a send fails outright (wsSend false AND the offline queue full),
+ * the optimistic 'Queued' badge would otherwise linger forever (no server
+ * message_queued/dequeued reconciles it). clearOptimisticQueuedMessage drops the
+ * stale badge locally while keeping the user's message bubble + other entries.
+ */
+describe('clearOptimisticQueuedMessage (#6451)', () => {
+  it('drops the badge by clientMessageId, keeping other entries + the user message', () => {
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          messages: [{ id: 'u1', type: 'user', content: 'hi', timestamp: 1 }],
+          queuedMessages: [
+            { clientMessageId: 'u1', text: 'hi', queuedAt: 1 },
+            { clientMessageId: 'u2', text: 'yo', queuedAt: 2 },
+          ],
+        },
+      },
+    } as never);
+
+    useConnectionStore.getState().clearOptimisticQueuedMessage('u1');
+
+    const ss = useConnectionStore.getState().sessionStates.s1;
+    expect(ss.queuedMessages?.find((q) => q.clientMessageId === 'u1')).toBeUndefined();
+    expect(ss.queuedMessages?.find((q) => q.clientMessageId === 'u2')).toBeDefined(); // other badge kept
+    expect(ss.messages.find((m) => m.id === 'u1')).toBeDefined(); // user's text bubble kept
+  });
+
+  it('is a no-op for an unknown / missing session', () => {
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} } as never);
+    expect(() => useConnectionStore.getState().clearOptimisticQueuedMessage('nope')).not.toThrow();
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1846,6 +1846,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return 'sent';
   },
 
+  // #6451 — locally drop an optimistic 'Queued' badge whose send failed outright
+  // (wsSend false AND the offline queue full), so the server will never send a
+  // message_queued/dequeued to reconcile it. Unlike sendCancelQueued this sends
+  // NOTHING (the message never reached the server) — it only clears the stale
+  // local badge so it can't linger forever. The user's message bubble is kept so
+  // their text stays visible; the caller surfaces a "couldn't send" notice.
+  clearOptimisticQueuedMessage: (clientMessageId: string, sessionId?: string) => {
+    const sid = sessionId ?? get().activeSessionId;
+    if (sid && get().sessionStates[sid]) {
+      updateSession(sid, (ss) => ({
+        queuedMessages: removeQueuedMessage(ss.queuedMessages ?? [], clientMessageId),
+      }));
+    }
+  },
+
   sendPermissionResponse: (requestId: string, decision: string) => {
     const { socket } = get();
     // #5699 — refuse to answer a permission prompt while disconnected, rather

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -488,6 +488,9 @@ export interface MessageInputActions {
   // #5938 (#5943) — cancel one queued follow-up by its clientMessageId before
   // it flushes. Returns false (refused) while disconnected; never offline-queued.
   sendCancelQueued: (clientMessageId: string, sessionId?: string) => 'sent' | false;
+  // #6451 — locally drop an optimistic 'Queued' badge whose send failed outright
+  // (no server confirm/dequeue will arrive), so it can't linger forever.
+  clearOptimisticQueuedMessage: (clientMessageId: string, sessionId?: string) => void;
   sendPermissionResponse: (requestId: string, decision: string) => 'sent' | 'queued' | false;
   /**
    * Send a `user_question_response` answer to the server.


### PR DESCRIPTION
Closes #6451.

## Bug
When a message is sent **while a turn is streaming** (`busy`), `addUserMessage({ queued: true })` adds an optimistic **'Queued' badge** before `sendInput` runs. `sendInput` returns `'sent'` / `'queued'` / `false`. On `false` — `wsSend` failed (OPEN→CLOSING TOCTOU) **and** the offline queue is full (`QUEUE_MAX_SIZE`) — the message never reaches the server, so **no `message_queued`/`message_dequeued` ever arrives to reconcile the badge**. It lingers forever as a phantom 'Queued'. (Doubly-rare, so this is defence-in-depth, but the badge promise — "this will flush" — is broken.)

## Fix
- New **local** store method `clearOptimisticQueuedMessage(clientMessageId)` — unlike `sendCancelQueued` it sends **nothing** (the message never reached the server); it just drops the stale badge. It **keeps the user's message bubble** so their text stays visible (and other queued entries untouched).
- `SessionScreen` now handles `result === false`: if a badge was shown (`busy` + chat/files view) it rolls it back, and either way surfaces a **'couldn't send — queue full'** system message (mirroring the existing `'queued'` notification) so the failure isn't silent.

Scoped to the streaming/`busy` path (the only one that adds this badge); the non-busy path's optimistic 'pending' state is already swept by its safety-net timer.

## Verified
+2 tests (drops the badge by id, keeps other entries + the user bubble; no-op for an unknown session). connection / SessionScreen / queue suites (396) green; tsc clean.

From the convergence-audit backlog (#6451).