### PR TITLE
fix(server): Windows onboarding follow-ups (asset containment, POSIX mode assert, PowerShell docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy init
 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
 ```
 
+On Windows PowerShell:
+
+```powershell
+git clone https://github.com/blamechris/chroxy.git
+cd chroxy
+npm install
+
+# Install and configure
+npx chroxy init
+
+# Start the server
+npx chroxy start
+```
+
 The server prints a QR code. Scan it with the Chroxy mobile app, or open the dashboard URL in your browser.
 
 #### Verify it worked
@@ -186,15 +200,28 @@ If your phone and dev machine are on the same WiFi, connect directly without the
 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --tunnel none
 ```
 
+On Windows PowerShell:
+
+```powershell
+npx chroxy start --tunnel none
+```
+
 Then:
 
 1. Find your machine's local IP:
    ```bash
+   # macOS
    ipconfig getifaddr en0
+
+   # Windows PowerShell
+   Get-NetIPAddress -AddressFamily IPv4 |
+     Where-Object { $_.IPAddress -notlike '127.*' -and $_.PrefixOrigin -ne 'WellKnown' } |
+     Select-Object IPAddress,InterfaceAlias
    ```
 2. In the Chroxy app, tap **"Enter manually"** and enter:
    - URL: `ws://YOUR_IP:8765`
    - Token: the API token printed during `chroxy init` (stored in OS keychain, or `~/.chroxy/config.json` as fallback)
+3. For the web dashboard, open `http://YOUR_IP:8765/dashboard?token=YOUR_TOKEN` the first time. The token query sets the dashboard auth cookie and lets the browser app open its WebSocket connection. After that, plain `/dashboard` can load the page, but reconnecting may still need the full token URL if browser storage was cleared.
 
 ### Tunnel Modes
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ Then:
    ```bash
    # macOS
    ipconfig getifaddr en0
-
+   ```
+   ```powershell
    # Windows PowerShell
    Get-NetIPAddress -AddressFamily IPv4 |
      Where-Object { $_.IPAddress -notlike '127.*' -and $_.PrefixOrigin -ne 'WellKnown' } |

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, statSync } from 'fs'
-import { join, resolve, dirname, relative, sep } from 'path'
+import { join, resolve, dirname, relative, sep, isAbsolute } from 'path'
 import { fileURLToPath } from 'url'
 import QRCode from 'qrcode'
 import { readConnectionInfo } from './connection-info.js'
@@ -1076,7 +1076,9 @@ export function createHttpHandler(server) {
       if (relPath.startsWith('assets/')) {
         const filePath = resolve(distDir, relPath)
         const assetRel = relative(distDir, filePath)
-        if (assetRel.startsWith('..') || assetRel === '' || assetRel.includes(`..${sep}`)) {
+        // isAbsolute catches the Windows different-drive escape: path.relative across
+        // drives (C:\dist -> D:\evil) returns an absolute path that has no leading '..'.
+        if (isAbsolute(assetRel) || assetRel.startsWith('..') || assetRel === '' || assetRel.includes(`..${sep}`)) {
           res.writeHead(403)
           res.end('Forbidden')
           return

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, statSync } from 'fs'
-import { join, resolve, dirname } from 'path'
+import { join, resolve, dirname, relative, sep } from 'path'
 import { fileURLToPath } from 'url'
 import QRCode from 'qrcode'
 import { readConnectionInfo } from './connection-info.js'
@@ -1075,7 +1075,8 @@ export function createHttpHandler(server) {
       // Serve static assets WITHOUT auth — hashed filenames from Vite build
       if (relPath.startsWith('assets/')) {
         const filePath = resolve(distDir, relPath)
-        if (!filePath.startsWith(distDir + '/')) {
+        const assetRel = relative(distDir, filePath)
+        if (assetRel.startsWith('..') || assetRel === '' || assetRel.includes(`..${sep}`)) {
           res.writeHead(403)
           res.end('Forbidden')
           return

--- a/packages/server/tests/server-identity.test.js
+++ b/packages/server/tests/server-identity.test.js
@@ -92,9 +92,13 @@ describe('server identity (#5536)', () => {
       const first = getOrCreateServerIdentity({ keychain: kc, filePath })
       assert.equal(first.backend, 'file')
       assert.equal(existsSync(filePath), true)
-      // Mode is owner-only (0600). statSync mode masks to the perm bits.
-      const mode = statSync(filePath).mode & 0o777
-      assert.equal(mode, 0o600)
+      // Mode is owner-only (0600) on POSIX. Windows does not expose the same
+      // chmod semantics through stat mode bits, so the permission contract is
+      // enforced by writeFileRestricted where the platform supports it.
+      if (process.platform !== 'win32') {
+        const mode = statSync(filePath).mode & 0o777
+        assert.equal(mode, 0o600)
+      }
       // The file is JSON with a base64 secret, NOT a plaintext key on its own.
       const parsed = JSON.parse(readFileSync(filePath, 'utf-8'))
       assert.equal(typeof parsed.secretKey, 'string')


### PR DESCRIPTION
## Summary

The code-only remainder of #6485, on top of current main after its overlapping hunks landed elsewhere. Three independent, POSIX-safe Windows-onboarding fixes:

- **`http-routes.js`** — the `/dashboard/assets/...` containment check used `filePath.startsWith(distDir + '/')`, which fails on Windows (backslash separator) and 403'd legit assets, leaving the dashboard black. Now uses `path.relative(distDir, filePath)` + `sep` — equal-or-stricter on POSIX (verified: traversal, sibling-dir escape, and exact-distDir all still 403), correct on Windows.
- **`server-identity.test.js`** — guard the `0600` mode assertion behind `process.platform !== 'win32'` (Windows doesn't expose chmod mode bits through `statSync`). POSIX still asserts.
- **`README.md`** — Windows PowerShell onboarding (clone/init/start, `--tunnel none`, `Get-NetIPAddress` local-IP lookup).

## Why this is a new PR

#6485 bundled these good code fixes with (a) a weaker duplicate of the resolve-binary + store-core crypto fixes that landed in #6483, (b) a `keychain.js` change superseded by #6487, and (c) a large `CLAUDE.md` → `AGENTS.md` restructure. This PR carries only the unique, non-conflicting code; the doc restructure is split into its own PR for separate review, and #6485 is being closed.

Related to #6469 (Windows smoke-test epic). Supersedes the code portion of #6485.

## Validation

- `node --import ./packages/server/tests/_setup.mjs --test ./packages/server/tests/server-identity.test.js` → 19/19 pass on macOS
- `node --check packages/server/src/http-routes.js` → OK
- All 5 `packages/server/scripts/lint-*.sh` custom Server Lints → pass