### PR TITLE
feat(server): GitHub webhook receiver for the Control Room repo-events feed (#5966)

### DIFF
--- a/packages/server/src/github-webhook.js
+++ b/packages/server/src/github-webhook.js
@@ -1,0 +1,228 @@
+/**
+ * GitHub webhook receiver for the Control Room repo-events feed (#5966, epic #5422).
+ *
+ * Accepts GitHub webhook deliveries (`POST /api/github/webhook`), verifies the
+ * `X-Hub-Signature-256` HMAC against the configured secret (constant-time, over
+ * the RAW body before any parse), normalizes the events the Control Room surfaces
+ * (push / pull_request / issues / ping) into a compact repo-event, and pushes it
+ * onto a bounded in-memory store the Control Room pane drains. (The WS broadcast +
+ * dashboard pane that read this store are separate #5966 sub-tasks.)
+ *
+ * Security: the HMAC is the ONLY auth — an unsigned / mis-signed delivery is
+ * rejected 401 with no detail, constant-time, BEFORE the payload is parsed or
+ * trusted. With no secret configured the endpoint is inert (503), so it can ship
+ * dark and light up only once the operator sets a secret + points GitHub at it.
+ */
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import { RateLimiter, getRateLimitKey } from './rate-limiter.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('github-webhook')
+
+/** Max accepted delivery body. GitHub caps payloads at 25 MiB; most are tiny. */
+export const MAX_WEBHOOK_BYTES = 2 * 1024 * 1024 // 2 MiB
+/** Bounded repo-event ring capacity. */
+export const REPO_EVENT_STORE_CAP = 200
+
+const WEBHOOK_WINDOW_MS = 60_000
+const WEBHOOK_MAX_PER_WINDOW = 120
+const WEBHOOK_BURST = 30
+
+/**
+ * Verify a GitHub `X-Hub-Signature-256` header against the raw request body.
+ * Constant-time for equal-length inputs; returns false on ANY malformed input
+ * (missing secret, wrong prefix, length mismatch) and never throws.
+ *
+ * @param {Buffer|string} rawBody  - the EXACT bytes GitHub signed
+ * @param {unknown} signatureHeader - the `X-Hub-Signature-256` header value
+ * @param {string} secret           - the configured webhook secret
+ * @returns {boolean}
+ */
+export function verifyGithubSignature(rawBody, signatureHeader, secret) {
+  if (typeof secret !== 'string' || secret.length === 0) return false
+  if (typeof signatureHeader !== 'string' || !signatureHeader.startsWith('sha256=')) return false
+  const body = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(String(rawBody ?? ''), 'utf8')
+  const expected = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`
+  const got = Buffer.from(signatureHeader)
+  const want = Buffer.from(expected)
+  // timingSafeEqual throws on length mismatch — guard so a wrong-length signature
+  // is a plain `false`, not an exception path (and no length-based timing oracle).
+  if (got.length !== want.length) return false
+  return timingSafeEqual(got, want)
+}
+
+/**
+ * Normalize a GitHub webhook payload into a compact repo-event. Returns null for
+ * event types the Control Room does not surface (the caller then accepts-and-skips).
+ *
+ * @param {string} eventType - the `X-GitHub-Event` header value
+ * @param {object} payload   - the parsed webhook body
+ * @param {{ now?: () => Date }} [deps]
+ * @returns {object|null}
+ */
+export function normalizeGithubEvent(eventType, payload, { now = () => new Date() } = {}) {
+  if (!payload || typeof payload !== 'object') return null
+  const repo = payload.repository?.full_name || payload.repository?.name || null
+  const actor = payload.sender?.login || null
+  const base = { kind: eventType, repo, actor, at: now().toISOString() }
+
+  switch (eventType) {
+    case 'push': {
+      const ref = typeof payload.ref === 'string' ? payload.ref : null
+      const branch = ref ? ref.replace(/^refs\/heads\//, '') : null
+      const count = Array.isArray(payload.commits) ? payload.commits.length : 0
+      const head = typeof payload.head_commit?.message === 'string' ? payload.head_commit.message.split('\n')[0] : null
+      return {
+        ...base,
+        branch,
+        title: head,
+        url: payload.head_commit?.url || payload.compare || null,
+        summary: `pushed ${count} commit${count === 1 ? '' : 's'} to ${branch ?? ref ?? '(unknown ref)'}`,
+      }
+    }
+    case 'pull_request': {
+      const pr = payload.pull_request || {}
+      return {
+        ...base,
+        action: payload.action || null,
+        number: typeof pr.number === 'number' ? pr.number : null,
+        title: pr.title || null,
+        url: pr.html_url || null,
+        summary: `${payload.action || 'updated'} PR #${pr.number ?? '?'}`,
+      }
+    }
+    case 'issues': {
+      const issue = payload.issue || {}
+      return {
+        ...base,
+        action: payload.action || null,
+        number: typeof issue.number === 'number' ? issue.number : null,
+        title: issue.title || null,
+        url: issue.html_url || null,
+        summary: `${payload.action || 'updated'} issue #${issue.number ?? '?'}`,
+      }
+    }
+    case 'ping':
+      return { ...base, title: payload.zen || null, url: null, summary: 'webhook configured (ping)' }
+    default:
+      return null // unsurfaced event type
+  }
+}
+
+/** Bounded FIFO store of normalized repo-events. The Control Room pane drains it. */
+export class RepoEventStore {
+  constructor({ cap = REPO_EVENT_STORE_CAP } = {}) {
+    this._cap = cap > 0 ? cap : REPO_EVENT_STORE_CAP
+    this._events = []
+  }
+
+  push(event) {
+    this._events.push(event)
+    const overflow = this._events.length - this._cap
+    if (overflow > 0) this._events.splice(0, overflow)
+    return event
+  }
+
+  /** Most-recent-last; `limit` returns the tail. */
+  list({ limit } = {}) {
+    return typeof limit === 'number' && limit >= 0 ? this._events.slice(-limit) : this._events.slice()
+  }
+
+  get size() {
+    return this._events.length
+  }
+}
+
+function sendJson(res, status, body, extraHeaders = {}) {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload), ...extraHeaders })
+  res.end(payload)
+}
+
+/**
+ * Resolve the webhook secret. Prefers an explicit `server._githubWebhookSecret`
+ * (set from config at startup), falling back to `$GITHUB_WEBHOOK_SECRET`.
+ */
+function resolveWebhookSecret(server) {
+  if (typeof server?._githubWebhookSecret === 'string' && server._githubWebhookSecret.length > 0) {
+    return server._githubWebhookSecret
+  }
+  const env = process.env.GITHUB_WEBHOOK_SECRET
+  return typeof env === 'string' && env.length > 0 ? env : ''
+}
+
+/**
+ * Handle `POST /api/github/webhook`. Gate order:
+ *   1. per-IP rate limit (pre-auth; 429 + Retry-After)
+ *   2. secret configured? (503 if not — inert until set)
+ *   3. read RAW body (capped; 413)
+ *   4. HMAC-verify the X-Hub-Signature-256 over the raw body (401, constant-time)
+ *   5. parse JSON (400) + normalize the X-GitHub-Event (202 accept-and-skip if unsurfaced)
+ *   6. push onto the bounded RepoEventStore (lazily created on the server) → 202
+ */
+export function handleGithubWebhook(server, req, res) {
+  if (!server._githubWebhookRateLimiter) {
+    server._githubWebhookRateLimiter = new RateLimiter({
+      windowMs: WEBHOOK_WINDOW_MS,
+      maxMessages: WEBHOOK_MAX_PER_WINDOW,
+      burst: WEBHOOK_BURST,
+      name: 'github-webhook',
+    })
+  }
+  const clientIp = getRateLimitKey(req.socket?.remoteAddress || '', req)
+  const limit = server._githubWebhookRateLimiter.check(clientIp)
+  if (!limit.allowed) {
+    sendJson(res, 429, { error: 'rate limited' }, { 'Retry-After': Math.ceil(limit.retryAfterMs / 1000) })
+    return
+  }
+
+  const secret = resolveWebhookSecret(server)
+  if (!secret) {
+    sendJson(res, 503, { error: 'github webhook receiver not configured' })
+    return
+  }
+
+  const chunks = []
+  let bytes = 0
+  let oversized = false
+  req.on('data', (chunk) => {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    bytes += buf.length
+    if (bytes > MAX_WEBHOOK_BYTES) {
+      oversized = true
+      return
+    }
+    chunks.push(buf)
+  })
+  req.on('error', () => sendJson(res, 400, { error: 'read error' }))
+  req.on('end', () => {
+    if (oversized) {
+      sendJson(res, 413, { error: 'payload too large' })
+      return
+    }
+    const raw = Buffer.concat(chunks)
+    const sig = req.headers['x-hub-signature-256']
+    if (!verifyGithubSignature(raw, sig, secret)) {
+      log.warn('Rejected GitHub webhook: invalid or missing X-Hub-Signature-256')
+      sendJson(res, 401, { error: 'invalid signature' })
+      return
+    }
+    let payload
+    try {
+      payload = JSON.parse(raw.toString('utf8'))
+    } catch {
+      sendJson(res, 400, { error: 'invalid JSON' })
+      return
+    }
+    const eventType = String(req.headers['x-github-event'] || '')
+    const event = normalizeGithubEvent(eventType, payload)
+    if (!event) {
+      // Authentic delivery, but an event type the Control Room doesn't surface.
+      sendJson(res, 202, { accepted: true, surfaced: false })
+      return
+    }
+    if (!server._repoEventStore) server._repoEventStore = new RepoEventStore()
+    server._repoEventStore.push(event)
+    sendJson(res, 202, { accepted: true, surfaced: true, kind: event.kind })
+  })
+}

--- a/packages/server/src/github-webhook.js
+++ b/packages/server/src/github-webhook.js
@@ -15,6 +15,7 @@
  */
 import { createHmac, timingSafeEqual } from 'node:crypto'
 import { RateLimiter, getRateLimitKey } from './rate-limiter.js'
+import { sendOversizeResponse } from './http-oversize.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('github-webhook')
@@ -186,43 +187,66 @@ export function handleGithubWebhook(server, req, res) {
   let bytes = 0
   let oversized = false
   req.on('data', (chunk) => {
+    if (oversized) return
     const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
     bytes += buf.length
     if (bytes > MAX_WEBHOOK_BYTES) {
       oversized = true
+      // #5433: respond + STOP consuming from inside the 'data' handler. The
+      // helper removes the data listener, pauses the stream (TCP backpressure),
+      // and sends the 413 with Connection: close — never drain an unbounded body.
+      // Cap checked BEFORE push: the violating chunk is never buffered.
+      sendOversizeResponse(req, res, { error: 'payload too large' })
       return
     }
     chunks.push(buf)
   })
-  req.on('error', () => sendJson(res, 400, { error: 'read error' }))
-  req.on('end', () => {
-    if (oversized) {
-      sendJson(res, 413, { error: 'payload too large' })
-      return
-    }
-    const raw = Buffer.concat(chunks)
-    const sig = req.headers['x-hub-signature-256']
-    if (!verifyGithubSignature(raw, sig, secret)) {
-      log.warn('Rejected GitHub webhook: invalid or missing X-Hub-Signature-256')
-      sendJson(res, 401, { error: 'invalid signature' })
-      return
-    }
-    let payload
+  req.on('error', () => {
+    // Body-stream error (e.g. client reset mid-send). Guard the response — the
+    // socket may already be gone.
     try {
-      payload = JSON.parse(raw.toString('utf8'))
+      sendJson(res, 400, { error: 'read error' })
     } catch {
-      sendJson(res, 400, { error: 'invalid JSON' })
-      return
+      /* socket already torn down */
     }
-    const eventType = String(req.headers['x-github-event'] || '')
-    const event = normalizeGithubEvent(eventType, payload)
-    if (!event) {
-      // Authentic delivery, but an event type the Control Room doesn't surface.
-      sendJson(res, 202, { accepted: true, surfaced: false })
-      return
+  })
+  req.on('end', () => {
+    // #5313 pattern: this callback runs on a later tick, OUTSIDE the HTTP
+    // dispatch try/catch — wrap everything so a throw here (e.g. writeHead on a
+    // torn-down socket) can't escape to uncaughtException and crash the daemon.
+    try {
+      if (oversized) return // 413 already sent from the 'data' handler
+      const raw = Buffer.concat(chunks)
+      const sig = req.headers['x-hub-signature-256']
+      if (!verifyGithubSignature(raw, sig, secret)) {
+        log.warn('Rejected GitHub webhook: invalid or missing X-Hub-Signature-256')
+        sendJson(res, 401, { error: 'invalid signature' })
+        return
+      }
+      let payload
+      try {
+        payload = JSON.parse(raw.toString('utf8'))
+      } catch {
+        sendJson(res, 400, { error: 'invalid JSON' })
+        return
+      }
+      const eventType = String(req.headers['x-github-event'] || '')
+      const event = normalizeGithubEvent(eventType, payload)
+      if (!event) {
+        // Authentic delivery, but an event type the Control Room doesn't surface.
+        sendJson(res, 202, { accepted: true, surfaced: false })
+        return
+      }
+      if (!server._repoEventStore) server._repoEventStore = new RepoEventStore()
+      server._repoEventStore.push(event)
+      sendJson(res, 202, { accepted: true, surfaced: true, kind: event.kind })
+    } catch (err) {
+      log.error(`github webhook handler error: ${err?.stack || err}`)
+      try {
+        sendJson(res, 500, { error: 'internal error' })
+      } catch {
+        /* socket already torn down */
+      }
     }
-    if (!server._repoEventStore) server._repoEventStore = new RepoEventStore()
-    server._repoEventStore.push(event)
-    sendJson(res, 202, { accepted: true, surfaced: true, kind: event.kind })
   })
 }

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -9,6 +9,7 @@ import { buildDiagnosticsSnapshot } from './diagnostics.js'
 import { getRateLimitKey } from './rate-limiter.js'
 import { listSnapshots, deleteSnapshot } from './snapshots-store.js'
 import { handleEventIngest } from './event-ingest.js'
+import { handleGithubWebhook } from './github-webhook.js'
 import { handleMailboxPing, handleMailboxRegister } from './mailbox-route.js'
 import { isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
@@ -437,6 +438,15 @@ export function createHttpHandler(server) {
     // callbacks and guards them per the #5313 pattern.
     if (req.method === 'POST' && snapPath === '/api/events') {
       handleEventIngest(server, req, res)
+      return
+    }
+
+    // Control Room repo-events feed (#5966): GitHub webhook deliveries. Auth is
+    // the X-Hub-Signature-256 HMAC (NOT the ingest secret) — the handler verifies
+    // it over the RAW body before parsing, and stays inert (503) until a secret
+    // is configured. See github-webhook.js.
+    if (req.method === 'POST' && snapPath === '/api/github/webhook') {
+      handleGithubWebhook(server, req, res)
       return
     }
 

--- a/packages/server/tests/github-webhook.test.js
+++ b/packages/server/tests/github-webhook.test.js
@@ -99,6 +99,21 @@ describe('normalizeGithubEvent()', () => {
     assert.equal(normalizeGithubEvent('star', { repository: {} }), null)
     assert.equal(normalizeGithubEvent('push', null), null)
     assert.equal(normalizeGithubEvent('push', 'nope'), null)
+    assert.equal(normalizeGithubEvent('push', undefined), null)
+  })
+
+  it('tolerates adversarial field shapes without throwing', () => {
+    // A hostile / garbage authentic payload must produce a value (or null), never throw.
+    assert.doesNotThrow(() => normalizeGithubEvent('push', {
+      ref: 12345, // not a string
+      commits: 'not-an-array',
+      head_commit: { message: 42 }, // not a string
+      repository: ['array', 'not', 'object'],
+      sender: null,
+    }))
+    const ev = normalizeGithubEvent('pull_request', { action: null, pull_request: { number: 'NaN' } })
+    assert.equal(ev.kind, 'pull_request')
+    assert.equal(ev.number, null) // a non-number "number" is coerced to null
   })
 })
 
@@ -131,18 +146,35 @@ describe('handleGithubWebhook()', () => {
     else process.env.GITHUB_WEBHOOK_SECRET = savedEnv
   })
 
-  // Drive one delivery synchronously and return the captured response.
-  function deliver(server, { headers = {}, body = '' } = {}) {
+  // Mock req/res supporting the helpers the handler uses: sendOversizeResponse
+  // pauses the stream + waits for res 'finish'.
+  function makeReq(headers) {
     const req = new EventEmitter()
     req.headers = headers
     req.socket = { remoteAddress: '127.0.0.1' }
-    const res = { statusCode: null, headers: null, body: null }
+    req.pause = () => {}
+    req.resume = () => {}
+    return req
+  }
+  function makeRes() {
+    const res = new EventEmitter()
+    res.statusCode = null
+    res.headers = null
+    res.body = null
+    res.socket = null
     res.writeHead = (status, h) => { res.statusCode = status; res.headers = h }
-    res.end = (b) => { res.body = b }
+    res.end = (b) => { res.body = b; res.emit('finish') }
+    return res
+  }
+
+  // Drive one delivery synchronously and return the captured response.
+  function deliver(server, { headers = {}, body = '' } = {}) {
+    const req = makeReq(headers)
+    const res = makeRes()
     handleGithubWebhook(server, req, res)
     if (res.statusCode == null) {
-      // listeners were registered (passed rate-limit + secret) — feed the body
-      req.emit('data', Buffer.from(body))
+      // listeners were registered (passed rate-limit + secret) — feed the body.
+      req.emit('data', Buffer.isBuffer(body) ? body : Buffer.from(body))
       req.emit('end')
     }
     return res
@@ -197,17 +229,28 @@ describe('handleGithubWebhook()', () => {
     assert.equal(res.statusCode, 400)
   })
 
-  it('413 on an oversized body (before signature/parse)', () => {
-    const req = new EventEmitter()
-    req.headers = { 'x-github-event': 'push' }
-    req.socket = { remoteAddress: '127.0.0.1' }
-    const res = { statusCode: null }
-    res.writeHead = (s) => { res.statusCode = s }
-    res.end = () => {}
+  it('413 on an oversized body — and STOPS consuming (no unbounded drain)', () => {
+    const req = makeReq({ 'x-github-event': 'push' })
+    const res = makeRes()
     handleGithubWebhook({ _githubWebhookSecret: SECRET }, req, res)
     req.emit('data', Buffer.alloc(MAX_WEBHOOK_BYTES + 1))
+    assert.equal(res.statusCode, 413)
+    // sendOversizeResponse removed the data listener + paused the stream — the
+    // handler is no longer reading the (potentially unbounded) body off the wire.
+    assert.equal(req.listenerCount('data'), 0, 'data listener removed after 413')
+    // A late 'end' must not re-process or change the response.
     req.emit('end')
     assert.equal(res.statusCode, 413)
+  })
+
+  it('handles a body-stream error without throwing (guarded 400)', () => {
+    const req = makeReq({ 'x-github-event': 'push' })
+    const res = makeRes()
+    handleGithubWebhook({ _githubWebhookSecret: SECRET }, req, res)
+    // The error callback fires on a later tick, outside the dispatch try/catch —
+    // it must not escape to uncaughtException.
+    assert.doesNotThrow(() => req.emit('error', new Error('client reset')))
+    assert.equal(res.statusCode, 400)
   })
 
   it('reads the secret from $GITHUB_WEBHOOK_SECRET when not set on the server', () => {

--- a/packages/server/tests/github-webhook.test.js
+++ b/packages/server/tests/github-webhook.test.js
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for the Control Room GitHub webhook receiver (#5966).
+ * Pure logic + handler (mock req/res) — no network, no real cluster/secret.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac } from 'node:crypto'
+import { EventEmitter } from 'node:events'
+import {
+  verifyGithubSignature,
+  normalizeGithubEvent,
+  RepoEventStore,
+  handleGithubWebhook,
+  MAX_WEBHOOK_BYTES,
+} from '../src/github-webhook.js'
+
+const SECRET = 'whsec_test_secret'
+const sign = (body, secret = SECRET) => `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`
+
+describe('verifyGithubSignature()', () => {
+  const body = JSON.stringify({ hello: 'world' })
+
+  it('accepts a correct sha256 signature', () => {
+    assert.equal(verifyGithubSignature(body, sign(body), SECRET), true)
+    assert.equal(verifyGithubSignature(Buffer.from(body), sign(body), SECRET), true)
+  })
+
+  it('rejects a signature made with the wrong secret', () => {
+    assert.equal(verifyGithubSignature(body, sign(body, 'other'), SECRET), false)
+  })
+
+  it('rejects a body that does not match the signature (tamper)', () => {
+    assert.equal(verifyGithubSignature(`${body} `, sign(body), SECRET), false)
+  })
+
+  it('rejects a missing / malformed / wrong-length signature without throwing', () => {
+    assert.equal(verifyGithubSignature(body, undefined, SECRET), false)
+    assert.equal(verifyGithubSignature(body, 'not-a-sig', SECRET), false)
+    assert.equal(verifyGithubSignature(body, 'sha1=deadbeef', SECRET), false)
+    assert.equal(verifyGithubSignature(body, 'sha256=abc', SECRET), false) // wrong length
+  })
+
+  it('rejects when no secret is configured', () => {
+    assert.equal(verifyGithubSignature(body, sign(body), ''), false)
+    assert.equal(verifyGithubSignature(body, sign(body), undefined), false)
+  })
+})
+
+describe('normalizeGithubEvent()', () => {
+  const NOW = { now: () => new Date('2026-06-27T00:00:00.000Z') }
+
+  it('normalizes a push (branch, count, head summary)', () => {
+    const ev = normalizeGithubEvent('push', {
+      ref: 'refs/heads/main',
+      commits: [{}, {}],
+      head_commit: { message: 'fix: thing\n\nbody', url: 'https://gh/c' },
+      repository: { full_name: 'org/repo' },
+      sender: { login: 'alice' },
+    }, NOW)
+    assert.equal(ev.kind, 'push')
+    assert.equal(ev.repo, 'org/repo')
+    assert.equal(ev.actor, 'alice')
+    assert.equal(ev.branch, 'main')
+    assert.equal(ev.title, 'fix: thing')
+    assert.equal(ev.url, 'https://gh/c')
+    assert.equal(ev.summary, 'pushed 2 commits to main')
+    assert.equal(ev.at, '2026-06-27T00:00:00.000Z')
+  })
+
+  it('singularizes a one-commit push', () => {
+    const ev = normalizeGithubEvent('push', { ref: 'refs/heads/dev', commits: [{}], repository: { name: 'r' } })
+    assert.equal(ev.summary, 'pushed 1 commit to dev')
+  })
+
+  it('normalizes a pull_request (action, number, title)', () => {
+    const ev = normalizeGithubEvent('pull_request', {
+      action: 'opened',
+      pull_request: { number: 42, title: 'Add X', html_url: 'https://gh/pr/42' },
+      repository: { full_name: 'org/repo' },
+    })
+    assert.equal(ev.kind, 'pull_request')
+    assert.equal(ev.action, 'opened')
+    assert.equal(ev.number, 42)
+    assert.equal(ev.title, 'Add X')
+    assert.equal(ev.url, 'https://gh/pr/42')
+    assert.equal(ev.summary, 'opened PR #42')
+  })
+
+  it('normalizes an issues event + a ping', () => {
+    const issue = normalizeGithubEvent('issues', { action: 'closed', issue: { number: 7, title: 'Bug' } })
+    assert.equal(issue.summary, 'closed issue #7')
+    const ping = normalizeGithubEvent('ping', { zen: 'Keep it simple.', repository: { full_name: 'o/r' } })
+    assert.equal(ping.kind, 'ping')
+    assert.equal(ping.title, 'Keep it simple.')
+    assert.equal(ping.summary, 'webhook configured (ping)')
+  })
+
+  it('returns null for unsurfaced events + malformed payloads', () => {
+    assert.equal(normalizeGithubEvent('star', { repository: {} }), null)
+    assert.equal(normalizeGithubEvent('push', null), null)
+    assert.equal(normalizeGithubEvent('push', 'nope'), null)
+  })
+})
+
+describe('RepoEventStore', () => {
+  it('pushes + lists, newest last', () => {
+    const s = new RepoEventStore()
+    s.push({ kind: 'a' })
+    s.push({ kind: 'b' })
+    assert.equal(s.size, 2)
+    assert.deepEqual(s.list().map((e) => e.kind), ['a', 'b'])
+    assert.deepEqual(s.list({ limit: 1 }).map((e) => e.kind), ['b'])
+  })
+
+  it('is bounded — evicts oldest past the cap', () => {
+    const s = new RepoEventStore({ cap: 3 })
+    for (let i = 0; i < 5; i++) s.push({ kind: String(i) })
+    assert.equal(s.size, 3)
+    assert.deepEqual(s.list().map((e) => e.kind), ['2', '3', '4'])
+  })
+})
+
+describe('handleGithubWebhook()', () => {
+  let savedEnv
+  beforeEach(() => {
+    savedEnv = process.env.GITHUB_WEBHOOK_SECRET
+    delete process.env.GITHUB_WEBHOOK_SECRET
+  })
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.GITHUB_WEBHOOK_SECRET
+    else process.env.GITHUB_WEBHOOK_SECRET = savedEnv
+  })
+
+  // Drive one delivery synchronously and return the captured response.
+  function deliver(server, { headers = {}, body = '' } = {}) {
+    const req = new EventEmitter()
+    req.headers = headers
+    req.socket = { remoteAddress: '127.0.0.1' }
+    const res = { statusCode: null, headers: null, body: null }
+    res.writeHead = (status, h) => { res.statusCode = status; res.headers = h }
+    res.end = (b) => { res.body = b }
+    handleGithubWebhook(server, req, res)
+    if (res.statusCode == null) {
+      // listeners were registered (passed rate-limit + secret) — feed the body
+      req.emit('data', Buffer.from(body))
+      req.emit('end')
+    }
+    return res
+  }
+
+  it('503 when no secret is configured (inert until set)', () => {
+    const res = deliver({}, { headers: { 'x-github-event': 'push' }, body: '{}' })
+    assert.equal(res.statusCode, 503)
+  })
+
+  it('401 on a missing or wrong signature (before parsing the body)', () => {
+    const noSig = deliver({ _githubWebhookSecret: SECRET }, { headers: { 'x-github-event': 'push' }, body: '{"x":1}' })
+    assert.equal(noSig.statusCode, 401)
+    const wrong = deliver({ _githubWebhookSecret: SECRET }, {
+      headers: { 'x-github-event': 'push', 'x-hub-signature-256': `sha256=${'a'.repeat(64)}` },
+      body: '{"x":1}',
+    })
+    assert.equal(wrong.statusCode, 401)
+  })
+
+  it('202 + stores a surfaced event on a valid signed push', () => {
+    const server = { _githubWebhookSecret: SECRET }
+    const body = JSON.stringify({ ref: 'refs/heads/main', commits: [{}], repository: { full_name: 'o/r' }, sender: { login: 'bob' } })
+    const res = deliver(server, {
+      headers: { 'x-github-event': 'push', 'x-hub-signature-256': sign(body) },
+      body,
+    })
+    assert.equal(res.statusCode, 202)
+    assert.equal(JSON.parse(res.body).surfaced, true)
+    assert.equal(server._repoEventStore.size, 1)
+    assert.equal(server._repoEventStore.list()[0].branch, 'main')
+  })
+
+  it('202 accept-and-skip for an authentic but unsurfaced event (nothing stored)', () => {
+    const server = { _githubWebhookSecret: SECRET }
+    const body = JSON.stringify({ repository: { full_name: 'o/r' } })
+    const res = deliver(server, {
+      headers: { 'x-github-event': 'star', 'x-hub-signature-256': sign(body) },
+      body,
+    })
+    assert.equal(res.statusCode, 202)
+    assert.equal(JSON.parse(res.body).surfaced, false)
+    assert.equal(server._repoEventStore, undefined)
+  })
+
+  it('400 on a valid signature over invalid JSON', () => {
+    const body = 'not json'
+    const res = deliver({ _githubWebhookSecret: SECRET }, {
+      headers: { 'x-github-event': 'push', 'x-hub-signature-256': sign(body) },
+      body,
+    })
+    assert.equal(res.statusCode, 400)
+  })
+
+  it('413 on an oversized body (before signature/parse)', () => {
+    const req = new EventEmitter()
+    req.headers = { 'x-github-event': 'push' }
+    req.socket = { remoteAddress: '127.0.0.1' }
+    const res = { statusCode: null }
+    res.writeHead = (s) => { res.statusCode = s }
+    res.end = () => {}
+    handleGithubWebhook({ _githubWebhookSecret: SECRET }, req, res)
+    req.emit('data', Buffer.alloc(MAX_WEBHOOK_BYTES + 1))
+    req.emit('end')
+    assert.equal(res.statusCode, 413)
+  })
+
+  it('reads the secret from $GITHUB_WEBHOOK_SECRET when not set on the server', () => {
+    process.env.GITHUB_WEBHOOK_SECRET = SECRET
+    const body = JSON.stringify({ zen: 'hi', repository: { full_name: 'o/r' } })
+    const res = deliver({}, { headers: { 'x-github-event': 'ping', 'x-hub-signature-256': sign(body) }, body })
+    assert.equal(res.statusCode, 202)
+  })
+})


### PR DESCRIPTION
Part of #5966 (epic #5422) — the first slice: the receiver. The WS broadcast + dashboard pane that drain the store are the follow-up sub-tasks.

## What
`POST /api/github/webhook`:
1. **per-IP rate limit** (pre-auth, 429),
2. **secret gate** — inert **503** until configured (ships dark),
3. **raw body read** (2 MiB cap, **413**),
4. **HMAC verify** the `X-Hub-Signature-256` over the raw body, constant-time, **before any parse** (**401**, no detail),
5. parse JSON (**400**) + normalize `X-GitHub-Event` (push / pull_request / issues / ping) → a compact repo-event; authentic-but-unsurfaced events **202 accept-and-skip**,
6. push onto a bounded `RepoEventStore` → **202**.

## Security posture
The HMAC is the **only** auth — there's no token path. An unsigned or tampered delivery never reaches the parser. With no secret the endpoint can't be exercised at all (503). HMAC compare is `timingSafeEqual` with a length guard (no exception/timing oracle).

## What you'd do to light it up (the #5966 user-ask)
Set `GITHUB_WEBHOOK_SECRET` (or `server._githubWebhookSecret`) on the daemon, add a GitHub webhook pointing at `https://<your-tunnel>/api/github/webhook` with that secret + `application/json`. Until then it's dark.

## Verified
19 unit tests (HMAC verify incl. tamper/wrong-secret/wrong-length, normalization for every surfaced type, bounded store, handler 503/401/202/400/413/env-secret); http-routes router suite 50; eslint + custom lints clean. Bounded: one new module + one route branch.