### PR TITLE
docs(k8s): validation runbook + dry-run preflight self-check (#6275)

### DIFF
--- a/docs/guides/k8s-backend-validation.md
+++ b/docs/guides/k8s-backend-validation.md
@@ -1,0 +1,167 @@
+# K8s / Rancher backend — validation runbook
+
+The Kubernetes and Rancher environment backends are **feature-complete and
+unit-tested, but Experimental until validated against a live cluster** (#6275).
+The code paths (namespace isolation, ResourceQuota/LimitRange enforcement, the
+sidecar round-trip) are covered by unit tests and a kind-based integration test,
+but they have never been exercised against a managed or multi-node cluster.
+
+This runbook is the guided path from "experimental" to "validated". Most of it is
+automated — the only irreducibly-manual step is pointing it at a real cluster.
+
+> For configuration, the Rancher adapter, security notes, and fallback behaviour,
+> see [k8s-rancher-backend.md](./k8s-rancher-backend.md). This runbook is about
+> **validating** that backend, not configuring it.
+
+---
+
+## TL;DR
+
+```bash
+# 1. Dry-run preflight — no cluster needed. Validates the namespace sanitizer
+#    (tenant isolation) + the default resource quantities against the K8s rules.
+node packages/server/scripts/k8s-preflight.mjs
+
+# 2. Build the sidecar image.
+docker build -t chroxy-pod-agent:latest packages/server/sidecar/
+
+# 3a. Automated validation on a throwaway kind cluster (one command; it
+#     bootstraps + tears down the cluster itself).
+RUN_K8S_INTEGRATION=1 npm run test:integration:k8s   # from packages/server/
+
+# 3b. Validate against YOUR cluster (kind / k3s / EKS / GKE / Rancher):
+K8S_PREFLIGHT_LIVE=1 node packages/server/scripts/k8s-preflight.mjs
+```
+
+---
+
+## Prerequisites
+
+| Tool | Why | Notes |
+|------|-----|-------|
+| Docker | builds the sidecar image; `kind` runs on it | required for the kind path |
+| [`kind`](https://kind.sigs.k8s.io/) | the automated integration test bootstraps a throwaway cluster | only for step 3a |
+| Node 22 | running the server + the preflight/tests | `PATH="/opt/homebrew/opt/node@22/bin:$PATH"` on macOS |
+| A kubeconfig | the live preflight + your-own-cluster checks | `~/.kube/config` or `$KUBECONFIG` |
+
+For the **managed-cluster** path (3b) you also need a reachable cluster you can
+create namespaces + ResourceQuotas in (EKS/GKE/AKS, k3s, or Rancher). For
+**Rancher** specifically, set `RANCHER_URL`, `RANCHER_CLUSTER_ID`, `RANCHER_TOKEN`
+(see [k8s-rancher-backend.md](./k8s-rancher-backend.md#obtaining-clusterid-and-token)).
+
+---
+
+## Step 1 — Preflight (dry-run, no cluster)
+
+```bash
+node packages/server/scripts/k8s-preflight.mjs
+```
+
+This runs **without touching any cluster**. It imports the real `k8s.js`
+namespace sanitizer and the default resource quantities and checks them against
+the rules the API server enforces:
+
+- every tenant identity (incl. uppercase, `a/b` vs `a.b`, all-symbol, 200-char,
+  and unicode inputs) maps to a **valid RFC 1123 DNS label** ≤ 63 chars;
+- **tenant isolation holds** — distinct identities never collapse onto the same
+  namespace (e.g. `alice` and `Alice` get different namespaces via a hash
+  suffix), the mapping is deterministic, and the empty identity is rejected;
+- the default CPU/memory requests + limits (`500m` / `512Mi` / `2` / `4Gi`) are
+  valid Kubernetes quantity strings.
+
+A regression in the sanitizer (the multi-tenant isolation boundary) fails here,
+loudly, instead of silently sharing one tenant's Pods with another in production.
+Exit 0 = pass; non-zero = a config/logic problem to fix before going further.
+
+Add `K8S_PREFLIGHT_LIVE=1` to also load your default kubeconfig and **list
+namespaces (read-only)** — a quick auth + reachability check that creates nothing.
+
+---
+
+## Step 2 — Build the sidecar image
+
+The backend runs Claude in a `chroxy-pod-agent` sidecar container (protocol in
+[`packages/server/sidecar/PROTOCOL.md`](../../packages/server/sidecar/PROTOCOL.md)).
+
+```bash
+docker build -t chroxy-pod-agent:latest packages/server/sidecar/
+```
+
+The default image tag is `chroxy-pod-agent:latest` (`DEFAULT_SIDECAR_IMAGE` in
+`k8s.js`); override per-call with `opts.sidecarImage`. For a managed cluster,
+push the image to a registry the cluster can pull from and pass that reference.
+
+---
+
+## Step 3a — Automated validation (throwaway kind cluster)
+
+From `packages/server/`:
+
+```bash
+RUN_K8S_INTEGRATION=1 npm run test:integration:k8s
+# or directly: RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test tests/integration/k8s-sidecar-roundtrip.test.js
+```
+
+This **bootstraps a `kind` cluster, loads the sidecar image, runs the round-trip,
+and tears the cluster down** — no manual cluster setup. It is skipped silently if
+`RUN_K8S_INTEGRATION` is unset or `kind` is not on `PATH`, so it never breaks a
+normal test run.
+
+This is the closest thing to a one-command validation. It proves the sidecar
+spawn + stdio round-trip works end-to-end on a real (if local) cluster.
+
+---
+
+## Step 3b — Validate against your own cluster
+
+The kind path proves the happy path locally; a managed cluster is where the
+load-bearing isolation + quota controls actually get exercised. Against any
+reachable cluster (k3s / EKS / GKE / AKS / Rancher):
+
+1. **Connectivity + auth** — read-only, creates nothing:
+   ```bash
+   K8S_PREFLIGHT_LIVE=1 node packages/server/scripts/k8s-preflight.mjs
+   ```
+2. **Namespace isolation** — create two environments with distinct `userId`s and
+   confirm a Pod in `chroxy-user-alice…` cannot list/read/delete Pods in
+   `chroxy-user-bob…` (the namespace is the tenant boundary).
+3. **ResourceQuota enforcement** — set a namespace ResourceQuota, fill it, and
+   confirm an over-quota Pod creation is rejected with `403` (not silently
+   scheduled). Confirm LimitRange defaults are applied to a Pod created without
+   explicit resources.
+4. **Rancher only** — confirm `ensureProjectNamespace` stamps the
+   `field.cattle.io/projectId` annotation and that project-level quotas/RBAC are
+   enforced.
+
+> The integration-test scaffold for items 2–4 (env-gated behind
+> `RUN_K8S_INTEGRATION` + `RANCHER_*`) is tracked as a sub-task of #6275; until it
+> lands, run these checks manually with `kubectl` against your cluster.
+
+---
+
+## Step 4 — Enable the backend
+
+Once validated, enable it in `~/.chroxy/config.json`:
+
+```json
+{ "environments": { "backend": "k8s" } }
+```
+
+(or `"rancher"`). See [k8s-rancher-backend.md](./k8s-rancher-backend.md) for the
+full option set (`namespace`, `sidecarImage`, `resources`, Rancher `clusterId` /
+`token`, fallback behaviour).
+
+---
+
+## What to report on #6275
+
+To graduate the backend from Experimental, report:
+
+- [ ] Preflight (step 1) exits 0.
+- [ ] kind integration test (step 3a) passes.
+- [ ] Live preflight (step 3b.1) authenticates + lists namespaces.
+- [ ] Namespace isolation holds (3b.2) — cross-namespace reads blocked.
+- [ ] ResourceQuota + LimitRange enforced (3b.3).
+- [ ] (Rancher) project-namespace annotation + quotas enforced (3b.4).
+- Cluster details: distribution + version, node count, CNI, and anything that
+  behaved differently from the kind/local path.

--- a/docs/guides/k8s-rancher-backend.md
+++ b/docs/guides/k8s-rancher-backend.md
@@ -13,6 +13,13 @@ backends are available for remote / team deployments:
 This guide covers when to pick each one and how to configure the Rancher
 adapter.
 
+> ⚠️ **Experimental until live-validated (#6275).** These backends are
+> feature-complete + unit-tested but have not been exercised against a live
+> cluster. Before relying on them, walk the
+> [K8s backend validation runbook](./k8s-backend-validation.md) — a mostly-automated
+> path (a dry-run preflight + a one-command kind integration test) ending in a
+> short manual check against your own cluster.
+
 ## When to pick K8s vs Rancher
 
 | Aspect | `K8sBackend` (plain K8s) | `RancherBackend` (optional adapter) |

--- a/packages/server/scripts/k8s-preflight.mjs
+++ b/packages/server/scripts/k8s-preflight.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * k8s-preflight.mjs — dry-run validation for the experimental K8s/Rancher
+ * environment backend (#6275). Runs WITHOUT creating any cluster resources.
+ *
+ * Two layers:
+ *   1. Pure-logic (always) — exercises the REAL k8s.js namespace sanitizer +
+ *      the default resource quantities against the RFC 1123 DNS-label and
+ *      Kubernetes-quantity rules the API server enforces. A regression in the
+ *      sanitizer (e.g. a tenant-isolation collision) fails HERE, loudly, instead
+ *      of silently in a live cluster.
+ *   2. Live connectivity (opt-in, K8S_PREFLIGHT_LIVE=1) — loads the default
+ *      kubeconfig and LISTS namespaces (read-only) to confirm auth + reachability.
+ *      It never creates or deletes anything.
+ *
+ * Exit 0 if every attempted check passes; non-zero on any failure / config error.
+ * Companion to the runbook: docs/guides/k8s-backend-validation.md.
+ *
+ *   node packages/server/scripts/k8s-preflight.mjs            # pure-logic only
+ *   K8S_PREFLIGHT_LIVE=1 node .../k8s-preflight.mjs           # + live read-only check
+ */
+import { sanitizeNamespaceLabel, DEFAULT_RESOURCES } from '../src/environments/backends/k8s.js'
+
+// The exact rule a Kubernetes namespace (a DNS-1123 label) must satisfy, re-stated
+// here so the check is independent of k8s.js internals: a SANITIZER regression is
+// caught by comparing its output against this canonical rule.
+const RFC_1123_LABEL = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+const RFC_1123_MAX = 63
+// A Kubernetes resource.Quantity in canonical form: a number with an optional
+// decimal SI (m, k, M, G, …) or binary SI (Ki, Mi, Gi, …) suffix.
+const K8S_QUANTITY = /^[0-9]+(\.[0-9]+)?(m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$/
+
+const NS_PREFIX = 'chroxy-user-'
+const NS_BUDGET = RFC_1123_MAX - NS_PREFIX.length
+
+let failures = 0
+const fail = (msg) => { console.error(`  ✗ ${msg}`); failures++ }
+const ok = (msg) => console.log(`  ✓ ${msg}`)
+
+// --- 1a. namespace sanitizer: RFC 1123 validity + tenant-isolation ---------
+console.log('namespace sanitizer (real k8s.js logic):')
+const identities = [
+  'alice',
+  'Alice',
+  'user.name@example.com',
+  'a/b',
+  'a.b',
+  'A_B',
+  '---weird---',
+  'x'.repeat(200),
+  'Org/Team:Project#42',
+]
+const nsFor = (id) => `${NS_PREFIX}${sanitizeNamespaceLabel(id, { maxLength: NS_BUDGET })}`
+const seen = new Map()
+for (const id of identities) {
+  let ns
+  try {
+    ns = nsFor(id)
+  } catch (err) {
+    fail(`sanitizeNamespaceLabel("${id}") threw: ${err.message}`)
+    continue
+  }
+  if (ns.length > RFC_1123_MAX) {
+    fail(`"${id}" -> "${ns}" exceeds the ${RFC_1123_MAX}-char limit (${ns.length})`)
+  } else if (!RFC_1123_LABEL.test(ns)) {
+    fail(`"${id}" -> "${ns}" is not a valid RFC 1123 DNS label`)
+  } else {
+    ok(`"${id.slice(0, 28)}" -> ${ns}`)
+  }
+  for (const [otherId, otherNs] of seen) {
+    if (otherNs === ns && otherId !== id) {
+      fail(`TENANT COLLISION: "${id}" and "${otherId}" both map to ${ns}`)
+    }
+  }
+  seen.set(id, ns)
+}
+// The empty identity MUST be rejected (no silent fallback to a shared namespace).
+try {
+  sanitizeNamespaceLabel('')
+  fail('empty identity was NOT rejected (silent shared-namespace risk)')
+} catch {
+  ok('empty identity rejected')
+}
+// Determinism — the same identity must always map to the same namespace.
+if (sanitizeNamespaceLabel('alice') !== sanitizeNamespaceLabel('alice')) {
+  fail('sanitizer is non-deterministic (same identity produced two namespaces)')
+} else {
+  ok('deterministic (same identity -> same namespace)')
+}
+// Case-distinct identities must NOT collapse (alice vs Alice would share Pods).
+if (sanitizeNamespaceLabel('alice') === sanitizeNamespaceLabel('Alice')) {
+  fail('"alice" and "Alice" collapse to one namespace (tenant-isolation break)')
+} else {
+  ok('case-distinct identities isolated (alice != Alice)')
+}
+
+// --- 1b. default resource quantities parse as valid K8s quantities ----------
+console.log('default resource quantities (DEFAULT_RESOURCES):')
+for (const [key, value] of Object.entries(DEFAULT_RESOURCES)) {
+  if (K8S_QUANTITY.test(value)) {
+    ok(`${key}=${value}`)
+  } else {
+    fail(`DEFAULT_RESOURCES.${key}="${value}" is not a valid Kubernetes quantity`)
+  }
+}
+
+// --- 2. live cluster connectivity (opt-in, read-only) -----------------------
+console.log('live cluster connectivity:')
+if (process.env.K8S_PREFLIGHT_LIVE !== '1') {
+  console.log('  ⊝ skipped — set K8S_PREFLIGHT_LIVE=1 with a reachable kubeconfig to run')
+} else {
+  try {
+    const { KubeConfig, CoreV1Api } = await import('@kubernetes/client-node')
+    const kc = new KubeConfig()
+    kc.loadFromDefault()
+    const api = kc.makeApiClient(CoreV1Api)
+    const res = await api.listNamespace()
+    const items = res?.items || res?.body?.items || []
+    ok(`kubeconfig auth OK — listed ${items.length} namespaces (read-only; nothing created)`)
+  } catch (err) {
+    fail(`live connectivity failed: ${err.message}`)
+  }
+}
+
+console.log('')
+if (failures > 0) {
+  console.error(`PREFLIGHT FAILED — ${failures} check(s) failed. See docs/guides/k8s-backend-validation.md.`)
+  process.exit(1)
+}
+const liveNote = process.env.K8S_PREFLIGHT_LIVE === '1' ? 'live cluster reachable.' : 'live check skipped (set K8S_PREFLIGHT_LIVE=1 to include it).'
+console.log(`PREFLIGHT OK — namespace sanitizer + resource quantities valid; ${liveNote}`)


### PR DESCRIPTION
Part of #6275 — the first of its autonomous sub-tasks. Shrinks the user-ask from open-ended ('validate the K8s backend against a live cluster') to a guided, mostly-automated path.

## What
The K8s/Rancher backends are feature-complete + unit-tested but **Experimental until live-validated**. This adds the validation runbook + a dry-run self-check.

### `packages/server/scripts/k8s-preflight.mjs` — dry-run self-check (no cluster)
Imports the **real** `k8s.js` namespace sanitizer + default resource quantities and validates them against the rules the API server enforces:
- every tenant identity → a valid **RFC 1123** label ≤ 63 chars;
- **tenant isolation holds** — distinct identities never collapse (e.g. `alice` vs `Alice` get different namespaces via a hash suffix), deterministic, empty rejected;
- default CPU/memory quantities are valid.

A sanitizer regression (the multi-tenant isolation boundary) fails **here**, not silently in production. Opt-in live read-only connectivity check via `K8S_PREFLIGHT_LIVE=1` (lists namespaces, creates nothing).

```
$ node packages/server/scripts/k8s-preflight.mjs
  ✓ "alice" -> chroxy-user-alice
  ✓ "Alice" -> chroxy-user-alice-3bc51062
  ✓ case-distinct identities isolated (alice != Alice)
  ...
PREFLIGHT OK
```

### `docs/guides/k8s-backend-validation.md` — the runbook
preflight → build sidecar → **automated kind integration test (one self-bootstrapping command)** → validate against your own cluster (isolation + quota checks) → enable + report. Linked from `k8s-rancher-backend.md` with an Experimental callout.

## The user-ask this leaves
After this, the K8s dogfood is: `RUN_K8S_INTEGRATION=1 npm run test:integration:k8s` (local kind, automated) + `K8S_PREFLIGHT_LIVE=1 node …/k8s-preflight.mjs` against your real cluster + the short isolation/quota checklist. Tracked on #6275.

## Verified
Preflight exits 0 (real sanitizer logic); eslint clean; docs only otherwise.