### PR TITLE
chore: normalize repository line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,12 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.pdf binary
+*.zip binary
+
 docs/empirical/*.jsonl linguist-generated


### PR DESCRIPTION
## Summary

Add repository-level line-ending attributes so Windows checkouts do not keep showing unchanged tracked files as modified under `core.autocrlf=true`.

## What changed

- Set text files to normalize to LF in the repository with `* text=auto eol=lf`.
- Mark common binary asset/archive formats as binary.
- Preserve the existing `docs/empirical/*.jsonl linguist-generated` rule.

## Why

While working on Windows, Git reported dozens of generated and source files as modified even though `git diff --ignore-cr-at-eol` showed no content changes. Pinning LF at the repo level prevents future phantom CRLF churn and reduces the chance that unrelated generated files leak into PRs.

## Validation

- `git diff --check`
- Verified the PR diff is one file: `.gitattributes`.

No runtime tests were run because this is Git metadata only.