### PR TITLE
refactor(store-core): migrate terminal-mirror cases to the shared dispatch table (#6449 slice 1)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -68,7 +68,6 @@ import {
   handlePermissionTimeout as sharedPermissionTimeout,
   // permission_rules_updated migrated to the shared dispatch table (#5556)
   // #5454 — remaining both-sides duplicates extracted into store-core
-  handleRawOutput as sharedRawOutput,
   handleTokenRotated as sharedTokenRotated,
   handlePairFail as sharedPairFail,
   // session_cost_threshold_crossed + notification_prefs migrated to the shared
@@ -1223,6 +1222,14 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
       updater(state as unknown as Record<string, unknown>) as Partial<ConnectionState>,
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
+  // #6449 slice 5 — terminal-mirror cases (raw/raw_background/terminal_output)
+  // migrated to the shared dispatch table. The app writes to BOTH the connection
+  // store and its secondary useTerminalStore (the dashboard omits the latter) —
+  // folding the prior switch cases' two writes into this one adapter primitive.
+  appendTerminalData: (data) => {
+    getStore().getState().appendTerminalData(data);
+    useTerminalStore.getState().appendTerminalData(data);
+  },
   getSessions: () => getStore().getState().sessions,
   // #5618 Batch 6 — checkpoint_created reads the prior flat list to append.
   getCheckpoints: () => getStore().getState().checkpoints,
@@ -2840,32 +2847,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // available_permission_modes — migrated to the shared dispatch table (#5556)
 
 
-    case 'raw': {
-      const { data: rawData } = sharedRawOutput(msg);
-      get().appendTerminalData(rawData);
-      useTerminalStore.getState().appendTerminalData(rawData);
-      break;
-    }
+    // raw — migrated to the shared dispatch table (#6449 slice 5; runDispatch
+    // handles it before this switch, via the appendTerminalData adapter hook).
 
-    // #5835 / #5987 — live PTY mirror channel. Unlike legacy 'raw' (claude-tui's
-    // headless output), terminal_output is the opt-in mirror stream for a
-    // user-shell ($SHELL) session subscribed via terminal_subscribe. Render it
-    // through the exact same write-callback → xterm path as 'raw' so user-shell
-    // output appears in TerminalView with no TerminalView changes. Read-only in
-    // PR1; interactive stdin (terminal_input) is deferred — see #6003.
-    case 'terminal_output': {
-      const data = msg.data;
-      if (typeof data !== 'string') break;
-      // Guard on the active session id (mirrors the dashboard handler): between
-      // an unsubscribe(old) and subscribe(new) during a session switch, a stale
-      // frame for the old session can still arrive — without this guard it would
-      // bleed into the new session's terminal (mobile renders one global
-      // terminalRawBuffer, so a mis-targeted frame paints the wrong shell).
-      if (typeof msg.sessionId !== 'string' || msg.sessionId !== get().activeSessionId) break;
-      get().appendTerminalData(data);
-      useTerminalStore.getState().appendTerminalData(data);
-      break;
-    }
+    // terminal_output — migrated to the shared dispatch table (#6449 slice 5).
+    // The live-PTY active-session guard (drop a stale frame whose sessionId isn't
+    // the active session) now lives in dispatchTerminalOutput, byte-identical.
 
     case 'claude_ready': {
       const patch = sharedClaudeReady();
@@ -2900,12 +2887,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
 
-    case 'raw_background': {
-      const { data: rawBgData } = sharedRawOutput(msg);
-      get().appendTerminalData(rawBgData);
-      useTerminalStore.getState().appendTerminalData(rawBgData);
-      break;
-    }
+    // raw_background — migrated to the shared dispatch table (#6449 slice 5).
 
     case 'permission_request': {
       const permPayload = sharedPermissionRequest(msg);

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1222,7 +1222,7 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
       updater(state as unknown as Record<string, unknown>) as Partial<ConnectionState>,
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
-  // #6449 slice 5 — terminal-mirror cases (raw/raw_background/terminal_output)
+  // #6449 slice 1 — terminal-mirror cases (raw/raw_background/terminal_output)
   // migrated to the shared dispatch table. The app writes to BOTH the connection
   // store and its secondary useTerminalStore (the dashboard omits the latter) —
   // folding the prior switch cases' two writes into this one adapter primitive.
@@ -2847,10 +2847,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // available_permission_modes — migrated to the shared dispatch table (#5556)
 
 
-    // raw — migrated to the shared dispatch table (#6449 slice 5; runDispatch
+    // raw — migrated to the shared dispatch table (#6449 slice 1; runDispatch
     // handles it before this switch, via the appendTerminalData adapter hook).
 
-    // terminal_output — migrated to the shared dispatch table (#6449 slice 5).
+    // terminal_output — migrated to the shared dispatch table (#6449 slice 1).
     // The live-PTY active-session guard (drop a stale frame whose sessionId isn't
     // the active session) now lives in dispatchTerminalOutput, byte-identical.
 
@@ -2887,7 +2887,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     // inactivity_warning — migrated to the shared dispatch table (#5556 slice 2)
 
-    // raw_background — migrated to the shared dispatch table (#6449 slice 5).
+    // raw_background — migrated to the shared dispatch table (#6449 slice 1).
 
     case 'permission_request': {
       const permPayload = sharedPermissionRequest(msg);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -63,7 +63,6 @@ import {
   handlePermissionRequest as sharedPermissionRequest,
   handlePermissionResolved as sharedPermissionResolved,
   handlePermissionTimeout as sharedPermissionTimeout,
-  handleRawOutput as sharedRawOutput,
   handleTokenRotated as sharedTokenRotated,
   handlePairFail as sharedPairFail,
   // session_cost_threshold_crossed / notification_prefs migrated to the shared
@@ -1043,6 +1042,10 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
       updater(state as unknown as Record<string, unknown>) as Partial<ConnectionState>,
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
+  // #6449 slice 5 — terminal-mirror cases (raw/raw_background/terminal_output)
+  // migrated to the shared dispatch table. The dashboard writes only the
+  // connection store (no secondary terminal store, unlike the app).
+  appendTerminalData: (data) => getStore().getState().appendTerminalData(data),
   // #5618 — budget_warning (and future notice types) surface a transient alert
   // via the dashboard's alert adapter.
   alert: (title, message) => _adapters.alert.alert(title, message),
@@ -1289,29 +1292,11 @@ function handlePong(msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _c
   _onPong(typeof msg.serverTs === 'number' ? msg.serverTs : undefined);
 }
 
-function handleRaw(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  get().appendTerminalData(sharedRawOutput(msg).data);
-}
-
-function handleRawBackground(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  get().appendTerminalData(sharedRawOutput(msg).data);
-}
-
-// #5835 (PR2): live claude-tui PTY mirror. The server delivers terminal_output
-// only to clients that opted in (terminal_subscribe) for a session they're
-// viewing — i.e. the active session whose Output tab is showing — so route the
-// raw bytes through appendTerminalData (active-session). Guard on the active id
-// anyway so a stale frame arriving just after a session switch can't paint the
-// new session's terminal.
-function handleTerminalOutput(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
-  if (typeof msg.data !== 'string') return;
-  // Require an explicit string sessionId that matches the active session. The
-  // server always stamps one (ws-forwarding.js); dropping a frame without one
-  // (malformed/legacy/empty) keeps it from bleeding into whatever terminal is
-  // currently active, matching the typeof guard the rest of this file uses.
-  if (typeof msg.sessionId !== 'string' || msg.sessionId !== get().activeSessionId) return;
-  get().appendTerminalData(msg.data);
-}
+// raw / raw_background / terminal_output — migrated to the shared dispatch table
+// (#6449 slice 5; runDispatch handles them before the HANDLERS map, via the
+// appendTerminalData adapter hook). terminal_output's active-session guard (drop
+// a stale frame whose sessionId isn't the active session) now lives in
+// dispatchTerminalOutput, byte-identical to the handler removed here.
 
 // #5835 Phase 2: the server's authoritative live-PTY grid size for a session
 // (sent on terminal_subscribe and on every primary-driven resize). Record it so
@@ -3116,9 +3101,8 @@ function handleBillingCanary(msg: Record<string, unknown>, get: MsgGet, set: Msg
 const HANDLERS: Record<string, Handler> = {
   billing_canary: handleBillingCanary,
   pong: handlePong,
-  raw: handleRaw,
-  raw_background: handleRawBackground,
-  terminal_output: handleTerminalOutput,
+  // raw / raw_background / terminal_output — migrated to the shared dispatch
+  // table (#6449 slice 5; runDispatch handles them before this HANDLERS map).
   terminal_size: handleTerminalSize,
   token_rotated: handleTokenRotated,
   pairing_refreshed: handlePairingRefreshed,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1042,7 +1042,7 @@ const _dispatchAdapter: ClientStoreAdapter<SessionState> = {
       updater(state as unknown as Record<string, unknown>) as Partial<ConnectionState>,
     ),
   addMessage: (m) => getStore().getState().addMessage(m),
-  // #6449 slice 5 — terminal-mirror cases (raw/raw_background/terminal_output)
+  // #6449 slice 1 — terminal-mirror cases (raw/raw_background/terminal_output)
   // migrated to the shared dispatch table. The dashboard writes only the
   // connection store (no secondary terminal store, unlike the app).
   appendTerminalData: (data) => getStore().getState().appendTerminalData(data),
@@ -1293,7 +1293,7 @@ function handlePong(msg: Record<string, unknown>, _get: MsgGet, _set: MsgSet, _c
 }
 
 // raw / raw_background / terminal_output — migrated to the shared dispatch table
-// (#6449 slice 5; runDispatch handles them before the HANDLERS map, via the
+// (#6449 slice 1; runDispatch handles them before the HANDLERS map, via the
 // appendTerminalData adapter hook). terminal_output's active-session guard (drop
 // a stale frame whose sessionId isn't the active session) now lives in
 // dispatchTerminalOutput, byte-identical to the handler removed here.
@@ -3102,7 +3102,7 @@ const HANDLERS: Record<string, Handler> = {
   billing_canary: handleBillingCanary,
   pong: handlePong,
   // raw / raw_background / terminal_output — migrated to the shared dispatch
-  // table (#6449 slice 5; runDispatch handles them before this HANDLERS map).
+  // table (#6449 slice 1; runDispatch handles them before this HANDLERS map).
   terminal_size: handleTerminalSize,
   token_rotated: handleTokenRotated,
   pairing_refreshed: handlePairingRefreshed,

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -88,6 +88,13 @@ export interface AdapterResult {
    * asserts they apply the SAME (url, previousUrl).
    */
   rotatedTunnelUrls: Array<{ url: string; previousUrl: string | null }>
+  /**
+   * Raw terminal-mirror writes via `appendTerminalData` (#6449 slice 5), in
+   * order — from the raw / raw_background / terminal_output cases. BOTH clients
+   * call it once per accepted frame (the app's extra useTerminalStore mirror is a
+   * platform side-effect below the hook), so the contract asserts identical writes.
+   */
+  terminalWrites: string[]
 }
 
 /** Which client an adapter models — drives the `updateSession` divergence. */
@@ -132,6 +139,7 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   const infoNotifications: string[] = []
   const switchedSessions: string[] = []
   const rotatedTunnelUrls: AdapterResult['rotatedTunnelUrls'] = []
+  const terminalWrites: string[] = []
 
   // Reproduce each client's real `updateSession`. Both share the
   // "no-op on missing session / empty patch" guard; they diverge only in the
@@ -166,6 +174,12 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     // live `flat` ref so the web-task upsert fixtures observe identical results.
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => added.push(m),
+    // #6449 slice 5 — terminal-mirror cases record one write per accepted frame.
+    // Both clients call this once; the app's extra useTerminalStore mirror is a
+    // platform side-effect below the hook, modelled as out-of-contract here.
+    appendTerminalData: (data) => {
+      terminalWrites.push(data)
+    },
     // #5618 — `alert` is a transient UI side-effect OUTSIDE the shared store-state
     // contract (no fixture asserts it), modelled as a no-op for the contract surface.
     alert: () => {},
@@ -285,7 +299,7 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
   return {
     adapter,
     get result(): AdapterResult {
-      return { sessions, flat, added, callbacks, serverErrors, infoNotifications, switchedSessions, rotatedTunnelUrls }
+      return { sessions, flat, added, callbacks, serverErrors, infoNotifications, switchedSessions, rotatedTunnelUrls, terminalWrites }
     },
     setActive: (id: string | null) => {
       activeSessionId = id

--- a/packages/store-core/src/contract-fixtures/client-adapters.ts
+++ b/packages/store-core/src/contract-fixtures/client-adapters.ts
@@ -89,7 +89,7 @@ export interface AdapterResult {
    */
   rotatedTunnelUrls: Array<{ url: string; previousUrl: string | null }>
   /**
-   * Raw terminal-mirror writes via `appendTerminalData` (#6449 slice 5), in
+   * Raw terminal-mirror writes via `appendTerminalData` (#6449 slice 1), in
    * order — from the raw / raw_background / terminal_output cases. BOTH clients
    * call it once per accepted frame (the app's extra useTerminalStore mirror is a
    * platform side-effect below the hook), so the contract asserts identical writes.
@@ -174,7 +174,7 @@ export function makeClientEnv(kind: ClientKind, init?: FixtureInitialState) {
     // live `flat` ref so the web-task upsert fixtures observe identical results.
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => added.push(m),
-    // #6449 slice 5 — terminal-mirror cases record one write per accepted frame.
+    // #6449 slice 1 — terminal-mirror cases record one write per accepted frame.
     // Both clients call this once; the app's extra useTerminalStore mirror is a
     // platform side-effect below the hook, modelled as out-of-contract here.
     appendTerminalData: (data) => {

--- a/packages/store-core/src/contract-fixtures/contract.test.ts
+++ b/packages/store-core/src/contract-fixtures/contract.test.ts
@@ -71,6 +71,7 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
     expect(result.infoNotifications, `${fx.name}: expected no addInfoNotification`).toHaveLength(0)
     expect(result.switchedSessions, `${fx.name}: expected no switchSession`).toHaveLength(0)
     expect(result.rotatedTunnelUrls, `${fx.name}: expected no applyRotatedTunnelUrl`).toHaveLength(0)
+    expect(result.terminalWrites, `${fx.name}: expected no appendTerminalData`).toHaveLength(0)
     // …and every seeded session is untouched beyond its shell: it must carry
     // only the keys it was seeded with (the `{ sessionId, messages }` shell plus
     // the fixture's own `init.sessions[id]` keys). A handler that wrote a NEW
@@ -126,6 +127,9 @@ function assertExpectation(result: AdapterResult, exp: FixtureExpectation, fx: C
   }
   if (exp.rotatedTunnelUrls) {
     expect(result.rotatedTunnelUrls, `${fx.name}: rotatedTunnelUrls`).toEqual(exp.rotatedTunnelUrls)
+  }
+  if (exp.terminalWrites) {
+    expect(result.terminalWrites, `${fx.name}: terminalWrites`).toEqual(exp.terminalWrites)
   }
 }
 

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -241,7 +241,7 @@ describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
     // migrating types OUT to the shared dispatch table (universe shrinks below
     // the floor) lowers it — adjust both bounds in the same PR. Keep the band
     // TIGHT around the real count so the "fail loudly" intent stays sharp. Band
-    // last lowered for #6449 slice 5 (raw / raw_background / terminal_output
+    // last lowered for #6449 slice 1 (raw / raw_background / terminal_output
     // migrated out to the shared dispatch table; universe down to 37).
     expect(both.length).toBeGreaterThanOrEqual(35)
     expect(both.length).toBeLessThanOrEqual(45)

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -241,11 +241,10 @@ describe('both-clients SWITCH_FIXTURES coverage lint (#5619)', () => {
     // migrating types OUT to the shared dispatch table (universe shrinks below
     // the floor) lowers it — adjust both bounds in the same PR. Keep the band
     // TIGHT around the real count so the "fail loudly" intent stays sharp. Band
-    // last lowered for #5618 (agent_idle / permission_mode_changed / budget_warning /
-    // plan_ready / rate_limited / server_shutdown / conversations_list /
-    // checkpoint_restored migrated out; universe down to 41).
-    expect(both.length).toBeGreaterThanOrEqual(39)
-    expect(both.length).toBeLessThanOrEqual(50)
+    // last lowered for #6449 slice 5 (raw / raw_background / terminal_output
+    // migrated out to the shared dispatch table; universe down to 37).
+    expect(both.length).toBeGreaterThanOrEqual(35)
+    expect(both.length).toBeLessThanOrEqual(45)
   })
 
   it('every both-clients switch type has a fixture, a PENDING entry, or a by-design exemption', () => {

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -182,7 +182,7 @@ function sysMsg(content: string): Partial<ChatMessage> {
 // ---------------------------------------------------------------------------
 
 export const DISPATCH_FIXTURES: ContractFixture[] = [
-  // --- slice 5 (#6449) — terminal-mirror pass-through. Moved here from
+  // --- slice 1 (#6449) — terminal-mirror pass-through. Moved here from
   // SWITCH_FIXTURES: raw / raw_background / terminal_output now live in the
   // shared dispatch table, so contract.test.ts drives them through runDispatch
   // (the contract adapter records one appendTerminalData write per accepted frame).

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -182,6 +182,43 @@ function sysMsg(content: string): Partial<ChatMessage> {
 // ---------------------------------------------------------------------------
 
 export const DISPATCH_FIXTURES: ContractFixture[] = [
+  // --- slice 5 (#6449) — terminal-mirror pass-through. Moved here from
+  // SWITCH_FIXTURES: raw / raw_background / terminal_output now live in the
+  // shared dispatch table, so contract.test.ts drives them through runDispatch
+  // (the contract adapter records one appendTerminalData write per accepted frame).
+  {
+    // #6345: raw PTY output. Both clients pass the shared handleRawOutput data
+    // (msg.data verbatim, '' on non-string) to get().appendTerminalData —
+    // unconditionally (no sessionId/active gate). The app also mirrors into the
+    // mocked useTerminalStore, but only the main-store write is captured, so both
+    // see exactly one identical write → a single terminalWrites expect. (Plain
+    // ASCII data — the contract is "verbatim pass-through"; the byte content is
+    // irrelevant and ANSI escapes only invite source-mangling.)
+    name: 'raw writes the PTY chunk to the terminal mirror, unconditionally (both clients)',
+    type: 'raw',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'raw', sessionId: 's1', data: 'raw-pty-chunk' },
+    expect: { terminalWrites: ['raw-pty-chunk'] },
+  },
+  {
+    // #6345: background-agent PTY output. Same as raw — unconditional verbatim
+    // get().appendTerminalData write in both clients; no gate, no init needed.
+    name: 'raw_background writes the decoded PTY chunk to the terminal mirror (both clients)',
+    type: 'raw_background',
+    message: { type: 'raw_background', data: 'background-agent-output' },
+    expect: { terminalWrites: ['background-agent-output'] },
+  },
+  {
+    // #6345: the opt-in live-PTY mirror channel (#5835). Both clients gate on
+    // typeof msg.data === 'string' AND msg.sessionId === activeSessionId, then write
+    // msg.data verbatim to get().appendTerminalData. Seed activeSessionId === the
+    // message sessionId so the active-id guard passes.
+    name: 'terminal_output writes the PTY chunk to the mirror for the active session (both clients)',
+    type: 'terminal_output',
+    init: { activeSessionId: 's1' },
+    message: { type: 'terminal_output', sessionId: 's1', data: 'term-line file.txt' },
+    expect: { terminalWrites: ['term-line file.txt'] },
+  },
   // 1. available_permission_modes — flat list replace
   {
     name: 'available_permission_modes sets the flat mode list when payload parses',
@@ -2402,38 +2439,5 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       app: { sessions: { s1: { messages: [] } } },
       dashboard: { sessions: { s1: { messages: [{ type: 'system', content: 'This action is bound to another session' }] } } },
     },
-  },
-  {
-    // #6345: raw PTY output. Both clients pass the shared handleRawOutput data
-    // (msg.data verbatim, '' on non-string) to get().appendTerminalData —
-    // unconditionally (no sessionId/active gate). The app also mirrors into the
-    // mocked useTerminalStore, but only the main-store write is captured, so both
-    // see exactly one identical write → a single terminalWrites expect. (Plain
-    // ASCII data — the contract is "verbatim pass-through"; the byte content is
-    // irrelevant and ANSI escapes only invite source-mangling.)
-    name: 'raw writes the PTY chunk to the terminal mirror, unconditionally (both clients)',
-    type: 'raw',
-    init: { activeSessionId: 's1', sessions: { s1: {} } },
-    message: { type: 'raw', sessionId: 's1', data: 'raw-pty-chunk' },
-    expect: { terminalWrites: ['raw-pty-chunk'] },
-  },
-  {
-    // #6345: background-agent PTY output. Same as raw — unconditional verbatim
-    // get().appendTerminalData write in both clients; no gate, no init needed.
-    name: 'raw_background writes the decoded PTY chunk to the terminal mirror (both clients)',
-    type: 'raw_background',
-    message: { type: 'raw_background', data: 'background-agent-output' },
-    expect: { terminalWrites: ['background-agent-output'] },
-  },
-  {
-    // #6345: the opt-in live-PTY mirror channel (#5835). Both clients gate on
-    // typeof msg.data === 'string' AND msg.sessionId === activeSessionId, then write
-    // msg.data verbatim to get().appendTerminalData. Seed activeSessionId === the
-    // message sessionId so the active-id guard passes.
-    name: 'terminal_output writes the PTY chunk to the mirror for the active session (both clients)',
-    type: 'terminal_output',
-    init: { activeSessionId: 's1' },
-    message: { type: 'terminal_output', sessionId: 's1', data: 'term-line file.txt' },
-    expect: { terminalWrites: ['term-line file.txt'] },
   },
 ]

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -145,6 +145,9 @@ function makeAdapter(init?: {
     setState: (patch) => Object.assign(flat, patch),
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => addedMessages.push(m),
+    // #6449 slice 5 — required by ClientStoreAdapter; this unit test doesn't
+    // exercise the terminal-mirror cases, so a no-op satisfies the contract.
+    appendTerminalData: () => {},
     alert: () => {},
     getSessions: () => sessionList,
     getCheckpoints: () => (flat.checkpoints as Checkpoint[] | undefined) ?? [],
@@ -242,10 +245,12 @@ describe('shared dispatch table', () => {
   describe('runner mechanics', () => {
     it('returns false (table miss) for an unregistered type so the caller falls through', () => {
       const env = makeAdapter()
-      // terminal_output is a terminal write, never a session-state update, so it is
-      // by-design NOT in the shared table (NO_SWITCH_CONTRACT_BY_DESIGN) — a clean
-      // miss → runDispatch returns false and the caller falls through to its switch.
-      expect(dispatch(env, { type: 'terminal_output', data: 'x' })).toBe(false)
+      // pong is handled by the heartbeat path (_onPong), never a store-state
+      // update, so it is by-design NOT in the shared table: a clean miss, so
+      // runDispatch returns false and the caller falls through to its switch.
+      // (terminal_output used to be the example here; it migrated INTO the table
+      // in #6449 slice 5, so this now uses a still-unregistered type.)
+      expect(dispatch(env, { type: 'pong', serverTs: 1 })).toBe(false)
     })
 
     it('returns false for a non-string type', () => {

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -145,7 +145,7 @@ function makeAdapter(init?: {
     setState: (patch) => Object.assign(flat, patch),
     updateState: (updater) => Object.assign(flat, updater(flat)),
     addMessage: (m) => addedMessages.push(m),
-    // #6449 slice 5 — required by ClientStoreAdapter; this unit test doesn't
+    // #6449 slice 1 — required by ClientStoreAdapter; this unit test doesn't
     // exercise the terminal-mirror cases, so a no-op satisfies the contract.
     appendTerminalData: () => {},
     alert: () => {},
@@ -249,7 +249,7 @@ describe('shared dispatch table', () => {
       // update, so it is by-design NOT in the shared table: a clean miss, so
       // runDispatch returns false and the caller falls through to its switch.
       // (terminal_output used to be the example here; it migrated INTO the table
-      // in #6449 slice 5, so this now uses a still-unregistered type.)
+      // in #6449 slice 1, so this now uses a still-unregistered type.)
       expect(dispatch(env, { type: 'pong', serverTs: 1 })).toBe(false)
     })
 

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -155,7 +155,7 @@ import {
   type GitStageResultPayload,
   type GitCommitResultPayload,
 } from './handlers'
-// #6449 slice 5 — shared raw-output parse for the terminal-mirror cases. The
+// #6449 slice 1 — shared raw-output parse for the terminal-mirror cases. The
 // './handlers' barrel doesn't re-export stream.ts, so import it directly.
 import { handleRawOutput } from './handlers/stream'
 
@@ -271,7 +271,7 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
   /** Append a chat message via the client's own add-message path. */
   addMessage(message: ChatMessage): void
   /**
-   * Append raw bytes to the client's terminal view (#6449 slice 5). Backs the
+   * Append raw bytes to the client's terminal view (#6449 slice 1). Backs the
    * terminal-mirror cases (`raw` / `raw_background` / `terminal_output`). Both
    * clients expose an `appendTerminalData(data)` store action; the APP impl ALSO
    * mirrors into its secondary `useTerminalStore` — a platform side-effect folded
@@ -921,7 +921,7 @@ export interface DispatchMessageMap {
     sessionId?: string
     checkpoints?: unknown[]
   }
-  // #6449 slice 5 — terminal-mirror pass-through cases (wire-shape optionality:
+  // #6449 slice 1 — terminal-mirror pass-through cases (wire-shape optionality:
   // raw_background carries no sessionId; the handlers guard defensively anyway).
   raw: {
     type: 'raw'
@@ -1996,7 +1996,7 @@ function dispatchMultiQuestionIntervention<S extends DispatchSessionBase>(
  * handlers are shared and identical.
  */
 // ---------------------------------------------------------------------------
-// slice 5 (#6449) — terminal-mirror pass-through (raw / raw_background /
+// slice 1 (#6449) — terminal-mirror pass-through (raw / raw_background /
 // terminal_output). All three are verbatim writes to the client's terminal view
 // via the single `appendTerminalData` adapter primitive; their both-clients
 // equivalence is gated by the #6345 SWITCH_FIXTURES the contract harness drives.
@@ -2128,7 +2128,7 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     // --- checkpoint cases (#5618 Batch 6) ---
     checkpoint_created: dispatchCheckpointCreated,
     checkpoint_list: dispatchCheckpointList,
-    // --- slice 5 (#6449) — terminal-mirror pass-through ---
+    // --- slice 1 (#6449) — terminal-mirror pass-through ---
     raw: dispatchRaw,
     raw_background: dispatchRawBackground,
     terminal_output: dispatchTerminalOutput,
@@ -2214,7 +2214,7 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   // --- checkpoint cases (#5618 Batch 6) ---
   'checkpoint_created',
   'checkpoint_list',
-  // --- slice 5 (#6449) — terminal-mirror pass-through ---
+  // --- slice 1 (#6449) — terminal-mirror pass-through ---
   'raw',
   'raw_background',
   'terminal_output',

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -155,6 +155,9 @@ import {
   type GitStageResultPayload,
   type GitCommitResultPayload,
 } from './handlers'
+// #6449 slice 5 — shared raw-output parse for the terminal-mirror cases. The
+// './handlers' barrel doesn't re-export stream.ts, so import it directly.
+import { handleRawOutput } from './handlers/stream'
 
 // ---------------------------------------------------------------------------
 // Client adapter
@@ -267,6 +270,15 @@ export interface ClientStoreAdapter<S extends DispatchSessionBase, Flat = Record
   updateState(updater: (flat: Flat) => Flat): void
   /** Append a chat message via the client's own add-message path. */
   addMessage(message: ChatMessage): void
+  /**
+   * Append raw bytes to the client's terminal view (#6449 slice 5). Backs the
+   * terminal-mirror cases (`raw` / `raw_background` / `terminal_output`). Both
+   * clients expose an `appendTerminalData(data)` store action; the APP impl ALSO
+   * mirrors into its secondary `useTerminalStore` — a platform side-effect folded
+   * into the adapter, in the same spirit as the push-store mirror in
+   * {@link ClientStoreAdapter.pushSessionNotification}.
+   */
+  appendTerminalData(data: string): void
   /**
    * Surface a transient alert/toast to the user (#5618). Both clients back this
    * with their own alert primitive (the app's React-Native `Alert.alert`, the
@@ -908,6 +920,22 @@ export interface DispatchMessageMap {
     type: 'checkpoint_list'
     sessionId?: string
     checkpoints?: unknown[]
+  }
+  // #6449 slice 5 — terminal-mirror pass-through cases (wire-shape optionality:
+  // raw_background carries no sessionId; the handlers guard defensively anyway).
+  raw: {
+    type: 'raw'
+    sessionId?: string
+    data?: string
+  }
+  raw_background: {
+    type: 'raw_background'
+    data?: string
+  }
+  terminal_output: {
+    type: 'terminal_output'
+    sessionId?: string
+    data?: string
   }
 }
 
@@ -1967,6 +1995,46 @@ function dispatchMultiQuestionIntervention<S extends DispatchSessionBase>(
  * `updateSession` updater typed against its own session shape; the underlying
  * handlers are shared and identical.
  */
+// ---------------------------------------------------------------------------
+// slice 5 (#6449) — terminal-mirror pass-through (raw / raw_background /
+// terminal_output). All three are verbatim writes to the client's terminal view
+// via the single `appendTerminalData` adapter primitive; their both-clients
+// equivalence is gated by the #6345 SWITCH_FIXTURES the contract harness drives.
+// ---------------------------------------------------------------------------
+
+/** `raw` — claude-tui headless output → terminal view (verbatim pass-through). */
+function dispatchRaw<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['raw'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  adapter.appendTerminalData(handleRawOutput(msg as Record<string, unknown>).data)
+}
+
+/** `raw_background` — background-agent output → terminal view (verbatim pass-through). */
+function dispatchRawBackground<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['raw_background'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  adapter.appendTerminalData(handleRawOutput(msg as Record<string, unknown>).data)
+}
+
+/**
+ * `terminal_output` — live PTY mirror for the ACTIVE session. Replicates both
+ * clients' guard exactly: drop a frame whose `data` isn't a string, or whose
+ * `sessionId` is missing / not the active session (a stale frame arriving across
+ * a session switch must not bleed into the new session's terminal). OWNS the
+ * message either way — the prior switch `break`/`return`ed without falling through.
+ */
+function dispatchTerminalOutput<S extends DispatchSessionBase>(
+  msg: DispatchMessageMap['terminal_output'],
+  adapter: ClientStoreAdapter<S>,
+): void {
+  const m = msg as Record<string, unknown>
+  if (typeof m.data !== 'string') return
+  if (typeof m.sessionId !== 'string' || m.sessionId !== adapter.getActiveSessionId()) return
+  adapter.appendTerminalData(m.data)
+}
+
 export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTable<S> {
   return {
     available_permission_modes: dispatchAvailablePermissionModes,
@@ -2060,6 +2128,10 @@ export function createDispatchTable<S extends DispatchSessionBase>(): DispatchTa
     // --- checkpoint cases (#5618 Batch 6) ---
     checkpoint_created: dispatchCheckpointCreated,
     checkpoint_list: dispatchCheckpointList,
+    // --- slice 5 (#6449) — terminal-mirror pass-through ---
+    raw: dispatchRaw,
+    raw_background: dispatchRawBackground,
+    terminal_output: dispatchTerminalOutput,
   }
 }
 
@@ -2142,6 +2214,10 @@ export const DISPATCH_TABLE_TYPES: readonly DispatchMessageType[] = [
   // --- checkpoint cases (#5618 Batch 6) ---
   'checkpoint_created',
   'checkpoint_list',
+  // --- slice 5 (#6449) — terminal-mirror pass-through ---
+  'raw',
+  'raw_background',
+  'terminal_output',
 ]
 
 /**


### PR DESCRIPTION
Part of #6449 (first incremental slice — does NOT close the issue; the campaign continues).

## What
`raw`, `raw_background`, and `terminal_output` were byte-identical terminal-write pass-throughs **duplicated** in both clients' `message-handler.ts`. They're the safest first slice because their both-clients equivalence is already **proven + CI-gated** by the #6345 `SWITCH_FIXTURES` (the contract harness drives them through `runDispatch` today).

## How
Migrate them into `@chroxy/store-core`'s dispatch table behind **one new adapter primitive**, `appendTerminalData(data: string)`:
- **dispatch-table.ts** — add `appendTerminalData` to `ClientStoreAdapter`; add `dispatchRaw` / `dispatchRawBackground` / `dispatchTerminalOutput` (the last replicating the active-session guard byte-for-byte, **owning the frame either way** — matching the prior `break`); register them + `DISPATCH_TABLE_TYPES`.
- **app + dashboard** — implement `appendTerminalData` on each live adapter (the **app** folds in its secondary `useTerminalStore` mirror — a platform side-effect below the hook; the **dashboard** writes only the connection store), delete the dead switch cases / HANDLERS entries, drop the now-unused `sharedRawOutput` import.
- **contract harness** — the 3 `SWITCH_FIXTURES` move to `DISPATCH_FIXTURES` (`contract.test.ts` now drives them through `runDispatch`); the contract adapter records `terminalWrites`; the both-clients-switch coverage band drops (40→37) for the 3 migrated types.

## Verified
- store-core **full suite 1919** (incl. byte-equivalence `contract.test.ts` + all 3 coverage-lint guards)
- protocol handler-coverage; app terminal-mirror + terminal-store + connection (**179**); dashboard contract-switch + message-handler (**293**)
- all packages typecheck clean. **Behaviour-preserving** — the #6345 fixtures keep asserting the same `terminalWrites`, now via the dispatch path.

## Next slices (tracked on #6449)
Same recipe widens from here (the analysis posted on #6449 lists the candidate clusters). Genuinely-divergent cases (activityState-deriving, dashboard flat dual-write) stay platform-local.