### PR TITLE
fix(dashboard): give read/search/web a distinct cyan in the presence rail (#6426)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -303,7 +303,7 @@ export function App() {
     return inFlight ? `Running ${formatToolName(inFlight.tool, inFlight.serverName)}…` : undefined
   }, [storeMessages])
 
-  // #6392 — color the presence rail by the in-flight tool's kind (Read=blue,
+  // #6392 — color the presence rail by the in-flight tool's kind (Read=cyan,
   // Bash=purple, Edit=orange…) via the shared tool-presentation registry, rather
   // than the generic 'busy' purple. A `var(--token)` string when a tool is
   // mid-flight, undefined otherwise → the rail falls back to its activity-state

--- a/packages/dashboard/src/theme/theme-engine.ts
+++ b/packages/dashboard/src/theme/theme-engine.ts
@@ -19,7 +19,7 @@ const ALL_CSS_VARS = [
   'bg-tool-bubble', 'bg-permission', 'bg-question', 'bg-plan-banner', 'bg-modal',
   'text-primary', 'text-secondary', 'text-muted', 'text-dim', 'text-disabled',
   'text-error', 'text-system', 'text-link', 'text-emphasis', 'text-heading', 'text-blockquote',
-  'accent-blue', 'accent-green', 'accent-purple', 'accent-orange', 'accent-red',
+  'accent-blue', 'accent-green', 'accent-purple', 'accent-orange', 'accent-red', 'accent-cyan',
   'accent-blue-light', 'accent-blue-subtle', 'accent-blue-border', 'accent-blue-border-strong',
   'accent-green-light', 'accent-green-border', 'accent-green-border-strong',
   'accent-purple-light', 'accent-purple-subtle', 'accent-purple-border-strong', 'accent-purple-code',

--- a/packages/dashboard/src/theme/theme.css
+++ b/packages/dashboard/src/theme/theme.css
@@ -39,6 +39,7 @@
   --accent-purple: #a78bfa;
   --accent-orange: #f59e0b;
   --accent-red: #ff4a4a;
+  --accent-cyan: #22d3ee;
 
   /* Accent opacity variants */
   --accent-blue-light: #4a9eff22;

--- a/packages/dashboard/src/theme/tokens.ts
+++ b/packages/dashboard/src/theme/tokens.ts
@@ -42,6 +42,7 @@ export const colors = {
     purple: '#a78bfa',
     orange: '#f59e0b',
     red: '#ff4a4a',
+    cyan: '#22d3ee',
     blueLight: '#4a9eff22',
     blueSubtle: '#4a9eff33',
     blueBorder: '#4a9eff44',

--- a/packages/design-tokens/src/tokens-data.js
+++ b/packages/design-tokens/src/tokens-data.js
@@ -58,6 +58,7 @@ export const TOKEN_GROUPS = [
       ["accent-purple", "#a78bfa"],
       ["accent-orange", "#f59e0b"],
       ["accent-red", "#ff4a4a"],
+      ["accent-cyan", "#22d3ee"], // #6426: distinct hue for the read/search/web retrieval family (vs thinking-blue)
     ],
   },
   {

--- a/packages/store-core/src/tool-presentation.ts
+++ b/packages/store-core/src/tool-presentation.ts
@@ -52,12 +52,16 @@ export interface ToolPresentation {
 /** Per-kind icon + color. Color tokens are the existing dashboard accent
  *  tokens (see theme.css); the icon keys are semantic and platform-neutral. */
 export const TOOL_KIND_META: Readonly<Record<ToolKind, { icon: string; colorToken: string }>> = {
-  read: { icon: 'file-text', colorToken: 'accent-blue' },
+  // #6426: read/search/web use accent-CYAN, not accent-blue — the latter is the
+  // presence rail's "thinking" colour, so the rail looked identical whether
+  // Claude was thinking or running a Read (the most common tool). Cyan keeps the
+  // cool/retrieval feel while reading as distinct from thinking-blue.
+  read: { icon: 'file-text', colorToken: 'accent-cyan' },
   edit: { icon: 'pencil', colorToken: 'accent-orange' },
   write: { icon: 'file-plus', colorToken: 'accent-green' },
   exec: { icon: 'terminal', colorToken: 'accent-purple' },
-  search: { icon: 'search', colorToken: 'accent-blue' },
-  web: { icon: 'world', colorToken: 'accent-blue' },
+  search: { icon: 'search', colorToken: 'accent-cyan' },
+  web: { icon: 'world', colorToken: 'accent-cyan' },
   task: { icon: 'subtask', colorToken: 'accent-purple' },
   todo: { icon: 'checklist', colorToken: 'accent-green' },
   question: { icon: 'help', colorToken: 'accent-orange' },


### PR DESCRIPTION
Closes #6426.

## Problem
The presence rail colours by the in-flight tool's `tool-presentation` `colorToken`, but `read` / `search` / `web` all mapped to **`accent-blue`** — the SAME blue the rail's **'thinking'** state uses. So the rail looked identical whether Claude was *thinking* or running a *Read* (the most common tool); only the breathe rhythm differed.

## Fix (shared-registry, per your call)
- Add **`--accent-cyan: #22d3ee`** via the `@chroxy/design-tokens` source (`tokens-data.js`) + regenerate `theme.css` + `tokens.ts` (theme.css is generated — edited the source, not the output).
- Point `read` / `search` / `web` at `accent-cyan` in `tool-presentation.ts`.

Cyan keeps the cool/retrieval feel while reading as distinct from thinking-blue. The rail is the **only** dynamic `colorToken` consumer today (App.tsx:315), so the visible effect is rail-scoped; mobile doesn't consume `colorToken`.

## Verified
`tool-presentation` 27 + store-core typecheck green. The registry test asserts `colorToken` self-referentially, so the value change is clean.

## ⚠️ Visual review (per your call)
`#22d3ee` is my pick for a distinct-but-cool retrieval hue. Eyeball the rail (thinking vs a Read) and tell me if a different shade/hue reads better.