### PR TITLE
refactor(protocol): single-source the WIRE attachment type (was ad-hoc in app + dashboard)

### DIFF
--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -9,6 +9,10 @@
  * Platform-specific types (SessionState, ConnectionState) are defined here.
  */
 
+// #6453 — canonical WIRE attachment type for the sendInput signature (was an
+// inline `{ type; mediaType; data; name }[]`; the app only sends binary).
+import type { BinaryAttachment } from '@chroxy/protocol';
+
 // Re-export shared protocol types from store-core
 export type {
   MessageAttachment,
@@ -483,7 +487,7 @@ export interface MessageInputActions {
   // and seed an optimistic `queuedMessages` entry (rendered with a "Queued"
   // badge) instead of starting a fresh turn.
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
-  sendInput: (input: string, wireAttachments?: { type: string; mediaType: string; data: string; name: string }[], options?: { isVoice?: boolean; clientMessageId?: string }) => 'sent' | 'queued' | false;
+  sendInput: (input: string, wireAttachments?: BinaryAttachment[], options?: { isVoice?: boolean; clientMessageId?: string }) => 'sent' | 'queued' | false;
   sendInterrupt: () => 'sent' | 'queued' | false;
   // #5938 (#5943) — cancel one queued follow-up by its clientMessageId before
   // it flushes. Returns false (refused) while disconnected; never offline-queued.

--- a/packages/app/src/utils/attachments.ts
+++ b/packages/app/src/utils/attachments.ts
@@ -2,6 +2,10 @@ import * as ImagePicker from 'expo-image-picker';
 import * as DocumentPicker from 'expo-document-picker';
 import { readAsStringAsync } from 'expo-file-system';
 import { Alert } from 'react-native';
+// #6453 — the WIRE shape `toWireAttachments` produces is the protocol's canonical
+// `BinaryAttachment` (the local `Attachment` below is the device-side picker type:
+// id, uri, size — those stay client-side and never cross the socket).
+import type { BinaryAttachment } from '@chroxy/protocol';
 
 // -- Types --
 
@@ -166,7 +170,7 @@ export function formatFileSize(bytes: number): string {
 }
 
 /** Build the wire-format attachments array for the WebSocket message */
-export function toWireAttachments(attachments: Attachment[]): { type: string; mediaType: string; data: string; name: string }[] {
+export function toWireAttachments(attachments: Attachment[]): BinaryAttachment[] {
   return attachments
     .filter((a) => a.data != null)
     .map((a) => ({

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -1262,7 +1262,9 @@ export interface ConnectionState {
   // control). Best-effort; the server enforces the single-driver authority.
   sendTerminalInput: (sessionId: string, data: string) => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
-  sendInput: (input: string, wireAttachments?: { type: string; name: string; [key: string]: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
+  // #6453 — canonical WIRE attachment type (was an inline loose shape with a
+  // `[key: string]: string` index); the dashboard sends both file_ref + image.
+  sendInput: (input: string, wireAttachments?: Attachment[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
   /**
    * Interrupt the current turn. Defaults to the active session; pass an explicit
    * `sessionId` to interrupt a specific session (e.g. the Control Room

--- a/packages/dashboard/src/utils/attachment-utils.ts
+++ b/packages/dashboard/src/utils/attachment-utils.ts
@@ -2,12 +2,9 @@
  * Attachment utilities — convert InputBar attachment types to WS wire format (#1304).
  */
 import type { FileAttachment, ImageAttachment } from '../components/InputBar'
-
-export interface WireAttachment {
-  type: string
-  name: string
-  [key: string]: string
-}
+// #6453 — canonical wire shape, single-sourced from the protocol schemas (was a
+// loose local `WireAttachment` interface with a `[key: string]: string` index).
+import type { Attachment } from '@chroxy/protocol'
 
 /**
  * Convert file and image attachments to WebSocket wire format.
@@ -16,8 +13,8 @@ export interface WireAttachment {
 export function toWireAttachments(
   files?: FileAttachment[],
   images?: ImageAttachment[],
-): WireAttachment[] {
-  const result: WireAttachment[] = []
+): Attachment[] {
+  const result: Attachment[] = []
 
   if (files) {
     for (const f of files) {

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -80,4 +80,5 @@ export type { RunnerStatusRequestMessage } from './schemas/client.ts';
 export type { IntegrationStatusRequestMessage } from './schemas/client.ts';
 export type { IntegrationActionMessage } from './schemas/client.ts';
 export type { SkillsInventoryRequestMessage } from './schemas/client.ts';
+export type { Attachment, BinaryAttachment, FileRefAttachment } from './schemas/client.ts';
 export * from './error-categories.ts';

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -14,6 +14,36 @@
  * are). This keeps server and client schemas on a single sanity ceiling.
  */
 import { z } from 'zod';
+declare const BinaryAttachmentSchema: z.ZodObject<{
+    type: z.ZodEnum<{
+        image: "image";
+        document: "document";
+    }>;
+    mediaType: z.ZodString;
+    data: z.ZodString;
+    name: z.ZodString;
+}, z.core.$strip>;
+declare const FileRefAttachmentSchema: z.ZodObject<{
+    type: z.ZodLiteral<"file_ref">;
+    path: z.ZodString;
+    name: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
+declare const AttachmentSchema: z.ZodUnion<readonly [z.ZodObject<{
+    type: z.ZodEnum<{
+        image: "image";
+        document: "document";
+    }>;
+    mediaType: z.ZodString;
+    data: z.ZodString;
+    name: z.ZodString;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"file_ref">;
+    path: z.ZodString;
+    name: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>]>;
+export type BinaryAttachment = z.infer<typeof BinaryAttachmentSchema>;
+export type FileRefAttachment = z.infer<typeof FileRefAttachmentSchema>;
+export type Attachment = z.infer<typeof AttachmentSchema>;
 export declare const AuthSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth">;
     token: z.ZodString;
@@ -1333,3 +1363,4 @@ export type SessionPresetRevokeMessage = z.infer<typeof SessionPresetRevokeSchem
 export type ClaimPrimaryMessage = z.infer<typeof ClaimPrimarySchema>;
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
 export type EncryptedEnvelope = z.infer<typeof EncryptedEnvelopeSchema>;
+export {};

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -169,6 +169,9 @@ export type { IntegrationStatusRequestMessage } from './schemas/client.ts'
 export type { IntegrationActionMessage } from './schemas/client.ts'
 // #5554: skills inventory survey request alias.
 export type { SkillsInventoryRequestMessage } from './schemas/client.ts'
+// #6453: canonical WIRE attachment types pinned at the entry point so the app +
+// dashboard import one shape (was a loose `WireAttachment` / inline ad-hoc type).
+export type { Attachment, BinaryAttachment, FileRefAttachment } from './schemas/client.ts'
 
 // Re-export client-side error-category detection (#3151)
 export * from './error-categories.ts'

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -31,6 +31,14 @@ const FileRefAttachmentSchema = z.object({
 
 const AttachmentSchema = z.union([BinaryAttachmentSchema, FileRefAttachmentSchema])
 
+// #6453 — canonical WIRE attachment types, single-sourced from the schemas above
+// (was a loose `WireAttachment` in the dashboard + an inline type in the app).
+// Client-local picker types (device uri / id / size) stay client-side; this is
+// only the wire shape that crosses the socket.
+export type BinaryAttachment = z.infer<typeof BinaryAttachmentSchema>
+export type FileRefAttachment = z.infer<typeof FileRefAttachmentSchema>
+export type Attachment = z.infer<typeof AttachmentSchema>
+
 // -- Device info (optional in auth) --
 const DeviceInfoSchema = z.object({
   deviceId: z.string().max(256).optional(),


### PR DESCRIPTION
Closes #6453 (the last actionable dedup of the cluster; see disposition below).

## What
The WebSocket **wire** attachment shape was re-declared as ad-hoc inline types in three places:
- the dashboard's loose `WireAttachment` (`{ type, name, [key: string]: string }`),
- the app's inline `{ type; mediaType; data; name }[]` on `toWireAttachments` + `sendInput`,
- the dashboard's `sendInput` signature,

…while `@chroxy/protocol` already had the precise `AttachmentSchema` (`Binary | FileRef` union) but **exported no TS type**.

## How
Export canonical `Attachment` / `BinaryAttachment` / `FileRefAttachment` types from the protocol (`z.infer` of the existing schemas) and point all wire-conversion code at them:
- **app** → `BinaryAttachment[]` (mobile only sends binary),
- **dashboard** → the full `Attachment` union (it also sends `file_ref`).

Pinned **explicitly at the protocol barrel** (like the existing `*RequestMessage` aliases) because the two-hop `export *` drops type-only client re-exports.

**Device-local picker types are NOT touched** — the app's `Attachment` (id/uri/size) and the dashboard's `FileAttachment`/`ImageAttachment` legitimately differ from the wire shape and stay client-side.

## Verified
Type-only change (emitted JS identical). protocol **347** + dashboard attachment-utils **5** green; app + dashboard + protocol all typecheck clean.

## #6453 disposition (4 dedups → resolved)
- ✅ **formatQuestionAnswerSummary** → #6460 (merged).
- ✅ **wire Attachment type** → this PR.
- ⛔ **validators** — declined: `validatePort` (app-only), `validateWsUrl` + `validateImageFile` (dashboard-only) are three *different single-client* validators with *opposite* return contracts — scattered, **not duplicated**. A shared module gives zero reuse and co-locates opposite semantics (a copy-paste-bug magnet). Not worth forcing.
- ⛔ **createEmptySessionState** — declined: both already call store-core's `createEmptyBaseSessionState` and correctly add *different platform fields* (app: activityState; dashboard: terminal/file/thinking state). The divergence is intentional, not duplication.