### PR TITLE
chore(ci): store-core dist/crypto.js drift-guard + explicit binary attrs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,9 +10,10 @@
 *.zip binary
 *.icns binary
 
-# Extensionless committed binaries need an explicit path rule (no extension for
-# `* text=auto` to key off) — the signed Mach-O speech helper (#3830) must never
-# be LF-normalized. (#6489)
+# The signed Mach-O speech helper (#3830) is EXTENSIONLESS, so no extension glob
+# (like the *.icns rule above) can ever match it — hence an explicit path rule.
+# Marking it `binary` removes any reliance on git's content-based (NUL-byte)
+# auto-detection so it can never be LF-normalized. (#6489)
 packages/desktop/src-tauri/swift/speech-helper binary
 
 docs/empirical/*.jsonl linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,11 @@
 *.webp binary
 *.pdf binary
 *.zip binary
+*.icns binary
+
+# Extensionless committed binaries need an explicit path rule (no extension for
+# `* text=auto` to key off) — the signed Mach-O speech helper (#3830) must never
+# be LF-normalized. (#6489)
+packages/desktop/src-tauri/swift/speech-helper binary
 
 docs/empirical/*.jsonl linguist-generated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,18 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Check committed dist/crypto.js is in sync with build:crypto
+        # #6488: the build:crypto import-shim rewrite is committed to dist/. Rebuild
+        # and diff so a stale committed artifact (or a generator change that isn't
+        # re-committed) fails CI, mirroring the packages/protocol/dist guard.
+        working-directory: .
+        run: |
+          npm run build:crypto -w @chroxy/store-core
+          git diff --exit-code packages/store-core/dist/crypto.js || {
+            echo "::error::packages/store-core/dist/crypto.js drift detected. Run 'npm run build:crypto -w @chroxy/store-core' and commit the result."
+            exit 1
+          }
+
   claude-hooks-tests:
     name: Claude Hooks Tests
     needs: runner-target


### PR DESCRIPTION
## Summary

Two small from-review hardening items batched (both config/CI only, no runtime change):

- **#6488** — add a drift-guard in the **Store Core Tests** job: rebuild `build:crypto` and `git diff --exit-code packages/store-core/dist/crypto.js`, mirroring the existing `packages/protocol/dist` guard. Catches a stale committed artifact or a generator change that wasn't re-committed (the committed `dist/crypto.js` is security-load-bearing).
- **#6489** — explicitly mark `*.icns` and the extensionless Mach-O `packages/desktop/src-tauri/swift/speech-helper` as `binary` in `.gitattributes`, so they never rely on git's NUL-byte auto-detection. The signed helper (#3830) must never be LF-normalized.

## Validation

- `npm run build:crypto -w @chroxy/store-core` → `git diff` on `dist/crypto.js` is **empty** (committed artifact matches; guard passes on a clean tree)
- `git check-attr binary` → `set` for both `speech-helper` and `icon.icns`; `text` → `unset` for `speech-helper`
- `actionlint` parses the workflow cleanly (only a pre-existing unrelated SC2034 warning elsewhere)

Closes #6488
Closes #6489