### PR TITLE
feat(server): opt-in IDE feature flag (features.ide) — #6481

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -96,6 +96,10 @@ const CONFIG_SCHEMA = {
   //   billing.monthlyCreditBudgetUsd raw USD cap (wins over the tier preset)
   //   billing.budgetWarningPercent   warn threshold 1-100 (default 80)
   billing: 'object',
+  // #6481 (epic #6469): opt-in IDE feature surface. `features.ide: true` (or the
+  // CHROXY_ENABLE_IDE=1 env override) reveals the IDE navigation/editing features;
+  // off by default so it never risks the core offering. See isIdeFeatureEnabled().
+  features: 'object',
   externalUrl: 'string',
   repos: 'array',
   // #5172 (Control Room v2): filesystem root the Host Status survey scans
@@ -641,6 +645,19 @@ function validateUserShellBlock(userShell, warnings) {
 // disabled. Used by SessionManager.createSession (the authoritative gate).
 export function isUserShellEnabled(config) {
   return config?.userShell?.enabled === true
+}
+
+// #6481 (epic #6469): single source of truth for the OPT-IN IDE feature surface
+// (file navigator, symbol navigation, go-to-definition, find-references,
+// edit-in-place). Off by default so it never risks the core remote-cockpit
+// offering. Enabled by an explicit `features.ide === true` in config OR the
+// `CHROXY_ENABLE_IDE=1` env override (quick opt-in / dev). When on, the server
+// registers the IDE WS handlers and advertises the `ide` capability so clients
+// reveal the IDE UI; off ⇒ no IDE handlers, no IDE UI, core byte-identical.
+// Fail-closed: anything but an explicit boolean true / the env "1" is off.
+export function isIdeFeatureEnabled(config) {
+  if (process.env.CHROXY_ENABLE_IDE === '1') return true
+  return config?.features?.ide === true
 }
 
 // #6277: single source of truth for "does a user-shell spawn need host-local

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -181,6 +181,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // surfaced as the `userShell` capability so the dashboard gates its "New
     // shell" affordance. Optional — absent → false (fail-closed) for old servers.
     userShellEnabled,
+    // #6481 (epic #6469): whether the opt-in IDE feature surface is enabled
+    // (config.features.ide / CHROXY_ENABLE_IDE). Surfaced as the `ide` capability
+    // so clients reveal IDE navigation/editing UI. Optional — absent → false
+    // (fail-closed) for old servers / callers.
+    ideEnabled,
     // #6006: whether the server has a rotating TokenManager (i.e. auth is on),
     // so the operator panic button (`revoke_token`) can fire. Surfaced as the
     // `tokenRevoke` capability, gated to primary-token clients below. Optional —
@@ -343,6 +348,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // (older server) fall back to requesting the three lists as before. The
     // request handlers stay live either way for post-connect refreshes.
     authBootstrap: true,
+    // #6481 (epic #6469): the opt-in IDE feature surface (file navigator, symbol
+    // navigation, go-to-definition, find-references, edit-in-place) is enabled on
+    // THIS server (config.features.ide / CHROXY_ENABLE_IDE). Clients gate ALL IDE
+    // UI on this flag; absent/false (default, or older servers) → no IDE chrome
+    // (fail-closed). A server-wide feature gate, not token-scoped — available to
+    // every client when the operator opts in.
+    ide: ideEnabled === true,
     // #5986 (epic #5982) — the embedded user-shell terminal is available to THIS
     // client: the server has it enabled (userShell.enabled) AND this connection
     // holds the primary token. Both conditions of the create gate are reflected

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -22,7 +22,7 @@ import { handleAuthMessage, handlePairMessage, handlePairRequestMessage, handleK
 import { postPairLinkToDiscord } from './discord-pair-delivery.js'
 import { sendPostAuthInfo, replayHistory, flushPostAuthQueue, sendSessionInfo } from './ws-history.js'
 import { createDevicePreferences } from './device-preferences.js'
-import { isUserShellEnabled } from './config.js'
+import { isUserShellEnabled, isIdeFeatureEnabled } from './config.js'
 import { createHttpHandler } from './http-routes.js'
 import { CheckpointManager } from './checkpoint-manager.js'
 import { DevPreviewManager } from './dev-preview.js'
@@ -930,6 +930,11 @@ export class WsServer {
       // user-shell provider is hidden from listProviders, so the picker can't
       // advertise it). Late-bound getter so a test mutating self.config is seen.
       get userShellEnabled() { return isUserShellEnabled(self.config) },
+      // #6481 (epic #6469): whether the opt-in IDE feature surface is enabled on
+      // this server (config.features.ide / CHROXY_ENABLE_IDE). Surfaced as the
+      // `ide` capability so clients gate IDE UI. Late-bound getter so a test
+      // mutating self.config is seen.
+      get ideEnabled() { return isIdeFeatureEnabled(self.config) },
       // #6006: whether the operator panic button (revoke_token) can fire — true
       // iff a usable rotating TokenManager exists (i.e. auth is on). Mirrors the
       // token-handlers availability check (`typeof revoke === 'function'`) so the

--- a/packages/server/tests/ide-feature-flag.test.js
+++ b/packages/server/tests/ide-feature-flag.test.js
@@ -1,0 +1,59 @@
+/**
+ * IDE feature-flag gate (#6481, epic #6469).
+ *
+ * The whole IDE surface (file navigator, symbol nav, go-to-definition,
+ * find-references, edit-in-place) is OPT-IN, OFF by default, so it never risks
+ * the core remote-cockpit offering. `isIdeFeatureEnabled(config)` is the single
+ * source of truth: server handler registration gates on it, and the `ide`
+ * capability advertised in auth_ok (ws-history.sendPostAuthInfo) is `ideEnabled
+ * === true`, so clients reveal IDE UI only when the operator opts in.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { isIdeFeatureEnabled } from '../src/config.js'
+
+describe('isIdeFeatureEnabled() — IDE opt-in gate (#6481)', () => {
+  let saved
+  beforeEach(() => {
+    saved = process.env.CHROXY_ENABLE_IDE
+    delete process.env.CHROXY_ENABLE_IDE
+  })
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CHROXY_ENABLE_IDE
+    else process.env.CHROXY_ENABLE_IDE = saved
+  })
+
+  it('is OFF by default — no config, empty config, or features without ide', () => {
+    assert.equal(isIdeFeatureEnabled(undefined), false)
+    assert.equal(isIdeFeatureEnabled(null), false)
+    assert.equal(isIdeFeatureEnabled({}), false)
+    assert.equal(isIdeFeatureEnabled({ features: {} }), false)
+    assert.equal(isIdeFeatureEnabled({ features: { ide: false } }), false)
+  })
+
+  it('is ON when config.features.ide === true', () => {
+    assert.equal(isIdeFeatureEnabled({ features: { ide: true } }), true)
+  })
+
+  it('fail-closed: requires the EXACT boolean true (no truthy coercion)', () => {
+    assert.equal(isIdeFeatureEnabled({ features: { ide: 1 } }), false)
+    assert.equal(isIdeFeatureEnabled({ features: { ide: 'true' } }), false)
+    assert.equal(isIdeFeatureEnabled({ features: { ide: {} } }), false)
+  })
+
+  it('CHROXY_ENABLE_IDE=1 forces it ON regardless of config (quick opt-in / dev)', () => {
+    process.env.CHROXY_ENABLE_IDE = '1'
+    assert.equal(isIdeFeatureEnabled(undefined), true)
+    assert.equal(isIdeFeatureEnabled({}), true)
+    assert.equal(isIdeFeatureEnabled({ features: { ide: false } }), true)
+  })
+
+  it('CHROXY_ENABLE_IDE other than "1" does not enable (only the explicit "1")', () => {
+    process.env.CHROXY_ENABLE_IDE = '0'
+    assert.equal(isIdeFeatureEnabled({}), false)
+    process.env.CHROXY_ENABLE_IDE = 'true'
+    assert.equal(isIdeFeatureEnabled({}), false)
+    process.env.CHROXY_ENABLE_IDE = ''
+    assert.equal(isIdeFeatureEnabled({}), false)
+  })
+})

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -324,6 +324,33 @@ describe('sendPostAuthInfo — userShell capability (#5986)', () => {
   })
 })
 
+// #6481 (epic #6469): the `ide` capability advertises that the opt-in IDE feature
+// surface is enabled on this server (config.features.ide / CHROXY_ENABLE_IDE).
+// Unlike userShell/tokenRevoke it is a server-WIDE gate, not token-scoped —
+// available to every client when the operator opts in. Clients gate ALL IDE UI on
+// it; absent/false (default, or older servers) → no IDE chrome (fail-closed).
+describe('sendPostAuthInfo — ide capability (#6481)', () => {
+  it('advertises ide:true when the IDE feature is enabled, for ANY client class', () => {
+    for (const primary of [true, false, undefined]) {
+      const ctx = makeCtx({ ideEnabled: true })
+      const ws = makeFakeWs()
+      registerClient(ctx, ws, primary === undefined ? {} : { isPrimaryToken: primary })
+      sendPostAuthInfo(ctx, ws)
+      assert.equal(ctx._sends[0].capabilities.ide, true)
+    }
+  })
+
+  it('advertises ide:false when disabled or absent (fail-closed)', () => {
+    for (const v of [false, undefined]) {
+      const ctx = makeCtx(v === undefined ? {} : { ideEnabled: v })
+      const ws = makeFakeWs()
+      registerClient(ctx, ws, { isPrimaryToken: true })
+      sendPostAuthInfo(ctx, ws)
+      assert.equal(ctx._sends[0].capabilities.ide, false)
+    }
+  })
+})
+
 // #6006: the tokenRevoke capability gates the dashboard's "Revoke token" panic
 // button. It requires BOTH a rotating TokenManager (tokenRevocable — i.e. auth
 // is on) AND the primary-token class, mirroring the server-side handler gate, so


### PR DESCRIPTION
Foundation for the IDE epic (#6469): the **whole IDE surface is opt-in, OFF by default**, so it never risks the core remote-cockpit offering.

## What
- **`isIdeFeatureEnabled(config)`** — single source of truth: `config.features.ide === true` OR `CHROXY_ENABLE_IDE=1`. Fail-closed (no truthy coercion).
- **`features`** added to `CONFIG_SCHEMA`.
- **ws-server** ctx: late-bound `ideEnabled` getter (mirrors `userShellEnabled`).
- **ws-history**: advertises the `ide` capability in `auth_ok` (`ideEnabled === true`). A **server-wide** gate, not token-scoped — every client sees it when the operator opts in.

## Why no client diff
The dashboard already stores the advertised capability map in `serverCapabilities: Record<string, boolean>`, so `ide` flows to clients automatically. There's **no IDE UI yet** — each IDE feature (#6470+) gates its UI on `serverCapabilities.ide` and its WS handlers on `isIdeFeatureEnabled` as it's built. This PR is purely the gate mechanism.

## No guard surface
`ide` is a boolean in the **existing** `capabilities` record — no new message type, no protocol/schema change, no coverage-guard tripping.

## Tests
- `isIdeFeatureEnabled` — 5 (default-off, on, fail-closed coercion, env override, env non-"1").
- `ws-history` ide-capability advertisement — 2 (true for any client class when on; false/absent fail-closed). Full ws-history suite 153/153.
- Server custom lints green.

Closes #6481